### PR TITLE
docs: clarify direct-Gradle application needs a pinned version

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ INIT_SCRIPT="$(compose-preview init-script --path)"
 
 The CLI's [auto-inject script](cli/src/main/kotlin/ee/schimke/composeai/cli/AutoInject.kt) detects projects that already declare the plugin (either literally as `id("ee.schimke.composeai.preview") version "..."` or via a `gradle/libs.versions.toml` alias resolved through `alias(libs.plugins.<x>)`) and skips the classpath injection for those builds, so mixed setups work without conflicts.
 
-The plugin is also published to [Maven Central](https://central.sonatype.com/artifact/ee.schimke.composeai/compose-preview-plugin) (no auth, no PAT) if you prefer to apply it in `build.gradle.kts` directly — see the working examples under [`samples/android/build.gradle.kts`](samples/android/build.gradle.kts), [`samples/wear/build.gradle.kts`](samples/wear/build.gradle.kts), and [`samples/cmp/build.gradle.kts`](samples/cmp/build.gradle.kts).
+The plugin is also published to [Maven Central](https://central.sonatype.com/artifact/ee.schimke.composeai/compose-preview-plugin) (no auth, no PAT). To apply it directly, add `id("ee.schimke.composeai.preview") version "<latest>"` to your `plugins { }` block, pinning the current version shown on Maven Central. The in-repo [`samples/`](samples/) build files apply it *without* a version because they resolve the plugin from this repository's own included build, so they aren't drop-in for an external project.
 
 Requires Java 17+, Gradle 8.13+, AGP 8.13.0+ (Android), Kotlin 2.0.21+,
 Compose Multiplatform 1.10.3+ (Desktop). The bottom edge of the supported


### PR DESCRIPTION
## Summary

Follow-up to #1932, addressing a Codex review point that landed after that PR auto-merged.

The direct-application note in the README Setup section linked the in-repo `samples/` build files as "working examples", but those apply `id("ee.schimke.composeai.preview")` *without* a version — they resolve the plugin from this repo's own included build, so they aren't drop-in for an external project. After #1932 removed the only versioned `plugins { ... version "..." }` snippet, the direct path no longer gave outside consumers a working integration.

This reword keeps zero-code as the primary path and avoids reintroducing the removed copy-paste example, but makes the direct path accurate:
- Spells out that direct application needs `id("ee.schimke.composeai.preview") version "<latest>"`, pinned to the current Maven Central release (linked).
- Notes that the `samples/` build files omit the version on purpose because they resolve from the included build.

A `<latest>` placeholder is used rather than a hardcoded version, so no `x-release-please` marker / release-please plumbing is reintroduced.

## Test plan

- Text-only docs change; no code paths affected.
- Verified the Setup section still reads cleanly with zero-code leading and the direct path now giving correct external guidance.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KPq5WeVbXY2LbgMuie8TVB)_