### PR TITLE
feat(xr): bake rotateToLookAtUser billboarding offline via fake perception runtime

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -1358,6 +1358,15 @@ internal object AndroidPreviewSupport {
         rendererConfig.name,
         "androidx.xr.compose:compose-testing:1.0.0-alpha14",
       )
+      // Fake ARCore perception runtime so `rotateToLookAtUser` (the billboard modifier, which reads
+      // the head pose from an `ArDevice`) renders offline. `:renderer-xr`'s `FakeXrHeadPose` seeds
+      // a
+      // viewer head pose into it; the `FakePerceptionRuntimeFactory` ServiceLoader registration
+      // ships in `:renderer-xr`'s main resources, alongside the scene/rendering fakes.
+      project.dependencies.add(
+        rendererConfig.name,
+        "androidx.xr.arcore:arcore-testing:1.0.0-alpha14",
+      )
     }
 
     // Mirror of rendererConfig for `:daemon:android`. The daemon

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -210,6 +210,13 @@ xr-glimmer = { module = "androidx.xr.glimmer:glimmer", version.ref = "xr-glimmer
 xr-glimmer-google-fonts = { module = "androidx.xr.glimmer:glimmer-google-fonts", version.ref = "xr-glimmer" }
 xr-compose = { module = "androidx.xr.compose:compose", version.ref = "xr-compose" }
 xr-compose-testing = { module = "androidx.xr.compose:compose-testing", version.ref = "xr-compose" }
+# Fake ARCore perception runtime (`FakePerceptionRuntimeFactory` + settable
+# `FakeRuntimeArDevice` head pose). Registered via `ServiceLoader` alongside the
+# scenecore/rendering fakes so the offline XR render/test path can drive
+# `rotateToLookAtUser` (the "face the viewer" billboard modifier reads the head
+# pose from an `ArDevice` perception job). Pinned literally like the other XR
+# `*-testing` artifacts; bump alongside `xr-compose`.
+xr-arcore-testing = { module = "androidx.xr.arcore:arcore-testing", version = "1.0.0-alpha14" }
 wear-tooling-preview = { module = "androidx.wear:wear-tooling-preview", version.ref = "wear-tooling-preview" }
 wear = { module = "androidx.wear:wear", version.ref = "wear" }
 horologist-compose-layout = { module = "com.google.android.horologist:horologist-compose-layout", version.ref = "horologist" }

--- a/renderers/xr/build.gradle.kts
+++ b/renderers/xr/build.gradle.kts
@@ -69,6 +69,11 @@ dependencies {
   testImplementation("androidx.compose.ui:ui-test-manifest")
   testImplementation("androidx.xr.runtime:runtime-testing:1.0.0-alpha14")
   testImplementation("androidx.xr.scenecore:scenecore-testing:1.0.0-alpha15")
+  // Fake ARCore perception runtime (settable `FakeRuntimeArDevice` head pose) so the recorder tests
+  // can drive `rotateToLookAtUser` offline via FakeXrHeadPose; registered for `ServiceLoader` in
+  // src/main/resources/META-INF/services. Test-only (and added to the render task classpath by the
+  // gradle plugin), mirroring how the scene/rendering fakes stay off this module's main classpath.
+  testImplementation(libs.xr.arcore.testing)
   testImplementation(libs.robolectric)
   testImplementation(libs.roborazzi)
   testImplementation(libs.roborazzi.compose)

--- a/renderers/xr/src/main/kotlin/ee/schimke/composeai/renderer/xr/FakeXrHeadPose.kt
+++ b/renderers/xr/src/main/kotlin/ee/schimke/composeai/renderer/xr/FakeXrHeadPose.kt
@@ -1,0 +1,113 @@
+package ee.schimke.composeai.renderer.xr
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.junit4.AndroidComposeTestRule
+import androidx.xr.compose.testing.session
+import androidx.xr.runtime.Config
+import androidx.xr.runtime.DeviceTrackingMode
+import androidx.xr.runtime.Session
+import androidx.xr.runtime.SessionCreateSuccess
+import androidx.xr.runtime.math.Pose
+import androidx.xr.runtime.math.Vector3
+
+/**
+ * Seeds the offline XR runtime with a **user head pose** so the `rotateToLookAtUser`
+ * ("face the viewer" / billboard) `SubspaceModifier` produces a sensible facing rotation under the
+ * fake XR runtime — the same recovery path [SubspaceSceneRecorder] drives for `@XrSubspacePreview`s.
+ *
+ * Why this is needed offline:
+ *  - `RotateToLookAtUserNode.onAttach` only wires up its `ArDevice` head-pose source when the
+ *    `Session` config has device tracking enabled; the default offline `Session` is created with
+ *    `DeviceTrackingMode.DISABLED`, so the node skips initialising `arDevice` and then crashes in its
+ *    head-pose job (`UninitializedPropertyAccessException: lateinit property arDevice ...`).
+ *  - Even configured, the fake `ArDevice` reports an identity pose at the origin, so a panel at the
+ *    origin would "look at" itself — a degenerate 180° Y-flip rather than facing the viewer.
+ *
+ * [install] fixes both: it pre-creates a `Session` (so `Subspace`'s `getOrCreateSession` reuses it
+ * via the decor-view tag rather than building a `DISABLED` one), flips its config to device-tracking,
+ * and seeds the fake `ArDevice`'s pose to the viewer's position — by default in front of the panels
+ * on +Z, where [SubspaceSceneRecorder.defaultCamera] puts the offline camera. The arcore fake
+ * (`FakePerceptionRuntimeFactory`) must be registered for `ServiceLoader`
+ * (`META-INF/services/androidx.xr.runtime.internal.PerceptionRuntimeFactory`) for this to resolve.
+ *
+ * Both the config flip and the pose seed go in through the runtime **state**, not `Session.configure`
+ * / `ArDevice.update`: those each spin an internal `runBlocking` that deadlocks under the Compose-UI
+ * test coroutine environment and register a live perception runtime that hangs the *next* preview
+ * rendered in the same JVM (the producer renders every `@XrSubspacePreview` in one
+ * `ParameterizedRobolectricTestRunner` JVM). Setting `Session.config` + the `ArDevice` state flow
+ * directly (reflectively, like the recorder's view/node recovery) keeps it side-effect-free and the
+ * arcore + arcore-testing artifacts off this module's compile classpath — they're a render-time
+ * dependency, registered alongside the scene/rendering fakes. The recorder tests are the canary if
+ * that shape shifts.
+ *
+ * Call **before** `setContent`, while the spatial system feature is already enabled.
+ */
+public object FakeXrHeadPose {
+
+  /**
+   * The viewer/head position used when none is supplied: in front of the panels, pulled back along
+   * +Z (the runtime works in metres; the recorder/compositor work in dp, but only the *direction*
+   * panel→head matters for the look-at rotation, so an order-of-magnitude-correct +Z is enough — it
+   * matches the sign of the offline camera in [SubspaceSceneRecorder.defaultCamera]).
+   */
+  public val DEFAULT_HEAD_POSE: Pose = Pose(translation = Vector3(0f, 0f, 2f))
+
+  /**
+   * Pre-creates the offline XR [Session] on [rule], enables device tracking on it, and seeds the fake
+   * head/device pose to [headPose]. Returns the session.
+   */
+  public fun install(
+    rule: AndroidComposeTestRule<*, ComponentActivity>,
+    headPose: Pose = DEFAULT_HEAD_POSE,
+  ): Session {
+    val created = Session.create(rule.activity)
+    check(created is SessionCreateSuccess) { "Could not create offline XR Session: $created" }
+    val session = created.session
+
+    // Flip the session config to device-tracking so RotateToLookAtUserNode.onAttach wires up its
+    // ArDevice source instead of bailing out and leaving `arDevice` uninitialised. Set the field
+    // directly (Session.configure runs a deadlock-prone runBlocking and registers a global perception
+    // runtime — see the class KDoc). The fake perception runtime already defaults to a device-tracking
+    // config, so ArDevice.getInstance resolves.
+    setSessionConfig(session, Config(deviceTracking = DeviceTrackingMode.SPATIAL_LAST_KNOWN))
+
+    // Make Subspace's getOrCreateSession reuse THIS session (it reads the decor-view tag first).
+    rule.session = session
+
+    seedHeadPose(session, headPose)
+    return session
+  }
+
+  /** Sets `Session.config` directly via the synthetic `access$setConfig$p` accessor (no runBlocking). */
+  private fun setSessionConfig(session: Session, config: Config) {
+    Session::class
+      .java
+      .getMethod("access\$setConfig\$p", Session::class.java, Config::class.java)
+      .invoke(null, session, config)
+  }
+
+  /**
+   * Seeds the head pose into the `ArDevice` state the node collects. `ArDevice.getInstance(session)`
+   * returns the cached wrapper the node reads; its pose comes from a `StateFlow<State>` seeded with an
+   * identity pose at construction. We set that flow's value directly (rather than `ArDevice.update()`,
+   * another deadlock-prone runBlocking) to a `State` carrying the viewer [headPose] and a live
+   * tracking state. All arcore access is reflective so the artifacts stay off the compile classpath.
+   */
+  private fun seedHeadPose(session: Session, headPose: Pose) {
+    val arDeviceClass = Class.forName("androidx.xr.arcore.ArDevice")
+    val arDevice = arDeviceClass.getMethod("getInstance", Session::class.java).invoke(null, session)
+
+    val trackingStateClass = Class.forName("androidx.xr.runtime.TrackingState")
+    val tracking = trackingStateClass.getField("TRACKING").get(null)
+    val stateClass = Class.forName("androidx.xr.arcore.ArDevice\$State")
+    val state =
+      stateClass
+        .getConstructor(Pose::class.java, trackingStateClass, arDeviceClass)
+        .newInstance(headPose, tracking, arDevice)
+
+    val stateField = arDeviceClass.getDeclaredField("_state").apply { isAccessible = true }
+    @Suppress("UNCHECKED_CAST")
+    val mutableState = stateField.get(arDevice) as kotlinx.coroutines.flow.MutableStateFlow<Any?>
+    mutableState.value = state
+  }
+}

--- a/renderers/xr/src/main/kotlin/ee/schimke/composeai/renderer/xr/XrSubspaceRenderer.kt
+++ b/renderers/xr/src/main/kotlin/ee/schimke/composeai/renderer/xr/XrSubspaceRenderer.kt
@@ -40,6 +40,12 @@ public object XrSubspaceRenderer {
     runCatching { method.asMethod().isAccessible = true }
     val receiver = resolveReceiver(clazz)
 
+    // Pre-create + configure the offline XR Session with device tracking + a seeded viewer head pose
+    // BEFORE setContent, so `rotateToLookAtUser` (the billboard modifier) can source a head pose and
+    // face the viewer instead of crashing on an uninitialised `arDevice`. Harmless for previews that
+    // don't use it — it just hands `Subspace` a ready-configured session. See FakeXrHeadPose.
+    FakeXrHeadPose.install(rule)
+
     rule.setContent { method.invoke(currentComposer, receiver) }
     rule.waitForIdle()
 

--- a/renderers/xr/src/main/resources/META-INF/services/androidx.xr.runtime.internal.PerceptionRuntimeFactory
+++ b/renderers/xr/src/main/resources/META-INF/services/androidx.xr.runtime.internal.PerceptionRuntimeFactory
@@ -1,0 +1,1 @@
+androidx.xr.arcore.testing.FakePerceptionRuntimeFactory

--- a/samples/xr-spatial/build.gradle.kts
+++ b/samples/xr-spatial/build.gradle.kts
@@ -85,6 +85,10 @@ dependencies {
   testImplementation(libs.xr.compose.testing)
   testImplementation("androidx.xr.runtime:runtime-testing:1.0.0-alpha14")
   testImplementation("androidx.xr.scenecore:scenecore-testing:1.0.0-alpha15")
+  // Fake ARCore perception runtime + settable head pose, so `SubspaceModifierPoseTest` can drive
+  // `rotateToLookAtUser` offline (registered for `ServiceLoader` in
+  // src/test/resources/META-INF/services alongside the scene/rendering fakes).
+  testImplementation(libs.xr.arcore.testing)
   testImplementation(libs.junit)
   testImplementation(libs.truth)
 }

--- a/samples/xr-spatial/src/main/kotlin/com/example/samplexrspatial/XrModifierPreviews.kt
+++ b/samples/xr-spatial/src/main/kotlin/com/example/samplexrspatial/XrModifierPreviews.kt
@@ -12,6 +12,7 @@ import androidx.xr.compose.subspace.layout.absoluteOffset
 import androidx.xr.compose.subspace.layout.height
 import androidx.xr.compose.subspace.layout.offset
 import androidx.xr.compose.subspace.layout.rotate
+import androidx.xr.compose.subspace.layout.rotateToLookAtUser
 import androidx.xr.compose.subspace.layout.width
 import androidx.xr.compose.subspace.semantics.testTag
 import androidx.xr.runtime.math.Quaternion
@@ -29,9 +30,11 @@ import ee.schimke.composeai.preview.XrSubspacePreview
  * perspective foreshortening in the compositor is obvious in the bake (and asserted in
  * `SubspaceModifierPoseTest`). Each `SpatialPanel` carries a unique `testTag`.
  *
- * `rotateToLookAtUser` (the "face the viewer" / billboard modifier) is deliberately **not** here: it
- * sources the user's head pose from live ARCore tracking, which doesn't exist offline, so it can't
- * be rendered to a meaningful scene — see `SubspaceModifierPoseTest` for the empirical demonstration.
+ * `rotateToLookAtUser` (the "face the viewer" / billboard modifier) is here too: it sources the
+ * user's head pose from an ARCore `ArDevice`, which the offline render path now supplies via a fake
+ * perception runtime seeded with a viewer head pose in front of the panels (see `:renderer-xr`'s
+ * `FakeXrHeadPose`, and `SubspaceModifierPoseTest` for the empirical recovery). Side panels visibly
+ * angle inward to face the viewer.
  */
 
 /** One tagged [SpatialPanel] with the dark [ReferencePanel] body — the unit these previews repeat. */
@@ -125,6 +128,41 @@ fun OffsetModifiersPreview() {
         modifier =
           SubspaceModifier.width(300.dp).height(200.dp).absoluteOffset(x = (-360).dp, y = (-280).dp),
         title = "absoluteOffset",
+      )
+    }
+  }
+}
+
+/**
+ * The "face the viewer" / billboard modifier: three panels offset left / centre / right, each
+ * `.rotateToLookAtUser()`. The modifier rotates each panel to face the user's head pose. Offline the
+ * render path seeds that head pose in front of the panels (see `:renderer-xr`'s `FakeXrHeadPose`), so
+ * on bake the centre panel faces head-on while the side panels visibly **angle inward** toward the
+ * viewer — the billboard behaviour, recovered offline. `SubspaceModifierPoseTest` asserts the
+ * recovered rotations (centre ≈ identity, sides turned about the vertical Y axis, never the old 180°
+ * flip).
+ */
+@XrSubspacePreview
+@Composable
+fun RotateToLookAtUserPreview() {
+  Subspace {
+    SpatialBox {
+      RefPanel(
+        tag = "look-left",
+        modifier =
+          SubspaceModifier.width(300.dp).height(380.dp).offset(x = (-520).dp).rotateToLookAtUser(),
+        title = "Look at user (L)",
+      )
+      RefPanel(
+        tag = "look-center",
+        modifier = SubspaceModifier.width(300.dp).height(380.dp).rotateToLookAtUser(),
+        title = "Look at user (C)",
+      )
+      RefPanel(
+        tag = "look-right",
+        modifier =
+          SubspaceModifier.width(300.dp).height(380.dp).offset(x = 520.dp).rotateToLookAtUser(),
+        title = "Look at user (R)",
       )
     }
   }

--- a/samples/xr-spatial/src/test/kotlin/com/example/samplexrspatial/RotateToLookAtUserPoseTest.kt
+++ b/samples/xr-spatial/src/test/kotlin/com/example/samplexrspatial/RotateToLookAtUserPoseTest.kt
@@ -1,0 +1,169 @@
+package com.example.samplexrspatial
+
+import android.content.Context
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.junit4.AndroidComposeTestRule
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.unit.dp
+import androidx.test.core.app.ApplicationProvider
+import androidx.xr.compose.spatial.Subspace
+import androidx.xr.compose.subspace.SpatialBox
+import androidx.xr.compose.subspace.SpatialPanel
+import androidx.xr.compose.subspace.layout.SubspaceModifier
+import androidx.xr.compose.subspace.layout.height
+import androidx.xr.compose.subspace.layout.offset
+import androidx.xr.compose.subspace.layout.rotateToLookAtUser
+import androidx.xr.compose.subspace.layout.width
+import androidx.xr.compose.subspace.semantics.testTag
+import androidx.xr.compose.testing.onSubspaceNodeWithTag
+import androidx.xr.compose.testing.session
+import androidx.xr.runtime.Config as XrConfig
+import androidx.xr.runtime.DeviceTrackingMode
+import androidx.xr.runtime.Session
+import androidx.xr.runtime.SessionCreateSuccess
+import androidx.xr.runtime.math.Pose
+import androidx.xr.runtime.math.Vector3
+import com.google.common.truth.Truth.assertThat
+import kotlin.math.abs
+import kotlin.math.sqrt
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.LooperMode
+
+/**
+ * Proves the **`rotateToLookAtUser`** ("face the viewer" / billboard) `SubspaceModifier` works under
+ * the offline fake XR runtime — the same recovery path `SubspaceSceneRecorder` drives for the
+ * [RotateToLookAtUserPreview] `@XrSubspacePreview`.
+ *
+ * `rotateToLookAtUser` is driven by `RotateToLookAtUserNode`, which reads the user's head pose from
+ * an ARCore `ArDevice` perception job. Out of the box offline that's unusable two ways: the default
+ * `Session` is created with device tracking `DISABLED`, so the node never initialises `arDevice` and
+ * crashes in its head-pose job (`UninitializedPropertyAccessException`); and with no head pose it
+ * degenerates to a 180° Y-flip. [seedHeadPose] fixes both — it registers the fake perception runtime
+ * (via `ServiceLoader`, see `src/test/resources/META-INF/services`), enables device tracking, and
+ * seeds a **viewer head pose in front of the panels (+Z)** — so a centred panel ends up facing the
+ * viewer (≈ identity) and side panels turn inward toward them. The render path seeds identically via
+ * `:renderer-xr`'s `FakeXrHeadPose`.
+ *
+ * Its own class (own Robolectric sandbox + PAUSED looper): the seeding calls `Session.configure` /
+ * `ArDevice.update`, each an internal `runBlocking` that deadlocks under Robolectric's default
+ * kotlinx-coroutines-test main dispatcher (PAUSED is the mode `:renderer-xr`'s render task runs in),
+ * and isolating it keeps the live perception runtime it spins up from leaking into the plainer
+ * `SubspaceModifierPoseTest` cases.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+@LooperMode(LooperMode.Mode.PAUSED)
+class RotateToLookAtUserPoseTest {
+
+  @Suppress("DEPRECATION")
+  @get:Rule val rule = createAndroidComposeRule<ComponentActivity>()
+
+  private fun enableSpatial() {
+    val pm = ApplicationProvider.getApplicationContext<Context>().packageManager
+    shadowOf(pm).setSystemFeature("android.software.xr.api.spatial", true)
+  }
+
+  /** A unit quaternion's rotation angle in degrees: `2·acos(|w|)`. */
+  private fun angleDeg(x: Float, y: Float, z: Float, w: Float): Double {
+    val vlen = sqrt((x * x + y * y + z * z).toDouble())
+    return Math.toDegrees(2.0 * Math.atan2(vlen, abs(w).toDouble()))
+  }
+
+  /**
+   * Makes `rotateToLookAtUser` viable offline: pre-creates a `Session` with **device tracking
+   * enabled** and seeds the fake `ArDevice` with a **viewer head pose** in front of the panels (+Z).
+   * Mirrors `:renderer-xr`'s `FakeXrHeadPose`, inlined so the sample test stays free of a renderer
+   * dependency. The arcore types are reached reflectively so the sample only needs the
+   * `arcore-testing` artifact on its classpath.
+   *
+   * Call **before** `setContent`, after the spatial feature is enabled.
+   */
+  private fun seedHeadPose(
+    rule: AndroidComposeTestRule<*, ComponentActivity>,
+    headPose: Pose = Pose(translation = Vector3(0f, 0f, 2f)),
+  ) {
+    val created = Session.create(rule.activity)
+    check(created is SessionCreateSuccess) { "Could not create offline XR Session: $created" }
+    val session = created.session
+    session.configure(XrConfig(deviceTracking = DeviceTrackingMode.SPATIAL_LAST_KNOWN))
+    rule.session = session // Subspace's getOrCreateSession reuses this (decor-view tag) session.
+
+    val arDeviceClass = Class.forName("androidx.xr.arcore.ArDevice")
+    val arDevice = arDeviceClass.getMethod("getInstance", Session::class.java).invoke(null, session)
+    val runtimeArDevice = arDeviceClass.getMethod("getRuntimeArDevice\$arcore").invoke(arDevice)
+    runtimeArDevice.javaClass
+      .getMethod("setDevicePose", Pose::class.java)
+      .invoke(runtimeArDevice, headPose)
+    val trackingStateClass = Class.forName("androidx.xr.arcore.runtime.TrackingState")
+    runtimeArDevice.javaClass
+      .getMethod("setTrackingState", trackingStateClass)
+      .invoke(runtimeArDevice, trackingStateClass.getField("TRACKING").get(null))
+    // Pump one update() (suspend) so the seeded pose lands in the StateFlow the node collects.
+    kotlinx.coroutines.runBlocking {
+      val update = arDeviceClass.getMethod("update", kotlin.coroutines.Continuation::class.java)
+      kotlin.coroutines.intrinsics.suspendCoroutineUninterceptedOrReturn<Unit> { cont ->
+        update.invoke(arDevice, cont)
+      }
+    }
+  }
+
+  @Test
+  fun rotateToLookAtUserFacesViewerOffline() {
+    enableSpatial()
+    // Enable device tracking + seed a head pose in front of the panels so "look at user" resolves.
+    seedHeadPose(rule)
+    rule.setContent {
+      Subspace {
+        SpatialBox {
+          // Centred panel: already in front of the viewer, so it should face straight on (≈ identity).
+          SpatialPanel(
+            SubspaceModifier.testTag("look-center").width(300.dp).height(200.dp).rotateToLookAtUser()
+          ) {
+            ReferencePanel("center")
+          }
+          // Offset to the left: must turn toward the viewer (rotate about the vertical Y axis).
+          SpatialPanel(
+            SubspaceModifier.testTag("look-left")
+              .width(300.dp)
+              .height(200.dp)
+              .offset(x = (-500).dp)
+              .rotateToLookAtUser()
+          ) {
+            ReferencePanel("left")
+          }
+        }
+      }
+    }
+    // Composes + measures + disposes WITHOUT crashing (the old failure mode was an
+    // UninitializedPropertyAccessException in the head-pose job / on disposal).
+    rule.waitForIdle()
+
+    val c =
+      rule
+        .onSubspaceNodeWithTag("look-center")
+        .fetchSemanticsNode("no 'look-center'")
+        .poseInRoot
+        .rotation
+    val l =
+      rule.onSubspaceNodeWithTag("look-left").fetchSemanticsNode("no 'look-left'").poseInRoot.rotation
+    val cAngle = angleDeg(c.x, c.y, c.z, c.w)
+    val lAngle = angleDeg(l.x, l.y, l.z, l.w)
+    println("rotateToLookAtUser center -> quat=(${c.x}, ${c.y}, ${c.z}, ${c.w}) angle=$cAngle°")
+    println("rotateToLookAtUser left   -> quat=(${l.x}, ${l.y}, ${l.z}, ${l.w}) angle=$lAngle°")
+
+    // Sensible, non-degenerate facing rotations — emphatically NOT the old ~180° Y-flip.
+    assertThat(cAngle).isLessThan(90.0)
+    assertThat(lAngle).isLessThan(90.0)
+    // The centred panel faces the viewer head-on (near identity).
+    assertThat(cAngle).isLessThan(5.0)
+    // The offset panel actually turns toward the viewer, about the vertical (Y) axis.
+    assertThat(lAngle).isGreaterThan(3.0)
+    assertThat(abs(l.y)).isGreaterThan(abs(l.x))
+    assertThat(abs(l.y)).isGreaterThan(abs(l.z))
+  }
+}

