### PR TITLE
feat: render JetStream XR subspace previews in CI, auto-enabled from androidx.xr.compose

### DIFF
--- a/.github/ci/patches/adaptive-apps-samples-xr-spatial-previews.patch
+++ b/.github/ci/patches/adaptive-apps-samples-xr-spatial-previews.patch
@@ -1,0 +1,198 @@
+diff --git a/AdaptiveJetStream/jetstream/src/main/java/com/google/jetstream/presentation/xr/SpatialJetStreamPreviews.kt b/AdaptiveJetStream/jetstream/src/main/java/com/google/jetstream/presentation/xr/SpatialJetStreamPreviews.kt
+new file mode 100644
+index 0000000..07ab481
+--- /dev/null
++++ b/AdaptiveJetStream/jetstream/src/main/java/com/google/jetstream/presentation/xr/SpatialJetStreamPreviews.kt
+@@ -0,0 +1,192 @@
++/*
++ * Copyright 2025 Google LLC
++ *
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at
++ *
++ * https://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++ */
++
++package com.google.jetstream.presentation.xr
++
++import androidx.compose.foundation.background
++import androidx.compose.foundation.layout.Arrangement
++import androidx.compose.foundation.layout.Box
++import androidx.compose.foundation.layout.Column
++import androidx.compose.foundation.layout.Row
++import androidx.compose.foundation.layout.fillMaxSize
++import androidx.compose.foundation.layout.padding
++import androidx.compose.foundation.layout.size
++import androidx.compose.material3.Surface
++import androidx.compose.material3.Text
++import androidx.compose.runtime.Composable
++import androidx.compose.ui.Alignment
++import androidx.compose.ui.Modifier
++import androidx.compose.ui.graphics.Color
++import androidx.compose.ui.unit.dp
++import androidx.xr.compose.spatial.Subspace
++import androidx.xr.compose.subspace.SpatialColumn
++import androidx.xr.compose.subspace.SpatialPanel
++import androidx.xr.compose.subspace.SpatialRow
++import androidx.xr.compose.subspace.layout.SpatialArrangement
++import androidx.xr.compose.subspace.layout.SubspaceModifier
++import androidx.xr.compose.subspace.layout.height
++import androidx.xr.compose.subspace.layout.width
++import androidx.xr.compose.subspace.semantics.testTag
++import com.google.jetstream.presentation.app.UserAvatar
++import com.google.jetstream.presentation.app.withNavigationSuiteScaffold.TopAppBar
++import com.google.jetstream.presentation.components.BackButton
++import com.google.jetstream.presentation.components.JetStreamPreview
++import com.google.jetstream.presentation.components.MovieCard
++import com.google.jetstream.presentation.components.WatchNowButton
++import com.google.jetstream.presentation.screens.Screens
++import ee.schimke.composeai.preview.XrSubspacePreview
++
++/**
++ * `@XrSubspacePreview`s that lay JetStream's real UI out across a Jetpack XR `Subspace` — the
++ * spatial multi-panel workspace the app presents on an Android XR headset (Full Space mode), as
++ * opposed to the flat phone/foldable/TV `@Preview`s elsewhere in the app.
++ *
++ * Unlike a plain `@Preview` of a `Subspace` (which captures an empty Home-Space frame, because the
++ * subspace body is skipped when spatialization is off), an `@XrSubspacePreview` is composed under a
++ * fake XR runtime so the panel poses/sizes are genuinely measured and recovered into a `scene.json`
++ * (plus one `<testTag>.png` texture per panel) by the offline `composePreviewRenderXr` task.
++ *
++ * Invariant — **every `SpatialPanel` carries a unique `SubspaceModifier.testTag("<id>")`.** The tag
++ * becomes the panel id in `scene.json` and the `<id>.png` texture filename; a duplicate or missing
++ * tag breaks the scene. Each panel body reuses JetStream's existing stateless components
++ * (`MovieCard`, `WatchNowButton`, `UserAvatar`, `TopAppBar`, …) wrapped in [JetStreamPreview] so the
++ * app theme is applied, mirroring the component screenshot tests.
++ */
++
++/** Wraps a panel body in the JetStream theme + a filled [Surface], the shape every panel shares. */
++@Composable
++private fun Panel(content: @Composable () -> Unit) {
++    JetStreamPreview {
++        Surface(modifier = Modifier.fillMaxSize()) {
++            Box(
++                modifier = Modifier.fillMaxSize().padding(24.dp),
++                contentAlignment = Alignment.Center,
++            ) {
++                content()
++            }
++        }
++    }
++}
++
++@Composable
++private fun BrowsePanel() = Panel {
++    Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
++        repeat(3) { index ->
++            MovieCard(
++                onClick = {},
++                title = { Text("Featured ${index + 1}") },
++            ) {
++                Box(
++                    modifier = Modifier.size(200.dp, 112.dp).background(Color.DarkGray),
++                    contentAlignment = Alignment.Center,
++                ) {
++                    Text("Poster")
++                }
++            }
++        }
++    }
++}
++
++@Composable
++private fun DetailPanel() = Panel {
++    Column(
++        horizontalAlignment = Alignment.CenterHorizontally,
++        verticalArrangement = Arrangement.spacedBy(16.dp),
++    ) {
++        Box(
++            modifier = Modifier.size(320.dp, 180.dp).background(Color(0xFF2A2A2A)),
++            contentAlignment = Alignment.Center,
++        ) {
++            Text("Now Playing")
++        }
++        WatchNowButton()
++        BackButton(onClick = {}, isRequired = true)
++    }
++}
++
++@Composable
++private fun ProfilePanel() = Panel {
++    Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
++        UserAvatar(selected = true, onClick = {})
++        UserAvatar(selected = false, onClick = {})
++    }
++}
++
++@Composable
++private fun AppBarPanel() = Panel {
++    TopAppBar(selectedScreen = Screens.Home, showScreen = {})
++}
++
++@Composable
++private fun QueuePanel() = Panel {
++    Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
++        repeat(3) {
++            MovieCard(
++                onClick = {},
++                title = { Text("Up Next") },
++            ) {
++                Box(
++                    modifier = Modifier.size(160.dp, 90.dp).background(Color.Gray),
++                    contentAlignment = Alignment.Center,
++                ) {
++                    Text("Poster")
++                }
++            }
++        }
++    }
++}
++
++/**
++ * The signature JetStream spatial workspace — a `SpatialRow` of three panels side by side: a browse
++ * rail, the now-playing detail, and the profile switcher. The flat multi-panel layout you reach for
++ * first when spreading the app across Full Space.
++ */
++@XrSubspacePreview
++@Composable
++fun JetStreamSpatialWorkspacePreview() {
++    Subspace {
++        SpatialRow(horizontalArrangement = SpatialArrangement.spacedBy(24.dp)) {
++            SpatialPanel(SubspaceModifier.testTag("browse").width(360.dp).height(520.dp)) {
++                BrowsePanel()
++            }
++            SpatialPanel(SubspaceModifier.testTag("detail").width(480.dp).height(520.dp)) {
++                DetailPanel()
++            }
++            SpatialPanel(SubspaceModifier.testTag("profile").width(320.dp).height(520.dp)) {
++                ProfilePanel()
++            }
++        }
++    }
++}
++
++/**
++ * A stacked `SpatialColumn` — the top app bar floating above a "up next" queue rail — the vertical
++ * arrangement for a focused browsing column.
++ */
++@XrSubspacePreview
++@Composable
++fun JetStreamSpatialStackPreview() {
++    Subspace {
++        SpatialColumn(verticalArrangement = SpatialArrangement.spacedBy(16.dp)) {
++            SpatialPanel(SubspaceModifier.testTag("appbar").width(720.dp).height(96.dp)) {
++                AppBarPanel()
++            }
++            SpatialPanel(SubspaceModifier.testTag("queue").width(720.dp).height(360.dp)) {
++                QueuePanel()
++            }
++        }
++    }
++}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -402,26 +402,41 @@ jobs:
             # daemon's own 17 toolchain is still resolved from the runner's
             # preinstalled JDKs via Gradle toolchain detection, so render still works.
             java_version: "21"
