### PR TITLE
feat(vscode): port semantics differ + history data-diff presenter

### DIFF
--- a/vscode-extension/src/test/historyDiffSemanticsPresenter.test.ts
+++ b/vscode-extension/src/test/historyDiffSemanticsPresenter.test.ts
@@ -1,0 +1,87 @@
+// History-diff semantics presenter (#1872). Pins delta → display-row derivation: ordering
+// (removed, added, changed), counts, the human label, and field rows for changed nodes.
+
+import * as assert from "assert";
+import { computeSemanticsDiffData } from "../webview/preview/historyDiffSemanticsPresenter";
+import { type SemanticsDelta } from "../webview/shared/semanticsDiff";
+
+describe("computeSemanticsDiffData", () => {
+    it("returns an empty data set for a null delta", () => {
+        const data = computeSemanticsDiffData(null);
+        assert.strictEqual(data.empty, true);
+        assert.strictEqual(data.rows.length, 0);
+        assert.strictEqual(data.addedCount, 0);
+        assert.strictEqual(data.removedCount, 0);
+        assert.strictEqual(data.changedCount, 0);
+    });
+
+    it("emits rows in removed → added → changed order with counts", () => {
+        const delta: SemanticsDelta = {
+            schema: "compose-semantics-diff/v1",
+            removed: [
+                {
+                    ref: "r/role:Old",
+                    role: "Old",
+                    testTag: null,
+                    text: null,
+                    label: null,
+                },
+            ],
+            added: [
+                {
+                    ref: "r/tag:new",
+                    role: null,
+                    testTag: "new",
+                    text: "Hi",
+                    label: null,
+                },
+            ],
+            changed: [
+                {
+                    ref: "r/tag:greeting",
+                    anchor: "tag:greeting",
+                    changes: [{ field: "text", from: "Hello", to: "World" }],
+                },
+            ],
+        };
+
+        const data = computeSemanticsDiffData(delta);
+
+        assert.strictEqual(data.empty, false);
+        assert.strictEqual(data.removedCount, 1);
+        assert.strictEqual(data.addedCount, 1);
+        assert.strictEqual(data.changedCount, 1);
+        assert.deepStrictEqual(
+            data.rows.map((r) => r.kind),
+            ["removed", "added", "changed"],
+        );
+        // Added row's label folds in testTag + text hints.
+        assert.strictEqual(
+            data.rows[1].label,
+            'r/tag:new (testTag=new text="Hi")',
+        );
+        // Changed row carries the field-level delta.
+        assert.deepStrictEqual(data.rows[2].fields, [
+            { field: "text", from: "Hello", to: "World" },
+        ]);
+        assert.strictEqual(data.rows[2].label, "r/tag:greeting (tag:greeting)");
+    });
+
+    it("labels a bare node by its ref alone", () => {
+        const data = computeSemanticsDiffData({
+            schema: "compose-semantics-diff/v1",
+            removed: [
+                {
+                    ref: "r/node",
+                    role: null,
+                    testTag: null,
+                    text: null,
+                    label: null,
+                },
+            ],
+            added: [],
+            changed: [],
+        });
+        assert.strictEqual(data.rows[0].label, "r/node");
+    });
+});

--- a/vscode-extension/src/test/semanticsDiff.test.ts
+++ b/vscode-extension/src/test/semanticsDiff.test.ts
@@ -46,6 +46,14 @@ describe("semanticsDiff", () => {
         assert.ok(semanticsDeltaIsEmpty(delta));
     });
 
