### PR TITLE
feat(vscode): feed real XR renders into the 3D spatial view

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -15,6 +15,7 @@ import { KotlinCompileError } from "./kotlinCompileErrorDetector";
 import { PreviewPanel } from "./previewPanel";
 import { parseSpatialSceneJson } from "./webview/spatial/sceneLoader";
 import { parseSpatialSemanticsTreeJson } from "./webview/spatial/semanticsTreeLoader";
+import { loadSpatialRender } from "./spatialRenderLoader";
 import { BundleViewerPanel } from "./bundleViewerPanel";
 import { FontBrowserPanel } from "./fontBrowserPanel";
 import { isLikelyBundle } from "./bundleFormat";
@@ -4645,6 +4646,39 @@ async function renderWithDiskFallback(
     }
 }
 
+/**
+ * Production XR bridge: if the rendered set contains an XR subspace preview (one
+ * whose render subdir holds a `scene.json`), feed its real scene + per-panel 2D
+ * semantics into the 3D spatial view — the same seam the `openSpatialFixture`
+ * dev command drives, but from live `renders/<id>/` output instead of a committed
+ * fixture. Best-effort and non-intrusive: it only makes the 2D⇄3D toggle live for
+ * that preview (the first one found — the view holds a single scene); it never
+ * steals focus, and ordinary previews (no `scene.json`) leave the 3D view untouched.
+ */
+function feedSpatialPreview(
+    previews: readonly PreviewInfo[],
+    moduleIndex: PreviewModuleIndex,
+    gradle: GradleService,
+    spatialPanel: PreviewPanel,
+): void {
+    for (const preview of previews) {
+        const mod = moduleIndex.get(preview.id);
+        if (!mod) continue;
+        const baseDir = gradle.previewsBaseDir(mod);
+        for (const capture of preview.captures ?? []) {
+            if (!capture.renderOutput) continue;
+            const loaded = loadSpatialRender(baseDir, capture.renderOutput);
+            if (!loaded) continue;
+            spatialPanel.showSpatialScene(
+                loaded.scene,
+                vscode.Uri.file(loaded.sceneDir),
+                loaded.semanticsTree,
+            );
+            return; // a single 3D scene — first XR preview wins
+        }
+    }
+}
+
 async function refresh(
     forceRender: boolean,
     forFilePath?: string,
@@ -5320,6 +5354,24 @@ async function refresh(
             // called finish().
             tracker.finish();
             writeCalibration(module, tracker.phaseDurations);
+        }
+
+        // Production XR bridge: surface a rendered XR subspace preview's real
+        // scene in the 3D spatial view. Best-effort — a malformed/absent scene
+        // just leaves the view as-is, never breaking the carousel refresh.
+        if (!abort.signal.aborted && panel && gradleService) {
+            try {
+                feedSpatialPreview(
+                    displayPreviews,
+                    previewModuleIndex,
+                    gradleService,
+                    panel,
+                );
+            } catch (err) {
+                logLine(
+                    `spatial view: skipped feeding scene — ${(err as Error).message}`,
+                );
+            }
         }
 
         // Compute `@ScrollingPreview(LONG/GIF)` image data products that no producer

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -4677,6 +4677,9 @@ function feedSpatialPreview(
             return; // a single 3D scene — first XR preview wins
         }
     }
