### PR TITLE
feat(xr-composite): warm room-like backdrop with swappable presets

### DIFF
--- a/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/xr/SpatialScene.kt
+++ b/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/xr/SpatialScene.kt
@@ -69,12 +69,33 @@ public data class OrbitCamera(
   val pitchDeg: Double,
 )
 
-/** Optional scene backdrop. `kind` is "color" (`#RRGGBB` in [color]) or "skybox" ([texture]). */
+/**
+ * Optional scene backdrop. `kind` is "color" (`#RRGGBB` in [color]) or "skybox" ([texture]).
+ *
+ * For gradient backdrops (any `kind` other than "color"), the offline compositor supports **named
+ * presets** ([preset], e.g. `"warm-room"` — the default — or `"studio-dark"`) plus explicit
+ * gradient stops that **override** the chosen preset: [sky] (straight up), [horizon] (eye level),
+ * and [floor] (straight down; its presence turns the 2-stop gradient into a 3-stop, room-like one).
+ * These knobs are optional; omit them to take the compositor's default `warm-room` backdrop. The
+ * compositor's `--environment` CLI flag overrides whatever the scene specifies.
+ */
 @Serializable
 public data class SpatialEnvironment(
   val kind: String,
   val color: String? = null,
   val texture: String? = null,
+  /**
+   * Named gradient preset (e.g. `"warm-room"`, `"studio-dark"`); ignored when `kind == "color"`.
+   */
+  val preset: String? = null,
+  /** Gradient colour straight up (`#RRGGBB`); overrides the preset. */
+  val sky: String? = null,
+  /**
+   * Gradient colour at eye level (`#RRGGBB`); overrides the preset. Doubles as the clear colour.
+   */
+  val horizon: String? = null,
+  /** Gradient colour straight down (`#RRGGBB`); overrides the preset and enables a 3-stop floor. */
+  val floor: String? = null,
 )
 
 /** The full scene the 3D viewer renders. [version] must equal [SPATIAL_SCENE_VERSION]. */

--- a/docs/design/SPATIAL_SCENE_CONTRACT.md
+++ b/docs/design/SPATIAL_SCENE_CONTRACT.md
@@ -60,9 +60,26 @@ See `spatialScene.ts` for the authoritative types. In brief:
         },
     ],
     "orbiters": [], // optional: edge-anchored control strips (same shape + "edge")
-    "environment": { "kind": "color", "color": "#101014" }, // optional backdrop
+    "environment": { "kind": "gradient", "preset": "warm-room" }, // optional backdrop (see below)
 }
 ```
+
+## Environment (backdrop)
+
+The optional `environment` selects the scene backdrop and is **swappable**:
+
+- `kind: "color"` — a flat solid skybox using `color` (`#RRGGBB`).
+- `kind: "skybox"` — an image-based skybox from `texture` (consumer-defined).
+- otherwise (e.g. `kind: "gradient"`, the default) — a **vertical-gradient, room-like** backdrop.
+  An optional `preset` names a built-in look; the offline compositor ships `"warm-room"` (the
+  default: a softly-lit warm passthrough room) and `"studio-dark"` (the legacy cold gradient).
+  Explicit `sky` (straight up), `horizon` (eye level), and `floor` (straight down — its presence
+  upgrades the 2-stop gradient to a 3-stop, room-like one) **override** the chosen preset, giving a
+  custom gradient. Omit `environment` entirely to take the compositor's default `warm-room`.
+
+The compositor also accepts a `--environment <preset | color:#RRGGBB>` CLI flag that **overrides**
+whatever the scene specifies (see the [compositor](xr-spatial/COMPOSITOR.md) and its
+[README](../../renderers/xr-composite/README.md)).
 
 ## Producer mapping (`:renderer-xr`, Phase A)
 

--- a/docs/design/xr-spatial/COMPOSITOR.md
+++ b/docs/design/xr-spatial/COMPOSITOR.md
@@ -49,7 +49,12 @@ convention, so the transform is essentially identity.
   black, and a `LinearToneMapper` so colors stay faithful.
 - `camera` (orbit) → eye = `target + distance · dir(yaw, pitch)`, `lookAt`,
   45° vertical FoV.
-- `environment.color` → skybox / clear color (defaults to a neutral dark).
+- `environment` → a **swappable** backdrop. `kind=="color"` → a flat skybox / clear
+  color (`color`). Otherwise a **vertical-gradient, room-like** backdrop chosen by a
+  named **preset** (`warm-room`, the softly-lit warm default, or `studio-dark`, the
+  legacy cold look), with optional explicit `sky`/`horizon`/`floor` stops overriding
+  the preset. The `--environment <preset|color:#RRGGBB>` CLI flag overrides the scene's
+  choice; the default is `warm-room`. The horizon doubles as the readback clear color.
 
 Implementation gotchas (buffer lifetime, alpha premultiply, readPixels
 orientation) are documented in the tool's

