### PR TITLE
feat(xr): keep xr/structure in step with updatePanels deltas

### DIFF
--- a/renderers/xr-client/src/main/kotlin/ee/schimke/composeai/renderer/xr/client/XrSessionManager.kt
+++ b/renderers/xr-client/src/main/kotlin/ee/schimke/composeai/renderer/xr/client/XrSessionManager.kt
@@ -3,6 +3,10 @@ package ee.schimke.composeai.renderer.xr.client
 import java.util.concurrent.ConcurrentHashMap
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonPrimitive
 
 /**
  * Multiplexes XR render sessions over a single shared native process. The first [open] lazily
@@ -23,9 +27,9 @@ public class XrSessionManager(
   // The one shared native process, started on first open(); null until then / after close().
   @Volatile private var server: XrRenderServerHandle? = null
   private val openIds = ConcurrentHashMap.newKeySet<String>()
-  // The scene each session was opened with — the daemon's view of the layout, served as the
-  // `xr/structure` data product (panel tree + poses, mirrors a11y/hierarchy). Per-frame
-  // `updatePanels` deltas are not merged in yet; this is the declared layout from `open`.
+  // The current scene per session — the daemon's view of the layout, served as the `xr/structure`
+  // data product (panel tree + poses, mirrors a11y/hierarchy). Seeded from `open` and kept in step
+  // with `updatePanels` deltas so the structure reflects live poses.
   private val scenes = ConcurrentHashMap<String, JsonElement>()
   private val lock = Any()
 
@@ -82,7 +86,11 @@ public class XrSessionManager(
     if (srv == null || !openIds.contains(id)) {
       throw XrServerException("no XR session open for id=$id")
     }
-    return srv.updatePanels(id, panels)
+    val frame = srv.updatePanels(id, panels)
+    // Keep the held structure (served via xr/structure) in step with the live scene: overlay each
+    // delta onto the matching panel by id (appending unknown ids), mirroring the native server.
+    scenes[id]?.let { scenes[id] = mergePanels(it, panels) }
+    return frame
   }
 
   /** Close and drop the session for [id]; no-op if none is open. */
@@ -115,6 +123,33 @@ public class XrSessionManager(
           "XrSessionManager: server close threw ${t.javaClass.simpleName}: ${t.message}; continuing"
         )
       }
+    }
+  }
+
+  /**
+   * Overlay each panel delta (`{id, …}`) onto the matching panel in [scene] by id, appending
+   * unknown ids — the same merge the native server applies — so the held structure tracks live
+   * updates. Returns [scene] unchanged if it isn't a scene object with a `panels` array.
+   */
+  private fun mergePanels(scene: JsonElement, deltas: JsonArray): JsonElement {
+    val obj = scene as? JsonObject ?: return scene
+    val panels =
+      (obj["panels"] as? JsonArray)?.map { it as JsonObject }?.toMutableList() ?: return scene
+    for (delta in deltas) {
+      val d = delta as? JsonObject ?: continue
+      val id = d["id"]?.jsonPrimitive?.contentOrNull ?: continue
+      val idx = panels.indexOfFirst { it["id"]?.jsonPrimitive?.contentOrNull == id }
+      if (idx >= 0) {
+        panels[idx] = buildJsonObject {
+          panels[idx].forEach { (k, v) -> put(k, v) }
+          d.forEach { (k, v) -> put(k, v) } // delta fields win
+        }
+      } else {
+        panels.add(d)
+      }
+    }
+    return buildJsonObject {
+      obj.forEach { (k, v) -> if (k == "panels") put("panels", JsonArray(panels)) else put(k, v) }
     }
   }
 

--- a/renderers/xr-client/src/main/kotlin/ee/schimke/composeai/renderer/xr/client/XrSessionManager.kt
+++ b/renderers/xr-client/src/main/kotlin/ee/schimke/composeai/renderer/xr/client/XrSessionManager.kt
@@ -144,7 +144,11 @@ public class XrSessionManager(
           panels[idx].forEach { (k, v) -> put(k, v) }
           d.forEach { (k, v) -> put(k, v) } // delta fields win
         }
-      } else {
+      } else if (
+        d.containsKey("poseInRoot") && d.containsKey("sizeDp") && d.containsKey("texture")
+      ) {
+        // The native server only appends an unknown id when it's a complete SpatialPanel; skip
+        // partial new-panel deltas so the structure can't report a panel the render dropped.
         panels.add(d)
       }
     }

