### PR TITLE
feat: produce layout/inspector on desktop and unify modifier-token resolution

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/LayoutInspectorExtension.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/LayoutInspectorExtension.kt
@@ -26,10 +26,14 @@ class LayoutInspectorExtension : PostCaptureProcessor {
     val rootDir = context.require(RenderDataArtifactContextKeys.RootDir)
     val outputBaseName = context.require(RenderDataArtifactContextKeys.OutputBaseName)
     val previewContext = context.require(RenderDataArtifactContextKeys.LayoutInspectorPreviewContext)
+    // Density (dp = px / density) only matters for resolving percent-based corner radii into dp on
+    // the per-node `tokens` the producer now carries (#1903); 1f keeps px-equals-dp captures intact.
+    val density = context.get(RenderDataArtifactContextKeys.Density) ?: 1f
     LayoutInspectorDataProducer.writeArtifacts(
       rootDir = rootDir,
       previewId = outputBaseName,
       previewContext = previewContext,
+      density = density,
     )
   }
 

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -494,6 +494,21 @@ class RenderEngine(
             root = root,
             density = density,
           )
+          // `layout-inspector.json` — the `layout/inspector` data product. Previously Android-only:
+          // the desktop registry advertised the kind but nothing wrote the file, so `data/fetch`
+          // degraded to `NotAvailable` (#1903). Write it from the same captured root + slot tables,
+          // through the CMP-portable `LayoutInspectorDataProducer` overload. This is the canonical
+          // home for the modifier-derived design `tokens` the producer now resolves once and
+          // mirrors
+          // onto `compose/semantics`. The Z-sorted child walk is valid here because
+          // `scene.render()` has already measured + drawn (and thus Z-sorted) the layout tree.
+          LayoutInspectorDataProducer.writeArtifacts(
+            rootDir = dataDir,
+            previewId = previewId,
+            root = root,
+            slotTables = state.slotTableCapture?.snapshot().orEmpty(),
+            density = density,
+          )
           ComposeSemanticsWireframeDataProducer.writeSvg(
             rootDir = dataDir,
             previewId = previewId,

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopLayoutInspectorTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopLayoutInspectorTest.kt
@@ -1,0 +1,116 @@
+@file:OptIn(androidx.compose.ui.ExperimentalComposeUiApi::class)
+
+package ee.schimke.composeai.daemon
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.ImageComposeScene
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.SemanticsNode
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.dp
+import ee.schimke.composeai.data.layoutinspector.LayoutInspectorNode
+import ee.schimke.composeai.data.layoutinspector.LayoutInspectorPayload
+import java.io.File
+import java.nio.file.Files
+import kotlinx.serialization.json.Json
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Pins the desktop `layout/inspector` producer (issue #1903). Before this the desktop backend
+ * registered [LayoutInspectorDataProductRegistry] but never wrote `layout-inspector.json`, so the
+ * kind degraded to `NotAvailable` on `data/fetch` — `layout/inspector` was Android-only. This
+ * drives the CMP-portable [LayoutInspectorDataProducer.writeArtifacts] overload against a real
+ * [ImageComposeScene] and asserts the produced tree carries the structural facts (a non-empty
+ * subtree with bounds + size) and the resolved design `tokens` the shared [ModifierTokenResolver]
+ * now mirrors across both products. Companion to [DesktopSemanticsTokensTest].
+ */
+class DesktopLayoutInspectorTest {
+
+  private lateinit var rootDir: File
+
+  @Before
+  fun setUp() {
+    rootDir = Files.createTempDirectory("desktop-layout-inspector").toFile()
+  }
+
+  @After
+  fun tearDown() {
+    rootDir.deleteRecursively()
+  }
+
+  private fun writeAndRead(
+    previewId: String = "preview",
+    density: Float = 1.0f,
+    content: @Composable () -> Unit,
+  ): LayoutInspectorNode {
+    val scene =
+      ImageComposeScene(width = 400, height = 400, density = Density(density), content = content)
+    try {
+      scene.render()
+      val root: SemanticsNode = scene.semanticsOwners.first().unmergedRootSemanticsNode
+      LayoutInspectorDataProducer.writeArtifacts(
+        rootDir = rootDir,
+        previewId = previewId,
+        root = root,
+        density = density,
+      )
+    } finally {
+      scene.close()
+    }
+    val file = rootDir.resolve(previewId).resolve(LayoutInspectorDataProducer.FILE)
+    assertTrue("expected $file to be written", file.exists())
+    return Json.decodeFromString(LayoutInspectorPayload.serializer(), file.readText()).root
+  }
+
+  private fun LayoutInspectorNode.firstWhere(
+    predicate: (LayoutInspectorNode) -> Boolean
+  ): LayoutInspectorNode? {
+    if (predicate(this)) return this
+    return children.firstNotNullOfOrNull { it.firstWhere(predicate) }
+  }
+
+  @Test
+  fun writes_a_non_empty_layout_tree_on_desktop() {
+    val root = writeAndRead {
+      Box(Modifier.testTag("card").size(120.dp, 60.dp).background(Color.White)) { Text("hello") }
+    }
+
+    // The root is produced and carries a real measured size + a populated subtree — proving the
+    // reflection walk reaches `LayoutNode` children after `scene.render()` Z-sorts the tree.
+    assertTrue("root must have a measured width", root.size.width > 0)
+    assertTrue("root must have a non-empty subtree", root.children.isNotEmpty())
+  }
+
+  @Test
+  fun resolves_container_tokens_onto_layout_inspector_nodes() {
+    val root = writeAndRead {
+      Box(
+        Modifier.testTag("card")
+          .background(Color(0xFF006A60), RoundedCornerShape(12.dp))
+          .padding(16.dp)
+      ) {
+        Text("Card body")
+      }
+    }
+
+    val card = root.firstWhere { it.tokens?.backgroundColor == "#FF006A60" }
+    assertNotNull("a node must carry the resolved background token", card)
+    val tokens = card!!.tokens!!
+    assertEquals("12.0dp", tokens.cornerRadius)
+    assertEquals("16.0dp", tokens.padding?.start)
+    assertEquals("16.0dp", tokens.padding?.bottom)
+  }
+}

--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
@@ -3,7 +3,6 @@ package ee.schimke.composeai.daemon
 import androidx.compose.runtime.tooling.CompositionData
 import androidx.compose.runtime.tooling.CompositionGroup
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.layout.ModifierInfo
@@ -15,7 +14,6 @@ import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.text.TextLayoutResult
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.TextUnitType
 import ee.schimke.composeai.daemon.protocol.DataProductCapability
 import ee.schimke.composeai.daemon.protocol.DataProductFacet
@@ -140,16 +138,14 @@ object ComposeSemanticsDataProducer {
 
   /**
    * Projects the design-token data carried by this node's Compose modifiers (issue #1897): the
-   * resolved container colour (`Modifier.background`, which `Surface`/`Card` apply), the corner
-   * radius of its `background` / `clip` / `border` shape, and its `Modifier.padding`. Returns null
+   * resolved container colour (`Modifier.background`, which `Surface`/`Card` apply), the outline
+   * colour (`Modifier.border`), the corner radius / shape of its `background` / `clip` / `border`
+   * shape, the `Arrangement` gap of its measure policy, and its `Modifier.padding`. Returns null
    * when the node declares none of them — the common case for pure layout / text nodes.
    *
-   * Modifiers are read off the node's [LayoutInfo.getModifierInfo] entries. The preferred source is
-   * each entry's [InspectableValue] projection (the same `nameFallback` / `inspectableElements`
-   * surface the layout inspector uses), but some foundation elements (notably `BackgroundElement`)
-   * don't populate inspector info on the desktop/skiko build, so each lookup falls back to
-   * reflecting the element's backing field. Reflection (rather than a `compose.foundation` compile
-   * dependency) also keeps this module foundation-free, matching the layout inspector's approach.
+   * The actual modifier → token resolution lives in [ModifierTokenResolver] so it is computed in
+   * one place shared with `layout/inspector` (issue #1903) rather than duplicated per product; this
+   * just gathers the per-node inputs (modifier chain, measure policy, measured size, density).
    */
   private fun SemanticsNode.resolvedTokens(density: Float): ComposeSemanticsTokens? {
     val modifiers =
@@ -158,280 +154,17 @@ object ComposeSemanticsDataProducer {
       } catch (_: Throwable) {
         return null
       }
-    var backgroundColor: String? = null
-    var borderColor: String? = null
-    var cornerRadius: String? = null
-    var shape: String? = null
-    var padding: ComposeSemanticsInsets? = null
-    // `CircleShape` / `CornerSize(50%)` resolve to dp against the node's shorter measured side.
-    val minSidePx = minOf(size.width, size.height)
-    for (info in modifiers) {
-      val mod = info.modifier
-      val inspectable = mod as? InspectableValue
-      val name = inspectable?.nameFallback
-      val elements = inspectable?.inspectableElements?.associate { it.name to it.value }.orEmpty()
-      val simpleName = mod.javaClass.simpleName
-
-      if (backgroundColor == null && (name == "background" || simpleName == "BackgroundElement")) {
-        backgroundColor = backgroundColorHex(mod, elements, inspectable?.valueOverride)
-      }
-      // `Modifier.border` carries the outline colour `Surface`/`Card`/dividers apply — a role
-      // colour
-      // (`outline` / `outlineVariant`) a plain `Modifier.background` never sees (issue #1908).
-      if (borderColor == null && (name == "border" || simpleName.startsWith("BorderModifier"))) {
-        borderColor = borderColorHex(mod, elements)
-      }
-      if (padding == null && (name == "padding" || simpleName.startsWith("PaddingElement"))) {
-        padding = paddingInsets(mod, elements, inspectable?.valueOverride)
-      }
-      // Shape comes from any shape-bearing modifier: `background(color, shape)`, `clip(shape)`
-      // (which Compose routes through `graphicsLayer`), or `border(..., shape)`. A plain rectangle
-      // yields null for both fields and is skipped.
-      val nodeShape = shapeOf(mod, elements)
-      if (nodeShape != null) {
-        if (cornerRadius == null) cornerRadius = nodeShape.cornerRadiusWire(minSidePx, density)
-        if (shape == null) shape = nodeShape.shapeDescriptor()
-      }
-    }
-    val gap = arrangementGapWire()
-    return if (
-      backgroundColor == null &&
-        borderColor == null &&
-        cornerRadius == null &&
-        shape == null &&
-        gap == null &&
-        padding == null
-    )
-      null
-    else
-      ComposeSemanticsTokens(
-        backgroundColor = backgroundColor,
-        borderColor = borderColor,
-        cornerRadius = cornerRadius,
-        shape = shape,
-        gap = gap,
-        padding = padding,
-      )
-  }
-
-  /**
-   * Resolves the inter-child spacing of a `Row`/`Column` from its measure policy (issue #1908).
-   * `Arrangement.spacedBy(n)` is stored on the `Row`/`Column`MeasurePolicy as an
-   * `Arrangement.HorizontalOrVertical` whose `spacing` `Dp` is kept in a `spacing` float field; the
-   * value-class `getSpacing` getter is name-mangled, so the field is read directly. Reflection (not
-   * a `compose.foundation` dependency) keeps this module foundation-free, matching the rest of the
-   * extractor. Returns null when the layout has no arrangement spacing.
-   */
-  private fun SemanticsNode.arrangementGapWire(): String? {
-    val policy =
+    val measurePolicy =
       runCatching { layoutInfo.javaClass.getMethod("getMeasurePolicy").invoke(layoutInfo) }
-        .getOrNull() ?: return null
-    var cls: Class<*>? = policy.javaClass
-    while (cls != null && cls != Any::class.java) {
-      for (field in cls.declaredFields) {
-        val value =
-          runCatching { field.apply { isAccessible = true }.get(policy) }.getOrNull() ?: continue
-        if (!value.javaClass.name.startsWith("androidx.compose.foundation.layout.Arrangement"))
-          continue
-        val spacing =
-          runCatching {
-              value.javaClass
-                .getDeclaredField("spacing")
-                .apply { isAccessible = true }
-                .getFloat(value)
-            }
-            .getOrNull() ?: continue
-        if (spacing > 0f) return "${spacing}dp"
-      }
-      cls = cls.superclass
-    }
-    return null
+        .getOrNull()
+    return ModifierTokenResolver.resolve(
+      modifierInfo = modifiers,
+      measurePolicy = measurePolicy,
+      sizeWidthPx = size.width,
+      sizeHeightPx = size.height,
+      density = density,
+    )
   }
-
-  /**
-   * Resolves a `background` modifier's fill colour as ARGB hex. Reads the inspector `color` element
-   * / `valueOverride` when present; otherwise reflects `BackgroundElement`'s `color` field — a
-   * [Color] value class stored as its packed `ULong`. For sRGB colours (the common case) the ARGB
-   * is the high 32 bits; brushes and non-sRGB packings are skipped rather than mis-decoded.
-   */
-  private fun backgroundColorHex(
-    mod: Any,
-    elements: Map<String, Any?>,
-    valueOverride: Any?,
-  ): String? {
-    ((elements["color"] ?: valueOverride) as? Color)?.let {
-      return if (it == Color.Unspecified) null else colorToWireString(it)
-    }
-    return runCatching {
-        val field = mod.javaClass.getDeclaredField("color").apply { isAccessible = true }
-        val packed = field.getLong(mod).toULong()
-        // sRGB packs the colour space id (non-zero) into the low 32 bits as 0; anything else is a
-        // wide-gamut/unspecified packing we can't read as a plain ARGB hex.
-        if (packed and 0xFFFFFFFFuL != 0uL) return null
-        val argb = (packed shr 32).toInt()
-        if (argb == 0) null else "#${String.format(Locale.US, "%08X", argb)}"
-      }
-      .getOrNull()
-  }
-
-  /**
-   * Resolves a `border` modifier's stroke colour as ARGB hex. `Modifier.border` projects its colour
-   * through the inspector `color` element even when the brush is a plain `SolidColor`; that's read
-   * first, falling back to reflecting the backing `brush` field's `SolidColor.value`. A gradient
-   * brush (no single colour) is skipped (issue #1908).
-   */
-  private fun borderColorHex(mod: Any, elements: Map<String, Any?>): String? {
-    (elements["color"] as? Color)?.let {
-      return if (it == Color.Unspecified) null else colorToWireString(it)
-    }
-    return runCatching {
-        val brush =
-          mod.javaClass.getDeclaredField("brush").apply { isAccessible = true }.get(mod)
-            ?: return null
-        if (brush.javaClass.simpleName != "SolidColor") return null
-        val value =
-          brush.javaClass.getDeclaredField("value").apply { isAccessible = true }.getLong(brush)
-        val packed = value.toULong()
-        if (packed and 0xFFFFFFFFuL != 0uL) return null
-        val argb = (packed shr 32).toInt()
-        if (argb == 0) null else "#${String.format(Locale.US, "%08X", argb)}"
-      }
-      .getOrNull()
-  }
-
-  /**
-   * Reads padding from a `padding` modifier. `Modifier.padding(all)` reports the value through
-   * [InspectableValue.valueOverride], the per-edge and horizontal/vertical overloads through named
-   * [elements]; when inspector info is absent the four `Dp` fields (`start`/`top`/`end`/`bottom`)
-   * are reflected off `PaddingElement`. The `PaddingValues` overload is left unresolved.
-   */
-  private fun paddingInsets(
-    mod: Any,
-    elements: Map<String, Any?>,
-    valueOverride: Any?,
-  ): ComposeSemanticsInsets? {
-    fun el(key: String): String? = (elements[key] as? Dp)?.toWireDp()
-    val all = el("all") ?: (valueOverride as? Dp)?.toWireDp()
-    if (all != null) return ComposeSemanticsInsets(start = all, top = all, end = all, bottom = all)
-    val horizontal = el("horizontal")
-    val vertical = el("vertical")
-    val start = el("start") ?: horizontal ?: reflectDp(mod, "start")
-    val top = el("top") ?: vertical ?: reflectDp(mod, "top")
-    val end = el("end") ?: horizontal ?: reflectDp(mod, "end")
-    val bottom = el("bottom") ?: vertical ?: reflectDp(mod, "bottom")
-    if (start == null && top == null && end == null && bottom == null) return null
-    return ComposeSemanticsInsets(start = start, top = top, end = end, bottom = bottom)
-  }
-
-  /** The inspector `shape` element, or a reflected `shape` field on the modifier element. */
-  private fun shapeOf(mod: Any, elements: Map<String, Any?>): Shape? {
-    (elements["shape"] as? Shape)?.let {
-      return it
-    }
-    return runCatching {
-        val field = mod.javaClass.getDeclaredField("shape").apply { isAccessible = true }
-        field.get(mod) as? Shape
-      }
-      .getOrNull()
-  }
-
-  /**
-   * Resolves the dp corner radius of a [Shape] without a `compose.foundation` compile dependency.
-   * `CornerBasedShape` exposes four `CornerSize` corners via no-arg getters. A dp-based
-   * `CornerSize` (`DpCornerSize`) stores its `Dp` in a `size` field (inlined to a float) and is
-   * emitted verbatim; a percent-based `CornerSize` (`PercentCornerSize`, what `CircleShape` and
-   * `CornerSize(50%)` use) is resolved against [minSidePx] / [density] so a circular avatar reports
-   * its effective dp radius (issue #1908). A uniform shape emits one value; otherwise the four
-   * corners are emitted comma-separated. Returns null for non-corner shapes and for pixel corners
-   * (`PxCornerSize`, `RoundedCornerShape(12f)`), which can't be expressed as a fixed dp.
-   */
-  private fun Shape.cornerRadiusWire(minSidePx: Int, density: Float): String? {
-    val corners =
-      listOf("getTopStart", "getTopEnd", "getBottomEnd", "getBottomStart").map { getter ->
-        cornerSizeDp(invokeNoArg(getter), minSidePx, density)
-      }
-    if (corners.any { it == null }) return null
-    val values = corners.filterNotNull()
-    return if (values.distinct().size == 1) "${values.first()}dp"
-    else values.joinToString(",") { "${it}dp" }
-  }
-
-  private fun cornerSizeDp(corner: Any?, minSidePx: Int, density: Float): Float? {
-    corner ?: return null
-    return when (corner.javaClass.simpleName) {
-      // A dp corner stores its `Dp` (inlined float) directly.
-      "DpCornerSize" ->
-        runCatching {
-            val field = corner.javaClass.getDeclaredField("size").apply { isAccessible = true }
-            when (val raw = field.get(corner)) {
-              is Float -> raw
-              is Dp -> raw.value
-              else -> null
-            }
-          }
-          .getOrNull()
-      // A percent corner is a fraction of the shorter side: `px = minSide * percent/100`, then dp.
-      "PercentCornerSize" ->
-        cornerPercent(corner)?.let { pct ->
-          if (minSidePx <= 0 || density <= 0f) null
-          else roundedDp((minSidePx * pct / 100f) / density)
-        }
-      // `PxCornerSize` (`RoundedCornerShape(12f)`) stores pixels we can't turn into a fixed dp.
-      else -> null
-    }
-  }
-
-  /**
-   * The percent (`50.0` for `CircleShape`) stored in a `PercentCornerSize`. The backing field is
-   * `percent` (its `toString` renders `"CornerSize(size = 50.0%)"`, but that label is not the field
-   * name); fall back to `size` defensively in case a future Compose renames it.
-   */
-  private fun cornerPercent(corner: Any?): Float? {
-    corner ?: return null
-    if (corner.javaClass.simpleName != "PercentCornerSize") return null
-    return sequenceOf("percent", "size")
-      .mapNotNull { name ->
-        runCatching {
-            corner.javaClass.getDeclaredField(name).apply { isAccessible = true }.getFloat(corner)
-          }
-          .getOrNull()
-      }
-      .firstOrNull()
-  }
-
-  /**
-   * Round a computed dp to 2 decimals so percent-derived radii read cleanly (`18.0`, not `17.99`).
-   */
-  private fun roundedDp(value: Float): Float = (value * 100f).roundToInt() / 100f
-
-  /**
-   * Shape-family descriptor for shapes whose radius isn't a single dp number (issue #1908):
-   * `"circle"` for a `CircleShape` / all-`CornerSize(50%)` rounded shape, `"cut"` for a
-   * `CutCornerShape`. Null for a plain rectangle or an ordinary dp `RoundedCornerShape` (its radius
-   * is already carried by [cornerRadiusWire]), so the descriptor stays signal, not noise.
-   */
-  private fun Shape.shapeDescriptor(): String? {
-    if (javaClass.simpleName == "CutCornerShape") return "cut"
-    val corners =
-      listOf("getTopStart", "getTopEnd", "getBottomEnd", "getBottomStart").map {
-        cornerPercent(invokeNoArg(it))
-      }
-    if (corners.all { it != null && it >= 50f }) return "circle"
-    return null
-  }
-
-  private fun reflectDp(mod: Any, field: String): String? =
-    runCatching {
-        val value =
-          mod.javaClass.getDeclaredField(field).apply { isAccessible = true }.getFloat(mod)
-        if (value.isNaN()) null else "${value}dp"
-      }
-      .getOrNull()
-
-  private fun Any.invokeNoArg(name: String): Any? =
-    runCatching { javaClass.getMethod(name).invoke(this) }.getOrNull()
-
-  private fun Dp.toWireDp(): String = "${value}dp"
 
   private fun SemanticsConfiguration.label(): String? {
     getOrNull(SemanticsProperties.ContentDescription)
@@ -603,10 +336,46 @@ object LayoutInspectorDataProducer {
     rootDir: File,
     previewId: String,
     previewContext: PreviewContext,
+    density: Float = 1f,
     fileSystem: FileSystem = SystemFileSystem,
   ) {
     val capture = LayoutInspectorCaptureContext.from(previewContext) ?: return
-    val layoutRoot = ComposeLayoutInspector.inspect(capture) ?: return
+    write(rootDir, previewId, capture, density, fileSystem)
+  }
+
+  /**
+   * Desktop / CMP-portable overload (issue #1903): build the inspector tree directly from a
+   * captured [root] `SemanticsNode` + composition [slotTables] — the inputs the desktop
+   * `RenderEngine` holds after `scene.render()`. The Android path resolves these from a
+   * `RootForTest`; desktop has no such handle, so this skips it. `ComposeLayoutInspector` then
+   * walks the `LayoutNode` reachable from the semantics root by reflection, identically on both
+   * backends — which is what lets `layout/inspector` finally ship on desktop instead of serving a
+   * never-written file.
+   */
+  fun writeArtifacts(
+    rootDir: File,
+    previewId: String,
+    root: SemanticsNode,
+    slotTables: List<CompositionData> = emptyList(),
+    density: Float = 1f,
+    fileSystem: FileSystem = SystemFileSystem,
+  ) {
+    val capture =
+      LayoutInspectorCaptureContext(
+        rootSemanticsNode = root,
+        slotTables = ExtensionSlotTables.of(slotTables),
+      )
+    write(rootDir, previewId, capture, density, fileSystem)
+  }
+
+  private fun write(
+    rootDir: File,
+    previewId: String,
+    capture: LayoutInspectorCaptureContext,
+    density: Float,
+    fileSystem: FileSystem,
+  ) {
+    val layoutRoot = ComposeLayoutInspector.inspect(capture, density) ?: return
     val previewDir = rootDir.resolve(previewId).also { it.mkdirs() }
     val payload = LayoutInspectorPayload(root = layoutRoot)
     fileSystem.write(previewDir.resolve(FILE).path.toPath()) {
@@ -642,19 +411,26 @@ internal data class LayoutInspectorCaptureContext(
  * context, get a [LayoutInspectorNode].
  */
 internal object ComposeLayoutInspector {
-  fun inspect(context: LayoutInspectorCaptureContext): LayoutInspectorNode? {
+  /**
+   * [density] (dp = px / density) is threaded only to resolve percent-based corner radii
+   * (`CircleShape`) into dp on the per-node [LayoutInspectorNode.tokens]; the default of `1f`
+   * leaves px-equals-dp captures unchanged, matching [ComposeSemanticsDataProducer.buildPayload].
+   */
+  fun inspect(context: LayoutInspectorCaptureContext, density: Float = 1f): LayoutInspectorNode? {
     val root = LayoutTreeAccess.rootLayoutNode(context.rootSemanticsNode) ?: return null
     val sources = LayoutSourceIndex(context.slotTables)
-    return root.toWireNode(rootCoordinates = null, sources = sources)
+    return root.toWireNode(rootCoordinates = null, sources = sources, density = density)
   }
 
   private fun LayoutNodeFacade.toWireNode(
     rootCoordinates: LayoutCoordinates?,
     sources: LayoutSourceIndex,
+    density: Float,
   ): LayoutInspectorNode {
     val rootCoords = rootCoordinates ?: coordinates
     val source = sources.sourceFor(raw)
-    val children = children.map { it.toWireNode(rootCoords, sources) }
+    val children = children.map { it.toWireNode(rootCoords, sources, density) }
+    val modifiers = modifierInfo
     return LayoutInspectorNode(
       nodeId = semanticsId?.toString() ?: identityId,
       component = source?.component ?: componentFallback,
@@ -666,7 +442,19 @@ internal object ComposeLayoutInspector {
       placed = placed,
       attached = attached,
       zIndex = zIndex,
-      modifiers = modifierInfo.mapNotNull { info -> info.toWireModifier(rootCoords) },
+      modifiers = modifiers.mapNotNull { info -> info.toWireModifier(rootCoords) },
+      // Resolved tokens are computed by the shared resolver (issue #1903) from the same modifier
+      // chain + measure policy + measured size this node already carries — `layout/inspector` is
+      // the
+      // canonical home for the modifier-derived token projection.
+      tokens =
+        ModifierTokenResolver.resolve(
+          modifierInfo = modifiers,
+          measurePolicy = measurePolicy,
+          sizeWidthPx = width,
+          sizeHeightPx = height,
+          density = density,
+        ),
       children = children,
     )
   }
@@ -779,6 +567,9 @@ internal object ComposeLayoutInspector {
     val componentFallback: String
       get() = LayoutTreeAccess.measurePolicyName(raw) ?: raw.javaClass.simpleName
 
+    val measurePolicy: Any?
+      get() = LayoutTreeAccess.measurePolicy(raw)
+
     val width: Int
       get() = LayoutTreeAccess.width(raw)
 
@@ -828,10 +619,34 @@ internal object ComposeLayoutInspector {
         ?: emptyList()
 
     fun children(node: Any): List<Any> =
-      sequenceOf("getZSortedChildren", "getChildren\$ui_release", "getFoldedChildren\$ui_release")
-        .mapNotNull { call(node, it) as? Iterable<*> }
-        .firstOrNull()
-        ?.filterNotNull() ?: emptyList()
+      // The child accessors carry an internal-visibility suffix that differs by build: Android
+      // (`compose.ui` aar) mangles to `$ui_release`, the desktop/skiko jar to `$ui` — and the
+      // z-sorted accessor has no suffix at all. Try every variant, in draw order first, and
+      // coerce the result (a `MutableVector` on desktop, a `List` on Android) to a `List`. Without
+      // this the desktop walk silently returned an empty subtree — `layout/inspector` was a lone
+      // root node (#1903).
+      sequenceOf(
+          "getZSortedChildren\$ui_release",
+          "getZSortedChildren\$ui",
+          "getZSortedChildren",
+          "getChildren\$ui_release",
+          "getChildren\$ui",
+          "getFoldedChildren\$ui_release",
+          "getFoldedChildren\$ui",
+        )
+        .mapNotNull { coerceNodeList(call(node, it)) }
+        .firstOrNull { it.isNotEmpty() } ?: emptyList()
+
+    /**
+     * Coerce a reflected children accessor's return value to a `List`. Compose returns either a
+     * plain `Iterable` or a `MutableVector` (not `Iterable`); the latter exposes `asMutableList()`.
+     */
+    private fun coerceNodeList(value: Any?): List<Any>? =
+      when (value) {
+        null -> null
+        is Iterable<*> -> value.filterNotNull()
+        else -> (call(value, "asMutableList") as? Iterable<*>)?.filterNotNull()
+      }
 
     fun constraints(node: Any): LayoutInspectorConstraints? {
       val delegate = call(node, "getLayoutDelegate\$ui_release") ?: return null
@@ -858,6 +673,8 @@ internal object ComposeLayoutInspector {
 
     fun measurePolicyName(node: Any): String? =
       call(node, "getMeasurePolicy")?.javaClass?.name?.substringAfterLast('.')?.substringBefore('$')
+
+    fun measurePolicy(node: Any): Any? = call(node, "getMeasurePolicy")
 
     private fun constraintsLong(value: Any): Long? =
       when (value) {

--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ModifierTokenResolver.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ModifierTokenResolver.kt
@@ -1,0 +1,322 @@
+package ee.schimke.composeai.daemon
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.layout.ModifierInfo
+import androidx.compose.ui.platform.InspectableValue
+import androidx.compose.ui.unit.Dp
+import java.util.Locale
+import kotlin.math.roundToInt
+
+/**
+ * Single home for the modifier → design-token resolution (issue #1903 consolidation).
+ *
+ * Before this, [ComposeSemanticsDataProducer] re-walked `getModifierInfo()` with its own private
+ * copy of this logic to populate the `tokens` it mirrors onto `compose/semantics` (#1897, #1908),
+ * while `layout/inspector` — the product that actually *models* per-node modifiers — carried only
+ * the raw, unresolved modifier chain. The resolved `{backgroundColor, borderColor, cornerRadius,
+ * shape, gap, padding}` projection is modifier-derived, so it belongs in one place that both
+ * products feed their per-node inputs into rather than being duplicated per product.
+ *
+ * The inputs are deliberately the lowest common denominator both backends and both products can
+ * supply by reflection, so this stays foundation-free (no `compose.foundation` compile dependency,
+ * matching the layout inspector's approach):
+ * - [modifierInfo] — the node's [ModifierInfo] entries (`LayoutInfo.getModifierInfo()`).
+ * - [measurePolicy] — the node's measure policy object (for `Arrangement.spacedBy` gap), or null.
+ * - [sizeWidthPx] / [sizeHeightPx] — the node's measured size in px (for percent-corner → dp).
+ * - [density] — the render density (dp = px / density), for percent-corner → dp.
+ */
+internal object ModifierTokenResolver {
+
+  /**
+   * Resolves the design tokens declared by a node's modifiers + measure policy. Returns null when
+   * the node declares none of them — the common case for pure layout / text nodes.
+   *
+   * The preferred source for each value is the entry's [InspectableValue] projection (the same
+   * `nameFallback` / `inspectableElements` surface the layout inspector reads), but some foundation
+   * elements (notably `BackgroundElement`) don't populate inspector info on the desktop/skiko
+   * build, so each lookup falls back to reflecting the element's backing field.
+   */
+  fun resolve(
+    modifierInfo: List<ModifierInfo>,
+    measurePolicy: Any?,
+    sizeWidthPx: Int,
+    sizeHeightPx: Int,
+    density: Float,
+  ): ComposeSemanticsTokens? {
+    var backgroundColor: String? = null
+    var borderColor: String? = null
+    var cornerRadius: String? = null
+    var shape: String? = null
+    var padding: ComposeSemanticsInsets? = null
+    // `CircleShape` / `CornerSize(50%)` resolve to dp against the node's shorter measured side.
+    val minSidePx = minOf(sizeWidthPx, sizeHeightPx)
+    for (info in modifierInfo) {
+      val mod = info.modifier
+      val inspectable = mod as? InspectableValue
+      val name = inspectable?.nameFallback
+      val elements = inspectable?.inspectableElements?.associate { it.name to it.value }.orEmpty()
+      val simpleName = mod.javaClass.simpleName
+
+      if (backgroundColor == null && (name == "background" || simpleName == "BackgroundElement")) {
+        backgroundColor = backgroundColorHex(mod, elements, inspectable?.valueOverride)
+      }
+      // `Modifier.border` carries the outline colour `Surface`/`Card`/dividers apply — a role
+      // colour
+      // (`outline` / `outlineVariant`) a plain `Modifier.background` never sees (issue #1908).
+      if (borderColor == null && (name == "border" || simpleName.startsWith("BorderModifier"))) {
+        borderColor = borderColorHex(mod, elements)
+      }
+      if (padding == null && (name == "padding" || simpleName.startsWith("PaddingElement"))) {
+        padding = paddingInsets(mod, elements, inspectable?.valueOverride)
+      }
+      // Shape comes from any shape-bearing modifier: `background(color, shape)`, `clip(shape)`
+      // (which Compose routes through `graphicsLayer`), or `border(..., shape)`. A plain rectangle
+      // yields null for both fields and is skipped.
+      val nodeShape = shapeOf(mod, elements)
+      if (nodeShape != null) {
+        if (cornerRadius == null) cornerRadius = nodeShape.cornerRadiusWire(minSidePx, density)
+        if (shape == null) shape = nodeShape.shapeDescriptor()
+      }
+    }
+    val gap = arrangementGapWire(measurePolicy)
+    return if (
+      backgroundColor == null &&
+        borderColor == null &&
+        cornerRadius == null &&
+        shape == null &&
+        gap == null &&
+        padding == null
+    )
+      null
+    else
+      ComposeSemanticsTokens(
+        backgroundColor = backgroundColor,
+        borderColor = borderColor,
+        cornerRadius = cornerRadius,
+        shape = shape,
+        gap = gap,
+        padding = padding,
+      )
+  }
+
+  /**
+   * Resolves the inter-child spacing of a `Row`/`Column` from its [measurePolicy] (issue #1908).
+   * `Arrangement.spacedBy(n)` is stored on the `Row`/`Column`MeasurePolicy as an
+   * `Arrangement.HorizontalOrVertical` whose `spacing` `Dp` is kept in a `spacing` float field; the
+   * value-class `getSpacing` getter is name-mangled, so the field is read directly. Returns null
+   * when the layout has no measure policy or no arrangement spacing.
+   */
+  private fun arrangementGapWire(measurePolicy: Any?): String? {
+    val policy = measurePolicy ?: return null
+    var cls: Class<*>? = policy.javaClass
+    while (cls != null && cls != Any::class.java) {
+      for (field in cls.declaredFields) {
+        val value =
+          runCatching { field.apply { isAccessible = true }.get(policy) }.getOrNull() ?: continue
+        if (!value.javaClass.name.startsWith("androidx.compose.foundation.layout.Arrangement"))
+          continue
+        val spacing =
+          runCatching {
+              value.javaClass
+                .getDeclaredField("spacing")
+                .apply { isAccessible = true }
+                .getFloat(value)
+            }
+            .getOrNull() ?: continue
+        if (spacing > 0f) return "${spacing}dp"
+      }
+      cls = cls.superclass
+    }
+    return null
+  }
+
+  /**
+   * Resolves a `background` modifier's fill colour as ARGB hex. Reads the inspector `color` element
+   * / `valueOverride` when present; otherwise reflects `BackgroundElement`'s `color` field — a
+   * [Color] value class stored as its packed `ULong`. For sRGB colours (the common case) the ARGB
+   * is the high 32 bits; brushes and non-sRGB packings are skipped rather than mis-decoded.
+   */
+  private fun backgroundColorHex(
+    mod: Any,
+    elements: Map<String, Any?>,
+    valueOverride: Any?,
+  ): String? {
+    ((elements["color"] ?: valueOverride) as? Color)?.let {
+      return if (it == Color.Unspecified) null else colorToWireString(it)
+    }
+    return runCatching {
+        val field = mod.javaClass.getDeclaredField("color").apply { isAccessible = true }
+        val packed = field.getLong(mod).toULong()
+        // sRGB packs the colour space id (non-zero) into the low 32 bits as 0; anything else is a
+        // wide-gamut/unspecified packing we can't read as a plain ARGB hex.
+        if (packed and 0xFFFFFFFFuL != 0uL) return null
+        val argb = (packed shr 32).toInt()
+        if (argb == 0) null else "#${String.format(Locale.US, "%08X", argb)}"
+      }
+      .getOrNull()
+  }
+
+  /**
+   * Resolves a `border` modifier's stroke colour as ARGB hex. `Modifier.border` projects its colour
+   * through the inspector `color` element even when the brush is a plain `SolidColor`; that's read
+   * first, falling back to reflecting the backing `brush` field's `SolidColor.value`. A gradient
+   * brush (no single colour) is skipped (issue #1908).
+   */
+  private fun borderColorHex(mod: Any, elements: Map<String, Any?>): String? {
+    (elements["color"] as? Color)?.let {
+      return if (it == Color.Unspecified) null else colorToWireString(it)
+    }
+    return runCatching {
+        val brush =
+          mod.javaClass.getDeclaredField("brush").apply { isAccessible = true }.get(mod)
+            ?: return null
+        if (brush.javaClass.simpleName != "SolidColor") return null
+        val value =
+          brush.javaClass.getDeclaredField("value").apply { isAccessible = true }.getLong(brush)
+        val packed = value.toULong()
+        if (packed and 0xFFFFFFFFuL != 0uL) return null
+        val argb = (packed shr 32).toInt()
+        if (argb == 0) null else "#${String.format(Locale.US, "%08X", argb)}"
+      }
+      .getOrNull()
+  }
+
+  /**
+   * Reads padding from a `padding` modifier. `Modifier.padding(all)` reports the value through
+   * [InspectableValue.valueOverride], the per-edge and horizontal/vertical overloads through named
+   * [elements]; when inspector info is absent the four `Dp` fields (`start`/`top`/`end`/`bottom`)
+   * are reflected off `PaddingElement`. The `PaddingValues` overload is left unresolved.
+   */
+  private fun paddingInsets(
+    mod: Any,
+    elements: Map<String, Any?>,
+    valueOverride: Any?,
+  ): ComposeSemanticsInsets? {
+    fun el(key: String): String? = (elements[key] as? Dp)?.toWireDp()
+    val all = el("all") ?: (valueOverride as? Dp)?.toWireDp()
+    if (all != null) return ComposeSemanticsInsets(start = all, top = all, end = all, bottom = all)
+    val horizontal = el("horizontal")
+    val vertical = el("vertical")
+    val start = el("start") ?: horizontal ?: reflectDp(mod, "start")
+    val top = el("top") ?: vertical ?: reflectDp(mod, "top")
+    val end = el("end") ?: horizontal ?: reflectDp(mod, "end")
+    val bottom = el("bottom") ?: vertical ?: reflectDp(mod, "bottom")
+    if (start == null && top == null && end == null && bottom == null) return null
+    return ComposeSemanticsInsets(start = start, top = top, end = end, bottom = bottom)
+  }
+
+  /** The inspector `shape` element, or a reflected `shape` field on the modifier element. */
+  private fun shapeOf(mod: Any, elements: Map<String, Any?>): Shape? {
+    (elements["shape"] as? Shape)?.let {
+      return it
+    }
+    return runCatching {
+        val field = mod.javaClass.getDeclaredField("shape").apply { isAccessible = true }
+        field.get(mod) as? Shape
+      }
+      .getOrNull()
+  }
+
+  /**
+   * Resolves the dp corner radius of a [Shape] without a `compose.foundation` compile dependency.
+   * `CornerBasedShape` exposes four `CornerSize` corners via no-arg getters. A dp-based
+   * `CornerSize` (`DpCornerSize`) stores its `Dp` in a `size` field (inlined to a float) and is
+   * emitted verbatim; a percent-based `CornerSize` (`PercentCornerSize`, what `CircleShape` and
+   * `CornerSize(50%)` use) is resolved against [minSidePx] / [density] so a circular avatar reports
+   * its effective dp radius (issue #1908). A uniform shape emits one value; otherwise the four
+   * corners are emitted comma-separated. Returns null for non-corner shapes and for pixel corners
+   * (`PxCornerSize`, `RoundedCornerShape(12f)`), which can't be expressed as a fixed dp.
+   */
+  private fun Shape.cornerRadiusWire(minSidePx: Int, density: Float): String? {
+    val corners =
+      listOf("getTopStart", "getTopEnd", "getBottomEnd", "getBottomStart").map { getter ->
+        cornerSizeDp(invokeNoArg(getter), minSidePx, density)
+      }
+    if (corners.any { it == null }) return null
+    val values = corners.filterNotNull()
+    return if (values.distinct().size == 1) "${values.first()}dp"
+    else values.joinToString(",") { "${it}dp" }
+  }
+
+  private fun cornerSizeDp(corner: Any?, minSidePx: Int, density: Float): Float? {
+    corner ?: return null
+    return when (corner.javaClass.simpleName) {
+      // A dp corner stores its `Dp` (inlined float) directly.
+      "DpCornerSize" ->
+        runCatching {
+            val field = corner.javaClass.getDeclaredField("size").apply { isAccessible = true }
+            when (val raw = field.get(corner)) {
+              is Float -> raw
+              is Dp -> raw.value
+              else -> null
+            }
+          }
+          .getOrNull()
+      // A percent corner is a fraction of the shorter side: `px = minSide * percent/100`, then dp.
+      "PercentCornerSize" ->
+        cornerPercent(corner)?.let { pct ->
+          if (minSidePx <= 0 || density <= 0f) null
+          else roundedDp((minSidePx * pct / 100f) / density)
+        }
+      // `PxCornerSize` (`RoundedCornerShape(12f)`) stores pixels we can't turn into a fixed dp.
+      else -> null
+    }
+  }
+
+  /**
+   * The percent (`50.0` for `CircleShape`) stored in a `PercentCornerSize`. The backing field is
+   * `percent` (its `toString` renders `"CornerSize(size = 50.0%)"`, but that label is not the field
+   * name); fall back to `size` defensively in case a future Compose renames it.
+   */
+  private fun cornerPercent(corner: Any?): Float? {
+    corner ?: return null
+    if (corner.javaClass.simpleName != "PercentCornerSize") return null
+    return sequenceOf("percent", "size")
+      .mapNotNull { name ->
+        runCatching {
+            corner.javaClass.getDeclaredField(name).apply { isAccessible = true }.getFloat(corner)
+          }
+          .getOrNull()
+      }
+      .firstOrNull()
+  }
+
+  /**
+   * Round a computed dp to 2 decimals so percent-derived radii read cleanly (`18.0`, not `17.99`).
+   */
+  private fun roundedDp(value: Float): Float = (value * 100f).roundToInt() / 100f
+
+  /**
+   * Shape-family descriptor for shapes whose radius isn't a single dp number (issue #1908):
+   * `"circle"` for a `CircleShape` / all-`CornerSize(50%)` rounded shape, `"cut"` for a
+   * `CutCornerShape`. Null for a plain rectangle or an ordinary dp `RoundedCornerShape` (its radius
+   * is already carried by [cornerRadiusWire]), so the descriptor stays signal, not noise.
+   */
+  private fun Shape.shapeDescriptor(): String? {
+    if (javaClass.simpleName == "CutCornerShape") return "cut"
+    val corners =
+      listOf("getTopStart", "getTopEnd", "getBottomEnd", "getBottomStart").map {
+        cornerPercent(invokeNoArg(it))
+      }
+    if (corners.all { it != null && it >= 50f }) return "circle"
+    return null
+  }
+
+  private fun reflectDp(mod: Any, field: String): String? =
+    runCatching {
+        val value =
+          mod.javaClass.getDeclaredField(field).apply { isAccessible = true }.getFloat(mod)
+        if (value.isNaN()) null else "${value}dp"
+      }
+      .getOrNull()
+
+  private fun Any.invokeNoArg(name: String): Any? =
+    runCatching { javaClass.getMethod(name).invoke(this) }.getOrNull()
+
+  private fun Dp.toWireDp(): String = "${value}dp"
+
+  private fun colorToWireString(color: Color): String =
+    "#${String.format(Locale.US, "%08X", color.toArgb())}"
+}

--- a/data/layoutinspector/connector/src/test/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProductRegistryTest.kt
+++ b/data/layoutinspector/connector/src/test/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProductRegistryTest.kt
@@ -95,7 +95,8 @@ class ComposeSemanticsDataProductRegistryTest {
     val registry = LayoutInspectorDataProductRegistry(rootDir)
     val cap = registry.capabilities.single()
     assertEquals("layout/inspector", cap.kind)
-    assertEquals(1, cap.schemaVersion)
+    // v2 (#1903): per-node `tokens` added to LayoutInspectorNode.
+    assertEquals(2, cap.schemaVersion)
     assertTrue(cap.attachable)
     assertTrue(cap.fetchable)
     assertTrue(!cap.requiresRerender)

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/ComposeSemanticsModels.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/ComposeSemanticsModels.kt
@@ -18,7 +18,14 @@ object ComposeSemanticsProduct {
 
 object LayoutInspectorProduct {
   const val KIND: String = "layout/inspector"
-  const val SCHEMA_VERSION: Int = 1
+  // v2 (#1903): each node may carry resolved design `tokens` — the modifier-derived
+  // `{backgroundColor, borderColor, cornerRadius, shape, gap, padding}` projection. This is the
+  // *canonical* home for those tokens: they come from modifiers, which `layout/inspector` already
+  // models, and the kind now ships on desktop too (the gap #1897 worked around by mirroring them
+  // onto `compose/semantics`). They stay mirrored on `compose/semantics` for the design-parity
+  // consumer; both products feed the same `ModifierTokenResolver`. Additive — older
+  // `layout-inspector.json` parses with `tokens = null`.
+  const val SCHEMA_VERSION: Int = 2
   const val FILE: String = "layout-inspector.json"
 }
 
@@ -152,6 +159,14 @@ data class LayoutInspectorNode(
   val attached: Boolean = true,
   val zIndex: Float? = null,
   val modifiers: List<LayoutInspectorModifier> = emptyList(),
+  /**
+   * Resolved design tokens for this node, derived from its [modifiers] + measure policy by the
+   * shared `ModifierTokenResolver` (issue #1903). `layout/inspector` is the canonical home for
+   * these — they are modifier-derived, and this product already models the modifier chain — while
+   * `compose/semantics` mirrors the same object (via the same resolver) for the design-parity
+   * consumer. Null for the common case of a node that declares none of them (pure layout nodes).
+   */
+  val tokens: ComposeSemanticsTokens? = null,
   val children: List<LayoutInspectorNode> = emptyList(),
 )
 

--- a/docs/daemon/DATA-PRODUCTS.md
+++ b/docs/daemon/DATA-PRODUCTS.md
@@ -278,7 +278,7 @@ A `data/fetch` that needs a re-render:
 | `a11y/hierarchy` | a11y | low | `AccessibilityNode[]` (label, role, states, bounds). Each node also carries a stable, content-independent `ref` (assigned by `AccessibilityRefs` — role-anchored, disambiguated by occurrence index), the a11y analogue of `compose/semantics`' `ref` (#1784). Additive — `schemaVersion` stays 1; older `accessibility.json` parses with `ref = null`. |
 | `a11y/overlay` | a11y | low | Path to annotated PNG. Pure-image. |
 | `a11y/touchTargets` | a11y | low | 48dp + overlap detection. |
-| `layout/inspector` | default | low | Compose layout/component hierarchy with bounds, constraints, modifiers, source refs. |
+| `layout/inspector` | default | low | Compose layout/component hierarchy with bounds, constraints, modifiers, source refs. schemaVersion 2 adds per-node `tokens` — the resolved modifier-derived design tokens (`backgroundColor`, `borderColor`, `cornerRadius`, `shape`, `gap`, `padding`). This is the **canonical** home for those tokens (they come from modifiers, which this product already models); `compose/semantics` mirrors the same object, and both compute it via the shared `ModifierTokenResolver` (#1903). Additive — older files parse with `tokens = null`. |
 | `compose/semantics` | default | low | SemanticsNode projection — testTag, role, mergeMode, bounds. Each node also carries a stable, content-independent `ref` (assigned by `SemanticsRefs`) used for ref/testTag/role targeting (#1784) and as the match key for the semantics text diff (#1785). schemaVersion 3 adds per-node `tokens` — resolved container design tokens (`backgroundColor`, `cornerRadius`, `padding`) read off the node's `Modifier.background` / `clip` / `border` / `padding`, so design-parity's token-compliance check can populate `actual` for colour/spacing/radius instead of degrading to "missing from candidate" (#1897). Additive — nodes that declare none omit `tokens`, older files parse with `tokens = null`. |
 | `compose/semantics-wireframe` | default | low | Standalone 2D wireframe of the semantics tree, derived from the same captured root. SVG primary (path); baked PNG rides as a `png` extra. Depth-cycled stroke hue, accent fill/stroke for clickable stops, dashed stroke for `clearAndSet`, top-left labels. |
 | `compose/spatial-semantics` | default | low | Unified **3D-over-2D** semantics tree (`SpatialSemanticsTree`): the subspace layout with each panel carrying its 2D `compose/semantics` tree. Ordinary previews emit the degenerate single-panel case (one `panel` at identity pose); XR previews emit the real multi-panel layout. The accessibility/structure view of [SPATIAL_SEMANTICS_TREE.md](../design/SPATIAL_SEMANTICS_TREE.md) / [XR_A11Y.md](../design/xr-spatial/XR_A11Y.md). |
@@ -294,6 +294,35 @@ A `data/fetch` that needs a re-render:
 | `fonts/used` | default | low | Font families with weight/style fallback chain. |
 | `history/diff/regions` | default | low | Per-pixel bbox of changed regions vs. another history entry. |
 | `test/failure` | failed render | low | Postmortem bundle: phase, error type/message/stack, fallback fields for what's not yet captured. Fetch-only after `renderFailed`. |
+
+### Where design tokens live (issue #1903)
+
+`#1897` resolved each node's modifier-derived design tokens (`backgroundColor`,
+`borderColor`, `cornerRadius`, `shape`, `gap`, `padding`) and put them on
+`compose/semantics` as a pragmatic choice — `layout/inspector`, the product that
+actually models per-node modifiers, wasn't produced on desktop, and `#1897` was
+a desktop-backend change. `#1903` closes that gap, so the home question is now
+settled:
+
+- **One resolver.** The modifier → token projection lives in a single
+  [`ModifierTokenResolver`](../../data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ModifierTokenResolver.kt).
+  Both products feed it their per-node inputs (modifier chain, measure policy,
+  measured size, density) instead of each re-walking `getModifierInfo()` with a
+  private copy of the logic.
+- **Canonical home: `layout/inspector`.** Tokens are modifier-derived and
+  `layout/inspector` already carries the modifier chain, so its per-node
+  `tokens` is the canonical surface. It now ships on **both** backends.
+- **Mirror on `compose/semantics`.** The same `tokens` object stays mirrored on
+  the semantics node for the design-parity token-compliance consumer, which
+  reads `*.semantics.json` and already maps `layoutForegroundColor` →
+  `onSurface`. Keeping the mirror means that contract is untouched (the `#1903`
+  non-goal). Both surfaces are byte-identical because they share the resolver.
+- **`layout*` text fields stay on `compose/semantics`.** `layoutForegroundColor`
+  / `layoutFontSize` / `layoutLineCount` / … are **not** modifier-derived: they
+  come from the `GetTextLayoutResult` *semantics action*, so they belong with
+  the text-bearing semantics node rather than the layout tree. That keeps them
+  distinct from the (modifier-derived) container `tokens`, and leaves the
+  design-parity consumer that reads them unchanged.
 
 ## Per-backend support matrix (issue #1201)
 
@@ -311,7 +340,7 @@ Which `kind` strings each backend's `extensions/list` advertises and serves thro
 | `compose/recomposition` | ✅ producer | ✅ producer | Compose-runtime observer install on both backends (desktop in-process; Android via the in-sandbox bridge). schemaVersion 2 adds the per-scope `reason` (#1605), derived symmetrically from `onScopeInvalidated`. |
 | `displayfilter/variants` | ✅ | ✅ | Both backends, gated on `composeai.displayfilter.filters`. Producer is pure `BufferedImage` post-capture. |
 | `fonts/used` | ✅ producer | 📁 registry-only | Android: `GoogleFontInterceptor` + Typeface accounting. Desktop: registry returns `NotAvailable` until a Skia-side font producer ports. |
-| `compose/semantics` / `layout/inspector` | ✅ producer | 📁 registry-only | Android producer reads the Robolectric semantics tree. Desktop registry serves the file once a CMP-portable producer driving `LocalView` / `SemanticsOwner` lands. |
+| `compose/semantics` / `layout/inspector` | ✅ producer | ✅ producer | Android producer reads the Robolectric semantics tree. Desktop drives both from the held `ImageComposeScene`'s `semanticsOwners` unmerged root after `scene.render()`: `compose/semantics` via `ComposeSemanticsDataProducer` (#1885 follow-up), `layout/inspector` via the CMP-portable `LayoutInspectorDataProducer.writeArtifacts(root, slotTables, density)` overload — `ComposeLayoutInspector` reflects the `LayoutNode` reachable from the semantics root identically on both backends (#1903). |
 | `compose/semantics-wireframe` | ✅ producer | ✅ producer | Android via the always-on post-capture extension; desktop via the `RenderEngine` block that reads `ImageComposeScene.semanticsOwners`' unmerged root (the CMP-portable `SemanticsOwner` read the `compose/semantics` row is still waiting on). SVG is backend-agnostic; the PNG is baked by `AndroidSemanticsWireframe` / `DesktopSemanticsWireframe`. |
 | `compose/spatial-semantics` | ✅ producer | ✅ producer | Degenerate single-panel tree from the same captured root, alongside the wireframe (Android post-capture extension / desktop `RenderEngine` block). The real multi-panel XR tree is written separately by the `:renderer-xr` batch render task (`SubspaceSceneRecorder.recordTree`). Both write `compose-spatial-semantics.json`. |
 | `text/strings` | ✅ producer | 📁 registry-only | Synthesised from `compose/semantics`; ports along with that kind. |
@@ -397,7 +426,7 @@ Compose runtime, daemon, or AndroidX:
 | `fonts/used` | `:data-fonts-core` | `FontsUsedPayload`, `FontUsedEntry` |
 | `history/diff/regions` | `:data-history-core` | `HistoryDiffPayload`, `HistoryDiffRegion` |
 | `i18n/translations` | `:data-strings-core` | `I18nTranslationsPayload`, `I18nVisibleString` |
-| `layout/inspector` | `:data-layoutinspector-core` | `LayoutInspectorPayload`, `LayoutInspectorNode` |
+| `layout/inspector` | `:data-layoutinspector-core` | `LayoutInspectorPayload`, `LayoutInspectorNode` (carries resolved `tokens`: `ComposeSemanticsTokens`, the canonical modifier-derived projection) |
 | _(pseudolocale, no payload)_ | `:data-pseudolocale-core` | `Pseudolocale`, `Pseudolocalizer` |
 | `resources/used` | `:data-resources-core` | `ResourcesUsedPayload`, `ResourceUsedReference` |
 | `text/strings` | `:data-strings-core` | `TextStringsPayload`, `TextStringEntry` |


### PR DESCRIPTION
Closes #1903 — the consolidation follow-up to #1897.

## Summary

- **Desktop now produces `layout/inspector`.** The desktop daemon registered the kind but never wrote `layout-inspector.json`, so `data/fetch` degraded to `NotAvailable`. The desktop `RenderEngine` now writes it from the same captured `ImageComposeScene` semantics root + slot tables it already uses for `compose/semantics`, via a new CMP-portable `LayoutInspectorDataProducer.writeArtifacts(root, slotTables, density)` overload.
- **Hardened the desktop `LayoutNode` child-walk.** The skiko/desktop build mangles the internal child accessors to `$ui` (not `$ui_release`) and returns a `MutableVector` (not `Iterable`). The old reflection only matched the Android `$ui_release` names and cast to `Iterable`, so the desktop tree came back as a lone root node. The walk now tries both suffix variants (and the no-suffix z-sorted accessor) and coerces a `MutableVector` via `asMutableList()`.
- **Single modifier-token resolver.** The modifier → `{backgroundColor, borderColor, cornerRadius, shape, gap, padding}` projection moves into one `ModifierTokenResolver`. Both `compose/semantics` and `layout/inspector` feed it per-node inputs instead of each re-walking `getModifierInfo()` with a private copy.
- **Canonical home decided.** `layout/inspector` is the canonical surface for these tokens (they are modifier-derived and it already models the modifier chain). `compose/semantics` keeps mirroring the byte-identical `tokens` object so the design-parity token-compliance consumer is untouched. `LayoutInspectorNode` gains `tokens`; its schemaVersion goes 1 → 2 (additive — older files parse with `tokens = null`). The `layout*` text-styling fields stay on `compose/semantics` only: they come from the `GetTextLayoutResult` semantics action, not modifiers.
- **Docs.** `docs/daemon/DATA-PRODUCTS.md` flips desktop `layout/inspector` to *producer*, records the resolved-home decision, and bumps the schema notes.

This is data-product plumbing (JSON artifacts), not a rendered surface, so per the repo's visual-evidence rule text-only verification is appropriate — there is no `@Preview`/webview output to diff.

## Test plan

- `./gradlew :data-layoutinspector-connector:test` — connector unit tests (incl. the registry/schema test) pass.
- New `DesktopLayoutInspectorTest` asserts the desktop `layout/inspector` tree is non-empty and that container tokens resolve onto nodes; it and the existing `DesktopSemanticsTokensTest` pass.
- `./gradlew ktfmtCheckAll` clean.
- `:daemon:android` compile/tests rely on CI — no Android SDK in the authoring sandbox. The Android-side change is a one-line slot-tables param pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RJFTgG9vWW2ZYYBEsmjW9T)_