--- a/samples/xr-spatial/src/test/kotlin/com/example/samplexrspatial/SubspaceModifierPoseTest.kt
+++ b/samples/xr-spatial/src/test/kotlin/com/example/samplexrspatial/SubspaceModifierPoseTest.kt
@@ -33,14 +33,10 @@ import org.robolectric.annotation.Config
  *  - `rotate(...)` (Euler / axis-angle / quaternion) is recovered faithfully as the panel's
  *    `poseInRoot.rotation`, and the three forms agree. So rotation flows end-to-end into `scene.json`
  *    and the `xr-composite` bake (it's what [RotatedYawRowPreview] / [RotationFormsPreview] exercise).
- *  - `rotateToLookAtUser()` (the "face the viewer" / billboard modifier) is **not offline-viable**,
- *    so it gets no test here and no `@XrSubspacePreview`. It's driven by **live ARCore head
- *    tracking**: `RotateToLookAtUserNode` reads the head pose from an `ArDevice` job. Composed under
- *    the fake runtime (empirically, alpha14) it (a) sees only the default identity head pose, so it
- *    degenerates to a 180° Y-flip — `quat=(0, 1, 0, 0)` — rather than facing the camera, and (b)
- *    crashes on disposal with `UninitializedPropertyAccessException: lateinit property arDevice has
- *    not been initialized`. So it can't be baked, and a preview using it would break the render — a
- *    real offline limitation, like `SpatialElevation`'s z-depth.
+ *  - `rotateToLookAtUser()` (the "face the viewer" / billboard modifier) **also works offline** now —
+ *    its recovery has its own test, [RotateToLookAtUserPoseTest], because it needs a seeded head pose
+ *    and a PAUSED looper. A centred panel ends up facing the viewer and side panels turn inward, which
+ *    is what [RotateToLookAtUserPreview] bakes.
  */
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [35])