+    // No XR preview in this set — clear any scene retained from a prior one so a
+    // stale 3D view doesn't linger behind the toggle (no-ops if none was shown).
+    spatialPanel.clearSpatialScene();
 }
 
 async function refresh(

--- a/vscode-extension/src/gradleService.ts
+++ b/vscode-extension/src/gradleService.ts
@@ -842,6 +842,21 @@ export class GradleService {
     }
 
     /**
+     * Absolute `<module>/build/compose-previews` directory — the base every
+     * render artifact (PNGs, `scene.json`, data products) is written under, and
+     * the root a capture's `renderOutput` path is relative to. Exposed so the
+     * spatial-view bridge can locate an XR preview's `renders/<id>/` output.
+     */
+    previewsBaseDir(module: ModuleInfo): string {
+        return path.join(
+            this.workspaceRoot,
+            module.projectDir,
+            "build",
+            "compose-previews",
+        );
+    }
+
+    /**
      * Read the per-preview runtime-error sidecar — written by the
      * renderer next to where the PNG would have gone, with `.error.json`
      * appended. Returns `null` when the file is absent (preview rendered

--- a/vscode-extension/src/previewPanel.ts
+++ b/vscode-extension/src/previewPanel.ts
@@ -103,6 +103,21 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
         this.postSpatialScene();
     }
 
+    /**
+     * Drop the retained spatial scene and tell the webview to hide its 3D
+     * toggle. Called when a refresh lands on previews with no XR scene, so a
+     * previously-viewed XR scene doesn't linger (it would otherwise be re-posted
+     * on every `webviewReady`). No-ops when nothing is currently shown, keeping
+     * the common non-XR refresh path quiet.
+     */
+    clearSpatialScene(): void {
+        if (!this.currentSpatialScene) {
+            return;
+        }
+        this.currentSpatialScene = undefined;
+        this.view?.webview.postMessage({ command: "clearSpatialScene" });
+    }
+
     private postSpatialScene(): void {
         const webview = this.view?.webview;
         if (!webview || !this.currentSpatialScene) {

--- a/vscode-extension/src/previewPanel.ts
+++ b/vscode-extension/src/previewPanel.ts
@@ -44,7 +44,16 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
         this.view = webviewView;
         webviewView.webview.options = {
             enableScripts: true,
-            localResourceRoots: [this.extensionUri],
+            // The extension dir covers the bundled scripts + committed fixtures;
+            // the open workspace folders cover live render output (an XR
+            // preview's `renders/<id>/` scene + panel textures, fed via
+            // `showSpatialScene` and addressed through `asWebviewUri`). The
+            // carousel base64-inlines its PNGs, but the 3D viewer loads textures
+            // by URI, so those dirs must sit inside `localResourceRoots`.
+            localResourceRoots: [
+                this.extensionUri,
+                ...(vscode.workspace.workspaceFolders?.map((f) => f.uri) ?? []),
+            ],
         };
         webviewView.webview.html = this.getHtml(webviewView.webview);
         webviewView.webview.onDidReceiveMessage((msg: WebviewToExtension) => {

--- a/vscode-extension/src/spatialRenderLoader.ts
+++ b/vscode-extension/src/spatialRenderLoader.ts
@@ -1,0 +1,61 @@
+import * as fs from "fs";
+import * as path from "path";
+import type { SpatialScene } from "./webview/shared/spatialScene";
+import type { SpatialSemanticsTree } from "./webview/shared/spatialSemanticsTree";
+import { parseSpatialSceneJson } from "./webview/spatial/sceneLoader";
+import { parseSpatialSemanticsTreeJson } from "./webview/spatial/semanticsTreeLoader";
+
+/** A real XR preview's render output, ready to hand to `PreviewPanel.showSpatialScene`. */
+export interface LoadedSpatialRender {
+    /** Absolute dir holding `scene.json` + the panel textures — the texture base. */
+    sceneDir: string;
+    scene: SpatialScene;
+    /** Per-panel 2D semantics overlay, when the producer emitted it. */
+    semanticsTree?: SpatialSemanticsTree;
+}
+
+/**
+ * Load the spatial render output for one preview capture, if it is an XR preview.
+ *
+ * The XR signal is a `scene.json` sitting in the capture's render subdir — the
+ * `renders/<id>/` directory next to the optional `composite.png` that the
+ * `composePreviewRenderXr` task writes. Ordinary previews have no `scene.json`,
+ * so this returns `null` for them (and for XR previews not yet rendered).
+ *
+ * `previewsBaseDir` is `<module>/build/compose-previews`; `renderOutput` is the
+ * capture's manifest-relative path (e.g. `renders/<id>/composite.png`). The
+ * scene's relative panel textures resolve against the returned `sceneDir`.
+ *
+ * Throws (via the parsers) when a `scene.json` is present but violates the wire
+ * contract — the caller surfaces that rather than silently degrading, since a
+ * malformed scene is a producer bug, not "this isn't an XR preview".
+ */
+export function loadSpatialRender(
+    previewsBaseDir: string,
+    renderOutput: string,
+): LoadedSpatialRender | null {
+    const sceneDir = path.join(previewsBaseDir, path.dirname(renderOutput));
+    let sceneText: string;
+    try {
+        sceneText = fs.readFileSync(path.join(sceneDir, "scene.json"), "utf8");
+    } catch {
+        return null; // no scene.json → not a (rendered) XR preview
+    }
+    const scene = parseSpatialSceneJson(sceneText);
+
+    // The companion semantics tree is best-effort: a missing or malformed one
+    // just means the 3D faces render without per-panel wireframe overlays.
+    let semanticsTree: SpatialSemanticsTree | undefined;
+    try {
+        semanticsTree = parseSpatialSemanticsTreeJson(
+            fs.readFileSync(
+                path.join(sceneDir, "compose-spatial-semantics.json"),
+                "utf8",
+            ),
+        );
+    } catch {
+        semanticsTree = undefined;
+    }
+
+    return { sceneDir, scene, semanticsTree };
+}

--- a/vscode-extension/src/test/handleErrorMessagePromote.test.ts
+++ b/vscode-extension/src/test/handleErrorMessagePromote.test.ts
@@ -75,6 +75,7 @@ function buildContextStub(): ContextWithSpy {
         },
         toggleBundle: noop,
         setSpatialScene: noop,
+        clearSpatialScene: noop,
     };
     return { ctx, promoteCalls: () => calls.promote };
 }

--- a/vscode-extension/src/test/handleLeaveFocusMode.test.ts
+++ b/vscode-extension/src/test/handleLeaveFocusMode.test.ts
@@ -66,6 +66,7 @@ function buildContextStub(): ContextWithSpy {
         promoteErrorsBundle: noop,
         toggleBundle: noop,
         setSpatialScene: noop,
+        clearSpatialScene: noop,
     };
     return { ctx, leaveCalls: () => calls.leave };
 }

--- a/vscode-extension/src/test/handleTriggerBundleToggle.test.ts
+++ b/vscode-extension/src/test/handleTriggerBundleToggle.test.ts
@@ -64,6 +64,7 @@ function buildContextStub(): ContextWithSpy {
             calls.push(bundleId);
         },
         setSpatialScene: noop,
+        clearSpatialScene: noop,
     };
     return { ctx, toggleCalls: () => calls };
 }

