### PR TITLE
feat(daemon): enable history recording by default; gate VS Code history UI behind early-access flag

### DIFF
--- a/build-logic/src/main/kotlin/ee/schimke/composeai/buildlogic/ComposeAiBaseConventionsPlugin.kt
+++ b/build-logic/src/main/kotlin/ee/schimke/composeai/buildlogic/ComposeAiBaseConventionsPlugin.kt
@@ -23,12 +23,13 @@ class ComposeAiBaseConventionsPlugin : Plugin<Project> {
     project.pluginManager.apply("com.ncorti.ktfmt.gradle")
     project.extensions.configure<KtfmtExtension>("ktfmt") { googleStyle() }
 
-    // History feature gate (`HistoryFeature.ENABLED`, post-1.0). Test JVMs run with the gate
-    // flipped on so the history implementation stays green and unbroken for the 1.1 re-enable —
-    // production daemons leave the property unset and the const-default `false` keeps the wire-up
-    // dead. Re-evaluate (and drop) when the 1.1 cut flips the default to `true`.
+    // History recording is on by default in the daemon (`HistoryFeature.ENABLED`); tests set it
+    // explicitly so they stay pinned if that default ever changes. Git-provenance caching is
+    // disabled in tests (`gitProvenanceTtlMs=0`) so per-render provenance stays fresh and
+    // deterministic — production uses the default TTL to collapse render-burst git fetches.
     project.tasks.withType<Test>().configureEach {
       systemProperty("composeai.history.enabled", "true")
+      systemProperty("composeai.history.gitProvenanceTtlMs", "0")
     }
   }
 }

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -254,10 +254,10 @@ fun main(args: Array<String>) {
       IncrementalDiscovery(classpath = classpath)
     } else null
 
