### PR TITLE
feat: A/B compare nominated preview variants side-by-side in CI

### DIFF
--- a/.github/actions/apply/README.md
+++ b/.github/actions/apply/README.md
@@ -103,6 +103,63 @@ with no plugin pinned in their build — are never tripped.
 | `source` | Build from the current checkout — internal CI only. |
 | `none` | Skip CLI install (pair with `skip-render: true` for non-Gradle build systems). |
 
+## A/B comparison of preview variants
+
+By default the comment and gallery show one "hero" render per function and
+collapse its other variants into "Other variants" links — a vertical, one-at-a-time
+read. When you want to compare two specific variants of the *same* function
+directly (an A/B test of a design or copy change), nominate them in a config
+file and they render **side-by-side horizontally** instead.
+
+The two variants can come from either source the discovery layer already
+distinguishes by a preview-id suffix:
+
+- **Two `@Preview` annotations** on one composable (including ones contributed
+  by a multi-preview meta-annotation), differentiated by `@Preview(name = …)`:
+
+  ```kotlin
+  @Preview(name = "Control")
+  @Preview(name = "Treatment")
+  @Composable fun ButtonPreview() { … }
+  ```
+
+- **Two values of a `@PreviewParameter`** provider (matched by the
+  `_PARAM_<index>` suffix).
+
+### Config file
+
+Drop a JSON file at `.github/preview-abtest.json` (override the path with the
+`ab-config` input). It's read by the compare (PR comment) and generate
+(baseline gallery) steps; a missing / malformed file is a no-op, so the
+feature is purely additive.
+
+```json
+{
+  "groups": [
+    {
+      "function": "ButtonPreview",
+      "module": "app",
+      "variants": ["Control", "Treatment"],
+      "label": "Button copy"
+    }
+  ]
+}
+```
+
+| Field | Required | Meaning |
+|---|---|---|
+| `function` | yes | Composable function name (not the FQN). |
+| `variants` | yes | ≥ 2 variant tokens — each the preview-id suffix (`@Preview` name, group, or `PARAM_<n>`). Columns render in this order. |
+| `module` | no | Restrict the match to one module; any module when omitted. |
+| `label` | no | Heading shown above the side-by-side table. |
+
+In the PR comment the group renders as a single table — variant tokens as
+columns, `Before` / `After` as rows — so the variants sit next to each other.
+A group is only surfaced when at least one of its variants actually changed
+(or is new), so unchanged A/B groups don't post a comment on no-op PRs. The
+non-nominated variants of the same function keep the historical "Other
+variants" treatment.
+
 ## Related actions
 
 - [`install`](../install/) — just put the CLI on `$PATH`, no pipelines.

--- a/.github/actions/apply/action.yml
+++ b/.github/actions/apply/action.yml
@@ -111,6 +111,16 @@ inputs:
       Override the event-based mode selector: `auto` (default), `baseline`,
       `comment`, or `skip`.
     default: 'auto'
+  ab-config:
+    description: >
+      Path (relative to the checkout) to the A/B comparison config JSON. When
+      the file exists, preview variants it nominates — two `@Preview`
+      annotations of one function (including multi-preview members) or two
+      values of a `@PreviewParameter` — render side-by-side horizontally in
+      the PR comment and baseline gallery instead of the default hero +
+      "Other variants" links. Absent file = feature off (purely additive).
+      See `.github/actions/apply/README.md` for the schema.
+    default: '.github/preview-abtest.json'
   skip-render:
     description: >
       When `true`, the compose and resources pipelines reuse pre-staged
@@ -317,6 +327,7 @@ runs:
         WANT_A11Y: ${{ steps.resolve.outputs.a11y }}
         WANT_NOTIFICATIONS: ${{ steps.resolve.outputs.notifications }}
         SKIP_RENDER: ${{ inputs.skip-render }}
+        AB_CONFIG: ${{ inputs.ab-config }}
       run: |
         set +e
         export PR_NUMBER="${PR_INPUT_NUMBER:-$EVENT_PR_NUMBER}"
@@ -471,6 +482,7 @@ runs:
         REPO: ${{ github.repository }}
         PR_HEAD_BRANCH: 'compose-preview/pr'
         RESOURCE_HEAD_BRANCH: 'compose-preview/resources/pr'
+        AB_CONFIG: ${{ inputs.ab-config }}
       run: |
         set -euo pipefail
         # Compose comment is only meaningful when the compose pipeline
@@ -484,12 +496,21 @@ runs:
         HEAD_REF=$(cat _head_sha 2>/dev/null || echo "")
         [ -z "$HEAD_REF" ] && HEAD_REF="$PR_HEAD_BRANCH"
 
+        # A/B comparison config (default `.github/preview-abtest.json`). Pass
+        # it through only when the file exists so the compare step degrades to
+        # the historical layout for projects that don't opt in.
+        AB_ARGS=()
+        if [ -n "${AB_CONFIG:-}" ] && [ -f "$AB_CONFIG" ]; then
+          AB_ARGS=(--ab-config "$AB_CONFIG")
+        fi
+
         python3 "$ACTION_PATH/../lib/compare-previews.py" compare _previews.json \
           --baselines _baselines/baselines.json \
           --baseline-renders _baselines/renders \
           --repo "$REPO" \
           --base-ref "$BASE_REF" \
           --head-ref "$HEAD_REF" \
