### PR TITLE
feat(daemon): extend compose/semantics token capture (gap, border, non-dp radii)

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsExtension.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsExtension.kt
@@ -26,10 +26,12 @@ class ComposeSemanticsExtension : PostCaptureProcessor {
     val rootDir = context.require(RenderDataArtifactContextKeys.RootDir)
     val outputBaseName = context.require(RenderDataArtifactContextKeys.OutputBaseName)
     val semanticsRoot = context.require(RenderDataArtifactContextKeys.SemanticsRoot)
+    val density = context.get(RenderDataArtifactContextKeys.Density) ?: 1f
     ComposeSemanticsDataProducer.writeArtifacts(
       rootDir = rootDir,
       previewId = outputBaseName,
       root = semanticsRoot,
+      density = density,
     )
   }
 

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderDataArtifactExtensions.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderDataArtifactExtensions.kt
@@ -72,6 +72,14 @@ object RenderDataArtifactContextKeys {
     )
 
   /**
+   * Render density (`spec.density`, dp = px / density). Threaded so producers that resolve a
+   * percent-based corner radius (`CircleShape`) against a node's measured px size can express it in
+   * dp (issue #1908); other token fields carry dp directly and don't need it.
+   */
+  val Density: ExtensionContextKey<Float> =
+    ExtensionContextKey(name = "render-data-artifact.density", type = Float::class.javaObjectType)
+
+  /**
    * The held [`androidx.activity.ComponentActivity`] the rule launched for this render. Threaded
    * to extensions that read activity-scoped state — `getIntent()` (deep-link routing audits),
    * `onBackPressedDispatcher.hasEnabledCallbacks()` (registered back callbacks). Robolectric's

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -539,6 +539,7 @@ class RenderEngine(
                 resolvedSemanticsRoot?.let {
                   add(RenderDataArtifactContextKeys.SemanticsRoot provides it)
                 }
+                add(RenderDataArtifactContextKeys.Density provides spec.density)
                 add(RenderDataArtifactContextKeys.HeldActivity provides rule.activity)
                 layoutInspectorPreviewContext?.let {
                   add(RenderDataArtifactContextKeys.LayoutInspectorPreviewContext provides it)

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -479,7 +479,10 @@ class RenderEngine(
       if (root != null) {
         trace.section("wireframe") {
           val previewId = state.spec.previewId ?: state.spec.outputBaseName
-          val payload = ComposeSemanticsDataProducer.buildPayload(root)
+          // Pass the render density so percent-based corner radii (`CircleShape`) resolve to dp
+          // instead of dropping out (#1908). dp-valued tokens (padding/gap/colours) don't use it.
+          val density = state.spec.density
+          val payload = ComposeSemanticsDataProducer.buildPayload(root, density)
           // `compose-semantics.json` — the plain `compose/semantics` data product the Android
           // ComposeSemanticsExtension writes per render. The desktop backend previously fed this
           // tree only into the wireframe / spatial / a11y views and never wrote the sidecar, so
@@ -489,6 +492,7 @@ class RenderEngine(
             rootDir = dataDir,
             previewId = previewId,
             root = root,
+            density = density,
           )
           ComposeSemanticsWireframeDataProducer.writeSvg(
             rootDir = dataDir,

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopSemanticsTokensTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopSemanticsTokensTest.kt
@@ -38,7 +38,10 @@ import org.junit.Test
  */
 class DesktopSemanticsTokensTest {
 
-  private fun buildTree(density: Float = 1.0f, content: @Composable () -> Unit): ComposeSemanticsNode {
+  private fun buildTree(
+    density: Float = 1.0f,
+    content: @Composable () -> Unit,
+  ): ComposeSemanticsNode {
     val scene =
       ImageComposeScene(width = 400, height = 400, density = Density(density), content = content)
     try {
@@ -145,7 +148,12 @@ class DesktopSemanticsTokensTest {
 
   @Test
   fun layout_without_arrangement_spacing_omits_gap() {
-    val root = buildTree { Column(Modifier.testTag("col")) { Text("a"); Text("b") } }
+    val root = buildTree {
+      Column(Modifier.testTag("col")) {
+        Text("a")
+        Text("b")
+      }
+    }
 
     assertNull("a layout with no arrangement spacing must omit gap", root.find("col")?.tokens?.gap)
   }
@@ -170,9 +178,7 @@ class DesktopSemanticsTokensTest {
     // The percent → dp resolution must divide out the render density: a 36dp circle at density 2.5
     // measures 90px, whose 50% corner (45px) is still 18dp.
     val root =
-      buildTree(density = 2.5f) {
-        Box(Modifier.testTag("avatar").size(36.dp).clip(CircleShape))
-      }
+      buildTree(density = 2.5f) { Box(Modifier.testTag("avatar").size(36.dp).clip(CircleShape)) }
 
     assertEquals("18.0dp", root.find("avatar")?.tokens?.cornerRadius)
   }

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopSemanticsTokensTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopSemanticsTokensTest.kt
@@ -2,14 +2,22 @@
 
 package ee.schimke.composeai.daemon
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.ImageComposeScene
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.SemanticsNode
@@ -30,13 +38,13 @@ import org.junit.Test
  */
 class DesktopSemanticsTokensTest {
 
-  private fun buildTree(content: @Composable () -> Unit): ComposeSemanticsNode {
+  private fun buildTree(density: Float = 1.0f, content: @Composable () -> Unit): ComposeSemanticsNode {
     val scene =
-      ImageComposeScene(width = 400, height = 400, density = Density(1.0f), content = content)
+      ImageComposeScene(width = 400, height = 400, density = Density(density), content = content)
     try {
       scene.render()
       val root: SemanticsNode = scene.semanticsOwners.first().unmergedRootSemanticsNode
-      return ComposeSemanticsDataProducer.buildPayload(root).root
+      return ComposeSemanticsDataProducer.buildPayload(root, density).root
     } finally {
       scene.close()
     }
@@ -107,5 +115,82 @@ class DesktopSemanticsTokensTest {
     val label = root.find("label")
     assertNotNull(label)
     assertNull("a node with no background / shape / padding must omit tokens", label!!.tokens)
+  }
+
+  @Test
+  fun resolves_row_arrangement_spacing_as_gap() {
+    // #1908 ask 1: `Arrangement.spacedBy` is a measure-policy property, not a `Modifier.padding`;
+    // it must surface as `gap` so spacing tokens (`cardGap` / `rowGap`) evaluate.
+    val root = buildTree {
+      Row(Modifier.testTag("row"), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        Text("a")
+        Text("b")
+      }
+    }
+
+    assertEquals("8.0dp", root.find("row")?.tokens?.gap)
+  }
+
+  @Test
+  fun resolves_column_arrangement_spacing_as_gap() {
+    val root = buildTree {
+      Column(Modifier.testTag("col"), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        Text("a")
+        Text("b")
+      }
+    }
+
+    assertEquals("12.0dp", root.find("col")?.tokens?.gap)
+  }
+
+  @Test
+  fun layout_without_arrangement_spacing_omits_gap() {
+    val root = buildTree { Column(Modifier.testTag("col")) { Text("a"); Text("b") } }
+
+    assertNull("a layout with no arrangement spacing must omit gap", root.find("col")?.tokens?.gap)
+  }
+
+  @Test
+  fun resolves_circle_shape_descriptor_and_effective_radius() {
+    // #1908 ask 3: `CircleShape` is a percent (`CornerSize(50%)`) shape — no dp corner — so the
+    // radius was silently dropped. It now emits a `"circle"` descriptor and the effective dp radius
+    // resolved against the node's measured size (36dp square → 18dp).
+    val root = buildTree {
+      Box(Modifier.testTag("avatar").size(36.dp).clip(CircleShape).background(Color(0xFF006A60)))
+    }
+
+    val tokens = root.find("avatar")?.tokens
+    assertNotNull("avatar must carry resolved tokens", tokens)
+    assertEquals("circle", tokens!!.shape)
+    assertEquals("18.0dp", tokens.cornerRadius)
+  }
+
+  @Test
+  fun resolves_circle_radius_against_render_density() {
+    // The percent → dp resolution must divide out the render density: a 36dp circle at density 2.5
+    // measures 90px, whose 50% corner (45px) is still 18dp.
+    val root =
+      buildTree(density = 2.5f) {
+        Box(Modifier.testTag("avatar").size(36.dp).clip(CircleShape))
+      }
+
+    assertEquals("18.0dp", root.find("avatar")?.tokens?.cornerRadius)
+  }
+
+  @Test
+  fun resolves_border_outline_colour() {
+    // #1908 ask 2: outline / role colours come from `Modifier.border`, not `Modifier.background`,
+    // so `backgroundColor` never saw them. They now surface as `borderColor`.
+    val root = buildTree {
+      Box(
+        Modifier.testTag("chip")
+          .border(BorderStroke(1.dp, Color(0xFFCAC4D0)), CircleShape)
+          .size(24.dp)
+      )
+    }
+
+    val tokens = root.find("chip")?.tokens
+    assertNotNull("chip must carry resolved tokens", tokens)
+    assertEquals("#FFCAC4D0", tokens!!.borderColor)
   }
 }

--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
@@ -53,9 +53,10 @@ object ComposeSemanticsDataProducer {
     previewId: String,
     root: SemanticsNode,
     fileSystem: FileSystem = SystemFileSystem,
+    density: Float = 1f,
   ) {
     val previewDir = rootDir.resolve(previewId).also { it.mkdirs() }
-    val payload = buildPayload(root)
+    val payload = buildPayload(root, density)
     fileSystem.write(previewDir.resolve(FILE).path.toPath()) {
       writeUtf8(json.encodeToString(ComposeSemanticsPayload.serializer(), payload))
     }
@@ -65,9 +66,13 @@ object ComposeSemanticsDataProducer {
    * Projects a captured semantics [root] into the stable wire model. Public so the wireframe
    * producer (and any other derived view) reuses the exact same projection — label precedence,
    * bounds formatting, merge-mode mapping — rather than re-walking the tree with different rules.
+   *
+   * [density] is the render density (dp = px / density). It is only needed to express a
+   * percent-based corner radius (`CircleShape`) as dp; the default of `1f` leaves px-equals-dp
+   * captures (and the token text/colour fields, which carry dp directly) unchanged (issue #1908).
    */
-  fun buildPayload(root: SemanticsNode): ComposeSemanticsPayload =
-    SemanticsRefs.assign(ComposeSemanticsPayload(root = root.toWireNode()))
+  fun buildPayload(root: SemanticsNode, density: Float = 1f): ComposeSemanticsPayload =
+    SemanticsRefs.assign(ComposeSemanticsPayload(root = root.toWireNode(density)))
 
   private val probeNodesSerializer = ListSerializer(RecordingProbeNode.serializer())
 
@@ -99,7 +104,7 @@ object ComposeSemanticsDataProducer {
   fun decodeProbeNodes(payload: String): List<RecordingProbeNode> =
     json.decodeFromString(probeNodesSerializer, payload)
 
-  private fun SemanticsNode.toWireNode(): ComposeSemanticsNode {
+  private fun SemanticsNode.toWireNode(density: Float): ComposeSemanticsNode {
     val cfg = config
     val layout = cfg.layoutDetails()
     return ComposeSemanticsNode(
@@ -128,8 +133,8 @@ object ComposeSemanticsDataProducer {
           else -> null
         },
       clickable = cfg.getOrNull(SemanticsActions.OnClick) != null,
-      tokens = resolvedTokens(),
-      children = children.map { it.toWireNode() },
+      tokens = resolvedTokens(density),
+      children = children.map { it.toWireNode(density) },
     )
   }
 
@@ -146,7 +151,7 @@ object ComposeSemanticsDataProducer {
    * reflecting the element's backing field. Reflection (rather than a `compose.foundation` compile
    * dependency) also keeps this module foundation-free, matching the layout inspector's approach.
    */
-  private fun SemanticsNode.resolvedTokens(): ComposeSemanticsTokens? {
+  private fun SemanticsNode.resolvedTokens(density: Float): ComposeSemanticsTokens? {
     val modifiers =
       try {
         layoutInfo.getModifierInfo()
@@ -154,8 +159,12 @@ object ComposeSemanticsDataProducer {
         return null
       }
     var backgroundColor: String? = null
+    var borderColor: String? = null
     var cornerRadius: String? = null
+    var shape: String? = null
     var padding: ComposeSemanticsInsets? = null
+    // `CircleShape` / `CornerSize(50%)` resolve to dp against the node's shorter measured side.
+    val minSidePx = minOf(size.width, size.height)
     for (info in modifiers) {
       val mod = info.modifier
       val inspectable = mod as? InspectableValue
@@ -166,23 +175,73 @@ object ComposeSemanticsDataProducer {
       if (backgroundColor == null && (name == "background" || simpleName == "BackgroundElement")) {
         backgroundColor = backgroundColorHex(mod, elements, inspectable?.valueOverride)
       }
+      // `Modifier.border` carries the outline colour `Surface`/`Card`/dividers apply — a role colour
+      // (`outline` / `outlineVariant`) a plain `Modifier.background` never sees (issue #1908).
+      if (borderColor == null && (name == "border" || simpleName.startsWith("BorderModifier"))) {
+        borderColor = borderColorHex(mod, elements)
+      }
       if (padding == null && (name == "padding" || simpleName.startsWith("PaddingElement"))) {
         padding = paddingInsets(mod, elements, inspectable?.valueOverride)
       }
-      // Corner radius comes from any shape-bearing modifier: `background(color, shape)`,
-      // `clip(shape)` (which Compose routes through `graphicsLayer`), or `border(..., shape)`.
-      // Non-rounded shapes (RectangleShape, etc.) yield null and are skipped.
-      if (cornerRadius == null) {
-        cornerRadius = shapeOf(mod, elements)?.cornerRadiusWire()
+      // Shape comes from any shape-bearing modifier: `background(color, shape)`, `clip(shape)`
+      // (which Compose routes through `graphicsLayer`), or `border(..., shape)`. A plain rectangle
+      // yields null for both fields and is skipped.
+      val nodeShape = shapeOf(mod, elements)
+      if (nodeShape != null) {
+        if (cornerRadius == null) cornerRadius = nodeShape.cornerRadiusWire(minSidePx, density)
+        if (shape == null) shape = nodeShape.shapeDescriptor()
       }
     }
-    return if (backgroundColor == null && cornerRadius == null && padding == null) null
+    val gap = arrangementGapWire()
+    return if (
+      backgroundColor == null &&
+        borderColor == null &&
+        cornerRadius == null &&
+        shape == null &&
+        gap == null &&
+        padding == null
+    )
+      null
     else
       ComposeSemanticsTokens(
         backgroundColor = backgroundColor,
+        borderColor = borderColor,
         cornerRadius = cornerRadius,
+        shape = shape,
+        gap = gap,
         padding = padding,
       )
+  }
+
+  /**
+   * Resolves the inter-child spacing of a `Row`/`Column` from its measure policy (issue #1908).
+   * `Arrangement.spacedBy(n)` is stored on the `Row`/`Column`MeasurePolicy as an
+   * `Arrangement.HorizontalOrVertical` whose `spacing` `Dp` is kept in a `spacing` float field; the
+   * value-class `getSpacing` getter is name-mangled, so the field is read directly. Reflection (not
+   * a `compose.foundation` dependency) keeps this module foundation-free, matching the rest of the
+   * extractor. Returns null when the layout has no arrangement spacing.
+   */
+  private fun SemanticsNode.arrangementGapWire(): String? {
+    val policy =
+      runCatching { layoutInfo.javaClass.getMethod("getMeasurePolicy").invoke(layoutInfo) }
+        .getOrNull() ?: return null
+    var cls: Class<*>? = policy.javaClass
+    while (cls != null && cls != Any::class.java) {
+      for (field in cls.declaredFields) {
+        val value =
+          runCatching { field.apply { isAccessible = true }.get(policy) }.getOrNull() ?: continue
+        if (!value.javaClass.name.startsWith("androidx.compose.foundation.layout.Arrangement"))
+          continue
+        val spacing =
+          runCatching {
+              value.javaClass.getDeclaredField("spacing").apply { isAccessible = true }.getFloat(value)
+            }
+            .getOrNull() ?: continue
+        if (spacing > 0f) return "${spacing}dp"
+      }
+      cls = cls.superclass
+    }
+    return null
   }
 
   /**
@@ -204,6 +263,30 @@ object ComposeSemanticsDataProducer {
         val packed = field.getLong(mod).toULong()
         // sRGB packs the colour space id (non-zero) into the low 32 bits as 0; anything else is a
         // wide-gamut/unspecified packing we can't read as a plain ARGB hex.
+        if (packed and 0xFFFFFFFFuL != 0uL) return null
+        val argb = (packed shr 32).toInt()
+        if (argb == 0) null else "#${String.format(Locale.US, "%08X", argb)}"
+      }
+      .getOrNull()
+  }
+
+  /**
+   * Resolves a `border` modifier's stroke colour as ARGB hex. `Modifier.border` projects its colour
+   * through the inspector `color` element even when the brush is a plain `SolidColor`; that's read
+   * first, falling back to reflecting the backing `brush` field's `SolidColor.value`. A gradient
+   * brush (no single colour) is skipped (issue #1908).
+   */
+  private fun borderColorHex(mod: Any, elements: Map<String, Any?>): String? {
+    (elements["color"] as? Color)?.let {
+      return if (it == Color.Unspecified) null else colorToWireString(it)
+    }
+    return runCatching {
+        val brush =
+          mod.javaClass.getDeclaredField("brush").apply { isAccessible = true }.get(mod) ?: return null
+        if (brush.javaClass.simpleName != "SolidColor") return null
+        val value =
+          brush.javaClass.getDeclaredField("value").apply { isAccessible = true }.getLong(brush)
+        val packed = value.toULong()
         if (packed and 0xFFFFFFFFuL != 0uL) return null
         val argb = (packed shr 32).toInt()
         if (argb == 0) null else "#${String.format(Locale.US, "%08X", argb)}"
@@ -249,16 +332,18 @@ object ComposeSemanticsDataProducer {
 
   /**
    * Resolves the dp corner radius of a [Shape] without a `compose.foundation` compile dependency.
-   * `CornerBasedShape` exposes four `CornerSize` corners via no-arg getters; a dp-based
-   * `CornerSize` stores its `Dp` in a `size` field (inlined to a float). A uniform shape emits one
-   * value; otherwise the four corners are emitted comma-separated. Returns null for non-corner
-   * shapes and for `CornerSize`s that aren't dp-based (e.g. percent), which can't be expressed as a
-   * fixed dp.
+   * `CornerBasedShape` exposes four `CornerSize` corners via no-arg getters. A dp-based `CornerSize`
+   * (`DpCornerSize`) stores its `Dp` in a `size` field (inlined to a float) and is emitted verbatim;
+   * a percent-based `CornerSize` (`PercentCornerSize`, what `CircleShape` and `CornerSize(50%)` use)
+   * is resolved against [minSidePx] / [density] so a circular avatar reports its effective dp radius
+   * (issue #1908). A uniform shape emits one value; otherwise the four corners are emitted
+   * comma-separated. Returns null for non-corner shapes and for pixel corners (`PxCornerSize`,
+   * `RoundedCornerShape(12f)`), which can't be expressed as a fixed dp.
    */
-  private fun Shape.cornerRadiusWire(): String? {
+  private fun Shape.cornerRadiusWire(minSidePx: Int, density: Float): String? {
     val corners =
       listOf("getTopStart", "getTopEnd", "getBottomEnd", "getBottomStart").map { getter ->
-        cornerSizeDp(invokeNoArg(getter))
+        cornerSizeDp(invokeNoArg(getter), minSidePx, density)
       }
     if (corners.any { it == null }) return null
     val values = corners.filterNotNull()
@@ -266,21 +351,66 @@ object ComposeSemanticsDataProducer {
     else values.joinToString(",") { "${it}dp" }
   }
 
-  private fun cornerSizeDp(corner: Any?): Float? {
+  private fun cornerSizeDp(corner: Any?, minSidePx: Int, density: Float): Float? {
     corner ?: return null
-    // Only a dp-based corner can be expressed as a fixed dp radius. `PxCornerSize`
-    // (`RoundedCornerShape(12f)`) also stores a `size: Float`, but in pixels, and
-    // `PercentCornerSize` a `percent: Float` — reading either as dp would emit a wrong unit/value.
-    if (corner.javaClass.simpleName != "DpCornerSize") return null
-    return runCatching {
-        val field = corner.javaClass.getDeclaredField("size").apply { isAccessible = true }
-        when (val raw = field.get(corner)) {
-          is Float -> raw
-          is Dp -> raw.value
-          else -> null
+    return when (corner.javaClass.simpleName) {
+      // A dp corner stores its `Dp` (inlined float) directly.
+      "DpCornerSize" ->
+        runCatching {
+            val field = corner.javaClass.getDeclaredField("size").apply { isAccessible = true }
+            when (val raw = field.get(corner)) {
+              is Float -> raw
+              is Dp -> raw.value
+              else -> null
+            }
+          }
+          .getOrNull()
+      // A percent corner is a fraction of the shorter side: `px = minSide * percent/100`, then dp.
+      "PercentCornerSize" ->
+        cornerPercent(corner)?.let { pct ->
+          if (minSidePx <= 0 || density <= 0f) null
+          else roundedDp((minSidePx * pct / 100f) / density)
         }
+      // `PxCornerSize` (`RoundedCornerShape(12f)`) stores pixels we can't turn into a fixed dp.
+      else -> null
+    }
+  }
+
+  /**
+   * The percent (`50.0` for `CircleShape`) stored in a `PercentCornerSize`. The backing field is
+   * `percent` (its `toString` renders `"CornerSize(size = 50.0%)"`, but that label is not the field
+   * name); fall back to `size` defensively in case a future Compose renames it.
+   */
+  private fun cornerPercent(corner: Any?): Float? {
+    corner ?: return null
+    if (corner.javaClass.simpleName != "PercentCornerSize") return null
+    return sequenceOf("percent", "size")
+      .mapNotNull { name ->
+        runCatching {
+            corner.javaClass.getDeclaredField(name).apply { isAccessible = true }.getFloat(corner)
+          }
+          .getOrNull()
       }
-      .getOrNull()
+      .firstOrNull()
+  }
+
+  /** Round a computed dp to 2 decimals so percent-derived radii read cleanly (`18.0`, not `17.99`). */
+  private fun roundedDp(value: Float): Float = (value * 100f).roundToInt() / 100f
+
+  /**
+   * Shape-family descriptor for shapes whose radius isn't a single dp number (issue #1908):
+   * `"circle"` for a `CircleShape` / all-`CornerSize(50%)` rounded shape, `"cut"` for a
+   * `CutCornerShape`. Null for a plain rectangle or an ordinary dp `RoundedCornerShape` (its radius
+   * is already carried by [cornerRadiusWire]), so the descriptor stays signal, not noise.
+   */
+  private fun Shape.shapeDescriptor(): String? {
+    if (javaClass.simpleName == "CutCornerShape") return "cut"
+    val corners =
+      listOf("getTopStart", "getTopEnd", "getBottomEnd", "getBottomStart").map {
+        cornerPercent(invokeNoArg(it))
+      }
+    if (corners.all { it != null && it >= 50f }) return "circle"
+    return null
   }
 
   private fun reflectDp(mod: Any, field: String): String? =

--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
@@ -175,7 +175,8 @@ object ComposeSemanticsDataProducer {
       if (backgroundColor == null && (name == "background" || simpleName == "BackgroundElement")) {
         backgroundColor = backgroundColorHex(mod, elements, inspectable?.valueOverride)
       }
-      // `Modifier.border` carries the outline colour `Surface`/`Card`/dividers apply — a role colour
+      // `Modifier.border` carries the outline colour `Surface`/`Card`/dividers apply — a role
+      // colour
       // (`outline` / `outlineVariant`) a plain `Modifier.background` never sees (issue #1908).
       if (borderColor == null && (name == "border" || simpleName.startsWith("BorderModifier"))) {
         borderColor = borderColorHex(mod, elements)
@@ -234,7 +235,10 @@ object ComposeSemanticsDataProducer {
           continue
         val spacing =
           runCatching {
-              value.javaClass.getDeclaredField("spacing").apply { isAccessible = true }.getFloat(value)
+              value.javaClass
+                .getDeclaredField("spacing")
+                .apply { isAccessible = true }
+                .getFloat(value)
             }
             .getOrNull() ?: continue
         if (spacing > 0f) return "${spacing}dp"
@@ -282,7 +286,8 @@ object ComposeSemanticsDataProducer {
     }
     return runCatching {
         val brush =
-          mod.javaClass.getDeclaredField("brush").apply { isAccessible = true }.get(mod) ?: return null
+          mod.javaClass.getDeclaredField("brush").apply { isAccessible = true }.get(mod)
+            ?: return null
         if (brush.javaClass.simpleName != "SolidColor") return null
         val value =
           brush.javaClass.getDeclaredField("value").apply { isAccessible = true }.getLong(brush)
@@ -332,13 +337,13 @@ object ComposeSemanticsDataProducer {
 
   /**
    * Resolves the dp corner radius of a [Shape] without a `compose.foundation` compile dependency.
-   * `CornerBasedShape` exposes four `CornerSize` corners via no-arg getters. A dp-based `CornerSize`
-   * (`DpCornerSize`) stores its `Dp` in a `size` field (inlined to a float) and is emitted verbatim;
-   * a percent-based `CornerSize` (`PercentCornerSize`, what `CircleShape` and `CornerSize(50%)` use)
-   * is resolved against [minSidePx] / [density] so a circular avatar reports its effective dp radius
-   * (issue #1908). A uniform shape emits one value; otherwise the four corners are emitted
-   * comma-separated. Returns null for non-corner shapes and for pixel corners (`PxCornerSize`,
-   * `RoundedCornerShape(12f)`), which can't be expressed as a fixed dp.
+   * `CornerBasedShape` exposes four `CornerSize` corners via no-arg getters. A dp-based
+   * `CornerSize` (`DpCornerSize`) stores its `Dp` in a `size` field (inlined to a float) and is
+   * emitted verbatim; a percent-based `CornerSize` (`PercentCornerSize`, what `CircleShape` and
+   * `CornerSize(50%)` use) is resolved against [minSidePx] / [density] so a circular avatar reports
+   * its effective dp radius (issue #1908). A uniform shape emits one value; otherwise the four
+   * corners are emitted comma-separated. Returns null for non-corner shapes and for pixel corners
+   * (`PxCornerSize`, `RoundedCornerShape(12f)`), which can't be expressed as a fixed dp.
    */
   private fun Shape.cornerRadiusWire(minSidePx: Int, density: Float): String? {
     val corners =
@@ -394,7 +399,9 @@ object ComposeSemanticsDataProducer {
       .firstOrNull()
   }
 
-  /** Round a computed dp to 2 decimals so percent-derived radii read cleanly (`18.0`, not `17.99`). */
+  /**
+   * Round a computed dp to 2 decimals so percent-derived radii read cleanly (`18.0`, not `17.99`).
+   */
   private fun roundedDp(value: Float): Float = (value * 100f).roundToInt() / 100f
 
   /**

--- a/data/layoutinspector/connector/src/test/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProductRegistryTest.kt
+++ b/data/layoutinspector/connector/src/test/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProductRegistryTest.kt
@@ -29,7 +29,7 @@ class ComposeSemanticsDataProductRegistryTest {
     val registry = ComposeSemanticsDataProductRegistry(rootDir)
     val cap = registry.capabilities.single()
     assertEquals("compose/semantics", cap.kind)
-    assertEquals(3, cap.schemaVersion)
+    assertEquals(4, cap.schemaVersion)
     assertTrue(cap.attachable)
     assertTrue(cap.fetchable)
     assertTrue(!cap.requiresRerender)

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/ComposeSemanticsModels.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/ComposeSemanticsModels.kt
@@ -8,7 +8,11 @@ object ComposeSemanticsProduct {
   // corner radius, padding — so design-parity's token-compliance check can populate `actual`
   // instead of degrading to "missing from candidate". Additive: older `compose-semantics.json`
   // parses with `tokens = null`.
-  const val SCHEMA_VERSION: Int = 3
+  // v4 (#1908): the `tokens` object gains `borderColor` (outline role), `gap` (arrangement
+  // spacing), and `shape` (descriptor for non-dp shapes), and `cornerRadius` now resolves
+  // percent/`CircleShape` corners against the node's size. Still additive — every new field is
+  // optional, so a v3 reader parses a v4 file unchanged.
+  const val SCHEMA_VERSION: Int = 4
   const val FILE: String = "compose-semantics.json"
 }
 
@@ -80,21 +84,45 @@ data class ComposeSemanticsNode(
 )
 
 /**
- * Resolved design-token data for a single semantics node (issue #1897). Populated from the node's
- * Compose modifiers — `Modifier.background` (and `Surface`/`Card`, which apply it), the shape on
- * `background` / `clip` / `border`, and `Modifier.padding`. All fields are optional: a node emits
- * only the tokens it actually declares.
+ * Resolved design-token data for a single semantics node (issues #1897, #1908). Populated from the
+ * node's Compose modifiers — `Modifier.background` (and `Surface`/`Card`, which apply it),
+ * `Modifier.border` (outline colour), the shape on `background` / `clip` / `border` / `graphicsLayer`,
+ * `Modifier.padding`, and the `Arrangement` spacing of a `Row`/`Column` measure policy. All fields
+ * are optional: a node emits only the tokens it actually declares.
  */
 @Serializable
 data class ComposeSemanticsTokens(
   /** Resolved container/fill colour as ARGB hex (`#AARRGGBB`), e.g. from `Modifier.background`. */
   val backgroundColor: String? = null,
   /**
-   * Resolved corner radius in dp from the node's `background` / `clip` / `border` shape. A uniform
-   * `RoundedCornerShape` emits a single value (`"12.0dp"`); a non-uniform shape emits the four
-   * corners comma-separated (`"12.0dp,12.0dp,0.0dp,0.0dp"`, top-start → bottom-start).
+   * Resolved outline/stroke colour as ARGB hex (`#AARRGGBB`) from `Modifier.border` (issue #1908) —
+   * the role colours (`outline` / `outlineVariant`) a direct `Modifier.background` never carries.
+   */
+  val borderColor: String? = null,
+  /**
+   * Resolved corner radius in dp from the node's `background` / `clip` / `border` / `graphicsLayer`
+   * shape. A uniform shape emits a single value (`"12.0dp"`); a non-uniform shape emits the four
+   * corners comma-separated (`"12.0dp,12.0dp,0.0dp,0.0dp"`, top-start → bottom-start). dp-based
+   * corners are emitted verbatim; percent-based corners (`CircleShape`, `CornerSize(50%)`) are
+   * resolved against the node's measured size and density so a circular avatar still reports its
+   * effective radius instead of dropping out (issue #1908). Pixel corners (`RoundedCornerShape(12f)`)
+   * stay null — they can't be expressed as a fixed dp.
    */
   val cornerRadius: String? = null,
+  /**
+   * Shape-family descriptor for shapes whose radius isn't a single dp number (issue #1908):
+   * `"circle"` for a `CircleShape` / all-`CornerSize(50%)` rounded shape, `"cut"` for a
+   * `CutCornerShape`. Null for a plain rectangle or an ordinary dp `RoundedCornerShape` (whose
+   * radius is already carried by [cornerRadius]).
+   */
+  val shape: String? = null,
+  /**
+   * Resolved inter-child spacing in dp from a `Row`/`Column` `Arrangement.spacedBy(...)` (or any
+   * `Arrangement.HorizontalOrVertical` carrying a non-zero `spacing`), e.g. `"8.0dp"` (issue #1908).
+   * Null for layouts with no arrangement spacing. This is the gap the spacing tokens
+   * (`cardGap` / `rowGap`) compare against — distinct from [padding], which is the node's own inset.
+   */
+  val gap: String? = null,
   /** Resolved padding from `Modifier.padding`, in dp per edge. */
   val padding: ComposeSemanticsInsets? = null,
 )

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/ComposeSemanticsModels.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/ComposeSemanticsModels.kt
@@ -86,9 +86,9 @@ data class ComposeSemanticsNode(
 /**
  * Resolved design-token data for a single semantics node (issues #1897, #1908). Populated from the
  * node's Compose modifiers — `Modifier.background` (and `Surface`/`Card`, which apply it),
- * `Modifier.border` (outline colour), the shape on `background` / `clip` / `border` / `graphicsLayer`,
- * `Modifier.padding`, and the `Arrangement` spacing of a `Row`/`Column` measure policy. All fields
- * are optional: a node emits only the tokens it actually declares.
+ * `Modifier.border` (outline colour), the shape on `background` / `clip` / `border` /
+ * `graphicsLayer`, `Modifier.padding`, and the `Arrangement` spacing of a `Row`/`Column` measure
+ * policy. All fields are optional: a node emits only the tokens it actually declares.
  */
 @Serializable
 data class ComposeSemanticsTokens(
@@ -105,8 +105,8 @@ data class ComposeSemanticsTokens(
    * corners comma-separated (`"12.0dp,12.0dp,0.0dp,0.0dp"`, top-start → bottom-start). dp-based
    * corners are emitted verbatim; percent-based corners (`CircleShape`, `CornerSize(50%)`) are
    * resolved against the node's measured size and density so a circular avatar still reports its
-   * effective radius instead of dropping out (issue #1908). Pixel corners (`RoundedCornerShape(12f)`)
-   * stay null — they can't be expressed as a fixed dp.
+   * effective radius instead of dropping out (issue #1908). Pixel corners
+   * (`RoundedCornerShape(12f)`) stay null — they can't be expressed as a fixed dp.
    */
   val cornerRadius: String? = null,
   /**
@@ -118,9 +118,10 @@ data class ComposeSemanticsTokens(
   val shape: String? = null,
   /**
    * Resolved inter-child spacing in dp from a `Row`/`Column` `Arrangement.spacedBy(...)` (or any
-   * `Arrangement.HorizontalOrVertical` carrying a non-zero `spacing`), e.g. `"8.0dp"` (issue #1908).
-   * Null for layouts with no arrangement spacing. This is the gap the spacing tokens
-   * (`cardGap` / `rowGap`) compare against — distinct from [padding], which is the node's own inset.
+   * `Arrangement.HorizontalOrVertical` carrying a non-zero `spacing`), e.g. `"8.0dp"`
+   * (issue #1908). Null for layouts with no arrangement spacing. This is the gap the spacing tokens
+   * (`cardGap` / `rowGap`) compare against — distinct from [padding], which is the node's own
+   * inset.
    */
   val gap: String? = null,
   /** Resolved padding from `Modifier.padding`, in dp per edge. */

--- a/schema/compose-semantics.schema.json
+++ b/schema/compose-semantics.schema.json
@@ -5,7 +5,7 @@
   "description": "Payload for the `compose/semantics` data product: the Compose semantics tree projected for a render. Kotlin source of truth: ComposeSemanticsPayload / ComposeSemanticsNode in :data-layoutinspector-core. Each node carries a stable `ref` (see #1784).",
   "x-composeai": {
     "kind": "compose/semantics",
-    "schemaVersion": 3,
+    "schemaVersion": 4,
     "kotlinType": "ee.schimke.composeai.data.layoutinspector.ComposeSemanticsPayload",
     "kotlinConst": "ComposeSemanticsProduct.SCHEMA_VERSION",
     "fixture": "vscode-extension/preview-harness/fixtures/inspection-tree.json"
@@ -42,10 +42,13 @@
     },
     "ComposeSemanticsTokens": {
       "type": "object",
-      "description": "Resolved container design tokens for a node (#1897): from Modifier.background / Surface / Card, the background/clip/border shape, and Modifier.padding.",
+      "description": "Resolved container design tokens for a node (#1897, extended in v4 #1908): from Modifier.background / Surface / Card, Modifier.border, the background/clip/border/graphicsLayer shape, Modifier.padding, and the Row/Column arrangement spacing.",
       "properties": {
         "backgroundColor": { "type": ["string", "null"], "description": "Resolved container/fill colour as ARGB hex `#AARRGGBB`." },
-        "cornerRadius": { "type": ["string", "null"], "description": "Resolved corner radius in dp (`12.0dp`); non-uniform shapes emit four comma-separated corners." },
+        "borderColor": { "type": ["string", "null"], "description": "Resolved outline/stroke colour as ARGB hex `#AARRGGBB` from Modifier.border (#1908)." },
+        "cornerRadius": { "type": ["string", "null"], "description": "Resolved corner radius in dp (`12.0dp`); non-uniform shapes emit four comma-separated corners. Percent/CircleShape corners resolve against the node's size and density (#1908)." },
+        "shape": { "type": ["string", "null"], "description": "Shape-family descriptor for non-dp shapes (#1908): `circle` for CircleShape / all-CornerSize(50%), `cut` for CutCornerShape." },
+        "gap": { "type": ["string", "null"], "description": "Resolved Row/Column arrangement spacing in dp (`8.0dp`) from Arrangement.spacedBy (#1908)." },
         "padding": { "anyOf": [{ "$ref": "#/definitions/ComposeSemanticsInsets" }, { "type": "null" }] }
       }
     },


### PR DESCRIPTION
## Summary

Follow-up to #1897. The desktop semantics extractor only surfaced a node's `Modifier.background` colour, a dp `RoundedCornerShape` radius, and `Modifier.padding`, so design-parity reported values the rendered UI genuinely uses as "missing from candidate". This extends the per-node `tokens` object to cover the three independent gaps in #1908.

**Where this data lives:** it stays on the per-node `compose/semantics` `tokens` object — the consumer already deep-merges every node's tokens into one flat bag, so a container's token is collected wherever it sits in the tree. The additions (schema **v3 → v4**, all fields optional, so a v3 reader parses a v4 file unchanged):

| Ask (#1908) | Field | Source |
|---|---|---|
| 1. Arrangement spacing | `gap` (dp) | `Row`/`Column` measure policy's `Arrangement.spacedBy` spacing (reflected, foundation-free) |
| 2. Container colours beyond `Modifier.background` | `borderColor` | `Modifier.border` stroke colour (`outline`/`outlineVariant` roles). *Surface/Card fills already resolve via the existing `Modifier.background` path — verified against real Material3.* |
| 3. Non-rounded shape radii | `shape` (`"circle"`/`"cut"`) + `cornerRadius` | percent / `CircleShape` corners now resolve to dp against the node's measured size and render density instead of dropping out |

Render density is threaded from `RenderEngine` (desktop) and via a new `Density` extension-context key (Android) so percent corners resolve to dp; it defaults to `1f` for callers that don't supply it.

The companion consumer change (translating `gap`/`borderColor`/`shape`) is in yschimke/design-parity on the same branch. The consumer-side colour-collapse limitation noted in #1908 remains tracked separately.

## Test plan

- `:daemon:desktop:test` — new `DesktopSemanticsTokensTest` cases pin, against a real `ImageComposeScene`: Row/Column `Arrangement.spacedBy` → `gap`; `CircleShape` → `"circle"` + effective dp radius (incl. a density-2.5 case); `Modifier.border` → `borderColor`. Existing cases (background/dp-radius/padding, pixel-corner-stays-null) still pass. Full `:daemon:desktop:test` suite green.
- `:data-layoutinspector-connector:test` — schema-version assertion updated to 4; suite green.
- Android module compiles on CI (no Android SDK in the authoring sandbox; the shared connector module carrying the logic compiles and is exercised by the desktop tests).

Closes #1908

---
_Generated by [Claude Code](https://claude.ai/code/session_01FbdPRDVrf5jh79HfvcuyLG)_