### PR TITLE
feat(xr): gate XR frames through FrameStreamRegistry (visibility/fps/dedup)

### DIFF
--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/FrameStreamRegistry.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/FrameStreamRegistry.kt
@@ -126,8 +126,10 @@ internal class FrameStreamRegistry(
       if (minIntervalMs > 0 && s.lastEmittedAtMs != Long.MIN_VALUE) {
         if (now - s.lastEmittedAtMs < minIntervalMs) continue
       }
-      val isUnchanged = pngHash != null && s.lastHash == pngHash
       val keyframe = s.keyframePending
+      // A pending keyframe (fresh stream or scroll-back-into-view) overrides dedup so the client
+      // always gets a real paint anchor, even when the pixels are byte-identical.
+      val isUnchanged = !keyframe && pngHash != null && s.lastHash == pngHash
       val seq = ++s.seq
       val params: StreamFrameParams =
         if (isUnchanged) {
@@ -226,8 +228,10 @@ internal class FrameStreamRegistry(
       if (now - s.lastEmittedAtMs < minIntervalMs) return null
     }
     val hash = payloadBase64?.let(::sha256)
-    val isUnchanged = hash != null && s.lastHash == hash
     val keyframe = s.keyframePending
+    // A pending keyframe (fresh stream or scroll-back-into-view) overrides dedup so the client
+    // always gets a real paint anchor, even when the payload is byte-identical.
+    val isUnchanged = !keyframe && hash != null && s.lastHash == hash
     val seq = ++s.seq
     val params =
       if (isUnchanged || payloadBase64 == null) {

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/FrameStreamRegistry.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/FrameStreamRegistry.kt
@@ -201,6 +201,66 @@ internal class FrameStreamRegistry(
     )
   }
 
+  /**
+   * Per-stream variant of [consumeForPreview] for externally-produced frames (the XR render service
+   * — frames arrive from the native `xr-composite --serve` already base64-encoded, keyed by
+   * `frameStreamId` rather than a preview render). Applies the same gating to the one stream:
+   * 1. fps gate — returns null (drop the frame) when below the per-stream minimum interval.
+   * 2. dedup — emits an `unchanged` heartbeat (codec/payload null) when [payloadBase64] hashes to
+   *    the prior frame's content.
+   * 3. keyframe-pending — marks the first frame (or the first after a visibility flip) as a
+   *    keyframe.
+   *
+   * Returns null when the stream id is unknown or the fps gate dropped the frame.
+   */
+  fun consumeForStream(
+    frameStreamId: String,
+    payloadBase64: String?,
+    widthPx: Int,
+    heightPx: Int,
+  ): StreamFrameParams? {
+    val s = states[frameStreamId] ?: return null
+    val now = clock()
+    val minIntervalMs = effectiveMinIntervalMs(s)
+    if (minIntervalMs > 0 && s.lastEmittedAtMs != Long.MIN_VALUE) {
+      if (now - s.lastEmittedAtMs < minIntervalMs) return null
+    }
+    val hash = payloadBase64?.let(::sha256)
+    val isUnchanged = hash != null && s.lastHash == hash
+    val keyframe = s.keyframePending
+    val seq = ++s.seq
+    val params =
+      if (isUnchanged || payloadBase64 == null) {
+        StreamFrameParams(
+          frameStreamId = s.frameStreamId,
+          seq = seq,
+          ptsMillis = now,
+          widthPx = widthPx,
+          heightPx = heightPx,
+          codec = null,
+          keyframe = false,
+          final = false,
+          payloadBase64 = null,
+        )
+      } else {
+        StreamFrameParams(
+          frameStreamId = s.frameStreamId,
+          seq = seq,
+          ptsMillis = now,
+          widthPx = widthPx,
+          heightPx = heightPx,
+          codec = s.codec,
+          keyframe = keyframe,
+          final = false,
+          payloadBase64 = payloadBase64,
+        )
+      }
+    s.lastEmittedAtMs = now
+    if (hash != null) s.lastHash = hash
+    if (params.codec != null) s.keyframePending = false
+    return params
+  }
+
   private fun effectiveMinIntervalMs(s: State): Long {
     val visibilityCap = if (!s.visible) (s.visibilityFps ?: 1) else null
     val cap =
@@ -232,5 +292,12 @@ internal class FrameStreamRegistry(
 
     private fun base64(bytes: ByteArray): String =
       java.util.Base64.getEncoder().encodeToString(bytes)
+
+    /** Content hash for dedup of already-encoded (e.g. XR) frame payloads. */
+    private fun sha256(s: String): String {
+      val digest = java.security.MessageDigest.getInstance("SHA-256")
+      return java.util.Base64.getEncoder()
+        .encodeToString(digest.digest(s.toByteArray(Charsets.UTF_8)))
+    }
   }
 }

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -2258,6 +2258,15 @@ class JsonRpcServer(
         return
       }
     val streamId = streamRegistry.mintStreamId()
+    // Register with the frame-stream registry so XR frames get the same visibility / fps / dedup
+    // gating as `stream/start` (driven by `stream/visibility` + maxFps), keyed by this stream id.
+    val codec = streamRegistry.negotiateCodec(params.codec)
+    streamRegistry.register(
+      frameStreamId = streamId,
+      previewId = params.previewId,
+      codec = codec,
+      maxFps = params.maxFps,
+    )
     val frame =
       try {
         manager.open(
@@ -2269,6 +2278,7 @@ class JsonRpcServer(
           params.height,
         )
       } catch (t: Throwable) {
+        streamRegistry.unregister(streamId)
         sendErrorResponse(
           req.id,
           ERR_INTERNAL,
@@ -2277,12 +2287,16 @@ class JsonRpcServer(
         return
       }
     if (frame == null) {
+      streamRegistry.unregister(streamId)
       sendErrorResponse(req.id, ERR_INTERNAL, "xr/start: native XR server unavailable")
       return
     }
     sendResponse(
       req.id,
-      encode(XrStartResult.serializer(), XrStartResult(frameStreamId = streamId, available = true)),
+      encode(
+        XrStartResult.serializer(),
+        XrStartResult(frameStreamId = streamId, codec = codec, available = true),
+      ),
     )
     emitXrFrame(streamId, frame)
   }
@@ -2304,22 +2318,25 @@ class JsonRpcServer(
   }
 
   private fun handleXrStop(params: XrStopParams) {
+    // Emit a final marker (mirrors stream/stop) so the client releases decoder state, drop the
+    // registry state, then tear down the native session.
+    val finalFrame = streamRegistry.finalFrameOnStop(params.frameStreamId)
+    streamRegistry.unregister(params.frameStreamId)
     xrSessions?.close(params.frameStreamId)
+    if (finalFrame != null) {
+      sendNotification("streamFrame", encode(StreamFrameParams.serializer(), finalFrame))
+    }
   }
 
-  /** Emit one XR [frame] as a `streamFrame` notification (base64 PNG already in hand). */
+  /**
+   * Route one XR [frame] through the frame-stream registry (visibility / fps / dedup gating) and,
+   * if it survives the gate, send it as a `streamFrame` notification. The native server already
+   * base64-encodes the PNG, so the registry forwards the payload as-is.
+   */
   private fun emitXrFrame(frameStreamId: String, frame: XrStreamFrame) {
     val params =
-      StreamFrameParams(
-        frameStreamId = frameStreamId,
-        seq = frame.seq,
-        ptsMillis = System.currentTimeMillis(),
-        widthPx = frame.width,
-        heightPx = frame.height,
-        codec = ee.schimke.composeai.daemon.protocol.StreamCodec.PNG,
-        keyframe = frame.seq == 1L,
-        payloadBase64 = frame.dataBase64,
-      )
+      streamRegistry.consumeForStream(frameStreamId, frame.dataBase64, frame.width, frame.height)
+        ?: return
     sendNotification("streamFrame", encode(StreamFrameParams.serializer(), params))
   }
 

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -2179,10 +2179,19 @@ data class XrStartParams(
   val environment: String? = null,
   val width: Int? = null,
   val height: Int? = null,
+  /** Per-stream frame-rate cap; null = uncapped (visibility throttling still applies). */
+  val maxFps: Int? = null,
+  /** Requested frame codec; the daemon negotiates down to a supported one (PNG today). */
+  val codec: StreamCodec? = null,
 )
 
-/** `xr/start` result — the allocated stream id frames will arrive on. */
-@Serializable data class XrStartResult(val frameStreamId: String, val available: Boolean = true)
+/** `xr/start` result — the allocated stream id + negotiated codec frames will arrive on. */
+@Serializable
+data class XrStartResult(
+  val frameStreamId: String,
+  val codec: StreamCodec,
+  val available: Boolean = true,
+)
 
 /**
  * `xr/updatePanels` — per-frame panel mutations; each entry is `{id, texture?, poseInRoot?,

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/FrameStreamRegistryTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/FrameStreamRegistryTest.kt
@@ -275,4 +275,21 @@ class FrameStreamRegistryTest {
       registry.consumeForStream("xr1", "c", 64, 48)!!.keyframe,
     )
   }
+
+  @Test
+  fun consumeForStream_pending_keyframe_overrides_dedup_after_reshow() {
+    val registry = FrameStreamRegistry(clock = { 0L })
+    registry.register("xr1", "xr-A", StreamCodec.PNG, maxFps = null)
+    registry.consumeForStream("xr1", "SAME", 64, 48) // establishes lastHash
+
+    registry.setVisibility("xr1", visible = false, fps = null)
+    registry.setVisibility("xr1", visible = true, fps = null)
+
+    // Identical payload after scroll-back must still deliver the keyframe anchor, not a heartbeat.
+    val f = registry.consumeForStream("xr1", "SAME", 64, 48)
+    assertNotNull(f)
+    assertTrue(f!!.keyframe)
+    assertEquals(StreamCodec.PNG, f.codec)
+    assertEquals("SAME", f.payloadBase64)
+  }
 }

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/FrameStreamRegistryTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/FrameStreamRegistryTest.kt
@@ -206,4 +206,73 @@ class FrameStreamRegistryTest {
     registry.unregister("s1")
     assertFalse(registry.hasStreamsFor("preview-A"))
   }
+
+  // ---- consumeForStream (XR render service: externally-produced base64 frames) ----
+
+  @Test
+  fun consumeForStream_first_frame_is_keyframe_with_payload() {
+    val registry = FrameStreamRegistry(clock = { 0L })
+    registry.register("xr1", "xr-A", StreamCodec.PNG, maxFps = null)
+
+    val f = registry.consumeForStream("xr1", "AAAA", 64, 48)
+
+    assertNotNull(f)
+    assertEquals(1L, f!!.seq)
+    assertEquals(StreamCodec.PNG, f.codec)
+    assertTrue(f.keyframe)
+    assertEquals("AAAA", f.payloadBase64)
+  }
+
+  @Test
+  fun consumeForStream_dedups_identical_payload_to_heartbeat() {
+    val registry = FrameStreamRegistry(clock = { 0L })
+    registry.register("xr1", "xr-A", StreamCodec.PNG, maxFps = null)
+
+    registry.consumeForStream("xr1", "SAME", 64, 48)
+    val second = registry.consumeForStream("xr1", "SAME", 64, 48)
+
+    assertNotNull(second)
+    assertEquals(2L, second!!.seq)
+    assertNull("identical payload must downgrade to a heartbeat", second.codec)
+    assertNull(second.payloadBase64)
+    assertFalse(second.keyframe)
+  }
+
+  @Test
+  fun consumeForStream_fps_gate_drops_frames_within_interval() {
+    var now = 0L
+    val registry = FrameStreamRegistry(clock = { now })
+    registry.register("xr1", "xr-A", StreamCodec.PNG, maxFps = 10) // 100ms min interval
+
+    assertNotNull(registry.consumeForStream("xr1", "f1", 64, 48))
+    now = 50 // < 100ms
+    assertNull(
+      "within the fps interval the frame is dropped",
+      registry.consumeForStream("xr1", "f2", 64, 48),
+    )
+    now = 150 // >= 100ms since the last emit
+    assertNotNull(registry.consumeForStream("xr1", "f3", 64, 48))
+  }
+
+  @Test
+  fun consumeForStream_unknown_stream_returns_null() {
+    val registry = FrameStreamRegistry(clock = { 0L })
+    assertNull(registry.consumeForStream("nope", "x", 64, 48))
+  }
+
+  @Test
+  fun consumeForStream_keyframe_again_after_visibility_flips_back() {
+    val registry = FrameStreamRegistry(clock = { 0L })
+    registry.register("xr1", "xr-A", StreamCodec.PNG, maxFps = null)
+    assertTrue(registry.consumeForStream("xr1", "a", 64, 48)!!.keyframe)
+    // A changed frame mid-stream is not a keyframe.
+    assertFalse(registry.consumeForStream("xr1", "b", 64, 48)!!.keyframe)
+
+    registry.setVisibility("xr1", visible = false, fps = null)
+    registry.setVisibility("xr1", visible = true, fps = null)
+    assertTrue(
+      "first frame after re-show must be a keyframe",
+      registry.consumeForStream("xr1", "c", 64, 48)!!.keyframe,
+    )
+  }
 }

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/StreamRpcIntegrationTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/StreamRpcIntegrationTest.kt
@@ -623,7 +623,9 @@ private class FakeXrHandle : XrRenderServerHandle {
   @Volatile var closed = false
   override val capabilities = buildJsonObject {}
 
-  private fun frame() = XrStreamFrame(seq.incrementAndGet().toLong(), 64, 48, "png", "ZGF0YQ==")
+  // Distinct payload per frame so the registry doesn't dedup them to heartbeats.
+  private fun frame() =
+    seq.incrementAndGet().let { n -> XrStreamFrame(n.toLong(), 64, 48, "png", "data-$n") }
 
   override fun render(
     scene: kotlinx.serialization.json.JsonElement,

--- a/docs/design/xr-spatial/RENDERER_SERVICE.md
+++ b/docs/design/xr-spatial/RENDERER_SERVICE.md
@@ -22,9 +22,12 @@ into a long-lived, extensible render service.
 >   only when `XrCompositeBinary.resolve(...)` finds the binary, so the real (host) daemon flips
 >   `capabilities.xr` on when provisioned and stays `MethodNotFound` otherwise. XR is host-native, so
 >   it's wired on the desktop daemon only.
+> - **Frame gating** — XR streams register with `FrameStreamRegistry` and frames route through
+>   `consumeForStream` (per-stream fps cap via `xr/start.maxFps`, `stream/visibility` downshift,
+>   content dedup → `unchanged` heartbeats, keyframe-on-(re)show), the same gating `stream/start` gets.
 >
-> **Still to do:** route XR frames through `FrameStreamRegistry` for visibility/fps gating, native
-> multi-session concurrency, and the `xr/structure` / `xr/a11y-overlay` data-product kinds.
+> **Still to do:** native multi-session concurrency (one Filament engine fanned across sessions
+> rather than one child per session), and the `xr/structure` / `xr/a11y-overlay` data-product kinds.
 
 ## Motivation
 


### PR DESCRIPTION
## Summary

Enhancement #1 of the post-milestone follow-ups: route XR frames through `FrameStreamRegistry` so they get the same buttery-streaming gating as `stream/start`, instead of being emitted raw.

- New per-stream **`FrameStreamRegistry.consumeForStream(frameStreamId, payloadBase64, w, h)`** — mirrors `consumeForPreview`'s gating but for externally-produced, already-base64 frames (the XR native server), keyed by `frameStreamId`:
  - **fps cap** (`xr/start.maxFps`) + **`stream/visibility`** downshift,
  - **content dedup** (identical payload → `unchanged` heartbeat, codec/payload null),
  - **keyframe** on first frame and after a visibility flip back to visible,
  - monotonic per-stream `seq`.
- `xr/start` now negotiates + returns the `codec` and **registers** the stream; `xr/stop` emits a `final` marker, unregisters, then closes the native session.
- Frames forward the native server's base64 payload as-is (no decode/re-encode); dedup hashes the payload (SHA-256).

`stream/visibility` already routes by `frameStreamId`, so it Just Works on XR streams now that they're registered.

## Test plan

- [x] New `FrameStreamRegistryTest` cases: keyframe-with-payload first frame, dedup→heartbeat on identical payload, fps-gate drop within the interval, unknown-stream→null, keyframe-again-after-reshow.
- [x] Daemon `xr/*` integration tests still green (fake now returns distinct payloads per frame so the wire flow shows full frames).
- [x] `:daemon:core:test` (those suites) + `ktfmtCheck` clean. (Local runs use a UTF-8 locale to dodge the pre-existing em-dash-classname incremental-compiler ICE; CI is UTF-8.)

## Remaining (in order)

2. Native multi-session concurrency (one Filament engine fanned across sessions vs. one child per session).
3. `xr/structure` / `xr/a11y-overlay` data-product kinds.


---
_Generated by [Claude Code](https://claude.ai/code/session_01X8ZwHy8Sgg5eVJzNqr1LMb)_