### PR TITLE
fix(ci): rename reusable codex-review secret off the reserved GITHUB_ prefix

### DIFF
--- a/.github/workflows/codex-pr-review-blessed.yml
+++ b/.github/workflows/codex-pr-review-blessed.yml
@@ -98,4 +98,4 @@ jobs:
       codex_api_key: ${{ secrets.CODEX_API_KEY }}
       claude_api_key: ${{ secrets.CLAUDE_API_KEY }}
       gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
-      github_token: ${{ secrets.GITHUB_TOKEN }}
+      gh_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/codex-pr-review-reusable.yml
+++ b/.github/workflows/codex-pr-review-reusable.yml
@@ -87,7 +87,7 @@ on:
       gemini_api_key:
         description: "Optional API key used by Gemini review tooling."
         required: false
-      github_token:
+      gh_token:
         description: "Token used to read artifacts and write PR comments/checks."
         required: true
 
@@ -315,7 +315,7 @@ jobs:
       - name: Optionally update PR branch with review artifacts
         if: ${{ inputs.update_pr_branch }}
         env:
-          GITHUB_TOKEN: ${{ secrets.github_token }}
+          GITHUB_TOKEN: ${{ secrets.gh_token }}
         run: |
           set -euo pipefail
           if [[ "${{ github.event_name }}" != "pull_request" ]]; then
@@ -355,7 +355,7 @@ jobs:
         if: ${{ inputs.post_review_comment }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          github-token: ${{ secrets.github_token }}
+          github-token: ${{ secrets.gh_token }}
           script: |
             const fs = require('fs')
             const body = fs.readFileSync('review-output/codex-review.md', 'utf8')

--- a/.github/workflows/codex-pr-review.yml
+++ b/.github/workflows/codex-pr-review.yml
@@ -60,4 +60,4 @@ jobs:
       codex_api_key: ${{ secrets.CODEX_API_KEY }}
       claude_api_key: ${{ secrets.CLAUDE_API_KEY }}
       gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
-      github_token: ${{ secrets.GITHUB_TOKEN }}
+      gh_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The AI PR Review reusable workflow declared a workflow_call secret named
`github_token`. GitHub forbids secret names starting with the `GITHUB_`
prefix, so the file failed schema validation and emitted a startup_failure
on every push to main (a recurring red X, ~run #1995), even though its
callers are gated to workflow_dispatch only.

Rename the secret to `gh_token` in the reusable workflow and update the
two callers (codex-pr-review.yml, codex-pr-review-blessed.yml) that pass
it. The built-in `secrets.GITHUB_TOKEN` on the caller side is unchanged.