-  // History feature gated to 1.1 (see [HistoryFeature]). When disabled — the 1.0 cut —
-  // `historyManager` stays null and every history wireup (sysprop reads, git-ref sources, prune
-  // budgets) compiles out. Mirrors the desktop daemon's gate; HISTORY.md describes the original
-  // H1+H2 wiring this block preserves verbatim for the 1.1 re-enable.
+  // History recording is on by default (see [HistoryFeature]); with
+  // `-Dcomposeai.history.enabled=false` `historyManager` stays null and every history wireup
+  // (sysprop reads, git-ref sources, prune budgets) elides. Mirrors the desktop daemon's gate;
+  // HISTORY.md describes the H1+H2 wiring this block sets up.
   val historyManager: HistoryManager? =
     if (HistoryFeature.ENABLED) {
       val historyDirProp = System.getProperty(HISTORY_DIR_PROP)

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/HistoryFeature.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/HistoryFeature.kt
@@ -1,14 +1,13 @@
 package ee.schimke.composeai.daemon
 
 /**
- * History feature gate — **post-1.0; deferred to 1.1**.
+ * History feature gate.
  *
  * The per-render history archive and the history JSON-RPC surface (`history/list`, `history/read`,
  * `history/diff`, `history/prune`, the `history/diff-regions` data product, the VS Code history
- * panel, the `composeai.daemon.historyDir` sysprop wiring) added more moving parts than we want to
- * cut 1.0 with: PNG + JSON write-back on every render, the git-ref-backed read sources, prune
- * budgets, and the diff UI on the panel side. Until 1.1 those pay no rent — when [ENABLED] is
- * `false`:
+ * panel, the `composeai.daemon.historyDir` sysprop wiring) are **on by default** — the daemon
+ * records each changed render to the local history archive and serves the `history/…` methods. When
+ * [ENABLED] is `false`:
  *
  * - `HistoryManager` is never constructed (no `historyDir` reads, no fs touches).
  * - The `history/diff-regions` extension is not registered, so it doesn't show up in
@@ -18,20 +17,16 @@ package ee.schimke.composeai.daemon
  *   pre-dates H1.
  * - The VS Code extension hides its history panel and the focus-view history section.
  *
- * **Production / tests.** [ENABLED] reads `composeai.history.enabled` on each access, defaulting to
- * `false`. Production daemons never set the property and pay the gate cost (one `getProperty` per
- * check); test JVMs flip the property to `true` via a shared Gradle `systemProperty` declaration
- * (root `build.gradle.kts` → `allprojects.tasks.withType<Test>`) so the history implementation
- * keeps green and unbroken for the 1.1 re-enable. The implementation files are preserved in place —
- * this is a feature gate, **not a deletion**.
- *
- * Flip the default to `true` (and drop the sysprop indirection) when the 1.1 re-enable lands.
+ * [ENABLED] reads `composeai.history.enabled` on each access, defaulting to `true`. The sysprop
+ * stays as an explicit off-switch (`-Dcomposeai.history.enabled=false`) for anyone who wants to opt
+ * out of history recording. `history/diff` carries its own additional experimental gate (see
+ * `JsonRpcServer`), so flipping this on does not by itself enable diffing.
  */
 object HistoryFeature {
-  /** Override sysprop name; default `false`. */
+  /** Override sysprop name; default `true`. */
   const val PROP: String = "composeai.history.enabled"
 
   @JvmStatic
   val ENABLED: Boolean
-    get() = System.getProperty(PROP, "false").toBoolean()
+    get() = System.getProperty(PROP, "true").toBoolean()
 }

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/GitProvenance.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/GitProvenance.kt
@@ -3,6 +3,7 @@ package ee.schimke.composeai.daemon.history
 import java.io.File
 import java.nio.file.Path
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * Resolves the per-render `git.*` and `worktree.*` provenance fields for [HistoryEntry] — see
@@ -10,34 +11,65 @@ import java.util.concurrent.TimeUnit
  *
  * Two-phase resolution:
  *
- * 1. **Construction (cheap, called once per daemon).** Captures [worktree], [remote] — the worktree
- *    root and remote URL never change for a daemon's lifetime. Resolution failure leaves the fields
- *    as null. No exception escapes; a non-git directory is fine.
- * 2. **Per-render refresh ([snapshot]).** Re-resolves [GitInfo.branch], [GitInfo.commit],
- *    [GitInfo.dirty] each call (single `git rev-parse` + `git status --porcelain` is sub-50ms in
- *    the typical project). [GitInfo.remote] is taken from the cached value.
+ * 1. **Construction (cheap, called once per daemon).** Captures the worktree root + remote URL —
+ *    they never change for a daemon's lifetime. Resolution failure leaves the fields null; a
+ *    non-git directory is fine.
+ * 2. **Per-render refresh ([snapshot]).** Re-resolves branch / commit / dirty. A fresh resolution
+ *    is three `git` subprocess spawns (`symbolic-ref`, `rev-parse HEAD`, `status --porcelain`), and
+ *    `git status` scales with working-tree size — tens of ms on a large repo. Since history records
+ *    on every render, a discovery pass that re-renders many previews would otherwise pay that cost
+ *    N times back-to-back. So [snapshot] **caches** the resolved pair for [cacheTtlMs] (default
+ *    [DEFAULT_CACHE_TTL_MS]): a render burst collapses to a single git fetch, while an interactive
+ *    edit-loop (renders spaced wider than the TTL) still gets fresh provenance each time. branch /
+ *    commit only change on checkout/commit; `dirty` may lag by at most the TTL, which is acceptable
+ *    for best-effort provenance metadata. Set `-D[CACHE_TTL_PROP]=0` to disable caching (always
+ *    fresh) — tests run with it `0` for deterministic, per-call provenance.
  *
- * **Safety against subprocess failures.** Every shell-out is wrapped in [runGit] which times out
- * after 5s, captures stderr, and returns null on any error. The daemon never blocks on a misbehaved
- * git binary.
+ * **Safety against subprocess failures.** Every shell-out times out after 5s and returns null on
+ * any error. The daemon never blocks on a misbehaved git binary.
  *
  * @param workspaceRoot the directory under which `git rev-parse --show-toplevel` runs; defaults to
  *   the daemon's CWD when null. Production callers pass the InitializeParams.workspaceRoot.
  * @param env environment overrides for tests — production passes `System.getenv()`.
+ * @param cacheTtlMs per-render provenance cache window in ms; `0` disables caching. Defaults to the
+ *   `[CACHE_TTL_PROP]` sysprop, else [DEFAULT_CACHE_TTL_MS].
+ * @param nowNanos monotonic clock source (injected in tests); defaults to `System.nanoTime`.
+ * @param gitRunner runs `git <args>` in a working dir and returns trimmed stdout (or null on
+ *   failure); injected in tests to avoid spawning real subprocesses.
  */
 class GitProvenance(
   private val workspaceRoot: Path?,
   private val env: Map<String, String> = System.getenv(),
+  private val cacheTtlMs: Long = resolveGitProvenanceTtlMs(),
+  private val nowNanos: () -> Long = System::nanoTime,
+  private val gitRunner: (workingDir: String, args: List<String>) -> String? = ::runGitProcess,
 ) {
 
   /** Captured once at construction. Stable for the daemon's lifetime. */
   private val cached: WorktreeRoot = resolveWorktreeRoot()
 
+  /** Most recent ([snapshot]) result + the nanos it was resolved at; null until the first call. */
+  private val snapshotCache = AtomicReference<CachedSnapshot?>(null)
+
   /**
-   * Returns a fresh [WorktreeInfo] / [GitInfo] pair. Cheap (refreshes branch/commit/dirty per
-   * call); safe to invoke per-render.
+   * Returns a fresh-or-cached [WorktreeInfo] / [GitInfo] pair. Within [cacheTtlMs] of the previous
+   * call the cached value is returned without spawning git; otherwise it re-resolves and re-caches.
    */
   fun snapshot(): Pair<WorktreeInfo?, GitInfo?> {
+    if (cacheTtlMs > 0L) {
+      val hit = snapshotCache.get()
+      if (hit != null && nowNanos() - hit.atNanos < cacheTtlMs * NANOS_PER_MS) {
+        return hit.value
+      }
+    }
+    val fresh = computeSnapshot()
+    if (cacheTtlMs > 0L) {
+      snapshotCache.set(CachedSnapshot(nowNanos(), fresh))
+    }
+    return fresh
+  }
+
+  private fun computeSnapshot(): Pair<WorktreeInfo?, GitInfo?> {
     val worktreePath = cached.worktreePath
     val worktreeInfo =
       WorktreeInfo(
@@ -78,32 +110,16 @@ class GitProvenance(
     return WorktreeRoot(worktreePath = worktreePath, worktreeId = worktreeId, remote = remote)
   }
 
-  private fun runGit(workingDir: String, vararg args: String): String? {
-    return try {
-      val process =
-        ProcessBuilder(listOf("git") + args.toList())
-          .directory(File(workingDir))
-          .redirectErrorStream(false)
-          .start()
-      val finished = process.waitFor(5, TimeUnit.SECONDS)
-      if (!finished) {
-        process.destroyForcibly()
-        return null
-      }
-      if (process.exitValue() != 0) return null
-      process.inputStream.bufferedReader(Charsets.UTF_8).use { it.readText().trim() }
-    } catch (t: Throwable) {
-      // Swallow — non-git workspace, missing git binary, exotic file-system permission errors.
-      // History still works without git provenance; the daemon log captures the cause.
-      null
-    }
-  }
+  private fun runGit(workingDir: String, vararg args: String): String? =
+    gitRunner(workingDir, args.toList())
 
   private data class WorktreeRoot(
     val worktreePath: String?,
     val worktreeId: String?,
     val remote: String?,
   )
+
+  private data class CachedSnapshot(val atNanos: Long, val value: Pair<WorktreeInfo?, GitInfo?>)
 
   companion object {
     /**
@@ -116,5 +132,38 @@ class GitProvenance(
      * Environment variable that overrides the worktree dir basename — HISTORY.md § "Worktree IDs".
      */
     const val ENV_WORKTREE_ID: String = "COMPOSEAI_WORKTREE_ID"
+
+    /** Sysprop overriding the per-render provenance cache TTL (ms). `0` disables caching. */
+    const val CACHE_TTL_PROP: String = "composeai.history.gitProvenanceTtlMs"
+
+    /** Default cache window — collapses a render burst's repeated provenance fetches into one. */
+    const val DEFAULT_CACHE_TTL_MS: Long = 1000L
+
+    private const val NANOS_PER_MS: Long = 1_000_000L
+  }
+}
+
+private fun resolveGitProvenanceTtlMs(): Long =
+  System.getProperty(GitProvenance.CACHE_TTL_PROP)?.toLongOrNull()?.coerceAtLeast(0L)
+    ?: GitProvenance.DEFAULT_CACHE_TTL_MS
+
+private fun runGitProcess(workingDir: String, args: List<String>): String? {
+  return try {
+    val process =
+      ProcessBuilder(listOf("git") + args)
+        .directory(File(workingDir))
+        .redirectErrorStream(false)
+        .start()
+    val finished = process.waitFor(5, TimeUnit.SECONDS)
+    if (!finished) {
+      process.destroyForcibly()
+      return null
+    }
+    if (process.exitValue() != 0) return null
+    process.inputStream.bufferedReader(Charsets.UTF_8).use { it.readText().trim() }
+  } catch (t: Throwable) {
+    // Swallow — non-git workspace, missing git binary, exotic file-system permission errors.
+    // History still works without git provenance; the daemon log captures the cause.
+    null
   }
 }

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/GitProvenanceCacheTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/GitProvenanceCacheTest.kt
@@ -1,0 +1,83 @@
+package ee.schimke.composeai.daemon.history
+
+import java.util.concurrent.atomic.AtomicInteger
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins the per-render provenance cache ([GitProvenance.snapshot]) — the optimization that keeps
+ * history-on-by-default cheap. A render burst must collapse to a single git fetch; once the TTL
+ * elapses the next call re-resolves. Uses an injected git runner + clock so it asserts the exact
+ * number of `git` invocations without spawning subprocesses or needing a real repo.
+ */
+class GitProvenanceCacheTest {
+
+  /** Fake `git` for a clean repo at /repo on branch main; counts invocations. */
+  private fun countingRunner(counter: AtomicInteger): (String, List<String>) -> String? =
+    { _, args ->
+      counter.incrementAndGet()
+      when (args.firstOrNull()) {
+        "rev-parse" -> if (args.contains("--show-toplevel")) "/repo" else "deadbeefcafebabe"
+        "remote" -> "https://example.com/repo.git"
+        "symbolic-ref" -> "main"
+        "status" -> "" // clean working tree
+        else -> null
+      }
+    }
+
+  @Test
+  fun caches_snapshot_within_ttl_and_refreshes_after_expiry() {
+    val calls = AtomicInteger(0)
+    var nowNanos = 0L
+    val provenance =
+      GitProvenance(
+        workspaceRoot = null,
+        env = emptyMap(),
+        cacheTtlMs = 1000L,
+        nowNanos = { nowNanos },
+        gitRunner = countingRunner(calls),
+      )
+    // Construction resolved the worktree root + remote (2 git calls); none since.
+    val afterCtor = calls.get()
+    assertEquals(2, afterCtor)
+
+    // First snapshot resolves branch + commit + dirty (3 git calls).
+    val first = provenance.snapshot()
+    val afterFirst = calls.get()
+    assertEquals(afterCtor + 3, afterFirst)
+    assertEquals("main", first.second?.branch)
+    assertEquals(false, first.second?.dirty)
+
+    // A render burst of 49 more calls within the TTL must not spawn any more git.
+    repeat(49) { provenance.snapshot() }
+    assertEquals("burst served from cache", afterFirst, calls.get())
+
+    // Once the TTL elapses, the next snapshot re-resolves (3 more git calls).
+    nowNanos += 1_000_000_000L + 1L
+    provenance.snapshot()
+    assertEquals(afterFirst + 3, calls.get())
+  }
+
+  @Test
+  fun ttl_zero_disables_caching_every_call_resolves() {
+    val calls = AtomicInteger(0)
+    val provenance =
+      GitProvenance(
+        workspaceRoot = null,
+        env = emptyMap(),
+        cacheTtlMs = 0L,
+        nowNanos = { 0L }, // clock never advances; caching would otherwise serve a hit forever
+        gitRunner = countingRunner(calls),
+      )
+    val afterCtor = calls.get()
+    provenance.snapshot()
+    val afterFirst = calls.get()
+    provenance.snapshot()
+    val afterSecond = calls.get()
+
+    assertTrue(afterFirst > afterCtor)
+    // Each snapshot does the same number of git calls — no caching despite the frozen clock.
+    assertEquals(afterFirst - afterCtor, afterSecond - afterFirst)
+  }
+}

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -186,11 +186,11 @@ fun runDaemon(
       IncrementalDiscovery(classpath = classpath)
     } else null
 
-  // History feature gated to 1.1 (see [HistoryFeature]). Until then `historyManager` is null on
-  // every launch — `composeai.daemon.historyDir`, the git-ref read sources, prune budgets, and the
-  // `historyManager?.setPruneListener` wire in `JsonRpcServer` all elide because the const-folded
-  // branch goes dead. HISTORY.md describes the original H1+H2 wiring this block preserves
-  // verbatim for the 1.1 re-enable.
+  // History recording is on by default (see [HistoryFeature]); set
+  // `-Dcomposeai.history.enabled=false` to opt out, in which case `historyManager` is null on every
+  // launch and `composeai.daemon.historyDir`, the git-ref read sources, prune budgets, and the
+  // `historyManager?.setPruneListener` wire in `JsonRpcServer` all elide. HISTORY.md describes the
+  // H1+H2 wiring this block sets up.
   val historyManager: HistoryManager? =
     if (HistoryFeature.ENABLED) {
       val historyDirProp = System.getProperty(HISTORY_DIR_PROP)

--- a/daemon/harness/src/main/kotlin/ee/schimke/composeai/daemon/harness/HarnessLauncher.kt
+++ b/daemon/harness/src/main/kotlin/ee/schimke/composeai/daemon/harness/HarnessLauncher.kt
@@ -6,16 +6,22 @@ import okio.FileSystem
 import okio.Path.Companion.toPath
 
 /**
- * Propagates the `composeai.history.enabled` sysprop from the test JVM into a spawned daemon
- * subprocess. Production daemons leave the property unset and the `HistoryFeature` default
- * (`false`) keeps the history surface dead; the test JVM sets it `true` via the root build's
- * `tasks.withType<Test>().configureEach { systemProperty("composeai.history.enabled", "true") }`
- * hook so the history implementation stays exercised in CI. Without the explicit propagation here
- * the spawned daemon JVM inherits nothing and the harness's history scenarios (S9 / S10 / S11) trip
- * `MethodNotFound` for every history method call. Drop when 1.1 flips the default.
+ * Propagates the history-related sysprops from the test JVM into a spawned daemon subprocess.
+ *
+ * - `composeai.history.enabled` — history records on by default, but tests set it explicitly (root
+ *   build's `tasks.withType<Test>` hook) so the harness's history scenarios (S9 / S10 / S11) stay
+ *   pinned regardless of the production default.
+ * - `composeai.history.gitProvenanceTtlMs` — tests set this `0` so spawned daemons resolve git
+ *   provenance fresh per render (no TTL cache), keeping provenance assertions deterministic.
+ *
+ * Without explicit propagation here the spawned daemon JVM inherits neither, so it would silently
+ * use the production defaults instead of the test settings.
  */
-private fun MutableList<String>.addHistoryFeatureSyspropIfSet() {
+private fun MutableList<String>.addHistorySyspropsIfSet() {
   System.getProperty("composeai.history.enabled")?.let { add("-Dcomposeai.history.enabled=$it") }
+  System.getProperty("composeai.history.gitProvenanceTtlMs")?.let {
+    add("-Dcomposeai.history.gitProvenanceTtlMs=$it")
+  }
 }
 
 /**
@@ -109,7 +115,7 @@ class FakeHarnessLauncher(
           add("-Dcomposeai.daemon.history.maxTotalSizeBytes=$pruneMaxTotalSizeBytes")
         if (pruneAutoIntervalMs != null)
           add("-Dcomposeai.daemon.history.autoPruneIntervalMs=$pruneAutoIntervalMs")
-        addHistoryFeatureSyspropIfSet()
+        addHistorySyspropsIfSet()
         addAll(extraJvmArgs)
         add("-cp")
         add(cpString)
@@ -185,7 +191,7 @@ class RealDesktopHarnessLauncher(
         add("-Dcomposeai.daemon.idleTimeoutMs=2000")
         // Save-after-render ordering watchdog — same justification as `FakeHarnessLauncher` above.
         add("-Dcomposeai.daemon.discoveryWatchdogMs=500")
-        addHistoryFeatureSyspropIfSet()
+        addHistorySyspropsIfSet()
         addAll(extraJvmArgs)
         add("-cp")
         add(cpString)
@@ -330,7 +336,7 @@ class RealAndroidHarnessLauncher(
         // can dominate the first render's wall-clock; tests should use a large *poll* timeout
         // (60-120s) rather than relying on this idle timeout to back-stop a hung daemon.
         add("-Dcomposeai.daemon.idleTimeoutMs=2000")
-        addHistoryFeatureSyspropIfSet()
+        addHistorySyspropsIfSet()
         addAll(extraJvmArgs)
         add("-cp")
         add(cpString)

--- a/docs/daemon/HISTORY.md
+++ b/docs/daemon/HISTORY.md
@@ -243,6 +243,21 @@ sidecar.pngHash`. Mismatch → entry is treated as corrupted and dropped
 from listings. Self-heals on next prune. Truncated index lines are
 skipped; missing sidecars drop the entry. Symlinks are followed once.
 
+### Provenance cost + caching
+
+`git.*` provenance (branch / commit / dirty) is resolved per render by
+`GitProvenance.snapshot()` — three `git` spawns, of which `git status
+--porcelain` scales with working-tree size (tens of ms on a large repo).
+Since recording is on by default, a discovery pass re-rendering many
+previews would otherwise pay that cost N times back-to-back. So
+`snapshot()` caches the resolved pair for a short TTL
+(`composeai.history.gitProvenanceTtlMs`, default `1000`): a render
+**burst** collapses to a single git fetch, while an interactive edit-loop
+(renders spaced wider than the TTL) still gets fresh provenance. branch /
+commit only change on checkout/commit; `dirty` may lag by at most the TTL,
+acceptable for best-effort metadata. Set the sysprop to `0` to disable
+caching (tests run with `0` for deterministic per-call provenance).
+
 ## Pruning policy
 
 Defaults read from sysprops on the spawned daemon JVM:

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -211,7 +211,7 @@
                 "composePreview.earlyFeatures.enabled": {
                     "type": "boolean",
                     "default": false,
-                    "description": "Enable early, unstable preview features in the VS Code panel, including focus-mode diffs, focus inspector extension layers, a11y overlay controls, recording, and diff-all commands. Focus mode and live interactive previews remain available when this is off."
+                    "description": "Enable early, unstable preview features in the VS Code panel, including focus-mode diffs, focus inspector extension layers, a11y overlay controls, recording, diff-all commands, and the render-history timeline. Focus mode and live interactive previews remain available when this is off."
                 },
                 "composePreview.bundleCliPath": {
                     "type": "string",

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -83,7 +83,7 @@ import {
     HistoryScope,
     HistorySource,
 } from "./historyPanel";
-import { HISTORY_FEATURE_ENABLED } from "./historyFeature";
+import { historyFeatureEnabled } from "./historyFeature";
 import {
     disposePreviewMainBatches,
     readPreviewMainPng,
@@ -1618,81 +1618,86 @@ export async function activate(
 
     // Phase H7 — preview history source. The standalone History view is not
     // contributed; history is surfaced from the focus view alongside data products.
-    // History feature gated to 1.1 (see `historyFeature.ts`). When disabled, `historySource`
-    // stays null and every call site already guards on it; the focus webview's history section
-    // hides, and `composePreview.diffAllVsMain` / `diffVsHead` short-circuit to the same
-    // "not ready" branch the daemon-unavailable path already covers.
+    // History UI is gated behind the early-access flag (see `historyFeature.ts`). When the flag
+    // is off, `historySource` stays null and every call site already guards on it; the focus
+    // webview's history section hides, and `composePreview.diffAllVsMain` / `diffVsHead`
+    // short-circuit to the same "not ready" branch the daemon-unavailable path already covers.
+    // `refreshHistorySource` is also called from the config-change listener so toggling the flag
+    // takes effect without a window reload.
     historyScopeRef.current = null;
     const moduleInfoFromScope = (modulePath: string): ModuleInfo | null =>
         gradleService?.findModuleByPath(modulePath) ?? null;
-    historySource = HISTORY_FEATURE_ENABLED
-        ? buildHistorySource({
-              isDaemonReady: (moduleId) =>
-                  daemonGate?.isDaemonReady(moduleId) ?? false,
-              daemonList: async (scope) => {
-                  const module = moduleInfoFromScope(scope.moduleId);
-                  if (!module) {
-                      throw new Error("daemon unavailable");
-                  }
-                  const client = await daemonGate?.getOrSpawn(
-                      module,
-                      daemonScheduler!.daemonEvents(scope.moduleId),
-                  );
-                  if (!client) {
-                      throw new Error("daemon unavailable");
-                  }
-                  return client.historyList({ previewId: scope.previewId });
-              },
-              daemonRead: async (id) => {
-                  const moduleId = historyScopeRef.current?.moduleId;
-                  if (!moduleId) {
-                      throw new Error("no scope");
-                  }
-                  const module = moduleInfoFromScope(moduleId);
-                  if (!module) {
-                      throw new Error("daemon unavailable");
-                  }
-                  const client = await daemonGate?.getOrSpawn(
-                      module,
-                      daemonScheduler!.daemonEvents(moduleId),
-                  );
-                  if (!client) {
-                      throw new Error("daemon unavailable");
-                  }
-                  return client.historyRead({ id, inline: false });
-              },
-              daemonDiff: async (fromId, toId) => {
-                  const moduleId = historyScopeRef.current?.moduleId;
-                  if (!moduleId) {
-                      throw new Error("no scope");
-                  }
-                  const module = moduleInfoFromScope(moduleId);
-                  if (!module) {
-                      throw new Error("daemon unavailable");
-                  }
-                  const client = await daemonGate?.getOrSpawn(
-                      module,
-                      daemonScheduler!.daemonEvents(moduleId),
-                  );
-                  if (!client) {
-                      throw new Error("daemon unavailable");
-                  }
-                  // TODO(1.1): history/diff is experimental in the 1.0 daemon and
-                  // returns MethodNotFound unless the user opts in via
-                  // `composeai.experimental.historyDiff`. Once the daemon flips the
-                  // default, simplify this back to a direct call. Until then,
-                  // surface the gate as a clear "diff unavailable" rather than a
-                  // raw RPC error.
-                  return client.historyDiff({
-                      from: fromId,
-                      to: toId,
-                      mode: "metadata",
-                  });
-              },
-              getCurrentScope: () => historyScopeRef.current,
-              logger: outputChannel,
-          })
-        : null;
+    const makeHistorySource = () =>
+        buildHistorySource({
+            isDaemonReady: (moduleId) =>
+                daemonGate?.isDaemonReady(moduleId) ?? false,
+            daemonList: async (scope) => {
+                const module = moduleInfoFromScope(scope.moduleId);
+                if (!module) {
+                    throw new Error("daemon unavailable");
+                }
+                const client = await daemonGate?.getOrSpawn(
+                    module,
+                    daemonScheduler!.daemonEvents(scope.moduleId),
+                );
+                if (!client) {
+                    throw new Error("daemon unavailable");
+                }
+                return client.historyList({ previewId: scope.previewId });
+            },
+            daemonRead: async (id) => {
+                const moduleId = historyScopeRef.current?.moduleId;
+                if (!moduleId) {
+                    throw new Error("no scope");
+                }
+                const module = moduleInfoFromScope(moduleId);
+                if (!module) {
+                    throw new Error("daemon unavailable");
+                }
+                const client = await daemonGate?.getOrSpawn(
+                    module,
+                    daemonScheduler!.daemonEvents(moduleId),
+                );
+                if (!client) {
+                    throw new Error("daemon unavailable");
+                }
+                return client.historyRead({ id, inline: false });
+            },
+            daemonDiff: async (fromId, toId) => {
+                const moduleId = historyScopeRef.current?.moduleId;
+                if (!moduleId) {
+                    throw new Error("no scope");
+                }
+                const module = moduleInfoFromScope(moduleId);
+                if (!module) {
+                    throw new Error("daemon unavailable");
+                }
+                const client = await daemonGate?.getOrSpawn(
+                    module,
+                    daemonScheduler!.daemonEvents(moduleId),
+                );
+                if (!client) {
+                    throw new Error("daemon unavailable");
+                }
+                // TODO(1.1): history/diff is experimental in the 1.0 daemon and
+                // returns MethodNotFound unless the user opts in via
+                // `composeai.experimental.historyDiff`. Once the daemon flips the
+                // default, simplify this back to a direct call. Until then,
+                // surface the gate as a clear "diff unavailable" rather than a
+                // raw RPC error.
+                return client.historyDiff({
+                    from: fromId,
+                    to: toId,
+                    mode: "metadata",
+                });
+            },
+            getCurrentScope: () => historyScopeRef.current,
+            logger: outputChannel,
+        });
+    const refreshHistorySource = () => {
+        historySource = historyFeatureEnabled() ? makeHistorySource() : null;
+    };
+    refreshHistorySource();
     context.subscriptions.push(
         vscode.commands.registerCommand("composePreview.refresh", () =>
             refresh(true, editorScope.file ?? undefined),
@@ -2098,6 +2103,9 @@ export async function activate(
                     "composePreview.earlyFeatures.enabled",
                 )
             ) {
+                // History UI rides on the early-access flag; rebuild (or tear down)
+                // the history source so the toggle takes effect without a reload.
+                refreshHistorySource();
                 panel?.postMessage({
                     command: "setEarlyFeatures",
                     enabled: earlyFeaturesEnabled(),

--- a/vscode-extension/src/historyFeature.ts
+++ b/vscode-extension/src/historyFeature.ts
@@ -1,13 +1,21 @@
+import * as vscode from "vscode";
+
 /**
- * History feature gate — **post-1.0; deferred to 1.1**.
+ * History feature gate — gated behind the early-access flag.
  *
- * Mirrors the Kotlin-side `HistoryFeature.ENABLED` constant in `:daemon:core`. While `false` the
- * VS Code extension does not build a `historySource`, does not register the history-related panel
- * messages on the focus-mode webview, and does not call `history/*` JSON-RPC methods on the
- * daemon (which themselves return `MethodNotFound` when the daemon's flag is off). The Diff vs
- * Main / Diff vs Head commands short-circuit to the same "history is not ready" branches the
- * daemon-unavailable path already covers.
+ * The render-history UI (the focus-view history section, the Diff vs Main / Diff vs Head
+ * affordances) is an early, unstable preview feature, so it rides on the shared
+ * `composePreview.earlyFeatures.enabled` setting alongside the other early features. When the
+ * setting is `false` the extension does not build a `historySource`, does not register the
+ * history-related panel messages on the focus-mode webview, and does not call `history/*`
+ * JSON-RPC methods on the daemon. The Diff vs Main / Diff vs Head commands short-circuit to the
+ * same "history is not ready" branches the daemon-unavailable path already covers.
  *
- * Flip back to `true` for the 1.1 cut.
+ * The daemon records history on by default now (`HistoryFeature.ENABLED` in `:daemon:core`); this
+ * flag only controls whether the VS Code surfaces it.
  */
-export const HISTORY_FEATURE_ENABLED = false;
+export function historyFeatureEnabled(): boolean {
+    return vscode.workspace
+        .getConfiguration("composePreview")
+        .get<boolean>("earlyFeatures.enabled", false);
+}


### PR DESCRIPTION
Part of #1872 (report-history epic #1866). Turns the substrate **on** so history actually accumulates, keeps the VS Code surface **opt-in** behind the existing early-access flag, and makes per-render history recording cheap so on-by-default doesn't tax routine work.

## Daemon — history on by default

- `HistoryFeature.ENABLED` now defaults to `true`. The daemon constructs `HistoryManager` and records each changed render to the local `.compose-preview-history/` archive, and serves `history/list` · `history/read` · `history/prune`.
- The sysprop `composeai.history.enabled` stays as an explicit **off-switch** (`-Dcomposeai.history.enabled=false`).
- `history/diff` keeps its **separate** experimental gate, so flipping this on does not by itself enable diffing.
- Tests already forced the gate on via the Gradle `systemProperty` convention, so the default flip is a no-op for the suite; nothing asserted the disabled-by-default path. Refreshed the two `DaemonMain` comments + the `HistoryFeature` KDoc.

## Daemon — git-provenance caching (the "is on-by-default cheap?" part)

Recording on every render means `GitProvenance.snapshot()` runs per render: **three `git` spawns** (`symbolic-ref`, `rev-parse HEAD`, `status --porcelain`), measured at **~27 ms** on this repo (`git status` dominates and scales with working-tree size — much more on a large monorepo). A discovery pass re-rendering N previews paid that N times back-to-back.

- `snapshot()` now **caches** the resolved `(worktree, git)` pair for a short TTL (`composeai.history.gitProvenanceTtlMs`, default **1000 ms**): a render **burst** collapses to one git fetch; an interactive edit-loop (renders spaced wider than the TTL) still gets fresh provenance. branch/commit only change on checkout/commit; `dirty` may lag by at most the TTL — fine for best-effort metadata.
- Injectable clock + git-runner seams; **`GitProvenanceCacheTest`** asserts a 50-call burst does a single git fetch, that TTL expiry re-resolves, and that TTL=0 disables caching.
- Tests run with `gitProvenanceTtlMs=0` (build-logic `Test` convention + harness propagation) so provenance stays deterministic per render.
- `HISTORY.md` documents the cost + cache + sysprop.

## VS Code — history UI behind `earlyFeatures.enabled`

- Replaces the hardcoded `HISTORY_FEATURE_ENABLED = false` with `historyFeatureEnabled()`, reading the existing `composePreview.earlyFeatures.enabled` setting — the same house flag that already gates focus-mode diffs, a11y overlay controls, recording, and diff-all commands. No new setting invented.
- The history source is (re)built **reactively** in the existing `onDidChangeConfiguration` listener, so toggling the flag takes effect without a window reload.
- Updated the `earlyFeatures.enabled` description to mention the render-history timeline.

## Test plan

- **VS Code:** `tsc -p ./` clean, `prettier --check` clean (pre-commit hook), unit suite **1542 passing**.
- **Daemon:** `:daemon:core` + `:daemon:harness` compile, ktfmt clean; `GitProvenanceCacheTest` (2), `GitProvenanceTest` (5), `JsonRpcServerHistoryIntegrationTest` (2) green.

## Visual evidence

Feature-flag + perf wiring — it changes *reachability* and *cost*, not rendering. The history panel's own markup/layout is unchanged, so there are no new/altered pixels to diff; text-only is appropriate per the repo's visual-evidence guidance. To see it live: set `composePreview.earlyFeatures.enabled: true`, render a preview twice, open the focus view's history section (needs a headed VS Code e2e the headless CI container can't run).

## Follow-ups (tracked separately)

`history/diff` pixel/semantics modes (#1873) and a CLI daemon client remain their own issues.