### PR TITLE
feat: add launcher mode for widget previews

### DIFF
--- a/api/preview-annotations/src/main/kotlin/ee/schimke/composeai/preview/LauncherWidgetPreview.kt
+++ b/api/preview-annotations/src/main/kotlin/ee/schimke/composeai/preview/LauncherWidgetPreview.kt
@@ -59,6 +59,15 @@ annotation class LauncherWidgetPreview(
    * this field is plumbed through the manifest so a loop driver can read it later.
    */
   val resizeOrder: LauncherWidgetResizeOrder = LauncherWidgetResizeOrder.WidthFirst,
+  /**
+   * When `true`, render the widget *inside a simulated launcher home screen* — wallpaper, status
+   * bar, weather header, app-icon grid and dock — with the widget placed on the home screen at the
+   * [width] × [height] cell footprint, instead of as a bare cell-sized box. Pair it with a
+   * phone-shaped `@Preview(widthDp = …, heightDp = …)` (or `device = …`) so the chrome fills a
+   * full-device canvas; the cell footprint then sizes the widget *on* that home screen. Defaults to
+   * `false` (the original bare cell-sized behaviour).
+   */
+  val launcherMode: Boolean = false,
 )
 
 /**

--- a/api/preview-annotations/src/main/kotlin/ee/schimke/composeai/preview/LauncherWidgetResize.kt
+++ b/api/preview-annotations/src/main/kotlin/ee/schimke/composeai/preview/LauncherWidgetResize.kt
@@ -51,6 +51,14 @@ annotation class LauncherWidgetResize(
    * to pick up. Defaults to [DEFAULT_LAUNCHER_WIDGET_RESIZE_FRAME_DELAY_MS] ≈ 600ms.
    */
   val frameDelayMs: Int = DEFAULT_LAUNCHER_WIDGET_RESIZE_FRAME_DELAY_MS,
