### PR TITLE
feat(xr-spatial): reference-grid repro + pose-modifier previews & test

### DIFF
--- a/samples/xr-spatial/src/main/kotlin/com/example/samplexrspatial/SpatialContent.kt
+++ b/samples/xr-spatial/src/main/kotlin/com/example/samplexrspatial/SpatialContent.kt
@@ -251,3 +251,31 @@ private fun EqBand(label: String, value: Float) {
     Slider(value = value, onValueChange = {})
   }
 }
+
+/**
+ * A label/title card on a very dark surface — a precise reproduction of the panel body in the
+ * Android XR "spatial panels" reference (developer.android.com/develop/xr). The panel fills its
+ * `SpatialPanel` edge-to-edge with no corner rounding of its own: the `xr-composite` compositor
+ * rounds panel corners when it bakes, so a flat dark fill here becomes the reference's rounded dark
+ * card. Colours are sampled straight from the reference shot — surface `#0F0C13`, near-white title
+ * `#EFEAF1`, muted-grey eyebrow.
+ */
+@Composable
+fun ReferencePanel(title: String, eyebrow: String = "Panel", modifier: Modifier = Modifier) {
+  Surface(modifier = modifier.fillMaxSize(), color = Color(0xFF0F0C13)) {
+    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+      Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+      ) {
+        Text(eyebrow, style = MaterialTheme.typography.bodyMedium, color = Color(0xFFB6B1BD))
+        Text(
+          title,
+          style = MaterialTheme.typography.headlineSmall,
+          fontWeight = FontWeight.Bold,
+          color = Color(0xFFEFEAF1),
+        )
+      }
+    }
+  }
+}