--- a/samples/xr-spatial/src/test/resources/META-INF/services/androidx.xr.runtime.internal.PerceptionRuntimeFactory
+++ b/samples/xr-spatial/src/test/resources/META-INF/services/androidx.xr.runtime.internal.PerceptionRuntimeFactory
@@ -1,0 +1,1 @@
+androidx.xr.arcore.testing.FakePerceptionRuntimeFactory


### PR DESCRIPTION
## Summary

Makes the Android XR **`rotateToLookAtUser`** ("face the viewer" / billboard) `SubspaceModifier` work in the offline preview render path. It reads the user's head pose from an ARCore `ArDevice`; offline that perception runtime was never registered, so the modifier crashed on disposal (`UninitializedPropertyAccessException: lateinit property arDevice has not been initialized`) and, with no head pose, degenerated to a 180° Y-flip — so it was excluded from previews.

The fix wires up the **fake ARCore perception runtime** offline, mirroring how the repo already registers the scene/rendering fakes:

- Register `androidx.xr.arcore.testing.FakePerceptionRuntimeFactory` via ServiceLoader (`META-INF/services/androidx.xr.runtime.internal.PerceptionRuntimeFactory`) in `:renderer-xr` main resources and the sample test resources; add the `arcore-testing` dependency (incl. the gradle-plugin render-task classpath).
- **`FakeXrHeadPose`** — pre-creates + configures the offline `Session` with device tracking enabled and seeds the fake `ArDevice` with a **viewer head pose in front of the panels** (+Z, where `SubspaceSceneRecorder.defaultCamera` sits). ARCore types are reached reflectively to keep them off the module's compile classpath (same idiom as the recorder's view/node recovery). `XrSubspaceRenderer` installs it before `setContent` for every preview (harmless for those that don't use the modifier).
- Add **`RotateToLookAtUserPreview`** (panels left / centre / right, each `.rotateToLookAtUser()`) and **`RotateToLookAtUserPoseTest`**.

## Result

`rotateToLookAtUser` now produces sensible facing rotations offline instead of crashing:

- centre panel → `(0,0,0,1)` = **0.0°** (faces the viewer head-on)
- left-offset panel → `(0, 0.107, 0, 0.994)` = **12.2° about Y** (turns inward toward the viewer)

No crash on disposal, no 180° flip.

## Test plan

- `:samples:xr-spatial:testDebugUnitTest` — green, incl. the new `RotateToLookAtUserPoseTest` (asserts centre ≈ identity, side panel turns about Y, never the old 180° flip) and the existing `SubspaceModifierPoseTest`.
- `:renderer-xr` **pipeline E2E** (`XrRenderPipelineE2eTest`) — green: the per-render head-pose seeding does **not** break the multi-preview render path (all previews rendered in one JVM).
- ktfmt clean on the touched modules.
- The new `RotateToLookAtUserPreview` is an `@XrSubspacePreview`, so it renders + bakes via the offline pipeline (baked PNGs are gitignored).

Builds on the XR-spatial modifier-samples work (now on `main`).