### PR TITLE
test(vscode): capture the Google Fonts browser in the preview-harness

### DIFF
--- a/vscode-extension/preview-harness/fixtures/fonts-browser.json
+++ b/vscode-extension/preview-harness/fixtures/fonts-browser.json
@@ -1,0 +1,154 @@
+{
+    "description": "Google Fonts browser: search/browse list, a downloaded variable font, and the live customiser (weight/italic/size/spacing + per-axis sliders + Compose snippet). app/bundle/styles point the harness at the font-browser bundle instead of preview-app.",
+    "app": "font-browser-app",
+    "bundle": "../media/webview/fonts.js",
+    "styles": ["../media/fonts.css"],
+    "dataset": {},
+    "messages": [
+        {
+            "command": "catalog",
+            "catalog": {
+                "fetchedAt": "2026-06-04T00:00:00.000Z",
+                "categories": ["Display", "Sans Serif", "Serif"],
+                "families": [
+                    {
+                        "family": "Roboto",
+                        "category": "Sans Serif",
+                        "subsets": ["latin"],
+                        "popularity": 1,
+                        "axes": [],
+                        "instances": [
+                            { "weight": 400, "italic": false },
+                            { "weight": 400, "italic": true },
+                            { "weight": 700, "italic": false }
+                        ],
+                        "weights": [400, 700],
+                        "hasItalic": true,
+                        "isVariable": false
+                    },
+                    {
+                        "family": "Roboto Flex",
+                        "category": "Sans Serif",
+                        "subsets": ["latin"],
+                        "popularity": 12,
+                        "axes": [
+                            {
+                                "tag": "wght",
+                                "displayName": "Weight",
+                                "min": 100,
+                                "max": 1000,
+                                "defaultValue": 400
+                            },
+                            {
+                                "tag": "opsz",
+                                "displayName": "Optical Size",
+                                "min": 8,
+                                "max": 144,
+                                "defaultValue": 14
+                            },
+                            {
+                                "tag": "GRAD",
+                                "displayName": "Grade",
+                                "min": -200,
+                                "max": 150,
+                                "defaultValue": 0
+                            }
+                        ],
+                        "instances": [{ "weight": 400, "italic": false }],
+                        "weights": [400],
+                        "hasItalic": false,
+                        "isVariable": true
+                    },
+                    {
+                        "family": "Inter",
+                        "category": "Sans Serif",
+                        "subsets": ["latin"],
+                        "popularity": 8,
+                        "axes": [
+                            {
+                                "tag": "wght",
+                                "displayName": "Weight",
+                                "min": 100,
+                                "max": 900,
+                                "defaultValue": 400
+                            }
+                        ],
+                        "instances": [{ "weight": 400, "italic": false }],
+                        "weights": [400],
+                        "hasItalic": false,
+                        "isVariable": true
+                    },
+                    {
+                        "family": "Lora",
+                        "category": "Serif",
+                        "subsets": ["latin"],
+                        "popularity": 30,
+                        "axes": [],
+                        "instances": [
+                            { "weight": 400, "italic": false },
+                            { "weight": 700, "italic": false }
+                        ],
+                        "weights": [400, 700],
+                        "hasItalic": false,
+                        "isVariable": false
+                    },
+                    {
+                        "family": "Bebas Neue",
+                        "category": "Display",
+                        "subsets": ["latin"],
+                        "popularity": 40,
+                        "axes": [],
+                        "instances": [{ "weight": 400, "italic": false }],
+                        "weights": [400],
+                        "hasItalic": false,
+                        "isVariable": false
+                    }
+                ]
+            }
+        },
+        {
+            "command": "downloaded",
+            "fonts": [
+                {
+                    "family": "Roboto Flex",
+                    "familyId": "roboto-flex",
+                    "category": "Sans Serif",
+                    "isVariable": true,
+                    "axes": [
+                        {
+                            "tag": "wght",
+                            "displayName": "Weight",
+                            "min": 100,
+                            "max": 1000,
+                            "defaultValue": 400
+                        },
+                        {
+                            "tag": "opsz",
+                            "displayName": "Optical Size",
+                            "min": 8,
+                            "max": 144,
+                            "defaultValue": 14
+                        },
+                        {
+                            "tag": "GRAD",
+                            "displayName": "Grade",
+                            "min": -200,
+                            "max": 150,
+                            "defaultValue": 0
+                        }
+                    ],
+                    "faces": [
+                        {
+                            "style": "normal",
+                            "weightMin": 100,
+                            "weightMax": 1000,
+                            "uri": "/media/codicon.ttf",
+                            "format": "ttf"
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "actions": [{ "click": ".gfb-chip" }]
+}

--- a/vscode-extension/preview-harness/scenario.html
+++ b/vscode-extension/preview-harness/scenario.html
@@ -12,6 +12,10 @@
         <link rel="stylesheet" href="../media/codicon.css" />
         <link rel="stylesheet" href="./vscode-theme.css" />
         <link rel="stylesheet" href="../media/preview.css" />
+        <!-- Extra per-fixture stylesheets (e.g. the font browser's
+             media/fonts.css) are appended at boot from the fixture's
+             `styles` array, so a non-preview app can bring its own CSS
+             without this page hard-coding every panel's sheet. -->
 
         <!-- The shim must run before preview.js loads, so getVsCodeApi()
              finds window.acquireVsCodeApi on its first call. -->
@@ -60,14 +64,41 @@
                 const data = await res.json();
                 harness.fixtureData = data;
 
-                const app = document.createElement("preview-app");
+                // App/bundle/styles are fixture-driven so non-preview
+                // panels (e.g. the Google Fonts browser's
+                // `<font-browser-app>` from `fonts.js`) can be captured
+                // through the same loop. Defaults keep every existing
+                // preview-app fixture working untouched.
+                const appTag = data.app ?? "preview-app";
+                const bundle = data.bundle ?? "../media/webview/preview.js";
+                // Await each fixture stylesheet before rendering — a
+                // dynamically inserted <link> doesn't block this module
+                // script, so without this the screenshot can race a
+                // still-loading sheet (e.g. media/fonts.css) and capture
+                // unstyled chrome. Resolve on error too so an offline /
+                // 404 sheet doesn't hang the harness.
+                await Promise.all(
+                    (data.styles ?? []).map(
+                        (href) =>
+                            new Promise((res) => {
+                                const link = document.createElement("link");
+                                link.rel = "stylesheet";
+                                link.href = href;
+                                link.onload = res;
+                                link.onerror = res;
+                                document.head.appendChild(link);
+                            }),
+                    ),
+                );
+
+                const app = document.createElement(appTag);
                 for (const [k, v] of Object.entries(data.dataset ?? {})) {
                     app.dataset[k] = v;
                 }
                 document.body.appendChild(app);
 
-                await loadScript("../media/webview/preview.js");
-                await customElements.whenDefined("preview-app");
+                await loadScript(bundle);
+                await customElements.whenDefined(appTag);
                 await app.updateComplete;
 
                 for (const msg of data.messages ?? []) {


### PR DESCRIPTION
Follow-up to #1757 — adds the visual record for the Google Fonts browser webview that #1757 introduced.

## What
- Generalises the preview-harness `scenario.html` to be **fixture-driven**: a fixture can set `app` / `bundle` / `styles`, defaulting to `preview-app` + `preview.js` + `preview.css` so every existing fixture is untouched. Fixture stylesheets are awaited before render so a still-loading sheet can't race the screenshot.
- Adds a `fonts-browser` fixture that boots `font-browser-app` from `fonts.js` with a seeded catalog + one downloaded variable font, and an action that opens the live customiser — so the browse list, downloaded shelf, weight/italic/size/spacing controls, per-axis sliders, and the generated Compose snippet are all captured in `(fixture × theme)` snapshots.

## Notes
- #1757 has merged; this branch is rebased onto `main` so the diff is just the two harness files.
- Brand-new UI, so there is no "before" baseline — the preview-diff bot reports both captures as **new**.

## Test plan
- [x] `node preview-harness/snapshot.mjs --fixture fonts-browser` renders dark + light PNGs.
- [x] `--fixture grid-default` still renders — the `scenario.html` change is backward-compatible.
- [x] `npm run compile` (host + webview) clean; full mocha suite green.
- Browse-row/specimen text renders in the fallback face in the harness because it runs offline (the css2 font links can't load); layout + theming are what the snapshot pins.