--- a/renderers/xr-composite/README.md
+++ b/renderers/xr-composite/README.md
@@ -80,6 +80,40 @@ never fails and the interactive viewer + `scene.json` are unaffected.
 | `--out <path>` | output PNG | `composite.png` |
 | `--materials <dir>` | directory with the compiled `.filamat` blobs | `.` |
 | `--width` / `--height` | output size in px | `1280` × `800` |
+| `--environment <preset\|color:#RRGGBB>` | backdrop override (see "Background"): a named preset, or `color:#RRGGBB` for a flat skybox. Overrides the scene's `environment`. | `warm-room` |
+
+## Background (swappable presets)
+
+The backdrop is a **vertical-gradient, room-like environment cubemap** (an HDRI-style
+ceiling / wall / floor) so the light Material panels pop. It is **swappable** via named
+presets:
+
+| preset | look |
+|--------|------|
+| `warm-room` *(default)* | a softly-lit, muted warm passthrough room — warm-taupe ceiling (`#332e27`), a warm wall at the horizon with a gentle glow (`#5a4d40`), and a deep warm-brown floor (`#1e1a16`). Echoes a real Android XR room while staying mid-dark so panels read clearly. |
+| `studio-dark` | the legacy cold gradient — sky `#05070d` → horizon `#1a1f2b`, no floor (2-stop), preserved byte-for-byte. |
+
+The gradient is built as a cubemap: the upper hemisphere interpolates horizon → sky, the
+lower hemisphere interpolates horizon → floor (when the preset has one), with a soft glow
+band on the horizon. The horizon colour also doubles as the readback **clear colour**.
+
+**How to swap.** Selection precedence, most → least specific:
+
+1. **CLI** `--environment <name>` picks a preset; `--environment color:#RRGGBB` forces a
+   flat-colour skybox. This overrides whatever the scene says.
+2. **`scene.json` `environment`**: `kind:"color"` → flat colour (`color`); otherwise a
+   `preset` field selects a named preset, and explicit `sky` / `horizon` / `floor`
+   fields override the preset's stops (a custom gradient). Legacy scenes with
+   `kind:"gradient"` + `sky`/`horizon` still render (a custom-gradient override on the
+   default). A `floor` enables the 3-stop room look.
+3. **Built-in default** = `warm-room`.
+
+```sh
+# swap to the legacy cold look:
+./build/xr-composite --scene scene.json --out studio.png --environment studio-dark
+# force a flat backdrop:
+./build/xr-composite --scene scene.json --out flat.png   --environment color:#101014
+```
 
 ## Consumer flow — auto-provisioned by the CLI
 

