### PR TITLE
feat(data): add compose/shared-element data-product core model

### DIFF
--- a/data/shared-element/core/build.gradle.kts
+++ b/data/shared-element/core/build.gradle.kts
@@ -1,0 +1,20 @@
+plugins {
+  id("composeai.base-conventions")
+  id("composeai.maven-publishing")
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.kotlin.serialization)
+}
+
+dependencies {
+  api(libs.kotlinx.serialization.json)
+  testImplementation(libs.junit)
+}
+
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "data-shared-element-core",
+    displayName = "Compose Preview - Shared Element Data Product Core",
+    description = "Shared-element transition findings model classes for Compose Preview.",
+  )
+  inceptionYear.set("2026")
+}

--- a/data/shared-element/core/src/main/kotlin/ee/schimke/composeai/data/sharedelement/SharedElementModels.kt
+++ b/data/shared-element/core/src/main/kotlin/ee/schimke/composeai/data/sharedelement/SharedElementModels.kt
@@ -1,0 +1,94 @@
+package ee.schimke.composeai.data.sharedelement
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Stable identity and wire shape of the `compose/shared-element` data product — the structured,
+ * machine-readable counterpart to the pixels that Compose 1.11's
+ * `LookaheadAnimationVisualDebugging` overlay paints over an in-flight shared-element transition.
+ *
+ * The overlay (`androidx.compose.animation.LookaheadAnimationVisualDebugging`, gated by
+ * `@ExperimentalLookaheadAnimationVisualDebugApi`) classifies every `rememberSharedContentState`
+ * key into one of three states and rasterises them — target bounds in `overlayColor`, **unmatched**
+ * keys in `unmatchedElementColor` (red), **multiply-matched** keys in `multipleMatchesColor`
+ * (green) — but exposes none of that as data: the classification is computed inside the
+ * (module-internal) `LookaheadAnimationVisualDebugHelper` at draw time and never surfaced. This
+ * model is the wire shape a future producer emits so an agent or CI can *assert* "no unmatched
+ * shared elements" without OCR'ing a GIF — the same role `compose/semantics` plays for the
+ * layout-inspector overlay.
+ *
+ * This module is deliberately producer-free and dependency-light (no Compose, no Robolectric, no
+ * experimental API): the three-way classification and the per-key target bounds are the *public*
+ * contract of the overlay, so the shape is stable to model even though extracting the values at
+ * render time is not yet in scope (it requires either reflection into the experimental internals or
+ * an independent re-derivation of the match state). Mirrors `:data-layoutinspector-core` so MCP
+ * clients in other languages can depend on the findings model without dragging in a renderer.
+ */
+object SharedElementProduct {
+  const val KIND: String = "compose/shared-element"
+  const val SCHEMA_VERSION: Int = 1
+  const val FILE: String = "shared-element-findings.json"
+}
+
+/**
+ * Match classification of a single shared-element key during a transition — the three states the
+ * 1.11 overlay paints.
+ *
+ * - [MATCHED] — the key has exactly one counterpart in the other `AnimatedContent` state, so the
+ *   element animates its bounds between the two; the overlay draws only target bounds + label.
+ * - [UNMATCHED] — the key is registered on only one side, so it has nothing to animate toward; the
+ *   overlay flags it in red. The single most common shared-element bug (a key missing on one side).
+ * - [MULTIPLE_MATCHES] — the same key is registered more than once in a state, leaving the match
+ *   ambiguous; the overlay flags it in green.
+ */
+@Serializable
+enum class SharedElementMatchStatus {
+  MATCHED,
+  UNMATCHED,
+  MULTIPLE_MATCHES,
+}
+
+/**
+ * One shared-element key observed during the transition.
+ *
+ * @property key the `rememberSharedContentState(key = …)` value, as the overlay's optional key
+ *   label would render it.
+ * @property status the [SharedElementMatchStatus] classification for this key.
+ * @property occurrences how many times the key was registered in the captured frame — `1` for a
+ *   well-formed [MATCHED]/[UNMATCHED] key, `> 1` for [MULTIPLE_MATCHES].
+ * @property modifier which shared modifier registered the key — `"sharedElement"` or
+ *   `"sharedBounds"` — or null when the producer can't attribute it.
+ * @property targetBoundsInRoot the bounds the element animates toward, as `"left,top,right,bottom"`
+ *   in root pixels (matching the `boundsInRoot` convention on `compose/semantics`), or null when
+ *   there is no target (an [UNMATCHED] key) or the producer didn't resolve it.
+ */
+@Serializable
+data class SharedElementFinding(
+  val key: String,
+  val status: SharedElementMatchStatus,
+  val occurrences: Int = 1,
+  val modifier: String? = null,
+  val targetBoundsInRoot: String? = null,
+)
+
+/**
+ * The `compose/shared-element` payload: every shared-element key observed in the captured
+ * transition frame, with convenience tallies a CLI report or CI gate reads to decide pass/fail. The
+ * derived counts live in the class body (not the constructor), so they are computed on read and
+ * never serialised — the JSON carries only [findings].
+ */
+@Serializable
+data class SharedElementPayload(val findings: List<SharedElementFinding> = emptyList()) {
+  val matchedCount: Int
+    get() = findings.count { it.status == SharedElementMatchStatus.MATCHED }
+
+  val unmatchedCount: Int
+    get() = findings.count { it.status == SharedElementMatchStatus.UNMATCHED }
+
+  val multipleMatchesCount: Int
+    get() = findings.count { it.status == SharedElementMatchStatus.MULTIPLE_MATCHES }
+
+  /** True when any key is unmatched or multiply-matched — the threshold a CI gate fails on. */
+  val hasProblems: Boolean
+    get() = unmatchedCount > 0 || multipleMatchesCount > 0
+}

