### PR TITLE
feat(cli): add history list/read/diff commands

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/HistoryCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/HistoryCommand.kt
@@ -1,0 +1,355 @@
+package ee.schimke.composeai.cli
+
+import ee.schimke.composeai.daemon.history.GitRefHistorySource
+import ee.schimke.composeai.daemon.history.HistoryEntry
+import ee.schimke.composeai.daemon.history.HistoryFilter
+import ee.schimke.composeai.daemon.history.HistorySource
+import ee.schimke.composeai.daemon.history.LocalFsHistorySource
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.util.Base64
+import kotlin.system.exitProcess
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+
+/**
+ * `compose-preview history <list|read|diff>` — inspect the render history the daemon archives.
+ *
+ * Reads the local filesystem archive (`.compose-preview-history/`, the daemon's default
+ * [LocalFsHistorySource]) by default, or the reporting branch ([GitRefHistorySource]) when `--ref
+ * <fullRef>` is given. Both expose the same [HistorySource] read API, so the three subcommands are
+ * source-agnostic. Reading off disk gives correct results whether or not a daemon is running, since
+ * the daemon writes there.
+ *
+ * **Structured-first** (cf. #1787): human output is compact metadata; `--json` emits a versioned
+ * envelope (`compose-preview-history/v1`); heavy snapshots (PNG bytes, a11y/semantics/theme data)
+ * ride only on explicit opt-in (`--inline`, `--out`, `--data`).
+ *
+ * v1 reads on-disk / on-branch history directly. Preferring a running daemon's `history` JSON-RPC
+ * methods (for live, not-yet-flushed state) needs a CLI-side daemon client — tracked as a
+ * follow-up; the on-disk read is the source of truth the daemon persists to.
+ */
+class HistoryCommand(private val args: List<String>) {
+
+  fun run() {
+    when (args.firstOrNull { !it.startsWith("-") } ?: "help") {
+      "list" -> list()
+      "read" -> read()
+      "diff" -> diff()
+      "help" -> printUsage()
+      else -> {
+        System.err.println(
+          "Unknown history subcommand: ${args.firstOrNull { !it.startsWith("-") }}"
+        )
+        printUsage()
+        exitProcess(1)
+      }
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Subcommands
+  // -------------------------------------------------------------------------
+
+  private fun list() {
+    val json = "--json" in args
+    val source = openSource(json) ?: return
+    val filter =
+      HistoryFilter(
+        previewId = args.flagValue("--preview"),
+        since = args.flagValue("--since"),
+        until = args.flagValue("--until"),
+        branch = args.flagValue("--branch"),
+        commit = args.flagValue("--commit"),
+        agentId = args.flagValue("--agent"),
+        sourceKind = args.flagValue("--source"),
+        cursor = args.flagValue("--cursor"),
+        limit = args.flagValue("--limit")?.toIntOrNull() ?: DEFAULT_LIMIT,
+      )
+    val page = source.list(filter)
+
+    if (json) {
+      val payload =
+        HistoryListResponse(
+          schema = HISTORY_SCHEMA,
+          total = page.totalCount,
+          nextCursor = page.nextCursor,
+          entries = page.entries.map(::leanEntryJson),
+        )
+      println(OUT.encodeToString(HistoryListResponse.serializer(), payload))
+      return
+    }
+
+    if (page.entries.isEmpty()) {
+      println("No history entries (source: ${source.id}).")
+      return
+    }
+    println("Showing ${page.entries.size} of ${page.totalCount} entries (source: ${source.id}):")
+    for (e in page.entries) {
+      val short = e.git?.shortCommit?.let { " @$it" } ?: ""
+      val data = dataProductsOf(e).takeIf { it.isNotEmpty() }?.joinToString(",", " [", "]") ?: ""
+      println("  ${e.id}  ${e.previewId}  ${e.timestamp}  (${e.trigger})$short$data")
+    }
+    page.nextCursor?.let { println("\nmore: --cursor $it") }
+  }
+
+  private fun read() {
+    val json = "--json" in args
+    val id = positionalAfter("read")
+    if (id == null) {
+      System.err.println("history read: missing <entryId>")
+      exitProcess(1)
+    }
+    val source =
+      openSource(json)
+        ?: run {
+          // openSource already reported "no history"; a read of a specific id is then a miss.
+          System.err.println("history read: entry not found: $id")
+          exitProcess(2)
+        }
+    val out = args.flagValue("--out")
+    val wantData = "--data" in args
+    val inline = "--inline" in args
+    val result = source.read(id, includeBytes = inline || out != null)
+    if (result == null) {
+      System.err.println("history read: entry not found: $id")
+      exitProcess(2)
+    }
+    val entry = result.entry
+
+    out?.let { path ->
+      val bytes = result.pngBytes
+      if (bytes == null) {
+        System.err.println("history read: no PNG bytes available for $id")
+        exitProcess(2)
+      }
+      Files.write(Paths.get(path), bytes)
+    }
+
+    if (json) {
+      val payload =
+        HistoryReadResponse(
+          schema = HISTORY_SCHEMA,
+          entry = if (wantData) fullEntryJson(entry) else leanEntryJson(entry),
+          pngPath = result.pngPath,
+          dataProducts = dataProductsOf(entry),
+          pngBytes =
+            if (inline) result.pngBytes?.let { Base64.getEncoder().encodeToString(it) } else null,
+        )
+      println(OUT.encodeToString(HistoryReadResponse.serializer(), payload))
+      return
+    }
+
+    println(entry.id)
+    println("  preview:   ${entry.previewId}  (${entry.module})")
+    println("  timestamp: ${entry.timestamp}   trigger: ${entry.trigger}")
+    println(
+      "  png:       ${result.pngPath}  (${entry.pngSize} bytes, sha ${entry.pngHash.take(12)})"
+    )
+    entry.git?.let { g ->
+      println(
+        "  git:       ${g.branch ?: "(detached)"}@${g.shortCommit ?: "?"}  dirty=${g.dirty ?: "?"}"
+      )
+    }
+    val data = dataProductsOf(entry)
+    println("  data:      ${if (data.isEmpty()) "none" else data.joinToString(", ")}")
+    out?.let { println("  wrote PNG: $it") }
+  }
+
+  private fun diff() {
+    val json = "--json" in args
+    val mode = args.flagValue("--mode") ?: "metadata"
+    if (mode != "metadata") {
+      System.err.println(
+        "history diff: --mode $mode is not available from the CLI yet (pixel/semantics diff is " +
+          "daemon-backed via history/diff). Use --mode metadata."
+      )
+      exitProcess(1)
+    }
+    val ids = positionalsAfter("diff")
+    if (ids.size < 2) {
+      System.err.println("history diff: need two entry ids: <fromId> <toId>")
+      exitProcess(1)
+    }
+    val (fromId, toId) = ids
+    val source =
+      openSource(json)
+        ?: run {
+          System.err.println("history diff: entries not found")
+          exitProcess(2)
+        }
+    val from = source.read(fromId)?.entry
+    val to = source.read(toId)?.entry
+    if (from == null || to == null) {
+      System.err.println("history diff: entry not found: ${if (from == null) fromId else toId}")
+      exitProcess(2)
+    }
+    if (from.previewId != to.previewId) {
+      System.err.println(
+        "history diff: entries are different previews (${from.previewId} vs ${to.previewId})"
+      )
+      exitProcess(2)
+    }
+    val pngHashChanged = from.pngHash != to.pngHash
+
+    if (json) {
+      val payload =
+        HistoryDiffResponse(
+          schema = HISTORY_SCHEMA,
+          mode = "metadata",
+          pngHashChanged = pngHashChanged,
+          from = leanEntryJson(from),
+          to = leanEntryJson(to),
+        )
+      println(OUT.encodeToString(HistoryDiffResponse.serializer(), payload))
+      return
+    }
+
+    println("diff ${from.id} → ${to.id}  (preview ${from.previewId})")
+    println("  pixels:    ${if (pngHashChanged) "CHANGED" else "unchanged"}")
+    if (from.timestamp != to.timestamp) println("  timestamp: ${from.timestamp} → ${to.timestamp}")
+    if (from.git?.commit != to.git?.commit) {
+      println("  commit:    ${from.git?.shortCommit ?: "?"} → ${to.git?.shortCommit ?: "?"}")
+    }
+    val fromData = dataProductsOf(from)
+    val toData = dataProductsOf(to)
+    if (fromData != toData) println("  data:      $fromData → $toData")
+  }
+
+  // -------------------------------------------------------------------------
+  // Source resolution + helpers
+  // -------------------------------------------------------------------------
+
+  /**
+   * Opens the history source: `--ref <fullRef>` reads the reporting branch (git), else the local
+   * `.compose-preview-history/`. Returns null (after reporting "no history") only for the local
+   * case when the dir is absent, so callers can short-circuit.
+   */
+  private fun openSource(json: Boolean): HistorySource? {
+    val ref = args.flagValue("--ref")
+    val cwd = Paths.get(System.getProperty("user.dir"))
+    if (ref != null) {
+      return GitRefHistorySource(repoRoot = cwd, ref = ref)
+    }
+    val dir = args.flagValue("--history-dir")?.let { Paths.get(it) } ?: cwd.resolve(HISTORY_DIRNAME)
+    if (!Files.isDirectory(dir)) {
+      if (json) {
+        println(
+          OUT.encodeToString(
+            HistoryListResponse.serializer(),
+            HistoryListResponse(schema = HISTORY_SCHEMA, total = 0, entries = emptyList()),
+          )
+        )
+      } else {
+        println("No history found at $dir (no renders archived yet).")
+      }
+      return null
+    }
+    return LocalFsHistorySource(dir)
+  }
+
+  private fun positionalAfter(sub: String): String? = positionalsAfter(sub).firstOrNull()
+
+  /** Non-flag args after the subcommand token, in order (the entry ids). */
+  private fun positionalsAfter(sub: String): List<String> {
+    val nonFlags = args.filterNot { it.startsWith("-") }
+    val idx = nonFlags.indexOf(sub)
+    return if (idx >= 0) nonFlags.drop(idx + 1) else emptyList()
+  }
+
+  private fun dataProductsOf(e: HistoryEntry): List<String> = buildList {
+    if (e.semantics != null) add("compose/semantics")
+    if (e.a11yHierarchy != null) add("a11y/hierarchy")
+    if (e.a11yAtf != null) add("a11y/atf")
+    if (e.a11yTouchTargets != null) add("a11y/touchTargets")
+    if (e.theme != null) add("compose/theme")
+  }
+
+  private fun leanEntryJson(e: HistoryEntry): JsonElement =
+    ENTRY.encodeToJsonElement(
+      HistoryEntry.serializer(),
+      e.copy(
+        semantics = null,
+        a11yAtf = null,
+        a11yHierarchy = null,
+        a11yTouchTargets = null,
+        theme = null,
+      ),
+    )
+
+  private fun fullEntryJson(e: HistoryEntry): JsonElement =
+    ENTRY.encodeToJsonElement(HistoryEntry.serializer(), e)
+
+  private fun printUsage() {
+    println(
+      """
+      compose-preview history — inspect archived render history
+
+      Subcommands:
+        list                 List history entries (newest first)
+        read <entryId>       Show one entry's metadata (and optionally its PNG / data)
+        diff <fromId> <toId> Compare two entries (metadata mode)
+        help                 Show this help message
+
+      Source:
+        --history-dir <dir>  History dir (default: <cwd>/$HISTORY_DIRNAME)
+        --ref <fullRef>      Read the reporting branch instead, e.g. refs/heads/preview/main
+
+      list options:
+        --preview <id>  --since <iso>  --until <iso>  --branch <b>  --commit <sha>
+        --agent <id>    --source <fs|git>  --limit <n>  --cursor <c>
+
+      read options:
+        --out <path>   Write the entry's PNG to <path>
+        --data         Include the full a11y/semantics/theme snapshots (--json)
+        --inline       Include base64 PNG bytes (--json)
+
+      diff options:
+        --mode metadata        (pixel/semantics diff is daemon-backed; not in the CLI yet)
+
+      Common:
+        --json         Emit JSON (schema: $HISTORY_SCHEMA)
+      """
+        .trimIndent()
+    )
+  }
+
+  internal companion object {
+    const val HISTORY_SCHEMA = "compose-preview-history/v1"
+    const val HISTORY_DIRNAME = ".compose-preview-history"
+    private const val DEFAULT_LIMIT = 50
+
+    private val OUT = Json {
+      prettyPrint = true
+      encodeDefaults = true
+    }
+    private val ENTRY = Json { encodeDefaults = false }
+  }
+}
+
+@Serializable
+internal data class HistoryListResponse(
+  val schema: String,
+  val total: Int,
+  val nextCursor: String? = null,
+  val entries: List<JsonElement>,
+)
+
+@Serializable
+internal data class HistoryReadResponse(
+  val schema: String,
+  val entry: JsonElement,
+  val pngPath: String,
+  val dataProducts: List<String>,
+  val pngBytes: String? = null,
+)
+
+@Serializable
+internal data class HistoryDiffResponse(
+  val schema: String,
+  val mode: String,
+  val pngHashChanged: Boolean,
+  val from: JsonElement,
+  val to: JsonElement,
+)

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/HistoryCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/HistoryCommand.kt
@@ -251,11 +251,27 @@ class HistoryCommand(private val args: List<String>) {
 
   private fun positionalAfter(sub: String): String? = positionalsAfter(sub).firstOrNull()
 
-  /** Non-flag args after the subcommand token, in order (the entry ids). */
+  /**
+   * Operands after the subcommand token, in order (the entry ids). Skips flag tokens *and* the
+   * value of a space-separated valued flag (e.g. `--history-dir /tmp/h e1` → `[e1]`), so options
+   * may appear before the ids.
+   */
   private fun positionalsAfter(sub: String): List<String> {
-    val nonFlags = args.filterNot { it.startsWith("-") }
-    val idx = nonFlags.indexOf(sub)
-    return if (idx >= 0) nonFlags.drop(idx + 1) else emptyList()
+    val positionals = mutableListOf<String>()
+    var i = 0
+    while (i < args.size) {
+      val a = args[i]
+      when {
+        a.startsWith("--") && "=" !in a && a in VALUED_FLAGS -> i += 2 // flag + its value
+        a.startsWith("-") -> i += 1 // boolean flag, or `--flag=value`
+        else -> {
+          positionals.add(a)
+          i += 1
+        }
+      }
+    }
+    val idx = positionals.indexOf(sub)
+    return if (idx >= 0) positionals.drop(idx + 1) else emptyList()
   }
 
   private fun dataProductsOf(e: HistoryEntry): List<String> = buildList {
@@ -319,6 +335,24 @@ class HistoryCommand(private val args: List<String>) {
     const val HISTORY_SCHEMA = "compose-preview-history/v1"
     const val HISTORY_DIRNAME = ".compose-preview-history"
     private const val DEFAULT_LIMIT = 50
+
+    /** Flags that take a value, so a space-separated value isn't mistaken for an operand. */
+    private val VALUED_FLAGS =
+      setOf(
+        "--history-dir",
+        "--ref",
+        "--preview",
+        "--since",
+        "--until",
+        "--branch",
+        "--commit",
+        "--agent",
+        "--source",
+        "--cursor",
+        "--limit",
+        "--mode",
+        "--out",
+      )
 
     private val OUT = Json {
       prettyPrint = true

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
@@ -76,6 +76,7 @@ fun main(args: Array<String>) {
     "render-matrix" -> RenderMatrixCommand(allArgs).run()
     "a11y" -> A11yCommand(allArgs).run()
     "diff-semantics" -> SemanticsDiffCommand(allArgs).run()
+    "history" -> HistoryCommand(allArgs).run()
     "extensions" -> ExtensionsCommand(allArgs).run()
     "profile" -> ProfileCommand(allArgs).run()
     "doctor" -> DoctorCommand(allArgs).run()
@@ -120,6 +121,8 @@ private fun printUsage() {
       diff-semantics   Diff two compose/semantics trees (base vs head) and report what
                        changed semantically — a cheap, pixel-free regression signal:
                        `compose-preview diff-semantics <base> <head> [--json] [--fail-on-change]`
+      history          Inspect archived render history: `history list|read|diff` over the
+                       local `.compose-preview-history/` archive or a `--ref` reporting branch
       extensions       Introspect registered data extensions (`extensions list`)
       profile          Run a saved JSON profile: `compose-preview profile <path.json>`. A
                        profile bundles `extensions`, `filter`, `failOn`, and a chosen `report`

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/HistoryCommandTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/HistoryCommandTest.kt
@@ -1,0 +1,136 @@
+package ee.schimke.composeai.cli
+
+import ee.schimke.composeai.daemon.history.HistoryEntry
+import ee.schimke.composeai.daemon.history.HistorySourceInfo
+import ee.schimke.composeai.daemon.history.LocalFsHistorySource
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+/** Coverage for `compose-preview history list|read|diff` over a seeded local FS archive. */
+class HistoryCommandTest {
+
+  private lateinit var historyDir: Path
+  private lateinit var capturedOut: ByteArrayOutputStream
+  private var savedOut: PrintStream? = null
+
+  @BeforeTest
+  fun setUp() {
+    historyDir = Files.createTempDirectory("history-cmd-test")
+    capturedOut = ByteArrayOutputStream()
+    savedOut = System.out
+    System.setOut(PrintStream(capturedOut))
+  }
+
+  @AfterTest
+  fun tearDown() {
+    savedOut?.let { System.setOut(it) }
+    historyDir.toFile().deleteRecursively()
+  }
+
+  private fun output(): String = capturedOut.toString()
+
+  /** Seeds one entry; returns its id. */
+  private fun seed(
+    id: String,
+    previewId: String,
+    bytes: ByteArray,
+    timestamp: String,
+    a11yHierarchy: Boolean = false,
+  ): String {
+    val source = LocalFsHistorySource(historyDir)
+    val entry =
+      HistoryEntry(
+        id = id,
+        previewId = previewId,
+        module = ":t",
+        timestamp = timestamp,
+        pngHash = LocalFsHistorySource.sha256Hex(bytes),
+        pngSize = bytes.size.toLong(),
+        pngPath = "$id.png",
+        producer = "daemon",
+        trigger = "renderNow",
+        source = HistorySourceInfo(kind = "fs", id = "fs:${historyDir.toAbsolutePath()}"),
+        renderTookMs = 1L,
+        a11yHierarchy =
+          if (a11yHierarchy)
+            Json.parseToJsonElement("""{"nodes":[{"label":"x","boundsInScreen":"0,0,1,1"}]}""")
+          else null,
+      )
+    source.write(entry, bytes)
+    return id
+  }
+
+  @Test
+  fun `list --json emits versioned envelope newest-first`() {
+    seed("20260430-100000-aaaaaaaa", "com.example.A", "v1".toByteArray(), "2026-04-30T10:00:00Z")
+    seed("20260430-100100-bbbbbbbb", "com.example.A", "v2".toByteArray(), "2026-04-30T10:01:00Z")
+
+    HistoryCommand(listOf("list", "--history-dir", historyDir.toString(), "--json")).run()
+    val payload = Json.parseToJsonElement(output()).jsonObject
+
+    assertEquals(JsonPrimitive(HistoryCommand.HISTORY_SCHEMA), payload["schema"])
+    assertEquals(2, payload["total"]?.jsonPrimitive?.content?.toInt())
+    val ids = payload["entries"]!!.jsonArray.map { it.jsonObject["id"]?.jsonPrimitive?.content }
+    assertEquals(
+      listOf("20260430-100100-bbbbbbbb", "20260430-100000-aaaaaaaa"),
+      ids,
+      "newest-first",
+    )
+  }
+
+  @Test
+  fun `read --json returns metadata, pngPath and dataProducts`() {
+    val id =
+      seed(
+        "20260430-100000-cccccccc",
+        "com.example.Card",
+        "x".toByteArray(),
+        "2026-04-30T10:00:00Z",
+        a11yHierarchy = true,
+      )
+
+    HistoryCommand(listOf("read", id, "--history-dir", historyDir.toString(), "--json")).run()
+    val payload = Json.parseToJsonElement(output()).jsonObject
+
+    assertEquals(JsonPrimitive(HistoryCommand.HISTORY_SCHEMA), payload["schema"])
+    assertEquals(id, payload["entry"]!!.jsonObject["id"]?.jsonPrimitive?.content)
+    assertTrue(payload["pngPath"]?.jsonPrimitive?.content?.endsWith(".png") == true)
+    val data = payload["dataProducts"]!!.jsonArray.map { it.jsonPrimitive.content }
+    assertTrue("a11y/hierarchy" in data, "expected a11y/hierarchy in $data")
+  }
+
+  @Test
+  fun `diff --json reports pngHashChanged for differing renders`() {
+    val from =
+      seed("20260430-100000-d0d0d0d0", "com.example.A", "v1".toByteArray(), "2026-04-30T10:00:00Z")
+    val to =
+      seed("20260430-100100-e1e1e1e1", "com.example.A", "v2".toByteArray(), "2026-04-30T10:01:00Z")
+
+    HistoryCommand(listOf("diff", from, to, "--history-dir", historyDir.toString(), "--json")).run()
+    val payload = Json.parseToJsonElement(output()).jsonObject
+
+    assertEquals(JsonPrimitive(HistoryCommand.HISTORY_SCHEMA), payload["schema"])
+    assertEquals(true, payload["pngHashChanged"]?.jsonPrimitive?.content?.toBoolean())
+  }
+
+  @Test
+  fun `list on a missing history dir emits an empty envelope`() {
+    val missing = historyDir.resolve("nope")
+    HistoryCommand(listOf("list", "--history-dir", missing.toString(), "--json")).run()
+    val payload = Json.parseToJsonElement(output()).jsonObject
+    assertEquals(0, payload["total"]?.jsonPrimitive?.content?.toInt())
+    assertTrue(payload["entries"]!!.jsonArray.isEmpty())
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/HistoryCommandTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/HistoryCommandTest.kt
@@ -126,6 +126,43 @@ class HistoryCommandTest {
   }
 
   @Test
+  fun `read resolves the id when a valued option precedes it`() {
+    val id =
+      seed("20260430-100000-ffffffff", "com.example.A", "x".toByteArray(), "2026-04-30T10:00:00Z")
+
+    // --history-dir's value sits between the subcommand and the id.
+    HistoryCommand(listOf("read", "--history-dir", historyDir.toString(), id, "--json")).run()
+    val payload = Json.parseToJsonElement(output()).jsonObject
+
+    assertEquals(id, payload["entry"]!!.jsonObject["id"]?.jsonPrimitive?.content)
+  }
+
+  @Test
+  fun `diff resolves both ids when --mode precedes them`() {
+    val from =
+      seed("20260430-100000-a1a1a1a1", "com.example.A", "v1".toByteArray(), "2026-04-30T10:00:00Z")
+    val to =
+      seed("20260430-100100-b2b2b2b2", "com.example.A", "v2".toByteArray(), "2026-04-30T10:01:00Z")
+
+    HistoryCommand(
+        listOf(
+          "diff",
+          "--mode",
+          "metadata",
+          "--history-dir",
+          historyDir.toString(),
+          from,
+          to,
+          "--json",
+        )
+      )
+      .run()
+    val payload = Json.parseToJsonElement(output()).jsonObject
+
+    assertEquals(true, payload["pngHashChanged"]?.jsonPrimitive?.content?.toBoolean())
+  }
+
+  @Test
   fun `list on a missing history dir emits an empty envelope`() {
     val missing = historyDir.resolve("nope")
     HistoryCommand(listOf("list", "--history-dir", missing.toString(), "--json")).run()

--- a/docs/daemon/HISTORY.md
+++ b/docs/daemon/HISTORY.md
@@ -333,6 +333,29 @@ read or write history — the legacy writer was removed.
 Cross-worktree merging happens above Layer 2 (in MCP, or in the
 editor) — never inside a daemon.
 
+## CLI
+
+`compose-preview history <list|read|diff>` inspects the archive from the
+terminal (issue #1871). It reads the on-disk `.compose-preview-history/`
+([LocalFsHistorySource]) directly — correct whether or not a daemon is
+running, since the daemon persists there — or a reporting branch with
+`--ref refs/heads/preview/main` ([GitRefHistorySource]).
+
+```
+compose-preview history list   [--preview <id>] [--since/--until <iso>] [--branch <b>]
+                               [--commit <sha>] [--source fs|git] [--agent <id>]
+                               [--limit <n>] [--cursor <c>] [--history-dir <dir> | --ref <ref>] [--json]
+compose-preview history read   <entryId> [--out <png>] [--data] [--inline] [--json]
+compose-preview history diff   <fromId> <toId> [--mode metadata] [--json]
+```
+
+Structured-first (cf. #1787): human output is compact; `--json` emits a
+versioned envelope (`compose-preview-history/v1`); heavy snapshots (PNG
+bytes via `--inline`/`--out`, a11y/semantics/theme data via `--data`) ride
+only on explicit opt-in. `diff` is metadata-mode only today; pixel /
+semantics diff is daemon-backed (`history/diff`) and reaches the CLI once
+it grows a daemon JSON-RPC client (follow-up).
+
 ## MCP mapping
 
 URI scheme: `compose-preview-history://<module>/<previewFqn>/<entryId>`


### PR DESCRIPTION
First **surfacing-tier** piece of the report-history epic (#1866): the terminal/scriptable surface for inspecting the history the foundation now collects. Closes #1871.

## What this adds

`compose-preview history <list|read|diff>`:

- **`list`** — newest-first, with `--preview` / `--since` / `--until` / `--branch` / `--commit` / `--source` / `--agent` / `--limit` / `--cursor` filters.
- **`read <entryId>`** — entry metadata + `pngPath`; `--out <png>` writes the PNG, `--data` includes the a11y/semantics/theme snapshots, `--inline` includes base64 bytes.
- **`diff <fromId> <toId>`** — metadata mode (pixel/semantics diff is daemon-backed `history/diff`, a follow-up — see below).

**Source**: reads the on-disk `.compose-preview-history/` archive (`LocalFsHistorySource`) directly — correct whether or not a daemon is running, since the daemon persists there — or a reporting branch via `--ref refs/heads/preview/main` (`GitRefHistorySource`). Both share the `HistorySource` read API, so the subcommands are source-agnostic.

**Structured-first** (cf. #1787): human output is compact; `--json` emits a versioned envelope (`compose-preview-history/v1`); heavy snapshots (PNG bytes, a11y/semantics/theme data) ride only on explicit opt-in (`--inline` / `--out` / `--data`) — token-frugal by default for agent use.

Registered in `Main.kt` + usage; `HISTORY.md` documents the CLI surface.

## Scope / follow-up

v1 reads on-disk / on-branch history directly (the source of truth the daemon persists to). Preferring a *running* daemon's `history/*` JSON-RPC for live not-yet-flushed state needs a CLI-side daemon JSON-RPC client — there's none today; tracked as a follow-up. Same for `diff --mode pixel|semantics` (daemon-backed).

## Test plan

`./gradlew :cli:test --tests "*HistoryCommandTest"` — **4/4 pass**: `list`/`read`/`diff` `--json` envelopes (schema, totals, newest-first ordering, `dataProducts`, `pngHashChanged`) + empty-history-dir handling. `:cli:ktfmtFormat` applied; `:cli:compileKotlin` clean.

Non-visual change (CLI plumbing + tests + docs), so no rendered evidence applies.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CPjwnCtY5aiBTFkVrrFjhS)_