### PR TITLE
feat(cli): bundle embed --in-bundle — embed web resources into the bundle zip

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
@@ -326,7 +326,8 @@ private class EmbedSubcommand(
         mode = mode,
       )
 
-    if (inBundle) embedInBundle(file, out, outArg) else writeToDirectory(file, out, outArg)
+    if (inBundle) embedInBundle(file, out, outArg, BundleSource.looksLikeUrl(path))
+    else writeToDirectory(file, out, outArg)
   }
 
   /** Default mode: write the web embed as loose files under a directory. */
@@ -363,8 +364,25 @@ private class EmbedSubcommand(
    * still a valid polyglot *and* now carries a `web/index.html` someone can open straight out of
    * the unzipped bundle. Re-embedding replaces any prior `web/` entries (idempotent). Writes in
    * place by default; `-o <file.png>` writes an enriched copy instead.
+   *
+   * A URL input resolves to a delete-on-exit temp file, so rewriting it "in place" would vanish on
+   * exit — `-o` is required for downloaded bundles ([resolveInBundleTarget] returns null and we
+   * error rather than silently lose the result).
    */
-  private fun embedInBundle(file: File, out: WebEmbed.Output, outArg: String?) {
+  private fun embedInBundle(
+    file: File,
+    out: WebEmbed.Output,
+    outArg: String?,
+    sourceIsUrl: Boolean,
+  ) {
+    val targetArg = resolveInBundleTarget(outArg, file.absolutePath, sourceIsUrl)
+    if (targetArg == null) {
+      System.err.println(
+        "bundle embed --in-bundle: the input is a downloaded URL (a temporary file). " +
+          "Pass -o <file.png> so the enriched bundle is written somewhere durable."
+      )
+      exitProcess(64)
+    }
     val full = fileSystem.read(file.path.toPath()) { readByteArray() }
     val zip = BundleReader.extractZipBytes(file)
     // The appended zip is a suffix of the file; everything before it is the leading PNG cover.
@@ -372,7 +390,7 @@ private class EmbedSubcommand(
     val webFiles = out.files.mapKeys { (rel, _) -> "$BUNDLE_WEB_DIR/$rel" }
     val newZip = embedWebIntoZip(zip, webFiles)
 
-    val target = File(outArg ?: file.absolutePath).absoluteFile
+    val target = File(targetArg).absoluteFile
     target.parentFile?.mkdirs()
     // Write via a temp sibling + move so an in-place enrich never truncates the bundle on failure.
     val tmp = File(target.parentFile, "${target.name}.embed-tmp")
@@ -498,6 +516,24 @@ internal fun embedWebIntoZip(existingZip: ByteArray, webFiles: Map<String, ByteA
  */
 internal val ZIP_DOS_EPOCH_MS: Long =
   java.util.GregorianCalendar(1980, java.util.Calendar.JANUARY, 1, 0, 0, 0).timeInMillis
+
+/**
+ * The output path for `bundle embed --in-bundle`, or `null` when the caller must error and demand
+ * `-o`. An explicit [outArg] always wins. Otherwise we default to rewriting [inputPath] in place —
+ * but only for a *local* input: a URL input ([sourceIsUrl]) resolved to a delete-on-exit temp file,
+ * and rewriting that "in place" would lose the enriched bundle on exit, so we refuse and require an
+ * explicit output instead.
+ */
+internal fun resolveInBundleTarget(
+  outArg: String?,
+  inputPath: String,
+  sourceIsUrl: Boolean,
+): String? =
+  when {
+    outArg != null -> outArg
+    sourceIsUrl -> null
+    else -> inputPath
+  }
 
 /**
  * Extracts a zip safely — every entry's resolved target path is verified to live inside [target].

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
@@ -2,8 +2,11 @@ package ee.schimke.composeai.cli
 
 import ee.schimke.composeai.io.SystemFileSystem
 import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
 import java.io.File
+import java.util.zip.ZipEntry
 import java.util.zip.ZipInputStream
+import java.util.zip.ZipOutputStream
 import kotlin.system.exitProcess
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
@@ -42,7 +45,9 @@ import okio.source
  *   `compose-preview-embed.js` web component plus an `index.html` demo page, with the baked
  *   previews inlined as `data:` URIs. An app drops the one script into its site and adds
  *   `<compose-preview-gallery>` to put the rendered previews on a web page — no build step, no
- *   framework, no network. See [WebEmbed].
+ *   framework, no network. By default the files land in a directory; `--in-bundle` instead writes
+ *   them into the bundle's own zip under `web/` (the `.png` stays a valid polyglot). See
+ *   [WebEmbed].
  */
 class BundleCommand(args: List<String>) : Command(args) {
 
@@ -81,7 +86,7 @@ class BundleCommand(args: List<String>) : Command(args) {
         compose-preview bundle pack [--module <name>] [--id <preview>...] [-o <file.png>] [--no-render]
         compose-preview bundle inspect <bundle.png | URL>
         compose-preview bundle extract <bundle.png | URL> [-o <dir>]
-        compose-preview bundle embed   <bundle.png | URL> [-o <dir>] [--title T] [--external-images]
+        compose-preview bundle embed   <bundle.png | URL> [-o <dir|file.png>] [--title T] [--external-images] [--in-bundle]
         compose-preview bundle render  <bundle.png | URL> [-o <dir>]   (v1: stub — prints what would render)
         compose-preview bundle daemon  <bundle.png | URL> [-v]         (spawn the desktop daemon over stdio)
 
@@ -97,10 +102,14 @@ class BundleCommand(args: List<String>) : Command(args) {
         -o, --output <dir>  Directory to extract / render into. Default: alongside the bundle.
 
       Embed flags:
-        -o, --output <dir>  Directory to write the web embed into. Default: alongside the bundle.
+        -o, --output <path> Directory to write the web embed into (default: alongside the bundle),
+                            or, with --in-bundle, the output .png (default: rewrite in place).
         --title <text>      Heading shown on the demo page / gallery. Default: the module path.
         --external-images   Write previews as previews/<id>.png files instead of inlining them as
                             data: URIs in the script (cacheable assets vs one self-contained .js).
+        --in-bundle         Embed the web resources into the bundle's own zip under web/ instead of
+                            a loose directory — the .png stays a valid polyglot and now carries a
+                            web/index.html you can open after unzipping. Idempotent.
       """
         .trimIndent()
     )
@@ -280,13 +289,15 @@ private class EmbedSubcommand(
 ) {
   fun run() {
     val path = args.firstOrNull { !it.startsWith("-") }
-    val outDir = args.flagValue("--output") ?: args.flagValue("-o")
+    val outArg = args.flagValue("--output") ?: args.flagValue("-o")
     val title = args.flagValue("--title")
+    val inBundle = "--in-bundle" in args
     val mode =
       if ("--external-images" in args) WebEmbed.InlineMode.EXTERNAL else WebEmbed.InlineMode.INLINE
     if (path == null) {
       System.err.println(
-        "Usage: compose-preview bundle embed <bundle.png | URL> [-o <dir>] [--title T] [--external-images]"
+        "Usage: compose-preview bundle embed <bundle.png | URL> [-o <dir|file.png>] [--title T] " +
+          "[--external-images] [--in-bundle]"
       )
       exitProcess(64)
     }
@@ -307,9 +318,6 @@ private class EmbedSubcommand(
       exitProcess(1)
     }
 
-    val target =
-      File(outDir ?: (file.absoluteFile.parent.toString() + "/${file.nameWithoutExtension}-web"))
-        .absoluteFile
     val out =
       WebEmbed.generate(
         title = title ?: data.manifest.modulePath,
@@ -318,6 +326,14 @@ private class EmbedSubcommand(
         mode = mode,
       )
 
+    if (inBundle) embedInBundle(file, out, outArg) else writeToDirectory(file, out, outArg)
+  }
+
+  /** Default mode: write the web embed as loose files under a directory. */
+  private fun writeToDirectory(file: File, out: WebEmbed.Output, outArg: String?) {
+    val target =
+      File(outArg ?: (file.absoluteFile.parent.toString() + "/${file.nameWithoutExtension}-web"))
+        .absoluteFile
     target.mkdirs()
     val targetPath = target.canonicalFile.toPath()
     for ((rel, bytes) in out.files) {
@@ -338,6 +354,39 @@ private class EmbedSubcommand(
     println(
       "  ${WebEmbed.SCRIPT_NAME}  add <script src> + <compose-preview-gallery> to embed in a page"
     )
+  }
+
+  /**
+   * `--in-bundle` mode: append the web embed's files into the bundle's own zip under
+   * [BUNDLE_WEB_DIR] (`web/`), leaving the leading PNG cover and every existing entry untouched.
+   * The directory is additive — an older reader / the renderer ignores it — so the same `.png` is
+   * still a valid polyglot *and* now carries a `web/index.html` someone can open straight out of
+   * the unzipped bundle. Re-embedding replaces any prior `web/` entries (idempotent). Writes in
+   * place by default; `-o <file.png>` writes an enriched copy instead.
+   */
+  private fun embedInBundle(file: File, out: WebEmbed.Output, outArg: String?) {
+    val full = fileSystem.read(file.path.toPath()) { readByteArray() }
+    val zip = BundleReader.extractZipBytes(file)
+    // The appended zip is a suffix of the file; everything before it is the leading PNG cover.
+    val prefix = full.copyOfRange(0, full.size - zip.size)
+    val webFiles = out.files.mapKeys { (rel, _) -> "$BUNDLE_WEB_DIR/$rel" }
+    val newZip = embedWebIntoZip(zip, webFiles)
+
+    val target = File(outArg ?: file.absolutePath).absoluteFile
+    target.parentFile?.mkdirs()
+    // Write via a temp sibling + move so an in-place enrich never truncates the bundle on failure.
+    val tmp = File(target.parentFile, "${target.name}.embed-tmp")
+    fileSystem.write(tmp.path.toPath()) {
+      write(prefix)
+      write(newZip)
+    }
+    fileSystem.atomicMove(tmp.path.toPath(), target.path.toPath())
+
+    println(
+      "embedded web gallery (${out.previewCount} preview(s)) into ${target.path} " +
+        "under $BUNDLE_WEB_DIR/ (${target.length()} bytes)"
+    )
+    println("  unzip it and open $BUNDLE_WEB_DIR/${WebEmbed.INDEX_NAME}")
   }
 }
 
@@ -404,6 +453,51 @@ private fun encodePreviewId(id: String): String =
       append(c)
     }
   }
+
+/**
+ * Well-known directory inside a bundle zip holding an optional, self-contained web embed
+ * (`web/index.html` + `web/compose-preview-embed.js`, and `web/previews/<id>.png` in external-image
+ * mode). Written by `bundle embed --in-bundle`. Additive: an older reader, the renderer, and the
+ * daemon all ignore it, so a bundle carrying a `web/` directory is still a valid polyglot.
+ */
+internal const val BUNDLE_WEB_DIR: String = "web"
+
+/**
+ * Return a copy of [existingZip] with [webFiles] (path → bytes) added. Every original entry is
+ * preserved except ones already under `$BUNDLE_WEB_DIR/`, which are dropped first so re-embedding
+ * is idempotent (no duplicate `web/…` entries on a second run). New entries are pinned to the DOS
+ * epoch so the result is reproducible. Operates on raw zip bytes — the caller re-attaches the
+ * polyglot's leading PNG.
+ */
+internal fun embedWebIntoZip(existingZip: ByteArray, webFiles: Map<String, ByteArray>): ByteArray {
+  val baos = ByteArrayOutputStream()
+  ZipOutputStream(baos).use { zout ->
+    ZipInputStream(ByteArrayInputStream(existingZip)).use { zin ->
+      while (true) {
+        val entry = zin.nextEntry ?: break
+        if (!entry.isDirectory && !entry.name.startsWith("$BUNDLE_WEB_DIR/")) {
+          zout.putNextEntry(ZipEntry(entry.name).apply { time = ZIP_DOS_EPOCH_MS })
+          zin.copyTo(zout)
+          zout.closeEntry()
+        }
+        zin.closeEntry()
+      }
+    }
+    for ((path, bytes) in webFiles) {
+      zout.putNextEntry(ZipEntry(path).apply { time = ZIP_DOS_EPOCH_MS })
+      zout.write(bytes)
+      zout.closeEntry()
+    }
+  }
+  return baos.toByteArray()
+}
+
+/**
+ * 1980-01-01 DOS-epoch floor stamped on entries written by [embedWebIntoZip], matching the plugin's
+ * reproducible-bundle writer so an enriched bundle stays byte-stable across runs.
+ */
+internal val ZIP_DOS_EPOCH_MS: Long =
+  java.util.GregorianCalendar(1980, java.util.Calendar.JANUARY, 1, 0, 0, 0).timeInMillis
 
 /**
  * Extracts a zip safely — every entry's resolved target path is verified to live inside [target].

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleEmbedDataTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleEmbedDataTest.kt
@@ -212,6 +212,17 @@ class BundleEmbedDataTest {
   }
 
   @Test
+  fun `in-bundle target requires an explicit output for downloaded url inputs`() {
+    // Explicit -o always wins, regardless of source.
+    assertEquals("/out.png", resolveInBundleTarget("/out.png", "/tmp/x.png", sourceIsUrl = true))
+    assertEquals("/out.png", resolveInBundleTarget("/out.png", "/tmp/x.png", sourceIsUrl = false))
+    // Local input with no -o rewrites in place.
+    assertEquals("/tmp/x.png", resolveInBundleTarget(null, "/tmp/x.png", sourceIsUrl = false))
+    // URL input with no -o resolves to a delete-on-exit temp; refuse so the result isn't lost.
+    assertEquals(null, resolveInBundleTarget(null, "/tmp/dl.png", sourceIsUrl = true))
+  }
+
+  @Test
   fun `in-bundle embed keeps the bundle a valid polyglot the reader can still parse`() {
     val coverPng = png(4, 8)
     val bundleJson =

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleEmbedDataTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleEmbedDataTest.kt
@@ -144,4 +144,112 @@ class BundleEmbedDataTest {
     assertTrue("compose-preview-gallery" in script)
     assertTrue("data:image/png;base64," in script)
   }
+
+  private fun entries(zip: ByteArray): Map<String, ByteArray> {
+    val out = LinkedHashMap<String, ByteArray>()
+    java.util.zip.ZipInputStream(java.io.ByteArrayInputStream(zip)).use { zin ->
+      while (true) {
+        val e = zin.nextEntry ?: break
+        if (!e.isDirectory) out[e.name] = zin.readBytes()
+        zin.closeEntry()
+      }
+    }
+    return out
+  }
+
+  @Test
+  fun `embedWebIntoZip adds web files and preserves existing entries`() {
+    val original =
+      ByteArrayOutputStream()
+        .also { baos ->
+          ZipOutputStream(baos).use { z ->
+            z.putNextEntry(ZipEntry("bundle.json"))
+            z.write("{}".toByteArray())
+            z.closeEntry()
+            z.putNextEntry(ZipEntry("previews/a.png"))
+            z.write(png())
+            z.closeEntry()
+          }
+        }
+        .toByteArray()
+
+    val web =
+      mapOf(
+        "web/index.html" to "<html></html>".toByteArray(),
+        "web/compose-preview-embed.js" to "// js".toByteArray(),
+      )
+    val result = entries(embedWebIntoZip(original, web))
+
+    // Originals survive untouched; the web files are added.
+    assertTrue("bundle.json" in result.keys)
+    assertTrue("previews/a.png" in result.keys)
+    assertEquals("<html></html>", result.getValue("web/index.html").toString(Charsets.UTF_8))
+    assertEquals("// js", result.getValue("web/compose-preview-embed.js").toString(Charsets.UTF_8))
+  }
+
+  @Test
+  fun `embedWebIntoZip is idempotent — re-embedding replaces stale web entries`() {
+    val withOldWeb =
+      ByteArrayOutputStream()
+        .also { baos ->
+          ZipOutputStream(baos).use { z ->
+            z.putNextEntry(ZipEntry("bundle.json"))
+            z.write("{}".toByteArray())
+            z.closeEntry()
+            z.putNextEntry(ZipEntry("web/index.html"))
+            z.write("OLD".toByteArray())
+            z.closeEntry()
+          }
+        }
+        .toByteArray()
+
+    val result =
+      entries(embedWebIntoZip(withOldWeb, mapOf("web/index.html" to "NEW".toByteArray())))
+
+    // Exactly one web/index.html (no duplicate), carrying the new bytes.
+    assertEquals(1, result.keys.count { it == "web/index.html" })
+    assertEquals("NEW", result.getValue("web/index.html").toString(Charsets.UTF_8))
+  }
+
+  @Test
+  fun `in-bundle embed keeps the bundle a valid polyglot the reader can still parse`() {
+    val coverPng = png(4, 8)
+    val bundleJson =
+      """
+      {"schemaVersion":2,"backend":"desktop","previewIds":["a"],"coverPreviewId":"a",
+       "classpath":[{"kind":"module","path":"classes/app.jar"}],
+       "modulePath":":samples:cmp","producedBy":"test"}
+      """
+        .trimIndent()
+    val file =
+      polyglot(
+        coverPng,
+        linkedMapOf("bundle.json" to bundleJson.toByteArray(), "previews/a.png" to coverPng),
+      )
+    val originalPrefixLen = file.readBytes().size - BundleReader.extractZipBytes(file).size
+
+    // Mirror what `embed --in-bundle` does: regenerate the web embed and splice it into the zip,
+    // re-attaching the leading PNG prefix.
+    val full = file.readBytes()
+    val zip = BundleReader.extractZipBytes(file)
+    val prefix = full.copyOfRange(0, full.size - zip.size)
+    val data = BundleReader.readWebEmbedData(file)
+    val out = WebEmbed.generate("Demo", data.manifest.modulePath, data.previews)
+    val newZip = embedWebIntoZip(zip, out.files.mapKeys { (rel, _) -> "web/$rel" })
+    val enriched = File(workRoot, "enriched.png")
+    enriched.outputStream().use {
+      it.write(prefix)
+      it.write(newZip)
+    }
+
+    // The leading PNG cover is byte-identical, so it's still a polyglot readers detect as PNG.
+    assertEquals(originalPrefixLen, prefix.size)
+    assertEquals(coverPng.toList(), enriched.readBytes().copyOfRange(0, prefix.size).toList())
+    // The reader still parses it, and the new web/ entries are present alongside the originals.
+    val reread = BundleReader.readWebEmbedData(enriched)
+    assertEquals(listOf("a"), reread.previews.map { it.id })
+    val names = entries(BundleReader.extractZipBytes(enriched)).keys
+    assertTrue("bundle.json" in names && "previews/a.png" in names)
+    assertTrue("web/index.html" in names && "web/compose-preview-embed.js" in names)
+  }
 }

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewBundleFormat.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewBundleFormat.kt
@@ -48,6 +48,12 @@ import kotlinx.serialization.json.JsonClassDiscriminator
  *                            full Compose graph that produced it. See [BundleIr] and
  *                            [BundleManifest.intermediateRepresentations].
  * report.json              — [MinimizationReport]: which deps contributed reachable classes
+ * web/                     — (optional) a self-contained web embed added after packing by
+ *                            `compose-preview bundle embed --in-bundle`: `web/index.html` +
+ *                            `web/compose-preview-embed.js` (a `<compose-preview-gallery>` web
+ *                            component with the baked previews inlined). Purely additive — the
+ *                            renderer / daemon never read it — so a bundle with a `web/` directory is
+ *                            still a valid polyglot. Not written by this task.
  * ```
  *
  * # Multiple previews, detached from a project


### PR DESCRIPTION
## Summary

Follow-up to #1837. Adds an opt-in `--in-bundle` flag to `compose-preview bundle embed` that writes the generated web embed **into the bundle's own zip** (under a well-known `web/` directory) instead of a loose output directory — so the resources travel inside the existing PNG/ZIP polyglot.

```
compose-preview bundle embed bundle.png --in-bundle
# → bundle.png now also contains web/index.html + web/compose-preview-embed.js
#   unzip it and open web/index.html
```

- The leading PNG cover and every existing entry are preserved, so the `.png` **stays a valid polyglot**: `file(1)` still reports PNG, and `bundle inspect` / `render` / the daemon ignore the additive `web/` directory.
- Re-embedding replaces any prior `web/` entries (**idempotent**); new entries are pinned to the DOS epoch for reproducibility.
- The write goes through a temp file + atomic move, so an in-place enrich can't truncate the bundle on failure. `-o <file.png>` writes an enriched copy instead of rewriting in place.
- `--external-images` still honored (writes `web/previews/<id>.png`); default stays inline (one self-contained `web/compose-preview-embed.js`).
- The optional `web/` directory is documented in `PreviewBundleFormat.kt` as additive.

Default behaviour (loose directory output) is unchanged.

## Test plan

- [x] `BundleEmbedDataTest` — `embedWebIntoZip` adds `web/` files + preserves originals; idempotent re-embed (no duplicate `web/index.html`); in-bundle splice keeps the leading PNG byte-identical and the reader still parses the enriched polyglot.
- [x] `./gradlew :cli:ktfmtCheckMain :cli:ktfmtCheckTest :gradle-plugin:ktfmtCheckMain` + targeted `:cli:test` green.
- [x] End-to-end on a real `:samples:cmp` bundle: `embed --in-bundle` in place → `file(1)` still PNG, `unzip -l` shows all originals + `web/`, second run stays at one `web/index.html`, `bundle inspect` exits 0, and the `web/index.html` extracted from the bundle renders all 17 cards headlessly (Chromium).

_(Gallery screenshots shared with the author in-session — the surface is reproducible via `bundle embed --in-bundle` then opening the extracted `web/index.html`.)_

---
_Generated by [Claude Code](https://claude.ai/code/session_0141FYrUJ7fUE5dBH9YhCQub)_