--- a/vscode-extension/src/test/spatialRenderLoader.test.ts
+++ b/vscode-extension/src/test/spatialRenderLoader.test.ts
@@ -1,0 +1,115 @@
+import * as assert from "assert";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import * as path from "path";
+import { loadSpatialRender } from "../spatialRenderLoader";
+import { SPATIAL_SCENE_VERSION } from "../webview/shared/spatialScene";
+import { SPATIAL_SEMANTICS_TREE_VERSION } from "../webview/shared/spatialSemanticsTree";
+
+const sceneJson = (previewId: string) =>
+    JSON.stringify({
+        version: SPATIAL_SCENE_VERSION,
+        units: "dp",
+        previewId,
+        camera: {
+            kind: "orbit",
+            target: { x: 0, y: 0, z: 0 },
+            distance: 1200,
+            yawDeg: 0,
+            pitchDeg: -10,
+        },
+        panels: [
+            {
+                id: "top",
+                label: "Now Playing",
+                poseInRoot: {
+                    translation: { x: 0, y: 80, z: 0 },
+                    rotation: { x: 0, y: 0, z: 0, w: 1 },
+                },
+                sizeDp: { width: 560, height: 200 },
+                texture: "top.png",
+            },
+        ],
+    });
+
+const treeJson = JSON.stringify({
+    version: SPATIAL_SEMANTICS_TREE_VERSION,
+    units: "dp",
+    root: {
+        id: "subspaceRoot",
+        kind: "subspaceRoot",
+        poseInRoot: {
+            translation: { x: 0, y: 0, z: 0 },
+            rotation: { x: 0, y: 0, z: 0, w: 1 },
+        },
+        sizeDp: { width: 0, height: 0, depth: 0 },
+        children: [
+            {
+                id: "top",
+                kind: "panel",
+                poseInRoot: {
+                    translation: { x: 0, y: 0, z: 0 },
+                    rotation: { x: 0, y: 0, z: 0, w: 1 },
+                },
+                sizeDp: { width: 560, height: 200, depth: 0 },
+                panelContent: { nodeId: "1", boundsInRoot: "0,0,560,200" },
+            },
+        ],
+    },
+});
+
+describe("loadSpatialRender", () => {
+    let baseDir: string;
+
+    beforeEach(() => {
+        baseDir = mkdtempSync(path.join(tmpdir(), "spatial-render-"));
+    });
+
+    afterEach(() => {
+        rmSync(baseDir, { recursive: true, force: true });
+    });
+
+    // The capture path the XR discovery emits: renders/<id>/composite.png.
+    const renderOutput = "renders/com.example.Xr/composite.png";
+    const renderDir = () => path.join(baseDir, "renders", "com.example.Xr");
+
+    it("returns null when the capture has no scene.json (ordinary preview)", () => {
+        assert.strictEqual(loadSpatialRender(baseDir, "SomePreview.png"), null);
+    });
+
+    it("loads scene + companion semantics tree from the render subdir", () => {
+        mkdirSync(renderDir(), { recursive: true });
+        writeFileSync(path.join(renderDir(), "scene.json"), sceneJson("Xr"));
+        writeFileSync(
+            path.join(renderDir(), "compose-spatial-semantics.json"),
+            treeJson,
+        );
+
+        const loaded = loadSpatialRender(baseDir, renderOutput);
+        assert.ok(loaded, "expected a loaded spatial render");
+        assert.strictEqual(loaded.sceneDir, renderDir());
+        assert.strictEqual(loaded.scene.previewId, "Xr");
+        assert.deepStrictEqual(
+            loaded.scene.panels.map((p) => p.id),
+            ["top"],
+        );
+        assert.ok(loaded.semanticsTree, "expected the companion tree");
+        assert.strictEqual(loaded.semanticsTree.root.kind, "subspaceRoot");
+    });
+
+    it("loads the scene even when the semantics tree is absent (best-effort)", () => {
+        mkdirSync(renderDir(), { recursive: true });
+        writeFileSync(path.join(renderDir(), "scene.json"), sceneJson("Xr"));
+
+        const loaded = loadSpatialRender(baseDir, renderOutput);
+        assert.ok(loaded);
+        assert.strictEqual(loaded.semanticsTree, undefined);
+    });
+
+    it("throws when scene.json is present but violates the contract", () => {
+        mkdirSync(renderDir(), { recursive: true });
+        writeFileSync(path.join(renderDir(), "scene.json"), '{"version":999}');
+
+        assert.throws(() => loadSpatialRender(baseDir, renderOutput));
+    });
+});

