### PR TITLE
feat(xr): daemon JSON-RPC surface for the XR render service

### DIFF
--- a/daemon/core/build.gradle.kts
+++ b/daemon/core/build.gradle.kts
@@ -27,9 +27,10 @@ dependencies {
   // public surface keeps its java.io.File signatures.
   implementation(project(":common-io"))
 
-  // JVM client for the native XR render server — the daemon fronts it for `xr/*`
-  // (RENDERER_SERVICE).
-  implementation(project(":renderer-xr-client"))
+  // JVM client for the native XR render server — the daemon fronts it for `xr/…`
+  // (RENDERER_SERVICE). `api`, not `implementation`: `JsonRpcServer`'s public constructor exposes
+  // `XrRenderServerFactory?`, so the type is part of this published module's compile ABI.
+  api(project(":renderer-xr-client"))
 
   // Protocol message types are @Serializable. Exposed as `api` so downstream
   // daemon modules (e.g. :daemon:android) get

--- a/daemon/core/build.gradle.kts
+++ b/daemon/core/build.gradle.kts
@@ -27,6 +27,10 @@ dependencies {
   // public surface keeps its java.io.File signatures.
   implementation(project(":common-io"))
 
+  // JVM client for the native XR render server — the daemon fronts it for `xr/*`
+  // (RENDERER_SERVICE).
+  implementation(project(":renderer-xr-client"))
+
   // Protocol message types are @Serializable. Exposed as `api` so downstream
   // daemon modules (e.g. :daemon:android) get
   // kotlinx-serialization-json on their compile classpath without re-declaring

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -2260,7 +2260,14 @@ class JsonRpcServer(
     val streamId = streamRegistry.mintStreamId()
     val frame =
       try {
-        manager.open(streamId, params.scene, params.sceneDir, params.environment)
+        manager.open(
+          streamId,
+          params.scene,
+          params.sceneDir,
+          params.environment,
+          params.width,
+          params.height,
+        )
       } catch (t: Throwable) {
         sendErrorResponse(
           req.id,

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -62,7 +62,14 @@ import ee.schimke.composeai.daemon.protocol.StreamFrameParams
 import ee.schimke.composeai.daemon.protocol.StreamStartParams
 import ee.schimke.composeai.daemon.protocol.StreamStartResult
 import ee.schimke.composeai.daemon.protocol.UiMode
+import ee.schimke.composeai.daemon.protocol.XrStartParams
+import ee.schimke.composeai.daemon.protocol.XrStartResult
+import ee.schimke.composeai.daemon.protocol.XrStopParams
+import ee.schimke.composeai.daemon.protocol.XrUpdatePanelsParams
 import ee.schimke.composeai.io.SystemFileSystem
+import ee.schimke.composeai.renderer.xr.client.StreamFrame as XrStreamFrame
+import ee.schimke.composeai.renderer.xr.client.XrRenderServerFactory
+import ee.schimke.composeai.renderer.xr.client.XrSessionManager
 import java.io.ByteArrayOutputStream
 import java.io.EOFException
 import java.io.IOException
@@ -239,6 +246,14 @@ class JsonRpcServer(
   private val btaCompileService: ee.schimke.composeai.daemon.bta.BtaCompileService? = null,
   private val fileSystem: FileSystem = SystemFileSystem,
   private val onExit: (Int) -> Unit = { code -> System.exit(code) },
+  /**
+   * RENDERER_SERVICE.md — factory for the native XR render server. When non-null the daemon
+   * advertises `capabilities.xr` and serves `xr/start` / `xr/updatePanels` / `xr/stop`, spawning
+   * one `xr-composite --serve` child per session. When null (the in-process integration tests,
+   * fake-mode harness, daemons whose host has no XR binary) the `xr/…` methods reply
+   * `MethodNotFound` — the one-shot composite path is unaffected.
+   */
+  private val xrServerFactory: XrRenderServerFactory? = null,
 ) {
 
   private val json = Json {
@@ -461,6 +476,13 @@ class JsonRpcServer(
    */
   private val streamSessions = ConcurrentHashMap<String, InteractiveSession>()
 
+  /**
+   * RENDERER_SERVICE.md — held native XR render sessions, one per `frameStreamId`, present only
+   * when [xrServerFactory] was wired. The daemon's `xr/…` handlers drive it and feed each returned
+   * frame out as a `streamFrame` notification.
+   */
+  private val xrSessions: XrSessionManager? = xrServerFactory?.let { XrSessionManager(it) }
+
   // ----------------------------------------------------------------------
   // Recording (scripted screen-record) state — see docs/daemon/RECORDING.md.
   //
@@ -524,6 +546,7 @@ class JsonRpcServer(
       // [closeAllInteractiveSessions] is idempotent, so the second call inside [cleanShutdown]
       // is a safe no-op on this path.
       closeAllInteractiveSessions()
+      xrSessions?.close()
       // EOF without exit notification — PROTOCOL.md § 3 idle-timeout exit.
       if (!shutdownRequested.get()) {
         try {
@@ -670,6 +693,7 @@ class JsonRpcServer(
       "extensions/disable" -> handleExtensionsDisable(req)
       "interactive/start" -> handleInteractiveStart(req)
       "stream/start" -> handleStreamStart(req)
+      "xr/start" -> handleXrStart(req)
       "recording/start" -> handleRecordingStart(req)
       "recording/stop" -> handleRecordingStop(req)
       "recording/encode" -> handleRecordingEncode(req)
@@ -752,6 +776,9 @@ class JsonRpcServer(
             // held-scene recording driver (DesktopHost). `false` keeps `recording/start` behind a
             // `MethodNotFound` reply so clients can grey out the toggle.
             recording = host.supportsRecording,
+            // RENDERER_SERVICE.md — `true` when the daemon can front the native XR render server
+            // (the `xrServerFactory` was wired). Gates the `xr/…` methods.
+            xr = xrSessions != null,
             // RECORDING.md § "encoded formats" — list of wire format spellings the host can
             // produce (`"apng"`, `"mp4"`, `"webm"`). APNG is always present when recording is
             // enabled; MP4 / WEBM appear only when an `ffmpeg` binary was detected at host
@@ -2206,6 +2233,89 @@ class JsonRpcServer(
   // either map.
   // --------------------------------------------------------------------------
 
+  // --------------------------------------------------------------------------
+  // XR render service — `xr/start` (request) / `xr/updatePanels` + `xr/stop`
+  // (notifications). Fronts the native `xr-composite --serve` via [xrSessions].
+  // Frames flow out as `streamFrame` notifications, same wire shape as the
+  // interactive/stream surfaces. See docs/design/xr-spatial/RENDERER_SERVICE.md.
+  // --------------------------------------------------------------------------
+
+  private fun handleXrStart(req: JsonRpcRequest) {
+    val manager = xrSessions
+    if (manager == null) {
+      sendErrorResponse(
+        id = req.id,
+        code = ERR_METHOD_NOT_FOUND,
+        message = "xr/start: XR rendering is not available on this daemon",
+      )
+      return
+    }
+    val params =
+      try {
+        decodeParams(req.params, XrStartParams.serializer())
+      } catch (e: Throwable) {
+        sendErrorResponse(req.id, ERR_INVALID_PARAMS, "invalid xr/start params: ${e.message}")
+        return
+      }
+    val streamId = streamRegistry.mintStreamId()
+    val frame =
+      try {
+        manager.open(streamId, params.scene, params.sceneDir, params.environment)
+      } catch (t: Throwable) {
+        sendErrorResponse(
+          req.id,
+          ERR_INTERNAL,
+          "xr/start: render failed: ${t.javaClass.simpleName}: ${t.message}",
+        )
+        return
+      }
+    if (frame == null) {
+      sendErrorResponse(req.id, ERR_INTERNAL, "xr/start: native XR server unavailable")
+      return
+    }
+    sendResponse(
+      req.id,
+      encode(XrStartResult.serializer(), XrStartResult(frameStreamId = streamId, available = true)),
+    )
+    emitXrFrame(streamId, frame)
+  }
+
+  private fun handleXrUpdatePanels(params: XrUpdatePanelsParams) {
+    val manager = xrSessions ?: return
+    if (!manager.isOpen(params.frameStreamId)) return
+    val frame =
+      try {
+        manager.updatePanels(params.frameStreamId, params.panels)
+      } catch (t: Throwable) {
+        System.err.println(
+          "compose-ai-daemon: xr/updatePanels failed for ${params.frameStreamId}: " +
+            "${t.javaClass.simpleName}: ${t.message}"
+        )
+        return
+      }
+    emitXrFrame(params.frameStreamId, frame)
+  }
+
+  private fun handleXrStop(params: XrStopParams) {
+    xrSessions?.close(params.frameStreamId)
+  }
+
+  /** Emit one XR [frame] as a `streamFrame` notification (base64 PNG already in hand). */
+  private fun emitXrFrame(frameStreamId: String, frame: XrStreamFrame) {
+    val params =
+      StreamFrameParams(
+        frameStreamId = frameStreamId,
+        seq = frame.seq,
+        ptsMillis = System.currentTimeMillis(),
+        widthPx = frame.width,
+        heightPx = frame.height,
+        codec = ee.schimke.composeai.daemon.protocol.StreamCodec.PNG,
+        keyframe = frame.seq == 1L,
+        payloadBase64 = frame.dataBase64,
+      )
+    sendNotification("streamFrame", encode(StreamFrameParams.serializer(), params))
+  }
+
   private fun handleStreamStart(req: JsonRpcRequest) {
     val params =
       try {
@@ -3020,6 +3130,9 @@ class JsonRpcServer(
         tryDecode(ee.schimke.composeai.daemon.protocol.StreamVisibilityParams.serializer(), n) {
           handleStreamVisibility(it)
         }
+      "xr/updatePanels" ->
+        tryDecode(XrUpdatePanelsParams.serializer(), n) { handleXrUpdatePanels(it) }
+      "xr/stop" -> tryDecode(XrStopParams.serializer(), n) { handleXrStop(it) }
       "recording/script" ->
         tryDecode(ee.schimke.composeai.daemon.protocol.RecordingScriptParams.serializer(), n) {
           handleRecordingScript(it)
@@ -3281,6 +3394,7 @@ class JsonRpcServer(
     // safe no-op on this path.
     closeAllInteractiveSessions()
     closeAllRecordingSessions()
+    xrSessions?.close()
     running.set(false)
     cleanShutdown()
     invokeExit(exitCode)
@@ -3439,6 +3553,7 @@ class JsonRpcServer(
     }
     closeAllInteractiveSessions()
     closeAllRecordingSessions()
+    xrSessions?.close()
     try {
       host.shutdown()
     } catch (e: Throwable) {

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -7,6 +7,7 @@ import kotlinx.serialization.EncodeDefault
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 
 // ---------------------------------------------------------------------------
@@ -161,6 +162,14 @@ data class ServerCapabilities(
    * "recording unsupported by this backend" when the toggle is offered.
    */
   val recording: Boolean = false,
+  /**
+   * RENDERER_SERVICE.md — `true` when the daemon can front the native XR render server
+   * (`xr-composite --serve`): `xr/start` opens a held spatial-scene session, `xr/updatePanels`
+   * mutates it per-frame, and frames arrive as `streamFrame` notifications. `false` (the default
+   * for daemons without the native binary, or that pre-date the feature) means the `xr/…` methods
+   * reply `MethodNotFound`; clients fall back to the one-shot composite still.
+   */
+  val xr: Boolean = false,
   /**
    * Encoded video formats the daemon's host can produce — names match the wire spelling on
    * [RecordingFormat]. APNG is always present when [recording] is true (pure-JVM encoder, no native
@@ -2123,3 +2132,34 @@ data class StreamFrameParams(
    */
   val payloadBase64: String? = null,
 )
+
+// ---- XR render service (RENDERER_SERVICE.md) ----------------------------------------------------
+
+/**
+ * `xr/start` — open a held spatial-scene session backed by the native `xr-composite --serve`. The
+ * daemon mints a `frameStreamId`, renders [scene] (a serialized `SpatialScene`), and streams the
+ * first frame as a `streamFrame` notification.
+ */
+@Serializable
+data class XrStartParams(
+  val previewId: String,
+  val scene: JsonElement,
+  /** Directory the scene's relative panel textures resolve against. */
+  val sceneDir: String? = null,
+  /** Backdrop override (a preset name or `color:#RRGGBB`); see the compositor's `--environment`. */
+  val environment: String? = null,
+  val width: Int? = null,
+  val height: Int? = null,
+)
+
+/** `xr/start` result — the allocated stream id frames will arrive on. */
+@Serializable data class XrStartResult(val frameStreamId: String, val available: Boolean = true)
+
+/**
+ * `xr/updatePanels` — per-frame panel mutations; each entry is `{id, texture?, poseInRoot?,
+ * sizeDp?}`.
+ */
+@Serializable data class XrUpdatePanelsParams(val frameStreamId: String, val panels: JsonArray)
+
+/** `xr/stop` — close the held XR session for [frameStreamId]. */
+@Serializable data class XrStopParams(val frameStreamId: String)

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/StreamRpcIntegrationTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/StreamRpcIntegrationTest.kt
@@ -1,5 +1,8 @@
 package ee.schimke.composeai.daemon
 
+import ee.schimke.composeai.renderer.xr.client.StreamFrame as XrStreamFrame
+import ee.schimke.composeai.renderer.xr.client.XrRenderServerFactory
+import ee.schimke.composeai.renderer.xr.client.XrRenderServerHandle
 import java.io.File
 import java.io.PipedInputStream
 import java.io.PipedOutputStream
@@ -10,8 +13,10 @@ import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.jsonObject
@@ -444,7 +449,10 @@ class StreamRpcIntegrationTest {
     val exitLatch: CountDownLatch,
   )
 
-  private fun bringUpServer(host: RenderHost): ServerHarness {
+  private fun bringUpServer(
+    host: RenderHost,
+    xrServerFactory: XrRenderServerFactory? = null,
+  ): ServerHarness {
     val clientToServerOut = PipedOutputStream()
     val clientToServerIn = PipedInputStream(clientToServerOut, 64 * 1024)
     val serverToClientOut = PipedOutputStream()
@@ -459,6 +467,7 @@ class StreamRpcIntegrationTest {
         daemonVersion = "test",
         interactiveFrameIntervalMs = 0,
         onExit = { _ -> exitLatch.countDown() },
+        xrServerFactory = xrServerFactory,
       )
     val thread = Thread({ server.run() }, "stream-rpc-server").apply { isDaemon = true }
     thread.start()
@@ -530,11 +539,110 @@ class StreamRpcIntegrationTest {
     return null
   }
 
+  // ---- XR render service (xr/start, xr/updatePanels, xr/stop) -------------------------------
+
+  @Test(timeout = 30_000)
+  fun xrStart_then_updatePanels_emit_streamFrames_and_stop_closes() {
+    val tmp = Files.createTempDirectory("xr-rpc-test").toFile()
+    val pngFile = File(tmp, "preview-A.png").apply { writeBytes(testPngBytes(seed = 0)) }
+    val factory = FakeXrFactory()
+    val (_, serverThread, out, received, exitLatch) =
+      bringUpServer(StreamRpcFakeHost(pngFile), factory)
+    resourcesToClose.add(AutoCloseable { runCatching { out.close() } })
+    handshake(out, received)
+
+    writeFrame(
+      out,
+      """{"jsonrpc":"2.0","id":20,"method":"xr/start","params":{
+            "previewId":"p","sceneDir":".",
+            "scene":{"version":1,"units":"dp","camera":{"kind":"orbit"},"panels":[]}}}""",
+    )
+    val resp = pollUntil(received) { it["id"]?.jsonPrimitive?.intOrNull == 20 }
+    assertNotNull("xr/start must respond", resp)
+    val streamId = resp!!["result"]!!.jsonObject["frameStreamId"]!!.jsonPrimitive.contentOrNull!!
+
+    val f1 = pollUntil(received) { it["method"]?.jsonPrimitive?.contentOrNull == "streamFrame" }
+    assertNotNull("xr/start must push the first frame", f1)
+    assertEquals(
+      streamId,
+      f1!!["params"]!!.jsonObject["frameStreamId"]?.jsonPrimitive?.contentOrNull,
+    )
+    assertEquals(1L, f1["params"]!!.jsonObject["seq"]?.jsonPrimitive?.longOrNull)
+    assertNotNull(f1["params"]!!.jsonObject["payloadBase64"]?.jsonPrimitive?.contentOrNull)
+
+    writeFrame(
+      out,
+      """{"jsonrpc":"2.0","method":"xr/updatePanels","params":{
+            "frameStreamId":"$streamId","panels":[{"id":"top"}]}}""",
+    )
+    val f2 =
+      pollUntil(received) {
+        it["method"]?.jsonPrimitive?.contentOrNull == "streamFrame" &&
+          it["params"]!!.jsonObject["seq"]?.jsonPrimitive?.longOrNull == 2L
+      }
+    assertNotNull("xr/updatePanels must push a fresh frame (seq=2)", f2)
+
+    writeFrame(
+      out,
+      """{"jsonrpc":"2.0","method":"xr/stop","params":{"frameStreamId":"$streamId"}}""",
+    )
+    teardownServer(out, received, serverThread, exitLatch)
+    assertTrue("the native session must be closed", factory.created.single().closed)
+  }
+
+  @Test(timeout = 30_000)
+  fun xrStart_replies_methodNotFound_when_xr_unavailable() {
+    val tmp = Files.createTempDirectory("xr-rpc-test").toFile()
+    val pngFile = File(tmp, "preview-A.png").apply { writeBytes(testPngBytes(seed = 0)) }
+    // No xrServerFactory → capability off, methods rejected.
+    val (_, serverThread, out, received, exitLatch) = bringUpServer(StreamRpcFakeHost(pngFile))
+    resourcesToClose.add(AutoCloseable { runCatching { out.close() } })
+    handshake(out, received)
+
+    writeFrame(
+      out,
+      """{"jsonrpc":"2.0","id":21,"method":"xr/start","params":{
+            "previewId":"p","scene":{"version":1,"units":"dp","camera":{"kind":"orbit"},"panels":[]}}}""",
+    )
+    val resp = pollUntil(received) { it["id"]?.jsonPrimitive?.intOrNull == 21 }
+    assertNotNull("xr/start must respond", resp)
+    assertNotNull("xr/start must error when XR is unavailable", resp!!["error"])
+    teardownServer(out, received, serverThread, exitLatch)
+  }
+
   private fun testPngBytes(seed: Int): ByteArray {
     val sig = byteArrayOf(-119, 80, 78, 71, 13, 10, 26, 10)
     val payload = ByteArray(16) { i -> ((i + seed * 13) and 0xFF).toByte() }
     return sig + payload
   }
+}
+
+/** Fake native XR render server — returns monotonically-sequenced frames, tracks close. */
+private class FakeXrHandle : XrRenderServerHandle {
+  private val seq = AtomicInteger(0)
+  @Volatile var closed = false
+  override val capabilities = buildJsonObject {}
+
+  private fun frame() = XrStreamFrame(seq.incrementAndGet().toLong(), 64, 48, "png", "ZGF0YQ==")
+
+  override fun render(
+    scene: kotlinx.serialization.json.JsonElement,
+    sceneDir: String?,
+    environment: String?,
+  ) = frame()
+
+  override fun updatePanels(panels: JsonArray) = frame()
+
+  override fun close() {
+    closed = true
+  }
+}
+
+private class FakeXrFactory : XrRenderServerFactory {
+  val created = mutableListOf<FakeXrHandle>()
+
+  override fun start(width: Int, height: Int): XrRenderServerHandle =
+    FakeXrHandle().also { created.add(it) }
 }
 
 /** Mirror of the test-only host in InteractiveRpcIntegrationTest. */

--- a/docs/design/xr-spatial/RENDERER_SERVICE.md
+++ b/docs/design/xr-spatial/RENDERER_SERVICE.md
@@ -11,13 +11,18 @@ into a long-lived, extensible render service.
 >   held, mutable session — in prototype form). See
 >   [renderers/xr-composite/README.md → Server mode](../../../renderers/xr-composite/README.md#server-mode---serve).
 > - `:renderer-xr-client` — the JVM side: `XrServerClient` (the framed JSON-RPC transport),
->   `XrCompositeBinary` (binary/materials resolution), and `XrRenderServer` (resolve → spawn →
->   `initialize` → render/updatePanels → close), the single entry point the daemon backend will hold.
+>   `XrCompositeBinary` (binary/materials resolution), `XrRenderServer` (resolve → spawn →
+>   `initialize` → render/updatePanels → close), and `XrSessionManager` (one server per stream id).
 >   A real-binary integration test drives the loop end-to-end in the XR CI job.
+> - **Daemon `xr/*` surface** — `JsonRpcServer` now serves `xr/start` (request) / `xr/updatePanels`
+>   / `xr/stop` (notifications) behind an injected `XrRenderServerFactory`, advertising
+>   `capabilities.xr` and emitting frames as `streamFrame` notifications (the unchanged wire shape).
+>   Covered by in-process integration tests with a fake factory.
 >
-> **Still to do:** the daemon fronting `XrRenderServer` (a `RenderSession`-style backend + JSON-RPC
-> surface + frame proxying through `FrameStreamRegistry` — item #2), native multi-session
-> concurrency, and the `xr/structure` / `xr/a11y-overlay` data-product kinds.
+> **Still to do:** wire the production factory in `DaemonMain` (resolve the binary at startup so the
+> real daemon flips `capabilities.xr` on — best verified with the daemon harness), route XR frames
+> through `FrameStreamRegistry` for visibility/fps gating, native multi-session concurrency, and the
+> `xr/structure` / `xr/a11y-overlay` data-product kinds.
 
 ## Motivation
 

--- a/renderers/xr-client/build.gradle.kts
+++ b/renderers/xr-client/build.gradle.kts
@@ -5,6 +5,7 @@
 
 plugins {
   id("composeai.base-conventions")
+  id("composeai.maven-publishing")
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.kotlin.serialization)
 }
@@ -14,4 +15,19 @@ dependencies {
 
   testImplementation(libs.junit)
   testImplementation(kotlin("test"))
+}
+
+// Published because `:daemon-core` (itself published to Maven Central) depends on it — a published
+// module can't have an unpublished (`unspecified`) transitive dependency, or coordinate-based
+// consumers (the bundle render path, sample builds) fail to resolve it.
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "renderer-xr-client",
+    displayName = "Compose Preview — XR Render Client",
+    description =
+      "JVM client for the native xr-composite --serve render server: the framed JSON-RPC " +
+        "transport, binary resolution, and held-session management the daemon fronts for the " +
+        "XR render service. Pre-1.0.",
+  )
+  inceptionYear.set("2026")
 }

--- a/renderers/xr-client/src/main/kotlin/ee/schimke/composeai/renderer/xr/client/XrSessionManager.kt
+++ b/renderers/xr-client/src/main/kotlin/ee/schimke/composeai/renderer/xr/client/XrSessionManager.kt
@@ -19,8 +19,8 @@ import kotlinx.serialization.json.JsonElement
  */
 public class XrSessionManager(
   private val factory: XrRenderServerFactory = XrRenderServerFactory.Native,
-  private val width: Int = 1280,
-  private val height: Int = 800,
+  private val defaultWidth: Int = 1280,
+  private val defaultHeight: Int = 800,
 ) : AutoCloseable {
 
   private val sessions = ConcurrentHashMap<String, XrRenderServerHandle>()
@@ -34,17 +34,20 @@ public class XrSessionManager(
 
   /**
    * Open a session for [id] and render [scene], returning the first frame — or `null` when the
-   * native server isn't available (XR is best-effort, so the caller degrades gracefully). Closes
-   * any prior session held under the same [id] first.
+   * native server isn't available (XR is best-effort, so the caller degrades gracefully). [width] /
+   * [height] set the render viewport (falling back to the manager defaults). Closes any prior
+   * session held under the same [id] first.
    */
   public fun open(
     id: String,
     scene: JsonElement,
     sceneDir: String? = null,
     environment: String? = null,
+    width: Int? = null,
+    height: Int? = null,
   ): StreamFrame? {
     close(id)
-    val server = factory.start(width, height) ?: return null
+    val server = factory.start(width ?: defaultWidth, height ?: defaultHeight) ?: return null
     sessions[id] = server
     return try {
       server.render(scene, sceneDir, environment)

--- a/renderers/xr-client/src/test/kotlin/ee/schimke/composeai/renderer/xr/client/XrSessionManagerTest.kt
+++ b/renderers/xr-client/src/test/kotlin/ee/schimke/composeai/renderer/xr/client/XrSessionManagerTest.kt
@@ -80,6 +80,42 @@ class XrSessionManagerTest {
   }
 
   @Test
+  fun passesRequestedDimensionsToFactory() {
+    var seenW = 0
+    var seenH = 0
+    val manager =
+      XrSessionManager(
+        factory = { w, h ->
+          seenW = w
+          seenH = h
+          FakeServer()
+        }
+      )
+    manager.open("s1", scene, width = 640, height = 400)
+    assertEquals(640, seenW)
+    assertEquals(400, seenH)
+  }
+
+  @Test
+  fun fallsBackToDefaultDimensionsWhenUnset() {
+    var seenW = 0
+    var seenH = 0
+    val manager =
+      XrSessionManager(
+        factory = { w, h ->
+          seenW = w
+          seenH = h
+          FakeServer()
+        },
+        defaultWidth = 800,
+        defaultHeight = 600,
+      )
+    manager.open("s1", scene)
+    assertEquals(800, seenW)
+    assertEquals(600, seenH)
+  }
+
+  @Test
   fun closeAllClosesEveryLiveSession() {
     val servers = mutableListOf<FakeServer>()
     val manager = XrSessionManager(factory = { _, _ -> FakeServer().also { servers.add(it) } })


### PR DESCRIPTION
## Summary

The daemon now fronts the native XR render server — RENDERER_SERVICE item #2 (the interactive-session model), building on `XrSessionManager` (#1791). Since the Compose `InteractiveSession` interface is pointer/semantics/lifecycle-specific, XR rides a **parallel session path** but reuses the **unchanged `streamFrame` wire shape**, so existing clients consume XR frames as-is.

`JsonRpcServer` gains an injected `XrRenderServerFactory`; when wired it advertises `capabilities.xr` and serves:

- **`xr/start`** (request) — open a held spatial-scene session via `XrSessionManager`, mint a `frameStreamId`, render the `SpatialScene`, push the first frame.
- **`xr/updatePanels`** (notification) — mutate panels per-frame, push the next frame.
- **`xr/stop`** (notification) — close the held session.

Frames go out as `streamFrame` / `StreamFrameParams` notifications. Sessions are torn down on `xr/stop` and on every daemon-shutdown path. When **no** factory is wired (in-process tests, hosts without the binary), `xr/*` replies `MethodNotFound` and `capabilities.xr` is `false` — the one-shot composite path is untouched.

## Test plan

- [x] `StreamRpcIntegrationTest` gains in-process coverage against a **fake** `XrRenderServerFactory`: `xr/start` → `streamFrame(seq=1)` → `xr/updatePanels` → `streamFrame(seq=2)` → `xr/stop` (asserts the native session is closed), plus the unsupported-when-no-factory (`MethodNotFound`) path.
- [x] `:daemon:core` compiles; `:daemon:core:ktfmtCheck` clean. (Local run needs a UTF-8 locale to dodge a pre-existing incremental-compiler ICE on an em-dash test-class name — unrelated to this change; CI's locale is UTF-8.)

## Follow-ups

- Wire the production factory in `DaemonMain` (resolve the binary at startup so the real daemon flips `capabilities.xr` on) — best verified with the daemon harness.
- Route XR frames through `FrameStreamRegistry` for visibility/fps gating + dedup.
- Native multi-session concurrency; the `xr/structure` / `xr/a11y-overlay` data-product kinds.


---
_Generated by [Claude Code](https://claude.ai/code/session_01X8ZwHy8Sgg5eVJzNqr1LMb)_