### PR TITLE
fix(apply): guard against CLI/plugin version skew (#1920)

### DIFF
--- a/.github/actions/apply/README.md
+++ b/.github/actions/apply/README.md
@@ -1,0 +1,108 @@
+# `apply` — compose-preview CI in one step
+
+Unified composite action for the compose-preview CI surface. Auto-selects
+baseline vs. comment mode from the triggering event, runs the four
+pipelines (compose / resources / a11y / notifications) back-to-back, and
+pushes baselines / PR renders + posts sticky PR comments. Replaces the
+per-surface `preview-baselines` / `preview-comment` / `a11y-report` /
+`notification-previews` composites (now thin, deprecated forwarders).
+
+## Basic usage
+
+<!-- x-release-please-start-version -->
+```yaml
+- uses: actions/setup-java@v5
+  with:
+    distribution: temurin
+    java-version: 17
+- uses: yschimke/compose-ai-tools/.github/actions/apply@v0.15.9
+  with:
+    cli-version: catalog          # track the plugin — see "Version skew" below
+    catalog-key: composePreviewPlugin
+```
+<!-- x-release-please-end -->
+
+On a `pull_request` this renders the PR and posts before/after comparison
+comments; on a `push` to the development branch (`main` by default) it
+refreshes the baselines. See [`action.yml`](action.yml) for the full input
+schema — there are ~20 inputs covering pipeline selection (`only` / `skip`),
+per-module allow/deny lists, the missing-render policy, and non-Gradle
+`skip-render` integration.
+
+## Version skew
+
+> **The single most common way this action breaks.** Pinning the action ref
+> (`apply@vX`) does **not** pin the CLI. `cli-version` defaults to `latest`,
+> so every new compose-ai-tools release auto-installs the newest CLI against
+> your still-pinned Gradle plugin. A CLI **newer** than the applied plugin
+> can't discover that older plugin, so the render finds zero preview modules
+> and the pipeline fails repo-wide — on a release, not on your diff — with a
+> misleading:
+>
+> ```
+> ✗ no modules have the compose-preview plugin applied
+> compose pipeline: No preview modules discovered ... skipping.
+> ```
+
+Pin the CLI to the **same source of truth as the plugin** so the two can't
+skew. Declare the plugin version once in your version catalog and point the
+action at it:
+
+<!-- x-release-please-start-version -->
+```toml
+# gradle/libs.versions.toml
+[versions]
+composePreviewPlugin = "0.15.9"
+
+[plugins]
+composePreview = { id = "ee.schimke.composeai.preview", version.ref = "composePreviewPlugin" }
+```
+
+```yaml
+- uses: yschimke/compose-ai-tools/.github/actions/apply@v0.15.9
+  with:
+    cli-version: catalog            # reads the version below from the catalog
+    catalog-key: composePreviewPlugin
+```
+<!-- x-release-please-end -->
+
+[Renovate](https://docs.renovatebot.com/) then bumps the one `[versions]`
+entry on each release and the CLI follows automatically. (The same
+catalog/Renovate recipe is documented for the standalone
+[`install`](../install/README.md#pin-the-cli-to-a-gradle-version-catalog)
+action.)
+
+### Skew guardrail
+
+Even without switching to `catalog`, the action defends against this footgun:
+after installing the CLI it reads the plugin version you pin in the checkout
+(catalog `[plugins]` entry or a literal `id("…") version "…"`) and, when the
+installed CLI is newer, **fails fast with an actionable message** instead of
+letting the pipeline die downstream with the confusing "no modules" error.
+
+Control it with the `skew-check` input:
+
+| `skew-check` | Behaviour |
+|---|---|
+| `fail` (default) | Error out before the pipelines run when the CLI is newer than the pinned plugin. |
+| `warn` | Log a `::warning::` and keep going. |
+| `off` | Skip the check entirely. |
+
+The guard only acts when it can read a concrete plugin version **and** both
+sides are clean releases (no `-SNAPSHOT` / pre-release suffixes), so consumers
+who deliberately track `latest` via the CLI's `--init-script` auto-inject —
+with no plugin pinned in their build — are never tripped.
+
+## `cli-version` values
+
+| Value | Meaning |
+|---|---|
+| `latest` (current default) | Newest published release. **Skews ahead of a pinned plugin** — see above. |
+| `catalog` | Read the version from a Gradle version catalog (`catalog-path` / `catalog-key`). Recommended. |
+| literal (e.g. `0.15.9`) | Exact release. |
+| `source` | Build from the current checkout — internal CI only. |
+| `none` | Skip CLI install (pair with `skip-render: true` for non-Gradle build systems). |
+
+## Related actions
+
+- [`install`](../install/) — just put the CLI on `$PATH`, no pipelines.

--- a/.github/actions/apply/action.yml
+++ b/.github/actions/apply/action.yml
@@ -22,6 +22,20 @@ inputs:
   catalog-key:
     description: '[versions] key to read (when cli-version=catalog).'
     default: 'composePreviewCli'
+  skew-check:
+    description: >
+      Guardrail against CLI / Gradle-plugin version skew (issue #1920). After
+      the CLI is installed, compare its resolved version against the plugin
+      version pinned in the consumer's checkout (version catalog `[plugins]`
+      entry or a literal `id("…") version "…"`). When the CLI is *newer* than
+      the applied plugin — the case where the newer CLI silently fails to
+      discover the older plugin and the render reports "no modules have the
+      plugin applied" — surface an actionable message instead. `fail` (default)
+      errors out fast; `warn` logs a `::warning::` and continues; `off` skips
+      the check. Only acts when a concrete plugin version is detectable and both
+      sides are clean releases, so auto-inject consumers tracking `latest` are
+      never tripped.
+    default: 'fail'
   timeout:
     description: 'CLI render timeout in seconds.'
     default: '600'
@@ -200,6 +214,7 @@ runs:
     # `skip-render: true` and pre-staged JSON; a11y / notifications fail
     # cleanly with "command not found" when selected without a CLI.
     - name: Install CLI from release
+      id: install-release
       if: steps.resolve.outputs.mode != 'skip' && inputs.cli-version != 'source' && inputs.cli-version != 'none'
       # zizmor: ignore[known-vulnerable-actions] same-repo release action trips GitHub Advisories API 403 under GITHUB_TOKEN
       uses: yschimke/compose-ai-tools/.github/actions/install@v0.11.5 # x-release-please-version
@@ -207,6 +222,27 @@ runs:
         version: ${{ inputs.cli-version }}
         catalog-path: ${{ inputs.catalog-path }}
         catalog-key: ${{ inputs.catalog-key }}
+
+    # Guardrail against CLI / plugin version skew (issue #1920). The install
+    # action resolved a concrete CLI version above; compare it against the
+    # plugin version the consumer actually pins in their checkout. A CLI newer
+    # than the applied plugin is the silent footgun that breaks discovery
+    # repo-wide on every release — fail fast here with an actionable message
+    # rather than letting the pipeline die downstream with the misleading
+    # "no modules have the plugin applied". Skipped for `source` (internal CI,
+    # no resolved release version) and `none` (no CLI installed). Pure-Python,
+    # no Gradle cost — runs before doctor so the headline is the skew, not the
+    # confusing symptom.
+    - name: Check CLI / plugin version skew
+      if: steps.resolve.outputs.mode != 'skip' && inputs.cli-version != 'source' && inputs.cli-version != 'none'
+      shell: bash
+      env:
+        ACTION_PATH: ${{ github.action_path }}
+        RESOLVED_CLI_VERSION: ${{ steps.install-release.outputs.version }}
+        SKEW_MODE: ${{ inputs.skew-check }}
+        WORKSPACE: ${{ github.workspace }}
+        CATALOG_PATH: ${{ inputs.catalog-path }}
+      run: python3 "$ACTION_PATH/check-skew.py"
 
     # Surface `compose-preview doctor`'s environment + project checks at
     # the top of the run, before any pipeline starts paying Gradle cost.

--- a/.github/actions/apply/check-skew.py
+++ b/.github/actions/apply/check-skew.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""Guardrail against compose-preview CLI / Gradle-plugin version skew.
+
+Background (issue #1920): the `apply` action installs the CLI independently
+of the Gradle plugin the consumer pins in their build. When the installed CLI
+is *newer* than the applied plugin, the newer CLI's Tooling-model query fails
+to discover the older plugin, so the render finds zero preview modules and the
+pipeline dies with a generic "no modules have the compose-preview plugin
+applied" — which reads like a project misconfiguration, not the version skew
+it actually is. Defaulting `cli-version: latest` made the *common* path the
+broken path: every new release auto-jumped the CLI ahead of a still-pinned
+plugin.
+
+This script runs after the CLI is installed and BEFORE the pipelines pay any
+Gradle cost. It reads the resolved CLI version from the environment, sniffs
+the applied plugin version out of the consumer's checkout (version catalog
+`[plugins]` entry or a literal `id("…") version "…"` in a build script), and
+when the CLI is strictly newer, surfaces an actionable message instead of the
+misleading downstream failure.
+
+Conservative by construction — it only acts when it can read a concrete plugin
+version AND both versions are clean releases (no `-SNAPSHOT` / pre-release
+suffixes). When the plugin version can't be found (e.g. the consumer relies on
+the CLI's `--init-script` auto-inject and deliberately tracks `latest`) it
+stays silent, so the guardrail never invents a failure on the happy path.
+
+Environment inputs:
+- ``RESOLVED_CLI_VERSION`` — the concrete version the install action resolved
+  (no leading "v"). Empty → skip (nothing to compare).
+- ``SKEW_MODE`` — ``fail`` (default; emit ``::error::`` + exit 1), ``warn``
+  (emit ``::warning::`` + exit 0), or ``off`` (skip entirely).
+- ``WORKSPACE`` — consumer checkout root to scan. Defaults to ``$GITHUB_WORKSPACE``
+  then ``.``.
+- ``CATALOG_PATH`` — version-catalog path (the action's ``catalog-path`` input),
+  relative to ``WORKSPACE``. Defaults to ``gradle/libs.versions.toml``.
+
+Kept as a standalone, import-friendly script (pure functions + a thin
+``main``) so the detection + comparison logic is unit-tested in isolation
+(`test_check_skew.py`) without spinning up a runner.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+import tomllib
+
+PLUGIN_ID = "ee.schimke.composeai.preview"
+
+# Directories we never descend into while hunting for a literal plugin
+# declaration — build outputs and VCS/tooling metadata can't host a consumer's
+# `plugins { }` block, and walking them is pure cost.
+_SKIP_DIRS = {"build", ".gradle", ".git", "node_modules", "out", "dist", ".idea"}
+
+# Bounded walk depth: module build scripts live a handful of directories below
+# the root in normal layouts. Deep enough for nested modules, shallow enough to
+# stay cheap on a large monorepo.
+_MAX_DEPTH = 5
+
+# `id("ee.schimke.composeai.preview") version "0.15.8"` and its spelling
+# variants: `id 'x' version '0.15.8'` (Groovy), `id("x").version("0.15.8")`,
+# `version("0.15.8")`. Capture group 1 is the version literal.
+_LITERAL_RE = re.compile(
+    r"""id\s*[(\s]\s*["']"""
+    + re.escape(PLUGIN_ID)
+    + r"""["']\s*\)?\s*(?:\.\s*)?version\s*[(\s]\s*["']([^"']+)["']""",
+)
+
+
+def _strip_comments(source: str) -> str:
+    """Drop `//` line comments and `/* … */` block comments.
+
+    Keeps a commented-out example (`// id("…") version "…"`) from being read as
+    a real declaration. Not a full Gradle parser — string-literal tracking is
+    out of scope, same posture as the CLI's own auto-inject scanner.
+    """
+    out: list[str] = []
+    i = 0
+    n = len(source)
+    while i < n:
+        c = source[i]
+        nxt = source[i + 1] if i + 1 < n else ""
+        if c == "/" and nxt == "/":
+            nl = source.find("\n", i)
+            if nl < 0:
+                break
+            i = nl
+        elif c == "/" and nxt == "*":
+            end = source.find("*/", i + 2)
+            i = n if end < 0 else end + 2
+        else:
+            out.append(c)
+            i += 1
+    return "".join(out)
+
+
+def plugin_version_from_catalog(catalog_file: str) -> str | None:
+    """Read the compose-preview plugin version from a Gradle version catalog.
+
+    Handles the three `[plugins]` spellings:
+    - inline table with a literal version:
+      ``foo = { id = "ee.schimke.composeai.preview", version = "0.15.8" }``
+    - inline table with a `version.ref` into `[versions]`:
+      ``foo = { id = "…", version.ref = "composePreviewPlugin" }``
+    - the colon string form: ``foo = "ee.schimke.composeai.preview:0.15.8"``
+
+    Returns the bare version (no leading "v") or ``None`` when the catalog is
+    missing/unparseable or declares no entry for the plugin id.
+    """
+    try:
+        with open(catalog_file, "rb") as fh:
+            cat = tomllib.load(fh)
+    except (FileNotFoundError, OSError, tomllib.TOMLDecodeError):
+        return None
+    plugins = cat.get("plugins")
+    if not isinstance(plugins, dict):
+        return None
+    versions = cat.get("versions")
+    versions = versions if isinstance(versions, dict) else {}
+    for entry in plugins.values():
+        if isinstance(entry, str):
+            # "id:version" — only ours, and only when a version is present.
+            base, _, ver = entry.partition(":")
+            if base == PLUGIN_ID and ver:
+                return ver.lstrip("v")
+            continue
+        if not isinstance(entry, dict) or entry.get("id") != PLUGIN_ID:
+            continue
+        ver = entry.get("version")
+        if isinstance(ver, str) and ver:
+            return ver.lstrip("v")
+        # `version.ref = "key"` parses as {"version": {"ref": "key"}}.
+        if isinstance(ver, dict):
+            ref = ver.get("ref")
+            resolved = versions.get(ref) if isinstance(ref, str) else None
+            if isinstance(resolved, str) and resolved:
+                return resolved.lstrip("v")
+    return None
+
+
+def plugin_version_from_build_scripts(workspace: str) -> str | None:
+    """Find a literal `id("…") version "…"` plugin pin in the checkout.
+
+    Walks build scripts under [workspace] (bounded depth, build/VCS dirs
+    skipped) and returns the first version literal that pins the plugin id.
+    Returns ``None`` when nothing matches.
+    """
+    root_depth = workspace.rstrip(os.sep).count(os.sep)
+    for dirpath, dirnames, filenames in os.walk(workspace):
+        depth = dirpath.rstrip(os.sep).count(os.sep) - root_depth
+        if depth >= _MAX_DEPTH:
+            dirnames[:] = []
+        else:
+            dirnames[:] = [d for d in dirnames if d not in _SKIP_DIRS]
+        for name in ("build.gradle.kts", "build.gradle"):
+            if name not in filenames:
+                continue
+            try:
+                with open(os.path.join(dirpath, name), encoding="utf-8") as fh:
+                    text = _strip_comments(fh.read())
+            except OSError:
+                continue
+            m = _LITERAL_RE.search(text)
+            if m:
+                return m.group(1).lstrip("v")
+    return None
+
+
+def detect_plugin_version(workspace: str, catalog_path: str) -> str | None:
+    """Best-effort applied-plugin version for [workspace].
+
+    Catalog first (the documented, Renovate-friendly pin), then a literal
+    declaration in a build script. ``None`` when neither is found — the signal
+    to stay silent rather than guess.
+    """
+    catalog_file = (
+        catalog_path
+        if os.path.isabs(catalog_path)
+        else os.path.join(workspace, catalog_path)
+    )
+    return plugin_version_from_catalog(catalog_file) or plugin_version_from_build_scripts(
+        workspace
+    )
+
+
+_SEMVER_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
+
+
+def parse_release(version: str) -> tuple[int, int, int] | None:
+    """Parse a *clean release* `major.minor.patch` into a tuple.
+
+    Returns ``None`` for anything with a pre-release / build suffix
+    (``0.15.9-SNAPSHOT``, ``0.16.0-rc1``, ``…-feature-x``) or a non-numeric
+    shape. We only compare clean releases — skew between SNAPSHOTs / locally
+    built CLIs is expected during development and must never trip the guard.
+    """
+    m = _SEMVER_RE.match(version.strip().lstrip("v"))
+    if not m:
+        return None
+    return (int(m.group(1)), int(m.group(2)), int(m.group(3)))
+
+
+def main() -> int:
+    mode = (os.environ.get("SKEW_MODE") or "fail").strip().lower()
+    if mode == "off":
+        return 0
+
+    cli_raw = (os.environ.get("RESOLVED_CLI_VERSION") or "").strip().lstrip("v")
+    if not cli_raw:
+        # No resolved CLI version handed in (source build, install skipped) —
+        # nothing to compare against.
+        return 0
+
+    workspace = (
+        os.environ.get("WORKSPACE") or os.environ.get("GITHUB_WORKSPACE") or "."
+    )
+    catalog_path = os.environ.get("CATALOG_PATH") or "gradle/libs.versions.toml"
+
+    plugin_raw = detect_plugin_version(workspace, catalog_path)
+    if not plugin_raw:
+        # Couldn't read a pinned plugin version (auto-inject / unrecognised
+        # shape). Don't guess — staying silent keeps the happy path green.
+        return 0
+
+    cli = parse_release(cli_raw)
+    plugin = parse_release(plugin_raw)
+    if cli is None or plugin is None:
+        # A SNAPSHOT / pre-release on either side — skew is expected, skip.
+        return 0
+
+    if cli <= plugin:
+        # CLI matches or trails the plugin: the plugin-discovery hazard this
+        # guard exists for doesn't apply. (Plugin newer than CLI is a separate,
+        # rarer case that `compose-preview doctor` already flags for majors.)
+        print(
+            f"compose-preview: CLI v{cli_raw} aligned with applied plugin v{plugin_raw}."
+        )
+        return 0
+
+    message = (
+        f"compose-preview CLI v{cli_raw} is newer than the applied Gradle plugin "
+        f"v{plugin_raw}. The newer CLI can't discover the older plugin, so the "
+        f"render finds no preview modules (you'd otherwise see the misleading "
+        f'"no modules have the compose-preview plugin applied"). Fix by bumping '
+        f"the plugin to v{cli_raw}, or pin the CLI to the plugin so they can't "
+        f"skew: set `cli-version: catalog` (with `catalog-key` pointing at your "
+        f"plugin's version key). See "
+        f"https://github.com/yschimke/compose-ai-tools/blob/main/.github/actions/apply/README.md#version-skew"
+    )
+    if mode == "warn":
+        print(f"::warning::{message}")
+        return 0
+    print(f"::error::{message}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/actions/apply/test_check_skew.py
+++ b/.github/actions/apply/test_check_skew.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""Tests for check-skew.py (issue #1920 CLI/plugin skew guardrail).
+
+Pure stdlib (unittest) — same shape as the lib/test_*.py suites. Run:
+
+    python3 .github/actions/apply/test_check_skew.py -v
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import os
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_SPEC = importlib.util.spec_from_file_location("check_skew", _HERE / "check-skew.py")
+cs = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(cs)
+
+
+class ParseReleaseTests(unittest.TestCase):
+    def test_clean_release(self):
+        self.assertEqual(cs.parse_release("0.15.9"), (0, 15, 9))
+        self.assertEqual(cs.parse_release("v1.2.3"), (1, 2, 3))
+
+    def test_ordering(self):
+        self.assertLess(cs.parse_release("0.15.8"), cs.parse_release("0.15.9"))
+        self.assertLess(cs.parse_release("0.9.0"), cs.parse_release("0.15.0"))
+        self.assertLess(cs.parse_release("0.15.9"), cs.parse_release("1.0.0"))
+
+    def test_snapshot_and_prerelease_skip(self):
+        self.assertIsNone(cs.parse_release("0.15.9-SNAPSHOT"))
+        self.assertIsNone(cs.parse_release("0.16.0-rc1"))
+        self.assertIsNone(cs.parse_release("0.8.13-feature-x-abc123-SNAPSHOT"))
+
+    def test_malformed_skip(self):
+        self.assertIsNone(cs.parse_release(""))
+        self.assertIsNone(cs.parse_release("latest"))
+        self.assertIsNone(cs.parse_release("0.15"))
+
+
+class CatalogDetectionTests(unittest.TestCase):
+    def _catalog(self, body: str) -> str:
+        d = tempfile.mkdtemp()
+        self.addCleanup(lambda: __import__("shutil").rmtree(d, ignore_errors=True))
+        p = os.path.join(d, "libs.versions.toml")
+        Path(p).write_text(body, encoding="utf-8")
+        return p
+
+    def test_version_ref(self):
+        cat = self._catalog(
+            """
+[versions]
+composePreviewPlugin = "0.15.8"
+
+[plugins]
+composePreview = { id = "ee.schimke.composeai.preview", version.ref = "composePreviewPlugin" }
+"""
+        )
+        self.assertEqual(cs.plugin_version_from_catalog(cat), "0.15.8")
+
+    def test_inline_version(self):
+        cat = self._catalog(
+            """
+[plugins]
+composePreview = { id = "ee.schimke.composeai.preview", version = "0.15.7" }
+"""
+        )
+        self.assertEqual(cs.plugin_version_from_catalog(cat), "0.15.7")
+
+    def test_string_form(self):
+        cat = self._catalog(
+            """
+[plugins]
+composePreview = "ee.schimke.composeai.preview:0.15.6"
+"""
+        )
+        self.assertEqual(cs.plugin_version_from_catalog(cat), "0.15.6")
+
+    def test_unrelated_plugins_ignored(self):
+        cat = self._catalog(
+            """
+[versions]
+agp = "8.13.0"
+
+[plugins]
+android = { id = "com.android.application", version.ref = "agp" }
+"""
+        )
+        self.assertIsNone(cs.plugin_version_from_catalog(cat))
+
+    def test_missing_file(self):
+        self.assertIsNone(cs.plugin_version_from_catalog("/nonexistent/libs.versions.toml"))
+
+
+class BuildScriptDetectionTests(unittest.TestCase):
+    def _workspace(self) -> str:
+        d = tempfile.mkdtemp()
+        self.addCleanup(lambda: __import__("shutil").rmtree(d, ignore_errors=True))
+        return d
+
+    def test_literal_kts(self):
+        ws = self._workspace()
+        mod = os.path.join(ws, "app")
+        os.makedirs(mod)
+        Path(os.path.join(mod, "build.gradle.kts")).write_text(
+            'plugins {\n  id("ee.schimke.composeai.preview") version "0.15.8"\n}\n',
+            encoding="utf-8",
+        )
+        self.assertEqual(cs.plugin_version_from_build_scripts(ws), "0.15.8")
+
+    def test_groovy_single_quotes(self):
+        ws = self._workspace()
+        Path(os.path.join(ws, "build.gradle")).write_text(
+            "plugins {\n  id 'ee.schimke.composeai.preview' version '0.14.0'\n}\n",
+            encoding="utf-8",
+        )
+        self.assertEqual(cs.plugin_version_from_build_scripts(ws), "0.14.0")
+
+    def test_commented_out_declaration_ignored(self):
+        ws = self._workspace()
+        Path(os.path.join(ws, "build.gradle.kts")).write_text(
+            '// id("ee.schimke.composeai.preview") version "0.1.0"\nplugins {}\n',
+            encoding="utf-8",
+        )
+        self.assertIsNone(cs.plugin_version_from_build_scripts(ws))
+
+    def test_build_dir_skipped(self):
+        ws = self._workspace()
+        buildout = os.path.join(ws, "build")
+        os.makedirs(buildout)
+        Path(os.path.join(buildout, "build.gradle.kts")).write_text(
+            'id("ee.schimke.composeai.preview") version "9.9.9"\n', encoding="utf-8"
+        )
+        self.assertIsNone(cs.plugin_version_from_build_scripts(ws))
+
+
+class MainTests(unittest.TestCase):
+    def _run(self, env: dict[str, str]) -> tuple[int, str]:
+        saved = dict(os.environ)
+        os.environ.clear()
+        os.environ.update(env)
+        buf = io.StringIO()
+        try:
+            with redirect_stdout(buf):
+                rc = cs.main()
+        finally:
+            os.environ.clear()
+            os.environ.update(saved)
+        return rc, buf.getvalue()
+
+    def _ws_with_plugin(self, version: str) -> str:
+        d = tempfile.mkdtemp()
+        self.addCleanup(lambda: __import__("shutil").rmtree(d, ignore_errors=True))
+        os.makedirs(os.path.join(d, "gradle"))
+        Path(os.path.join(d, "gradle", "libs.versions.toml")).write_text(
+            f'[plugins]\ncomposePreview = "ee.schimke.composeai.preview:{version}"\n',
+            encoding="utf-8",
+        )
+        return d
+
+    def test_cli_newer_fails(self):
+        ws = self._ws_with_plugin("0.15.8")
+        rc, out = self._run(
+            {"RESOLVED_CLI_VERSION": "0.15.9", "WORKSPACE": ws, "SKEW_MODE": "fail"}
+        )
+        self.assertEqual(rc, 1)
+        self.assertIn("::error::", out)
+        self.assertIn("0.15.9", out)
+        self.assertIn("0.15.8", out)
+
+    def test_cli_newer_warn_mode(self):
+        ws = self._ws_with_plugin("0.15.8")
+        rc, out = self._run(
+            {"RESOLVED_CLI_VERSION": "0.15.9", "WORKSPACE": ws, "SKEW_MODE": "warn"}
+        )
+        self.assertEqual(rc, 0)
+        self.assertIn("::warning::", out)
+
+    def test_cli_newer_off_mode(self):
+        ws = self._ws_with_plugin("0.15.8")
+        rc, out = self._run(
+            {"RESOLVED_CLI_VERSION": "0.15.9", "WORKSPACE": ws, "SKEW_MODE": "off"}
+        )
+        self.assertEqual(rc, 0)
+        self.assertEqual(out, "")
+
+    def test_aligned_ok(self):
+        ws = self._ws_with_plugin("0.15.9")
+        rc, out = self._run({"RESOLVED_CLI_VERSION": "0.15.9", "WORKSPACE": ws})
+        self.assertEqual(rc, 0)
+        self.assertNotIn("::error::", out)
+
+    def test_cli_older_ok(self):
+        ws = self._ws_with_plugin("0.16.0")
+        rc, out = self._run({"RESOLVED_CLI_VERSION": "0.15.9", "WORKSPACE": ws})
+        self.assertEqual(rc, 0)
+        self.assertNotIn("::error::", out)
+
+    def test_no_plugin_detected_silent(self):
+        d = tempfile.mkdtemp()
+        self.addCleanup(lambda: __import__("shutil").rmtree(d, ignore_errors=True))
+        rc, out = self._run({"RESOLVED_CLI_VERSION": "0.15.9", "WORKSPACE": d})
+        self.assertEqual(rc, 0)
+        self.assertNotIn("::error::", out)
+
+    def test_snapshot_cli_skips(self):
+        ws = self._ws_with_plugin("0.15.8")
+        rc, out = self._run(
+            {"RESOLVED_CLI_VERSION": "0.15.9-SNAPSHOT", "WORKSPACE": ws}
+        )
+        self.assertEqual(rc, 0)
+        self.assertNotIn("::error::", out)
+
+    def test_empty_cli_version_skips(self):
+        ws = self._ws_with_plugin("0.15.8")
+        rc, out = self._run({"RESOLVED_CLI_VERSION": "", "WORKSPACE": ws})
+        self.assertEqual(rc, 0)
+        self.assertNotIn("::error::", out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/actions/install/README.md
+++ b/.github/actions/install/README.md
@@ -26,6 +26,13 @@ remainder of the job.
 
 ## Pin the CLI to a Gradle version catalog
 
+> **Avoid CLI / plugin version skew.** `version: latest` floats to the
+> newest release independent of the Gradle plugin you've pinned. A CLI
+> newer than the applied plugin can't discover it, so renders break on
+> every release (issue #1920). Pin both from one source of truth — and if
+> you drive CI through the [`apply`](../apply/README.md#version-skew)
+> action, it also guards against this automatically.
+
 To keep the CLI version in lockstep with the rest of the project's
 toolchain, declare it in `gradle/libs.versions.toml` and let
 [Renovate](https://docs.renovatebot.com/) bump it on releases:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -461,6 +461,8 @@ jobs:
         run: python3 .github/actions/lib/test_notification_previews.py -v
       - name: Run xr-gallery tests
         run: python3 .github/actions/lib/test_xr_gallery.py -v
+      - name: Run apply skew-guard tests
+        run: python3 .github/actions/apply/test_check_skew.py -v
 
   # VS Code extension tests — both the existing in-process Mocha suite and
   # the @vscode/test-electron integration tests. The latter download a


### PR DESCRIPTION
The apply action installs the compose-preview CLI independently of the
Gradle plugin a consumer pins. With cli-version defaulting to `latest`,
every new release auto-jumps the CLI ahead of a still-pinned plugin; the
newer CLI can't discover the older plugin, so the render finds zero
preview modules and the pipeline dies repo-wide with a misleading "no
modules have the compose-preview plugin applied" — tracking the release,
not the diff.

Add a pure-Python guardrail that runs after install and before any Gradle
cost: it reads the resolved CLI version and the plugin version pinned in
the checkout (version-catalog `[plugins]` entry or a literal
`id("…") version "…"`), and when the CLI is strictly newer it fails fast
with an actionable message (bump the plugin, or pin the CLI with
`cli-version: catalog`). Conservative by design — only acts on a concrete,
detectable plugin version where both sides are clean releases, so
auto-inject consumers tracking `latest` are never tripped. Behaviour is
configurable via the new `skew-check` input (fail / warn / off).

Document the footgun prominently in a new apply README and cross-link it
from the install README. Unit-tested (test_check_skew.py, wired into the
ci.yml actions-tests job).