### PR TITLE
feat(daemon): archive a11y + theme data products with each history entry

### DIFF
--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -1273,25 +1273,17 @@ class JsonRpcServer(
           config = null,
         )
       }
-    // Snapshot the `compose/semantics` tree this render produced (issue #1785) so a later
-    // `history/diff mode=SEMANTICS` can diff two entries structurally. Opportunistic: the inline
-    // fetch returns the payload only when the producer wrote the artefact for this pass (it never
-    // forces a re-render — a missing file is NotAvailable, not RequiresRerender), so renders that
-    // didn't compute semantics simply record `semantics = null`.
-    val semantics =
-      try {
-        val outcome =
-          extensions
-            .publicDataProducts()
-            .fetch(previewId, ComposeSemanticsProduct.KIND, params = null, inline = true)
-        (outcome as? DataProductRegistry.Outcome.Ok)?.result?.payload
-      } catch (t: Throwable) {
-        System.err.println(
-          "compose-ai-daemon: history: compose/semantics fetch for $previewId failed " +
-            "(${t.javaClass.simpleName}: ${t.message}); recording entry without a semantics snapshot"
-        )
-        null
-      }
+    // Snapshot the structured data products this render produced (issues #1785, #1869) so a later
+    // data diff can compare two entries without pixels. Opportunistic: each inline fetch returns a
+    // payload only when the producer wrote that artefact for this pass (it never forces a
+    // re-render — a missing file is NotAvailable, not RequiresRerender), so a render that didn't
+    // compute a given kind simply records null for it. a11y/theme kinds use literal strings to keep
+    // daemon-core off the :data-a11y-core / :data-theme-core build edges.
+    val semantics = fetchHistorySnapshot(previewId, ComposeSemanticsProduct.KIND)
+    val a11yAtf = fetchHistorySnapshot(previewId, "a11y/atf")
+    val a11yHierarchy = fetchHistorySnapshot(previewId, "a11y/hierarchy")
+    val a11yTouchTargets = fetchHistorySnapshot(previewId, "a11y/touchTargets")
+    val theme = fetchHistorySnapshot(previewId, "compose/theme")
     val entry =
       try {
         mgr.recordRender(
@@ -1303,6 +1295,10 @@ class JsonRpcServer(
           metrics = finished.metrics,
           previewMetadata = previewMetadata,
           semantics = semantics,
+          a11yAtf = a11yAtf,
+          a11yHierarchy = a11yHierarchy,
+          a11yTouchTargets = a11yTouchTargets,
+          theme = theme,
         )
       } catch (t: Throwable) {
         System.err.println(
@@ -1322,12 +1318,37 @@ class JsonRpcServer(
     }
   }
 
-  // Strips the heavy captured `semantics` snapshot (issue #1785) before echoing an entry on the
-  // wire: `history/list` / `history/read` / `historyAdded` / metadata-mode `history/diff` only want
-  // metadata, and the tree is read back off the sidecar exclusively by `history/diff
-  // mode=SEMANTICS`.
+  // Opportunistically fetch a data-product payload to freeze into the history entry (issues #1785,
+  // #1869). Inline and never forces a re-render; any failure or unavailable kind yields null so
+  // history recording stays best-effort and never affects the render itself.
+  private fun fetchHistorySnapshot(previewId: String, kind: String): JsonElement? =
+    try {
+      val outcome =
+        extensions.publicDataProducts().fetch(previewId, kind, params = null, inline = true)
+      (outcome as? DataProductRegistry.Outcome.Ok)?.result?.payload
+    } catch (t: Throwable) {
+      System.err.println(
+        "compose-ai-daemon: history: $kind fetch for $previewId failed " +
+          "(${t.javaClass.simpleName}: ${t.message}); recording entry without it"
+      )
+      null
+    }
+
+  // Strips the heavy captured snapshots (semantics #1785, a11y/theme data products #1869) before
+  // echoing an entry on the wire: `history/list` / `history/read` / `historyAdded` / metadata-mode
+  // `history/diff` only want metadata. The payloads are read back off the sidecar exclusively by
+  // `history/diff mode=SEMANTICS` and (later) the data-diff surfaces.
   private fun encodeHistoryEntry(entry: HistoryEntry): JsonElement =
-    json.encodeToJsonElement(HistoryEntry.serializer(), entry.copy(semantics = null))
+    json.encodeToJsonElement(
+      HistoryEntry.serializer(),
+      entry.copy(
+        semantics = null,
+        a11yAtf = null,
+        a11yHierarchy = null,
+        a11yTouchTargets = null,
+        theme = null,
+      ),
+    )
 
   private fun handleHistoryList(req: JsonRpcRequest) {
     val params =

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -1275,14 +1275,23 @@ class JsonRpcServer(
       }
     // Snapshot the structured data products this render produced (issues #1785, #1869) so a later
     // data diff can compare two entries without pixels. Opportunistic: each inline fetch returns a
-    // payload only when the producer wrote that artefact for this pass (it never forces a
+    // payload only when the producer wrote the artefact for this pass (it never forces a
     // re-render — a missing file is NotAvailable, not RequiresRerender), so a render that didn't
     // compute a given kind simply records null for it. a11y/theme kinds use literal strings to keep
     // daemon-core off the :data-a11y-core / :data-theme-core build edges.
+    //
+    // Freshness gate (a11y): a11y artefacts are file-backed and (re)written ONLY on an a11y-mode
+    // render; a normal render leaves a prior a11y render's files on disk, so an unconditional fetch
+    // would freeze STALE a11y data into this entry and corrupt data diffs. Capture the a11y kinds
+    // only when this render actually ran a11y. compose/semantics is written every render, and
+    // compose/theme's in-memory registry self-clears when a render doesn't capture it (fetch then
+    // returns RequiresRerender, not stale Ok) — so both are fresh-or-null and need no gate.
+    val a11yFresh = result.previewContext?.renderMode == "a11y"
     val semantics = fetchHistorySnapshot(previewId, ComposeSemanticsProduct.KIND)
-    val a11yAtf = fetchHistorySnapshot(previewId, "a11y/atf")
-    val a11yHierarchy = fetchHistorySnapshot(previewId, "a11y/hierarchy")
-    val a11yTouchTargets = fetchHistorySnapshot(previewId, "a11y/touchTargets")
+    val a11yAtf = if (a11yFresh) fetchHistorySnapshot(previewId, "a11y/atf") else null
+    val a11yHierarchy = if (a11yFresh) fetchHistorySnapshot(previewId, "a11y/hierarchy") else null
+    val a11yTouchTargets =
+      if (a11yFresh) fetchHistorySnapshot(previewId, "a11y/touchTargets") else null
     val theme = fetchHistorySnapshot(previewId, "compose/theme")
     val entry =
       try {

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryEntry.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryEntry.kt
@@ -40,7 +40,10 @@ import kotlinx.serialization.json.JsonElement
  *   per-render `a11y/atf`, `a11y/hierarchy`, `a11y/touchTargets` and `compose/theme` payloads
  *   captured alongside this render (issue #1869), so history covers structured **data**, not just
  *   pixels — a later data diff can answer "what were this preview's a11y findings a commit ago?".
- *   Each is null when the producer didn't compute that kind for this pass. Handled exactly like
+ *   Each is null when the producer didn't compute that kind for this pass. The a11y kinds are
+ *   captured only on an a11y-mode render: their artefacts are file-backed and not cleared between
+ *   renders, so a normal render must NOT freeze a prior a11y render's stale files (the freshness
+ *   gate lives in `JsonRpcServer.recordHistoryForRender`). Otherwise handled exactly like
  *   [semantics]: heavy, sidecar-only, stripped from `index.jsonl` and the wire surfaces; the
  *   reporting-branch writer (issue #1870) projects them into the per-product files (`a11y.json`,
  *   `theme.json`, …) described in docs/daemon/REPORTING-BRANCH.md, validated by the published

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryEntry.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryEntry.kt
@@ -36,6 +36,15 @@ import kotlinx.serialization.json.JsonElement
  *   it lives only in the per-entry sidecar: it's stripped from the lean `index.jsonl` (like
  *   [previewMetadata]) and never echoed on the `history/list` / `history/read` / `historyAdded`
  *   wire surfaces — only `history/diff mode=SEMANTICS` reads it back off disk.
+ * - **Data-product snapshots** — [a11yAtf], [a11yHierarchy], [a11yTouchTargets], [theme]. The
+ *   per-render `a11y/atf`, `a11y/hierarchy`, `a11y/touchTargets` and `compose/theme` payloads
+ *   captured alongside this render (issue #1869), so history covers structured **data**, not just
+ *   pixels — a later data diff can answer "what were this preview's a11y findings a commit ago?".
+ *   Each is null when the producer didn't compute that kind for this pass. Handled exactly like
+ *   [semantics]: heavy, sidecar-only, stripped from `index.jsonl` and the wire surfaces; the
+ *   reporting-branch writer (issue #1870) projects them into the per-product files (`a11y.json`,
+ *   `theme.json`, …) described in docs/daemon/REPORTING-BRANCH.md, validated by the published
+ *   schemas under `schema/`.
  */
 @Serializable
 data class HistoryEntry(
@@ -58,6 +67,10 @@ data class HistoryEntry(
   val previousId: String? = null,
   val deltaFromPrevious: HistoryDelta? = null,
   val semantics: JsonElement? = null,
+  val a11yAtf: JsonElement? = null,
+  val a11yHierarchy: JsonElement? = null,
+  val a11yTouchTargets: JsonElement? = null,
+  val theme: JsonElement? = null,
 )
 
 /**

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryManager.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryManager.kt
@@ -96,6 +96,10 @@ class HistoryManager(
     metrics: RenderMetrics? = null,
     previewMetadata: PreviewMetadataSnapshot? = null,
     semantics: JsonElement? = null,
+    a11yAtf: JsonElement? = null,
+    a11yHierarchy: JsonElement? = null,
+    a11yTouchTargets: JsonElement? = null,
+    theme: JsonElement? = null,
     timestamp: Instant = Instant.now(),
   ): HistoryEntry? {
     if (!isEnabled) return null
@@ -146,6 +150,10 @@ class HistoryManager(
         previousId = previousId,
         deltaFromPrevious = delta,
         semantics = semantics,
+        a11yAtf = a11yAtf,
+        a11yHierarchy = a11yHierarchy,
+        a11yTouchTargets = a11yTouchTargets,
+        theme = theme,
       )
 
     var anyWritten = false

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/LocalFsHistorySource.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/LocalFsHistorySource.kt
@@ -126,11 +126,19 @@ class LocalFsHistorySource(private val historyDir: Path) : HistorySource {
     sidecarFile.writeText(sidecarText, StandardCharsets.UTF_8)
 
     // index.jsonl append. Build a "lite" form by encoding the same entry minus the heavy
-    // previewMetadata + semantics snapshots — readers fetch the full sidecar via `history/read`
-    // (metadata) or `history/diff mode=SEMANTICS` (the tree). HISTORY.md § "index.jsonl" says:
-    // "same fields as the sidecar minus `previewMetadata`"; the semantics tree is kept out for the
-    // same reason — it would bloat every listing line.
-    val indexEntry = canonicalEntry.copy(previewMetadata = null, semantics = null)
+    // previewMetadata + semantics + data-product (a11y / theme) snapshots. Readers fetch the full
+    // sidecar via `history/read` (metadata) or a data diff (the payloads). Per HISTORY.md §
+    // "index.jsonl" the index keeps the same fields as the sidecar minus previewMetadata; the
+    // captured payloads are kept out for the same reason — they would bloat every listing line.
+    val indexEntry =
+      canonicalEntry.copy(
+        previewMetadata = null,
+        semantics = null,
+        a11yAtf = null,
+        a11yHierarchy = null,
+        a11yTouchTargets = null,
+        theme = null,
+      )
     val indexLine = JSON.encodeToString(HistoryEntry.serializer(), indexEntry) + "\n"
     val indexFile = historyDir.resolve(INDEX_FILENAME)
     Files.write(

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/LocalFsHistorySourceWriteTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/LocalFsHistorySourceWriteTest.kt
@@ -7,6 +7,7 @@ import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -79,6 +80,66 @@ class LocalFsHistorySourceWriteTest {
     assertEquals(3, indexLines.size)
     val ids = indexLines.map { json.decodeFromString(HistoryEntry.serializer(), it).id }
     assertEquals(entries.map { it.first.id }, ids)
+  }
+
+  @Test
+  fun data_products_persist_in_sidecar_but_are_stripped_from_index() {
+    // Issue #1869 — the a11y/theme payloads captured per render must round-trip through the full
+    // sidecar (so a later data diff can read them back) yet stay out of the lean index.jsonl,
+    // exactly like the semantics snapshot (#1785).
+    val source = LocalFsHistorySource(historyDir = tmpDir)
+    val previewId = "com.example.Card"
+    val bytes = byteArrayOf(0x01, 0x02, 0x03, 0x04)
+    val hash = LocalFsHistorySource.sha256Hex(bytes)
+    val atf =
+      json.parseToJsonElement(
+        """{"findings":[{"level":"ERROR","type":"TouchTargetSizeCheck","message":"too small"}]}"""
+      )
+    val hierarchy =
+      json.parseToJsonElement("""{"nodes":[{"label":"Submit","boundsInScreen":"0,0,10,10"}]}""")
+    val touch =
+      json.parseToJsonElement(
+        """{"targets":[{"nodeId":"n2","boundsInScreen":"0,0,10,10","widthDp":10.0,"heightDp":10.0,"findings":["belowMinimumSize"]}]}"""
+      )
+    val theme =
+      json.parseToJsonElement(
+        """{"resolvedTokens":{"colorScheme":{"primary":"#FF0000"},"typography":{},"shapes":{}}}"""
+      )
+
+    val entry =
+      makeEntry(
+        id = "20260430-101010-${hash.take(8)}",
+        previewId = previewId,
+        hash = hash,
+        size = bytes.size.toLong(),
+        a11yAtf = atf,
+        a11yHierarchy = hierarchy,
+        a11yTouchTargets = touch,
+        theme = theme,
+      )
+    assertEquals(WriteResult.WRITTEN, source.write(entry, bytes))
+
+    val sidecar =
+      json.decodeFromString(
+        HistoryEntry.serializer(),
+        Files.readString(tmpDir.resolve(previewId).resolve("${entry.id}.json")),
+      )
+    assertEquals("a11y/atf snapshot survives in the sidecar", atf, sidecar.a11yAtf)
+    assertEquals(hierarchy, sidecar.a11yHierarchy)
+    assertEquals(touch, sidecar.a11yTouchTargets)
+    assertEquals("compose/theme snapshot survives in the sidecar", theme, sidecar.theme)
+
+    val indexLines =
+      Files.readAllLines(tmpDir.resolve(LocalFsHistorySource.INDEX_FILENAME)).filter {
+        it.isNotBlank()
+      }
+    assertEquals(1, indexLines.size)
+    val indexEntry = json.decodeFromString(HistoryEntry.serializer(), indexLines.single())
+    assertEquals(entry.id, indexEntry.id)
+    assertNull("a11y/atf must be stripped from the lean index line", indexEntry.a11yAtf)
+    assertNull(indexEntry.a11yHierarchy)
+    assertNull(indexEntry.a11yTouchTargets)
+    assertNull("compose/theme must be stripped from the lean index line", indexEntry.theme)
   }
 
   @Test
@@ -395,6 +456,10 @@ class LocalFsHistorySourceWriteTest {
     hash: String,
     size: Long,
     semantics: JsonElement? = null,
+    a11yAtf: JsonElement? = null,
+    a11yHierarchy: JsonElement? = null,
+    a11yTouchTargets: JsonElement? = null,
+    theme: JsonElement? = null,
   ): HistoryEntry =
     HistoryEntry(
       id = id,
@@ -409,6 +474,10 @@ class LocalFsHistorySourceWriteTest {
       source = HistorySourceInfo(kind = "fs", id = "fs:${tmpDir.toAbsolutePath()}"),
       renderTookMs = 1L,
       semantics = semantics,
+      a11yAtf = a11yAtf,
+      a11yHierarchy = a11yHierarchy,
+      a11yTouchTargets = a11yTouchTargets,
+      theme = theme,
     )
 
   /** A one-node `compose/semantics` payload as a [JsonElement], for seeding sidecars. */

--- a/docs/daemon/HISTORY.md
+++ b/docs/daemon/HISTORY.md
@@ -71,7 +71,14 @@ renders inside the same second.
   "previousId": "20260430-101207-9f8e7d6c",
   "deltaFromPrevious": { "pngHashChanged": true, "diffPx": 142, "ssim": null },
 
-  "semantics": { "root": { "nodeId": "1", "ref": "r", ... } }  // compose/semantics, frozen at render time (#1785)
+  "semantics": { "root": { "nodeId": "1", "ref": "r", ... } },  // compose/semantics, frozen at render time (#1785)
+
+  // Per-render data-product snapshots, frozen at render time (#1869). Each is null when the
+  // producer didn't compute that kind for this render.
+  "a11yAtf":          { "findings": [ ... ] },   // a11y/atf
+  "a11yHierarchy":    { "nodes": [ ... ] },       // a11y/hierarchy
+  "a11yTouchTargets": { "targets": [ ... ] },     // a11y/touchTargets
+  "theme":            { "resolvedTokens": { ... } } // compose/theme
 }
 ```
 
@@ -79,10 +86,15 @@ The entry shape is published as a JSON schema —
 [`schema/history-entry.schema.json`](../../schema/history-entry.schema.json) —
 and the per-render data products archived alongside it (a11y, semantics,
 theme, …) have their own schemas under [`schema/`](../../schema/README.md).
+The reporting branch (#1870) projects these inline snapshots into the
+per-product files (`a11y.json`, `theme.json`, …) described in
+[`REPORTING-BRANCH.md`](REPORTING-BRANCH.md).
 
-`index.jsonl` carries the same fields minus the two heavy snapshots,
-`previewMetadata` and `semantics` — readers fetch the full sidecar via
-`history/read` (metadata) or `history/diff mode=semantics` (the tree).
+`index.jsonl` carries the same fields minus the heavy snapshots —
+`previewMetadata`, `semantics`, and the data-product snapshots
+(`a11yAtf` / `a11yHierarchy` / `a11yTouchTargets` / `theme`) — readers fetch
+the full sidecar via `history/read` (metadata) or `history/diff mode=semantics`
+(the tree).
 Opened in `O_APPEND` mode — each line is under POSIX `PIPE_BUF` so writes
 are atomic.
 

--- a/schema/history-entry.schema.json
+++ b/schema/history-entry.schema.json
@@ -99,7 +99,11 @@
         "previewMetadata": { "$ref": "#/definitions/PreviewMetadataSnapshot" },
         "previousId": { "type": ["string", "null"] },
         "deltaFromPrevious": { "$ref": "#/definitions/HistoryDelta" },
-        "semantics": { "description": "Optional inline semantics snapshot (JSON); see compose-semantics.schema.json." }
+        "semantics": { "description": "Optional inline compose/semantics payload captured at render time (#1785); see compose-semantics.schema.json." },
+        "a11yAtf": { "description": "Optional inline a11y/atf payload captured at render time (#1869); see a11y-atf.schema.json." },
+        "a11yHierarchy": { "description": "Optional inline a11y/hierarchy payload captured at render time (#1869); see a11y-hierarchy.schema.json." },
+        "a11yTouchTargets": { "description": "Optional inline a11y/touchTargets payload captured at render time (#1869); see a11y-touch-targets.schema.json." },
+        "theme": { "description": "Optional inline compose/theme payload captured at render time (#1869); see compose-theme.schema.json." }
       }
     }
   },


### PR DESCRIPTION
Second foundation issue of the report-history epic (#1866), building on the contracts merged in #1874. Makes a history entry **multi-product** so history covers structured **data**, not just pixels.

Closes #1869.

## Approach

Mirrors the just-merged `semantics` snapshot (#1785) exactly, rather than introducing a new sibling-file layout + write-signature change — lowest-risk, consistent with merged code:

- **`HistoryEntry`** gains four inline snapshot fields — `a11yAtf`, `a11yHierarchy`, `a11yTouchTargets`, `theme` (`JsonElement?`, null when the producer didn't compute that kind).
- **`recordHistoryForRender`** captures each per render via a shared opportunistic `fetchHistorySnapshot` helper: inline fetch, never forces a re-render, best-effort (a failure/unavailable kind → null, never affects the render). a11y/theme use literal kind strings so `daemon-core` doesn't gain `:data-a11y-core` / `:data-theme-core` build edges.
- Persisted in the **full sidecar**; **stripped from the lean `index.jsonl` and every wire echo** (`history/list` / `history/read` / `historyAdded`), identically to `semantics`.

The separate, git-diffable `a11y.json` / `theme.json` files described in `REPORTING-BRANCH.md` (#1868) and the published schemas (#1867) are the **reporting-branch projection**, produced by the writer in **#1870** — this PR lands the capture/persist half in the local FS source. Surfacing/diffing these over time is #1872/#1873 (exactly as `mode=SEMANTICS` consumes `semantics`).

Dedup is unchanged: tier-1 still keys on pixels + semantics; a11y/theme ride along in the sidecar.

## Test plan

- New `LocalFsHistorySourceWriteTest.data_products_persist_in_sidecar_but_are_stripped_from_index` — asserts the four payloads round-trip in the sidecar and are absent from the index line.
- `./gradlew :daemon:core:compileKotlin` passes locally; `:daemon:core:ktfmtFormat` applied. Existing `recordRender` callers compile unchanged (new params default to null).

Non-visual change (daemon data plumbing), so no rendered evidence applies.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CPjwnCtY5aiBTFkVrrFjhS)_