### PR TITLE
fix(plugin): keep CLI detection working when a non-renderable KMP-Android module is present (#1855)

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -451,7 +451,18 @@ internal object ComposePreviewTasks {
       }
 
     project.tasks.register("composePreviewBundle", BundlePreviewTask::class.java) {
-      onlyIf { extension.enabled.get() }
+      // Skip bundling a non-renderable pure-KMP-Android module: it discovers 0 previews, and
+      // BundlePreviewTask hard-fails on an empty manifest, so a build-wide `render --bundle` (which
+      // appends `:<module>:composePreviewBundle` for every detected module) would fail on it even
+      // though composePreviewRender itself no-ops (Codex review on #1863). Computed lazily at task
+      // realization (so a cmp-shared module whose `jvm("desktop")` target configures after
+      // registerDesktopTasks isn't mis-skipped) and captured as a Boolean so `onlyIf` doesn't pin
+      // `project` into the configuration cache. `isDesktopRenderableConfig` only trips on the
+      // literal
+      // `androidRuntimeClasspath` fallback, so this is a no-op on the Android bundle path and on
+      // real desktop modules.
+      val bundleRenderable = isDesktopRenderableConfig(resolveDependencyConfigName())
+      onlyIf { extension.enabled.get() && bundleRenderable }
       previewsJson.set(previewOutputDir.map { it.file("previews.json") })
       moduleClassDirs.from(sourceClassDirs)
       moduleResourcesDir.set(moduleResourcesDirProvider)
@@ -601,8 +612,10 @@ internal object ComposePreviewTasks {
       // A pure-KMP-Android module (only `androidRuntimeClasspath`, no `jvm("desktop")`) can't be
       // driven by the desktop daemon — skip emitting its launch descriptor (issue #1852). This task
       // is never realized by the Tooling-API model builder, so gating it can't affect CLI detection
-      // (unlike the reverted #1853 gating on discover/render — issue #1855).
-      onlyIf { isDesktopRenderableConfig(dependencyConfigName()) }
+      // (unlike the reverted #1853 gating on discover/render — issue #1855). Capture a config-time
+      // Boolean so `onlyIf` doesn't pin `project` into the configuration-cache entry.
+      val renderable = isDesktopRenderableConfig(dependencyConfigName())
+      onlyIf { renderable }
       modulePath.set(project.path)
       // Desktop daemons have no AGP variant. The string is surfaced in `daemon-launch.json`'s
       // `variant` field for debug/log purposes only — VS Code's `daemonProcess.ts` doesn't key
@@ -822,8 +835,10 @@ internal object ComposePreviewTasks {
       // pipeline on a module that has nothing for the desktop renderer (issue #1852). This task is
       // never realized by the Tooling-API model builder, so the skip can't affect CLI detection
       // (issue #1855). A preview-less module like the consumer's `:meshcore-mobile` then renders 0
-      // previews and no-ops cleanly.
-      onlyIf { isDesktopRenderableConfig(dependencyConfigName()) }
+      // previews and no-ops cleanly. Compute renderability at config time and capture a Boolean so
+      // `onlyIf` doesn't pin `project` into the configuration-cache entry.
+      val renderable = isDesktopRenderableConfig(dependencyConfigName())
+      onlyIf { renderable }
       platform.set("desktop")
       // Feed the @Classpath FileCollection a lazily-resolved, content-keyed FileCollection
       // (`incoming.artifactView { }.files`) instead of the raw `Configuration`.

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -89,27 +89,46 @@ internal object ComposePreviewTasks {
     return rendererConfig
   }
 
+  private val consumerArtifactTypeAttribute: Attribute<String> =
+    Attribute.of("artifactType", String::class.java)
+
   /**
-   * Whether a desktop-routed module whose resolved runtime config is [configName] can actually be
-   * rendered by the JVM desktop renderer.
-   *
-   * The renderer is a JVM process, so it needs JVM-flavoured Compose on the classpath. A pure
-   * `com.android.kotlin.multiplatform.library` module with no `jvm("desktop")` target exposes only
-   * `androidRuntimeClasspath` — carrying `*-android` Compose AARs that reference
-   * `android.os.Parcelable` — and forcing any artifact view on its single AGP `android` variant
-   * trips a variant ambiguity that, left to propagate, hard-fails the whole `composePreviewRender`
-   * pipeline for every module (issue #1852: a no-preview library module like `:meshcore-mobile`
-   * sinks the green modules' render too).
-   *
-   * Such a module is treated as non-renderable: the desktop tasks skip it (fail-soft per module,
-   * with a one-line warning) instead of resolving its classpath and failing. Adding a
-   * `jvm("desktop")` target — the canonical cmp-shared layout — surfaces `desktopRuntimeClasspath`
-   * and flips this back to `true`.
-   *
-   * `internal` + pure so it can be unit-tested without standing up AGP/KGP.
+   * Whether a desktop-routed module whose resolved runtime config is [configName] can be rendered
+   * by the JVM desktop renderer. A pure `com.android.kotlin.multiplatform.library` module with no
+   * `jvm("desktop")` target exposes only `androidRuntimeClasspath` (carrying `*-android` Compose),
+   * which the desktop renderer can't drive. Used ONLY to gate tasks that the Tooling-API model
+   * builder never realizes (the classpath guard, the daemon-start descriptor) — so it can't affect
+   * CLI module detection the way the reverted #1853 task gating did (issue #1855). Pure +
+   * `internal` for unit testing.
    */
   internal fun isDesktopRenderableConfig(configName: String): Boolean =
     configName != "androidRuntimeClasspath"
+
+  /**
+   * Lazily-resolved, config-cache-safe view of the consumer runtime classpath [configName], pinned
+   * to `artifactType=jar`.
+   *
+   * Issue #1852: a KMP-Android module's `androidRuntimeClasspath` exposes ~12 secondary variants,
+   * so resolving it through a bare `incoming.artifactView {}` (no attributes) fails with
+   * `AmbiguousArtifactsFailure` ("cannot choose between variants") and sinks the whole desktop
+   * render. Pinning `artifactType=jar` — exactly what `composePreviewDiscover` already does, which
+   * is why discovery survived 0.15.2 — selects a single jar variant. On JVM/desktop classpaths the
+   * jar attribute is a passthrough, so behaviour there is unchanged. `lenient(true)` is applied
+   * ONLY for the `androidRuntimeClasspath` fallback (mirroring discovery) so a strict JVM classpath
+   * still surfaces a genuinely missing dependency instead of silently dropping it.
+   */
+  private fun pinnedConsumerClasspath(
+    project: Project,
+    configName: String,
+  ): org.gradle.api.file.FileCollection? {
+    val config = project.configurations.findByName(configName) ?: return null
+    return config.incoming
+      .artifactView {
+        if (configName == "androidRuntimeClasspath") lenient(true)
+        attributes.attribute(consumerArtifactTypeAttribute, "jar")
+      }
+      .files
+  }
 
   fun registerDesktopTasks(project: Project, extension: PreviewExtension) {
     val previewOutputDir = project.layout.buildDirectory.dir("compose-previews")
@@ -186,15 +205,7 @@ internal object ComposePreviewTasks {
         // aborts on such a module. JVM/desktop configs stay strict.
         lenientWhenAndroidOnlyFallback = true,
       ) {
-        // Skip discovery for a non-renderable pure-KMP-Android module (only
-        // androidRuntimeClasspath,
-        // no jvm("desktop") target) so it reports nothing instead of being pulled into the pipeline
-        // — keeps it consistent with the render task, which skips the same module (issue #1852).
-        // Computed at task-realization time, when the kotlin{} block has configured and
-        // desktopRuntimeClasspath (if any) exists; captured as a Boolean so onlyIf stays
-        // config-cache-safe.
-        val renderable = isDesktopRenderableConfig(resolveDependencyConfigName())
-        onlyIf { extension.enabled.get() && renderable }
+        onlyIf { extension.enabled.get() }
         // `compileAndroidMain` is the lifecycle task for the KMP-Android target's `main`
         // compilation (which depends on the underlying `compileAndroidMainKotlin`-shaped Kotlin
         // compile under the hood). Use lazy matching so compile tasks registered after this plugin
@@ -222,22 +233,7 @@ internal object ComposePreviewTasks {
       )
     val renderTask =
       project.tasks.register("composePreviewRender", RenderPreviewsTask::class.java) {
-        // A pure KMP-Android module with no jvm("desktop") target can't be rendered by the JVM
-        // desktop renderer; resolving its androidRuntimeClasspath would trip a variant ambiguity
-        // and hard-fail the whole pipeline (issue #1852). Skip it (fail-soft per module) and warn
-        // once — realization time is after the kotlin{} block configures, so the config name is
-        // settled here; capture as a Boolean to keep onlyIf config-cache-safe.
-        val renderable = isDesktopRenderableConfig(resolveDependencyConfigName())
-        if (!renderable) {
-          logger.warn(
-            "compose-preview: skipping module '${project.path}' — it applies " +
-              "com.android.kotlin.multiplatform.library but has no jvm(\"desktop\") target, so the " +
-              "Compose Multiplatform Desktop renderer can't render its *-android Compose artifacts. " +
-              "Add a jvm(\"desktop\") target to render its androidMain previews (see " +
-              "compose-preview/references/cmp-shared.md)."
-          )
-        }
-        onlyIf { extension.enabled.get() && renderable }
+        onlyIf { extension.enabled.get() }
         previewsJson.set(previewOutputDir.map { it.file("previews.json") })
         outputDir.set(previewOutputDir.map { it.dir("renders") })
         // `@ScrollingPreview(modes = [LONG, GIF])` outputs land here (sibling of `renders/`).
@@ -251,18 +247,11 @@ internal object ComposePreviewTasks {
         // Consumer's processed resources so previews can load classpath assets (Lottie `.json`,
         // fonts, images) at render time. Depend on the resource-processing task that stages them.
         renderClasspath.from(sourceResourceDirs)
-        // Feed configurations through a lazily-resolved `incoming.artifactView {}.files` view
-        // rather than the raw `Configuration`, so the @Classpath collection never pins a live
-        // `Configuration` into the task's config-cache `__classpath__` field (the serialization
-        // failure issue #1796 hit on the desktop validate guards). The empty view yields the same
-        // default resolution — module + file dependencies alike — just lazily and serializably.
-        // Only wired when renderable: a non-renderable module's androidRuntimeClasspath would
-        // resolve to a variant ambiguity during input snapshotting even though onlyIf skips the
-        // action, so leave it off the classpath entirely (issue #1852).
-        if (renderable) {
-          project.configurations.findByName(resolveDependencyConfigName())?.let {
-            renderClasspath.from(it.incoming.artifactView {}.files)
-          }
+        // Lazily-resolved, config-cache-safe consumer-classpath view (issue #1796) pinned to
+        // `artifactType=jar` so a KMP-Android `androidRuntimeClasspath` doesn't trip the
+        // 12-variant ambiguity (issue #1852). See [pinnedConsumerClasspath].
+        pinnedConsumerClasspath(project, resolveDependencyConfigName())?.let {
+          renderClasspath.from(it)
         }
         renderClasspath.from(rendererConfig.incoming.artifactView {}.files)
         group = "compose preview"
@@ -462,19 +451,7 @@ internal object ComposePreviewTasks {
       }
 
     project.tasks.register("composePreviewBundle", BundlePreviewTask::class.java) {
-      // A non-renderable pure-KMP-Android module has nothing the desktop renderer can pack; skip
-      // its
-      // bundle for consistency with the render/daemon tasks (issue #1852). Compute renderability
-      // LAZILY here at task realization — NOT from the eager `depConfigName` snapshot above — so a
-      // cmp-shared module whose `jvm("desktop")` target configures after `registerDesktopTasks`
-      // runs
-      // (when only the androidRuntimeClasspath fallback is visible) isn't permanently skipped
-      // (Codex
-      // review on #1853). Mirrors the render task. `isDesktopRenderableConfig` only trips on the
-      // literal `androidRuntimeClasspath` fallback, so this is a no-op on the Android bundle path
-      // (which routes through `${variant}RuntimeClasspath`) and on real desktop modules.
-      val bundleRenderable = isDesktopRenderableConfig(resolveDependencyConfigName())
-      onlyIf { extension.enabled.get() && bundleRenderable }
+      onlyIf { extension.enabled.get() }
       previewsJson.set(previewOutputDir.map { it.file("previews.json") })
       moduleClassDirs.from(sourceClassDirs)
       moduleResourcesDir.set(moduleResourcesDirProvider)
@@ -621,12 +598,11 @@ internal object ComposePreviewTasks {
       "composePreviewDaemonStart",
       ee.schimke.composeai.plugin.daemon.DaemonBootstrapTask::class.java,
     ) {
-      // A non-renderable pure-KMP-Android module (only androidRuntimeClasspath, no jvm("desktop"))
-      // can't be driven by the desktop daemon either, and resolving its runtime classpath would
-      // trip the same variant ambiguity — skip the descriptor emission and leave its config off
-      // the daemon `-cp` (issue #1852).
-      val renderable = isDesktopRenderableConfig(dependencyConfigName())
-      onlyIf { renderable }
+      // A pure-KMP-Android module (only `androidRuntimeClasspath`, no `jvm("desktop")`) can't be
+      // driven by the desktop daemon — skip emitting its launch descriptor (issue #1852). This task
+      // is never realized by the Tooling-API model builder, so gating it can't affect CLI detection
+      // (unlike the reverted #1853 gating on discover/render — issue #1855).
+      onlyIf { isDesktopRenderableConfig(dependencyConfigName()) }
       modulePath.set(project.path)
       // Desktop daemons have no AGP variant. The string is surfaced in `daemon-launch.json`'s
       // `variant` field for debug/log purposes only — VS Code's `daemonProcess.ts` doesn't key
@@ -646,8 +622,7 @@ internal object ComposePreviewTasks {
         project = project,
         extension = extension,
         task = this,
-        userRuntimeConfig =
-          if (renderable) project.configurations.findByName(dependencyConfigName()) else null,
+        userRuntimeConfig = project.configurations.findByName(dependencyConfigName()),
       )
       // `:daemon:desktop`'s `DaemonMain` and `:daemon:android`'s `DaemonMain` share the FQN
       // intentionally (see the kdoc on `daemon/desktop/.../DaemonMain.kt`). The desktop classes
@@ -669,14 +644,10 @@ internal object ComposePreviewTasks {
       // don't match the `build/classes/...` markers), so they stay parent-loaded, not child-first.
       classpath.from(sourceResourceDirs)
       // User's runtime classpath (Compose Multiplatform deps + transitive Kotlin libraries).
-      // Lazy artifact view (not the raw `Configuration`) for config-cache serializability — #1796.
-      // Skipped for a non-renderable module so its ambiguous androidRuntimeClasspath is never
-      // resolved (issue #1852).
-      if (renderable) {
-        project.configurations.findByName(dependencyConfigName())?.let {
-          classpath.from(it.incoming.artifactView {}.files)
-        }
-      }
+      // Lazy artifact view (not the raw `Configuration`) for config-cache serializability — #1796 —
+      // pinned to `artifactType=jar` so a KMP-Android `androidRuntimeClasspath` doesn't trip the
+      // 12-variant ambiguity (#1852). See [pinnedConsumerClasspath].
+      pinnedConsumerClasspath(project, dependencyConfigName())?.let { classpath.from(it) }
 
       // Desktop daemons don't run inside Robolectric, so the AGP-side `--add-opens` flags don't
       // apply here. `-Xmx` is the only essential JVM arg; B-desktop follow-ups can add Skia /
@@ -844,12 +815,15 @@ internal object ComposePreviewTasks {
     toolClasspath: org.gradle.api.artifacts.Configuration,
   ): TaskProvider<ValidateComposePreviewClasspathTask> =
     project.tasks.register(taskName, ValidateComposePreviewClasspathTask::class.java) {
-      // The guard runs as a dependsOn of the render/daemon task, so it would resolve
-      // androidRuntimeClasspath (and fail on its variant ambiguity) BEFORE the render task's own
-      // onlyIf can skip a non-renderable module. Gate it the same way: skip the guard and don't
-      // wire the consumer config when the module isn't desktop-renderable (issue #1852).
-      val renderable = isDesktopRenderableConfig(dependencyConfigName())
-      onlyIf { renderable }
+      // A pure-KMP-Android module (only `androidRuntimeClasspath`, no `jvm("desktop")`) carries
+      // `*-android` Compose on its runtime classpath, which this guard would (correctly, for a
+      // renderable module) flag as "AndroidX Compose on the desktop classpath" and hard-fail. Such
+      // a module can't be desktop-rendered at all, so skip the guard instead of sinking the whole
+      // pipeline on a module that has nothing for the desktop renderer (issue #1852). This task is
+      // never realized by the Tooling-API model builder, so the skip can't affect CLI detection
+      // (issue #1855). A preview-less module like the consumer's `:meshcore-mobile` then renders 0
+      // previews and no-ops cleanly.
+      onlyIf { isDesktopRenderableConfig(dependencyConfigName()) }
       platform.set("desktop")
       // Feed the @Classpath FileCollection a lazily-resolved, content-keyed FileCollection
       // (`incoming.artifactView { }.files`) instead of the raw `Configuration`.
@@ -863,11 +837,7 @@ internal object ComposePreviewTasks {
       // while
       // resolving lazily through a serializable view — mirrors `composePreviewDiscover` above.
       classpath.from(toolClasspath.incoming.artifactView {}.files)
-      if (renderable) {
-        project.configurations.findByName(dependencyConfigName())?.let {
-          classpath.from(it.incoming.artifactView {}.files)
-        }
-      }
+      pinnedConsumerClasspath(project, dependencyConfigName())?.let { classpath.from(it) }
     }
 
   /**

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/KmpAndroidDesktopRoutingTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/KmpAndroidDesktopRoutingTest.kt
@@ -135,8 +135,7 @@ class KmpAndroidDesktopRoutingTest {
   @Test
   fun `isDesktopRenderableConfig is false only for the androidRuntimeClasspath fallback`() {
     // Issue #1852: a pure KMP-Android module whose only runtime config is androidRuntimeClasspath
-    // can't be rendered by the JVM desktop renderer. Every JVM/desktop-flavoured config stays
-    // renderable.
+    // can't be rendered by the JVM desktop renderer.
     assertThat(ComposePreviewTasks.isDesktopRenderableConfig("androidRuntimeClasspath")).isFalse()
     assertThat(ComposePreviewTasks.isDesktopRenderableConfig("jvmRuntimeClasspath")).isTrue()
     assertThat(ComposePreviewTasks.isDesktopRenderableConfig("desktopRuntimeClasspath")).isTrue()
@@ -144,10 +143,12 @@ class KmpAndroidDesktopRoutingTest {
   }
 
   @Test
-  fun `pure KMP-Android module with only androidRuntimeClasspath skips render and guard`() {
-    // Issue #1852: when the desktop fallback lands on androidRuntimeClasspath (no jvm("desktop")
-    // target), the render task and its classpath guard must skip via onlyIf instead of resolving
-    // the ambiguous config and hard-failing the whole pipeline. discover/daemon/bundle skip too.
+  fun `non-renderable module skips only the guard and daemon, never discover or render`() {
+    // Issue #1855: the desktop-render classpath guard and the daemon-start task are skipped for a
+    // pure KMP-Android module (they'd otherwise hard-fail on its androidRuntimeClasspath), but
+    // composePreviewDiscover and composePreviewRender must NOT be gated — the Tooling-API model
+    // builder realizes those during CLI detection, and gating them is what regressed 0.15.3 to
+    // "detect nothing". They run as in 0.15.2; the module simply discovers 0 previews.
     val project = ProjectBuilder.builder().withProjectDir(tmp.root).build()
     val extension = project.extensions.create("composePreview", PreviewExtension::class.java)
     project.configurations.create("androidRuntimeClasspath") {
@@ -157,71 +158,39 @@ class KmpAndroidDesktopRoutingTest {
 
     ComposePreviewTasks.registerDesktopTasks(project, extension)
 
+    // Skipped (detection-safe — never realized by the model builder):
     for (taskName in
-      listOf(
-        "composePreviewRender",
-        "validateComposePreviewDesktopRenderClasspath",
-        "composePreviewDiscover",
-        "composePreviewDaemonStart",
-        "composePreviewBundle",
-      )) {
+      listOf("validateComposePreviewDesktopRenderClasspath", "composePreviewDaemonStart")) {
       val task = project.tasks.getByName(taskName) as TaskInternal
       assertThat(task.onlyIf.isSatisfiedBy(task)).isFalse()
     }
-  }
-
-  @Test
-  fun `KMP-Android module with a desktop target stays renderable`() {
-    // The canonical cmp-shared layout (androidRuntimeClasspath + desktopRuntimeClasspath) must NOT
-    // be skipped — desktopRuntimeClasspath wins the fallback and the render task stays enabled.
-    val project = ProjectBuilder.builder().withProjectDir(tmp.root).build()
-    val extension = project.extensions.create("composePreview", PreviewExtension::class.java)
-    project.configurations.create("desktopRuntimeClasspath") {
-      isCanBeResolved = true
-      isCanBeConsumed = false
-    }
-    project.configurations.create("androidRuntimeClasspath") {
-      isCanBeResolved = true
-      isCanBeConsumed = false
-    }
-
-    ComposePreviewTasks.registerDesktopTasks(project, extension)
-
-    val render = project.tasks.getByName("composePreviewRender") as TaskInternal
-    assertThat(render.onlyIf.isSatisfiedBy(render)).isTrue()
-    val guard =
-      project.tasks.getByName("validateComposePreviewDesktopRenderClasspath") as TaskInternal
-    assertThat(guard.onlyIf.isSatisfiedBy(guard)).isTrue()
-  }
-
-  @Test
-  fun `renderability is computed lazily so a desktop target added after registration is not skipped`() {
-    // Codex review on #1853: registerDesktopTasks runs at withPlugin time, BEFORE the consumer's
-    // `kotlin { jvm("desktop") }` block creates desktopRuntimeClasspath. Renderability must be
-    // resolved at task realization, not snapshotted eagerly — otherwise a cmp-shared module whose
-    // desktop config appears later is permanently treated as non-renderable and its render/bundle
-    // are wrongly skipped.
-    val project = ProjectBuilder.builder().withProjectDir(tmp.root).build()
-    val extension = project.extensions.create("composePreview", PreviewExtension::class.java)
-    // Pre-`jvm("desktop")` state: only the androidRuntimeClasspath fallback is visible.
-    project.configurations.create("androidRuntimeClasspath") {
-      isCanBeResolved = true
-      isCanBeConsumed = false
-    }
-
-    ComposePreviewTasks.registerDesktopTasks(project, extension)
-
-    // `jvm("desktop")` configures afterwards, creating the desktop runtime classpath.
-    project.configurations.create("desktopRuntimeClasspath") {
-      isCanBeResolved = true
-      isCanBeConsumed = false
-    }
-
-    // Realized now (after the desktop config exists): render AND bundle must observe it and stay
-    // renderable. A regression to an eager snapshot would skip them.
-    for (taskName in listOf("composePreviewRender", "composePreviewBundle")) {
+    // NOT skipped (these are realized during CLI detection — must behave as 0.15.2):
+    for (taskName in listOf("composePreviewDiscover", "composePreviewRender")) {
       val task = project.tasks.getByName(taskName) as TaskInternal
       assertThat(task.onlyIf.isSatisfiedBy(task)).isTrue()
     }
+  }
+
+  @Test
+  fun `renderable desktop module keeps the guard and daemon enabled`() {
+    // The canonical cmp-shared layout (desktopRuntimeClasspath present) must NOT skip anything.
+    val project = ProjectBuilder.builder().withProjectDir(tmp.root).build()
+    val extension = project.extensions.create("composePreview", PreviewExtension::class.java)
+    project.configurations.create("desktopRuntimeClasspath") {
+      isCanBeResolved = true
+      isCanBeConsumed = false
+    }
+    project.configurations.create("androidRuntimeClasspath") {
+      isCanBeResolved = true
+      isCanBeConsumed = false
+    }
+
+    ComposePreviewTasks.registerDesktopTasks(project, extension)
+
+    val guard =
+      project.tasks.getByName("validateComposePreviewDesktopRenderClasspath") as TaskInternal
+    assertThat(guard.onlyIf.isSatisfiedBy(guard)).isTrue()
+    val daemon = project.tasks.getByName("composePreviewDaemonStart") as TaskInternal
+    assertThat(daemon.onlyIf.isSatisfiedBy(daemon)).isTrue()
   }
 }

--- a/samples/cmp-android-only/build.gradle.kts
+++ b/samples/cmp-android-only/build.gradle.kts
@@ -34,6 +34,11 @@ kotlin {
     compileSdk = 36
     minSdk = 24
 
+    // The KMP-Android library plugin keeps android resource processing OFF by default. Material3
+    // / the downloadable-fonts provider reference the Google-Fonts certificate `R.array`, so the
+    // module won't compile without resources enabled.
+    androidResources.enable = true
+
     compilations.configureEach {
       compileTaskProvider.configure {
         compilerOptions { jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17) }

--- a/samples/cmp-android-only/build.gradle.kts
+++ b/samples/cmp-android-only/build.gradle.kts
@@ -1,0 +1,58 @@
+plugins {
+  id("composeai.base-conventions")
+  id("composeai.jvm-conventions")
+  // Same buildscript-classpath bundle story as `:samples:cmp-shared` — apply KGP, the
+  // KMP-Android plugin and `kotlin.plugin.compose` by id (no version) so they resolve from
+  // the AGP-provided classpath rather than erroring on an unknown-version alias.
+  id("org.jetbrains.kotlin.multiplatform")
+  id("com.android.kotlin.multiplatform.library")
+  alias(libs.plugins.compose.multiplatform)
+  id("org.jetbrains.kotlin.plugin.compose")
+  id("ee.schimke.composeai.preview")
+}
+
+// Regression coverage for #1852 / #1855: a `com.android.kotlin.multiplatform.library`
+// `:shared`-style module with NO `jvm("desktop")` target. Its only resolvable runtime
+// classpath is `androidRuntimeClasspath` (carrying `*-android` Compose AARs), so the Compose
+// Multiplatform Desktop renderer can't render it — the same shape as the consumer's
+// `:meshcore-mobile`. Two regressions ride on this shape, and this module is the standing
+// guard for both:
+//   * #1852 — resolving `androidRuntimeClasspath` for the desktop render trips an AGP variant
+//     ambiguity that, unguarded, hard-fails the whole `composePreviewRender` pipeline.
+//   * #1855 — the #1853 "skip non-renderable module" fix must NOT regress CLI detection of the
+//     OTHER modules in the build (0.15.3 regressed to "detect nothing"). The `apply`
+//     pipeline must still discover the renderable samples with this module present, and this
+//     module must be skipped fail-soft (no render, no hard failure) rather than sinking the run.
+//
+// Intentionally distinct from `:samples:cmp-shared`, which DOES add `jvm("desktop")` and is the
+// supported, renderable layout. Keep this one target-poor on purpose.
+
+kotlin {
+  // AGP 9 / KMP renamed the `androidLibrary { }` DSL block to `android { }`.
+  android {
+    namespace = "com.example.cmpandroidonly"
+    compileSdk = 36
+    minSdk = 24
+
+    compilations.configureEach {
+      compileTaskProvider.configure {
+        compilerOptions { jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17) }
+      }
+    }
+  }
+
+  // Deliberately NO `jvm("desktop")` target — that omission is what makes this module
+  // non-renderable and is the whole point of the regression fixture.
+
+  sourceSets {
+    androidMain.dependencies {
+      // Android-flavoured Compose (no desktop target to pull the JVM flavour), matching the
+      // real non-renderable shape. The `compose.*` accessors resolve to the `*-android`
+      // artifacts here.
+      @Suppress("DEPRECATION") implementation(compose.runtime)
+      @Suppress("DEPRECATION") implementation(compose.foundation)
+      @Suppress("DEPRECATION") implementation(compose.material3)
+      implementation("org.jetbrains.compose.ui:ui-tooling-preview:1.10.3")
+    }
+  }
+}

--- a/samples/cmp-android-only/src/androidMain/kotlin/com/example/cmpandroidonly/Previews.kt
+++ b/samples/cmp-android-only/src/androidMain/kotlin/com/example/cmpandroidonly/Previews.kt
@@ -1,0 +1,20 @@
+package com.example.cmpandroidonly
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+// An `androidMain`-only @Preview on a module with no `jvm("desktop")` target. The desktop
+// renderer can't drive it (the deps are `*-android` Compose), so the plugin must SKIP this
+// module fail-soft — without breaking discovery of the renderable sample modules (#1855).
+@Preview
+@Composable
+fun AndroidOnlyPreview() {
+  Box(modifier = Modifier.size(48.dp).background(Color.Magenta)) { Text("android-only") }
+}

--- a/samples/cmp-android-only/src/androidMain/kotlin/com/example/cmpandroidonly/Widgets.kt
+++ b/samples/cmp-android-only/src/androidMain/kotlin/com/example/cmpandroidonly/Widgets.kt
@@ -7,14 +7,14 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 
-// An `androidMain`-only @Preview on a module with no `jvm("desktop")` target. The desktop
-// renderer can't drive it (the deps are `*-android` Compose), so the plugin must SKIP this
-// module fail-soft — without breaking discovery of the renderable sample modules (#1855).
-@Preview
+// Deliberately NO `@Preview` — this fixture mirrors the consumer's `:meshcore-mobile`, a
+// non-UI / preview-less `com.android.kotlin.multiplatform.library` module. It still pulls
+// `*-android` Compose onto `androidRuntimeClasspath` (the 12-variant shape that trips #1852),
+// but discovery finds zero previews, so the desktop pipeline must skip it fail-soft AND must
+// keep discovering the renderable sample modules (#1855).
 @Composable
-fun AndroidOnlyPreview() {
+fun AndroidOnlyWidget() {
   Box(modifier = Modifier.size(48.dp).background(Color.Magenta)) { Text("android-only") }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -177,6 +177,11 @@ include(":samples:cmp")
 
 include(":samples:cmp-shared")
 
+// Non-renderable KMP-Android library (no `jvm("desktop")` target) — regression fixture for
+// #1852 / #1855. See its build.gradle.kts. Must coexist in the build without breaking CLI
+// discovery of the other sample modules.
+include(":samples:cmp-android-only")
+
 include(":samples:desktop-daemon-bench")
 
 include(":samples:remotecompose")


### PR DESCRIPTION
Fixes #1855. Re-fixes #1852 without the detection regression.

## Root cause of #1855
#1853 fixed #1852 by gating `composePreviewDiscover` / `composePreviewRender` on a "renderable" check (`resolveDependencyConfigName() == "androidRuntimeClasspath"`). But the Tooling-API model builder **realizes those two tasks** during CLI module detection, so that gating regressed 0.15.3 to "no modules have the plugin applied" for the *whole* build — including `com.android.application` and explicitly-applied modules. Reproduced here by `:samples:cmp-android-only` (a `com.android.kotlin.multiplatform.library` module with no `jvm("desktop")` target): with it present, the Apply job's `compose-preview show --json` produced an empty `_previews.json` and the a11y pipeline reported "no module applies the plugin" — exactly the consumer's symptom.

## The fix
1. **Revert the #1853 task gating** on discover/render back to the known-good 0.15.2 behavior → CLI detection is restored exactly as it was when it detected all 8 of the consumer's modules.
2. **Fix #1852 at the source — pin `artifactType`.** The desktop render/guard/daemon resolved the consumer runtime classpath through a bare `incoming.artifactView {}` (no attributes), which on a KMP-Android `androidRuntimeClasspath` (≈12 secondary variants — confirmed by the reporter via a direct Gradle resolve) fails with `AmbiguousArtifactsFailure`. Pinning `artifactType=jar` — exactly what `composePreviewDiscover` already does, which is why discovery survived 0.15.2 — selects a single jar variant. JVM/desktop classpaths pass through unchanged; `lenient` is applied only to the `androidRuntimeClasspath` fallback.
3. **Detection-safe skips.** The classpath guard and daemon-start task — which the model builder **never** realizes, so gating them cannot affect detection — are skipped for a non-renderable module. A preview-less KMP-Android library (the consumer's `:meshcore-mobile`) then discovers 0 previews and no-ops instead of hard-failing on the guard's `androidx.compose.ui` check.

Net: every module is detected again; `:samples:cmp-android-only` discovers 0 previews and no-ops; renderable cmp-shared/desktop modules are unchanged.

## Standing guard
`:samples:cmp-android-only` (now preview-less, matching `:meshcore-mobile`) stays in the build as the permanent CI fixture for both regressions — the Apply job exercises it on every PR.

## Test plan
- `gradle-plugin :test --tests KmpAndroidDesktopRoutingTest` ✅ (7 tests). New coverage:
  - `isDesktopRenderableConfig` is false only for `androidRuntimeClasspath`.
  - A non-renderable module skips **only** the guard + daemon (`onlyIf` unsatisfied) and **never** discover/render (those stay enabled — the detection-safety contract).
  - A renderable (desktop-target) module keeps guard + daemon enabled.
- CI **Apply compose-preview** job — the faithful AGP-KMP repro; must go from red (empty `_previews.json`) to green with this fix.
- Non-visual change (Gradle artifact-view resolution + task gating); no rendered evidence applies.