--- a/data/shared-element/core/src/test/kotlin/ee/schimke/composeai/data/sharedelement/SharedElementModelsTest.kt
+++ b/data/shared-element/core/src/test/kotlin/ee/schimke/composeai/data/sharedelement/SharedElementModelsTest.kt
@@ -1,0 +1,84 @@
+package ee.schimke.composeai.data.sharedelement
+
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SharedElementModelsTest {
+
+  private val json = Json { prettyPrint = false }
+
+  @Test
+  fun payloadRoundTripsThroughJson() {
+    val payload =
+      SharedElementPayload(
+        findings =
+          listOf(
+            SharedElementFinding(
+              key = "avatar",
+              status = SharedElementMatchStatus.MATCHED,
+              modifier = "sharedElement",
+              targetBoundsInRoot = "0,0,120,120",
+            ),
+            SharedElementFinding(key = "badge", status = SharedElementMatchStatus.UNMATCHED),
+            SharedElementFinding(
+              key = "title",
+              status = SharedElementMatchStatus.MULTIPLE_MATCHES,
+              occurrences = 2,
+              modifier = "sharedBounds",
+            ),
+          )
+      )
+
+    val decoded = json.decodeFromString<SharedElementPayload>(json.encodeToString(payload))
+
+    assertEquals(payload, decoded)
+  }
+
+  @Test
+  fun derivedCountsAreNotSerialisedButAreComputedOnRead() {
+    val payload =
+      SharedElementPayload(
+        findings =
+          listOf(
+            SharedElementFinding("a", SharedElementMatchStatus.MATCHED),
+            SharedElementFinding("b", SharedElementMatchStatus.MATCHED),
+            SharedElementFinding("c", SharedElementMatchStatus.UNMATCHED),
+            SharedElementFinding("d", SharedElementMatchStatus.MULTIPLE_MATCHES, occurrences = 3),
+          )
+      )
+
+    assertEquals(2, payload.matchedCount)
+    assertEquals(1, payload.unmatchedCount)
+    assertEquals(1, payload.multipleMatchesCount)
+    assertTrue(payload.hasProblems)
+
+    // The derived tallies live in the class body, so they must not leak into the wire form.
+    val encoded = json.encodeToString(payload)
+    assertFalse(encoded.contains("matchedCount"))
+    assertFalse(encoded.contains("hasProblems"))
+  }
+
+  @Test
+  fun wellFormedTransitionHasNoProblems() {
+    val payload =
+      SharedElementPayload(
+        findings =
+          listOf(
+            SharedElementFinding("avatar", SharedElementMatchStatus.MATCHED),
+            SharedElementFinding("title", SharedElementMatchStatus.MATCHED),
+          )
+      )
+
+    assertFalse(payload.hasProblems)
+    assertEquals(0, payload.unmatchedCount)
+  }
+
+  @Test
+  fun emptyPayloadIsTheDefault() {
+    assertEquals(emptyList<SharedElementFinding>(), SharedElementPayload().findings)
+    assertFalse(SharedElementPayload().hasProblems)
+  }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -324,6 +324,10 @@ include(":data-ambient-connector")
 
 project(":data-ambient-connector").projectDir = file("data/ambient/connector")
 
+include(":data-shared-element-core")
+
+project(":data-shared-element-core").projectDir = file("data/shared-element/core")
+
 include(":data-focus-core")
 
 project(":data-focus-core").projectDir = file("data/focus/core")


### PR DESCRIPTION
## Summary

Adds `:data-shared-element-core` — the stable wire shape for a future **shared-element transition findings** data product (`compose/shared-element`).

Compose 1.11's `LookaheadAnimationVisualDebugging` overlay classifies every `rememberSharedContentState` key as **matched / unmatched / multiply-matched** and paints it (red = unmatched, green = multiple matches), but exposes none of that as data — the classification is computed inside the module-internal `LookaheadAnimationVisualDebugHelper` at draw time. This module is the structured counterpart an agent or CI can *assert* against ("no unmatched shared elements") without OCR'ing a GIF — the same role `compose/semantics` plays for the layout-inspector overlay.

What's modelled:
- `SharedElementProduct` — kind (`compose/shared-element`), schema version, file name.
- `SharedElementMatchStatus` — the three-way classification.
- `SharedElementFinding` — per-key status, occurrence count, registering modifier (`sharedElement` / `sharedBounds`), and target bounds (`"l,t,r,b"`, matching the `boundsInRoot` convention on `compose/semantics`).
- `SharedElementPayload` — the findings list plus convenience tallies (`unmatchedCount`, `hasProblems`, …) for a CI gate. Tallies live in the class body, so they're computed on read and never serialised.

Mirrors `:data-layoutinspector-core` (build wiring, package layout, publishing coordinates).

### Scope / what's deliberately *not* here
This is the **core data shape only**. The producer is out of scope on purpose: extracting the match state at render time needs either reflection into the experimental, name-mangled overlay internals or an independent re-derivation of the classification — neither is stable enough to land yet. The module is producer-free and dependency-light (no Compose / Robolectric / experimental API) so the wire shape can stabilise first. The visual half already exists as samples (`SharedElementDebugPreviews`, `SharedElementFilmstripPreview`).

Non-visual change (data-product model + tests), so no rendered evidence applies.

## Test plan
- [x] `./gradlew :data-shared-element-core:test` — 4 tests: JSON round-trip, derived tallies are computed-not-serialised, well-formed transition has no problems, empty default.
- [x] `./gradlew :data-shared-element-core:ktfmtCheckMain :data-shared-element-core:ktfmtCheckTest` — formatting gate clean.
- [x] Module wired into `settings.gradle.kts`; configures and builds on the current `main` base.