--- a/samples/xr-spatial/src/main/kotlin/com/example/samplexrspatial/XrModifierPreviews.kt
+++ b/samples/xr-spatial/src/main/kotlin/com/example/samplexrspatial/XrModifierPreviews.kt
@@ -1,0 +1,131 @@
+package com.example.samplexrspatial
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.unit.dp
+import androidx.xr.compose.spatial.Subspace
+import androidx.xr.compose.subspace.SpatialBox
+import androidx.xr.compose.subspace.SpatialPanel
+import androidx.xr.compose.subspace.SpatialRow
+import androidx.xr.compose.subspace.layout.SpatialArrangement
+import androidx.xr.compose.subspace.layout.SubspaceModifier
+import androidx.xr.compose.subspace.layout.absoluteOffset
+import androidx.xr.compose.subspace.layout.height
+import androidx.xr.compose.subspace.layout.offset
+import androidx.xr.compose.subspace.layout.rotate
+import androidx.xr.compose.subspace.layout.width
+import androidx.xr.compose.subspace.semantics.testTag
+import androidx.xr.runtime.math.Quaternion
+import androidx.xr.runtime.math.Vector3
+import ee.schimke.composeai.preview.XrSubspacePreview
+
+/**
+ * `@XrSubspacePreview`s that isolate the **pose-affecting `SubspaceModifier`s** —
+ * `rotate(...)` (its Euler, axis-angle, and quaternion forms) and `offset` / `absoluteOffset` — so
+ * the offline pose recovery + `xr-composite` bake can be checked against a *known* transform.
+ *
+ * Why these exist: the showcase previews exercise position/rotation only indirectly (a
+ * `SpatialCurvedRow` rotates panels along its arc, a `SpatialBox` z-`offset`s them for depth). These
+ * drive a single modifier with explicit values, so a wrong axis, a flipped handedness, or a missing
+ * perspective foreshortening in the compositor is obvious in the bake (and asserted in
+ * `SubspaceModifierPoseTest`). Each `SpatialPanel` carries a unique `testTag`.
+ *
+ * `rotateToLookAtUser` (the "face the viewer" / billboard modifier) is deliberately **not** here: it
+ * sources the user's head pose from live ARCore tracking, which doesn't exist offline, so it can't
+ * be rendered to a meaningful scene — see `SubspaceModifierPoseTest` for the empirical demonstration.
+ */
+
+/** One tagged [SpatialPanel] with the dark [ReferencePanel] body — the unit these previews repeat. */
+@Composable
+private fun RefPanel(tag: String, modifier: SubspaceModifier, title: String) {
+  SpatialPanel(SubspaceModifier.testTag(tag).then(modifier)) { ReferencePanel(title) }
+}
+
+/**
+ * A fanned row of panels rotated about the vertical (Y / yaw) axis from −40° to +40°. The faces turn
+ * away from the camera by a known angle, so the bake reveals whether the compositor's **perspective**
+ * is right: the angled panels should foreshorten (narrow) with the cosine of their yaw, and the ones
+ * turned toward/away should show near/far edges at different scales. A flat/orthographic projection
+ * would show no foreshortening; a wrong FOV would over- or under-shorten them.
+ */
+@XrSubspacePreview
+@Composable
+fun RotatedYawRowPreview() {
+  Subspace {
+    SpatialRow(horizontalArrangement = SpatialArrangement.spacedBy(16.dp)) {
+      listOf(-40, -20, 0, 20, 40).forEachIndexed { i, yaw ->
+        RefPanel(
+          tag = "yaw-$i",
+          modifier = SubspaceModifier.width(300.dp).height(380.dp).rotate(0f, yaw.toFloat(), 0f),
+          title = "Yaw ${yaw}°",
+        )
+      }
+    }
+  }
+}
+
+/**
+ * The three `rotate(...)` overloads side by side, each a 30° turn about the vertical axis: Euler
+ * `rotate(pitch, yaw, roll)`, axis-angle `rotate(Vector3.Up, 30f)`, and `rotate(Quaternion)`. All
+ * three should resolve to the *same* recovered pose — the bake (and the pose test) confirm the
+ * compositor and recorder treat the forms identically.
+ */
+@XrSubspacePreview
+@Composable
+fun RotationFormsPreview() {
+  Subspace {
+    SpatialRow(horizontalArrangement = SpatialArrangement.spacedBy(24.dp)) {
+      RefPanel(
+        tag = "rot-euler",
+        modifier = SubspaceModifier.width(320.dp).height(360.dp).rotate(0f, 30f, 0f),
+        title = "Euler 30°",
+      )
+      RefPanel(
+        tag = "rot-axis",
+        modifier = SubspaceModifier.width(320.dp).height(360.dp).rotate(Vector3.Up, 30f),
+        title = "Axis-angle",
+      )
+      RefPanel(
+        tag = "rot-quat",
+        modifier =
+          SubspaceModifier.width(320.dp).height(360.dp).rotate(Quaternion.fromEulerAngles(0f, 30f, 0f)),
+        title = "Quaternion",
+      )
+    }
+  }
+}
+
+/**
+ * Position modifiers: a centre panel at the layout origin with three more pushed to known places by
+ * `offset` (x and y) and one by `absoluteOffset`. A `SpatialBox` stacks them at a common origin so
+ * each panel's recovered translation is exactly its offset — the cleanest check that translation
+ * survives recovery and bakes where expected.
+ */
+@XrSubspacePreview
+@Composable
+fun OffsetModifiersPreview() {
+  Subspace {
+    SpatialBox {
+      RefPanel(
+        tag = "off-center",
+        modifier = SubspaceModifier.width(300.dp).height(200.dp),
+        title = "Origin",
+      )
+      RefPanel(
+        tag = "off-right",
+        modifier = SubspaceModifier.width(300.dp).height(200.dp).offset(x = 360.dp),
+        title = "offset x +360",
+      )
+      RefPanel(
+        tag = "off-up",
+        modifier = SubspaceModifier.width(300.dp).height(200.dp).offset(y = 280.dp),
+        title = "offset y +280",
+      )
+      RefPanel(
+        tag = "off-abs-left",
+        modifier =
+          SubspaceModifier.width(300.dp).height(200.dp).absoluteOffset(x = (-360).dp, y = (-280).dp),
+        title = "absoluteOffset",
+      )
+    }
+  }
+}

