### PR TITLE
feat(xr): supervise + resolve the native XR render server from the JVM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,6 +210,19 @@ jobs:
             python3 renderers/xr-composite/test/serve_smoke.py \
               "$PWD/dist/xr-composite" "$PWD/dist/materials" \
               "$PWD/vscode-extension/preview-harness/fixtures/spatial-scene"
+      # Exercise the JVM client (:renderer-xr-client) against the real native server: unit tests
+      # plus the XR_COMPOSITE_BIN-gated XrRenderServerIntegrationTest, which spawns the dist binary
+      # and asserts a per-frame panel update changes the image. Mirrors the python smoke from Kotlin.
+      - name: Integration-test the JVM client against the native server
+        shell: bash
+        env:
+          LIBGL_ALWAYS_SOFTWARE: '1'
+          GALLIUM_DRIVER: llvmpipe
+          XR_COMPOSITE_BIN: ${{ github.workspace }}/dist/xr-composite
+          XR_COMPOSITE_MATERIALS: ${{ github.workspace }}/dist/materials
+        run: |
+          xvfb-run -a -s "-screen 0 2000x1400x24" \
+            ./gradlew --no-daemon :renderer-xr-client:test --stacktrace
       - name: Upload XR composite
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/docs/design/xr-spatial/RENDERER_SERVICE.md
+++ b/docs/design/xr-spatial/RENDERER_SERVICE.md
@@ -4,14 +4,20 @@
 decisions (see [Decisions](#decisions)) for evolving `renderers/xr-composite` from a one-shot CLI
 into a long-lived, extensible render service.
 
-> **Implemented so far:** `xr-composite --serve` is a working long-lived native process speaking the
-> daemon's JSON-RPC + `Content-Length` framing (`initialize`, `render`, `xr/updatePanels`,
-> `streamFrame` base64 frames), holding one Filament engine across frames — i.e. "what is genuinely
-> new" items #1 and #3 (native JSON-RPC peer + a held, mutable session) in prototype form, plus
-> migration steps #2–#3 on the native side. **Still to do:** the daemon fronting it (a
-> `RenderSession`-style backend that spawns/proxies the child — item #2), native multi-session
-> concurrency, and the `xr/structure` / `xr/a11y-overlay` data-product kinds. See
-> [renderers/xr-composite/README.md → Server mode](../../../renderers/xr-composite/README.md#server-mode---serve).
+> **Implemented so far:**
+> - `xr-composite --serve` — a working long-lived native process speaking the daemon's JSON-RPC +
+>   `Content-Length` framing (`initialize`, `render`, `xr/updatePanels`, `streamFrame` base64
+>   frames), holding one Filament engine across frames (items #1 and #3 — native JSON-RPC peer + a
+>   held, mutable session — in prototype form). See
+>   [renderers/xr-composite/README.md → Server mode](../../../renderers/xr-composite/README.md#server-mode---serve).
+> - `:renderer-xr-client` — the JVM side: `XrServerClient` (the framed JSON-RPC transport),
+>   `XrCompositeBinary` (binary/materials resolution), and `XrRenderServer` (resolve → spawn →
+>   `initialize` → render/updatePanels → close), the single entry point the daemon backend will hold.
+>   A real-binary integration test drives the loop end-to-end in the XR CI job.
+>
+> **Still to do:** the daemon fronting `XrRenderServer` (a `RenderSession`-style backend + JSON-RPC
+> surface + frame proxying through `FrameStreamRegistry` — item #2), native multi-session
+> concurrency, and the `xr/structure` / `xr/a11y-overlay` data-product kinds.
 
 ## Motivation
 

--- a/renderers/xr-client/src/main/kotlin/ee/schimke/composeai/renderer/xr/client/XrCompositeBinary.kt
+++ b/renderers/xr-client/src/main/kotlin/ee/schimke/composeai/renderer/xr/client/XrCompositeBinary.kt
@@ -1,0 +1,77 @@
+package ee.schimke.composeai.renderer.xr.client
+
+import java.io.File
+
+/**
+ * Resolves the native `xr-composite` binary + its compiled materials directory for the server-mode
+ * client. Mirrors the precedence the Gradle plugin / CLI use for the one-shot tool, minus the
+ * Gradle property layer (this runs outside Gradle): explicit env override, then the shared
+ * provisioning cache.
+ *
+ * 1. `XR_COMPOSITE_BIN` — explicit path to the binary (and `XR_COMPOSITE_MATERIALS` for its
+ *    `materials/` dir; defaults to a `materials` sibling of the binary).
+ * 2. The shared cache the CLI provisions into:
+ *    `${XDG_CACHE_HOME:-~/.cache}/composeai/xr-composite/<version>/<platform>/`.
+ *
+ * Returns `null` when nothing resolves to an existing file — callers degrade gracefully (the XR
+ * render service is best-effort, exactly like the one-shot composite).
+ */
+public object XrCompositeBinary {
+
+  /** Resolve the binary, or `null` if unavailable. [version]/[platform] address the cache layer. */
+  public fun resolve(
+    env: (String) -> String? = System::getenv,
+    version: String? = null,
+    platform: String = currentPlatform(),
+  ): File? {
+    env("XR_COMPOSITE_BIN")?.let { p ->
+      val f = File(p)
+      if (f.isFile) return f
+    }
+    if (version != null) {
+      val cached = cacheRoot(env).resolve("$version/$platform/${binaryName(platform)}")
+      if (cached.isFile) return cached
+    }
+    return null
+  }
+
+  /**
+   * Resolve the materials directory: `XR_COMPOSITE_MATERIALS`, else a `materials` sibling of
+   * [binary]. Returns `null` if neither exists.
+   */
+  public fun resolveMaterials(binary: File, env: (String) -> String? = System::getenv): File? {
+    env("XR_COMPOSITE_MATERIALS")?.let { p ->
+      val f = File(p)
+      if (f.isDirectory) return f
+    }
+    val sibling = binary.parentFile?.resolve("materials")
+    return sibling?.takeIf { it.isDirectory }
+  }
+
+  private fun cacheRoot(env: (String) -> String?): File {
+    val xdg = env("XDG_CACHE_HOME")?.takeIf { it.isNotBlank() }
+    val base = if (xdg != null) File(xdg) else File(System.getProperty("user.home"), ".cache")
+    return File(base, "composeai/xr-composite")
+  }
+
+  private fun binaryName(platform: String): String =
+    if (platform.startsWith("windows")) "xr-composite.exe" else "xr-composite"
+
+  /** The provisioning platform key, e.g. `linux-x86_64` / `macos-arm64` / `windows-x86_64`. */
+  public fun currentPlatform(): String {
+    val os = System.getProperty("os.name").lowercase()
+    val arch = System.getProperty("os.arch").lowercase()
+    val osKey =
+      when {
+        os.contains("mac") || os.contains("darwin") -> "macos"
+        os.contains("win") -> "windows"
+        else -> "linux"
+      }
+    val archKey =
+      when {
+        arch.contains("aarch64") || arch.contains("arm64") -> "arm64"
+        else -> "x86_64"
+      }
+    return "$osKey-$archKey"
+  }
+}

--- a/renderers/xr-client/src/main/kotlin/ee/schimke/composeai/renderer/xr/client/XrRenderServer.kt
+++ b/renderers/xr-client/src/main/kotlin/ee/schimke/composeai/renderer/xr/client/XrRenderServer.kt
@@ -1,0 +1,73 @@
+package ee.schimke.composeai.renderer.xr.client
+
+import java.io.File
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+
+/**
+ * A running native `xr-composite --serve` render server, driven over [XrServerClient]. This is the
+ * single entry point the daemon's XR `RenderSession` backend holds: [start] resolves + spawns the
+ * binary and performs the `initialize` handshake (so the returned instance is ready to render),
+ * then [render] / [updatePanels] return the streamed frames and [close] tears the child down.
+ *
+ * The daemon owns one of these per native process and multiplexes sessions over it; keeping the
+ * supervision here (resolve → spawn → initialize → close) keeps the daemon side a thin proxy.
+ */
+public class XrRenderServer
+private constructor(
+  private val client: XrServerClient,
+  /** The server's advertised `capabilities` from `initialize`. */
+  public val capabilities: JsonObject,
+) : AutoCloseable {
+
+  /** Render a full [scene] (serialized `SpatialScene`); returns the streamed frame. */
+  public fun render(
+    scene: JsonElement,
+    sceneDir: String? = null,
+    environment: String? = null,
+  ): StreamFrame = client.render(scene, sceneDir, environment)
+
+  /** Apply per-frame panel mutations and return the freshly streamed frame. */
+  public fun updatePanels(panels: JsonArray): StreamFrame = client.updatePanels(panels)
+
+  override fun close(): Unit = client.close()
+
+  public companion object {
+    /**
+     * Spawn `xr-composite --serve` from [binary] (+ [materials]) and complete `initialize`. Throws
+     * [XrServerException] if the handshake fails.
+     */
+    public fun start(
+      binary: File,
+      materials: File,
+      width: Int = 1280,
+      height: Int = 800,
+      frameStreamId: String? = null,
+    ): XrRenderServer {
+      val client = XrServerClient.spawn(binary, materials, width, height)
+      val caps =
+        try {
+          client.initialize(frameStreamId)
+        } catch (e: Throwable) {
+          client.close()
+          throw e
+        }
+      return XrRenderServer(client, caps)
+    }
+
+    /**
+     * Convenience: resolve the binary + materials via [XrCompositeBinary] and [start], or `null` if
+     * the binary isn't available (the XR render service is best-effort).
+     */
+    public fun startIfAvailable(
+      width: Int = 1280,
+      height: Int = 800,
+      version: String? = null,
+    ): XrRenderServer? {
+      val binary = XrCompositeBinary.resolve(version = version) ?: return null
+      val materials = XrCompositeBinary.resolveMaterials(binary) ?: return null
+      return start(binary, materials, width, height)
+    }
+  }
+}

--- a/renderers/xr-client/src/test/kotlin/ee/schimke/composeai/renderer/xr/client/XrCompositeBinaryTest.kt
+++ b/renderers/xr-client/src/test/kotlin/ee/schimke/composeai/renderer/xr/client/XrCompositeBinaryTest.kt
@@ -1,0 +1,42 @@
+package ee.schimke.composeai.renderer.xr.client
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class XrCompositeBinaryTest {
+
+  @Test
+  fun resolvesExplicitEnvBinary() {
+    val bin = File.createTempFile("xr-composite", "").apply { deleteOnExit() }
+    val env = mapOf("XR_COMPOSITE_BIN" to bin.path)
+    assertEquals(bin, XrCompositeBinary.resolve(env = env::get))
+  }
+
+  @Test
+  fun returnsNullWhenNothingResolves() {
+    assertNull(XrCompositeBinary.resolve(env = { null }, version = "0.0.0"))
+  }
+
+  @Test
+  fun ignoresEnvBinaryThatDoesNotExist() {
+    val env = mapOf("XR_COMPOSITE_BIN" to "/no/such/xr-composite")
+    assertNull(XrCompositeBinary.resolve(env = env::get))
+  }
+
+  @Test
+  fun materialsFallBackToSiblingDir() {
+    val dir = kotlin.io.path.createTempDirectory("xr").toFile().apply { deleteOnExit() }
+    val bin = File(dir, "xr-composite").apply { createNewFile() }
+    val materials = File(dir, "materials").apply { mkdirs() }
+    assertEquals(materials, XrCompositeBinary.resolveMaterials(bin, env = { null }))
+  }
+
+  @Test
+  fun platformKeyHasOsAndArch() {
+    val key = XrCompositeBinary.currentPlatform()
+    assertTrue(key.matches(Regex("(linux|macos|windows)-(x86_64|arm64)")), "unexpected key: $key")
+  }
+}

--- a/renderers/xr-client/src/test/kotlin/ee/schimke/composeai/renderer/xr/client/XrRenderServerIntegrationTest.kt
+++ b/renderers/xr-client/src/test/kotlin/ee/schimke/composeai/renderer/xr/client/XrRenderServerIntegrationTest.kt
@@ -1,0 +1,87 @@
+package ee.schimke.composeai.renderer.xr.client
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import org.junit.Assume.assumeTrue
+
+/**
+ * Real end-to-end: drives the actual native `xr-composite --serve` binary through [XrRenderServer]
+ * (the Kotlin equivalent of `renderers/xr-composite/test/serve_smoke.py`). Gated on the binary
+ * being resolvable (`XR_COMPOSITE_BIN` + materials) and a usable GL context — so it runs in the XR
+ * CI job (Xvfb + the dist binary) and locally under `xvfb-run`, and skips cleanly everywhere else.
+ */
+class XrRenderServerIntegrationTest {
+
+  private val json = Json { ignoreUnknownKeys = true }
+
+  private fun repoRoot(): File {
+    var dir = File(".").absoluteFile
+    while (dir.parentFile != null && !File(dir, "settings.gradle.kts").exists()) {
+      dir = dir.parentFile
+    }
+    return dir
+  }
+
+  @Test
+  fun rendersFixtureAndUpdatesPanelPerFrame() {
+    val binary = XrCompositeBinary.resolve()
+    assumeTrue("XR_COMPOSITE_BIN not set / not found — skipping native integration", binary != null)
+    val materials = XrCompositeBinary.resolveMaterials(binary!!)
+    assumeTrue("xr-composite materials not found — skipping", materials != null)
+
+    val fixtureDir = File(repoRoot(), "vscode-extension/preview-harness/fixtures/spatial-scene")
+    val scene = json.parseToJsonElement(File(fixtureDir, "scene.json").readText())
+
+    XrRenderServer.start(binary, materials!!, width = 640, height = 400).use { server ->
+      assertEquals(true, server.capabilities["render"].toString().toBoolean())
+
+      val first = server.render(scene, sceneDir = fixtureDir.path)
+      assertEquals(1L, first.seq)
+      assertTrue(first.width > 0 && first.height > 0)
+      assertTrue(first.dataBase64.isNotEmpty())
+
+      val moved =
+        server.updatePanels(
+          buildJsonArray {
+            add(
+              buildJsonObject {
+                put("id", "top")
+                put(
+                  "poseInRoot",
+                  buildJsonObject {
+                    put(
+                      "translation",
+                      buildJsonObject {
+                        put("x", 140)
+                        put("y", 180)
+                        put("z", 0)
+                      },
+                    )
+                    put(
+                      "rotation",
+                      buildJsonObject {
+                        put("x", 0)
+                        put("y", 0)
+                        put("z", 0)
+                        put("w", 1)
+                      },
+                    )
+                  },
+                )
+              }
+            )
+          }
+        )
+      assertEquals(2L, moved.seq)
+      // Moving a panel must change the rendered image.
+      assertTrue(moved.dataBase64 != first.dataBase64, "frame did not change after moving a panel")
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Next daemon-fronting increment, building on `XrServerClient` (#1780): the supervision + binary-resolution pieces the daemon's XR `RenderSession` backend will hold, plus a **real-binary** integration test closing the Kotlin↔native loop.

- **`XrCompositeBinary`** — resolves the `xr-composite` binary + materials (`XR_COMPOSITE_BIN` / `XR_COMPOSITE_MATERIALS`, else the shared provisioning cache `~/.cache/composeai/xr-composite/<version>/<platform>/`), returning `null` when unavailable so callers degrade gracefully (best-effort, like the one-shot composite).
- **`XrRenderServer`** — the single supervised entry point: resolve → spawn → `initialize` → `render`/`updatePanels` → `close`, holding the server's advertised `capabilities`.

## Test plan

- [x] Pure-JVM unit tests for the resolver (`XrCompositeBinaryTest`) — run everywhere.
- [x] **`XrRenderServerIntegrationTest` against the real native binary**, verified locally under `xvfb-run`: spawns `xr-composite --serve`, renders the committed fixture (seq 1), moves a panel via `xr/updatePanels` (seq 2), asserts the frame **changes**, clean teardown. Gated on `XR_COMPOSITE_BIN` + a GL context, so it skips cleanly when the binary/display aren't present.
- [x] CI: the **Render XR composite (sample)** job now runs `:renderer-xr-client:test` with the dist binary under Xvfb, so both the unit tests and the native integration test are gated in CI (alongside the existing `serve_smoke.py`).
- [x] `:renderer-xr-client:test` + `ktfmtCheck` green locally.

## Next

The daemon `RenderSession` backend that owns `XrRenderServer`, exposes the XR JSON-RPC surface, and proxies frames through `FrameStreamRegistry` — the last big piece of RENDERER_SERVICE item #2.


---
_Generated by [Claude Code](https://claude.ai/code/session_01X8ZwHy8Sgg5eVJzNqr1LMb)_