### PR TITLE
feat(bundle): carry per-preview semantics blob via pack --with-semantics

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
@@ -83,7 +83,7 @@ class BundleCommand(args: List<String>) : Command(args) {
       A <bundle> below is a local path OR an http(s)/file URL — URLs are downloaded first.
 
       Usage:
-        compose-preview bundle pack [--module <name>] [--id <preview>...] [-o <file.png>] [--no-render]
+        compose-preview bundle pack [--module <name>] [--id <preview>...] [-o <file.png>] [--no-render] [--with-semantics]
         compose-preview bundle inspect <bundle.png | URL>
         compose-preview bundle extract <bundle.png | URL> [-o <dir>]
         compose-preview bundle embed   <bundle.png | URL> [-o <dir|file.png>] [--title T] [--external-images] [--in-bundle]
@@ -102,6 +102,11 @@ class BundleCommand(args: List<String>) : Command(args) {
                             strings, …) under extensions/<id>.json, sliced to the cover (default)
                             preview, so a reader can surface the headline image's data without
                             re-rendering. Off by default.
+        --with-semantics    Carry each preview's semantics tree (per-node bounds, label/text, and
+                            resolved foreground/background colours) as previews/<id>.semantics.json —
+                            the shape design-parity reads for contrast/a11y + token checks. Produced
+                            by a short-lived daemon render (no separate --with-extension pass needed).
+                            Off by default; ignored with --no-render.
 
       Inspect / extract / render flags:
         -o, --output <dir>  Directory to extract / render into. Default: alongside the bundle.
@@ -127,6 +132,7 @@ private class PackSubcommand(private val args: List<String>) {
   private val noRender: Boolean = "--no-render" in args
   private val embedDeps: Boolean = "--embed-deps" in args
   private val includeDataExtensions: Boolean = "--include-data-extensions" in args
+  private val withSemantics: Boolean = "--with-semantics" in args
   private val verbose: Boolean = "--verbose" in args || "-v" in args
   private val ids: List<String> =
     args
@@ -166,10 +172,24 @@ private class PackSubcommand(private val args: List<String>) {
               if (includeDataExtensions) add("-PbundleIncludeDataExtensions=true")
               add("-PbundleOutput=${resolvedOutput.absolutePath}")
             }
+            // `--with-semantics` carries the per-preview semantics blob (issue #1843). The
+            // semantics tree is produced exclusively by the daemon (the standalone
+            // composePreviewRender task writes no semantics sidecars), so we also start the daemon
+            // in the same Gradle invocation — its launch descriptor is written fresh against the
+            // consumer's current classpath, then a short-lived render session reads the blobs back.
+            // Pointless without a render (the daemon needs something to capture), so skip when
+            // --no-render.
+            val packSemantics = withSemantics && !noRender
+            if (withSemantics && noRender) {
+              System.err.println(
+                "bundle pack: --with-semantics needs a render; ignoring it because --no-render was passed."
+              )
+            }
             val tasks =
               buildList {
                   if (!noRender) add(":${target.gradlePath}:composePreviewRender")
                   add(":${target.gradlePath}:composePreviewBundle")
+                  if (packSemantics) add(":${target.gradlePath}:composePreviewDaemonStart")
                 }
                 .toTypedArray()
             val ok = runGradle(gradle, *tasks, arguments = gradleArgsWithForce(gradleArgs))
@@ -194,11 +214,72 @@ private class PackSubcommand(private val args: List<String>) {
                 )
                 exitProcess(1)
               }
+            // Inject semantics (if requested) before the summary so its byte count reflects the
+            // enriched bundle; the summary line for semantics is printed after the main summary.
+            val semanticsLine =
+              if (packSemantics) packSemanticsBlob(target, resolvedOutput, meta) else null
+
             printPackSummary(resolvedOutput, meta)
+            semanticsLine?.let { println(it) }
           }
         }
       }
       .run()
