### PR TITLE
test(vscode): poll for the renamed-preview PNG instead of asserting once

### DIFF
--- a/vscode-extension/src/test/electron/suite/e2eInteractive.test.ts
+++ b/vscode-extension/src/test/electron/suite/e2eInteractive.test.ts
@@ -769,12 +769,23 @@ describeE2E("Compose Preview interactive scenarios (real Gradle)", function () {
                 newRenderOutputs.length > 0,
                 "renamed preview arrived with 0 captures",
             );
-            for (const p of newRenderOutputs) {
-                assert.ok(
-                    fs.existsSync(p),
-                    `renamed preview render PNG missing on disk at ${p}`,
-                );
-            }
+            // E2 is the one disk check in this suite that races the render
+            // pipeline: the renamed preview is rendered fresh, so its
+            // `setPreviews` metadata (already carrying the capture's
+            // `renderOutput` path) can be published a beat before the PNG bytes
+            // are flushed to disk. Poll for the file rather than asserting once
+            // — every other PNG check here reads a pre-existing render, so only
+            // this freshly-rendered one needs the wait. A genuine "never
+            // written" regression still fails, just via waitFor's timeout.
+            await waitFor(
+                `renamed preview render PNG(s) on disk: ${newRenderOutputs.join(", ")}`,
+                this.timeout(),
+                500,
+                () =>
+                    newRenderOutputs.every((p) => fs.existsSync(p))
+                        ? true
+                        : undefined,
+            );
 
             // Invariant E3: the stale PNG no longer exists on disk. The
             // gradle-level repro proved the renderer sanitises these; this


### PR DESCRIPTION
## Summary

The `VS Code Extension E2E (real Gradle)` job has been flaking intermittently on `main` — the *"E. rename a @Preview function"* scenario fails at invariant E2 with `renamed preview render PNG missing on disk`. It failed on several unrelated recent pushes (release 0.14.0, a deps bump, the preview-harness migration) and passed on others — a classic timing flake, not a regression.

**Root cause:** after the rename the preview is rendered *fresh*, so its `setPreviews` message — which already carries the capture's `renderOutput` path — can be published a beat before the PNG bytes are flushed to disk. The test asserted `fs.existsSync(p)` **once, immediately**, and lost that race. Every other on-disk PNG check in the suite reads a *pre-existing* render (baseline, or paths rendered in an earlier phase), which is why only this freshly-rendered one flaked.

**Fix:** wait for the file using the suite's existing `waitFor` helper (poll every 500ms up to the test timeout) instead of asserting a single time. A genuine "never written" regression still fails — just via `waitFor`'s timeout rather than an instant false negative.

## Test plan

- `npm --prefix vscode-extension run compile:host` — typecheck passes.
- `npm --prefix vscode-extension run format:check` — Prettier clean.
- The real-Gradle e2e itself can't run in this environment (no Android SDK / Electron harness), so the flaky path is verified by CI on this PR. The change is a poll-instead-of-assert that cannot pass an unwritten PNG and only widens the timing tolerance.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LbZxmNfgeDSRQg1kWUjE62)_