### PR TITLE
fix(resources): skip themed adaptive-icon captures when no `<monochrome>` layer

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ResourceDiscovery.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ResourceDiscovery.kt
@@ -82,6 +82,15 @@ object ResourceDiscovery {
             }
           val id = "${parsed.base}/$resourceName"
           val builder = collected.getOrPut(id) { Builder(id = id, type = type) }
+          if (
+            type == ResourceType.ADAPTIVE_ICON && ResourceXmlClassifier.hasMonochromeLayer(file)
+          ) {
+            // Themed captures (THEMED_LIGHT / THEMED_DARK) require a <monochrome> layer; record its
+            // presence so the capture fan-out can skip themed styles for plain
+            // background+foreground
+            // icons rather than emit captures the renderer can't produce (counted as missing).
+            builder.hasMonochrome = true
+          }
           if (builder.type != type) {
             // Same logical id classifies as different ResourceTypes across qualifier dirs (e.g.
             // `drawable/ic_foo.xml` is a vector but `drawable-night/ic_foo.xml` is an
@@ -111,6 +120,7 @@ object ResourceDiscovery {
     stretches: List<NinePatchStretch> = DEFAULT_NINE_PATCH_STRETCHES,
     filmstrip: Boolean = true,
     filmstripFractions: List<Float> = DEFAULT_RESOURCE_FILMSTRIP_FRACTIONS,
+    hasMonochrome: Boolean = true,
   ): List<ResourceCapture> {
     val out = linkedSetOf<ResourceCapture>()
     val baseQualifierSets =
@@ -124,8 +134,14 @@ object ResourceDiscovery {
         when (type) {
           ResourceType.ADAPTIVE_ICON -> {
             // Two-axis fan-out: every (shape × non-LEGACY style) plus one bare LEGACY capture
-            // (mask-independent — pre-O fallback ignores the system mask).
-            val maskedStyles = styles.filter { it != AdaptiveStyle.LEGACY }
+            // (mask-independent — pre-O fallback ignores the system mask). Themed styles need a
+            // <monochrome> layer to render; drop them when the icon has none so a plain
+            // background+foreground icon doesn't emit captures that can't be produced.
+            val maskedStyles = styles.filter {
+              it != AdaptiveStyle.LEGACY &&
+                (hasMonochrome ||
+                  (it != AdaptiveStyle.THEMED_LIGHT && it != AdaptiveStyle.THEMED_DARK))
+            }
             for (shape in shapes) {
               for (style in maskedStyles) {
                 out +=
@@ -306,6 +322,12 @@ object ResourceDiscovery {
     val id: String,
     val type: ResourceType,
     val sourceFiles: LinkedHashMap<String, String> = linkedMapOf(),
+    /**
+     * `true` once any adaptive-icon source file for this resource declares a `<monochrome>` layer.
+     * Gates the THEMED_LIGHT / THEMED_DARK capture fan-out — see
+     * [ResourceXmlClassifier.hasMonochromeLayer].
+     */
+    var hasMonochrome: Boolean = false,
   ) {
     fun build(config: Config): ResourcePreview {
       val qualifierSuffixes: Set<String?> =
@@ -321,6 +343,7 @@ object ResourceDiscovery {
           stretches = config.stretches,
           filmstrip = config.filmstrip,
           filmstripFractions = config.filmstripFractions,
+          hasMonochrome = hasMonochrome,
         )
       return ResourcePreview(
         id = id,

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ResourceXmlClassifier.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ResourceXmlClassifier.kt
@@ -27,6 +27,48 @@ object ResourceXmlClassifier {
 
   fun classify(file: File): ResourceType? = file.inputStream().use { classify(it) }
 
+  /**
+   * Returns `true` when [file] is an `<adaptive-icon>` that declares a `<monochrome>` child layer
+   * (the Android 13+ themed-icon source). Discovery uses this to gate the `THEMED_LIGHT` /
+   * `THEMED_DARK` capture fan-out: those captures can only be rendered from a `<monochrome>` layer,
+   * so a plain `<background>` + `<foreground>` icon would otherwise emit themed captures the
+   * renderer can't produce — counted as missing renders and hard-failing `missing-renders: fail`
+   * (issue: adaptive-icon themed captures with no `<monochrome>` produce no PNG). Returns `false`
+   * for non-adaptive-icon roots and for adaptive icons without a `<monochrome>` child.
+   */
+  fun hasMonochromeLayer(file: File): Boolean = file.inputStream().use { hasMonochromeLayer(it) }
+
+  fun hasMonochromeLayer(input: InputStream): Boolean {
+    val reader =
+      try {
+        factory.createXMLStreamReader(input)
+      } catch (_: XMLStreamException) {
+        return false
+      }
+    try {
+      var sawRoot = false
+      while (reader.hasNext()) {
+        val event = reader.next()
+        if (event != XMLStreamConstants.START_ELEMENT) continue
+        if (!sawRoot) {
+          sawRoot = true
+          if (reader.localName != "adaptive-icon") return false
+        } else if (reader.localName == "monochrome") {
+          return true
+        }
+      }
+      return false
+    } catch (_: XMLStreamException) {
+      return false
+    } finally {
+      try {
+        reader.close()
+      } catch (_: XMLStreamException) {
+        // already closed / never opened — ignore
+      }
+    }
+  }
+
   fun classify(input: InputStream): ResourceType? {
     val reader =
       try {

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/ResourceDiscoveryTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/ResourceDiscoveryTest.kt
@@ -85,7 +85,11 @@ class ResourceDiscoveryTest {
 
   @Test
   fun `adaptive icon fans out shape x style and emits a single LEGACY capture`() {
-    writeXml("mipmap-anydpi-v26", "ic_launcher.xml", "<adaptive-icon />")
+    writeXml(
+      "mipmap-anydpi-v26",
+      "ic_launcher.xml",
+      "<adaptive-icon><monochrome /></adaptive-icon>",
+    )
     val preview =
       discover(
           shapes = listOf(AdaptiveShape.CIRCLE),
@@ -124,7 +128,11 @@ class ResourceDiscoveryTest {
 
   @Test
   fun `themed styles produce themed-light and themed-dark filename suffixes`() {
-    writeXml("mipmap-anydpi-v26", "ic_launcher.xml", "<adaptive-icon />")
+    writeXml(
+      "mipmap-anydpi-v26",
+      "ic_launcher.xml",
+      "<adaptive-icon><monochrome /></adaptive-icon>",
+    )
     val preview =
       discover(
           shapes = listOf(AdaptiveShape.SQUIRCLE),
@@ -135,6 +143,60 @@ class ResourceDiscoveryTest {
       .containsExactly(
         "renders/resources/mipmap/ic_launcher_xhdpi_SHAPE_squircle_themed-light.png",
         "renders/resources/mipmap/ic_launcher_xhdpi_SHAPE_squircle_themed-dark.png",
+      )
+      .inOrder()
+  }
+
+  @Test
+  fun `adaptive icon without monochrome layer omits themed captures`() {
+    // Plain background+foreground icon (the Android Studio template default) — no <monochrome>.
+    writeXml(
+      "mipmap-anydpi-v26",
+      "ic_launcher.xml",
+      "<adaptive-icon><background /><foreground /></adaptive-icon>",
+    )
+    val preview =
+      discover(
+          shapes = listOf(AdaptiveShape.CIRCLE),
+          styles =
+            listOf(
+              AdaptiveStyle.FULL_COLOR,
+              AdaptiveStyle.THEMED_LIGHT,
+              AdaptiveStyle.THEMED_DARK,
+              AdaptiveStyle.LEGACY,
+            ),
+        )
+        .single()
+    // Themed captures (which need a <monochrome> layer to render) are dropped; FULL_COLOR + LEGACY
+    // stay because they render from background/foreground alone.
+    assertThat(preview.captures.map { it.renderOutput })
+      .containsExactly(
+        "renders/resources/mipmap/ic_launcher_xhdpi_SHAPE_circle.png",
+        "renders/resources/mipmap/ic_launcher_xhdpi_LEGACY.png",
+      )
+      .inOrder()
+    assertThat(preview.captures.map { it.variant?.style })
+      .doesNotContain(AdaptiveStyle.THEMED_LIGHT)
+    assertThat(preview.captures.map { it.variant?.style }).doesNotContain(AdaptiveStyle.THEMED_DARK)
+  }
+
+  @Test
+  fun `adaptive icon with monochrome layer keeps themed captures`() {
+    writeXml(
+      "mipmap-anydpi-v26",
+      "ic_launcher.xml",
+      "<adaptive-icon><background /><foreground /><monochrome /></adaptive-icon>",
+    )
+    val preview =
+      discover(
+          shapes = listOf(AdaptiveShape.CIRCLE),
+          styles = listOf(AdaptiveStyle.FULL_COLOR, AdaptiveStyle.THEMED_LIGHT),
+        )
+        .single()
+    assertThat(preview.captures.map { it.renderOutput })
+      .containsExactly(
+        "renders/resources/mipmap/ic_launcher_xhdpi_SHAPE_circle.png",
+        "renders/resources/mipmap/ic_launcher_xhdpi_SHAPE_circle_themed-light.png",
       )
       .inOrder()
   }

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/ResourceXmlClassifierTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/ResourceXmlClassifierTest.kt
@@ -52,6 +52,45 @@ class ResourceXmlClassifierTest {
   }
 
   @Test
+  fun `adaptive-icon with monochrome layer is detected`() {
+    val xml =
+      """
+      <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+        <background android:drawable="@drawable/ic_launcher_background" />
+        <foreground android:drawable="@drawable/ic_launcher_foreground" />
+        <monochrome android:drawable="@drawable/ic_launcher_foreground" />
+      </adaptive-icon>
+      """
+        .trimIndent()
+    assertThat(ResourceXmlClassifier.hasMonochromeLayer(xml.byteInputStream())).isTrue()
+  }
+
+  @Test
+  fun `adaptive-icon without monochrome layer is not detected`() {
+    val xml =
+      """
+      <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+        <background android:drawable="@drawable/ic_launcher_background" />
+        <foreground android:drawable="@drawable/ic_launcher_foreground" />
+      </adaptive-icon>
+      """
+        .trimIndent()
+    assertThat(ResourceXmlClassifier.hasMonochromeLayer(xml.byteInputStream())).isFalse()
+  }
+
+  @Test
+  fun `hasMonochromeLayer is false for non-adaptive-icon roots`() {
+    val xml = "<vector><monochrome /></vector>"
+    assertThat(ResourceXmlClassifier.hasMonochromeLayer(xml.byteInputStream())).isFalse()
+  }
+
+  @Test
+  fun `hasMonochromeLayer is false for malformed xml`() {
+    assertThat(ResourceXmlClassifier.hasMonochromeLayer("<adaptive-icon this is".byteInputStream()))
+      .isFalse()
+  }
+
+  @Test
   fun `unknown root tag returns null`() {
     val xml = """<shape xmlns:android="http://schemas.android.com/apk/res/android" />"""
     assertThat(ResourceXmlClassifier.classify(xml.byteInputStream())).isNull()


### PR DESCRIPTION
## Summary

Plain adaptive icons (`<background>` + `<foreground>` only — the Android Studio template default) have no `<monochrome>` layer, so `THEMED_LIGHT` / `THEMED_DARK` captures cannot be rendered. Discovery still fanned them out, and the renderer's skip-with-warning was counted as a **missing render** — hard-failing `render-previews` under `missing-renders: fail` even though every `FULL_COLOR` shape and the `LEGACY` fallback rasterise fine.

This is the root cause of the "16 captures produced no PNG" report: 2 resources × 4 shapes × 2 themed styles = 16, all themed variants that need a `<monochrome>` layer the plain icon doesn't have.

## Fix

Detect the `<monochrome>` layer at discovery time (`ResourceXmlClassifier.hasMonochromeLayer`) and gate the themed-style fan-out on it, so plain icons emit only the captures the renderer can actually produce. Icons that *do* declare a `<monochrome>` layer keep their themed captures unchanged. The renderer's existing null-guard stays as defence in depth.

## Test plan

- [x] New `hasMonochromeLayer` cases in `ResourceXmlClassifierTest` (present / absent / non-adaptive root / malformed).
- [x] New with/without-`<monochrome>` cases in `ResourceDiscoveryTest`; existing themed-fan-out tests updated to declare `<monochrome>`.
- [x] `./gradlew :gradle-plugin:ktfmtCheckMain :gradle-plugin:ktfmtCheckTest :gradle-plugin:test` green.
- [x] End-to-end reproduction against the real Robolectric resource pipeline: stripping `<monochrome>` from the android sample reproduced `22 file(s), 16 capture(s) missing`; with the fix the same plain icons render `22 file(s), 0 capture(s) missing`, FULL_COLOR shapes + LEGACY intact.