### PR TITLE
feat(daemon): resolve interactive input targets by semantic ref (desktop)

### DIFF
--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -1601,6 +1601,16 @@ data class InteractiveInputParams(
   val pixelX: Int? = null,
   val pixelY: Int? = null,
   /**
+   * Stable semantic handle for the node this input targets, resolved server-side against the held
+   * composition's live semantics tree (issue #1784) so agents act by ref / testTag / role+text
+   * instead of guessing pixel coordinates. The daemon resolves it to the node's centre point and
+   * dispatches there. When both [pixelX]/[pixelY] and [target] are set, explicit pixels win. A
+   * target matching no node — or, for testTag / role+text, more than one — drops the input
+   * (interactive/input is fire-and-forget); use [SemanticsInputTarget.ref] for an unambiguous
+   * handle.
+   */
+  val target: SemanticsInputTarget? = null,
+  /**
    * Per-pointer identifier for multi-touch dispatch (pinch-to-zoom, two-finger rotate, …). Defaults
    * to `0` for backwards compatibility; the daemon tracks active pointers by id across
    * `pointerDown` → `pointerMove`(s) → `pointerUp` so Compose's gesture pipeline groups them
@@ -1611,6 +1621,25 @@ data class InteractiveInputParams(
   val scrollDeltaY: Float? = null,
   /** For `keyDown` / `keyUp`. */
   val keyCode: String? = null,
+)
+
+/**
+ * A stable handle for the node an interaction targets, resolved server-side against the live
+ * semantics tree (issue #1784). Set exactly one of:
+ * - [ref] — the stable `ComposeSemanticsNode.ref` assigned by `SemanticsRefs` (the unambiguous
+ *   handle; survives content edits),
+ * - [testTag] — a `Modifier.testTag(...)` value,
+ * - [role] and/or [text] — match by accessibility role and/or visible text/label.
+ *
+ * Resolution returns the matched node's centre in image-natural pixel space. Zero matches or more
+ * than one (for testTag / role+text) is an unresolved target; refs are unique by construction.
+ */
+@Serializable
+data class SemanticsInputTarget(
+  val ref: String? = null,
+  val testTag: String? = null,
+  val role: String? = null,
+  val text: String? = null,
 )
 
 @Serializable

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopInteractiveSession.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopInteractiveSession.kt
@@ -16,6 +16,10 @@ import androidx.compose.ui.input.pointer.PointerType
 import androidx.compose.ui.scene.ComposeScenePointer
 import ee.schimke.composeai.daemon.protocol.InteractiveInputKind
 import ee.schimke.composeai.daemon.protocol.InteractiveInputParams
