### PR TITLE
feat(daemon): curate the reporting branch by publish policy (skip dirty / off-branch renders)

### DIFF
--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/GitRefHistorySource.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/GitRefHistorySource.kt
@@ -83,6 +83,8 @@ class GitRefHistorySource(
    * render (synchronous, today's behaviour).
    */
   private val debounceMs: Long = 0,
+  /** Which renders reach the reporting branch (#1872 curation); see [PublishPolicy]. */
+  private val publishPolicy: PublishPolicy = PublishPolicy.CLEAN_ON_BRANCH,
 ) : HistorySource {
 
   override val id: String = displayId
@@ -101,6 +103,10 @@ class GitRefHistorySource(
     if (!supportsWrites()) {
       error("GitRefHistorySource(ref=$ref) is $syncMode; writes go to a writable source.")
     }
+    // Curation (#1872): keep uncommitted / off-branch local states off the shared branch. The
+    // render
+    // still lands in the local FS history; it just isn't buffered, committed, or pushed here.
+    if (!shouldPublish(entry)) return WriteResult.SKIPPED_DUPLICATE
     return try {
       // Debounced: buffer for the window; a burst coalesces into one commit on flush (#1882). The
       // local FS source (priority 0) drives `historyAdded`, so deferring the branch commit is
@@ -116,6 +122,23 @@ class GitRefHistorySource(
       )
       WriteResult.SKIPPED_DUPLICATE
     }
+  }
+
+  /** The branch this ref tracks (e.g. `refs/heads/preview/main` → `main`). */
+  private val sourceBranch: String
+    get() = ref.removePrefix("refs/heads/preview/").removePrefix("refs/heads/")
+
+  /**
+   * Curation gate (#1872): whether [entry] may reach the reporting branch under [publishPolicy].
+   * [PublishPolicy.ALL] is always true; [PublishPolicy.CLEAN_ON_BRANCH] requires a clean working
+   * tree (`git.dirty != true`) on the tracked [sourceBranch]. A render with no git provenance is
+   * allowed (nothing to curate against — e.g. fake-mode / tests).
+   */
+  private fun shouldPublish(entry: HistoryEntry): Boolean {
+    if (publishPolicy == PublishPolicy.ALL) return true
+    val git = entry.git ?: return true
+    if (git.dirty == true) return false
+    return git.branch == sourceBranch
   }
 
   /**
@@ -487,7 +510,7 @@ class GitRefHistorySource(
         formatVersion = REPORTING_BRANCH_FORMAT_VERSION,
         generatedAt = Instant.now().toString(),
         commit = changed.firstOrNull()?.first?.git?.commit,
-        sourceBranch = ref.removePrefix("refs/heads/preview/").removePrefix("refs/heads/"),
+        sourceBranch = sourceBranch,
         previews = previews,
       )
     return MANIFEST_JSON.encodeToString(ReportingBranchManifest.serializer(), manifest).toBytes()
@@ -830,6 +853,23 @@ class GitRefHistorySource(
     WRITE_PUSH,
   }
 
+  /**
+   * Which renders are allowed onto the reporting branch (#1872 curation). The local FS source
+   * always records every render (the developer's scratch history); this only gates the *shared*
+   * branch so uncommitted / off-branch local states don't pollute it.
+   */
+  enum class PublishPolicy {
+    /** Record every render (today's behaviour) — no curation. */
+    ALL,
+    /**
+     * Only record renders of a **clean** working tree (`git.dirty != true`) that were produced **on
+     * the branch this ref tracks** (`git.branch == sourceBranch`), so each branch entry is a
+     * committed, reproducible state. Renders with no git provenance are allowed (nothing to curate
+     * against — e.g. fake-mode).
+     */
+    CLEAN_ON_BRANCH,
+  }
+
   companion object {
     /** Stable filename for the overwritten-per-render PNG on the ref. */
     const val RENDER_FILENAME: String = "render.png"
@@ -908,6 +948,21 @@ class GitRefHistorySource(
       if (propValue == null) return DEFAULT_DEBOUNCE_MS
       return propValue.trim().toLongOrNull()?.coerceAtLeast(0) ?: 0
     }
+
+    /** Sysprop for the reporting-branch publish policy (#1872 curation). */
+    const val PUBLISH_POLICY_PROP: String = "composeai.daemon.gitRefHistoryPublishPolicy"
+
+    /**
+     * Parses [PUBLISH_POLICY_PROP]; `all` → [PublishPolicy.ALL], else →
+     * [PublishPolicy.CLEAN_ON_BRANCH].
+     */
+    fun parsePublishPolicySysprop(
+      propValue: String? = System.getProperty(PUBLISH_POLICY_PROP)
+    ): PublishPolicy =
+      when (propValue?.trim()?.lowercase()) {
+        "all" -> PublishPolicy.ALL
+        else -> PublishPolicy.CLEAN_ON_BRANCH
+      }
 
     fun defaultCacheDir(historyDir: Path): Path = historyDir.resolve(".git-ref-cache")
   }

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryManager.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryManager.kt
@@ -513,6 +513,10 @@ class HistoryManager(
       // so the daemon mains need no change. On-demand read sources never write, so stay
       // un-debounced.
       gitRefDebounceMs: Long = GitRefHistorySource.parseDebounceSysprop(),
+      // #1872 — curation policy for the writable reporting-branch source; defaults from the
+      // sysprop.
+      gitRefPublishPolicy: GitRefHistorySource.PublishPolicy =
+        GitRefHistorySource.parsePublishPolicySysprop(),
     ): HistoryManager {
       val sources = buildList {
         if (historyDir != null) add(LocalFsHistorySource(historyDir = historyDir))
@@ -528,6 +532,7 @@ class HistoryManager(
                     ?: repoRoot.resolve(".compose-preview-history").resolve(".git-ref-cache"),
                 warnEmitter = warnEmitter,
                 debounceMs = gitRefDebounceMs,
+                publishPolicy = gitRefPublishPolicy,
               )
             )
           }

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/GitRefHistorySourceTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/GitRefHistorySourceTest.kt
@@ -629,6 +629,75 @@ class GitRefHistorySourceTest {
   }
 
   // -------------------------------------------------------------------------
+  // Publish policy / curation (#1872) — `ref` is refs/heads/preview/main ⇒ sourceBranch = "main"
+  // -------------------------------------------------------------------------
+
+  @Test
+  fun clean_on_branch_records_a_clean_render_on_the_tracked_branch() {
+    val src = source(SyncModeOf.WRITE_LOCAL, publishPolicy = PolicyOf.CLEAN_ON_BRANCH)
+    val e =
+      entry(
+        "20260430-100000-aaaaaaaa",
+        "com.example.A",
+        "a".toByteArray(),
+        git = GitInfo(branch = "main", dirty = false),
+      )
+    assertEquals(WriteResult.WRITTEN, src.write(e, "a".toByteArray()))
+    assertEquals(1, src.list(HistoryFilter()).totalCount)
+  }
+
+  @Test
+  fun clean_on_branch_skips_a_dirty_render() {
+    val src = source(SyncModeOf.WRITE_LOCAL, publishPolicy = PolicyOf.CLEAN_ON_BRANCH)
+    val e =
+      entry(
+        "20260430-100000-aaaaaaaa",
+        "com.example.A",
+        "a".toByteArray(),
+        git = GitInfo(branch = "main", dirty = true),
+      )
+    assertEquals(WriteResult.SKIPPED_DUPLICATE, src.write(e, "a".toByteArray()))
+    assertEquals("dirty render kept off the branch", 0, src.list(HistoryFilter()).totalCount)
+  }
+
+  @Test
+  fun clean_on_branch_skips_an_off_branch_render() {
+    val src = source(SyncModeOf.WRITE_LOCAL, publishPolicy = PolicyOf.CLEAN_ON_BRANCH)
+    val e =
+      entry(
+        "20260430-100000-aaaaaaaa",
+        "com.example.A",
+        "a".toByteArray(),
+        git = GitInfo(branch = "feature/x", dirty = false),
+      )
+    assertEquals(WriteResult.SKIPPED_DUPLICATE, src.write(e, "a".toByteArray()))
+    assertEquals("off-branch render kept off the branch", 0, src.list(HistoryFilter()).totalCount)
+  }
+
+  @Test
+  fun clean_on_branch_allows_a_render_without_git_provenance() {
+    // Fake-mode / no-git renders have null provenance — nothing to curate against, so they record.
+    val src = source(SyncModeOf.WRITE_LOCAL, publishPolicy = PolicyOf.CLEAN_ON_BRANCH)
+    val e = entry("20260430-100000-aaaaaaaa", "com.example.A", "a".toByteArray(), git = null)
+    assertEquals(WriteResult.WRITTEN, src.write(e, "a".toByteArray()))
+    assertEquals(1, src.list(HistoryFilter()).totalCount)
+  }
+
+  @Test
+  fun policy_all_records_dirty_and_off_branch_renders() {
+    val src = source(SyncModeOf.WRITE_LOCAL, publishPolicy = PolicyOf.ALL)
+    val dirtyOffBranch =
+      entry(
+        "20260430-100000-aaaaaaaa",
+        "com.example.A",
+        "a".toByteArray(),
+        git = GitInfo(branch = "feature/x", dirty = true),
+      )
+    assertEquals(WriteResult.WRITTEN, src.write(dirtyOffBranch, "a".toByteArray()))
+    assertEquals("ALL keeps today's behaviour", 1, src.list(HistoryFilter()).totalCount)
+  }
+
+  // -------------------------------------------------------------------------
   // Helpers
   // -------------------------------------------------------------------------
 
@@ -657,10 +726,16 @@ class GitRefHistorySourceTest {
     val WRITE_PUSH = GitRefHistorySource.SyncMode.WRITE_PUSH
   }
 
+  private object PolicyOf {
+    val ALL = GitRefHistorySource.PublishPolicy.ALL
+    val CLEAN_ON_BRANCH = GitRefHistorySource.PublishPolicy.CLEAN_ON_BRANCH
+  }
+
   private fun source(
     syncMode: GitRefHistorySource.SyncMode,
     ref: String = this.ref,
     debounceMs: Long = 0,
+    publishPolicy: GitRefHistorySource.PublishPolicy = GitRefHistorySource.PublishPolicy.ALL,
   ): GitRefHistorySource =
     GitRefHistorySource(
       repoRoot = repoRoot,
@@ -668,6 +743,7 @@ class GitRefHistorySourceTest {
       syncMode = syncMode,
       warnEmitter = warnEmitter,
       debounceMs = debounceMs,
+      publishPolicy = publishPolicy,
     )
 
   private fun entry(
@@ -677,6 +753,7 @@ class GitRefHistorySourceTest {
     timestamp: String = "2026-04-30T10:12:34Z",
     a11yHierarchy: JsonElement? = null,
     theme: JsonElement? = null,
+    git: GitInfo? = null,
   ): HistoryEntry =
     HistoryEntry(
       id = id,
@@ -692,6 +769,7 @@ class GitRefHistorySourceTest {
       renderTookMs = 1L,
       a11yHierarchy = a11yHierarchy,
       theme = theme,
+      git = git,
     )
 
   private fun mktree(input: String): String {

--- a/docs/daemon/REPORTING-BRANCH.md
+++ b/docs/daemon/REPORTING-BRANCH.md
@@ -163,6 +163,16 @@ paths, a competing writer's renders survive the replay rather than being clobber
 Credentials are the host's concern; when the push (or its fetch retry) can't reach the
 remote it degrades to a one-time warning — the local commit always stands.
 
+**Publish policy** (#1872 curation): the reporting branch is a *curated* record, so by default
+(`composeai.daemon.gitRefHistoryPublishPolicy=clean-on-branch`) only renders of a **clean**
+working tree (`git.dirty != true`) produced **on the branch the ref tracks** (`git.branch ==
+sourceBranch`, where `refs/heads/preview/main` → `main`) reach the branch — uncommitted or
+off-branch local states never pollute it. Renders with no git provenance (fake-mode) are
+allowed. Set the policy to `all` to record every render (the pre-curation behaviour). This gates
+*only* the reporting branch; the local FS source always captures every render as the developer's
+scratch history. (A stricter `pushed`-only mode — require the commit be reachable from the
+published branch — is a possible follow-up.)
+
 **Burst debounce** (#1882): under `WRITE_LOCAL` / `WRITE_PUSH`, writes are buffered for a
 short window (`composeai.daemon.gitRefHistoryDebounceMs`, default `1000`; `0` = commit per
 render) and coalesced into a **single** commit covering every preview changed in the window


### PR DESCRIPTION
## Summary

Answers the concern *"should we only push reporting diffs when they're clean/committed, and will local changes pollute things?"* — **yes, they could**, and this fixes it.

Today the reporting-branch writer commits/pushes **every** render. The git provenance (`dirty` / `branch` / `commit`) is captured per entry but never consulted, so:
- a save against a **dirty working tree** lands an entry whose `produced-from` points at a clean commit but whose pixels reflect uncommitted work (non-reproducible);
- rendering on a **feature branch** pushes those states onto `preview/main`.

This adds a **publish policy** gate on the reporting-branch write:

- **`composeai.daemon.gitRefHistoryPublishPolicy=clean-on-branch`** (new default): only record renders of a **clean** tree (`git.dirty != true`) produced **on the branch the ref tracks** (`git.branch == sourceBranch`, e.g. `refs/heads/preview/main` → `main`). Renders with no git provenance (fake-mode) are allowed (nothing to curate against).
- **`=all`**: record every render — the pre-curation behaviour, an escape hatch.

Crucially this gates **only the reporting branch**. The local FS source still captures *every* render as the developer's scratch history — so nothing is lost locally; the shared branch just stays a curated, reproducible record. Implemented as a one-line check at the top of `write()` (so gated renders are never buffered, committed, or pushed), defaulting from the sysprop in `forLocalFsAndGitRefs` — **no daemon-main / Android changes**.

A stricter `pushed`-only mode (require the commit be reachable from the published branch) is noted as a possible follow-up.

## Test plan
New `GitRefHistorySourceTest` cases (git-gated): clean-on-branch records; **dirty** render skipped (kept off the branch); **off-branch** render skipped; **null provenance** allowed; **`all`** records dirty + off-branch. `daemon:core` history + `JsonRpcServerHistory` suites pass; `ktfmt` clean. Existing write tests are unaffected (the test `source()` helper defaults the policy to `all`).

Daemon-only; no protocol change, no visual surface. Doc: `REPORTING-BRANCH.md` § Status documents the policy.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CPjwnCtY5aiBTFkVrrFjhS)_