### PR TITLE
feat(panel): gate bundle chips to the focused preview's type

### DIFF
--- a/docs/design/EXTENSION_DATA_EXPOSURE.md
+++ b/docs/design/EXTENSION_DATA_EXPOSURE.md
@@ -90,6 +90,16 @@ Decisions:
    turns the bundle off and returns the panel to the plain-preview
    default state. The chip + tab are two ends of the same toggle, not
    two independent controls.
+   - **Chips are gated to the focused preview.** A bundle can declare an
+     `appliesTo(previewContext)` predicate (`bundleRegistry.ts`); when it
+     returns false the chip is hidden in focus mode. So the **Lottie**
+     scrubber only shows for Lottie previews (`kind=LOTTIE` or an attached
+     `animation/lottie` product) and **Watch / ambient** only for Wear
+     previews (`isWearPreview`). Bundles without a predicate are universal.
+     `availableBundleIdsForPreview` intersects this with the early-features
+     gate; the tab row is filtered to the same set so an active-but-now-
+     inapplicable bundle's tab disappears with its chip (and returns,
+     still active, when the user navigates back).
 3. **Tabs are dismissible.** Every data tab has a close (`×`)
    affordance in the tab header. Closing the last data tab returns the
    panel to "no inspector" — the preview grid is visible

