### PR TITLE
feat(xr): xr/structure data product (held panel tree + poses)

### DIFF
--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -65,6 +65,8 @@ import ee.schimke.composeai.daemon.protocol.UiMode
 import ee.schimke.composeai.daemon.protocol.XrStartParams
 import ee.schimke.composeai.daemon.protocol.XrStartResult
 import ee.schimke.composeai.daemon.protocol.XrStopParams
+import ee.schimke.composeai.daemon.protocol.XrStructureParams
+import ee.schimke.composeai.daemon.protocol.XrStructureResult
 import ee.schimke.composeai.daemon.protocol.XrUpdatePanelsParams
 import ee.schimke.composeai.io.SystemFileSystem
 import ee.schimke.composeai.renderer.xr.client.StreamFrame as XrStreamFrame
@@ -694,6 +696,7 @@ class JsonRpcServer(
       "interactive/start" -> handleInteractiveStart(req)
       "stream/start" -> handleStreamStart(req)
       "xr/start" -> handleXrStart(req)
+      "xr/structure" -> handleXrStructure(req)
       "recording/start" -> handleRecordingStart(req)
       "recording/stop" -> handleRecordingStop(req)
       "recording/encode" -> handleRecordingEncode(req)
@@ -2315,6 +2318,41 @@ class JsonRpcServer(
         return
       }
     emitXrFrame(params.frameStreamId, frame)
+  }
+
+  private fun handleXrStructure(req: JsonRpcRequest) {
+    val manager = xrSessions
+    if (manager == null) {
+      sendErrorResponse(
+        id = req.id,
+        code = ERR_METHOD_NOT_FOUND,
+        message = "xr/structure: XR rendering is not available on this daemon",
+      )
+      return
+    }
+    val params =
+      try {
+        decodeParams(req.params, XrStructureParams.serializer())
+      } catch (e: Throwable) {
+        sendErrorResponse(req.id, ERR_INVALID_PARAMS, "invalid xr/structure params: ${e.message}")
+        return
+      }
+    val structure = manager.structure(params.frameStreamId)
+    if (structure == null) {
+      sendErrorResponse(
+        req.id,
+        ERR_INVALID_PARAMS,
+        "xr/structure: no session open for ${params.frameStreamId}",
+      )
+      return
+    }
+    sendResponse(
+      req.id,
+      encode(
+        XrStructureResult.serializer(),
+        XrStructureResult(frameStreamId = params.frameStreamId, structure = structure),
+      ),
+    )
   }
 
   private fun handleXrStop(params: XrStopParams) {

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -2211,3 +2211,12 @@ data class XrStartResult(
 
 /** `xr/stop` — close the held XR session for [frameStreamId]. */
 @Serializable data class XrStopParams(val frameStreamId: String)
+
+/** `xr/structure` — fetch the held scene's panel tree + poses for [frameStreamId]. */
+@Serializable data class XrStructureParams(val frameStreamId: String)
+
+/**
+ * `xr/structure` result — the `SpatialScene` structure (panel tree + poses) the session was opened
+ * with, inline as JSON (mirrors `a11y/hierarchy`).
+ */
+@Serializable data class XrStructureResult(val frameStreamId: String, val structure: JsonElement)

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/StreamRpcIntegrationTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/StreamRpcIntegrationTest.kt
@@ -570,6 +570,17 @@ class StreamRpcIntegrationTest {
     assertEquals(1L, f1["params"]!!.jsonObject["seq"]?.jsonPrimitive?.longOrNull)
     assertNotNull(f1["params"]!!.jsonObject["payloadBase64"]?.jsonPrimitive?.contentOrNull)
 
+    // xr/structure returns the held scene (panel tree + poses), mirroring a11y/hierarchy.
+    writeFrame(
+      out,
+      """{"jsonrpc":"2.0","id":22,"method":"xr/structure","params":{"frameStreamId":"$streamId"}}""",
+    )
+    val structResp = pollUntil(received) { it["id"]?.jsonPrimitive?.intOrNull == 22 }
+    assertNotNull("xr/structure must respond", structResp)
+    val structure = structResp!!["result"]!!.jsonObject["structure"]!!.jsonObject
+    assertEquals("dp", structure["units"]?.jsonPrimitive?.contentOrNull)
+    assertEquals("orbit", structure["camera"]!!.jsonObject["kind"]?.jsonPrimitive?.contentOrNull)
+
     writeFrame(
       out,
       """{"jsonrpc":"2.0","method":"xr/updatePanels","params":{

--- a/docs/design/xr-spatial/RENDERER_SERVICE.md
+++ b/docs/design/xr-spatial/RENDERER_SERVICE.md
@@ -30,7 +30,12 @@ into a long-lived, extensible render service.
 >   session down, engine kept), and `XrSessionManager` drives them all over a single child process,
 >   demuxing frames per `sessionId` in `XrServerClient` — replacing one-process-per-session.
 >
-> **Still to do:** the `xr/structure` / `xr/a11y-overlay` data-product kinds.
+> - **`xr/structure` data product** — the daemon serves the held session's `SpatialScene` (panel
+>   tree + poses) as inline JSON via the `xr/structure` request, from its own copy of the scene
+>   (no native round-trip), mirroring `a11y/hierarchy`.
+>
+> **Still to do:** the `xr/a11y-overlay` data-product kind — deferred until how XR a11y/TalkBack
+> surfaces is understood (it mirrors `a11y/overlay`, a rendered overlay PNG).
 
 ## Motivation
 

--- a/renderers/xr-client/src/main/kotlin/ee/schimke/composeai/renderer/xr/client/XrSessionManager.kt
+++ b/renderers/xr-client/src/main/kotlin/ee/schimke/composeai/renderer/xr/client/XrSessionManager.kt
@@ -23,6 +23,10 @@ public class XrSessionManager(
   // The one shared native process, started on first open(); null until then / after close().
   @Volatile private var server: XrRenderServerHandle? = null
   private val openIds = ConcurrentHashMap.newKeySet<String>()
+  // The scene each session was opened with — the daemon's view of the layout, served as the
+  // `xr/structure` data product (panel tree + poses, mirrors a11y/hierarchy). Per-frame
+  // `updatePanels` deltas are not merged in yet; this is the declared layout from `open`.
+  private val scenes = ConcurrentHashMap<String, JsonElement>()
   private val lock = Any()
 
   /** Number of live sessions — for diagnostics / tests. */
@@ -59,8 +63,15 @@ public class XrSessionManager(
         throw t
       }
     openIds.add(id)
+    scenes[id] = scene
     return frame
   }
+
+  /**
+   * The held scene for [id] — the `xr/structure` data product (panel tree + poses as inline JSON).
+   * `null` when no session is open for [id].
+   */
+  public fun structure(id: String): JsonElement? = scenes[id]
 
   /**
    * Push per-frame panel mutations into the session for [id], returning the fresh frame. Throws
@@ -76,6 +87,7 @@ public class XrSessionManager(
 
   /** Close and drop the session for [id]; no-op if none is open. */
   public fun close(id: String) {
+    scenes.remove(id)
     if (!openIds.remove(id)) return
     try {
       server?.stop(id)
@@ -94,6 +106,7 @@ public class XrSessionManager(
       server = null
     }
     openIds.clear()
+    scenes.clear()
     srv?.let {
       try {
         it.close()

--- a/renderers/xr-client/src/test/kotlin/ee/schimke/composeai/renderer/xr/client/XrSessionManagerTest.kt
+++ b/renderers/xr-client/src/test/kotlin/ee/schimke/composeai/renderer/xr/client/XrSessionManagerTest.kt
@@ -12,6 +12,7 @@ import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 
 class XrSessionManagerTest {
 
@@ -133,6 +134,19 @@ class XrSessionManagerTest {
     assertEquals(0, manager.activeCount)
     // The native server may have allocated the session before the render failed; it's stopped.
     assertEquals(listOf("s1"), server.stopped)
+  }
+
+  @Test
+  fun retainsSceneAsStructureUntilClosed() {
+    val server = FakeServer()
+    val manager = XrSessionManager(CountingFactory(server))
+    val scene = buildJsonObject { put("units", "dp") }
+
+    manager.open("s1", scene)
+    assertEquals(scene, manager.structure("s1"))
+
+    manager.close("s1")
+    assertNull(manager.structure("s1"))
   }
 
   @Test

--- a/renderers/xr-composite/README.md
+++ b/renderers/xr-composite/README.md
@@ -85,6 +85,8 @@ Methods (all params are JSON):
 | `render` (alias `xr/render`) | `{scene: SpatialScene, sessionId?, sceneDir?, environment?, width?, height?, out?}` | open/replace the session's scene + camera, render; emits a `streamFrame`; `out` also writes a PNG |
 | `xr/updatePanels` | `{sessionId?, panels: [{id, texture?, poseInRoot?, sizeDp?}], out?}` | mutate matching panels (or append a full new panel) on the session and re-render; emits a `streamFrame` |
 | `xr/stop` | `{sessionId?}` | tear down the session's per-session Filament objects (engine kept for other sessions) |
+
+The daemon additionally serves **`xr/structure`** (`{frameStreamId}` → the held `SpatialScene` panel tree + poses as inline JSON, mirroring `a11y/hierarchy`) from its own copy of the scene — it doesn't round-trip to the native server. (`xr/a11y-overlay` is a planned kind, pending how XR a11y surfaces.)
 | `shutdown` / `exit` | — | `shutdown` acks; `exit` ends the loop |
 
 Rendered frames are delivered as **`streamFrame` notifications** —


### PR DESCRIPTION
## Summary

Enhancement #3 — the **`xr/structure`** data product. (The RFC's other listed kind, `xr/a11y-overlay`, is explicitly deferred there — "produced when we learn how XR a11y surfaces" — so this lands the implementable half.)

The daemon serves an `xr/structure` request returning the held session's `SpatialScene` (panel tree + poses) as inline JSON, **mirroring `a11y/hierarchy`** — letting the WebGL viewer / agents inspect the spatial layout (labels, hierarchy, hit-testing) without decoding frames.

- **`XrSessionManager`** retains the scene each session was opened with (dropped on `close`/`closeAll`) and exposes `structure(id)`.
- **`JsonRpcServer`** adds `xr/structure {frameStreamId}` → `{frameStreamId, structure}`, served **entirely daemon-side from its own copy of the scene** (no native round-trip), gated behind `capabilities.xr` (`MethodNotFound` otherwise).

Per-frame `updatePanels` deltas aren't merged into the structure yet — it's the declared layout from `xr/start` (noted as a follow-up).

## Test plan

- [x] `:renderer-xr-client:test` — `retainsSceneAsStructureUntilClosed` (manager retains the scene, drops it on `close`).
- [x] `:daemon:core:test` `StreamRpcIntegrationTest` — after `xr/start`, `xr/structure` returns the scene's `units`/`camera`.
- [x] ktfmt clean across both modules.

## Remaining

Only `xr/a11y-overlay` remains from the RFC's data-product kinds — deferred until XR a11y/TalkBack semantics are understood (mirrors `a11y/overlay`, a rendered overlay PNG). With this, the RENDERER_SERVICE follow-ups are otherwise complete.


---
_Generated by [Claude Code](https://claude.ai/code/session_01X8ZwHy8Sgg5eVJzNqr1LMb)_