--- a/vscode-extension/src/test/spatialToggle.test.ts
+++ b/vscode-extension/src/test/spatialToggle.test.ts
@@ -148,6 +148,22 @@ describe("SpatialToggleController", () => {
         assert.strictEqual(h.button.getAttribute("aria-pressed"), "false");
     });
 
+    it("clearScene hides the toggle, falls back to 2D, and drops the view scene", async () => {
+        const h = makeHarness();
+        h.controller.setScene(scene(), "https://base/");
+        await h.controller.setMode("3d");
+        const view = h.mount.children[0] as HTMLElement & { scene?: unknown };
+        assert.ok(view.scene, "scene applied before clear");
+
+        await h.controller.clearScene();
+
+        assert.strictEqual(h.controller.hasScene, false);
+        assert.strictEqual(h.button.hidden, true, "toggle re-hidden");
+        assert.strictEqual(h.controller.currentMode, "2d", "fell back to 2D");
+        assert.strictEqual(h.twoDStage.hidden, false);
+        assert.strictEqual(view.scene, null, "view scene cleared");
+    });
+
     it("loads the bundle only once across multiple toggles", async () => {
         const h = makeHarness();
         h.controller.setScene(scene(), "https://base/");

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -739,6 +739,14 @@ export type ExtensionToWebview =
            * matched to the scene by panel id. Omitted until a producer emits it.
            */
           semanticsTree?: SpatialSemanticsTree;
+      }
+    /**
+     * Drop any installed spatial scene — hide the 2D⇄3D toggle and fall back to
+     * 2D. Posted when a refresh moves to previews with no XR scene, so a stale
+     * scene from a previously-viewed XR preview doesn't linger behind the toggle.
+     */
+    | {
+          command: "clearSpatialScene";
       };
 
 /**

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -3550,6 +3550,7 @@ export class PreviewApp extends LitElement {
                 bundleController.toggleBundle(bundleId as BundleId),
             setSpatialScene: (scene, textureBaseUri, semanticsTree) =>
                 spatialToggle.setScene(scene, textureBaseUri, semanticsTree),
+            clearSpatialScene: () => void spatialToggle.clearScene(),
         };
         window.addEventListener("message", (event) => {
             handleExtensionMessage(event.data, messageContext);

--- a/vscode-extension/src/webview/preview/messageHandlers.ts
+++ b/vscode-extension/src/webview/preview/messageHandlers.ts
@@ -175,6 +175,8 @@ export interface PreviewMessageContext {
         textureBaseUri: string,
         semanticsTree?: SpatialSemanticsTree,
     ): void;
+    /** Drop any installed spatial scene (hide the toggle, fall back to 2D). */
+    clearSpatialScene(): void;
 }
 
 /** Methods the dispatcher needs from `<filter-toolbar>`. The component
@@ -251,6 +253,9 @@ export function handleExtensionMessage(
                 msg.textureBaseUri,
                 msg.semanticsTree,
             );
+            return;
+        case "clearSpatialScene":
+            ctx.clearSpatialScene();
             return;
         case "triggerBundleToggle":
             ctx.toggleBundle(msg.bundleId);

--- a/vscode-extension/src/webview/preview/spatialToggle.ts
+++ b/vscode-extension/src/webview/preview/spatialToggle.ts
@@ -125,6 +125,27 @@ export class SpatialToggleController {
         this.reflectButton();
     }
 
+    /**
+     * Drop any installed scene: fall back to 2D, clear the viewer, and re-hide
+     * the toggle. Used when a refresh moves to previews with no XR scene, so a
+     * stale scene from a previously-viewed XR preview doesn't linger behind the
+     * toggle.
+     */
+    async clearScene(): Promise<void> {
+        this.scene = null;
+        this.semanticsTree = null;
+        this.textureBaseUri = "";
+        if (this.mode === "3d") {
+            await this.setMode("2d");
+        }
+        if (this.view) {
+            this.view.scene = null;
+            this.view.semanticsTree = null;
+        }
+        this.deps.toggleButton.hidden = true;
+        this.reflectButton();
+    }
+
     /** Flip between 2D and 3D. */
     toggle(): Promise<void> {
         return this.setMode(this.mode === "2d" ? "3d" : "2d");


### PR DESCRIPTION
## Summary

The production XR bridge: when a rendered preview set contains an `@XrSubspacePreview`, its **real** rendered scene + per-panel 2D semantics now surface in the 3D spatial view. Previously the 3D view was only reachable via the `openSpatialFixture` dev command reading a committed fixture; this wires it to live `renders/<id>/` output.

Builds on #1816 (the `compose/spatial-semantics` producer) and #1818 (the host→webview tree wiring).

- **`spatialRenderLoader.loadSpatialRender()`** (new, pure, unit-tested): reads `scene.json` (+ optional `compose-spatial-semantics.json`) from a capture's `renders/<id>/` subdir. The XR signal is `scene.json`'s presence, so ordinary previews return `null` and are untouched; a malformed scene throws (surfaced, not silently degraded).
- **`GradleService.previewsBaseDir()`**: exposes the `build/compose-previews` base the loader resolves `renderOutput` against.
- **`refresh()`** feeds the first XR preview's scene via `showSpatialScene` after render — best-effort, no focus-stealing, never breaks the carousel.
- **`PreviewPanel` `localResourceRoots`** now includes the open workspace folders so the 3D viewer can load live render textures by URI under the strict CSP. (The 2D carousel base64-inlines its PNGs; the three.js viewer addresses textures by URI, so those dirs must be reachable.)

## Visual evidence

This feeds an existing rendered surface (it doesn't change how it renders), and that surface — the 3D view with per-panel 2D wireframe overlays — is already auto-diffed by the committed `spatial-semantics` harness fixture (one of the bot's captures). I rendered that fixture locally (Chromium + swiftshader) to confirm the exact output users get when an XR preview is fed in:

![spatial view with per-panel wireframe overlays](https://github.com/yschimke/compose-ai-tools/assets/placeholder)

> Panels at their 3D poses (Up Next / Now Playing / Transport / Lyrics / Volume), each with its 2D semantics wireframe overlay. _(Rendered from `preview-harness/fixtures/spatial-semantics` — shared with the author; GitHub image embedding from a headless container isn't available, but this fixture is the auto-diffed proxy per the CLAUDE.md visual-evidence rule.)_

A true end-to-end screenshot needs a real Android XR render (`composePreviewRenderXr`, Robolectric) + a running VS Code host — neither is reachable in this environment; the harness fixture is the renderable proxy.

## Test plan

- [x] `npm test` → 1533 passing, incl. new `loadSpatialRender` suite (null for ordinary previews; loads scene + companion tree; best-effort when tree absent; throws on contract violation).
- [x] `npm run compile:host` (tsc) clean; `npm run format:check` clean.
- [x] Rendered the `spatial-semantics` fixture headlessly (above).
- [ ] Real XR module e2e (Android render → extension feed → 3D view) is CI/Android-only.

## Follow-ups

- Per-selection trigger: click a specific XR card → show *its* scene (today the first XR preview wins, since the view holds a single scene).
- A live-render harness fixture sourced from real `composePreviewRenderXr` output would close the loop from fixture-proxy to true e2e capture.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X8ZwHy8Sgg5eVJzNqr1LMb)_