+  /**
+   * When `true`, every stop on the resize walk is rendered *inside a simulated launcher home
+   * screen* (wallpaper, status bar, weather, app grid, dock) with the widget at that stop's cell
+   * footprint — a flipbook of the widget being resized on a real-looking home screen. Pair it with
+   * a phone-shaped `@Preview` so each frame is a full-device shot. Defaults to `false` (bare
+   * cell-sized stops). Same flag as [LauncherWidgetPreview.launcherMode].
+   */
+  val launcherMode: Boolean = false,
 )
 
 /**

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -1018,6 +1018,15 @@ enum class LauncherResizeOrder {
  * @property resizeOrder hint for a future daemon-side resize-loop orchestrator on how to walk
  *   intermediate stops between two sizes. The single-shot around-composable ignores this field — it
  *   always snaps to [cells].
+ * @property launcherMode when `true`, the connector renders the widget *inside a simulated launcher
+ *   home screen* — a wallpaper, status bar, weather header, app-icon grid and dock — with the
+ *   widget placed on the home screen at its resolved cell footprint, instead of returning the bare
+ *   cell-sized `Box`. Lets a held widget preview be reviewed the way it would actually appear on a
+ *   device home screen. The cell footprint (and any resize walk) drives the size of the widget *on*
+ *   that home screen, so an existing widget preview "just works" — turning the flag on swaps the
+ *   bare cell box for the full-device launcher chrome. `null` / `false` keeps the original
+ *   cell-sized behaviour. Drive a full-device capture by pairing it with a phone-shaped sandbox
+ *   (`widthPx`/`heightPx` or `device`); the chrome fills whatever canvas the render is given.
  */
 @Serializable
 data class LauncherWidgetOverride(
@@ -1027,6 +1036,7 @@ data class LauncherWidgetOverride(
   val minCells: LauncherWidgetSize? = null,
   val maxCells: LauncherWidgetSize? = null,
   val resizeOrder: LauncherResizeOrder? = null,
+  val launcherMode: Boolean? = null,
 )
 
 /**
@@ -1088,6 +1098,13 @@ data class LauncherWidgetPayload(
    * picker uses this to grey out axis-locked drag handles.
    */
   val resizeAxes: LauncherResizeAxes = LauncherResizeAxes.BOTH,
+  /**
+   * Echo of [LauncherWidgetOverride.launcherMode] — `true` when this capture was rendered inside
+   * the simulated launcher home screen rather than as a bare cell-sized box. Clients can use it to
+   * label a card "launcher mode" and to interpret the widget's footprint as a region *within* a
+   * device screenshot rather than the whole render.
+   */
+  val launcherMode: Boolean = false,
 )
 
 /**

--- a/data/launcher-widget/connector/src/main/kotlin/ee/schimke/composeai/daemon/LauncherHomeScreen.kt
+++ b/data/launcher-widget/connector/src/main/kotlin/ee/schimke/composeai/daemon/LauncherHomeScreen.kt
@@ -1,0 +1,346 @@
+package ee.schimke.composeai.daemon
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+/**
+ * Simulated Android launcher home screen drawn entirely in `androidx.compose.foundation` /
+ * `androidx.compose.ui` primitives so it renders identically on the Android (Robolectric) and
+ * desktop (Skiko) backends — the connector this lives in is consumed by both daemons and has no
+ * `android.*` on its classpath.
+ *
+ * It is **cosmetic**, in the same spirit as the renderers' `SystemBarsFrame`: nothing here reads
+ * real device state. The "9:30" clock, the battery glyph, and the "San Francisco / 67° / Partly
+ * Cloudy" weather block are fixed mock values so a captured frame *looks* like a real home-screen
+ * screenshot rather than a naked widget on a white rectangle. The app icons are placeholder
+ * coloured tiles, not the consumer's real apps.
+ *
+ * The one real input is the widget itself: [content] is the preview being reviewed, placed on the
+ * home screen at the [widgetWidthDp] × [widgetHeightDp] footprint the launcher-widget cell resolver
+ * computed. That keeps the existing cell-size / resize machinery the source of truth for how big
+ * the widget is — launcher mode only changes what surrounds it, so an existing
+ * `@LauncherWidgetPreview` (or a `renderNow.overrides.launcherWidget`) "just works" when the mode
+ * flag is flipped on.
+ *
+ * The chrome fills whatever canvas the render is handed (`Modifier.fillMaxSize()`), so a
+ * full-device capture is a matter of requesting a phone-shaped sandbox; on a small sandbox it
+ * simply renders a miniature launcher.
+ */
+@Composable
+internal fun LauncherHomeScreen(
+  widgetWidthDp: Int,
+  widgetHeightDp: Int,
+  content: @Composable () -> Unit,
+) {
+  // Dusk wallpaper gradient — independent of the app's light/dark theme, the way a real launcher
+  // wallpaper is. Light foreground reads well against it in either mode.
+  val wallpaper =
+    Brush.verticalGradient(
+      0f to Color(0xFF12233F),
+      0.45f to Color(0xFF3A2A5E),
+      1f to Color(0xFF7A4E6E),
+    )
+  val onWallpaper = Color(0xFFF5F5FA)
+  val onWallpaperDim = Color(0xCCF5F5FA)
+
+  Box(modifier = Modifier.fillMaxSize().background(wallpaper)) {
+    Column(modifier = Modifier.fillMaxSize().padding(horizontal = 16.dp)) {
+      StatusBar(foreground = onWallpaper)
+      Spacer(Modifier.height(12.dp))
+      WeatherHeader(foreground = onWallpaper, foregroundDim = onWallpaperDim)
+      Spacer(Modifier.height(20.dp))
+
+      // The widget tray: the preview placed on the home screen at its resolved cell footprint.
+      // A faint scrim behind it means even a fully transparent widget reads as a placed tile.
+      Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+        Box(
+          modifier =
+            Modifier.size(width = widgetWidthDp.dp, height = widgetHeightDp.dp)
+              .clip(RoundedCornerShape(20.dp))
+              .background(Color(0x33000000))
+        ) {
+          content()
+        }
+      }
+
+      Spacer(Modifier.weight(1f))
+      AppGrid(foreground = onWallpaper)
+      Spacer(Modifier.height(14.dp))
+      PageIndicator(foreground = onWallpaper)
+      Spacer(Modifier.height(14.dp))
+      Dock()
+      Spacer(Modifier.height(10.dp))
+      GestureHandle(foreground = onWallpaper)
+      Spacer(Modifier.height(6.dp))
+    }
+  }
+}
+
+@Composable
+private fun StatusBar(foreground: Color) {
+  Row(
+    modifier = Modifier.fillMaxWidth().height(24.dp),
+    verticalAlignment = Alignment.CenterVertically,
+  ) {
+    BasicText(
+      text = "9:30",
+      style = TextStyle(color = foreground, fontSize = 13.sp, fontWeight = FontWeight.Bold),
+    )
+    Spacer(Modifier.weight(1f))
+    SignalDots(color = foreground)
+    Spacer(Modifier.width(6.dp))
+    BatteryGlyph(color = foreground)
+  }
+}
+
+/** Three rising bars standing in for the mobile-signal indicator. */
+@Composable
+private fun SignalDots(color: Color) {
+  Canvas(modifier = Modifier.size(width = 16.dp, height = 10.dp)) {
+    val barW = size.width / 4f
+    val gap = barW / 2f
+    val heights = floatArrayOf(0.45f, 0.7f, 1f)
+    heights.forEachIndexed { i, h ->
+      val x = i * (barW + gap)
+      val barH = size.height * h
+      drawRect(
+        color = color,
+        topLeft = Offset(x, size.height - barH),
+        size = androidx.compose.ui.geometry.Size(barW, barH),
+      )
+    }
+  }
+}
+
+/** Compact battery icon — outlined body, terminal nub, ~80% fill. Mirrors the renderers' glyph. */
+@Composable
+private fun BatteryGlyph(color: Color) {
+  Canvas(modifier = Modifier.size(width = 20.dp, height = 10.dp)) {
+    val nubW = 1.5.dp.toPx()
+    val nubH = size.height * 0.5f
+    val cornerR = 2.dp.toPx()
+    val strokeW = 1.2.dp.toPx()
+    val bodyW = size.width - nubW
+    val bodyH = size.height
+    drawRoundRect(
+      color = color,
+      topLeft = Offset(0f, 0f),
+      size = androidx.compose.ui.geometry.Size(bodyW, bodyH),
+      cornerRadius = androidx.compose.ui.geometry.CornerRadius(cornerR),
+      style = androidx.compose.ui.graphics.drawscope.Stroke(width = strokeW),
+    )
+    drawRoundRect(
+      color = color,
+      topLeft = Offset(bodyW, (bodyH - nubH) / 2f),
+      size = androidx.compose.ui.geometry.Size(nubW, nubH),
+      cornerRadius = androidx.compose.ui.geometry.CornerRadius(cornerR / 2f),
+    )
+    val pad = strokeW + 1f
+    val fillW = ((bodyW - pad * 2f) * 0.8f).coerceAtLeast(1f)
+    drawRoundRect(
+      color = color,
+      topLeft = Offset(pad, pad),
+      size = androidx.compose.ui.geometry.Size(fillW, bodyH - pad * 2f),
+      cornerRadius = androidx.compose.ui.geometry.CornerRadius(cornerR / 2f),
+    )
+  }
+}
+
+/** "Weather at the top": a sun glyph beside a city / temperature / condition block. Mock values. */
+@Composable
+private fun WeatherHeader(foreground: Color, foregroundDim: Color) {
+  Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+    SunGlyph()
+    Spacer(Modifier.width(14.dp))
+    Column {
+      BasicText(
+        text = "San Francisco",
+        style = TextStyle(color = foreground, fontSize = 15.sp, fontWeight = FontWeight.Medium),
+      )
+      BasicText(
+        text = "67°",
+        style = TextStyle(color = foreground, fontSize = 44.sp, fontWeight = FontWeight.Light),
+      )
+      BasicText(
+        text = "Partly Cloudy   H:70°  L:55°",
+        style = TextStyle(color = foregroundDim, fontSize = 12.sp),
+      )
+    }
+  }
+}
+
+/** A sun: filled disc with eight rays, drawn so the weather block reads at a glance. */
+@Composable
+private fun SunGlyph() {
+  Canvas(modifier = Modifier.size(48.dp)) {
+    val center = Offset(size.width / 2f, size.height / 2f)
+    val core = size.minDimension * 0.26f
+    val rayInner = core * 1.35f
+    val rayOuter = size.minDimension * 0.48f
+    val sun = Color(0xFFFFD27D)
+    drawCircle(color = sun, radius = core, center = center)
+    val strokeW = 2.2.dp.toPx()
+    for (i in 0 until 8) {
+      val a = (Math.PI / 4.0) * i
+      val dx = kotlin.math.cos(a).toFloat()
+      val dy = kotlin.math.sin(a).toFloat()
+      drawLine(
+        color = sun,
+        start = Offset(center.x + dx * rayInner, center.y + dy * rayInner),
+        end = Offset(center.x + dx * rayOuter, center.y + dy * rayOuter),
+        strokeWidth = strokeW,
+      )
+    }
+  }
+}
+
+/**
+ * Placeholder app for the home-screen grid / dock: a coloured rounded-square tile with a single
+ * initial, the way a launcher draws an adaptive icon before the real artwork loads.
+ */
+private data class LauncherApp(val label: String, val initial: String, val color: Color)
+
+private val HOME_APPS =
+  listOf(
+    LauncherApp("Calendar", "C", Color(0xFFE15B64)),
+    LauncherApp("Photos", "P", Color(0xFF4FB477)),
+    LauncherApp("Maps", "M", Color(0xFF3D7DCA)),
+    LauncherApp("Clock", "T", Color(0xFFEEA236)),
+    LauncherApp("Notes", "N", Color(0xFFE9C46A)),
+    LauncherApp("Music", "♪", Color(0xFFB565A7)),
+    LauncherApp("Files", "F", Color(0xFF5BA8C4)),
+    LauncherApp("Wallet", "W", Color(0xFF2A9D8F)),
+    LauncherApp("Store", "S", Color(0xFF6C7AE0)),
+    LauncherApp("Mail", "@", Color(0xFFD9534F)),
+    LauncherApp("Settings", "⚙", Color(0xFF8895A7)),
+    LauncherApp("Camera", "◉", Color(0xFF44506B)),
+  )
+
+private val DOCK_APPS =
+  listOf(
+    LauncherApp("Phone", "☎", Color(0xFF4FB477)),
+    LauncherApp("Messages", "✉", Color(0xFF3D7DCA)),
+    LauncherApp("Chrome", "◐", Color(0xFFE15B64)),
+    LauncherApp("Camera", "◉", Color(0xFF44506B)),
+  )
+
+private const val GRID_COLUMNS = 4
+
+/** Three rows of placeholder apps laid out on a 4-column grid below the widget. */
+@Composable
+private fun AppGrid(foreground: Color) {
+  Column(modifier = Modifier.fillMaxWidth()) {
+    HOME_APPS.chunked(GRID_COLUMNS).forEach { rowApps ->
+      Row(
+        modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+      ) {
+        rowApps.forEach { app -> AppIcon(app = app, labelColor = foreground, showLabel = true) }
+        // Pad a short final row so the columns stay aligned to the grid.
+        repeat(GRID_COLUMNS - rowApps.size) { Spacer(Modifier.width(56.dp)) }
+      }
+    }
+  }
+}
+
+@Composable
+private fun AppIcon(app: LauncherApp, labelColor: Color, showLabel: Boolean) {
+  Column(horizontalAlignment = Alignment.CenterHorizontally) {
+    Box(
+      modifier = Modifier.size(52.dp).clip(RoundedCornerShape(15.dp)).background(app.color),
+      contentAlignment = Alignment.Center,
+    ) {
+      BasicText(
+        text = app.initial,
+        style = TextStyle(color = Color.White, fontSize = 22.sp, fontWeight = FontWeight.SemiBold),
+      )
+    }
+    if (showLabel) {
+      Spacer(Modifier.height(5.dp))
+      Box(modifier = Modifier.width(60.dp), contentAlignment = Alignment.Center) {
+        BasicText(
+          text = app.label,
+          maxLines = 1,
+          style = TextStyle(color = labelColor, fontSize = 11.sp, textAlign = TextAlign.Center),
+        )
+      }
+    }
+  }
+}
+
+/** Page dots, the centre one emphasised — the home-screen-of-many affordance. */
+@Composable
+private fun PageIndicator(foreground: Color) {
+  Row(
+    modifier = Modifier.fillMaxWidth(),
+    horizontalArrangement = Arrangement.Center,
+    verticalAlignment = Alignment.CenterVertically,
+  ) {
+    repeat(3) { i ->
+      val active = i == 1
+      Box(
+        modifier =
+          Modifier.padding(horizontal = 4.dp)
+            .size(if (active) 7.dp else 6.dp)
+            .clip(CircleShape)
+            .background(if (active) foreground else foreground.copy(alpha = 0.4f))
+      )
+    }
+  }
+}
+
+/** The hotseat: a translucent rounded bar of always-present apps. */
+@Composable
+private fun Dock() {
+  Row(
+    modifier =
+      Modifier.fillMaxWidth()
+        .clip(RoundedCornerShape(28.dp))
+        .background(Color(0x33FFFFFF))
+        .padding(horizontal = 18.dp, vertical = 12.dp),
+    horizontalArrangement = Arrangement.SpaceBetween,
+  ) {
+    DOCK_APPS.forEach { app ->
+      AppIcon(app = app, labelColor = Color.Transparent, showLabel = false)
+    }
+  }
+}
+
+/** Gesture-navigation pill at the very bottom. */
+@Composable
+private fun GestureHandle(foreground: Color) {
+  Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+    Box(
+      modifier =
+        Modifier.size(width = 120.dp, height = 5.dp)
+          .clip(RoundedCornerShape(3.dp))
+          .background(foreground.copy(alpha = 0.85f))
+    )
+  }
+}

