### PR TITLE
docs: simplify README and site homepage; move MCP/daemon to secondary pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,151 +1,93 @@
 # compose-ai-tools
 
-**[Documentation](https://yschimke.github.io/compose-ai-tools/)** —
-install, VS Code Marketplace, and one-page-per-product reference for
-each data extension.
+**See your Compose UI without opening Android Studio.**
 
-Render `@Preview` composables to PNG outside Android Studio, so AI coding
-agents can see what they're changing. Works with Jetpack Compose (Android,
-via Robolectric) and Compose Multiplatform Desktop (via `ImageComposeScene`).
+`compose-ai-tools` renders your `@Preview` composables to PNG from the
+command line — so your AI coding agent can actually *look* at the screen it
+just changed, and so can you. Works with Jetpack Compose (Android, via
+Robolectric) and Compose Multiplatform Desktop (via `ImageComposeScene`).
 
-Renders include
-[paused-clock animation captures](https://github.com/yschimke/skills/blob/main/skills/compose-preview/references/capture-modes.md#animations-and-the-paused-frame-clock-android-only)
-(GIF or single frame) and opt-in
-[ATF accessibility checks](https://github.com/yschimke/skills/blob/main/skills/compose-preview/references/a11y.md)
-with annotated overlays.
+That's the whole idea. Everything else on this page is optional.
 
-Also renders [Android XML resources](https://github.com/yschimke/skills/blob/main/skills/compose-preview/references/resource-previews.md) —
-vector drawables, adaptive launcher icons, animated-vector drawables — and indexes the icon
-attributes in `AndroidManifest.xml` so tooling can link manifest lines to the same rendered PNG.
-Modules without any matching resources self-no-op, so this comes along for free with the plugin.
+**[📖 Documentation](https://yschimke.github.io/compose-ai-tools/)** ·
+[Install](https://yschimke.github.io/compose-ai-tools/install/) ·
+[Reference](https://yschimke.github.io/compose-ai-tools/reference/)
 
-## The agent loop
+## Get started
 
-These tools give AI coding agents a tight, token-frugal feedback loop over
-Compose UI — the way [Playwright](https://playwright.dev) gave web agents one
-over the DOM: act by a stable reference, observe structure rather than pixels,
-and turn exploration into durable tests. The capabilities below are exposed by
-the preview daemon's MCP server (and, where noted, the `compose-preview` CLI);
-see [`docs/daemon/MCP.md`](docs/daemon/MCP.md) for the full tool surface.
+Pick the one that fits you. Each is a single step.
 
-- **Target by semantic ref, not pixels.** `interactive/input` and
-  `record_preview` accept a `target` (`testTag` / `role`+`text` / a stable
-  node `ref`) that the daemon resolves to the node's centre, so a click
-  survives layout changes instead of breaking on a coordinate. Works on
-  Android (Robolectric) and Desktop (Skiko).
-- **Token-frugal observation.** `render_preview observe=semantics|hash`
-  returns the `compose/semantics` tree + a hash + dimensions instead of a
-  base64 PNG — typically a few hundred tokens versus ~1.5k. Fetch pixels only
-  when you actually need to look.
-- **Semantics diff.** `diff_semantics` (MCP) and `compose-preview
-  diff-semantics` (CLI) diff two semantics trees and report what changed
-  *semantically* (text, label, role, testTag, overflow…), matched by stable
-  ref — a deterministic, pixel-free regression signal, the Compose analogue of
-  Playwright's aria-snapshot diff.
-- **Matrix render.** `render_matrix` (and the `compose-preview render-matrix`
-  CLI) renders one preview across a cross-product of
-  `device × locale × uiMode × fontScale` in a single call, returning a per-cell
-  hash and which cells changed — "does this survive small screen + RTL + large
-  font?" without N screenshots. Opt into a stitched contact-sheet image when you
-  want to eyeball every cell at once.
-- **Recording → test.** `record_preview emitTest=true` turns a scripted
-  interaction into a runnable Compose UI test (semantic targets become
-  `onNodeWithTag(...).performClick()` steps; each `recording.probe` is diffed
-  against the previous probe's captured semantics into `assertExists()` /
-  `assertDoesNotExist()` assertions).
-- **Structured failures.** A failed render reports a typed `kind` plus a
-  one-line fix hint for recognized signatures (classpath skew, Robolectric SDK
-  mismatch, missing `@Composable`, …) instead of an opaque message.
+### 🤖 With an AI coding agent
 
-Cost budget for these in [`docs/TOKEN_USAGE.md`](docs/TOKEN_USAGE.md).
-
-## What it ships
-
-- **Agent skills** — the `compose-preview` and `compose-preview-review`
-  skill bundles live in
-  [`yschimke/skills`](https://github.com/yschimke/skills). Point any
-  agent that can fetch a URL at them; each skill is a complete
-  install-and-iterate playbook. Bootstrap a host machine (CLI + skills
-  in one shot) with the installer in
-  [`yschimke/skills`](https://github.com/yschimke/skills/blob/main/scripts/install.sh):
-
-  ```sh
-  curl -fsSL https://raw.githubusercontent.com/yschimke/skills/main/scripts/install.sh | bash
-  ```
-- **VS Code extension** — published to the
-  [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=yuri-schimke.compose-preview)
-  and [Open VSX](https://open-vsx.org/extension/yuri-schimke/compose-preview)
-  (for VSCodium / Cursor / Windsurf). Install from inside the IDE: open
-  the Extensions view (⇧⌘X / Ctrl+Shift+X), search **Compose Preview**,
-  click *Install*. Source in [`vscode-extension/`](vscode-extension/).
-- **GitHub Actions** — composite actions for CI:
-  [`install`](.github/actions/install/) (CLI on `$PATH`),
-  [`apply`](.github/actions/apply/) (unified pipeline — baselines on push,
-  before/after PR comments, a11y + notification surfaces).
-
-## Setup
-
-No build edits required. The `compose-preview` CLI ships a bundled Gradle init script and passes it via `--init-script` on every invocation, so projects that already apply `com.android.application` / `com.android.library` / `org.jetbrains.compose` pick up the preview plugin without modifying `build.gradle.kts` — useful for AI agents on the CLI, in CI, or when exploring the tool without committing changes:
+Run the one-line installer once. It drops the `compose-preview` CLI **and**
+the agent skill into place (Claude Code, Codex, Gemini):
 
 ```sh
-compose-preview list                # scan @Preview annotations
-compose-preview render              # render every @Preview to PNG
-compose-preview render-matrix --id com.example.MyPreview --ui-mode light,dark --font-scale 1.0,2.0
-                                    # one preview across a device × locale × uiMode × fontScale grid
+curl -fsSL https://raw.githubusercontent.com/yschimke/skills/main/scripts/install.sh | bash
 ```
 
-For direct `./gradlew` use (e.g., a CI step that needs extra Gradle flags), materialise the same init script once and thread its path through each invocation:
+Then just ask your agent to preview a composable. The
+[`compose-preview` skill](https://github.com/yschimke/skills/tree/main/skills/compose-preview)
+is the playbook — it tells the agent how to render, iterate, and check its own
+work. You don't have to learn the commands; the agent reads the skill. (If
+your agent can fetch URLs but not run the installer, point it straight at the
+[SKILL.md](https://github.com/yschimke/skills/blob/main/skills/compose-preview/SKILL.md)
+— it bootstraps the CLI itself.)
+
+### 🧩 In VS Code (or Cursor / Windsurf / VSCodium)
+
+Open the Extensions view (⇧⌘X / Ctrl+Shift+X), search **Compose Preview**,
+click *Install*. It renders previews inline and needs no project changes.
+([Marketplace](https://marketplace.visualstudio.com/items?itemName=yuri-schimke.compose-preview) ·
+[Open VSX](https://open-vsx.org/extension/yuri-schimke/compose-preview))
+
+### ⌨️ From the command line
+
+Install the CLI (same one-liner as above), then point it at any Compose
+project — **no build edits required**:
 
 ```sh
-INIT_SCRIPT="$(compose-preview init-script --path)"
-./gradlew --init-script "$INIT_SCRIPT" :app:composePreviewDiscover
-./gradlew --init-script "$INIT_SCRIPT" :app:composePreviewRenderAll
+compose-preview render    # render every @Preview to PNG
 ```
 
-> **VS Code users:** the [`Compose Preview` extension](vscode-extension/) already auto-injects via `--init-script` on every Gradle invocation it makes — no extra setup needed.
+The CLI injects itself into your build at runtime, so projects that already
+apply `com.android.application` / `com.android.library` /
+`org.jetbrains.compose` just work.
 
-The CLI's [auto-inject script](cli/src/main/kotlin/ee/schimke/composeai/cli/AutoInject.kt) detects projects that already declare the plugin (either literally as `id("ee.schimke.composeai.preview") version "..."` or via a `gradle/libs.versions.toml` alias resolved through `alias(libs.plugins.<x>)`) and skips the classpath injection for those builds, so mixed setups work without conflicts.
+> Prefer a version-pinned Gradle plugin? It's on
+> [Maven Central](https://central.sonatype.com/artifact/ee.schimke.composeai/compose-preview-plugin)
+> (no auth, no token). See the
+> [Install page](https://yschimke.github.io/compose-ai-tools/install/) for
+> that, CI recipes, and the full requirements (Java 17+, Gradle 8.13+, AGP
+> 8.13.0+, Kotlin 2.0.21+).
 
-The plugin is also published to [Maven Central](https://central.sonatype.com/artifact/ee.schimke.composeai/compose-preview-plugin) (no auth, no PAT). To apply it directly, add `id("ee.schimke.composeai.preview") version "<latest>"` to your `plugins { }` block, pinning the current version shown on Maven Central. The in-repo [`samples/`](samples/) build files apply it *without* a version because they resolve the plugin from this repository's own included build, so they aren't drop-in for an external project.
+## What else it can do
 
-Requires Java 17+, Gradle 8.13+, AGP 8.13.0+ (Android), Kotlin 2.0.21+,
-Compose Multiplatform 1.10.3+ (Desktop). The bottom edge of the supported
-consumer envelope is exercised on every push by the
-[`agp8-min` job](.github/workflows/integration.yml) against the fixture
-under [`.github/ci/fixtures/agp8-min/`](.github/ci/fixtures/agp8-min/);
-the project's own build runs on a newer toolchain (see
-[`docs/AGENTS.md`](docs/AGENTS.md)).
+None of this is required to get value from the tool — it's there when you want
+more than a PNG.
+
+- **[Data products](https://yschimke.github.io/compose-ai-tools/reference/)** —
+  alongside each PNG the renderer can emit structured data: accessibility
+  findings, layout trees, theme tokens, recomposition heat maps, drawn text,
+  resource captures, and more. One page per product.
+- **[Agents & MCP](https://yschimke.github.io/compose-ai-tools/mcp/)** — a
+  push-based, token-frugal agent loop over Compose UI: target by semantic ref,
+  observe semantics instead of pixels, diff renders, turn recordings into
+  tests. The aria-snapshot story for Compose.
+- **[Daemon](https://yschimke.github.io/compose-ai-tools/daemon/)** — an
+  optional long-lived renderer that keeps Robolectric / Compose-Desktop warm
+  so re-renders are fast.
 
 ## Samples
 
-Source under [`samples/`](samples/). Rendered baselines (PNGs and animation
-GIFs, regenerated on every push to `main`) are browsable inline on the
+Rendered baselines (PNGs and animation GIFs, regenerated on every push to
+`main`) are browsable inline on the
 [`compose-preview/main`](https://github.com/yschimke/compose-ai-tools/tree/compose-preview/main)
-branch:
-
-- [`samples:android`](https://github.com/yschimke/compose-ai-tools/tree/compose-preview/main#samplesandroid) — phone, font-family showcase, scrolling captures, animation timelines.
-- [`samples:wear`](https://github.com/yschimke/compose-ai-tools/tree/compose-preview/main#sampleswear) — Wear OS Material 3 Expressive, `EdgeButton`, tile previews.
-- [`samples:cmp`](https://github.com/yschimke/compose-ai-tools/tree/compose-preview/main#samplescmp) — Compose Multiplatform Desktop.
-- [`samples:remotecompose`](https://github.com/yschimke/compose-ai-tools/tree/compose-preview/main#samplesremotecompose) — Remote Compose against `wear-compose-remote-material3`.
-- [`samples:xr-spatial`](https://github.com/yschimke/compose-ai-tools/tree/compose-preview/main#samplesxr-spatial) — Jetpack Compose for XR (`androidx.xr.compose`), 2D Home-Space fallback of `Orbiter` / `SpatialElevation` / `SpatialPanel` content.
-
-ATF a11y findings for the same samples are on the
-[`compose-preview/a11y/main`](https://github.com/yschimke/compose-ai-tools/tree/compose-preview/a11y/main)
-branch.
-
-## Integration previews
-
-The [integration matrix](.github/workflows/integration.yml) renders the
-plugin against real-world external Compose projects on every push to `main`.
-Each render-enabled project publishes its own browsable
-`compose-preview/integration/<slug>` branch — same gallery layout as
-`compose-preview/main`, with a **CI notes** section recording any
-workarounds the harness applied (consumer patches, stubbed credentials,
-non-blocking status):
-
-- [`wear-os-samples` (ComposeStarter)](https://github.com/yschimke/compose-ai-tools/tree/compose-preview/integration/wear-os-samples) — full Android render + daemon round-trip, isolated-projects + configuration-cache.
-- [`wear-os-samples` (WearTilesKotlin)](https://github.com/yschimke/compose-ai-tools/tree/compose-preview/integration/wear-tiles) — Wear Tiles render path (`kind: TILE`).
-- [`adaptive-apps-samples` (AdaptiveJetStream)](https://github.com/yschimke/compose-ai-tools/tree/compose-preview/integration/jetstream-xr) — XR spatial Compose, rendered on the `androidx.xr.compose` alpha14 baseline.
+branch — `samples:android`, `samples:wear`, `samples:cmp`,
+`samples:remotecompose`, `samples:xr-spatial`. Source under
+[`samples/`](samples/). The
+[integration matrix](.github/workflows/integration.yml) also renders the
+plugin against real-world external Compose projects on every push.
 
 ## Agent PR hall of fame
 
@@ -160,121 +102,12 @@ Have one to add? Open a PR or [an issue](https://github.com/yschimke/compose-ai-
 
 ## More
 
-- [Documentation site](https://yschimke.github.io/compose-ai-tools/) — installation, VS Code Marketplace, and the per-product data-extension reference.
-- [How it works](docs/HOW_IT_WORKS.md) — discovery, renderer, caching, project structure, plugin configuration.
-- [CI install action](.github/actions/install/README.md) — pin the CLI on `$PATH` in any GitHub Actions job, with version-catalog + Renovate recipes.
-- [Cloud sandbox setup](https://github.com/yschimke/skills/blob/main/skills/compose-preview/references/agent-cloud.md) — Claude Code on the web, network allowlist.
-- [CI workflows](https://github.com/yschimke/skills/blob/main/skills/compose-preview-review/references/ci-previews.md) — `compose-preview/main` baselines, PR diff comments.
+- [Documentation site](https://yschimke.github.io/compose-ai-tools/) — install, reference, agents & MCP, daemon.
+- [How it works](docs/HOW_IT_WORKS.md) — discovery, renderer, caching, project structure.
+- [PR review workflow](docs/PR_REVIEW_WORKFLOW.md) — reusable, preview-gated AI PR review (Codex / Claude / Gemini).
 - [Development](docs/DEVELOPMENT.md) — building plugin, CLI, and extension from source; consuming `-SNAPSHOT` builds.
 - [Architecture (contributor)](docs/AGENTS.md) — class-by-class map of the four-stage pipeline.
 - [Releases](https://github.com/yschimke/compose-ai-tools/releases) ·
   [Changelog](CHANGELOG.md) ·
   [License (Apache 2.0)](LICENSE)
-
-## Reusable Codex PR review workflow (Preview-gated)
-
-Use `.github/workflows/codex-pr-review-reusable.yml` to run AI PR review **only after** preview generation succeeds and with both code + visual context. The reusable workflow supports Codex, Claude, or Gemini based on which API key is configured (exactly one).
-
-### Minimal caller setup
-This repository wires the reusable workflow in `.github/workflows/codex-pr-review.yml` using a `preview` job plus a thin `uses:` call to the reusable workflow.
-
-In this repository the unified `.github/workflows/compose-preview.yml` runs on every push to `main`, every PR, and `workflow_dispatch`. Consumer repos can split that into separate workflows (or keep one workflow per surface) based on their needs.
-
-
-```yaml
-name: PR Review (Codex + Preview)
-
-on:
-  pull_request:
-    types: [opened, synchronize, reopened]
-
-jobs:
-  preview:
-    runs-on: ubuntu-latest
-    outputs:
-      preview_status: ${{ job.status }}
-    steps:
-      - uses: actions/checkout@v4
-      - run: ./gradlew :app:composePreviewRenderAll
-      - uses: actions/upload-artifact@v4
-        with:
-          name: compose-preview-images
-          path: app/build/compose-previews/renders
-      - uses: actions/upload-artifact@v4
-        with:
-          name: compose-preview-diff-images
-          path: app/build/compose-previews/diffs
-      - uses: actions/upload-artifact@v4
-        with:
-          name: compose-preview-metadata
-          path: app/build/compose-previews/**/*.json
-
-  codex-review:
-    needs: [preview]
-    uses: yschimke/compose-ai-tools/.github/workflows/codex-pr-review-reusable.yml@main
-    with:
-      preview_status: ${{ needs.preview.result }}
-      strict_mode: true
-    secrets:
-      codex_api_key: ${{ secrets.CODEX_API_KEY }}
-      claude_api_key: ${{ secrets.CLAUDE_API_KEY }}
-      gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
-      github_token: ${{ secrets.GITHUB_TOKEN }}
-```
-
-### Artifact contract
-
-- Agent selection is key-driven: set exactly one of `codex_api_key`, `claude_api_key`, or `gemini_api_key`.
-- Codex has a built-in default command. Claude/Gemini require `claude_review_command` / `gemini_review_command` inputs unless you wrap them in your own caller.
-- `compose-preview-images`: rendered head/PR preview images.
-- `compose-preview-diff-images`: visual diffs (baseline vs PR/head), if your preview pipeline generates them.
-- `compose-preview-baseline`: optional baseline images used to generate diffs.
-- `compose-preview-metadata`: preview index and mapping files (for example: preview id → file path/module).
-
-### Runtime/toolchain provided by reusable workflow
-
-- Java 21 (`actions/setup-java`, `JAVA_HOME` from the action).
-- Android SDK (`android-actions/setup-android`).
-- `compose-preview-review` skill installation from `yschimke/skills`.
-- Code diff capture (`git diff`) plus artifact download for visual review.
-
-### Failure modes / troubleshooting
-
-- **Preview failed/cancelled/skipped**: workflow posts a blocked comment and does not run Codex visual review.
-- **Artifacts missing**: workflow posts a blocked comment with “missing context” details.
-- **Strict mode enabled** + blocking findings: reusable workflow fails its check.
-- **PR branch update** (`update_pr_branch`, default `true`): workflow attempts to commit `.codex/review-output/{codex-review.md,codex-review.json}` to the PR branch; for fork PRs or restricted tokens it skips with a warning.
-- **No preview diffs available**: Codex still reviews code + available preview images and explicitly marks missing visual-diff context.
-
-### Optional integration patterns
-
-- `needs:` pattern (shown above): same workflow, same run.
-- `workflow_run` pattern: trigger a second workflow after preview workflow completion and pass `preview_status: success` plus artifact names into the reusable workflow call.
-
-### Example review comment template
-
-```md
-## Codex PR Review
-
-### Code findings
-- [blocking] `ui/ProfileCard.kt:84` Null-state branch removed; can crash in empty profile payload.
-- [warning] `ui/Theme.kt:42` Hard-coded color bypasses design token.
-
-### Preview findings
-- [blocking] `ProfileCard_Default.png` text overlaps avatar at 320dp width.
-- [warning] `SettingsScreen_Dark.png` contrast drop on secondary action.
-
-### Missing context / blocked checks
-- Baseline metadata for `WearSummaryPreview` missing.
-- Visual diff for `TabletLandscape` not present in uploaded artifacts.
-```
-
-### Validation recipe with intentional bad UI change
-
-1. Intentionally regress a composable (for example, shrink parent width and increase fixed text size to force clipping).
-2. Run your preview job to regenerate preview images and visual diffs.
-3. Open/update a PR and confirm:
-   - Preview job succeeds.
-   - Reusable Codex workflow runs after preview (`needs`/`workflow_run` gate).
-   - PR comment includes both code and preview findings.
-   - In strict mode, blocking visual regression findings fail the check.
+</content>

--- a/docs/PR_REVIEW_WORKFLOW.md
+++ b/docs/PR_REVIEW_WORKFLOW.md
@@ -1,0 +1,116 @@
+# Reusable PR review workflow (preview-gated)
+
+Use `.github/workflows/codex-pr-review-reusable.yml` to run AI PR review
+**only after** preview generation succeeds, and with both code + visual
+context. The reusable workflow supports Codex, Claude, or Gemini based on
+which API key is configured (exactly one).
+
+## Minimal caller setup
+
+This repository wires the reusable workflow in
+`.github/workflows/codex-pr-review.yml` using a `preview` job plus a thin
+`uses:` call to the reusable workflow.
+
+In this repository the unified `.github/workflows/compose-preview.yml` runs on
+every push to `main`, every PR, and `workflow_dispatch`. Consumer repos can
+split that into separate workflows (or keep one workflow per surface) based on
+their needs.
+
+```yaml
+name: PR Review (Codex + Preview)
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    outputs:
+      preview_status: ${{ job.status }}
+    steps:
+      - uses: actions/checkout@v4
+      - run: ./gradlew :app:composePreviewRenderAll
+      - uses: actions/upload-artifact@v4
+        with:
+          name: compose-preview-images
+          path: app/build/compose-previews/renders
+      - uses: actions/upload-artifact@v4
+        with:
+          name: compose-preview-diff-images
+          path: app/build/compose-previews/diffs
+      - uses: actions/upload-artifact@v4
+        with:
+          name: compose-preview-metadata
+          path: app/build/compose-previews/**/*.json
+
+  codex-review:
+    needs: [preview]
+    uses: yschimke/compose-ai-tools/.github/workflows/codex-pr-review-reusable.yml@main
+    with:
+      preview_status: ${{ needs.preview.result }}
+      strict_mode: true
+    secrets:
+      codex_api_key: ${{ secrets.CODEX_API_KEY }}
+      claude_api_key: ${{ secrets.CLAUDE_API_KEY }}
+      gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
+      github_token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+## Artifact contract
+
+- Agent selection is key-driven: set exactly one of `codex_api_key`, `claude_api_key`, or `gemini_api_key`.
+- Codex has a built-in default command. Claude/Gemini require `claude_review_command` / `gemini_review_command` inputs unless you wrap them in your own caller.
+- `compose-preview-images`: rendered head/PR preview images.
+- `compose-preview-diff-images`: visual diffs (baseline vs PR/head), if your preview pipeline generates them.
+- `compose-preview-baseline`: optional baseline images used to generate diffs.
+- `compose-preview-metadata`: preview index and mapping files (for example: preview id → file path/module).
+
+## Runtime / toolchain provided by reusable workflow
+
+- Java 21 (`actions/setup-java`, `JAVA_HOME` from the action).
+- Android SDK (`android-actions/setup-android`).
+- `compose-preview-review` skill installation from `yschimke/skills`.
+- Code diff capture (`git diff`) plus artifact download for visual review.
+
+## Failure modes / troubleshooting
+
+- **Preview failed/cancelled/skipped**: workflow posts a blocked comment and does not run Codex visual review.
+- **Artifacts missing**: workflow posts a blocked comment with “missing context” details.
+- **Strict mode enabled** + blocking findings: reusable workflow fails its check.
+- **PR branch update** (`update_pr_branch`, default `true`): workflow attempts to commit `.codex/review-output/{codex-review.md,codex-review.json}` to the PR branch; for fork PRs or restricted tokens it skips with a warning.
+- **No preview diffs available**: Codex still reviews code + available preview images and explicitly marks missing visual-diff context.
+
+## Optional integration patterns
+
+- `needs:` pattern (shown above): same workflow, same run.
+- `workflow_run` pattern: trigger a second workflow after preview workflow completion and pass `preview_status: success` plus artifact names into the reusable workflow call.
+
+## Example review comment template
+
+```md
+## Codex PR Review
+
+### Code findings
+- [blocking] `ui/ProfileCard.kt:84` Null-state branch removed; can crash in empty profile payload.
+- [warning] `ui/Theme.kt:42` Hard-coded color bypasses design token.
+
+### Preview findings
+- [blocking] `ProfileCard_Default.png` text overlaps avatar at 320dp width.
+- [warning] `SettingsScreen_Dark.png` contrast drop on secondary action.
+
+### Missing context / blocked checks
+- Baseline metadata for `WearSummaryPreview` missing.
+- Visual diff for `TabletLandscape` not present in uploaded artifacts.
+```
+
+## Validation recipe with intentional bad UI change
+
+1. Intentionally regress a composable (for example, shrink parent width and increase fixed text size to force clipping).
+2. Run your preview job to regenerate preview images and visual diffs.
+3. Open/update a PR and confirm:
+   - Preview job succeeds.
+   - Reusable Codex workflow runs after preview (`needs`/`workflow_run` gate).
+   - PR comment includes both code and preview findings.
+   - In strict mode, blocking visual regression findings fail the check.
+</content>

--- a/site/daemon.md
+++ b/site/daemon.md
@@ -16,7 +16,7 @@ interactive re-renders fast.
 A persistent preview server that replaces the per-save Gradle invocation with
 a long-lived JVM holding a hot Robolectric (Android) or Compose-Desktop
 renderer. A cold Gradle render is 10s+; a warm daemon render is a fraction of
-that. It's what the VS Code extension and the [MCP server](./mcp/) drive
+that. It's what the VS Code extension and the [MCP server](../mcp/) drive
 behind the scenes.
 
 It's configured with `composePreview.daemon { ... }` and defaults on for
@@ -31,7 +31,7 @@ server bring it up as needed.
   renders.
 - **`:daemon:desktop`** — Compose-Desktop backend; holds a warm render thread.
 - **`:mcp`** — multiplexes per-`(workspace, module)` daemons behind one MCP
-  surface (see [Agents & MCP](./mcp/)).
+  surface (see [Agents & MCP](../mcp/)).
 
 ## Going deeper
 

--- a/site/daemon.md
+++ b/site/daemon.md
@@ -1,0 +1,45 @@
+---
+title: Daemon
+layout: default
+nav_order: 5
+permalink: /daemon/
+---
+
+# Daemon
+
+The daemon is an optional speed-up. The Gradle `composePreviewRender` task is
+the canonical render path (and what CI uses); the daemon just makes
+interactive re-renders fast.
+
+## What it is
+
+A persistent preview server that replaces the per-save Gradle invocation with
+a long-lived JVM holding a hot Robolectric (Android) or Compose-Desktop
+renderer. A cold Gradle render is 10s+; a warm daemon render is a fraction of
+that. It's what the VS Code extension and the [MCP server](./mcp/) drive
+behind the scenes.
+
+It's configured with `composePreview.daemon { ... }` and defaults on for
+editor use. You don't start or manage it by hand — the extension and MCP
+server bring it up as needed.
+
+## What ships
+
+- **`:daemon:core`** — renderer-agnostic JSON-RPC server, protocol types,
+  preview index, classloader holder, classpath fingerprint, history manager.
+- **`:daemon:android`** — Robolectric backend; holds a sandbox open across
+  renders.
+- **`:daemon:desktop`** — Compose-Desktop backend; holds a warm render thread.
+- **`:mcp`** — multiplexes per-`(workspace, module)` daemons behind one MCP
+  surface (see [Agents & MCP](./mcp/)).
+
+## Going deeper
+
+The full design docs live in
+[`docs/daemon/`](https://github.com/yschimke/compose-ai-tools/tree/main/docs/daemon):
+
+- [`DESIGN.md`](https://github.com/yschimke/compose-ai-tools/blob/main/docs/daemon/DESIGN.md) — architecture, lifecycle, leak defense, decisions log.
+- [`PROTOCOL.md`](https://github.com/yschimke/compose-ai-tools/blob/main/docs/daemon/PROTOCOL.md) — the v1 client ↔ daemon wire format.
+- [`CONFIG.md`](https://github.com/yschimke/compose-ai-tools/blob/main/docs/daemon/CONFIG.md) — the `composePreview.daemon { … }` DSL.
+- [`MCP.md`](https://github.com/yschimke/compose-ai-tools/blob/main/docs/daemon/MCP.md) — daemon ↔ MCP mapping and tool surface.
+</content>

--- a/site/index.md
+++ b/site/index.md
@@ -2,61 +2,80 @@
 title: Home
 layout: default
 nav_order: 1
-description: "Render @Preview composables to PNG so AI coding agents can see what they're changing."
+description: "Render @Preview composables to PNG so AI coding agents (and you) can see what they're changing."
 permalink: /
 ---
 
 # compose-ai-tools
 
-Render `@Preview` composables to PNG outside Android Studio, so AI coding
-agents can see what they're changing. Works with Jetpack Compose
-(Android, via Robolectric) and Compose Multiplatform Desktop (via
-`ImageComposeScene`).
+**See your Compose UI without opening Android Studio.**
 
-Alongside each PNG the renderer can emit **structured data products** —
-ATF accessibility findings, layout-inspector trees, recomposition heat
-maps, resolved theme tokens, drawn text, and more — so an agent can
-reason about the UI, not just look at it.
+`compose-ai-tools` renders your `@Preview` composables to PNG from the
+command line — so your AI coding agent can actually *look* at the screen it
+just changed, and so can you. Works with Jetpack Compose (Android) and
+Compose Multiplatform Desktop.
 
-[Get started](#installation){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
+That's the whole idea. Everything else is optional.
+
+[Get started](#get-started){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
 [Reference](./reference/){: .btn .fs-5 .mb-4 .mb-md-0 .mr-2 }
 [GitHub](https://github.com/yschimke/compose-ai-tools){: .btn .fs-5 .mb-4 .mb-md-0 }
 
 ---
 
-## The agent loop
+## Get started
 
-A tight, token-frugal feedback loop over Compose UI — the way Playwright gave
-web agents one over the DOM. Exposed by the preview daemon's MCP server (and
-the `compose-preview` CLI where noted):
+Pick the one that fits you. Each is a single step.
 
-- **Target by semantic ref, not pixels** — drive a preview by `testTag` /
-  `role`+`text` / a stable node `ref`; the daemon resolves it to the node's
-  centre, so interactions survive layout changes (Android + Desktop).
-- **Token-frugal observation** — `render_preview observe=semantics|hash`
-  returns the semantics tree + hash + dimensions (a few hundred tokens)
-  instead of a base64 PNG; fetch pixels only when you need to look.
-- **Semantics diff** — `diff_semantics` / `compose-preview diff-semantics`
-  report what changed *semantically* between two renders, a deterministic
-  pixel-free regression signal (the aria-snapshot diff for Compose).
-- **Matrix render** — `render_matrix` (and the `compose-preview render-matrix`
-  CLI) covers `device × locale × uiMode × fontScale` in one call with per-cell
-  hashes, a "which changed" flag, and an optional stitched contact-sheet image.
-- **Recording → test** — `record_preview emitTest=true` emits a runnable
-  Compose UI test from a scripted interaction, inferring assertions at each
-  `recording.probe` from the captured semantics.
-- **Structured failures** — a failed render reports a typed kind + a one-line
-  fix hint instead of an opaque message.
+### 🤖 With an AI coding agent
+
+Run the one-line installer once. It drops the `compose-preview` CLI **and**
+the agent skill into place (Claude Code, Codex, Gemini):
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/yschimke/skills/main/scripts/install.sh | bash
+```
+
+Then just ask your agent to preview a composable. The
+[`compose-preview` skill](https://github.com/yschimke/skills/tree/main/skills/compose-preview)
+is the playbook — it tells the agent how to render, iterate, and check its
+own work. You don't have to learn the commands; the agent reads the skill.
+
+> Already have an agent that fetches URLs but can't run the installer? Point
+> it straight at the
+> [skill](https://github.com/yschimke/skills/blob/main/skills/compose-preview/SKILL.md)
+> — it's self-contained and will bootstrap the CLI itself.
+
+### 🧩 In VS Code (or Cursor / Windsurf / VSCodium)
+
+Open the Extensions view (⇧⌘X / Ctrl+Shift+X), search **Compose Preview**,
+click *Install*. That's it — it renders previews inline and needs no project
+changes.
+
+[Marketplace](https://marketplace.visualstudio.com/items?itemName=yuri-schimke.compose-preview) ·
+[Open VSX](https://open-vsx.org/extension/yuri-schimke/compose-preview)
+
+### ⌨️ From the command line
+
+Install the CLI (same one-liner as above), then point it at any Compose
+project — no build edits required:
+
+```sh
+compose-preview render    # render every @Preview to PNG
+```
+
+The CLI injects itself into your build at runtime, so projects that already
+use `com.android.application` / `com.android.library` /
+`org.jetbrains.compose` just work. Full options on the
+[Install page](./install/).
 
 ---
 
-## Installation
+## Want a version-pinned Gradle plugin instead?
 
-### Gradle plugin
-
-The plugin is published to
+If you'd rather wire it into your build explicitly, the plugin is on
 [Maven Central](https://central.sonatype.com/artifact/ee.schimke.composeai/compose-preview-plugin)
-— no auth, no PAT.
+— no auth, no token:
 
 <!-- x-release-please-start-version -->
 ```kotlin
@@ -67,54 +86,34 @@ plugins {
 ```
 <!-- x-release-please-end -->
 
-Then:
-
 ```sh
-./gradlew :app:composePreviewDiscover    # scan @Preview annotations
 ./gradlew :app:composePreviewRenderAll   # render every @Preview to PNG
 ```
 
-Requires Java 17+, Gradle 8.13+, AGP 8.13.0+ (Android), Kotlin 2.0.21+,
-Compose Multiplatform 1.10.3+ (Desktop).
-
-### VS Code extension
-
-Published to the
-[VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=yuri-schimke.compose-preview)
-and [Open VSX](https://open-vsx.org/extension/yuri-schimke/compose-preview)
-(for VSCodium / Cursor / Windsurf).
-
-Install from inside the IDE: open the Extensions view (⇧⌘X /
-Ctrl+Shift+X), search **Compose Preview**, click *Install*.
-
-### CLI
-
-Install on `$PATH` for shell or agent use via the bootstrap script:
-
-```sh
-curl -fsSL https://raw.githubusercontent.com/yschimke/skills/main/scripts/install.sh | bash
-```
-
-### Agent skill
-
-Point any agent that can fetch a URL at
-[`skills/compose-preview/SKILL.md`](https://github.com/yschimke/skills/blob/main/skills/compose-preview/SKILL.md)
-— the skill is a complete install-and-iterate playbook.
-
-### CI / GitHub Actions
-
-Composite actions for CI pipelines:
-
-- [`install`](https://github.com/yschimke/compose-ai-tools/tree/main/.github/actions/install) — pin the CLI on `$PATH`.
-- [`apply`](https://github.com/yschimke/compose-ai-tools/tree/main/.github/actions/apply) — unified pipeline: baselines on push, before/after PR comments, a11y + notification surfaces.
+Requirements and CI recipes live on the [Install page](./install/).
 
 ---
 
-## Where next?
+## Going further
 
-- **[Reference](./reference/)** — one page per data product (a11y,
-  layout, theme, recomposition, scroll captures, …): what it is, what
-  it answers, and how to enable it.
+Once you're rendering PNGs, there's more your agent can do — but none of it
+is required to get value from the tool.
+
+- **[Data products](./reference/)** — alongside each PNG the renderer can
+  emit structured data: accessibility findings, layout trees, theme tokens,
+  recomposition heat maps, drawn text, and more. One page per product.
+- **[MCP server](./mcp/)** — a push-based, token-frugal agent loop over
+  Compose UI (target by semantic ref, observe semantics instead of pixels,
+  diff renders, generate tests). The aria-snapshot story for Compose.
+- **[Daemon](./daemon/)** — a long-lived renderer that keeps Robolectric /
+  Compose-Desktop warm so re-renders are fast.
+
+---
+
+## More
+
 - **[How it works](https://github.com/yschimke/compose-ai-tools/blob/main/docs/HOW_IT_WORKS.md)** — discovery, renderer pipeline, caching.
 - **[Samples](https://github.com/yschimke/compose-ai-tools/tree/compose-preview/main)** — rendered baselines for `samples:android`, `samples:wear`, `samples:cmp`, `samples:remotecompose`, regenerated on every push to `main`.
 - **[Releases](https://github.com/yschimke/compose-ai-tools/releases)** · **[Changelog](https://github.com/yschimke/compose-ai-tools/blob/main/CHANGELOG.md)** · **[License](https://github.com/yschimke/compose-ai-tools/blob/main/LICENSE)** (Apache 2.0).
+</content>
+</invoke>

--- a/site/install.md
+++ b/site/install.md
@@ -1,0 +1,120 @@
+---
+title: Install
+layout: default
+nav_order: 2
+permalink: /install/
+---
+
+# Install
+
+Most people don't need this page — the [home page](./) covers the one-step
+paths for agents, VS Code, and the CLI. This page is the full reference:
+every install surface, requirements, and CI recipes.
+
+## CLI
+
+The `compose-preview` binary works against any Compose project with **no
+build edits** — it injects the preview plugin at runtime via a bundled
+Gradle init script.
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/yschimke/skills/main/scripts/install.sh | bash
+```
+
+The installer drops the CLI on your `$PATH` and (unless you pass
+`--cli-only`) the `compose-preview` / `compose-preview-review` agent skills
+into the Claude / Codex / Gemini skill directories. Useful flags:
+
+| Flag | Effect |
+|------|--------|
+| `--cli-only` | Install the CLI only, skip the skill bundles. |
+| `--android-sdk` | Also install the Android `cmdline-tools` + platform + build-tools. |
+| `--jdk 17,21` | Install the listed JDK majors. |
+| `VERSION` | Install a specific release instead of latest. |
+
+Then:
+
+```sh
+compose-preview doctor    # check Java + project compatibility
+compose-preview list      # scan @Preview annotations
+compose-preview render    # render every @Preview to PNG
+compose-preview render-matrix --id com.example.MyPreview \
+    --ui-mode light,dark --font-scale 1.0,2.0   # one preview across a grid
+```
+
+Because the CLI auto-injects, projects that already apply
+`com.android.application` / `com.android.library` / `org.jetbrains.compose`
+work without touching `build.gradle.kts`. Projects that already declare the
+plugin are detected and left alone, so mixed setups don't conflict.
+
+## Gradle plugin (version-pinned)
+
+If you'd rather wire it into your build explicitly, the plugin is published
+to [Maven Central](https://central.sonatype.com/artifact/ee.schimke.composeai/compose-preview-plugin)
+— no auth, no PAT.
+
+```kotlin
+// <module>/build.gradle.kts
+plugins {
+    id("ee.schimke.composeai.preview") version "<latest>"
+}
+```
+
+Pin the version shown on Maven Central. (The in-repo `samples/` apply it
+*without* a version because they resolve it from this repository's own
+included build — that's not drop-in for an external project.)
+
+```sh
+./gradlew :app:composePreviewDiscover    # scan @Preview annotations
+./gradlew :app:composePreviewRenderAll   # render every @Preview to PNG
+```
+
+For direct `./gradlew` use with the auto-inject script (e.g. a CI step that
+needs extra Gradle flags), materialise the init script once and thread its
+path through each invocation:
+
+```sh
+INIT_SCRIPT="$(compose-preview init-script --path)"
+./gradlew --init-script "$INIT_SCRIPT" :app:composePreviewRenderAll
+```
+
+## VS Code extension
+
+Published to the
+[VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=yuri-schimke.compose-preview)
+and [Open VSX](https://open-vsx.org/extension/yuri-schimke/compose-preview)
+(VSCodium / Cursor / Windsurf). Open the Extensions view (⇧⌘X /
+Ctrl+Shift+X), search **Compose Preview**, click *Install*. It auto-injects
+on every Gradle invocation it makes — no project changes needed.
+
+## Agent skill
+
+Point any agent that can fetch a URL at the
+[`compose-preview` skill](https://github.com/yschimke/skills/blob/main/skills/compose-preview/SKILL.md)
+— a complete install-and-iterate playbook. The skill checks whether the CLI
+is present and bootstraps it (via the installer above) if not, so "point the
+agent at the skill" and "run the installer" converge on the same place. See
+[Agents & MCP](./mcp/) for the agent loop the skill drives.
+
+## CI / GitHub Actions
+
+Composite actions for pipelines:
+
+- [`install`](https://github.com/yschimke/compose-ai-tools/tree/main/.github/actions/install) — pin the CLI on `$PATH`, with version-catalog + Renovate recipes.
+- [`apply`](https://github.com/yschimke/compose-ai-tools/tree/main/.github/actions/apply) — unified pipeline: baselines on push, before/after PR comments, a11y + notification surfaces.
+
+There's also a reusable, preview-gated AI PR-review workflow (Codex / Claude
+/ Gemini): see
+[PR review workflow](https://github.com/yschimke/compose-ai-tools/blob/main/docs/PR_REVIEW_WORKFLOW.md).
+
+## Requirements
+
+Java 17+, Gradle 8.13+, AGP 8.13.0+ (Android), Kotlin 2.0.21+, Compose
+Multiplatform 1.10.3+ (Desktop). The bottom edge of this envelope is
+exercised on every push by the
+[`agp8-min` job](https://github.com/yschimke/compose-ai-tools/blob/main/.github/workflows/integration.yml).
+
+Running an agent in a cloud sandbox (Claude Code on the web, etc.)? See the
+[cloud sandbox setup](https://github.com/yschimke/skills/blob/main/skills/compose-preview/references/agent-cloud.md)
+for the network allowlist and `install.sh --android-sdk` Setup recipe.
+</content>

--- a/site/install.md
+++ b/site/install.md
@@ -94,7 +94,7 @@ Point any agent that can fetch a URL at the
 — a complete install-and-iterate playbook. The skill checks whether the CLI
 is present and bootstraps it (via the installer above) if not, so "point the
 agent at the skill" and "run the installer" converge on the same place. See
-[Agents & MCP](./mcp/) for the agent loop the skill drives.
+[Agents & MCP](../mcp/) for the agent loop the skill drives.
 
 ## CI / GitHub Actions
 

--- a/site/mcp.md
+++ b/site/mcp.md
@@ -73,7 +73,7 @@ For the full tool surface, URI scheme, and wire protocol see
 Point the agent at the
 [`compose-preview` skill](https://github.com/yschimke/skills/tree/main/skills/compose-preview).
 It's the install-and-iterate playbook: it checks for the CLI, bootstraps it
-via the [installer](./install/) if missing, and walks the agent through
+via the [installer](../install/) if missing, and walks the agent through
 rendering and verifying. The skill and the installer aren't alternatives —
 the installer is just the one command the skill runs to get the CLI in place.
 </content>

--- a/site/mcp.md
+++ b/site/mcp.md
@@ -1,0 +1,79 @@
+---
+title: Agents & MCP
+layout: default
+nav_order: 4
+permalink: /mcp/
+---
+
+# Agents & MCP
+
+You don't need any of this to use compose-ai-tools — rendering `@Preview`s to
+PNG already lets an agent see its work. This page is for when you want a
+tighter, push-based loop than "run a command, read a file."
+
+## The agent loop
+
+A token-frugal feedback loop over Compose UI — the way
+[Playwright](https://playwright.dev) gave web agents one over the DOM: act by
+a stable reference, observe structure rather than pixels, and turn
+exploration into durable tests. These are exposed by the preview daemon's MCP
+server (and the `compose-preview` CLI where noted).
+
+- **Target by semantic ref, not pixels.** `interactive/input` and
+  `record_preview` accept a `target` (`testTag` / `role`+`text` / a stable
+  node `ref`) that the daemon resolves to the node's centre, so a click
+  survives layout changes instead of breaking on a coordinate. Android
+  (Robolectric) and Desktop (Skiko).
+- **Token-frugal observation.** `render_preview observe=semantics|hash`
+  returns the `compose/semantics` tree + a hash + dimensions instead of a
+  base64 PNG — typically a few hundred tokens versus ~1.5k. Fetch pixels only
+  when you actually need to look.
+- **Semantics diff.** `diff_semantics` (MCP) and `compose-preview
+  diff-semantics` (CLI) diff two semantics trees and report what changed
+  *semantically* (text, label, role, testTag, overflow…), matched by stable
+  ref — a deterministic, pixel-free regression signal, the Compose analogue
+  of Playwright's aria-snapshot diff.
+- **Matrix render.** `render_matrix` (and `compose-preview render-matrix`)
+  renders one preview across a cross-product of
+  `device × locale × uiMode × fontScale` in a single call, returning a
+  per-cell hash and which cells changed — "does this survive small screen +
+  RTL + large font?" without N screenshots. Opt into a stitched contact-sheet
+  image when you want to eyeball every cell at once.
+- **Recording → test.** `record_preview emitTest=true` turns a scripted
+  interaction into a runnable Compose UI test (semantic targets become
+  `onNodeWithTag(...).performClick()` steps; each `recording.probe` is diffed
+  against the previous probe's captured semantics into `assertExists()` /
+  `assertDoesNotExist()` assertions).
+- **Structured failures.** A failed render reports a typed `kind` plus a
+  one-line fix hint for recognized signatures (classpath skew, Robolectric
+  SDK mismatch, missing `@Composable`, …) instead of an opaque message.
+
+Cost budget for these in
+[`docs/TOKEN_USAGE.md`](https://github.com/yschimke/compose-ai-tools/blob/main/docs/TOKEN_USAGE.md).
+
+## The MCP server
+
+The `:mcp` module exposes the preview daemon's JSON-RPC over stdio, so
+MCP-aware agents can render previews on demand and be *notified* when bytes
+change — instead of running Gradle (10s+ cold) or polling PNGs off disk with
+no way to request a re-render.
+
+Each `@Preview` becomes one MCP `Resource` under a stable
+`compose-preview://<workspaceId>/<module>/<previewFqn>` URI. The server
+supports `subscribe` (per-resource update notifications) and `listChanged`
+(the set of resources mutated), plus `notifications/progress` for
+long-running calls. Data products are read via `list_data_products`,
+`subscribe_preview_data`, and `get_preview_data`.
+
+For the full tool surface, URI scheme, and wire protocol see
+[`docs/daemon/MCP.md`](https://github.com/yschimke/compose-ai-tools/blob/main/docs/daemon/MCP.md).
+
+## What we tell agents
+
+Point the agent at the
+[`compose-preview` skill](https://github.com/yschimke/skills/tree/main/skills/compose-preview).
+It's the install-and-iterate playbook: it checks for the CLI, bootstraps it
+via the [installer](./install/) if missing, and walks the agent through
+rendering and verifying. The skill and the installer aren't alternatives —
+the installer is just the one command the skill runs to get the CLI in place.
+</content>

--- a/site/reference/index.md
+++ b/site/reference/index.md
@@ -1,7 +1,7 @@
 ---
 title: Reference
 layout: default
-nav_order: 2
+nav_order: 3
 has_children: true
 permalink: /reference/
 ---


### PR DESCRIPTION
## Summary

Make the README and docs homepage non-scary and genuinely simple — one idea up front, one step per audience to get started — and move the advanced surfaces off the front page.

- **Lead with the single idea**: render `@Preview` to PNG so AI agents (and you) can see the UI they changed.
- **Get started = one step per audience** (AI agent / VS Code / CLI). No numbered multi-step gauntlet.
- **Pushed to secondary pages:**
  - `site/install.md` — full install reference (CLI flags, version-pinned Gradle plugin, VS Code, CI, requirements).
  - `site/mcp.md` (*Agents & MCP*) — the agent-loop + MCP-server detail moved here.
  - `site/daemon.md` — daemon overview, links into `docs/daemon/`.
  - `docs/PR_REVIEW_WORKFLOW.md` — the reusable Codex/Claude/Gemini PR-review YAML moved out of the README.
- Nav order: Home → Install → Reference → Agents & MCP → Daemon. The release-please version marker in `site/index.md` is preserved.

**Agent guidance** (the open question this resolves): point agents at the `compose-preview` skill — it's the playbook. `install.sh` isn't an alternative; it's the one-liner the skill runs to put the CLI + skill bundles in place.

## Test plan

- [ ] Docs-only change — no code paths touched.
- [ ] Verify the Jekyll site builds and nav renders in order (Home, Install, Reference, Agents & MCP, Daemon).
- [ ] Confirm internal links resolve (Install / MCP / Daemon / reference / PR_REVIEW_WORKFLOW).
- [ ] Confirm the `x-release-please-start-version` block in `site/index.md` still matches the manifest so release automation keeps working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8zmdNetKy9Vfjer3VWst7)_