### PR TITLE
fix(mcp): install request handlers before connecting the stdio transport

### DIFF
--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
@@ -344,14 +344,14 @@ class DaemonMcpServer(
 
   fun newSession(input: java.io.InputStream, output: java.io.OutputStream): McpSession {
     lateinit var session: McpSession
-    val sdkServer = composePreviewSdkServer(serverInfo)
     session =
       McpSession(
-        server = sdkServer,
+        serverInfo = serverInfo,
+        options = composePreviewServerOptions(),
         input = input,
         output = output,
         configure = { sdkSession ->
-          sdkServer.installComposePreviewHandlers(
+          installComposePreviewHandlers(
             sdkSession = sdkSession,
             session = session,
             listTools = { currentToolDefs(session) },

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/McpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/McpServer.kt
@@ -3,7 +3,6 @@ package ee.schimke.composeai.mcp
 import ee.schimke.composeai.mcp.protocol.CallToolResult
 import ee.schimke.composeai.mcp.protocol.ContentBlock
 import ee.schimke.composeai.mcp.protocol.ToolDef
-import io.modelcontextprotocol.kotlin.sdk.server.Server
 import io.modelcontextprotocol.kotlin.sdk.server.ServerOptions
 import io.modelcontextprotocol.kotlin.sdk.server.ServerSession
 import io.modelcontextprotocol.kotlin.sdk.server.StdioServerTransport
@@ -38,6 +37,7 @@ import io.modelcontextprotocol.kotlin.sdk.types.UnsubscribeRequest
 import java.io.Closeable
 import java.io.InputStream
 import java.io.OutputStream
+import java.util.UUID
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
 import kotlinx.coroutines.Dispatchers
@@ -81,7 +81,8 @@ interface Session {
 
 /** SDK-backed stdio session with the same lifecycle shape the old hand-rolled session exposed. */
 class McpSession(
-  private val server: Server,
+  private val serverInfo: Implementation,
+  private val options: ServerOptions,
   private val input: InputStream,
   private val output: OutputStream,
   private val configure: (ServerSession) -> Unit,
@@ -94,16 +95,26 @@ class McpSession(
         {
           try {
             runBlocking(Dispatchers.IO) {
-              val session =
-                server.createSession(
-                  StdioServerTransport(input.asSource().buffered(), output.asSink().buffered())
-                )
+              // Build the session ourselves and install our request handlers BEFORE connecting the
+              // transport. `Server.createSession` connects the transport — and so starts draining
+              // client messages — *inside* the call, before it returns the session for us to
+              // configure. Installing handlers after that leaves a race window: an early
+              // `tools/call` (e.g. a client that pipelines initialize → initialized →
+              // register_project) can be answered by the SDK's default tools/call handler, which
+              // looks up an empty registry (we manage tools ourselves and never `addTool`) and
+              // replies "Tool <name> not found". Constructing the ServerSession directly lets us
+              // set every handler first, then connect, so no request is ever served by the SDK
+              // defaults. ServerSession's constructor wires up initialize/ping/logging itself.
+              val session = ServerSession(serverInfo, options, UUID.randomUUID().toString())
               sdkSession = session
               session.onClose {
                 closed.complete(Unit)
                 onClose()
               }
               configure(session)
+              session.connect(
+                StdioServerTransport(input.asSource().buffered(), output.asSink().buffered())
+              )
               while (!closed.isDone) {
                 delay(100)
               }
@@ -128,7 +139,7 @@ class McpSession(
   }
 
   override fun close() {
-    runBlocking { server.close() }
+    runBlocking { sdkSession?.close() }
     closed.complete(Unit)
     thread.join(2_000)
   }
@@ -193,7 +204,7 @@ class SessionRegistry {
   }
 }
 
-internal fun Server.installComposePreviewHandlers(
+internal fun installComposePreviewHandlers(
   sdkSession: ServerSession,
   session: Session,
   listTools: () -> List<ToolDef>,
@@ -230,17 +241,13 @@ internal fun Server.installComposePreviewHandlers(
   }
 }
 
-internal fun composePreviewSdkServer(serverInfo: Implementation): Server =
-  Server(
-    serverInfo = serverInfo,
-    options =
-      ServerOptions(
-        capabilities =
-          ServerCapabilities(
-            tools = ServerCapabilities.Tools(listChanged = true),
-            resources = ServerCapabilities.Resources(subscribe = true, listChanged = true),
-          )
-      ),
+internal fun composePreviewServerOptions(): ServerOptions =
+  ServerOptions(
+    capabilities =
+      ServerCapabilities(
+        tools = ServerCapabilities.Tools(listChanged = true),
+        resources = ServerCapabilities.Resources(subscribe = true, listChanged = true),
+      )
   )
 
 private fun ToolDef.toSdkTool(): Tool {


### PR DESCRIPTION
The agent-audit-samples CI job failed at register_project with "Tool
register_project not found". The MCP server registers that tool, so the
failure was a startup race, not a missing tool.

McpSession built its session via Server.createSession(transport), which
connects the transport — and starts draining client messages — inside the
call, then returns the session for configure() to install our request
handlers. A client that pipelines initialize -> initialized ->
tools/call (as the audit script and any fast stdio client does) could hit
the SDK's default tools/call handler before our override landed; that
handler looks up the SDK tool registry (empty, since we manage tools
ourselves and never addTool) and replies "Tool <name> not found".

Construct the ServerSession directly and install every handler before
calling connect(), so no request is ever served by the SDK defaults. The
session constructor still wires up initialize/ping/logging. Verified by
driving the built CLI's mcp serve over stdio (register_project now
succeeds on the first call, stable across repeated runs) and the full
:mcp:test suite.