### PR TITLE
fix(vscode): correct history semantics-diff direction; add harness fixture

### DIFF
--- a/vscode-extension/preview-harness/fixtures/history-semantics-diff.gen.mjs
+++ b/vscode-extension/preview-harness/fixtures/history-semantics-diff.gen.mjs
@@ -1,0 +1,119 @@
+// Generator for `history-semantics-diff.json`. Run with:
+//   node preview-harness/fixtures/history-semantics-diff.gen.mjs > preview-harness/fixtures/history-semantics-diff.json
+//
+// Drives the **history panel** webview (`history.js` / `<history-app>`, not the preview app) to
+// capture the semantics data-diff section (#1872) that renders below the pixel diff when two history
+// entries are diffed. A `setEntries` populates the timeline; a `diffReady` carrying both entries'
+// `compose/semantics` trees makes `historyDiffView.appendSemanticsDiffSection` paint the
+// `.diff-semantics` block (added / removed / changed nodes).
+//
+// The trees are shaped so the diff exercises all three row kinds:
+//   - changed: the `submit` button's text "Submit" → "Send" (same stable ref)
+//   - added:   a `hero` image present only in this (newer) entry
+//   - removed: a `caption` present only in the previous (older) entry
+
+import { buildMobileMock } from "./_utils.mjs";
+
+const mock = buildMobileMock();
+const previewId = "com.example.OnboardingKt.WelcomeScreenPreview";
+const thisId = "20260430-101200-bbbbbbbb";
+const prevId = "20260430-101000-aaaaaaaa";
+
+function entry(id, timestamp, pngHash, trigger) {
+    return {
+        id,
+        previewId,
+        module: ":sample-android",
+        timestamp,
+        pngHash,
+        pngSize: 4218,
+        pngPath: `${id}.png`,
+        producer: "daemon",
+        trigger,
+        source: { kind: "fs", id: "fs:/workspace/.compose-preview-history" },
+        git: { branch: "feature/onboarding", shortCommit: "a1b2c3d", dirty: false },
+    };
+}
+
+// "Previous" (older) tree — base side of the diff.
+const previousSemantics = {
+    root: {
+        nodeId: "1",
+        boundsInRoot: "0,0,360,600",
+        role: "Column",
+        children: [
+            {
+                nodeId: "2",
+                boundsInRoot: "40,240,160,296",
+                role: "Button",
+                testTag: "submit",
+                text: "Submit",
+            },
+            {
+                nodeId: "3",
+                boundsInRoot: "0,520,360,600",
+                testTag: "caption",
+                text: "By continuing you agree to the terms",
+            },
+        ],
+    },
+};
+
+// "This entry" (newer) tree — head side of the diff.
+const thisSemantics = {
+    root: {
+        nodeId: "1",
+        boundsInRoot: "0,0,360,600",
+        role: "Column",
+        children: [
+            {
+                nodeId: "2",
+                boundsInRoot: "40,240,160,296",
+                role: "Button",
+                testTag: "submit",
+                text: "Send",
+            },
+            {
+                nodeId: "9",
+                boundsInRoot: "0,80,360,200",
+                role: "Image",
+                testTag: "hero",
+            },
+        ],
+    },
+};
+
+const fixture = {
+    name: "history-semantics-diff",
+    description:
+        "History panel webview: two entries diffed, with the semantics data-diff section rendered below the pixel diff. Exercises all three delta kinds — a changed button label, an added image, and a removed caption — matched by stable ref.",
+    app: "history-app",
+    bundle: "../media/webview/history.js",
+    dataset: { earlyFeatures: "true", minimalMode: "false" },
+    messages: [
+        {
+            command: "setEntries",
+            result: {
+                entries: [
+                    entry(thisId, "2026-04-30T10:12:00Z", "b".repeat(64), "fileChanged"),
+                    entry(prevId, "2026-04-30T10:10:00Z", "a".repeat(64), "renderNow"),
+                ],
+            },
+        },
+        {
+            // No host in the harness, so post `diffReady` directly (the same message the host sends
+            // after a "Diff vs previous" click). `setDiff` opens + fills the expansion.
+            command: "diffReady",
+            id: thisId,
+            against: "previous",
+            leftLabel: "This entry · 10:12",
+            leftImage: mock.png,
+            rightLabel: "Previous · 10:10",
+            rightImage: mock.png,
+            leftSemantics: thisSemantics,
+            rightSemantics: previousSemantics,
+        },
+    ],
+};
+
+process.stdout.write(JSON.stringify(fixture, null, 2) + "\n");

