### PR TITLE
feat(lottie): live timeline scrub via held session (interactive/setLottie)

### DIFF
--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/InteractiveSession.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/InteractiveSession.kt
@@ -85,6 +85,25 @@ interface InteractiveSession : AutoCloseable {
   fun dispatchRemoteComposeChange(change: RemoteComposeChange): Boolean = false
 
   /**
+   * Push one Lottie timeline scrub into the held composition without a fresh `renderNow`. The
+   * desktop session holds the progress in Compose snapshot state that `LocalLottieProgress` reads,
+   * so setting it recomposes the held scene to [progress]; the next [render] (the
+   * `interactive/setLottie` handler requests one) paints that frame. This is the live-scrub payoff:
+   * dragging the panel's timeline slider re-renders the same scene via recomposition instead of
+   * standing up a new scene per tick.
+   *
+   * Default returns `false` so hosts without a live Lottie binding (Android today — there is no
+   * Compottie Android render path; any host where the held scene carries no Lottie state) cleanly
+   * surface "no live scrub" and the caller's fallback re-issues a `renderNow` with
+   * `overrides.lottie.progress`. The desktop session mutates the scene's `lottieProgressState`,
+   * remembers it for cross-render stickiness, and returns `true`.
+   *
+   * @param progress timeline position in `0f..1f` (implementations clamp); mirrors the panel's
+   *   `setLottieProgress` value.
+   */
+  fun dispatchLottieProgress(progress: Float): Boolean = false
+
+  /**
    * Accessibility-driven dispatch: resolve a node by its visible content description and invoke the
    * named
    * [`SemanticsActions`](https://developer.android.com/reference/kotlin/androidx/compose/ui/semantics/SemanticsActions)

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -425,6 +425,16 @@ class JsonRpcServer(
    */
   private val interactiveRenderInFlight = ConcurrentHashMap<String, Boolean>()
 
+  /**
+   * Latest pending Lottie scrub position per `frameStreamId`, set by `interactive/setLottie`.
+   * Unlike [pendingInteractiveInputs] this is a single value, not a queue: a slider drag fires many
+   * ticks but only the most recent one matters, so each tick overwrites the last. The in-flight
+   * render worker dispatches it into the held session right before rendering (and the `finally`
+   * re-claim treats a non-empty entry as pending work), so the final drag position always paints
+   * even if it arrived while an earlier tick's render was in flight.
+   */
+  private val pendingLottieScrub = ConcurrentHashMap<String, Float>()
+
   /** Per-held-session frame loops for live previews with time-based animations. */
   private val interactiveFrameLoops = ConcurrentHashMap<String, Thread>()
 
@@ -2427,6 +2437,7 @@ class JsonRpcServer(
   private fun cleanupClosedInteractiveSession(streamId: String) {
     interactiveSessions.remove(streamId)
     pendingInteractiveInputs.remove(streamId)
+    pendingLottieScrub.remove(streamId)
     interactiveRenderInFlight.remove(streamId)
     streamSessions.remove(streamId)
     streamRegistry.unregister(streamId)
@@ -2466,6 +2477,24 @@ class JsonRpcServer(
       )
       e.printStackTrace(System.err)
     }
+  }
+
+  /**
+   * `interactive/setLottie` — scrub the held Lottie scene's timeline in place. Records the latest
+   * progress for the stream (coalescing rapid drag ticks to the most recent) and requests a render
+   * through the held session; [submitInteractiveRenderAsync] dispatches the pending scrub into the
+   * session via [InteractiveSession.dispatchLottieProgress] right before painting. No held session
+   * for this stream → drop silently (the panel's `renderNow.overrides.lottie.progress` fallback is
+   * the canonical path, as with `interactive/setRemoteCompose`).
+   */
+  private fun handleInteractiveSetLottie(
+    params: ee.schimke.composeai.daemon.protocol.InteractiveSetLottieParams
+  ) {
+    if (classpathDirtyEmitted.get() || shutdownRequested.get()) return
+    val target = interactiveTargets[params.frameStreamId] ?: return
+    val session = interactiveSessions[params.frameStreamId] ?: return
+    pendingLottieScrub[params.frameStreamId] = params.progress
+    requestInteractiveRender(params.frameStreamId, target.previewId, session)
   }
 
   private fun handleInteractiveInput(
@@ -2536,6 +2565,11 @@ class JsonRpcServer(
               val next = queue.poll() ?: break
               session.dispatch(next)
             }
+            // Apply the latest pending Lottie scrub (if any) before rendering — coalesced to the
+            // most recent drag position. Mutates the held scene's snapshot state so the render
+            // below
+            // paints the scrubbed frame.
+            pendingLottieScrub.remove(streamId)?.let { session.dispatchLottieProgress(it) }
             val result = session.render(hostId)
             renderResultsQueue.put(result)
           } catch (e: Throwable) {
@@ -2571,11 +2605,10 @@ class JsonRpcServer(
               cleanupClosedInteractiveSession(streamId)
             } else {
               val pending = pendingInteractiveInputs[streamId]
-              if (
-                pending != null &&
-                  pending.isNotEmpty() &&
-                  interactiveRenderInFlight.putIfAbsent(streamId, true) == null
-              ) {
+              val hasPendingWork =
+                (pending != null && pending.isNotEmpty()) ||
+                  pendingLottieScrub.containsKey(streamId)
+              if (hasPendingWork && interactiveRenderInFlight.putIfAbsent(streamId, true) == null) {
                 val curSession = interactiveSessions[streamId]
                 val curTarget = interactiveTargets[streamId]
                 if (curSession != null && curTarget != null && !curSession.isClosed) {
@@ -2585,6 +2618,7 @@ class JsonRpcServer(
                   // the slot. Stale inputs against a stopped stream are dropped per the v1
                   // contract (handleInteractiveInput would also short-circuit on the next poll).
                   pendingInteractiveInputs.remove(streamId)
+                  pendingLottieScrub.remove(streamId)
                   interactiveRenderInFlight.remove(streamId)
                 }
               }
@@ -2973,6 +3007,10 @@ class JsonRpcServer(
           n,
         ) {
           handleInteractiveSetRemoteCompose(it)
+        }
+      "interactive/setLottie" ->
+        tryDecode(ee.schimke.composeai.daemon.protocol.InteractiveSetLottieParams.serializer(), n) {
+          handleInteractiveSetLottie(it)
         }
       "stream/stop" ->
         tryDecode(ee.schimke.composeai.daemon.protocol.StreamStopParams.serializer(), n) {

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -1549,6 +1549,27 @@ data class InteractiveSetRemoteComposeParams(
 )
 
 /**
+ * `interactive/setLottie` notification — push one Lottie timeline scrub into a held session so the
+ * scene recomposes to the new frame via snapshot state, no fresh `renderNow`. The Lottie analogue
+ * of [InteractiveSetRemoteComposeParams]: the panel's timeline slider sends this on every drag tick
+ * when a live session is up, and the daemon coalesces ticks to the latest before painting.
+ *
+ * Distinct from `renderNow.overrides.lottie.progress` (which still works and re-renders from a
+ * fresh scene): this is the snappy live-session path that scrubs the held scene in place. Backends
+ * without a live Lottie binding silently drop the notification and the panel falls back to
+ * `renderNow`.
+ */
+@Serializable
+data class InteractiveSetLottieParams(
+  /**
+   * Routing key — same `frameStreamId` `interactive/start` allocated and `interactive/input` uses.
+   */
+  val frameStreamId: String,
+  /** Timeline position in `0f..1f` (the daemon clamps). */
+  val progress: Float,
+)
+
+/**
  * Discriminated edit shape for `interactive/setRemoteCompose`. Mirrors the VS Code panel's
  * `RemoteComposeChangeDetail` so the wire shape is the same on both sides — the host can forward
  * the panel's payload verbatim without restructuring.

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/InteractiveSessionPlumbingTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/InteractiveSessionPlumbingTest.kt
@@ -156,6 +156,67 @@ class InteractiveSessionPlumbingTest {
   }
 
   @Test(timeout = 30_000)
+  fun setLottie_scrubs_held_session_and_renders() {
+    val tmp = Files.createTempDirectory("interactive-session-setlottie").toFile()
+    val pngFile = File(tmp, "lottie-A.png").apply { writeBytes(testPngBytes(seed = 0)) }
+    val host = SessionAwareFakeHost(pngFile)
+
+    val (_, serverThread, clientToServerOut, received, exitLatch) = bringUpServer(host)
+    resourcesToClose.add(AutoCloseable { runCatching { clientToServerOut.close() } })
+
+    handshake(clientToServerOut, received)
+
+    writeFrame(
+      clientToServerOut,
+      """{"jsonrpc":"2.0","id":20,"method":"interactive/start","params":{"previewId":"lottie-A"}}""",
+    )
+    val startResp = pollUntil(received) { it["id"]?.jsonPrimitive?.intOrNull == 20 }
+    val streamId =
+      startResp!!["result"]!!.jsonObject["frameStreamId"]!!.jsonPrimitive.contentOrNull!!
+    val session = host.lastSession()!!
+
+    // interactive/setLottie — scrubs the held session's progress and paints a frame, without any
+    // interactive/input (no click dispatch).
+    writeFrame(
+      clientToServerOut,
+      """{"jsonrpc":"2.0","method":"interactive/setLottie","params":{"frameStreamId":"$streamId","progress":0.42}}""",
+    )
+    val finished =
+      pollUntil(received) { it["method"]?.jsonPrimitive?.contentOrNull == "renderFinished" }
+    assertNotNull("interactive/setLottie must produce a renderFinished", finished)
+    assertEquals("lottie-A", finished!!["params"]!!.jsonObject["id"]?.jsonPrimitive?.contentOrNull)
+    assertEquals("scrub should dispatch progress once", 1, session.lottieDispatchCount.get())
+    assertEquals(0.42f, session.lastLottieProgress()!!, 1e-4f)
+    assertEquals(
+      "scrub must not go through the click dispatch path",
+      0,
+      session.dispatchCount.get(),
+    )
+    assertTrue("scrub should render through the held session", session.renderCount.get() >= 1)
+
+    // Stop, then a stale setLottie — must not dispatch or render.
+    writeFrame(
+      clientToServerOut,
+      """{"jsonrpc":"2.0","method":"interactive/stop","params":{"frameStreamId":"$streamId"}}""",
+    )
+    Thread.sleep(50)
+    val rendersAfterStop = session.renderCount.get()
+    writeFrame(
+      clientToServerOut,
+      """{"jsonrpc":"2.0","method":"interactive/setLottie","params":{"frameStreamId":"$streamId","progress":0.9}}""",
+    )
+    val stale =
+      pollUntil(received, timeoutMs = 500) {
+        it["method"]?.jsonPrimitive?.contentOrNull == "renderFinished"
+      }
+    assertNull("stale interactive/setLottie must not produce a renderFinished", stale)
+    assertEquals("scrub must not dispatch after stop", 1, session.lottieDispatchCount.get())
+    assertEquals(rendersAfterStop, session.renderCount.get())
+
+    teardownServer(clientToServerOut, received, serverThread, exitLatch)
+  }
+
+  @Test(timeout = 30_000)
   fun start_with_live_frame_loop_renders_without_input() {
     val tmp = Files.createTempDirectory("interactive-session-live-loop").toFile()
     val pngFile = File(tmp, "preview-A.png").apply { writeBytes(testPngBytes(seed = 0)) }
@@ -627,12 +688,16 @@ private class RecordingSession(
   val dispatchCount = AtomicInteger(0)
   val renderCount = AtomicInteger(0)
   val closeCount = AtomicInteger(0)
+  val lottieDispatchCount = AtomicInteger(0)
 
   @Volatile private var lastClickX: Int? = null
   @Volatile private var lastClickY: Int? = null
+  @Volatile private var lastLottieProgress: Float? = null
   @Volatile private var closedFlag: Boolean = false
 
   fun lastClick(): Pair<Int, Int>? = lastClickX?.let { x -> lastClickY?.let { y -> x to y } }
+
+  fun lastLottieProgress(): Float? = lastLottieProgress
 
   /**
    * Flip the session into the closed state without going through [close] — models a host-internal
@@ -657,6 +722,13 @@ private class RecordingSession(
     dispatchCount.incrementAndGet()
     lastClickX = input.pixelX
     lastClickY = input.pixelY
+  }
+
+  override fun dispatchLottieProgress(progress: Float): Boolean {
+    if (closedFlag) return false
+    lottieDispatchCount.incrementAndGet()
+    lastLottieProgress = progress
+    return true
   }
 
   override fun render(requestId: Long, advanceTimeMs: Long?): RenderResult {

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopInteractiveSession.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopInteractiveSession.kt
@@ -189,6 +189,21 @@ class DesktopInteractiveSession(
     }
   }
 
+  override fun dispatchLottieProgress(progress: Float): Boolean {
+    if (closed) return false
+    val clamped = progress.coerceIn(0f, 1f)
+    runOnSceneThread {
+      if (closed) return@runOnSceneThread
+      // Mutate the snapshot state `LocalLottieProgress` reads inside the held composition → the
+      // scene recomposes to the new frame; the `interactive/setLottie` handler requests the
+      // [render] that paints it. Also remember it per preview so a later fresh render (a save /
+      // warmup re-render that bypasses this session) stays pinned at the scrubbed position.
+      state.lottieProgressState.value = clamped
+      state.spec.previewId?.let { LottieProgressController.remember(it, clamped) }
+    }
+    return !closed
+  }
+
   override fun render(requestId: Long, advanceTimeMs: Long?): RenderResult {
     check(!closed) { "DesktopInteractiveSession.render() called after close()" }
     return runOnSceneThreadForResult {

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -10,10 +10,12 @@ import androidx.compose.material3.Typography
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.InternalComposeApi
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.ProvidedValue
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.currentComposer
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.reflect.ComposableMethod
 import androidx.compose.runtime.reflect.getDeclaredComposableMethod
 import androidx.compose.runtime.remember
@@ -259,6 +261,20 @@ class RenderEngine(
     // as `LocalDensity` below since a few ui-text/text-foundation paths read it directly during
     // composition rather than going through the scene density.
     val density = Density(spec.density, spec.fontScale ?: 1.0f)
+
+    // Resolve the effective Lottie timeline position and hold it in snapshot state so a held
+    // session can live-scrub it. An explicit `overrides.lottie.progress` (a panel scrub) wins and
+    // is remembered per preview; a render with no override (a save / warmup re-render through the
+    // fresh-scene path) re-uses the last scrub so the captured frame — and the slider — stay pinned
+    // at the scrubbed position. `LocalLottieProgress` reads `.value` inside the composition below,
+    // so [DesktopInteractiveSession.dispatchLottieProgress] mutating this state recomposes the held
+    // scene without a fresh setUp — the held-scene scrub path. See [LottieProgressController].
+    val lottieProgressState: MutableState<Float?> =
+      mutableStateOf(
+        spec.overrides?.lottie?.progress?.also { p ->
+          spec.previewId?.let { LottieProgressController.remember(it, p) }
+        } ?: spec.previewId?.let { LottieProgressController.progressFor(it) }
+      )
     val scene =
       try {
         ImageComposeScene(width = spec.widthPx, height = spec.heightPx, density = density)
@@ -283,24 +299,17 @@ class RenderEngine(
               RenderSpec.SpecUiMode.LIGHT -> SystemTheme.Light
               null -> SystemTheme.Unknown
             }
-          // Resolve the effective Lottie timeline position. An explicit `overrides.lottie.progress`
-          // (a panel scrub) wins and is remembered per preview; a render that carries no override
-          // (a save / warmup re-render through this fresh-scene path) re-uses the last scrub so the
-          // captured frame — and the slider — stay pinned at the scrubbed position. See
-          // [LottieProgressController].
-          val lottieProgress: Float? =
-            spec.overrides?.lottie?.progress?.also { p ->
-              spec.previewId?.let { LottieProgressController.remember(it, p) }
-            } ?: spec.previewId?.let { LottieProgressController.progressFor(it) }
           CompositionLocalProvider(
             LocalInspectionMode provides inspectionMode,
             androidx.compose.ui.LocalSystemTheme provides systemTheme,
             LocalDensity provides density,
             // Interactive Lottie scrubbing: a non-null progress lands the captured frame at that
             // timeline position, winning over the composable's authored progress (file-discovered
-            // `LottiePreview` below, or any `@Preview` calling it). Sticky across renders via
-            // [LottieProgressController] so an unrelated re-render keeps the scrubbed frame.
-            ee.schimke.composeai.preview.lottie.LocalLottieProgress provides lottieProgress,
+            // `LottiePreview` below, or any `@Preview` calling it). Read from snapshot state so a
+            // held session's `dispatchLottieProgress` recomposes live; sticky across fresh renders
+            // via [LottieProgressController] so an unrelated re-render keeps the scrubbed frame.
+            ee.schimke.composeai.preview.lottie.LocalLottieProgress provides
+              lottieProgressState.value,
             *localeProviders,
           ) {
             if (previewContextCapture?.shouldCapture(spec.previewId, spec.renderMode) == true) {
@@ -327,10 +336,24 @@ class RenderEngine(
                   // running composition. Mirrors `:renderer-desktop`'s InvokeComposable. Honours
                   // `@PreviewWrapper(SomeProvider::class)` by routing through the wrapper's `Wrap`.
                   if (isLottie) {
-                    LottiePreview(
-                      asset = spec.assetPath.orEmpty(),
-                      modifier = Modifier.fillMaxSize(),
-                    )
+                    // Drive the file-discovered Lottie through the draw-time `progress` lambda
+                    // reading the snapshot state, so a held-session scrub (mutating
+                    // `lottieProgressState`) repaints on the next `render()` by redraw alone — no
+                    // recomposition required. This is the same redraw-only path `renderLottieGif`
+                    // uses to sweep a single held scene into GIF frames. Shadow
+                    // `LocalLottieProgress`
+                    // to null here so the overload's draw-time `progress()` wins; the outer provide
+                    // still targets user `@Preview`s that call `LottiePreview` themselves.
+                    CompositionLocalProvider(
+                      ee.schimke.composeai.preview.lottie.LocalLottieProgress provides null
+                    ) {
+                      LottiePreview(
+                        asset = spec.assetPath.orEmpty(),
+                        modifier = Modifier.fillMaxSize(),
+                      ) {
+                        lottieProgressState.value ?: 0f
+                      }
+                    }
                   } else {
                     InvokeWithOptionalWrapper(composableMethod!!, spec.wrapperClassName)
                   }
@@ -364,6 +387,7 @@ class RenderEngine(
       previousContext = previousContext,
       slotTableCapture = slotTableCapture,
       themeFallbackCapture = themeFallbackCapture,
+      lottieProgressState = lottieProgressState,
     )
   }
 
@@ -389,6 +413,19 @@ class RenderEngine(
     useWallClockFrameTime: Boolean = false,
   ): RenderResult {
     val startNs = System.nanoTime()
+
+    // Flush snapshot state written out-of-composition since the last render so the held scene
+    // observes it before painting. The held-session scrub path mutates `lottieProgressState` from
+    // the scene thread *between* renderOnce calls
+    // (DesktopInteractiveSession.dispatchLottieProgress);
+    // the file-Lottie content reads it in its draw-time `progress` lambda, but that read only
+    // invalidates once apply-notifications fire. Same pairing `:renderers:desktop`'s
+    // `renderLottieGif`
+    // uses (`sendApplyNotifications()` after each write, before `render()`). Event-driven writes
+    // (clicks) are flushed by the scene's own pointer processing; this covers the out-of-band
+    // write.
+    // Harmless for the one-shot path — nothing is pending right after setUp.
+    androidx.compose.runtime.snapshots.Snapshot.sendApplyNotifications()
 
     // Render two frames so any LaunchedEffect / animations have a tick to settle. Same reasoning
     // as `:renderer-desktop`'s renderPreview.
@@ -549,6 +586,14 @@ class RenderEngine(
     internal val previousContext: ClassLoader?,
     internal val slotTableCapture: PreviewSlotTableCapture?,
     internal val themeFallbackCapture: MaterialThemeFallbackCapture?,
+    /**
+     * Snapshot-backed Lottie timeline position read by `LocalLottieProgress` inside the held
+     * composition. Mutating it on the scene thread (via
+     * [DesktopInteractiveSession.dispatchLottieProgress]) recomposes the scene to the new frame
+     * without a fresh [setUp] — the live-scrub path. `null` for non-Lottie previews / renders that
+     * never carried a progress.
+     */
+    internal val lottieProgressState: MutableState<Float?> = mutableStateOf(null),
   ) {
     internal fun previewContext(): PreviewContext {
       val slotTables = slotTableCapture?.snapshot().orEmpty()

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/RenderEngineLottieScrubTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/RenderEngineLottieScrubTest.kt
@@ -69,6 +69,45 @@ class RenderEngineLottieScrubTest {
   }
 
   @Test
+  fun liveScrubRecomposesHeldSceneInPlace() {
+    // The held-session live-scrub path: set up the scene once, then mutate the snapshot progress
+    // state (exactly what DesktopInteractiveSession.dispatchLottieProgress does) and render again
+    // WITHOUT a fresh setUp. The second frame must differ — proof `LocalLottieProgress` reads the
+    // snapshot state reactively so the held scene recomposes to the new timeline position.
+    val engine = RenderEngine(outputDir = tempFolder.newFolder("held"))
+    val spec =
+      RenderSpec(
+        previewId = "lottie__held",
+        className = "",
+        functionName = "spin.json",
+        kind = "LOTTIE",
+        assetPath = "lottie/spin.json",
+        widthPx = 48,
+        heightPx = 48,
+        density = 1.0f,
+        showBackground = true,
+        outputBaseName = "spin",
+        overrides = null,
+      )
+    val state = engine.setUp(spec, classLoader = javaClass.classLoader, inspectionMode = false)
+    try {
+      engine.renderOnce(state, requestId = 1L)
+      val atZero = state.outputFile.readBytes()
+
+      state.lottieProgressState.value = 0.25f
+      engine.renderOnce(state, requestId = 2L)
+      val atQuarter = state.outputFile.readBytes()
+
+      assertFalse(
+        "mutating the held scene's progress state must recompose to a different frame",
+        atZero.contentEquals(atQuarter),
+      )
+    } finally {
+      engine.tearDown(state)
+    }
+  }
+
+  @Test
   fun scrubPersistsAcrossRenderWithoutOverride() {
     // Scrub to 0.25, then re-render the SAME preview with no override — the controller re-applies
     // the last scrub, so the frame stays at 0.25 rather than snapping back to frame 0.

--- a/docs/LOTTIE_PREVIEWS.md
+++ b/docs/LOTTIE_PREVIEWS.md
@@ -132,13 +132,17 @@ interactive editing + a VS Code presenter.
    `kind=LOTTIE` preview's timeline straight from the asset — `totalFrames`, `frameRate`,
    `durationMillis`, `width`, `height` — with no render (`requiresRerender = false`). The VS Code
    panel ships a **Lottie** bundle (`lottieScrubberPresenter.ts`): a timeline slider that reads that
-   metadata for its range/labels and, on drag, posts `setLottieProgress` → the host re-renders via
-   `renderNow.overrides.lottie.progress` (the wire path from #1). The scrub is **sticky per preview**:
-   `LottieProgressController` remembers the last position, and `RenderEngine` re-applies it on any
-   later render that carries no override (a save / warmup re-render), so the frame — and the slider —
-   stay pinned instead of snapping back to frame 0. Follow-on polish: markers, and a held-scene
-   `interactive/setLottie` for sub-frame scrubbing via snapshot recomposition instead of a fresh
-   render (mirrors `interactive/setRemoteCompose`).
+   metadata for its range/labels and, on drag, posts `setLottieProgress`. The scrub is **sticky per
+   preview**: `LottieProgressController` remembers the last position, and `RenderEngine` re-applies it
+   on any later render that carries no override (a save / warmup re-render), so the frame — and the
+   slider — stay pinned instead of snapping back to frame 0. When a **live session** is up for the
+   preview the panel prefers `interactive/setLottie` (the Lottie analogue of
+   `interactive/setRemoteCompose`): the daemon mutates the held scene's snapshot progress state and
+   the file-Lottie content reads it in its draw-time `progress` lambda, so a drag repaints the held
+   scene in place — no fresh `ImageComposeScene` per tick. The daemon coalesces rapid ticks to the
+   latest. Otherwise it falls back to `renderNow.overrides.lottie.progress` (the wire path from #1).
+   Follow-on polish: markers, and auto-starting a held session for the duration of a scrub so the
+   efficient path applies even without LIVE mode.
 3. **Android backend.** A Robolectric render path (Compottie has an Android variant) so Lottie
    previews work in `:samples:android`, sibling to the Android-only runtime modules.
 4. **Rive.** Tracked separately — Rive's Kotlin runtime is Android/JNI-only with **no** JVM/Desktop

--- a/vscode-extension/src/daemon/daemonClient.ts
+++ b/vscode-extension/src/daemon/daemonClient.ts
@@ -27,6 +27,7 @@ import {
     InitializeParams,
     InitializeResult,
     InteractiveInputParams,
+    InteractiveSetLottieParams,
     InteractiveSetRemoteComposeParams,
     InteractiveStartParams,
     InteractiveStartResult,
@@ -323,6 +324,18 @@ export class DaemonClient {
         params: InteractiveSetRemoteComposeParams,
     ): void {
         this.notify("interactive/setRemoteCompose", params);
+    }
+
+    /**
+     * Notification — scrub a held Lottie scene's timeline in place. The
+     * daemon mutates the held composition's snapshot progress state, so the
+     * next streaming frame paints the new timeline position without a fresh
+     * `renderNow.overrides.lottie.progress` round-trip. Backends without a
+     * live Lottie binding silently drop it; the caller falls back to
+     * `renderNow`.
+     */
+    interactiveSetLottie(params: InteractiveSetLottieParams): void {
+        this.notify("interactive/setLottie", params);
     }
 
     /**

--- a/vscode-extension/src/daemon/daemonProtocol.ts
+++ b/vscode-extension/src/daemon/daemonProtocol.ts
@@ -1044,6 +1044,20 @@ export interface InteractiveSetRemoteComposeParams {
 }
 
 /**
+ * `interactive/setLottie` notification params — scrub a held Lottie scene's timeline in place. The
+ * Lottie analogue of {@link InteractiveSetRemoteComposeParams}: the panel's timeline slider sends
+ * this on every drag tick when a live session is up, and the daemon coalesces ticks to the latest
+ * before recomposing the held scene to that frame — no fresh `renderNow.overrides.lottie.progress`
+ * round-trip. Hosts without a live Lottie binding silently drop it and the panel falls back to
+ * `renderNow`.
+ */
+export interface InteractiveSetLottieParams {
+    frameStreamId: string;
+    /** Timeline position in 0..1 (the daemon clamps). */
+    progress: number;
+}
+
+/**
  * Discriminated edit shape carried by `interactive/setRemoteCompose`. Mirrors the
  * `RemoteComposeChange` Kotlin sealed class on the daemon wire side and the
  * `RemoteComposeChangeDetail` discriminated union the VS Code panel emits. Single shape across

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1403,6 +1403,7 @@ export async function activate(
                                   params.frameStreamId,
                               );
                               activeStreamFrameStreams.delete(previewId);
+                              heldSessionStreams.delete(previewId);
                           }
                       },
                       onChannelClosed: (moduleId) => {
@@ -1426,6 +1427,7 @@ export async function activate(
                           }
                           for (const previewId of stale) {
                               activeInteractiveStreams.delete(previewId);
+                              heldSessionStreams.delete(previewId);
                           }
                           // Same hygiene for `composestream/1` streams — frameStreamIds don't survive
                           // a daemon respawn either, so a `requestStreamStop` against a stale id would
@@ -1442,6 +1444,7 @@ export async function activate(
                               const sid =
                                   activeStreamFrameStreams.get(previewId);
                               activeStreamFrameStreams.delete(previewId);
+                              heldSessionStreams.delete(previewId);
                               if (sid) streamFrameIdToPreviewId.delete(sid);
                               panel?.postMessage({
                                   command: "streamStopped",
@@ -6080,18 +6083,19 @@ async function handleSetRemoteComposeNamedValue(
 /**
  * Apply one scrub from the panel's Lottie timeline slider.
  *
- * When a live session is up for the preview (LIVE mode), prefer the held-session path:
- * `interactive/setLottie` mutates the held scene's snapshot progress and recomposes in place, so a
- * slider drag paints sub-frame without standing up a fresh `ImageComposeScene` per tick — efficient
- * live scrubbing. The daemon coalesces rapid ticks to the latest, and the held render persists the
- * scrub via `LottieProgressController` so a later save/warmup render stays pinned. The bundled
- * daemon ships `interactive/setLottie` alongside the live-stream surface, so a live streamId implies
- * support — we don't also fire `renderNow` per tick (that would defeat the point).
+ * When a **held-session-backed** live stream is up for the preview (LIVE mode on a daemon that
+ * returned `heldSession: true`), prefer the held-session path: `interactive/setLottie` mutates the
+ * held scene's snapshot progress and recomposes in place, so a slider drag paints sub-frame without
+ * standing up a fresh `ImageComposeScene` per tick — efficient live scrubbing. The daemon coalesces
+ * rapid ticks to the latest, and the held render persists the scrub via `LottieProgressController`
+ * so a later save/warmup render stays pinned. Only in that case do we skip the `renderNow` fallback.
  *
- * No live session → `renderNow.overrides.lottie.progress` re-renders the held `kind=LOTTIE` preview
- * at that 0..1 position (itself sticky per preview via the controller). Auto-starting a session just
- * for the duration of a scrub — so the efficient path applies even without LIVE mode — is a noted
- * follow-on.
+ * Otherwise — no live stream, or a live stream with no held session (`heldSession: false`, an older
+ * daemon, or a backend lacking the Lottie binding, where `interactive/setLottie` would be silently
+ * dropped) — fall back to `renderNow.overrides.lottie.progress`, which re-renders the held
+ * `kind=LOTTIE` preview at that 0..1 position (itself sticky per preview via the controller).
+ * Auto-starting a held session just for the duration of a scrub — so the efficient path applies even
+ * without LIVE mode — is a noted follow-on.
  */
 async function handleSetLottieProgress(
     previewId: string,
@@ -6106,10 +6110,15 @@ async function handleSetLottieProgress(
     }
     const clamped = Math.min(1, Math.max(0, progress));
 
+    // Only skip the renderNow fallback when a daemon-side held session backs the live stream — that
+    // is the only context where `interactive/setLottie` is guaranteed to paint. For a live stream
+    // without a held session (`heldSession: false`, older daemon, or a backend lacking the Lottie
+    // binding) the notification is silently dropped, so we must fall through to renderNow or the
+    // slider would go dead (PR #1781 review P2).
     const liveStreamId =
         activeStreamFrameStreams.get(previewId) ??
         activeInteractiveStreams.get(previewId);
-    if (liveStreamId && daemonGate) {
+    if (liveStreamId && heldSessionStreams.has(previewId) && daemonGate) {
         const client = await daemonGate.getOrSpawn(
             moduleInfo,
             daemonScheduler.daemonEvents(moduleInfo.modulePath),
@@ -7120,6 +7129,7 @@ async function handleSetInteractive(
         const stream = activeInteractiveStreams.get(previewId);
         if (stream) {
             activeInteractiveStreams.delete(previewId);
+            heldSessionStreams.delete(previewId);
             updateInteractiveStatus();
             const client = await daemonGate?.getOrSpawn(
                 module,
@@ -7170,6 +7180,9 @@ async function handleSetInteractive(
             return;
         }
         activeInteractiveStreams.set(previewId, result.frameStreamId);
+        // This path already returned above when `heldSession === false`, so reaching here means a
+        // held session backs the stream — eligible for the `interactive/setLottie` scrub path.
+        heldSessionStreams.add(previewId);
         updateInteractiveStatus();
         logLine(
             `[interactive] live mode on for ${previewId} (module=${module.modulePath}, ` +
@@ -7242,6 +7255,14 @@ async function handleRequestStreamStart(
         // `lookupActiveStreamId`. See PR #847 reviewer P1.
         activeStreamFrameStreams.set(previewId, result.frameStreamId);
         streamFrameIdToPreviewId.set(result.frameStreamId, previewId);
+        // Only a held-session-backed stream can be scrubbed via `interactive/setLottie`; without
+        // one the notification is dropped and the scrub must renderNow. `activeStreamFrameStreams`
+        // is set regardless, so track the held-session capability separately.
+        if (result.heldSession === true) {
+            heldSessionStreams.add(previewId);
+        } else {
+            heldSessionStreams.delete(previewId);
+        }
         updateInteractiveStatus();
         panel?.postMessage({
             command: "streamStarted",
@@ -7277,6 +7298,7 @@ async function handleRequestStreamStop(previewId: string): Promise<void> {
     }
     activeStreamFrameStreams.delete(previewId);
     streamFrameIdToPreviewId.delete(sid);
+    heldSessionStreams.delete(previewId);
     updateInteractiveStatus();
     const module = previewModuleIndex.get(previewId);
     if (!daemonGate || !daemonScheduler || !module) {
@@ -7334,6 +7356,18 @@ const activeInteractiveStreams = new Map<string, string>();
  */
 const activeStreamFrameStreams = new Map<string, string>();
 const streamFrameIdToPreviewId = new Map<string, string>();
+
+/**
+ * previewIds whose live stream is backed by a daemon-side **held session** (`streamStart` /
+ * `interactiveStart` returned `heldSession: true`). Only these can be scrubbed purely via
+ * `interactive/setLottie`: the daemon mutates the held scene and emits a frame. For a live stream
+ * with no held session (`heldSession: false`, an older daemon, or a backend that inherits
+ * `dispatchLottieProgress()`'s default `false`) the notification is silently dropped, so a scrub
+ * must fall back to `renderNow.overrides.lottie.progress`. Gating the skip-renderNow path on this
+ * set keeps the efficient path correct (PR #1781 review P2). `activeStreamFrameStreams` is populated
+ * even when `heldSession` is false, so membership here — not in that map — is the authority.
+ */
+const heldSessionStreams = new Set<string>();
 
 const activeRecordingSessions = new Map<string, string>();
 

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -6078,12 +6078,20 @@ async function handleSetRemoteComposeNamedValue(
 }
 
 /**
- * Apply one scrub from the panel's Lottie timeline slider. Unlike Remote Compose / permissions
- * there's no override bag to merge — the override is a single scalar — so we just dispatch a fresh
- * `renderNow.overrides.lottie.progress`. The desktop renderer provides it as `LocalLottieProgress`,
- * re-rendering the held `kind=LOTTIE` preview at that 0..1 position. (A held-session
- * `interactive/setLottie` for sub-frame scrubbing is a future optimisation; `renderNow` is the
- * canonical path today.)
+ * Apply one scrub from the panel's Lottie timeline slider.
+ *
+ * When a live session is up for the preview (LIVE mode), prefer the held-session path:
+ * `interactive/setLottie` mutates the held scene's snapshot progress and recomposes in place, so a
+ * slider drag paints sub-frame without standing up a fresh `ImageComposeScene` per tick — efficient
+ * live scrubbing. The daemon coalesces rapid ticks to the latest, and the held render persists the
+ * scrub via `LottieProgressController` so a later save/warmup render stays pinned. The bundled
+ * daemon ships `interactive/setLottie` alongside the live-stream surface, so a live streamId implies
+ * support — we don't also fire `renderNow` per tick (that would defeat the point).
+ *
+ * No live session → `renderNow.overrides.lottie.progress` re-renders the held `kind=LOTTIE` preview
+ * at that 0..1 position (itself sticky per preview via the controller). Auto-starting a session just
+ * for the duration of a scrub — so the efficient path applies even without LIVE mode — is a noted
+ * follow-on.
  */
 async function handleSetLottieProgress(
     previewId: string,
@@ -6097,6 +6105,27 @@ async function handleSetLottieProgress(
         return;
     }
     const clamped = Math.min(1, Math.max(0, progress));
+
+    const liveStreamId =
+        activeStreamFrameStreams.get(previewId) ??
+        activeInteractiveStreams.get(previewId);
+    if (liveStreamId && daemonGate) {
+        const client = await daemonGate.getOrSpawn(
+            moduleInfo,
+            daemonScheduler.daemonEvents(moduleInfo.modulePath),
+        );
+        if (client) {
+            logInfo(
+                `[panel] lottie progress=${clamped.toFixed(3)} for ${previewId} via live session ${liveStreamId}`,
+            );
+            client.interactiveSetLottie({
+                frameStreamId: liveStreamId,
+                progress: clamped,
+            });
+            return;
+        }
+    }
+
     logInfo(
         `[panel] lottie progress=${clamped.toFixed(3)} for ${previewId} via renderNow`,
     );

--- a/vscode-extension/src/test/daemonClient.test.ts
+++ b/vscode-extension/src/test/daemonClient.test.ts
@@ -306,6 +306,24 @@ describe("DaemonClient", () => {
         client.exit();
     });
 
+    it("interactiveSetLottie emits a notification carrying the scrub progress", async () => {
+        const { toServer, toClient } = bidiPair();
+        const frames = captureFrames(toServer);
+        const client = new DaemonClient(toServer, toClient, {});
+        client.interactiveSetLottie({
+            frameStreamId: "stream-42",
+            progress: 0.42,
+        });
+        const sent = (await frames.take()) as JsonRpcRequest;
+        assert.strictEqual(sent.method, "interactive/setLottie");
+        assert.strictEqual((sent as unknown as { id?: number }).id, undefined);
+        assert.deepStrictEqual(sent.params, {
+            frameStreamId: "stream-42",
+            progress: 0.42,
+        });
+        client.exit();
+    });
+
     it("issues monotonically increasing ids", async () => {
         const { toServer, toClient } = bidiPair();
         const frames = captureFrames(toServer);


### PR DESCRIPTION
## Summary

Makes Lottie scrubbing **efficient** when a live session is up: instead of standing up a fresh `ImageComposeScene` per slider tick (`renderNow`), the held scene is scrubbed in place via snapshot state + redraw. The Lottie analogue of `interactive/setRemoteCompose`. Follows on from the merged slider (#1778), which gave us the UI and the sticky-per-preview persistence.

**Daemon**
- `InteractiveSession.dispatchLottieProgress(progress)` — default no-op (Android has no Compottie render path); the desktop session mutates the held scene's snapshot progress state and remembers it in `LottieProgressController` for cross-render stickiness.
- `RenderEngine` holds the Lottie progress in snapshot state on `SceneState` and drives the file-discovered Lottie through the **draw-time `progress` lambda** — the redraw-only path `renderLottieGif` already uses — with `Snapshot.sendApplyNotifications()` before each render so an out-of-composition write is observed. A held-scene mutation then repaints on the next `render()` with **no recomposition**.
- `interactive/setLottie` notification (`InteractiveSetLottieParams`) → a handler that **coalesces** rapid drag ticks to the latest per stream and requests a held-session render; the in-flight re-claim treats a pending scrub as work, so the final drag position always paints even if it arrived mid-render. Cleared alongside pending inputs on stop/cleanup.

**Extension**
- `daemonClient.interactiveSetLottie` + protocol type.
- `handleSetLottieProgress` prefers the live session when one exists (so **no `renderNow` per tick**), else falls back to `renderNow.overrides.lottie.progress` (itself sticky via the controller).

The efficient path applies whenever LIVE mode is on for the preview. Auto-starting a held session purely for the duration of a scrub — so it applies even without LIVE mode — is a noted follow-on.

## Test plan
- `RenderEngineLottieScrubTest.liveScrubRecomposesHeldSceneInPlace` — set up once, mutate the snapshot progress, render again with no fresh `setUp`; the frame changes (proof the draw-time read + flush repaints in place). Existing scrub + sticky-persistence cases still pass.
- `InteractiveSessionPlumbingTest.setLottie_scrubs_held_session_and_renders` — `interactive/setLottie` dispatches the progress once, renders through the held session (no click-dispatch), and a stale scrub after stop produces no frame.
- `daemonClient.test` — `interactiveSetLottie` emits the right notification shape.
- `:daemon:core` + `:daemon:desktop` Lottie/interactive suites green; `:daemon:android` compiles (default interface method); extension `tsc` + 1516 mocha tests + prettier green.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LgpZdLpQJujUG6bg4So6TR)_