### PR TITLE
feat(mcp): render_matrix across device/locale/uiMode/fontScale (#1788)

### DIFF
--- a/docs/daemon/MCP.md
+++ b/docs/daemon/MCP.md
@@ -106,6 +106,7 @@ supervisor stops respawning.
 | `list_projects()` | List registered projects. |
 | `list_devices()` | List the known `@Preview(device=...)` catalog with resolved geometry. |
 | `render_preview(uri, overrides?, observe?)` | Force-render a preview. `observe` defaults to `png` (base64 image); `semantics` returns the `compose/semantics` tree + sha256 + dimensions and `hash` returns just sha256 + dimensions — token-frugal responses with no base64 (issue #1787). |
+| `render_matrix(uri, axes)` | Render one preview across a cross-product of display axes (`device` × `locale` × `uiMode` × `fontScale`) and return a token-frugal per-cell summary (`overrides`, `sha256`, dimensions, `changed` vs the first cell). No base64; bounded at 24 cells (issue #1788). |
 | `watch(workspaceId, module?, fqnGlob?, awaitDiscovery?, awaitTimeoutMs?)` | Register an area of interest and keep matching previews warm. |
 | `unwatch(workspaceId?, module?, fqnGlob?)` | Drop matching watches. |
 | `list_watches()` | List watches registered by the current session. |

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
@@ -2028,27 +2028,29 @@ class DaemonMcpServer(
       }
     }
 
-    // Validate the axis field names once against the daemon's supportedOverrides (same field set in
-    // every cell), so an unsupported field fails fast instead of after a render.
+    // Decode + validate EVERY cell before rendering — validateOverrides also checks the `device`
+    // catalog id, which varies per cell, so a typo in any cell (not just the first) must be caught.
     val daemon =
       runCatching { supervisor.daemonFor(uri.workspaceId, uri.modulePath) }
         .getOrElse {
           return errorCallToolResult("render_matrix: daemon spawn failed: ${it.message}")
         }
-    val validationOverrides =
-      runCatching { decodePreviewOverrides(cellOverrides.first()) }
-        .getOrElse {
-          return errorCallToolResult("render_matrix: invalid axis values: ${it.message}")
-        }
-    val violations = validateOverrides(validationOverrides, daemon)
+    val decodedCells = cellOverrides.map { cellJson ->
+      val overrides =
+        runCatching { decodePreviewOverrides(cellJson) }
+          .getOrElse {
+            return errorCallToolResult("render_matrix: invalid axis values: ${it.message}")
+          }
+      cellJson to overrides
+    }
+    val violations = decodedCells.flatMap { (_, overrides) -> validateOverrides(overrides, daemon) }
     if (violations.isNotEmpty()) {
-      return errorCallToolResult("render_matrix: ${violations.joinToString("; ")}")
+      return errorCallToolResult("render_matrix: ${violations.distinct().joinToString("; ")}")
     }
 
     return runCatching {
         var baselineSha: String? = null
-        val cells = cellOverrides.map { cellJson ->
-          val overrides = decodePreviewOverrides(cellJson)
+        val cells = decodedCells.map { (cellJson, overrides) ->
           val bytes = renderAndReadBytes(uri, overrides = overrides)
           val sha = sha256Hex(bytes)
           val dimensions = pngDimensions(bytes)

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
@@ -76,6 +76,9 @@ import okio.Path.Companion.toPath
  * `<className>.<methodName>` per `DiscoverPreviewsTask`), and the URI builder pairs them with the
  * (workspace, module) they came from.
  */
+/** Upper bound on `render_matrix` cells, so a careless cross-product can't fan out unboundedly. */
+private const val MATRIX_CELL_CAP = 24
+
 class DaemonMcpServer(
   private val supervisor: DaemonSupervisor,
   private val sessions: SessionRegistry = SessionRegistry(),
@@ -1514,6 +1517,34 @@ class DaemonMcpServer(
           ),
       ),
       ToolDef(
+        name = "render_matrix",
+        description =
+          "Render one preview across a cross-product of display axes in a single call and return a token-frugal per-cell summary — for 'does this survive small screen + RTL + large font?' without looping render_preview and reading N PNGs (issue #1788). `axes` sets any of device / locale / uiMode / fontScale (each a non-empty array); the result has one cell per combination with its `overrides`, `sha256`, `widthPx`/`heightPx`, and `changed` (sha differs from the first cell — the quick 'which configs render differently?' signal). No base64 images; fetch a specific cell's pixels with render_preview + those overrides when you need to look. Bounded at 24 cells; narrow the axes if you exceed it. Pairs with diff_semantics for per-cell structural diffs.",
+        inputSchema =
+          parseSchema(
+            """
+            {
+              "type":"object",
+              "properties":{
+                "uri":{"type":"string","description":"compose-preview://<workspace>/<module>/<fqn>"},
+                "axes":{
+                  "type":"object",
+                  "description":"Cross-product axes; set at least one. Each is a non-empty array.",
+                  "properties":{
+                    "device":{"type":"array","items":{"type":"string"},"description":"@Preview(device=...) ids/specs, e.g. ['id:pixel_5','id:pixel_tablet']."},
+                    "locale":{"type":"array","items":{"type":"string"},"description":"BCP-47 locale tags, e.g. ['en','ar','ja-JP']."},
+                    "uiMode":{"type":"array","items":{"type":"string","enum":["light","dark"]}},
+                    "fontScale":{"type":"array","items":{"type":"number"},"description":"Font-scale multipliers, e.g. [1.0, 2.0]."}
+                  }
+                }
+              },
+              "required":["uri","axes"]
+            }
+            """
+              .trimIndent()
+          ),
+      ),
+      ToolDef(
         name = "subscribe_preview_data",
         description =
           "Subscribe to a data-product kind for one preview. While subscribed, every renderFinished for the preview produces the kind alongside the PNG (subject to the daemon's producer wiring). Useful when the agent expects to ask repeatedly about the same preview — pre-computing on render avoids the get_preview_data re-render cost. Subscriptions are sticky-while-visible: the daemon drops them automatically when the preview leaves the most recent set_visible set, so re-subscribe when the preview returns to view. Idempotent. Errors: DataProductUnknown if the kind isn't advertised or isn't attachable. NOTE: today, MCP doesn't push the attached payload to clients automatically — agents still call get_preview_data to read it; the subscribe just primes the daemon-side cache.",
@@ -1721,6 +1752,7 @@ class DaemonMcpServer(
       "list_projects" -> toolListProjects()
       "list_devices" -> toolListDevices()
       "render_preview" -> toolRenderPreview(args)
+      "render_matrix" -> toolRenderMatrix(args)
       "watch" -> toolWatch(session, args)
       "unwatch" -> toolUnwatch(session, args)
       "list_watches" -> toolListWatches(session)
@@ -1932,6 +1964,114 @@ class DaemonMcpServer(
         }
       }
       .getOrElse { errorCallToolResult("render_preview failed: ${it.message}") }
+  }
+
+  /**
+   * `render_matrix` (issue #1788) — render one preview across a cross-product of display axes
+   * (device × locale × uiMode × fontScale) and return a token-frugal per-cell summary (overrides +
+   * sha256 + dimensions + `changed` vs the first cell). No base64 images; the agent fetches a
+   * specific cell's pixels with `render_preview` + those overrides when it needs to look. Bounded
+   * so a careless cross-product can't fan out unboundedly.
+   */
+  private fun toolRenderMatrix(args: JsonObject): CallToolResult {
+    val uriStr =
+      args["uri"]?.jsonPrimitive?.contentOrNull
+        ?: return errorCallToolResult("render_matrix: missing 'uri'")
+    val uri =
+      PreviewUri.parseOrNull(uriStr)
+        ?: return errorCallToolResult("render_matrix: invalid uri: $uriStr")
+    val axes =
+      args["axes"] as? JsonObject
+        ?: return errorCallToolResult("render_matrix: missing 'axes' (object of arrays)")
+
+    fun stringAxis(key: String): List<String>? =
+      (axes[key] as? JsonArray)
+        ?.mapNotNull { it.jsonPrimitive.contentOrNull?.takeIf { s -> s.isNotBlank() } }
+        ?.takeIf { it.isNotEmpty() }
+    fun floatAxis(key: String): List<Float>? =
+      (axes[key] as? JsonArray)
+        ?.mapNotNull { it.jsonPrimitive.contentOrNull?.toFloatOrNull() }
+        ?.takeIf { it.isNotEmpty() }
+
+    val devices = stringAxis("device")
+    val locales = stringAxis("locale")
+    val uiModes = stringAxis("uiMode")
+    val fontScales = floatAxis("fontScale")
+    if (devices == null && locales == null && uiModes == null && fontScales == null) {
+      return errorCallToolResult(
+        "render_matrix: 'axes' must set at least one of device | locale | uiMode | fontScale " +
+          "(each a non-empty array)"
+      )
+    }
+    val cellCount =
+      (devices?.size ?: 1) * (locales?.size ?: 1) * (uiModes?.size ?: 1) * (fontScales?.size ?: 1)
+    if (cellCount > MATRIX_CELL_CAP) {
+      return errorCallToolResult(
+        "render_matrix: $cellCount cells exceeds the cap of $MATRIX_CELL_CAP; narrow the axes"
+      )
+    }
+
+    // One overrides object per axis combination, preserving device → locale → uiMode → fontScale
+    // order so cell ordering is stable.
+    val cellOverrides: List<JsonObject> = buildList {
+      for (device in devices ?: listOf<String?>(null)) for (locale in
+        locales ?: listOf<String?>(null)) for (uiMode in
+        uiModes ?: listOf<String?>(null)) for (fontScale in fontScales ?: listOf<Float?>(null)) {
+        add(
+          buildJsonObject {
+            device?.let { put("device", it) }
+            locale?.let { put("localeTag", it) }
+            uiMode?.let { put("uiMode", it) }
+            fontScale?.let { put("fontScale", it) }
+          }
+        )
+      }
+    }
+
+    // Validate the axis field names once against the daemon's supportedOverrides (same field set in
+    // every cell), so an unsupported field fails fast instead of after a render.
+    val daemon =
+      runCatching { supervisor.daemonFor(uri.workspaceId, uri.modulePath) }
+        .getOrElse {
+          return errorCallToolResult("render_matrix: daemon spawn failed: ${it.message}")
+        }
+    val validationOverrides =
+      runCatching { decodePreviewOverrides(cellOverrides.first()) }
+        .getOrElse {
+          return errorCallToolResult("render_matrix: invalid axis values: ${it.message}")
+        }
+    val violations = validateOverrides(validationOverrides, daemon)
+    if (violations.isNotEmpty()) {
+      return errorCallToolResult("render_matrix: ${violations.joinToString("; ")}")
+    }
+
+    return runCatching {
+        var baselineSha: String? = null
+        val cells = cellOverrides.map { cellJson ->
+          val overrides = decodePreviewOverrides(cellJson)
+          val bytes = renderAndReadBytes(uri, overrides = overrides)
+          val sha = sha256Hex(bytes)
+          val dimensions = pngDimensions(bytes)
+          if (baselineSha == null) baselineSha = sha
+          buildJsonObject {
+            put("overrides", cellJson)
+            put("sha256", sha)
+            dimensions?.let {
+              put("widthPx", it.first)
+              put("heightPx", it.second)
+            }
+            put("changed", sha != baselineSha)
+          }
+        }
+        val payload = buildJsonObject {
+          put("schema", "compose-preview-matrix/v1")
+          put("uri", uri.toUri())
+          put("cellCount", cells.size)
+          putJsonArray("cells") { cells.forEach { add(it) } }
+        }
+        CallToolResult(content = listOf(ContentBlock.Text(payload.toString())))
+      }
+      .getOrElse { errorCallToolResult("render_matrix failed: ${it.message}") }
   }
 
   /**

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
@@ -97,6 +97,7 @@ class DaemonMcpServerTest {
         "list_projects",
         "list_devices",
         "render_preview",
+        "render_matrix",
         "watch",
         "unwatch",
         "list_watches",
@@ -948,6 +949,130 @@ class DaemonMcpServerTest {
     assertThat(root["testTag"]?.jsonPrimitive?.contentOrNull).isEqualTo("hero")
     // ref assigned by SemanticsRefs on the producer side round-trips through.
     assertThat(parsed["sha256"]?.jsonPrimitive?.contentOrNull).isNotEmpty()
+  }
+
+  @Test
+  fun `render_matrix renders one cell per axis combination with per-cell hashes`() {
+    client.initialize()
+    val projectDir = tmp.newFolder("workspace")
+    tmp.newFolder("workspace", "module")
+    val workspaceId = registerWorkspace(projectDir, "demo")
+    val daemon = warmDaemonFor(workspaceId, ":module")
+    val previewId = "com.example.Red"
+    daemon.emitDiscovery(previewId)
+    client.expectNotification("notifications/resources/list_changed", 2_000)
+    val pngBytes =
+      byteArrayOf(
+        0x89.toByte(),
+        0x50,
+        0x4e,
+        0x47,
+        0x0d,
+        0x0a,
+        0x1a,
+        0x0a,
+        0x00,
+        0x00,
+        0x00,
+        0x0d,
+        0x49,
+        0x48,
+        0x44,
+        0x52,
+        0x00,
+        0x00,
+        0x00,
+        0x28,
+        0x00,
+        0x00,
+        0x00,
+        0x1e,
+      )
+    val pngFile = tmp.newFile("matrix-render.png")
+    Files.write(pngFile.toPath(), pngBytes)
+    daemon.autoRenderPngPath = { id -> if (id == previewId) pngFile.absolutePath else null }
+
+    val uri = PreviewUri(workspaceId, ":module", previewId).toUri()
+    val resp =
+      client.callTool(
+        "render_matrix",
+        buildJsonObject {
+          put("uri", uri)
+          putJsonObject("axes") {
+            putJsonArray("uiMode") {
+              add(JsonPrimitive("light"))
+              add(JsonPrimitive("dark"))
+            }
+          }
+        },
+        timeoutMs = 10_000,
+      )
+    val parsed = json.parseToJsonElement(resp.firstTextContent()).jsonObject
+    assertThat(parsed["schema"]?.jsonPrimitive?.contentOrNull)
+      .isEqualTo("compose-preview-matrix/v1")
+    assertThat(parsed["cellCount"]?.jsonPrimitive?.content?.toInt()).isEqualTo(2)
+    val cells = parsed["cells"]!!.jsonArray
+    assertThat(cells).hasSize(2)
+    assertThat(
+        cells[0].jsonObject["overrides"]!!.jsonObject["uiMode"]?.jsonPrimitive?.contentOrNull
+      )
+      .isEqualTo("light")
+    assertThat(
+        cells[1].jsonObject["overrides"]!!.jsonObject["uiMode"]?.jsonPrimitive?.contentOrNull
+      )
+      .isEqualTo("dark")
+    assertThat(cells[0].jsonObject["sha256"]?.jsonPrimitive?.contentOrNull).isNotEmpty()
+    assertThat(cells[0].jsonObject["widthPx"]?.jsonPrimitive?.content?.toInt()).isEqualTo(40)
+    // First cell is the baseline, so it is never "changed".
+    assertThat(cells[0].jsonObject["changed"]?.jsonPrimitive?.content?.toBoolean()).isFalse()
+  }
+
+  @Test
+  fun `render_matrix rejects a cross-product over the cell cap`() {
+    client.initialize()
+    val projectDir = tmp.newFolder("workspace")
+    tmp.newFolder("workspace", "module")
+    val workspaceId = registerWorkspace(projectDir, "demo")
+    warmDaemonFor(workspaceId, ":module")
+    val uri = PreviewUri(workspaceId, ":module", "com.example.Red").toUri()
+    // 5 locales × 5 fontScales = 25 > cap of 24.
+    val resp =
+      client.callTool(
+        "render_matrix",
+        buildJsonObject {
+          put("uri", uri)
+          putJsonObject("axes") {
+            putJsonArray("locale") {
+              listOf("en", "fr", "de", "es", "ja").forEach { add(JsonPrimitive(it)) }
+            }
+            putJsonArray("fontScale") {
+              listOf(1.0, 1.3, 1.6, 2.0, 0.85).forEach { add(JsonPrimitive(it)) }
+            }
+          }
+        },
+        timeoutMs = 10_000,
+      )
+    assertThat(resp.firstTextContent()).contains("exceeds the cap")
+  }
+
+  @Test
+  fun `render_matrix requires at least one axis`() {
+    client.initialize()
+    val projectDir = tmp.newFolder("workspace")
+    tmp.newFolder("workspace", "module")
+    val workspaceId = registerWorkspace(projectDir, "demo")
+    warmDaemonFor(workspaceId, ":module")
+    val uri = PreviewUri(workspaceId, ":module", "com.example.Red").toUri()
+    val resp =
+      client.callTool(
+        "render_matrix",
+        buildJsonObject {
+          put("uri", uri)
+          putJsonObject("axes") {}
+        },
+        timeoutMs = 10_000,
+      )
+    assertThat(resp.firstTextContent()).contains("at least one of device")
   }
 
   @Test

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
@@ -1076,6 +1076,47 @@ class DaemonMcpServerTest {
   }
 
   @Test
+  fun `render_matrix validates the device id in every cell not just the first`() {
+    client.initialize()
+    val projectDir = tmp.newFolder("workspace")
+    tmp.newFolder("workspace", "module")
+    val workspaceId = registerWorkspace(projectDir, "demo")
+    factory.daemonConfigurer = { d ->
+      d.advertisedSupportedOverrides = listOf("device")
+      d.advertisedKnownDevices =
+        listOf(
+          ee.schimke.composeai.daemon.protocol.KnownDevice(
+            id = "id:pixel_5",
+            widthDp = 393,
+            heightDp = 851,
+            density = 2.75f,
+          )
+        )
+    }
+    val daemon = warmDaemonFor(workspaceId, ":module")
+    val previewId = "com.example.Red"
+    daemon.emitDiscovery(previewId)
+    client.expectNotification("notifications/resources/list_changed", 2_000)
+    val uri = PreviewUri(workspaceId, ":module", previewId).toUri()
+    val resp =
+      client.callTool(
+        "render_matrix",
+        buildJsonObject {
+          put("uri", uri)
+          putJsonObject("axes") {
+            // First device is valid; the second is a typo — it must still be rejected.
+            putJsonArray("device") {
+              add(JsonPrimitive("id:pixel_5"))
+              add(JsonPrimitive("id:typo_phone"))
+            }
+          }
+        },
+        timeoutMs = 10_000,
+      )
+    assertThat(resp.firstTextContent()).contains("id:typo_phone")
+  }
+
+  @Test
   fun `render_preview rejects overrides the daemon does not support`() {
     // Daemon advertises supportedOverrides = ["widthPx", "uiMode"]; an agent passes localeTag
     // (which the backend would silently ignore today). MCP rejects with a diagnostic instead


### PR DESCRIPTION
## Summary

**#1788** — "does this survive small screen + RTL + large font?" took N `render_preview` calls + N PNG reads. `render_matrix` renders the cross-product in one call and returns a token-frugal per-cell summary.

- **`render_matrix(uri, axes)`**: `axes` sets any of `device` / `locale` / `uiMode` / `fontScale` (each a non-empty array); one cell per combination, in stable `device → locale → uiMode → fontScale` order.
- Per cell: the `overrides`, `sha256`, `widthPx`/`heightPx` (PNG-header parse, no decode), and `changed` (sha differs from the first cell — the quick "which configs render differently?" signal). **No base64** — the agent fetches a specific cell's pixels with `render_preview` + those overrides when it needs to look. Pairs with `diff_semantics` for per-cell structural diffs.
- Bounded at **24 cells**; reuses the #1787 `sha256Hex`/`pngDimensions` helpers and the existing overrides decode + `supportedOverrides` validation (every cell validated — device ids vary per cell).

## Test plan

- [x] `./gradlew :mcp:test --tests "*DaemonMcpServerTest"` — a 2-cell `uiMode:[light,dark]` matrix (overrides echoed, per-cell sha + dims, baseline `changed=false`); a 25-cell cross-product → cap error; empty `axes` → "at least one axis" error; a typo device in the 2nd cell → rejected; tool-list expectation updated.
- [x] `:mcp` `ktfmtCheck` clean; `docs/daemon/MCP.md` tool table updated.

## Scope / follow-up

- A `compose-preview` CLI equivalent (the issue mentions both surfaces).
- A stitched **contact-sheet** image as an optional non-default output (the per-cell hashes already answer "which changed?" token-frugally).