### PR TITLE
fix(daemon): read live git state for the reporting-branch curation gate

### DIFF
--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/GitRefHistorySource.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/GitRefHistorySource.kt
@@ -149,8 +149,38 @@ class GitRefHistorySource(
     return branch == sourceBranch
   }
 
-  /** Fresh working-tree dirtiness (`git status --porcelain`), or null when git can't be run. */
-  private fun currentDirty(): Boolean? = runGit("status", "--porcelain")?.let { it.isNotEmpty() }
+  /**
+   * Fresh working-tree dirtiness, **ignoring the history system's own artifacts** — the local FS
+   * archive and the git-ref cache both live under the history dir ([cacheDir]'s parent), and
+   * `HistoryManager` writes the FS source before this one, so if that dir isn't gitignored its
+   * just-written files would make every render look dirty and self-block curation (#1923 review). A
+   * change anywhere else marks the tree dirty. Null when git can't be run.
+   */
+  private fun currentDirty(): Boolean? {
+    val out = runGit("-c", "core.quotePath=false", "status", "--porcelain") ?: return null
+    if (out.isEmpty()) return false
+    val historyDir = relativeHistoryDir()
+    return out.lineSequence().any { line ->
+      // Porcelain v1 line: two status chars + a space + the path (from index 3).
+      if (line.length < 4) return@any false
+      val path = line.substring(3)
+      historyDir == null || !(path == historyDir || path.startsWith("$historyDir/"))
+    }
+  }
+
+  /**
+   * The history dir (FS archive + git-ref cache) relative to [repoRoot]; null when not under it.
+   */
+  private fun relativeHistoryDir(): String? {
+    val historyRoot = cacheDir.parent ?: return null
+    return try {
+      repoRoot.relativize(historyRoot).toString().replace('\\', '/').takeIf {
+        it.isNotEmpty() && !it.startsWith("..")
+      }
+    } catch (_: Throwable) {
+      null
+    }
+  }
 
   /** Fresh current branch (`symbolic-ref`), or null on detached HEAD / when git can't be run. */
   private fun currentBranch(): String? =

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/GitRefHistorySource.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/GitRefHistorySource.kt
@@ -131,15 +131,30 @@ class GitRefHistorySource(
   /**
    * Curation gate (#1872): whether [entry] may reach the reporting branch under [publishPolicy].
    * [PublishPolicy.ALL] is always true; [PublishPolicy.CLEAN_ON_BRANCH] requires a clean working
-   * tree (`git.dirty != true`) on the tracked [sourceBranch]. A render with no git provenance is
-   * allowed (nothing to curate against — e.g. fake-mode / tests).
+   * tree on the tracked [sourceBranch].
+   *
+   * Reads `dirty` / `branch` **fresh** at decision time rather than trusting `entry.git`: that's
+   * filled from `GitProvenance.snapshot()`, which caches for a short TTL, so in a save-loop a
+   * render of a now-dirty tree can carry a stale `dirty=false` and would otherwise slip onto the
+   * curated branch. Falls back to the recorded `entry.git` only when a fresh read isn't possible
+   * (git unavailable); when neither yields provenance (fake-mode) the render is allowed — nothing
+   * to curate against.
    */
   private fun shouldPublish(entry: HistoryEntry): Boolean {
     if (publishPolicy == PublishPolicy.ALL) return true
-    val git = entry.git ?: return true
-    if (git.dirty == true) return false
-    return git.branch == sourceBranch
+    val dirty = currentDirty() ?: entry.git?.dirty
+    val branch = currentBranch() ?: entry.git?.branch
+    if (dirty == null && branch == null) return true
+    if (dirty == true) return false
+    return branch == sourceBranch
   }
+
+  /** Fresh working-tree dirtiness (`git status --porcelain`), or null when git can't be run. */
+  private fun currentDirty(): Boolean? = runGit("status", "--porcelain")?.let { it.isNotEmpty() }
+
+  /** Fresh current branch (`symbolic-ref`), or null on detached HEAD / when git can't be run. */
+  private fun currentBranch(): String? =
+    runGit("symbolic-ref", "--short", "HEAD")?.takeIf { it.isNotEmpty() }
 
   /**
    * Commits [renders] as one batch and, under `WRITE_PUSH`, publishes it — or, when the batch

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/GitRefHistorySourceTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/GitRefHistorySourceTest.kt
@@ -694,6 +694,37 @@ class GitRefHistorySourceTest {
   }
 
   @Test
+  fun clean_on_branch_ignores_history_artifacts_when_checking_dirtiness() {
+    // #1923 review: HistoryManager writes the local FS archive (under .compose-preview-history/)
+    // before this git source, so a fresh `git status` sees those just-written files. If the
+    // history dir isn't gitignored that churn must NOT count as "dirty" and self-block curation —
+    // only a change to *real* source content should.
+    onBranch("main")
+    val historyDir = repoRoot.resolve(".compose-preview-history")
+    Files.createDirectories(historyDir)
+    Files.writeString(historyDir.resolve("20260430-100000-aaaaaaaa.png"), "fs-archive-render")
+    val src = source(SyncModeOf.WRITE_LOCAL, publishPolicy = PolicyOf.CLEAN_ON_BRANCH)
+    val e = entry("20260430-100000-aaaaaaaa", "com.example.A", "a".toByteArray())
+    assertEquals(WriteResult.WRITTEN, src.write(e, "a".toByteArray()))
+    assertEquals("history churn alone isn't dirty", 1, src.list(HistoryFilter()).totalCount)
+  }
+
+  @Test
+  fun clean_on_branch_skips_when_real_content_dirty_despite_history_artifacts() {
+    // The flip side: history artifacts are ignored, but a real source edit alongside them still
+    // marks the tree dirty and keeps the render off the branch.
+    onBranch("main")
+    val historyDir = repoRoot.resolve(".compose-preview-history")
+    Files.createDirectories(historyDir)
+    Files.writeString(historyDir.resolve("20260430-100000-aaaaaaaa.png"), "fs-archive-render")
+    dirtyWorkingTree()
+    val src = source(SyncModeOf.WRITE_LOCAL, publishPolicy = PolicyOf.CLEAN_ON_BRANCH)
+    val e = entry("20260430-100000-aaaaaaaa", "com.example.A", "a".toByteArray())
+    assertEquals(WriteResult.SKIPPED_DUPLICATE, src.write(e, "a".toByteArray()))
+    assertEquals("real dirty content still blocks", 0, src.list(HistoryFilter()).totalCount)
+  }
+
+  @Test
   fun policy_all_records_dirty_and_off_branch_renders() {
     onBranch("feature-x")
     dirtyWorkingTree()

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/GitRefHistorySourceTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/GitRefHistorySourceTest.kt
@@ -632,68 +632,74 @@ class GitRefHistorySourceTest {
   // Publish policy / curation (#1872) — `ref` is refs/heads/preview/main ⇒ sourceBranch = "main"
   // -------------------------------------------------------------------------
 
+  // The gate reads live git state (not the cached entry.git), so these drive the real working tree:
+  // `onBranch("main")` matches sourceBranch; `dirtyWorkingTree()` makes `git status` non-empty.
+
+  private fun onBranch(name: String) {
+    runOk("git", "-C", repoRoot.toString(), "checkout", "-B", name)
+  }
+
+  private fun dirtyWorkingTree() {
+    Files.writeString(repoRoot.resolve("wip.uncommitted"), "edit-in-progress")
+  }
+
   @Test
   fun clean_on_branch_records_a_clean_render_on_the_tracked_branch() {
+    onBranch("main")
     val src = source(SyncModeOf.WRITE_LOCAL, publishPolicy = PolicyOf.CLEAN_ON_BRANCH)
-    val e =
-      entry(
-        "20260430-100000-aaaaaaaa",
-        "com.example.A",
-        "a".toByteArray(),
-        git = GitInfo(branch = "main", dirty = false),
-      )
+    val e = entry("20260430-100000-aaaaaaaa", "com.example.A", "a".toByteArray())
     assertEquals(WriteResult.WRITTEN, src.write(e, "a".toByteArray()))
     assertEquals(1, src.list(HistoryFilter()).totalCount)
   }
 
   @Test
   fun clean_on_branch_skips_a_dirty_render() {
+    onBranch("main")
+    dirtyWorkingTree()
     val src = source(SyncModeOf.WRITE_LOCAL, publishPolicy = PolicyOf.CLEAN_ON_BRANCH)
-    val e =
-      entry(
-        "20260430-100000-aaaaaaaa",
-        "com.example.A",
-        "a".toByteArray(),
-        git = GitInfo(branch = "main", dirty = true),
-      )
+    val e = entry("20260430-100000-aaaaaaaa", "com.example.A", "a".toByteArray())
     assertEquals(WriteResult.SKIPPED_DUPLICATE, src.write(e, "a".toByteArray()))
     assertEquals("dirty render kept off the branch", 0, src.list(HistoryFilter()).totalCount)
   }
 
   @Test
   fun clean_on_branch_skips_an_off_branch_render() {
+    onBranch("feature-x")
     val src = source(SyncModeOf.WRITE_LOCAL, publishPolicy = PolicyOf.CLEAN_ON_BRANCH)
-    val e =
-      entry(
-        "20260430-100000-aaaaaaaa",
-        "com.example.A",
-        "a".toByteArray(),
-        git = GitInfo(branch = "feature/x", dirty = false),
-      )
+    val e = entry("20260430-100000-aaaaaaaa", "com.example.A", "a".toByteArray())
     assertEquals(WriteResult.SKIPPED_DUPLICATE, src.write(e, "a".toByteArray()))
     assertEquals("off-branch render kept off the branch", 0, src.list(HistoryFilter()).totalCount)
   }
 
   @Test
-  fun clean_on_branch_allows_a_render_without_git_provenance() {
-    // Fake-mode / no-git renders have null provenance — nothing to curate against, so they record.
+  fun clean_on_branch_reads_live_dirtiness_not_stale_provenance() {
+    // #1922 review: a save-loop can carry a stale clean snapshot (entry.git dirty=false) into a
+    // render of a now-dirty tree. The gate must read the tree *now* and still skip it.
+    onBranch("main")
+    dirtyWorkingTree()
     val src = source(SyncModeOf.WRITE_LOCAL, publishPolicy = PolicyOf.CLEAN_ON_BRANCH)
-    val e = entry("20260430-100000-aaaaaaaa", "com.example.A", "a".toByteArray(), git = null)
-    assertEquals(WriteResult.WRITTEN, src.write(e, "a".toByteArray()))
-    assertEquals(1, src.list(HistoryFilter()).totalCount)
-  }
-
-  @Test
-  fun policy_all_records_dirty_and_off_branch_renders() {
-    val src = source(SyncModeOf.WRITE_LOCAL, publishPolicy = PolicyOf.ALL)
-    val dirtyOffBranch =
+    val staleClean =
       entry(
         "20260430-100000-aaaaaaaa",
         "com.example.A",
         "a".toByteArray(),
-        git = GitInfo(branch = "feature/x", dirty = true),
+        git = GitInfo(branch = "main", dirty = false),
       )
-    assertEquals(WriteResult.WRITTEN, src.write(dirtyOffBranch, "a".toByteArray()))
+    assertEquals(WriteResult.SKIPPED_DUPLICATE, src.write(staleClean, "a".toByteArray()))
+    assertEquals(
+      "stale-clean provenance doesn't admit a dirty render",
+      0,
+      src.list(HistoryFilter()).totalCount,
+    )
+  }
+
+  @Test
+  fun policy_all_records_dirty_and_off_branch_renders() {
+    onBranch("feature-x")
+    dirtyWorkingTree()
+    val src = source(SyncModeOf.WRITE_LOCAL, publishPolicy = PolicyOf.ALL)
+    val e = entry("20260430-100000-aaaaaaaa", "com.example.A", "a".toByteArray())
+    assertEquals(WriteResult.WRITTEN, src.write(e, "a".toByteArray()))
     assertEquals("ALL keeps today's behaviour", 1, src.list(HistoryFilter()).totalCount)
   }
 


### PR DESCRIPTION
## Summary

Follow-up to #1922 addressing a Codex P2 that landed before I could fix it (auto-merge).

The `clean-on-branch` curation gate trusted `entry.git`, but that's filled from `GitProvenance.snapshot()`, which **caches** `dirty`/`branch`/`commit` for a short TTL. So in a save-loop — a clean render caches `dirty=false`, you make an uncommitted edit, a second render fires inside the TTL — the **stale clean** provenance reached the gate and the dirty render was still committed/pushed to the curated branch. The new default didn't actually keep uncommitted states off the branch in exactly the fast-edit case it targets.

**Fix:** `shouldPublish` now reads `dirty`/`branch` **fresh** at decision time via the source's own git (`git status --porcelain` + `symbolic-ref --short HEAD`), instead of trusting the cached `entry.git`. It falls back to the recorded `entry.git` only when a fresh read isn't possible (git unavailable), and allows the render when neither yields provenance (fake-mode — nothing to curate against). Cost is one uncached `git status` per render under `clean-on-branch` — the price of an accurate guarantee. `ALL` short-circuits before any read, unchanged.

## Test plan
The curation tests now drive **real working-tree state** (`git checkout -B <branch>`, an uncommitted file) rather than synthetic `entry.git`, and add a direct regression — **`clean_on_branch_reads_live_dirtiness_not_stale_provenance`**: a stale-clean `entry.git` (`dirty=false`) against an actually-dirty tree is still skipped. Covers clean-on-branch records / dirty skipped / off-branch skipped / stale-provenance skipped / `ALL` records everything.

`daemon:core` history + `JsonRpcServerHistory` suites pass; `ktfmt` clean. Existing write tests unaffected (the test `source()` helper defaults the policy to `all`, which short-circuits the gate).

Daemon-only; no protocol change, no visual surface.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CPjwnCtY5aiBTFkVrrFjhS)_