### PR TITLE
feat(xr): XR session manager + fakeable render-server handle (daemon-fronting core)

### DIFF
--- a/renderers/xr-client/src/main/kotlin/ee/schimke/composeai/renderer/xr/client/XrRenderServer.kt
+++ b/renderers/xr-client/src/main/kotlin/ee/schimke/composeai/renderer/xr/client/XrRenderServer.kt
@@ -6,6 +6,42 @@ import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 
 /**
+ * Abstraction over a running XR render server, so callers (and the daemon's session manager) can be
+ * unit-tested against a fake without spawning the native process. [XrRenderServer] is the real,
+ * process-backed implementation.
+ */
+public interface XrRenderServerHandle : AutoCloseable {
+  /** The server's advertised `capabilities` from `initialize`. */
+  public val capabilities: JsonObject
+
+  /** Render a full [scene] (serialized `SpatialScene`); returns the streamed frame. */
+  public fun render(
+    scene: JsonElement,
+    sceneDir: String? = null,
+    environment: String? = null,
+  ): StreamFrame
+
+  /** Apply per-frame panel mutations and return the freshly streamed frame. */
+  public fun updatePanels(panels: JsonArray): StreamFrame
+}
+
+/**
+ * Spawns an [XrRenderServerHandle], or `null` when the native binary isn't available. Injected into
+ * the session manager so tests substitute a fake. The default implementation resolves + spawns the
+ * real `xr-composite --serve` via [XrRenderServer.startIfAvailable].
+ */
+public fun interface XrRenderServerFactory {
+  public fun start(width: Int, height: Int): XrRenderServerHandle?
+
+  public companion object {
+    /** The production factory: resolve + spawn the real native server. */
+    public val Native: XrRenderServerFactory = XrRenderServerFactory { w, h ->
+      XrRenderServer.startIfAvailable(width = w, height = h)
+    }
+  }
+}
+
+/**
  * A running native `xr-composite --serve` render server, driven over [XrServerClient]. This is the
  * single entry point the daemon's XR `RenderSession` backend holds: [start] resolves + spawns the
  * binary and performs the `initialize` handshake (so the returned instance is ready to render),
@@ -18,18 +54,18 @@ public class XrRenderServer
 private constructor(
   private val client: XrServerClient,
   /** The server's advertised `capabilities` from `initialize`. */
