### PR TITLE
fix(vscode-preview): wait for webfonts before snapshotting

### DIFF
--- a/vscode-extension/preview-harness/scenario.html
+++ b/vscode-extension/preview-harness/scenario.html
@@ -167,6 +167,24 @@
                 // dispatcher's downstream paths to land DOM.
                 await new Promise((r) => requestAnimationFrame(r));
                 await new Promise((r) => requestAnimationFrame(r));
+                // Wait for webfonts before the screenshot. The codicon
+                // icon font (tab-bar glyphs) and the font browser's
+                // per-family preview faces (e.g. Bebas Neue) load lazily —
+                // the browser only fetches them once layout first needs a
+                // glyph, which the rAFs above have now triggered. Until
+                // they land, glyphs measure at fallback width: the bottom
+                // tab strip's last tab (`Lottie`) wraps or not (±24px page
+                // height) and the font browser paints family names in a
+                // fallback face. Both flip non-deterministically between
+                // runs, so every snapshot of those fixtures churned the
+                // baseline on each push regardless of the PR's diff.
+                // `document.fonts.ready` resolves once all faces the layout
+                // has requested have finished loading; a follow-up rAF lets
+                // the reflow they trigger settle before we read the DOM.
+                if (document.fonts?.ready) {
+                    await document.fonts.ready;
+                    await new Promise((r) => requestAnimationFrame(r));
+                }
                 const imgs = Array.from(
                     document.querySelectorAll(".preview-card img"),
                 );


### PR DESCRIPTION
The preview-harness screenshots fullPage as soon as the `ready` flag
flips, with a settle() that waits on rAF, card images, and finite
animations — but never on webfont loading. The codicon icon font (bottom
tab-bar glyphs) and the font browser's per-family preview faces (e.g.
Bebas Neue) load lazily, so under CI timing they often weren't applied at
capture time:

- tab labels measured at fallback width, so the last tab (`Lottie`)
  wrapped or not, flipping page height by 24px on inspection-tree,
  a11y-findings, history-diff, text-strings, a11y-wear, … — the top
  baseline churners (changed in ~25 of 44 main pushes);
- fonts-browser painted family names in a fallback face, flipping
  between two fixed states (identical 3019-px diff every run).

Both surfaced as false "Changed" entries on PRs that never touched those
fixtures (e.g. #1818's spatial-view change flagging fonts-browser.dark).

settle() now awaits `document.fonts.ready` (then one rAF for the reflow
it triggers) so the capture is deterministic. Shared by the snapshot and
contract runners. Verified: 4× repeated renders of inspection-tree.dark
and fonts-browser.dark are now byte-identical and match the intended
compact / display-font state.