-            # Upstream tracks androidx.xr.compose 1.0.0-alpha07, whose
-            # `ApplicationSubspace` / `MovePolicy` / `SpatialConfiguration`
-            # APIs were removed or deprecated by alpha14 — the version our XR
-            # render path compiles against. Apply the in-repo alpha14 upgrade
-            # patch to the freshly-checked-out tree before Gradle configures
-            # the build (see "Apply consumer patch" step below).
+            # Two patches are applied in order to the freshly-checked-out tree
+            # before Gradle configures it (see "Apply consumer patches" step):
+            #   1. adaptive-apps-samples-xr-alpha14.patch — the upstreamable
+            #      alpha14 upgrade. Upstream tracks alpha07, whose
+            #      `ApplicationSubspace` / `MovePolicy` / `SpatialConfiguration`
+            #      APIs were removed or deprecated by alpha14, the version our
+            #      XR render path compiles against.
+            #   2. adaptive-apps-samples-xr-spatial-previews.patch — a CI-only
+            #      overlay adding two @XrSubspacePreview functions that lay
+            #      JetStream's real components (MovieCard / WatchNowButton /
+            #      UserAvatar / TopAppBar) across a Subspace, so the XR render
+            #      path has genuine spatial coverage. Kept separate so patch #1
+            #      stays clean for upstream submission to android/adaptive-apps-
+            #      samples. The overlay needs no plugin configuration: the plugin
+            #      auto-enables the XR render path from JetStream's existing
+            #      androidx.xr.compose dependency, and the only CI-side wiring is
+            #      adding the preview-annotations library so @XrSubspacePreview
+            #      resolves (see "Add preview-annotations dependency" step).
             #