+          "${AB_ARGS[@]}" \
           > _comment_body.md
 
     # Sibling step for the resources comment — separately gated on

--- a/.github/actions/apply/pipelines/compose.sh
+++ b/.github/actions/apply/pipelines/compose.sh
@@ -76,6 +76,17 @@ fi
 
 set -e
 
+# Optional A/B comparison config. When present (default
+# `.github/preview-abtest.json`, overridable via the action's `ab-config`
+# input → AB_CONFIG env), nominated variant groups render side-by-side in the
+# gallery / PR comment. Absent file = no A/B groups, purely additive.
+AB_CONFIG="${AB_CONFIG:-.github/preview-abtest.json}"
+AB_ARGS=()
+if [ -n "$AB_CONFIG" ] && [ -f "$AB_CONFIG" ]; then
+  AB_ARGS=(--ab-config "$AB_CONFIG")
+  echo "compose pipeline: A/B comparison config found at $AB_CONFIG."
+fi
+
 if [ "$MODE" = "baseline" ]; then
   # Fetch prior baselines so per-preview flakes don't drop entries.
   mkdir -p _prior_baselines
@@ -95,7 +106,8 @@ if [ "$MODE" = "baseline" ]; then
     --repo "$REPO" \
     --branch "$BASELINE_BRANCH" \
     --prior-baselines _prior_baselines/baselines.json \
-    --prior-renders _prior_baselines/renders
+    --prior-renders _prior_baselines/renders \
+    "${AB_ARGS[@]}"
 
   # Stage the push commit MSG into the staging dir for the post-wait step.
   echo "Update preview baselines from ${GITHUB_SHA::8}" > _baselines/_push_msg

--- a/.github/actions/lib/compare-previews.py
+++ b/.github/actions/lib/compare-previews.py
@@ -809,8 +809,18 @@ def _emit_ab_comparisons(
                 before_cells.append(f'<img src="{url}" width="200" />')
             lines.append("| Before | " + " | ".join(before_cells) + " |")
         after_cells = []
-        for _token, _key, info, _changed, _bl in rows:
-            url = _render_url(repo, head_ref, g["module"], info["renderBasename"])
+        for _token, _key, info, changed, bl in rows:
+            if changed or bl is None:
+                # Changed / new variants are staged to the head renders branch
+                # by `copy-changed`, so the PR ref has their PNG.
+                url = _render_url(repo, head_ref, g["module"], info["renderBasename"])
+            else:
+                # Unchanged companion: `copy-changed` only stages new/changed
+                # PNGs, so this render was never pushed to the head ref. Its
+                # "After" pixels are byte-identical to the baseline, so point at
+                # the baseline ref to avoid a broken-image cell.
+                basename = bl.get("renderBasename") or info["renderBasename"]
+                url = _render_url(repo, base_ref, g["module"], basename)
             after_cells.append(f'<img src="{url}" width="200" />')
         lines.append("| After | " + " | ".join(after_cells) + " |")
         lines.append("")

--- a/.github/actions/lib/compare-previews.py
+++ b/.github/actions/lib/compare-previews.py
@@ -390,6 +390,9 @@ def cmd_generate(args: argparse.Namespace) -> int:
     prior_renders = (
         Path(args.prior_renders) if getattr(args, "prior_renders", None) else None
     )
+    ab_config = ABTestConfig.load(
+        Path(args.ab_config) if getattr(args, "ab_config", None) else None
+    )
 
     previews = load_cli_output(cli_json)
     if not previews:
@@ -520,17 +523,45 @@ def cmd_generate(args: argparse.Namespace) -> int:
     for module, entries in sorted(by_module.items()):
         lines.append(f"## {module}")
         lines.append("")
-        lines.append("| Preview | Image |")
-        lines.append("|---------|-------|")
-        for _, info in entries:
-            label_suffix = f" · {info['captureLabel']}" if info["captureLabel"] else ""
-            fn = f"{info['functionName']}{label_suffix}"
-            img_path = f"renders/{info['module']}/{info['renderBasename']}"
-            raw_url = f"https://raw.githubusercontent.com/{repo}/{branch}/{img_path}"
-            lines.append(
-                f"| `{fn}` | <img src=\"{raw_url}\" width=\"150\" /> |"
-            )
-        lines.append("")
+
+        # A/B groups render side-by-side at the top of the module section;
+        # their member rows are then skipped from the standard per-preview
+        # table below so they aren't listed twice.
+        ab_groups, promoted = (
+            _ab_groups_in_gallery(ab_config, module, entries)
+            if ab_config
+            else ([], set())
+        )
+        for g in ab_groups:
+            if g["label"]:
+                lines.append(f"### A/B: {g['label']} (`{g['fn']}`)")
+            else:
+                lines.append(f"### A/B: `{g['fn']}`")
+            lines.append("")
+            tokens = [token for token, _k, _i in g["rows"]]
+            lines.append("| " + " | ".join(tokens) + " |")
+            lines.append("|" + "---|" * len(tokens))
+            cells = []
+            for _token, _key, info in g["rows"]:
+                img_path = f"renders/{info['module']}/{info['renderBasename']}"
+                raw_url = f"https://raw.githubusercontent.com/{repo}/{branch}/{img_path}"
+                cells.append(f'<img src="{raw_url}" width="200" />')
+            lines.append("| " + " | ".join(cells) + " |")
+            lines.append("")
+
+        standard = [(key, info) for key, info in entries if key not in promoted]
+        if standard:
+            lines.append("| Preview | Image |")
+            lines.append("|---------|-------|")
+            for _key, info in standard:
+                label_suffix = f" · {info['captureLabel']}" if info["captureLabel"] else ""
+                fn = f"{info['functionName']}{label_suffix}"
+                img_path = f"renders/{info['module']}/{info['renderBasename']}"
+                raw_url = f"https://raw.githubusercontent.com/{repo}/{branch}/{img_path}"
+                lines.append(
+                    f"| `{fn}` | <img src=\"{raw_url}\" width=\"150\" /> |"
+                )
+            lines.append("")
 
     (out_dir / "README.md").write_text("\n".join(lines) + "\n")
 
@@ -576,6 +607,221 @@ def _render_url(repo: str, ref: str, module: str, basename: str) -> str:
     )
 
 
