### PR TITLE
feat(xr): re-spawn the shared XR process after it dies

### DIFF
--- a/renderers/xr-client/src/main/kotlin/ee/schimke/composeai/renderer/xr/client/XrRenderServer.kt
+++ b/renderers/xr-client/src/main/kotlin/ee/schimke/composeai/renderer/xr/client/XrRenderServer.kt
@@ -30,6 +30,12 @@ public interface XrRenderServerHandle : AutoCloseable {
 
   /** Tear down [sessionId] on the server (its per-session GL resources; the engine is kept). */
   public fun stop(sessionId: String)
+
+  /**
+   * Whether the underlying process is still usable. The session manager drops a handle that returns
+   * `false` and re-spawns on the next open. Default `true` keeps fakes simple.
+   */
+  public fun isAlive(): Boolean = true
 }
 
 /**
@@ -78,6 +84,8 @@ private constructor(
     client.updatePanels(sessionId, panels)
 
   public override fun stop(sessionId: String): Unit = client.stop(sessionId)
+
+  public override fun isAlive(): Boolean = client.isAlive()
 
   override fun close(): Unit = client.close()
 

--- a/renderers/xr-client/src/main/kotlin/ee/schimke/composeai/renderer/xr/client/XrServerClient.kt
+++ b/renderers/xr-client/src/main/kotlin/ee/schimke/composeai/renderer/xr/client/XrServerClient.kt
@@ -135,6 +135,9 @@ internal constructor(
     frames.remove(sessionId)
   }
 
+  /** Whether the spawned child is still alive (always true for the stream-backed test client). */
+  public fun isAlive(): Boolean = process?.isAlive ?: true
+
   /** Sends `exit`; the server ends its loop and the process terminates. */
   public fun exit() {
     sendFrame(

--- a/renderers/xr-client/src/main/kotlin/ee/schimke/composeai/renderer/xr/client/XrSessionManager.kt
+++ b/renderers/xr-client/src/main/kotlin/ee/schimke/composeai/renderer/xr/client/XrSessionManager.kt
@@ -158,12 +158,18 @@ public class XrSessionManager(
   }
 
   private fun ensureServer(): XrRenderServerHandle? {
-    server?.let {
-      return it
-    }
+    server?.let { if (it.isAlive()) return it }
     synchronized(lock) {
-      server?.let {
-        return it
+      val current = server
+      if (current != null) {
+        if (current.isAlive()) return current
+        // The shared child died: drop it and forget every session that lived on it (those native
+        // sessions are gone), then re-spawn so callers recover without a daemon restart. Stale ids
+        // surface as "no session open" on their next updatePanels, prompting a fresh open.
+        runCatching { current.close() }
+        server = null
+        openIds.clear()
+        scenes.clear()
       }
       val started = factory.start() ?: return null
       server = started

--- a/renderers/xr-client/src/main/kotlin/ee/schimke/composeai/renderer/xr/client/XrSessionManager.kt
+++ b/renderers/xr-client/src/main/kotlin/ee/schimke/composeai/renderer/xr/client/XrSessionManager.kt
@@ -86,6 +86,13 @@ public class XrSessionManager(
     if (srv == null || !openIds.contains(id)) {
       throw XrServerException("no XR session open for id=$id")
     }
+    // The shared child can die between frames on a live stream (no xr/start runs in that path), so
+    // check here too: drop the dead server and tell the caller the session is gone rather than
+    // hammering a dead handle. The client recovers by reopening with xr/start.
+    if (!srv.isAlive()) {
+      dropServer(srv)
+      throw XrServerException("XR server died; session $id lost — reopen with xr/start")
+    }
     val frame = srv.updatePanels(id, panels)
     // Keep the held structure (served via xr/structure) in step with the live scene: overlay each
     // delta onto the matching panel by id (appending unknown ids), mirroring the native server.
@@ -158,22 +165,29 @@ public class XrSessionManager(
   }
 
   private fun ensureServer(): XrRenderServerHandle? {
-    server?.let { if (it.isAlive()) return it }
+    server?.let { if (it.isAlive()) return it else dropServer(it) }
     synchronized(lock) {
-      val current = server
-      if (current != null) {
-        if (current.isAlive()) return current
-        // The shared child died: drop it and forget every session that lived on it (those native
-        // sessions are gone), then re-spawn so callers recover without a daemon restart. Stale ids
-        // surface as "no session open" on their next updatePanels, prompting a fresh open.
-        runCatching { current.close() }
-        server = null
-        openIds.clear()
-        scenes.clear()
-      }
+      // Another thread may have re-spawned while we were dropping the dead one.
+      server?.let { if (it.isAlive()) return it }
       val started = factory.start() ?: return null
       server = started
       return started
     }
+  }
+
+  /**
+   * Drop the dead [dead] server: forget every session that lived on it (those native sessions are
+   * gone with the process), then close it. Only clears state if [dead] is still the current server,
+   * so a concurrent re-spawn isn't wiped. [close] runs outside the lock (it can block on teardown).
+   */
+  private fun dropServer(dead: XrRenderServerHandle) {
+    synchronized(lock) {
+      if (server === dead) {
+        server = null
+        openIds.clear()
+        scenes.clear()
+      }
+    }
+    runCatching { dead.close() }
   }
 }

--- a/renderers/xr-client/src/test/kotlin/ee/schimke/composeai/renderer/xr/client/XrSessionManagerTest.kt
+++ b/renderers/xr-client/src/test/kotlin/ee/schimke/composeai/renderer/xr/client/XrSessionManagerTest.kt
@@ -240,6 +240,19 @@ class XrSessionManagerTest {
   }
 
   @Test
+  fun updatePanelsOnDeadServerDropsSessionAndThrows() {
+    val server = FakeServer()
+    val manager = XrSessionManager(CountingFactory(server))
+    manager.open("s1", scene)
+
+    server.alive = false // child died between frames on a live stream
+
+    assertFailsWith<XrServerException> { manager.updatePanels("s1", buildJsonArray {}) }
+    assertFalse(manager.isOpen("s1"), "the dead session is forgotten")
+    assertTrue(server.closed, "the dead server is closed")
+  }
+
+  @Test
   fun closeClosesTheSharedServer() {
     val server = FakeServer()
     val manager = XrSessionManager(CountingFactory(server))

--- a/renderers/xr-client/src/test/kotlin/ee/schimke/composeai/renderer/xr/client/XrSessionManagerTest.kt
+++ b/renderers/xr-client/src/test/kotlin/ee/schimke/composeai/renderer/xr/client/XrSessionManagerTest.kt
@@ -28,9 +28,12 @@ class XrSessionManagerTest {
     val seq = AtomicLong(0)
     var closed = false
     var failNextRender = false
+    @Volatile var alive = true
     val stopped = mutableListOf<String>()
     val renders = mutableListOf<RenderCall>()
     override val capabilities: JsonObject = buildJsonObject {}
+
+    override fun isAlive(): Boolean = alive
 
     private fun frame() = StreamFrame(seq.incrementAndGet(), 64, 48, "png", "data")
 
@@ -58,13 +61,16 @@ class XrSessionManagerTest {
     }
   }
 
-  /** Factory that hands out one fixed server (or null) and counts how many times it was started. */
-  private class CountingFactory(private val server: XrRenderServerHandle?) : XrRenderServerFactory {
+  /** Factory backed by a supplier; counts how many times it was started. */
+  private class CountingFactory(private val supplier: () -> XrRenderServerHandle?) :
+    XrRenderServerFactory {
+    constructor(server: XrRenderServerHandle?) : this({ server })
+
     var starts = 0
 
     override fun start(): XrRenderServerHandle? {
       starts++
-      return server
+      return supplier()
     }
   }
 
@@ -208,6 +214,29 @@ class XrSessionManagerTest {
     assertEquals(120, byId["top"]!!.jsonObject["x"]?.jsonPrimitive?.int) // existing moved
     assertTrue(byId.containsKey("extra"), "complete new panel is appended")
     assertFalse(byId.containsKey("junk"), "partial new panel is dropped")
+  }
+
+  @Test
+  fun respawnsAfterTheSharedServerDies() {
+    val dead = FakeServer()
+    val fresh = FakeServer()
+    val queue = ArrayDeque(listOf<XrRenderServerHandle>(dead, fresh))
+    val factory = CountingFactory { queue.removeFirst() }
+    val manager = XrSessionManager(factory)
+
+    manager.open("a", scene)
+    assertEquals(1, factory.starts)
+    assertTrue(manager.isOpen("a"))
+
+    dead.alive = false // the shared child crashed
+
+    // The next open detects the dead process, drops it, and re-spawns a fresh one.
+    manager.open("b", scene)
+    assertEquals(2, factory.starts)
+    assertTrue(dead.closed, "the dead server is closed")
+    assertFalse(manager.isOpen("a"), "sessions on the dead process are forgotten")
+    assertTrue(manager.isOpen("b"))
+    assertNull(manager.structure("a"))
   }
 
   @Test


### PR DESCRIPTION
## Summary

The dead-child recovery I flagged on #1805. If the shared `xr-composite --serve` process crashes, the daemon previously kept the stale handle cached and every subsequent `open` kept hitting the dead process — XR stayed wedged until a daemon restart.

- Add **`isAlive()`** to `XrRenderServerHandle` (default `true`; `XrServerClient` → `process.isAlive`, `XrRenderServer` delegates).
- `XrSessionManager.ensureServer()` now checks liveness: a dead server is closed and **dropped** (forgetting the sessions/scenes that died with the process), then a **fresh one is re-spawned** on the next `open`. Stale `frameStreamId`s surface as "no session open" on their next `updatePanels`, prompting a clean re-open.

## Test plan

- [x] `:renderer-xr-client:test` — `respawnsAfterTheSharedServerDies`: open a session, mark the shared server dead, next `open` closes the dead one + re-spawns (factory started twice), the prior session is forgotten (`isOpen`/`structure` cleared), new session works. Existing manager/client tests still pass.
- [x] `:daemon:core:test` `StreamRpcIntegrationTest` green (handle gains a default method — fakes unaffected).
- [x] ktfmt clean.

## Remaining

Only `xr/a11y-overlay` is left from the RFC — deferred there until XR a11y/TalkBack semantics are understood (it needs a design pass first, not just code).


---
_Generated by [Claude Code](https://claude.ai/code/session_01X8ZwHy8Sgg5eVJzNqr1LMb)_