### PR TITLE
fix(bundle): pack module bytecode from the scoped PROJECT CLASSES artifact

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -2227,40 +2227,66 @@ internal object AndroidPreviewSupport {
     // (only matters for coordinate-mode re-rendering on an Android player, which isn't built yet):
     // the coordinate type is recorded as `jar` even for AAR-published deps, and Android-merged
     // resources aren't packed. `--embed-deps` sidesteps the type concern by inlining resolved jars.
-    ComposePreviewTasks.registerBundleTask(
-      project = project,
-      extension = extension,
-      previewOutputDir = previewOutputDir,
-      sourceClassDirs = sourceClassDirs,
-      resolveDependencyConfigName = { dependencyConfigName },
-      discoverTaskName = "composePreviewDiscover",
-      backendId = "android",
-      // (v6) Feed the AGP artefacts a protolayout-IR bundle carries for tile replay on a detached
-      // daemon: `unitTestConfigDir`'s `test_config.properties` names the merged resource APK +
-      // manifest, and the pack action reads those by absolute path — so union the artefacts they
-      // point at (the `apk_for_local_test` output dir + the merged manifest) into the tracked
-      // `@InputFiles` so the cacheable task re-packs when their content changes even if the paths
-      // don't.
-      androidUnitTestConfigFiles =
-        project.files(
-          unitTestConfigDir,
-          project.layout.buildDirectory.dir(
-            "intermediates/apk_for_local_test/${variantName}UnitTest"
+    val bundleTask =
+      ComposePreviewTasks.registerBundleTask(
+        project = project,
+        extension = extension,
+        previewOutputDir = previewOutputDir,
+        sourceClassDirs = sourceClassDirs,
+        resolveDependencyConfigName = { dependencyConfigName },
+        discoverTaskName = "composePreviewDiscover",
+        backendId = "android",
+        // (v6) Feed the AGP artefacts a protolayout-IR bundle carries for tile replay on a detached
+        // daemon: `unitTestConfigDir`'s `test_config.properties` names the merged resource APK +
+        // manifest, and the pack action reads those by absolute path — so union the artefacts they
+        // point at (the `apk_for_local_test` output dir + the merged manifest) into the tracked
+        // `@InputFiles` so the cacheable task re-packs when their content changes even if the paths
+        // don't.
+        androidUnitTestConfigFiles =
+          project.files(
+            unitTestConfigDir,
+            project.layout.buildDirectory.dir(
+              "intermediates/apk_for_local_test/${variantName}UnitTest"
+            ),
+            variant.artifacts.get(SingleArtifact.MERGED_MANIFEST),
           ),
-          variant.artifacts.get(SingleArtifact.MERGED_MANIFEST),
-        ),
-      // The generated library R classes the tile renderer links
-      // (`androidx.wear.protolayout.renderer.R$style`) are generated only into the unit-test merged
-      // R.jar. That jar lives on AGP's `test<Variant>UnitTest` task classpath (a raw file dep added
-      // without the `artifactType=jar` attribute, so the bundle's filtered `dependencyJars` view —
-      // and a configuration `artifactView` — drop it). Source it from the Test task's *resolved*
-      // classpath, the SAME collection `composePreviewRender` links it from (so it resolves cleanly
-      // without the `AmbiguousArtifactsFailure` a raw configuration read hits). Supplied lazily and
-      // invoked inside the bundle task's config lambda, by which point the unit-test task exists.
-      androidUnitTestRuntimeClasspath = {
-        (project.tasks.findByName("test${capVariant}UnitTest") as? Test)?.classpath
-      },
-    )
+        // The generated library R classes the tile renderer links
+        // (`androidx.wear.protolayout.renderer.R$style`) are generated only into the unit-test
+        // merged
+        // R.jar. That jar lives on AGP's `test<Variant>UnitTest` task classpath (a raw file dep
+        // added
+        // without the `artifactType=jar` attribute, so the bundle's filtered `dependencyJars` view
+        // —
+        // and a configuration `artifactView` — drop it). Source it from the Test task's *resolved*
+        // classpath, the SAME collection `composePreviewRender` links it from (so it resolves
+        // cleanly
+        // without the `AmbiguousArtifactsFailure` a raw configuration read hits). Supplied lazily
+        // and
+        // invoked inside the bundle task's config lambda, by which point the unit-test task exists.
+        androidUnitTestRuntimeClasspath = {
+          (project.tasks.findByName("test${capVariant}UnitTest") as? Test)?.classpath
+        },
+      )
+
+    // Feed the variant's OWN compiled classes into the bundle packer via AGP's scoped-artifact API,
+    // mirroring the identical `forScope(PROJECT).toGet(CLASSES, …)` wiring `composePreviewDiscover`
+    // uses (issue #1924). Discovery resolves previews from the scoped artifact, so without this the
+    // bundle's class set could be strictly narrower than the manifest discovery wrote — a preview
+    // resolved only from a scoped element (e.g. AGP 9.x built-in Kotlin output, which never lands
+    // in
+    // the hardcoded `sourceClassDirs`) would be listed in `previews.json` but missing from
+    // `classes/app.jar`, breaking detached/portable rendering of that preview (issue #1926).
+    // Resolving the artifact also wires the implicit dependency on whichever task produced the
+    // classes, so the bundle's bytecode is compiled first even when no standalone
+    // `compile<Variant>Kotlin` task exists.
+    variant.artifacts
+      .forScope(ScopedArtifacts.Scope.PROJECT)
+      .use(bundleTask)
+      .toGet(
+        ScopedArtifact.CLASSES,
+        BundlePreviewTask::projectClassJars,
+        BundlePreviewTask::projectClassDirs,
+      )
 
     // Phase 1, Stream A — preview daemon bootstrap descriptor. Registered
     // unconditionally so the VS Code extension can sniff the output file

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
@@ -18,7 +18,9 @@ import kotlinx.serialization.json.jsonPrimitive
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.Directory
 import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFile
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.MapProperty
@@ -83,6 +85,39 @@ abstract class BundlePreviewTask : DefaultTask() {
    * resources directory is taken separately via [moduleResourcesDir] when present.
    */
   @get:Classpath abstract val moduleClassDirs: ConfigurableFileCollection
+
+  /**
+   * The module's own compiled classes laid out as directories, sourced from AGP's scoped `PROJECT`
+   * `CLASSES` artifact (`variant.artifacts.forScope(PROJECT).use(bundleTask).toGet(CLASSES, …)`).
+   * Wired by the Android backend *in addition to* [moduleClassDirs], for the same reason
+   * [DiscoverPreviewsTask.projectClassDirs] is: under AGP 9.x built-in Kotlin (`built_in_kotlinc`)
+   * the compiled classes never land in the hardcoded `build/tmp/kotlin-classes/<variant>` directory
+   * the desktop/legacy path keys off. Discovery already consumes the scoped artifact (issue #1924),
+   * so packing it here keeps the bundle's class set from being *narrower* than what discovery wrote
+   * into `previews.json` — a preview whose class is resolved only from a scoped dir would otherwise
+   * appear in the manifest but be missing from `classes/app.jar` (issue #1926). These dirs are
+   * scanned for the closure walk and per-class minimization exactly like [moduleClassDirs]; any
+   * overlap dedupes by relative class path. Optional / empty on non-Android backends.
+   */
+  @get:InputFiles
+  @get:Optional
+  @get:PathSensitive(PathSensitivity.RELATIVE)
+  abstract val projectClassDirs: ListProperty<Directory>
+
+  /**
+   * The module's own compiled classes packaged as jars, the jar half of AGP's scoped `PROJECT`
+   * `CLASSES` artifact (see [projectClassDirs]). Packed as *module* classes (minimized into
+   * `classes/app.jar`), NOT recorded as third-party [dependencyJars] coordinates — they are the
+   * consumer's own bytecode and can't be re-resolved from Maven. Mirrors
+   * [DiscoverPreviewsTask.projectClassJars], which method-walks the same jars, so bundling sees the
+   * identical class set discovery does. `PROJECT`-scope `CLASSES` are directories in practice, so
+   * this is usually empty, but it's wired and packed so the two paths never diverge (issue #1926).
+   * Optional / empty on non-Android backends.
+   */
+  @get:InputFiles
+  @get:Optional
+  @get:PathSensitive(PathSensitivity.RELATIVE)
+  abstract val projectClassJars: ListProperty<RegularFile>
 
   /**
    * Consumer module's processed resources directory (e.g. `build/processedResources/jvm/main`).
@@ -279,15 +314,34 @@ abstract class BundlePreviewTask : DefaultTask() {
     val depSeedFqns = selected.map { it.className }.toSet() + replayEntrySeeds
     val packSeedFqns = selected.filter { it.id !in irByPreview }.map { it.className }.toSet()
 
-    val classDirsList = moduleClassDirs.files.filter { it.exists() && it.isDirectory }
+    // Union the legacy hardcoded `moduleClassDirs` with AGP's scoped PROJECT CLASSES (dirs + jars)
+    // so the packed class set matches discovery's, which already consumes the scoped artifact
+    // (#1924). Without this, a preview whose class is resolved only from a scoped element would be
+    // in `previews.json` but absent from `classes/app.jar` (#1926). Scoped project jars are the
+    // module's OWN bytecode, so they're packed as module classes — not recorded as dependency
+    // coordinates the way `dependencyJars` are.
+    val scopedClassDirs = projectClassDirs.getOrElse(emptyList()).map { it.asFile }
+    val scopedClassJars =
+      projectClassJars
+        .getOrElse(emptyList())
+        .map { it.asFile }
+        .filter { it.isFile && it.name.endsWith(".jar") }
+    val classDirsList =
+      (moduleClassDirs.files + scopedClassDirs).filter { it.exists() && it.isDirectory }.distinct()
     val jarsList = dependencyJars.files.filter { it.isFile && it.name.endsWith(".jar") }
-    val scanPaths = (classDirsList + jarsList).map { it.absolutePath }
+    // Scoped project jars join the closure scan so reachability is computed over them too, but they
+    // are kept separate from `jarsList` (dependency jars) so `buildDepDecisions` never mistakes the
+    // module's own jar for a third-party coordinate.
+    val scanPaths = (classDirsList + jarsList + scopedClassJars).map { it.absolutePath }
 
     val closure = closureWalk(scanPaths, depSeed = depSeedFqns, packSeed = packSeedFqns)
 
-    val moduleClassFqns = collectClassFqns(classDirsList)
+    val moduleClassFqns =
+      collectClassFqns(classDirsList) + collectClassFqnsFromJars(scopedClassJars)
     val reachableModuleClasses = moduleClassFqns intersect closure.packReachable
-    val keptModuleClassFiles = packModuleClasses(classDirsList, reachableModuleClasses)
+    val keptModuleClassFiles =
+      packModuleClasses(classDirsList, reachableModuleClasses) +
+        packModuleClassesFromJars(scopedClassJars, reachableModuleClasses)
     val appJarBytes = buildJar(keptModuleClassFiles, moduleResourcesDir.orNull?.asFile)
 
     val coordMap = dependencyCoordinates.getOrElse(emptyMap())
@@ -772,6 +826,65 @@ abstract class BundlePreviewTask : DefaultTask() {
           val rel = f.relativeTo(root).path.replace(File.separatorChar, '/')
           result += rel.removeSuffix(".class").replace('/', '.')
         }
+    }
+    return result
+  }
+
+  /**
+   * Jar-form counterpart of [collectClassFqns] for scoped PROJECT-CLASSES jars
+   * ([projectClassJars]). Returns the FQN of every `.class` entry so the caller can intersect
+   * against the closure's pack-reachable set, exactly as it does for the directory-backed module
+   * classes.
+   */
+  private fun collectClassFqnsFromJars(jars: List<File>): Set<String> {
+    val result = mutableSetOf<String>()
+    for (jar in jars) {
+      try {
+        ZipInputStream(jar.inputStream().buffered()).use { zin ->
+          while (true) {
+            val entry = zin.nextEntry ?: break
+            val name = entry.name
+            if (!entry.isDirectory && name.endsWith(".class")) {
+              result += name.removeSuffix(".class").replace('/', '.')
+            }
+            zin.closeEntry()
+          }
+        }
+      } catch (e: Exception) {
+        logger.warn("composePreviewBundle: couldn't scan $jar for module classes: ${e.message}")
+      }
+    }
+    return result
+  }
+
+  /**
+   * Jar-form counterpart of [packModuleClasses]: extracts the `.class` entries whose FQN is in
+   * [reachable] from each scoped PROJECT-CLASSES jar, keyed by entry name (the same `pkg/Foo.class`
+   * relative path the directory packer emits) so they merge cleanly into `classes/app.jar`.
+   */
+  private fun packModuleClassesFromJars(
+    jars: List<File>,
+    reachable: Set<String>,
+  ): Map<String, ByteArray> {
+    val result = LinkedHashMap<String, ByteArray>()
+    for (jar in jars) {
+      try {
+        ZipInputStream(jar.inputStream().buffered()).use { zin ->
+          while (true) {
+            val entry = zin.nextEntry ?: break
+            val name = entry.name
+            if (!entry.isDirectory && name.endsWith(".class")) {
+              val fqn = name.removeSuffix(".class").replace('/', '.')
+              if (fqn in reachable && name !in result) {
+                result[name] = zin.readBytes()
+              }
+            }
+            zin.closeEntry()
+          }
+        }
+      } catch (e: Exception) {
+        logger.warn("composePreviewBundle: couldn't pack module classes from $jar: ${e.message}")
+      }
     }
     return result
   }

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -329,7 +329,7 @@ internal object ComposePreviewTasks {
     // `artifactType=jar` attribute, so the bundle's filtered `dependencyJars` view drops it.
     androidUnitTestConfigFiles: FileCollection? = null,
     androidUnitTestRuntimeClasspath: (() -> FileCollection?)? = null,
-  ) {
+  ): TaskProvider<BundlePreviewTask> {
     val previewIdsProperty: Provider<List<String>> =
       project.providers.gradleProperty("bundlePreviewIds").map { raw ->
         BundlePreviewIds.parse(raw)
@@ -450,7 +450,7 @@ internal object ComposePreviewTasks {
         candidates.firstOrNull { it != null && it.asFile.isDirectory }
       }
 
-    project.tasks.register("composePreviewBundle", BundlePreviewTask::class.java) {
+    return project.tasks.register("composePreviewBundle", BundlePreviewTask::class.java) {
       // Skip bundling a non-renderable pure-KMP-Android module: it discovers 0 previews, and
       // BundlePreviewTask hard-fails on an empty manifest, so a build-wide `render --bundle` (which
       // appends `:<module>:composePreviewBundle` for every detected module) would fail on it even

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/BundleScopedClassesTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/BundleScopedClassesTest.kt
@@ -1,0 +1,175 @@
+package ee.schimke.composeai.plugin
+
+import com.google.common.truth.Truth.assertThat
+import ee.schimke.composeai.discovery.PreviewInfo
+import ee.schimke.composeai.discovery.PreviewManifest
+import java.io.ByteArrayInputStream
+import java.io.File
+import java.util.zip.ZipEntry
+import java.util.zip.ZipInputStream
+import java.util.zip.ZipOutputStream
+import kotlinx.serialization.json.Json
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * Pins that [BundlePreviewTask] packs the module's own bytecode from AGP's scoped `PROJECT`
+ * `CLASSES` artifact — wired by the Android backend into [BundlePreviewTask.projectClassDirs] /
+ * [BundlePreviewTask.projectClassJars] — not just from the hardcoded `moduleClassDirs` directory
+ * list.
+ *
+ * Discovery already resolves previews from the scoped artifact (issue #1924), so without this the
+ * bundle's class set could be strictly narrower than the `previews.json` discovery wrote: a preview
+ * whose class lands only in a scoped element (e.g. AGP 9.x built-in Kotlin output, which never
+ * reaches `build/tmp/kotlin-classes/<variant>`) would be listed in the manifest but missing from
+ * `classes/app.jar`, breaking detached rendering of that preview (issue #1926).
+ *
+ * The test drives the task action directly (no AGP/KGP) using a real compiled class off the test
+ * classpath as a stand-in module "preview" class, with `moduleClassDirs` deliberately empty so the
+ * scoped wiring is the only thing that can carry the class into the bundle.
+ */
+class BundleScopedClassesTest {
+
+  @get:Rule val tmp = TemporaryFolder()
+
+  private val json = Json {
+    classDiscriminator = "kind"
+    ignoreUnknownKeys = true
+    encodeDefaults = true
+  }
+
+  // A real compiled class guaranteed to be on the test runtime classpath as a directory entry.
+  private val previewClassFqn = "ee.schimke.composeai.plugin.BundlePreviewIds"
+  private val previewClassRel = previewClassFqn.replace('.', '/') + ".class"
+
+  private fun moduleClassBytes(): ByteArray {
+    val root = File(BundlePreviewIds::class.java.protectionDomain.codeSource.location.toURI())
+    val classFile = File(root, previewClassRel)
+    check(classFile.isFile) { "expected a compiled class at $classFile" }
+    return classFile.readBytes()
+  }
+
+  private fun newBundleTask(outDir: File): BundlePreviewTask {
+    val project = ProjectBuilder.builder().withProjectDir(tmp.root).build()
+    val task = project.tasks.register("composePreviewBundle", BundlePreviewTask::class.java).get()
+    val manifest =
+      PreviewManifest(
+        module = ":sample",
+        variant = "debug",
+        previews =
+          listOf(
+            PreviewInfo(
+              id = "$previewClassFqn.sample",
+              functionName = "sample",
+              className = previewClassFqn,
+            )
+          ),
+      )
+    val previewsJson =
+      File(outDir, "previews.json").apply {
+        writeText(json.encodeToString(PreviewManifest.serializer(), manifest))
+      }
+    task.previewsJson.set(previewsJson)
+    task.output.set(File(outDir, "bundle.png"))
+    task.rendersDir.set(File(outDir, "renders").apply { mkdirs() })
+    task.modulePath.set(":sample")
+    task.producedBy.set("test")
+    task.backend.set("android")
+    task.previewIds.set(emptyList())
+    return task
+  }
+
+  @Test
+  fun `packs module classes from scoped PROJECT class dirs`() {
+    val outDir = tmp.newFolder("out-dirs")
+    val scoped = tmp.newFolder("scoped-dir")
+    File(scoped, previewClassRel).apply {
+      parentFile.mkdirs()
+      writeBytes(moduleClassBytes())
+    }
+
+    val task = newBundleTask(outDir)
+    // moduleClassDirs intentionally left empty — the scoped PROJECT dir is the only carrier.
+    task.projectClassDirs.add(task.project.layout.projectDirectory.dir(scoped.absolutePath))
+    task.pack()
+
+    assertThat(appJarEntries(task.output.get().asFile)).contains(previewClassRel)
+  }
+
+  @Test
+  fun `packs module classes from scoped PROJECT class jars`() {
+    val outDir = tmp.newFolder("out-jars")
+    val jar = File(tmp.newFolder("scoped-jar"), "module-classes.jar")
+    ZipOutputStream(jar.outputStream().buffered()).use { zip ->
+      zip.putNextEntry(ZipEntry(previewClassRel))
+      zip.write(moduleClassBytes())
+      zip.closeEntry()
+    }
+
+    val task = newBundleTask(outDir)
+    task.projectClassJars.add(task.project.layout.projectDirectory.file(jar.absolutePath))
+    task.pack()
+
+    assertThat(appJarEntries(task.output.get().asFile)).contains(previewClassRel)
+  }
+
+  @Test
+  fun `class is absent when neither moduleClassDirs nor the scoped artifact carry it`() {
+    val outDir = tmp.newFolder("out-empty")
+    val task = newBundleTask(outDir)
+    task.pack()
+
+    // Control: with nothing wired the bundle is still well-formed but cannot contain the class —
+    // proving the two tests above pass because of the scoped wiring, not some ambient classpath.
+    assertThat(appJarEntries(task.output.get().asFile)).doesNotContain(previewClassRel)
+  }
+
+  /** Entry names inside `classes/app.jar`, read out of the PNG+ZIP polyglot bundle. */
+  private fun appJarEntries(bundle: File): Set<String> {
+    val zipBytes = extractZipBytes(bundle.readBytes())
+    val appJar = readZipEntry(zipBytes, "classes/app.jar") ?: return emptySet()
+    val names = mutableSetOf<String>()
+    ZipInputStream(ByteArrayInputStream(appJar)).use { zin ->
+      while (true) {
+        val entry = zin.nextEntry ?: break
+        names += entry.name
+        zin.closeEntry()
+      }
+    }
+    return names
+  }
+
+  private fun readZipEntry(zipBytes: ByteArray, name: String): ByteArray? {
+    ZipInputStream(ByteArrayInputStream(zipBytes)).use { zin ->
+      while (true) {
+        val entry = zin.nextEntry ?: break
+        if (entry.name == name) {
+          val out = zin.readBytes()
+          zin.closeEntry()
+          return out
+        }
+        zin.closeEntry()
+      }
+    }
+    return null
+  }
+
+  /** Strip the leading PNG (the polyglot cover) so the trailing ZIP can be read. */
+  private fun extractZipBytes(bytes: ByteArray): ByteArray {
+    if (bytes[0] == 0x50.toByte() && bytes[1] == 0x4B.toByte()) return bytes
+    var offset = 8 // PNG signature
+    while (offset < bytes.size) {
+      val length =
+        ((bytes[offset].toInt() and 0xff) shl 24) or
+          ((bytes[offset + 1].toInt() and 0xff) shl 16) or
+          ((bytes[offset + 2].toInt() and 0xff) shl 8) or
+          (bytes[offset + 3].toInt() and 0xff)
+      val type = String(bytes, offset + 4, 4, Charsets.US_ASCII)
+      offset += 4 + 4 + length + 4
+      if (type == "IEND") return bytes.copyOfRange(offset, bytes.size)
+    }
+    error("PNG IEND not found")
+  }
+}


### PR DESCRIPTION
## Summary

Follow-up to #1924 / #1925. `composePreviewDiscover` now resolves the module's own classes from AGP's scoped `PROJECT` `CLASSES` artifact, but `composePreviewBundle` still packed module bytecode only from the hardcoded `sourceClassDirs` directory list — so discovery was strictly broader than bundling. A preview whose class is resolved only from a scoped element (e.g. AGP 9.x built-in Kotlin output, which never lands in `build/tmp/kotlin-classes/<variant>`) would be listed in `previews.json` but missing from `classes/app.jar`, breaking detached/portable rendering of that preview.

This plumbs the scoped `PROJECT` `CLASSES` (dirs **and** jars) into `BundlePreviewTask` the same way discovery consumes them, so the two never diverge on which class set they see.

- `BundlePreviewTask` gains `projectClassDirs` / `projectClassJars` inputs (mirroring `DiscoverPreviewsTask`), wired from the Android caller via `variant.artifacts.forScope(PROJECT).use(bundleTask).toGet(CLASSES, …)`. Resolving the artifact also wires the implicit dependency on whichever task compiled the classes.
- The packer unions the scoped dirs into `moduleClassDirs` for the closure walk + per-class minimization. Scoped project **jars** are packed as *module* classes (minimized into `classes/app.jar`), **not** recorded as third-party dependency coordinates — they're the consumer's own bytecode and can't be re-resolved from Maven.
- `registerBundleTask` now returns the `TaskProvider<BundlePreviewTask>` so the Android caller can wire the scoped artifact onto it. Desktop/JVM callers are unchanged (the new inputs are `@Optional`, empty there).

Closes #1926.

## Test plan

- New `BundleScopedClassesTest` drives the task action directly (no AGP/KGP) with `moduleClassDirs` deliberately empty, proving a class carried **only** via `projectClassDirs` and via `projectClassJars` lands in `classes/app.jar`, plus a control asserting it's absent when neither is wired.
- `./gradlew :gradle-plugin:test --tests "…BundleScopedClassesTest" --tests "…RegisterBundleTaskBackendTest"` — green.
- `:gradle-plugin:compileKotlin` + `ktfmtFormat` — clean.

Non-visual change (build/data-plumbing only), so no rendered evidence.

---
_Generated by [Claude Code](https://claude.ai/code/session_0197v7mNsmqgAUcQdoxPfrYA)_