+# ---------------------------------------------------------------------------
+# A/B comparison config
+#
+# Lets a project nominate specific preview *variants* of a single function for
+# a side-by-side horizontal comparison instead of the default
+# hero-plus-"Other variants"-links treatment. The variants can come from two
+# `@Preview` annotations (including ones contributed by a multi-preview
+# meta-annotation) or from distinct values of a `@PreviewParameter` provider —
+# in every case the discovery layer encodes the distinguishing token as the
+# preview id's suffix, which is what we match on here.
+# ---------------------------------------------------------------------------
+
+def _row_matches_variant(info: dict, token: str) -> bool:
+    """Whether a loaded CLI row belongs to the A/B variant named ``token``.
+
+    The token is matched against the preview id's variant suffix (the part
+    after the last underscore — e.g. ``Control`` in
+    ``…ButtonPreviewKt.ButtonPreview_Control``), with two looser fallbacks so
+    multi-segment suffixes (``…_PARAM_0``) and exact-id configs still resolve:
+    a trailing ``_<token>`` match and a whole-id match.
+    """
+    pid = info.get("previewId", "")
+    if _variant_label(pid) == token:
+        return True
+    if pid == token:
+        return True
+    return pid.endswith(f"_{token}")
+
+
+class ABTestConfig:
+    """A/B comparison groups loaded from a project's JSON config file.
+
+    Default location ``.github/preview-abtest.json`` (overridable via the
+    action's ``ab-config`` input). Schema::
+
+        {
+          "groups": [
+            {
+              "function": "ButtonPreview",
+              "module": "app",                       # optional; any module if omitted
+              "variants": ["Control", "Treatment"],  # >= 2 variant tokens
+              "label": "Button copy"                 # optional heading
+            }
+          ]
+        }
+
+    A discovered preview row matches a group when its ``functionName`` equals
+    ``function`` (and ``module`` matches, when the group pins one) and its
+    variant suffix is one of ``variants``. Matched variants get promoted to a
+    side-by-side horizontal layout in the PR comment and the baseline gallery
+    instead of being stacked / collapsed into "Other variants" links.
+
+    Missing / empty / malformed config is treated as "no A/B groups" — the
+    feature is strictly additive, so a broken file degrades to the historical
+    behaviour rather than failing the run.
+    """
+
+    def __init__(self, groups: list[dict]):
+        self._groups = groups
+
+    @classmethod
+    def load(cls, path: Path | None) -> "ABTestConfig":
+        if path is None or not path.exists():
+            return cls([])
+        try:
+            text = path.read_text()
+        except OSError:
+            return cls([])
+        if not text.strip():
+            return cls([])
+        try:
+            raw = json.loads(text)
+        except json.JSONDecodeError:
+            return cls([])
+        if not isinstance(raw, dict):
+            return cls([])
+        groups: list[dict] = []
+        for g in raw.get("groups", []) or []:
+            if not isinstance(g, dict):
+                continue
+            fn = g.get("function")
+            variants = g.get("variants")
+            # A group needs a target function and at least two variants to
+            # compare; anything else is silently dropped.
+            if not fn or not isinstance(variants, list) or len(variants) < 2:
+                continue
+            groups.append({
+                "function": fn,
+                "module": g.get("module"),
+                "variants": [str(v) for v in variants],
+                "label": g.get("label"),
+            })
+        return cls(groups)
+
+    def __bool__(self) -> bool:
+        return bool(self._groups)
+
+    def match(self, module: str, function_name: str) -> dict | None:
+        """First group matching ``function_name`` (and ``module`` if pinned)."""
+        for g in self._groups:
+            if g["function"] != function_name:
+                continue
+            if g["module"] is not None and g["module"] != module:
+                continue
+            return g
+        return None
+
+
+def _ab_resolve_rows(
+    group: dict, module: str, fn: str, rows: dict
+) -> list[tuple[str, str, dict]]:
+    """Resolve a group's variant tokens to concrete rendered rows, in config order.
+
+    ``rows`` is a ``key -> info`` map (the loaded CLI output or a baseline set).
+    Only rows in ``module`` / ``fn`` that produced a PNG are considered. Returns
+    ``[(token, key, info), …]`` for the tokens that resolved — order follows
+    the config so the side-by-side columns read A, B, C as authored.
+    """
+    candidates = [
+        (key, info)
+        for key, info in sorted(rows.items())
+        if info.get("module") == module
+        and info.get("functionName") == fn
+        and info.get("sha256")
+    ]
+    resolved: list[tuple[str, str, dict]] = []
+    for token in group["variants"]:
+        for key, info in candidates:
+            if _row_matches_variant(info, token):
+                resolved.append((token, key, info))
+                break
+    return resolved
+
+
+def _ab_groups_in_gallery(
+    ab_config: "ABTestConfig", module: str, entries: list[tuple[str, dict]]
+) -> tuple[list[dict], set[str]]:
+    """Find A/B groups among a module's gallery entries.
+
+    ``entries`` is the ``[(key, info), …]`` list the generate gallery builds
+    per module. Returns ``(groups, promoted_keys)`` where each group is
+    ``{label, fn, rows:[(token, key, info), …]}`` and ``promoted_keys`` are the
+    row keys that should be skipped from the standard per-preview table.
+    """
+    rows_map = {key: info for key, info in entries}
+    groups: list[dict] = []
+    promoted: set[str] = set()
+    seen: set[str] = set()
+    for _key, info in entries:
+        fn = info["functionName"]
+        if fn in seen:
+            continue
+        group = ab_config.match(module, fn)
+        if group is None:
+            continue
+        resolved = _ab_resolve_rows(group, module, fn, rows_map)
+        if len(resolved) < 2:
+            continue
+        seen.add(fn)
+        for _token, rkey, _rinfo in resolved:
+            promoted.add(rkey)
+        groups.append({"label": group.get("label"), "fn": fn, "rows": resolved})
+    return groups, promoted
+
+
+def _emit_ab_comparisons(
+    lines: list[str],
+    ab_groups: list[dict],
+    repo: str,
+    base_ref: str,
+    head_ref: str,
+) -> None:
+    """Append the side-by-side A/B section to ``lines`` (in place).
+
+    One table per group: variant tokens are the columns, and the rows are the
+    baseline (``Before``) and PR (``After``) renders so the variants sit next
+    to each other horizontally for direct comparison. The ``Before`` row is
+    omitted entirely when no variant has a baseline (a brand-new A/B group).
+    """
+    lines.append(f"### A/B Comparisons ({len(ab_groups)} group(s))")
+    lines.append("")
+    for g in ab_groups:
+        rows = g["rows"]
+        if g["label"]:
+            lines.append(f"**{g['label']}** — `{g['fn']}` ({g['module']})")
+        else:
+            lines.append(f"**`{g['fn']}`** ({g['module']})")
+        lines.append("")
+        tokens = [token for token, _k, _i, _c, _b in rows]
+        lines.append("| | " + " | ".join(tokens) + " |")
+        lines.append("|" + "---|" * (len(tokens) + 1))
+        if any(bl is not None for _t, _k, _i, _c, bl in rows):
+            before_cells = []
+            for token, _key, info, _changed, bl in rows:
+                if bl is None:
+                    before_cells.append("_new_")
+                    continue
+                basename = bl.get("renderBasename") or info["renderBasename"]
+                url = _render_url(repo, base_ref, g["module"], basename)
+                before_cells.append(f'<img src="{url}" width="200" />')
+            lines.append("| Before | " + " | ".join(before_cells) + " |")
+        after_cells = []
+        for _token, _key, info, _changed, _bl in rows:
+            url = _render_url(repo, head_ref, g["module"], info["renderBasename"])
+            after_cells.append(f'<img src="{url}" width="200" />')
+        lines.append("| After | " + " | ".join(after_cells) + " |")
+        lines.append("")
+        diffed = [
+            token for token, _k, _i, changed, bl in rows if changed or bl is None
+        ]
+        if diffed:
+            lines.append("Changed: " + ", ".join(f"`{t}`" for t in diffed) + ".")
+            lines.append("")
+
+
 def cmd_compare(args: argparse.Namespace) -> int:
     cli_json = Path(args.cli_json)
     baselines_path = Path(args.baselines)
