### PR TITLE
fix(integration): drop duplicate java_version key on the jetstream-xr cell

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -423,13 +423,6 @@ jobs:
             # Compose app once it's on the alpha14 baseline.
             render: true
             extra_gradle_args: ""
-            # AdaptiveJetStream's `:jetstream` module compiles with Java 21
-            # source/target (Hilt's `hiltJavaCompileDebug` fails with
-            # `invalid source release: 21` on the workflow-default JDK 17).
-            # Pin this cell to 21 — same override the androidchka entry uses.
-            # 21 is also what Robolectric needs once the consumer's compileSdk
-            # reaches 36, so it keeps the render step viable too.
-            java_version: "21"
             notes: |
               - XR spatial Compose. Upstream tracks `androidx.xr.compose`
                 alpha07, whose `ApplicationSubspace` / `MovePolicy` /


### PR DESCRIPTION
## Summary

The `jetstream-xr` integration matrix entry carried **two** `java_version: "21"` keys (added across #1756 + #1760). PyYAML silently keeps the last value, so it passed local `yaml.safe_load` checks — but GitHub Actions' own workflow parser **rejects duplicate mapping keys**, so the push-to-main run for #1760 (run #3352) failed at startup with **zero jobs**.

Because the whole workflow never started, the `publish-previews` job didn't run either, so the `compose-preview/integration/<slug>` browsable branches stopped updating on new pushes (they're still live from the last good run, just stale).

This collapses the entry to a single `java_version: "21"` key. Verified no other duplicate mapping keys exist anywhere in the workflow.

## Test plan

- [x] `yaml.safe_load` parses
- [x] Custom duplicate-mapping-key scan of the whole file → none
- [x] jetstream-xr keeps exactly one `java_version: "21"`
- [ ] Push-to-main integration run starts jobs again and `publish-previews` refreshes the three integration branches


---
_Generated by [Claude Code](https://claude.ai/code/session_01M4mQiqxrneEqECeoqPn53q)_