### PR TITLE
fix(discovery): match project classes by canonical path for symlinked build trees

### DIFF
--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
@@ -210,6 +210,25 @@ object PreviewDiscovery {
   private const val ROBO_COMPOSE_PREVIEW_OPTIONS_FQN =
     "com.github.takahirom.roborazzi.annotations.RoboComposePreviewOptions"
 
+  /**
+   * Both the un-resolved ([File.getAbsolutePath]) and symlink-resolved ([File.getCanonicalPath])
+   * forms of [file], used to match a class's owning classpath element against the project's own
+   * class dirs / jars.
+   *
+   * ClassGraph canonicalises the classpath element it reports for each class (resolving symlinks),
+   * while Gradle/AGP hand discovery the location verbatim. On an overlay / symlinked build tree —
+   * e.g. the AndroidX "androidchka" overlay — the two forms differ, so a raw `absolutePath`
+   * comparison matches nothing: every class is then treated as a dependency class, never
+   * method-walked, and discovery reports `Discovered 0 preview(s)` even though the annotated
+   * classes are present in `classDirs`. Comparing on the union of both forms makes the match
+   * symlink-agnostic — it succeeds whenever either side's absolute or canonical path coincides.
+   * `canonicalPath` does I/O and can throw, so it's added best-effort. See issue #1924.
+   */
+  private fun pathMatchKeys(file: File): Set<String> = buildSet {
+    add(file.absolutePath)
+    runCatching { add(file.canonicalPath) }
+  }
+
   fun discover(input: Input): Outcome {
     val warnings = mutableListOf<String>()
     val infoMessages = mutableListOf<String>()
@@ -281,13 +300,13 @@ object PreviewDiscovery {
           // the ClassGraph classpath (for multi-preview annotation resolution)
           // but aren't method-walked. See issue #1039 / #1924.
           val projectElementPaths =
-            (existingClassDirs + existingProjectJars).map { it.absolutePath }.toSet()
+            (existingClassDirs + existingProjectJars).flatMap { pathMatchKeys(it) }.toSet()
           val projectClassFqns =
             scanResult.allClasses
               .asSequence()
               .filter { ci ->
                 val element = ci.classpathElementFile ?: return@filter false
-                element.absolutePath in projectElementPaths
+                pathMatchKeys(element).any { it in projectElementPaths }
               }
               .map { it.name }
               .toSet()

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewDiscoverySymlinkedClassDirTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewDiscoverySymlinkedClassDirTest.kt
@@ -1,0 +1,108 @@
+package ee.schimke.composeai.discovery
+
+import com.google.common.truth.Truth.assertThat
+import java.io.File
+import java.nio.file.Files
+import org.junit.Assume.assumeTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.objectweb.asm.AnnotationVisitor
+import org.objectweb.asm.ClassWriter
+import org.objectweb.asm.Opcodes
+
+/**
+ * Regression coverage for issue #1924: discovery must find the consumer module's own `@Preview`
+ * functions when its class directory is reached through a **symlink** — the shape produced by
+ * overlay build trees such as the AndroidX "androidchka" overlay.
+ *
+ * ClassGraph canonicalises the classpath element it reports for each class (resolving the symlink),
+ * while Gradle/AGP hand discovery the un-resolved `classDirs` location. Matching project classes on
+ * the raw `absolutePath` therefore missed every class on a symlinked tree, leaving
+ * `projectClassFqns` empty so the method-walk skipped everything and discovery reported `Discovered
+ * 0 preview(s)` even though the annotated classes were present (see
+ * [PreviewDiscovery.pathMatchKeys]).
+ *
+ * The hand-rolled class mirrors real bytecode: `androidx.compose.ui.tooling.preview.Preview` has
+ * `CLASS` retention, so it's emitted as a `RuntimeInvisibleAnnotations` entry (ASM `visible =
+ * false`).
+ */
+class PreviewDiscoverySymlinkedClassDirTest {
+
+  @get:Rule val tempDir = TemporaryFolder()
+
+  @Test
+  fun `previews under a symlinked class dir are discovered and method-walked`() {
+    val realClasses = File(tempDir.root, "real/classes")
+    writePreviewClass(
+      classesDir = realClasses,
+      internalName = "test/ZzDiagDirectPreviewKt",
+      methodName = "ZzDiagDirectPreview",
+    )
+
+    // The path discovery is actually handed points at the class dir through a symlink, exactly as a
+    // symlinked / overlay build tree exposes `build/.../classes`. ClassGraph resolves it to the
+    // real
+    // path; discovery must still recognise the classes as the project's own.
+    val linkRoot = File(tempDir.root, "link").toPath()
+    try {
+      Files.createSymbolicLink(linkRoot, File(tempDir.root, "real").toPath())
+    } catch (e: Exception) {
+      // Some CI filesystems / Windows without privilege can't create symlinks — skip rather than
+      // fail; the production fix is exercised wherever symlinks are supported.
+      assumeTrue("symlinks unsupported on this filesystem: ${e.message}", false)
+    }
+    val symlinkedClasses = File(linkRoot.toFile(), "classes")
+    assertThat(symlinkedClasses.canonicalPath).isEqualTo(realClasses.canonicalPath)
+    assertThat(symlinkedClasses.absolutePath).isNotEqualTo(realClasses.canonicalPath)
+
+    val outcome =
+      PreviewDiscovery.discover(
+        PreviewDiscovery.Input(
+          classDirs = listOf(symlinkedClasses),
+          dependencyJars = emptyList(),
+          sourceFiles = emptyList(),
+          moduleName = ":overlay-samples",
+          variantName = "debug",
+          projectDirectory = tempDir.root,
+          failOnEmpty = true,
+        )
+      )
+
+    assertThat(outcome).isInstanceOf(PreviewDiscovery.Outcome.Success::class.java)
+    val preview = (outcome as PreviewDiscovery.Outcome.Success).manifest.previews.single()
+    assertThat(preview.className).isEqualTo("test.ZzDiagDirectPreviewKt")
+    assertThat(preview.functionName).isEqualTo("ZzDiagDirectPreview")
+  }
+
+  /**
+   * Writes a single class with one parameterless `public static` method annotated with
+   * `androidx.compose.ui.tooling.preview.Preview` (emitted as `RuntimeInvisibleAnnotations` to
+   * match the CLASS-retention bytecode the Compose compiler produces) into [classesDir], laid out
+   * by package like a real compiler output directory.
+   */
+  private fun writePreviewClass(classesDir: File, internalName: String, methodName: String) {
+    val cw = ClassWriter(0)
+    cw.visit(
+      Opcodes.V17,
+      Opcodes.ACC_PUBLIC or Opcodes.ACC_FINAL or Opcodes.ACC_SUPER,
+      internalName,
+      null,
+      "java/lang/Object",
+      null,
+    )
+    val mv = cw.visitMethod(Opcodes.ACC_PUBLIC or Opcodes.ACC_STATIC, methodName, "()V", null, null)
+    val av: AnnotationVisitor =
+      mv.visitAnnotation("Landroidx/compose/ui/tooling/preview/Preview;", false)
+    av.visitEnd()
+    mv.visitCode()
+    mv.visitInsn(Opcodes.RETURN)
+    mv.visitMaxs(0, 0)
+    mv.visitEnd()
+    cw.visitEnd()
+
+    val classFile = File(classesDir, "$internalName.class")
+    classFile.parentFile.mkdirs()
+    classFile.writeBytes(cw.toByteArray())
+  }
+}


### PR DESCRIPTION
## Summary

Follow-up to #1924 / #1925. On AGP 9.3 + built-in Kotlin, `composePreviewDiscover` still reported `Discovered 0 preview(s)` on **overlay build trees** (the reporter's "androidchka overlay"), even though #1925 made `classDirs` correctly include the `built_in_kotlinc/<variant>/compile<Variant>Kotlin/classes` dir and that dir contains the annotated classes.

**Root cause.** Discovery decides which classes to method-walk by matching each class's owning classpath element against the project's own class dirs/jars. It compared raw `File.absolutePath` — but **ClassGraph canonicalises the classpath element it reports** (resolving symlinks), while Gradle/AGP hand discovery the location verbatim. On a symlinked / overlay tree the two forms differ, so the match found nothing, `projectClassFqns` was empty, and the `if (classInfo.name !in projectClassFqns) continue` gate skipped **every** class → zero previews. (The scoped `PROJECT CLASSES` artifact the reporter saw fail to resolve is a separate, additive path; it isn't needed once the `classDirs` classes are walked.)

Verified empirically: `ClassGraph().overrideClasspath("<symlink>")` reports `getClasspathElementFile().getAbsolutePath()` as the **resolved** target, not the symlink — so the old `absolutePath` set never matched.

**Fix.** Match on the union of absolute **and** canonical paths (`pathMatchKeys`), so the project-vs-dependency classification is symlink-agnostic — it succeeds whenever either side's absolute or canonical form coincides. `canonicalPath` is added best-effort (it does I/O and can throw).

## Test plan

- New `PreviewDiscoverySymlinkedClassDirTest` scans a class dir reached through a **symlink** (ASM-emitted `@Preview` class, `RuntimeInvisibleAnnotations` to mirror CLASS retention). **Fails before this change** (outcome is `Failure`/0 previews), **passes after**. Skips gracefully where the filesystem can't create symlinks.
- `:gradle-plugin:preview-discovery:test` (new test + existing `PreviewDiscoveryProjectJarTest`) — green; `ktfmtFormat` clean.

Non-visual change (discovery plumbing), so no rendered evidence.

Refs #1924.

---
_Generated by [Claude Code](https://claude.ai/code/session_0197v7mNsmqgAUcQdoxPfrYA)_