### PR TITLE
feat(daemon/history): history/diff data mode — a11y/semantics/theme diff (#1873)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -126,6 +126,7 @@ tasks.register("functionalTestWithAndroid") {
 //       api :daemon:core
 //         api :renderer-xr-client (daemon-core fronts the native XR render server — RENDERER_SERVICE)
 //         api :data-layoutinspector-core (semantics models + differ for `history/diff mode=semantics`, #1785)
+//         api :data-theme-core (theme-token models + differ for `history/diff mode=data`, #1873)
 //     implementation :lottie-preview-runtime (Compottie-backed kind=LOTTIE render path)
 //   plus :common-io (the Okio file-IO foundation those modules read/write through).
 val bundleRenderFunctionalTestPublishTargets =
@@ -140,6 +141,7 @@ val bundleRenderFunctionalTestPublishTargets =
     ":daemon:core",
     ":renderer-xr-client",
     ":data-layoutinspector-core",
+    ":data-theme-core",
     ":lottie-preview-runtime",
     ":common-io",
   )

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/HistoryCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/HistoryCommand.kt
@@ -1,6 +1,8 @@
 package ee.schimke.composeai.cli
 
 import ee.schimke.composeai.daemon.history.GitRefHistorySource
+import ee.schimke.composeai.daemon.history.HistoryDataDelta
+import ee.schimke.composeai.daemon.history.HistoryDataDiff
 import ee.schimke.composeai.daemon.history.HistoryDiffArtifacts
 import ee.schimke.composeai.daemon.history.HistoryEntry
 import ee.schimke.composeai.daemon.history.HistoryFilter
