### PR TITLE
feat(daemon): commit-walk timeline read for the reporting branch

### DIFF
--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/GitRefHistorySource.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/GitRefHistorySource.kt
@@ -443,7 +443,7 @@ class GitRefHistorySource(
         }
       if (parsed != null) entries += timelineEntry(parsed, c.take(7))
     }
-    return entries
+    return linkPrevious(entries)
   }
 
   /** Stamps a parsed branch entry with its commit-walk id + git source (#1868). */
@@ -452,6 +452,25 @@ class GitRefHistorySource(
       id = "$shortCommit:${entry.previewId}",
       source = HistorySourceInfo(kind = "git", id = "$id@$shortCommit"),
     )
+
+  /**
+   * Rewrites each entry's [HistoryEntry.previousId] to the adjacent-older timeline id for the same
+   * preview (#1868). The raw value carried in `entry.json` is the producing LocalFs timestamp id,
+   * which a git-ref [read] can't resolve (it resolves `<shortCommit>:<previewId>` ids), so a client
+   * following `previousId` for "diff vs previous" would otherwise get a not-found. The oldest entry
+   * of each preview gets `previousId = null`. Input is newest-first; output preserves that order.
+   */
+  private fun linkPrevious(newestFirst: List<HistoryEntry>): List<HistoryEntry> {
+    val olderId = HashMap<String, String>() // previewId -> id of the next-older entry seen so far
+    // Walk oldest-first so each entry's "previous" is the older neighbour we already passed.
+    val relinked =
+      newestFirst.asReversed().map { entry ->
+        val prev = olderId[entry.previewId]
+        olderId[entry.previewId] = entry.id
+        entry.copy(previousId = prev)
+      }
+    return relinked.asReversed()
+  }
 
   /**
    * Legacy reader: parse the aggregate `_index.jsonl`, tolerating truncated lines; newest-first.

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/GitRefHistorySource.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/GitRefHistorySource.kt
@@ -287,7 +287,7 @@ class GitRefHistorySource(
 
   override fun list(filter: HistoryFilter): HistoryListPage {
     val refCommit = refHeadCommit() ?: return emptyPage()
-    val entries = listEntries(refCommit).map { rewriteSource(it, refCommit) }
+    val entries = timelineEntries(refCommit)
     val matched = entries.filter { HistoryFilters.matches(it, filter) }
     val totalCount = matched.size
     val slice = HistoryFilters.paginate(matched, filter)
@@ -299,18 +299,54 @@ class GitRefHistorySource(
   }
 
   override fun read(entryId: String, includeBytes: Boolean): HistoryReadResult? {
+    // Commit-walk form `<shortCommit>:<previewId>` (#1868) — resolve straight to the blobs at that
+    // commit, no need to materialise the whole timeline.
+    val sep = entryId.indexOf(':')
+    if (sep > 0) {
+      return readAtCommit(
+        shortCommit = entryId.substring(0, sep),
+        previewId = entryId.substring(sep + 1),
+        includeBytes = includeBytes,
+      )
+    }
+    // Legacy / tip id (no commit prefix) — resolve against the listing (legacy `_index.jsonl`
+    // refs).
     val refCommit = refHeadCommit() ?: return null
-    val match = listEntries(refCommit).firstOrNull { it.id == entryId } ?: return null
-    val full = rewriteSource(match, refCommit)
+    val match = timelineEntries(refCommit).firstOrNull { it.id == entryId } ?: return null
     val dir = PreviewIdSanitiser.sanitise(match.previewId)
-    // New layout stores the PNG at <dir>/render.png; the legacy format at <dir>/<entryId>.png. The
-    // entry's own pngPath carries whichever was written, so resolve relative to it.
+    // Legacy format stores the PNG at <dir>/<entryId>.png; the entry's own pngPath carries it.
     val pngRel = match.pngPath.takeIf { it.isNotBlank() } ?: RENDER_FILENAME
     val pngFile = extractBlobToCache(refCommit, "$dir/$pngRel") ?: return null
     val bytes = if (includeBytes) Files.readAllBytes(pngFile) else null
     return HistoryReadResult(
-      entry = full,
-      previewMetadata = full.previewMetadata,
+      entry = match,
+      previewMetadata = match.previewMetadata,
+      pngPath = pngFile.toAbsolutePath().toString(),
+      pngBytes = bytes,
+    )
+  }
+
+  /** Reads one timeline entry addressed by `<shortCommit>:<previewId>` (#1868). */
+  private fun readAtCommit(
+    shortCommit: String,
+    previewId: String,
+    includeBytes: Boolean,
+  ): HistoryReadResult? {
+    val dir = PreviewIdSanitiser.sanitise(previewId)
+    val text = catFile(shortCommit, "$dir/entry.json") ?: return null
+    val parsed =
+      try {
+        JSON.decodeFromString(HistoryEntry.serializer(), text)
+      } catch (_: Throwable) {
+        return null
+      }
+    val entry = timelineEntry(parsed, shortCommit)
+    val pngRel = parsed.pngPath.takeIf { it.isNotBlank() } ?: RENDER_FILENAME
+    val pngFile = extractBlobToCache(shortCommit, "$dir/$pngRel") ?: return null
+    val bytes = if (includeBytes) Files.readAllBytes(pngFile) else null
+    return HistoryReadResult(
+      entry = entry,
+      previewMetadata = entry.previewMetadata,
       pngPath = pngFile.toAbsolutePath().toString(),
       pngBytes = bytes,
     )
@@ -355,41 +391,67 @@ class GitRefHistorySource(
     return out.takeIf { it.isNotEmpty() }
   }
 
-  /** Reads the current branch state: every `<dir>/entry.json`, newest-first by timestamp. */
-  private fun listEntries(refCommit: String): List<HistoryEntry> {
+  /**
+   * Reconstructs the preview timeline (#1868) by walking the ref's commit history: every commit
+   * that changed a `<dir>/entry.json` contributes one entry per changed preview, addressed by
+   * `<shortCommit>:<previewId>`, newest-first (git-log order), capped at [MAX_TIMELINE_DEPTH].
+   * Cached per ref HEAD (invalidated on write). Falls back to the legacy `_index.jsonl` tip read
+   * for refs that predate the git-as-the-log layout (those have no `entry.json` to walk).
+   */
+  private fun timelineEntries(refCommit: String): List<HistoryEntry> {
     cachedEntries.get()?.let { if (it.refCommit == refCommit) return it.entries }
-    val tree = runGit("ls-tree", "-r", "--name-only", refCommit)
-    if (tree == null) {
-      cachedEntries.set(CachedEntries(refCommit, emptyList()))
-      return emptyList()
+    val walked = walkTimeline(refCommit)
+    val resolved = walked.ifEmpty {
+      readLegacyIndex(refCommit).map { rewriteSource(it, refCommit) }
     }
-    val entries =
-      tree
-        .split('\n')
-        .map { it.trim() }
-        .filter { it.endsWith("/entry.json") }
-        .mapNotNull { path ->
-          catFile(refCommit, path)?.let { text ->
-            try {
-              JSON.decodeFromString(HistoryEntry.serializer(), text)
-            } catch (t: Throwable) {
-              System.err.println(
-                "compose-ai-daemon: GitRefHistorySource.list($ref): malformed $path " +
-                  "(${t.javaClass.simpleName}: ${t.message})"
-              )
-              null
-            }
-          }
-        }
-        .sortedByDescending { it.timestamp }
-    // Backward compatibility: a ref written under the legacy read-only format (an aggregate
-    // `_index.jsonl` + `<entryId>.{png,json}` per preview dir, the layout the old read-only
-    // GitRefHistorySource documented) has no `entry.json` files, so the scan above is empty.
-    // Fall back to parsing `_index.jsonl` so existing preview/* refs keep reading.
-    val resolved = entries.ifEmpty { readLegacyIndex(refCommit) }
     cachedEntries.set(CachedEntries(refCommit, resolved))
     return resolved
   }
+
+  /**
+   * Git-log walk over `entry.json` changes — see [timelineEntries]. Each commit's changed
+   * `<dir>/entry.json` blobs are read and stamped with a `<shortCommit>:<previewId>` id. A render
+   * that produced no diff made no commit, so the walk yields exactly one entry per *changed*
+   * render.
+   */
+  private fun walkTimeline(refCommit: String): List<HistoryEntry> {
+    // `%x00%H` prefixes each commit's section with NUL+sha; `--name-only` then lists the files it
+    // changed (one per line). Walking newest-first and capped keeps the read cost bounded.
+    val out =
+      runGit("log", "--format=%x00%H", "--name-only", "--max-count=$MAX_TIMELINE_DEPTH", refCommit)
+        ?: return emptyList()
+    val entries = mutableListOf<HistoryEntry>()
+    var commit: String? = null
+    for (raw in out.split('\n')) {
+      if (raw.startsWith(' ')) {
+        commit = raw.substring(1).trim().ifEmpty { null }
+        continue
+      }
+      val path = raw.trim()
+      val c = commit
+      if (c == null || !path.endsWith("/entry.json")) continue
+      val text = catFile(c, path) ?: continue
+      val parsed =
+        try {
+          JSON.decodeFromString(HistoryEntry.serializer(), text)
+        } catch (t: Throwable) {
+          System.err.println(
+            "compose-ai-daemon: GitRefHistorySource.walk($ref): malformed $path@${c.take(7)} " +
+              "(${t.javaClass.simpleName}: ${t.message})"
+          )
+          null
+        }
+      if (parsed != null) entries += timelineEntry(parsed, c.take(7))
+    }
+    return entries
+  }
+
+  /** Stamps a parsed branch entry with its commit-walk id + git source (#1868). */
+  private fun timelineEntry(entry: HistoryEntry, shortCommit: String): HistoryEntry =
+    entry.copy(
+      id = "$shortCommit:${entry.previewId}",
+      source = HistorySourceInfo(kind = "git", id = "$id@$shortCommit"),
+    )
 
   /**
    * Legacy reader: parse the aggregate `_index.jsonl`, tolerating truncated lines; newest-first.
@@ -535,6 +597,14 @@ class GitRefHistorySource(
 
     /** Bumped on incompatible reporting-branch layout changes. */
     const val REPORTING_BRANCH_FORMAT_VERSION: Int = 1
+
+    /**
+     * Depth cap for the commit-walk timeline read (#1868) — the newest N commits of the ref are
+     * walked when reconstructing a preview's history. Bounds read cost on long-lived branches;
+     * older history stays reachable by tightening the `since`/`until` filter against a re-orphaned
+     * ref.
+     */
+    const val MAX_TIMELINE_DEPTH: Int = 500
 
     /**
      * Comma/semicolon-separated list of refs (e.g.

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/GitRefHistorySourceTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/GitRefHistorySourceTest.kt
@@ -143,11 +143,14 @@ class GitRefHistorySourceTest {
     // Round-trips through the source's own read surface, stamped as a git source.
     val page = src.list(HistoryFilter())
     assertEquals(1, page.totalCount)
-    assertEquals(e.id, page.entries[0].id)
-    assertEquals("git", page.entries[0].source.kind)
-    assertTrue(page.entries[0].source.id.startsWith("git:$ref"))
+    val listed = page.entries[0]
+    // Commit-walk timeline (#1868): entries are addressed by `<shortCommit>:<previewId>`.
+    assertEquals("com.example.A", listed.previewId)
+    assertTrue(listed.id.endsWith(":com.example.A"))
+    assertEquals("git", listed.source.kind)
+    assertTrue(listed.source.id.startsWith("git:$ref"))
 
-    val read = src.read(e.id, includeBytes = true)
+    val read = src.read(listed.id, includeBytes = true)
     assertNotNull(read)
     assertTrue(File(read!!.pngPath).exists())
     assertEquals("render-A", String(read.pngBytes!!))
@@ -201,9 +204,49 @@ class GitRefHistorySourceTest {
     )
 
     val page = src.list(HistoryFilter())
-    assertEquals("current-state read → one entry per preview", 1, page.totalCount)
-    assertEquals(second.id, page.entries[0].id)
+    // Commit-walk timeline (#1868): both renders of the preview are visible (one per commit), even
+    // though the tip tree keeps only the latest render.png.
+    assertEquals("timeline read → one entry per changed render", 2, page.totalCount)
+    assertEquals("com.example.Card", page.entries[0].previewId)
+    assertTrue(page.entries[0].id.endsWith(":com.example.Card"))
     assertEquals("2", capture("git", "-C", repoRoot.toString(), "rev-list", "--count", ref).trim())
+  }
+
+  // -------------------------------------------------------------------------
+  // Commit-walk timeline read (#1868)
+  // -------------------------------------------------------------------------
+
+  @Test
+  fun commit_walk_exposes_full_timeline_and_reads_an_older_point() {
+    val src = source(SyncModeOf.WRITE_LOCAL)
+    val previewId = "com.example.Timeline"
+    // Three distinct renders of the same preview → three commits (skip-if-no-diff would collapse
+    // identical ones, so the bytes differ).
+    val v1 =
+      entry("20260430-100000-11111111", previewId, "v1".toByteArray(), "2026-04-30T10:00:00Z")
+    val v2 =
+      entry("20260430-100100-22222222", previewId, "v2".toByteArray(), "2026-04-30T10:01:00Z")
+    val v3 =
+      entry("20260430-100200-33333333", previewId, "v3".toByteArray(), "2026-04-30T10:02:00Z")
+    assertEquals(WriteResult.WRITTEN, src.write(v1, "v1".toByteArray()))
+    assertEquals(WriteResult.WRITTEN, src.write(v2, "v2".toByteArray()))
+    assertEquals(WriteResult.WRITTEN, src.write(v3, "v3".toByteArray()))
+
+    val page = src.list(HistoryFilter())
+    // The tip tree still holds one render.png, but the timeline exposes all three commits.
+    assertEquals(3, page.totalCount)
+    assertTrue(page.entries.all { it.previewId == previewId })
+    assertTrue(page.entries.all { it.id.endsWith(":$previewId") })
+    // Newest commit first.
+    assertEquals("2026-04-30T10:02:00Z", page.entries[0].timestamp)
+    assertEquals("2026-04-30T10:00:00Z", page.entries[2].timestamp)
+
+    // Read the *oldest* point by its `<shortCommit>:<previewId>` id → its own bytes, not the tip's.
+    val oldest = page.entries[2]
+    val read = src.read(oldest.id, includeBytes = true)
+    assertNotNull(read)
+    assertEquals("v1", String(read!!.pngBytes!!))
+    assertEquals("git", read.entry.source.kind)
   }
 
   @Test
@@ -237,7 +280,7 @@ class GitRefHistorySourceTest {
         "fs",
         all.entries.first { it.id == shared.id }.source.kind,
       )
-      assertEquals("git", all.entries.first { it.id == gitOnly.id }.source.kind)
+      assertEquals("git", all.entries.first { it.previewId == "com.example.Y" }.source.kind)
 
       val gitPage = manager.list(HistoryFilter(sourceKind = "git"))
       assertEquals(2, gitPage.totalCount)
@@ -326,19 +369,25 @@ class GitRefHistorySourceTest {
       val page = manager.list(HistoryFilter(ref = ref))
       assertEquals(2, page.totalCount)
       assertTrue(page.entries.all { it.source.kind == "git" })
-      assertEquals(setOf(entryA.id, entryB.id), page.entries.map { it.id }.toSet())
+      // Commit-walk ids are `<shortCommit>:<previewId>`; match on the stable previewId.
+      assertEquals(
+        setOf("com.example.A", "com.example.B"),
+        page.entries.map { it.previewId }.toSet(),
+      )
 
       // Other filter dimensions still apply within the ref's entries.
       val narrowed = manager.list(HistoryFilter(ref = ref, previewId = "com.example.A"))
       assertEquals(1, narrowed.totalCount)
       assertEquals("com.example.A", narrowed.entries.single().previewId)
 
-      // A ref-scoped read resolves the bytes; the same id without a ref stays invisible.
-      val read = manager.read(entryA.id, includeBytes = true, ref = ref)
+      // A ref-scoped read resolves the bytes by the timeline id; an id without a ref stays
+      // invisible.
+      val aId = narrowed.entries.single().id
+      val read = manager.read(aId, includeBytes = true, ref = ref)
       assertNotNull(read)
       assertEquals("render-A", String(read!!.pngBytes!!))
       assertEquals("git", read.entry.source.kind)
-      assertNull(manager.read(entryA.id, includeBytes = false))
+      assertNull(manager.read(aId, includeBytes = false))
     } finally {
       localDir.toFile().deleteRecursively()
     }

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/GitRefHistorySourceTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/GitRefHistorySourceTest.kt
@@ -241,6 +241,12 @@ class GitRefHistorySourceTest {
     assertEquals("2026-04-30T10:02:00Z", page.entries[0].timestamp)
     assertEquals("2026-04-30T10:00:00Z", page.entries[2].timestamp)
 
+    // previousId is relinked to the adjacent-older timeline id (resolvable on the ref), not the raw
+    // LocalFs timestamp id; the oldest entry has none.
+    assertEquals(page.entries[1].id, page.entries[0].previousId)
+    assertEquals(page.entries[2].id, page.entries[1].previousId)
+    assertNull(page.entries[2].previousId)
+
     // Read the *oldest* point by its `<shortCommit>:<previewId>` id → its own bytes, not the tip's.
     val oldest = page.entries[2]
     val read = src.read(oldest.id, includeBytes = true)

--- a/docs/daemon/REPORTING-BRANCH.md
+++ b/docs/daemon/REPORTING-BRANCH.md
@@ -144,8 +144,10 @@ feeds the hosted "drift over time" surface (design-parity#13).
 git-as-the-log layout above via git plumbing (a throwaway index +
 `hash-object` / `read-tree` / `update-index` / `write-tree` / `commit-tree` /
 `update-ref`, never touching the working tree), commits one change per render
-with content-based skip-if-no-diff, and reads back the **current** branch state
-(one entry per preview). Enable it with `composeai.daemon.gitRefHistorySyncMode=WRITE_LOCAL`
+with content-based skip-if-no-diff. It reads back the per-preview **timeline** by walking the ref's
+commit history (#1868): `list` walks the newest commits (capped at `MAX_TIMELINE_DEPTH`) and emits
+one entry per *changed* render, addressed by `<shortCommit>:<previewId>`, and `read` resolves that id
+straight to the blobs at that commit. Enable it with `composeai.daemon.gitRefHistorySyncMode=WRITE_LOCAL`
 alongside `composeai.daemon.gitRefHistory=<ref>`. The skip-if-no-diff predicate matches
 `LocalFsHistorySource`'s (pixels + structural semantics) so the two writable sources never
 disagree on what counts as a duplicate. The reader also falls back to the legacy read-only
@@ -155,8 +157,5 @@ Still to land (follow-ups):
 
 - **`WRITE_PUSH`** — also `git push` the ref, with fetch–rebase–retry on a push
   race (needs a remote + credentials).
-- **Commit-walk timeline read** — `list` / `read` over the full history of a
-  preview (and the `<shortCommit>:<previewId>` entryId addressing), rather than
-  only the current state. Spec'd here; tracked under #1868.
 - **Burst debounce** — batch a render burst into one commit instead of one
   commit per render.


### PR DESCRIPTION
## Summary

Implements the **commit-walk timeline read** for the reporting branch (#1868) — the last remaining follow-up in that issue (the layout/contract were already spec'd in `docs/daemon/REPORTING-BRANCH.md`).

Previously `GitRefHistorySource` read only the ref **tip** (one `entry.json` per preview = current state), so a reporting branch exposed a single entry per preview and "diff vs previous" had nothing to compare against. Now it reconstructs each preview's full history by **walking the ref's commit log**:

- `list()` walks the newest commits (capped at `MAX_TIMELINE_DEPTH = 500`), emitting one entry per *changed* render — addressed by `<shortCommit>:<previewId>` per the spec.
- `read()` parses that id and resolves straight to the `entry.json` + `render.png` blobs at the commit (`readAtCommit`); an id without a `:` falls back to the legacy `_index.jsonl` tip read, **preserved unchanged** for refs that predate the git-as-the-log layout.

This unblocks render-history diffs (pixel + the semantics/theme data-diffs) on reporting branches — the gap Codex flagged on #1912, which was blocked here rather than at the panel's sidecar read.

### Changes
- `GitRefHistorySource.kt` — replace the tip-only `listEntries` with `timelineEntries` + `walkTimeline` (git-log over `entry.json` changes, NUL-delimited, depth-capped, cached per ref HEAD); add `timelineEntry` (stamps `<shortCommit>:<previewId>` id + git source) and `readAtCommit`; add the `MAX_TIMELINE_DEPTH` constant. Legacy fallback retained.
- `REPORTING-BRANCH.md` — move the commit-walk read from "still to land" into the implemented Status.

## Test plan
- `GitRefHistorySourceTest` (daemon:core), git-gated:
  - **New** `commit_walk_exposes_full_timeline_and_reads_an_older_point` — writes three renders of one preview (three commits), asserts the timeline returns all three newest-first, and reads the *oldest* by its `<shortCommit>:<previewId>` id to get *its* bytes (not the tip's).
  - Updated the WRITE_LOCAL round-trip / overwrite / cross-source / on-demand-ref cases for the new id scheme (match on `previewId` / `endsWith(":<previewId>")`); the overwrite case now asserts the timeline exposes **both** renders while the tip tree keeps one.
  - `reads_legacy_index_format_as_fallback` unchanged — confirms the legacy tip read still works.
- `daemon:core` history + `JsonRpcServerHistory` suites pass; `ktfmt` clean.
- The harness integration test `S10MainHistoryReadTest` (legacy-format, exercises the fallback) couldn't run locally (needs the Android SDK); it's covered by the unit-level legacy test and runs in CI.

Daemon-only; no protocol change (`entryId` is opaque on the wire) and no visual surface.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CPjwnCtY5aiBTFkVrrFjhS)_