### PR TITLE
feat(xr): JVM client for the native XR render server (daemon-fronting groundwork)

### DIFF
--- a/renderers/xr-client/build.gradle.kts
+++ b/renderers/xr-client/build.gradle.kts
@@ -1,0 +1,17 @@
+// JVM client for the native `xr-composite --serve` render server. The daemon's future XR
+// RenderSession backend (RENDERER_SERVICE RFC) wraps this to spawn/multiplex the native process and
+// proxy its frames to clients. Kept dependency-light: just kotlinx-serialization for the JSON-RPC
+// payloads — the framing is hand-rolled over the process streams.
+
+plugins {
+  id("composeai.base-conventions")
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.kotlin.serialization)
+}
+
+dependencies {
+  api(libs.kotlinx.serialization.json)
+
+  testImplementation(libs.junit)
+  testImplementation(kotlin("test"))
+}

--- a/renderers/xr-client/src/main/kotlin/ee/schimke/composeai/renderer/xr/client/XrServerClient.kt
+++ b/renderers/xr-client/src/main/kotlin/ee/schimke/composeai/renderer/xr/client/XrServerClient.kt
@@ -117,9 +117,17 @@ internal constructor(
   override fun close() {
     try {
       if (process?.isAlive == true) {
+        // Graceful (exit) → SIGTERM (destroy) → SIGKILL (destroyForcibly), waiting at each rung so
+        // a
+        // hung native child (e.g. Filament stuck mid-render) can't survive close() and leak across
+        // daemon sessions. Mirrors HarnessClient's shutdown ladder.
         exit()
-        process.waitFor(2, TimeUnit.SECONDS)
-        if (process.isAlive) process.destroy()
+        if (!process.waitFor(2, TimeUnit.SECONDS)) {
+          process.destroy()
+          if (!process.waitFor(2, TimeUnit.SECONDS)) {
+            process.destroyForcibly().waitFor(2, TimeUnit.SECONDS)
+          }
+        }
       }
     } catch (_: Exception) {
       process?.destroyForcibly()

--- a/renderers/xr-client/src/main/kotlin/ee/schimke/composeai/renderer/xr/client/XrServerClient.kt
+++ b/renderers/xr-client/src/main/kotlin/ee/schimke/composeai/renderer/xr/client/XrServerClient.kt
@@ -1,0 +1,263 @@
+package ee.schimke.composeai.renderer.xr.client
+
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.IOException
+import java.io.InputStream
+import java.io.OutputStream
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicLong
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.long
+import kotlinx.serialization.json.put
+
+/** One rendered frame pushed by the server as a `streamFrame` notification. */
+public data class StreamFrame(
+  val seq: Long,
+  val width: Int,
+  val height: Int,
+  val encoding: String,
+  /** Base64-encoded image bytes (`encoding` says the container, e.g. `png`). */
+  val dataBase64: String,
+)
+
+/** Thrown on transport / protocol failure talking to the native render server. */
+public class XrServerException(message: String, cause: Throwable? = null) :
+  RuntimeException(message, cause)
+
+/**
+ * JVM client for the native `xr-composite --serve` render server (see
+ * `renderers/xr-composite/README.md` → "Server mode"). Speaks the same LSP-style `Content-Length`
+ * JSON-RPC framing the daemon's subprocess backend uses, demultiplexing id-matched responses from
+ * `streamFrame` notifications on a background reader thread.
+ *
+ * This is the transport the daemon's future XR `RenderSession` backend wraps (RENDERER_SERVICE
+ * RFC): the daemon owns/multiplexes one native process and proxies its frames to clients. The
+ * client is constructed over raw streams so it is unit-testable without a real process; [spawn]
+ * wires it to an actual `xr-composite --serve` child.
+ *
+ * Threading: safe for sequential calls from one caller thread. Each request blocks for its ack; the
+ * matching `streamFrame` is collected from a queue the reader thread fills.
+ */
+public class XrServerClient
+internal constructor(
+  private val output: OutputStream,
+  input: InputStream,
+  private val process: Process?,
+) : AutoCloseable {
+
+  private val json = Json { ignoreUnknownKeys = true }
+  private val nextId = AtomicLong(1)
+  private val responseSlots = ConcurrentHashMap<Long, LinkedBlockingQueue<JsonObject>>()
+  private val frames = LinkedBlockingQueue<StreamFrame>()
+  private val reader =
+    Thread({ runReader(input) }, "xr-server-client-reader").apply {
+      isDaemon = true
+      start()
+    }
+
+  /** Drives `initialize`; returns the server's `capabilities` object. */
+  public fun initialize(frameStreamId: String? = null, timeout: Duration = 60.seconds): JsonObject {
+    val params = buildJsonObject { frameStreamId?.let { put("frameStreamId", it) } }
+    val result = request("initialize", params, timeout)
+    return result["capabilities"]?.jsonObject
+      ?: throw XrServerException("initialize: no capabilities in result ($result)")
+  }
+
+  /**
+   * Drives `render` with a full [scene] (a serialized `SpatialScene`). `sceneDir` resolves relative
+   * panel textures; `environment` overrides the backdrop. Returns the rendered [StreamFrame].
+   */
+  public fun render(
+    scene: JsonElement,
+    sceneDir: String? = null,
+    environment: String? = null,
+    timeout: Duration = 60.seconds,
+  ): StreamFrame {
+    val params = buildJsonObject {
+      put("scene", scene)
+      sceneDir?.let { put("sceneDir", it) }
+      environment?.let { put("environment", it) }
+    }
+    request("render", params, timeout)
+    return awaitFrame(timeout)
+  }
+
+  /**
+   * Drives `xr/updatePanels` — each entry in [panels] is `{id, texture?, poseInRoot?, sizeDp?}`,
+   * mutating the held scene per-frame. Returns the freshly rendered [StreamFrame].
+   */
+  public fun updatePanels(panels: JsonArray, timeout: Duration = 60.seconds): StreamFrame {
+    val params = buildJsonObject { put("panels", panels) }
+    request("xr/updatePanels", params, timeout)
+    return awaitFrame(timeout)
+  }
+
+  /** Sends `exit`; the server ends its loop and the process terminates. */
+  public fun exit() {
+    sendFrame(
+      buildJsonObject {
+        put("jsonrpc", "2.0")
+        put("method", "exit")
+      }
+    )
+  }
+
+  override fun close() {
+    try {
+      if (process?.isAlive == true) {
+        exit()
+        process.waitFor(2, TimeUnit.SECONDS)
+        if (process.isAlive) process.destroy()
+      }
+    } catch (_: Exception) {
+      process?.destroyForcibly()
+    }
+    reader.join(2_000)
+  }
+
+  // ---- internals ----
+
+  private fun awaitFrame(timeout: Duration): StreamFrame =
+    frames.poll(timeout.inWholeMilliseconds, TimeUnit.MILLISECONDS)
+      ?: throw XrServerException("no streamFrame within $timeout")
+
+  private fun request(method: String, params: JsonObject, timeout: Duration): JsonObject {
+    val id = nextId.getAndIncrement()
+    val slot = responseSlots.computeIfAbsent(id) { LinkedBlockingQueue() }
+    sendFrame(
+      buildJsonObject {
+        put("jsonrpc", "2.0")
+        put("id", id)
+        put("method", method)
+        put("params", params)
+      }
+    )
+    val response =
+      slot.poll(timeout.inWholeMilliseconds, TimeUnit.MILLISECONDS)
+        ?: run {
+          responseSlots.remove(id)
+          throw XrServerException("$method timed out after $timeout")
+        }
+    responseSlots.remove(id)
+    response["error"]?.let { throw XrServerException("$method failed: $it") }
+    return response["result"]?.jsonObject ?: JsonObject(emptyMap())
+  }
+
+  private fun sendFrame(message: JsonObject) {
+    val payload = json.encodeToString(JsonObject.serializer(), message).toByteArray(Charsets.UTF_8)
+    val header = "Content-Length: ${payload.size}\r\n\r\n".toByteArray(Charsets.US_ASCII)
+    synchronized(output) {
+      output.write(header)
+      output.write(payload)
+      output.flush()
+    }
+  }
+
+  private fun runReader(input: InputStream) {
+    try {
+      while (true) {
+        val frame = readFrame(input) ?: return
+        val obj = json.parseToJsonElement(frame.toString(Charsets.UTF_8)).jsonObject
+        val id = obj["id"]?.jsonPrimitive?.long
+        if (id != null) {
+          responseSlots.computeIfAbsent(id) { LinkedBlockingQueue() }.put(obj)
+        } else if (obj["method"]?.jsonPrimitive?.content == "streamFrame") {
+          obj["params"]?.jsonObject?.let { frames.put(parseFrame(it)) }
+        }
+      }
+    } catch (_: IOException) {
+      // EOF / pipe closed — normal teardown.
+    } catch (_: Throwable) {
+      // Reader is best-effort; pending requests time out and surface the failure.
+    }
+  }
+
+  private fun parseFrame(params: JsonObject): StreamFrame =
+    StreamFrame(
+      seq = params["seq"]?.jsonPrimitive?.long ?: 0,
+      width = params["width"]?.jsonPrimitive?.int ?: 0,
+      height = params["height"]?.jsonPrimitive?.int ?: 0,
+      encoding = params["encoding"]?.jsonPrimitive?.content ?: "png",
+      dataBase64 = params["data"]?.jsonPrimitive?.content ?: "",
+    )
+
+  public companion object {
+    /** Spawn `xr-composite --serve` and wire a client to its stdio. Stderr inherits the JVM's. */
+    public fun spawn(
+      binary: File,
+      materialsDir: File,
+      width: Int = 1280,
+      height: Int = 800,
+    ): XrServerClient {
+      val process =
+        ProcessBuilder(
+            binary.absolutePath,
+            "--serve",
+            "--materials",
+            materialsDir.absolutePath,
+            "--width",
+            width.toString(),
+            "--height",
+            height.toString(),
+          )
+          .redirectError(ProcessBuilder.Redirect.INHERIT)
+          .start()
+      return XrServerClient(process.outputStream, process.inputStream, process)
+    }
+
+    private fun readFrame(input: InputStream): ByteArray? {
+      var contentLength = -1
+      val headerBuf = ByteArrayOutputStream(64)
+      var sawAny = false
+      while (true) {
+        val line = readHeaderLine(input, headerBuf) ?: return null
+        if (line.isEmpty()) {
+          if (sawAny) break else continue
+        }
+        sawAny = true
+        val colon = line.indexOf(':')
+        if (colon <= 0) continue
+        if (line.substring(0, colon).trim().equals("Content-Length", ignoreCase = true)) {
+          contentLength = line.substring(colon + 1).trim().toIntOrNull() ?: -1
+        }
+      }
+      if (contentLength < 0) return null
+      val payload = ByteArray(contentLength)
+      var off = 0
+      while (off < contentLength) {
+        val n = input.read(payload, off, contentLength - off)
+        if (n < 0) return null
+        off += n
+      }
+      return payload
+    }
+
+    private fun readHeaderLine(input: InputStream, buf: ByteArrayOutputStream): String? {
+      buf.reset()
+      while (true) {
+        val b = input.read()
+        if (b < 0) return if (buf.size() == 0) null else buf.toString(Charsets.US_ASCII.name())
+        if (b == '\n'.code) {
+          val bytes = buf.toByteArray()
+          val end =
+            if (bytes.isNotEmpty() && bytes.last() == '\r'.code.toByte()) bytes.size - 1
+            else bytes.size
+          return String(bytes, 0, end, Charsets.US_ASCII)
+        }
+        buf.write(b)
+      }
+    }
+  }
+}

--- a/renderers/xr-client/src/test/kotlin/ee/schimke/composeai/renderer/xr/client/XrServerClientTest.kt
+++ b/renderers/xr-client/src/test/kotlin/ee/schimke/composeai/renderer/xr/client/XrServerClientTest.kt
@@ -1,0 +1,231 @@
+package ee.schimke.composeai.renderer.xr.client
+
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+import java.io.OutputStream
+import java.io.PipedInputStream
+import java.io.PipedOutputStream
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.long
+import kotlinx.serialization.json.put
+
+/**
+ * Exercises [XrServerClient]'s framing + request/notification demultiplexing against an in-memory
+ * fake server over piped streams — no native binary required (the real end-to-end is covered by
+ * `renderers/xr-composite/test/serve_smoke.py`). Verifies that `render` / `xr/updatePanels` return
+ * the `streamFrame` the server pushed before its ack, in order.
+ */
+class XrServerClientTest {
+
+  private val json = Json { ignoreUnknownKeys = true }
+  private lateinit var serverThread: Thread
+
+  @AfterTest
+  fun tearDown() {
+    if (::serverThread.isInitialized) serverThread.join(2_000)
+  }
+
+  /**
+   * A scripted fake server: reads each request and replies, pushing a streamFrame before the ack.
+   */
+  private fun startFakeServer(serverIn: InputStream, serverOut: OutputStream) {
+    serverThread =
+      Thread {
+          var seq = 0L
+          while (true) {
+            val frame = readFrame(serverIn) ?: return@Thread
+            val req = json.parseToJsonElement(frame.toString(Charsets.UTF_8)).jsonObject
+            val method = req["method"]?.jsonPrimitive?.content ?: continue
+            val id = req["id"]?.jsonPrimitive?.long
+            when (method) {
+              "initialize" ->
+                writeFrame(
+                  serverOut,
+                  result(
+                    id!!,
+                    buildJsonObject {
+                      put(
+                        "capabilities",
+                        buildJsonObject {
+                          put("render", true)
+                          put("updatePanels", true)
+                          put("streamFrame", true)
+                        },
+                      )
+                    },
+                  ),
+                )
+              "render",
+              "xr/updatePanels" -> {
+                seq += 1
+                // Push the frame first (as the native server does), then the ack.
+                writeFrame(serverOut, streamFrame(seq, "frame-$seq"))
+                writeFrame(
+                  serverOut,
+                  result(
+                    id!!,
+                    buildJsonObject {
+                      put("ok", true)
+                      put("seq", seq)
+                    },
+                  ),
+                )
+              }
+              "exit" -> return@Thread
+            }
+          }
+        }
+        .apply {
+          isDaemon = true
+          start()
+        }
+  }
+
+  @Test
+  fun initializeRenderAndUpdatePanelsReturnFramesInOrder() {
+    // client.output -> server.input ; server.output -> client.input
+    val clientToServer = PipedOutputStream()
+    val serverIn = PipedInputStream(clientToServer, 1 shl 16)
+    val serverToClient = PipedOutputStream()
+    val clientIn = PipedInputStream(serverToClient, 1 shl 16)
+    startFakeServer(serverIn, serverToClient)
+
+    val client = XrServerClient(clientToServer, clientIn, process = null)
+
+    val caps = client.initialize()
+    assertEquals(true, caps["render"]?.jsonPrimitive?.content?.toBoolean())
+
+    val scene = buildJsonObject {
+      put("version", 1)
+      put("units", "dp")
+      put("camera", buildJsonObject { put("kind", "orbit") })
+      put("panels", buildJsonArray {})
+    }
+    val f1 = client.render(scene, sceneDir = ".")
+    assertEquals(1L, f1.seq)
+    assertEquals("png", f1.encoding)
+    assertEquals("frame-1", f1.dataBase64)
+
+    val f2 =
+      client.updatePanels(
+        buildJsonArray {
+          add(
+            buildJsonObject {
+              put("id", "top")
+              put(
+                "poseInRoot",
+                buildJsonObject {
+                  put(
+                    "translation",
+                    buildJsonObject {
+                      put("x", 1)
+                      put("y", 2)
+                      put("z", 3)
+                    },
+                  )
+                  put(
+                    "rotation",
+                    buildJsonObject {
+                      put("x", 0)
+                      put("y", 0)
+                      put("z", 0)
+                      put("w", 1)
+                    },
+                  )
+                },
+              )
+            }
+          )
+        }
+      )
+    assertEquals(2L, f2.seq)
+    assertEquals("frame-2", f2.dataBase64)
+    assertTrue(f2.seq > f1.seq)
+
+    client.exit()
+  }
+
+  // ---- framing helpers (mirror the wire format the client speaks) ----
+
+  private fun result(id: Long, result: JsonObject): JsonObject = buildJsonObject {
+    put("jsonrpc", "2.0")
+    put("id", id)
+    put("result", result)
+  }
+
+  private fun streamFrame(seq: Long, data: String): JsonObject = buildJsonObject {
+    put("jsonrpc", "2.0")
+    put("method", "streamFrame")
+    put(
+      "params",
+      buildJsonObject {
+        put("encoding", "png")
+        put("width", 64)
+        put("height", 48)
+        put("seq", seq)
+        put("data", data)
+      },
+    )
+  }
+
+  private fun writeFrame(out: OutputStream, message: JsonObject) {
+    val payload = json.encodeToString(JsonObject.serializer(), message).toByteArray(Charsets.UTF_8)
+    synchronized(out) {
+      out.write("Content-Length: ${payload.size}\r\n\r\n".toByteArray(Charsets.US_ASCII))
+      out.write(payload)
+      out.flush()
+    }
+  }
+
+  private fun readFrame(input: InputStream): ByteArray? {
+    var contentLength = -1
+    val buf = ByteArrayOutputStream(64)
+    var sawAny = false
+    while (true) {
+      val line = readHeaderLine(input, buf) ?: return null
+      if (line.isEmpty()) {
+        if (sawAny) break else continue
+      }
+      sawAny = true
+      val colon = line.indexOf(':')
+      if (colon > 0 && line.substring(0, colon).trim().equals("Content-Length", true)) {
+        contentLength = line.substring(colon + 1).trim().toIntOrNull() ?: -1
+      }
+    }
+    if (contentLength < 0) return null
+    val payload = ByteArray(contentLength)
+    var off = 0
+    while (off < contentLength) {
+      val n = input.read(payload, off, contentLength - off)
+      if (n < 0) return null
+      off += n
+    }
+    return payload
+  }
+
+  private fun readHeaderLine(input: InputStream, buf: ByteArrayOutputStream): String? {
+    buf.reset()
+    while (true) {
+      val b = input.read()
+      if (b < 0) return if (buf.size() == 0) null else buf.toString(Charsets.US_ASCII.name())
+      if (b == '\n'.code) {
+        val bytes = buf.toByteArray()
+        val end =
+          if (bytes.isNotEmpty() && bytes.last() == '\r'.code.toByte()) bytes.size - 1
+          else bytes.size
+        return String(bytes, 0, end, Charsets.US_ASCII)
+      }
+      buf.write(b)
+    }
+  }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -193,6 +193,12 @@ include(":renderer-xr")
 
 project(":renderer-xr").projectDir = file("renderers/xr")
 
+// JVM client for the native `xr-composite --serve` render server (RENDERER_SERVICE RFC). The
+// daemon's future XR RenderSession backend wraps this.
+include(":renderer-xr-client")
+
+project(":renderer-xr-client").projectDir = file("renderers/xr-client")
+
 include(":daemon:core")
 
 // Per-product data-product modules — each `data/<product>/` carries a `core` (generic Android /


### PR DESCRIPTION
## Summary

First JVM-side increment toward the [renderer-service RFC](https://github.com/yschimke/compose-ai-tools/blob/main/docs/design/xr-spatial/RENDERER_SERVICE.md), building on the native `xr-composite --serve` server that landed in #1779.

Adds a `:renderer-xr-client` module with **`XrServerClient`** — the client the daemon's future XR `RenderSession` backend will wrap to spawn/multiplex the native process and proxy its frames to VS Code/CLI/MCP.

- Speaks the same LSP-style `Content-Length` JSON-RPC framing as the daemon's subprocess backend (modeled on `HarnessClient`); a background reader thread demultiplexes id-matched responses from `streamFrame` notifications.
- API: `initialize` (→ capabilities), `render` (a `SpatialScene`), `updatePanels` (per-frame mutations), `exit`.
- Constructed over raw streams (`internal` ctor) so it's unit-testable without a process; `XrServerClient.spawn()` wires it to a real `xr-composite --serve` child.

## Test plan

- [x] `:renderer-xr-client:test` drives the client over in-memory pipes against a scripted fake server (`initialize → render → xr/updatePanels`, frames returned in order, seq increments) — **no binary needed**, runs in plain `./gradlew test`.
- [x] `ktfmtCheckAll` clean (new module auto-joins the gate).
- [x] The real native end-to-end stays covered by `renderers/xr-composite/test/serve_smoke.py` (the Python smoke from #1779).

## Next (separate PR)

The daemon `RenderSession` backend that owns this client, supervises the native process, surfaces XR as a preview kind, and proxies frames through the existing `FrameStreamRegistry` — plus an XR-binary-gated daemon-harness scenario.


---
_Generated by [Claude Code](https://claude.ai/code/session_01X8ZwHy8Sgg5eVJzNqr1LMb)_