+  }
+
+  /**
+   * Carry the per-preview semantics blob inside [bundleFile] (issue #1843). Drives a short-lived
+   * daemon ([DaemonSemanticsFetcher]) to render the bundle's selected previews and read back each
+   * one's `compose/semantics` tree (with resolved foreground/background colours), then injects them
+   * as `previews/<id>.semantics.json` — the location + shape the design-parity static bundle reader
+   * expects.
+   *
+   * Best-effort: any failure (missing descriptor, daemon open/render error, an unsupported backend)
+   * warns to stderr and leaves the already-written bundle untouched rather than failing the pack —
+   * the cover PNG and every other entry are preserved and the polyglot stays valid. Returns the
+   * stdout summary line to print after the main pack summary, or null when nothing was carried.
+   */
+  private fun packSemanticsBlob(
+    target: PreviewModule,
+    bundleFile: File,
+    meta: BundleReader.Metadata,
+  ): String? {
+    val previewIds = meta.manifest.previewIds
+    if (previewIds.isEmpty()) return null
+    val fetcher = DaemonSemanticsFetcher(onLog = { System.err.println("[daemon semantics] $it") })
+    val outcome =
+      fetcher.fetch(
+        projectDir = target.projectDir,
+        moduleName = target.gradlePath,
+        previewIds = previewIds,
+      )
+    when (outcome) {
+      is DaemonSemanticsFetcher.Outcome.Ok -> {
+        if (outcome.semanticsById.isEmpty()) {
+          System.err.println(
+            "bundle pack: --with-semantics produced no semantics for ${target.gradlePath} " +
+              "(see daemon log above); bundle written without previews/<id>.semantics.json."
+          )
+          return null
+        }
+        val written = injectSemanticsIntoBundle(bundleFile, outcome.semanticsById)
+        val missing = previewIds.size - written
+        return "  semantics:     $written / ${previewIds.size} preview(s) carried as " +
+          "previews/<id>$BUNDLE_SEMANTICS_SUFFIX" +
+          if (missing > 0) " ($missing without a captured tree)" else ""
+      }
+      is DaemonSemanticsFetcher.Outcome.DescriptorMissing ->
+        System.err.println(
+          "bundle pack: --with-semantics could not find daemon-launch.json at " +
+            "${outcome.expected.path} — bundle written without semantics."
+        )
+      is DaemonSemanticsFetcher.Outcome.OpenFailed ->
+        System.err.println(
+          "bundle pack: --with-semantics could not open a render session (${outcome.reason}) — " +
+            "bundle written without semantics."
+        )
+    }
+    return null
   }
 
   private fun printPackSummary(file: File, meta: BundleReader.Metadata) {
@@ -492,6 +573,87 @@ private fun encodePreviewId(id: String): String =
  * daemon all ignore it, so a bundle carrying a `web/` directory is still a valid polyglot.
  */
 internal const val BUNDLE_WEB_DIR: String = "web"
+
+/**
+ * Well-known directory inside a bundle zip holding the per-preview baked PNGs (`previews/<id>.png`)
+ * and, when packed with `--with-semantics`, each preview's semantics sidecar
+ * (`previews/<id>.semantics.json`). Mirrors `BUNDLE_PREVIEWS_DIR` in `:gradle-plugin`.
+ */
+internal const val BUNDLE_PREVIEWS_DIR: String = "previews"
+
+/**
+ * Suffix for the per-preview semantics blob carried beside `previews/<id>.png` (issue #1843). The
+ * payload is the `compose/semantics`
+ * [ee.schimke.composeai.data.layoutinspector.ComposeSemanticsPayload] tree — per-node bounds,
+ * label/text, and resolved foreground/background colours — the shape the design-parity static
+ * bundle reader consumes as a sibling of the rendered PNG.
+ */
+internal const val BUNDLE_SEMANTICS_SUFFIX: String = ".semantics.json"
+
+/**
+ * Inject `previews/<id>.semantics.json` entries (id → `compose-semantics.json` bytes) into
+ * [bundleFile]'s zip portion **in place**, preserving the leading PNG cover and every existing
+ * entry. Re-injecting replaces any prior semantics entry for the same id, so a second
+ * `--with-semantics` pack is idempotent. New entries are pinned to the DOS epoch so the enriched
+ * bundle stays byte-stable. Written via a temp sibling + atomic move so a failure never truncates
+ * the bundle. Returns the number of entries written.
+ */
+internal fun injectSemanticsIntoBundle(
+  bundleFile: File,
+  semanticsById: Map<String, ByteArray>,
+  fileSystem: FileSystem = SystemFileSystem,
+): Int {
+  if (semanticsById.isEmpty()) return 0
+  val full = fileSystem.read(bundleFile.path.toPath()) { readByteArray() }
+  val zip = BundleReader.extractZipBytes(bundleFile)
+  // The appended zip is a suffix of the file; everything before it is the leading PNG cover.
+  val prefix = full.copyOfRange(0, full.size - zip.size)
+  val entries =
+    semanticsById.entries.associate { (id, bytes) ->
+      "$BUNDLE_PREVIEWS_DIR/$id$BUNDLE_SEMANTICS_SUFFIX" to bytes
+    }
+  val newZip = addOrReplaceZipEntries(zip, entries)
+
+  val tmp = File(bundleFile.parentFile, "${bundleFile.name}.semantics-tmp")
+  fileSystem.write(tmp.path.toPath()) {
+    write(prefix)
+    write(newZip)
+  }
+  fileSystem.atomicMove(tmp.path.toPath(), bundleFile.path.toPath())
+  return entries.size
+}
+
+/**
+ * Return a copy of [existingZip] with [newEntries] (path → bytes) added, replacing any existing
+ * entry with the same name (so the operation is idempotent). Every other original entry is
+ * preserved verbatim. New entries are pinned to [ZIP_DOS_EPOCH_MS] for reproducibility. Operates on
+ * raw zip bytes — the caller re-attaches the polyglot's leading PNG.
+ */
+internal fun addOrReplaceZipEntries(
+  existingZip: ByteArray,
+  newEntries: Map<String, ByteArray>,
+): ByteArray {
+  val baos = ByteArrayOutputStream()
+  ZipOutputStream(baos).use { zout ->
+    ZipInputStream(ByteArrayInputStream(existingZip)).use { zin ->
+      while (true) {
+        val entry = zin.nextEntry ?: break
+        if (!entry.isDirectory && entry.name !in newEntries) {
+          zout.putNextEntry(ZipEntry(entry.name).apply { time = ZIP_DOS_EPOCH_MS })
+          zin.copyTo(zout)
+          zout.closeEntry()
+        }
+        zin.closeEntry()
+      }
+    }
+    for ((path, bytes) in newEntries) {
+      zout.putNextEntry(ZipEntry(path).apply { time = ZIP_DOS_EPOCH_MS })
+      zout.write(bytes)
+      zout.closeEntry()
+    }
+  }
+  return baos.toByteArray()
+}
 
 /**
  * Return a copy of [existingZip] with [webFiles] (path → bytes) added. Every original entry is

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DaemonSemanticsFetcher.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DaemonSemanticsFetcher.kt
@@ -8,7 +8,12 @@ import ee.schimke.composeai.render.session.RenderSessionException
 import ee.schimke.composeai.render.session.RenderSessionFactory
 import ee.schimke.composeai.render.session.subprocess.SubprocessRenderSessions
 import java.io.File
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import kotlin.time.Duration.Companion.seconds
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonPrimitive
 import okio.FileSystem
 import okio.Path.Companion.toPath
 
@@ -71,18 +76,54 @@ internal class DaemonSemanticsFetcher(
       }
 
     return session.use { live ->
-      // Render so the always-on ComposeSemanticsExtension writes each preview's sidecar. A failure
-      // here is non-fatal — some previews may still have rendered, so we fall through to the disk
-      // read and carry whatever materialised.
-      try {
-        live.renderNow(
-          previewIds = previewIds,
-          reason = "bundle pack semantics",
-          timeout = SEMANTICS_RENDER_TIMEOUT,
-        )
-      } catch (e: RenderSessionException) {
-        onLog("renderNow for semantics failed: ${e.message}")
-      }
+      // `renderNow` only *queues* the renders and acks immediately (`RenderNowResult.queued`) — the
+      // daemon's always-on ComposeSemanticsExtension writes each sidecar later, signalled by a
+      // `renderFinished` notification per preview. Reading the files right after the ack would race
+      // the render and inject nothing (or a stale sidecar from a prior run), so we wait for the
+      // notifications before reading. Mirrors `render-session/cli`'s RenderCli wait loop.
+      //
+      // Clear any stale sidecars first so a render that doesn't fire (rejected / failed) can't
+      // leave
+      // us reading cross-run data. Safe because `bundle pack` spawns a fresh, cold daemon that
+      // always renders (no warm cache to serve "unchanged").
+      for (previewId in previewIds) sidecarFile(projectDir, previewId).delete()
+
+      val pending = ConcurrentHashMap.newKeySet<String>().apply { addAll(previewIds) }
+      val latch = CountDownLatch(previewIds.size)
+      live
+        .onNotification { method, params ->
+          if (method != "renderFinished" || params == null) return@onNotification
+          val id = params["id"]?.jsonPrimitive?.contentOrNull ?: return@onNotification
+          // Count down on any finish for a pending id, regardless of pngPath — a failed render
+          // emits renderFinished without one, and we must not block forever waiting on it. Whether
+          // a sidecar actually materialised is decided by the disk read below.
+          if (pending.remove(id)) latch.countDown()
+        }
+        .use {
+          val ack =
+            try {
+              live.renderNow(
+                previewIds = previewIds,
+                reason = "bundle pack semantics",
+                timeout = RENDER_ACK_TIMEOUT,
+              )
+            } catch (e: RenderSessionException) {
+              onLog("renderNow for semantics failed: ${e.message}")
+              null
+            }
+          // Rejected ids will never emit renderFinished — stop waiting on them.
+          ack?.rejected?.forEach { rejected ->
+            onLog("render rejected for '${rejected.id}': ${rejected.reason}")
+            if (pending.remove(rejected.id)) latch.countDown()
+          }
+          val finished = latch.await(SEMANTICS_RENDER_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+          if (!finished) {
+            onLog(
+              "timed out after ${SEMANTICS_RENDER_TIMEOUT_SECONDS}s waiting for renders: " +
+                pending.joinToString(",")
+            )
+          }
+        }
 
       val byId = LinkedHashMap<String, ByteArray>()
       for (previewId in previewIds) {
@@ -113,10 +154,13 @@ internal class DaemonSemanticsFetcher(
   }
 
   private companion object {
+    /** RPC ack budget for the (fast, queue-only) `renderNow` call itself. */
+    val RENDER_ACK_TIMEOUT = 60.seconds
+
     /**
-     * Generous per-`renderNow` budget — the daemon renders every selected preview in one call, and
-     * the first render also pays the sandbox cold-start.
+     * Generous budget for every queued render to emit `renderFinished` — the daemon renders the
+     * selected previews in sequence and the first also pays the sandbox cold-start.
      */
-    val SEMANTICS_RENDER_TIMEOUT = 180.seconds
+    const val SEMANTICS_RENDER_TIMEOUT_SECONDS = 180L
   }
 }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DaemonSemanticsFetcher.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DaemonSemanticsFetcher.kt
