### PR TITLE
fix(desktop): resolve renderer in the consumer's graph so Skiko stays coherent

### DIFF
--- a/docs/RENDERER_COMPATIBILITY.md
+++ b/docs/RENDERER_COMPATIBILITY.md
@@ -48,6 +48,36 @@ The VS Code extension surfaces the same findings in the Problems panel (via
      `-android` coordinate; `compose-preview doctor` reports the same skew for
      the consumer's own test tasks.
 
+## Desktop (Compose Multiplatform) renderer
+
+The desktop backend has the mirror-image hazard. `renderer-desktop` (and
+`daemon-desktop`) bundle their own JetBrains Compose + Skiko, pinned to the
+repo's `compose-multiplatform` (currently 1.10.3). A consumer module tracks
+*its own* Compose Multiplatform version, which can be newer. The plugin builds
+the render subprocess classpath from two configurations — the renderer tool
+config (`composePreviewRenderer` / `composePreviewDesktopDaemon`) and the
+consumer's runtime classpath — so if those resolve as **separate** graphs, both
+Skikos land on the classpath. Skiko's Java bindings and its native library must
+be the same version; the newer bindings (e.g. CMP 1.11's
+`TextStyleKt._nSetFontEdging`) against the renderer's older native `.so` fail at
+render time with `UnsatisfiedLinkError`, not a clean resolution error (issue
+#1844).
+
+The mitigation mirrors Android's #2 above:
+`ComposePreviewTasks.alignDesktopToolWithConsumerGraph` makes the renderer tool
+config `extendsFrom` the consumer's runtime classpath and copies its
+JVM/Kotlin platform attributes, so the two resolve in **one** graph. Gradle's
+conflict resolution then picks a single coherent max version of Skiko (and the
+rest of the JetBrains Compose stack) — the consumer's, whose bindings and
+native library agree. The renderer's own code is compiled against the pinned
+floor (1.10.3) but runs against whatever coherent version the consumer pulls;
+because Skiko/Compose minor bumps are additive at the API surface the renderer
+uses, the consumer's newer stack satisfies it. This is scoped to genuinely
+JVM/desktop consumer classpaths — a pure-Android KMP fallback
+(`androidRuntimeClasspath`) is left alone (no `androidJvm` renderer variant
+exists, and that classpath can't feed the JVM renderer anyway). Covered by
+`DesktopRendererGraphAlignmentFunctionalTest`.
+
 ## Known findings that still warrant a note
 
 ### A library declares a higher minSdk than the module

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DesktopRendererGraphAlignmentFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DesktopRendererGraphAlignmentFunctionalTest.kt
@@ -1,0 +1,155 @@
+package ee.schimke.composeai.plugin
+
+import com.google.common.truth.Truth.assertThat
+import java.io.File
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * Proves the desktop renderer config resolves in the consumer's dependency graph so a single
+ * coherent (max) version of every shared module wins — the fix for issue #1844.
+ *
+ * Background: a consumer on Compose Multiplatform 1.11 pulls a newer Skiko whose Java bindings call
+ * `org.jetbrains.skia.paragraph.TextStyleKt._nSetFontEdging`; the renderer bundles an older Skiko
+ * (pinned to CMP 1.10.3) whose native library doesn't export that symbol. Before the fix the
+ * renderer config and the consumer's runtime classpath were merged as raw `FileCollection`s with no
+ * cross-graph conflict resolution, so both Skikos landed on the render classpath and the older
+ * native + newer bindings collided at runtime with `UnsatisfiedLinkError`.
+ * `ComposePreviewTasks.alignDesktopToolWithConsumerGraph` makes the renderer config `extendsFrom`
+ * the consumer's runtime classpath, so Gradle picks one coherent version.
+ *
+ * This test stands in for "renderer pinned older than consumer" by pre-seeding
+ * `composePreviewRenderer` with an *older* `org.jetbrains.compose.material3` than the consumer's
+ * Compose plugin resolves. Without the fold the renderer config would resolve that older version in
+ * isolation; with it, conflict resolution against the consumer graph collapses to the single newer
+ * version — the same mechanism that aligns the Skiko native library with the bindings.
+ */
+class DesktopRendererGraphAlignmentFunctionalTest {
+
+  @get:Rule val tempDir = TemporaryFolder()
+
+  private fun createTestProject(): File {
+    val projectDir = tempDir.root
+
+    File(projectDir, "settings.gradle.kts")
+      .writeText(
+        """
+        pluginManagement {
+            repositories {
+                gradlePluginPortal()
+                google()
+                mavenCentral()
+            }
+        }
+        dependencyResolutionManagement {
+            repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+            repositories {
+                google()
+                mavenCentral()
+            }
+        }
+        rootProject.name = "test-desktop-graph-alignment"
+        """
+          .trimIndent()
+      )
+
+    File(projectDir, "build.gradle.kts")
+      .writeText(
+        """
+        @file:Suppress("DEPRECATION")
+        plugins {
+            kotlin("jvm") version "2.2.21"
+            kotlin("plugin.compose") version "2.2.21"
+            id("org.jetbrains.compose") version "1.10.3"
+            id("ee.schimke.composeai.preview")
+        }
+        dependencies {
+            implementation(compose.desktop.currentOs)
+            implementation(compose.material3)
+            implementation(compose.components.uiToolingPreview)
+        }
+        // Stand in for the renderer: pre-seed the tool config so `ensureRendererDesktopConfig` skips
+        // its Maven add for the unpublished `ee.schimke.composeai:renderer-desktop` coordinate (a
+        // synthetic temp project can't resolve it). Pin an OLDER material3 than the Compose plugin
+        // resolves for the consumer's own deps — without the graph fold the renderer config would
+        // resolve this older version on its own.
+        configurations.maybeCreate("composePreviewRenderer")
+        dependencies {
+            "composePreviewRenderer"("org.jetbrains.compose.material3:material3:1.7.3")
+        }
+        java {
+            toolchain { languageVersion.set(JavaLanguageVersion.of(17)) }
+        }
+
+        // Resolve the renderer tool classpath and print one line per artifact + the extendsFrom
+        // edges so the test can assert on the coherent, single-version result.
+        tasks.register("dumpRendererClasspath") {
+            val rendererCfg = configurations.getByName("composePreviewRenderer")
+            doLast {
+                rendererCfg.extendsFrom.forEach { println("RENDERER_EXTENDS ${'$'}{it.name}") }
+                rendererCfg.incoming.artifactView { }.files.forEach { println("RENDERER_JAR ${'$'}{it.name}") }
+            }
+        }
+        """
+          .trimIndent()
+      )
+
+    return projectDir
+  }
+
+  @Test
+  fun `desktop renderer config folds into the consumer graph and resolves one coherent version`() {
+    val projectDir = createTestProject()
+
+    val result =
+      GradleRunner.create()
+        .withProjectDir(projectDir)
+        .withArguments("dumpRendererClasspath", "-q", "--stacktrace")
+        .withPluginClasspath()
+        .build()
+
+    val jars =
+      result.output
+        .lineSequence()
+        .filter { it.startsWith("RENDERER_JAR ") }
+        .map { it.removePrefix("RENDERER_JAR ").trim() }
+        .toList()
+    val extendsFrom =
+      result.output
+        .lineSequence()
+        .filter { it.startsWith("RENDERER_EXTENDS ") }
+        .map { it.removePrefix("RENDERER_EXTENDS ").trim() }
+        .toList()
+
+    // Sanity: the dump task resolved a real classpath (guards against an empty-resolution false
+    // pass, and surfaces the actual artifact set in the failure message if anything below trips).
+    assertThat(jars).isNotEmpty()
+
+    // The fold is wired: the renderer config extends the consumer's runtime classpath.
+    assertThat(extendsFrom).contains("runtimeClasspath")
+
+    // The invariant the fix guarantees: the renderer's transitive Skiko native runtime resolves to
+    // at most one version — the side-by-side duplicate (renderer-pinned older + consumer newer)
+    // that
+    // produced the `UnsatisfiedLinkError` is gone. Asserting "no duplicate version" rather than
+    // "exactly one" keeps the test deterministic even when the OS-native variant download lands
+    // late
+    // on a cold cache.
+    val skikoRuntimeVersions =
+      jars
+        .filter { it.startsWith("skiko-awt-runtime") }
+        .map { it.substringAfterLast('-').removeSuffix(".jar") }
+        .toSet()
+    assertThat(skikoRuntimeVersions.size).isAtMost(1)
+
+    // Positive proof that the graphs were actually folded: conflict resolution against the consumer
+    // graph wins, so the pre-seeded older material3 (1.7.3) is replaced by the single version the
+    // consumer's Compose plugin resolves (a `-desktop`-suffixed KMP artifact), not carried
+    // alongside.
+    val material3Jars = jars.filter { it.startsWith("material3-") && it.endsWith(".jar") }
+    assertThat(material3Jars).hasSize(1)
+    assertThat(material3Jars.single()).doesNotContain("1.7.3")
+  }
+}

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -719,16 +719,28 @@ internal object ComposePreviewTasks {
   }
 
   /**
-   * Copies every attribute from [source] onto [target]. AGP-free mirror of the identically named
+   * Copies attributes from [source] onto [target] for variant selection, EXCEPT the consumer's
+   * bytecode-target attribute (`org.gradle.jvm.version`). AGP-free mirror of the identically named
    * helper in [AndroidPreviewSupport] — kept here so the desktop wiring doesn't pull AGP onto its
    * classpath. Used by [alignDesktopToolWithConsumerGraph] to give the renderer tool config the
    * consumer classpath's JVM/Kotlin platform attributes before extending it.
+   *
+   * `org.gradle.jvm.version` is deliberately skipped: the renderer / daemon tool modules are built
+   * at the repo's Java 17 convention, so inheriting a consumer that targets a lower bytecode level
+   * (e.g. a project on a JVM 11 toolchain, whose `runtimeClasspath` carries
+   * `org.gradle.jvm.version=11`) would make Gradle demand a Java-11-compatible variant of
+   * `renderer-desktop` / `daemon-desktop` that doesn't exist and reject the dependency before
+   * rendering. The platform-type / usage attributes we DO need for KMP variant selection are
+   * copied.
    */
   private fun copyAttributes(
     target: org.gradle.api.attributes.AttributeContainer,
     source: org.gradle.api.attributes.AttributeContainer,
   ) {
+    val targetJvmVersion =
+      org.gradle.api.attributes.java.TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE.name
     source.keySet().forEach { key ->
+      if (key.name == targetJvmVersion) return@forEach
       @Suppress("UNCHECKED_CAST") val attr = key as Attribute<Any>
       source.getAttribute(attr)?.let { target.attribute(attr, it) }
     }

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -174,6 +174,9 @@ internal object ComposePreviewTasks {
     registerCompileOnlyTask(project, extension, DESKTOP_COMPILE_TASK_CANDIDATES)
 
     val rendererConfig = ensureRendererDesktopConfig(project, "composePreviewRenderer")
+    // Resolve the renderer in the consumer's dependency graph so a single coherent Skiko / Compose
+    // version wins (issue #1844). See [alignDesktopToolWithConsumerGraph].
+    alignDesktopToolWithConsumerGraph(project, rendererConfig, resolveDependencyConfigName)
 
     val renderClasspathGuard =
       registerDesktopClasspathGuard(
@@ -474,6 +477,10 @@ internal object ComposePreviewTasks {
         isCanBeResolved = true
         isCanBeConsumed = false
       }
+    // The daemon JVM puts the consumer's full runtime classpath on its parent `-cp` (below), so it
+    // hits the same Skiko skew as the one-shot render path — resolve it in the consumer's graph too
+    // (issue #1844). See [alignDesktopToolWithConsumerGraph].
+    alignDesktopToolWithConsumerGraph(project, daemonRendererConfig, dependencyConfigName)
     if (useLocalDaemon) {
       try {
         project.dependencies.add(
@@ -664,6 +671,66 @@ internal object ComposePreviewTasks {
       group = "compose preview"
       description =
         "Emit build/compose-previews/daemon-launch.json so VS Code can spawn the desktop preview daemon JVM"
+    }
+  }
+
+  /**
+   * Folds the desktop renderer / daemon tool configuration [toolConfig] into the SAME dependency
+   * graph as the consumer's runtime classpath, so Gradle's conflict resolution picks one coherent
+   * max-version of every shared module instead of leaving the renderer's pinned versions and the
+   * consumer's newer versions side by side on the classpath as separate JARs.
+   *
+   * Issue #1844: a consumer on Compose Multiplatform 1.11 resolves a newer Skiko whose Java
+   * bindings call `org.jetbrains.skia.paragraph.TextStyleKt._nSetFontEdging`. The renderer bundles
+   * an older Skiko (pinned to CMP 1.10.3) whose native library doesn't export that symbol; merging
+   * the two configurations as raw `FileCollection`s does no cross-graph conflict resolution, so
+   * both Skikos land on the render classpath and the older native library + newer Java bindings
+   * collide at runtime with `UnsatisfiedLinkError`. `extendsFrom` makes the tool config resolve in
+   * one graph with the consumer's deps, so the higher Skiko (the consumer's) wins for both the Java
+   * bindings and the native library — and because both configs then resolve the same artifact file,
+   * the `FileCollection` (a `Set<File>`) carries it exactly once. Mirrors the Android renderer's
+   * `extendsFrom(testConfig)` (docs/RENDERER_COMPATIBILITY.md mitigation #2); [copyAttributes]
+   * hands Gradle the consumer's JVM/Kotlin platform attributes so it selects the matching variant
+   * of each KMP-published module (Skiko, the JetBrains Compose runtime) without us declaring them
+   * by hand.
+   *
+   * Scoped to genuinely JVM/desktop consumer classpaths. The pure-Android KMP fallback
+   * (`androidRuntimeClasspath`, `platform.type=androidJvm`) is left untouched: the desktop renderer
+   * has no `androidJvm` variant, so extending it would fail resolution outright — and that
+   * classpath can't feed the JVM renderer anyway ([ValidateComposePreviewClasspathTask] already
+   * rejects its AndroidX Compose artifacts). Wired in `afterEvaluate` because the KMP
+   * `jvm`/`desktop` runtime classpaths the consumer resolves against may not exist yet when
+   * [registerDesktopTasks] runs (the `kotlin { jvm("desktop") }` block can configure after
+   * `pluginManager.withPlugin` fires).
+   */
+  private fun alignDesktopToolWithConsumerGraph(
+    project: Project,
+    toolConfig: org.gradle.api.artifacts.Configuration,
+    dependencyConfigName: () -> String,
+  ) {
+    project.afterEvaluate {
+      val depName = dependencyConfigName()
+      // androidJvm classpath: the desktop renderer has no matching variant — leave it alone.
+      if (depName == "androidRuntimeClasspath") return@afterEvaluate
+      val depConfig = project.configurations.findByName(depName) ?: return@afterEvaluate
+      copyAttributes(toolConfig.attributes, depConfig.attributes)
+      toolConfig.extendsFrom(depConfig)
+    }
+  }
+
+  /**
+   * Copies every attribute from [source] onto [target]. AGP-free mirror of the identically named
+   * helper in [AndroidPreviewSupport] — kept here so the desktop wiring doesn't pull AGP onto its
+   * classpath. Used by [alignDesktopToolWithConsumerGraph] to give the renderer tool config the
+   * consumer classpath's JVM/Kotlin platform attributes before extending it.
+   */
+  private fun copyAttributes(
+    target: org.gradle.api.attributes.AttributeContainer,
+    source: org.gradle.api.attributes.AttributeContainer,
+  ) {
+    source.keySet().forEach { key ->
+      @Suppress("UNCHECKED_CAST") val attr = key as Attribute<Any>
+      source.getAttribute(attr)?.let { target.attribute(attr, it) }
     }
   }
 


### PR DESCRIPTION
## Summary

The desktop render subprocess classpath was assembled from two **separately resolved** configurations — the renderer tool config (`composePreviewRenderer` / `composePreviewDesktopDaemon`, which bundles JetBrains Compose + Skiko pinned to CMP 1.10.3) and the consumer's runtime classpath — merged as raw `FileCollection`s. With no cross-graph conflict resolution, a consumer tracking a newer Compose Multiplatform (e.g. 1.11) ended up with **two** Skikos on the render classpath. The newer Skiko Java bindings call `org.jetbrains.skia.paragraph.TextStyleKt._nSetFontEdging`, which the renderer's older native library doesn't export, so the render died at runtime with `UnsatisfiedLinkError` and produced no PNG (#1844).

The fix makes the renderer tool config `extendsFrom` the consumer's runtime classpath and copies its JVM/Kotlin platform attributes, so both resolve in **one** graph. Gradle's conflict resolution then selects a single coherent max-version of Skiko (and the rest of the JetBrains Compose stack) — the consumer's, whose Java bindings and native library agree. This mirrors the Android renderer's `extendsFrom(testConfig)` mitigation (docs/RENDERER_COMPATIBILITY.md #2). Scoped to genuinely JVM/desktop consumer classpaths; the pure-Android KMP fallback (`androidRuntimeClasspath`, no `androidJvm` renderer variant) is left untouched.

Applied to both the one-shot render path (`composePreviewRender`) and the desktop daemon launch path, since both build the subprocess classpath the same way.

Closes #1844.

## Test plan

- [x] `./gradlew :samples:cmp:composePreviewRenderAll` — 18 previews render end-to-end (no regression at the repo's pinned CMP 1.10.3; config cache stored clean).
- [x] New `DesktopRendererGraphAlignmentFunctionalTest` — a synthetic desktop consumer whose renderer config is pre-seeded with an *older* `material3` resolves to the single consumer-max version, and Skiko's native runtime carries no duplicate version. Manually confirmed the real resolved set collapses to one `skiko-awt-runtime-*.jar` + `material3-desktop-1.9.0...` (not the pinned 1.7.3).
- [x] `:gradle-plugin:test` + `DesktopClasspathGuardFunctionalTest` (config-cache round-trip guard) green.

Non-visual change (dependency-graph / build wiring), so no rendered evidence — verified via the end-to-end sample render above.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FGVYZhrFVkzgy6KpmY6fYJ)_