+import ee.schimke.composeai.daemon.protocol.SemanticsInputTarget
+import ee.schimke.composeai.data.layoutinspector.SemanticsTarget
+import ee.schimke.composeai.data.layoutinspector.SemanticsTargets
+import ee.schimke.composeai.data.layoutinspector.TargetResolution
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.RejectedExecutionException
@@ -113,8 +117,9 @@ class DesktopInteractiveSession(
   }
 
   private fun dispatchOnSceneThread(input: InteractiveInputParams) {
-    val px = input.pixelX
-    val py = input.pixelY
+    val resolved = resolvePointerPixels(input)
+    val px = resolved?.first
+    val py = resolved?.second
     when (input.kind) {
       InteractiveInputKind.CLICK -> {
         if (px == null || py == null) return
@@ -286,6 +291,61 @@ class DesktopInteractiveSession(
       Thread.currentThread().interrupt()
       throw e
     }
+  }
+
+  /**
+   * Resolve the image-natural pixel coordinates for [input]. Explicit
+   * [InteractiveInputParams.pixelX]/`pixelY` win; otherwise the [InteractiveInputParams.target]
+   * semantic handle is resolved against the held scene's live semantics tree (issue #1784) and the
+   * matched node's centre is used. Returns `null` — and the dispatch no-ops — when neither is
+   * available or the target doesn't resolve to exactly one node (interactive/input is
+   * fire-and-forget, so a miss is logged rather than reported on the wire).
+   *
+   * Runs on [sceneExecutor]'s thread (its only caller is [dispatchOnSceneThread]), so reaching into
+   * `state.scene` for the semantics root is safe.
+   */
+  private fun resolvePointerPixels(input: InteractiveInputParams): Pair<Int, Int>? {
+    val explicitX = input.pixelX
+    val explicitY = input.pixelY
+    if (explicitX != null && explicitY != null) return explicitX to explicitY
+    val target = input.target?.toCoreTarget() ?: return null
+    val root = currentSemanticsRoot() ?: return logUnresolved(target, "no semantics root available")
+    return when (val res = SemanticsTargets.resolve(root, target)) {
+      is TargetResolution.Resolved -> res.point.x to res.point.y
+      TargetResolution.NotFound -> logUnresolved(target, "no node matched")
+      is TargetResolution.Ambiguous ->
+        logUnresolved(target, "${res.candidates.size} nodes matched; use a ref to disambiguate")
+    }
+  }
+
+  /**
+   * Project the held scene's unmerged semantics tree into the ref-bearing wire model — the same
+   * projection the `compose/semantics` data product uses ([ComposeSemanticsDataProducer]) — so
+   * target resolution sees identical refs / testTags / roles / bounds to what an agent fetched.
+   */
+  private fun currentSemanticsRoot(): ComposeSemanticsNode? {
+    val node = state.scene.semanticsOwners.firstOrNull()?.unmergedRootSemanticsNode ?: return null
+    return ComposeSemanticsDataProducer.buildPayload(node).root
+  }
+
+  /** Map the wire target onto the core resolver's [SemanticsTarget]; null when no field is set. */
+  private fun SemanticsInputTarget.toCoreTarget(): SemanticsTarget? {
+    val r = ref
+    val tag = testTag
+    return when {
+      !r.isNullOrBlank() -> SemanticsTarget.Ref(r)
+      !tag.isNullOrBlank() -> SemanticsTarget.Tag(tag)
+      role != null || text != null -> SemanticsTarget.RoleText(role, text)
+      else -> null
+    }
+  }
+
+  private fun logUnresolved(target: SemanticsTarget, reason: String): Pair<Int, Int>? {
+    System.err.println(
+      "compose-ai-daemon: DesktopInteractiveSession($previewId): target $target unresolved " +
+        "($reason); dropping input"
+    )
+    return null
   }
 
   /**

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopInteractiveSessionTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopInteractiveSessionTest.kt
@@ -2,6 +2,7 @@ package ee.schimke.composeai.daemon
 
 import ee.schimke.composeai.daemon.protocol.InteractiveInputKind
 import ee.schimke.composeai.daemon.protocol.InteractiveInputParams
+import ee.schimke.composeai.daemon.protocol.SemanticsInputTarget
 import java.io.ByteArrayInputStream
 import java.io.File
 import javax.imageio.ImageIO
@@ -226,6 +227,92 @@ class DesktopInteractiveSessionTest {
     }
   }
 
+  /**
+   * Issue #1784 — a click that carries only a semantic `target` (testTag, no pixel coordinates) is
+   * resolved server-side to the target node's centre and dispatched there, flipping the fixture
+   * green. The negative control proves the resolution is real: the `target-box` node sits in the
+   * top-left corner, so a plain centre click (32,32) misses it and the card stays red — only the
+   * resolved centroid (~10,10) hits.
+   */
+  @Test
+  fun target_testTag_click_resolves_to_node_centre_and_flips_state() {
+    val outputDir = tempFolder.newFolder("interactive-target-renders")
+    val host = taggedTargetHost(RenderEngine(outputDir = outputDir))
+    host.start()
+    try {
+      val session =
+        host.acquireInteractiveSession(
+          previewId = TAGGED_TARGET_PREVIEW_ID,
+          classLoader =
+            DesktopInteractiveSessionTest::class.java.classLoader
+              ?: ClassLoader.getSystemClassLoader(),
+        )
+      try {
+        // Bootstrap render — red.
+        val first = session.render(requestId = RenderHost.nextRequestId())
+        assertTrue(
+          "fixture must start red",
+          pixelMatchPct(readPng(File(first.pngPath!!)), 0xEF5350, 8) >= 0.95,
+        )
+
+        // Negative control: a bottom-right corner pixel click misses the top-left target → still
+        // red. (Coords stay clear of the target at any render density — the scene renders at ~2×,
+        // so the 20dp target spans roughly the top-left 40px; 62,62 is well outside it.)
+        session.dispatch(
+          InteractiveInputParams(
+            frameStreamId = "test-target-corner-miss",
+            kind = InteractiveInputKind.CLICK,
+            pixelX = 62,
+            pixelY = 62,
+          )
+        )
+        val afterMiss = session.render(requestId = RenderHost.nextRequestId())
+        assertTrue(
+          "opposite-corner click must miss the top-left target-box; card should still be red",
+          pixelMatchPct(readPng(File(afterMiss.pngPath!!)), 0xEF5350, 8) >= 0.95,
+        )
+
+        // The payload: a CLICK with NO pixel coords, only a testTag target.
+        session.dispatch(
+          InteractiveInputParams(
+            frameStreamId = "test-target-tag-hit",
+            kind = InteractiveInputKind.CLICK,
+            target = SemanticsInputTarget(testTag = "target-box"),
+          )
+        )
+        val afterHit = session.render(requestId = RenderHost.nextRequestId())
+        val greenMatch = pixelMatchPct(readPng(File(afterHit.pngPath!!)), 0x66BB6A, 8)
+        assertTrue(
+          "testTag target must resolve to the corner node's centre and flip green; got " +
+            "${"%.2f".format(greenMatch * 100)}% — load-bearing #1784 assertion (resolution ran, " +
+            "not a whole-card click).",
+          greenMatch >= 0.95,
+        )
+      } finally {
+        session.close()
+      }
+    } finally {
+      host.shutdown()
+    }
+  }
+
+  private fun taggedTargetHost(engine: RenderEngine): DesktopHost =
+    DesktopHost(
+      engine = engine,
+      previewSpecResolver = { previewId ->
+        if (previewId == TAGGED_TARGET_PREVIEW_ID) {
+          RenderSpec(
+            className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+            functionName = "TaggedClickTargetSquare",
+            widthPx = 64,
+            heightPx = 64,
+            density = 1.0f,
+            outputBaseName = "tagged-click-target-square",
+          )
+        } else null
+      },
+    )
+
   private fun readPng(file: File): java.awt.image.BufferedImage {
     assertTrue("rendered PNG must exist on disk: ${file.absolutePath}", file.exists())
     assertTrue("rendered PNG must be non-empty", file.length() > 0)
@@ -427,5 +514,6 @@ class DesktopInteractiveSessionTest {
     private const val FIXTURE_PREVIEW_ID = "click-toggle-square"
     private const val FRAME_CLOCK_PREVIEW_ID = "frame-clock-square"
     private const val KEY_PRESS_PREVIEW_ID = "key-press-color-square"
+    private const val TAGGED_TARGET_PREVIEW_ID = "tagged-click-target-square"
   }
 }

--- a/daemon/desktop/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
+++ b/daemon/desktop/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.focusable
 import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
@@ -24,6 +25,8 @@ import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
 
 /**
  * Test fixtures for [RenderEngineTest] / [JsonRpcDesktopIntegrationTest]. Lives in the test source
@@ -136,6 +139,34 @@ fun ClickToggleSquare() {
         }
       }
   )
+}
+
+/**
+ * Issue #1784 fixture — proves an interaction can target a node by `testTag` (resolved to its
+ * centre point server-side) instead of pixel coordinates. The whole 64×64 card starts red; only a
+ * click inside the small 20×20 `testTag("target-box")` node pinned to the **top-left corner** flips
+ * it green.
+ *
+ * The target node is deliberately off-centre: a naive centre click (`32,32`) misses it, so a green
+ * result is only reachable by resolving the testTag to its real centroid (~`10,10`). That makes the
+ * green assertion load-bearing for `DesktopInteractiveSession`'s `target` → centroid resolution
+ * rather than something a whole-card click would also satisfy.
+ */
+@Composable
+fun TaggedClickTargetSquare() {
+  var clicked by remember { mutableStateOf(false) }
+  val color = if (clicked) Color(0xFF66BB6A) else Color(0xFFEF5350)
+  Box(modifier = Modifier.fillMaxSize().background(color)) {
+    Box(
+      modifier =
+        Modifier.size(20.dp).testTag("target-box").pointerInput(Unit) {
+          awaitPointerEventScope {
+            awaitFirstDown()
+            clicked = true
+          }
+        }
+    )
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

Builds on the merged semantics foundation (#1790) to deliver the first slice of **#1784** — drive a held preview by **semantic ref / testTag / role+text instead of pixel coordinates**, the Playwright "act by a stable ref, not pixels" loop.

- **Protocol** (`Messages.kt`): `InteractiveInputParams` gains an optional `target: SemanticsInputTarget` (`ref | testTag | role+text`). Additive — explicit `pixelX`/`pixelY` still win when both are present, so existing clients are unaffected.
- **Desktop** (`DesktopInteractiveSession`): when a `target` is set and no pixels are given, it projects the held scene's live unmerged semantics tree through the **same `ComposeSemanticsDataProducer`** the `compose/semantics` data product uses (so refs/testTags/roles/bounds match exactly what an agent fetched), resolves the target to the node's centre with `SemanticsTargets`, and dispatches through the existing pointer path. Unresolved / ambiguous targets are logged and the input dropped (interactive input is fire-and-forget).
- **Fixture + test**: an off-centre `testTag("target-box")` node proves a `CLICK` carrying **only a testTag** (no coordinates) resolves to the node centroid and flips state green; an opposite-corner pixel click is the density-robust negative control.

### Scope / follow-ups (same issue)

- **Android**: resolves sandbox-side (its semantics root lives in the Robolectric classloader, unreachable from the host session — it already resolves uiautomator/a11y selectors there), so it rides a follow-up over the existing `InteractiveCommand` bridge.
- **`record_preview`** event targeting (`RecordingScriptEvent`) and reporting **ambiguity/NotFound on the wire** (interactive input is fire-and-forget today) also follow.

## Test plan

- [x] `./gradlew :daemon:desktop:test --tests "*DesktopInteractiveSessionTest"` — new `target_testTag_click_resolves_to_node_centre_and_flips_state` plus the existing click/key/frame-clock cases (7 total) pass.
- [x] `:daemon:core` / `:daemon:desktop` `ktfmtCheck` clean.
- [x] `:daemon:core` compiles with the new wire field (additive; `encodeDefaults=false` keeps it off the wire when unset).

> Note: `InteractiveCoalescingTest` (a pre-existing thread/latch timing test) fails in my local sandbox on **clean `origin/main`** too — an environment timing flake unrelated to this change; CI runs it in a normal environment.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mdfg35bMd7txPNNZHkToww)_