+    it("treats a lean-encoded delta with omitted arrays as empty (no throw)", () => {
+        // A daemon `history/diff mode=semantics` result with an empty diff omits the arrays.
+        const lean = {
+            schema: "compose-semantics-diff/v1",
+        } as unknown as Parameters<typeof semanticsDeltaIsEmpty>[0];
+        assert.strictEqual(semanticsDeltaIsEmpty(lean), true);
+    });
+
     it("detects added and removed nodes (matched by ref, not content)", () => {
         const base = {
             root: node({

--- a/vscode-extension/src/test/semanticsDiff.test.ts
+++ b/vscode-extension/src/test/semanticsDiff.test.ts
@@ -1,0 +1,118 @@
+// TS port of the daemon's SemanticsDiff (#1785). Pins the same behaviours the Kotlin
+// `SemanticsDiffTest` / `HistoryDiffTest` semantics cases assert: ref-matched field changes,
+// add/remove, identical → empty, and that a copy edit stays on the same ref (not remove + add).
+
+import * as assert from "assert";
+import {
+    assignSemanticsRefs,
+    diffSemantics,
+    semanticsDeltaIsEmpty,
+    type SemanticsNode,
+} from "../webview/shared/semanticsDiff";
+
+function node(partial: Partial<SemanticsNode>): SemanticsNode {
+    return { ...partial };
+}
+
+describe("semanticsDiff", () => {
+    it("reports a field change on the same ref for a copy edit", () => {
+        const base = { root: node({ testTag: "greeting", text: "Hello" }) };
+        const head = { root: node({ testTag: "greeting", text: "World" }) };
+
+        const delta = diffSemantics(base, head);
+
+        assert.strictEqual(delta.schema, "compose-semantics-diff/v1");
+        assert.strictEqual(delta.added.length, 0, "copy edit must not add");
+        assert.strictEqual(
+            delta.removed.length,
+            0,
+            "copy edit must not remove",
+        );
+        assert.strictEqual(delta.changed.length, 1);
+        const change = delta.changed[0].changes;
+        assert.strictEqual(change.length, 1);
+        assert.deepStrictEqual(change[0], {
+            field: "text",
+            from: "Hello",
+            to: "World",
+        });
+    });
+
+    it("reports identical trees as an empty delta", () => {
+        const tree = () => ({
+            root: node({ testTag: "greeting", text: "Hello" }),
+        });
+        const delta = diffSemantics(tree(), tree());
+        assert.ok(semanticsDeltaIsEmpty(delta));
+    });
+
+    it("detects added and removed nodes (matched by ref, not content)", () => {
+        const base = {
+            root: node({
+                role: "Column",
+                children: [node({ testTag: "a", text: "A" })],
+            }),
+        };
+        const head = {
+            root: node({
+                role: "Column",
+                children: [
+                    node({ testTag: "a", text: "A" }),
+                    node({ testTag: "b", text: "B" }),
+                ],
+            }),
+        };
+
+        const delta = diffSemantics(base, head);
+        assert.strictEqual(delta.removed.length, 0);
+        assert.strictEqual(delta.added.length, 1);
+        assert.strictEqual(delta.added[0].testTag, "b");
+        assert.strictEqual(delta.changed.length, 0);
+
+        // Reverse direction: the b node now reads as removed.
+        const reverse = diffSemantics(head, base);
+        assert.strictEqual(reverse.added.length, 0);
+        assert.strictEqual(reverse.removed.length, 1);
+        assert.strictEqual(reverse.removed[0].testTag, "b");
+    });
+
+    it("keeps refs stable across a content edit (ref ignores text/label)", () => {
+        const before = assignSemanticsRefs(
+            node({ testTag: "greeting", text: "Hello" }),
+        );
+        const after = assignSemanticsRefs(
+            node({ testTag: "greeting", text: "World" }),
+        );
+        assert.strictEqual(before.ref, after.ref);
+    });
+
+    it("disambiguates same-anchor siblings by occurrence index", () => {
+        const root = assignSemanticsRefs(
+            node({
+                role: "Column",
+                children: [node({ role: "Button" }), node({ role: "Button" })],
+            }),
+        );
+        const refs = (root.children ?? []).map((c) => c.ref);
+        assert.deepStrictEqual(refs, ["r/role:Button[0]", "r/role:Button[1]"]);
+    });
+
+    it("treats a changed testTag as a moved ref (remove + add, not a field change)", () => {
+        // testTag is part of the ref, so changing it relocates the node.
+        const base = {
+            root: node({
+                role: "Column",
+                children: [node({ testTag: "old" })],
+            }),
+        };
+        const head = {
+            root: node({
+                role: "Column",
+                children: [node({ testTag: "new" })],
+            }),
+        };
+        const delta = diffSemantics(base, head);
+        assert.strictEqual(delta.added.length, 1);
+        assert.strictEqual(delta.removed.length, 1);
+    });
+});

--- a/vscode-extension/src/webview/preview/historyDiffSemanticsPresenter.ts
+++ b/vscode-extension/src/webview/preview/historyDiffSemanticsPresenter.ts
@@ -1,0 +1,112 @@
+// Presenter for the history panel's semantics data-diff section (#1872). Pure: turns a
+// `SemanticsDelta` (from the client-side `semanticsDiff` port) into display rows the webview renders
+// beneath the pixel diff. No DOM — mirrors the `computeHistoryDiffBundleData` pattern so it's unit-
+// testable without a browser.
+
+import {
+    type SemanticsDelta,
+    type SemanticsNodeChange,
+    type SemanticsNodeSummary,
+} from "../shared/semanticsDiff";
+
+export type SemanticsDiffRowKind = "added" | "removed" | "changed";
+
+export interface SemanticsDiffFieldRow {
+    field: string;
+    from: string | null;
+    to: string | null;
+}
+
+export interface SemanticsDiffRow {
+    kind: SemanticsDiffRowKind;
+    /** Stable node ref the change is keyed on. */
+    ref: string;
+    /** Human-readable label: ref plus testTag/role/text hints. */
+    label: string;
+    /** Field-level changes (only for `kind === "changed"`; empty for added/removed). */
+    fields: SemanticsDiffFieldRow[];
+}
+
+export interface SemanticsDiffData {
+    empty: boolean;
+    addedCount: number;
+    removedCount: number;
+    changedCount: number;
+    /** Removed first, then added, then changed — matches the CLI/daemon human ordering. */
+    rows: SemanticsDiffRow[];
+}
+
+const EMPTY: SemanticsDiffData = {
+    empty: true,
+    addedCount: 0,
+    removedCount: 0,
+    changedCount: 0,
+    rows: [],
+};
+
+/** Derives the display rows for a semantics delta. Null/empty delta → an empty data set. */
+export function computeSemanticsDiffData(
+    delta: SemanticsDelta | null | undefined,
+): SemanticsDiffData {
+    if (!delta) {
+        return EMPTY;
+    }
+    const removed = delta.removed ?? [];
+    const added = delta.added ?? [];
+    const changed = delta.changed ?? [];
+    const rows: SemanticsDiffRow[] = [];
+    for (const node of removed) {
+        rows.push({
+            kind: "removed",
+            ref: node.ref,
+            label: describeSummary(node),
+            fields: [],
+        });
+    }
+    for (const node of added) {
+        rows.push({
+            kind: "added",
+            ref: node.ref,
+            label: describeSummary(node),
+            fields: [],
+        });
+    }
+    for (const change of changed) {
+        rows.push({
+            kind: "changed",
+            ref: change.ref,
+            label: describeChange(change),
+            fields: change.changes.map((c) => ({
+                field: c.field,
+                from: c.from,
+                to: c.to,
+            })),
+        });
+    }
+    return {
+        empty: rows.length === 0,
+        addedCount: added.length,
+        removedCount: removed.length,
+        changedCount: changed.length,
+        rows,
+    };
+}
+
+function describeSummary(node: SemanticsNodeSummary): string {
+    const parts: string[] = [];
+    if (node.testTag) {
+        parts.push(`testTag=${node.testTag}`);
+    }
+    if (node.role) {
+        parts.push(`role=${node.role}`);
+    }
+    const content = node.text ?? node.label;
+    if (content) {
+        parts.push(`text="${content}"`);
+    }
+    return parts.length === 0 ? node.ref : `${node.ref} (${parts.join(" ")})`;
+}
+
+function describeChange(change: SemanticsNodeChange): string {
+    return change.anchor ? `${change.ref} (${change.anchor})` : change.ref;
+}

--- a/vscode-extension/src/webview/shared/semanticsDiff.ts
+++ b/vscode-extension/src/webview/shared/semanticsDiff.ts
@@ -217,9 +217,11 @@ export function diffSemanticsNodes(
 }
 
 export function semanticsDeltaIsEmpty(delta: SemanticsDelta): boolean {
+    // Tolerate a lean-encoded delta (e.g. from the daemon's `history/diff mode=semantics`, whose
+    // encoder omits empty arrays) — absent means empty, not a throw.
     return (
-        delta.added.length === 0 &&
-        delta.removed.length === 0 &&
-        delta.changed.length === 0
+        (delta.added?.length ?? 0) === 0 &&
+        (delta.removed?.length ?? 0) === 0 &&
+        (delta.changed?.length ?? 0) === 0
     );
 }

--- a/vscode-extension/src/webview/shared/semanticsDiff.ts
+++ b/vscode-extension/src/webview/shared/semanticsDiff.ts
@@ -1,0 +1,225 @@
+// TypeScript port of the daemon's `SemanticsDiff` (Kotlin, issue #1785) so the history panel can
+// diff two entries' captured `compose/semantics` trees client-side — no daemon round-trip, mirroring
+// the client-side pixel diff in `pixelDiff.ts`. The algorithm must stay faithful to the Kotlin
+// original (`data/layoutinspector/.../SemanticsDiff.kt` + `SemanticsRefs.kt`) so the panel, the
+// daemon's `history/diff mode=semantics`, the CLI, and the MCP `diff_semantics` tool all agree.
+//
+// Nodes are matched by a stable, content-independent `ref` (a `/`-joined path anchored on
+// testTag → role → "node", disambiguated by sibling occurrence). Text/label are NOT part of the ref,
+// so a copy edit reports as a field change on the same ref rather than a remove + add. Positional
+// bounds and the volatile per-render nodeId are ignored — bounds churn is the pixel diff's job.
+
+export const SEMANTICS_DIFF_SCHEMA = "compose-semantics-diff/v1";
+export const SEMANTICS_ROOT_REF = "r";
+
+/** Subset of `compose/semantics` node fields the differ reads (parsed leniently from the sidecar). */
+export interface SemanticsNode {
+    ref?: string | null;
+    role?: string | null;
+    testTag?: string | null;
+    label?: string | null;
+    text?: string | null;
+    mergeMode?: string | null;
+    clickable?: boolean;
+    editableText?: string | null;
+    inputText?: string | null;
+    layoutTruncated?: boolean | null;
+    layoutOverflow?: string | null;
+    layoutLineCount?: number | null;
+    layoutMaxLines?: number | null;
+    layoutDidOverflowWidth?: boolean | null;
+    layoutDidOverflowHeight?: boolean | null;
+    children?: SemanticsNode[];
+}
+
+export interface SemanticsPayload {
+    root: SemanticsNode;
+}
+
+export interface SemanticsFieldChange {
+    field: string;
+    from: string | null;
+    to: string | null;
+}
+
+export interface SemanticsNodeChange {
+    ref: string;
+    /** testTag/role anchor of the node, for human-readable output. */
+    anchor: string | null;
+    changes: SemanticsFieldChange[];
+}
+
+export interface SemanticsNodeSummary {
+    ref: string;
+    role: string | null;
+    testTag: string | null;
+    text: string | null;
+    label: string | null;
+}
+
+export interface SemanticsDelta {
+    schema: string;
+    added: SemanticsNodeSummary[];
+    removed: SemanticsNodeSummary[];
+    changed: SemanticsNodeChange[];
+}
+
+const GENERIC_ANCHOR = "node";
+// Strip characters that would collide with the ref path grammar (`/`, `[`, `]`, whitespace).
+const SANITIZE = new RegExp("[\\s/\\[\\]]+", "g");
+
+function sanitize(value: string): string {
+    return value.replace(SANITIZE, "_");
+}
+
+/** The anchor token for a node, before sibling disambiguation. */
+export function semanticsAnchor(node: SemanticsNode): string {
+    const tag = node.testTag?.trim();
+    if (tag) {
+        return `tag:${sanitize(tag)}`;
+    }
+    const role = node.role?.trim();
+    if (role) {
+        return `role:${sanitize(role)}`;
+    }
+    return GENERIC_ANCHOR;
+}
+
+function assignNode(node: SemanticsNode, ref: string): SemanticsNode {
+    const children = node.children ?? [];
+    const totals = new Map<string, number>();
+    for (const child of children) {
+        const a = semanticsAnchor(child);
+        totals.set(a, (totals.get(a) ?? 0) + 1);
+    }
+    const seen = new Map<string, number>();
+    const newChildren = children.map((child) => {
+        const a = semanticsAnchor(child);
+        const index = seen.get(a) ?? 0;
+        seen.set(a, index + 1);
+        const segment = (totals.get(a) ?? 0) > 1 ? `${a}[${index}]` : a;
+        return assignNode(child, `${ref}/${segment}`);
+    });
+    return { ...node, ref, children: newChildren };
+}
+
+/** Assigns a stable [SemanticsNode.ref] to every node, rooted at [SEMANTICS_ROOT_REF]. */
+export function assignSemanticsRefs(root: SemanticsNode): SemanticsNode {
+    return assignNode(root, SEMANTICS_ROOT_REF);
+}
+
+type Extractor = (n: SemanticsNode) => string | null;
+
+const asStr = (v: string | null | undefined): string | null =>
+    v == null ? null : v;
+const asBool = (v: boolean | null | undefined): string | null =>
+    v == null ? null : String(v);
+const asNum = (v: number | null | undefined): string | null =>
+    v == null ? null : String(v);
+
+// Semantic fields compared between two nodes sharing a ref, in stable report order. Mirrors the
+// Kotlin COMPARED_FIELDS exactly.
+const COMPARED_FIELDS: Array<[string, Extractor]> = [
+    ["role", (n) => asStr(n.role)],
+    ["testTag", (n) => asStr(n.testTag)],
+    ["label", (n) => asStr(n.label)],
+    ["text", (n) => asStr(n.text)],
+    ["mergeMode", (n) => asStr(n.mergeMode)],
+    ["clickable", (n) => String(n.clickable ?? false)],
+    ["editableText", (n) => asStr(n.editableText)],
+    ["inputText", (n) => asStr(n.inputText)],
+    ["layoutTruncated", (n) => asBool(n.layoutTruncated)],
+    ["layoutOverflow", (n) => asStr(n.layoutOverflow)],
+    ["layoutLineCount", (n) => asNum(n.layoutLineCount)],
+    ["layoutMaxLines", (n) => asNum(n.layoutMaxLines)],
+    ["layoutDidOverflowWidth", (n) => asBool(n.layoutDidOverflowWidth)],
+    ["layoutDidOverflowHeight", (n) => asBool(n.layoutDidOverflowHeight)],
+];
+
+function byRef(root: SemanticsNode): Map<string, SemanticsNode> {
+    const out = new Map<string, SemanticsNode>();
+    const walk = (node: SemanticsNode): void => {
+        if (node.ref) {
+            out.set(node.ref, node);
+        }
+        (node.children ?? []).forEach(walk);
+    };
+    walk(root);
+    return out;
+}
+
+function summary(node: SemanticsNode): SemanticsNodeSummary {
+    return {
+        ref: node.ref ?? SEMANTICS_ROOT_REF,
+        role: asStr(node.role),
+        testTag: asStr(node.testTag),
+        text: asStr(node.text),
+        label: asStr(node.label),
+    };
+}
+
+function nodeChange(
+    ref: string,
+    base: SemanticsNode,
+    head: SemanticsNode,
+): SemanticsNodeChange | null {
+    const changes: SemanticsFieldChange[] = [];
+    for (const [field, extract] of COMPARED_FIELDS) {
+        const from = extract(base);
+        const to = extract(head);
+        if (from !== to) {
+            changes.push({ field, from, to });
+        }
+    }
+    if (changes.length === 0) {
+        return null;
+    }
+    return { ref, anchor: semanticsAnchor(head), changes };
+}
+
+/** Diffs two `compose/semantics` payloads. See module header for the matching contract. */
+export function diffSemantics(
+    base: SemanticsPayload,
+    head: SemanticsPayload,
+): SemanticsDelta {
+    return diffSemanticsNodes(base.root, head.root);
+}
+
+export function diffSemanticsNodes(
+    base: SemanticsNode,
+    head: SemanticsNode,
+): SemanticsDelta {
+    const baseByRef = byRef(assignSemanticsRefs(base));
+    const headByRef = byRef(assignSemanticsRefs(head));
+
+    const removed = [...baseByRef.keys()]
+        .filter((ref) => !headByRef.has(ref))
+        .sort()
+        .map((ref) => summary(baseByRef.get(ref)!));
+    const added = [...headByRef.keys()]
+        .filter((ref) => !baseByRef.has(ref))
+        .sort()
+        .map((ref) => summary(headByRef.get(ref)!));
+    const changed: SemanticsNodeChange[] = [];
+    for (const ref of [...baseByRef.keys()]
+        .filter((ref) => headByRef.has(ref))
+        .sort()) {
+        const change = nodeChange(
+            ref,
+            baseByRef.get(ref)!,
+            headByRef.get(ref)!,
+        );
+        if (change) {
+            changed.push(change);
+        }
+    }
+    return { schema: SEMANTICS_DIFF_SCHEMA, added, removed, changed };
+}
+
+export function semanticsDeltaIsEmpty(delta: SemanticsDelta): boolean {
+    return (
+        delta.added.length === 0 &&
+        delta.removed.length === 0 &&
+        delta.changed.length === 0
+    );
+}


### PR DESCRIPTION
Foundation for the history panel's semantics data-diff (#1872 item 3 / #1785). Per the agreed approach, the differ is **reimplemented in TypeScript** so the panel can diff two entries' captured `compose/semantics` trees client-side (no daemon round-trip), mirroring the client-side pixel diff in `pixelDiff.ts`.

This PR is the **verifiable core** — the differ + a pure presenter, both fully unit-tested. Wiring it into the diff view (a section below the pixel diff, fed by the two entries' sidecar semantics) plus a playwright webview snapshot is the **immediate follow-up**, kept separate so this self-contained, deterministic core lands on its own.

## What changed

- **`webview/shared/semanticsDiff.ts`** — faithful TS port of the daemon's `SemanticsDiff` + `SemanticsRefs` (Kotlin, #1785). Same stable ref scheme (testTag → role → `node` path, sibling-disambiguated by occurrence index), same `COMPARED_FIELDS`, same add/remove/change semantics — so the panel agrees with the daemon, CLI, and MCP. Text/label aren't part of the ref, so a copy edit reports as a field change on the same ref, not remove+add. Ignores unknown JSON fields (e.g. #1901's new token fields).
- **`webview/preview/historyDiffSemanticsPresenter.ts`** — pure `SemanticsDelta → display rows` (removed → added → changed, counts, human labels), following the `computeHistoryDiffBundleData` presenter pattern.

## Test plan

- `semanticsDiff` (6 cases, mirroring the Kotlin `SemanticsDiff` behaviour): copy edit → field change on same ref; add/remove matched by ref not content; identical → empty; ref stable across content edit; sibling occurrence-index disambiguation; `testTag` change → moved ref.
- `computeSemanticsDiffData` (3 cases): null → empty; ordering + counts + labels + field rows; bare-node label.
- All green via mocha; `tsc -p ./` (strict) clean; prettier clean.

## Visual evidence

No rendered surface in this PR — it's the pure differ + presenter (data, not DOM). Text-only is appropriate. The follow-up that adds the actual panel section will carry a playwright webview snapshot (`harness:snapshot`).