### PR TITLE
feat(vscode): render wireframe-overlay panel faces from SpatialSemanticsTree

### DIFF
--- a/vscode-extension/src/test/semanticsTreeLoader.test.ts
+++ b/vscode-extension/src/test/semanticsTreeLoader.test.ts
@@ -1,0 +1,185 @@
+import * as assert from "assert";
+import { readFileSync } from "fs";
+import * as path from "path";
+import {
+    flattenPanels,
+    panelWireframesById,
+    parseSpatialSemanticsTree,
+    parseSpatialSemanticsTreeJson,
+    SpatialSemanticsTreeParseError,
+} from "../webview/spatial/semanticsTreeLoader";
+import { SPATIAL_SEMANTICS_TREE_VERSION } from "../webview/shared/spatialSemanticsTree";
+
+const extensionRoot = path.resolve(__dirname, "../..");
+
+/** The minimum a payload needs to clear the contract guard + this loader's version check. */
+function validTreeObject(): Record<string, unknown> {
+    return {
+        version: SPATIAL_SEMANTICS_TREE_VERSION,
+        units: "dp",
+        previewId: "Demo",
+        root: {
+            id: "subspaceRoot",
+            kind: "subspaceRoot",
+            poseInRoot: {
+                translation: { x: 0, y: 0, z: 0 },
+                rotation: { x: 0, y: 0, z: 0, w: 1 },
+            },
+            sizeDp: { width: 0, height: 0 },
+            children: [
+                {
+                    id: "panel",
+                    kind: "panel",
+                    poseInRoot: {
+                        translation: { x: 0, y: 0, z: 0 },
+                        rotation: { x: 0, y: 0, z: 0, w: 1 },
+                    },
+                    sizeDp: { width: 100, height: 50 },
+                    panelContent: {
+                        nodeId: "1",
+                        boundsInRoot: "0,0,100,50",
+                        children: [
+                            { nodeId: "2", boundsInRoot: "10,10,40,30" },
+                        ],
+                    },
+                },
+            ],
+        },
+    };
+}
+
+function loadFixtureTree() {
+    const text = readFileSync(
+        path.resolve(
+            extensionRoot,
+            "preview-harness/fixtures/spatial-semantics-tree/tree.json",
+        ),
+        "utf8",
+    );
+    return parseSpatialSemanticsTreeJson(text);
+}
+
+describe("semanticsTreeLoader", () => {
+    describe("parseSpatialSemanticsTree", () => {
+        it("accepts a valid tree", () => {
+            const tree = parseSpatialSemanticsTree(validTreeObject());
+            assert.strictEqual(tree.version, SPATIAL_SEMANTICS_TREE_VERSION);
+            assert.strictEqual(tree.root.id, "subspaceRoot");
+        });
+
+        it("rejects a version mismatch with an actionable message", () => {
+            const bad = { ...validTreeObject(), version: 999 };
+            assert.throws(
+                () => parseSpatialSemanticsTree(bad),
+                (err: unknown) =>
+                    err instanceof SpatialSemanticsTreeParseError &&
+                    /unsupported SpatialSemanticsTree version 999/.test(
+                        (err as Error).message,
+                    ),
+            );
+        });
+
+        it("rejects a payload with no root", () => {
+            const bad = {
+                version: SPATIAL_SEMANTICS_TREE_VERSION,
+                units: "dp",
+            };
+            assert.throws(
+                () => parseSpatialSemanticsTree(bad),
+                SpatialSemanticsTreeParseError,
+            );
+        });
+
+        it("rejects non-objects", () => {
+            assert.throws(
+                () => parseSpatialSemanticsTree(null),
+                SpatialSemanticsTreeParseError,
+            );
+            assert.throws(
+                () => parseSpatialSemanticsTree("nope"),
+                SpatialSemanticsTreeParseError,
+            );
+        });
+    });
+
+    describe("parseSpatialSemanticsTreeJson", () => {
+        it("wraps JSON syntax errors", () => {
+            assert.throws(
+                () => parseSpatialSemanticsTreeJson("{ not json"),
+                (err: unknown) =>
+                    err instanceof SpatialSemanticsTreeParseError &&
+                    /invalid JSON/.test((err as Error).message),
+            );
+        });
+
+        it("parses the committed fixture", () => {
+            const tree = loadFixtureTree();
+            assert.strictEqual(tree.previewId, "NowPlayingSpatialPreview");
+            assert.strictEqual(tree.root.kind, "column");
+        });
+    });
+
+    describe("flattenPanels", () => {
+        it("returns only content-hosting panels, depth-first", () => {
+            const panels = flattenPanels(loadFixtureTree());
+            assert.deepStrictEqual(
+                panels.map((p) => p.id),
+                ["now-playing", "transport"],
+            );
+        });
+
+        it("skips pure container nodes", () => {
+            // The synthetic tree's subspaceRoot has no panelContent; only its panel child does.
+            const panels = flattenPanels(
+                parseSpatialSemanticsTree(validTreeObject()),
+            );
+            assert.deepStrictEqual(
+                panels.map((p) => p.id),
+                ["panel"],
+            );
+        });
+    });
+
+    describe("panelWireframesById", () => {
+        it("derives per-panel boxes keyed by panel id from the fixture", () => {
+            const byId = panelWireframesById(loadFixtureTree());
+            assert.deepStrictEqual([...byId.keys()].sort(), [
+                "now-playing",
+                "transport",
+            ]);
+
+            const np = byId.get("now-playing")!;
+            assert.deepStrictEqual(np.contentSize, { width: 560, height: 200 });
+            // Root (10) + two children (11, 12), namespaced by panel id.
+            assert.deepStrictEqual(
+                np.boxes.map((b) => b.id),
+                ["now-playing:10", "now-playing:11", "now-playing:12"],
+            );
+            assert.deepStrictEqual(np.boxes[1].bounds, {
+                left: 16,
+                top: 16,
+                right: 300,
+                bottom: 52,
+            });
+            assert.ok(np.boxes.every((b) => b.level === "info"));
+        });
+
+        it("flags a mergeDescendants node as a warning-level box", () => {
+            const byId = panelWireframesById(loadFixtureTree());
+            const transport = byId.get("transport")!;
+            const root = transport.boxes.find((b) => b.id === "transport:20")!;
+            assert.strictEqual(root.level, "warning");
+            const play = transport.boxes.find((b) => b.id === "transport:21")!;
+            assert.strictEqual(play.level, "info");
+            // The clickable "Play" button's tooltip carries its label + role.
+            assert.strictEqual(play.tooltip, "Play [Button]");
+        });
+
+        it("skips a panel whose content root has unparseable bounds", () => {
+            const obj = validTreeObject() as any;
+            obj.root.children[0].panelContent.boundsInRoot = "garbage";
+            const byId = panelWireframesById(parseSpatialSemanticsTree(obj));
+            assert.strictEqual(byId.size, 0);
+        });
+    });
+});