--- a/vscode-extension/preview-harness/fixtures/history-semantics-diff.json
+++ b/vscode-extension/preview-harness/fixtures/history-semantics-diff.json
@@ -1,0 +1,112 @@
+{
+  "name": "history-semantics-diff",
+  "description": "History panel webview: two entries diffed, with the semantics data-diff section rendered below the pixel diff. Exercises all three delta kinds — a changed button label, an added image, and a removed caption — matched by stable ref.",
+  "app": "history-app",
+  "bundle": "../media/webview/history.js",
+  "dataset": {
+    "earlyFeatures": "true",
+    "minimalMode": "false"
+  },
+  "messages": [
+    {
+      "command": "setEntries",
+      "result": {
+        "entries": [
+          {
+            "id": "20260430-101200-bbbbbbbb",
+            "previewId": "com.example.OnboardingKt.WelcomeScreenPreview",
+            "module": ":sample-android",
+            "timestamp": "2026-04-30T10:12:00Z",
+            "pngHash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            "pngSize": 4218,
+            "pngPath": "20260430-101200-bbbbbbbb.png",
+            "producer": "daemon",
+            "trigger": "fileChanged",
+            "source": {
+              "kind": "fs",
+              "id": "fs:/workspace/.compose-preview-history"
+            },
+            "git": {
+              "branch": "feature/onboarding",
+              "shortCommit": "a1b2c3d",
+              "dirty": false
+            }
+          },
+          {
+            "id": "20260430-101000-aaaaaaaa",
+            "previewId": "com.example.OnboardingKt.WelcomeScreenPreview",
+            "module": ":sample-android",
+            "timestamp": "2026-04-30T10:10:00Z",
+            "pngHash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "pngSize": 4218,
+            "pngPath": "20260430-101000-aaaaaaaa.png",
+            "producer": "daemon",
+            "trigger": "renderNow",
+            "source": {
+              "kind": "fs",
+              "id": "fs:/workspace/.compose-preview-history"
+            },
+            "git": {
+              "branch": "feature/onboarding",
+              "shortCommit": "a1b2c3d",
+              "dirty": false
+            }
+          }
+        ]
+      }
+    },
+    {
+      "command": "diffReady",
+      "id": "20260430-101200-bbbbbbbb",
+      "against": "previous",
+      "leftLabel": "This entry · 10:12",
+      "leftImage": "iVBORw0KGgoAAAANSUhEUgAAAWgAAAJYCAIAAADAFeuyAAAH9UlEQVR4nO3UQQ2DUBRFwa+gilDSbW1VAFIQURuwYIWGs+GHdG5GwEtecsbyXgGSMf0C4HGEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8jGfpwAiXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAA2bRwvD5fbjDrvz+7ZcKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5QkHwmF5woFwWJ5wIByWJxwIh+UJB8JhecKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5QkHwmF5woFwWJ5wIByWJxwIh+UJB8JhecKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5QkHwmF5woFwWJ5wIByWJxwIh+UJB8JhecKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5QkHwmF5woFwWJ5wIByWJxwIh+UJB8JhecKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5f1dOIDnEg4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gG5uZWZxwmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFneBUZcMccpTkvCAAAAAElFTkSuQmCC",
+      "rightLabel": "Previous · 10:10",
+      "rightImage": "iVBORw0KGgoAAAANSUhEUgAAAWgAAAJYCAIAAADAFeuyAAAH9UlEQVR4nO3UQQ2DUBRFwa+gilDSbW1VAFIQURuwYIWGs+GHdG5GwEtecsbyXgGSMf0C4HGEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8jGfpwAiXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAA2bRwvD5fbjDrvz+7ZcKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5QkHwmF5woFwWJ5wIByWJxwIh+UJB8JhecKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5QkHwmF5woFwWJ5wIByWJxwIh+UJB8JhecKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5QkHwmF5woFwWJ5wIByWJxwIh+UJB8JhecKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5QkHwmF5woFwWJ5wIByWJxwIh+UJB8JhecKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5f1dOIDnEg4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gG5uZWZxwmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFneBUZcMccpTkvCAAAAAElFTkSuQmCC",
+      "leftSemantics": {
+        "root": {
+          "nodeId": "1",
+          "boundsInRoot": "0,0,360,600",
+          "role": "Column",
+          "children": [
+            {
+              "nodeId": "2",
+              "boundsInRoot": "40,240,160,296",
+              "role": "Button",
+              "testTag": "submit",
+              "text": "Send"
+            },
+            {
+              "nodeId": "9",
+              "boundsInRoot": "0,80,360,200",
+              "role": "Image",
+              "testTag": "hero"
+            }
+          ]
+        }
+      },
+      "rightSemantics": {
+        "root": {
+          "nodeId": "1",
+          "boundsInRoot": "0,0,360,600",
+          "role": "Column",
+          "children": [
+            {
+              "nodeId": "2",
+              "boundsInRoot": "40,240,160,296",
+              "role": "Button",
+              "testTag": "submit",
+              "text": "Submit"
+            },
+            {
+              "nodeId": "3",
+              "boundsInRoot": "0,520,360,600",
+              "testTag": "caption",
+              "text": "By continuing you agree to the terms"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/vscode-extension/src/webview/history/historyDiffView.ts
+++ b/vscode-extension/src/webview/history/historyDiffView.ts
@@ -133,8 +133,11 @@ function appendSemanticsDiffSection(
     }
     let data: ReturnType<typeof computeSemanticsDiffData>;
     try {
+        // Direction: base = the older "Previous" entry (right), head = "This entry" (left), so
+        // `added` reads as nodes newly present in this entry and `removed` as nodes gone from it —
+        // matching how the user reads "what changed in this entry vs the previous".
         data = computeSemanticsDiffData(
-            diffSemantics(leftSemantics, rightSemantics),
+            diffSemantics(rightSemantics, leftSemantics),
         );
     } catch {
         return;


### PR DESCRIPTION
Closes the visual-coverage gap flagged on #1904 — and, while building the fixture, surfaced a direction bug in that merged code.

## 1. Direction fix

`appendSemanticsDiffSection` (from #1904) called `diffSemantics(leftSemantics, rightSemantics)` — i.e. `base = "This entry"` (newer), `head = "Previous"` (older). That **inverts** added/removed: a node newly added in *this* entry rendered as "removed". Swapped to `diffSemantics(rightSemantics, leftSemantics)` so `base = previous (older)`, `head = this (newer)` — `added` = newly present in this entry, `removed` = gone from it, matching how you read "what changed in this entry vs the previous".

## 2. Preview-harness fixture for the history-panel webview

The history-panel webview wasn't reached by the preview-harness (it only drove the *preview* app). The harness is bundle-agnostic, so this adds `history-semantics-diff.{gen.mjs,json}` that targets `history.js` / `<history-app>` and drives it with `setEntries` + a `diffReady` carrying both entries' `compose/semantics` trees — so the CI visual-diff bot renders + diffs the `.diff-semantics` section on every PR. No harness code changes needed. The trees exercise all three kinds: **changed** (button `Submit→Send`), **added** (hero image), **removed** (caption).

## Test plan

- tsc (host + webview) clean, `history.js` rebuilt; semantics unit suite green (38); prettier clean.
- **Data path validated in Node** against the compiled differ with the *corrected* direction → `added = hero`, `removed = caption`, `changed = submit (Submit→Send)` — confirms the fixture exercises the section and the direction fix is right.

## On the rendered baseline

The PNG snapshot is captured by **CI**, not here: chromium can't be installed in this environment (the egress policy blocks the playwright browser download — `cdn.playwright.dev` 403). So I verified the message contract + data path locally; the visual-diff bot will post the actual rendered `.diff-semantics` capture on this PR. If it comes back blank/wrong I'll fix the fixture (I'm watching).