### PR TITLE
feat(vscode): show theme data-diff below the pixel diff in history panel

### DIFF
--- a/vscode-extension/media/preview.css
+++ b/vscode-extension/media/preview.css
@@ -1768,6 +1768,45 @@ preview-app {
     color: var(--vscode-charts-yellow, #cca700);
 }
 
+/* Theme data-diff (#1872) — mirrors the semantics section's add/remove/change
+ * colour coding; `.diff-theme-change` shows the previous → current value. */
+.diff-theme {
+    margin-top: 10px;
+    padding-top: 8px;
+    border-top: 1px solid var(--vscode-widget-border, rgba(128, 128, 128, 0.35));
+    font-size: calc(var(--vscode-font-size) - 1px);
+}
+.diff-theme-header {
+    color: var(--text-secondary);
+    margin-bottom: 4px;
+}
+.diff-theme-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+.diff-theme-row {
+    padding: 1px 0;
+}
+.diff-theme-label {
+    font-family: var(--vscode-editor-font-family, monospace);
+}
+.diff-theme-change {
+    margin: 2px 0 4px 16px;
+    color: var(--text-secondary);
+    font-family: var(--vscode-editor-font-family, monospace);
+    font-variant-numeric: tabular-nums;
+}
+.diff-theme-added .diff-theme-label {
+    color: var(--vscode-charts-green, #89d185);
+}
+.diff-theme-removed .diff-theme-label {
+    color: var(--vscode-charts-red, #f14c4c);
+}
+.diff-theme-changed .diff-theme-label {
+    color: var(--vscode-charts-yellow, #cca700);
+}
+
 @keyframes fadeIn {
     from {
         opacity: 0;

--- a/vscode-extension/preview-harness/fixtures/history-theme-diff.gen.mjs
+++ b/vscode-extension/preview-harness/fixtures/history-theme-diff.gen.mjs
@@ -1,0 +1,124 @@
+// Generator for `history-theme-diff.json`. Run with:
+//   node preview-harness/fixtures/history-theme-diff.gen.mjs > preview-harness/fixtures/history-theme-diff.json
+//
+// Drives the **history panel** webview (`history.js` / `<history-app>`) to capture the theme
+// data-diff section (#1872) that renders below the pixel diff when two history entries are diffed.
+// A `setEntries` populates the timeline; a `diffReady` carrying both entries' `compose/theme`
+// resolved tokens makes `historyDiffView.appendThemeDiffSection` paint the `.diff-theme` block.
+//
+// The token maps are shaped so the diff exercises all three kinds across categories:
+//   - changed: color `primary`, shape `small`, typography `bodyLarge` (weight 400 → 500)
+//   - added:   typography `labelSmall` (present only in this entry)
+//   - removed: color `tertiary` (present only in the previous entry)
+
+import { buildMobileMock } from "./_utils.mjs";
+
+const mock = buildMobileMock();
+const previewId = "com.example.OnboardingKt.WelcomeScreenPreview";
+const thisId = "20260430-101200-bbbbbbbb";
+const prevId = "20260430-101000-aaaaaaaa";
+
+function entry(id, timestamp, pngHash, trigger) {
+    return {
+        id,
+        previewId,
+        module: ":sample-android",
+        timestamp,
+        pngHash,
+        pngSize: 4218,
+        pngPath: `${id}.png`,
+        producer: "daemon",
+        trigger,
+        source: { kind: "fs", id: "fs:/workspace/.compose-preview-history" },
+        git: { branch: "feature/onboarding", shortCommit: "a1b2c3d", dirty: false },
+    };
+}
+
+// "Previous" (older) tokens — base side of the diff.
+const previousTheme = {
+    resolvedTokens: {
+        colorScheme: {
+            primary: "#6750A4",
+            secondary: "#625B71",
+            tertiary: "#7D5260",
+        },
+        typography: {
+            bodyLarge: {
+                fontFamily: "Roboto",
+                fontSize: 16,
+                fontSizeUnit: "sp",
+                fontWeight: "400",
+            },
+        },
+        shapes: {
+            small: "RoundedCorner(4.0.dp)",
+            medium: "RoundedCorner(12.0.dp)",
+        },
+    },
+};
+
+// "This entry" (newer) tokens — head side of the diff.
+const thisTheme = {
+    resolvedTokens: {
+        colorScheme: {
+            // primary changed; tertiary removed; secondary unchanged.
+            primary: "#4F378B",
+            secondary: "#625B71",
+        },
+        typography: {
+            // bodyLarge weight changed; labelSmall added.
+            bodyLarge: {
+                fontFamily: "Roboto",
+                fontSize: 16,
+                fontSizeUnit: "sp",
+                fontWeight: "500",
+            },
+            labelSmall: {
+                fontFamily: "Roboto",
+                fontSize: 11,
+                fontSizeUnit: "sp",
+                fontWeight: "500",
+            },
+        },
+        shapes: {
+            // small changed; medium unchanged.
+            small: "RoundedCorner(8.0.dp)",
+            medium: "RoundedCorner(12.0.dp)",
+        },
+    },
+};
+
+const fixture = {
+    name: "history-theme-diff",
+    description:
+        "History panel webview: two entries diffed, with the theme data-diff section rendered below the pixel diff. Exercises changed (color/shape/typography), added (typography token), and removed (color token) across all three token categories.",
+    app: "history-app",
+    bundle: "../media/webview/history.js",
+    dataset: { earlyFeatures: "true", minimalMode: "false" },
+    messages: [
+        {
+            command: "setEntries",
+            result: {
+                entries: [
+                    entry(thisId, "2026-04-30T10:12:00Z", "b".repeat(64), "fileChanged"),
+                    entry(prevId, "2026-04-30T10:10:00Z", "a".repeat(64), "renderNow"),
+                ],
+            },
+        },
+        {
+            // No host in the harness, so post `diffReady` directly (the same message the host sends
+            // after a "Diff vs previous" click). `setDiff` opens + fills the expansion.
+            command: "diffReady",
+            id: thisId,
+            against: "previous",
+            leftLabel: "This entry · 10:12",
+            leftImage: mock.png,
+            rightLabel: "Previous · 10:10",
+            rightImage: mock.png,
+            leftTheme: thisTheme,
+            rightTheme: previousTheme,
+        },
+    ],
+};
+
+process.stdout.write(JSON.stringify(fixture, null, 2) + "\n");

--- a/vscode-extension/preview-harness/fixtures/history-theme-diff.json
+++ b/vscode-extension/preview-harness/fixtures/history-theme-diff.json
@@ -1,0 +1,115 @@
+{
+  "name": "history-theme-diff",
+  "description": "History panel webview: two entries diffed, with the theme data-diff section rendered below the pixel diff. Exercises changed (color/shape/typography), added (typography token), and removed (color token) across all three token categories.",
+  "app": "history-app",
+  "bundle": "../media/webview/history.js",
+  "dataset": {
+    "earlyFeatures": "true",
+    "minimalMode": "false"
+  },
+  "messages": [
+    {
+      "command": "setEntries",
+      "result": {
+        "entries": [
+          {
+            "id": "20260430-101200-bbbbbbbb",
+            "previewId": "com.example.OnboardingKt.WelcomeScreenPreview",
+            "module": ":sample-android",
+            "timestamp": "2026-04-30T10:12:00Z",
+            "pngHash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            "pngSize": 4218,
+            "pngPath": "20260430-101200-bbbbbbbb.png",
+            "producer": "daemon",
+            "trigger": "fileChanged",
+            "source": {
+              "kind": "fs",
+              "id": "fs:/workspace/.compose-preview-history"
+            },
+            "git": {
+              "branch": "feature/onboarding",
+              "shortCommit": "a1b2c3d",
+              "dirty": false
+            }
+          },
+          {
+            "id": "20260430-101000-aaaaaaaa",
+            "previewId": "com.example.OnboardingKt.WelcomeScreenPreview",
+            "module": ":sample-android",
+            "timestamp": "2026-04-30T10:10:00Z",
+            "pngHash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "pngSize": 4218,
+            "pngPath": "20260430-101000-aaaaaaaa.png",
+            "producer": "daemon",
+            "trigger": "renderNow",
+            "source": {
+              "kind": "fs",
+              "id": "fs:/workspace/.compose-preview-history"
+            },
+            "git": {
+              "branch": "feature/onboarding",
+              "shortCommit": "a1b2c3d",
+              "dirty": false
+            }
+          }
+        ]
+      }
+    },
+    {
+      "command": "diffReady",
+      "id": "20260430-101200-bbbbbbbb",
+      "against": "previous",
+      "leftLabel": "This entry · 10:12",
+      "leftImage": "iVBORw0KGgoAAAANSUhEUgAAAWgAAAJYCAIAAADAFeuyAAAH9UlEQVR4nO3UQQ2DUBRFwa+gilDSbW1VAFIQURuwYIWGs+GHdG5GwEtecsbyXgGSMf0C4HGEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8jGfpwAiXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAA2bRwvD5fbjDrvz+7ZcKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5QkHwmF5woFwWJ5wIByWJxwIh+UJB8JhecKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5QkHwmF5woFwWJ5wIByWJxwIh+UJB8JhecKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5QkHwmF5woFwWJ5wIByWJxwIh+UJB8JhecKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5QkHwmF5woFwWJ5wIByWJxwIh+UJB8JhecKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5f1dOIDnEg4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gG5uZWZxwmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFneBUZcMccpTkvCAAAAAElFTkSuQmCC",
+      "rightLabel": "Previous · 10:10",
+      "rightImage": "iVBORw0KGgoAAAANSUhEUgAAAWgAAAJYCAIAAADAFeuyAAAH9UlEQVR4nO3UQQ2DUBRFwa+gilDSbW1VAFIQURuwYIWGs+GHdG5GwEtecsbyXgGSMf0C4HGEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8jGfpwAiXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAA2bRwvD5fbjDrvz+7ZcKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5QkHwmF5woFwWJ5wIByWJxwIh+UJB8JhecKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5QkHwmF5woFwWJ5wIByWJxwIh+UJB8JhecKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5QkHwmF5woFwWJ5wIByWJxwIh+UJB8JhecKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5QkHwmF5woFwWJ5wIByWJxwIh+UJB8JhecKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5f1dOIDnEg4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gG5uZWZxwmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFneBUZcMccpTkvCAAAAAElFTkSuQmCC",
+      "leftTheme": {
+        "resolvedTokens": {
+          "colorScheme": {
+            "primary": "#4F378B",
+            "secondary": "#625B71"
+          },
+          "typography": {
+            "bodyLarge": {
+              "fontFamily": "Roboto",
+              "fontSize": 16,
+              "fontSizeUnit": "sp",
+              "fontWeight": "500"
+            },
+            "labelSmall": {
+              "fontFamily": "Roboto",
+              "fontSize": 11,
+              "fontSizeUnit": "sp",
+              "fontWeight": "500"
+            }
+          },
+          "shapes": {
+            "small": "RoundedCorner(8.0.dp)",
+            "medium": "RoundedCorner(12.0.dp)"
+          }
+        }
+      },
+      "rightTheme": {
+        "resolvedTokens": {
+          "colorScheme": {
+            "primary": "#6750A4",
+            "secondary": "#625B71",
+            "tertiary": "#7D5260"
+          },
+          "typography": {
+            "bodyLarge": {
+              "fontFamily": "Roboto",
+              "fontSize": 16,
+              "fontSizeUnit": "sp",
+              "fontWeight": "400"
+            }
+          },
+          "shapes": {
+            "small": "RoundedCorner(4.0.dp)",
+            "medium": "RoundedCorner(12.0.dp)"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/vscode-extension/src/historyPanel.ts
+++ b/vscode-extension/src/historyPanel.ts
@@ -345,6 +345,10 @@ export class HistoryPanel implements vscode.WebviewViewProvider {
                 rightSemantics: rightId
                     ? readSidecarSemantics(scope, rightId)
                     : null,
+                // Likewise forward each entry's captured compose/theme tokens for the theme
+                // data-diff section (#1872), read from the sidecar for the same reason.
+                leftTheme: readSidecarTheme(scope, id),
+                rightTheme: rightId ? readSidecarTheme(scope, rightId) : null,
             });
         } catch (err) {
             this.view.webview.postMessage({
@@ -659,6 +663,22 @@ function readSidecarSemantics(scope: HistoryScope, id: string): unknown {
         return (
             (result?.entry as { semantics?: unknown } | undefined)?.semantics ??
             null
+        );
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Reads an entry's raw `compose/theme` resolved tokens straight from its on-disk sidecar (#1872),
+ * for the theme data-diff. Same rationale as [readSidecarSemantics]: the sidecar carries the full
+ * payload the daemon's `history/read` wire shape strips. Best-effort → null on any failure.
+ */
+function readSidecarTheme(scope: HistoryScope, id: string): unknown {
+    try {
+        const result = new HistoryReader(historyDirFor(scope)).read(id);
+        return (
+            (result?.entry as { theme?: unknown } | undefined)?.theme ?? null
         );
     } catch {
         return null;

--- a/vscode-extension/src/test/historyDiffThemePresenter.test.ts
+++ b/vscode-extension/src/test/historyDiffThemePresenter.test.ts
@@ -1,0 +1,51 @@
+// Coverage for the theme data-diff presenter (#1872) — pure mapping from a `ThemeDelta` to the
+// display rows the history panel renders. No DOM.
+
+import * as assert from "assert";
+
+import { computeThemeDiffData } from "../webview/preview/historyDiffThemePresenter";
+import { type ThemeDelta } from "../webview/shared/themeDiff";
+
+describe("computeThemeDiffData", () => {
+    it("returns an empty data set for null / empty deltas", () => {
+        const empty = computeThemeDiffData(null);
+        assert.strictEqual(empty.empty, true);
+        assert.deepStrictEqual(empty.rows, []);
+        assert.strictEqual(empty.addedCount, 0);
+    });
+
+    it("orders rows removed → added → changed with counts", () => {
+        const delta: ThemeDelta = {
+            schema: "compose-theme-diff/v1",
+            added: [{ category: "color", key: "tertiary", value: "#FFFF00" }],
+            removed: [{ category: "shape", key: "small", value: "Cut(4dp)" }],
+            changed: [
+                {
+                    category: "color",
+                    key: "primary",
+                    from: "#FF0000",
+                    to: "#0000FF",
+                },
+            ],
+        };
+        const data = computeThemeDiffData(delta);
+        assert.strictEqual(data.empty, false);
+        assert.strictEqual(data.addedCount, 1);
+        assert.strictEqual(data.removedCount, 1);
+        assert.strictEqual(data.changedCount, 1);
+        assert.deepStrictEqual(
+            data.rows.map((r) => r.kind),
+            ["removed", "added", "changed"],
+        );
+
+        const [removed, added, changed] = data.rows;
+        assert.deepStrictEqual(
+            { kind: removed.kind, key: removed.key, value: removed.value },
+            { kind: "removed", key: "small", value: "Cut(4dp)" },
+        );
+        assert.strictEqual(added.value, "#FFFF00");
+        assert.strictEqual(changed.value, null);
+        assert.strictEqual(changed.from, "#FF0000");
+        assert.strictEqual(changed.to, "#0000FF");
+    });
+});

--- a/vscode-extension/src/test/themeDiff.test.ts
+++ b/vscode-extension/src/test/themeDiff.test.ts
@@ -1,0 +1,123 @@
+// Coverage for the client-side theme data-diff (#1872) used by the history panel. Pure-data tests
+// (no DOM): a base/head pair of `compose/theme` payloads in, a `ThemeDelta` out.
+
+import * as assert from "assert";
+
+import {
+    diffTheme,
+    isThemePayload,
+    themeDeltaIsEmpty,
+    type ThemePayloadLike,
+} from "../webview/shared/themeDiff";
+
+function payload(resolvedTokens: unknown): ThemePayloadLike {
+    return { resolvedTokens } as ThemePayloadLike;
+}
+
+describe("diffTheme", () => {
+    it("detects changed, added, and removed tokens across categories", () => {
+        const base = payload({
+            colorScheme: { primary: "#FF0000", secondary: "#00FF00" },
+            typography: { bodyLarge: { fontFamily: "Roboto", fontSize: 14 } },
+            shapes: {
+                small: "RoundedCorner(4dp)",
+                large: "RoundedCorner(16dp)",
+            },
+        });
+        const head = payload({
+            // primary changed; secondary removed; tertiary added.
+            colorScheme: { primary: "#0000FF", tertiary: "#FFFF00" },
+            // bodyLarge font size changed.
+            typography: { bodyLarge: { fontFamily: "Roboto", fontSize: 16 } },
+            // large unchanged; small unchanged.
+            shapes: {
+                small: "RoundedCorner(4dp)",
+                large: "RoundedCorner(16dp)",
+            },
+        });
+
+        const delta = diffTheme(base, head);
+
+        assert.deepStrictEqual(delta.added, [
+            { category: "color", key: "tertiary", value: "#FFFF00" },
+        ]);
+        assert.deepStrictEqual(delta.removed, [
+            { category: "color", key: "secondary", value: "#00FF00" },
+        ]);
+        assert.strictEqual(delta.changed.length, 2);
+        // Colors come before typography in category order.
+        assert.deepStrictEqual(delta.changed[0], {
+            category: "color",
+            key: "primary",
+            from: "#FF0000",
+            to: "#0000FF",
+        });
+        assert.strictEqual(delta.changed[1].category, "typography");
+        assert.strictEqual(delta.changed[1].key, "bodyLarge");
+        assert.ok(delta.changed[1].from.includes("14"));
+        assert.ok(delta.changed[1].to.includes("16"));
+    });
+
+    it("returns an empty delta for identical token maps", () => {
+        const tokens = {
+            colorScheme: { primary: "#FF0000" },
+            typography: { bodyLarge: { fontFamily: "Roboto", fontSize: 14 } },
+            shapes: { small: "RoundedCorner(4dp)" },
+        };
+        const delta = diffTheme(payload(tokens), payload({ ...tokens }));
+        assert.ok(themeDeltaIsEmpty(delta));
+        assert.deepStrictEqual(delta.added, []);
+        assert.deepStrictEqual(delta.removed, []);
+        assert.deepStrictEqual(delta.changed, []);
+    });
+
+    it("tolerates missing categories on either side", () => {
+        const base = payload({ colorScheme: { primary: "#FF0000" } });
+        const head = payload({ shapes: { small: "Cut(4dp)" } });
+        const delta = diffTheme(base, head);
+        assert.deepStrictEqual(delta.removed, [
+            { category: "color", key: "primary", value: "#FF0000" },
+        ]);
+        assert.deepStrictEqual(delta.added, [
+            { category: "shape", key: "small", value: "Cut(4dp)" },
+        ]);
+        assert.deepStrictEqual(delta.changed, []);
+    });
+
+    it("formats typography changes as readable one-liners", () => {
+        const base = payload({
+            typography: {
+                titleLarge: {
+                    fontFamily: "Roboto",
+                    fontSize: 22,
+                    fontSizeUnit: "sp",
+                    fontWeight: "400",
+                },
+            },
+        });
+        const head = payload({
+            typography: {
+                titleLarge: {
+                    fontFamily: "Roboto",
+                    fontSize: 22,
+                    fontSizeUnit: "sp",
+                    fontWeight: "700",
+                },
+            },
+        });
+        const delta = diffTheme(base, head);
+        assert.strictEqual(delta.changed.length, 1);
+        assert.match(delta.changed[0].from, /Roboto · 22sp · w400/);
+        assert.match(delta.changed[0].to, /Roboto · 22sp · w700/);
+    });
+});
+
+describe("isThemePayload", () => {
+    it("accepts a { resolvedTokens } object and rejects others", () => {
+        assert.ok(isThemePayload({ resolvedTokens: { colorScheme: {} } }));
+        assert.ok(!isThemePayload({ resolvedTokens: null }));
+        assert.ok(!isThemePayload({}));
+        assert.ok(!isThemePayload(null));
+        assert.ok(!isThemePayload("nope"));
+    });
+});

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -1298,6 +1298,10 @@ export type HistoryToWebview =
           // when either render didn't capture semantics.
           leftSemantics?: unknown;
           rightSemantics?: unknown;
+          // Raw `compose/theme` payloads ({ resolvedTokens }) for each entry, when captured. Diffed
+          // client-side for the theme data-diff section (#1872). null/omitted when not captured.
+          leftTheme?: unknown;
+          rightTheme?: unknown;
       }
     | {
           command: "diffPairError";

--- a/vscode-extension/src/webview/history/behavior.ts
+++ b/vscode-extension/src/webview/history/behavior.ts
@@ -340,6 +340,8 @@ export function setupHistoryBehavior(): void {
                         msg.rightImage,
                         msg.leftSemantics,
                         msg.rightSemantics,
+                        msg.leftTheme,
+                        msg.rightTheme,
                     );
                 break;
             }

--- a/vscode-extension/src/webview/history/components/HistoryRow.ts
+++ b/vscode-extension/src/webview/history/components/HistoryRow.ts
@@ -154,6 +154,8 @@ export class HistoryRow extends LitElement {
         rightImage: string;
         leftSemantics?: unknown;
         rightSemantics?: unknown;
+        leftTheme?: unknown;
+        rightTheme?: unknown;
     } | null = null;
 
     /** Error text for the open diff expansion, populated by the host
@@ -225,6 +227,8 @@ export class HistoryRow extends LitElement {
                     this.diffViewConfig,
                     this._diffPayload.leftSemantics,
                     this._diffPayload.rightSemantics,
+                    this._diffPayload.leftTheme,
+                    this._diffPayload.rightTheme,
                 );
             }
         }
@@ -410,6 +414,8 @@ export class HistoryRow extends LitElement {
         rightImage: string,
         leftSemantics?: unknown,
         rightSemantics?: unknown,
+        leftTheme?: unknown,
+        rightTheme?: unknown,
     ): void {
         this._expandedKind = "diff";
         this._diffAgainst = against;
@@ -421,6 +427,8 @@ export class HistoryRow extends LitElement {
             rightImage,
             leftSemantics,
             rightSemantics,
+            leftTheme,
+            rightTheme,
         };
     }
 

--- a/vscode-extension/src/webview/history/historyDiffView.ts
+++ b/vscode-extension/src/webview/history/historyDiffView.ts
@@ -15,6 +15,7 @@
 // preview panel's diff overlay reaches for the same algorithm.
 
 import { computeSemanticsDiffData } from "../preview/historyDiffSemanticsPresenter";
+import { computeThemeDiffData } from "../preview/historyDiffThemePresenter";
 import { buildDiffModeBar, type DiffMode } from "../shared/diffModeBar";
 import {
     applyDiffStats,
@@ -22,6 +23,11 @@ import {
     type DiffStats,
 } from "../shared/pixelDiff";
 import { diffSemantics, type SemanticsPayload } from "../shared/semanticsDiff";
+import {
+    diffTheme,
+    isThemePayload,
+    type ThemeCategory,
+} from "../shared/themeDiff";
 import type { HistoryDiffSummary } from "../shared/types";
 import type { VsCodeApi } from "../shared/vscode";
 import { cssEscape } from "./historyData";
@@ -65,6 +71,8 @@ export function fillDiff(
     config: HistoryDiffViewConfig,
     leftSemantics?: unknown,
     rightSemantics?: unknown,
+    leftTheme?: unknown,
+    rightTheme?: unknown,
 ): void {
     const expansion = config.timelineEl.querySelector<HTMLElement>(
         '.expanded[data-id="' +
@@ -111,6 +119,7 @@ export function fillDiff(
         applyDiffStats(stats, s);
     });
     appendSemanticsDiffSection(expansion, leftSemantics, rightSemantics);
+    appendThemeDiffSection(expansion, leftTheme, rightTheme);
 }
 
 /**
@@ -188,6 +197,72 @@ function isSemanticsPayload(value: unknown): value is SemanticsPayload {
         typeof (value as { root: unknown }).root === "object" &&
         (value as { root: unknown }).root !== null
     );
+}
+
+const THEME_CATEGORY_LABEL: Record<ThemeCategory, string> = {
+    color: "color",
+    typography: "type",
+    shape: "shape",
+};
+
+/**
+ * Appends the theme data-diff (#1872) below the pixel diff (and the semantics section). Both
+ * entries' captured `compose/theme` resolved tokens are diffed client-side via [diffTheme]; the
+ * section is omitted entirely when either payload is missing (a render that didn't capture theme) so
+ * the pixel-only case is unchanged. A sibling of the pixel `body`, so the mode switches leave it
+ * intact.
+ */
+function appendThemeDiffSection(
+    expansion: HTMLElement,
+    leftTheme: unknown,
+    rightTheme: unknown,
+): void {
+    if (!isThemePayload(leftTheme) || !isThemePayload(rightTheme)) {
+        return;
+    }
+    let data: ReturnType<typeof computeThemeDiffData>;
+    try {
+        // base = older "Previous" (right), head = "This entry" (left): `added` reads as tokens newly
+        // present and `changed` as previous → current, matching the semantics direction.
+        data = computeThemeDiffData(diffTheme(rightTheme, leftTheme));
+    } catch {
+        return;
+    }
+    const section = document.createElement("div");
+    section.className = "diff-theme";
+    const head = document.createElement("div");
+    head.className = "diff-theme-header";
+    head.textContent = data.empty
+        ? "Theme · no changes"
+        : `Theme · ${data.addedCount} added · ${data.removedCount} removed · ${data.changedCount} changed`;
+    section.appendChild(head);
+    if (!data.empty) {
+        const list = document.createElement("ul");
+        list.className = "diff-theme-list";
+        for (const row of data.rows) {
+            const li = document.createElement("li");
+            li.className = `diff-theme-row diff-theme-${row.kind}`;
+            const sigil =
+                row.kind === "added" ? "+" : row.kind === "removed" ? "−" : "~";
+            const label = document.createElement("span");
+            label.className = "diff-theme-label";
+            const badge = THEME_CATEGORY_LABEL[row.category];
+            label.textContent =
+                row.kind === "changed"
+                    ? `${sigil} [${badge}] ${row.key}`
+                    : `${sigil} [${badge}] ${row.key} = ${row.value ?? ""}`;
+            li.appendChild(label);
+            if (row.kind === "changed") {
+                const change = document.createElement("div");
+                change.className = "diff-theme-change";
+                change.textContent = `${row.from ?? "∅"} → ${row.to ?? "∅"}`;
+                li.appendChild(change);
+            }
+            list.appendChild(li);
+        }
+        section.appendChild(list);
+    }
+    expansion.appendChild(section);
 }
 
 function renderHistoryDiffMode(

--- a/vscode-extension/src/webview/preview/historyDiffThemePresenter.ts
+++ b/vscode-extension/src/webview/preview/historyDiffThemePresenter.ts
@@ -1,0 +1,95 @@
+// Presenter for the history panel's theme data-diff section (#1872). Pure: turns a `ThemeDelta`
+// (from the client-side `themeDiff` differ) into display rows the webview renders beneath the pixel
+// diff. No DOM — mirrors `historyDiffSemanticsPresenter` so it's unit-testable without a browser.
+
+import {
+    type ThemeCategory,
+    type ThemeDelta,
+    type ThemeTokenChange,
+    type ThemeTokenSummary,
+} from "../shared/themeDiff";
+
+export type ThemeDiffRowKind = "added" | "removed" | "changed";
+
+export interface ThemeDiffRow {
+    kind: ThemeDiffRowKind;
+    category: ThemeCategory;
+    /** Token name, e.g. `primary` / `bodyLarge` / `small`. */
+    key: string;
+    /** Resolved value for added/removed rows; null for changed (use from/to). */
+    value: string | null;
+    /** Previous → current value for changed rows; null for added/removed. */
+    from: string | null;
+    to: string | null;
+}
+
+export interface ThemeDiffData {
+    empty: boolean;
+    addedCount: number;
+    removedCount: number;
+    changedCount: number;
+    /** Removed first, then added, then changed — matches the semantics section ordering. */
+    rows: ThemeDiffRow[];
+}
+
+const EMPTY: ThemeDiffData = {
+    empty: true,
+    addedCount: 0,
+    removedCount: 0,
+    changedCount: 0,
+    rows: [],
+};
+
+/** Derives the display rows for a theme delta. Null/empty delta → an empty data set. */
+export function computeThemeDiffData(
+    delta: ThemeDelta | null | undefined,
+): ThemeDiffData {
+    if (!delta) {
+        return EMPTY;
+    }
+    const removed = delta.removed ?? [];
+    const added = delta.added ?? [];
+    const changed = delta.changed ?? [];
+    const rows: ThemeDiffRow[] = [];
+    for (const token of removed) {
+        rows.push(summaryRow("removed", token));
+    }
+    for (const token of added) {
+        rows.push(summaryRow("added", token));
+    }
+    for (const change of changed) {
+        rows.push(changeRow(change));
+    }
+    return {
+        empty: rows.length === 0,
+        addedCount: added.length,
+        removedCount: removed.length,
+        changedCount: changed.length,
+        rows,
+    };
+}
+
+function summaryRow(
+    kind: "added" | "removed",
+    token: ThemeTokenSummary,
+): ThemeDiffRow {
+    return {
+        kind,
+        category: token.category,
+        key: token.key,
+        value: token.value,
+        from: null,
+        to: null,
+    };
+}
+
+function changeRow(change: ThemeTokenChange): ThemeDiffRow {
+    return {
+        kind: "changed",
+        category: change.category,
+        key: change.key,
+        value: null,
+        from: change.from,
+        to: change.to,
+    };
+}

--- a/vscode-extension/src/webview/shared/themeDiff.ts
+++ b/vscode-extension/src/webview/shared/themeDiff.ts
@@ -1,0 +1,186 @@
+// Client-side theme data-diff for the history panel (#1872), mirroring the semantics differ in
+// `semanticsDiff.ts`. Diffs two entries' captured `compose/theme` resolved-token maps so the panel
+// can show which Material 3 design tokens drifted between renders — no daemon round-trip.
+//
+// Tokens are matched by key within their category (Colors / Typography / Shapes). Colors and shapes
+// are flat `key → string` maps; typography is `key → object`, formatted into a compact display
+// string so a changed token reads as `old → new` like every other category. There is no Kotlin
+// `ThemeDiff` yet — this is the first implementation; a daemon/CLI port can follow for parity.
+
+export const THEME_DIFF_SCHEMA = "compose-theme-diff/v1";
+
+export type ThemeCategory = "color" | "typography" | "shape";
+
+/** A token present on only one side (added/removed). */
+export interface ThemeTokenSummary {
+    category: ThemeCategory;
+    key: string;
+    value: string;
+}
+
+/** A token present on both sides with a different resolved value. */
+export interface ThemeTokenChange {
+    category: ThemeCategory;
+    key: string;
+    from: string;
+    to: string;
+}
+
+export interface ThemeDelta {
+    schema: string;
+    added: ThemeTokenSummary[];
+    removed: ThemeTokenSummary[];
+    changed: ThemeTokenChange[];
+}
+
+/** Lenient view of `compose/theme`'s `resolvedTokens` — parsed straight from the sidecar JSON. */
+interface ResolvedTokensLike {
+    colorScheme?: unknown;
+    typography?: unknown;
+    shapes?: unknown;
+}
+
+/** Lenient view of the `compose/theme` payload as stored in `HistoryEntry.theme`. */
+export interface ThemePayloadLike {
+    resolvedTokens?: ResolvedTokensLike | null;
+}
+
+/** Narrows an untyped wire value to a `{ resolvedTokens }` theme payload. */
+export function isThemePayload(value: unknown): value is ThemePayloadLike {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "resolvedTokens" in value &&
+        typeof (value as { resolvedTokens: unknown }).resolvedTokens ===
+            "object" &&
+        (value as { resolvedTokens: unknown }).resolvedTokens !== null
+    );
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+    return typeof value === "object" && value !== null
+        ? (value as Record<string, unknown>)
+        : {};
+}
+
+/** Colors / shapes are already strings; null-safe stringify keeps the diff total. */
+function formatScalar(value: unknown): string {
+    return value == null ? "" : String(value);
+}
+
+/**
+ * Formats one typography token (`{ fontFamily, fontSize, fontWeight, … }`) into a compact, stable
+ * one-liner so a changed token diffs as `old → new`. Mirrors the fields `TypographyToken` carries;
+ * omitted fields drop out so the string only reflects what was captured.
+ */
+function formatTypography(value: unknown): string {
+    const t = asRecord(value);
+    const parts: string[] = [];
+    const push = (v: unknown, suffix: unknown = ""): void => {
+        if (v != null && v !== "") {
+            parts.push(`${String(v)}${suffix == null ? "" : String(suffix)}`);
+        }
+    };
+    push(t.fontFamily);
+    if (t.fontSize != null) {
+        push(t.fontSize, t.fontSizeUnit);
+    }
+    if (t.fontWeight != null && t.fontWeight !== "") {
+        parts.push(`w${String(t.fontWeight)}`);
+    }
+    if (
+        t.fontStyle != null &&
+        String(t.fontStyle) !== "" &&
+        String(t.fontStyle).toLowerCase() !== "normal"
+    ) {
+        parts.push(String(t.fontStyle));
+    }
+    if (t.lineHeight != null) {
+        parts.push(
+            `lh=${String(t.lineHeight)}${formatScalar(t.lineHeightUnit)}`,
+        );
+    }
+    if (t.letterSpacing != null) {
+        parts.push(
+            `ls=${String(t.letterSpacing)}${formatScalar(t.letterSpacingUnit)}`,
+        );
+    }
+    return parts.join(" · ");
+}
+
+function normalize(
+    map: unknown,
+    format: (v: unknown) => string,
+): Map<string, string> {
+    const out = new Map<string, string>();
+    const record = asRecord(map);
+    for (const key of Object.keys(record)) {
+        out.set(key, format(record[key]));
+    }
+    return out;
+}
+
+function diffCategory(
+    category: ThemeCategory,
+    base: Map<string, string>,
+    head: Map<string, string>,
+    delta: Pick<ThemeDelta, "added" | "removed" | "changed">,
+): void {
+    const keys = [...new Set([...base.keys(), ...head.keys()])].sort();
+    for (const key of keys) {
+        const from = base.get(key);
+        const to = head.get(key);
+        if (from === undefined && to !== undefined) {
+            delta.added.push({ category, key, value: to });
+        } else if (from !== undefined && to === undefined) {
+            delta.removed.push({ category, key, value: from });
+        } else if (from !== undefined && to !== undefined && from !== to) {
+            delta.changed.push({ category, key, from, to });
+        }
+    }
+}
+
+/**
+ * Diffs two `compose/theme` payloads. `base` is the older entry, `head` the newer, so `added` reads
+ * as tokens newly present and `changed` as `old → new` — matching how the panel labels "this entry
+ * vs the previous". Categories are diffed in Colors → Typography → Shapes order.
+ */
+export function diffTheme(
+    base: ThemePayloadLike,
+    head: ThemePayloadLike,
+): ThemeDelta {
+    const b = asRecord(base.resolvedTokens);
+    const h = asRecord(head.resolvedTokens);
+    const delta: Pick<ThemeDelta, "added" | "removed" | "changed"> = {
+        added: [],
+        removed: [],
+        changed: [],
+    };
+    diffCategory(
+        "color",
+        normalize(b.colorScheme, formatScalar),
+        normalize(h.colorScheme, formatScalar),
+        delta,
+    );
+    diffCategory(
+        "typography",
+        normalize(b.typography, formatTypography),
+        normalize(h.typography, formatTypography),
+        delta,
+    );
+    diffCategory(
+        "shape",
+        normalize(b.shapes, formatScalar),
+        normalize(h.shapes, formatScalar),
+        delta,
+    );
+    return { schema: THEME_DIFF_SCHEMA, ...delta };
+}
+
+export function themeDeltaIsEmpty(delta: ThemeDelta): boolean {
+    return (
+        (delta.added?.length ?? 0) === 0 &&
+        (delta.removed?.length ?? 0) === 0 &&
+        (delta.changed?.length ?? 0) === 0
+    );
+}


### PR DESCRIPTION
## Summary

Adds a **Theme** data-diff section to the History panel, beneath the pixel diff and the existing semantics section (#1872). When two entries are diffed, it shows which `compose/theme` resolved tokens drifted between renders — added / removed / changed across **Colors, Typography, and Shapes**, matched by token key. Mirrors the semantics data-diff stack (#1902/#1904), and is fully client-side (reads each entry's sidecar; no daemon round-trip).

This is the first of two slices for the remaining "a11y / theme data-diffs in the panel" epic item (now unblocked by stable refs, #1784). **a11y follows in a fast-follow PR**, reusing the `diffReady` → `setDiff` → `fillDiff` wiring established here.

### Changes
- **`themeDiff.ts`** (new, shared, pure) — normalises each token category to `key → string` (typography objects formatted to a compact one-liner) and emits `added` / `removed` / `changed`, ordered Colors → Typography → Shapes. Unit-tested.
- **`historyDiffThemePresenter.ts`** (new, pure) — `ThemeDelta` → display rows; **`appendThemeDiffSection`** in `historyDiffView.ts` renders the `.diff-theme` block with add/remove/change colour coding matching the semantics section. CSS added to `preview.css`.
- **Wiring** — thread `leftTheme`/`rightTheme` through the `diffReady` message (`types.ts`), `HistoryRow.setDiff` + `_diffPayload` + the `fillDiff` call, `behavior.ts`, and host `runPairDiff` via a new `readSidecarTheme` (same sidecar-read rationale as semantics — `history/read` strips these payloads from the wire).
- The section is omitted entirely when either entry lacks captured theme data, so the pixel-only / no-theme case is unchanged.

## Visual evidence
Visual change, but the panel webview can't render in this headless container (no chromium). Coverage is wired in: a new **`history-theme-diff`** preview-harness fixture drives the panel with a `diffReady` carrying two `compose/theme` payloads (exercising changed color/shape/typography, an added typography token, a removed color token), so the **CI `vscode-preview-diff` bot renders and diffs the new `.diff-theme` section** here and on every future PR. See its comment for the capture.

## Test plan
- New `themeDiff.test.ts` (5 cases) + `historyDiffThemePresenter.test.ts` (2 cases): cross-category add/remove/change, identical → empty, missing categories tolerated, typography formatting, presenter row ordering/counts.
- `tsc --noEmit` clean (host + webview); full unit suite green (1566 passing); `prettier --check` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CPjwnCtY5aiBTFkVrrFjhS)_