### PR TITLE
feat(cli): history diff --mode pixel (local pixel diff)

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/HistoryCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/HistoryCommand.kt
@@ -1,8 +1,10 @@
 package ee.schimke.composeai.cli
 
 import ee.schimke.composeai.daemon.history.GitRefHistorySource
+import ee.schimke.composeai.daemon.history.HistoryDiffArtifacts
 import ee.schimke.composeai.daemon.history.HistoryEntry
 import ee.schimke.composeai.daemon.history.HistoryFilter
+import ee.schimke.composeai.daemon.history.HistoryImageDiff
 import ee.schimke.composeai.daemon.history.HistorySource
 import ee.schimke.composeai.daemon.history.LocalFsHistorySource
 import java.nio.file.Files
@@ -29,6 +31,10 @@ import kotlinx.serialization.json.JsonElement
  * v1 reads on-disk / on-branch history directly. Preferring a running daemon's `history` JSON-RPC
  * methods (for live, not-yet-flushed state) needs a CLI-side daemon client — tracked as a
  * follow-up; the on-disk read is the source of truth the daemon persists to.
+ *
+ * `diff --mode pixel` is computed locally via the shared [HistoryImageDiff] (the same code the
+ * daemon's `history/diff mode=pixel` runs, so results agree), reusing the archived PNG bytes off
+ * disk — no daemon round-trip. `--mode semantics` stays daemon-backed for now (follow-up).
  */
 class HistoryCommand(private val args: List<String>) {
 
@@ -160,10 +166,10 @@ class HistoryCommand(private val args: List<String>) {
   private fun diff() {
     val json = "--json" in args
     val mode = args.flagValue("--mode") ?: "metadata"
-    if (mode != "metadata") {
+    if (mode != "metadata" && mode != "pixel") {
       System.err.println(
-        "history diff: --mode $mode is not available from the CLI yet (pixel/semantics diff is " +
-          "daemon-backed via history/diff). Use --mode metadata."
+        "history diff: --mode $mode is not available from the CLI yet (semantics diff is " +
+          "daemon-backed via history/diff). Use --mode metadata or --mode pixel."
       )
       exitProcess(1)
     }
@@ -179,8 +185,12 @@ class HistoryCommand(private val args: List<String>) {
           System.err.println("history diff: entries not found")
           exitProcess(2)
         }
-    val from = source.read(fromId)?.entry
-    val to = source.read(toId)?.entry
+    // Pixel mode decodes the archived frames, so it needs the bytes; metadata mode doesn't.
+    val pixel = mode == "pixel"
+    val fromRead = source.read(fromId, includeBytes = pixel)
+    val toRead = source.read(toId, includeBytes = pixel)
+    val from = fromRead?.entry
+    val to = toRead?.entry
     if (from == null || to == null) {
       System.err.println("history diff: entry not found: ${if (from == null) fromId else toId}")
       exitProcess(2)
@@ -192,6 +202,49 @@ class HistoryCommand(private val args: List<String>) {
       exitProcess(2)
     }
     val pngHashChanged = from.pngHash != to.pngHash
+
+    if (pixel) {
+      // Computed locally via the shared HistoryImageDiff — same code the daemon's `history/diff
+      // mode=pixel` runs, so results agree, and it works whether or not a daemon is up.
+      val fromBytes = fromRead.pngBytes
+      val toBytes = toRead.pngBytes
+      if (fromBytes == null || toBytes == null) {
+        System.err.println("history diff: no PNG bytes available to pixel-diff")
+        exitProcess(2)
+      }
+      val result =
+        try {
+          HistoryImageDiff.diff(fromBytes, toBytes)
+        } catch (e: HistoryImageDiff.UndecodableImageException) {
+          System.err.println("history diff: ${e.message}")
+          exitProcess(2)
+        }
+      val diffPngPath =
+        result.markedPng?.let { writeDiffArtifact(toRead.pngPath, fromId, toId, it) }
+
+      if (json) {
+        val payload =
+          HistoryDiffResponse(
+            schema = HISTORY_SCHEMA,
+            mode = "pixel",
+            pngHashChanged = pngHashChanged,
+            from = leanEntryJson(from),
+            to = leanEntryJson(to),
+            diffPx = result.diffPx,
+            ssim = result.ssim,
+            diffPngPath = diffPngPath,
+          )
+        println(OUT.encodeToString(HistoryDiffResponse.serializer(), payload))
+        return
+      }
+
+      println("diff ${from.id} → ${to.id}  (preview ${from.previewId})")
+      println("  pixels:    ${if (pngHashChanged) "CHANGED" else "unchanged"}")
+      println("  diffPx:    ${result.diffPx}")
+      println("  ssim:      ${"%.4f".format(result.ssim)}")
+      println("  diff PNG:  ${diffPngPath ?: "(none — dimension mismatch)"}")
+      return
+    }
 
     if (json) {
       val payload =
@@ -216,6 +269,39 @@ class HistoryCommand(private val args: List<String>) {
     val toData = dataProductsOf(to)
     if (fromData != toData) println("  data:      $fromData → $toData")
   }
+
+  /**
+   * Writes the marked-diff [pngBytes]. `--out <path>` wins; otherwise it mirrors the daemon's
+   * `<previewDir>/.diffs/<from>__<to>.png` convention (derived from the `to` entry's PNG path) via
+   * [HistoryDiffArtifacts], so CLI- and daemon-produced artefacts land in the same place.
+   * Best-effort — returns the absolute path, or null (after reporting) if the write fails.
+   */
+  private fun writeDiffArtifact(
+    toPngPath: String,
+    fromId: String,
+    toId: String,
+    pngBytes: ByteArray,
+  ): String? =
+    try {
+      val out = args.flagValue("--out")
+      val target =
+        if (out != null) {
+          Paths.get(out)
+        } else {
+          val diffsDir =
+            Paths.get(toPngPath)
+              .toAbsolutePath()
+              .parent
+              .resolve(HistoryDiffArtifacts.DIFFS_DIR_NAME)
+          Files.createDirectories(diffsDir)
+          diffsDir.resolve(HistoryDiffArtifacts.fileName(fromId, toId))
+        }
+      Files.write(target, pngBytes)
+      target.toAbsolutePath().toString()
+    } catch (t: Throwable) {
+      System.err.println("history diff: failed to write diff PNG: ${t.message}")
+      null
+    }
 
   // -------------------------------------------------------------------------
   // Source resolution + helpers
@@ -322,7 +408,8 @@ class HistoryCommand(private val args: List<String>) {
         --inline       Include base64 PNG bytes (--json)
 
       diff options:
-        --mode metadata        (pixel/semantics diff is daemon-backed; not in the CLI yet)
+        --mode metadata|pixel  pixel reports diffPx + ssim and writes a marked-diff PNG
+        --out <path>           (pixel) write the marked-diff PNG here instead of <preview>/.diffs/
 
       Common:
         --json         Emit JSON (schema: $HISTORY_SCHEMA)
@@ -386,4 +473,8 @@ internal data class HistoryDiffResponse(
   val pngHashChanged: Boolean,
   val from: JsonElement,
   val to: JsonElement,
+  // Pixel-mode fields (`--mode pixel`); null in metadata mode.
+  val diffPx: Long? = null,
+  val ssim: Double? = null,
+  val diffPngPath: String? = null,
 )

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/HistoryCommandTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/HistoryCommandTest.kt
@@ -3,10 +3,12 @@ package ee.schimke.composeai.cli
 import ee.schimke.composeai.daemon.history.HistoryEntry
 import ee.schimke.composeai.daemon.history.HistorySourceInfo
 import ee.schimke.composeai.daemon.history.LocalFsHistorySource
+import java.awt.image.BufferedImage
 import java.io.ByteArrayOutputStream
 import java.io.PrintStream
 import java.nio.file.Files
 import java.nio.file.Path
+import javax.imageio.ImageIO
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -126,6 +128,71 @@ class HistoryCommandTest {
   }
 
   @Test
+  fun `diff --mode pixel reports diffPx and ssim and writes a marked PNG`() {
+    // 8×8 all-black vs. top 4 rows white → exactly 32/64 pixels differ.
+    val from =
+      seed("20260430-100000-aa00aa00", "com.example.A", solidPng(0x000000), "2026-04-30T10:00:00Z")
+    val to =
+      seed(
+        "20260430-100100-bb11bb11",
+        "com.example.A",
+        pngOf { _, y -> if (y < 4) 0xFFFFFF else 0x000000 },
+        "2026-04-30T10:01:00Z",
+      )
+
+    HistoryCommand(
+        listOf(
+          "diff",
+          from,
+          to,
+          "--mode",
+          "pixel",
+          "--history-dir",
+          historyDir.toString(),
+          "--json",
+        )
+      )
+      .run()
+    val payload = Json.parseToJsonElement(output()).jsonObject
+
+    assertEquals("pixel", payload["mode"]?.jsonPrimitive?.content)
+    assertEquals(32L, payload["diffPx"]?.jsonPrimitive?.content?.toLong())
+    assertTrue((payload["ssim"]?.jsonPrimitive?.content?.toDouble() ?: 1.0) < 0.99)
+    val diffPngPath = payload["diffPngPath"]!!.jsonPrimitive.content
+    assertTrue(diffPngPath.contains(".diffs"), "diff PNG under .diffs/: $diffPngPath")
+    assertTrue(Files.exists(Path.of(diffPngPath)), "diff PNG written")
+  }
+
+  @Test
+  fun `diff --mode pixel honours --out`() {
+    val from =
+      seed("20260430-100000-cc22cc22", "com.example.A", solidPng(0x102030), "2026-04-30T10:00:00Z")
+    val to =
+      seed("20260430-100100-dd33dd33", "com.example.A", solidPng(0x405060), "2026-04-30T10:01:00Z")
+    val outPng = historyDir.resolve("my-diff.png")
+
+    HistoryCommand(
+        listOf(
+          "diff",
+          from,
+          to,
+          "--mode",
+          "pixel",
+          "--out",
+          outPng.toString(),
+          "--history-dir",
+          historyDir.toString(),
+          "--json",
+        )
+      )
+      .run()
+    val payload = Json.parseToJsonElement(output()).jsonObject
+
+    assertEquals(outPng.toString(), payload["diffPngPath"]?.jsonPrimitive?.content)
+    assertTrue(Files.exists(outPng), "marked PNG written to --out path")
+  }
+
+  @Test
   fun `read resolves the id when a valued option precedes it`() {
     val id =
       seed("20260430-100000-ffffffff", "com.example.A", "x".toByteArray(), "2026-04-30T10:00:00Z")
@@ -160,6 +227,19 @@ class HistoryCommandTest {
     val payload = Json.parseToJsonElement(output()).jsonObject
 
     assertEquals(true, payload["pngHashChanged"]?.jsonPrimitive?.content?.toBoolean())
+  }
+
+  /** A solid 8×8 opaque PNG of [rgb] (`0xRRGGBB`). */
+  private fun solidPng(rgb: Int): ByteArray = pngOf { _, _ -> rgb }
+
+  /** An 8×8 opaque PNG sampling [rgbAt] (`0xRRGGBB`) per pixel. */
+  private fun pngOf(rgbAt: (x: Int, y: Int) -> Int): ByteArray {
+    val img = BufferedImage(8, 8, BufferedImage.TYPE_INT_RGB)
+    for (y in 0 until 8) for (x in 0 until 8) img.setRGB(x, y, rgbAt(x, y))
+    return ByteArrayOutputStream().use { out ->
+      ImageIO.write(img, "png", out)
+      out.toByteArray()
+    }
   }
 
   @Test

--- a/docs/daemon/HISTORY.md
+++ b/docs/daemon/HISTORY.md
@@ -372,15 +372,18 @@ compose-preview history list   [--preview <id>] [--since/--until <iso>] [--branc
                                [--commit <sha>] [--source fs|git] [--agent <id>]
                                [--limit <n>] [--cursor <c>] [--history-dir <dir> | --ref <ref>] [--json]
 compose-preview history read   <entryId> [--out <png>] [--data] [--inline] [--json]
-compose-preview history diff   <fromId> <toId> [--mode metadata] [--json]
+compose-preview history diff   <fromId> <toId> [--mode metadata|pixel] [--out <png>] [--json]
 ```
 
 Structured-first (cf. #1787): human output is compact; `--json` emits a
 versioned envelope (`compose-preview-history/v1`); heavy snapshots (PNG
 bytes via `--inline`/`--out`, a11y/semantics/theme data via `--data`) ride
-only on explicit opt-in. `diff` is metadata-mode only today; pixel /
-semantics diff is daemon-backed (`history/diff`) and reaches the CLI once
-it grows a daemon JSON-RPC client (follow-up).
+only on explicit opt-in. `diff --mode pixel` is computed locally via the
+shared `HistoryImageDiff` (the same code the daemon's `history/diff
+mode=pixel` runs, so results agree) — it reports `diffPx` + `ssim` and
+writes a marked-diff PNG (to `--out`, else `<preview>/.diffs/`), no daemon
+required. `--mode semantics` stays daemon-backed (`history/diff`) and
+reaches the CLI once it grows a daemon JSON-RPC client (follow-up).
 
 ## MCP mapping
 


### PR DESCRIPTION
Wires the H5 pixel diff into the CLI. The daemon's `history/diff mode=pixel` landed in #1892; `compose-preview history diff` now offers the same via `--mode pixel`.

Part of the report-history epic (#1866 / #1873).

## Approach

Computed **locally** with the shared `HistoryImageDiff` (the exact code the daemon's `history/diff mode=pixel` runs → identical results) over the archived PNG bytes read off disk — no daemon round-trip. This fits the CLI's existing read-off-disk design (the class already reads the `.compose-preview-history/` archive directly, "whether or not a daemon is running") and means pixel diff works without a live daemon. `--mode semantics` stays daemon-backed and remains a follow-up (it needs a CLI-side daemon client).

## What changed

- `history diff --mode pixel` reports `diffPx` (RGB+alpha-differing pixels) + `ssim` and writes a marked-diff PNG — to `--out <path>` if given, else the daemon's `<preview>/.diffs/<from>__<to>.png` location (via the shared `HistoryDiffArtifacts`, so CLI- and daemon-produced artefacts co-locate).
- `--json` envelope gains `diffPx` / `ssim` / `diffPngPath`.
- Dimension mismatch → metrics with no overlay; undecodable frames → clean error + exit 2.
- HISTORY.md CLI section + `history` usage updated.

## Test plan

- Two new `HistoryCommandTest` cases: `--mode pixel` over a known 8×8 pair (top half flipped → `diffPx = 32`, `ssim < 0.99`, marked PNG written under `.diffs/`); and `--out` honoured. Full `HistoryCommandTest` green (8/8); `:cli` compiles, ktfmt clean.

## Visual evidence

No new rendered surface — the CLI reuses the merged `HistoryImageDiff` overlay (sample shown in #1892); this PR only adds the CLI entry point. Text-only is appropriate (CLI plumbing).