### PR TITLE
feat(mcp): diff_semantics tool — pixel-free semantics regression signal

### DIFF
--- a/docs/daemon/MCP.md
+++ b/docs/daemon/MCP.md
@@ -116,6 +116,7 @@ supervisor stops respawning.
 | `history_diff(workspaceId, module, from, to)` | Diff two history entries in metadata mode. |
 | `list_data_products(workspaceId?, module?)` | List advertised data-product kinds per daemon. |
 | `get_preview_data(uri, kind, params?, inline?)` | Fetch one structured data product for a preview, auto-rendering when needed. |
+| `diff_semantics(baseUri, headUri)` | Diff the `compose/semantics` trees of two previews (matched by stable `ref`) and return added/removed/changed-field deltas + a one-line summary — a cheap, deterministic, pixel-free regression signal (aria-snapshot analogue). |
 | `subscribe_preview_data(uri, kind)` | Prime a data product on every render for one preview. |
 | `unsubscribe_preview_data(uri, kind)` | Drop a preview data-product subscription. |
 | `render_preview_overlay(uri, kind?, inline?, overrides?)` | Render a preview and return an annotated overlay image. |

--- a/mcp/build.gradle.kts
+++ b/mcp/build.gradle.kts
@@ -57,6 +57,8 @@ dependencies {
   // only and consumers resolving from POM metadata fail to compile against the MCP APIs.
   api(project(":daemon:core"))
   api(project(":render-session-api"))
+  // Semantics diff engine + payload model for the `diff_semantics` tool (issue #1785).
+  implementation(project(":data-layoutinspector-core"))
 
   testImplementation(libs.junit)
   testImplementation(libs.truth)

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
@@ -1491,15 +1491,15 @@ class DaemonMcpServer(
       ToolDef(
         name = "diff_semantics",
         description =
-          "Diff the Compose semantics trees of two previews and report what changed semantically — the cheap, deterministic, pixel-free regression signal (the analogue of Playwright's aria-snapshot diff). Fetches compose/semantics for `baseUri` and `headUri` (auto-rendering each if needed), matches nodes by their stable `ref`, and returns added / removed / changed-field deltas as JSON plus a one-line summary. Use it to answer 'what changed?' between a baseline and a candidate without reading two PNGs: pass a compose-preview-history:// URI as base and a live compose-preview:// URI as head, or any two preview URIs. Text/label changes show up as field changes on the same ref (not remove+add); positional bounds churn is ignored (that's the pixel diff's job). Cheaper than reading screenshots — prefer it for copy/label/role/overflow regressions.",
+          "Diff the Compose semantics trees of two live previews and report what changed semantically — the cheap, deterministic, pixel-free regression signal (the analogue of Playwright's aria-snapshot diff). Fetches compose/semantics for `baseUri` and `headUri` (two compose-preview:// URIs, auto-rendering each if needed), matches nodes by their stable `ref`, and returns added / removed / changed-field deltas as JSON plus a one-line summary. Use it to answer 'what changed?' between two rendered previews without reading two PNGs — e.g. the same preview before and after an edit, or two related previews. Text/label changes show up as field changes on the same ref (not remove+add); positional bounds churn is ignored (that's the pixel diff's job). Cheaper than reading screenshots — prefer it for copy/label/role/overflow regressions. (Diffing against a compose-preview-history:// baseline needs the semantics payload persisted per history entry — tracked as a follow-up.)",
         inputSchema =
           parseSchema(
             """
             {
               "type":"object",
               "properties":{
-                "baseUri":{"type":"string","description":"Baseline preview URI (compose-preview:// or compose-preview-history://)."},
-                "headUri":{"type":"string","description":"Candidate preview URI to compare against the baseline."}
+                "baseUri":{"type":"string","description":"Baseline live preview URI (compose-preview://<workspace>/<module>/<fqn>)."},
+                "headUri":{"type":"string","description":"Candidate live preview URI (compose-preview://...) to compare against the baseline."}
               },
               "required":["baseUri","headUri"]
             }
@@ -3025,7 +3025,15 @@ class DaemonMcpServer(
     uriStr: String,
     side: String,
   ): Pair<ComposeSemanticsPayload?, String?> {
-    val uri = PreviewUri.parseOrNull(uriStr) ?: return null to "invalid $side uri: $uriStr"
+    val uri =
+      PreviewUri.parseOrNull(uriStr)
+        ?: return null to
+          if (uriStr.startsWith("${HistoryUri.SCHEME}://")) {
+            "$side: history URIs aren't supported yet (compose/semantics isn't persisted per " +
+              "history entry); pass a live compose-preview:// URI"
+          } else {
+            "invalid $side uri: $uriStr"
+          }
     if (supervisor.project(uri.workspaceId) == null) {
       return null to "$side workspace '${uri.workspaceId.value}' not registered"
     }

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
@@ -17,6 +17,10 @@ import ee.schimke.composeai.daemon.protocol.RemoteComposeOverride
 import ee.schimke.composeai.daemon.protocol.RenderTier
 import ee.schimke.composeai.daemon.protocol.UiMode
 import ee.schimke.composeai.daemon.protocol.WallpaperOverride
+import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsPayload
+import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsProduct
+import ee.schimke.composeai.data.layoutinspector.SemanticsDelta
+import ee.schimke.composeai.data.layoutinspector.SemanticsDiff
 import ee.schimke.composeai.data.render.pipeline.PreviewExtensionCommandCatalog
 import ee.schimke.composeai.data.render.pipeline.PreviewExtensionDescriptor
 import ee.schimke.composeai.io.SystemFileSystem
@@ -1485,6 +1489,25 @@ class DaemonMcpServer(
           ),
       ),
       ToolDef(
+        name = "diff_semantics",
+        description =
+          "Diff the Compose semantics trees of two previews and report what changed semantically — the cheap, deterministic, pixel-free regression signal (the analogue of Playwright's aria-snapshot diff). Fetches compose/semantics for `baseUri` and `headUri` (auto-rendering each if needed), matches nodes by their stable `ref`, and returns added / removed / changed-field deltas as JSON plus a one-line summary. Use it to answer 'what changed?' between a baseline and a candidate without reading two PNGs: pass a compose-preview-history:// URI as base and a live compose-preview:// URI as head, or any two preview URIs. Text/label changes show up as field changes on the same ref (not remove+add); positional bounds churn is ignored (that's the pixel diff's job). Cheaper than reading screenshots — prefer it for copy/label/role/overflow regressions.",
+        inputSchema =
+          parseSchema(
+            """
+            {
+              "type":"object",
+              "properties":{
+                "baseUri":{"type":"string","description":"Baseline preview URI (compose-preview:// or compose-preview-history://)."},
+                "headUri":{"type":"string","description":"Candidate preview URI to compare against the baseline."}
+              },
+              "required":["baseUri","headUri"]
+            }
+            """
+              .trimIndent()
+          ),
+      ),
+      ToolDef(
         name = "subscribe_preview_data",
         description =
           "Subscribe to a data-product kind for one preview. While subscribed, every renderFinished for the preview produces the kind alongside the PNG (subject to the daemon's producer wiring). Useful when the agent expects to ask repeatedly about the same preview — pre-computing on render avoids the get_preview_data re-render cost. Subscriptions are sticky-while-visible: the daemon drops them automatically when the preview leaves the most recent set_visible set, so re-subscribe when the preview returns to view. Idempotent. Errors: DataProductUnknown if the kind isn't advertised or isn't attachable. NOTE: today, MCP doesn't push the attached payload to clients automatically — agents still call get_preview_data to read it; the subscribe just primes the daemon-side cache.",
@@ -1703,6 +1726,7 @@ class DaemonMcpServer(
       "list_extension_commands" -> toolListExtensionCommands(args)
       "run_extension_command" -> toolRunExtensionCommand(args)
       "get_preview_data" -> toolGetPreviewData(args)
+      "diff_semantics" -> toolDiffSemantics(args)
       "render_preview_overlay" -> toolRenderPreviewOverlay(args)
       "get_preview_extras" -> toolGetPreviewExtras(args)
       "subscribe_preview_data" -> toolDataSubOrUnsub(session, args, subscribe = true)
@@ -2963,6 +2987,116 @@ class DaemonMcpServer(
       }
     }
     return CallToolResult(content = listOf(ContentBlock.Text(payload.toString())))
+  }
+
+  /**
+   * `diff_semantics` — fetch `compose/semantics` for two preview URIs and report the structural
+   * delta between their trees (issue #1785). The cheap, deterministic, pixel-free regression
+   * signal: nodes are matched by their stable `ref`, so a copy edit is a field change on the same
+   * ref rather than a remove + add. Returns `{ schema, summary, delta }` as a single text block.
+   */
+  private fun toolDiffSemantics(args: JsonObject): CallToolResult {
+    val baseUriStr =
+      args["baseUri"]?.jsonPrimitive?.contentOrNull
+        ?: return errorCallToolResult("diff_semantics: missing 'baseUri'")
+    val headUriStr =
+      args["headUri"]?.jsonPrimitive?.contentOrNull
+        ?: return errorCallToolResult("diff_semantics: missing 'headUri'")
+    val (base, baseErr) = fetchSemanticsPayload(baseUriStr, "base")
+    if (base == null) return errorCallToolResult("diff_semantics: $baseErr")
+    val (head, headErr) = fetchSemanticsPayload(headUriStr, "head")
+    if (head == null) return errorCallToolResult("diff_semantics: $headErr")
+    val delta = SemanticsDiff.diff(base, head)
+    val out = buildJsonObject {
+      put("schema", delta.schema)
+      put("summary", summarizeSemanticsDelta(delta))
+      put("delta", json.encodeToJsonElement(SemanticsDelta.serializer(), delta))
+    }
+    return CallToolResult(content = listOf(ContentBlock.Text(out.toString())))
+  }
+
+  /**
+   * Fetch and decode `compose/semantics` for one URI, auto-rendering once on the
+   * `DataProductNotAvailable` path (same fold as [toolGetPreviewData]). Returns `(payload, null)`
+   * on success or `(null, message)` with a [side]-prefixed diagnostic the caller wraps into a tool
+   * error.
+   */
+  private fun fetchSemanticsPayload(
+    uriStr: String,
+    side: String,
+  ): Pair<ComposeSemanticsPayload?, String?> {
+    val uri = PreviewUri.parseOrNull(uriStr) ?: return null to "invalid $side uri: $uriStr"
+    if (supervisor.project(uri.workspaceId) == null) {
+      return null to "$side workspace '${uri.workspaceId.value}' not registered"
+    }
+    val daemon =
+      runCatching { supervisor.daemonFor(uri.workspaceId, uri.modulePath) }
+        .getOrElse {
+          return null to "$side daemon spawn failed: ${it.message}"
+        }
+    val result =
+      runCatching {
+          try {
+            daemon.client.dataFetch(
+              uri.previewFqn,
+              ComposeSemanticsProduct.KIND,
+              null,
+              inline = true,
+            )
+          } catch (e: DataProductWireException) {
+            if (e.code != DataProductWireException.NOT_AVAILABLE) throw e
+            awaitNextRender(uri)
+            daemon.client.dataFetch(
+              uri.previewFqn,
+              ComposeSemanticsProduct.KIND,
+              null,
+              inline = true,
+            )
+          }
+        }
+        .getOrElse { e ->
+          return null to
+            when (e) {
+              is DataProductWireException -> "$side ${nameOf(e.code)}: ${e.wireMessage}"
+              else -> "$side fetch failed: ${e.message}"
+            }
+        }
+    return runCatching { decodeSemanticsPayload(result) }
+      .map { it to null }
+      .getOrElse { null to "$side: could not read compose/semantics (${it.message})" }
+  }
+
+  /**
+   * Decode a [DataFetchResult] into a [ComposeSemanticsPayload] from whichever transport it used.
+   */
+  private fun decodeSemanticsPayload(
+    result: ee.schimke.composeai.daemon.protocol.DataFetchResult
+  ): ComposeSemanticsPayload {
+    result.payload?.let {
+      return json.decodeFromJsonElement(ComposeSemanticsPayload.serializer(), it)
+    }
+    result.bytes?.let {
+      val text = String(Base64.getDecoder().decode(it), Charsets.UTF_8)
+      return json.decodeFromString(ComposeSemanticsPayload.serializer(), text)
+    }
+    result.path?.let { path ->
+      val text = SystemFileSystem.read(path.toPath()) { readUtf8() }
+      return json.decodeFromString(ComposeSemanticsPayload.serializer(), text)
+    }
+    error("empty data/fetch result (no payload, bytes, or path)")
+  }
+
+  /** One-line human summary of a [SemanticsDelta] for the tool response. */
+  private fun summarizeSemanticsDelta(delta: SemanticsDelta): String {
+    if (delta.isEmpty) return "no semantic changes"
+    return buildString {
+      append("${delta.added.size} added, ${delta.removed.size} removed, ")
+      append("${delta.changed.size} changed")
+      delta.changed.take(3).forEach { change ->
+        val fields = change.changes.joinToString(", ") { it.field }
+        append("; ${change.anchor ?: change.ref}: $fields")
+      }
+    }
   }
 
   /**

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
@@ -110,6 +110,7 @@ class DaemonMcpServerTest {
         "enable_extensions",
         "run_extension_command",
         "get_preview_data",
+        "diff_semantics",
         "subscribe_preview_data",
         "unsubscribe_preview_data",
         "render_preview_overlay",
@@ -2602,6 +2603,76 @@ class DaemonMcpServerTest {
     val nodes = payload["payload"]!!.jsonObject["nodes"]!!.jsonArray
     assertThat(nodes.single().jsonObject["label"]!!.jsonPrimitive.content)
       .isEqualTo("Hello $previewId")
+  }
+
+  @Test
+  fun `diff_semantics reports a text change on the same ref between two previews`() {
+    client.initialize()
+    val projectDir = tmp.newFolder("workspace")
+    tmp.newFolder("workspace", "module")
+    val workspaceId = registerWorkspace(projectDir, "demo")
+
+    // A two-node tree: root + a testTag'd child whose text differs between the base and head
+    // previews. The differ should match by the stable ref and report a single `text` field change.
+    fun semanticsPayload(childText: String) = buildJsonObject {
+      putJsonObject("root") {
+        put("nodeId", "1")
+        put("boundsInRoot", "0,0,64,64")
+        putJsonArray("children") {
+          add(
+            buildJsonObject {
+              put("nodeId", "2")
+              put("boundsInRoot", "0,0,20,20")
+              put("testTag", "label")
+              put("text", childText)
+            }
+          )
+        }
+      }
+    }
+    factory.daemonConfigurer = { daemon ->
+      daemon.advertisedDataProducts =
+        listOf(
+          ee.schimke.composeai.daemon.protocol.DataProductCapability(
+            kind = "compose/semantics",
+            schemaVersion = 2,
+            transport = ee.schimke.composeai.daemon.protocol.DataProductTransport.INLINE,
+            attachable = true,
+            fetchable = true,
+            requiresRerender = false,
+          )
+        )
+      daemon.dataFetchHandler = { previewId, kind, _, _ ->
+        FakeDaemon.DataFetchOutcome.Ok(
+          kind = kind,
+          schemaVersion = 2,
+          payload = semanticsPayload(if (previewId.endsWith("Head")) "Goodbye" else "Hello"),
+        )
+      }
+    }
+    warmDaemonFor(workspaceId, ":module")
+
+    val baseUri = PreviewUri(workspaceId, ":module", "com.example.Base").toUri()
+    val headUri = PreviewUri(workspaceId, ":module", "com.example.Head").toUri()
+    val resp =
+      client.callTool(
+        "diff_semantics",
+        buildJsonObject {
+          put("baseUri", baseUri)
+          put("headUri", headUri)
+        },
+      )
+    val parsed = json.parseToJsonElement(resp.firstTextContent()).jsonObject
+    assertThat(parsed["schema"]?.jsonPrimitive?.contentOrNull)
+      .isEqualTo("compose-semantics-diff/v1")
+    assertThat(parsed["summary"]?.jsonPrimitive?.contentOrNull).contains("changed")
+    val changed = parsed["delta"]!!.jsonObject["changed"]!!.jsonArray
+    val change = changed.single().jsonObject
+    assertThat(change["ref"]?.jsonPrimitive?.contentOrNull).isEqualTo("r/tag:label")
+    val fieldChange = change["changes"]!!.jsonArray.single().jsonObject
+    assertThat(fieldChange["field"]?.jsonPrimitive?.contentOrNull).isEqualTo("text")
+    assertThat(fieldChange["from"]?.jsonPrimitive?.contentOrNull).isEqualTo("Hello")
+    assertThat(fieldChange["to"]?.jsonPrimitive?.contentOrNull).isEqualTo("Goodbye")
   }
 
   @Test


### PR DESCRIPTION
## Summary

First surface for **#1785** (semantics text diff), reusing the `SemanticsDiff` engine already on `main`. Gives agents a cheap, deterministic **"what changed?"** between two previews without reading two PNGs — the Compose analogue of Playwright's `toMatchAriaSnapshot` text diff.

- **New MCP tool `diff_semantics(baseUri, headUri)`**: fetches `compose/semantics` for both **live** preview URIs (`compose-preview://`) via the daemon's existing `data/fetch` (auto-rendering on the `NotAvailable` path, the same fold as `get_preview_data`), matches nodes by their stable `ref`, and returns `{ schema, summary, delta }` where `delta` is added / removed / changed-field. Compare the same preview before/after an edit, or two related previews.
- Text/label edits report as a **field change on the same ref** (not remove+add); positional bounds churn is ignored (that's the pixel diff's job).
- `:mcp` gains a dependency on `:data-layoutinspector-core` for the engine + payload model.

## Test plan

- [x] `./gradlew :mcp:test --tests "*DaemonMcpServerTest"` — new `diff_semantics reports a text change on the same ref between two previews` (two previews differing only in a child's text → one `changed` entry on `r/tag:label`, `text` Hello→Goodbye), plus the updated tools-list expectation; green.
- [x] `:mcp` `ktfmtFormat` applied.
- [x] `docs/daemon/MCP.md` tool table updated.

## Scope / follow-ups (same issue)

- **`compose-preview-history://` baselines** are out of scope here: history doesn't persist the `compose/semantics` payload per entry, so the tool takes two live preview URIs and a history URI returns an explanatory error. Persisting semantics in history (which also unlocks `history/diff mode=SEMANTICS`) is the follow-up.
- A `compose-preview diff --semantics` CLI surface for the review skill also remains a follow-up.