### PR TITLE
feat(vscode): show a11y data-diff below the pixel diff in history panel

### DIFF
--- a/vscode-extension/media/preview.css
+++ b/vscode-extension/media/preview.css
@@ -1807,6 +1807,46 @@ preview-app {
     color: var(--vscode-charts-yellow, #cca700);
 }
 
+/* Accessibility data-diff (#1872) — mirrors the semantics section's add/remove/
+ * change colour coding; `.diff-a11y-fields` lists per-field label/role/states
+ * changes. */
+.diff-a11y {
+    margin-top: 10px;
+    padding-top: 8px;
+    border-top: 1px solid var(--vscode-widget-border, rgba(128, 128, 128, 0.35));
+    font-size: calc(var(--vscode-font-size) - 1px);
+}
+.diff-a11y-header {
+    color: var(--text-secondary);
+    margin-bottom: 4px;
+}
+.diff-a11y-list,
+.diff-a11y-fields {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+.diff-a11y-fields {
+    margin: 2px 0 4px 16px;
+    color: var(--text-secondary);
+    font-variant-numeric: tabular-nums;
+}
+.diff-a11y-row {
+    padding: 1px 0;
+}
+.diff-a11y-label {
+    font-family: var(--vscode-editor-font-family, monospace);
+}
+.diff-a11y-added .diff-a11y-label {
+    color: var(--vscode-charts-green, #89d185);
+}
+.diff-a11y-removed .diff-a11y-label {
+    color: var(--vscode-charts-red, #f14c4c);
+}
+.diff-a11y-changed .diff-a11y-label {
+    color: var(--vscode-charts-yellow, #cca700);
+}
+
 @keyframes fadeIn {
     from {
         opacity: 0;

--- a/vscode-extension/preview-harness/fixtures/history-a11y-diff.gen.mjs
+++ b/vscode-extension/preview-harness/fixtures/history-a11y-diff.gen.mjs
@@ -1,0 +1,129 @@
+// Generator for `history-a11y-diff.json`. Run with:
+//   node preview-harness/fixtures/history-a11y-diff.gen.mjs > preview-harness/fixtures/history-a11y-diff.json
+//
+// Drives the **history panel** webview (`history.js` / `<history-app>`) to capture the a11y
+// data-diff section (#1872) that renders below the pixel diff when two history entries are diffed.
+// A `setEntries` populates the timeline; a `diffReady` carrying both entries' `a11y/hierarchy` node
+// lists makes `historyDiffView.appendA11yDiffSection` paint the `.diff-a11y` block.
+//
+// The node lists are shaped so the diff exercises all three kinds (matched by stable ref, #1784):
+//   - changed: the `submit` button's label "Submit" → "Send" and states Enabled → Disabled
+//   - added:   a `hero` image present only in this (newer) entry
+//   - removed: a `caption` present only in the previous (older) entry
+
+import { buildMobileMock } from "./_utils.mjs";
+
+const mock = buildMobileMock();
+const previewId = "com.example.OnboardingKt.WelcomeScreenPreview";
+const thisId = "20260430-101200-bbbbbbbb";
+const prevId = "20260430-101000-aaaaaaaa";
+
+function entry(id, timestamp, pngHash, trigger) {
+    return {
+        id,
+        previewId,
+        module: ":sample-android",
+        timestamp,
+        pngHash,
+        pngSize: 4218,
+        pngPath: `${id}.png`,
+        producer: "daemon",
+        trigger,
+        source: { kind: "fs", id: "fs:/workspace/.compose-preview-history" },
+        git: { branch: "feature/onboarding", shortCommit: "a1b2c3d", dirty: false },
+    };
+}
+
+// "Previous" (older) hierarchy — base side of the diff.
+const previousA11y = {
+    nodes: [
+        {
+            ref: "a1",
+            role: "Button",
+            label: "Submit",
+            states: ["Enabled"],
+            merged: true,
+            boundsInScreen: "40,240,160,296",
+        },
+        {
+            ref: "a2",
+            role: "Image",
+            label: "Logo",
+            states: [],
+            merged: true,
+            boundsInScreen: "0,0,360,80",
+        },
+        {
+            ref: "a3",
+            label: "By continuing you agree to the terms",
+            states: [],
+            merged: true,
+            boundsInScreen: "0,520,360,600",
+        },
+    ],
+};
+
+// "This entry" (newer) hierarchy — head side of the diff.
+const thisA11y = {
+    nodes: [
+        {
+            ref: "a1",
+            role: "Button",
+            label: "Send",
+            states: ["Disabled"],
+            merged: true,
+            boundsInScreen: "40,240,160,296",
+        },
+        {
+            ref: "a2",
+            role: "Image",
+            label: "Logo",
+            states: [],
+            merged: true,
+            boundsInScreen: "0,0,360,80",
+        },
+        {
+            ref: "a4",
+            role: "Image",
+            label: "Hero",
+            states: [],
+            merged: true,
+            boundsInScreen: "0,80,360,200",
+        },
+    ],
+};
+
+const fixture = {
+    name: "history-a11y-diff",
+    description:
+        "History panel webview: two entries diffed, with the a11y data-diff section rendered below the pixel diff. Exercises a changed node (label + states), an added image node, and a removed caption — matched by stable ref.",
+    app: "history-app",
+    bundle: "../media/webview/history.js",
+    dataset: { earlyFeatures: "true", minimalMode: "false" },
+    messages: [
+        {
+            command: "setEntries",
+            result: {
+                entries: [
+                    entry(thisId, "2026-04-30T10:12:00Z", "b".repeat(64), "fileChanged"),
+                    entry(prevId, "2026-04-30T10:10:00Z", "a".repeat(64), "renderNow"),
+                ],
+            },
+        },
+        {
+            // No host in the harness, so post `diffReady` directly (the same message the host sends
+            // after a "Diff vs previous" click). `setDiff` opens + fills the expansion.
+            command: "diffReady",
+            id: thisId,
+            against: "previous",
+            leftLabel: "This entry · 10:12",
+            leftImage: mock.png,
+            rightLabel: "Previous · 10:10",
+            rightImage: mock.png,
+            leftA11y: thisA11y,
+            rightA11y: previousA11y,
+        },
+    ],
+};
+
+process.stdout.write(JSON.stringify(fixture, null, 2) + "\n");

--- a/vscode-extension/preview-harness/fixtures/history-a11y-diff.json
+++ b/vscode-extension/preview-harness/fixtures/history-a11y-diff.json
@@ -1,0 +1,127 @@
+{
+  "name": "history-a11y-diff",
+  "description": "History panel webview: two entries diffed, with the a11y data-diff section rendered below the pixel diff. Exercises a changed node (label + states), an added image node, and a removed caption — matched by stable ref.",
+  "app": "history-app",
+  "bundle": "../media/webview/history.js",
+  "dataset": {
+    "earlyFeatures": "true",
+    "minimalMode": "false"
+  },
+  "messages": [
+    {
+      "command": "setEntries",
+      "result": {
+        "entries": [
+          {
+            "id": "20260430-101200-bbbbbbbb",
+            "previewId": "com.example.OnboardingKt.WelcomeScreenPreview",
+            "module": ":sample-android",
+            "timestamp": "2026-04-30T10:12:00Z",
+            "pngHash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            "pngSize": 4218,
+            "pngPath": "20260430-101200-bbbbbbbb.png",
+            "producer": "daemon",
+            "trigger": "fileChanged",
+            "source": {
+              "kind": "fs",
+              "id": "fs:/workspace/.compose-preview-history"
+            },
+            "git": {
+              "branch": "feature/onboarding",
+              "shortCommit": "a1b2c3d",
+              "dirty": false
+            }
+          },
+          {
+            "id": "20260430-101000-aaaaaaaa",
+            "previewId": "com.example.OnboardingKt.WelcomeScreenPreview",
+            "module": ":sample-android",
+            "timestamp": "2026-04-30T10:10:00Z",
+            "pngHash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "pngSize": 4218,
+            "pngPath": "20260430-101000-aaaaaaaa.png",
+            "producer": "daemon",
+            "trigger": "renderNow",
+            "source": {
+              "kind": "fs",
+              "id": "fs:/workspace/.compose-preview-history"
+            },
+            "git": {
+              "branch": "feature/onboarding",
+              "shortCommit": "a1b2c3d",
+              "dirty": false
+            }
+          }
+        ]
+      }
+    },
+    {
+      "command": "diffReady",
+      "id": "20260430-101200-bbbbbbbb",
+      "against": "previous",
+      "leftLabel": "This entry · 10:12",
+      "leftImage": "iVBORw0KGgoAAAANSUhEUgAAAWgAAAJYCAIAAADAFeuyAAAH9UlEQVR4nO3UQQ2DUBRFwa+gilDSbW1VAFIQURuwYIWGs+GHdG5GwEtecsbyXgGSMf0C4HGEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8jGfpwAiXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAA2bRwvD5fbjDrvz+7ZcKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5QkHwmF5woFwWJ5wIByWJxwIh+UJB8JhecKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5QkHwmF5woFwWJ5wIByWJxwIh+UJB8JhecKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5QkHwmF5woFwWJ5wIByWJxwIh+UJB8JhecKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5QkHwmF5woFwWJ5wIByWJxwIh+UJB8JhecKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5f1dOIDnEg4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gG5uZWZxwmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFneBUZcMccpTkvCAAAAAElFTkSuQmCC",
+      "rightLabel": "Previous · 10:10",
+      "rightImage": "iVBORw0KGgoAAAANSUhEUgAAAWgAAAJYCAIAAADAFeuyAAAH9UlEQVR4nO3UQQ2DUBRFwa+gilDSbW1VAFIQURuwYIWGs+GHdG5GwEtecsbyXgGSMf0C4HGEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8jGfpwAiXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAA2bRwvD5fbjDrvz+7ZcKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5QkHwmF5woFwWJ5wIByWJxwIh+UJB8JhecKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5QkHwmF5woFwWJ5wIByWJxwIh+UJB8JhecKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5QkHwmF5woFwWJ5wIByWJxwIh+UJB8JhecKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5QkHwmF5woFwWJ5wIByWJxwIh+UJB8JhecKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5f1dOIDnEg4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gG5uZWZxwmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFneBUZcMccpTkvCAAAAAElFTkSuQmCC",
+      "leftA11y": {
+        "nodes": [
+          {
+            "ref": "a1",
+            "role": "Button",
+            "label": "Send",
+            "states": [
+              "Disabled"
+            ],
+            "merged": true,
+            "boundsInScreen": "40,240,160,296"
+          },
+          {
+            "ref": "a2",
+            "role": "Image",
+            "label": "Logo",
+            "states": [],
+            "merged": true,
+            "boundsInScreen": "0,0,360,80"
+          },
+          {
+            "ref": "a4",
+            "role": "Image",
+            "label": "Hero",
+            "states": [],
+            "merged": true,
+            "boundsInScreen": "0,80,360,200"
+          }
+        ]
+      },
+      "rightA11y": {
+        "nodes": [
+          {
+            "ref": "a1",
+            "role": "Button",
+            "label": "Submit",
+            "states": [
+              "Enabled"
+            ],
+            "merged": true,
+            "boundsInScreen": "40,240,160,296"
+          },
+          {
+            "ref": "a2",
+            "role": "Image",
+            "label": "Logo",
+            "states": [],
+            "merged": true,
+            "boundsInScreen": "0,0,360,80"
+          },
+          {
+            "ref": "a3",
+            "label": "By continuing you agree to the terms",
+            "states": [],
+            "merged": true,
+            "boundsInScreen": "0,520,360,600"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/vscode-extension/src/historyPanel.ts
+++ b/vscode-extension/src/historyPanel.ts
@@ -349,6 +349,9 @@ export class HistoryPanel implements vscode.WebviewViewProvider {
                 // data-diff section (#1872), read from the sidecar for the same reason.
                 leftTheme: readSidecarTheme(scope, id),
                 rightTheme: rightId ? readSidecarTheme(scope, rightId) : null,
+                // And each entry's captured a11y/hierarchy nodes for the a11y data-diff (#1872).
+                leftA11y: readSidecarA11y(scope, id),
+                rightA11y: rightId ? readSidecarA11y(scope, rightId) : null,
             });
         } catch (err) {
             this.view.webview.postMessage({
@@ -679,6 +682,22 @@ function readSidecarTheme(scope: HistoryScope, id: string): unknown {
         const result = new HistoryReader(historyDirFor(scope)).read(id);
         return (
             (result?.entry as { theme?: unknown } | undefined)?.theme ?? null
+        );
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Reads an entry's raw `a11y/hierarchy` nodes straight from its on-disk sidecar (#1872), for the
+ * a11y data-diff. Same rationale as [readSidecarSemantics]. Best-effort → null on any failure.
+ */
+function readSidecarA11y(scope: HistoryScope, id: string): unknown {
+    try {
+        const result = new HistoryReader(historyDirFor(scope)).read(id);
+        return (
+            (result?.entry as { a11yHierarchy?: unknown } | undefined)
+                ?.a11yHierarchy ?? null
         );
     } catch {
         return null;

--- a/vscode-extension/src/test/a11yDiff.test.ts
+++ b/vscode-extension/src/test/a11yDiff.test.ts
@@ -1,0 +1,99 @@
+// Coverage for the client-side a11y-hierarchy data-diff (#1872) used by the history panel. Pure-data
+// tests (no DOM): two `a11y/hierarchy` payloads in, an `A11yDelta` out.
+
+import * as assert from "assert";
+
+import {
+    a11yDeltaIsEmpty,
+    diffA11y,
+    type A11yPayload,
+} from "../webview/shared/a11yDiff";
+
+describe("diffA11y", () => {
+    it("matches by stable ref and reports changed / added / removed", () => {
+        const base: A11yPayload = {
+            nodes: [
+                {
+                    ref: "a1",
+                    role: "Button",
+                    label: "Submit",
+                    states: ["Enabled"],
+                    merged: true,
+                },
+                { ref: "a3", label: "Caption", states: [], merged: true },
+            ],
+        };
+        const head: A11yPayload = {
+            nodes: [
+                {
+                    ref: "a1",
+                    role: "Button",
+                    label: "Send",
+                    states: ["Disabled"],
+                    merged: true,
+                },
+                { ref: "a4", role: "Image", label: "Hero", merged: true },
+            ],
+        };
+
+        const delta = diffA11y(base, head);
+
+        assert.deepStrictEqual(
+            delta.added.map((n) => n.label),
+            ["Hero"],
+        );
+        assert.deepStrictEqual(
+            delta.removed.map((n) => n.label),
+            ["Caption"],
+        );
+        assert.strictEqual(delta.changed.length, 1);
+        const change = delta.changed[0];
+        assert.strictEqual(change.key, "ref:a1");
+        const fields = change.changes.map((c) => c.field);
+        assert.deepStrictEqual(fields, ["label", "states"]);
+        assert.deepStrictEqual(change.changes[0], {
+            field: "label",
+            from: "Submit",
+            to: "Send",
+        });
+        assert.deepStrictEqual(change.changes[1], {
+            field: "states",
+            from: "Enabled",
+            to: "Disabled",
+        });
+    });
+
+    it("ignores boundsInScreen churn (pixel diff's job)", () => {
+        const base: A11yPayload = {
+            nodes: [{ ref: "a1", label: "X", boundsInScreen: "0,0,1,1" }],
+        };
+        const head: A11yPayload = {
+            nodes: [{ ref: "a1", label: "X", boundsInScreen: "9,9,9,9" }],
+        };
+        assert.ok(a11yDeltaIsEmpty(diffA11y(base, head)));
+    });
+
+    it("falls back to a role+label anchor when refs are absent", () => {
+        const base: A11yPayload = {
+            nodes: [{ role: "Button", label: "Submit", states: [] }],
+        };
+        const head: A11yPayload = {
+            nodes: [{ role: "Button", label: "Submit", states: ["Disabled"] }],
+        };
+        const delta = diffA11y(base, head);
+        // Same role+label anchor → matched → a states change, not add+remove.
+        assert.strictEqual(delta.added.length, 0);
+        assert.strictEqual(delta.removed.length, 0);
+        assert.strictEqual(delta.changed.length, 1);
+        assert.deepStrictEqual(delta.changed[0].changes[0], {
+            field: "states",
+            from: null,
+            to: "Disabled",
+        });
+    });
+
+    it("returns an empty delta for identical hierarchies", () => {
+        const nodes = [{ ref: "a1", role: "Button", label: "Go", states: [] }];
+        assert.ok(a11yDeltaIsEmpty(diffA11y({ nodes }, { nodes: [...nodes] })));
+    });
+});

--- a/vscode-extension/src/test/a11yDiff.test.ts
+++ b/vscode-extension/src/test/a11yDiff.test.ts
@@ -92,6 +92,23 @@ describe("diffA11y", () => {
         });
     });
 
+    it("treats a missing merged as true (no spurious change vs a newer capture)", () => {
+        // Legacy sidecar omits `merged`; newer capture has the wire default `true`.
+        const base: A11yPayload = { nodes: [{ ref: "a1", label: "X" }] };
+        const head: A11yPayload = {
+            nodes: [{ ref: "a1", label: "X", merged: true }],
+        };
+        assert.ok(a11yDeltaIsEmpty(diffA11y(base, head)));
+        // A real merged:false still shows as a change.
+        const unmerged: A11yPayload = {
+            nodes: [{ ref: "a1", label: "X", merged: false }],
+        };
+        const delta = diffA11y(base, unmerged);
+        assert.deepStrictEqual(delta.changed[0].changes, [
+            { field: "merged", from: "true", to: "false" },
+        ]);
+    });
+
     it("returns an empty delta for identical hierarchies", () => {
         const nodes = [{ ref: "a1", role: "Button", label: "Go", states: [] }];
         assert.ok(a11yDeltaIsEmpty(diffA11y({ nodes }, { nodes: [...nodes] })));

--- a/vscode-extension/src/test/historyDiffA11yPresenter.test.ts
+++ b/vscode-extension/src/test/historyDiffA11yPresenter.test.ts
@@ -1,0 +1,47 @@
+// Coverage for the a11y data-diff presenter (#1872) — pure mapping from an `A11yDelta` to the
+// display rows the history panel renders. No DOM.
+
+import * as assert from "assert";
+
+import { computeA11yDiffData } from "../webview/preview/historyDiffA11yPresenter";
+import { type A11yDelta } from "../webview/shared/a11yDiff";
+
+describe("computeA11yDiffData", () => {
+    it("returns an empty data set for null deltas", () => {
+        const empty = computeA11yDiffData(null);
+        assert.strictEqual(empty.empty, true);
+        assert.deepStrictEqual(empty.rows, []);
+    });
+
+    it("orders rows removed → added → changed with field rows on changes", () => {
+        const delta: A11yDelta = {
+            schema: "a11y-hierarchy-diff/v1",
+            added: [{ key: "ref:a4", label: "Hero", role: "Image" }],
+            removed: [{ key: "ref:a3", label: "Caption", role: null }],
+            changed: [
+                {
+                    key: "ref:a1",
+                    label: "Send",
+                    role: "Button",
+                    changes: [{ field: "label", from: "Submit", to: "Send" }],
+                },
+            ],
+        };
+        const data = computeA11yDiffData(delta);
+        assert.strictEqual(data.empty, false);
+        assert.strictEqual(data.addedCount, 1);
+        assert.strictEqual(data.removedCount, 1);
+        assert.strictEqual(data.changedCount, 1);
+        assert.deepStrictEqual(
+            data.rows.map((r) => r.kind),
+            ["removed", "added", "changed"],
+        );
+        // Added/removed rows carry no field rows; the changed row carries the field delta.
+        assert.deepStrictEqual(data.rows[0].fields, []);
+        assert.ok(data.rows[1].label.includes("Hero"));
+        assert.deepStrictEqual(data.rows[2].fields, [
+            { field: "label", from: "Submit", to: "Send" },
+        ]);
+        assert.ok(data.rows[2].label.includes("role=Button"));
+    });
+});

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -1302,6 +1302,10 @@ export type HistoryToWebview =
           // client-side for the theme data-diff section (#1872). null/omitted when not captured.
           leftTheme?: unknown;
           rightTheme?: unknown;
+          // Raw `a11y/hierarchy` payloads ({ nodes }) for each entry, when captured. Diffed
+          // client-side for the a11y data-diff section (#1872). null/omitted when not captured.
+          leftA11y?: unknown;
+          rightA11y?: unknown;
       }
     | {
           command: "diffPairError";

--- a/vscode-extension/src/webview/history/behavior.ts
+++ b/vscode-extension/src/webview/history/behavior.ts
@@ -342,6 +342,8 @@ export function setupHistoryBehavior(): void {
                         msg.rightSemantics,
                         msg.leftTheme,
                         msg.rightTheme,
+                        msg.leftA11y,
+                        msg.rightA11y,
                     );
                 break;
             }

--- a/vscode-extension/src/webview/history/components/HistoryRow.ts
+++ b/vscode-extension/src/webview/history/components/HistoryRow.ts
@@ -156,6 +156,8 @@ export class HistoryRow extends LitElement {
         rightSemantics?: unknown;
         leftTheme?: unknown;
         rightTheme?: unknown;
+        leftA11y?: unknown;
+        rightA11y?: unknown;
     } | null = null;
 
     /** Error text for the open diff expansion, populated by the host
@@ -229,6 +231,8 @@ export class HistoryRow extends LitElement {
                     this._diffPayload.rightSemantics,
                     this._diffPayload.leftTheme,
                     this._diffPayload.rightTheme,
+                    this._diffPayload.leftA11y,
+                    this._diffPayload.rightA11y,
                 );
             }
         }
@@ -416,6 +420,8 @@ export class HistoryRow extends LitElement {
         rightSemantics?: unknown,
         leftTheme?: unknown,
         rightTheme?: unknown,
+        leftA11y?: unknown,
+        rightA11y?: unknown,
     ): void {
         this._expandedKind = "diff";
         this._diffAgainst = against;
@@ -429,6 +435,8 @@ export class HistoryRow extends LitElement {
             rightSemantics,
             leftTheme,
             rightTheme,
+            leftA11y,
+            rightA11y,
         };
     }
 

--- a/vscode-extension/src/webview/history/historyDiffView.ts
+++ b/vscode-extension/src/webview/history/historyDiffView.ts
@@ -14,8 +14,10 @@
 // The pixel-diff helper lives in `webview/shared/pixelDiff.ts` — the
 // preview panel's diff overlay reaches for the same algorithm.
 
+import { computeA11yDiffData } from "../preview/historyDiffA11yPresenter";
 import { computeSemanticsDiffData } from "../preview/historyDiffSemanticsPresenter";
 import { computeThemeDiffData } from "../preview/historyDiffThemePresenter";
+import { diffA11y, type A11yPayload } from "../shared/a11yDiff";
 import { buildDiffModeBar, type DiffMode } from "../shared/diffModeBar";
 import {
     applyDiffStats,
@@ -73,6 +75,8 @@ export function fillDiff(
     rightSemantics?: unknown,
     leftTheme?: unknown,
     rightTheme?: unknown,
+    leftA11y?: unknown,
+    rightA11y?: unknown,
 ): void {
     const expansion = config.timelineEl.querySelector<HTMLElement>(
         '.expanded[data-id="' +
@@ -120,6 +124,7 @@ export function fillDiff(
     });
     appendSemanticsDiffSection(expansion, leftSemantics, rightSemantics);
     appendThemeDiffSection(expansion, leftTheme, rightTheme);
+    appendA11yDiffSection(expansion, leftA11y, rightA11y);
 }
 
 /**
@@ -263,6 +268,74 @@ function appendThemeDiffSection(
         section.appendChild(list);
     }
     expansion.appendChild(section);
+}
+
+/**
+ * Appends the a11y data-diff (#1872) below the pixel diff (and the semantics / theme sections). Both
+ * entries' captured `a11y/hierarchy` node lists are diffed client-side via [diffA11y]; the section
+ * is omitted when either payload is missing (a render that didn't capture a11y) so the pixel-only
+ * case is unchanged.
+ */
+function appendA11yDiffSection(
+    expansion: HTMLElement,
+    leftA11y: unknown,
+    rightA11y: unknown,
+): void {
+    if (!isA11yPayload(leftA11y) || !isA11yPayload(rightA11y)) {
+        return;
+    }
+    let data: ReturnType<typeof computeA11yDiffData>;
+    try {
+        // base = older "Previous" (right), head = "This entry" (left), matching the other sections.
+        data = computeA11yDiffData(diffA11y(rightA11y, leftA11y));
+    } catch {
+        return;
+    }
+    const section = document.createElement("div");
+    section.className = "diff-a11y";
+    const head = document.createElement("div");
+    head.className = "diff-a11y-header";
+    head.textContent = data.empty
+        ? "Accessibility · no changes"
+        : `Accessibility · ${data.addedCount} added · ${data.removedCount} removed · ${data.changedCount} changed`;
+    section.appendChild(head);
+    if (!data.empty) {
+        const list = document.createElement("ul");
+        list.className = "diff-a11y-list";
+        for (const row of data.rows) {
+            const li = document.createElement("li");
+            li.className = `diff-a11y-row diff-a11y-${row.kind}`;
+            const sigil =
+                row.kind === "added" ? "+" : row.kind === "removed" ? "−" : "~";
+            const label = document.createElement("span");
+            label.className = "diff-a11y-label";
+            label.textContent = `${sigil} ${row.label}`;
+            li.appendChild(label);
+            if (row.fields.length > 0) {
+                const fields = document.createElement("ul");
+                fields.className = "diff-a11y-fields";
+                for (const field of row.fields) {
+                    const fieldLi = document.createElement("li");
+                    fieldLi.textContent = `${field.field}: ${field.from ?? "∅"} → ${field.to ?? "∅"}`;
+                    fields.appendChild(fieldLi);
+                }
+                li.appendChild(fields);
+            }
+            list.appendChild(li);
+        }
+        section.appendChild(list);
+    }
+    expansion.appendChild(section);
+}
+
+/** Narrows an untyped wire value to a `{ nodes }` a11y/hierarchy payload. */
+function isA11yPayload(value: unknown): value is A11yPayload {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "nodes" in value &&
+        Array.isArray((value as { nodes: unknown }).nodes)
+    );
 }
 
 function renderHistoryDiffMode(

--- a/vscode-extension/src/webview/preview/historyDiffA11yPresenter.ts
+++ b/vscode-extension/src/webview/preview/historyDiffA11yPresenter.ts
@@ -1,0 +1,106 @@
+// Presenter for the history panel's a11y data-diff section (#1872). Pure: turns an `A11yDelta`
+// (from the client-side `a11yDiff` differ) into display rows the webview renders beneath the pixel
+// diff. No DOM — mirrors `historyDiffSemanticsPresenter` / `historyDiffThemePresenter`.
+
+import {
+    type A11yDelta,
+    type A11yNodeChange,
+    type A11yNodeSummary,
+} from "../shared/a11yDiff";
+
+export type A11yDiffRowKind = "added" | "removed" | "changed";
+
+export interface A11yDiffFieldRow {
+    field: string;
+    from: string | null;
+    to: string | null;
+}
+
+export interface A11yDiffRow {
+    kind: A11yDiffRowKind;
+    /** Human-readable label: role/label hints (falls back to the match key). */
+    label: string;
+    /** Field-level changes (only for `kind === "changed"`; empty for added/removed). */
+    fields: A11yDiffFieldRow[];
+}
+
+export interface A11yDiffData {
+    empty: boolean;
+    addedCount: number;
+    removedCount: number;
+    changedCount: number;
+    /** Removed first, then added, then changed — matches the semantics/theme sections. */
+    rows: A11yDiffRow[];
+}
+
+const EMPTY: A11yDiffData = {
+    empty: true,
+    addedCount: 0,
+    removedCount: 0,
+    changedCount: 0,
+    rows: [],
+};
+
+/** Derives the display rows for an a11y delta. Null/empty delta → an empty data set. */
+export function computeA11yDiffData(
+    delta: A11yDelta | null | undefined,
+): A11yDiffData {
+    if (!delta) {
+        return EMPTY;
+    }
+    const removed = delta.removed ?? [];
+    const added = delta.added ?? [];
+    const changed = delta.changed ?? [];
+    const rows: A11yDiffRow[] = [];
+    for (const node of removed) {
+        rows.push({
+            kind: "removed",
+            label: describeSummary(node),
+            fields: [],
+        });
+    }
+    for (const node of added) {
+        rows.push({ kind: "added", label: describeSummary(node), fields: [] });
+    }
+    for (const change of changed) {
+        rows.push({
+            kind: "changed",
+            label: describeChange(change),
+            fields: change.changes.map((c) => ({
+                field: c.field,
+                from: c.from,
+                to: c.to,
+            })),
+        });
+    }
+    return {
+        empty: rows.length === 0,
+        addedCount: added.length,
+        removedCount: removed.length,
+        changedCount: changed.length,
+        rows,
+    };
+}
+
+function describeSummary(node: A11yNodeSummary): string {
+    return describe(node.role, node.label, node.key);
+}
+
+function describeChange(change: A11yNodeChange): string {
+    return describe(change.role, change.label, change.key);
+}
+
+function describe(
+    role: string | null,
+    label: string | null,
+    key: string,
+): string {
+    const parts: string[] = [];
+    if (role) {
+        parts.push(`role=${role}`);
+    }
+    if (label) {
+        parts.push(`label="${label}"`);
+    }
+    return parts.length === 0 ? key : parts.join(" ");
+}

--- a/vscode-extension/src/webview/shared/a11yDiff.ts
+++ b/vscode-extension/src/webview/shared/a11yDiff.ts
@@ -1,0 +1,157 @@
+// Client-side a11y-hierarchy data-diff for the history panel (#1872), mirroring `semanticsDiff.ts`
+// and `themeDiff.ts`. Diffs two entries' captured `a11y/hierarchy` node lists so the panel can show
+// which accessibility nodes were added / removed / changed between renders — no daemon round-trip.
+//
+// Nodes are matched by their stable `ref` (#1784) when present, falling back to a content anchor
+// (`role` + `label`, sibling-disambiguated) for older captures that predate refs. Positional
+// `boundsInScreen` is deliberately NOT compared — bounds churn is the pixel diff's job; the a11y
+// diff reports semantic changes (label / role / states / merged). There is no Kotlin a11y differ
+// yet; this is the first implementation.
+
+export const A11Y_DIFF_SCHEMA = "a11y-hierarchy-diff/v1";
+
+/** Subset of an `a11y/hierarchy` node the differ reads (parsed leniently from the sidecar). */
+export interface A11yNode {
+    ref?: string | null;
+    label?: string | null;
+    role?: string | null;
+    states?: string[] | null;
+    merged?: boolean | null;
+    boundsInScreen?: string | null;
+}
+
+export interface A11yPayload {
+    nodes?: A11yNode[] | null;
+}
+
+export interface A11yFieldChange {
+    field: string;
+    from: string | null;
+    to: string | null;
+}
+
+export interface A11yNodeSummary {
+    /** Stable match key (ref or derived anchor). */
+    key: string;
+    label: string | null;
+    role: string | null;
+}
+
+export interface A11yNodeChange {
+    key: string;
+    label: string | null;
+    role: string | null;
+    changes: A11yFieldChange[];
+}
+
+export interface A11yDelta {
+    schema: string;
+    added: A11yNodeSummary[];
+    removed: A11yNodeSummary[];
+    changed: A11yNodeChange[];
+}
+
+const asStr = (v: string | null | undefined): string | null =>
+    v == null || v === "" ? null : v;
+
+function statesStr(states: string[] | null | undefined): string | null {
+    if (!states || states.length === 0) {
+        return null;
+    }
+    return [...states].sort().join(", ");
+}
+
+// Fields compared between two nodes sharing a key, in stable report order. Bounds excluded by design.
+const COMPARED_FIELDS: Array<[string, (n: A11yNode) => string | null]> = [
+    ["label", (n) => asStr(n.label)],
+    ["role", (n) => asStr(n.role)],
+    ["states", (n) => statesStr(n.states)],
+    ["merged", (n) => (n.merged == null ? null : String(n.merged))],
+];
+
+/** Content anchor for a node lacking a stable ref: role + label, before sibling disambiguation. */
+function anchor(node: A11yNode): string {
+    return `role=${asStr(node.role) ?? ""}|label=${asStr(node.label) ?? ""}`;
+}
+
+/** Keys each node by `ref:<ref>` when present, else a sibling-disambiguated content anchor. */
+function keyed(nodes: A11yNode[]): Map<string, A11yNode> {
+    const out = new Map<string, A11yNode>();
+    const seen = new Map<string, number>();
+    for (const node of nodes) {
+        const ref = node.ref?.trim();
+        let key: string;
+        if (ref) {
+            key = `ref:${ref}`;
+        } else {
+            const a = anchor(node);
+            const index = seen.get(a) ?? 0;
+            seen.set(a, index + 1);
+            key = `a:${a}[${index}]`;
+        }
+        if (!out.has(key)) {
+            out.set(key, node);
+        }
+    }
+    return out;
+}
+
+function summary(key: string, node: A11yNode): A11yNodeSummary {
+    return { key, label: asStr(node.label), role: asStr(node.role) };
+}
+
+function nodeChange(
+    key: string,
+    base: A11yNode,
+    head: A11yNode,
+): A11yNodeChange | null {
+    const changes: A11yFieldChange[] = [];
+    for (const [field, extract] of COMPARED_FIELDS) {
+        const from = extract(base);
+        const to = extract(head);
+        if (from !== to) {
+            changes.push({ field, from, to });
+        }
+    }
+    if (changes.length === 0) {
+        return null;
+    }
+    return { key, label: asStr(head.label), role: asStr(head.role), changes };
+}
+
+/**
+ * Diffs two `a11y/hierarchy` payloads. `base` is the older entry, `head` the newer, so `added` reads
+ * as nodes newly present and `changed` as `old → new` — matching the panel's "this entry vs the
+ * previous" framing and the semantics/theme sections.
+ */
+export function diffA11y(base: A11yPayload, head: A11yPayload): A11yDelta {
+    const baseByKey = keyed(base.nodes ?? []);
+    const headByKey = keyed(head.nodes ?? []);
+
+    const removed = [...baseByKey.keys()]
+        .filter((k) => !headByKey.has(k))
+        .sort()
+        .map((k) => summary(k, baseByKey.get(k)!));
+    const added = [...headByKey.keys()]
+        .filter((k) => !baseByKey.has(k))
+        .sort()
+        .map((k) => summary(k, headByKey.get(k)!));
+    const changed: A11yNodeChange[] = [];
+    for (const k of [...baseByKey.keys()]
+        .filter((k) => headByKey.has(k))
+        .sort()) {
+        const change = nodeChange(k, baseByKey.get(k)!, headByKey.get(k)!);
+        if (change) {
+            changed.push(change);
+        }
+    }
+    return { schema: A11Y_DIFF_SCHEMA, added, removed, changed };
+}
+
+export function a11yDeltaIsEmpty(delta: A11yDelta): boolean {
+    return (
+        (delta.added?.length ?? 0) === 0 &&
+        (delta.removed?.length ?? 0) === 0 &&
+        (delta.changed?.length ?? 0) === 0
+    );
+}

--- a/vscode-extension/src/webview/shared/a11yDiff.ts
+++ b/vscode-extension/src/webview/shared/a11yDiff.ts
@@ -66,7 +66,10 @@ const COMPARED_FIELDS: Array<[string, (n: A11yNode) => string | null]> = [
     ["label", (n) => asStr(n.label)],
     ["role", (n) => asStr(n.role)],
     ["states", (n) => statesStr(n.states)],
-    ["merged", (n) => (n.merged == null ? null : String(n.merged))],
+    // The wire model defaults a missing `merged` to true (AccessibilityNode.merged); mirror that
+    // here so a legacy sidecar (written before the field existed) doesn't report a spurious
+    // `merged: ∅ → true` against a newer capture.
+    ["merged", (n) => String(n.merged ?? true)],
 ];
 
 /** Content anchor for a node lacking a stable ref: role + label, before sibling disambiguation. */


### PR DESCRIPTION
## Summary

Adds an **Accessibility** data-diff section to the History panel's diff view, beneath the pixel diff and the existing semantics + theme sections (#1872). When two entries are diffed it shows which `a11y/hierarchy` nodes were added / removed / changed between renders. Fully client-side, mirroring the semantics (#1902/#1904) and theme (#1912) stacks.

This **completes the panel data-diffs trio** — semantics, theme, and now a11y.

### Matching & comparison
- Nodes are matched by their **stable `ref`** (#1784) when present, falling back to a `role`+`label` content anchor (sibling-disambiguated) for older captures that predate refs.
- Compares `label` / `role` / `states` / `merged`. `boundsInScreen` is deliberately **excluded** — positional churn is the pixel diff's job (consistent with how semantics ignores bounds).

### Changes
- **`a11yDiff.ts`** (new, shared, pure) — keyed add/removed/changed, ordered for display. Unit-tested.
- **`historyDiffA11yPresenter.ts`** (new, pure) — `A11yDelta` → display rows; **`appendA11yDiffSection`** in `historyDiffView.ts` renders the `.diff-a11y` block with add/remove/change colour coding + per-field rows, matching the other sections. CSS added to `preview.css`.
- **Wiring** — thread `leftA11y`/`rightA11y` through `diffReady` (`types.ts`), `HistoryRow.setDiff` + `_diffPayload` + the `fillDiff` call, `behavior.ts`, and host `runPairDiff` via a new `readSidecarA11y` (same sidecar-read rationale as semantics/theme). Section omitted when either entry lacks captured a11y.

## Visual evidence
Visual change; the panel webview can't render in this headless container (no chromium). Coverage is wired in: a new **`history-a11y-diff`** preview-harness fixture drives the panel with a `diffReady` carrying two `a11y/hierarchy` payloads (a changed node — label + states, an added image node, a removed caption), so the **CI `vscode-preview-diff` bot renders and diffs the `.diff-a11y` section** here and on every future PR. See its comment for the capture.

## Test plan
- New `a11yDiff.test.ts` (4) + `historyDiffA11yPresenter.test.ts` (2): ref matching with changed/added/removed, bounds-churn ignored, role+label fallback when refs absent, identical → empty; presenter row ordering + field rows.
- `tsc --noEmit` clean (host + webview); full unit suite green (1572 passing); `prettier --check` clean.

Note: this targets **local** history (like the merged theme/semantics diffs). Surfacing these diffs on a reporting branch additionally needs the ref-aware data-product read, which builds on the commit-walk timeline (#1913, in review) — a fast-follow once that lands.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CPjwnCtY5aiBTFkVrrFjhS)_