### PR TITLE
fix(xr): seed rotateToLookAtUser head pose in the render task + guard NaN poses

### DIFF
--- a/renderers/xr/src/main/kotlin/ee/schimke/composeai/renderer/xr/FakeXrHeadPose.kt
+++ b/renderers/xr/src/main/kotlin/ee/schimke/composeai/renderer/xr/FakeXrHeadPose.kt
@@ -97,6 +97,21 @@ public object FakeXrHeadPose {
     val arDeviceClass = Class.forName("androidx.xr.arcore.ArDevice")
     val arDevice = arDeviceClass.getMethod("getInstance", Session::class.java).invoke(null, session)
 
+    // Seed the underlying fake *runtime* device's pose, not just the ArDevice state flow below: the
+    // perception runtime's update cycle (which runs during waitForIdle in the multi-preview render
+    // task) refreshes ArDevice.state FROM the runtime device, and would otherwise overwrite a
+    // directly-set state back to the runtime's default identity pose — leaving the panel looking at
+    // the origin instead of the viewer. Setting both makes the seed survive a refresh AND be present
+    // immediately on attach.
+    val runtimeArDevice = arDeviceClass.getMethod("getRuntimeArDevice\$arcore").invoke(arDevice)
+    runtimeArDevice.javaClass
+      .getMethod("setDevicePose", Pose::class.java)
+      .invoke(runtimeArDevice, headPose)
+    val runtimeTrackingClass = Class.forName("androidx.xr.arcore.runtime.TrackingState")
+    runtimeArDevice.javaClass
+      .getMethod("setTrackingState", runtimeTrackingClass)
+      .invoke(runtimeArDevice, runtimeTrackingClass.getField("TRACKING").get(null))
+
     val trackingStateClass = Class.forName("androidx.xr.runtime.TrackingState")
     val tracking = trackingStateClass.getField("TRACKING").get(null)
     val stateClass = Class.forName("androidx.xr.arcore.ArDevice\$State")

--- a/renderers/xr/src/main/kotlin/ee/schimke/composeai/renderer/xr/SubspaceSceneRecorder.kt
+++ b/renderers/xr/src/main/kotlin/ee/schimke/composeai/renderer/xr/SubspaceSceneRecorder.kt
@@ -159,18 +159,32 @@ public object SubspaceSceneRecorder {
     val t = node.poseInRoot.translation
     val r = node.poseInRoot.rotation
     val size = node.size
+    // A modifier can resolve to a degenerate pose — e.g. `rotateToLookAtUser` when the head pose
+    // coincides with the panel position gives a zero-length look direction and a NaN quaternion.
+    // JSON has no NaN/Infinity, so emitting one fails scene.json serialization and breaks the whole
+    // render; sanitise to a finite pose (identity rotation, dropped non-finite offset) so one bad
+    // panel degrades to facing forward instead of taking down the scene.
+    val rot =
+      if (r.x.isFinite() && r.y.isFinite() && r.z.isFinite() && r.w.isFinite()) {
+        Quat(r.x.toDouble(), r.y.toDouble(), r.z.toDouble(), r.w.toDouble())
+      } else {
+        Quat(0.0, 0.0, 0.0, 1.0)
+      }
     return SpatialPanel(
       id = id,
       poseInRoot =
         SpatialPose(
-          translation = Vec3(t.x.toDouble(), t.y.toDouble(), t.z.toDouble()),
-          rotation = Quat(r.x.toDouble(), r.y.toDouble(), r.z.toDouble(), r.w.toDouble()),
+          translation = Vec3(t.x.finiteOrZero(), t.y.finiteOrZero(), t.z.finiteOrZero()),
+          rotation = rot,
         ),
       sizeDp = SizeDp(width = size.width, height = size.height),
       texture = "$id.png",
       parentId = parentId,
     )
   }
+
+  /** A finite value as a [Double], or `0.0` for `NaN`/`Infinity` (which JSON can't represent). */
+  private fun Float.finiteOrZero(): Double = if (isFinite()) toDouble() else 0.0
 
   /**
    * A neutral orbit camera framing the panels near head-on: look at the centre of their combined


### PR DESCRIPTION
## Summary

#1752 merged with the **`Render XR composite (sample)`** check still red (auto-merge treated it as non-required), so `main`'s `composePreviewRenderXr` is currently **broken**: `RotateToLookAtUserPreview` failed with `JsonEncodingException: Unexpected special floating-point value NaN`, and the billboard wasn't actually facing the viewer. Two root causes, two fixes:

- **`FakeXrHeadPose`** — the seed set only the `ArDevice` state flow, **not** the underlying fake *runtime* device's pose. In the multi-preview render task the perception runtime's update cycle (driven by `waitForIdle`) refreshes `ArDevice.state` *from* the runtime device — whose pose was still the default identity — **overwriting** the seed. So panels "looked at" the origin: the centre panel (at the origin) went degenerate → NaN, and the side panels turned 90° edge-on. Now it seeds the runtime device's pose + tracking state too, so the refresh keeps the viewer head pose.
- **`SubspaceSceneRecorder.panelFrom`** — general hardening: sanitise any non-finite recovered pose (a degenerate look-at can yield NaN) to a finite one (identity rotation, dropped non-finite offset), so one bad panel degrades to facing forward instead of failing scene.json serialization and taking down the whole render.

## Result

`composePreviewRenderXr` renders all previews; the recovered `rotateToLookAtUser` poses are now correct and symmetric:

| panel | position | rotation |
|---|---|---|
| `look-center` | origin | **0.0°** (faces viewer head-on) |
| `look-left` | x −520 | **+12.7° about Y** (turns inward) |
| `look-right` | x +520 | **−12.7° about Y** (turns inward) |

## Test plan

- `:samples:xr-spatial:composePreviewRenderXr` — all previews render (was 1/12 failing with NaN).
- `:samples:xr-spatial:testDebugUnitTest` (incl. `RotateToLookAtUserPoseTest`, `SubspaceModifierPoseTest`) — green.
- `:renderer-xr:testDebugUnitTest` (`SubspaceSceneRecorder*` + `XrRenderPipelineE2eTest`) — green (the NaN-guard doesn't change finite poses).
- ktfmt clean.