### PR TITLE
feat(cli): auto-inject the preview plugin into KMP-Android library modules

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/AutoInject.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/AutoInject.kt
@@ -77,15 +77,24 @@ internal fun renderInitScript(pluginVersion: String): String =
 // publish the CLI's own release version to `~/.m2` and resolve from there
 // rather than Maven Central.
 //
-// Auto-inject is suppressed for modules that apply
-// `com.android.kotlin.multiplatform.library` — the AGP-KMP plugin's single
-// `android` variant trips a variant-ambiguity error on
-// `androidRuntimeClasspath` once the renderer-android artifact view kicks in,
-// breaking `compose-preview show` for any project where the plugin landed
-// purely via auto-inject. The supported KMP-Android layout
-// (samples/cmp-shared, with a `jvm("desktop")` target) still works when the
-// user adds `id("ee.schimke.composeai.preview")` to that module's plugins {}
-// block themselves — we just no longer apply it implicitly.
+// Modules that apply `com.android.kotlin.multiplatform.library` (AGP 9's
+// KMP-Android library plugin) are auto-injected like any other Compose module —
+// the init script's `withPlugin("com.android.kotlin.multiplatform.library")` hook
+// applies the plugin, and the plugin's own apply() routes them through the
+// Compose Multiplatform Desktop pipeline (the matching withPlugin hook in
+// ComposePreviewPlugin -> ComposePreviewTasks.registerDesktopTasks). So the
+// canonical layout — a `:shared` module with an `androidMain` target plus a
+// `jvm("desktop")` target (samples/cmp-shared) — previews without the user
+// pre-applying `id("ee.schimke.composeai.preview")` themselves.
+//
+// A pure KMP-Android module with NO `jvm("desktop")` target has no JVM-flavoured
+// runtime classpath, so the desktop renderer can't drive it: its only runtime
+// config is `androidRuntimeClasspath`, which carries `*-android` Compose AARs
+// that reference `android.os.Parcelable` and explode in a host JVM. That case
+// fails soft in the plugin — `validateComposePreviewDesktopRenderClasspath`
+// aborts the render task with an actionable "add a `jvm("desktop")` target"
+// message, and the discovery / Tooling-API model paths resolve leniently — so
+// auto-injecting the plugin id build-wide never crashes the whole query.
 //
 // When the consumer's settings file declares `exclusiveContent { ... }`
 // inside `pluginManagement { repositories { ... } }` (the Confetti shape;
@@ -118,7 +127,6 @@ val useMavenLocal = pluginVersion.endsWith("-SNAPSHOT") ||
     System.getenv("COMPOSE_PREVIEW_INIT_USE_MAVEN_LOCAL") == "1"
 
 var composeAiPreviewPreAppliedDirs: Set<java.io.File> = emptySet()
-var composeAiPreviewKmpAndroidDirs: Set<java.io.File> = emptySet()
 var composeAiPreviewSettingsHasExclusiveContent: Boolean = false
 // Projects that declare their own `buildscript { repositories { ... } }` block — populated
 // at settingsEvaluated time. Only consulted when composeAiPreviewSettingsHasExclusiveContent
