### PR TITLE
feat(daemon): history/diff mode=SEMANTICS — pixel-free semantics regression diff (#1785)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -125,6 +125,7 @@ tasks.register("functionalTestWithAndroid") {
 //       api :data-displayfilter-core
 //       api :daemon:core
 //         api :renderer-xr-client (daemon-core fronts the native XR render server — RENDERER_SERVICE)
+//         api :data-layoutinspector-core (semantics models + differ for `history/diff mode=semantics`, #1785)
 //     implementation :lottie-preview-runtime (Compottie-backed kind=LOTTIE render path)
 //   plus :common-io (the Okio file-IO foundation those modules read/write through).
 val bundleRenderFunctionalTestPublishTargets =
@@ -138,6 +139,7 @@ val bundleRenderFunctionalTestPublishTargets =
     ":data-displayfilter-core",
     ":daemon:core",
     ":renderer-xr-client",
+    ":data-layoutinspector-core",
     ":lottie-preview-runtime",
     ":common-io",
   )

--- a/daemon/core/build.gradle.kts
+++ b/daemon/core/build.gradle.kts
@@ -22,6 +22,12 @@ plugins {
 dependencies {
   api(project(":data-render-core"))
 
+  // Semantics-tree models + structural differ (issue #1785). `api`, not `implementation`: the
+  // published `HistoryDiffResult.semanticsDelta` field is a `SemanticsDelta`, so the type is part
+  // of this module's compile ABI. Pure-JVM core module (no Compose/Android) — safe on the
+  // renderer-agnostic daemon classpath.
+  api(project(":data-layoutinspector-core"))
+
   // Okio-based file IO (`SystemFileSystem`) for data-product reads, history sidecars, bundle IR
   // replay, and forensics dumps. `implementation` — Okio stays an internal detail; daemon/core's
   // public surface keeps its java.io.File signatures.

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -1206,12 +1206,14 @@ class JsonRpcServer(
     // history write failure never blocks the renderFinished wire-format. The render's notification
     // has already been sent above; history is observation, not state.
     //
-    // Skip history when the frame is byte-identical to the prior one for this preview — there's
-    // nothing new to archive, and a duplicate sidecar would inflate `history/list` results
-    // without changing what the user sees on disk.
-    if (!isUnchanged) {
-      recordHistoryForRender(previewId = previewId, result = result, finished = finished)
-    }
+    // Dedup is the history source's job, not this gate's: a byte-identical frame may still carry a
+    // changed `compose/semantics` tree (a dropped contentDescription leaves pixels untouched), and
+    // that's exactly what `history/diff mode=semantics` exists to catch (issue #1785). So we record
+    // regardless of the pixel-only `isUnchanged` flag and let `LocalFsHistorySource` skip only when
+    // BOTH the bytes and the semantics tree are unchanged — `recordHistoryForRender` returns null
+    // on
+    // that skip, so a truly-redundant frame still emits no `historyAdded` and adds no sidecar.
+    recordHistoryForRender(previewId = previewId, result = result, finished = finished)
     inFlightRenders.remove(result.id)
     previewIdsWithOverridesInFlight.remove(previewId)
     // D3 — wake any `data/fetch` waiter that queued this render. The waiter re-invokes

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -69,6 +69,9 @@ import ee.schimke.composeai.daemon.protocol.XrStopParams
 import ee.schimke.composeai.daemon.protocol.XrStructureParams
 import ee.schimke.composeai.daemon.protocol.XrStructureResult
 import ee.schimke.composeai.daemon.protocol.XrUpdatePanelsParams
+import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsPayload
+import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsProduct
+import ee.schimke.composeai.data.layoutinspector.SemanticsDiff
 import ee.schimke.composeai.io.SystemFileSystem
 import ee.schimke.composeai.renderer.xr.client.StreamFrame as XrStreamFrame
 import ee.schimke.composeai.renderer.xr.client.XrRenderServerFactory
@@ -1268,6 +1271,25 @@ class JsonRpcServer(
           config = null,
         )
       }
+    // Snapshot the `compose/semantics` tree this render produced (issue #1785) so a later
+    // `history/diff mode=SEMANTICS` can diff two entries structurally. Opportunistic: the inline
+    // fetch returns the payload only when the producer wrote the artefact for this pass (it never
+    // forces a re-render — a missing file is NotAvailable, not RequiresRerender), so renders that
+    // didn't compute semantics simply record `semantics = null`.
+    val semantics =
+      try {
+        val outcome =
+          extensions
+            .publicDataProducts()
+            .fetch(previewId, ComposeSemanticsProduct.KIND, params = null, inline = true)
+        (outcome as? DataProductRegistry.Outcome.Ok)?.result?.payload
+      } catch (t: Throwable) {
+        System.err.println(
+          "compose-ai-daemon: history: compose/semantics fetch for $previewId failed " +
+            "(${t.javaClass.simpleName}: ${t.message}); recording entry without a semantics snapshot"
+        )
+        null
+      }
     val entry =
       try {
         mgr.recordRender(
@@ -1278,6 +1300,7 @@ class JsonRpcServer(
           renderTookMs = finished.tookMs,
           metrics = finished.metrics,
           previewMetadata = previewMetadata,
+          semantics = semantics,
         )
       } catch (t: Throwable) {
         System.err.println(
@@ -1297,8 +1320,12 @@ class JsonRpcServer(
     }
   }
 
+  // Strips the heavy captured `semantics` snapshot (issue #1785) before echoing an entry on the
+  // wire: `history/list` / `history/read` / `historyAdded` / metadata-mode `history/diff` only want
+  // metadata, and the tree is read back off the sidecar exclusively by `history/diff
+  // mode=SEMANTICS`.
   private fun encodeHistoryEntry(entry: HistoryEntry): JsonElement =
-    json.encodeToJsonElement(HistoryEntry.serializer(), entry)
+    json.encodeToJsonElement(HistoryEntry.serializer(), entry.copy(semantics = null))
 
   private fun handleHistoryList(req: JsonRpcRequest) {
     val params =
@@ -1425,10 +1452,13 @@ class JsonRpcServer(
    * - `HistoryEntryNotFound` (-32010) when either id is missing.
    * - `HistoryDiffMismatch` (-32011) when the two entries belong to different previews.
    * - `ERR_HISTORY_PIXEL_NOT_IMPLEMENTED` (-32012) when the caller asks for `mode = pixel` (H5).
+   * - `ERR_HISTORY_SEMANTICS_NOT_CAPTURED` (-32013) when `mode = semantics` but one of the two
+   *   entries has no captured `compose/semantics` snapshot (issue #1785).
    *
    * The metadata-mode response is `pngHashChanged + fromMetadata + toMetadata` (full sidecars).
    * Pixel-mode fields (`diffPx`, `ssim`, `diffPngPath`) stay null in METADATA mode by design — H5
-   * lands the pixel pass.
+   * lands the pixel pass. SEMANTICS mode (issue #1785) adds `semanticsDelta`, the typed structural
+   * diff of the two entries' captured semantics trees.
    */
   private fun handleHistoryDiff(req: JsonRpcRequest) {
     val params =
@@ -1505,8 +1535,55 @@ class JsonRpcServer(
         code = ERR_HISTORY_DIFF_MISMATCH,
         message =
           "history/diff: from.previewId='${from.entry.previewId}' but " +
-            "to.previewId='${to.entry.previewId}'; pixel diff would be meaningless",
+            "to.previewId='${to.entry.previewId}'; a diff across previews would be meaningless",
       )
+      return
+    }
+    // SEMANTICS mode (issue #1785) — diff the two entries' captured `compose/semantics` trees.
+    // Each entry's snapshot is frozen at record time in the sidecar (stripped from the lean index),
+    // so the diff is the pixel-free regression signal: "Button 'Submit' lost its label" instead of
+    // "some pixels moved". The differ ([SemanticsDiff]) ignores positional bounds + the volatile
+    // nodeId, matching nodes by their stable `ref`.
+    if (params.mode == HistoryDiffMode.SEMANTICS) {
+      val missing =
+        when {
+          from.entry.semantics == null -> params.from
+          to.entry.semantics == null -> params.to
+          else -> null
+        }
+      if (missing != null) {
+        sendErrorResponse(
+          id = req.id,
+          code = ERR_HISTORY_SEMANTICS_NOT_CAPTURED,
+          message =
+            "history/diff: entry '$missing' has no captured compose/semantics snapshot; " +
+              "mode='semantics' needs both entries to have been recorded with semantics",
+        )
+        return
+      }
+      val delta =
+        try {
+          val base =
+            json.decodeFromJsonElement(ComposeSemanticsPayload.serializer(), from.entry.semantics!!)
+          val head =
+            json.decodeFromJsonElement(ComposeSemanticsPayload.serializer(), to.entry.semantics!!)
+          SemanticsDiff.diff(base, head)
+        } catch (t: Throwable) {
+          sendErrorResponse(
+            id = req.id,
+            code = ERR_INTERNAL,
+            message = "history/diff: semantics diff failed: ${t.message}",
+          )
+          return
+        }
+      val result =
+        HistoryDiffResult(
+          pngHashChanged = from.entry.pngHash != to.entry.pngHash,
+          fromMetadata = encodeHistoryEntry(from.entry),
+          toMetadata = encodeHistoryEntry(to.entry),
+          semanticsDelta = delta,
+        )
+      sendResponse(req.id, encode(HistoryDiffResult.serializer(), result))
       return
     }
     val result =
@@ -3808,6 +3885,15 @@ class JsonRpcServer(
      * fields by design."
      */
     const val ERR_HISTORY_PIXEL_NOT_IMPLEMENTED: Int = -32012
+
+    /**
+     * HISTORY.md § "Error codes" — `history/diff` was called with `mode = semantics` but one of the
+     * two entries has no captured `compose/semantics` snapshot (issue #1785). Distinct from
+     * `HistoryEntryNotFound`: the entry exists, but it was recorded by a render that didn't compute
+     * semantics (a stub host, or a render that never had the kind subscribed), so there's nothing
+     * to diff against.
+     */
+    const val ERR_HISTORY_SEMANTICS_NOT_CAPTURED: Int = -32013
 
     /** DATA-PRODUCTS.md § "Error codes" — kind not advertised by the daemon. */
     const val ERR_DATA_PRODUCT_UNKNOWN: Int = -32020

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryEntry.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryEntry.kt
@@ -29,6 +29,13 @@ import kotlinx.serialization.json.JsonElement
  * - **Optional delta** — [previousId] + [deltaFromPrevious]. The first render of a preview has
  *   `previousId == null` and `deltaFromPrevious == null`. H1 leaves the pixel-mode fields
  *   ([HistoryDelta.diffPx], [HistoryDelta.ssim]) as `null`; H5 will populate them.
+ * - **Semantics snapshot** — [semantics]. The `compose/semantics` payload captured alongside this
+ *   render, frozen so `history/diff mode=SEMANTICS` (issue #1785) can diff two entries' trees
+ *   structurally — the cheap, pixel-free regression signal. Null when the producer didn't compute
+ *   semantics for this render (e.g. stub hosts, renders that never subscribed the kind). Heavy, so
+ *   it lives only in the per-entry sidecar: it's stripped from the lean `index.jsonl` (like
+ *   [previewMetadata]) and never echoed on the `history/list` / `history/read` / `historyAdded`
+ *   wire surfaces — only `history/diff mode=SEMANTICS` reads it back off disk.
  */
 @Serializable
 data class HistoryEntry(
@@ -50,6 +57,7 @@ data class HistoryEntry(
   val previewMetadata: PreviewMetadataSnapshot? = null,
   val previousId: String? = null,
   val deltaFromPrevious: HistoryDelta? = null,
+  val semantics: JsonElement? = null,
 )
 
 /**

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryManager.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryManager.kt
@@ -95,6 +95,7 @@ class HistoryManager(
     renderTookMs: Long,
     metrics: RenderMetrics? = null,
     previewMetadata: PreviewMetadataSnapshot? = null,
+    semantics: JsonElement? = null,
     timestamp: Instant = Instant.now(),
   ): HistoryEntry? {
     if (!isEnabled) return null
@@ -144,6 +145,7 @@ class HistoryManager(
         previewMetadata = previewMetadata,
         previousId = previousId,
         deltaFromPrevious = delta,
+        semantics = semantics,
       )
 
     var anyWritten = false

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/LocalFsHistorySource.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/LocalFsHistorySource.kt
@@ -111,9 +111,11 @@ class LocalFsHistorySource(private val historyDir: Path) : HistorySource {
     sidecarFile.writeText(sidecarText, StandardCharsets.UTF_8)
 
     // index.jsonl append. Build a "lite" form by encoding the same entry minus the heavy
-    // previewMetadata snapshot — readers fetch the full sidecar via `history/read`. HISTORY.md
-    // § "index.jsonl" says: "same fields as the sidecar minus `previewMetadata`".
-    val indexEntry = canonicalEntry.copy(previewMetadata = null)
+    // previewMetadata + semantics snapshots — readers fetch the full sidecar via `history/read`
+    // (metadata) or `history/diff mode=SEMANTICS` (the tree). HISTORY.md § "index.jsonl" says:
+    // "same fields as the sidecar minus `previewMetadata`"; the semantics tree is kept out for the
+    // same reason — it would bloat every listing line.
+    val indexEntry = canonicalEntry.copy(previewMetadata = null, semantics = null)
     val indexLine = JSON.encodeToString(HistoryEntry.serializer(), indexEntry) + "\n"
     val indexFile = historyDir.resolve(INDEX_FILENAME)
     Files.write(
@@ -329,8 +331,9 @@ class LocalFsHistorySource(private val historyDir: Path) : HistorySource {
       val sb = StringBuilder()
       // index.jsonl is append-order = oldest first. survivors is newest-first; reverse for write.
       for (entry in survivors.asReversed()) {
-        // Match the live append shape: same fields as the sidecar, minus previewMetadata.
-        val indexEntry = entry.copy(previewMetadata = null)
+        // Match the live append shape: same fields as the sidecar, minus previewMetadata + the
+        // heavy semantics snapshot.
+        val indexEntry = entry.copy(previewMetadata = null, semantics = null)
         sb.append(JSON.encodeToString(HistoryEntry.serializer(), indexEntry))
         sb.append('\n')
       }

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/LocalFsHistorySource.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/LocalFsHistorySource.kt
@@ -1,5 +1,7 @@
 package ee.schimke.composeai.daemon.history
 
+import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsPayload
+import ee.schimke.composeai.data.layoutinspector.SemanticsDiff
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
@@ -16,6 +18,7 @@ import kotlin.io.path.readText
 import kotlin.io.path.writeBytes
 import kotlin.io.path.writeText
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
 
 /**
  * Filesystem-backed [HistorySource] — the H1 default. Writes PNGs + sidecar JSON files plus an
@@ -77,11 +80,23 @@ class LocalFsHistorySource(private val historyDir: Path) : HistorySource {
     Files.createDirectories(previewDir)
 
     // Tier 1 — skip-on-most-recent-match. If the absolute newest sidecar for this preview already
-    // has the same hash, this render is redundant from the consumer's perspective; skip everything.
-    // Different from tier 2 below: rule is "most recent", not "any match" — A → B → A keeps three
-    // entries (the third is a meaningful "we went back to A" event), but A → A → A keeps one.
-    val mostRecentHash = findMostRecentEntryHash(previewDir, exclude = entry.id)
-    if (mostRecentHash != null && mostRecentHash == entry.pngHash) {
+    // has the same hash AND the same semantics tree, this render is redundant from the consumer's
+    // perspective; skip everything. Different from tier 2 below: rule is "most recent", not "any
+    // match" — A → B → A keeps three entries (the third is a meaningful "we went back to A" event),
+    // but A → A → A keeps one.
+    //
+    // The semantics check (issue #1785) is what keeps a *semantics-only* change recordable: a
+    // render that drops a `contentDescription` / `role` / `testTag` produces byte-identical pixels
+    // but a changed `compose/semantics` tree, and that's exactly what `history/diff mode=semantics`
+    // exists to catch — so it must NOT be deduped away here. Comparison is structural (via
+    // [SemanticsDiff]), so the volatile per-render `nodeId` and positional bounds don't register as
+    // a change and a truly-identical re-render still dedups.
+    val mostRecent = findMostRecentEntry(previewDir, exclude = entry.id)
+    if (
+      mostRecent != null &&
+        mostRecent.pngHash == entry.pngHash &&
+        !semanticsChanged(mostRecent.semantics, entry.semantics)
+    ) {
       return WriteResult.SKIPPED_DUPLICATE
     }
 
@@ -129,13 +144,14 @@ class LocalFsHistorySource(private val historyDir: Path) : HistorySource {
   }
 
   /**
-   * Returns the [HistoryEntry.pngHash] of the absolute newest sidecar in [previewDir], or null when
-   * the dir is empty or all sidecars are unreadable. Used by tier 1 of the dedup ladder.
+   * Returns the absolute newest sidecar's [HistoryEntry] in [previewDir], or null when the dir is
+   * empty or all sidecars are unreadable. Used by tier 1 of the dedup ladder (which compares both
+   * its `pngHash` and its captured `semantics` snapshot against the incoming entry).
    *
    * Sidecar filenames lead with a UTC timestamp in `yyyyMMdd-HHmmss-<hash>` shape, so reverse lex
    * sort = newest first. We don't need to parse the timestamp — string compare is enough.
    */
-  private fun findMostRecentEntryHash(previewDir: Path, exclude: String): String? {
+  private fun findMostRecentEntry(previewDir: Path, exclude: String): HistoryEntry? {
     if (!Files.exists(previewDir)) return null
     val newest =
       try {
@@ -155,13 +171,30 @@ class LocalFsHistorySource(private val historyDir: Path) : HistorySource {
       } catch (_: Throwable) {
         return null
       }
-    val parsed =
-      try {
-        JSON.decodeFromString(HistoryEntry.serializer(), text)
-      } catch (_: Throwable) {
-        return null
-      }
-    return parsed.pngHash
+    return try {
+      JSON.decodeFromString(HistoryEntry.serializer(), text)
+    } catch (_: Throwable) {
+      null
+    }
+  }
+
+  /**
+   * True when both [old] and [new] carry a captured `compose/semantics` snapshot and their trees
+   * differ semantically (issue #1785). Returns false when either side has no snapshot — semantics
+   * dedup only applies when there's something to compare on both sides, so toggling capture on/off
+   * never forces a spurious entry. Comparison is via [SemanticsDiff] (not a raw byte hash) so the
+   * volatile per-render `nodeId` and positional bounds don't count as a change. A malformed
+   * snapshot can't be diffed, so it conservatively reports "unchanged" (preserve pixel dedup).
+   */
+  private fun semanticsChanged(old: JsonElement?, new: JsonElement?): Boolean {
+    if (old == null || new == null) return false
+    return try {
+      val base = JSON.decodeFromJsonElement(ComposeSemanticsPayload.serializer(), old)
+      val head = JSON.decodeFromJsonElement(ComposeSemanticsPayload.serializer(), new)
+      !SemanticsDiff.diff(base, head).isEmpty
+    } catch (_: Throwable) {
+      false
+    }
   }
 
   override fun list(filter: HistoryFilter): HistoryListPage {

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.daemon.protocol
 
+import ee.schimke.composeai.data.layoutinspector.SemanticsDelta
 import ee.schimke.composeai.data.render.extensions.DataExtensionDescriptor
 import ee.schimke.composeai.data.render.pipeline.PreviewExtensionDescriptor
 import ee.schimke.composeai.data.render.pipeline.SamplingPolicy
@@ -1683,6 +1684,10 @@ enum class InteractiveInputKind {
 enum class HistoryDiffMode {
   @SerialName("metadata") METADATA,
   @SerialName("pixel") PIXEL,
+  // Structural text diff of the two entries' `compose/semantics` trees (issue #1785) — the cheap,
+  // pixel-free regression signal. Populates `semanticsDelta`; requires both entries to carry a
+  // captured semantics snapshot (else `ERR_HISTORY_SEMANTICS_NOT_CAPTURED`).
+  @SerialName("semantics") SEMANTICS,
 }
 
 @Serializable
@@ -1701,6 +1706,9 @@ data class HistoryDiffResult(
   val diffPx: Long? = null,
   val ssim: Double? = null,
   val diffPngPath: String? = null,
+  // Semantics-mode field (issue #1785) — the typed structural delta of the two entries'
+  // `compose/semantics` trees. Null in METADATA / PIXEL modes by design.
+  val semanticsDelta: SemanticsDelta? = null,
 )
 
 // ---------------------------------------------------------------------------

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/HistoryDiffTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/HistoryDiffTest.kt
@@ -14,8 +14,10 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.junit.After
@@ -203,6 +205,121 @@ class HistoryDiffTest {
       assertEquals(JsonRpcServer.ERR_HISTORY_PIXEL_NOT_IMPLEMENTED, errCode)
     }
   }
+
+  // -------------------------------------------------------------------------
+  // SEMANTICS mode (issue #1785) — structural text diff of two entries' captured
+  // `compose/semantics` trees. Entries are seeded with a semantics snapshot directly via
+  // `recordRender(semantics = …)`, mirroring what the render path captures off the data-product
+  // registry.
+  // -------------------------------------------------------------------------
+
+  @Test(timeout = 30_000)
+  fun semantics_mode_reports_field_change_on_same_ref() {
+    runWith { _, manager, send, receive ->
+      val from =
+        manager.recordRender(
+          "preview-A",
+          "bytes-1".toByteArray(),
+          trigger = "renderNow",
+          renderTookMs = 1,
+          semantics = semanticsPayload(testTag = "greeting", text = "Hello"),
+        )!!
+      val to =
+        manager.recordRender(
+          "preview-A",
+          "bytes-2".toByteArray(),
+          trigger = "renderNow",
+          renderTookMs = 1,
+          semantics = semanticsPayload(testTag = "greeting", text = "World"),
+        )!!
+
+      val resp = diffRoundTrip(send, receive, from = from.id, to = to.id, mode = "semantics")
+      val delta = resp["result"]!!.jsonObject["semanticsDelta"]!!.jsonObject
+      // Versioned schema rides the wire even though the server encodes with encodeDefaults=false.
+      assertEquals("compose-semantics-diff/v1", delta["schema"]!!.jsonPrimitive.content)
+      // Empty added/removed lists are omitted by the lean encoder — absent ⇒ empty.
+      assertTrue(emptyOrAbsent(delta["added"]))
+      assertTrue(emptyOrAbsent(delta["removed"]))
+      val changed = delta["changed"]!!.jsonArray
+      assertEquals(1, changed.size)
+      val change = changed[0].jsonObject["changes"]!!.jsonArray.single().jsonObject
+      assertEquals("text", change["field"]!!.jsonPrimitive.content)
+      assertEquals("Hello", change["from"]!!.jsonPrimitive.content)
+      assertEquals("World", change["to"]!!.jsonPrimitive.content)
+    }
+  }
+
+  @Test(timeout = 30_000)
+  fun semantics_mode_identical_trees_empty_delta() {
+    runWith { _, manager, send, receive ->
+      val from =
+        manager.recordRender(
+          "preview-A",
+          "bytes-1".toByteArray(),
+          trigger = "renderNow",
+          renderTookMs = 1,
+          semantics = semanticsPayload(testTag = "greeting", text = "Hello"),
+        )!!
+      val to =
+        manager.recordRender(
+          "preview-A",
+          // Different PNG bytes (so dedup doesn't skip the write) but an identical semantics tree.
+          "bytes-2".toByteArray(),
+          trigger = "renderNow",
+          renderTookMs = 1,
+          semantics = semanticsPayload(testTag = "greeting", text = "Hello"),
+        )!!
+
+      val resp = diffRoundTrip(send, receive, from = from.id, to = to.id, mode = "semantics")
+      val delta = resp["result"]!!.jsonObject["semanticsDelta"]!!.jsonObject
+      assertTrue(emptyOrAbsent(delta["added"]))
+      assertTrue(emptyOrAbsent(delta["removed"]))
+      assertTrue(emptyOrAbsent(delta["changed"]))
+    }
+  }
+
+  @Test(timeout = 30_000)
+  fun semantics_mode_missing_snapshot_errors() {
+    runWith { _, manager, send, receive ->
+      val withSemantics =
+        manager.recordRender(
+          "preview-A",
+          "bytes-1".toByteArray(),
+          trigger = "renderNow",
+          renderTookMs = 1,
+          semantics = semanticsPayload(testTag = "greeting", text = "Hello"),
+        )!!
+      val withoutSemantics =
+        manager.recordRender(
+          "preview-A",
+          "bytes-2".toByteArray(),
+          trigger = "renderNow",
+          renderTookMs = 1,
+          // No semantics captured for this render.
+        )!!
+
+      val resp =
+        diffRoundTrip(
+          send,
+          receive,
+          from = withSemantics.id,
+          to = withoutSemantics.id,
+          mode = "semantics",
+        )
+      val errCode = resp["error"]!!.jsonObject["code"]!!.jsonPrimitive.intOrNull
+      assertEquals(JsonRpcServer.ERR_HISTORY_SEMANTICS_NOT_CAPTURED, errCode)
+    }
+  }
+
+  /** True when a delta list field is absent (omitted because empty) or present-but-empty. */
+  private fun emptyOrAbsent(element: JsonElement?): Boolean =
+    element == null || element.jsonArray.isEmpty()
+
+  /** A one-node `compose/semantics` payload as a [JsonElement], for seeding history entries. */
+  private fun semanticsPayload(testTag: String, text: String): JsonElement =
+    json.parseToJsonElement(
+      """{"root":{"nodeId":"1","boundsInRoot":"0,0,100,50","testTag":"$testTag","text":"$text"}}"""
+    )
 
   // -------------------------------------------------------------------------
   // Test infrastructure — minimal JSON-RPC client over piped streams.

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/LocalFsHistorySourceWriteTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/LocalFsHistorySourceWriteTest.kt
@@ -2,6 +2,7 @@ package ee.schimke.composeai.daemon.history
 
 import java.nio.file.Files
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -250,6 +251,125 @@ class LocalFsHistorySourceWriteTest {
   }
 
   @Test
+  fun semantics_only_change_with_identical_pixels_is_recorded_not_deduped() {
+    // Issue #1785 — a render that changes only semantics (e.g. a dropped testTag /
+    // contentDescription) produces byte-identical pixels. Tier-1 dedup must NOT skip it, else
+    // `history/diff mode=semantics` could never report the change. The PNG is still pointer-deduped
+    // (tier 2), so only a fresh sidecar + index line land — no duplicate bytes.
+    val source = LocalFsHistorySource(historyDir = tmpDir)
+    val previewId = "SemanticOnly"
+    val bytes = byteArrayOf(0x42, 0x42, 0x42)
+    val hash = LocalFsHistorySource.sha256Hex(bytes)
+
+    val first =
+      makeEntry(
+        id = "20260430-100000-${hash.take(8)}",
+        previewId = previewId,
+        hash = hash,
+        size = bytes.size.toLong(),
+        semantics = semanticsJson(testTag = "submit"),
+      )
+    val second =
+      makeEntry(
+        id = "20260430-100001-${hash.take(8)}",
+        previewId = previewId,
+        hash = hash,
+        size = bytes.size.toLong(),
+        semantics = semanticsJson(testTag = "cancel"),
+      )
+
+    assertEquals(WriteResult.WRITTEN, source.write(first, bytes))
+    assertEquals(
+      "identical pixels but a changed semantics tree must land",
+      WriteResult.WRITTEN,
+      source.write(second, bytes),
+    )
+
+    val previewDir = tmpDir.resolve("SemanticOnly")
+    val secondPng = previewDir.resolve("${second.id}.png")
+    val secondSidecar = previewDir.resolve("${second.id}.json")
+    assertFalse("Second PNG must NOT be rewritten — pointer-only", Files.exists(secondPng))
+    assertTrue("Second sidecar must exist", Files.exists(secondSidecar))
+    val secondEntry =
+      json.decodeFromString(HistoryEntry.serializer(), Files.readString(secondSidecar))
+    assertEquals("Second pngPath points at first's PNG", "${first.id}.png", secondEntry.pngPath)
+
+    val indexLines =
+      Files.readAllLines(tmpDir.resolve(LocalFsHistorySource.INDEX_FILENAME)).filter {
+        it.isNotBlank()
+      }
+    assertEquals(2, indexLines.size)
+  }
+
+  @Test
+  fun identical_pixels_and_identical_semantics_is_skipped() {
+    val source = LocalFsHistorySource(historyDir = tmpDir)
+    val previewId = "Steady"
+    val bytes = byteArrayOf(0x55, 0x66, 0x77)
+    val hash = LocalFsHistorySource.sha256Hex(bytes)
+
+    val first =
+      makeEntry(
+        id = "20260430-100000-${hash.take(8)}",
+        previewId = previewId,
+        hash = hash,
+        size = bytes.size.toLong(),
+        semantics = semanticsJson(testTag = "submit"),
+      )
+    val second =
+      makeEntry(
+        id = "20260430-100001-${hash.take(8)}",
+        previewId = previewId,
+        hash = hash,
+        size = bytes.size.toLong(),
+        semantics = semanticsJson(testTag = "submit"),
+      )
+
+    assertEquals(WriteResult.WRITTEN, source.write(first, bytes))
+    assertEquals(
+      "identical pixels AND identical semantics is still a pure duplicate",
+      WriteResult.SKIPPED_DUPLICATE,
+      source.write(second, bytes),
+    )
+  }
+
+  @Test
+  fun identical_semantics_with_different_nodeId_is_skipped() {
+    // The volatile per-render `nodeId` reshuffles between identical renders. Because the dedup
+    // compares trees structurally (SemanticsDiff ignores nodeId), a re-render whose only delta is
+    // nodeId churn must still dedup — otherwise every identical render would record a spurious
+    // entry.
+    val source = LocalFsHistorySource(historyDir = tmpDir)
+    val previewId = "NodeIdChurn"
+    val bytes = byteArrayOf(0x01, 0x02, 0x03, 0x04)
+    val hash = LocalFsHistorySource.sha256Hex(bytes)
+
+    val first =
+      makeEntry(
+        id = "20260430-100000-${hash.take(8)}",
+        previewId = previewId,
+        hash = hash,
+        size = bytes.size.toLong(),
+        semantics = semanticsJson(nodeId = "1", testTag = "submit"),
+      )
+    val second =
+      makeEntry(
+        id = "20260430-100001-${hash.take(8)}",
+        previewId = previewId,
+        hash = hash,
+        size = bytes.size.toLong(),
+        semantics = semanticsJson(nodeId = "999", testTag = "submit"),
+      )
+
+    assertEquals(WriteResult.WRITTEN, source.write(first, bytes))
+    assertEquals(
+      "nodeId-only churn is not a semantic change → dedup still skips",
+      WriteResult.SKIPPED_DUPLICATE,
+      source.write(second, bytes),
+    )
+  }
+
+  @Test
   fun previewId_with_path_separator_is_sanitised() {
     val source = LocalFsHistorySource(historyDir = tmpDir)
     val rawId = "com/example/foo:bar"
@@ -269,7 +389,13 @@ class LocalFsHistorySourceWriteTest {
     assertNotNull(Files.list(tmpDir.resolve("com_example_foo_bar")).findFirst().orElse(null))
   }
 
-  private fun makeEntry(id: String, previewId: String, hash: String, size: Long): HistoryEntry =
+  private fun makeEntry(
+    id: String,
+    previewId: String,
+    hash: String,
+    size: Long,
+    semantics: JsonElement? = null,
+  ): HistoryEntry =
     HistoryEntry(
       id = id,
       previewId = previewId,
@@ -282,5 +408,12 @@ class LocalFsHistorySourceWriteTest {
       trigger = "renderNow",
       source = HistorySourceInfo(kind = "fs", id = "fs:${tmpDir.toAbsolutePath()}"),
       renderTookMs = 1L,
+      semantics = semantics,
+    )
+
+  /** A one-node `compose/semantics` payload as a [JsonElement], for seeding sidecars. */
+  private fun semanticsJson(nodeId: String = "1", testTag: String): JsonElement =
+    json.parseToJsonElement(
+      """{"root":{"nodeId":"$nodeId","boundsInRoot":"0,0,10,10","testTag":"$testTag"}}"""
     )
 }

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/SemanticsDiff.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/SemanticsDiff.kt
@@ -1,5 +1,7 @@
 package ee.schimke.composeai.data.layoutinspector
 
+import kotlinx.serialization.EncodeDefault
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
 
 object SemanticsDiffProduct {
@@ -112,9 +114,14 @@ data class SemanticsNodeSummary(
   val label: String? = null,
 )
 
+@OptIn(ExperimentalSerializationApi::class)
 @Serializable
 data class SemanticsDelta(
-  val schema: String = SemanticsDiffProduct.SCHEMA,
+  // `@EncodeDefault` so the versioned schema rides every wire surface — including JSON encoders
+  // configured with `encodeDefaults = false` (the daemon's `history/diff mode=SEMANTICS` result and
+  // the MCP `diff_semantics` payload). Without it an empty-or-default delta would serialize without
+  // its `schema`, defeating the "versioned JSON delta" contract (issue #1785).
+  @EncodeDefault val schema: String = SemanticsDiffProduct.SCHEMA,
   val added: List<SemanticsNodeSummary> = emptyList(),
   val removed: List<SemanticsNodeSummary> = emptyList(),
   val changed: List<SemanticsNodeChange> = emptyList(),

--- a/docs/daemon/HISTORY.md
+++ b/docs/daemon/HISTORY.md
@@ -91,9 +91,19 @@ trees structurally without reading PNGs.
 Two-tier ladder:
 
 1. **Skip-on-most-recent-match.** If the absolute newest existing entry
-   for this `previewId` has the same `pngHash`, the writer returns
-   `WriteResult.SKIPPED_DUPLICATE` and writes nothing. No PNG, no
-   sidecar, no index line, no `historyAdded` notification.
+   for this `previewId` has the same `pngHash` **and the same semantics
+   tree**, the writer returns `WriteResult.SKIPPED_DUPLICATE` and writes
+   nothing. No PNG, no sidecar, no index line, no `historyAdded`
+   notification. The semantics check (issue #1785) is what keeps a
+   *semantics-only* change recordable: a render that drops a
+   `contentDescription` / `role` / `testTag` produces byte-identical
+   pixels but a changed `compose/semantics` tree, and that's exactly the
+   regression `history/diff mode=semantics` exists to catch — so it must
+   land, not dedup away. The comparison is structural (via `SemanticsDiff`,
+   the same differ the diff uses), so the volatile per-render `nodeId` and
+   positional bounds don't count as a change and a truly-identical
+   re-render still dedups. When either side has no captured snapshot the
+   check falls back to pure `pngHash` dedup.
 2. **Pointer-on-any-match.** If the new bytes match an earlier entry
    (but not the most recent), the new sidecar's `pngPath` points at
    the older PNG and the bytes aren't re-written. Sidecar + index line

--- a/docs/daemon/HISTORY.md
+++ b/docs/daemon/HISTORY.md
@@ -69,13 +69,22 @@ renders inside the same second.
   },
 
   "previousId": "20260430-101207-9f8e7d6c",
-  "deltaFromPrevious": { "pngHashChanged": true, "diffPx": 142, "ssim": null }
+  "deltaFromPrevious": { "pngHashChanged": true, "diffPx": 142, "ssim": null },
+
+  "semantics": { "root": { "nodeId": "1", "ref": "r", ... } }  // compose/semantics, frozen at render time (#1785)
 }
 ```
 
-`index.jsonl` carries the same fields minus `previewMetadata`. Opened
-in `O_APPEND` mode — each line is under POSIX `PIPE_BUF` so writes are
-atomic.
+`index.jsonl` carries the same fields minus the two heavy snapshots,
+`previewMetadata` and `semantics` — readers fetch the full sidecar via
+`history/read` (metadata) or `history/diff mode=semantics` (the tree).
+Opened in `O_APPEND` mode — each line is under POSIX `PIPE_BUF` so writes
+are atomic.
+
+`semantics` is the `compose/semantics` payload the render produced,
+captured opportunistically (null when the render didn't compute it). It
+exists so `history/diff mode=semantics` (#1785) can diff two entries'
+trees structurally without reading PNGs.
 
 ### Dedup-by-hash on write
 
@@ -133,10 +142,11 @@ base64 bytes.
 ### `history/diff` (§ H3)
 
 ```ts
-params: { from: string; to: string; mode?: "metadata" | "pixel" }
+params: { from: string; to: string; mode?: "metadata" | "pixel" | "semantics" }
 result: {
   pngHashChanged: boolean;
   diffPx?: number; ssim?: number; diffPngPath?: string;  // pixel mode only
+  semanticsDelta?: SemanticsDelta;                        // semantics mode only
   fromMetadata: HistoryEntry;
   toMetadata: HistoryEntry;
 }
@@ -145,9 +155,29 @@ result: {
 `mode = "metadata"` (default) is hash-compare + sidecar diff.
 `mode = "pixel"` (H5, not yet implemented) writes a marked-diff PNG to
 `<historyDir>/<previewId>/.diffs/`.
+`mode = "semantics"` (issue #1785) diffs the two entries' captured
+`compose/semantics` trees and returns a typed `SemanticsDelta`
+(`compose-semantics-diff/v1`: added / removed / changed nodes, matched by
+each node's stable `ref`). The cheap, pixel-free regression signal — the
+Compose analogue of Playwright's aria-snapshot diff. Each entry's tree is
+snapshotted into its sidecar at record time (see `HistoryEntry.semantics`
+below), so the diff is deterministic and reads no PNGs. The same differ
+(`SemanticsDiff`) backs `compose-preview diff-semantics` and the MCP
+`diff_semantics` tool, so all three surfaces agree.
 
 Mismatched previews → `HistoryDiffMismatch (-32011)`. Missing entry →
-`HistoryEntryNotFound (-32010)`.
+`HistoryEntryNotFound (-32010)`. `mode = "pixel"` →
+`ERR_HISTORY_PIXEL_NOT_IMPLEMENTED (-32012)`. `mode = "semantics"` where one
+of the two entries has no captured semantics snapshot →
+`ERR_HISTORY_SEMANTICS_NOT_CAPTURED (-32013)` (distinct from "entry not
+found": the entry exists, but the render that produced it didn't compute
+semantics).
+
+The semantics snapshot is heavy, so it lives **only** in the per-entry
+sidecar — it's stripped from the lean `index.jsonl` (like `previewMetadata`)
+and never echoed on the `history/list` / `history/read` / `historyAdded` /
+metadata-mode `history/diff` wire surfaces; `history/diff mode=semantics` is
+the one reader that loads it back off disk.
 
 ### `history/prune`
 

--- a/docs/daemon/PROTOCOL.md
+++ b/docs/daemon/PROTOCOL.md
@@ -53,6 +53,7 @@ Standard JSON-RPC codes plus daemon-specific extensions in the reserved `-32000.
 | -32010   | HistoryEntryNotFound  | `history/read` or `history/diff` referenced a missing entry id. |
 | -32011   | HistoryDiffMismatch   | `history/diff` was given two entries from different previews. |
 | -32012   | HistoryPixelNotImplemented | `history/diff` was called with `mode = "pixel"`; reserved for phase H5. |
+| -32013   | HistorySemanticsNotCaptured | `history/diff` was called with `mode = "semantics"` but one of the two entries has no captured `compose/semantics` snapshot (issue #1785). |
 | -32020   | DataProductUnknown    | `data/*` referenced a kind not advertised by the daemon. See [DATA-PRODUCTS.md](DATA-PRODUCTS.md). |
 | -32021   | DataProductNotAvailable | `data/fetch` against a preview that has never rendered. |
 | -32022   | DataProductFetchFailed  | `data/fetch` re-render or projection failed; details in `data`. |
@@ -429,9 +430,9 @@ Errors:
 ```ts
 // params
 {
-  from: string;                     // entry id
-  to: string;                       // entry id
-  mode?: "metadata" | "pixel";      // default "metadata"
+  from: string;                            // entry id
+  to: string;                              // entry id
+  mode?: "metadata" | "pixel" | "semantics"; // default "metadata"
 }
 
 // result
@@ -443,6 +444,8 @@ Errors:
   diffPx?: number;
   ssim?: number;
   diffPngPath?: string;
+  // Semantics-mode field (issue #1785) — null in METADATA / PIXEL modes.
+  semanticsDelta?: SemanticsDelta;  // compose-semantics-diff/v1
 }
 ```
 
@@ -453,6 +456,14 @@ Errors:
 `mode = "pixel"` return `-32012` (`HistoryPixelNotImplemented`) so callers can distinguish
 "asked for pixel and the daemon isn't ready" from "asked for metadata and got null pixel fields
 by design."
+
+`mode = "semantics"` (issue #1785) diffs the two entries' captured `compose/semantics` trees and
+returns a typed `semanticsDelta` (`compose-semantics-diff/v1`: added / removed / changed nodes,
+matched by each node's stable `ref`). The cheap, pixel-free regression signal — the same
+`SemanticsDiff` that backs `compose-preview diff-semantics` and the MCP `diff_semantics` tool, so
+all three agree. Each entry's tree is snapshotted into its sidecar at record time, so the diff
+reads no PNGs. When one of the two entries has no captured semantics snapshot the call returns
+`-32013` (`HistorySemanticsNotCaptured`), distinct from `HistoryEntryNotFound`.
 
 The diff resolves `from` and `to` across all configured `HistorySource`s — `from` may live in
 `LocalFsHistorySource` while `to` lives on a `preview/main` ref via `GitRefHistorySource`. This is
@@ -465,6 +476,8 @@ Errors:
   be meaningless.
 - `HistoryPixelNotImplemented` (-32012) — `mode = "pixel"` was requested but the pixel pass is
   reserved for phase H5.
+- `HistorySemanticsNotCaptured` (-32013) — `mode = "semantics"` was requested but one of the two
+  entries has no captured `compose/semantics` snapshot.
 
 ### `data/fetch`, `data/subscribe`, `data/unsubscribe` (phase D1)
 


### PR DESCRIPTION
## Summary

Closes #1785.

The structural semantics-tree differ, the `compose-preview diff-semantics` CLI, and the MCP `diff_semantics` tool all landed in #1803. This PR adds the **one remaining acceptance-criteria item**: the second entry point — `history/diff mode=SEMANTICS`.

`history/diff` now accepts `mode=semantics`, diffing two history entries' captured `compose/semantics` trees and returning a typed `SemanticsDelta` (`compose-semantics-diff/v1` — added / removed / changed nodes, matched by each node's stable `ref`). It reuses the same `SemanticsDiff` as the CLI/MCP, so all three surfaces agree, and reads no PNGs.

To make this work, the semantics tree is snapshotted into each history entry at record time:

- **Storage.** A new optional `HistoryEntry.semantics` (`JsonElement`). It's heavy, so it lives **only** in the per-entry sidecar — stripped from the lean `index.jsonl` (exactly like `previewMetadata`) and never echoed on the `history/list` / `history/read` / `historyAdded` / metadata-mode `history/diff` wire surfaces. `history/diff mode=semantics` is the single reader that loads it back off disk. No change to the `HistorySource.write` signature.
- **Capture.** `recordHistoryForRender` fetches `compose/semantics` inline from the data-product registry. It's opportunistic — a missing artefact records `semantics = null` and never forces a re-render.
- **Errors.** A diff where either entry has no captured snapshot returns `ERR_HISTORY_SEMANTICS_NOT_CAPTURED` (-32013), distinct from "entry not found".

Also: `SemanticsDelta.schema` is now `@EncodeDefault`, so the versioned schema rides every wire surface — including the daemon's `encodeDefaults=false` encoder (previously an empty-or-default delta would serialize without its `schema`).

`history/diff` remains gated experimental (`-Dcomposeai.experimental.historyDiff=true`), so this is additive and off by default in production.

This is data/protocol plumbing with no visual surface, so text-only evidence is appropriate (per the repo's visual-evidence rule).

## Test plan

- [x] `:daemon:core:test --tests "*HistoryDiffTest*"` — new SEMANTICS-mode tests: field-change on the same ref, identical-trees → empty delta, missing-snapshot → -32013 error.
- [x] Full `:daemon:core:test` green except a pre-existing, timing-flaky `InteractiveCoalescingTest` (confirmed failing identically on clean `main` with these changes stashed; unrelated to this PR).
- [x] `:data-layoutinspector-core:test`, `:cli:test --tests "*SemanticsDiffCommand*"`, `:mcp:test --tests "*DaemonMcpServerTest*"`, `:daemon:core:test --tests "*HistoryEntryRoundTrip*"` — green (covers the `@EncodeDefault` change and the new `HistoryEntry` field round-trip).
- [x] `ktfmtCheckMain` / `ktfmtCheckTest` on touched modules; downstream `:mcp` / `:daemon:desktop` / `:daemon:harness` compile against the new daemon-core ABI.
- [x] Docs updated: `docs/daemon/HISTORY.md`, `docs/daemon/PROTOCOL.md` (mode, result field, sidecar field, error code).

---
_Generated by [Claude Code](https://claude.ai/code/session_01XDk94Aru4kWn27Ct21NU67)_