### PR TITLE
feat(vscode): add Google Fonts browser with live customiser

### DIFF
--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -104,12 +104,30 @@ to `minimal` when the daemon's memory cost isn't worth it for your project.
 3. Use the **Previews** panel to browse discovered `@Preview` functions and
    their rendered images.
 
+### Google Fonts browser
+
+Run **Compose Preview: Browse Google Fonts** from the command palette to open a
+font browser backed by the keyless Google Fonts catalog (no API key required):
+
+- **Search** the full catalog by name and filter by category. Each result row
+  is painted in its own real typeface.
+- **Download** a family — its files are cached under the extension's global
+  storage (nothing is written to your workspace).
+- Downloaded fonts appear on a shelf rendered in their actual face. Select one
+  to **live-customise** it: weight, italic, size, letter-spacing, line-height,
+  and — for variable fonts — a slider per registered variation axis (`opsz`,
+  `slnt`, `GRAD`, …).
+- The customiser generates a ready-to-paste Compose `FontFamily` / `TextStyle`
+  snippet (with `FontVariation.Settings` for variable axes) and a **Copy**
+  button.
+
 ### Commands
 
 | Command                                | Description                                                                      |
 | -------------------------------------- | -------------------------------------------------------------------------------- |
 | `Compose Preview: Refresh Previews`    | Re-read `previews.json` and rendered PNGs from `build/compose-previews/`.        |
 | `Compose Preview: Render All Previews` | Run the `composePreviewRenderAll` Gradle task to discover and render everything. |
+| `Compose Preview: Browse Google Fonts` | Open the Google Fonts browser: search, download, and live-customise fonts.       |
 
 ### Settings
 

--- a/vscode-extension/esbuild.webview.mjs
+++ b/vscode-extension/esbuild.webview.mjs
@@ -42,6 +42,10 @@ const entries = [
         in: resolve(root, "src/webview/spatial/main.ts"),
         out: resolve(root, "media/webview/spatial.js"),
     },
+    {
+        in: resolve(root, "src/webview/fonts/main.ts"),
+        out: resolve(root, "media/webview/fonts.js"),
+    },
 ];
 
 if (watch) {

--- a/vscode-extension/media/fonts.css
+++ b/vscode-extension/media/fonts.css
@@ -1,0 +1,292 @@
+/* Styling for the Google Fonts browser webview (`font-browser-app`). */
+
+body {
+    font-family: var(--vscode-font-family);
+    font-size: var(--vscode-font-size);
+    color: var(--vscode-foreground);
+    margin: 0;
+    padding: 12px;
+}
+
+.gfb-toolbar {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    position: sticky;
+    top: 0;
+    background: var(--vscode-editor-background);
+    padding-bottom: 8px;
+    z-index: 2;
+}
+
+.gfb-search {
+    flex: 1;
+    min-width: 120px;
+    background: var(--vscode-input-background);
+    color: var(--vscode-input-foreground);
+    border: 1px solid var(--vscode-input-border, transparent);
+    padding: 5px 8px;
+    border-radius: 3px;
+}
+
+.gfb-category {
+    background: var(--vscode-dropdown-background);
+    color: var(--vscode-dropdown-foreground);
+    border: 1px solid var(--vscode-dropdown-border, transparent);
+    padding: 4px 6px;
+    border-radius: 3px;
+}
+
+.gfb-btn {
+    background: var(--vscode-button-secondaryBackground);
+    color: var(--vscode-button-secondaryForeground);
+    border: 0;
+    padding: 5px 12px;
+    border-radius: 3px;
+    cursor: pointer;
+}
+
+.gfb-btn:hover {
+    background: var(--vscode-button-secondaryHoverBackground);
+}
+
+.gfb-btn[disabled] {
+    opacity: 0.5;
+    cursor: default;
+}
+
+.gfb-primary {
+    background: var(--vscode-button-background);
+    color: var(--vscode-button-foreground);
+}
+
+.gfb-primary:hover {
+    background: var(--vscode-button-hoverBackground);
+}
+
+.gfb-link {
+    background: none;
+    border: 0;
+    color: var(--vscode-textLink-foreground);
+    cursor: pointer;
+    padding: 4px 6px;
+    font-size: 90%;
+}
+
+.gfb-link:hover {
+    text-decoration: underline;
+}
+
+.gfb-section-title {
+    font-size: 1em;
+    font-weight: 600;
+    margin: 16px 0 6px;
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+}
+
+.gfb-count {
+    font-size: 80%;
+    font-weight: 400;
+    color: var(--vscode-descriptionForeground);
+}
+
+.gfb-message {
+    padding: 16px;
+    color: var(--vscode-descriptionForeground);
+}
+
+.gfb-error {
+    color: var(--vscode-errorForeground);
+}
+
+.gfb-results {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.gfb-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 8px 10px;
+    border: 1px solid transparent;
+    border-radius: 4px;
+}
+
+.gfb-row:hover {
+    background: var(--vscode-list-hoverBackground);
+}
+
+.gfb-row-main {
+    min-width: 0;
+    flex: 1;
+}
+
+.gfb-specimen-line {
+    font-size: 24px;
+    line-height: 1.3;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.gfb-row-meta {
+    display: flex;
+    gap: 6px;
+    margin-top: 2px;
+    flex-wrap: wrap;
+}
+
+.gfb-tag {
+    font-size: 75%;
+    padding: 1px 6px;
+    border-radius: 8px;
+    background: var(--vscode-badge-background);
+    color: var(--vscode-badge-foreground);
+}
+
+.gfb-variable {
+    background: var(--vscode-charts-blue, #3794ff);
+    color: #fff;
+}
+
+.gfb-row-actions {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex-shrink: 0;
+}
+
+.gfb-downloaded-pill {
+    font-size: 80%;
+    color: var(--vscode-descriptionForeground);
+    padding: 4px 8px;
+}
+
+.gfb-downloaded {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.gfb-chip {
+    background: var(--vscode-editorWidget-background);
+    color: var(--vscode-foreground);
+    border: 1px solid var(--vscode-widget-border, transparent);
+    border-radius: 14px;
+    padding: 4px 12px;
+    cursor: pointer;
+    font-size: 16px;
+}
+
+.gfb-chip-active {
+    border-color: var(--vscode-focusBorder);
+    background: var(--vscode-list-activeSelectionBackground);
+    color: var(--vscode-list-activeSelectionForeground);
+}
+
+.gfb-customiser {
+    border: 1px solid var(--vscode-widget-border, var(--vscode-panel-border));
+    border-radius: 6px;
+    padding: 12px;
+    margin: 12px 0;
+    background: var(--vscode-editorWidget-background);
+}
+
+.gfb-customiser-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.gfb-customiser-head-actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.gfb-warn {
+    color: var(--vscode-editorWarning-foreground);
+    font-size: 85%;
+}
+
+.gfb-specimen-input {
+    width: 100%;
+    box-sizing: border-box;
+    min-height: 48px;
+    resize: vertical;
+    background: var(--vscode-input-background);
+    color: var(--vscode-input-foreground);
+    border: 1px solid var(--vscode-input-border, transparent);
+    border-radius: 3px;
+    padding: 6px 8px;
+    font-family: var(--vscode-font-family);
+}
+
+.gfb-preview {
+    margin: 12px 0;
+    padding: 16px;
+    background: var(--vscode-editor-background);
+    border-radius: 4px;
+    overflow-wrap: anywhere;
+    min-height: 48px;
+}
+
+.gfb-controls {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 10px 16px;
+}
+
+.gfb-control {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    font-size: 85%;
+}
+
+.gfb-control-label {
+    display: flex;
+    justify-content: space-between;
+    color: var(--vscode-descriptionForeground);
+}
+
+.gfb-control-value {
+    font-variant-numeric: tabular-nums;
+    color: var(--vscode-foreground);
+}
+
+.gfb-control input[type="range"] {
+    width: 100%;
+}
+
+.gfb-checkbox {
+    flex-direction: row;
+    align-items: center;
+    gap: 6px;
+    align-self: end;
+}
+
+.gfb-snippet-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-top: 14px;
+    margin-bottom: 4px;
+    font-weight: 600;
+}
+
+.gfb-snippet {
+    margin: 0;
+    padding: 10px;
+    background: var(--vscode-textCodeBlock-background);
+    border-radius: 4px;
+    overflow: auto;
+    font-family: var(--vscode-editor-font-family, monospace);
+    font-size: 90%;
+    white-space: pre;
+}

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -131,6 +131,12 @@
                 "category": "Compose Preview",
                 "icon": "$(package)",
                 "enablement": "config.composePreview.earlyFeatures.enabled"
+            },
+            {
+                "command": "composePreview.openFontBrowser",
+                "title": "Browse Google Fonts",
+                "category": "Compose Preview",
+                "icon": "$(text-size)"
             }
         ],
         "menus": {

--- a/vscode-extension/src/downloadedFontsStore.ts
+++ b/vscode-extension/src/downloadedFontsStore.ts
@@ -1,0 +1,224 @@
+// Persistent store for fonts the user has downloaded from the browser.
+//
+// Per the chosen design ("extension cache only") downloads live under
+// the extension's global-storage directory, never the workspace:
+//
+//   <globalStorage>/fonts/index.json          ← manifest of all families
+//   <globalStorage>/fonts/<familyId>/<file>   ← the woff2/ttf bytes
+//
+// The browser lists whatever the manifest records, and serves each face
+// to the webview as a `webview.asWebviewUri(...)` resource so the real
+// typeface paints even though the panel never had it on its system
+// stack.
+//
+// All disk access funnels through an injected `StorageFs`, so the unit
+// tests exercise add/list/remove against an in-memory fake.
+
+import * as fsp from "fs/promises";
+import * as path from "path";
+import type { FontAxis } from "./googleFontsCatalog";
+import type { Css2Face } from "./googleFontsClient";
+
+export interface DownloadedFace {
+    style: "normal" | "italic";
+    weightMin: number;
+    weightMax: number;
+    /** File name within the family directory. */
+    fileName: string;
+    /** CSS `format(...)` token, e.g. `woff2`. */
+    format: string;
+}
+
+export interface DownloadedFont {
+    family: string;
+    /** Slugged, filesystem-safe id (also the sub-directory name). */
+    familyId: string;
+    category: string;
+    isVariable: boolean;
+    axes: FontAxis[];
+    faces: DownloadedFace[];
+    downloadedAt: string;
+}
+
+interface IndexFile {
+    version: 1;
+    fonts: DownloadedFont[];
+}
+
+/** Minimal disk surface — satisfied by `nodeStorageFs()` in production. */
+export interface StorageFs {
+    mkdirp(dir: string): Promise<void>;
+    readText(file: string): Promise<string>;
+    writeText(file: string, text: string): Promise<void>;
+    writeBytes(file: string, data: Uint8Array): Promise<void>;
+    remove(target: string): Promise<void>;
+    exists(target: string): Promise<boolean>;
+}
+
+/** Slug a family name into a filesystem-safe directory / resource id. */
+export function slugFamily(family: string): string {
+    return (
+        family
+            .toLowerCase()
+            .replace(/[^a-z0-9]+/g, "-")
+            .replace(/^-+|-+$/g, "") || "font"
+    );
+}
+
+function extForFormat(format: string): string {
+    switch (format.toLowerCase()) {
+        case "woff2":
+            return "woff2";
+        case "woff":
+            return "woff";
+        case "truetype":
+        case "ttf":
+            return "ttf";
+        case "opentype":
+        case "otf":
+            return "otf";
+        default:
+            return "woff2";
+    }
+}
+
+/** Deterministic per-face file name (style + weight range). */
+export function faceFileName(familyId: string, face: Css2Face): string {
+    const range =
+        face.weightMin === face.weightMax
+            ? String(face.weightMin)
+            : `${face.weightMin}_${face.weightMax}`;
+    return `${familyId}-${face.style}-${range}.${extForFormat(face.format)}`;
+}
+
+export interface AddFontInput {
+    family: string;
+    category: string;
+    isVariable: boolean;
+    axes: FontAxis[];
+    /** Parsed css2 face + its downloaded bytes. */
+    faces: { face: Css2Face; bytes: Uint8Array }[];
+}
+
+export class DownloadedFontsStore {
+    private readonly fontsDir: string;
+    private readonly indexPath: string;
+
+    constructor(
+        rootDir: string,
+        private readonly fs: StorageFs,
+    ) {
+        this.fontsDir = path.join(rootDir, "fonts");
+        this.indexPath = path.join(this.fontsDir, "index.json");
+    }
+
+    /** Directory that must be added to the webview's `localResourceRoots`. */
+    get resourceRoot(): string {
+        return this.fontsDir;
+    }
+
+    /** Absolute path to a stored face file (for `asWebviewUri`). */
+    facePath(font: DownloadedFont, face: DownloadedFace): string {
+        return path.join(this.fontsDir, font.familyId, face.fileName);
+    }
+
+    async list(): Promise<DownloadedFont[]> {
+        if (!(await this.fs.exists(this.indexPath))) return [];
+        try {
+            const parsed = JSON.parse(
+                await this.fs.readText(this.indexPath),
+            ) as Partial<IndexFile>;
+            return Array.isArray(parsed.fonts)
+                ? (parsed.fonts as DownloadedFont[])
+                : [];
+        } catch {
+            // Corrupt manifest — treat as empty rather than wedging the panel.
+            return [];
+        }
+    }
+
+    async has(familyId: string): Promise<boolean> {
+        return (await this.list()).some((f) => f.familyId === familyId);
+    }
+
+    async add(input: AddFontInput): Promise<DownloadedFont> {
+        const familyId = slugFamily(input.family);
+        const dir = path.join(this.fontsDir, familyId);
+        await this.fs.mkdirp(dir);
+
+        const faces: DownloadedFace[] = [];
+        for (const { face, bytes } of input.faces) {
+            const fileName = faceFileName(familyId, face);
+            await this.fs.writeBytes(path.join(dir, fileName), bytes);
+            faces.push({
+                style: face.style,
+                weightMin: face.weightMin,
+                weightMax: face.weightMax,
+                fileName,
+                format: face.format,
+            });
+        }
+
+        const record: DownloadedFont = {
+            family: input.family,
+            familyId,
+            category: input.category,
+            isVariable: input.isVariable,
+            axes: input.axes,
+            faces,
+            downloadedAt: new Date().toISOString(),
+        };
+
+        const existing = (await this.list()).filter(
+            (f) => f.familyId !== familyId,
+        );
+        await this.writeIndex([...existing, record]);
+        return record;
+    }
+
+    async remove(familyId: string): Promise<void> {
+        const remaining = (await this.list()).filter(
+            (f) => f.familyId !== familyId,
+        );
+        const dir = path.join(this.fontsDir, familyId);
+        if (await this.fs.exists(dir)) {
+            await this.fs.remove(dir);
+        }
+        await this.writeIndex(remaining);
+    }
+
+    private async writeIndex(fonts: DownloadedFont[]): Promise<void> {
+        await this.fs.mkdirp(this.fontsDir);
+        const index: IndexFile = { version: 1, fonts };
+        await this.fs.writeText(this.indexPath, JSON.stringify(index, null, 2));
+    }
+}
+
+/** Production `StorageFs` backed by `node:fs/promises`. */
+export function nodeStorageFs(): StorageFs {
+    return {
+        async mkdirp(dir) {
+            await fsp.mkdir(dir, { recursive: true });
+        },
+        async readText(file) {
+            return fsp.readFile(file, "utf8");
+        },
+        async writeText(file, text) {
+            await fsp.writeFile(file, text, "utf8");
+        },
+        async writeBytes(file, data) {
+            await fsp.writeFile(file, data);
+        },
+        async remove(target) {
+            await fsp.rm(target, { recursive: true, force: true });
+        },
+        async exists(target) {
+            try {
+                await fsp.stat(target);
+                return true;
+            } catch {
+                return false;
+            }
+        },
+    };
+}

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -15,6 +15,7 @@ import { KotlinCompileError } from "./kotlinCompileErrorDetector";
 import { PreviewPanel } from "./previewPanel";
 import { parseSpatialSceneJson } from "./webview/spatial/sceneLoader";
 import { BundleViewerPanel } from "./bundleViewerPanel";
+import { FontBrowserPanel } from "./fontBrowserPanel";
 import { isLikelyBundle } from "./bundleFormat";
 import { PreviewRegistry } from "./previewRegistry";
 import { PreviewGutterDecorations } from "./previewGutterDecorations";
@@ -2000,6 +2001,16 @@ export async function activate(
                 }
                 const fsPath = resource?.fsPath ?? "";
                 void handleBundleDropped(fsPath, path.basename(fsPath) || "");
+            },
+        ),
+        vscode.commands.registerCommand(
+            "composePreview.openFontBrowser",
+            () => {
+                FontBrowserPanel.open({
+                    extensionUri: context.extensionUri,
+                    globalStorageUri: context.globalStorageUri,
+                    logLine,
+                });
             },
         ),
     );

