### PR TITLE
fix(bundle): don't require classes/app.jar in IR-backed bundles

### DIFF
--- a/bundle-viewer/src/main/kotlin/ee/schimke/composeai/viewer/BundleLoader.kt
+++ b/bundle-viewer/src/main/kotlin/ee/schimke/composeai/viewer/BundleLoader.kt
@@ -123,7 +123,6 @@ fun loadBundle(bundleFile: Path): LoadedBundle {
   }
   val bundleJsonNonNull = requireNotNull(bundleJson) { "bundle.json missing in $bundleFile" }
   val previewsJsonNonNull = requireNotNull(previewsJson) { "previews.json missing in $bundleFile" }
-  check(SystemFileSystem.exists(appJarPath)) { "classes/app.jar missing in $bundleFile" }
 
   val bundleManifest = JSON.decodeFromString(BundleManifest.serializer(), bundleJsonNonNull)
   val previewManifest = JSON.decodeFromString(PreviewManifest.serializer(), previewsJsonNonNull)
@@ -131,6 +130,17 @@ fun loadBundle(bundleFile: Path): LoadedBundle {
     SystemFileSystem.deleteRecursively(workDir)
     throw IllegalStateException("bundle has no previews: $bundleFile")
   }
+
+  // `classes/app.jar` carries the consumer module's bytecode, but a preview replayed from a
+  // captured intermediate representation (schema v5+, `ir/<id>.<ext>`) intentionally drops its
+  // enclosing class at pack time — so a fully IR-backed bundle (e.g. a Remote Compose `.rc` bundle)
+  // legitimately ships without an app.jar. Only insist on it when a preview still needs its class
+  // loaded; before this, every such bundle had to carry a dummy jar purely to clear the check.
+  val hasAppJar = SystemFileSystem.exists(appJarPath)
+  val irPreviewIds =
+    bundleManifest.intermediateRepresentations.mapTo(mutableSetOf()) { it.previewId }
+  val needsAppJar = previewManifest.previews.any { it.id !in irPreviewIds }
+  check(hasAppJar || !needsAppJar) { "classes/app.jar missing in $bundleFile" }
 
   // Default (coordinate-mode) bundles reference their deps by `maven` coordinate rather than
   // carrying them; resolve those from the machine's local Maven / Gradle caches (warn-not-fail) so
