### PR TITLE
feat(a11y): render the TalkBack focus overlay in desktop recordings (#1956)

### DIFF
--- a/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/cli/TalkBack.kt
+++ b/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/cli/TalkBack.kt
@@ -1,0 +1,113 @@
+package ee.schimke.composeai.cli
+
+/**
+ * JVM mirror of `:data-a11y-core`'s pure TalkBack helpers (issue #1956), operating on the
+ * wire-format [AccessibilityNode] in this module. The desktop daemon is plain JVM and deliberately
+ * doesn't depend on the Android `:data-a11y-core`, so — exactly like [AccessibilityNode] mirrors
+ * `ee.schimke.composeai.renderer.AccessibilityNode` field-for-field — these mirror
+ * `TalkBackUtterance` / `TalkBackTraversal` / `TalkBackOverlayFrames`. The two copies are kept in
+ * lock-step by identical unit-test suites pinning the same expected strings / boundaries on both
+ * sides. See the a11y-core originals for the full rationale.
+ */
+object TalkBackUtterance {
+
+  /** The single "what TalkBack speaks" string for [node]: `label, role, state…, usage-hint`. */
+  fun compose(node: AccessibilityNode): String {
+    val checkable = node.states.any { it == CHECKED || it == UNCHECKED }
+    val disabled = node.states.any { it == DISABLED }
+
+    val stateWords = mutableListOf<String>()
+    val hints = mutableListOf<String>()
+    var hintText: String? = null
+
+    for (state in node.states) {
+      when {
+        state == CHECKED -> stateWords += "checked"
+        state == UNCHECKED -> stateWords += "not checked"
+        state == DISABLED -> stateWords += "disabled"
+        state == EDITABLE -> stateWords += "edit box"
+        state == HEADING -> stateWords += "heading"
+        state == CLICKABLE ->
+          hints += if (checkable) "double-tap to toggle" else "double-tap to activate"
+        state == LONG_CLICKABLE -> hints += "double-tap and hold to long press"
+        state == SCROLLABLE -> hints += "swipe with two fingers to scroll"
+        state.startsWith(HINT_PREFIX) -> hintText = state.removePrefix(HINT_PREFIX).trim()
+        else -> stateWords += state.trim()
+      }
+    }
+
+    val parts = mutableListOf<String>()
+    node.label.trim().takeIf { it.isNotEmpty() }?.let { parts += it }
+    node.role?.trim()?.takeIf { it.isNotEmpty() }?.let { parts += it.lowercase() }
+    parts += stateWords
+    if (!disabled) parts += hints
+    hintText?.takeIf { it.isNotEmpty() }?.let { parts += it }
+
+    return parts.joinToString(", ")
+  }
+
+  private const val CHECKED = "checked"
+  private const val UNCHECKED = "unchecked"
+  private const val DISABLED = "disabled"
+  private const val CLICKABLE = "clickable"
+  private const val LONG_CLICKABLE = "long-clickable"
+  private const val SCROLLABLE = "scrollable"
+  private const val EDITABLE = "editable"
+  private const val HEADING = "heading"
+  private const val HINT_PREFIX = "hint: "
+}
+
+/** JVM mirror of `:data-a11y-core`'s `TalkBackTraversal` (focus-stop walk). */
+object TalkBackTraversal {
+
+  /** The focus stops in TalkBack traversal order — the merged nodes, in extraction order. */
+  fun focusStops(nodes: List<AccessibilityNode>): List<AccessibilityNode> = nodes.filter {
+    it.merged
+  }
+
+  fun next(nodes: List<AccessibilityNode>, currentRef: String?): AccessibilityNode? {
+    val stops = focusStops(nodes)
+    if (stops.isEmpty()) return null
+    val idx = indexOfRef(stops, currentRef)
+    if (idx < 0) return stops.first()
+    return stops.getOrNull(idx + 1)
+  }
+
+  fun previous(nodes: List<AccessibilityNode>, currentRef: String?): AccessibilityNode? {
+    val stops = focusStops(nodes)
+    if (stops.isEmpty()) return null
+    val idx = indexOfRef(stops, currentRef)
+    if (idx < 0) return stops.last()
+    return stops.getOrNull(idx - 1)
+  }
+
+  private fun indexOfRef(stops: List<AccessibilityNode>, ref: String?): Int {
+    if (ref == null) return -1
+    return stops.indexOfFirst { it.ref == ref }
+  }
+}
+
+/** JVM mirror of `:data-a11y-core`'s `TalkBackOverlayFrames` (frame index → focus stop). */
+object TalkBackOverlayFrames {
+
+  const val DEFAULT_DWELL_MS: Long = 900L
+
+  fun focusedStopForFrame(
+    frameIndex: Int,
+    fps: Int,
+    stopCount: Int,
+    dwellMs: Long = DEFAULT_DWELL_MS,
+  ): Int {
+    if (stopCount <= 0) return -1
+    if (fps <= 0 || dwellMs <= 0L) return 0
+    val tMs = frameIndex.toLong() * 1000L / fps.toLong()
+    val stop = (tMs / dwellMs).toInt()
+    return stop.coerceIn(0, stopCount - 1)
+  }
+
+  fun totalFrames(fps: Int, stopCount: Int, dwellMs: Long = DEFAULT_DWELL_MS): Int {
+    if (stopCount <= 0 || fps <= 0 || dwellMs <= 0L) return 0
+    val durationMs = stopCount.toLong() * dwellMs
+    return (durationMs * fps / 1000L).toInt() + 1
+  }
+}

--- a/api/preview-data-api/src/test/kotlin/ee/schimke/composeai/cli/TalkBackTest.kt
+++ b/api/preview-data-api/src/test/kotlin/ee/schimke/composeai/cli/TalkBackTest.kt
@@ -1,0 +1,92 @@
+package ee.schimke.composeai.cli
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Pins the JVM `cli` TalkBack helpers (issue #1956) to the same behaviour as the `:data-a11y-core`
+ * originals — the field-for-field mirror is only safe if both sides agree on these exact strings
+ * and boundaries. Mirrors the a11y-core suites' key cases.
+ */
+class TalkBackTest {
+
+  private fun node(
+    label: String = "",
+    ref: String? = null,
+    role: String? = null,
+    states: List<String> = emptyList(),
+    merged: Boolean = true,
+  ) =
+    AccessibilityNode(
+      label = label,
+      ref = ref,
+      role = role,
+      states = states,
+      merged = merged,
+      boundsInScreen = "0,0,10,10",
+    )
+
+  @Test
+  fun utterance_button() {
+    assertEquals(
+      "Buy now, button, double-tap to activate",
+      TalkBackUtterance.compose(
+        node(label = "Buy now", role = "Button", states = listOf("clickable"))
+      ),
+    )
+  }
+
+  @Test
+  fun utterance_checkboxUncheckedAndDisabledAndSlider() {
+    assertEquals(
+      "Remember me, checkbox, not checked, double-tap to toggle",
+      TalkBackUtterance.compose(
+        node(label = "Remember me", role = "CheckBox", states = listOf("unchecked", "clickable"))
+      ),
+    )
+    assertEquals(
+      "Submit, button, disabled",
+      TalkBackUtterance.compose(
+        node(label = "Submit", role = "Button", states = listOf("clickable", "disabled"))
+      ),
+    )
+    assertEquals(
+      "Volume, seekbar, 70%",
+      TalkBackUtterance.compose(node(label = "Volume", role = "SeekBar", states = listOf("70%"))),
+    )
+  }
+
+  private val tree =
+    listOf(
+      node(label = "h", ref = "a/Header[0]", merged = true),
+      node(label = "c", ref = "a/Card[0]", merged = true),
+      node(label = "t", ref = "a/Text[0]", merged = false),
+      node(label = "b", ref = "a/Button[0]", merged = true),
+    )
+
+  @Test
+  fun traversal_focusStopsAndMoves() {
+    assertEquals(
+      listOf("a/Header[0]", "a/Card[0]", "a/Button[0]"),
+      TalkBackTraversal.focusStops(tree).map { it.ref },
+    )
+    assertEquals("a/Header[0]", TalkBackTraversal.next(tree, null)?.ref)
+    assertEquals("a/Button[0]", TalkBackTraversal.next(tree, "a/Card[0]")?.ref)
+    assertNull(TalkBackTraversal.next(tree, "a/Button[0]"))
+    assertEquals("a/Button[0]", TalkBackTraversal.previous(tree, null)?.ref)
+    assertNull(TalkBackTraversal.previous(tree, "a/Header[0]"))
+  }
+
+  @Test
+  fun frames_dwellAndClamp() {
+    assertEquals(0, TalkBackOverlayFrames.focusedStopForFrame(0, 30, stopCount = 3, dwellMs = 900L))
+    assertEquals(
+      1,
+      TalkBackOverlayFrames.focusedStopForFrame(27, 30, stopCount = 3, dwellMs = 900L),
+    )
+    assertEquals(2, TalkBackOverlayFrames.focusedStopForFrame(10_000, 30, stopCount = 3))
+    assertEquals(-1, TalkBackOverlayFrames.focusedStopForFrame(0, 30, stopCount = 0))
+    assertEquals(82, TalkBackOverlayFrames.totalFrames(30, stopCount = 3, dwellMs = 900L))
+  }
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/RecordPreviewCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/RecordPreviewCommand.kt
@@ -261,6 +261,7 @@ class RecordPreviewCommand(args: List<String>) : Command(args) {
       overrides =
         when (key) {
           "touchOverlay" -> overrides.copy(touchOverlay = value.toBooleanFlag(key))
+          "talkBack" -> overrides.copy(talkBack = value.toBooleanFlag(key))
           "inspectionMode" -> overrides.copy(inspectionMode = value.toBooleanFlag(key))
           "device" -> overrides.copy(device = value)
           "localeTag" -> overrides.copy(localeTag = value)

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewOverrideMerge.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewOverrideMerge.kt
@@ -34,6 +34,7 @@ data class PreviewOverrideBaseSpec(
   val ambient: AmbientOverride? = null,
   val focus: FocusOverride? = null,
   val touchOverlay: Boolean? = null,
+  val talkBack: Boolean? = null,
   val permissions: PermissionsOverride? = null,
   val remoteCompose: RemoteComposeOverride? = null,
   val launcherWidget: LauncherWidgetOverride? = null,
@@ -54,6 +55,7 @@ data class MergedPreviewOverrides(
   val ambient: AmbientOverride?,
   val focus: FocusOverride?,
   val touchOverlay: Boolean?,
+  val talkBack: Boolean?,
   val permissions: PermissionsOverride?,
   val remoteCompose: RemoteComposeOverride?,
   val launcherWidget: LauncherWidgetOverride?,
@@ -79,6 +81,7 @@ data class MergedPreviewOverrides(
         ambient == null &&
         focus == null &&
         touchOverlay != true &&
+        talkBack != true &&
         permissions == null &&
         remoteCompose == null &&
         launcherWidget == null &&
@@ -93,6 +96,7 @@ data class MergedPreviewOverrides(
       focus = focus,
       localeTag = if (isPseudolocale) localeTag else null,
       touchOverlay = touchOverlay,
+      talkBack = talkBack,
       permissions = permissions,
       remoteCompose = remoteCompose,
       launcherWidget = launcherWidget,
@@ -140,6 +144,7 @@ fun mergePreviewOverrides(
       ambient = base.ambient,
       focus = base.focus,
       touchOverlay = base.touchOverlay,
+      talkBack = base.talkBack,
       permissions = base.permissions,
       remoteCompose = base.remoteCompose,
       launcherWidget = base.launcherWidget,
@@ -169,6 +174,7 @@ fun mergePreviewOverrides(
     ambient = overrides.ambient ?: base.ambient,
     focus = overrides.focus ?: base.focus,
     touchOverlay = overrides.touchOverlay ?: base.touchOverlay,
+    talkBack = overrides.talkBack ?: base.talkBack,
     permissions = overrides.permissions ?: base.permissions,
     remoteCompose = overrides.remoteCompose ?: base.remoteCompose,
     launcherWidget = overrides.launcherWidget ?: base.launcherWidget,

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/PreviewOverrideMergeTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/PreviewOverrideMergeTest.kt
@@ -142,6 +142,32 @@ class PreviewOverrideMergeTest {
   }
 
   @Test
+  fun `talkBack override merges into the bag and flows through toExtensionOverrides`() {
+    // Issue #1956 — the TalkBack focus overlay is opt-in via overrides.talkBack; it must survive
+    // the
+    // merge → toExtensionOverrides projection so DesktopRecordingSession can read it off the spec.
+    val base =
+      PreviewOverrideBaseSpec(
+        widthPx = 320,
+        heightPx = 480,
+        density = 2.0f,
+        device = null,
+        localeTag = null,
+        fontScale = null,
+        uiMode = null,
+        orientation = null,
+        inspectionMode = null,
+      )
+
+    val merged = mergePreviewOverrides(base, PreviewOverrides(talkBack = true))
+    assertEquals(true, merged.talkBack)
+    assertEquals(true, merged.toExtensionOverrides()?.talkBack)
+
+    // Default (unset) stays off and projects to an empty bag.
+    assertNull(mergePreviewOverrides(base, PreviewOverrides()).toExtensionOverrides())
+  }
+
+  @Test
   fun `remoteCompose override merges into the bag and flows through toExtensionOverrides`() {
     val base =
       PreviewOverrideBaseSpec(

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
@@ -216,6 +216,9 @@ open class DesktopHost(
     // not silently ignored. Pseudolocale is driven by `localeTag` (no separate field).
     add("keyboard")
     add("touchOverlay")
+    // Issue #1956 — `overrides.talkBack` drives the per-frame TalkBack focus overlay composited in
+    // DesktopRecordingSession.writeTalkBackFrame.
+    add("talkBack")
     add("launcherWidget")
   }
 

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSession.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSession.kt
@@ -14,6 +14,9 @@ import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerId
 import androidx.compose.ui.input.pointer.PointerType
 import androidx.compose.ui.scene.ComposeScenePointer
+import ee.schimke.composeai.cli.AccessibilityNode
+import ee.schimke.composeai.cli.TalkBackOverlayFrames
+import ee.schimke.composeai.cli.TalkBackTraversal
 import ee.schimke.composeai.daemon.protocol.RecordingFormat
 import ee.schimke.composeai.daemon.protocol.RecordingInputParams
 import ee.schimke.composeai.daemon.protocol.RecordingScriptEvent
@@ -24,8 +27,13 @@ import ee.schimke.composeai.data.layoutinspector.SemanticsTargets
 import ee.schimke.composeai.data.layoutinspector.TargetResolution
 import ee.schimke.composeai.data.render.extensions.RecordingScriptDataExtensions
 import ee.schimke.composeai.io.SystemFileSystem
+import java.awt.RenderingHints
+import java.awt.image.BufferedImage
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
 import java.io.File
 import java.util.concurrent.ConcurrentLinkedQueue
+import javax.imageio.ImageIO
 import okio.FileSystem
 import okio.Path.Companion.toPath
 import org.jetbrains.skia.EncodedImageFormat
@@ -778,6 +786,14 @@ class DesktopRecordingSession(
     @Suppress("UNUSED_PARAMETER") virtualTimeMs: Long,
   ) {
     val outFile = File(framesDir, "frame-${"%05d".format(frameIndex)}.png")
+    // TalkBack focus overlay (issue #1956): when opted in, composite the focus walk onto this frame
+    // before encoding. Done in natural pixel space (node bounds are source-bitmap px), then scaled
+    // if needed — separate from the plain encode path below so a non-talkBack recording stays
+    // byte-identical.
+    if (state.spec.overrides?.talkBack == true) {
+      writeTalkBackFrame(image, frameIndex, outFile)
+      return
+    }
     val bytes =
       if (scale == 1.0f && image.width == frameWidthPx && image.height == frameHeightPx) {
         // Fast path: no scaling needed, encode the held scene's Image directly.
@@ -811,6 +827,66 @@ class DesktopRecordingSession(
         }
       }
     fileSystem.write(outFile.path.toPath()) { write(bytes) }
+  }
+
+  /**
+   * Composite the TalkBack focus overlay onto [image] and write the result to [outFile]. Extracts
+   * this frame's accessibility nodes from the live semantics tree, picks the focus stop the walk
+   * has reached at [frameIndex] ([TalkBackOverlayFrames]), draws the overlay in natural pixel space
+   * via [DesktopTalkBackFocusOverlay], then scales to the recording's frame size if `scale != 1.0`.
+   * If there are no focus stops (or anything fails) the frame is written unchanged.
+   */
+  private fun writeTalkBackFrame(image: Image, frameIndex: Int, outFile: File) {
+    val naturalBytes =
+      image.encodeToData(EncodedImageFormat.PNG)?.bytes
+        ?: error("encodeToData(PNG) returned null at frame $frameIndex (talkBack)")
+    val nodes = extractTalkBackNodes()
+    val stopCount = TalkBackTraversal.focusStops(nodes).size
+    val focusedStop = TalkBackOverlayFrames.focusedStopForFrame(frameIndex, fps, stopCount)
+    val overlaidNatural =
+      if (stopCount > 0) {
+        DesktopTalkBackFocusOverlay.overlayPngBytes(naturalBytes, nodes, focusedStop)
+          ?: naturalBytes
+      } else {
+        naturalBytes
+      }
+    val finalBytes =
+      if (scale == 1.0f && image.width == frameWidthPx && image.height == frameHeightPx) {
+        overlaidNatural
+      } else {
+        scalePngBytes(overlaidNatural, frameWidthPx, frameHeightPx)
+      }
+    fileSystem.write(outFile.path.toPath()) { write(finalBytes) }
+  }
+
+  /** This frame's accessibility nodes from the held scene's live semantics tree (pre-order). */
+  private fun extractTalkBackNodes(): List<AccessibilityNode> {
+    val root =
+      state.scene.semanticsOwners.firstOrNull()?.unmergedRootSemanticsNode ?: return emptyList()
+    return DesktopAccessibilityNodeExtractor.extractNodes(root)
+  }
+
+  /**
+   * Bilinear-scale PNG [bytes] to [w]×[h] via AWT (the overlay path's scaler; matches the recording
+   * size).
+   */
+  private fun scalePngBytes(bytes: ByteArray, w: Int, h: Int): ByteArray {
+    val src = ImageIO.read(ByteArrayInputStream(bytes)) ?: return bytes
+    val dst = BufferedImage(w, h, BufferedImage.TYPE_INT_ARGB)
+    val g = dst.createGraphics()
+    try {
+      g.setRenderingHint(
+        RenderingHints.KEY_INTERPOLATION,
+        RenderingHints.VALUE_INTERPOLATION_BILINEAR,
+      )
+      g.drawImage(src, 0, 0, w, h, null)
+    } finally {
+      g.dispose()
+    }
+    return ByteArrayOutputStream().use { out ->
+      ImageIO.write(dst, "png", out)
+      out.toByteArray()
+    }
   }
 
   private fun sceneOffset(px: Int, py: Int): androidx.compose.ui.geometry.Offset {

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopTalkBackFocusOverlay.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopTalkBackFocusOverlay.kt
@@ -1,0 +1,205 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.cli.AccessibilityNode
+import ee.schimke.composeai.cli.TalkBackTraversal
+import ee.schimke.composeai.cli.TalkBackUtterance
+import java.awt.BasicStroke
+import java.awt.Color
+import java.awt.Font
+import java.awt.Graphics2D
+import java.awt.RenderingHints
+import java.awt.geom.RoundRectangle2D
+import java.awt.image.BufferedImage
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import javax.imageio.ImageIO
+import kotlin.math.max
+import kotlin.math.min
+
+/**
+ * Desktop (AWT / `Graphics2D`) twin of the Android `TalkBackFocusOverlay` (issue #1956). It draws
+ * the identical TalkBack focus visualization — a green focus rectangle around the focused stop,
+ * faint traversal-order badges on every stop, and a caption card with the composed announcement —
+ * but onto a `BufferedImage` via `java.awt.Graphics2D`, the way [DesktopAccessibilityOverlay] and
+ * [DesktopSemanticsWireframe] composite onto captured frames (the Compose-Multiplatform desktop
+ * recording path has no `android.graphics`).
+ *
+ * The shared, backend-agnostic logic lives in `:data-a11y-core`: [TalkBackTraversal.focusStops]
+ * picks the stops, [TalkBackUtterance.compose] writes the caption. Only the drawing is duplicated
+ * per graphics stack, so the desktop and Android overlays stay visually in step by construction.
+ *
+ * Operates on the natural-size frame (node `boundsInScreen` are in source-bitmap pixels), so
+ * callers composite **before** any scale-down.
+ */
+object DesktopTalkBackFocusOverlay {
+
+  // Visual constants mirror the Android renderer so the two backends look the same.
+  private val FOCUS_GREEN = Color(0x00, 0xC8, 0x53)
+  private const val FOCUS_STROKE_PX = 6f
+  private const val FOCUS_INSET_PX = 3f
+  private const val NUMBER_RADIUS_PX = 18
+  private const val NUMBER_TEXT_PX = 22
+  private const val CAPTION_MARGIN_PX = 16
+  private const val CAPTION_PADDING_PX = 18
+  private const val CAPTION_TEXT_PX = 28
+  private const val CAPTION_LINE_PX = 36
+  private const val CAPTION_CORNER_PX = 16f
+  private val CAPTION_BG = Color(0x10, 0x10, 0x12, 0xE6)
+  private val NUMBER_BG_IDLE = Color(0x33, 0x33, 0x38, 0xB0)
+
+  /**
+   * Composites the focus overlay for [focusedStop] onto the PNG-encoded frame [pngBytes], returning
+   * re-encoded PNG bytes. Returns `null` (caller should write the frame untouched) when [nodes] has
+   * no focus stops or the bytes can't be decoded. Out-of-range [focusedStop] is clamped.
+   */
+  fun overlayPngBytes(
+    pngBytes: ByteArray,
+    nodes: List<AccessibilityNode>,
+    focusedStop: Int,
+  ): ByteArray? {
+    val stops = TalkBackTraversal.focusStops(nodes)
+    if (stops.isEmpty()) return null
+    val source =
+      try {
+        ImageIO.read(ByteArrayInputStream(pngBytes))
+      } catch (t: Throwable) {
+        System.err.println(
+          "[compose-a11y] desktop talkback overlay decode failed: ${t.javaClass.simpleName}: ${t.message}"
+        )
+        null
+      } ?: return null
+    val composite = compose(source, stops, focusedStop.coerceIn(0, stops.size - 1))
+    return ByteArrayOutputStream().use { out ->
+      ImageIO.write(composite, "png", out)
+      out.toByteArray()
+    }
+  }
+
+  /**
+   * Pure AWT compositing — exposed for unit tests. [stops] are the focus stops; [focusedStop]
+   * indexes them.
+   */
+  internal fun compose(
+    source: BufferedImage,
+    stops: List<AccessibilityNode>,
+    focusedStop: Int,
+  ): BufferedImage {
+    val out = BufferedImage(source.width, source.height, BufferedImage.TYPE_INT_ARGB)
+    val g = out.createGraphics()
+    try {
+      g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON)
+      g.setRenderingHint(
+        RenderingHints.KEY_TEXT_ANTIALIASING,
+        RenderingHints.VALUE_TEXT_ANTIALIAS_ON,
+      )
+      g.drawImage(source, 0, 0, null)
+      drawTraversalNumbers(g, stops, focusedStop)
+      drawFocusRect(g, stops[focusedStop])
+      drawCaption(g, out.width, out.height, TalkBackUtterance.compose(stops[focusedStop]))
+    } finally {
+      g.dispose()
+    }
+    return out
+  }
+
+  private fun drawFocusRect(g: Graphics2D, node: AccessibilityNode) {
+    val r = parseBounds(node.boundsInScreen) ?: return
+    g.color = FOCUS_GREEN
+    g.stroke = BasicStroke(FOCUS_STROKE_PX)
+    val o = (FOCUS_INSET_PX + FOCUS_STROKE_PX / 2f)
+    val x = r[0] - o
+    val y = r[1] - o
+    val w = (r[2] - r[0]) + 2 * o
+    val h = (r[3] - r[1]) + 2 * o
+    g.draw(java.awt.geom.Rectangle2D.Float(x, y, w, h))
+  }
+
+  private fun drawTraversalNumbers(
+    g: Graphics2D,
+    stops: List<AccessibilityNode>,
+    focusedStop: Int,
+  ) {
+    g.font = Font(Font.SANS_SERIF, Font.BOLD, NUMBER_TEXT_PX)
+    val fm = g.fontMetrics
+    stops.forEachIndexed { i, node ->
+      val r = parseBounds(node.boundsInScreen) ?: return@forEachIndexed
+      val cx = max(r[0], NUMBER_RADIUS_PX.toFloat())
+      val cy = max(r[1], NUMBER_RADIUS_PX.toFloat())
+      g.color = if (i == focusedStop) FOCUS_GREEN else NUMBER_BG_IDLE
+      g.fillOval(
+        (cx - NUMBER_RADIUS_PX).toInt(),
+        (cy - NUMBER_RADIUS_PX).toInt(),
+        NUMBER_RADIUS_PX * 2,
+        NUMBER_RADIUS_PX * 2,
+      )
+      g.color = Color.WHITE
+      val label = (i + 1).toString()
+      g.drawString(label, cx - fm.stringWidth(label) / 2f, cy + (fm.ascent - fm.descent) / 2f)
+    }
+  }
+
+  private fun drawCaption(g: Graphics2D, width: Int, height: Int, utterance: String) {
+    if (utterance.isEmpty()) return
+    g.font = Font(Font.SANS_SERIF, Font.PLAIN, CAPTION_TEXT_PX)
+    val fm = g.fontMetrics
+    val maxTextWidth = width - 2 * CAPTION_MARGIN_PX - 2 * CAPTION_PADDING_PX
+    val lines = wrap(utterance, fm, maxTextWidth)
+    val cardHeight = 2 * CAPTION_PADDING_PX + lines.size * CAPTION_LINE_PX
+    val cardTop = height - CAPTION_MARGIN_PX - cardHeight
+    g.color = CAPTION_BG
+    g.fill(
+      RoundRectangle2D.Float(
+        CAPTION_MARGIN_PX.toFloat(),
+        cardTop.toFloat(),
+        (width - 2 * CAPTION_MARGIN_PX).toFloat(),
+        cardHeight.toFloat(),
+        CAPTION_CORNER_PX,
+        CAPTION_CORNER_PX,
+      )
+    )
+    // Green accent bar down the left edge, tying the caption to the focus rectangle's colour.
+    g.color = FOCUS_GREEN
+    g.fill(
+      RoundRectangle2D.Float(
+        CAPTION_MARGIN_PX.toFloat(),
+        cardTop.toFloat(),
+        6f,
+        cardHeight.toFloat(),
+        CAPTION_CORNER_PX,
+        CAPTION_CORNER_PX,
+      )
+    )
+    g.color = Color.WHITE
+    var baseline = cardTop + CAPTION_PADDING_PX + CAPTION_TEXT_PX
+    val textX = (CAPTION_MARGIN_PX + CAPTION_PADDING_PX).toFloat()
+    for (line in lines) {
+      g.drawString(line, textX, baseline.toFloat())
+      baseline += CAPTION_LINE_PX
+    }
+  }
+
+  /** `l,t,r,b` integer pixels → `[left, top, right, bottom]` floats, normalised. */
+  private fun parseBounds(s: String?): FloatArray? {
+    if (s == null) return null
+    val p = s.split(",").mapNotNull { it.trim().toFloatOrNull() }
+    if (p.size != 4) return null
+    return floatArrayOf(min(p[0], p[2]), min(p[1], p[3]), max(p[0], p[2]), max(p[1], p[3]))
+  }
+
+  private fun wrap(text: String, fm: java.awt.FontMetrics, maxWidth: Int): List<String> {
+    if (text.isEmpty()) return emptyList()
+    val out = mutableListOf<String>()
+    var current = StringBuilder()
+    for (word in text.split(' ')) {
+      val candidate = if (current.isEmpty()) word else "$current $word"
+      if (fm.stringWidth(candidate) <= maxWidth) {
+        current = StringBuilder(candidate)
+      } else {
+        if (current.isNotEmpty()) out.add(current.toString())
+        current = StringBuilder(word)
+      }
+    }
+    if (current.isNotEmpty()) out.add(current.toString())
+    return out
+  }
+}

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopTalkBackFocusOverlayTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopTalkBackFocusOverlayTest.kt
@@ -1,0 +1,99 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.cli.AccessibilityNode
+import java.awt.Color
+import java.awt.image.BufferedImage
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import javax.imageio.ImageIO
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Rasterised coverage for [DesktopTalkBackFocusOverlay] (issue #1956) — the AWT desktop twin of the
+ * Android `TalkBackFocusOverlay`. Pure JVM (`Graphics2D` + `ImageIO`), no Robolectric: the green
+ * focus rectangle must land on the focused node, the caption accent must paint at the bottom, and a
+ * stopless tree must produce no overlay.
+ */
+class DesktopTalkBackFocusOverlayTest {
+
+  private val nodes =
+    listOf(
+      AccessibilityNode(
+        label = "Settings",
+        role = "Heading",
+        merged = true,
+        boundsInScreen = "40,40,360,90",
+      ),
+      AccessibilityNode(
+        label = "Buy now",
+        role = "Button",
+        states = listOf("clickable"),
+        merged = true,
+        boundsInScreen = "40,140,360,210",
+      ),
+      AccessibilityNode(label = "inner", merged = false, boundsInScreen = "50,150,200,200"),
+    )
+
+  private fun blackPng(w: Int, h: Int): ByteArray {
+    val bm = BufferedImage(w, h, BufferedImage.TYPE_INT_ARGB)
+    val g = bm.createGraphics()
+    g.color = Color.BLACK
+    g.fillRect(0, 0, w, h)
+    g.dispose()
+    return ByteArrayOutputStream().use {
+      ImageIO.write(bm, "png", it)
+      it.toByteArray()
+    }
+  }
+
+  private fun isGreen(rgb: Int): Boolean {
+    val c = Color(rgb, true)
+    return c.green > 140 && c.green > c.red + 40 && c.green > c.blue + 40
+  }
+
+  @Test
+  fun `focus rectangle is green and lands on the focused node`() {
+    val out =
+      DesktopTalkBackFocusOverlay.overlayPngBytes(blackPng(400, 400), nodes, focusedStop = 1)
+    assertNotNull(out)
+    val bm = ImageIO.read(ByteArrayInputStream(out))
+
+    var greenFocused = 0
+    for (yy in (140 - 8)..(140 - 2)) for (x in 40..360) if (isGreen(bm.getRGB(x, yy)))
+      greenFocused++
+    assertTrue("focused node should be ringed in green: $greenFocused", greenFocused > 50)
+
+    var greenUnfocused = 0
+    for (yy in (40 - 8)..(40 - 2)) for (x in 60..360) if (isGreen(bm.getRGB(x, yy)))
+      greenUnfocused++
+    assertTrue("unfocused heading must not be ringed: $greenUnfocused", greenUnfocused < 10)
+  }
+
+  @Test
+  fun `caption accent bar paints at the bottom-left`() {
+    val out =
+      DesktopTalkBackFocusOverlay.overlayPngBytes(blackPng(400, 400), nodes, focusedStop = 1)
+    assertNotNull(out)
+    val bm = ImageIO.read(ByteArrayInputStream(out))
+    var accent = 0
+    for (y in 300 until 400) for (x in 16..26) if (isGreen(bm.getRGB(x, y))) accent++
+    assertTrue("caption accent bar should paint near the bottom-left: $accent", accent > 20)
+  }
+
+  @Test
+  fun `no focus stops yields no overlay`() {
+    val onlyUnmerged =
+      listOf(AccessibilityNode(label = "x", merged = false, boundsInScreen = "0,0,10,10"))
+    assertNull(DesktopTalkBackFocusOverlay.overlayPngBytes(blackPng(40, 40), onlyUnmerged, 0))
+  }
+
+  @Test
+  fun `out of range focused stop is clamped`() {
+    assertNotNull(
+      DesktopTalkBackFocusOverlay.overlayPngBytes(blackPng(400, 400), nodes, focusedStop = 99)
+    )
+  }
+}

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/TalkBackOverlayRecordingTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/TalkBackOverlayRecordingTest.kt
@@ -1,0 +1,207 @@
+package ee.schimke.composeai.daemon
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.daemon.protocol.RecordingFormat
+import ee.schimke.composeai.daemon.protocol.RecordingScriptEvent
+import java.awt.Color as AwtColor
+import java.io.File
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * End-to-end test for the TalkBack focus-overlay recording path (issue #1956). Records a multi-stop
+ * [SettingsFixture] with `overrides.talkBack = true` over the real desktop renderer and verifies:
+ *
+ * 1. The recording spans the whole focus walk (many frames).
+ * 2. The overlay actually painted on the real render — captured frames carry the TalkBack-green
+ *    focus rectangle / badges.
+ * 3. The focus walk *advances*: an early frame concentrates the green near the top of the screen
+ *    (the heading, first stop); a late frame concentrates it lower (a button further down the
+ *    traversal order).
+ * 4. APNG encodes (always), and MP4 encodes when ffmpeg is on PATH.
+ *
+ * Also stitches a GIF artifact for the PR comment. Fixture lives in this file (resolved by the
+ * `…TalkBackOverlayRecordingTestKt` synthetic class name) so the test is self-contained.
+ */
+class TalkBackOverlayRecordingTest {
+
+  @get:Rule val tempFolder: TemporaryFolder = TemporaryFolder()
+
+  private var savedRecordingsDir: String? = null
+
+  @After
+  fun tearDown() {
+    val saved = savedRecordingsDir
+    if (saved == null) System.clearProperty(DesktopHost.RECORDINGS_DIR_PROP)
+    else System.setProperty(DesktopHost.RECORDINGS_DIR_PROP, saved)
+  }
+
+  @Test
+  fun talkBack_overlay_walks_focus_through_stops_on_real_render() {
+    val outputDir = tempFolder.newFolder("talkback-renders")
+    val recordingsRoot = tempFolder.newFolder("talkback-recordings")
+    savedRecordingsDir = System.getProperty(DesktopHost.RECORDINGS_DIR_PROP)
+    System.setProperty(DesktopHost.RECORDINGS_DIR_PROP, recordingsRoot.absolutePath)
+
+    val engine = RenderEngine(outputDir = outputDir)
+    val host =
+      DesktopHost(
+        engine = engine,
+        previewSpecResolver = { previewId ->
+          if (previewId == TALKBACK_PREVIEW_ID) {
+            RenderSpec(
+              className = "ee.schimke.composeai.daemon.TalkBackOverlayRecordingTestKt",
+              functionName = "SettingsFixture",
+              widthPx = CANVAS_W,
+              heightPx = CANVAS_H,
+              density = 1.0f,
+              outputBaseName = "talkback-walk",
+            )
+          } else null
+        },
+      )
+    host.start()
+    try {
+      val session =
+        host.acquireRecordingSession(
+          previewId = TALKBACK_PREVIEW_ID,
+          recordingId = "test-rec-talkback",
+          classLoader =
+            TalkBackOverlayRecordingTest::class.java.classLoader
+              ?: ClassLoader.getSystemClassLoader(),
+          fps = FPS,
+          scale = 1.0f,
+          overrides = PreviewOverrides(talkBack = true),
+        )
+      try {
+        // No real interaction needed — just extend the recording long enough for the focus walk to
+        // step through every stop. Two harmless clicks on empty padding bracket the timeline; the
+        // walk advancement is driven by frame index, not by these events.
+        session.postScript(
+          listOf(
+            RecordingScriptEvent(tMs = 0L, kind = "input.click", pixelX = 4, pixelY = 4),
+            RecordingScriptEvent(tMs = WALK_MS, kind = "input.click", pixelX = 4, pixelY = 4),
+          )
+        )
+
+        val result = session.stop()
+        assertTrue(
+          "expected a multi-frame walk over $WALK_MS ms at $FPS fps; got ${result.frameCount}",
+          result.frameCount >= 100,
+        )
+
+        val framesDir = File(result.framesDir)
+        // 2. Overlay painted on the real render — green present in a mid-walk frame.
+        val mid = TouchOverlayTestSupport.readPng(frame(framesDir, result.frameCount / 2))
+        val greenMid =
+          TouchOverlayTestSupport.pixelMatchPctApprox(
+            mid,
+            FOCUS_GREEN_RGB,
+            perChannelTolerance = 50,
+          )
+        assertTrue(
+          "mid-walk frame must carry TalkBack-green overlay pixels; got ${"%.4f".format(greenMid * 100)}%",
+          greenMid > 0.0005,
+        )
+
+        // 3. Focus advances down the traversal order: more green up top early, lower later.
+        val early = TouchOverlayTestSupport.readPng(frame(framesDir, 5))
+        val late = TouchOverlayTestSupport.readPng(frame(framesDir, result.frameCount - 5))
+        val topBand = 0 until CANVAS_H / 3
+        val bottomBand = (CANVAS_H * 2 / 3) until CANVAS_H
+        val earlyTop = greenCount(early, topBand)
+        val lateTop = greenCount(late, topBand)
+        val lateBottom = greenCount(late, bottomBand)
+        assertTrue(
+          "focus rectangle should start near the top (early top-green=$earlyTop) and move down " +
+            "(late top-green=$lateTop, late bottom-green=$lateBottom)",
+          earlyTop > lateTop && lateBottom > lateTop,
+        )
+
+        // 4. Encode artifacts.
+        val apng = session.encode(RecordingFormat.APNG)
+        assertTrue("APNG must be non-empty", File(apng.videoPath).isFile && apng.sizeBytes > 0)
+        if (FfmpegEncoder.available()) {
+          val mp4 = session.encode(RecordingFormat.MP4)
+          assertTrue(
+            "MP4 must be non-empty when ffmpeg present",
+            File(mp4.videoPath).isFile && mp4.sizeBytes > 0,
+          )
+        }
+
+        // GIF artifact for the PR comment.
+        val gif = ARTIFACT_DIR.also { it.mkdirs() }.resolve("talkback-desktop-walk.gif")
+        TouchOverlayTestSupport.encodeFramesAsGif(framesDir, result.frameCount, gif, fps = FPS)
+        assertTrue("GIF artifact must be written", gif.isFile && gif.length() > 0)
+      } finally {
+        session.close()
+      }
+    } finally {
+      host.shutdown()
+    }
+  }
+
+  private fun frame(dir: File, index: Int) = File(dir, "frame-${"%05d".format(index)}.png")
+
+  /** Count TalkBack-green pixels within the given vertical band. */
+  private fun greenCount(img: java.awt.image.BufferedImage, yRange: IntRange): Int {
+    var n = 0
+    for (y in yRange) {
+      if (y !in 0 until img.height) continue
+      for (x in 0 until img.width) {
+        val c = AwtColor(img.getRGB(x, y), true)
+        if (c.green > 140 && c.green > c.red + 40 && c.green > c.blue + 40) n++
+      }
+    }
+    return n
+  }
+
+  companion object {
+    private const val TALKBACK_PREVIEW_ID = "talkback-settings"
+    private const val CANVAS_W = 320
+    private const val CANVAS_H = 520
+    private const val FPS = 30
+    private const val FOCUS_GREEN_RGB = 0x00C853
+    // 4 stops × 900ms default dwell = 3600ms; record the full walk.
+    private const val WALK_MS = 3600L
+    // Repo-root `build/talkback-artifacts` (user.dir is the module dir under gradle — up two
+    // levels),
+    // matching where TouchOverlayTestSupport drops its GIF for the PR-artifact upload step.
+    private val ARTIFACT_DIR: File =
+      File(System.getProperty("user.dir")).parentFile.parentFile.resolve("build/talkback-artifacts")
+  }
+}
+
+/**
+ * Recording fixture: a small settings screen with a heading and three buttons — four TalkBack focus
+ * stops the overlay walks top-to-bottom.
+ */
+@Composable
+fun SettingsFixture() {
+  Column(
+    modifier = Modifier.fillMaxSize().background(Color(0xFFF5F5F7)).padding(20.dp),
+    verticalArrangement = Arrangement.spacedBy(20.dp),
+  ) {
+    Text("Settings", modifier = Modifier.semantics { heading() })
+    Button(onClick = {}, modifier = Modifier.fillMaxWidth()) { Text("Wi-Fi") }
+    Button(onClick = {}, modifier = Modifier.fillMaxWidth()) { Text("Bluetooth") }
+    Button(onClick = {}, modifier = Modifier.fillMaxWidth()) { Text("Sign out") }
+  }
+}

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
@@ -1209,6 +1209,7 @@ class DaemonMcpServer(
                       }
                     },
                     "touchOverlay":{"type":"boolean","description":"Opt-in touch-event visualization (Android 'Show touches' style) for live/recording sessions."},
+                    "talkBack":{"type":"boolean","description":"Opt-in TalkBack focus-overlay visualization for recordings: a green focus rectangle, traversal-order badges, and the spoken-announcement caption, walked through the screen's focus stops."},
                     "permissions":{
                       "type":"object",
                       "description":"Android runtime-permissions override. Seeds Robolectric's grant state so checkSelfPermission reads see the requested values. Android-only; desktop ignores it.",
@@ -2478,6 +2479,7 @@ class DaemonMcpServer(
       check("focus", overrides.focus != null)
       check("keyboard", overrides.keyboard != null)
       check("touchOverlay", overrides.touchOverlay != null)
+      check("talkBack", overrides.talkBack != null)
       check("launcherWidget", overrides.launcherWidget != null)
       check("permissions", overrides.permissions != null)
       check("remoteCompose", overrides.remoteCompose != null)
@@ -2576,6 +2578,7 @@ class DaemonMcpServer(
       focus = nested("focus", FocusOverride.serializer()),
       keyboard = nested("keyboard", KeyboardOverride.serializer()),
       touchOverlay = bool("touchOverlay"),
+      talkBack = bool("talkBack"),
       permissions = nested("permissions", PermissionsOverride.serializer()),
       remoteCompose = nested("remoteCompose", RemoteComposeOverride.serializer()),
       launcherWidget = nested("launcherWidget", LauncherWidgetOverride.serializer()),

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
@@ -1549,7 +1549,8 @@ class DaemonMcpServerTest {
     // through renderNow.overrides. A backend that advertises them (Android-shaped) accepts the
     // call and the daemon observes the typed fields.
     factory.daemonConfigurer = { d ->
-      d.advertisedSupportedOverrides = listOf("focus", "keyboard", "permissions", "touchOverlay")
+      d.advertisedSupportedOverrides =
+        listOf("focus", "keyboard", "permissions", "touchOverlay", "talkBack")
       d.autoRenderPngPath = { _ ->
         java.io.File.createTempFile("preview", ".png").also { it.deleteOnExit() }.absolutePath
       }
@@ -1575,6 +1576,7 @@ class DaemonMcpServerTest {
           }
           putJsonObject("keyboard") { put("visible", true) }
           put("touchOverlay", true)
+          put("talkBack", true)
           putJsonObject("permissions") {
             putJsonObject("grants") { put("android.permission.CAMERA", "granted") }
           }
@@ -1589,6 +1591,7 @@ class DaemonMcpServerTest {
     assertThat(observed.focus?.overlay).isTrue()
     assertThat(observed.keyboard?.visible).isTrue()
     assertThat(observed.touchOverlay).isTrue()
+    assertThat(observed.talkBack).isTrue()
     assertThat(observed.permissions?.grants)
       .containsEntry(
         "android.permission.CAMERA",


### PR DESCRIPTION
Follow-up to #1956. The first PR landed the tested cores (utterance, traversal, the Android overlay renderer, the `talkBack` flag) but deferred the integration that makes `overrides.talkBack = true` actually *do* something. This wires it end-to-end on the desktop recording backend, so a recording with `talkBack` enabled produces an animated TalkBack focus walk.

## What's wired
- **`DesktopTalkBackFocusOverlay`** — an AWT/`Graphics2D` twin of the Android `TalkBackFocusOverlay` (the Compose-Multiplatform desktop recording path has no `android.graphics`, same reason the desktop a11y path already uses `Graphics2D`). Draws the identical green focus rectangle, traversal-order badges, and announcement caption.
- **`DesktopRecordingSession.writeTalkBackFrame`** — when `overrides.talkBack` is set, extracts this frame's accessibility nodes from the live semantics tree (`DesktopAccessibilityNodeExtractor`), picks the focus stop the walk has reached (`TalkBackOverlayFrames`), composites in natural pixel space, then scales. The non-talkBack path stays byte-identical (guarded separately), so existing pixel-exact recordings are unaffected.
- **`PreviewOverrideMerge`** — `talkBack` was being dropped in `toExtensionOverrides()` (its base spec didn't carry it); threaded it through alongside `touchOverlay`, and advertised `talkBack` in `DesktopHost.supportedOverrides`.
- **`cli.TalkBack`** — a JVM mirror of the pure `:data-a11y-core` helpers (`TalkBackUtterance` / `TalkBackTraversal` / `TalkBackOverlayFrames`) for the plain-JVM desktop daemon. This is the same field-for-field mirror pattern `cli.AccessibilityNode` already uses against the Android `renderer.AccessibilityNode`, pinned by a parity test suite.

## Visual evidence
A real-renderer recording of a 4-stop settings screen (heading + 3 buttons), captured by the E2E test below (109 frames, full focus walk, GIF artifact emitted to `build/talkback-artifacts/`):

- **Frame 10 — stop 1:** green focus box on the "Settings" heading, badges 1–4 on every stop, caption "Settings".
- **Frame 90 — stop 4:** focus box advanced to "Sign out", caption "Sign out, button, double-tap to activate".

(Frames attached in the session.)

## Test plan
- `:daemon:desktop:test --tests "*DesktopTalkBackFocusOverlayTest"` — pure-AWT rasterisation (green rect lands on the focused node, caption accent paints, stopless tree → no overlay).
- `:daemon:desktop:test --tests "*TalkBackOverlayRecordingTest"` — **real-renderer E2E**: records with `talkBack=true`, asserts the overlay painted on the live render and the focus advances down the traversal order, encodes APNG + MP4 (ffmpeg), emits the GIF artifact.
- `:preview-data-api:test --tests "*TalkBackTest"` — cli-mirror parity with the a11y-core originals.
- `:daemon:core:test --tests "*PreviewOverrideMergeTest"` — `talkBack` survives merge → `toExtensionOverrides`; non-talkBack still projects an empty bag.
- Existing `DesktopRecordingSessionTest` / `TouchOverlayPinchRecordingTest` / `OverrideIntegrationTest` re-run green (non-talkBack path unchanged).

## Still deferred (one of the two seams)
The Android-backend per-frame overlay and the **host-side `next`/`previous` focus dispatch** are not in this PR. Both need the Robolectric sandbox to verify, and `next`/`previous` specifically require reconstructing Compose's traversal order + node identity inside the host — I'd rather do that as its own focused, sandbox-verified change than bundle fragile, unverified host code into this desktop-verified PR. The deterministic traversal core it needs already ships in `TalkBackTraversal`, and this PR's overlay exercises that walk visually.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PjVRQ7fXGAA4zHVD7eoT3z)_