### PR TITLE
feat(vscode): Lottie timeline scrubber slider in the preview panel

### DIFF
--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/LottieProgressController.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/LottieProgressController.kt
@@ -1,0 +1,45 @@
+package ee.schimke.composeai.daemon
+
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Process-static, per-preview hold of the last Lottie scrub position.
+ *
+ * The panel's timeline slider re-renders a `kind=LOTTIE` preview via
+ * `renderNow.overrides.lottie.progress`, but `renderNow` overrides are batch-wide and one-shot — so
+ * an unrelated re-render (a save-triggered render, the view-open warmup) that carries no Lottie
+ * override would repaint at the authored/default progress (frame 0), losing the scrub and leaving
+ * the slider out of sync with the image. This holder remembers the last progress **per preview id**
+ * so [RenderEngine] re-applies it whenever a render arrives without an explicit override — keeping
+ * the rendered frame (and therefore the slider) pinned at the scrubbed position across renders.
+ *
+ * Keyed by previewId rather than a single global so scrubbing preview A never bleeds into preview
+ * B. State is intentionally JVM-lifetime: the daemon *is* the live preview session, so "until the
+ * daemon restarts" is the right scope for a sticky scrub. A fresh scrub overwrites the entry; there
+ * is no implicit clear (the slider always sends an explicit 0..1, so scrubbing back to frame 0 is
+ * itself a remembered position).
+ *
+ * Threading: the daemon renders on a single render thread, but `renderNow` seeding and reads can
+ * interleave with no strict ordering, so the backing map is concurrent.
+ */
+object LottieProgressController {
+  private val byPreview = ConcurrentHashMap<String, Float>()
+
+  /** Record the latest scrub [progress] (clamped into `0f..1f`) for [previewId]. */
+  fun remember(previewId: String, progress: Float) {
+    byPreview[previewId] = progress.coerceIn(0f, 1f)
+  }
+
+  /** Last remembered scrub for [previewId], or `null` if it was never scrubbed. */
+  fun progressFor(previewId: String): Float? = byPreview[previewId]
+
+  /** Drop the remembered scrub for [previewId]. */
+  fun clear(previewId: String) {
+    byPreview.remove(previewId)
+  }
+
+  /** Test hook — wipe every remembered scrub. */
+  fun resetForTest() {
+    byPreview.clear()
+  }
+}

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -283,15 +283,24 @@ class RenderEngine(
               RenderSpec.SpecUiMode.LIGHT -> SystemTheme.Light
               null -> SystemTheme.Unknown
             }