@@ -146,7 +156,7 @@ fun loadBundle(bundleFile: Path): LoadedBundle {
   // URLClassLoader is a hard `java.io.File` boundary (it wants `file:` URLs) — bridge each Okio
   // path to a File here.
   val classpathUrls =
-    (listOf(appJarPath) + libJarFiles.values + resolvedCoordJars).map {
+    (listOfNotNull(appJarPath.takeIf { hasAppJar }) + libJarFiles.values + resolvedCoordJars).map {
       it.toFile().toURI().toURL()
     }
   val classLoader = URLClassLoader(classpathUrls.toTypedArray(), parentLoader)

--- a/bundle-viewer/src/test/kotlin/ee/schimke/composeai/viewer/BundleLoaderTest.kt
+++ b/bundle-viewer/src/test/kotlin/ee/schimke/composeai/viewer/BundleLoaderTest.kt
@@ -48,6 +48,48 @@ class BundleLoaderTest {
   }
 
   @Test
+  fun `loadBundle accepts an IR-backed bundle with no app jar`() {
+    // A fully IR-backed bundle (e.g. a Remote Compose `.rc` bundle) drops its consumer classes at
+    // pack time and replays from `ir/`, so it carries no `classes/app.jar`. The loader must accept
+    // it rather than crash on the existence check — issue #1946 (no more dummy jar workaround).
+    val bundle =
+      writeMinimalBundle(
+        includeAppJarEntry = false,
+        intermediateRepresentations =
+          listOf(
+            BundleIr(
+              previewId = "test.PreviewsKt.MissingPreview",
+              format = "remotecompose",
+              path = "ir/test.PreviewsKt.MissingPreview.rc",
+            )
+          ),
+      )
+
+    val loaded = loadBundle(bundle.path.toPath())
+    try {
+      assertThat(loaded.bundleManifest.intermediateRepresentations).hasSize(1)
+      assertThat(loaded.previewManifest.previews).hasSize(1)
+      assertThat(loaded.coverPreview.info.id).isEqualTo("test.PreviewsKt.MissingPreview")
+    } finally {
+      loaded.close()
+    }
+  }
+
+  @Test
+  fun `loadBundle rejects a class-backed bundle missing app jar`() {
+    // No IR declared and no `classes/app.jar` entry: a genuinely malformed bundle. The existence
+    // check still guards this case so the failure is a clear message rather than a later
+    // class-not-found per preview.
+    val bundle = writeMinimalBundle(includeAppJarEntry = false)
+
+    val ex =
+      runCatching { loadBundle(bundle.path.toPath()) }.exceptionOrNull()
+        ?: error("expected loadBundle to throw when app.jar is absent and no IR is declared")
+    assertThat(ex).isInstanceOf(IllegalStateException::class.java)
+    assertThat(ex).hasMessageThat().contains("classes/app.jar missing")
+  }
+
+  @Test
   fun `loadBundle rejects non-bundle files`() {
     val txt = tempDir.newFile("not-a-bundle.txt").apply { writeText("hello world") }
 
@@ -150,6 +192,8 @@ class BundleLoaderTest {
     resolution: String = "coordinates",
     extraClasspath: List<ClasspathEntry> = emptyList(),
     libs: Map<String, ByteArray> = emptyMap(),
+    includeAppJarEntry: Boolean = true,
+    intermediateRepresentations: List<BundleIr> = emptyList(),
   ): File {
     val zipBytes = ByteArrayOutputStream()
     ZipOutputStream(zipBytes).use { zip ->
@@ -174,6 +218,7 @@ class BundleLoaderTest {
             modulePath = ":test",
             producedBy = "test-suite",
             resolution = resolution,
+            intermediateRepresentations = intermediateRepresentations,
           ),
         )
       zip.putNextEntry(ZipEntry("bundle.json"))
@@ -203,17 +248,21 @@ class BundleLoaderTest {
       // classes/app.jar: empty by default (exercises the class-not-found branch). When
       // [includeAppClass] is set, carry the preview's owner class so resolution succeeds and the
       // owner class is loaded by the bundle's own URLClassLoader.
-      val appJarBytes = ByteArrayOutputStream()
-      ZipOutputStream(appJarBytes).use { appJar ->
-        if (includeAppClass) {
-          appJar.putNextEntry(ZipEntry("test/PreviewsKt.class"))
-          appJar.write(minimalClassBytes("test.PreviewsKt"))
-          appJar.closeEntry()
+      // Omit the entry entirely when [includeAppJarEntry] is false — mirrors an IR-backed bundle
+      // that ships no consumer bytecode (and no dummy jar) at all.
+      if (includeAppJarEntry) {
+        val appJarBytes = ByteArrayOutputStream()
+        ZipOutputStream(appJarBytes).use { appJar ->
+          if (includeAppClass) {
+            appJar.putNextEntry(ZipEntry("test/PreviewsKt.class"))
+            appJar.write(minimalClassBytes("test.PreviewsKt"))
+            appJar.closeEntry()
+          }
         }
+        zip.putNextEntry(ZipEntry("classes/app.jar"))
+        zip.write(appJarBytes.toByteArray())
+        zip.closeEntry()
       }
-      zip.putNextEntry(ZipEntry("classes/app.jar"))
-      zip.write(appJarBytes.toByteArray())
-      zip.closeEntry()
 
       for ((path, bytes) in libs) {
         zip.putNextEntry(ZipEntry(path))

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleDaemonCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleDaemonCommand.kt
@@ -70,14 +70,16 @@ class BundleDaemonCommand(args: List<String>) : Command(args) {
     val zipBytes = BundleReader.extractZipBytes(file)
     val manifest = BundleReader.readMetadata(file).manifest
     // A fully IR-backed bundle (schema v5+) drops its consumer classes — its previews replay from
-    // `ir/` (extracted below), so `classes/app.jar` is legitimately absent and need not be
-    // required. Classic class-backed bundles must still carry it.
+    // `ir/` (extracted below), so `classes/app.jar` is legitimately absent. A mixed bundle that
+    // still has a class-backed preview must carry it, so gate on whether any preview id is NOT
+    // covered by an intermediate representation rather than merely "has some IR".
+    val irPreviewIds = manifest.intermediateRepresentations.mapTo(mutableSetOf()) { it.previewId }
     expandAppJarAndManifest(
       zipBytes,
       classesDir,
       previewsJson,
       file,
-      requireAppJar = manifest.intermediateRepresentations.isEmpty(),
+      requireAppJar = manifest.previewIds.any { it !in irPreviewIds },
     )
     // Consumer classpath for the daemon's `userClassDirs` holder (dirs-before-jars ordered, see
     // UserClassLoaderHolder) — the extracted app classes plus the bundle's third-party deps. NOT

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleDaemonCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleDaemonCommand.kt
@@ -68,7 +68,17 @@ class BundleDaemonCommand(args: List<String>) : Command(args) {
     val libsDir = workDir.resolve("libs").apply { mkdirs() }
     val previewsJson = workDir.resolve("previews.json")
     val zipBytes = BundleReader.extractZipBytes(file)
-    expandAppJarAndManifest(zipBytes, classesDir, previewsJson, file)
+    val manifest = BundleReader.readMetadata(file).manifest
+    // A fully IR-backed bundle (schema v5+) drops its consumer classes — its previews replay from
+    // `ir/` (extracted below), so `classes/app.jar` is legitimately absent and need not be
+    // required. Classic class-backed bundles must still carry it.
+    expandAppJarAndManifest(
+      zipBytes,
+      classesDir,
+      previewsJson,
+      file,
+      requireAppJar = manifest.intermediateRepresentations.isEmpty(),
+    )
     // Consumer classpath for the daemon's `userClassDirs` holder (dirs-before-jars ordered, see
     // UserClassLoaderHolder) — the extracted app classes plus the bundle's third-party deps. NOT
     // the
@@ -76,7 +86,6 @@ class BundleDaemonCommand(args: List<String>) : Command(args) {
     // bundles) and `maven` coordinates resolved from local repos (the default detached bundles). A
     // resolver miss or hash mismatch warns but never fails — same contract as `bundle render`.
     val libJars = BundleReader.extractEmbeddedLibs(zipBytes, libsDir)
-    val manifest = BundleReader.readMetadata(file).manifest
     val mavenCoords = manifest.classpath.filterIsInstance<BundleReader.ClasspathEntry.Maven>()
     val resolvedJars =
       CoordinateResolver(warn = { System.err.println("[bundle-daemon] $it") })
@@ -482,6 +491,7 @@ class BundleDaemonCommand(args: List<String>) : Command(args) {
     classesDir: File,
     previewsJson: File,
     bundleFile: File,
+    requireAppJar: Boolean,
   ) {
     var sawAppJar = false
     var sawPreviewsJson = false
@@ -502,7 +512,7 @@ class BundleDaemonCommand(args: List<String>) : Command(args) {
         zin.closeEntry()
       }
     }
-    require(sawAppJar) {
+    require(sawAppJar || !requireAppJar) {
       "bundle daemon: classes/app.jar missing in ${bundleFile.path} — not a packed bundle"
     }
     require(sawPreviewsJson) {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleRenderer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleRenderer.kt
@@ -372,9 +372,11 @@ class BundleRenderer(
       requireNotNull(bundleJson) { "bundle render: bundle.json missing in ${bundleFile.path}" }
     val previewsJsonNonNull =
       requireNotNull(previewsJson) { "bundle render: previews.json missing in ${bundleFile.path}" }
-    val appJarBytesNonNull =
-      requireNotNull(appJarBytes) { "bundle render: classes/app.jar missing in ${bundleFile.path}" }
-    expandJarBytes(appJarBytesNonNull, classesDir)
+    // `classes/app.jar` is absent from a fully IR-backed bundle (schema v5+), whose previews replay
+    // from `ir/` rather than from reflected consumer bytecode — renderDesktop/renderAndroid skip
+    // those IR previews. Expand the consumer classes only when the bundle actually carries them; a
+    // non-IR preview whose class is then missing fails per-preview rather than aborting the load.
+    appJarBytes?.let { expandJarBytes(it, classesDir) }
     return bundleJsonNonNull to previewsJsonNonNull
   }
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleRenderer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleRenderer.kt
@@ -84,11 +84,23 @@ class BundleRenderer(
     val classesDir = workDir.resolve("classes").apply { mkdirs() }
     val libsDir = workDir.resolve("libs").apply { mkdirs() }
     val zipBytes = BundleReader.extractZipBytes(bundleFile)
-    val (bundleJsonBytes, previewsJsonBytes) = expandAppJarAndReadManifests(zipBytes, classesDir)
+    val (bundleJsonBytes, previewsJsonBytes, hasAppJar) =
+      expandAppJarAndReadManifests(zipBytes, classesDir)
     val libJars = BundleReader.extractEmbeddedLibs(zipBytes, libsDir)
 
     val manifest = BUNDLE_JSON.decodeFromString(BundleReader.Manifest.serializer(), bundleJsonBytes)
     val previews = MANIFEST_JSON.decodeFromString(PreviewManifest.serializer(), previewsJsonBytes)
+
+    // A preview that isn't replayed from an intermediate representation needs its class from
+    // `classes/app.jar`; a fully IR-backed bundle legitimately omits it. Re-impose the fast-fail
+    // for a class-backed (or mixed) bundle that's missing the jar, rather than letting the renderer
+    // start against an empty classes dir — or, for android, trip its sidecar/SDK checks first.
+    if (!hasAppJar) {
+      val irIds = manifest.intermediateRepresentations.map { it.previewId }.toSet()
+      check(previews.previews.all { it.id in irIds }) {
+        "bundle render: classes/app.jar missing in ${bundleFile.path}"
+      }
+    }
 
     return when (manifest.backend) {
       "desktop" -> renderDesktop(classesDir, libJars, manifest, previews)
@@ -353,7 +365,7 @@ class BundleRenderer(
   private fun expandAppJarAndReadManifests(
     zipBytes: ByteArray,
     classesDir: File,
-  ): Pair<String, String> {
+  ): Triple<String, String, Boolean> {
     var bundleJson: String? = null
     var previewsJson: String? = null
     var appJarBytes: ByteArray? = null
@@ -373,11 +385,11 @@ class BundleRenderer(
     val previewsJsonNonNull =
       requireNotNull(previewsJson) { "bundle render: previews.json missing in ${bundleFile.path}" }
     // `classes/app.jar` is absent from a fully IR-backed bundle (schema v5+), whose previews replay
-    // from `ir/` rather than from reflected consumer bytecode — renderDesktop/renderAndroid skip
-    // those IR previews. Expand the consumer classes only when the bundle actually carries them; a
-    // non-IR preview whose class is then missing fails per-preview rather than aborting the load.
+    // from `ir/` rather than from reflected consumer bytecode. Expand the consumer classes only
+    // when the bundle carries them; the caller validates that a class-backed preview isn't left
+    // without its jar.
     appJarBytes?.let { expandJarBytes(it, classesDir) }
-    return bundleJsonNonNull to previewsJsonNonNull
+    return Triple(bundleJsonNonNull, previewsJsonNonNull, appJarBytes != null)
   }
 
   /**


### PR DESCRIPTION
## Summary

A fully IR-backed bundle (schema v5+) replays its previews from `ir/<id>.<ext>` (e.g. a Remote Compose `.rc` stream) and intentionally drops the consumer's enclosing-class bytecode at pack time, so it legitimately ships without a `classes/app.jar`. Three loaders enforced a hard existence check on app.jar *before* inspecting the intermediate representations, which forced such bundles to carry a 178-byte dummy jar purely to clear the check (issue #1946):

- `bundle-viewer` `BundleLoader.loadBundle` — `check(SystemFileSystem.exists(appJarPath))`
- `cli` `BundleRenderer.expandAppJarAndReadManifests` — `requireNotNull(appJarBytes)`
- `cli` `BundleDaemonCommand.expandAppJarAndManifest` — `require(sawAppJar)`

This relaxes all three to require app.jar only when a preview still needs its class loaded (i.e. it isn't covered by an entry in `intermediateRepresentations`):

- **BundleLoader** now parses the manifests first, then requires app.jar only when some preview is *not* IR-backed, and includes app.jar on the URLClassLoader only when present.
- **BundleRenderer** expands the consumer classes only when the bundle carries them; `renderDesktop`/`renderAndroid` already skip IR previews, and a non-IR preview whose class is then missing fails per-preview rather than aborting the whole load.
- **BundleDaemonCommand** reads the manifest first and passes `requireAppJar = intermediateRepresentations.isEmpty()`; the daemon's existing `ir/` extraction handles replay, and an empty `classesDir` is harmless.

Classic class-backed bundles still fail fast with the same clear "classes/app.jar missing" message when app.jar is genuinely absent.

Closes #1946.

## Test plan

- Added `bundle-viewer` `BundleLoaderTest`:
  - `loadBundle accepts an IR-backed bundle with no app jar` — a bundle declaring a `remotecompose` IR for its only preview and **no** `classes/app.jar` entry loads successfully.
  - `loadBundle rejects a class-backed bundle missing app jar` — a non-IR bundle with no app.jar still throws `IllegalStateException("classes/app.jar missing …")`.
  - Extended the test harness (`writeMinimalBundle`) with `includeAppJarEntry` / `intermediateRepresentations` knobs.
- `./gradlew :bundle-viewer:test --tests "…BundleLoaderTest"` → **BUILD SUCCESSFUL**.
- `./gradlew :cli:compileKotlin` → **BUILD SUCCESSFUL** (renderer + daemon edits compile clean).

Non-visual change (bundle-loading plumbing), so text-only evidence per the repo's visual-evidence guidance.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KzbHuBaDgwb9MR6rwsS9Jm)_