### PR TITLE
chore: mark generated preview-harness fixtures as linguist-generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,10 +1,15 @@
-# Generated spatial-rich fixtures — rendered + harvested by
-# `daemon/desktop` `SpatialRichFixtureGeneratorTest` (panel PNGs, scene.json,
-# semantics-tree.json) and wrapped by `spatial-semantics.gen.mjs`. Mark them
-# generated so GitHub collapses them in pull-request diffs and excludes them
-# from language stats: review the generators (SpatialPanelFixtures.kt, the
-# *.gen.mjs scripts), not their output.
+# Generated fixtures — output of in-repo generators, committed so the dev harness can replay them.
+# Mark them generated so GitHub collapses them in pull-request diffs and excludes them from language
+# stats: review the generators, not their output. (Files stay in the tree; "Load diff" still expands
+# them on demand.)
+
+# Spatial-rich: rendered + harvested by `daemon/desktop` `SpatialRichFixtureGeneratorTest` (panel
+# PNGs, scene.json, semantics-tree.json), then wrapped by `spatial-semantics.gen.mjs`.
 vscode-extension/spatial-fixtures/spatial-rich/scene.json linguist-generated=true
 vscode-extension/spatial-fixtures/spatial-rich/semantics-tree.json linguist-generated=true
 vscode-extension/spatial-fixtures/spatial-rich/panels/*.png linguist-generated=true
-vscode-extension/preview-harness/fixtures/spatial-semantics.json linguist-generated=true
+
+# Preview-harness scenario fixtures: each `<name>.json` is emitted by its `<name>.gen.mjs`. The lone
+# exception is `fonts-browser.json`, which is hand-authored — keep it reviewable.
+vscode-extension/preview-harness/fixtures/*.json linguist-generated=true
+vscode-extension/preview-harness/fixtures/fonts-browser.json linguist-generated=false


### PR DESCRIPTION
## Summary

Extends #1776 to the rest of the generated dev fixtures. Every `vscode-extension/preview-harness/fixtures/<name>.json` is emitted by its `<name>.gen.mjs` generator (~2.1k lines across 11 files: `a11y-wear`, `theming`, `text-strings`, `inspection-tree`, `a11y-findings`, `spatial-view`, `permissions`, `notifications`, `grid-default`, `history-diff`, `remotecompose-state`).

Marks them `linguist-generated` (blanket rule over the fixtures dir) so GitHub collapses them in PR diffs and excludes them from language stats — reviewers see the generators, not their output. `fonts-browser.json` is hand-authored, so it's explicitly excluded and stays reviewable. The files stay in the tree; "Load diff" still expands them on demand.

No code or behaviour change. Also tidies the `.gitattributes` comments and folds the now-redundant explicit `spatial-semantics.json` line into the wildcard.

## Test plan
- `git check-attr linguist-generated` confirms the generated fixtures resolve `true` and `fonts-browser.json` resolves `false`.