--- a/renderers/xr-client/src/test/kotlin/ee/schimke/composeai/renderer/xr/client/XrSessionManagerTest.kt
+++ b/renderers/xr-client/src/test/kotlin/ee/schimke/composeai/renderer/xr/client/XrSessionManagerTest.kt
@@ -10,8 +10,13 @@ import kotlin.test.assertTrue
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.add
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 
 class XrSessionManagerTest {
@@ -147,6 +152,50 @@ class XrSessionManagerTest {
 
     manager.close("s1")
     assertNull(manager.structure("s1"))
+  }
+
+  @Test
+  fun updatePanelsMergesDeltasIntoStructure() {
+    val manager = XrSessionManager(CountingFactory(FakeServer()))
+    val scene = buildJsonObject {
+      put("units", "dp")
+      put(
+        "panels",
+        buildJsonArray {
+          add(
+            buildJsonObject {
+              put("id", "top")
+              put("x", 0)
+            }
+          )
+        },
+      )
+    }
+    manager.open("s1", scene)
+
+    manager.updatePanels(
+      "s1",
+      buildJsonArray {
+        add(
+          buildJsonObject {
+            put("id", "top")
+            put("x", 120)
+          }
+        ) // move existing
+        add(
+          buildJsonObject {
+            put("id", "extra")
+            put("x", 5)
+          }
+        ) // append new
+      },
+    )
+
+    val panels = manager.structure("s1")!!.jsonObject["panels"]!!.jsonArray
+    assertEquals(2, panels.size)
+    val top = panels.first { it.jsonObject["id"]?.jsonPrimitive?.content == "top" }.jsonObject
+    assertEquals(120, top["x"]?.jsonPrimitive?.int)
+    assertTrue(panels.any { it.jsonObject["id"]?.jsonPrimitive?.content == "extra" })
   }
 
   @Test

--- a/renderers/xr-client/src/test/kotlin/ee/schimke/composeai/renderer/xr/client/XrSessionManagerTest.kt
+++ b/renderers/xr-client/src/test/kotlin/ee/schimke/composeai/renderer/xr/client/XrSessionManagerTest.kt
@@ -18,6 +18,7 @@ import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonObject
 
 class XrSessionManagerTest {
 
@@ -176,26 +177,37 @@ class XrSessionManagerTest {
     manager.updatePanels(
       "s1",
       buildJsonArray {
+        // Partial delta on an existing panel — overlays.
         add(
           buildJsonObject {
             put("id", "top")
             put("x", 120)
           }
-        ) // move existing
+        )
+        // Complete new panel — appended.
         add(
           buildJsonObject {
             put("id", "extra")
-            put("x", 5)
+            putJsonObject("poseInRoot") {}
+            putJsonObject("sizeDp") {}
+            put("texture", "extra.png")
           }
-        ) // append new
+        )
+        // Partial new panel — dropped (the native renderer would skip it).
+        add(
+          buildJsonObject {
+            put("id", "junk")
+            put("x", 9)
+          }
+        )
       },
     )
 
     val panels = manager.structure("s1")!!.jsonObject["panels"]!!.jsonArray
-    assertEquals(2, panels.size)
-    val top = panels.first { it.jsonObject["id"]?.jsonPrimitive?.content == "top" }.jsonObject
-    assertEquals(120, top["x"]?.jsonPrimitive?.int)
-    assertTrue(panels.any { it.jsonObject["id"]?.jsonPrimitive?.content == "extra" })
+    val byId = panels.associateBy { it.jsonObject["id"]?.jsonPrimitive?.content }
+    assertEquals(120, byId["top"]!!.jsonObject["x"]?.jsonPrimitive?.int) // existing moved
+    assertTrue(byId.containsKey("extra"), "complete new panel is appended")
+    assertFalse(byId.containsKey("junk"), "partial new panel is dropped")
   }
 
   @Test


### PR DESCRIPTION
## Summary

Follow-up to #1806: `xr/structure` previously returned only the declared layout from `xr/start`. Now `XrSessionManager.updatePanels` **merges each delta into the held scene** — overlay the matching panel by id, append unknown ids (the same merge the native server applies) — so `xr/structure` reflects **live** panel poses/textures/sizes, not just the initial layout.

## Test plan

- [x] `:renderer-xr-client:test` — `updatePanelsMergesDeltasIntoStructure`: opens a scene with one panel, then `updatePanels` moves it **and** appends a new panel; asserts `structure()` shows the moved pose and the appended panel.
- [x] ktfmt clean.

Pure-JVM, contained to `:renderer-xr-client`. This closes the "declared layout only" caveat I noted on #1806. Remaining RFC item is still just `xr/a11y-overlay` (deferred pending XR a11y semantics).


---
_Generated by [Claude Code](https://claude.ai/code/session_01X8ZwHy8Sgg5eVJzNqr1LMb)_