### PR TITLE
docs: publicise the token-frugal, Playwright-style agent loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,42 @@ vector drawables, adaptive launcher icons, animated-vector drawables — and ind
 attributes in `AndroidManifest.xml` so tooling can link manifest lines to the same rendered PNG.
 Modules without any matching resources self-no-op, so this comes along for free with the plugin.
 
+## The agent loop
+
+These tools give AI coding agents a tight, token-frugal feedback loop over
+Compose UI — the way [Playwright](https://playwright.dev) gave web agents one
+over the DOM: act by a stable reference, observe structure rather than pixels,
+and turn exploration into durable tests. The capabilities below are exposed by
+the preview daemon's MCP server (and, where noted, the `compose-preview` CLI);
+see [`docs/daemon/MCP.md`](docs/daemon/MCP.md) for the full tool surface.
+
+- **Target by semantic ref, not pixels.** `interactive/input` and
+  `record_preview` accept a `target` (`testTag` / `role`+`text` / a stable
+  node `ref`) that the daemon resolves to the node's centre, so a click
+  survives layout changes instead of breaking on a coordinate. Works on
+  Android (Robolectric) and Desktop (Skiko).
+- **Token-frugal observation.** `render_preview observe=semantics|hash`
+  returns the `compose/semantics` tree + a hash + dimensions instead of a
+  base64 PNG — typically a few hundred tokens versus ~1.5k. Fetch pixels only
+  when you actually need to look.
+- **Semantics diff.** `diff_semantics` (MCP) and `compose-preview
+  diff-semantics` (CLI) diff two semantics trees and report what changed
+  *semantically* (text, label, role, testTag, overflow…), matched by stable
+  ref — a deterministic, pixel-free regression signal, the Compose analogue of
+  Playwright's aria-snapshot diff.
+- **Matrix render.** `render_matrix` renders one preview across a cross-product
+  of `device × locale × uiMode × fontScale` in a single call, returning a
+  per-cell hash and which cells changed — "does this survive small screen + RTL
+  + large font?" without N screenshots.
+- **Recording → test.** `record_preview emitTest=true` turns a scripted
+  interaction into a runnable Compose UI test (semantic targets become
+  `onNodeWithTag(...).performClick()` steps).
+- **Structured failures.** A failed render reports a typed `kind` plus a
+  one-line fix hint for recognized signatures (classpath skew, Robolectric SDK
+  mismatch, missing `@Composable`, …) instead of an opaque message.
+
+Cost budget for these in [`docs/TOKEN_USAGE.md`](docs/TOKEN_USAGE.md).
+
 ## What it ships
 
 - **Agent skills** — the `compose-preview` and `compose-preview-review`

--- a/docs/TOKEN_USAGE.md
+++ b/docs/TOKEN_USAGE.md
@@ -84,7 +84,11 @@ previews.
   is ~5–8 KB (~1.5–2.3 k tokens).
 - Visual regression scales linearly per changed preview (~3 k input
   tokens each, dominated by the two PNG reads). A UI PR with 10
-  changed previews is ~30 k input on top of baseline.
+  changed previews is ~30 k input on top of baseline. The pixel-free
+  alternative is `diff_semantics` (MCP) / `compose-preview
+  diff-semantics` (CLI): a semantics-tree diff is a few hundred tokens
+  per changed preview (no PNG reads) and reports *what* changed
+  semantically rather than *that* pixels moved (issue #1785).
 - `record_preview` response size scales with `fps × duration`: each
   captured frame adds a `frames[]` entry plus optional metadata. The
   APNG/MP4 capture path keeps per-frame JSON small; embedded-PNG debug
@@ -99,6 +103,12 @@ previews.
   iterating and only need to know *whether* / *what* changed; fetch
   `observe: "png"` when you actually need to look at pixels (issue
   #1787).
+- `render_matrix` returns one compact cell per axis combination
+  (`overrides` + sha256 + dimensions + a `changed` flag, no base64), so
+  a `device × locale × uiMode × fontScale` sweep costs roughly
+  `cellCount × ~40` tokens instead of `cellCount × ~1.5 k` PNG reads —
+  bounded at 24 cells (issue #1788). Pull a specific cell's pixels with
+  `render_preview` + those overrides when one looks off.
 - These numbers count tokens crossing the LLM/tool boundary, not
   Anthropic billing on cached prefixes. With prompt caching the
   ~13 k MCP baseline is paid once per session and replayed from cache

--- a/site/index.md
+++ b/site/index.md
@@ -24,6 +24,30 @@ reason about the UI, not just look at it.
 
 ---
 
+## The agent loop
+
+A tight, token-frugal feedback loop over Compose UI — the way Playwright gave
+web agents one over the DOM. Exposed by the preview daemon's MCP server (and
+the `compose-preview` CLI where noted):
+
+- **Target by semantic ref, not pixels** — drive a preview by `testTag` /
+  `role`+`text` / a stable node `ref`; the daemon resolves it to the node's
+  centre, so interactions survive layout changes (Android + Desktop).
+- **Token-frugal observation** — `render_preview observe=semantics|hash`
+  returns the semantics tree + hash + dimensions (a few hundred tokens)
+  instead of a base64 PNG; fetch pixels only when you need to look.
+- **Semantics diff** — `diff_semantics` / `compose-preview diff-semantics`
+  report what changed *semantically* between two renders, a deterministic
+  pixel-free regression signal (the aria-snapshot diff for Compose).
+- **Matrix render** — `render_matrix` covers `device × locale × uiMode ×
+  fontScale` in one call with per-cell hashes and a "which changed" flag.
+- **Recording → test** — `record_preview emitTest=true` emits a runnable
+  Compose UI test from a scripted interaction.
+- **Structured failures** — a failed render reports a typed kind + a one-line
+  fix hint instead of an opaque message.
+
+---
+
 ## Installation
 
 ### Gradle plugin


### PR DESCRIPTION
## Summary

Capstone docs for the agent-loop-ergonomics series (#1784–#1789, now all on `main`) — the two updates requested: refresh token-usage guidance, and publicise the token-friendly / Playwright-style functionality.

**Publicise the agent loop**
- `README.md` + `site/index.md`: a new **"The agent loop"** section framing the new capabilities as the Compose analogue of Playwright's agent loop — target by semantic ref (not pixels), token-frugal `observe` modes, semantics diff, matrix render, recording→test, and structured render failures, with links to `docs/daemon/MCP.md` and `docs/TOKEN_USAGE.md`.

**Token-usage mentions**
- `docs/TOKEN_USAGE.md`: noted `diff_semantics` as the pixel-free alternative to the visual-regression audit (~few hundred tokens, no PNG reads), and `render_matrix`'s per-cell cost (~40 tok/cell vs ~1.5k PNG reads, 24-cell cap) — alongside the `render_preview observe` note already added with #1787.
- `docs/daemon/MCP.md` already carries `observe` / `render_matrix` / `diff_semantics` / `emitTest` rows (added with the feature PRs), so no change needed there.

Docs-only; no code.

## Note

Deep consumer docs (the `compose-preview` / `compose-preview-review` skill bundles) live in the separate **`yschimke/skills`** repo, which is outside this session's scope — those SKILL/reference pages should mirror the same capabilities (semantic targeting, `observe`, `diff_semantics`, `render_matrix`, `emitTest`). I can do that pass if you add that repo to the session.