### PR TITLE
feat(daemon): classify renderFailed into a typed kind + fix hint (#1789)

### DIFF
--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -50,6 +50,7 @@ import ee.schimke.composeai.daemon.protocol.Orientation
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.daemon.protocol.PruneReasonWire
 import ee.schimke.composeai.daemon.protocol.RejectedRender
+import ee.schimke.composeai.daemon.protocol.RenderError
 import ee.schimke.composeai.daemon.protocol.RenderFinishedParams
 import ee.schimke.composeai.daemon.protocol.RenderMetrics
 import ee.schimke.composeai.daemon.protocol.RenderNowParams
@@ -1621,16 +1622,18 @@ class JsonRpcServer(
       ?.complete(
         RerenderOutcome.Failed(failure.cause.message ?: failure.cause.javaClass.simpleName)
       )
-    // Minimal renderFailed; B1.4 widens this to the real RenderError shape.
+    // #1789 — classify the failure into a typed RenderErrorKind + a one-line fix hint for
+    // recognized skew signatures, instead of the old blanket kind = "internal".
+    val classification = RenderErrorClassifier.classify(failure.cause)
+    val renderError =
+      RenderError(
+        kind = classification.kind,
+        message = failure.cause.message ?: failure.cause.javaClass.name,
+        suggestion = classification.suggestion,
+      )
     val payload = buildJsonObject {
       put("id", JsonPrimitive(previewId))
-      put(
-        "error",
-        buildJsonObject {
-          put("kind", JsonPrimitive("internal"))
-          put("message", JsonPrimitive(failure.cause.message ?: failure.cause.javaClass.name))
-        },
-      )
+      put("error", json.encodeToJsonElement(RenderError.serializer(), renderError))
     }
     sendNotification("renderFailed", payload)
   }

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RenderErrorClassifier.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RenderErrorClassifier.kt
@@ -1,0 +1,106 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.protocol.RenderErrorKind
+
+/**
+ * Classifies a failed render's [Throwable] into a [RenderErrorKind] plus a one-line remediation
+ * (issue #1789), so `renderFailed` carries a typed kind and a specific fix hint instead of the old
+ * blanket `kind = "internal"`. The signatures come from the load-bearing skew cases catalogued in
+ * `docs/RENDERER_COMPATIBILITY.md` / `docs/SDK_COMPATIBILITY.md` / the cloud-sandbox notes.
+ *
+ * Pure (matches on the throwable's message + class names down the cause chain) so it is
+ * unit-testable and works whether the cause is a real desktop throwable or a re-thrown sandbox
+ * error whose message carries the signature text. New fine-grained kinds (e.g. a dedicated
+ * `classpathSkew`) wait on the wire-level tolerant-enum work; until then the skew is conveyed
+ * through the suggestion, keeping the change additive and decode-safe for old clients.
+ */
+object RenderErrorClassifier {
+
+  data class Classification(val kind: RenderErrorKind, val suggestion: String? = null)
+
+  fun classify(cause: Throwable): Classification {
+    val diagnostic = buildString {
+      var t: Throwable? = cause
+      var depth = 0
+      while (t != null && depth < MAX_CAUSE_DEPTH) {
+        append(t.javaClass.name).append(": ").append(t.message ?: "").append('\n')
+        t = t.cause
+        depth++
+      }
+    }
+    return classify(diagnostic)
+  }
+
+  /** Classify from the pre-flattened cause-chain diagnostic text. Internal for direct testing. */
+  internal fun classify(diagnostic: String): Classification {
+    val s = diagnostic.lowercase()
+    fun has(vararg needles: String): Boolean = needles.any { it in s }
+
+    return when {
+      has("implemented only in jetbrains fork") ||
+        (has("nosuchmethoderror", "noclassdeffounderror") && has("androidx.compose")) ||
+        (has("androidx.compose") && has("jvmstubs")) ->
+        Classification(
+          RenderErrorKind.RUNTIME,
+          "Desktop classpath contains AndroidX Compose UI artifacts; use the org.jetbrains.compose " +
+            "UI artifacts for Compose Multiplatform desktop. See docs/RENDERER_COMPATIBILITY.md.",
+        )
+      has("requires newer sdk version", "packageparser") ->
+        Classification(
+          RenderErrorKind.RUNTIME,
+          "Robolectric's SDK is below the consumer's compileSdk; set composePreview.sdkVersion " +
+            "(SDK 36 also needs a JDK 21 toolchain). See docs/SDK_COMPATIBILITY.md.",
+        )
+      has(".robolectric") && has("lock", "download", "read-only", "permission denied") ->
+        Classification(
+          RenderErrorKind.CAPTURE,
+          "Robolectric could not write its host cache/lock; allow \$HOME/.robolectric-download-lock " +
+            "in the sandbox network/FS policy. See the compose-preview agent-cloud reference.",
+        )
+      has("getdeclaredcomposablemethod") ||
+        (has("nosuchmethodexception") && has("composer")) ||
+        has("is not a @composable") ->
+        Classification(
+          RenderErrorKind.RUNTIME,
+          "The preview must be a @Composable function with no required parameters (or a " +
+            "@PreviewParameter provider). Non-composable previews (tile / notification / Glance) " +
+            "render through their own kind.",
+        )
+      has("@previewparameter") || (has("parameter") && has("no value", "missing", "required")) ->
+        Classification(
+          RenderErrorKind.RUNTIME,
+          "The preview function has required parameters; give them defaults or a @PreviewParameter " +
+            "provider.",
+        )
+      has(
+        "captureroboimage",
+        "pixelcopy",
+        "imagereader",
+        "hardwarerenderer",
+        "nativecreateplanes",
+        "roborazzi",
+      ) ->
+        Classification(
+          RenderErrorKind.CAPTURE,
+          "The Robolectric capture path failed — usually a Robolectric × compileSdk skew. See " +
+            "docs/RENDERER_COMPATIBILITY.md.",
+        )
+      has("timeoutexception", "timed out", "timeout") ->
+        Classification(
+          RenderErrorKind.TIMEOUT,
+          "The render exceeded its time budget; raise composeai.daemon.renderTimeoutMs or simplify " +
+            "the preview (paused-clock animations terminate deterministically).",
+        )
+      has("compilation error", "unresolved reference", "cannot access class") ->
+        Classification(
+          RenderErrorKind.COMPILE,
+          "The module did not compile; fix the build error before rendering.",
+        )
+      // Reached emitRenderFailed → the render ran the preview and threw; runtime is the accurate
+      // default (more useful than the old blanket `internal`).
+      else -> Classification(RenderErrorKind.RUNTIME)
+    }
+  }
+
+  private const val MAX_CAUSE_DEPTH = 8
+}

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RenderErrorClassifier.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RenderErrorClassifier.kt
@@ -45,7 +45,9 @@ object RenderErrorClassifier {
           "Desktop classpath contains AndroidX Compose UI artifacts; use the org.jetbrains.compose " +
             "UI artifacts for Compose Multiplatform desktop. See docs/RENDERER_COMPATIBILITY.md.",
         )
-      has("requires newer sdk version", "packageparser") ->
+      // Require the specific "newer sdk version" text — a bare PackageParser error (e.g. a
+      // malformed manifest) is a different failure and shouldn't get the compileSdk hint.
+      has("requires newer sdk version") || (has("packageparser") && has("newer sdk")) ->
         Classification(
           RenderErrorKind.RUNTIME,
           "Robolectric's SDK is below the consumer's compileSdk; set composePreview.sdkVersion " +
@@ -96,8 +98,20 @@ object RenderErrorClassifier {
           RenderErrorKind.COMPILE,
           "The module did not compile; fix the build error before rendering.",
         )
-      // Reached emitRenderFailed → the render ran the preview and threw; runtime is the accurate
-      // default (more useful than the old blanket `internal`).
+      // Host / sandbox infrastructure failure (e.g. host.submit throwing before the preview body
+      // ran — a crashed sandbox's EOF/broken pipe, a closed stdio stream). These aren't user
+      // runtime errors, so keep them `internal` rather than falling through to the runtime default.
+      has("eofexception") ||
+        has("broken pipe") ||
+        (has("ioexception") && has("closed", "pipe", "reset", "stream")) ||
+        (has("sandbox") && has("crash", "died", "exited", "terminated", "killed")) ->
+        Classification(
+          RenderErrorKind.INTERNAL,
+          "The render host or sandbox failed before/around running the preview (not a fault in the " +
+            "preview itself); check the daemon log.",
+        )
+      // Reached emitRenderFailed without an infra signature → the render ran the preview and threw;
+      // runtime is the accurate default (more useful than the old blanket `internal`).
       else -> Classification(RenderErrorKind.RUNTIME)
     }
   }

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -1361,6 +1361,13 @@ data class RenderError(
   val kind: RenderErrorKind,
   val message: String,
   val stackTrace: String? = null,
+  /**
+   * Optional one-line remediation for a recognized failure signature (issue #1789) — e.g. an
+   * AndroidX-Compose-on-desktop classpath skew or a Robolectric SDK mismatch. Additive and
+   * tolerant-decode-safe (unknown to old clients, which ignore it). Null when no specific fix is
+   * known; agents fall back to [message].
+   */
+  val suggestion: String? = null,
 )
 
 @Serializable

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/RenderErrorClassifierTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/RenderErrorClassifierTest.kt
@@ -58,6 +58,24 @@ class RenderErrorClassifierTest {
   }
 
   @Test
