### PR TITLE
feat(recording): assert.textEquals — assert a resolved node's text

### DIFF
--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSession.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSession.kt
@@ -318,6 +318,7 @@ class DesktopRecordingSession(
           RecordingScriptDataExtensions.ASSERT_NOT_VISIBLE_EVENT,
           assertVisibilityHandler(expectVisible = false),
         )
+        put(RecordingScriptDataExtensions.ASSERT_TEXT_EQUALS_EVENT, assertTextEqualsHandler())
         put(
           RecordingScriptDataExtensions.PROBE_EVENT,
           RecordingScriptEventHandler { e, _ ->
@@ -466,6 +467,75 @@ class DesktopRecordingSession(
             } else null
           failedEvidence(event, verdict.reason, targetUnresolvedReason = reason)
         }
+      }
+    }
+
+  /**
+   * `assert.textEquals` — resolve the event's [RecordingScriptEvent.target] to a single node and
+   * fail unless that node's text equals the expected string carried in the event's existing
+   * `inputText` field (reused rather than adding a new wire field). A missing target/expected, or a
+   * target that matches no node (or more than one, so "the text" is ambiguous), is a failed
+   * assertion. The string comparison itself lives in the pure [evaluateTextEqualsAssertion].
+   */
+  private fun assertTextEqualsHandler(): RecordingScriptEventHandler =
+    RecordingScriptEventHandler { event, _ ->
+      val expected =
+        event.inputText
+          ?: return@RecordingScriptEventHandler failedEvidence(
+            event,
+            "${event.kind} requires the expected text in the 'inputText' field",
+          )
+      val wireTarget =
+        event.target
+          ?: return@RecordingScriptEventHandler failedEvidence(
+            event,
+            "${event.kind} requires a 'target' (ref / testTag / role+text) to assert on",
+          )
+      val target =
+        wireTarget.toSemanticsTarget()
+          ?: return@RecordingScriptEventHandler failedEvidence(
+            event,
+            "${event.kind} target has no resolvable field; set ref, testTag, role, or text",
+          )
+      val root =
+        state.scene.composeSemanticsRoot()
+          ?: return@RecordingScriptEventHandler failedEvidence(
+            event,
+            "${event.kind}: nothing rendered yet, so $target resolved to no node",
+          )
+      when (val res = SemanticsTargets.resolve(root, target)) {
+        is TargetResolution.Resolved -> {
+          when (
+            val verdict = evaluateTextEqualsAssertion(expected, res.node.text, target.toString())
+          ) {
+            AssertionVerdict.Passed -> appliedEvidence(event, "${event.kind} satisfied")
+            is AssertionVerdict.Failed -> failedEvidence(event, verdict.reason)
+          }
+        }
+        TargetResolution.NotFound ->
+          failedEvidence(
+            event,
+            "${event.kind}: $target matched no node",
+            targetUnresolvedReason =
+              semanticsTargetUnresolvedReason(
+                SemanticsTargetUnresolvedCode.NO_MATCH,
+                wireTarget,
+                matchCount = 0,
+                candidates = SemanticsTargets.targetableNodes(root),
+              ),
+          )
+        is TargetResolution.Ambiguous ->
+          failedEvidence(
+            event,
+            "${event.kind}: $target matched ${res.candidates.size} nodes; narrow it to assert text",
+            targetUnresolvedReason =
+              semanticsTargetUnresolvedReason(
+                SemanticsTargetUnresolvedCode.AMBIGUOUS,
+                wireTarget,
+                matchCount = res.candidates.size,
+                candidates = res.candidates,
+              ),
+          )
       }
     }
 

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSession.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSession.kt
@@ -506,7 +506,8 @@ class DesktopRecordingSession(
       when (val res = SemanticsTargets.resolve(root, target)) {
         is TargetResolution.Resolved -> {
           when (
-            val verdict = evaluateTextEqualsAssertion(expected, res.node.text, target.toString())
+            val verdict =
+              evaluateTextEqualsAssertion(expected, resolvedNodeText(res.node), target.toString())
           ) {
             AssertionVerdict.Passed -> appliedEvidence(event, "${event.kind} satisfied")
             is AssertionVerdict.Failed -> failedEvidence(event, verdict.reason)

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RecordingAssertions.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RecordingAssertions.kt
@@ -1,5 +1,7 @@
 package ee.schimke.composeai.daemon
 
+import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsNode
+
 /**
  * Pure decision logic for the Maestro-style `assert.visible` / `assert.notVisible` /
  * `assert.textEquals` recording events. Kept free of any Compose / Skiko dependency so it's
@@ -57,3 +59,30 @@ internal fun evaluateTextEqualsAssertion(
       "assert.textEquals: $targetLabel text was ${actual?.let { "\"$it\"" } ?: "<none>"} " +
         "but expected \"$expected\""
     )
+
+/**
+ * The text to compare a resolved node against for `assert.textEquals`. Prefers the node's own
+ * `text`; when it has none, falls back to the **merged** text of its descendants.
+ *
+ * `composeSemanticsRoot()` builds the UNMERGED semantics tree, so a common shape like
+ * `Button(Modifier.testTag("submit")) { Text("Submit") }` resolves the tag-bearing container —
+ * whose own `text` is null — while the visible text sits on a descendant node. Compose's merged
+ * semantics concatenates that descendant text into the parent; mirror it here (depth-first,
+ * newline-joined, the same separator Compose uses) so the assertion sees what the user sees rather
+ * than `<none>`. Pure (operates on the [ComposeSemanticsNode] model, no scene) so it's
+ * unit-testable directly.
+ */
+internal fun resolvedNodeText(node: ComposeSemanticsNode): String? {
+  node.text
+    ?.takeIf { it.isNotEmpty() }
+    ?.let {
+      return it
+    }
+  val parts = mutableListOf<String>()
+  fun collect(n: ComposeSemanticsNode) {
+    n.text?.takeIf { it.isNotEmpty() }?.let { parts.add(it) }
+    n.children.forEach(::collect)
+  }
+  node.children.forEach(::collect)
+  return parts.joinToString("\n").ifEmpty { null }
+}

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RecordingAssertions.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RecordingAssertions.kt
@@ -1,10 +1,11 @@
 package ee.schimke.composeai.daemon
 
 /**
- * Pure decision logic for the Maestro-style `assert.visible` / `assert.notVisible` recording
- * events. Kept free of any Compose / Skiko dependency so it's unit-testable without standing up a
- * held scene: the [DesktopRecordingSession] handler resolves the event's target against the live
- * semantics tree, reduces it to a [matchCount], and asks this function for the verdict.
+ * Pure decision logic for the Maestro-style `assert.visible` / `assert.notVisible` /
+ * `assert.textEquals` recording events. Kept free of any Compose / Skiko dependency so it's
+ * unit-testable without standing up a held scene: the [DesktopRecordingSession] handler resolves
+ * the event's target against the live semantics tree, reduces it to a [matchCount] (or the resolved
+ * node's text), and asks these functions for the verdict.
  *
  * **Semantics (matching Maestro).** `assertVisible` passes when *at least one* node matches the
  * target — multiple matches still count as "present". `assertNotVisible` passes only when *zero*
@@ -37,3 +38,22 @@ internal fun evaluateVisibilityAssertion(
         "assert.notVisible: $matchCount node(s) matched $targetLabel but none were expected"
       )
   }
+
+/**
+ * Evaluate an `assert.textEquals` assertion against the **resolved** node's text. [expected] is the
+ * string the script asked for (the event's `inputText`); [actual] is the resolved node's `text`
+ * (`null` when the node carries no text). [targetLabel] renders the target for the failure message.
+ * The target-resolution failure (no match / ambiguous) is handled by the caller before this runs —
+ * this is purely the string comparison.
+ */
+internal fun evaluateTextEqualsAssertion(
+  expected: String,
+  actual: String?,
+  targetLabel: String,
+): AssertionVerdict =
+  if (actual == expected) AssertionVerdict.Passed
+  else
+    AssertionVerdict.Failed(
+      "assert.textEquals: $targetLabel text was ${actual?.let { "\"$it\"" } ?: "<none>"} " +
+        "but expected \"$expected\""
+    )

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSessionTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSessionTest.kt
@@ -953,6 +953,87 @@ class DesktopRecordingSessionTest {
     }
   }
 
+  /**
+   * `assert.textEquals` (issue #1965) resolves the target node and compares its text to the
+   * expected string carried in the event's `inputText` field. Reuses the `TaggedTextSquare` fixture
+   * whose `Text("Hello")` carries `testTag("greeting")`: an exact match is APPLIED; a wrong
+   * expected value or a missing tag is FAILED.
+   */
+  @Test
+  fun scripted_text_equals_assertion_passes_on_match_and_fails_on_mismatch() {
+    val outputDir = tempFolder.newFolder("text-assert-recording-renders")
+    val recordingsRoot = tempFolder.newFolder("text-assert-recordings-root")
+    savedRecordingsDir = System.getProperty(DesktopHost.RECORDINGS_DIR_PROP)
+    System.setProperty(DesktopHost.RECORDINGS_DIR_PROP, recordingsRoot.absolutePath)
+
+    val previewId = "tagged-text-square"
+    val engine = RenderEngine(outputDir = outputDir)
+    val host =
+      DesktopHost(
+        engine = engine,
+        previewSpecResolver = { id ->
+          if (id == previewId) {
+            RenderSpec(
+              className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+              functionName = "TaggedTextSquare",
+              widthPx = 64,
+              heightPx = 64,
+              density = 1.0f,
+              outputBaseName = "tagged-text-square-rec",
+            )
+          } else null
+        },
+      )
+    host.start()
+    try {
+      val session =
+        host.acquireRecordingSession(
+          previewId = previewId,
+          recordingId = "test-rec-text-assert",
+          classLoader =
+            DesktopRecordingSessionTest::class.java.classLoader
+              ?: ClassLoader.getSystemClassLoader(),
+          fps = FPS,
+          scale = 1.0f,
+          overrides = null,
+        )
+      try {
+        fun textAssert(tMs: Long, tag: String, expected: String) =
+          RecordingScriptEvent(
+            tMs = tMs,
+            kind = "assert.textEquals",
+            target = ee.schimke.composeai.daemon.protocol.SemanticsInputTarget(testTag = tag),
+            inputText = expected,
+          )
+        session.postScript(
+          listOf(
+            textAssert(0L, "greeting", "Hello"), // matches → APPLIED
+            textAssert(0L, "greeting", "Goodbye"), // wrong text → FAILED
+            textAssert(0L, "missing", "Hello"), // no such node → FAILED
+          )
+        )
+        val result = session.stop()
+        val asserts = result.scriptEvents.filter { it.kind == "assert.textEquals" }
+        assertEquals(3, asserts.size)
+        assertEquals(RecordingScriptEventStatus.APPLIED, asserts[0].status)
+        assertEquals(RecordingScriptEventStatus.FAILED, asserts[1].status)
+        assertTrue(
+          "mismatch evidence should report the actual text; got ${asserts[1].message}",
+          asserts[1].message?.contains("Hello") == true,
+        )
+        assertEquals(RecordingScriptEventStatus.FAILED, asserts[2].status)
+        assertNotNull(
+          "unresolved target should carry candidates",
+          asserts[2].targetUnresolvedReason,
+        )
+      } finally {
+        session.close()
+      }
+    } finally {
+      host.shutdown()
+    }
+  }
+
   private fun readPng(file: File): java.awt.image.BufferedImage {
     assertTrue("rendered PNG must exist on disk: ${file.absolutePath}", file.exists())
     assertTrue("rendered PNG must be non-empty", file.length() > 0)

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/RecordingAssertionsTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/RecordingAssertionsTest.kt
@@ -52,4 +52,29 @@ class RecordingAssertionsTest {
     assertTrue((verdict as AssertionVerdict.Failed).reason.contains("assert.notVisible"))
     assertTrue(verdict.reason.contains("text=Error"))
   }
+
+  @Test
+  fun assert_text_equals_passes_on_exact_match() {
+    assertEquals(
+      AssertionVerdict.Passed,
+      evaluateTextEqualsAssertion(expected = "Hello", actual = "Hello", "tag=greeting"),
+    )
+  }
+
+  @Test
+  fun assert_text_equals_fails_on_mismatch_and_reports_both() {
+    val verdict =
+      evaluateTextEqualsAssertion(expected = "Hello", actual = "Goodbye", "tag=greeting")
+    assertTrue(verdict is AssertionVerdict.Failed)
+    val reason = (verdict as AssertionVerdict.Failed).reason
+    assertTrue("reports actual", reason.contains("Goodbye"))
+    assertTrue("reports expected", reason.contains("Hello"))
+  }
+
+  @Test
+  fun assert_text_equals_fails_when_node_has_no_text() {
+    val verdict = evaluateTextEqualsAssertion(expected = "Hello", actual = null, "tag=greeting")
+    assertTrue(verdict is AssertionVerdict.Failed)
+    assertTrue((verdict as AssertionVerdict.Failed).reason.contains("<none>"))
+  }
 }

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/RecordingAssertionsTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/RecordingAssertionsTest.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.daemon
 
+import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsNode
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -77,4 +78,50 @@ class RecordingAssertionsTest {
     assertTrue(verdict is AssertionVerdict.Failed)
     assertTrue((verdict as AssertionVerdict.Failed).reason.contains("<none>"))
   }
+
+  @Test
+  fun resolved_node_text_uses_own_text_when_present() {
+    val node = node(testTag = "greeting", text = "Hello")
+    assertEquals("Hello", resolvedNodeText(node))
+  }
+
+  @Test
+  fun resolved_node_text_falls_back_to_descendant_text() {
+    // `Button(Modifier.testTag("submit")) { Text("Submit") }`: the tag-bearing container has no
+    // text
+    // of its own in the unmerged tree; the visible text lives on a child node.
+    val container = node(testTag = "submit", text = null, children = listOf(node(text = "Submit")))
+    assertEquals("Submit", resolvedNodeText(container))
+  }
+
+  @Test
+  fun resolved_node_text_joins_multiple_descendant_texts() {
+    val container =
+      node(
+        testTag = "row",
+        text = null,
+        children = listOf(node(text = "Hello"), node(text = "World")),
+      )
+    assertEquals("Hello\nWorld", resolvedNodeText(container))
+  }
+
+  @Test
+  fun resolved_node_text_is_null_when_nothing_has_text() {
+    assertEquals(null, resolvedNodeText(node(testTag = "empty", text = null)))
+  }
+
+  private var nodeCounter = 0
+
+  private fun node(
+    testTag: String? = null,
+    text: String? = null,
+    children: List<ComposeSemanticsNode> = emptyList(),
+  ): ComposeSemanticsNode =
+    ComposeSemanticsNode(
+      nodeId = "n${nodeCounter++}",
+      boundsInRoot = "",
+      testTag = testTag,
+      text = text,
+      children = children,
+    )
 }