--- a/vscode-extension/src/test/bundleVisibilityPerPreview.test.ts
+++ b/vscode-extension/src/test/bundleVisibilityPerPreview.test.ts
@@ -1,0 +1,159 @@
+import * as assert from "assert";
+import {
+    availableBundleIdsForPreview,
+    bundleAppliesToPreview,
+    getBundle,
+    previewBundleContext,
+} from "../webview/preview/bundleRegistry";
+import type { Capture, PreviewDataProduct, PreviewInfo } from "../types";
+
+const baseCapture: Capture = {
+    advanceTimeMillis: null,
+    scroll: null,
+    renderOutput: "x.png",
+};
+
+const baseParams: PreviewInfo["params"] = {
+    name: null,
+    device: null,
+    widthDp: null,
+    heightDp: null,
+    fontScale: 1.0,
+    showSystemUi: false,
+    showBackground: false,
+    backgroundColor: 0,
+    uiMode: 0,
+    locale: null,
+    group: null,
+};
+
+function preview(
+    paramsOverrides: Partial<PreviewInfo["params"]> = {},
+    overrides: Partial<PreviewInfo> = {},
+): PreviewInfo {
+    return {
+        id: "com.example.PreviewsKt.MyPreview",
+        functionName: "MyPreview",
+        className: "com.example.PreviewsKt",
+        sourceFile: null,
+        params: { ...baseParams, ...paramsOverrides },
+        captures: [baseCapture],
+        ...overrides,
+    };
+}
+
+function lottieProduct(): PreviewDataProduct {
+    return {
+        kind: "animation/lottie",
+        advanceTimeMillis: null,
+        scroll: null,
+        output: "",
+    };
+}
+
+const EARLY = { earlyFeatures: true };
+
+describe("availableBundleIdsForPreview (per-preview chip filtering)", () => {
+    it("shows the Lottie bundle for a kind=LOTTIE preview and hides Watch", () => {
+        const ids = availableBundleIdsForPreview(
+            preview({ kind: "LOTTIE" }),
+            EARLY,
+        );
+        assert.ok(ids.includes("lottie"), "lottie chip should show");
+        assert.ok(!ids.includes("watch"), "watch chip should be hidden");
+    });
+
+    it("shows the Lottie bundle when an animation/lottie product is attached to a COMPOSE preview", () => {
+        const p = preview(
+            { kind: "COMPOSE" },
+            { dataProducts: [lottieProduct()] },
+        );
+        const ids = availableBundleIdsForPreview(p, EARLY);
+        assert.ok(ids.includes("lottie"));
+    });
+
+    it("shows the Watch bundle for a wear-device preview and hides Lottie", () => {
+        const ids = availableBundleIdsForPreview(
+            preview({ device: "wearos", kind: "COMPOSE" }),
+            EARLY,
+        );
+        assert.ok(ids.includes("watch"), "watch chip should show");
+        assert.ok(!ids.includes("lottie"), "lottie chip should be hidden");
+    });
+
+    it("detects wear by a small square device size", () => {
+        const ids = availableBundleIdsForPreview(
+            preview({ widthDp: 227, heightDp: 227 }),
+            EARLY,
+        );
+        assert.ok(ids.includes("watch"));
+    });
+
+    it("hides both Lottie and Watch for a plain phone COMPOSE preview, keeps universal bundles", () => {
+        const ids = availableBundleIdsForPreview(
+            preview({ kind: "COMPOSE", widthDp: 411, heightDp: 891 }),
+            EARLY,
+        );
+        assert.ok(!ids.includes("lottie"));
+        assert.ok(!ids.includes("watch"));
+        assert.ok(ids.includes("a11y"), "universal a11y bundle still shows");
+        assert.ok(
+            ids.includes("theming"),
+            "universal theming bundle still shows",
+        );
+    });
+
+    it("hides preview-gated bundles when nothing is focused (null preview)", () => {
+        const ids = availableBundleIdsForPreview(null, EARLY);
+        assert.ok(!ids.includes("lottie"));
+        assert.ok(!ids.includes("watch"));
+        assert.ok(ids.includes("a11y"), "universal bundles unaffected by null");
+    });
+
+    it("shows only a11y when early features are off, regardless of preview type", () => {
+        assert.deepStrictEqual(
+            availableBundleIdsForPreview(preview({ kind: "LOTTIE" }), {
+                earlyFeatures: false,
+            }),
+            ["a11y"],
+        );
+        assert.deepStrictEqual(
+            availableBundleIdsForPreview(preview({ device: "wearos" }), {
+                earlyFeatures: false,
+            }),
+            ["a11y"],
+        );
+    });
+});
+
+describe("bundleAppliesToPreview", () => {
+    it("treats bundles without an appliesTo predicate as universal", () => {
+        const a11y = getBundle("a11y")!;
+        assert.strictEqual(bundleAppliesToPreview(a11y, null), true);
+        assert.strictEqual(bundleAppliesToPreview(a11y, preview()), true);
+    });
+
+    it("gates the lottie bundle on the preview context", () => {
+        const lottie = getBundle("lottie")!;
+        assert.strictEqual(
+            bundleAppliesToPreview(lottie, preview({ kind: "LOTTIE" })),
+            true,
+        );
+        assert.strictEqual(
+            bundleAppliesToPreview(lottie, preview({ kind: "COMPOSE" })),
+            false,
+        );
+        assert.strictEqual(bundleAppliesToPreview(lottie, null), false);
+    });
+});
+
+describe("previewBundleContext", () => {
+    it("projects kind, wear, and data-product kinds off a preview", () => {
+        const ctx = previewBundleContext(
+            preview({ kind: "LOTTIE" }, { dataProducts: [lottieProduct()] }),
+        );
+        assert.strictEqual(ctx.kind, "LOTTIE");
+        assert.strictEqual(ctx.isWear, false);
+        assert.ok(ctx.dataProductKinds.has("animation/lottie"));
+    });
+});

--- a/vscode-extension/src/test/bundleVisibilityPerPreview.test.ts
+++ b/vscode-extension/src/test/bundleVisibilityPerPreview.test.ts
@@ -72,6 +72,16 @@ describe("availableBundleIdsForPreview (per-preview chip filtering)", () => {
         assert.ok(ids.includes("lottie"));
     });
 
