### PR TITLE
feat(cli): diff-semantics command — pixel-free semantics regression diff

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -129,6 +129,9 @@ dependencies {
 
   implementation(libs.kotlinx.serialization.json)
 
+  // Semantics text-diff engine + payload model for the `diff-semantics` command (issue #1785).
+  implementation(project(":data-layoutinspector-core"))
+
   // Ktor client (OkHttp engine) for downloading a bundle when the open arg is a URL. The explicit
   // okhttp dep pins the engine to OkHttp 5.x — ktor-client-okhttp 3.0.3 only declares a transitive
   // 4.12.0, so without this the catalog's okhttp 5 version is never selected.

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
@@ -72,6 +72,7 @@ fun main(args: Array<String>) {
     "list" -> ListCommand(allArgs).run()
     "render" -> RenderCommand(allArgs).run()
     "a11y" -> A11yCommand(allArgs).run()
+    "diff-semantics" -> SemanticsDiffCommand(allArgs).run()
     "extensions" -> ExtensionsCommand(allArgs).run()
     "profile" -> ProfileCommand(allArgs).run()
     "doctor" -> DoctorCommand(allArgs).run()
@@ -111,6 +112,9 @@ private fun printUsage() {
                        portable PNG+ZIP bundle (off by default).
       a11y             Render previews with the a11y data extension on and
                        print ATF findings (thin wrapper over `--with-extension a11y`)
+      diff-semantics   Diff two compose/semantics trees (base vs head) and report what
+                       changed semantically — a cheap, pixel-free regression signal:
+                       `compose-preview diff-semantics <base> <head> [--json] [--fail-on-change]`
       extensions       Introspect registered data extensions (`extensions list`)
       profile          Run a saved JSON profile: `compose-preview profile <path.json>`. A
                        profile bundles `extensions`, `filter`, `failOn`, and a chosen `report`

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/SemanticsDiffCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/SemanticsDiffCommand.kt
@@ -34,7 +34,7 @@ class SemanticsDiffCommand(
 ) {
   private val jsonOutput = "--json" in args
   private val failOnChange = "--fail-on-change" in args
-  private val positionals = args.filterNot { it.startsWith("-") }
+  private val positionals = collectOperands(args)
 
   fun run() {
     if ("--help" in args || "-h" in args) {
@@ -89,6 +89,32 @@ class SemanticsDiffCommand(
 /** Stable schema id for the JSON delta, re-exported for the usage text. */
 internal object ComposeSemanticsDiffSchema {
   val SCHEMA: String = SemanticsDelta().schema
+}
+
+/** This command's own boolean flags — everything else `--x` is treated as a valued option. */
+private val SEMANTICS_DIFF_BOOLEAN_FLAGS = setOf("--json", "--fail-on-change", "--help", "-h")
+
+/**
+ * Collect the two path operands, skipping the *value* of any valued option (e.g. a global `--module
+ * :app` that `Main` forwards) so it isn't mistaken for `<base>`/`<head>`. Tokens starting with `-`
+ * are flags: this command's own flags (and `--x=value` forms) consume one token, any other bare
+ * `--x` consumes its following value too.
+ */
+internal fun collectOperands(args: List<String>): List<String> {
+  val operands = mutableListOf<String>()
+  var i = 0
+  while (i < args.size) {
+    val arg = args[i]
+    when {
+      !arg.startsWith("-") -> {
+        operands.add(arg)
+        i++
+      }
+      arg in SEMANTICS_DIFF_BOOLEAN_FLAGS || arg.contains("=") -> i++
+      else -> i += 2 // valued option: skip the flag and its value
+    }
+  }
+  return operands
 }
 
 internal sealed interface SemanticsDiffOutcome {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/SemanticsDiffCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/SemanticsDiffCommand.kt
@@ -1,0 +1,172 @@
+package ee.schimke.composeai.cli
+
+import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsPayload
+import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsProduct
+import ee.schimke.composeai.data.layoutinspector.SemanticsDelta
+import ee.schimke.composeai.data.layoutinspector.SemanticsDiff
+import ee.schimke.composeai.data.layoutinspector.SemanticsNodeSummary
+import ee.schimke.composeai.io.SystemFileSystem
+import kotlin.system.exitProcess
+import kotlinx.serialization.json.Json
+import okio.FileSystem
+import okio.Path.Companion.toPath
+
+private val semanticsDiffJson = Json {
+  prettyPrint = true
+  encodeDefaults = true
+  ignoreUnknownKeys = true
+}
+
+/**
+ * `compose-preview diff-semantics <base> <head>` — diff two `compose/semantics` trees and report
+ * what changed semantically (issue #1785). The cheap, deterministic, pixel-free regression signal —
+ * the Compose analogue of Playwright's aria-snapshot diff — for the `compose-preview-review`
+ * skill's base-vs-head loop: render both sides, then diff their `compose-semantics.json` artifacts
+ * instead of reading two PNGs.
+ *
+ * Each argument is either a `compose-semantics.json` file or a directory containing one. Output is
+ * a human summary by default, or the versioned JSON [SemanticsDelta] with `--json`.
+ * `--fail-on-change` exits 2 when the trees differ, so CI can gate on it.
+ */
+class SemanticsDiffCommand(
+  private val args: List<String>,
+  private val fileSystem: FileSystem = SystemFileSystem,
+) {
+  private val jsonOutput = "--json" in args
+  private val failOnChange = "--fail-on-change" in args
+  private val positionals = args.filterNot { it.startsWith("-") }
+
+  fun run() {
+    if ("--help" in args || "-h" in args) {
+      printUsage()
+      return
+    }
+    if (positionals.size < 2) {
+      System.err.println(
+        "diff-semantics: expected <base> and <head> compose-semantics.json paths (or directories)"
+      )
+      printUsage()
+      exitProcess(64)
+    }
+    when (val outcome = computeSemanticsDiff(positionals[0], positionals[1], fileSystem)) {
+      is SemanticsDiffOutcome.Error -> {
+        System.err.println("diff-semantics: ${outcome.message}")
+        exitProcess(outcome.code)
+      }
+      is SemanticsDiffOutcome.Ok -> {
+        println(
+          if (jsonOutput) {
+            semanticsDiffJson.encodeToString(SemanticsDelta.serializer(), outcome.delta)
+          } else {
+            formatSemanticsDeltaHuman(outcome.delta)
+          }
+        )
+        if (failOnChange && !outcome.delta.isEmpty) exitProcess(2)
+      }
+    }
+  }
+
+  private fun printUsage() {
+    println(
+      """
+      compose-preview diff-semantics <base> <head> [--json] [--fail-on-change]
+
+      Diff two compose/semantics trees and report what changed semantically — added /
+      removed nodes and per-node field changes (text, label, role, testTag, overflow, …),
+      matched by each node's stable `ref`. A cheap, deterministic, pixel-free regression
+      signal; copy edits show as field changes on the same ref, not remove+add.
+
+      <base> / <head>  A compose-semantics.json file, or a directory containing one
+                       (the daemon writes build/compose-previews/data/<id>/compose-semantics.json).
+      --json           Emit the versioned ${ComposeSemanticsDiffSchema.SCHEMA} JSON delta.
+      --fail-on-change Exit 2 when the trees differ (for CI gating).
+      """
+        .trimIndent()
+    )
+  }
+}
+
+/** Stable schema id for the JSON delta, re-exported for the usage text. */
+internal object ComposeSemanticsDiffSchema {
+  val SCHEMA: String = SemanticsDelta().schema
+}
+
+internal sealed interface SemanticsDiffOutcome {
+  data class Ok(val delta: SemanticsDelta) : SemanticsDiffOutcome
+
+  data class Error(val message: String, val code: Int) : SemanticsDiffOutcome
+}
+
+internal fun computeSemanticsDiff(
+  baseArg: String,
+  headArg: String,
+  fileSystem: FileSystem = SystemFileSystem,
+): SemanticsDiffOutcome {
+  val base =
+    readSemanticsPayload(baseArg, fileSystem)
+      ?: return SemanticsDiffOutcome.Error(
+        "could not read base compose/semantics from '$baseArg'",
+        1,
+      )
+  val head =
+    readSemanticsPayload(headArg, fileSystem)
+      ?: return SemanticsDiffOutcome.Error(
+        "could not read head compose/semantics from '$headArg'",
+        1,
+      )
+  return SemanticsDiffOutcome.Ok(SemanticsDiff.diff(base, head))
+}
+
+/**
+ * Resolve [arg] to a compose-semantics.json file (directories resolve their canonical name) and
+ * parse it.
+ */
+internal fun readSemanticsPayload(
+  arg: String,
+  fileSystem: FileSystem = SystemFileSystem,
+): ComposeSemanticsPayload? {
+  val path = arg.toPath()
+  val file =
+    if (fileSystem.metadataOrNull(path)?.isDirectory == true) path / ComposeSemanticsProduct.FILE
+    else path
+  if (!fileSystem.exists(file)) return null
+  val text =
+    try {
+      fileSystem.read(file) { readUtf8() }
+    } catch (_: Throwable) {
+      return null
+    }
+  return try {
+    semanticsDiffJson.decodeFromString(ComposeSemanticsPayload.serializer(), text)
+  } catch (_: Throwable) {
+    null
+  }
+}
+
+internal fun formatSemanticsDeltaHuman(delta: SemanticsDelta): String {
+  if (delta.isEmpty) return "No semantic changes."
+  return buildString {
+      appendLine(
+        "${delta.added.size} added, ${delta.removed.size} removed, ${delta.changed.size} changed"
+      )
+      delta.removed.forEach { appendLine("  - removed ${describeNode(it)}") }
+      delta.added.forEach { appendLine("  + added ${describeNode(it)}") }
+      delta.changed.forEach { change ->
+        appendLine("  ~ ${change.anchor ?: change.ref}")
+        change.changes.forEach { field ->
+          appendLine("      ${field.field}: ${field.from ?: "∅"} → ${field.to ?: "∅"}")
+        }
+      }
+    }
+    .trimEnd()
+}
+
+private fun describeNode(node: SemanticsNodeSummary): String {
+  val parts =
+    listOfNotNull(
+      node.testTag?.let { "testTag=$it" },
+      node.role?.let { "role=$it" },
+      (node.text ?: node.label)?.let { "text=\"$it\"" },
+    )
+  return if (parts.isEmpty()) node.ref else "${node.ref} (${parts.joinToString(" ")})"
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/SemanticsDiffCommandTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/SemanticsDiffCommandTest.kt
@@ -68,6 +68,21 @@ class SemanticsDiffCommandTest {
   }
 
   @Test
+  fun collectOperandsSkipsValuedGlobalOptionValues() {
+    // `compose-preview --module :app diff-semantics base.json head.json --json` — Main strips the
+    // command token, so the command sees the global option + its value ahead of the two paths.
+    assertEquals(
+      listOf("base.json", "head.json"),
+      collectOperands(listOf("--module", ":app", "base.json", "head.json", "--json")),
+    )
+    // `--flag=value` form consumes one token; own boolean flags consume one; operands survive.
+    assertEquals(
+      listOf("a", "b"),
+      collectOperands(listOf("--variant=demoDebug", "a", "--fail-on-change", "b")),
+    )
+  }
+
+  @Test
   fun missingFileIsAnError() {
     val base = writeSemantics("base.json", "Hello")
     val outcome = computeSemanticsDiff(base, tmp.resolve("does-not-exist.json").absolutePath)

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/SemanticsDiffCommandTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/SemanticsDiffCommandTest.kt
@@ -1,0 +1,95 @@
+package ee.schimke.composeai.cli
+
+import java.nio.file.Files
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class SemanticsDiffCommandTest {
+
+  private val tmp = Files.createTempDirectory("semantics-diff").toFile()
+
+  @AfterTest
+  fun cleanup() {
+    tmp.deleteRecursively()
+  }
+
+  private fun writeSemantics(name: String, childText: String): String {
+    val file = tmp.resolve(name)
+    file.writeText(
+      """
+      {"root":{"nodeId":"1","boundsInRoot":"0,0,64,64","children":[
+        {"nodeId":"2","boundsInRoot":"0,0,20,20","testTag":"label","text":"$childText"}
+      ]}}
+      """
+        .trimIndent()
+    )
+    return file.absolutePath
+  }
+
+  @Test
+  fun textChangeIsReportedAsAFieldChangeOnTheSameRef() {
+    val base = writeSemantics("base.json", "Hello")
+    val head = writeSemantics("head.json", "Goodbye")
+
+    val outcome = computeSemanticsDiff(base, head)
+    assertTrue(outcome is SemanticsDiffOutcome.Ok, "expected Ok, got $outcome")
+    val delta = outcome.delta
+
+    assertTrue(delta.added.isEmpty())
+    assertTrue(delta.removed.isEmpty())
+    assertEquals(1, delta.changed.size)
+    val change = delta.changed.single()
+    assertEquals("r/tag:label", change.ref)
+    assertEquals("text", change.changes.single().field)
+    assertEquals("Hello", change.changes.single().from)
+    assertEquals("Goodbye", change.changes.single().to)
+  }
+
+  @Test
+  fun identicalTreesProduceAnEmptyDelta() {
+    val base = writeSemantics("a.json", "Same")
+    val head = writeSemantics("b.json", "Same")
+    val outcome = computeSemanticsDiff(base, head) as SemanticsDiffOutcome.Ok
+    assertTrue(outcome.delta.isEmpty)
+    assertEquals("No semantic changes.", formatSemanticsDeltaHuman(outcome.delta))
+  }
+
+  @Test
+  fun humanOutputNamesTheChangedFieldAndAnchor() {
+    val base = writeSemantics("base.json", "Hello")
+    val head = writeSemantics("head.json", "Goodbye")
+    val human =
+      formatSemanticsDeltaHuman((computeSemanticsDiff(base, head) as SemanticsDiffOutcome.Ok).delta)
+    assertTrue(human.contains("1 changed"), human)
+    assertTrue(human.contains("tag:label"), human)
+    assertTrue(human.contains("text: Hello → Goodbye"), human)
+  }
+
+  @Test
+  fun missingFileIsAnError() {
+    val base = writeSemantics("base.json", "Hello")
+    val outcome = computeSemanticsDiff(base, tmp.resolve("does-not-exist.json").absolutePath)
+    assertTrue(outcome is SemanticsDiffOutcome.Error)
+    assertEquals(1, outcome.code)
+  }
+
+  @Test
+  fun directoryArgResolvesTheCanonicalSemanticsFile() {
+    // The daemon writes build/compose-previews/data/<id>/compose-semantics.json — point at the dir.
+    val baseDir = tmp.resolve("base-id").also { it.mkdirs() }
+    baseDir
+      .resolve("compose-semantics.json")
+      .writeText("""{"root":{"nodeId":"1","boundsInRoot":"0,0,10,10","testTag":"x","text":"A"}}""")
+    val headDir = tmp.resolve("head-id").also { it.mkdirs() }
+    headDir
+      .resolve("compose-semantics.json")
+      .writeText("""{"root":{"nodeId":"1","boundsInRoot":"0,0,10,10","testTag":"x","text":"B"}}""")
+
+    val outcome = computeSemanticsDiff(baseDir.absolutePath, headDir.absolutePath)
+    assertTrue(outcome is SemanticsDiffOutcome.Ok)
+    val change = outcome.delta.changed.single()
+    assertEquals("text", change.changes.single().field)
+  }
+}


### PR DESCRIPTION
## Summary

Second surface for **#1785** (after the MCP `diff_semantics` tool, #1795): a CLI command for the `compose-preview-review` skill's base-vs-head loop — render both sides, then diff their `compose-semantics.json` artifacts instead of reading two PNGs. The cheap, deterministic, pixel-free regression signal (Compose's aria-snapshot-diff analogue), reusing the merged `SemanticsDiff` engine.

- **`compose-preview diff-semantics <base> <head> [--json] [--fail-on-change]`**. Each arg is a `compose-semantics.json` file or a directory containing one (the daemon writes `build/compose-previews/data/<id>/compose-semantics.json`).
- Human summary by default — added/removed nodes + per-node field changes, matched by each node's stable `ref` (so copy edits are field changes on the same ref, not remove+add). `--json` emits the versioned `compose-semantics-diff/v1` delta. `--fail-on-change` exits 2 when the trees differ, for CI gating.
- `:cli` gains a dependency on `:data-layoutinspector-core`.

## Test plan

- [x] `./gradlew :cli:test --tests "*SemanticsDiffCommandTest"` — text change → one field change on the same ref; identical trees → empty delta; human formatting names the field/anchor; missing file → error (exit 1); directory-arg resolves the canonical `compose-semantics.json`.
- [x] `:cli` `ktfmtCheck` clean.

## Scope / follow-up

- `history/diff mode=SEMANTICS` (needs the `compose/semantics` payload persisted per history entry) remains the last #1785 follow-up.