### PR TITLE
feat(vscode): read data-product diffs from the reporting branch

### DIFF
--- a/vscode-extension/src/historyPanel.ts
+++ b/vscode-extension/src/historyPanel.ts
@@ -9,7 +9,10 @@ import {
     HistoryReadResult,
     HistorySourceKind,
 } from "./daemon/daemonProtocol";
-import { reportingBranchLabel } from "./reportingBranches";
+import {
+    readGitRefEntryField,
+    reportingBranchLabel,
+} from "./reportingBranches";
 
 /**
  * Read-only Preview History panel — HISTORY.md § "VS Code integration".
@@ -655,12 +658,15 @@ function historyDirFor(scope: HistoryScope): string {
 }
 
 /**
- * Reads an entry's raw `compose/semantics` tree straight from its on-disk sidecar (#1872). The
- * sidecar always carries the full tree, unlike the daemon's `history/read` wire shape which strips
- * it — so this is daemon-independent. Best-effort: returns null for a missing sidecar, unparseable
- * JSON, or an entry that captured no semantics.
+ * Reads an entry's raw `compose/semantics` tree for the data-diff (#1872). On a reporting branch
+ * (`scope.gitRef`) the entry id is `<shortCommit>:<previewId>` and the payload lives in git, so read
+ * it from the ref; otherwise read the on-disk sidecar (which carries the full tree the daemon's
+ * `history/read` wire shape strips). Best-effort: null for a missing/unparseable entry or no capture.
  */
 function readSidecarSemantics(scope: HistoryScope, id: string): unknown {
+    if (scope.gitRef) {
+        return readGitRefEntryField(scope.projectDir, id, "semantics");
+    }
     try {
         const result = new HistoryReader(historyDirFor(scope)).read(id);
         return (
@@ -673,11 +679,13 @@ function readSidecarSemantics(scope: HistoryScope, id: string): unknown {
 }
 
 /**
- * Reads an entry's raw `compose/theme` resolved tokens straight from its on-disk sidecar (#1872),
- * for the theme data-diff. Same rationale as [readSidecarSemantics]: the sidecar carries the full
- * payload the daemon's `history/read` wire shape strips. Best-effort → null on any failure.
+ * Reads an entry's raw `compose/theme` resolved tokens for the theme data-diff (#1872). Reporting
+ * branch → from git; otherwise the on-disk sidecar. Same rationale as [readSidecarSemantics].
  */
 function readSidecarTheme(scope: HistoryScope, id: string): unknown {
+    if (scope.gitRef) {
+        return readGitRefEntryField(scope.projectDir, id, "theme");
+    }
     try {
         const result = new HistoryReader(historyDirFor(scope)).read(id);
         return (
@@ -689,10 +697,13 @@ function readSidecarTheme(scope: HistoryScope, id: string): unknown {
 }
 
 /**
- * Reads an entry's raw `a11y/hierarchy` nodes straight from its on-disk sidecar (#1872), for the
- * a11y data-diff. Same rationale as [readSidecarSemantics]. Best-effort → null on any failure.
+ * Reads an entry's raw `a11y/hierarchy` nodes for the a11y data-diff (#1872). Reporting branch →
+ * from git; otherwise the on-disk sidecar. Same rationale as [readSidecarSemantics].
  */
 function readSidecarA11y(scope: HistoryScope, id: string): unknown {
+    if (scope.gitRef) {
+        return readGitRefEntryField(scope.projectDir, id, "a11yHierarchy");
+    }
     try {
         const result = new HistoryReader(historyDirFor(scope)).read(id);
         return (

--- a/vscode-extension/src/reportingBranches.ts
+++ b/vscode-extension/src/reportingBranches.ts
@@ -4,7 +4,7 @@
 // picker lets the user point the panel at one of them via the daemon's on-demand
 // `ref` history param.
 
-import { execFile } from "child_process";
+import { execFile, execFileSync } from "child_process";
 import { promisify } from "util";
 
 const execFileAsync = promisify(execFile);
@@ -80,4 +80,71 @@ export function reportingBranchLabel(ref: string): string | null {
         return remote[1];
     }
     return null;
+}
+
+// Characters kept verbatim in a sanitised preview-id directory name: Unicode letters/digits plus
+// `.`, `_`, `-`. Mirrors the daemon's Kotlin `PreviewIdSanitiser` (Char.isLetterOrDigit, Unicode).
+const SANITISE_KEEP = /[\p{L}\p{N}._-]/u;
+
+/**
+ * Sanitises a `previewId` into the reporting-branch directory name, mirroring the daemon's
+ * `PreviewIdSanitiser`: kept characters pass through, everything else collapses to `_`, and an
+ * empty id yields `_`. The reporting branch stores each preview under `<sanitised>/`.
+ */
+export function sanitisePreviewId(previewId: string): string {
+    if (previewId.length === 0) {
+        return "_";
+    }
+    let out = "";
+    for (const ch of previewId) {
+        out += SANITISE_KEEP.test(ch) ? ch : "_";
+    }
+    return out;
+}
+
+/** A reporting-branch data-product field embedded in `entry.json`. */
+export type GitRefEntryField = "semantics" | "theme" | "a11yHierarchy";
+
+/**
+ * Reads a single data-product field embedded in a reporting-branch entry, addressed by a
+ * `<shortCommit>:<previewId>` id (#1868), via `git show <commit>:<dir>/entry.json`. The branch's
+ * `entry.json` carries the full `semantics` / `theme` / `a11yHierarchy` payloads, so the History
+ * panel can diff a reporting-branch entry without the data living on the local FS.
+ *
+ * Synchronous — this runs on a user-driven "diff vs previous" click. Best-effort: returns `null`
+ * for a malformed id, a missing entry/field, or any git/parse failure.
+ */
+export function readGitRefEntryField(
+    repoRoot: string,
+    entryId: string,
+    field: GitRefEntryField,
+): unknown {
+    const sep = entryId.indexOf(":");
+    if (sep <= 0) {
+        return null;
+    }
+    const shortCommit = entryId.slice(0, sep);
+    const dir = sanitisePreviewId(entryId.slice(sep + 1));
+    let text: string;
+    try {
+        text = execFileSync(
+            "git",
+            ["show", `${shortCommit}:${dir}/entry.json`],
+            {
+                cwd: repoRoot,
+                encoding: "utf8",
+                timeout: 5000,
+                stdio: ["ignore", "pipe", "ignore"],
+                maxBuffer: 32 * 1024 * 1024,
+            },
+        );
+    } catch {
+        return null;
+    }
+    try {
+        const entry = JSON.parse(text) as Record<string, unknown>;
+        return entry[field] ?? null;
+    } catch {
+        return null;
+    }
 }

--- a/vscode-extension/src/test/reportingBranches.test.ts
+++ b/vscode-extension/src/test/reportingBranches.test.ts
@@ -14,7 +14,9 @@ import * as path from "path";
 
 import {
     listReportingBranches,
+    readGitRefEntryField,
     reportingBranchLabel,
+    sanitisePreviewId,
 } from "../reportingBranches";
 
 function gitAvailable(): boolean {
@@ -139,5 +141,101 @@ describe("listReportingBranches", () => {
         } finally {
             fs.rmSync(notRepo, { recursive: true, force: true });
         }
+    });
+});
+
+describe("sanitisePreviewId", () => {
+    it("keeps letters/digits/._- verbatim and collapses the rest", () => {
+        assert.strictEqual(
+            sanitisePreviewId("com.example.OnboardingKt.WelcomeScreenPreview"),
+            "com.example.OnboardingKt.WelcomeScreenPreview",
+        );
+        assert.strictEqual(sanitisePreviewId("a b/c:d"), "a_b_c_d");
+        assert.strictEqual(sanitisePreviewId(""), "_");
+    });
+});
+
+describe("readGitRefEntryField", () => {
+    let repo: string;
+    const hasGit = gitAvailable();
+
+    beforeEach(function () {
+        if (!hasGit) {
+            this.skip();
+        }
+        repo = fs.mkdtempSync(path.join(os.tmpdir(), "git-ref-entry-"));
+        git(repo, "init", "-q");
+        git(repo, "config", "user.email", "test@example.com");
+        git(repo, "config", "user.name", "Test");
+        git(repo, "config", "commit.gpgsign", "false");
+    });
+
+    afterEach(() => {
+        if (repo) {
+            fs.rmSync(repo, { recursive: true, force: true });
+        }
+    });
+
+    // Commits `<sanitisedPreviewId>/entry.json` (mirroring the reporting-branch layout) and returns
+    // the `<shortCommit>:<previewId>` id addressing it.
+    function commitEntry(previewId: string, entry: unknown): string {
+        const dir = sanitisePreviewId(previewId);
+        fs.mkdirSync(path.join(repo, dir), { recursive: true });
+        fs.writeFileSync(
+            path.join(repo, dir, "entry.json"),
+            JSON.stringify(entry),
+        );
+        git(repo, "add", ".");
+        git(repo, "commit", "-q", "-m", `render ${previewId}`);
+        const short = execFileSync(
+            "git",
+            ["-C", repo, "rev-parse", "--short", "HEAD"],
+            { encoding: "utf8" },
+        ).trim();
+        return `${short}:${previewId}`;
+    }
+
+    it("extracts embedded data-product fields from the ref entry.json", () => {
+        const entryId = commitEntry("com.example.A", {
+            id: "x",
+            previewId: "com.example.A",
+            semantics: { root: { ref: "r", role: "Column" } },
+            theme: { resolvedTokens: { colorScheme: { primary: "#FFF" } } },
+            a11yHierarchy: { nodes: [{ ref: "a1", label: "Go" }] },
+        });
+        assert.deepStrictEqual(
+            readGitRefEntryField(repo, entryId, "semantics"),
+            {
+                root: { ref: "r", role: "Column" },
+            },
+        );
+        assert.deepStrictEqual(readGitRefEntryField(repo, entryId, "theme"), {
+            resolvedTokens: { colorScheme: { primary: "#FFF" } },
+        });
+        assert.deepStrictEqual(
+            readGitRefEntryField(repo, entryId, "a11yHierarchy"),
+            { nodes: [{ ref: "a1", label: "Go" }] },
+        );
+    });
+
+    it("returns null when the field, entry, or commit is absent", () => {
+        const entryId = commitEntry("com.example.B", {
+            id: "y",
+            previewId: "com.example.B",
+        });
+        // Field not captured on this entry.
+        assert.strictEqual(
+            readGitRefEntryField(repo, entryId, "semantics"),
+            null,
+        );
+        // Malformed id (no commit prefix) and an unknown commit both degrade to null.
+        assert.strictEqual(
+            readGitRefEntryField(repo, "no-colon", "theme"),
+            null,
+        );
+        assert.strictEqual(
+            readGitRefEntryField(repo, "deadbee:com.example.Z", "theme"),
+            null,
+        );
     });
 });


### PR DESCRIPTION
## Summary

Closes the gap Codex flagged on #1912: the History panel's **semantics / theme / a11y data-diffs were silently omitted when viewing a reporting branch**, because the sidecar reads hit the local `.compose-preview-history` FS, which has nothing for a git-ref entry. Now that the commit-walk timeline (#1868, #1913) gives a reporting branch a diffable *previous* entry — and entry ids are `<shortCommit>:<previewId>` — this makes the reads **ref-aware**, so all three data-diffs (plus the pixel diff) surface on a reporting-branch timeline.

### How
- New **`readGitRefEntryField(repoRoot, entryId, field)`** in `reportingBranches.ts`: parses the `<shortCommit>:<previewId>` id and reads the payload via `git show <commit>:<sanitisedPreviewId>/entry.json`. The reporting branch's `entry.json` embeds the full `semantics` / `theme` / `a11yHierarchy` payloads (see `GitRefHistorySource.projectFiles`), so one blob read covers all three. Synchronous (a click-driven diff read); best-effort → `null` on any failure.
- New **`sanitisePreviewId`** mirroring the daemon's Kotlin `PreviewIdSanitiser` (Unicode letter/digit + `._-` kept, else `_`, empty → `_`) so the directory name matches what the writer produced.
- `readSidecarSemantics` / `readSidecarTheme` / `readSidecarA11y` now route through it when `scope.gitRef` is set; the local-FS path is unchanged otherwise.

## Test plan
- New unit tests in `reportingBranches.test.ts` (git-gated): `sanitisePreviewId` mapping; `readGitRefEntryField` extracts `semantics`/`theme`/`a11yHierarchy` from a committed `<dir>/entry.json`, and returns `null` for an uncaptured field, a malformed id, and an unknown commit.
- `tsc --noEmit` clean (host + webview); full unit suite green (1576 passing); `prettier --check` clean.

Non-visual: this changes only the **data source** for diffs the panel already renders (the semantics/theme/a11y sections + their harness fixtures landed in #1904/#1912/#1914). The rendered DOM is identical regardless of whether the payload came from the local sidecar or git, so existing fixture coverage applies; per the repo's guidance this is data-product plumbing, so it's text-only.

With this, the reporting-branch source picker (#1911) + timeline (#1913) + data-diffs are end-to-end: pick a `preview/*` branch, diff an entry vs its previous, and see pixel + semantics + theme + a11y deltas.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CPjwnCtY5aiBTFkVrrFjhS)_