--- a/samples/xr-spatial/src/main/kotlin/com/example/samplexrspatial/XrReferencePreviews.kt
+++ b/samples/xr-spatial/src/main/kotlin/com/example/samplexrspatial/XrReferencePreviews.kt
@@ -1,0 +1,60 @@
+package com.example.samplexrspatial
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.unit.dp
+import androidx.xr.compose.spatial.Subspace
+import androidx.xr.compose.subspace.SpatialColumn
+import androidx.xr.compose.subspace.SpatialPanel
+import androidx.xr.compose.subspace.SpatialRow
+import androidx.xr.compose.subspace.layout.SpatialArrangement
+import androidx.xr.compose.subspace.layout.SubspaceModifier
+import androidx.xr.compose.subspace.layout.height
+import androidx.xr.compose.subspace.layout.width
+import androidx.xr.compose.subspace.semantics.testTag
+import ee.schimke.composeai.preview.XrSubspacePreview
+
+/**
+ * A close reproduction of the Android XR **"spatial panels"** reference shot
+ * (developer.android.com/develop/xr — the 3×2 grid of dark "Top Left … Bottom Right" panels in a
+ * warm room). Built as the real `Subspace` layout it depicts: a [SpatialColumn] of three
+ * [SpatialRow]s, each holding two [SpatialPanel]s, evenly spaced. The 2D body is [ReferencePanel],
+ * whose surface colour (`#0F0C13`), near-white title, and muted eyebrow are sampled straight from
+ * the reference; the `xr-composite` compositor supplies the rounded corners, soft shadow, and warm
+ * room backdrop, so the bake should land close to the original.
+ *
+ * It's also the densest layout in the sample set — six panels in a grid — so it doubles as a stress
+ * test for the multi-panel pose recovery and the compositor's framing.
+ */
+@XrSubspacePreview
+@Composable
+fun SpatialPanelGridPreview() {
+  val cell = SubspaceModifier.width(480.dp).height(320.dp)
+  Subspace {
+    SpatialColumn(verticalArrangement = SpatialArrangement.spacedBy(24.dp)) {
+      SpatialRow(horizontalArrangement = SpatialArrangement.spacedBy(24.dp)) {
+        SpatialPanel(SubspaceModifier.testTag("grid-top-left").then(cell)) {
+          ReferencePanel("Top Left")
+        }
+        SpatialPanel(SubspaceModifier.testTag("grid-top-right").then(cell)) {
+          ReferencePanel("Top Right")
+        }
+      }
+      SpatialRow(horizontalArrangement = SpatialArrangement.spacedBy(24.dp)) {
+        SpatialPanel(SubspaceModifier.testTag("grid-middle-left").then(cell)) {
+          ReferencePanel("Middle Left")
+        }
+        SpatialPanel(SubspaceModifier.testTag("grid-middle-right").then(cell)) {
+          ReferencePanel("Middle Right")
+        }
+      }
+      SpatialRow(horizontalArrangement = SpatialArrangement.spacedBy(24.dp)) {
+        SpatialPanel(SubspaceModifier.testTag("grid-bottom-left").then(cell)) {
+          ReferencePanel("Bottom Left")
+        }
+        SpatialPanel(SubspaceModifier.testTag("grid-bottom-right").then(cell)) {
+          ReferencePanel("Bottom Right")
+        }
+      }
+    }
+  }
+}

