### PR TITLE
fix(plugin): skip non-renderable KMP-Android modules instead of failing the desktop render

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -89,6 +89,28 @@ internal object ComposePreviewTasks {
     return rendererConfig
   }
 
+  /**
+   * Whether a desktop-routed module whose resolved runtime config is [configName] can actually be
+   * rendered by the JVM desktop renderer.
+   *
+   * The renderer is a JVM process, so it needs JVM-flavoured Compose on the classpath. A pure
+   * `com.android.kotlin.multiplatform.library` module with no `jvm("desktop")` target exposes only
+   * `androidRuntimeClasspath` — carrying `*-android` Compose AARs that reference
+   * `android.os.Parcelable` — and forcing any artifact view on its single AGP `android` variant
+   * trips a variant ambiguity that, left to propagate, hard-fails the whole `composePreviewRender`
+   * pipeline for every module (issue #1852: a no-preview library module like `:meshcore-mobile`
+   * sinks the green modules' render too).
+   *
+   * Such a module is treated as non-renderable: the desktop tasks skip it (fail-soft per module,
+   * with a one-line warning) instead of resolving its classpath and failing. Adding a
+   * `jvm("desktop")` target — the canonical cmp-shared layout — surfaces `desktopRuntimeClasspath`
+   * and flips this back to `true`.
+   *
+   * `internal` + pure so it can be unit-tested without standing up AGP/KGP.
+   */
+  internal fun isDesktopRenderableConfig(configName: String): Boolean =
+    configName != "androidRuntimeClasspath"
+
   fun registerDesktopTasks(project: Project, extension: PreviewExtension) {
     val previewOutputDir = project.layout.buildDirectory.dir("compose-previews")
 
@@ -164,7 +186,15 @@ internal object ComposePreviewTasks {
         // aborts on such a module. JVM/desktop configs stay strict.
         lenientWhenAndroidOnlyFallback = true,
       ) {
-        onlyIf { extension.enabled.get() }
+        // Skip discovery for a non-renderable pure-KMP-Android module (only
+        // androidRuntimeClasspath,
+        // no jvm("desktop") target) so it reports nothing instead of being pulled into the pipeline
+        // — keeps it consistent with the render task, which skips the same module (issue #1852).
+        // Computed at task-realization time, when the kotlin{} block has configured and
+        // desktopRuntimeClasspath (if any) exists; captured as a Boolean so onlyIf stays
+        // config-cache-safe.
+        val renderable = isDesktopRenderableConfig(resolveDependencyConfigName())
+        onlyIf { extension.enabled.get() && renderable }
         // `compileAndroidMain` is the lifecycle task for the KMP-Android target's `main`
         // compilation (which depends on the underlying `compileAndroidMainKotlin`-shaped Kotlin
         // compile under the hood). Use lazy matching so compile tasks registered after this plugin
@@ -192,7 +222,22 @@ internal object ComposePreviewTasks {
       )
     val renderTask =
       project.tasks.register("composePreviewRender", RenderPreviewsTask::class.java) {
-        onlyIf { extension.enabled.get() }
+        // A pure KMP-Android module with no jvm("desktop") target can't be rendered by the JVM
+        // desktop renderer; resolving its androidRuntimeClasspath would trip a variant ambiguity
+        // and hard-fail the whole pipeline (issue #1852). Skip it (fail-soft per module) and warn
+        // once — realization time is after the kotlin{} block configures, so the config name is
+        // settled here; capture as a Boolean to keep onlyIf config-cache-safe.
+        val renderable = isDesktopRenderableConfig(resolveDependencyConfigName())
+        if (!renderable) {
+          logger.warn(
+            "compose-preview: skipping module '${project.path}' — it applies " +
+              "com.android.kotlin.multiplatform.library but has no jvm(\"desktop\") target, so the " +
+              "Compose Multiplatform Desktop renderer can't render its *-android Compose artifacts. " +
+              "Add a jvm(\"desktop\") target to render its androidMain previews (see " +
+              "compose-preview/references/cmp-shared.md)."
+          )
+        }
+        onlyIf { extension.enabled.get() && renderable }
         previewsJson.set(previewOutputDir.map { it.file("previews.json") })
         outputDir.set(previewOutputDir.map { it.dir("renders") })
         // `@ScrollingPreview(modes = [LONG, GIF])` outputs land here (sibling of `renders/`).
@@ -211,8 +256,13 @@ internal object ComposePreviewTasks {
         // `Configuration` into the task's config-cache `__classpath__` field (the serialization
         // failure issue #1796 hit on the desktop validate guards). The empty view yields the same
         // default resolution — module + file dependencies alike — just lazily and serializably.
-        project.configurations.findByName(resolveDependencyConfigName())?.let {
-          renderClasspath.from(it.incoming.artifactView {}.files)
+        // Only wired when renderable: a non-renderable module's androidRuntimeClasspath would
+        // resolve to a variant ambiguity during input snapshotting even though onlyIf skips the
+        // action, so leave it off the classpath entirely (issue #1852).
+        if (renderable) {
+          project.configurations.findByName(resolveDependencyConfigName())?.let {
+            renderClasspath.from(it.incoming.artifactView {}.files)
+          }
         }
         renderClasspath.from(rendererConfig.incoming.artifactView {}.files)
         group = "compose preview"
@@ -411,8 +461,15 @@ internal object ComposePreviewTasks {
         candidates.firstOrNull { it != null && it.asFile.isDirectory }
       }
 
+    // A non-renderable pure-KMP-Android module has nothing the desktop renderer can pack; skip its
+    // bundle for consistency with the render/daemon tasks (issue #1852).
+    // `isDesktopRenderableConfig`
+    // only trips on the literal `androidRuntimeClasspath` fallback, so this is a no-op on the
+    // Android
+    // bundle path (which routes through `${variant}RuntimeClasspath`) and on real desktop modules.
+    val bundleRenderable = isDesktopRenderableConfig(depConfigName)
     project.tasks.register("composePreviewBundle", BundlePreviewTask::class.java) {
-      onlyIf { extension.enabled.get() }
+      onlyIf { extension.enabled.get() && bundleRenderable }
       previewsJson.set(previewOutputDir.map { it.file("previews.json") })
       moduleClassDirs.from(sourceClassDirs)
       moduleResourcesDir.set(moduleResourcesDirProvider)
@@ -559,6 +616,12 @@ internal object ComposePreviewTasks {
       "composePreviewDaemonStart",
       ee.schimke.composeai.plugin.daemon.DaemonBootstrapTask::class.java,
     ) {
+      // A non-renderable pure-KMP-Android module (only androidRuntimeClasspath, no jvm("desktop"))
+      // can't be driven by the desktop daemon either, and resolving its runtime classpath would
+      // trip the same variant ambiguity — skip the descriptor emission and leave its config off
+      // the daemon `-cp` (issue #1852).
+      val renderable = isDesktopRenderableConfig(dependencyConfigName())
+      onlyIf { renderable }
       modulePath.set(project.path)
       // Desktop daemons have no AGP variant. The string is surfaced in `daemon-launch.json`'s
       // `variant` field for debug/log purposes only — VS Code's `daemonProcess.ts` doesn't key
@@ -578,7 +641,8 @@ internal object ComposePreviewTasks {
         project = project,
         extension = extension,
         task = this,
-        userRuntimeConfig = project.configurations.findByName(dependencyConfigName()),
+        userRuntimeConfig =
+          if (renderable) project.configurations.findByName(dependencyConfigName()) else null,
       )
       // `:daemon:desktop`'s `DaemonMain` and `:daemon:android`'s `DaemonMain` share the FQN
       // intentionally (see the kdoc on `daemon/desktop/.../DaemonMain.kt`). The desktop classes
@@ -601,8 +665,12 @@ internal object ComposePreviewTasks {
       classpath.from(sourceResourceDirs)
       // User's runtime classpath (Compose Multiplatform deps + transitive Kotlin libraries).
       // Lazy artifact view (not the raw `Configuration`) for config-cache serializability — #1796.
-      project.configurations.findByName(dependencyConfigName())?.let {
-        classpath.from(it.incoming.artifactView {}.files)
+      // Skipped for a non-renderable module so its ambiguous androidRuntimeClasspath is never
+      // resolved (issue #1852).
+      if (renderable) {
+        project.configurations.findByName(dependencyConfigName())?.let {
+          classpath.from(it.incoming.artifactView {}.files)
+        }
       }
 
       // Desktop daemons don't run inside Robolectric, so the AGP-side `--add-opens` flags don't
@@ -771,6 +839,12 @@ internal object ComposePreviewTasks {
     toolClasspath: org.gradle.api.artifacts.Configuration,
   ): TaskProvider<ValidateComposePreviewClasspathTask> =
     project.tasks.register(taskName, ValidateComposePreviewClasspathTask::class.java) {
+      // The guard runs as a dependsOn of the render/daemon task, so it would resolve
+      // androidRuntimeClasspath (and fail on its variant ambiguity) BEFORE the render task's own
+      // onlyIf can skip a non-renderable module. Gate it the same way: skip the guard and don't
+      // wire the consumer config when the module isn't desktop-renderable (issue #1852).
+      val renderable = isDesktopRenderableConfig(dependencyConfigName())
+      onlyIf { renderable }
       platform.set("desktop")
       // Feed the @Classpath FileCollection a lazily-resolved, content-keyed FileCollection
       // (`incoming.artifactView { }.files`) instead of the raw `Configuration`.
@@ -784,8 +858,10 @@ internal object ComposePreviewTasks {
       // while
       // resolving lazily through a serializable view — mirrors `composePreviewDiscover` above.
       classpath.from(toolClasspath.incoming.artifactView {}.files)
-      project.configurations.findByName(dependencyConfigName())?.let {
-        classpath.from(it.incoming.artifactView {}.files)
+      if (renderable) {
+        project.configurations.findByName(dependencyConfigName())?.let {
+          classpath.from(it.incoming.artifactView {}.files)
+        }
       }
     }
 

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -461,14 +461,19 @@ internal object ComposePreviewTasks {
         candidates.firstOrNull { it != null && it.asFile.isDirectory }
       }
 
-    // A non-renderable pure-KMP-Android module has nothing the desktop renderer can pack; skip its
-    // bundle for consistency with the render/daemon tasks (issue #1852).
-    // `isDesktopRenderableConfig`
-    // only trips on the literal `androidRuntimeClasspath` fallback, so this is a no-op on the
-    // Android
-    // bundle path (which routes through `${variant}RuntimeClasspath`) and on real desktop modules.
-    val bundleRenderable = isDesktopRenderableConfig(depConfigName)
     project.tasks.register("composePreviewBundle", BundlePreviewTask::class.java) {
+      // A non-renderable pure-KMP-Android module has nothing the desktop renderer can pack; skip
+      // its
+      // bundle for consistency with the render/daemon tasks (issue #1852). Compute renderability
+      // LAZILY here at task realization — NOT from the eager `depConfigName` snapshot above — so a
+      // cmp-shared module whose `jvm("desktop")` target configures after `registerDesktopTasks`
+      // runs
+      // (when only the androidRuntimeClasspath fallback is visible) isn't permanently skipped
+      // (Codex
+      // review on #1853). Mirrors the render task. `isDesktopRenderableConfig` only trips on the
+      // literal `androidRuntimeClasspath` fallback, so this is a no-op on the Android bundle path
+      // (which routes through `${variant}RuntimeClasspath`) and on real desktop modules.
+      val bundleRenderable = isDesktopRenderableConfig(resolveDependencyConfigName())
       onlyIf { extension.enabled.get() && bundleRenderable }
       previewsJson.set(previewOutputDir.map { it.file("previews.json") })
       moduleClassDirs.from(sourceClassDirs)

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/KmpAndroidDesktopRoutingTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/KmpAndroidDesktopRoutingTest.kt
@@ -193,4 +193,35 @@ class KmpAndroidDesktopRoutingTest {
       project.tasks.getByName("validateComposePreviewDesktopRenderClasspath") as TaskInternal
     assertThat(guard.onlyIf.isSatisfiedBy(guard)).isTrue()
   }
+
+  @Test
+  fun `renderability is computed lazily so a desktop target added after registration is not skipped`() {
+    // Codex review on #1853: registerDesktopTasks runs at withPlugin time, BEFORE the consumer's
+    // `kotlin { jvm("desktop") }` block creates desktopRuntimeClasspath. Renderability must be
+    // resolved at task realization, not snapshotted eagerly — otherwise a cmp-shared module whose
+    // desktop config appears later is permanently treated as non-renderable and its render/bundle
+    // are wrongly skipped.
+    val project = ProjectBuilder.builder().withProjectDir(tmp.root).build()
+    val extension = project.extensions.create("composePreview", PreviewExtension::class.java)
+    // Pre-`jvm("desktop")` state: only the androidRuntimeClasspath fallback is visible.
+    project.configurations.create("androidRuntimeClasspath") {
+      isCanBeResolved = true
+      isCanBeConsumed = false
+    }
+
+    ComposePreviewTasks.registerDesktopTasks(project, extension)
+
+    // `jvm("desktop")` configures afterwards, creating the desktop runtime classpath.
+    project.configurations.create("desktopRuntimeClasspath") {
+      isCanBeResolved = true
+      isCanBeConsumed = false
+    }
+
+    // Realized now (after the desktop config exists): render AND bundle must observe it and stay
+    // renderable. A regression to an eager snapshot would skip them.
+    for (taskName in listOf("composePreviewRender", "composePreviewBundle")) {
+      val task = project.tasks.getByName(taskName) as TaskInternal
+      assertThat(task.onlyIf.isSatisfiedBy(task)).isTrue()
+    }
+  }
 }

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/KmpAndroidDesktopRoutingTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/KmpAndroidDesktopRoutingTest.kt
@@ -1,6 +1,7 @@
 package ee.schimke.composeai.plugin
 
 import com.google.common.truth.Truth.assertThat
+import org.gradle.api.internal.TaskInternal
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.Rule
 import org.junit.Test
@@ -129,5 +130,67 @@ class KmpAndroidDesktopRoutingTest {
     discoverTask.dependencyJars.files // resolves; throws on a misnamed config
     assertThat(project.configurations.findByName("desktopRuntimeClasspath")).isNotNull()
     assertThat(project.configurations.findByName("androidRuntimeClasspath")).isNotNull()
+  }
+
+  @Test
+  fun `isDesktopRenderableConfig is false only for the androidRuntimeClasspath fallback`() {
+    // Issue #1852: a pure KMP-Android module whose only runtime config is androidRuntimeClasspath
+    // can't be rendered by the JVM desktop renderer. Every JVM/desktop-flavoured config stays
+    // renderable.
+    assertThat(ComposePreviewTasks.isDesktopRenderableConfig("androidRuntimeClasspath")).isFalse()
+    assertThat(ComposePreviewTasks.isDesktopRenderableConfig("jvmRuntimeClasspath")).isTrue()
+    assertThat(ComposePreviewTasks.isDesktopRenderableConfig("desktopRuntimeClasspath")).isTrue()
+    assertThat(ComposePreviewTasks.isDesktopRenderableConfig("runtimeClasspath")).isTrue()
+  }
+
+  @Test
+  fun `pure KMP-Android module with only androidRuntimeClasspath skips render and guard`() {
+    // Issue #1852: when the desktop fallback lands on androidRuntimeClasspath (no jvm("desktop")
+    // target), the render task and its classpath guard must skip via onlyIf instead of resolving
+    // the ambiguous config and hard-failing the whole pipeline. discover/daemon/bundle skip too.
+    val project = ProjectBuilder.builder().withProjectDir(tmp.root).build()
+    val extension = project.extensions.create("composePreview", PreviewExtension::class.java)
+    project.configurations.create("androidRuntimeClasspath") {
+      isCanBeResolved = true
+      isCanBeConsumed = false
+    }
+
+    ComposePreviewTasks.registerDesktopTasks(project, extension)
+
+    for (taskName in
+      listOf(
+        "composePreviewRender",
+        "validateComposePreviewDesktopRenderClasspath",
+        "composePreviewDiscover",
+        "composePreviewDaemonStart",
+        "composePreviewBundle",
+      )) {
+      val task = project.tasks.getByName(taskName) as TaskInternal
+      assertThat(task.onlyIf.isSatisfiedBy(task)).isFalse()
+    }
+  }
+
+  @Test
+  fun `KMP-Android module with a desktop target stays renderable`() {
+    // The canonical cmp-shared layout (androidRuntimeClasspath + desktopRuntimeClasspath) must NOT
+    // be skipped — desktopRuntimeClasspath wins the fallback and the render task stays enabled.
+    val project = ProjectBuilder.builder().withProjectDir(tmp.root).build()
+    val extension = project.extensions.create("composePreview", PreviewExtension::class.java)
+    project.configurations.create("desktopRuntimeClasspath") {
+      isCanBeResolved = true
+      isCanBeConsumed = false
+    }
+    project.configurations.create("androidRuntimeClasspath") {
+      isCanBeResolved = true
+      isCanBeConsumed = false
+    }
+
+    ComposePreviewTasks.registerDesktopTasks(project, extension)
+
+    val render = project.tasks.getByName("composePreviewRender") as TaskInternal
+    assertThat(render.onlyIf.isSatisfiedBy(render)).isTrue()
+    val guard =
+      project.tasks.getByName("validateComposePreviewDesktopRenderClasspath") as TaskInternal
+    assertThat(guard.onlyIf.isSatisfiedBy(guard)).isTrue()
   }
 }


### PR DESCRIPTION
Fixes #1852.

## Summary

Auto-inject (#1850) applies `ee.schimke.composeai.preview` to **every** `com.android.kotlin.multiplatform.library` module, including no-preview library modules. A pure KMP-Android module with no `jvm("desktop")` target exposes only `androidRuntimeClasspath`, and resolving it for the desktop render trips a **variant ambiguity** on its single AGP `android` variant — which hard-failed the whole `composePreviewRender` pipeline. In a multi-module repo (meshcore-mobile) one no-preview module like `:meshcore-mobile` sank the green modules' render too, surfacing as an empty `_previews.json` / red CI.

#1851 only made *discovery's* artifact views lenient; the **render task, its classpath guard, and the daemon** still resolved the runtime config strictly — so 0.15.2 still reproduced the failure.

This implements the issue's suggestion #2 (fail-soft per module): a module whose only runtime classpath is `androidRuntimeClasspath` genuinely can't be rendered by the JVM desktop renderer (`*-android` Compose AARs reference `android.os.Parcelable`), so it's **skipped instead of failing**.

- New pure helper `ComposePreviewTasks.isDesktopRenderableConfig(configName)` — `false` only for the literal `androidRuntimeClasspath` fallback.
- Computed at task-realization time (after the `kotlin {}` block configures, so the config name is settled) and captured as a `Boolean` for config-cache safety.
- Gates `composePreviewDiscover`, `composePreviewRender`, both desktop classpath guards (`validateComposePreviewDesktop{Render,Daemon}Classpath`), `composePreviewDaemonStart`, and `composePreviewBundle` via `onlyIf`, and leaves the ambiguous config off their classpaths entirely so it's never resolved (even during input snapshotting).
- The render task logs a one-line warning naming the module and pointing the user at adding a `jvm("desktop")` target.
- Modules with a desktop target (the canonical cmp-shared layout) resolve `desktopRuntimeClasspath` and stay fully renderable — no regression.

Net: `:meshcore-mobile` and other no-desktop-target KMP-Android modules no-op out of the desktop pipeline; `app`, `wear`, `meshcore-components` render green.

Not addressed here (separate concern, issue suggestion #4): surfacing the full Gradle variant-ambiguity message from the CLI. Happy to do that as a fast-follow on the CLI side if wanted.

## Test plan

- `gradle-plugin :test --tests KmpAndroidDesktopRoutingTest` ✅ green (6 tests). New coverage:
  - `isDesktopRenderableConfig` is false only for `androidRuntimeClasspath`.
  - A project with only `androidRuntimeClasspath` → `composePreviewRender`, both guards, discover, daemon, and bundle all have `onlyIf` unsatisfied (skipped).
  - A project with `desktopRuntimeClasspath` + `androidRuntimeClasspath` (cmp-shared shape) → render + guard stay enabled.
- `ktfmtFormat` applied (gradle-plugin).

Non-visual change (Gradle task gating), so no rendered evidence applies.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WmL6Xj4mr6RaK5mdyv436u)_