### PR TITLE
feat(mcp): default record_preview to the frames observation

### DIFF
--- a/docs/TOKEN_USAGE.md
+++ b/docs/TOKEN_USAGE.md
@@ -89,10 +89,18 @@ previews.
   diff-semantics` (CLI): a semantics-tree diff is a few hundred tokens
   per changed preview (no PNG reads) and reports *what* changed
   semantically rather than *that* pixels moved (issue #1785).
-- `record_preview` response size scales with `fps × duration`: each
-  captured frame adds a `frames[]` entry plus optional metadata. The
-  APNG/MP4 capture path keeps per-frame JSON small; embedded-PNG debug
-  mode grows fast.
+- `record_preview` **defaults to `observe: "frames"`** (issue #1860): the
+  structured per-frame observation only — `frames[]` (per-frame sha256 +
+  changed-pixel counts), `changedFrameCount`, and the on-disk frame/video
+  paths — with **no inline media**. The inline encoded bytes are what scale
+  with `fps × duration` and can dwarf a single PNG (an APNG of a 2 s / 12 fps
+  interaction is ~24 frames of base64 — easily 30–60 k tokens); the default
+  drops them entirely, leaving a few-hundred-token JSON observation regardless
+  of clip length. Pass `observe: "media"` only when you actually need the
+  pixels inline; the artifact is on disk at `videoPath` either way, so a local
+  agent can read it without re-recording. The per-frame `changed` /
+  `changedPixelsFromPrevious` signal is usually enough to assert "the click
+  changed the UI" without any pixels.
 - `render_preview` **defaults to `observe: "semantics"`** (issue #1787):
   the `compose/semantics` tree + sha256 + dimensions with **no base64** —
   typically a few hundred tokens for a small preview (scaling with node

--- a/docs/daemon/MCP.md
+++ b/docs/daemon/MCP.md
@@ -122,7 +122,7 @@ supervisor stops respawning.
 | `unsubscribe_preview_data(uri, kind)` | Drop a preview data-product subscription. |
 | `render_preview_overlay(uri, kind?, inline?, overrides?)` | Render a preview and return an annotated overlay image. |
 | `get_preview_extras(uri, kind)` | List non-JSON outputs produced alongside a data product. |
-| `record_preview(uri, fps?, scale?, format?, events, overrides?, emitTest?)` | Record a scripted preview interaction to APNG/MP4/WebM. With `emitTest: true`, also returns a runnable Compose UI test generated from the interaction (issue #1786) — target-bearing events become `onNodeWith…().performClick()` steps, and each `recording.probe` is diffed against the previous probe's captured semantics into `assertExists()` / `assertDoesNotExist()` assertions (falling back to a TODO stub when nothing assertable was captured). |
+| `record_preview(uri, fps?, scale?, format?, observe?, events, overrides?, emitTest?)` | Record a scripted preview interaction to APNG/MP4/WebM. `observe` defaults to `frames` — the structured per-frame observation (per-frame sha256 + changed-pixel counts, `changedFrameCount`, on-disk paths) with no inline media; `media` also returns the encoded bytes inline (the artifact is on disk at `videoPath` either way). Token-frugal default since recording bytes scale with fps × duration (issue #1860). With `emitTest: true`, also returns a runnable Compose UI test generated from the interaction (issue #1786) — target-bearing events become `onNodeWith…().performClick()` steps, and each `recording.probe` is diffed against the previous probe's captured semantics into `assertExists()` / `assertDoesNotExist()` assertions (falling back to a TODO stub when nothing assertable was captured). |
 
 The daemon's render queue is single-priority FIFO today, so `setVisible` /
 `setFocus` traffic flows through the wire but doesn't yet reorder the queue.
@@ -192,12 +192,21 @@ interactive-session payload variants and are **not** valid `record_preview`
 event ids — agents that send `{ "kind": "click" }` get rejected with
 `kind 'click' is not advertised by this daemon`. Prefix with `input.` instead.
 
-On success the tool returns an inline media block plus a JSON metadata text
-block containing `recordingId`, `videoPath`, `mimeType`, `sizeBytes`,
-`frameCount`, `durationMs`, `framesDir`, `frameWidthPx`, and
-`frameHeightPx`. It also includes `scriptEvents[]`, a per-event evidence list
-with `applied` or `unsupported` status. Raw PNG frames live at
-`<framesDir>/frame-00000.png`, `<framesDir>/frame-00001.png`, etc.
+On success the tool returns a JSON metadata text block containing `observe`,
+`recordingId`, `videoPath`, `mimeType`, `sizeBytes`, `frameCount`,
+`durationMs`, `framesDir`, `frameWidthPx`, and `frameHeightPx`, plus the
+`frames[]` per-frame observation (sha256 + changed-pixel counts) and
+`changedFrameCount` / first-last changed-frame paths. It also includes
+`scriptEvents[]`, a per-event evidence list with `applied` or `unsupported`
+status. Raw PNG frames live at `<framesDir>/frame-00000.png`,
+`<framesDir>/frame-00001.png`, etc.
+
+By default (`observe="frames"`) that text block is the whole result — no
+inline media, since a recording's base64 bytes scale with fps × duration and
+can dwarf a single PNG (issue #1860). Pass `observe="media"` to lead the
+result with the encoded bytes inline (APNG as an `image` block, mp4/webm as an
+`EmbeddedResource` blob); the encoded artifact is on disk at `videoPath` either
+way.
 
 Sandbox note: Android recordings run through Robolectric. Restricted agent
 sandboxes must allow Robolectric to create its host cache/lock files,

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
@@ -1701,11 +1701,16 @@ class DaemonMcpServer(
       ToolDef(
         name = "record_preview",
         description =
-          "Record a scripted screen-recording of an interactive preview and return the encoded " +
-            "video bytes. Drives the daemon's recording surface (RECORDING.md) end-to-end: open a " +
+          "Record a scripted screen-recording of an interactive preview. Drives the daemon's " +
+            "recording surface (RECORDING.md) end-to-end: open a " +
             "held-scene session at the requested fps + scale, post the script of `(tMs, kind, " +
-            "pixelX, pixelY)` events, play back the timeline at virtual frame time, encode to APNG " +
-            "and return the bytes inline as a base64 image content block. " +
+            "pixelX, pixelY)` events, play back the timeline at virtual frame time, and encode to " +
+            "APNG/MP4/WebM on disk. " +
+            "**Token-frugal default (issue #1860).** `observe` defaults to `frames`: the result is " +
+            "the structured per-frame observation (hashes + changed-frame indices + on-disk paths), " +
+            "NOT the inline media — a recording's base64 bytes scale with fps × duration and can " +
+            "dwarf a single PNG. Pass `observe=\"media\"` to also get the encoded bytes inline (the " +
+            "pre-#1860 behaviour); the artifact is always on disk at `videoPath` either way. " +
             "**Why virtual time matters.** Pointer events and `scene.render` both key off the " +
             "session's virtual nanoTime, so a script of `(tMs=0, click) + (tMs=500, click)` always " +
             "produces 500ms of inter-click animation in the output regardless of how long the " +
@@ -1734,6 +1739,7 @@ class DaemonMcpServer(
                 "fps":{"type":"integer","description":"Frames per second of the virtual clock. Default 30; range [1, 120]."},
                 "scale":{"type":"number","description":"Output-frame size multiplier. Default 1.0; range (0, 8]. Pointer coords stay in image-natural pixel space."},
                 "format":{"type":"string","enum":["apng","mp4","webm"],"description":"Encoded video format. Default 'apng' (always available, pure-JVM). 'mp4' and 'webm' require an ffmpeg binary on the daemon's PATH; check ServerCapabilities.recordingFormats first or expect a clean rejection if unavailable."},
+                "observe":{"type":"string","enum":["frames","media"],"description":"Observation level (issue #1860). Default 'frames' returns the structured per-frame observation — per-frame sha256 + changed-pixel counts, changedFrameCount, and the on-disk frame/video paths — with NO inline media (token-frugal; recording bytes scale with fps × duration). 'media' also returns the encoded APNG/MP4/WebM bytes inline (APNG as an image block, mp4/webm as an embedded resource). The artifact is on disk at 'videoPath' regardless of this flag."},
                 "emitTest":{"type":"boolean","description":"Default false. When true, also return a runnable Compose UI test generated from this interaction (issue #1786) as an extra text block — each event with a testTag/role/text target becomes an onNodeWith…().performClick() step, and each recording.probe is diffed against the previous probe's captured semantics into assertExists()/assertDoesNotExist() assertions (a TODO stub when nothing assertable was captured). Write it to src/test and review the inferred probe assertions."},
                 "events":{
                   "type":"array",
@@ -3628,6 +3634,14 @@ class DaemonMcpServer(
             "record_preview: unsupported 'format' '$formatStr' — supported: apng, mp4, webm"
           )
       }
+    // Issue #1860: token-frugal default. `frames` returns the structured per-frame observation
+    // (hashes + changed-frame indices + the on-disk paths) with NO inline media; `media` opts into
+    // the encoded APNG/MP4/WebM bytes inline (the pre-#1860 behaviour). Mirrors render_preview's
+    // observe split: a recording's inline bytes scale with fps × duration and can dwarf a PNG.
+    val observe = args["observe"]?.jsonPrimitive?.contentOrNull?.lowercase() ?: "frames"
+    if (observe !in setOf("frames", "media")) {
+      return errorCallToolResult("record_preview: 'observe' must be one of frames | media")
+    }
     val overrides =
       args["overrides"]?.let {
         runCatching { decodePreviewOverrides(it) }
@@ -3696,8 +3710,18 @@ class DaemonMcpServer(
         val stopResult = daemon.client.recordingStop(recordingId)
         val frameMetadata = inspectRecordingFrames(File(stopResult.framesDir))
         val encoded = daemon.client.recordingEncode(recordingId, format)
-        val videoBytes = fileSystem.read(File(encoded.videoPath).path.toPath()) { readByteArray() }
+        // Only read the encoded bytes when the caller opted into inline media (observe="media");
+        // the default frames observation never touches them (issue #1860).
+        val videoBytes by lazy {
+          fileSystem.read(File(encoded.videoPath).path.toPath()) { readByteArray() }
+        }
         val payload = buildJsonObject {
+          put("observe", observe)
+          if (observe == "frames") {
+            // The encoded artifact still exists on disk at `videoPath`; re-call with
+            // observe="media" to get the bytes inline.
+            put("mediaInline", false)
+          }
           put("recordingId", recordingId)
           put("videoPath", encoded.videoPath)
           put("mimeType", encoded.mimeType)
@@ -3761,24 +3785,30 @@ class DaemonMcpServer(
         // strict clients reject mismatches. APNG (`image/apng`) round-trips as an image; mp4 /
         // webm route through `EmbeddedResource` wrapping a `Blob` so a client that already
         // understands `resources/read` reads them via the same code path.
-        val base64 = Base64.getEncoder().encodeToString(videoBytes)
-        val mediaBlock: ContentBlock =
-          if (encoded.mimeType.startsWith("image/")) {
-            ContentBlock.Image(data = base64, mimeType = encoded.mimeType)
+        val mediaBlock: ContentBlock? =
+          if (observe != "media") {
+            null
+          } else if (encoded.mimeType.startsWith("image/")) {
+            ContentBlock.Image(
+              data = Base64.getEncoder().encodeToString(videoBytes),
+              mimeType = encoded.mimeType,
+            )
           } else {
             ContentBlock.EmbeddedResource(
               resource =
                 ResourceContents.Blob(
                   uri = "compose-preview-recording://$recordingId",
                   mimeType = encoded.mimeType,
-                  blob = base64,
+                  blob = Base64.getEncoder().encodeToString(videoBytes),
                 )
             )
           }
         CallToolResult(
           content =
             buildList {
-              add(mediaBlock)
+              // observe="media" (opt-in): the inline APNG/MP4/WebM bytes lead the result, as
+              // before. observe="frames" (default): structured per-frame observation only.
+              mediaBlock?.let { add(it) }
               add(ContentBlock.Text(payload.toString()))
               // #1786 — opt-in: turn the recorded interaction into a runnable Compose UI test
               // (the codegen analogue). Built from the recording's applied evidence so an

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
@@ -1705,6 +1705,7 @@ class DaemonMcpServerTest {
           put("uri", uri)
           put("fps", 30)
           put("scale", 4.0)
+          put("observe", "media")
           putJsonArray("events") {
             add(
               buildJsonObject {
@@ -1838,6 +1839,80 @@ class DaemonMcpServerTest {
       .isEqualTo(0)
     assertThat(metadata["sizeBytes"]?.jsonPrimitive?.contentOrNull?.toLongOrNull())
       .isEqualTo(cannedApngBytes.size.toLong())
+  }
+
+  @Test
+  fun `record_preview defaults to the frames observation with no inline media`() {
+    // Issue #1860 acceptance criterion: a bare record_preview (no `observe`) returns the structured
+    // per-frame observation — frames[] + changedFrameCount + on-disk paths — and NO inline media
+    // block. Bytes are opt-in via observe="media"; the encoded artifact stays on disk at videoPath.
+    val framesDir = tmp.newFolder("frames-default")
+    writeSolidPng(framesDir.resolve("frame-00000.png"), 0xFF000000.toInt())
+    writeSolidPng(framesDir.resolve("frame-00001.png"), 0xFFFFFFFF.toInt())
+    val recordingsDir = tmp.newFolder("frames-default-out")
+    factory.daemonConfigurer = { d ->
+      d.recordingEncodedBytes = byteArrayOf(-119, 80, 78, 71, 13, 10, 26, 10, 0x01, 0x02)
+      d.recordingEncodeDir = recordingsDir
+      d.advertisedDataExtensions =
+        listOf(ee.schimke.composeai.daemon.InputTouchRecordingScriptEvents.descriptor)
+      d.recordingStopResult =
+        ee.schimke.composeai.daemon.protocol.RecordingStopResult(
+          frameCount = 2,
+          durationMs = 100L,
+          framesDir = framesDir.absolutePath,
+          frameWidthPx = 120,
+          frameHeightPx = 40,
+          scriptEvents = emptyList(),
+        )
+    }
+    client.initialize()
+    val projectDir = tmp.newFolder("frames-default-workspace")
+    tmp.newFolder("frames-default-workspace", "module")
+    val workspaceId = registerWorkspace(projectDir, "demo")
+    val daemon = warmDaemonFor(workspaceId, ":module")
+    val previewId = "com.example.Red"
+    daemon.emitDiscovery(previewId)
+    client.expectNotification("notifications/resources/list_changed", 2_000)
+
+    val uri = PreviewUri(workspaceId, ":module", previewId).toUri()
+    val resp =
+      client.callTool(
+        "record_preview",
+        buildJsonObject {
+          put("uri", uri)
+          putJsonArray("events") {
+            add(
+              buildJsonObject {
+                put("tMs", 0)
+                put("kind", "input.click")
+                put("pixelX", 10)
+                put("pixelY", 10)
+              }
+            )
+          }
+        },
+        timeoutMs = 10_000,
+      )
+
+    assertThat(resp.isError()).isFalse()
+    // Single text block — no image / embedded-resource media rode along by default.
+    val blocks = resp.raw["content"]!!.jsonArray
+    assertThat(blocks).hasSize(1)
+    assertThat(blocks.single().jsonObject["type"]?.jsonPrimitive?.contentOrNull).isEqualTo("text")
+
+    val metadata = json.parseToJsonElement(resp.firstTextContent()).jsonObject
+    assertThat(metadata["observe"]?.jsonPrimitive?.contentOrNull).isEqualTo("frames")
+    assertThat(metadata["mediaInline"]?.jsonPrimitive?.contentOrNull).isEqualTo("false")
+    // The encoded artifact is still produced and addressable on disk.
+    assertThat(metadata["videoPath"]?.jsonPrimitive?.contentOrNull).isNotEmpty()
+    assertThat(metadata["mimeType"]?.jsonPrimitive?.contentOrNull).isEqualTo("image/apng")
+    // The structured per-frame observation is present (the whole point of the default).
+    assertThat(metadata["changedFrameCount"]?.jsonPrimitive?.contentOrNull?.toIntOrNull())
+      .isEqualTo(1)
+    val frames = metadata["frames"]!!.jsonArray
+    assertThat(frames).hasSize(2)
+    assertThat(frames[1].jsonObject["changedFromPrevious"]?.jsonPrimitive?.contentOrNull)
+      .isEqualTo("true")
   }
 
   @Test
@@ -2471,6 +2546,7 @@ class DaemonMcpServerTest {
         buildJsonObject {
           put("uri", uri)
           put("format", "mp4")
+          put("observe", "media")
           putJsonArray("events") {
             add(
               buildJsonObject {


### PR DESCRIPTION
## Summary

Closes #1860. Applies the structured-first / pixels-on-demand split from #1787 to the recording loop. `record_preview` gains an `observe` parameter:

- **`observe="frames"` (default):** the structured per-frame observation only — `frames[]` (per-frame `sha256` + changed-pixel counts), `changedFrameCount`, and the on-disk frame/video paths — with **no inline media**. A recording's base64 bytes scale with `fps × duration` and can dwarf a single PNG, so the default drops them entirely.
- **`observe="media"`:** also returns the encoded APNG/MP4/WebM bytes inline (the pre-#1860 behaviour) — APNG as an `image` block, mp4/webm as an `EmbeddedResource` blob.

The encoded artifact is on disk at `videoPath` either way (on-disk frame artifacts are unchanged / out of scope), and the encoded bytes are now read **lazily** — the default path never touches the file.

## Acceptance criteria (issue #1860)

- [x] A default `record_preview` response carries per-frame hashes + changed-frame indices, not inline media bytes, unless explicitly requested.
- [x] The opt-in path (`observe="media"`) returns the inline media (APNG / MP4 / WebM) exactly as today.
- [x] Measured token reduction documented for a representative recording.

## Test plan

- [x] `./gradlew :mcp:ktfmtCheck :mcp:test` — passes.
- [x] New `record_preview defaults to the frames observation with no inline media` test: a bare call returns a single text block (no image/embedded-resource), `observe="frames"`, `mediaInline=false`, `videoPath` present, and the `frames[]` / `changedFrameCount` observation populated.
- [x] The existing APNG-inline and mp4 embedded-resource tests now pass `observe="media"` (their intent is the inline-media path); `emitTest`, rejection, and tool-list tests unchanged (`observe` is a field, not a new tool).
- [x] `docs/daemon/MCP.md` + `docs/TOKEN_USAGE.md` updated with the new default and the budget delta.

Non-visual change (tool response shape + docs + tests), so no rendered-preview evidence applies. Pairs with the lockstep skill-bundle update yschimke/skills `agent/issue-1860-record-observe`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E9YCPujYKb12wtEYtUpzMr)_