### PR TITLE
ci(integration): run the jetstream-xr cell on JDK 21

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -416,6 +416,13 @@ jobs:
             # Compose app once it's on the alpha14 baseline.
             render: true
             extra_gradle_args: ""
+            # AdaptiveJetStream's `:jetstream` module compiles with Java 21
+            # source/target (Hilt's `hiltJavaCompileDebug` fails with
+            # `invalid source release: 21` on the workflow-default JDK 17).
+            # Pin this cell to 21 — same override the androidchka entry uses.
+            # 21 is also what Robolectric needs once the consumer's compileSdk
+            # reaches 36, so it keeps the render step viable too.
+            java_version: "21"
             notes: |
               - XR spatial Compose. Upstream tracks `androidx.xr.compose`
                 alpha07, whose `ApplicationSubspace` / `MovePolicy` /


### PR DESCRIPTION
## Summary

The `adaptive-apps-samples (AdaptiveJetStream — XR spatial Compose)` integration cell fails during `composePreviewDiscover` with:

```
> Task :jetstream:hiltJavaCompileDebug FAILED
> Java compilation initialization error
    error: invalid source release: 21
```

The consumer's `:jetstream` module compiles with **Java 21** source/target, but the cell runs on the workflow-default **JDK 17**, so Hilt's `hiltJavaCompileDebug` can't initialize and the build dies before any preview work. This is a blocking cell (no `continue_on_error`), so it reds the whole Integration workflow on `main`.

Fix: pin the cell to `java_version: "21"` — the same override the (commented) `androidchka` entry already uses. JDK 21 is also what Robolectric requires once a consumer's `compileSdk` reaches 36, so it keeps the render step viable rather than just the compile.

## Test plan

- [ ] Integration workflow's `adaptive-apps-samples (AdaptiveJetStream)` cell goes green (discover + render).
- [ ] Other matrix cells unaffected (they keep the default JDK 17).

---
_Generated by [Claude Code](https://claude.ai/code/session_01M4mQiqxrneEqECeoqPn53q)_