### PR TITLE
fix(discovery): find previews under AGP 9.x built-in Kotlin (#1924)

### DIFF
--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
@@ -72,6 +72,18 @@ object PreviewDiscovery {
      * relative to the `compose-previews` root, so any subdir validates uniformly.
      */
     val lottieRenderSubdir: String = "renders",
+    /**
+     * JARs of compiled `.class` files belonging to the consumer module itself — the module's *own*
+     * classes packaged as a jar rather than laid out in a [classDirs] directory. Unlike
+     * [dependencyJars] these are method-walked as project classes (their `@Preview` functions are
+     * discovered) and are NOT subject to the preview-relevant name/path filter. Sourced from AGP's
+     * scoped `PROJECT` `CLASSES` artifact, which is populated regardless of whether Kotlin was
+     * compiled by the standalone Kotlin Gradle Plugin or AGP 9.x built-in Kotlin
+     * (`built_in_kotlinc`) — the legacy `build/tmp/kotlin-classes/<variant>` directory it used to
+     * read is never written under built-in Kotlin. Empty (the default) for build systems / module
+     * types that expose the module's classes only as directories. See issue #1924.
+     */
+    val projectClassJars: List<File> = emptyList(),
   )
 
   /** Outcome of a [discover] call. */
@@ -203,6 +215,16 @@ object PreviewDiscovery {
     val infoMessages = mutableListOf<String>()
 
     val existingClassDirs = input.classDirs.filter { it.exists() && it.isDirectory }
+    // The module's OWN classes, packaged as a jar (AGP scoped PROJECT CLASSES
+    // artifact). Walked as project classes like [existingClassDirs] — NOT
+    // subject to the dependency-jar preview-relevance filter below. This is the
+    // path that rescues discovery under AGP 9.x built-in Kotlin, where the
+    // module's classes never land in the legacy `build/tmp/kotlin-classes/
+    // <variant>` directory the directory scan reads. See issue #1924.
+    val existingProjectJars =
+      input.projectClassJars.filter {
+        it.exists() && it.isFile && it.name.lowercase().endsWith(".jar")
+      }
     // Match on the absolute path, not just the file name: AGP 9.x +
     // KGP 2.3 resolve AAR dependencies to `<cache>/transforms/<hash>/
     // transformed/<library>/jars/classes.jar` where the library name
@@ -220,7 +242,10 @@ object PreviewDiscovery {
               path.contains("annotation")
           }
       }
-    val classpath = existingClassDirs + filteredDependencyJars
+    // Project jars BEFORE dependency jars so a class present in both (the
+    // module's own output shadowing a stale dependency copy) is attributed by
+    // ClassGraph to the project element and method-walked.
+    val classpath = existingClassDirs + existingProjectJars + filteredDependencyJars
 
     val previews = mutableListOf<PreviewInfo>()
     // Populated only on the diagnostics path (failOnEmpty + 0 previews)
@@ -248,16 +273,21 @@ object PreviewDiscovery {
         .use { scanResult ->
           reachablePreviewFqns = PREVIEW_FQNS.filter { scanResult.getClassInfo(it) != null }
           // Project-local class FQNs — only classes loaded from the project's own
-          // class output directories, never from a dependency JAR. Powers the
+          // class output (its [classDirs] directories or its scoped PROJECT
+          // [projectClassJars]), never from a dependency JAR. Powers the
           // "is this @Composable call into project code?" filter inside
           // PreviewTargetInference; computed once per scan and passed through.
-          val classDirPaths = existingClassDirs.map { it.absolutePath }.toSet()
+          // The dependency JARs stay OUT of this set, so their classes remain on
+          // the ClassGraph classpath (for multi-preview annotation resolution)
+          // but aren't method-walked. See issue #1039 / #1924.
+          val projectElementPaths =
+            (existingClassDirs + existingProjectJars).map { it.absolutePath }.toSet()
           val projectClassFqns =
             scanResult.allClasses
               .asSequence()
               .filter { ci ->
                 val element = ci.classpathElementFile ?: return@filter false
-                element.isDirectory && element.absolutePath in classDirPaths
+                element.absolutePath in projectElementPaths
               }
               .map { it.name }
               .toSet()
@@ -342,6 +372,8 @@ object PreviewDiscovery {
           header = "composePreview: failOnEmpty diagnostics (0 previews discovered):",
           existingClassDirs = existingClassDirs,
           allClassDirs = input.classDirs,
+          projectJars = existingProjectJars,
+          allProjectJars = input.projectClassJars,
           filteredJars = filteredDependencyJars,
           allJarCount = input.dependencyJars.size,
           scanClassCount = scanClassCount,
@@ -387,6 +419,8 @@ object PreviewDiscovery {
               "(soft warning — set composePreview.failOnEmpty=true to fail the build):",
           existingClassDirs = existingClassDirs,
           allClassDirs = input.classDirs,
+          projectJars = existingProjectJars,
+          allProjectJars = input.projectClassJars,
           filteredJars = filteredDependencyJars,
           allJarCount = input.dependencyJars.size,
           scanClassCount = scanClassCount,
@@ -506,6 +540,8 @@ object PreviewDiscovery {
     header: String,
     existingClassDirs: List<File>,
     allClassDirs: List<File>,
+    projectJars: List<File>,
+    allProjectJars: List<File>,
     filteredJars: List<File>,
     allJarCount: Int,
     scanClassCount: Int,
@@ -525,6 +561,16 @@ object PreviewDiscovery {
         } else 0
       out.add("    - $dir")
       out.add("      exists=$exists isDir=$isDir classFiles=$classCount")
+    }
+    // Project-own class jars (AGP scoped PROJECT CLASSES) — the built-in-Kotlin
+    // rescue path. Listed separately from dependencyJars because these ARE
+    // method-walked. See issue #1924.
+    if (allProjectJars.isNotEmpty()) {
+      out.add("  projectClassJars (${allProjectJars.size} declared, ${projectJars.size} existing):")
+      for (jar in allProjectJars) {
+        out.add("    - $jar")
+        out.add("      exists=${jar.exists()} isFile=${jar.isFile}")
+      }
     }
     out.add(
       "  dependencyJars: $allJarCount total, ${filteredJars.size} match " +

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewDiscoveryProjectJarTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewDiscoveryProjectJarTest.kt
@@ -1,0 +1,130 @@
+package ee.schimke.composeai.discovery
+
+import com.google.common.truth.Truth.assertThat
+import java.io.File
+import java.util.jar.JarEntry
+import java.util.jar.JarOutputStream
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.objectweb.asm.AnnotationVisitor
+import org.objectweb.asm.ClassWriter
+import org.objectweb.asm.Opcodes
+
+/**
+ * Regression coverage for issue #1924: discovery must find the consumer module's own `@Preview`
+ * functions when they arrive packaged as a project JAR (AGP's scoped `PROJECT` `CLASSES` artifact)
+ * rather than laid out in a [PreviewDiscovery.Input.classDirs] directory.
+ *
+ * Under AGP 9.x built-in Kotlin (`built_in_kotlinc`) the module's classes never land in the legacy
+ * `build/tmp/kotlin-classes/<variant>` directory the directory scan reads, so the Android backend
+ * now feeds them in via [PreviewDiscovery.Input.projectClassJars]. Unlike
+ * [PreviewDiscovery.Input.dependencyJars] those jars are method-walked as project classes.
+ *
+ * The hand-rolled class uses a `RuntimeInvisibleAnnotations`-encoded `@Preview` (ASM `visible =
+ * false`) to mirror the real bytecode: `androidx.compose.ui.tooling.preview.Preview` has `CLASS`
+ * retention, so the compiler emits it as invisible — exactly what `javap -v` showed in the issue.
+ */
+class PreviewDiscoveryProjectJarTest {
+
+  @get:Rule val tempDir = TemporaryFolder()
+
+  @Test
+  fun `previews in a project class jar are discovered and method-walked`() {
+    val jar = File(tempDir.root, "classes.jar")
+    writePreviewClassJar(
+      jar,
+      internalName = "test/ZzDiagDirectPreviewKt",
+      methodName = "ZzDiagDirectPreview",
+    )
+
+    val outcome =
+      PreviewDiscovery.discover(
+        PreviewDiscovery.Input(
+          // No classDirs at all — exactly the built-in-Kotlin shape where the module's own
+          // classes are only reachable through the scoped PROJECT CLASSES jar.
+          classDirs = emptyList(),
+          dependencyJars = emptyList(),
+          sourceFiles = emptyList(),
+          moduleName = ":remote-material3-samples",
+          variantName = "debug",
+          projectDirectory = tempDir.root,
+          failOnEmpty = true,
+          projectClassJars = listOf(jar),
+        )
+      )
+
+    assertThat(outcome).isInstanceOf(PreviewDiscovery.Outcome.Success::class.java)
+    val success = outcome as PreviewDiscovery.Outcome.Success
+    val preview = success.manifest.previews.single()
+    assertThat(preview.className).isEqualTo("test.ZzDiagDirectPreviewKt")
+    assertThat(preview.functionName).isEqualTo("ZzDiagDirectPreview")
+  }
+
+  @Test
+  fun `a dependency jar with the same shape is NOT method-walked`() {
+    // The dual to the test above: an identical jar handed in as a dependency (not a project jar)
+    // must NOT surface previews — dependency classes stay on the ClassGraph classpath for
+    // multi-preview resolution but are never walked for their own @Preview methods (issue #1039).
+    // Name the jar so it survives the preview-relevance filter (path must contain one of
+    // preview|tooling|compose|annotation) — otherwise it'd be dropped before the walk and the
+    // test wouldn't actually exercise the project-vs-dependency distinction.
+    val jar = File(tempDir.root, "compose-classes.jar")
+    writePreviewClassJar(
+      jar,
+      internalName = "test/ZzDiagDirectPreviewKt",
+      methodName = "ZzDiagDirectPreview",
+    )
+
+    val outcome =
+      PreviewDiscovery.discover(
+        PreviewDiscovery.Input(
+          classDirs = emptyList(),
+          dependencyJars = listOf(jar),
+          sourceFiles = emptyList(),
+          moduleName = ":remote-material3-samples",
+          variantName = "debug",
+          projectDirectory = tempDir.root,
+          failOnEmpty = false,
+        )
+      )
+
+    assertThat(outcome).isInstanceOf(PreviewDiscovery.Outcome.Success::class.java)
+    assertThat((outcome as PreviewDiscovery.Outcome.Success).manifest.previews).isEmpty()
+  }
+
+  /**
+   * Writes a JAR containing a single class with one parameterless `public static` method annotated
+   * with `androidx.compose.ui.tooling.preview.Preview`. The annotation is emitted as a
+   * `RuntimeInvisibleAnnotations` entry (`visible = false`) to match the CLASS-retention bytecode
+   * the Compose compiler produces. A parameterless `()V` method is the simplest shape discovery
+   * accepts as a preview (no `@PreviewParameter` wiring needed).
+   */
+  private fun writePreviewClassJar(jar: File, internalName: String, methodName: String) {
+    val cw = ClassWriter(0)
+    cw.visit(
+      Opcodes.V17,
+      Opcodes.ACC_PUBLIC or Opcodes.ACC_FINAL or Opcodes.ACC_SUPER,
+      internalName,
+      null,
+      "java/lang/Object",
+      null,
+    )
+    val mv = cw.visitMethod(Opcodes.ACC_PUBLIC or Opcodes.ACC_STATIC, methodName, "()V", null, null)
+    val av: AnnotationVisitor =
+      mv.visitAnnotation("Landroidx/compose/ui/tooling/preview/Preview;", false)
+    av.visitEnd()
+    mv.visitCode()
+    mv.visitInsn(Opcodes.RETURN)
+    mv.visitMaxs(0, 0)
+    mv.visitEnd()
+    cw.visitEnd()
+
+    jar.parentFile.mkdirs()
+    JarOutputStream(jar.outputStream()).use { jos ->
+      jos.putNextEntry(JarEntry("$internalName.class"))
+      jos.write(cw.toByteArray())
+      jos.closeEntry()
+    }
+  }
+}

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -1,8 +1,10 @@
 package ee.schimke.composeai.plugin
 
+import com.android.build.api.artifact.ScopedArtifact
 import com.android.build.api.artifact.SingleArtifact
 import com.android.build.api.dsl.CommonExtension
 import com.android.build.api.variant.AndroidComponentsExtension
+import com.android.build.api.variant.ScopedArtifacts
 import com.android.build.api.variant.Variant
 import ee.schimke.composeai.daemonlaunch.*
 import ee.schimke.composeai.discovery.*
@@ -610,6 +612,27 @@ internal object AndroidPreviewSupport {
           }
         }
       }
+
+    // Feed the variant's OWN compiled classes into discovery via AGP's scoped-artifact API rather
+    // than relying solely on the hardcoded `sourceClassDirs` directory candidates. The scoped
+    // PROJECT CLASSES artifact is populated regardless of whether Kotlin was compiled by the
+    // standalone Kotlin Gradle Plugin (`compile<Variant>Kotlin` → `build/tmp/kotlin-classes/…`) or
+    // by AGP 9.x built-in Kotlin (`built_in_kotlinc`, whose output never lands in the legacy
+    // directory), so discovery no longer finds 0 previews on built-in-Kotlin modules (issue #1924).
+    // Resolving the artifact also wires the implicit task dependency on whichever task produced the
+    // classes — so `composePreviewDiscover` compiles them first even when no standalone
+    // `compile<Variant>Kotlin` task exists to `dependsOn`. This is additive: `sourceClassDirs`
+    // stays
+    // wired for the KGP layout, and ClassGraph dedupes overlapping class FQNs across the two.
+    variant.artifacts
+      .forScope(ScopedArtifacts.Scope.PROJECT)
+      .use(discoverTask)
+      .toGet(
+        ScopedArtifact.CLASSES,
+        DiscoverPreviewsTask::projectClassJars,
+        DiscoverPreviewsTask::projectClassDirs,
+      )
+
     // `composePreviewCompile` — the daemon-mode save loop calls this instead of
     // `composePreviewDiscover`
     // so the recompile (and on-disk `.class` refresh) runs without re-walking the dependency-JAR

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
@@ -6,11 +6,15 @@ import kotlinx.serialization.json.Json
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.Directory
+import org.gradle.api.file.RegularFile
 import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
@@ -33,6 +37,31 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
   @get:InputFiles
   @get:PathSensitive(PathSensitivity.RELATIVE)
   abstract val classDirs: ConfigurableFileCollection
+
+  /**
+   * The module's own compiled classes laid out as directories, sourced from AGP's scoped `PROJECT`
+   * `CLASSES` artifact (`variant.artifacts.forScope(PROJECT).toGet(CLASSES, …)`). Wired by the
+   * Android backend in addition to [classDirs]; resolving the scoped artifact also creates the
+   * implicit task dependency on whichever task compiled the classes — the standalone Kotlin Gradle
+   * Plugin's `compile<Variant>Kotlin` OR AGP 9.x built-in Kotlin (`built_in_kotlinc`), whose output
+   * the legacy hardcoded `build/tmp/kotlin-classes/<variant>` directory never receives. Optional /
+   * empty on non-Android backends (desktop/JVM). See issue #1924.
+   */
+  @get:InputFiles
+  @get:Optional
+  @get:PathSensitive(PathSensitivity.RELATIVE)
+  abstract val projectClassDirs: ListProperty<Directory>
+
+  /**
+   * The module's own compiled classes packaged as jars, the jar half of AGP's scoped `PROJECT`
+   * `CLASSES` artifact (see [projectClassDirs]). Method-walked as project classes by
+   * [PreviewDiscovery] — unlike [dependencyJars] — so previews compiled into a project jar are
+   * discovered. Optional / empty on non-Android backends. See issue #1924.
+   */
+  @get:InputFiles
+  @get:Optional
+  @get:PathSensitive(PathSensitivity.RELATIVE)
+  abstract val projectClassJars: ListProperty<RegularFile>
 
   @get:InputFiles
   @get:PathSensitive(PathSensitivity.NONE)
@@ -90,9 +119,16 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
 
   @TaskAction
   fun discover() {
+    // Union the directory-scan candidates ([classDirs]) with the scoped PROJECT
+    // CLASSES directories so the module's own classes are found regardless of
+    // which compiler produced them. ClassGraph attributes each FQN to a single
+    // element and previews are deduped by id, so any overlap between the two
+    // sources is harmless. See issue #1924.
+    val scopedClassDirs = projectClassDirs.getOrElse(emptyList()).map { it.asFile }
+    val scopedClassJars = projectClassJars.getOrElse(emptyList()).map { it.asFile }
     val input =
       PreviewDiscovery.Input(
-        classDirs = classDirs.files.toList(),
+        classDirs = classDirs.files.toList() + scopedClassDirs,
         dependencyJars = dependencyJars.files.toList(),
         sourceFiles = sourceFiles.files.toList(),
         moduleName = moduleName.get(),
@@ -101,6 +137,7 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
         failOnEmpty = failOnEmpty.get(),
         resourceDirs = resourceDirs.files.toList(),
         lottieRenderSubdir = lottieRenderSubdir.getOrElse("renders"),
+        projectClassJars = scopedClassJars,
       )
     when (val outcome = PreviewDiscovery.discover(input)) {
       is PreviewDiscovery.Outcome.Success -> {


### PR DESCRIPTION
## Summary

Fixes #1924 — `composePreviewDiscover` (and therefore `composePreviewRender*` and CLI `list`/`show`) found **0 previews** for modules built with **AGP 9.x built-in Kotlin** (`built_in_kotlinc`).

Discovery resolved the module's own classes only from hardcoded **legacy KGP directory paths** (`build/tmp/kotlin-classes/<variant>`, `classes/kotlin/*/main`, …), and `composePreviewDiscover` only `dependsOn` a `compile<Variant>Kotlin` KGP task. Under AGP built-in Kotlin neither exists — the module's classes land in `build/intermediates/built_in_kotlinc/<variant>/compile<Variant>Kotlin/classes` and there is no standalone Kotlin compile task to trigger or locate them — so the scan set was effectively empty.

## Fix

Implements the approach suggested in the issue: resolve the module's own classes for discovery via AGP's **scoped artifacts API** instead of relying solely on hardcoded paths.

- **`AndroidPreviewSupport.kt`** — wire the variant's own compiled classes into `composePreviewDiscover` via `variant.artifacts.forScope(ScopedArtifacts.Scope.PROJECT).use(discoverTask).toGet(ScopedArtifact.CLASSES, …jars, …dirs)`. The scoped `PROJECT` `CLASSES` artifact is populated regardless of whether Kotlin was compiled by the standalone Kotlin Gradle Plugin **or** AGP built-in Kotlin, and resolving it also wires the implicit task dependency on whichever task produced the classes (so discovery compiles them first even with no `compile<Variant>Kotlin` task to `dependsOn`). Additive — the legacy `sourceClassDirs` candidates stay wired for the KGP layout, and ClassGraph dedupes overlapping class FQNs.
- **`DiscoverPreviewsTask.kt`** — added `projectClassDirs` / `projectClassJars` inputs (the dir + jar halves of the scoped artifact) and merged them into the `PreviewDiscovery.Input`.
- **`PreviewDiscovery.kt`** — `Input.projectClassJars` are method-walked **as project classes** (unlike `dependencyJars`, which stay on the ClassGraph classpath for multi-preview resolution but are not walked), so previews compiled into a project jar are discovered. Also surfaced in the `failOnEmpty` diagnostics.

## Test plan

- New `PreviewDiscoveryProjectJarTest` reproduces the exact bug shape — a `RuntimeInvisibleAnnotations`-encoded `@Preview` (CLASS retention, as `javap -v` showed in the issue) packaged in a jar with **no** `classDirs` — and asserts the preview is discovered; a dual test confirms an identical jar handed in as a *dependency* is **not** method-walked.
- `./gradlew :gradle-plugin:preview-discovery:test :gradle-plugin:test` — BUILD SUCCESSFUL, including the existing `KmpAndroidDesktopRouting`, `RegisterBundleTaskBackend`, and `DiscoverPreviews` suites (no regressions).

Non-visual change (build/discovery plumbing), so no preview-render evidence applies. A full end-to-end run against a real AGP 9.3.0-alpha01 built-in-Kotlin module isn't reproducible in the CI sandbox; coverage is via the unit tests and the AGP scoped-artifact contract.

---
_Generated by [Claude Code](https://claude.ai/code/session_0197v7mNsmqgAUcQdoxPfrYA)_