### PR TITLE
fix: publish :renderer-xr so external consumers can resolve the XR render path

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -63,12 +63,17 @@ jobs:
 
       - uses: ./.github/actions/setup
 
-      - name: Publish plugin + renderer-android + data-* + daemon-* to mavenLocal
+      - name: Publish plugin + renderer-android + renderer-xr + data-* + daemon-* to mavenLocal
         # Both `gradle-plugin` and `renderer-android` are needed end-to-end:
         # the plugin resolves through the init script's buildscript classpath
         # injection from mavenLocal, and at render time it wires
         # `ee.schimke.composeai:renderer-android:<version>` into the consumer's
         # `composePreviewAndroidRenderer<Variant>` configuration.
+        # `renderer-xr` rides the same fan-out: the plugin wires it onto the
+        # same render configuration when it auto-enables the XR path for a
+        # consumer that depends on `androidx.xr.compose` (the jetstream-xr cell),
+        # so it must resolve from mavenLocal too — otherwise the XR render fails
+        # with `Could not find ee.schimke.composeai:renderer-xr`.
         # Publishing only the plugin here would mean the render path silently
         # falls back to whatever's on the consumer's remote repos (or fails
         # resolution) — exactly the kind of release-vs-source drift these tests

--- a/renderers/xr/build.gradle.kts
+++ b/renderers/xr/build.gradle.kts
@@ -1,6 +1,17 @@
+import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
+import com.vanniktech.maven.publish.JavadocJar
+import com.vanniktech.maven.publish.SourcesJar
+
 plugins {
   id("composeai.base-conventions")
-  id("composeai.android-conventions")
+  // Published so external consumers can resolve `ee.schimke.composeai:renderer-xr:<version>` —
+  // the gradle plugin adds it to a consumer's render configuration when it auto-enables the XR
+  // path (AndroidPreviewSupport, the `xrPreviewsEnabled` branch). `composeai.maven-publishing`
+  // brings the android/jvm/kotlin conventions too, so the explicit `android-conventions` apply is
+  // dropped here (mirrors `:renderer-android`). Without this the XR render path resolves nowhere
+  // for an external consumer — only the in-repo `includeBuild` path (the `Render XR composite`
+  // sample job) worked before.
+  id("composeai.maven-publishing")
   alias(libs.plugins.android.library)
   alias(libs.plugins.compose.compiler)
 }
@@ -79,4 +90,32 @@ dependencies {
   testImplementation(libs.roborazzi.compose)
   testImplementation(libs.junit)
   testImplementation(libs.truth)
+}
+
+// Single `release` variant publication — `XrSubspaceRenderTest` (the render entry the plugin's
+// composePreviewRenderXr task runs) and the fake-runtime ServiceLoader registrations both live in
+// `src/main`, so the release AAR carries everything the plugin needs; no testFixtures publication.
+// The heavy XR / compose-test libs are `compileOnly`, so they stay out of the published POM and the
+// plugin supplies the `*-testing` fakes on the render configuration itself (mirrors
+// `:renderer-android`).
+mavenPublishing {
+  configure(
+    AndroidSingleVariantLibrary(
+      javadocJar = JavadocJar.Empty(),
+      sourcesJar = SourcesJar.Sources(),
+      variant = "release",
+    )
+  )
+}
+
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "renderer-xr",
+    displayName = "Compose Preview — XR Renderer",
+    description =
+      "Offline producer of the SpatialScene wire format — recovers a Compose-XR Subspace layout " +
+        "under a fake XR runtime and maps each tagged panel's pose/size into the SpatialScene DTO. " +
+        "Consumed by the compose-preview Gradle plugin's composePreviewRenderXr task.",
+  )
+  inceptionYear.set("2025")
 }


### PR DESCRIPTION
## Summary

Follow-up fix for the `jetstream-xr` integration cell, which started failing on `main` after #1766 with:

```
Could not find ee.schimke.composeai:renderer-xr:0.1.0-SNAPSHOT
Required by: project ':jetstream'
```

**Root cause:** when the plugin auto-enables the XR render path (a consumer that declares `androidx.xr.compose`), it adds `ee.schimke.composeai:renderer-xr:<version>` to the render configuration. But `:renderer-xr` never applied `composeai.maven-publishing`, so it was never published to mavenLocal / shipped in the integration bundle — only the in-repo `includeBuild` path (the `Render XR composite` sample job) ever resolved it. No external-consumer cell had enabled XR before #1766, so the gap was latent.

**Fix:** apply `composeai.maven-publishing` to `:renderer-xr` with a single `release`-variant publication, mirroring `:renderer-android`. The render entry point (`XrSubspaceRenderTest`) and the fake-runtime `ServiceLoader` registrations both live in `src/main`, so the release AAR carries everything the plugin needs — no testFixtures publication. The heavy XR / compose-test libraries stay `compileOnly`, so the published POM only references `preview-data-api` (already published), and the plugin supplies the `*-testing` fakes on the render configuration itself. It rides the existing root `publishToMavenLocal` fan-out, so it's automatically bundled.

## Test plan

- `./gradlew :renderer-xr:publishToMavenLocal` succeeds locally and produces `renderer-xr-<version>.aar` + `.pom`.
- The published POM carries only `preview-data-api` (compile) + `kotlin-stdlib` — no `compileOnly` XR/Robolectric/Roborazzi leakage (verified, matches `renderer-android`).
- This PR touches `renderers/xr/` (not paths-ignored), so the integration workflow — including the `jetstream-xr` cell that previously failed — runs on this PR and validates the XR render end-to-end (`composePreviewRenderXr` → `scene.json` + per-panel textures).


---
_Generated by [Claude Code](https://claude.ai/code/session_01WUMD4xmJ9LUtL5dBsqPU2S)_