### PR TITLE
feat(doctor): flag transitive libraries whose minSdk exceeds the module

### DIFF
--- a/docs/RENDERER_COMPATIBILITY.md
+++ b/docs/RENDERER_COMPATIBILITY.md
@@ -19,8 +19,10 @@ The VS Code extension surfaces the same findings in the Problems panel (via
 - **When to add a rule.** A new rule goes into
   [`CompatRules.kt`](../gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/CompatRules.kt)
   when a new AndroidX AAR adds an R.id field that older transitives don't
-  have, or when Gradle can select a platform sibling whose bytecode shape does
-  not match the Android renderer's expectations. Add a test in
+  have, when Gradle can select a platform sibling whose bytecode shape does
+  not match the Android renderer's expectations, or when an AGP step the
+  renderer forces (e.g. the unit-test manifest merge) fails with an opaque
+  message we can pre-empt with a clear finding. Add a test in
   `CompatRulesTest.kt` with both the triggering and non-triggering paths.
 - **The four mitigation mechanisms** in the renderer/plugin that must move
   together — remove any one and the compat matrix re-opens:
@@ -45,6 +47,46 @@ The VS Code extension surfaces the same findings in the Problems panel (via
      `org.jetbrains.compose.*` `-desktop` / `-jvmstubs` requests to the matching
      `-android` coordinate; `compose-preview doctor` reports the same skew for
      the consumer's own test tasks.
+
+## Known findings that still warrant a note
+
+### A library declares a higher minSdk than the module
+
+compose-preview renders inside a Robolectric **unit test**, so applying the
+plugin flips `testOptions.unitTests.isIncludeAndroidResources = true` and the
+render/daemon tasks depend on AGP's unit-test manifest merge
+(`process<Variant>UnitTestManifest`). That merge enforces `uses-sdk`: a
+transitive library whose `minSdkVersion` is higher than the consumer module's
+fails it with
+
+```
+uses-sdk:minSdkVersion 26 cannot be smaller than version 35 declared in library [ai.koog:koog-agents-android]
+```
+
+The conflict is the consumer's (`./gradlew :module:testDebugUnitTest` with
+resources included fails identically), but absent the plugin a module may never
+trigger the merge — so compose-preview is what surfaces it. The
+`library-minsdk-exceeds-module` rule in `CompatRules` reads each AAR's declared
+`minSdkVersion` (via the `android-manifest` artifacts on the unit-test
+classpath, parsed by `AarManifestReader`) and compares it against
+`defaultConfig.minSdk`, turning the opaque AGP failure into a doctor finding.
+
+minSdk is meaningless for a host-side unit test, so the recommended fix is the
+unit-test-only `tools:overrideLibrary` escape hatch (the finding names the exact
+library packages it parsed):
+
+```xml
+<!-- src/test/AndroidManifest.xml (or src/androidUnitTest/ for a KMP/CMP module) -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+    <uses-sdk tools:overrideLibrary="ai.koog.agents" />
+</manifest>
+```
+
+Raising the module's `minSdk` is the alternative, correct only when you intend
+to ship the higher floor on-device. We deliberately do **not** override this
+silently — that would mask the conflict for the consumer's own unit tests and
+let a genuinely API-35 library link against a lower-minSdk module unnoticed.
 
 ## Tile-rendering defaults
 

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -188,6 +188,10 @@ internal object AndroidPreviewSupport {
     // otherwise `PackageParser` rejects the manifest with "Requires newer sdk
     // version" at sandbox bootstrap (issue #1248).
     val consumerCompileSdk = project.objects.property(Int::class.java)
+    // The module's `defaultConfig.minSdk`, captured here so the doctor task can compare it against
+    // transitive libraries' declared minSdk (the `process<Variant>UnitTestManifest` merge conflict
+    // CompatRules.checkLibraryMinSdk surfaces). Left unset when the consumer omits minSdk.
+    val consumerMinSdk = project.objects.property(Int::class.java)
 
     androidComponents.finalizeDsl { android: Any ->
       val common = android as CommonExtension
@@ -201,6 +205,10 @@ internal object AndroidPreviewSupport {
       val resolvedCompileSdk: Int? = common.compileSdk
       if (resolvedCompileSdk != null) {
         consumerCompileSdk.set(resolvedCompileSdk)
+      }
+      val resolvedMinSdk: Int? = common.defaultConfig.minSdk
+      if (resolvedMinSdk != null) {
+        consumerMinSdk.set(resolvedMinSdk)
       }
     }
 
@@ -249,6 +257,7 @@ internal object AndroidPreviewSupport {
         variant,
         androidComponents.sdkComponents.bootClasspath,
         consumerCompileSdk,
+        consumerMinSdk,
       )
       registerAndroidResourcePreviewTasks(project, extension, variant)
     }
@@ -443,6 +452,7 @@ internal object AndroidPreviewSupport {
     variant: Variant,
     bootClasspath: org.gradle.api.provider.Provider<List<org.gradle.api.file.RegularFile>>,
     consumerCompileSdk: org.gradle.api.provider.Provider<Int>,
+    consumerMinSdk: org.gradle.api.provider.Provider<Int>,
   ) {
     val variantName = variant.name
     val capVariant = variantName.cap()
@@ -616,6 +626,19 @@ internal object AndroidPreviewSupport {
         ?.incoming
         ?.resolutionResult
         ?.rootComponent
+    // AAR `AndroidManifest.xml`s on the unit-test classpath — resolved lazily so the doctor task
+    // can read each library's declared `minSdkVersion` (CompatRules.checkLibraryMinSdk) without
+    // forcing artifact resolution at configuration time.
+    val testManifestArtifacts =
+      project.configurations
+        .findByName("${variantName}UnitTestRuntimeClasspath")
+        ?.incoming
+        ?.artifactView {
+          lenient(true)
+          attributes.attribute(artifactType, "android-manifest")
+        }
+        ?.artifacts
+        ?.resolvedArtifacts
 
     // Capture the running Gradle version at configuration time so the
     // task action stays config-cache safe (GradleVersion.current() is a
@@ -648,6 +671,8 @@ internal object AndroidPreviewSupport {
       this.outputFile.set(previewOutputDir.map { it.file("doctor.json") })
       mainRuntimeRoot?.let { this.mainRuntimeRoot.set(it) }
       testRuntimeRoot?.let { this.testRuntimeRoot.set(it) }
+      this.moduleMinSdk.set(consumerMinSdk)
+      testManifestArtifacts?.let { this.testManifestArtifacts.set(it) }
       this.previewToolingDeclared.set(previewToolingDeclaredAtRegistration)
       this.enforcePreviewToolingDependency.set(extension.enforcePreviewToolingDependency)
       this.injectedDependenciesJson.set(

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/CompatRules.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/CompatRules.kt
@@ -90,6 +90,8 @@ internal object CompatRules {
     previewToolingDeclared: Boolean? = null,
     enforcePreviewToolingDependency: Boolean? = null,
     transitivePreviewToolingDetected: Boolean? = null,
+    moduleMinSdk: Int? = null,
+    libraryMinSdks: List<LibraryMinSdk> = emptyList(),
   ): List<ModuleFindingData> {
     val findings = mutableListOf<ModuleFindingData>()
     val mainV = parseVersions(main)
@@ -101,6 +103,7 @@ internal object CompatRules {
     checkComposeBom(main)?.let(findings::add)
     checkHamcrestSkew(test)?.let(findings::add)
     checkKmpAndroidSiblingMismatch(test)?.let(findings::add)
+    checkLibraryMinSdk(moduleMinSdk, libraryMinSdks)?.let(findings::add)
     checkUndeclaredPreviewTooling(
         previewToolingDeclared,
         enforcePreviewToolingDependency,
@@ -284,6 +287,59 @@ internal object CompatRules {
   }
 
   /**
+   * Fires when a transitive library on the unit-test classpath declares a higher `minSdkVersion`
+   * than the consumer module. compose-preview renders inside a Robolectric **unit test**, which
+   * makes AGP merge the unit-test `AndroidManifest.xml` (`process<Variant>UnitTestManifest`) — and
+   * the merger rejects any library whose `uses-sdk:minSdkVersion` exceeds the module's. Absent the
+   * plugin many modules never trigger this merge (it only runs when `isIncludeAndroidResources` is
+   * on), so the opaque AGP "minSdkVersion N cannot be smaller than version M declared in library …"
+   * failure is something compose-preview surfaces; this rule turns it into an actionable finding.
+   *
+   * minSdk is meaningless for a host-side Robolectric run, so the recommended fix is the unit-test-
+   * only `tools:overrideLibrary` escape hatch (named with the exact library packages we parsed from
+   * the AAR manifests), with "raise the module minSdk" offered as the on-device alternative.
+   * Returns `null` when the module minSdk is unknown (non-Android / unset) or no library exceeds
+   * it.
+   */
+  private fun checkLibraryMinSdk(
+    moduleMinSdk: Int?,
+    libraryMinSdks: List<LibraryMinSdk>,
+  ): ModuleFindingData? {
+    if (moduleMinSdk == null) return null
+    val offenders =
+      libraryMinSdks.filter { it.minSdk > moduleMinSdk }.sortedByDescending { it.minSdk }
+    if (offenders.isEmpty()) return null
+    val highest = offenders.first().minSdk
+    val packages = offenders.mapNotNull { it.packageName }.distinct()
+    val overrideValue =
+      if (packages.isNotEmpty()) packages.joinToString(", ") else "<library.package.name>"
+    val offenderList = offenders.joinToString(", ") { "${it.coordinate} (minSdk ${it.minSdk})" }
+    return ModuleFindingData(
+      id = "library-minsdk-exceeds-module",
+      severity = "error",
+      message = "library minSdk exceeds module minSdk ($moduleMinSdk): $offenderList",
+      detail =
+        "compose-preview renders inside a Robolectric unit test, so AGP merges the unit-test " +
+          "AndroidManifest (`process<Variant>UnitTestManifest`). That merge fails when a library " +
+          "declares a higher `minSdkVersion` than this module ($moduleMinSdk) — here $offenderList. " +
+          "minSdk has no meaning for a host-side unit test, so the `tools:overrideLibrary` escape " +
+          "hatch clears the merge for the test variant without changing the minSdk you ship. Use " +
+          "it unless you actually intend to raise this module's on-device minSdk to >= $highest.",
+      remediationSummary =
+        "Add tools:overrideLibrary to the unit-test AndroidManifest, or raise the module minSdk to >= $highest.",
+      remediationCommands =
+        listOf(
+          "<!-- src/test/AndroidManifest.xml (or src/androidUnitTest/ for a KMP/CMP module) -->",
+          "<manifest xmlns:android=\"http://schemas.android.com/apk/res/android\"",
+          "    xmlns:tools=\"http://schemas.android.com/tools\">",
+          "    <uses-sdk tools:overrideLibrary=\"$overrideValue\" />",
+          "</manifest>",
+        ),
+      docsUrl = DOCS_LIBRARY_MINSDK,
+    )
+  }
+
+  /**
    * Flags Gradle versions below [GRADLE_MIN]. Parameter is the raw version string from
    * `GradleVersion.current().version` (e.g. `"9.3.1"`, `"9.4.1"`, `"9.5.0-rc-1"`). `null` means the
    * caller didn't plumb the version through — keeps the pre-existing call sites and tests working
@@ -456,6 +512,8 @@ internal object CompatRules {
   private const val DOCS_COMPOSE_UI_VS_CORE =
     "$DOCS_ROOT#compose-ui-110-on-a-consumer-with-older-androidxcore"
   private const val DOCS_HAMCREST_SKEW = "$DOCS_ROOT#hamcrest-2x-on-the-unit-test-classpath"
+  private const val DOCS_LIBRARY_MINSDK =
+    "$DOCS_ROOT#a-library-declares-a-higher-minsdk-than-the-module"
 }
 
 /**

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/ComposePreviewDoctorTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/ComposePreviewDoctorTask.kt
@@ -7,12 +7,15 @@ import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.gradle.api.DefaultTask
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
+import org.gradle.api.artifacts.result.ResolvedArtifactResult
 import org.gradle.api.artifacts.result.ResolvedComponentResult
 import org.gradle.api.artifacts.result.ResolvedDependencyResult
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import org.gradle.work.DisableCachingByDefault
@@ -55,6 +58,21 @@ abstract class ComposePreviewDoctorTask : DefaultTask() {
   @get:Internal abstract val mainRuntimeRoot: Property<ResolvedComponentResult>
 
   @get:Internal abstract val testRuntimeRoot: Property<ResolvedComponentResult>
+
+  /**
+   * The module's `android.defaultConfig.minSdk`, captured in `finalizeDsl`. Optional because it's
+   * unset for non-Android modules and consumers who omit it; [CompatRules.checkLibraryMinSdk]
+   * treats `null` as "not checkable".
+   */
+  @get:Input @get:Optional abstract val moduleMinSdk: Property<Int>
+
+  /**
+   * The `android-manifest` artifacts (AAR `AndroidManifest.xml`s) on
+   * `${variant}UnitTestRuntimeClasspath`. Wired as a lazy `Provider<Set<ResolvedArtifactResult>>`
+   * so resolution happens at execution, not configuration. Feeds [CompatRules.checkLibraryMinSdk]
+   * via each AAR's declared `minSdkVersion`.
+   */
+  @get:Internal abstract val testManifestArtifacts: SetProperty<ResolvedArtifactResult>
 
   /**
    * JSON-encoded `List<InjectedDependency>` captured at plugin-apply time (populated inside
@@ -100,6 +118,9 @@ abstract class ComposePreviewDoctorTask : DefaultTask() {
       mainRoot?.let {
         ee.schimke.composeai.plugin.ValidatePreviewToolingPresentTask.containsPreviewTooling(it)
       } ?: false
+    val libraryMinSdks =
+      runCatching { LibraryMinSdkCollector.collect(testManifestArtifacts.getOrElse(emptySet())) }
+        .getOrElse { emptyList() }
     val findings =
       CompatRules.evaluate(
         main,
@@ -108,6 +129,8 @@ abstract class ComposePreviewDoctorTask : DefaultTask() {
         previewToolingDeclared = previewToolingDeclared.getOrElse(true),
         enforcePreviewToolingDependency = enforcePreviewToolingDependency.getOrElse(true),
         transitivePreviewToolingDetected = transitivePreviewToolingDetected,
+        moduleMinSdk = moduleMinSdk.orNull,
+        libraryMinSdks = libraryMinSdks,
       )
     val injections = decodeInjectedDependencys(injectedDependenciesJson.getOrElse("[]"))
     val report =

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/ComposePreviewModelBuilder.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/ComposePreviewModelBuilder.kt
@@ -45,6 +45,8 @@ internal class ComposePreviewModelBuilder : ToolingModelBuilder {
         gradleVersion,
         previewToolingDeclared = toolingDeclared,
         enforcePreviewToolingDependency = enforceTooling,
+        moduleMinSdk = resolveModuleMinSdk(project),
+        libraryMinSdks = resolveLibraryMinSdks(project, "${variant}UnitTestRuntimeClasspath"),
       )
     val info: ModuleInfo =
       ModuleInfoData(
@@ -181,6 +183,43 @@ internal class ComposePreviewModelBuilder : ToolingModelBuilder {
         ?: return null to null
     val enforce = ext.enforcePreviewToolingDependency.getOrElse(true)
     return declared to enforce
+  }
+
+  /**
+   * Reads the module's `android.defaultConfig.minSdk` reflectively (same no-hard-AGP-dep approach
+   * as [resolveAgpVersion]). Returns `null` for non-Android modules, unset minSdk, or any
+   * reflection failure — [CompatRules.checkLibraryMinSdk] treats `null` as "not checkable".
+   */
+  private fun resolveModuleMinSdk(project: Project): Int? =
+    runCatching {
+        val android = project.extensions.findByName("android") ?: return null
+        val defaultConfig = android.javaClass.getMethod("getDefaultConfig").invoke(android)
+        defaultConfig?.javaClass?.getMethod("getMinSdk")?.invoke(defaultConfig) as? Int
+      }
+      .getOrNull()
+
+  /**
+   * Resolves the `android-manifest` artifacts on [configName] (the AAR `AndroidManifest.xml`s) and
+   * reads each library's declared `minSdkVersion`. Lenient + failure-swallowing so a single
+   * unresolvable artifact doesn't sink doctor; empty list means "nothing to check".
+   */
+  private fun resolveLibraryMinSdks(project: Project, configName: String): List<LibraryMinSdk> {
+    val config = project.configurations.findByName(configName) ?: return emptyList()
+    if (!config.isCanBeResolved) return emptyList()
+    return runCatching {
+        val artifactType =
+          org.gradle.api.attributes.Attribute.of("artifactType", String::class.java)
+        val artifacts =
+          config.incoming
+            .artifactView {
+              lenient(true)
+              attributes.attribute(artifactType, "android-manifest")
+            }
+            .artifacts
+            .artifacts
+        LibraryMinSdkCollector.collect(artifacts)
+      }
+      .getOrElse { emptyList() }
   }
 
   /**

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/LibraryMinSdk.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/LibraryMinSdk.kt
@@ -1,0 +1,89 @@
+package ee.schimke.composeai.plugin.tooling
+
+import java.io.File
+import javax.xml.parsers.DocumentBuilderFactory
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier
+import org.gradle.api.artifacts.result.ResolvedArtifactResult
+
+/**
+ * One library's declared `minSdkVersion`, read from its AAR `AndroidManifest.xml`. Feeds
+ * [CompatRules.checkLibraryMinSdk], which fires when a transitive library on the unit-test
+ * classpath demands a higher minSdk than the consumer module declares — the conflict AGP's manifest
+ * merger rejects at `process<Variant>UnitTestManifest`, surfaced when compose-preview forces the
+ * unit-test manifest merge (its renderer runs as a Robolectric unit test).
+ *
+ * [packageName] is the AAR manifest's `package` attribute — exactly the value AGP's
+ * `tools:overrideLibrary` escape hatch wants, so the remediation can name it concretely.
+ */
+internal data class LibraryMinSdk(
+  val coordinate: String,
+  val packageName: String?,
+  val minSdk: Int,
+) : java.io.Serializable
+
+/**
+ * Parses the two fields [CompatRules] needs out of an AAR `AndroidManifest.xml`: the `package`
+ * attribute and `uses-sdk`'s `android:minSdkVersion`. Namespace-unaware DOM parse with external
+ * entity/DTD loading disabled (the manifests come from third-party artifacts). Any parse failure or
+ * a non-integer codename minSdk (`"VanillaIceCream"`) yields a null field rather than throwing —
+ * the rule simply skips libraries it can't read a numeric floor from.
+ */
+internal object AarManifestReader {
+
+  data class Parsed(val packageName: String?, val minSdk: Int?)
+
+  fun parse(manifest: File): Parsed =
+    runCatching { manifest.inputStream().use { parseDocument(it) } }
+      .getOrElse { Parsed(null, null) }
+
+  /** String overload for tests; production reads from the resolved manifest file. */
+  internal fun parse(xml: String): Parsed =
+    runCatching { xml.byteInputStream().use { parseDocument(it) } }.getOrElse { Parsed(null, null) }
+
+  private fun parseDocument(input: java.io.InputStream): Parsed {
+    val factory =
+      DocumentBuilderFactory.newInstance().apply {
+        isNamespaceAware = false
+        setHardenedFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
+        setHardenedFeature("http://xml.org/sax/features/external-general-entities", false)
+        setHardenedFeature("http://xml.org/sax/features/external-parameter-entities", false)
+      }
+    val doc = factory.newDocumentBuilder().parse(input)
+    val root = doc.documentElement
+    val packageName = root?.getAttribute("package")?.takeIf { it.isNotBlank() }
+    val usesSdk = doc.getElementsByTagName("uses-sdk")
+    val minSdk =
+      (0 until usesSdk.length)
+        .asSequence()
+        .map { usesSdk.item(it) as? org.w3c.dom.Element }
+        .filterNotNull()
+        .mapNotNull { it.getAttribute("android:minSdkVersion").takeIf { v -> v.isNotBlank() } }
+        .firstOrNull()
+        ?.toIntOrNull()
+    return Parsed(packageName, minSdk)
+  }
+
+  private fun DocumentBuilderFactory.setHardenedFeature(name: String, value: Boolean) {
+    runCatching { setFeature(name, value) }
+  }
+}
+
+/** Reads [LibraryMinSdk] entries from a set of resolved `android-manifest` artifacts. */
+internal object LibraryMinSdkCollector {
+  fun collect(artifacts: Iterable<ResolvedArtifactResult>): List<LibraryMinSdk> {
+    val out = LinkedHashMap<String, LibraryMinSdk>()
+    for (artifact in artifacts) {
+      // Module deps only — project (`:foo`) deps resolve their own minSdk from defaultConfig and
+      // can't conflict with the consuming module in a way `tools:overrideLibrary` addresses.
+      val id = artifact.id.componentIdentifier as? ModuleComponentIdentifier ?: continue
+      val coordinate = "${id.group}:${id.module}"
+      if (out.containsKey(coordinate)) continue
+      val file = artifact.file
+      if (!file.isFile) continue
+      val parsed = AarManifestReader.parse(file)
+      val min = parsed.minSdk ?: continue
+      out[coordinate] = LibraryMinSdk(coordinate, parsed.packageName, min)
+    }
+    return out.values.toList()
+  }
+}

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/tooling/AarManifestReaderTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/tooling/AarManifestReaderTest.kt
@@ -1,0 +1,70 @@
+package ee.schimke.composeai.plugin.tooling
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class AarManifestReaderTest {
+
+  @Test
+  fun `reads package and integer minSdk`() {
+    val parsed =
+      AarManifestReader.parse(
+        """
+        <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+            package="ai.koog.agents">
+            <uses-sdk android:minSdkVersion="35" />
+        </manifest>
+        """
+          .trimIndent()
+      )
+    assertEquals("ai.koog.agents", parsed.packageName)
+    assertEquals(35, parsed.minSdk)
+  }
+
+  @Test
+  fun `missing uses-sdk yields null minSdk`() {
+    val parsed =
+      AarManifestReader.parse(
+        """<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.example" />"""
+      )
+    assertEquals("com.example", parsed.packageName)
+    assertNull(parsed.minSdk)
+  }
+
+  @Test
+  fun `codename minSdk is treated as unknown`() {
+    val parsed =
+      AarManifestReader.parse(
+        """
+        <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.example">
+            <uses-sdk android:minSdkVersion="VanillaIceCream" />
+        </manifest>
+        """
+          .trimIndent()
+      )
+    assertNull(parsed.minSdk)
+  }
+
+  @Test
+  fun `malformed xml does not throw`() {
+    val parsed = AarManifestReader.parse("not xml <<<")
+    assertNull(parsed.packageName)
+    assertNull(parsed.minSdk)
+  }
+
+  @Test
+  fun `blank package is reported as null`() {
+    val parsed =
+      AarManifestReader.parse(
+        """
+        <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+            <uses-sdk android:minSdkVersion="21" />
+        </manifest>
+        """
+          .trimIndent()
+      )
+    assertNull(parsed.packageName)
+    assertEquals(21, parsed.minSdk)
+  }
+}

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/tooling/CompatRulesTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/tooling/CompatRulesTest.kt
@@ -281,6 +281,64 @@ class CompatRulesTest {
   }
 
   @Test
+  fun `library minSdk higher than module fires error with overrideLibrary remediation`() {
+    val findings =
+      CompatRules.evaluate(
+        mainWithBom(),
+        mainWithBom() + ("androidx.compose.ui:ui-test-manifest" to "1.10.6"),
+        moduleMinSdk = 26,
+        libraryMinSdks = listOf(LibraryMinSdk("ai.koog:koog-agents-android", "ai.koog.agents", 35)),
+      )
+    val f = findings.single { it.id == "library-minsdk-exceeds-module" }
+    assertEquals("error", f.severity)
+    assertTrue("ai.koog:koog-agents-android (minSdk 35)" in f.message)
+    assertTrue("26" in f.message)
+    assertTrue(f.remediationCommands.any { "tools:overrideLibrary=\"ai.koog.agents\"" in it })
+  }
+
+  @Test
+  fun `library minSdk equal to or below module is quiet`() {
+    val findings =
+      CompatRules.evaluate(
+        mainWithBom(),
+        mainWithBom() + ("androidx.compose.ui:ui-test-manifest" to "1.10.6"),
+        moduleMinSdk = 35,
+        libraryMinSdks =
+          listOf(
+            LibraryMinSdk("ai.koog:koog-agents-android", "ai.koog.agents", 35),
+            LibraryMinSdk("com.example:legacy", "com.example.legacy", 21),
+          ),
+      )
+    assertNull(findings.firstOrNull { it.id == "library-minsdk-exceeds-module" })
+  }
+
+  @Test
+  fun `unknown module minSdk skips the library-minSdk check`() {
+    val findings =
+      CompatRules.evaluate(
+        mainWithBom(),
+        mainWithBom() + ("androidx.compose.ui:ui-test-manifest" to "1.10.6"),
+        moduleMinSdk = null,
+        libraryMinSdks = listOf(LibraryMinSdk("ai.koog:koog-agents-android", "ai.koog.agents", 35)),
+      )
+    assertNull(findings.firstOrNull { it.id == "library-minsdk-exceeds-module" })
+  }
+
+  @Test
+  fun `library minSdk finding without a parsed package falls back to placeholder`() {
+    val findings =
+      CompatRules.evaluate(
+        mainWithBom(),
+        mainWithBom() + ("androidx.compose.ui:ui-test-manifest" to "1.10.6"),
+        moduleMinSdk = 24,
+        libraryMinSdks = listOf(LibraryMinSdk("com.example:lib", null, 30)),
+      )
+    val f = findings.single { it.id == "library-minsdk-exceeds-module" }
+    assertTrue(f.remediationCommands.any { "<library.package.name>" in it })
+    assertTrue(f.remediationSummary!!.contains(">= 30"))
+  }
+
+  @Test
   fun `semver parses and compares`() {
     assertEquals(Semver(1, 16, 0), Semver.parseOrNull("1.16.0"))
     assertEquals(Semver(1, 16, 0), Semver.parseOrNull("1.16"))


### PR DESCRIPTION
compose-preview renders inside a Robolectric unit test, so applying the
plugin flips testOptions.unitTests.isIncludeAndroidResources = true and the
render/daemon tasks depend on AGP's unit-test manifest merge. That merge
rejects any transitive library whose uses-sdk:minSdkVersion is higher than
the consumer module's (e.g. ai.koog:koog-agents-android minSdk 35 against a
module on minSdk 26), surfacing an opaque manifest-merger failure that the
plugin is what triggers.

Add a CompatRules rule that reads each AAR's declared minSdkVersion from the
android-manifest artifacts on the unit-test classpath, compares it against
defaultConfig.minSdk, and emits an actionable doctor finding pointing at the
unit-test-only tools:overrideLibrary escape hatch (named with the exact
library packages) or a minSdk bump. Wired into both the CLI Tooling-API path
(ComposePreviewModelBuilder) and the Gradle-task path (ComposePreviewDoctorTask)
for parity. No silent override — that would mask the conflict for the
consumer's own unit tests.