### PR TITLE
feat(cli): add bundle embed — web embed ("js bundle") from a preview bundle

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
@@ -38,6 +38,11 @@ import okio.source
  *   v1 is a stub: it extracts the bundle, prints the manifest + resolved classpath, and tells you
  *   what *would* render. Actual rendering (resolving Maven coords + spawning DesktopRendererMain)
  *   is the next milestone.
+ * - **`embed`** — convert a packed bundle into a **self-contained web embed** (the "js bundle"): a
+ *   `compose-preview-embed.js` web component plus an `index.html` demo page, with the baked
+ *   previews inlined as `data:` URIs. An app drops the one script into its site and adds
+ *   `<compose-preview-gallery>` to put the rendered previews on a web page — no build step, no
+ *   framework, no network. See [WebEmbed].
  */
 class BundleCommand(args: List<String>) : Command(args) {
 
@@ -47,6 +52,7 @@ class BundleCommand(args: List<String>) : Command(args) {
       "pack" -> PackSubcommand(args.drop(args.indexOf(sub) + 1)).run()
       "inspect" -> InspectSubcommand(args.drop(args.indexOf(sub) + 1)).run()
       "extract" -> ExtractSubcommand(args.drop(args.indexOf(sub) + 1)).run()
+      "embed" -> EmbedSubcommand(args.drop(args.indexOf(sub) + 1)).run()
       "render" -> RenderSubcommand(args.drop(args.indexOf(sub) + 1)).run()
       "daemon" -> BundleDaemonCommand(args.drop(args.indexOf(sub) + 1)).run()
       null,
@@ -75,6 +81,7 @@ class BundleCommand(args: List<String>) : Command(args) {
         compose-preview bundle pack [--module <name>] [--id <preview>...] [-o <file.png>] [--no-render]
         compose-preview bundle inspect <bundle.png | URL>
         compose-preview bundle extract <bundle.png | URL> [-o <dir>]
+        compose-preview bundle embed   <bundle.png | URL> [-o <dir>] [--title T] [--external-images]
         compose-preview bundle render  <bundle.png | URL> [-o <dir>]   (v1: stub — prints what would render)
         compose-preview bundle daemon  <bundle.png | URL> [-v]         (spawn the desktop daemon over stdio)
 
@@ -88,6 +95,12 @@ class BundleCommand(args: List<String>) : Command(args) {
 
       Inspect / extract / render flags:
         -o, --output <dir>  Directory to extract / render into. Default: alongside the bundle.
+
+      Embed flags:
+        -o, --output <dir>  Directory to write the web embed into. Default: alongside the bundle.
+        --title <text>      Heading shown on the demo page / gallery. Default: the module path.
+        --external-images   Write previews as previews/<id>.png files instead of inlining them as
+                            data: URIs in the script (cacheable assets vs one self-contained .js).
       """
         .trimIndent()
     )
@@ -258,6 +271,73 @@ private class ExtractSubcommand(private val args: List<String>) {
     val zipBytes = BundleReader.extractZipBytes(file)
     safeExtractZip(zipBytes, target)
     println("extracted ${file.name} → ${target.path}")
+  }
+}
+
+private class EmbedSubcommand(
+  private val args: List<String>,
+  private val fileSystem: FileSystem = SystemFileSystem,
+) {
+  fun run() {
+    val path = args.firstOrNull { !it.startsWith("-") }
+    val outDir = args.flagValue("--output") ?: args.flagValue("-o")
+    val title = args.flagValue("--title")
+    val mode =
+      if ("--external-images" in args) WebEmbed.InlineMode.EXTERNAL else WebEmbed.InlineMode.INLINE
+    if (path == null) {
+      System.err.println(
+        "Usage: compose-preview bundle embed <bundle.png | URL> [-o <dir>] [--title T] [--external-images]"
+      )
+      exitProcess(64)
+    }
+    val file =
+      try {
+        BundleSource.resolveToFile(path)
+      } catch (e: IllegalArgumentException) {
+        System.err.println(e.message)
+        exitProcess(1)
+      }
+
+    val data = BundleReader.readWebEmbedData(file)
+    if (data.previews.isEmpty()) {
+      System.err.println(
+        "bundle embed: ${file.name} has no baked preview images — nothing to put on a page. " +
+          "Pack with a render (drop --no-render) so previews/<id>.png exist."
+      )
+      exitProcess(1)
+    }
+
+    val target =
+      File(outDir ?: (file.absoluteFile.parent.toString() + "/${file.nameWithoutExtension}-web"))
+        .absoluteFile
+    val out =
+      WebEmbed.generate(
+        title = title ?: data.manifest.modulePath,
+        modulePath = data.manifest.modulePath,
+        previews = data.previews,
+        mode = mode,
+      )
+
+    target.mkdirs()
+    val targetPath = target.canonicalFile.toPath()
+    for ((rel, bytes) in out.files) {
+      val resolved = targetPath.resolve(rel).normalize()
+      // Generated paths are all controlled (script / index / previews/<id>.png), but resolve+verify
+      // anyway so a stray id can never write outside the output dir.
+      if (!resolved.startsWith(targetPath)) {
+        System.err.println("bundle embed: refusing to write outside $target: $rel")
+        exitProcess(1)
+      }
+      val dest = resolved.toFile()
+      dest.parentFile?.mkdirs()
+      fileSystem.write(dest.path.toPath()) { write(bytes) }
+    }
+
+    println("wrote web embed for ${out.previewCount} preview(s) → ${target.path}")
+    println("  ${WebEmbed.INDEX_NAME}   open this to view the gallery")
+    println(
+      "  ${WebEmbed.SCRIPT_NAME}  add <script src> + <compose-preview-gallery> to embed in a page"
+    )
   }
 }
 
@@ -472,9 +552,77 @@ internal object BundleReader {
 
   data class Metadata(val manifest: Manifest, val report: Report?)
 
+  /**
+   * The previews needed to build a web embed, read out of a packed bundle in one pass: the manifest
+   * (for ordering + cover) plus each selected preview's baked PNG and a display label.
+   *
+   * Previews without a baked `previews/<id>.png` (e.g. a `--no-render` pack, or one that failed to
+   * render) are dropped — there's nothing to show on a web page. Returned in `previewIds` order
+   * with the cover first, matching how the polyglot lays them out.
+   */
+  data class WebEmbedData(val manifest: Manifest, val previews: List<WebEmbed.Preview>)
+
   private val json = Json {
     ignoreUnknownKeys = true
     classDiscriminator = "kind"
+  }
+
+  private val previewsJson = Json {
+    ignoreUnknownKeys = true
+    isLenient = true
+  }
+
+  /**
+   * Read everything a [WebEmbed] needs from a bundle file: the manifest, `previews.json` (for
+   * human-readable labels), and every baked `previews/<id>.png`. The PNGs are the single source of
+   * what's shown, so previews with no baked image are omitted.
+   */
+  fun readWebEmbedData(file: File): WebEmbedData {
+    val zipBytes = extractZipBytes(file)
+    var manifest: Manifest? = null
+    val labels = HashMap<String, String>()
+    val pngs = HashMap<String, ByteArray>()
+    ZipInputStream(ByteArrayInputStream(zipBytes)).use { zin ->
+      while (true) {
+        val entry = zin.nextEntry ?: break
+        val name = entry.name
+        when {
+          name == "bundle.json" ->
+            manifest =
+              json.decodeFromString(Manifest.serializer(), zin.readBytes().toString(Charsets.UTF_8))
+          name == "previews.json" -> {
+            // Best-effort: labels are a nicety. A malformed/foreign previews.json must not sink the
+            // embed — we still have ids from bundle.json to fall back on.
+            runCatching {
+                previewsJson.decodeFromString(
+                  PreviewManifest.serializer(),
+                  zin.readBytes().toString(Charsets.UTF_8),
+                )
+              }
+              .getOrNull()
+              ?.previews
+              ?.forEach { labels[it.id] = it.functionName.ifBlank { it.id } }
+          }
+          name.startsWith("previews/") && name.endsWith(".png") -> {
+            val id = name.removePrefix("previews/").removeSuffix(".png")
+            pngs[id] = zin.readBytes()
+          }
+        }
+        zin.closeEntry()
+      }
+    }
+    val m = manifest ?: throw IllegalArgumentException("bundle.json missing in ${file.path}")
+    val previews =
+      m.previewIds.mapNotNull { id ->
+        val png = pngs[id] ?: return@mapNotNull null
+        WebEmbed.Preview(
+          id = id,
+          label = labels[id] ?: id,
+          pngBytes = png,
+          isCover = id == m.coverPreviewId,
+        )
+      }
+    return WebEmbedData(manifest = m, previews = previews)
   }
 
   fun readMetadata(file: File): Metadata {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/WebEmbed.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/WebEmbed.kt
@@ -36,6 +36,10 @@ import kotlinx.serialization.json.Json
  * [shadow root](https://developer.mozilla.org/docs/Web/API/Web_components/Using_shadow_DOM) so the
  * host page's CSS can't leak in and the embed's styles can't leak out. An optional
  * `only="<id>,<id>"` attribute filters to a subset of previews (e.g. show just the cover).
+ *
+ * Multiple embeds (from different bundles) can coexist on one page: each script registers its data
+ * under a stable key, and a gallery selects its bundle with `embed="<key>"` — the generated
+ * `index.html` sets this. A single embed needs no attribute.
  */
 object WebEmbed {
 
@@ -83,18 +87,25 @@ object WebEmbed {
         when (mode) {
           InlineMode.INLINE ->
             "data:image/png;base64," + Base64.getEncoder().encodeToString(p.pngBytes)
-          InlineMode.EXTERNAL -> "previews/${p.id}.png"
+          // The file is written under the raw id (a single path segment — discovery strips `/`),
+          // but the URL must percent-encode it: an id can carry `#`, `?`, or spaces, and a raw `#`
+          // in `src` would be parsed as a URL fragment, leaving the image broken. The browser
+          // decodes the request back to the raw filename, so the static file still resolves.
+          InlineMode.EXTERNAL -> "previews/${urlEncodeSegment(p.id)}.png"
         }
       if (mode == InlineMode.EXTERNAL) files["previews/${p.id}.png"] = p.pngBytes
       val (w, h) = pngDimensions(p.pngBytes)
       EmbedItem(id = p.id, label = p.label, src = src, width = w, height = h, cover = p.isCover)
     }
 
-    val data = EmbedData(title = title, module = modulePath, previews = items)
+    // A stable per-bundle key so two embeds on one page stay isolated: each script registers its
+    // data under this key and a `<compose-preview-gallery embed="<key>">` element selects it.
+    val key = embedKey(title, modulePath, previews.map { it.id })
+    val data = EmbedData(key = key, title = title, module = modulePath, previews = items)
     val dataJson = JSON.encodeToString(EmbedData.serializer(), data)
 
     files[SCRIPT_NAME] = script(dataJson).toByteArray(Charsets.UTF_8)
-    files[INDEX_NAME] = indexHtml(title).toByteArray(Charsets.UTF_8)
+    files[INDEX_NAME] = indexHtml(title, key).toByteArray(Charsets.UTF_8)
     return Output(files = files, previewCount = previews.size)
   }
 
@@ -118,6 +129,8 @@ object WebEmbed {
   @Serializable
   private data class EmbedData(
     val schema: String = "compose-preview-web-embed/v1",
+    /** Stable id distinguishing this embed from others on the same page. */
+    val key: String,
     val title: String,
     val module: String,
     val previews: List<EmbedItem>,
@@ -137,10 +150,18 @@ object WebEmbed {
 
   /**
    * The web-component script. The `COMPOSE_PREVIEW_DATA` literal is the only generated part; the
-   * rest is static. Wrapped in an IIFE and guarded with `customElements.get` so loading it twice
-   * (or alongside another embed) is harmless. `</script>` can't appear in the JSON (kotlinx escapes
-   * `<`? — no; it does not, so we defensively split any `</` sequence) which keeps the script safe
-   * to also paste inline into a page.
+   * rest is static.
+   *
+   * Each script registers its data into a shared `window.__composePreviewEmbeds__` array keyed by
+   * the embed's `key`, rather than closing the element over a single module-level constant. The
+   * element class is defined once (guarded with `customElements.get`); a second script from a
+   * *different* bundle adds its own data to the registry and re-renders existing galleries, so a
+   * page can host multiple embeds without the first one's previews leaking into the others. A
+   * gallery picks its data via an optional `embed="<key>"` attribute (the generated `index.html`
+   * sets it); with a single embed on the page the attribute is unnecessary.
+   *
+   * `</script>` can't safely sit in an inline `<script>` block, so we defensively split any `</`
+   * sequence — keeping the script paste-safe inline as well as referenced as an external file.
    */
   private fun script(dataJson: String): String {
     // Defensive: if this script is ever pasted *inline* into an HTML <script> block, a literal
@@ -151,6 +172,8 @@ object WebEmbed {
       (function () {
         "use strict";
         const COMPOSE_PREVIEW_DATA = $safeJson;
+        const REGISTRY = (window.__composePreviewEmbeds__ = window.__composePreviewEmbeds__ || []);
+        if (!REGISTRY.some((d) => d.key === COMPOSE_PREVIEW_DATA.key)) REGISTRY.push(COMPOSE_PREVIEW_DATA);
 
         const STYLE = `
           :host { display: block; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; color: #1b1b1f; }
@@ -175,16 +198,35 @@ object WebEmbed {
           }
         `;
 
+        const esc = (s) => String(s).replace(/[&<>"]/g, c => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c]));
+
         class ComposePreviewGallery extends HTMLElement {
-          static get observedAttributes() { return ["only"]; }
+          static get observedAttributes() { return ["only", "embed"]; }
           connectedCallback() { this.render(); }
           attributeChangedCallback() { if (this.shadowRoot) this.render(); }
+          // Resolve which embed's data this element shows: an explicit embed="<key>" wins; otherwise
+          // the sole registered embed. With several embeds and no key we render the first and warn,
+          // so a missing attribute degrades visibly rather than silently showing the wrong bundle.
+          dataFor() {
+            const key = this.getAttribute("embed");
+            if (key) return REGISTRY.find((d) => d.key === key) || null;
+            if (REGISTRY.length > 1) {
+              console.warn('compose-preview: ' + REGISTRY.length + ' embeds on this page; set embed="<key>" to pick one. Showing the first.');
+            }
+            return REGISTRY[0] || null;
+          }
           render() {
             const root = this.shadowRoot || this.attachShadow({ mode: "open" });
+            const data = this.dataFor();
+            if (!data) {
+              const key = this.getAttribute("embed");
+              root.innerHTML = '<style>' + STYLE + '</style><p class="cp-empty">No compose-preview embed' +
+                (key ? ' with key "' + esc(key) + '"' : '') + ' found on this page.</p>';
+              return;
+            }
             const only = (this.getAttribute("only") || "").split(",").map(s => s.trim()).filter(Boolean);
-            const all = (COMPOSE_PREVIEW_DATA.previews || []);
+            const all = (data.previews || []);
             const previews = only.length ? all.filter(p => only.includes(p.id)) : all;
-            const esc = (s) => String(s).replace(/[&<>"]/g, c => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c]));
             const cards = previews.map(p => {
               const dim = (p.width > 0 && p.height > 0) ? ` width="${'$'}{p.width}" height="${'$'}{p.height}"` : "";
               const badge = p.cover ? '<span class="cp-badge">cover</span>' : "";
@@ -201,8 +243,8 @@ object WebEmbed {
             root.innerHTML =
               '<style>' + STYLE + '</style>' +
               '<header class="cp-header">' +
-                '<p class="cp-title">' + esc(COMPOSE_PREVIEW_DATA.title) + '</p>' +
-                (COMPOSE_PREVIEW_DATA.module ? '<p class="cp-module">' + esc(COMPOSE_PREVIEW_DATA.module) + '</p>' : '') +
+                '<p class="cp-title">' + esc(data.title) + '</p>' +
+                (data.module ? '<p class="cp-module">' + esc(data.module) + '</p>' : '') +
               '</header>' +
               body;
           }
@@ -211,14 +253,20 @@ object WebEmbed {
         if (typeof customElements !== "undefined" && !customElements.get("compose-preview-gallery")) {
           customElements.define("compose-preview-gallery", ComposePreviewGallery);
         }
-        if (typeof window !== "undefined") { window.composePreviewData = COMPOSE_PREVIEW_DATA; }
+        // A later script (a second bundle) registers its data after the element was already upgraded
+        // by the first script's define(), so re-render existing galleries now that this embed exists.
+        if (typeof document !== "undefined") {
+          document.querySelectorAll("compose-preview-gallery").forEach((el) => {
+            if (typeof el.render === "function") el.render();
+          });
+        }
       })();
       """
       .trimIndent() + "\n"
   }
 
   /** Minimal demo page that mounts the gallery from the sibling script. */
-  private fun indexHtml(title: String): String {
+  private fun indexHtml(title: String, key: String): String {
     val safeTitle = htmlEscape(title)
     return """
       <!doctype html>
@@ -233,12 +281,43 @@ object WebEmbed {
           </style>
         </head>
         <body>
-          <compose-preview-gallery></compose-preview-gallery>
+          <compose-preview-gallery embed="$key"></compose-preview-gallery>
           <script src="$SCRIPT_NAME"></script>
         </body>
       </html>
       """
       .trimIndent() + "\n"
+  }
+
+  /** Unreserved URL characters (RFC 3986 §2.3) — left as-is when encoding a path segment. */
+  private fun isUrlUnreserved(c: Char): Boolean =
+    c in 'A'..'Z' || c in 'a'..'z' || c in '0'..'9' || c == '-' || c == '_' || c == '.' || c == '~'
+
+  /**
+   * Percent-encode [s] for safe use as a single URL path segment (RFC 3986): every byte outside the
+   * unreserved set becomes `%XX`. Used for `--external-images` `src` URLs so a preview id
+   * containing `#`, `?`, `&`, or a space resolves to its `previews/<id>.png` file instead of being
+   * mangled by URL parsing.
+   */
+  internal fun urlEncodeSegment(s: String): String =
+    buildString(s.length) {
+      for (b in s.toByteArray(Charsets.UTF_8)) {
+        val c = (b.toInt() and 0xff)
+        if (isUrlUnreserved(c.toChar())) append(c.toChar())
+        else append('%').append("%02X".format(c))
+      }
+    }
+
+  /**
+   * A short, stable key distinguishing one embed from another on the same page. Derived from the
+   * title, module, and preview ids so two embeds built from different bundles get different keys
+   * (and re-generating the same bundle yields the same key). Hex, so it's safe in an HTML
+   * attribute.
+   */
+  internal fun embedKey(title: String, modulePath: String, previewIds: List<String>): String {
+    val material = (listOf(title, modulePath) + previewIds).joinToString(" ")
+    val digest = java.security.MessageDigest.getInstance("SHA-256").digest(material.toByteArray())
+    return digest.take(6).joinToString("") { "%02x".format(it) }
   }
 
   private fun htmlEscape(s: String): String =

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/WebEmbed.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/WebEmbed.kt
@@ -1,0 +1,256 @@
+package ee.schimke.composeai.cli
+
+import java.util.Base64
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/**
+ * Generates a **self-contained web embed** from a packed preview bundle — the "js bundle" sibling
+ * of the PNG+ZIP polyglot. Where the polyglot is for image viewers / re-rendering tooling, the web
+ * embed is for *putting the rendered previews on a web page*: an app drops one `.js` file into its
+ * site, adds a `<compose-preview-gallery>` element, and the baked previews render with no build
+ * step, no framework, and no network.
+ *
+ * # Output
+ *
+ * [generate] returns a map of relative path → bytes, written verbatim by the caller:
+ * - **`compose-preview-embed.js`** — a framework-free ES/UMD script that defines and registers a
+ *   `<compose-preview-gallery>`
+ *   [custom element](https://developer.mozilla.org/docs/Web/API/Web_components/Using_custom_elements).
+ *   The previews' metadata and (by default) their PNG bytes as `data:` URIs are baked into a single
+ *   `COMPOSE_PREVIEW_DATA` constant inside the script, so the one file is fully self-contained.
+ * - **`index.html`** — a ready-to-open demo page that loads the script and mounts the gallery, so a
+ *   double-click on the extracted directory shows the previews immediately.
+ * - **`previews/<id>.png`** — only in [InlineMode.EXTERNAL]: the PNGs are written beside the script
+ *   and referenced by relative URL instead of inlined, for callers that prefer cacheable image
+ *   assets over one fat script.
+ *
+ * # Embedding in an app's page
+ *
+ * ```html
+ * <script src="compose-preview-embed.js"></script>
+ * <compose-preview-gallery></compose-preview-gallery>
+ * ```
+ *
+ * The element renders into a
+ * [shadow root](https://developer.mozilla.org/docs/Web/API/Web_components/Using_shadow_DOM) so the
+ * host page's CSS can't leak in and the embed's styles can't leak out. An optional
+ * `only="<id>,<id>"` attribute filters to a subset of previews (e.g. show just the cover).
+ */
+object WebEmbed {
+
+  /** A single preview baked into the embed. */
+  data class Preview(
+    val id: String,
+    /** Human-readable label (the preview's function name, falling back to its id). */
+    val label: String,
+    /** The rendered PNG bytes baked into `previews/<id>.png`. */
+    val pngBytes: ByteArray,
+    /** True for the bundle's cover preview — rendered first and tagged in the UI. */
+    val isCover: Boolean = false,
+  )
+
+  /** How the previews' PNG bytes are carried in the generated output. */
+  enum class InlineMode {
+    /** PNGs baked into the script as `data:` URIs — one self-contained `.js` file. */
+    INLINE,
+    /** PNGs written as `previews/<id>.png` and referenced by relative URL. */
+    EXTERNAL,
+  }
+
+  /** The generated file set, plus the cover dimensions for the caller's summary. */
+  data class Output(val files: Map<String, ByteArray>, val previewCount: Int)
+
+  const val SCRIPT_NAME: String = "compose-preview-embed.js"
+  const val INDEX_NAME: String = "index.html"
+
+  /**
+   * Build the web-embed file set. [title] heads the demo page and the gallery; [modulePath] is
+   * shown as provenance. [previews] are rendered in order — put the cover first. With [mode] =
+   * [InlineMode.EXTERNAL] the PNGs are emitted as separate `previews/<id>.png` files and referenced
+   * by URL; the default [InlineMode.INLINE] bakes them into the script as `data:` URIs.
+   */
+  fun generate(
+    title: String,
+    modulePath: String,
+    previews: List<Preview>,
+    mode: InlineMode = InlineMode.INLINE,
+  ): Output {
+    val files = LinkedHashMap<String, ByteArray>()
+
+    val items = previews.map { p ->
+      val src =
+        when (mode) {
+          InlineMode.INLINE ->
+            "data:image/png;base64," + Base64.getEncoder().encodeToString(p.pngBytes)
+          InlineMode.EXTERNAL -> "previews/${p.id}.png"
+        }
+      if (mode == InlineMode.EXTERNAL) files["previews/${p.id}.png"] = p.pngBytes
+      val (w, h) = pngDimensions(p.pngBytes)
+      EmbedItem(id = p.id, label = p.label, src = src, width = w, height = h, cover = p.isCover)
+    }
+
+    val data = EmbedData(title = title, module = modulePath, previews = items)
+    val dataJson = JSON.encodeToString(EmbedData.serializer(), data)
+
+    files[SCRIPT_NAME] = script(dataJson).toByteArray(Charsets.UTF_8)
+    files[INDEX_NAME] = indexHtml(title).toByteArray(Charsets.UTF_8)
+    return Output(files = files, previewCount = previews.size)
+  }
+
+  /**
+   * Width/height from a PNG's IHDR chunk (the first chunk after the 8-byte signature: 4-byte width,
+   * 4-byte height, big-endian). Returns `0 to 0` when the bytes aren't a PNG we can read, in which
+   * case the component falls back to the image's intrinsic size at render time.
+   */
+  internal fun pngDimensions(bytes: ByteArray): Pair<Int, Int> {
+    // 8 (sig) + 4 (len) + 4 ("IHDR") + 4 (w) + 4 (h) = need at least 24 bytes.
+    if (bytes.size < 24) return 0 to 0
+    if (bytes[12] != 'I'.code.toByte() || bytes[13] != 'H'.code.toByte()) return 0 to 0
+    fun be(off: Int) =
+      ((bytes[off].toInt() and 0xff) shl 24) or
+        ((bytes[off + 1].toInt() and 0xff) shl 16) or
+        ((bytes[off + 2].toInt() and 0xff) shl 8) or
+        (bytes[off + 3].toInt() and 0xff)
+    return be(16) to be(20)
+  }
+
+  @Serializable
+  private data class EmbedData(
+    val schema: String = "compose-preview-web-embed/v1",
+    val title: String,
+    val module: String,
+    val previews: List<EmbedItem>,
+  )
+
+  @Serializable
+  private data class EmbedItem(
+    val id: String,
+    val label: String,
+    val src: String,
+    val width: Int,
+    val height: Int,
+    val cover: Boolean,
+  )
+
+  private val JSON = Json { encodeDefaults = true }
+
+  /**
+   * The web-component script. The `COMPOSE_PREVIEW_DATA` literal is the only generated part; the
+   * rest is static. Wrapped in an IIFE and guarded with `customElements.get` so loading it twice
+   * (or alongside another embed) is harmless. `</script>` can't appear in the JSON (kotlinx escapes
+   * `<`? — no; it does not, so we defensively split any `</` sequence) which keeps the script safe
+   * to also paste inline into a page.
+   */
+  private fun script(dataJson: String): String {
+    // Defensive: if this script is ever pasted *inline* into an HTML <script> block, a literal
+    // `</script>` in the data would close the block early. Split the sequence so the parser can't
+    // see it; JS string concatenation reassembles it. Harmless for the external-file case.
+    val safeJson = dataJson.replace("</", "<\\/")
+    return """
+      (function () {
+        "use strict";
+        const COMPOSE_PREVIEW_DATA = $safeJson;
+
+        const STYLE = `
+          :host { display: block; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; color: #1b1b1f; }
+          .cp-header { margin: 0 0 12px; }
+          .cp-title { font-size: 1.1rem; font-weight: 600; margin: 0; }
+          .cp-module { font-size: 0.8rem; color: #6b6b70; margin: 2px 0 0; }
+          .cp-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(180px, 1fr)); gap: 16px; }
+          .cp-card { border: 1px solid #e3e3e8; border-radius: 10px; overflow: hidden; background: #fff; }
+          .cp-imgwrap { display: flex; align-items: center; justify-content: center; background:
+            repeating-conic-gradient(#f4f4f6 0% 25%, #fff 0% 50%) 50% / 16px 16px; padding: 8px; }
+          .cp-imgwrap img { max-width: 100%; height: auto; display: block; }
+          .cp-meta { padding: 8px 10px; font-size: 0.82rem; display: flex; align-items: center; gap: 6px; }
+          .cp-label { font-weight: 500; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+          .cp-badge { font-size: 0.65rem; text-transform: uppercase; letter-spacing: 0.04em; color: #fff;
+            background: #5b5bd6; border-radius: 4px; padding: 1px 5px; }
+          .cp-empty { color: #6b6b70; font-size: 0.85rem; }
+          @media (prefers-color-scheme: dark) {
+            :host { color: #e6e6e9; }
+            .cp-module, .cp-empty { color: #a0a0a8; }
+            .cp-card { border-color: #34343a; background: #1d1d20; }
+            .cp-imgwrap { background: repeating-conic-gradient(#26262b 0% 25%, #1d1d20 0% 50%) 50% / 16px 16px; }
+          }
+        `;
+
+        class ComposePreviewGallery extends HTMLElement {
+          static get observedAttributes() { return ["only"]; }
+          connectedCallback() { this.render(); }
+          attributeChangedCallback() { if (this.shadowRoot) this.render(); }
+          render() {
+            const root = this.shadowRoot || this.attachShadow({ mode: "open" });
+            const only = (this.getAttribute("only") || "").split(",").map(s => s.trim()).filter(Boolean);
+            const all = (COMPOSE_PREVIEW_DATA.previews || []);
+            const previews = only.length ? all.filter(p => only.includes(p.id)) : all;
+            const esc = (s) => String(s).replace(/[&<>"]/g, c => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c]));
+            const cards = previews.map(p => {
+              const dim = (p.width > 0 && p.height > 0) ? ` width="${'$'}{p.width}" height="${'$'}{p.height}"` : "";
+              const badge = p.cover ? '<span class="cp-badge">cover</span>' : "";
+              return (
+                '<figure class="cp-card">' +
+                  '<div class="cp-imgwrap"><img loading="lazy" alt="' + esc(p.label) + '" src="' + esc(p.src) + '"' + dim + '></div>' +
+                  '<figcaption class="cp-meta">' + badge + '<span class="cp-label" title="' + esc(p.id) + '">' + esc(p.label) + '</span></figcaption>' +
+                '</figure>'
+              );
+            }).join("");
+            const body = previews.length
+              ? '<div class="cp-grid">' + cards + '</div>'
+              : '<p class="cp-empty">No previews in this embed.</p>';
+            root.innerHTML =
+              '<style>' + STYLE + '</style>' +
+              '<header class="cp-header">' +
+                '<p class="cp-title">' + esc(COMPOSE_PREVIEW_DATA.title) + '</p>' +
+                (COMPOSE_PREVIEW_DATA.module ? '<p class="cp-module">' + esc(COMPOSE_PREVIEW_DATA.module) + '</p>' : '') +
+              '</header>' +
+              body;
+          }
+        }
+
+        if (typeof customElements !== "undefined" && !customElements.get("compose-preview-gallery")) {
+          customElements.define("compose-preview-gallery", ComposePreviewGallery);
+        }
+        if (typeof window !== "undefined") { window.composePreviewData = COMPOSE_PREVIEW_DATA; }
+      })();
+      """
+      .trimIndent() + "\n"
+  }
+
+  /** Minimal demo page that mounts the gallery from the sibling script. */
+  private fun indexHtml(title: String): String {
+    val safeTitle = htmlEscape(title)
+    return """
+      <!doctype html>
+      <html lang="en">
+        <head>
+          <meta charset="utf-8">
+          <meta name="viewport" content="width=device-width, initial-scale=1">
+          <title>$safeTitle — compose-preview</title>
+          <style>
+            body { margin: 0; padding: 24px; background: #fafafb; }
+            @media (prefers-color-scheme: dark) { body { background: #161618; } }
+          </style>
+        </head>
+        <body>
+          <compose-preview-gallery></compose-preview-gallery>
+          <script src="$SCRIPT_NAME"></script>
+        </body>
+      </html>
+      """
+      .trimIndent() + "\n"
+  }
+
+  private fun htmlEscape(s: String): String =
+    buildString(s.length) {
+      for (c in s) {
+        when (c) {
+          '&' -> append("&amp;")
+          '<' -> append("&lt;")
+          '>' -> append("&gt;")
+          '"' -> append("&quot;")
+          else -> append(c)
+        }
+      }
+    }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleEmbedDataTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleEmbedDataTest.kt
@@ -1,0 +1,147 @@
+package ee.schimke.composeai.cli
+
+import java.awt.image.BufferedImage
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.nio.file.Files
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+import javax.imageio.ImageIO
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Coverage for [BundleReader.readWebEmbedData] — reading the previews a web embed needs out of a
+ * real PNG+ZIP polyglot bundle. Builds the polyglot the same way the plugin does (a leading PNG
+ * followed by the appended zip) so the reader's polyglot detection is exercised end to end.
+ */
+class BundleEmbedDataTest {
+
+  private val workRoot = Files.createTempDirectory("bundle-embed-test-").toFile()
+
+  @AfterTest
+  fun cleanup() {
+    workRoot.deleteRecursively()
+  }
+
+  private fun png(w: Int = 4, h: Int = 4): ByteArray {
+    val img = BufferedImage(w, h, BufferedImage.TYPE_INT_RGB)
+    img.setRGB(0, 0, 0x112233)
+    val baos = ByteArrayOutputStream()
+    ImageIO.write(img, "png", baos)
+    return baos.toByteArray()
+  }
+
+  private fun polyglot(cover: ByteArray, entries: Map<String, ByteArray>): File {
+    val zip = ByteArrayOutputStream()
+    ZipOutputStream(zip).use { z ->
+      for ((path, bytes) in entries) {
+        z.putNextEntry(ZipEntry(path))
+        z.write(bytes)
+        z.closeEntry()
+      }
+    }
+    val file = File(workRoot, "bundle-${entries.hashCode()}.png")
+    file.outputStream().use {
+      it.write(cover)
+      it.write(zip.toByteArray())
+    }
+    return file
+  }
+
+  @Test
+  fun `reads previews in manifest order with cover flagged and labels from previews_json`() {
+    val coverPng = png(4, 8)
+    val bPng = png(6, 6)
+    val bundleJson =
+      """
+      {"schemaVersion":2,"backend":"desktop","previewIds":["a","b"],"coverPreviewId":"a",
+       "classpath":[{"kind":"module","path":"classes/app.jar"}],
+       "modulePath":":samples:cmp","producedBy":"test"}
+      """
+        .trimIndent()
+    val previewsJson =
+      """
+      {"module":":samples:cmp","variant":"main","previews":[
+        {"id":"a","functionName":"Alpha","className":"X"},
+        {"id":"b","functionName":"Beta","className":"X"}]}
+      """
+        .trimIndent()
+    val file =
+      polyglot(
+        coverPng,
+        linkedMapOf(
+          "bundle.json" to bundleJson.toByteArray(),
+          "previews.json" to previewsJson.toByteArray(),
+          "previews/a.png" to coverPng,
+          "previews/b.png" to bPng,
+        ),
+      )
+
+    val data = BundleReader.readWebEmbedData(file)
+
+    assertEquals(listOf("a", "b"), data.previews.map { it.id })
+    assertEquals(listOf("Alpha", "Beta"), data.previews.map { it.label })
+    assertTrue(data.previews[0].isCover)
+    assertTrue(!data.previews[1].isCover)
+    assertEquals(coverPng.toList(), data.previews[0].pngBytes.toList())
+  }
+
+  @Test
+  fun `previews with no baked png are dropped`() {
+    val bundleJson =
+      """
+      {"schemaVersion":2,"backend":"desktop","previewIds":["a","b","c"],"coverPreviewId":"a",
+       "classpath":[{"kind":"module","path":"classes/app.jar"}],
+       "modulePath":":m","producedBy":"test"}
+      """
+        .trimIndent()
+    val file =
+      polyglot(
+        png(),
+        linkedMapOf(
+          "bundle.json" to bundleJson.toByteArray(),
+          // Only a and c have baked PNGs; b is rendered-but-missing and must be dropped.
+          "previews/a.png" to png(),
+          "previews/c.png" to png(),
+        ),
+      )
+
+    val data = BundleReader.readWebEmbedData(file)
+
+    // b is omitted; a and c stay in manifest order. Labels fall back to ids (no previews.json).
+    assertEquals(listOf("a", "c"), data.previews.map { it.id })
+    assertEquals(listOf("a", "c"), data.previews.map { it.label })
+  }
+
+  @Test
+  fun `end-to-end generate produces a self-contained gallery from the bundle`() {
+    val bundleJson =
+      """
+      {"schemaVersion":2,"backend":"desktop","previewIds":["a"],"coverPreviewId":"a",
+       "classpath":[{"kind":"module","path":"classes/app.jar"}],
+       "modulePath":":app","producedBy":"test"}
+      """
+        .trimIndent()
+    val file =
+      polyglot(
+        png(),
+        linkedMapOf("bundle.json" to bundleJson.toByteArray(), "previews/a.png" to png()),
+      )
+
+    val data = BundleReader.readWebEmbedData(file)
+    val out =
+      WebEmbed.generate(
+        title = "Demo",
+        modulePath = data.manifest.modulePath,
+        previews = data.previews,
+      )
+
+    assertEquals(1, out.previewCount)
+    val script = out.files.getValue(WebEmbed.SCRIPT_NAME).toString(Charsets.UTF_8)
+    assertTrue("compose-preview-gallery" in script)
+    assertTrue("data:image/png;base64," in script)
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/WebEmbedTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/WebEmbedTest.kt
@@ -1,0 +1,121 @@
+package ee.schimke.composeai.cli
+
+import java.awt.image.BufferedImage
+import java.io.ByteArrayOutputStream
+import java.util.Base64
+import javax.imageio.ImageIO
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/** Unit coverage for [WebEmbed] — the bundle → web-embed ("js bundle") generator. */
+class WebEmbedTest {
+
+  private fun png(w: Int, h: Int): ByteArray {
+    val img = BufferedImage(w, h, BufferedImage.TYPE_INT_RGB)
+    img.setRGB(0, 0, 0x336699)
+    val baos = ByteArrayOutputStream()
+    ImageIO.write(img, "png", baos)
+    return baos.toByteArray()
+  }
+
+  @Test
+  fun `inline mode bakes one self-contained script and a demo page`() {
+    val out =
+      WebEmbed.generate(
+        title = "My Previews",
+        modulePath = ":samples:cmp",
+        previews =
+          listOf(
+            WebEmbed.Preview("a", "HomePreview", png(4, 8), isCover = true),
+            WebEmbed.Preview("b", "DetailPreview", png(6, 6)),
+          ),
+      )
+
+    assertEquals(2, out.previewCount)
+    // Inline mode emits exactly the script + the demo page — no separate image files.
+    assertEquals(setOf(WebEmbed.SCRIPT_NAME, WebEmbed.INDEX_NAME), out.files.keys)
+
+    val script = out.files.getValue(WebEmbed.SCRIPT_NAME).toString(Charsets.UTF_8)
+    // The component is defined and registered.
+    assertTrue("customElements.define(\"compose-preview-gallery\"" in script)
+    // Both previews' bytes are inlined as data: URIs, so the file is self-contained.
+    assertTrue("data:image/png;base64," in script)
+    // The IHDR-derived dimensions travelled into the data so the cards avoid layout shift.
+    assertTrue("\"width\":4" in script && "\"height\":8" in script)
+    // Labels and the cover flag are present.
+    assertTrue("HomePreview" in script && "DetailPreview" in script)
+    assertTrue("\"cover\":true" in script)
+
+    val index = out.files.getValue(WebEmbed.INDEX_NAME).toString(Charsets.UTF_8)
+    assertTrue("<compose-preview-gallery></compose-preview-gallery>" in index)
+    assertTrue("<script src=\"${WebEmbed.SCRIPT_NAME}\">" in index)
+    assertTrue("My Previews" in index)
+  }
+
+  @Test
+  fun `external mode writes png files and references them by url`() {
+    val bytes = png(10, 20)
+    val out =
+      WebEmbed.generate(
+        title = "t",
+        modulePath = ":m",
+        previews = listOf(WebEmbed.Preview("only", "OnlyPreview", bytes)),
+        mode = WebEmbed.InlineMode.EXTERNAL,
+      )
+
+    // The PNG is emitted as a sibling file, byte-identical to the input.
+    assertTrue("previews/only.png" in out.files.keys)
+    assertEquals(bytes.toList(), out.files.getValue("previews/only.png").toList())
+
+    val script = out.files.getValue(WebEmbed.SCRIPT_NAME).toString(Charsets.UTF_8)
+    // The script references the file by relative URL, not a data: URI.
+    assertTrue("\"src\":\"previews/only.png\"" in script)
+    assertFalse("data:image/png" in script)
+  }
+
+  @Test
+  fun `titles and labels are html-escaped against injection`() {
+    val out =
+      WebEmbed.generate(
+        title = "<img onerror=alert(1)>",
+        modulePath = ":m",
+        previews = listOf(WebEmbed.Preview("x", "Plain", png(2, 2))),
+      )
+    val index = out.files.getValue(WebEmbed.INDEX_NAME).toString(Charsets.UTF_8)
+    // The raw tag must not appear unescaped in the demo page <title>.
+    assertFalse("<img onerror=alert(1)>" in index)
+    assertTrue("&lt;img onerror=alert(1)&gt;" in index)
+  }
+
+  @Test
+  fun `closing script sequences in data are defused`() {
+    // A label containing </script> must not be able to close an inline <script> block if the
+    // generated JS is ever pasted inline rather than referenced as an external file.
+    val out =
+      WebEmbed.generate(
+        title = "t",
+        modulePath = ":m",
+        previews = listOf(WebEmbed.Preview("x", "</script><b>", png(2, 2))),
+      )
+    val script = out.files.getValue(WebEmbed.SCRIPT_NAME).toString(Charsets.UTF_8)
+    assertFalse("</script>" in script)
+  }
+
+  @Test
+  fun `png dimensions read the IHDR width and height`() {
+    assertEquals(13 to 27, WebEmbed.pngDimensions(png(13, 27)))
+    // Non-PNG bytes fall back to "unknown" rather than throwing.
+    assertEquals(0 to 0, WebEmbed.pngDimensions(byteArrayOf(1, 2, 3)))
+  }
+
+  @Test
+  fun `data uri round-trips the original png bytes`() {
+    val bytes = png(3, 5)
+    val out = WebEmbed.generate("t", ":m", listOf(WebEmbed.Preview("x", "X", bytes)))
+    val script = out.files.getValue(WebEmbed.SCRIPT_NAME).toString(Charsets.UTF_8)
+    val b64 = Base64.getEncoder().encodeToString(bytes)
+    assertTrue("data:image/png;base64,$b64" in script)
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/WebEmbedTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/WebEmbedTest.kt
@@ -49,7 +49,8 @@ class WebEmbedTest {
     assertTrue("\"cover\":true" in script)
 
     val index = out.files.getValue(WebEmbed.INDEX_NAME).toString(Charsets.UTF_8)
-    assertTrue("<compose-preview-gallery></compose-preview-gallery>" in index)
+    assertTrue("<compose-preview-gallery embed=" in index)
+    assertTrue("</compose-preview-gallery>" in index)
     assertTrue("<script src=\"${WebEmbed.SCRIPT_NAME}\">" in index)
     assertTrue("My Previews" in index)
   }
@@ -101,6 +102,57 @@ class WebEmbedTest {
       )
     val script = out.files.getValue(WebEmbed.SCRIPT_NAME).toString(Charsets.UTF_8)
     assertFalse("</script>" in script)
+  }
+
+  @Test
+  fun `external image urls are percent-encoded while files keep the raw id`() {
+    val bytes = png(2, 2)
+    val id = "Foo_#dark and?more"
+    val out =
+      WebEmbed.generate(
+        title = "t",
+        modulePath = ":m",
+        previews = listOf(WebEmbed.Preview(id, "Foo", bytes)),
+        mode = WebEmbed.InlineMode.EXTERNAL,
+      )
+
+    // The file on disk keeps the raw id (a single path segment); the URL is percent-encoded so the
+    // browser doesn't treat `#dark...` as a fragment or `?more` as a query.
+    assertTrue("previews/$id.png" in out.files.keys)
+    val script = out.files.getValue(WebEmbed.SCRIPT_NAME).toString(Charsets.UTF_8)
+    assertTrue("\"src\":\"previews/Foo_%23dark%20and%3Fmore.png\"" in script)
+    // The raw, unencoded URL must not appear.
+    assertFalse("\"src\":\"previews/Foo_#dark" in script)
+  }
+
+  @Test
+  fun `url encoding leaves unreserved characters untouched`() {
+    assertEquals("Abc-_.~09", WebEmbed.urlEncodeSegment("Abc-_.~09"))
+    assertEquals("a%20b", WebEmbed.urlEncodeSegment("a b"))
+    assertEquals("%23%2F%3F", WebEmbed.urlEncodeSegment("#/?"))
+  }
+
+  @Test
+  fun `two embeds get distinct keys and register into a shared registry`() {
+    val a = WebEmbed.generate("A", ":app-a", listOf(WebEmbed.Preview("x", "X", png(2, 2))))
+    val b = WebEmbed.generate("B", ":app-b", listOf(WebEmbed.Preview("y", "Y", png(2, 2))))
+
+    val keyA = WebEmbed.embedKey("A", ":app-a", listOf("x"))
+    val keyB = WebEmbed.embedKey("B", ":app-b", listOf("y"))
+    assertTrue(keyA != keyB)
+    // The key is stable across regenerations of the same bundle.
+    assertEquals(keyA, WebEmbed.embedKey("A", ":app-a", listOf("x")))
+
+    val scriptA = a.files.getValue(WebEmbed.SCRIPT_NAME).toString(Charsets.UTF_8)
+    val scriptB = b.files.getValue(WebEmbed.SCRIPT_NAME).toString(Charsets.UTF_8)
+    // Both scripts push into the same global registry rather than closing over a single constant.
+    assertTrue("window.__composePreviewEmbeds__" in scriptA)
+    assertTrue("\"key\":\"$keyA\"" in scriptA)
+    assertTrue("\"key\":\"$keyB\"" in scriptB)
+
+    // Each demo page targets its own embed by key, so combining them shows the right bundle each.
+    val indexA = a.files.getValue(WebEmbed.INDEX_NAME).toString(Charsets.UTF_8)
+    assertTrue("<compose-preview-gallery embed=\"$keyA\">" in indexA)
   }
 
   @Test


### PR DESCRIPTION
## Summary

Adds a **"js bundle"** sibling to the existing PNG/ZIP polyglot: `compose-preview bundle embed <bundle.png>` converts a packed preview bundle into a self-contained web embed apps can drop into a web page.

Where the polyglot is for image viewers / re-rendering tooling, the web embed is for *putting rendered previews on a web page*. It produces:

- **`compose-preview-embed.js`** — a framework-free web component defining `<compose-preview-gallery>`, with the baked previews inlined as `data:` URIs so the one file is fully self-contained (no build step, no framework, no network).
- **`index.html`** — a ready-to-open demo page that mounts the gallery.
- `--external-images` writes `previews/<id>.png` as cacheable assets instead of inlining them.

Embedding in an app's page is two lines:

```html
<script src="compose-preview-embed.js"></script>
<compose-preview-gallery></compose-preview-gallery>
```

The element renders into a shadow root (no CSS leakage in either direction) and supports an `only="<id>,..."` attribute to show a subset.

## Details

- Backend-agnostic: reads previews straight off the bundle's baked `previews/<id>.png`, so it works for any backend that bakes PNGs (CMP/desktop). Previews with no baked image are dropped.
- Titles/labels are HTML-escaped, and `</script>` sequences in the embedded data are defused so the script is safe even when pasted inline.
- Implemented entirely in `:cli` (`WebEmbed.kt` generator + `BundleReader.readWebEmbedData` + `EmbedSubcommand`); renderer/daemon/plugin untouched. IO goes through Okio with zip-slip-safe writes.

## Visual evidence

Generated from a real `:samples:cmp` bundle (17 previews → a single 208 KB self-contained script + demo page) and rendered in Chromium — responsive grid, per-preview labels, a "COVER" badge, checkerboard transparency backing, dark-mode aware:

![web embed gallery](https://github.com/yschimke/compose-ai-tools/assets/placeholder)

_(Gallery screenshot shared with the author in-session; the surface is reproducible via `compose-preview bundle embed <bundle.png>` + opening `index.html`.)_

## Test plan

- [x] `WebEmbedTest` — inline/external modes, HTML escaping, `</script>` defusing, PNG IHDR dimension reads, data-URI round-trip.
- [x] `BundleEmbedDataTest` — reads a real PNG+ZIP polyglot: manifest order, cover flag, labels from `previews.json`, missing-PNG drop, end-to-end `generate`.
- [x] `./gradlew :cli:ktfmtCheckMain :cli:ktfmtCheckTest :cli:test` green.
- [x] End-to-end smoke: packed `:samples:cmp` → `bundle embed` → rendered the gallery headlessly.

---
_Generated by [Claude Code](https://claude.ai/code/session_0141FYrUJ7fUE5dBH9YhCQub)_