### PR TITLE
fix(cli): keep bundle pack --with-semantics best-effort when daemon-start fails (#1885)

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
@@ -174,11 +174,13 @@ private class PackSubcommand(private val args: List<String>) {
             }
             // `--with-semantics` carries the per-preview semantics blob (issue #1843). The
             // semantics tree is produced exclusively by the daemon (the standalone
-            // composePreviewRender task writes no semantics sidecars), so we also start the daemon
-            // in the same Gradle invocation — its launch descriptor is written fresh against the
-            // consumer's current classpath, then a short-lived render session reads the blobs back.
-            // Pointless without a render (the daemon needs something to capture), so skip when
-            // --no-render.
+            // composePreviewRender task writes no semantics sidecars), so we start the daemon and
+            // read the blobs back below. composePreviewDaemonStart runs in its OWN Gradle
+            // invocation (not bundled with render+bundle), AFTER the bundle is already written, so
+            // a
+            // daemon-start failure degrades gracefully instead of aborting the pack —
+            // `--with-semantics` is best-effort (issue #1885). Pointless without a render (the
+            // daemon needs something to capture), so skip when --no-render.
             val packSemantics = withSemantics && !noRender
             if (withSemantics && noRender) {
               System.err.println(
@@ -189,12 +191,15 @@ private class PackSubcommand(private val args: List<String>) {
               buildList {
                   if (!noRender) add(":${target.gradlePath}:composePreviewRender")
                   add(":${target.gradlePath}:composePreviewBundle")
-                  if (packSemantics) add(":${target.gradlePath}:composePreviewDaemonStart")
                 }
                 .toTypedArray()
             val ok = runGradle(gradle, *tasks, arguments = gradleArgsWithForce(gradleArgs))
             if (!ok) {
-              System.err.println("Gradle bundle task failed.")
+              System.err.println(
+                "Gradle bundle task failed." +
+                  if (!verbose) " Re-run with --verbose to surface the underlying Gradle error."
+                  else ""
+              )
               exitProcess(1)
             }
 
@@ -216,8 +221,31 @@ private class PackSubcommand(private val args: List<String>) {
               }
             // Inject semantics (if requested) before the summary so its byte count reflects the
             // enriched bundle; the summary line for semantics is printed after the main summary.
+            // The bundle is already written and valid at this point, so everything below is
+            // best-effort: a daemon-start / open / render failure warns and leaves the bundle as-is
+            // (issue #1885), never failing the pack.
             val semanticsLine =
-              if (packSemantics) packSemanticsBlob(target, resolvedOutput, meta) else null
+              if (packSemantics) {
+                // Start the daemon in a SEPARATE Gradle invocation — its failure must NOT abort the
+                // pack. The launch descriptor is regenerated fresh against the consumer's current
+                // classpath, then DaemonSemanticsFetcher reads the blobs back.
+                val daemonStarted =
+                  runGradle(
+                    gradle,
+                    ":${target.gradlePath}:composePreviewDaemonStart",
+                    arguments = gradleArgsWithForce(gradleArgs),
+                  )
+                if (!daemonStarted) {
+                  System.err.println(
+                    "bundle pack: --with-semantics could not start the preview daemon for " +
+                      "${target.gradlePath} (composePreviewDaemonStart failed) — bundle written " +
+                      "without semantics. Re-run with --verbose to surface the underlying Gradle error."
+                  )
+                  null
+                } else {
+                  packSemanticsBlob(target, resolvedOutput, meta)
+                }
+              } else null
 
             printPackSummary(resolvedOutput, meta)
             semanticsLine?.let { println(it) }


### PR DESCRIPTION
Fixes #1885.

## Problem
`compose-preview bundle pack --with-semantics` (added in #1845) is documented as best-effort, but on the desktop/CMP backend a `composePreviewDaemonStart` failure aborted the **entire** pack with "Gradle bundle task failed" (exit 1) — no bundle written, graceful degradation never reached.

**Root cause:** `--with-semantics` appended `composePreviewDaemonStart` to the **same** Gradle invocation as render+bundle. When that task fails, `runGradle` returns `false` and the command `exitProcess(1)`s *before* the best-effort logic in `packSemanticsBlob` (which only runs on success) can warn-and-continue.

## Fix (the issue's recommended option 1)
Run `composePreviewDaemonStart` in its **own** Gradle invocation, **after** render+bundle has already written the bundle:

- render+bundle invocation failing → still a hard error (the bundle genuinely failed).
- daemon-start invocation failing → warn to stderr, leave the visual/structural bundle valid, **exit 0** — consistent with the other best-effort outcomes (`DescriptorMissing` / `OpenFailed` / empty-`Ok`).

Also addresses the **secondary** point: both failure paths now append a "Re-run with `--verbose` to surface the underlying Gradle error" hint (when not already verbose), so the swallowed Gradle exception is diagnosable.

## Test plan
- `:cli:test --tests RenderBundleFlagTest --tests DaemonSemanticsFetcherTest --tests BundleSemanticsInjectTest` ✅ (no regression; the pack control-flow itself drives real Gradle and isn't unit-tested).
- Validating end-to-end locally against a CMP-desktop module (`bundle pack --with-semantics`): the pack must exit 0 and write a valid bundle whether daemon-start succeeds (semantics carried) or fails (warned, semantics omitted). Will report results on the PR.

Non-visual change (CLI control flow). The deeper question of *why* desktop `composePreviewDaemonStart` fails for the reporter (a possible separate daemon defect, now unmasked by the `--verbose` hint) is out of scope here per the issue.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WmL6Xj4mr6RaK5mdyv436u)_