### PR TITLE
ci: fold XR scenes into the browsable gallery + document zero-config XR enablement

### DIFF
--- a/.github/actions/lib/test_xr_gallery.py
+++ b/.github/actions/lib/test_xr_gallery.py
@@ -110,6 +110,41 @@ class FoldTest(unittest.TestCase):
         # Texture wasn't on disk, so it isn't copied, but the section still renders.
         self.assertFalse((self.gallery / "renders" / "xr" / "P" / "ghost.png").exists())
 
+    def test_traversal_texture_is_rejected_not_copied(self) -> None:
+        # A crafted scene.json points `texture` outside the render dir; the fold must
+        # neither copy the target into the gallery nor emit an image link to it.
+        secret = self.root / "secret.txt"
+        secret.write_text("do not publish me")
+        d = self.root / "consumer" / "build" / "compose-previews" / "renders" / "Evil"
+        d.mkdir(parents=True)
+        panels = [
+            {"id": "abs", "sizeDp": {"width": 1, "height": 1},
+             "texture": str(secret)},
+            {"id": "dotdot", "sizeDp": {"width": 1, "height": 1},
+             "texture": "../../secret.txt"},
+            {"id": "subdir", "sizeDp": {"width": 1, "height": 1},
+             "texture": "nested/x.png"},
+        ]
+        (d / "scene.json").write_text(json.dumps(_scene(panels)))
+
+        self.assertEqual(xg.fold(self.gallery, self.root), 1)
+
+        dest = self.gallery / "renders" / "xr" / "Evil"
+        # Nothing escaped into the gallery, regardless of basename collisions.
+        copied = {p.name for p in dest.glob("*") if p.is_file()}
+        self.assertEqual(copied, {"scene.json"})
+        readme = (self.gallery / "README.md").read_text()
+        self.assertNotIn("secret.txt", readme)
+        self.assertNotIn("../", readme)
+        # Each unsafe panel still appears as a header cell, just without an image.
+        self.assertIn("`abs`", readme)
+        self.assertIn("_(no texture)_", readme)
+
+    def test_safe_texture_name(self) -> None:
+        self.assertEqual(xg._safe_texture_name("browse.png"), "browse.png")
+        for bad in ("../x.png", "a/b.png", "/abs/x.png", "..", ".", "", None, 5):
+            self.assertIsNone(xg._safe_texture_name(bad), bad)
+
     def test_excludes_external_build_paths(self) -> None:
         # A scene under */external/build/* (the integration checkout's own build) must be ignored.
         d = self.root / "external" / "build" / "compose-previews" / "renders" / "Stray"

