### PR TITLE
feat(renderer-desktop): simulate Android system bars for showSystemUi (#1930)

### DIFF
--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
@@ -123,6 +123,10 @@ class PreviewManifestRouter(
             effectiveDevice
               ?.takeIf { it.isNotBlank() }
               ?.let { append("device=").append(it).append(';') }
+            // `@Preview(showSystemUi = ...)` (issue #1930) — forwarded so the render body wraps the
+            // composition in the synthetic `SystemBarsFrame`. Only emitted when set; absent keeps
+            // the chrome-less default.
+            if (resolved.showSystemUi) append("showSystemUi=true;")
             // PROTOCOL.md § 5 (`renderNow.overrides`) — locale / fontScale / uiMode / orientation
             // pass straight through. `orientation = landscape` is applied above as a swap of the
             // forwarded widthPx/heightPx; the token still rides along so downstream consumers see
@@ -203,6 +207,7 @@ class PreviewManifestRouter(
           showBackground = resolved.showBackground,
           backgroundColor = resolved.backgroundColor,
           device = resolved.device,
+          showSystemUi = resolved.showSystemUi,
           wrapperClassName = resolved.wrapperClassName,
           kind = resolved.kind,
           assetPath = resolved.assetPath,
@@ -251,6 +256,12 @@ data class PreviewManifestEntry(
    * qualifier; the desktop path ignores it (no circular crop on JVM rendering).
    */
   val device: String? = null,
+  /**
+   * Flat-schema mirror of `@Preview(showSystemUi = ...)` (issue #1930). Optional; when null the
+   * resolver consults the nested `params.showSystemUi`. Drives the synthetic `SystemBarsFrame` wrap
+   * in the render body.
+   */
+  val showSystemUi: Boolean? = null,
   val outputBaseName: String? = null,
 ) {
   fun resolved(): ResolvedRenderParams {
@@ -261,6 +272,7 @@ data class PreviewManifestEntry(
     val showBackground = showBackground ?: p?.showBackground ?: true
     val backgroundColor = backgroundColor ?: p?.backgroundColor ?: 0L
     val device = device ?: p?.device
+    val showSystemUi = showSystemUi ?: p?.showSystemUi ?: false
     val wrapperClassName = p?.wrapperClassName
     return ResolvedRenderParams(
       widthPx = widthPx,
@@ -269,6 +281,7 @@ data class PreviewManifestEntry(
       showBackground = showBackground,
       backgroundColor = backgroundColor,
       device = device,
+      showSystemUi = showSystemUi,
       outputBaseName = outputBaseName ?: id,
       wrapperClassName = wrapperClassName,
       kind = p?.kind,
@@ -296,6 +309,12 @@ data class PreviewParamsEntry(
   /** For `kind="LOTTIE"`: the classpath-relative Lottie asset path. */
   val assetPath: String? = null,
   /**
+   * `@Preview(showSystemUi = ...)` (issue #1930). Drives the synthetic `SystemBarsFrame` wrap so
+   * the daemon's desktop capture draws Android phone chrome to match the Android / standalone
+   * renderers.
+   */
+  val showSystemUi: Boolean = false,
+  /**
    * FQN of the `PreviewWrapperProvider` from `@PreviewWrapper(SomeProvider::class)` when the source
    * preview is annotated. Read at discovery time by `extractWrapperFqn` against the class-file
    * annotation tables (the upstream annotation has `AnnotationRetention.BINARY`, so
@@ -316,6 +335,7 @@ data class ResolvedRenderParams(
   val showBackground: Boolean,
   val backgroundColor: Long,
   val device: String?,
+  val showSystemUi: Boolean = false,
   val outputBaseName: String,
   val wrapperClassName: String? = null,
   val kind: String? = null,

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
@@ -133,7 +133,17 @@ class PreviewManifestRouter(
             // the resolved orientation. Other fields are honoured by `RenderEngine` directly.
             inbound["localeTag"]?.let { append("localeTag=").append(it).append(';') }
             inbound["fontScale"]?.let { append("fontScale=").append(it).append(';') }
-            inbound["uiMode"]?.let { append("uiMode=").append(it).append(';') }
+            // uiMode: an inbound override wins; otherwise derive from the manifest-declared
+            // `@Preview(uiMode = …)` so a night `showSystemUi` preview paints dark
+            // `SystemBarsFrame`
+            // chrome in the live daemon, matching the standalone Gradle renderer (which gets the
+            // raw
+            // uiMode arg). `RenderSpec.parseFromPayload` only understands `light`/`dark`, so map
+            // the
+            // night bit to a token; light/unset emits nothing (the daemon's default).
+            val effectiveUiMode =
+              inbound["uiMode"] ?: if ((resolved.uiMode and 0x30) == 0x20) "dark" else null
+            effectiveUiMode?.let { append("uiMode=").append(it).append(';') }
             inbound["orientation"]?.let { append("orientation=").append(it).append(';') }
             inbound["captureAdvanceMs"]?.let { append("captureAdvanceMs=").append(it).append(';') }
             inbound["inspectionMode"]?.let { append("inspectionMode=").append(it).append(';') }
@@ -208,6 +218,10 @@ class PreviewManifestRouter(
           backgroundColor = resolved.backgroundColor,
           device = resolved.device,
           showSystemUi = resolved.showSystemUi,
+          // Map the manifest night bit to the daemon's light/dark enum so interactive/recording
+          // sessions of a night `showSystemUi` preview also get dark chrome (issue #1930
+          // follow-up).
+          uiMode = if ((resolved.uiMode and 0x30) == 0x20) RenderSpec.SpecUiMode.DARK else null,
           wrapperClassName = resolved.wrapperClassName,
           kind = resolved.kind,
           assetPath = resolved.assetPath,
@@ -262,6 +276,12 @@ data class PreviewManifestEntry(
    * in the render body.
    */
   val showSystemUi: Boolean? = null,
+  /**
+   * Flat-schema mirror of `@Preview(uiMode = ...)`. Optional; when null the resolver consults the
+   * nested `params.uiMode`. Only the `UI_MODE_NIGHT_*` bits matter — drives dark `SystemBarsFrame`
+   * chrome for night `showSystemUi` previews (issue #1930 follow-up).
+   */
+  val uiMode: Int? = null,
   val outputBaseName: String? = null,
 ) {
   fun resolved(): ResolvedRenderParams {
@@ -273,6 +293,7 @@ data class PreviewManifestEntry(
     val backgroundColor = backgroundColor ?: p?.backgroundColor ?: 0L
     val device = device ?: p?.device
     val showSystemUi = showSystemUi ?: p?.showSystemUi ?: false
+    val uiMode = uiMode ?: p?.uiMode ?: 0
     val wrapperClassName = p?.wrapperClassName
     return ResolvedRenderParams(
       widthPx = widthPx,
@@ -282,6 +303,7 @@ data class PreviewManifestEntry(
       backgroundColor = backgroundColor,
       device = device,
       showSystemUi = showSystemUi,
+      uiMode = uiMode,
       outputBaseName = outputBaseName ?: id,
       wrapperClassName = wrapperClassName,
       kind = p?.kind,
@@ -315,6 +337,12 @@ data class PreviewParamsEntry(
    */
   val showSystemUi: Boolean = false,
   /**
+   * `@Preview(uiMode = ...)`. Only the `UI_MODE_NIGHT_*` bits are consumed — selects dark
+   * `SystemBarsFrame` chrome (and dark `LocalSystemTheme`) for night `showSystemUi` previews so the
+   * live daemon matches the standalone renderer instead of painting light chrome (issue #1930).
+   */
+  val uiMode: Int = 0,
+  /**
    * FQN of the `PreviewWrapperProvider` from `@PreviewWrapper(SomeProvider::class)` when the source
    * preview is annotated. Read at discovery time by `extractWrapperFqn` against the class-file
    * annotation tables (the upstream annotation has `AnnotationRetention.BINARY`, so
@@ -336,6 +364,7 @@ data class ResolvedRenderParams(
   val backgroundColor: Long,
   val device: String?,
   val showSystemUi: Boolean = false,
+  val uiMode: Int = 0,
   val outputBaseName: String,
   val wrapperClassName: String? = null,
   val kind: String? = null,

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -360,10 +360,35 @@ class RenderEngine(
                 }
               }
             }
+            // `@Preview(showSystemUi = true)` (issue #1930) — wrap the composition in the synthetic
+            // [ee.schimke.composeai.renderer.SystemBarsFrame] so the daemon's desktop capture draws
+            // the same Android phone chrome (status bar + gesture-nav pill) the Android renderer
+            // and
+            // the standalone `:renderer-desktop` path do, instead of a chrome-less surface. Dark
+            // chrome follows the resolved [RenderSpec.uiMode]; skipped for round/Wear devices.
+            val framed: @Composable () -> Unit = {
+              if (
+                ee.schimke.composeai.renderer.shouldApplySystemBars(
+                  showSystemUi = spec.showSystemUi,
+                  device = spec.device,
+                  kind = spec.kind,
+                )
+              ) {
+                ee.schimke.composeai.renderer.SystemBarsFrame(
+                  // 0x20 == Configuration.UI_MODE_NIGHT_YES — the only bit SystemBarsFrame
+                  // inspects.
+                  uiMode = if (spec.uiMode == RenderSpec.SpecUiMode.DARK) 0x20 else 0
+                ) {
+                  content()
+                }
+              } else {
+                content()
+              }
+            }
             if (slotTableCapture != null) {
-              InspectablePreviewContent(slotTableCapture, content)
+              InspectablePreviewContent(slotTableCapture, framed)
             } else {
-              content()
+              framed()
             }
           }
         }
@@ -945,6 +970,14 @@ data class RenderSpec(
    * payload can drive both backends.
    */
   val device: String? = null,
+  /**
+   * `@Preview(showSystemUi = ...)` (issue #1930). When `true` on a phone-shape capture the render
+   * body wraps the composition in `:renderer-desktop`'s `SystemBarsFrame` — a synthetic status bar
+   * + gesture-nav pill that simulates Android phone chrome on this non-Android backend, matching
+   *   what the Android renderer draws so a single design reference matches either candidate.
+   *   Skipped for round/Wear [device]s. Dark chrome follows [uiMode].
+   */
+  val showSystemUi: Boolean = false,
   /** Stem used for the output PNG filename (e.g. "preview-A" → "<outputDir>/preview-A.png"). */
   val outputBaseName: String = "${className.substringAfterLast('.')}-$functionName",
   /**
@@ -1047,6 +1080,7 @@ data class RenderSpec(
         showBackground = map["showBackground"]?.toBoolean() ?: defaults.showBackground,
         backgroundColor = map["backgroundColor"]?.toLongOrNull() ?: defaults.backgroundColor,
         device = map["device"]?.takeIf { it.isNotBlank() } ?: defaults.device,
+        showSystemUi = map["showSystemUi"]?.toBoolean() ?: defaults.showSystemUi,
         outputBaseName = map["outputBaseName"] ?: defaults.outputBaseName,
         localeTag = map["localeTag"]?.takeIf { it.isNotBlank() },
         fontScale = map["fontScale"]?.toFloatOrNull(),

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderPreviewsTask.kt
@@ -280,6 +280,14 @@ abstract class RenderPreviewsTask : DefaultTask() {
           // annotation default / no-op; omitting it keeps older callers at 1.0 on the renderer
           // side.
           preview.params.fontScale.toString(),
+          // 22nd–24th — `@Preview(showSystemUi = ...)` (issue #1930). When set on a phone-shape
+          // capture, DesktopRendererMain wraps the composition in the synthetic `SystemBarsFrame`
+          // (status bar + gesture-nav pill) so the desktop capture matches the Android renderer
+          // instead of coming back chrome-less. uiMode carries the night bit for dark chrome;
+          // device is forwarded only so the renderer can skip round/Wear surfaces.
+          preview.params.showSystemUi.toString(),
+          preview.params.uiMode.toString(),
+          preview.params.device.orEmpty(),
         )
     }
   }

--- a/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRendererMain.kt
+++ b/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRendererMain.kt
@@ -43,6 +43,14 @@ import org.jetbrains.skia.EncodedImageFormat
  * no resource-qualifier system, so it's threaded through `Density(density, fontScale)` (and
  * re-provided as `LocalDensity`); omit or pass `1.0` for the no-op default.
  *
+ * Args 22–24 carry `@Preview(showSystemUi = ...)` support (issue #1930). When [showSystemUi] is
+ * `true` and the capture is phone-shape (not a round/Wear device, not a tile), the renderer wraps
+ * the composition in [SystemBarsFrame] — a synthetic status bar + gesture-nav pill that *simulates*
+ * Android phone chrome on this non-Android backend, matching what the Android/Robolectric renderer
+ * draws for the same `@Preview`. Arg 23 (`uiMode`) is the `@Preview(uiMode = …)` int (only the
+ * `UI_MODE_NIGHT_*` bits matter — dark chrome on a night capture); arg 24 (`device`) is the raw
+ * device string used only to skip round/Wear surfaces. All default to "no system UI".
+ *
  * The optional 9th argument is the FQN of a `PreviewWrapperProvider` (Compose 1.11+); pass an empty
  * string or omit to skip wrapping.
  *
@@ -137,6 +145,13 @@ fun main(args: Array<String>) {
   // unparseable falls back to 1.0f (no-op) so older callers and the LOTTIE path keep their
   // behaviour.
   val fontScale = args.getOrNull(20)?.toFloatOrNull()?.takeIf { it > 0f } ?: 1.0f
+  // Args 22–24 — `@Preview(showSystemUi = ...)` (issue #1930). When showSystemUi is set on a
+  // phone-shape capture the renderer wraps the composition in [SystemBarsFrame] (synthetic Android
+  // chrome). uiMode supplies the night bit for dark chrome; device is consulted only to skip
+  // round/Wear surfaces. All optional — missing/blank keeps the chrome-less default.
+  val showSystemUi = args.getOrNull(21)?.toBoolean() ?: false
+  val uiMode = args.getOrNull(22)?.toIntOrNull() ?: 0
+  val device = args.getOrNull(23)?.takeIf { it.isNotBlank() }
   if (previewKind == "LOTTIE") {
     val assetPath = args.getOrNull(19)?.takeIf { it.isNotBlank() }
     val sidecar = errorSidecarFor(outputFile)
@@ -272,6 +287,9 @@ fun main(args: Array<String>) {
             previewArgs,
             localeTag,
             fontScale,
+            showSystemUi,
+            uiMode,
+            device,
           )
         }
       } else {
@@ -290,6 +308,9 @@ fun main(args: Array<String>) {
           previewArgs,
           localeTag,
           fontScale,
+          showSystemUi,
+          uiMode,
+          device,
         )
       }
       // Display filters — post-capture colour-matrix variants (grayscale / invert / daltonizer
@@ -508,6 +529,9 @@ private fun renderPreview(
   previewArgs: List<Any?>,
   localeTag: String?,
   fontScale: Float = 1.0f,
+  showSystemUi: Boolean = false,
+  uiMode: Int = 0,
+  device: String? = null,
   fileSystem: FileSystem = SystemFileSystem,
 ) {
   val clazz = Class.forName(className)
@@ -614,10 +638,25 @@ private fun renderPreview(
       // `@PreviewWrapper(Provider::class)` — instantiate the provider reflectively
       // so the renderer stays compatible with apps on stable Compose (no
       // `PreviewWrapperProvider` on classpath).
-      if (wrapperClassName != null) {
-        InvokeWrappedComposable(wrapperClassName, body)
+      val wrapped: @Composable () -> Unit = {
+        if (wrapperClassName != null) {
+          InvokeWrappedComposable(wrapperClassName, body)
+        } else {
+          body()
+        }
+      }
+      // `@Preview(showSystemUi = true)` on a phone-shape capture wraps the composition in the
+      // synthetic [SystemBarsFrame] (issue #1930). Desktop/Skiko has no Android SystemUI process,
+      // so without this the canvas comes back at the right device size but chrome-less; the frame
+      // simulates the status + gesture-nav bars to match the Android renderer. showSystemUi pins
+      // both axes to the device frame (no wrap-content crop), so wrapping outside `body` is safe.
+      // kind is always COMPOSE here — LOTTIE short-circuits in main() before reaching
+      // renderPreview,
+      // and desktop never produces TILE captures — so the gate reduces to showSystemUi + non-round.
+      if (shouldApplySystemBars(showSystemUi, device, kind = null)) {
+        SystemBarsFrame(uiMode = uiMode) { wrapped() }
       } else {
-        body()
+        wrapped()
       }
     }
   }

--- a/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/SystemBarsFrame.kt
+++ b/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/SystemBarsFrame.kt
@@ -1,0 +1,210 @@
+package ee.schimke.composeai.renderer
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+/**
+ * **Simulation of an Android system-UI feature on a non-Android backend.**
+ *
+ * The desktop (Skiko / `ImageComposeScene`) renderer has no Android `SystemUI` process and no
+ * LayoutLib frame overlay, so it has no real status bar or navigation bar to draw —
+ * `@Preview(showSystemUi = true)` would otherwise be a silent no-op here, coming back at the right
+ * canvas size but chrome-less (issue #1930). This composable *fakes* the phone chrome — a status
+ * bar at the top and a gesture-pill navigation bar at the bottom — purely in Compose, so a desktop
+ * capture renders inside something that *looks* like a phone screenshot rather than a naked
+ * rectangle.
+ *
+ * It is **not** real Android system UI: it's a synthetic, cosmetic frame the renderer paints to
+ * imitate what Android Studio's preview pane (and the Android/Robolectric renderer's
+ * [`SystemBarsFrame`][android equivalent]) show for the same `@Preview`. Nothing here reads device
+ * state, the time, or a real battery level — the "9:30" clock and ~75% battery glyph are fixed mock
+ * values, matching the Android side.
+ *
+ * **Why it's a verbatim port.** The whole point of #1930 is cross-backend parity: the same
+ * `@Preview(showSystemUi = true)` should render identically on the Android and desktop backends so
+ * a single committed design reference (which depicts a realistic phone screen *including* the
+ * status bar) matches either candidate. The bar heights, clock, battery, gesture pill, and the
+ * light/dark tint logic are therefore kept pixel-identical to
+ * `renderers/android/.../SystemBarsFrame.kt`. **If you change one, change both** — divergence
+ * reintroduces the systematic vertical offset (#1930) that this frame exists to eliminate.
+ *
+ * Usage on desktop mirrors the Android renderer's automatic wrap: the renderer wraps the
+ * composition in this frame when `showSystemUi = true` resolves to a phone-shape capture (skipped
+ * for round Wear devices and tile previews). It is also safe to call directly from a composable
+ * when you want the simulated chrome inside an app screenshot.
+ *
+ * Style choices (kept in lockstep with the Android renderer):
+ * - Bars are translucent overlays on top of the content (`Box` overlay, not a `Column` that resizes
+ *   the body), matching modern edge-to-edge Android behaviour. No content is reserved out from
+ *   under the bars.
+ * - 24dp status bar with a "9:30" clock on the left and a small battery glyph on the right.
+ * - 24dp navigation bar with a centred gesture pill (~108×4dp).
+ * - Light/dark tint chosen from the [uiMode] mask so a `night` capture gets dark chrome with light
+ *   icons rather than always-light overlays on top of a dark surface.
+ *
+ * @param uiMode Configuration UI-mode bits. Only the `UI_MODE_NIGHT_*` bits are inspected — the
+ *   renderer threads through the discovered `@Preview(uiMode = …)` value; pass `0` for light
+ *   chrome.
+ */
+@Composable
+fun SystemBarsFrame(uiMode: Int, content: @Composable () -> Unit) {
+  val night = (uiMode and UI_MODE_NIGHT_MASK) == UI_MODE_NIGHT_YES
+  val barTint = if (night) Color(0x70000000) else Color(0x70FFFFFF)
+  val foreground = if (night) Color(0xFFEBEBEB) else Color(0xFF141414)
+
+  Box(modifier = Modifier.fillMaxSize()) {
+    content()
+    StatusBar(
+      modifier = Modifier.align(Alignment.TopCenter),
+      tint = barTint,
+      foreground = foreground,
+    )
+    NavigationPillBar(
+      modifier = Modifier.align(Alignment.BottomCenter),
+      tint = barTint,
+      foreground = foreground,
+    )
+  }
+}
+
+@Composable
+private fun StatusBar(modifier: Modifier, tint: Color, foreground: Color) {
+  Row(
+    modifier =
+      modifier
+        .fillMaxWidth()
+        .height(STATUS_BAR_HEIGHT_DP.dp)
+        .background(tint)
+        .padding(horizontal = SIDE_INSET_DP.dp),
+    verticalAlignment = Alignment.CenterVertically,
+  ) {
+    BasicText(
+      text = "9:30",
+      style = TextStyle(color = foreground, fontSize = 12.sp, fontWeight = FontWeight.Bold),
+    )
+    Spacer(modifier = Modifier.weight(1f))
+    BatteryGlyph(color = foreground)
+  }
+}
+
+/**
+ * Compact battery icon — outlined body with a terminal nub and a ~75% fill. Drawn with `Canvas`
+ * rather than nested `Box`es so the stroke + fill can share one drawing pass. Mirrors the Android
+ * renderer's glyph exactly.
+ */
+@Composable
+private fun BatteryGlyph(color: Color) {
+  Canvas(modifier = Modifier.width(BATTERY_WIDTH_DP.dp).height(BATTERY_HEIGHT_DP.dp)) {
+    val nubW = 1.5.dp.toPx()
+    val nubH = size.height * 0.5f
+    val cornerR = 1.5.dp.toPx()
+    val strokeW = 1.dp.toPx()
+    val bodyW = size.width - nubW
+    val bodyH = size.height
+    // Outline — drawn as stroke, leaves the centre transparent so the
+    // background tint shows through.
+    drawRoundRect(
+      color = color,
+      topLeft = androidx.compose.ui.geometry.Offset(0f, 0f),
+      size = androidx.compose.ui.geometry.Size(bodyW, bodyH),
+      cornerRadius = androidx.compose.ui.geometry.CornerRadius(cornerR),
+      style = androidx.compose.ui.graphics.drawscope.Stroke(width = strokeW),
+    )
+    // Terminal nub.
+    drawRoundRect(
+      color = color,
+      topLeft = androidx.compose.ui.geometry.Offset(bodyW, (bodyH - nubH) / 2f),
+      size = androidx.compose.ui.geometry.Size(nubW, nubH),
+      cornerRadius = androidx.compose.ui.geometry.CornerRadius(cornerR / 2f),
+    )
+    // ~75% charge fill so the glyph reads as a battery rather than an
+    // empty rectangle.
+    val pad = strokeW + 0.5f
+    val fillW = ((bodyW - pad * 2f) * 0.75f).coerceAtLeast(1f)
+    drawRoundRect(
+      color = color,
+      topLeft = androidx.compose.ui.geometry.Offset(pad, pad),
+      size = androidx.compose.ui.geometry.Size(fillW, bodyH - pad * 2f),
+      cornerRadius = androidx.compose.ui.geometry.CornerRadius(cornerR / 2f),
+    )
+  }
+}
+
+@Composable
+private fun NavigationPillBar(modifier: Modifier, tint: Color, foreground: Color) {
+  Box(
+    modifier = modifier.fillMaxWidth().height(NAV_BAR_HEIGHT_DP.dp).background(tint),
+    contentAlignment = Alignment.Center,
+  ) {
+    // Gesture handle: rounded pill centred horizontally; sits visually a
+    // hair lower than the bar's centre to match Android's placement.
+    Box(
+      modifier =
+        Modifier.padding(top = (NAV_BAR_HEIGHT_DP / 6).dp)
+          .size(width = PILL_WIDTH_DP.dp, height = PILL_HEIGHT_DP.dp)
+          .clip(RoundedCornerShape(PILL_HEIGHT_DP.dp / 2))
+          .background(foreground)
+          .fillMaxHeight()
+    )
+  }
+}
+
+private const val STATUS_BAR_HEIGHT_DP = 24
+private const val NAV_BAR_HEIGHT_DP = 24
+private const val SIDE_INSET_DP = 16
+private const val BATTERY_WIDTH_DP = 16
+private const val BATTERY_HEIGHT_DP = 8
+private const val PILL_WIDTH_DP = 108
+private const val PILL_HEIGHT_DP = 4
+
+/**
+ * `(uiMode and UI_MODE_NIGHT_MASK) == UI_MODE_NIGHT_YES` — kept as raw constants so the call site
+ * stays free of an `android.content.res` import (there is no `android.*` on the desktop classpath
+ * anyway), matching how the Android renderer's twin consumes the `uiMode` int.
+ */
+private const val UI_MODE_NIGHT_MASK = 0x30
+private const val UI_MODE_NIGHT_YES = 0x20
+
+/**
+ * Phone-shape gate for the synthetic [SystemBarsFrame], mirroring the Android renderer's
+ * `showSystemUi && kind != TILE && !isRoundDevice(device)` decision.
+ *
+ * The desktop renderer never produces Wear/tile captures (those are Android-only render kinds), but
+ * the round-device string check is kept for parity so a `device = "id:wearos_*_round"` /
+ * `spec:...,isRound=true` capture doesn't get phone chrome stamped on a circular surface.
+ * Recognises the same tokens as the device catalog's `isRoundDeviceString`.
+ */
+fun shouldApplySystemBars(showSystemUi: Boolean, device: String?, kind: String?): Boolean {
+  if (!showSystemUi) return false
+  if (kind.equals("TILE", ignoreCase = true)) return false
+  return !isRoundDeviceString(device)
+}
+
+private fun isRoundDeviceString(device: String?): Boolean {
+  val lower = device?.lowercase() ?: return false
+  return lower.contains("_round") ||
+    lower.contains("isround=true") ||
+    lower.contains("shape=round") ||
+    lower.contains("wear")
+}

--- a/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/SystemBarsFrameTest.kt
+++ b/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/SystemBarsFrameTest.kt
@@ -1,0 +1,137 @@
+package ee.schimke.composeai.renderer
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.ImageComposeScene
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.unit.Density
+import java.awt.image.BufferedImage
+import java.io.ByteArrayInputStream
+import javax.imageio.ImageIO
+import org.jetbrains.skia.EncodedImageFormat
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Desktop twin of the Android renderer's `SystemBarsFrameTest`. Verifies the ported
+ * [SystemBarsFrame] paints a status bar at the top and a navigation pill bar at the bottom on the
+ * Skiko backend, with the same light/dark tint behaviour — the cross-backend parity issue #1930
+ * relies on. Renders through [ImageComposeScene] (the same path `DesktopRendererMain` uses),
+ * encodes to PNG, and samples pixel rows at known y-offsets.
+ *
+ * Also covers [shouldApplySystemBars]'s phone-shape gate so a round/Wear surface or a chrome-less
+ * default doesn't accidentally get phone bars stamped on it.
+ */
+class SystemBarsFrameTest {
+
+  private fun renderToImage(
+    width: Int,
+    height: Int,
+    uiMode: Int,
+    body: @Composable () -> Unit,
+  ): BufferedImage {
+    val scene = ImageComposeScene(width = width, height = height, density = Density(1f))
+    try {
+      scene.setContent {
+        CompositionLocalProvider(LocalInspectionMode provides true) {
+          SystemBarsFrame(uiMode = uiMode, content = body)
+        }
+      }
+      scene.render()
+      val image = scene.render()
+      val png =
+        image.encodeToData(EncodedImageFormat.PNG)
+          ?: error("Failed to encode SystemBarsFrame test image")
+      return ByteArrayInputStream(png.bytes).use { ImageIO.read(it) }
+    } finally {
+      scene.close()
+    }
+  }
+
+  @Test
+  fun `light mode paints translucent bars over the top and bottom of the content`() {
+    val width = 200
+    val height = 600
+    val image =
+      renderToImage(width, height, uiMode = 0) {
+        Box(modifier = Modifier.fillMaxSize().background(Color.Red))
+      }
+
+    val centre = image.getRGB(width / 2, height / 2)
+    // Centre is body content — the red fill is preserved untouched.
+    assertTrue(
+      "centre pixel should remain a strong red, got rgb=" +
+        "(${centre.red()},${centre.green()},${centre.blue()})",
+      centre.red() > 200 && centre.green() < 50 && centre.blue() < 50,
+    )
+
+    // Status bar lifts the red toward pink via its translucent white tint. Sample the bar middle
+    // (clear of the left clock text and the right battery glyph).
+    val status = image.getRGB(width / 2, 4)
+    assertTrue(
+      "status bar pixel should have a green/blue lift from the white tint, " +
+        "got rgb=(${status.red()},${status.green()},${status.blue()})",
+      status.green() > 40 && status.blue() > 40,
+    )
+
+    val nav = image.getRGB(width / 2, height - 4)
+    assertTrue(
+      "nav bar pixel should have a green/blue lift from the white tint, " +
+        "got rgb=(${nav.red()},${nav.green()},${nav.blue()})",
+      nav.green() > 40 && nav.blue() > 40,
+    )
+  }
+
+  @Test
+  fun `dark mode darkens the top strip rather than lightening it`() {
+    val width = 200
+    val height = 600
+    // 0x20 == Configuration.UI_MODE_NIGHT_YES — the only bit SystemBarsFrame inspects.
+    val image =
+      renderToImage(width, height, uiMode = 0x20) {
+        Box(modifier = Modifier.fillMaxSize().background(Color.Red))
+      }
+
+    val status = image.getRGB(width / 2, 4)
+    // Translucent black tint pulls the red channel below the original 255 fill.
+    assertTrue(
+      "dark-mode status bar pixel should be darkened by the night tint, got red=${status.red()}",
+      status.red() < 230,
+    )
+  }
+
+  @Test
+  fun `gate applies bars only for phone-shape system-ui captures`() {
+    assertTrue(shouldApplySystemBars(showSystemUi = true, device = "id:pixel_8", kind = "COMPOSE"))
+    assertTrue(shouldApplySystemBars(showSystemUi = true, device = null, kind = null))
+    // No showSystemUi → chrome-less default.
+    assertFalse(
+      shouldApplySystemBars(showSystemUi = false, device = "id:pixel_8", kind = "COMPOSE")
+    )
+    // Round / Wear surfaces keep their own framing.
+    assertFalse(
+      shouldApplySystemBars(showSystemUi = true, device = "id:wearos_large_round", kind = "COMPOSE")
+    )
+    assertFalse(
+      shouldApplySystemBars(
+        showSystemUi = true,
+        device = "spec:width=200dp,height=200dp,isRound=true",
+        kind = "COMPOSE",
+      )
+    )
+    // Tiles fill the whole watch face — bars don't apply.
+    assertFalse(shouldApplySystemBars(showSystemUi = true, device = "id:pixel_8", kind = "TILE"))
+  }
+
+  private fun Int.red() = (this shr 16) and 0xFF
+
+  private fun Int.green() = (this shr 8) and 0xFF
+
+  private fun Int.blue() = this and 0xFF
+}

--- a/samples/cmp/src/main/kotlin/com/example/samplecmp/Previews.kt
+++ b/samples/cmp/src/main/kotlin/com/example/samplecmp/Previews.kt
@@ -1,16 +1,24 @@
 package com.example.samplecmp
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 
 @Preview(name = "Red Box", backgroundColor = 0xFFFF0000, showBackground = true)
 @Composable
@@ -50,5 +58,43 @@ fun WallpaperDemoPreview() {
     contentAlignment = Alignment.Center,
   ) {
     Text("Primary", color = MaterialTheme.colorScheme.onPrimary)
+  }
+}
+
+/**
+ * Issue #1930: rendering a known phone (Pixel 8) with `showSystemUi = true` on the **desktop /
+ * Compose-Multiplatform** backend should produce a PNG that *looks* like a phone screenshot — full
+ * device canvas plus the synthetic system bars (status bar at the top, gesture-pill nav at the
+ * bottom). The desktop/Skiko renderer has no Android `SystemUI` process to draw real bars, so it
+ * simulates them via `SystemBarsFrame` to match what the Android renderer (issue #256) and Android
+ * Studio draw for the same `@Preview`, so a single committed design reference matches either
+ * candidate.
+ *
+ * Two variants — light and dark — exercise the `uiMode`-aware tint branches of the frame so
+ * reviewers can confirm the bars adapt to the theme rather than always rendering as light chrome on
+ * a dark surface. This is the CMP-desktop counterpart of the Android sample's
+ * `Pixel8SystemUiPreview`.
+ */
+@Preview(name = "Pixel 8", device = "id:pixel_8", showSystemUi = true)
+@Preview(
+  name = "Pixel 8 - Night",
+  device = "id:pixel_8",
+  showSystemUi = true,
+  // 32 == android.content.res.Configuration.UI_MODE_NIGHT_YES. The CMP common source set has no
+  // `android.*`, so the raw bit value is used directly (the discovery + renderer treat it as an
+  // int).
+  uiMode = 32,
+)
+@Composable
+fun Pixel8SystemUiPreview() {
+  val scheme = if (isSystemInDarkTheme()) darkColorScheme() else lightColorScheme()
+  MaterialTheme(colorScheme = scheme) {
+    Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
+      Column(modifier = Modifier.padding(24.dp)) {
+        Text(text = "Pixel 8", color = MaterialTheme.colorScheme.onBackground, fontSize = 28.sp)
+        Box(modifier = Modifier.size(8.dp))
+        Text(text = "showSystemUi = true", color = MaterialTheme.colorScheme.onBackground)
+      }
+    }
   }
 }


### PR DESCRIPTION
Closes #1930.

## Problem

The desktop (Skiko) renderer had no equivalent of the Android renderer's `SystemBarsFrame`, so `@Preview(showSystemUi = true)` was silently a no-op on desktop: the capture came back at the right device size but **chrome-less** — no status bar, no nav bar, the screen's own top app bar sitting at y=0. Adopting design-parity on the CMP desktop path (meshcore-mobile), that missing ~28px status bar offset every candidate row upward and dominated the visual diff, forcing the references to strip their (realistic) status bar to match.

## Fix

Port the synthetic system-bars frame (status bar + gesture-nav pill) to the desktop render path, kept **pixel-identical** to the Android renderer so a single committed design reference matches either backend.

To be explicit about what this is: it's a **cosmetic simulation of an Android system-UI feature on a non-Android backend** — there's no SystemUI process on Skiko, so we fake the chrome the same way the Android/Robolectric renderer and Android Studio do. It reads no device state; the "9:30" clock and ~75% battery are fixed mock values. This framing is called out in the new file's KDoc and the `shouldApplySystemBars` naming, **not** in the rendered pixels (so parity holds).

- **`renderers/desktop/.../SystemBarsFrame.kt`** — verbatim port of the Android twin (pure Compose, no `android.*`), plus a `shouldApplySystemBars(showSystemUi, device, kind)` gate mirroring Android's `showSystemUi && kind != TILE && !isRoundDevice`.
- **Standalone renderer** — `DesktopRendererMain` gains args 22–24 (`showSystemUi` / `uiMode` / `device`) and wraps the composition when phone-shaped; the gradle `RenderPreviewsTask` forwards them. This is the path that produces design-parity captures.
- **Live daemon** — `RenderEngine` + `PreviewManifestRouter` honor `showSystemUi` too (reusing the shared composable), so VS Code's desktop preview stays consistent with the gradle path rather than splitting chrome / chrome-less.
- **Coverage** — added a CMP `Pixel8SystemUiPreview` (light + night) mirroring the Android #256 demo, so the preview-comment CI bot renders and diffs it on every future PR automatically; plus a desktop `SystemBarsFrameTest`.

`showSystemUi` stays opt-in — default desktop captures remain naked surfaces (no behaviour change for previews that don't ask for chrome). Round/Wear and tile surfaces are skipped so phone chrome isn't stamped on a circular face.

## Visual evidence

Rendered through this repo's own `:samples:cmp:composePreviewRenderAll` (local renderer with the change). **Before:** the same `@Preview` returned chrome-less. **After:** simulated bars appear and adapt to `uiMode`:

| Light | Night |
|---|---|
| status bar `9:30` + battery, gesture pill at bottom | dark-tinted bars with light glyphs |

(Renders attached in chat; the CI preview-comment bot will also render the new fixture on this PR.)

## Test plan

- `./gradlew :renderer-desktop:test --tests "*SystemBarsFrameTest"` — passes (light/dark pixel sampling + gate).
- `:renderer-desktop`, `:daemon:desktop`, `:samples:cmp`, and `gradle-plugin` all compile.
- `:samples:cmp:composePreviewRenderAll` renders `Pixel8SystemUiPreview` with the bars (light + night).

---
_Generated by [Claude Code](https://claude.ai/code/session_017WGHki1uNQU2LafGEbGFvq)_