--- a/renderers/xr-composite/src/main.cpp
+++ b/renderers/xr-composite/src/main.cpp
@@ -66,6 +66,7 @@ struct Args {
   std::string materialsDir;
   uint32_t width = 1280;
   uint32_t height = 800;
+  std::string environment;  // CLI override: a preset name, or "color:#RRGGBB"
 };
 
 std::vector<uint8_t> readFile(const std::string& path) {
@@ -112,11 +113,15 @@ float3 cubeDir(int face, float u, float v) {
 
 // Build a vertical-gradient environment cubemap emulating an HDRI sky/horizon, and install it as the
 // scene's skybox. `sky` is the colour straight up, `horizon` the colour at eye level; a soft glow
-// band brightens the horizon to read as atmospheric haze. RGBA16F (half) texels, one face at a time
-// via Texture::FaceOffsets. The texel buffer is heap-allocated and freed in the PixelBufferDescriptor
-// callback — Filament reads it on the driver thread during flushAndWait, so it must outlive this call
-// (same idiom as the panel textures below).
-Skybox* buildGradientSkybox(Engine& engine, float3 sky, float3 horizon) {
+// band brightens the horizon to read as atmospheric haze. `floor` (when set, i.e. `hasFloor`) colours
+// the lower hemisphere (dir.y < 0), turning the 2-stop gradient into a 3-stop room-like environment
+// with a ceiling, wall, and floor; when unset the lower hemisphere mirrors the original 2-stop
+// horizon→sky interpolation so the legacy look is byte-for-byte preserved. `glow` scales the horizon
+// glow band. RGBA16F (half) texels, one face at a time via Texture::FaceOffsets. The texel buffer is
+// heap-allocated and freed in the PixelBufferDescriptor callback — Filament reads it on the driver
+// thread during flushAndWait, so it must outlive this call (same idiom as the panel textures below).
+Skybox* buildGradientSkybox(Engine& engine, float3 sky, float3 horizon, float3 floor, bool hasFloor,
+                            float glow) {
   constexpr uint32_t kFace = 128;
   constexpr uint32_t kTexelsPerFace = kFace * kFace;
   constexpr uint32_t kChannels = 4;
@@ -132,11 +137,19 @@ Skybox* buildGradientSkybox(Engine& engine, float3 sky, float3 horizon) {
         float u = ((x + 0.5f) / kFace) * 2.0f - 1.0f;
         float v = ((y + 0.5f) / kFace) * 2.0f - 1.0f;
         float3 dir = normalize(cubeDir(face, u, v));
-        float t = smoothstep01(dir.y * 0.5f + 0.5f);
-        float3 c = mix(horizon, sky, t);
+        float3 c;
+        if (hasFloor && dir.y < 0.0f) {
+          // Lower hemisphere: interpolate horizon (at the wall) → floor (straight down).
+          float t = smoothstep01(-dir.y);  // 0 at horizon, 1 straight down
+          c = mix(horizon, floor, t);
+        } else {
+          // Upper hemisphere (and the whole sphere in legacy 2-stop mode): horizon → sky.
+          float t = smoothstep01(dir.y * 0.5f + 0.5f);
+          c = mix(horizon, sky, t);
+        }
         // Soft horizon glow: a gentle band centred on dir.y == 0, fading above and below.
-        float glow = std::exp(-(dir.y * dir.y) / (2.0f * 0.06f * 0.06f));
-        c = c + horizon * (glow * 0.35f);
+        float glowBand = std::exp(-(dir.y * dir.y) / (2.0f * 0.06f * 0.06f));
+        c = c + horizon * (glowBand * glow);
         size_t i = ((size_t)y * kFace + x) * kChannels;
         dst[i + 0] = half(c.r);
         dst[i + 1] = half(c.g);
@@ -162,6 +175,33 @@ Skybox* buildGradientSkybox(Engine& engine, float3 sky, float3 horizon) {
   return Skybox::Builder().environment(cube).showSun(false).build(engine);
 }
 
+// A named gradient-skybox preset. `floor` is only used when `hasFloor` is true (a 3-stop, room-like
+// environment); otherwise the lower hemisphere mirrors the upper one (the classic 2-stop look).
+struct GradientPreset {
+  const char* name;
+  const char* sky;      // colour straight up (#RRGGBB)
+  const char* horizon;  // colour at eye level (#RRGGBB)
+  const char* floor;    // colour straight down (#RRGGBB); ignored unless hasFloor
+  bool hasFloor;
+  float glow;  // horizon glow-band strength
+};
+
+// Built-in backdrops. `warm-room` is the default: a softly-lit, muted warm passthrough room
+// (warm-taupe ceiling, warm wall at the horizon with a gentle glow, deep warm-brown floor) tuned to
+// echo real Android XR rooms while keeping the light panel surfaces popping. `studio-dark` preserves
+// the original cold 2-stop gradient byte-for-byte (no floor, glow 0.35).
+constexpr GradientPreset kPresets[] = {
+    {"warm-room", "#332e27", "#5a4d40", "#1e1a16", true, 0.30f},
+    {"studio-dark", "#05070d", "#1a1f2b", "", false, 0.35f},
+};
+constexpr const char* kDefaultPreset = "warm-room";
+
+const GradientPreset* findPreset(const std::string& name) {
+  for (const auto& p : kPresets)
+    if (name == p.name) return &p;
+  return nullptr;
+}
+
 }  // namespace
 
 int main(int argc, char** argv) {
@@ -174,6 +214,7 @@ int main(int argc, char** argv) {
     else if (a == "--materials") args.materialsDir = next();
     else if (a == "--width") args.width = std::stoul(next());
     else if (a == "--height") args.height = std::stoul(next());
+    else if (a == "--environment") args.environment = next();
   }
   if (args.scenePath.empty()) { fprintf(stderr, "usage: --scene scene.json --out out.png\n"); return 2; }
   // A bare filename (no '/') means the scene lives in the current directory; find_last_of
@@ -216,30 +257,87 @@ int main(int argc, char** argv) {
   }
 
   // ---- background ----
-  // Default: a tasteful dark vertical-gradient environment cubemap (HDRI-style sky/horizon) so the
-  // light Material panels pop. `environment.kind=="color"` keeps the legacy flat skybox; an explicit
-  // `kind=="gradient"` may override the `sky`/`horizon` hex defaults. `bg` doubles as the clear
-  // colour for the readback path, so we always pick a sensible solid even in gradient mode.
-  std::string envKind = "gradient";
-  float3 gradSky = hexToLinear("#05070d");
-  float3 gradHorizon = hexToLinear("#1a1f2b");
+  // The backdrop is a swappable, room-like vertical-gradient environment cubemap (HDRI-style
+  // ceiling/wall/floor) so the light Material panels pop. Selection precedence, most → least
+  // specific:
+  //   1. CLI `--environment <name>`     → a named preset (see kPresets)
+  //      CLI `--environment color:#RRGGBB` → a flat-colour skybox
+  //   2. scene.json `environment`:
+  //        kind=="color"                 → flat colour (uses `color`)
+  //        else                          → `preset` selects a named preset; explicit
+  //                                        `sky`/`horizon`/`floor`/`glow` OVERRIDE its values
+  //        (legacy scenes with kind=="gradient" + sky/horizon still render: a custom-gradient
+  //         override on top of the default preset)
+  //   3. Built-in default = `warm-room`.
+  // `bg` doubles as the clear colour for the readback path: it mirrors the horizon in gradient mode
+  // and the colour in colour mode, so any uncovered edge blends with the backdrop.
+  bool wantColor = false;       // resolved as a flat-colour skybox?
+  float3 colorBg = {0.06f, 0.06f, 0.08f};
+
+  // Start from the default preset, then layer overrides on top.
+  const GradientPreset* preset = findPreset(kDefaultPreset);
+  float3 gradSky = hexToLinear(preset->sky);
+  float3 gradHorizon = hexToLinear(preset->horizon);
+  float3 gradFloor = hexToLinear(preset->floor);
+  bool gradHasFloor = preset->hasFloor;
+  float gradGlow = preset->glow;
+
+  // Applies a named preset's params over the current gradient state.
+  auto applyPreset = [&](const GradientPreset* p) {
+    gradSky = hexToLinear(p->sky);
+    gradHorizon = hexToLinear(p->horizon);
+    gradFloor = hexToLinear(p->floor);
+    gradHasFloor = p->hasFloor;
+    gradGlow = p->glow;
+  };
+
+  // (2) scene.json environment.
   if (scene.contains("environment") && scene["environment"].is_object()) {
     auto& env = scene["environment"];
-    envKind = env.value("kind", "gradient");
-    if (env.contains("sky")) gradSky = hexToLinear(env["sky"].get<std::string>());
-    if (env.contains("horizon")) gradHorizon = hexToLinear(env["horizon"].get<std::string>());
+    std::string kind = env.value("kind", "gradient");
+    if (kind == "color") {
+      wantColor = true;
+      if (env.contains("color")) colorBg = hexToLinear(env["color"].get<std::string>());
+    } else {
+      if (env.contains("preset")) {
+        if (const GradientPreset* p = findPreset(env["preset"].get<std::string>())) applyPreset(p);
+        else fprintf(stderr, "unknown environment preset '%s'; using default\n",
+                     env["preset"].get<std::string>().c_str());
+      }
+      // Explicit fields override the chosen preset (custom gradient).
+      if (env.contains("sky")) gradSky = hexToLinear(env["sky"].get<std::string>());
+      if (env.contains("horizon")) gradHorizon = hexToLinear(env["horizon"].get<std::string>());
+      if (env.contains("floor")) {
+        gradFloor = hexToLinear(env["floor"].get<std::string>());
+        gradHasFloor = true;
+      }
+      if (env.contains("glow")) gradGlow = env["glow"].get<float>();
+    }
   }
 
-  float3 bg = {0.06f, 0.06f, 0.08f};
+  // (1) CLI override — highest precedence, wins over scene.json.
+  if (!args.environment.empty()) {
+    const std::string& e = args.environment;
+    if (e.rfind("color:", 0) == 0) {
+      wantColor = true;
+      colorBg = hexToLinear(e.substr(6));
+    } else if (const GradientPreset* p = findPreset(e)) {
+      wantColor = false;
+      applyPreset(p);
+    } else {
+      fprintf(stderr, "unknown --environment '%s'; using scene/default backdrop\n", e.c_str());
+    }
+  }
+
+  float3 bg;
   Skybox* skybox = nullptr;
-  if (envKind == "color") {
-    if (scene.contains("environment") && scene["environment"].contains("color"))
-      bg = hexToLinear(scene["environment"]["color"].get<std::string>());
+  if (wantColor) {
+    bg = colorBg;
     skybox = Skybox::Builder().color({bg.r, bg.g, bg.b, 1.0f}).build(*engine);
   } else {
     // Clear colour mirrors the horizon so any uncovered edge blends with the gradient.
     bg = gradHorizon;
-    skybox = buildGradientSkybox(*engine, gradSky, gradHorizon);
+    skybox = buildGradientSkybox(*engine, gradSky, gradHorizon, gradFloor, gradHasFloor, gradGlow);
     if (!skybox) {
       // Fall back to a flat horizon-coloured skybox if the cubemap couldn't be built.
       fprintf(stderr, "gradient skybox build failed; falling back to solid\n");

--- a/vscode-extension/src/webview/shared/spatialScene.ts
+++ b/vscode-extension/src/webview/shared/spatialScene.ts
@@ -80,13 +80,30 @@ export interface OrbitCamera {
     pitchDeg: number;
 }
 
-/** Optional scene backdrop. */
+/**
+ * Optional scene backdrop.
+ *
+ * For gradient backdrops (any `kind` other than `"color"`), the offline compositor supports named
+ * `preset`s (e.g. `"warm-room"` — the default — or `"studio-dark"`) plus explicit gradient stops
+ * that override the chosen preset: `sky` (straight up), `horizon` (eye level), and `floor`
+ * (straight down; its presence turns the 2-stop gradient into a 3-stop, room-like one). All are
+ * optional; omit them to take the compositor's default `warm-room` backdrop. The compositor's
+ * `--environment` CLI flag overrides whatever the scene specifies.
+ */
 export interface SpatialEnvironment {
-    kind: "color" | "skybox";
+    kind: "color" | "skybox" | "gradient";
     /** `#RRGGBB` for `kind: "color"`. */
     color?: string;
     /** Texture path/URI for `kind: "skybox"`. */
     texture?: string;
+    /** Named gradient preset (e.g. `"warm-room"`, `"studio-dark"`); ignored when `kind: "color"`. */
+    preset?: string;
+    /** Gradient colour straight up (`#RRGGBB`); overrides the preset. */
+    sky?: string;
+    /** Gradient colour at eye level (`#RRGGBB`); overrides the preset. Doubles as the clear colour. */
+    horizon?: string;
+    /** Gradient colour straight down (`#RRGGBB`); overrides the preset and enables a 3-stop floor. */
+    floor?: string;
 }
 
 /** The full scene the 3D viewer renders. */


### PR DESCRIPTION
## Summary

Replaces the cold dark-gradient backdrop with a softly-lit, **warm room-like** environment as the new default, and makes the backdrop **swappable** via named presets (the old cold look stays selectable as `studio-dark`). Builds on #1745 (rounded panels + soft shadow); base will auto-retarget to `main` once that merges.

- **`src/main.cpp`** — a `GradientPreset` table (`warm-room` default, `studio-dark` legacy); `buildGradientSkybox` extended to a 3-stop gradient with an optional **floor** colour + configurable glow (2-stop legacy path preserved byte-for-byte); a new `--environment <preset|color:#RRGGBB>` CLI flag; selection precedence **CLI > scene.json (`kind`/`preset`/explicit stops) > built-in default**.
- **`SpatialEnvironment`** (Kotlin `SpatialScene.kt` + TS `spatialScene.ts` mirror) — optional `preset`/`sky`/`horizon`/`floor` fields, kept field-identical and locked by `SpatialSceneTest`.
- **Docs** — contract Environment section + example, `COMPOSITOR.md` env bullet, README CLI flag row + a Background section explaining presets and how to swap.

### `warm-room` (new default)
Warm taupe ceiling `#332e27` → warm wall `#5a4d40` (gentle glow) → deeper warm-brown floor `#1e1a16`, 3-stop. Kept mid-dark/muted so the light panel surfaces still pop.

### `studio-dark` (legacy cold, preserved)
`#05070d` → `#1a1f2b`, 2-stop, byte-for-byte the previous look.

## Test plan

- Binary + materials build clean; **7/7 composites re-baked** with the new binary under xvfb/llvmpipe.
- `:preview-data-api:test` (incl. `SpatialSceneTest`), `:renderer-xr:test`, `:samples:xr-spatial:testDebugUnitTest`, `:renderer-xr:ktfmtCheck` — all green.
- vscode-extension `compile:host` + `compile:webview` typecheck clean (the TS change adds no new errors).
- Manual: same scene baked `--environment warm-room` vs `--environment studio-dark` confirms the swap; baked composite PNGs live under gitignored `build/` (not committed).

---
_Generated by [Claude Code](https://claude.ai/code/session_01WUMD4xmJ9LUtL5dBsqPU2S)_