### PR TITLE
feat(a11y): scriptable TalkBack next/previous focus navigation (#1956)

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSession.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSession.kt
@@ -306,6 +306,13 @@ class AndroidRecordingSession(
         for (action in A11Y_SEMANTIC_ACTIONS) {
           put("a11y.action.$action", a11ySemanticsActionHandler(action))
         }
+        // TalkBack linear-navigation verbs (issue #1956). Unlike the content-description-targeted
+        // actions above, `next` / `previous` carry no target node — they advance the host-side
+        // focus cursor through the merged focus stops in traversal order. Routed through the same
+        // dispatchSemanticsAction bridge (the host branches on the action kind), so they share the
+        // settle window but skip the nodeContentDescription requirement.
+        put(AccessibilityRecordingScriptEvents.ACTION_NEXT, a11yNavigationHandler("next"))
+        put(AccessibilityRecordingScriptEvents.ACTION_PREVIOUS, a11yNavigationHandler("previous"))
         // UIAutomator-shaped dispatch — every `uia.<actionKind>` id reads the event's `selector`
         // JsonObject (multi-axis BySelector predicate), encodes it as a JSON string, and routes
         // through `interactive.dispatchUiAutomator(actionKind, selectorJson, useUnmergedTree,
@@ -423,6 +430,26 @@ class AndroidRecordingSession(
         unsupportedEvidence(
           event,
           "no node with contentDescription='$description' exposes the '$actionKind' semantic",
+        )
+      }
+    }
+
+  /**
+   * Handler for the `a11y.action.next` / `a11y.action.previous` linear-navigation verbs (issue
+   * #1956). No target node — moves the host-side TalkBack focus cursor through the merged focus
+   * stops in traversal order via `interactive.dispatchSemanticsAction(direction, "")`. `matched` is
+   * `true` when focus moved, `false` at a list boundary (end of screen — no wrap), surfaced as
+   * applied / unsupported evidence respectively.
+   */
+  private fun a11yNavigationHandler(direction: String): RecordingScriptEventHandler =
+    RecordingScriptEventHandler { event, _ ->
+      val moved = interactive.dispatchSemanticsAction(direction, "")
+      if (moved) {
+        appliedEvidence(event, "TalkBack focus moved to the $direction focus stop")
+      } else {
+        unsupportedEvidence(
+          event,
+          "no further focus stop in the '$direction' direction (end of screen)",
         )
       }
     }

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.hasClickAction
 import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.hasRequestFocusAction
@@ -2067,6 +2068,12 @@ open class RobolectricHost(
             // panel-side frame stream, so we tear down the prior install on overwrite.
             val recompositionHandles =
               java.util.concurrent.ConcurrentHashMap<String, () -> Unit>()
+            // TalkBack focus cursor for this held session (issue #1956). Tracks the
+            // accessibility-hierarchy `ref` of the node TalkBack is currently stopped on; the
+            // `a11y.action.next` / `previous` arms advance it through the merged focus stops in
+            // traversal order. Null = no focus yet (a `next` enters at the first stop, `previous`
+            // at the last). Held-session scoped so it resets cleanly between recordings.
+            val a11yFocusCursor = AtomicReference<String?>(null)
             setupTrace.section("compose:setContent") {
               rule.setContent {
                 androidx.compose.runtime.key(reloadCounter.intValue) {
@@ -2243,7 +2250,14 @@ open class RobolectricHost(
                 }
                 is InteractiveCommand.DispatchSemanticsAction -> {
                   try {
-                    val matched = performSemanticsActionByContentDescription(rule, cmd)
+                    val matched =
+                      if (cmd.actionKind == "next" || cmd.actionKind == "previous") {
+                        // TalkBack linear navigation moves the session focus cursor rather than
+                        // resolving a node by content description (issue #1956).
+                        performTalkBackNavigation(rule, cmd.actionKind, a11yFocusCursor)
+                      } else {
+                        performSemanticsActionByContentDescription(rule, cmd)
+                      }
                     cmd.replyMatched.set(matched)
                     if (matched) {
                       // Match the input-dispatch settle pattern so a screen-reader-driven click
@@ -2978,6 +2992,42 @@ open class RobolectricHost(
         "scrollRight" -> invokeScrollBy(rule, target, dx = target.size.width.toFloat(), dy = 0f)
         else -> false
       }
+    }
+
+    /**
+     * TalkBack linear navigation (issue #1956): advance the held session's focus [cursor] to the
+     * next / previous focus stop in traversal order and request focus on it.
+     *
+     * Builds the focus-stop list from the merged semantics tree — each merged node that carries a
+     * label or a click action is a screen-reader stop, mirroring the desktop extractor's keep
+     * filter — sorted into reading order (top-to-bottom, then left-to-right) and stamped with the
+     * same role-anchored refs [AccessibilityRefs] assigns to the a11y hierarchy. The shared
+     * [TalkBackTraversal] then walks them: `null` cursor enters at the first stop (`next`) or last
+     * (`previous`); a boundary returns `false` (TalkBack announces "end of screen" rather than
+     * wrapping). Focus is requested best-effort — a stop that isn't input-focusable (a heading
+     * `Text`) still advances the cursor.
+     */
+    private fun performTalkBackNavigation(
+      rule:
+        androidx.compose.ui.test.junit4.AndroidComposeTestRule<
+          *,
+          androidx.activity.ComponentActivity,
+        >,
+      direction: String,
+      cursor: AtomicReference<String?>,
+    ): Boolean {
+      val semantics =
+        rule
+          .onAllNodes(SemanticsMatcher("any node") { true }, useUnmergedTree = false)
+          .fetchSemanticsNodes(atLeastOneRootRequired = false)
+      val move = TalkBackHostNavigation.move(semantics, direction, cursor.get())
+      cursor.set(move.cursor)
+      // Move input focus to the stop so the focus highlight follows the cursor. Best-effort: a stop
+      // with no RequestFocus action (e.g. a heading Text) still counts as a successful move.
+      move.focusTarget?.config?.getOrNull(SemanticsActions.RequestFocus)?.action?.let { act ->
+        rule.runOnUiThread { act.invoke() }
+      }
+      return move.matched
     }
 
     /**

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/TalkBackHostNavigation.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/TalkBackHostNavigation.kt
@@ -41,9 +41,7 @@ internal object TalkBackHostNavigation {
       semantics
         .sortedWith(compareBy({ it.boundsInRoot.top }, { it.boundsInRoot.left }))
         .map { it to it.toFocusStop() }
-        .filter { (sn, an) ->
-          an.label.isNotEmpty() || sn.config.getOrNull(SemanticsActions.OnClick) != null
-        }
+        .filter { (sn, an) -> an.label.isNotEmpty() || sn.isStateOnlyFocusStop() }
     if (stops.isEmpty()) return Move(matched = false, cursor = currentCursor, focusTarget = null)
     val nodes = AccessibilityRefs.assign(stops.map { it.second })
     val target =
@@ -52,6 +50,27 @@ internal object TalkBackHostNavigation {
     if (target == null) return Move(matched = false, cursor = currentCursor, focusTarget = null)
     val idx = nodes.indexOfFirst { it.ref == target.ref }
     return Move(matched = true, cursor = target.ref, focusTarget = stops.getOrNull(idx)?.first)
+  }
+
+  /**
+   * Whether a node with no label is still a TalkBack focus stop because it carries actionable /
+   * stateful semantics — an empty edit field (`SetText` / `EditableText`), an unlabeled scrollable
+   * (`ScrollBy` / a scroll-axis range), a clickable, a toggle, or a slider. Mirrors the desktop
+   * accessibility extractor's state-based keep filter so the cursor order matches the a11y hierarchy
+   * (a bare `Role` with nothing else is *not* a stop — e.g. an undescribed Image — matching the
+   * hierarchy, which only surfaces a roled node when it's also actionable / labelled).
+   */
+  private fun SemanticsNode.isStateOnlyFocusStop(): Boolean {
+    val cfg = config
+    return cfg.contains(SemanticsActions.OnClick) ||
+      cfg.contains(SemanticsActions.OnLongClick) ||
+      cfg.contains(SemanticsActions.SetText) ||
+      cfg.getOrNull(SemanticsProperties.EditableText) != null ||
+      cfg.contains(SemanticsActions.ScrollBy) ||
+      cfg.getOrNull(SemanticsProperties.HorizontalScrollAxisRange) != null ||
+      cfg.getOrNull(SemanticsProperties.VerticalScrollAxisRange) != null ||
+      cfg.getOrNull(SemanticsProperties.ToggleableState) != null ||
+      cfg.getOrNull(SemanticsProperties.ProgressBarRangeInfo) != null
   }
 
   /** Project a merged [SemanticsNode] to the a11y-core node model used by [TalkBackTraversal]. */

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/TalkBackHostNavigation.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/TalkBackHostNavigation.kt
@@ -1,0 +1,69 @@
+package ee.schimke.composeai.daemon
+
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.SemanticsNode
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
+import ee.schimke.composeai.renderer.AccessibilityNode
+import ee.schimke.composeai.renderer.AccessibilityRefs
+import ee.schimke.composeai.renderer.TalkBackTraversal
+
+/**
+ * Host-side TalkBack linear-navigation core (issue #1956). Given the merged Compose semantics nodes
+ * of the current frame and the session's focus cursor, computes the next / previous focus stop in
+ * traversal order using the shared, unit-tested [TalkBackTraversal].
+ *
+ * Kept separate from [RobolectricHost] so the focus-stop extraction (which merged nodes are stops,
+ * reading-order sort, role-anchored refs) is testable against a real Compose semantics tree via a
+ * lightweight compose rule, without standing up the full held-session sandbox. [RobolectricHost]
+ * supplies `rule.onAllNodes(...).fetchSemanticsNodes(...)`, applies the returned [Move] to the
+ * cursor, and requests focus on [Move.focusTarget].
+ */
+internal object TalkBackHostNavigation {
+
+  /**
+   * Result of a navigation step. [matched] is `true` when the cursor moved; `false` at a list
+   * boundary (TalkBack's "end of screen" — no wrap) or when there are no focus stops. [cursor] is
+   * the new cursor value to store, and [focusTarget] is the semantics node to request focus on
+   * (best-effort; `null` when no move or the stop has no node).
+   */
+  data class Move(val matched: Boolean, val cursor: String?, val focusTarget: SemanticsNode?)
+
+  /**
+   * Compute the [direction] (`"next"` / `"previous"`) move from [currentCursor] over [semantics]
+   * (the merged tree's nodes for the frame). Focus stops are the merged nodes that carry a label or
+   * a click action — the screen-reader-focusable ones, mirroring the desktop extractor's keep
+   * filter — taken in reading order (top-to-bottom, then left-to-right) and stamped with the same
+   * role-anchored refs the a11y hierarchy uses.
+   */
+  fun move(semantics: List<SemanticsNode>, direction: String, currentCursor: String?): Move {
+    val stops =
+      semantics
+        .sortedWith(compareBy({ it.boundsInRoot.top }, { it.boundsInRoot.left }))
+        .map { it to it.toFocusStop() }
+        .filter { (sn, an) ->
+          an.label.isNotEmpty() || sn.config.getOrNull(SemanticsActions.OnClick) != null
+        }
+    if (stops.isEmpty()) return Move(matched = false, cursor = currentCursor, focusTarget = null)
+    val nodes = AccessibilityRefs.assign(stops.map { it.second })
+    val target =
+      if (direction == "previous") TalkBackTraversal.previous(nodes, currentCursor)
+      else TalkBackTraversal.next(nodes, currentCursor)
+    if (target == null) return Move(matched = false, cursor = currentCursor, focusTarget = null)
+    val idx = nodes.indexOfFirst { it.ref == target.ref }
+    return Move(matched = true, cursor = target.ref, focusTarget = stops.getOrNull(idx)?.first)
+  }
+
+  /** Project a merged [SemanticsNode] to the a11y-core node model used by [TalkBackTraversal]. */
+  private fun SemanticsNode.toFocusStop(): AccessibilityNode {
+    val cd = config.getOrNull(SemanticsProperties.ContentDescription)?.joinToString(" ")
+    val text = config.getOrNull(SemanticsProperties.Text)?.joinToString(" ") { it.text }
+    val r = boundsInRoot
+    return AccessibilityNode(
+      label = (cd ?: text ?: "").trim(),
+      role = config.getOrNull(SemanticsProperties.Role)?.toString(),
+      merged = true,
+      boundsInScreen = "${r.left.toInt()},${r.top.toInt()},${r.right.toInt()},${r.bottom.toInt()}",
+    )
+  }
+}

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSessionTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSessionTest.kt
@@ -457,6 +457,72 @@ class AndroidRecordingSessionTest {
   }
 
   @Test
+  fun a11yNextPreviousRouteThroughDispatchWithoutATargetNode() {
+    // #1956: a11y.action.next / .previous carry no target node — they route through
+    // dispatchSemanticsAction(direction, "") (the host advances its focus cursor) and report
+    // applied evidence when focus moved, unsupported (end of screen) when it didn't.
+    val framesDir = tempFolder.newFolder("a11y-nav-frames")
+    val encodedDir = tempFolder.newFolder("a11y-nav-encoded")
+    val sourcePng = File(tempFolder.newFolder("a11y-nav-source"), "source.png")
+    ImageIO.write(
+      java.awt.image.BufferedImage(8, 8, java.awt.image.BufferedImage.TYPE_INT_ARGB),
+      "png",
+      sourcePng,
+    )
+    // First next/previous move (true); the third call hits the boundary (false).
+    val interactive =
+      RecordingDeltaSession(sourcePng).apply { semanticsActionResults = ArrayDeque(listOf(true, true, false)) }
+    val session =
+      AndroidRecordingSession(
+        previewId = INTERACTIVE_PREVIEW_ID,
+        recordingId = "test-rec-a11y-nav",
+        fps = FPS,
+        scale = 1.0f,
+        interactive = interactive,
+        framesDir = framesDir,
+        encodedDir = encodedDir,
+      )
+
+    try {
+      session.postScript(
+        listOf(
+          RecordingScriptEvent(tMs = 0L, kind = "a11y.action.next"),
+          RecordingScriptEvent(tMs = 30L, kind = "a11y.action.previous"),
+          RecordingScriptEvent(tMs = 60L, kind = "a11y.action.next"),
+        )
+      )
+      val result = session.stop()
+
+      // No pointer dispatch, and each nav routed with an empty content description.
+      assertEquals(0, interactive.dispatchCount)
+      assertEquals(
+        listOf("next" to "", "previous" to "", "next" to ""),
+        interactive.semanticsActionCalls,
+      )
+      assertEquals(3, result.scriptEvents.size)
+      assertEquals(
+        ee.schimke.composeai.daemon.protocol.RecordingScriptEventStatus.APPLIED,
+        result.scriptEvents[0].status,
+      )
+      assertEquals(
+        ee.schimke.composeai.daemon.protocol.RecordingScriptEventStatus.APPLIED,
+        result.scriptEvents[1].status,
+      )
+      // The boundary call is surfaced as unsupported with an end-of-screen reason.
+      assertEquals(
+        ee.schimke.composeai.daemon.protocol.RecordingScriptEventStatus.UNSUPPORTED,
+        result.scriptEvents[2].status,
+      )
+      assertTrue(
+        "boundary evidence should explain end of screen; got '${result.scriptEvents[2].message}'",
+        (result.scriptEvents[2].message ?: "").contains("end of screen"),
+      )
+    } finally {
+      session.close()
+    }
+  }
+
+  @Test
   fun a11yActionClickReportsUnsupportedWhenNoNodeMatches() {
     // When `dispatchSemanticsAction` returns false (no matching node, or matched node didn't
     // expose OnClick), the handler must surface a specific unsupported reason — not let the agent
@@ -1604,6 +1670,13 @@ class AndroidRecordingSessionTest {
     var semanticsActionResult: Boolean? = null
 
     /**
+     * When non-null, [dispatchSemanticsAction] pops the next result from this queue per call (used by
+     * the next/previous test to model a focus walk that hits a boundary on its last step). Takes
+     * precedence over [semanticsActionResult]; falls back to it once exhausted.
+     */
+    var semanticsActionResults: ArrayDeque<Boolean>? = null
+
+    /**
      * When non-null, [dispatchLifecycle] returns this value verbatim and records the call into
      * [lifecycleCalls]. When null (the default), the inherited interface-level default (`return
      * false`) is used so existing tests don't have to opt in.
@@ -1630,6 +1703,7 @@ class AndroidRecordingSessionTest {
       nodeContentDescription: String,
     ): Boolean {
       semanticsActionCalls += actionKind to nodeContentDescription
+      semanticsActionResults?.let { if (it.isNotEmpty()) return it.removeFirst() }
       val override = semanticsActionResult
       return override ?: super.dispatchSemanticsAction(actionKind, nodeContentDescription)
     }

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/TalkBackHostNavigationTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/TalkBackHostNavigationTest.kt
@@ -2,6 +2,7 @@ package ee.schimke.composeai.daemon
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.ui.Modifier
@@ -101,6 +102,16 @@ class TalkBackHostNavigationTest {
     val move = TalkBackHostNavigation.move(mergedNodes(), "previous", null)
     assertTrue(move.matched)
     assertEquals("Last", textOf(move))
+  }
+
+  @Test
+  fun `an unlabeled editable node is a focus stop`() {
+    // #1956 review: a node with no label and no OnClick is still a TalkBack stop when it carries
+    // edit semantics. An empty BasicTextField (SetText + EditableText, no contentDescription) must
+    // be walked — the old label-or-OnClick predicate dropped it.
+    composeRule.setContent { BasicTextField(value = "", onValueChange = {}) }
+    composeRule.waitForIdle()
+    assertTrue(TalkBackHostNavigation.move(mergedNodes(), "next", null).matched)
   }
 
   @Test

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/TalkBackHostNavigationTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/TalkBackHostNavigationTest.kt
@@ -1,0 +1,119 @@
+package ee.schimke.composeai.daemon
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.junit4.createComposeRule
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * Verifies the TalkBack linear-navigation core (issue #1956) against a *real* Compose semantics tree
+ * via a Robolectric compose rule — exercising the actual focus-stop extraction (which merged nodes
+ * are stops, reading order, refs) and the cursor walk through [TalkBackHostNavigation.move], the
+ * same code path `RobolectricHost.performTalkBackNavigation` drives during a recording.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+class TalkBackHostNavigationTest {
+
+  @get:Rule val composeRule = createComposeRule()
+
+  /** Fetch the merged-tree semantics nodes the host would feed to [TalkBackHostNavigation]. */
+  private fun mergedNodes() =
+    composeRule
+      .onAllNodes(SemanticsMatcher("any") { true }, useUnmergedTree = false)
+      .fetchSemanticsNodes(atLeastOneRootRequired = false)
+
+  @Test
+  fun `next walks the focus stops top to bottom and previous walks back, halting at boundaries`() {
+    composeRule.setContent {
+      Column {
+        Text("Settings", modifier = Modifier.semantics { heading() })
+        Button(onClick = {}, modifier = Modifier.fillMaxWidth()) { Text("Wi-Fi") }
+        Button(onClick = {}, modifier = Modifier.fillMaxWidth()) { Text("Bluetooth") }
+        Button(onClick = {}, modifier = Modifier.fillMaxWidth()) { Text("Sign out") }
+      }
+    }
+    composeRule.waitForIdle()
+    val nodes = mergedNodes()
+
+    // Cold start: next enters at the first stop (the heading), then walks down.
+    var cursor: String? = null
+    var move = TalkBackHostNavigation.move(nodes, "next", cursor)
+    assertTrue(move.matched)
+    cursor = move.cursor
+
+    val visited = mutableListOf<String?>()
+    // Record the focused label at each stop by re-deriving from the focusTarget.
+    visited += textOf(move)
+    repeat(3) {
+      move = TalkBackHostNavigation.move(nodes, "next", cursor)
+      cursor = move.cursor
+      if (move.matched) visited += textOf(move)
+    }
+    assertEquals(listOf("Settings", "Wi-Fi", "Bluetooth", "Sign out"), visited)
+
+    // Past the last stop: end of screen, no wrap, cursor unchanged.
+    val atEnd = TalkBackHostNavigation.move(nodes, "next", cursor)
+    assertFalse("next past the last stop must not match (end of screen)", atEnd.matched)
+    assertEquals(cursor, atEnd.cursor)
+
+    // previous walks back up.
+    move = TalkBackHostNavigation.move(nodes, "previous", cursor)
+    assertEquals("Bluetooth", textOf(move))
+    cursor = move.cursor
+    move = TalkBackHostNavigation.move(nodes, "previous", cursor)
+    assertEquals("Wi-Fi", textOf(move))
+    cursor = move.cursor
+    move = TalkBackHostNavigation.move(nodes, "previous", cursor)
+    assertEquals("Settings", textOf(move))
+    cursor = move.cursor
+
+    // Before the first stop: end of screen.
+    assertFalse(TalkBackHostNavigation.move(nodes, "previous", cursor).matched)
+  }
+
+  @Test
+  fun `previous from cold start enters at the last stop`() {
+    composeRule.setContent {
+      Column {
+        Button(onClick = {}) { Text("First") }
+        Button(onClick = {}) { Text("Last") }
+      }
+    }
+    composeRule.waitForIdle()
+    val move = TalkBackHostNavigation.move(mergedNodes(), "previous", null)
+    assertTrue(move.matched)
+    assertEquals("Last", textOf(move))
+  }
+
+  @Test
+  fun `a tree with no focus stops yields no move`() {
+    composeRule.setContent { Column {} }
+    composeRule.waitForIdle()
+    val move = TalkBackHostNavigation.move(mergedNodes(), "next", null)
+    assertFalse(move.matched)
+  }
+
+  private fun textOf(move: TalkBackHostNavigation.Move): String? =
+    move.focusTarget
+      ?.config
+      ?.getOrNull(SemanticsProperties.Text)
+      ?.joinToString(" ") { it.text }
+}

--- a/data/a11y/connector/src/main/kotlin/ee/schimke/composeai/daemon/AccessibilityRecordingScriptEvents.kt
+++ b/data/a11y/connector/src/main/kotlin/ee/schimke/composeai/daemon/AccessibilityRecordingScriptEvents.kt
@@ -23,12 +23,12 @@ import ee.schimke.composeai.data.render.extensions.RecordingScriptEventDescripto
  *
  * **Single descriptor, mixed support.** All 22 a11y actions live in one
  * `DataExtensionDescriptor(id = "a11y", ...)`. Each event carries its own `supported` flag —
- * 13 wired ids ride on `SemanticsActions` constants and report `supported = true`; the remaining 9
- * (`clearFocus`, `accessibilityFocus`, `clearAccessibilityFocus`, `select`, `clearSelection`,
- * `nextAtGranularity`, `previousAtGranularity`, plus the TalkBack linear-navigation `next` /
- * `previous` from issue #1956) report `supported = false` because Compose doesn't expose a clean
- * `SemanticsActions` equivalent today (the traversal computation behind `next` / `previous` ships
- * in `TalkBackTraversal`, but the host-side focus-state dispatch is still roadmap). Agents calling `list_data_products`
+ * 15 wired ids report `supported = true` — 13 ride on `SemanticsActions` constants, plus the
+ * TalkBack linear-navigation `next` / `previous` (issue #1956), which advance a host-side focus
+ * cursor through the merged focus stops (`TalkBackTraversal`). The remaining 7 (`clearFocus`,
+ * `accessibilityFocus`, `clearAccessibilityFocus`, `select`, `clearSelection`, `nextAtGranularity`,
+ * `previousAtGranularity`) report `supported = false` because Compose doesn't expose a clean
+ * equivalent today. Agents calling `list_data_products`
  * see one `a11y` extension with the full surface; the per-event flag is the source of truth for
  * "can `record_preview` accept this kind right now."
  */
@@ -63,7 +63,7 @@ object AccessibilityRecordingScriptEvents {
 
   /**
    * Single `a11y` data-extension descriptor advertising all 22 actions. Wired ids appear with
-   * `supported = true`; the remaining 9 carry `supported = false` so agents see the full
+   * `supported = true`; the remaining 7 carry `supported = false` so agents see the full
    * accessibility action surface (planned + shipped) in one extension entry.
    *
    * Each `supported = true` entry corresponds to a `when` arm in
@@ -164,23 +164,22 @@ object AccessibilityRecordingScriptEvents {
               "double-tap-to-activate verb. Pairs with next/previous for a scripted TalkBack walk " +
               "(issue #1956).",
           ),
-          // --- Roadmap (supported = false) ---
-          unsupportedEvent(
+          supportedEvent(
             ACTION_NEXT,
             "Next (linear navigation)",
-            "Moves TalkBack focus to the next focus stop in traversal order (issue #1956). The " +
-              "deterministic traversal computation ships in TalkBackTraversal (data-a11y-core, " +
-              "unit-tested) and drives the live TalkBack focus overlay's auto-advance; the " +
-              "remaining work is the host-side focus-state dispatch over the live Compose " +
-              "semantics tree. Tracked as roadmap.",
+            "Moves TalkBack focus to the next focus stop in traversal order (issue #1956). Advances " +
+              "a host-side focus cursor through the merged focus stops (TalkBackTraversal) and " +
+              "requests focus on the new stop; no target node required. Returns end-of-screen " +
+              "(no wrap) once past the last stop.",
           ),
-          unsupportedEvent(
+          supportedEvent(
             ACTION_PREVIOUS,
             "Previous (linear navigation)",
             "Counterpart to next — moves TalkBack focus to the previous focus stop in traversal " +
-              "order (issue #1956). Same TalkBackTraversal core; host-side focus-state dispatch is " +
-              "tracked as roadmap.",
+              "order (issue #1956). Same host-side focus cursor; returns end-of-screen before the " +
+              "first stop.",
           ),
+          // --- Roadmap (supported = false) ---
           unsupportedEvent(
             ACTION_CLEAR_FOCUS,
             "Clear focus",

--- a/data/a11y/connector/src/test/kotlin/ee/schimke/composeai/daemon/AccessibilityRecordingScriptEventsTest.kt
+++ b/data/a11y/connector/src/test/kotlin/ee/schimke/composeai/daemon/AccessibilityRecordingScriptEventsTest.kt
@@ -61,6 +61,8 @@ class AccessibilityRecordingScriptEventsTest {
         AccessibilityRecordingScriptEvents.ACTION_SCROLL_LEFT,
         AccessibilityRecordingScriptEvents.ACTION_SCROLL_RIGHT,
         AccessibilityRecordingScriptEvents.ACTION_ACTIVATE,
+        AccessibilityRecordingScriptEvents.ACTION_NEXT,
+        AccessibilityRecordingScriptEvents.ACTION_PREVIOUS,
       )
     val actuallySupported =
       AccessibilityRecordingScriptEvents.descriptor.recordingScriptEvents
@@ -85,8 +87,6 @@ class AccessibilityRecordingScriptEventsTest {
         AccessibilityRecordingScriptEvents.ACTION_CLEAR_SELECTION,
         AccessibilityRecordingScriptEvents.ACTION_NEXT_AT_GRANULARITY,
         AccessibilityRecordingScriptEvents.ACTION_PREVIOUS_AT_GRANULARITY,
-        AccessibilityRecordingScriptEvents.ACTION_NEXT,
-        AccessibilityRecordingScriptEvents.ACTION_PREVIOUS,
       )
     val actuallyUnsupported =
       AccessibilityRecordingScriptEvents.descriptor.recordingScriptEvents


### PR DESCRIPTION
Second of the two deferred #1956 seams (the desktop overlay landed in #1973). This makes `a11y.action.next` / `a11y.action.previous` first-class scriptable verbs on the Android (Robolectric) backend: they move TalkBack focus through the screen's focus stops in traversal order, so an agent can script a TalkBack walk and assert what each stop announces.

## Design
TalkBack's linear navigation has no target node — it advances a focus *cursor*. So unlike the content-description-targeted a11y actions, `next`/`previous`:

- **`TalkBackHostNavigation`** (new, `internal`) — builds the focus stops from the merged Compose semantics tree (the merged nodes that carry a label or click action, in reading order, stamped with the same role-anchored refs `AccessibilityRefs` assigns to the a11y hierarchy) and walks them with the shared, already-unit-tested `TalkBackTraversal`. Returns the cursor move + the node to focus. Extracted from `RobolectricHost` precisely so it's testable against a *real* semantics tree without standing up the full sandbox.
- **`RobolectricHost`** — holds a per-held-session focus cursor (`AtomicReference<String?>`, reset per recording); the `DispatchSemanticsAction` arm branches `next`/`previous` to `performTalkBackNavigation`, which applies the move and best-effort `RequestFocus`es the new stop (a non-focusable stop like a heading `Text` still advances the cursor). Every other action path is unchanged.
- **`AndroidRecordingSession`** — registers `next`/`previous` handlers that need no `nodeContentDescription`, routing through `dispatchSemanticsAction(direction, "")` and reporting **applied** when focus moved / **unsupported "end of screen"** at a boundary (TalkBack doesn't wrap).
- **Descriptor** — `next`/`previous` flip to `supported = true` (15 supported, 7 roadmap).

## Test plan
- `:daemon:android:testDebugUnitTest --tests "*TalkBackHostNavigationTest"` — drives the core against a **real Compose semantics tree** via a Robolectric compose rule: a heading + three buttons walked `Settings → Wi-Fi → Bluetooth → Sign out` and back, with `next` past the last stop and `previous` before the first both returning end-of-screen (no wrap, cursor unchanged); plus `previous`-from-cold-start entering at the last stop and a stopless tree yielding no move.
- `:daemon:android:testDebugUnitTest --tests "*AndroidRecordingSessionTest"` — new `a11yNextPreviousRouteThroughDispatchWithoutATargetNode` pins routing through `dispatchSemanticsAction(direction, "")` and applied/end-of-screen evidence; existing a11y routing tests still green.
- `:data-a11y-connector:testDebugUnitTest --tests "*AccessibilityRecordingScriptEventsTest"` — supported/roadmap split updated.

This completes both deferred seams from #1956. Text-only PR — no rendered surface changes (the visualization is the merged desktop overlay; this is dispatch wiring), verified by the Robolectric semantics-tree tests above.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PjVRQ7fXGAA4zHVD7eoT3z)_