@@ -588,6 +834,53 @@ def cmd_compare(args: argparse.Namespace) -> int:
 
     current = load_cli_output(cli_json)
     baselines = _load_baselines(baselines_path)
+    ab_config = ABTestConfig.load(
+        Path(args.ab_config) if getattr(args, "ab_config", None) else None
+    )
+
+    # --- A/B comparison groups ---
+    # Resolve these up front so their rows can be excluded from the standard
+    # new/changed/unchanged buckets (otherwise an A/B variant would be listed
+    # twice). A group is only *promoted* to the side-by-side section when at
+    # least one of its variants actually changed or is new — an all-unchanged
+    # group stays out of the comment so we don't post on no-op PRs (the
+    # empty-diff sentinel below still fires).
+    ab_groups: list[dict] = []
+    ab_keys: set[str] = set()
+    if ab_config:
+        seen_fns: set[tuple[str, str]] = set()
+        for key, info in sorted(current.items()):
+            if not info["sha256"]:
+                continue
+            gk = (info["module"], info["functionName"])
+            if gk in seen_fns:
+                continue
+            group = ab_config.match(info["module"], info["functionName"])
+            if group is None:
+                continue
+            rows = _ab_resolve_rows(group, gk[0], gk[1], current)
+            if len(rows) < 2:
+                # Need at least two variants present in this run to compare.
+                continue
+            seen_fns.add(gk)
+            resolved = []
+            has_change = False
+            for token, rkey, rinfo in rows:
+                bl = baselines.get(rkey)
+                changed = bl is not None and _is_changed(rinfo, bl, baseline_renders)
+                if changed or bl is None:
+                    has_change = True
+                resolved.append((token, rkey, rinfo, changed, bl))
+            if not has_change:
+                continue
+            for token, rkey, rinfo, changed, bl in resolved:
+                ab_keys.add(rkey)
+            ab_groups.append({
+                "label": group.get("label"),
+                "module": gk[0],
+                "fn": gk[1],
+                "rows": resolved,
+            })
 
     new: list[tuple[str, dict]] = []
     changed: list[tuple[str, dict, dict]] = []