+  fun barePackageParserErrorDoesNotGetTheSdkSuggestion() {
+    val c = RenderErrorClassifier.classify("PackageParser: Malformed AndroidManifest.xml")
+    assertNull(
+      "a non-SDK PackageParser error must not be masked with the compileSdk hint",
+      c.suggestion,
+    )
+    assertEquals(RenderErrorKind.RUNTIME, c.kind)
+  }
+
+  @Test
+  fun hostInfraFailureStaysInternal() {
+    val eof = RenderErrorClassifier.classify("java.io.EOFException: sandbox stdio closed")
+    assertEquals(RenderErrorKind.INTERNAL, eof.kind)
+    val ioClosed = RenderErrorClassifier.classify("java.io.IOException: Stream closed")
+    assertEquals(RenderErrorKind.INTERNAL, ioClosed.kind)
+  }
+
+  @Test
   fun timeoutIsTimeout() {
     val c = RenderErrorClassifier.classify("java.util.concurrent.TimeoutException: timed out")
     assertEquals(RenderErrorKind.TIMEOUT, c.kind)

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/RenderErrorClassifierTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/RenderErrorClassifierTest.kt
@@ -1,0 +1,83 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.protocol.RenderErrorKind
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RenderErrorClassifierTest {
+
+  @Test
+  fun androidxComposeOnDesktopIsRuntimeWithAClasspathSuggestion() {
+    val c =
+      RenderErrorClassifier.classify(
+        "java.lang.NoSuchMethodError: Implemented only in JetBrains fork"
+      )
+    assertEquals(RenderErrorKind.RUNTIME, c.kind)
+    assertTrue(c.suggestion, c.suggestion!!.contains("org.jetbrains.compose"))
+  }
+
+  @Test
+  fun newerSdkIsRuntimeWithAnSdkSuggestion() {
+    val c =
+      RenderErrorClassifier.classify("PackageParser: Requires newer sdk version #36 (current #35)")
+    assertEquals(RenderErrorKind.RUNTIME, c.kind)
+    assertTrue(c.suggestion, c.suggestion!!.contains("compileSdk"))
+  }
+
+  @Test
+  fun capturePathFailureIsCapture() {
+    val c =
+      RenderErrorClassifier.classify(
+        "java.lang.RuntimeException: captureRoboImage / PixelCopy failed"
+      )
+    assertEquals(RenderErrorKind.CAPTURE, c.kind)
+    assertNotNull(c.suggestion)
+  }
+
+  @Test
+  fun robolectricLockIsCaptureWithSandboxSuggestion() {
+    val c =
+      RenderErrorClassifier.classify(
+        "java.io.IOException: /home/user/.robolectric-download-lock: permission denied"
+      )
+    assertEquals(RenderErrorKind.CAPTURE, c.kind)
+    assertTrue(c.suggestion, c.suggestion!!.contains(".robolectric-download-lock"))
+  }
+
+  @Test
+  fun missingComposableIsRuntimeWithASuggestion() {
+    val c =
+      RenderErrorClassifier.classify(
+        "java.lang.NoSuchMethodException: getDeclaredComposableMethod failed"
+      )
+    assertEquals(RenderErrorKind.RUNTIME, c.kind)
+    assertTrue(c.suggestion, c.suggestion!!.contains("@Composable"))
+  }
+
+  @Test
+  fun timeoutIsTimeout() {
+    val c = RenderErrorClassifier.classify("java.util.concurrent.TimeoutException: timed out")
+    assertEquals(RenderErrorKind.TIMEOUT, c.kind)
+  }
+
+  @Test
+  fun unknownCompositionErrorDefaultsToRuntimeWithoutASuggestion() {
+    val c = RenderErrorClassifier.classify(IllegalStateException("boom"))
+    assertEquals(RenderErrorKind.RUNTIME, c.kind)
+    assertNull(c.suggestion)
+  }
+
+  @Test
+  fun walksTheCauseChainForSignatures() {
+    val cause =
+      RuntimeException(
+        "wrapper",
+        IllegalStateException("PackageParser: Requires newer sdk version"),
+      )
+    assertEquals(RenderErrorKind.RUNTIME, RenderErrorClassifier.classify(cause).kind)
+    assertNotNull(RenderErrorClassifier.classify(cause).suggestion)
+  }
+}


### PR DESCRIPTION
## Summary

**#1789** (closes #798 §B) — `renderFailed` hard-coded `error.kind = "internal"`, so agents got a bare message with no remediation. Now it carries a typed kind **and** a specific fix hint.

- **`RenderErrorClassifier`** (`:daemon:core`, pure): maps a failed render's `Throwable` (message + class names down the cause chain) to a `RenderErrorKind` + a one-line suggestion for the recognized skew signatures from `RENDERER_COMPATIBILITY.md` / `SDK_COMPATIBILITY.md` / the cloud-sandbox notes — AndroidX-Compose-on-desktop classpath skew, Robolectric SDK mismatch, missing `@Composable` / required parameters, capture-path failures, Robolectric cache-lock, timeout, compile. Unknown render failures default to `RUNTIME` (the render ran the preview and threw), not `internal`.
- **`RenderError`** gains an additive, decode-safe `suggestion` field.
- **`emitRenderFailed`** serializes the classified `RenderError` instead of the hard-coded internal stub.

Fine-grained kinds (`classpathSkew`, `sdkMismatch`, …) would need new enum values, which the 1.0 tolerant-enum-decoding work gates — so the skew is conveyed via the `suggestion` string for now, keeping this additive and decode-safe for old clients.

## Test plan

- [x] `./gradlew :daemon:core:test --tests "*RenderErrorClassifierTest"` — each signature → expected kind + suggestion substring; cause-chain walk; unknown → `RUNTIME` with no suggestion.
- [x] `./gradlew :daemon:harness:test --tests "*S5RenderFailedTest"` — the renderFailed wire-shape regression stays green (kind is a valid value, message preserved).
- [x] `:daemon:core` `ktfmtCheck` clean.

## Scope / follow-ups

- Fine-grained `RenderErrorKind` values once tolerant enum decoding lands (roadmap P0).
- CLI/MCP **explicit display** of `suggestion` (the wire field is there; consumers that decode `RenderError` already receive it), and reusing the `test/failure` data product for the richer post-mortem shape.