--- a/.github/actions/lib/test_xr_gallery.py
+++ b/.github/actions/lib/test_xr_gallery.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Tests for xr-gallery.py.
+
+Pure stdlib (unittest) — no third-party deps so the test runs anywhere the
+action runs. Run directly:
+
+    python3 -m unittest .github/actions/lib/test_xr_gallery.py
+
+The script under test has a hyphen in its filename, so we load it via importlib
+rather than a normal import.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_SPEC = importlib.util.spec_from_file_location("xr_gallery", _HERE / "xr-gallery.py")
+xg = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(xg)
+
+
+def _scene(panels: list[dict]) -> dict:
+    return {
+        "schemaVersion": 1,
+        "camera": {"kind": "orbit", "target": {"x": 0, "y": 0, "z": 0}, "distance": 1.0,
+                   "yawDeg": 0.0, "pitchDeg": 0.0},
+        "panels": panels,
+    }
+
+
+def _panel(pid: str, w: int, h: int) -> dict:
+    return {
+        "id": pid,
+        "poseInRoot": {"translation": {"x": 0, "y": 0, "z": 0},
+                       "rotation": {"x": 0, "y": 0, "z": 0, "w": 1}},
+        "sizeDp": {"width": w, "height": h},
+        "texture": f"{pid}.png",
+    }
+
+
+class FoldTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name)
+        self.gallery = self.root / "gallery"
+        self.gallery.mkdir()
+        (self.gallery / "README.md").write_text("# Gallery\n\nSome 2D previews.\n")
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def _make_scene(self, name: str, panels: list[dict], *, write_textures=True) -> Path:
+        d = self.root / "consumer" / "build" / "compose-previews" / "renders" / name
+        d.mkdir(parents=True)
+        (d / "scene.json").write_text(json.dumps(_scene(panels)))
+        if write_textures:
+            for p in panels:
+                (d / p["texture"]).write_bytes(b"\x89PNG\r\n\x1a\n" + p["id"].encode())
+        return d
+
+    def test_fold_copies_artifacts_and_appends_section(self) -> None:
+        self._make_scene("WorkspacePreview", [_panel("browse", 360, 520),
+                                              _panel("detail", 480, 520)])
+        n = xg.fold(self.gallery, self.root)
+        self.assertEqual(n, 1)
+
+        dest = self.gallery / "renders" / "xr" / "WorkspacePreview"
+        self.assertTrue((dest / "scene.json").is_file())
+        self.assertTrue((dest / "browse.png").is_file())
+        self.assertTrue((dest / "detail.png").is_file())
+
+        readme = (self.gallery / "README.md").read_text()
+        self.assertIn("## XR spatial previews", readme)
+        self.assertIn("### `WorkspacePreview` — 2 panel(s)", readme)
+        self.assertIn("[`scene.json`](renders/xr/WorkspacePreview/scene.json)", readme)
+        self.assertIn("![browse](renders/xr/WorkspacePreview/browse.png)", readme)
+        self.assertIn("`detail` (480×520)", readme)
+        # Original 2D content is preserved (append, not overwrite).
+        self.assertIn("Some 2D previews.", readme)
+
+    def test_missing_readme_is_noop(self) -> None:
+        (self.gallery / "README.md").unlink()
+        self._make_scene("P", [_panel("a", 10, 10)])
+        self.assertEqual(xg.fold(self.gallery, self.root), 0)
+
+    def test_no_scenes_is_noop(self) -> None:
+        self.assertEqual(xg.fold(self.gallery, self.root), 0)
+        self.assertNotIn("XR spatial previews", (self.gallery / "README.md").read_text())
+
+    def test_idempotent_second_fold_noop(self) -> None:
+        self._make_scene("P", [_panel("a", 10, 10)])
+        self.assertEqual(xg.fold(self.gallery, self.root), 1)
+        first = (self.gallery / "README.md").read_text()
+        # Second fold sees the marker and bails without re-appending.
+        self.assertEqual(xg.fold(self.gallery, self.root), 0)
+        self.assertEqual((self.gallery / "README.md").read_text(), first)
+        self.assertEqual(first.count("## XR spatial previews"), 1)
+
+    def test_missing_texture_file_lists_header_without_crashing(self) -> None:
+        self._make_scene("P", [_panel("ghost", 10, 10)], write_textures=False)
+        self.assertEqual(xg.fold(self.gallery, self.root), 1)
+        readme = (self.gallery / "README.md").read_text()
+        self.assertIn("`ghost` (10×10)", readme)
+        # Texture wasn't on disk, so it isn't copied, but the section still renders.
+        self.assertFalse((self.gallery / "renders" / "xr" / "P" / "ghost.png").exists())
+
+    def test_excludes_external_build_paths(self) -> None:
+        # A scene under */external/build/* (the integration checkout's own build) must be ignored.
+        d = self.root / "external" / "build" / "compose-previews" / "renders" / "Stray"
+        d.mkdir(parents=True)
+        (d / "scene.json").write_text(json.dumps(_scene([_panel("x", 1, 1)])))
+        self.assertEqual(xg.fold(self.gallery, self.root), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/actions/lib/xr-gallery.py
+++ b/.github/actions/lib/xr-gallery.py
@@ -39,6 +39,26 @@ _SECTION_MARKER = "<!-- xr-spatial-previews -->"
 _SCENE_GLOB = "**/build/compose-previews/renders/*/scene.json"
 
 
+def _safe_texture_name(texture: object) -> str | None:
+    """Return [texture] iff it's a plain basename safe to copy/link, else None.
+
+    `texture` comes from a `scene.json` the renderer wrote, but the staged gallery
+    is later pushed to a shared branch by the `publish-previews` job, so a crafted
+    scene must not be able to pull files from outside the render directory into the
+    published tree (path traversal). The renderer only ever emits a bare
+    `<panelId>.png` sibling of scene.json, so we accept *only* a basename: anything
+    with a directory component, an absolute path, or a `..` segment is rejected.
+    """
+    if not isinstance(texture, str) or not texture:
+        return None
+    name = Path(texture).name
+    # `Path(texture).name` strips any directory part, so a value that survives
+    # unchanged has no `/`, no leading `/`, and isn't `.`/`..`.
+    if name != texture or name in (".", ".."):
+        return None
+    return name
+
+
 def _panel_rows(panels: list[dict], rel_dir: str, columns: int = 3) -> list[str]:
     """Markdown tables (one per `columns`-wide chunk) embedding each panel texture.
 
@@ -58,7 +78,7 @@ def _panel_rows(panels: list[dict], rel_dir: str, columns: int = 3) -> list[str]
             w, h = size.get("width"), size.get("height")
             dims = f" ({w}×{h})" if w is not None and h is not None else ""
             headers.append(f"`{pid}`{dims}")
-            texture = panel.get("texture")
+            texture = _safe_texture_name(panel.get("texture"))
             if texture:
                 cells.append(f"![{pid}]({rel_dir}/{texture})")
             else:
@@ -116,14 +136,20 @@ def fold(gallery_dir: Path, search_root: Path) -> int:
             print(f"::warning::could not parse {scene}: {exc}; linking raw only")
             data = {}
         panels = data.get("panels") if isinstance(data.get("panels"), list) else []
-        # Copy the textures the scene references (siblings of scene.json).
+        # Copy the textures the scene references (must be basenames living next
+        # to scene.json — see _safe_texture_name for why traversal is rejected).
         for panel in panels:
-            texture = panel.get("texture")
+            texture = _safe_texture_name(panel.get("texture"))
             if not texture:
+                if panel.get("texture"):
+                    print(
+                        f"::warning::ignoring unsafe texture path "
+                        f"{panel.get('texture')!r} in {scene}"
+                    )
                 continue
             src = scene.parent / texture
             if src.is_file():
-                shutil.copy2(src, dest / src.name)
+                shutil.copy2(src, dest / texture)
         rel_dir = f"renders/xr/{name}"
         lines.append(f"### `{name}` — {len(panels)} panel(s)")
         lines.append("")

--- a/.github/actions/lib/xr-gallery.py
+++ b/.github/actions/lib/xr-gallery.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Fold `@XrSubspacePreview` render output into a browsable preview gallery.
+
+`composePreviewRenderXr` writes, per XR preview,
+``build/compose-previews/renders/<preview>/scene.json`` (the framework-computed
+spatial panel layout — see ``docs/design/SPATIAL_SCENE_CONTRACT.md``) plus one
+``<panelId>.png`` texture per ``SpatialPanel``. Unlike a flat ``@Preview`` (one
+preview-named PNG), an XR preview produces a *directory* of artifacts and no
+single PNG, so the CLI's ``compose-preview show --json`` envelope carries no
+``pngPath`` for it (``kind == "XR_SUBSPACE"``) — which is exactly why
+``compare-previews.py generate`` (envelope-driven) can't reach these files and
+leaves XR previews out of the gallery README.
+
+This helper closes that gap from the filesystem side: after the gallery has been
+staged, it copies each scene's ``scene.json`` + panel textures under
+``<gallery>/renders/xr/<preview>/`` and appends an "XR spatial previews" section
+to the gallery ``README.md`` — a per-preview table of panel textures plus a link
+to the recovered ``scene.json``. The integration workflow's "Fold XR scenes into
+the browsable gallery" step runs it against the ``_integration_baselines``
+payload before the publish job pushes the ``compose-preview/integration/<slug>``
+branch.
+
+Idempotent within a run (single append); re-running ``generate`` upstream wipes
+``renders/`` first, so the fold always re-copies fresh.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+from pathlib import Path
+
+# Marker so a second invocation against an already-folded README is a no-op
+# rather than appending the section twice.
+_SECTION_MARKER = "<!-- xr-spatial-previews -->"
+
+# Render-output layout written by composePreviewRenderXr.
+_SCENE_GLOB = "**/build/compose-previews/renders/*/scene.json"
+
+
+def _panel_rows(panels: list[dict], rel_dir: str, columns: int = 3) -> list[str]:
+    """Markdown tables (one per `columns`-wide chunk) embedding each panel texture.
+
+    Each panel carries `id`, `sizeDp` ({width,height}) and `texture` (the PNG
+    basename, a sibling of scene.json). Panels whose texture is missing on disk
+    are still listed (header only) so a partial render is visible rather than
+    silently dropped.
+    """
+    lines: list[str] = []
+    for start in range(0, len(panels), columns):
+        chunk = panels[start : start + columns]
+        headers = []
+        cells = []
+        for panel in chunk:
+            pid = str(panel.get("id", "?"))
+            size = panel.get("sizeDp") or {}
+            w, h = size.get("width"), size.get("height")
+            dims = f" ({w}×{h})" if w is not None and h is not None else ""
+            headers.append(f"`{pid}`{dims}")
+            texture = panel.get("texture")
+            if texture:
+                cells.append(f"![{pid}]({rel_dir}/{texture})")
+            else:
+                cells.append("_(no texture)_")
+        lines.append("| " + " | ".join(headers) + " |")
+        lines.append("| " + " | ".join("---" for _ in chunk) + " |")
+        lines.append("| " + " | ".join(cells) + " |")
+        lines.append("")
+    return lines
+
+
+def fold(gallery_dir: Path, search_root: Path) -> int:
+    """Copy XR scene artifacts into [gallery_dir] and append a README section.
+
+    Returns the number of scenes folded. A missing README (gallery wasn't
+    staged — e.g. the upstream `generate` bailed) or no scenes found are both
+    no-ops returning 0, so the caller never fails the build over a missing
+    gallery.
+    """
+    readme = gallery_dir / "README.md"
+    if not readme.is_file():
+        print(f"no staged gallery README at {readme}; nothing to fold")
+        return 0
+    if _SECTION_MARKER in readme.read_text():
+        print("README already contains the XR section; skipping")
+        return 0
+
+    scenes = sorted(
+        p
+        for p in search_root.glob(_SCENE_GLOB)
+        if "/external/build/" not in p.as_posix()
+    )
+    if not scenes:
+        print("no scene.json under the search root; nothing to fold")
+        return 0
+
+    lines = [
+        "",
+        _SECTION_MARKER,
+        "## XR spatial previews",
+        "",
+        "Each `@XrSubspacePreview` renders to a `scene.json` (the framework-computed "
+        "spatial panel layout) plus one texture per `SpatialPanel`, recovered offline "
+        "by `composePreviewRenderXr` — no headset, no OpenXR.",
+        "",
+    ]
+    for scene in scenes:
+        name = scene.parent.name
+        dest = gallery_dir / "renders" / "xr" / name
+        dest.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(scene, dest / "scene.json")
+        try:
+            data = json.loads(scene.read_text())
+        except (OSError, json.JSONDecodeError) as exc:
+            print(f"::warning::could not parse {scene}: {exc}; linking raw only")
+            data = {}
+        panels = data.get("panels") if isinstance(data.get("panels"), list) else []
+        # Copy the textures the scene references (siblings of scene.json).
+        for panel in panels:
+            texture = panel.get("texture")
+            if not texture:
+                continue
+            src = scene.parent / texture
+            if src.is_file():
+                shutil.copy2(src, dest / src.name)
+        rel_dir = f"renders/xr/{name}"
+        lines.append(f"### `{name}` — {len(panels)} panel(s)")
+        lines.append("")
+        lines.append(f"[`scene.json`]({rel_dir}/scene.json)")
+        lines.append("")
+        lines.extend(_panel_rows(panels, rel_dir))
+
+    with readme.open("a") as fh:
+        fh.write("\n".join(lines).rstrip() + "\n")
+    print(f"folded {len(scenes)} XR scene(s) into {readme}")
+    return len(scenes)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+    fold_p = sub.add_parser("fold", help="fold XR scene artifacts into a gallery")
+    fold_p.add_argument(
+        "--gallery-dir",
+        required=True,
+        help="the staged gallery dir (contains README.md + renders/)",
+    )
+    fold_p.add_argument(
+        "--search-root",
+        default=".",
+        help="root to scan for build/compose-previews/renders/*/scene.json",
+    )
+    args = parser.parse_args(argv)
+    if args.command == "fold":
+        fold(Path(args.gallery_dir), Path(args.search_root))
+        return 0
+    parser.error(f"unknown command {args.command!r}")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -339,6 +339,8 @@ jobs:
         run: python3 .github/actions/lib/test_a11y_report.py -v
       - name: Run notification-previews tests
         run: python3 .github/actions/lib/test_notification_previews.py -v
+      - name: Run xr-gallery tests
+        run: python3 .github/actions/lib/test_xr_gallery.py -v
 
   # VS Code extension tests — both the existing in-process Mocha suite and
   # the @vscode/test-electron integration tests. The latter download a

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -117,6 +117,10 @@ jobs:
           # baseline uses. The integration job has no checkout of this repo,
           # so these scripts ride in via the bundle like daemon-roundtrip.py.
           cp .github/actions/lib/compare-previews.py bundle/ci/
+          # Folds @XrSubspacePreview scene.json + panel textures into the staged
+          # gallery (the show-envelope carries no path for XR previews, so
+          # compare-previews.py can't reach them) — used by render_xr cells.
+          cp .github/actions/lib/xr-gallery.py bundle/ci/
           cp .github/actions/apply/lib/push-branch.sh bundle/ci/
           # Ship consumer patches (e.g. the adaptive-apps-samples XR
           # alpha14 upgrade) so the integration matrix can apply them to
@@ -929,6 +933,29 @@ jobs:
           echo "Update ${SLUG} integration previews from ${GITHUB_SHA::8}" \
             > "$GITHUB_WORKSPACE/_integration_baselines/_push_msg"
           echo "1" > "$GITHUB_WORKSPACE/_integration_baselines/_skip_if_unchanged"
+
+      - name: Fold XR scenes into the browsable gallery
+        # compare-previews.py builds the gallery from `compose-preview show
+        # --json`, whose envelope carries no path for an @XrSubspacePreview
+        # (kind XR_SUBSPACE renders a scene.json + panel textures, not a single
+        # preview-named PNG). Reach those files from disk and append an "XR
+        # spatial previews" section (panel textures + scene.json link) to the
+        # staged gallery README so the spatial previews are browsable on the
+        # published branch alongside the flat ones. No-op when the gallery
+        # wasn't staged (README absent) or no scene.json was produced.
+        if: matrix.render_xr && github.event_name != 'pull_request'
+        working-directory: external/${{ matrix.workdir }}
+        env:
+          GALLERY_DIR: ${{ github.workspace }}/_integration_baselines
+        run: |
+          set -euo pipefail
+          if [ ! -f "$GALLERY_DIR/README.md" ]; then
+            echo "::notice::no staged gallery (README.md absent) — skipping XR fold."
+            exit 0
+          fi
+          python3 "$GITHUB_WORKSPACE/bundle/ci/xr-gallery.py" fold \
+            --gallery-dir "$GALLERY_DIR" \
+            --search-root .
 
       - name: Upload browsable preview gallery payload
         if: matrix.render && github.event_name != 'pull_request' && hashFiles('_integration_baselines/baselines.json') != ''

--- a/docs/design/XR_SPATIAL_PREVIEW.md
+++ b/docs/design/XR_SPATIAL_PREVIEW.md
@@ -177,3 +177,40 @@ runtime still loads and `Subspace` still composes before any projector feature r
   renderer behaviour (there's no spatial scene to drive offline), so it would be sugar over a shared
   `device =` string. Left out until there's behaviour to attach; the sample uses a shared
   `SPATIAL_PANEL_DEVICE` const instead.
+
+## Enabling XR previews in a consumer (zero-config)
+
+There is **no `composePreview { }` switch to flip** to turn the XR render path on. The plugin
+auto-enables it for any module that already declares an `androidx.xr.compose` dependency — the same
+declared-dependency signal it uses to auto-inject the Wear Tiles renderer
+([`AndroidPreviewSupport.moduleDeclaresXrCompose`](../../gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt)).
+Concretely, an XR module just needs:
+
+1. **`androidx.xr.compose`** on a declarable configuration (it's already there — it's what provides
+   `Subspace` / `SpatialPanel`). This both flips `enableXrPreviews` on *and* counts as a
+   preview-task registration signal in `hasPreviewDependency`, so a module that has **only**
+   `@XrSubspacePreview`s (no flat `@Preview` tooling) still gets `composePreviewRenderXr` registered.
+2. **`ee.schimke.composeai:preview-annotations`** on the compile classpath, for the
+   [`@XrSubspacePreview`](../../api/preview-annotations/src/main/kotlin/ee/schimke/composeai/preview/XrSubspacePreview.kt)
+   annotation that marks which subspace layouts to recover. The annotation is the per-preview signal;
+   the dependency is the per-module signal.
+
+Then `./gradlew :<module>:composePreviewRenderXr` (or `composePreviewRenderAll`) writes
+`build/compose-previews/renders/<preview>/scene.json` + one `<panelId>.png` texture per
+`SpatialPanel`.
+
+The legacy `composePreview { enableXrPreviews.set(true) }` flag still works and forces the path on —
+use it only for the rare module that pulls `androidx.xr.compose` in transitively rather than
+declaring it directly.
+
+> **SDK / JDK note.** `:samples:xr-spatial` pins `sdkVersion.set(35)` because the repo toolchain is
+> JDK 17 and Robolectric 4.16.1 needs JDK 21+ for an SDK-36 sandbox. A consumer normally needs no
+> such pin: the plugin auto-clamps the Robolectric sandbox from `compileSdk = 36` down to 35 on
+> JDK < 21 (and renders at 36 on JDK 21+) — see
+> [`GenerateRobolectricPropertiesTask.resolveSdk`](../../gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/GenerateRobolectricPropertiesTask.kt).
+
+CI exercises this end-to-end with **zero consumer build edits beyond the `preview-annotations`
+dependency**: the `adaptive-apps-samples (AdaptiveJetStream — XR spatial Compose)` integration cell
+applies a `@XrSubspacePreview` overlay to JetStream (which already depends on `androidx.xr.compose`),
+runs `composePreviewRenderXr`, and folds the recovered `scene.json` + panel textures into the
+browsable `compose-preview/integration/jetstream-xr` gallery.


### PR DESCRIPTION
## Summary

Two follow-ups requested after the XR preview work landed:

### 1. Fold XR scenes into the browsable gallery
`@XrSubspacePreview` previews render to a `scene.json` + per-panel textures, not a single preview-named PNG, and the `compose-preview show --json` envelope carries no path for them (`kind == "XR_SUBSPACE"` ⇒ null `pngPath`). So the envelope-driven `compare-previews.py` generator left XR previews out of the published gallery — only the flat 2D previews showed up.

- New `.github/actions/lib/xr-gallery.py` (`fold` subcommand) reaches the `scene.json` + textures on disk, copies them under `<gallery>/renders/xr/<preview>/`, and appends an **"XR spatial previews"** section (per-panel texture table + `scene.json` link) to the staged gallery README. Idempotent; no-op when the gallery wasn't staged or no scene was produced.
- Stdlib `unittest` (`test_xr_gallery.py`, 6 cases) run in `ci.yml` alongside the other lib-script tests.
- The integration matrix bundles the script and runs it in a `render_xr`-gated **"Fold XR scenes"** step between gallery staging and upload, so the spatial previews are browsable on the `compose-preview/integration/jetstream-xr` branch next to the flat ones.

### 2. Document the zero-config XR enablement
New "Enabling XR previews in a consumer" section in `docs/design/XR_SPATIAL_PREVIEW.md`: declaring `androidx.xr.compose` auto-enables the XR render path (no `composePreview { }` switch) and counts as a preview-task registration signal so a pure-XR module isn't gated out; `@XrSubspacePreview` from `preview-annotations` marks which layouts to recover. Notes the legacy `enableXrPreviews` override, the JDK-17 SDK 36→35 auto-clamp (consumers don't need the sample's `sdkVersion` pin), and points at the AdaptiveJetStream integration cell as the end-to-end example.

## Test plan

- `python3 .github/actions/lib/test_xr_gallery.py -v` — 6/6 pass (fold copies artifacts + appends section, missing-README no-op, no-scenes no-op, idempotent, missing-texture tolerated, `external/build` excluded).
- Both workflow files parse; gallery step order is Stage → Fold → Upload; the script is bundled and invoked from the `render_xr` cell.
- Docs-only change otherwise.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WUMD4xmJ9LUtL5dBsqPU2S)_