### PR TITLE
fix(xr): add renderer-xr-client to the bundle-render e2e publish set

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -124,6 +124,7 @@ tasks.register("functionalTestWithAndroid") {
 //     implementation :data-displayfilter-connector
 //       api :data-displayfilter-core
 //       api :daemon:core
+//         api :renderer-xr-client (daemon-core fronts the native XR render server — RENDERER_SERVICE)
 //     implementation :lottie-preview-runtime (Compottie-backed kind=LOTTIE render path)
 //   plus :common-io (the Okio file-IO foundation those modules read/write through).
 val bundleRenderFunctionalTestPublishTargets =
@@ -136,6 +137,7 @@ val bundleRenderFunctionalTestPublishTargets =
     ":data-displayfilter-connector",
     ":data-displayfilter-core",
     ":daemon:core",
+    ":renderer-xr-client",
     ":lottie-preview-runtime",
     ":common-io",
   )


### PR DESCRIPTION
## Summary

Follow-up to #1792 (merged). That PR made `:daemon:core` `api`-depend on the newly-published `:renderer-xr-client`, which broke the **Bundle Render E2E** job: its functional-test fixture publishes a *curated* set of modules to `mavenLocal` (the closure of `:renderer-desktop`'s publishable transitive project deps), and `:renderer-xr-client` wasn't in it — so the synthetic Compose Desktop project failed to resolve `ee.schimke.composeai:renderer-xr-client:<ver>`:

```
Could not find ee.schimke.composeai:renderer-xr-client:0.13.5-SNAPSHOT
  Required by: …renderer-desktop → data-displayfilter-connector → daemon-core
```

This adds `:renderer-xr-client` to `bundleRenderFunctionalTestPublishTargets` (used by both `functionalTestWithBundleRender` and `functionalTestWithAndroidBundleDaemon`). The external-sample integration jobs (wear/adaptive/agp8) already publish via the root `publishToMavenLocal` (all publications), so they were fixed by #1792's publishing change itself — only this curated list needed the entry.

## Test plan

- [x] `./gradlew functionalTestWithBundleRender --dry-run` now schedules `:renderer-xr-client:publishToMavenLocal` in the task graph.

Two-line fixture fix; no production-code change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01X8ZwHy8Sgg5eVJzNqr1LMb)_