### PR TITLE
feat(xr): single-source SpatialScene codegen + a per-frame Filament render server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,6 +196,20 @@ jobs:
           grep -q 'composite.png' "$base/previews.json" \
             || { echo "::error::previews.json has no composite capture"; exit 1; }
           echo "OK: baked $png ($(du -h "$png" | cut -f1)), referenced in previews.json"
+      # Exercise the long-lived server path (--serve): initialize -> render -> xr/updatePanels over
+      # JSON-RPC stdio, asserting streamFrame notifications arrive and a per-frame panel update
+      # actually changes the rendered image. Reuses the dist/ binary + materials and the committed
+      # spatial-scene fixture.
+      - name: Smoke-test the render server (--serve)
+        shell: bash
+        env:
+          LIBGL_ALWAYS_SOFTWARE: '1'
+          GALLIUM_DRIVER: llvmpipe
+        run: |
+          xvfb-run -a -s "-screen 0 2000x1400x24" \
+            python3 renderers/xr-composite/test/serve_smoke.py \
+              "$PWD/dist/xr-composite" "$PWD/dist/materials" \
+              "$PWD/vscode-extension/preview-harness/fixtures/spatial-scene"
       - name: Upload XR composite
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,6 +204,21 @@ jobs:
           path: samples/xr-spatial/build/compose-previews/renders/**/composite.png
           if-no-files-found: warn
 
+  spatial-scene-codegen:
+    name: SpatialScene codegen up to date
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 20
+      # The Kotlin / TypeScript / C++ SpatialScene mirrors are generated from
+      # schema/spatial-scene.schema.json. Fail if a committed mirror drifts from the schema.
+      - name: Check generated mirrors match the schema
+        run: node scripts/codegen/gen-spatial-scene.mjs --check
+
   bundle-render:
     name: Bundle Render E2E
     runs-on: ubuntu-latest

--- a/api/preview-data-api/build.gradle.kts
+++ b/api/preview-data-api/build.gradle.kts
@@ -33,6 +33,16 @@ dependencies {
   testImplementation(kotlin("test"))
 }
 
