### PR TITLE
fix(gradle-plugin): make desktop classpath guard config-cache serializable

### DIFF
--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DesktopClasspathGuardFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DesktopClasspathGuardFunctionalTest.kt
@@ -1,0 +1,134 @@
+package ee.schimke.composeai.plugin
+
+import com.google.common.truth.Truth.assertThat
+import java.io.File
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * Configuration-cache coverage for the desktop classpath guard
+ * ([ValidateComposePreviewClasspathTask], wired by
+ * `ComposePreviewTasks.registerDesktopClasspathGuard`).
+ *
+ * Issue #1796: the guard fed its `@Classpath` collection with `classpath.from(toolClasspath)`,
+ * pinning the live `Configuration` into the task's `__classpath__` backing field. When that
+ * configuration resolves the published `renderer-desktop` graph, the configuration cache can't
+ * serialize the reference — the nested TestKit bundle E2E builds (config cache on) failed the store
+ * step with "field `__classpath__` … error writing value" and the bundle task exited 1, breaking
+ * `BundleRenderEndToEndFunctionalTest` / `BundleDaemonEndToEndFunctionalTest`. Those checks are
+ * non-gating, so it had been merging red. The fix feeds a lazily-resolved `incoming.artifactView {
+ * }.files` view instead, dropping the unserializable `Configuration` reference (mirrors how the
+ * sibling `composePreviewDiscover` task already resolves its classpath).
+ *
+ * The full failure needs the published multi-module renderer graph the bundle E2E sets up, which a
+ * synthetic temp project can't resolve. This gating test instead locks in that the desktop validate
+ * path round-trips the configuration cache (store + reuse) for the common single-module case, so a
+ * regression that breaks serialization outright fails a required check rather than only the
+ * advisory bundle E2E. Both desktop guard tasks share the one helper, so the render variant covers
+ * both.
+ *
+ * `composePreviewRenderer` is pre-seeded with a resolvable Compose artifact —
+ * `ensureRendererDesktopConfig` skips its Maven add when the config already has dependencies — so
+ * the guard resolves a real classpath without reaching for the unpublished
+ * `ee.schimke.composeai:renderer-desktop` coordinate.
+ */
+class DesktopClasspathGuardFunctionalTest {
+
+  @get:Rule val tempDir = TemporaryFolder()
+
+  private fun createTestProject(): File {
+    val projectDir = tempDir.root
+
+    File(projectDir, "settings.gradle.kts")
+      .writeText(
+        """
+        pluginManagement {
+            repositories {
+                gradlePluginPortal()
+                google()
+                mavenCentral()
+            }
+        }
+        dependencyResolutionManagement {
+            repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+            repositories {
+                google()
+                mavenCentral()
+            }
+        }
+        rootProject.name = "test-desktop-guard"
+        """
+          .trimIndent()
+      )
+
+    File(projectDir, "build.gradle.kts")
+      .writeText(
+        """
+        @file:Suppress("DEPRECATION")
+        plugins {
+            kotlin("jvm") version "2.2.21"
+            kotlin("plugin.compose") version "2.2.21"
+            id("org.jetbrains.compose") version "1.10.3"
+            id("ee.schimke.composeai.preview")
+        }
+        dependencies {
+            implementation(compose.desktop.currentOs)
+            implementation(compose.material3)
+            implementation(compose.uiTooling)
+            implementation(compose.components.uiToolingPreview)
+        }
+        // Pre-seed the renderer tool classpath with a resolvable artifact so
+        // `ensureRendererDesktopConfig` skips its Maven add for the unpublished
+        // `ee.schimke.composeai:renderer-desktop` coordinate (which a synthetic temp project can't
+        // see). The guard then resolves a real classpath and exercises the configuration-cache store.
+        configurations.maybeCreate("composePreviewRenderer")
+        dependencies {
+            "composePreviewRenderer"(compose.material3)
+        }
+        java {
+            toolchain { languageVersion.set(JavaLanguageVersion.of(17)) }
+        }
+        """
+          .trimIndent()
+      )
+
+    // Configuration cache on — mirrors the repo + the nested bundle E2E builds. A non-serializable
+    // `__classpath__` field aborts the store outright (a store failure is a hard error regardless
+    // of
+    // the `problems` mode), so a wiring that pins an unserializable reference fails `.build()`
+    // here.
+    File(projectDir, "gradle.properties").writeText("org.gradle.configuration-cache=true\n")
+
+    return projectDir
+  }
+
+  @Test
+  fun `desktop render classpath guard serializes cleanly under the configuration cache`() {
+    val projectDir = createTestProject()
+
+    // First invocation stores the cache.
+    val store =
+      GradleRunner.create()
+        .withProjectDir(projectDir)
+        .withArguments("validateComposePreviewDesktopRenderClasspath", "--stacktrace")
+        .withPluginClasspath()
+        .build()
+
+    assertThat(store.output).contains("Configuration cache entry stored")
+    assertThat(store.output).doesNotContain("__classpath__")
+    assertThat(store.output).doesNotContain("Configuration cache problems found")
+
+    // Second invocation must reuse the stored entry — proves the entry round-trips, not just that
+    // the store didn't crash.
+    val reuse =
+      GradleRunner.create()
+        .withProjectDir(projectDir)
+        .withArguments("validateComposePreviewDesktopRenderClasspath", "--stacktrace")
+        .withPluginClasspath()
+        .build()
+
+    assertThat(reuse.output).contains("Configuration cache entry reused")
+  }
+}

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -654,8 +654,21 @@ internal object ComposePreviewTasks {
   ): TaskProvider<ValidateComposePreviewClasspathTask> =
     project.tasks.register(taskName, ValidateComposePreviewClasspathTask::class.java) {
       platform.set("desktop")
-      classpath.from(toolClasspath)
-      project.configurations.findByName(dependencyConfigName())?.let { classpath.from(it) }
+      // Feed the @Classpath FileCollection a lazily-resolved, content-keyed FileCollection
+      // (`incoming.artifactView { }.files`) instead of the raw `Configuration`.
+      // `classpath.from(config)`
+      // pins the live `Configuration` instance into the task's `__classpath__` backing field, and
+      // the
+      // configuration cache can't serialize it — the nested TestKit bundle builds (config cache on,
+      // `org.gradle.configuration-cache.problems=fail`) fail the store step with
+      // "field `__classpath__` … error writing value" and the bundle task exits 1 (issue #1796).
+      // The empty artifact view preserves the default resolution (same files as `from(config)`)
+      // while
+      // resolving lazily through a serializable view — mirrors `composePreviewDiscover` above.
+      classpath.from(toolClasspath.incoming.artifactView {}.files)
+      project.configurations.findByName(dependencyConfigName())?.let {
+        classpath.from(it.incoming.artifactView {}.files)
+      }
     }
 
   /**


### PR DESCRIPTION
## Summary

Fixes #1796.

`ValidateComposePreviewClasspathTask` (the desktop classpath guard) fed its `@Classpath` collection with `classpath.from(toolClasspath)`, pinning the live `Configuration` into the task's `__classpath__` backing field. When that configuration resolves the published `renderer-desktop` graph, the configuration cache can't serialize the reference, so the nested TestKit bundle E2E builds (config cache on) failed the store step with:

```
field `__classpath__` of task `:app:validateComposePreviewDesktopRenderClasspath`
of type `ValidateComposePreviewClasspathTask`: error writing value of type 'org.gradle.api.internal…'
```

and the bundle task exited 1 — breaking the desktop `BundleRenderEndToEndFunctionalTest` and `BundleDaemonEndToEndFunctionalTest`. Because that check is non-gating, it had been merging red.

### Fix

`registerDesktopClasspathGuard` now feeds the guard a lazily-resolved, content-keyed `incoming.artifactView { }.files` view instead of the raw `Configuration`, dropping the unserializable reference. This mirrors how the sibling `composePreviewDiscover` task already resolves its classpath config-cache-cleanly. Both desktop guard tasks (`validateComposePreviewDesktopRenderClasspath` and `validateComposePreviewDesktopDaemonClasspath`) share the one helper, so both are covered. Validation behaviour is unchanged — the empty artifact view yields the same default resolution, just lazily.

Added a gating functional test (`DesktopClasspathGuardFunctionalTest`) that exercises the desktop validate path under the configuration cache (store + reuse), so a serialization regression fails a required check instead of only the advisory bundle E2E.

## Test plan

- `./gradlew :cli:installDist :gradle-plugin:publishToMavenLocal` then the bundle E2E (`BundleRenderEndToEndFunctionalTest` + `BundleDaemonEndToEndFunctionalTest`) with `-Pbundle.render.e2e=true` — both now **pass** (`tests=1, skipped=0, failures=0` each); previously they failed on the config-cache store.
- New `DesktopClasspathGuardFunctionalTest` passes (store + reuse round-trip clean, no `__classpath__` error).
- `./gradlew :gradle-plugin:ktfmtFormatMain :gradle-plugin:ktfmtFormatFunctionalTest` — clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BHRQ7guM2KJphsUK78wMfn)_