--- a/daemon/desktop/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
+++ b/daemon/desktop/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
@@ -86,6 +86,18 @@ fun ThemedAttributionText() {
 }
 
 /**
+ * Fixture for `assert.textEquals` (issue #1965). The `Text` carries both a `testTag` and its text
+ * on the same semantics node, so a script can resolve it by `testTag("greeting")` and assert the
+ * resolved node's text equals `"Hello"`.
+ */
+@Composable
+fun TaggedTextSquare() {
+  Box(modifier = Modifier.fillMaxSize().background(Color(0xFFEF5350))) {
+    Text(text = "Hello", modifier = Modifier.testTag("greeting"))
+  }
+}
+
+/**
  * Fixture for the B-desktop.1.6 cancellation-invariant regression test. Sleeps for ~500ms inside
  * the composition body so the test can race a `host.shutdown(...)` call against an in-flight render
  * and assert the render still completes (per

--- a/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/extensions/DataExtensionPlan.kt
+++ b/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/extensions/DataExtensionPlan.kt
@@ -272,6 +272,13 @@ object RecordingScriptDataExtensions {
   const val ASSERT_NOT_VISIBLE_EVENT: String = "assert.notVisible"
 
   /**
+   * `assert.textEquals` — resolves the event's `target` and fails unless the resolved node's text
+   * equals the expected string carried in the event's existing `inputText` field (no new wire
+   * field). The Maestro `assertVisible: "text"` / Espresso `withText` equivalent.
+   */
+  const val ASSERT_TEXT_EQUALS_EVENT: String = "assert.textEquals"
+
+  /**
    * `recording.probe` descriptor with `supported = true`. Returned from each
    * `RenderHost.recordingScriptEventDescriptors()` that wires a real probe handler in its
    * recording-session registry (today: both desktop and android backends).
@@ -314,6 +321,14 @@ object RecordingScriptDataExtensions {
             id = ASSERT_NOT_VISIBLE_EVENT,
             displayName = "Assert not visible",
             summary = "Fails the recording if the target matches any node.",
+            supported = true,
+          ),
+          RecordingScriptEventDescriptor(
+            id = ASSERT_TEXT_EQUALS_EVENT,
+            displayName = "Assert text equals",
+            summary =
+              "Fails the recording unless the target node's text equals the expected " +
+                "string (carried in the event's inputText field).",
             supported = true,
           ),
         ),

--- a/docs/daemon/RECORDING-ASSERTIONS.md
+++ b/docs/daemon/RECORDING-ASSERTIONS.md
@@ -21,7 +21,10 @@ The `target` is the existing `SemanticsInputTarget` (`ref` / `testTag` / `role`+
 handle `input.click` and the rest of the recording vocabulary already resolve, so assertions and
 input share one resolver (`SemanticsTargets.resolve`). No new target shape, no new finder.
 `assert.textEquals` carries its expected string in the **existing `inputText` field** (reused from
-`uia.inputText`), so it adds no new wire field either.
+`uia.inputText`), so it adds no new wire field either. It compares against the resolved node's own
+text, or — for a tag-on-the-container shape like `Button(Modifier.testTag("submit")) { Text("Submit") }`
+— the **merged text of its descendants**, mirroring Compose's merged semantics so the check sees what
+the user sees.
 
 A failed assertion produces `RecordingScriptEvidence` with the new
 `RecordingScriptEventStatus.FAILED` status (distinct from `UNSUPPORTED` — the daemon *did* evaluate

--- a/docs/daemon/RECORDING-ASSERTIONS.md
+++ b/docs/daemon/RECORDING-ASSERTIONS.md
@@ -15,10 +15,13 @@ event's `tMs`:
 |---------------------|---------------------------------------|-------------------------------------|
 | `assert.visible`    | the `target` matches ≥ 1 node         | the target matches no node          |
 | `assert.notVisible` | the `target` matches no node          | the target matches ≥ 1 node         |
+| `assert.textEquals` | the `target` resolves and its text == the expected string | the text differs, or the target matches 0 / >1 nodes |
 
 The `target` is the existing `SemanticsInputTarget` (`ref` / `testTag` / `role`+`text`) — the same
 handle `input.click` and the rest of the recording vocabulary already resolve, so assertions and
 input share one resolver (`SemanticsTargets.resolve`). No new target shape, no new finder.
+`assert.textEquals` carries its expected string in the **existing `inputText` field** (reused from
+`uia.inputText`), so it adds no new wire field either.
 
 A failed assertion produces `RecordingScriptEvidence` with the new
 `RecordingScriptEventStatus.FAILED` status (distinct from `UNSUPPORTED` — the daemon *did* evaluate
@@ -63,7 +66,7 @@ Comparison with the emulator-driven UI-test tools this is modelled on:
 | Driving by stable handle, not coordinates (Maestro `id:`/text, Espresso `withTag`) | Already present | `SemanticsInputTarget` predates this PR; assertions reuse it. |
 | Deterministic virtual clock (vs. emulator wall-clock + idling resources) | Already present | Recordings tick on `frameIndex * 1e9 / fps`; no flakiness, no `IdlingResource` needed — the scene can't run ahead of the script. |
 | Same artifact for human review + machine gate (Maestro recordings, Robo crawl reports) | **Shipped** | One GIF/APNG/MP4 doubles as the visual record and, via assertions, the pass/fail signal. |
-| Assert exact text / value (Maestro `assertTrue`, Espresso `withText`) | Roadmap | `assert.textEquals` against the resolved node's `text`. Held off v1 to keep the wire shape additive. |
+| Assert exact text / value (Maestro `assertTrue`, Espresso `withText`) | **Shipped** | `assert.textEquals` compares the resolved node's `text` to the expected string in the existing `inputText` field. |
 | Crawl / auto-explore (Robo, Monkey) | Roadmap, narrow | A preview is a single held scene, not an app graph — "crawl" reduces to "fan a tap over every clickable semantics node and snapshot," which the probe machinery could drive. Useful as a smoke check, not a crawl. |
 
 ### Other emulator-test techniques worth borrowing
@@ -93,7 +96,7 @@ land (each is a separate follow-up, not in this PR):
 - Event kinds + descriptor: `RecordingScriptDataExtensions.ASSERT_VISIBLE_EVENT` /
   `ASSERT_NOT_VISIBLE_EVENT` / `assertionDescriptor`
   (`data/render/core/.../DataExtensionPlan.kt`).
-- Verdict logic (pure, unit-tested): `evaluateVisibilityAssertion`
+- Verdict logic (pure, unit-tested): `evaluateVisibilityAssertion` / `evaluateTextEqualsAssertion`
   (`daemon/desktop/.../RecordingAssertions.kt`).
 - Handler wiring: `DesktopRecordingSession.assertVisibilityHandler`; advertised by
   `DesktopHost.recordingScriptEventDescriptors`.


### PR DESCRIPTION
Closes #1965. First of the #1964–#1969 follow-ups to the recording-assertions work (#1963).

Completes the core recording-assertion vocabulary — the Maestro `assertVisible: "text"` / Espresso `withText` equivalent. `assert.textEquals` resolves the event's `target` to a single node and fails unless that node's text equals the expected string.

## Reuses the existing wire shape (no new field)

Per the issue's "reuse existing syntax/features" steer:

- **Expected text rides the existing `RecordingScriptEvent.inputText` field** (shared with `uia.inputText`) — no new wire field.
- Node resolved by the existing `SemanticsInputTarget` + `SemanticsTargets.resolve`, same handle as `input.click` / `assert.visible`.
- Failures reuse `RecordingScriptEventStatus.FAILED` + `failedEvidence`; a miss (0 or >1 match) carries the candidate list.
- Advertised via the existing `assertionDescriptor`. The CLI gate already fails any non-`APPLIED` `assert.*`, so **no CLI change is needed**.

```json
{ "tMs": 300, "kind": "assert.textEquals", "target": { "testTag": "greeting" }, "inputText": "Hello" }
```

The string comparison is extracted to the pure `evaluateTextEqualsAssertion` (unit-tested); the handler does resolution + evidence wiring only. Desktop today (mirrors `assert.visible`/`notVisible`); Android tracked in #1964.

## Test plan

- [x] `:daemon:desktop:test --tests "*RecordingAssertionsTest"` — pure verdict (match / mismatch / no-text). **Ran locally, green.**
- [x] `:daemon:desktop:test --tests "*scripted_text_equals_assertion*"` — integration against a new `TaggedTextSquare` fixture (`Text("Hello")` carrying `testTag("greeting")`): APPLIED on match, FAILED (with actual text) on mismatch, FAILED (+candidates) on a missing tag. **Ran locally with the real renderer, green.**
- [x] `:daemon:desktop:compileKotlin` + `ktfmtFormat` clean.

## Visual evidence

No rendered surface changes — protocol/handler/test plumbing around the existing recording pipeline. Behaviour is `FAILED` evidence + the CLI's existing non-zero exit, verified by the tests above.

---
_Generated by [Claude Code](https://claude.ai/code/session_015XGE7oXG27kAaotihUDCag)_