### PR TITLE
feat(samples): shared-element transitions + Compose 1.11 visual-debug previews

### DIFF
--- a/samples/android/src/main/kotlin/com/example/sampleandroid/SharedElementDebugPreviews.kt
+++ b/samples/android/src/main/kotlin/com/example/sampleandroid/SharedElementDebugPreviews.kt
@@ -1,0 +1,259 @@
+package com.example.sampleandroid
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.AnimatedVisibilityScope
+import androidx.compose.animation.BoundsTransform
+import androidx.compose.animation.ExperimentalLookaheadAnimationVisualDebugApi
+import androidx.compose.animation.LookaheadAnimationVisualDebugging
+import androidx.compose.animation.SharedTransitionLayout
+import androidx.compose.animation.SharedTransitionScope
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import ee.schimke.composeai.preview.AnimatedPreview
+
+/**
+ * Compose **1.11's shared-element visual debugging** (`LookaheadAnimationVisualDebugging`) captured
+ * as GIFs.
+ *
+ * 1.11 added a runtime debug composable you wrap *around* a `SharedTransitionLayout`. While a shared
+ * transition is in flight it paints, into the shared overlay:
+ * - the **target bounds** each element is animating toward (semi-transparent fill, [overlayColor]),
+ * - **unmatched** elements — a shared key with no counterpart in the other state — in
+ *   [unmatchedColor] (red), the single most common shared-element bug,
+ * - **multiply-matched** keys — the same key registered more than once — in [multipleMatchesColor]
+ *   (green), the other common bug,
+ * - optional **key labels** so you can read which `rememberSharedContentState(key = …)` each box
+ *   belongs to.
+ *
+ * Android Studio's Animation Preview can't inspect shared elements, and the overlay only exists
+ * *during* a transition, so a paused-clock GIF is the natural way to put it in front of a reviewer
+ * or an agent. These previews are the rendered, diffable proof that the overlay behaves — pair them
+ * with the un-instrumented transitions in [ContainerTransformAnimatedPreview].
+ *
+ * Requires the `@ExperimentalLookaheadAnimationVisualDebugApi` opt-in (the debug API is still
+ * experimental in 1.11 even though the shared-element APIs themselves are stable).
+ */
+private val debugBoundsSpec = BoundsTransform { _, _ -> tween(durationMillis = 600) }
+
+private enum class DebugScreen {
+    Collapsed,
+    Expanded,
+}
+
+/**
+ * A **well-formed** container transform under the debug overlay: every shared key (`avatar`,
+ * `title`, `container`) has a matched counterpart, so the overlay only draws target-bounds rectangles
+ * and key labels — no red, no green. This is the "what correct looks like" baseline.
+ */
+@OptIn(ExperimentalLookaheadAnimationVisualDebugApi::class)
+@Preview(name = "Shared Element Debug — Matched", widthDp = 300, heightDp = 520, showBackground = true)
+@AnimatedPreview(durationMs = 750)
+@Composable
+fun SharedElementDebugMatchedAnimatedPreview() {
+    var screen by remember { mutableStateOf(DebugScreen.Collapsed) }
+    LaunchedEffect(Unit) { screen = DebugScreen.Expanded }
+    MaterialTheme {
+        Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.surface) {
+            LookaheadAnimationVisualDebugging(isEnabled = true, isShowKeyLabelEnabled = true) {
+                SharedTransitionLayout(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+                    AnimatedContent(
+                        targetState = screen,
+                        label = "debug-matched",
+                        modifier = Modifier.fillMaxSize(),
+                    ) { target ->
+                        when (target) {
+                            DebugScreen.Collapsed ->
+                                DebugCollapsed(
+                                    this@SharedTransitionLayout,
+                                    this@AnimatedContent,
+                                    includeBadge = false,
+                                )
+                            DebugScreen.Expanded ->
+                                DebugExpanded(this@SharedTransitionLayout, this@AnimatedContent)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * The **broken** version: the collapsed state declares an extra `badge` shared element that the
+ * expanded state never registers. During the transition the overlay flags `badge` as **unmatched**
+ * in red — exactly the diagnostic you'd reach for when a shared element silently fails to animate
+ * because a key is missing on one side.
+ */
+@OptIn(ExperimentalLookaheadAnimationVisualDebugApi::class)
+@Preview(
+    name = "Shared Element Debug — Unmatched",
+    widthDp = 300,
+    heightDp = 520,
+    showBackground = true,
+)
+@AnimatedPreview(durationMs = 750)
+@Composable
+fun SharedElementDebugUnmatchedAnimatedPreview() {
+    var screen by remember { mutableStateOf(DebugScreen.Collapsed) }
+    LaunchedEffect(Unit) { screen = DebugScreen.Expanded }
+    MaterialTheme {
+        Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.surface) {
+            LookaheadAnimationVisualDebugging(
+                isEnabled = true,
+                unmatchedElementColor = Color(0xCCD32F2F),
+                isShowKeyLabelEnabled = true,
+            ) {
+                SharedTransitionLayout(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+                    AnimatedContent(
+                        targetState = screen,
+                        label = "debug-unmatched",
+                        modifier = Modifier.fillMaxSize(),
+                    ) { target ->
+                        when (target) {
+                            DebugScreen.Collapsed ->
+                                DebugCollapsed(
+                                    this@SharedTransitionLayout,
+                                    this@AnimatedContent,
+                                    includeBadge = true,
+                                )
+                            DebugScreen.Expanded ->
+                                DebugExpanded(this@SharedTransitionLayout, this@AnimatedContent)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DebugCollapsed(
+    sharedScope: SharedTransitionScope,
+    visibilityScope: AnimatedVisibilityScope,
+    includeBadge: Boolean,
+) =
+    with(sharedScope) {
+        Row(
+            modifier =
+                Modifier.sharedBounds(
+                        rememberSharedContentState(key = "container"),
+                        animatedVisibilityScope = visibilityScope,
+                        boundsTransform = debugBoundsSpec,
+                    )
+                    .clip(RoundedCornerShape(20.dp))
+                    .background(Color(0xFFD7E3FF))
+                    .fillMaxWidth()
+                    .padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Box(
+                modifier =
+                    Modifier.sharedElement(
+                            rememberSharedContentState(key = "avatar"),
+                            animatedVisibilityScope = visibilityScope,
+                            boundsTransform = debugBoundsSpec,
+                        )
+                        .size(48.dp)
+                        .clip(CircleShape)
+                        .background(Color(0xFF345CA8))
+            )
+            Spacer(Modifier.size(12.dp))
+            Text(
+                "Glacier trail",
+                modifier =
+                    Modifier.sharedBounds(
+                        rememberSharedContentState(key = "title"),
+                        animatedVisibilityScope = visibilityScope,
+                        boundsTransform = debugBoundsSpec,
+                    ),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+            )
+            if (includeBadge) {
+                Spacer(Modifier.size(8.dp))
+                // This `badge` key exists only in the collapsed state — the overlay flags it as an
+                // unmatched (red) shared element while the transition runs.
+                Box(
+                    modifier =
+                        Modifier.sharedElement(
+                                rememberSharedContentState(key = "badge"),
+                                animatedVisibilityScope = visibilityScope,
+                                boundsTransform = debugBoundsSpec,
+                            )
+                            .size(20.dp)
+                            .clip(CircleShape)
+                            .background(Color(0xFFEF6C00))
+                )
+            }
+        }
+    }
+
+@Composable
+private fun DebugExpanded(
+    sharedScope: SharedTransitionScope,
+    visibilityScope: AnimatedVisibilityScope,
+) =
+    with(sharedScope) {
+        Column(
+            modifier =
+                Modifier.sharedBounds(
+                        rememberSharedContentState(key = "container"),
+                        animatedVisibilityScope = visibilityScope,
+                        boundsTransform = debugBoundsSpec,
+                    )
+                    .clip(RoundedCornerShape(28.dp))
+                    .background(Color(0xFFD7E3FF))
+                    .fillMaxSize()
+                    .padding(20.dp)
+        ) {
+            Box(
+                modifier =
+                    Modifier.sharedElement(
+                            rememberSharedContentState(key = "avatar"),
+                            animatedVisibilityScope = visibilityScope,
+                            boundsTransform = debugBoundsSpec,
+                        )
+                        .size(120.dp)
+                        .clip(CircleShape)
+                        .background(Color(0xFF345CA8))
+            )
+            Spacer(Modifier.size(16.dp))
+            Text(
+                "Glacier trail",
+                modifier =
+                    Modifier.sharedBounds(
+                        rememberSharedContentState(key = "title"),
+                        animatedVisibilityScope = visibilityScope,
+                        boundsTransform = debugBoundsSpec,
+                    ),
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold,
+            )
+        }
+    }

--- a/samples/android/src/main/kotlin/com/example/sampleandroid/SharedElementFilmstripPreview.kt
+++ b/samples/android/src/main/kotlin/com/example/sampleandroid/SharedElementFilmstripPreview.kt
@@ -1,0 +1,194 @@
+package com.example.sampleandroid
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.AnimatedVisibilityScope
+import androidx.compose.animation.BoundsTransform
+import androidx.compose.animation.SharedTransitionLayout
+import androidx.compose.animation.SharedTransitionScope
+import androidx.compose.animation.core.SeekableTransitionState
+import androidx.compose.animation.core.rememberTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+/**
+ * A **deterministic filmstrip** of a shared-element container transform — one static, diffable PNG
+ * that lays the same transition out at five fixed progress fractions (0% → 100%) stacked top to
+ * bottom.
+ *
+ * Where [ContainerTransformAnimatedPreview] uses the `@AnimatedPreview` paused-clock GIF (great for
+ * *watching* the motion), this preview is the static counterpart: each panel freezes the transition
+ * at an exact fraction with [SeekableTransitionState.seekTo], so the in-between bounds interpolation
+ * is legible in a single image and a visual-diff bot can compare it pixel-for-pixel without the
+ * frame-timing jitter a GIF carries. `seekTo(fraction, target)` is the stable primitive for "render
+ * any intermediate frame" — the same one Android Studio's scrubber is built on — driven here to a
+ * literal constant per panel rather than swept by a clock.
+ *
+ * Each panel builds its own `SeekableTransitionState`, seeks it once on first composition, and feeds
+ * the resulting `Transition` into `Transition.AnimatedContent` so the shared modifiers get the
+ * `AnimatedVisibilityScope` they need.
+ */
+private val filmstripBoundsSpec = BoundsTransform { _, _ -> tween(durationMillis = 600) }
+
+private enum class FilmScreen {
+    Collapsed,
+    Expanded,
+}
+
+private val FILMSTRIP_FRACTIONS = listOf(0f, 0.25f, 0.5f, 0.75f, 1f)
+
+@Preview(name = "Shared Element Filmstrip", widthDp = 340, heightDp = 820, showBackground = true)
+@Composable
+fun SharedElementFilmstripPreview() {
+    MaterialTheme {
+        Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.surface) {
+            Column(
+                modifier = Modifier.fillMaxSize().padding(12.dp),
+                verticalArrangement = Arrangement.spacedBy(10.dp),
+            ) {
+                FILMSTRIP_FRACTIONS.forEach { fraction -> FilmstripPanel(fraction) }
+            }
+        }
+    }
+}
+
+@Composable
+private fun FilmstripPanel(fraction: Float) {
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Text(
+            "${(fraction * 100).toInt()}%",
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            fontWeight = FontWeight.SemiBold,
+        )
+        val seekState = remember { SeekableTransitionState(FilmScreen.Collapsed) }
+        // One-shot seek to a constant fraction; the panel renders the transition frozen there.
+        LaunchedEffect(Unit) { seekState.seekTo(fraction = fraction, targetState = FilmScreen.Expanded) }
+        val transition = rememberTransition(seekState, label = "filmstrip-$fraction")
+        Box(modifier = Modifier.fillMaxWidth().height(132.dp)) {
+            SharedTransitionLayout(modifier = Modifier.fillMaxSize()) {
+                transition.AnimatedContent { target ->
+                    when (target) {
+                        FilmScreen.Collapsed ->
+                            FilmCollapsed(this@SharedTransitionLayout, this@AnimatedContent)
+                        FilmScreen.Expanded ->
+                            FilmExpanded(this@SharedTransitionLayout, this@AnimatedContent)
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun FilmCollapsed(
+    sharedScope: SharedTransitionScope,
+    visibilityScope: AnimatedVisibilityScope,
+) =
+    with(sharedScope) {
+        Row(
+            modifier =
+                Modifier.sharedBounds(
+                        rememberSharedContentState(key = "container"),
+                        animatedVisibilityScope = visibilityScope,
+                        boundsTransform = filmstripBoundsSpec,
+                    )
+                    .clip(RoundedCornerShape(16.dp))
+                    .background(Color(0xFFE8DEF8))
+                    .padding(10.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Box(
+                modifier =
+                    Modifier.sharedElement(
+                            rememberSharedContentState(key = "avatar"),
+                            animatedVisibilityScope = visibilityScope,
+                            boundsTransform = filmstripBoundsSpec,
+                        )
+                        .size(36.dp)
+                        .clip(CircleShape)
+                        .background(Color(0xFF6750A4))
+            )
+            Spacer(Modifier.size(10.dp))
+            Text(
+                "Aurora ridge",
+                modifier =
+                    Modifier.sharedBounds(
+                        rememberSharedContentState(key = "title"),
+                        animatedVisibilityScope = visibilityScope,
+                        boundsTransform = filmstripBoundsSpec,
+                    ),
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.SemiBold,
+            )
+        }
+    }
+
+@Composable
+private fun FilmExpanded(
+    sharedScope: SharedTransitionScope,
+    visibilityScope: AnimatedVisibilityScope,
+) =
+    with(sharedScope) {
+        Row(
+            modifier =
+                Modifier.sharedBounds(
+                        rememberSharedContentState(key = "container"),
+                        animatedVisibilityScope = visibilityScope,
+                        boundsTransform = filmstripBoundsSpec,
+                    )
+                    .clip(RoundedCornerShape(22.dp))
+                    .background(Color(0xFFE8DEF8))
+                    .fillMaxSize()
+                    .padding(14.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Box(
+                modifier =
+                    Modifier.sharedElement(
+                            rememberSharedContentState(key = "avatar"),
+                            animatedVisibilityScope = visibilityScope,
+                            boundsTransform = filmstripBoundsSpec,
+                        )
+                        .size(88.dp)
+                        .clip(CircleShape)
+                        .background(Color(0xFF6750A4))
+            )
+            Spacer(Modifier.size(14.dp))
+            Text(
+                "Aurora ridge",
+                modifier =
+                    Modifier.sharedBounds(
+                        rememberSharedContentState(key = "title"),
+                        animatedVisibilityScope = visibilityScope,
+                        boundsTransform = filmstripBoundsSpec,
+                    ),
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold,
+            )
+        }
+    }

--- a/samples/android/src/main/kotlin/com/example/sampleandroid/SharedElementPreviews.kt
+++ b/samples/android/src/main/kotlin/com/example/sampleandroid/SharedElementPreviews.kt
@@ -1,0 +1,288 @@
+package com.example.sampleandroid
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.AnimatedVisibilityScope
+import androidx.compose.animation.BoundsTransform
+import androidx.compose.animation.SharedTransitionLayout
+import androidx.compose.animation.SharedTransitionScope
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import ee.schimke.composeai.preview.AnimatedPreview
+
+/**
+ * Shared-element transition samples, captured as GIFs through the `@AnimatedPreview` paused-clock
+ * pipeline.
+ *
+ * Compose's shared transition APIs (`SharedTransitionLayout`, `Modifier.sharedBounds` /
+ * `Modifier.sharedElement`, `rememberSharedContentState`) became **stable in 1.10** (Dec 2025) and
+ * are what these previews exercise. Because Android Studio's Animation Preview does **not** inspect
+ * shared-element transitions, the headless GIF capture here is the only way to *see* a container
+ * transform stepped frame-by-frame outside a running device — it's the shared-element analogue of
+ * the existing `FadeInBoxAnimatedPreview`.
+ *
+ * Each preview kicks the transition off on the first frame: the `AnimatedContent` target flips from
+ * the "collapsed" to the "expanded" state inside a `LaunchedEffect`, so the inspector sees a
+ * transition in flight across the whole captured window. A fixed `tween` [boundsSpec] keeps the
+ * bounds morph deterministic (the default `sharedBounds` spec is a spring, whose settle time drifts
+ * between Compose versions and makes diffs noisy).
+ */
+private val boundsSpec = BoundsTransform { _, _ -> tween(durationMillis = 600) }
+
+private enum class CardScreen {
+    Collapsed,
+    Expanded,
+}
+
+/**
+ * The canonical **container transform**: a compact list row morphs into a full detail pane. The
+ * avatar (`sharedElement`), the title (`sharedBounds`), and the card surface (`sharedBounds`) all
+ * carry continuous identity, so the row visually grows into the detail screen rather than
+ * cross-fading.
+ */
+@Preview(name = "Container Transform", widthDp = 300, heightDp = 520, showBackground = true)
+@AnimatedPreview(durationMs = 750)
+@Composable
+fun ContainerTransformAnimatedPreview() {
+    var screen by remember { mutableStateOf(CardScreen.Collapsed) }
+    LaunchedEffect(Unit) { screen = CardScreen.Expanded }
+    MaterialTheme {
+        Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.surface) {
+            SharedTransitionLayout(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+                AnimatedContent(
+                    targetState = screen,
+                    label = "container-transform",
+                    modifier = Modifier.fillMaxSize(),
+                ) { target ->
+                    when (target) {
+                        CardScreen.Collapsed ->
+                            CollapsedCard(this@SharedTransitionLayout, this@AnimatedContent)
+                        CardScreen.Expanded ->
+                            ExpandedCard(this@SharedTransitionLayout, this@AnimatedContent)
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CollapsedCard(
+    sharedScope: SharedTransitionScope,
+    visibilityScope: AnimatedVisibilityScope,
+) =
+    with(sharedScope) {
+        Row(
+            modifier =
+                Modifier.sharedBounds(
+                        rememberSharedContentState(key = "container"),
+                        animatedVisibilityScope = visibilityScope,
+                        boundsTransform = boundsSpec,
+                    )
+                    .clip(RoundedCornerShape(20.dp))
+                    .background(Color(0xFFE8DEF8))
+                    .fillMaxWidth()
+                    .padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Box(
+                modifier =
+                    Modifier.sharedElement(
+                            rememberSharedContentState(key = "avatar"),
+                            animatedVisibilityScope = visibilityScope,
+                            boundsTransform = boundsSpec,
+                        )
+                        .size(48.dp)
+                        .clip(CircleShape)
+                        .background(Color(0xFF6750A4))
+            )
+            Spacer(Modifier.size(12.dp))
+            Text(
+                "Aurora ridge",
+                modifier =
+                    Modifier.sharedBounds(
+                        rememberSharedContentState(key = "title"),
+                        animatedVisibilityScope = visibilityScope,
+                        boundsTransform = boundsSpec,
+                    ),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+            )
+        }
+    }
+
+@Composable
+private fun ExpandedCard(
+    sharedScope: SharedTransitionScope,
+    visibilityScope: AnimatedVisibilityScope,
+) =
+    with(sharedScope) {
+        Column(
+            modifier =
+                Modifier.sharedBounds(
+                        rememberSharedContentState(key = "container"),
+                        animatedVisibilityScope = visibilityScope,
+                        boundsTransform = boundsSpec,
+                    )
+                    .clip(RoundedCornerShape(28.dp))
+                    .background(Color(0xFFE8DEF8))
+                    .fillMaxSize()
+                    .padding(20.dp)
+        ) {
+            Box(
+                modifier =
+                    Modifier.sharedElement(
+                            rememberSharedContentState(key = "avatar"),
+                            animatedVisibilityScope = visibilityScope,
+                            boundsTransform = boundsSpec,
+                        )
+                        .size(120.dp)
+                        .clip(CircleShape)
+                        .background(Color(0xFF6750A4))
+            )
+            Spacer(Modifier.size(16.dp))
+            Text(
+                "Aurora ridge",
+                modifier =
+                    Modifier.sharedBounds(
+                        rememberSharedContentState(key = "title"),
+                        animatedVisibilityScope = visibilityScope,
+                        boundsTransform = boundsSpec,
+                    ),
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold,
+            )
+            Spacer(Modifier.size(12.dp))
+            Text(
+                "A long ridgeline walk above the cloud line, finishing at a glacial tarn. " +
+                    "Body copy that only exists in the detail state fades in over the morphing " +
+                    "container.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+
+private enum class FabScreen {
+    Fab,
+    Sheet,
+}
+
+/**
+ * **FAB → sheet** container transform: a floating action button morphs into a bottom sheet. Shows
+ * `sharedBounds` with an explicit enter/exit ([fadeIn] / [fadeOut]) so the FAB's icon cross-fades
+ * out while the sheet's content fades in over the shared, resizing container — the resize behaviour
+ * Material's `ResizeMode.scaleToBounds()` would otherwise scale, here remeasured so the text stays
+ * crisp.
+ */
+@Preview(name = "FAB To Sheet", widthDp = 320, heightDp = 360, showBackground = true)
+@AnimatedPreview(durationMs = 750)
+@Composable
+fun FabToSheetAnimatedPreview() {
+    var screen by remember { mutableStateOf(FabScreen.Fab) }
+    LaunchedEffect(Unit) { screen = FabScreen.Sheet }
+    MaterialTheme {
+        Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.surface) {
+            SharedTransitionLayout(modifier = Modifier.fillMaxSize()) {
+                AnimatedContent(
+                    targetState = screen,
+                    label = "fab-to-sheet",
+                    modifier = Modifier.fillMaxSize(),
+                ) { target ->
+                    when (target) {
+                        FabScreen.Fab -> FabState(this@SharedTransitionLayout, this@AnimatedContent)
+                        FabScreen.Sheet ->
+                            SheetState(this@SharedTransitionLayout, this@AnimatedContent)
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun FabState(sharedScope: SharedTransitionScope, visibilityScope: AnimatedVisibilityScope) =
+    with(sharedScope) {
+        Box(modifier = Modifier.fillMaxSize().padding(20.dp), contentAlignment = Alignment.BottomEnd) {
+            Box(
+                modifier =
+                    Modifier.sharedBounds(
+                            rememberSharedContentState(key = "fab-container"),
+                            animatedVisibilityScope = visibilityScope,
+                            enter = fadeIn(),
+                            exit = fadeOut(),
+                            boundsTransform = boundsSpec,
+                        )
+                        .size(64.dp)
+                        .clip(RoundedCornerShape(20.dp))
+                        .background(Color(0xFF6750A4)),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text("+", color = Color.White, fontSize = 28.sp)
+            }
+        }
+    }
+
+@Composable
+private fun SheetState(
+    sharedScope: SharedTransitionScope,
+    visibilityScope: AnimatedVisibilityScope,
+) =
+    with(sharedScope) {
+        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.BottomCenter) {
+            Column(
+                modifier =
+                    Modifier.sharedBounds(
+                            rememberSharedContentState(key = "fab-container"),
+                            animatedVisibilityScope = visibilityScope,
+                            enter = fadeIn(),
+                            exit = fadeOut(),
+                            boundsTransform = boundsSpec,
+                        )
+                        .fillMaxWidth()
+                        .height(220.dp)
+                        .clip(RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp))
+                        .background(Color(0xFF6750A4))
+                        .padding(20.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Text("New reminder", color = Color.White, style = MaterialTheme.typography.titleLarge)
+                Text(
+                    "The FAB expands into the sheet surface — the same node, resized — while the " +
+                        "form content fades in on top.",
+                    color = Color.White.copy(alpha = 0.85f),
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+            }
+        }
+    }


### PR DESCRIPTION
## Summary

Adds Android samples that exercise Compose's **shared-element transitions** through the existing preview pipeline. Shared-element APIs (`SharedTransitionLayout` / `sharedBounds` / `sharedElement` / `rememberSharedContentState`) went stable in **1.10**; **1.11** added the runtime visual-debugging composable `LookaheadAnimationVisualDebugging`. Android Studio's Animation Preview *can't* inspect shared elements, so headless capture is the only way to step one frame-by-frame outside a device. Verified against the repo's actual classpath (`compose-bom 2026.05.01` → `androidx.compose.animation:animation:1.11.2`).

Three new files / five previews:

- **`SharedElementPreviews.kt`** — `@AnimatedPreview` GIFs of a container transform (list row → detail) and a FAB → sheet morph.
- **`SharedElementDebugPreviews.kt`** — Compose 1.11's `LookaheadAnimationVisualDebugging` overlay (`@ExperimentalLookaheadAnimationVisualDebugApi`), with a matched baseline and a deliberately-**unmatched** key the overlay flags (`badge: 0`).
- **`SharedElementFilmstripPreview.kt`** — a single static PNG laying the transition out at five frozen progress fractions (0% → 100%) via `SeekableTransitionState.seekTo`. The deterministic, diffable counterpart to the GIFs.

These flow through `@AnimatedPreview` / `@Preview` discovery, so future PRs get before/after coverage automatically — no new capture path needed.

## Visual evidence (rendered headless via the preview pipeline)

### Container transform (`@AnimatedPreview` GIF, mid-frame)
List row morphs into the detail pane — avatar enlarges, title moves, body copy fades in; the animation-curve strip below tracks the transition.

### 1.11 visual-debug overlay — unmatched element (`@AnimatedPreview` GIF, early frame)
`container` / `avatar` / `title` are matched (target-bounds rects + rainbow trajectory borders + key labels); the `badge` key — present only in the collapsed state — is flagged `badge: 0` (zero matches), the most common shared-element bug made visible.

### Deterministic filmstrip (static PNG)
The same container transform frozen at 0% / 25% / 50% / 75% / 100% via `seekTo`, so the in-between bounds interpolation is legible in one diffable image.

> GIFs + frames were shared with the author in the session; they render green end-to-end (23-frame GIFs + one static filmstrip PNG).

## Test plan

- [x] `./gradlew :samples:android:compileDebugKotlin` — compiles against Compose 1.11.2
- [x] `./gradlew :samples:android:ktfmtCheck` — passes the format gate
- [x] `./gradlew :samples:android:composePreviewRenderAll` — all five previews render (4 GIFs + 1 PNG)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YDJXuRjJfB96JM6QpsmHng)_