### PR TITLE
feat(daemon): GitRefHistorySource WRITE_LOCAL — publish render history to the reporting branch

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -267,17 +267,19 @@ fun main(args: Array<String>) {
           GitProvenance(workspaceRoot = workspaceRootProp?.let(Path::of))
         } else null
       val gitRefHistoryRefs = GitRefHistorySource.parseRefsSysprop()
+      val gitRefSyncMode = GitRefHistorySource.parseSyncModeSysprop()
       val pruneConfig = HistoryPruneConfig.fromSysprops()
       historyDirProp?.let { dir ->
         System.err.println(
           "compose-ai-tools daemon: HistoryManager active (dir=$dir, gitRefs=${gitRefHistoryRefs}, " +
-            "pruneConfig=$pruneConfig)"
+            "gitRefSyncMode=$gitRefSyncMode, pruneConfig=$pruneConfig)"
         )
         HistoryManager.forLocalFsAndGitRefs(
           historyDir = Path.of(dir),
           module = System.getProperty(MODULE_ID_PROP) ?: "",
           gitProvenance = gitProvenance,
           gitRefs = gitRefHistoryRefs,
+          gitRefSyncMode = gitRefSyncMode,
           repoRoot = workspaceRootProp?.let(Path::of) ?: Path.of(dir).parent,
           pruneConfig = pruneConfig,
         )

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/GitRefHistorySource.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/GitRefHistorySource.kt
@@ -5,54 +5,66 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.StandardCopyOption
+import java.time.Instant
+import java.util.UUID
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
 
 /**
- * Read-only [HistorySource] backed by a git ref (e.g. `refs/heads/preview/main`).
+ * [HistorySource] backed by a git ref (the **reporting branch**, e.g. `refs/heads/preview/main`).
  *
- * **Storage convention** (HISTORY.md § "GitRefHistorySource"):
+ * Implements the "git-as-the-log" contract in docs/daemon/REPORTING-BRANCH.md: stable, overwritten
+ * per-preview paths, one commit per *changed* render, history reconstructed from git rather than an
+ * append index.
+ *
+ * **On-ref layout:**
+ *
  * ```
  * <ref>'s tree
- * ├── <sanitisedPreviewId>/
- * │   ├── <entryId>.png
- * │   └── <entryId>.json
- * ├── ...
- * └── _index.jsonl                ← aggregate of every entry on this ref's HEAD commit
+ * ├── manifest.json                       ← current-state pointer (formatVersion + previews[])
+ * └── <sanitisedPreviewId>/
+ *     ├── render.png                       ← overwritten each render
+ *     ├── entry.json                       ← the full HistoryEntry sidecar
+ *     ├── semantics.json                   ← optional, when entry.semantics is non-null
+ *     ├── a11y.json                        ← optional, a11y/hierarchy
+ *     ├── a11y-atf.json                    ← optional, a11y/atf
+ *     ├── a11y-touch-targets.json          ← optional, a11y/touchTargets
+ *     └── theme.json                       ← optional, compose/theme
  * ```
  *
- * **Implementation strategy.** Shells out to `git` via [ProcessBuilder] (mirrors [GitProvenance]'s
- * pattern). No JGit dependency. The shell-out cost is fine for read operations and we cache results
- * keyed by the ref's HEAD commit-sha so repeated calls during a single session don't re-extract
- * blobs.
+ * **Sync modes** ([SyncMode]):
+ * - [SyncMode.READ_ONLY] (default) — read the ref, never write. Used to mirror a branch populated
+ *   elsewhere (a remote fetch, CI).
+ * - [SyncMode.WRITE_LOCAL] — also commit each changed render onto the ref via git plumbing. No
+ *   push. `WRITE_PUSH` (also pushing the ref) is a follow-up (issue #1870).
  *
- * **Ref-missing behaviour.** When `git rev-parse --verify <ref>` fails, [list] / [read] return
- * empty / null and emit a one-time warn-level notification via [warnEmitter] explaining how to
- * populate the ref. The daemon doesn't fail; the consumer just sees "no main-history available."
+ * **Working-tree safety.** Writes go through a throwaway temporary index plus `hash-object` /
+ * `read-tree` / `update-index` / `write-tree` / `commit-tree` / `update-ref` — the daemon runs
+ * inside the user's live repo, so it must never `checkout` / `add` or otherwise touch the working
+ * tree or the checked-out branch. Only the reporting ref and the object database are modified.
  *
- * **Source rewriting.** The on-ref sidecars carry whatever `source` field they were written with —
- * but we know the source is *us* now. Both [list] and [read] rewrite `entry.source` to a `kind:
- * "git"` shape stamped with this source's id, the ref name, and the ref's HEAD commit sha.
+ * **Skip-if-no-diff.** When the freshly built tree is byte-identical to the ref's current tree, no
+ * commit is made and [write] returns [WriteResult.SKIPPED_DUPLICATE]. Dedup is free.
  *
- * **PNG extraction.** [read] writes the PNG blob into a daemon-managed cache dir
- * (`<historyDir>/.git-ref-cache/`) keyed by `(refCommit, entryId)`. Subsequent reads of the same
- * blob hit the cache. Tempfiles are cleaned up on JVM shutdown via [Runtime.addShutdownHook].
+ * **Read.** Returns the *current* state of the branch (one entry per preview, read from each
+ * `<dir>/entry.json`). The full commit-walk timeline read is a follow-up (issue #1868).
  *
  * @param repoRoot the working tree (or bare repo) the ref lives in.
- * @param ref the full ref name (e.g. `refs/heads/preview/main`); use full form to avoid ambiguity
- *   between heads, remotes, and tags.
+ * @param ref the full ref name (e.g. `refs/heads/preview/main`).
+ * @param syncMode read-only vs write-local; see [SyncMode].
  * @param displayId stable identifier for `entry.source.id` rewriting; defaults to `git:$ref`.
- * @param cacheDir where extracted PNG blobs land; defaults to
- *   `<repoRoot>/.compose-preview-history/.git-ref-cache`.
+ * @param cacheDir where extracted PNG blobs and the throwaway write-index land.
  * @param gitExecutable git binary; defaults to `git` on PATH.
- * @param warnEmitter logger for the ref-missing case. The production daemon passes
- *   [JsonRpcServer]'s log emitter; tests pass a buffer-capturing lambda.
+ * @param warnEmitter logger for the ref-missing read case.
  */
 class GitRefHistorySource(
   private val repoRoot: Path,
   private val ref: String,
+  private val syncMode: SyncMode = SyncMode.READ_ONLY,
   displayId: String = "git:$ref",
   private val cacheDir: Path =
     repoRoot.resolve(".compose-preview-history").resolve(".git-ref-cache"),
@@ -63,38 +75,202 @@ class GitRefHistorySource(
   override val id: String = displayId
   override val kind: String = "git"
 
-  override fun supportsWrites(): Boolean = false
+  override fun supportsWrites(): Boolean = syncMode == SyncMode.WRITE_LOCAL
 
+  /**
+   * Materialises this render into the reporting ref's tree and commits it (when the tree changed).
+   * Never throws: any git failure degrades to [WriteResult.SKIPPED_DUPLICATE] with a logged warning
+   * so history recording can't break the render (history is observation, not state).
+   */
   override fun write(entry: HistoryEntry, png: ByteArray): WriteResult {
-    error("GitRefHistorySource is read-only (ref=$ref); writes go to a writable source.")
+    if (syncMode != SyncMode.WRITE_LOCAL) {
+      error("GitRefHistorySource(ref=$ref) is $syncMode; writes go to a writable source.")
+    }
+    return try {
+      writeLocal(entry, png)
+    } catch (t: Throwable) {
+      System.err.println(
+        "compose-ai-daemon: GitRefHistorySource.write($ref, ${entry.id}) failed " +
+          "(${t.javaClass.simpleName}: ${t.message}); skipping the reporting-branch commit"
+      )
+      WriteResult.SKIPPED_DUPLICATE
+    }
+  }
+
+  private fun writeLocal(entry: HistoryEntry, png: ByteArray): WriteResult {
+    Files.createDirectories(cacheDir)
+    // A non-warning probe (writers create the ref on first render; refHeadCommit() warns, which is
+    // a read-side concern). Null = the ref doesn't exist yet → first commit creates it.
+    val parent = runGit("rev-parse", "--verify", "--quiet", ref)?.takeIf { it.isNotEmpty() }
+
+    val dir = PreviewIdSanitiser.sanitise(entry.previewId)
+    // entry.json mirrors the sidecar but points pngPath at the branch's stable filename.
+    val branchEntry = entry.copy(pngPath = RENDER_FILENAME)
+
+    // Skip-if-no-diff (free dedup): if the preview's current branch entry has byte-identical render
+    // content — same pixels AND the same data-product snapshots — this render adds nothing, so make
+    // no commit. We compare render *content*, not the entry id/timestamp (which churn every render)
+    // or the manifest's generatedAt — otherwise an unchanged re-render would still commit.
+    if (parent != null) {
+      val current =
+        catFile(parent, "$dir/entry.json")?.let {
+          runCatching { JSON.decodeFromString(HistoryEntry.serializer(), it) }.getOrNull()
+        }
+      if (current != null && renderContentUnchanged(current, branchEntry)) {
+        return WriteResult.SKIPPED_DUPLICATE
+      }
+    }
+
+    val indexPath = cacheDir.resolve("write-index-${UUID.randomUUID()}.tmp")
+    val baseEnv = mapOf("GIT_INDEX_FILE" to indexPath.toAbsolutePath().toString())
+    try {
+      // Seed the throwaway index from the parent tree (empty index when the ref is new).
+      if (parent != null && !plumbingOk(baseEnv, "read-tree", parent))
+        return WriteResult.SKIPPED_DUPLICATE
+
+      // Overwrite the preview's directory wholesale: drop every prior path under it so a render
+      // that no longer produces a given data product doesn't leave a stale file behind.
+      if (parent != null) {
+        val existing = runGit("ls-tree", "-r", "--name-only", parent, "--", "$dir/")
+        if (existing != null) {
+          for (p in existing.split('\n').map { it.trim() }.filter { it.isNotEmpty() }) {
+            plumbingOk(baseEnv, "update-index", "--force-remove", p)
+          }
+        }
+      }
+
+      for ((path, bytes) in projectFiles(dir, branchEntry, png)) {
+        val blob = hashObject(baseEnv, bytes) ?: return WriteResult.SKIPPED_DUPLICATE
+        if (!plumbingOk(baseEnv, "update-index", "--add", "--cacheinfo", "100644,$blob,$path")) {
+          return WriteResult.SKIPPED_DUPLICATE
+        }
+      }
+
+      // Refresh the manifest (read prior, upsert this preview).
+      val manifestBytes = buildManifest(parent, branchEntry, dir)
+      val manifestBlob = hashObject(baseEnv, manifestBytes) ?: return WriteResult.SKIPPED_DUPLICATE
+      if (
+        !plumbingOk(
+          baseEnv,
+          "update-index",
+          "--add",
+          "--cacheinfo",
+          "100644,$manifestBlob,$MANIFEST_FILENAME",
+        )
+      ) {
+        return WriteResult.SKIPPED_DUPLICATE
+      }
+
+      val tree = plumbing(baseEnv, "write-tree")?.trim() ?: return WriteResult.SKIPPED_DUPLICATE
+
+      val message =
+        "compose-preview history: ${entry.previewId}\n\n" +
+          "render: ${entry.id}\n" +
+          "produced-from: ${entry.git?.commit ?: "unknown"}\n"
+      val commitArgs = buildList {
+        add("commit-tree")
+        add(tree)
+        if (parent != null) {
+          add("-p")
+          add(parent)
+        }
+        add("-m")
+        add(message)
+      }
+      val commit = plumbing(commitEnv(baseEnv), *commitArgs.toTypedArray())?.trim()
+      if (commit.isNullOrEmpty()) return WriteResult.SKIPPED_DUPLICATE
+
+      val updated =
+        if (parent != null) plumbingOk(baseEnv, "update-ref", ref, commit, parent)
+        else plumbingOk(baseEnv, "update-ref", ref, commit)
+      if (!updated) return WriteResult.SKIPPED_DUPLICATE
+
+      cachedEntries.set(null) // invalidate the read cache so the new commit is visible.
+      return WriteResult.WRITTEN
+    } finally {
+      try {
+        Files.deleteIfExists(indexPath)
+      } catch (_: Throwable) {
+        // best-effort cleanup
+      }
+    }
+  }
+
+  /** The set of `(path, bytes)` this render contributes under the preview's directory. */
+  private fun projectFiles(
+    dir: String,
+    branchEntry: HistoryEntry,
+    png: ByteArray,
+  ): List<Pair<String, ByteArray>> = buildList {
+    add("$dir/$RENDER_FILENAME" to png)
+    add("$dir/entry.json" to JSON.encodeToString(HistoryEntry.serializer(), branchEntry).toBytes())
+    branchEntry.semantics?.let { add("$dir/semantics.json" to encodeJson(it)) }
+    branchEntry.a11yHierarchy?.let { add("$dir/a11y.json" to encodeJson(it)) }
+    branchEntry.a11yAtf?.let { add("$dir/a11y-atf.json" to encodeJson(it)) }
+    branchEntry.a11yTouchTargets?.let { add("$dir/a11y-touch-targets.json" to encodeJson(it)) }
+    branchEntry.theme?.let { add("$dir/theme.json" to encodeJson(it)) }
   }
 
   /**
-   * Cache of `(refCommit, _index.jsonl-bytes)`. Invalidated when [refHeadCommit] returns a
-   * different sha. Populated lazily on first [list] / [read].
+   * True when [candidate] adds no new render content over the branch's [current] entry — same
+   * pixels and the same captured data-product snapshots. Deliberately ignores id / timestamp /
+   * provenance churn so an unchanged re-render produces no commit.
    */
-  private val cachedIndex: AtomicReference<CachedIndex?> = AtomicReference(null)
+  private fun renderContentUnchanged(current: HistoryEntry, candidate: HistoryEntry): Boolean =
+    current.pngHash == candidate.pngHash &&
+      current.semantics == candidate.semantics &&
+      current.a11yHierarchy == candidate.a11yHierarchy &&
+      current.a11yAtf == candidate.a11yAtf &&
+      current.a11yTouchTargets == candidate.a11yTouchTargets &&
+      current.theme == candidate.theme
 
-  /** One-shot guard so a recurring "ref missing" doesn't flood the log. */
-  private val refMissingWarned = AtomicBoolean(false)
+  /**
+   * Reads the prior manifest off [parent] (when present), upserts this preview, returns the bytes.
+   */
+  private fun buildManifest(parent: String?, branchEntry: HistoryEntry, dir: String): ByteArray {
+    val prior: List<ReportingBranchPreview> =
+      parent
+        ?.let { catFile(it, MANIFEST_FILENAME) }
+        ?.let {
+          try {
+            MANIFEST_JSON.decodeFromString(ReportingBranchManifest.serializer(), it).previews
+          } catch (_: Throwable) {
+            emptyList()
+          }
+        } ?: emptyList()
 
-  private data class CachedIndex(val refCommit: String, val entries: List<HistoryEntry>)
-
-  init {
-    // Best-effort: ensure the cache dir exists if the parent already does. Failures here don't
-    // fail the source — read() recreates as needed.
-    try {
-      Files.createDirectories(cacheDir)
-    } catch (_: Throwable) {
-      // ignore — we'll retry in read()
+    val dataProducts = buildList {
+      branchEntry.semantics?.let { add("compose/semantics") }
+      branchEntry.a11yHierarchy?.let { add("a11y/hierarchy") }
+      branchEntry.a11yAtf?.let { add("a11y/atf") }
+      branchEntry.a11yTouchTargets?.let { add("a11y/touchTargets") }
+      branchEntry.theme?.let { add("compose/theme") }
     }
+    val mine =
+      ReportingBranchPreview(
+        previewId = branchEntry.previewId,
+        module = branchEntry.module,
+        dir = dir,
+        pngHash = branchEntry.pngHash,
+        dataProducts = dataProducts,
+      )
+    val previews =
+      (prior.filterNot { it.previewId == branchEntry.previewId } + mine).sortedBy { it.previewId }
+    val manifest =
+      ReportingBranchManifest(
+        formatVersion = REPORTING_BRANCH_FORMAT_VERSION,
+        generatedAt = Instant.now().toString(),
+        commit = branchEntry.git?.commit,
+        sourceBranch = ref.removePrefix("refs/heads/preview/").removePrefix("refs/heads/"),
+        previews = previews,
+      )
+    return MANIFEST_JSON.encodeToString(ReportingBranchManifest.serializer(), manifest).toBytes()
   }
 
   override fun list(filter: HistoryFilter): HistoryListPage {
     val refCommit = refHeadCommit() ?: return emptyPage()
-    val entries = loadIndex(refCommit) ?: return emptyPage()
-    val rewritten = entries.map { rewriteSource(it, refCommit) }
-    val matched = rewritten.filter { HistoryFilters.matches(it, filter) }
+    val entries = listEntries(refCommit).map { rewriteSource(it, refCommit) }
+    val matched = entries.filter { HistoryFilters.matches(it, filter) }
     val totalCount = matched.size
     val slice = HistoryFilters.paginate(matched, filter)
     return HistoryListPage(
@@ -106,36 +282,14 @@ class GitRefHistorySource(
 
   override fun read(entryId: String, includeBytes: Boolean): HistoryReadResult? {
     val refCommit = refHeadCommit() ?: return null
-    val entries = loadIndex(refCommit) ?: return null
-    val match = entries.firstOrNull { it.id == entryId } ?: return null
-    val rewritten = rewriteSource(match, refCommit)
-
-    // Resolve the sidecar path on the ref. The on-disk layout uses a sanitised previewId dir, and
-    // entry.pngPath is "<entryId>.png" (relative to that dir). We re-fetch the *full* sidecar so
-    // we get the previewMetadata snapshot back.
-    val sanitised = PreviewIdSanitiser.sanitise(match.previewId)
-    val sidecarPath = "$sanitised/$entryId.json"
-    val sidecarText = catFile(refCommit, sidecarPath) ?: return null
-    val fullEntry =
-      try {
-        JSON.decodeFromString(HistoryEntry.serializer(), sidecarText)
-      } catch (t: Throwable) {
-        System.err.println(
-          "compose-ai-daemon: GitRefHistorySource.read($entryId): malformed sidecar at " +
-            "$ref:$sidecarPath (${t.javaClass.simpleName}: ${t.message})"
-        )
-        return null
-      }
-    val rewrittenFull = rewriteSource(fullEntry, refCommit)
-
-    // Extract PNG blob to the cache dir.
-    val pngRel = "$sanitised/$entryId.png"
-    val pngFile = extractBlobToCache(refCommit, pngRel) ?: return null
+    val match = listEntries(refCommit).firstOrNull { it.id == entryId } ?: return null
+    val full = rewriteSource(match, refCommit)
+    val dir = PreviewIdSanitiser.sanitise(match.previewId)
+    val pngFile = extractBlobToCache(refCommit, "$dir/$RENDER_FILENAME") ?: return null
     val bytes = if (includeBytes) Files.readAllBytes(pngFile) else null
-
     return HistoryReadResult(
-      entry = rewrittenFull,
-      previewMetadata = rewrittenFull.previewMetadata,
+      entry = full,
+      previewMetadata = full.previewMetadata,
       pngPath = pngFile.toAbsolutePath().toString(),
       pngBytes = bytes,
     )
@@ -145,16 +299,22 @@ class GitRefHistorySource(
   // Internals
   // -------------------------------------------------------------------------
 
+  /** Cache of `(refCommit, entries)`; invalidated when the ref HEAD shifts or a write lands. */
+  private val cachedEntries: AtomicReference<CachedEntries?> = AtomicReference(null)
+  private val refMissingWarned = AtomicBoolean(false)
+
+  private data class CachedEntries(val refCommit: String, val entries: List<HistoryEntry>)
+
+  init {
+    try {
+      Files.createDirectories(cacheDir)
+    } catch (_: Throwable) {
+      // ignore — recreated on demand
+    }
+  }
+
   private fun rewriteSource(entry: HistoryEntry, refCommit: String): HistoryEntry =
-    entry.copy(
-      source =
-        HistorySourceInfo(
-          kind = "git",
-          // We embed the commit + ref into the id so cross-source dedup ("same render visible in
-          // both LocalFs and GitRef") can compare ids cheaply.
-          id = "$id@${refCommit.take(7)}",
-        )
-    )
+    entry.copy(source = HistorySourceInfo(kind = "git", id = "$id@${refCommit.take(7)}"))
 
   /** Returns the ref's HEAD commit sha or null if the ref is missing. Emits one warn on miss. */
   private fun refHeadCommit(): String? {
@@ -165,7 +325,7 @@ class GitRefHistorySource(
         warnEmitter(
           "GitRefHistorySource: ref '$ref' is not present locally.\n" +
             "  Hint: populate it by fetching from a remote (e.g. `git fetch origin $ref:$ref`)\n" +
-            "  or set up CI to push render history on each merge to $branch.\n" +
+            "  or enable WRITE_LOCAL so the daemon records render history on $branch.\n" +
             "  Until then, main-history comparison will not be available."
         )
       }
@@ -174,79 +334,52 @@ class GitRefHistorySource(
     return out.takeIf { it.isNotEmpty() }
   }
 
-  /**
-   * Loads the `_index.jsonl` from the ref's tree, parsing line-by-line and tolerating truncated
-   * lines (skip + warn). Cached by ref-commit-sha; invalidated when the sha shifts.
-   */
-  private fun loadIndex(refCommit: String): List<HistoryEntry>? {
-    val cached = cachedIndex.get()
-    if (cached != null && cached.refCommit == refCommit) return cached.entries
-
-    val text = catFile(refCommit, INDEX_FILENAME)
-    if (text == null) {
-      // No index — empty ref. Cache the empty result so we don't re-shell for nothing.
-      cachedIndex.set(CachedIndex(refCommit, emptyList()))
+  /** Reads the current branch state: every `<dir>/entry.json`, newest-first by timestamp. */
+  private fun listEntries(refCommit: String): List<HistoryEntry> {
+    cachedEntries.get()?.let { if (it.refCommit == refCommit) return it.entries }
+    val tree = runGit("ls-tree", "-r", "--name-only", refCommit)
+    if (tree == null) {
+      cachedEntries.set(CachedEntries(refCommit, emptyList()))
       return emptyList()
     }
-    val parsed = ArrayList<HistoryEntry>()
-    for (line in text.split('\n')) {
-      val trimmed = line.trim()
-      if (trimmed.isEmpty()) continue
-      val entry =
-        try {
-          JSON.decodeFromString(HistoryEntry.serializer(), trimmed)
-        } catch (t: Throwable) {
-          System.err.println(
-            "compose-ai-daemon: GitRefHistorySource.list($ref): skipping malformed index line " +
-              "(${t.javaClass.simpleName}: ${t.message})"
-          )
-          continue
+    val entries =
+      tree
+        .split('\n')
+        .map { it.trim() }
+        .filter { it.endsWith("/entry.json") }
+        .mapNotNull { path ->
+          catFile(refCommit, path)?.let { text ->
+            try {
+              JSON.decodeFromString(HistoryEntry.serializer(), text)
+            } catch (t: Throwable) {
+              System.err.println(
+                "compose-ai-daemon: GitRefHistorySource.list($ref): malformed $path " +
+                  "(${t.javaClass.simpleName}: ${t.message})"
+              )
+              null
+            }
+          }
         }
-      parsed.add(entry)
-    }
-    // _index.jsonl is append-order (oldest first); reverse for newest-first listing.
-    parsed.reverse()
-    val toCache = CachedIndex(refCommit, parsed)
-    cachedIndex.set(toCache)
-    return parsed
+        .sortedByDescending { it.timestamp }
+    cachedEntries.set(CachedEntries(refCommit, entries))
+    return entries
   }
 
-  /**
-   * Returns the contents of `<refCommit>:<path>` as text, or null if the path isn't present in the
-   * tree. Uses `git show` with `--`. Trailing newline is preserved verbatim — the index parser
-   * handles blank lines.
-   */
   private fun catFile(refCommit: String, path: String): String? = runGit("show", "$refCommit:$path")
 
-  /**
-   * Extracts a binary blob from `<refCommit>:<path>` into [cacheDir]. Returns the cached file path
-   * or null on failure. Idempotent: subsequent reads with the same key see the existing file.
-   */
   private fun extractBlobToCache(refCommit: String, path: String): Path? {
     val safeName = "${refCommit.take(7)}-${path.replace('/', '_')}"
     val target = cacheDir.resolve(safeName)
     if (Files.exists(target)) return target
-
     try {
       Files.createDirectories(cacheDir)
     } catch (t: Throwable) {
-      System.err.println(
-        "compose-ai-daemon: GitRefHistorySource.extractBlobToCache: failed to create cache dir " +
-          "$cacheDir (${t.javaClass.simpleName}: ${t.message})"
-      )
       return null
     }
-
-    // Use `git -C <repoRoot> show <refCommit>:<path>` and write stdout to the target tempfile via
-    // ProcessBuilder.redirectOutput. Avoids holding the full PNG in JVM memory.
     val tmp =
       try {
         Files.createTempFile(cacheDir, "extract-", ".tmp")
       } catch (t: Throwable) {
-        System.err.println(
-          "compose-ai-daemon: GitRefHistorySource.extractBlobToCache: tempfile create failed " +
-            "(${t.javaClass.simpleName}: ${t.message})"
-        )
         return null
       }
     try {
@@ -266,8 +399,6 @@ class GitRefHistorySource(
         Files.deleteIfExists(tmp)
         return null
       }
-      // Atomic rename so concurrent reads don't see a half-written cache file. ATOMIC_MOVE may not
-      // be supported on all FSes — fall back to REPLACE_EXISTING when not.
       try {
         Files.move(tmp, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING)
       } catch (_: Throwable) {
@@ -275,10 +406,6 @@ class GitRefHistorySource(
       }
       return target
     } catch (t: IOException) {
-      System.err.println(
-        "compose-ai-daemon: GitRefHistorySource.extractBlobToCache: IO failure " +
-          "(${t.javaClass.simpleName}: ${t.message})"
-      )
       Files.deleteIfExists(tmp)
       return null
     } catch (t: Throwable) {
@@ -287,58 +414,138 @@ class GitRefHistorySource(
     }
   }
 
-  private fun runGit(vararg args: String): String? {
+  /** Read-side git: stdout text trimmed of a trailing newline, or null on non-zero/timeout. */
+  private fun runGit(vararg args: String): String? = plumbing(emptyMap(), *args)
+
+  /**
+   * Runs git with optional [env] (e.g. `GIT_INDEX_FILE`) and optional [stdin]; returns stdout or
+   * null on failure. Used for the write plumbing as well as reads.
+   */
+  private fun plumbing(
+    env: Map<String, String>,
+    vararg args: String,
+    stdin: ByteArray? = null,
+    timeoutSec: Long = 30,
+  ): String? {
     return try {
-      val process =
+      val pb =
         ProcessBuilder(listOf(gitExecutable) + args.toList())
           .directory(repoRoot.toFile())
           .redirectErrorStream(false)
-          .start()
-      val finished = process.waitFor(10, TimeUnit.SECONDS)
+      if (env.isNotEmpty()) pb.environment().putAll(env)
+      val process = pb.start()
+      if (stdin != null) process.outputStream.use { it.write(stdin) }
+      else process.outputStream.close()
+      val out = process.inputStream.readBytes()
+      val finished = process.waitFor(timeoutSec, TimeUnit.SECONDS)
       if (!finished) {
         process.destroyForcibly()
         return null
       }
       if (process.exitValue() != 0) return null
-      process.inputStream.bufferedReader(StandardCharsets.UTF_8).use { it.readText() }.trimEnd('\n')
+      String(out, StandardCharsets.UTF_8).trimEnd('\n')
     } catch (_: Throwable) {
       null
     }
   }
 
+  private fun plumbingOk(env: Map<String, String>, vararg args: String): Boolean =
+    plumbing(env, *args) != null
+
+  private fun hashObject(env: Map<String, String>, bytes: ByteArray): String? =
+    plumbing(env, "hash-object", "-w", "--stdin", stdin = bytes)?.trim()?.takeIf { it.isNotEmpty() }
+
+  private fun commitEnv(base: Map<String, String>): Map<String, String> =
+    base +
+      mapOf(
+        "GIT_AUTHOR_NAME" to GIT_IDENTITY_NAME,
+        "GIT_AUTHOR_EMAIL" to GIT_IDENTITY_EMAIL,
+        "GIT_COMMITTER_NAME" to GIT_IDENTITY_NAME,
+        "GIT_COMMITTER_EMAIL" to GIT_IDENTITY_EMAIL,
+      )
+
+  private fun encodeJson(element: JsonElement): ByteArray =
+    JSON.encodeToString(JsonElement.serializer(), element).toBytes()
+
+  private fun String.toBytes(): ByteArray = toByteArray(StandardCharsets.UTF_8)
+
   private fun emptyPage(): HistoryListPage =
     HistoryListPage(entries = emptyList(), nextCursor = null, totalCount = 0)
 
+  /** Read-only vs write-local for a reporting ref. `WRITE_PUSH` is a follow-up (issue #1870). */
+  enum class SyncMode {
+    READ_ONLY,
+    WRITE_LOCAL,
+  }
+
   companion object {
-    /** Aggregate index filename on the ref's tree. HISTORY.md § "GitRefHistorySource". */
-    const val INDEX_FILENAME: String = "_index.jsonl"
+    /** Stable filename for the overwritten-per-render PNG on the ref. */
+    const val RENDER_FILENAME: String = "render.png"
+
+    /** Current-state pointer at the ref root. docs/daemon/REPORTING-BRANCH.md § manifest.json. */
+    const val MANIFEST_FILENAME: String = "manifest.json"
+
+    /** Bumped on incompatible reporting-branch layout changes. */
+    const val REPORTING_BRANCH_FORMAT_VERSION: Int = 1
 
     /**
-     * Sysprop name — comma-separated list of refs (e.g.
-     * `refs/heads/preview/main,refs/heads/preview/agent/foo`). Wired by each per-target
-     * [DaemonMain] alongside [LocalFsHistorySource].
+     * Comma/semicolon-separated list of refs (e.g.
+     * `refs/heads/preview/main,refs/heads/preview/agent/foo`).
      */
     const val GIT_REF_HISTORY_PROP: String = "composeai.daemon.gitRefHistory"
+
+    /** Sync mode for the reporting refs: `READ_ONLY` (default) or `WRITE_LOCAL`. */
+    const val SYNC_MODE_PROP: String = "composeai.daemon.gitRefHistorySyncMode"
+
+    // Synthetic identity for daemon-authored reporting-branch commits. These are machine-generated
+    // history commits in the *consumer's* repo (not this project's git history), so they carry a
+    // clear non-human author rather than borrowing the developer's identity.
+    private const val GIT_IDENTITY_NAME: String = "compose-preview history"
+    private const val GIT_IDENTITY_EMAIL: String = "compose-preview-history@users.noreply.localhost"
 
     private val JSON: Json = Json {
       ignoreUnknownKeys = true
       encodeDefaults = false
     }
 
-    /**
-     * Parses the [GIT_REF_HISTORY_PROP] sysprop (or [propValue] when explicit) into a list of
-     * non-blank ref strings. Returns an empty list when the property is unset.
-     */
+    /** Manifest is human-/git-diff-friendly: pretty-printed, defaults encoded (formatVersion). */
+    private val MANIFEST_JSON: Json = Json {
+      ignoreUnknownKeys = true
+      encodeDefaults = true
+      prettyPrint = true
+    }
+
     fun parseRefsSysprop(
       propValue: String? = System.getProperty(GIT_REF_HISTORY_PROP)
     ): List<String> =
       propValue?.split(',', ';')?.map { it.trim() }?.filter { it.isNotEmpty() } ?: emptyList()
 
-    /**
-     * Default cache dir for a given history dir. Mirrors the in-source default but exposed so
-     * [DaemonMain] callers can pin the cache adjacent to the local-fs history dir for symmetric
-     * lifecycle management.
-     */
+    /** Parses [SYNC_MODE_PROP]; unknown / unset → [SyncMode.READ_ONLY]. */
+    fun parseSyncModeSysprop(propValue: String? = System.getProperty(SYNC_MODE_PROP)): SyncMode =
+      when (propValue?.trim()?.uppercase()) {
+        "WRITE_LOCAL" -> SyncMode.WRITE_LOCAL
+        else -> SyncMode.READ_ONLY
+      }
+
     fun defaultCacheDir(historyDir: Path): Path = historyDir.resolve(".git-ref-cache")
   }
 }
+
+/** Current-state manifest written at the reporting ref root. docs/daemon/REPORTING-BRANCH.md. */
+@Serializable
+data class ReportingBranchManifest(
+  val formatVersion: Int = 1,
+  val generatedAt: String,
+  val commit: String? = null,
+  val sourceBranch: String? = null,
+  val previews: List<ReportingBranchPreview> = emptyList(),
+)
+
+@Serializable
+data class ReportingBranchPreview(
+  val previewId: String,
+  val module: String,
+  val dir: String,
+  val pngHash: String,
+  val dataProducts: List<String> = emptyList(),
+)

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/GitRefHistorySource.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/GitRefHistorySource.kt
@@ -1,5 +1,7 @@
 package ee.schimke.composeai.daemon.history
 
+import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsPayload
+import ee.schimke.composeai.data.layoutinspector.SemanticsDiff
 import java.io.IOException
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
@@ -212,17 +214,33 @@ class GitRefHistorySource(
   }
 
   /**
-   * True when [candidate] adds no new render content over the branch's [current] entry — same
-   * pixels and the same captured data-product snapshots. Deliberately ignores id / timestamp /
-   * provenance churn so an unchanged re-render produces no commit.
+   * True when [candidate] adds no new render content over the branch's [current] entry. Uses the
+   * **same** criteria as `LocalFsHistorySource`'s tier-1 dedup — same pixels and a structurally
+   * unchanged `compose/semantics` tree — deliberately and explicitly NOT the a11y/theme snapshots.
+   *
+   * Matching LocalFs is the point: if the two writable sources disagreed on what counts as a
+   * duplicate (e.g. GitRef wrote a same-pixel render because a11y changed while LocalFs skipped
+   * it), `HistoryManager.list` would de-dup the pair by `(previewId, pngHash)`, keep the older
+   * LocalFs entry, and the git-only entry would vanish from the default listing. Keeping the
+   * predicates aligned means both sources make the same skip decision, so no entry is silently
+   * hidden. Comparison ignores id / timestamp / provenance churn so an unchanged re-render makes no
+   * commit.
    */
   private fun renderContentUnchanged(current: HistoryEntry, candidate: HistoryEntry): Boolean =
     current.pngHash == candidate.pngHash &&
-      current.semantics == candidate.semantics &&
-      current.a11yHierarchy == candidate.a11yHierarchy &&
-      current.a11yAtf == candidate.a11yAtf &&
-      current.a11yTouchTargets == candidate.a11yTouchTargets &&
-      current.theme == candidate.theme
+      !semanticsChanged(current.semantics, candidate.semantics)
+
+  /** Mirrors `LocalFsHistorySource.semanticsChanged`: structural (SemanticsDiff), null-tolerant. */
+  private fun semanticsChanged(old: JsonElement?, new: JsonElement?): Boolean {
+    if (old == null || new == null) return false
+    return try {
+      val base = JSON.decodeFromJsonElement(ComposeSemanticsPayload.serializer(), old)
+      val head = JSON.decodeFromJsonElement(ComposeSemanticsPayload.serializer(), new)
+      !SemanticsDiff.diff(base, head).isEmpty
+    } catch (_: Throwable) {
+      false
+    }
+  }
 
   /**
    * Reads the prior manifest off [parent] (when present), upserts this preview, returns the bytes.
@@ -285,7 +303,10 @@ class GitRefHistorySource(
     val match = listEntries(refCommit).firstOrNull { it.id == entryId } ?: return null
     val full = rewriteSource(match, refCommit)
     val dir = PreviewIdSanitiser.sanitise(match.previewId)
-    val pngFile = extractBlobToCache(refCommit, "$dir/$RENDER_FILENAME") ?: return null
+    // New layout stores the PNG at <dir>/render.png; the legacy format at <dir>/<entryId>.png. The
+    // entry's own pngPath carries whichever was written, so resolve relative to it.
+    val pngRel = match.pngPath.takeIf { it.isNotBlank() } ?: RENDER_FILENAME
+    val pngFile = extractBlobToCache(refCommit, "$dir/$pngRel") ?: return null
     val bytes = if (includeBytes) Files.readAllBytes(pngFile) else null
     return HistoryReadResult(
       entry = full,
@@ -361,8 +382,32 @@ class GitRefHistorySource(
           }
         }
         .sortedByDescending { it.timestamp }
-    cachedEntries.set(CachedEntries(refCommit, entries))
-    return entries
+    // Backward compatibility: a ref written under the legacy read-only format (an aggregate
+    // `_index.jsonl` + `<entryId>.{png,json}` per preview dir, the layout the old read-only
+    // GitRefHistorySource documented) has no `entry.json` files, so the scan above is empty.
+    // Fall back to parsing `_index.jsonl` so existing preview/* refs keep reading.
+    val resolved = entries.ifEmpty { readLegacyIndex(refCommit) }
+    cachedEntries.set(CachedEntries(refCommit, resolved))
+    return resolved
+  }
+
+  /**
+   * Legacy reader: parse the aggregate `_index.jsonl`, tolerating truncated lines; newest-first.
+   */
+  private fun readLegacyIndex(refCommit: String): List<HistoryEntry> {
+    val text = catFile(refCommit, LEGACY_INDEX_FILENAME) ?: return emptyList()
+    val parsed =
+      text.split('\n').mapNotNull { line ->
+        val trimmed = line.trim()
+        if (trimmed.isEmpty()) return@mapNotNull null
+        try {
+          JSON.decodeFromString(HistoryEntry.serializer(), trimmed)
+        } catch (_: Throwable) {
+          null // truncated / malformed line — skip
+        }
+      }
+    // _index.jsonl is append-order (oldest first); reverse for newest-first listing.
+    return parsed.asReversed()
   }
 
   private fun catFile(refCommit: String, path: String): String? = runGit("show", "$refCommit:$path")
@@ -484,6 +529,9 @@ class GitRefHistorySource(
 
     /** Current-state pointer at the ref root. docs/daemon/REPORTING-BRANCH.md § manifest.json. */
     const val MANIFEST_FILENAME: String = "manifest.json"
+
+    /** Aggregate index of the legacy read-only format; read as a fallback for old refs. */
+    const val LEGACY_INDEX_FILENAME: String = "_index.jsonl"
 
     /** Bumped on incompatible reporting-branch layout changes. */
     const val REPORTING_BRANCH_FORMAT_VERSION: Int = 1

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryManager.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryManager.kt
@@ -461,6 +461,7 @@ class HistoryManager(
       module: String,
       gitProvenance: GitProvenance?,
       gitRefs: List<String> = emptyList(),
+      gitRefSyncMode: GitRefHistorySource.SyncMode = GitRefHistorySource.SyncMode.READ_ONLY,
       repoRoot: java.nio.file.Path? = historyDir?.parent,
       warnEmitter: (String) -> Unit = { System.err.println(it) },
       pruneConfig: HistoryPruneConfig = HistoryPruneConfig(),
@@ -473,6 +474,7 @@ class HistoryManager(
               GitRefHistorySource(
                 repoRoot = repoRoot,
                 ref = ref,
+                syncMode = gitRefSyncMode,
                 cacheDir =
                   historyDir?.let(GitRefHistorySource::defaultCacheDir)
                     ?: repoRoot.resolve(".compose-preview-history").resolve(".git-ref-cache"),

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/GitRefHistorySourceTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/GitRefHistorySourceTest.kt
@@ -7,8 +7,10 @@ import java.nio.file.Path
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -17,13 +19,13 @@ import org.junit.Before
 import org.junit.Test
 
 /**
- * H10-read — `GitRefHistorySource` unit tests. Each test synthesises a temp git repo on disk, sets
- * up a `refs/heads/preview/...` ref with the documented storage convention (HISTORY.md §
- * "GitRefHistorySource"), and exercises the source through its public surface.
+ * `GitRefHistorySource` unit tests — the reporting-branch source (read + WRITE_LOCAL). Each test
+ * synthesises a temp git repo, then drives the source through its public surface; WRITE_LOCAL tests
+ * dogfood the writer (write via the source, read back via the source) and inspect the resulting ref
+ * tree directly.
  *
  * **`git` binary required.** All tests `Assume.assumeTrue` on `git --version` so CI runners without
- * git skip cleanly. Production callers (the daemon mains) tolerate missing git the same way
- * [GitProvenance] does — silent degradation.
+ * git skip cleanly. Production callers tolerate missing git the same way [GitProvenance] does.
  */
 class GitRefHistorySourceTest {
 
@@ -38,6 +40,8 @@ class GitRefHistorySourceTest {
     }
   }
 
+  private val ref = "refs/heads/preview/main"
+
   @Before
   fun setUp() {
     assumeTrue("git on PATH required for GitRefHistorySource tests", gitAvailable())
@@ -47,7 +51,6 @@ class GitRefHistorySourceTest {
     runOk("git", "-C", repoRoot.toString(), "config", "user.name", "Test")
     runOk("git", "-C", repoRoot.toString(), "config", "commit.gpgsign", "false")
     runOk("git", "-C", repoRoot.toString(), "config", "tag.gpgsign", "false")
-    // Seed an initial commit so HEAD exists — we reuse it as the parent of preview/ refs.
     Files.writeString(repoRoot.resolve("README"), "init")
     runOk("git", "-C", repoRoot.toString(), "add", "README")
     runOk("git", "-C", repoRoot.toString(), "commit", "-q", "-m", "init")
@@ -59,227 +62,197 @@ class GitRefHistorySourceTest {
   }
 
   // -------------------------------------------------------------------------
-  // Tests
+  // Read: missing / empty ref
   // -------------------------------------------------------------------------
 
   @Test
   fun missing_ref_returns_empty_and_warns_once() {
-    val source =
-      GitRefHistorySource(
-        repoRoot = repoRoot,
-        ref = "refs/heads/preview/nonexistent",
-        warnEmitter = warnEmitter,
-      )
+    val source = source(SyncModeOf.READ_ONLY, "refs/heads/preview/nonexistent")
     val page = source.list(HistoryFilter())
     assertEquals(0, page.totalCount)
     assertTrue(page.entries.isEmpty())
     assertEquals(1, warnCount.get())
-    assertTrue("warn must include ref name", warnLog.contains("refs/heads/preview/nonexistent"))
-    assertTrue("warn must include hint", warnLog.contains("git fetch"))
+    assertTrue(warnLog.contains("refs/heads/preview/nonexistent"))
+    assertTrue(warnLog.contains("git fetch"))
 
-    // Second call → no second warn (one-shot guard).
-    val page2 = source.list(HistoryFilter())
-    assertEquals(0, page2.totalCount)
-    assertEquals(1, warnCount.get())
+    source.list(HistoryFilter())
+    assertEquals("one-shot warn guard", 1, warnCount.get())
 
-    // read() of a missing entry → null. Must not warn again either.
-    val read = source.read("does-not-exist", includeBytes = false)
-    assertNull(read)
+    assertNull(source.read("does-not-exist", includeBytes = false))
     assertEquals(1, warnCount.get())
   }
 
   @Test
   fun empty_ref_returns_empty_no_warn() {
-    // Create the ref pointing at an empty tree (no _index.jsonl, no preview dirs).
-    val emptyTree = createEmptyTree()
-    val emptyCommit = commitTree(emptyTree, parent = null, message = "empty")
-    runOk("git", "-C", repoRoot.toString(), "update-ref", "refs/heads/preview/main", emptyCommit)
+    val emptyCommit = commitTree(mktree(""), parent = null, message = "empty")
+    runOk("git", "-C", repoRoot.toString(), "update-ref", ref, emptyCommit)
 
-    val source =
-      GitRefHistorySource(
-        repoRoot = repoRoot,
-        ref = "refs/heads/preview/main",
-        warnEmitter = warnEmitter,
-      )
-    val page = source.list(HistoryFilter())
+    val page = source(SyncModeOf.READ_ONLY).list(HistoryFilter())
     assertEquals(0, page.totalCount)
-    assertTrue(page.entries.isEmpty())
     assertEquals("ref exists → no warn", 0, warnCount.get())
   }
 
+  // -------------------------------------------------------------------------
+  // WRITE_LOCAL
+  // -------------------------------------------------------------------------
+
   @Test
-  fun populated_ref_lists_and_reads_entries_with_git_source_kind() {
-    // Build three sidecar+png pairs for two preview dirs, plus a matching _index.jsonl.
-    val entries =
-      listOf(
-        synthEntry(
-          id = "20260430-101234-aaaaaaaa",
-          previewId = "com.example.A",
-          bytes = "first".toByteArray(),
-        ),
-        synthEntry(
-          id = "20260430-101300-bbbbbbbb",
-          previewId = "com.example.A",
-          bytes = "second".toByteArray(),
-        ),
-        synthEntry(
-          id = "20260430-101400-cccccccc",
-          previewId = "com.example.B",
-          bytes = "third".toByteArray(),
-        ),
-      )
-    populatePreviewMain(entries)
+  fun supportsWrites_reflects_sync_mode() {
+    assertFalse(source(SyncModeOf.READ_ONLY).supportsWrites())
+    assertTrue(source(SyncModeOf.WRITE_LOCAL).supportsWrites())
+  }
 
-    val source =
-      GitRefHistorySource(
-        repoRoot = repoRoot,
-        ref = "refs/heads/preview/main",
-        warnEmitter = warnEmitter,
+  @Test
+  fun write_local_creates_ref_round_trips_and_writes_manifest() {
+    val src = source(SyncModeOf.WRITE_LOCAL)
+    val bytes = "render-A".toByteArray()
+    val e =
+      entry(
+        id = "20260430-101234-aaaaaaaa",
+        previewId = "com.example.A",
+        bytes = bytes,
+        a11yHierarchy = json.parseToJsonElement("""{"nodes":[]}"""),
+        theme =
+          json.parseToJsonElement(
+            """{"resolvedTokens":{"colorScheme":{},"typography":{},"shapes":{}}}"""
+          ),
       )
-    val page = source.list(HistoryFilter())
-    assertEquals(3, page.totalCount)
-    assertEquals(3, page.entries.size)
-    // Newest first by timestamp (iso strings in entries).
-    assertEquals("20260430-101400-cccccccc", page.entries[0].id)
-    // All entries get source.kind = "git"; the id includes the source's id + the ref's commit.
-    for (entry in page.entries) {
-      assertEquals("git", entry.source.kind)
-      assertTrue(entry.source.id.startsWith("git:refs/heads/preview/main"))
-    }
+    assertEquals(WriteResult.WRITTEN, src.write(e, bytes))
 
-    // read() resolves a real entry to a cache file containing the original bytes.
-    val read = source.read("20260430-101300-bbbbbbbb", includeBytes = true)
+    // The ref tree carries the git-as-the-log layout (overwritten per-preview paths + manifest).
+    val tree = capture("git", "-C", repoRoot.toString(), "ls-tree", "-r", "--name-only", ref)
+    assertTrue(tree.contains("com.example.A/render.png"))
+    assertTrue(tree.contains("com.example.A/entry.json"))
+    assertTrue(tree.contains("com.example.A/a11y.json"))
+    assertTrue(tree.contains("com.example.A/theme.json"))
+    assertTrue(tree.contains("manifest.json"))
+    assertFalse("no a11y-atf file when not captured", tree.contains("a11y-atf.json"))
+
+    val manifest =
+      json.decodeFromString(
+        ReportingBranchManifest.serializer(),
+        capture("git", "-C", repoRoot.toString(), "show", "$ref:manifest.json"),
+      )
+    assertEquals(1, manifest.formatVersion)
+    assertEquals(1, manifest.previews.size)
+    assertEquals("com.example.A", manifest.previews[0].previewId)
+    assertTrue(
+      manifest.previews[0].dataProducts.containsAll(listOf("a11y/hierarchy", "compose/theme"))
+    )
+
+    // Round-trips through the source's own read surface, stamped as a git source.
+    val page = src.list(HistoryFilter())
+    assertEquals(1, page.totalCount)
+    assertEquals(e.id, page.entries[0].id)
+    assertEquals("git", page.entries[0].source.kind)
+    assertTrue(page.entries[0].source.id.startsWith("git:$ref"))
+
+    val read = src.read(e.id, includeBytes = true)
     assertNotNull(read)
-    val pngFile = File(read!!.pngPath)
-    assertTrue("PNG cache file must exist", pngFile.exists())
-    assertEquals("second", pngFile.readText())
-    assertNotNull(read.pngBytes)
-    assertEquals("second", String(read.pngBytes!!))
-    assertEquals("git", read.entry.source.kind)
+    assertTrue(File(read!!.pngPath).exists())
+    assertEquals("render-A", String(read.pngBytes!!))
   }
 
   @Test
-  fun corrupt_index_skips_truncated_line_and_lists_others() {
-    val good1 =
-      synthEntry(
-        id = "20260430-100000-11111111",
-        previewId = "com.example.A",
-        bytes = "a".toByteArray(),
-      )
-    val good2 =
-      synthEntry(
-        id = "20260430-100100-22222222",
-        previewId = "com.example.A",
-        bytes = "b".toByteArray(),
-      )
-    val tree =
-      createTreeWithEntriesAndIndex(listOf(good1, good2)) { jsonl ->
-        // Corrupt: append a half-line that's not valid JSON.
-        jsonl + "{\"id\":\"truncat" + "\n"
-      }
-    val commit = commitTree(tree, parent = null, message = "corrupt-index")
-    runOk("git", "-C", repoRoot.toString(), "update-ref", "refs/heads/preview/main", commit)
+  fun write_local_skips_unchanged_render() {
+    val src = source(SyncModeOf.WRITE_LOCAL)
+    val bytes = "steady".toByteArray()
+    val e = entry(id = "20260430-100000-11111111", previewId = "com.example.Steady", bytes = bytes)
 
-    val source =
-      GitRefHistorySource(
-        repoRoot = repoRoot,
-        ref = "refs/heads/preview/main",
-        warnEmitter = warnEmitter,
-      )
-    val page = source.list(HistoryFilter())
-    // Two valid entries — the third (truncated) line is skipped.
-    assertEquals(2, page.totalCount)
-    assertEquals(2, page.entries.size)
+    assertEquals(WriteResult.WRITTEN, src.write(e, bytes))
+    assertEquals(
+      "identical render content adds nothing → no second commit",
+      WriteResult.SKIPPED_DUPLICATE,
+      src.write(e, bytes),
+    )
+    assertEquals("1", capture("git", "-C", repoRoot.toString(), "rev-list", "--count", ref).trim())
   }
 
   @Test
-  fun cross_source_listing_dedups_and_filter_by_sourceKind() {
-    // Same render lands in BOTH a LocalFs source and the git ref. Cross-source dedup keys on
-    // (previewId, pngHash) and keeps the first writer (LocalFs).
+  fun write_local_overwrites_and_drops_stale_data_file() {
+    val src = source(SyncModeOf.WRITE_LOCAL)
+    val previewId = "com.example.Card"
+
+    val first =
+      entry(
+        id = "20260430-100000-aaaaaaaa",
+        previewId = previewId,
+        bytes = "v1".toByteArray(),
+        a11yHierarchy =
+          json.parseToJsonElement("""{"nodes":[{"label":"x","boundsInScreen":"0,0,1,1"}]}"""),
+      )
+    assertEquals(WriteResult.WRITTEN, src.write(first, "v1".toByteArray()))
+    assertTrue(
+      capture("git", "-C", repoRoot.toString(), "ls-tree", "-r", "--name-only", ref)
+        .contains("$previewId/a11y.json")
+    )
+
+    // A later render with different pixels and NO a11y must overwrite render.png and drop
+    // a11y.json.
+    val second =
+      entry(id = "20260430-100100-bbbbbbbb", previewId = previewId, bytes = "v2".toByteArray())
+    assertEquals(WriteResult.WRITTEN, src.write(second, "v2".toByteArray()))
+
+    val tree = capture("git", "-C", repoRoot.toString(), "ls-tree", "-r", "--name-only", ref)
+    assertTrue(tree.contains("$previewId/render.png"))
+    assertFalse(
+      "stale a11y.json must be removed on overwrite",
+      tree.contains("$previewId/a11y.json"),
+    )
+
+    val page = src.list(HistoryFilter())
+    assertEquals("current-state read → one entry per preview", 1, page.totalCount)
+    assertEquals(second.id, page.entries[0].id)
+    assertEquals("2", capture("git", "-C", repoRoot.toString(), "rev-list", "--count", ref).trim())
+  }
+
+  @Test
+  fun cross_source_listing_dedups_and_filters_by_source_kind() {
     val historyDir = Files.createTempDirectory("xsource-localfs")
     try {
       val localFs = LocalFsHistorySource(historyDir = historyDir)
+      val git = source(SyncModeOf.WRITE_LOCAL)
       val previewId = "com.example.X"
-      val sharedBytes = "shared-render".toByteArray()
-      val sharedHash = LocalFsHistorySource.sha256Hex(sharedBytes)
 
-      // 1. Write the same render to LocalFs.
-      val localFsEntry =
-        HistoryEntry(
-          id = "20260430-090000-deadbeef",
-          previewId = previewId,
-          module = ":t",
-          timestamp = "2026-04-30T09:00:00Z",
-          pngHash = sharedHash,
-          pngSize = sharedBytes.size.toLong(),
-          pngPath = "20260430-090000-deadbeef.png",
-          producer = "daemon",
-          trigger = "renderNow",
-          source = HistorySourceInfo(kind = "fs", id = "fs:${historyDir.toAbsolutePath()}"),
-          renderTookMs = 1L,
-        )
-      localFs.write(localFsEntry, sharedBytes)
+      // Same render written to BOTH sources.
+      val sharedBytes = "shared".toByteArray()
+      val shared =
+        entry(id = "20260430-090000-deadbeef", previewId = previewId, bytes = sharedBytes)
+      localFs.write(shared, sharedBytes)
+      git.write(shared, sharedBytes)
 
-      // 2. Build a git ref carrying the same render PLUS one git-only render.
+      // A git-only render of a different preview.
       val gitOnlyBytes = "git-only".toByteArray()
-      val gitRefEntries =
-        listOf(
-          synthEntryFromHash(
-            id = localFsEntry.id,
-            previewId = previewId,
-            timestamp = localFsEntry.timestamp,
-            pngHash = sharedHash,
-            bytes = sharedBytes,
-          ),
-          synthEntry(
-            id = "20260430-100000-99999999",
-            previewId = previewId,
-            bytes = gitOnlyBytes,
-            timestamp = "2026-04-30T10:00:00Z",
-          ),
-        )
-      populatePreviewMain(gitRefEntries)
+      val gitOnly =
+        entry(id = "20260430-100000-99999999", previewId = "com.example.Y", bytes = gitOnlyBytes)
+      git.write(gitOnly, gitOnlyBytes)
 
-      val gitSource =
-        GitRefHistorySource(
-          repoRoot = repoRoot,
-          ref = "refs/heads/preview/main",
-          warnEmitter = warnEmitter,
-        )
       val manager =
-        HistoryManager(sources = listOf(localFs, gitSource), module = ":t", gitProvenance = null)
+        HistoryManager(sources = listOf(localFs, git), module = ":t", gitProvenance = null)
 
       val all = manager.list(HistoryFilter())
-      // Two unique renders — shared render's LocalFs copy is canonical, git-only render comes from
-      // git.
       assertEquals(2, all.totalCount)
-      val sharedSurface = all.entries.first { it.id == localFsEntry.id }
       assertEquals(
-        "shared render must surface from LocalFs (priority 0)",
+        "shared render surfaces from LocalFs (priority 0)",
         "fs",
-        sharedSurface.source.kind,
+        all.entries.first { it.id == shared.id }.source.kind,
       )
-      val gitOnlySurface = all.entries.first { it.id == "20260430-100000-99999999" }
-      assertEquals("git", gitOnlySurface.source.kind)
+      assertEquals("git", all.entries.first { it.id == gitOnly.id }.source.kind)
 
-      // sourceKind=git filter narrows to git-source entries — both the shared render's git copy
-      // AND the git-only render show up here because the LocalFs (kind="fs") source is filtered
-      // out at the per-source layer before merge-dedup runs.
-      val gitOnlyPage = manager.list(HistoryFilter(sourceKind = "git"))
-      assertEquals(2, gitOnlyPage.totalCount)
-      assertTrue(gitOnlyPage.entries.all { it.source.kind == "git" })
+      val gitPage = manager.list(HistoryFilter(sourceKind = "git"))
+      assertEquals(2, gitPage.totalCount)
+      assertTrue(gitPage.entries.all { it.source.kind == "git" })
 
-      // sourceKind=fs filter shows just the LocalFs canonical copy.
-      val fsOnlyPage = manager.list(HistoryFilter(sourceKind = "fs"))
-      assertEquals(1, fsOnlyPage.totalCount)
-      assertEquals(localFsEntry.id, fsOnlyPage.entries.single().id)
+      val fsPage = manager.list(HistoryFilter(sourceKind = "fs"))
+      assertEquals(1, fsPage.totalCount)
+      assertEquals(shared.id, fsPage.entries.single().id)
     } finally {
       historyDir.toFile().deleteRecursively()
     }
   }
 
   // -------------------------------------------------------------------------
-  // Helpers — temp git repo manipulation via shell-out
+  // Helpers
   // -------------------------------------------------------------------------
 
   private val json = Json {
@@ -287,89 +260,46 @@ class GitRefHistorySourceTest {
     encodeDefaults = false
   }
 
-  private fun synthEntry(
+  // Alias so the tests read clearly without importing the nested enum at call sites.
+  private object SyncModeOf {
+    val READ_ONLY = GitRefHistorySource.SyncMode.READ_ONLY
+    val WRITE_LOCAL = GitRefHistorySource.SyncMode.WRITE_LOCAL
+  }
+
+  private fun source(
+    syncMode: GitRefHistorySource.SyncMode,
+    ref: String = this.ref,
+  ): GitRefHistorySource =
+    GitRefHistorySource(
+      repoRoot = repoRoot,
+      ref = ref,
+      syncMode = syncMode,
+      warnEmitter = warnEmitter,
+    )
+
+  private fun entry(
     id: String,
     previewId: String,
     bytes: ByteArray,
-    timestamp: String =
-      "2026-04-30T${id.substring(9, 11)}:${id.substring(11, 13)}:${id.substring(13, 15)}Z",
-  ): SynthEntry {
-    val pngHash = LocalFsHistorySource.sha256Hex(bytes)
-    return synthEntryFromHash(id, previewId, timestamp, pngHash, bytes)
-  }
-
-  private fun synthEntryFromHash(
-    id: String,
-    previewId: String,
-    timestamp: String,
-    pngHash: String,
-    bytes: ByteArray,
-  ): SynthEntry {
-    val entry =
-      HistoryEntry(
-        id = id,
-        previewId = previewId,
-        module = ":t",
-        timestamp = timestamp,
-        pngHash = pngHash,
-        pngSize = bytes.size.toLong(),
-        pngPath = "$id.png",
-        producer = "daemon",
-        trigger = "renderNow",
-        // The on-ref entry usually carries whatever source it was written under; rewrite happens
-        // at read-time. Here we set "fs" to prove the rewrite is unconditional.
-        source = HistorySourceInfo(kind = "fs", id = "fs:/some/dir"),
-        renderTookMs = 1L,
-      )
-    return SynthEntry(entry = entry, bytes = bytes)
-  }
-
-  private data class SynthEntry(val entry: HistoryEntry, val bytes: ByteArray)
-
-  private fun populatePreviewMain(entries: List<SynthEntry>) {
-    val tree = createTreeWithEntriesAndIndex(entries) { it }
-    val commit = commitTree(tree, parent = null, message = "history")
-    runOk("git", "-C", repoRoot.toString(), "update-ref", "refs/heads/preview/main", commit)
-  }
-
-  /**
-   * Builds an in-tree layout `<previewIdSan>/<id>.{png,json}` + `_index.jsonl` and returns the tree
-   * sha. Uses `git hash-object` + `git mktree` rather than building the working tree.
-   */
-  private fun createTreeWithEntriesAndIndex(
-    entries: List<SynthEntry>,
-    transformIndex: (String) -> String,
-  ): String {
-    // Group entries by sanitisedPreviewId. For each group, build a sub-tree with the per-entry
-    // .png + .json blobs.
-    val byPreview = entries.groupBy { PreviewIdSanitiser.sanitise(it.entry.previewId) }
-    val rootEntries = StringBuilder()
-    for ((sanitised, group) in byPreview) {
-      val subTreeEntries = StringBuilder()
-      for (synth in group) {
-        val pngSha = hashObject(synth.bytes)
-        val sidecarText = json.encodeToString(HistoryEntry.serializer(), synth.entry)
-        val sidecarSha = hashObject(sidecarText.toByteArray(StandardCharsets.UTF_8))
-        subTreeEntries.append("100644 blob $pngSha\t${synth.entry.id}.png\n")
-        subTreeEntries.append("100644 blob $sidecarSha\t${synth.entry.id}.json\n")
-      }
-      val subTree = mktree(subTreeEntries.toString())
-      rootEntries.append("040000 tree $subTree\t$sanitised\n")
-    }
-    // Build _index.jsonl — entries minus previewMetadata, one per line, append-order (oldest
-    // first).
-    val sortedByTs = entries.sortedBy { it.entry.timestamp }
-    val indexBody =
-      sortedByTs.joinToString("\n") {
-        json.encodeToString(HistoryEntry.serializer(), it.entry.copy(previewMetadata = null))
-      } + "\n"
-    val transformed = transformIndex(indexBody)
-    val indexSha = hashObject(transformed.toByteArray(StandardCharsets.UTF_8))
-    rootEntries.append("100644 blob $indexSha\t_index.jsonl\n")
-    return mktree(rootEntries.toString())
-  }
-
-  private fun createEmptyTree(): String = mktree("")
+    timestamp: String = "2026-04-30T10:12:34Z",
+    a11yHierarchy: JsonElement? = null,
+    theme: JsonElement? = null,
+  ): HistoryEntry =
+    HistoryEntry(
+      id = id,
+      previewId = previewId,
+      module = ":t",
+      timestamp = timestamp,
+      pngHash = LocalFsHistorySource.sha256Hex(bytes),
+      pngSize = bytes.size.toLong(),
+      pngPath = "$id.png",
+      producer = "daemon",
+      trigger = "renderNow",
+      source = HistorySourceInfo(kind = "fs", id = "fs:/some/dir"),
+      renderTookMs = 1L,
+      a11yHierarchy = a11yHierarchy,
+      theme = theme,
+    )
 
   private fun mktree(input: String): String {
     val pb =
@@ -377,23 +307,8 @@ class GitRefHistorySourceTest {
         .redirectErrorStream(false)
         .start()
     pb.outputStream.use { it.write(input.toByteArray(StandardCharsets.UTF_8)) }
-    val finished = pb.waitFor(15, TimeUnit.SECONDS)
-    require(finished) { "mktree timed out" }
-    require(pb.exitValue() == 0) { "mktree failed: ${pb.errorStream.bufferedReader().readText()}" }
-    return pb.inputStream.bufferedReader().readText().trim()
-  }
-
-  private fun hashObject(bytes: ByteArray): String {
-    val pb =
-      ProcessBuilder(listOf("git", "-C", repoRoot.toString(), "hash-object", "-w", "--stdin"))
-        .redirectErrorStream(false)
-        .start()
-    pb.outputStream.use { it.write(bytes) }
-    val finished = pb.waitFor(15, TimeUnit.SECONDS)
-    require(finished) { "hash-object timed out" }
-    require(pb.exitValue() == 0) {
-      "hash-object failed: ${pb.errorStream.bufferedReader().readText()}"
-    }
+    require(pb.waitFor(15, TimeUnit.SECONDS)) { "mktree timed out" }
+    require(pb.exitValue() == 0) { "mktree failed" }
     return pb.inputStream.bufferedReader().readText().trim()
   }
 
@@ -405,30 +320,32 @@ class GitRefHistorySourceTest {
       args.add(parent)
     }
     val pb = ProcessBuilder(args).redirectErrorStream(false).start()
-    val finished = pb.waitFor(15, TimeUnit.SECONDS)
-    require(finished) { "commit-tree timed out" }
-    require(pb.exitValue() == 0) {
-      "commit-tree failed: ${pb.errorStream.bufferedReader().readText()}"
-    }
+    require(pb.waitFor(15, TimeUnit.SECONDS)) { "commit-tree timed out" }
+    require(pb.exitValue() == 0) { "commit-tree failed" }
     return pb.inputStream.bufferedReader().readText().trim()
+  }
+
+  private fun capture(vararg args: String): String {
+    val pb = ProcessBuilder(args.toList()).redirectErrorStream(false).start()
+    val out = pb.inputStream.readBytes()
+    require(pb.waitFor(15, TimeUnit.SECONDS)) { "${args.joinToString(" ")} timed out" }
+    require(pb.exitValue() == 0) { "${args.joinToString(" ")} failed" }
+    return String(out, StandardCharsets.UTF_8)
   }
 
   private fun runOk(vararg args: String) {
     val pb = ProcessBuilder(args.toList()).redirectErrorStream(true).start()
-    val finished = pb.waitFor(15, TimeUnit.SECONDS)
-    require(finished) { "${args.joinToString(" ")} timed out" }
+    require(pb.waitFor(15, TimeUnit.SECONDS)) { "${args.joinToString(" ")} timed out" }
     if (pb.exitValue() != 0) {
-      val out = pb.inputStream.bufferedReader().readText()
-      error("${args.joinToString(" ")} failed: $out")
+      error("${args.joinToString(" ")} failed: ${pb.inputStream.bufferedReader().readText()}")
     }
   }
 
-  private fun gitAvailable(): Boolean {
-    return try {
+  private fun gitAvailable(): Boolean =
+    try {
       val pb = ProcessBuilder("git", "--version").redirectErrorStream(true).start()
       pb.waitFor(5, TimeUnit.SECONDS) && pb.exitValue() == 0
     } catch (_: Throwable) {
       false
     }
-  }
 }

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/GitRefHistorySourceTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/GitRefHistorySourceTest.kt
@@ -251,6 +251,44 @@ class GitRefHistorySourceTest {
     }
   }
 
+  @Test
+  fun reads_legacy_index_format_as_fallback() {
+    // A ref written under the legacy read-only format (`_index.jsonl` + `<id>.{png,json}`) must
+    // keep reading via the fallback, even though the writer now emits the git-as-the-log layout.
+    val e =
+      entry(
+        id = "20260430-100000-aaaaaaaa",
+        previewId = "com.example.Legacy",
+        bytes = "x".toByteArray(),
+      )
+    val dir = "com.example.Legacy"
+    val pngSha = hashObject("x".toByteArray())
+    val sidecarSha =
+      hashObject(
+        json.encodeToString(HistoryEntry.serializer(), e).toByteArray(StandardCharsets.UTF_8)
+      )
+    val sub = mktree("100644 blob $pngSha\t${e.id}.png\n100644 blob $sidecarSha\t${e.id}.json\n")
+    val indexSha =
+      hashObject(
+        (json.encodeToString(HistoryEntry.serializer(), e) + "\n").toByteArray(
+          StandardCharsets.UTF_8
+        )
+      )
+    val root = mktree("040000 tree $sub\t$dir\n100644 blob $indexSha\t_index.jsonl\n")
+    val commit = commitTree(root, parent = null, message = "legacy")
+    runOk("git", "-C", repoRoot.toString(), "update-ref", ref, commit)
+
+    val src = source(SyncModeOf.READ_ONLY)
+    val page = src.list(HistoryFilter())
+    assertEquals(1, page.totalCount)
+    assertEquals(e.id, page.entries[0].id)
+    assertEquals("git", page.entries[0].source.kind)
+
+    val read = src.read(e.id, includeBytes = true)
+    assertNotNull(read)
+    assertEquals("x", String(read!!.pngBytes!!))
+  }
+
   // -------------------------------------------------------------------------
   // Helpers
   // -------------------------------------------------------------------------
@@ -309,6 +347,17 @@ class GitRefHistorySourceTest {
     pb.outputStream.use { it.write(input.toByteArray(StandardCharsets.UTF_8)) }
     require(pb.waitFor(15, TimeUnit.SECONDS)) { "mktree timed out" }
     require(pb.exitValue() == 0) { "mktree failed" }
+    return pb.inputStream.bufferedReader().readText().trim()
+  }
+
+  private fun hashObject(bytes: ByteArray): String {
+    val pb =
+      ProcessBuilder(listOf("git", "-C", repoRoot.toString(), "hash-object", "-w", "--stdin"))
+        .redirectErrorStream(false)
+        .start()
+    pb.outputStream.use { it.write(bytes) }
+    require(pb.waitFor(15, TimeUnit.SECONDS)) { "hash-object timed out" }
+    require(pb.exitValue() == 0) { "hash-object failed" }
     return pb.inputStream.bufferedReader().readText().trim()
   }
 

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -200,17 +200,19 @@ fun runDaemon(
           GitProvenance(workspaceRoot = workspaceRootProp?.let(Path::of))
         } else null
       val gitRefHistoryRefs = GitRefHistorySource.parseRefsSysprop()
+      val gitRefSyncMode = GitRefHistorySource.parseSyncModeSysprop()
       val pruneConfig = HistoryPruneConfig.fromSysprops()
       historyDirProp?.let { dir ->
         System.err.println(
           "compose-ai-tools desktop daemon: HistoryManager active (dir=$dir, " +
-            "gitRefs=${gitRefHistoryRefs}, pruneConfig=$pruneConfig)"
+            "gitRefs=${gitRefHistoryRefs}, gitRefSyncMode=$gitRefSyncMode, pruneConfig=$pruneConfig)"
         )
         HistoryManager.forLocalFsAndGitRefs(
           historyDir = Path.of(dir),
           module = System.getProperty(MODULE_ID_PROP) ?: "",
           gitProvenance = gitProvenance,
           gitRefs = gitRefHistoryRefs,
+          gitRefSyncMode = gitRefSyncMode,
           repoRoot = workspaceRootProp?.let(Path::of) ?: Path.of(dir).parent,
           pruneConfig = pruneConfig,
         )

--- a/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S10MainHistoryReadTest.kt
+++ b/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S10MainHistoryReadTest.kt
@@ -48,6 +48,10 @@ class S10MainHistoryReadTest {
     val repoRoot = Files.createTempDirectory("s10-repo").toFile().apply { deleteOnExit() }
     initGitRepo(repoRoot)
     // Populate refs/heads/preview/main with two synthetic entries.
+    // Synthesised in the LEGACY read-only format (`_index.jsonl` + `<entryId>.{png,json}`), so this
+    // also covers GitRefHistorySource's legacy fallback reader for refs predating the
+    // git-as-the-log
+    // layout. Two renders of one preview → two index entries.
     val entries =
       listOf(
         synth(

--- a/docs/daemon/HISTORY.md
+++ b/docs/daemon/HISTORY.md
@@ -318,10 +318,11 @@ warn-level log message via the daemon log channel, then degrades:
 `list` returns empty, `read` returns null. `history/diff` against a
 missing ref entry returns `HistoryEntryNotFound (-32010)`.
 
-Sync modes: `READ_ONLY` (default, landed); `WRITE_LOCAL` (debounced
-local commits, no push); `WRITE_PUSH` (also `git push`). The daemon
-doesn't manage credentials — `WRITE_PUSH` requires a credential helper
-or SSH key in standard locations.
+Sync modes (`composeai.daemon.gitRefHistorySyncMode`): `READ_ONLY`
+(default) and `WRITE_LOCAL` (commit each changed render onto the ref via
+git plumbing, no push) are landed (#1870). `WRITE_PUSH` (also `git push`;
+the daemon doesn't manage credentials, so it needs a credential helper or
+SSH key) is a follow-up. See [`REPORTING-BRANCH.md`](REPORTING-BRANCH.md).
 
 ## Layering
 

--- a/docs/daemon/REPORTING-BRANCH.md
+++ b/docs/daemon/REPORTING-BRANCH.md
@@ -146,7 +146,10 @@ git-as-the-log layout above via git plumbing (a throwaway index +
 `update-ref`, never touching the working tree), commits one change per render
 with content-based skip-if-no-diff, and reads back the **current** branch state
 (one entry per preview). Enable it with `composeai.daemon.gitRefHistorySyncMode=WRITE_LOCAL`
-alongside `composeai.daemon.gitRefHistory=<ref>`.
+alongside `composeai.daemon.gitRefHistory=<ref>`. The skip-if-no-diff predicate matches
+`LocalFsHistorySource`'s (pixels + structural semantics) so the two writable sources never
+disagree on what counts as a duplicate. The reader also falls back to the legacy read-only
+format (`_index.jsonl` + `<entryId>.{png,json}`) for refs that predate this layout.
 
 Still to land (follow-ups):
 

--- a/docs/daemon/REPORTING-BRANCH.md
+++ b/docs/daemon/REPORTING-BRANCH.md
@@ -140,7 +140,20 @@ feeds the hosted "drift over time" surface (design-parity#13).
 
 ## Status
 
-This document specifies the contract. The write/push path that produces the
-branch (`GitRefHistorySource` `WRITE_LOCAL` / `WRITE_PUSH`) is **not yet
-landed** — see #1870. Today `GitRefHistorySource` is read-only and reads a
-single HEAD index; #1870 moves it to the commit-walk model above.
+`GitRefHistorySource` now implements **`WRITE_LOCAL`** (#1870): it writes the
+git-as-the-log layout above via git plumbing (a throwaway index +
+`hash-object` / `read-tree` / `update-index` / `write-tree` / `commit-tree` /
+`update-ref`, never touching the working tree), commits one change per render
+with content-based skip-if-no-diff, and reads back the **current** branch state
+(one entry per preview). Enable it with `composeai.daemon.gitRefHistorySyncMode=WRITE_LOCAL`
+alongside `composeai.daemon.gitRefHistory=<ref>`.
+
+Still to land (follow-ups):
+
+- **`WRITE_PUSH`** — also `git push` the ref, with fetch–rebase–retry on a push
+  race (needs a remote + credentials).
+- **Commit-walk timeline read** — `list` / `read` over the full history of a
+  preview (and the `<shortCommit>:<previewId>` entryId addressing), rather than
+  only the current state. Spec'd here; tracked under #1868.
+- **Burst debounce** — batch a render burst into one commit instead of one
+  commit per render.


### PR DESCRIPTION
The last foundation piece of the report-history epic (#1866). Lands the **reporting-branch writer** (`WRITE_LOCAL` scope of #1870) per the git-as-the-log contract in `REPORTING-BRANCH.md` (#1868), consuming the multi-product history entries from #1869.

## What this does

- **`SyncMode { READ_ONLY (default), WRITE_LOCAL }`** on `GitRefHistorySource`; `supportsWrites()` gates on it. Configured via `composeai.daemon.gitRefHistorySyncMode=WRITE_LOCAL` (alongside `composeai.daemon.gitRefHistory=<ref>`), wired through `HistoryManager.forLocalFsAndGitRefs` and both daemon mains. Default stays `READ_ONLY`, so existing behaviour is unchanged.
- **`write()` materialises the git-as-the-log layout** — overwritten per-preview `render.png` + `entry.json`, the projected `semantics.json` / `a11y.json` / `a11y-atf.json` / `a11y-touch-targets.json` / `theme.json` (from the entry's inline #1869 snapshots), and a regenerated `manifest.json` — and commits **one change per render**.
- **Working-tree safe.** Uses a throwaway temp index + plumbing (`hash-object` / `read-tree` / `update-index` / `write-tree` / `commit-tree` / `update-ref`). The daemon runs inside the user's live repo, so it never `checkout`/`add`s or touches the working tree or checked-out branch — only the reporting ref + object DB.
- **Content-based skip-if-no-diff.** An unchanged re-render (same pixels **and** same data snapshots) makes no commit. Compares render *content*, not id/timestamp churn or the manifest's `generatedAt` (which would otherwise defeat dedup). The preview dir is rewritten wholesale, so a render that drops a data product doesn't leave a stale file behind.
- **Read returns current branch state** (one entry per preview, from each `<dir>/entry.json`), stamped as a `git` source.
- **Never throws:** any git failure degrades to `SKIPPED_DUPLICATE` and logs — history can't break a render.

## Deferred (follow-ups, noted in REPORTING-BRANCH.md)

- `WRITE_PUSH` (also `git push` with fetch–rebase–retry) — needs a remote/credentials, can't be exercised in this sandbox.
- Commit-walk **timeline** read + `<shortCommit>:<previewId>` addressing (#1868) — this PR reads current state only.
- Burst debounce (batch a render burst into one commit).

## Test plan

`./gradlew :daemon:core:test --tests "*GitRefHistorySourceTest"` — **7/7 pass, 0 skipped**:
- write→read round-trip + `manifest.json` (formatVersion + previews + dataProducts),
- skip-unchanged render (asserts exactly one commit),
- overwrite drops a stale `a11y.json`,
- cross-source dedup + `sourceKind` filtering across LocalFs + git,
- missing/empty ref read behaviour.

(Verified locally under a UTF-8 locale; an unrelated pre-existing test with an em-dash in its method name trips a non-UTF-8 sandbox locale, not this change.)

Non-visual change (daemon git plumbing + tests + docs), so no rendered evidence applies.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CPjwnCtY5aiBTFkVrrFjhS)_