### PR TITLE
feat(vscode): generate downloadable Google Fonts snippet with variations

### DIFF
--- a/vscode-extension/src/test/composeFontSnippet.test.ts
+++ b/vscode-extension/src/test/composeFontSnippet.test.ts
@@ -3,7 +3,6 @@
 import * as assert from "assert";
 import {
     fontIdentifier,
-    fontResourceName,
     generateComposeSnippet,
 } from "../webview/fonts/composeFontSnippet";
 import type { FontAxis } from "../googleFontsCatalog";
@@ -24,14 +23,12 @@ const opsz: FontAxis = {
 };
 
 describe("composeFontSnippet", () => {
-    it("derives resource names and identifiers", () => {
-        assert.strictEqual(fontResourceName("Open Sans"), "open_sans");
-        assert.strictEqual(fontResourceName("IBM Plex Mono"), "ibm_plex_mono");
+    it("derives PascalCase identifiers", () => {
         assert.strictEqual(fontIdentifier("Open Sans"), "OpenSans");
         assert.strictEqual(fontIdentifier("roboto-flex"), "RobotoFlex");
     });
 
-    it("emits a static FontFamily without variation settings", () => {
+    it("emits a downloadable static FontFamily without variation settings", () => {
         const out = generateComposeSnippet({
             family: "Lora",
             weight: 700,
@@ -43,8 +40,12 @@ describe("composeFontSnippet", () => {
             letterSpacingSp: 0.5,
             lineHeightSp: 24,
         });
+        // Downloadable Google Fonts provider — not a bundled R.font resource.
+        assert.ok(out.includes("GoogleFont.Provider("));
         assert.ok(out.includes("val LoraFontFamily = FontFamily("));
-        assert.ok(out.includes("resId = R.font.lora"));
+        assert.ok(out.includes('googleFont = GoogleFont("Lora")'));
+        assert.ok(out.includes("fontProvider = provider"));
+        assert.ok(!out.includes("R.font."));
         assert.ok(out.includes("weight = FontWeight(700)"));
         assert.ok(out.includes("style = FontStyle.Italic"));
         assert.ok(!out.includes("FontVariation"));
@@ -53,7 +54,7 @@ describe("composeFontSnippet", () => {
         assert.ok(out.includes("fontStyle = FontStyle.Italic"));
     });
 
-    it("emits FontVariation.Settings for variable fonts", () => {
+    it("emits FontVariation.Settings for downloadable variable fonts", () => {
         const out = generateComposeSnippet({
             family: "Roboto Flex",
             weight: 500,
@@ -65,10 +66,13 @@ describe("composeFontSnippet", () => {
             letterSpacingSp: 0,
             lineHeightSp: 40,
         });
+        assert.ok(out.includes('googleFont = GoogleFont("Roboto Flex")'));
         assert.ok(out.includes("variationSettings = FontVariation.Settings("));
         assert.ok(out.includes("FontVariation.weight(500)"));
         assert.ok(out.includes('FontVariation.Setting("opsz", 40f)'));
         // wght goes through the dedicated helper, not a generic Setting.
         assert.ok(!out.includes('FontVariation.Setting("wght"'));
+        // The variation-on-downloadable-font core requirement is called out.
+        assert.ok(out.includes("androidx.core:core:1.19.0"));
     });
 });

--- a/vscode-extension/src/test/composeFontSnippet.test.ts
+++ b/vscode-extension/src/test/composeFontSnippet.test.ts
@@ -42,6 +42,13 @@ describe("composeFontSnippet", () => {
         });
         // Downloadable Google Fonts provider — not a bundled R.font resource.
         assert.ok(out.includes("GoogleFont.Provider("));
+        // Certs array is fully-qualified to the ui-text-google-fonts R so the
+        // snippet compiles under non-transitive R (the AGP default).
+        assert.ok(
+            out.includes(
+                "androidx.compose.ui.text.googlefonts.R.array.com_google_android_gms_fonts_certs",
+            ),
+        );
         assert.ok(out.includes("val LoraFontFamily = FontFamily("));
         assert.ok(out.includes('googleFont = GoogleFont("Lora")'));
         assert.ok(out.includes("fontProvider = provider"));

--- a/vscode-extension/src/webview/fonts/composeFontSnippet.ts
+++ b/vscode-extension/src/webview/fonts/composeFontSnippet.ts
@@ -53,7 +53,12 @@ const PROVIDER_BLOCK = [
     "val provider = GoogleFont.Provider(",
     '    providerAuthority = "com.google.android.gms.fonts",',
     '    providerPackage = "com.google.android.gms",',
-    "    certificates = R.array.com_google_android_gms_fonts_certs,",
+    // The certs array ships in androidx.compose.ui:ui-text-google-fonts, so
+    // fully-qualify its R — an unqualified `R` resolves to the app module
+    // (which lacks it) under non-transitive R, the AGP default.
+    "    certificates =",
+    "        androidx.compose.ui.text.googlefonts.R.array" +
+        ".com_google_android_gms_fonts_certs,",
     ")",
 ].join("\n");
 

--- a/vscode-extension/src/webview/fonts/composeFontSnippet.ts
+++ b/vscode-extension/src/webview/fonts/composeFontSnippet.ts
@@ -1,8 +1,13 @@
 // Pure Compose-snippet codegen for the font browser's customiser.
 //
-// Given the live attribute selections (weight, italic, and — for
-// variable fonts — the per-axis values) this emits a Kotlin
-// `FontFamily` + `TextStyle` the user can paste into a Compose project.
+// Everything the browser lists is a Google **downloadable** font, so the
+// emitted Kotlin uses the Google Fonts provider API
+// (`androidx.compose.ui.text.googlefonts`) rather than a bundled
+// `R.font.<name>` resource: a `GoogleFont.Provider` plus
+// `Font(googleFont = …, fontProvider = …)`. For variable fonts we also
+// emit `variationSettings` — downloadable variable fonts gained
+// variation support in `androidx.core:core:1.19.0`.
+//
 // No DOM / node deps so it's unit-tested directly and shared by the
 // webview bundle.
 
@@ -22,16 +27,6 @@ export interface SnippetOptions {
     lineHeightSp: number;
 }
 
-/** Android `res/font` resource name (lowercase, underscores only). */
-export function fontResourceName(family: string): string {
-    return (
-        family
-            .toLowerCase()
-            .replace(/[^a-z0-9]+/g, "_")
-            .replace(/^_+|_+$/g, "") || "font"
-    );
-}
-
 /** PascalCase identifier prefix for the generated `val`s. */
 export function fontIdentifier(family: string): string {
     const parts = family
@@ -47,25 +42,41 @@ function fmt(value: number): string {
     return Number.isInteger(value) ? String(value) : value.toFixed(2);
 }
 
+/** Escape a family name for embedding in a Kotlin string literal. */
+function kotlinString(value: string): string {
+    return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+// The standard Google Fonts downloadable-font provider — the same
+// `com.google.android.gms.fonts` authority every consumer declares once.
+const PROVIDER_BLOCK = [
+    "val provider = GoogleFont.Provider(",
+    '    providerAuthority = "com.google.android.gms.fonts",',
+    '    providerPackage = "com.google.android.gms",',
+    "    certificates = R.array.com_google_android_gms_fonts_certs,",
+    ")",
+].join("\n");
+
 /**
- * Generate the Compose `FontFamily` + `TextStyle` snippet reflecting the
- * current customiser selections.
+ * Generate the Compose downloadable-`FontFamily` + `TextStyle` snippet
+ * reflecting the current customiser selections.
  */
 export function generateComposeSnippet(opts: SnippetOptions): string {
-    const res = fontResourceName(opts.family);
     const id = fontIdentifier(opts.family);
     const styleEnum = opts.italic ? "FontStyle.Italic" : "FontStyle.Normal";
 
     const fontArgs: string[] = [
-        `resId = R.font.${res}`,
+        `googleFont = GoogleFont("${kotlinString(opts.family)}")`,
+        `fontProvider = provider`,
         `weight = FontWeight(${opts.weight})`,
         `style = ${styleEnum}`,
     ];
 
     if (opts.isVariable) {
         const settings: string[] = [];
-        // Always pin weight + italic through the variation API so the
-        // variable file renders exactly what the customiser shows.
+        // Pin weight (+ italic) through the variation API so the
+        // downloadable variable font renders exactly what the
+        // customiser shows.
         settings.push(`FontVariation.weight(${opts.weight})`);
         if (opts.italic) settings.push(`FontVariation.italic(1f)`);
         for (const axis of opts.axes) {
@@ -84,7 +95,17 @@ export function generateComposeSnippet(opts: SnippetOptions): string {
 
     const fontArgsBlock = fontArgs.map((a) => `        ${a},`).join("\n");
 
-    return [
+    const lines: string[] = [];
+    if (opts.isVariable) {
+        // variationSettings on a downloadable font needs core 1.19.0+.
+        lines.push(
+            "// Variable-axis variationSettings on downloadable fonts requires",
+            "// androidx.core:core:1.19.0+ and ui-text-google-fonts.",
+        );
+    }
+    lines.push(
+        PROVIDER_BLOCK,
+        "",
         `val ${id}FontFamily = FontFamily(`,
         `    Font(`,
         fontArgsBlock,
@@ -99,5 +120,6 @@ export function generateComposeSnippet(opts: SnippetOptions): string {
         `    letterSpacing = ${fmt(opts.letterSpacingSp)}.sp,`,
         `    lineHeight = ${fmt(opts.lineHeightSp)}.sp,`,
         `)`,
-    ].join("\n");
+    );
+    return lines.join("\n");
 }


### PR DESCRIPTION
Follow-up to the Google Fonts browser (#1757). Everything the browser lists is a Google **downloadable** font, so the customiser's generated Compose snippet should reflect that — not imply a bundled font resource.

## What changed
- The Compose snippet now uses the **Google Fonts provider** API: a `GoogleFont.Provider` declaration plus `Font(googleFont = GoogleFont("<family>"), fontProvider = provider, …)` from `androidx.compose.ui.text.googlefonts`, instead of `Font(resId = R.font.<name>, …)`. The certs array is fully-qualified (`androidx.compose.ui.text.googlefonts.R.array.com_google_android_gms_fonts_certs`) so the snippet compiles under non-transitive R.
- For **variable** fonts the downloadable `Font(...)` now carries `variationSettings = FontVariation.Settings(...)` — downloadable variable fonts gained variation support in **`androidx.core:core:1.19.0`**, which the snippet calls out in a comment.
- Static fonts emit just `weight` / `style` (no `variationSettings`).

## Test plan
- [x] `npm run compile` (host + webview) clean.
- [x] `composeFontSnippet` unit tests updated + green (full mocha suite passes).
- [x] Re-rendered the `fonts-browser` preview-harness fixture to confirm the new snippet renders.