### PR TITLE
feat(daemon): per-call ref param for history list/read/diff

### DIFF
--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -1398,6 +1398,7 @@ class JsonRpcServer(
         agentId = params.agentId,
         sourceKind = params.sourceKind,
         sourceId = params.sourceId,
+        ref = params.ref,
       )
     val page =
       try {
@@ -1442,7 +1443,7 @@ class JsonRpcServer(
     }
     val read =
       try {
-        mgr.read(params.id, includeBytes = params.inline)
+        mgr.read(params.id, includeBytes = params.inline, ref = params.ref)
       } catch (t: Throwable) {
         sendErrorResponse(
           id = req.id,
@@ -1521,7 +1522,7 @@ class JsonRpcServer(
     val includeBytes = params.mode == HistoryDiffMode.PIXEL
     val from =
       try {
-        mgr.read(params.from, includeBytes = includeBytes)
+        mgr.read(params.from, includeBytes = includeBytes, ref = params.ref)
       } catch (t: Throwable) {
         sendErrorResponse(
           id = req.id,
@@ -1540,7 +1541,7 @@ class JsonRpcServer(
     }
     val to =
       try {
-        mgr.read(params.to, includeBytes = includeBytes)
+        mgr.read(params.to, includeBytes = includeBytes, ref = params.ref)
       } catch (t: Throwable) {
         sendErrorResponse(
           id = req.id,

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryManager.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryManager.kt
@@ -47,6 +47,15 @@ class HistoryManager(
    * manual `history/prune` RPC calls override individual fields per-call.
    */
   pruneConfig: HistoryPruneConfig = HistoryPruneConfig(),
+  /**
+   * H10-read — builds a read-only [HistorySource] for an arbitrary git ref on demand, so a
+   * `history/list` / `read` / `diff` carrying a [HistoryFilter.ref] can serve from a reporting
+   * branch that wasn't wired at daemon startup. Given a full ref name, returns the source (a fresh
+   * [GitRefHistorySource]); null when on-demand ref reads aren't available (no repo root — e.g.
+   * fake-mode/test managers), in which case a `ref` request yields empty / not-found rather than
+   * falling back to the configured sources.
+   */
+  private val gitRefSourceFactory: ((String) -> HistorySource?)? = null,
 ) {
   private val pruneConfigRef: AtomicReference<HistoryPruneConfig> = AtomicReference(pruneConfig)
 
@@ -210,6 +219,14 @@ class HistoryManager(
    * surfaces its `source.kind = "git"` entry.
    */
   fun list(filter: HistoryFilter): HistoryListPage {
+    // H10-read — a `ref` request is served from a single on-demand git-ref source, bypassing the
+    // configured sources entirely (the caller wants *that* branch's history, not a merge).
+    filter.ref?.let { ref ->
+      val source =
+        gitRefSourceFactory?.invoke(ref)
+          ?: return HistoryListPage(entries = emptyList(), totalCount = 0)
+      return source.list(filter)
+    }
     if (sources.isEmpty()) return HistoryListPage(entries = emptyList(), totalCount = 0)
     if (sources.size == 1) return sources.single().list(filter)
 
@@ -249,8 +266,16 @@ class HistoryManager(
     )
   }
 
-  /** Reads one entry. Falls through sources in order until a hit. */
-  fun read(entryId: String, includeBytes: Boolean): HistoryReadResult? {
+  /**
+   * Reads one entry. When [ref] is set, reads from a single on-demand [GitRefHistorySource] for
+   * that branch (matching the routing in [list]); otherwise falls through the configured sources in
+   * order until a hit.
+   */
+  fun read(entryId: String, includeBytes: Boolean, ref: String? = null): HistoryReadResult? {
+    if (ref != null) {
+      val source = gitRefSourceFactory?.invoke(ref) ?: return null
+      return source.read(entryId, includeBytes = includeBytes)
+    }
     for (source in sources) {
       val result = source.read(entryId, includeBytes = includeBytes)
       if (result != null) return result
@@ -484,11 +509,29 @@ class HistoryManager(
           }
         }
       }
+      // H10-read — on-demand ref reads reuse the same construction as the startup-wired refs, so a
+      // `history/list?ref=…` for any branch behaves identically to a configured one. Available only
+      // when a repo root is known.
+      val gitRefSourceFactory: ((String) -> HistorySource?)? =
+        if (repoRoot != null) {
+          { ref ->
+            GitRefHistorySource(
+              repoRoot = repoRoot,
+              ref = ref,
+              syncMode = gitRefSyncMode,
+              cacheDir =
+                historyDir?.let(GitRefHistorySource::defaultCacheDir)
+                  ?: repoRoot.resolve(".compose-preview-history").resolve(".git-ref-cache"),
+              warnEmitter = warnEmitter,
+            )
+          }
+        } else null
       return HistoryManager(
         sources = sources,
         module = module,
         gitProvenance = gitProvenance,
         pruneConfig = pruneConfig,
+        gitRefSourceFactory = gitRefSourceFactory,
       )
     }
   }

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistorySource.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistorySource.kt
@@ -29,6 +29,14 @@ data class HistoryFilter(
   val agentId: String? = null,
   val sourceKind: String? = null,
   val sourceId: String? = null,
+  /**
+   * H10-read — when set, the listing is served from a single on-demand [GitRefHistorySource] for
+   * this full ref name (e.g. `refs/heads/preview/main`) instead of the manager's configured
+   * sources. Lets a client view *any* reporting branch without that ref being wired at daemon
+   * startup. Routing only — not an entry field, so [HistoryFilters.matches] ignores it; the other
+   * filter dimensions still apply within the ref's entries.
+   */
+  val ref: String? = null,
 )
 
 /**

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -1541,11 +1541,7 @@ data class HistoryListResult(
 // `ref` (H10-read) — read this id from an on-demand git reporting branch instead of the configured
 // sources; must match the `ref` the id was listed from.
 @Serializable
-data class HistoryReadParams(
-  val id: String,
-  val inline: Boolean = false,
-  val ref: String? = null,
-)
+data class HistoryReadParams(val id: String, val inline: Boolean = false, val ref: String? = null)
 
 @Serializable
 data class HistoryReadResultDto(

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -1526,6 +1526,9 @@ data class HistoryListParams(
   val agentId: String? = null,
   val sourceKind: String? = null,
   val sourceId: String? = null,
+  // H10-read — serve this listing from an on-demand git reporting branch (full ref name, e.g.
+  // `refs/heads/preview/main`) instead of the daemon's configured sources. See HISTORY.md.
+  val ref: String? = null,
 )
 
 @Serializable
@@ -1535,7 +1538,14 @@ data class HistoryListResult(
   val totalCount: Int,
 )
 
-@Serializable data class HistoryReadParams(val id: String, val inline: Boolean = false)
+// `ref` (H10-read) — read this id from an on-demand git reporting branch instead of the configured
+// sources; must match the `ref` the id was listed from.
+@Serializable
+data class HistoryReadParams(
+  val id: String,
+  val inline: Boolean = false,
+  val ref: String? = null,
+)
 
 @Serializable
 data class HistoryReadResultDto(
@@ -1750,6 +1760,9 @@ data class HistoryDiffParams(
   val from: String,
   val to: String,
   val mode: HistoryDiffMode = HistoryDiffMode.METADATA,
+  // H10-read — resolve both `from` and `to` from this on-demand git reporting branch instead of the
+  // configured sources. One ref per diff request (both sides share it).
+  val ref: String? = null,
 )
 
 @Serializable

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/GitRefHistorySourceTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/GitRefHistorySourceTest.kt
@@ -290,6 +290,69 @@ class GitRefHistorySourceTest {
   }
 
   // -------------------------------------------------------------------------
+  // H10-read — on-demand ref serving through HistoryManager (issue #1872)
+  // -------------------------------------------------------------------------
+
+  @Test
+  fun on_demand_ref_serves_unconfigured_branch_through_manager() {
+    // Populate the reporting branch via the WRITE_LOCAL writer (dogfood), with two previews.
+    val writer = source(SyncModeOf.WRITE_LOCAL)
+    val bytesA = "render-A".toByteArray()
+    val bytesB = "render-B".toByteArray()
+    val entryA = entry(id = "20260430-101200-aaaaaaaa", previewId = "com.example.A", bytes = bytesA)
+    val entryB = entry(id = "20260430-101300-bbbbbbbb", previewId = "com.example.B", bytes = bytesB)
+    assertEquals(WriteResult.WRITTEN, writer.write(entryA, bytesA))
+    assertEquals(WriteResult.WRITTEN, writer.write(entryB, bytesB))
+
+    val localDir = Files.createTempDirectory("on-demand-localfs")
+    try {
+      // The branch is deliberately NOT in `gitRefs` — it's only reachable on demand via `ref`.
+      val manager =
+        HistoryManager.forLocalFsAndGitRefs(
+          historyDir = localDir,
+          module = ":t",
+          gitProvenance = null,
+          gitRefs = emptyList(),
+          repoRoot = repoRoot,
+          warnEmitter = warnEmitter,
+        )
+
+      // Without `ref`, only the (empty) configured local source is consulted — the branch is unseen.
+      assertEquals(0, manager.list(HistoryFilter()).totalCount)
+      assertNull(manager.read(entryA.id, includeBytes = false))
+
+      // With `ref`, the listing is served on-demand from that branch, stamped as a git source.
+      val page = manager.list(HistoryFilter(ref = ref))
+      assertEquals(2, page.totalCount)
+      assertTrue(page.entries.all { it.source.kind == "git" })
+      assertEquals(setOf(entryA.id, entryB.id), page.entries.map { it.id }.toSet())
+
+      // Other filter dimensions still apply within the ref's entries.
+      val narrowed = manager.list(HistoryFilter(ref = ref, previewId = "com.example.A"))
+      assertEquals(1, narrowed.totalCount)
+      assertEquals("com.example.A", narrowed.entries.single().previewId)
+
+      // A ref-scoped read resolves the bytes; the same id without a ref stays invisible.
+      val read = manager.read(entryA.id, includeBytes = true, ref = ref)
+      assertNotNull(read)
+      assertEquals("render-A", String(read!!.pngBytes!!))
+      assertEquals("git", read.entry.source.kind)
+      assertNull(manager.read(entryA.id, includeBytes = false))
+    } finally {
+      localDir.toFile().deleteRecursively()
+    }
+  }
+
+  @Test
+  fun on_demand_ref_without_factory_yields_empty() {
+    // A manager with no git-ref factory (no repo root — fake-mode/test paths) must tolerate a `ref`
+    // request: it returns empty / null rather than throwing or falling back to configured sources.
+    val manager = HistoryManager(sources = emptyList(), module = ":t", gitProvenance = null)
+    assertEquals(0, manager.list(HistoryFilter(ref = ref)).totalCount)
+    assertNull(manager.read("any-id", includeBytes = false, ref = ref))
+  }
+
+  // -------------------------------------------------------------------------
   // Helpers
   // -------------------------------------------------------------------------
 

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/GitRefHistorySourceTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/GitRefHistorySourceTest.kt
@@ -317,7 +317,8 @@ class GitRefHistorySourceTest {
           warnEmitter = warnEmitter,
         )
 
-      // Without `ref`, only the (empty) configured local source is consulted — the branch is unseen.
+      // Without `ref`, only the (empty) configured local source is consulted — the branch is
+      // unseen.
       assertEquals(0, manager.list(HistoryFilter()).totalCount)
       assertNull(manager.read(entryA.id, includeBytes = false))
 

--- a/docs/daemon/HISTORY.md
+++ b/docs/daemon/HISTORY.md
@@ -156,20 +156,28 @@ result: { entries: HistoryEntry[]; nextCursor?: string; totalCount: number }
 Filters `branch`, `branchPattern`, `commit`, `worktreePath`, `agentId`,
 `sourceKind`, `sourceId` are also accepted. Newest first.
 
+`ref?` (H10-read) serves the listing from an on-demand `GitRefHistorySource`
+for that full ref name (e.g. `refs/heads/preview/main`) **instead of** the
+daemon's configured sources, so a client can view any reporting branch without
+it being wired at daemon startup (`composeai.daemon.gitRefHistory`). The other
+filter dimensions still apply within that ref's entries. Available only when the
+daemon knows a repo root; otherwise a `ref` request returns empty.
+
 ### `history/read`
 
 ```ts
-params: { id: string; inline?: boolean }
+params: { id: string; inline?: boolean; ref? }
 result: { entry: HistoryEntry; previewMetadata: PreviewInfoDto; pngPath: string; pngBytes?: string }
 ```
 
 Local clients use `pngPath`; remote clients pass `inline: true` for
-base64 bytes.
+base64 bytes. `ref?` reads the id from that on-demand reporting branch (must
+match the `ref` it was listed from), mirroring `history/list`.
 
 ### `history/diff` (§ H3)
 
 ```ts
-params: { from: string; to: string; mode?: "metadata" | "pixel" | "semantics" }
+params: { from: string; to: string; mode?: "metadata" | "pixel" | "semantics"; ref? }
 result: {
   pngHashChanged: boolean;
   diffPx?: number; ssim?: number; diffPngPath?: string;  // pixel mode only
@@ -196,6 +204,10 @@ snapshotted into its sidecar at record time (see `HistoryEntry.semantics`
 below), so the diff is deterministic and reads no PNGs. The same differ
 (`SemanticsDiff`) backs `compose-preview diff-semantics` and the MCP
 `diff_semantics` tool, so all three surfaces agree.
+
+`ref?` (H10-read) resolves both `from` and `to` from that on-demand reporting
+branch instead of the configured sources — one ref per diff request (both sides
+share it), mirroring `history/list`.
 
 Mismatched previews → `HistoryDiffMismatch (-32011)`. Missing entry →
 `HistoryEntryNotFound (-32010)`. (`-32012` `ERR_HISTORY_PIXEL_NOT_IMPLEMENTED`

--- a/vscode-extension/src/daemon/daemonProtocol.ts
+++ b/vscode-extension/src/daemon/daemonProtocol.ts
@@ -901,6 +901,11 @@ export interface HistoryListParams {
     agentId?: string;
     sourceKind?: HistorySourceKind;
     sourceId?: string;
+    /** H10-read — serve this listing from an on-demand git reporting branch
+     *  (full ref name, e.g. `refs/heads/preview/main`) instead of the daemon's
+     *  configured sources. Lets the panel view any reporting branch without it
+     *  being wired at daemon startup. */
+    ref?: string;
 }
 
 export interface HistoryListResult {
@@ -917,6 +922,9 @@ export interface HistoryReadParams {
      *  false, the client reads `pngPath` from disk — preferred for local
      *  same-host clients (VS Code) to avoid the wire round-trip. */
     inline?: boolean;
+    /** H10-read — read this id from an on-demand git reporting branch instead
+     *  of the configured sources; must match the `ref` it was listed from. */
+    ref?: string;
 }
 
 export interface HistoryReadResult {
@@ -937,6 +945,9 @@ export interface HistoryDiffParams {
     from: string;
     to: string;
     mode?: HistoryDiffMode; // default 'metadata'
+    /** H10-read — resolve both `from` and `to` from this on-demand git
+     *  reporting branch instead of the configured sources. One ref per diff. */
+    ref?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

Backend groundwork for viewing a **git reporting branch** in the render-history panel (#1872 item 2). Adds an optional `ref` to the `history/list`, `history/read`, and `history/diff` JSON-RPC params so a client can read history from an arbitrary reporting branch (e.g. `refs/heads/preview/main`) **on demand**, without that ref being wired at daemon startup (`composeai.daemon.gitRefHistory`).

When `ref` is set, `HistoryManager` serves the request from a single on-demand `GitRefHistorySource` — built by the same factory used for the startup-configured refs — and bypasses the configured sources (the caller wants *that* branch's history, not a merge). Other filter dimensions (`previewId`, `since`, pagination, …) still apply within the ref's entries. Available only when the daemon knows a repo root; otherwise a `ref` request returns empty rather than falling back.

This is the first of two slices (architecture chosen: route through the daemon rather than a TS-side git reader). The VS Code quick-pick UI that drives it (`git branch -l 'preview/*'`) follows in a fast-follow PR.

### Changes
- `Messages.kt` — `ref?: String? = null` on `HistoryListParams` / `HistoryReadParams` / `HistoryDiffParams`.
- `HistorySource.kt` — `ref?` on `HistoryFilter` (routing hint; `HistoryFilters.matches` ignores it).
- `HistoryManager.kt` — optional `gitRefSourceFactory`; `list` routes on `filter.ref`, `read` gains an optional `ref`; `forLocalFsAndGitRefs` wires the factory (reusing the startup ref construction: repoRoot, syncMode, cacheDir, warnEmitter).
- `JsonRpcServer.kt` — threads `params.ref` into the list filter and both diff `read` calls.
- `daemonProtocol.ts` — `ref?` on the three TS param interfaces (no consumer yet; PR 2 uses them).
- `docs/daemon/HISTORY.md` — documents `ref?` on all three methods.

## Test plan
- `daemon:core` unit tests, including two new cases in `GitRefHistorySourceTest`:
  - `on_demand_ref_serves_unconfigured_branch_through_manager` — writes two previews to a branch via the WRITE_LOCAL writer, builds a manager with that ref **not** configured, and asserts: no-`ref` list is empty; `ref` list returns both entries stamped `source.kind = "git"`; in-ref `previewId` filter narrows; ref-scoped `read` returns the bytes; the same id without `ref` stays invisible.
  - `on_demand_ref_without_factory_yields_empty` — a manager with no repo root tolerates a `ref` request (empty / null, no throw).
- Full `history.*` + `*JsonRpcServerHistory*` suites pass (no regression).
- `tsc --noEmit` clean for the extension.

Backend only — no visual surface changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CPjwnCtY5aiBTFkVrrFjhS)_