-            # Idempotent by design: the apply step runs `git apply
-            # --reverse --check` first, so once the same upgrade lands in
-            # `android/adaptive-apps-samples@main` the patch is detected as
-            # already-present and skipped rather than failing on a no-op. If
-            # upstream instead drifts such that the patch no longer applies,
-            # the step fails loudly so we re-cut it against the new baseline.
-            patch_file: adaptive-apps-samples-xr-alpha14.patch
+            # Each apply is idempotent: the step runs `git apply --reverse
+            # --check` first, so once a patch lands upstream it's detected as
+            # already-present and skipped rather than failing on a no-op; if
+            # upstream drifts so a patch no longer applies, the step fails
+            # loudly so we re-cut it against the new baseline.
+            patch_file: >-
+              adaptive-apps-samples-xr-alpha14.patch
+              adaptive-apps-samples-xr-spatial-previews.patch
             # :jetstream carries 12 device-targeted previews via custom
-            # multi-preview annotations (@PhonePreview/@TvPreview/etc.), so
-            # discovery has real coverage. Render end-to-end too — this entry
-            # exists to prove the renderer-android pipeline survives a real XR
-            # Compose app once it's on the alpha14 baseline.
+            # multi-preview annotations (@PhonePreview/@TvPreview/etc.) plus the
+            # two @XrSubspacePreview functions from the overlay. Render the 2D
+            # previews to PNG (render) AND the subspace layouts to scene.json
+            # (render_xr) — proving the renderer-android and renderer-xr paths
+            # both survive a real XR Compose app on the alpha14 baseline.
             render: true
+            render_xr: true
             extra_gradle_args: ""
             # AdaptiveJetStream's `:jetstream` module compiles with Java 21
             # source/target (Hilt's `hiltJavaCompileDebug` fails with
@@ -588,29 +603,86 @@ jobs:
         working-directory: external/${{ matrix.workdir }}
         run: chmod +x ./gradlew
 
-      - name: Apply consumer patch (idempotent)
+      - name: Apply consumer patches (idempotent)
         if: matrix.patch_file != ''
-        # Runs from the external checkout root so the patch's
+        # Runs from the external checkout root so each patch's
         # repo-root-relative paths (e.g. AdaptiveJetStream/jetstream/...)
         # line up with `git apply -p1`. The bundle was extracted into
         # $GITHUB_WORKSPACE/bundle by the "Install plugin and CLI" step.
+        # matrix.patch_file may name several patches (whitespace-separated);
+        # they're applied in the listed order.
         working-directory: external
+        env:
+          PATCH_FILES: ${{ matrix.patch_file }}
         run: |
           set -euo pipefail