--- a/vscode-extension/src/fontBrowserPanel.ts
+++ b/vscode-extension/src/fontBrowserPanel.ts
@@ -1,0 +1,376 @@
+// Editor-style webview panel: a Google Fonts browser.
+//
+// Search the keyless Google Fonts catalog, download a family into the
+// extension's global-storage cache, and live-customise the downloaded
+// face (weight / italic / size / spacing, plus per-axis sliders for
+// variable fonts) with a generated Compose snippet.
+//
+// The panel owns all network + disk work; the webview only renders and
+// posts intent. One panel per window — re-invoking the command reveals
+// the existing tab.
+
+import * as crypto from "crypto";
+import * as fsp from "fs/promises";
+import * as path from "path";
+import * as vscode from "vscode";
+import {
+    buildCss2DownloadUrl,
+    type FontCatalog,
+    type FontFamilyMeta,
+} from "./googleFontsCatalog";
+import {
+    downloadFontBytes,
+    fetchCss2Faces,
+    fetchFontCatalog,
+    type Css2Face,
+} from "./googleFontsClient";
+import {
+    DownloadedFontsStore,
+    nodeStorageFs,
+    slugFamily,
+    type DownloadedFont,
+} from "./downloadedFontsStore";
+import type {
+    DownloadedFontView,
+    FaceView,
+} from "./webview/fonts/fontBrowserLogic";
+import type { HostToWebview, WebviewToHost } from "./webview/fonts/protocol";
+
+const CHANNEL = "[font-browser]";
+const CATALOG_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+export interface FontBrowserDeps {
+    extensionUri: vscode.Uri;
+    globalStorageUri: vscode.Uri;
+    logLine: (message: string) => void;
+}
+
+export class FontBrowserPanel {
+    private static current: FontBrowserPanel | null = null;
+
+    static open(deps: FontBrowserDeps): FontBrowserPanel {
+        if (FontBrowserPanel.current) {
+            FontBrowserPanel.current.panel.reveal(vscode.ViewColumn.Active);
+            return FontBrowserPanel.current;
+        }
+        const store = new DownloadedFontsStore(
+            deps.globalStorageUri.fsPath,
+            nodeStorageFs(),
+        );
+        const panel = vscode.window.createWebviewPanel(
+            "composePreview.fontBrowser",
+            "Google Fonts",
+            vscode.ViewColumn.Active,
+            {
+                enableScripts: true,
+                retainContextWhenHidden: true,
+                localResourceRoots: [
+                    deps.extensionUri,
+                    vscode.Uri.file(store.resourceRoot),
+                ],
+            },
+        );
+        const browser = new FontBrowserPanel(panel, deps, store);
+        FontBrowserPanel.current = browser;
+        return browser;
+    }
+
+    private disposed = false;
+    private catalog: FontCatalog | null = null;
+
+    private constructor(
+        private readonly panel: vscode.WebviewPanel,
+        private readonly deps: FontBrowserDeps,
+        private readonly store: DownloadedFontsStore,
+    ) {
+        panel.webview.html = this.buildHtml();
+        panel.onDidDispose(() => this.dispose());
+        panel.webview.onDidReceiveMessage((msg: WebviewToHost) => {
+            void this.onMessage(msg);
+        });
+    }
+
+    private dispose(): void {
+        if (this.disposed) return;
+        this.disposed = true;
+        if (FontBrowserPanel.current === this) {
+            FontBrowserPanel.current = null;
+        }
+    }
+
+    private postToWebview(msg: HostToWebview): void {
+        if (this.disposed) return;
+        void this.panel.webview.postMessage(msg);
+    }
+
+    private async onMessage(msg: WebviewToHost): Promise<void> {
+        if (this.disposed) return;
+        switch (msg.command) {
+            case "ready":
+                await this.sendDownloaded();
+                await this.loadCatalog(false);
+                break;
+            case "refreshCatalog":
+                await this.loadCatalog(true);
+                break;
+            case "download":
+                await this.handleDownload(msg.family);
+                break;
+            case "removeDownloaded":
+                await this.handleRemove(msg.familyId);
+                break;
+            case "copySnippet":
+                await vscode.env.clipboard.writeText(msg.text);
+                void vscode.window.showInformationMessage(
+                    "Compose font snippet copied to clipboard.",
+                );
+                break;
+            case "openExternal":
+                if (/^https?:\/\//i.test(msg.url)) {
+                    void vscode.env.openExternal(vscode.Uri.parse(msg.url));
+                }
+                break;
+        }
+    }
+
+    // ---- catalog --------------------------------------------------------
+
+    private get catalogCachePath(): string {
+        return path.join(
+            this.deps.globalStorageUri.fsPath,
+            "fonts",
+            "catalog.json",
+        );
+    }
+
+    private async loadCatalog(forceRefresh: boolean): Promise<void> {
+        this.postToWebview({ command: "catalogLoading" });
+        if (!forceRefresh) {
+            if (this.catalog) {
+                this.postToWebview({
+                    command: "catalog",
+                    catalog: this.catalog,
+                });
+                return;
+            }
+            const cached = await this.readCachedCatalog();
+            if (cached) {
+                this.catalog = cached;
+                this.postToWebview({ command: "catalog", catalog: cached });
+                return;
+            }
+        }
+        try {
+            const catalog = await fetchFontCatalog();
+            this.catalog = catalog;
+            await this.writeCachedCatalog(catalog);
+            this.postToWebview({ command: "catalog", catalog });
+        } catch (err) {
+            const message = (err as Error).message;
+            this.deps.logLine(`${CHANNEL} catalog fetch failed: ${message}`);
+            // Fall back to a stale cache if we have one before erroring.
+            const stale = this.catalog ?? (await this.readCachedCatalog());
+            if (stale) {
+                this.catalog = stale;
+                this.postToWebview({ command: "catalog", catalog: stale });
+            } else {
+                this.postToWebview({ command: "catalogError", message });
+            }
+        }
+    }
+
+    private async readCachedCatalog(): Promise<FontCatalog | null> {
+        try {
+            const raw = await fsp.readFile(this.catalogCachePath, "utf8");
+            const catalog = JSON.parse(raw) as FontCatalog;
+            const age = Date.now() - Date.parse(catalog.fetchedAt);
+            if (!Number.isFinite(age) || age > CATALOG_TTL_MS) return null;
+            return catalog;
+        } catch {
+            return null;
+        }
+    }
+
+    private async writeCachedCatalog(catalog: FontCatalog): Promise<void> {
+        try {
+            await fsp.mkdir(path.dirname(this.catalogCachePath), {
+                recursive: true,
+            });
+            await fsp.writeFile(
+                this.catalogCachePath,
+                JSON.stringify(catalog),
+                "utf8",
+            );
+        } catch (err) {
+            this.deps.logLine(
+                `${CHANNEL} catalog cache write failed: ${(err as Error).message}`,
+            );
+        }
+    }
+
+    // ---- downloads ------------------------------------------------------
+
+    private async handleDownload(family: string): Promise<void> {
+        const familyId = slugFamily(family);
+        const meta = this.findMeta(family);
+        if (!meta) {
+            this.postToWebview({
+                command: "downloadState",
+                familyId,
+                family,
+                state: "error",
+                message: "Font not found in catalog",
+            });
+            return;
+        }
+        this.postToWebview({
+            command: "downloadState",
+            familyId,
+            family,
+            state: "downloading",
+        });
+        try {
+            const faces = await this.downloadFamily(meta);
+            if (faces.length === 0) {
+                throw new Error("Google returned no downloadable font files");
+            }
+            await this.store.add({
+                family: meta.family,
+                category: meta.category,
+                isVariable: meta.isVariable,
+                axes: [...meta.axes],
+                faces,
+            });
+            this.postToWebview({
+                command: "downloadState",
+                familyId,
+                family,
+                state: "done",
+            });
+            await this.sendDownloaded();
+            this.deps.logLine(
+                `${CHANNEL} downloaded ${meta.family} (${faces.length} faces)`,
+            );
+        } catch (err) {
+            const message = (err as Error).message;
+            this.deps.logLine(
+                `${CHANNEL} download ${family} failed: ${message}`,
+            );
+            this.postToWebview({
+                command: "downloadState",
+                familyId,
+                family,
+                state: "error",
+                message,
+            });
+            void vscode.window.showErrorMessage(
+                `Compose Preview — failed to download ${family}: ${message}`,
+            );
+        }
+    }
+
+    private async downloadFamily(
+        meta: FontFamilyMeta,
+    ): Promise<{ face: Css2Face; bytes: Uint8Array }[]> {
+        const css2Url = buildCss2DownloadUrl(meta);
+        const cssFaces = await fetchCss2Faces(css2Url);
+        // De-duplicate by file URL so the same gstatic file isn't fetched
+        // twice (variable fonts emit one block per ital tuple).
+        const seen = new Map<string, Css2Face>();
+        for (const face of cssFaces) {
+            if (!seen.has(face.url)) seen.set(face.url, face);
+        }
+        const out: { face: Css2Face; bytes: Uint8Array }[] = [];
+        for (const face of seen.values()) {
+            const bytes = await downloadFontBytes(face.url);
+            out.push({ face, bytes });
+        }
+        return out;
+    }
+
+    private async handleRemove(familyId: string): Promise<void> {
+        await this.store.remove(familyId);
+        await this.sendDownloaded();
+    }
+
+    private async sendDownloaded(): Promise<void> {
+        const fonts = await this.store.list();
+        this.postToWebview({
+            command: "downloaded",
+            fonts: fonts.map((f) => this.toView(f)),
+        });
+    }
+
+    private toView(font: DownloadedFont): DownloadedFontView {
+        const faces: FaceView[] = font.faces.map((face) => ({
+            style: face.style,
+            weightMin: face.weightMin,
+            weightMax: face.weightMax,
+            format: face.format,
+            uri: this.panel.webview
+                .asWebviewUri(vscode.Uri.file(this.store.facePath(font, face)))
+                .toString(),
+        }));
+        return {
+            family: font.family,
+            familyId: font.familyId,
+            category: font.category,
+            isVariable: font.isVariable,
+            axes: font.axes,
+            faces,
+        };
+    }
+
+    private findMeta(family: string): FontFamilyMeta | null {
+        if (!this.catalog) return null;
+        const lower = family.toLowerCase();
+        return (
+            this.catalog.families.find(
+                (f) => f.family.toLowerCase() === lower,
+            ) ?? null
+        );
+    }
+
+    // ---- html -----------------------------------------------------------
+
+    private buildHtml(): string {
+        const webview = this.panel.webview;
+        const nonce = crypto.randomBytes(16).toString("hex");
+        const styleUri = webview.asWebviewUri(
+            vscode.Uri.joinPath(this.deps.extensionUri, "media", "fonts.css"),
+        );
+        const scriptUri = webview.asWebviewUri(
+            vscode.Uri.joinPath(
+                this.deps.extensionUri,
+                "media",
+                "webview",
+                "fonts.js",
+            ),
+        );
+        // `style-src` carries `'unsafe-inline'` (not a nonce) because the
+        // webview sets inline `style="font-variation-settings: …"` on the
+        // live specimen and injects `@font-face` rules at runtime —
+        // attribute-level inline styles can't be nonced. Scripts stay
+        // locked to the nonce. Font files come from gstatic (browse
+        // previews) and the webview-served cache (`cspSource`).
+        const csp = [
+            "default-src 'none'",
+            `img-src ${webview.cspSource} data:`,
+            `font-src ${webview.cspSource} https://fonts.gstatic.com`,
+            `style-src ${webview.cspSource} https://fonts.googleapis.com 'unsafe-inline'`,
+            `script-src 'nonce-${nonce}'`,
+        ].join("; ");
+        return /* html */ `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="Content-Security-Policy" content="${csp};">
+    <link href="${styleUri}" rel="stylesheet">
+</head>
+<body>
+    <font-browser-app></font-browser-app>
+    <script nonce="${nonce}" src="${scriptUri}"></script>
+</body>
+</html>`;
+    }
+}

