### PR TITLE
feat(daemon): sandbox-side semantic-target dispatch on Android (#1784)

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidInteractiveSession.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidInteractiveSession.kt
@@ -218,13 +218,21 @@ internal constructor(
     val isKey = input.kind == InteractiveInputKind.KEY_DOWN || input.kind == InteractiveInputKind.KEY_UP
     val px = input.pixelX
     val py = input.pixelY
+    val hasPixels = px != null && py != null
     // #1784 — a pointer event may carry a semantic target instead of pixels; the sandbox resolves
-    // it to the node centre. Only require pixels when neither pixels nor a target are present.
-    val target = input.target
-    val hasTarget =
-      target != null &&
-        (target.ref != null || target.testTag != null || target.role != null || target.text != null)
-    if (!isKey && (px == null || py == null) && !hasTarget) return
+    // it to the node centre. Explicit pixels win when both are present (the wire contract + desktop
+    // parity), so only forward the target when pixels are absent. Require pixels only when neither
+    // pixels nor a target are present.
+    val rawTarget = input.target
+    val rawHasTarget =
+      rawTarget != null &&
+        (rawTarget.ref != null ||
+          rawTarget.testTag != null ||
+          rawTarget.role != null ||
+          rawTarget.text != null)
+    if (!isKey && !hasPixels && !rawHasTarget) return
+    val target = if (hasPixels) null else rawTarget
+    val hasTarget = !hasPixels && rawHasTarget
     if (isKey && input.keyCode.isNullOrBlank()) return
     if (isKey) {
       // Mirror the keycode into the soft-keyboard band before the held-rule loop runs the actual
@@ -271,8 +279,9 @@ internal constructor(
     // dispatch leaves [replyMatched] null and is unaffected.
     if (hasTarget && replyMatched?.get() == false) {
       error(
-        "AndroidInteractiveSession.dispatch: target did not resolve to a node (ref=${target.ref}, " +
-          "testTag=${target.testTag}, role=${target.role}, text=${target.text})"
+        "AndroidInteractiveSession.dispatch: target did not resolve to a node " +
+          "(ref=${rawTarget?.ref}, testTag=${rawTarget?.testTag}, role=${rawTarget?.role}, " +
+          "text=${rawTarget?.text})"
       )
     }
   }

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidInteractiveSession.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidInteractiveSession.kt
@@ -218,7 +218,13 @@ internal constructor(
     val isKey = input.kind == InteractiveInputKind.KEY_DOWN || input.kind == InteractiveInputKind.KEY_UP
     val px = input.pixelX
     val py = input.pixelY
-    if (!isKey && (px == null || py == null)) return
+    // #1784 — a pointer event may carry a semantic target instead of pixels; the sandbox resolves
+    // it to the node centre. Only require pixels when neither pixels nor a target are present.
+    val target = input.target
+    val hasTarget =
+      target != null &&
+        (target.ref != null || target.testTag != null || target.role != null || target.text != null)
+    if (!isKey && (px == null || py == null) && !hasTarget) return
     if (isKey && input.keyCode.isNullOrBlank()) return
     if (isKey) {
       // Mirror the keycode into the soft-keyboard band before the held-rule loop runs the actual
@@ -234,6 +240,7 @@ internal constructor(
     lastUsedAtMs.set(System.currentTimeMillis())
     val replyLatch = CountDownLatch(1)
     val replyError = AtomicReference<Throwable?>(null)
+    val replyMatched = if (hasTarget) AtomicBoolean(false) else null
     slot.interactiveCommands.put(
       InteractiveCommand.Dispatch(
         streamId = streamId,
@@ -242,6 +249,11 @@ internal constructor(
         pixelY = py ?: 0,
         scrollDeltaY = input.scrollDeltaY,
         keyCode = input.keyCode,
+        targetRef = target?.ref,
+        targetTestTag = target?.testTag,
+        targetRole = target?.role,
+        targetText = target?.text,
+        replyMatched = replyMatched,
         replyLatch = replyLatch,
         replyError = replyError,
       )
@@ -254,6 +266,15 @@ internal constructor(
       )
     }
     replyError.get()?.let { throw it }
+    // A target that resolved to no node (or more than one) is reported as unmatched; throw so the
+    // recording path can record `unsupported` evidence and interactive input logs the miss. Pixel
+    // dispatch leaves [replyMatched] null and is unaffected.
+    if (hasTarget && replyMatched?.get() == false) {
+      error(
+        "AndroidInteractiveSession.dispatch: target did not resolve to a node (ref=${target.ref}, " +
+          "testTag=${target.testTag}, role=${target.role}, text=${target.text})"
+      )
+    }
   }
 
   /**

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSession.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSession.kt
@@ -348,16 +348,35 @@ class AndroidRecordingSession(
    */
   private fun interactiveDispatchHandler(kind: InteractiveInputKind): RecordingScriptEventHandler =
     RecordingScriptEventHandler { event, _ ->
-      interactive.dispatch(
-        InteractiveInputParams(
-          frameStreamId = "android-recording-internal",
-          kind = kind,
-          pixelX = event.pixelX,
-          pixelY = event.pixelY,
-          scrollDeltaY = event.scrollDeltaY,
-          keyCode = event.keyCode,
+      // #1784 — a pointer event may carry a semantic `target` (ref/testTag/role+text) resolved
+      // sandbox-side to the node centre. The host's dispatch throws when the target matches no node;
+      // surface that as `unsupported` evidence rather than failing the whole recording (mirrors the
+      // desktop recording path). Pixel events (no target) keep propagating real failures.
+      val target = event.target
+      val hasTarget =
+        target != null &&
+          (target.ref != null || target.testTag != null || target.role != null || target.text != null)
+      try {
+        interactive.dispatch(
+          InteractiveInputParams(
+            frameStreamId = "android-recording-internal",
+            kind = kind,
+            pixelX = event.pixelX,
+            pixelY = event.pixelY,
+            target = target,
+            scrollDeltaY = event.scrollDeltaY,
+            keyCode = event.keyCode,
+          )
         )
-      )
+      } catch (t: Throwable) {
+        if (hasTarget) {
+          return@RecordingScriptEventHandler unsupportedEvidence(
+            event,
+            t.message ?: "target did not resolve to a node",
+          )
+        }
+        throw t
+      }
       appliedEvidence(event)
     }
 

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -15,6 +15,9 @@ import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performKeyInput
 import androidx.compose.ui.test.performTouchInput
 import com.github.takahirom.roborazzi.captureRoboImage
+import ee.schimke.composeai.data.layoutinspector.SemanticsTarget
+import ee.schimke.composeai.data.layoutinspector.SemanticsTargets
+import ee.schimke.composeai.data.layoutinspector.TargetResolution
 import ee.schimke.composeai.data.render.PreviewContext
 import ee.schimke.composeai.data.render.PreviewDeviceContext
 import ee.schimke.composeai.data.render.PreviewDeviceSpec
@@ -2154,16 +2157,25 @@ open class RobolectricHost(
               when (cmd) {
                 is InteractiveCommand.Dispatch -> {
                   try {
-                    val inputTrace =
-                      PerfettoTraceDataProducer.recorder(
-                        start.outputBaseName,
-                        backend = "android-live",
-                      )
-                    inputTrace.section("interactive:dispatch") { dispatchHeldMotion(rule, cmd) }
-                    inputTrace.section("compose:advanceClock") {
-                      rule.mainClock.advanceTimeBy(POINTER_HOLD_MS)
+                    // #1784 — a semantic target resolves to a node centre here, sandbox-side, where
+                    // the live semantics tree lives. Pixel/key dispatch resolves to the wire coords.
+                    // A null position means a target matched no node — replyMatched is already false
+                    // and we dispatch nothing.
+                    val position = resolveDispatchPosition(rule, cmd)
+                    if (position != null) {
+                      val inputTrace =
+                        PerfettoTraceDataProducer.recorder(
+                          start.outputBaseName,
+                          backend = "android-live",
+                        )
+                      inputTrace.section("interactive:dispatch") {
+                        dispatchHeldMotion(rule, cmd, position)
+                      }
+                      inputTrace.section("compose:advanceClock") {
+                        rule.mainClock.advanceTimeBy(POINTER_HOLD_MS)
+                      }
+                      dataDir?.let(inputTrace::write)
                     }
-                    dataDir?.let(inputTrace::write)
                   } catch (t: Throwable) {
                     cmd.replyError.set(t)
                   } finally {
@@ -2666,6 +2678,48 @@ open class RobolectricHost(
      * the wheel position, then sends a native SOURCE_ROTARY_ENCODER ACTION_SCROLL to the Compose
      * view, matching Wear's RSB route.
      */
+    /**
+     * Resolve where a [InteractiveCommand.Dispatch] lands. Pixel/key dispatch uses the wire coords;
+     * a semantic target (issue #1784) is resolved sandbox-side against the live semantics tree —
+     * the same `ComposeSemanticsDataProducer` projection an agent fetched via `compose/semantics`,
+     * matched by [SemanticsTargets] — to the matched node's centre. Sets [Dispatch.replyMatched] when
+     * a target was given (`true` resolved, `false` no/ambiguous match) and returns `null` on a
+     * target miss so the caller dispatches nothing.
+     */
+    private fun resolveDispatchPosition(
+      rule:
+        androidx.compose.ui.test.junit4.AndroidComposeTestRule<
+          *,
+          androidx.activity.ComponentActivity,
+        >,
+      cmd: InteractiveCommand.Dispatch,
+    ): Offset? {
+      val target =
+        semanticsTargetOf(cmd) ?: return Offset(cmd.pixelX.toFloat(), cmd.pixelY.toFloat())
+      val root =
+        runCatching { rule.onRoot(useUnmergedTree = true).fetchSemanticsNode() }.getOrNull()
+      val resolved =
+        root?.let {
+          val payload = ComposeSemanticsDataProducer.buildPayload(it)
+          when (val res = SemanticsTargets.resolve(payload, target)) {
+            is TargetResolution.Resolved -> Offset(res.point.x.toFloat(), res.point.y.toFloat())
+            else -> null
+          }
+        }
+      cmd.replyMatched?.set(resolved != null)
+      return resolved
+    }
+
+    /** Build the core [SemanticsTarget] from the bridge command's string fields (ref → tag → role+text). */
+    private fun semanticsTargetOf(cmd: InteractiveCommand.Dispatch): SemanticsTarget? =
+      when {
+        !cmd.targetRef.isNullOrBlank() -> SemanticsTarget.Ref(cmd.targetRef)
+        !cmd.targetTestTag.isNullOrBlank() -> SemanticsTarget.Tag(cmd.targetTestTag)
+        cmd.targetRole != null || cmd.targetText != null ->
+          SemanticsTarget.RoleText(cmd.targetRole, cmd.targetText)
+        else -> null
+      }
+
     private fun dispatchHeldMotion(
       rule:
         androidx.compose.ui.test.junit4.AndroidComposeTestRule<
@@ -2673,8 +2727,8 @@ open class RobolectricHost(
           androidx.activity.ComponentActivity,
         >,
       cmd: InteractiveCommand.Dispatch,
+      position: Offset,
     ) {
-      val position = Offset(cmd.pixelX.toFloat(), cmd.pixelY.toFloat())
       when (cmd.kind) {
         "click" -> {
           if (!performClickActionAt(rule, position)) {

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/bridge/DaemonHostBridge.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/bridge/DaemonHostBridge.kt
@@ -450,6 +450,24 @@ sealed interface InteractiveCommand {
      * value is just a `java.lang.String` (do-not-acquire), so the bridge serialises trivially.
      */
     val keyCode: String? = null,
+    /**
+     * Issue #1784 — optional semantic target. When any of these is set the sandbox resolves it to
+     * the matched node's centre (via `ComposeSemanticsDataProducer.buildPayload` + `SemanticsTargets`)
+     * and dispatches there instead of using [pixelX]/[pixelY]. Passed as plain `java.lang.String`s
+     * (like [keyCode] / `DispatchUiAutomator.selectorJson`) so no Compose / domain type crosses the
+     * classloader boundary. Precedence sandbox-side: ref → testTag → role+text.
+     */
+    val targetRef: String? = null,
+    val targetTestTag: String? = null,
+    val targetRole: String? = null,
+    val targetText: String? = null,
+    /**
+     * Set by the sandbox when a target was provided: `true` if it resolved to exactly one node and
+     * dispatched, `false` if it matched no node (or was ambiguous). Null / unused for pixel
+     * dispatch. The host's `dispatch` throws when a target was given but `replyMatched` is `false`,
+     * so the recording path surfaces `unsupported` evidence and interactive input logs the miss.
+     */
+    val replyMatched: AtomicBoolean? = null,
     val replyLatch: CountDownLatch,
     val replyError: AtomicReference<Throwable?>,
   ) : InteractiveCommand

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AndroidInteractiveSessionTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AndroidInteractiveSessionTest.kt
@@ -2,6 +2,7 @@ package ee.schimke.composeai.daemon
 
 import ee.schimke.composeai.daemon.protocol.InteractiveInputKind
 import ee.schimke.composeai.daemon.protocol.InteractiveInputParams
+import ee.schimke.composeai.daemon.protocol.SemanticsInputTarget
 import java.io.ByteArrayInputStream
 import java.io.File
 import javax.imageio.ImageIO
@@ -877,6 +878,75 @@ class AndroidInteractiveSessionTest {
     )
   }
 
+  /**
+   * Issue #1784 — a click carrying only a semantic `target` (testTag, no pixel coordinates) is
+   * resolved sandbox-side (where the live semantics tree lives) to the target node's centre and
+   * dispatched there, flipping [TaggedClickTargetSquare] green. The negative control proves the
+   * resolution is real: the `target-box` node sits in the top-left corner, so a centre pixel click
+   * misses it and the card stays red — only the resolved centroid hits.
+   */
+  @Test
+  fun heldClickResolvesTestTagTargetToNodeCentre() {
+    System.setProperty(
+      RenderEngine.OUTPUT_DIR_PROP,
+      tempFolder.newFolder("interactive-target").absolutePath,
+    )
+    System.setProperty("roborazzi.test.record", "true")
+    val host = RobolectricHost(sandboxCount = 2, previewSpecResolver = previewSpecResolver())
+    host.start()
+    try {
+      val session =
+        host.acquireInteractiveSession(
+          previewId = TAGGED_TARGET_PREVIEW_ID,
+          classLoader = javaClass.classLoader!!,
+        )
+      try {
+        // Bootstrap render — red.
+        val before = decode(File(session.render(RenderHost.nextRequestId()).pngPath!!))
+        assertTrue(
+          "tagged-target fixture should start red",
+          pixelMatchPct(before, RED_RGB, perChannelTolerance = 8) >= 0.95,
+        )
+
+        // Negative control: a centre pixel click misses the top-left target → still red.
+        session.dispatch(
+          InteractiveInputParams(
+            frameStreamId = "irrelevant-on-host-side",
+            kind = InteractiveInputKind.CLICK,
+            pixelX = INTERACTIVE_WIDTH_PX / 2,
+            pixelY = INTERACTIVE_HEIGHT_PX / 2,
+          )
+        )
+        val afterMiss = decode(File(session.render(RenderHost.nextRequestId()).pngPath!!))
+        assertTrue(
+          "centre pixel click must miss the corner target-box; card should still be red",
+          pixelMatchPct(afterMiss, RED_RGB, perChannelTolerance = 8) >= 0.95,
+        )
+
+        // The payload: a CLICK with NO pixel coords, only a testTag target. Resolved sandbox-side to
+        // the corner node's centre → flips green.
+        session.dispatch(
+          InteractiveInputParams(
+            frameStreamId = "irrelevant-on-host-side",
+            kind = InteractiveInputKind.CLICK,
+            target = SemanticsInputTarget(testTag = "target-box"),
+          )
+        )
+        val afterHit = decode(File(session.render(RenderHost.nextRequestId()).pngPath!!))
+        val green = pixelMatchPct(afterHit, GREEN_RGB, perChannelTolerance = 8)
+        assertTrue(
+          "testTag target must resolve sandbox-side to the corner node's centre and flip green; " +
+            "got ${"%.2f".format(green * 100)}% — load-bearing #1784 Android assertion",
+          green >= 0.95,
+        )
+      } finally {
+        session.close()
+      }
+    } finally {
+      host.shutdown()
+    }
+  }
+
   private fun previewSpecResolver(): (String) -> RenderSpec? = { previewId ->
     when (previewId) {
       INTERACTIVE_PREVIEW_ID ->
@@ -888,6 +958,16 @@ class AndroidInteractiveSessionTest {
           density = 1.0f,
           showBackground = true,
           outputBaseName = "interactive-clicktoggle",
+        )
+      TAGGED_TARGET_PREVIEW_ID ->
+        RenderSpec(
+          className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+          functionName = "TaggedClickTargetSquare",
+          widthPx = INTERACTIVE_WIDTH_PX,
+          heightPx = INTERACTIVE_HEIGHT_PX,
+          density = 1.0f,
+          showBackground = true,
+          outputBaseName = "interactive-tagged-target",
         )
       DARK_PREVIEW_ID ->
         RenderSpec(
@@ -994,6 +1074,7 @@ class AndroidInteractiveSessionTest {
 
   companion object {
     private const val INTERACTIVE_PREVIEW_ID = "interactive-clicktoggle"
+    private const val TAGGED_TARGET_PREVIEW_ID = "interactive-tagged-target"
     private const val DARK_PREVIEW_ID = "interactive-darkaware"
     private const val CLICKABLE_PREVIEW_ID = "interactive-clickable"
     private const val SCROLL_PREVIEW_ID = "interactive-scroll"

--- a/daemon/android/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
+++ b/daemon/android/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.BasicText
@@ -25,6 +26,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.changedToUp
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.input.rotary.onRotaryScrollEvent
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
@@ -223,6 +225,22 @@ fun ClickToggleSquare() {
         }
       }
   )
+}
+
+/**
+ * Issue #1784 fixture — proves an interaction can target a node by `testTag` (resolved sandbox-side
+ * to its centre) instead of pixel coordinates. The whole card starts red; only a click inside the
+ * small 24×24 `testTag("target-box")` clickable node pinned to the **top-left corner** flips it
+ * green. The node is deliberately off-centre so a naive centre click misses it — a green result is
+ * only reachable by resolving the testTag to the node's real centroid.
+ */
+@Composable
+fun TaggedClickTargetSquare() {
+  var clicked by androidx.compose.runtime.remember { androidx.compose.runtime.mutableStateOf(false) }
+  val color = if (clicked) Color(0xFF66BB6A) else Color(0xFFEF5350)
+  Box(modifier = Modifier.fillMaxSize().background(color)) {
+    Box(modifier = Modifier.size(24.dp).testTag("target-box").clickable { clicked = true })
+  }
 }
 
 @Composable


### PR DESCRIPTION
## Summary

Completes **#1784** cross-backend: Android interactive (`interactive/input`) **and** `record_preview` pointer events can now target a node by **ref / testTag / role+text** instead of pixel coordinates — matching the desktop behavior (#1793, #1798).

Android's live semantics tree lives in the **Robolectric sandbox classloader**, unreachable from the host-side session, so resolution happens **sandbox-side** — the same place `uia.*` / `a11y.action.*` selectors already resolve.

- **Bridge** (`DaemonHostBridge.InteractiveCommand.Dispatch`): carries the target as plain `String`s (`targetRef` / `targetTestTag` / `targetRole` / `targetText`) so no Compose/domain type crosses the classloader boundary (the same discipline as `DispatchUiAutomator.selectorJson` — relevant given the pre-existing cross-classloader `ClassCastException` flake on `uiAutomatorClickReportsUnmatched…`), plus an `AtomicBoolean replyMatched` for the resolution outcome.
- **Host** (`AndroidInteractiveSession.dispatch`): forwards the target (allowing a target without pixels) and throws when `replyMatched` is false — so the recording path records `unsupported` evidence and interactive input logs the miss.
- **Sandbox** (`RobolectricHost.resolveDispatchPosition`): builds the semantics payload from the held rule's root (`ComposeSemanticsDataProducer.buildPayload` + `SemanticsTargets`) and dispatches at the matched node's centre. `dispatchHeldMotion` now takes an explicit `position`, so pixel and target paths converge on the same click logic.
- **Recording** (`AndroidRecordingSession`): forwards `event.target` and maps an unresolved-target throw to `unsupported` script evidence.

## Test plan

- [x] `:daemon:android:testDebugUnitTest --tests "*AndroidInteractiveSessionTest.heldClickResolvesTestTagTargetToNodeCentre"` — a CLICK carrying only a testTag resolves sandbox-side to the off-centre node's centre → fixture flips green; a centre pixel click is the negative control.
- [x] `…heldClickToggleSurvivesAcrossInputs` (pixel dispatch via the refactored `dispatchHeldMotion`) and the full `AndroidRecordingSessionTest` + `bridge.InteractiveCommandTest` pass unchanged.
- [x] `:daemon:android:ktfmtCheck` clean.

> Pre-existing, unrelated: `AndroidInteractiveSessionTest.uiAutomatorClickReportsUnmatchedWhenNoNodeSatisfiesTheSelector` fails with a cross-classloader `ClassCastException` on clean `main` in my sandbox (not touched here).

## #1784 status

With this, semantic-target dispatch is complete on **both backends** for **both** interactive and recording. Remaining in the issue: structured ambiguity/NotFound surfaced on the wire (today: logged / `unsupported` evidence).