### PR TITLE
fix(cli): don't fail --missing-renders on non-PNG preview kinds; list offenders

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -680,7 +680,13 @@ abstract class Command(
       total = results.size,
       changed = results.count { it.anyChanged() },
       unchanged = results.count { !it.anyChanged() && it.captures.any { c -> c.pngPath != null } },
-      missing = results.count { it.captures.all { c -> c.pngPath == null } },
+      // Exclude kinds that never emit a PNG (see [NON_PNG_PREVIEW_KINDS]) so `counts.missing`
+      // matches what `--missing-renders` actually gates on — an `@XrSubspacePreview` with no
+      // composite still isn't a render failure.
+      missing =
+        results.count {
+          it.params.kind !in NON_PNG_PREVIEW_KINDS && it.captures.all { c -> c.pngPath == null }
+        },
     )
 
   protected fun matchesRequest(result: PreviewResult): Boolean {
@@ -722,6 +728,42 @@ abstract class Command(
     return null
   }
 }
+
+/**
+ * Preview kinds whose render legitimately never emits a PNG, so a null `pngPath` is expected rather
+ * than a render failure. Currently just XR subspace previews: they render to a `scene.json`, and
+ * the composite still PNG is an optional extra that only materialises when the `xr-composite`
+ * binary is provisioned (it 404s on most CI runners). Gating `--missing-renders fail` on their
+ * absent PNG would fail every run that ships an `@XrSubspacePreview`.
+ *
+ * Keep this in sync with `NON_PNG_PREVIEW_KINDS` in `.github/actions/lib/compare-previews.py`,
+ * which already excludes the same kinds from its PR-comment "Render Failures" section. When the two
+ * disagree the CLI fails the job while the comparison tool reports nothing — a red check with no
+ * comment explaining it.
+ */
+internal val NON_PNG_PREVIEW_KINDS = setOf("XR_SUBSPACE")
+
+/**
+ * Previews that finished rendering but produced no PNG for at least one capture — the set
+ * `--missing-renders` gates on and the diagnostic enumerates. Excludes [NON_PNG_PREVIEW_KINDS],
+ * whose empty `pngPath` is by design. Pulled out as a pure function so the policy is unit-testable
+ * without standing up a Gradle render.
+ */
+internal fun previewsMissingPng(results: List<PreviewResult>): List<PreviewResult> =
+  results.filter { r ->
+    r.params.kind !in NON_PNG_PREVIEW_KINDS && r.captures.any { it.pngPath == null }
+  }
+
+/**
+ * Human-readable coordinate for a capture: `default`, `500ms`, `scroll long`, `500ms · scroll end`.
+ */
+internal fun captureCoordLabel(c: CaptureResult): String =
+  listOfNotNull(
+      c.advanceTimeMillis?.let { "${it}ms" },
+      c.scroll?.let { "scroll ${it.mode.lowercase()}" },
+    )
+    .joinToString(" · ")
+    .ifEmpty { "default" }
 
 class ShowCommand(args: List<String>) : Command(args) {
   private val jsonOutput = "--json" in args
@@ -801,22 +843,16 @@ class ShowCommand(args: List<String>) : Command(args) {
                 c.changed == true -> " [changed]"
                 else -> ""
               }
-            val coord =
-              listOfNotNull(
-                  c.advanceTimeMillis?.let { "${it}ms" },
-                  c.scroll?.let { "scroll ${it.mode.lowercase()}" },
-                )
-                .joinToString(" · ")
-                .ifEmpty { "default" }
-            println("  [$coord]$tag ${c.pngPath ?: ""}")
+            println("  [${captureCoordLabel(c)}]$tag ${c.pngPath ?: ""}")
           }
         }
         emitInlineImage(r)
       }
     }
 