--- a/vscode-extension/src/test/spatialToggle.test.ts
+++ b/vscode-extension/src/test/spatialToggle.test.ts
@@ -9,7 +9,27 @@ import {
     type SpatialToggleEffects,
 } from "../webview/preview/spatialToggle";
 import { SPATIAL_SCENE_VERSION } from "../webview/shared/spatialScene";
+import {
+    SPATIAL_SEMANTICS_TREE_VERSION,
+    type SpatialSemanticsTree,
+} from "../webview/shared/spatialSemanticsTree";
 import { parseSpatialScene } from "../webview/spatial/sceneLoader";
+
+function semanticsTree(): SpatialSemanticsTree {
+    return {
+        version: SPATIAL_SEMANTICS_TREE_VERSION,
+        units: "dp",
+        root: {
+            id: "subspaceRoot",
+            kind: "subspaceRoot",
+            poseInRoot: {
+                translation: { x: 0, y: 0, z: 0 },
+                rotation: { x: 0, y: 0, z: 0, w: 1 },
+            },
+            sizeDp: { width: 0, height: 0 },
+        },
+    };
+}
 
 function scene() {
     return parseSpatialScene({
@@ -198,6 +218,27 @@ describe("SpatialToggleController", () => {
         const first = view.scene;
         h.controller.setScene(scene(), "https://other/");
         assert.notStrictEqual(view.scene, first, "view scene re-applied");
+    });
+
+    it("threads an optional semantics tree to the view for wireframe overlays", async () => {
+        const h = makeHarness();
+        const tree = semanticsTree();
+        h.controller.setScene(scene(), "https://base/", tree);
+        await h.controller.setMode("3d");
+        const view = h.mount.children[0] as HTMLElement & {
+            semanticsTree?: unknown;
+        };
+        assert.strictEqual(view.semanticsTree, tree, "tree applied to view");
+    });
+
+    it("leaves the view's semantics tree null when none is supplied", async () => {
+        const h = makeHarness();
+        h.controller.setScene(scene(), "https://base/");
+        await h.controller.setMode("3d");
+        const view = h.mount.children[0] as HTMLElement & {
+            semanticsTree?: unknown;
+        };
+        assert.strictEqual(view.semanticsTree, null);
     });
 
     it("throws on 3D entry when no bundle source is configured", async () => {

--- a/vscode-extension/src/test/wireframeCompositor.test.ts
+++ b/vscode-extension/src/test/wireframeCompositor.test.ts
@@ -1,0 +1,96 @@
+import * as assert from "assert";
+import {
+    drawWireframeBoxes,
+    type WireframeContext2D,
+} from "../webview/spatial/wireframeCompositor";
+import { type PanelWireframe } from "../webview/spatial/semanticsTreeLoader";
+
+interface StrokeCall {
+    style: string;
+    rect: [number, number, number, number];
+}
+
+/** A recording stand-in for CanvasRenderingContext2D so the pure draw logic is testable. */
+class FakeContext implements WireframeContext2D {
+    lineWidth = 0;
+    strokeStyle: string | CanvasGradient | CanvasPattern = "";
+    readonly calls: StrokeCall[] = [];
+    strokeRect(x: number, y: number, w: number, h: number): void {
+        this.calls.push({
+            style: String(this.strokeStyle),
+            rect: [x, y, w, h],
+        });
+    }
+}
+
+function wireframe(): PanelWireframe {
+    return {
+        panelId: "now-playing",
+        contentSize: { width: 560, height: 200 },
+        boxes: [
+            {
+                id: "now-playing:10",
+                bounds: { left: 0, top: 0, right: 560, bottom: 200 },
+                level: "info",
+            },
+            {
+                id: "now-playing:11",
+                bounds: { left: 16, top: 16, right: 300, bottom: 52 },
+                level: "info",
+            },
+            {
+                id: "now-playing:button",
+                bounds: { left: 24, top: 24, right: 88, bottom: 72 },
+                level: "warning",
+            },
+        ],
+    };
+}
+
+describe("wireframeCompositor", () => {
+    describe("drawWireframeBoxes", () => {
+        it("scales box bounds from content space onto the target pixel size", () => {
+            const ctx = new FakeContext();
+            // 2× the content size, so every coordinate doubles.
+            drawWireframeBoxes(ctx, wireframe(), 1120, 400);
+
+            assert.strictEqual(ctx.calls.length, 3);
+            assert.deepStrictEqual(ctx.calls[0].rect, [0, 0, 1120, 400]);
+            assert.deepStrictEqual(ctx.calls[1].rect, [32, 32, 568, 72]);
+            assert.deepStrictEqual(ctx.calls[2].rect, [48, 48, 128, 96]);
+        });
+
+        it("strokes each box in its level colour", () => {
+            const ctx = new FakeContext();
+            drawWireframeBoxes(ctx, wireframe(), 560, 200);
+            assert.strictEqual(ctx.calls[0].style, "#4a9eff"); // info
+            assert.strictEqual(ctx.calls[2].style, "#ffb84a"); // warning
+        });
+
+        it("honours an explicit per-box colour override", () => {
+            const wf = wireframe();
+            wf.boxes[0].color = "#00ff00";
+            const ctx = new FakeContext();
+            drawWireframeBoxes(ctx, wf, 560, 200);
+            assert.strictEqual(ctx.calls[0].style, "#00ff00");
+        });
+
+        it("sets a target-relative line width of at least 2px", () => {
+            const small = new FakeContext();
+            drawWireframeBoxes(small, wireframe(), 560, 200);
+            assert.strictEqual(small.lineWidth, 2);
+
+            const large = new FakeContext();
+            drawWireframeBoxes(large, wireframe(), 2800, 1000);
+            assert.strictEqual(large.lineWidth, Math.round(1000 / 240));
+        });
+
+        it("no-ops on a degenerate content size", () => {
+            const ctx = new FakeContext();
+            const wf = wireframe();
+            wf.contentSize = { width: 0, height: 0 };
+            drawWireframeBoxes(ctx, wf, 560, 200);
+            assert.strictEqual(ctx.calls.length, 0);
+        });
+    });
+});

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -1,4 +1,5 @@
 import type { SpatialScene } from "./webview/shared/spatialScene";
+import type { SpatialSemanticsTree } from "./webview/shared/spatialSemanticsTree";
 
 export interface PreviewParams {
     name: string | null;
@@ -731,6 +732,13 @@ export type ExtensionToWebview =
            * arbitrary disk paths, so textures must be addressed this way.
            */
           textureBaseUri: string;
+          /**
+           * Optional companion 3D-over-2D semantics tree (see
+           * `webview/shared/spatialSemanticsTree.ts`). When present, the viewer
+           * overlays each panel's 2D wireframe boxes onto its screenshot face,
+           * matched to the scene by panel id. Omitted until a producer emits it.
+           */
+          semanticsTree?: SpatialSemanticsTree;
       };
 
 /**

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -3425,8 +3425,8 @@ export class PreviewApp extends LitElement {
                 bundleController.handleExternalKindToggle("test/failure", true),
             toggleBundle: (bundleId) =>
                 bundleController.toggleBundle(bundleId as BundleId),
-            setSpatialScene: (scene, textureBaseUri) =>
-                spatialToggle.setScene(scene, textureBaseUri),
+            setSpatialScene: (scene, textureBaseUri, semanticsTree) =>
+                spatialToggle.setScene(scene, textureBaseUri, semanticsTree),
         };
         window.addEventListener("message", (event) => {
             handleExtensionMessage(event.data, messageContext);

--- a/vscode-extension/src/webview/preview/messageHandlers.ts
+++ b/vscode-extension/src/webview/preview/messageHandlers.ts
@@ -41,6 +41,7 @@ import type {
     PreviewInfo,
 } from "../shared/types";
 import type { SpatialScene } from "../shared/spatialScene";
+import type { SpatialSemanticsTree } from "../shared/spatialSemanticsTree";
 import type { VsCodeApi } from "../shared/vscode";
 import { safeArrayIndex } from "../shared/safeIndex";
 import { sanitizeId } from "./cardData";
@@ -169,7 +170,11 @@ export interface PreviewMessageContext {
      * `SpatialToggleController`, which mounts the (separately-bundled) viewer
      * lazily — so this can land before or after the user toggles to 3D.
      */
-    setSpatialScene(scene: SpatialScene, textureBaseUri: string): void;
+    setSpatialScene(
+        scene: SpatialScene,
+        textureBaseUri: string,
+        semanticsTree?: SpatialSemanticsTree,
+    ): void;
 }
 
 /** Methods the dispatcher needs from `<filter-toolbar>`. The component
@@ -241,7 +246,11 @@ export function handleExtensionMessage(
             );
             return;
         case "setSpatialScene":
-            ctx.setSpatialScene(msg.scene, msg.textureBaseUri);
+            ctx.setSpatialScene(
+                msg.scene,
+                msg.textureBaseUri,
+                msg.semanticsTree,
+            );
             return;
         case "triggerBundleToggle":
             ctx.toggleBundle(msg.bundleId);

--- a/vscode-extension/src/webview/preview/spatialToggle.ts
+++ b/vscode-extension/src/webview/preview/spatialToggle.ts
@@ -12,10 +12,13 @@
 // button stays hidden until a scene arrives so non-XR panels look unchanged.
 
 import type { SpatialScene } from "../shared/spatialScene";
+import type { SpatialSemanticsTree } from "../shared/spatialSemanticsTree";
 
 /** The `<spatial-view>` element's public surface this controller drives. */
 interface SpatialViewElement extends HTMLElement {
     scene: SpatialScene | null;
+    /** Optional companion semantics tree — overlays wireframes on the panel faces. */
+    semanticsTree?: SpatialSemanticsTree | null;
     resolveTextureUrl?: (texture: string) => string;
     focusPanel?(panelId: string): void;
 }
@@ -75,6 +78,7 @@ export class SpatialToggleController {
     private readonly effects: SpatialToggleEffects;
     private mode: "2d" | "3d" = "2d";
     private scene: SpatialScene | null = null;
+    private semanticsTree: SpatialSemanticsTree | null = null;
     private textureBaseUri = "";
     private view: SpatialViewElement | null = null;
     private bundlePromise: Promise<void> | null = null;
@@ -102,10 +106,17 @@ export class SpatialToggleController {
 
     /**
      * Install a scene + the base URI its relative texture paths resolve
-     * against. Reveals the toggle button and, if already in 3D, repaints.
+     * against. Reveals the toggle button and, if already in 3D, repaints. The
+     * optional [semanticsTree] companion overlays each panel's 2D wireframe onto
+     * its screenshot face (matched to the scene by panel id).
      */
-    setScene(scene: SpatialScene, textureBaseUri: string): void {
+    setScene(
+        scene: SpatialScene,
+        textureBaseUri: string,
+        semanticsTree: SpatialSemanticsTree | null = null,
+    ): void {
         this.scene = scene;
+        this.semanticsTree = semanticsTree;
         this.textureBaseUri = textureBaseUri;
         this.deps.toggleButton.hidden = false;
         if (this.mode === "3d" && this.view) {
@@ -185,6 +196,7 @@ export class SpatialToggleController {
 
     private applyScene(): void {
         if (this.view) {
+            this.view.semanticsTree = this.semanticsTree;
             this.view.scene = this.scene;
         }
     }

--- a/vscode-extension/src/webview/spatial/main.ts
+++ b/vscode-extension/src/webview/spatial/main.ts
@@ -16,7 +16,12 @@
 import { LitElement, html, css, type TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import type { SpatialScene } from "../shared/spatialScene";
+import type { SpatialSemanticsTree } from "../shared/spatialSemanticsTree";
 import { parseSpatialSceneJson } from "./sceneLoader";
+import {
+    panelWireframesById,
+    parseSpatialSemanticsTreeJson,
+} from "./semanticsTreeLoader";
 import { SpatialViewer } from "./spatialViewer";
 
 @customElement("spatial-view")
@@ -57,6 +62,14 @@ export class SpatialView extends LitElement {
     @property({ attribute: false })
     resolveTextureUrl?: (texture: string) => string;
 
+    /**
+     * Optional companion 2D-over-3D semantics tree. When present, each panel's wireframe boxes are
+     * composited onto its screenshot face (matched to the scene by panel id). Set directly, or via
+     * `setSemanticsTreeJson`.
+     */
+    @property({ attribute: false })
+    semanticsTree: SpatialSemanticsTree | null = null;
+
     private viewer?: SpatialViewer;
     private stage?: HTMLDivElement;
 
@@ -76,15 +89,22 @@ export class SpatialView extends LitElement {
             this.renderRoot.querySelector<HTMLDivElement>(".spatial-stage") ??
             undefined;
         this.ensureViewer();
-        if (this.scene) {
-            this.viewer?.load(this.scene);
-        }
+        this.loadIntoViewer();
     }
 
     protected updated(changed: Map<string, unknown>): void {
-        if (changed.has("scene") && this.viewer && this.scene) {
-            this.viewer.load(this.scene);
+        if (changed.has("scene") || changed.has("semanticsTree")) {
+            this.loadIntoViewer();
         }
+    }
+
+    /** (Re)load the current scene + derived wireframe overlays into the viewer. */
+    private loadIntoViewer(): void {
+        if (!this.viewer || !this.scene) return;
+        const wireframes = this.semanticsTree
+            ? panelWireframesById(this.semanticsTree)
+            : undefined;
+        this.viewer.load(this.scene, wireframes);
     }
 
     disconnectedCallback(): void {
@@ -96,6 +116,14 @@ export class SpatialView extends LitElement {
     /** Parse + load a scene from raw JSON text (throws on contract violation). */
     setSceneJson(text: string): void {
         this.scene = parseSpatialSceneJson(text);
+    }
+
+    /**
+     * Parse + apply a companion semantics tree from raw JSON text (throws on contract violation).
+     * Overlays the per-panel wireframes on the next viewer load.
+     */
+    setSemanticsTreeJson(text: string): void {
+        this.semanticsTree = parseSpatialSemanticsTreeJson(text);
     }
 
     /**

--- a/vscode-extension/src/webview/spatial/semanticsTreeLoader.ts
+++ b/vscode-extension/src/webview/spatial/semanticsTreeLoader.ts
@@ -1,0 +1,165 @@
+// Consumer-side loading for the `SpatialSemanticsTree` wire contract
+// ([../shared/spatialSemanticsTree.ts](../shared/spatialSemanticsTree.ts)) — the 3D-over-2D tree the
+// recorder (`SubspaceSceneRecorder.recordTree`) produces. The spatial viewer already renders the
+// `SpatialScene` (panel geometry + screenshot textures + camera); this module turns the companion
+// semantics tree into the per-panel **2D wireframe overlay** the viewer composites onto each panel's
+// textured face — keyed by panel id so it lines up with the scene's panels.
+//
+// Pure — no three.js, no DOM — so it runs under the Mocha unit suite. The actual canvas
+// compositing lives in the viewer (spatialViewer.ts); here we only derive the boxes.
+
+import { type OverlayBox } from "../preview/components/BoxOverlay";
+import { parseBounds } from "../preview/cardData";
+import {
+    isSpatialSemanticsTree,
+    SPATIAL_SEMANTICS_TREE_VERSION,
+    type SemanticsTreeNode,
+    type SpatialSemanticsNode,
+    type SpatialSemanticsTree,
+} from "../shared/spatialSemanticsTree";
+
+/** Thrown when a payload fails the contract guard or version check. */
+export class SpatialSemanticsTreeParseError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = "SpatialSemanticsTreeParseError";
+    }
+}
+
+/**
+ * Validate an untyped value against the contract and normalise it. Throws
+ * {@link SpatialSemanticsTreeParseError} on a failed {@link isSpatialSemanticsTree} guard or a
+ * `version` mismatch (the contract says `version` *must equal*
+ * {@link SPATIAL_SEMANTICS_TREE_VERSION}). Normalisation is shallow — additive optional fields at the
+ * same version pass through untouched.
+ */
+export function parseSpatialSemanticsTree(raw: unknown): SpatialSemanticsTree {
+    if (
+        typeof raw === "object" &&
+        raw !== null &&
+        typeof (raw as { version?: unknown }).version === "number" &&
+        (raw as { version: number }).version !== SPATIAL_SEMANTICS_TREE_VERSION
+    ) {
+        throw new SpatialSemanticsTreeParseError(
+            `unsupported SpatialSemanticsTree version ${(raw as { version: number }).version}: ` +
+                `this viewer was built against version ${SPATIAL_SEMANTICS_TREE_VERSION}`,
+        );
+    }
+    if (!isSpatialSemanticsTree(raw)) {
+        throw new SpatialSemanticsTreeParseError(
+            "not a SpatialSemanticsTree: expected an object with units:'dp', version " +
+                `${SPATIAL_SEMANTICS_TREE_VERSION}, and a root node`,
+        );
+    }
+    return raw;
+}
+
+/** Convenience wrapper: parse a JSON string into a {@link SpatialSemanticsTree}. */
+export function parseSpatialSemanticsTreeJson(
+    text: string,
+): SpatialSemanticsTree {
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(text);
+    } catch (err) {
+        throw new SpatialSemanticsTreeParseError(
+            `invalid JSON: ${(err as Error).message}`,
+        );
+    }
+    return parseSpatialSemanticsTree(parsed);
+}
+
+/**
+ * Every content-hosting node in the tree (a `panel`/`orbiter` carrying `panelContent`), in
+ * depth-first order. Pure container nodes (`subspaceRoot`/`row`/`column`/`box`) are walked through
+ * but not returned; a container that *also* hosts content (rare) is included.
+ */
+export function flattenPanels(
+    tree: SpatialSemanticsTree,
+): SpatialSemanticsNode[] {
+    const out: SpatialSemanticsNode[] = [];
+    const walk = (node: SpatialSemanticsNode): void => {
+        if (node.panelContent) out.push(node);
+        for (const child of node.children ?? []) walk(child);
+    };
+    walk(tree.root);
+    return out;
+}
+
+/** A panel's 2D wireframe: its content coordinate-space size plus the boxes to draw over it. */
+export interface PanelWireframe {
+    /** Matches the `SpatialScene` panel id (both derive from the panel's testTag). */
+    panelId: string;
+    /**
+     * The content coordinate-space extent (from the `panelContent` root's `boundsInRoot`). The
+     * viewer scales boxes from this space onto the panel texture's natural pixel size.
+     */
+    contentSize: { width: number; height: number };
+    /** Wireframe boxes in content coordinate space, ready for the overlay/compositor. */
+    boxes: OverlayBox[];
+}
+
+/** Walk a 2D semantics subtree into flat {@link OverlayBox}es, parsing each node's bounds. */
+function boxesFromSemantics(
+    panelId: string,
+    root: SemanticsTreeNode,
+): OverlayBox[] {
+    const out: OverlayBox[] = [];
+    const walk = (node: SemanticsTreeNode): void => {
+        const bounds = parseBounds(node.boundsInRoot);
+        if (bounds) {
+            out.push({
+                // Namespaced by panel so ids stay unique across the whole tree.
+                id: `${panelId}:${node.nodeId}`,
+                bounds,
+                // Mirror the 2D inspector overlay: a merge boundary is the one
+                // distinction worth surfacing; everything else is plain info.
+                level:
+                    node.mergeMode === "mergeDescendants" ? "warning" : "info",
+                tooltip: wireframeTooltip(node),
+            });
+        }
+        for (const child of node.children ?? []) walk(child);
+    };
+    walk(root);
+    return out;
+}
+
+/** A short hover label — the most identifying text the node carries, plus role/tag when present. */
+function wireframeTooltip(node: SemanticsTreeNode): string | undefined {
+    const primary = node.label ?? node.text ?? node.testTag;
+    const role = node.role ? `[${node.role}]` : undefined;
+    const parts = [primary, role].filter((p): p is string => !!p);
+    return parts.length > 0 ? parts.join(" ") : undefined;
+}
+
+/**
+ * Per-panel wireframes keyed by panel id, for every panel that carries 2D content. The viewer looks
+ * each panel's entry up by its `SpatialScene` panel id and composites the boxes onto its screenshot
+ * face; a panel with no entry simply renders its plain texture.
+ */
+export function panelWireframesById(
+    tree: SpatialSemanticsTree,
+): Map<string, PanelWireframe> {
+    const byId = new Map<string, PanelWireframe>();
+    for (const panel of flattenPanels(tree)) {
+        const content = panel.panelContent;
+        if (!content) continue;
+        const rootBounds = parseBounds(content.boundsInRoot);
+        // The content root's bounds define the coordinate space the child boxes live in. Without a
+        // parseable root extent we can't scale the boxes onto the texture, so skip the panel's
+        // overlay (its plain screenshot still renders).
+        if (!rootBounds) continue;
+        const contentSize = {
+            width: rootBounds.right - rootBounds.left,
+            height: rootBounds.bottom - rootBounds.top,
+        };
+        if (contentSize.width <= 0 || contentSize.height <= 0) continue;
+        byId.set(panel.id, {
+            panelId: panel.id,
+            contentSize,
+            boxes: boxesFromSemantics(panel.id, content),
+        });
+    }
+    return byId;
+}

--- a/vscode-extension/src/webview/spatial/spatialViewer.ts
+++ b/vscode-extension/src/webview/spatial/spatialViewer.ts
@@ -25,6 +25,8 @@ import type {
     Vec3,
 } from "../shared/spatialScene";
 import { renderableQuads } from "./sceneLoader";
+import { type PanelWireframe } from "./semanticsTreeLoader";
+import { composePanelTexture } from "./wireframeCompositor";
 
 /** Optional injection points for the viewer. */
 export interface SpatialViewerOptions {
@@ -110,6 +112,8 @@ export class SpatialViewer {
     private readonly skydome: THREE.Mesh;
     private quadObjects: QuadObject[] = [];
     private focusedId: string | null = null;
+    /** Per-panel 2D wireframe overlays, keyed by panel id; empty when no semantics tree is loaded. */
+    private wireframes = new Map<string, PanelWireframe>();
 
     private disposed = false;
     private frameHandle: number | null = null;
@@ -176,9 +180,17 @@ export class SpatialViewer {
         this.startLoop();
     }
 
-    /** Replace the rendered scene. Tears down the previous quads/textures. */
-    load(scene: SpatialScene): void {
+    /**
+     * Replace the rendered scene. Tears down the previous quads/textures. The optional
+     * [wireframes] map (keyed by panel id, from `panelWireframesById`) overlays each matching
+     * panel's 2D semantics boxes onto its screenshot face; omit it for a plain textured scene.
+     */
+    load(
+        scene: SpatialScene,
+        wireframes: Map<string, PanelWireframe> = new Map(),
+    ): void {
         this.clearQuads();
+        this.wireframes = wireframes;
         this.applyEnvironment(scene);
 
         for (const quad of renderableQuads(scene)) {
@@ -259,6 +271,7 @@ export class SpatialViewer {
         mesh.add(edges);
 
         const url = this.resolveTextureUrl(quad.texture);
+        const wireframe = this.wireframes.get(quad.id);
         this.textureLoader.load(
             url,
             (texture) => {
@@ -267,7 +280,24 @@ export class SpatialViewer {
                     return;
                 }
                 texture.colorSpace = THREE.SRGBColorSpace;
-                material.map = texture;
+                // "screenshot + wireframe overlay" face: when this panel carries a 2D semantics
+                // tree, composite its boxes over the screenshot. Falls back to the plain texture
+                // when there's no overlay or compositing isn't possible (no DOM / sized image).
+                let map: THREE.Texture = texture;
+                if (wireframe) {
+                    const composed = composePanelTexture(
+                        texture.image as CanvasImageSource & {
+                            width?: number;
+                            height?: number;
+                        },
+                        wireframe,
+                    );
+                    if (composed) {
+                        texture.dispose();
+                        map = composed;
+                    }
+                }
+                material.map = map;
                 material.color.set(0xffffff);
                 material.needsUpdate = true;
             },

--- a/vscode-extension/src/webview/spatial/wireframeCompositor.ts
+++ b/vscode-extension/src/webview/spatial/wireframeCompositor.ts
@@ -1,0 +1,87 @@
+// Composites a panel's 2D wireframe boxes ([./semanticsTreeLoader.ts]) onto its screenshot face for
+// the 3D spatial viewer: the panel quad keeps showing the real render, with the semantics boxes
+// drawn over it (the "screenshot + wireframe overlay" panel face). The box geometry is scaled from
+// the panel's *content* coordinate space (the `panelContent` root bounds) onto the texture's natural
+// pixel size, so it lines up regardless of capture density.
+//
+// `drawWireframeBoxes` is pure (takes a minimal 2D-context surface) and unit-tested; the three.js
+// `composePanelTexture` wrapper just owns the canvas + `CanvasTexture` and is exercised by the
+// viewer at runtime.
+
+import * as THREE from "three";
+import { type PanelWireframe } from "./semanticsTreeLoader";
+
+/** Stroke colours per overlay level — mirrors the 2D inspector accents (info matches the focus blue). */
+const LEVEL_STROKE: Record<string, string> = {
+    error: "#ff5c5c",
+    warning: "#ffb84a",
+    info: "#4a9eff",
+};
+const DEFAULT_STROKE = "#4a9eff";
+
+/** The minimal 2D-context surface {@link drawWireframeBoxes} needs (so tests pass a fake recorder). */
+export interface WireframeContext2D {
+    lineWidth: number;
+    strokeStyle: string | CanvasGradient | CanvasPattern;
+    strokeRect(x: number, y: number, w: number, h: number): void;
+}
+
+/**
+ * Draw a panel's wireframe boxes, scaled from {@link PanelWireframe.contentSize} onto a target of
+ * the given pixel size. Pure — no canvas/DOM/three.js. Boxes are stroked in their level colour (or
+ * an explicit `box.color` override); the line width scales gently with the target so it stays
+ * visible on high-density captures without overwhelming small panels.
+ */
+export function drawWireframeBoxes(
+    ctx: WireframeContext2D,
+    wireframe: PanelWireframe,
+    targetWidth: number,
+    targetHeight: number,
+): void {
+    const { width: contentW, height: contentH } = wireframe.contentSize;
+    if (contentW <= 0 || contentH <= 0) return;
+    const sx = targetWidth / contentW;
+    const sy = targetHeight / contentH;
+    ctx.lineWidth = Math.max(2, Math.round(targetHeight / 240));
+    for (const box of wireframe.boxes) {
+        ctx.strokeStyle =
+            box.color ?? LEVEL_STROKE[box.level ?? "info"] ?? DEFAULT_STROKE;
+        ctx.strokeRect(
+            box.bounds.left * sx,
+            box.bounds.top * sy,
+            (box.bounds.right - box.bounds.left) * sx,
+            (box.bounds.bottom - box.bounds.top) * sy,
+        );
+    }
+}
+
+/** A drawable image source carrying its natural pixel dimensions (an `HTMLImageElement`, etc.). */
+type SizedImageSource = CanvasImageSource & { width?: number; height?: number };
+
+/**
+ * Composite a loaded panel screenshot with its wireframe overlay into a {@link THREE.CanvasTexture}.
+ * Returns `null` when there's no DOM (tests / SSR) or the image has no intrinsic size — the caller
+ * then falls back to the plain screenshot texture, so a missing overlay degrades gracefully.
+ */
+export function composePanelTexture(
+    image: SizedImageSource,
+    wireframe: PanelWireframe,
+): THREE.CanvasTexture | null {
+    if (typeof document === "undefined") return null;
+    const width = typeof image.width === "number" ? image.width : 0;
+    const height = typeof image.height === "number" ? image.height : 0;
+    if (width <= 0 || height <= 0) return null;
+
+    const canvas = document.createElement("canvas");
+    canvas.width = width;
+    canvas.height = height;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return null;
+
+    ctx.drawImage(image, 0, 0, width, height);
+    drawWireframeBoxes(ctx, wireframe, width, height);
+
+    const texture = new THREE.CanvasTexture(canvas);
+    texture.colorSpace = THREE.SRGBColorSpace;
+    return texture;
+}


### PR DESCRIPTION
## Summary

Extends the 3D spatial viewer to render each panel face as the **screenshot with its 2D wireframe boxes overlaid** — the consumer side of the `SpatialSemanticsTree` that #1755 introduced (model + `recordTree` harvest).

The `SpatialScene` still provides panel geometry, screenshot textures, and the camera; the new `SpatialSemanticsTree` is an **optional overlay layer keyed by panel id**, so the viewer composites each panel's 2D semantics boxes onto its existing textured face. Built in pure, testable layers:

- **`semanticsTreeLoader.ts`** — parses/validates the tree, flattens it to the content-hosting panels, and derives per-panel `OverlayBox`es (reusing `parseBounds`), keyed by panel id. Pure (no three.js/DOM).
- **`wireframeCompositor.ts`** — `drawWireframeBoxes` scales boxes from the panel's content coordinate space onto the texture's natural pixels and strokes them per level colour (a merge boundary reads as a warning, matching the 2D inspector). `composePanelTexture` wraps it in a `CanvasTexture`. Falls back to the plain screenshot when there's no DOM / sized image.
- **`SpatialViewer.load(scene, wireframes?)`** — composites the overlay onto each matching panel quad; unchanged behaviour when no tree is supplied.
- **Wiring** — `<spatial-view>` gains a `semanticsTree` property (+ `setSemanticsTreeJson`); `SpatialToggleController.setScene` takes the optional tree; the `setSpatialScene` message carries an optional `semanticsTree`, threaded host-handler → controller → element.

Forward-compatible: the `semanticsTree` field is omitted until a producer emits it. The remaining follow-up (separate, backend) is the daemon emitting `tree.json` and the host posting it on `setSpatialScene` — at which point this consumer path lights up end-to-end.

## Test plan
- `npm test` (mocha/happy-dom) — **1507 passing**, including:
  - `semanticsTreeLoader` — 11 tests (parse/version guard, flatten, per-panel box derivation incl. the committed `spatial-semantics-tree/tree.json` fixture, merge-boundary level, degenerate-bounds skip).
  - `wireframeCompositor` — 5 tests (content→pixel scaling, level colours, colour override, line width, degenerate no-op) via a recording fake 2D context.
  - `SpatialToggleController` — +2 tests (tree threaded to the view; null when absent).
- `tsc` (host + webview) and the esbuild webview bundle — clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WBC1gMrTAL3vgMuZAn7Bgm)_