### PR TITLE
fix(daemon): write compose/semantics JSON sidecar on the desktop backend (#1885 follow-up)

### DIFF
--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -469,17 +469,27 @@ class RenderEngine(
       }
     }
 
-    // Compose semantics wireframe — derive the standalone 2D schematic (SVG + baked PNG) from the
-    // held scene's unmerged semantics root, matching the unmerged tree the Android producer uses so
-    // both backends emit the same diagram. Always-on (requiresRerender = false) like the Android
+    // Compose semantics (`compose/semantics` JSON sidecar) + wireframe — both derive from the held
+    // scene's unmerged semantics root, matching the unmerged tree the Android producer uses so both
+    // backends emit the same data. Always-on (requiresRerender = false) like the Android
     // post-capture extension, and wrapped in try/catch so a walk/bake failure never strands the
-    // PNG.
+    // outputs.
     try {
       val root = state.scene.semanticsOwners.firstOrNull()?.unmergedRootSemanticsNode
       if (root != null) {
         trace.section("wireframe") {
           val previewId = state.spec.previewId ?: state.spec.outputBaseName
           val payload = ComposeSemanticsDataProducer.buildPayload(root)
+          // `compose-semantics.json` — the plain `compose/semantics` data product the Android
+          // ComposeSemanticsExtension writes per render. The desktop backend previously fed this
+          // tree only into the wireframe / spatial / a11y views and never wrote the sidecar, so
+          // `bundle pack --with-semantics` and design-parity found no semantics on desktop (#1885
+          // follow-up). Write it from the same captured root.
+          ComposeSemanticsDataProducer.writeArtifacts(
+            rootDir = dataDir,
+            previewId = previewId,
+            root = root,
+          )
           ComposeSemanticsWireframeDataProducer.writeSvg(
             rootDir = dataDir,
             previewId = previewId,

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/RenderEngineTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/RenderEngineTest.kt
@@ -90,9 +90,13 @@ class RenderEngineTest {
   }
 
   @Test
-  fun renderAlsoProducesSemanticsWireframe() {
-    // End-to-end: a real desktop render must drop the always-on `compose/semantics-wireframe`
-    // artefacts (SVG + baked PNG) into the data dir, keyed by the preview id, alongside the PNG.
+  fun renderAlsoProducesSemanticsArtifacts() {
+    // End-to-end: a real desktop render must drop the always-on `compose/semantics` JSON sidecar
+    // AND the `compose/semantics-wireframe` artefacts (SVG + baked PNG) into the data dir, keyed by
+    // the preview id, alongside the PNG. The plain JSON sidecar (compose-semantics.json) is what
+    // `bundle pack --with-semantics` and design-parity read — the desktop backend previously wrote
+    // only the wireframe and omitted it, so semantics never reached the bundle (issue #1885
+    // follow-up).
     val outputDir = tempFolder.newFolder("renders-wireframe")
     val dataDir = tempFolder.newFolder("data-wireframe")
     val engine = RenderEngine(outputDir = outputDir, dataDir = dataDir)
@@ -111,6 +115,15 @@ class RenderEngineTest {
       host.submit(request, timeoutMs = 60_000)
 
       val previewDir = File(dataDir, "wireframe-red")
+      val semantics = File(previewDir, "compose-semantics.json")
+      assertTrue(
+        "compose-semantics.json sidecar must be produced: ${semantics.absolutePath}",
+        semantics.exists(),
+      )
+      assertTrue(
+        "compose-semantics.json must carry a node tree",
+        semantics.readText().contains("\"root\""),
+      )
       val svg = File(previewDir, "compose-semantics-wireframe.svg")
       val png = File(previewDir, "compose-semantics-wireframe.png")
       assertTrue("wireframe SVG must be produced: ${svg.absolutePath}", svg.exists())


### PR DESCRIPTION
Follow-up to #1885 — fixes the underlying desktop defect that the abort fix (#1886) unmasked: `--with-semantics` produced **no** semantics on the desktop/CMP backend.

## Root cause
The desktop daemon `RenderEngine` captures the unmerged semantics root and `buildPayload`s it, but only feeds that tree into the **wireframe** (`compose/semantics-wireframe`), spatial-semantics, and a11y views. It never calls `ComposeSemanticsDataProducer.writeArtifacts(...)` to write the plain **`compose-semantics.json`** sidecar — the data product the Android `ComposeSemanticsExtension` writes per render, and the one `DaemonSemanticsFetcher` (`bundle pack --with-semantics`) and design-parity read.

Notably the desktop `DaemonMain` *already registers* `ComposeSemanticsDataProductRegistry` — so `compose/semantics` was advertised on desktop but resolved to nothing (a consumer with no producer). On Android both halves exist; desktop had only the consumer.

## Fix
Write the `compose-semantics.json` sidecar in `RenderEngine` from the same captured root, alongside the existing wireframe write (always-on, same try/catch).

## Validation (local, real AGP-KMP + desktop render)
`compose-preview bundle pack --module samples:cmp --with-semantics`:
- **Before:** `--with-semantics produced no semantics for samples:cmp … bundle written without previews/<id>.semantics.json` (0 carried).
- **After:** `semantics: 16 / 18 preview(s) carried as previews/<id>.semantics.json` (the 2 misses are Lottie assets with no semantics tree). Bundle contains 16 `semantics.json` entries; the daemon writes `compose-semantics.json` per preview under `build/compose-previews/data/<id>/`.

## Test plan
- `:daemon:desktop:test --tests RenderEngineTest` ✅ 4 tests. `renderAlsoProducesSemanticsArtifacts` (renamed from `…Wireframe`) now renders a real desktop preview and asserts the `compose-semantics.json` sidecar exists and carries a node tree, in addition to the wireframe SVG/PNG.

Non-visual change (data-product plumbing). Net effect for the reporter: re-adding `--with-semantics` on the desktop backend now actually lights up design-parity's token/contrast/a11y checks (#1843) instead of reporting "missing from candidate."

---
_Generated by [Claude Code](https://claude.ai/code/session_01WmL6Xj4mr6RaK5mdyv436u)_