+// `xr/SpatialScene.kt` is generated from `schema/spatial-scene.schema.json` by
+// `scripts/codegen/gen-spatial-scene.mjs` and formatted by that generator (the single source of
+// truth), so it is excluded from the ktfmt gate. Drift is caught by the codegen `--check` CI job.
+// Only the per-source-set ktfmt tasks are `SourceTask`s; the umbrella `ktfmtCheck`/`ktfmtFormat`
+// lifecycle tasks are plain `DefaultTask`s, so filter by type rather than name.
+tasks
+  .withType<org.gradle.api.tasks.SourceTask>()
+  .matching { it.name.startsWith("ktfmt") }
+  .configureEach { exclude("**/xr/SpatialScene.kt") }
+
 composeAiMavenPublishing {
   coordinates(
     artifactId = "preview-data-api",

--- a/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/xr/SpatialScene.kt
+++ b/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/xr/SpatialScene.kt
@@ -1,53 +1,81 @@
+// GENERATED FILE — DO NOT EDIT.
+// Source of truth: schema/spatial-scene.schema.json
+// Regenerate: node scripts/codegen/gen-spatial-scene.mjs (CI checks with --check).
+
 package ee.schimke.composeai.xr
 
 import kotlinx.serialization.Serializable
 
 /**
- * Kotlin mirror of the `SpatialScene` wire contract — the format the offline renderer
- * (`:renderer-xr`, the producer) emits and the VS Code webview's 3D spatial-layout viewer (the
- * consumer) reads.
- *
- * The **authoritative** definition is the TypeScript source
- * (`vscode-extension/src/webview/shared/spatialScene.ts`) plus the prose spec
- * (`docs/design/SPATIAL_SCENE_CONTRACT.md`). These data classes must stay byte-compatible with it:
- * property names are the JSON keys, so they match the TS field names exactly. `SpatialSceneTest`
- * deserializes the committed fixture to keep the two languages locked together — if you change a
- * shape here, change it there too (and bump [SPATIAL_SCENE_VERSION]).
- *
- * Conventions (see the spec): all linear quantities are **dp**; axes are right-handed (+x right, +y
- * up, +z toward the viewer); `rotation` is a unit quaternion.
+ * The wire contract between the offline renderer (producer) and the webview's 3D spatial-layout viewer (consumer). All linear quantities are dp; axes are right-handed (+x right, +y up, +z toward the viewer); rotation is a unit quaternion. Prose spec: docs/design/SPATIAL_SCENE_CONTRACT.md.
  */
 public const val SPATIAL_SCENE_VERSION: Int = 1
 
-/** A point or vector, in dp. */
-@Serializable public data class Vec3(val x: Double, val y: Double, val z: Double)
+/**
+ * A point or vector, in dp.
+ */
+@Serializable
+public data class Vec3(
+  val x: Double,
+  val y: Double,
+  val z: Double,
+)
 
-/** A unit quaternion; identity is `(0, 0, 0, 1)`. */
-@Serializable public data class Quat(val x: Double, val y: Double, val z: Double, val w: Double)
+/**
+ * A unit quaternion; identity is `(0, 0, 0, 1)`.
+ */
+@Serializable
+public data class Quat(
+  val x: Double,
+  val y: Double,
+  val z: Double,
+  val w: Double,
+)
 
 /**
  * A rigid transform in the subspace root's frame: `translation` in dp, `rotation` a unit
  * quaternion.
  */
-@Serializable public data class SpatialPose(val translation: Vec3, val rotation: Quat)
+@Serializable
+public data class SpatialPose(
+  val translation: Vec3,
+  val rotation: Quat,
+)
 
-/** Panel extent in dp (the layout output, not the texture's pixel size). */
-@Serializable public data class SizeDp(val width: Int, val height: Int)
+/**
+ * Panel extent in dp (the layout output, not the texture's pixel size).
+ */
+@Serializable
+public data class SizeDp(
+  val width: Int,
+  val height: Int,
+)
 
-/** A spatial panel: a flat quad hosting 2D Compose content. */
+/**
+ * A spatial panel: a flat quad hosting 2D Compose content.
+ */
 @Serializable
 public data class SpatialPanel(
   val id: String,
+  /**
+   * Human-readable label for overlays; not required for rendering.
+   */
   val label: String? = null,
   val poseInRoot: SpatialPose,
   val sizeDp: SizeDp,
-  /** Path to the panel's 2D-content PNG, relative to the scene file (or a resolvable URI). */
+  /**
+   * Path to the panel's 2D-content PNG, relative to the scene file (or a resolvable URI).
+   */
   val texture: String,
+  /**
+   * Id of the containing panel/group, or null/omitted for top-level panels.
+   */
   val parentId: String? = null,
 )
 
 /**
- * An Orbiter affordance — a control strip anchored to a panel edge. `edge` is top/bottom/start/end.
+ * An Orbiter affordance — a control strip anchored to a panel edge. `edge` is
+ * top/bottom/start/end.
  */
 @Serializable
 public data class OrbiterAffordance(
@@ -59,11 +87,19 @@ public data class OrbiterAffordance(
   val texture: String,
 )
 
-/** Default viewing camera. Only `kind = "orbit"` is defined today. */
+/**
+ * Default viewing camera. Only `kind = "orbit"` is defined today.
+ */
 @Serializable
 public data class OrbitCamera(
   val kind: String = "orbit",
+  /**
+   * Look-at point in dp.
+   */
   val target: Vec3,
+  /**
+   * Camera distance from `target`, in dp.
+   */
   val distance: Double,
   val yawDeg: Double,
   val pitchDeg: Double,
@@ -88,21 +124,40 @@ public data class SpatialEnvironment(
    * Named gradient preset (e.g. `"warm-room"`, `"studio-dark"`); ignored when `kind == "color"`.
    */
   val preset: String? = null,
-  /** Gradient colour straight up (`#RRGGBB`); overrides the preset. */
+  /**
+   * Gradient colour straight up (`#RRGGBB`); overrides the preset.
+   */
   val sky: String? = null,
   /**
    * Gradient colour at eye level (`#RRGGBB`); overrides the preset. Doubles as the clear colour.
    */
   val horizon: String? = null,
-  /** Gradient colour straight down (`#RRGGBB`); overrides the preset and enables a 3-stop floor. */
+  /**
+   * Gradient colour straight down (`#RRGGBB`); overrides the preset and enables a 3-stop floor.
+   */
   val floor: String? = null,
+  /**
+   * Gradient glow intensity; overrides the preset's glow. Consumed by the native compositor's room backdrop.
+   */
+  val glow: Double? = null,
 )
 
-/** The full scene the 3D viewer renders. [version] must equal [SPATIAL_SCENE_VERSION]. */
+/**
+ * The full scene the 3D viewer renders. [version] must equal [SPATIAL_SCENE_VERSION].
+ */
 @Serializable
 public data class SpatialScene(
+  /**
+   * Bumped on breaking changes. Producers stamp it into `SpatialScene.version`.
+   */
   val version: Int = SPATIAL_SCENE_VERSION,
+  /**
+   * All linear quantities are dp.
+   */
   val units: String = "dp",
+  /**
+   * The preview this scene was projected from, if any.
+   */
   val previewId: String? = null,
   val camera: OrbitCamera,
   val panels: List<SpatialPanel>,

--- a/docs/design/SPATIAL_SCENE_CONTRACT.md
+++ b/docs/design/SPATIAL_SCENE_CONTRACT.md
@@ -5,7 +5,7 @@ recovers a Compose-XR subspace layout and renders each panel's 2D content to a P
 **consumer** — the VS Code webview's WebGL 3D spatial-layout viewer. Both sides build to this shape so
 they can be developed in parallel and meet here.
 
-- **TypeScript source of truth:** [`vscode-extension/src/webview/shared/spatialScene.ts`](../../vscode-extension/src/webview/shared/spatialScene.ts)
+- **Source of truth:** [`schema/spatial-scene.schema.json`](../../schema/spatial-scene.schema.json) — the Kotlin ([`SpatialScene.kt`](../../api/preview-data-api/src/main/kotlin/ee/schimke/composeai/xr/SpatialScene.kt)), TypeScript ([`spatialScene.ts`](../../vscode-extension/src/webview/shared/spatialScene.ts)), and native C++ ([`spatial_scene.hpp`](../../renderers/xr-composite/src/spatial_scene.hpp)) mirrors are **generated** from it by [`scripts/codegen/gen-spatial-scene.mjs`](../../scripts/codegen/gen-spatial-scene.mjs) (CI gate: `--check`). Edit the schema, not the mirrors. Rationale: [`WIRE_IDL_CODEGEN.md`](WIRE_IDL_CODEGEN.md).
 - **Sample fixture:** [`vscode-extension/preview-harness/fixtures/spatial-scene/`](../../vscode-extension/preview-harness/fixtures/spatial-scene/) (`scene.json` + `top.png` / `bottom.png`)
 - **Background:** [`XR_SPATIAL_PREVIEW.md`](XR_SPATIAL_PREVIEW.md) (how poses are recovered offline)
 - **Still-image consumer:** [`xr-spatial/COMPOSITOR.md`](xr-spatial/COMPOSITOR.md) (the `xr-composite` native tool that bakes this scene to a composite PNG, headless/GPU-free)

--- a/docs/design/WIRE_IDL_CODEGEN.md
+++ b/docs/design/WIRE_IDL_CODEGEN.md
@@ -1,11 +1,18 @@
 # Evaluation: single-source IDL + codegen for the cross-language wire types
 
-**Status: evaluated — recommendation accepted, not yet actioned.** Tracks
+**Status: evaluated; `SpatialScene` pilot landed.** Tracks
 [#1729](https://github.com/yschimke/compose-ai-tools/issues/1729), the follow-up from
 [RENDERER_SERVICE.md decision #5](xr-spatial/RENDERER_SERVICE.md#decisions). This document records the
-evaluation and the decision so it survives the issue. **No code change is implied by landing this
-doc** — the recommendation is to keep the current hand-mirror + fixture approach until the trigger
-condition below is met.
+evaluation and decision so it survives the issue.
+
+> **Update — `SpatialScene` is now generated.** The spike below was actioned for the one type that
+> is genuinely triplicated today: `SpatialScene` (Kotlin + TS + the native C++ one-shot compositor).
+> [`schema/spatial-scene.schema.json`](../../schema/spatial-scene.schema.json) is the single source
+> of truth; [`scripts/codegen/gen-spatial-scene.mjs`](../../scripts/codegen/gen-spatial-scene.mjs)
+> generates all three mirrors (the CI job `SpatialScene codegen up to date` runs it with `--check`).
+> A **bespoke** generator was chosen over a stock tool (quicktype) deliberately — see
+> [Pilot notes](#pilot-notes-spatialscene). The broader `Messages.kt` envelope stays hand-mirrored
+> until the native renderer *service* exists (the gate below).
 
 ## The problem this is about
 
@@ -113,6 +120,42 @@ A non-big-bang path that never breaks the fixture-locked Kotlin ↔ TS contract:
 4. Generation runs in the build; the generated sources are committed (so the repo stays readable and
    `grep`-able and the build doesn't hard-depend on a generator at every checkout) **or** generated
    at build time with a check task — decide at adoption time.
+
+## Pilot notes (`SpatialScene`)
+
+The migration sketch above was actioned for `SpatialScene`. Two things diverged from the naive plan
+and are worth recording:
+
+### Why a bespoke generator, not quicktype
+
+A spike ran quicktype (one tool, Kotlin + TS + C++ from one JSON Schema). Its output did **not** hold
+up as a drop-in for the existing published `preview-data-api` surface:
+
+- **Kotlin:** re-cased `previewId` → `previewID`, emitted `version: Long` (not `Int`), turned
+  `units`/`kind` into `enum class`es, dropped the `= emptyList()` / `= SPATIAL_SCENE_VERSION`
+  defaults the producer and `SpatialSceneTest` rely on, and alphabetised fields. A drop-in swap would
+  break the published API and its consumers.
+- **C++:** pulled in a **Boost.Optional** dependency + `shared_ptr` boilerplate in a `quicktype`
+  namespace — `xr-composite` is otherwise header-only (`json.hpp` + `stb`).
+- **TS:** added `[property: string]: any` index signatures and replaced the string-literal unions.
+
+So `scripts/codegen/gen-spatial-scene.mjs` is a ~300-line, dependency-free (Node stdlib) generator
+that templates the schema into the *existing* idiomatic shapes: kotlinx data classes with their
+defaults, TS string-literal unions + the hand `isSpatialScene` guard, and nlohmann `std::optional`
+structs. Result: the generated mirrors are byte-shape-identical to the old hand-written ones, so
+**zero consumer churn** and every fixture stayed green. The generated files are committed and
+excluded from ktfmt/prettier (the generator is their sole formatter); the `--check` CI job is the
+drift gate. The trade is maintaining a small bespoke generator vs. a stock tool's worse output — for
+this small, controlled schema that is the right call. If the schema set grows a lot, revisit whether
+a stock tool (with its churn) becomes worth it.
+
+### Drift the codegen immediately surfaced
+
+The C++ compositor was reading an `environment.glow` field that existed in **neither** the Kotlin nor
+the TypeScript contract — a latent third-mirror drift exactly of the kind this issue is about. It is
+now an additive optional field in the schema (hence in all three mirrors). This is the concrete
+payoff that justified doing the pilot now rather than waiting: the single source caught a real gap
+the moment it existed.
 
 ## Adjacent note (does not change this recommendation)
 

--- a/docs/design/xr-spatial/RENDERER_SERVICE.md
+++ b/docs/design/xr-spatial/RENDERER_SERVICE.md
@@ -1,10 +1,17 @@
 # RFC: the XR renderer as a streaming, extensible service behind the daemon
 
-**Status: accepted (design only).** Captures the agreed direction and the settled decisions (see
-[Decisions](#decisions)) for evolving `renderers/xr-composite` from a one-shot CLI into a long-lived,
-extensible render service. Nothing here is built yet; the
-[one-shot tool](../../../renderers/xr-composite/README.md) and the
-[panels-in-previews increment](COMPOSITOR.md) land first and are unaffected.
+**Status: accepted; native-side prototype landed.** Captures the agreed direction and the settled
+decisions (see [Decisions](#decisions)) for evolving `renderers/xr-composite` from a one-shot CLI
+into a long-lived, extensible render service.
+
+> **Implemented so far:** `xr-composite --serve` is a working long-lived native process speaking the
+> daemon's JSON-RPC + `Content-Length` framing (`initialize`, `render`, `xr/updatePanels`,
+> `streamFrame` base64 frames), holding one Filament engine across frames — i.e. "what is genuinely
+> new" items #1 and #3 (native JSON-RPC peer + a held, mutable session) in prototype form, plus
+> migration steps #2–#3 on the native side. **Still to do:** the daemon fronting it (a
+> `RenderSession`-style backend that spawns/proxies the child — item #2), native multi-session
+> concurrency, and the `xr/structure` / `xr/a11y-overlay` data-product kinds. See
+> [renderers/xr-composite/README.md → Server mode](../../../renderers/xr-composite/README.md#server-mode---serve).
 
 ## Motivation
 

--- a/renderers/xr-composite/README.md
+++ b/renderers/xr-composite/README.md
@@ -3,8 +3,16 @@
 A small native (C++) tool that renders a **SpatialScene** — the `scene.json` +
 per-panel `<id>.png` textures emitted by `:renderer-xr` (see
 [`docs/design/SPATIAL_SCENE_CONTRACT.md`](../../docs/design/SPATIAL_SCENE_CONTRACT.md)) —
-into a single composite PNG: a baked still of the 3D spatial layout, the same
-scene the VS Code WebGL viewer shows interactively.
+into a composite PNG: a baked still of the 3D spatial layout, the same scene the
+VS Code WebGL viewer shows interactively.
+
+It runs two ways: **one-shot** (`--scene` → one PNG → exit) and a long-lived
+**server** (`--serve`) that speaks JSON-RPC over stdio, holds one Filament engine
+across frames, and streams rendered frames back as panels are updated per-frame —
+the first increment of the [renderer-service RFC](../../docs/design/xr-spatial/RENDERER_SERVICE.md).
+The `SpatialScene` types it parses are generated from
+[`schema/spatial-scene.schema.json`](../../schema/spatial-scene.schema.json) (see
+[`spatial_scene.hpp`](src/spatial_scene.hpp)).
 
 It exists because the still has to be produced **headless, with no GPU**, on
 ordinary CI. It uses [Filament](https://github.com/google/filament)'s OpenGL
@@ -14,8 +22,10 @@ binary rather than via JNI.
 
 > **Status: prototype.** The renderer is proven end-to-end (parses a real
 > `scene.json`, places a textured quad per panel, orbit camera, reads pixels to
-> PNG — all GPU-free in ~1s). It is **not yet wired into the Gradle pipeline**,
-> and only the Linux build is exercised. See "Roadmap" below.
+> PNG — all GPU-free in ~1s), and `--serve` adds a working per-frame JSON-RPC
+> server (CI-smoked). **Not yet daemon-fronted** — the daemon spawning/proxying
+> this process (RENDERER_SERVICE RFC) is the next step — and only the Linux build
+> is runtime-exercised. See "Roadmap" below.
 
 ## Build
 
@@ -46,6 +56,33 @@ xvfb-run -a -s "-screen 0 2000x1400x24" \
 
 `--scene` points at the `scene.json`; panel `texture` paths are resolved
 relative to its directory. A panel whose texture is missing is skipped.
+
+## Server mode (`--serve`)
+
+`--serve` turns the tool into a long-lived JSON-RPC peer over stdio, framed with LSP-style
+`Content-Length` headers — the same framing the daemon's subprocess render-session backend speaks, so
+the daemon can front it (RENDERER_SERVICE RFC). One Filament engine/scene is held for the life of the
+process; panels can be mutated per-frame and each render is streamed back.
+
+```sh
+xvfb-run -a -s "-screen 0 2000x1400x24" \
+  env LIBGL_ALWAYS_SOFTWARE=1 GALLIUM_DRIVER=llvmpipe \
+  ./build/xr-composite --serve --materials build/materials --width 1280 --height 800
+```
+
+Methods (all params are JSON):
+
+| method | params | effect |
+|--------|--------|--------|
+| `initialize` | `{frameStreamId?}` | returns `{serverInfo, capabilities}` (`render`/`updatePanels`/`streamFrame`, `spatialSceneVersion`, `dataProducts:["xr/composite"]`) |
+| `render` (alias `xr/render`) | `{scene: SpatialScene, sceneDir?, environment?, out?}` | (re)build the whole scene + camera, render; emits a `streamFrame`; `out` also writes a PNG file |
+| `xr/updatePanels` | `{panels: [{id, texture?, poseInRoot?, sizeDp?}], out?}` | mutate matching panels (or append a full new panel) and re-render; emits a `streamFrame` |
+| `shutdown` / `exit` | — | `shutdown` acks; `exit` ends the loop |
+
+Rendered frames are delivered as **`streamFrame` notifications** —
+`{encoding:"png", width, height, seq, data:<base64>, frameStreamId?}` — reusing the daemon's
+`composestream/1` shape (RFC decision #4: base64-over-JSON). The
+[`test/serve_smoke.py`](test/serve_smoke.py) harness drives this flow and is run in CI under Xvfb.
 
 ### Why Xvfb?
 
@@ -81,6 +118,7 @@ never fails and the interactive viewer + `scene.json` are unaffected.
 | `--materials <dir>` | directory with the compiled `.filamat` blobs | `.` |
 | `--width` / `--height` | output size in px | `1280` × `800` |
 | `--environment <preset\|color:#RRGGBB>` | backdrop override (see "Background"): a named preset, or `color:#RRGGBB` for a flat skybox. Overrides the scene's `environment`. | `warm-room` |
+| `--serve` | run as a long-lived JSON-RPC server over stdio instead of one-shot (see "Server mode"). `--scene`/`--out` are ignored. | off |
 
 ## Background (swappable presets)
 

--- a/renderers/xr-composite/src/main.cpp
+++ b/renderers/xr-composite/src/main.cpp
@@ -1,5 +1,12 @@
 // xr-composite — render a SpatialScene (scene.json + panel PNGs) to a composite PNG, headless.
 // Spike: Filament OpenGL backend on llvmpipe under Xvfb. No GPU required.
+//
+// Two modes:
+//   * one-shot (default): --scene scene.json --out composite.png → render once, exit.
+//   * server (--serve): a long-lived JSON-RPC peer over stdio (LSP-style Content-Length framing,
+//     the same framing the daemon's subprocess backend speaks). Holds one Filament Engine/Scene
+//     across frames so panels can be updated per-frame (`xr/updatePanels`) and rendered frames
+//     streamed back out (`streamFrame`). See docs/design/xr-spatial/RENDERER_SERVICE.md.
 
 // Third-party headers FIRST: Filament's utils/debug.h defines an `assert_invariant`
 // macro that otherwise clobbers nlohmann::json's member function of the same name.
@@ -42,10 +49,13 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <fstream>
+#include <iostream>
+#include <map>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -68,6 +78,7 @@ struct Args {
   uint32_t width = 1280;
   uint32_t height = 800;
   std::string environment;  // CLI override: a preset name, or "color:#RRGGBB"
+  bool serve = false;       // long-lived JSON-RPC server over stdio
 };
 
 std::vector<uint8_t> readFile(const std::string& path) {
@@ -203,6 +214,620 @@ const GradientPreset* findPreset(const std::string& name) {
   return nullptr;
 }
 
+// Standard base64 (RFC 4648) — the wire encoding for `streamFrame` PNG payloads. No padding tricks,
+// no line wrapping; small and dependency-free.
+std::string base64Encode(const uint8_t* data, size_t len) {
+  static const char* kT = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+  std::string out;
+  out.reserve(((len + 2) / 3) * 4);
+  size_t i = 0;
+  for (; i + 2 < len; i += 3) {
+    uint32_t n = (data[i] << 16) | (data[i + 1] << 8) | data[i + 2];
+    out.push_back(kT[(n >> 18) & 63]);
+    out.push_back(kT[(n >> 12) & 63]);
+    out.push_back(kT[(n >> 6) & 63]);
+    out.push_back(kT[n & 63]);
+  }
+  if (i < len) {
+    uint32_t n = data[i] << 16;
+    bool two = (i + 1 < len);
+    if (two) n |= data[i + 1] << 8;
+    out.push_back(kT[(n >> 18) & 63]);
+    out.push_back(kT[(n >> 12) & 63]);
+    out.push_back(two ? kT[(n >> 6) & 63] : '=');
+    out.push_back('=');
+  }
+  return out;
+}
+
+// Encode an RGBA buffer to PNG bytes in memory (stb writes via a callback rather than to a file).
+std::vector<uint8_t> encodePng(const std::vector<uint8_t>& rgba, uint32_t w, uint32_t h) {
+  std::vector<uint8_t> bytes;
+  stbi_write_png_to_func(
+      [](void* ctx, void* data, int size) {
+        auto* v = static_cast<std::vector<uint8_t>*>(ctx);
+        v->insert(v->end(), (uint8_t*)data, (uint8_t*)data + size);
+      },
+      &bytes, (int)w, (int)h, 4, rgba.data(), (int)w * 4);
+  return bytes;
+}
+
+// Holds the Filament render state across frames. Built once; `setScene` (re)builds the whole scene,
+// `applyPanelUpdates` mutates panel poses/textures in place and rebuilds just the panels, and
+// `renderPixels` reads back one frame. The one-shot path uses it for a single render; the server
+// reuses one instance for the life of the process.
+class Compositor {
+ public:
+  bool init(uint32_t w, uint32_t h, const std::string& materialsDir);
+  // Replace the whole scene (background + panels + camera). `envOverride` is the CLI `--environment`
+  // value (empty = none).
+  void setScene(const xrcomposite::SpatialScene& scene, const std::string& sceneDir,
+                const std::string& envOverride);
+  // Per-frame panel mutation: each entry is `{id, texture?, poseInRoot?, sizeDp?}`. Unknown ids are
+  // logged and skipped. Rebuilds the panel renderables (background/camera untouched).
+  void applyPanelUpdates(const json& panels);
+  std::vector<uint8_t> renderPixels();
+  bool writePng(const std::string& path);
+  uint32_t width() const { return W_; }
+  uint32_t height() const { return H_; }
+
+ private:
+  void resolveBackground(const std::string& envOverride);
+  void rebuildPanels();
+  void setupCamera();
+  void clearPanels();
+  utils::Entity buildQuad(float hw, float hh, MaterialInstance* mi);
+  Texture* loadTexture(const std::string& relTexture, const std::string& fallbackId);
+
+  Engine* engine_ = nullptr;
+  SwapChain* swapChain_ = nullptr;
+  Renderer* renderer_ = nullptr;
+  Scene* scene_ = nullptr;
+  View* view_ = nullptr;
+  Camera* camera_ = nullptr;
+  utils::Entity camEntity_;
+  Material* unlit_ = nullptr;
+  Material* shadowMat_ = nullptr;
+  Skybox* skybox_ = nullptr;
+  uint32_t W_ = 0, H_ = 0;
+  std::string materialsDir_;
+  std::string sceneDir_ = ".";
+  float3 bg_ = {0.06f, 0.06f, 0.08f};
+
+  xrcomposite::SpatialScene model_;  // current logical scene
+
+  // Per-rebuild Filament resources, torn down on the next rebuild.
+  std::vector<utils::Entity> panelEntities_;
+  std::vector<VertexBuffer*> vbs_;
+  std::vector<IndexBuffer*> ibs_;
+  std::vector<MaterialInstance*> mis_;
+  // Panel textures cached by resolved path so per-frame re-renders don't re-decode unchanged images.
+  std::map<std::string, Texture*> texCache_;
+};
+
+bool Compositor::init(uint32_t w, uint32_t h, const std::string& materialsDir) {
+  W_ = w;
+  H_ = h;
+  materialsDir_ = materialsDir.empty() ? "." : materialsDir;
+
+  engine_ = Engine::Builder().backend(backend::Backend::OPENGL).build();
+  if (!engine_) { fprintf(stderr, "engine create failed\n"); return false; }
+  swapChain_ = engine_->createSwapChain(W_, H_);
+  renderer_ = engine_->createRenderer();
+  scene_ = engine_->createScene();
+  view_ = engine_->createView();
+  camEntity_ = utils::EntityManager::get().create();
+  camera_ = engine_->createCamera(camEntity_);
+
+  view_->setScene(scene_);
+  view_->setCamera(camera_);
+  view_->setViewport({0, 0, W_, H_});
+
+  // faithful colors: linear tonemap (no filmic curve), keep post-processing for sRGB output + MSAA
+  static LinearToneMapper toneMapper;
+  ColorGrading* colorGrading = ColorGrading::Builder().toneMapper(&toneMapper).build(*engine_);
+  view_->setColorGrading(colorGrading);
+  view_->setPostProcessingEnabled(true);
+  {
+    MultiSampleAntiAliasingOptions msaa;
+    msaa.enabled = true;
+    msaa.sampleCount = 4;
+    view_->setMultiSampleAntiAliasingOptions(msaa);
+    view_->setAntiAliasing(View::AntiAliasing::FXAA);
+  }
+
+  auto unlitPkg = readFile(materialsDir_ + "/unlit_texture.filamat");
+  unlit_ = Material::Builder().package(unlitPkg.data(), unlitPkg.size()).build(*engine_);
+
+  // Soft contact shadow behind each panel — a separate transparent quad that feathers a rounded-rect
+  // silhouette. Real Filament shadows are unstable / expensive on llvmpipe, so we composite a baked
+  // soft shadow quad instead (deterministic, no shadow map, no GPU shadow pass).
+  auto shadowPkg = readFile(materialsDir_ + "/panel_shadow.filamat");
+  shadowMat_ = Material::Builder().package(shadowPkg.data(), shadowPkg.size()).build(*engine_);
+  return true;
+}
+
+void Compositor::resolveBackground(const std::string& envOverride) {
+  // The backdrop is a swappable, room-like vertical-gradient environment cubemap (HDRI-style
+  // ceiling/wall/floor) so the light Material panels pop. Selection precedence, most → least
+  // specific:
+  //   1. CLI `--environment <name>`     → a named preset (see kPresets)
+  //      CLI `--environment color:#RRGGBB` → a flat-colour skybox
+  //   2. scene `environment`:
+  //        kind=="color"                 → flat colour (uses `color`)
+  //        else                          → `preset` selects a named preset; explicit
+  //                                        `sky`/`horizon`/`floor`/`glow` OVERRIDE its values
+  //   3. Built-in default = `warm-room`.
+  // `bg_` doubles as the clear colour for the readback path.
+  bool wantColor = false;
+  float3 colorBg = {0.06f, 0.06f, 0.08f};
+
+  const GradientPreset* preset = findPreset(kDefaultPreset);
+  float3 gradSky = hexToLinear(preset->sky);
+  float3 gradHorizon = hexToLinear(preset->horizon);
+  float3 gradFloor = hexToLinear(preset->floor);
+  bool gradHasFloor = preset->hasFloor;
+  float gradGlow = preset->glow;
+
+  auto applyPreset = [&](const GradientPreset* p) {
+    gradSky = hexToLinear(p->sky);
+    gradHorizon = hexToLinear(p->horizon);
+    gradFloor = hexToLinear(p->floor);
+    gradHasFloor = p->hasFloor;
+    gradGlow = p->glow;
+  };
+
+  // (2) scene environment.
+  if (model_.environment) {
+    const auto& env = *model_.environment;
+    if (env.kind == "color") {
+      wantColor = true;
+      if (env.color) colorBg = hexToLinear(*env.color);
+    } else {
+      if (env.preset) {
+        if (const GradientPreset* p = findPreset(*env.preset)) applyPreset(p);
+        else fprintf(stderr, "unknown environment preset '%s'; using default\n", env.preset->c_str());
+      }
+      if (env.sky) gradSky = hexToLinear(*env.sky);
+      if (env.horizon) gradHorizon = hexToLinear(*env.horizon);
+      if (env.floor) {
+        gradFloor = hexToLinear(*env.floor);
+        gradHasFloor = true;
+      }
+      if (env.glow) gradGlow = static_cast<float>(*env.glow);
+    }
+  }
+
+  // (1) CLI override — highest precedence.
+  if (!envOverride.empty()) {
+    if (envOverride.rfind("color:", 0) == 0) {
+      wantColor = true;
+      colorBg = hexToLinear(envOverride.substr(6));
+    } else if (const GradientPreset* p = findPreset(envOverride)) {
+      wantColor = false;
+      applyPreset(p);
+    } else {
+      fprintf(stderr, "unknown --environment '%s'; using scene/default backdrop\n",
+              envOverride.c_str());
+    }
+  }
+
+  if (skybox_) {
+    scene_->setSkybox(nullptr);
+    engine_->destroy(skybox_);
+    skybox_ = nullptr;
+  }
+  if (wantColor) {
+    bg_ = colorBg;
+    skybox_ = Skybox::Builder().color({bg_.r, bg_.g, bg_.b, 1.0f}).build(*engine_);
+  } else {
+    bg_ = gradHorizon;  // clear colour mirrors the horizon so uncovered edges blend in
+    skybox_ = buildGradientSkybox(*engine_, gradSky, gradHorizon, gradFloor, gradHasFloor, gradGlow);
+    if (!skybox_) {
+      fprintf(stderr, "gradient skybox build failed; falling back to solid\n");
+      skybox_ = Skybox::Builder().color({bg_.r, bg_.g, bg_.b, 1.0f}).build(*engine_);
+    }
+  }
+  scene_->setSkybox(skybox_);
+}
+
+Texture* Compositor::loadTexture(const std::string& relTexture, const std::string& fallbackId) {
+  std::string texRel = relTexture.empty() ? (fallbackId + ".png") : relTexture;
+  std::string texPath = sceneDir_ + "/" + texRel;
+  auto it = texCache_.find(texPath);
+  if (it != texCache_.end()) return it->second;
+
+  // Filament readPixels on this swapchain is top-origin and UV0 (0,0) maps to the quad's
+  // bottom-left, so loading the PNG top-down (no stb flip) keeps panel content upright.
+  stbi_set_flip_vertically_on_load(false);
+  int tw, th, tn;
+  unsigned char* pix = stbi_load(texPath.c_str(), &tw, &th, &tn, 4);
+  if (!pix) {
+    fprintf(stderr, "  panel %s: no texture %s (skipped)\n", fallbackId.c_str(), texPath.c_str());
+    return nullptr;
+  }
+  size_t texBytes = (size_t)tw * th * 4;
+  Texture* tex = Texture::Builder()
+      .width(tw).height(th).levels(0xff)
+      .format(Texture::InternalFormat::SRGB8_A8)
+      .usage(Texture::Usage::SAMPLEABLE | Texture::Usage::UPLOADABLE |
+             Texture::Usage::GEN_MIPMAPPABLE)
+      .sampler(Texture::Sampler::SAMPLER_2D)
+      .build(*engine_);
+  Texture::PixelBufferDescriptor pbd(
+      pix, texBytes, Texture::Format::RGBA, Texture::Type::UBYTE,
+      [](void* buf, size_t, void*) { stbi_image_free(buf); }, nullptr);
+  tex->setImage(*engine_, 0, std::move(pbd));
+  tex->generateMipmaps(*engine_);
+  texCache_[texPath] = tex;
+  return tex;
+}
+
+// Build a textured/coloured quad renderable spanning [-hw,hw] x [-hh,hh] in the XY plane, UV0
+// running (0,0) bottom-left to (1,1) top-right. The GPU vertex/index buffers are tracked for teardown
+// on the next rebuild; their CPU backing is freed in the descriptor callbacks.
+utils::Entity Compositor::buildQuad(float hw, float hh, MaterialInstance* mi) {
+  auto* verts = new Vertex[4]{
+      {-hw, -hh, 0, 0, 0},
+      { hw, -hh, 0, 1, 0},
+      { hw,  hh, 0, 1, 1},
+      {-hw,  hh, 0, 0, 1},
+  };
+  auto* idx = new uint16_t[6]{0, 1, 2, 0, 2, 3};
+  VertexBuffer* vb = VertexBuffer::Builder()
+      .vertexCount(4).bufferCount(1)
+      .attribute(VertexAttribute::POSITION, 0, VertexBuffer::AttributeType::FLOAT3, 0, sizeof(Vertex))
+      .attribute(VertexAttribute::UV0, 0, VertexBuffer::AttributeType::FLOAT2, offsetof(Vertex, u), sizeof(Vertex))
+      .build(*engine_);
+  vb->setBufferAt(*engine_, 0, VertexBuffer::BufferDescriptor(
+      verts, sizeof(Vertex) * 4, [](void* p, size_t, void*) { delete[] (Vertex*)p; }));
+  IndexBuffer* ib = IndexBuffer::Builder()
+      .indexCount(6).bufferType(IndexBuffer::IndexType::USHORT).build(*engine_);
+  ib->setBuffer(*engine_, IndexBuffer::BufferDescriptor(
+      idx, sizeof(uint16_t) * 6, [](void* p, size_t, void*) { delete[] (uint16_t*)p; }));
+  utils::Entity e = utils::EntityManager::get().create();
+  RenderableManager::Builder(1)
+      .boundingBox({{-hw, -hh, -1.0f}, {hw, hh, 1.0f}})
+      .material(0, mi)
+      .geometry(0, RenderableManager::PrimitiveType::TRIANGLES, vb, ib, 0, 6)
+      .culling(false).castShadows(false).receiveShadows(false)
+      .build(*engine_, e);
+  vbs_.push_back(vb);
+  ibs_.push_back(ib);
+  return e;
+}
+
+void Compositor::clearPanels() {
+  for (auto e : panelEntities_) {
+    scene_->remove(e);
+    engine_->destroy(e);
+    utils::EntityManager::get().destroy(e);
+  }
+  for (auto* m : mis_) engine_->destroy(m);
+  for (auto* v : vbs_) engine_->destroy(v);
+  for (auto* i : ibs_) engine_->destroy(i);
+  panelEntities_.clear();
+  mis_.clear();
+  vbs_.clear();
+  ibs_.clear();
+}
+
+void Compositor::rebuildPanels() {
+  clearPanels();
+  auto& tcm = engine_->getTransformManager();
+  static TextureSampler sampler(TextureSampler::MinFilter::LINEAR_MIPMAP_LINEAR,
+                                TextureSampler::MagFilter::LINEAR);
+  int placed = 0;
+  for (const auto& panel : model_.panels) {
+    Texture* tex = loadTexture(panel.texture, panel.id);
+    if (!tex) continue;
+
+    float wDp = static_cast<float>(panel.sizeDp.width);
+    float hDp = static_cast<float>(panel.sizeDp.height);
+    float hw = wDp * 0.5f, hh = hDp * 0.5f;
+
+    // Fidelity params evaluated in an aspect-corrected "rect space" where the panel spans
+    // [-halfSize, halfSize] and rounded corners stay circular regardless of aspect (see the .mat).
+    float aspect = (hDp > 0.0f) ? (wDp / hDp) : 1.0f;
+    float2 halfSize = (wDp >= hDp) ? float2{aspect, 1.0f} : float2{1.0f, 1.0f / aspect};
+    const float kCornerRadius = 0.18f;
+    const float kRimWidth = 0.06f;
+    const float kRimStrength = 0.10f;
+    const float kEdgeSoftness = 0.012f;
+
+    MaterialInstance* mi = unlit_->createInstance();
+    mi->setParameter("albedo", tex, sampler);
+    mi->setParameter("halfSize", halfSize);
+    mi->setParameter("cornerRadius", kCornerRadius);
+    mi->setParameter("rimWidth", kRimWidth);
+    mi->setParameter("rimStrength", kRimStrength);
+    mi->setParameter("edgeSoftness", kEdgeSoftness);
+    mis_.push_back(mi);
+
+    // transform: translate * rotate(quat)
+    const auto& T = panel.poseInRoot.translation;
+    const auto& R = panel.poseInRoot.rotation;
+    float3 t = {static_cast<float>(T.x), static_cast<float>(T.y), static_cast<float>(T.z)};
+    quatf q = {static_cast<float>(R.w), static_cast<float>(R.x), static_cast<float>(R.y),
+               static_cast<float>(R.z)};
+    mat4f rot(q);
+
+    // ---- soft drop/contact shadow behind+below the panel ----
+    {
+      float dpPerUnitX = hw / halfSize.x;
+      float blurUnits = 0.22f;
+      float2 outerHalf = halfSize + float2{blurUnits, blurUnits};
+      float shw = outerHalf.x * dpPerUnitX;
+      float shh = outerHalf.y * dpPerUnitX;
+
+      MaterialInstance* smi = shadowMat_->createInstance();
+      smi->setParameter("halfSize", halfSize);
+      smi->setParameter("cornerRadius", kCornerRadius);
+      smi->setParameter("blur", blurUnits);
+      smi->setParameter("color", float4{0.0f, 0.0f, 0.0f, 0.42f});
+      mis_.push_back(smi);
+
+      utils::Entity se = buildQuad(shw, shh, smi);
+      float3 shadowOffset = {0.0f, -0.06f * hDp, -2.0f};
+      mat4f shadowModel = mat4f::translation(t) * rot * mat4f::translation(shadowOffset);
+      tcm.setTransform(tcm.getInstance(se), shadowModel);
+      scene_->addEntity(se);
+      panelEntities_.push_back(se);
+    }
+
+    utils::Entity re = buildQuad(hw, hh, mi);
+    mat4f model = mat4f::translation(t) * rot;
+    tcm.setTransform(tcm.getInstance(re), model);
+    scene_->addEntity(re);
+    panelEntities_.push_back(re);
+    placed++;
+    fprintf(stderr, "  panel %s: pos(%.0f,%.0f,%.0f) size %.0fx%.0f\n",
+            panel.id.c_str(), t.x, t.y, t.z, wDp, hDp);
+  }
+  fprintf(stderr, "placed %d panel(s)\n", placed);
+}
+
+void Compositor::setupCamera() {
+  const auto& cam = model_.camera;
+  float3 target = {static_cast<float>(cam.target.x), static_cast<float>(cam.target.y),
+                   static_cast<float>(cam.target.z)};
+  double distance = cam.distance;
+  double yaw = cam.yawDeg * kPi / 180.0;
+  double pitch = cam.pitchDeg * kPi / 180.0;
+  float3 dir = {(float)(std::cos(pitch) * std::sin(yaw)), (float)std::sin(pitch),
+                (float)(std::cos(pitch) * std::cos(yaw))};
+  float3 eye = target + dir * (float)distance;
+  camera_->lookAt(eye, target, {0, 1, 0});
+  double aspect = (double)W_ / (double)H_;
+  camera_->setProjection(45.0, aspect, 1.0, distance * 10.0 + 10000.0, Camera::Fov::VERTICAL);
+}
+
+void Compositor::setScene(const xrcomposite::SpatialScene& scene, const std::string& sceneDir,
+                          const std::string& envOverride) {
+  model_ = scene;
+  sceneDir_ = sceneDir.empty() ? "." : sceneDir;
+  resolveBackground(envOverride);
+  rebuildPanels();
+  setupCamera();
+}
+
+void Compositor::applyPanelUpdates(const json& panels) {
+  if (!panels.is_array()) return;
+  for (const auto& u : panels) {
+    if (!u.contains("id")) continue;
+    std::string id = u.at("id").get<std::string>();
+    auto it = std::find_if(model_.panels.begin(), model_.panels.end(),
+                           [&](const xrcomposite::SpatialPanel& p) { return p.id == id; });
+    if (it == model_.panels.end()) {
+      // A new panel: parse the whole entry and append (must carry the required fields).
+      try {
+        model_.panels.push_back(u.get<xrcomposite::SpatialPanel>());
+      } catch (const std::exception& e) {
+        fprintf(stderr, "updatePanels: unknown panel '%s' and not a full panel (%s)\n",
+                id.c_str(), e.what());
+      }
+      continue;
+    }
+    if (u.contains("texture")) it->texture = u.at("texture").get<std::string>();
+    if (u.contains("poseInRoot")) it->poseInRoot = u.at("poseInRoot").get<xrcomposite::SpatialPose>();
+    if (u.contains("sizeDp")) it->sizeDp = u.at("sizeDp").get<xrcomposite::SizeDp>();
+  }
+  rebuildPanels();
+}
+
+std::vector<uint8_t> Compositor::renderPixels() {
+  Renderer::ClearOptions co;
+  co.clear = true;
+  co.clearColor = {bg_.r, bg_.g, bg_.b, 1.0f};
+  renderer_->setClearOptions(co);
+
+  std::vector<uint8_t> pixels((size_t)W_ * H_ * 4);
+  struct Capture { bool done; } capture{false};
+  if (renderer_->beginFrame(swapChain_)) {
+    renderer_->render(view_);
+    backend::PixelBufferDescriptor pb(
+        pixels.data(), pixels.size(),
+        backend::PixelDataFormat::RGBA, backend::PixelDataType::UBYTE,
+        [](void*, size_t, void* user) { ((Capture*)user)->done = true; }, &capture);
+    renderer_->readPixels(0, 0, W_, H_, std::move(pb));
+    renderer_->endFrame();
+  } else {
+    fprintf(stderr, "beginFrame returned false\n");
+  }
+  engine_->flushAndWait();
+  return pixels;
+}
+
+bool Compositor::writePng(const std::string& path) {
+  auto pixels = renderPixels();
+  // Filament's readPixels here returns top-origin rows, matching PNG's top-left origin — no flip.
+  if (!stbi_write_png(path.c_str(), W_, H_, 4, pixels.data(), W_ * 4)) {
+    fprintf(stderr, "png write failed\n");
+    return false;
+  }
+  fprintf(stderr, "wrote %s (%ux%u)\n", path.c_str(), W_, H_);
+  return true;
+}
+
+// Directory containing a scene file (for resolving relative panel textures). A bare filename has no
+// '/', so default to ".".
+std::string dirOf(const std::string& path) {
+  auto slash = path.find_last_of('/');
+  return (slash == std::string::npos) ? "." : path.substr(0, slash);
+}
+
+// ---- JSON-RPC over stdio (LSP-style Content-Length framing) ----
+
+bool readMessage(std::string& body) {
+  size_t contentLength = 0;
+  std::string line;
+  bool sawHeader = false;
+  while (std::getline(std::cin, line)) {
+    if (!line.empty() && line.back() == '\r') line.pop_back();
+    if (line.empty()) {
+      if (sawHeader) break;  // blank line terminates headers
+      continue;              // tolerate leading blank lines
+    }
+    sawHeader = true;
+    auto colon = line.find(':');
+    if (colon != std::string::npos) {
+      std::string key = line.substr(0, colon);
+      std::string val = line.substr(colon + 1);
+      // trim leading spaces
+      size_t s = val.find_first_not_of(" \t");
+      if (s != std::string::npos) val = val.substr(s);
+      std::transform(key.begin(), key.end(), key.begin(), ::tolower);
+      if (key == "content-length") contentLength = std::stoul(val);
+    }
+  }
+  if (contentLength == 0) return false;  // EOF or framing end
+  body.resize(contentLength);
+  std::cin.read(&body[0], (std::streamsize)contentLength);
+  return (size_t)std::cin.gcount() == contentLength;
+}
+
+void writeMessage(const json& msg) {
+  std::string s = msg.dump();
+  std::cout << "Content-Length: " << s.size() << "\r\n\r\n" << s;
+  std::cout.flush();
+}
+
+void writeResult(const json& id, const json& result) {
+  writeMessage({{"jsonrpc", "2.0"}, {"id", id}, {"result", result}});
+}
+
+void writeError(const json& id, int code, const std::string& message) {
+  writeMessage({{"jsonrpc", "2.0"}, {"id", id}, {"error", {{"code", code}, {"message", message}}}});
+}
+
+// Emit one rendered frame as a `streamFrame` notification (base64 PNG), reusing the daemon's
+// composestream/1 shape. `seq` is a monotonic frame counter.
+void emitStreamFrame(Compositor& comp, uint64_t seq, const std::string& frameStreamId) {
+  auto pixels = comp.renderPixels();
+  auto png = encodePng(pixels, comp.width(), comp.height());
+  json params = {
+      {"encoding", "png"},
+      {"width", comp.width()},
+      {"height", comp.height()},
+      {"seq", seq},
+      {"data", base64Encode(png.data(), png.size())},
+  };
+  if (!frameStreamId.empty()) params["frameStreamId"] = frameStreamId;
+  writeMessage({{"jsonrpc", "2.0"}, {"method", "streamFrame"}, {"params", params}});
+}
+
+int runServer(const Args& args) {
+  Compositor comp;
+  if (!comp.init(args.width, args.height, args.materialsDir)) return 3;
+  fprintf(stderr, "xr-composite: serving on stdio (%ux%u)\n", args.width, args.height);
+
+  bool haveScene = false;
+  uint64_t seq = 0;
+  std::string frameStreamId;
+  std::string body;
+  while (readMessage(body)) {
+    json msg;
+    try {
+      msg = json::parse(body);
+    } catch (const std::exception& e) {
+      writeError(nullptr, -32700, std::string("parse error: ") + e.what());
+      continue;
+    }
+    json id = msg.contains("id") ? msg["id"] : json(nullptr);
+    std::string method = msg.value("method", "");
+    const json& params = msg.contains("params") ? msg["params"] : json::object();
+
+    if (method == "initialize") {
+      frameStreamId = params.value("frameStreamId", "");
+      writeResult(id, {
+          {"serverInfo", {{"name", "xr-composite"}, {"version", 1}}},
+          {"capabilities", {
+              {"render", true},
+              {"updatePanels", true},
+              {"streamFrame", true},
+              {"spatialSceneVersion", xrcomposite::SPATIAL_SCENE_VERSION},
+              {"dataProducts", json::array({"xr/composite"})},
+          }},
+      });
+    } else if (method == "render" || method == "xr/render") {
+      try {
+        auto scene = params.at("scene").get<xrcomposite::SpatialScene>();
+        std::string sceneDir = params.value("sceneDir", ".");
+        std::string envOverride = params.value("environment", "");
+        comp.setScene(scene, sceneDir, envOverride);
+        haveScene = true;
+        if (params.contains("out")) comp.writePng(params.at("out").get<std::string>());
+        emitStreamFrame(comp, ++seq, frameStreamId);
+        if (!id.is_null()) writeResult(id, {{"ok", true}, {"seq", seq},
+                                            {"width", comp.width()}, {"height", comp.height()}});
+      } catch (const std::exception& e) {
+        if (!id.is_null()) writeError(id, -32602, std::string("render failed: ") + e.what());
+      }
+    } else if (method == "xr/updatePanels") {
+      if (!haveScene) {
+        if (!id.is_null()) writeError(id, -32002, "no scene: call render first");
+        continue;
+      }
+      try {
+        if (params.contains("panels")) comp.applyPanelUpdates(params.at("panels"));
+        if (params.contains("out")) comp.writePng(params.at("out").get<std::string>());
+        emitStreamFrame(comp, ++seq, frameStreamId);
+        if (!id.is_null()) writeResult(id, {{"ok", true}, {"seq", seq}});
+      } catch (const std::exception& e) {
+        if (!id.is_null()) writeError(id, -32602, std::string("updatePanels failed: ") + e.what());
+      }
+    } else if (method == "shutdown") {
+      if (!id.is_null()) writeResult(id, json::object());
+    } else if (method == "exit") {
+      break;
+    } else if (!method.empty()) {
+      if (!id.is_null()) writeError(id, -32601, "unknown method: " + method);
+    }
+  }
+  fprintf(stderr, "xr-composite: stdio closed, exiting\n");
+  fflush(stderr);
+  // Skip Filament teardown (asserts on destroy order); the process exits here.
+  std::_Exit(0);
+}
+
+int runOneShot(const Args& args) {
+  xrcomposite::SpatialScene scene;
+  {
+    std::ifstream f(args.scenePath);
+    json raw;
+    f >> raw;
+    scene = raw.get<xrcomposite::SpatialScene>();
+  }
+  Compositor comp;
+  if (!comp.init(args.width, args.height, args.materialsDir)) return 3;
+  comp.setScene(scene, dirOf(args.scenePath), args.environment);
+  if (!comp.writePng(args.outPath)) return 4;
+  fflush(stderr);
+  // std::_Exit terminates without running destructors/atexit (portable equivalent of POSIX _exit);
+  // avoids Filament's teardown-order asserts on all platforms.
+  std::_Exit(0);
+}
+
 }  // namespace
 
 int main(int argc, char** argv) {
@@ -216,335 +841,15 @@ int main(int argc, char** argv) {
     else if (a == "--width") args.width = std::stoul(next());
     else if (a == "--height") args.height = std::stoul(next());
     else if (a == "--environment") args.environment = next();
+    else if (a == "--serve") args.serve = true;
   }
-  if (args.scenePath.empty()) { fprintf(stderr, "usage: --scene scene.json --out out.png\n"); return 2; }
-  // A bare filename (no '/') means the scene lives in the current directory; find_last_of
-  // returns npos there, so default to "." rather than treating the filename as the directory.
-  auto slash = args.scenePath.find_last_of('/');
-  args.sceneDir = (slash == std::string::npos) ? "." : args.scenePath.substr(0, slash);
   if (args.materialsDir.empty()) args.materialsDir = ".";
 
-  // ---- parse scene.json (typed via the generated SpatialScene mirror) ----
-  xrcomposite::SpatialScene scene;
-  {
-    std::ifstream f(args.scenePath);
-    json raw;
-    f >> raw;
-    scene = raw.get<xrcomposite::SpatialScene>();
+  if (args.serve) return runServer(args);
+
+  if (args.scenePath.empty()) {
+    fprintf(stderr, "usage: --scene scene.json --out out.png   (or --serve for JSON-RPC stdio)\n");
+    return 2;
   }
-
-  const uint32_t W = args.width, H = args.height;
-
-  // ---- engine / render targets ----
-  Engine* engine = Engine::Builder().backend(backend::Backend::OPENGL).build();
-  if (!engine) { fprintf(stderr, "engine create failed\n"); return 3; }
-  SwapChain* swapChain = engine->createSwapChain(W, H);
-  Renderer* renderer = engine->createRenderer();
-  Scene* fscene = engine->createScene();
-  View* view = engine->createView();
-  utils::Entity camEntity = utils::EntityManager::get().create();
-  Camera* camera = engine->createCamera(camEntity);
-
-  view->setScene(fscene);
-  view->setCamera(camera);
-  view->setViewport({0, 0, W, H});
-
-  // faithful colors: linear tonemap (no filmic curve), keep post-processing for sRGB output + MSAA
-  LinearToneMapper toneMapper;
-  ColorGrading* colorGrading = ColorGrading::Builder().toneMapper(&toneMapper).build(*engine);
-  view->setColorGrading(colorGrading);
-  view->setPostProcessingEnabled(true);
-  {
-    MultiSampleAntiAliasingOptions msaa;
-    msaa.enabled = true;
-    msaa.sampleCount = 4;
-    view->setMultiSampleAntiAliasingOptions(msaa);
-    view->setAntiAliasing(View::AntiAliasing::FXAA);
-  }
-
-  // ---- background ----
-  // The backdrop is a swappable, room-like vertical-gradient environment cubemap (HDRI-style
-  // ceiling/wall/floor) so the light Material panels pop. Selection precedence, most → least
-  // specific:
-  //   1. CLI `--environment <name>`     → a named preset (see kPresets)
-  //      CLI `--environment color:#RRGGBB` → a flat-colour skybox
-  //   2. scene.json `environment`:
-  //        kind=="color"                 → flat colour (uses `color`)
-  //        else                          → `preset` selects a named preset; explicit
-  //                                        `sky`/`horizon`/`floor`/`glow` OVERRIDE its values
-  //        (legacy scenes with kind=="gradient" + sky/horizon still render: a custom-gradient
-  //         override on top of the default preset)
-  //   3. Built-in default = `warm-room`.
-  // `bg` doubles as the clear colour for the readback path: it mirrors the horizon in gradient mode
-  // and the colour in colour mode, so any uncovered edge blends with the backdrop.
-  bool wantColor = false;       // resolved as a flat-colour skybox?
-  float3 colorBg = {0.06f, 0.06f, 0.08f};
-
-  // Start from the default preset, then layer overrides on top.
-  const GradientPreset* preset = findPreset(kDefaultPreset);
-  float3 gradSky = hexToLinear(preset->sky);
-  float3 gradHorizon = hexToLinear(preset->horizon);
-  float3 gradFloor = hexToLinear(preset->floor);
-  bool gradHasFloor = preset->hasFloor;
-  float gradGlow = preset->glow;
-
-  // Applies a named preset's params over the current gradient state.
-  auto applyPreset = [&](const GradientPreset* p) {
-    gradSky = hexToLinear(p->sky);
-    gradHorizon = hexToLinear(p->horizon);
-    gradFloor = hexToLinear(p->floor);
-    gradHasFloor = p->hasFloor;
-    gradGlow = p->glow;
-  };
-
-  // (2) scene.json environment.
-  if (scene.environment) {
-    const auto& env = *scene.environment;
-    if (env.kind == "color") {
-      wantColor = true;
-      if (env.color) colorBg = hexToLinear(*env.color);
-    } else {
-      if (env.preset) {
-        if (const GradientPreset* p = findPreset(*env.preset)) applyPreset(p);
-        else fprintf(stderr, "unknown environment preset '%s'; using default\n",
-                     env.preset->c_str());
-      }
-      // Explicit fields override the chosen preset (custom gradient).
-      if (env.sky) gradSky = hexToLinear(*env.sky);
-      if (env.horizon) gradHorizon = hexToLinear(*env.horizon);
-      if (env.floor) {
-        gradFloor = hexToLinear(*env.floor);
-        gradHasFloor = true;
-      }
-      if (env.glow) gradGlow = static_cast<float>(*env.glow);
-    }
-  }
-
-  // (1) CLI override — highest precedence, wins over scene.json.
-  if (!args.environment.empty()) {
-    const std::string& e = args.environment;
-    if (e.rfind("color:", 0) == 0) {
-      wantColor = true;
-      colorBg = hexToLinear(e.substr(6));
-    } else if (const GradientPreset* p = findPreset(e)) {
-      wantColor = false;
-      applyPreset(p);
-    } else {
-      fprintf(stderr, "unknown --environment '%s'; using scene/default backdrop\n", e.c_str());
-    }
-  }
-
-  float3 bg;
-  Skybox* skybox = nullptr;
-  if (wantColor) {
-    bg = colorBg;
-    skybox = Skybox::Builder().color({bg.r, bg.g, bg.b, 1.0f}).build(*engine);
-  } else {
-    // Clear colour mirrors the horizon so any uncovered edge blends with the gradient.
-    bg = gradHorizon;
-    skybox = buildGradientSkybox(*engine, gradSky, gradHorizon, gradFloor, gradHasFloor, gradGlow);
-    if (!skybox) {
-      // Fall back to a flat horizon-coloured skybox if the cubemap couldn't be built.
-      fprintf(stderr, "gradient skybox build failed; falling back to solid\n");
-      skybox = Skybox::Builder().color({bg.r, bg.g, bg.b, 1.0f}).build(*engine);
-    }
-  }
-  fscene->setSkybox(skybox);
-
-  // ---- material ----
-  auto unlitPkg = readFile(args.materialsDir + "/unlit_texture.filamat");
-  Material* unlit = Material::Builder().package(unlitPkg.data(), unlitPkg.size()).build(*engine);
-
-  // Soft contact shadow behind each panel — a separate transparent quad that feathers a rounded-rect
-  // silhouette. Real Filament shadows are unstable / expensive on llvmpipe, so we composite a baked
-  // soft shadow quad instead (deterministic, no shadow map, no GPU shadow pass).
-  auto shadowPkg = readFile(args.materialsDir + "/panel_shadow.filamat");
-  Material* shadowMat =
-      Material::Builder().package(shadowPkg.data(), shadowPkg.size()).build(*engine);
-
-  TextureSampler sampler(TextureSampler::MinFilter::LINEAR_MIPMAP_LINEAR,
-                         TextureSampler::MagFilter::LINEAR);
-
-  auto& tcm = engine->getTransformManager();
-
-  // Build a textured/coloured quad renderable spanning [-hw,hw] x [-hh,hh] in the XY plane, UV0
-  // running (0,0) bottom-left to (1,1) top-right. Heap-allocates the vertex/index buffers and frees
-  // them in the descriptor callbacks (Filament reads them on the driver thread during flushAndWait).
-  auto buildQuad = [&](float hw, float hh, MaterialInstance* mi) -> utils::Entity {
-    auto* verts = new Vertex[4]{
-        {-hw, -hh, 0, 0, 0},
-        { hw, -hh, 0, 1, 0},
-        { hw,  hh, 0, 1, 1},
-        {-hw,  hh, 0, 0, 1},
-    };
-    auto* idx = new uint16_t[6]{0, 1, 2, 0, 2, 3};
-    VertexBuffer* vb = VertexBuffer::Builder()
-        .vertexCount(4).bufferCount(1)
-        .attribute(VertexAttribute::POSITION, 0, VertexBuffer::AttributeType::FLOAT3, 0, sizeof(Vertex))
-        .attribute(VertexAttribute::UV0, 0, VertexBuffer::AttributeType::FLOAT2, offsetof(Vertex, u), sizeof(Vertex))
-        .build(*engine);
-    vb->setBufferAt(*engine, 0, VertexBuffer::BufferDescriptor(
-        verts, sizeof(Vertex) * 4, [](void* p, size_t, void*) { delete[] (Vertex*)p; }));
-    IndexBuffer* ib = IndexBuffer::Builder()
-        .indexCount(6).bufferType(IndexBuffer::IndexType::USHORT).build(*engine);
-    ib->setBuffer(*engine, IndexBuffer::BufferDescriptor(
-        idx, sizeof(uint16_t) * 6, [](void* p, size_t, void*) { delete[] (uint16_t*)p; }));
-    utils::Entity e = utils::EntityManager::get().create();
-    RenderableManager::Builder(1)
-        .boundingBox({{-hw, -hh, -1.0f}, {hw, hh, 1.0f}})
-        .material(0, mi)
-        .geometry(0, RenderableManager::PrimitiveType::TRIANGLES, vb, ib, 0, 6)
-        .culling(false).castShadows(false).receiveShadows(false)
-        .build(*engine, e);
-    return e;
-  };
-
-  // ---- panels ----
-  int placed = 0;
-  for (const auto& panel : scene.panels) {
-    const std::string& id = panel.id;
-    std::string texRel = panel.texture.empty() ? (id + ".png") : panel.texture;
-    std::string texPath = args.sceneDir + "/" + texRel;
-
-    // Filament readPixels on this swapchain is top-origin and UV0 (0,0) maps to the quad's
-    // bottom-left, so loading the PNG top-down (no stb flip) keeps panel content upright.
-    stbi_set_flip_vertically_on_load(false);
-    int tw, th, tn;
-    unsigned char* pix = stbi_load(texPath.c_str(), &tw, &th, &tn, 4);
-    if (!pix) { fprintf(stderr, "  panel %s: no texture %s (skipped)\n", id.c_str(), texPath.c_str()); continue; }
-
-    size_t texBytes = (size_t)tw * th * 4;
-    Texture* tex = Texture::Builder()
-        .width(tw).height(th).levels(0xff)
-        .format(Texture::InternalFormat::SRGB8_A8)
-        .usage(Texture::Usage::SAMPLEABLE | Texture::Usage::UPLOADABLE |
-               Texture::Usage::GEN_MIPMAPPABLE)
-        .sampler(Texture::Sampler::SAMPLER_2D)
-        .build(*engine);
-    Texture::PixelBufferDescriptor pbd(
-        pix, texBytes, Texture::Format::RGBA, Texture::Type::UBYTE,
-        [](void* buf, size_t, void*) { stbi_image_free(buf); }, nullptr);
-    tex->setImage(*engine, 0, std::move(pbd));
-    tex->generateMipmaps(*engine);
-
-    float wDp = static_cast<float>(panel.sizeDp.width);
-    float hDp = static_cast<float>(panel.sizeDp.height);
-    float hw = wDp * 0.5f, hh = hDp * 0.5f;
-
-    // Fidelity params evaluated in an aspect-corrected "rect space" where the panel spans
-    // [-halfSize, halfSize] and rounded corners stay circular regardless of aspect (see the .mat).
-    // For w>=h: halfSize=(aspect,1); else (1,1/aspect). Radius/rim/softness are fractions of the
-    // shorter half-extent (always 1.0), so they read consistently across panel shapes.
-    float aspect = (hDp > 0.0f) ? (wDp / hDp) : 1.0f;
-    float2 halfSize = (wDp >= hDp) ? float2{aspect, 1.0f} : float2{1.0f, 1.0f / aspect};
-    // ~24-32dp corner radius on a typical ~320dp-tall panel ≈ 0.16-0.20 of the half-extent.
-    const float kCornerRadius = 0.18f;
-    const float kRimWidth = 0.06f;     // rim band width inside the edge
-    const float kRimStrength = 0.10f;  // subtle additive highlight
-    const float kEdgeSoftness = 0.012f;  // AA feather of the rounded edge
-
-    MaterialInstance* mi = unlit->createInstance();
-    mi->setParameter("albedo", tex, sampler);
-    mi->setParameter("halfSize", halfSize);
-    mi->setParameter("cornerRadius", kCornerRadius);
-    mi->setParameter("rimWidth", kRimWidth);
-    mi->setParameter("rimStrength", kRimStrength);
-    mi->setParameter("edgeSoftness", kEdgeSoftness);
-
-    // transform: translate * rotate(quat)
-    const auto& T = panel.poseInRoot.translation;
-    const auto& R = panel.poseInRoot.rotation;
-    float3 t = {static_cast<float>(T.x), static_cast<float>(T.y), static_cast<float>(T.z)};
-    quatf q = {static_cast<float>(R.w), static_cast<float>(R.x), static_cast<float>(R.y),
-               static_cast<float>(R.z)};
-    mat4f rot(q);
-
-    // ---- soft drop/contact shadow behind+below the panel ----
-    // Mirror the panel's rect-space metrics so the shadow silhouette matches the rounded panel, then
-    // map the aspect-corrected units back to dp via the per-axis dp-per-unit scale. The shadow quad
-    // is inflated by `blur` so its feathered penumbra has room; it sits slightly behind the panel
-    // (toward -Z in panel-local space) and is offset down a touch for a grounded, floating look.
-    {
-      float dpPerUnitX = hw / halfSize.x;   // == hh / halfSize.y
-      float blurUnits = 0.22f;              // penumbra width in rect-space units
-      float2 outerHalf = halfSize + float2{blurUnits, blurUnits};
-      float shw = outerHalf.x * dpPerUnitX;
-      float shh = outerHalf.y * dpPerUnitX;
-
-      MaterialInstance* smi = shadowMat->createInstance();
-      smi->setParameter("halfSize", halfSize);
-      smi->setParameter("cornerRadius", kCornerRadius);
-      smi->setParameter("blur", blurUnits);
-      // Soft near-black shadow; peak alpha kept subtle so it reads as a contact shadow, not a slab.
-      smi->setParameter("color", float4{0.0f, 0.0f, 0.0f, 0.42f});
-
-      utils::Entity se = buildQuad(shw, shh, smi);
-      // Offset: down by ~6% of panel height and back behind the panel so it never z-fights the quad.
-      float3 shadowOffset = {0.0f, -0.06f * hDp, -2.0f};
-      mat4f shadowModel = mat4f::translation(t) * rot * mat4f::translation(shadowOffset);
-      tcm.setTransform(tcm.getInstance(se), shadowModel);
-      fscene->addEntity(se);
-    }
-
-    utils::Entity re = buildQuad(hw, hh, mi);
-    mat4f model = mat4f::translation(t) * rot;
-    tcm.setTransform(tcm.getInstance(re), model);
-
-    fscene->addEntity(re);
-    placed++;
-    fprintf(stderr, "  panel %s: pos(%.0f,%.0f,%.0f) size %.0fx%.0f tex %dx%d\n",
-            id.c_str(), t.x, t.y, t.z, wDp, hDp, tw, th);
-  }
-  fprintf(stderr, "placed %d panel(s)\n", placed);
-
-  // ---- camera (orbit) ----
-  const auto& cam = scene.camera;
-  float3 target = {static_cast<float>(cam.target.x), static_cast<float>(cam.target.y),
-                   static_cast<float>(cam.target.z)};
-  double distance = cam.distance;
-  double yaw = cam.yawDeg * kPi / 180.0;
-  double pitch = cam.pitchDeg * kPi / 180.0;
-  float3 dir = {(float)(std::cos(pitch) * std::sin(yaw)), (float)std::sin(pitch),
-                (float)(std::cos(pitch) * std::cos(yaw))};
-  float3 eye = target + dir * (float)distance;
-  fprintf(stderr, "camera eye(%.0f,%.0f,%.0f) -> target(%.0f,%.0f,%.0f) dist %.0f\n",
-          eye.x, eye.y, eye.z, target.x, target.y, target.z, distance);
-  camera->lookAt(eye, target, {0, 1, 0});
-  double aspect = (double)W / (double)H;
-  camera->setProjection(45.0, aspect, 1.0, distance * 10.0 + 10000.0, Camera::Fov::VERTICAL);
-
-  // ---- render + readback ----
-  Renderer::ClearOptions co;
-  co.clear = true;
-  co.clearColor = {bg.r, bg.g, bg.b, 1.0f};
-  renderer->setClearOptions(co);
-
-  std::vector<uint8_t> pixels(W * H * 4);
-  struct Capture { uint8_t* dst; size_t size; bool done; } capture{pixels.data(), pixels.size(), false};
-
-  if (renderer->beginFrame(swapChain)) {
-    renderer->render(view);
-    backend::PixelBufferDescriptor pb(
-        pixels.data(), pixels.size(),
-        backend::PixelDataFormat::RGBA, backend::PixelDataType::UBYTE,
-        [](void*, size_t, void* user) { ((Capture*)user)->done = true; }, &capture);
-    renderer->readPixels(0, 0, W, H, std::move(pb));
-    renderer->endFrame();
-  } else {
-    fprintf(stderr, "beginFrame returned false\n");
-  }
-  engine->flushAndWait();
-
-  // Filament's readPixels here returns top-origin rows, matching PNG's top-left origin — no flip.
-  if (!stbi_write_png(args.outPath.c_str(), W, H, 4, pixels.data(), W * 4)) {
-    fprintf(stderr, "png write failed\n");
-    return 4;
-  }
-  fprintf(stderr, "wrote %s (%ux%u)\n", args.outPath.c_str(), W, H);
-
-  // Spike: skip explicit Filament teardown (asserts on destroy order); the process exits here.
-  fflush(stderr);
-  // std::_Exit terminates without running destructors/atexit (portable equivalent
-  // of POSIX _exit); avoids Filament's teardown-order asserts on all platforms.
-  std::_Exit(0);
+  return runOneShot(args);
 }

--- a/renderers/xr-composite/src/main.cpp
+++ b/renderers/xr-composite/src/main.cpp
@@ -4,6 +4,7 @@
 // Third-party headers FIRST: Filament's utils/debug.h defines an `assert_invariant`
 // macro that otherwise clobbers nlohmann::json's member function of the same name.
 #include "json.hpp"
+#include "spatial_scene.hpp"  // generated typed mirror of the SpatialScene wire contract
 #define STB_IMAGE_IMPLEMENTATION
 #include "stb_image.h"
 #define STB_IMAGE_WRITE_IMPLEMENTATION
@@ -223,9 +224,14 @@ int main(int argc, char** argv) {
   args.sceneDir = (slash == std::string::npos) ? "." : args.scenePath.substr(0, slash);
   if (args.materialsDir.empty()) args.materialsDir = ".";
 
-  // ---- parse scene.json ----
-  json scene;
-  { std::ifstream f(args.scenePath); f >> scene; }
+  // ---- parse scene.json (typed via the generated SpatialScene mirror) ----
+  xrcomposite::SpatialScene scene;
+  {
+    std::ifstream f(args.scenePath);
+    json raw;
+    f >> raw;
+    scene = raw.get<xrcomposite::SpatialScene>();
+  }
 
   const uint32_t W = args.width, H = args.height;
 
@@ -292,26 +298,25 @@ int main(int argc, char** argv) {
   };
 
   // (2) scene.json environment.
-  if (scene.contains("environment") && scene["environment"].is_object()) {
-    auto& env = scene["environment"];
-    std::string kind = env.value("kind", "gradient");
-    if (kind == "color") {
+  if (scene.environment) {
+    const auto& env = *scene.environment;
+    if (env.kind == "color") {
       wantColor = true;
-      if (env.contains("color")) colorBg = hexToLinear(env["color"].get<std::string>());
+      if (env.color) colorBg = hexToLinear(*env.color);
     } else {
-      if (env.contains("preset")) {
-        if (const GradientPreset* p = findPreset(env["preset"].get<std::string>())) applyPreset(p);
+      if (env.preset) {
+        if (const GradientPreset* p = findPreset(*env.preset)) applyPreset(p);
         else fprintf(stderr, "unknown environment preset '%s'; using default\n",
-                     env["preset"].get<std::string>().c_str());
+                     env.preset->c_str());
       }
       // Explicit fields override the chosen preset (custom gradient).
-      if (env.contains("sky")) gradSky = hexToLinear(env["sky"].get<std::string>());
-      if (env.contains("horizon")) gradHorizon = hexToLinear(env["horizon"].get<std::string>());
-      if (env.contains("floor")) {
-        gradFloor = hexToLinear(env["floor"].get<std::string>());
+      if (env.sky) gradSky = hexToLinear(*env.sky);
+      if (env.horizon) gradHorizon = hexToLinear(*env.horizon);
+      if (env.floor) {
+        gradFloor = hexToLinear(*env.floor);
         gradHasFloor = true;
       }
-      if (env.contains("glow")) gradGlow = env["glow"].get<float>();
+      if (env.glow) gradGlow = static_cast<float>(*env.glow);
     }
   }
 
@@ -396,9 +401,9 @@ int main(int argc, char** argv) {
 
   // ---- panels ----
   int placed = 0;
-  for (auto& p : scene["panels"]) {
-    std::string id = p.value("id", "panel");
-    std::string texRel = p.value("texture", id + ".png");
+  for (const auto& panel : scene.panels) {
+    const std::string& id = panel.id;
+    std::string texRel = panel.texture.empty() ? (id + ".png") : panel.texture;
     std::string texPath = args.sceneDir + "/" + texRel;
 
     // Filament readPixels on this swapchain is top-origin and UV0 (0,0) maps to the quad's
@@ -422,8 +427,8 @@ int main(int argc, char** argv) {
     tex->setImage(*engine, 0, std::move(pbd));
     tex->generateMipmaps(*engine);
 
-    float wDp = p["sizeDp"].value("width", 100);
-    float hDp = p["sizeDp"].value("height", 100);
+    float wDp = static_cast<float>(panel.sizeDp.width);
+    float hDp = static_cast<float>(panel.sizeDp.height);
     float hw = wDp * 0.5f, hh = hDp * 0.5f;
 
     // Fidelity params evaluated in an aspect-corrected "rect space" where the panel spans
@@ -447,10 +452,11 @@ int main(int argc, char** argv) {
     mi->setParameter("edgeSoftness", kEdgeSoftness);
 
     // transform: translate * rotate(quat)
-    auto& T = p["poseInRoot"]["translation"];
-    auto& R = p["poseInRoot"]["rotation"];
-    float3 t = {T.value("x", 0.0f), T.value("y", 0.0f), T.value("z", 0.0f)};
-    quatf q = {R.value("w", 1.0f), R.value("x", 0.0f), R.value("y", 0.0f), R.value("z", 0.0f)};
+    const auto& T = panel.poseInRoot.translation;
+    const auto& R = panel.poseInRoot.rotation;
+    float3 t = {static_cast<float>(T.x), static_cast<float>(T.y), static_cast<float>(T.z)};
+    quatf q = {static_cast<float>(R.w), static_cast<float>(R.x), static_cast<float>(R.y),
+               static_cast<float>(R.z)};
     mat4f rot(q);
 
     // ---- soft drop/contact shadow behind+below the panel ----
@@ -492,12 +498,12 @@ int main(int argc, char** argv) {
   fprintf(stderr, "placed %d panel(s)\n", placed);
 
   // ---- camera (orbit) ----
-  auto& cam = scene["camera"];
-  float3 target = {cam["target"].value("x", 0.0f), cam["target"].value("y", 0.0f),
-                   cam["target"].value("z", 0.0f)};
-  double distance = cam.value("distance", 1200.0);
-  double yaw = cam.value("yawDeg", 0.0) * kPi / 180.0;
-  double pitch = cam.value("pitchDeg", -10.0) * kPi / 180.0;
+  const auto& cam = scene.camera;
+  float3 target = {static_cast<float>(cam.target.x), static_cast<float>(cam.target.y),
+                   static_cast<float>(cam.target.z)};
+  double distance = cam.distance;
+  double yaw = cam.yawDeg * kPi / 180.0;
+  double pitch = cam.pitchDeg * kPi / 180.0;
   float3 dir = {(float)(std::cos(pitch) * std::sin(yaw)), (float)std::sin(pitch),
                 (float)(std::cos(pitch) * std::cos(yaw))};
   float3 eye = target + dir * (float)distance;

--- a/renderers/xr-composite/src/spatial_scene.hpp
+++ b/renderers/xr-composite/src/spatial_scene.hpp
@@ -1,0 +1,316 @@
+// GENERATED FILE — DO NOT EDIT.
+// Source of truth: schema/spatial-scene.schema.json
+// Regenerate: node scripts/codegen/gen-spatial-scene.mjs (CI checks with --check).
+
+#pragma once
+
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "json.hpp"
+
+namespace xrcomposite {
+
+using nlohmann::json;
+
+/**
+ * The wire contract between the offline renderer (producer) and the webview's 3D spatial-layout viewer (consumer). All linear quantities are dp; axes are right-handed (+x right, +y up, +z toward the viewer); rotation is a unit quaternion. Prose spec: docs/design/SPATIAL_SCENE_CONTRACT.md.
+ */
+constexpr int SPATIAL_SCENE_VERSION = 1;
+
+/**
+ * A point or vector, in dp.
+ */
+struct Vec3 {
+  double x;
+  double y;
+  double z;
+};
+
+/**
+ * A unit quaternion; identity is `(0, 0, 0, 1)`.
+ */
+struct Quat {
+  double x;
+  double y;
+  double z;
+  double w;
+};
+
+/**
+ * A rigid transform in the subspace root's frame: `translation` in dp, `rotation` a unit
+ * quaternion.
+ */
+struct SpatialPose {
+  Vec3 translation;
+  Quat rotation;
+};
+
+/**
+ * Panel extent in dp (the layout output, not the texture's pixel size).
+ */
+struct SizeDp {
+  int width;
+  int height;
+};
+
+/**
+ * A spatial panel: a flat quad hosting 2D Compose content.
+ */
+struct SpatialPanel {
+  std::string id;
+  /**
+   * Human-readable label for overlays; not required for rendering.
+   */
+  std::optional<std::string> label;
+  SpatialPose poseInRoot;
+  SizeDp sizeDp;
+  /**
+   * Path to the panel's 2D-content PNG, relative to the scene file (or a resolvable URI).
+   */
+  std::string texture;
+  /**
+   * Id of the containing panel/group, or null/omitted for top-level panels.
+   */
+  std::optional<std::string> parentId;
+};
+
+/**
+ * An Orbiter affordance — a control strip anchored to a panel edge. `edge` is
+ * top/bottom/start/end.
+ */
+struct OrbiterAffordance {
+  std::string id;
+  std::optional<std::string> label;
+  std::string edge;
+  SpatialPose poseInRoot;
+  SizeDp sizeDp;
+  std::string texture;
+};
+
+/**
+ * Default viewing camera. Only `kind = "orbit"` is defined today.
+ */
+struct OrbitCamera {
+  std::string kind = "orbit";
+  /**
+   * Look-at point in dp.
+   */
+  Vec3 target;
+  /**
+   * Camera distance from `target`, in dp.
+   */
+  double distance;
+  double yawDeg;
+  double pitchDeg;
+};
+
+/**
+ * Optional scene backdrop. `kind` is "color" (`#RRGGBB` in [color]) or "skybox" ([texture]).
+ *
+ * For gradient backdrops (any `kind` other than "color"), the offline compositor supports **named
+ * presets** ([preset], e.g. `"warm-room"` — the default — or `"studio-dark"`) plus explicit
+ * gradient stops that **override** the chosen preset: [sky] (straight up), [horizon] (eye level),
+ * and [floor] (straight down; its presence turns the 2-stop gradient into a 3-stop, room-like one).
+ * These knobs are optional; omit them to take the compositor's default `warm-room` backdrop. The
+ * compositor's `--environment` CLI flag overrides whatever the scene specifies.
+ */
+struct SpatialEnvironment {
+  std::string kind;
+  std::optional<std::string> color;
+  std::optional<std::string> texture;
+  /**
+   * Named gradient preset (e.g. `"warm-room"`, `"studio-dark"`); ignored when `kind == "color"`.
+   */
+  std::optional<std::string> preset;
+  /**
+   * Gradient colour straight up (`#RRGGBB`); overrides the preset.
+   */
+  std::optional<std::string> sky;
+  /**
+   * Gradient colour at eye level (`#RRGGBB`); overrides the preset. Doubles as the clear colour.
+   */
+  std::optional<std::string> horizon;
+  /**
+   * Gradient colour straight down (`#RRGGBB`); overrides the preset and enables a 3-stop floor.
+   */
+  std::optional<std::string> floor;
+  /**
+   * Gradient glow intensity; overrides the preset's glow. Consumed by the native compositor's room backdrop.
+   */
+  std::optional<double> glow;
+};
+
+/**
+ * The full scene the 3D viewer renders. [version] must equal [SPATIAL_SCENE_VERSION].
+ */
+struct SpatialScene {
+  /**
+   * Bumped on breaking changes. Producers stamp it into `SpatialScene.version`.
+   */
+  int version = SPATIAL_SCENE_VERSION;
+  /**
+   * All linear quantities are dp.
+   */
+  std::string units = "dp";
+  /**
+   * The preview this scene was projected from, if any.
+   */
+  std::optional<std::string> previewId;
+  OrbitCamera camera;
+  std::vector<SpatialPanel> panels;
+  std::vector<OrbiterAffordance> orbiters;
+  std::optional<SpatialEnvironment> environment;
+};
+
+inline void from_json(const json& j, Vec3& x) {
+  j.at("x").get_to(x.x);
+  j.at("y").get_to(x.y);
+  j.at("z").get_to(x.z);
+}
+
+inline void to_json(json& j, const Vec3& x) {
+  j = json::object();
+  j["x"] = x.x;
+  j["y"] = x.y;
+  j["z"] = x.z;
+}
+
+inline void from_json(const json& j, Quat& x) {
+  j.at("x").get_to(x.x);
+  j.at("y").get_to(x.y);
+  j.at("z").get_to(x.z);
+  j.at("w").get_to(x.w);
+}
+
+inline void to_json(json& j, const Quat& x) {
+  j = json::object();
+  j["x"] = x.x;
+  j["y"] = x.y;
+  j["z"] = x.z;
+  j["w"] = x.w;
+}
+
+inline void from_json(const json& j, SpatialPose& x) {
+  j.at("translation").get_to(x.translation);
+  j.at("rotation").get_to(x.rotation);
+}
+
+inline void to_json(json& j, const SpatialPose& x) {
+  j = json::object();
+  j["translation"] = x.translation;
+  j["rotation"] = x.rotation;
+}
+
+inline void from_json(const json& j, SizeDp& x) {
+  j.at("width").get_to(x.width);
+  j.at("height").get_to(x.height);
+}
+
+inline void to_json(json& j, const SizeDp& x) {
+  j = json::object();
+  j["width"] = x.width;
+  j["height"] = x.height;
+}
+
+inline void from_json(const json& j, SpatialPanel& x) {
+  j.at("id").get_to(x.id);
+  if (j.contains("label") && !j.at("label").is_null()) x.label = j.at("label").get<std::string>();
+  j.at("poseInRoot").get_to(x.poseInRoot);
+  j.at("sizeDp").get_to(x.sizeDp);
+  j.at("texture").get_to(x.texture);
+  if (j.contains("parentId") && !j.at("parentId").is_null()) x.parentId = j.at("parentId").get<std::string>();
+}
+
+inline void to_json(json& j, const SpatialPanel& x) {
+  j = json::object();
+  j["id"] = x.id;
+  if (x.label) j["label"] = *x.label;
+  j["poseInRoot"] = x.poseInRoot;
+  j["sizeDp"] = x.sizeDp;
+  j["texture"] = x.texture;
+  if (x.parentId) j["parentId"] = *x.parentId;
+}
+
+inline void from_json(const json& j, OrbiterAffordance& x) {
+  j.at("id").get_to(x.id);
+  if (j.contains("label") && !j.at("label").is_null()) x.label = j.at("label").get<std::string>();
+  j.at("edge").get_to(x.edge);
+  j.at("poseInRoot").get_to(x.poseInRoot);
+  j.at("sizeDp").get_to(x.sizeDp);
+  j.at("texture").get_to(x.texture);
+}
+
+inline void to_json(json& j, const OrbiterAffordance& x) {
+  j = json::object();
+  j["id"] = x.id;
+  if (x.label) j["label"] = *x.label;
+  j["edge"] = x.edge;
+  j["poseInRoot"] = x.poseInRoot;
+  j["sizeDp"] = x.sizeDp;
+  j["texture"] = x.texture;
+}
+
+inline void from_json(const json& j, OrbitCamera& x) {
+  if (j.contains("kind") && !j.at("kind").is_null()) j.at("kind").get_to(x.kind);
+  j.at("target").get_to(x.target);
+  j.at("distance").get_to(x.distance);
+  j.at("yawDeg").get_to(x.yawDeg);
+  j.at("pitchDeg").get_to(x.pitchDeg);
+}
+
+inline void to_json(json& j, const OrbitCamera& x) {
+  j = json::object();
+  j["kind"] = x.kind;
+  j["target"] = x.target;
+  j["distance"] = x.distance;
+  j["yawDeg"] = x.yawDeg;
+  j["pitchDeg"] = x.pitchDeg;
+}
+
+inline void from_json(const json& j, SpatialEnvironment& x) {
+  j.at("kind").get_to(x.kind);
+  if (j.contains("color") && !j.at("color").is_null()) x.color = j.at("color").get<std::string>();
+  if (j.contains("texture") && !j.at("texture").is_null()) x.texture = j.at("texture").get<std::string>();
+  if (j.contains("preset") && !j.at("preset").is_null()) x.preset = j.at("preset").get<std::string>();
+  if (j.contains("sky") && !j.at("sky").is_null()) x.sky = j.at("sky").get<std::string>();
+  if (j.contains("horizon") && !j.at("horizon").is_null()) x.horizon = j.at("horizon").get<std::string>();
+  if (j.contains("floor") && !j.at("floor").is_null()) x.floor = j.at("floor").get<std::string>();
+  if (j.contains("glow") && !j.at("glow").is_null()) x.glow = j.at("glow").get<double>();
+}
+
+inline void to_json(json& j, const SpatialEnvironment& x) {
+  j = json::object();
+  j["kind"] = x.kind;
+  if (x.color) j["color"] = *x.color;
+  if (x.texture) j["texture"] = *x.texture;
+  if (x.preset) j["preset"] = *x.preset;
+  if (x.sky) j["sky"] = *x.sky;
+  if (x.horizon) j["horizon"] = *x.horizon;
+  if (x.floor) j["floor"] = *x.floor;
+  if (x.glow) j["glow"] = *x.glow;
+}
+
+inline void from_json(const json& j, SpatialScene& x) {
+  if (j.contains("version") && !j.at("version").is_null()) j.at("version").get_to(x.version);
+  if (j.contains("units") && !j.at("units").is_null()) j.at("units").get_to(x.units);
+  if (j.contains("previewId") && !j.at("previewId").is_null()) x.previewId = j.at("previewId").get<std::string>();
+  j.at("camera").get_to(x.camera);
+  if (j.contains("panels")) j.at("panels").get_to(x.panels);
+  if (j.contains("orbiters")) j.at("orbiters").get_to(x.orbiters);
+  if (j.contains("environment") && !j.at("environment").is_null()) x.environment = j.at("environment").get<SpatialEnvironment>();
+}
+
+inline void to_json(json& j, const SpatialScene& x) {
+  j = json::object();
+  j["version"] = x.version;
+  j["units"] = x.units;
+  if (x.previewId) j["previewId"] = *x.previewId;
+  j["camera"] = x.camera;
+  j["panels"] = x.panels;
+  j["orbiters"] = x.orbiters;
+  if (x.environment) j["environment"] = *x.environment;
+}
+
+}  // namespace xrcomposite

--- a/renderers/xr-composite/test/serve_smoke.py
+++ b/renderers/xr-composite/test/serve_smoke.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Smoke test for `xr-composite --serve` (the long-lived JSON-RPC render server).
+
+Drives the server over stdio with the LSP-style Content-Length framing it speaks:
+`initialize` -> `render` (a scene) -> `xr/updatePanels` (move a panel). Asserts that each render
+emits a `streamFrame` notification and that moving a panel actually produces a different frame
+(i.e. the held Filament engine re-rendered the mutated scene). Exits non-zero on any failure.
+
+Must run under a GL context (headless: Xvfb + Mesa llvmpipe), same as the one-shot render. Usage:
+
+    xvfb-run -a -s "-screen 0 2000x1400x24" \
+      env LIBGL_ALWAYS_SOFTWARE=1 GALLIUM_DRIVER=llvmpipe \
+      python3 test/serve_smoke.py <xr-composite-binary> <materials-dir> <scene-dir>
+"""
+import json
+import os
+import subprocess
+import sys
+
+
+def main() -> int:
+    binary, materials, scene_dir = sys.argv[1], sys.argv[2], sys.argv[3]
+    scene = json.load(open(os.path.join(scene_dir, "scene.json")))
+
+    proc = subprocess.Popen(
+        [binary, "--serve", "--materials", materials, "--width", "640", "--height", "400"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+    )
+
+    def send(obj):
+        body = json.dumps(obj).encode()
+        proc.stdin.write(b"Content-Length: %d\r\n\r\n" % len(body) + body)
+        proc.stdin.flush()
+
+    def read_msg():
+        length = 0
+        while True:
+            line = proc.stdout.readline()
+            if not line:
+                return None
+            line = line.rstrip(b"\r\n")
+            if line == b"":
+                break
+            if line.lower().startswith(b"content-length:"):
+                length = int(line.split(b":")[1])
+        return json.loads(proc.stdout.read(length))
+
+    frames = []  # streamFrame seqs seen
+
+    def pump_until_id(want):
+        while True:
+            m = read_msg()
+            if m is None:
+                raise SystemExit("server closed stdout before responding")
+            if m.get("method") == "streamFrame":
+                p = m["params"]
+                assert p["encoding"] == "png" and p["data"], "streamFrame missing png data"
+                frames.append((p["seq"], p["data"]))
+            elif m.get("id") == want:
+                return m
+
+    send({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {"frameStreamId": "fs1"}})
+    caps = pump_until_id(1)["result"]["capabilities"]
+    assert caps.get("render") and caps.get("updatePanels") and caps.get("streamFrame"), caps
+
+    send({"jsonrpc": "2.0", "id": 2, "method": "render",
+          "params": {"scene": scene, "sceneDir": scene_dir}})
+    assert pump_until_id(2)["result"]["ok"], "render did not ack ok"
+
+    send({"jsonrpc": "2.0", "id": 3, "method": "xr/updatePanels",
+          "params": {"panels": [
+              {"id": scene["panels"][0]["id"],
+               "poseInRoot": {"translation": {"x": 120, "y": 160, "z": 0},
+                              "rotation": {"x": 0, "y": 0, "z": 0, "w": 1}}}]}})
+    assert pump_until_id(3)["result"]["ok"], "updatePanels did not ack ok"
+
+    send({"jsonrpc": "2.0", "method": "exit"})
+    proc.wait(timeout=15)
+
+    assert len(frames) >= 2, f"expected >=2 streamFrames, got {len(frames)}"
+    assert frames[0][0] == 1 and frames[1][0] == 2, f"unexpected seq order: {[f[0] for f in frames]}"
+    assert frames[0][1] != frames[1][1], "frame did not change after moving a panel"
+    assert proc.returncode == 0, f"server exit code {proc.returncode}"
+    print(f"OK: {len(frames)} streamFrames; per-frame update changed the image")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/schema/spatial-scene.schema.json
+++ b/schema/spatial-scene.schema.json
@@ -1,0 +1,130 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://schimke.ee/composeai/spatial-scene.schema.json",
+  "title": "SpatialScene",
+  "description": "The wire contract between the offline renderer (producer) and the webview's 3D spatial-layout viewer (consumer). All linear quantities are dp; axes are right-handed (+x right, +y up, +z toward the viewer); rotation is a unit quaternion. Prose spec: docs/design/SPATIAL_SCENE_CONTRACT.md.",
+  "x-codegen": {
+    "version-const": "SPATIAL_SCENE_VERSION",
+    "kotlin-package": "ee.schimke.composeai.xr",
+    "cpp-namespace": "xrcomposite",
+    "root": "SpatialScene"
+  },
+  "definitions": {
+    "Vec3": {
+      "type": "object",
+      "description": "A point or vector, in dp.",
+      "required": ["x", "y", "z"],
+      "additionalProperties": false,
+      "properties": {
+        "x": { "type": "number" },
+        "y": { "type": "number" },
+        "z": { "type": "number" }
+      }
+    },
+    "Quat": {
+      "type": "object",
+      "description": "A unit quaternion; identity is `(0, 0, 0, 1)`.",
+      "required": ["x", "y", "z", "w"],
+      "additionalProperties": false,
+      "properties": {
+        "x": { "type": "number" },
+        "y": { "type": "number" },
+        "z": { "type": "number" },
+        "w": { "type": "number" }
+      }
+    },
+    "SpatialPose": {
+      "type": "object",
+      "description": "A rigid transform in the subspace root's frame: `translation` in dp, `rotation` a unit\nquaternion.",
+      "required": ["translation", "rotation"],
+      "additionalProperties": false,
+      "properties": {
+        "translation": { "$ref": "#/definitions/Vec3" },
+        "rotation": { "$ref": "#/definitions/Quat" }
+      }
+    },
+    "SizeDp": {
+      "type": "object",
+      "description": "Panel extent in dp (the layout output, not the texture's pixel size).",
+      "required": ["width", "height"],
+      "additionalProperties": false,
+      "properties": {
+        "width": { "type": "integer" },
+        "height": { "type": "integer" }
+      }
+    },
+    "SpatialPanel": {
+      "type": "object",
+      "description": "A spatial panel: a flat quad hosting 2D Compose content.",
+      "required": ["id", "poseInRoot", "sizeDp", "texture"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string" },
+        "label": { "type": "string", "description": "Human-readable label for overlays; not required for rendering." },
+        "poseInRoot": { "$ref": "#/definitions/SpatialPose" },
+        "sizeDp": { "$ref": "#/definitions/SizeDp" },
+        "texture": { "type": "string", "description": "Path to the panel's 2D-content PNG, relative to the scene file (or a resolvable URI)." },
+        "parentId": { "type": ["string", "null"], "description": "Id of the containing panel/group, or null/omitted for top-level panels." }
+      }
+    },
+    "OrbiterAffordance": {
+      "type": "object",
+      "description": "An Orbiter affordance — a control strip anchored to a panel edge. `edge` is\ntop/bottom/start/end.",
+      "required": ["id", "edge", "poseInRoot", "sizeDp", "texture"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string" },
+        "label": { "type": "string" },
+        "edge": { "type": "string", "enum": ["top", "bottom", "start", "end"] },
+        "poseInRoot": { "$ref": "#/definitions/SpatialPose" },
+        "sizeDp": { "$ref": "#/definitions/SizeDp" },
+        "texture": { "type": "string" }
+      }
+    },
+    "OrbitCamera": {
+      "type": "object",
+      "description": "Default viewing camera. Only `kind = \"orbit\"` is defined today.",
+      "required": ["target", "distance", "yawDeg", "pitchDeg"],
+      "additionalProperties": false,
+      "properties": {
+        "kind": { "type": "string", "enum": ["orbit"], "default": "orbit" },
+        "target": { "$ref": "#/definitions/Vec3", "description": "Look-at point in dp." },
+        "distance": { "type": "number", "description": "Camera distance from `target`, in dp." },
+        "yawDeg": { "type": "number" },
+        "pitchDeg": { "type": "number" }
+      }
+    },
+    "SpatialEnvironment": {
+      "type": "object",
+      "description": "Optional scene backdrop. `kind` is \"color\" (`#RRGGBB` in [color]) or \"skybox\" ([texture]).\n\nFor gradient backdrops (any `kind` other than \"color\"), the offline compositor supports **named\npresets** ([preset], e.g. `\"warm-room\"` — the default — or `\"studio-dark\"`) plus explicit\ngradient stops that **override** the chosen preset: [sky] (straight up), [horizon] (eye level),\nand [floor] (straight down; its presence turns the 2-stop gradient into a 3-stop, room-like one).\nThese knobs are optional; omit them to take the compositor's default `warm-room` backdrop. The\ncompositor's `--environment` CLI flag overrides whatever the scene specifies.",
+      "required": ["kind"],
+      "additionalProperties": false,
+      "properties": {
+        "kind": { "type": "string", "enum": ["color", "skybox", "gradient"] },
+        "color": { "type": "string" },
+        "texture": { "type": "string" },
+        "preset": { "type": "string", "description": "Named gradient preset (e.g. `\"warm-room\"`, `\"studio-dark\"`); ignored when `kind == \"color\"`." },
+        "sky": { "type": "string", "description": "Gradient colour straight up (`#RRGGBB`); overrides the preset." },
+        "horizon": { "type": "string", "description": "Gradient colour at eye level (`#RRGGBB`); overrides the preset. Doubles as the clear colour." },
+        "floor": { "type": "string", "description": "Gradient colour straight down (`#RRGGBB`); overrides the preset and enables a 3-stop floor." },
+        "glow": { "type": "number", "description": "Gradient glow intensity; overrides the preset's glow. Consumed by the native compositor's room backdrop." }
+      }
+    },
+    "SpatialScene": {
+      "type": "object",
+      "description": "The full scene the 3D viewer renders. [version] must equal [SPATIAL_SCENE_VERSION].",
+      "required": ["camera", "panels"],
+      "additionalProperties": false,
+      "properties": {
+        "version": { "type": "integer", "default": 1, "description": "Bumped on breaking changes. Producers stamp it into `SpatialScene.version`." },
+        "units": { "type": "string", "enum": ["dp"], "default": "dp", "description": "All linear quantities are dp." },
+        "previewId": { "type": "string", "description": "The preview this scene was projected from, if any." },
+        "camera": { "$ref": "#/definitions/OrbitCamera" },
+        "panels": { "type": "array", "items": { "$ref": "#/definitions/SpatialPanel" } },
+        "orbiters": { "type": "array", "items": { "$ref": "#/definitions/OrbiterAffordance" }, "default": [] },
+        "environment": { "oneOf": [ { "$ref": "#/definitions/SpatialEnvironment" }, { "type": "null" } ], "default": null }
+      }
+    }
+  },
+  "$ref": "#/definitions/SpatialScene"
+}

--- a/scripts/codegen/gen-spatial-scene.mjs
+++ b/scripts/codegen/gen-spatial-scene.mjs
@@ -1,0 +1,322 @@
+#!/usr/bin/env node
+// Single-source codegen for the SpatialScene wire contract.
+//
+// Source of truth: schema/spatial-scene.schema.json. This script templates that schema into the
+// three language mirrors (Kotlin / TypeScript / C++) so they cannot drift. Run it after editing the
+// schema; CI runs it with --check to fail if a committed mirror is stale.
+//
+//   node scripts/codegen/gen-spatial-scene.mjs          # (re)write the mirrors
+//   node scripts/codegen/gen-spatial-scene.mjs --check  # fail if any mirror is out of date
+//
+// Deliberately dependency-free (Node stdlib only) and bespoke to this small schema: it produces the
+// existing idiomatic shapes (kotlinx defaults, TS string-literal unions, nlohmann std::optional)
+// rather than a generic tool's lowest-common-denominator output. See docs/design/WIRE_IDL_CODEGEN.md.
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, "..", "..");
+const schemaPath = resolve(repoRoot, "schema/spatial-scene.schema.json");
+const schema = JSON.parse(readFileSync(schemaPath, "utf8"));
+const defs = schema.definitions;
+const cfg = schema["x-codegen"];
+const VERSION_CONST = cfg["version-const"];
+const VERSION_VALUE = defs[cfg.root].properties.version.default;
+
+const OUTPUTS = {
+  kotlin: "api/preview-data-api/src/main/kotlin/ee/schimke/composeai/xr/SpatialScene.kt",
+  typescript: "vscode-extension/src/webview/shared/spatialScene.ts",
+  cpp: "renderers/xr-composite/src/spatial_scene.hpp",
+};
+
+const BANNER = (relPath) => [
+  `// GENERATED FILE — DO NOT EDIT.`,
+  `// Source of truth: schema/spatial-scene.schema.json`,
+  `// Regenerate: node scripts/codegen/gen-spatial-scene.mjs (CI checks with --check).`,
+];
+
+// ---- schema helpers ----------------------------------------------------------------------------
+
+const refName = (s) => s.$ref ? s.$ref.replace("#/definitions/", "") : null;
+
+// Resolve a property schema into a normalized descriptor the emitters share.
+function describe(name, prop, required) {
+  const isReq = required.includes(name);
+  let kind, item, ref, nullable = false;
+  if (prop.$ref) {
+    kind = "ref"; ref = refName(prop);
+  } else if (prop.oneOf) {
+    nullable = prop.oneOf.some((s) => s.type === "null");
+    const r = prop.oneOf.find((s) => s.$ref);
+    kind = "ref"; ref = refName(r);
+  } else if (prop.type === "array") {
+    kind = "array"; item = refName(prop.items) ?? prop.items.type;
+  } else if (Array.isArray(prop.type)) {
+    nullable = prop.type.includes("null");
+    kind = prop.type.find((t) => t !== "null");
+  } else {
+    kind = prop.type;
+  }
+  const def = "default" in prop ? prop.default : undefined;
+  const hasScalarDefault = def !== undefined && def !== null && kind !== "array";
+  return {
+    name, kind, item, ref, nullable, required: isReq,
+    enum: prop.enum, default: def, hasScalarDefault,
+    description: prop.description,
+    isVersion: name === "version" && kind === "integer",
+  };
+}
+
+function properties(defName) {
+  const d = defs[defName];
+  const req = d.required ?? [];
+  return Object.entries(d.properties).map(([n, p]) => describe(n, p, req));
+}
+
+const typeOrder = Object.keys(defs); // authored in dependency order
+
+// ---- doc-comment formatting --------------------------------------------------------------------
+
+function block(text, indent = "") {
+  if (!text) return [];
+  const lines = text.split("\n");
+  return [
+    `${indent}/**`,
+    ...lines.map((l) => `${indent} *${l ? " " + l : ""}`),
+    `${indent} */`,
+  ];
+}
+
+// ---- Kotlin ------------------------------------------------------------------------------------
+
+function ktType(p) {
+  const scalar = { number: "Double", integer: "Int", string: "String", boolean: "Boolean" };
+  if (p.kind === "array") return `List<${defs[p.item] ? p.item : scalar[p.item]}>`;
+  if (p.kind === "ref") return p.ref;
+  return scalar[p.kind];
+}
+
+function ktField(p) {
+  const t = ktType(p);
+  let decl;
+  if (p.required) {
+    decl = `val ${p.name}: ${t}`;
+  } else if (p.isVersion) {
+    decl = `val ${p.name}: ${t} = ${VERSION_CONST}`;
+  } else if (p.hasScalarDefault) {
+    const lit = typeof p.default === "string" ? `"${p.default}"` : `${p.default}`;
+    decl = `val ${p.name}: ${t} = ${lit}`;
+  } else if (p.kind === "array" && Array.isArray(p.default)) {
+    decl = `val ${p.name}: ${t} = emptyList()`;
+  } else {
+    decl = `val ${p.name}: ${t}? = null`;
+  }
+  return decl;
+}
+
+function emitKotlin() {
+  const out = [];
+  out.push(...BANNER());
+  out.push("");
+  out.push(`package ${cfg["kotlin-package"]}`);
+  out.push("");
+  out.push("import kotlinx.serialization.Serializable");
+  out.push("");
+  out.push(...block(schema.description));
+  out.push(`public const val ${VERSION_CONST}: Int = ${VERSION_VALUE}`);
+  for (const name of typeOrder) {
+    out.push("");
+    out.push(...block(defs[name].description));
+    out.push("@Serializable");
+    const props = properties(name);
+    out.push(`public data class ${name}(`);
+    props.forEach((p, i) => {
+      const comma = i < props.length - 1 ? "," : ",";
+      if (p.description) out.push(...block(p.description, "  "));
+      out.push(`  ${ktField(p)}${comma}`);
+    });
+    out.push(")");
+  }
+  return out.join("\n") + "\n";
+}
+
+// ---- TypeScript --------------------------------------------------------------------------------
+
+function tsType(p) {
+  const scalar = { number: "number", integer: "number", string: "string", boolean: "boolean" };
+  if (p.enum) return p.enum.map((e) => `"${e}"`).join(" | ");
+  if (p.kind === "array") return `${defs[p.item] ? p.item : scalar[p.item]}[]`;
+  if (p.kind === "ref") return p.ref;
+  return scalar[p.kind];
+}
+
+function tsField(p) {
+  // Required in the TS interface when JSON-required, or an always-emitted scalar identity
+  // (version/units/kind) carrying a non-null scalar default. Arrays/objects stay optional.
+  const tsRequired = p.required || p.hasScalarDefault;
+  let t = tsType(p);
+  if (p.nullable) t = `${t} | null`;
+  return `${p.name}${tsRequired ? "" : "?"}: ${t};`;
+}
+
+function emitTypeScript() {
+  const out = [];
+  out.push(...BANNER());
+  out.push("");
+  out.push(...block(schema.description).map(stripLeadingSlash));
+  out.push(`export const ${VERSION_CONST} = ${VERSION_VALUE};`);
+  for (const name of typeOrder) {
+    out.push("");
+    out.push(...block(defs[name].description));
+    const props = properties(name);
+    out.push(`export interface ${name} {`);
+    props.forEach((p) => {
+      if (p.description) out.push(...block(p.description, "    "));
+      out.push(`    ${tsField(p)}`);
+    });
+    out.push("}");
+  }
+  // Shallow structural guard — logic, not shape; templated against the version const.
+  out.push("");
+  out.push(...block(
+    "Minimal structural guard — rejects payloads the consumer can't safely render: a `version`\n" +
+    `other than {@link ${VERSION_CONST}}, or missing required fields. Shallow otherwise; the viewer\n` +
+    "should still tolerate missing optional fields."));
+  out.push("export function isSpatialScene(value: unknown): value is SpatialScene {");
+  out.push("    if (typeof value !== \"object\" || value === null) {");
+  out.push("        return false;");
+  out.push("    }");
+  out.push("    const scene = value as Partial<SpatialScene>;");
+  out.push("    return (");
+  out.push("        scene.units === \"dp\" &&");
+  out.push(`        scene.version === ${VERSION_CONST} &&`);
+  out.push("        Array.isArray(scene.panels) &&");
+  out.push("        typeof scene.camera === \"object\" &&");
+  out.push("        scene.camera !== null");
+  out.push("    );");
+  out.push("}");
+  return out.join("\n") + "\n";
+}
+
+const stripLeadingSlash = (l) => l; // banner already // comments; doc blocks stay /** */
+
+// ---- C++ ---------------------------------------------------------------------------------------
+
+function cppType(p) {
+  const scalar = { number: "double", integer: "int", string: "std::string", boolean: "bool" };
+  if (p.kind === "array") return `std::vector<${defs[p.item] ? p.item : scalar[p.item]}>`;
+  if (p.kind === "ref") return p.ref;
+  return scalar[p.kind];
+}
+
+function cppField(p) {
+  const t = cppType(p);
+  if (p.kind === "array") return `${t} ${p.name};`;
+  if (p.required) return `${t} ${p.name};`;
+  if (p.isVersion) return `${t} ${p.name} = ${VERSION_CONST};`;
+  if (p.hasScalarDefault) {
+    const lit = typeof p.default === "string" ? `"${p.default}"` : `${p.default}`;
+    return `${t} ${p.name} = ${lit};`;
+  }
+  return `std::optional<${t}> ${p.name};`;
+}
+
+function emitCpp() {
+  const ns = cfg["cpp-namespace"];
+  const out = [];
+  out.push(...BANNER());
+  out.push("");
+  out.push("#pragma once");
+  out.push("");
+  out.push("#include <optional>");
+  out.push("#include <string>");
+  out.push("#include <vector>");
+  out.push("");
+  out.push('#include "json.hpp"');
+  out.push("");
+  out.push(`namespace ${ns} {`);
+  out.push("");
+  out.push("using nlohmann::json;");
+  out.push("");
+  out.push(...block(schema.description));
+  out.push(`constexpr int ${VERSION_CONST} = ${VERSION_VALUE};`);
+  // structs
+  for (const name of typeOrder) {
+    out.push("");
+    out.push(...block(defs[name].description));
+    out.push(`struct ${name} {`);
+    properties(name).forEach((p) => {
+      if (p.description) out.push(...block(p.description, "  "));
+      out.push(`  ${cppField(p)}`);
+    });
+    out.push("};");
+  }
+  // (de)serializers
+  for (const name of typeOrder) {
+    const props = properties(name);
+    out.push("");
+    out.push(`inline void from_json(const json& j, ${name}& x) {`);
+    props.forEach((p) => {
+      const n = p.name;
+      if (p.kind === "array") {
+        out.push(`  if (j.contains("${n}")) j.at("${n}").get_to(x.${n});`);
+      } else if (p.required) {
+        out.push(`  j.at("${n}").get_to(x.${n});`);
+      } else if (p.isVersion || p.hasScalarDefault) {
+        out.push(`  if (j.contains("${n}") && !j.at("${n}").is_null()) j.at("${n}").get_to(x.${n});`);
+      } else {
+        out.push(`  if (j.contains("${n}") && !j.at("${n}").is_null()) x.${n} = j.at("${n}").get<${cppType(p)}>();`);
+      }
+    });
+    out.push("}");
+    out.push("");
+    out.push(`inline void to_json(json& j, const ${name}& x) {`);
+    out.push("  j = json::object();");
+    props.forEach((p) => {
+      const n = p.name;
+      const optional = !p.required && !p.isVersion && !p.hasScalarDefault && p.kind !== "array";
+      if (optional) {
+        out.push(`  if (x.${n}) j["${n}"] = *x.${n};`);
+      } else {
+        out.push(`  j["${n}"] = x.${n};`);
+      }
+    });
+    out.push("}");
+  }
+  out.push("");
+  out.push(`}  // namespace ${ns}`);
+  return out.join("\n") + "\n";
+}
+
+// ---- driver ------------------------------------------------------------------------------------
+
+const generated = {
+  [OUTPUTS.kotlin]: emitKotlin(),
+  [OUTPUTS.typescript]: emitTypeScript(),
+  [OUTPUTS.cpp]: emitCpp(),
+};
+
+const check = process.argv.includes("--check");
+let stale = [];
+for (const [rel, content] of Object.entries(generated)) {
+  const abs = resolve(repoRoot, rel);
+  if (check) {
+    let current = "";
+    try { current = readFileSync(abs, "utf8"); } catch { /* missing */ }
+    if (current !== content) stale.push(rel);
+  } else {
+    writeFileSync(abs, content);
+    console.log(`wrote ${rel}`);
+  }
+}
+
+if (check) {
+  if (stale.length) {
+    console.error("Stale generated mirrors (run: node scripts/codegen/gen-spatial-scene.mjs):");
+    stale.forEach((s) => console.error(`  - ${s}`));
+    process.exit(1);
+  }
+  console.log("SpatialScene mirrors are up to date.");
+}

--- a/vscode-extension/.prettierignore
+++ b/vscode-extension/.prettierignore
@@ -1,0 +1,4 @@
+# Generated from schema/spatial-scene.schema.json by scripts/codegen/gen-spatial-scene.mjs.
+# Formatted by that generator (the single source of truth); drift is caught by the codegen --check
+# CI job, so prettier must not reformat it.
+src/webview/shared/spatialScene.ts

--- a/vscode-extension/src/webview/shared/spatialScene.ts
+++ b/vscode-extension/src/webview/shared/spatialScene.ts
@@ -1,23 +1,24 @@
-// SpatialScene — the wire contract between the offline renderer (producer) and the webview's 3D
-// spatial-layout viewer (consumer). The renderer (`:renderer-xr`, Phase A) recovers each panel's
-// pose/size from the Compose-XR subspace layout and renders its 2D content to a PNG; the webview
-// loads this JSON + those textures and draws the panels as textured quads in a WebGL scene.
-//
-// This file is the single source of truth for the TypeScript side; the prose spec (units, axes,
-// versioning, producer mapping) lives in docs/design/SPATIAL_SCENE_CONTRACT.md. Keep the two in
-// sync. Bump SPATIAL_SCENE_VERSION on any breaking shape change.
+// GENERATED FILE — DO NOT EDIT.
+// Source of truth: schema/spatial-scene.schema.json
+// Regenerate: node scripts/codegen/gen-spatial-scene.mjs (CI checks with --check).
 
-/** Bumped on breaking changes to the shapes below. Producers stamp it into `SpatialScene.version`. */
+/**
+ * The wire contract between the offline renderer (producer) and the webview's 3D spatial-layout viewer (consumer). All linear quantities are dp; axes are right-handed (+x right, +y up, +z toward the viewer); rotation is a unit quaternion. Prose spec: docs/design/SPATIAL_SCENE_CONTRACT.md.
+ */
 export const SPATIAL_SCENE_VERSION = 1;
 
-/** A point or vector, in density-independent pixels (dp). See the spec for the axis convention. */
+/**
+ * A point or vector, in dp.
+ */
 export interface Vec3 {
     x: number;
     y: number;
     z: number;
 }
 
-/** A unit quaternion. Identity (no rotation) is `{ x: 0, y: 0, z: 0, w: 1 }`. */
+/**
+ * A unit quaternion; identity is `(0, 0, 0, 1)`.
+ */
 export interface Quat {
     x: number;
     y: number;
@@ -26,40 +27,47 @@ export interface Quat {
 }
 
 /**
- * A rigid transform in the subspace root's frame. Right-handed: +x right, +y up, +z toward the
- * viewer (camera looks down −z). `translation` is in dp; `rotation` is a unit quaternion.
+ * A rigid transform in the subspace root's frame: `translation` in dp, `rotation` a unit
+ * quaternion.
  */
 export interface SpatialPose {
     translation: Vec3;
     rotation: Quat;
 }
 
-/** Panel size in dp (the layout output, not the texture's pixel dimensions). */
+/**
+ * Panel extent in dp (the layout output, not the texture's pixel size).
+ */
 export interface SizeDp {
     width: number;
     height: number;
 }
 
-/** A spatial panel: a flat, axis-aligned-by-default quad hosting 2D Compose content. */
+/**
+ * A spatial panel: a flat quad hosting 2D Compose content.
+ */
 export interface SpatialPanel {
-    /** Stable id (the subspace node's testTag / semantics id). */
     id: string;
-    /** Human-readable label for overlays; not required for rendering. */
+    /**
+     * Human-readable label for overlays; not required for rendering.
+     */
     label?: string;
-    /** Pose in the subspace root frame. */
     poseInRoot: SpatialPose;
-    /** Panel extent in dp. */
     sizeDp: SizeDp;
     /**
-     * Path to the panel's 2D-content PNG, relative to the scene file's directory (or an absolute
-     * URI the consumer can resolve to a webview resource). The image is mapped onto the quad.
+     * Path to the panel's 2D-content PNG, relative to the scene file (or a resolvable URI).
      */
     texture: string;
-    /** Id of the containing panel/group, or null/omitted for top-level panels. */
+    /**
+     * Id of the containing panel/group, or null/omitted for top-level panels.
+     */
     parentId?: string | null;
 }
 
-/** An Orbiter affordance — a control strip anchored to a panel edge in Full Space. */
+/**
+ * An Orbiter affordance — a control strip anchored to a panel edge. `edge` is
+ * top/bottom/start/end.
+ */
 export interface OrbiterAffordance {
     id: string;
     label?: string;
@@ -69,50 +77,74 @@ export interface OrbiterAffordance {
     texture: string;
 }
 
-/** Default viewing camera. Only orbit is defined today. */
+/**
+ * Default viewing camera. Only `kind = "orbit"` is defined today.
+ */
 export interface OrbitCamera {
     kind: "orbit";
-    /** Look-at point in dp. */
+    /**
+     * Look-at point in dp.
+     */
     target: Vec3;
-    /** Camera distance from `target`, in dp. */
+    /**
+     * Camera distance from `target`, in dp.
+     */
     distance: number;
     yawDeg: number;
     pitchDeg: number;
 }
 
 /**
- * Optional scene backdrop.
+ * Optional scene backdrop. `kind` is "color" (`#RRGGBB` in [color]) or "skybox" ([texture]).
  *
- * For gradient backdrops (any `kind` other than `"color"`), the offline compositor supports named
- * `preset`s (e.g. `"warm-room"` — the default — or `"studio-dark"`) plus explicit gradient stops
- * that override the chosen preset: `sky` (straight up), `horizon` (eye level), and `floor`
- * (straight down; its presence turns the 2-stop gradient into a 3-stop, room-like one). All are
- * optional; omit them to take the compositor's default `warm-room` backdrop. The compositor's
- * `--environment` CLI flag overrides whatever the scene specifies.
+ * For gradient backdrops (any `kind` other than "color"), the offline compositor supports **named
+ * presets** ([preset], e.g. `"warm-room"` — the default — or `"studio-dark"`) plus explicit
+ * gradient stops that **override** the chosen preset: [sky] (straight up), [horizon] (eye level),
+ * and [floor] (straight down; its presence turns the 2-stop gradient into a 3-stop, room-like one).
+ * These knobs are optional; omit them to take the compositor's default `warm-room` backdrop. The
+ * compositor's `--environment` CLI flag overrides whatever the scene specifies.
  */
 export interface SpatialEnvironment {
     kind: "color" | "skybox" | "gradient";
-    /** `#RRGGBB` for `kind: "color"`. */
     color?: string;
-    /** Texture path/URI for `kind: "skybox"`. */
     texture?: string;
-    /** Named gradient preset (e.g. `"warm-room"`, `"studio-dark"`); ignored when `kind: "color"`. */
+    /**
+     * Named gradient preset (e.g. `"warm-room"`, `"studio-dark"`); ignored when `kind == "color"`.
+     */
     preset?: string;
-    /** Gradient colour straight up (`#RRGGBB`); overrides the preset. */
+    /**
+     * Gradient colour straight up (`#RRGGBB`); overrides the preset.
+     */
     sky?: string;
-    /** Gradient colour at eye level (`#RRGGBB`); overrides the preset. Doubles as the clear colour. */
+    /**
+     * Gradient colour at eye level (`#RRGGBB`); overrides the preset. Doubles as the clear colour.
+     */
     horizon?: string;
-    /** Gradient colour straight down (`#RRGGBB`); overrides the preset and enables a 3-stop floor. */
+    /**
+     * Gradient colour straight down (`#RRGGBB`); overrides the preset and enables a 3-stop floor.
+     */
     floor?: string;
+    /**
+     * Gradient glow intensity; overrides the preset's glow. Consumed by the native compositor's room backdrop.
+     */
+    glow?: number;
 }
 
-/** The full scene the 3D viewer renders. */
+/**
+ * The full scene the 3D viewer renders. [version] must equal [SPATIAL_SCENE_VERSION].
+ */
 export interface SpatialScene {
-    /** Must equal {@link SPATIAL_SCENE_VERSION} the consumer was built against. */
+    /**
+     * Bumped on breaking changes. Producers stamp it into `SpatialScene.version`.
+     */
     version: number;
-    /** All linear quantities are dp. */
+    /**
+     * All linear quantities are dp.
+     */
     units: "dp";
-    /** The preview this scene was projected from, if any. */
+    /**
+     * The preview this scene was projected from, if any.
+     */
     previewId?: string;
     camera: OrbitCamera;
     panels: SpatialPanel[];
@@ -121,11 +153,9 @@ export interface SpatialScene {
 }
 
 /**
- * Minimal structural guard — enough to reject payloads the consumer can't safely render before it
- * touches them: a `version` other than the {@link SPATIAL_SCENE_VERSION} this build was compiled
- * against (the version is bumped only on breaking shape changes, so a mismatch — newer *or* older —
- * means an incompatible shape), or missing required fields. It is intentionally shallow otherwise;
- * the viewer should still tolerate missing optional fields.
+ * Minimal structural guard — rejects payloads the consumer can't safely render: a `version`
+ * other than {@link SPATIAL_SCENE_VERSION}, or missing required fields. Shallow otherwise; the viewer
+ * should still tolerate missing optional fields.
  */
 export function isSpatialScene(value: unknown): value is SpatialScene {
     if (typeof value !== "object" || value === null) {


### PR DESCRIPTION
Two related commits toward the #1729 follow-up and the [renderer-service RFC](https://github.com/yschimke/compose-ai-tools/blob/main/docs/design/xr-spatial/RENDERER_SERVICE.md). (Kept on one branch per the dev-branch constraint; reviewable as two commits.)

## 1 — `feat(xr): generate the SpatialScene wire types from a single-source schema`

`SpatialScene` is the one wire type genuinely triplicated today (Kotlin + TypeScript + the native C++ `xr-composite` tool). `schema/spatial-scene.schema.json` becomes the single source of truth; `scripts/codegen/gen-spatial-scene.mjs` (dependency-free Node) generates all three mirrors, gated by the new **SpatialScene codegen up to date** CI job (`--check`).

A **bespoke** generator is used rather than quicktype — quicktype's output would break the published `preview-data-api` API (re-cased `previewId`, `version: Long`, enum classes, dropped kotlinx defaults) and pull Boost into the header-only C++ build. The generator templates the *existing* idiomatic shapes, so the mirrors are byte-shape-identical → **zero consumer churn, fixtures stay green**. It immediately caught a real drift: `environment.glow` existed only in the C++ tool — now an additive optional field in all three. Rationale: `docs/design/WIRE_IDL_CODEGEN.md`.

## 2 — `feat(xr): add a per-frame Filament render server to xr-composite (--serve)`

Turns the one-shot compositor into a long-lived JSON-RPC peer over stdio (LSP-style `Content-Length` framing — the same the daemon's subprocess render-session backend speaks). A `Compositor` holds one Filament engine/scene across frames; methods: `initialize`, `render`/`xr/render`, `xr/updatePanels` (mutate panel texture/pose/size in place + re-render), `shutdown`/`exit`. Each render is delivered as a `streamFrame` notification with a base64 PNG (reusing the `composestream/1` shape, RFC decision #4). The one-shot CLI is preserved as the floor. Consumes the generated `spatial_scene.hpp` from commit 1.

This is the native side of "what's genuinely new" in the RFC (a native JSON-RPC peer + a held, mutable session). **Still to do** (follow-ups): the daemon fronting/spawning it as a `RenderSession` backend, native multi-session concurrency, and the `xr/structure` / `xr/a11y-overlay` kinds.

## Test plan

- [x] `ktfmtCheckAll` + `:preview-data-api:test` (fixture lock + round-trip + defaults); generated `SpatialScene.kt` excluded from ktfmt.
- [x] vscode `tsc` + 21 spatial unit tests + `prettier` green with generated TS.
- [x] **Filament built locally** (llvmpipe + Xvfb): one-shot renders the fixture; `spatial_scene.hpp` compiles (c++17) and round-trips the fixture.
- [x] **Server verified locally**: `initialize → render → xr/updatePanels` emits two `streamFrame`s and a panel move changes the image; clean exit. Captured in `renderers/xr-composite/test/serve_smoke.py`.
- [x] CI: the **Render XR composite (sample)** job now also runs the server smoke under Xvfb; **SpatialScene codegen** `--check` gate added.
