### PR TITLE
feat(daemon): classify renderFailed into a fine-grained error taxonomy

### DIFF
--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RenderErrorClassifier.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RenderErrorClassifier.kt
@@ -10,9 +10,11 @@ import ee.schimke.composeai.daemon.protocol.RenderErrorKind
  *
  * Pure (matches on the throwable's message + class names down the cause chain) so it is
  * unit-testable and works whether the cause is a real desktop throwable or a re-thrown sandbox
- * error whose message carries the signature text. New fine-grained kinds (e.g. a dedicated
- * `classpathSkew`) wait on the wire-level tolerant-enum work; until then the skew is conveyed
- * through the suggestion, keeping the change additive and decode-safe for old clients.
+ * error whose message carries the signature text. Recognised skew signatures map to the
+ * fine-grained [RenderErrorKind] discriminants (`classpathSkew` / `sdkMismatch` /
+ * `missingComposable` / `unsetParameter`); the enum decodes tolerantly on the wire, so emitting a
+ * fine-grained kind stays additive and decode-safe for old clients (which see it as
+ * [RenderErrorKind.UNKNOWN] and fall back to [Classification.suggestion] / the message).
  */
 object RenderErrorClassifier {
 
@@ -41,7 +43,7 @@ object RenderErrorClassifier {
         (has("nosuchmethoderror", "noclassdeffounderror") && has("androidx.compose")) ||
         (has("androidx.compose") && has("jvmstubs")) ->
         Classification(
-          RenderErrorKind.RUNTIME,
+          RenderErrorKind.CLASSPATH_SKEW,
           "Desktop classpath contains AndroidX Compose UI artifacts; use the org.jetbrains.compose " +
             "UI artifacts for Compose Multiplatform desktop. See docs/RENDERER_COMPATIBILITY.md.",
         )
@@ -49,7 +51,7 @@ object RenderErrorClassifier {
       // malformed manifest) is a different failure and shouldn't get the compileSdk hint.
       has("requires newer sdk version") || (has("packageparser") && has("newer sdk")) ->
         Classification(
-          RenderErrorKind.RUNTIME,
+          RenderErrorKind.SDK_MISMATCH,
           "Robolectric's SDK is below the consumer's compileSdk; set composePreview.sdkVersion " +
             "(SDK 36 also needs a JDK 21 toolchain). See docs/SDK_COMPATIBILITY.md.",
         )
@@ -63,14 +65,14 @@ object RenderErrorClassifier {
         (has("nosuchmethodexception") && has("composer")) ||
         has("is not a @composable") ->
         Classification(
-          RenderErrorKind.RUNTIME,
+          RenderErrorKind.MISSING_COMPOSABLE,
           "The preview must be a @Composable function with no required parameters (or a " +
             "@PreviewParameter provider). Non-composable previews (tile / notification / Glance) " +
             "render through their own kind.",
         )
       has("@previewparameter") || (has("parameter") && has("no value", "missing", "required")) ->
         Classification(
-          RenderErrorKind.RUNTIME,
+          RenderErrorKind.UNSET_PARAMETER,
           "The preview function has required parameters; give them defaults or a @PreviewParameter " +
             "provider.",
         )

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -5,8 +5,14 @@ import ee.schimke.composeai.data.render.pipeline.PreviewExtensionDescriptor
 import ee.schimke.composeai.data.render.pipeline.SamplingPolicy
 import kotlinx.serialization.EncodeDefault
 import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 
@@ -1370,13 +1376,60 @@ data class RenderError(
   val suggestion: String? = null,
 )
 
-@Serializable
-enum class RenderErrorKind {
-  @SerialName("compile") COMPILE,
-  @SerialName("runtime") RUNTIME,
-  @SerialName("capture") CAPTURE,
-  @SerialName("timeout") TIMEOUT,
-  @SerialName("internal") INTERNAL,
+/**
+ * Taxonomy for a failed render (issue #1789). The coarse stages (`compile`/`runtime`/`capture`/
+ * `timeout`/`internal`) are joined by fine-grained discriminants for the load-bearing skew
+ * signatures catalogued in `docs/RENDERER_COMPATIBILITY.md` / `docs/SDK_COMPATIBILITY.md` so an
+ * agent can branch on the *class* of failure rather than re-parse the message:
+ *
+ * - [CLASSPATH_SKEW] — AndroidX Compose UI artifacts on a Compose-Multiplatform desktop classpath
+ *   (the "Implemented only in JetBrains fork" / `jvmstubs` family).
+ * - [MISSING_COMPOSABLE] — the preview target isn't an invokable zero-arg `@Composable`.
+ * - [UNSET_PARAMETER] — the preview function has required parameters and no `@PreviewParameter`.
+ * - [SDK_MISMATCH] — Robolectric's pinned SDK is below the consumer's `compileSdk`.
+ *
+ * Decoded **tolerantly** per [docs/VERSIONING.md § 4.1](../../../../../../../docs/VERSIONING.md):
+ * an unknown future kind from a newer daemon maps to [UNKNOWN] instead of throwing, so adding a
+ * value here stays additive for old clients. Every `when (kind)` must carry an explicit `else`.
+ */
+@Serializable(with = RenderErrorKindSerializer::class)
+enum class RenderErrorKind(val wire: String) {
+  COMPILE("compile"),
+  RUNTIME("runtime"),
+  CAPTURE("capture"),
+  TIMEOUT("timeout"),
+  CLASSPATH_SKEW("classpathSkew"),
+  MISSING_COMPOSABLE("missingComposable"),
+  UNSET_PARAMETER("unsetParameter"),
+  SDK_MISMATCH("sdkMismatch"),
+  INTERNAL("internal"),
+
+  /**
+   * Tolerant-decode sentinel for a kind this build doesn't recognise (a newer daemon emitting a
+   * value added after this client shipped). Never produced by the classifier — only reached when
+   * decoding an unknown wire string. Encodes back as `"unknown"`.
+   */
+  UNKNOWN("unknown"),
+}
+
+/**
+ * Tolerant [RenderErrorKind] serializer: encodes via the [RenderErrorKind.wire] spelling and decodes
+ * an unrecognised string to [RenderErrorKind.UNKNOWN] rather than throwing (VERSIONING.md § 4.1
+ * enum discipline). This is what keeps adding a new failure discriminant an additive, non-breaking
+ * change for older clients.
+ */
+object RenderErrorKindSerializer : KSerializer<RenderErrorKind> {
+  override val descriptor: SerialDescriptor =
+    PrimitiveSerialDescriptor("ee.schimke.composeai.daemon.protocol.RenderErrorKind", PrimitiveKind.STRING)
+
+  override fun serialize(encoder: Encoder, value: RenderErrorKind) {
+    encoder.encodeString(value.wire)
+  }
+
+  override fun deserialize(decoder: Decoder): RenderErrorKind {
+    val raw = decoder.decodeString()
+    return RenderErrorKind.entries.firstOrNull { it.wire == raw } ?: RenderErrorKind.UNKNOWN
+  }
 }
 
 @Serializable

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -1413,14 +1413,17 @@ enum class RenderErrorKind(val wire: String) {
 }
 
 /**
- * Tolerant [RenderErrorKind] serializer: encodes via the [RenderErrorKind.wire] spelling and decodes
- * an unrecognised string to [RenderErrorKind.UNKNOWN] rather than throwing (VERSIONING.md § 4.1
- * enum discipline). This is what keeps adding a new failure discriminant an additive, non-breaking
- * change for older clients.
+ * Tolerant [RenderErrorKind] serializer: encodes via the [RenderErrorKind.wire] spelling and
+ * decodes an unrecognised string to [RenderErrorKind.UNKNOWN] rather than throwing (VERSIONING.md §
+ * 4.1 enum discipline). This is what keeps adding a new failure discriminant an additive,
+ * non-breaking change for older clients.
  */
 object RenderErrorKindSerializer : KSerializer<RenderErrorKind> {
   override val descriptor: SerialDescriptor =
-    PrimitiveSerialDescriptor("ee.schimke.composeai.daemon.protocol.RenderErrorKind", PrimitiveKind.STRING)
+    PrimitiveSerialDescriptor(
+      "ee.schimke.composeai.daemon.protocol.RenderErrorKind",
+      PrimitiveKind.STRING,
+    )
 
   override fun serialize(encoder: Encoder, value: RenderErrorKind) {
     encoder.encodeString(value.wire)

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/RenderErrorClassifierTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/RenderErrorClassifierTest.kt
@@ -10,20 +10,20 @@ import org.junit.Test
 class RenderErrorClassifierTest {
 
   @Test
-  fun androidxComposeOnDesktopIsRuntimeWithAClasspathSuggestion() {
+  fun androidxComposeOnDesktopIsClasspathSkewWithAClasspathSuggestion() {
     val c =
       RenderErrorClassifier.classify(
         "java.lang.NoSuchMethodError: Implemented only in JetBrains fork"
       )
-    assertEquals(RenderErrorKind.RUNTIME, c.kind)
+    assertEquals(RenderErrorKind.CLASSPATH_SKEW, c.kind)
     assertTrue(c.suggestion, c.suggestion!!.contains("org.jetbrains.compose"))
   }
 
   @Test
-  fun newerSdkIsRuntimeWithAnSdkSuggestion() {
+  fun newerSdkIsSdkMismatchWithAnSdkSuggestion() {
     val c =
       RenderErrorClassifier.classify("PackageParser: Requires newer sdk version #36 (current #35)")
-    assertEquals(RenderErrorKind.RUNTIME, c.kind)
+    assertEquals(RenderErrorKind.SDK_MISMATCH, c.kind)
     assertTrue(c.suggestion, c.suggestion!!.contains("compileSdk"))
   }
 
@@ -48,13 +48,24 @@ class RenderErrorClassifierTest {
   }
 
   @Test
-  fun missingComposableIsRuntimeWithASuggestion() {
+  fun missingComposableIsMissingComposableWithASuggestion() {
     val c =
       RenderErrorClassifier.classify(
         "java.lang.NoSuchMethodException: getDeclaredComposableMethod failed"
       )
-    assertEquals(RenderErrorKind.RUNTIME, c.kind)
+    assertEquals(RenderErrorKind.MISSING_COMPOSABLE, c.kind)
     assertTrue(c.suggestion, c.suggestion!!.contains("@Composable"))
+  }
+
+  @Test
+  fun requiredParameterIsUnsetParameterWithASuggestion() {
+    val c =
+      RenderErrorClassifier.classify(
+        "java.lang.IllegalArgumentException: preview parameter 'user' has no value (missing " +
+          "@PreviewParameter provider)"
+      )
+    assertEquals(RenderErrorKind.UNSET_PARAMETER, c.kind)
+    assertTrue(c.suggestion, c.suggestion!!.contains("@PreviewParameter"))
   }
 
   @Test
@@ -95,7 +106,7 @@ class RenderErrorClassifierTest {
         "wrapper",
         IllegalStateException("PackageParser: Requires newer sdk version"),
       )
-    assertEquals(RenderErrorKind.RUNTIME, RenderErrorClassifier.classify(cause).kind)
+    assertEquals(RenderErrorKind.SDK_MISMATCH, RenderErrorClassifier.classify(cause).kind)
     assertNotNull(RenderErrorClassifier.classify(cause).suggestion)
   }
 }

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/protocol/MessagesTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/protocol/MessagesTest.kt
@@ -166,6 +166,41 @@ class MessagesTest {
     assertEquals("missing protocol fixtures: $missing", emptySet<String>(), missing)
   }
 
+  // -- RenderErrorKind tolerant decode (issue #1789 / VERSIONING.md § 4.1) ----
+
+  @Test
+  fun renderErrorKindDecodesFineGrainedDiscriminants() {
+    val params =
+      json.decodeFromString(
+        RenderFailedParams.serializer(),
+        """{"id":"com.example.HomeKt#HomePreview","error":""" +
+          """{"kind":"classpathSkew","message":"Implemented only in JetBrains fork",""" +
+          """"suggestion":"use the org.jetbrains.compose UI artifacts"}}""",
+      )
+    assertEquals(RenderErrorKind.CLASSPATH_SKEW, params.error.kind)
+    // Re-encodes back to the documented wire spelling.
+    val reEncoded = json.encodeToString(RenderFailedParams.serializer(), params)
+    assertEquals(
+      "classpathSkew",
+      json
+        .parseToJsonElement(reEncoded)
+        .let { it as kotlinx.serialization.json.JsonObject }["error"]
+        .let { it as kotlinx.serialization.json.JsonObject }["kind"]
+        .let { (it as kotlinx.serialization.json.JsonPrimitive).content },
+    )
+  }
+
+  @Test
+  fun renderErrorKindToleratesAnUnknownFutureValue() {
+    // A newer daemon emits a kind this client predates — it must decode to UNKNOWN, not throw.
+    val params =
+      json.decodeFromString(
+        RenderFailedParams.serializer(),
+        """{"id":"p","error":{"kind":"someFutureKind","message":"boom"}}""",
+      )
+    assertEquals(RenderErrorKind.UNKNOWN, params.error.kind)
+  }
+
   // -- helpers ----------------------------------------------------------------
 
   private inline fun <reified T : Any> roundTrip(fixtureName: String) {

--- a/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S5RenderFailedAndroidRealModeTest.kt
+++ b/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S5RenderFailedAndroidRealModeTest.kt
@@ -97,7 +97,17 @@ class S5RenderFailedAndroidRealModeTest {
       assertTrue(
         "renderFailed.params.error.kind must be one of the v1 RenderErrorKind values " +
           "(PROTOCOL.md § 6); was $errKind",
-        errKind in setOf("internal", "runtime", "compile", "capture", "timeout"),
+        errKind in setOf(
+          "internal",
+          "runtime",
+          "compile",
+          "capture",
+          "timeout",
+          "classpathSkew",
+          "missingComposable",
+          "unsetParameter",
+          "sdkMismatch",
+        ),
       )
       val errMsg = errorObj["message"]?.jsonPrimitive?.contentOrNull
       assertNotNull("renderFailed.params.error.message must be present", errMsg)

--- a/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S5RenderFailedAndroidRealModeTest.kt
+++ b/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S5RenderFailedAndroidRealModeTest.kt
@@ -97,17 +97,18 @@ class S5RenderFailedAndroidRealModeTest {
       assertTrue(
         "renderFailed.params.error.kind must be one of the v1 RenderErrorKind values " +
           "(PROTOCOL.md § 6); was $errKind",
-        errKind in setOf(
-          "internal",
-          "runtime",
-          "compile",
-          "capture",
-          "timeout",
-          "classpathSkew",
-          "missingComposable",
-          "unsetParameter",
-          "sdkMismatch",
-        ),
+        errKind in
+          setOf(
+            "internal",
+            "runtime",
+            "compile",
+            "capture",
+            "timeout",
+            "classpathSkew",
+            "missingComposable",
+            "unsetParameter",
+            "sdkMismatch",
+          ),
       )
       val errMsg = errorObj["message"]?.jsonPrimitive?.contentOrNull
       assertNotNull("renderFailed.params.error.message must be present", errMsg)

--- a/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S5RenderFailedRealModeTest.kt
+++ b/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S5RenderFailedRealModeTest.kt
@@ -93,7 +93,17 @@ class S5RenderFailedRealModeTest {
       assertTrue(
         "renderFailed.params.error.kind must be one of the v1 RenderErrorKind values " +
           "(PROTOCOL.md § 6); was $errKind",
-        errKind in setOf("internal", "runtime", "compile", "capture", "timeout"),
+        errKind in setOf(
+          "internal",
+          "runtime",
+          "compile",
+          "capture",
+          "timeout",
+          "classpathSkew",
+          "missingComposable",
+          "unsetParameter",
+          "sdkMismatch",
+        ),
       )
       val errMsg = errorObj["message"]?.jsonPrimitive?.contentOrNull
       assertNotNull("renderFailed.params.error.message must be present", errMsg)

--- a/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S5RenderFailedRealModeTest.kt
+++ b/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S5RenderFailedRealModeTest.kt
@@ -93,17 +93,18 @@ class S5RenderFailedRealModeTest {
       assertTrue(
         "renderFailed.params.error.kind must be one of the v1 RenderErrorKind values " +
           "(PROTOCOL.md § 6); was $errKind",
-        errKind in setOf(
-          "internal",
-          "runtime",
-          "compile",
-          "capture",
-          "timeout",
-          "classpathSkew",
-          "missingComposable",
-          "unsetParameter",
-          "sdkMismatch",
-        ),
+        errKind in
+          setOf(
+            "internal",
+            "runtime",
+            "compile",
+            "capture",
+            "timeout",
+            "classpathSkew",
+            "missingComposable",
+            "unsetParameter",
+            "sdkMismatch",
+          ),
       )
       val errMsg = errorObj["message"]?.jsonPrimitive?.contentOrNull
       assertNotNull("renderFailed.params.error.message must be present", errMsg)

--- a/docs/daemon/PROTOCOL.md
+++ b/docs/daemon/PROTOCOL.md
@@ -583,16 +583,19 @@ empty are interchangeable on the wire. See
 {
   id: string;
   error: {
-    kind: "compile" | "runtime" | "capture" | "timeout" | "internal";
+    kind: "compile" | "runtime" | "capture" | "timeout"
+        | "classpathSkew" | "missingComposable" | "unsetParameter" | "sdkMismatch"
+        | "internal";
     message: string;
     stackTrace?: string;             // present for kind="runtime" | "internal"
+    suggestion?: string;             // one-line remediation for a recognised signature (#1789)
   };
 }
 ```
 
 Render failures are not protocol errors — `renderNow` succeeded in queueing the work. A failure here means the render itself blew up.
 
-> **Implementation gap:** the daemon currently emits `kind: "internal"` for every render failure regardless of the underlying cause; the `compile` / `runtime` / `capture` / `timeout` discriminants are reserved on the wire but not yet populated. Clients should treat any `kind` value as opaque text until this lands.
+The daemon classifies the thrown cause into `kind` (see `RenderErrorClassifier`): the coarse stages (`compile` / `runtime` / `capture` / `timeout` / `internal`) plus fine-grained skew discriminants — `classpathSkew` (AndroidX Compose on a CMP-desktop classpath), `missingComposable` (target isn't an invokable zero-arg `@Composable`), `unsetParameter` (required parameter with no `@PreviewParameter`), and `sdkMismatch` (Robolectric SDK below the consumer's `compileSdk`). Recognised signatures also carry a one-line `suggestion`. `kind` is decoded **tolerantly** ([VERSIONING.md § 4.1](../VERSIONING.md#41-enum-discipline)): adding a discriminant is additive, and an old client maps an unknown value to its `UNKNOWN` sentinel and falls back to `suggestion` / `message`. Branch with an explicit default arm.
 
 ### `classpathDirty`
 

--- a/docs/daemon/protocol-fixtures/daemon-renderFailed.json
+++ b/docs/daemon/protocol-fixtures/daemon-renderFailed.json
@@ -1,8 +1,9 @@
 {
   "id": "com.example.HomeKt#HomePreview",
   "error": {
-    "kind": "runtime",
-    "message": "java.lang.IllegalStateException: not on main thread",
-    "stackTrace": "java.lang.IllegalStateException: not on main thread\n\tat ee.schimke.composeai.daemon.RenderEngine.render(RenderEngine.kt:42)"
+    "kind": "classpathSkew",
+    "message": "java.lang.NoSuchMethodError: Implemented only in JetBrains fork",
+    "stackTrace": "java.lang.NoSuchMethodError: Implemented only in JetBrains fork\n\tat ee.schimke.composeai.daemon.RenderEngine.render(RenderEngine.kt:42)",
+    "suggestion": "Desktop classpath contains AndroidX Compose UI artifacts; use the org.jetbrains.compose UI artifacts for Compose Multiplatform desktop. See docs/RENDERER_COMPATIBILITY.md."
   }
 }

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
@@ -567,7 +567,14 @@ class DaemonMcpServer(
       }
     return when (outcome) {
       is RenderOutcome.Failed ->
-        error("awaitNextRender failed for $uri: ${outcome.kind} ${outcome.message}")
+        error(
+          buildString {
+            append("awaitNextRender failed for $uri: ${outcome.kind} ${outcome.message}")
+            // #1789 — append the daemon's classified remediation so the agent gets the fix hint
+            // inline rather than having to re-diagnose the failure from the message alone.
+            outcome.suggestion?.let { append(" — suggestion: $it") }
+          }
+        )
       is RenderOutcome.Finished -> outcome
     }
   }
@@ -4337,6 +4344,8 @@ class DaemonMcpServer(
     val errorObj = params["error"] as? JsonObject
     val kind = errorObj?.get("kind")?.jsonPrimitive?.contentOrNull ?: "unknown"
     val message = errorObj?.get("message")?.jsonPrimitive?.contentOrNull ?: "no message"
+    // #1789 — carry the daemon's classified one-line remediation through to the agent-facing error.
+    val suggestion = errorObj?.get("suggestion")?.jsonPrimitive?.contentOrNull
     // Same pop-and-promote shape as `onRenderFinished` — failure of the head group does NOT
     // sympathetically fail queued non-head groups. Different overrides could plausibly succeed
     // even when O1 throws (e.g., a composable that fails only at small widths), so we keep the
@@ -4344,7 +4353,7 @@ class DaemonMcpServer(
     // next group's renderNow normally. If a follow-up group's render also fails, the same path
     // surfaces it.
     val key = PreviewIdKey(daemon.workspaceId, daemon.modulePath, previewId)
-    popHeadAndPromoteNext(daemon, key, RenderOutcome.Failed(kind, message))
+    popHeadAndPromoteNext(daemon, key, RenderOutcome.Failed(kind, message, suggestion))
   }
 
   /**
@@ -4569,7 +4578,16 @@ class DaemonMcpServer(
   private sealed interface RenderOutcome {
     data class Finished(val pngPath: String) : RenderOutcome
 
-    data class Failed(val kind: String, val message: String) : RenderOutcome
+    data class Failed(
+      val kind: String,
+      val message: String,
+      /**
+       * One-line remediation the daemon classified for a recognised failure signature (issue
+       * #1789), e.g. a classpath-skew or Robolectric SDK-mismatch fix hint. `null` when the daemon
+       * had no specific suggestion (or pre-dates the field — tolerant decode).
+       */
+      val suggestion: String? = null,
+    ) : RenderOutcome
   }
 
   private fun parseSchema(s: String): JsonElement = json.parseToJsonElement(s)

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
@@ -4582,9 +4582,9 @@ class DaemonMcpServer(
       val kind: String,
       val message: String,
       /**
-       * One-line remediation the daemon classified for a recognised failure signature (issue
-       * #1789), e.g. a classpath-skew or Robolectric SDK-mismatch fix hint. `null` when the daemon
-       * had no specific suggestion (or pre-dates the field — tolerant decode).
+       * One-line remediation the daemon classified for a recognised failure signature
+       * (issue #1789), e.g. a classpath-skew or Robolectric SDK-mismatch fix hint. `null` when the
+       * daemon had no specific suggestion (or pre-dates the field — tolerant decode).
        */
       val suggestion: String? = null,
     ) : RenderOutcome

--- a/vscode-extension/src/daemon/daemonProtocol.ts
+++ b/vscode-extension/src/daemon/daemonProtocol.ts
@@ -813,10 +813,34 @@ export interface RenderFinishedParams {
     unchanged?: boolean;
 }
 
+/**
+ * Classified render-failure kind (issue #1789). The coarse stages are joined by fine-grained
+ * skew discriminants (`classpathSkew` / `missingComposable` / `unsetParameter` / `sdkMismatch`).
+ * Decoded tolerantly per VERSIONING.md § 4.1 — the trailing `(string & {})` keeps an unrecognised
+ * future kind assignable instead of a type error, and consumers must branch with a default arm.
+ */
+export type RenderErrorKind =
+    | "compile"
+    | "runtime"
+    | "capture"
+    | "timeout"
+    | "classpathSkew"
+    | "missingComposable"
+    | "unsetParameter"
+    | "sdkMismatch"
+    | "internal"
+    | (string & {});
+
 export interface RenderError {
-    kind: "compile" | "runtime" | "capture" | "timeout" | "internal";
+    kind: RenderErrorKind;
     message: string;
     stackTrace?: string;
+    /**
+     * One-line remediation for a recognised failure signature (#1789), e.g. a classpath-skew or
+     * Robolectric SDK-mismatch fix hint. Absent when the daemon had no specific suggestion or
+     * pre-dates the field.
+     */
+    suggestion?: string;
 }
 
 export interface RenderFailedParams {

--- a/vscode-extension/src/test/daemonProtocol.test.ts
+++ b/vscode-extension/src/test/daemonProtocol.test.ts
@@ -26,6 +26,7 @@ import {
     InitializeParams,
     InitializeResult,
     PROTOCOL_VERSION,
+    RenderFailedParams,
     RenderFinishedParams,
     RenderNowParams,
     RenderNowResult,
@@ -129,6 +130,19 @@ describe("daemon protocol — golden fixtures", () => {
         assert.strictEqual(params.kind, "source");
         assert.strictEqual(params.changeType, "modified");
         assert.match(params.path, /\.kt$/);
+    });
+
+    it("parses daemon-renderFailed.json with a fine-grained kind + suggestion", () => {
+        // #1789 — renderFailed carries a classified RenderErrorKind and a one-line remediation,
+        // not just a bare runtime message.
+        const params = readFixture<RenderFailedParams>(
+            "daemon-renderFailed.json",
+        );
+        assert.strictEqual(params.error.kind, "classpathSkew");
+        assert.ok(
+            params.error.suggestion?.includes("org.jetbrains.compose"),
+            "fine-grained failure should carry a remediation suggestion",
+        );
     });
 
     it("parses client-setVisible.json into a string-array shape", () => {


### PR DESCRIPTION
## Summary

Finishes the #1789 work the earlier classifier pass deliberately deferred ("fine-grained kinds wait on the wire-level tolerant-enum work").

- **Full `RenderErrorKind` taxonomy.** Adds the fine-grained discriminants `classpathSkew | missingComposable | unsetParameter | sdkMismatch` on top of the existing `compile | runtime | capture | timeout | internal` stages, and points each recognised skew signature in `RenderErrorClassifier` at the right kind (keeping the one-line remediation suggestions).
- **Tolerant decode (VERSIONING.md § 4.1).** `RenderErrorKind` now decodes via a custom serializer that maps an unknown future value (from a newer daemon) to a new `UNKNOWN` sentinel instead of throwing — so adding a discriminant stays additive for old clients. This is the "wire-level tolerant-enum work" the classifier was blocked on.
- **MCP propagates the suggestion.** `onRenderFailed` now reads `error.suggestion` and surfaces it on the agent-facing render failure instead of dropping it.
- **Docs + cross-language parity.** `PROTOCOL.md`, the shared `daemon-renderFailed.json` fixture, and the TypeScript protocol types document the new kinds and the `suggestion` field.

Closes #1789.

## Test plan

- `:daemon:core:test --tests RenderErrorClassifierTest --tests MessagesTest` — green. Classifier tests assert each known failure class maps to its fine-grained kind + remediation; `MessagesTest` adds a fine-grained-kind decode test and an unknown-future-value → `UNKNOWN` tolerance test.
- `:mcp:compileKotlin` — green (suggestion threaded through `RenderOutcome.Failed`).
- vscode-extension `npm run compile` + mocha suite — green (1541 passing), including a new assertion that `daemon-renderFailed.json` parses to a fine-grained kind + suggestion.
- Harness real-mode `renderFailed` tests had their allowed-kind set widened to the full taxonomy.

Non-visual change (daemon error-taxonomy plumbing, tests, docs), so no rendered evidence applies.

---
_Generated by [Claude Code](https://claude.ai/code/session_016zfBJaSi1phkd6E7mKqEPJ)_