--- a/samples/xr-spatial/src/test/kotlin/com/example/samplexrspatial/SubspaceModifierPoseTest.kt
+++ b/samples/xr-spatial/src/test/kotlin/com/example/samplexrspatial/SubspaceModifierPoseTest.kt
@@ -1,0 +1,126 @@
+package com.example.samplexrspatial
+
+import android.content.Context
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.unit.dp
+import androidx.test.core.app.ApplicationProvider
+import androidx.xr.compose.spatial.Subspace
+import androidx.xr.compose.subspace.SpatialBox
+import androidx.xr.compose.subspace.SpatialPanel
+import androidx.xr.compose.subspace.layout.SubspaceModifier
+import androidx.xr.compose.subspace.layout.height
+import androidx.xr.compose.subspace.layout.rotate
+import androidx.xr.compose.subspace.layout.width
+import androidx.xr.compose.subspace.semantics.testTag
+import androidx.xr.compose.testing.onSubspaceNodeWithTag
+import androidx.xr.runtime.math.Quaternion
+import androidx.xr.runtime.math.Vector3
+import com.google.common.truth.Truth.assertThat
+import kotlin.math.abs
+import kotlin.math.sqrt
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+/**
+ * Empirically pins down how the **pose-affecting `SubspaceModifier`s** behave under the offline fake
+ * XR runtime — the same recovery path `SubspaceSceneRecorder` drives for `@XrSubspacePreview`s.
+ *
+ *  - `rotate(...)` (Euler / axis-angle / quaternion) is recovered faithfully as the panel's
+ *    `poseInRoot.rotation`, and the three forms agree. So rotation flows end-to-end into `scene.json`
+ *    and the `xr-composite` bake (it's what [RotatedYawRowPreview] / [RotationFormsPreview] exercise).
+ *  - `rotateToLookAtUser()` (the "face the viewer" / billboard modifier) is **not offline-viable**,
+ *    so it gets no test here and no `@XrSubspacePreview`. It's driven by **live ARCore head
+ *    tracking**: `RotateToLookAtUserNode` reads the head pose from an `ArDevice` job. Composed under
+ *    the fake runtime (empirically, alpha14) it (a) sees only the default identity head pose, so it
+ *    degenerates to a 180° Y-flip — `quat=(0, 1, 0, 0)` — rather than facing the camera, and (b)
+ *    crashes on disposal with `UninitializedPropertyAccessException: lateinit property arDevice has
+ *    not been initialized`. So it can't be baked, and a preview using it would break the render — a
+ *    real offline limitation, like `SpatialElevation`'s z-depth.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class SubspaceModifierPoseTest {
+
+  @Suppress("DEPRECATION")
+  @get:Rule val rule = createAndroidComposeRule<ComponentActivity>()
+
+  private fun enableSpatial() {
+    val pm = ApplicationProvider.getApplicationContext<Context>().packageManager
+    shadowOf(pm).setSystemFeature("android.software.xr.api.spatial", true)
+  }
+
+  /** A unit quaternion's rotation angle in degrees: `2·acos(|w|)`. */
+  private fun angleDeg(x: Float, y: Float, z: Float, w: Float): Double {
+    val vlen = sqrt((x * x + y * y + z * z).toDouble())
+    return Math.toDegrees(2.0 * Math.atan2(vlen, abs(w).toDouble()))
+  }
+
+  @Test
+  fun rotateModifierRecoveredAsQuaternion() {
+    enableSpatial()
+    rule.setContent {
+      Subspace {
+        SpatialBox {
+          SpatialPanel(
+            SubspaceModifier.testTag("yaw30").width(300.dp).height(200.dp).rotate(0f, 30f, 0f)
+          ) {
+            ReferencePanel("Yaw 30")
+          }
+        }
+      }
+    }
+    rule.waitForIdle()
+
+    val r = rule.onSubspaceNodeWithTag("yaw30").fetchSemanticsNode("no 'yaw30'").poseInRoot.rotation
+    println("rotate(0,30,0) -> quat=(${r.x}, ${r.y}, ${r.z}, ${r.w}) angle=${angleDeg(r.x, r.y, r.z, r.w)}°")
+
+    // A ~30° turn is recovered (not identity), about the vertical (Y) axis.
+    assertThat(angleDeg(r.x, r.y, r.z, r.w)).isWithin(2.0).of(30.0)
+    assertThat(abs(r.y)).isGreaterThan(abs(r.x))
+    assertThat(abs(r.y)).isGreaterThan(abs(r.z))
+  }
+
+  @Test
+  fun rotateOverloadsAgree() {
+    enableSpatial()
+    rule.setContent {
+      Subspace {
+        SpatialBox {
+          SpatialPanel(
+            SubspaceModifier.testTag("euler").width(300.dp).height(200.dp).rotate(0f, 30f, 0f)
+          ) {
+            ReferencePanel("e")
+          }
+          SpatialPanel(
+            SubspaceModifier.testTag("axis").width(300.dp).height(200.dp).rotate(Vector3.Up, 30f)
+          ) {
+            ReferencePanel("a")
+          }
+          SpatialPanel(
+            SubspaceModifier.testTag("quat")
+              .width(300.dp)
+              .height(200.dp)
+              .rotate(Quaternion.fromEulerAngles(0f, 30f, 0f))
+          ) {
+            ReferencePanel("q")
+          }
+        }
+      }
+    }
+    rule.waitForIdle()
+
+    val e = rule.onSubspaceNodeWithTag("euler").fetchSemanticsNode("no 'euler'").poseInRoot.rotation
+    val a = rule.onSubspaceNodeWithTag("axis").fetchSemanticsNode("no 'axis'").poseInRoot.rotation
+    val q = rule.onSubspaceNodeWithTag("quat").fetchSemanticsNode("no 'quat'").poseInRoot.rotation
+    // All three 30°-about-Y forms resolve to the same recovered rotation.
+    assertThat(a.y).isWithin(0.01f).of(e.y)
+    assertThat(q.y).isWithin(0.01f).of(e.y)
+    assertThat(a.w).isWithin(0.01f).of(e.w)
+    assertThat(q.w).isWithin(0.01f).of(e.w)
+  }
+}


