### PR TITLE
feat(cli): history diff --mode semantics (local semantics diff)

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/HistoryCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/HistoryCommand.kt
@@ -7,6 +7,9 @@ import ee.schimke.composeai.daemon.history.HistoryFilter
 import ee.schimke.composeai.daemon.history.HistoryImageDiff
 import ee.schimke.composeai.daemon.history.HistorySource
 import ee.schimke.composeai.daemon.history.LocalFsHistorySource
+import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsPayload
+import ee.schimke.composeai.data.layoutinspector.SemanticsDelta
+import ee.schimke.composeai.data.layoutinspector.SemanticsDiff
 import java.nio.file.Files
 import java.nio.file.Paths
 import java.util.Base64
@@ -32,9 +35,9 @@ import kotlinx.serialization.json.JsonElement
  * methods (for live, not-yet-flushed state) needs a CLI-side daemon client — tracked as a
  * follow-up; the on-disk read is the source of truth the daemon persists to.
  *
- * `diff --mode pixel` is computed locally via the shared [HistoryImageDiff] (the same code the
- * daemon's `history/diff mode=pixel` runs, so results agree), reusing the archived PNG bytes off
- * disk — no daemon round-trip. `--mode semantics` stays daemon-backed for now (follow-up).
+ * `diff --mode pixel` and `--mode semantics` are computed locally via the shared [HistoryImageDiff]
+ * / [SemanticsDiff] (the same code the daemon's `history/diff` runs, so results agree), reusing the
+ * archived PNG bytes / captured `compose/semantics` snapshots off disk — no daemon round-trip.
  */
 class HistoryCommand(private val args: List<String>) {
 
@@ -166,10 +169,9 @@ class HistoryCommand(private val args: List<String>) {
   private fun diff() {
     val json = "--json" in args
     val mode = args.flagValue("--mode") ?: "metadata"
-    if (mode != "metadata" && mode != "pixel") {
+    if (mode != "metadata" && mode != "pixel" && mode != "semantics") {
       System.err.println(
-        "history diff: --mode $mode is not available from the CLI yet (semantics diff is " +
-          "daemon-backed via history/diff). Use --mode metadata or --mode pixel."
+        "history diff: unknown --mode '$mode'. Use metadata (default), pixel, or semantics."
       )
       exitProcess(1)
     }
@@ -243,6 +245,54 @@ class HistoryCommand(private val args: List<String>) {
       println("  diffPx:    ${result.diffPx}")
       println("  ssim:      ${"%.4f".format(result.ssim)}")
       println("  diff PNG:  ${diffPngPath ?: "(none — dimension mismatch)"}")
+      return
+    }
+
+    if (mode == "semantics") {
+      // Structural diff of the two entries' captured compose/semantics trees, computed locally via
+      // the shared SemanticsDiff — the same differ the daemon's `history/diff mode=semantics` runs.
+      // Each entry's tree was snapshotted into its sidecar at record time, so this reads no PNGs.
+      val missing =
+        when {
+          from.semantics == null -> fromId
+          to.semantics == null -> toId
+          else -> null
+        }
+      if (missing != null) {
+        System.err.println(
+          "history diff: entry '$missing' has no captured compose/semantics snapshot " +
+            "(the render that produced it didn't compute semantics)"
+        )
+        exitProcess(2)
+      }
+      val delta =
+        try {
+          val base =
+            DECODE.decodeFromJsonElement(ComposeSemanticsPayload.serializer(), from.semantics!!)
+          val head =
+            DECODE.decodeFromJsonElement(ComposeSemanticsPayload.serializer(), to.semantics!!)
+          SemanticsDiff.diff(base, head)
+        } catch (t: Throwable) {
+          System.err.println("history diff: semantics diff failed: ${t.message}")
+          exitProcess(2)
+        }
+
+      if (json) {
+        val payload =
+          HistoryDiffResponse(
+            schema = HISTORY_SCHEMA,
+            mode = "semantics",
+            pngHashChanged = pngHashChanged,
+            from = leanEntryJson(from),
+            to = leanEntryJson(to),
+            semanticsDelta = OUT.encodeToJsonElement(SemanticsDelta.serializer(), delta),
+          )
+        println(OUT.encodeToString(HistoryDiffResponse.serializer(), payload))
+        return
+      }
+
+      println("diff ${from.id} → ${to.id}  (preview ${from.previewId})")
+      println(formatSemanticsDeltaHuman(delta).prependIndent("  "))
       return
     }
 
@@ -391,7 +441,7 @@ class HistoryCommand(private val args: List<String>) {
       Subcommands:
         list                 List history entries (newest first)
         read <entryId>       Show one entry's metadata (and optionally its PNG / data)
-        diff <fromId> <toId> Compare two entries (metadata mode)
+        diff <fromId> <toId> Compare two entries (metadata | pixel | semantics)
         help                 Show this help message
 
       Source:
@@ -408,7 +458,9 @@ class HistoryCommand(private val args: List<String>) {
         --inline       Include base64 PNG bytes (--json)
 
       diff options:
-        --mode metadata|pixel  pixel reports diffPx + ssim and writes a marked-diff PNG
+        --mode metadata|pixel|semantics
+                               pixel reports diffPx + ssim and writes a marked-diff PNG;
+                               semantics diffs the captured compose/semantics trees
         --out <path>           (pixel) write the marked-diff PNG here instead of <preview>/.diffs/
 
       Common:
@@ -446,6 +498,11 @@ class HistoryCommand(private val args: List<String>) {
       encodeDefaults = true
     }
     private val ENTRY = Json { encodeDefaults = false }
+
+    /**
+     * Lenient decoder for the entries' captured `compose/semantics` payloads (`--mode semantics`).
+     */
+    private val DECODE = Json { ignoreUnknownKeys = true }
   }
 }
 
@@ -477,4 +534,7 @@ internal data class HistoryDiffResponse(
   val diffPx: Long? = null,
   val ssim: Double? = null,
   val diffPngPath: String? = null,
+  // Semantics-mode field (`--mode semantics`); null otherwise. The typed compose-semantics-diff/v1
+  // delta of the two entries' captured trees.
+  val semanticsDelta: JsonElement? = null,
 )

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/HistoryCommandTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/HistoryCommandTest.kt
@@ -15,6 +15,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
@@ -50,6 +51,7 @@ class HistoryCommandTest {
     bytes: ByteArray,
     timestamp: String,
     a11yHierarchy: Boolean = false,
+    semantics: JsonElement? = null,
   ): String {
     val source = LocalFsHistorySource(historyDir)
     val entry =
@@ -69,10 +71,16 @@ class HistoryCommandTest {
           if (a11yHierarchy)
             Json.parseToJsonElement("""{"nodes":[{"label":"x","boundsInScreen":"0,0,1,1"}]}""")
           else null,
+        semantics = semantics,
       )
     source.write(entry, bytes)
     return id
   }
+
+  private fun semanticsPayload(text: String): JsonElement =
+    Json.parseToJsonElement(
+      """{"root":{"nodeId":"1","boundsInRoot":"0,0,100,50","testTag":"greeting","text":"$text"}}"""
+    )
 
   @Test
   fun `list --json emits versioned envelope newest-first`() {
@@ -161,6 +169,51 @@ class HistoryCommandTest {
     val diffPngPath = payload["diffPngPath"]!!.jsonPrimitive.content
     assertTrue(diffPngPath.contains(".diffs"), "diff PNG under .diffs/: $diffPngPath")
     assertTrue(Files.exists(Path.of(diffPngPath)), "diff PNG written")
+  }
+
+  @Test
+  fun `diff --mode semantics reports field changes on the same node`() {
+    val from =
+      seed(
+        "20260430-100000-5e11a000",
+        "com.example.A",
+        "v1".toByteArray(),
+        "2026-04-30T10:00:00Z",
+        semantics = semanticsPayload("Hello"),
+      )
+    val to =
+      seed(
+        "20260430-100100-5e11b111",
+        "com.example.A",
+        "v2".toByteArray(),
+        "2026-04-30T10:01:00Z",
+        semantics = semanticsPayload("World"),
+      )
+
+    HistoryCommand(
+        listOf(
+          "diff",
+          from,
+          to,
+          "--mode",
+          "semantics",
+          "--history-dir",
+          historyDir.toString(),
+          "--json",
+        )
+      )
+      .run()
+    val payload = Json.parseToJsonElement(output()).jsonObject
+
+    assertEquals("semantics", payload["mode"]?.jsonPrimitive?.content)
+    val delta = payload["semanticsDelta"]!!.jsonObject
+    assertEquals("compose-semantics-diff/v1", delta["schema"]?.jsonPrimitive?.content)
+    val changed = delta["changed"]!!.jsonArray
+    assertEquals(1, changed.size)
+    val change = changed[0].jsonObject["changes"]!!.jsonArray[0].jsonObject
+    assertEquals("text", change["field"]?.jsonPrimitive?.content)
+    assertEquals("Hello", change["from"]?.jsonPrimitive?.content)
+    assertEquals("World", change["to"]?.jsonPrimitive?.content)
   }
 
   @Test

--- a/docs/daemon/HISTORY.md
+++ b/docs/daemon/HISTORY.md
@@ -372,18 +372,19 @@ compose-preview history list   [--preview <id>] [--since/--until <iso>] [--branc
                                [--commit <sha>] [--source fs|git] [--agent <id>]
                                [--limit <n>] [--cursor <c>] [--history-dir <dir> | --ref <ref>] [--json]
 compose-preview history read   <entryId> [--out <png>] [--data] [--inline] [--json]
-compose-preview history diff   <fromId> <toId> [--mode metadata|pixel] [--out <png>] [--json]
+compose-preview history diff   <fromId> <toId> [--mode metadata|pixel|semantics] [--out <png>] [--json]
 ```
 
 Structured-first (cf. #1787): human output is compact; `--json` emits a
 versioned envelope (`compose-preview-history/v1`); heavy snapshots (PNG
 bytes via `--inline`/`--out`, a11y/semantics/theme data via `--data`) ride
-only on explicit opt-in. `diff --mode pixel` is computed locally via the
-shared `HistoryImageDiff` (the same code the daemon's `history/diff
-mode=pixel` runs, so results agree) — it reports `diffPx` + `ssim` and
-writes a marked-diff PNG (to `--out`, else `<preview>/.diffs/`), no daemon
-required. `--mode semantics` stays daemon-backed (`history/diff`) and
-reaches the CLI once it grows a daemon JSON-RPC client (follow-up).
+only on explicit opt-in. `diff --mode pixel` / `--mode semantics` are
+computed locally via the shared `HistoryImageDiff` / `SemanticsDiff` (the
+same code the daemon's `history/diff` runs, so results agree), reading the
+archived PNG bytes / captured `compose/semantics` snapshots off disk — no
+daemon required. Pixel reports `diffPx` + `ssim` and writes a marked-diff
+PNG (to `--out`, else `<preview>/.diffs/`); semantics emits the
+`compose-semantics-diff/v1` delta (added / removed / changed nodes).
 
 ## MCP mapping
 


### PR DESCRIPTION
Adds the third `history/diff` mode to the CLI: `compose-preview history diff --mode semantics`. Completes the CLI history-diff trio (metadata #1883, pixel #1896, semantics here).

Part of the report-history epic (#1866 / #1785).

## Approach

Same local-compute pattern as `--mode pixel`: computed via the shared `SemanticsDiff` — the exact differ the daemon's `history/diff mode=semantics` runs, and the one behind `compose-preview diff-semantics` — over the entries' captured `compose/semantics` snapshots read off disk. No daemon round-trip; results agree with the daemon's. (Each entry's tree is snapshotted into its sidecar at record time, so this reads no PNGs.)

## What changed

- `history diff --mode semantics` decodes both entries' `compose/semantics` trees, diffs them, and prints the human summary (reusing the existing `formatSemanticsDeltaHuman`) or, with `--json`, embeds the versioned `compose-semantics-diff/v1` `SemanticsDelta` (added / removed / changed nodes, matched by each node's stable `ref` — copy edits show as field changes, not remove+add).
- Missing snapshot on either side → clean error + exit 2 (mirrors the daemon's `ERR_HISTORY_SEMANTICS_NOT_CAPTURED`).
- `--json` envelope gains `semanticsDelta`. Usage + HISTORY.md CLI section updated.

## Test plan

- New `HistoryCommandTest` case: two entries whose semantics differ by one field (`text` "Hello" → "World" on the same node) → `mode=semantics`, `compose-semantics-diff/v1` delta with one changed node. Full `HistoryCommandTest` green (9/9); `:cli` compiles, ktfmt clean.

## Visual evidence

Non-visual — CLI plumbing over the existing semantics differ; no rendered surface. Text-only is appropriate.