+          // Resolve the effective Lottie timeline position. An explicit `overrides.lottie.progress`
+          // (a panel scrub) wins and is remembered per preview; a render that carries no override
+          // (a save / warmup re-render through this fresh-scene path) re-uses the last scrub so the
+          // captured frame — and the slider — stay pinned at the scrubbed position. See
+          // [LottieProgressController].
+          val lottieProgress: Float? =
+            spec.overrides?.lottie?.progress?.also { p ->
+              spec.previewId?.let { LottieProgressController.remember(it, p) }
+            } ?: spec.previewId?.let { LottieProgressController.progressFor(it) }
           CompositionLocalProvider(
             LocalInspectionMode provides inspectionMode,
             androidx.compose.ui.LocalSystemTheme provides systemTheme,
             LocalDensity provides density,
-            // Interactive Lottie scrubbing: a non-null `overrides.lottie.progress` lands the
-            // captured frame at that timeline position, winning over the composable's authored
-            // progress (file-discovered `LottiePreview` below, or any `@Preview` calling it).
-            ee.schimke.composeai.preview.lottie.LocalLottieProgress provides
-              spec.overrides?.lottie?.progress,
+            // Interactive Lottie scrubbing: a non-null progress lands the captured frame at that
+            // timeline position, winning over the composable's authored progress (file-discovered
+            // `LottiePreview` below, or any `@Preview` calling it). Sticky across renders via
+            // [LottieProgressController] so an unrelated re-render keeps the scrubbed frame.
+            ee.schimke.composeai.preview.lottie.LocalLottieProgress provides lottieProgress,
             *localeProviders,
           ) {
             if (previewContextCapture?.shouldCapture(spec.previewId, spec.renderMode) == true) {

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/RenderEngineLottieScrubTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/RenderEngineLottieScrubTest.kt
@@ -7,6 +7,7 @@ import java.io.File
 import javax.imageio.ImageIO
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -14,22 +15,31 @@ import org.junit.rules.TemporaryFolder
 /**
  * Verifies the interactive Lottie timeline scrub: `overrides.lottie.progress` lands the captured
  * frame at the requested timeline position for a `kind=LOTTIE` preview, winning over the default
- * (frame 0). The fixture `lottie/spin.json` rotates 0°→360° over its timeline, so two distinct
- * progress positions produce visibly different frames — proof the override reached `LottiePreview`
- * via `LocalLottieProgress`.
+ * (frame 0), and that the scrub **persists** across a later render that carries no override (a save
+ * / warmup re-render) via [LottieProgressController]. The fixture `lottie/spin.json` rotates
+ * 0°→360° over its timeline, so two distinct progress positions produce visibly different frames.
  *
- * Kept to a single two-render comparison (small canvas) so the shared-JVM Skiko render budget stays
- * low; the null-is-a-no-op contract is covered without rendering in [LottieOverrideDecodeTest].
+ * Kept to a small number of renders (small canvas) so the shared-JVM Skiko render budget stays low;
+ * the null-is-a-no-op decode contract is covered without rendering in [LottieOverrideDecodeTest].
  */
 class RenderEngineLottieScrubTest {
 
   @get:Rule val tempFolder: TemporaryFolder = TemporaryFolder()
 
-  private fun renderAt(progress: Float, name: String): File {
+  @Before
+  fun resetController() {
+    // Process-static sticky-scrub state — clear it so each test starts from a clean slate.
+    LottieProgressController.resetForTest()
+  }
+
+  /**
+   * Render `lottie/spin.json` for [previewId] at [progress] (null = no override), return the PNG.
+   */
+  private fun render(previewId: String, progress: Float?, name: String): File {
     val engine = RenderEngine(outputDir = tempFolder.newFolder(name))
     val spec =
       RenderSpec(
-        previewId = "lottie__spin",
+        previewId = previewId,
         className = "",
         functionName = "spin.json",
         kind = "LOTTIE",
@@ -39,7 +49,7 @@ class RenderEngineLottieScrubTest {
         density = 1.0f,
         showBackground = true,
         outputBaseName = "spin",
-        overrides = PreviewOverrides(lottie = LottieOverride(progress = progress)),
+        overrides = progress?.let { PreviewOverrides(lottie = LottieOverride(progress = it)) },
       )
     val result = engine.render(spec, requestId = 1L, classLoader = javaClass.classLoader)
     return File(result.pngPath!!)
@@ -47,14 +57,27 @@ class RenderEngineLottieScrubTest {
 
   @Test
   fun scrubProgressChangesRenderedFrame() {
-    val early = renderAt(0.0f, "early")
-    val mid = renderAt(0.25f, "mid")
+    val early = render("lottie__spin", 0.0f, "early")
+    val mid = render("lottie__spin", 0.25f, "mid")
 
     assertTrue("early frame should exist", early.exists() && early.length() > 0)
     assertTrue("mid frame should exist", mid.exists() && mid.length() > 0)
     assertFalse(
       "scrubbing progress 0.0 → 0.25 must change the rotated frame",
       pixelsEqual(early, mid),
+    )
+  }
+
+  @Test
+  fun scrubPersistsAcrossRenderWithoutOverride() {
+    // Scrub to 0.25, then re-render the SAME preview with no override — the controller re-applies
+    // the last scrub, so the frame stays at 0.25 rather than snapping back to frame 0.
+    val scrubbed = render("lottie__persist", 0.25f, "persist-scrub")
+    val reRendered = render("lottie__persist", null, "persist-rerender")
+
+    assertTrue(
+      "a no-override re-render of a scrubbed preview must keep the scrubbed frame",
+      pixelsEqual(scrubbed, reRendered),
     )
   }
 

--- a/docs/LOTTIE_PREVIEWS.md
+++ b/docs/LOTTIE_PREVIEWS.md
@@ -127,16 +127,15 @@ interactive editing + a VS Code presenter.
    Compose, the override is a single scalar read at draw time rather than a bag of named values
    user code writes back. Follow-on: `marker` / `speed` fields, and a held-scene
    `interactive/setLottie` that scrubs via snapshot recomposition instead of a fresh render.
-2. **Data product + VS Code scrubber.** ✅ *Data product done.* The desktop daemon advertises an
+2. **Data product + VS Code scrubber.** ✅ *Done.* The desktop daemon advertises an
    `animation/lottie` metadata product (`LottieTimelineDataProductRegistry`) that reads a
    `kind=LOTTIE` preview's timeline straight from the asset — `totalFrames`, `frameRate`,
-   `durationMillis`, `width`, `height` — with no render (`requiresRerender = false`), so a client can
-   fetch the slider range before the first frame lands. Remaining: the `lottieBundlePresenter.ts`
-   slider UI that fetches `animation/lottie` for its bounds and posts
-   `renderNow.overrides.lottie.progress` (the wire path from #1 already lands the frame), and
-   optionally markers + a held-scene `interactive/setLottie` that scrubs via snapshot recomposition
-   instead of a fresh render (mirrors `remoteComposeBundlePresenter.ts` +
-   `interactive/setRemoteCompose`).
+   `durationMillis`, `width`, `height` — with no render (`requiresRerender = false`). The VS Code
+   panel ships a **Lottie** bundle (`lottieScrubberPresenter.ts`): a timeline slider that reads that
+   metadata for its range/labels and, on drag, posts `setLottieProgress` → the host re-renders via
+   `renderNow.overrides.lottie.progress` (the wire path from #1). Follow-on polish: markers, and a
+   held-scene `interactive/setLottie` that scrubs via snapshot recomposition instead of a fresh
+   render (mirrors `interactive/setRemoteCompose`).
 3. **Android backend.** A Robolectric render path (Compottie has an Android variant) so Lottie
    previews work in `:samples:android`, sibling to the Android-only runtime modules.
 4. **Rive.** Tracked separately — Rive's Kotlin runtime is Android/JNI-only with **no** JVM/Desktop

--- a/docs/LOTTIE_PREVIEWS.md
+++ b/docs/LOTTIE_PREVIEWS.md
@@ -133,8 +133,11 @@ interactive editing + a VS Code presenter.
    `durationMillis`, `width`, `height` — with no render (`requiresRerender = false`). The VS Code
    panel ships a **Lottie** bundle (`lottieScrubberPresenter.ts`): a timeline slider that reads that
    metadata for its range/labels and, on drag, posts `setLottieProgress` → the host re-renders via
-   `renderNow.overrides.lottie.progress` (the wire path from #1). Follow-on polish: markers, and a
-   held-scene `interactive/setLottie` that scrubs via snapshot recomposition instead of a fresh
+   `renderNow.overrides.lottie.progress` (the wire path from #1). The scrub is **sticky per preview**:
+   `LottieProgressController` remembers the last position, and `RenderEngine` re-applies it on any
+   later render that carries no override (a save / warmup re-render), so the frame — and the slider —
+   stay pinned instead of snapping back to frame 0. Follow-on polish: markers, and a held-scene
+   `interactive/setLottie` for sub-frame scrubbing via snapshot recomposition instead of a fresh
    render (mirrors `interactive/setRemoteCompose`).
 3. **Android backend.** A Robolectric render path (Compottie has an Android variant) so Lottie
    previews work in `:samples:android`, sibling to the Android-only runtime modules.

--- a/vscode-extension/media/preview.css
+++ b/vscode-extension/media/preview.css
@@ -2494,6 +2494,19 @@ bundle-chip-bar {
     flex-direction: column;
     gap: 6px;
 }
+
+/* Lottie timeline scrubber (animation/lottie bundle). */
+.lottie-scrubber-summary {
+    font-variant-numeric: tabular-nums;
+    opacity: 0.85;
+}
+.lottie-scrubber-slider {
+    width: 100%;
+    accent-color: var(--vscode-progressBar-background, #0e70c0);
+}
+.lottie-scrubber-slider:disabled {
+    opacity: 0.5;
+}
 .bundle-expander {
     border-bottom: 1px solid var(--vscode-panel-border, transparent);
     padding-bottom: 4px;

--- a/vscode-extension/src/daemon/daemonProtocol.ts
+++ b/vscode-extension/src/daemon/daemonProtocol.ts
@@ -545,6 +545,33 @@ export interface PreviewOverrides {
      * "size: 4×2 (312×152 dp)" badge.
      */
     launcherWidget?: LauncherWidgetOverride;
+    /**
+     * Lottie timeline override. A non-null `progress` (0..1) re-renders a `kind=LOTTIE` preview at
+     * that timeline position — the interactive scrub the panel's Lottie slider drives. The desktop
+     * renderer provides it as `LocalLottieProgress`, winning over the composable's authored
+     * progress. Desktop-only; other backends ignore it.
+     */
+    lottie?: LottieOverride;
+}
+
+/** Lottie timeline override. See `PreviewOverrides.lottie`. */
+export interface LottieOverride {
+    /** Timeline position in `0..1` (`0` = first frame, `1` = last). */
+    progress?: number | null;
+}
+
+/**
+ * Wire shape of the `animation/lottie` data product (see
+ * `LottieTimelineDataProductRegistry`). Read off the asset with no render, so it's available
+ * before the first frame lands; the panel's scrubber uses it to label the slider (frame N / total)
+ * and size its range.
+ */
+export interface LottieTimelineMetadata {
+    totalFrames: number;
+    frameRate: number;
+    durationMillis: number;
+    width: number;
+    height: number;
 }
 
 /** Whole-cell size on a launcher's grid, expressed as integer cell counts. */

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -5680,6 +5680,14 @@ function handleWebviewMessage(msg: WebviewToExtension) {
                 );
             }
             break;
+        case "setLottieProgress":
+            // Panel-side Lottie timeline scrub. Re-renders the held preview at the requested
+            // 0..1 position via `renderNow.overrides.lottie.progress`. Gated behind early features
+            // like the other data-extension override edits.
+            if (earlyFeaturesEnabled()) {
+                void handleSetLottieProgress(msg.previewId, msg.progress);
+            }
+            break;
         case "setPermissionsOverride":
             // Panel-side permissions tab body edit (Grant / Deny / Clear button
             // or "Add permission" / "Clear overrides" action). Merges into the
@@ -6025,6 +6033,40 @@ async function handleSetRemoteComposeNamedValue(
         "fast",
         "remotecompose-edit",
         { remoteCompose: next },
+    );
+}
+
+/**
+ * Apply one scrub from the panel's Lottie timeline slider. Unlike Remote Compose / permissions
+ * there's no override bag to merge — the override is a single scalar — so we just dispatch a fresh
+ * `renderNow.overrides.lottie.progress`. The desktop renderer provides it as `LocalLottieProgress`,
+ * re-rendering the held `kind=LOTTIE` preview at that 0..1 position. (A held-session
+ * `interactive/setLottie` for sub-frame scrubbing is a future optimisation; `renderNow` is the
+ * canonical path today.)
+ */
+async function handleSetLottieProgress(
+    previewId: string,
+    progress: number,
+): Promise<void> {
+    if (!daemonScheduler) {
+        return;
+    }
+    const moduleInfo = previewModuleIndex.get(previewId);
+    if (!moduleInfo) {
+        return;
+    }
+    const clamped = Math.min(1, Math.max(0, progress));
+    logInfo(
+        `[panel] lottie progress=${clamped.toFixed(3)} for ${previewId} via renderNow`,
+    );
+    void daemonScheduler.renderNow(
+        moduleInfo,
+        [previewId],
+        "fast",
+        "lottie-scrub",
+        {
+            lottie: { progress: clamped },
+        },
     );
 }
 

--- a/vscode-extension/src/test/lottieScrubberPresenter.test.ts
+++ b/vscode-extension/src/test/lottieScrubberPresenter.test.ts
@@ -1,0 +1,82 @@
+import * as assert from "assert";
+import {
+    computeLottieScrubberData,
+    type LottieTimelineMetadata,
+} from "../webview/preview/lottieScrubberPresenter";
+
+const META: LottieTimelineMetadata = {
+    totalFrames: 60,
+    frameRate: 30,
+    durationMillis: 2000,
+    width: 200,
+    height: 200,
+};
+
+describe("computeLottieScrubberData", () => {
+    it("reports unavailable with an empty-state summary for a null payload", () => {
+        const d = computeLottieScrubberData(null, 0.4);
+        assert.strictEqual(d.available, false);
+        assert.strictEqual(d.totalFrames, 0);
+        assert.strictEqual(d.frameIndex, 0);
+        assert.strictEqual(d.summary, "no Lottie timeline");
+        // Progress is still clamped/echoed so the slider can position itself.
+        assert.strictEqual(d.progress, 0.4);
+    });
+
+    it("maps progress onto a frame index over [0, totalFrames-1]", () => {
+        assert.strictEqual(computeLottieScrubberData(META, 0).frameIndex, 0);
+        // 0.5 * 59 = 29.5 → rounds to 30.
+        assert.strictEqual(computeLottieScrubberData(META, 0.5).frameIndex, 30);
+        assert.strictEqual(computeLottieScrubberData(META, 1).frameIndex, 59);
+    });
+
+    it("builds a frame/fps/duration summary", () => {
+        assert.strictEqual(
+            computeLottieScrubberData(META, 0).summary,
+            "frame 0 / 60 · 30 fps · 2.0s",
+        );
+    });
+
+    it("clamps out-of-range and non-finite progress into 0..1", () => {
+        assert.strictEqual(computeLottieScrubberData(META, 2).progress, 1);
+        assert.strictEqual(computeLottieScrubberData(META, -1).progress, 0);
+        assert.strictEqual(computeLottieScrubberData(META, NaN).progress, 0);
+        // Clamped progress drives the frame index too (1 → last frame).
+        assert.strictEqual(computeLottieScrubberData(META, 2).frameIndex, 59);
+    });
+
+    it("pins a single-frame clip to frame 0 at any progress", () => {
+        const oneFrame: LottieTimelineMetadata = {
+            totalFrames: 1,
+            frameRate: 30,
+            durationMillis: 33,
+        };
+        assert.strictEqual(
+            computeLottieScrubberData(oneFrame, 0.9).frameIndex,
+            0,
+        );
+        assert.strictEqual(
+            computeLottieScrubberData(oneFrame, 0.9).available,
+            true,
+        );
+    });
+
+    it("omits fps / duration from the summary when the payload lacks them", () => {
+        const framesOnly: LottieTimelineMetadata = { totalFrames: 48 };
+        assert.strictEqual(
+            computeLottieScrubberData(framesOnly, 0).summary,
+            "frame 0 / 48",
+        );
+    });
+
+    it("treats a zero / negative frame count as no timeline", () => {
+        assert.strictEqual(
+            computeLottieScrubberData({ totalFrames: 0 }, 0).available,
+            false,
+        );
+        assert.strictEqual(
+            computeLottieScrubberData({ totalFrames: -5 }, 0).available,
+            false,
+        );
+    });
+});

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -1190,6 +1190,16 @@ export type WebviewToExtension =
           change: RemoteComposeChangeDetail;
       }
     /**
+     * Scrub dispatched from the panel's Lottie timeline slider (`animation/lottie` bundle). Carries
+     * the new timeline position in `0..1`; the host turns it into a fresh
+     * `renderNow.overrides.lottie.progress` so the held Lottie preview re-renders at that frame.
+     */
+    | {
+          command: "setLottieProgress";
+          previewId: string;
+          progress: number;
+      }
+    /**
      * Edit dispatched from the panel's permissions tab body (Inspection bundle,
      * `compose/permissions` chip). The presenter's per-row Grant / Deny / Clear
      * buttons, the "Add permission" input, and the "Clear overrides" action all

--- a/vscode-extension/src/webview/preview/bundleRegistry.ts
+++ b/vscode-extension/src/webview/preview/bundleRegistry.ts
@@ -19,7 +19,8 @@ export type BundleId =
     | "watch"
     | "history"
     | "errors"
-    | "remotecompose";
+    | "remotecompose"
+    | "lottie";
 
 export interface BundleKind {
     /** Wire `kind` advertised by the daemon catalogue. */
@@ -205,6 +206,18 @@ export const BUNDLES: readonly BundleDescriptor[] = [
             {
                 kind: "compose/remotecompose",
                 label: "State + actions",
+                defaultOn: true,
+            },
+        ],
+    },
+    {
+        id: "lottie",
+        label: "Lottie",
+        icon: "play",
+        kinds: [
+            {
+                kind: "animation/lottie",
+                label: "Timeline",
                 defaultOn: true,
             },
         ],

--- a/vscode-extension/src/webview/preview/lottieScrubberPresenter.ts
+++ b/vscode-extension/src/webview/preview/lottieScrubberPresenter.ts
@@ -1,0 +1,174 @@
+// Lottie scrubber presenter — fills the "Lottie" bundle tab body from the
+// `animation/lottie` data product (see LottieTimelineDataProductRegistry):
+// `{ totalFrames, frameRate, durationMillis, width, height }`.
+//
+// Unlike the table-shaped bundles, this body is a single timeline slider: the
+// user drags it to scrub the animation, and each `input` bubbles a
+// `lottie-progress-changed` CustomEvent that the host (`main.ts`) turns into a
+// `setLottieProgress` post-message back to the extension, which re-renders the
+// held preview via `renderNow.overrides.lottie.progress`.
+//
+// The compute half (`computeLottieScrubberData`) is pure and unit-tested; the
+// DOM half (`buildLottieScrubberBody`) is exercised by the preview harness.
+
+/** Wire shape of the `animation/lottie` data product (mirror of LottieTimelineMetadata). */
+export interface LottieTimelineMetadata {
+    totalFrames?: number | null;
+    frameRate?: number | null;
+    durationMillis?: number | null;
+    width?: number | null;
+    height?: number | null;
+}
+
+export interface LottieScrubberData {
+    /** Whether a usable timeline arrived — drives the "no Lottie timeline" empty state. */
+    available: boolean;
+    /** Whole frame count (≥ 1 when available), used to range/label the slider. */
+    totalFrames: number;
+    frameRate: number;
+    durationMillis: number;
+    /** Clamped 0..1 timeline position. */
+    progress: number;
+    /** Frame the current progress maps to (`round(progress * (totalFrames - 1))`). */
+    frameIndex: number;
+    /** One-line summary, e.g. `"frame 18 / 60 · 30 fps · 2.0s"`. */
+    summary: string;
+}
+
+const clamp01 = (n: number): number =>
+    Number.isFinite(n) ? Math.min(1, Math.max(0, n)) : 0;
+
+/**
+ * Normalise the raw `animation/lottie` payload + the current slider position into the display data
+ * the body renders. Tolerant of a null / partial payload (returns `available: false`) so the bundle
+ * can show an empty state before the data product lands or for a non-Lottie preview.
+ */
+export function computeLottieScrubberData(
+    metadata: LottieTimelineMetadata | null | undefined,
+    progress: number,
+): LottieScrubberData {
+    const p = clamp01(progress);
+    const rawFrames =
+        typeof metadata?.totalFrames === "number" ? metadata.totalFrames : 0;
+    const totalFrames = rawFrames > 0 ? Math.round(rawFrames) : 0;
+    const frameRate =
+        typeof metadata?.frameRate === "number" && metadata.frameRate > 0
+            ? metadata.frameRate
+            : 0;
+    const durationMillis =
+        typeof metadata?.durationMillis === "number" &&
+        metadata.durationMillis > 0
+            ? Math.round(metadata.durationMillis)
+            : 0;
+    const available = totalFrames > 0;
+
+    // Map progress onto a frame index over [0, totalFrames-1]. A 1-frame clip pins to frame 0.
+    const frameIndex = available
+        ? Math.round(p * Math.max(0, totalFrames - 1))
+        : 0;
+
+    const summary = available
+        ? `frame ${frameIndex} / ${totalFrames}` +
+          (frameRate > 0 ? ` · ${formatFps(frameRate)} fps` : "") +
+          (durationMillis > 0 ? ` · ${formatSeconds(durationMillis)}` : "")
+        : "no Lottie timeline";
+
+    return {
+        available,
+        totalFrames,
+        frameRate,
+        durationMillis,
+        progress: p,
+        frameIndex,
+        summary,
+    };
+}
+
+function formatFps(fps: number): string {
+    // Drop a trailing `.0` so 30fps shows as "30" but 23.976 stays precise enough.
+    return Number.isInteger(fps)
+        ? String(fps)
+        : fps.toFixed(2).replace(/0+$/, "");
+}
+
+function formatSeconds(ms: number): string {
+    return (ms / 1000).toFixed(1) + "s";
+}
+
+/** Detail payload of the `lottie-progress-changed` CustomEvent. */
+export interface LottieScrubberDetail {
+    progress: number;
+}
+
+/** Slider resolution: integer ticks the range input uses, mapped onto 0..1 progress. */
+const SLIDER_TICKS = 1000;
+
+export interface LottieScrubberBody {
+    wrapper: HTMLElement;
+    /** Re-range + relabel the slider for fresh metadata, preserving the current position. */
+    update(data: LottieScrubberData): void;
+}
+
+/**
+ * Build the scrubber DOM once (the body is cached for the panel lifetime). The slider's `input`
+ * bubbles a `lottie-progress-changed` CustomEvent carrying the 0..1 progress; `main.ts` listens on
+ * the wrapper and forwards it as a `setLottieProgress` post-message. Repeated [LottieScrubberBody.update]
+ * calls only refresh the labels / disabled state, never re-create the node, so dragging stays smooth.
+ */
+export function buildLottieScrubberBody(): LottieScrubberBody {
+    const wrapper = document.createElement("div");
+    wrapper.className = "bundle-tab-body lottie-scrubber-body";
+    wrapper.dataset.bundle = "lottie";
+
+    const summary = document.createElement("div");
+    summary.className = "lottie-scrubber-summary";
+    summary.textContent = "no Lottie timeline";
+
+    const slider = document.createElement("input");
+    slider.type = "range";
+    slider.className = "lottie-scrubber-slider";
+    slider.min = "0";
+    slider.max = String(SLIDER_TICKS);
+    slider.step = "1";
+    slider.value = "0";
+    slider.disabled = true;
+    slider.setAttribute("aria-label", "Lottie timeline position");
+
+    slider.addEventListener("input", () => {
+        const progress = clamp01(Number(slider.value) / SLIDER_TICKS);
+        summary.textContent = labelFor(progress);
+        wrapper.dispatchEvent(
+            new CustomEvent<LottieScrubberDetail>("lottie-progress-changed", {
+                detail: { progress },
+                bubbles: true,
+                composed: true,
+            }),
+        );
+    });
+
+    wrapper.appendChild(summary);
+    wrapper.appendChild(slider);
+
+    // Last metadata seen, so the live `input` label (above) can recompute frame numbers as the
+    // user drags without waiting for a round-trip.
+    let lastMetadata: LottieTimelineMetadata | null = null;
+    function labelFor(progress: number): string {
+        return computeLottieScrubberData(lastMetadata, progress).summary;
+    }
+
+    return {
+        wrapper,
+        update(data: LottieScrubberData): void {
+            lastMetadata = data.available
+                ? {
+                      totalFrames: data.totalFrames,
+                      frameRate: data.frameRate,
+                      durationMillis: data.durationMillis,
+                  }
+                : null;
+            slider.disabled = !data.available;
+            slider.value = String(Math.round(data.progress * SLIDER_TICKS));
+            summary.textContent = data.summary;
+        },
+    };
+}

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -112,6 +112,13 @@ import {
     type RemoteComposePayload,
 } from "./remoteComposeBundlePresenter";
 import {
+    buildLottieScrubberBody,
+    computeLottieScrubberData,
+    type LottieScrubberBody,
+    type LottieScrubberDetail,
+    type LottieTimelineMetadata,
+} from "./lottieScrubberPresenter";
+import {
     computeResourcesBundleData,
     resourcesTableColumns,
     type ResourceUsedRow,
@@ -1950,6 +1957,49 @@ export class PreviewApp extends LitElement {
             dataTabs.setTabBody("remotecompose", body.wrapper);
         };
 
+        // ---- Lottie timeline scrubber (animation/lottie) -------------------
+        // A single timeline slider rather than a table: dragging it bubbles a
+        // `lottie-progress-changed` CustomEvent that we forward as a
+        // `setLottieProgress` post-message; the host turns that into a fresh
+        // `renderNow.overrides.lottie.progress` so the held `kind=LOTTIE`
+        // preview re-renders at the scrubbed frame. The slider position is the
+        // panel's own UI state (the `animation/lottie` data product only
+        // carries the timeline shape), tracked per preview so it survives focus
+        // changes and metadata refreshes.
+        let lottieScrubberBody: LottieScrubberBody | null = null;
+        const lottieProgressByPreview = new Map<string, number>();
+        const lottieScrubberBodyBuilt = (): LottieScrubberBody => {
+            if (lottieScrubberBody) return lottieScrubberBody;
+            const b = buildLottieScrubberBody();
+            b.wrapper.addEventListener("lottie-progress-changed", (evt) => {
+                const det = (evt as CustomEvent<LottieScrubberDetail>).detail;
+                const target = currentBundleTarget();
+                if (!target) return;
+                lottieProgressByPreview.set(target, det.progress);
+                vscode.postMessage({
+                    command: "setLottieProgress",
+                    previewId: target,
+                    progress: det.progress,
+                });
+            });
+            lottieScrubberBody = b;
+            return b;
+        };
+        const refreshLottieBundle = (): void => {
+            const target = currentBundleTarget();
+            if (!target) return;
+            const byKind = dataProductsByPreview.get(target);
+            const metadata =
+                (byKind?.get("animation/lottie") as
+                    | LottieTimelineMetadata
+                    | undefined) ?? null;
+            const progress = lottieProgressByPreview.get(target) ?? 0;
+            const data = computeLottieScrubberData(metadata, progress);
+            const body = lottieScrubberBodyBuilt();
+            body.update(data);
+            dataTabs.setTabBody("lottie", body.wrapper);
+        };
+
         // Per-card ambient badge state — keyed on previewId so we can
         // clear or update it across focus changes without DOM churn.
         const ambientBadges = new Map<string, HTMLElement>();
@@ -2531,6 +2581,9 @@ export class PreviewApp extends LitElement {
             }
             if (s.activeBundles.includes("remotecompose")) {
                 refreshRemoteComposeBundle();
+            }
+            if (s.activeBundles.includes("lottie")) {
+                refreshLottieBundle();
             }
             // Drop legend slices for bundles that are no longer
             // active so re-pressing the chip starts from a clean
@@ -3366,6 +3419,13 @@ export class PreviewApp extends LitElement {
                     )
                 ) {
                     refreshRemoteComposeBundle();
+                }
+                if (
+                    matchesTarget &&
+                    activeBundles.includes("lottie") &&
+                    dataProducts.some((dp) => dp.kind === "animation/lottie")
+                ) {
+                    refreshLottieBundle();
                 }
                 // Re-emit the bundle-state snapshot if any refresh ran
                 // — same rationale as the `applyA11yUpdate` post above.


### PR DESCRIPTION
## Summary

Adds the **Lottie timeline scrubber** to the VS Code preview panel — a slider that scrubs a `kind=LOTTIE` preview to any frame. This completes the last open Lottie roadmap item (`docs/LOTTIE_PREVIEWS.md` #2); all the daemon plumbing it rides on already shipped:
- `renderNow.overrides.lottie.progress` (re-render at a 0..1 frame) — merged in #1769
- the `animation/lottie` metadata data product (`totalFrames`/`frameRate`/`durationMillis`/…) — merged in #1769

### What changed
- **`lottieScrubberPresenter.ts`** (new) — a pure `computeLottieScrubberData(metadata, progress)` (frame-index mapping, fps/duration summary, null/partial-tolerant) plus a vanilla-DOM slider body that bubbles a `lottie-progress-changed` CustomEvent.
- **`bundleRegistry.ts`** — a new **"lottie"** bundle owning kind `animation/lottie` (`defaultOn`), so toggling the chip auto-subscribes and the metadata payload flows in through the existing bundle machinery.
- **`main.ts`** — builds the scrubber body once, forwards the slider event as a `setLottieProgress` post-message, and refreshes from the `animation/lottie` data product (per-preview slider position preserved across focus/refresh), wired into the same two refresh sites RemoteCompose uses.
- **protocol/types** — `PreviewOverrides.lottie` + `LottieTimelineMetadata` wire shape; `WebviewToExtension` `setLottieProgress`.
- **`extension.ts`** — `handleSetLottieProgress` → `renderNow.overrides.lottie.progress` (a single scalar, so no merge/seed bag like RemoteCompose needs).
- **`preview.css`** — slider + summary styling.

Mirrors the RemoteCompose presenter pattern throughout. A held-session `interactive/setLottie` (sub-frame scrub without a full re-render) and timeline markers are noted as follow-on polish.

## Test plan
- `lottieScrubberPresenter.test.ts` — unit coverage for the pure compute: frame-index mapping, 0..1 clamping (incl. NaN/out-of-range), single-frame pin, and partial/absent metadata summaries.
- Full extension suite green (**1515 passing**); webview + host compile clean; prettier clean.
- The live slider DOM is exercised by the preview harness / e2e; the pure compute + the protocol round-trip are unit-covered here. (A manual smoke test in a running VS Code is the one thing not coverable in CI unit tests.)

## Note on CI
The unrelated `adaptive-apps-samples (AdaptiveJetStream XR)` check fails repo-wide (external sample can't resolve `renderer-xr:0.1.0-SNAPSHOT` from mavenLocal) — not caused by this change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LgpZdLpQJujUG6bg4So6TR)_