@@ -597,6 +890,8 @@ def cmd_compare(args: argparse.Namespace) -> int:
     for key, info in sorted(current.items()):
         if not info["sha256"]:
             continue
+        if key in ab_keys:
+            continue
         if key not in baselines:
             new.append((key, info))
         elif _is_changed(info, baselines[key], baseline_renders):
@@ -605,6 +900,8 @@ def cmd_compare(args: argparse.Namespace) -> int:
             unchanged.append((key, info))
 
     for key, bl_info in sorted(baselines.items()):
+        if key in ab_keys:
+            continue
         if key not in current:
             removed.append((key, bl_info))
 
@@ -614,13 +911,16 @@ def cmd_compare(args: argparse.Namespace) -> int:
     marker = "<!-- preview-diff -->"
     lines = [marker, "## Preview Changes", ""]
 
-    if not new and not changed and not removed and not failures:
+    if not new and not changed and not removed and not failures and not ab_groups:
         lines.append("No visual changes detected.")
         lines.append("")
         if unchanged:
             lines.append(f"_{len(unchanged)} preview(s) unchanged._")
         print("\n".join(lines))
         return 0
+
+    if ab_groups:
+        _emit_ab_comparisons(lines, ab_groups, repo, base_ref, head_ref)
 
     if failures:
         lines.append(
@@ -1296,6 +1596,12 @@ def main() -> int:
     gen.add_argument("--prior-renders",
                      help="Directory containing the existing renders/<module>/<basename> "
                           "PNG tree on the baseline branch.")
+    # Same A/B config as `compare` — nominated variant groups render
+    # side-by-side at the top of their module section in the gallery README.
+    gen.add_argument("--ab-config",
+                     help="Path to the A/B comparison config JSON "
+                          "(default off; the apply action passes "
+                          ".github/preview-abtest.json when present).")
 
     cmp = sub.add_parser("compare", help="Compare CLI output against baselines")
     cmp.add_argument("cli_json", help="Path to compose-preview show --json output")
@@ -1313,6 +1619,14 @@ def main() -> int:
     # doesn't appear in the comment. Falls back to strict-bytes when omitted.
     cmp.add_argument("--baseline-renders",
                      help="Directory containing baseline PNGs (renders/<module>/<basename>)")
+    # Optional. Path to the A/B comparison config (default
+    # `.github/preview-abtest.json`, wired by the apply action). Nominated
+    # variant groups render side-by-side instead of hero+links. Missing /
+    # malformed → no A/B groups (feature is purely additive).
+    cmp.add_argument("--ab-config",
+                     help="Path to the A/B comparison config JSON "
+                          "(default off; the apply action passes "
+                          ".github/preview-abtest.json when present).")
 
     cp = sub.add_parser("copy-changed", help="Copy new/changed PNGs to output dir")
     cp.add_argument("cli_json", help="Path to compose-preview show --json output")

--- a/.github/actions/lib/test_compare_previews.py
+++ b/.github/actions/lib/test_compare_previews.py
@@ -955,6 +955,227 @@ class MultiCaptureCompareTest(unittest.TestCase):
         self.assertIn("S_SCROLL_end.png", out)
 
 
+class ABTestConfigTest(unittest.TestCase):
+    """`ABTestConfig.load` + matching are the gate for the side-by-side path."""
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.tmp)
+
+    def _write(self, payload) -> Path:
+        p = self.tmp / "abtest.json"
+        p.write_text(json.dumps(payload))
+        return p
+
+    def test_missing_file_is_empty_config(self):
+        cfg = cp.ABTestConfig.load(self.tmp / "nope.json")
+        self.assertFalse(cfg)
+        self.assertIsNone(cfg.match("app", "Fn"))
+
+    def test_malformed_and_non_dict_degrade_to_empty(self):
+        bad = self.tmp / "bad.json"
+        bad.write_text("not json {{")
+        self.assertFalse(cp.ABTestConfig.load(bad))
+        arr = self.tmp / "arr.json"
+        arr.write_text("[]")
+        self.assertFalse(cp.ABTestConfig.load(arr))
+
+    def test_groups_need_function_and_two_variants(self):
+        cfg = cp.ABTestConfig.load(self._write({"groups": [
+            {"function": "OnlyOne", "variants": ["A"]},          # too few
+            {"variants": ["A", "B"]},                            # no function
+            {"function": "Good", "variants": ["A", "B"]},        # kept
+        ]}))
+        self.assertIsNone(cfg.match("app", "OnlyOne"))
+        self.assertIsNotNone(cfg.match("app", "Good"))
+
+    def test_module_pin_scopes_the_match(self):
+        cfg = cp.ABTestConfig.load(self._write({"groups": [
+            {"function": "Fn", "module": "app", "variants": ["A", "B"]},
+        ]}))
+        self.assertIsNotNone(cfg.match("app", "Fn"))
+        self.assertIsNone(cfg.match("lib", "Fn"))
+
+    def test_unpinned_module_matches_any(self):
+        cfg = cp.ABTestConfig.load(self._write({"groups": [
+            {"function": "Fn", "variants": ["A", "B"]},
+        ]}))
+        self.assertIsNotNone(cfg.match("anything", "Fn"))
+
+    def test_row_matches_variant_by_suffix_and_fallbacks(self):
+        self.assertTrue(cp._row_matches_variant({"previewId": "K.Fn_Control"}, "Control"))
+        self.assertTrue(cp._row_matches_variant({"previewId": "K.Fn_PARAM_0"}, "PARAM_0"))
+        self.assertTrue(cp._row_matches_variant({"previewId": "K.Fn_Treatment"}, "K.Fn_Treatment"))
+        self.assertFalse(cp._row_matches_variant({"previewId": "K.Fn_Control"}, "Treatment"))
+
+
+class ABCompareTest(unittest.TestCase):
+    """End-to-end: an A/B group renders a side-by-side table instead of the
+    hero+links treatment, and only when at least one variant diffed."""
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.tmp)
+
+    def _run(self, current_payload, baselines_payload, ab_config) -> str:
+        cli_path = self.tmp / "cli.json"
+        cli_path.write_text(json.dumps(current_payload))
+        bl_path = self.tmp / "baselines.json"
+        bl_path.write_text(json.dumps(baselines_payload))
+        ab_path = self.tmp / "abtest.json"
+        ab_path.write_text(json.dumps(ab_config))
+
+        import io
+        import contextlib
+        from types import SimpleNamespace
+
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            cp.cmd_compare(SimpleNamespace(
+                cli_json=str(cli_path),
+                baselines=str(bl_path),
+                repo="owner/repo",
+                base_ref="deadbeef",
+                head_ref="cafef00d",
+                ab_config=str(ab_path),
+            ))
+        return buf.getvalue()
+
+    def _two_variant_payload(self, control_sha, treatment_sha):
+        return {"previews": [
+            _entry(id="K.ButtonPreview_Control", function="ButtonPreview",
+                   png="/Control.png", sha=control_sha),
+            _entry(id="K.ButtonPreview_Treatment", function="ButtonPreview",
+                   png="/Treatment.png", sha=treatment_sha),
+        ]}
+
+    def test_changed_variant_promotes_group_to_side_by_side(self):
+        out = self._run(
+            self._two_variant_payload("ctrl-sha", "new-treat-sha"),
+            {
+                "app/K.ButtonPreview_Control": {"sha256": "ctrl-sha", "functionName": "ButtonPreview"},
+                "app/K.ButtonPreview_Treatment": {"sha256": "old-treat-sha", "functionName": "ButtonPreview"},
+            },
+            {"groups": [{"function": "ButtonPreview",
+                         "variants": ["Control", "Treatment"],
+                         "label": "Button copy"}]},
+        )
+        # Side-by-side section header + both variant columns in one table row.
+        self.assertIn("### A/B Comparisons (1 group(s))", out)
+        self.assertIn("**Button copy** — `ButtonPreview` (app)", out)
+        self.assertIn("| | Control | Treatment |", out)
+        self.assertIn("| Before |", out)
+        self.assertIn("| After |", out)
+        # Both Before (base ref) and After (head ref) images resolve.
+        self.assertIn("raw.githubusercontent.com/owner/repo/deadbeef/renders/app/Control.png", out)
+        self.assertIn("raw.githubusercontent.com/owner/repo/cafef00d/renders/app/Treatment.png", out)
+        # Only the diffed variant is flagged.
+        self.assertIn("Changed: `Treatment`.", out)
+        # The A/B rows are NOT also listed in the standard Changed section.
+        self.assertNotIn("### Changed", out)
+
+    def test_unchanged_group_is_not_promoted_and_stays_silent(self):
+        # No variant changed → group drops out, comment is the empty-diff
+        # sentinel so the action's no-op gate keeps it off the PR.
+        out = self._run(
+            self._two_variant_payload("ctrl-sha", "treat-sha"),
+            {
+                "app/K.ButtonPreview_Control": {"sha256": "ctrl-sha", "functionName": "ButtonPreview"},
+                "app/K.ButtonPreview_Treatment": {"sha256": "treat-sha", "functionName": "ButtonPreview"},
+            },
+            {"groups": [{"function": "ButtonPreview", "variants": ["Control", "Treatment"]}]},
+        )
+        self.assertNotIn("A/B Comparisons", out)
+        self.assertIn("No visual changes detected.", out)
+
+    def test_new_ab_group_has_no_before_row(self):
+        # Brand-new function (no baseline at all) → After-only table.
+        out = self._run(
+            self._two_variant_payload("ctrl-sha", "treat-sha"),
+            {},
+            {"groups": [{"function": "ButtonPreview", "variants": ["Control", "Treatment"]}]},
+        )
+        self.assertIn("### A/B Comparisons (1 group(s))", out)
+        self.assertNotIn("| Before |", out)
+        self.assertIn("| After |", out)
+        self.assertIn("Changed: `Control`, `Treatment`.", out)
+
+    def test_no_config_keeps_legacy_hero_plus_links(self):
+        # Without an A/B config the same two variants collapse to the
+        # historical hero + "Other variants" layout.
+        from types import SimpleNamespace
+        import io, contextlib
+        cli_path = self.tmp / "cli.json"
+        cli_path.write_text(json.dumps(self._two_variant_payload("ctrl-sha", "new-treat-sha")))
+        bl_path = self.tmp / "baselines.json"
+        bl_path.write_text(json.dumps({
+            "app/K.ButtonPreview_Control": {"sha256": "old1", "functionName": "ButtonPreview"},
+            "app/K.ButtonPreview_Treatment": {"sha256": "old2", "functionName": "ButtonPreview"},
+        }))
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            cp.cmd_compare(SimpleNamespace(
+                cli_json=str(cli_path), baselines=str(bl_path),
+                repo="owner/repo", base_ref="deadbeef", head_ref="cafef00d",
+            ))
+        out = buf.getvalue()
+        self.assertNotIn("A/B Comparisons", out)
+        self.assertIn("### Changed", out)
+
+
+class ABGenerateGalleryTest(unittest.TestCase):
+    """`generate` renders A/B groups side-by-side at the top of the module
+    section and drops them from the standard per-preview table."""
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.tmp)
+        self.control = self.tmp / "Control.png"
+        self.control.write_bytes(b"control-bytes")
+        self.treatment = self.tmp / "Treatment.png"
+        self.treatment.write_bytes(b"treatment-bytes")
+        self.plain = self.tmp / "Plain.png"
+        self.plain.write_bytes(b"plain-bytes")
+
+        self.cli_path = self.tmp / "cli.json"
+        self.cli_path.write_text(json.dumps({"previews": [
+            _entry(id="K.ButtonPreview_Control", module="app", function="ButtonPreview",
+                   png=str(self.control), sha="c"),
+            _entry(id="K.ButtonPreview_Treatment", module="app", function="ButtonPreview",
+                   png=str(self.treatment), sha="t"),
+            _entry(id="K.OtherPreview", module="app", function="OtherPreview",
+                   png=str(self.plain), sha="p"),
+        ]}))
+        self.out = self.tmp / "out"
+        self.ab_path = self.tmp / "abtest.json"
+        self.ab_path.write_text(json.dumps({"groups": [
+            {"function": "ButtonPreview", "variants": ["Control", "Treatment"]},
+        ]}))
+
+    def test_gallery_promotes_ab_group_and_keeps_others_in_table(self):
+        from types import SimpleNamespace
+        rc = cp.cmd_generate(SimpleNamespace(
+            cli_json=str(self.cli_path),
+            output_dir=str(self.out),
+            repo="owner/repo",
+            branch="compose-preview/main",
+            prior_baselines=None,
+            prior_renders=None,
+            ab_config=str(self.ab_path),
+        ))
+        self.assertEqual(rc, 0)
+        readme = (self.out / "README.md").read_text()
+        # A/B side-by-side block with both variants as columns.
+        self.assertIn("### A/B: `ButtonPreview`", readme)
+        self.assertIn("| Control | Treatment |", readme)
+        # The non-A/B preview still appears in the standard table.
+        self.assertIn("`OtherPreview`", readme)
+        # `ButtonPreview` appears only in the A/B heading, never as a
+        # standard per-preview table row (the variants were promoted).
+        self.assertEqual(readme.count("`ButtonPreview`"), 1)
+        self.assertNotIn("| `ButtonPreview` |", readme)
+
+
 def _resource_envelope(*resources: dict) -> dict:
     """Wrap one or more `resources` entries in the
     `compose-preview-show-resources/v1` envelope shape the CLI emits."""