-          patch="$GITHUB_WORKSPACE/bundle/ci/${{ matrix.patch_file }}"
-          if [ ! -f "$patch" ]; then
-            echo "::error::patch file not found in bundle: $patch"
+          for name in $PATCH_FILES; do
+            patch="$GITHUB_WORKSPACE/bundle/ci/$name"
+            if [ ! -f "$patch" ]; then
+              echo "::error::patch file not found in bundle: $patch"
+              exit 1
+            fi
+            if git apply --reverse --check "$patch" 2>/dev/null; then
+              echo "$name is already applied upstream — skipping."
+            elif git apply --check "$patch" 2>/dev/null; then
+              git apply "$patch"
+              echo "Applied $name."
+            else
+              echo "::error::$name does not apply cleanly against ${{ matrix.repo }}@${{ matrix.ref }} (upstream likely drifted). Re-cut the patch against the new baseline."
+              exit 1
+            fi
+          done
+
+      - name: Add preview-annotations dependency for the XR overlay
+        if: matrix.render_xr
+        # The @XrSubspacePreview overlay needs the preview-annotations artifact
+        # (which defines @XrSubspacePreview) on the module's compile classpath.
+        # That's an ordinary library dependency, not plugin configuration: the
+        # plugin auto-enables the XR render path on its own once it sees the
+        # module's androidx.xr.compose dependency (AndroidPreviewSupport
+        # .moduleDeclaresXrCompose), so no composePreview { } block is appended
+        # to the consumer build. Must run BEFORE discovery, since the overlay
+        # source won't compile without preview-annotations.
+        working-directory: external/${{ matrix.workdir }}
+        env:
+          MATRIX_MODULE: ${{ matrix.module }}
+        run: |
+          set -euo pipefail
+          # preview-annotations publishes at the repo's release-please version
+          # (changes every release), so read it from the mavenLocal snapshot the
+          # "Install plugin and CLI" step seeded rather than hardcoding a version
+          # that rots.
+          ann_dir="$HOME/.m2/repository/ee/schimke/composeai/preview-annotations"
+          version=$(ls -1 "$ann_dir" 2>/dev/null | grep -E '^[0-9]' | sort -V | tail -1 || true)
+          if [ -z "$version" ]; then
+            echo "::error::preview-annotations not found in mavenLocal ($ann_dir) — the build-plugin job must publish it."
             exit 1
           fi
-          if git apply --reverse --check "$patch" 2>/dev/null; then
-            echo "${{ matrix.patch_file }} is already applied upstream — skipping."
-          elif git apply --check "$patch" 2>/dev/null; then
-            git apply "$patch"
-            echo "Applied ${{ matrix.patch_file }}."
-          else
-            echo "::error::${{ matrix.patch_file }} does not apply cleanly against ${{ matrix.repo }}@${{ matrix.ref }} (upstream likely drifted). Re-cut the patch against the new baseline."
-            exit 1
-          fi
+          echo "Using ee.schimke.composeai:preview-annotations:$version"
+          ANN_VERSION="$version" python3 - <<'PY'
+          import os
+          from pathlib import Path
+          module = os.environ["MATRIX_MODULE"].lstrip(":").replace(":", "/")
+          version = os.environ["ANN_VERSION"]
+          build = Path(module) / "build.gradle.kts"
+          if not build.exists():
+              raise SystemExit(f"expected module build script not found: {build}")
+          text = build.read_text()
+          if "ee.schimke.composeai:preview-annotations" in text:
+              print(f"preview-annotations dependency already present in {build}")
+          else:
+              block = (
+                  "\n\n// compose-preview integration CI: put the @XrSubspacePreview annotation on\n"
+                  "// the compile classpath so the overlay's spatial previews compile. The plugin\n"
+                  "// auto-enables the XR render path from the module's androidx.xr.compose\n"
+                  "// dependency, so no composePreview { } configuration is needed here.\n"
+                  "dependencies {\n"
+                  f'  implementation("ee.schimke.composeai:preview-annotations:{version}")\n'
+                  "}\n"
+              )
+              build.write_text(text + block)
+              print(f"appended preview-annotations:{version} dependency to {build}")
+          PY
 
       - name: Repo-specific pre-Gradle patches
         if: matrix.pre_gradle_script != ''
@@ -710,6 +782,39 @@ jobs:
           echo "Rendered ${#pngs[@]} PNG file(s):"
           printf '  %s\n' "${pngs[@]}"
 
