### PR TITLE
feat(samples): Remote Compose gradient-shader preview with a named-color control

### DIFF
--- a/samples/remotecompose/src/main/kotlin/com/example/sampleremotecompose/Previews.kt
+++ b/samples/remotecompose/src/main/kotlin/com/example/sampleremotecompose/Previews.kt
@@ -87,3 +87,18 @@ fun RemoteButtonWithBorderPreview() {
 fun RemoteButtonWithNamedLabelPreview() {
     Container { RemoteButtonWithNamedLabel() }
 }
+
+/**
+ * Preview for [RemoteShaderGradient] — a Remote Compose gradient-**shader** fill. Uses the same
+ * `@PreviewWrapper(RemotePreviewWrapper::class)` path as the named-label preview so the connector's
+ * substitution wires the `shaderColor` named value into the running player: the default render shows
+ * the static gradient, and `renderNow.overrides.remoteCompose.namedValues = {"shaderColor": ...}`
+ * recolours the shader live. This is the "shader control" surfaced through the existing
+ * named-value override mechanism rather than a new control type.
+ */
+@Preview(showBackground = true, widthDp = 200, heightDp = 200)
+@PreviewWrapper(RemotePreviewWrapper::class)
+@Composable
+fun RemoteShaderGradientPreview() {
+    Container { RemoteShaderGradient() }
+}

--- a/samples/remotecompose/src/main/kotlin/com/example/sampleremotecompose/RemoteComponents.kt
+++ b/samples/remotecompose/src/main/kotlin/com/example/sampleremotecompose/RemoteComponents.kt
@@ -7,11 +7,15 @@ import androidx.compose.remote.creation.compose.layout.RemoteAlignment
 import androidx.compose.remote.creation.compose.layout.RemoteBox
 import androidx.compose.remote.creation.compose.layout.RemoteComposable
 import androidx.compose.remote.creation.compose.modifier.RemoteModifier
+import androidx.compose.remote.creation.compose.modifier.background
 import androidx.compose.remote.creation.compose.modifier.fillMaxSize
+import androidx.compose.remote.creation.compose.shaders.RemoteBrush
+import androidx.compose.remote.creation.compose.shaders.linearGradient
 import androidx.compose.remote.creation.compose.shapes.RemoteRoundedCornerShape
 import androidx.compose.remote.creation.compose.state.RemoteColor
 import androidx.compose.remote.creation.compose.state.rb
 import androidx.compose.remote.creation.compose.state.rdp
+import androidx.compose.remote.creation.compose.state.rememberNamedRemoteColor
 import androidx.compose.remote.creation.compose.state.rememberNamedRemoteString
 import androidx.compose.remote.creation.compose.state.rf
 import androidx.compose.remote.creation.compose.state.rs
@@ -92,6 +96,40 @@ fun RemoteButtonWithShape() {
         modifier = RemoteModifier.buttonSizeModifier(),
         shape = RemoteRoundedCornerShape(4.rdp),
         content = { RemoteText("Custom shape".rs) },
+    )
+}
+
+/**
+ * A Remote Compose **shader** component: a full-size box painted with a [RemoteBrush] gradient
+ * shader (Remote Compose's `shaders` package — `RemoteLinearGradient`/`RemoteRadialGradient`/etc.
+ * are the document-level equivalents of Compose's `Brush.linearGradient`). The gradient serialises
+ * into the `RemoteDocument` byte stream and is rasterised by the player, not by an app-side
+ * `ShaderBrush`.
+ *
+ * **Shader control** — the middle gradient stop is a [rememberNamedRemoteColor] binding named
+ * `shaderColor`, so the panel-side Remote Compose editor (or any caller seeding
+ * `renderNow.overrides.remoteCompose.namedValues = {"shaderColor": ColorValue(...)}`) recolours the
+ * shader live, without rebuilding the document — the same override path
+ * [RemoteButtonWithNamedLabel]'s string label uses, here driving a shader uniform. Without an
+ * override the default cyan stop shows, so the preview is a useful static capture in
+ * `composePreviewRenderAll` runs.
+ */
+@Composable
+@RemoteComposable
+fun RemoteShaderGradient() {
+    val shaderColor = rememberNamedRemoteColor("shaderColor", Color(0xFF7DE2FF))
+    val brush =
+        RemoteBrush.linearGradient(
+            listOf(
+                RemoteColor(Color(0xFF101820)),
+                shaderColor,
+                RemoteColor(Color(0xFFFFB86C)),
+            )
+        )
+    RemoteBox(
+        modifier = RemoteModifier.fillMaxSize().background(brush),
+        contentAlignment = RemoteAlignment.Center,
+        content = { RemoteText("Shader".rs) },
     )
 }
 


### PR DESCRIPTION
## Summary

Adds a Remote Compose **shader** sample with an overridable control, and a compatible `@Preview`.

- **`RemoteShaderGradient`** (`RemoteComponents.kt`) — a `RemoteBox` painted with `RemoteModifier.background(RemoteBrush.linearGradient(...))`. This is a document-level Remote Compose shader (the `shaders` package — `RemoteLinearGradient`/`RemoteRadialGradient`/`RemoteSweepGradient`), so the gradient serialises into the `RemoteDocument` (`.rcdoc`) byte stream and is rasterised by the player, not by an app-side `ShaderBrush`.
- **Shader control** — the middle gradient stop is a `rememberNamedRemoteColor("shaderColor", …)` binding. The connector already wires this end to end: `applyConnectorOverrides` maps `RemoteNamedValue.ColorValue → StateUpdater.setUserLocalColor`, so `renderNow.overrides.remoteCompose.namedValues = {"shaderColor": ColorValue(...)}` recolours the shader live — the same override path the existing string-label sample uses, here driving a shader stop instead of text.
- **`RemoteShaderGradientPreview`** — `@Preview` + `@PreviewWrapper(RemotePreviewWrapper::class)` so the connector's wrapper substitution activates the override path. The default capture shows the static gradient.

## Visual evidence

Default render (cyan middle stop = the `shaderColor` control; `.rcdoc` companion also written). Hosted on the `shader-gallery-assets` branch so `main` stays free of binaries.

![Remote Compose shader gradient](https://raw.githubusercontent.com/yschimke/compose-ai-tools/shader-gallery-assets/docs/shader-gallery/remotecompose-shader.png)

## Test plan

- [x] `./gradlew :samples:remotecompose:composePreviewRenderAll` — `RemoteShaderGradientPreview` discovered and captured (PNG + `.rcdoc`), no error sidecar.
- [x] `./gradlew ktfmtCheckAll` — green.

## Notes

- The capture shows the **default** static gradient; the live recolour happens through the daemon/panel override path (verified by the connector's `ColorValue → setUserLocalColor` mapping, not a running daemon). A follow-up could drive an actual `shaderColor` override through the daemon to capture a recoloured variant.
- Remote Compose's `shaders` are gradient/bitmap brushes (not AGSL runtime shaders); a `RemoteShader`/AGSL-style path is a separate, larger surface if wanted later.

---
_Generated by [Claude Code](https://claude.ai/code/session_011gBmD8DshfK4WyjiphSKwT)_