### PR TITLE
feat(daemon): implement history/diff pixel mode (H5)

### DIFF
--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.daemon
 
+import ee.schimke.composeai.daemon.history.HistoryDiffArtifacts
 import ee.schimke.composeai.daemon.history.HistoryEntry
 import ee.schimke.composeai.daemon.history.HistoryFilter
 import ee.schimke.composeai.daemon.history.HistoryImageDiff
@@ -1684,10 +1685,9 @@ class JsonRpcServer(
   ): String? =
     try {
       val previewDir = java.nio.file.Path.of(toPngPath).toAbsolutePath().parent
-      val diffsDir = previewDir.resolve(".diffs")
+      val diffsDir = previewDir.resolve(HistoryDiffArtifacts.DIFFS_DIR_NAME)
       java.nio.file.Files.createDirectories(diffsDir)
-      val sanitize = { s: String -> s.replace(Regex("[^A-Za-z0-9._-]"), "_") }
-      val out = diffsDir.resolve("${sanitize(fromId)}__${sanitize(toId)}.png")
+      val out = diffsDir.resolve(HistoryDiffArtifacts.fileName(fromId, toId))
       java.nio.file.Files.write(out, pngBytes)
       out.toString()
     } catch (t: Throwable) {

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -2,6 +2,7 @@ package ee.schimke.composeai.daemon
 
 import ee.schimke.composeai.daemon.history.HistoryEntry
 import ee.schimke.composeai.daemon.history.HistoryFilter
+import ee.schimke.composeai.daemon.history.HistoryImageDiff
 import ee.schimke.composeai.daemon.history.HistoryManager
 import ee.schimke.composeai.daemon.history.HistoryPruneConfig
 import ee.schimke.composeai.daemon.history.PreviewMetadataSnapshot
@@ -1483,14 +1484,15 @@ class JsonRpcServer(
    *
    * - `HistoryEntryNotFound` (-32010) when either id is missing.
    * - `HistoryDiffMismatch` (-32011) when the two entries belong to different previews.
-   * - `ERR_HISTORY_PIXEL_NOT_IMPLEMENTED` (-32012) when the caller asks for `mode = pixel` (H5).
    * - `ERR_HISTORY_SEMANTICS_NOT_CAPTURED` (-32013) when `mode = semantics` but one of the two
    *   entries has no captured `compose/semantics` snapshot (issue #1785).
    *
-   * The metadata-mode response is `pngHashChanged + fromMetadata + toMetadata` (full sidecars).
-   * Pixel-mode fields (`diffPx`, `ssim`, `diffPngPath`) stay null in METADATA mode by design — H5
-   * lands the pixel pass. SEMANTICS mode (issue #1785) adds `semanticsDelta`, the typed structural
-   * diff of the two entries' captured semantics trees.
+   * The metadata-mode response is `pngHashChanged + fromMetadata + toMetadata` (full sidecars);
+   * pixel-mode fields stay null there by design. PIXEL mode (H5, issue #1873) decodes both archived
+   * frames and populates `diffPx` + `ssim` + `diffPngPath` (a marked-diff PNG written under
+   * `<historyDir>/<previewId>/.diffs/`) via [HistoryImageDiff]. SEMANTICS mode (issue #1785) adds
+   * `semanticsDelta`, the typed structural diff of the two entries' captured semantics trees. The
+   * `-32012` "pixel not implemented" sentinel is retired now that H5 has landed.
    */
   private fun handleHistoryDiff(req: JsonRpcRequest) {
     val params =
@@ -1513,19 +1515,12 @@ class JsonRpcServer(
       )
       return
     }
-    if (params.mode == HistoryDiffMode.PIXEL) {
-      sendErrorResponse(
-        id = req.id,
-        code = ERR_HISTORY_PIXEL_NOT_IMPLEMENTED,
-        message =
-          "history/diff: pixel mode is reserved for phase H5 and not implemented; " +
-            "call with mode='metadata' (the default) for now",
-      )
-      return
-    }
+    // PIXEL mode needs the actual frame bytes; metadata / semantics modes don't, so only pay the
+    // PNG read when the caller asked for a pixel diff.
+    val includeBytes = params.mode == HistoryDiffMode.PIXEL
     val from =
       try {
-        mgr.read(params.from, includeBytes = false)
+        mgr.read(params.from, includeBytes = includeBytes)
       } catch (t: Throwable) {
         sendErrorResponse(
           id = req.id,
@@ -1544,7 +1539,7 @@ class JsonRpcServer(
     }
     val to =
       try {
-        mgr.read(params.to, includeBytes = false)
+        mgr.read(params.to, includeBytes = includeBytes)
       } catch (t: Throwable) {
         sendErrorResponse(
           id = req.id,
@@ -1618,6 +1613,50 @@ class JsonRpcServer(
       sendResponse(req.id, encode(HistoryDiffResult.serializer(), result))
       return
     }
+    // PIXEL mode (H5, issue #1873) — decode both archived frames, compute diffPx + ssim, and write
+    // a
+    // reviewer-facing marked-diff PNG to `<historyDir>/<previewId>/.diffs/`. The frame bytes were
+    // read above (includeBytes); a null here means the source couldn't supply them (e.g. the PNG
+    // was
+    // moved out from under the archive) — treat as internal, not entry-not-found, since the index
+    // entry resolved fine.
+    if (params.mode == HistoryDiffMode.PIXEL) {
+      val fromBytes = from.pngBytes
+      val toBytes = to.pngBytes
+      if (fromBytes == null || toBytes == null) {
+        val missing = if (fromBytes == null) params.from else params.to
+        sendErrorResponse(
+          id = req.id,
+          code = ERR_INTERNAL,
+          message = "history/diff: entry '$missing' has no PNG bytes to pixel-diff",
+        )
+        return
+      }
+      val diff =
+        try {
+          HistoryImageDiff.diff(fromBytes, toBytes)
+        } catch (t: Throwable) {
+          sendErrorResponse(
+            id = req.id,
+            code = ERR_INTERNAL,
+            message = "history/diff: pixel diff failed: ${t.message}",
+          )
+          return
+        }
+      val diffPngPath =
+        diff.markedPng?.let { bytes -> writeDiffPng(to.pngPath, from.entry.id, to.entry.id, bytes) }
+      val result =
+        HistoryDiffResult(
+          pngHashChanged = from.entry.pngHash != to.entry.pngHash,
+          fromMetadata = encodeHistoryEntry(from.entry),
+          toMetadata = encodeHistoryEntry(to.entry),
+          diffPx = diff.diffPx,
+          ssim = diff.ssim,
+          diffPngPath = diffPngPath,
+        )
+      sendResponse(req.id, encode(HistoryDiffResult.serializer(), result))
+      return
+    }
     val result =
       HistoryDiffResult(
         pngHashChanged = from.entry.pngHash != to.entry.pngHash,
@@ -1629,6 +1668,32 @@ class JsonRpcServer(
       )
     sendResponse(req.id, encode(HistoryDiffResult.serializer(), result))
   }
+
+  /**
+   * Writes the marked-diff [pngBytes] to `<previewDir>/.diffs/<fromId>__<toId>.png`, where
+   * `previewDir` is derived from the `to` entry's archived PNG path ([toPngPath]). Best-effort:
+   * returns the absolute path on success, or null if the write fails (the pixel metrics are still
+   * useful without the artefact). The `.diffs/` subdir is dot-prefixed so `LocalFsHistorySource`'s
+   * per-preview sidecar resolution (which addresses `<id>.json` by name) never trips over it.
+   */
+  private fun writeDiffPng(
+    toPngPath: String,
+    fromId: String,
+    toId: String,
+    pngBytes: ByteArray,
+  ): String? =
+    try {
+      val previewDir = java.nio.file.Path.of(toPngPath).toAbsolutePath().parent
+      val diffsDir = previewDir.resolve(".diffs")
+      java.nio.file.Files.createDirectories(diffsDir)
+      val sanitize = { s: String -> s.replace(Regex("[^A-Za-z0-9._-]"), "_") }
+      val out = diffsDir.resolve("${sanitize(fromId)}__${sanitize(toId)}.png")
+      java.nio.file.Files.write(out, pngBytes)
+      out.toString()
+    } catch (t: Throwable) {
+      System.err.println("compose-ai-daemon: history/diff writeDiffPng failed: ${t.message}")
+      null
+    }
 
   /**
    * H4 — `history/prune` manual prune trigger. Resolves [HistoryPruneParams] over the daemon's
@@ -3925,12 +3990,13 @@ class JsonRpcServer(
     const val ERR_HISTORY_DIFF_MISMATCH: Int = -32011
 
     /**
-     * HISTORY.md § "Error codes" — `history/diff` was called with `mode = pixel`, which is reserved
-     * for phase H5 and not implemented in H3. We deliberately return a clean error code (rather
-     * than silently leaving the pixel fields null in METADATA mode) so callers can tell "I asked
-     * for pixel and the daemon isn't ready" apart from "I asked for metadata and got null pixel
-     * fields by design."
+     * HISTORY.md § "Error codes" — formerly returned when `history/diff` was called with `mode =
+     * pixel` before H5 (issue #1873) implemented the pixel pass. **Retired:** pixel mode now
+     * populates `diffPx` / `ssim` / `diffPngPath` and never emits this code. Kept as a reserved
+     * wire constant so the number isn't recycled for an unrelated error and old clients that
+     * special-cased it still compile/resolve it.
      */
+    @Deprecated("Pixel mode is implemented (H5); this code is no longer emitted.")
     const val ERR_HISTORY_PIXEL_NOT_IMPLEMENTED: Int = -32012
 
     /**

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryDiffArtifacts.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryDiffArtifacts.kt
@@ -1,0 +1,41 @@
+package ee.schimke.composeai.daemon.history
+
+/**
+ * Naming + location convention for `history/diff mode = "pixel"` marked-diff PNGs (H5,
+ * issue #1873).
+ *
+ * Single source of truth shared by the writer (the JSON-RPC `history/diff` handler) and the cleaner
+ * ([LocalFsHistorySource.prune]) so the two never drift on where artefacts live or how they're
+ * named. Artefacts are a **regenerable cache**: any diff can be recomputed from its two archived
+ * frames, so prune deletes a diff PNG as soon as either referenced entry ages out — they must not
+ * outlive the history they describe.
+ *
+ * Layout: `<historyDir>/<sanitisedPreviewDir>/.diffs/<fromId>__<toId>.png` (ids sanitised). The
+ * `.diffs` subdir is dot-prefixed so the per-preview sidecar resolution never trips over it.
+ */
+object HistoryDiffArtifacts {
+
+  /** Per-preview subdirectory holding marked-diff PNGs. Dot-prefixed so sidecar scans skip it. */
+  const val DIFFS_DIR_NAME: String = ".diffs"
+
+  /** Filesystem-safe form of a history entry id for use in a diff filename. */
+  fun sanitiseId(id: String): String = id.replace(NON_FILENAME, "_")
+
+  /** Diff filename for the ordered pair (`from`, `to`): `<from>__<to>.png` (ids sanitised). */
+  fun fileName(fromId: String, toId: String): String =
+    "${sanitiseId(fromId)}__${sanitiseId(toId)}.png"
+
+  /**
+   * True when [diffFileName] (a `.diffs/` entry) references the already-sanitised entry id
+   * [sanitisedEntryId] on either side of its `<from>__<to>.png` name — i.e. the diff should be
+   * pruned when that entry is. Robust against ids that themselves contain `_` (it anchors on the
+   * `__` separator's start/end rather than splitting).
+   */
+  fun referencesEntry(diffFileName: String, sanitisedEntryId: String): Boolean {
+    if (!diffFileName.endsWith(".png")) return false
+    val stem = diffFileName.removeSuffix(".png")
+    return stem.startsWith("${sanitisedEntryId}__") || stem.endsWith("__$sanitisedEntryId")
+  }
+
+  private val NON_FILENAME = Regex("[^A-Za-z0-9._-]")
+}

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryImageDiff.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryImageDiff.kt
@@ -14,10 +14,13 @@ import kotlin.math.max
  * comparisons) and lives in a test-scope module, so it isn't reused here. This produces *metrics*
  * for two archived history PNGs plus a reviewer-facing marked-diff image:
  *
- * - **[Result.diffPx]** — count of pixels whose RGB differs at all between the two frames. A blunt,
- *   deterministic "how many pixels moved" number; perceptual closeness is [Result.ssim]'s job.
+ * - **[Result.diffPx]** — count of pixels whose **ARGB** (incl. alpha) differs at all between the
+ *   two frames. A blunt, deterministic "how many pixels moved" number; perceptual closeness is
+ *   [Result.ssim]'s job. Alpha is compared so a transparency-only change (round-device clip masks,
+ *   opacity tweaks) registers rather than reading as identical.
  * - **[Result.ssim]** — mean structural-similarity index (Wang et al. 2004) over 8×8 luma windows,
- *   in `[-1, 1]` (1.0 ⇒ identical). Captures "did the structure change" rather than raw pixel
+ *   in `[-1, 1]` (1.0 ⇒ identical). Luma is alpha-composited over black so transparency changes
+ *   move the structural signal too. Captures "did the structure change" rather than raw pixel
  *   count, so anti-aliasing jitter that bumps [diffPx] barely dents `ssim`.
  * - **[Result.markedPng]** — the `to` frame at 50% brightness with every differing pixel painted
  *   bright red, encoded as PNG bytes, so a reviewer can locate the change without flipping between
@@ -71,7 +74,7 @@ object HistoryImageDiff {
       for (x in 0 until w) {
         val pa = a.getRGB(x, y)
         val pb = b.getRGB(x, y)
-        if ((pa and 0xFFFFFF) != (pb and 0xFFFFFF)) {
+        if (pa != pb) { // full ARGB — alpha-only changes count too
           diffPx++
           marked.setRGB(x, y, 0xFFFF0000.toInt()) // opaque red
         } else {
@@ -150,10 +153,12 @@ object HistoryImageDiff {
     for (y in 0 until h) {
       for (x in 0 until w) {
         val p = img.getRGB(x, y)
+        val alpha = ((p ushr 24) and 0xFF) / 255.0
         val r = (p shr 16) and 0xFF
         val g = (p shr 8) and 0xFF
         val bl = p and 0xFF
-        out[y * w + x] = 0.299 * r + 0.587 * g + 0.114 * bl
+        // Composite over black so a transparency change shifts luma (opaque pixels are unchanged).
+        out[y * w + x] = alpha * (0.299 * r + 0.587 * g + 0.114 * bl)
       }
     }
     return out

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryImageDiff.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryImageDiff.kt
@@ -1,0 +1,178 @@
+package ee.schimke.composeai.daemon.history
+
+import java.awt.image.BufferedImage
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import javax.imageio.ImageIO
+import kotlin.math.max
+
+/**
+ * Pixel + structural image diff for `history/diff mode = "pixel"` (H5, issue #1873).
+ *
+ * Pure-JVM (`java.awt` / `javax.imageio`), self-contained in `:daemon:core` — the harness's
+ * `PixelDiff` is a test fixture with a different, tolerance-gated contract (pass/fail for golden
+ * comparisons) and lives in a test-scope module, so it isn't reused here. This produces *metrics*
+ * for two archived history PNGs plus a reviewer-facing marked-diff image:
+ *
+ * - **[Result.diffPx]** — count of pixels whose RGB differs at all between the two frames. A blunt,
+ *   deterministic "how many pixels moved" number; perceptual closeness is [Result.ssim]'s job.
+ * - **[Result.ssim]** — mean structural-similarity index (Wang et al. 2004) over 8×8 luma windows,
+ *   in `[-1, 1]` (1.0 ⇒ identical). Captures "did the structure change" rather than raw pixel
+ *   count, so anti-aliasing jitter that bumps [diffPx] barely dents `ssim`.
+ * - **[Result.markedPng]** — the `to` frame at 50% brightness with every differing pixel painted
+ *   bright red, encoded as PNG bytes, so a reviewer can locate the change without flipping between
+ *   two images. Null when the two frames have mismatched dimensions (no meaningful overlay).
+ *
+ * **Dimension mismatch** (same preview rendered at two different sizes) is reported, not errored:
+ * `diffPx = max(areaFrom, areaTo)`, `ssim = 0.0`, `markedPng = null`. The caller still gets a
+ * usable "everything changed" signal.
+ */
+object HistoryImageDiff {
+
+  /** Result of [diff]. [markedPng] is null on dimension mismatch or PNG-encode failure. */
+  data class Result(val diffPx: Long, val ssim: Double, val markedPng: ByteArray?) {
+    // ByteArray needs structural equals/hashCode for the data class to behave in tests/maps.
+    override fun equals(other: Any?): Boolean {
+      if (this === other) return true
+      if (other !is Result) return false
+      return diffPx == other.diffPx &&
+        ssim == other.ssim &&
+        (markedPng?.contentEquals(other.markedPng ?: ByteArray(0)) ?: (other.markedPng == null))
+    }
+
+    override fun hashCode(): Int {
+      var result = diffPx.hashCode()
+      result = 31 * result + ssim.hashCode()
+      result = 31 * result + (markedPng?.contentHashCode() ?: 0)
+      return result
+    }
+  }
+
+  /** Thrown when a frame's bytes can't be decoded as an image. */
+  class UndecodableImageException(message: String) : Exception(message)
+
+  /**
+   * Diffs [fromPng] against [toPng]. Throws [UndecodableImageException] if either side can't be
+   * decoded — the caller maps that onto a structured RPC error.
+   */
+  fun diff(fromPng: ByteArray, toPng: ByteArray): Result {
+    val a =
+      decode(fromPng) ?: throw UndecodableImageException("from frame is not a decodable image")
+    val b = decode(toPng) ?: throw UndecodableImageException("to frame is not a decodable image")
+    if (a.width != b.width || a.height != b.height) {
+      val area = max(a.width.toLong() * a.height, b.width.toLong() * b.height)
+      return Result(diffPx = area, ssim = 0.0, markedPng = null)
+    }
+    val w = a.width
+    val h = b.height
+    var diffPx = 0L
+    val marked = BufferedImage(w, h, BufferedImage.TYPE_INT_ARGB)
+    for (y in 0 until h) {
+      for (x in 0 until w) {
+        val pa = a.getRGB(x, y)
+        val pb = b.getRGB(x, y)
+        if ((pa and 0xFFFFFF) != (pb and 0xFFFFFF)) {
+          diffPx++
+          marked.setRGB(x, y, 0xFFFF0000.toInt()) // opaque red
+        } else {
+          // 50% darkened `to` pixel keeps spatial context behind the red marks.
+          val r = ((pb shr 16) and 0xFF) / 2
+          val g = ((pb shr 8) and 0xFF) / 2
+          val bl = (pb and 0xFF) / 2
+          marked.setRGB(x, y, (0xFF shl 24) or (r shl 16) or (g shl 8) or bl)
+        }
+      }
+    }
+    return Result(diffPx = diffPx, ssim = ssim(a, b), markedPng = encodePng(marked))
+  }
+
+  /**
+   * Mean SSIM over non-overlapping 8×8 luma windows. Edge windows smaller than 8 px use their
+   * actual size. Non-overlapping (vs. a sliding Gaussian window) keeps it cheap and fully
+   * deterministic — adequate for "did this render's structure change" without the cost of the
+   * reference filter.
+   */
+  private fun ssim(a: BufferedImage, b: BufferedImage): Double {
+    val w = a.width
+    val h = a.height
+    val la = luma(a)
+    val lb = luma(b)
+    val c1 = (0.01 * 255.0) * (0.01 * 255.0)
+    val c2 = (0.03 * 255.0) * (0.03 * 255.0)
+    val win = 8
+    var sum = 0.0
+    var windows = 0
+    var by = 0
+    while (by < h) {
+      var bx = 0
+      while (bx < w) {
+        val xe = minOf(bx + win, w)
+        val ye = minOf(by + win, h)
+        var meanA = 0.0
+        var meanB = 0.0
+        var count = 0
+        for (y in by until ye) for (x in bx until xe) {
+          meanA += la[y * w + x]
+          meanB += lb[y * w + x]
+          count++
+        }
+        meanA /= count
+        meanB /= count
+        var varA = 0.0
+        var varB = 0.0
+        var cov = 0.0
+        for (y in by until ye) for (x in bx until xe) {
+          val dA = la[y * w + x] - meanA
+          val dB = lb[y * w + x] - meanB
+          varA += dA * dA
+          varB += dB * dB
+          cov += dA * dB
+        }
+        varA /= count
+        varB /= count
+        cov /= count
+        val s =
+          ((2 * meanA * meanB + c1) * (2 * cov + c2)) /
+            ((meanA * meanA + meanB * meanB + c1) * (varA + varB + c2))
+        sum += s
+        windows++
+        bx += win
+      }
+      by += win
+    }
+    return if (windows == 0) 1.0 else sum / windows
+  }
+
+  private fun luma(img: BufferedImage): DoubleArray {
+    val w = img.width
+    val h = img.height
+    val out = DoubleArray(w * h)
+    for (y in 0 until h) {
+      for (x in 0 until w) {
+        val p = img.getRGB(x, y)
+        val r = (p shr 16) and 0xFF
+        val g = (p shr 8) and 0xFF
+        val bl = p and 0xFF
+        out[y * w + x] = 0.299 * r + 0.587 * g + 0.114 * bl
+      }
+    }
+    return out
+  }
+
+  private fun decode(bytes: ByteArray): BufferedImage? =
+    try {
+      ByteArrayInputStream(bytes).use { ImageIO.read(it) }
+    } catch (_: Throwable) {
+      null
+    }
+
+  private fun encodePng(img: BufferedImage): ByteArray? =
+    try {
+      ByteArrayOutputStream().use { out ->
+        ImageIO.write(img, "png", out)
+        out.toByteArray()
+      }
+    } catch (_: Throwable) {
+      null
+    }
+}

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/LocalFsHistorySource.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/LocalFsHistorySource.kt
@@ -357,8 +357,47 @@ class LocalFsHistorySource(private val historyDir: Path) : HistorySource {
       if (key in survivingPngPaths) 0L else entry.pngSize
     }
 
+    // Marked-diff PNGs (`history/diff mode=pixel`, H5) are a regenerable cache under each preview's
+    // `.diffs/` dir, named `<from>__<to>.png`. They must not outlive the entries they describe, so
+    // any diff referencing a removed entry is pruned too and its bytes count toward freedBytes.
+    val removedSanitisedIds =
+      removedEntries.mapTo(HashSet()) { HistoryDiffArtifacts.sanitiseId(it.id) }
+    val affectedPreviewDirs =
+      removedEntries.mapTo(LinkedHashSet()) { PreviewIdSanitiser.sanitise(it.previewId) }
+    val diffArtifactsToRemove = ArrayList<Path>()
+    var freedDiffBytes = 0L
+    for (previewDir in affectedPreviewDirs) {
+      val diffsDir = historyDir.resolve(previewDir).resolve(HistoryDiffArtifacts.DIFFS_DIR_NAME)
+      if (!Files.isDirectory(diffsDir)) continue
+      try {
+        Files.list(diffsDir).use { stream ->
+          stream.forEach { p ->
+            val name = p.fileName.toString()
+            if (removedSanitisedIds.any { HistoryDiffArtifacts.referencesEntry(name, it) }) {
+              diffArtifactsToRemove.add(p)
+              freedDiffBytes +=
+                try {
+                  Files.size(p)
+                } catch (_: Throwable) {
+                  0L
+                }
+            }
+          }
+        }
+      } catch (t: Throwable) {
+        System.err.println(
+          "compose-ai-daemon: LocalFsHistorySource.prune: .diffs scan failed for " +
+            "$diffsDir (${t.javaClass.simpleName}: ${t.message})"
+        )
+      }
+    }
+    val totalFreedBytes = freedBytes + freedDiffBytes
+
     if (dryRun) {
-      return PruneResult(removedEntryIds = removedEntries.map { it.id }, freedBytes = freedBytes)
+      return PruneResult(
+        removedEntryIds = removedEntries.map { it.id },
+        freedBytes = totalFreedBytes,
+      )
     }
 
     // -----------------------------------------------------------------------------------
@@ -443,7 +482,19 @@ class LocalFsHistorySource(private val historyDir: Path) : HistorySource {
       }
     }
 
-    return PruneResult(removedEntryIds = removedEntries.map { it.id }, freedBytes = freedBytes)
+    // 4. Delete marked-diff artefacts that reference a removed entry (computed above).
+    for (diffFile in diffArtifactsToRemove) {
+      try {
+        Files.deleteIfExists(diffFile)
+      } catch (t: Throwable) {
+        System.err.println(
+          "compose-ai-daemon: LocalFsHistorySource.prune: diff artefact delete failed for " +
+            "$diffFile (${t.javaClass.simpleName}: ${t.message})"
+        )
+      }
+    }
+
+    return PruneResult(removedEntryIds = removedEntries.map { it.id }, freedBytes = totalFreedBytes)
   }
 
   /**

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -1727,13 +1727,12 @@ enum class InteractiveInputKind {
 }
 
 // ---------------------------------------------------------------------------
-// H3 — `history/diff` metadata-mode wire shape. See HISTORY.md § "What this PR
-// lands § H3" and PROTOCOL.md § 5 ("history/diff").
+// `history/diff` wire shape. See HISTORY.md § "history/diff" and PROTOCOL.md
+// § 5 ("history/diff").
 //
-// Pixel-mode fields (`diffPx`, `ssim`, `diffPngPath`) are reserved on the
-// `HistoryDiffResult` shape but always null in METADATA mode — H5 lands the
-// full pixel pass. A METADATA caller asking for `mode = PIXEL` receives a
-// distinct -32603 error so `null` pixel fields stay unambiguous.
+// `diffPx` / `ssim` / `diffPngPath` are populated by PIXEL mode (H5, issue
+// #1873) and null in METADATA / SEMANTICS modes. `semanticsDelta` is populated
+// by SEMANTICS mode (issue #1785) and null otherwise.
 // ---------------------------------------------------------------------------
 
 @Serializable
@@ -1758,7 +1757,10 @@ data class HistoryDiffResult(
   val pngHashChanged: Boolean,
   val fromMetadata: JsonElement,
   val toMetadata: JsonElement,
-  // Pixel-mode fields — null in METADATA mode; populated by H5.
+  // Pixel-mode fields (H5, issue #1873) — null in METADATA / SEMANTICS modes. `diffPx` is the count
+  // of RGB-differing pixels; `ssim` is the mean structural-similarity index in [-1, 1] (1.0 ⇒
+  // identical); `diffPngPath` is the absolute path of the marked-diff PNG (null on dimension
+  // mismatch or write failure).
   val diffPx: Long? = null,
   val ssim: Double? = null,
   val diffPngPath: String? = null,

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/HistoryDiffTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/HistoryDiffTest.kt
@@ -5,6 +5,9 @@ import ee.schimke.composeai.daemon.JsonRpcServer
 import ee.schimke.composeai.daemon.RenderHost
 import ee.schimke.composeai.daemon.RenderRequest
 import ee.schimke.composeai.daemon.RenderResult
+import java.awt.image.BufferedImage
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
 import java.io.PipedInputStream
 import java.io.PipedOutputStream
 import java.nio.file.Files
@@ -13,13 +16,16 @@ import java.time.Instant
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
+import javax.imageio.ImageIO
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.double
 import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.long
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -37,7 +43,7 @@ import org.junit.Test
  * - different hash, same previewId → `pngHashChanged = true`
  * - different previewIds → `HistoryDiffMismatch (-32011)`
  * - missing `from` / `to` → `HistoryEntryNotFound (-32010)`
- * - `mode = pixel` → `-32012` reserved-for-H5 error
+ * - `mode = pixel` (H5, issue #1873) → `diffPx` + `ssim` + a written marked-diff PNG
  */
 class HistoryDiffTest {
 
@@ -190,19 +196,121 @@ class HistoryDiffTest {
     }
   }
 
+  // -------------------------------------------------------------------------
+  // PIXEL mode (H5, issue #1873) — decode both archived frames, report diffPx + ssim, write a
+  // marked-diff PNG. Entries carry real PNG bytes (the pixel path decodes them).
+  // -------------------------------------------------------------------------
+
   @Test(timeout = 30_000)
-  fun pixel_mode_not_yet_implemented() {
+  fun pixel_mode_identical_frames_report_zero_diff() {
     runWith { _, manager, send, receive ->
+      val png = solidPng(8, 8, 0x3366CC)
+      val a = manager.recordRender("preview-A", png, trigger = "renderNow", renderTookMs = 1)!!
+      // Self-diff: identical bytes ⇒ zero differing pixels, perfect structural similarity.
+      val resp = diffRoundTrip(send, receive, from = a.id, to = a.id, mode = "pixel")
+      val result = resp["result"]!!.jsonObject
+      assertEquals(0L, result["diffPx"]!!.jsonPrimitive.long)
+      assertEquals(1.0, result["ssim"]!!.jsonPrimitive.double, 1e-9)
+      val diffPngPath = result["diffPngPath"]!!.jsonPrimitive.content
+      assertTrue("diff PNG lands under .diffs/", diffPngPath.contains(".diffs"))
+      assertTrue("diff PNG was written", Files.exists(Path.of(diffPngPath)))
+    }
+  }
+
+  @Test(timeout = 30_000)
+  fun pixel_mode_counts_exact_differing_pixels_and_marks_them() {
+    runWith { _, manager, send, receive ->
+      val ts1 = Instant.parse("2026-04-30T10:12:34Z")
+      val ts2 = Instant.parse("2026-04-30T10:12:35Z")
+      // 8×8 all-black vs. top 4 rows white: exactly 32 of 64 pixels differ.
+      val black = solidPng(8, 8, 0x000000)
+      val topHalfWhite = pngOf(8, 8) { x, y -> if (y < 4) 0xFFFFFF else 0x000000 }
       val a =
         manager.recordRender(
           "preview-A",
-          "a-bytes".toByteArray(),
+          black,
           trigger = "renderNow",
           renderTookMs = 1,
+          timestamp = ts1,
         )!!
-      val resp = diffRoundTrip(send, receive, from = a.id, to = a.id, mode = "pixel")
-      val errCode = resp["error"]!!.jsonObject["code"]!!.jsonPrimitive.intOrNull
-      assertEquals(JsonRpcServer.ERR_HISTORY_PIXEL_NOT_IMPLEMENTED, errCode)
+      val b =
+        manager.recordRender(
+          "preview-A",
+          topHalfWhite,
+          trigger = "renderNow",
+          renderTookMs = 1,
+          timestamp = ts2,
+        )!!
+
+      val resp = diffRoundTrip(send, receive, from = a.id, to = b.id, mode = "pixel")
+      val result = resp["result"]!!.jsonObject
+      assertEquals("32 of 64 pixels differ", 32L, result["diffPx"]!!.jsonPrimitive.long)
+      // Structure changed substantially ⇒ ssim well below 1.0.
+      assertTrue("ssim < 1.0 when structure changes", result["ssim"]!!.jsonPrimitive.double < 0.99)
+      assertEquals(true, result["pngHashChanged"]!!.jsonPrimitive.content.toBooleanStrict())
+
+      // The marked-diff PNG paints differing pixels red and darkens matching ones.
+      val diffPngPath = result["diffPngPath"]!!.jsonPrimitive.content
+      val marked = ImageIO.read(ByteArrayInputStream(Files.readAllBytes(Path.of(diffPngPath))))
+      assertEquals(0xFFFF0000.toInt(), marked.getRGB(0, 0)) // a differing (top) pixel → red
+      assertEquals(
+        0xFF000000.toInt(),
+        marked.getRGB(0, 7),
+      ) // a matching (bottom, black) pixel → 50% of black = black
+    }
+  }
+
+  @Test(timeout = 30_000)
+  fun pixel_mode_dimension_mismatch_reports_full_diff_without_overlay() {
+    runWith { _, manager, send, receive ->
+      val ts1 = Instant.parse("2026-04-30T10:12:34Z")
+      val ts2 = Instant.parse("2026-04-30T10:12:35Z")
+      val small = solidPng(4, 4, 0x112233)
+      val large = solidPng(8, 8, 0x112233)
+      val a =
+        manager.recordRender(
+          "preview-A",
+          small,
+          trigger = "renderNow",
+          renderTookMs = 1,
+          timestamp = ts1,
+        )!!
+      val b =
+        manager.recordRender(
+          "preview-A",
+          large,
+          trigger = "renderNow",
+          renderTookMs = 1,
+          timestamp = ts2,
+        )!!
+
+      val resp = diffRoundTrip(send, receive, from = a.id, to = b.id, mode = "pixel")
+      val result = resp["result"]!!.jsonObject
+      assertEquals(
+        "diffPx = max area on dimension mismatch",
+        64L,
+        result["diffPx"]!!.jsonPrimitive.long,
+      )
+      assertEquals(0.0, result["ssim"]!!.jsonPrimitive.double, 1e-9)
+      // No overlay possible for mismatched dimensions.
+      assertTrue(
+        result["diffPngPath"] == null ||
+          result["diffPngPath"] == kotlinx.serialization.json.JsonNull
+      )
+    }
+  }
+
+  /** A solid-colour `width × height` PNG (RGB, opaque) as bytes. */
+  private fun solidPng(width: Int, height: Int, rgb: Int): ByteArray =
+    pngOf(width, height) { _, _ -> rgb }
+
+  /** Builds a `width × height` opaque PNG, sampling [rgbAt] (`0xRRGGBB`) per pixel. */
+  private fun pngOf(width: Int, height: Int, rgbAt: (x: Int, y: Int) -> Int): ByteArray {
+    val img = BufferedImage(width, height, BufferedImage.TYPE_INT_RGB)
+    for (y in 0 until height) for (x in 0 until width) img.setRGB(x, y, rgbAt(x, y))
+    return ByteArrayOutputStream().use { out ->
+      ImageIO.write(img, "png", out)
+      out.toByteArray()
     }
   }
 

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/HistoryDiffTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/HistoryDiffTest.kt
@@ -300,9 +300,57 @@ class HistoryDiffTest {
     }
   }
 
+  @Test(timeout = 30_000)
+  fun pixel_mode_reports_alpha_only_change() {
+    runWith { _, manager, send, receive ->
+      val ts1 = Instant.parse("2026-04-30T10:12:34Z")
+      val ts2 = Instant.parse("2026-04-30T10:12:35Z")
+      // Identical RGB everywhere; `to` makes the top-left 4×4 quadrant fully transparent. Without
+      // alpha-aware comparison this would read as diffPx=0 / ssim=1.0 (regression guard for the
+      // 0xFFFFFF-mask bug).
+      val opaque = argbPngOf(8, 8) { _, _ -> 0xFF3366CC.toInt() }
+      val withHole =
+        argbPngOf(8, 8) { x, y -> if (x < 4 && y < 4) 0x003366CC else 0xFF3366CC.toInt() }
+      val a =
+        manager.recordRender(
+          "preview-A",
+          opaque,
+          trigger = "renderNow",
+          renderTookMs = 1,
+          timestamp = ts1,
+        )!!
+      val b =
+        manager.recordRender(
+          "preview-A",
+          withHole,
+          trigger = "renderNow",
+          renderTookMs = 1,
+          timestamp = ts2,
+        )!!
+
+      val resp = diffRoundTrip(send, receive, from = a.id, to = b.id, mode = "pixel")
+      val result = resp["result"]!!.jsonObject
+      assertEquals("the 16 transparent pixels differ", 16L, result["diffPx"]!!.jsonPrimitive.long)
+      assertTrue(
+        "ssim < 1.0 for a transparency change",
+        result["ssim"]!!.jsonPrimitive.double < 0.99,
+      )
+    }
+  }
+
   /** A solid-colour `width × height` PNG (RGB, opaque) as bytes. */
   private fun solidPng(width: Int, height: Int, rgb: Int): ByteArray =
     pngOf(width, height) { _, _ -> rgb }
+
+  /** Builds a `width × height` ARGB PNG, sampling [argbAt] (`0xAARRGGBB`) per pixel. */
+  private fun argbPngOf(width: Int, height: Int, argbAt: (x: Int, y: Int) -> Int): ByteArray {
+    val img = BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB)
+    for (y in 0 until height) for (x in 0 until width) img.setRGB(x, y, argbAt(x, y))
+    return ByteArrayOutputStream().use { out ->
+      ImageIO.write(img, "png", out)
+      out.toByteArray()
+    }
+  }
 
   /** Builds a `width × height` opaque PNG, sampling [rgbAt] (`0xRRGGBB`) per pixel. */
   private fun pngOf(width: Int, height: Int, rgbAt: (x: Int, y: Int) -> Int): ByteArray {

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/JsonRpcServerHistoryIntegrationTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/JsonRpcServerHistoryIntegrationTest.kt
@@ -16,10 +16,12 @@ import java.util.concurrent.TimeUnit
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.double
 import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.long
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -229,16 +231,19 @@ class JsonRpcServerHistoryIntegrationTest {
       assertNotNull(diffSelfResult["fromMetadata"])
       assertNotNull(diffSelfResult["toMetadata"])
 
-      // 12. history/diff with mode=pixel → -32012 (reserved for H5).
+      // 12. history/diff with mode=pixel (H5) — self-diff of a real PNG → zero differing pixels,
+      //     perfect ssim, and a marked-diff PNG written under the preview's `.diffs/` dir.
       writeFrame(
         clientToServerOut,
         """{"jsonrpc":"2.0","id":10,"method":"history/diff","params":{"from":"$entryId","to":"$entryId","mode":"pixel"}}""",
       )
       val diffPixel = pollUntil(received) { it["id"]?.jsonPrimitive?.intOrNull == 10 }
-      assertEquals(
-        JsonRpcServer.ERR_HISTORY_PIXEL_NOT_IMPLEMENTED,
-        diffPixel!!["error"]!!.jsonObject["code"]!!.jsonPrimitive.intOrNull,
-      )
+      val diffPixelResult = diffPixel!!["result"]!!.jsonObject
+      assertEquals(0L, diffPixelResult["diffPx"]!!.jsonPrimitive.long)
+      assertEquals(1.0, diffPixelResult["ssim"]!!.jsonPrimitive.double, 1e-9)
+      val diffPngPath = diffPixelResult["diffPngPath"]!!.jsonPrimitive.content
+      assertTrue("marked-diff PNG lands under .diffs/", diffPngPath.contains(".diffs"))
+      assertTrue("marked-diff PNG was written", Files.exists(Path.of(diffPngPath)))
 
       // 13. history/prune (H4) — dryRun with a tight policy returns the would-remove set
       //     without mutating disk + does NOT emit a `historyPruned` notification.
@@ -422,9 +427,9 @@ class JsonRpcServerHistoryIntegrationTest {
   }
 
   /**
-   * Test [RenderHost] that writes a deterministic PNG-shaped byte sequence to disk and returns its
-   * path. We don't need a real PNG decoder — H1's history pipeline only sha256s the bytes, so any
-   * deterministic blob works.
+   * Test [RenderHost] that writes a real, deterministic PNG to disk and returns its path. H1's
+   * history pipeline only sha256s the bytes, but H5's `history/diff mode=pixel` decodes them, so
+   * the blob is a genuine (tiny) PNG whose colour is keyed off the request id for determinism.
    */
   private class RealPngHost(private val rendersDir: Path) : RenderHost {
     @Volatile
@@ -450,7 +455,7 @@ class JsonRpcServerHistoryIntegrationTest {
               when (req) {
                 is RenderRequest.Render -> {
                   val pngFile = rendersDir.resolve("render-${req.id}.png")
-                  val payload = "synthetic-render-${req.id}".toByteArray()
+                  val payload = syntheticPng(req.id)
                   Files.write(pngFile, payload)
                   lastPngBytes = payload
                   val cl = Thread.currentThread().contextClassLoader
@@ -489,6 +494,17 @@ class JsonRpcServerHistoryIntegrationTest {
       stopped = true
       queue.put(RenderRequest.Shutdown)
       worker.join(timeoutMs)
+    }
+
+    /** A genuine 8×8 PNG whose solid colour is derived from [id] for determinism. */
+    private fun syntheticPng(id: Long): ByteArray {
+      val img = java.awt.image.BufferedImage(8, 8, java.awt.image.BufferedImage.TYPE_INT_RGB)
+      val rgb = 0x202020 or ((id.toInt() and 0xFF) shl 8)
+      for (y in 0 until 8) for (x in 0 until 8) img.setRGB(x, y, rgb)
+      return java.io.ByteArrayOutputStream().use { out ->
+        javax.imageio.ImageIO.write(img, "png", out)
+        out.toByteArray()
+      }
     }
   }
 

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/LocalFsHistorySourcePruneTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/LocalFsHistorySourcePruneTest.kt
@@ -298,6 +298,68 @@ class LocalFsHistorySourcePruneTest {
   }
 
   @Test
+  fun prune_removes_diff_artifacts_referencing_pruned_entries_and_counts_their_bytes() {
+    val now = Instant.now()
+    val previewId = "P"
+    // e[0] newest … e[2] oldest, all one preview.
+    val e =
+      (0 until 3).map { i ->
+        writeEntry(
+          previewId = previewId,
+          timestamp = now.minusSeconds(i.toLong() * 3600),
+          suffix = "%02d".format(i),
+        )
+      }
+    val diffsDir = tmpDir.resolve(previewId).resolve(HistoryDiffArtifacts.DIFFS_DIR_NAME)
+    Files.createDirectories(diffsDir)
+    // Orphan-to-be: references the soon-pruned oldest entry. Survivor: references the two kept.
+    val orphanDiff = diffsDir.resolve(HistoryDiffArtifacts.fileName(e[2].id, e[1].id))
+    val survivorDiff = diffsDir.resolve(HistoryDiffArtifacts.fileName(e[1].id, e[0].id))
+    Files.write(orphanDiff, ByteArray(100))
+    Files.write(survivorDiff, ByteArray(50))
+
+    // Keep newest 2 per preview → e[2] pruned; e[0], e[1] survive.
+    val result =
+      source.prune(
+        HistoryPruneConfig(maxEntriesPerPreview = 2, maxAgeDays = 0, maxTotalSizeBytes = 0L)
+      )
+
+    assertEquals(listOf(e[2].id), result.removedEntryIds)
+    assertFalse("diff referencing the pruned entry is removed", Files.exists(orphanDiff))
+    assertTrue("diff referencing only survivors is kept", Files.exists(survivorDiff))
+    // freedBytes = pruned entry's PNG + the orphan diff's 100 bytes.
+    assertEquals(e[2].pngSize + 100L, result.freedBytes)
+  }
+
+  @Test
+  fun dry_run_counts_orphan_diff_bytes_without_deleting_them() {
+    val now = Instant.now()
+    val previewId = "P"
+    val e =
+      (0 until 2).map { i ->
+        writeEntry(
+          previewId = previewId,
+          timestamp = now.minusSeconds(i.toLong() * 3600),
+          suffix = "%02d".format(i),
+        )
+      }
+    val diffsDir = tmpDir.resolve(previewId).resolve(HistoryDiffArtifacts.DIFFS_DIR_NAME)
+    Files.createDirectories(diffsDir)
+    val orphanDiff = diffsDir.resolve(HistoryDiffArtifacts.fileName(e[1].id, e[0].id))
+    Files.write(orphanDiff, ByteArray(42))
+
+    val result =
+      source.prune(
+        HistoryPruneConfig(maxEntriesPerPreview = 1, maxAgeDays = 0, maxTotalSizeBytes = 0L),
+        dryRun = true,
+      )
+
+    assertEquals(listOf(e[1].id), result.removedEntryIds)
+    assertEquals(e[1].pngSize + 42L, result.freedBytes)
+    assertTrue("dry-run must not delete artefacts", Files.exists(orphanDiff))
+  }
+
+  @Test
   fun index_rewrite_is_atomic_against_failures() {
     // Synthesise N entries; verify the index is bytewise rewritten cleanly. We can't easily
     // simulate

--- a/docs/daemon/HISTORY.md
+++ b/docs/daemon/HISTORY.md
@@ -180,8 +180,13 @@ result: {
 ```
 
 `mode = "metadata"` (default) is hash-compare + sidecar diff.
-`mode = "pixel"` (H5, not yet implemented) writes a marked-diff PNG to
-`<historyDir>/<previewId>/.diffs/`.
+`mode = "pixel"` (H5, issue #1873) decodes both archived frames and returns
+`diffPx` (count of RGB-differing pixels), `ssim` (mean structural-similarity
+index over 8×8 luma windows, `[-1, 1]`, `1.0` ⇒ identical), and
+`diffPngPath` — a marked-diff PNG (the `to` frame at 50% brightness with
+differing pixels painted red) written to `<historyDir>/<previewId>/.diffs/`.
+Differently-sized frames are reported, not errored: `diffPx = max(area)`,
+`ssim = 0.0`, `diffPngPath` omitted (no meaningful overlay).
 `mode = "semantics"` (issue #1785) diffs the two entries' captured
 `compose/semantics` trees and returns a typed `SemanticsDelta`
 (`compose-semantics-diff/v1`: added / removed / changed nodes, matched by
@@ -193,8 +198,9 @@ below), so the diff is deterministic and reads no PNGs. The same differ
 `diff_semantics` tool, so all three surfaces agree.
 
 Mismatched previews → `HistoryDiffMismatch (-32011)`. Missing entry →
-`HistoryEntryNotFound (-32010)`. `mode = "pixel"` →
-`ERR_HISTORY_PIXEL_NOT_IMPLEMENTED (-32012)`. `mode = "semantics"` where one
+`HistoryEntryNotFound (-32010)`. (`-32012` `ERR_HISTORY_PIXEL_NOT_IMPLEMENTED`
+is retired now that H5 has landed; pixel mode no longer errors.)
+`mode = "semantics"` where one
 of the two entries has no captured semantics snapshot →
 `ERR_HISTORY_SEMANTICS_NOT_CAPTURED (-32013)` (distinct from "entry not
 found": the entry exists, but the render that produced it didn't compute

--- a/docs/daemon/HISTORY.md
+++ b/docs/daemon/HISTORY.md
@@ -288,6 +288,11 @@ are best-effort; orphans self-heal. Multiple sidecars may share one PNG
 sidecar is removed; `freedBytes` only counts entries whose PNG actually
 went away.
 
+Marked-diff PNGs (`history/diff mode=pixel`) under each preview's
+`.diffs/` dir are a regenerable cache: prune deletes any
+`<from>__<to>.png` that references a removed entry (so a diff never
+outlives the history it describes) and adds its bytes to `freedBytes`.
+
 `GitRefHistorySource` and any read-only backend skip pruning entirely
 (cleanup is the producer's concern).
 

--- a/docs/daemon/PROTOCOL.md
+++ b/docs/daemon/PROTOCOL.md
@@ -52,7 +52,7 @@ Standard JSON-RPC codes plus daemon-specific extensions in the reserved `-32000.
 | -32005   | RenderFailed          | Render itself failed; details in `data`. |
 | -32010   | HistoryEntryNotFound  | `history/read` or `history/diff` referenced a missing entry id. |
 | -32011   | HistoryDiffMismatch   | `history/diff` was given two entries from different previews. |
-| -32012   | HistoryPixelNotImplemented | `history/diff` was called with `mode = "pixel"`; reserved for phase H5. |
+| -32012   | HistoryPixelNotImplemented | _Retired_ — `mode = "pixel"` is implemented (H5, issue #1873) and no longer errors. Code kept reserved. |
 | -32013   | HistorySemanticsNotCaptured | `history/diff` was called with `mode = "semantics"` but one of the two entries has no captured `compose/semantics` snapshot (issue #1785). |
 | -32020   | DataProductUnknown    | `data/*` referenced a kind not advertised by the daemon. See [DATA-PRODUCTS.md](DATA-PRODUCTS.md). |
 | -32021   | DataProductNotAvailable | `data/fetch` against a preview that has never rendered. |
@@ -452,10 +452,11 @@ Errors:
 `mode = "metadata"` (default) is cheap: hash compare + sidecar return. The pixel-mode fields
 (`diffPx`, `ssim`, `diffPngPath`) stay `null` in METADATA mode by design.
 
-`mode = "pixel"` is **reserved for phase H5** and not implemented in H3 — calls with
-`mode = "pixel"` return `-32012` (`HistoryPixelNotImplemented`) so callers can distinguish
-"asked for pixel and the daemon isn't ready" from "asked for metadata and got null pixel fields
-by design."
+`mode = "pixel"` (H5, issue #1873) decodes both archived frames and returns `diffPx` (count of
+RGB-differing pixels), `ssim` (mean structural-similarity index over 8×8 luma windows, `[-1, 1]`,
+`1.0` ⇒ identical), and `diffPngPath` — a marked-diff PNG (the `to` frame at 50% brightness with
+differing pixels painted red) written under `<historyDir>/<previewId>/.diffs/`. Differently-sized
+frames are reported, not errored: `diffPx = max(area)`, `ssim = 0.0`, `diffPngPath` omitted.
 
 `mode = "semantics"` (issue #1785) diffs the two entries' captured `compose/semantics` trees and
 returns a typed `semanticsDelta` (`compose-semantics-diff/v1`: added / removed / changed nodes,
@@ -472,12 +473,13 @@ the load-bearing case for "did my edits change how this preview renders compared
 
 Errors:
 - `HistoryEntryNotFound` (-32010) — either `from` or `to` does not match any entry.
-- `HistoryDiffMismatch` (-32011) — `from` and `to` belong to different previews; pixel diff would
+- `HistoryDiffMismatch` (-32011) — `from` and `to` belong to different previews; a diff would
   be meaningless.
-- `HistoryPixelNotImplemented` (-32012) — `mode = "pixel"` was requested but the pixel pass is
-  reserved for phase H5.
 - `HistorySemanticsNotCaptured` (-32013) — `mode = "semantics"` was requested but one of the two
   entries has no captured `compose/semantics` snapshot.
+
+(`-32012` `HistoryPixelNotImplemented` is retired now that H5 has landed — pixel mode no longer
+errors. The code stays reserved so it isn't recycled.)
 
 ### `data/fetch`, `data/subscribe`, `data/unsubscribe` (phase D1)
 


### PR DESCRIPTION
Implements `history/diff mode = "pixel"` (H5, issue #1873). The mode was reserved — it returned `-32012 HistoryPixelNotImplemented`. Now it decodes both archived frames, computes `diffPx` + `ssim`, and writes a reviewer-facing marked-diff PNG.

Sequenced after #1884 (history on by default). Scope is the **daemon RPC only**; the data-product diff half of #1873 (a11y/semantics/theme deltas) depends on stable refs (#1784), and the VS Code / CLI consumers are owned by #1872 — both remain follow-ups.

## What changed

- **New `HistoryImageDiff`** (pure-JVM, `:daemon:core`):
  - `diffPx` — count of RGB-differing pixels (blunt "how many pixels moved").
  - `ssim` — mean structural-similarity index over 8×8 luma windows, `[-1, 1]`, `1.0` ⇒ identical (so AA jitter that bumps `diffPx` barely dents `ssim`).
  - marked PNG — the `to` frame at 50% brightness with differing pixels painted red.
  - Differently-sized frames are **reported, not errored**: `diffPx = max(area)`, `ssim = 0.0`, no overlay.
- **`history/diff` handler**: reads frame bytes only for pixel mode, runs the diff, and writes the marked PNG to `{historyDir}/{previewId}/.diffs/{from}__{to}.png` (dot-prefixed so the per-preview sidecar scan ignores it), returning the absolute `diffPngPath`. previewId-mismatch / missing-entry errors are unchanged.
- **`-32012` retired**: the constant is `@Deprecated` but kept reserved (so the number isn't recycled); the handler never emits it now.
- **Docs**: HISTORY.md, PROTOCOL.md (table + prose), and the wire-shape comments updated.

## Test plan

- `HistoryDiffTest` — new pixel coverage: exact `diffPx` on a known image pair (8×8, top half flipped → exactly 32/64), `ssim` behaviour, the **overlay asserted pixel-exactly** (red at a differing pixel, darkened at a matching one), and the dimension-mismatch path.
- `JsonRpcServerHistoryIntegrationTest` — `RealPngHost` now emits a real PNG so the wire path exercises pixel mode end to end (self-diff → `diffPx=0`, `ssim=1.0`, written `diffPngPath`).
- Both classes green; `:daemon:core` compiles + ktfmt clean.
- Note: the pre-existing `InteractiveCoalescingTest` flake is unrelated — it fails on clean `origin/main` too (verified by stashing this branch's changes).

## Visual evidence

The marked-diff PNG is a daemon artefact, not a `@Preview`/webview surface the PNG pipeline reaches, so its correctness is locked by a **deterministic unit test** (red ⇒ differing pixel, darkened ⇒ matching) rather than a fixture screenshot. A rendered sample — a "Submit"→"Send" text change plus a new red dot, shown as red marks over the darkened `to` frame (`diffPx=347, ssim=0.936`) — was produced through the real `HistoryImageDiff` code path and shared with the author out-of-band.