### PR TITLE
feat(vscode): show semantics data-diff below the pixel diff in history panel

### DIFF
--- a/vscode-extension/media/preview.css
+++ b/vscode-extension/media/preview.css
@@ -1730,6 +1730,44 @@ preview-app {
     color: var(--vscode-editorWarning-foreground, #cca700);
 }
 
+/* Semantics data-diff section, rendered below the pixel diff (#1872). */
+.diff-semantics {
+    margin-top: 10px;
+    padding-top: 8px;
+    border-top: 1px solid var(--vscode-widget-border, rgba(128, 128, 128, 0.35));
+    font-size: calc(var(--vscode-font-size) - 1px);
+}
+.diff-semantics-header {
+    color: var(--text-secondary);
+    margin-bottom: 4px;
+}
+.diff-semantics-list,
+.diff-semantics-fields {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+.diff-semantics-fields {
+    margin: 2px 0 4px 16px;
+    color: var(--text-secondary);
+    font-variant-numeric: tabular-nums;
+}
+.diff-semantics-row {
+    padding: 1px 0;
+}
+.diff-semantics-label {
+    font-family: var(--vscode-editor-font-family, monospace);
+}
+.diff-semantics-added .diff-semantics-label {
+    color: var(--vscode-charts-green, #89d185);
+}
+.diff-semantics-removed .diff-semantics-label {
+    color: var(--vscode-charts-red, #f14c4c);
+}
+.diff-semantics-changed .diff-semantics-label {
+    color: var(--vscode-charts-yellow, #cca700);
+}
+
 @keyframes fadeIn {
     from {
         opacity: 0;

--- a/vscode-extension/src/historyPanel.ts
+++ b/vscode-extension/src/historyPanel.ts
@@ -236,6 +236,9 @@ export class HistoryPanel implements vscode.WebviewViewProvider {
 
             let right: HistoryReadResult | null = null;
             let rightLabel = "";
+            // Entry id of the comparison side, for sidecar-based semantics lookup. Null for the
+            // synthetic "current render" (no sidecar / no captured semantics).
+            let rightId: string | null = null;
             if (against === "current") {
                 const synthList = currentRendersFor(scope).list(previewId);
                 const synth = synthList.entries[0] as
@@ -280,6 +283,7 @@ export class HistoryPanel implements vscode.WebviewViewProvider {
                     return;
                 }
                 right = await this.source.read(prev.id);
+                rightId = prev.id;
                 rightLabel = `Previous · ${formatLabelTime(prev.timestamp)}`;
             }
             if (!right) {
@@ -305,12 +309,17 @@ export class HistoryPanel implements vscode.WebviewViewProvider {
                 leftImage: leftBytes,
                 rightLabel,
                 rightImage: rightBytes,
-                // Forward each entry's captured compose/semantics tree (from the sidecar) so the
-                // webview can render the semantics data-diff below the pixel diff (#1872).
-                leftSemantics:
-                    (left.entry as { semantics?: unknown }).semantics ?? null,
-                rightSemantics:
-                    (right.entry as { semantics?: unknown }).semantics ?? null,
+                // Forward each entry's captured compose/semantics tree so the webview can render the
+                // semantics data-diff below the pixel diff (#1872). Read straight from the on-disk
+                // sidecar (which always carries the full tree) rather than `left.entry` / `right.entry`
+                // — the daemon's `history/read` strips `semantics` from the wire (only
+                // `history/diff mode=semantics` returns it), so the daemon-backed flow would otherwise
+                // always see null. The sidecar read is daemon-independent and matches the local
+                // archive the daemon writes to.
+                leftSemantics: readSidecarSemantics(scope, id),
+                rightSemantics: rightId
+                    ? readSidecarSemantics(scope, rightId)
+                    : null,
             });
         } catch (err) {
             this.view.webview.postMessage({
@@ -588,6 +597,24 @@ export function buildHistorySource(opts: BuildSourceOptions): HistorySource {
 
 function historyDirFor(scope: HistoryScope): string {
     return `${scope.projectDir}/.compose-preview-history`;
+}
+
+/**
+ * Reads an entry's raw `compose/semantics` tree straight from its on-disk sidecar (#1872). The
+ * sidecar always carries the full tree, unlike the daemon's `history/read` wire shape which strips
+ * it — so this is daemon-independent. Best-effort: returns null for a missing sidecar, unparseable
+ * JSON, or an entry that captured no semantics.
+ */
+function readSidecarSemantics(scope: HistoryScope, id: string): unknown {
+    try {
+        const result = new HistoryReader(historyDirFor(scope)).read(id);
+        return (
+            (result?.entry as { semantics?: unknown } | undefined)?.semantics ??
+            null
+        );
+    } catch {
+        return null;
+    }
 }
 
 function currentRendersFor(scope: HistoryScope): CurrentRendersHistory {

--- a/vscode-extension/src/historyPanel.ts
+++ b/vscode-extension/src/historyPanel.ts
@@ -305,6 +305,12 @@ export class HistoryPanel implements vscode.WebviewViewProvider {
                 leftImage: leftBytes,
                 rightLabel,
                 rightImage: rightBytes,
+                // Forward each entry's captured compose/semantics tree (from the sidecar) so the
+                // webview can render the semantics data-diff below the pixel diff (#1872).
+                leftSemantics:
+                    (left.entry as { semantics?: unknown }).semantics ?? null,
+                rightSemantics:
+                    (right.entry as { semantics?: unknown }).semantics ?? null,
             });
         } catch (err) {
             this.view.webview.postMessage({

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -1289,6 +1289,11 @@ export type HistoryToWebview =
           leftImage: string;
           rightLabel: string;
           rightImage: string;
+          // Raw `compose/semantics` payloads ({ root }) for each entry, when captured. The webview
+          // diffs them client-side to render the semantics data-diff section (#1872). null/omitted
+          // when either render didn't capture semantics.
+          leftSemantics?: unknown;
+          rightSemantics?: unknown;
       }
     | {
           command: "diffPairError";

--- a/vscode-extension/src/webview/history/behavior.ts
+++ b/vscode-extension/src/webview/history/behavior.ts
@@ -307,6 +307,8 @@ export function setupHistoryBehavior(): void {
                         msg.leftImage,
                         msg.rightLabel,
                         msg.rightImage,
+                        msg.leftSemantics,
+                        msg.rightSemantics,
                     );
                 break;
             }

--- a/vscode-extension/src/webview/history/components/HistoryRow.ts
+++ b/vscode-extension/src/webview/history/components/HistoryRow.ts
@@ -152,6 +152,8 @@ export class HistoryRow extends LitElement {
         leftImage: string;
         rightLabel: string;
         rightImage: string;
+        leftSemantics?: unknown;
+        rightSemantics?: unknown;
     } | null = null;
 
     /** Error text for the open diff expansion, populated by the host
@@ -221,6 +223,8 @@ export class HistoryRow extends LitElement {
                     this._diffPayload.rightLabel,
                     this._diffPayload.rightImage,
                     this.diffViewConfig,
+                    this._diffPayload.leftSemantics,
+                    this._diffPayload.rightSemantics,
                 );
             }
         }
@@ -404,11 +408,20 @@ export class HistoryRow extends LitElement {
         leftImage: string,
         rightLabel: string,
         rightImage: string,
+        leftSemantics?: unknown,
+        rightSemantics?: unknown,
     ): void {
         this._expandedKind = "diff";
         this._diffAgainst = against;
         this._diffError = null;
-        this._diffPayload = { leftLabel, leftImage, rightLabel, rightImage };
+        this._diffPayload = {
+            leftLabel,
+            leftImage,
+            rightLabel,
+            rightImage,
+            leftSemantics,
+            rightSemantics,
+        };
     }
 
     /** Host-side hook for `diffPairError`. Renders the error inside

--- a/vscode-extension/src/webview/history/historyDiffView.ts
+++ b/vscode-extension/src/webview/history/historyDiffView.ts
@@ -14,12 +14,14 @@
 // The pixel-diff helper lives in `webview/shared/pixelDiff.ts` — the
 // preview panel's diff overlay reaches for the same algorithm.
 
+import { computeSemanticsDiffData } from "../preview/historyDiffSemanticsPresenter";
 import { buildDiffModeBar, type DiffMode } from "../shared/diffModeBar";
 import {
     applyDiffStats,
     computeDiffStats,
     type DiffStats,
 } from "../shared/pixelDiff";
+import { diffSemantics, type SemanticsPayload } from "../shared/semanticsDiff";
 import type { HistoryDiffSummary } from "../shared/types";
 import type { VsCodeApi } from "../shared/vscode";
 import { cssEscape } from "./historyData";
@@ -61,6 +63,8 @@ export function fillDiff(
     rightLabel: string,
     rightImage: string,
     config: HistoryDiffViewConfig,
+    leftSemantics?: unknown,
+    rightSemantics?: unknown,
 ): void {
     const expansion = config.timelineEl.querySelector<HTMLElement>(
         '.expanded[data-id="' +
@@ -106,6 +110,81 @@ export function fillDiff(
     computeDiffStats(payload.leftImage, payload.rightImage).then((s) => {
         applyDiffStats(stats, s);
     });
+    appendSemanticsDiffSection(expansion, leftSemantics, rightSemantics);
+}
+
+/**
+ * Appends the semantics data-diff (#1872) below the pixel diff. Both entries' captured
+ * `compose/semantics` trees are diffed client-side via the shared [diffSemantics] port; the section
+ * is omitted entirely when either tree is missing (a render that didn't capture semantics) so the
+ * pixel-only case is unchanged. Lives as a sibling of the pixel `body`, so the Side/Overlay/Onion
+ * mode switches (which rewrite `body`) leave it intact.
+ */
+function appendSemanticsDiffSection(
+    expansion: HTMLElement,
+    leftSemantics: unknown,
+    rightSemantics: unknown,
+): void {
+    if (
+        !isSemanticsPayload(leftSemantics) ||
+        !isSemanticsPayload(rightSemantics)
+    ) {
+        return;
+    }
+    let data: ReturnType<typeof computeSemanticsDiffData>;
+    try {
+        data = computeSemanticsDiffData(
+            diffSemantics(leftSemantics, rightSemantics),
+        );
+    } catch {
+        return;
+    }
+    const section = document.createElement("div");
+    section.className = "diff-semantics";
+    const head = document.createElement("div");
+    head.className = "diff-semantics-header";
+    head.textContent = data.empty
+        ? "Semantics · no changes"
+        : `Semantics · ${data.addedCount} added · ${data.removedCount} removed · ${data.changedCount} changed`;
+    section.appendChild(head);
+    if (!data.empty) {
+        const list = document.createElement("ul");
+        list.className = "diff-semantics-list";
+        for (const row of data.rows) {
+            const li = document.createElement("li");
+            li.className = `diff-semantics-row diff-semantics-${row.kind}`;
+            const sigil =
+                row.kind === "added" ? "+" : row.kind === "removed" ? "−" : "~";
+            const label = document.createElement("span");
+            label.className = "diff-semantics-label";
+            label.textContent = `${sigil} ${row.label}`;
+            li.appendChild(label);
+            if (row.fields.length > 0) {
+                const fields = document.createElement("ul");
+                fields.className = "diff-semantics-fields";
+                for (const field of row.fields) {
+                    const fieldLi = document.createElement("li");
+                    fieldLi.textContent = `${field.field}: ${field.from ?? "∅"} → ${field.to ?? "∅"}`;
+                    fields.appendChild(fieldLi);
+                }
+                li.appendChild(fields);
+            }
+            list.appendChild(li);
+        }
+        section.appendChild(list);
+    }
+    expansion.appendChild(section);
+}
+
+/** Narrows an untyped wire value to a `{ root }` semantics payload. */
+function isSemanticsPayload(value: unknown): value is SemanticsPayload {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "root" in value &&
+        typeof (value as { root: unknown }).root === "object" &&
+        (value as { root: unknown }).root !== null
+    );
 }
 
 function renderHistoryDiffMode(


### PR DESCRIPTION
Wires the merged TS semantics differ + presenter (#1902) into the history panel's diff view — the consuming half of #1872 item 3. When two history entries are diffed, the panel now shows a **Semantics** section beneath the pixel diff listing added / removed / changed nodes (with per-node field changes), computed **client-side** via the shared `diffSemantics` port — no daemon round-trip.

Follows the PR-B plan from #1902 (which landed the differ + presenter as the verifiable core).

## What changed

- **Host** (`historyPanel.runPairDiff`): forwards each entry's captured `compose/semantics` tree (already read from the sidecar for the diff) in the `diffReady` message as `leftSemantics` / `rightSemantics`.
- **Webview**: `HistoryRow.setDiff` / `fillDiff` thread the two trees through; `fillDiff` appends a semantics section as a **sibling of the pixel `body`**, so the Side / Overlay / Onion mode switches (which rewrite `body`) leave it intact. The section is **omitted entirely** when either render didn't capture semantics, so the pixel-only path is unchanged.
- Reuses `computeSemanticsDiffData` (#1902) for the rows; small CSS for the added/removed/changed colouring (`--vscode-charts-*`).

## Test plan

- `tsc -p ./` (host) + webview `tsc`/esbuild clean; full mocha unit suite **1552 passing** (includes the #1902 differ/presenter tests that back the data path); prettier clean.

## Visual evidence — and a gap

This is a webview surface, but the **history-panel webview isn't reached by the current `preview-harness` playwright path** (those fixtures drive the *preview* panel's bundles, not the sidebar history timeline). So I can't capture a headless snapshot here. The data correctness is locked by the merged `semanticsDiff` + `computeSemanticsDiffData` unit tests; the rendered section needs a headed VS Code e2e to eyeball.

Per the repo's visual-evidence guidance, I'm flagging this as a gap to close in a **fast-follow**: extend the preview-harness to cover the history-panel webview (a `history-diff` fixture that drives `diffReady` with semantics) so this section gets automatic before/after coverage. Happy to do that next if you'd like it bundled or as its own PR.