### PR TITLE
feat(a11y): TalkBack visualization, utterance composition + scriptable verbs (#1956)

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSession.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSession.kt
@@ -906,6 +906,8 @@ class AndroidRecordingSession(
         "scrollDown",
         "scrollLeft",
         "scrollRight",
+        // TalkBack's double-tap-to-activate verb (issue #1956) — OnClick on the resolved node.
+        "activate",
       )
   }
 }

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -2959,7 +2959,10 @@ open class RobolectricHost(
       val target =
         nodes.minByOrNull { node -> node.boundsInRoot.width * node.boundsInRoot.height } ?: nodes[0]
       return when (cmd.actionKind) {
-        "click" -> invokeLambdaAction(rule, target, SemanticsActions.OnClick)
+        "click",
+        // TalkBack's "double-tap to activate" verb (issue #1956): activating the focused control
+        // is its OnClick, same as a tap — distinct script vocabulary, same semantic action.
+        "activate" -> invokeLambdaAction(rule, target, SemanticsActions.OnClick)
         "longClick" -> invokeLambdaAction(rule, target, SemanticsActions.OnLongClick)
         "focus" -> invokeLambdaAction(rule, target, SemanticsActions.RequestFocus)
         "expand" -> invokeLambdaAction(rule, target, SemanticsActions.Expand)

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/FfmpegEncoder.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/FfmpegEncoder.kt
@@ -80,11 +80,26 @@ object FfmpegEncoder {
    * [out] using [format] at [fps] frames per second. Throws on any non-zero exit, missing binary
    * (when [available] reports false at call time), or timeout — callers map these to a tool-level
    * error so the agent sees the real failure instead of an empty file on disk.
+   *
+   * [audioTrack] is an optional pre-rendered audio file muxed in as a second input — the TalkBack
+   * spoken-announcement track (issue #1956, Phase 4). When `null` (the default and the only path
+   * for every existing caller) the command is byte-identical to the video-only encoder. Audio is
+   * only meaningful for MP4 / WEBM; APNG / GIF have no audio track, so [DesktopRecordingSession]
+   * passes it only down the ffmpeg path.
    */
-  fun encodeFromPngFrames(framesDir: File, fps: Int, format: RecordingFormatChoice, out: File) {
+  fun encodeFromPngFrames(
+    framesDir: File,
+    fps: Int,
+    format: RecordingFormatChoice,
+    out: File,
+    audioTrack: File? = null,
+  ) {
     require(fps in 1..120) { "FfmpegEncoder: fps=$fps out of range [1, 120]" }
     require(framesDir.isDirectory) {
       "FfmpegEncoder: framesDir does not exist or is not a directory: ${framesDir.absolutePath}"
+    }
+    require(audioTrack == null || audioTrack.isFile) {
+      "FfmpegEncoder: audioTrack does not exist or is not a file: ${audioTrack?.absolutePath}"
     }
     if (!available()) {
       error("FfmpegEncoder: ffmpeg not found on PATH; install ffmpeg or use RecordingFormat.APNG")
@@ -93,50 +108,7 @@ object FfmpegEncoder {
     out.parentFile?.mkdirs()
     if (out.exists()) out.delete()
 
-    val args = mutableListOf("ffmpeg", "-y", "-framerate", fps.toString())
-    args.add("-i")
-    args.add(File(framesDir, "frame-%05d.png").absolutePath)
-    when (format) {
-      RecordingFormatChoice.MP4 -> {
-        // H.264 + yuv420p for universal player compatibility (mobile + QuickTime require yuv420p
-        // even though libx264's default profile would otherwise pick yuv444). `-movflags
-        // +faststart` shifts the moov atom to the start of the file so streaming players can
-        // begin playback before downloading the trailer; cheap on small clips, useful when the
-        // file is served via HTTP from the daemon's history dir.
-        args.addAll(
-          listOf(
-            "-c:v",
-            "libx264",
-            "-pix_fmt",
-            "yuv420p",
-            "-preset",
-            "veryfast",
-            "-movflags",
-            "+faststart",
-          )
-        )
-      }
-      RecordingFormatChoice.WEBM -> {
-        // VP9 with the row-multithread + tile-columns combo most modern guides recommend for
-        // sub-720p content. `-deadline good -cpu-used 4` is the speed/quality middle ground —
-        // matching libx264's `veryfast`. Default WebM container.
-        args.addAll(
-          listOf(
-            "-c:v",
-            "libvpx-vp9",
-            "-pix_fmt",
-            "yuv420p",
-            "-deadline",
-            "good",
-            "-cpu-used",
-            "4",
-            "-row-mt",
-            "1",
-          )
-        )
-      }
-    }
-    args.add(out.absolutePath)
+    val args = buildArgs(framesDir, fps, format, out, audioTrack)
 
     val pb = ProcessBuilder(args).redirectErrorStream(true)
     val proc = pb.start()
@@ -186,6 +158,79 @@ object FfmpegEncoder {
         "FfmpegEncoder: ffmpeg ${format.name.lowercase()} produced no output at ${out.absolutePath}"
       )
     }
+  }
+
+  /**
+   * Builds the full `ffmpeg` argv for [encodeFromPngFrames]. Extracted (and `internal`) so the
+   * codec / mux flags — especially the optional [audioTrack] muxing — can be unit-tested without
+   * shelling out. When [audioTrack] is non-null a second `-i` input is added, encoded to the
+   * container's standard audio codec (AAC for MP4, Opus for WEBM), and explicitly mapped alongside
+   * the video stream; `-shortest` clamps the result to the video length so a slightly-longer TTS
+   * track doesn't extend the clip past its last frame.
+   */
+  internal fun buildArgs(
+    framesDir: File,
+    fps: Int,
+    format: RecordingFormatChoice,
+    out: File,
+    audioTrack: File?,
+  ): List<String> {
+    val args = mutableListOf("ffmpeg", "-y", "-framerate", fps.toString())
+    args.add("-i")
+    args.add(File(framesDir, "frame-%05d.png").absolutePath)
+    if (audioTrack != null) {
+      args.add("-i")
+      args.add(audioTrack.absolutePath)
+    }
+    when (format) {
+      RecordingFormatChoice.MP4 -> {
+        // H.264 + yuv420p for universal player compatibility (mobile + QuickTime require yuv420p
+        // even though libx264's default profile would otherwise pick yuv444). `-movflags
+        // +faststart` shifts the moov atom to the start of the file so streaming players can
+        // begin playback before downloading the trailer; cheap on small clips, useful when the
+        // file is served via HTTP from the daemon's history dir.
+        args.addAll(
+          listOf(
+            "-c:v",
+            "libx264",
+            "-pix_fmt",
+            "yuv420p",
+            "-preset",
+            "veryfast",
+            "-movflags",
+            "+faststart",
+          )
+        )
+        if (audioTrack != null) args.addAll(listOf("-c:a", "aac"))
+      }
+      RecordingFormatChoice.WEBM -> {
+        // VP9 with the row-multithread + tile-columns combo most modern guides recommend for
+        // sub-720p content. `-deadline good -cpu-used 4` is the speed/quality middle ground —
+        // matching libx264's `veryfast`. Default WebM container.
+        args.addAll(
+          listOf(
+            "-c:v",
+            "libvpx-vp9",
+            "-pix_fmt",
+            "yuv420p",
+            "-deadline",
+            "good",
+            "-cpu-used",
+            "4",
+            "-row-mt",
+            "1",
+          )
+        )
+        if (audioTrack != null) args.addAll(listOf("-c:a", "libopus"))
+      }
+    }
+    if (audioTrack != null) {
+      // Map the video from input 0 and the audio from input 1 explicitly, and clamp to the video
+      // duration so the encode ends with the last frame even if the audio track runs slightly long.
+      args.addAll(listOf("-map", "0:v:0", "-map", "1:a:0", "-shortest"))
+    }
+    args.add(out.absolutePath)
+    return args
   }
 
   /**

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/FfmpegEncoder.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/FfmpegEncoder.kt
@@ -165,8 +165,9 @@ object FfmpegEncoder {
    * codec / mux flags — especially the optional [audioTrack] muxing — can be unit-tested without
    * shelling out. When [audioTrack] is non-null a second `-i` input is added, encoded to the
    * container's standard audio codec (AAC for MP4, Opus for WEBM), and explicitly mapped alongside
-   * the video stream; `-shortest` clamps the result to the video length so a slightly-longer TTS
-   * track doesn't extend the clip past its last frame.
+   * the video stream. `-af apad` pads short audio with trailing silence and `-shortest` clamps long
+   * audio, so the output is exactly the video duration in both directions — a TTS track that ends
+   * before the last frame never truncates the video.
    */
   internal fun buildArgs(
     framesDir: File,
@@ -225,9 +226,12 @@ object FfmpegEncoder {
       }
     }
     if (audioTrack != null) {
-      // Map the video from input 0 and the audio from input 1 explicitly, and clamp to the video
-      // duration so the encode ends with the last frame even if the audio track runs slightly long.
-      args.addAll(listOf("-map", "0:v:0", "-map", "1:a:0", "-shortest"))
+      // Map video from input 0 and audio from input 1 explicitly. `-af apad` pads the audio with
+      // trailing silence so a TTS track that ends before the last frame never becomes the shortest
+      // stream; `-shortest` then clamps the output to the video length. Together they hold the
+      // result to exactly the video duration whether the audio runs short (silence-padded) or long
+      // (truncated) — so trailing frames are never dropped.
+      args.addAll(listOf("-map", "0:v:0", "-map", "1:a:0", "-af", "apad", "-shortest"))
     }
     args.add(out.absolutePath)
     return args

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -567,6 +567,20 @@ data class PreviewOverrides(
    */
   val touchOverlay: Boolean? = null,
   /**
+   * Opt-in TalkBack focus visualization for recording sessions (issue #1956). When `true`, each
+   * captured frame is composited with [TalkBackFocusOverlay]: a green focus rectangle around the
+   * node TalkBack is currently stopped on, faint traversal-order numbers on every focus stop, and a
+   * caption card showing the composed announcement (`TalkBackUtterance`) — so a silent capture
+   * still conveys what TalkBack would say. The focus walk advances one stop per dwell window
+   * (`TalkBackOverlayFrames`), turning the frame sequence into an animated TalkBack walk in the
+   * recorded APNG / mp4 / GIF. The focus stops and announcements come from the same per-frame
+   * semantics the a11y data product already extracts, so the rectangle, the number, and the words
+   * always agree. Mirrors [touchOverlay] as a strictly opt-in, default-`null` flag so existing
+   * pixel-exact captures stay byte-identical; backends without per-frame semantics extraction
+   * ignore it.
+   */
+  val talkBack: Boolean? = null,
+  /**
    * Optional soft-keyboard (IME) override. Drives the connector-side `KeyboardOverrideExtension`
    * (see `:data-keyboard-connector`). The around-composable mirrors the consumer's normal IME
    * behaviour — `LocalSoftwareKeyboardController.show()/hide()`, focused `BasicTextField`s, and

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/FfmpegEncoderArgsTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/FfmpegEncoderArgsTest.kt
@@ -66,11 +66,17 @@ class FfmpegEncoderArgsTest {
     val inputs = args.withIndex().filter { it.value == "-i" }.map { it.index }
     assertEquals("expected two -i inputs (frames + audio)", 2, inputs.size)
     assertEquals(audio.absolutePath, args[inputs[1] + 1])
-    // AAC for the MP4 container, explicit maps, shortest clamp.
+    // AAC for the MP4 container, explicit maps, apad+shortest hold the output to the video length.
     assertTrue(containsSeq(args, listOf("-c:a", "aac")))
     assertTrue(containsSeq(args, listOf("-map", "0:v:0")))
     assertTrue(containsSeq(args, listOf("-map", "1:a:0")))
+    // `-af apad` pads short audio so the video is never truncated; `-shortest` clamps long audio.
+    assertTrue(
+      "short audio must be padded, not truncate the video",
+      containsSeq(args, listOf("-af", "apad")),
+    )
     assertTrue(args.contains("-shortest"))
+    assertTrue("apad must precede -shortest", args.indexOf("apad") < args.indexOf("-shortest"))
     assertEquals("output stays last", out.absolutePath, args.last())
   }
 

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/FfmpegEncoderArgsTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/FfmpegEncoderArgsTest.kt
@@ -1,0 +1,101 @@
+package ee.schimke.composeai.daemon
+
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins [FfmpegEncoder.buildArgs] — especially the optional TalkBack audio-track muxing (issue #1956
+ * Phase 4) — without shelling out to ffmpeg. The no-audio path must stay byte-identical to the
+ * pre-#1956 video-only command; the audio path must add a second input, the container's audio
+ * codec, explicit stream maps, and `-shortest`.
+ */
+class FfmpegEncoderArgsTest {
+
+  private val frames = File("/frames")
+  private val out = File("/out/clip.mp4")
+
+  @Test
+  fun `mp4 without audio is the video-only command`() {
+    val args =
+      FfmpegEncoder.buildArgs(
+        frames,
+        fps = 30,
+        FfmpegEncoder.RecordingFormatChoice.MP4,
+        out,
+        audioTrack = null,
+      )
+    assertEquals(
+      listOf(
+        "ffmpeg",
+        "-y",
+        "-framerate",
+        "30",
+        "-i",
+        File(frames, "frame-%05d.png").absolutePath,
+        "-c:v",
+        "libx264",
+        "-pix_fmt",
+        "yuv420p",
+        "-preset",
+        "veryfast",
+        "-movflags",
+        "+faststart",
+        out.absolutePath,
+      ),
+      args,
+    )
+    // No audio plumbing leaks into the silent path.
+    assertFalse(args.any { it == "-c:a" || it == "-map" || it == "-shortest" })
+  }
+
+  @Test
+  fun `mp4 with audio adds aac input, maps and shortest`() {
+    val audio = File("/tmp/talkback.wav")
+    val args =
+      FfmpegEncoder.buildArgs(
+        frames,
+        fps = 30,
+        FfmpegEncoder.RecordingFormatChoice.MP4,
+        out,
+        audioTrack = audio,
+      )
+    // Second input is the audio track.
+    val inputs = args.withIndex().filter { it.value == "-i" }.map { it.index }
+    assertEquals("expected two -i inputs (frames + audio)", 2, inputs.size)
+    assertEquals(audio.absolutePath, args[inputs[1] + 1])
+    // AAC for the MP4 container, explicit maps, shortest clamp.
+    assertTrue(containsSeq(args, listOf("-c:a", "aac")))
+    assertTrue(containsSeq(args, listOf("-map", "0:v:0")))
+    assertTrue(containsSeq(args, listOf("-map", "1:a:0")))
+    assertTrue(args.contains("-shortest"))
+    assertEquals("output stays last", out.absolutePath, args.last())
+  }
+
+  @Test
+  fun `webm with audio uses libopus`() {
+    val audio = File("/tmp/talkback.wav")
+    val webmOut = File("/out/clip.webm")
+    val args =
+      FfmpegEncoder.buildArgs(
+        frames,
+        fps = 24,
+        FfmpegEncoder.RecordingFormatChoice.WEBM,
+        webmOut,
+        audioTrack = audio,
+      )
+    assertTrue(containsSeq(args, listOf("-c:v", "libvpx-vp9")))
+    assertTrue(containsSeq(args, listOf("-c:a", "libopus")))
+    assertTrue(args.contains("-shortest"))
+  }
+
+  private fun containsSeq(haystack: List<String>, needle: List<String>): Boolean {
+    if (needle.isEmpty()) return true
+    for (i in 0..haystack.size - needle.size) {
+      if (haystack.subList(i, i + needle.size) == needle) return true
+    }
+    return false
+  }
+}

--- a/data/a11y/connector/src/main/kotlin/ee/schimke/composeai/daemon/AccessibilityRecordingScriptEvents.kt
+++ b/data/a11y/connector/src/main/kotlin/ee/schimke/composeai/daemon/AccessibilityRecordingScriptEvents.kt
@@ -21,12 +21,14 @@ import ee.schimke.composeai.data.render.extensions.RecordingScriptEventDescripto
  * daemon's `dataExtensions` when the a11y preview extension is enabled — same gate as the a11y
  * preview-extension publishers.
  *
- * **Single descriptor, mixed support.** All 19 a11y actions live in one
+ * **Single descriptor, mixed support.** All 22 a11y actions live in one
  * `DataExtensionDescriptor(id = "a11y", ...)`. Each event carries its own `supported` flag —
- * 12 wired ids ride on `SemanticsActions` constants and report `supported = true`; the remaining 7
+ * 13 wired ids ride on `SemanticsActions` constants and report `supported = true`; the remaining 9
  * (`clearFocus`, `accessibilityFocus`, `clearAccessibilityFocus`, `select`, `clearSelection`,
- * `nextAtGranularity`, `previousAtGranularity`) report `supported = false` because Compose
- * doesn't expose a clean `SemanticsActions` equivalent today. Agents calling `list_data_products`
+ * `nextAtGranularity`, `previousAtGranularity`, plus the TalkBack linear-navigation `next` /
+ * `previous` from issue #1956) report `supported = false` because Compose doesn't expose a clean
+ * `SemanticsActions` equivalent today (the traversal computation behind `next` / `previous` ships
+ * in `TalkBackTraversal`, but the host-side focus-state dispatch is still roadmap). Agents calling `list_data_products`
  * see one `a11y` extension with the full surface; the per-event flag is the source of truth for
  * "can `record_preview` accept this kind right now."
  */
@@ -53,9 +55,15 @@ object AccessibilityRecordingScriptEvents {
   const val ACTION_NEXT_AT_GRANULARITY: String = "a11y.action.nextAtGranularity"
   const val ACTION_PREVIOUS_AT_GRANULARITY: String = "a11y.action.previousAtGranularity"
 
+  // TalkBack linear-navigation verbs (issue #1956). `activate` is wired (the focused control's
+  // OnClick); `next` / `previous` advance focus through the merged-semantics traversal order.
+  const val ACTION_NEXT: String = "a11y.action.next"
+  const val ACTION_PREVIOUS: String = "a11y.action.previous"
+  const val ACTION_ACTIVATE: String = "a11y.action.activate"
+
   /**
-   * Single `a11y` data-extension descriptor advertising all 19 actions. Wired ids appear with
-   * `supported = true`; the remaining 7 carry `supported = false` so agents see the full
+   * Single `a11y` data-extension descriptor advertising all 22 actions. Wired ids appear with
+   * `supported = true`; the remaining 9 carry `supported = false` so agents see the full
    * accessibility action surface (planned + shipped) in one extension entry.
    *
    * Each `supported = true` entry corresponds to a `when` arm in
@@ -149,7 +157,30 @@ object AccessibilityRecordingScriptEvents {
             "Scroll right",
             "Scrolls the targeted scrollable right by one viewport-width via SemanticsActions.ScrollBy(+width, 0).",
           ),
+          supportedEvent(
+            ACTION_ACTIVATE,
+            "Activate",
+            "Activates the targeted accessibility node via SemanticsActions.OnClick — TalkBack's " +
+              "double-tap-to-activate verb. Pairs with next/previous for a scripted TalkBack walk " +
+              "(issue #1956).",
+          ),
           // --- Roadmap (supported = false) ---
+          unsupportedEvent(
+            ACTION_NEXT,
+            "Next (linear navigation)",
+            "Moves TalkBack focus to the next focus stop in traversal order (issue #1956). The " +
+              "deterministic traversal computation ships in TalkBackTraversal (data-a11y-core, " +
+              "unit-tested) and drives the live TalkBack focus overlay's auto-advance; the " +
+              "remaining work is the host-side focus-state dispatch over the live Compose " +
+              "semantics tree. Tracked as roadmap.",
+          ),
+          unsupportedEvent(
+            ACTION_PREVIOUS,
+            "Previous (linear navigation)",
+            "Counterpart to next — moves TalkBack focus to the previous focus stop in traversal " +
+              "order (issue #1956). Same TalkBackTraversal core; host-side focus-state dispatch is " +
+              "tracked as roadmap.",
+          ),
           unsupportedEvent(
             ACTION_CLEAR_FOCUS,
             "Clear focus",

--- a/data/a11y/connector/src/test/kotlin/ee/schimke/composeai/daemon/AccessibilityRecordingScriptEventsTest.kt
+++ b/data/a11y/connector/src/test/kotlin/ee/schimke/composeai/daemon/AccessibilityRecordingScriptEventsTest.kt
@@ -12,7 +12,7 @@ import org.junit.Test
 class AccessibilityRecordingScriptEventsTest {
 
   @Test
-  fun `descriptor advertises a11y as one extension with all 19 actions`() {
+  fun `descriptor advertises a11y as one extension with all 22 actions`() {
     val descriptor = AccessibilityRecordingScriptEvents.descriptor
     assertEquals("a11y", descriptor.id.value)
     val ids = descriptor.recordingScriptEvents.map { it.id }.toSet()
@@ -30,6 +30,7 @@ class AccessibilityRecordingScriptEventsTest {
         AccessibilityRecordingScriptEvents.ACTION_SCROLL_DOWN,
         AccessibilityRecordingScriptEvents.ACTION_SCROLL_LEFT,
         AccessibilityRecordingScriptEvents.ACTION_SCROLL_RIGHT,
+        AccessibilityRecordingScriptEvents.ACTION_ACTIVATE,
         AccessibilityRecordingScriptEvents.ACTION_CLEAR_FOCUS,
         AccessibilityRecordingScriptEvents.ACTION_ACCESSIBILITY_FOCUS,
         AccessibilityRecordingScriptEvents.ACTION_CLEAR_ACCESSIBILITY_FOCUS,
@@ -37,6 +38,8 @@ class AccessibilityRecordingScriptEventsTest {
         AccessibilityRecordingScriptEvents.ACTION_CLEAR_SELECTION,
         AccessibilityRecordingScriptEvents.ACTION_NEXT_AT_GRANULARITY,
         AccessibilityRecordingScriptEvents.ACTION_PREVIOUS_AT_GRANULARITY,
+        AccessibilityRecordingScriptEvents.ACTION_NEXT,
+        AccessibilityRecordingScriptEvents.ACTION_PREVIOUS,
       )
     assertEquals(expectedIds, ids)
   }
@@ -57,6 +60,7 @@ class AccessibilityRecordingScriptEventsTest {
         AccessibilityRecordingScriptEvents.ACTION_SCROLL_DOWN,
         AccessibilityRecordingScriptEvents.ACTION_SCROLL_LEFT,
         AccessibilityRecordingScriptEvents.ACTION_SCROLL_RIGHT,
+        AccessibilityRecordingScriptEvents.ACTION_ACTIVATE,
       )
     val actuallySupported =
       AccessibilityRecordingScriptEvents.descriptor.recordingScriptEvents
@@ -81,6 +85,8 @@ class AccessibilityRecordingScriptEventsTest {
         AccessibilityRecordingScriptEvents.ACTION_CLEAR_SELECTION,
         AccessibilityRecordingScriptEvents.ACTION_NEXT_AT_GRANULARITY,
         AccessibilityRecordingScriptEvents.ACTION_PREVIOUS_AT_GRANULARITY,
+        AccessibilityRecordingScriptEvents.ACTION_NEXT,
+        AccessibilityRecordingScriptEvents.ACTION_PREVIOUS,
       )
     val actuallyUnsupported =
       AccessibilityRecordingScriptEvents.descriptor.recordingScriptEvents

--- a/data/a11y/core/src/main/kotlin/ee/schimke/composeai/renderer/TalkBackAudioTrack.kt
+++ b/data/a11y/core/src/main/kotlin/ee/schimke/composeai/renderer/TalkBackAudioTrack.kt
@@ -1,0 +1,50 @@
+package ee.schimke.composeai.renderer
+
+/**
+ * One spoken cue in a TalkBack walk: the [text] TalkBack would speak on focus stop [stopIndex],
+ * scheduled to begin at [startMs] from the start of the recording.
+ */
+data class TalkBackSpokenCue(val stopIndex: Int, val startMs: Long, val text: String)
+
+/**
+ * Plans the timed spoken-announcement track for a TalkBack walk — issue #1956, Phase 4 (the
+ * "read out the text" exploration). It assigns each focus stop the utterance
+ * [TalkBackUtterance.compose] produces and the time the focus overlay lands on that stop, so a
+ * downstream step can synthesize one TTS clip per cue, lay them out on a silent timeline at
+ * [TalkBackSpokenCue.startMs], and mux the result into the MP4/WEBM via
+ * [ee.schimke.composeai.daemon.FfmpegEncoder]'s optional audio track.
+ *
+ * Crucially it dwells on the **same** [TalkBackOverlayFrames.DEFAULT_DWELL_MS] the silent overlay
+ * uses, so the spoken word and the green focus rectangle land on each control at the same instant —
+ * the caption you read and the audio you'd hear stay in lock-step by construction.
+ *
+ * Pure and dependency-free: it produces the *plan*. Turning a cue's [text] into PCM is a separate,
+ * environment-dependent concern (an on-device or CLI TTS engine), kept out of this module so the
+ * scheduling stays unit-testable and engine-agnostic.
+ */
+object TalkBackAudioTrack {
+
+  /**
+   * One cue per focus stop, in traversal order, each starting when the walk reaches it. Empty when
+   * there are no focus stops. Cues with an empty utterance are dropped — there's nothing to speak.
+   */
+  fun plan(
+    nodes: List<AccessibilityNode>,
+    dwellMs: Long = TalkBackOverlayFrames.DEFAULT_DWELL_MS,
+  ): List<TalkBackSpokenCue> {
+    val step = if (dwellMs > 0L) dwellMs else TalkBackOverlayFrames.DEFAULT_DWELL_MS
+    return TalkBackTraversal.focusStops(nodes).mapIndexedNotNull { i, node ->
+      val text = TalkBackUtterance.compose(node)
+      if (text.isEmpty()) null else TalkBackSpokenCue(stopIndex = i, startMs = i * step, text = text)
+    }
+  }
+
+  /** Total walk duration (one dwell window per focus stop). `0` when nothing is focusable. */
+  fun totalDurationMs(
+    nodes: List<AccessibilityNode>,
+    dwellMs: Long = TalkBackOverlayFrames.DEFAULT_DWELL_MS,
+  ): Long {
+    val step = if (dwellMs > 0L) dwellMs else TalkBackOverlayFrames.DEFAULT_DWELL_MS
+    return TalkBackTraversal.focusStops(nodes).size.toLong() * step
+  }
+}

--- a/data/a11y/core/src/main/kotlin/ee/schimke/composeai/renderer/TalkBackFocusOverlay.kt
+++ b/data/a11y/core/src/main/kotlin/ee/schimke/composeai/renderer/TalkBackFocusOverlay.kt
@@ -1,0 +1,208 @@
+package ee.schimke.composeai.renderer
+
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.RectF
+import android.graphics.Typeface
+import java.io.File
+import kotlin.math.max
+import kotlin.math.min
+
+/**
+ * Renders the TalkBack focus visualization for one frame — issue #1956, Phase 1.
+ *
+ * Where [AccessibilityOverlay] paints a *static* Paparazzi-style legend of every node, this draws
+ * what TalkBack *does*: a single green focus rectangle around the node TalkBack is currently stopped
+ * on, the spoken announcement for that node in a caption card (so a silent capture still conveys
+ * "what TalkBack says"), and faint traversal-order numbers on every focus stop so the path through
+ * the screen reads at a glance.
+ *
+ * It composites onto the source screenshot at its native size (no side panel) so the output frame is
+ * the same dimensions as the input — drop one of these per captured frame, advance [focusedStop] as
+ * the walk progresses ([TalkBackOverlayFrames] maps frame index → stop), and the APNG / MP4 / GIF
+ * encoder turns the sequence into an animated focus walk for free. The focus stops are the merged
+ * nodes ([TalkBackTraversal.focusStops]); the caption text is [TalkBackUtterance.compose] of the
+ * focused stop, so the rectangle, the number, and the words always agree.
+ *
+ * Android-only (uses `Bitmap` / `Canvas`), same as [AccessibilityOverlay]. A desktop Skia variant
+ * could mirror it the day live mode lands there.
+ */
+object TalkBackFocusOverlay {
+
+  /** TalkBack's focus rectangle is a thick green box; this matches its recognisable look. */
+  private val FOCUS_GREEN: Int = Color.rgb(0x00, 0xC8, 0x53)
+  private const val FOCUS_STROKE_PX: Float = 6f
+
+  /** Inset so the stroke sits just outside the node bounds rather than biting into the control. */
+  private const val FOCUS_INSET_PX: Float = 3f
+
+  /** Traversal-order badge sizing for the un-focused stops. */
+  private const val NUMBER_RADIUS_PX: Float = 18f
+  private const val NUMBER_TEXT_PX: Float = 22f
+
+  /** Caption card chrome. */
+  private const val CAPTION_MARGIN_PX: Float = 16f
+  private const val CAPTION_PADDING_PX: Float = 18f
+  private const val CAPTION_TEXT_PX: Float = 28f
+  private const val CAPTION_LINE_PX: Float = 36f
+  private const val CAPTION_CORNER_PX: Float = 16f
+  private val CAPTION_BG: Int = Color.argb(0xE6, 0x10, 0x10, 0x12)
+  private val CAPTION_TEXT: Int = Color.WHITE
+  private val CAPTION_ACCENT: Int = FOCUS_GREEN
+
+  /**
+   * Writes the focus-overlay frame for the stop at [focusedStop] (an index into the focus-stop
+   * sub-list of [nodes]) to [destPng]. No-op (returns `null`) when there are no focus stops or the
+   * source can't be decoded. Out-of-range [focusedStop] is clamped into range.
+   */
+  fun generate(
+    sourcePng: File,
+    nodes: List<AccessibilityNode>,
+    focusedStop: Int,
+    destPng: File,
+  ): File? {
+    val stops = TalkBackTraversal.focusStops(nodes)
+    if (stops.isEmpty()) return null
+    if (!sourcePng.exists()) {
+      System.err.println(
+        "[compose-a11y] talkback overlay skipped: source PNG missing at ${sourcePng.absolutePath}"
+      )
+      return null
+    }
+    return try {
+      val source = BitmapFactory.decodeFile(sourcePng.absolutePath) ?: return null
+      val composite = compose(source, stops, focusedStop.coerceIn(0, stops.size - 1))
+      destPng.parentFile?.mkdirs()
+      destPng.outputStream().use { composite.compress(Bitmap.CompressFormat.PNG, 100, it) }
+      source.recycle()
+      composite.recycle()
+      destPng
+    } catch (t: Throwable) {
+      System.err.println(
+        "[compose-a11y] talkback overlay failed for ${sourcePng.name}: " +
+          "${t.javaClass.simpleName}: ${t.message}"
+      )
+      t.printStackTrace(System.err)
+      null
+    }
+  }
+
+  /** In-memory variant for tests / live drawing — returns the composited bitmap. */
+  fun compose(
+    source: Bitmap,
+    stops: List<AccessibilityNode>,
+    focusedStop: Int,
+  ): Bitmap {
+    val out = source.copy(Bitmap.Config.ARGB_8888, /* isMutable = */ true)
+    val canvas = Canvas(out)
+    drawTraversalNumbers(canvas, stops, focusedStop)
+    drawFocusRect(canvas, stops[focusedStop])
+    drawCaption(canvas, out.width, out.height, TalkBackUtterance.compose(stops[focusedStop]))
+    return out
+  }
+
+  private fun drawFocusRect(canvas: Canvas, node: AccessibilityNode) {
+    val r = parseBounds(node.boundsInScreen) ?: return
+    val stroke =
+      Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        style = Paint.Style.STROKE
+        strokeWidth = FOCUS_STROKE_PX
+        color = FOCUS_GREEN
+      }
+    val o = FOCUS_INSET_PX + FOCUS_STROKE_PX / 2f
+    canvas.drawRect(r.left - o, r.top - o, r.right + o, r.bottom + o, stroke)
+  }
+
+  private fun drawTraversalNumbers(canvas: Canvas, stops: List<AccessibilityNode>, focusedStop: Int) {
+    val bg = Paint(Paint.ANTI_ALIAS_FLAG).apply { style = Paint.Style.FILL }
+    val text =
+      Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = Color.WHITE
+        textSize = NUMBER_TEXT_PX
+        textAlign = Paint.Align.CENTER
+        typeface = Typeface.create(Typeface.DEFAULT, Typeface.BOLD)
+      }
+    val fm = text.fontMetrics
+    stops.forEachIndexed { i, node ->
+      val r = parseBounds(node.boundsInScreen) ?: return@forEachIndexed
+      // Badge at the node's top-left corner, nudged inside the frame so edge nodes stay visible.
+      val cx = r.left.coerceAtLeast(NUMBER_RADIUS_PX)
+      val cy = r.top.coerceAtLeast(NUMBER_RADIUS_PX)
+      // The focused stop gets the bright green badge; the rest are translucent grey so the path is
+      // legible without competing with the focus rectangle.
+      bg.color = if (i == focusedStop) FOCUS_GREEN else Color.argb(0xB0, 0x33, 0x33, 0x38)
+      canvas.drawCircle(cx, cy, NUMBER_RADIUS_PX, bg)
+      canvas.drawText((i + 1).toString(), cx, cy - (fm.ascent + fm.descent) / 2f, text)
+    }
+  }
+
+  private fun drawCaption(canvas: Canvas, width: Int, height: Int, utterance: String) {
+    if (utterance.isEmpty()) return
+    val text =
+      Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = CAPTION_TEXT
+        textSize = CAPTION_TEXT_PX
+      }
+    val maxTextWidth = (width - 2 * CAPTION_MARGIN_PX - 2 * CAPTION_PADDING_PX).toInt()
+    val lines = wrap(utterance, text, maxTextWidth)
+    val cardHeight = 2 * CAPTION_PADDING_PX + lines.size * CAPTION_LINE_PX
+    val cardTop = height - CAPTION_MARGIN_PX - cardHeight
+    val cardRect =
+      RectF(
+        CAPTION_MARGIN_PX,
+        cardTop,
+        width - CAPTION_MARGIN_PX,
+        height - CAPTION_MARGIN_PX,
+      )
+    val bg = Paint(Paint.ANTI_ALIAS_FLAG).apply { style = Paint.Style.FILL; color = CAPTION_BG }
+    canvas.drawRoundRect(cardRect, CAPTION_CORNER_PX, CAPTION_CORNER_PX, bg)
+    // A green accent bar down the left edge ties the caption to the focus rectangle's colour.
+    val accent = Paint(Paint.ANTI_ALIAS_FLAG).apply { style = Paint.Style.FILL; color = CAPTION_ACCENT }
+    canvas.drawRoundRect(
+      RectF(cardRect.left, cardRect.top, cardRect.left + 6f, cardRect.bottom),
+      CAPTION_CORNER_PX,
+      CAPTION_CORNER_PX,
+      accent,
+    )
+    var baseline = cardTop + CAPTION_PADDING_PX + CAPTION_TEXT_PX
+    val textX = CAPTION_MARGIN_PX + CAPTION_PADDING_PX
+    for (line in lines) {
+      canvas.drawText(line, textX, baseline, text)
+      baseline += CAPTION_LINE_PX
+    }
+  }
+
+  private fun parseBounds(s: String?): RectF? {
+    if (s == null) return null
+    val parts = s.split(",").mapNotNull { it.trim().toFloatOrNull() }
+    if (parts.size != 4) return null
+    return RectF(
+      min(parts[0], parts[2]),
+      min(parts[1], parts[3]),
+      max(parts[0], parts[2]),
+      max(parts[1], parts[3]),
+    )
+  }
+
+  /** Greedy word-wrap fitting [text] into [maxWidth] px using [paint]'s metrics. */
+  private fun wrap(text: String, paint: Paint, maxWidth: Int): List<String> {
+    if (text.isEmpty()) return emptyList()
+    val words = text.split(' ')
+    val out = mutableListOf<String>()
+    var current = StringBuilder()
+    for (word in words) {
+      val candidate = if (current.isEmpty()) word else "$current $word"
+      if (paint.measureText(candidate) <= maxWidth) {
+        current = StringBuilder(candidate)
+      } else {
+        if (current.isNotEmpty()) out.add(current.toString())
+        current = StringBuilder(word)
+      }
+    }
+    if (current.isNotEmpty()) out.add(current.toString())
+    return out
+  }
+}

--- a/data/a11y/core/src/main/kotlin/ee/schimke/composeai/renderer/TalkBackOverlayFrames.kt
+++ b/data/a11y/core/src/main/kotlin/ee/schimke/composeai/renderer/TalkBackOverlayFrames.kt
@@ -1,0 +1,47 @@
+package ee.schimke.composeai.renderer
+
+/**
+ * Maps a recording's frame index to the TalkBack focus stop that should be highlighted on it —
+ * issue #1956, Phase 1. The focus walk dwells [DEFAULT_DWELL_MS] on each stop (long enough to read
+ * the caption), then advances to the next, holding on the final stop for the rest of the capture.
+ *
+ * Pure and deterministic so the silent recording path (drive [TalkBackFocusOverlay] per frame) and a
+ * future spoken-audio track (schedule one utterance per stop at the same times) stay in lock-step.
+ */
+object TalkBackOverlayFrames {
+
+  /** Default per-stop dwell. ~0.9s reads a short announcement comfortably at any fps. */
+  const val DEFAULT_DWELL_MS: Long = 900L
+
+  /**
+   * The focus-stop index to highlight on [frameIndex] (rendered at [fps]). Clamped to
+   * `0..stopCount-1`; once the walk reaches the last stop it holds there. Returns `-1` when there's
+   * nothing to focus ([stopCount] <= 0).
+   */
+  fun focusedStopForFrame(
+    frameIndex: Int,
+    fps: Int,
+    stopCount: Int,
+    dwellMs: Long = DEFAULT_DWELL_MS,
+  ): Int {
+    if (stopCount <= 0) return -1
+    if (fps <= 0 || dwellMs <= 0L) return 0
+    val tMs = frameIndex.toLong() * 1000L / fps.toLong()
+    val stop = (tMs / dwellMs).toInt()
+    return stop.coerceIn(0, stopCount - 1)
+  }
+
+  /**
+   * Total frames a full walk over [stopCount] stops needs at [fps] (one [dwellMs] window per stop,
+   * plus a final frame so the last stop is actually rendered). `0` when there's nothing to walk.
+   */
+  fun totalFrames(
+    fps: Int,
+    stopCount: Int,
+    dwellMs: Long = DEFAULT_DWELL_MS,
+  ): Int {
+    if (stopCount <= 0 || fps <= 0 || dwellMs <= 0L) return 0
+    val durationMs = stopCount.toLong() * dwellMs
+    return (durationMs * fps / 1000L).toInt() + 1
+  }
+}

--- a/data/a11y/core/src/main/kotlin/ee/schimke/composeai/renderer/TalkBackTraversal.kt
+++ b/data/a11y/core/src/main/kotlin/ee/schimke/composeai/renderer/TalkBackTraversal.kt
@@ -1,0 +1,78 @@
+package ee.schimke.composeai.renderer
+
+/**
+ * Computes TalkBack linear-navigation focus moves over an extracted accessibility hierarchy —
+ * issue #1956, Phase 3.
+ *
+ * TalkBack's swipe-right / swipe-left gestures walk **focus stops** in traversal order. A focus stop
+ * is a node that is its own screen-reader target — exactly the nodes the extractors mark
+ * [AccessibilityNode.merged] = `true` (a merged container is one stop; its unmerged descendant text
+ * runs are *not* separate stops). The node list the extractors produce is already in pre-order
+ * traversal ([AccessibilityChecker] walks ATF's `allViews`; the desktop extractor walks the
+ * semantics tree depth-first), so the focus-stop sequence is just `nodes.filter { it.merged }` in
+ * order.
+ *
+ * This object is the deterministic, pure core behind the `a11y.action.next` / `a11y.action.previous`
+ * / `a11y.action.activate` recording-script events and behind the live focus overlay's auto-advance:
+ * given the current focus (by [AccessibilityNode.ref]) it returns the next / previous stop. Keeping
+ * it pure means the same traversal math drives the scripted host dispatch and the overlay caption,
+ * so they never disagree about "which node is focused now".
+ *
+ * **Boundary + entry semantics** (matching how TalkBack behaves from a cold start):
+ * - [next] with no current focus enters at the **first** stop; [previous] with no current focus
+ *   enters at the **last** stop.
+ * - [next] past the last stop and [previous] before the first stop return `null` (no move) — TalkBack
+ *   announces "end of screen" rather than wrapping, and a non-wrapping linear walk is the
+ *   deterministic thing to script.
+ * - A `currentRef` that no longer resolves to a stop (the focused node was removed / re-keyed) is
+ *   treated as "no current focus", so navigation re-enters cleanly instead of dead-ending.
+ */
+object TalkBackTraversal {
+
+  /** The focus stops in TalkBack traversal order — the merged nodes, in extraction order. */
+  fun focusStops(nodes: List<AccessibilityNode>): List<AccessibilityNode> = nodes.filter { it.merged }
+
+  /** The first focus stop, or `null` when nothing is focusable. */
+  fun first(nodes: List<AccessibilityNode>): AccessibilityNode? = focusStops(nodes).firstOrNull()
+
+  /** The last focus stop, or `null` when nothing is focusable. */
+  fun last(nodes: List<AccessibilityNode>): AccessibilityNode? = focusStops(nodes).lastOrNull()
+
+  /**
+   * The stop currently focused, identified by its [AccessibilityNode.ref]. `null` when [currentRef]
+   * is null or no stop carries it.
+   */
+  fun current(nodes: List<AccessibilityNode>, currentRef: String?): AccessibilityNode? {
+    if (currentRef == null) return null
+    return focusStops(nodes).firstOrNull { it.ref == currentRef }
+  }
+
+  /**
+   * The next focus stop after the one identified by [currentRef]. Enters at the first stop when
+   * [currentRef] is null / unresolved; returns `null` when already at (or past) the last stop.
+   */
+  fun next(nodes: List<AccessibilityNode>, currentRef: String?): AccessibilityNode? {
+    val stops = focusStops(nodes)
+    if (stops.isEmpty()) return null
+    val idx = indexOfRef(stops, currentRef)
+    if (idx < 0) return stops.first()
+    return stops.getOrNull(idx + 1)
+  }
+
+  /**
+   * The previous focus stop before the one identified by [currentRef]. Enters at the last stop when
+   * [currentRef] is null / unresolved; returns `null` when already at (or before) the first stop.
+   */
+  fun previous(nodes: List<AccessibilityNode>, currentRef: String?): AccessibilityNode? {
+    val stops = focusStops(nodes)
+    if (stops.isEmpty()) return null
+    val idx = indexOfRef(stops, currentRef)
+    if (idx < 0) return stops.last()
+    return stops.getOrNull(idx - 1)
+  }
+
+  private fun indexOfRef(stops: List<AccessibilityNode>, ref: String?): Int {
+    if (ref == null) return -1
+    return stops.indexOfFirst { it.ref == ref }
+  }
+}

--- a/data/a11y/core/src/main/kotlin/ee/schimke/composeai/renderer/TalkBackUtterance.kt
+++ b/data/a11y/core/src/main/kotlin/ee/schimke/composeai/renderer/TalkBackUtterance.kt
@@ -1,0 +1,98 @@
+package ee.schimke.composeai.renderer
+
+/**
+ * Composes the single "what the user hears" announcement string for an [AccessibilityNode] —
+ * issue #1956, Phase 2.
+ *
+ * Until now the a11y data product surfaced `label` / `role` / `states` as *separate* fields and let
+ * each consumer (the overlay legend, the CLI table) lay them out however it liked. Nothing assembled
+ * the one continuous utterance a screen reader would actually speak. The TalkBack focus overlay
+ * ([the caption card] and the exploratory TTS track both need exactly that string, so it lives here
+ * as a single pure function the live overlay, the post-capture overlay, and any future spoken-audio
+ * track all share — one definition, no drift between the caption you see and the audio you'd hear.
+ *
+ * **Ordering** follows modern Android TalkBack's node announcement shape:
+ *
+ * ```
+ * <label>, <role>, <state…>, <usage hint…>
+ * ```
+ *
+ * e.g. `"Buy now, button, double-tap to activate"` or `"Remember me, checkbox, not checked,
+ * double-tap to toggle"`. Concretely:
+ *
+ * 1. **label** — the node's visible text / contentDescription, spoken first. (Emitted a11y nodes
+ *    always carry a non-blank label; a blank one is tolerated and simply dropped so the utterance
+ *    starts with the role.)
+ * 2. **role** — TalkBack speaks the control type after the name, lower-cased (`Button` → `button`,
+ *    `CheckBox` → `checkbox`). `null` roles (plain text nodes) contribute nothing — TalkBack doesn't
+ *    say "text view" for every label.
+ * 3. **state words** — `checked` / `not checked`, `disabled`, `edit box`, plus any verbatim
+ *    `stateDescription` the extractor captured (a slider's `"70%"`, an expandable's `"Expanded"`).
+ *    These map from the [AccessibilityNode.states] tokens the extractors emit
+ *    ([AccessibilityChecker] on Android, the desktop node extractor on CMP).
+ * 4. **usage hints** — the "how do I operate this" affix TalkBack appends from the node's actions:
+ *    `double-tap to activate` (clickable), `double-tap to toggle` (a clickable that's also
+ *    checkable), `double-tap and hold to long press` (long-clickable), and an explicit
+ *    `hint: <text>` (the node's accessibility hint). Hints are **suppressed when the node is
+ *    disabled** — TalkBack doesn't offer "double-tap to activate" on a control you can't operate.
+ *
+ * The function is intentionally pure and dependency-free (no Compose, no Android) so it unit-tests
+ * trivially and runs anywhere the [AccessibilityNode] model does.
+ */
+object TalkBackUtterance {
+
+  /**
+   * Builds the spoken/caption announcement for [node]. Returns an empty string only for a node with
+   * no label, role, or announceable state (which the extractors never emit, but callers may
+   * hand-build).
+   */
+  fun compose(node: AccessibilityNode): String {
+    val checkable = node.states.any { it == CHECKED || it == UNCHECKED }
+    val disabled = node.states.any { it == DISABLED }
+
+    val stateWords = mutableListOf<String>()
+    val hints = mutableListOf<String>()
+    var hintText: String? = null
+
+    for (state in node.states) {
+      when {
+        state == CHECKED -> stateWords += "checked"
+        state == UNCHECKED -> stateWords += "not checked"
+        state == DISABLED -> stateWords += "disabled"
+        state == EDITABLE -> stateWords += "edit box"
+        state == HEADING -> stateWords += "heading"
+        state == CLICKABLE ->
+          hints += if (checkable) "double-tap to toggle" else "double-tap to activate"
+        state == LONG_CLICKABLE -> hints += "double-tap and hold to long press"
+        state == SCROLLABLE -> hints += "swipe with two fingers to scroll"
+        state.startsWith(HINT_PREFIX) -> hintText = state.removePrefix(HINT_PREFIX).trim()
+        // Anything else is a verbatim getStateDescription() string (a slider's "70%", a
+        // collapsible's "Expanded") — TalkBack reads it as-is, so we do too.
+        else -> stateWords += state.trim()
+      }
+    }
+
+    val parts = mutableListOf<String>()
+    node.label.trim().takeIf { it.isNotEmpty() }?.let { parts += it }
+    // Heading is announced as a role even when ATF can't surface it as a state — let an explicit
+    // "Heading" role flow through the role slot too (lower-cased like any other role).
+    node.role?.trim()?.takeIf { it.isNotEmpty() }?.let { parts += it.lowercase() }
+    parts += stateWords
+    // Usage hints only make sense on an operable control.
+    if (!disabled) parts += hints
+    hintText?.takeIf { it.isNotEmpty() }?.let { parts += it }
+
+    return parts.joinToString(", ")
+  }
+
+  // State tokens as emitted by AccessibilityChecker.extractStates / the desktop node extractor.
+  private const val CHECKED = "checked"
+  private const val UNCHECKED = "unchecked"
+  private const val DISABLED = "disabled"
+  private const val CLICKABLE = "clickable"
+  private const val LONG_CLICKABLE = "long-clickable"
+  private const val SCROLLABLE = "scrollable"
+  private const val EDITABLE = "editable"
+  private const val HEADING = "heading"
+  private const val HINT_PREFIX = "hint: "
+}

--- a/data/a11y/core/src/test/kotlin/ee/schimke/composeai/renderer/TalkBackAudioTrackTest.kt
+++ b/data/a11y/core/src/test/kotlin/ee/schimke/composeai/renderer/TalkBackAudioTrackTest.kt
@@ -1,0 +1,59 @@
+package ee.schimke.composeai.renderer
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Coverage for the spoken-cue scheduling that backs the optional TTS track (issue #1956 Phase 4). */
+class TalkBackAudioTrackTest {
+
+  private val nodes =
+    listOf(
+      AccessibilityNode(label = "Settings", role = "Heading", merged = true, boundsInScreen = "0,0,10,10"),
+      AccessibilityNode(
+        label = "Buy now",
+        role = "Button",
+        states = listOf("clickable"),
+        merged = true,
+        boundsInScreen = "0,20,10,30",
+      ),
+      // Unmerged child — not a focus stop, never spoken.
+      AccessibilityNode(label = "inner", merged = false, boundsInScreen = "0,21,5,29"),
+    )
+
+  @Test
+  fun `one cue per focus stop in traversal order, spoken text matches the utterance`() {
+    val cues = TalkBackAudioTrack.plan(nodes, dwellMs = 900L)
+    assertEquals(2, cues.size)
+    assertEquals(TalkBackSpokenCue(0, 0L, "Settings, heading"), cues[0])
+    assertEquals(TalkBackSpokenCue(1, 900L, "Buy now, button, double-tap to activate"), cues[1])
+  }
+
+  @Test
+  fun `cue start times lock-step with the overlay dwell`() {
+    val dwell = 900L
+    val cues = TalkBackAudioTrack.plan(nodes, dwellMs = dwell)
+    // Each cue starts exactly when the silent overlay first focuses its stop.
+    cues.forEach { cue ->
+      val fps = 30
+      val firstFrameOnStop = ((cue.startMs * fps) / 1000L).toInt()
+      assertEquals(
+        "cue ${cue.stopIndex} must start as the overlay focuses that stop",
+        cue.stopIndex,
+        TalkBackOverlayFrames.focusedStopForFrame(firstFrameOnStop, fps, stopCount = 2, dwellMs = dwell),
+      )
+    }
+  }
+
+  @Test
+  fun `total duration is one dwell window per stop`() {
+    assertEquals(1800L, TalkBackAudioTrack.totalDurationMs(nodes, dwellMs = 900L))
+  }
+
+  @Test
+  fun `no focus stops yields no cues`() {
+    val onlyChild = listOf(AccessibilityNode(label = "x", merged = false, boundsInScreen = "0,0,1,1"))
+    assertTrue(TalkBackAudioTrack.plan(onlyChild).isEmpty())
+    assertEquals(0L, TalkBackAudioTrack.totalDurationMs(onlyChild))
+  }
+}

--- a/data/a11y/core/src/test/kotlin/ee/schimke/composeai/renderer/TalkBackFocusOverlayDemoRender.kt
+++ b/data/a11y/core/src/test/kotlin/ee/schimke/composeai/renderer/TalkBackFocusOverlayDemoRender.kt
@@ -1,0 +1,124 @@
+package ee.schimke.composeai.renderer
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.RectF
+import android.graphics.Typeface
+import java.io.File
+import org.junit.Assume.assumeNotNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * Not an assertion test — a deterministic generator for the PR's visual evidence (issue #1956).
+ * When `TALKBACK_DEMO_DIR` is set it paints a mock settings screen and writes the TalkBack focus
+ * overlay for each focus stop there, so the author can attach before/after frames. Skipped silently
+ * in normal CI (no env var) so it costs nothing.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+class TalkBackFocusOverlayDemoRender {
+
+  @Test
+  fun renderDemoFrames() {
+    val dir = System.getenv("TALKBACK_DEMO_DIR")
+    assumeNotNull(dir)
+    val outDir = File(dir).apply { mkdirs() }
+
+    val nodes = mockScreenNodes()
+    val screen = paintMockScreen()
+    val sourcePng = File(outDir, "00-source.png")
+    sourcePng.outputStream().use { screen.compress(Bitmap.CompressFormat.PNG, 100, it) }
+
+    val stops = TalkBackTraversal.focusStops(nodes)
+    stops.indices.forEach { i ->
+      TalkBackFocusOverlay.generate(
+        sourcePng = sourcePng,
+        nodes = nodes,
+        focusedStop = i,
+        destPng = File(outDir, "stop-${i + 1}-${slug(stops[i].label)}.png"),
+      )
+    }
+  }
+
+  private fun slug(s: String): String = s.lowercase().replace(Regex("[^a-z0-9]+"), "-").trim('-')
+
+  private fun mockScreenNodes(): List<AccessibilityNode> =
+    listOf(
+      AccessibilityNode(label = "Settings", role = "Heading", merged = true, boundsInScreen = "40,60,440,120"),
+      AccessibilityNode(
+        label = "Wi-Fi",
+        role = "Switch",
+        states = listOf("checked", "clickable"),
+        merged = true,
+        boundsInScreen = "40,160,440,240",
+      ),
+      AccessibilityNode(
+        label = "Notifications",
+        role = "Switch",
+        states = listOf("unchecked", "clickable"),
+        merged = true,
+        boundsInScreen = "40,260,440,340",
+      ),
+      AccessibilityNode(
+        label = "Brightness",
+        role = "SeekBar",
+        states = listOf("70%"),
+        merged = true,
+        boundsInScreen = "40,360,440,440",
+      ),
+      AccessibilityNode(
+        label = "Sign out",
+        role = "Button",
+        states = listOf("clickable"),
+        merged = true,
+        boundsInScreen = "40,500,440,580",
+      ),
+    )
+
+  private fun paintMockScreen(): Bitmap {
+    val w = 480
+    val h = 800
+    val bm = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888)
+    val c = Canvas(bm).apply { drawColor(Color.rgb(0xF5, 0xF5, 0xF7)) }
+    val title =
+      Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = Color.rgb(0x20, 0x20, 0x24)
+        textSize = 40f
+        typeface = Typeface.create(Typeface.DEFAULT, Typeface.BOLD)
+      }
+    c.drawText("Settings", 40f, 108f, title)
+    fun row(top: Float, label: String, trailing: String, trailingColor: Int) {
+      val card = Paint(Paint.ANTI_ALIAS_FLAG).apply { color = Color.WHITE }
+      c.drawRoundRect(RectF(40f, top, 440f, top + 80f), 16f, 16f, card)
+      val text =
+        Paint(Paint.ANTI_ALIAS_FLAG).apply {
+          color = Color.rgb(0x20, 0x20, 0x24)
+          textSize = 30f
+        }
+      c.drawText(label, 64f, top + 50f, text)
+      val tp = Paint(Paint.ANTI_ALIAS_FLAG).apply { color = trailingColor; textSize = 26f }
+      c.drawText(trailing, 320f, top + 50f, tp)
+    }
+    row(160f, "Wi-Fi", "On", Color.rgb(0x2E, 0x7D, 0x32))
+    row(260f, "Notifications", "Off", Color.rgb(0x9E, 0x9E, 0x9E))
+    row(360f, "Brightness", "70%", Color.rgb(0x55, 0x55, 0x55))
+    val btn = Paint(Paint.ANTI_ALIAS_FLAG).apply { color = Color.rgb(0x16, 0x6F, 0xE0) }
+    c.drawRoundRect(RectF(40f, 500f, 440f, 580f), 16f, 16f, btn)
+    val btnText =
+      Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = Color.WHITE
+        textSize = 30f
+        textAlign = Paint.Align.CENTER
+        typeface = Typeface.create(Typeface.DEFAULT, Typeface.BOLD)
+      }
+    c.drawText("Sign out", 240f, 548f, btnText)
+    return bm
+  }
+}

--- a/data/a11y/core/src/test/kotlin/ee/schimke/composeai/renderer/TalkBackFocusOverlayTest.kt
+++ b/data/a11y/core/src/test/kotlin/ee/schimke/composeai/renderer/TalkBackFocusOverlayTest.kt
@@ -1,0 +1,134 @@
+package ee.schimke.composeai.renderer
+
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.Color
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * Rasterised coverage for [TalkBackFocusOverlay] (issue #1956 Phase 1). Same Robolectric + native
+ * graphics setup as [AccessibilityOverlayMergedTest] so `Canvas.drawRect` / `drawRoundRect`
+ * actually paint. The overlay composites onto the source frame at native size, so we assert the
+ * green focus rectangle lands on the focused node's bounds, the caption card paints at the bottom,
+ * and the output stays the same dimensions as the input.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+class TalkBackFocusOverlayTest {
+
+  @get:Rule val tempDir = TemporaryFolder()
+
+  private val nodes =
+    listOf(
+      AccessibilityNode(
+        label = "Settings",
+        role = "Heading",
+        merged = true,
+        boundsInScreen = "40,40,360,90",
+      ),
+      AccessibilityNode(
+        label = "Buy now",
+        role = "Button",
+        states = listOf("clickable"),
+        merged = true,
+        boundsInScreen = "40,140,360,210",
+      ),
+      // An unmerged child — must NOT be treated as a focus stop.
+      AccessibilityNode(
+        label = "inner",
+        merged = false,
+        boundsInScreen = "50,150,200,200",
+      ),
+    )
+
+  @Test
+  fun `focus rectangle is green and lands on the focused node`() {
+    val source = blackSource(400, 400)
+    val out = TalkBackFocusOverlay.generate(source, nodes, focusedStop = 1, destPng = dest())
+    assertNotNull("overlay should be written", out)
+    val bm = BitmapFactory.decodeFile(out!!.absolutePath)
+    assertEquals("overlay keeps source dimensions", 400, bm.width)
+    assertEquals(400, bm.height)
+
+    // The focused node (stop 1) bounds are 40,140..360,210. The green stroke rings just outside;
+    // sample the top stroke row a few px above the bounds top.
+    val greenHitsFocused = countGreenAlong(bm, y = 140 - 6, xRange = 40..360)
+    assertTrue("focused node should be ringed in green: hits=$greenHitsFocused", greenHitsFocused > 50)
+
+    // Stop 0 (the heading) is NOT focused, so its bounds top should have no green focus stroke.
+    val greenHitsUnfocused = countGreenAlong(bm, y = 40 - 6, xRange = 40..360)
+    assertTrue(
+      "unfocused node must not be ringed in green: hits=$greenHitsUnfocused",
+      greenHitsUnfocused < 10,
+    )
+  }
+
+  @Test
+  fun `caption card paints at the bottom of the frame`() {
+    val source = blackSource(400, 400)
+    val bm =
+      BitmapFactory.decodeFile(
+        TalkBackFocusOverlay.generate(source, nodes, focusedStop = 1, destPng = dest())!!.absolutePath
+      )
+    // The caption card is a near-opaque dark panel over the black source; its green accent bar on
+    // the left edge is the easiest signal. Scan the left margin band in the bottom quarter.
+    var accentHits = 0
+    for (y in 300 until 400) {
+      for (x in 16..28) {
+        if (isGreen(bm.getPixel(x, y))) accentHits++
+      }
+    }
+    assertTrue("caption accent bar should paint near the bottom-left: hits=$accentHits", accentHits > 20)
+  }
+
+  @Test
+  fun `no focus stops yields no overlay`() {
+    val onlyUnmerged =
+      listOf(AccessibilityNode(label = "x", merged = false, boundsInScreen = "0,0,10,10"))
+    assertNull(TalkBackFocusOverlay.generate(blackSource(40, 40), onlyUnmerged, 0, dest()))
+  }
+
+  @Test
+  fun `out of range focused stop is clamped`() {
+    // focusedStop far past the end clamps to the last stop rather than throwing.
+    val out = TalkBackFocusOverlay.generate(blackSource(400, 400), nodes, focusedStop = 99, dest())
+    assertNotNull(out)
+  }
+
+  private fun dest(): File = File(tempDir.newFolder(), "tb-${System.nanoTime()}.png")
+
+  private fun blackSource(w: Int, h: Int): File {
+    val src = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888).apply { eraseColor(Color.BLACK) }
+    val f = tempDir.newFile()
+    f.outputStream().use { src.compress(Bitmap.CompressFormat.PNG, 100, it) }
+    return f
+  }
+
+  private fun isGreen(px: Int): Boolean =
+    Color.green(px) > 140 && Color.green(px) > Color.red(px) + 40 && Color.green(px) > Color.blue(px) + 40
+
+  private fun countGreenAlong(bm: Bitmap, y: Int, xRange: IntRange): Int {
+    var hits = 0
+    // Stroke AA spreads across a couple of rows; check the row and its neighbours.
+    for (yy in (y - 2)..(y + 2)) {
+      if (yy !in 0 until bm.height) continue
+      for (x in xRange) {
+        if (x !in 0 until bm.width) continue
+        if (isGreen(bm.getPixel(x, yy))) hits++
+      }
+    }
+    return hits
+  }
+}

--- a/data/a11y/core/src/test/kotlin/ee/schimke/composeai/renderer/TalkBackOverlayFramesTest.kt
+++ b/data/a11y/core/src/test/kotlin/ee/schimke/composeai/renderer/TalkBackOverlayFramesTest.kt
@@ -1,0 +1,44 @@
+package ee.schimke.composeai.renderer
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/** Coverage for the pure frame → focus-stop mapping that drives the TalkBack walk (issue #1956). */
+class TalkBackOverlayFramesTest {
+
+  @Test
+  fun dwellsOnEachStopThenAdvances() {
+    val fps = 30
+    val dwell = 900L
+    // First ~0.9s on stop 0, next on stop 1, etc.
+    assertEquals(0, TalkBackOverlayFrames.focusedStopForFrame(0, fps, stopCount = 3, dwellMs = dwell))
+    assertEquals(0, TalkBackOverlayFrames.focusedStopForFrame(26, fps, stopCount = 3, dwellMs = dwell))
+    // frame 27 → 900ms → stop 1
+    assertEquals(1, TalkBackOverlayFrames.focusedStopForFrame(27, fps, stopCount = 3, dwellMs = dwell))
+    assertEquals(2, TalkBackOverlayFrames.focusedStopForFrame(54, fps, stopCount = 3, dwellMs = dwell))
+  }
+
+  @Test
+  fun holdsOnLastStopPastEndOfWalk() {
+    // Way past the walk's end: clamp to the final stop, never out of range.
+    assertEquals(2, TalkBackOverlayFrames.focusedStopForFrame(10_000, 30, stopCount = 3))
+  }
+
+  @Test
+  fun noStopsYieldsNoFocus() {
+    assertEquals(-1, TalkBackOverlayFrames.focusedStopForFrame(0, 30, stopCount = 0))
+    assertEquals(0, TalkBackOverlayFrames.totalFrames(30, stopCount = 0))
+  }
+
+  @Test
+  fun totalFramesCoversEveryStopPlusFinalHold() {
+    // 3 stops × 900ms = 2700ms; at 30fps → 81 frames + 1 final = 82.
+    assertEquals(82, TalkBackOverlayFrames.totalFrames(30, stopCount = 3, dwellMs = 900L))
+  }
+
+  @Test
+  fun degenerateFpsOrDwellFallsBackToFirstStop() {
+    assertEquals(0, TalkBackOverlayFrames.focusedStopForFrame(5, fps = 0, stopCount = 3))
+    assertEquals(0, TalkBackOverlayFrames.focusedStopForFrame(5, fps = 30, stopCount = 3, dwellMs = 0L))
+  }
+}

--- a/data/a11y/core/src/test/kotlin/ee/schimke/composeai/renderer/TalkBackTraversalTest.kt
+++ b/data/a11y/core/src/test/kotlin/ee/schimke/composeai/renderer/TalkBackTraversalTest.kt
@@ -1,0 +1,94 @@
+package ee.schimke.composeai.renderer
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Coverage for [TalkBackTraversal] (issue #1956 Phase 3): focus-stop filtering, deterministic
+ * next/previous moves in traversal order, cold-start entry, and non-wrapping boundaries.
+ */
+class TalkBackTraversalTest {
+
+  private fun node(ref: String, merged: Boolean = true): AccessibilityNode =
+    AccessibilityNode(
+      label = ref,
+      ref = ref,
+      merged = merged,
+      boundsInScreen = "0,0,10,10",
+    )
+
+  // A header (stop), a clickable card (stop) with two merged-away text children (not stops),
+  // and a button (stop). Focus stops in order: header, card, button.
+  private val tree =
+    listOf(
+      node("a/role:Header[0]"),
+      node("a/role:ViewGroup[0]"),
+      node("a/role:TextView[0]", merged = false),
+      node("a/role:TextView[1]", merged = false),
+      node("a/role:Button[0]"),
+    )
+
+  @Test
+  fun focusStopsAreTheMergedNodesInOrder() {
+    assertEquals(
+      listOf("a/role:Header[0]", "a/role:ViewGroup[0]", "a/role:Button[0]"),
+      TalkBackTraversal.focusStops(tree).map { it.ref },
+    )
+  }
+
+  @Test
+  fun nextFromNoFocusEntersAtFirstStop() {
+    assertEquals("a/role:Header[0]", TalkBackTraversal.next(tree, null)?.ref)
+  }
+
+  @Test
+  fun previousFromNoFocusEntersAtLastStop() {
+    assertEquals("a/role:Button[0]", TalkBackTraversal.previous(tree, null)?.ref)
+  }
+
+  @Test
+  fun nextWalksForwardSkippingUnmergedChildren() {
+    assertEquals("a/role:ViewGroup[0]", TalkBackTraversal.next(tree, "a/role:Header[0]")?.ref)
+    assertEquals("a/role:Button[0]", TalkBackTraversal.next(tree, "a/role:ViewGroup[0]")?.ref)
+  }
+
+  @Test
+  fun previousWalksBackward() {
+    assertEquals("a/role:ViewGroup[0]", TalkBackTraversal.previous(tree, "a/role:Button[0]")?.ref)
+    assertEquals("a/role:Header[0]", TalkBackTraversal.previous(tree, "a/role:ViewGroup[0]")?.ref)
+  }
+
+  @Test
+  fun nextPastLastStopDoesNotWrap() {
+    assertNull(TalkBackTraversal.next(tree, "a/role:Button[0]"))
+  }
+
+  @Test
+  fun previousBeforeFirstStopDoesNotWrap() {
+    assertNull(TalkBackTraversal.previous(tree, "a/role:Header[0]"))
+  }
+
+  @Test
+  fun unresolvedRefReEntersAtBoundary() {
+    // The focused node was removed / re-keyed: navigation re-enters rather than dead-ending.
+    assertEquals("a/role:Header[0]", TalkBackTraversal.next(tree, "a/gone[9]")?.ref)
+    assertEquals("a/role:Button[0]", TalkBackTraversal.previous(tree, "a/gone[9]")?.ref)
+  }
+
+  @Test
+  fun currentResolvesFocusedStopAndIgnoresUnmergedRefs() {
+    assertEquals("a/role:ViewGroup[0]", TalkBackTraversal.current(tree, "a/role:ViewGroup[0]")?.ref)
+    // An unmerged child ref is not a focus stop, so it never resolves as "current".
+    assertNull(TalkBackTraversal.current(tree, "a/role:TextView[0]"))
+    assertNull(TalkBackTraversal.current(tree, null))
+  }
+
+  @Test
+  fun emptyAndStoplessTreesYieldNothing() {
+    assertNull(TalkBackTraversal.next(emptyList(), null))
+    val noStops = listOf(node("x", merged = false))
+    assertNull(TalkBackTraversal.first(noStops))
+    assertNull(TalkBackTraversal.next(noStops, null))
+  }
+}

--- a/data/a11y/core/src/test/kotlin/ee/schimke/composeai/renderer/TalkBackUtteranceTest.kt
+++ b/data/a11y/core/src/test/kotlin/ee/schimke/composeai/renderer/TalkBackUtteranceTest.kt
@@ -1,0 +1,125 @@
+package ee.schimke.composeai.renderer
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Acceptance coverage for [TalkBackUtterance] (issue #1956 Phase 2): button, checkbox
+ * checked/unchecked, disabled, heading, slider with `stateDescription`, plus the affix/ordering
+ * rules. Plain JUnit — the composer is pure.
+ */
+class TalkBackUtteranceTest {
+
+  private fun node(
+    label: String = "",
+    role: String? = null,
+    states: List<String> = emptyList(),
+  ): AccessibilityNode =
+    AccessibilityNode(label = label, role = role, states = states, boundsInScreen = "0,0,10,10")
+
+  @Test
+  fun button() {
+    assertEquals(
+      "Buy now, button, double-tap to activate",
+      TalkBackUtterance.compose(node(label = "Buy now", role = "Button", states = listOf("clickable"))),
+    )
+  }
+
+  @Test
+  fun checkboxChecked() {
+    // A clickable + checkable control activates via "double-tap to toggle", and its checked state
+    // is spoken as the word "checked".
+    assertEquals(
+      "Remember me, checkbox, checked, double-tap to toggle",
+      TalkBackUtterance.compose(
+        node(label = "Remember me", role = "CheckBox", states = listOf("checked", "clickable")),
+      ),
+    )
+  }
+
+  @Test
+  fun checkboxUnchecked() {
+    // TalkBack speaks the unchecked state as "not checked", not the raw "unchecked" token.
+    assertEquals(
+      "Remember me, checkbox, not checked, double-tap to toggle",
+      TalkBackUtterance.compose(
+        node(label = "Remember me", role = "CheckBox", states = listOf("unchecked", "clickable")),
+      ),
+    )
+  }
+
+  @Test
+  fun disabledSuppressesUsageHint() {
+    // A disabled control is announced as "disabled" and does NOT offer "double-tap to activate" —
+    // you can't operate it.
+    assertEquals(
+      "Submit, button, disabled",
+      TalkBackUtterance.compose(
+        node(label = "Submit", role = "Button", states = listOf("clickable", "disabled")),
+      ),
+    )
+  }
+
+  @Test
+  fun heading() {
+    assertEquals(
+      "Settings, heading",
+      TalkBackUtterance.compose(node(label = "Settings", role = "Heading")),
+    )
+  }
+
+  @Test
+  fun headingFromStateWhenRoleless() {
+    // If ATF can only surface heading as a state token, it still reads as "heading".
+    assertEquals(
+      "Settings, heading",
+      TalkBackUtterance.compose(node(label = "Settings", states = listOf("heading"))),
+    )
+  }
+
+  @Test
+  fun sliderWithStateDescription() {
+    // A slider's verbatim getStateDescription() ("70%") is read as-is after the role.
+    assertEquals(
+      "Volume, seekbar, 70%",
+      TalkBackUtterance.compose(node(label = "Volume", role = "SeekBar", states = listOf("70%"))),
+    )
+  }
+
+  @Test
+  fun rolelessLabelOnly() {
+    // A plain text node — no role, no states — is just its label. TalkBack doesn't say "text view".
+    assertEquals("Workouts this week", TalkBackUtterance.compose(node(label = "Workouts this week")))
+  }
+
+  @Test
+  fun longClickableAddsLongPressHint() {
+    assertEquals(
+      "Open, button, double-tap to activate, double-tap and hold to long press",
+      TalkBackUtterance.compose(
+        node(label = "Open", role = "Button", states = listOf("clickable", "long-clickable")),
+      ),
+    )
+  }
+
+  @Test
+  fun explicitHintTextIsAppendedLast() {
+    assertEquals(
+      "Email, edit box, double-tap to activate, Enter your work address",
+      TalkBackUtterance.compose(
+        node(
+          label = "Email",
+          states = listOf("editable", "clickable", "hint: Enter your work address"),
+        ),
+      ),
+    )
+  }
+
+  @Test
+  fun blankLabelStartsWithRole() {
+    assertEquals(
+      "image",
+      TalkBackUtterance.compose(node(label = "  ", role = "Image")),
+    )
+  }
+}


### PR DESCRIPTION
Implements issue #1956 — do for accessibility / TalkBack what the touch overlay did for gestures.

The work splits into pure, fully-tested cores (shared by the live overlay, the post-capture overlay, and the spoken track so they never drift) plus the wiring around them. Phases map to the issue:

## Phase 2 — Utterance composition
`TalkBackUtterance.compose(node)` assembles the single "what TalkBack speaks" string from an `AccessibilityNode`, following modern TalkBack ordering: `label, role, state…, usage-hint`. Maps the extractors' state tokens to spoken forms (`unchecked` → "not checked", verbatim `stateDescription` like a slider's "70%"), picks the right affix (`double-tap to activate` vs `toggle`), and suppresses hints on disabled controls. Pure/dependency-free; unit-tested against every acceptance case (button, checkbox checked/unchecked, disabled, heading, slider with stateDescription).

## Phase 1 — TalkBack focus overlay
`TalkBackFocusOverlay` composites the focus visualization onto a captured frame at native size: a thick green focus rectangle around the focused stop, faint traversal-order numbers on every stop, and a caption card with the composed announcement — so a silent capture still conveys what TalkBack says. `TalkBackOverlayFrames` maps frame index → focus stop (dwell-then-advance), so one overlay per captured frame yields an animated walk the APNG/MP4/GIF encoder turns into a recording. Rect, number, and words all derive from `TalkBackTraversal.focusStops`, so they always agree. `PreviewOverrides.talkBack` is the strictly opt-in, default-null entry point (mirrors `touchOverlay`). Rasterised coverage runs under Robolectric native graphics like the existing `AccessibilityOverlay`.

## Phase 3 — Scriptable TalkBack session
`TalkBackTraversal` computes deterministic next/previous focus-stop moves over the extracted, pre-order hierarchy (merged nodes are the stops), with cold-start entry and non-wrapping boundaries — unit-tested. `a11y.action.activate` is wired end-to-end (TalkBack's double-tap-to-activate → `OnClick` on the resolved node) through `A11Y_SEMANTIC_ACTIONS` + `RobolectricHost`, covered by the existing routing test. `a11y.action.next` / `a11y.action.previous` are advertised on the descriptor backed by `TalkBackTraversal`; they also drive the overlay's auto-advance, which demonstrates the deterministic walk visually.

## Phase 4 — Spoken audio (exploration)
`TalkBackAudioTrack.plan(nodes)` schedules one timed spoken cue per focus stop, dwelling on the **same** window the silent overlay uses so the spoken word and the green rectangle land on each control together. `FfmpegEncoder` gains an optional `audioTrack` input — muxes a second stream (AAC for MP4, Opus for WEBM) with explicit maps + `-shortest`; when null the command is byte-identical to today's video-only encoder. The arg builder is extracted and unit-tested so the muxing is verified without shelling out.

## Visual evidence
`TalkBackFocusOverlayDemoRender` (committed, env-gated so it's a CI no-op) regenerates the focus-walk frames on demand. Sample frames over a mock Settings screen:
- **Stop 2 — Wi-Fi (switch, checked):** green focus box on the Wi-Fi row, badges 1–5, caption "Wi-Fi, switch, checked, double-tap to toggle".
- **Stop 4 — Brightness (slider):** focus box on Brightness, caption "Brightness, seekbar, 70%" (verbatim stateDescription).

(Frames attached in the session; regenerate with `TALKBACK_DEMO_DIR=… ./gradlew :data-a11y-core:testDebugUnitTest --tests "*TalkBackFocusOverlayDemoRender"`.)

## Test plan
- `:data-a11y-core:testDebugUnitTest` — `TalkBackUtteranceTest`, `TalkBackTraversalTest`, `TalkBackFocusOverlayTest` (Robolectric native graphics), `TalkBackOverlayFramesTest`, `TalkBackAudioTrackTest`, plus the full existing suite — green.
- `:data-a11y-connector:testDebugUnitTest` — updated `AccessibilityRecordingScriptEventsTest` (22 actions, activate supported, next/previous roadmap) — green.
- `:daemon:android:testDebugUnitTest --tests "*a11ySemanticsActionsRouteThroughDispatch"` — activate routes through dispatch — green.
- `:daemon:core:test --tests "*FfmpegEncoderArgsTest"` — audio-mux args; silent path unchanged — green.

## Scope notes
The pure cores, the `activate` verb, the overlay renderer, and the ffmpeg audio-mux args are landed and tested here. Two integration seams are intentionally deferred (the issue framed Phase 4 as exploration): the per-frame recording-pipeline call that drives `TalkBackFocusOverlay` when `talkBack=true` across both daemon backends, and the host-side focus-state dispatch that makes `next`/`previous` first-class scriptable verbs (the deterministic computation they need already ships in `TalkBackTraversal`). The actual TTS engine (cue text → PCM) is left pluggable and environment-specific.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PjVRQ7fXGAA4zHVD7eoT3z)_