+      - name: Render XR subspace previews (composePreviewRenderXr)
+        if: matrix.render_xr
+        working-directory: external/${{ matrix.workdir }}
+        env:
+          COMPOSE_PREVIEW_INIT_USE_MAVEN_LOCAL: "1"
+          GRADLE_OPTS: -Xmx4g -Dfile.encoding=UTF-8
+        run: |
+          # composePreviewRenderXr is registered automatically once the plugin
+          # sees the module's androidx.xr.compose dependency (no composePreview
+          # { } opt-in). It composes each @XrSubspacePreview under the fake XR
+          # runtime on the :renderer-xr render configuration and writes
+          # renders/<preview>/scene.json plus a <testTag>.png texture per
+          # SpatialPanel.
+          ./gradlew --init-script "$COMPOSE_AI_INIT_SCRIPT" composePreviewRenderXr \
+            ${{ matrix.extra_gradle_args }} \
+            --stacktrace
+
+      - name: Verify XR scene.json was produced
+        if: matrix.render_xr
+        working-directory: external/${{ matrix.workdir }}
+        run: |
+          set -euo pipefail
+          mapfile -t scenes < <(find . -path '*/build/compose-previews/renders/*/scene.json' -not -path '*/external/build/*' 2>/dev/null)
+          if [ "${#scenes[@]}" -eq 0 ]; then
+            echo "::error::composePreviewRenderXr ran but no scene.json was produced. The @XrSubspacePreview functions either failed to render or were not discovered (check the overlay patch applied and preview-annotations is on the classpath)."
+            exit 1
+          fi
+          echo "Produced ${#scenes[@]} XR scene(s):"
+          for s in "${scenes[@]}"; do
+            textures=$(find "$(dirname "$s")" -name '*.png' 2>/dev/null | wc -l | tr -d ' ')
+            echo "  $s → $textures panel texture(s)"
+          done
+
       - name: Stage browsable preview gallery
         # Build the `compose-preview/integration/<slug>` payload (renders/ +
         # baselines.json + README gallery) so the rendered previews are
@@ -776,7 +881,7 @@ jobs:
             echo
             echo "- Source: [\`${MATRIX_REPO}@${MATRIX_REF}\`](https://github.com/${MATRIX_REPO}/tree/${MATRIX_REF})"
             if [ -n "${MATRIX_PATCH_FILE:-}" ]; then
-              echo "- Consumer patch applied before configuring the build: \`${MATRIX_PATCH_FILE}\` (idempotent — auto-skipped once the change lands upstream)."
+              echo "- Consumer patch(es) applied before configuring the build: \`${MATRIX_PATCH_FILE}\` (idempotent — auto-skipped once the change lands upstream)."
             fi
             if [ -n "${MATRIX_PRE_GRADLE:-}" ]; then
               echo "- Build script patched before Gradle to stub out CI-unavailable plugins / credentials (e.g. Firebase Crashlytics, Google Services, Play Publisher)."
@@ -963,13 +1068,15 @@ jobs:
           retention-days: 7
 
       - name: Upload rendered PNGs
-        if: always() && matrix.render
+        if: always() && (matrix.render || matrix.render_xr)
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: renders-${{ matrix.slug }}
           path: |
             external/**/build/compose-previews/renders/*.png
             external/**/build/compose-previews/renders/*.error.json
+            external/**/build/compose-previews/renders/*/scene.json
+            external/**/build/compose-previews/renders/*/*.png
           if-no-files-found: warn
           retention-days: 7
 

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -369,6 +369,14 @@ internal object AndroidPreviewSupport {
    * exactly what AGP gives the test JVM, so any coord that would actually be on the renderer's
    * classpath gets seen.
    *
+   * **Why XR modules pass.** A module that declares `androidx.xr.compose` (see
+   * [moduleDeclaresXrCompose]) hosts `@XrSubspacePreview` spatial previews even when it declares no
+   * traditional `@Preview` tooling coord — `androidx.xr.compose` is the standalone signal that the
+   * module has XR preview surface, the same way `ui-tooling-preview` is the signal for flat
+   * `@Preview`. Without this tier a pure-XR module would fail the gate, `onVariants` would return
+   * before [registerAndroidTasks], and the `androidx.xr.compose`-driven auto-enable of
+   * `composePreviewRenderXr` would never run — defeating the documented zero-config XR path.
+   *
    * The `variantName` argument is unused but kept on the public signature for test-fixture
    * compatibility.
    */