@@ -169,9 +171,9 @@ class HistoryCommand(private val args: List<String>) {
   private fun diff() {
     val json = "--json" in args
     val mode = args.flagValue("--mode") ?: "metadata"
-    if (mode != "metadata" && mode != "pixel" && mode != "semantics") {
+    if (mode != "metadata" && mode != "pixel" && mode != "semantics" && mode != "data") {
       System.err.println(
-        "history diff: unknown --mode '$mode'. Use metadata (default), pixel, or semantics."
+        "history diff: unknown --mode '$mode'. Use metadata (default), pixel, semantics, or data."
       )
       exitProcess(1)
     }
@@ -293,6 +295,37 @@ class HistoryCommand(private val args: List<String>) {
 
       println("diff ${from.id} → ${to.id}  (preview ${from.previewId})")
       println(formatSemanticsDeltaHuman(delta).prependIndent("  "))
+      return
+    }
+
+    if (mode == "data") {
+      // Data-product roll-up (semantics + a11y + theme), computed locally via the shared
+      // HistoryDataDiff — the same code the daemon's `history/diff mode=data` runs, reading the
+      // snapshots frozen in each entry's sidecar (no PNGs, no daemon round-trip).
+      val delta =
+        try {
+          HistoryDataDiff.diff(from, to)
+        } catch (t: Throwable) {
+          System.err.println("history diff: data diff failed: ${t.message}")
+          exitProcess(2)
+        }
+
+      if (json) {
+        val payload =
+          HistoryDiffResponse(
+            schema = HISTORY_SCHEMA,
+            mode = "data",
+            pngHashChanged = pngHashChanged,
+            from = leanEntryJson(from),
+            to = leanEntryJson(to),
+            dataDelta = OUT.encodeToJsonElement(HistoryDataDelta.serializer(), delta),
+          )
+        println(OUT.encodeToString(HistoryDiffResponse.serializer(), payload))
+        return
+      }
+
+      println("diff ${from.id} → ${to.id}  (preview ${from.previewId})")
+      println(formatDataDeltaHuman(delta).prependIndent("  "))
       return
     }
 
@@ -441,7 +474,7 @@ class HistoryCommand(private val args: List<String>) {
       Subcommands:
         list                 List history entries (newest first)
         read <entryId>       Show one entry's metadata (and optionally its PNG / data)
-        diff <fromId> <toId> Compare two entries (metadata | pixel | semantics)
+        diff <fromId> <toId> Compare two entries (metadata | pixel | semantics | data)
         help                 Show this help message
 
       Source:
@@ -458,9 +491,10 @@ class HistoryCommand(private val args: List<String>) {
         --inline       Include base64 PNG bytes (--json)
 
       diff options:
-        --mode metadata|pixel|semantics
+        --mode metadata|pixel|semantics|data
                                pixel reports diffPx + ssim and writes a marked-diff PNG;
-                               semantics diffs the captured compose/semantics trees
+                               semantics diffs the captured compose/semantics trees;
+                               data rolls semantics + a11y + theme into one versioned delta
         --out <path>           (pixel) write the marked-diff PNG here instead of <preview>/.diffs/
 
       Common:
@@ -537,4 +571,60 @@ internal data class HistoryDiffResponse(
   // Semantics-mode field (`--mode semantics`); null otherwise. The typed compose-semantics-diff/v1
   // delta of the two entries' captured trees.
   val semanticsDelta: JsonElement? = null,
+  // Data-mode field (`--mode data`); null otherwise. The versioned history-data-diff/v1 roll-up
+  // (semantics + a11y + theme) of the two entries' captured data products.
+  val dataDelta: JsonElement? = null,
 )
+
+/**
+ * Renders a [HistoryDataDelta] for the terminal — one block per compared product. Sections that
+ * weren't compared (the product wasn't captured on both entries) are reported as such, distinct
+ * from a compared-but-unchanged section, so a reviewer can tell "no a11y data" from "a11y
+ * unchanged".
+ */
+internal fun formatDataDeltaHuman(delta: HistoryDataDelta): String =
+  buildString {
+      appendLine("semantics:")
+      appendLine(
+        when (val s = delta.semantics) {
+          null -> "  (not captured on both entries)"
+          else -> formatSemanticsDeltaHuman(s).prependIndent("  ")
+        }
+      )
+      appendLine("a11y:")
+      val a = delta.a11y
+      if (a == null) {
+        appendLine("  (not captured on both entries)")
+      } else if (a.isEmpty) {
+        appendLine("  No a11y finding changes.")
+      } else {
+        appendLine(
+          "  ${a.added.size} added, ${a.removed.size} removed, ${a.changed.size} changed".trimEnd()
+        )
+        a.removed.forEach {
+          appendLine("    - ${it.level} ${it.type}${it.ref?.let { r -> " @$r" } ?: ""}")
+        }
+        a.added.forEach {
+          appendLine("    + ${it.level} ${it.type}${it.ref?.let { r -> " @$r" } ?: ""}")
+        }
+        a.changed.forEach { change ->
+          appendLine("    ~ ${change.type}${change.ref?.let { r -> " @$r" } ?: ""}")
+          change.changes.forEach { f ->
+            appendLine("        ${f.field}: ${f.from ?: "∅"} → ${f.to ?: "∅"}")
+          }
+        }
+      }
+      appendLine("theme:")
+      val t = delta.theme
+      if (t == null) {
+        appendLine("  (not captured on both entries)")
+      } else if (t.isEmpty) {
+        appendLine("  No theme token changes.")
+      } else {
+        (t.colorScheme + t.shapes).forEach { tok ->
+          appendLine("    ~ ${tok.token}: ${tok.from ?: "∅"} → ${tok.to ?: "∅"}")
+        }
+        t.typography.forEach { tok -> appendLine("    ~ ${tok.token} (typography changed)") }
+      }
+    }
+    .trimEnd()

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/HistoryCommandTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/HistoryCommandTest.kt
@@ -52,6 +52,8 @@ class HistoryCommandTest {
     timestamp: String,
     a11yHierarchy: Boolean = false,
     semantics: JsonElement? = null,
+    a11yAtf: JsonElement? = null,
+    theme: JsonElement? = null,
   ): String {
     val source = LocalFsHistorySource(historyDir)
     val entry =
@@ -72,10 +74,17 @@ class HistoryCommandTest {
             Json.parseToJsonElement("""{"nodes":[{"label":"x","boundsInScreen":"0,0,1,1"}]}""")
           else null,
         semantics = semantics,
+        a11yAtf = a11yAtf,
+        theme = theme,
       )
     source.write(entry, bytes)
     return id
   }
+
+  private fun themePayload(primary: String): JsonElement =
+    Json.parseToJsonElement(
+      """{"resolvedTokens":{"colorScheme":{"primary":"$primary"},"typography":{},"shapes":{}},"consumers":[]}"""
+    )
 
   private fun semanticsPayload(text: String): JsonElement =
     Json.parseToJsonElement(
@@ -214,6 +223,51 @@ class HistoryCommandTest {
     assertEquals("text", change["field"]?.jsonPrimitive?.content)
     assertEquals("Hello", change["from"]?.jsonPrimitive?.content)
     assertEquals("World", change["to"]?.jsonPrimitive?.content)
+  }
+
+  @Test
+  fun `diff --mode data rolls up semantics and theme deltas`() {
+    val from =
+      seed(
+        "20260430-100000-da7a0000",
+        "com.example.A",
+        "v1".toByteArray(),
+        "2026-04-30T10:00:00Z",
+        semantics = semanticsPayload("Hello"),
+        theme = themePayload("0xFF6750A4"),
+      )
+    val to =
+      seed(
+        "20260430-100100-da7a1111",
+        "com.example.A",
+        "v2".toByteArray(),
+        "2026-04-30T10:01:00Z",
+        semantics = semanticsPayload("World"),
+        theme = themePayload("0xFFB3261E"),
+      )
+
+    HistoryCommand(
+        listOf("diff", from, to, "--mode", "data", "--history-dir", historyDir.toString(), "--json")
+      )
+      .run()
+    val payload = Json.parseToJsonElement(output()).jsonObject
+
+    assertEquals("data", payload["mode"]?.jsonPrimitive?.content)
+    val delta = payload["dataDelta"]!!.jsonObject
+    assertEquals("history-data-diff/v1", delta["schema"]?.jsonPrimitive?.content)
+    // semantics section: text changed.
+    val semChange =
+      delta["semantics"]!!
+        .jsonObject["changed"]!!
+        .jsonArray[0]
+        .jsonObject["changes"]!!
+        .jsonArray[0]
+        .jsonObject
+    assertEquals("World", semChange["to"]?.jsonPrimitive?.content)
+    // theme section: primary colour token changed. a11y wasn't captured → section is null.
+    val themeChange = delta["theme"]!!.jsonObject["colorScheme"]!!.jsonArray[0].jsonObject
+    assertEquals("primary", themeChange["token"]?.jsonPrimitive?.content)
+    assertEquals("0xFFB3261E", themeChange["to"]?.jsonPrimitive?.content)
   }
 
   @Test

--- a/daemon/core/build.gradle.kts
+++ b/daemon/core/build.gradle.kts
@@ -28,6 +28,12 @@ dependencies {
   // renderer-agnostic daemon classpath.
   api(project(":data-layoutinspector-core"))
 
+  // Theme-token models + structural differ (issue #1873). `api`, not `implementation`: the
+  // published `HistoryDataDelta.theme` field is a `ThemeDelta`, so the type is part of this
+  // module's compile ABI. Pure-JVM core module (no Compose/Android) — safe on the
+  // renderer-agnostic daemon classpath, same as `:data-layoutinspector-core`.
+  api(project(":data-theme-core"))
+
   // Okio-based file IO (`SystemFileSystem`) for data-product reads, history sidecars, bundle IR
   // replay, and forensics dumps. `implementation` — Okio stays an internal detail; daemon/core's
   // public surface keeps its java.io.File signatures.

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.daemon
 
+import ee.schimke.composeai.daemon.history.HistoryDataDiff
 import ee.schimke.composeai.daemon.history.HistoryDiffArtifacts
 import ee.schimke.composeai.daemon.history.HistoryEntry
 import ee.schimke.composeai.daemon.history.HistoryFilter
@@ -1493,8 +1494,11 @@ class JsonRpcServer(
    * pixel-mode fields stay null there by design. PIXEL mode (H5, issue #1873) decodes both archived
    * frames and populates `diffPx` + `ssim` + `diffPngPath` (a marked-diff PNG written under
    * `<historyDir>/<previewId>/.diffs/`) via [HistoryImageDiff]. SEMANTICS mode (issue #1785) adds
-   * `semanticsDelta`, the typed structural diff of the two entries' captured semantics trees. The
-   * `-32012` "pixel not implemented" sentinel is retired now that H5 has landed.
+   * `semanticsDelta`, the typed structural diff of the two entries' captured semantics trees. DATA
+   * mode (issue #1873) rolls the captured `compose/semantics`, `a11y/atf` and `compose/theme`
+   * snapshots into one versioned `dataDelta` via [HistoryDataDiff] — each section present only when
+   * both entries carry that product. The `-32012` "pixel not implemented" sentinel is retired now
+   * that H5 has landed.
    */
   private fun handleHistoryDiff(req: JsonRpcRequest) {
     val params =
@@ -1611,6 +1615,34 @@ class JsonRpcServer(
           fromMetadata = encodeHistoryEntry(from.entry),
           toMetadata = encodeHistoryEntry(to.entry),
           semanticsDelta = delta,
+        )
+      sendResponse(req.id, encode(HistoryDiffResult.serializer(), result))
+      return
+    }
+    // DATA mode (issue #1873) — the data-product diff. Like SEMANTICS, it reads the snapshots
+    // frozen
+    // in each entry's sidecar (no PNG bytes), so it works the same off the local FS or a reporting
+    // ref. Sections (semantics / a11y / theme) are populated only when both entries carry that
+    // product; an absent product simply leaves its section null rather than erroring — DATA is a
+    // best-effort roll-up, not the strict single-product SEMANTICS contract.
+    if (params.mode == HistoryDiffMode.DATA) {
+      val delta =
+        try {
+          HistoryDataDiff.diff(from.entry, to.entry, json)
+        } catch (t: Throwable) {
+          sendErrorResponse(
+            id = req.id,
+            code = ERR_INTERNAL,
+            message = "history/diff: data diff failed: ${t.message}",
+          )
+          return
+        }
+      val result =
+        HistoryDiffResult(
+          pngHashChanged = from.entry.pngHash != to.entry.pngHash,
+          fromMetadata = encodeHistoryEntry(from.entry),
+          toMetadata = encodeHistoryEntry(to.entry),
+          dataDelta = delta,
         )
       sendResponse(req.id, encode(HistoryDiffResult.serializer(), result))
       return

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryDataDiff.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryDataDiff.kt
@@ -1,0 +1,259 @@
+package ee.schimke.composeai.daemon.history
+
+import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsPayload
+import ee.schimke.composeai.data.layoutinspector.SemanticsDelta
+import ee.schimke.composeai.data.layoutinspector.SemanticsDiff
+import ee.schimke.composeai.data.theme.ThemeDelta
+import ee.schimke.composeai.data.theme.ThemeDiff
+import ee.schimke.composeai.data.theme.ThemePayload
+import kotlinx.serialization.EncodeDefault
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+
+// ---------------------------------------------------------------------------
+// `history/diff mode=data` — the data-product diff over two history entries
+// (issue #1873). Where PIXEL mode answers "what moved on screen" and SEMANTICS
+// mode diffs the captured `compose/semantics` tree, DATA mode rolls the three
+// archived **data** products into one versioned delta:
+//
+//   - `semantics` — reuses `SemanticsDiff` (compose-semantics-diff/v1).
+//   - `a11y`      — ATF findings added / removed / changed, keyed by the stable
+//                   hierarchy `ref` from #1784 (a11y-diff/v1).
+//   - `theme`     — Material 3 resolved-token deltas (compose-theme-diff/v1).
+//
+// Each section is computed only when BOTH entries carry that product; a section
+// is null when neither (or only one) side has it, so a consumer can tell "not
+// captured" apart from "captured and identical" (an empty-but-present section).
+// The a11y mirror types below are structurally-identical copies of the
+// `:data-a11y-core` models — that module is an Android library the plain-JVM
+// `:daemon:core` can't depend on, and the a11y kdoc explicitly sanctions JVM
+// consumers keeping their own mirrors. Only the handful of fields the diff
+// needs are mirrored; `ignoreUnknownKeys` skips the rest.
+// ---------------------------------------------------------------------------
+
+object HistoryDataDiffProduct {
+  const val SCHEMA: String = "history-data-diff/v1"
+}
+
+object HistoryDataDiff {
+
+  private val DECODE = Json { ignoreUnknownKeys = true }
+
+  /**
+   * Diffs the archived data products of [from] against [to]. Both are assumed to belong to the same
+   * preview (the caller enforces that). Decoding uses a lenient JSON reader so an older sidecar
+   * with extra/renamed fields still diffs on the fields this product cares about.
+   */
+  fun diff(from: HistoryEntry, to: HistoryEntry, json: Json = DECODE): HistoryDataDelta {
+    val semantics =
+      bothPresent(from.semantics, to.semantics) { base, head ->
+        SemanticsDiff.diff(
+          json.decodeFromJsonElement(ComposeSemanticsPayload.serializer(), base),
+          json.decodeFromJsonElement(ComposeSemanticsPayload.serializer(), head),
+        )
+      }
+    val a11y =
+      bothPresent(from.a11yAtf, to.a11yAtf) { _, _ ->
+        A11yDiff.diff(
+          baseFindings = decodeFindings(from.a11yAtf, json),
+          baseNodes = decodeNodes(from.a11yHierarchy, json),
+          headFindings = decodeFindings(to.a11yAtf, json),
+          headNodes = decodeNodes(to.a11yHierarchy, json),
+        )
+      }
+    val theme =
+      bothPresent(from.theme, to.theme) { base, head ->
+        ThemeDiff.diff(
+          json.decodeFromJsonElement(ThemePayload.serializer(), base),
+          json.decodeFromJsonElement(ThemePayload.serializer(), head),
+        )
+      }
+    return HistoryDataDelta(semantics = semantics, a11y = a11y, theme = theme)
+  }
+
+  private inline fun <T> bothPresent(
+    base: JsonElement?,
+    head: JsonElement?,
+    block: (JsonElement, JsonElement) -> T,
+  ): T? = if (base != null && head != null) block(base, head) else null
+
+  private fun decodeFindings(element: JsonElement?, json: Json): List<A11yFindingMirror> =
+    element?.let { json.decodeFromJsonElement(A11yFindingsPayloadMirror.serializer(), it).findings }
+      ?: emptyList()
+
+  private fun decodeNodes(element: JsonElement?, json: Json): List<A11yNodeMirror> =
+    element?.let { json.decodeFromJsonElement(A11yHierarchyPayloadMirror.serializer(), it).nodes }
+      ?: emptyList()
+}
+
+@OptIn(ExperimentalSerializationApi::class)
+@Serializable
+data class HistoryDataDelta(
+  // `@EncodeDefault` so the versioned schema discriminator rides the wire even under
+  // `encodeDefaults = false`, matching the `SemanticsDelta` / `ThemeDelta` contract.
+  @EncodeDefault val schema: String = HistoryDataDiffProduct.SCHEMA,
+  val semantics: SemanticsDelta? = null,
+  val a11y: A11yDelta? = null,
+  val theme: ThemeDelta? = null,
+) {
+  /** True when every compared section is absent or carries no changes. */
+  val isEmpty: Boolean
+    get() = (semantics?.isEmpty ?: true) && (a11y?.isEmpty ?: true) && (theme?.isEmpty ?: true)
+}
+
+// ---------------------------------------------------------------------------
+// a11y findings diff (a11y-diff/v1)
+// ---------------------------------------------------------------------------
+
+object A11yDiffProduct {
+  const val SCHEMA: String = "a11y-diff/v1"
+}
+
+/**
+ * Diffs two entries' ATF findings (`a11y/atf`). Each finding is keyed by its rule [type] plus the
+ * stable hierarchy `ref` of the node it sits on (issue #1784) — resolved by matching the finding's
+ * `boundsInScreen` against the `a11y/hierarchy` nodes captured in the same entry. When no hierarchy
+ * is captured (or no node matches the bounds), the key falls back to the bounds string so the diff
+ * is still deterministic; a copy edit (message text changing on the same ref) then reports as a
+ * field change rather than a remove + add.
+ */
+object A11yDiff {
+
+  // `internal` because the parameter types are internal mirrors; the only caller is
+  // `HistoryDataDiff` in this module. The result type (`A11yDelta`) is public.
+  internal fun diff(
+    baseFindings: List<A11yFindingMirror>,
+    baseNodes: List<A11yNodeMirror>,
+    headFindings: List<A11yFindingMirror>,
+    headNodes: List<A11yNodeMirror>,
+  ): A11yDelta {
+    val baseByKey = indexByKey(baseFindings, boundsToRef(baseNodes))
+    val headByKey = indexByKey(headFindings, boundsToRef(headNodes))
+
+    val removed =
+      baseByKey.keys.filter { it !in headByKey }.sorted().map { baseByKey.getValue(it).summary() }
+    val added =
+      headByKey.keys.filter { it !in baseByKey }.sorted().map { headByKey.getValue(it).summary() }
+    val changed =
+      baseByKey.keys
+        .filter { it in headByKey }
+        .sorted()
+        .mapNotNull { key -> findingChange(baseByKey.getValue(key), headByKey.getValue(key)) }
+
+    return A11yDelta(added = added, removed = removed, changed = changed)
+  }
+
+  /** `boundsInScreen` → first node `ref` carrying it, for attributing findings to stable refs. */
+  private fun boundsToRef(nodes: List<A11yNodeMirror>): Map<String, String> {
+    val out = LinkedHashMap<String, String>()
+    for (node in nodes) {
+      val bounds = node.boundsInScreen ?: continue
+      val ref = node.ref ?: continue
+      out.putIfAbsent(bounds, ref)
+    }
+    return out
+  }
+
+  /** Map each finding to its identity key, keeping the resolved `ref` on a small wrapper. */
+  private fun indexByKey(
+    findings: List<A11yFindingMirror>,
+    boundsToRef: Map<String, String>,
+  ): Map<String, Resolved> {
+    val out = LinkedHashMap<String, Resolved>()
+    for (finding in findings) {
+      val ref = finding.boundsInScreen?.let { boundsToRef[it] }
+      val anchor = ref ?: finding.boundsInScreen ?: ""
+      val key = "${finding.type}|$anchor"
+      // First finding for a key wins; duplicate (type, ref) findings collapse, which is fine for a
+      // structural "did this class of finding appear/disappear" signal.
+      out.putIfAbsent(key, Resolved(finding, ref))
+    }
+    return out
+  }
+
+  private fun findingChange(base: Resolved, head: Resolved): A11yFindingChange? {
+    val changes = COMPARED_FIELDS.mapNotNull { (field, extract) ->
+      val from = extract(base.finding)
+      val to = extract(head.finding)
+      if (from != to) A11yFieldChange(field, from, to) else null
+    }
+    return if (changes.isEmpty()) null
+    else A11yFindingChange(ref = head.ref ?: base.ref, type = head.finding.type, changes = changes)
+  }
+
+  private val COMPARED_FIELDS: List<Pair<String, (A11yFindingMirror) -> String?>> =
+    listOf(
+      "level" to { it.level },
+      "message" to { it.message },
+      "viewDescription" to { it.viewDescription },
+    )
+
+  private class Resolved(val finding: A11yFindingMirror, val ref: String?) {
+    fun summary(): A11yFindingSummary =
+      A11yFindingSummary(
+        ref = ref,
+        type = finding.type,
+        level = finding.level,
+        message = finding.message,
+        boundsInScreen = finding.boundsInScreen,
+      )
+  }
+}
+
+@Serializable
+data class A11yFieldChange(val field: String, val from: String? = null, val to: String? = null)
+
+@Serializable
+data class A11yFindingSummary(
+  val ref: String? = null,
+  val type: String,
+  val level: String,
+  val message: String,
+  val boundsInScreen: String? = null,
+)
+
+@Serializable
+data class A11yFindingChange(
+  val ref: String? = null,
+  val type: String,
+  val changes: List<A11yFieldChange>,
+)
+
+@OptIn(ExperimentalSerializationApi::class)
+@Serializable
+data class A11yDelta(
+  @EncodeDefault val schema: String = A11yDiffProduct.SCHEMA,
+  val added: List<A11yFindingSummary> = emptyList(),
+  val removed: List<A11yFindingSummary> = emptyList(),
+  val changed: List<A11yFindingChange> = emptyList(),
+) {
+  val isEmpty: Boolean
+    get() = added.isEmpty() && removed.isEmpty() && changed.isEmpty()
+}
+
+// ---------------------------------------------------------------------------
+// a11y mirror types — structurally-identical to `:data-a11y-core`'s
+// `AccessibilityFinding` / `AccessibilityNode` payloads, mirrored here because
+// that module is an Android library `:daemon:core` (plain JVM) can't depend on.
+// Only the diffed fields are kept; `ignoreUnknownKeys` drops the rest.
+// ---------------------------------------------------------------------------
+
+@Serializable
+internal data class A11yFindingMirror(
+  val level: String = "",
+  val type: String = "",
+  val message: String = "",
+  val viewDescription: String? = null,
+  val boundsInScreen: String? = null,
+)
+
+@Serializable
+internal data class A11yFindingsPayloadMirror(val findings: List<A11yFindingMirror> = emptyList())
+
+@Serializable
+internal data class A11yNodeMirror(val ref: String? = null, val boundsInScreen: String? = null)
+
+@Serializable
+internal data class A11yHierarchyPayloadMirror(val nodes: List<A11yNodeMirror> = emptyList())

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.daemon.protocol
 
+import ee.schimke.composeai.daemon.history.HistoryDataDelta
 import ee.schimke.composeai.data.layoutinspector.SemanticsDelta
 import ee.schimke.composeai.data.render.extensions.DataExtensionDescriptor
 import ee.schimke.composeai.data.render.pipeline.PreviewExtensionDescriptor
@@ -1749,6 +1750,11 @@ enum class HistoryDiffMode {
   // pixel-free regression signal. Populates `semanticsDelta`; requires both entries to carry a
   // captured semantics snapshot (else `ERR_HISTORY_SEMANTICS_NOT_CAPTURED`).
   @SerialName("semantics") SEMANTICS,
+  // Data-product diff (issue #1873) — rolls the captured `compose/semantics`, `a11y/atf` and
+  // `compose/theme` snapshots into one versioned `dataDelta`. A section is present only when both
+  // entries carry that product. Superset of SEMANTICS; SEMANTICS stays for the narrow tree-only
+  // case (and its dedicated `ERR_HISTORY_SEMANTICS_NOT_CAPTURED` contract).
+  @SerialName("data") DATA,
 }
 
 @Serializable
@@ -1776,6 +1782,9 @@ data class HistoryDiffResult(
   // Semantics-mode field (issue #1785) — the typed structural delta of the two entries'
   // `compose/semantics` trees. Null in METADATA / PIXEL modes by design.
   val semanticsDelta: SemanticsDelta? = null,
+  // Data-mode field (issue #1873) — the versioned data-product delta (semantics + a11y + theme).
+  // Null outside DATA mode by design.
+  val dataDelta: HistoryDataDelta? = null,
 )
 
 // ---------------------------------------------------------------------------

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/HistoryDataDiffTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/HistoryDataDiffTest.kt
@@ -1,0 +1,174 @@
+package ee.schimke.composeai.daemon.history
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for the `history/diff mode=data` data-product diff (issue #1873) at the
+ * [HistoryDataDiff] object level — no wire round-trip. Covers the three sections (semantics / a11y
+ * / theme), a11y finding ref-keying via the captured hierarchy, and the "present only when both
+ * entries carry the product" rule.
+ */
+class HistoryDataDiffTest {
+
+  private val json = Json { ignoreUnknownKeys = true }
+
+  private fun parse(text: String): JsonElement = json.parseToJsonElement(text)
+
+  private fun entry(
+    id: String,
+    semantics: JsonElement? = null,
+    a11yAtf: JsonElement? = null,
+    a11yHierarchy: JsonElement? = null,
+    theme: JsonElement? = null,
+  ): HistoryEntry =
+    HistoryEntry(
+      id = id,
+      previewId = "preview-A",
+      module = ":t",
+      timestamp = "2026-06-17T10:00:00Z",
+      pngHash = "hash-$id",
+      pngSize = 1,
+      pngPath = "$id.png",
+      producer = "daemon",
+      trigger = "renderNow",
+      source = HistorySourceInfo(kind = "fs", id = "fs:/tmp"),
+      renderTookMs = 1,
+      semantics = semantics,
+      a11yAtf = a11yAtf,
+      a11yHierarchy = a11yHierarchy,
+      theme = theme,
+    )
+
+  @Test
+  fun semantics_section_reports_field_change() {
+    val from = entry("e1", semantics = semanticsPayload("greeting", "Hello"))
+    val to = entry("e2", semantics = semanticsPayload("greeting", "World"))
+    val delta = HistoryDataDiff.diff(from, to)
+    val semantics = delta.semantics!!
+    assertEquals(1, semantics.changed.size)
+    val change = semantics.changed.single().changes.single()
+    assertEquals("text", change.field)
+    assertEquals("Hello", change.from)
+    assertEquals("World", change.to)
+    // The other products weren't captured, so their sections stay null.
+    assertNull(delta.a11y)
+    assertNull(delta.theme)
+  }
+
+  @Test
+  fun a11y_finding_change_keyed_by_stable_ref() {
+    // Same node bounds → same hierarchy ref → the contrast finding's level/message change reports
+    // as a change on the same ref, not a remove + add.
+    val hierarchy = hierarchyPayload(ref = "a/role:Button[0]", bounds = "0,0,48,48")
+    val from =
+      entry(
+        "e1",
+        a11yAtf =
+          findingsPayload(type = "TextContrastCheck", level = "WARNING", bounds = "0,0,48,48"),
+        a11yHierarchy = hierarchy,
+      )
+    val to =
+      entry(
+        "e2",
+        a11yAtf =
+          findingsPayload(type = "TextContrastCheck", level = "ERROR", bounds = "0,0,48,48"),
+        a11yHierarchy = hierarchy,
+      )
+    val a11y = HistoryDataDiff.diff(from, to).a11y!!
+    assertTrue(a11y.added.isEmpty())
+    assertTrue(a11y.removed.isEmpty())
+    assertEquals(1, a11y.changed.size)
+    val change = a11y.changed.single()
+    assertEquals("a/role:Button[0]", change.ref)
+    assertEquals("TextContrastCheck", change.type)
+    val levelChange = change.changes.single { it.field == "level" }
+    assertEquals("WARNING", levelChange.from)
+    assertEquals("ERROR", levelChange.to)
+  }
+
+  @Test
+  fun a11y_finding_added_and_removed() {
+    val from =
+      entry("e1", a11yAtf = findingsPayload(type = "SpeakableTextPresentCheck", bounds = "0,0,1,1"))
+    val to =
+      entry("e2", a11yAtf = findingsPayload(type = "TouchTargetSizeCheck", bounds = "0,0,2,2"))
+    val a11y = HistoryDataDiff.diff(from, to).a11y!!
+    assertEquals(listOf("TouchTargetSizeCheck"), a11y.added.map { it.type })
+    assertEquals(listOf("SpeakableTextPresentCheck"), a11y.removed.map { it.type })
+    assertTrue(a11y.changed.isEmpty())
+  }
+
+  @Test
+  fun theme_section_reports_color_token_change() {
+    val from = entry("e1", theme = themePayload(primary = "0xFF6750A4"))
+    val to = entry("e2", theme = themePayload(primary = "0xFFB3261E"))
+    val theme = HistoryDataDiff.diff(from, to).theme!!
+    assertEquals(1, theme.colorScheme.size)
+    assertEquals("0xFFB3261E", theme.colorScheme.single().to)
+  }
+
+  @Test
+  fun section_is_null_when_product_only_on_one_side() {
+    val from = entry("e1", theme = themePayload(primary = "0xFF6750A4"))
+    val to = entry("e2") // no theme captured
+    val delta = HistoryDataDiff.diff(from, to)
+    assertNull("theme not compared when only one side has it", delta.theme)
+    assertTrue(delta.isEmpty)
+  }
+
+  @Test
+  fun combined_delta_carries_all_three_sections() {
+    val from =
+      entry(
+        "e1",
+        semantics = semanticsPayload("greeting", "Hello"),
+        a11yAtf =
+          findingsPayload(type = "TouchTargetSizeCheck", level = "ERROR", bounds = "0,0,1,1"),
+        theme = themePayload(primary = "0xFF6750A4"),
+      )
+    val to =
+      entry(
+        "e2",
+        semantics = semanticsPayload("greeting", "World"),
+        a11yAtf =
+          findingsPayload(type = "TouchTargetSizeCheck", level = "ERROR", bounds = "0,0,1,1"),
+        theme = themePayload(primary = "0xFFB3261E"),
+      )
+    val delta = HistoryDataDiff.diff(from, to)
+    assertEquals(HistoryDataDiffProduct.SCHEMA, delta.schema)
+    assertTrue("semantics changed", delta.semantics!!.changed.isNotEmpty())
+    assertTrue("a11y identical → empty section", delta.a11y!!.isEmpty)
+    assertTrue("theme changed", delta.theme!!.colorScheme.isNotEmpty())
+    assertTrue("delta overall non-empty", !delta.isEmpty)
+  }
+
+  // --- payload builders ------------------------------------------------------
+
+  private fun semanticsPayload(testTag: String, text: String): JsonElement =
+    parse(
+      """{"root":{"nodeId":"1","boundsInRoot":"0,0,100,50","testTag":"$testTag","text":"$text"}}"""
+    )
+
+  private fun findingsPayload(
+    type: String,
+    level: String = "WARNING",
+    message: String = "msg",
+    bounds: String,
+  ): JsonElement =
+    parse(
+      """{"findings":[{"level":"$level","type":"$type","message":"$message","boundsInScreen":"$bounds"}]}"""
+    )
+
+  private fun hierarchyPayload(ref: String, bounds: String): JsonElement =
+    parse("""{"nodes":[{"label":"x","ref":"$ref","boundsInScreen":"$bounds"}]}""")
+
+  private fun themePayload(primary: String): JsonElement =
+    parse(
+      """{"resolvedTokens":{"colorScheme":{"primary":"$primary"},"typography":{},"shapes":{}},"consumers":[]}"""
+    )
+}

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/HistoryDiffTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/HistoryDiffTest.kt
@@ -467,6 +467,124 @@ class HistoryDiffTest {
     }
   }
 
+  // -------------------------------------------------------------------------
+  // DATA mode (issue #1873) — the data-product roll-up (semantics + a11y + theme). Entries are
+  // seeded with the captured snapshots directly via `recordRender(...)`, the same way the render
+  // path freezes them off the data-product registry.
+  // -------------------------------------------------------------------------
+
+  @Test(timeout = 30_000)
+  fun data_mode_rolls_up_semantics_a11y_and_theme() {
+    runWith { _, manager, send, receive ->
+      val from =
+        manager.recordRender(
+          "preview-A",
+          "bytes-1".toByteArray(),
+          trigger = "renderNow",
+          renderTookMs = 1,
+          semantics = semanticsPayload(testTag = "greeting", text = "Hello"),
+          a11yAtf = findingsPayload("TextContrastCheck", "WARNING", "0,0,48,48"),
+          a11yHierarchy = hierarchyPayload("a/role:Button[0]", "0,0,48,48"),
+          theme = themePayload(primary = "0xFF6750A4"),
+        )!!
+      val to =
+        manager.recordRender(
+          "preview-A",
+          "bytes-2".toByteArray(),
+          trigger = "renderNow",
+          renderTookMs = 1,
+          semantics = semanticsPayload(testTag = "greeting", text = "World"),
+          a11yAtf = findingsPayload("TextContrastCheck", "ERROR", "0,0,48,48"),
+          a11yHierarchy = hierarchyPayload("a/role:Button[0]", "0,0,48,48"),
+          theme = themePayload(primary = "0xFFB3261E"),
+        )!!
+
+      val resp = diffRoundTrip(send, receive, from = from.id, to = to.id, mode = "data")
+      val data = resp["result"]!!.jsonObject["dataDelta"]!!.jsonObject
+      assertEquals("history-data-diff/v1", data["schema"]!!.jsonPrimitive.content)
+
+      // semantics: text changed on the same ref.
+      val semChange =
+        data["semantics"]!!
+          .jsonObject["changed"]!!
+          .jsonArray
+          .single()
+          .jsonObject["changes"]!!
+          .jsonArray
+          .single()
+          .jsonObject
+      assertEquals("text", semChange["field"]!!.jsonPrimitive.content)
+      assertEquals("World", semChange["to"]!!.jsonPrimitive.content)
+
+      // a11y: the contrast finding's level changed, keyed by the stable hierarchy ref.
+      val a11yChange = data["a11y"]!!.jsonObject["changed"]!!.jsonArray.single().jsonObject
+      assertEquals("a/role:Button[0]", a11yChange["ref"]!!.jsonPrimitive.content)
+      val levelChange =
+        a11yChange["changes"]!!
+          .jsonArray
+          .map { it.jsonObject }
+          .single { it["field"]!!.jsonPrimitive.content == "level" }
+      assertEquals("ERROR", levelChange["to"]!!.jsonPrimitive.content)
+
+      // theme: the primary colour token changed.
+      val themeChange = data["theme"]!!.jsonObject["colorScheme"]!!.jsonArray.single().jsonObject
+      assertEquals("primary", themeChange["token"]!!.jsonPrimitive.content)
+      assertEquals("0xFFB3261E", themeChange["to"]!!.jsonPrimitive.content)
+    }
+  }
+
+  @Test(timeout = 30_000)
+  fun data_mode_omits_uncaptured_sections() {
+    runWith { _, manager, send, receive ->
+      // Only theme captured on both sides; semantics + a11y were never computed.
+      val from =
+        manager.recordRender(
+          "preview-A",
+          "bytes-1".toByteArray(),
+          trigger = "renderNow",
+          renderTookMs = 1,
+          theme = themePayload(primary = "0xFF6750A4"),
+        )!!
+      val to =
+        manager.recordRender(
+          "preview-A",
+          "bytes-2".toByteArray(),
+          trigger = "renderNow",
+          renderTookMs = 1,
+          theme = themePayload(primary = "0xFFB3261E"),
+        )!!
+
+      val resp = diffRoundTrip(send, receive, from = from.id, to = to.id, mode = "data")
+      val data = resp["result"]!!.jsonObject["dataDelta"]!!.jsonObject
+      // Sections for products absent on both entries are omitted (null, encodeDefaults=false).
+      assertTrue("semantics omitted", data["semantics"] == null)
+      assertTrue("a11y omitted", data["a11y"] == null)
+      assertEquals(
+        "0xFFB3261E",
+        data["theme"]!!
+          .jsonObject["colorScheme"]!!
+          .jsonArray
+          .single()
+          .jsonObject["to"]!!
+          .jsonPrimitive
+          .content,
+      )
+    }
+  }
+
+  private fun findingsPayload(type: String, level: String, bounds: String): JsonElement =
+    json.parseToJsonElement(
+      """{"findings":[{"level":"$level","type":"$type","message":"contrast","boundsInScreen":"$bounds"}]}"""
+    )
+
+  private fun hierarchyPayload(ref: String, bounds: String): JsonElement =
+    json.parseToJsonElement("""{"nodes":[{"label":"x","ref":"$ref","boundsInScreen":"$bounds"}]}""")
+
+  private fun themePayload(primary: String): JsonElement =
+    json.parseToJsonElement(
+      """{"resolvedTokens":{"colorScheme":{"primary":"$primary"},"typography":{},"shapes":{}},"consumers":[]}"""
+    )
+
   /** True when a delta list field is absent (omitted because empty) or present-but-empty. */
   private fun emptyOrAbsent(element: JsonElement?): Boolean =
     element == null || element.jsonArray.isEmpty()

--- a/data/theme/core/src/main/kotlin/ee/schimke/composeai/data/theme/ThemeDiff.kt
+++ b/data/theme/core/src/main/kotlin/ee/schimke/composeai/data/theme/ThemeDiff.kt
@@ -1,0 +1,80 @@
+package ee.schimke.composeai.data.theme
+
+import kotlinx.serialization.EncodeDefault
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.Serializable
+
+object ThemeDiffProduct {
+  const val SCHEMA: String = "compose-theme-diff/v1"
+}
+
+/**
+ * A structural diff of two [ThemePayload]s' resolved Material 3 tokens (issue #1873) — the theme
+ * analogue of [ee.schimke.composeai.data.layoutinspector.SemanticsDelta]. It answers "which design
+ * tokens changed between two history entries" ("`primary` 0xFF6750A4 → 0xFFB3261E", "the `large`
+ * shape corner went 16dp → 28dp") without reading pixels.
+ *
+ * Tokens are matched by their **name** (the stable map key Material 3 owns — `primary`,
+ * `onSurface`, `bodyLarge`, `large`, …). A token present on only one side reports with the absent
+ * side `null` (added when only `to` has it, removed when only `from` does); a token on both sides
+ * with a differing value reports `from` → `to`. Only the resolved tokens are diffed —
+ * [ThemePayload.consumers] (node → token attribution) is deliberately ignored, the way
+ * `SemanticsDiff` ignores volatile bounds.
+ */
+object ThemeDiff {
+
+  fun diff(base: ThemePayload, head: ThemePayload): ThemeDelta {
+    val b = base.resolvedTokens
+    val h = head.resolvedTokens
+    return ThemeDelta(
+      colorScheme = diffStringTokens(b.colorScheme, h.colorScheme),
+      shapes = diffStringTokens(b.shapes, h.shapes),
+      typography = diffTypographyTokens(b.typography, h.typography),
+    )
+  }
+
+  private fun diffStringTokens(
+    base: Map<String, String>,
+    head: Map<String, String>,
+  ): List<ThemeTokenChange> =
+    (base.keys + head.keys).sorted().mapNotNull { token ->
+      val from = base[token]
+      val to = head[token]
+      if (from != to) ThemeTokenChange(token = token, from = from, to = to) else null
+    }
+
+  private fun diffTypographyTokens(
+    base: Map<String, TypographyToken>,
+    head: Map<String, TypographyToken>,
+  ): List<ThemeTypographyChange> =
+    (base.keys + head.keys).sorted().mapNotNull { token ->
+      val from = base[token]
+      val to = head[token]
+      if (from != to) ThemeTypographyChange(token = token, from = from, to = to) else null
+    }
+}
+
+@Serializable
+data class ThemeTokenChange(val token: String, val from: String? = null, val to: String? = null)
+
+@Serializable
+data class ThemeTypographyChange(
+  val token: String,
+  val from: TypographyToken? = null,
+  val to: TypographyToken? = null,
+)
+
+@OptIn(ExperimentalSerializationApi::class)
+@Serializable
+data class ThemeDelta(
+  // `@EncodeDefault` so the versioned schema discriminator rides every wire surface even under
+  // `encodeDefaults = false` (the daemon's `history/diff mode=data` result), matching the
+  // `SemanticsDelta` contract.
+  @EncodeDefault val schema: String = ThemeDiffProduct.SCHEMA,
+  val colorScheme: List<ThemeTokenChange> = emptyList(),
+  val shapes: List<ThemeTokenChange> = emptyList(),
+  val typography: List<ThemeTypographyChange> = emptyList(),
+) {
+  val isEmpty: Boolean
+    get() = colorScheme.isEmpty() && shapes.isEmpty() && typography.isEmpty()
+}

--- a/data/theme/core/src/test/kotlin/ee/schimke/composeai/data/theme/ThemeDiffTest.kt
+++ b/data/theme/core/src/test/kotlin/ee/schimke/composeai/data/theme/ThemeDiffTest.kt
@@ -1,0 +1,72 @@
+package ee.schimke.composeai.data.theme
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ThemeDiffTest {
+
+  private fun payload(
+    colors: Map<String, String> = emptyMap(),
+    shapes: Map<String, String> = emptyMap(),
+    typography: Map<String, TypographyToken> = emptyMap(),
+  ): ThemePayload = ThemePayload(ResolvedThemeTokens(colors, typography, shapes))
+
+  @Test
+  fun identical_tokens_yield_empty_delta() {
+    val p = payload(colors = mapOf("primary" to "0xFF6750A4"), shapes = mapOf("large" to "16.0dp"))
+    val delta = ThemeDiff.diff(p, p)
+    assertTrue(delta.isEmpty)
+    // Versioned schema discriminator is always set.
+    assertEquals(ThemeDiffProduct.SCHEMA, delta.schema)
+  }
+
+  @Test
+  fun changed_color_reports_from_to() {
+    val base = payload(colors = mapOf("primary" to "0xFF6750A4"))
+    val head = payload(colors = mapOf("primary" to "0xFFB3261E"))
+    val delta = ThemeDiff.diff(base, head)
+    assertEquals(1, delta.colorScheme.size)
+    val change = delta.colorScheme.single()
+    assertEquals("primary", change.token)
+    assertEquals("0xFF6750A4", change.from)
+    assertEquals("0xFFB3261E", change.to)
+  }
+
+  @Test
+  fun added_and_removed_tokens_have_null_on_the_absent_side() {
+    val base = payload(colors = mapOf("primary" to "0xFF000000"))
+    val head = payload(colors = mapOf("tertiary" to "0xFF7D5260"))
+    val delta = ThemeDiff.diff(base, head)
+    // Sorted by token name: "primary" (removed) before "tertiary" (added).
+    assertEquals(listOf("primary", "tertiary"), delta.colorScheme.map { it.token })
+    val removed = delta.colorScheme.first { it.token == "primary" }
+    assertEquals("0xFF000000", removed.from)
+    assertEquals(null, removed.to)
+    val added = delta.colorScheme.first { it.token == "tertiary" }
+    assertEquals(null, added.from)
+    assertEquals("0xFF7D5260", added.to)
+  }
+
+  @Test
+  fun shape_changes_are_reported() {
+    val base = payload(shapes = mapOf("large" to "16.0dp"))
+    val head = payload(shapes = mapOf("large" to "28.0dp"))
+    val delta = ThemeDiff.diff(base, head)
+    assertTrue(delta.colorScheme.isEmpty())
+    assertEquals(1, delta.shapes.size)
+    assertEquals("28.0dp", delta.shapes.single().to)
+  }
+
+  @Test
+  fun typography_token_change_is_reported_whole() {
+    val base = payload(typography = mapOf("bodyLarge" to TypographyToken(fontSize = 16f)))
+    val head = payload(typography = mapOf("bodyLarge" to TypographyToken(fontSize = 18f)))
+    val delta = ThemeDiff.diff(base, head)
+    assertEquals(1, delta.typography.size)
+    val change = delta.typography.single()
+    assertEquals("bodyLarge", change.token)
+    assertEquals(16f, change.from?.fontSize)
+    assertEquals(18f, change.to?.fontSize)
+  }
+}

--- a/docs/daemon/HISTORY.md
+++ b/docs/daemon/HISTORY.md
@@ -177,11 +177,12 @@ match the `ref` it was listed from), mirroring `history/list`.
 ### `history/diff` (§ H3)
 
 ```ts
-params: { from: string; to: string; mode?: "metadata" | "pixel" | "semantics"; ref? }
+params: { from: string; to: string; mode?: "metadata" | "pixel" | "semantics" | "data"; ref? }
 result: {
   pngHashChanged: boolean;
   diffPx?: number; ssim?: number; diffPngPath?: string;  // pixel mode only
   semanticsDelta?: SemanticsDelta;                        // semantics mode only
+  dataDelta?: HistoryDataDelta;                           // data mode only
   fromMetadata: HistoryEntry;
   toMetadata: HistoryEntry;
 }
@@ -204,6 +205,15 @@ snapshotted into its sidecar at record time (see `HistoryEntry.semantics`
 below), so the diff is deterministic and reads no PNGs. The same differ
 (`SemanticsDiff`) backs `compose-preview diff-semantics` and the MCP
 `diff_semantics` tool, so all three surfaces agree.
+`mode = "data"` (issue #1873) is the data-product roll-up: one versioned
+`HistoryDataDelta` (`history-data-diff/v1`) carrying optional `semantics`
+(the `compose-semantics-diff/v1` delta), `a11y` (`a11y-diff/v1`: ATF findings
+added / removed / changed, keyed by the stable hierarchy `ref` from #1784) and
+`theme` (`compose-theme-diff/v1`: Material 3 resolved-token deltas). Each
+section is populated only when **both** entries carry that product (a `null`
+section ⇒ "not captured on both"; an empty-but-present section ⇒ "captured and
+identical"). Like semantics it reads the sidecar snapshots, not PNGs; unlike
+semantics it never errors on a missing product — the section is simply omitted.
 
 `ref?` (H10-read) resolves both `from` and `to` from that on-demand reporting
 branch instead of the configured sources — one ref per diff request (both sides

--- a/docs/daemon/PROTOCOL.md
+++ b/docs/daemon/PROTOCOL.md
@@ -432,7 +432,7 @@ Errors:
 {
   from: string;                            // entry id
   to: string;                              // entry id
-  mode?: "metadata" | "pixel" | "semantics"; // default "metadata"
+  mode?: "metadata" | "pixel" | "semantics" | "data"; // default "metadata"
 }
 
 // result
@@ -446,6 +446,8 @@ Errors:
   diffPngPath?: string;
   // Semantics-mode field (issue #1785) — null in METADATA / PIXEL modes.
   semanticsDelta?: SemanticsDelta;  // compose-semantics-diff/v1
+  // Data-mode field (issue #1873) — null outside DATA mode.
+  dataDelta?: HistoryDataDelta;     // history-data-diff/v1
 }
 ```
 
@@ -465,6 +467,16 @@ matched by each node's stable `ref`). The cheap, pixel-free regression signal �
 all three agree. Each entry's tree is snapshotted into its sidecar at record time, so the diff
 reads no PNGs. When one of the two entries has no captured semantics snapshot the call returns
 `-32013` (`HistorySemanticsNotCaptured`), distinct from `HistoryEntryNotFound`.
+
+`mode = "data"` (issue #1873) is the data-product roll-up: a single versioned `dataDelta`
+(`history-data-diff/v1`) with three optional sections — `semantics` (the same
+`compose-semantics-diff/v1` delta), `a11y` (`a11y-diff/v1`: ATF findings added / removed / changed,
+keyed by the stable hierarchy `ref` from #1784, resolved by matching the finding's bounds against
+the captured `a11y/hierarchy`), and `theme` (`compose-theme-diff/v1`: Material 3 resolved-token
+deltas). Each section is present only when **both** entries carry that product, so a `null` section
+means "not captured on both" while an empty-but-present section means "captured and identical".
+Like `semantics`, it reads the sidecar snapshots, not PNGs. Unlike `semantics` it never errors on a
+missing product — an absent product just omits its section (DATA is a best-effort roll-up).
 
 The diff resolves `from` and `to` across all configured `HistorySource`s — `from` may live in
 `LocalFsHistorySource` while `to` lives on a `preview/main` ref via `GitRefHistorySource`. This is

--- a/schema/README.md
+++ b/schema/README.md
@@ -22,6 +22,9 @@ Part of the report-history epic (#1866); this directory is sub-issue #1867.
 | [`compose-semantics.schema.json`](compose-semantics.schema.json) | `compose/semantics` | 6 | `ComposeSemanticsPayload` |
 | [`compose-semantics-diff.schema.json`](compose-semantics-diff.schema.json) | `compose-semantics-diff/v1` | 1 | `SemanticsDelta` |
 | [`compose-theme.schema.json`](compose-theme.schema.json) | `compose/theme` | 2 | `ThemePayload` |
+| [`compose-theme-diff.schema.json`](compose-theme-diff.schema.json) | `compose-theme-diff/v1` | 1 | `ThemeDelta` |
+| [`a11y-diff.schema.json`](a11y-diff.schema.json) | `a11y-diff/v1` | 1 | `A11yDelta` |
+| [`history-data-diff.schema.json`](history-data-diff.schema.json) | `history-data-diff/v1` | 1 | `HistoryDataDelta` |
 | [`render-trace.schema.json`](render-trace.schema.json) | `render/trace` | 1 | `RenderTraceDataProduct` |
 | [`history-diff-regions.schema.json`](history-diff-regions.schema.json) | `history/diff/regions` | 1 | `HistoryDiffPayload` |
 

--- a/schema/a11y-diff.schema.json
+++ b/schema/a11y-diff.schema.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://schimke.ee/composeai/a11y-diff.schema.json",
+  "title": "A11yDelta",
+  "description": "Payload for the `a11y-diff/v1` derived product: the diff between two entries' ATF findings (`a11y/atf`), keyed by rule type plus the stable hierarchy `ref` from #1784 (resolved by matching the finding's bounds against the captured `a11y/hierarchy` nodes). Kotlin source of truth: A11yDelta in :daemon:core. The `schema` discriminator is always emitted (@EncodeDefault).",
+  "x-composeai": {
+    "kind": "a11y-diff/v1",
+    "schemaVersion": 1,
+    "kotlinType": "ee.schimke.composeai.daemon.history.A11yDelta",
+    "kotlinConst": "A11yDiffProduct.SCHEMA",
+    "example": "schema/examples/a11y-diff.json"
+  },
+  "definitions": {
+    "A11yFindingSummary": {
+      "type": "object",
+      "required": ["type", "level", "message"],
+      "properties": {
+        "ref": { "type": ["string", "null"] },
+        "type": { "type": "string" },
+        "level": { "type": "string" },
+        "message": { "type": "string" },
+        "boundsInScreen": { "type": ["string", "null"] }
+      }
+    },
+    "A11yFieldChange": {
+      "type": "object",
+      "required": ["field"],
+      "properties": {
+        "field": { "type": "string" },
+        "from": { "type": ["string", "null"] },
+        "to": { "type": ["string", "null"] }
+      }
+    },
+    "A11yFindingChange": {
+      "type": "object",
+      "required": ["type", "changes"],
+      "properties": {
+        "ref": { "type": ["string", "null"] },
+        "type": { "type": "string" },
+        "changes": { "type": "array", "items": { "$ref": "#/definitions/A11yFieldChange" } }
+      }
+    },
+    "A11yDelta": {
+      "type": "object",
+      "required": ["schema"],
+      "properties": {
+        "schema": { "type": "string", "const": "a11y-diff/v1" },
+        "added": { "type": "array", "items": { "$ref": "#/definitions/A11yFindingSummary" } },
+        "removed": { "type": "array", "items": { "$ref": "#/definitions/A11yFindingSummary" } },
+        "changed": { "type": "array", "items": { "$ref": "#/definitions/A11yFindingChange" } }
+      }
+    }
+  },
+  "$ref": "#/definitions/A11yDelta"
+}

--- a/schema/compose-theme-diff.schema.json
+++ b/schema/compose-theme-diff.schema.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://schimke.ee/composeai/compose-theme-diff.schema.json",
+  "title": "ThemeDelta",
+  "description": "Payload for the `compose-theme-diff/v1` derived product: the diff between two `compose/theme` payloads' resolved Material 3 tokens (issue #1873), keyed by token name. Kotlin source of truth: ThemeDelta in :data-theme-core. The `schema` discriminator is always emitted (@EncodeDefault).",
+  "x-composeai": {
+    "kind": "compose-theme-diff/v1",
+    "schemaVersion": 1,
+    "kotlinType": "ee.schimke.composeai.data.theme.ThemeDelta",
+    "kotlinConst": "ThemeDiffProduct.SCHEMA",
+    "example": "schema/examples/compose-theme-diff.json"
+  },
+  "definitions": {
+    "ThemeTokenChange": {
+      "type": "object",
+      "required": ["token"],
+      "properties": {
+        "token": { "type": "string" },
+        "from": { "type": ["string", "null"] },
+        "to": { "type": ["string", "null"] }
+      }
+    },
+    "TypographyToken": {
+      "type": ["object", "null"],
+      "properties": {
+        "fontFamily": { "type": ["string", "null"] },
+        "fontSize": { "type": ["number", "null"] },
+        "fontSizeUnit": { "type": ["string", "null"] },
+        "fontWeight": { "type": ["string", "null"] },
+        "fontStyle": { "type": ["string", "null"] },
+        "lineHeight": { "type": ["number", "null"] },
+        "lineHeightUnit": { "type": ["string", "null"] },
+        "letterSpacing": { "type": ["number", "null"] },
+        "letterSpacingUnit": { "type": ["string", "null"] }
+      }
+    },
+    "ThemeTypographyChange": {
+      "type": "object",
+      "required": ["token"],
+      "properties": {
+        "token": { "type": "string" },
+        "from": { "$ref": "#/definitions/TypographyToken" },
+        "to": { "$ref": "#/definitions/TypographyToken" }
+      }
+    },
+    "ThemeDelta": {
+      "type": "object",
+      "required": ["schema"],
+      "properties": {
+        "schema": { "type": "string", "const": "compose-theme-diff/v1" },
+        "colorScheme": { "type": "array", "items": { "$ref": "#/definitions/ThemeTokenChange" } },
+        "shapes": { "type": "array", "items": { "$ref": "#/definitions/ThemeTokenChange" } },
+        "typography": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/ThemeTypographyChange" }
+        }
+      }
+    }
+  },
+  "$ref": "#/definitions/ThemeDelta"
+}

--- a/schema/examples/a11y-diff.json
+++ b/schema/examples/a11y-diff.json
@@ -1,0 +1,35 @@
+{
+  "schema": "a11y-diff/v1",
+  "added": [
+    {
+      "ref": "a/role:Button[1]",
+      "type": "TouchTargetSizeCheck",
+      "level": "ERROR",
+      "message": "This item's size is 32x32dp. Consider making it 48x48dp.",
+      "boundsInScreen": "0,120,32,152"
+    }
+  ],
+  "removed": [
+    {
+      "ref": "a/role:Image[0]",
+      "type": "SpeakableTextPresentCheck",
+      "level": "WARNING",
+      "message": "View is missing speakable text.",
+      "boundsInScreen": "0,0,48,48"
+    }
+  ],
+  "changed": [
+    {
+      "ref": "a/role:Button[0]",
+      "type": "TextContrastCheck",
+      "changes": [
+        { "field": "level", "from": "WARNING", "to": "ERROR" },
+        {
+          "field": "message",
+          "from": "Contrast ratio 3.8 is below 4.5.",
+          "to": "Contrast ratio 2.1 is below 4.5."
+        }
+      ]
+    }
+  ]
+}

--- a/schema/examples/compose-theme-diff.json
+++ b/schema/examples/compose-theme-diff.json
@@ -1,0 +1,25 @@
+{
+  "schema": "compose-theme-diff/v1",
+  "colorScheme": [
+    { "token": "primary", "from": "0xFF6750A4", "to": "0xFFB3261E" },
+    { "token": "tertiary", "from": null, "to": "0xFF7D5260" }
+  ],
+  "shapes": [{ "token": "large", "from": "16.0dp", "to": "28.0dp" }],
+  "typography": [
+    {
+      "token": "bodyLarge",
+      "from": {
+        "fontFamily": "Roboto",
+        "fontSize": 16.0,
+        "fontSizeUnit": "sp",
+        "fontWeight": "400"
+      },
+      "to": {
+        "fontFamily": "Roboto",
+        "fontSize": 18.0,
+        "fontSizeUnit": "sp",
+        "fontWeight": "500"
+      }
+    }
+  ]
+}

--- a/schema/examples/history-data-diff.json
+++ b/schema/examples/history-data-diff.json
@@ -1,0 +1,29 @@
+{
+  "schema": "history-data-diff/v1",
+  "semantics": {
+    "schema": "compose-semantics-diff/v1",
+    "changed": [
+      {
+        "ref": "r/tag:greeting",
+        "anchor": "greeting",
+        "changes": [{ "field": "text", "from": "Hello", "to": "World" }]
+      }
+    ]
+  },
+  "a11y": {
+    "schema": "a11y-diff/v1",
+    "added": [
+      {
+        "ref": "a/role:Button[1]",
+        "type": "TouchTargetSizeCheck",
+        "level": "ERROR",
+        "message": "This item's size is 32x32dp. Consider making it 48x48dp.",
+        "boundsInScreen": "0,120,32,152"
+      }
+    ]
+  },
+  "theme": {
+    "schema": "compose-theme-diff/v1",
+    "colorScheme": [{ "token": "primary", "from": "0xFF6750A4", "to": "0xFFB3261E" }]
+  }
+}

--- a/schema/history-data-diff.schema.json
+++ b/schema/history-data-diff.schema.json
@@ -1,0 +1,151 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://schimke.ee/composeai/history-data-diff.schema.json",
+  "title": "HistoryDataDelta",
+  "description": "Payload for the `history-data-diff/v1` derived product (issue #1873): the data-product diff over two history entries, rolling the `compose-semantics-diff/v1`, `a11y-diff/v1` and `compose-theme-diff/v1` sub-deltas into one versioned shape. Each section is present only when both entries carry that product. Kotlin source of truth: HistoryDataDelta in :daemon:core. Sub-delta definitions are inlined here (and mirror compose-semantics-diff / a11y-diff / compose-theme-diff). The `schema` discriminator is always emitted (@EncodeDefault).",
+  "x-composeai": {
+    "kind": "history-data-diff/v1",
+    "schemaVersion": 1,
+    "kotlinType": "ee.schimke.composeai.daemon.history.HistoryDataDelta",
+    "kotlinConst": "HistoryDataDiffProduct.SCHEMA",
+    "example": "schema/examples/history-data-diff.json"
+  },
+  "definitions": {
+    "SemanticsNodeSummary": {
+      "type": "object",
+      "required": ["ref"],
+      "properties": {
+        "ref": { "type": "string" },
+        "role": { "type": ["string", "null"] },
+        "testTag": { "type": ["string", "null"] },
+        "text": { "type": ["string", "null"] },
+        "label": { "type": ["string", "null"] }
+      }
+    },
+    "SemanticsFieldChange": {
+      "type": "object",
+      "required": ["field", "from", "to"],
+      "properties": {
+        "field": { "type": "string" },
+        "from": { "type": ["string", "null"] },
+        "to": { "type": ["string", "null"] }
+      }
+    },
+    "SemanticsNodeChange": {
+      "type": "object",
+      "required": ["ref", "changes"],
+      "properties": {
+        "ref": { "type": "string" },
+        "anchor": { "type": ["string", "null"] },
+        "changes": { "type": "array", "items": { "$ref": "#/definitions/SemanticsFieldChange" } }
+      }
+    },
+    "SemanticsDelta": {
+      "type": "object",
+      "required": ["schema"],
+      "properties": {
+        "schema": { "type": "string", "const": "compose-semantics-diff/v1" },
+        "added": { "type": "array", "items": { "$ref": "#/definitions/SemanticsNodeSummary" } },
+        "removed": { "type": "array", "items": { "$ref": "#/definitions/SemanticsNodeSummary" } },
+        "changed": { "type": "array", "items": { "$ref": "#/definitions/SemanticsNodeChange" } }
+      }
+    },
+    "A11yFindingSummary": {
+      "type": "object",
+      "required": ["type", "level", "message"],
+      "properties": {
+        "ref": { "type": ["string", "null"] },
+        "type": { "type": "string" },
+        "level": { "type": "string" },
+        "message": { "type": "string" },
+        "boundsInScreen": { "type": ["string", "null"] }
+      }
+    },
+    "A11yFieldChange": {
+      "type": "object",
+      "required": ["field"],
+      "properties": {
+        "field": { "type": "string" },
+        "from": { "type": ["string", "null"] },
+        "to": { "type": ["string", "null"] }
+      }
+    },
+    "A11yFindingChange": {
+      "type": "object",
+      "required": ["type", "changes"],
+      "properties": {
+        "ref": { "type": ["string", "null"] },
+        "type": { "type": "string" },
+        "changes": { "type": "array", "items": { "$ref": "#/definitions/A11yFieldChange" } }
+      }
+    },
+    "A11yDelta": {
+      "type": "object",
+      "required": ["schema"],
+      "properties": {
+        "schema": { "type": "string", "const": "a11y-diff/v1" },
+        "added": { "type": "array", "items": { "$ref": "#/definitions/A11yFindingSummary" } },
+        "removed": { "type": "array", "items": { "$ref": "#/definitions/A11yFindingSummary" } },
+        "changed": { "type": "array", "items": { "$ref": "#/definitions/A11yFindingChange" } }
+      }
+    },
+    "ThemeTokenChange": {
+      "type": "object",
+      "required": ["token"],
+      "properties": {
+        "token": { "type": "string" },
+        "from": { "type": ["string", "null"] },
+        "to": { "type": ["string", "null"] }
+      }
+    },
+    "TypographyToken": {
+      "type": ["object", "null"],
+      "properties": {
+        "fontFamily": { "type": ["string", "null"] },
+        "fontSize": { "type": ["number", "null"] },
+        "fontSizeUnit": { "type": ["string", "null"] },
+        "fontWeight": { "type": ["string", "null"] },
+        "fontStyle": { "type": ["string", "null"] },
+        "lineHeight": { "type": ["number", "null"] },
+        "lineHeightUnit": { "type": ["string", "null"] },
+        "letterSpacing": { "type": ["number", "null"] },
+        "letterSpacingUnit": { "type": ["string", "null"] }
+      }
+    },
+    "ThemeTypographyChange": {
+      "type": "object",
+      "required": ["token"],
+      "properties": {
+        "token": { "type": "string" },
+        "from": { "$ref": "#/definitions/TypographyToken" },
+        "to": { "$ref": "#/definitions/TypographyToken" }
+      }
+    },
+    "ThemeDelta": {
+      "type": "object",
+      "required": ["schema"],
+      "properties": {
+        "schema": { "type": "string", "const": "compose-theme-diff/v1" },
+        "colorScheme": { "type": "array", "items": { "$ref": "#/definitions/ThemeTokenChange" } },
+        "shapes": { "type": "array", "items": { "$ref": "#/definitions/ThemeTokenChange" } },
+        "typography": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/ThemeTypographyChange" }
+        }
+      }
+    },
+    "HistoryDataDelta": {
+      "type": "object",
+      "required": ["schema"],
+      "properties": {
+        "schema": { "type": "string", "const": "history-data-diff/v1" },
+        "semantics": {
+          "anyOf": [{ "$ref": "#/definitions/SemanticsDelta" }, { "type": "null" }]
+        },
+        "a11y": { "anyOf": [{ "$ref": "#/definitions/A11yDelta" }, { "type": "null" }] },
+        "theme": { "anyOf": [{ "$ref": "#/definitions/ThemeDelta" }, { "type": "null" }] }
+      }
+    }
+  },
+  "$ref": "#/definitions/HistoryDataDelta"
+}

--- a/vscode-extension/src/daemon/daemonProtocol.ts
+++ b/vscode-extension/src/daemon/daemonProtocol.ts
@@ -939,7 +939,7 @@ export interface HistoryReadResult {
     pngBytes?: string;
 }
 
-export type HistoryDiffMode = "metadata" | "pixel";
+export type HistoryDiffMode = "metadata" | "pixel" | "semantics" | "data";
 
 export interface HistoryDiffParams {
     from: string;
@@ -951,11 +951,22 @@ export interface HistoryDiffParams {
 }
 
 /**
- * `mode = 'metadata'` (default) is cheap: daemon hashes both PNGs and
- * returns the sidecars. Pixel-mode fields are reserved for phase H5; in
- * METADATA mode they are always undefined/null. A caller asking for
- * `mode = 'pixel'` against a current daemon receives error
- * `HistoryPixelNotImplemented` (-32012).
+ * `mode = 'metadata'` (default) is cheap: daemon hashes both PNGs and returns
+ * the sidecars; the diff/delta fields below stay undefined.
+ *
+ * `mode = 'pixel'` (H5, #1873) populates `diffPx` / `ssim` / `diffPngPath`
+ * (the marked-diff PNG written under `<historyDir>/<previewId>/.diffs/`;
+ * undefined on a dimension mismatch).
+ *
+ * `mode = 'semantics'` (#1785) populates `semanticsDelta` (`compose-semantics-diff/v1`).
+ *
+ * `mode = 'data'` (#1873) populates `dataDelta` (`history-data-diff/v1`): the
+ * data-product roll-up with optional `semantics` / `a11y` / `theme` sections,
+ * each present only when both entries carry that product.
+ *
+ * Nested payloads are typed `unknown` here (matching `fromMetadata` /
+ * `toMetadata`); the Kotlin `@Serializable` types under `schema/` are the
+ * source of truth for their shapes.
  */
 export interface HistoryDiffResult {
     pngHashChanged: boolean;
@@ -964,6 +975,10 @@ export interface HistoryDiffResult {
     diffPx?: number;
     ssim?: number;
     diffPngPath?: string;
+    /** Semantics-mode delta (`compose-semantics-diff/v1`); undefined otherwise. */
+    semanticsDelta?: unknown;
+    /** Data-mode roll-up (`history-data-diff/v1`); undefined outside `mode='data'`. */
+    dataDelta?: unknown;
 }
 
 export interface HistoryAddedParams {


### PR DESCRIPTION
## Summary

Pixel mode (H5) for `history/diff` already landed on `main`; this PR implements the **data-product diff** half of #1873 — diffing the archived data products of two history entries over time.

Adds `mode: "data"` to `history/diff`, rolling the captured `compose/semantics`, `a11y/atf` and `compose/theme` snapshots into one versioned `dataDelta` (`history-data-diff/v1`):

- **semantics** — reuses `SemanticsDiff` (`compose-semantics-diff/v1`).
- **a11y** — ATF findings added / removed / changed, keyed by the stable hierarchy `ref` from #1784, resolved by matching each finding's `boundsInScreen` against the captured `a11y/hierarchy` (`a11y-diff/v1`).
- **theme** — Material 3 resolved-token deltas via a new `ThemeDiff` in `:data-theme-core` (`compose-theme-diff/v1`).

Each section is populated only when **both** entries carry that product, so a `null` section means "not captured on both" while an empty-but-present section means "captured and identical". Unlike `mode=semantics`, DATA never errors on a missing product — it just omits the section.

Surfaced through the daemon `history/diff` and the CLI (`compose-preview history diff --mode data`). VS Code surfacing of data diffs is tracked separately in #1872 (the gate-flip sibling).

### Design notes
- `ThemeDiff` lives in `:data-theme-core` next to `ThemePayload`, mirroring how `SemanticsDiff` lives beside its models. The combined `HistoryDataDiff` orchestrator + the a11y diff live in `:daemon:core` (plain JVM). The a11y models are in an Android-only module, so the diff uses small structurally-identical `@Serializable` mirrors of the finding/node fields it needs — the pattern the a11y kdoc explicitly sanctions for JVM consumers.
- New published JSON schemas + examples for `compose-theme-diff/v1`, `a11y-diff/v1`, and `history-data-diff/v1`; README table and `PROTOCOL.md` / `HISTORY.md` updated.

## Test plan
- [x] `ThemeDiffTest` (`:data-theme-core`) — color/shape/typography token add/remove/change, identical → empty.
- [x] `HistoryDataDiffTest` (`:daemon:core`) — semantics/a11y/theme sections, a11y finding change keyed by stable ref, added/removed findings, null section when product only on one side, combined delta.
- [x] `HistoryDiffTest` wire-level DATA-mode tests — `dataDelta` rolls up all three; uncaptured sections omitted.
- [x] `HistoryCommandTest` — `compose-preview history diff --mode data` rolls up semantics + theme.
- [x] `node scripts/validate-report-schemas.mjs` — all schemas validate against their examples.

> Note: the unrelated, timing-sensitive `InteractiveCoalescingTest` flakes on slow/loaded VMs (confirmed failing on clean `main` in the same sandbox); it is not touched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gq937FF8p6kZjuNSMVTiBE)_