### PR TITLE
feat(recording): assert.visible / assert.notVisible script events that fail the recording

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
@@ -131,7 +131,9 @@ private fun printUsage() {
                        --script is a JSON array of RecordingScriptEvent (tap/drag/pinch/keys, the
                        same vocabulary MCP record_preview uses). The encoder is picked from the
                        --out extension unless --format is given. gif/apng are always available
-                       (pure-JVM); mp4/webm need ffmpeg on PATH.
+                       (pure-JVM); mp4/webm need ffmpeg on PATH. Scripts may include Maestro-style
+                       assert.visible / assert.notVisible events (with a target); a failed assertion
+                       still writes the recording but exits non-zero (code 2).
       a11y             Render previews with the a11y data extension on and
                        print ATF findings (thin wrapper over `--with-extension a11y`)
       diff-semantics   Diff two compose/semantics trees (base vs head) and report what

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/RecordPreviewCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/RecordPreviewCommand.kt
@@ -1,8 +1,11 @@
 package ee.schimke.composeai.cli
 
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.daemon.protocol.RecordingEncodeResult
 import ee.schimke.composeai.daemon.protocol.RecordingFormat
 import ee.schimke.composeai.daemon.protocol.RecordingScriptEvent
+import ee.schimke.composeai.daemon.protocol.RecordingScriptEventStatus
+import ee.schimke.composeai.daemon.protocol.RecordingScriptEvidence
 import ee.schimke.composeai.render.session.RenderSession
 import ee.schimke.composeai.render.session.RenderSessionConfig
 import ee.schimke.composeai.render.session.RenderSessionException
@@ -37,6 +40,15 @@ import okio.Path.Companion.toPath
  * emit through MCP `record_preview` (`input.pointerDown` / `pointerMove` / `pointerUp` / `click`,
  * `input.keyDown` / `keyUp`, `recording.probe`, …). Recordings tick on a virtual clock keyed to
  * `fps`, so the same script reproduces the same frames every run.
+ *
+ * **Assertions.** The script can also carry Maestro-style `assert.visible` / `assert.notVisible`
+ * events, each with a `target` (ref / testTag / role+text). They resolve against the live semantics
+ * tree at their `tMs`; if any assertion isn't met the command still writes the recording (the
+ * frames show why it failed) but exits non-zero (code 2), turning a recording into a check CI can
+ * gate on:
+ * ```json
+ * { "tMs": 1500, "kind": "assert.visible", "target": { "text": "Submit" } }
+ * ```
  */
 class RecordPreviewCommand(args: List<String>) : Command(args) {
 
@@ -139,7 +151,7 @@ class RecordPreviewCommand(args: List<String>) : Command(args) {
         fail("failed to open render session: ${e.message ?: e.javaClass.simpleName}")
       }
 
-    val encoded = session.use { live ->
+    val outcome = session.use { live ->
       val started =
         live.recordingStart(target.previewId, fps = fps, scale = scale, overrides = overrides)
       if (events.isNotEmpty()) {
@@ -152,19 +164,41 @@ class RecordPreviewCommand(args: List<String>) : Command(args) {
             "(${stopped.frameWidthPx}x${stopped.frameHeightPx}px)"
         )
       }
-      try {
-        live.recordingEncode(started.recordingId, format = format)
-      } catch (e: RenderSessionException) {
-        fail(encodeFailureMessage(format, e))
-      }
+      val encoded =
+        try {
+          live.recordingEncode(started.recordingId, format = format)
+        } catch (e: RenderSessionException) {
+          fail(encodeFailureMessage(format, e))
+        }
+      RecordingOutcome(scriptEvents = stopped.scriptEvents, encoded = encoded)
     }
 
-    val outFile = copyArtifact(encoded.videoPath, outPath)
+    val outFile = copyArtifact(outcome.encoded.videoPath, outPath)
     println(
       "Recorded ${target.previewId} → ${outFile.path} " +
-        "(${format.name.lowercase()}, ${encoded.sizeBytes} bytes)"
+        "(${format.name.lowercase()}, ${outcome.encoded.sizeBytes} bytes)"
     )
+
+    // Gate on assertions last, after the artifact is on disk — a failing recording is still worth
+    // keeping (the captured frames show *why* the assertion failed). A non-zero exit lets CI /
+    // agents
+    // treat a recording as a check, the way Maestro's `assertVisible` fails a flow.
+    val failures = outcome.scriptEvents.filter { it.status == RecordingScriptEventStatus.FAILED }
+    if (failures.isNotEmpty()) {
+      System.err.println(
+        "compose-preview record: ${failures.size} assertion(s) failed for ${target.previewId}:"
+      )
+      for (f in failures) {
+        System.err.println("  - [t=${f.tMs}ms] ${f.kind}: ${f.message ?: "assertion not met"}")
+      }
+      exitProcess(2)
+    }
   }
+
+  private data class RecordingOutcome(
+    val scriptEvents: List<RecordingScriptEvidence>,
+    val encoded: RecordingEncodeResult,
+  )
 
   private data class ResolvedModule(val projectDir: File, val previewId: String)
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/RecordPreviewCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/RecordPreviewCommand.kt
@@ -183,13 +183,30 @@ class RecordPreviewCommand(args: List<String>) : Command(args) {
     // keeping (the captured frames show *why* the assertion failed). A non-zero exit lets CI /
     // agents
     // treat a recording as a check, the way Maestro's `assertVisible` fails a flow.
-    val failures = outcome.scriptEvents.filter { it.status == RecordingScriptEventStatus.FAILED }
+    //
+    // Two failure shapes count: a FAILED assertion (the condition was evaluated and not met), and
+    // an
+    // `assert.*` event that came back anything other than APPLIED — most commonly UNSUPPORTED on a
+    // backend that doesn't advertise assertions (e.g. Android today). An assertion that never ran
+    // is
+    // NOT a pass; treating it as one would let a CI recording exit 0 while silently skipping the
+    // check it was written to enforce.
+    val failures =
+      outcome.scriptEvents.filter {
+        it.status == RecordingScriptEventStatus.FAILED ||
+          (it.kind.startsWith("assert.") && it.status != RecordingScriptEventStatus.APPLIED)
+      }
     if (failures.isNotEmpty()) {
       System.err.println(
         "compose-preview record: ${failures.size} assertion(s) failed for ${target.previewId}:"
       )
       for (f in failures) {
-        System.err.println("  - [t=${f.tMs}ms] ${f.kind}: ${f.message ?: "assertion not met"}")
+        val statusNote =
+          if (f.status == RecordingScriptEventStatus.UNSUPPORTED) " (unsupported by this backend)"
+          else ""
+        System.err.println(
+          "  - [t=${f.tMs}ms] ${f.kind}$statusNote: ${f.message ?: "assertion not met"}"
+        )
       }
       exitProcess(2)
     }

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RecordingScriptHandlerRegistry.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RecordingScriptHandlerRegistry.kt
@@ -150,3 +150,28 @@ fun unsupportedEvidence(
     unsupportedReason = unsupportedReason,
     targetUnresolvedReason = targetUnresolvedReason,
   )
+
+/**
+ * Build an [RecordingScriptEvidence] for an assertion event whose condition was **not** met (status
+ * [RecordingScriptEventStatus.FAILED]). The daemon understood and evaluated the event — this is a
+ * test-style failure, not a dispatch gap, so it's distinct from [unsupportedEvidence]. The required
+ * [message] states the unmet condition; optional [targetUnresolvedReason] carries the matched-count
+ * + candidate nodes so the agent can see what *was* present without re-rendering.
+ */
+fun failedEvidence(
+  event: RecordingScriptEvent,
+  message: String,
+  targetUnresolvedReason: ee.schimke.composeai.daemon.protocol.SemanticsTargetUnresolvedReason? =
+    null,
+): RecordingScriptEvidence =
+  RecordingScriptEvidence(
+    tMs = event.tMs,
+    kind = event.kind,
+    status = RecordingScriptEventStatus.FAILED,
+    label = event.label,
+    checkpointId = event.checkpointId,
+    lifecycleEvent = event.lifecycleEvent,
+    tags = event.tags,
+    message = message,
+    targetUnresolvedReason = targetUnresolvedReason,
+  )

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -1932,6 +1932,13 @@ data class RecordingInputParams(
 enum class RecordingScriptEventStatus {
   @SerialName("applied") APPLIED,
   @SerialName("unsupported") UNSUPPORTED,
+  /**
+   * The event ran but its assertion was not satisfied (e.g. `assert.visible` matched no node).
+   * Distinct from [UNSUPPORTED] — the daemon understood and evaluated the event; the UI just didn't
+   * meet the asserted condition. Tooling that gates on assertions (the `record` command's non-zero
+   * exit) keys off this status; a failed assertion is a test failure, not a dispatch gap.
+   */
+  @SerialName("failed") FAILED,
 }
 
 /** One scripted input/control event on the virtual timeline. */

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
@@ -172,6 +172,7 @@ open class DesktopHost(
     if (supportsRecording)
       listOf(
         RecordingScriptDataExtensions.recordingDescriptor,
+        RecordingScriptDataExtensions.assertionDescriptor,
         InputTouchRecordingScriptEvents.descriptor,
         InputKeyboardRecordingScriptEvents.supportedDescriptor,
       )

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSession.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSession.kt
@@ -311,6 +311,14 @@ class DesktopRecordingSession(
         put(InputKeyboardRecordingScriptEvents.KEY_DOWN_EVENT, keyHandler(KeyEventType.KeyDown))
         put(InputKeyboardRecordingScriptEvents.KEY_UP_EVENT, keyHandler(KeyEventType.KeyUp))
         put(
+          RecordingScriptDataExtensions.ASSERT_VISIBLE_EVENT,
+          assertVisibilityHandler(expectVisible = true),
+        )
+        put(
+          RecordingScriptDataExtensions.ASSERT_NOT_VISIBLE_EVENT,
+          assertVisibilityHandler(expectVisible = false),
+        )
+        put(
           RecordingScriptDataExtensions.PROBE_EVENT,
           RecordingScriptEventHandler { e, _ ->
             // Snapshot the live semantics at the probe (issue #1786) so the codegen path can diff
@@ -401,6 +409,65 @@ class DesktopRecordingSession(
         )
     }
   }
+
+  /**
+   * Maestro-style visibility assertion. Resolves the event's [RecordingScriptEvent.target] against
+   * the held scene's live semantics tree (the same resolver the tap path uses) and records
+   * [appliedEvidence] when the condition holds or [failedEvidence] (status `FAILED`) when it
+   * doesn't. A missing/empty `target` is itself a failed assertion — the script asked to check
+   * something it never named. The verdict logic lives in the pure [evaluateVisibilityAssertion] so
+   * it's testable without a scene; this handler only does the resolution + evidence wiring.
+   */
+  private fun assertVisibilityHandler(expectVisible: Boolean): RecordingScriptEventHandler =
+    RecordingScriptEventHandler { event, _ ->
+      val wireTarget =
+        event.target
+          ?: return@RecordingScriptEventHandler failedEvidence(
+            event,
+            "${event.kind} requires a 'target' (ref / testTag / role+text) to assert on",
+          )
+      val target =
+        wireTarget.toSemanticsTarget()
+          ?: return@RecordingScriptEventHandler failedEvidence(
+            event,
+            "${event.kind} target has no resolvable field; set ref, testTag, role, or text",
+          )
+      val root = state.scene.composeSemanticsRoot()
+      var matchCount = 0
+      var candidates: List<ComposeSemanticsNode> = emptyList()
+      if (root != null) {
+        when (val res = SemanticsTargets.resolve(root, target)) {
+          is TargetResolution.Resolved -> matchCount = 1
+          TargetResolution.NotFound -> {
+            matchCount = 0
+            candidates = SemanticsTargets.targetableNodes(root)
+          }
+          is TargetResolution.Ambiguous -> {
+            matchCount = res.candidates.size
+            candidates = res.candidates
+          }
+        }
+      }
+      when (
+        val verdict = evaluateVisibilityAssertion(expectVisible, matchCount, target.toString())
+      ) {
+        AssertionVerdict.Passed -> appliedEvidence(event, "${event.kind} satisfied")
+        is AssertionVerdict.Failed -> {
+          // Attach the candidate list when the target was expected but absent, so the agent sees
+          // what *is* on screen without re-rendering — same affordance the tap-miss path gives.
+          val reason =
+            if (expectVisible && root != null) {
+              semanticsTargetUnresolvedReason(
+                SemanticsTargetUnresolvedCode.NO_MATCH,
+                wireTarget,
+                matchCount = matchCount,
+                candidates = candidates,
+              )
+            } else null
+          failedEvidence(event, verdict.reason, targetUnresolvedReason = reason)
+        }
+      }
+    }
 
   private fun clickHandler(): RecordingScriptEventHandler =
     RecordingScriptEventHandler { event, ctx ->

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RecordingAssertions.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RecordingAssertions.kt
@@ -1,0 +1,39 @@
+package ee.schimke.composeai.daemon
+
+/**
+ * Pure decision logic for the Maestro-style `assert.visible` / `assert.notVisible` recording
+ * events. Kept free of any Compose / Skiko dependency so it's unit-testable without standing up a
+ * held scene: the [DesktopRecordingSession] handler resolves the event's target against the live
+ * semantics tree, reduces it to a [matchCount], and asks this function for the verdict.
+ *
+ * **Semantics (matching Maestro).** `assertVisible` passes when *at least one* node matches the
+ * target — multiple matches still count as "present". `assertNotVisible` passes only when *zero*
+ * nodes match. This is deliberately laxer than the tap-dispatch path (which treats an ambiguous
+ * match as unresolved): an existence check doesn't need a unique node, it needs a yes/no answer.
+ */
+internal sealed interface AssertionVerdict {
+  data object Passed : AssertionVerdict
+
+  data class Failed(val reason: String) : AssertionVerdict
+}
+
+/**
+ * Evaluate a visibility assertion. [expectVisible] = `true` for `assert.visible`, `false` for
+ * `assert.notVisible`. [matchCount] is how many semantics nodes the target resolved to (0, 1, or
+ * more). [targetLabel] is a human-readable rendering of the target for the failure message.
+ */
+internal fun evaluateVisibilityAssertion(
+  expectVisible: Boolean,
+  matchCount: Int,
+  targetLabel: String,
+): AssertionVerdict =
+  if (expectVisible) {
+    if (matchCount >= 1) AssertionVerdict.Passed
+    else AssertionVerdict.Failed("assert.visible: no node matched $targetLabel")
+  } else {
+    if (matchCount == 0) AssertionVerdict.Passed
+    else
+      AssertionVerdict.Failed(
+        "assert.notVisible: $matchCount node(s) matched $targetLabel but none were expected"
+      )
+  }

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSessionTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSessionTest.kt
@@ -863,6 +863,96 @@ class DesktopRecordingSessionTest {
     }
   }
 
+  /**
+   * Assertion events (`assert.visible` / `assert.notVisible`) resolve their semantic `target`
+   * against the held scene's live semantics tree and record APPLIED when the condition holds,
+   * FAILED when it doesn't. Reuses the `target-box`-tagged fixture: a tag that exists is visible
+   * (and not not-visible); a tag that doesn't is the inverse. A failed `assert.visible` also
+   * carries the candidate list so the agent sees what *is* on screen.
+   */
+  @Test
+  fun scripted_visibility_assertions_pass_and_fail_against_live_semantics() {
+    val outputDir = tempFolder.newFolder("assert-recording-renders")
+    val recordingsRoot = tempFolder.newFolder("assert-recordings-root")
+    savedRecordingsDir = System.getProperty(DesktopHost.RECORDINGS_DIR_PROP)
+    System.setProperty(DesktopHost.RECORDINGS_DIR_PROP, recordingsRoot.absolutePath)
+
+    val engine = RenderEngine(outputDir = outputDir)
+    val host =
+      DesktopHost(
+        engine = engine,
+        previewSpecResolver = { previewId ->
+          if (previewId == TAGGED_TARGET_PREVIEW_ID) {
+            RenderSpec(
+              className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+              functionName = "TaggedClickTargetSquare",
+              widthPx = 64,
+              heightPx = 64,
+              density = 1.0f,
+              outputBaseName = "assert-target-square-rec",
+            )
+          } else null
+        },
+      )
+    host.start()
+    try {
+      val session =
+        host.acquireRecordingSession(
+          previewId = TAGGED_TARGET_PREVIEW_ID,
+          recordingId = "test-rec-assert",
+          classLoader =
+            DesktopRecordingSessionTest::class.java.classLoader
+              ?: ClassLoader.getSystemClassLoader(),
+          fps = FPS,
+          scale = 1.0f,
+          overrides = null,
+        )
+      try {
+        fun assertEvent(tMs: Long, kind: String, tag: String) =
+          RecordingScriptEvent(
+            tMs = tMs,
+            kind = kind,
+            target = ee.schimke.composeai.daemon.protocol.SemanticsInputTarget(testTag = tag),
+          )
+        session.postScript(
+          listOf(
+            assertEvent(0L, "assert.visible", "target-box"), // present → APPLIED
+            assertEvent(0L, "assert.visible", "does-not-exist"), // absent → FAILED + candidates
+            assertEvent(0L, "assert.notVisible", "does-not-exist"), // absent → APPLIED
+            assertEvent(0L, "assert.notVisible", "target-box"), // present → FAILED
+          )
+        )
+        val result = session.stop()
+        val asserts = result.scriptEvents.filter { it.kind.startsWith("assert.") }
+        assertEquals("expected four assertion evidences", 4, asserts.size)
+
+        val visiblePresent = asserts[0]
+        assertEquals(RecordingScriptEventStatus.APPLIED, visiblePresent.status)
+
+        val visibleAbsent = asserts[1]
+        assertEquals(RecordingScriptEventStatus.FAILED, visibleAbsent.status)
+        assertNotNull(
+          "failed assert.visible should carry candidates",
+          visibleAbsent.targetUnresolvedReason,
+        )
+        assertTrue(
+          "candidates must list the target-box that exists; got ${visibleAbsent.targetUnresolvedReason?.candidates}",
+          visibleAbsent.targetUnresolvedReason!!.candidates.any { it.testTag == "target-box" },
+        )
+
+        val notVisibleAbsent = asserts[2]
+        assertEquals(RecordingScriptEventStatus.APPLIED, notVisibleAbsent.status)
+
+        val notVisiblePresent = asserts[3]
+        assertEquals(RecordingScriptEventStatus.FAILED, notVisiblePresent.status)
+      } finally {
+        session.close()
+      }
+    } finally {
+      host.shutdown()
+    }
+  }
+
   private fun readPng(file: File): java.awt.image.BufferedImage {
     assertTrue("rendered PNG must exist on disk: ${file.absolutePath}", file.exists())
     assertTrue("rendered PNG must be non-empty", file.length() > 0)

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/RecordingAssertionsTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/RecordingAssertionsTest.kt
@@ -1,0 +1,55 @@
+package ee.schimke.composeai.daemon
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for the pure [evaluateVisibilityAssertion] verdict logic — the part of the
+ * `assert.visible` / `assert.notVisible` recording handlers that doesn't need a held scene. The
+ * wired handler (target resolution against the live semantics tree) is covered by the integration
+ * test in `DesktopRecordingSessionTest`.
+ */
+class RecordingAssertionsTest {
+
+  @Test
+  fun assert_visible_passes_when_a_node_matches() {
+    assertEquals(
+      AssertionVerdict.Passed,
+      evaluateVisibilityAssertion(true, matchCount = 1, "tag=ok"),
+    )
+  }
+
+  @Test
+  fun assert_visible_passes_when_multiple_nodes_match() {
+    // Maestro semantics: an existence check is satisfied by ≥ 1 match, even if ambiguous.
+    assertEquals(
+      AssertionVerdict.Passed,
+      evaluateVisibilityAssertion(true, matchCount = 3, "tag=ok"),
+    )
+  }
+
+  @Test
+  fun assert_visible_fails_when_no_node_matches() {
+    val verdict = evaluateVisibilityAssertion(true, matchCount = 0, "text=Submit")
+    assertTrue(verdict is AssertionVerdict.Failed)
+    assertTrue((verdict as AssertionVerdict.Failed).reason.contains("text=Submit"))
+    assertTrue(verdict.reason.contains("assert.visible"))
+  }
+
+  @Test
+  fun assert_not_visible_passes_when_no_node_matches() {
+    assertEquals(
+      AssertionVerdict.Passed,
+      evaluateVisibilityAssertion(false, matchCount = 0, "text=Error"),
+    )
+  }
+
+  @Test
+  fun assert_not_visible_fails_when_a_node_matches() {
+    val verdict = evaluateVisibilityAssertion(false, matchCount = 1, "text=Error")
+    assertTrue(verdict is AssertionVerdict.Failed)
+    assertTrue((verdict as AssertionVerdict.Failed).reason.contains("assert.notVisible"))
+    assertTrue(verdict.reason.contains("text=Error"))
+  }
+}

--- a/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/extensions/DataExtensionPlan.kt
+++ b/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/extensions/DataExtensionPlan.kt
@@ -263,6 +263,15 @@ object RecordingScriptDataExtensions {
   const val PREVIEW_RELOAD_EVENT: String = "preview.reload"
 
   /**
+   * Assertion script events (Maestro-style `assertVisible` / `assertNotVisible`). Each resolves the
+   * event's `target` (ref / testTag / role+text) against the held scene's live semantics tree and
+   * records [ee.schimke.composeai.daemon.protocol.RecordingScriptEventStatus.FAILED] evidence when
+   * the condition isn't met — turning a recording into a check the `record` command can gate on.
+   */
+  const val ASSERT_VISIBLE_EVENT: String = "assert.visible"
+  const val ASSERT_NOT_VISIBLE_EVENT: String = "assert.notVisible"
+
+  /**
    * `recording.probe` descriptor with `supported = true`. Returned from each
    * `RenderHost.recordingScriptEventDescriptors()` that wires a real probe handler in its
    * recording-session registry (today: both desktop and android backends).
@@ -279,6 +288,34 @@ object RecordingScriptDataExtensions {
             summary = "Records a named point in the recording timeline.",
             supported = true,
           )
+        ),
+    )
+
+  /**
+   * `assert.*` descriptor. Advertised (`supported = true`) only by hosts that wire the assertion
+   * handlers in their recording-session registry — desktop today; Android is a follow-up (its
+   * semantics snapshot doesn't yet carry the refs the resolver needs). Hosts that don't wire them
+   * simply omit this descriptor, so the MCP layer rejects `assert.*` up front for those daemons.
+   */
+  val assertionDescriptor: DataExtensionDescriptor =
+    DataExtensionDescriptor(
+      id = DataExtensionId("assertion"),
+      displayName = "Recording assertions",
+      recordingScriptEvents =
+        listOf(
+          RecordingScriptEventDescriptor(
+            id = ASSERT_VISIBLE_EVENT,
+            displayName = "Assert visible",
+            summary =
+              "Fails the recording unless the target (ref/testTag/role+text) matches a node.",
+            supported = true,
+          ),
+          RecordingScriptEventDescriptor(
+            id = ASSERT_NOT_VISIBLE_EVENT,
+            displayName = "Assert not visible",
+            summary = "Fails the recording if the target matches any node.",
+            supported = true,
+          ),
         ),
     )
 

--- a/docs/daemon/RECORDING-ASSERTIONS.md
+++ b/docs/daemon/RECORDING-ASSERTIONS.md
@@ -1,0 +1,100 @@
+# Recording assertions
+
+The scripted-recording surface (`compose-preview record`, MCP `record_preview`) can now carry
+**assertions** that turn a recording into a check: a recording that scripts a tap and then asserts
+the resulting state either passes or fails, and the `record` command exits non-zero when an
+assertion isn't met. This is the Maestro / Espresso model — drive the UI, then assert — applied to
+held `@Preview` scenes instead of an emulator.
+
+## What shipped
+
+Two assertion script events, evaluated against the held scene's **live semantics tree** at the
+event's `tMs`:
+
+| Kind                | Passes when…                          | Fails when…                         |
+|---------------------|---------------------------------------|-------------------------------------|
+| `assert.visible`    | the `target` matches ≥ 1 node         | the target matches no node          |
+| `assert.notVisible` | the `target` matches no node          | the target matches ≥ 1 node         |
+
+The `target` is the existing `SemanticsInputTarget` (`ref` / `testTag` / `role`+`text`) — the same
+handle `input.click` and the rest of the recording vocabulary already resolve, so assertions and
+input share one resolver (`SemanticsTargets.resolve`). No new target shape, no new finder.
+
+A failed assertion produces `RecordingScriptEvidence` with the new
+`RecordingScriptEventStatus.FAILED` status (distinct from `UNSUPPORTED` — the daemon *did* evaluate
+the event, the UI just didn't meet the condition). A failed `assert.visible` also carries the
+candidate node list, so the agent sees what *is* on screen without re-rendering — the same
+affordance a missed `input.click` target gives.
+
+### In a script
+
+```json
+[
+  { "tMs": 0,    "kind": "input.click",     "target": { "testTag": "submit" } },
+  { "tMs": 300,  "kind": "assert.visible",  "target": { "text": "Thanks!" } },
+  { "tMs": 300,  "kind": "assert.notVisible","target": { "text": "Submit" } }
+]
+```
+
+```
+compose-preview record --preview MyForm --script form.json --out form.gif
+# writes form.gif, then exits 2 if either assertion failed (with the unmet condition printed)
+```
+
+The recording is **always written**, even on failure — the captured frames are the evidence for
+*why* the assertion failed. The non-zero exit (code `2`) is what lets CI or an agent treat a
+recording as a gating check.
+
+### Backend support
+
+Desktop today. The desktop host advertises the `assertion` data extension
+(`RecordingScriptDataExtensions.assertionDescriptor`) and wires the handlers in
+`DesktopRecordingSession`. Android is a follow-up: its probe-semantics snapshot doesn't yet carry
+the refs the resolver needs, so `RobolectricHost` omits the descriptor and the MCP layer rejects
+`assert.*` for Android daemons up front rather than silently no-op'ing.
+
+## What we borrowed (and what we deliberately didn't)
+
+Comparison with the emulator-driven UI-test tools this is modelled on:
+
+| Concept (source)                         | Status here | Notes |
+|------------------------------------------|-------------|-------|
+| Assert visible / not-visible (Maestro `assertVisible`, Espresso `matches(isDisplayed())`) | **Shipped** | Reuses the semantics-target resolver. |
+| Driving by stable handle, not coordinates (Maestro `id:`/text, Espresso `withTag`) | Already present | `SemanticsInputTarget` predates this PR; assertions reuse it. |
+| Deterministic virtual clock (vs. emulator wall-clock + idling resources) | Already present | Recordings tick on `frameIndex * 1e9 / fps`; no flakiness, no `IdlingResource` needed — the scene can't run ahead of the script. |
+| Same artifact for human review + machine gate (Maestro recordings, Robo crawl reports) | **Shipped** | One GIF/APNG/MP4 doubles as the visual record and, via assertions, the pass/fail signal. |
+| Assert exact text / value (Maestro `assertTrue`, Espresso `withText`) | Roadmap | `assert.textEquals` against the resolved node's `text`. Held off v1 to keep the wire shape additive. |
+| Crawl / auto-explore (Robo, Monkey) | Roadmap, narrow | A preview is a single held scene, not an app graph — "crawl" reduces to "fan a tap over every clickable semantics node and snapshot," which the probe machinery could drive. Useful as a smoke check, not a crawl. |
+
+### Other emulator-test techniques worth borrowing
+
+Things these tools apply on emulators that *could* map onto held preview scenes, with how they'd
+land (each is a separate follow-up, not in this PR):
+
+- **State / network / clock injection** — Maestro's `setLocation`, Espresso's `IdlingResource` and
+  test doubles. Previews already expose `PreviewOverrides` (locale, font scale, theme, ambient,
+  permissions, …); the same `DataExtension` seam could inject a fake clock or a canned network
+  response so an assertion checks a *loaded* state rather than a spinner. Fits the existing override
+  model cleanly.
+- **Retry / flake quarantine** — emulator suites re-run flaky tests. Here it's mostly moot: the
+  virtual clock makes a scripted recording deterministic frame-for-frame, so a flaky assertion is a
+  real bug, not a timing race. Worth a note in docs rather than a retry knob.
+- **Accessibility assertions** — Espresso/ATF fail a test on a11y violations. The daemon already
+  produces `a11y/atf` findings; an `assert.a11y` event (or a `--fail-on a11y` flag on `record`)
+  would let a scripted walk gate on them — pairs naturally with the TalkBack spec (#1955's sibling).
+- **Pixel / golden assertions** — Robo and screenshot tests diff against a baseline. The preview
+  pipeline already has the visual-diff bot + `baselines.json`; an `assert.pixels` event diffing the
+  current frame against a committed PNG would fold golden-image checks into the same script.
+
+## Code map
+
+- Status + evidence: `RecordingScriptEventStatus.FAILED`, `failedEvidence(...)`
+  (`daemon/core/.../RecordingScriptHandlerRegistry.kt`).
+- Event kinds + descriptor: `RecordingScriptDataExtensions.ASSERT_VISIBLE_EVENT` /
+  `ASSERT_NOT_VISIBLE_EVENT` / `assertionDescriptor`
+  (`data/render/core/.../DataExtensionPlan.kt`).
+- Verdict logic (pure, unit-tested): `evaluateVisibilityAssertion`
+  (`daemon/desktop/.../RecordingAssertions.kt`).
+- Handler wiring: `DesktopRecordingSession.assertVisibilityHandler`; advertised by
+  `DesktopHost.recordingScriptEventDescriptors`.
+- CLI gate: `RecordPreviewCommand` — scans returned evidence for `FAILED`, prints each, exits 2.

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
@@ -4062,6 +4062,7 @@ class DaemonMcpServer(
     when (this) {
       RecordingScriptEventStatus.APPLIED -> "applied"
       RecordingScriptEventStatus.UNSUPPORTED -> "unsupported"
+      RecordingScriptEventStatus.FAILED -> "failed"
     }
 
   /**


### PR DESCRIPTION
Follow-up to #1960. Asks: *what can we learn from Maestro / Robo, and can a recording assert things and fail if they're not met?*

Answer: yes. This borrows the **Maestro / Espresso "drive then assert"** model for held `@Preview` scenes. A recording script can now assert UI conditions, and `compose-preview record` exits non-zero (code `2`) when an assertion isn't met — so a recording becomes a gating check, not just an artifact.

## What shipped

Two assertion script events, resolved against the held scene's **live semantics tree** at the event's `tMs`:

| Kind | Passes when… | Fails when… |
|------|--------------|-------------|
| `assert.visible` | `target` matches ≥ 1 node | matches no node |
| `assert.notVisible` | `target` matches no node | matches ≥ 1 node |

```json
[
  { "tMs": 0,   "kind": "input.click",      "target": { "testTag": "submit" } },
  { "tMs": 300, "kind": "assert.visible",   "target": { "text": "Thanks!" } },
  { "tMs": 300, "kind": "assert.notVisible","target": { "text": "Submit" } }
]
```

- Reuses the existing `SemanticsInputTarget` (`ref` / `testTag` / `role`+`text`) and `SemanticsTargets.resolve` — the **same handle** `input.click` already resolves. No new target shape, no new finder.
- New `RecordingScriptEventStatus.FAILED` — distinct from `UNSUPPORTED`: the daemon *evaluated* the event, the UI just didn't meet the condition. Plus a `failedEvidence(...)` builder. A failed `assert.visible` carries the **candidate node list** so the agent sees what *is* on screen without re-rendering (same affordance a missed click target gives).
- Verdict logic extracted to a pure, unit-tested `evaluateVisibilityAssertion` (Maestro semantics: `assertVisible` passes on ≥ 1 match even if ambiguous; an existence check needs yes/no, not a unique node).
- Desktop host advertises the new `assertion` data extension and wires the handlers. **Android omits it** (its probe snapshot doesn't yet carry the refs the resolver needs), so the MCP layer rejects `assert.*` for Android daemons up front rather than silently no-op'ing — a clean follow-up.
- `compose-preview record` still **writes the recording on failure** (the frames are the evidence for *why* it failed), then scans the returned evidence and exits `2` if any assertion failed, printing each unmet condition.

## Answering the research questions

`docs/daemon/RECORDING-ASSERTIONS.md` documents the feature and includes a comparison table with Maestro / Espresso / Robo — what we borrowed (assert visible/not-visible, stable-handle targeting, one artifact as both human record and machine gate) and what we deliberately didn't (crawl/auto-explore doesn't fit a single held scene). It also lists **other emulator-test techniques worth borrowing** as scoped follow-ups:

- **State / clock / network injection** (Maestro `setLocation`, Espresso test doubles) — fits the existing `PreviewOverrides` / `DataExtension` seam; assert a *loaded* state rather than a spinner.
- **Accessibility gating** (Espresso/ATF) — the daemon already produces `a11y/atf`; an `assert.a11y` / `--fail-on a11y` would gate a scripted walk on it. Pairs with #1955's sibling TalkBack spec.
- **Golden-image asserts** (Robo / screenshot tests) — fold the existing visual-diff baselines into a script via `assert.pixels`.
- **Retry / flake quarantine** — mostly moot here: the virtual clock makes scripted recordings deterministic frame-for-frame, so a flaky assertion is a real bug.
- **`assert.textEquals`** — natural next assertion; held off v1 to keep the wire shape additive.

## Test plan

- [x] `:daemon:desktop:test --tests "*RecordingAssertionsTest"` — pure verdict logic (visible/not-visible × present/absent/ambiguous). Runs locally.
- [x] `:cli:compileKotlin :daemon:desktop:compileKotlin :mcp:compileKotlin` compile clean.
- [x] `ktfmtFormat` applied to all touched modules.
- [ ] `DesktopRecordingSessionTest.scripted_visibility_assertions_pass_and_fail_against_live_semantics` — integration case against the tagged fixture (APPLIED for a present tag, FAILED + candidates for an absent one, and the inverse for `assert.notVisible`). Runs in CI's desktop-renderer harness (needs skiko).

## Visual evidence

No rendered surface changes — this adds protocol/handler/CLI plumbing around the existing recording pipeline. The behaviour is a non-zero exit + `FAILED` evidence, verified by the tests above rather than a pixel diff.

---
_Generated by [Claude Code](https://claude.ai/code/session_015XGE7oXG27kAaotihUDCag)_