### PR TITLE
feat(xr): multiplex XR sessions over one shared process (JVM side)

### DIFF
--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/StreamRpcIntegrationTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/StreamRpcIntegrationTest.kt
@@ -617,10 +617,11 @@ class StreamRpcIntegrationTest {
   }
 }
 
-/** Fake native XR render server — returns monotonically-sequenced frames, tracks close. */
+/** Fake native XR render server — returns monotonically-sequenced frames, tracks stop/close. */
 private class FakeXrHandle : XrRenderServerHandle {
   private val seq = AtomicInteger(0)
   @Volatile var closed = false
+  val stopped = java.util.concurrent.ConcurrentHashMap.newKeySet<String>()
   override val capabilities = buildJsonObject {}
 
   // Distinct payload per frame so the registry doesn't dedup them to heartbeats.
@@ -628,12 +629,19 @@ private class FakeXrHandle : XrRenderServerHandle {
     seq.incrementAndGet().let { n -> XrStreamFrame(n.toLong(), 64, 48, "png", "data-$n") }
 
   override fun render(
+    sessionId: String,
     scene: kotlinx.serialization.json.JsonElement,
     sceneDir: String?,
     environment: String?,
+    width: Int?,
+    height: Int?,
   ) = frame()
 
-  override fun updatePanels(panels: JsonArray) = frame()
+  override fun updatePanels(sessionId: String, panels: JsonArray) = frame()
+
+  override fun stop(sessionId: String) {
+    stopped.add(sessionId)
+  }
 
   override fun close() {
     closed = true
@@ -643,8 +651,7 @@ private class FakeXrHandle : XrRenderServerHandle {
 private class FakeXrFactory : XrRenderServerFactory {
   val created = mutableListOf<FakeXrHandle>()
 
-  override fun start(width: Int, height: Int): XrRenderServerHandle =
-    FakeXrHandle().also { created.add(it) }
+  override fun start(): XrRenderServerHandle = FakeXrHandle().also { created.add(it) }
 }
 
 /** Mirror of the test-only host in InteractiveRpcIntegrationTest. */

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -341,9 +341,7 @@ fun runDaemon(
   val xrMaterials = xrBinary?.let { XrCompositeBinary.resolveMaterials(it) }
   val xrServerFactory =
     if (xrBinary != null && xrMaterials != null) {
-      XrRenderServerFactory { width, height ->
-        XrRenderServer.start(xrBinary, xrMaterials, width, height)
-      }
+      XrRenderServerFactory { XrRenderServer.start(xrBinary, xrMaterials) }
     } else {
       null
     }

--- a/docs/design/xr-spatial/RENDERER_SERVICE.md
+++ b/docs/design/xr-spatial/RENDERER_SERVICE.md
@@ -25,9 +25,12 @@ into a long-lived, extensible render service.
 > - **Frame gating** — XR streams register with `FrameStreamRegistry` and frames route through
 >   `consumeForStream` (per-stream fps cap via `xr/start.maxFps`, `stream/visibility` downshift,
 >   content dedup → `unchanged` heartbeats, keyframe-on-(re)show), the same gating `stream/start` gets.
+> - **Multi-session concurrency** — one shared Filament engine fans across sessions keyed by
+>   `sessionId`: the native `--serve` server holds per-session swapchain/scene/view (`xr/stop` tears a
+>   session down, engine kept), and `XrSessionManager` drives them all over a single child process,
+>   demuxing frames per `sessionId` in `XrServerClient` — replacing one-process-per-session.
 >
-> **Still to do:** native multi-session concurrency (one Filament engine fanned across sessions
-> rather than one child per session), and the `xr/structure` / `xr/a11y-overlay` data-product kinds.
+> **Still to do:** the `xr/structure` / `xr/a11y-overlay` data-product kinds.
 
 ## Motivation
 

--- a/renderers/xr-client/src/main/kotlin/ee/schimke/composeai/renderer/xr/client/XrRenderServer.kt
+++ b/renderers/xr-client/src/main/kotlin/ee/schimke/composeai/renderer/xr/client/XrRenderServer.kt
@@ -6,46 +6,54 @@ import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 
 /**
- * Abstraction over a running XR render server, so callers (and the daemon's session manager) can be
- * unit-tested against a fake without spawning the native process. [XrRenderServer] is the real,
- * process-backed implementation.
+ * Abstraction over a running, multi-session XR render server, so callers (and the daemon's session
+ * manager) can be unit-tested against a fake without spawning the native process. One handle fronts
+ * one native process that fans many sessions (keyed by `sessionId`) over a single Filament engine.
+ * [XrRenderServer] is the real, process-backed implementation.
  */
 public interface XrRenderServerHandle : AutoCloseable {
   /** The server's advertised `capabilities` from `initialize`. */
   public val capabilities: JsonObject
 
-  /** Render a full [scene] (serialized `SpatialScene`); returns the streamed frame. */
+  /** Render [scene] (serialized `SpatialScene`) for [sessionId]; returns the streamed frame. */
   public fun render(
+    sessionId: String,
     scene: JsonElement,
     sceneDir: String? = null,
     environment: String? = null,
+    width: Int? = null,
+    height: Int? = null,
   ): StreamFrame
 
-  /** Apply per-frame panel mutations and return the freshly streamed frame. */
-  public fun updatePanels(panels: JsonArray): StreamFrame
+  /** Apply per-frame panel mutations to [sessionId] and return the freshly streamed frame. */
+  public fun updatePanels(sessionId: String, panels: JsonArray): StreamFrame
+
+  /** Tear down [sessionId] on the server (its per-session GL resources; the engine is kept). */
+  public fun stop(sessionId: String)
 }
 
 /**
- * Spawns an [XrRenderServerHandle], or `null` when the native binary isn't available. Injected into
- * the session manager so tests substitute a fake. The default implementation resolves + spawns the
- * real `xr-composite --serve` via [XrRenderServer.startIfAvailable].
+ * Spawns the shared [XrRenderServerHandle], or `null` when the native binary isn't available.
+ * Injected into the session manager so tests substitute a fake. The default implementation resolves
+ * + spawns the real `xr-composite --serve` via [XrRenderServer.startIfAvailable]. The factory
+ *   starts one process for the whole manager; per-session sizing is passed on each `render`.
  */
 public fun interface XrRenderServerFactory {
-  public fun start(width: Int, height: Int): XrRenderServerHandle?
+  public fun start(): XrRenderServerHandle?
 
   public companion object {
     /** The production factory: resolve + spawn the real native server. */
-    public val Native: XrRenderServerFactory = XrRenderServerFactory { w, h ->
-      XrRenderServer.startIfAvailable(width = w, height = h)
+    public val Native: XrRenderServerFactory = XrRenderServerFactory {
+      XrRenderServer.startIfAvailable()
     }
   }
 }
 
 /**
- * A running native `xr-composite --serve` render server, driven over [XrServerClient]. This is the
- * single entry point the daemon's XR `RenderSession` backend holds: [start] resolves + spawns the
- * binary and performs the `initialize` handshake (so the returned instance is ready to render),
- * then [render] / [updatePanels] return the streamed frames and [close] tears the child down.
+ * A running native `xr-composite --serve` render server, driven over [XrServerClient]. [start]
+ * resolves + spawns the binary and performs the `initialize` handshake (so the returned instance is
+ * ready to render), then [render] / [updatePanels] / [stop] drive sessions by id and [close] tears
+ * the child down.
  *
  * The daemon owns one of these per native process and multiplexes sessions over it; keeping the
  * supervision here (resolve → spawn → initialize → close) keeps the daemon side a thin proxy.
@@ -57,34 +65,38 @@ private constructor(
   public override val capabilities: JsonObject,
 ) : XrRenderServerHandle {
 
-  /** Render a full [scene] (serialized `SpatialScene`); returns the streamed frame. */
   public override fun render(
+    sessionId: String,
     scene: JsonElement,
     sceneDir: String?,
     environment: String?,
-  ): StreamFrame = client.render(scene, sceneDir, environment)
+    width: Int?,
+    height: Int?,
+  ): StreamFrame = client.render(sessionId, scene, sceneDir, environment, width, height)
 
-  /** Apply per-frame panel mutations and return the freshly streamed frame. */
-  public override fun updatePanels(panels: JsonArray): StreamFrame = client.updatePanels(panels)
+  public override fun updatePanels(sessionId: String, panels: JsonArray): StreamFrame =
+    client.updatePanels(sessionId, panels)
+
+  public override fun stop(sessionId: String): Unit = client.stop(sessionId)
 
   override fun close(): Unit = client.close()
 
   public companion object {
     /**
      * Spawn `xr-composite --serve` from [binary] (+ [materials]) and complete `initialize`. Throws
-     * [XrServerException] if the handshake fails.
+     * [XrServerException] if the handshake fails. [width]/[height] are the process-level defaults
+     * for sessions that don't pass their own.
      */
     public fun start(
       binary: File,
       materials: File,
       width: Int = 1280,
       height: Int = 800,
-      frameStreamId: String? = null,
     ): XrRenderServer {
       val client = XrServerClient.spawn(binary, materials, width, height)
       val caps =
         try {
-          client.initialize(frameStreamId)
+          client.initialize()
         } catch (e: Throwable) {
           client.close()
           throw e
@@ -96,14 +108,10 @@ private constructor(
      * Convenience: resolve the binary + materials via [XrCompositeBinary] and [start], or `null` if
      * the binary isn't available (the XR render service is best-effort).
      */
-    public fun startIfAvailable(
-      width: Int = 1280,
-      height: Int = 800,
-      version: String? = null,
-    ): XrRenderServer? {
+    public fun startIfAvailable(version: String? = null): XrRenderServer? {
       val binary = XrCompositeBinary.resolve(version = version) ?: return null
       val materials = XrCompositeBinary.resolveMaterials(binary) ?: return null
-      return start(binary, materials, width, height)
+      return start(binary, materials)
     }
   }
 }

--- a/renderers/xr-client/src/main/kotlin/ee/schimke/composeai/renderer/xr/client/XrServerClient.kt
+++ b/renderers/xr-client/src/main/kotlin/ee/schimke/composeai/renderer/xr/client/XrServerClient.kt
@@ -42,13 +42,16 @@ public class XrServerException(message: String, cause: Throwable? = null) :
  * JSON-RPC framing the daemon's subprocess backend uses, demultiplexing id-matched responses from
  * `streamFrame` notifications on a background reader thread.
  *
- * This is the transport the daemon's future XR `RenderSession` backend wraps (RENDERER_SERVICE
- * RFC): the daemon owns/multiplexes one native process and proxies its frames to clients. The
- * client is constructed over raw streams so it is unit-testable without a real process; [spawn]
+ * **Multi-session:** one client drives one native process that fans many sessions over a single
+ * Filament engine. Every call carries a `sessionId`; the reader routes each `streamFrame` to a
+ * per-session queue so concurrent sessions don't cross frames. The daemon's XR backend holds one
+ * client and maps each `frameStreamId` to a session id.
+ *
+ * The client is constructed over raw streams so it is unit-testable without a real process; [spawn]
  * wires it to an actual `xr-composite --serve` child.
  *
- * Threading: safe for sequential calls from one caller thread. Each request blocks for its ack; the
- * matching `streamFrame` is collected from a queue the reader thread fills.
+ * Threading: safe for sequential calls per session from the caller; each request blocks for its
+ * ack, then collects the matching session's frame.
  */
 public class XrServerClient
 internal constructor(
@@ -60,7 +63,9 @@ internal constructor(
   private val json = Json { ignoreUnknownKeys = true }
   private val nextId = AtomicLong(1)
   private val responseSlots = ConcurrentHashMap<Long, LinkedBlockingQueue<JsonObject>>()
-  private val frames = LinkedBlockingQueue<StreamFrame>()
+  // One frame queue per sessionId — the reader routes `streamFrame` notifications here by
+  // sessionId.
+  private val frames = ConcurrentHashMap<String, LinkedBlockingQueue<StreamFrame>>()
   private val reader =
     Thread({ runReader(input) }, "xr-server-client-reader").apply {
       isDaemon = true
@@ -68,40 +73,66 @@ internal constructor(
     }
 
   /** Drives `initialize`; returns the server's `capabilities` object. */
-  public fun initialize(frameStreamId: String? = null, timeout: Duration = 60.seconds): JsonObject {
-    val params = buildJsonObject { frameStreamId?.let { put("frameStreamId", it) } }
-    val result = request("initialize", params, timeout)
+  public fun initialize(timeout: Duration = 60.seconds): JsonObject {
+    val result = request("initialize", buildJsonObject {}, timeout)
     return result["capabilities"]?.jsonObject
       ?: throw XrServerException("initialize: no capabilities in result ($result)")
   }
 
   /**
-   * Drives `render` with a full [scene] (a serialized `SpatialScene`). `sceneDir` resolves relative
-   * panel textures; `environment` overrides the backdrop. Returns the rendered [StreamFrame].
+   * Drives `render` for [sessionId] with a full [scene] (a serialized `SpatialScene`). `sceneDir`
+   * resolves relative panel textures; `environment` overrides the backdrop; `width`/`height` set
+   * the session viewport. Returns the rendered [StreamFrame].
    */
   public fun render(
+    sessionId: String,
     scene: JsonElement,
     sceneDir: String? = null,
     environment: String? = null,
+    width: Int? = null,
+    height: Int? = null,
     timeout: Duration = 60.seconds,
   ): StreamFrame {
     val params = buildJsonObject {
+      put("sessionId", sessionId)
       put("scene", scene)
       sceneDir?.let { put("sceneDir", it) }
       environment?.let { put("environment", it) }
+      width?.let { put("width", it) }
+      height?.let { put("height", it) }
     }
     request("render", params, timeout)
-    return awaitFrame(timeout)
+    return awaitFrame(sessionId, timeout)
   }
 
   /**
-   * Drives `xr/updatePanels` — each entry in [panels] is `{id, texture?, poseInRoot?, sizeDp?}`,
-   * mutating the held scene per-frame. Returns the freshly rendered [StreamFrame].
+   * Drives `xr/updatePanels` for [sessionId] — each entry in [panels] is `{id, texture?,
+   * poseInRoot?, sizeDp?}`, mutating that session's held scene. Returns the freshly rendered
+   * [StreamFrame].
    */
-  public fun updatePanels(panels: JsonArray, timeout: Duration = 60.seconds): StreamFrame {
-    val params = buildJsonObject { put("panels", panels) }
+  public fun updatePanels(
+    sessionId: String,
+    panels: JsonArray,
+    timeout: Duration = 60.seconds,
+  ): StreamFrame {
+    val params = buildJsonObject {
+      put("sessionId", sessionId)
+      put("panels", panels)
+    }
     request("xr/updatePanels", params, timeout)
-    return awaitFrame(timeout)
+    return awaitFrame(sessionId, timeout)
+  }
+
+  /** Sends `xr/stop` to tear down [sessionId] on the server (notification; no ack awaited). */
+  public fun stop(sessionId: String) {
+    sendFrame(
+      buildJsonObject {
+        put("jsonrpc", "2.0")
+        put("method", "xr/stop")
+        put("params", buildJsonObject { put("sessionId", sessionId) })
+      }
+    )
+    frames.remove(sessionId)
   }
 
   /** Sends `exit`; the server ends its loop and the process terminates. */
@@ -137,9 +168,12 @@ internal constructor(
 
   // ---- internals ----
 
-  private fun awaitFrame(timeout: Duration): StreamFrame =
-    frames.poll(timeout.inWholeMilliseconds, TimeUnit.MILLISECONDS)
-      ?: throw XrServerException("no streamFrame within $timeout")
+  private fun frameQueue(sessionId: String): LinkedBlockingQueue<StreamFrame> =
+    frames.computeIfAbsent(sessionId) { LinkedBlockingQueue() }
+
+  private fun awaitFrame(sessionId: String, timeout: Duration): StreamFrame =
+    frameQueue(sessionId).poll(timeout.inWholeMilliseconds, TimeUnit.MILLISECONDS)
+      ?: throw XrServerException("no streamFrame for session $sessionId within $timeout")
 
   private fun request(method: String, params: JsonObject, timeout: Duration): JsonObject {
     val id = nextId.getAndIncrement()
@@ -182,7 +216,10 @@ internal constructor(
         if (id != null) {
           responseSlots.computeIfAbsent(id) { LinkedBlockingQueue() }.put(obj)
         } else if (obj["method"]?.jsonPrimitive?.content == "streamFrame") {
-          obj["params"]?.jsonObject?.let { frames.put(parseFrame(it)) }
+          obj["params"]?.jsonObject?.let { p ->
+            val sid = p["sessionId"]?.jsonPrimitive?.content ?: "default"
+            frameQueue(sid).put(parseFrame(p))
+          }
         }
       }
     } catch (_: IOException) {

--- a/renderers/xr-client/src/main/kotlin/ee/schimke/composeai/renderer/xr/client/XrSessionManager.kt
+++ b/renderers/xr-client/src/main/kotlin/ee/schimke/composeai/renderer/xr/client/XrSessionManager.kt
@@ -5,38 +5,38 @@ import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 
 /**
- * Holds one native XR render server per live stream id (the daemon's `frameStreamId`), the
- * server-side analogue of the daemon's held interactive sessions: open a session for a scene, push
- * per-frame panel updates, and close it. Each session owns its own native process via the injected
- * [factory] (defaulting to the real `xr-composite --serve`); tests inject a fake.
+ * Multiplexes XR render sessions over a single shared native process. The first [open] lazily
+ * starts one [XrRenderServerHandle] via the injected [factory] (defaulting to the real
+ * `xr-composite --serve`); every session (the daemon's `frameStreamId`) is then driven on that one
+ * process/engine, keyed by `sessionId`. Tests inject a fake factory.
  *
- * The daemon's JSON-RPC layer (the next increment) wraps this: `xr/start` → [open],
- * `xr/updatePanels` → [updatePanels], `xr/stop` → [close], and feeds each returned [StreamFrame]
- * into its frame-stream registry. Keeping the lifecycle here keeps that wiring a thin adapter.
+ * The daemon's JSON-RPC layer wraps this: `xr/start` → [open], `xr/updatePanels` → [updatePanels],
+ * `xr/stop` → [close], and feeds each returned [StreamFrame] into its frame-stream registry.
  *
  * Threading: safe for concurrent calls on distinct ids; calls for one id are expected to be
  * serialised by the caller (the daemon dispatches per-stream from one thread).
  */
 public class XrSessionManager(
-  private val factory: XrRenderServerFactory = XrRenderServerFactory.Native,
-  private val defaultWidth: Int = 1280,
-  private val defaultHeight: Int = 800,
+  private val factory: XrRenderServerFactory = XrRenderServerFactory.Native
 ) : AutoCloseable {
 
-  private val sessions = ConcurrentHashMap<String, XrRenderServerHandle>()
+  // The one shared native process, started on first open(); null until then / after close().
+  @Volatile private var server: XrRenderServerHandle? = null
+  private val openIds = ConcurrentHashMap.newKeySet<String>()
+  private val lock = Any()
 
   /** Number of live sessions — for diagnostics / tests. */
   public val activeCount: Int
-    get() = sessions.size
+    get() = openIds.size
 
   /** True if a session is currently open for [id]. */
-  public fun isOpen(id: String): Boolean = sessions.containsKey(id)
+  public fun isOpen(id: String): Boolean = openIds.contains(id)
 
   /**
-   * Open a session for [id] and render [scene], returning the first frame — or `null` when the
-   * native server isn't available (XR is best-effort, so the caller degrades gracefully). [width] /
-   * [height] set the render viewport (falling back to the manager defaults). Closes any prior
-   * session held under the same [id] first.
+   * Open a session for [id] and render [scene] on the shared server, returning the first frame — or
+   * `null` when the native server isn't available (XR is best-effort, so the caller degrades
+   * gracefully). [width]/[height] set the session viewport. Re-opening an existing [id] replaces
+   * its scene.
    */
   public fun open(
     id: String,
@@ -46,15 +46,16 @@ public class XrSessionManager(
     width: Int? = null,
     height: Int? = null,
   ): StreamFrame? {
-    close(id)
-    val server = factory.start(width ?: defaultWidth, height ?: defaultHeight) ?: return null
-    sessions[id] = server
-    return try {
-      server.render(scene, sceneDir, environment)
-    } catch (t: Throwable) {
-      close(id)
-      throw t
-    }
+    val srv = ensureServer() ?: return null
+    val frame =
+      try {
+        srv.render(id, scene, sceneDir, environment, width, height)
+      } catch (t: Throwable) {
+        close(id)
+        throw t
+      }
+    openIds.add(id)
+    return frame
   }
 
   /**
@@ -62,25 +63,55 @@ public class XrSessionManager(
    * [XrServerException] if no session is open for [id].
    */
   public fun updatePanels(id: String, panels: JsonArray): StreamFrame {
-    val server = sessions[id] ?: throw XrServerException("no XR session open for id=$id")
-    return server.updatePanels(panels)
+    val srv = server
+    if (srv == null || !openIds.contains(id)) {
+      throw XrServerException("no XR session open for id=$id")
+    }
+    return srv.updatePanels(id, panels)
   }
 
   /** Close and drop the session for [id]; no-op if none is open. */
   public fun close(id: String) {
-    sessions.remove(id)?.let { server ->
+    if (!openIds.remove(id)) return
+    try {
+      server?.stop(id)
+    } catch (t: Throwable) {
+      System.err.println(
+        "XrSessionManager: stop($id) threw ${t.javaClass.simpleName}: ${t.message}; continuing"
+      )
+    }
+  }
+
+  /** Close every live session and the shared process — call on daemon shutdown. */
+  override fun close() {
+    val srv: XrRenderServerHandle?
+    synchronized(lock) {
+      srv = server
+      server = null
+    }
+    openIds.clear()
+    srv?.let {
       try {
-        server.close()
+        it.close()
       } catch (t: Throwable) {
         System.err.println(
-          "XrSessionManager: close($id) threw ${t.javaClass.simpleName}: ${t.message}; continuing"
+          "XrSessionManager: server close threw ${t.javaClass.simpleName}: ${t.message}; continuing"
         )
       }
     }
   }
 
-  /** Close every live session — call on daemon shutdown. */
-  override fun close() {
-    sessions.keys.toList().forEach(::close)
+  private fun ensureServer(): XrRenderServerHandle? {
+    server?.let {
+      return it
+    }
+    synchronized(lock) {
+      server?.let {
+        return it
+      }
+      val started = factory.start() ?: return null
+      server = started
+      return started
+    }
   }
 }

--- a/renderers/xr-client/src/main/kotlin/ee/schimke/composeai/renderer/xr/client/XrSessionManager.kt
+++ b/renderers/xr-client/src/main/kotlin/ee/schimke/composeai/renderer/xr/client/XrSessionManager.kt
@@ -51,7 +51,11 @@ public class XrSessionManager(
       try {
         srv.render(id, scene, sceneDir, environment, width, height)
       } catch (t: Throwable) {
-        close(id)
+        // The native server inserts the session before scene setup, so a failed first render can
+        // leave a session allocated. close(id) is a no-op here (id isn't registered yet), so stop
+        // it
+        // directly — best-effort, since on a transport failure the pipe may already be dead.
+        runCatching { srv.stop(id) }
         throw t
       }
     openIds.add(id)

--- a/renderers/xr-client/src/test/kotlin/ee/schimke/composeai/renderer/xr/client/XrRenderServerIntegrationTest.kt
+++ b/renderers/xr-client/src/test/kotlin/ee/schimke/composeai/renderer/xr/client/XrRenderServerIntegrationTest.kt
@@ -39,49 +39,79 @@ class XrRenderServerIntegrationTest {
     val fixtureDir = File(repoRoot(), "vscode-extension/preview-harness/fixtures/spatial-scene")
     val scene = json.parseToJsonElement(File(fixtureDir, "scene.json").readText())
 
-    XrRenderServer.start(binary, materials!!, width = 640, height = 400).use { server ->
+    XrRenderServer.start(binary, materials!!).use { server ->
       assertEquals(true, server.capabilities["render"].toString().toBoolean())
 
-      val first = server.render(scene, sceneDir = fixtureDir.path)
+      val first = server.render("s1", scene, sceneDir = fixtureDir.path, width = 640, height = 400)
       assertEquals(1L, first.seq)
       assertTrue(first.width > 0 && first.height > 0)
       assertTrue(first.dataBase64.isNotEmpty())
 
-      val moved =
-        server.updatePanels(
-          buildJsonArray {
-            add(
-              buildJsonObject {
-                put("id", "top")
-                put(
-                  "poseInRoot",
-                  buildJsonObject {
-                    put(
-                      "translation",
-                      buildJsonObject {
-                        put("x", 140)
-                        put("y", 180)
-                        put("z", 0)
-                      },
-                    )
-                    put(
-                      "rotation",
-                      buildJsonObject {
-                        put("x", 0)
-                        put("y", 0)
-                        put("z", 0)
-                        put("w", 1)
-                      },
-                    )
-                  },
-                )
-              }
-            )
-          }
-        )
+      val moved = server.updatePanels("s1", movePanel("top", 140, 180))
       assertEquals(2L, moved.seq)
       // Moving a panel must change the rendered image.
       assertTrue(moved.dataBase64 != first.dataBase64, "frame did not change after moving a panel")
+
+      server.stop("s1")
     }
+  }
+
+  @Test
+  fun multipleSessionsShareOneProcess() {
+    val binary = XrCompositeBinary.resolve()
+    assumeTrue("XR_COMPOSITE_BIN not set / not found — skipping native integration", binary != null)
+    val materials = XrCompositeBinary.resolveMaterials(binary!!)
+    assumeTrue("xr-composite materials not found — skipping", materials != null)
+
+    val fixtureDir = File(repoRoot(), "vscode-extension/preview-harness/fixtures/spatial-scene")
+    val scene = json.parseToJsonElement(File(fixtureDir, "scene.json").readText())
+
+    // One process, two concurrent sessions of different sizes — frames must not cross.
+    XrRenderServer.start(binary, materials!!).use { server ->
+      val a = server.render("a", scene, sceneDir = fixtureDir.path, width = 480, height = 320)
+      val b = server.render("b", scene, sceneDir = fixtureDir.path, width = 640, height = 400)
+      assertEquals(480, a.width)
+      assertEquals(320, a.height)
+      assertEquals(640, b.width)
+      assertEquals(400, b.height)
+      assertTrue(a.dataBase64.isNotEmpty() && b.dataBase64.isNotEmpty())
+
+      val a2 = server.updatePanels("a", movePanel("top", 60, 90))
+      assertEquals(480, a2.width) // still session a's viewport
+      assertTrue(a2.dataBase64 != a.dataBase64)
+
+      server.stop("a")
+      server.stop("b")
+    }
+  }
+
+  private fun movePanel(id: String, x: Int, y: Int) = buildJsonArray {
+    add(
+      buildJsonObject {
+        put("id", id)
+        put(
+          "poseInRoot",
+          buildJsonObject {
+            put(
+              "translation",
+              buildJsonObject {
+                put("x", x)
+                put("y", y)
+                put("z", 0)
+              },
+            )
+            put(
+              "rotation",
+              buildJsonObject {
+                put("x", 0)
+                put("y", 0)
+                put("z", 0)
+                put("w", 1)
+              },
+            )
+          },
+        )
+      }
+    )
   }
 }

--- a/renderers/xr-client/src/test/kotlin/ee/schimke/composeai/renderer/xr/client/XrServerClientTest.kt
+++ b/renderers/xr-client/src/test/kotlin/ee/schimke/composeai/renderer/xr/client/XrServerClientTest.kt
@@ -68,8 +68,11 @@ class XrServerClientTest {
               "render",
               "xr/updatePanels" -> {
                 seq += 1
-                // Push the frame first (as the native server does), then the ack.
-                writeFrame(serverOut, streamFrame(seq, "frame-$seq"))
+                val sid =
+                  req["params"]?.jsonObject?.get("sessionId")?.jsonPrimitive?.content ?: "default"
+                // Push the frame first (as the native server does), tagged with the session, then
+                // ack.
+                writeFrame(serverOut, streamFrame(seq, "frame-$seq", sid))
                 writeFrame(
                   serverOut,
                   result(
@@ -111,13 +114,14 @@ class XrServerClientTest {
       put("camera", buildJsonObject { put("kind", "orbit") })
       put("panels", buildJsonArray {})
     }
-    val f1 = client.render(scene, sceneDir = ".")
+    val f1 = client.render("s1", scene, sceneDir = ".")
     assertEquals(1L, f1.seq)
     assertEquals("png", f1.encoding)
     assertEquals("frame-1", f1.dataBase64)
 
     val f2 =
       client.updatePanels(
+        "s1",
         buildJsonArray {
           add(
             buildJsonObject {
@@ -146,7 +150,7 @@ class XrServerClientTest {
               )
             }
           )
-        }
+        },
       )
     assertEquals(2L, f2.seq)
     assertEquals("frame-2", f2.dataBase64)
@@ -163,20 +167,22 @@ class XrServerClientTest {
     put("result", result)
   }
 
-  private fun streamFrame(seq: Long, data: String): JsonObject = buildJsonObject {
-    put("jsonrpc", "2.0")
-    put("method", "streamFrame")
-    put(
-      "params",
-      buildJsonObject {
-        put("encoding", "png")
-        put("width", 64)
-        put("height", 48)
-        put("seq", seq)
-        put("data", data)
-      },
-    )
-  }
+  private fun streamFrame(seq: Long, data: String, sessionId: String): JsonObject =
+    buildJsonObject {
+      put("jsonrpc", "2.0")
+      put("method", "streamFrame")
+      put(
+        "params",
+        buildJsonObject {
+          put("encoding", "png")
+          put("width", 64)
+          put("height", 48)
+          put("seq", seq)
+          put("sessionId", sessionId)
+          put("data", data)
+        },
+      )
+    }
 
   private fun writeFrame(out: OutputStream, message: JsonObject) {
     val payload = json.encodeToString(JsonObject.serializer(), message).toByteArray(Charsets.UTF_8)

--- a/renderers/xr-client/src/test/kotlin/ee/schimke/composeai/renderer/xr/client/XrSessionManagerTest.kt
+++ b/renderers/xr-client/src/test/kotlin/ee/schimke/composeai/renderer/xr/client/XrSessionManagerTest.kt
@@ -20,6 +20,7 @@ class XrSessionManagerTest {
   private class FakeServer : XrRenderServerHandle {
     val seq = AtomicLong(0)
     var closed = false
+    var failNextRender = false
     val stopped = mutableListOf<String>()
     val renders = mutableListOf<RenderCall>()
     override val capabilities: JsonObject = buildJsonObject {}
@@ -35,6 +36,7 @@ class XrSessionManagerTest {
       height: Int?,
     ): StreamFrame {
       renders.add(RenderCall(sessionId, width, height))
+      if (failNextRender) throw XrServerException("render boom")
       return frame()
     }
 
@@ -118,6 +120,19 @@ class XrSessionManagerTest {
     val call = server.renders.single()
     assertEquals(640, call.width)
     assertEquals(400, call.height)
+  }
+
+  @Test
+  fun failedOpenStopsThePartialSession() {
+    val server = FakeServer().apply { failNextRender = true }
+    val manager = XrSessionManager(CountingFactory(server))
+
+    assertFailsWith<XrServerException> { manager.open("s1", scene) }
+
+    assertFalse(manager.isOpen("s1"))
+    assertEquals(0, manager.activeCount)
+    // The native server may have allocated the session before the render failed; it's stopped.
+    assertEquals(listOf("s1"), server.stopped)
   }
 
   @Test

--- a/renderers/xr-client/src/test/kotlin/ee/schimke/composeai/renderer/xr/client/XrSessionManagerTest.kt
+++ b/renderers/xr-client/src/test/kotlin/ee/schimke/composeai/renderer/xr/client/XrSessionManagerTest.kt
@@ -15,28 +15,56 @@ import kotlinx.serialization.json.buildJsonObject
 
 class XrSessionManagerTest {
 
+  private data class RenderCall(val sessionId: String, val width: Int?, val height: Int?)
+
   private class FakeServer : XrRenderServerHandle {
     val seq = AtomicLong(0)
     var closed = false
+    val stopped = mutableListOf<String>()
+    val renders = mutableListOf<RenderCall>()
     override val capabilities: JsonObject = buildJsonObject {}
 
     private fun frame() = StreamFrame(seq.incrementAndGet(), 64, 48, "png", "data")
 
-    override fun render(scene: JsonElement, sceneDir: String?, environment: String?) = frame()
+    override fun render(
+      sessionId: String,
+      scene: JsonElement,
+      sceneDir: String?,
+      environment: String?,
+      width: Int?,
+      height: Int?,
+    ): StreamFrame {
+      renders.add(RenderCall(sessionId, width, height))
+      return frame()
+    }
 
-    override fun updatePanels(panels: JsonArray) = frame()
+    override fun updatePanels(sessionId: String, panels: JsonArray) = frame()
+
+    override fun stop(sessionId: String) {
+      stopped.add(sessionId)
+    }
 
     override fun close() {
       closed = true
     }
   }
 
+  /** Factory that hands out one fixed server (or null) and counts how many times it was started. */
+  private class CountingFactory(private val server: XrRenderServerHandle?) : XrRenderServerFactory {
+    var starts = 0
+
+    override fun start(): XrRenderServerHandle? {
+      starts++
+      return server
+    }
+  }
+
   private val scene: JsonElement = buildJsonObject {}
 
   @Test
-  fun openRendersFirstFrameAndUpdatePanelsAdvances() {
+  fun openRendersFirstFrame_updatePanelsAdvances_closeStops() {
     val server = FakeServer()
-    val manager = XrSessionManager(factory = { _, _ -> server })
+    val manager = XrSessionManager(CountingFactory(server))
 
     val first = manager.open("s1", scene, sceneDir = ".")
     assertEquals(1L, first?.seq)
@@ -48,12 +76,29 @@ class XrSessionManagerTest {
 
     manager.close("s1")
     assertFalse(manager.isOpen("s1"))
-    assertTrue(server.closed)
+    assertEquals(0, manager.activeCount)
+    // close(id) stops the session on the shared server; it does NOT tear the process down.
+    assertEquals(listOf("s1"), server.stopped)
+    assertFalse(server.closed)
+  }
+
+  @Test
+  fun sessionsShareOneServerProcess() {
+    val server = FakeServer()
+    val factory = CountingFactory(server)
+    val manager = XrSessionManager(factory)
+
+    manager.open("a", scene)
+    manager.open("b", scene)
+
+    assertEquals(2, manager.activeCount)
+    assertEquals(1, factory.starts) // one shared native process for both sessions
+    assertEquals(setOf("a", "b"), server.renders.map { it.sessionId }.toSet())
   }
 
   @Test
   fun openReturnsNullWhenServerUnavailable() {
-    val manager = XrSessionManager(factory = { _, _ -> null })
+    val manager = XrSessionManager(CountingFactory(null))
     assertNull(manager.open("s1", scene))
     assertFalse(manager.isOpen("s1"))
     assertEquals(0, manager.activeCount)
@@ -61,70 +106,30 @@ class XrSessionManagerTest {
 
   @Test
   fun updatePanelsOnUnknownSessionThrows() {
-    val manager = XrSessionManager(factory = { _, _ -> FakeServer() })
+    val manager = XrSessionManager(CountingFactory(FakeServer()))
     assertFailsWith<XrServerException> { manager.updatePanels("missing", buildJsonArray {}) }
   }
 
   @Test
-  fun reopeningSameIdClosesThePriorSession() {
-    val first = FakeServer()
-    val second = FakeServer()
-    val servers = ArrayDeque(listOf(first, second))
-    val manager = XrSessionManager(factory = { _, _ -> servers.removeFirst() })
-
-    manager.open("s1", scene)
-    manager.open("s1", scene)
-    assertTrue(first.closed, "prior session should be closed on reopen")
-    assertFalse(second.closed)
-    assertEquals(1, manager.activeCount)
-  }
-
-  @Test
-  fun passesRequestedDimensionsToFactory() {
-    var seenW = 0
-    var seenH = 0
-    val manager =
-      XrSessionManager(
-        factory = { w, h ->
-          seenW = w
-          seenH = h
-          FakeServer()
-        }
-      )
+  fun passesRequestedDimensionsToRender() {
+    val server = FakeServer()
+    val manager = XrSessionManager(CountingFactory(server))
     manager.open("s1", scene, width = 640, height = 400)
-    assertEquals(640, seenW)
-    assertEquals(400, seenH)
+    val call = server.renders.single()
+    assertEquals(640, call.width)
+    assertEquals(400, call.height)
   }
 
   @Test
-  fun fallsBackToDefaultDimensionsWhenUnset() {
-    var seenW = 0
-    var seenH = 0
-    val manager =
-      XrSessionManager(
-        factory = { w, h ->
-          seenW = w
-          seenH = h
-          FakeServer()
-        },
-        defaultWidth = 800,
-        defaultHeight = 600,
-      )
-    manager.open("s1", scene)
-    assertEquals(800, seenW)
-    assertEquals(600, seenH)
-  }
-
-  @Test
-  fun closeAllClosesEveryLiveSession() {
-    val servers = mutableListOf<FakeServer>()
-    val manager = XrSessionManager(factory = { _, _ -> FakeServer().also { servers.add(it) } })
+  fun closeClosesTheSharedServer() {
+    val server = FakeServer()
+    val manager = XrSessionManager(CountingFactory(server))
     manager.open("a", scene)
     manager.open("b", scene)
     assertEquals(2, manager.activeCount)
 
     manager.close()
     assertEquals(0, manager.activeCount)
-    assertTrue(servers.all { it.closed })
+    assertTrue(server.closed)
   }
 }


### PR DESCRIPTION
## Summary

Completes enhancement #2 (PR B — JVM side; PR A #1802 did the native side). The daemon now drives **all XR sessions over one shared `xr-composite --serve` process**, instead of spawning a child per session.

- **`XrServerClient`** — every call carries a `sessionId`; `render`/`updatePanels` take it, a new `stop(sessionId)` sends `xr/stop`, and `streamFrame` notifications are **demuxed into per-session frame queues** by `sessionId` so concurrent sessions never cross frames.
- **`XrRenderServerHandle` / `XrRenderServer`** — per-session `render(sessionId,…)` / `updatePanels(sessionId,…)` / `stop(sessionId)`; the factory now `start()`s one process (sizing is per-`render`, not per-process).
- **`XrSessionManager`** — holds one lazily-started shared server; `open`/`updatePanels`/`close` route by `sessionId`, `closeAll` tears down the single process. **Public API unchanged** (`open`/`updatePanels`/`close`/`closeAll`/`isOpen`/`activeCount`), so `JsonRpcServer` is untouched — only `DaemonMain`'s factory lambda adjusts.

## Test plan

- [x] `:renderer-xr-client:test` — `XrServerClientTest` (sessionId plumbing + demux), `XrSessionManagerTest` rewritten (one shared server across sessions, dims→`render`, `close`→`stop` vs `closeAll`→server close), `XrCompositeBinaryTest`.
- [x] `:daemon:core:test` `StreamRpcIntegrationTest` (fake handle updated to per-session API).
- [x] `:daemon:desktop` compiles; ktfmt clean across all three modules.
- [x] **Real-binary `XrRenderServerIntegrationTest` under Xvfb** — single-session flow **and** a new `multipleSessionsShareOneProcess` (two different-sized sessions `a`/`b` over one process, viewports preserved, frames don't cross).

## Remaining

Enhancement #3: the `xr/structure` / `xr/a11y-overlay` data-product kinds.


---
_Generated by [Claude Code](https://claude.ai/code/session_01X8ZwHy8Sgg5eVJzNqr1LMb)_