### PR TITLE
feat(mcp): token-frugal render_preview observe modes (#1787)

### DIFF
--- a/docs/TOKEN_USAGE.md
+++ b/docs/TOKEN_USAGE.md
@@ -89,6 +89,16 @@ previews.
   captured frame adds a `frames[]` entry plus optional metadata. The
   APNG/MP4 capture path keeps per-frame JSON small; embedded-PNG debug
   mode grows fast.
+- `render_preview` defaults to returning the base64 PNG (~1.5 k input
+  tokens per read at typical preview dimensions). For multi-step agent
+  loops, `observe: "semantics"` returns the `compose/semantics` tree +
+  sha256 + dimensions with **no base64** — typically a few hundred
+  tokens for a small preview (scaling with node count, like
+  `compose/semantics` elsewhere in this table), and `observe: "hash"`
+  is ~30 tokens (sha + dimensions only). Prefer these when you're
+  iterating and only need to know *whether* / *what* changed; fetch
+  `observe: "png"` when you actually need to look at pixels (issue
+  #1787).
 - These numbers count tokens crossing the LLM/tool boundary, not
   Anthropic billing on cached prefixes. With prompt caching the
   ~13 k MCP baseline is paid once per session and replayed from cache

--- a/docs/daemon/MCP.md
+++ b/docs/daemon/MCP.md
@@ -105,7 +105,7 @@ supervisor stops respawning.
 | `unregister_project(workspaceId)` | Tear down a workspace's daemons. |
 | `list_projects()` | List registered projects. |
 | `list_devices()` | List the known `@Preview(device=...)` catalog with resolved geometry. |
-| `render_preview(uri, overrides?)` | Force-render a preview, returning the PNG inline. |
+| `render_preview(uri, overrides?, observe?)` | Force-render a preview. `observe` defaults to `png` (base64 image); `semantics` returns the `compose/semantics` tree + sha256 + dimensions and `hash` returns just sha256 + dimensions — token-frugal responses with no base64 (issue #1787). |
 | `watch(workspaceId, module?, fqnGlob?, awaitDiscovery?, awaitTimeoutMs?)` | Register an area of interest and keep matching previews warm. |
 | `unwatch(workspaceId?, module?, fqnGlob?)` | Drop matching watches. |
 | `list_watches()` | List watches registered by the current session. |

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
@@ -959,6 +959,8 @@ class DaemonMcpServer(
         name = "render_preview",
         description =
           "Render a preview by URI, bypassing the in-memory render cache. Returns the PNG inline. " +
+            "Pass `observe=\"semantics\"` (or `\"hash\"`) for a token-frugal response — the " +
+            "compose/semantics snapshot + sha + dimensions instead of a base64 PNG (issue #1787). " +
             "Pass `force={reason}` only when the freshness probe missed a real edit (this should be rare); " +
             "report each use on https://github.com/yschimke/compose-ai-tools/issues/924. " +
             "Do NOT delete `build/classes/...` or run `./gradlew clean` to chase a stale render.",
@@ -969,6 +971,7 @@ class DaemonMcpServer(
               "type":"object",
               "properties":{
                 "uri":{"type":"string","description":"compose-preview://<workspace>/<module>/<fqn>?config=<qualifier>"},
+                "observe":{"type":"string","enum":["png","semantics","hash"],"description":"Observation level. Default 'png' (base64 image). 'semantics' returns the compose/semantics tree + sha256 + dimensions (no base64 — far cheaper for an agent loop); 'hash' returns just sha256 + dimensions."},
                 "overrides":{"type":"object","description":"Optional per-call display overrides."},
                 "force":{"type":"object","description":"Sanctioned escape hatch when the freshness probe missed an edit. Forwards fileChanged({kind:\"classpath\"}) before rendering, dropping the daemon's user classloader. Each use is logged + counted; please report on issue #924.","properties":{"reason":{"type":"string","description":"Human-readable reason for needing force (required)."}},"required":["reason"]}
               },
@@ -1106,6 +1109,7 @@ class DaemonMcpServer(
               "type":"object",
               "properties":{
                 "uri":{"type":"string","description":"compose-preview://<workspace>/<module>/<fqn>?config=<qualifier>"},
+                "observe":{"type":"string","enum":["png","semantics","hash"],"description":"Observation level (issue #1787). Default 'png' returns the base64 image. 'semantics' returns the compose/semantics tree + sha256 + width/height with NO base64 — a token-frugal default for a multi-step agent loop (fetch pixels only when you need them); 'hash' returns just sha256 + dimensions."},
                 "overrides":{
                   "type":"object",
                   "description":"Per-call display overrides. Each field is optional; nulls fall back to the discovery-time RenderSpec. Backends that don't model a field (e.g. desktop has no Android resource qualifier system) ignore it.",
@@ -1889,6 +1893,10 @@ class DaemonMcpServer(
       args["uri"]?.jsonPrimitive?.contentOrNull
         ?: return errorCallToolResult("render_preview: missing 'uri'")
     val uri = PreviewUri.parseOrNull(uriStr) ?: return errorCallToolResult("invalid uri: $uriStr")
+    val observe = args["observe"]?.jsonPrimitive?.contentOrNull?.lowercase() ?: "png"
+    if (observe !in setOf("png", "semantics", "hash")) {
+      return errorCallToolResult("render_preview: 'observe' must be one of png | semantics | hash")
+    }
     val overrides =
       args["overrides"]?.let {
         runCatching { decodePreviewOverrides(it) }
@@ -1917,10 +1925,70 @@ class DaemonMcpServer(
     if (forceReason != null) invalidateClasspathForForce(uri, forceReason)
     return runCatching {
         val bytes = renderAndReadBytes(uri, overrides = overrides)
-        pngCallToolResult(Base64.getEncoder().encodeToString(bytes))
+        if (observe == "png") {
+          pngCallToolResult(Base64.getEncoder().encodeToString(bytes))
+        } else {
+          renderObservation(uri, bytes, includeSemantics = observe == "semantics")
+        }
       }
       .getOrElse { errorCallToolResult("render_preview failed: ${it.message}") }
   }
+
+  /**
+   * Token-frugal `render_preview` response (issue #1787): a structured observation — sha256 + pixel
+   * dimensions, and (for `observe="semantics"`) the compose/semantics tree — instead of a base64
+   * PNG. Mirrors Playwright's snapshot-default / screenshot-on-demand split; an agent loop reads
+   * pixels only when it actually needs them.
+   */
+  private fun renderObservation(
+    uri: PreviewUri,
+    pngBytes: ByteArray,
+    includeSemantics: Boolean,
+  ): CallToolResult {
+    val dimensions = pngDimensions(pngBytes)
+    val payload = buildJsonObject {
+      put("observe", if (includeSemantics) "semantics" else "hash")
+      put("uri", uri.toUri())
+      put("sha256", sha256Hex(pngBytes))
+      put("sizeBytes", pngBytes.size)
+      dimensions?.let {
+        put("widthPx", it.first)
+        put("heightPx", it.second)
+      }
+      if (includeSemantics) {
+        val (semantics, error) = fetchSemanticsPayload(uri.toUri(), "preview")
+        if (semantics != null) {
+          put(
+            "semantics",
+            json.encodeToJsonElement(ComposeSemanticsPayload.serializer(), semantics),
+          )
+        } else {
+          put("semanticsUnavailable", error ?: "compose/semantics not available for this preview")
+        }
+      }
+    }
+    return CallToolResult(content = listOf(ContentBlock.Text(payload.toString())))
+  }
+
+  /**
+   * Parse a PNG's IHDR width/height (big-endian, at byte offsets 16/20) without decoding pixels.
+   */
+  private fun pngDimensions(bytes: ByteArray): Pair<Int, Int>? {
+    if (bytes.size < 24) return null
+    fun int32(offset: Int): Int =
+      ((bytes[offset].toInt() and 0xFF) shl 24) or
+        ((bytes[offset + 1].toInt() and 0xFF) shl 16) or
+        ((bytes[offset + 2].toInt() and 0xFF) shl 8) or
+        (bytes[offset + 3].toInt() and 0xFF)
+    val width = int32(16)
+    val height = int32(20)
+    return if (width in 1..100_000 && height in 1..100_000) width to height else null
+  }
+
+  private fun sha256Hex(bytes: ByteArray): String =
+    java.security.MessageDigest.getInstance("SHA-256").digest(bytes).joinToString("") {
+      "%02x".format(it)
+    }
 
   /**
    * Sanctioned classpath invalidation for `render_preview.force`. Forwards a

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
@@ -801,6 +801,156 @@ class DaemonMcpServerTest {
   }
 
   @Test
+  fun `render_preview observe hash returns sha and dimensions without a base64 image`() {
+    client.initialize()
+    val projectDir = tmp.newFolder("workspace")
+    tmp.newFolder("workspace", "module")
+    val workspaceId = registerWorkspace(projectDir, "demo")
+    val daemon = warmDaemonFor(workspaceId, ":module")
+    val previewId = "com.example.Red"
+    daemon.emitDiscovery(previewId)
+    client.expectNotification("notifications/resources/list_changed", 2_000)
+
+    // A 24-byte PNG with a valid IHDR (width=40, height=30) so dimensions parse from the header.
+    val pngBytes =
+      byteArrayOf(
+        0x89.toByte(),
+        0x50,
+        0x4e,
+        0x47,
+        0x0d,
+        0x0a,
+        0x1a,
+        0x0a, // signature
+        0x00,
+        0x00,
+        0x00,
+        0x0d,
+        0x49,
+        0x48,
+        0x44,
+        0x52, // IHDR length + "IHDR"
+        0x00,
+        0x00,
+        0x00,
+        0x28, // width = 40
+        0x00,
+        0x00,
+        0x00,
+        0x1e, // height = 30
+      )
+    val pngFile = tmp.newFile("observe-render.png")
+    Files.write(pngFile.toPath(), pngBytes)
+    daemon.autoRenderPngPath = { id -> if (id == previewId) pngFile.absolutePath else null }
+
+    val uri = PreviewUri(workspaceId, ":module", previewId).toUri()
+    val resp =
+      client.callTool(
+        "render_preview",
+        buildJsonObject {
+          put("uri", uri)
+          put("observe", "hash")
+        },
+        timeoutMs = 10_000,
+      )
+    val parsed = json.parseToJsonElement(resp.firstTextContent()).jsonObject
+    assertThat(parsed["observe"]?.jsonPrimitive?.contentOrNull).isEqualTo("hash")
+    assertThat(parsed["widthPx"]?.jsonPrimitive?.contentOrNull).isEqualTo("40")
+    assertThat(parsed["heightPx"]?.jsonPrimitive?.contentOrNull).isEqualTo("30")
+    assertThat(parsed["sizeBytes"]?.jsonPrimitive?.contentOrNull).isEqualTo("24")
+    assertThat(parsed["sha256"]?.jsonPrimitive?.contentOrNull).isNotEmpty()
+    // The first (only) content block is text JSON — firstTextContent() above would have errored on
+    // an image block, so the token-frugal path returned no base64 PNG.
+    assertThat(resp.textContents()).hasSize(1)
+  }
+
+  @Test
+  fun `render_preview observe semantics embeds the compose semantics tree`() {
+    client.initialize()
+    val projectDir = tmp.newFolder("workspace")
+    tmp.newFolder("workspace", "module")
+    val workspaceId = registerWorkspace(projectDir, "demo")
+    factory.daemonConfigurer = { d ->
+      d.advertisedDataProducts =
+        listOf(
+          ee.schimke.composeai.daemon.protocol.DataProductCapability(
+            kind = "compose/semantics",
+            schemaVersion = 2,
+            transport = ee.schimke.composeai.daemon.protocol.DataProductTransport.INLINE,
+            attachable = true,
+            fetchable = true,
+            requiresRerender = false,
+          )
+        )
+      d.dataFetchHandler = { _, kind, _, _ ->
+        FakeDaemon.DataFetchOutcome.Ok(
+          kind = kind,
+          schemaVersion = 2,
+          payload =
+            buildJsonObject {
+              putJsonObject("root") {
+                put("nodeId", "1")
+                put("boundsInRoot", "0,0,40,30")
+                put("testTag", "hero")
+              }
+            },
+        )
+      }
+    }
+    val daemon = warmDaemonFor(workspaceId, ":module")
+    val previewId = "com.example.Red"
+    daemon.emitDiscovery(previewId)
+    client.expectNotification("notifications/resources/list_changed", 2_000)
+    val pngBytes =
+      byteArrayOf(
+        0x89.toByte(),
+        0x50,
+        0x4e,
+        0x47,
+        0x0d,
+        0x0a,
+        0x1a,
+        0x0a,
+        0x00,
+        0x00,
+        0x00,
+        0x0d,
+        0x49,
+        0x48,
+        0x44,
+        0x52,
+        0x00,
+        0x00,
+        0x00,
+        0x28,
+        0x00,
+        0x00,
+        0x00,
+        0x1e,
+      )
+    val pngFile = tmp.newFile("observe-semantics.png")
+    Files.write(pngFile.toPath(), pngBytes)
+    daemon.autoRenderPngPath = { id -> if (id == previewId) pngFile.absolutePath else null }
+
+    val uri = PreviewUri(workspaceId, ":module", previewId).toUri()
+    val resp =
+      client.callTool(
+        "render_preview",
+        buildJsonObject {
+          put("uri", uri)
+          put("observe", "semantics")
+        },
+        timeoutMs = 10_000,
+      )
+    val parsed = json.parseToJsonElement(resp.firstTextContent()).jsonObject
+    assertThat(parsed["observe"]?.jsonPrimitive?.contentOrNull).isEqualTo("semantics")
+    val root = parsed["semantics"]!!.jsonObject["root"]!!.jsonObject
+    assertThat(root["testTag"]?.jsonPrimitive?.contentOrNull).isEqualTo("hero")
+    // ref assigned by SemanticsRefs on the producer side round-trips through.
+    assertThat(parsed["sha256"]?.jsonPrimitive?.contentOrNull).isNotEmpty()
+  }
+
+  @Test
   fun `render_preview rejects overrides the daemon does not support`() {
     // Daemon advertises supportedOverrides = ["widthPx", "uiMode"]; an agent passes localeTag
     // (which the backend would silently ignore today). MCP rejects with a diagnostic instead


### PR DESCRIPTION
## Summary

**#1787** — `render_preview` returned a base64 PNG (~1.5k tokens) on every call. Adds an opt-in `observe` parameter for a structured-first, pixels-on-demand response — the Compose analogue of Playwright's snapshot-default / screenshot-on-demand split:

- `observe="png"` (default, **unchanged**): the base64 image.
- `observe="semantics"`: the `compose/semantics` tree + `sha256` + `width`/`height`, **no base64** — a few hundred tokens vs ~1.5k.
- `observe="hash"`: just `sha256` + dimensions (~tiny), for a cheap "did it change?".

Dimensions are parsed straight from the PNG IHDR header (no image decode); semantics reuses the existing `data/fetch` path (with the `ref`s from #1790). The default stays `png` so the published `compose-preview` skill is unaffected; flipping the default to a cheap mode needs a coordinated skill update (noted follow-up).

## Test plan

- [x] `./gradlew :mcp:test --tests "*DaemonMcpServerTest"` — `observe="hash"` returns `sha256` + `widthPx=40`/`heightPx=30` with a single text block (no base64 image); `observe="semantics"` embeds the `compose/semantics` tree; existing png/overrides/tool-list tests unchanged (`observe` is a field, not a new tool).
- [x] `:mcp` `ktfmtCheck` clean; both `render_preview` schemas + `docs/daemon/MCP.md` + `docs/TOKEN_USAGE.md` updated.

## Scope / follow-up

- Flipping the **default** to the cheap mode (the issue's eventual goal) once the skill bundle is updated in lockstep.
- Applying the same structured-first default to interactive/record frames.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mdfg35bMd7txPNNZHkToww)_