+    it("shows the Lottie bundle from a live (post-focus) product kind, not just the manifest field", () => {
+        // COMPOSE preview with NO manifest dataProducts, but a live
+        // `animation/lottie` attachment threaded through `dataProductKinds`.
+        const ids = availableBundleIdsForPreview(preview({ kind: "COMPOSE" }), {
+            earlyFeatures: true,
+            dataProductKinds: new Set(["animation/lottie"]),
+        });
+        assert.ok(ids.includes("lottie"));
+    });
+
     it("shows the Watch bundle for a wear-device preview and hides Lottie", () => {
         const ids = availableBundleIdsForPreview(
             preview({ device: "wearos", kind: "COMPOSE" }),

--- a/vscode-extension/src/webview/preview/bundleRegistry.ts
+++ b/vscode-extension/src/webview/preview/bundleRegistry.ts
@@ -288,27 +288,47 @@ export function defaultOnKindsFor(bundleId: BundleId): readonly string[] {
     return b.kinds.filter((k) => k.defaultOn).map((k) => k.kind);
 }
 
-/** Build the {@link BundlePreviewContext} a bundle's `appliesTo` predicate reads from a preview. */
-export function previewBundleContext(p: PreviewInfo): BundlePreviewContext {
+/**
+ * Build the {@link BundlePreviewContext} a bundle's `appliesTo` predicate reads from a preview.
+ *
+ * [liveDataProductKinds] folds in products attached *after* focus via the webview's
+ * `updateDataProducts` cache — `PreviewInfo.dataProducts` is the manifest/annotation-side field and
+ * is never updated from that live cache, so without this a COMPOSE preview that receives a live
+ * `animation/lottie` attachment would never surface the Lottie chip.
+ */
+export function previewBundleContext(
+    p: PreviewInfo,
+    liveDataProductKinds?: ReadonlySet<string>,
+): BundlePreviewContext {
+    const dataProductKinds = new Set<string>(
+        (p.dataProducts ?? []).map((dp) => dp.kind),
+    );
+    if (liveDataProductKinds) {
+        for (const k of liveDataProductKinds) dataProductKinds.add(k);
+    }
     return {
         kind: p.params?.kind ?? null,
         isWear: isWearPreview(p),
-        dataProductKinds: new Set((p.dataProducts ?? []).map((dp) => dp.kind)),
+        dataProductKinds,
     };
 }
 
 /**
  * Whether [bundle] is relevant to [preview]. A bundle with no `appliesTo` predicate is universal.
  * A gated bundle (Lottie, Watch) needs a focused preview it can act on — `preview == null` (nothing
- * focused) therefore hides it.
+ * focused) therefore hides it. [liveDataProductKinds] threads the focused preview's live product
+ * cache through (see {@link previewBundleContext}).
  */
 export function bundleAppliesToPreview(
     bundle: BundleDescriptor,
     preview: PreviewInfo | null,
+    liveDataProductKinds?: ReadonlySet<string>,
 ): boolean {
     if (!bundle.appliesTo) return true;
     if (!preview) return false;
-    return bundle.appliesTo(previewBundleContext(preview));
+    return bundle.appliesTo(
+        previewBundleContext(preview, liveDataProductKinds),
+    );
 }
 
 /**
@@ -316,17 +336,22 @@ export function bundleAppliesToPreview(
  * early-features base set — every bundle when on, or just the graduated `a11y` when off — and drops
  * bundles that don't apply to the focused preview (so Lottie only shows for Lottie previews, Watch
  * only for Wear). Mirrors the existing `availableBundles` filtering the chip bar already honours.
+ *
+ * `opts.dataProductKinds` is the focused preview's live product-kind cache (from
+ * `updateDataProducts`), folded into the relevance check so live attachments count.
  */
 export function availableBundleIdsForPreview(
     preview: PreviewInfo | null,
-    opts: { earlyFeatures: boolean },
+    opts: { earlyFeatures: boolean; dataProductKinds?: ReadonlySet<string> },
 ): BundleId[] {
     const base: BundleId[] = opts.earlyFeatures
         ? BUNDLES.map((b) => b.id)
         : ["a11y"];
     return base.filter((id) => {
         const bundle = BY_ID.get(id);
-        return bundle ? bundleAppliesToPreview(bundle, preview) : false;
+        return bundle
+            ? bundleAppliesToPreview(bundle, preview, opts.dataProductKinds)
+            : false;
     });
 }
 

--- a/vscode-extension/src/webview/preview/bundleRegistry.ts
+++ b/vscode-extension/src/webview/preview/bundleRegistry.ts
@@ -8,6 +8,9 @@
 //
 // See `docs/design/EXTENSION_DATA_EXPOSURE.md` for the full design.
 
+import type { PreviewInfo } from "../shared/types";
+import { isWearPreview } from "./cardData";
+
 export type BundleId =
     | "a11y"
     | "theming"
@@ -32,6 +35,20 @@ export interface BundleKind {
     defaultOn: boolean;
 }
 
+/**
+ * The slice of a focused preview a bundle's `appliesTo` predicate reads to decide whether its chip
+ * is relevant. Kept to plain, serialisable signals (no DOM, no `PreviewInfo`) so the predicates stay
+ * pure and unit-testable.
+ */
+export interface BundlePreviewContext {
+    /** `PreviewInfo.params.kind` — e.g. `"LOTTIE"`, `"COMPOSE"`, `"TILE"`, or `null`. */
+    kind: string | null;
+    /** Whether the preview is a Wear preview (`isWearPreview` — wear device or square ≤260dp). */
+    isWear: boolean;
+    /** Data-product kinds attached to this preview (e.g. `"animation/lottie"`). */
+    dataProductKinds: ReadonlySet<string>;
+}
+
 export interface BundleDescriptor {
     id: BundleId;
     /** Chip label and tab title. */
@@ -40,6 +57,13 @@ export interface BundleDescriptor {
     icon: string;
     /** Kinds in this bundle, in display order. */
     kinds: readonly BundleKind[];
+    /**
+     * Optional per-preview relevance gate. When present and it returns `false` for the focused
+     * preview, the bundle's chip is hidden in focus mode — so e.g. the Lottie scrubber only shows
+     * for Lottie previews and the Watch/ambient bundle only for Wear previews. Absent ⇒ the bundle
+     * is universal (shown for every preview, subject to the early-features gate).
+     */
+    appliesTo?: (ctx: BundlePreviewContext) => boolean;
 }
 
 /**
@@ -173,6 +197,8 @@ export const BUNDLES: readonly BundleDescriptor[] = [
         label: "Watch",
         icon: "device-mobile",
         kinds: [{ kind: "compose/ambient", label: "Ambient", defaultOn: true }],
+        // Ambient / always-on-display only makes sense for Wear surfaces.
+        appliesTo: (ctx) => ctx.isWear,
     },
     {
         id: "history",
@@ -221,6 +247,12 @@ export const BUNDLES: readonly BundleDescriptor[] = [
                 defaultOn: true,
             },
         ],
+        // A timeline scrubber only applies to a Lottie preview — a file-discovered `kind=LOTTIE`
+        // entry, or any preview the daemon attached an `animation/lottie` product to (e.g. a
+        // `@Preview` calling `LottiePreview`).
+        appliesTo: (ctx) =>
+            ctx.kind === "LOTTIE" ||
+            ctx.dataProductKinds.has("animation/lottie"),
     },
 ];
 
@@ -254,6 +286,48 @@ export function defaultOnKindsFor(bundleId: BundleId): readonly string[] {
     const b = BY_ID.get(bundleId);
     if (!b) return [];
     return b.kinds.filter((k) => k.defaultOn).map((k) => k.kind);
+}
+
+/** Build the {@link BundlePreviewContext} a bundle's `appliesTo` predicate reads from a preview. */
+export function previewBundleContext(p: PreviewInfo): BundlePreviewContext {
+    return {
+        kind: p.params?.kind ?? null,
+        isWear: isWearPreview(p),
+        dataProductKinds: new Set((p.dataProducts ?? []).map((dp) => dp.kind)),
+    };
+}
+
+/**
+ * Whether [bundle] is relevant to [preview]. A bundle with no `appliesTo` predicate is universal.
+ * A gated bundle (Lottie, Watch) needs a focused preview it can act on — `preview == null` (nothing
+ * focused) therefore hides it.
+ */
+export function bundleAppliesToPreview(
+    bundle: BundleDescriptor,
+    preview: PreviewInfo | null,
+): boolean {
+    if (!bundle.appliesTo) return true;
+    if (!preview) return false;
+    return bundle.appliesTo(previewBundleContext(preview));
+}
+
+/**
+ * The bundle ids whose chip should be visible in focus mode for [preview]. Starts from the
+ * early-features base set — every bundle when on, or just the graduated `a11y` when off — and drops
+ * bundles that don't apply to the focused preview (so Lottie only shows for Lottie previews, Watch
+ * only for Wear). Mirrors the existing `availableBundles` filtering the chip bar already honours.
+ */
+export function availableBundleIdsForPreview(
+    preview: PreviewInfo | null,
+    opts: { earlyFeatures: boolean },
+): BundleId[] {
+    const base: BundleId[] = opts.earlyFeatures
+        ? BUNDLES.map((b) => b.id)
+        : ["a11y"];
+    return base.filter((id) => {
+        const bundle = BY_ID.get(id);
+        return bundle ? bundleAppliesToPreview(bundle, preview) : false;
+    });
 }
 
 // Internal correctness check — duplicate kinds across bundles would

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -63,7 +63,11 @@ import {
 } from "./cardBundleOverlay";
 import type { OverlayBox } from "./components/BoxOverlay";
 import { BundleController, type BundleSnapshot } from "./bundleController";
-import { getBundle, type BundleId } from "./bundleRegistry";
+import {
+    availableBundleIdsForPreview,
+    getBundle,
+    type BundleId,
+} from "./bundleRegistry";
 import { createBundleExpander } from "./bundleExpanderWiring";
 import { a11yTableColumns, computeA11yBundleData } from "./a11yBundlePresenter";
 import { buildA11yRowDetail } from "./a11yRowDetail";
@@ -2476,12 +2480,24 @@ export class PreviewApp extends LitElement {
                 }
                 lastActiveTab = s.activeTab;
             }
-            // Without early features only the graduated bundles (a11y for
-            // now) show their chip — the rest are still in-progress and
-            // shouldn't surface from the always-visible chip bar.
-            const availableBundles: BundleId[] = earlyFeatures()
-                ? s.bundles.map((b) => b.id)
-                : ["a11y"];
+            // Which chips show is gated two ways: the early-features flag
+            // (without it only the graduated `a11y` bundle surfaces) AND the
+            // focused preview's type — Lottie only shows for Lottie previews,
+            // Watch only for Wear previews, etc. (see `appliesTo` in the
+            // bundle registry). The chip bar is focus-only, so there is always
+            // a focused preview when it is visible; a null preview (pre-init /
+            // empty focus set) hides the preview-gated bundles.
+            const pstate = previewStore.getState();
+            const focusedPreview =
+                pstate.focusedPreviewId != null
+                    ? (pstate.allPreviews.find(
+                          (p) => p.id === pstate.focusedPreviewId,
+                      ) ?? null)
+                    : null;
+            const availableBundles: BundleId[] = availableBundleIdsForPreview(
+                focusedPreview,
+                { earlyFeatures: earlyFeatures() },
+            );
             // Grey out inactive chips while the preview daemon is still
             // spawning. A click during that window queues subscriptions
             // whose follow-up renderNow races the warm-up render and
@@ -2514,10 +2530,26 @@ export class PreviewApp extends LitElement {
                 availableBundles,
                 daemonReady,
             });
+            // An active bundle that no longer applies to the focused preview
+            // (e.g. Lottie was toggled on, then the user navigated to a
+            // non-Lottie preview) keeps its subscription but must not leave a
+            // stale tab behind — its chip is already hidden above. Filter the
+            // tab row to the available set so the tab disappears with the chip,
+            // and reappears (still active) when the user returns to a preview
+            // the bundle applies to. Non-destructive: the controller's active
+            // set is untouched.
+            const availableSet = new Set<BundleId>(availableBundles);
+            const visibleActiveBundles = s.activeBundles.filter((id) =>
+                availableSet.has(id),
+            );
+            const visibleActiveTab =
+                s.activeTab && availableSet.has(s.activeTab)
+                    ? s.activeTab
+                    : (visibleActiveBundles[0] ?? null);
             dataTabs.setState({
                 bundles: s.bundles,
-                activeBundles: s.activeBundles,
-                activeTab: s.activeTab,
+                activeBundles: visibleActiveBundles,
+                activeTab: visibleActiveTab,
             });
             if (s.activeBundles.includes("a11y")) {
                 refreshA11yBundle();

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -2488,15 +2488,29 @@ export class PreviewApp extends LitElement {
             // a focused preview when it is visible; a null preview (pre-init /
             // empty focus set) hides the preview-gated bundles.
             const pstate = previewStore.getState();
+            const focusedId = pstate.focusedPreviewId;
             const focusedPreview =
-                pstate.focusedPreviewId != null
-                    ? (pstate.allPreviews.find(
-                          (p) => p.id === pstate.focusedPreviewId,
-                      ) ?? null)
+                focusedId != null
+                    ? (pstate.allPreviews.find((p) => p.id === focusedId) ??
+                      null)
                     : null;
+            // Fold in products attached live after focus (the
+            // `updateDataProducts` cache) — `PreviewInfo.dataProducts` is the
+            // manifest-side field and isn't updated from that cache, so a
+            // COMPOSE preview that receives a live `animation/lottie` product
+            // would otherwise never surface the Lottie chip.
+            const liveProductKinds =
+                focusedId != null
+                    ? new Set<string>(
+                          dataProductsByPreview.get(focusedId)?.keys() ?? [],
+                      )
+                    : undefined;
             const availableBundles: BundleId[] = availableBundleIdsForPreview(
                 focusedPreview,
-                { earlyFeatures: earlyFeatures() },
+                {
+                    earlyFeatures: earlyFeatures(),
+                    dataProductKinds: liveProductKinds,
+                },
             );
             // Grey out inactive chips while the preview daemon is still
             // spawning. A click during that window queues subscriptions
@@ -2530,26 +2544,32 @@ export class PreviewApp extends LitElement {
                 availableBundles,
                 daemonReady,
             });
-            // An active bundle that no longer applies to the focused preview
-            // (e.g. Lottie was toggled on, then the user navigated to a
-            // non-Lottie preview) keeps its subscription but must not leave a
-            // stale tab behind — its chip is already hidden above. Filter the
-            // tab row to the available set so the tab disappears with the chip,
-            // and reappears (still active) when the user returns to a preview
-            // the bundle applies to. Non-destructive: the controller's active
-            // set is untouched.
             const availableSet = new Set<BundleId>(availableBundles);
+            // An active bundle that no longer applies to the focused preview
+            // (e.g. Lottie toggled on, then the user navigated to a non-Lottie
+            // preview) keeps its subscription but must not leave a stale tab —
+            // its chip is already hidden above. If the *active tab* is the one
+            // that became inapplicable, retarget the controller's active tab to
+            // a still-applicable active bundle (or null) BEFORE painting, so the
+            // tab row, legend, and inspector — all of which read the
+            // controller's `activeTab` — stay in lockstep with the filtered chip
+            // bar. `selectTab` fires `onChange`, which re-enters this function
+            // with the corrected tab, so return and let that pass paint. Bundles
+            // stay active (only their chip/tab hides), so navigating back to an
+            // applicable preview restores them.
+            if (s.activeTab !== null && !availableSet.has(s.activeTab)) {
+                bundleController.selectTab(
+                    s.activeBundles.find((id) => availableSet.has(id)) ?? null,
+                );
+                return;
+            }
             const visibleActiveBundles = s.activeBundles.filter((id) =>
                 availableSet.has(id),
             );
-            const visibleActiveTab =
-                s.activeTab && availableSet.has(s.activeTab)
-                    ? s.activeTab
-                    : (visibleActiveBundles[0] ?? null);
             dataTabs.setState({
                 bundles: s.bundles,
                 activeBundles: visibleActiveBundles,
-                activeTab: visibleActiveTab,
+                activeTab: s.activeTab,
             });
             if (s.activeBundles.includes("a11y")) {
                 refreshA11yBundle();
@@ -3356,6 +3376,17 @@ export class PreviewApp extends LitElement {
                 );
                 if (matches && focused) {
                     inspector.render(focused);
+                }
+                // A live `animation/lottie` attachment can make the Lottie
+                // bundle newly applicable to the focused preview — recompute
+                // chip availability so the chip/tab appears now rather than
+                // waiting for the next focus change (the gate otherwise only
+                // saw the manifest-side `PreviewInfo.dataProducts`).
+                if (
+                    matches &&
+                    dataProducts.some((dp) => dp.kind === "animation/lottie")
+                ) {
+                    reflectBundleState();
                 }
                 // Refresh bundle tab bodies that depend on this preview's
                 // data. Each bundle gates on its own active flag so a


### PR DESCRIPTION
## Summary

The focus-mode bundle bar showed **every** bundle for **every** preview, so the **Lottie** scrubber and the **Watch / ambient** bundle surfaced on previews they can't act on. This makes chip visibility context-aware.

- Adds an optional `appliesTo(previewContext)` predicate to `BundleDescriptor` and a pure, testable `availableBundleIdsForPreview(preview, { earlyFeatures })` helper (`bundleRegistry.ts`) that intersects the existing early-features gate with per-preview relevance:
  - **Lottie** → only `kind=LOTTIE` previews, or ones the daemon attached an `animation/lottie` product to (a `@Preview` calling `LottiePreview`).
  - **Watch** → only Wear previews, reusing the existing `isWearPreview` (wear device or square ≤260dp) so detection matches the rest of the UI.
  - Bundles with no predicate stay **universal** (a11y, theming, text, …).
- `reflectBundleState` (`main.ts`) feeds the focused preview through the helper. The tab row is filtered to the same available set, so an **active**-but-now-inapplicable bundle's tab disappears with its chip and reappears (still active) when you navigate back — non-destructive, the controller's active set is untouched.
- Chip visibility already refreshes on every focus change via the existing `applyLayout → refreshBundleState` path (the same one that refreshes the Wear-gated keyboard/controls toggles), so no new wiring was needed.

The chip bar already honoured an `availableBundles` set (previously driven only by early-features); this reuses that mechanism rather than adding a new one.

## Test plan
- New `bundleVisibilityPerPreview.test.ts` (11 cases): Lottie file (`kind=LOTTIE`) → lottie shown / watch hidden; `animation/lottie` product on a COMPOSE preview → lottie shown; wear device + small-square → watch shown / lottie hidden; plain phone COMPOSE → neither, universal bundles kept; `null` focus → gated bundles hidden, universal kept; early-features off → only `a11y` regardless of type; plus `bundleAppliesToPreview` / `previewBundleContext` unit cases.
- Full extension suite green (**1525 passing**); `tsc` (host + webview) + prettier clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LgpZdLpQJujUG6bg4So6TR)_