### PR TITLE
fix(mcp): emit the real composable name in record_preview generated tests

### DIFF
--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
@@ -3340,20 +3340,30 @@ class DaemonMcpServer(
   }
 
   /**
-   * Generate a Compose UI test from a `record_preview` interaction (issue #1786). Scaffolds from
-   * the preview FQN (`<class>.<method>` → `setContent { <method>() }`; the generated header tells
-   * the author to confirm the call + add its import, since named/variant preview ids share their
-   * base function and the daemon doesn't expose the bare method name here). Steps are built from
-   * the recording's [evidence] so an `unsupported` event becomes a skipped-step comment rather than
-   * a fabricated step; when the evidence can't be aligned 1:1 we fall back to treating every event
-   * as applied.
+   * Generate a Compose UI test from a `record_preview` interaction (issue #1786). The `setContent {
+   * <method>() }` call uses the preview's real `@Composable` method name resolved from the catalog
+   * ([PreviewEntry.functionName], sourced from the daemon's `discoveryUpdated` `functionName`
+   * field). That's load-bearing for named/variant previews (issue #1807): their id is a synthetic
+   * `…WeatherForecast_Light`, so the old `previewFqn.substringAfterLast('.')` heuristic emitted
+   * `WeatherForecast_Light()` — a call to a function that doesn't exist, yielding an uncompilable
+   * test. We only fall back to that heuristic when the catalog has no entry (e.g. a synthetic uri
+   * that never went through discovery). The generated header still tells the author to add the
+   * composable's import. Steps are built from the recording's [evidence] so an `unsupported` event
+   * becomes a skipped-step comment rather than a fabricated step; when the evidence can't be
+   * aligned 1:1 we fall back to treating every event as applied.
    */
   private fun generateRecordingTestSource(
     uri: PreviewUri,
     events: List<ee.schimke.composeai.daemon.protocol.RecordingScriptEvent>,
     evidence: List<ee.schimke.composeai.daemon.protocol.RecordingScriptEvidence>,
   ): String {
-    val method = uri.previewFqn.substringAfterLast('.').ifBlank { "preview" }
+    val resolvedFunctionName =
+      catalog[DaemonAddr(uri.workspaceId, uri.modulePath)]
+        ?.get(uri.previewFqn)
+        ?.functionName
+        ?.takeIf { it.isNotBlank() }
+    val method =
+      resolvedFunctionName ?: uri.previewFqn.substringAfterLast('.').ifBlank { "preview" }
     val pascal = method.replaceFirstChar { it.uppercaseChar() }
     val camel = method.replaceFirstChar { it.lowercaseChar() }
     // The recording dispatches script events in tMs order and appends one evidence each, so a
@@ -3766,6 +3776,7 @@ class DaemonMcpServer(
           displayName = entry["displayName"]?.jsonPrimitive?.contentOrNull,
           config = entry["config"]?.jsonPrimitive?.contentOrNull,
           sourceFile = sourceFile,
+          functionName = entry["functionName"]?.jsonPrimitive?.contentOrNull,
           sourceLastModifiedMs = sourceLastModifiedMs,
           sourceContentHash = sourceContentHash,
         )
@@ -4028,6 +4039,16 @@ class DaemonMcpServer(
     val displayName: String?,
     val config: String?,
     val sourceFile: String?,
+    /**
+     * Bare `@Composable` method name of the `@Preview` function (the wire field `functionName` on a
+     * `discoveryUpdated` entry — `PreviewInfoDto.methodName`). Distinct from [fqn]/[displayName]: a
+     * named or variant preview (`@Preview(name = "Light")`) carries a synthetic id like
+     * `…WeatherForecast_Light` while every variant of the same function shares this base method
+     * name. `null` for legacy entries / fakes that don't send the field. Used by
+     * [generateRecordingTestSource] to emit a `setContent { <functionName>() }` call that actually
+     * compiles. See issue #1807.
+     */
+    val functionName: String? = null,
     val sourceLastModifiedMs: Long? = null,
     /**
      * SHA-256 of the source file's bytes captured at discovery and refreshed on every

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
@@ -1218,6 +1218,72 @@ class DaemonMcpServerTest {
   }
 
   @Test
+  fun `record_preview emitTest uses the preview's real composable name for a variant preview`() {
+    // Issue #1807: a named/variant `@Preview(name = "Light")` on `fun Forecast()` is catalogued
+    // under a synthetic id whose last segment is `Forecast_Light`, but the only callable that
+    // actually exists is the base `Forecast()`. The generated `setContent { … }` must call the real
+    // function (resolved from the catalog's `functionName`), not the id's last segment, or the test
+    // doesn't compile. Drive `record_preview` with `emitTest=true` and assert the emitted source.
+    val framesDir = tmp.newFolder("variant-frames")
+    writeSolidPng(framesDir.resolve("frame-00000.png"), 0xFF000000.toInt())
+    writeSolidPng(framesDir.resolve("frame-00001.png"), 0xFFFFFFFF.toInt())
+    val recordingsDir = tmp.newFolder("variant-recordings-out")
+    val cannedApngBytes = byteArrayOf(-119, 80, 78, 71, 13, 10, 26, 10, 0x01, 0x02)
+    factory.daemonConfigurer = { d ->
+      d.recordingEncodedBytes = cannedApngBytes
+      d.recordingEncodeDir = recordingsDir
+      d.advertisedDataExtensions =
+        ee.schimke.composeai.data.render.extensions.RecordingScriptDataExtensions.descriptors +
+          ee.schimke.composeai.daemon.InputTouchRecordingScriptEvents.descriptor
+      d.recordingStopResult =
+        ee.schimke.composeai.daemon.protocol.RecordingStopResult(
+          frameCount = 2,
+          durationMs = 100L,
+          framesDir = framesDir.absolutePath,
+          frameWidthPx = 120,
+          frameHeightPx = 40,
+          scriptEvents = emptyList(),
+        )
+    }
+    client.initialize()
+    val projectDir = tmp.newFolder("variant-workspace")
+    tmp.newFolder("variant-workspace", "module")
+    val workspaceId = registerWorkspace(projectDir, "demo")
+    val daemon = warmDaemonFor(workspaceId, ":module")
+    // Synthetic variant id (`…Forecast_Light`) whose base @Composable is `Forecast`.
+    val previewId = "com.example.ForecastKt.Forecast_Light"
+    daemon.emitDiscovery(previewId, functionName = "Forecast")
+    client.expectNotification("notifications/resources/list_changed", 2_000)
+
+    val uri = PreviewUri(workspaceId, ":module", previewId).toUri()
+    val resp =
+      client.callTool(
+        "record_preview",
+        buildJsonObject {
+          put("uri", uri)
+          put("emitTest", true)
+          putJsonArray("events") {
+            add(
+              buildJsonObject {
+                put("tMs", 0)
+                put("kind", "input.click")
+                put("pixelX", 60)
+                put("pixelY", 20)
+              }
+            )
+          }
+        },
+        timeoutMs = 10_000,
+      )
+
+    assertThat(resp.isError()).isFalse()
+    val generated = resp.textContents().last()
+    assertThat(generated).contains("composeTestRule.setContent { Forecast() }")
+    // The id's last segment must NOT leak into the generated call — that's the #1807 bug.
+    assertThat(generated).doesNotContain("Forecast_Light()")
+  }
+
+  @Test
   fun `MCP exposes data slash navigation snapshot and dispatches navigation deepLink + back`() {
     // End-to-end exercise of the navigation surface from an MCP-tool perspective:
     //
@@ -2402,7 +2468,7 @@ class DaemonMcpServerTest {
       // Boot manifest — one entry. The supervisor's `synthesiseInitialDiscovery` reads it on
       // initialize, so the catalog already contains `Initial`.
       manifestFile.writeText(
-        """{"previews":[{"id":"com.example.Initial","className":"com.example","methodName":"Initial","displayName":"Initial"}]}"""
+        """{"previews":[{"id":"com.example.Initial","className":"com.example","functionName":"Initial","displayName":"Initial"}]}"""
       )
       val initialMtime = System.currentTimeMillis() - 60_000
       assertThat(manifestFile.setLastModified(initialMtime)).isTrue()
@@ -2449,8 +2515,8 @@ class DaemonMcpServerTest {
       manifestFile.writeText(
         """
         {"previews":[
-          {"id":"com.example.Initial","className":"com.example","methodName":"Initial","displayName":"Initial"},
-          {"id":"com.example.WeatherForecast_Light","className":"com.example","methodName":"WeatherForecast_Light","displayName":"WeatherForecast_Light"}
+          {"id":"com.example.Initial","className":"com.example","functionName":"Initial","displayName":"Initial"},
+          {"id":"com.example.WeatherForecast_Light","className":"com.example","functionName":"WeatherForecast","displayName":"WeatherForecast_Light"}
         ]}
         """
           .trimIndent()

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/FakeDaemon.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/FakeDaemon.kt
@@ -272,11 +272,19 @@ class FakeDaemon : DaemonSpawn {
     runCatching { daemonReadIn.close() }
   }
 
-  /** Pushes a `discoveryUpdated` notification with one preview added. Test helper. */
+  /**
+   * Pushes a `discoveryUpdated` notification with one preview added. Test helper.
+   *
+   * [functionName] is the bare `@Composable` method name; it defaults to the last id segment but
+   * can be set independently so a test can model a named/variant preview whose id (e.g.
+   * `…Forecast_Light`) differs from its base function (`Forecast`). Emitted under the wire key
+   * `functionName` to match the real daemon's `PreviewInfoDto` `@SerialName("functionName")`.
+   */
   fun emitDiscovery(
     previewId: String,
     displayName: String = previewId,
     sourceFile: String? = null,
+    functionName: String = previewId.substringAfterLast('.'),
   ) {
     val params = buildJsonObject {
       putJsonArray("added") {
@@ -284,7 +292,7 @@ class FakeDaemon : DaemonSpawn {
           buildJsonObject {
             put("id", previewId)
             put("className", previewId.substringBeforeLast('.'))
-            put("methodName", previewId.substringAfterLast('.'))
+            put("functionName", functionName)
             put("displayName", displayName)
             if (sourceFile != null) put("sourceFile", sourceFile)
           }


### PR DESCRIPTION
A named/variant @Preview (e.g. @Preview(name = "Light") on fun Forecast())
is catalogued under a synthetic id whose last segment is Forecast_Light, but
the only callable that exists is the base Forecast(). generateRecordingTestSource
derived the setContent call via previewFqn.substringAfterLast('.'), so emitTest
produced setContent { Forecast_Light() } — a call to a function that doesn't
exist, yielding an uncompilable test (issue #1807).

The daemon already ships the real method name on every discoveryUpdated entry
(PreviewInfoDto.methodName, wire key functionName); the MCP catalog just dropped
it. Capture functionName into PreviewEntry and resolve it when generating the
test, falling back to the old heuristic only when the uri has no catalog entry.

Also fixes FakeDaemon.emitDiscovery to emit the real wire key (functionName,
not methodName) and the previews.json test fixtures to match.