### PR TITLE
feat(vscode): view render history from a reporting branch in the History panel

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -71,6 +71,13 @@
                     "id": "composePreview.panel",
                     "name": "Previews",
                     "visibility": "visible"
+                },
+                {
+                    "type": "webview",
+                    "id": "composePreview.historyPanel",
+                    "name": "Preview History",
+                    "visibility": "collapsed",
+                    "when": "config.composePreview.earlyFeatures.enabled"
                 }
             ]
         },
@@ -137,6 +144,13 @@
                 "title": "Browse Google Fonts",
                 "category": "Compose Preview",
                 "icon": "$(text-size)"
+            },
+            {
+                "command": "composePreview.history.selectSourceRef",
+                "title": "Select History Source (local or reporting branch)",
+                "category": "Compose Preview",
+                "icon": "$(git-branch)",
+                "enablement": "config.composePreview.earlyFeatures.enabled"
             }
         ],
         "menus": {
@@ -155,6 +169,11 @@
                     "command": "composePreview.copyDoctorReport",
                     "when": "view == composePreview.panel",
                     "group": "navigation@3"
+                },
+                {
+                    "command": "composePreview.history.selectSourceRef",
+                    "when": "view == composePreview.historyPanel",
+                    "group": "navigation@1"
                 }
             ],
             "explorer/context": [
@@ -167,6 +186,10 @@
             "commandPalette": [
                 {
                     "command": "composePreview.openBundle",
+                    "when": "config.composePreview.earlyFeatures.enabled"
+                },
+                {
+                    "command": "composePreview.history.selectSourceRef",
                     "when": "config.composePreview.earlyFeatures.enabled"
                 }
             ]

--- a/vscode-extension/preview-harness/fixtures/history-source-ref.gen.mjs
+++ b/vscode-extension/preview-harness/fixtures/history-source-ref.gen.mjs
@@ -1,0 +1,70 @@
+// Generator for `history-source-ref.json`. Run with:
+//   node preview-harness/fixtures/history-source-ref.gen.mjs > preview-harness/fixtures/history-source-ref.json
+//
+// Drives the **history panel** webview (`history.js` / `<history-app>`) to capture the reporting-
+// branch source picker (#1872, slice 2). A `setSourceRef` message labels the toolbar's source
+// button with the active reporting branch (`preview/main`) and flags it active; a `setEntries`
+// populates the timeline with git-sourced entries so the panel shows what "viewing a reporting
+// branch" looks like. This is the visual evidence for the new toolbar control — the CI visual-diff
+// bot renders it on every PR.
+
+const previewId = "com.example.OnboardingKt.WelcomeScreenPreview";
+
+function entry(id, timestamp, pngHash, shortCommit) {
+    return {
+        id,
+        previewId,
+        module: ":sample-android",
+        timestamp,
+        pngHash,
+        pngSize: 4218,
+        pngPath: `${id}.png`,
+        producer: "daemon",
+        trigger: "renderNow",
+        // Reporting-branch entries are stamped as a git source (see GitRefHistorySource).
+        source: {
+            kind: "git",
+            id: `git:refs/heads/preview/main@${shortCommit}`,
+        },
+        git: { branch: "main", shortCommit, dirty: false },
+    };
+}
+
+const fixture = {
+    name: "history-source-ref",
+    description:
+        "History panel webview: viewing a pushed reporting branch (#1872). The toolbar source button shows the active branch `preview/main` and the timeline lists git-sourced entries.",
+    app: "history-app",
+    bundle: "../media/webview/history.js",
+    dataset: { earlyFeatures: "true", minimalMode: "false" },
+    messages: [
+        // Toolbar reflects the active source: a reporting branch, not local.
+        {
+            command: "setSourceRef",
+            ref: "refs/heads/preview/main",
+            label: "preview/main",
+        },
+        { command: "setScopeLabel", label: "WelcomeScreenPreview" },
+        {
+            command: "setEntries",
+            result: {
+                entries: [
+                    entry(
+                        "20260430-101200-bbbbbbbb",
+                        "2026-04-30T10:12:00Z",
+                        "b".repeat(64),
+                        "a1b2c3d",
+                    ),
+                    entry(
+                        "20260430-101000-aaaaaaaa",
+                        "2026-04-30T10:10:00Z",
+                        "a".repeat(64),
+                        "9f8e7d6",
+                    ),
+                ],
+            },
+        },
+    ],
+};
+
+process.stdout.write(JSON.stringify(fixture, null, 2) + "\n");

--- a/vscode-extension/preview-harness/fixtures/history-source-ref.json
+++ b/vscode-extension/preview-harness/fixtures/history-source-ref.json
@@ -1,0 +1,68 @@
+{
+  "name": "history-source-ref",
+  "description": "History panel webview: viewing a pushed reporting branch (#1872). The toolbar source button shows the active branch `preview/main` and the timeline lists git-sourced entries.",
+  "app": "history-app",
+  "bundle": "../media/webview/history.js",
+  "dataset": {
+    "earlyFeatures": "true",
+    "minimalMode": "false"
+  },
+  "messages": [
+    {
+      "command": "setSourceRef",
+      "ref": "refs/heads/preview/main",
+      "label": "preview/main"
+    },
+    {
+      "command": "setScopeLabel",
+      "label": "WelcomeScreenPreview"
+    },
+    {
+      "command": "setEntries",
+      "result": {
+        "entries": [
+          {
+            "id": "20260430-101200-bbbbbbbb",
+            "previewId": "com.example.OnboardingKt.WelcomeScreenPreview",
+            "module": ":sample-android",
+            "timestamp": "2026-04-30T10:12:00Z",
+            "pngHash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            "pngSize": 4218,
+            "pngPath": "20260430-101200-bbbbbbbb.png",
+            "producer": "daemon",
+            "trigger": "renderNow",
+            "source": {
+              "kind": "git",
+              "id": "git:refs/heads/preview/main@a1b2c3d"
+            },
+            "git": {
+              "branch": "main",
+              "shortCommit": "a1b2c3d",
+              "dirty": false
+            }
+          },
+          {
+            "id": "20260430-101000-aaaaaaaa",
+            "previewId": "com.example.OnboardingKt.WelcomeScreenPreview",
+            "module": ":sample-android",
+            "timestamp": "2026-04-30T10:10:00Z",
+            "pngHash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "pngSize": 4218,
+            "pngPath": "20260430-101000-aaaaaaaa.png",
+            "producer": "daemon",
+            "trigger": "renderNow",
+            "source": {
+              "kind": "git",
+              "id": "git:refs/heads/preview/main@9f8e7d6"
+            },
+            "git": {
+              "branch": "main",
+              "shortCommit": "9f8e7d6",
+              "dirty": false
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -80,9 +80,11 @@ import { mergeRemoteComposeChange } from "./daemon/remoteComposeMerge";
 import { mergePermissionsChange } from "./daemon/permissionsMerge";
 import {
     buildHistorySource,
+    HistoryPanel,
     HistoryScope,
     HistorySource,
 } from "./historyPanel";
+import { listReportingBranches } from "./reportingBranches";
 import { historyFeatureEnabled } from "./historyFeature";
 import {
     disposePreviewMainBatches,
@@ -195,6 +197,15 @@ let historySource: HistorySource | null = null;
  * source when the user navigates between modules.
  */
 const historyScopeRef: { current: HistoryScope | null } = { current: null };
+/** The standalone "Preview History" view (#1872). Registered in `activate()`
+ *  when the early-access flag is on; null otherwise. */
+let historyView: HistoryPanel | null = null;
+/** Sets the active history scope and keeps the standalone panel in sync, so
+ *  switching files / previews / reporting branch re-lists the timeline. */
+function applyHistoryScope(scope: HistoryScope | null): void {
+    historyScopeRef.current = scope;
+    historyView?.setScope(scope);
+}
 /** Tracks the most recent preview set per module for daemon focus computation.
  *  The daemon path doesn't re-issue `composePreviewDiscover` on every save — it
  *  pushes `discoveryUpdated`. We mirror the latest snapshot here so save-
@@ -1643,7 +1654,10 @@ export async function activate(
                 if (!client) {
                     throw new Error("daemon unavailable");
                 }
-                return client.historyList({ previewId: scope.previewId });
+                return client.historyList({
+                    previewId: scope.previewId,
+                    ref: scope.gitRef,
+                });
             },
             daemonRead: async (id) => {
                 const moduleId = historyScopeRef.current?.moduleId;
@@ -1661,7 +1675,11 @@ export async function activate(
                 if (!client) {
                     throw new Error("daemon unavailable");
                 }
-                return client.historyRead({ id, inline: false });
+                return client.historyRead({
+                    id,
+                    inline: false,
+                    ref: historyScopeRef.current?.gitRef,
+                });
             },
             daemonDiff: async (fromId, toId) => {
                 const moduleId = historyScopeRef.current?.moduleId;
@@ -1689,6 +1707,7 @@ export async function activate(
                     from: fromId,
                     to: toId,
                     mode: "metadata",
+                    ref: historyScopeRef.current?.gitRef,
                 });
             },
             getCurrentScope: () => historyScopeRef.current,
@@ -1698,6 +1717,71 @@ export async function activate(
         historySource = historyFeatureEnabled() ? makeHistorySource() : null;
     };
     refreshHistorySource();
+
+    // #1872 — register the standalone "Preview History" timeline view. It's
+    // gated behind the early-access flag via the `composePreview.historyEnabled`
+    // context key (see package.json `when`). The view delegates to the live
+    // `historySource`, which `refreshHistorySource` swaps when the flag toggles,
+    // so wrap it in a stable indirection that reads `historySource` at call time.
+    const historyViewSource: HistorySource = {
+        list: (scope) =>
+            historySource?.list(scope) ??
+            Promise.resolve({ entries: [], totalCount: 0 }),
+        read: (id) => historySource?.read(id) ?? Promise.resolve(null),
+        diff: (fromId, toId) =>
+            historySource?.diff(fromId, toId) ?? Promise.resolve(null),
+    };
+    historyView = new HistoryPanel(context.extensionUri, historyViewSource);
+    historyView.setScope(historyScopeRef.current);
+    context.subscriptions.push(
+        vscode.window.registerWebviewViewProvider(
+            HistoryPanel.viewId,
+            historyView,
+        ),
+        vscode.commands.registerCommand(
+            "composePreview.history.selectSourceRef",
+            async () => {
+                const scope = historyScopeRef.current;
+                if (!scope) {
+                    void vscode.window.showInformationMessage(
+                        "Open a Kotlin file with a @Preview to choose a history source.",
+                    );
+                    return;
+                }
+                const branches = await listReportingBranches(workspaceRoot);
+                interface RefItem extends vscode.QuickPickItem {
+                    ref?: string;
+                }
+                const items: RefItem[] = [
+                    {
+                        label: "$(folder) Local (working tree)",
+                        description: "History recorded in this checkout",
+                        picked: !scope.gitRef,
+                        ref: undefined,
+                    },
+                    ...branches.map(
+                        (b): RefItem => ({
+                            label: "$(git-branch) " + b.label,
+                            description: b.ref,
+                            picked: scope.gitRef === b.ref,
+                            ref: b.ref,
+                        }),
+                    ),
+                ];
+                const pick = await vscode.window.showQuickPick(items, {
+                    title: "Preview History — source",
+                    placeHolder:
+                        branches.length === 0
+                            ? "No preview/* reporting branches found — showing local only"
+                            : "View local history or a pushed reporting branch",
+                });
+                if (!pick || pick.ref === scope.gitRef) {
+                    return; // cancelled or unchanged
+                }
+                applyHistoryScope({ ...scope, gitRef: pick.ref });
+            },
+        ),
+    );
     context.subscriptions.push(
         vscode.commands.registerCommand("composePreview.refresh", () =>
             refresh(true, editorScope.file ?? undefined),
@@ -4852,7 +4936,7 @@ async function refresh(
         pendingScrollBackfill = new Map();
         setCurrentScopeFile(null);
         clearHeavyRefreshOptIns();
-        historyScopeRef.current = null;
+        applyHistoryScope(null);
         return "no-module";
     }
     // Cancel any in-flight refresh — we have a valid replacement.
@@ -4945,9 +5029,12 @@ async function refresh(
               projectDir,
               previewId: prior!.previewId,
               previewLabel: prior!.previewLabel,
+              // Keep the chosen reporting branch across same-module refreshes
+              // (mirrors the previewId narrow); a module switch resets to local.
+              gitRef: prior!.gitRef,
           }
         : { moduleId: module.modulePath, projectDir };
-    historyScopeRef.current = newScope;
+    applyHistoryScope(newScope);
     const modules: ModuleInfo[] = [module];
     const modulePathList = modules.map((m) => m.modulePath);
 
@@ -5756,7 +5843,7 @@ function handleWebviewMessage(msg: WebviewToExtension) {
                 previewId: requested,
                 previewLabel: requestedLabel,
             };
-            historyScopeRef.current = newScope;
+            applyHistoryScope(newScope);
             break;
         }
         case "openCompileError":

--- a/vscode-extension/src/historyPanel.ts
+++ b/vscode-extension/src/historyPanel.ts
@@ -9,6 +9,7 @@ import {
     HistoryReadResult,
     HistorySourceKind,
 } from "./daemon/daemonProtocol";
+import { reportingBranchLabel } from "./reportingBranches";
 
 /**
  * Read-only Preview History panel — HISTORY.md § "VS Code integration".
@@ -113,6 +114,9 @@ export class HistoryPanel implements vscode.WebviewViewProvider {
 
     /** Force a re-list against the current scope. */
     async refresh(): Promise<void> {
+        // Reflect the active source (Local vs a reporting branch) in the
+        // toolbar regardless of whether there's a scope/preview to list yet.
+        this.postSourceRef();
         if (!this.view || !this.currentScope) {
             this.view?.webview.postMessage({
                 command: "showMessage",
@@ -154,10 +158,31 @@ export class HistoryPanel implements vscode.WebviewViewProvider {
         }
     }
 
+    /** Pushes the active history source (Local vs reporting branch) to the
+     *  webview so the toolbar control shows where entries are coming from. */
+    private postSourceRef(): void {
+        if (!this.view) {
+            return;
+        }
+        const ref = this.currentScope?.gitRef ?? null;
+        this.view.webview.postMessage({
+            command: "setSourceRef",
+            ref,
+            label: ref ? (reportingBranchLabel(ref) ?? ref) : null,
+        });
+    }
+
     private async handleMessage(msg: HistoryWebviewMessage): Promise<void> {
         switch (msg.command) {
             case "refresh":
                 await this.refresh();
+                break;
+            case "selectSourceRef":
+                // Routed to the extension command, which runs the quick-pick and
+                // calls back into setScope() with the chosen ref.
+                await vscode.commands.executeCommand(
+                    "composePreview.history.selectSourceRef",
+                );
                 break;
             case "loadImage":
                 if (msg.id) {
@@ -506,6 +531,13 @@ export interface HistoryScope {
      *  Surfaced in the panel's toolbar as a chip when set so the user can
      *  see why entries are narrowed. Not used for filtering. */
     previewLabel?: string;
+    /** Reporting-branch source (#1872). When set to a full git ref (e.g.
+     *  `refs/heads/preview/main`), the panel reads history from that pushed
+     *  reporting branch via the daemon's on-demand `ref` param instead of the
+     *  local working tree. Undefined ⇒ local history. Reading a ref is
+     *  daemon-only (the FS reader can't read a git ref), so the panel shows
+     *  empty rather than misleading local entries when the daemon is down. */
+    gitRef?: string;
 }
 
 /**
@@ -524,6 +556,13 @@ export function buildHistorySource(opts: BuildSourceOptions): HistorySource {
                         `[history] daemon list failed for ${scope.moduleId}, falling back to FS: ${(err as Error).message}`,
                     );
                 }
+            }
+            if (scope.gitRef) {
+                // Reporting-branch view is daemon-only: the FS reader and the
+                // synthetic current-render fallback below are both local, so
+                // falling back would mask a down daemon with the wrong (local)
+                // history. Empty ⇒ the panel shows its "no history" hint.
+                return result ?? { entries: [], totalCount: 0 };
             }
             if (!result) {
                 result = new HistoryReader(historyDirFor(scope)).list({
@@ -561,6 +600,11 @@ export function buildHistorySource(opts: BuildSourceOptions): HistorySource {
                     );
                 }
             }
+            // Reporting-branch entries only exist on the daemon side; never
+            // resolve a git-ref id against the local FS reader.
+            if (scope.gitRef) {
+                return null;
+            }
             return new HistoryReader(historyDirFor(scope)).read(id);
         },
         diff: async (fromId, toId) => {
@@ -585,6 +629,10 @@ export function buildHistorySource(opts: BuildSourceOptions): HistorySource {
                         `[history] daemon diff failed, falling back to FS: ${(err as Error).message}`,
                     );
                 }
+            }
+            // Reporting-branch entries are daemon-only — no local FS diff.
+            if (scope.gitRef) {
+                return null;
             }
             return new HistoryReader(historyDirFor(scope)).diff(
                 fromId,

--- a/vscode-extension/src/reportingBranches.ts
+++ b/vscode-extension/src/reportingBranches.ts
@@ -1,0 +1,83 @@
+// Enumerates pushed render-history reporting branches (#1872) for the History
+// panel's source picker. The daemon's reporting-branch writer publishes history
+// under `preview/<source-branch>` refs (see docs/daemon/REPORTING-BRANCH.md); the
+// picker lets the user point the panel at one of them via the daemon's on-demand
+// `ref` history param.
+
+import { execFile } from "child_process";
+import { promisify } from "util";
+
+const execFileAsync = promisify(execFile);
+
+/** A reporting branch the user can view in the History panel. */
+export interface ReportingBranch {
+    /** Full git ref, e.g. `refs/heads/preview/main` — passed to the daemon. */
+    ref: string;
+    /** Short, friendly label for the picker, e.g. `preview/main` or
+     *  `origin/preview/main`. */
+    label: string;
+}
+
+/**
+ * Lists `preview/*` reporting branches under local heads and every remote,
+ * de-duplicated by ref and sorted by label. Returns full ref names so the
+ * daemon resolves them unambiguously.
+ *
+ * Best-effort: returns `[]` when git is missing, `repoRoot` isn't a repo, or
+ * there are no preview branches — callers degrade to "Local only".
+ */
+export async function listReportingBranches(
+    repoRoot: string,
+): Promise<ReportingBranch[]> {
+    let stdout: string;
+    try {
+        ({ stdout } = await execFileAsync(
+            "git",
+            [
+                "for-each-ref",
+                "--format=%(refname)",
+                "refs/heads",
+                "refs/remotes",
+            ],
+            { cwd: repoRoot, timeout: 5000 },
+        ));
+    } catch {
+        return [];
+    }
+    const seen = new Set<string>();
+    const branches: ReportingBranch[] = [];
+    for (const raw of stdout.split("\n")) {
+        const ref = raw.trim();
+        if (!ref || seen.has(ref)) {
+            continue;
+        }
+        const label = reportingBranchLabel(ref);
+        if (!label) {
+            continue;
+        }
+        seen.add(ref);
+        branches.push({ ref, label });
+    }
+    branches.sort((a, b) => a.label.localeCompare(b.label));
+    return branches;
+}
+
+/**
+ * Maps a full ref to a picker label iff it's a `preview/*` reporting branch:
+ * - `refs/heads/preview/main` → `preview/main`
+ * - `refs/remotes/origin/preview/main` → `origin/preview/main`
+ *
+ * Returns null for any ref that isn't a preview branch (so non-reporting refs
+ * are filtered out).
+ */
+export function reportingBranchLabel(ref: string): string | null {
+    const local = ref.match(/^refs\/heads\/(preview\/.+)$/);
+    if (local) {
+        return local[1];
+    }
+    const remote = ref.match(/^refs\/remotes\/([^/]+\/preview\/.+)$/);
+    if (remote) {
+        return remote[1];
+    }
+    return null;
+}

--- a/vscode-extension/src/test/reportingBranches.test.ts
+++ b/vscode-extension/src/test/reportingBranches.test.ts
@@ -1,0 +1,143 @@
+// Coverage for the History panel's reporting-branch enumeration (#1872).
+//
+// `listReportingBranches` shells out to `git for-each-ref`, so we synthesise a
+// throwaway repo with a mix of `preview/*` and non-preview branches and assert
+// only the reporting branches surface, mapped to friendly labels. `git` is
+// required; tests skip cleanly when it's unavailable (mirrors the daemon-side
+// GitRefHistorySource tests).
+
+import * as assert from "assert";
+import { execFileSync } from "child_process";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+import {
+    listReportingBranches,
+    reportingBranchLabel,
+} from "../reportingBranches";
+
+function gitAvailable(): boolean {
+    try {
+        execFileSync("git", ["--version"], { stdio: "ignore" });
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+function git(repo: string, ...args: string[]): void {
+    execFileSync("git", ["-C", repo, ...args], { stdio: "ignore" });
+}
+
+describe("reportingBranchLabel", () => {
+    it("maps local preview heads to their short name", () => {
+        assert.strictEqual(
+            reportingBranchLabel("refs/heads/preview/main"),
+            "preview/main",
+        );
+    });
+
+    it("maps remote preview branches to remote/preview/name", () => {
+        assert.strictEqual(
+            reportingBranchLabel("refs/remotes/origin/preview/feature-x"),
+            "origin/preview/feature-x",
+        );
+    });
+
+    it("returns null for non-preview refs", () => {
+        assert.strictEqual(reportingBranchLabel("refs/heads/main"), null);
+        assert.strictEqual(
+            reportingBranchLabel("refs/remotes/origin/main"),
+            null,
+        );
+        assert.strictEqual(reportingBranchLabel("refs/tags/v1"), null);
+    });
+});
+
+describe("listReportingBranches", () => {
+    let repo: string;
+    const hasGit = gitAvailable();
+
+    beforeEach(function () {
+        if (!hasGit) {
+            this.skip();
+        }
+        repo = fs.mkdtempSync(path.join(os.tmpdir(), "reporting-branches-"));
+        git(repo, "init", "-q");
+        git(repo, "config", "user.email", "test@example.com");
+        git(repo, "config", "user.name", "Test");
+        git(repo, "config", "commit.gpgsign", "false");
+        fs.writeFileSync(path.join(repo, "README"), "init");
+        git(repo, "add", "README");
+        git(repo, "commit", "-q", "-m", "init");
+    });
+
+    afterEach(() => {
+        if (repo) {
+            fs.rmSync(repo, { recursive: true, force: true });
+        }
+    });
+
+    it("returns only preview/* branches, sorted, with friendly labels", async () => {
+        git(repo, "branch", "preview/main");
+        git(repo, "branch", "preview/feature-x");
+        git(repo, "branch", "feature/unrelated");
+
+        const branches = await listReportingBranches(repo);
+
+        assert.deepStrictEqual(
+            branches.map((b) => b.label),
+            ["preview/feature-x", "preview/main"],
+        );
+        assert.deepStrictEqual(
+            branches.map((b) => b.ref),
+            ["refs/heads/preview/feature-x", "refs/heads/preview/main"],
+        );
+    });
+
+    it("includes remote preview branches", async () => {
+        // Synthesise a remote-tracking ref without a real remote by writing the
+        // packed/loose ref directly under refs/remotes.
+        git(repo, "branch", "preview/main");
+        const remoteDir = path.join(repo, ".git", "refs", "remotes", "origin");
+        fs.mkdirSync(remoteDir, { recursive: true });
+        const sha = execFileSync(
+            "git",
+            ["-C", repo, "rev-parse", "refs/heads/preview/main"],
+            { encoding: "utf8" },
+        ).trim();
+        fs.writeFileSync(
+            path.join(remoteDir, "preview"),
+            "", // placeholder; real ref written below as preview/main
+        );
+        fs.rmSync(path.join(remoteDir, "preview"));
+        fs.mkdirSync(path.join(remoteDir, "preview"), { recursive: true });
+        fs.writeFileSync(path.join(remoteDir, "preview", "main"), sha + "\n");
+
+        const branches = await listReportingBranches(repo);
+        const labels = branches.map((b) => b.label);
+        assert.ok(
+            labels.includes("preview/main"),
+            "local preview/main present",
+        );
+        assert.ok(
+            labels.includes("origin/preview/main"),
+            "remote origin/preview/main present",
+        );
+    });
+
+    it("returns [] when there are no preview branches", async () => {
+        git(repo, "branch", "feature/x");
+        assert.deepStrictEqual(await listReportingBranches(repo), []);
+    });
+
+    it("returns [] for a non-git directory", async () => {
+        const notRepo = fs.mkdtempSync(path.join(os.tmpdir(), "not-a-repo-"));
+        try {
+            assert.deepStrictEqual(await listReportingBranches(notRepo), []);
+        } finally {
+            fs.rmSync(notRepo, { recursive: true, force: true });
+        }
+    });
+});

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -1266,6 +1266,10 @@ export type HistoryToWebview =
     | { command: "entryAdded"; entry: HistoryEntry }
     | { command: "entriesPruned"; removedIds: string[] }
     | { command: "setScopeLabel"; label: string }
+    // Active history source (#1872): `ref` is the full git ref of the reporting
+    // branch being viewed (null = local working tree); `label` is its friendly
+    // form for the toolbar (null = local).
+    | { command: "setSourceRef"; ref: string | null; label: string | null }
     | { command: "showMessage"; text: string }
     | {
           command: "imageReady";

--- a/vscode-extension/src/webview/history/behavior.ts
+++ b/vscode-extension/src/webview/history/behavior.ts
@@ -47,6 +47,8 @@ export function setupHistoryBehavior(): void {
         requireElementById<HTMLSelectElement>("filter-branch");
     const btnRefreshEl = requireElementById<HTMLButtonElement>("btn-refresh");
     const btnDiffEl = requireElementById<HTMLButtonElement>("btn-diff");
+    const btnSourceRefEl =
+        requireElementById<HTMLButtonElement>("btn-source-ref");
     // Scope chip is owned by `<scope-chip>` — see
     // `components/ScopeChip.ts`. It listens for `setScopeLabel` directly.
 
@@ -84,6 +86,9 @@ export function setupHistoryBehavior(): void {
 
     btnRefreshEl.addEventListener("click", () => {
         vscode.postMessage({ command: "refresh" });
+    });
+    btnSourceRefEl.addEventListener("click", () => {
+        vscode.postMessage({ command: "selectSourceRef" });
     });
     btnDiffEl.addEventListener("click", () => {
         if (selectedOrder.length === 2) {
@@ -270,6 +275,18 @@ export function setupHistoryBehavior(): void {
                 // for this command. Listed here so the discriminated-union
                 // exhaustiveness check holds.
                 break;
+            case "setSourceRef": {
+                // Reflect the active history source in the toolbar button: the
+                // local working tree, or a pushed reporting branch (#1872).
+                const label = msg.label ?? "Local";
+                btnSourceRefEl.textContent = label;
+                btnSourceRefEl.classList.toggle("active", msg.ref != null);
+                btnSourceRefEl.title =
+                    msg.ref != null
+                        ? `Viewing reporting branch ${label} — click to change source`
+                        : "Choose history source: the local working tree or a pushed reporting branch";
+                break;
+            }
             case "imageReady": {
                 const row = findRow(msg.id);
                 if (row) row.setImage(msg.imageData, msg.entry);

--- a/vscode-extension/src/webview/history/behavior.ts
+++ b/vscode-extension/src/webview/history/behavior.ts
@@ -53,6 +53,10 @@ export function setupHistoryBehavior(): void {
     // `components/ScopeChip.ts`. It listens for `setScopeLabel` directly.
 
     let entries: HistoryEntry[] = [];
+    // The active history source's ref (null = local). Tracked so the "Source"
+    // filter is only reset when the source genuinely changes (#1872), not on
+    // every routine `setSourceRef` re-post. `undefined` until the first push.
+    let activeSourceRef: string | null | undefined = undefined;
     // (max-2) selection queue (oldest first). Each `<history-row>` owns
     // its own `selected` state and dispatches
     // `history-row-selection-change` on shift-click; this list is the
@@ -285,6 +289,16 @@ export function setupHistoryBehavior(): void {
                     msg.ref != null
                         ? `Viewing reporting branch ${label} — click to change source`
                         : "Choose history source: the local working tree or a pushed reporting branch";
+                // Switching the underlying source flips the entries' source kind
+                // (git for a reporting branch, fs for local). A stale "Source"
+                // filter (fs/git) would then hide the entire new dataset and the
+                // panel would look empty, so reset it to "all" when the source
+                // actually changes — but leave a deliberate filter alone across
+                // routine refreshes (which re-post the same ref).
+                if (msg.ref !== activeSourceRef) {
+                    activeSourceRef = msg.ref;
+                    filterSourceEl.value = "all";
+                }
                 break;
             }
             case "imageReady": {

--- a/vscode-extension/src/webview/history/main.ts
+++ b/vscode-extension/src/webview/history/main.ts
@@ -25,6 +25,12 @@ export class HistoryApp extends LitElement {
     protected render(): TemplateResult {
         return html`
             <div class="toolbar" role="toolbar" aria-label="History filters">
+                <button
+                    id="btn-source-ref"
+                    title="Choose history source: the local working tree or a pushed reporting branch"
+                >
+                    Local
+                </button>
                 <select id="filter-source" title="Source">
                     <option value="all">All sources</option>
                     <option value="fs">Local filesystem</option>


### PR DESCRIPTION
## Summary

Slice 2 of the reporting-branch source UI (#1872 item 2), building on the daemon `ref` param from #1909. Lets the user point the render-history view at a pushed **reporting branch** (`preview/*`) instead of the local working tree.

While wiring this I found the standalone **Preview History** timeline view (`HistoryPanel`) was fully built but **never contributed** — it wasn't in `package.json` and wasn't instantiated. Per the decision to go end-to-end, this PR activates it and adds the picker on its toolbar.

### Changes
- **Activate the view** — register `composePreview.historyPanel` as a collapsed webview in the Compose Preview container, gated on `config.composePreview.earlyFeatures.enabled` (reactive `when`, matching the existing early-access surfaces). Instantiate `HistoryPanel` in `extension.ts` over a stable wrapper around the live `historySource`, and keep its scope in sync with the active editor via a small `applyHistoryScope` helper.
- **Source plumbing** — `HistoryScope` gains `gitRef`. `buildHistorySource` passes it to the daemon `list`/`read`/`diff` calls and is **daemon-only** on that path: a git ref can't be read by the local FS reader, so the panel shows empty rather than misleading local entries when the daemon is down. `gitRef` is preserved across same-module refreshes (a module switch resets to local).
- **Picker** — new `composePreview.history.selectSourceRef` command + a toolbar button. It runs a quick-pick of local/remote `preview/*` branches (plus "Local (working tree)"); the toolbar button reflects the active source. Branch enumeration lives in `reportingBranches.ts` (via `git for-each-ref`).

### Decisions / scope notes
- Enumeration uses `child_process` `git for-each-ref` (no `vscode.git` dependency), covering `refs/heads/preview/*` and `refs/remotes/*/preview/*`.
- Live `historyAdded`/`historyPruned` push into the newly-activated panel is **not** wired here — it re-lists on becoming visible / on refresh. Fast-follow if wanted.

## Visual evidence
This change is visual, but the panel webview can't be rendered in this headless container (no chromium — same constraint as #1907). I wired the coverage in instead: a new **`history-source-ref`** preview-harness fixture drives the panel with `setSourceRef` + git-sourced entries, so the **CI visual-diff bot renders and diffs the new toolbar control** (active `preview/main` state) on this PR and every future one. See the `vscode-preview-diff` comment for the rendered capture.

## Test plan
- New `reportingBranches.test.ts` (7 cases): `listReportingBranches` against a synthesised repo (local + remote `preview/*`, sorted labels, non-preview filtered, empty + non-repo → `[]`) and `reportingBranchLabel` mapping. `git`-gated, skips cleanly without it.
- `tsc --noEmit` clean for host (`tsconfig.json`) and webview (`tsconfig.webview.json`).
- Full extension unit suite green (1559 passing).
- `prettier --check` clean.
- `buildHistorySource` ref-passing isn't unit-tested (it imports `vscode`, which the plain-mocha harness has no stub for); it's covered by tsc + the daemon-side tests in #1909 + the harness fixture.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CPjwnCtY5aiBTFkVrrFjhS)_