### PR TITLE
fix(apply): default cli-version to auto so the CLI tracks the pinned plugin (#1920)

### DIFF
--- a/.github/actions/apply/README.md
+++ b/.github/actions/apply/README.md
@@ -16,11 +16,13 @@ per-surface `preview-baselines` / `preview-comment` / `a11y-report` /
     distribution: temurin
     java-version: 17
 - uses: yschimke/compose-ai-tools/.github/actions/apply@v0.15.9
-  with:
-    cli-version: catalog          # track the plugin — see "Version skew" below
-    catalog-key: composePreviewPlugin
 ```
 <!-- x-release-please-end -->
+
+`cli-version` defaults to **`auto`**, which pins the CLI to the plugin version
+you already pin in your checkout — so the version skew described below can't
+happen on the happy path, with no extra config. See
+[Version skew](#version-skew) for what `auto` does and when to override it.
 
 On a `pull_request` this renders the PR and posts before/after comparison
 comments; on a `push` to the development branch (`main` by default) it
@@ -31,22 +33,24 @@ per-module allow/deny lists, the missing-render policy, and non-Gradle
 
 ## Version skew
 
-> **The single most common way this action breaks.** Pinning the action ref
-> (`apply@vX`) does **not** pin the CLI. `cli-version` defaults to `latest`,
-> so every new compose-ai-tools release auto-installs the newest CLI against
-> your still-pinned Gradle plugin. A CLI **newer** than the applied plugin
-> can't discover that older plugin, so the render finds zero preview modules
-> and the pipeline fails repo-wide — on a release, not on your diff — with a
-> misleading:
+> **What used to be the single most common way this action breaks.** Pinning
+> the action ref (`apply@vX`) does **not** pin the CLI. When `cli-version` was
+> `latest`, every new compose-ai-tools release auto-installed the newest CLI
+> against your still-pinned Gradle plugin. A CLI **newer** than the applied
+> plugin can't discover that older plugin, so the render finds zero preview
+> modules and the pipeline fails repo-wide — on a release, not on your diff —
+> with a misleading:
 >
 > ```
 > ✗ no modules have the compose-preview plugin applied
 > compose pipeline: No preview modules discovered ... skipping.
 > ```
 
-Pin the CLI to the **same source of truth as the plugin** so the two can't
-skew. Declare the plugin version once in your version catalog and point the
-action at it:
+**The default `cli-version: auto` removes this footgun.** It detects the plugin
+version you pin in your checkout (version-catalog `[plugins]` entry or a literal
+`id("…") version "…"` in a build script) and installs the CLI at *exactly* that
+version, so the CLI and plugin can't skew — declare the plugin version once and
+the CLI follows it for free:
 
 <!-- x-release-please-start-version -->
 ```toml
@@ -57,20 +61,23 @@ composePreviewPlugin = "0.15.9"
 [plugins]
 composePreview = { id = "ee.schimke.composeai.preview", version.ref = "composePreviewPlugin" }
 ```
-
-```yaml
-- uses: yschimke/compose-ai-tools/.github/actions/apply@v0.15.9
-  with:
-    cli-version: catalog            # reads the version below from the catalog
-    catalog-key: composePreviewPlugin
-```
 <!-- x-release-please-end -->
 
-[Renovate](https://docs.renovatebot.com/) then bumps the one `[versions]`
-entry on each release and the CLI follows automatically. (The same
-catalog/Renovate recipe is documented for the standalone
+> The `version.ref` is the plugin's own version key; `auto` reads it directly
+> off the `[plugins]` entry — no `catalog-key` needed.
+
+[Renovate](https://docs.renovatebot.com/) bumps that one `[versions]` entry on
+each release and `auto` picks it up automatically — no `cli-version` /
+`catalog-key` wiring needed. When `auto` finds **no** pinned plugin (the
+auto-inject / zero-code path, where the CLI injects a matching plugin via
+`--init-script`) it falls back to `latest`, which is correct there because the
+injected plugin always matches the installed CLI.
+
+If you want to pin the CLI to a *specific* `[versions]` key regardless of the
+plugin (e.g. a dedicated `composePreviewCli` entry), use `cli-version: catalog`
+with `catalog-key`; the same recipe is documented for the standalone
 [`install`](../install/README.md#pin-the-cli-to-a-gradle-version-catalog)
-action.)
+action. Set `cli-version: latest` to opt back into the old floating behaviour.
 
 ### Skew guardrail
 
@@ -97,8 +104,9 @@ with no plugin pinned in their build — are never tripped.
 
 | Value | Meaning |
 |---|---|
-| `latest` (current default) | Newest published release. **Skews ahead of a pinned plugin** — see above. |
-| `catalog` | Read the version from a Gradle version catalog (`catalog-path` / `catalog-key`). Recommended. |
+| `auto` (default) | Pin the CLI to the plugin version detected in the checkout (catalog `[plugins]` entry or literal `id("…") version "…"`); fall back to `latest` when no plugin is pinned. **Skew-proof on the happy path** — see above. |
+| `latest` | Newest published release. **Skews ahead of a pinned plugin** — see above. |
+| `catalog` | Read the version from a Gradle version catalog (`catalog-path` / `catalog-key`). Use to pin the CLI to a dedicated `[versions]` key. |
 | literal (e.g. `0.15.9`) | Exact release. |
 | `source` | Build from the current checkout — internal CI only. |
 | `none` | Skip CLI install (pair with `skip-render: true` for non-Gradle build systems). |

--- a/.github/actions/apply/action.yml
+++ b/.github/actions/apply/action.yml
@@ -10,12 +10,22 @@ description: >
 inputs:
   cli-version:
     description: >
-      compose-preview CLI version. Literal (e.g. "0.8.1"), "latest", "catalog",
-      "source" (build from the current checkout — internal CI only), or
-      "none" (skip CLI install entirely; pair with `skip-render: true` and
-      `only: compose,resources` for non-Gradle build systems that pre-stage
-      `_previews.json` / `_resources.json`).
-    default: 'latest'
+      compose-preview CLI version. "auto" (default), a literal (e.g. "0.8.1"),
+      "latest", "catalog", "source" (build from the current checkout — internal
+      CI only), or "none" (skip CLI install entirely; pair with
+      `skip-render: true` and `only: compose,resources` for non-Gradle build
+      systems that pre-stage `_previews.json` / `_resources.json`).
+
+      "auto" (issue #1920) makes the common path skew-proof with no extra
+      config: it sniffs the plugin version you pin in the checkout (version
+      catalog `[plugins]` entry or a literal `id("…") version "…"`) and installs
+      the CLI at *exactly* that version, so a new release can't float the CLI
+      ahead of the applied plugin and silently break discovery. When no plugin
+      pin is found — the auto-inject / zero-code path where the CLI injects a
+      matching plugin via `--init-script` — it falls back to "latest". Set
+      "latest" explicitly to keep the old floating behaviour, or "catalog" to
+      track a specific `[versions]` key via `catalog-key`.
+    default: 'auto'
   catalog-path:
     description: 'Path to the Gradle version catalog (when cli-version=catalog).'
     default: 'gradle/libs.versions.toml'
@@ -199,13 +209,47 @@ runs:
           echo "::notice::No pipeline applicable for event=$EVENT_NAME ref=$REF_NAME — skipping."
         fi
 
+    # Resolve `cli-version: auto` (the default, issue #1920) to a concrete
+    # value before any install runs. `auto` pins the CLI to the plugin version
+    # detected in the consumer's checkout so a new release can't float the CLI
+    # ahead of the applied plugin (the silent skew this issue is about); with
+    # no plugin pinned it falls back to `latest` (the auto-inject path). Every
+    # other value (`latest` / `catalog` / literal / `source` / `none`) passes
+    # straight through. Downstream steps gate on this resolved value, not the
+    # raw input, so `auto` flows into the right install branch. Pure-Python,
+    # reuses the skew guard's tested detection (single source of truth).
+    - name: Resolve CLI version
+      id: clivers
+      if: steps.resolve.outputs.mode != 'skip'
+      shell: bash
+      env:
+        ACTION_PATH: ${{ github.action_path }}
+        CLI_VERSION: ${{ inputs.cli-version }}
+        WORKSPACE: ${{ github.workspace }}
+        CATALOG_PATH: ${{ inputs.catalog-path }}
+      run: |
+        set -euo pipefail
+        if [ "$CLI_VERSION" = "auto" ]; then
+          detected=$(python3 "$ACTION_PATH/check-skew.py" detect-plugin || true)
+          if [ -n "$detected" ]; then
+            eff="$detected"
+            echo "::notice::compose-preview/apply: cli-version=auto pinned the CLI to the applied plugin v${eff} (skew-proof)."
+          else
+            eff="latest"
+            echo "::notice::compose-preview/apply: cli-version=auto found no pinned plugin — using 'latest' (auto-inject path)."
+          fi
+        else
+          eff="$CLI_VERSION"
+        fi
+        echo "version=$eff" >> "$GITHUB_OUTPUT"
+
     # See preview-baselines/action.yml history for the source-vs-release
     # rationale and for why these are full `org/repo/path@ref` references
     # rather than `./.github/actions/...` (relative `./` from inside a
     # composite resolves against the consumer's $GITHUB_WORKSPACE, breaking
     # external use). Tag bumped per release by release-please.
     - name: Install CLI from source
-      if: steps.resolve.outputs.mode != 'skip' && inputs.cli-version == 'source'
+      if: steps.resolve.outputs.mode != 'skip' && steps.clivers.outputs.version == 'source'
       # zizmor: ignore[known-vulnerable-actions] same-repo release action trips GitHub Advisories API 403 under GITHUB_TOKEN
       uses: yschimke/compose-ai-tools/.github/actions/install-cli@v0.11.5 # x-release-please-version
 
@@ -215,11 +259,11 @@ runs:
     # cleanly with "command not found" when selected without a CLI.
     - name: Install CLI from release
       id: install-release
-      if: steps.resolve.outputs.mode != 'skip' && inputs.cli-version != 'source' && inputs.cli-version != 'none'
+      if: steps.resolve.outputs.mode != 'skip' && steps.clivers.outputs.version != 'source' && steps.clivers.outputs.version != 'none'
       # zizmor: ignore[known-vulnerable-actions] same-repo release action trips GitHub Advisories API 403 under GITHUB_TOKEN
       uses: yschimke/compose-ai-tools/.github/actions/install@v0.11.5 # x-release-please-version
       with:
-        version: ${{ inputs.cli-version }}
+        version: ${{ steps.clivers.outputs.version }}
         catalog-path: ${{ inputs.catalog-path }}
         catalog-key: ${{ inputs.catalog-key }}
 
@@ -234,7 +278,7 @@ runs:
     # no Gradle cost — runs before doctor so the headline is the skew, not the
     # confusing symptom.
     - name: Check CLI / plugin version skew
-      if: steps.resolve.outputs.mode != 'skip' && inputs.cli-version != 'source' && inputs.cli-version != 'none'
+      if: steps.resolve.outputs.mode != 'skip' && steps.clivers.outputs.version != 'source' && steps.clivers.outputs.version != 'none'
       shell: bash
       env:
         ACTION_PATH: ${{ github.action_path }}
@@ -255,7 +299,7 @@ runs:
     # actionable error. A non-zero doctor surfaces as a `::warning::`
     # annotation so it's still visible in the run summary.
     - name: Run compose-preview doctor
-      if: steps.resolve.outputs.mode != 'skip' && inputs.cli-version != 'none'
+      if: steps.resolve.outputs.mode != 'skip' && steps.clivers.outputs.version != 'none'
       shell: bash
       run: |
         echo "::group::compose-preview doctor"

--- a/.github/actions/apply/check-skew.py
+++ b/.github/actions/apply/check-skew.py
@@ -201,6 +201,36 @@ def parse_release(version: str) -> tuple[int, int, int] | None:
     return (int(m.group(1)), int(m.group(2)), int(m.group(3)))
 
 
+def _workspace_and_catalog() -> tuple[str, str]:
+    """Resolve the (workspace, catalog_path) pair from the environment.
+
+    Shared by the skew guard (`main`) and the `detect-plugin` resolver so both
+    read the consumer checkout the same way.
+    """
+    workspace = (
+        os.environ.get("WORKSPACE") or os.environ.get("GITHUB_WORKSPACE") or "."
+    )
+    catalog_path = os.environ.get("CATALOG_PATH") or "gradle/libs.versions.toml"
+    return workspace, catalog_path
+
+
+def detect_plugin_main() -> int:
+    """`detect-plugin` entry point: print the applied plugin version, or nothing.
+
+    Backs the `apply` action's `cli-version: auto` resolution — when a concrete
+    plugin version is pinned in the checkout the CLI is installed at exactly
+    that version (skew-proof by construction), otherwise the action falls back
+    to `latest`. Prints the bare version on stdout when found, prints nothing
+    when not, and always exits 0 (a missing pin is the expected auto-inject
+    case, not an error).
+    """
+    workspace, catalog_path = _workspace_and_catalog()
+    version = detect_plugin_version(workspace, catalog_path)
+    if version:
+        print(version)
+    return 0
+
+
 def main() -> int:
     mode = (os.environ.get("SKEW_MODE") or "fail").strip().lower()
     if mode == "off":
@@ -212,10 +242,7 @@ def main() -> int:
         # nothing to compare against.
         return 0
 
-    workspace = (
-        os.environ.get("WORKSPACE") or os.environ.get("GITHUB_WORKSPACE") or "."
-    )
-    catalog_path = os.environ.get("CATALOG_PATH") or "gradle/libs.versions.toml"
+    workspace, catalog_path = _workspace_and_catalog()
 
     plugin_raw = detect_plugin_version(workspace, catalog_path)
     if not plugin_raw:
@@ -256,4 +283,6 @@ def main() -> int:
 
 
 if __name__ == "__main__":
+    if len(sys.argv) > 1 and sys.argv[1] == "detect-plugin":
+        sys.exit(detect_plugin_main())
     sys.exit(main())

--- a/.github/actions/apply/test_check_skew.py
+++ b/.github/actions/apply/test_check_skew.py
@@ -11,12 +11,15 @@ from __future__ import annotations
 import importlib.util
 import io
 import os
+import subprocess
+import sys
 import tempfile
 import unittest
 from contextlib import redirect_stdout
 from pathlib import Path
 
 _HERE = Path(__file__).resolve().parent
+_SCRIPT = _HERE / "check-skew.py"
 _SPEC = importlib.util.spec_from_file_location("check_skew", _HERE / "check-skew.py")
 cs = importlib.util.module_from_spec(_SPEC)
 assert _SPEC.loader is not None
@@ -138,6 +141,62 @@ class BuildScriptDetectionTests(unittest.TestCase):
             'id("ee.schimke.composeai.preview") version "9.9.9"\n', encoding="utf-8"
         )
         self.assertIsNone(cs.plugin_version_from_build_scripts(ws))
+
+
+class DetectPluginCliTests(unittest.TestCase):
+    """The `detect-plugin` subcommand backs `cli-version: auto` resolution.
+
+    Drives the script the same way action.yml does — `python3 check-skew.py
+    detect-plugin` with WORKSPACE/CATALOG_PATH in the env — so the contract the
+    action's bash relies on (bare version on stdout, empty + rc 0 when nothing
+    is pinned) is locked in.
+    """
+
+    def _detect(self, workspace: str) -> tuple[int, str]:
+        env = dict(os.environ)
+        env["WORKSPACE"] = workspace
+        proc = subprocess.run(
+            [sys.executable, str(_SCRIPT), "detect-plugin"],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        return proc.returncode, proc.stdout.strip()
+
+    def _ws_with_catalog(self, body: str) -> str:
+        d = tempfile.mkdtemp()
+        self.addCleanup(lambda: __import__("shutil").rmtree(d, ignore_errors=True))
+        os.makedirs(os.path.join(d, "gradle"))
+        Path(os.path.join(d, "gradle", "libs.versions.toml")).write_text(
+            body, encoding="utf-8"
+        )
+        return d
+
+    def test_prints_catalog_plugin_version(self):
+        ws = self._ws_with_catalog(
+            '[plugins]\ncomposePreview = "ee.schimke.composeai.preview:0.15.8"\n'
+        )
+        rc, out = self._detect(ws)
+        self.assertEqual(rc, 0)
+        self.assertEqual(out, "0.15.8")
+
+    def test_prints_literal_build_script_version(self):
+        d = tempfile.mkdtemp()
+        self.addCleanup(lambda: __import__("shutil").rmtree(d, ignore_errors=True))
+        Path(os.path.join(d, "build.gradle.kts")).write_text(
+            'plugins {\n  id("ee.schimke.composeai.preview") version "0.14.0"\n}\n',
+            encoding="utf-8",
+        )
+        rc, out = self._detect(d)
+        self.assertEqual(rc, 0)
+        self.assertEqual(out, "0.14.0")
+
+    def test_no_pin_prints_nothing(self):
+        d = tempfile.mkdtemp()
+        self.addCleanup(lambda: __import__("shutil").rmtree(d, ignore_errors=True))
+        rc, out = self._detect(d)
+        self.assertEqual(rc, 0)
+        self.assertEqual(out, "")
 
 
 class MainTests(unittest.TestCase):

--- a/.github/actions/preview-baselines/action.yml
+++ b/.github/actions/preview-baselines/action.yml
@@ -8,7 +8,13 @@ description: >
 inputs:
   cli-version:
     description: 'Forwarded to apply.cli-version.'
-    default: 'auto'
+    # Stays 'latest', not 'auto': this shim forwards to a *pinned, released*
+    # apply ref (`apply@vX` below, bumped by release-please), which may predate
+    # the `auto` resolver and would pass `auto` straight to install as a literal
+    # version (→ 404 on `vauto/...tar.gz`). The released apply still carries the
+    # #1920 skew guardrail. New consumers should call `apply` directly, where
+    # `auto` is the default.
+    default: 'latest'
   catalog-path:
     default: 'gradle/libs.versions.toml'
   catalog-key:

--- a/.github/actions/preview-baselines/action.yml
+++ b/.github/actions/preview-baselines/action.yml
@@ -8,7 +8,7 @@ description: >
 inputs:
   cli-version:
     description: 'Forwarded to apply.cli-version.'
-    default: 'latest'
+    default: 'auto'
   catalog-path:
     default: 'gradle/libs.versions.toml'
   catalog-key:

--- a/.github/actions/preview-comment/action.yml
+++ b/.github/actions/preview-comment/action.yml
@@ -7,7 +7,7 @@ description: >
 
 inputs:
   cli-version:
-    default: 'latest'
+    default: 'auto'
   catalog-path:
     default: 'gradle/libs.versions.toml'
   catalog-key:

--- a/.github/actions/preview-comment/action.yml
+++ b/.github/actions/preview-comment/action.yml
@@ -7,7 +7,14 @@ description: >
 
 inputs:
   cli-version:
-    default: 'auto'
+    # Stays 'latest', not 'auto': this shim forwards to a *pinned, released*
+    # apply ref (`apply@vX` below, bumped by release-please), which may predate
+    # the `auto` resolver and would pass `auto` straight to install as a literal
+    # version (→ 404 on `vauto/...tar.gz`). The released apply still carries the
+    # #1920 skew guardrail, so pinned-plugin consumers get a fail-fast message
+    # rather than a silent break. New consumers should call `apply` directly,
+    # where `auto` is the default.
+    default: 'latest'
   catalog-path:
     default: 'gradle/libs.versions.toml'
   catalog-key:


### PR DESCRIPTION
Closes #1920.

## Problem

`cli-version` defaulted to `latest`, so pinning the action ref (`apply@vX`) did **not** pin the CLI. Every new compose-ai-tools release floated the CLI ahead of the consumer's still-pinned Gradle plugin; the newer CLI couldn't discover the older plugin, and the render broke **repo-wide** with the misleading `✗ no modules have the compose-preview plugin applied` — tracking the release, not the diff. The *documented happy path* was the broken path.

PR #1921 added a fail-fast **guardrail** (option 2) that turns the silent break into an actionable error, but the root cause — the `latest` default — was still there, so the issue stayed open. This removes it.

## Fix (issue option 1, the "auto-detect the applied plugin" variant)

- **New `cli-version: auto`, now the default.** It sniffs the plugin version pinned in the consumer's checkout (version-catalog `[plugins]` entry or a literal `id("…") version "…"`) and installs the CLI at *exactly* that version, so the CLI and plugin can't skew. Declare the plugin version once; the CLI follows it for free (Renovate-friendly), no `catalog-key` wiring needed.
- **Falls back to `latest` when no plugin is pinned** — the auto-inject / zero-code path, where the CLI injects a matching plugin via `--init-script`, so `latest` is correct there.
- `latest` / `catalog` / literal / `source` / `none` are unchanged; set `cli-version: latest` to opt back into the old floating behaviour. The skew guardrail still backstops an explicit `latest`.
- Detection reuses the skew guard's already-tested logic via a new `detect-plugin` subcommand on `check-skew.py` (single source of truth).
- The deprecated `preview-baselines` / `preview-comment` forwarders flip to the same `auto` default.

## Behaviour matrix

| Consumer setup | Before | After |
|---|---|---|
| Pins plugin, default `cli-version` | CLI floats to `latest`, **breaks on every release** | CLI pinned to the plugin version — **skew-proof** |
| No plugin pin (auto-inject) | `latest` | `latest` (unchanged) |
| Explicit `latest` / `catalog` / literal | as set | as set (unchanged) |
| In-repo CI (`cli-version: source`) | source | source (unchanged) |

## Test plan

- `python3 .github/actions/apply/test_check_skew.py -v` — 24 tests pass, including new `DetectPluginCliTests` that drive the `detect-plugin` subcommand the way `action.yml` does (bare version on stdout from a catalog pin / a literal build-script pin; empty + rc 0 when nothing is pinned).
- Simulated the `auto` resolution shell both ways: catalog pin → resolves to `0.15.8`; no pin → resolves to `latest`.
- YAML-validated `apply` / `preview-baselines` / `preview-comment` action files.

Non-visual change (CI action wiring + docs), so no preview render evidence applies.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KoKszoUn4jduGMCgydMewx)_