@@ -377,6 +385,7 @@ internal object AndroidPreviewSupport {
     @Suppress("UNUSED_PARAMETER") variantName: String,
   ): Boolean =
     hasDirectPreviewDependency(project) ||
+      moduleDeclaresXrCompose(project) ||
       (isComposeModule(project) && hasAnyProjectDependency(project))
 
   /**

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -415,6 +415,28 @@ internal object AndroidPreviewSupport {
   }
 
   /**
+   * True when this module declares a dependency on Jetpack XR Compose (`androidx.xr.compose:*`) in
+   * any declarable `*Implementation` / `*Api` / `*RuntimeOnly` bucket.
+   *
+   * Drives auto-enablement of the XR subspace render path so a module's `@XrSubspacePreview`s
+   * render with zero `composePreview { }` configuration — the same declared-dependency-signal
+   * approach the Wear Tiles renderer auto-injection uses. Declarative-only (no classpath
+   * resolution), so it's cheap and IP-safe, mirroring [hasDirectPreviewDependency]. The
+   * `androidx.xr.compose` group is the signal because that artifact is what provides `Subspace` /
+   * `SpatialPanel` — a module with no XR Compose dependency can't host an `@XrSubspacePreview`, and
+   * gating the (minCompileSdk-36, heavyweight) XR `*-testing` fakes on it keeps non-XR consumers
+   * off that classpath.
+   */
+  internal fun moduleDeclaresXrCompose(project: Project): Boolean {
+    for (config in declarableBucketsOf(project)) {
+      for (dep in config.allDependencies) {
+        if (dep.group == "androidx.xr.compose") return true
+      }
+    }
+    return false
+  }
+
+  /**
    * True when this module declares at least one `project(":...")` dep in any declarable bucket.
    * IP-safe via [ProjectDependency.getPath] (Gradle 8.11+) — returns the target project's path as a
    * string without touching the other `Project` object the way the legacy `getDependencyProject()`
@@ -1321,15 +1343,22 @@ internal object AndroidPreviewSupport {
       )
     }
 
-    // XR render backend (opt-in via `composePreview.enableXrPreviews`). Adds `:renderer-xr`'s
-    // `XrSubspaceRenderTest` + the fake XR runtime to the render config so `composePreviewRenderXr`
-    // (below) can render `@XrSubspacePreview` to `scene.json`. Gated because `androidx.xr.compose`
-    // declares `minCompileSdk = 36` and the `*-testing` fakes are heavyweight — a non-XR consumer
-    // (especially below compileSdk 36) must never get them on its render classpath. The fakes are
-    // inert for compose/tile/notification/glance renders anyway (they only engage when a `Subspace`
-    // reaches `Session.create`); the fake `SceneRuntimeFactory` / `RenderingRuntimeFactory`
-    // ServiceLoader registration ships in `:renderer-xr`'s main resources.
-    val xrPreviewsEnabled = extension.enableXrPreviews.get()
+    // XR render backend. Adds `:renderer-xr`'s `XrSubspaceRenderTest` + the fake XR runtime to the
+    // render config so `composePreviewRenderXr` (below) can render `@XrSubspacePreview` to
+    // `scene.json`. Auto-enabled for any module that declares an `androidx.xr.compose` dependency
+    // (the same declared-dependency signal the Wear Tiles renderer auto-injection uses), so XR
+    // previews render with zero `composePreview { }` configuration; `enableXrPreviews = true` still
+    // forces it on for the transitive-only case. Gated on that signal rather than always-on because
+    // `androidx.xr.compose` declares `minCompileSdk = 36` and the `*-testing` fakes are heavyweight
+    // —
+    // a non-XR consumer (especially below compileSdk 36) must never get them on its render
+    // classpath.
+    // The fakes are inert for compose/tile/notification/glance renders anyway (they only engage
+    // when
+    // a `Subspace` reaches `Session.create`); the fake `SceneRuntimeFactory` /
+    // `RenderingRuntimeFactory` ServiceLoader registration ships in `:renderer-xr`'s main
+    // resources.
+    val xrPreviewsEnabled = extension.enableXrPreviews.get() || moduleDeclaresXrCompose(project)
     if (xrPreviewsEnabled) {
       if (useLocalRenderer) {
         try {

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewExtension.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewExtension.kt
@@ -149,14 +149,22 @@ abstract class PreviewExtension @Inject constructor(private val objects: ObjectF
     objects.property(Boolean::class.java).convention(false)
 
   /**
-   * Opt-in for the XR subspace render path. When true, the plugin registers
+   * Forces the XR subspace render path on. When the effective value is true, the plugin registers
    * `composePreviewRenderXr` (and folds it into `composePreviewRenderAll`), pulling
    * `:renderer-xr` + the fake XR runtime onto a dedicated render configuration to render
    * `@XrSubspacePreview` functions to `scene.json`.
    *
-   * Off by default — `androidx.xr.compose` declares `minCompileSdk = 36` and the XR `*-testing`
-   * fakes are heavyweight, so a non-XR consumer (especially below compileSdk 36) must never pay for
-   * them on its render classpath. Enable it only in modules that actually use `@XrSubspacePreview`.
+   * Usually you don't set this: the plugin **auto-enables** the XR path for any module that
+   * declares an `androidx.xr.compose` dependency (see
+   * `AndroidPreviewSupport.moduleDeclaresXrCompose`), the same declared-dependency signal it uses
+   * to auto-inject the Wear Tiles renderer — so `@XrSubspacePreview`s render with zero
+   * `composePreview { }` configuration. Set this to true only to force the path on for a module
+   * that pulls `androidx.xr.compose` in transitively rather than declaring it directly.
+   *
+   * The auto-detect is gated on the declared dependency (not always-on) because
+   * `androidx.xr.compose` declares `minCompileSdk = 36` and the XR `*-testing` fakes are
+   * heavyweight, so a non-XR consumer (especially below compileSdk 36) must never pay for them on
+   * its render classpath.
    */
   val enableXrPreviews: Property<Boolean> = objects.property(Boolean::class.java).convention(false)
 

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/HasPreviewDependencyTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/HasPreviewDependencyTest.kt
@@ -54,6 +54,20 @@ class HasPreviewDependencyTest {
   }
 
   @Test
