### PR TITLE
feat(cli): guide convention-plugin builds when auto-inject can't see AGP

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -774,21 +774,22 @@ internal fun printDiscoveryFailures(
 }
 
 /**
- * Recognises the "auto-injected plugin can't see AGP" failure signature: a
- * `NoClassDefFoundError` / `ClassNotFoundException` on an AGP variant-API class
- * (`com.android.build.api.variant.*`, e.g. `AndroidComponentsExtension`). The
- * `NoClassDefFoundError` form carries the internal name (`com/android/build/api/variant/…`) and the
- * `ClassNotFoundException` form the dotted name, so we match either separator.
+ * Recognises the "auto-injected plugin can't see AGP" failure signature: a `NoClassDefFoundError` /
+ * `ClassNotFoundException` on an AGP variant-API class (`com.android.build.api.variant.*`, e.g.
+ * `AndroidComponentsExtension`). The `NoClassDefFoundError` form carries the internal name
+ * (`com/android/build/api/variant/…`) and the `ClassNotFoundException` form the dotted name, so we
+ * match either separator.
  *
  * This arises when AGP is supplied by an **included build's convention plugin** (the `build-logic`
  * pattern): AGP's classes live on the convention plugin's classloader, but auto-inject puts
  * `ee.schimke.composeai.preview` on each project's *own* buildscript classpath — a sibling
  * classloader that can't see AGP — so the plugin's `apply()` throws the moment it touches
- * `AndroidComponentsExtension`. See [agpClassloaderGuidance] for the user-facing remedy (issue
- * #1947).
+ * `AndroidComponentsExtension`. See [agpClassloaderGuidance] for the user-facing remedy
+ * (issue #1947).
  */
 internal fun isAgpClassloaderFailure(message: String): Boolean {
-  val mentionsAgpVariantApi = Regex("""com[./]android[./]build[./]api[./]variant""").containsMatchIn(message)
+  val mentionsAgpVariantApi =
+    Regex("""com[./]android[./]build[./]api[./]variant""").containsMatchIn(message)
   val classloaderError =
     message.contains("NoClassDefFoundError") || message.contains("ClassNotFoundException")
   return mentionsAgpVariantApi && classloaderError

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -757,6 +757,13 @@ internal fun printDiscoveryFailures(
   err: (String) -> Unit = System.err::println,
 ) {
   if (failures.isEmpty()) return
+  // When the failures are dominated by the "auto-injected plugin can't see AGP" signature there's
+  // a single actionable cause — emit the guidance instead of N cryptic NoClassDefFoundError stacks
+  // (issue #1947).
+  agpClassloaderGuidance(failures)?.let {
+    err(it)
+    return
+  }
   err(
     "${failures.size} project(s) failed to configure during discovery and were skipped — " +
       "their previews are not listed. This is the usual cause of an empty discovery when the " +
@@ -764,6 +771,72 @@ internal fun printDiscoveryFailures(
   )
   failures.take(limit).forEach { err("  ${it.path}: ${it.message}") }
   if (failures.size > limit) err("  … and ${failures.size - limit} more")
+}
+
+/**
+ * Recognises the "auto-injected plugin can't see AGP" failure signature: a
+ * `NoClassDefFoundError` / `ClassNotFoundException` on an AGP variant-API class
+ * (`com.android.build.api.variant.*`, e.g. `AndroidComponentsExtension`). The
+ * `NoClassDefFoundError` form carries the internal name (`com/android/build/api/variant/…`) and the
+ * `ClassNotFoundException` form the dotted name, so we match either separator.
+ *
+ * This arises when AGP is supplied by an **included build's convention plugin** (the `build-logic`
+ * pattern): AGP's classes live on the convention plugin's classloader, but auto-inject puts
+ * `ee.schimke.composeai.preview` on each project's *own* buildscript classpath — a sibling
+ * classloader that can't see AGP — so the plugin's `apply()` throws the moment it touches
+ * `AndroidComponentsExtension`. See [agpClassloaderGuidance] for the user-facing remedy (issue
+ * #1947).
+ */
+internal fun isAgpClassloaderFailure(message: String): Boolean {
+  val mentionsAgpVariantApi = Regex("""com[./]android[./]build[./]api[./]variant""").containsMatchIn(message)
+  val classloaderError =
+    message.contains("NoClassDefFoundError") || message.contains("ClassNotFoundException")
+  return mentionsAgpVariantApi && classloaderError
+}
+
+/**
+ * When discovery failures are *dominated* by the AGP-classloader signature
+ * ([isAgpClassloaderFailure]), returns one actionable message explaining that auto-inject can't be
+ * made to work for the included-build / convention-plugin layout and how to apply the plugin from
+ * the convention plugin instead. Returns `null` otherwise so [printDiscoveryFailures] falls back to
+ * the per-project list — a lone AGP error amid many unrelated configuration failures shouldn't
+ * suppress the others.
+ *
+ * "Dominated" = the signature accounts for at least half the failures. Auto-inject genuinely can't
+ * reach AGP's classloader here (there is no init-script API to add a dependency to an included
+ * build's classpath), so this is a guidance fix, not a render fix (issue #1947).
+ */
+internal fun agpClassloaderGuidance(failures: List<ProjectDiscoveryFailure>): String? {
+  if (failures.isEmpty()) return null
+  val matching = failures.count { isAgpClassloaderFailure(it.message) }
+  if (matching == 0 || matching * 2 < failures.size) return null
+  return buildString {
+    appendLine(
+      "$matching of ${failures.size} project(s) failed to configure during discovery with the " +
+        "same root cause: the compose-preview plugin can't see the Android Gradle Plugin " +
+        "(NoClassDefFoundError on com.android.build.api.variant.* — AGP's variant API)."
+    )
+    appendLine()
+    appendLine(
+      "This build supplies AGP through an included build's convention plugin (the build-logic " +
+        "pattern), so AGP is loaded by the convention plugin's classloader. Auto-inject puts " +
+        "ee.schimke.composeai.preview on each project's own buildscript classpath — a sibling " +
+        "classloader that can't reach AGP — so the plugin throws the moment it touches AGP. " +
+        "There is no init-script API to add the plugin to the included build's classpath, so " +
+        "auto-inject can't fix this layout."
+    )
+    appendLine()
+    appendLine(
+      "Apply the plugin from your convention plugin instead: stage " +
+        "`id(\"ee.schimke.composeai.preview\") apply false` and put the plugin marker on " +
+        "build-logic's classpath, then apply it alongside AGP in the convention plugin. The CLI " +
+        "detects that and skips auto-inject automatically."
+    )
+    append(
+      "Docs: https://yschimke.github.io/compose-ai-tools/install/" +
+        "#builds-that-apply-agp-via-a-convention-plugin"
+    )
+  }
 }
 
 internal val NON_PNG_PREVIEW_KINDS = setOf("XR_SUBSPACE")

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -828,10 +828,13 @@ internal fun agpClassloaderGuidance(failures: List<ProjectDiscoveryFailure>): St
     )
     appendLine()
     appendLine(
-      "Apply the plugin from your convention plugin instead: stage " +
-        "`id(\"ee.schimke.composeai.preview\") apply false` and put the plugin marker on " +
-        "build-logic's classpath, then apply it alongside AGP in the convention plugin. The CLI " +
-        "detects that and skips auto-inject automatically."
+      "Apply the plugin from your convention plugin instead: add the plugin marker to your " +
+        "build-logic build's dependencies " +
+        "(implementation(\"ee.schimke.composeai.preview:" +
+        "ee.schimke.composeai.preview.gradle.plugin:<version>\")) so it's on the convention " +
+        "plugin's runtime classpath, then pluginManager.apply(\"ee.schimke.composeai.preview\") " +
+        "alongside AGP in the convention plugin. The CLI detects that and skips auto-inject " +
+        "automatically."
     )
     append(
       "Docs: https://yschimke.github.io/compose-ai-tools/install/" +

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/DiscoveryFailureReportingTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/DiscoveryFailureReportingTest.kt
@@ -44,4 +44,74 @@ class DiscoveryFailureReportingTest {
     assertEquals(12, lines.size, "got $lines")
     assertTrue(lines.last().contains("and 5 more"), "got ${lines.last()}")
   }
+
+  // The AGP-classloader signature (issue #1947): auto-inject puts the plugin on a sibling
+  // classloader that can't see AGP when AGP is supplied by an included build's convention plugin.
+  private val noClassDefFound =
+    "ComposePreviewPlugin failure -> NoClassDefFoundError: " +
+      "com/android/build/api/variant/AndroidComponentsExtension -> " +
+      "ClassNotFoundException: com.android.build.api.variant.AndroidComponentsExtension"
+
+  @Test
+  fun `recognises the AGP NoClassDefFoundError signature in either name form`() {
+    assertTrue(isAgpClassloaderFailure(noClassDefFound))
+    // NoClassDefFoundError alone (internal slash name).
+    assertTrue(
+      isAgpClassloaderFailure(
+        "NoClassDefFoundError: com/android/build/api/variant/Variant"
+      )
+    )
+    // ClassNotFoundException alone (dotted name).
+    assertTrue(
+      isAgpClassloaderFailure(
+        "ClassNotFoundException: com.android.build.api.variant.AndroidComponentsExtension"
+      )
+    )
+    // Unrelated failures don't match.
+    assertTrue(!isAgpClassloaderFailure("Cannot resolve external dependency"))
+    assertTrue(
+      !isAgpClassloaderFailure("already on the classpath with an unknown version"),
+      "the #1855 double-apply collision is a different cause and must not be misclassified",
+    )
+    // AGP class mentioned without a classloader error → not this signature.
+    assertTrue(
+      !isAgpClassloaderFailure("com.android.build.api.variant.Variant misconfigured")
+    )
+  }
+
+  @Test
+  fun `emits the convention-plugin guidance instead of the raw stack list when dominated by AGP`() {
+    val failures =
+      (1..59).map { ProjectDiscoveryFailure(":module$it", noClassDefFound) }
+    val lines = mutableListOf<String>()
+    printDiscoveryFailures(failures, err = { lines += it })
+    // One guidance block, not 59 NoClassDefFoundError lines.
+    assertEquals(1, lines.size, "expected a single guidance message; got $lines")
+    val msg = lines.single()
+    assertTrue(msg.contains("can't see the Android Gradle Plugin"), msg)
+    assertTrue(msg.contains("convention plugin"), msg)
+    assertTrue(msg.contains("ee.schimke.composeai.preview\") apply false"), msg)
+    assertTrue(
+      msg.contains("install/#builds-that-apply-agp-via-a-convention-plugin"),
+      "guidance should link to the integration docs; got $msg",
+    )
+    // Reports the proportion so the count from #1939 is preserved.
+    assertTrue(msg.contains("59 of 59 project(s)"), msg)
+  }
+
+  @Test
+  fun `falls back to the per-project list when AGP failures are not dominant`() {
+    val failures =
+      listOf(
+        ProjectDiscoveryFailure(":app", noClassDefFound),
+        ProjectDiscoveryFailure(":lib", "Cannot resolve external dependency"),
+        ProjectDiscoveryFailure(":data", "Cannot resolve external dependency"),
+      )
+    val lines = mutableListOf<String>()
+    printDiscoveryFailures(failures, err = { lines += it })
+    // A lone AGP error among unrelated failures keeps the detailed list.
+    assertTrue(lines.first().contains("3 project(s) failed to configure"), "got ${lines.first()}")
+    assertTrue(lines.any { it.contains(":lib:") }, "got $lines")
+    assertEquals(null, agpClassloaderGuidance(failures))
+  }
 }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/DiscoveryFailureReportingTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/DiscoveryFailureReportingTest.kt
@@ -57,9 +57,7 @@ class DiscoveryFailureReportingTest {
     assertTrue(isAgpClassloaderFailure(noClassDefFound))
     // NoClassDefFoundError alone (internal slash name).
     assertTrue(
-      isAgpClassloaderFailure(
-        "NoClassDefFoundError: com/android/build/api/variant/Variant"
-      )
+      isAgpClassloaderFailure("NoClassDefFoundError: com/android/build/api/variant/Variant")
     )
     // ClassNotFoundException alone (dotted name).
     assertTrue(
@@ -74,15 +72,12 @@ class DiscoveryFailureReportingTest {
       "the #1855 double-apply collision is a different cause and must not be misclassified",
     )
     // AGP class mentioned without a classloader error → not this signature.
-    assertTrue(
-      !isAgpClassloaderFailure("com.android.build.api.variant.Variant misconfigured")
-    )
+    assertTrue(!isAgpClassloaderFailure("com.android.build.api.variant.Variant misconfigured"))
   }
 
   @Test
   fun `emits the convention-plugin guidance instead of the raw stack list when dominated by AGP`() {
-    val failures =
-      (1..59).map { ProjectDiscoveryFailure(":module$it", noClassDefFound) }
+    val failures = (1..59).map { ProjectDiscoveryFailure(":module$it", noClassDefFound) }
     val lines = mutableListOf<String>()
     printDiscoveryFailures(failures, err = { lines += it })
     // One guidance block, not 59 NoClassDefFoundError lines.

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/DiscoveryFailureReportingTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/DiscoveryFailureReportingTest.kt
@@ -85,7 +85,15 @@ class DiscoveryFailureReportingTest {
     val msg = lines.single()
     assertTrue(msg.contains("can't see the Android Gradle Plugin"), msg)
     assertTrue(msg.contains("convention plugin"), msg)
-    assertTrue(msg.contains("ee.schimke.composeai.preview\") apply false"), msg)
+    // The remedy must put the plugin marker on the convention build's runtime classpath via an
+    // implementation dependency — `apply false` in build-logic's plugins{} block resolves it only
+    // for that build script, not for the compiled convention plugin (PR #1948 Codex review).
+    assertTrue(
+      msg.contains("implementation(\"ee.schimke.composeai.preview:") &&
+        msg.contains("ee.schimke.composeai.preview.gradle.plugin"),
+      "guidance should tell users to add the plugin marker as a build-logic dependency; got $msg",
+    )
+    assertTrue(msg.contains("pluginManager.apply(\"ee.schimke.composeai.preview\")"), msg)
     assertTrue(
       msg.contains("install/#builds-that-apply-agp-via-a-convention-plugin"),
       "guidance should link to the integration docs; got $msg",

--- a/site/install.md
+++ b/site/install.md
@@ -47,6 +47,66 @@ Because the CLI auto-injects, projects that already apply
 work without touching `build.gradle.kts`. Projects that already declare the
 plugin are detected and left alone, so mixed setups don't conflict.
 
+## Builds that apply AGP via a convention plugin
+
+If your build supplies the Android Gradle Plugin through an **included build's
+convention plugin** — the `build-logic` / `gradle/conventions` pattern used by
+[Now in Android](https://github.com/android/nowinandroid), AndroidX, and
+similar repos — auto-inject **cannot** apply the preview plugin, and discovery
+will report `0 modules` with failures like:
+
+```
+NoClassDefFoundError: com/android/build/api/variant/AndroidComponentsExtension
+```
+
+This is a classloader limitation, not a bug. With the convention-plugin layout
+AGP is applied by the included build, so AGP's classes live on the *convention
+plugin's* classloader. Auto-inject can only add the preview plugin to each
+project's **own** buildscript classpath — a sibling classloader that can't see
+AGP — so the plugin throws the moment it touches `AndroidComponentsExtension`.
+There is no Gradle init-script API to contribute a dependency to an included
+build's classpath, so auto-inject genuinely can't reach AGP here.
+
+**Apply the plugin from your convention plugin instead.** That puts it on the
+same classloader as AGP, where it renders correctly. The CLI then detects the
+included-build apply and skips auto-inject automatically (no
+`--no-auto-inject` needed).
+
+1. Stage the plugin in `build-logic`'s `plugins {}` block (so its marker lands
+   on the convention build's classpath) and apply it from your convention
+   plugin alongside AGP:
+
+   ```kotlin
+   // build-logic/.../build.gradle.kts (the convention build)
+   plugins {
+       `kotlin-dsl`
+       // Stage so the marker is on build-logic's classpath. `apply false`:
+       // the convention plugin applies it per-module, not build-logic itself.
+       id("ee.schimke.composeai.preview") version "<latest>" apply false
+   }
+   ```
+
+   ```kotlin
+   // build-logic/.../YourAndroidConventionPlugin.kt
+   override fun apply(target: Project) = with(target) {
+       pluginManager.apply("com.android.library") // or the AGP plugin you use
+       pluginManager.apply("ee.schimke.composeai.preview")
+       // …rest of your convention…
+   }
+   ```
+
+2. Run the CLI as usual — it sees the included build provides the plugin and
+   leaves your build alone:
+
+   ```sh
+   compose-preview render
+   ```
+
+This is the explicit "apply manually via your convention plugin" integration
+mode: auto-inject is the zero-config convenience for the common
+`plugins { id("com.android.application") }` layout; the convention-plugin
+layout opts out of it by design.
+
 ## Gradle plugin (version-pinned)
 
 If you'd rather wire it into your build explicitly, the plugin is published

--- a/site/install.md
+++ b/site/install.md
@@ -72,19 +72,30 @@ same classloader as AGP, where it renders correctly. The CLI then detects the
 included-build apply and skips auto-inject automatically (no
 `--no-auto-inject` needed).
 
-1. Stage the plugin in `build-logic`'s `plugins {}` block (so its marker lands
-   on the convention build's classpath) and apply it from your convention
-   plugin alongside AGP:
+1. Add the preview plugin's **marker artifact** to your `build-logic` build's
+   dependencies. This is the key step: it puts the plugin on the convention
+   build's *runtime* classpath, so the compiled convention plugin can apply it
+   by id. (Declaring it in `build-logic`'s `plugins {}` block with `apply
+   false` only resolves it for that build script — not for the convention
+   plugin applied to your app modules, which fails with `Plugin with id … not
+   found`.) The marker coordinate is `<id>:<id>.gradle.plugin:<version>`:
 
    ```kotlin
    // build-logic/.../build.gradle.kts (the convention build)
    plugins {
        `kotlin-dsl`
-       // Stage so the marker is on build-logic's classpath. `apply false`:
-       // the convention plugin applies it per-module, not build-logic itself.
-       id("ee.schimke.composeai.preview") version "<latest>" apply false
+   }
+   dependencies {
+       implementation(
+           "ee.schimke.composeai.preview:ee.schimke.composeai.preview.gradle.plugin:<latest>"
+       )
    }
    ```
+
+   Make sure `build-logic`'s repositories include where the plugin is
+   published (`mavenCentral()` / `gradlePluginPortal()`).
+
+2. Apply it from your convention plugin alongside AGP:
 
    ```kotlin
    // build-logic/.../YourAndroidConventionPlugin.kt
@@ -95,7 +106,7 @@ included-build apply and skips auto-inject automatically (no
    }
    ```
 
-2. Run the CLI as usual — it sees the included build provides the plugin and
+3. Run the CLI as usual — it sees the included build provides the plugin and
    leaves your build alone:
 
    ```sh


### PR DESCRIPTION
## Summary

When a build supplies AGP via an **included build's convention plugin** (the `build-logic` pattern — AndroidX, Now in Android, the `yschimke/androidchka` overlay), auto-inject can't apply `ee.schimke.composeai.preview`: the injected plugin lands on each project's own buildscript classpath, a sibling classloader that can't see AGP, so every Android project fails discovery with `NoClassDefFoundError: com.android.build.api.variant.AndroidComponentsExtension` and the CLI reports 0 modules (surfaced via #1939's per-project failure reporting).

Auto-inject genuinely **can't** be made to work for this layout — there's no init-script API to add a dependency to an included build's classpath. So per the issue, this is a *guidance* fix, not a render fix:

1. **Detect & guide.** `printDiscoveryFailures` now recognises when discovery failures are *dominated* by the AGP-classloader signature (`NoClassDefFoundError` / `ClassNotFoundException` on `com.android.build.api.variant.*`) and emits **one** actionable message — "apply the plugin from your convention plugin instead" — rather than N cryptic stack lines. A lone AGP error among unrelated failures still gets the full per-project list.
2. **Document.** Adds a "Builds that apply AGP via a convention plugin" section to the install docs describing the explicit *apply-via-your-convention-plugin* integration mode (`id(...) apply false` + the build-logic classpath marker), which the CLI already auto-detects via `includedBuildProvidesComposeAiPreviewPlugin` (#1939) and skips auto-inject for.

## Changes

- `cli/.../Commands.kt`: new `isAgpClassloaderFailure` / `agpClassloaderGuidance` helpers; `printDiscoveryFailures` short-circuits to the guidance when the signature dominates.
- `site/install.md`: new integration-mode section, linked from the guidance message.
- `cli/.../DiscoveryFailureReportingTest.kt`: coverage for the signature matcher (both name forms, negative cases incl. the #1855 double-apply collision), the dominated-by guidance path, and the non-dominant fallback.

## Test plan

- `./gradlew :cli:test --tests "ee.schimke.composeai.cli.DiscoveryFailureReportingTest"` — green.
- Non-visual change (CLI diagnostics + docs + tests), so no rendered-preview evidence applies.

Closes #1947

---
_Generated by [Claude Code](https://claude.ai/code/session_01W9BEQj3eeHdDWcExAbUcb5)_