### PR TITLE
feat(semantics): stable node refs, target resolver, and tree diff engine

### DIFF
--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
@@ -20,6 +20,7 @@ import ee.schimke.composeai.daemon.protocol.DataProductFacet
 import ee.schimke.composeai.daemon.protocol.DataProductTransport
 import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsProduct
 import ee.schimke.composeai.data.layoutinspector.LayoutInspectorProduct
+import ee.schimke.composeai.data.layoutinspector.SemanticsRefs
 import ee.schimke.composeai.data.render.PreviewContext
 import ee.schimke.composeai.data.render.extensions.compose.ExtensionSlotTables
 import ee.schimke.composeai.data.render.pipeline.SamplingPolicy
@@ -62,7 +63,7 @@ object ComposeSemanticsDataProducer {
    * bounds formatting, merge-mode mapping — rather than re-walking the tree with different rules.
    */
   fun buildPayload(root: SemanticsNode): ComposeSemanticsPayload =
-    ComposeSemanticsPayload(root = root.toWireNode())
+    SemanticsRefs.assign(ComposeSemanticsPayload(root = root.toWireNode()))
 
   private fun SemanticsNode.toWireNode(): ComposeSemanticsNode {
     val cfg = config

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/ComposeSemanticsModels.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/ComposeSemanticsModels.kt
@@ -35,6 +35,15 @@ object ComposeSemanticsWireframeProduct {
 @Serializable
 data class ComposeSemanticsNode(
   val nodeId: String,
+  /**
+   * Stable, content-independent handle for this node within the tree, assigned by [SemanticsRefs].
+   *
+   * Unlike [nodeId] (Compose's per-composition `SemanticsNode.id`, which is reassigned on every
+   * fresh render) this survives content edits, so it is the handle agents target for interaction
+   * (issue #1784) and the key the semantics differ matches on (issue #1785). Null only when the
+   * payload was built without running ref assignment.
+   */
+  val ref: String? = null,
   val boundsInRoot: String,
   val label: String? = null,
   val text: String? = null,

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/SemanticsDiff.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/SemanticsDiff.kt
@@ -1,0 +1,124 @@
+package ee.schimke.composeai.data.layoutinspector
+
+import kotlinx.serialization.Serializable
+
+object SemanticsDiffProduct {
+  const val SCHEMA: String = "compose-semantics-diff/v1"
+}
+
+/**
+ * A structural, content-aware diff of two [ComposeSemanticsPayload] trees (issue #1785).
+ *
+ * This is the Compose analogue of Playwright's `toMatchAriaSnapshot` text diff: a cheap,
+ * deterministic regression signal that says *what changed semantically* ("Button 'Submit' lost its
+ * label", "text 'Hello' → 'Helloo'") without reading pixels. Nodes are matched by their stable
+ * [ComposeSemanticsNode.ref] (assigned by [SemanticsRefs]), so a copy edit reports as a field
+ * change on the same ref rather than a remove + add.
+ *
+ * Positional fields ([ComposeSemanticsNode.boundsInRoot]) and the volatile per-render
+ * [ComposeSemanticsNode.nodeId] are deliberately ignored — bounds churn is the pixel diff's job.
+ */
+object SemanticsDiff {
+
+  /** Semantic fields compared between two nodes sharing a ref, in stable report order. */
+  private val COMPARED_FIELDS: List<Pair<String, (ComposeSemanticsNode) -> String?>> =
+    listOf(
+      "role" to { it.role },
+      "testTag" to { it.testTag },
+      "label" to { it.label },
+      "text" to { it.text },
+      "mergeMode" to { it.mergeMode },
+      "clickable" to { it.clickable.toString() },
+      "editableText" to { it.editableText },
+      "inputText" to { it.inputText },
+      "layoutTruncated" to { it.layoutTruncated?.toString() },
+      "layoutOverflow" to { it.layoutOverflow },
+      "layoutLineCount" to { it.layoutLineCount?.toString() },
+      "layoutMaxLines" to { it.layoutMaxLines?.toString() },
+      "layoutDidOverflowWidth" to { it.layoutDidOverflowWidth?.toString() },
+      "layoutDidOverflowHeight" to { it.layoutDidOverflowHeight?.toString() },
+    )
+
+  fun diff(base: ComposeSemanticsPayload, head: ComposeSemanticsPayload): SemanticsDelta =
+    diff(base.root, head.root)
+
+  fun diff(base: ComposeSemanticsNode, head: ComposeSemanticsNode): SemanticsDelta {
+    val baseByRef = SemanticsRefs.assign(base).byRef()
+    val headByRef = SemanticsRefs.assign(head).byRef()
+
+    val removed =
+      baseByRef.keys.filter { it !in headByRef }.sorted().map { baseByRef.getValue(it).summary() }
+    val added =
+      headByRef.keys.filter { it !in baseByRef }.sorted().map { headByRef.getValue(it).summary() }
+    val changed =
+      baseByRef.keys
+        .filter { it in headByRef }
+        .sorted()
+        .mapNotNull { ref -> nodeChange(ref, baseByRef.getValue(ref), headByRef.getValue(ref)) }
+
+    return SemanticsDelta(added = added, removed = removed, changed = changed)
+  }
+
+  private fun nodeChange(
+    ref: String,
+    base: ComposeSemanticsNode,
+    head: ComposeSemanticsNode,
+  ): SemanticsNodeChange? {
+    val changes = COMPARED_FIELDS.mapNotNull { (field, extract) ->
+      val from = extract(base)
+      val to = extract(head)
+      if (from != to) SemanticsFieldChange(field, from, to) else null
+    }
+    return if (changes.isEmpty()) null
+    else SemanticsNodeChange(ref = ref, anchor = SemanticsRefs.anchor(head), changes = changes)
+  }
+
+  private fun ComposeSemanticsNode.byRef(): Map<String, ComposeSemanticsNode> {
+    val out = LinkedHashMap<String, ComposeSemanticsNode>()
+    fun walk(node: ComposeSemanticsNode) {
+      node.ref?.let { out[it] = node }
+      node.children.forEach(::walk)
+    }
+    walk(this)
+    return out
+  }
+
+  private fun ComposeSemanticsNode.summary(): SemanticsNodeSummary =
+    SemanticsNodeSummary(
+      ref = ref ?: SemanticsRefs.ROOT_REF,
+      role = role,
+      testTag = testTag,
+      text = text,
+      label = label,
+    )
+}
+
+@Serializable data class SemanticsFieldChange(val field: String, val from: String?, val to: String?)
+
+@Serializable
+data class SemanticsNodeChange(
+  val ref: String,
+  /** testTag/role anchor of the node, for human-readable output. */
+  val anchor: String? = null,
+  val changes: List<SemanticsFieldChange>,
+)
+
+@Serializable
+data class SemanticsNodeSummary(
+  val ref: String,
+  val role: String? = null,
+  val testTag: String? = null,
+  val text: String? = null,
+  val label: String? = null,
+)
+
+@Serializable
+data class SemanticsDelta(
+  val schema: String = SemanticsDiffProduct.SCHEMA,
+  val added: List<SemanticsNodeSummary> = emptyList(),
+  val removed: List<SemanticsNodeSummary> = emptyList(),
+  val changed: List<SemanticsNodeChange> = emptyList(),
+) {
+  val isEmpty: Boolean
+    get() = added.isEmpty() && removed.isEmpty() && changed.isEmpty()
+}

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/SemanticsRefs.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/SemanticsRefs.kt
@@ -1,0 +1,59 @@
+package ee.schimke.composeai.data.layoutinspector
+
+/**
+ * Assigns a stable [ComposeSemanticsNode.ref] to every node in a [ComposeSemanticsPayload] tree.
+ *
+ * The ref is the handle agents target for interaction (issue #1784) and the key the semantics
+ * differ matches on (issue #1785). It must therefore stay stable across renders that change only
+ * *content* (text, labels, colors) — just structural changes (a node added / removed / reparented,
+ * or its `testTag` / `role` changing) should move a ref.
+ *
+ * Scheme: a `/`-joined path from the root. Each segment anchors on the most stable identity the
+ * node carries:
+ * 1. its `testTag` if set (developer-controlled, the strongest anchor),
+ * 2. else its `role`,
+ * 3. else a generic `node` token,
+ *
+ * disambiguated by occurrence index among siblings that share the same anchor (`role:Button[0]`,
+ * `role:Button[1]`). Text and label are deliberately **not** part of the ref so a copy edit shows
+ * up as a field change on the same ref rather than a remove + add.
+ *
+ * Assignment is deterministic and idempotent: running it twice yields identical refs, so callers
+ * can re-assign defensively (the differ does) without surprise.
+ */
+object SemanticsRefs {
+  const val ROOT_REF: String = "r"
+
+  fun assign(payload: ComposeSemanticsPayload): ComposeSemanticsPayload =
+    ComposeSemanticsPayload(root = assign(payload.root))
+
+  fun assign(root: ComposeSemanticsNode): ComposeSemanticsNode = assignNode(root, ROOT_REF)
+
+  /** The anchor token for a node, before sibling disambiguation. */
+  fun anchor(node: ComposeSemanticsNode): String =
+    node.testTag?.trim()?.takeIf { it.isNotEmpty() }?.let { "tag:${sanitize(it)}" }
+      ?: node.role?.trim()?.takeIf { it.isNotEmpty() }?.let { "role:${sanitize(it)}" }
+      ?: GENERIC_ANCHOR
+
+  private fun assignNode(node: ComposeSemanticsNode, ref: String): ComposeSemanticsNode {
+    val children = node.children
+    val totals = HashMap<String, Int>()
+    for (child in children) totals[anchor(child)] = (totals[anchor(child)] ?: 0) + 1
+
+    val seen = HashMap<String, Int>()
+    val newChildren = children.map { child ->
+      val a = anchor(child)
+      val index = (seen[a] ?: 0).also { seen[a] = it + 1 }
+      val segment = if ((totals[a] ?: 0) > 1) "$a[$index]" else a
+      assignNode(child, "$ref/$segment")
+    }
+    return node.copy(ref = ref, children = newChildren)
+  }
+
+  private const val GENERIC_ANCHOR = "node"
+
+  /** Strip characters that would collide with the ref path grammar (`/`, `[`, `]`, whitespace). */
+  private fun sanitize(value: String): String = value.replace(SANITIZE_REGEX, "_")
+
+  private val SANITIZE_REGEX = Regex("""[\s/\[\]]+""")
+}

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/SemanticsTargets.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/SemanticsTargets.kt
@@ -1,0 +1,104 @@
+package ee.schimke.composeai.data.layoutinspector
+
+/**
+ * Resolves a [SemanticsTarget] — a stable handle for a node — to a concrete node and a pixel point
+ * an interactive session can dispatch at, so agents drive previews by ref / testTag / role+text
+ * instead of guessing coordinates (issue #1784).
+ *
+ * Resolution runs against a [ComposeSemanticsPayload] tree whose [ComposeSemanticsNode.ref]s have
+ * been assigned by [SemanticsRefs]; [resolve] re-assigns defensively so a caller can pass a raw
+ * (unref'd) tree. The returned [SemanticsPoint] is the node's centre in the same root-pixel space
+ * as [ComposeSemanticsNode.boundsInRoot].
+ */
+object SemanticsTargets {
+
+  fun resolve(payload: ComposeSemanticsPayload, target: SemanticsTarget): TargetResolution =
+    resolve(payload.root, target)
+
+  fun resolve(root: ComposeSemanticsNode, target: SemanticsTarget): TargetResolution {
+    val refRoot = SemanticsRefs.assign(root)
+    val matches =
+      when (target) {
+        is SemanticsTarget.Ref -> refRoot.flatten().filter { it.ref == target.ref }
+        is SemanticsTarget.Tag -> refRoot.flatten().filter { it.testTag == target.testTag }
+        is SemanticsTarget.RoleText -> refRoot.flatten().filter { matchesRoleText(it, target) }
+      }
+    return when (matches.size) {
+      0 -> TargetResolution.NotFound
+      1 -> matches.single().let { node -> resolvedAt(node) }
+      else -> TargetResolution.Ambiguous(matches)
+    }
+  }
+
+  private fun resolvedAt(node: ComposeSemanticsNode): TargetResolution {
+    val bounds = SemanticsBounds.parse(node.boundsInRoot)
+    return if (bounds == null) TargetResolution.NotFound
+    else TargetResolution.Resolved(node, SemanticsPoint(bounds.centerX, bounds.centerY))
+  }
+
+  private fun matchesRoleText(
+    node: ComposeSemanticsNode,
+    target: SemanticsTarget.RoleText,
+  ): Boolean {
+    val roleOk = target.role == null || node.role.equals(target.role, ignoreCase = true)
+    val textOk =
+      target.text == null ||
+        sequiv(node.text, target.text) ||
+        sequiv(node.label, target.text) ||
+        sequiv(node.layoutText, target.text)
+    return roleOk && textOk && (target.role != null || target.text != null)
+  }
+
+  /** Case-insensitive, whitespace-trimmed equality, ignoring null. */
+  private fun sequiv(actual: String?, expected: String): Boolean =
+    actual != null && actual.trim().equals(expected.trim(), ignoreCase = true)
+
+  private fun ComposeSemanticsNode.flatten(): List<ComposeSemanticsNode> = buildList {
+    add(this@flatten)
+    children.forEach { addAll(it.flatten()) }
+  }
+}
+
+/** A request to identify a node by stable handle rather than pixel coordinates (issue #1784). */
+sealed interface SemanticsTarget {
+  /** Match the unique node whose [ComposeSemanticsNode.ref] equals [ref]. */
+  data class Ref(val ref: String) : SemanticsTarget
+
+  /** Match nodes carrying this exact `testTag`. */
+  data class Tag(val testTag: String) : SemanticsTarget
+
+  /** Match nodes by role and/or accessible text (at least one must be non-null). */
+  data class RoleText(val role: String? = null, val text: String? = null) : SemanticsTarget
+}
+
+sealed interface TargetResolution {
+  /** Exactly one node matched; dispatch at [point] (centre of the node, root-pixel space). */
+  data class Resolved(val node: ComposeSemanticsNode, val point: SemanticsPoint) : TargetResolution
+
+  /** No node matched. */
+  data object NotFound : TargetResolution
+
+  /** More than one node matched; the caller should disambiguate among [candidates]. */
+  data class Ambiguous(val candidates: List<ComposeSemanticsNode>) : TargetResolution
+}
+
+/** A point in the root-pixel coordinate space used by [ComposeSemanticsNode.boundsInRoot]. */
+data class SemanticsPoint(val x: Int, val y: Int)
+
+/** Bounds parsed from the `"left,top,right,bottom"` wire string. */
+data class SemanticsBounds(val left: Int, val top: Int, val right: Int, val bottom: Int) {
+  val centerX: Int
+    get() = (left + right) / 2
+
+  val centerY: Int
+    get() = (top + bottom) / 2
+
+  companion object {
+    fun parse(wire: String): SemanticsBounds? {
+      val parts = wire.split(',')
+      if (parts.size != 4) return null
+      val ints = parts.map { it.trim().toIntOrNull() ?: return null }
+      return SemanticsBounds(ints[0], ints[1], ints[2], ints[3])
+    }
+  }
+}

--- a/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/SemanticsDiffTest.kt
+++ b/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/SemanticsDiffTest.kt
@@ -1,0 +1,99 @@
+package ee.schimke.composeai.data.layoutinspector
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SemanticsDiffTest {
+
+  private fun node(
+    role: String? = null,
+    testTag: String? = null,
+    text: String? = null,
+    label: String? = null,
+    clickable: Boolean = false,
+    layoutTruncated: Boolean? = null,
+    children: List<ComposeSemanticsNode> = emptyList(),
+  ) =
+    ComposeSemanticsNode(
+      nodeId = "0",
+      boundsInRoot = "0,0,10,10",
+      role = role,
+      testTag = testTag,
+      text = text,
+      label = label,
+      clickable = clickable,
+      layoutTruncated = layoutTruncated,
+      children = children,
+    )
+
+  @Test
+  fun identicalTreesProduceEmptyDelta() {
+    val tree = node(children = listOf(node(testTag = "submit", text = "Go")))
+    assertTrue(SemanticsDiff.diff(tree, tree).isEmpty)
+  }
+
+  @Test
+  fun textChangeReportsFieldChangeOnSameRef() {
+    val base = node(children = listOf(node(testTag = "label", text = "Hello")))
+    val head = node(children = listOf(node(testTag = "label", text = "Helloo")))
+    val delta = SemanticsDiff.diff(base, head)
+
+    assertTrue(delta.added.isEmpty())
+    assertTrue(delta.removed.isEmpty())
+    assertEquals(1, delta.changed.size)
+    val change = delta.changed.single()
+    assertEquals("r/tag:label", change.ref)
+    assertEquals(1, change.changes.size)
+    assertEquals(SemanticsFieldChange("text", "Hello", "Helloo"), change.changes.single())
+  }
+
+  @Test
+  fun addedNodeIsReported() {
+    val base = node(children = listOf(node(testTag = "a")))
+    val head = node(children = listOf(node(testTag = "a"), node(testTag = "b")))
+    val delta = SemanticsDiff.diff(base, head)
+    assertTrue(delta.changed.isEmpty())
+    assertEquals(listOf("r/tag:b"), delta.added.map { it.ref })
+  }
+
+  @Test
+  fun removedNodeIsReported() {
+    val base = node(children = listOf(node(testTag = "a"), node(testTag = "b")))
+    val head = node(children = listOf(node(testTag = "a")))
+    val delta = SemanticsDiff.diff(base, head)
+    assertEquals(listOf("r/tag:b"), delta.removed.map { it.ref })
+  }
+
+  @Test
+  fun lostContentDescriptionIsAFieldChange() {
+    val base = node(children = listOf(node(role = "Button", label = "Submit")))
+    val head = node(children = listOf(node(role = "Button", label = null)))
+    val change = SemanticsDiff.diff(base, head).changed.single()
+    assertEquals(SemanticsFieldChange("label", "Submit", null), change.changes.single())
+  }
+
+  @Test
+  fun overflowFlagFlipIsReported() {
+    val base = node(children = listOf(node(testTag = "t", layoutTruncated = false)))
+    val head = node(children = listOf(node(testTag = "t", layoutTruncated = true)))
+    val change = SemanticsDiff.diff(base, head).changed.single()
+    assertEquals("layoutTruncated", change.changes.single().field)
+  }
+
+  @Test
+  fun changeCarriesAnchorForHumanOutput() {
+    val base = node(children = listOf(node(testTag = "submit", text = "Go")))
+    val head = node(children = listOf(node(testTag = "submit", text = "Send")))
+    assertEquals("tag:submit", SemanticsDiff.diff(base, head).changed.single().anchor)
+  }
+
+  @Test
+  fun worksOnRawUnrefdTrees() {
+    // Nodes built without running SemanticsRefs (ref == null) still diff correctly.
+    val base = node(children = listOf(node(testTag = "x", text = "1")))
+    val head = node(children = listOf(node(testTag = "x", text = "2")))
+    assertFalse(SemanticsDiff.diff(base, head).isEmpty)
+  }
+}

--- a/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/SemanticsRefsTest.kt
+++ b/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/SemanticsRefsTest.kt
@@ -1,0 +1,88 @@
+package ee.schimke.composeai.data.layoutinspector
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+class SemanticsRefsTest {
+
+  private fun node(
+    role: String? = null,
+    testTag: String? = null,
+    text: String? = null,
+    children: List<ComposeSemanticsNode> = emptyList(),
+  ) =
+    ComposeSemanticsNode(
+      nodeId = "0",
+      boundsInRoot = "0,0,10,10",
+      role = role,
+      testTag = testTag,
+      text = text,
+      children = children,
+    )
+
+  @Test
+  fun rootGetsRootRef() {
+    assertEquals("r", SemanticsRefs.assign(node()).ref)
+  }
+
+  @Test
+  fun testTagIsTheStrongestAnchor() {
+    val root = node(children = listOf(node(testTag = "submit")))
+    val child = SemanticsRefs.assign(root).children.single()
+    assertEquals("r/tag:submit", child.ref)
+  }
+
+  @Test
+  fun roleAnchorsWhenNoTestTag() {
+    val root = node(children = listOf(node(role = "Button")))
+    assertEquals("r/role:Button", SemanticsRefs.assign(root).children.single().ref)
+  }
+
+  @Test
+  fun genericAnchorWhenNoTagOrRole() {
+    val root = node(children = listOf(node(text = "hi")))
+    assertEquals("r/node", SemanticsRefs.assign(root).children.single().ref)
+  }
+
+  @Test
+  fun siblingsSharingAnAnchorAreIndexed() {
+    val root = node(children = listOf(node(role = "Button"), node(role = "Button")))
+    val refs = SemanticsRefs.assign(root).children.map { it.ref }
+    assertEquals(listOf("r/role:Button[0]", "r/role:Button[1]"), refs)
+  }
+
+  @Test
+  fun loneAnchorIsNotIndexed() {
+    val root = node(children = listOf(node(role = "Button"), node(role = "Text")))
+    val refs = SemanticsRefs.assign(root).children.map { it.ref }
+    assertEquals(listOf("r/role:Button", "r/role:Text"), refs)
+  }
+
+  @Test
+  fun refIsContentIndependent() {
+    val before = SemanticsRefs.assign(node(children = listOf(node(testTag = "t", text = "Hello"))))
+    val after = SemanticsRefs.assign(node(children = listOf(node(testTag = "t", text = "Goodbye"))))
+    assertEquals(before.children.single().ref, after.children.single().ref)
+  }
+
+  @Test
+  fun changingTestTagMovesTheRef() {
+    val before = SemanticsRefs.assign(node(children = listOf(node(testTag = "a"))))
+    val after = SemanticsRefs.assign(node(children = listOf(node(testTag = "b"))))
+    assertNotEquals(before.children.single().ref, after.children.single().ref)
+  }
+
+  @Test
+  fun assignmentIsIdempotent() {
+    val once = SemanticsRefs.assign(node(children = listOf(node(role = "Button"))))
+    val twice = SemanticsRefs.assign(once)
+    assertEquals(once, twice)
+  }
+
+  @Test
+  fun pathSeparatorsInTagsAreSanitised() {
+    val root = node(children = listOf(node(testTag = "nav/home tab")))
+    assertEquals("r/tag:nav_home_tab", SemanticsRefs.assign(root).children.single().ref)
+  }
+}

--- a/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/SemanticsTargetsTest.kt
+++ b/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/SemanticsTargetsTest.kt
@@ -1,0 +1,80 @@
+package ee.schimke.composeai.data.layoutinspector
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SemanticsTargetsTest {
+
+  private fun node(
+    bounds: String = "0,0,10,10",
+    role: String? = null,
+    testTag: String? = null,
+    text: String? = null,
+    label: String? = null,
+    children: List<ComposeSemanticsNode> = emptyList(),
+  ) =
+    ComposeSemanticsNode(
+      nodeId = "0",
+      boundsInRoot = bounds,
+      role = role,
+      testTag = testTag,
+      text = text,
+      label = label,
+      children = children,
+    )
+
+  @Test
+  fun resolvesTagToCentrePoint() {
+    val root = node(children = listOf(node(bounds = "100,40,140,80", testTag = "submit")))
+    val res = SemanticsTargets.resolve(root, SemanticsTarget.Tag("submit"))
+    assertTrue(res is TargetResolution.Resolved)
+    val resolved = res as TargetResolution.Resolved
+    assertEquals(SemanticsPoint(120, 60), resolved.point)
+    assertEquals("submit", resolved.node.testTag)
+  }
+
+  @Test
+  fun resolvesByRef() {
+    val root = node(children = listOf(node(role = "Button")))
+    val res = SemanticsTargets.resolve(root, SemanticsTarget.Ref("r/role:Button"))
+    assertTrue(res is TargetResolution.Resolved)
+  }
+
+  @Test
+  fun missingTargetIsNotFound() {
+    val root = node(children = listOf(node(testTag = "submit")))
+    assertEquals(
+      TargetResolution.NotFound,
+      SemanticsTargets.resolve(root, SemanticsTarget.Tag("cancel")),
+    )
+  }
+
+  @Test
+  fun duplicateTagsAreAmbiguous() {
+    val root = node(children = listOf(node(testTag = "row"), node(testTag = "row")))
+    val res = SemanticsTargets.resolve(root, SemanticsTarget.Tag("row"))
+    assertTrue(res is TargetResolution.Ambiguous)
+    assertEquals(2, (res as TargetResolution.Ambiguous).candidates.size)
+  }
+
+  @Test
+  fun roleAndTextNarrowsToOne() {
+    val root =
+      node(
+        children =
+          listOf(node(role = "Button", text = "Save"), node(role = "Button", text = "Cancel"))
+      )
+    val res =
+      SemanticsTargets.resolve(root, SemanticsTarget.RoleText(role = "Button", text = "cancel"))
+    assertTrue(res is TargetResolution.Resolved)
+    assertEquals("Cancel", (res as TargetResolution.Resolved).node.text)
+  }
+
+  @Test
+  fun textMatchesAccessibleLabel() {
+    val root = node(children = listOf(node(role = "Button", label = "Add to cart")))
+    val res = SemanticsTargets.resolve(root, SemanticsTarget.RoleText(text = "add to cart"))
+    assertTrue(res is TargetResolution.Resolved)
+  }
+}

--- a/docs/daemon/DATA-PRODUCTS.md
+++ b/docs/daemon/DATA-PRODUCTS.md
@@ -276,7 +276,7 @@ A `data/fetch` that needs a re-render:
 | `a11y/overlay` | a11y | low | Path to annotated PNG. Pure-image. |
 | `a11y/touchTargets` | a11y | low | 48dp + overlap detection. |
 | `layout/inspector` | default | low | Compose layout/component hierarchy with bounds, constraints, modifiers, source refs. |
-| `compose/semantics` | default | low | SemanticsNode projection — testTag, role, mergeMode, bounds. |
+| `compose/semantics` | default | low | SemanticsNode projection — testTag, role, mergeMode, bounds. Each node also carries a stable, content-independent `ref` (assigned by `SemanticsRefs`) used for ref/testTag/role targeting (#1784) and as the match key for the semantics text diff (#1785). Adding `ref` is additive — `schemaVersion` stays 2. |
 | `compose/semantics-wireframe` | default | low | Standalone 2D wireframe of the semantics tree, derived from the same captured root. SVG primary (path); baked PNG rides as a `png` extra. Depth-cycled stroke hue, accent fill/stroke for clickable stops, dashed stroke for `clearAndSet`, top-left labels. |
 | `compose/recomposition` | instrumented | medium | schemaVersion 2: `[{nodeId, count, reason, bounds?, sourceFile?…}]` + `sinceFrameStreamId`/`inputSeq`. `reason` (PARAMETER_CHANGE/STATE_READ/BOTH/UNKNOWN) attributes each scope; `bounds`/source markers nullable until their joins land (#1605). Heat map. Snapshot or click-delta. |
 | `compose/theme` | default | medium | Resolved `MaterialTheme.*` values + which nodes consumed them. |
@@ -382,7 +382,8 @@ Compose runtime, daemon, or AndroidX:
 | `a11y/touchTargets` | `:data-a11y-core` | `AccessibilityTouchTargetsPayload`, `AccessibilityTouchTarget` |
 | `a11y/overlay` | `:data-a11y-core` | `AccessibilityOverlayArtifact` (path-only) |
 | `compose/recomposition` | `:data-recomposition-core` | `RecompositionPayload`, `RecompositionNode` |
-| `compose/semantics` | `:data-layoutinspector-core` | `ComposeSemanticsPayload`, `ComposeSemanticsNode` |
+| `compose/semantics` | `:data-layoutinspector-core` | `ComposeSemanticsPayload`, `ComposeSemanticsNode` (carries stable `ref`) |
+| _(semantics diff, derived)_ | `:data-layoutinspector-core` | `SemanticsDelta`, `SemanticsNodeChange`, `SemanticsFieldChange` (schema `compose-semantics-diff/v1`) |
 | `compose/theme` | `:data-theme-core` | `ThemePayload`, `ResolvedThemeTokens`, `TypographyToken` |
 | `compose/wallpaper` | `:data-wallpaper-core` | `WallpaperPayload` |
 | `compose/permissions` | `:data-permissions-core` | `PermissionsPayload`, `PermissionGrantWire` |


### PR DESCRIPTION
Foundation for ref-based interaction (#1784) and a semantics text diff
(#1785), informed by how agents drive Playwright (act by stable ref /
aria-snapshot diff, not pixels).

- ComposeSemanticsNode gains a stable, content-independent `ref`
  (additive — schemaVersion stays 2). Unlike the per-render `nodeId`
  (Compose's reassigned SemanticsNode.id), it survives content edits, so
  it works as both an interaction handle and a diff match key.
- SemanticsRefs: deterministic, idempotent ref assignment anchored on
  testTag > role > generic, with sibling-index disambiguation. Text/label
  are excluded so a copy edit is a field change, not a remove+add.
- SemanticsTargets: resolves {ref | testTag | role+text} to a node and a
  centre point (root-pixel space), returning NotFound/Ambiguous with
  candidates. Core resolver for #1784.
- SemanticsDiff: pure tree diff over two payloads, matching by ref and
  reporting added/removed/changed-field deltas (schema
  compose-semantics-diff/v1). Engine for #1785.
- Producer assigns refs in buildPayload; docs note the field + schema.

All pure-JVM in :data-layoutinspector-core with unit tests. Daemon/MCP/CLI
wiring (interactive dispatch, history/diff mode, review command) follows.