@@ -142,30 +150,6 @@ fun composeAiPreviewCatalogAccessors(rootDir: java.io.File): List<Regex> {
         "(?m)^[ \\t]*([A-Za-z0-9_.\\-]+)\\s*=\\s*(?:" +
             "\\{[^}]*\\bid\\s*=\\s*\"ee\\.schimke\\.composeai\\.preview\"[^}]*\\}|" +
             "\"ee\\.schimke\\.composeai\\.preview(?::[^\"]*)?\"" +
-            ")"
-    )
-    return entryRe.findAll(section).map { match ->
-        val accessor = match.groupValues[1].replace(Regex("[-_]"), ".")
-        Regex("\\blibs\\s*\\.\\s*plugins\\s*\\.\\s*" + Regex.escape(accessor) + "\\b")
-    }.toList()
-}
-
-// Catalog-alias accessors for `com.android.kotlin.multiplatform.library` — same shape as
-// composeAiPreviewCatalogAccessors but pinned to the KMP-Android plugin id so a module
-// declaring it via `alias(libs.plugins.android.kotlin.multiplatform.library)` is detected
-// alongside the literal `id("com.android.kotlin.multiplatform.library")` form.
-fun composeAiPreviewKmpAndroidCatalogAccessors(rootDir: java.io.File): List<Regex> {
-    val catalog = java.io.File(rootDir, "gradle/libs.versions.toml")
-    if (!catalog.isFile) return emptyList()
-    val text = runCatching { catalog.readText() }.getOrNull() ?: return emptyList()
-    val pluginsHeader = Regex("(?m)^\\[plugins\\]\\s*${'$'}").find(text) ?: return emptyList()
-    val sectionStart = pluginsHeader.range.last + 1
-    val nextSection = Regex("(?m)^\\[").find(text, sectionStart)
-    val section = text.substring(sectionStart, nextSection?.range?.first ?: text.length)
-    val entryRe = Regex(
-        "(?m)^[ \\t]*([A-Za-z0-9_.\\-]+)\\s*=\\s*(?:" +
-            "\\{[^}]*\\bid\\s*=\\s*\"com\\.android\\.kotlin\\.multiplatform\\.library\"[^}]*\\}|" +
-            "\"com\\.android\\.kotlin\\.multiplatform\\.library(?::[^\"]*)?\"" +
             ")"
     )
     return entryRe.findAll(section).map { match ->
@@ -215,42 +199,6 @@ fun scanForComposeAiPreviewDeclaration(
             val raw = runCatching { buildFile.readText() }.getOrNull() ?: continue
             val text = composeAiPreviewStripComments(raw)
             if (literalVersionedRe.containsMatchIn(text)) {
-                declared.add(dir)
-                break
-            }
-            if (catalogAccessors.any { it.containsMatchIn(text) }) {
-                declared.add(dir)
-                break
-            }
-        }
-    }
-    return declared
-}
-
-// Scan for modules that apply `com.android.kotlin.multiplatform.library` — auto-inject
-// skips both the buildscript classpath injection and the withPlugin apply hooks for these
-// dirs. Applying compose-preview to a KMP-Android module trips an AGP-KMP variant model
-// mismatch on `androidRuntimeClasspath` once the consumer's CLI run resolves the renderer's
-// artifact view. Users who explicitly want previews on a KMP-Android module can add
-// `id("ee.schimke.composeai.preview")` to that module's plugins {} block themselves — the
-// supported layout in samples/cmp-shared (with a `jvm("desktop")` target) still works that
-// way; we just don't apply it implicitly anymore.
-fun scanForKmpAndroidDeclaration(
-    rootDir: java.io.File,
-    projectDirs: List<java.io.File>,
-): Set<java.io.File> {
-    val catalogAccessors = composeAiPreviewKmpAndroidCatalogAccessors(rootDir)
-    val literalRe = Regex(
-        "\\bid\\s*[(\\s]\\s*[\"']com\\.android\\.kotlin\\.multiplatform\\.library[\"']"
-    )
-    val declared = LinkedHashSet<java.io.File>()
-    for (dir in projectDirs) {
-        for (name in listOf("build.gradle.kts", "build.gradle")) {
-            val buildFile = java.io.File(dir, name)
-            if (!buildFile.isFile) continue
-            val raw = runCatching { buildFile.readText() }.getOrNull() ?: continue
-            val text = composeAiPreviewStripComments(raw)
-            if (literalRe.containsMatchIn(text)) {
                 declared.add(dir)
                 break
             }
@@ -420,7 +368,6 @@ gradle.settingsEvaluated {
     }
     collect(rootProject)
     composeAiPreviewPreAppliedDirs = scanForComposeAiPreviewDeclaration(rootDir, projectDirs)
-    composeAiPreviewKmpAndroidDirs = scanForKmpAndroidDeclaration(rootDir, projectDirs)
     composeAiPreviewSettingsHasExclusiveContent =
         composeAiPreviewSettingsDeclaresExclusiveContent(settingsDir)
     // Only walk the buildscript-repos scan when it matters — in the non-exclusiveContent
@@ -456,28 +403,19 @@ gradle.settingsEvaluated {
 
 allprojects {
     if (composeAiPreviewIsIncludedBuild) return@allprojects
-    // Skip BOTH the buildscript classpath injection AND the apply hooks for KMP-Android
-    // modules. Doing only one half leaves the other half active: skipping the classpath
-    // injection alone still fires the withPlugin hooks (which then fail to find the plugin
-    // class), and skipping only the hooks still drags an unused plugin marker onto the
-    // buildscript classpath. Both halves gated together is the safe shape — see
-    // scanForKmpAndroidDeclaration() above for the rationale.
-    val composeAiPreviewSkipKmpAndroid = projectDir in composeAiPreviewKmpAndroidDirs
-
     // In the exclusiveContent shape we can't add repositories to buildscript.repositories
     // (Gradle 9.3+ rejects it; issues #1470, #1482), so projects that don't already have
     // their own buildscript repos have no way to resolve our classpath dep — adding it
     // there would only produce `Cannot resolve external dependency ... because no
     // repositories are defined` at configuration time, which short-circuits the entire
     // Tooling API query (the 0.11.8 regression). Skip the injection wholesale for those
-    // projects; they silently miss the plugin, the same as projects that we explicitly
-    // skip for KMP-Android, and the user's recourse is the same plugins { } DSL apply.
+    // projects; they silently miss the plugin, and the user's recourse is the
+    // plugins { } DSL apply.
     val composeAiPreviewSkipExclusiveContentClasspathDep =
         composeAiPreviewSettingsHasExclusiveContent &&
             projectDir !in composeAiPreviewProjectsWithOwnBuildscriptRepos
 
-    if (!composeAiPreviewSkipKmpAndroid &&
-        !composeAiPreviewSkipExclusiveContentClasspathDep &&
+    if (!composeAiPreviewSkipExclusiveContentClasspathDep &&
         projectDir !in composeAiPreviewPreAppliedDirs) {
         buildscript {
             // When the settings file declares `exclusiveContent { ... }` in `pluginManagement {
@@ -504,7 +442,6 @@ allprojects {
         }
     }
 
-    if (composeAiPreviewSkipKmpAndroid) return@allprojects
     // No buildscript classpath dep was injected and the project doesn't pre-apply, so
     // `pluginManager.apply(...)` from the withPlugin hooks would fail with "Plugin with id
     // ... not found." Skipping the hooks keeps the failure mode quiet — non-preview
@@ -519,6 +456,14 @@ allprojects {
 
     pluginManager.withPlugin("com.android.application") { applyComposeAiPreview() }
     pluginManager.withPlugin("com.android.library") { applyComposeAiPreview() }
+    // `com.android.kotlin.multiplatform.library` (AGP 9's KMP-Android library plugin) is
+    // applied like any other Compose module; ComposePreviewPlugin's matching withPlugin hook
+    // routes it through the Compose Multiplatform Desktop pipeline. The canonical
+    // `:shared` + `jvm("desktop")` layout previews without a manual apply; a pure
+    // KMP-Android module with no desktop target fails soft in the plugin (the desktop
+    // render-classpath guard aborts with an actionable message) rather than crashing the
+    // CLI's Tooling-API query — see the header comment.
+    pluginManager.withPlugin("com.android.kotlin.multiplatform.library") { applyComposeAiPreview() }
     pluginManager.withPlugin("org.jetbrains.compose") { applyComposeAiPreview() }
 }
 """

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/AutoInjectTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/AutoInjectTest.kt
@@ -455,61 +455,39 @@ class AutoInjectTest {
   }
 
   @Test
-  fun `init script skips auto-inject for KMP-Android modules`() {
-    // Regression coverage for the meshcore-mobile report: applying compose-preview to a module
-    // that uses `com.android.kotlin.multiplatform.library` trips an AGP-KMP variant-ambiguity
-    // error on `androidRuntimeClasspath` once the renderer's artifact view kicks in, which
-    // breaks `compose-preview show` for any project where the plugin landed via auto-inject.
-    // Auto-inject must scan for the KMP-Android plugin id, mark those modules, and skip both
-    // the buildscript classpath injection AND the apply hooks for them — partial skipping
-    // leaves the other half active and still fails. Pins the wire shape of both halves.
-    val script = renderInitScript("0.11.4")
-    assertTrue(
-      script.contains("var composeAiPreviewKmpAndroidDirs: Set<java.io.File> = emptySet()"),
-      "expected the KMP-Android skip set declaration",
-    )
+  fun `init script applies auto-inject to KMP-Android modules via withPlugin`() {
+    // The previous behaviour skipped `com.android.kotlin.multiplatform.library` modules
+    // wholesale. We now auto-inject them like any other Compose module: the plugin's own
+    // apply() routes them through the Compose Multiplatform Desktop pipeline, so the canonical
+    // `:shared` + `jvm("desktop")` layout previews without the user pre-applying the plugin.
+    // A pure KMP-Android module with no desktop target fails soft inside the plugin (the
+    // desktop render-classpath guard aborts with an actionable message; discovery resolves
+    // leniently) rather than crashing the CLI's Tooling-API query.
+    val script = renderInitScript("0.15.1")
     assertTrue(
       script.contains(
-        "composeAiPreviewKmpAndroidDirs = scanForKmpAndroidDeclaration(rootDir, projectDirs)"
+        "pluginManager.withPlugin(\"com.android.kotlin.multiplatform.library\") { applyComposeAiPreview() }"
       ),
-      "expected settingsEvaluated to populate the KMP-Android skip set",
-    )
-    assertTrue(
-      script.contains(
-        "val composeAiPreviewSkipKmpAndroid = projectDir in composeAiPreviewKmpAndroidDirs"
-      ),
-      "expected the per-project skip flag",
-    )
-    assertTrue(
-      script.contains("!composeAiPreviewSkipKmpAndroid &&") &&
-        script.contains("projectDir !in composeAiPreviewPreAppliedDirs"),
-      "expected the buildscript classpath injection to be gated on the KMP-Android skip flag " +
-        "and the pre-applied dir set",
-    )
-    assertTrue(
-      script.contains("if (composeAiPreviewSkipKmpAndroid) return@allprojects"),
-      "expected the withPlugin apply hooks to short-circuit for KMP-Android modules",
+      "expected an apply hook for the KMP-Android library plugin id",
     )
   }
 
   @Test
-  fun `init script's scanForKmpAndroidDeclaration matches the literal id form`() {
-    // Pins the regex contract so a future refactor doesn't drop literal-id detection. The
-    // canonical KMP-Android module shape is `id("com.android.kotlin.multiplatform.library")`
-    // in a `plugins { ... }` block; the regex anchors on the `id (` / `id "` prefix and the
-    // exact plugin coordinate.
-    val script = renderInitScript("1.0.0")
-    assertTrue(
-      script.contains(
-        "fun scanForKmpAndroidDeclaration(\n    rootDir: java.io.File,\n    projectDirs: List<java.io.File>,\n): Set<java.io.File> {"
-      ),
-      "expected scanForKmpAndroidDeclaration to return Set<File> of KMP-Android project dirs",
+  fun `init script no longer carries the KMP-Android skip machinery`() {
+    // Guards against a half-revert: the skip set, its scanner, and the per-project skip flag
+    // must all be gone now that KMP-Android modules are injected.
+    val script = renderInitScript("0.15.1")
+    assertFalse(
+      script.contains("composeAiPreviewKmpAndroidDirs"),
+      "expected the KMP-Android skip set to be removed",
     )
-    assertTrue(
-      script.contains(
-        "\"\\\\bid\\\\s*[(\\\\s]\\\\s*[\\\"']com\\\\.android\\\\.kotlin\\\\.multiplatform\\\\.library[\\\"']\""
-      ),
-      "expected the literal-id regex for com.android.kotlin.multiplatform.library",
+    assertFalse(
+      script.contains("scanForKmpAndroidDeclaration"),
+      "expected the KMP-Android scanner to be removed",
+    )
+    assertFalse(
+      script.contains("composeAiPreviewSkipKmpAndroid"),
+      "expected the per-project KMP-Android skip flag to be removed",
     )
   }
 
@@ -584,27 +562,6 @@ class AutoInjectTest {
       "the early-return for exclusiveContent is too aggressive — it throws away the classpath " +
         "dep and apply hooks, but those can still work via the consumer's existing buildscript " +
         "repositories. Only the repositories add must be skipped.",
-    )
-  }
-
-  @Test
-  fun `init script's KMP-Android scan recognises catalog aliases`() {
-    // Mirrors the compose-preview catalog-accessor path so a project that declares the
-    // KMP-Android plugin in `gradle/libs.versions.toml` (e.g.
-    // `androidKotlinMultiplatformLibrary = { id = "com.android.kotlin.multiplatform.library",
-    // version = "..." }`) and references it via
-    // `alias(libs.plugins.androidKotlinMultiplatformLibrary)`
-    // is still detected — that's the shape the meshcore-mobile reproducer uses.
-    val script = renderInitScript("1.0.0")
-    assertTrue(
-      script.contains(
-        "fun composeAiPreviewKmpAndroidCatalogAccessors(rootDir: java.io.File): List<Regex>"
-      ),
-      "expected a catalog-accessor scanner pinned to the KMP-Android plugin id",
-    )
-    assertTrue(
-      script.contains("com\\\\.android\\\\.kotlin\\\\.multiplatform\\\\.library"),
-      "expected the catalog-accessor regex to anchor on the KMP-Android plugin id",
     )
   }
 

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -158,6 +158,10 @@ internal object ComposePreviewTasks {
         resolveDependencyConfigName,
         previewOutputDir,
         extension,
+        // Desktop fallback can resolve a KMP-Android module's androidRuntimeClasspath, whose
+        // single AGP variant trips AmbiguousArtifactsFailure under a forced artifactType view —
+        // keep discovery lenient so `compose-preview list` never aborts on such a module.
+        lenientDependencyJars = true,
       ) {
         onlyIf { extension.enabled.get() }
         // `compileAndroidMain` is the lifecycle task for the KMP-Android target's `main`
@@ -315,7 +319,15 @@ internal object ComposePreviewTasks {
     // recording a `ClasspathEntry.Maven`. On JVM this view is a passthrough, so desktop is
     // unchanged; on Android it's what makes coordinate-mode bundles stay small + re-resolvable.
     val depJarView =
-      depConfig?.incoming?.artifactView { attributes.attribute(artifactTypeAttr, "jar") }
+      depConfig?.incoming?.artifactView {
+        // `lenient(true)` for the same reason as the sibling `typeByComponent` view below: when the
+        // resolved config is a KMP-Android module's `androidRuntimeClasspath` (no `jvm("desktop")`
+        // target), its single AGP `android` variant can't satisfy a forced `artifactType=jar`
+        // selection and would otherwise raise `AmbiguousArtifactsFailure` and sink the whole
+        // bundle. Lenient skips the unselectable dep; on clean JVM/desktop configs it's a no-op.
+        lenient(true)
+        attributes.attribute(artifactTypeAttr, "jar")
+      }
     val depJarFiles = depJarView?.files
     // The `artifactType=jar` view extracts every AAR to its `classes.jar`, erasing the aar/jar
     // distinction — but the player's `CoordinateResolver` needs the real packaging to find the
@@ -1063,6 +1075,16 @@ internal object ComposePreviewTasks {
     dependencyConfigName: () -> String,
     previewOutputDir: Provider<Directory>,
     extension: PreviewExtension,
+    // Desktop callers pass `true`: the desktop runtime-config fallback can land on a
+    // KMP-Android module's `androidRuntimeClasspath` (a `:shared` module with no
+    // `jvm("desktop")` target), whose single AGP `android` variant trips an
+    // `AmbiguousArtifactsFailure` when an `artifactType=jar` view is forced on it. Discovery's
+    // dependency jars are a best-effort ClassGraph scan classpath, so `lenient(true)` skips the
+    // unselectable dep instead of aborting the whole `compose-preview list` Tooling-API query —
+    // the desktop render guard still emits an actionable error if the user actually renders that
+    // module. The Android path keeps the default (`false`) so a genuinely unresolvable AAR there
+    // still surfaces loudly.
+    lenientDependencyJars: Boolean = false,
     configureDeps: DiscoverPreviewsTask.() -> Unit,
   ): TaskProvider<DiscoverPreviewsTask> {
     val artifactType = Attribute.of("artifactType", String::class.java)
@@ -1080,11 +1102,19 @@ internal object ComposePreviewTasks {
         // filtering to request the extracted classes.jar (AGP registers the
         // transform). Desktop/JVM projects already return JARs so this is a no-op.
         dependencyJars.from(
-          config.incoming.artifactView { attributes.attribute(artifactType, "jar") }.files
+          config.incoming
+            .artifactView {
+              if (lenientDependencyJars) lenient(true)
+              attributes.attribute(artifactType, "jar")
+            }
+            .files
         )
         dependencyJars.from(
           config.incoming
-            .artifactView { attributes.attribute(artifactType, "android-classes") }
+            .artifactView {
+              if (lenientDependencyJars) lenient(true)
+              attributes.attribute(artifactType, "android-classes")
+            }
             .files
         )
       }

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ValidateComposePreviewClasspathTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ValidateComposePreviewClasspathTask.kt
@@ -61,6 +61,18 @@ abstract class ValidateComposePreviewClasspathTask : DefaultTask() {
         )
         offenders.take(8).forEach { appendLine(" - $it") }
         if (offenders.size > 8) appendLine(" - (+${offenders.size - 8} more)")
+        // The most common way `*-android` Compose artifacts reach the desktop renderer is a
+        // `com.android.kotlin.multiplatform.library` (`:shared`-style) module with no
+        // `jvm("desktop")` target: the desktop pipeline then falls back to `androidRuntimeClasspath`
+        // and surfaces the `*-android` AARs (which reference `android.os.Parcelable`) to the host
+        // JVM. The fix is to give the module a JVM-flavoured runtime classpath.
+        appendLine()
+        appendLine(
+          "If this is a com.android.kotlin.multiplatform.library (:shared) module, add a " +
+            "`jvm(\"desktop\")` target to its `kotlin { }` block so androidMain previews render " +
+            "through the Compose Multiplatform Desktop pipeline. See " +
+            "compose-preview/references/cmp-shared.md."
+        )
       }
     )
   }

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/ValidateComposePreviewClasspathTaskTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/ValidateComposePreviewClasspathTaskTest.kt
@@ -51,6 +51,38 @@ class ValidateComposePreviewClasspathTaskTest {
   }
 
   @Test
+  fun `desktop validator message points KMP-Android users at a jvm desktop target`() {
+    // The most common way `*-android` Compose artifacts reach the desktop renderer is a
+    // `com.android.kotlin.multiplatform.library` (`:shared`) module that was auto-injected but
+    // has no `jvm("desktop")` target — the desktop pipeline then falls back to
+    // `androidRuntimeClasspath`. The guard's message must hand that user the concrete fix so the
+    // fail-soft path is actionable rather than cryptic.
+    val project = ProjectBuilder.builder().build()
+    val badJar =
+      project.layout.buildDirectory
+        .file("fake-cache/androidx.compose.ui/ui-android/1.9.5/ui-android-1.9.5.aar")
+        .get()
+        .asFile
+    badJar.parentFile.mkdirs()
+    badJar.writeText("not a real aar")
+
+    val task =
+      project.tasks.register(
+        "validateComposePreviewDesktopKmpMessage",
+        ValidateComposePreviewClasspathTask::class.java,
+      ) {
+        platform.set("desktop")
+        classpath.from(badJar)
+      }
+
+    val thrown = runCatching { task.get().validate() }.exceptionOrNull()
+
+    assertThat(thrown).isInstanceOf(GradleException::class.java)
+    assertThat(thrown!!.message).contains("com.android.kotlin.multiplatform.library")
+    assertThat(thrown.message).contains("jvm(\"desktop\")")
+  }
+
+  @Test
   fun `android validator allows androidx compose artifacts`() {
     val project = ProjectBuilder.builder().build()
     val badJar =


### PR DESCRIPTION
## Summary

The auto-inject init script previously skipped every module applying `com.android.kotlin.multiplatform.library`, so even the **supported** `cmp-shared` layout (a `:shared` module with a `jvm("desktop")` target) had to apply `id("ee.schimke.composeai.preview")` by hand. But the plugin already routes that plugin id through the Compose Multiplatform Desktop pipeline (`ComposePreviewPlugin` → `registerDesktopTasks`, issue #248), so the blanket skip was over-broad — it blocked the working layout from auto-injecting.

This makes "compose AI tools work without explicitly pre-applying" for KMP-Android modules:

**A — apply instead of skip.** Auto-inject now applies the plugin to KMP-Android modules via a `withPlugin("com.android.kotlin.multiplatform.library")` hook, and the skip-set machinery is removed (the scanner, catalog-accessor matcher, per-project skip flag, and the buildscript-injection/apply-hook gating).

**B — fail soft so it's safe build-wide.** A *pure* KMP-Android module with no `jvm("desktop")` target has no JVM-flavoured runtime classpath (its only runtime config is `androidRuntimeClasspath`, carrying `*-android` Compose AARs that reference `android.os.Parcelable`). To keep one such module from aborting the whole run:

- `composePreviewDiscover` resolves its dependency jars **leniently** on the desktop path, so an AGP single-variant `AmbiguousArtifactsFailure` can't sink the `compose-preview list` Tooling-API query. The Android path keeps the strict default.
- The bundle task's forced `artifactType=jar` view is lenient for the same reason (matching its sibling `typeByComponent` view).
- The desktop render-classpath guard's error now tells KMP-Android users to add a `jvm("desktop")` target, instead of only naming the offending AndroidX Compose artifacts.

Net effect: the canonical `:shared` + `jvm("desktop")` module previews with zero manual setup; a no-desktop-target module fails soft with an actionable message rather than crashing the CLI query.

## Test plan

- `:cli:test --tests AutoInjectTest` — updated the obsolete skip tests; now asserts the KMP-Android `withPlugin` apply hook is rendered and that the skip-set/scanner/flag are gone. ✅ green
- `gradle-plugin :test --tests ValidateComposePreviewClasspathTaskTest --tests KmpAndroidDesktopRoutingTest` — added a case pinning the new actionable `jvm("desktop")` guidance in the desktop guard message; existing desktop-routing contract unchanged. ✅ green

Non-visual change (auto-inject + Gradle task wiring), so no rendered before/after evidence applies.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WmL6Xj4mr6RaK5mdyv436u)_