-  public val capabilities: JsonObject,
-) : AutoCloseable {
+  public override val capabilities: JsonObject,
+) : XrRenderServerHandle {
 
   /** Render a full [scene] (serialized `SpatialScene`); returns the streamed frame. */
-  public fun render(
+  public override fun render(
     scene: JsonElement,
-    sceneDir: String? = null,
-    environment: String? = null,
+    sceneDir: String?,
+    environment: String?,
   ): StreamFrame = client.render(scene, sceneDir, environment)
 
   /** Apply per-frame panel mutations and return the freshly streamed frame. */
-  public fun updatePanels(panels: JsonArray): StreamFrame = client.updatePanels(panels)
+  public override fun updatePanels(panels: JsonArray): StreamFrame = client.updatePanels(panels)
 
   override fun close(): Unit = client.close()
 

--- a/renderers/xr-client/src/main/kotlin/ee/schimke/composeai/renderer/xr/client/XrSessionManager.kt
+++ b/renderers/xr-client/src/main/kotlin/ee/schimke/composeai/renderer/xr/client/XrSessionManager.kt
@@ -1,0 +1,83 @@
+package ee.schimke.composeai.renderer.xr.client
+
+import java.util.concurrent.ConcurrentHashMap
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+
+/**
+ * Holds one native XR render server per live stream id (the daemon's `frameStreamId`), the
+ * server-side analogue of the daemon's held interactive sessions: open a session for a scene, push
+ * per-frame panel updates, and close it. Each session owns its own native process via the injected
+ * [factory] (defaulting to the real `xr-composite --serve`); tests inject a fake.
+ *
+ * The daemon's JSON-RPC layer (the next increment) wraps this: `xr/start` → [open],
+ * `xr/updatePanels` → [updatePanels], `xr/stop` → [close], and feeds each returned [StreamFrame]
+ * into its frame-stream registry. Keeping the lifecycle here keeps that wiring a thin adapter.
+ *
+ * Threading: safe for concurrent calls on distinct ids; calls for one id are expected to be
+ * serialised by the caller (the daemon dispatches per-stream from one thread).
+ */
+public class XrSessionManager(
+  private val factory: XrRenderServerFactory = XrRenderServerFactory.Native,
+  private val width: Int = 1280,
+  private val height: Int = 800,
+) : AutoCloseable {
+
+  private val sessions = ConcurrentHashMap<String, XrRenderServerHandle>()
+
+  /** Number of live sessions — for diagnostics / tests. */
+  public val activeCount: Int
+    get() = sessions.size
+
+  /** True if a session is currently open for [id]. */
+  public fun isOpen(id: String): Boolean = sessions.containsKey(id)
+
+  /**
+   * Open a session for [id] and render [scene], returning the first frame — or `null` when the
+   * native server isn't available (XR is best-effort, so the caller degrades gracefully). Closes
+   * any prior session held under the same [id] first.
+   */
+  public fun open(
+    id: String,
+    scene: JsonElement,
+    sceneDir: String? = null,
+    environment: String? = null,
+  ): StreamFrame? {
+    close(id)
+    val server = factory.start(width, height) ?: return null
+    sessions[id] = server
+    return try {
+      server.render(scene, sceneDir, environment)
+    } catch (t: Throwable) {
+      close(id)
+      throw t
+    }
+  }
+
+  /**
+   * Push per-frame panel mutations into the session for [id], returning the fresh frame. Throws
+   * [XrServerException] if no session is open for [id].
+   */
+  public fun updatePanels(id: String, panels: JsonArray): StreamFrame {
+    val server = sessions[id] ?: throw XrServerException("no XR session open for id=$id")
+    return server.updatePanels(panels)
+  }
+
+  /** Close and drop the session for [id]; no-op if none is open. */
+  public fun close(id: String) {
+    sessions.remove(id)?.let { server ->
+      try {
+        server.close()
+      } catch (t: Throwable) {
+        System.err.println(
+          "XrSessionManager: close($id) threw ${t.javaClass.simpleName}: ${t.message}; continuing"
+        )
+      }
+    }
+  }
+
+  /** Close every live session — call on daemon shutdown. */
+  override fun close() {
+    sessions.keys.toList().forEach(::close)
+  }
+}

--- a/renderers/xr-client/src/test/kotlin/ee/schimke/composeai/renderer/xr/client/XrSessionManagerTest.kt
+++ b/renderers/xr-client/src/test/kotlin/ee/schimke/composeai/renderer/xr/client/XrSessionManagerTest.kt
@@ -1,0 +1,94 @@
+package ee.schimke.composeai.renderer.xr.client
+
+import java.util.concurrent.atomic.AtomicLong
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+
+class XrSessionManagerTest {
+
+  private class FakeServer : XrRenderServerHandle {
+    val seq = AtomicLong(0)
+    var closed = false
+    override val capabilities: JsonObject = buildJsonObject {}
+
+    private fun frame() = StreamFrame(seq.incrementAndGet(), 64, 48, "png", "data")
+
+    override fun render(scene: JsonElement, sceneDir: String?, environment: String?) = frame()
+
+    override fun updatePanels(panels: JsonArray) = frame()
+
+    override fun close() {
+      closed = true
+    }
+  }
+
+  private val scene: JsonElement = buildJsonObject {}
+
+  @Test
+  fun openRendersFirstFrameAndUpdatePanelsAdvances() {
+    val server = FakeServer()
+    val manager = XrSessionManager(factory = { _, _ -> server })
+
+    val first = manager.open("s1", scene, sceneDir = ".")
+    assertEquals(1L, first?.seq)
+    assertTrue(manager.isOpen("s1"))
+    assertEquals(1, manager.activeCount)
+
+    val second = manager.updatePanels("s1", buildJsonArray {})
+    assertEquals(2L, second.seq)
+
+    manager.close("s1")
+    assertFalse(manager.isOpen("s1"))
+    assertTrue(server.closed)
+  }
+
+  @Test
+  fun openReturnsNullWhenServerUnavailable() {
+    val manager = XrSessionManager(factory = { _, _ -> null })
+    assertNull(manager.open("s1", scene))
+    assertFalse(manager.isOpen("s1"))
+    assertEquals(0, manager.activeCount)
+  }
+
+  @Test
+  fun updatePanelsOnUnknownSessionThrows() {
+    val manager = XrSessionManager(factory = { _, _ -> FakeServer() })
+    assertFailsWith<XrServerException> { manager.updatePanels("missing", buildJsonArray {}) }
+  }
+
+  @Test
+  fun reopeningSameIdClosesThePriorSession() {
+    val first = FakeServer()
+    val second = FakeServer()
+    val servers = ArrayDeque(listOf(first, second))
+    val manager = XrSessionManager(factory = { _, _ -> servers.removeFirst() })
+
+    manager.open("s1", scene)
+    manager.open("s1", scene)
+    assertTrue(first.closed, "prior session should be closed on reopen")
+    assertFalse(second.closed)
+    assertEquals(1, manager.activeCount)
+  }
+
+  @Test
+  fun closeAllClosesEveryLiveSession() {
+    val servers = mutableListOf<FakeServer>()
+    val manager = XrSessionManager(factory = { _, _ -> FakeServer().also { servers.add(it) } })
+    manager.open("a", scene)
+    manager.open("b", scene)
+    assertEquals(2, manager.activeCount)
+
+    manager.close()
+    assertEquals(0, manager.activeCount)
+    assertTrue(servers.all { it.closed })
+  }
+}


### PR DESCRIPTION
## Summary

First increment of the daemon's XR integration (the **interactive-session model**): the held-session core, kept unit-testable without the native binary. Builds on `XrRenderServer` (#1782).

The daemon's Compose `InteractiveSession` interface is pointer/semantics/lifecycle-specific, so XR can't implement it — the faithful realization is a **parallel XR session** holding `XrRenderServer`, whose frames feed the same `FrameStreamRegistry`. This PR lands that session layer:

- Extract **`XrRenderServerHandle`** from `XrRenderServer` + an **`XrRenderServerFactory`** fun-interface (default = the real native server) so the manager is testable against a fake.
- **`XrSessionManager`** — one XR render server per stream id (the daemon's `frameStreamId`): `open(scene)` → first frame, `updatePanels` → next frame, `close`/`closeAll`. `open()` returns `null` when the native server is unavailable, keeping XR best-effort.

## Test plan

- [x] `:renderer-xr-client:test` — `XrSessionManagerTest` drives the lifecycle against a fake factory (open/update/close/closeAll, reopen-closes-prior, null-when-unavailable, unknown-id throws). No binary needed.
- [x] Real-binary `XrRenderServerIntegrationTest` still green under Xvfb after the interface extraction.
- [x] `ktfmtCheck` clean.

## Next

The `JsonRpcServer` surface — `xr/start` / `xr/updatePanels` / `xr/stop` + a capability flag — feeding each `StreamFrame` into the existing `FrameStreamRegistry` (reusing visibility/fps/dedup + the unchanged `streamFrame` wire shape). That wiring is best verified with the daemon harness.


---
_Generated by [Claude Code](https://claude.ai/code/session_01X8ZwHy8Sgg5eVJzNqr1LMb)_