--- a/.github/actions/lib/test_compare_previews.py
+++ b/.github/actions/lib/test_compare_previews.py
@@ -1073,6 +1073,12 @@ class ABCompareTest(unittest.TestCase):
         self.assertIn("Changed: `Treatment`.", out)
         # The A/B rows are NOT also listed in the standard Changed section.
         self.assertNotIn("### Changed", out)
+        # Regression: the unchanged companion (Control) is never staged to the
+        # head renders branch by `copy-changed`, so its "After" cell must point
+        # at the baseline ref, not the head ref (which would 404 / broken-image).
+        self.assertNotIn(
+            "raw.githubusercontent.com/owner/repo/cafef00d/renders/app/Control.png", out
+        )
 
     def test_unchanged_group_is_not_promoted_and_stays_silent(self):
         # No variant changed → group drops out, comment is the empty-diff
@@ -1099,6 +1105,31 @@ class ABCompareTest(unittest.TestCase):
         self.assertNotIn("| Before |", out)
         self.assertIn("| After |", out)
         self.assertIn("Changed: `Control`, `Treatment`.", out)
+
+    def test_unchanged_companion_after_cell_uses_baseline_ref(self):
+        # Control unchanged, Treatment changed. The "After" row must show both
+        # columns: Treatment from the head ref (staged by copy-changed) and
+        # Control from the baseline ref (unchanged renders are never pushed to
+        # the head branch, so linking them there would be a broken image).
+        out = self._run(
+            self._two_variant_payload("ctrl-sha", "new-treat-sha"),
+            {
+                "app/K.ButtonPreview_Control": {"sha256": "ctrl-sha", "functionName": "ButtonPreview"},
+                "app/K.ButtonPreview_Treatment": {"sha256": "old-treat-sha", "functionName": "ButtonPreview"},
+            },
+            {"groups": [{"function": "ButtonPreview", "variants": ["Control", "Treatment"]}]},
+        )
+        after_row = next(ln for ln in out.splitlines() if ln.startswith("| After |"))
+        # Treatment changed → head ref; Control unchanged → baseline ref.
+        self.assertIn(
+            "raw.githubusercontent.com/owner/repo/cafef00d/renders/app/Treatment.png", after_row
+        )
+        self.assertIn(
+            "raw.githubusercontent.com/owner/repo/deadbeef/renders/app/Control.png", after_row
+        )
+        self.assertNotIn(
+            "raw.githubusercontent.com/owner/repo/cafef00d/renders/app/Control.png", after_row
+        )
 
     def test_no_config_keeps_legacy_hero_plus_links(self):
         # Without an A/B config the same two variants collapse to the


