### PR TITLE
feat(bundle): optionally carry cover-preview data-extension reports (schema v7)

### DIFF
--- a/bundle-viewer/src/main/kotlin/ee/schimke/composeai/viewer/Schema.kt
+++ b/bundle-viewer/src/main/kotlin/ee/schimke/composeai/viewer/Schema.kt
@@ -33,7 +33,15 @@ data class BundleManifest(
    * by re-running their consumer bytecode. Empty for a classic all-classes bundle.
    */
   val intermediateRepresentations: List<BundleIr> = emptyList(),
+  /**
+   * v7+: optional per-extension data reports carried under `extensions/<id>.json`. Empty unless the
+   * bundle was packed with `--include-data-extensions`.
+   */
+  val dataExtensions: List<BundleDataExtension> = emptyList(),
 )
+
+/** v7+ mirror of `BundleDataExtension` in `PreviewBundleFormat.kt`. */
+@Serializable data class BundleDataExtension(val extensionId: String, val path: String)
 
 /** v5+ mirror of `BundleIr` in `PreviewBundleFormat.kt`. */
 @Serializable

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
@@ -85,6 +85,10 @@ class BundleCommand(args: List<String>) : Command(args) {
         --embed-deps        Carry reachable third-party jars inside the bundle (libs/) instead of
                             referencing Maven coordinates. Bigger file, but renders with no network
                             and no build system on the other end (resolution=embedded).
+        --include-data-extensions
+                            Carry the aggregated per-extension data reports (a11y findings, theme
+                            tokens, drawn strings, …) under extensions/<id>.json so a reader can
+                            surface them without re-rendering. Off by default.
 
       Inspect / extract / render flags:
         -o, --output <dir>  Directory to extract / render into. Default: alongside the bundle.
@@ -99,6 +103,7 @@ private class PackSubcommand(private val args: List<String>) {
   private val output: String? = args.flagValue("--output") ?: args.flagValue("-o")
   private val noRender: Boolean = "--no-render" in args
   private val embedDeps: Boolean = "--embed-deps" in args
+  private val includeDataExtensions: Boolean = "--include-data-extensions" in args
   private val verbose: Boolean = "--verbose" in args || "-v" in args
   private val ids: List<String> =
     args
@@ -135,6 +140,7 @@ private class PackSubcommand(private val args: List<String>) {
               if (ids.isNotEmpty())
                 add("-PbundlePreviewIds=${ids.joinToString(",") { encodePreviewId(it) }}")
               if (embedDeps) add("-PbundleEmbedDeps=true")
+              if (includeDataExtensions) add("-PbundleIncludeDataExtensions=true")
               add("-PbundleOutput=${resolvedOutput.absolutePath}")
             }
             val tasks =
@@ -188,6 +194,12 @@ private class PackSubcommand(private val args: List<String>) {
       "  classpath:     ${meta.manifest.classpath.size} entries " +
         "(Maven=$mavenCount, embedded=$embeddedCount, inlined=$projectCount)"
     )
+    if (meta.manifest.dataExtensions.isNotEmpty()) {
+      println(
+        "  data exts:     ${meta.manifest.dataExtensions.size} " +
+          "(${meta.manifest.dataExtensions.joinToString(", ") { it.extensionId }})"
+      )
+    }
     val r = meta.report
     if (r != null) {
       println("  entry classes: ${r.entryClassFqns.size}")
@@ -392,7 +404,16 @@ internal object BundleReader {
      * bundles. See `BundleAndroidResources` in `PreviewBundleFormat.kt`.
      */
     val androidResources: AndroidResources? = null,
+    /**
+     * v7+: optional per-extension data reports carried under `extensions/<id>.json` (a11y findings,
+     * theme tokens, …). Empty unless the bundle was packed with `--include-data-extensions`. See
+     * `BundleDataExtension` in `PreviewBundleFormat.kt`.
+     */
+    val dataExtensions: List<DataExtension> = emptyList(),
   )
+
+  /** v7+ mirror of `BundleDataExtension` in `PreviewBundleFormat.kt`. */
+  @Serializable data class DataExtension(val extensionId: String, val path: String)
 
   /** v6+ mirror of `BundleAndroidResources` in `PreviewBundleFormat.kt`. */
   @Serializable

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
@@ -86,9 +86,10 @@ class BundleCommand(args: List<String>) : Command(args) {
                             referencing Maven coordinates. Bigger file, but renders with no network
                             and no build system on the other end (resolution=embedded).
         --include-data-extensions
-                            Carry the aggregated per-extension data reports (a11y findings, theme
-                            tokens, drawn strings, …) under extensions/<id>.json so a reader can
-                            surface them without re-rendering. Off by default.
+                            Carry the per-extension data reports (a11y findings, theme tokens, drawn
+                            strings, …) under extensions/<id>.json, sliced to the cover (default)
+                            preview, so a reader can surface the headline image's data without
+                            re-rendering. Off by default.
 
       Inspect / extract / render flags:
         -o, --output <dir>  Directory to extract / render into. Default: alongside the bundle.

--- a/docs/portable-bundles.md
+++ b/docs/portable-bundles.md
@@ -122,6 +122,7 @@ previews/<id>.png     # baked images — IDENTICAL across all build systems
 classes/app.jar       # module bytecode, minimized (ClassGraph closure is build-system-agnostic:
                       #   it walks whatever class dirs + jars it's given — Bazel/Amper outputs work)
 libs/<name>.jar       # inlined deps: today only project-style; in "embedded" mode, all reachable deps
+extensions/<id>.json  # (v7, opt-in) carried per-extension data reports — IDENTICAL across build systems
 report.json
 ```
 

--- a/docs/portable-bundles.md
+++ b/docs/portable-bundles.md
@@ -122,7 +122,7 @@ previews/<id>.png     # baked images — IDENTICAL across all build systems
 classes/app.jar       # module bytecode, minimized (ClassGraph closure is build-system-agnostic:
                       #   it walks whatever class dirs + jars it's given — Bazel/Amper outputs work)
 libs/<name>.jar       # inlined deps: today only project-style; in "embedded" mode, all reachable deps
-extensions/<id>.json  # (v7, opt-in) carried per-extension data reports — IDENTICAL across build systems
+extensions/<id>.json  # (v7, opt-in) per-extension data reports, sliced to the cover preview — IDENTICAL across build systems
 report.json
 ```
 

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/BundleFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/BundleFunctionalTest.kt
@@ -302,11 +302,13 @@ class BundleFunctionalTest {
     val projectDir = createTestProject()
     val redId = "test.RedKt.RedBoxPreview"
 
-    // Discover so previews.json exists, then inject a dataExtensionReports pointer + drop the report
+    // Discover so previews.json exists, then inject a dataExtensionReports pointer + drop the
+    // report
     // sidecar it names — mimicking what a data extension's aggregate step would have produced after
     // discovery. (A real render isn't available here; this exercises the carriage path the same way
     // the PNG-baking test seeds fake renders.) The pack runs exclude `composePreviewDiscover`
-    // (`-x`): discover owns previews.json, so without the exclude Gradle would treat our hand-edit as
+    // (`-x`): discover owns previews.json, so without the exclude Gradle would treat our hand-edit
+    // as
     // a stale output and re-run discover, reverting the injected pointer to the empty default.
     GradleRunner.create()
       .withProjectDir(projectDir)
@@ -361,7 +363,8 @@ class BundleFunctionalTest {
 
     val bundle = File(previewOutputDir, "bundle.png")
     assertThat(listEntries(bundle)).contains("extensions/a11y.json")
-    // The carried report is sliced to the cover (red) preview: red's entry survives, blue's is gone,
+    // The carried report is sliced to the cover (red) preview: red's entry survives, blue's is
+    // gone,
     // and the top-level `module` field is preserved.
     val carriedReport =
       json
@@ -375,7 +378,8 @@ class BundleFunctionalTest {
     assertThat(carriedReport["module"]!!.jsonPrimitive.content).isEqualTo(":")
 
     val bundleManifest =
-      json.parseToJsonElement(readZipEntry(bundle, "bundle.json")!!.toString(Charsets.UTF_8))
+      json
+        .parseToJsonElement(readZipEntry(bundle, "bundle.json")!!.toString(Charsets.UTF_8))
         .jsonObject
     assertThat(bundleManifest["schemaVersion"]!!.jsonPrimitive.int).isEqualTo(BUNDLE_SCHEMA_VERSION)
     val carried = bundleManifest["dataExtensions"]!!.jsonArray

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/BundleFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/BundleFunctionalTest.kt
@@ -319,7 +319,13 @@ class BundleFunctionalTest {
     val manifest = json.decodeFromString(PreviewManifest.serializer(), previewsJson.readText())
     val withReports = manifest.copy(dataExtensionReports = mapOf("a11y" to "accessibility.json"))
     previewsJson.writeText(json.encodeToString(PreviewManifest.serializer(), withReports))
-    val reportBody = """{"findings":[{"node":"RedBox","level":"warning"}]}"""
+    // A module-wide report keyed by previewId — entries for the cover (red) AND a non-selected
+    // preview (blue). Carriage must slice it to the cover only.
+    val blueId = "test.BlueKt.BlueBoxPreview"
+    val reportBody =
+      """{"module":":","entries":[""" +
+        """{"previewId":"$redId","findings":[{"level":"warning"}]},""" +
+        """{"previewId":"$blueId","findings":[{"level":"error"}]}]}"""
     File(previewOutputDir, "accessibility.json").writeText(reportBody)
 
     // Off by default: a plain pack must NOT carry the report even though the manifest names it.
@@ -355,8 +361,18 @@ class BundleFunctionalTest {
 
     val bundle = File(previewOutputDir, "bundle.png")
     assertThat(listEntries(bundle)).contains("extensions/a11y.json")
-    assertThat(readZipEntry(bundle, "extensions/a11y.json")!!.toString(Charsets.UTF_8))
-      .isEqualTo(reportBody)
+    // The carried report is sliced to the cover (red) preview: red's entry survives, blue's is gone,
+    // and the top-level `module` field is preserved.
+    val carriedReport =
+      json
+        .parseToJsonElement(readZipEntry(bundle, "extensions/a11y.json")!!.toString(Charsets.UTF_8))
+        .jsonObject
+    val entryIds =
+      carriedReport["entries"]!!.jsonArray.map {
+        it.jsonObject["previewId"]!!.jsonPrimitive.content
+      }
+    assertThat(entryIds).containsExactly(redId)
+    assertThat(carriedReport["module"]!!.jsonPrimitive.content).isEqualTo(":")
 
     val bundleManifest =
       json.parseToJsonElement(readZipEntry(bundle, "bundle.json")!!.toString(Charsets.UTF_8))
@@ -367,6 +383,16 @@ class BundleFunctionalTest {
     assertThat(carried.first().jsonObject["extensionId"]!!.jsonPrimitive.content).isEqualTo("a11y")
     assertThat(carried.first().jsonObject["path"]!!.jsonPrimitive.content)
       .isEqualTo("extensions/a11y.json")
+
+    // The bundled previews.json's dataExtensionReports is rewritten to the in-bundle path, so both
+    // pointers agree and resolve to a real entry — no dangling reference to the producer's
+    // module-relative `accessibility.json`.
+    val bundledPreviews =
+      json.decodeFromString(
+        PreviewManifest.serializer(),
+        readZipEntry(bundle, "previews.json")!!.toString(Charsets.UTF_8),
+      )
+    assertThat(bundledPreviews.dataExtensionReports).containsExactly("a11y", "extensions/a11y.json")
   }
 
   @Test

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/BundleFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/BundleFunctionalTest.kt
@@ -298,6 +298,78 @@ class BundleFunctionalTest {
   }
 
   @Test
+  fun `include-data-extensions carries the named report sidecars under extensions`() {
+    val projectDir = createTestProject()
+    val redId = "test.RedKt.RedBoxPreview"
+
+    // Discover so previews.json exists, then inject a dataExtensionReports pointer + drop the report
+    // sidecar it names — mimicking what a data extension's aggregate step would have produced after
+    // discovery. (A real render isn't available here; this exercises the carriage path the same way
+    // the PNG-baking test seeds fake renders.) The pack runs exclude `composePreviewDiscover`
+    // (`-x`): discover owns previews.json, so without the exclude Gradle would treat our hand-edit as
+    // a stale output and re-run discover, reverting the injected pointer to the empty default.
+    GradleRunner.create()
+      .withProjectDir(projectDir)
+      .withArguments("composePreviewDiscover")
+      .withPluginClasspath()
+      .build()
+
+    val previewOutputDir = File(projectDir, "build/compose-previews")
+    val previewsJson = File(previewOutputDir, "previews.json")
+    val manifest = json.decodeFromString(PreviewManifest.serializer(), previewsJson.readText())
+    val withReports = manifest.copy(dataExtensionReports = mapOf("a11y" to "accessibility.json"))
+    previewsJson.writeText(json.encodeToString(PreviewManifest.serializer(), withReports))
+    val reportBody = """{"findings":[{"node":"RedBox","level":"warning"}]}"""
+    File(previewOutputDir, "accessibility.json").writeText(reportBody)
+
+    // Off by default: a plain pack must NOT carry the report even though the manifest names it.
+    GradleRunner.create()
+      .withProjectDir(projectDir)
+      .withArguments(
+        "composePreviewBundle",
+        "-PbundlePreviewIds=$redId",
+        "-x",
+        "composePreviewDiscover",
+        "--stacktrace",
+      )
+      .withPluginClasspath()
+      .build()
+    val plainBundle = File(previewOutputDir, "bundle.png")
+    assertThat(listEntries(plainBundle).none { it.startsWith("extensions/") }).isTrue()
+
+    // Opt-in: the report is carried under extensions/<id>.json and recorded in the manifest.
+    val result =
+      GradleRunner.create()
+        .withProjectDir(projectDir)
+        .withArguments(
+          "composePreviewBundle",
+          "-PbundlePreviewIds=$redId",
+          "-PbundleIncludeDataExtensions=true",
+          "-x",
+          "composePreviewDiscover",
+          "--stacktrace",
+        )
+        .withPluginClasspath()
+        .build()
+    assertThat(result.task(":composePreviewBundle")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+
+    val bundle = File(previewOutputDir, "bundle.png")
+    assertThat(listEntries(bundle)).contains("extensions/a11y.json")
+    assertThat(readZipEntry(bundle, "extensions/a11y.json")!!.toString(Charsets.UTF_8))
+      .isEqualTo(reportBody)
+
+    val bundleManifest =
+      json.parseToJsonElement(readZipEntry(bundle, "bundle.json")!!.toString(Charsets.UTF_8))
+        .jsonObject
+    assertThat(bundleManifest["schemaVersion"]!!.jsonPrimitive.int).isEqualTo(BUNDLE_SCHEMA_VERSION)
+    val carried = bundleManifest["dataExtensions"]!!.jsonArray
+    assertThat(carried).hasSize(1)
+    assertThat(carried.first().jsonObject["extensionId"]!!.jsonPrimitive.content).isEqualTo("a11y")
+    assertThat(carried.first().jsonObject["path"]!!.jsonPrimitive.content)
+      .isEqualTo("extensions/a11y.json")
+  }
+
+  @Test
   fun `composePreviewBundle filters previews_json to selected ids`() {
     val projectDir = createTestProject()
     val redId = "test.RedKt.RedBoxPreview"

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/BundleFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/BundleFunctionalTest.kt
@@ -400,6 +400,47 @@ class BundleFunctionalTest {
   }
 
   @Test
+  fun `include-data-extensions falls back to the conventional report path`() {
+    val projectDir = createTestProject()
+    val redId = "test.RedKt.RedBoxPreview"
+
+    // Discover writes previews.json with an EMPTY dataExtensionReports map (the standalone-plugin
+    // behaviour). The standard a11y flow drops build/compose-previews/accessibility.json without
+    // stamping a manifest pointer — so the pack must find it via the conventional-path fallback.
+    GradleRunner.create()
+      .withProjectDir(projectDir)
+      .withArguments("composePreviewDiscover")
+      .withPluginClasspath()
+      .build()
+
+    val previewOutputDir = File(projectDir, "build/compose-previews")
+    File(previewOutputDir, "accessibility.json")
+      .writeText("""{"module":":","entries":[{"previewId":"$redId","findings":[]}]}""")
+
+    // No previews.json edit, so composePreviewDiscover stays up to date — no `-x` needed.
+    GradleRunner.create()
+      .withProjectDir(projectDir)
+      .withArguments(
+        "composePreviewBundle",
+        "-PbundlePreviewIds=$redId",
+        "-PbundleIncludeDataExtensions=true",
+        "--stacktrace",
+      )
+      .withPluginClasspath()
+      .build()
+
+    val bundle = File(previewOutputDir, "bundle.png")
+    assertThat(listEntries(bundle)).contains("extensions/a11y.json")
+    val carried =
+      json
+        .parseToJsonElement(readZipEntry(bundle, "bundle.json")!!.toString(Charsets.UTF_8))
+        .jsonObject["dataExtensions"]!!
+        .jsonArray
+        .map { it.jsonObject["extensionId"]!!.jsonPrimitive.content }
+    assertThat(carried).contains("a11y")
+  }
+
+  @Test
   fun `composePreviewBundle filters previews_json to selected ids`() {
     val projectDir = createTestProject()
     val redId = "test.RedKt.RedBoxPreview"

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
@@ -217,8 +217,8 @@ abstract class BundlePreviewTask : DefaultTask() {
   @get:Input @get:Optional abstract val includeDataExtensions: Property<Boolean>
 
   /**
-   * The data-extension report sidecars named by `previews.json`'s `dataExtensionReports`, tracked as
-   * a real input so the bundle re-packs (and its cache key changes) when a report's *content*
+   * The data-extension report sidecars named by `previews.json`'s `dataExtensionReports`, tracked
+   * as a real input so the bundle re-packs (and its cache key changes) when a report's *content*
    * changes, not just when the manifest pointer does. Wired to the top-level `*.json` files under
    * the preview output dir (where the render task writes the aggregated reports); the paths are
    * resolved from the manifest at pack time against [previewsJson]'s parent. `@Optional` because a
@@ -395,11 +395,13 @@ abstract class BundlePreviewTask : DefaultTask() {
 
     val filteredManifest =
       if (includeDataExtensions.getOrElse(false)) {
-        // When carrying extension data, rewrite the bundled manifest's `dataExtensionReports` to the
+        // When carrying extension data, rewrite the bundled manifest's `dataExtensionReports` to
+        // the
         // in-bundle `extensions/<id>.json` paths (bundle-root-relative, the same convention the map
         // documents). Otherwise the bundled `previews.json` would still name the producer's
         // module-relative paths (e.g. `accessibility.json`) — pointers that don't resolve inside a
-        // detached bundle and disagree with `bundle.json`'s [BundleManifest.dataExtensions]. Reports
+        // detached bundle and disagree with `bundle.json`'s [BundleManifest.dataExtensions].
+        // Reports
         // that were skipped (source missing) drop out of the map so nothing dangles. Left untouched
         // in the default (non-carrying) pack, preserving the historical on-disk pointers.
         manifest.copy(
@@ -932,16 +934,16 @@ abstract class BundlePreviewTask : DefaultTask() {
 
   /**
    * Slice an aggregated per-extension report down to just the cover (default) preview — the one
-   * shown as the bundle's leading PNG — so the carried `extensions/<id>.json` describes the headline
-   * image and not every preview the module rendered.
+   * shown as the bundle's leading PNG — so the carried `extensions/<id>.json` describes the
+   * headline image and not every preview the module rendered.
    *
    * Applied uniformly to every report: any top-level array whose elements are all JSON objects
    * carrying a string `previewId` is filtered to the entries whose `previewId` equals [coverId];
-   * everything else in the document is left untouched. This keys on the common `entries[].previewId`
-   * convention (e.g. the a11y report's `entries`) as a generic structural transform — it is NOT
-   * per-extension logic, so a report that doesn't follow the convention is carried whole. Returns the
-   * input bytes unchanged on a parse failure, a non-object root, or when no array matched the shape
-   * (so a report with nothing to scope is byte-identical to the source).
+   * everything else in the document is left untouched. This keys on the common
+   * `entries[].previewId` convention (e.g. the a11y report's `entries`) as a generic structural
+   * transform — it is NOT per-extension logic, so a report that doesn't follow the convention is
+   * carried whole. Returns the input bytes unchanged on a parse failure, a non-object root, or when
+   * no array matched the shape (so a report with nothing to scope is byte-identical to the source).
    */
   private fun scopeReportToCoverPreview(reportBytes: ByteArray, coverId: String): ByteArray {
     val root =
@@ -952,21 +954,21 @@ abstract class BundlePreviewTask : DefaultTask() {
       }
     if (root !is JsonObject) return reportBytes
     var changed = false
-    val scoped =
-      root.mapValues { (_, value) ->
-        if (
-          value is JsonArray &&
-            value.isNotEmpty() &&
-            value.all { it is JsonObject && (it["previewId"] as? JsonPrimitive)?.isString == true }
-        ) {
-          val kept =
-            value.filter { (it as JsonObject)["previewId"]!!.jsonPrimitive.content == coverId }
-          if (kept.size != value.size) changed = true
-          JsonArray(kept)
-        } else {
-          value
+    val scoped = root.mapValues { (_, value) ->
+      if (
+        value is JsonArray &&
+          value.isNotEmpty() &&
+          value.all { it is JsonObject && (it["previewId"] as? JsonPrimitive)?.isString == true }
+      ) {
+        val kept = value.filter {
+          (it as JsonObject)["previewId"]!!.jsonPrimitive.content == coverId
         }
+        if (kept.size != value.size) changed = true
+        JsonArray(kept)
+      } else {
+        value
       }
+    }
     return if (changed) JsonObject(scoped).toString().toByteArray(Charsets.UTF_8) else reportBytes
   }
 

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
@@ -202,6 +202,30 @@ abstract class BundlePreviewTask : DefaultTask() {
    */
   @get:Input @get:Optional abstract val embedDeps: Property<Boolean>
 
+  /**
+   * Include-data-extensions mode (`-PbundleIncludeDataExtensions=true`, schema-v7
+   * [BundleManifest.dataExtensions]). When true, the aggregated per-extension data reports named by
+   * `previews.json`'s `dataExtensionReports` (a11y findings, theme tokens, drawn strings, …) are
+   * packed verbatim under `extensions/<id>.json` so a detached reader can surface them without
+   * re-rendering. Defaults to false: the normal pack carries no reports and stays small. A no-op
+   * when the manifest has no `dataExtensionReports` (no extension produced a canned report).
+   */
+  @get:Input @get:Optional abstract val includeDataExtensions: Property<Boolean>
+
+  /**
+   * The data-extension report sidecars named by `previews.json`'s `dataExtensionReports`, tracked as
+   * a real input so the bundle re-packs (and its cache key changes) when a report's *content*
+   * changes, not just when the manifest pointer does. Wired to the top-level `*.json` files under
+   * the preview output dir (where the render task writes the aggregated reports); the paths are
+   * resolved from the manifest at pack time against [previewsJson]'s parent. `@Optional` because a
+   * pack with no extension reports — the common case — snapshots this as empty. Only read when
+   * [includeDataExtensions] is set.
+   */
+  @get:InputFiles
+  @get:Optional
+  @get:PathSensitive(PathSensitivity.RELATIVE)
+  abstract val dataExtensionFiles: ConfigurableFileCollection
+
   /** Output `.png` polyglot file. */
   @get:OutputFile abstract val output: RegularFileProperty
 
@@ -313,6 +337,32 @@ abstract class BundlePreviewTask : DefaultTask() {
         resolveAndroidResources(irZipFiles)
       else null
 
+    // v7 optional data-extension carriage: when asked, pack the aggregated per-extension report
+    // sidecars (a11y findings, theme tokens, …) named by `previews.json`'s `dataExtensionReports` so
+    // a detached reader can surface that data without re-rendering. Paths are module-relative from
+    // the manifest's parent dir (where the render task writes the reports). Missing files warn and
+    // skip — the bundle is still well-formed without a report that didn't get written. Sorted by id
+    // for a deterministic (reproducible) zip order. No-op when the flag is off or the manifest has
+    // no reports.
+    val dataExtensionEntries = mutableListOf<BundleDataExtension>()
+    val dataExtensionZipFiles = LinkedHashMap<String, ByteArray>()
+    if (includeDataExtensions.getOrElse(false)) {
+      val reportBaseDir = manifestFile.parentFile
+      for ((id, relPath) in manifest.dataExtensionReports.toSortedMap()) {
+        val src = File(reportBaseDir, relPath)
+        if (!src.isFile) {
+          logger.warn(
+            "composePreviewBundle: data-extension '$id' report '$relPath' not found at " +
+              "${src.path} — skipping (the bundle omits this extension's data)."
+          )
+          continue
+        }
+        val zipPath = "$BUNDLE_EXTENSIONS_DIR/$id.json"
+        dataExtensionZipFiles[zipPath] = src.readBytes()
+        dataExtensionEntries += BundleDataExtension(extensionId = id, path = zipPath)
+      }
+    }
+
     val bundle =
       BundleManifest(
         schemaVersion = BUNDLE_SCHEMA_VERSION,
@@ -326,6 +376,7 @@ abstract class BundlePreviewTask : DefaultTask() {
         resolution = classpath.resolution,
         intermediateRepresentations = irEntries,
         androidResources = androidResources,
+        dataExtensions = dataExtensionEntries,
       )
 
     // Bake one PNG per selected preview into `previews/<id>.png` so the bundle renders detached
@@ -346,6 +397,7 @@ abstract class BundlePreviewTask : DefaultTask() {
         report = JSON.encodeToString(MinimizationReport.serializer(), report),
         previewPngs = previewPngs,
         irFiles = irZipFiles,
+        dataExtensionFiles = dataExtensionZipFiles,
       )
 
     // The cover (first selected preview) forms the polyglot's leading bytes. Reuse its baked PNG
@@ -364,6 +416,7 @@ abstract class BundlePreviewTask : DefaultTask() {
         "  resolution:           ${classpath.resolution}\n" +
         "  previews baked:       ${previewPngs.size} / ${selected.size} (cover=$coverId)\n" +
         "  IR-backed previews:   ${irEntries.size} (replayed from ir/, classes dropped)\n" +
+        "  data extensions:      ${dataExtensionEntries.size} (carried under extensions/)\n" +
         "  entry classes:        ${report.entryClassFqns.size}\n" +
         "  reachable classes:    ${report.reachableClassCount} / ${report.totalScannedClassCount}\n" +
         "  module classes kept:  ${report.moduleClasses.reachableClasses} / ${report.moduleClasses.totalClasses}\n" +
@@ -837,6 +890,7 @@ abstract class BundlePreviewTask : DefaultTask() {
     report: String,
     previewPngs: Map<String, ByteArray>,
     irFiles: Map<String, ByteArray>,
+    dataExtensionFiles: Map<String, ByteArray>,
   ): ByteArray {
     val baos = ByteArrayOutputStream()
     ZipOutputStream(baos).use { zip ->
@@ -846,6 +900,8 @@ abstract class BundlePreviewTask : DefaultTask() {
       previewPngs.forEach { (id, bytes) -> zip.writeFile("$BUNDLE_PREVIEWS_DIR/$id.png", bytes) }
       // Captured IR bytes (Remote Compose doc / protolayout proto) under `ir/`.
       irFiles.forEach { (path, bytes) -> zip.writeFile(path, bytes) }
+      // (v7) Optional per-extension data reports under `extensions/<id>.json`.
+      dataExtensionFiles.forEach { (path, bytes) -> zip.writeFile(path, bytes) }
       zip.writeFile("classes/app.jar", appJar)
       inlinedProjectJars.forEach { (path, file) -> zip.writeFile(path, file.readBytes()) }
       zip.writeFile("report.json", report.toByteArray(Charsets.UTF_8))

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
@@ -208,11 +208,13 @@ abstract class BundlePreviewTask : DefaultTask() {
 
   /**
    * Include-data-extensions mode (`-PbundleIncludeDataExtensions=true`, schema-v7
-   * [BundleManifest.dataExtensions]). When true, the aggregated per-extension data reports named by
-   * `previews.json`'s `dataExtensionReports` (a11y findings, theme tokens, drawn strings, …) are
-   * packed verbatim under `extensions/<id>.json` so a detached reader can surface them without
-   * re-rendering. Defaults to false: the normal pack carries no reports and stays small. A no-op
-   * when the manifest has no `dataExtensionReports` (no extension produced a canned report).
+   * [BundleManifest.dataExtensions]). When true, the per-extension data reports (a11y findings,
+   * theme tokens, drawn strings, …) — those named by `previews.json`'s `dataExtensionReports` plus
+   * a conventional-path fallback for registered extensions that write a report without stamping the
+   * manifest ([CONVENTIONAL_DATA_EXTENSION_REPORTS], e.g. a11y's `accessibility.json`) — are packed
+   * under `extensions/<id>.json`, sliced to the cover preview, so a detached reader can surface
+   * them without re-rendering. Defaults to false: the normal pack carries no reports and stays
+   * small. A no-op when no report is found on disk.
    */
   @get:Input @get:Optional abstract val includeDataExtensions: Property<Boolean>
 
@@ -342,19 +344,35 @@ abstract class BundlePreviewTask : DefaultTask() {
       else null
 
     // v7 optional data-extension carriage: when asked, pack the per-extension report sidecars (a11y
-    // findings, theme tokens, …) named by `previews.json`'s `dataExtensionReports` so a detached
-    // reader can surface that data without re-rendering. The report is sliced down to the COVER
-    // (default) preview — the one shown as the bundle's leading PNG — so the headline image carries
-    // its detailed results and the bundle doesn't drag along data for previews it doesn't even show
-    // (see [scopeReportToCoverPreview]). Paths are module-relative from the manifest's parent dir
-    // (where the render task writes the reports). Missing files warn and skip — the bundle is still
-    // well-formed without a report that didn't get written. Sorted by id for a deterministic
-    // (reproducible) zip order. No-op when the flag is off or the manifest has no reports.
+    // findings, theme tokens, …) so a detached reader can surface that data without re-rendering.
+    // The
+    // report is sliced down to the COVER (default) preview — the one shown as the bundle's leading
+    // PNG — so the headline image carries its detailed results and the bundle doesn't drag along
+    // data
+    // for previews it doesn't even show (see [scopeReportToCoverPreview]). The set of reports is
+    // the
+    // manifest's `dataExtensionReports` pointers plus a conventional-path fallback for any
+    // registered
+    // extension the manifest names no report for ([CONVENTIONAL_DATA_EXTENSION_REPORTS]) — the
+    // standard a11y flow writes `accessibility.json` but leaves the manifest map empty, so without
+    // the fallback the flag would carry nothing. Paths are module-relative from the manifest's
+    // parent
+    // dir (where the render task writes the reports). A manifest-named report that's missing warns
+    // and
+    // skips; a fallback only contributes when its file actually exists. Sorted by id for a
+    // deterministic (reproducible) zip order. No-op when the flag is off or no report is found.
     val dataExtensionEntries = mutableListOf<BundleDataExtension>()
     val dataExtensionZipFiles = LinkedHashMap<String, ByteArray>()
     if (includeDataExtensions.getOrElse(false)) {
       val reportBaseDir = manifestFile.parentFile
-      for ((id, relPath) in manifest.dataExtensionReports.toSortedMap()) {
+      val effectiveReports = LinkedHashMap<String, String>()
+      effectiveReports.putAll(manifest.dataExtensionReports)
+      for ((id, conventionalName) in CONVENTIONAL_DATA_EXTENSION_REPORTS) {
+        if (id !in effectiveReports && File(reportBaseDir, conventionalName).isFile) {
+          effectiveReports[id] = conventionalName
+        }
+      }
+      for ((id, relPath) in effectiveReports.toSortedMap()) {
         val src = File(reportBaseDir, relPath)
         if (!src.isFile) {
           logger.warn(

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
@@ -11,6 +11,10 @@ import java.util.zip.ZipInputStream
 import java.util.zip.ZipOutputStream
 import javax.imageio.ImageIO
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonPrimitive
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.file.ConfigurableFileCollection
@@ -337,13 +341,15 @@ abstract class BundlePreviewTask : DefaultTask() {
         resolveAndroidResources(irZipFiles)
       else null
 
-    // v7 optional data-extension carriage: when asked, pack the aggregated per-extension report
-    // sidecars (a11y findings, theme tokens, …) named by `previews.json`'s `dataExtensionReports` so
-    // a detached reader can surface that data without re-rendering. Paths are module-relative from
-    // the manifest's parent dir (where the render task writes the reports). Missing files warn and
-    // skip — the bundle is still well-formed without a report that didn't get written. Sorted by id
-    // for a deterministic (reproducible) zip order. No-op when the flag is off or the manifest has
-    // no reports.
+    // v7 optional data-extension carriage: when asked, pack the per-extension report sidecars (a11y
+    // findings, theme tokens, …) named by `previews.json`'s `dataExtensionReports` so a detached
+    // reader can surface that data without re-rendering. The report is sliced down to the COVER
+    // (default) preview — the one shown as the bundle's leading PNG — so the headline image carries
+    // its detailed results and the bundle doesn't drag along data for previews it doesn't even show
+    // (see [scopeReportToCoverPreview]). Paths are module-relative from the manifest's parent dir
+    // (where the render task writes the reports). Missing files warn and skip — the bundle is still
+    // well-formed without a report that didn't get written. Sorted by id for a deterministic
+    // (reproducible) zip order. No-op when the flag is off or the manifest has no reports.
     val dataExtensionEntries = mutableListOf<BundleDataExtension>()
     val dataExtensionZipFiles = LinkedHashMap<String, ByteArray>()
     if (includeDataExtensions.getOrElse(false)) {
@@ -358,7 +364,7 @@ abstract class BundlePreviewTask : DefaultTask() {
           continue
         }
         val zipPath = "$BUNDLE_EXTENSIONS_DIR/$id.json"
-        dataExtensionZipFiles[zipPath] = src.readBytes()
+        dataExtensionZipFiles[zipPath] = scopeReportToCoverPreview(src.readBytes(), coverId)
         dataExtensionEntries += BundleDataExtension(extensionId = id, path = zipPath)
       }
     }
@@ -387,7 +393,22 @@ abstract class BundlePreviewTask : DefaultTask() {
       resolvePreviewPng(preview)?.let { previewPngs[preview.id] = it }
     }
 
-    val filteredManifest = manifest.copy(previews = selected)
+    val filteredManifest =
+      if (includeDataExtensions.getOrElse(false)) {
+        // When carrying extension data, rewrite the bundled manifest's `dataExtensionReports` to the
+        // in-bundle `extensions/<id>.json` paths (bundle-root-relative, the same convention the map
+        // documents). Otherwise the bundled `previews.json` would still name the producer's
+        // module-relative paths (e.g. `accessibility.json`) — pointers that don't resolve inside a
+        // detached bundle and disagree with `bundle.json`'s [BundleManifest.dataExtensions]. Reports
+        // that were skipped (source missing) drop out of the map so nothing dangles. Left untouched
+        // in the default (non-carrying) pack, preserving the historical on-disk pointers.
+        manifest.copy(
+          previews = selected,
+          dataExtensionReports = dataExtensionEntries.associate { it.extensionId to it.path },
+        )
+      } else {
+        manifest.copy(previews = selected)
+      }
     val zipBytes =
       buildZip(
         bundleJson = JSON.encodeToString(BundleManifest.serializer(), bundle),
@@ -907,6 +928,46 @@ abstract class BundlePreviewTask : DefaultTask() {
       zip.writeFile("report.json", report.toByteArray(Charsets.UTF_8))
     }
     return baos.toByteArray()
+  }
+
+  /**
+   * Slice an aggregated per-extension report down to just the cover (default) preview — the one
+   * shown as the bundle's leading PNG — so the carried `extensions/<id>.json` describes the headline
+   * image and not every preview the module rendered.
+   *
+   * Applied uniformly to every report: any top-level array whose elements are all JSON objects
+   * carrying a string `previewId` is filtered to the entries whose `previewId` equals [coverId];
+   * everything else in the document is left untouched. This keys on the common `entries[].previewId`
+   * convention (e.g. the a11y report's `entries`) as a generic structural transform — it is NOT
+   * per-extension logic, so a report that doesn't follow the convention is carried whole. Returns the
+   * input bytes unchanged on a parse failure, a non-object root, or when no array matched the shape
+   * (so a report with nothing to scope is byte-identical to the source).
+   */
+  private fun scopeReportToCoverPreview(reportBytes: ByteArray, coverId: String): ByteArray {
+    val root =
+      try {
+        Json.parseToJsonElement(reportBytes.toString(Charsets.UTF_8))
+      } catch (_: Exception) {
+        return reportBytes
+      }
+    if (root !is JsonObject) return reportBytes
+    var changed = false
+    val scoped =
+      root.mapValues { (_, value) ->
+        if (
+          value is JsonArray &&
+            value.isNotEmpty() &&
+            value.all { it is JsonObject && (it["previewId"] as? JsonPrimitive)?.isString == true }
+        ) {
+          val kept =
+            value.filter { (it as JsonObject)["previewId"]!!.jsonPrimitive.content == coverId }
+          if (kept.size != value.size) changed = true
+          JsonArray(kept)
+        } else {
+          value
+        }
+      }
+    return if (changed) JsonObject(scoped).toString().toByteArray(Charsets.UTF_8) else reportBytes
   }
 
   private fun ZipOutputStream.writeFile(path: String, bytes: ByteArray) {

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -293,6 +293,11 @@ internal object ComposePreviewTasks {
     // renders with no network / no consumer build system.
     val embedDepsProperty: Provider<Boolean> =
       project.providers.gradleProperty("bundleEmbedDeps").map { it.toBoolean() }
+    // `-PbundleIncludeDataExtensions=true` → schema-v7: carry the aggregated per-extension data
+    // reports (a11y findings, theme tokens, …) named by `previews.json`'s `dataExtensionReports`
+    // under `extensions/<id>.json` so a detached reader can surface them without re-rendering.
+    val includeDataExtensionsProperty: Provider<Boolean> =
+      project.providers.gradleProperty("bundleIncludeDataExtensions").map { it.toBoolean() }
     val pluginVersionProperty = PluginVersion.value
 
     val artifactTypeAttr = Attribute.of("artifactType", String::class.java)
@@ -409,6 +414,12 @@ internal object ComposePreviewTasks {
       renderFiles.from(previewOutputDir.map { it.dir("renders") })
       previewIds.set(previewIdsProperty.orElse(emptyList()))
       embedDeps.set(embedDepsProperty.orElse(false))
+      includeDataExtensions.set(includeDataExtensionsProperty.orElse(false))
+      // Track the aggregated extension report sidecars (the render task writes them as top-level
+      // `*.json` under the preview output dir) so a content change re-packs the bundle. The bundle
+      // output is a `.png`, so the `*.json` filter never captures it as a circular input. Paths are
+      // resolved from the manifest at pack time; this is just the up-to-date / cache-key signal.
+      dataExtensionFiles.from(previewOutputDir.map { it.asFileTree.matching { include("*.json") } })
       modulePath.set(project.path)
       // (v6 Android) base dir for resolving test_config.properties' module-relative apk/manifest
       // paths. Harmless on desktop. See [BundlePreviewTask.moduleProjectDir].

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewBundleFormat.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewBundleFormat.kt
@@ -47,6 +47,14 @@ import kotlinx.serialization.json.JsonClassDiscriminator
  *                            runtime — it needs neither the consumer's `@Preview` bytecode nor the
  *                            full Compose graph that produced it. See [BundleIr] and
  *                            [BundleManifest.intermediateRepresentations].
+ * extensions/<id>.json     — (v7, optional) the aggregated sidecar JSON a data extension produced
+ *                            for this render (a11y findings, theme tokens, drawn strings, …),
+ *                            carried verbatim so a detached reader can surface the extension's data
+ *                            without re-rendering. `previews.json`'s `dataExtensionReports` already
+ *                            names these reports by extension id; this directory carries their
+ *                            *bytes* and [BundleManifest.dataExtensions] records the mapping. Present
+ *                            only for an opt-in `--include-data-extensions` pack. See
+ *                            [BundleDataExtension] and [BUNDLE_EXTENSIONS_DIR].
  * report.json              — [MinimizationReport]: which deps contributed reachable classes
  * ```
  *
@@ -156,6 +164,32 @@ data class BundleManifest(
    * none). Additive — a pre-v6 reader ignores the field and the `android/` entries.
    */
   val androidResources: BundleAndroidResources? = null,
+  /**
+   * (v7) Optional carriage of the per-extension data reports a render produced. Each entry names a
+   * data extension whose aggregated sidecar JSON (the file `previews.json`'s `dataExtensionReports`
+   * points at) is packed verbatim under `extensions/<id>.json` ([BUNDLE_EXTENSIONS_DIR]), so a
+   * detached reader can surface a11y findings / theme tokens / drawn strings / … without
+   * re-rendering. Empty unless the producer was asked to include extension data (the opt-in
+   * `--include-data-extensions` / `-PbundleIncludeDataExtensions=true` pack) — the default pack
+   * stays small and carries no reports. Additive: the field defaults to empty and `ignoreUnknownKeys`
+   * readers skip the `extensions/` entries, so a pre-v7 reader opening a v7 bundle still works; only
+   * a reader that wants the carried data needs to be v7-aware. See [BundleDataExtension].
+   */
+  val dataExtensions: List<BundleDataExtension> = emptyList(),
+)
+
+/**
+ * One data-extension report carried inside the bundle. The bytes live under `extensions/<id>.json`
+ * ([path]); a reader keys on [extensionId] to know which extension produced them and decodes the
+ * JSON against that extension's published DTOs (the same shape its live render result carries). The
+ * id matches the key in `previews.json`'s `dataExtensionReports` map (e.g. `"a11y"`).
+ */
+@Serializable
+data class BundleDataExtension(
+  /** Stable extension id, e.g. `"a11y"`. Matches the `dataExtensionReports` map key. */
+  val extensionId: String,
+  /** Posix zip path of the carried report bytes, e.g. `extensions/a11y.json`. */
+  val path: String,
 )
 
 /**
@@ -332,6 +366,13 @@ const val ANDROID_MERGED_MANIFEST_PATH: String = "android/AndroidManifest.xml"
 const val ANDROID_R_CLASSES_JAR_PATH: String = "android/r-classes.jar"
 
 /**
+ * Well-known directory inside the bundle zip holding optional per-extension data reports
+ * (`extensions/<extensionId>.json`), one verbatim sidecar per [BundleManifest.dataExtensions] entry
+ * (v7).
+ */
+const val BUNDLE_EXTENSIONS_DIR: String = "extensions"
+
+/**
  * Schema version stamped into [BundleManifest.schemaVersion].
  * - v1 — `bundle.json` + `previews.json` + `classes/app.jar` + `report.json`, cover PNG as the
  *   polyglot's leading bytes only.
@@ -363,8 +404,14 @@ const val ANDROID_R_CLASSES_JAR_PATH: String = "android/r-classes.jar"
  *   resource and link its `R$style` class on replay. Additive — the field defaults to null and
  *   `ignoreUnknownKeys` readers skip the `android/` entries, so a v5 reader opening a v6 bundle
  *   still works; only protolayout IR replay on a detached Android daemon needs a v6-aware player.
+ * - v7 — adds [BundleManifest.dataExtensions] and the `extensions/` directory: an opt-in pack
+ *   (`--include-data-extensions`) carries the aggregated per-extension data reports (a11y findings,
+ *   theme tokens, drawn strings, …) named by `previews.json`'s `dataExtensionReports` so a detached
+ *   reader can surface them without re-rendering. Additive — the field defaults to empty and
+ *   `ignoreUnknownKeys` readers skip the `extensions/` entries, so a v6 reader opening a v7 bundle
+ *   still works; only a reader that wants the carried data needs to be v7-aware.
  */
-const val BUNDLE_SCHEMA_VERSION: Int = 6
+const val BUNDLE_SCHEMA_VERSION: Int = 7
 
 /**
  * Well-known directory inside the bundle zip holding one rendered PNG per selected preview, keyed

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewBundleFormat.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewBundleFormat.kt
@@ -382,6 +382,19 @@ const val ANDROID_R_CLASSES_JAR_PATH: String = "android/r-classes.jar"
 const val BUNDLE_EXTENSIONS_DIR: String = "extensions"
 
 /**
+ * Conventional on-disk report filenames (relative to the preview output dir, i.e. `previews.json`'s
+ * parent) for built-in data extensions that write their aggregated report **without** stamping
+ * `previews.json`'s `dataExtensionReports` pointer. An `--include-data-extensions` pack probes
+ * these for any registered extension the manifest names no report for, so a report produced by the
+ * standard flow is still carried — the daemon / `compose-preview a11y` writes `accessibility.json`
+ * but the standalone plugin leaves the manifest map empty (`ComposePreviewTasks` discovery). A
+ * manifest pointer, when present, always wins over the conventional fallback. Keyed by the same
+ * extension id as `dataExtensionReports` / [BundleDataExtension.extensionId]; mirrors the
+ * conventional fallback in `:cli`'s `A11yReportRenderer`.
+ */
+val CONVENTIONAL_DATA_EXTENSION_REPORTS: Map<String, String> = mapOf("a11y" to "accessibility.json")
+
+/**
  * Schema version stamped into [BundleManifest.schemaVersion].
  * - v1 — `bundle.json` + `previews.json` + `classes/app.jar` + `report.json`, cover PNG as the
  *   polyglot's leading bytes only.

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewBundleFormat.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewBundleFormat.kt
@@ -173,14 +173,14 @@ data class BundleManifest(
    * preview**, the one shown as the leading PNG — so a detached reader can surface a11y findings /
    * theme tokens / drawn strings / … for the headline image without re-rendering. Empty unless the
    * producer was asked to include extension data (the opt-in `--include-data-extensions` /
-   * `-PbundleIncludeDataExtensions=true` pack) — the default pack stays small and carries no reports.
-   * Additive: the field defaults to empty and `ignoreUnknownKeys` readers skip the `extensions/`
-   * entries, so a pre-v7 reader opening a v7 bundle still works; only a reader that wants the carried
-   * data needs to be v7-aware. See [BundleDataExtension].
+   * `-PbundleIncludeDataExtensions=true` pack) — the default pack stays small and carries no
+   * reports. Additive: the field defaults to empty and `ignoreUnknownKeys` readers skip the
+   * `extensions/` entries, so a pre-v7 reader opening a v7 bundle still works; only a reader that
+   * wants the carried data needs to be v7-aware. See [BundleDataExtension].
    *
    * When this carriage is present the bundled `previews.json`'s `dataExtensionReports` map is
-   * realigned to the same in-bundle `extensions/<id>.json` paths, so the two pointers agree and both
-   * resolve inside the bundle (the producer's original module-relative report paths don't).
+   * realigned to the same in-bundle `extensions/<id>.json` paths, so the two pointers agree and
+   * both resolve inside the bundle (the producer's original module-relative report paths don't).
    */
   val dataExtensions: List<BundleDataExtension> = emptyList(),
 )
@@ -415,8 +415,8 @@ const val BUNDLE_EXTENSIONS_DIR: String = "extensions"
  *   still works; only protolayout IR replay on a detached Android daemon needs a v6-aware player.
  * - v7 — adds [BundleManifest.dataExtensions] and the `extensions/` directory: an opt-in pack
  *   (`--include-data-extensions`) carries the per-extension data reports (a11y findings, theme
- *   tokens, drawn strings, …) named by `previews.json`'s `dataExtensionReports`, sliced to the cover
- *   (default) preview, so a detached reader can surface the headline image's data without
+ *   tokens, drawn strings, …) named by `previews.json`'s `dataExtensionReports`, sliced to the
+ *   cover (default) preview, so a detached reader can surface the headline image's data without
  *   re-rendering. Additive — the field defaults to empty and `ignoreUnknownKeys` readers skip the
  *   `extensions/` entries, so a v6 reader opening a v7 bundle still works; only a reader that wants
  *   the carried data needs to be v7-aware.

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewBundleFormat.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewBundleFormat.kt
@@ -47,14 +47,16 @@ import kotlinx.serialization.json.JsonClassDiscriminator
  *                            runtime — it needs neither the consumer's `@Preview` bytecode nor the
  *                            full Compose graph that produced it. See [BundleIr] and
  *                            [BundleManifest.intermediateRepresentations].
- * extensions/<id>.json     — (v7, optional) the aggregated sidecar JSON a data extension produced
- *                            for this render (a11y findings, theme tokens, drawn strings, …),
- *                            carried verbatim so a detached reader can surface the extension's data
- *                            without re-rendering. `previews.json`'s `dataExtensionReports` already
- *                            names these reports by extension id; this directory carries their
- *                            *bytes* and [BundleManifest.dataExtensions] records the mapping. Present
- *                            only for an opt-in `--include-data-extensions` pack. See
- *                            [BundleDataExtension] and [BUNDLE_EXTENSIONS_DIR].
+ * extensions/<id>.json     — (v7, optional) a data extension's report (a11y findings, theme tokens,
+ *                            drawn strings, …) **sliced to the cover (default) preview** — the one
+ *                            shown as the leading PNG — so the headline image carries its detailed
+ *                            results and the bundle doesn't drag along data for previews it doesn't
+ *                            show. A detached reader surfaces the extension's data without
+ *                            re-rendering. `previews.json`'s `dataExtensionReports` names these
+ *                            reports by extension id; this directory carries their (scoped) *bytes*
+ *                            and [BundleManifest.dataExtensions] records the mapping. Present only
+ *                            for an opt-in `--include-data-extensions` pack. See [BundleDataExtension]
+ *                            and [BUNDLE_EXTENSIONS_DIR].
  * report.json              — [MinimizationReport]: which deps contributed reachable classes
  * ```
  *
@@ -166,23 +168,30 @@ data class BundleManifest(
   val androidResources: BundleAndroidResources? = null,
   /**
    * (v7) Optional carriage of the per-extension data reports a render produced. Each entry names a
-   * data extension whose aggregated sidecar JSON (the file `previews.json`'s `dataExtensionReports`
-   * points at) is packed verbatim under `extensions/<id>.json` ([BUNDLE_EXTENSIONS_DIR]), so a
-   * detached reader can surface a11y findings / theme tokens / drawn strings / … without
-   * re-rendering. Empty unless the producer was asked to include extension data (the opt-in
-   * `--include-data-extensions` / `-PbundleIncludeDataExtensions=true` pack) — the default pack
-   * stays small and carries no reports. Additive: the field defaults to empty and `ignoreUnknownKeys`
-   * readers skip the `extensions/` entries, so a pre-v7 reader opening a v7 bundle still works; only
-   * a reader that wants the carried data needs to be v7-aware. See [BundleDataExtension].
+   * data extension whose report (the file `previews.json`'s `dataExtensionReports` points at) is
+   * packed under `extensions/<id>.json` ([BUNDLE_EXTENSIONS_DIR]) — **sliced to the cover (default)
+   * preview**, the one shown as the leading PNG — so a detached reader can surface a11y findings /
+   * theme tokens / drawn strings / … for the headline image without re-rendering. Empty unless the
+   * producer was asked to include extension data (the opt-in `--include-data-extensions` /
+   * `-PbundleIncludeDataExtensions=true` pack) — the default pack stays small and carries no reports.
+   * Additive: the field defaults to empty and `ignoreUnknownKeys` readers skip the `extensions/`
+   * entries, so a pre-v7 reader opening a v7 bundle still works; only a reader that wants the carried
+   * data needs to be v7-aware. See [BundleDataExtension].
+   *
+   * When this carriage is present the bundled `previews.json`'s `dataExtensionReports` map is
+   * realigned to the same in-bundle `extensions/<id>.json` paths, so the two pointers agree and both
+   * resolve inside the bundle (the producer's original module-relative report paths don't).
    */
   val dataExtensions: List<BundleDataExtension> = emptyList(),
 )
 
 /**
- * One data-extension report carried inside the bundle. The bytes live under `extensions/<id>.json`
- * ([path]); a reader keys on [extensionId] to know which extension produced them and decodes the
- * JSON against that extension's published DTOs (the same shape its live render result carries). The
- * id matches the key in `previews.json`'s `dataExtensionReports` map (e.g. `"a11y"`).
+ * One data-extension report carried inside the bundle, sliced to the cover (default) preview. The
+ * bytes live under `extensions/<id>.json` ([path]); a reader keys on [extensionId] to know which
+ * extension produced them and decodes the JSON against that extension's published DTOs (the same
+ * shape its live render result carries). The id matches the key in `previews.json`'s
+ * `dataExtensionReports` map (e.g. `"a11y"`). Join [BundleManifest.coverPreviewId] to the report's
+ * per-preview entries to line the data up with the leading PNG.
  */
 @Serializable
 data class BundleDataExtension(
@@ -405,11 +414,12 @@ const val BUNDLE_EXTENSIONS_DIR: String = "extensions"
  *   `ignoreUnknownKeys` readers skip the `android/` entries, so a v5 reader opening a v6 bundle
  *   still works; only protolayout IR replay on a detached Android daemon needs a v6-aware player.
  * - v7 — adds [BundleManifest.dataExtensions] and the `extensions/` directory: an opt-in pack
- *   (`--include-data-extensions`) carries the aggregated per-extension data reports (a11y findings,
- *   theme tokens, drawn strings, …) named by `previews.json`'s `dataExtensionReports` so a detached
- *   reader can surface them without re-rendering. Additive — the field defaults to empty and
- *   `ignoreUnknownKeys` readers skip the `extensions/` entries, so a v6 reader opening a v7 bundle
- *   still works; only a reader that wants the carried data needs to be v7-aware.
+ *   (`--include-data-extensions`) carries the per-extension data reports (a11y findings, theme
+ *   tokens, drawn strings, …) named by `previews.json`'s `dataExtensionReports`, sliced to the cover
+ *   (default) preview, so a detached reader can surface the headline image's data without
+ *   re-rendering. Additive — the field defaults to empty and `ignoreUnknownKeys` readers skip the
+ *   `extensions/` entries, so a v6 reader opening a v7 bundle still works; only a reader that wants
+ *   the carried data needs to be v7-aware.
  */
 const val BUNDLE_SCHEMA_VERSION: Int = 7
 

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/PreviewBundleFormatTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/PreviewBundleFormatTest.kt
@@ -23,8 +23,57 @@ class PreviewBundleFormatTest {
   }
 
   @Test
-  fun `current schema version is 6`() {
-    assertThat(BUNDLE_SCHEMA_VERSION).isEqualTo(6)
+  fun `current schema version is 7`() {
+    assertThat(BUNDLE_SCHEMA_VERSION).isEqualTo(7)
+  }
+
+  @Test
+  fun `data extensions round-trip`() {
+    val original =
+      BundleManifest(
+        schemaVersion = BUNDLE_SCHEMA_VERSION,
+        backend = "desktop",
+        previewIds = listOf("pkg.Foo"),
+        coverPreviewId = "pkg.Foo",
+        classpath = listOf(ClasspathEntry.Module(path = "classes/app.jar")),
+        modulePath = ":sample",
+        producedBy = "test",
+        dataExtensions =
+          listOf(
+            BundleDataExtension(extensionId = "a11y", path = "extensions/a11y.json"),
+            BundleDataExtension(extensionId = "theme", path = "extensions/theme.json"),
+          ),
+      )
+
+    val decoded =
+      json.decodeFromString(
+        BundleManifest.serializer(),
+        json.encodeToString(BundleManifest.serializer(), original),
+      )
+
+    assertThat(decoded).isEqualTo(original)
+    assertThat(decoded.dataExtensions.map { it.extensionId }).containsExactly("a11y", "theme")
+  }
+
+  @Test
+  fun `v6 manifest without dataExtensions decodes with an empty list`() {
+    val v6 =
+      """
+      {
+        "schemaVersion": 6,
+        "backend": "desktop",
+        "previewIds": ["pkg.Foo"],
+        "coverPreviewId": "pkg.Foo",
+        "classpath": [ { "kind": "module", "path": "classes/app.jar" } ],
+        "modulePath": ":sample",
+        "producedBy": "test"
+      }
+      """
+        .trimIndent()
+
+    val decoded = json.decodeFromString(BundleManifest.serializer(), v6)
+
+    assertThat(decoded.dataExtensions).isEmpty()
   }
 
   @Test


### PR DESCRIPTION
## Summary

A preview bundle's `previews.json` already records `dataExtensionReports` (extension id → aggregated sidecar JSON path), but the sidecar **bytes** were never packed — a detached reader saw the pointer yet not the data. This adds an **opt-in** pack that carries those reports, as additive schema **v7**.

- **Format** (`PreviewBundleFormat.kt`) — new `BundleManifest.dataExtensions: List<BundleDataExtension>`, well-known `extensions/<id>.json` directory (`BUNDLE_EXTENSIONS_DIR`), version bumped 6 → 7. Fully additive: defaults to empty, so pre-v7 readers ignore the field and the new entries.
- **Producer** (`BundlePreviewTask` + `ComposePreviewTasks`) — `includeDataExtensions` flag, wired to `-PbundleIncludeDataExtensions=true`. Resolves each report relative to the manifest dir, warns-and-skips a missing one, sorts by id for a reproducible zip. The report sidecars are tracked as a real task input so a content change re-packs.
- **Cover-only slice** — each carried report is sliced down to the **cover (default) preview** — the one shown as the leading PNG. So the headline image carries its detailed results and the bundle doesn't drag along data for previews it doesn't show. It's a generic structural transform keyed on the common `entries[].previewId` convention, applied uniformly to every extension (no per-extension special-casing); a report that doesn't follow the convention is carried whole.
- **Pointer consistency** — when carrying, the bundled `previews.json`'s `dataExtensionReports` is realigned to the in-bundle `extensions/<id>.json` paths, so both pointers agree and resolve inside a detached bundle.
- **CLI** (`BundleCommand`) — `bundle pack --include-data-extensions`; `inspect`/pack summary now lists the carried extensions.
- **Reader mirrors** (`cli/BundleReader`, `bundle-viewer/Schema`) — gained the field so it round-trips. `bundle extract` surfaces `extensions/*.json` for free.

The default pack is unchanged and carries no reports.

A reader lines the data up with the image by joining `bundle.json`'s `coverPreviewId` to the report's per-preview entry — trivial now, since the carried report only contains that one preview.

## Test plan

- `:gradle-plugin:compileKotlin`, `:cli:compileKotlin`, `:bundle-viewer:compileKotlin` — clean.
- `PreviewBundleFormatTest` (10 tests) — schema-version assertion updated to 7; added round-trip + v6-back-compat coverage for `dataExtensions`.
- `BundleFunctionalTest.include-data-extensions carries the named report sidecars under extensions` — end-to-end: off-by-default carries nothing; opt-in carries `extensions/a11y.json`, records it in `bundle.json`'s `dataExtensions`, realigns `previews.json`, and **slices a module-wide red+blue report to just the cover (red)** with the top-level `module` field preserved.

This change is non-visual (data-product plumbing + build wiring), so evidence is the tests above rather than rendered output.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VnnDPobr4WdrKzvEnRyDJH)_