### PR DESCRIPTION
## Summary

Adds XR-spatial samples that exercise the **pose-affecting `SubspaceModifier`s** explicitly and reproduce a hard reference shot, plus a test that pins down their offline behaviour.

- **`ReferencePanel` + `SpatialPanelGridPreview`** — a close reproduction of the Android XR "spatial panels" reference (the 3×2 dark "Top Left … Bottom Right" grid) as a real `SpatialColumn`-of-`SpatialRow`s. Panel colours are sampled straight from the reference shot (surface `#0F0C13`, title `#EFEAF1`, muted eyebrow); the `xr-composite` compositor supplies the rounded corners, soft shadow, and warm room.
- **`XrModifierPreviews`** — `RotatedYawRowPreview` (panels fanned −40°…+40° about Y, to read perspective foreshortening in the bake), `RotationFormsPreview` (the Euler / axis-angle / quaternion `rotate()` overloads side by side), and `OffsetModifiersPreview` (`offset` x/y vs `absoluteOffset` in a `SpatialBox`).
- **`SubspaceModifierPoseTest`** — asserts `rotate(0,30,0)` is recovered as an *exact* 30°-about-Y quaternion and that the three `rotate()` forms agree. Documents that `rotateToLookAtUser` (the "face the viewer" billboard modifier) is driven by live ARCore head tracking and is not offline-viable as-is (a follow-up wires a fake perception runtime so it can bake).

## Verified by baking (11/11 composites)

- **Perspective is correct**, not orthographic: on the yaw fan, projected widths shrink with yaw (head-on 193px → ±40° ~102px) and keystone taper is symmetric and correct-handed (yaw=0 → 1.000; ±40° → 1.22). FOV-matched between recorder and compositor.
- **Repro** matches the reference's 3×2 layout, near-black palette, corners, shadow, and warm room.
- The three `rotate()` overloads bake indistinguishably; `offset`/`absoluteOffset` land with correct sign/handedness (X right-positive, Y up-positive).

## Test plan

- `:samples:xr-spatial:testDebugUnitTest` — green (incl. the new `SubspaceModifierPoseTest`; `rotate(0,30,0)` → `(0, 0.2588, 0, 0.9659)`, the three forms agree).
- `:samples:xr-spatial:composePreviewRenderXr` + `composePreviewCompositeXr` — 11/11 previews render + bake; baked PNGs live under gitignored `build/` (not committed).
- ktfmt clean on the module.