+  fun `pure-XR module passes the gate via the androidx_xr_compose signal`() {
+    // An @XrSubspacePreview-only module declares androidx.xr.compose but no traditional
+    // ui-tooling-preview coord and no project deps. It must still pass the registration gate, or
+    // onVariants returns before registerAndroidTasks and composePreviewRenderXr never registers —
+    // defeating the zero-config XR path.
+    val project = ProjectBuilder.builder().withProjectDir(tmp.root).build()
+
+    project.configurations.create("implementation")
+    project.dependencies.add("implementation", "androidx.xr.compose:compose:1.0.0-alpha14")
+
+    assertThat(AndroidPreviewSupport.hasPreviewDependency(project, "debug")).isTrue()
+  }
+
+  @Test
   fun `module without any declarable buckets returns false without throwing`() {
     val project = ProjectBuilder.builder().withProjectDir(tmp.root).build()
     // Mirrors a fresh module before AGP has wired its variant configurations — the gate must

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/ModuleDeclaresXrComposeTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/ModuleDeclaresXrComposeTest.kt
@@ -1,0 +1,60 @@
+package ee.schimke.composeai.plugin
+
+import com.google.common.truth.Truth.assertThat
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * Pins the contract of [AndroidPreviewSupport.moduleDeclaresXrCompose] — the config-time signal
+ * that auto-enables the XR subspace render path (registers `composePreviewRenderXr` + pulls the
+ * minCompileSdk-36 XR `*-testing` fakes onto the render config) without any `composePreview { }`
+ * configuration in the consumer build.
+ *
+ * Same declarative, IP-safe shape as [AndroidPreviewSupport.hasDirectPreviewDependency]: declared
+ * `*Implementation` / `*Api` / `*RuntimeOnly` inspection only, no classpath resolution. The gate
+ * must stay closed for non-XR modules so they never pay for the heavyweight XR fakes.
+ */
+class ModuleDeclaresXrComposeTest {
+
+  @get:Rule val tmp = TemporaryFolder()
+
+  @Test
+  fun `declared androidx_xr_compose dep is detected`() {
+    val project = ProjectBuilder.builder().withProjectDir(tmp.root).build()
+
+    project.configurations.create("implementation")
+    project.dependencies.add("implementation", "androidx.xr.compose:compose:1.0.0-alpha14")
+
+    assertThat(AndroidPreviewSupport.moduleDeclaresXrCompose(project)).isTrue()
+  }
+
+  @Test
+  fun `xr compose dep in a variant-scoped bucket is detected`() {
+    val project = ProjectBuilder.builder().withProjectDir(tmp.root).build()
+
+    project.configurations.create("debugImplementation")
+    project.dependencies.add("debugImplementation", "androidx.xr.compose:compose:1.0.0-alpha14")
+
+    assertThat(AndroidPreviewSupport.moduleDeclaresXrCompose(project)).isTrue()
+  }
+
+  @Test
+  fun `unrelated dep returns false`() {
+    val project = ProjectBuilder.builder().withProjectDir(tmp.root).build()
+
+    project.configurations.create("implementation")
+    project.dependencies.add("implementation", "com.google.guava:guava:33.0.0-jre")
+    // A sibling androidx group must not trip the exact-group match.
+    project.dependencies.add("implementation", "androidx.compose.ui:ui:1.7.0")
+
+    assertThat(AndroidPreviewSupport.moduleDeclaresXrCompose(project)).isFalse()
+  }
+
+  @Test
+  fun `module without any declarable buckets returns false without throwing`() {
+    val project = ProjectBuilder.builder().withProjectDir(tmp.root).build()
+    assertThat(AndroidPreviewSupport.moduleDeclaresXrCompose(project)).isFalse()
+  }
+}


### PR DESCRIPTION
## Summary

Extends the AdaptiveJetStream integration cell to exercise the **XR subspace render path** end-to-end, and makes that path **config-free** for consumers.

- **Plugin auto-enables XR previews from the `androidx.xr.compose` dependency.** No `composePreview { enableXrPreviews.set(true) }` block needed in the consumer build. `AndroidPreviewSupport.moduleDeclaresXrCompose` does a declarative, IP-safe scan of `*Implementation`/`*Api`/`*RuntimeOnly` buckets for the `androidx.xr.compose` group — the same declared-dependency signal the Wear Tiles renderer auto-injection already uses. The annotation (`@XrSubspacePreview`) signals *which* previews are spatial; the dependency signals the module is an XR module.
  - Sub-36 safety is preserved: a non-XR consumer never declares `androidx.xr.compose`, so it never gets the `minCompileSdk 36`, heavyweight XR `*-testing` fakes on its render classpath.
  - The explicit `enableXrPreviews` flag still forces the path on for the transitive-only case.
- **CI-only overlay patch** `adaptive-apps-samples-xr-spatial-previews.patch` adds two `@XrSubspacePreview` functions that arrange JetStream's real components (`MovieCard` / `WatchNowButton` / `UserAvatar` / `TopAppBar`) across a `Subspace`. Kept separate from the alpha14 upgrade patch so that one stays clean for upstream submission to `android/adaptive-apps-samples`.
- **Workflow wiring:** the apply step now applies a whitespace-separated list of patches in order (alpha14 → overlay), each still idempotent. A new step adds the `preview-annotations` library (version discovered from the seeded mavenLocal, so never hardcoded) so `@XrSubspacePreview` resolves. A new `render_xr` flag drives `composePreviewRenderXr` plus a `scene.json` verification step; uploaded artifacts now include the per-panel textures and `scene.json`. No `sdkVersion` override — the cell already runs on JDK 21.

## Test plan

- `:gradle-plugin:test --tests ModuleDeclaresXrComposeTest` passes (hit / variant-scoped / sibling-group `androidx.compose.ui` stays false / empty).
- ktfmt clean; `integration.yml` parses and the embedded Python parses; step order is Apply patches → Add preview-annotations → Discover → Render → Verify PNGs → Render XR → Verify XR → Upload.
- Both consumer patches verified to apply in sequence against a pristine `android/adaptive-apps-samples@main` checkout.
- The integration cell itself is the end-to-end test for the XR-external-consumer render path (`composePreviewRenderXr` → `scene.json` + panel textures) — first exercised by this PR's CI run.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WUMD4xmJ9LUtL5dBsqPU2S)_