### PR TITLE
feat(daemon): GitRefHistorySource WRITE_PUSH — publish the reporting branch to a remote

### DIFF
--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/GitRefHistorySource.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/GitRefHistorySource.kt
@@ -41,8 +41,9 @@ import kotlinx.serialization.json.JsonElement
  * **Sync modes** ([SyncMode]):
  * - [SyncMode.READ_ONLY] (default) — read the ref, never write. Used to mirror a branch populated
  *   elsewhere (a remote fetch, CI).
- * - [SyncMode.WRITE_LOCAL] — also commit each changed render onto the ref via git plumbing. No
- *   push. `WRITE_PUSH` (also pushing the ref) is a follow-up (issue #1870).
+ * - [SyncMode.WRITE_LOCAL] — also commit each changed render onto the local ref via git plumbing.
+ * - [SyncMode.WRITE_PUSH] — like `WRITE_LOCAL`, then `git push` the ref to [remote], with
+ *   fetch–rebase–retry on a push race (issue #1880).
  *
  * **Working-tree safety.** Writes go through a throwaway temporary index plus `hash-object` /
  * `read-tree` / `update-index` / `write-tree` / `commit-tree` / `update-ref` — the daemon runs
@@ -52,12 +53,13 @@ import kotlinx.serialization.json.JsonElement
  * **Skip-if-no-diff.** When the freshly built tree is byte-identical to the ref's current tree, no
  * commit is made and [write] returns [WriteResult.SKIPPED_DUPLICATE]. Dedup is free.
  *
- * **Read.** Returns the *current* state of the branch (one entry per preview, read from each
- * `<dir>/entry.json`). The full commit-walk timeline read is a follow-up (issue #1868).
+ * **Read.** Reconstructs the per-preview timeline (#1868) by walking the ref's commits, one entry
+ * per changed render addressed by `<shortCommit>:<previewId>`; falls back to the legacy
+ * `_index.jsonl` tip read for refs that predate the git-as-the-log layout.
  *
  * @param repoRoot the working tree (or bare repo) the ref lives in.
  * @param ref the full ref name (e.g. `refs/heads/preview/main`).
- * @param syncMode read-only vs write-local; see [SyncMode].
+ * @param syncMode read-only / write-local / write-push; see [SyncMode].
  * @param displayId stable identifier for `entry.source.id` rewriting; defaults to `git:$ref`.
  * @param cacheDir where extracted PNG blobs and the throwaway write-index land.
  * @param gitExecutable git binary; defaults to `git` on PATH.
@@ -72,30 +74,90 @@ class GitRefHistorySource(
     repoRoot.resolve(".compose-preview-history").resolve(".git-ref-cache"),
   private val gitExecutable: String = "git",
   private val warnEmitter: (String) -> Unit = { System.err.println(it) },
+  /** Git remote pushed to under [SyncMode.WRITE_PUSH]. Defaults to `origin`. */
+  private val remote: String = DEFAULT_REMOTE,
 ) : HistorySource {
 
   override val id: String = displayId
   override val kind: String = "git"
 
-  override fun supportsWrites(): Boolean = syncMode == SyncMode.WRITE_LOCAL
+  override fun supportsWrites(): Boolean = syncMode != SyncMode.READ_ONLY
 
   /**
-   * Materialises this render into the reporting ref's tree and commits it (when the tree changed).
-   * Never throws: any git failure degrades to [WriteResult.SKIPPED_DUPLICATE] with a logged warning
-   * so history recording can't break the render (history is observation, not state).
+   * Materialises this render into the reporting ref's tree and commits it (when the tree changed),
+   * and under [SyncMode.WRITE_PUSH] also pushes the ref to [remote] (best-effort, with
+   * fetch–rebase–retry on a push race). Never throws: any git failure degrades to
+   * [WriteResult.SKIPPED_DUPLICATE] / a one-time warning so history recording can't break the
+   * render (history is observation, not state).
    */
   override fun write(entry: HistoryEntry, png: ByteArray): WriteResult {
-    if (syncMode != SyncMode.WRITE_LOCAL) {
+    if (!supportsWrites()) {
       error("GitRefHistorySource(ref=$ref) is $syncMode; writes go to a writable source.")
     }
     return try {
-      writeLocal(entry, png)
+      val result = writeLocal(entry, png)
+      if (syncMode == SyncMode.WRITE_PUSH && result == WriteResult.WRITTEN) {
+        pushWithRetry(entry, png)
+      }
+      result
     } catch (t: Throwable) {
       System.err.println(
         "compose-ai-daemon: GitRefHistorySource.write($ref, ${entry.id}) failed " +
           "(${t.javaClass.simpleName}: ${t.message}); skipping the reporting-branch commit"
       )
       WriteResult.SKIPPED_DUPLICATE
+    }
+  }
+
+  private val pushFailedWarned = AtomicBoolean(false)
+
+  /**
+   * Publishes the local commit by pushing `ref:ref` to [remote]. On a push race (the remote ref
+   * advanced — non-fast-forward) the disjoint-paths layout means our render just needs replaying on
+   * the new tip: fetch it, fast-forward the local ref to it, and re-run [writeLocal] to rebuild our
+   * render on top, then retry. An identical render dedups to `SKIPPED_DUPLICATE` on replay (the
+   * remote already has our content) and we stop. A non-race failure (no remote / bad credentials)
+   * can't fetch either, so it falls through to a one-time warning — the local commit still stands.
+   */
+  private fun pushWithRetry(entry: HistoryEntry, png: ByteArray) {
+    var attempt = 1
+    while (attempt <= MAX_PUSH_ATTEMPTS) {
+      if (plumbingOk(emptyMap(), "push", remote, "$ref:$ref")) {
+        return
+      }
+      // Push rejected — fetch the remote tip; null ⇒ no reachable remote, give up (warn).
+      val remoteTip = fetchRemoteTip() ?: break
+      if (!plumbingOk(emptyMap(), "update-ref", ref, remoteTip)) break
+      cachedEntries.set(null) // local ref moved; invalidate the read cache.
+      // Replay our render on the fetched tip. SKIPPED ⇒ the remote already carries it → done.
+      if (writeLocal(entry, png) == WriteResult.SKIPPED_DUPLICATE) return
+      backoff(attempt)
+      attempt++
+    }
+    warnOncePush()
+  }
+
+  /** Fetches [ref] from [remote] into FETCH_HEAD and resolves its tip; null on any failure. */
+  private fun fetchRemoteTip(): String? {
+    if (!plumbingOk(emptyMap(), "fetch", remote, ref)) return null
+    return runGit("rev-parse", "FETCH_HEAD")?.takeIf { it.isNotEmpty() }
+  }
+
+  private fun backoff(attempt: Int) {
+    try {
+      Thread.sleep((50L shl (attempt - 1)).coerceAtMost(2_000L))
+    } catch (_: InterruptedException) {
+      Thread.currentThread().interrupt()
+    }
+  }
+
+  private fun warnOncePush() {
+    if (pushFailedWarned.compareAndSet(false, true)) {
+      warnEmitter(
+        "GitRefHistorySource: could not push '$ref' to remote '$remote'.\n" +
+          "  History is still recorded locally on the ref; only the push to the remote failed.\n" +
+          "  Hint: ensure the remote exists and credentials (credential helper / SSH key) are set up."
+      )
     }
   }
 
@@ -415,16 +477,18 @@ class GitRefHistorySource(
    * render.
    */
   private fun walkTimeline(refCommit: String): List<HistoryEntry> {
-    // `%x00%H` prefixes each commit's section with NUL+sha; `--name-only` then lists the files it
-    // changed (one per line). Walking newest-first and capped keeps the read cost bounded.
+    // `@@@%H` prefixes each commit's section with a sentinel + sha (sanitised preview dirs can't
+    // start with `@`, so it never collides with a `--name-only` path line). Walking newest-first
+    // and
+    // capped keeps the read cost bounded.
     val out =
-      runGit("log", "--format=%x00%H", "--name-only", "--max-count=$MAX_TIMELINE_DEPTH", refCommit)
+      runGit("log", "--format=@@@%H", "--name-only", "--max-count=$MAX_TIMELINE_DEPTH", refCommit)
         ?: return emptyList()
     val entries = mutableListOf<HistoryEntry>()
     var commit: String? = null
     for (raw in out.split('\n')) {
-      if (raw.startsWith(' ')) {
-        commit = raw.substring(1).trim().ifEmpty { null }
+      if (raw.startsWith("@@@")) {
+        commit = raw.substring(3).trim().ifEmpty { null }
         continue
       }
       val path = raw.trim()
@@ -598,10 +662,17 @@ class GitRefHistorySource(
   private fun emptyPage(): HistoryListPage =
     HistoryListPage(entries = emptyList(), nextCursor = null, totalCount = 0)
 
-  /** Read-only vs write-local for a reporting ref. `WRITE_PUSH` is a follow-up (issue #1870). */
+  /** How this source treats the reporting ref. */
   enum class SyncMode {
+    /** Read the ref, never write. */
     READ_ONLY,
+    /** Commit each changed render onto the local ref via git plumbing; no push. */
     WRITE_LOCAL,
+    /**
+     * Like [WRITE_LOCAL], then `git push` the ref to a remote, with fetch–rebase–retry on a push
+     * race. Credentials are the host's concern; push failure degrades to a one-time warning.
+     */
+    WRITE_PUSH,
   }
 
   companion object {
@@ -661,8 +732,15 @@ class GitRefHistorySource(
     fun parseSyncModeSysprop(propValue: String? = System.getProperty(SYNC_MODE_PROP)): SyncMode =
       when (propValue?.trim()?.uppercase()) {
         "WRITE_LOCAL" -> SyncMode.WRITE_LOCAL
+        "WRITE_PUSH" -> SyncMode.WRITE_PUSH
         else -> SyncMode.READ_ONLY
       }
+
+    /** Default git remote for `WRITE_PUSH`. Remote-name config is a follow-up. */
+    const val DEFAULT_REMOTE: String = "origin"
+
+    /** Max push attempts before giving up (one initial + retries after fetch–rebase on a race). */
+    const val MAX_PUSH_ATTEMPTS: Int = 5
 
     fun defaultCacheDir(historyDir: Path): Path = historyDir.resolve(".git-ref-cache")
   }

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/GitRefHistorySource.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/GitRefHistorySource.kt
@@ -96,8 +96,15 @@ class GitRefHistorySource(
     }
     return try {
       val result = writeLocal(entry, png)
-      if (syncMode == SyncMode.WRITE_PUSH && result == WriteResult.WRITTEN) {
-        pushWithRetry(entry, png)
+      if (syncMode == SyncMode.WRITE_PUSH) {
+        if (result == WriteResult.WRITTEN) {
+          pushWithRetry(entry, png)
+        } else {
+          // No new commit this round, but a prior push may have failed (offline / missing creds),
+          // leaving the local ref ahead of the remote. Try to publish it now so a dedup'd render
+          // doesn't strand the ref unpublished until the pixels change again.
+          publishPendingCommits()
+        }
       }
       result
     } catch (t: Throwable) {
@@ -135,6 +142,20 @@ class GitRefHistorySource(
       attempt++
     }
     warnOncePush()
+  }
+
+  /**
+   * Best-effort fast-forward publish of any local commits the remote is missing — used when a write
+   * dedups ([WriteResult.SKIPPED_DUPLICATE]) but an earlier push may have failed, so the ref would
+   * otherwise stay unpublished until the pixels change again (#1880 review). A plain `git push`
+   * fast-forwards the remote (and is a no-op "up-to-date" success when nothing is pending); a
+   * genuine divergence is left for the next changed render's full replay rather than risking a
+   * clobber here. Only warns (once) on a real failure.
+   */
+  private fun publishPendingCommits() {
+    if (!plumbingOk(emptyMap(), "push", remote, "$ref:$ref")) {
+      warnOncePush()
+    }
   }
 
   /** Fetches [ref] from [remote] into FETCH_HEAD and resolves its tip; null on any failure. */

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/GitRefHistorySourceTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/GitRefHistorySourceTest.kt
@@ -475,6 +475,27 @@ class GitRefHistorySourceTest {
     assertTrue(warnLog.contains("could not push"))
   }
 
+  @Test
+  fun write_push_publishes_pending_commits_on_a_later_dedup() {
+    // First render commits locally but the push fails — no remote yet (one warning).
+    val src = source(SyncModeOf.WRITE_PUSH)
+    val bytes = "render-A".toByteArray()
+    val e = entry(id = "20260430-101200-aaaaaaaa", previewId = "com.example.A", bytes = bytes)
+    assertEquals(WriteResult.WRITTEN, src.write(e, bytes))
+    assertEquals(1, warnCount.get())
+
+    // The remote becomes available; an unchanged render dedups locally but must still publish the
+    // pending local commit (#1880 review) — not strand it until the pixels change.
+    val bare = setUpBareRemote()
+    assertEquals(WriteResult.SKIPPED_DUPLICATE, src.write(e, bytes))
+    val remoteTree = capture("git", "--git-dir=$bare", "ls-tree", "-r", "--name-only", ref)
+    assertTrue(
+      "dedup'd render still published the pending commit",
+      remoteTree.contains("com.example.A/entry.json"),
+    )
+    assertEquals("no new warning once the push succeeds", 1, warnCount.get())
+  }
+
   // -------------------------------------------------------------------------
   // Helpers
   // -------------------------------------------------------------------------

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/GitRefHistorySourceTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/GitRefHistorySourceTest.kt
@@ -30,6 +30,7 @@ import org.junit.Test
 class GitRefHistorySourceTest {
 
   private lateinit var repoRoot: Path
+  private var bareRemote: Path? = null
   private val warnLog = StringBuilder()
   private val warnCount = AtomicInteger(0)
 
@@ -59,6 +60,7 @@ class GitRefHistorySourceTest {
   @After
   fun tearDown() {
     if (this::repoRoot.isInitialized) repoRoot.toFile().deleteRecursively()
+    bareRemote?.parent?.toFile()?.deleteRecursively()
   }
 
   // -------------------------------------------------------------------------
@@ -409,8 +411,82 @@ class GitRefHistorySourceTest {
   }
 
   // -------------------------------------------------------------------------
+  // WRITE_PUSH (#1880) — push to a local bare remote; auth remotes can't run in CI.
+  // -------------------------------------------------------------------------
+
+  @Test
+  fun write_push_publishes_the_ref_to_the_remote() {
+    val bare = setUpBareRemote()
+    val src = source(SyncModeOf.WRITE_PUSH)
+    val bytes = "render-A".toByteArray()
+    val e = entry(id = "20260430-101200-aaaaaaaa", previewId = "com.example.A", bytes = bytes)
+    assertEquals(WriteResult.WRITTEN, src.write(e, bytes))
+
+    // The local ref has it...
+    assertEquals(1, src.list(HistoryFilter()).totalCount)
+    // ...and the push landed it on the remote too.
+    val remoteTree = capture("git", "--git-dir=$bare", "ls-tree", "-r", "--name-only", ref)
+    assertTrue(remoteTree.contains("com.example.A/entry.json"))
+    assertTrue(remoteTree.contains("com.example.A/render.png"))
+    assertEquals("no push warning on success", 0, warnCount.get())
+  }
+
+  @Test
+  fun write_push_retries_on_a_race_without_clobbering() {
+    val bare = setUpBareRemote()
+    val src = source(SyncModeOf.WRITE_PUSH)
+
+    // Two clean pushes of different previews advance the remote to an X+Z tip.
+    val x =
+      entry(id = "20260430-100000-aaaaaaaa", previewId = "com.example.X", bytes = "x".toByteArray())
+    assertEquals(WriteResult.WRITTEN, src.write(x, "x".toByteArray()))
+    val z =
+      entry(id = "20260430-100100-bbbbbbbb", previewId = "com.example.Z", bytes = "z".toByteArray())
+    assertEquals(WriteResult.WRITTEN, src.write(z, "z".toByteArray()))
+
+    // Simulate a competing writer: rewind the LOCAL ref to the X-only commit so the next push is a
+    // non-fast-forward against the remote's X+Z tip (the remote keeps X+Z).
+    val xOnly = capture("git", "-C", repoRoot.toString(), "rev-parse", "$ref~1").trim()
+    runOk("git", "-C", repoRoot.toString(), "update-ref", ref, xOnly)
+
+    val y =
+      entry(id = "20260430-100200-cccccccc", previewId = "com.example.Y", bytes = "y".toByteArray())
+    assertEquals(WriteResult.WRITTEN, src.write(y, "y".toByteArray()))
+
+    // The retry fetched the remote tip and replayed Y on top — all three previews survive on the
+    // remote, with no clobber and no warning.
+    val remoteTree = capture("git", "--git-dir=$bare", "ls-tree", "-r", "--name-only", ref)
+    assertTrue("X kept", remoteTree.contains("com.example.X/entry.json"))
+    assertTrue("Z (the competing render) kept", remoteTree.contains("com.example.Z/entry.json"))
+    assertTrue("Y landed via retry", remoteTree.contains("com.example.Y/entry.json"))
+    assertEquals("race resolved without warning", 0, warnCount.get())
+  }
+
+  @Test
+  fun write_push_degrades_to_one_warning_without_a_remote() {
+    // No `origin` configured: the push (and the fetch retry) fail, but the render is unaffected and
+    // the local commit still lands.
+    val src = source(SyncModeOf.WRITE_PUSH)
+    val bytes = "render".toByteArray()
+    val e = entry(id = "20260430-101200-aaaaaaaa", previewId = "com.example.A", bytes = bytes)
+    assertEquals(WriteResult.WRITTEN, src.write(e, bytes))
+    assertEquals("local commit still made", 1, src.list(HistoryFilter()).totalCount)
+    assertEquals("one-time push warning", 1, warnCount.get())
+    assertTrue(warnLog.contains("could not push"))
+  }
+
+  // -------------------------------------------------------------------------
   // Helpers
   // -------------------------------------------------------------------------
+
+  /** Creates a bare repo and wires it as `origin` of [repoRoot]; cleaned up in [tearDown]. */
+  private fun setUpBareRemote(): String {
+    val bare = Files.createTempDirectory("git-ref-remote").resolve("remote.git")
+    bareRemote = bare
+    runOk("git", "init", "--bare", "-q", bare.toString())
+    runOk("git", "-C", repoRoot.toString(), "remote", "add", "origin", bare.toString())
+    return bare.toString()
+  }
 
   private val json = Json {
     ignoreUnknownKeys = true
@@ -421,6 +497,7 @@ class GitRefHistorySourceTest {
   private object SyncModeOf {
     val READ_ONLY = GitRefHistorySource.SyncMode.READ_ONLY
     val WRITE_LOCAL = GitRefHistorySource.SyncMode.WRITE_LOCAL
+    val WRITE_PUSH = GitRefHistorySource.SyncMode.WRITE_PUSH
   }
 
   private fun source(

--- a/docs/daemon/REPORTING-BRANCH.md
+++ b/docs/daemon/REPORTING-BRANCH.md
@@ -153,9 +153,18 @@ alongside `composeai.daemon.gitRefHistory=<ref>`. The skip-if-no-diff predicate 
 disagree on what counts as a duplicate. The reader also falls back to the legacy read-only
 format (`_index.jsonl` + `<entryId>.{png,json}`) for refs that predate this layout.
 
+**`WRITE_PUSH`** (#1880) extends `WRITE_LOCAL`: after the local commit it `git push`es
+`<ref>:<ref>` to a remote (default `origin`; enable with
+`composeai.daemon.gitRefHistorySyncMode=WRITE_PUSH`). A push race — the remote ref
+advanced (non-fast-forward) — is resolved with fetch → fast-forward the local ref to the
+remote tip → replay this render on top (re-running `WRITE_LOCAL`, which dedups to a no-op
+if the remote already carries it) → retry, with backoff. Because each preview owns disjoint
+paths, a competing writer's renders survive the replay rather than being clobbered.
+Credentials are the host's concern; when the push (or its fetch retry) can't reach the
+remote it degrades to a one-time warning — the local commit always stands.
+
 Still to land (follow-ups):
 
-- **`WRITE_PUSH`** — also `git push` the ref, with fetch–rebase–retry on a push
-  race (needs a remote + credentials).
 - **Burst debounce** — batch a render burst into one commit instead of one
   commit per render.
+- **Configurable push remote** — `WRITE_PUSH` currently pushes to `origin`.


### PR DESCRIPTION
## Summary

Implements **`WRITE_PUSH`** (#1880) — the reporting branch's "publish" step, so render history reaches a remote where others / CI / the hosted surface can read it. This is the last major piece of the report-history epic (#1866).

After the `WRITE_LOCAL` commit, `WRITE_PUSH` `git push`es `<ref>:<ref>` to a remote (default `origin`; `composeai.daemon.gitRefHistorySyncMode=WRITE_PUSH`). A **push race** — the remote ref advanced (non-fast-forward) — is resolved with **fetch → fast-forward the local ref to the remote tip → replay this render on top (re-running `WRITE_LOCAL`) → retry**, with backoff. Because each preview owns disjoint paths, a competing writer's renders survive the replay rather than being clobbered, and an identical render dedups to a no-op. **Credentials are the host's concern** — when the push (or its fetch retry) can't reach the remote, it degrades to a one-time warning and never fails the render (same posture as the rest of history recording).

This reuses the existing `writeLocal` for the replay rather than refactoring it, so the change is contained to `GitRefHistorySource` (+ enum/sysprop) — **no `DaemonMain`/Android changes** (remote defaults to `origin`; remote-name config is a noted follow-up).

### Also in this PR (drive-by hygiene)
The `walkTimeline` commit-marker introduced in #1913 used a `%x00` git format whose `''` char literal landed as a **raw NUL byte** in the source — making `GitRefHistorySource.kt` a *binary* file to `grep`/`diff`/review. Swapped it for a printable `@@@` sentinel (sanitised preview dirs can't start with `@`, so it never collides with a `--name-only` path line). Confirmed the timeline tests still pass and no NUL remains.

### Changes
- `SyncMode.WRITE_PUSH` + `supportsWrites()`/`parseSyncModeSysprop` wiring; `remote` ctor param (default `origin`); `pushWithRetry` / `fetchRemoteTip` / `warnOncePush` / `backoff`.
- `walkTimeline` NUL → `@@@` sentinel.
- `REPORTING-BRANCH.md` Status documents `WRITE_PUSH`.

## Test plan
- New `GitRefHistorySourceTest` cases (git-gated; **local bare remote** per #1880's note that auth remotes can't run in CI):
  - **clean push** lands the ref + entry on the remote, no warning;
  - **same-preview race** (rewind local ref so the next push is non-ff vs an X+Z remote tip) fetches + replays Y on top — all of X, Z, Y survive, no clobber, no warning;
  - **missing remote** → one-time `could not push` warning, local commit intact, render `WRITTEN`.
- `daemon:core` history + `JsonRpcServerHistory` suites pass; `ktfmt` clean.

Daemon-only; no protocol change, no visual surface.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CPjwnCtY5aiBTFkVrrFjhS)_