### PR TITLE
fix(cli): don't inject the plugin classpath into ancestors of a pre-applied module (#1855)

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/AutoInject.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/AutoInject.kt
@@ -415,7 +415,22 @@ allprojects {
         composeAiPreviewSettingsHasExclusiveContent &&
             projectDir !in composeAiPreviewProjectsWithOwnBuildscriptRepos
 
+    // Gradle inherits a project's buildscript classpath into its subprojects' `plugins { }`
+    // resolution. So injecting the plugin onto an ANCESTOR of a module that applies the plugin
+    // via the versioned plugins DSL (`id("...") version "..."` or `alias(libs.plugins.<x>)`)
+    // makes that subproject's declaration fail with "the plugin is already on the classpath with
+    // an unknown version, so compatibility cannot be checked" — which fails the subproject's
+    // configuration and makes the CLI's per-project Tooling API model query return zero modules
+    // (issue #1855: a single pre-applied module like `:meshcore-components` sinks discovery of the
+    // whole build). The pre-applied scan already skips the module's OWN injection; also skip every
+    // ancestor — the root project especially — because the ancestor's classpath is the one that
+    // actually leaks into the subproject's resolution. Auto-injected leaf modules still get the dep
+    // on their own buildscript, so the withPlugin hooks can resolve the plugin there.
+    val composeAiPreviewHasPreAppliedDescendant =
+        subprojects.any { it.projectDir in composeAiPreviewPreAppliedDirs }
+
     if (!composeAiPreviewSkipExclusiveContentClasspathDep &&
+        !composeAiPreviewHasPreAppliedDescendant &&
         projectDir !in composeAiPreviewPreAppliedDirs) {
         buildscript {
             // When the settings file declares `exclusiveContent { ... }` in `pluginManagement {
@@ -445,8 +460,11 @@ allprojects {
     // No buildscript classpath dep was injected and the project doesn't pre-apply, so
     // `pluginManager.apply(...)` from the withPlugin hooks would fail with "Plugin with id
     // ... not found." Skipping the hooks keeps the failure mode quiet — non-preview
-    // projects (e.g. Confetti's :backend) configure cleanly with no diagnostic noise.
-    if (composeAiPreviewSkipExclusiveContentClasspathDep &&
+    // projects (e.g. Confetti's :backend) configure cleanly with no diagnostic noise. The
+    // ancestor-of-pre-applied case (above) is gated the same way: its injection was skipped, so
+    // its hooks must be too.
+    if ((composeAiPreviewSkipExclusiveContentClasspathDep ||
+        composeAiPreviewHasPreAppliedDescendant) &&
         projectDir !in composeAiPreviewPreAppliedDirs) return@allprojects
 
     fun applyComposeAiPreview() {

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/AutoInjectTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/AutoInjectTest.kt
@@ -802,7 +802,7 @@ class AutoInjectTest {
     )
     assertTrue(
       script.contains(
-        "if (composeAiPreviewSkipExclusiveContentClasspathDep &&\n        projectDir !in composeAiPreviewPreAppliedDirs) return@allprojects"
+        "if ((composeAiPreviewSkipExclusiveContentClasspathDep ||\n        composeAiPreviewHasPreAppliedDescendant) &&\n        projectDir !in composeAiPreviewPreAppliedDirs) return@allprojects"
       ),
       "expected the apply hooks to short-circuit for skipped modules (otherwise " +
         "pluginManager.apply would fail with 'Plugin with id ... not found')",
@@ -810,6 +810,37 @@ class AutoInjectTest {
     assertFalse(
       script.contains("[compose-preview] settings.gradle.kts declares exclusiveContent in"),
       "init script should not emit lifecycle logs nudging the user to apply the plugin",
+    )
+  }
+
+  @Test
+  fun `init script skips classpath injection for ancestors of a pre-applied module`() {
+    // Regression for #1855 (the auto-inject half): Gradle inherits a project's buildscript
+    // classpath into its subprojects' `plugins {}` resolution, so injecting the plugin onto the
+    // root (or any ancestor) of a module that applies it via the versioned plugins DSL
+    // (`id("...") version "..."` / `alias(libs.plugins.<x>)`) makes that subproject fail with
+    // "the plugin is already on the classpath with an unknown version". That sinks the subproject's
+    // configuration and makes the CLI's per-project model query return zero modules. The init
+    // script must skip injection for any project that has a pre-applied descendant, and skip its
+    // apply hooks too.
+    val script = renderInitScript("0.15.5")
+    assertTrue(
+      script.contains(
+        "val composeAiPreviewHasPreAppliedDescendant =\n        subprojects.any { it.projectDir in composeAiPreviewPreAppliedDirs }"
+      ),
+      "expected the pre-applied-descendant scan in allprojects",
+    )
+    assertTrue(
+      script.contains(
+        "if (!composeAiPreviewSkipExclusiveContentClasspathDep &&\n        !composeAiPreviewHasPreAppliedDescendant &&\n        projectDir !in composeAiPreviewPreAppliedDirs) {"
+      ),
+      "expected the buildscript classpath injection to also be gated on the descendant flag",
+    )
+    assertTrue(
+      script.contains(
+        "if ((composeAiPreviewSkipExclusiveContentClasspathDep ||\n        composeAiPreviewHasPreAppliedDescendant) &&\n        projectDir !in composeAiPreviewPreAppliedDirs) return@allprojects"
+      ),
+      "expected the apply hooks to short-circuit for ancestors of pre-applied modules too",
     )
   }
 

--- a/vscode-extension/src/initScript.ts
+++ b/vscode-extension/src/initScript.ts
@@ -338,7 +338,18 @@ allprojects {
         composeAiPreviewSettingsHasExclusiveContent &&
             projectDir !in composeAiPreviewProjectsWithOwnBuildscriptRepos
 
+    // Gradle inherits a project's buildscript classpath into its subprojects' \`plugins { }\`
+    // resolution, so injecting the plugin onto an ANCESTOR of a module that applies it via the
+    // versioned plugins DSL (\`id("...") version "..."\` / \`alias(libs.plugins.<x>)\`) makes that
+    // subproject fail with "the plugin is already on the classpath with an unknown version" — which
+    // sinks its configuration and makes the CLI/VS Code model query return zero modules (issue
+    // #1855). Skip injection (and the apply hooks) for any project that has a pre-applied
+    // descendant — the root especially — since that classpath is the one that leaks in.
+    val composeAiPreviewHasPreAppliedDescendant =
+        subprojects.any { it.projectDir in composeAiPreviewPreAppliedDirs }
+
     if (!composeAiPreviewSkipExclusiveContentClasspathDep &&
+        !composeAiPreviewHasPreAppliedDescendant &&
         projectDir !in composeAiPreviewPreAppliedDirs) {
         buildscript {
             // When the settings file declares exclusiveContent in pluginManagement.repositories,
@@ -362,7 +373,8 @@ allprojects {
         }
     }
 
-    if (composeAiPreviewSkipExclusiveContentClasspathDep &&
+    if ((composeAiPreviewSkipExclusiveContentClasspathDep ||
+        composeAiPreviewHasPreAppliedDescendant) &&
         projectDir !in composeAiPreviewPreAppliedDirs) return@allprojects
 
     fun applyComposeAiPreview() {

--- a/vscode-extension/src/test/initScript.test.ts
+++ b/vscode-extension/src/test/initScript.test.ts
@@ -139,6 +139,34 @@ describe("renderInitScript", () => {
         );
     });
 
+    it("skips classpath injection for ancestors of a pre-applied module", () => {
+        // Regression for #1855 (auto-inject half): Gradle inherits a project's buildscript
+        // classpath into its subprojects' `plugins {}` resolution, so injecting onto the root (or
+        // any ancestor) of a module that applies the plugin with a version (`id("...") version
+        // "..."` / `alias(libs.plugins.<x>)`) makes that subproject fail with "the plugin is
+        // already on the classpath with an unknown version" — sinking discovery for the whole
+        // build. Mirror of the CLI renderer's gate; keep both in lockstep.
+        const script = renderInitScript();
+        assert.ok(
+            script.includes(
+                "val composeAiPreviewHasPreAppliedDescendant =\n        subprojects.any { it.projectDir in composeAiPreviewPreAppliedDirs }",
+            ),
+            "expected the pre-applied-descendant scan in allprojects",
+        );
+        assert.ok(
+            script.includes(
+                "if (!composeAiPreviewSkipExclusiveContentClasspathDep &&\n        !composeAiPreviewHasPreAppliedDescendant &&\n        projectDir !in composeAiPreviewPreAppliedDirs) {",
+            ),
+            "expected the injection to be gated on the descendant flag",
+        );
+        assert.ok(
+            script.includes(
+                "if ((composeAiPreviewSkipExclusiveContentClasspathDep ||\n        composeAiPreviewHasPreAppliedDescendant) &&\n        projectDir !in composeAiPreviewPreAppliedDirs) return@allprojects",
+            ),
+            "expected the apply hooks to short-circuit for ancestors of pre-applied modules",
+        );
+    });
+
     it("skips composite-included builds in settingsEvaluated and allprojects", () => {
         // Regression for the Confetti report: with `includeBuild("build-logic")` whose
         // settings.gradle.kts declares `exclusiveContent { ... }` in


### PR DESCRIPTION
Fixes the **auto-inject half of #1855** — the part #1863 did not cover.

## Root cause
Auto-inject injects the plugin onto **every** project's buildscript classpath via `allprojects { buildscript { classpath … } }`, including the **root**. Gradle inherits a project's buildscript classpath into its subprojects' `plugins {}` resolution, so a module that applies the plugin **with a version** — `id("…") version "…"` or `alias(libs.plugins.<x>)` (the consumer's `:meshcore-components`) — fails configuration with:

> The request for this plugin could not be satisfied because the plugin is already on the classpath with an unknown version, so compatibility cannot be checked.

The CLI's per-project Tooling-API model query catches that failure and returns **zero** modules → "No preview modules discovered" for the whole build, including modules that apply the plugin correctly. The pre-applied scan already skips the module's *own* injection — but not the **root's**, which is the classpath that actually leaks in.

This is distinct from #1863 (desktop task gating), and is why my #1863 CI was green: the samples build uses `includeBuild`, which disables auto-inject, so this path had **no coverage**.

## Fix
Skip the buildscript-classpath injection (and the apply hooks) for any project that has a **pre-applied descendant** — the root especially. Auto-injected leaf modules still get the dep on their own buildscript, so the `withPlugin` hooks resolve the plugin there.

```kotlin
val composeAiPreviewHasPreAppliedDescendant =
    subprojects.any { it.projectDir in composeAiPreviewPreAppliedDirs }
```

## Validation (locally, with the published 0.15.4 plugin + real AGP-KMP)
Built a standalone **auto-inject** project — `:components` (KMP-Android, `jvm("desktop")`, a `commonMain` `@Preview`, applies the plugin **explicitly with a version**) + `:mobile` (KMP-Android, no desktop, auto-injected). This is the consumer's topology.

- **Before:** `compose-preview list` → "No preview modules discovered" (rc=1); direct Gradle run surfaces the `already on the classpath` error.
- **After** (same edit applied to the materialized 0.15.4 init script): `:components` **and** `:mobile` configure cleanly, both register `composePreviewDiscover`, conflict gone (rc=0). Since the model query keys off `findByName("composePreviewDiscover") != null`, detection now returns both modules.

## Test plan
- `:cli:test --tests AutoInjectTest` ✅ 45 tests. Adds a regression test pinning the descendant-skip gate + the extended apply-hook short-circuit; updates the early-return assertion.
- Local end-to-end Gradle validation against the standalone auto-inject repro (above).

Non-visual change (Gradle init-script wiring).

---
_Generated by [Claude Code](https://claude.ai/code/session_01WmL6Xj4mr6RaK5mdyv436u)_