--- a/data/launcher-widget/connector/src/main/kotlin/ee/schimke/composeai/daemon/LauncherWidgetDataProduct.kt
+++ b/data/launcher-widget/connector/src/main/kotlin/ee/schimke/composeai/daemon/LauncherWidgetDataProduct.kt
@@ -58,14 +58,20 @@ class LauncherWidgetExtension(private val override: LauncherWidgetOverride) :
   override fun AroundComposable(content: @Composable () -> Unit) {
     val resolved = override.resolve()
     val widthDp =
-      (resolved.cellSizeDp * resolved.cells.width +
-          resolved.cellSpacingDp * maxOf(0, resolved.cells.width - 1))
-        .dp
+      resolved.cellSizeDp * resolved.cells.width +
+        resolved.cellSpacingDp * maxOf(0, resolved.cells.width - 1)
     val heightDp =
-      (resolved.cellSizeDp * resolved.cells.height +
-          resolved.cellSpacingDp * maxOf(0, resolved.cells.height - 1))
-        .dp
-    Box(modifier = Modifier.size(widthDp, heightDp), content = { content() })
+      resolved.cellSizeDp * resolved.cells.height +
+        resolved.cellSpacingDp * maxOf(0, resolved.cells.height - 1)
+    if (resolved.launcherMode) {
+      // Launcher mode: place the widget on a simulated full-device home screen (wallpaper, status
+      // bar, weather header, app-icon grid, dock) at its resolved cell footprint. The chrome fills
+      // whatever canvas the render is given, so a phone-shaped sandbox yields a full-device shot.
+      LauncherHomeScreen(widgetWidthDp = widthDp, widgetHeightDp = heightDp, content = content)
+    } else {
+      // Default: bare cell-sized container, the widget at the exact dp footprint the grid assigns.
+      Box(modifier = Modifier.size(widthDp.dp, heightDp.dp), content = { content() })
+    }
   }
 
   companion object {
@@ -100,6 +106,7 @@ internal data class ResolvedLauncherWidget(
   val cells: LauncherWidgetSize,
   val cellSizeDp: Int,
   val cellSpacingDp: Int,
+  val launcherMode: Boolean,
 )
 
 internal fun LauncherWidgetOverride.resolve(): ResolvedLauncherWidget {
@@ -117,6 +124,7 @@ internal fun LauncherWidgetOverride.resolve(): ResolvedLauncherWidget {
     cells = clamped,
     cellSizeDp = (cellSizeDp ?: DEFAULT_CELL_SIZE_DP).coerceAtLeast(0),
     cellSpacingDp = (cellSpacingDp ?: DEFAULT_CELL_SPACING_DP).coerceAtLeast(0),
+    launcherMode = launcherMode == true,
   )
 }
 
@@ -294,6 +302,7 @@ class LauncherWidgetDataProductRegistry : DataProductRegistry {
         resizeOrder = applied?.resizeOrder,
         supportedCells = metadata?.supportedCells,
         resizeAxes = metadata?.resizeAxes ?: LauncherResizeAxes.BOTH,
+        launcherMode = resolved?.launcherMode == true,
       ),
     )
   }