--- a/vscode-extension/src/fontBrowserPanel.ts
+++ b/vscode-extension/src/fontBrowserPanel.ts
@@ -153,7 +153,7 @@ export class FontBrowserPanel {
                 });
                 return;
             }
-            const cached = await this.readCachedCatalog();
+            const cached = await this.readCachedCatalog(false);
             if (cached) {
                 this.catalog = cached;
                 this.postToWebview({ command: "catalog", catalog: cached });
@@ -168,8 +168,11 @@ export class FontBrowserPanel {
         } catch (err) {
             const message = (err as Error).message;
             this.deps.logLine(`${CHANNEL} catalog fetch failed: ${message}`);
-            // Fall back to a stale cache if we have one before erroring.
-            const stale = this.catalog ?? (await this.readCachedCatalog());
+            // Fall back to any cached catalog if we have one before
+            // erroring — here we deliberately ignore the TTL: a stale
+            // catalog is far more useful than an empty error state when
+            // the network is unavailable.
+            const stale = this.catalog ?? (await this.readCachedCatalog(true));
             if (stale) {
                 this.catalog = stale;
                 this.postToWebview({ command: "catalog", catalog: stale });
@@ -179,12 +182,23 @@ export class FontBrowserPanel {
         }
     }
 
-    private async readCachedCatalog(): Promise<FontCatalog | null> {
+    /**
+     * Read the on-disk catalog cache. With [ignoreTtl] false (the normal
+     * pre-fetch path) a catalog older than [CATALOG_TTL_MS] is rejected
+     * so we refresh from the network; with it true (the network-failure
+     * fallback) any parseable cache is returned — stale data beats an
+     * error screen when we're offline.
+     */
+    private async readCachedCatalog(
+        ignoreTtl: boolean,
+    ): Promise<FontCatalog | null> {
         try {
             const raw = await fsp.readFile(this.catalogCachePath, "utf8");
             const catalog = JSON.parse(raw) as FontCatalog;
-            const age = Date.now() - Date.parse(catalog.fetchedAt);
-            if (!Number.isFinite(age) || age > CATALOG_TTL_MS) return null;
+            if (!ignoreTtl) {
+                const age = Date.now() - Date.parse(catalog.fetchedAt);
+                if (!Number.isFinite(age) || age > CATALOG_TTL_MS) return null;
+            }
             return catalog;
         } catch {
             return null;

--- a/vscode-extension/src/googleFontsCatalog.ts
+++ b/vscode-extension/src/googleFontsCatalog.ts
@@ -1,0 +1,278 @@
+// Pure model + parsing for the Google Fonts catalog.
+//
+// The catalog is sourced from `https://fonts.google.com/metadata/fonts`
+// (the same keyless JSON the fonts.google.com site itself consumes — no
+// Developer API key required). This module is deliberately free of any
+// `node`/`vscode`/`fs` imports so it can be shared verbatim between the
+// host (`googleFontsClient`, `fontBrowserPanel`) and the webview bundle
+// (`webview/fonts/*`), and unit-tested without a DOM.
+//
+// Nothing here touches the network — `googleFontsClient` owns the fetch
+// and hands the raw JSON text in. We only parse, normalise, search, and
+// build the `fonts.googleapis.com/css2` request URLs.
+
+/** A single registered variation axis on a variable font. */
+export interface FontAxis {
+    /** OpenType axis tag, e.g. `wght`, `opsz`, `slnt`, `GRAD`. */
+    tag: string;
+    /** Human label from the axis registry (falls back to the tag). */
+    displayName: string;
+    min: number;
+    max: number;
+    defaultValue: number;
+}
+
+/** A static named instance the family ships (from the `fonts` map). */
+export interface FontInstance {
+    weight: number;
+    italic: boolean;
+}
+
+export interface FontFamilyMeta {
+    family: string;
+    category: string;
+    subsets: readonly string[];
+    /** Lower is more popular (Google's ranking is 1-based). */
+    popularity: number;
+    /** Variable axes; empty for a non-variable family. */
+    axes: readonly FontAxis[];
+    /** Static instances parsed from the `fonts` map. */
+    instances: readonly FontInstance[];
+    /** Sorted, de-duplicated weights from `instances`. */
+    weights: readonly number[];
+    hasItalic: boolean;
+    isVariable: boolean;
+}
+
+export interface FontCatalog {
+    families: readonly FontFamilyMeta[];
+    categories: readonly string[];
+    fetchedAt: string;
+}
+
+const CSS2_BASE = "https://fonts.googleapis.com/css2";
+
+function num(value: unknown, fallback: number): number {
+    return typeof value === "number" && Number.isFinite(value)
+        ? value
+        : fallback;
+}
+
+/**
+ * Google prefixes some JSON endpoints with an XSSI guard (`)]}'`).
+ * Strip everything before the first `{` so `JSON.parse` succeeds. The
+ * guard contains no braces, so the first `{` is always the real start
+ * of the object payload.
+ */
+export function stripXssiPrefix(text: string): string {
+    const brace = text.indexOf("{");
+    return brace > 0 ? text.slice(brace) : text;
+}
+
+/** Parse a `fonts` map key (`"400"`, `"400italic"`, `"regular"`, …). */
+function parseInstanceKey(key: string): FontInstance | null {
+    if (key === "regular") return { weight: 400, italic: false };
+    if (key === "italic") return { weight: 400, italic: true };
+    const m = /^(\d{1,4})(italic)?$/.exec(key);
+    if (!m) return null;
+    return { weight: parseInt(m[1], 10), italic: m[2] != null };
+}
+
+/**
+ * Parse the raw `metadata/fonts` JSON object into a normalised catalog.
+ * Defensive against schema drift — unknown / malformed families are
+ * dropped rather than throwing, so one bad row can't blank the browser.
+ */
+export function parseFontsMetadata(raw: unknown): FontCatalog {
+    const root =
+        raw && typeof raw === "object" ? (raw as Record<string, unknown>) : {};
+
+    // Axis registry → displayName / default lookups for enrichment.
+    const registry = new Map<
+        string,
+        { displayName: string; defaultValue: number }
+    >();
+    const rawRegistry = root.axisRegistry;
+    if (Array.isArray(rawRegistry)) {
+        for (const entry of rawRegistry) {
+            if (!entry || typeof entry !== "object") continue;
+            const a = entry as Record<string, unknown>;
+            if (typeof a.tag !== "string") continue;
+            registry.set(a.tag, {
+                displayName:
+                    typeof a.displayName === "string" ? a.displayName : a.tag,
+                defaultValue: num(a.defaultValue, 0),
+            });
+        }
+    }
+
+    const families: FontFamilyMeta[] = [];
+    const list = Array.isArray(root.familyMetadataList)
+        ? root.familyMetadataList
+        : [];
+    for (const item of list) {
+        if (!item || typeof item !== "object") continue;
+        const f = item as Record<string, unknown>;
+        const family = typeof f.family === "string" ? f.family : "";
+        if (!family) continue;
+        const category =
+            typeof f.category === "string" && f.category ? f.category : "Other";
+        const subsets = Array.isArray(f.subsets)
+            ? (f.subsets.filter((s) => typeof s === "string") as string[])
+            : [];
+        const popularity = num(f.popularity, Number.MAX_SAFE_INTEGER);
+
+        const instances: FontInstance[] = [];
+        if (f.fonts && typeof f.fonts === "object") {
+            for (const key of Object.keys(f.fonts as object)) {
+                const parsed = parseInstanceKey(key);
+                if (parsed) instances.push(parsed);
+            }
+        }
+
+        const axes: FontAxis[] = [];
+        if (Array.isArray(f.axes)) {
+            for (const entry of f.axes) {
+                if (!entry || typeof entry !== "object") continue;
+                const a = entry as Record<string, unknown>;
+                if (typeof a.tag !== "string") continue;
+                const reg = registry.get(a.tag);
+                axes.push({
+                    tag: a.tag,
+                    displayName: reg?.displayName ?? a.tag,
+                    min: num(a.min, 0),
+                    max: num(a.max, 0),
+                    defaultValue: num(a.defaultValue, reg?.defaultValue ?? 0),
+                });
+            }
+        }
+
+        const weights = [...new Set(instances.map((i) => i.weight))].sort(
+            (a, b) => a - b,
+        );
+        const hasItalic = instances.some((i) => i.italic);
+        families.push({
+            family,
+            category,
+            subsets,
+            popularity,
+            axes,
+            instances,
+            weights: weights.length > 0 ? weights : [400],
+            hasItalic,
+            isVariable: axes.length > 0,
+        });
+    }
+
+    families.sort(
+        (a, b) =>
+            a.popularity - b.popularity || a.family.localeCompare(b.family),
+    );
+    const categories = [...new Set(families.map((f) => f.category))].sort();
+    return { families, categories, fetchedAt: new Date().toISOString() };
+}
+
+export interface SearchOptions {
+    query?: string;
+    /** Category filter; `"all"` (or empty) matches everything. */
+    category?: string;
+    /** Cap the result count (default 60 to keep browse previews cheap). */
+    limit?: number;
+}
+
+/**
+ * Filter + cap a catalog. Families arrive already sorted by popularity,
+ * so callers get the most popular matches first without re-sorting.
+ */
+export function searchCatalog(
+    catalog: FontCatalog,
+    options: SearchOptions = {},
+): FontFamilyMeta[] {
+    const query = (options.query ?? "").trim().toLowerCase();
+    const category = options.category ?? "all";
+    const limit = options.limit ?? 60;
+    const out: FontFamilyMeta[] = [];
+    for (const family of catalog.families) {
+        if (category && category !== "all" && family.category !== category) {
+            continue;
+        }
+        if (query && !family.family.toLowerCase().includes(query)) {
+            continue;
+        }
+        out.push(family);
+        if (out.length >= limit) break;
+    }
+    return out;
+}
+
+/** Encode a family name for a css2 `family=` segment (spaces → `+`). */
+export function css2FamilyToken(family: string): string {
+    return family.replace(/ /g, "+");
+}
+
+/**
+ * css2 requires axis tags sorted: lowercase tags alphabetically, then
+ * the rest (uppercase / custom registered axes like `GRAD`).
+ */
+export function sortAxisTags(tags: readonly string[]): string[] {
+    const lower = tags.filter((t) => t === t.toLowerCase()).sort();
+    const upper = tags.filter((t) => t !== t.toLowerCase()).sort();
+    return [...lower, ...upper];
+}
+
+function fmtAxisValue(value: number): string {
+    return Number.isInteger(value) ? String(value) : String(value);
+}
+
+/**
+ * A lightweight css2 URL for *browsing* — just the default upright face
+ * so each result row can paint in its real typeface without dragging
+ * every weight/axis down the wire.
+ */
+export function buildCss2BrowseUrl(family: string): string {
+    return `${CSS2_BASE}?family=${css2FamilyToken(family)}&display=swap`;
+}
+
+/**
+ * The css2 URL used when *downloading* a family. For a variable font we
+ * request the full range of every declared axis (plus both italic
+ * tuples when the family ships italics) so the cached file retains all
+ * its variation axes. For a static family we enumerate every shipped
+ * (italic, weight) instance so each face is downloaded individually.
+ */
+export function buildCss2DownloadUrl(meta: FontFamilyMeta): string {
+    const token = css2FamilyToken(meta.family);
+    let spec: string;
+    if (meta.isVariable) {
+        const tags: string[] = [];
+        if (meta.hasItalic) tags.push("ital");
+        for (const a of meta.axes) if (a.tag !== "ital") tags.push(a.tag);
+        const sorted = sortAxisTags(tags);
+        const rangeFor = (tag: string): string => {
+            const axis = meta.axes.find((a) => a.tag === tag);
+            return axis
+                ? `${fmtAxisValue(axis.min)}..${fmtAxisValue(axis.max)}`
+                : "0";
+        };
+        const tuple = (italValue: number | null): string =>
+            sorted
+                .map((t) =>
+                    t === "ital" ? String(italValue ?? 0) : rangeFor(t),
+                )
+                .join(",");
+        const tuples = meta.hasItalic ? [tuple(0), tuple(1)] : [tuple(null)];
+        spec = `${sorted.join(",")}@${tuples.join(";")}`;
+    } else {
+        const hasItalic = meta.hasItalic;
+        const tags = hasItalic ? ["ital", "wght"] : ["wght"];
+        const instances = [...meta.instances].sort(
+            (a, b) =>
+                (a.italic ? 1 : 0) - (b.italic ? 1 : 0) || a.weight - b.weight,
+        );
+        const tuples = instances.map((i) =>
+            hasItalic ? `${i.italic ? 1 : 0},${i.weight}` : `${i.weight}`,
+        );
+        spec = `${tags.join(",")}@${tuples.join(";")}`;
+    }
+    return `${CSS2_BASE}?family=${token}:${spec}&display=swap`;
+}

--- a/vscode-extension/src/googleFontsClient.ts
+++ b/vscode-extension/src/googleFontsClient.ts
@@ -1,0 +1,165 @@
+// Host-side network access for the Google Fonts browser.
+//
+// Three jobs, all driven through an injected `FetchLike` so the unit
+// tests can pin responses without touching the network:
+//
+//   * `fetchFontCatalog`  — GET the keyless `metadata/fonts` JSON.
+//   * `fetchCss2Faces`    — GET a `css2` stylesheet and parse the
+//                           `@font-face` blocks (one per face/subset)
+//                           down to the gstatic file URLs.
+//   * `downloadFontBytes` — GET a single gstatic font file.
+//
+// Google's css2 endpoint returns *modern* formats (woff2) only when the
+// request carries a browser-ish User-Agent; from Node we set one
+// explicitly so we don't get served legacy TTF.
+
+import {
+    FontCatalog,
+    parseFontsMetadata,
+    stripXssiPrefix,
+} from "./googleFontsCatalog";
+
+export interface FetchResponse {
+    ok: boolean;
+    status: number;
+    text(): Promise<string>;
+    arrayBuffer(): Promise<ArrayBuffer>;
+}
+
+export type FetchLike = (
+    url: string,
+    init?: { headers?: Record<string, string> },
+) => Promise<FetchResponse>;
+
+export const FONTS_METADATA_URL = "https://fonts.google.com/metadata/fonts";
+
+// A current-ish Chrome UA so css2 serves woff2 rather than legacy ttf.
+const BROWSER_UA =
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 " +
+    "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+
+function defaultFetch(): FetchLike {
+    const g = globalThis as { fetch?: FetchLike };
+    if (!g.fetch) {
+        throw new Error(
+            "global fetch is unavailable in this runtime; pass a FetchLike explicitly",
+        );
+    }
+    return g.fetch.bind(globalThis) as FetchLike;
+}
+
+/** GET + parse the keyless Google Fonts catalog. */
+export async function fetchFontCatalog(
+    fetchImpl: FetchLike = defaultFetch(),
+): Promise<FontCatalog> {
+    const res = await fetchImpl(FONTS_METADATA_URL, {
+        headers: { "User-Agent": BROWSER_UA, Accept: "application/json" },
+    });
+    if (!res.ok) {
+        throw new Error(
+            `Google Fonts metadata request failed (HTTP ${res.status})`,
+        );
+    }
+    const text = await res.text();
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(stripXssiPrefix(text));
+    } catch (err) {
+        throw new Error(
+            `Google Fonts metadata was not valid JSON: ${(err as Error).message}`,
+        );
+    }
+    return parseFontsMetadata(parsed);
+}
+
+export interface Css2Face {
+    style: "normal" | "italic";
+    /** Static weight, or the low end of a variable `font-weight` range. */
+    weightMin: number;
+    /** Equal to `weightMin` for a static face. */
+    weightMax: number;
+    /** gstatic file URL. */
+    url: string;
+    /** `woff2` / `woff` / `truetype` etc. (defaults to `woff2`). */
+    format: string;
+    /** Subset comment preceding the block (`latin`, `cyrillic`, …). */
+    subset: string | null;
+}
+
+const FONT_FACE_RE = /(?:\/\*\s*([\w-]+)\s*\*\/\s*)?@font-face\s*\{([^}]*)\}/g;
+
+/**
+ * Parse every `@font-face` block out of a css2 stylesheet. css2 emits
+ * one block per (style, weight) × subset, so the same face appears for
+ * `latin`, `latin-ext`, `cyrillic`, … each with its own file URL. We
+ * de-duplicate by (style, weightMin, weightMax) preferring the `latin`
+ * subset's file — that's the slice that covers the specimen text we
+ * render, and downloading one file per face keeps the cache small.
+ */
+export function parseCss2Faces(css: string): Css2Face[] {
+    const byKey = new Map<string, Css2Face>();
+    let m: RegExpExecArray | null;
+    FONT_FACE_RE.lastIndex = 0;
+    while ((m = FONT_FACE_RE.exec(css)) !== null) {
+        const subset = m[1] ?? null;
+        const body = m[2] ?? "";
+        const styleMatch = /font-style:\s*([a-z]+)/i.exec(body);
+        const style: "normal" | "italic" =
+            styleMatch && styleMatch[1].toLowerCase() === "italic"
+                ? "italic"
+                : "normal";
+        const weightMatch = /font-weight:\s*([\d]+)(?:\s+([\d]+))?/.exec(body);
+        const weightMin = weightMatch ? parseInt(weightMatch[1], 10) : 400;
+        const weightMax =
+            weightMatch && weightMatch[2]
+                ? parseInt(weightMatch[2], 10)
+                : weightMin;
+        const urlMatch = /src:\s*url\(([^)]+)\)/i.exec(body);
+        if (!urlMatch) continue;
+        const url = urlMatch[1].trim().replace(/^['"]|['"]$/g, "");
+        const formatMatch = /format\(\s*['"]?([\w-]+)/i.exec(body);
+        const format = formatMatch ? formatMatch[1] : "woff2";
+
+        const key = `${style}:${weightMin}:${weightMax}`;
+        const existing = byKey.get(key);
+        if (!existing || (subset === "latin" && existing.subset !== "latin")) {
+            byKey.set(key, {
+                style,
+                weightMin,
+                weightMax,
+                url,
+                format,
+                subset,
+            });
+        }
+    }
+    return [...byKey.values()];
+}
+
+/** GET a css2 stylesheet and return its parsed faces. */
+export async function fetchCss2Faces(
+    css2Url: string,
+    fetchImpl: FetchLike = defaultFetch(),
+): Promise<Css2Face[]> {
+    const res = await fetchImpl(css2Url, {
+        headers: { "User-Agent": BROWSER_UA },
+    });
+    if (!res.ok) {
+        throw new Error(
+            `Google Fonts css2 request failed (HTTP ${res.status})`,
+        );
+    }
+    return parseCss2Faces(await res.text());
+}
+
+/** GET a single font file as bytes. */
+export async function downloadFontBytes(
+    url: string,
+    fetchImpl: FetchLike = defaultFetch(),
+): Promise<Uint8Array> {
+    const res = await fetchImpl(url);
+    if (!res.ok) {
+        throw new Error(`Font file download failed (HTTP ${res.status})`);
+    }
+    return new Uint8Array(await res.arrayBuffer());
+}

--- a/vscode-extension/src/test/composeFontSnippet.test.ts
+++ b/vscode-extension/src/test/composeFontSnippet.test.ts
@@ -1,0 +1,74 @@
+// Pins the Compose snippet codegen for the font browser's customiser.
+
+import * as assert from "assert";
+import {
+    fontIdentifier,
+    fontResourceName,
+    generateComposeSnippet,
+} from "../webview/fonts/composeFontSnippet";
+import type { FontAxis } from "../googleFontsCatalog";
+
+const wght: FontAxis = {
+    tag: "wght",
+    displayName: "Weight",
+    min: 100,
+    max: 900,
+    defaultValue: 400,
+};
+const opsz: FontAxis = {
+    tag: "opsz",
+    displayName: "Optical Size",
+    min: 8,
+    max: 144,
+    defaultValue: 14,
+};
+
+describe("composeFontSnippet", () => {
+    it("derives resource names and identifiers", () => {
+        assert.strictEqual(fontResourceName("Open Sans"), "open_sans");
+        assert.strictEqual(fontResourceName("IBM Plex Mono"), "ibm_plex_mono");
+        assert.strictEqual(fontIdentifier("Open Sans"), "OpenSans");
+        assert.strictEqual(fontIdentifier("roboto-flex"), "RobotoFlex");
+    });
+
+    it("emits a static FontFamily without variation settings", () => {
+        const out = generateComposeSnippet({
+            family: "Lora",
+            weight: 700,
+            italic: true,
+            isVariable: false,
+            axisValues: {},
+            axes: [],
+            fontSizeSp: 16,
+            letterSpacingSp: 0.5,
+            lineHeightSp: 24,
+        });
+        assert.ok(out.includes("val LoraFontFamily = FontFamily("));
+        assert.ok(out.includes("resId = R.font.lora"));
+        assert.ok(out.includes("weight = FontWeight(700)"));
+        assert.ok(out.includes("style = FontStyle.Italic"));
+        assert.ok(!out.includes("FontVariation"));
+        assert.ok(out.includes("fontSize = 16.sp"));
+        assert.ok(out.includes("letterSpacing = 0.50.sp"));
+        assert.ok(out.includes("fontStyle = FontStyle.Italic"));
+    });
+
+    it("emits FontVariation.Settings for variable fonts", () => {
+        const out = generateComposeSnippet({
+            family: "Roboto Flex",
+            weight: 500,
+            italic: false,
+            isVariable: true,
+            axisValues: { wght: 500, opsz: 40 },
+            axes: [wght, opsz],
+            fontSizeSp: 32,
+            letterSpacingSp: 0,
+            lineHeightSp: 40,
+        });
+        assert.ok(out.includes("variationSettings = FontVariation.Settings("));
+        assert.ok(out.includes("FontVariation.weight(500)"));
+        assert.ok(out.includes('FontVariation.Setting("opsz", 40f)'));
+        // wght goes through the dedicated helper, not a generic Setting.
+        assert.ok(!out.includes('FontVariation.Setting("wght"'));
+    });
+});

--- a/vscode-extension/src/test/downloadedFontsStore.test.ts
+++ b/vscode-extension/src/test/downloadedFontsStore.test.ts
@@ -1,0 +1,157 @@
+// Pins the downloaded-fonts store add/list/remove cycle against an
+// in-memory StorageFs fake.
+
+import * as assert from "assert";
+import * as path from "path";
+import {
+    DownloadedFontsStore,
+    faceFileName,
+    slugFamily,
+    type StorageFs,
+} from "../downloadedFontsStore";
+import type { Css2Face } from "../googleFontsClient";
+
+class FakeFs implements StorageFs {
+    files = new Map<string, string | Uint8Array>();
+    dirs = new Set<string>();
+
+    async mkdirp(dir: string): Promise<void> {
+        this.dirs.add(dir);
+    }
+    async readText(file: string): Promise<string> {
+        const v = this.files.get(file);
+        if (v == null) throw new Error("ENOENT " + file);
+        return typeof v === "string" ? v : Buffer.from(v).toString("utf8");
+    }
+    async writeText(file: string, text: string): Promise<void> {
+        this.files.set(file, text);
+    }
+    async writeBytes(file: string, data: Uint8Array): Promise<void> {
+        this.files.set(file, data);
+    }
+    async remove(target: string): Promise<void> {
+        for (const key of [...this.files.keys()]) {
+            if (key === target || key.startsWith(target + path.sep)) {
+                this.files.delete(key);
+            }
+        }
+        this.dirs.delete(target);
+    }
+    async exists(target: string): Promise<boolean> {
+        if (this.files.has(target) || this.dirs.has(target)) return true;
+        for (const key of this.files.keys()) {
+            if (key.startsWith(target + path.sep)) return true;
+        }
+        return false;
+    }
+}
+
+function face(overrides: Partial<Css2Face> = {}): Css2Face {
+    return {
+        style: "normal",
+        weightMin: 400,
+        weightMax: 400,
+        url: "https://fonts.gstatic.com/x.woff2",
+        format: "woff2",
+        subset: "latin",
+        ...overrides,
+    };
+}
+
+describe("downloadedFontsStore", () => {
+    it("slugs family names", () => {
+        assert.strictEqual(slugFamily("Open Sans"), "open-sans");
+        assert.strictEqual(slugFamily("IBM Plex Mono"), "ibm-plex-mono");
+        assert.strictEqual(slugFamily("!!!"), "font");
+    });
+
+    it("names face files by style and weight range", () => {
+        assert.strictEqual(
+            faceFileName(
+                "roboto",
+                face({ style: "normal", weightMin: 400, weightMax: 400 }),
+            ),
+            "roboto-normal-400.woff2",
+        );
+        assert.strictEqual(
+            faceFileName(
+                "roboto-flex",
+                face({ style: "italic", weightMin: 100, weightMax: 900 }),
+            ),
+            "roboto-flex-italic-100_900.woff2",
+        );
+    });
+
+    it("returns an empty list when nothing has been downloaded", async () => {
+        const store = new DownloadedFontsStore("/root", new FakeFs());
+        assert.deepStrictEqual(await store.list(), []);
+    });
+
+    it("adds a font, writing files and a manifest entry", async () => {
+        const fs = new FakeFs();
+        const store = new DownloadedFontsStore("/root", fs);
+        const record = await store.add({
+            family: "Roboto",
+            category: "Sans Serif",
+            isVariable: false,
+            axes: [],
+            faces: [
+                { face: face({ style: "normal" }), bytes: new Uint8Array([1]) },
+                {
+                    face: face({ style: "italic", url: "https://x/i.woff2" }),
+                    bytes: new Uint8Array([2]),
+                },
+            ],
+        });
+        assert.strictEqual(record.familyId, "roboto");
+        assert.strictEqual(record.faces.length, 2);
+
+        const listed = await store.list();
+        assert.strictEqual(listed.length, 1);
+        assert.strictEqual(listed[0].family, "Roboto");
+
+        // Files were written under the family dir.
+        assert.ok(fs.files.has(store.facePath(record, record.faces[0])));
+        assert.ok(fs.files.has(store.facePath(record, record.faces[1])));
+        assert.ok(await store.has("roboto"));
+    });
+
+    it("replaces an existing family rather than duplicating it", async () => {
+        const store = new DownloadedFontsStore("/root", new FakeFs());
+        const input = {
+            family: "Lora",
+            category: "Serif",
+            isVariable: false,
+            axes: [],
+            faces: [{ face: face(), bytes: new Uint8Array([1]) }],
+        };
+        await store.add(input);
+        await store.add(input);
+        assert.strictEqual((await store.list()).length, 1);
+    });
+
+    it("removes a font and its files", async () => {
+        const fs = new FakeFs();
+        const store = new DownloadedFontsStore("/root", fs);
+        const record = await store.add({
+            family: "Roboto",
+            category: "Sans Serif",
+            isVariable: false,
+            axes: [],
+            faces: [{ face: face(), bytes: new Uint8Array([1]) }],
+        });
+        const filePath = store.facePath(record, record.faces[0]);
+        assert.ok(fs.files.has(filePath));
+
+        await store.remove("roboto");
+        assert.deepStrictEqual(await store.list(), []);
+        assert.ok(!fs.files.has(filePath));
+    });
+
+    it("survives a corrupt manifest", async () => {
+        const fs = new FakeFs();
+        const store = new DownloadedFontsStore("/root", fs);
+        fs.files.set(path.join("/root", "fonts", "index.json"), "not json{");
+        assert.deepStrictEqual(await store.list(), []);
+    });
+});

--- a/vscode-extension/src/test/fontBrowserLogic.test.ts
+++ b/vscode-extension/src/test/fontBrowserLogic.test.ts
@@ -1,0 +1,148 @@
+// Pins the webview-side font-browser helpers (font-face CSS, face
+// picking, axis defaults, variation settings).
+
+import * as assert from "assert";
+import {
+    buildFontFaceCss,
+    cssVariationSettings,
+    defaultAxisValues,
+    pickFace,
+    sliderAxes,
+    webviewFamilyName,
+    weightRange,
+    type DownloadedFontView,
+} from "../webview/fonts/fontBrowserLogic";
+import type { FontAxis } from "../googleFontsCatalog";
+
+const wght: FontAxis = {
+    tag: "wght",
+    displayName: "Weight",
+    min: 100,
+    max: 900,
+    defaultValue: 400,
+};
+const opsz: FontAxis = {
+    tag: "opsz",
+    displayName: "Optical Size",
+    min: 8,
+    max: 144,
+    defaultValue: 14,
+};
+
+const staticFont: DownloadedFontView = {
+    family: "Roboto",
+    familyId: "roboto",
+    category: "Sans Serif",
+    isVariable: false,
+    axes: [],
+    faces: [
+        {
+            style: "normal",
+            weightMin: 400,
+            weightMax: 400,
+            uri: "vscode://r400",
+            format: "woff2",
+        },
+        {
+            style: "normal",
+            weightMin: 700,
+            weightMax: 700,
+            uri: "vscode://r700",
+            format: "woff2",
+        },
+        {
+            style: "italic",
+            weightMin: 400,
+            weightMax: 400,
+            uri: "vscode://i400",
+            format: "woff2",
+        },
+    ],
+};
+
+const variableFont: DownloadedFontView = {
+    family: "Roboto Flex",
+    familyId: "roboto-flex",
+    category: "Sans Serif",
+    isVariable: true,
+    axes: [wght, opsz],
+    faces: [
+        {
+            style: "normal",
+            weightMin: 100,
+            weightMax: 900,
+            uri: "vscode://vf",
+            format: "woff2",
+        },
+    ],
+};
+
+describe("fontBrowserLogic", () => {
+    it("namespaces webview font families", () => {
+        assert.strictEqual(webviewFamilyName("roboto"), "gfb-roboto");
+    });
+
+    it("builds @font-face rules with mapped formats and weight ranges", () => {
+        const css = buildFontFaceCss(variableFont);
+        assert.ok(css.includes('font-family: "gfb-roboto-flex"'));
+        assert.ok(css.includes("font-weight: 100 900"));
+        assert.ok(css.includes('src: url("vscode://vf") format("woff2")'));
+    });
+
+    it("picks the nearest weight within the requested style", () => {
+        assert.strictEqual(
+            pickFace(staticFont, 600, false)!.uri,
+            "vscode://r700",
+        );
+        assert.strictEqual(
+            pickFace(staticFont, 450, false)!.uri,
+            "vscode://r400",
+        );
+        assert.strictEqual(
+            pickFace(staticFont, 400, true)!.uri,
+            "vscode://i400",
+        );
+    });
+
+    it("falls back across styles when the requested style is absent", () => {
+        // No italic faces → falls back to the normal pool.
+        assert.strictEqual(
+            pickFace(variableFont, 400, true)!.uri,
+            "vscode://vf",
+        );
+    });
+
+    it("matches any weight inside a variable face's range", () => {
+        assert.strictEqual(
+            pickFace(variableFont, 250, false)!.uri,
+            "vscode://vf",
+        );
+    });
+
+    it("derives weight range from the wght axis or static faces", () => {
+        assert.deepStrictEqual(weightRange(variableFont), {
+            min: 100,
+            max: 900,
+        });
+        assert.deepStrictEqual(weightRange(staticFont), { min: 400, max: 700 });
+    });
+
+    it("defaults axis values and excludes wght/ital from sliders", () => {
+        assert.deepStrictEqual(defaultAxisValues(variableFont.axes), {
+            wght: 400,
+            opsz: 14,
+        });
+        assert.deepStrictEqual(
+            sliderAxes(variableFont).map((a) => a.tag),
+            ["opsz"],
+        );
+    });
+
+    it("formats font-variation-settings", () => {
+        assert.strictEqual(
+            cssVariationSettings({ wght: 500, opsz: 40 }),
+            '"wght" 500, "opsz" 40',
+        );
+        assert.strictEqual(cssVariationSettings({}), "normal");
+    });
+});

--- a/vscode-extension/src/test/googleFontsCatalog.test.ts
+++ b/vscode-extension/src/test/googleFontsCatalog.test.ts
@@ -1,0 +1,194 @@
+// Pins the Google Fonts catalog parser + search + css2 URL builders.
+
+import * as assert from "assert";
+import {
+    buildCss2BrowseUrl,
+    buildCss2DownloadUrl,
+    css2FamilyToken,
+    parseFontsMetadata,
+    searchCatalog,
+    sortAxisTags,
+    stripXssiPrefix,
+    type FontFamilyMeta,
+} from "../googleFontsCatalog";
+
+const SAMPLE = {
+    axisRegistry: [
+        {
+            tag: "wght",
+            displayName: "Weight",
+            min: 1,
+            max: 1000,
+            defaultValue: 400,
+        },
+        {
+            tag: "opsz",
+            displayName: "Optical Size",
+            min: 6,
+            max: 144,
+            defaultValue: 14,
+        },
+        {
+            tag: "GRAD",
+            displayName: "Grade",
+            min: -200,
+            max: 150,
+            defaultValue: 0,
+        },
+    ],
+    familyMetadataList: [
+        {
+            family: "Roboto",
+            category: "Sans Serif",
+            subsets: ["latin", "cyrillic"],
+            popularity: 1,
+            fonts: { "100": {}, "400": {}, "400italic": {}, "700": {} },
+            axes: [],
+        },
+        {
+            family: "Roboto Flex",
+            category: "Sans Serif",
+            subsets: ["latin"],
+            popularity: 50,
+            fonts: { "400": {} },
+            axes: [
+                { tag: "wght", min: 100, max: 1000, defaultValue: 400 },
+                { tag: "opsz", min: 8, max: 144, defaultValue: 14 },
+                { tag: "GRAD", min: -200, max: 150, defaultValue: 0 },
+            ],
+        },
+        {
+            family: "Lora",
+            category: "Serif",
+            subsets: ["latin"],
+            popularity: 20,
+            fonts: { "400": {}, "700": {} },
+            axes: [],
+        },
+    ],
+};
+
+describe("googleFontsCatalog", () => {
+    it("strips the XSSI guard before the first brace", () => {
+        assert.strictEqual(stripXssiPrefix(')]}\'\n{"a":1}'), '{"a":1}');
+        assert.strictEqual(stripXssiPrefix('{"a":1}'), '{"a":1}');
+    });
+
+    it("parses families, instances, axes and sorts by popularity", () => {
+        const catalog = parseFontsMetadata(SAMPLE);
+        assert.deepStrictEqual(
+            catalog.families.map((f) => f.family),
+            ["Roboto", "Lora", "Roboto Flex"],
+        );
+        assert.deepStrictEqual(catalog.categories, ["Sans Serif", "Serif"]);
+
+        const roboto = catalog.families.find((f) => f.family === "Roboto")!;
+        assert.strictEqual(roboto.isVariable, false);
+        assert.strictEqual(roboto.hasItalic, true);
+        assert.deepStrictEqual(roboto.weights, [100, 400, 700]);
+
+        const flex = catalog.families.find((f) => f.family === "Roboto Flex")!;
+        assert.strictEqual(flex.isVariable, true);
+        assert.strictEqual(flex.axes.length, 3);
+        const opsz = flex.axes.find((a) => a.tag === "opsz")!;
+        assert.strictEqual(opsz.displayName, "Optical Size");
+        assert.strictEqual(opsz.max, 144);
+    });
+
+    it("drops malformed families without throwing", () => {
+        const catalog = parseFontsMetadata({
+            familyMetadataList: [
+                null,
+                { category: "Serif" }, // no family
+                { family: "Good", fonts: { regular: {}, italic: {} } },
+            ],
+        });
+        assert.deepStrictEqual(
+            catalog.families.map((f) => f.family),
+            ["Good"],
+        );
+        const good = catalog.families[0];
+        assert.strictEqual(good.hasItalic, true);
+        assert.deepStrictEqual(good.weights, [400]);
+    });
+
+    it("filters by query and category and caps results", () => {
+        const catalog = parseFontsMetadata(SAMPLE);
+        assert.deepStrictEqual(
+            searchCatalog(catalog, { query: "roboto" }).map((f) => f.family),
+            ["Roboto", "Roboto Flex"],
+        );
+        assert.deepStrictEqual(
+            searchCatalog(catalog, { category: "Serif" }).map((f) => f.family),
+            ["Lora"],
+        );
+        assert.strictEqual(searchCatalog(catalog, { limit: 1 }).length, 1);
+    });
+
+    it("encodes family tokens and sorts axis tags css2-style", () => {
+        assert.strictEqual(css2FamilyToken("Open Sans"), "Open+Sans");
+        assert.deepStrictEqual(sortAxisTags(["wght", "GRAD", "opsz", "ital"]), [
+            "ital",
+            "opsz",
+            "wght",
+            "GRAD",
+        ]);
+    });
+
+    it("builds a browse URL for the default upright face", () => {
+        assert.strictEqual(
+            buildCss2BrowseUrl("Open Sans"),
+            "https://fonts.googleapis.com/css2?family=Open+Sans&display=swap",
+        );
+    });
+
+    it("builds a static download URL enumerating instances", () => {
+        const roboto = parseFontsMetadata(SAMPLE).families.find(
+            (f) => f.family === "Roboto",
+        )!;
+        assert.strictEqual(
+            buildCss2DownloadUrl(roboto),
+            "https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100;0,400;0,700;1,400&display=swap",
+        );
+    });
+
+    it("builds a variable download URL with full axis ranges", () => {
+        const flex = parseFontsMetadata(SAMPLE).families.find(
+            (f) => f.family === "Roboto Flex",
+        )!;
+        // ital absent (no italic instances), axes sorted opsz,wght,GRAD.
+        assert.strictEqual(
+            buildCss2DownloadUrl(flex),
+            "https://fonts.googleapis.com/css2?family=Roboto+Flex:opsz,wght,GRAD@8..144,100..1000,-200..150&display=swap",
+        );
+    });
+
+    it("includes both ital tuples for a variable font with italics", () => {
+        const meta: FontFamilyMeta = {
+            family: "Test VF",
+            category: "Sans Serif",
+            subsets: ["latin"],
+            popularity: 1,
+            axes: [
+                {
+                    tag: "wght",
+                    displayName: "Weight",
+                    min: 100,
+                    max: 900,
+                    defaultValue: 400,
+                },
+            ],
+            instances: [
+                { weight: 400, italic: false },
+                { weight: 400, italic: true },
+            ],
+            weights: [400],
+            hasItalic: true,
+            isVariable: true,
+        };
+        assert.strictEqual(
+            buildCss2DownloadUrl(meta),
+            "https://fonts.googleapis.com/css2?family=Test+VF:ital,wght@0,100..900;1,100..900&display=swap",
+        );
+    });
+});

--- a/vscode-extension/src/test/googleFontsClient.test.ts
+++ b/vscode-extension/src/test/googleFontsClient.test.ts
@@ -1,0 +1,118 @@
+// Pins the network client's css2 parsing + fetch plumbing against an
+// injected FetchLike (no real network).
+
+import * as assert from "assert";
+import {
+    downloadFontBytes,
+    fetchCss2Faces,
+    fetchFontCatalog,
+    parseCss2Faces,
+    type FetchLike,
+    type FetchResponse,
+} from "../googleFontsClient";
+
+function jsonResponse(body: string, ok = true, status = 200): FetchResponse {
+    return {
+        ok,
+        status,
+        text: async () => body,
+        arrayBuffer: async () => new ArrayBuffer(0),
+    };
+}
+
+function bytesResponse(bytes: Uint8Array, ok = true): FetchResponse {
+    return {
+        ok,
+        status: ok ? 200 : 500,
+        text: async () => "",
+        arrayBuffer: async () => {
+            const ab = new ArrayBuffer(bytes.byteLength);
+            new Uint8Array(ab).set(bytes);
+            return ab;
+        },
+    };
+}
+
+const CSS2 = `
+/* cyrillic */
+@font-face {
+  font-family: 'Roboto';
+  font-style: normal;
+  font-weight: 400;
+  src: url(https://fonts.gstatic.com/s/roboto/cyr-400.woff2) format('woff2');
+}
+/* latin */
+@font-face {
+  font-family: 'Roboto';
+  font-style: normal;
+  font-weight: 400;
+  src: url(https://fonts.gstatic.com/s/roboto/lat-400.woff2) format('woff2');
+}
+/* latin */
+@font-face {
+  font-family: 'Roboto';
+  font-style: italic;
+  font-weight: 100 900;
+  src: url(https://fonts.gstatic.com/s/roboto/lat-ital.woff2) format('woff2');
+}
+`;
+
+describe("googleFontsClient", () => {
+    it("parses css2 faces, preferring the latin subset per face", () => {
+        const faces = parseCss2Faces(CSS2);
+        assert.strictEqual(faces.length, 2);
+
+        const normal = faces.find((f) => f.style === "normal")!;
+        assert.strictEqual(normal.weightMin, 400);
+        assert.strictEqual(normal.weightMax, 400);
+        assert.strictEqual(
+            normal.url,
+            "https://fonts.gstatic.com/s/roboto/lat-400.woff2",
+        );
+        assert.strictEqual(normal.format, "woff2");
+
+        const italic = faces.find((f) => f.style === "italic")!;
+        assert.strictEqual(italic.weightMin, 100);
+        assert.strictEqual(italic.weightMax, 900);
+    });
+
+    it("fetches and parses the catalog, stripping the XSSI prefix", async () => {
+        const body =
+            ")]}'\n" +
+            JSON.stringify({
+                familyMetadataList: [
+                    { family: "Roboto", fonts: { "400": {} }, axes: [] },
+                ],
+            });
+        const fetchImpl: FetchLike = async () => jsonResponse(body);
+        const catalog = await fetchFontCatalog(fetchImpl);
+        assert.strictEqual(catalog.families[0].family, "Roboto");
+    });
+
+    it("throws a clear error on a non-OK catalog response", async () => {
+        const fetchImpl: FetchLike = async () => jsonResponse("", false, 503);
+        await assert.rejects(() => fetchFontCatalog(fetchImpl), /HTTP 503/);
+    });
+
+    it("fetches css2 faces via the injected fetch", async () => {
+        const fetchImpl: FetchLike = async () => jsonResponse(CSS2);
+        const faces = await fetchCss2Faces("https://x/css2", fetchImpl);
+        assert.strictEqual(faces.length, 2);
+    });
+
+    it("downloads bytes", async () => {
+        const bytes = new Uint8Array([1, 2, 3, 4]);
+        const fetchImpl: FetchLike = async () => bytesResponse(bytes);
+        const out = await downloadFontBytes("https://x/f.woff2", fetchImpl);
+        assert.deepStrictEqual([...out], [1, 2, 3, 4]);
+    });
+
+    it("throws on a failed download", async () => {
+        const fetchImpl: FetchLike = async () =>
+            bytesResponse(new Uint8Array(), false);
+        await assert.rejects(
+            () => downloadFontBytes("https://x/f.woff2", fetchImpl),
+            /download failed/,
+        );
+    });
+});

--- a/vscode-extension/src/webview/fonts/composeFontSnippet.ts
+++ b/vscode-extension/src/webview/fonts/composeFontSnippet.ts
@@ -1,0 +1,103 @@
+// Pure Compose-snippet codegen for the font browser's customiser.
+//
+// Given the live attribute selections (weight, italic, and — for
+// variable fonts — the per-axis values) this emits a Kotlin
+// `FontFamily` + `TextStyle` the user can paste into a Compose project.
+// No DOM / node deps so it's unit-tested directly and shared by the
+// webview bundle.
+
+import type { FontAxis } from "../../googleFontsCatalog";
+
+export interface SnippetOptions {
+    family: string;
+    weight: number;
+    italic: boolean;
+    isVariable: boolean;
+    /** Variable-axis values keyed by tag (only consulted when variable). */
+    axisValues: Record<string, number>;
+    /** Axis metadata, used to order/emit the variation settings. */
+    axes: readonly FontAxis[];
+    fontSizeSp: number;
+    letterSpacingSp: number;
+    lineHeightSp: number;
+}
+
+/** Android `res/font` resource name (lowercase, underscores only). */
+export function fontResourceName(family: string): string {
+    return (
+        family
+            .toLowerCase()
+            .replace(/[^a-z0-9]+/g, "_")
+            .replace(/^_+|_+$/g, "") || "font"
+    );
+}
+
+/** PascalCase identifier prefix for the generated `val`s. */
+export function fontIdentifier(family: string): string {
+    const parts = family
+        .replace(/[^a-zA-Z0-9]+/g, " ")
+        .trim()
+        .split(/\s+/)
+        .filter(Boolean);
+    if (parts.length === 0) return "Custom";
+    return parts.map((p) => p.charAt(0).toUpperCase() + p.slice(1)).join("");
+}
+
+function fmt(value: number): string {
+    return Number.isInteger(value) ? String(value) : value.toFixed(2);
+}
+
+/**
+ * Generate the Compose `FontFamily` + `TextStyle` snippet reflecting the
+ * current customiser selections.
+ */
+export function generateComposeSnippet(opts: SnippetOptions): string {
+    const res = fontResourceName(opts.family);
+    const id = fontIdentifier(opts.family);
+    const styleEnum = opts.italic ? "FontStyle.Italic" : "FontStyle.Normal";
+
+    const fontArgs: string[] = [
+        `resId = R.font.${res}`,
+        `weight = FontWeight(${opts.weight})`,
+        `style = ${styleEnum}`,
+    ];
+
+    if (opts.isVariable) {
+        const settings: string[] = [];
+        // Always pin weight + italic through the variation API so the
+        // variable file renders exactly what the customiser shows.
+        settings.push(`FontVariation.weight(${opts.weight})`);
+        if (opts.italic) settings.push(`FontVariation.italic(1f)`);
+        for (const axis of opts.axes) {
+            if (axis.tag === "wght" || axis.tag === "ital") continue;
+            const value = opts.axisValues[axis.tag];
+            if (value == null) continue;
+            settings.push(
+                `FontVariation.Setting("${axis.tag}", ${fmt(value)}f)`,
+            );
+        }
+        const indented = settings.map((s) => `            ${s},`).join("\n");
+        fontArgs.push(
+            `variationSettings = FontVariation.Settings(\n${indented}\n        )`,
+        );
+    }
+
+    const fontArgsBlock = fontArgs.map((a) => `        ${a},`).join("\n");
+
+    return [
+        `val ${id}FontFamily = FontFamily(`,
+        `    Font(`,
+        fontArgsBlock,
+        `    ),`,
+        `)`,
+        ``,
+        `val ${id}TextStyle = TextStyle(`,
+        `    fontFamily = ${id}FontFamily,`,
+        `    fontWeight = FontWeight(${opts.weight}),`,
+        `    fontStyle = ${styleEnum},`,
+        `    fontSize = ${fmt(opts.fontSizeSp)}.sp,`,
+        `    letterSpacing = ${fmt(opts.letterSpacingSp)}.sp,`,
+        `    lineHeight = ${fmt(opts.lineHeightSp)}.sp,`,
+        `)`,
+    ].join("\n");
+}

--- a/vscode-extension/src/webview/fonts/fontBrowserLogic.ts
+++ b/vscode-extension/src/webview/fonts/fontBrowserLogic.ts
@@ -1,0 +1,140 @@
+// Pure helpers for the font-browser webview: turning catalog metadata
+// and downloaded-face records into the CSS the panel injects, and into
+// the customiser's control model. Kept DOM-free so it's unit-tested
+// without a webview.
+
+import type { FontAxis } from "../../googleFontsCatalog";
+
+/** A downloaded face as the host serialises it to the webview. */
+export interface FaceView {
+    style: "normal" | "italic";
+    weightMin: number;
+    weightMax: number;
+    /** `webview.asWebviewUri(...)` string for the cached file. */
+    uri: string;
+    format: string;
+}
+
+export interface DownloadedFontView {
+    family: string;
+    familyId: string;
+    category: string;
+    isVariable: boolean;
+    axes: FontAxis[];
+    faces: FaceView[];
+}
+
+/** Synthetic CSS family name for a downloaded font (avoids clashes with
+ *  any system family of the same name). */
+export function webviewFamilyName(familyId: string): string {
+    return `gfb-${familyId}`;
+}
+
+const CSS_FORMAT: Record<string, string> = {
+    woff2: "woff2",
+    woff: "woff",
+    ttf: "truetype",
+    truetype: "truetype",
+    otf: "opentype",
+    opentype: "opentype",
+};
+
+/** Build the `@font-face` rules for one downloaded font. */
+export function buildFontFaceCss(font: DownloadedFontView): string {
+    const familyName = webviewFamilyName(font.familyId);
+    return font.faces
+        .map((face) => {
+            const weight =
+                face.weightMin === face.weightMax
+                    ? String(face.weightMin)
+                    : `${face.weightMin} ${face.weightMax}`;
+            const fmt = CSS_FORMAT[face.format.toLowerCase()] ?? "woff2";
+            return [
+                `@font-face {`,
+                `  font-family: "${familyName}";`,
+                `  font-style: ${face.style};`,
+                `  font-weight: ${weight};`,
+                `  font-display: swap;`,
+                `  src: url("${face.uri}") format("${fmt}");`,
+                `}`,
+            ].join("\n");
+        })
+        .join("\n");
+}
+
+/** Concatenate the `@font-face` rules for every downloaded font. */
+export function buildAllFontFaceCss(
+    fonts: readonly DownloadedFontView[],
+): string {
+    return fonts.map(buildFontFaceCss).join("\n\n");
+}
+
+/**
+ * Pick the face that best matches a (weight, italic) request. Prefers an
+ * exact style match, then the nearest weight (variable faces match any
+ * weight inside their range). Falls back to the first face so a render
+ * never has an empty `font-family`.
+ */
+export function pickFace(
+    font: DownloadedFontView,
+    weight: number,
+    italic: boolean,
+): FaceView | null {
+    if (font.faces.length === 0) return null;
+    const wantStyle = italic ? "italic" : "normal";
+    const candidates = font.faces.filter((f) => f.style === wantStyle);
+    const pool = candidates.length > 0 ? candidates : font.faces;
+    let best = pool[0];
+    let bestDist = Number.POSITIVE_INFINITY;
+    for (const face of pool) {
+        const clamped = Math.max(
+            face.weightMin,
+            Math.min(face.weightMax, weight),
+        );
+        const dist = Math.abs(clamped - weight);
+        if (dist < bestDist) {
+            bestDist = dist;
+            best = face;
+        }
+    }
+    return best;
+}
+
+/** Default each axis to its registered default value. */
+export function defaultAxisValues(
+    axes: readonly FontAxis[],
+): Record<string, number> {
+    const out: Record<string, number> = {};
+    for (const axis of axes) out[axis.tag] = axis.defaultValue;
+    return out;
+}
+
+/** The weight axis range for a variable font, or the shipped static
+ *  weight span. Drives the customiser's weight slider bounds. */
+export function weightRange(font: DownloadedFontView): {
+    min: number;
+    max: number;
+} {
+    const wght = font.axes.find((a) => a.tag === "wght");
+    if (wght) return { min: wght.min, max: wght.max };
+    const weights = font.faces.map((f) => f.weightMin);
+    return {
+        min: weights.length ? Math.min(...weights) : 400,
+        max: weights.length ? Math.max(...weights) : 400,
+    };
+}
+
+/** CSS `font-variation-settings` string from the live axis values. */
+export function cssVariationSettings(
+    axisValues: Record<string, number>,
+): string {
+    const entries = Object.entries(axisValues);
+    if (entries.length === 0) return "normal";
+    return entries.map(([tag, value]) => `"${tag}" ${value}`).join(", ");
+}
+
+/** Axes the customiser exposes as sliders (every axis except weight,
+ *  which has its own dedicated control, and ital, which is a toggle). */
+export function sliderAxes(font: DownloadedFontView): FontAxis[] {
+    return font.axes.filter((a) => a.tag !== "wght" && a.tag !== "ital");
+}

--- a/vscode-extension/src/webview/fonts/main.ts
+++ b/vscode-extension/src/webview/fonts/main.ts
@@ -1,0 +1,569 @@
+// Bundled entry for the "Google Fonts" browser webview panel.
+//
+// `<font-browser-app>` renders three regions in light DOM (so
+// `media/fonts.css` and injected `<style>`/`@font-face` rules apply):
+//
+//   1. Search + category toolbar over the keyless Google Fonts catalog.
+//      Each result row paints in its *real* typeface via a lazily
+//      injected `fonts.googleapis.com/css2` <link>.
+//   2. A "Downloaded" shelf — fonts the host cached under global
+//      storage, rendered through `@font-face` rules pointing at the
+//      cached files (`webview.asWebviewUri`).
+//   3. A live customiser for the selected downloaded font: weight,
+//      italic, size / letter-spacing / line-height, and per-axis
+//      sliders for variable fonts, with a generated Compose snippet.
+//
+// The host owns all network + disk work; this bundle only renders and
+// posts intent messages. See `protocol.ts` for the message shapes.
+
+import { LitElement, html, nothing, type TemplateResult } from "lit";
+import { customElement, state } from "lit/decorators.js";
+import { getVsCodeApi } from "../shared/vscode";
+import {
+    buildCss2BrowseUrl,
+    searchCatalog,
+    type FontCatalog,
+    type FontFamilyMeta,
+} from "../../googleFontsCatalog";
+import {
+    buildAllFontFaceCss,
+    cssVariationSettings,
+    defaultAxisValues,
+    pickFace,
+    sliderAxes,
+    webviewFamilyName,
+    weightRange,
+    type DownloadedFontView,
+} from "./fontBrowserLogic";
+import { generateComposeSnippet } from "./composeFontSnippet";
+import type { HostToWebview } from "./protocol";
+
+const DEFAULT_SPECIMEN = "The quick brown fox jumps over the lazy dog";
+
+interface Customiser {
+    weight: number;
+    italic: boolean;
+    fontSizeSp: number;
+    letterSpacingSp: number;
+    lineHeightSp: number;
+    axisValues: Record<string, number>;
+}
+
+@customElement("font-browser-app")
+export class FontBrowserApp extends LitElement {
+    protected createRenderRoot(): HTMLElement {
+        return this;
+    }
+
+    private readonly vscode = getVsCodeApi<unknown>();
+
+    @state() private catalog: FontCatalog | null = null;
+    @state() private catalogError: string | null = null;
+    @state() private query = "";
+    @state() private category = "all";
+    @state() private downloaded: DownloadedFontView[] = [];
+    @state() private downloading = new Set<string>();
+    @state() private selectedId: string | null = null;
+    @state() private specimen = DEFAULT_SPECIMEN;
+    @state() private customiser: Customiser | null = null;
+    @state() private copied = false;
+
+    /** Families we've already injected a browse-preview <link> for. */
+    private readonly linkedFamilies = new Set<string>();
+
+    connectedCallback(): void {
+        super.connectedCallback();
+        window.addEventListener("message", this.onMessage);
+    }
+
+    disconnectedCallback(): void {
+        window.removeEventListener("message", this.onMessage);
+        super.disconnectedCallback();
+    }
+
+    protected firstUpdated(): void {
+        this.post({ command: "ready" });
+    }
+
+    private readonly onMessage = (ev: MessageEvent): void => {
+        const msg = ev.data as HostToWebview;
+        if (!msg || typeof msg !== "object") return;
+        switch (msg.command) {
+            case "catalog":
+                this.catalog = msg.catalog;
+                this.catalogError = null;
+                break;
+            case "catalogLoading":
+                this.catalogError = null;
+                break;
+            case "catalogError":
+                this.catalogError = msg.message;
+                break;
+            case "downloaded":
+                this.downloaded = msg.fonts;
+                this.syncFontFaces();
+                // Drop a selection that no longer exists.
+                if (
+                    this.selectedId &&
+                    !msg.fonts.some((f) => f.familyId === this.selectedId)
+                ) {
+                    this.selectedId = null;
+                    this.customiser = null;
+                }
+                break;
+            case "downloadState": {
+                const next = new Set(this.downloading);
+                if (msg.state === "downloading") next.add(msg.familyId);
+                else next.delete(msg.familyId);
+                this.downloading = next;
+                break;
+            }
+        }
+    };
+
+    private post(msg: import("./protocol").WebviewToHost): void {
+        this.vscode.postMessage(msg);
+    }
+
+    // ---- browse-preview <link> injection --------------------------------
+
+    private ensureBrowseLink(family: string): void {
+        if (this.linkedFamilies.has(family)) return;
+        this.linkedFamilies.add(family);
+        const link = document.createElement("link");
+        link.rel = "stylesheet";
+        link.href = buildCss2BrowseUrl(family);
+        document.head.appendChild(link);
+    }
+
+    // ---- downloaded @font-face injection --------------------------------
+
+    private syncFontFaces(): void {
+        let styleEl = document.getElementById(
+            "gfb-font-faces",
+        ) as HTMLStyleElement | null;
+        if (!styleEl) {
+            styleEl = document.createElement("style");
+            styleEl.id = "gfb-font-faces";
+            document.head.appendChild(styleEl);
+        }
+        styleEl.textContent = buildAllFontFaceCss(this.downloaded);
+    }
+
+    // ---- actions --------------------------------------------------------
+
+    private onDownload(meta: FontFamilyMeta): void {
+        const id = slug(meta.family);
+        if (this.downloading.has(id) || this.isDownloaded(id)) return;
+        const next = new Set(this.downloading);
+        next.add(id);
+        this.downloading = next;
+        this.post({ command: "download", family: meta.family });
+    }
+
+    private onRemove(font: DownloadedFontView): void {
+        this.post({ command: "removeDownloaded", familyId: font.familyId });
+    }
+
+    private onSelect(font: DownloadedFontView): void {
+        this.selectedId = font.familyId;
+        const range = weightRange(font);
+        this.customiser = {
+            weight: clamp(400, range.min, range.max),
+            italic: false,
+            fontSizeSp: 32,
+            letterSpacingSp: 0,
+            lineHeightSp: 40,
+            axisValues: defaultAxisValues(font.axes),
+        };
+        this.copied = false;
+    }
+
+    private updateCustomiser(patch: Partial<Customiser>): void {
+        if (!this.customiser) return;
+        this.customiser = { ...this.customiser, ...patch };
+        this.copied = false;
+    }
+
+    private updateAxis(tag: string, value: number): void {
+        if (!this.customiser) return;
+        this.customiser = {
+            ...this.customiser,
+            axisValues: { ...this.customiser.axisValues, [tag]: value },
+        };
+        this.copied = false;
+    }
+
+    private isDownloaded(familyId: string): boolean {
+        return this.downloaded.some((f) => f.familyId === familyId);
+    }
+
+    private get selected(): DownloadedFontView | null {
+        return (
+            this.downloaded.find((f) => f.familyId === this.selectedId) ?? null
+        );
+    }
+
+    private copySnippet(): void {
+        const font = this.selected;
+        const c = this.customiser;
+        if (!font || !c) return;
+        this.post({ command: "copySnippet", text: this.snippetFor(font, c) });
+        this.copied = true;
+    }
+
+    private snippetFor(font: DownloadedFontView, c: Customiser): string {
+        return generateComposeSnippet({
+            family: font.family,
+            weight: Math.round(c.weight),
+            italic: c.italic,
+            isVariable: font.isVariable,
+            axisValues: c.axisValues,
+            axes: font.axes,
+            fontSizeSp: c.fontSizeSp,
+            letterSpacingSp: c.letterSpacingSp,
+            lineHeightSp: c.lineHeightSp,
+        });
+    }
+
+    // ---- render ---------------------------------------------------------
+
+    protected render(): TemplateResult {
+        return html`
+            ${this.renderToolbar()} ${this.renderDownloaded()}
+            ${this.renderCustomiser()} ${this.renderResults()}
+        `;
+    }
+
+    private renderToolbar(): TemplateResult {
+        const categories = this.catalog?.categories ?? [];
+        return html`
+            <div class="gfb-toolbar" role="toolbar" aria-label="Font search">
+                <input
+                    class="gfb-search"
+                    type="search"
+                    placeholder="Search Google Fonts…"
+                    .value=${this.query}
+                    aria-label="Search fonts"
+                    @input=${(e: Event) =>
+                        (this.query = (e.target as HTMLInputElement).value)}
+                />
+                <select
+                    class="gfb-category"
+                    aria-label="Category"
+                    .value=${this.category}
+                    @change=${(e: Event) =>
+                        (this.category = (e.target as HTMLSelectElement).value)}
+                >
+                    <option value="all">All categories</option>
+                    ${categories.map(
+                        (c) => html`<option value=${c}>${c}</option>`,
+                    )}
+                </select>
+                <button
+                    class="gfb-btn"
+                    title="Reload the catalog from Google Fonts"
+                    @click=${() => this.post({ command: "refreshCatalog" })}
+                >
+                    Reload
+                </button>
+            </div>
+        `;
+    }
+
+    private renderResults(): TemplateResult {
+        if (this.catalogError) {
+            return html`<div class="gfb-message gfb-error">
+                Couldn't load the Google Fonts catalog: ${this.catalogError}
+                <button
+                    class="gfb-btn"
+                    @click=${() => this.post({ command: "refreshCatalog" })}
+                >
+                    Retry
+                </button>
+            </div>`;
+        }
+        if (!this.catalog) {
+            return html`<div class="gfb-message">Loading catalog…</div>`;
+        }
+        const results = searchCatalog(this.catalog, {
+            query: this.query,
+            category: this.category,
+            limit: 80,
+        });
+        if (results.length === 0) {
+            return html`<div class="gfb-message">No fonts match.</div>`;
+        }
+        return html`
+            <h2 class="gfb-section-title">
+                Browse
+                <span class="gfb-count">${results.length} shown</span>
+            </h2>
+            <div class="gfb-results" role="list">
+                ${results.map((meta) => this.renderResultRow(meta))}
+            </div>
+        `;
+    }
+
+    private renderResultRow(meta: FontFamilyMeta): TemplateResult {
+        this.ensureBrowseLink(meta.family);
+        const id = slug(meta.family);
+        const downloaded = this.isDownloaded(id);
+        const busy = this.downloading.has(id);
+        return html`
+            <div class="gfb-row" role="listitem">
+                <div class="gfb-row-main">
+                    <div
+                        class="gfb-specimen-line"
+                        style="font-family: '${meta.family}', sans-serif"
+                    >
+                        ${meta.family}
+                    </div>
+                    <div class="gfb-row-meta">
+                        <span class="gfb-tag">${meta.category}</span>
+                        ${meta.isVariable
+                            ? html`<span class="gfb-tag gfb-variable"
+                                  >variable · ${meta.axes.length} axes</span
+                              >`
+                            : html`<span class="gfb-tag"
+                                  >${meta.weights.length} weights</span
+                              >`}
+                        ${meta.hasItalic
+                            ? html`<span class="gfb-tag">italic</span>`
+                            : nothing}
+                    </div>
+                </div>
+                <div class="gfb-row-actions">
+                    <button
+                        class="gfb-link"
+                        title="Open on fonts.google.com"
+                        @click=${() =>
+                            this.post({
+                                command: "openExternal",
+                                url: `https://fonts.google.com/specimen/${encodeURIComponent(
+                                    meta.family.replace(/ /g, "+"),
+                                )}`,
+                            })}
+                    >
+                        Specimen ↗
+                    </button>
+                    ${downloaded
+                        ? html`<span class="gfb-downloaded-pill"
+                              >Downloaded</span
+                          >`
+                        : html`<button
+                              class="gfb-btn gfb-primary"
+                              ?disabled=${busy}
+                              @click=${() => this.onDownload(meta)}
+                          >
+                              ${busy ? "Downloading…" : "Download"}
+                          </button>`}
+                </div>
+            </div>
+        `;
+    }
+
+    private renderDownloaded(): TemplateResult {
+        if (this.downloaded.length === 0) return html``;
+        return html`
+            <h2 class="gfb-section-title">
+                Downloaded
+                <span class="gfb-count">${this.downloaded.length}</span>
+            </h2>
+            <div class="gfb-downloaded" role="list">
+                ${this.downloaded.map((font) => {
+                    const active = font.familyId === this.selectedId;
+                    return html`<button
+                        class="gfb-chip ${active ? "gfb-chip-active" : ""}"
+                        role="listitem"
+                        @click=${() => this.onSelect(font)}
+                        style="font-family: '${webviewFamilyName(
+                            font.familyId,
+                        )}', sans-serif"
+                    >
+                        ${font.family}
+                    </button>`;
+                })}
+            </div>
+        `;
+    }
+
+    private renderCustomiser(): TemplateResult {
+        const font = this.selected;
+        const c = this.customiser;
+        if (!font || !c) return html``;
+        const range = weightRange(font);
+        const previewFamily = webviewFamilyName(font.familyId);
+        const face = pickFace(font, Math.round(c.weight), c.italic);
+        const variation = font.isVariable
+            ? cssVariationSettings({
+                  ...c.axisValues,
+                  wght: Math.round(c.weight),
+              })
+            : "normal";
+        const previewStyle = [
+            `font-family: '${previewFamily}', sans-serif`,
+            `font-weight: ${Math.round(c.weight)}`,
+            `font-style: ${c.italic ? "italic" : "normal"}`,
+            `font-size: ${c.fontSizeSp}px`,
+            `letter-spacing: ${c.letterSpacingSp}px`,
+            `line-height: ${c.lineHeightSp}px`,
+            `font-variation-settings: ${variation}`,
+        ].join("; ");
+
+        return html`
+            <div class="gfb-customiser">
+                <div class="gfb-customiser-head">
+                    <h2 class="gfb-section-title">${font.family}</h2>
+                    <div class="gfb-customiser-head-actions">
+                        ${face
+                            ? nothing
+                            : html`<span class="gfb-warn"
+                                  >no matching face</span
+                              >`}
+                        <button
+                            class="gfb-btn"
+                            @click=${() => this.onRemove(font)}
+                        >
+                            Remove
+                        </button>
+                    </div>
+                </div>
+
+                <textarea
+                    class="gfb-specimen-input"
+                    aria-label="Specimen text"
+                    .value=${this.specimen}
+                    @input=${(e: Event) =>
+                        (this.specimen = (
+                            e.target as HTMLTextAreaElement
+                        ).value)}
+                ></textarea>
+
+                <div class="gfb-preview" style=${previewStyle}>
+                    ${this.specimen || DEFAULT_SPECIMEN}
+                </div>
+
+                <div class="gfb-controls">
+                    ${this.renderSlider(
+                        "Weight",
+                        c.weight,
+                        range.min,
+                        range.max,
+                        1,
+                        (v) => this.updateCustomiser({ weight: v }),
+                        Math.round(c.weight).toString(),
+                    )}
+                    <label class="gfb-control gfb-checkbox">
+                        <input
+                            type="checkbox"
+                            .checked=${c.italic}
+                            ?disabled=${!font.faces.some(
+                                (f) => f.style === "italic",
+                            )}
+                            @change=${(e: Event) =>
+                                this.updateCustomiser({
+                                    italic: (e.target as HTMLInputElement)
+                                        .checked,
+                                })}
+                        />
+                        Italic
+                    </label>
+                    ${this.renderSlider(
+                        "Size",
+                        c.fontSizeSp,
+                        8,
+                        96,
+                        1,
+                        (v) => this.updateCustomiser({ fontSizeSp: v }),
+                        `${c.fontSizeSp}sp`,
+                    )}
+                    ${this.renderSlider(
+                        "Letter spacing",
+                        c.letterSpacingSp,
+                        -2,
+                        10,
+                        0.1,
+                        (v) => this.updateCustomiser({ letterSpacingSp: v }),
+                        `${c.letterSpacingSp.toFixed(1)}sp`,
+                    )}
+                    ${this.renderSlider(
+                        "Line height",
+                        c.lineHeightSp,
+                        8,
+                        120,
+                        1,
+                        (v) => this.updateCustomiser({ lineHeightSp: v }),
+                        `${c.lineHeightSp}sp`,
+                    )}
+                    ${sliderAxes(font).map((axis) =>
+                        this.renderSlider(
+                            `${axis.displayName} (${axis.tag})`,
+                            c.axisValues[axis.tag] ?? axis.defaultValue,
+                            axis.min,
+                            axis.max,
+                            (axis.max - axis.min) / 100 || 1,
+                            (v) => this.updateAxis(axis.tag, v),
+                            fmtAxis(
+                                c.axisValues[axis.tag] ?? axis.defaultValue,
+                            ),
+                        ),
+                    )}
+                </div>
+
+                <div class="gfb-snippet-head">
+                    <span>Compose</span>
+                    <button class="gfb-btn" @click=${() => this.copySnippet()}>
+                        ${this.copied ? "Copied!" : "Copy"}
+                    </button>
+                </div>
+                <pre class="gfb-snippet"><code>${this.snippetFor(
+                    font,
+                    c,
+                )}</code></pre>
+            </div>
+        `;
+    }
+
+    private renderSlider(
+        label: string,
+        value: number,
+        min: number,
+        max: number,
+        step: number,
+        onChange: (v: number) => void,
+        display: string,
+    ): TemplateResult {
+        return html`<label class="gfb-control">
+            <span class="gfb-control-label"
+                >${label}<span class="gfb-control-value">${display}</span></span
+            >
+            <input
+                type="range"
+                min=${min}
+                max=${max}
+                step=${step}
+                .value=${String(value)}
+                @input=${(e: Event) =>
+                    onChange(Number((e.target as HTMLInputElement).value))}
+            />
+        </label>`;
+    }
+}
+
+function slug(family: string): string {
+    return (
+        family
+            .toLowerCase()
+            .replace(/[^a-z0-9]+/g, "-")
+            .replace(/^-+|-+$/g, "") || "font"
+    );
+}
+
+function clamp(value: number, min: number, max: number): number {
+    return Math.max(min, Math.min(max, value));
+}
+
+function fmtAxis(value: number): string {
+    return Number.isInteger(value) ? String(value) : value.toFixed(1);
+}

--- a/vscode-extension/src/webview/fonts/protocol.ts
+++ b/vscode-extension/src/webview/fonts/protocol.ts
@@ -1,0 +1,27 @@
+// Wire protocol between the font-browser host panel and its webview.
+// Shared by `fontBrowserPanel.ts` (host) and `main.ts` (webview) so the
+// two ends can't drift.
+
+import type { FontCatalog } from "../../googleFontsCatalog";
+import type { DownloadedFontView } from "./fontBrowserLogic";
+
+export type HostToWebview =
+    | { command: "catalog"; catalog: FontCatalog }
+    | { command: "catalogLoading" }
+    | { command: "catalogError"; message: string }
+    | { command: "downloaded"; fonts: DownloadedFontView[] }
+    | {
+          command: "downloadState";
+          familyId: string;
+          family: string;
+          state: "downloading" | "done" | "error";
+          message?: string;
+      };
+
+export type WebviewToHost =
+    | { command: "ready" }
+    | { command: "refreshCatalog" }
+    | { command: "download"; family: string }
+    | { command: "removeDownloaded"; familyId: string }
+    | { command: "copySnippet"; text: string }
+    | { command: "openExternal"; url: string };


### PR DESCRIPTION
Adds a "Browse Google Fonts" webview panel: search the keyless Google
Fonts catalog, download a family into the extension cache, and live-
customise the downloaded face.

- googleFontsCatalog: pure parse/search + css2 URL builders (shared
  host/webview, no node deps).
- googleFontsClient: keyless metadata fetch, css2 face parsing, font
  byte download — all via an injected FetchLike.
- downloadedFontsStore: extension-cache storage + manifest behind an
  injected StorageFs.
- fontBrowserPanel: webview host (CSP, catalog cache, download/remove,
  copy snippet, open specimen).
- webview/fonts: Lit UI with browse previews in the real typeface, a
  downloaded shelf, and a customiser (weight/italic/size/spacing,
  per-axis sliders for variable fonts) that emits a Compose
  FontFamily/TextStyle snippet.

Unit tests cover the parser, client, store, snippet codegen, and
browser logic.