-    // "Missing" = at least one capture failed to produce a PNG.
-    val missing = filtered.filter { r -> r.captures.any { it.pngPath == null } }
+    // "Missing" = at least one capture failed to produce a PNG, excluding kinds that never emit
+    // one (see [previewsMissingPng] / [NON_PNG_PREVIEW_KINDS]).
+    val missing = previewsMissingPng(filtered)
     if (missing.isNotEmpty()) {
       // Diagnostic stays under warn/ignore so CI logs remain grep-able — only the exit code
       // changes. `--missing-renders warn|ignore` is the explicit opt-down; everything else
@@ -825,12 +861,25 @@ class ShowCommand(args: List<String>) : Command(args) {
       val prefix =
         if (policy in setOf("warn", "ignore")) "missing-renders policy=$policy — " else ""
       System.err.println(
-        "${prefix}Render task completed but produced no PNG for ${missing.size} of ${filtered.size} preview(s)."
+        "${prefix}Render task completed but produced no PNG for ${missing.size} of " +
+          "${filtered.size} preview(s):"
       )
+      // List the offenders so the CI log is self-diagnosing — no need to download the
+      // `composePreviewRender-reports` artifact just to learn *which* previews failed.
+      for (r in missing) {
+        val nullCoords =
+          r.captures
+            .filter { it.pngPath == null }
+            .joinToString(", ") { captureCoordLabel(it) }
+            .ifEmpty { "default" }
+        val moduleTag = if (r.module.isNotBlank()) " (${r.module})" else ""
+        System.err.println("  - ${r.id}$moduleTag — no PNG for: $nullCoords")
+      }
       System.err.println(
         "Check the Gradle output above — a common cause is the `composePreviewRender` task " +
           "reporting NO-SOURCE, which means the renderer test class wasn't found on " +
-          "testClassesDirs."
+          "testClassesDirs. Per-preview stack traces are in the `composePreviewRender-reports` " +
+          "artifact attached to the run."
       )
       System.out.flush()
       if (shouldFailOnMissingRenders()) exitProcess(2)

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/MissingRendersPolicyTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/MissingRendersPolicyTest.kt
@@ -61,4 +61,74 @@ class MissingRendersPolicyTest {
     assertEquals("warn", p.policy())
     assertFalse(p.shouldFail())
   }
+
+  private fun result(
+    id: String,
+    kind: String = "COMPOSE",
+    captures: List<CaptureResult>,
+  ): PreviewResult =
+    PreviewResult(
+      id = id,
+      module = "samples:demo",
+      functionName = id.substringAfterLast('.'),
+      className = id.substringBeforeLast('.'),
+      params = PreviewParams(kind = kind),
+      captures = captures,
+      pngPath = captures.firstOrNull()?.pngPath,
+    )
+
+  @Test
+  fun `previewsMissingPng flags a compose preview with a null-PNG capture`() {
+    val results =
+      listOf(
+        result("p.Ok", captures = listOf(CaptureResult(pngPath = "/r/ok.png", sha256 = "a"))),
+        result("p.Broken", captures = listOf(CaptureResult(pngPath = null))),
+      )
+    assertEquals(listOf("p.Broken"), previewsMissingPng(results).map { it.id })
+  }
+
+  @Test
+  fun `previewsMissingPng excludes XR subspace previews whose composite still is absent`() {
+    // XR subspace renders to scene.json; the composite PNG only lands when the xr-composite
+    // binary is provisioned (it 404s on most CI runners), so a null pngPath is expected, not a
+    // failure — mirrors NON_PNG_PREVIEW_KINDS in compare-previews.py.
+    val results =
+      listOf(
+        result("p.Spatial", kind = "XR_SUBSPACE", captures = listOf(CaptureResult(pngPath = null)))
+      )
+    assertTrue(previewsMissingPng(results).isEmpty())
+    assertTrue("XR_SUBSPACE" in NON_PNG_PREVIEW_KINDS)
+  }
+
+  @Test
+  fun `previewsMissingPng catches a partially-rendered fan-out`() {
+    val results =
+      listOf(
+        result(
+          "p.FanOut",
+          captures =
+            listOf(
+              CaptureResult(advanceTimeMillis = 0, pngPath = "/r/a.png", sha256 = "a"),
+              CaptureResult(advanceTimeMillis = 500, pngPath = null),
+            ),
+        )
+      )
+    assertEquals(listOf("p.FanOut"), previewsMissingPng(results).map { it.id })
+  }
+
+  @Test
+  fun `captureCoordLabel renders static, time, and scroll coordinates`() {
+    assertEquals("default", captureCoordLabel(CaptureResult()))
+    assertEquals("500ms", captureCoordLabel(CaptureResult(advanceTimeMillis = 500)))
+    assertEquals(
+      "scroll long",
+      captureCoordLabel(CaptureResult(scroll = ScrollCapture(mode = "LONG"))),
+    )
+    assertEquals(
+      "500ms · scroll end",
+      captureCoordLabel(
+        CaptureResult(advanceTimeMillis = 500, scroll = ScrollCapture(mode = "END"))
+      ),
+    )
+  }
 }


### PR DESCRIPTION
## Summary

The `Apply compose-preview` check has been chronically red on `main` since
spatial previews were added, failing with *"produced no PNG for 7 of 160
preview(s)"* — yet **no PR comment** explained it. Root cause is a
CLI ↔ tooling inconsistency:

- The PR-comment tool (`.github/actions/lib/compare-previews.py`) already
  excludes `XR_SUBSPACE` previews from render-failures via
  `NON_PNG_PREVIEW_KINDS` — they render to a `scene.json`; the composite still
  PNG is an optional extra that only exists when the `xr-composite` binary is
  provisioned (it 404s on most CI runners).
- But the CLI's `compose-preview show --missing-renders fail` counted **any**
  null `pngPath` capture as a failure, including those XR-subspace previews.

So the CLI failed the job (`rc=2`) while the comparison tool found nothing to
report → a red check with no comment. (Confirmed by diffing the failing run:
`show` flags 7, the Python tool collects 0 failures → all 7 are `XR_SUBSPACE`.)

## What this changes

1. **Consistency / the actual fix:** the CLI's missing-renders gate (and the
   `counts.missing` JSON field) now mirror `NON_PNG_PREVIEW_KINDS`, so
   `@XrSubspacePreview` no longer trips `--missing-renders fail`. The two
   surfaces agree again.
2. **Easy to diagnose:** the missing-renders diagnostic now **lists the
   offenders** — each preview id + module + the capture coordinates that
   produced no PNG — instead of only a count, plus a pointer to the
   `composePreviewRender-reports` artifact. No more downloading artifacts just
   to learn *which* previews failed.
3. **Comments still post:** with the false-positive gone, a genuinely-failing
   `COMPOSE` preview is still caught (and `compare-previews.py` already renders
   a "Render Failures" section, so the comment posts); a legit non-PNG kind no
   longer reddens the check silently.

`previewsMissingPng` / `captureCoordLabel` are extracted as pure functions and
unit-tested.

## Test plan

- [x] `:cli:test --tests MissingRendersPolicyTest` (new cases: XR-subspace
      excluded, compose null-PNG flagged, partial fan-out flagged, coord
      labels) — green.
- [x] `:cli:ktfmtCheck` — green.
- [ ] CI `Apply compose-preview` on this PR should no longer report the
      XR-subspace previews as missing renders.


---
_Generated by [Claude Code](https://claude.ai/code/session_016JsGWTqqt77xGAc9LQEgnK)_