### PR TITLE
fix(cli): keep discovery working when a convention plugin supplies the preview plugin

### DIFF
--- a/api/gradle-preview-driver/src/main/kotlin/ee/schimke/composeai/cli/DiscoverPreviewModulesAction.kt
+++ b/api/gradle-preview-driver/src/main/kotlin/ee/schimke/composeai/cli/DiscoverPreviewModulesAction.kt
@@ -30,20 +30,27 @@ import org.gradle.tooling.model.gradle.GradleBuild
  *
  * Per-project failure isolation: each `findModel` is wrapped so a configuration failure in a module
  * that contributes no previews is skipped, not propagated — discovery still returns the modules
- * that did resolve.
+ * that did resolve. The skipped projects are *not* discarded silently: each failure's path and
+ * message are collected into [PreviewModuleDiscoveryResult.failures] so the CLI can tell the user
+ * *which* modules failed to configure and *why* when discovery comes back empty (issue #3 —
+ * "discovery finds 0 modules" with no diagnostic was undebuggable because every per-project
+ * exception was swallowed here).
  */
-class DiscoverPreviewModulesAction : BuildAction<ArrayList<PreviewModule>>, Serializable {
-  override fun execute(controller: BuildController): ArrayList<PreviewModule> {
+class DiscoverPreviewModulesAction : BuildAction<PreviewModuleDiscoveryResult>, Serializable {
+  override fun execute(controller: BuildController): PreviewModuleDiscoveryResult {
     val build = controller.getModel(GradleBuild::class.java)
     val modules = ArrayList<PreviewModule>()
+    val failures = ArrayList<ProjectDiscoveryFailure>()
     for (project in build.projects) {
       val model =
         try {
           controller.findModel(project, ComposePreviewModel::class.java)
-        } catch (_: Throwable) {
+        } catch (t: Throwable) {
           // A configuration failure in an unrelated module (or a Gradle version whose model
           // proxy can't be built) shouldn't sink the whole discovery — drop this project and
-          // keep going. See issue #1620's "isolate failures per module" point.
+          // keep going. See issue #1620's "isolate failures per module" point. We record the
+          // failure rather than discarding it so the CLI can surface it (issue #3).
+          failures.add(ProjectDiscoveryFailure(project.path, describeFailure(t)))
           null
         } ?: continue
       // The model builder keys `modules` by the project path only when the plugin is applied to
@@ -55,6 +62,42 @@ class DiscoverPreviewModulesAction : BuildAction<ArrayList<PreviewModule>>, Seri
         }
       }
     }
-    return modules
+    return PreviewModuleDiscoveryResult(modules, failures)
+  }
+
+  /**
+   * Flattens a throwable (and its cause chain) into a one-line, daemon-safe message. We can't ship
+   * the [Throwable] itself across the Tooling-API boundary (arbitrary exception types from the
+   * configured build may not be on the CLI's classpath), so collapse it to text here. The cause
+   * chain matters: Gradle wraps the actionable failure ("Plugin ... already on the classpath with
+   * an unknown version") several layers deep behind generic configuration exceptions.
+   */
+  private fun describeFailure(t: Throwable): String {
+    val parts = LinkedHashSet<String>()
+    var current: Throwable? = t
+    var depth = 0
+    while (current != null && depth < 10) {
+      val message = current.message?.trim()
+      parts.add(
+        if (message.isNullOrEmpty()) current.javaClass.name
+        else "${current.javaClass.simpleName}: $message"
+      )
+      current = current.cause
+      depth++
+    }
+    return parts.joinToString(" -> ")
   }
 }
+
+/**
+ * Result of [DiscoverPreviewModulesAction]: the modules that resolved plus the per-project failures
+ * encountered while walking the build. Serialized across the Tooling-API daemon boundary, so both
+ * fields are plain serializable values.
+ */
+data class PreviewModuleDiscoveryResult(
+  val modules: ArrayList<PreviewModule>,
+  val failures: ArrayList<ProjectDiscoveryFailure>,
+) : Serializable
+
+/** A project that threw while its [ComposePreviewModel] was being built during discovery. */
+data class ProjectDiscoveryFailure(val path: String, val message: String) : Serializable