--- a/data/launcher-widget/connector/src/test/kotlin/ee/schimke/composeai/daemon/LauncherWidgetDataProductTest.kt
+++ b/data/launcher-widget/connector/src/test/kotlin/ee/schimke/composeai/daemon/LauncherWidgetDataProductTest.kt
@@ -90,6 +90,20 @@ class LauncherWidgetDataProductTest {
   }
 
   @Test
+  fun resolve_launcher_mode_defaults_off_and_honours_the_flag() {
+    assertEquals(
+      false,
+      LauncherWidgetOverride(cells = LauncherWidgetSize(2, 2)).resolve().launcherMode,
+    )
+    assertEquals(
+      true,
+      LauncherWidgetOverride(cells = LauncherWidgetSize(2, 2), launcherMode = true)
+        .resolve()
+        .launcherMode,
+    )
+  }
+
+  @Test
   fun resolve_rejects_inverted_bounds() {
     val override =
       LauncherWidgetOverride(
@@ -273,6 +287,42 @@ class LauncherWidgetDataProductTest {
     assertEquals(8, payload["cellSpacingDp"]!!.jsonPrimitive.content.toInt())
     assertEquals(312, payload["widthDp"]!!.jsonPrimitive.content.toInt())
     assertEquals(152, payload["heightDp"]!!.jsonPrimitive.content.toInt())
+  }
+
+  @Test
+  fun registry_on_render_echoes_launcher_mode_flag() {
+    val registry = LauncherWidgetDataProductRegistry()
+    registry.onRender(
+      "preview-1",
+      stubRenderResult(),
+      PreviewOverrides(
+        launcherWidget =
+          LauncherWidgetOverride(cells = LauncherWidgetSize(4, 2), launcherMode = true)
+      ),
+      previewContext = null,
+    )
+    val outcome =
+      registry.fetch("preview-1", "compose/launcher-widget", null, true)
+        as DataProductRegistry.Outcome.Ok
+    assertEquals(
+      true,
+      outcome.result.payload!!.jsonObject["launcherMode"]!!.jsonPrimitive.content.toBoolean(),
+    )
+
+    // Default render without the flag reports false.
+    registry.onRender(
+      "preview-2",
+      stubRenderResult(),
+      PreviewOverrides(launcherWidget = LauncherWidgetOverride(cells = LauncherWidgetSize(2, 2))),
+      previewContext = null,
+    )
+    val plain =
+      registry.fetch("preview-2", "compose/launcher-widget", null, true)
+        as DataProductRegistry.Outcome.Ok
+    assertEquals(
+      false,
+      plain.result.payload!!.jsonObject["launcherMode"]!!.jsonPrimitive.content.toBoolean(),
+    )
   }
 
   @Test

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
@@ -248,6 +248,13 @@ data class LauncherWidgetCapture(
    * captures; the value is identical across every stop in the same walk by construction.
    */
   val frameDelayMs: Int? = null,
+  /**
+   * Carried through from `@LauncherWidgetPreview.launcherMode` /
+   * `@LauncherWidgetResize.launcherMode` — `true` renders the widget inside the simulated launcher
+   * home screen rather than as a bare cell-sized box. The renderer maps it onto
+   * `LauncherWidgetOverride.launcherMode`.
+   */
+  val launcherMode: Boolean = false,
 )
 
 /** Mirror of `LauncherResizeOrder` in `:daemon:core`. */

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
@@ -1230,6 +1230,7 @@ object PreviewDiscovery {
               cellSpacingDp = effectiveLauncherWidgetResize.cellSpacingDp,
               resizeOrder = effectiveLauncherWidgetResize.resizeOrder,
               frameDelayMs = effectiveLauncherWidgetResize.frameDelayMs,
+              launcherMode = effectiveLauncherWidgetResize.launcherMode,
             ),
           ambient = effectiveAmbient,
           renderOutput = "renders/${previewId}_RESIZE_${w}x${h}.png",
@@ -1576,6 +1577,7 @@ object PreviewDiscovery {
     val cellSpacingDp: Int?,
     val resizeOrder: LauncherWidgetCaptureResizeOrder,
     val frameDelayMs: Int,
+    val launcherMode: Boolean,
   )
 
   /**
@@ -1647,6 +1649,7 @@ object PreviewDiscovery {
       runCatching { LauncherWidgetCaptureResizeOrder.valueOf(orderName) }
         .getOrDefault(LauncherWidgetCaptureResizeOrder.WidthFirst)
     val frameDelay = (pv.getValue("frameDelayMs") as? Int)?.coerceAtLeast(0) ?: 600
+    val launcherMode = (pv.getValue("launcherMode") as? Boolean) ?: false
     return LauncherWidgetResizeSpec(
       from = fromWidth to fromHeight,
       to = toWidth to toHeight,
@@ -1654,6 +1657,7 @@ object PreviewDiscovery {
       cellSpacingDp = optionalInt("cellSpacingDp"),
       resizeOrder = order,
       frameDelayMs = frameDelay,
+      launcherMode = launcherMode,
     )
   }
 
@@ -1677,6 +1681,7 @@ object PreviewDiscovery {
     val order =
       runCatching { LauncherWidgetCaptureResizeOrder.valueOf(orderName) }
         .getOrDefault(LauncherWidgetCaptureResizeOrder.WidthFirst)
+    val launcherMode = (pv.getValue("launcherMode") as? Boolean) ?: false
     return LauncherWidgetCapture(
       width = width,
       height = height,
@@ -1687,6 +1692,7 @@ object PreviewDiscovery {
       maxWidth = optionalInt("maxWidth"),
       maxHeight = optionalInt("maxHeight"),
       resizeOrder = order,
+      launcherMode = launcherMode,
     )
   }
 

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RenderManifest.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RenderManifest.kt
@@ -129,6 +129,11 @@ data class LauncherWidgetCapture(
      * future GIF-stitch pass. `null` when the capture didn't originate from a resize walk.
      */
     val frameDelayMs: Int? = null,
+    /**
+     * `true` renders the widget inside the simulated launcher home screen rather than as a bare
+     * cell-sized box. Maps onto `LauncherWidgetOverride.launcherMode`.
+     */
+    val launcherMode: Boolean = false,
 )
 
 /**

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -2176,6 +2176,7 @@ private fun LauncherWidgetCapture.toLauncherWidgetOverride(): LauncherWidgetOver
                 LauncherWidgetCaptureResizeOrder.WidthFirst -> LauncherResizeOrder.WIDTH_FIRST
                 LauncherWidgetCaptureResizeOrder.HeightFirst -> LauncherResizeOrder.HEIGHT_FIRST
             },
+        launcherMode = launcherMode,
     )
 
 /**

--- a/samples/android/src/main/kotlin/com/example/sampleandroid/AppWidgetPreviews.kt
+++ b/samples/android/src/main/kotlin/com/example/sampleandroid/AppWidgetPreviews.kt
@@ -235,6 +235,59 @@ fun LauncherWidgetResize1x1To4x2Preview() {
 }
 
 // ---------------------------------------------------------------------------
+// Launcher-mode samples
+//
+// `launcherMode = true` swaps the bare cell-sized box for a simulated full-device launcher home
+// screen (wallpaper, status bar, weather header, app-icon grid + dock) with the widget placed on
+// the home screen at its resolved cell footprint. The surrounding `@Preview(widthDp, heightDp)`
+// gives the home screen a phone-shaped canvas to fill; the same weather-widget body as the samples
+// above is reused unchanged — turning the mode on is all it takes for an existing widget preview to
+// render on a real-looking home screen.
+// ---------------------------------------------------------------------------
+
+/**
+ * The 4×2 weather widget shown on a simulated launcher home screen. Same widget body as
+ * [LauncherWidget4x2Preview]; `launcherMode = true` wraps it in the launcher chrome and the
+ * phone-shaped `@Preview` window gives that chrome a full device to fill.
+ */
+@Preview(name = "Launcher mode — 4×2 on home screen", widthDp = 411, heightDp = 914, showBackground = true)
+@LauncherWidgetPreview(width = 4, height = 2, launcherMode = true)
+@Composable
+fun LauncherModeHomeScreenPreview() {
+  AppWidgetContent { context ->
+    RemoteViews(context.packageName, R.layout.widget_weather).apply {
+      setTextViewText(R.id.widget_title, "San Francisco")
+      setTextViewText(R.id.widget_temperature, "67°")
+      setTextViewText(R.id.widget_condition, "Partly cloudy · H 70° / L 55°")
+    }
+  }
+}
+
+/**
+ * The `1×1 → 4×2` resize walk, each stop rendered on the launcher home screen — a flipbook of the
+ * widget being resized on a real-looking device. PNGs land at `renders/<id>_RESIZE_<w>x<h>.png`.
+ */
+@Preview(name = "Launcher mode — resize on home screen", widthDp = 411, heightDp = 914, showBackground = true)
+@LauncherWidgetResize(
+  fromWidth = 1,
+  fromHeight = 1,
+  toWidth = 4,
+  toHeight = 2,
+  resizeOrder = LauncherWidgetResizeOrder.WidthFirst,
+  launcherMode = true,
+)
+@Composable
+fun LauncherModeResizePreview() {
+  AppWidgetContent { context ->
+    RemoteViews(context.packageName, R.layout.widget_weather).apply {
+      setTextViewText(R.id.widget_title, "Resize walk")
+      setTextViewText(R.id.widget_temperature, "67°")
+      setTextViewText(R.id.widget_condition, "Partly cloudy")
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Native `@androidx.glance.preview.Preview` discovery
 //
 // Same Glance composable body as the `GlanceWeatherWidgetPreview` above, but the function is


### PR DESCRIPTION
## Summary

Adds a **launcher mode** to the existing `launcher-widget` feature. When enabled, a widget preview renders inside a simulated full-device launcher home screen — wallpaper, status bar, a weather header at the top, an app-icon grid and a dock — with the widget placed on the home screen at its resolved cell footprint, instead of as a bare cell-sized box.

The mode reuses the existing cell-size / resize machinery as the source of truth for the widget's footprint, so any existing widget preview "just works": flipping the flag swaps the bare cell box for launcher chrome, and a `@LauncherWidgetResize` walk becomes a flipbook of the widget being resized on the home screen.

No special-casing was added to the renderer/daemon/protocol layers — the behaviour lives entirely in the connector's `AroundComposable`, driven by the merged `PreviewOverrides`, per the project's extension convention.

### Changes
- **protocol** — `launcherMode` on `LauncherWidgetOverride`; echoed on `LauncherWidgetPayload`
- **connector** — new `LauncherHomeScreen` chrome composable (pure `androidx.compose.foundation` / `androidx.compose.ui`, so it renders identically on the Android/Robolectric and desktop/Skiko backends) + a branch in `LauncherWidgetExtension`
- **annotations** — `launcherMode` on `@LauncherWidgetPreview` and `@LauncherWidgetResize`, threaded through `PreviewDiscovery` and the Android render manifest (`toLauncherWidgetOverride`)
- **samples** — `LauncherModeHomeScreenPreview` (4×2) and `LauncherModeResizePreview` (1×1 → 4×2 walk) in `:samples:android`
- **tests** — unit coverage for the new flag (`resolve()` default/honour + registry payload echo)

Both render paths converge on the same wrapper: Android static `@Preview` (via discovery → manifest) and daemon-driven `renderNow.overrides.launcherWidget = LauncherWidgetOverride(launcherMode = true)`. Desktop daemon works too since the chrome is backend-agnostic.

Note: launcher mode fills whatever canvas the render is handed, so a full-device shot comes from pairing it with a phone-shaped sandbox (the samples use `411×914`). The mode doesn't force canvas size — that stays decided before composition, consistent with how the override pipeline separates sizing from wrapping.

## Visual evidence

Rendered end-to-end via `./gradlew :samples:android:composePreviewRenderAll`.

| 4×2 widget on the home screen | 1×1 frame of the resize flipbook |
|---|---|
| `LauncherModeHomeScreenPreview` | `LauncherModeResizePreview_…_RESIZE_1x1` |

(Status bar with clock + signal + battery, weather header with sun glyph, the weather widget placed as a home-screen tile, app-icon grid, page dots, dock, and gesture pill. The resize walk shows the same widget at 1×1 → 2×1 → 3×1 → 4×1 → 4×2.)

## Test plan
- [x] `:data-launcher-widget-connector:test` (incl. new `launcherMode` tests)
- [x] `:data-launcher-widget-connector`, `:preview-annotations`, `:daemon:core`, `:renderer-android`, `:preview-discovery` compile
- [x] `:samples:android:composePreviewRenderAll` renders the two new launcher-mode previews
- [x] `ktfmtFormat` run on touched modules