### PR DESCRIPTION
## Summary

Adds a config-driven **A/B comparison** mechanism to the compose-preview CI workflow. A project nominates two specific variants of a single `@Preview` function, and the PR comment + baseline gallery render them **side-by-side horizontally** instead of the default "hero render + *Other variants* links" layout — so the two variants can be compared directly.

Variants are sourced from either form the discovery layer already distinguishes by preview-id suffix:
- **Two `@Preview` annotations** on one composable (incl. multi-preview meta-annotation members), e.g. `@Preview(name = "Control")` / `@Preview(name = "Treatment")`.
- **Two `@PreviewParameter` values** (matched by the `_PARAM_<n>` suffix).

A project opts in with `.github/preview-abtest.json` (path overridable via the new `ab-config` action input):

```json
{ "groups": [ { "function": "ButtonPreview", "module": "app",
                "variants": ["Control", "Treatment"], "label": "Button copy" } ] }
```

### Behavior
- PR comment: one table per group — variant tokens as columns, `Before`/`After` as rows.
- A group is surfaced only when a variant actually diffed, so no-op PRs stay silent (the empty-diff gate still fires). Non-nominated variants keep the historical "Other variants" treatment.
- Missing/malformed config is a no-op — the feature is purely additive.

### Files
- `.github/actions/lib/compare-previews.py` — `ABTestConfig` loader, variant matching, side-by-side rendering in both `compare` (comment) and `generate` (gallery).
- `.github/actions/apply/action.yml` + `pipelines/compose.sh` — `ab-config` input wired into both steps, passed only when the file exists.
- `.github/actions/lib/test_compare_previews.py` — 11 new tests (config parsing, matching, compare/gallery, unchanged-group + no-config fallbacks).
- `.github/actions/apply/README.md` — documentation + schema.

## Test plan
- `python -m pytest .github/actions/lib/test_compare_previews.py` — full suite of 76 tests passing.
- New cases cover: config parse (valid/missing/malformed), `@Preview`-name and `@PreviewParameter` variant matching, side-by-side compare table output, unchanged-group suppression, no-config fallback, and the gallery (`generate`) path.

## Visual evidence
This change alters the structure of the PR-comment / gallery markdown rather than any rendered surface itself; the side-by-side layout is verified via the generated markdown tables in the test suite. Real rendered `@Preview` PNGs could not be produced in this environment (no Android SDK), so the layout is validated through the markdown/table assertions rather than a live rendered comment. The first PR in a downstream repo that adopts `.github/preview-abtest.json` will exercise the rendered output end-to-end via the existing visual-diff bot.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pq9CtquoYv7NUgCuDqCvit)_