### PR TITLE
feat(vscode): overlay per-panel wireframes in the spatial view

### DIFF
--- a/vscode-extension/preview-harness/fixtures/spatial-scene/compose-spatial-semantics.json
+++ b/vscode-extension/preview-harness/fixtures/spatial-scene/compose-spatial-semantics.json
@@ -1,0 +1,66 @@
+{
+    "version": 1,
+    "units": "dp",
+    "previewId": "com.example.samplexrspatial.SubspaceXrLayout",
+    "root": {
+        "id": "column",
+        "kind": "column",
+        "poseInRoot": {
+            "translation": { "x": 0, "y": 0, "z": 0 },
+            "rotation": { "x": 0, "y": 0, "z": 0, "w": 1 }
+        },
+        "sizeDp": { "width": 560, "height": 360, "depth": 0 },
+        "children": [
+            {
+                "id": "top",
+                "kind": "panel",
+                "label": "Now Playing",
+                "poseInRoot": {
+                    "translation": { "x": 0, "y": 80, "z": 0 },
+                    "rotation": { "x": 0, "y": 0, "z": 0, "w": 1 }
+                },
+                "sizeDp": { "width": 560, "height": 200, "depth": 0 },
+                "panelContent": {
+                    "nodeId": "10",
+                    "boundsInRoot": "0,0,560,200",
+                    "children": [
+                        {
+                            "nodeId": "11",
+                            "boundsInRoot": "16,16,300,52",
+                            "text": "Midnight City"
+                        },
+                        {
+                            "nodeId": "12",
+                            "boundsInRoot": "16,60,200,88",
+                            "text": "M83"
+                        }
+                    ]
+                }
+            },
+            {
+                "id": "bottom",
+                "kind": "panel",
+                "label": "Transport",
+                "poseInRoot": {
+                    "translation": { "x": 0, "y": -100, "z": 0 },
+                    "rotation": { "x": 0, "y": 0, "z": 0, "w": 1 }
+                },
+                "sizeDp": { "width": 560, "height": 160, "depth": 0 },
+                "panelContent": {
+                    "nodeId": "20",
+                    "boundsInRoot": "0,0,560,160",
+                    "mergeMode": "mergeDescendants",
+                    "children": [
+                        {
+                            "nodeId": "21",
+                            "boundsInRoot": "24,24,88,72",
+                            "label": "Play",
+                            "role": "Button",
+                            "clickable": true
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+}

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -14,6 +14,7 @@ import { ClassVersionError } from "./classVersionErrorDetector";
 import { KotlinCompileError } from "./kotlinCompileErrorDetector";
 import { PreviewPanel } from "./previewPanel";
 import { parseSpatialSceneJson } from "./webview/spatial/sceneLoader";
+import { parseSpatialSemanticsTreeJson } from "./webview/spatial/semanticsTreeLoader";
 import { BundleViewerPanel } from "./bundleViewerPanel";
 import { FontBrowserPanel } from "./fontBrowserPanel";
 import { isLikelyBundle } from "./bundleFormat";
@@ -1716,6 +1717,25 @@ export async function activate(
                 try {
                     const text = fs.readFileSync(sceneFile.fsPath, "utf8");
                     const scene = parseSpatialSceneJson(text);
+                    // Optional companion semantics tree — when the fixture
+                    // ships `compose-spatial-semantics.json` (the
+                    // `compose/spatial-semantics` data product), overlay each
+                    // panel's 2D wireframe onto its 3D face. Best-effort: a
+                    // missing/invalid tree just shows the plain screenshots.
+                    const treeFile = vscode.Uri.joinPath(
+                        fixtureDir,
+                        "compose-spatial-semantics.json",
+                    );
+                    let semanticsTree:
+                        | ReturnType<typeof parseSpatialSemanticsTreeJson>
+                        | undefined;
+                    try {
+                        semanticsTree = parseSpatialSemanticsTreeJson(
+                            fs.readFileSync(treeFile.fsPath, "utf8"),
+                        );
+                    } catch {
+                        semanticsTree = undefined;
+                    }
                     // Reveal/resolve the panel first; `showSpatialScene`
                     // retains the scene and re-posts it on `webviewReady`, so
                     // it lands even when the view is resolving for the first
@@ -1723,7 +1743,7 @@ export async function activate(
                     await vscode.commands.executeCommand(
                         `${PreviewPanel.viewId}.focus`,
                     );
-                    panel.showSpatialScene(scene, fixtureDir);
+                    panel.showSpatialScene(scene, fixtureDir, semanticsTree);
                 } catch (err) {
                     void vscode.window.showErrorMessage(
                         `Could not load spatial fixture: ${(err as Error).message}`,

--- a/vscode-extension/src/previewPanel.ts
+++ b/vscode-extension/src/previewPanel.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import { ExtensionToWebview, WebviewToExtension } from "./types";
 import type { SpatialScene } from "./webview/shared/spatialScene";
+import type { SpatialSemanticsTree } from "./webview/shared/spatialSemanticsTree";
 
 export class PreviewPanel implements vscode.WebviewViewProvider {
     public static readonly viewId = "composePreview.panel";
@@ -12,8 +13,14 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
     private minimalModeEnabled: () => boolean;
     private shouldRestoreVisibility: () => boolean;
     /** The scene last handed to {@link showSpatialScene}; re-posted on every
-     *  `webviewReady` so a late-resolving or reloaded webview still gets it. */
-    private currentSpatialScene?: { scene: SpatialScene; sceneDir: vscode.Uri };
+     *  `webviewReady` so a late-resolving or reloaded webview still gets it.
+     *  `semanticsTree` is the optional companion that overlays per-panel 2D
+     *  wireframes (matched to the scene by panel id). */
+    private currentSpatialScene?: {
+        scene: SpatialScene;
+        sceneDir: vscode.Uri;
+        semanticsTree?: SpatialSemanticsTree;
+    };
 
     constructor(
         extensionUri: vscode.Uri,
@@ -70,14 +77,20 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
      * the panel PNGs live); it is run through `asWebviewUri` so textures load
      * under the strict CSP, and must sit inside `localResourceRoots` (the
      * extension dir covers the committed fixtures). The producer (`:renderer-xr`)
-     * and the dev `openSpatialFixture` command both drive this.
+     * and the dev `openSpatialFixture` command both drive this. The optional
+     * `semanticsTree` companion overlays each panel's 2D wireframe boxes onto
+     * its screenshot face, matched to the scene by panel id.
      */
-    showSpatialScene(scene: SpatialScene, sceneDir: vscode.Uri): void {
+    showSpatialScene(
+        scene: SpatialScene,
+        sceneDir: vscode.Uri,
+        semanticsTree?: SpatialSemanticsTree,
+    ): void {
         // Retain as the current scene so it survives a not-yet-resolved view
         // and a webview reload (hidden → shown): `postSpatialScene` re-sends it
         // on every `webviewReady`, the same way the host republishes
         // `setPreviews` et al.
-        this.currentSpatialScene = { scene, sceneDir };
+        this.currentSpatialScene = { scene, sceneDir, semanticsTree };
         this.postSpatialScene();
     }
 
@@ -86,12 +99,13 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
         if (!webview || !this.currentSpatialScene) {
             return;
         }
-        const { scene, sceneDir } = this.currentSpatialScene;
+        const { scene, sceneDir, semanticsTree } = this.currentSpatialScene;
         const textureBaseUri = `${webview.asWebviewUri(sceneDir)}/`;
         webview.postMessage({
             command: "setSpatialScene",
             scene,
             textureBaseUri,
+            ...(semanticsTree ? { semanticsTree } : {}),
         });
     }
 

--- a/vscode-extension/src/test/spatialFixturePair.test.ts
+++ b/vscode-extension/src/test/spatialFixturePair.test.ts
@@ -1,0 +1,44 @@
+import * as assert from "assert";
+import { readFileSync } from "fs";
+import * as path from "path";
+import { parseSpatialSceneJson } from "../webview/spatial/sceneLoader";
+import {
+    panelWireframesById,
+    parseSpatialSemanticsTreeJson,
+} from "../webview/spatial/semanticsTreeLoader";
+
+const extensionRoot = path.resolve(__dirname, "../..");
+const fixtureDir = path.join(
+    extensionRoot,
+    "preview-harness/fixtures/spatial-scene",
+);
+
+// The `openSpatialFixture` dev command loads scene.json + its companion
+// compose-spatial-semantics.json and overlays per-panel wireframes matched by
+// panel id. The overlay silently no-ops if the two fixtures drift apart, so
+// pin them together: every scene panel must have a matching wireframe.
+describe("spatial-scene fixture pair", () => {
+    const scene = parseSpatialSceneJson(
+        readFileSync(path.join(fixtureDir, "scene.json"), "utf8"),
+    );
+    const tree = parseSpatialSemanticsTreeJson(
+        readFileSync(
+            path.join(fixtureDir, "compose-spatial-semantics.json"),
+            "utf8",
+        ),
+    );
+
+    it("shares previewId across scene and semantics tree", () => {
+        assert.strictEqual(tree.previewId, scene.previewId);
+    });
+
+    it("provides a wireframe overlay for every scene panel", () => {
+        const wireframes = panelWireframesById(tree);
+        for (const panel of scene.panels) {
+            assert.ok(
+                wireframes.has(panel.id),
+                `no wireframe overlay for scene panel "${panel.id}"`,
+            );
+        }
+    });
+});


### PR DESCRIPTION
## Summary

Follow-up to #1816 (the `compose/spatial-semantics` data product). That PR produced and served the tree; this wires it into the **3D spatial view** so each panel's 2D wireframe overlays its screenshot face in the viewer.

The webview already accepted an optional `semanticsTree` on the `setSpatialScene` message (overlaying per-panel wireframes matched by panel id, covered by `spatialToggle.test.ts`) — only the **host** wasn't sending it. So this is the thin host glue plus a fixture:

- `PreviewPanel.showSpatialScene` takes an optional `SpatialSemanticsTree`, retains it, and posts it (re-posted on `webviewReady`, like the scene).
- `openSpatialFixture` loads the companion `compose-spatial-semantics.json` from the fixture dir (best-effort — a missing/invalid tree just shows the plain screenshots) and hands it through.
- Adds the `spatial-scene` companion fixture, panel ids (`top`/`bottom`) matched to `scene.json`.
- A test pins the fixture pair together: every scene panel must have a matching wireframe, so an id drift (which would silently drop the overlay) fails the build.

## Test plan

- [x] `npm test` (1529 passing), including the new `spatial-scene fixture pair` suite.
- [x] `npm run compile:host` (tsc) clean; `npm run format:check` (Prettier `--tab-width 4`) clean across all matched files.

## Notes

This wires the existing `openSpatialFixture` dev command end-to-end (scene + semantics + textures → 3D view with overlays). The broader production path — discovering real `renders/<dir>/` XR previews and feeding them into the view — remains the next step, as noted in `XR_A11Y.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X8ZwHy8Sgg5eVJzNqr1LMb)_