### PR TITLE
chore: mark generated spatial-rich fixtures as linguist-generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# Generated spatial-rich fixtures — rendered + harvested by
+# `daemon/desktop` `SpatialRichFixtureGeneratorTest` (panel PNGs, scene.json,
+# semantics-tree.json) and wrapped by `spatial-semantics.gen.mjs`. Mark them
+# generated so GitHub collapses them in pull-request diffs and excludes them
+# from language stats: review the generators (SpatialPanelFixtures.kt, the
+# *.gen.mjs scripts), not their output.
+vscode-extension/spatial-fixtures/spatial-rich/scene.json linguist-generated=true
+vscode-extension/spatial-fixtures/spatial-rich/semantics-tree.json linguist-generated=true
+vscode-extension/spatial-fixtures/spatial-rich/panels/*.png linguist-generated=true
+vscode-extension/preview-harness/fixtures/spatial-semantics.json linguist-generated=true


### PR DESCRIPTION
## Summary

Follow-up to #1774. Marks the generated `spatial-rich` fixtures as `linguist-generated` so GitHub collapses them in pull-request diffs and excludes them from language stats.

Those files — `scene.json`, `semantics-tree.json`, the panel PNGs, and the wrapped `spatial-semantics.json` — are rendered + harvested output of `SpatialRichFixtureGeneratorTest` / `spatial-semantics.gen.mjs`. They accounted for ~2.5k of the ~3k lines in #1774's diff, which made the real change (the generators) hard to find. With this in place, future regenerations show the generators and collapse the output.

No code or behaviour change.

## Test plan
- `.gitattributes` only; nothing to run. GitHub applies the collapse on subsequent diffs touching these paths.