### PR TITLE
feat(xr): multi-session support in the native render server

### DIFF
--- a/renderers/xr-composite/README.md
+++ b/renderers/xr-composite/README.md
@@ -72,17 +72,26 @@ xvfb-run -a -s "-screen 0 2000x1400x24" \
 
 Methods (all params are JSON):
 
+The server is **multi-session**: one shared Filament engine (+ renderer + compiled materials) fans
+across many concurrent sessions, each keyed by `sessionId` (the daemon's `frameStreamId`); a session
+owns only its own swapchain/scene/view/panels. Omit `sessionId` to address the implicit `"default"`
+session (back-compat with single-session callers + the one-shot path).
+
+Methods (all params are JSON):
+
 | method | params | effect |
 |--------|--------|--------|
-| `initialize` | `{frameStreamId?}` | returns `{serverInfo, capabilities}` (`render`/`updatePanels`/`streamFrame`, `spatialSceneVersion`, `dataProducts:["xr/composite"]`) |
-| `render` (alias `xr/render`) | `{scene: SpatialScene, sceneDir?, environment?, out?}` | (re)build the whole scene + camera, render; emits a `streamFrame`; `out` also writes a PNG file |
-| `xr/updatePanels` | `{panels: [{id, texture?, poseInRoot?, sizeDp?}], out?}` | mutate matching panels (or append a full new panel) and re-render; emits a `streamFrame` |
+| `initialize` | `{frameStreamId?}` | returns `{serverInfo, capabilities}` (`render`/`updatePanels`/`streamFrame`/`multiSession`, `spatialSceneVersion`, `dataProducts:["xr/composite"]`) |
+| `render` (alias `xr/render`) | `{scene: SpatialScene, sessionId?, sceneDir?, environment?, width?, height?, out?}` | open/replace the session's scene + camera, render; emits a `streamFrame`; `out` also writes a PNG |
+| `xr/updatePanels` | `{sessionId?, panels: [{id, texture?, poseInRoot?, sizeDp?}], out?}` | mutate matching panels (or append a full new panel) on the session and re-render; emits a `streamFrame` |
+| `xr/stop` | `{sessionId?}` | tear down the session's per-session Filament objects (engine kept for other sessions) |
 | `shutdown` / `exit` | — | `shutdown` acks; `exit` ends the loop |
 
 Rendered frames are delivered as **`streamFrame` notifications** —
-`{encoding:"png", width, height, seq, data:<base64>, frameStreamId?}` — reusing the daemon's
-`composestream/1` shape (RFC decision #4: base64-over-JSON). The
-[`test/serve_smoke.py`](test/serve_smoke.py) harness drives this flow and is run in CI under Xvfb.
+`{encoding:"png", width, height, seq, data:<base64>, sessionId?, frameStreamId?}` — reusing the
+daemon's `composestream/1` shape (RFC decision #4: base64-over-JSON). The
+[`test/serve_smoke.py`](test/serve_smoke.py) harness drives this flow (incl. two concurrent
+sessions) and is run in CI under Xvfb.
 
 ### Why Xvfb?
 

--- a/renderers/xr-composite/src/main.cpp
+++ b/renderers/xr-composite/src/main.cpp
@@ -56,6 +56,7 @@
 #include <fstream>
 #include <iostream>
 #include <map>
+#include <memory>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -252,13 +253,38 @@ std::vector<uint8_t> encodePng(const std::vector<uint8_t>& rgba, uint32_t w, uin
   return bytes;
 }
 
-// Holds the Filament render state across frames. Built once; `setScene` (re)builds the whole scene,
-// `applyPanelUpdates` mutates panel poses/textures in place and rebuilds just the panels, and
-// `renderPixels` reads back one frame. The one-shot path uses it for a single render; the server
-// reuses one instance for the life of the process.
+// Shared GL/Filament context fanned across sessions: one Engine + Renderer + compiled materials for
+// the whole process. Each Compositor (session) owns only its own SwapChain/Scene/View/panels, so the
+// server can multiplex many sessions over a single engine instead of one child process per session.
+struct SharedGl {
+  Engine* engine = nullptr;
+  Renderer* renderer = nullptr;
+  Material* unlit = nullptr;
+  Material* shadow = nullptr;
+
+  bool create(const std::string& materialsDir) {
+    engine = Engine::Builder().backend(backend::Backend::OPENGL).build();
+    if (!engine) { fprintf(stderr, "engine create failed\n"); return false; }
+    renderer = engine->createRenderer();
+    const std::string dir = materialsDir.empty() ? "." : materialsDir;
+    auto unlitPkg = readFile(dir + "/unlit_texture.filamat");
+    unlit = Material::Builder().package(unlitPkg.data(), unlitPkg.size()).build(*engine);
+    // Soft contact shadow behind each panel — a separate transparent quad that feathers a
+    // rounded-rect silhouette. Real Filament shadows are unstable / expensive on llvmpipe, so we
+    // composite a baked soft shadow quad instead (deterministic, no shadow map, no GPU shadow pass).
+    auto shadowPkg = readFile(dir + "/panel_shadow.filamat");
+    shadow = Material::Builder().package(shadowPkg.data(), shadowPkg.size()).build(*engine);
+    return true;
+  }
+};
+
+// Holds one session's render state. `setScene` (re)builds the whole scene, `applyPanelUpdates`
+// mutates panel poses/textures in place and rebuilds just the panels, and `renderPixels` reads back
+// one frame. The Engine/Renderer/materials are shared (see [SharedGl]); each instance owns only its
+// own SwapChain/Scene/View/Camera/panels so the server can hold many concurrently.
 class Compositor {
  public:
-  bool init(uint32_t w, uint32_t h, const std::string& materialsDir);
+  bool init(SharedGl& gl, uint32_t w, uint32_t h);
   // Replace the whole scene (background + panels + camera). `envOverride` is the CLI `--environment`
   // value (empty = none).
   void setScene(const xrcomposite::SpatialScene& scene, const std::string& sceneDir,
@@ -268,6 +294,9 @@ class Compositor {
   void applyPanelUpdates(const json& panels);
   std::vector<uint8_t> renderPixels();
   bool writePng(const std::string& path);
+  // Destroy this session's per-session Filament objects (panels, skybox, view, scene, camera,
+  // swapchain) via the shared engine; the shared Engine/Renderer/materials are left intact.
+  void teardown();
   uint32_t width() const { return W_; }
   uint32_t height() const { return H_; }
 
@@ -290,7 +319,6 @@ class Compositor {
   Material* shadowMat_ = nullptr;
   Skybox* skybox_ = nullptr;
   uint32_t W_ = 0, H_ = 0;
-  std::string materialsDir_;
   std::string sceneDir_ = ".";
   float3 bg_ = {0.06f, 0.06f, 0.08f};
 
@@ -305,15 +333,17 @@ class Compositor {
   std::map<std::string, Texture*> texCache_;
 };
 
-bool Compositor::init(uint32_t w, uint32_t h, const std::string& materialsDir) {
+bool Compositor::init(SharedGl& gl, uint32_t w, uint32_t h) {
   W_ = w;
   H_ = h;
-  materialsDir_ = materialsDir.empty() ? "." : materialsDir;
+  // Engine / Renderer / materials are shared across sessions; this instance owns only the
+  // per-session SwapChain / Scene / View / Camera below.
+  engine_ = gl.engine;
+  renderer_ = gl.renderer;
+  unlit_ = gl.unlit;
+  shadowMat_ = gl.shadow;
 
-  engine_ = Engine::Builder().backend(backend::Backend::OPENGL).build();
-  if (!engine_) { fprintf(stderr, "engine create failed\n"); return false; }
   swapChain_ = engine_->createSwapChain(W_, H_);
-  renderer_ = engine_->createRenderer();
   scene_ = engine_->createScene();
   view_ = engine_->createView();
   camEntity_ = utils::EntityManager::get().create();
@@ -335,16 +365,25 @@ bool Compositor::init(uint32_t w, uint32_t h, const std::string& materialsDir) {
     view_->setMultiSampleAntiAliasingOptions(msaa);
     view_->setAntiAliasing(View::AntiAliasing::FXAA);
   }
-
-  auto unlitPkg = readFile(materialsDir_ + "/unlit_texture.filamat");
-  unlit_ = Material::Builder().package(unlitPkg.data(), unlitPkg.size()).build(*engine_);
-
-  // Soft contact shadow behind each panel — a separate transparent quad that feathers a rounded-rect
-  // silhouette. Real Filament shadows are unstable / expensive on llvmpipe, so we composite a baked
-  // soft shadow quad instead (deterministic, no shadow map, no GPU shadow pass).
-  auto shadowPkg = readFile(materialsDir_ + "/panel_shadow.filamat");
-  shadowMat_ = Material::Builder().package(shadowPkg.data(), shadowPkg.size()).build(*engine_);
   return true;
+}
+
+void Compositor::teardown() {
+  // No frame is in flight (renderPixels flushAndWait()s after each render), but flush defensively so
+  // the driver isn't reading these objects when we destroy them. Engine/Renderer/materials are
+  // shared — left for the next session / process exit.
+  engine_->flushAndWait();
+  clearPanels();
+  if (skybox_) {
+    scene_->setSkybox(nullptr);
+    engine_->destroy(skybox_);
+    skybox_ = nullptr;
+  }
+  engine_->destroy(view_);
+  engine_->destroy(scene_);
+  engine_->destroyCameraComponent(camEntity_);
+  utils::EntityManager::get().destroy(camEntity_);
+  engine_->destroy(swapChain_);
 }
 
 void Compositor::resolveBackground(const std::string& envOverride) {
@@ -722,7 +761,7 @@ void writeError(const json& id, int code, const std::string& message) {
 
 // Emit one rendered frame as a `streamFrame` notification (base64 PNG), reusing the daemon's
 // composestream/1 shape. `seq` is a monotonic frame counter.
-void emitStreamFrame(Compositor& comp, uint64_t seq, const std::string& frameStreamId) {
+void emitStreamFrame(Compositor& comp, uint64_t seq, const std::string& sessionId) {
   auto pixels = comp.renderPixels();
   auto png = encodePng(pixels, comp.width(), comp.height());
   json params = {
@@ -732,19 +771,31 @@ void emitStreamFrame(Compositor& comp, uint64_t seq, const std::string& frameStr
       {"seq", seq},
       {"data", base64Encode(png.data(), png.size())},
   };
-  if (!frameStreamId.empty()) params["frameStreamId"] = frameStreamId;
+  // The session this frame belongs to, so a multiplexing client can demux frames from the one
+  // shared process. Mirrored as `frameStreamId` for the daemon's existing stream-frame shape.
+  if (!sessionId.empty()) {
+    params["sessionId"] = sessionId;
+    params["frameStreamId"] = sessionId;
+  }
   writeMessage({{"jsonrpc", "2.0"}, {"method", "streamFrame"}, {"params", params}});
 }
 
 int runServer(const Args& args) {
-  Compositor comp;
-  if (!comp.init(args.width, args.height, args.materialsDir)) return 3;
-  fprintf(stderr, "xr-composite: serving on stdio (%ux%u)\n", args.width, args.height);
+  SharedGl gl;
+  if (!gl.create(args.materialsDir)) return 3;
+  fprintf(stderr, "xr-composite: serving on stdio (multi-session, one shared engine)\n");
 
-  bool haveScene = false;
+  // One session per `sessionId` (the daemon's frameStreamId), all sharing `gl`'s engine.
+  std::map<std::string, std::unique_ptr<Compositor>> sessions;
   uint64_t seq = 0;
-  std::string frameStreamId;
   std::string body;
+
+  // sessionId precedence: explicit `sessionId`, then `frameStreamId`, else the implicit "default"
+  // session (back-compat with single-session callers and the one-shot smoke).
+  auto sessionIdOf = [](const json& params) -> std::string {
+    return params.value("sessionId", params.value("frameStreamId", std::string("default")));
+  };
+
   while (readMessage(body)) {
     json msg;
     try {
@@ -758,44 +809,73 @@ int runServer(const Args& args) {
     const json& params = msg.contains("params") ? msg["params"] : json::object();
 
     if (method == "initialize") {
-      frameStreamId = params.value("frameStreamId", "");
       writeResult(id, {
           {"serverInfo", {{"name", "xr-composite"}, {"version", 1}}},
           {"capabilities", {
               {"render", true},
               {"updatePanels", true},
               {"streamFrame", true},
+              {"multiSession", true},
               {"spatialSceneVersion", xrcomposite::SPATIAL_SCENE_VERSION},
               {"dataProducts", json::array({"xr/composite"})},
           }},
       });
     } else if (method == "render" || method == "xr/render") {
       try {
+        const std::string sid = sessionIdOf(params);
         auto scene = params.at("scene").get<xrcomposite::SpatialScene>();
         std::string sceneDir = params.value("sceneDir", ".");
         std::string envOverride = params.value("environment", "");
+        uint32_t w = params.value("width", args.width);
+        uint32_t h = params.value("height", args.height);
+        // (Re)create the session if absent or if its viewport changed.
+        auto it = sessions.find(sid);
+        if (it != sessions.end() && (it->second->width() != w || it->second->height() != h)) {
+          it->second->teardown();
+          sessions.erase(it);
+          it = sessions.end();
+        }
+        if (it == sessions.end()) {
+          auto comp = std::make_unique<Compositor>();
+          if (!comp->init(gl, w, h)) {
+            if (!id.is_null()) writeError(id, -32603, "session init failed");
+            continue;
+          }
+          it = sessions.emplace(sid, std::move(comp)).first;
+        }
+        Compositor& comp = *it->second;
         comp.setScene(scene, sceneDir, envOverride);
-        haveScene = true;
         if (params.contains("out")) comp.writePng(params.at("out").get<std::string>());
-        emitStreamFrame(comp, ++seq, frameStreamId);
-        if (!id.is_null()) writeResult(id, {{"ok", true}, {"seq", seq},
-                                            {"width", comp.width()}, {"height", comp.height()}});
+        emitStreamFrame(comp, ++seq, sid);
+        if (!id.is_null())
+          writeResult(id, {{"ok", true}, {"seq", seq}, {"sessionId", sid},
+                           {"width", comp.width()}, {"height", comp.height()}});
       } catch (const std::exception& e) {
         if (!id.is_null()) writeError(id, -32602, std::string("render failed: ") + e.what());
       }
     } else if (method == "xr/updatePanels") {
-      if (!haveScene) {
-        if (!id.is_null()) writeError(id, -32002, "no scene: call render first");
+      const std::string sid = sessionIdOf(params);
+      auto it = sessions.find(sid);
+      if (it == sessions.end()) {
+        if (!id.is_null()) writeError(id, -32002, "no scene: call render first for session " + sid);
         continue;
       }
       try {
-        if (params.contains("panels")) comp.applyPanelUpdates(params.at("panels"));
-        if (params.contains("out")) comp.writePng(params.at("out").get<std::string>());
-        emitStreamFrame(comp, ++seq, frameStreamId);
-        if (!id.is_null()) writeResult(id, {{"ok", true}, {"seq", seq}});
+        if (params.contains("panels")) it->second->applyPanelUpdates(params.at("panels"));
+        if (params.contains("out")) it->second->writePng(params.at("out").get<std::string>());
+        emitStreamFrame(*it->second, ++seq, sid);
+        if (!id.is_null()) writeResult(id, {{"ok", true}, {"seq", seq}, {"sessionId", sid}});
       } catch (const std::exception& e) {
         if (!id.is_null()) writeError(id, -32602, std::string("updatePanels failed: ") + e.what());
       }
+    } else if (method == "xr/stop") {
+      const std::string sid = sessionIdOf(params);
+      auto it = sessions.find(sid);
+      if (it != sessions.end()) {
+        it->second->teardown();
+        sessions.erase(it);
+      }
+      if (!id.is_null()) writeResult(id, {{"ok", true}, {"sessionId", sid}});
     } else if (method == "shutdown") {
       if (!id.is_null()) writeResult(id, json::object());
     } else if (method == "exit") {
@@ -818,8 +898,10 @@ int runOneShot(const Args& args) {
     f >> raw;
     scene = raw.get<xrcomposite::SpatialScene>();
   }
+  SharedGl gl;
+  if (!gl.create(args.materialsDir)) return 3;
   Compositor comp;
-  if (!comp.init(args.width, args.height, args.materialsDir)) return 3;
+  if (!comp.init(gl, args.width, args.height)) return 3;
   comp.setScene(scene, dirOf(args.scenePath), args.environment);
   if (!comp.writePng(args.outPath)) return 4;
   fflush(stderr);

--- a/renderers/xr-composite/src/main.cpp
+++ b/renderers/xr-composite/src/main.cpp
@@ -318,6 +318,7 @@ class Compositor {
   Material* unlit_ = nullptr;
   Material* shadowMat_ = nullptr;
   Skybox* skybox_ = nullptr;
+  ColorGrading* colorGrading_ = nullptr;
   uint32_t W_ = 0, H_ = 0;
   std::string sceneDir_ = ".";
   float3 bg_ = {0.06f, 0.06f, 0.08f};
@@ -355,8 +356,8 @@ bool Compositor::init(SharedGl& gl, uint32_t w, uint32_t h) {
 
   // faithful colors: linear tonemap (no filmic curve), keep post-processing for sRGB output + MSAA
   static LinearToneMapper toneMapper;
-  ColorGrading* colorGrading = ColorGrading::Builder().toneMapper(&toneMapper).build(*engine_);
-  view_->setColorGrading(colorGrading);
+  colorGrading_ = ColorGrading::Builder().toneMapper(&toneMapper).build(*engine_);
+  view_->setColorGrading(colorGrading_);
   view_->setPostProcessingEnabled(true);
   {
     MultiSampleAntiAliasingOptions msaa;
@@ -374,6 +375,10 @@ void Compositor::teardown() {
   // shared — left for the next session / process exit.
   engine_->flushAndWait();
   clearPanels();
+  // Panel textures are cached per resolved path for the session's lifetime; free them too (they live
+  // in the shared engine and would otherwise leak after this session is erased).
+  for (auto& [path, tex] : texCache_) engine_->destroy(tex);
+  texCache_.clear();
   if (skybox_) {
     scene_->setSkybox(nullptr);
     engine_->destroy(skybox_);
@@ -384,6 +389,10 @@ void Compositor::teardown() {
   engine_->destroyCameraComponent(camEntity_);
   utils::EntityManager::get().destroy(camEntity_);
   engine_->destroy(swapChain_);
+  if (colorGrading_) {
+    engine_->destroy(colorGrading_);
+    colorGrading_ = nullptr;
+  }
 }
 
 void Compositor::resolveBackground(const std::string& envOverride) {
@@ -789,11 +798,14 @@ int runServer(const Args& args) {
   std::map<std::string, std::unique_ptr<Compositor>> sessions;
   uint64_t seq = 0;
   std::string body;
+  // Single-session clients register a stream id once at `initialize` and then omit it on subsequent
+  // calls; remember it so their frames stay tagged with that id rather than the literal "default".
+  std::string defaultSessionId = "default";
 
-  // sessionId precedence: explicit `sessionId`, then `frameStreamId`, else the implicit "default"
-  // session (back-compat with single-session callers and the one-shot smoke).
-  auto sessionIdOf = [](const json& params) -> std::string {
-    return params.value("sessionId", params.value("frameStreamId", std::string("default")));
+  // sessionId precedence: explicit `sessionId`, then per-call `frameStreamId`, else the
+  // initialize-registered default (back-compat with single-session callers and the one-shot smoke).
+  auto sessionIdOf = [&](const json& params) -> std::string {
+    return params.value("sessionId", params.value("frameStreamId", defaultSessionId));
   };
 
   while (readMessage(body)) {
@@ -809,6 +821,7 @@ int runServer(const Args& args) {
     const json& params = msg.contains("params") ? msg["params"] : json::object();
 
     if (method == "initialize") {
+      defaultSessionId = params.value("frameStreamId", defaultSessionId);
       writeResult(id, {
           {"serverInfo", {{"name", "xr-composite"}, {"version", 1}}},
           {"capabilities", {

--- a/renderers/xr-composite/test/serve_smoke.py
+++ b/renderers/xr-composite/test/serve_smoke.py
@@ -56,14 +56,16 @@ def main() -> int:
             if m.get("method") == "streamFrame":
                 p = m["params"]
                 assert p["encoding"] == "png" and p["data"], "streamFrame missing png data"
-                frames.append((p["seq"], p["data"]))
+                frames.append((p["seq"], p["data"], p.get("sessionId")))
             elif m.get("id") == want:
                 return m
 
     send({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {"frameStreamId": "fs1"}})
     caps = pump_until_id(1)["result"]["capabilities"]
     assert caps.get("render") and caps.get("updatePanels") and caps.get("streamFrame"), caps
+    assert caps.get("multiSession"), f"expected multiSession capability: {caps}"
 
+    # Default-session flow (back-compat: no sessionId).
     send({"jsonrpc": "2.0", "id": 2, "method": "render",
           "params": {"scene": scene, "sceneDir": scene_dir}})
     assert pump_until_id(2)["result"]["ok"], "render did not ack ok"
@@ -75,14 +77,29 @@ def main() -> int:
                               "rotation": {"x": 0, "y": 0, "z": 0, "w": 1}}}]}})
     assert pump_until_id(3)["result"]["ok"], "updatePanels did not ack ok"
 
+    # Multi-session: two named sessions sharing one process / engine.
+    send({"jsonrpc": "2.0", "id": 4, "method": "render",
+          "params": {"sessionId": "a", "scene": scene, "sceneDir": scene_dir}})
+    assert pump_until_id(4)["result"].get("sessionId") == "a", "session a render missing sessionId"
+    send({"jsonrpc": "2.0", "id": 5, "method": "render",
+          "params": {"sessionId": "b", "scene": scene, "sceneDir": scene_dir}})
+    assert pump_until_id(5)["result"].get("sessionId") == "b", "session b render missing sessionId"
+
+    send({"jsonrpc": "2.0", "id": 6, "method": "xr/stop", "params": {"sessionId": "a"}})
+    assert pump_until_id(6)["result"]["ok"], "xr/stop a did not ack"
+    send({"jsonrpc": "2.0", "id": 7, "method": "xr/stop", "params": {"sessionId": "b"}})
+    assert pump_until_id(7)["result"]["ok"], "xr/stop b did not ack"
+
     send({"jsonrpc": "2.0", "method": "exit"})
     proc.wait(timeout=15)
 
-    assert len(frames) >= 2, f"expected >=2 streamFrames, got {len(frames)}"
+    assert len(frames) >= 4, f"expected >=4 streamFrames, got {len(frames)}"
     assert frames[0][0] == 1 and frames[1][0] == 2, f"unexpected seq order: {[f[0] for f in frames]}"
     assert frames[0][1] != frames[1][1], "frame did not change after moving a panel"
+    sids = {f[2] for f in frames}
+    assert "a" in sids and "b" in sids, f"expected per-session frames, got sessionIds {sids}"
     assert proc.returncode == 0, f"server exit code {proc.returncode}"
-    print(f"OK: {len(frames)} streamFrames; per-frame update changed the image")
+    print(f"OK: {len(frames)} streamFrames across sessions {sids}; per-frame update changed image")
     return 0
 
 

--- a/renderers/xr-composite/test/serve_smoke.py
+++ b/renderers/xr-composite/test/serve_smoke.py
@@ -96,6 +96,8 @@ def main() -> int:
     assert len(frames) >= 4, f"expected >=4 streamFrames, got {len(frames)}"
     assert frames[0][0] == 1 and frames[1][0] == 2, f"unexpected seq order: {[f[0] for f in frames]}"
     assert frames[0][1] != frames[1][1], "frame did not change after moving a panel"
+    # Default-session frames keep the id registered at initialize ("fs1"), not the literal "default".
+    assert frames[0][2] == "fs1", f"default frame should carry the initialized id, got {frames[0][2]}"
     sids = {f[2] for f in frames}
     assert "a" in sids and "b" in sids, f"expected per-session frames, got sessionIds {sids}"
     assert proc.returncode == 0, f"server exit code {proc.returncode}"


### PR DESCRIPTION
## Summary

Enhancement #2, **native side** (staged: PR B will do the JVM multiplexing). Re-architects `xr-composite --serve` from one global scene to **one shared Filament engine fanned across many sessions** — so the daemon can eventually multiplex sessions over a single child process instead of one process per session.

- **`SharedGl`** holds the `Engine` + `Renderer` + compiled materials for the whole process. `Compositor` becomes a per-session unit owning only its `SwapChain`/`Scene`/`View`/`Camera`/panels (its `engine_`/`renderer_`/material fields now *point at* the shared instances, so the render code is unchanged).
- The server keys sessions by **`sessionId`** (the daemon's `frameStreamId`): created on first `render`, torn down on the new **`xr/stop`**; `render` honors per-call `width`/`height` (recreating the session if the viewport changed). Omit `sessionId` → implicit `"default"` session (back-compat with single-session callers + one-shot).
- `streamFrame` carries `sessionId` for demuxing; `initialize` advertises `capabilities.multiSession`.
- Per-session teardown destroys view/scene/swapchain/camera/panels via the shared engine (clean — unlike whole-engine teardown, which asserts on order).

## Test plan

- [x] **Local, Filament/llvmpipe under Xvfb:** `serve_smoke.py` now drives **two concurrent sessions** over one process (frames tagged `a`/`b`/`default`, `xr/stop` each) + the default-session flow; asserts `multiSession` capability.
- [x] One-shot render still works.
- [x] Kotlin real-binary `XrRenderServerIntegrationTest` (default-session path) passes against the new binary — the existing single-session JVM client is unaffected.
- [x] Native build clean (clang/Filament).

## Next

PR B: JVM multiplexing — `XrSessionManager` holds one shared `XrRenderServer` and routes per `sessionId` (frame demux in `XrServerClient`), replacing the one-child-per-session model. Then enhancement #3 (`xr/structure` / `xr/a11y-overlay`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01X8ZwHy8Sgg5eVJzNqr1LMb)_