--- a/api/gradle-preview-driver/src/main/kotlin/ee/schimke/composeai/cli/GradleConnector.kt
+++ b/api/gradle-preview-driver/src/main/kotlin/ee/schimke/composeai/cli/GradleConnector.kt
@@ -53,6 +53,18 @@ class GradleConnection(
   val lastModelAccessFailure: GradleAccessFailure?
     get() = modelAccessFailure
 
+  private var discoveryFailures: List<ProjectDiscoveryFailure> = emptyList()
+
+  /**
+   * Per-project configuration failures recorded during the most recent [findPreviewModules] call —
+   * projects whose `ComposePreviewModel` couldn't be built and were therefore skipped. Lets callers
+   * explain an empty discovery ("3 modules failed to configure: …") instead of the bare "No preview
+   * modules discovered" that hid the real cause (issue #3). Empty when discovery succeeded for
+   * every project or hasn't run yet.
+   */
+  val lastDiscoveryFailures: List<ProjectDiscoveryFailure>
+    get() = discoveryFailures
+
   private val capturedTestFailures =
     Collections.synchronizedList(mutableListOf<CapturedTestFailure>())
 
@@ -387,9 +399,16 @@ class GradleConnection(
    * [lastModelAccessFailure] populated so callers can tell "no preview modules" from "couldn't talk
    * to Gradle." A generous timeout matches the old un-timed model query — discovery configures each
    * project, which can be slow on a cold daemon.
+   *
+   * Per-project configuration failures (a module the plugin applied to but that threw while its
+   * model was built) are recorded in [lastDiscoveryFailures] rather than silently dropped, so an
+   * empty result can be explained (issue #3).
    */
-  fun findPreviewModules(): List<PreviewModule> =
-    runBuildAction(DiscoverPreviewModulesAction(), timeoutSeconds = 300) ?: emptyList()
+  fun findPreviewModules(): List<PreviewModule> {
+    val result = runBuildAction(DiscoverPreviewModulesAction(), timeoutSeconds = 300)
+    discoveryFailures = result?.failures ?: emptyList()
+    return result?.modules ?: emptyList()
+  }
 
   /**
    * Resolve a single module by its Gradle path (colon-separated, with or without the leading `:`).

--- a/api/gradle-preview-driver/src/main/kotlin/ee/schimke/composeai/cli/GradlePreviewDriver.kt
+++ b/api/gradle-preview-driver/src/main/kotlin/ee/schimke/composeai/cli/GradlePreviewDriver.kt
@@ -48,6 +48,14 @@ class GradlePreviewDriver(projectRoot: File, private val options: DriverOptions 
     get() = connection.lastModelAccessFailure
 
   /**
+   * Per-project configuration failures from the most recent [discoverModules] call — modules that
+   * were skipped because building their `ComposePreviewModel` threw. Lets consumers explain an
+   * empty discovery instead of reporting a bare "no modules" (issue #3).
+   */
+  val lastDiscoveryFailures: List<ProjectDiscoveryFailure>
+    get() = connection.lastDiscoveryFailures
+
+  /**
    * Find every subproject that applies the `ee.schimke.composeai.preview` plugin. Detection is via
    * the plugin's `ComposePreviewModel` Tooling-API model (see [DiscoverPreviewModulesAction])
    * rather than a task-graph scan, so it avoids realizing unrelated modules' tasks during discovery

--- a/api/gradle-preview-driver/src/test/kotlin/ee/schimke/composeai/cli/DiscoverPreviewModulesActionTest.kt
+++ b/api/gradle-preview-driver/src/test/kotlin/ee/schimke/composeai/cli/DiscoverPreviewModulesActionTest.kt
@@ -134,10 +134,11 @@ class DiscoverPreviewModulesActionTest {
         }
       }
 
-    val modules = DiscoverPreviewModulesAction().execute(controller)
+    val result = DiscoverPreviewModulesAction().execute(controller)
 
-    assertEquals(listOf("ui"), modules.map { it.gradlePath })
-    assertEquals(File("/tmp/root/ui"), modules.single().projectDir)
+    assertEquals(listOf("ui"), result.modules.map { it.gradlePath })
+    assertEquals(File("/tmp/root/ui"), result.modules.single().projectDir)
+    assertTrue(result.failures.isEmpty(), "no module threw; got ${result.failures}")
   }
 
   @Test
@@ -154,9 +155,17 @@ class DiscoverPreviewModulesActionTest {
         }
       }
 
-    val modules = DiscoverPreviewModulesAction().execute(controller)
+    val result = DiscoverPreviewModulesAction().execute(controller)
 
-    assertEquals(listOf("ui"), modules.map { it.gradlePath })
+    assertEquals(listOf("ui"), result.modules.map { it.gradlePath })
+    // The poisoned module is no longer dropped silently — its failure is recorded so the CLI can
+    // surface it (issue #3).
+    assertTrue(
+      result.failures.any {
+        it.path == ":native-cli" && it.message.contains("toolchain download blocked")
+      },
+      "expected the poisoned module's failure to be recorded; got ${result.failures}",
+    )
   }
 
   @Test
@@ -164,8 +173,8 @@ class DiscoverPreviewModulesActionTest {
     val root = project(":", File("/tmp/root"))
     val controller = controller(build(listOf(root))) { model(":") }
 
-    val modules = DiscoverPreviewModulesAction().execute(controller)
+    val result = DiscoverPreviewModulesAction().execute(controller)
 
-    assertTrue(modules.isEmpty())
+    assertTrue(result.modules.isEmpty())
   }
 }

--- a/api/gradle-preview-driver/src/test/kotlin/ee/schimke/composeai/cli/DiscoverPreviewModulesIntegrationTest.kt
+++ b/api/gradle-preview-driver/src/test/kotlin/ee/schimke/composeai/cli/DiscoverPreviewModulesIntegrationTest.kt
@@ -86,7 +86,7 @@ class DiscoverPreviewModulesIntegrationTest {
       .use { connection ->
         // The fix: completes without realizing :native's poison task.
         val discovered = connection.action(DiscoverPreviewModulesAction()).run()
-        assertEquals(emptyList(), discovered.map { it.gradlePath })
+        assertEquals(emptyList(), discovered.modules.map { it.gradlePath })
 
         // Control: the old `GradleProject` discovery path realizes the task graph and dies.
         val failure =

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/AutoInject.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/AutoInject.kt
@@ -533,7 +533,11 @@ internal fun defaultInitScriptStorageDir(version: String): File =
  * - `--no-auto-inject` in [args],
  * - `COMPOSE_PREVIEW_NO_AUTO_INJECT=1` in the environment,
  * - [projectRoot]'s `settings.gradle[.kts]` declares `includeBuild("gradle-plugin")` (the
- *   compose-ai-tools dev-loop layout — running the CLI against its own samples).
+ *   compose-ai-tools dev-loop layout — running the CLI against its own samples),
+ * - an `includeBuild(...)`'d build supplies the plugin on its classpath, i.e. the plugin is applied
+ *   by a convention plugin rather than per-module `plugins { id(...) version }` (see
+ *   [includedBuildProvidesComposeAiPreviewPlugin]) — auto-injecting a second copy would collide
+ *   with it and break discovery (issue #3).
  *
  * Failures (storage dir not writable, disk full) are swallowed with a stderr note and downgrade to
  * "no auto-inject" — the CLI continues with whatever the user has manually configured.
@@ -549,6 +553,14 @@ internal fun autoInjectInitScriptArgs(
   if ("--no-auto-inject" in args) return emptyList()
   if (env("COMPOSE_PREVIEW_NO_AUTO_INJECT") == "1") return emptyList()
   if (projectRoot != null && hasIncludedPluginBuild(projectRoot)) return emptyList()
+  if (projectRoot != null && includedBuildProvidesComposeAiPreviewPlugin(projectRoot)) {
+    stderr(
+      "compose-preview: auto-inject disabled — an included build supplies the " +
+        "ee.schimke.composeai.preview plugin (applied via a convention plugin). The CLI will use " +
+        "the plugin your build already applies. Pass --no-auto-inject to silence this note."
+    )
+    return emptyList()
+  }
   return try {
     val path = materializeInitScript(storageDir, pluginVersion)
     listOf("--init-script", path.absolutePath)
@@ -579,6 +591,59 @@ internal fun hasIncludedPluginBuild(
   return candidates.any {
     it.isFile && pattern.containsMatchIn(fileSystem.read(it.path.toPath()) { readUtf8() })
   }
+}
+
+/**
+ * True when the build's root `settings.gradle[.kts]` `includeBuild(...)`s a build whose own build
+ * script puts the `ee.schimke.composeai.preview` plugin on its classpath — i.e. the plugin is
+ * supplied (and typically applied) by a *convention plugin* in an included build, not declared
+ * per-module via `plugins { id("…") version "…" }`.
+ *
+ * Why this disables auto-inject (issue #3): auto-inject decides which projects already have the
+ * plugin by scanning *module* build scripts for a literal `id(...) version` / catalog-alias
+ * declaration ([scanForComposeAiPreviewDeclaration]). A convention-plugin apply is invisible to
+ * that scan, so auto-inject would inject a *second* copy of the plugin onto every project's
+ * buildscript classpath — colliding with the copy the included build already supplies ("plugin …
+ * already on the classpath with an unknown version", the #1855 class of failure). That fails
+ * per-project configuration, and since the Tooling-API discovery walk isolates per-project
+ * failures, the CLI silently comes back with zero modules even though the render task works. When
+ * the plugin is already provided this way the right move mirrors the
+ * `includeBuild("gradle-plugin")` opt-out: leave auto-inject off and let the convention plugin own
+ * the application. The `androidchka.extras`-style convention plugin (yschimke/androidchka, which
+ * `includeBuild`s `build-logic` and stages the plugin marker on its classpath) is the motivating
+ * case.
+ *
+ * Detection is deliberately narrow: we only skip when an included build *actually references the
+ * plugin coordinate*. Merely `includeBuild("build-logic")` without the plugin (the common shape)
+ * leaves auto-inject on. Same parens-required heuristic scope as [hasIncludedPluginBuild].
+ *
+ * Visible for tests.
+ */
+internal fun includedBuildProvidesComposeAiPreviewPlugin(
+  projectRoot: File,
+  fileSystem: FileSystem = SystemFileSystem,
+): Boolean {
+  val settingsFile =
+    listOf(File(projectRoot, "settings.gradle.kts"), File(projectRoot, "settings.gradle"))
+      .firstOrNull { it.isFile } ?: return false
+  val settingsText =
+    runCatching { fileSystem.read(settingsFile.path.toPath()) { readUtf8() } }.getOrNull()
+      ?: return false
+  val includeBuildRe = Regex("""includeBuild\s*\(\s*["']([^"']+)["']\s*\)""")
+  val includedDirs =
+    includeBuildRe.findAll(stripGradleComments(settingsText)).map { it.groupValues[1] }.toList()
+  if (includedDirs.isEmpty()) return false
+  val pluginRe = Regex("""ee\.schimke\.composeai\.preview""")
+  for (dir in includedDirs) {
+    val buildScript =
+      listOf(File(projectRoot, "$dir/build.gradle.kts"), File(projectRoot, "$dir/build.gradle"))
+        .firstOrNull { it.isFile } ?: continue
+    val text =
+      runCatching { fileSystem.read(buildScript.path.toPath()) { readUtf8() } }.getOrNull()
+        ?: continue
+    if (pluginRe.containsMatchIn(stripGradleComments(text))) return true
+  }
+  return false
 }
 
 /**

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/AutoInject.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/AutoInject.kt
@@ -617,6 +617,12 @@ internal fun hasIncludedPluginBuild(
  * plugin coordinate*. Merely `includeBuild("build-logic")` without the plugin (the common shape)
  * leaves auto-inject on. Same parens-required heuristic scope as [hasIncludedPluginBuild].
  *
+ * The scan is recursive across each included build, not just its root build script: a multi-project
+ * convention build commonly declares the plugin dependency in a subproject
+ * (`build-logic/conventions/build.gradle.kts`) rather than the root (PR #1939 review). We walk
+ * every `build.gradle[.kts]` under the included build, pruning generated/output trees (`build/`,
+ * `.gradle/`, …) and bounding the traversal so a pathological tree can't stall the CLI.
+ *
  * Visible for tests.
  */
 internal fun includedBuildProvidesComposeAiPreviewPlugin(
@@ -633,15 +639,46 @@ internal fun includedBuildProvidesComposeAiPreviewPlugin(
   val includedDirs =
     includeBuildRe.findAll(stripGradleComments(settingsText)).map { it.groupValues[1] }.toList()
   if (includedDirs.isEmpty()) return false
-  val pluginRe = Regex("""ee\.schimke\.composeai\.preview""")
-  for (dir in includedDirs) {
-    val buildScript =
-      listOf(File(projectRoot, "$dir/build.gradle.kts"), File(projectRoot, "$dir/build.gradle"))
-        .firstOrNull { it.isFile } ?: continue
-    val text =
-      runCatching { fileSystem.read(buildScript.path.toPath()) { readUtf8() } }.getOrNull()
-        ?: continue
-    if (pluginRe.containsMatchIn(stripGradleComments(text))) return true
+  return includedDirs.any { dir ->
+    buildScriptsReferenceComposeAiPreview(File(projectRoot, dir), fileSystem)
+  }
+}
+
+/**
+ * Directory names never worth descending into when scanning an included build for build scripts.
+ */
+private val COMPOSE_AI_PREVIEW_SCAN_SKIP_DIRS =
+  setOf("build", ".gradle", ".git", ".idea", "node_modules")
+
+/**
+ * Walks [buildDir] for any `build.gradle[.kts]` whose (comment-stripped) text references the
+ * `ee.schimke.composeai.preview` coordinate. Iterative DFS over [fileSystem] that prunes
+ * generated/output dirs and caps the number of directories visited so it stays cheap on large or
+ * adversarial trees. Used only by [includedBuildProvidesComposeAiPreviewPlugin].
+ */
+private fun buildScriptsReferenceComposeAiPreview(
+  buildDir: File,
+  fileSystem: FileSystem,
+  maxDirs: Int = 500,
+): Boolean {
+  val coordinate = Regex("""ee\.schimke\.composeai\.preview""")
+  val root = buildDir.path.toPath()
+  if (fileSystem.metadataOrNull(root)?.isDirectory != true) return false
+  val stack = ArrayDeque<okio.Path>().apply { addLast(root) }
+  var visited = 0
+  while (stack.isNotEmpty() && visited < maxDirs) {
+    val current = stack.removeLast()
+    visited++
+    val entries = runCatching { fileSystem.list(current) }.getOrNull() ?: continue
+    for (entry in entries) {
+      val metadata = runCatching { fileSystem.metadataOrNull(entry) }.getOrNull()
+      if (metadata?.isDirectory == true) {
+        if (entry.name !in COMPOSE_AI_PREVIEW_SCAN_SKIP_DIRS) stack.addLast(entry)
+      } else if (entry.name == "build.gradle.kts" || entry.name == "build.gradle") {
+        val text = runCatching { fileSystem.read(entry) { readUtf8() } }.getOrNull() ?: continue
+        if (coordinate.containsMatchIn(stripGradleComments(text))) return true
+      }
+    }
   }
   return false
 }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -315,6 +315,7 @@ abstract class Command(
         System.err.println(
           "Module '$explicitModule' not found or does not apply the compose-ai-tools plugin."
         )
+        printDiscoveryFailures(gradle.lastDiscoveryFailures)
         exitProcess(1)
       }
       return listOf(one)
@@ -332,6 +333,7 @@ abstract class Command(
         exitProcess(1)
       }
       System.err.println("No preview modules discovered in this project.")
+      printDiscoveryFailures(gradle.lastDiscoveryFailures)
       exitProcess(1)
     }
     if (verbose || modules.size > 1) {
@@ -741,6 +743,29 @@ abstract class Command(
  * disagree the CLI fails the job while the comparison tool reports nothing — a red check with no
  * comment explaining it.
  */
+/**
+ * Prints per-project discovery failures (modules skipped because building their
+ * `ComposePreviewModel` threw) to stderr. Called after a discovery comes back empty so the user
+ * sees *why* — not the bare "No preview modules discovered" that hid the cause (issue #3). The
+ * convention-plugin double-apply collision, an unresolved classpath dep, or a config-cache problem
+ * all show up here. No-op when there were no failures (a genuinely plugin-free build). Capped so a
+ * large multi-module build doesn't flood the terminal.
+ */
+internal fun printDiscoveryFailures(
+  failures: List<ProjectDiscoveryFailure>,
+  limit: Int = 10,
+  err: (String) -> Unit = System.err::println,
+) {
+  if (failures.isEmpty()) return
+  err(
+    "${failures.size} project(s) failed to configure during discovery and were skipped — " +
+      "their previews are not listed. This is the usual cause of an empty discovery when the " +
+      "render task itself works. Rerun with --verbose for full Gradle output."
+  )
+  failures.take(limit).forEach { err("  ${it.path}: ${it.message}") }
+  if (failures.size > limit) err("  … and ${failures.size - limit} more")
+}
+
 internal val NON_PNG_PREVIEW_KINDS = setOf("XR_SUBSPACE")
 
 /**

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
@@ -410,15 +410,32 @@ class DoctorCommand(
     }
 
     if (model.modules.isEmpty()) {
+      // Per-project model-build failures are the usual reason discovery comes back empty while the
+      // render task works (issue #3) — surface them so the user isn't left guessing.
+      val failureDetail =
+        model.failures
+          .takeIf { it.isNotEmpty() }
+          ?.let { fs ->
+            "${fs.size} project(s) failed to configure during discovery and were skipped: " +
+              fs.take(10).joinToString("; ") { "${it.path}: ${it.message}" } +
+              if (fs.size > 10) " (… and ${fs.size - 10} more)" else ""
+          }
       addCheck(
         DoctorCheck(
           id = "project.plugin-applied",
           category = "project",
           status = "error",
           message = "no modules have the compose-preview plugin applied",
+          detail = failureDetail,
           remediation =
             DoctorRemediation(
-              summary = "Apply the plugin in your module's `plugins { }` block.",
+              summary =
+                if (failureDetail != null)
+                  "Projects failed to configure during discovery — rerun with --verbose for full " +
+                    "Gradle output. If the plugin is applied via a convention plugin, the CLI now " +
+                    "skips auto-inject automatically; otherwise apply it in your module's " +
+                    "`plugins { }` block."
+                else "Apply the plugin in your module's `plugins { }` block.",
               commands =
                 listOf(
                   "id(\"ee.schimke.composeai.preview\") version \"$recommendedPluginVersion\""

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/GatherComposePreviewModelAction.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/GatherComposePreviewModelAction.kt
@@ -25,12 +25,15 @@ class GatherComposePreviewModelAction : BuildAction<AggregatedComposePreviewMode
   override fun execute(controller: BuildController): AggregatedComposePreviewModel {
     val build = controller.getModel(GradleBuild::class.java)
     val aggregated = linkedMapOf<String, SerializableModuleInfo>()
+    val failures = ArrayList<ProjectDiscoveryFailure>()
     var pluginVersion = ""
     for (project in build.projects) {
       val model =
         try {
           controller.findModel(project, ComposePreviewModel::class.java)
-        } catch (_: Throwable) {
+        } catch (t: Throwable) {
+          // Record rather than silently drop so `doctor` can explain an empty result (issue #3).
+          failures.add(ProjectDiscoveryFailure(project.path, t.message ?: t.javaClass.name))
           null
         } ?: continue
       if (model.pluginVersion.isNotEmpty()) pluginVersion = model.pluginVersion
@@ -75,7 +78,7 @@ class GatherComposePreviewModelAction : BuildAction<AggregatedComposePreviewMode
           )
       }
     }
-    return AggregatedComposePreviewModel(pluginVersion, aggregated)
+    return AggregatedComposePreviewModel(pluginVersion, aggregated, failures)
   }
 
   /**
@@ -100,6 +103,13 @@ class GatherComposePreviewModelAction : BuildAction<AggregatedComposePreviewMode
 data class AggregatedComposePreviewModel(
   override val pluginVersion: String,
   override val modules: Map<String, SerializableModuleInfo>,
+  /**
+   * Per-project failures encountered while building each module's model — projects skipped because
+   * `findModel` threw. Carried alongside the (interface-defined) [modules] so `doctor` can explain
+   * an empty result instead of reporting a bare "no modules applied" (issue #3). Defaulted so older
+   * call sites / deserialization paths that don't set it still construct.
+   */
+  val failures: List<ProjectDiscoveryFailure> = emptyList(),
 ) : ComposePreviewModel, Serializable
 
 data class SerializableModuleInfo(

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/McpCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/McpCommand.kt
@@ -147,6 +147,7 @@ internal class McpCommand(
           if (moduleFilter.isEmpty()) "no modules apply the compose-preview plugin"
           else "none of --module ${moduleFilter.joinToString(",")} apply the plugin"
         System.err.println("compose-preview mcp install: $msg")
+        printDiscoveryFailures(driver.lastDiscoveryFailures)
         exitProcess(2)
       }
 
@@ -377,6 +378,7 @@ internal class McpCommand(
 
       if (modules.isEmpty()) {
         System.err.println("compose-preview mcp doctor: no matching modules apply the plugin")
+        printDiscoveryFailures(driver.lastDiscoveryFailures)
         exitProcess(2)
       }
 

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/AutoInjectTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/AutoInjectTest.kt
@@ -865,4 +865,127 @@ class AutoInjectTest {
       "expected a stderr note about the disabled auto-inject path; got $warnings",
     )
   }
+
+  // --- Convention-plugin provision detection (issue #3) -----------------------------------------
+
+  /**
+   * Lays out the androidchka shape: root settings `includeBuild`s build-logic, whose build script
+   * stages the ee.schimke.composeai.preview plugin marker on its classpath.
+   */
+  private fun seedConventionPluginBuild(
+    projectRoot: File,
+    includeIn: String = "pluginManagement { includeBuild(\"build-logic\") }",
+    buildLogicScript: String =
+      "implementation(\"ee.schimke.composeai.preview:ee.schimke.composeai.preview.gradle.plugin:0.15.12\")",
+  ) {
+    File(projectRoot, "settings.gradle.kts")
+      .writeText(
+        """
+        $includeIn
+        rootProject.name = "androidx-mini"
+        include(":app")
+        """
+          .trimIndent()
+      )
+    File(projectRoot, "build-logic").mkdirs()
+    File(projectRoot, "build-logic/build.gradle.kts")
+      .writeText(
+        """
+        plugins { `kotlin-dsl` }
+        dependencies {
+          $buildLogicScript
+        }
+        """
+          .trimIndent()
+      )
+  }
+
+  @Test
+  fun `includedBuildProvidesComposeAiPreviewPlugin detects convention-plugin classpath provision`() {
+    val projectRoot = tempDir()
+    seedConventionPluginBuild(projectRoot)
+    assertTrue(includedBuildProvidesComposeAiPreviewPlugin(projectRoot))
+  }
+
+  @Test
+  fun `includedBuildProvidesComposeAiPreviewPlugin is false when build-logic does not reference the plugin`() {
+    val projectRoot = tempDir()
+    // The exact shape of the existing "stays on when includeBuilds something else" test, now with a
+    // real build-logic dir on disk that genuinely doesn't supply the plugin.
+    File(projectRoot, "settings.gradle.kts")
+      .writeText("pluginManagement { includeBuild(\"build-logic\") }\ninclude(\":app\")\n")
+    File(projectRoot, "build-logic").mkdirs()
+    File(projectRoot, "build-logic/build.gradle.kts")
+      .writeText(
+        "plugins { `kotlin-dsl` }\ndependencies { implementation(\"com.gradleup.tapmoc:tapmoc-gradle-plugin:0.4.2\") }\n"
+      )
+    assertFalse(includedBuildProvidesComposeAiPreviewPlugin(projectRoot))
+  }
+
+  @Test
+  fun `includedBuildProvidesComposeAiPreviewPlugin is false with no included build at all`() {
+    val projectRoot = tempDir()
+    File(projectRoot, "settings.gradle.kts")
+      .writeText("rootProject.name = \"demo\"\ninclude(\":app\")\n")
+    assertFalse(includedBuildProvidesComposeAiPreviewPlugin(projectRoot))
+  }
+
+  @Test
+  fun `includedBuildProvidesComposeAiPreviewPlugin ignores a commented-out plugin reference`() {
+    val projectRoot = tempDir()
+    seedConventionPluginBuild(
+      projectRoot,
+      buildLogicScript =
+        "// implementation(\"ee.schimke.composeai.preview:ee.schimke.composeai.preview.gradle.plugin:0.15.12\")",
+    )
+    assertFalse(
+      includedBuildProvidesComposeAiPreviewPlugin(projectRoot),
+      "a commented-out classpath dep must not count as provision",
+    )
+  }
+
+  @Test
+  fun `autoInjectInitScriptArgs disables auto-inject when a convention plugin supplies the plugin`() {
+    val storage = tempDir()
+    val projectRoot = tempDir()
+    seedConventionPluginBuild(projectRoot)
+    val warnings = mutableListOf<String>()
+    val out =
+      autoInjectInitScriptArgs(
+        args = emptyList(),
+        pluginVersion = "0.15.12",
+        storageDir = storage,
+        env = { null },
+        projectRoot = projectRoot,
+        stderr = { warnings += it },
+      )
+    assertTrue(
+      out.isEmpty(),
+      "expected no --init-script when a convention plugin supplies the plugin; got $out",
+    )
+    assertFalse(File(storage, INIT_SCRIPT_FILENAME).exists())
+    assertTrue(
+      warnings.any { it.contains("auto-inject disabled") && it.contains("convention plugin") },
+      "expected an explanatory stderr note; got $warnings",
+    )
+  }
+
+  @Test
+  fun `autoInjectInitScriptArgs stays on when build-logic is present but plugin-free`() {
+    val storage = tempDir()
+    val projectRoot = tempDir()
+    File(projectRoot, "settings.gradle.kts")
+      .writeText("pluginManagement { includeBuild(\"build-logic\") }\ninclude(\":app\")\n")
+    File(projectRoot, "build-logic").mkdirs()
+    File(projectRoot, "build-logic/build.gradle.kts").writeText("plugins { `kotlin-dsl` }\n")
+    val out =
+      autoInjectInitScriptArgs(
+        args = emptyList(),
+        pluginVersion = "0.15.12",
+        storageDir = storage,
+        env = { null },
+        projectRoot = projectRoot,
+      )
+    assertEquals(listOf("--init-script", File(storage, INIT_SCRIPT_FILENAME).absolutePath), out)
+  }
 }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/AutoInjectTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/AutoInjectTest.kt
@@ -923,6 +923,38 @@ class AutoInjectTest {
   }
 
   @Test
+  fun `includedBuildProvidesComposeAiPreviewPlugin detects the dep in an included-build subproject`() {
+    // Multi-project convention build: the plugin dep lives in build-logic/conventions, not the
+    // build-logic root script (PR #1939 review). The recursive scan must still find it.
+    val projectRoot = tempDir()
+    File(projectRoot, "settings.gradle.kts")
+      .writeText("pluginManagement { includeBuild(\"build-logic\") }\ninclude(\":app\")\n")
+    File(projectRoot, "build-logic").mkdirs()
+    File(projectRoot, "build-logic/build.gradle.kts").writeText("// aggregator, no deps here\n")
+    File(projectRoot, "build-logic/conventions").mkdirs()
+    File(projectRoot, "build-logic/conventions/build.gradle.kts")
+      .writeText(
+        "plugins { `kotlin-dsl` }\ndependencies { implementation(\"ee.schimke.composeai.preview:ee.schimke.composeai.preview.gradle.plugin:0.15.12\") }\n"
+      )
+    assertTrue(includedBuildProvidesComposeAiPreviewPlugin(projectRoot))
+  }
+
+  @Test
+  fun `includedBuildProvidesComposeAiPreviewPlugin ignores matches under a build output dir`() {
+    // A stale copy of the coordinate under build-logic/build/ (generated output) must not count —
+    // the scan prunes output trees.
+    val projectRoot = tempDir()
+    File(projectRoot, "settings.gradle.kts")
+      .writeText("pluginManagement { includeBuild(\"build-logic\") }\ninclude(\":app\")\n")
+    File(projectRoot, "build-logic").mkdirs()
+    File(projectRoot, "build-logic/build.gradle.kts").writeText("plugins { `kotlin-dsl` }\n")
+    File(projectRoot, "build-logic/build/generated").mkdirs()
+    File(projectRoot, "build-logic/build/generated/build.gradle.kts")
+      .writeText("implementation(\"ee.schimke.composeai.preview:...\")\n")
+    assertFalse(includedBuildProvidesComposeAiPreviewPlugin(projectRoot))
+  }
+
+  @Test
   fun `includedBuildProvidesComposeAiPreviewPlugin is false with no included build at all`() {
     val projectRoot = tempDir()
     File(projectRoot, "settings.gradle.kts")

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/DiscoveryFailureReportingTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/DiscoveryFailureReportingTest.kt
@@ -1,0 +1,47 @@
+package ee.schimke.composeai.cli
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Unit coverage for [printDiscoveryFailures] — the stderr surfacing that turns an empty discovery
+ * into an explanation of *which* modules failed to configure and *why* (issue #3). Pure-function
+ * style: a capturing sink stands in for `System.err`.
+ */
+class DiscoveryFailureReportingTest {
+
+  @Test
+  fun `no output when there are no failures`() {
+    val lines = mutableListOf<String>()
+    printDiscoveryFailures(emptyList(), err = { lines += it })
+    assertTrue(lines.isEmpty(), "expected silence for a genuinely plugin-free build; got $lines")
+  }
+
+  @Test
+  fun `prints a header plus one line per failing project`() {
+    val lines = mutableListOf<String>()
+    printDiscoveryFailures(
+      listOf(
+        ProjectDiscoveryFailure(":app", "PluginApplicationException: already on the classpath"),
+        ProjectDiscoveryFailure(":lib", "Cannot resolve external dependency"),
+      ),
+      err = { lines += it },
+    )
+    assertTrue(lines.first().contains("2 project(s) failed to configure"), "got ${lines.first()}")
+    assertTrue(lines.any { it.contains(":app:") && it.contains("already on the classpath") })
+    assertTrue(
+      lines.any { it.contains(":lib:") && it.contains("Cannot resolve external dependency") }
+    )
+  }
+
+  @Test
+  fun `caps the per-project lines and reports the remainder`() {
+    val failures = (1..15).map { ProjectDiscoveryFailure(":m$it", "boom") }
+    val lines = mutableListOf<String>()
+    printDiscoveryFailures(failures, limit = 10, err = { lines += it })
+    // 1 header + 10 detail lines + 1 "and N more" line.
+    assertEquals(12, lines.size, "got $lines")
+    assertTrue(lines.last().contains("and 5 more"), "got ${lines.last()}")
+  }
+}


### PR DESCRIPTION
## Summary

CLI/MCP module discovery returned **0 modules** under builds that apply `ee.schimke.composeai.preview` via a *convention plugin* in an included build (androidchka's `androidchka.extras` + `build-logic`), even though the Gradle render tasks (`composePreviewRenderAll`) discovered and rendered previews fine. That left `compose-preview list`/`show`, `mcp doctor`/`install`, and the interactive MCP preview loop unusable there ([yschimke/androidchka#3](https://github.com/yschimke/androidchka/issues/3)). Two root causes, both fixed:

1. **Auto-inject double-applied the plugin.** `autoInjectInitScriptArgs` decides which modules already declare the plugin by scanning *module* build scripts for `id("…") version` / `alias(libs.plugins.…)`. A convention-plugin apply is invisible to that scan, so the CLI injected a **second** copy of the plugin onto every project's buildscript classpath — colliding with the copy the included build already supplies (the "plugin … already on the classpath with an unknown version" / #1855 failure class), which fails per-project configuration. Now `includedBuildProvidesComposeAiPreviewPlugin` detects when an `includeBuild(...)`'d build references the plugin coordinate and skips auto-inject, mirroring the existing `includeBuild("gradle-plugin")` opt-out (with a one-line stderr note explaining why). Detection is deliberately narrow — merely `includeBuild("build-logic")` *without* the plugin keeps auto-inject on, preserving existing behavior.

2. **Discovery swallowed per-project failures silently.** `DiscoverPreviewModulesAction` and `GatherComposePreviewModelAction` dropped any project whose `findModel` threw with a bare `catch { null }`, so an empty discovery had no diagnostic — the core reason this was undebuggable. They now collect per-project failures (`ProjectDiscoveryFailure`), and the CLI surfaces them on stderr (and in `doctor`) when discovery comes back empty.

## Test plan

- `./gradlew :gradle-preview-driver:compileTestKotlin :cli:compileTestKotlin` — **BUILD SUCCESSFUL**.
- `./gradlew :cli:test :gradle-preview-driver:test` (targeted classes) — **BUILD SUCCESSFUL**:
  - `AutoInjectTest` — new: convention-plugin classpath provision skips auto-inject; a plugin-free `build-logic` keeps it on; commented-out refs don't count; explanatory stderr note emitted.
  - `DiscoverPreviewModulesActionTest` — updated: a poisoned module's failure is now **recorded**, not silently dropped.
  - `DiscoveryFailureReportingTest` — new: stderr surfacing (header, per-project lines, cap + remainder).
- Could **not** run the end-to-end androidchka repro in this environment (no Android SDK / androidx checkout); verification is unit-level plus the analysis in androidchka#3. The Maven Central availability of `ee.schimke.composeai.preview.gradle.plugin:0.15.12` (the path androidchka resolves) was confirmed independently.

## Follow-up (not in this PR)

The VS Code extension has its own auto-inject decision (`initScript.ts`); for parity it should get the same convention-plugin opt-out.

Refs yschimke/androidchka#3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0184za5d2Ekf8C87EHFXL2AU)_