@@ -1,0 +1,122 @@
+package ee.schimke.composeai.cli
+
+import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsProduct
+import ee.schimke.composeai.io.SystemFileSystem
+import ee.schimke.composeai.render.session.RenderSession
+import ee.schimke.composeai.render.session.RenderSessionConfig
+import ee.schimke.composeai.render.session.RenderSessionException
+import ee.schimke.composeai.render.session.RenderSessionFactory
+import ee.schimke.composeai.render.session.subprocess.SubprocessRenderSessions
+import java.io.File
+import kotlin.time.Duration.Companion.seconds
+import okio.FileSystem
+import okio.Path.Companion.toPath
+
+/**
+ * Drives a short-lived [RenderSession] for one module, renders the requested previews so the
+ * daemon's always-on `compose/semantics` extension writes each one's `compose-semantics.json`
+ * sidecar, then reads those sidecars back off disk. Used by `compose-preview bundle pack
+ * --with-semantics` to carry the per-preview semantics blob (the [ComposeSemanticsProduct] tree
+ * with resolved foreground/background colours) inside the bundle as `previews/<id>.semantics.json`
+ * — the shape the design-parity static bundle reader consumes (issue #1843).
+ *
+ * The standalone `composePreviewRender` Gradle task is "normal render only" and never produces
+ * semantics — the daemon is the single producer (see `docs/AGENTS.md`). So unlike the rest of
+ * `pack` (which is pure Gradle), the semantics blob is obtained by spinning up the same daemon the
+ * VS Code extension / MCP server / `compose-preview a11y` use, fetching, and shutting it down.
+ *
+ * @param factory pluggable render-session factory; defaults to the subprocess backend. Test
+ *   scaffolding can inject a fake by constructing a custom [RenderSessionFactory].
+ */
+internal class DaemonSemanticsFetcher(
+  private val factory: RenderSessionFactory = SubprocessRenderSessions,
+  private val onLog: (String) -> Unit = {},
+  private val fileSystem: FileSystem = SystemFileSystem,
+) {
+  /**
+   * Render [previewIds] through a temporary daemon and return each preview's
+   * `compose-semantics.json` bytes, keyed by preview id. Previews whose sidecar never materialised
+   * (a `@PreviewParameter` fan-out whose data dir is keyed by a per-value base name, a render that
+   * failed, an unsupported backend) are simply absent from the returned map — the caller carries
+   * what it got and reports the rest.
+   *
+   * [projectDir] is the module's project directory (`PreviewModule.projectDir`);
+   * `daemon-launch.json` and the daemon's `build/compose-previews/data/<id>/` output both sit under
+   * it regardless of the module's gradle path.
+   */
+  fun fetch(
+    projectDir: File,
+    moduleName: String,
+    previewIds: List<String>,
+    workspaceRoot: File = projectDir,
+  ): Outcome {
+    if (previewIds.isEmpty()) return Outcome.Ok(emptyMap())
+
+    val descriptorFile = File(projectDir, "build/compose-previews/daemon-launch.json")
+    if (!descriptorFile.isFile) return Outcome.DescriptorMissing(descriptorFile)
+
+    val config =
+      RenderSessionConfig(
+        descriptorPath = descriptorFile,
+        workspaceRoot = workspaceRoot.absoluteFile,
+        workspaceName = workspaceRoot.name.ifBlank { moduleName },
+        logSink = onLog,
+      )
+
+    val session: RenderSession =
+      try {
+        factory.open(config)
+      } catch (e: RenderSessionException) {
+        return Outcome.OpenFailed(reason = e.message ?: e.javaClass.simpleName)
+      }
+
+    return session.use { live ->
+      // Render so the always-on ComposeSemanticsExtension writes each preview's sidecar. A failure
+      // here is non-fatal — some previews may still have rendered, so we fall through to the disk
+      // read and carry whatever materialised.
+      try {
+        live.renderNow(
+          previewIds = previewIds,
+          reason = "bundle pack semantics",
+          timeout = SEMANTICS_RENDER_TIMEOUT,
+        )
+      } catch (e: RenderSessionException) {
+        onLog("renderNow for semantics failed: ${e.message}")
+      }
+
+      val byId = LinkedHashMap<String, ByteArray>()
+      for (previewId in previewIds) {
+        val file = sidecarFile(projectDir, previewId)
+        if (file.isFile && file.length() > 0) {
+          byId[previewId] = fileSystem.read(file.path.toPath()) { readByteArray() }
+        } else {
+          onLog("no ${ComposeSemanticsProduct.FILE} for '$previewId'")
+        }
+      }
+      Outcome.Ok(semanticsById = byId)
+    }
+  }
+
+  private fun sidecarFile(projectDir: File, previewId: String): File =
+    File(projectDir, "build/compose-previews/data/$previewId/${ComposeSemanticsProduct.FILE}")
+
+  sealed interface Outcome {
+    /**
+     * Session opened and renders attempted. [semanticsById] holds one entry per preview whose
+     * `compose-semantics.json` materialised — possibly empty if every render failed.
+     */
+    data class Ok(val semanticsById: Map<String, ByteArray>) : Outcome
+
+    data class DescriptorMissing(val expected: File) : Outcome
+
+    data class OpenFailed(val reason: String) : Outcome
+  }
+
+  private companion object {
+    /**
+     * Generous per-`renderNow` budget — the daemon renders every selected preview in one call, and
+     * the first render also pays the sandbox cold-start.
+     */
+    val SEMANTICS_RENDER_TIMEOUT = 180.seconds
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleSemanticsInjectTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleSemanticsInjectTest.kt
@@ -1,0 +1,174 @@
+package ee.schimke.composeai.cli
+
+import java.awt.image.BufferedImage
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.nio.file.Files
+import java.util.zip.ZipEntry
+import java.util.zip.ZipInputStream
+import java.util.zip.ZipOutputStream
+import javax.imageio.ImageIO
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Coverage for [injectSemanticsIntoBundle] / [addOrReplaceZipEntries] — carrying the per-preview
+ * `previews/<id>.semantics.json` blob inside a packed bundle (issue #1843) while keeping the
+ * leading PNG cover and every existing entry intact, and staying idempotent across re-injection.
+ */
+class BundleSemanticsInjectTest {
+
+  private val workRoot = Files.createTempDirectory("bundle-semantics-test-").toFile()
+
+  @AfterTest
+  fun cleanup() {
+    workRoot.deleteRecursively()
+  }
+
+  private fun png(w: Int = 4, h: Int = 4): ByteArray {
+    val img = BufferedImage(w, h, BufferedImage.TYPE_INT_RGB)
+    img.setRGB(0, 0, 0x112233)
+    val baos = ByteArrayOutputStream()
+    ImageIO.write(img, "png", baos)
+    return baos.toByteArray()
+  }
+
+  private fun polyglot(cover: ByteArray, entries: Map<String, ByteArray>): File {
+    val zip = ByteArrayOutputStream()
+    ZipOutputStream(zip).use { z ->
+      for ((path, bytes) in entries) {
+        z.putNextEntry(ZipEntry(path))
+        z.write(bytes)
+        z.closeEntry()
+      }
+    }
+    val file = File(workRoot, "bundle-${entries.hashCode()}.png")
+    file.outputStream().use {
+      it.write(cover)
+      it.write(zip.toByteArray())
+    }
+    return file
+  }
+
+  private fun entries(zip: ByteArray): Map<String, ByteArray> {
+    val out = LinkedHashMap<String, ByteArray>()
+    ZipInputStream(ByteArrayInputStream(zip)).use { zin ->
+      while (true) {
+        val e = zin.nextEntry ?: break
+        if (!e.isDirectory) out[e.name] = zin.readBytes()
+        zin.closeEntry()
+      }
+    }
+    return out
+  }
+
+  @Test
+  fun `injects semantics sidecars and keeps the bundle a valid polyglot`() {
+    val coverPng = png(4, 8)
+    val bundleJson =
+      """
+      {"schemaVersion":2,"backend":"android","previewIds":["a","b"],"coverPreviewId":"a",
+       "classpath":[{"kind":"module","path":"classes/app.jar"}],
+       "modulePath":":app","producedBy":"test"}
+      """
+        .trimIndent()
+    val file =
+      polyglot(
+        coverPng,
+        linkedMapOf(
+          "bundle.json" to bundleJson.toByteArray(),
+          "previews/a.png" to coverPng,
+          "previews/b.png" to png(6, 6),
+        ),
+      )
+    val prefixLen = file.readBytes().size - BundleReader.extractZipBytes(file).size
+
+    val written =
+      injectSemanticsIntoBundle(
+        file,
+        linkedMapOf(
+          "a" to """{"root":{"nodeId":"1","boundsInRoot":"0,0,4,8"}}""".toByteArray(),
+          "b" to """{"root":{"nodeId":"2","boundsInRoot":"0,0,6,6"}}""".toByteArray(),
+        ),
+      )
+
+    assertEquals(2, written)
+    // Leading PNG cover is byte-identical — still a polyglot readers detect as PNG.
+    assertEquals(coverPng.toList(), file.readBytes().copyOfRange(0, prefixLen).toList())
+    val names = entries(BundleReader.extractZipBytes(file))
+    // Originals survive; the semantics sidecars land beside the PNGs.
+    assertTrue("bundle.json" in names.keys)
+    assertTrue("previews/a.png" in names.keys && "previews/b.png" in names.keys)
+    assertEquals(
+      """{"root":{"nodeId":"1","boundsInRoot":"0,0,4,8"}}""",
+      names.getValue("previews/a.semantics.json").toString(Charsets.UTF_8),
+    )
+    assertEquals(
+      """{"root":{"nodeId":"2","boundsInRoot":"0,0,6,6"}}""",
+      names.getValue("previews/b.semantics.json").toString(Charsets.UTF_8),
+    )
+    // The web-embed reader still parses the enriched bundle.
+    assertEquals(listOf("a", "b"), BundleReader.readWebEmbedData(file).previews.map { it.id })
+  }
+
+  @Test
+  fun `re-injection replaces a stale semantics entry without duplicating it`() {
+    val cover = png()
+    val file =
+      polyglot(
+        cover,
+        linkedMapOf(
+          "bundle.json" to "{}".toByteArray(),
+          "previews/a.png" to cover,
+          "previews/a.semantics.json" to "OLD".toByteArray(),
+        ),
+      )
+
+    injectSemanticsIntoBundle(file, mapOf("a" to "NEW".toByteArray()))
+
+    val names = entries(BundleReader.extractZipBytes(file))
+    assertEquals(1, names.keys.count { it == "previews/a.semantics.json" })
+    assertEquals("NEW", names.getValue("previews/a.semantics.json").toString(Charsets.UTF_8))
+  }
+
+  @Test
+  fun `empty input is a no-op`() {
+    val file = polyglot(png(), linkedMapOf("bundle.json" to "{}".toByteArray()))
+    val before = file.readBytes().toList()
+    assertEquals(0, injectSemanticsIntoBundle(file, emptyMap()))
+    assertEquals(before, file.readBytes().toList())
+  }
+
+  @Test
+  fun `addOrReplaceZipEntries preserves originals and replaces collisions`() {
+    val original =
+      ByteArrayOutputStream()
+        .also { baos ->
+          ZipOutputStream(baos).use { z ->
+            z.putNextEntry(ZipEntry("keep.txt"))
+            z.write("keep".toByteArray())
+            z.closeEntry()
+            z.putNextEntry(ZipEntry("replace.txt"))
+            z.write("old".toByteArray())
+            z.closeEntry()
+          }
+        }
+        .toByteArray()
+
+    val result =
+      entries(
+        addOrReplaceZipEntries(
+          original,
+          mapOf("replace.txt" to "new".toByteArray(), "add.txt" to "added".toByteArray()),
+        )
+      )
+
+    assertEquals("keep", result.getValue("keep.txt").toString(Charsets.UTF_8))
+    assertEquals("new", result.getValue("replace.txt").toString(Charsets.UTF_8))
+    assertEquals("added", result.getValue("add.txt").toString(Charsets.UTF_8))
+    assertEquals(1, result.keys.count { it == "replace.txt" })
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/DaemonSemanticsFetcherTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/DaemonSemanticsFetcherTest.kt
@@ -1,0 +1,293 @@
+package ee.schimke.composeai.cli
+
+import ee.schimke.composeai.daemon.protocol.ChangeType
+import ee.schimke.composeai.daemon.protocol.DataFetchResult
+import ee.schimke.composeai.daemon.protocol.DataSubscribeResult
+import ee.schimke.composeai.daemon.protocol.ExtensionsDisableResult
+import ee.schimke.composeai.daemon.protocol.ExtensionsEnableResult
+import ee.schimke.composeai.daemon.protocol.ExtensionsListResult
+import ee.schimke.composeai.daemon.protocol.FileKind
+import ee.schimke.composeai.daemon.protocol.HistoryDiffMode
+import ee.schimke.composeai.daemon.protocol.HistoryDiffResult
+import ee.schimke.composeai.daemon.protocol.HistoryListParams
+import ee.schimke.composeai.daemon.protocol.HistoryListResult
+import ee.schimke.composeai.daemon.protocol.HistoryReadResultDto
+import ee.schimke.composeai.daemon.protocol.InitializeResult
+import ee.schimke.composeai.daemon.protocol.Manifest
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.daemon.protocol.RecordingEncodeResult
+import ee.schimke.composeai.daemon.protocol.RecordingFormat
+import ee.schimke.composeai.daemon.protocol.RecordingScriptEvent
+import ee.schimke.composeai.daemon.protocol.RecordingStartResult
+import ee.schimke.composeai.daemon.protocol.RecordingStopResult
+import ee.schimke.composeai.daemon.protocol.RenderNowResult
+import ee.schimke.composeai.daemon.protocol.RenderTier
+import ee.schimke.composeai.daemon.protocol.ServerCapabilities
+import ee.schimke.composeai.render.session.NotificationListener
+import ee.schimke.composeai.render.session.RenderSession
+import ee.schimke.composeai.render.session.RenderSessionBackend
+import ee.schimke.composeai.render.session.RenderSessionConfig
+import ee.schimke.composeai.render.session.RenderSessionException
+import ee.schimke.composeai.render.session.RenderSessionFactory
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.JsonElement
+
+/**
+ * Contract for [DaemonSemanticsFetcher]: with a fake [RenderSessionFactory] whose `renderNow`
+ * writes `compose-semantics.json` sidecars (standing in for the daemon's always-on
+ * ComposeSemanticsExtension), the fetcher renders the requested previews and returns each one's
+ * sidecar bytes keyed by preview id (issue #1843).
+ */
+class DaemonSemanticsFetcherTest {
+
+  private fun newTempFolder(prefix: String): File =
+    java.nio.file.Files.createTempDirectory(prefix).toFile().also { it.deleteOnExit() }
+
+  private fun writeDescriptor(projectDir: File) {
+    File(projectDir, "build/compose-previews").mkdirs()
+    File(projectDir, "build/compose-previews/daemon-launch.json").writeText("{}")
+  }
+
+  @Test
+  fun `renders previews and returns their semantics sidecars`() {
+    val projectDir = newTempFolder("semantics-module")
+    writeDescriptor(projectDir)
+
+    val produced =
+      mapOf(
+        "AlphaPreview" to """{"root":{"nodeId":"1","boundsInRoot":"0,0,4,8"}}""",
+        "BetaPreview" to """{"root":{"nodeId":"2","boundsInRoot":"0,0,6,6"}}""",
+      )
+    val fetcher = DaemonSemanticsFetcher(factory = FakeFactory(produced))
+
+    val outcome =
+      fetcher.fetch(
+        projectDir = projectDir,
+        moduleName = "sample",
+        previewIds = listOf("AlphaPreview", "BetaPreview"),
+      )
+
+    assertTrue(outcome is DaemonSemanticsFetcher.Outcome.Ok, "expected Ok, got $outcome")
+    assertEquals(setOf("AlphaPreview", "BetaPreview"), outcome.semanticsById.keys)
+    assertEquals(
+      produced["AlphaPreview"],
+      outcome.semanticsById.getValue("AlphaPreview").toString(Charsets.UTF_8),
+    )
+    assertEquals(
+      produced["BetaPreview"],
+      outcome.semanticsById.getValue("BetaPreview").toString(Charsets.UTF_8),
+    )
+  }
+
+  @Test
+  fun `previews whose sidecar never materialised are simply absent`() {
+    val projectDir = newTempFolder("semantics-partial")
+    writeDescriptor(projectDir)
+
+    // Only Alpha produces a sidecar; Beta is rendered but writes nothing (e.g. an unsupported
+    // capture). The fetcher carries what it got and omits the rest.
+    val fetcher =
+      DaemonSemanticsFetcher(
+        factory =
+          FakeFactory(
+            mapOf("AlphaPreview" to """{"root":{"nodeId":"1","boundsInRoot":"0,0,1,1"}}""")
+          )
+      )
+
+    val outcome =
+      fetcher.fetch(
+        projectDir = projectDir,
+        moduleName = "sample",
+        previewIds = listOf("AlphaPreview", "BetaPreview"),
+      )
+
+    assertTrue(outcome is DaemonSemanticsFetcher.Outcome.Ok, "expected Ok, got $outcome")
+    assertEquals(setOf("AlphaPreview"), outcome.semanticsById.keys)
+  }
+
+  @Test
+  fun `missing descriptor returns DescriptorMissing`() {
+    val projectDir = newTempFolder("semantics-no-descriptor")
+    val fetcher = DaemonSemanticsFetcher(factory = FakeFactory(emptyMap()))
+
+    val outcome =
+      fetcher.fetch(projectDir = projectDir, moduleName = "sample", previewIds = listOf("Alpha"))
+
+    assertTrue(outcome is DaemonSemanticsFetcher.Outcome.DescriptorMissing)
+  }
+
+  @Test
+  fun `open failure returns OpenFailed`() {
+    val projectDir = newTempFolder("semantics-open-fails")
+    writeDescriptor(projectDir)
+    val fetcher = DaemonSemanticsFetcher(factory = OpenFailFactory())
+
+    val outcome =
+      fetcher.fetch(projectDir = projectDir, moduleName = "sample", previewIds = listOf("Alpha"))
+
+    assertTrue(outcome is DaemonSemanticsFetcher.Outcome.OpenFailed)
+  }
+
+  @Test
+  fun `empty preview list short-circuits to an empty Ok`() {
+    val projectDir = newTempFolder("semantics-empty")
+    val fetcher = DaemonSemanticsFetcher(factory = OpenFailFactory())
+
+    val outcome =
+      fetcher.fetch(projectDir = projectDir, moduleName = "sample", previewIds = emptyList())
+
+    assertTrue(outcome is DaemonSemanticsFetcher.Outcome.Ok)
+    assertTrue(outcome.semanticsById.isEmpty())
+  }
+
+  // -------------------------------------------------------------------------
+  // Fake factory + session
+
+  private class FakeFactory(private val produced: Map<String, String>) : RenderSessionFactory {
+    override val backendKind: RenderSessionBackend = RenderSessionBackend.Subprocess
+
+    override fun open(config: RenderSessionConfig): RenderSession =
+      FakeSession(
+        workspaceRoot = config.workspaceRoot.absolutePath,
+        produced = produced,
+        dataRoot = File(config.workspaceRoot, "build/compose-previews/data"),
+      )
+  }
+
+  private class OpenFailFactory : RenderSessionFactory {
+    override val backendKind: RenderSessionBackend = RenderSessionBackend.Subprocess
+
+    override fun open(config: RenderSessionConfig): RenderSession =
+      throw RenderSessionException("simulated daemon open failure")
+  }
+
+  /**
+   * Minimal [RenderSession] whose [renderNow] writes the daemon's always-on
+   * `compose-semantics.json` sidecar for every preview it has canned content for — the same on-disk
+   * location the production daemon writes. Every other method throws.
+   */
+  private class FakeSession(
+    override val workspaceRoot: String,
+    private val produced: Map<String, String>,
+    private val dataRoot: File,
+  ) : RenderSession {
+    override val modulePath: String = ":sample"
+    override val initializeResult: InitializeResult =
+      InitializeResult(
+        protocolVersion = 2,
+        daemonVersion = "fake",
+        pid = 0,
+        capabilities =
+          ServerCapabilities(
+            incrementalDiscovery = false,
+            sandboxRecycle = false,
+            leakDetection = emptyList(),
+          ),
+        classpathFingerprint = "",
+        manifest = Manifest(path = "", previewCount = 0),
+      )
+    override val backendKind: RenderSessionBackend = RenderSessionBackend.Subprocess
+
+    override fun setVisible(previewIds: List<String>) = Unit
+
+    override fun setFocus(previewIds: List<String>) = Unit
+
+    override fun fileChanged(path: String, kind: FileKind, changeType: ChangeType) = Unit
+
+    override fun renderNow(
+      previewIds: List<String>,
+      tier: RenderTier,
+      reason: String?,
+      overrides: PreviewOverrides?,
+      timeout: kotlin.time.Duration,
+    ): RenderNowResult {
+      for (id in previewIds) {
+        val content = produced[id] ?: continue
+        val dir = File(dataRoot, id).also { it.mkdirs() }
+        File(dir, "compose-semantics.json").writeText(content)
+      }
+      return RenderNowResult(queued = previewIds, rejected = emptyList())
+    }
+
+    override fun fetchData(
+      previewId: String,
+      kind: String,
+      inline: Boolean,
+      params: JsonElement?,
+      timeout: kotlin.time.Duration,
+    ): DataFetchResult = error("unused")
+
+    override fun subscribeData(
+      previewId: String,
+      kind: String,
+      params: JsonElement?,
+      timeout: kotlin.time.Duration,
+    ): DataSubscribeResult = error("unused")
+
+    override fun unsubscribeData(
+      previewId: String,
+      kind: String,
+      timeout: kotlin.time.Duration,
+    ): DataSubscribeResult = error("unused")
+
+    override fun listExtensions(timeout: kotlin.time.Duration): ExtensionsListResult =
+      error("unused")
+
+    override fun enableExtensions(
+      ids: List<String>,
+      timeout: kotlin.time.Duration,
+    ): ExtensionsEnableResult = ExtensionsEnableResult(newlyEnabled = ids)
+
+    override fun disableExtensions(
+      ids: List<String>,
+      timeout: kotlin.time.Duration,
+    ): ExtensionsDisableResult = error("unused")
+
+    override fun historyList(
+      params: HistoryListParams,
+      timeout: kotlin.time.Duration,
+    ): HistoryListResult = error("unused")
+
+    override fun historyRead(
+      entryId: String,
+      inline: Boolean,
+      timeout: kotlin.time.Duration,
+    ): HistoryReadResultDto = error("unused")
+
+    override fun historyDiff(
+      fromId: String,
+      toId: String,
+      mode: HistoryDiffMode,
+      timeout: kotlin.time.Duration,
+    ): HistoryDiffResult = error("unused")
+
+    override fun recordingStart(
+      previewId: String,
+      fps: Int?,
+      scale: Float?,
+      overrides: PreviewOverrides?,
+      timeout: kotlin.time.Duration,
+    ): RecordingStartResult = error("unused")
+
+    override fun recordingScript(recordingId: String, events: List<RecordingScriptEvent>) =
+      error("unused")
+
+    override fun recordingStop(
+      recordingId: String,
+      timeout: kotlin.time.Duration,
+    ): RecordingStopResult = error("unused")
+
+    override fun recordingEncode(
+      recordingId: String,
+      format: RecordingFormat,
+      timeout: kotlin.time.Duration,
+    ): RecordingEncodeResult = error("unused")
+
+    override fun onNotification(listener: NotificationListener): AutoCloseable = AutoCloseable {}
+
+    override fun close() = Unit
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/DaemonSemanticsFetcherTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/DaemonSemanticsFetcherTest.kt
@@ -34,6 +34,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.put
 
 /**
  * Contract for [DaemonSemanticsFetcher]: with a fake [RenderSessionFactory] whose `renderNow`
@@ -109,6 +110,31 @@ class DaemonSemanticsFetcherTest {
   }
 
   @Test
+  fun `clears a stale sidecar so a render that produces nothing carries no cross-run data`() {
+    val projectDir = newTempFolder("semantics-stale")
+    writeDescriptor(projectDir)
+    // A stale sidecar from a previous run that this render does NOT reproduce (no canned content).
+    val staleDir = File(projectDir, "build/compose-previews/data/BetaPreview").also { it.mkdirs() }
+    File(staleDir, "compose-semantics.json")
+      .writeText("""{"root":{"nodeId":"STALE","boundsInRoot":"0,0,1,1"}}""")
+
+    val fetcher = DaemonSemanticsFetcher(factory = FakeFactory(emptyMap()))
+    val outcome =
+      fetcher.fetch(
+        projectDir = projectDir,
+        moduleName = "sample",
+        previewIds = listOf("BetaPreview"),
+      )
+
+    assertTrue(outcome is DaemonSemanticsFetcher.Outcome.Ok, "expected Ok, got $outcome")
+    assertTrue(outcome.semanticsById.isEmpty(), "stale sidecar must not be carried")
+    assertTrue(
+      !File(staleDir, "compose-semantics.json").exists(),
+      "stale sidecar should have been deleted before the render",
+    )
+  }
+
+  @Test
   fun `missing descriptor returns DescriptorMissing`() {
     val projectDir = newTempFolder("semantics-no-descriptor")
     val fetcher = DaemonSemanticsFetcher(factory = FakeFactory(emptyMap()))
@@ -165,15 +191,18 @@ class DaemonSemanticsFetcherTest {
   }
 
   /**
-   * Minimal [RenderSession] whose [renderNow] writes the daemon's always-on
-   * `compose-semantics.json` sidecar for every preview it has canned content for — the same on-disk
-   * location the production daemon writes. Every other method throws.
+   * Minimal [RenderSession] modelling the real daemon's async render: [renderNow] writes the
+   * always-on `compose-semantics.json` sidecar for every preview it has canned content for, then
+   * emits a `renderFinished` notification per requested id (the signal the fetcher waits on before
+   * reading the files). Every other method throws.
    */
   private class FakeSession(
     override val workspaceRoot: String,
     private val produced: Map<String, String>,
     private val dataRoot: File,
   ) : RenderSession {
+    private val listeners = java.util.concurrent.CopyOnWriteArrayList<NotificationListener>()
+
     override val modulePath: String = ":sample"
     override val initializeResult: InitializeResult =
       InitializeResult(
@@ -205,9 +234,18 @@ class DaemonSemanticsFetcherTest {
       timeout: kotlin.time.Duration,
     ): RenderNowResult {
       for (id in previewIds) {
-        val content = produced[id] ?: continue
-        val dir = File(dataRoot, id).also { it.mkdirs() }
-        File(dir, "compose-semantics.json").writeText(content)
+        produced[id]?.let { content ->
+          val dir = File(dataRoot, id).also { it.mkdirs() }
+          File(dir, "compose-semantics.json").writeText(content)
+        }
+        // Emit renderFinished for *every* requested id — including ones that wrote no sidecar — so
+        // the fetcher's wait completes (a failed render still finishes) rather than timing out.
+        val params =
+          kotlinx.serialization.json.buildJsonObject {
+            put("id", id)
+            put("pngPath", "$id.png")
+          }
+        listeners.forEach { it.onNotification("renderFinished", params) }
       }
       return RenderNowResult(queued = previewIds, rejected = emptyList())
     }
@@ -286,7 +324,10 @@ class DaemonSemanticsFetcherTest {
       timeout: kotlin.time.Duration,
     ): RecordingEncodeResult = error("unused")
 
-    override fun onNotification(listener: NotificationListener): AutoCloseable = AutoCloseable {}
+    override fun onNotification(listener: NotificationListener): AutoCloseable {
+      listeners.add(listener)
+      return AutoCloseable { listeners.remove(listener) }
+    }
 
     override fun close() = Unit
   }

--- a/docs/portable-bundles.md
+++ b/docs/portable-bundles.md
@@ -68,10 +68,17 @@ Schema v2 bakes a PNG per preview. Reading them needs **none** of the classpath
 machinery — just:
 
 ```
-bundle.json          → schemaVersion, previewIds, coverPreviewId (unknown keys ignored)
-previews.json        → preview metadata (names, dimensions)
-previews/<id>.png    → one rendered image per preview
+bundle.json                  → schemaVersion, previewIds, coverPreviewId (unknown keys ignored)
+previews.json                → preview metadata (names, dimensions)
+previews/<id>.png            → one rendered image per preview
+previews/<id>.semantics.json → (opt-in, `pack --with-semantics`) per-preview compose/semantics tree
 ```
+
+The `previews/<id>.semantics.json` sidecar carries the `compose/semantics` tree (per-node
+bounds, label/text, and resolved foreground/background colours) beside each rendered image —
+the shape design-parity reads for contrast/a11y and design-token checks. It's produced by a
+short-lived daemon render at pack time (the standalone render writes no semantics), so it's
+opt-in behind `compose-preview bundle pack --with-semantics`.
 
 Players on this read path:
 - Any **PNG viewer** — the polyglot's leading bytes are the cover. Finder,
@@ -118,7 +125,8 @@ expression of `classpath[]` changes:
 ```
 bundle.json          # manifest; classpath[] differs per producer/mode
 previews.json
-previews/<id>.png     # baked images — IDENTICAL across all build systems
+previews/<id>.png            # baked images — IDENTICAL across all build systems
+previews/<id>.semantics.json # (opt-in) per-preview compose/semantics tree (resolved fg/bg colours)
 classes/app.jar       # module bytecode, minimized (ClassGraph closure is build-system-agnostic:
                       #   it walks whatever class dirs + jars it's given — Bazel/Amper outputs work)
 libs/<name>.jar       # inlined deps: today only project-style; in "embedded" mode, all reachable deps


### PR DESCRIPTION
Closes #1843.

## Summary

`bundle pack` baked the rendered PNG but no per-preview semantics, so a [`design-parity`](https://github.com/yschimke/design-parity) run over the bundle silently degraded to visual/structural only — contrast/a11y checks couldn't run and every design-reference token reported *missing from candidate*.

This adds `compose-preview bundle pack --with-semantics`. After the normal render + bundle Gradle pass, it:

1. starts the daemon in the same Gradle invocation (`composePreviewDaemonStart`) so the launch descriptor is fresh against the consumer's classpath,
2. opens a short-lived `RenderSession` — the daemon is the **single** producer of `compose/semantics` (the standalone `composePreviewRender` task writes no semantics sidecars), and `renderNow`s the bundle's selected previews so the always-on `ComposeSemanticsExtension` writes each one's tree, and
3. injects them into the bundle as `previews/<id>.semantics.json`.

The payload is the existing `ComposeSemanticsPayload` shape (per-node bounds, label/text, **resolved foreground/background colours**) — the location + shape the design-parity static bundle reader consumes as a sibling of `previews/<id>.png`. No separate `--with-extension a11y` render pass is needed.

Design decisions:
- **Opt-in flag**, not default: producing semantics spins up a daemon and re-renders, which roughly doubles a pack's cost; plain `bundle pack` stays cheap. The flag is the CLI surface the issue asked for. Ignored (with a warning) when combined with `--no-render`.
- **Graceful degradation**: a missing descriptor / daemon open or render failure / unsupported backend warns to stderr and leaves the already-written bundle valid (cover PNG + every entry preserved) rather than failing the pack.
- **Idempotent injection**: re-packing replaces any prior `previews/<id>.semantics.json`, and the splice re-attaches the leading PNG so the file stays a valid polyglot.

## Test plan

- [x] `:cli:test` — `BundleSemanticsInjectTest` (polyglot-safe injection: cover preserved, sidecars beside the PNGs, idempotent re-injection, empty no-op, `addOrReplaceZipEntries` collision replacement) and `DaemonSemanticsFetcherTest` (fake `RenderSessionFactory` whose `renderNow` writes sidecars → fetcher returns them keyed by id; partial materialisation, missing descriptor, open failure, empty list).
- [x] `:cli:compileKotlin` / `:cli:compileTestKotlin` clean; existing `Bundle*` / `Daemon*` / `A11y*` CLI tests still green.
- [x] `ktfmtFormat` applied.

Non-visual change (CLI / bundle plumbing), so no rendered evidence per the repo's visual-evidence guidance.

Follow-up (separate repo, out of scope here): document the `--with-semantics` flag in `yschimke/skills` consumer docs.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YHDPrc1Hh6WtVuft5i1nus)_