### PR TITLE
fix: make device-frame prefetch work and un-break Bundle Render E2E

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -127,6 +127,8 @@ tasks.register("functionalTestWithAndroid") {
 //         api :renderer-xr-client (daemon-core fronts the native XR render server — RENDERER_SERVICE)
 //         api :data-layoutinspector-core (semantics models + differ for `history/diff mode=semantics`, #1785)
 //         api :data-theme-core (theme-token models + differ for `history/diff mode=data`, #1873)
+//     implementation :data-deviceframe-connector (device-art bezel compositing — post-capture)
+//       api :data-deviceframe-core
 //     implementation :lottie-preview-runtime (Compottie-backed kind=LOTTIE render path)
 //   plus :common-io (the Okio file-IO foundation those modules read/write through).
 val bundleRenderFunctionalTestPublishTargets =
@@ -138,6 +140,8 @@ val bundleRenderFunctionalTestPublishTargets =
     ":data-pseudolocale-core",
     ":data-displayfilter-connector",
     ":data-displayfilter-core",
+    ":data-deviceframe-connector",
+    ":data-deviceframe-core",
     ":daemon:core",
     ":renderer-xr-client",
     ":data-layoutinspector-core",

--- a/data/deviceframe/connector/src/main/kotlin/ee/schimke/composeai/daemon/DeviceArtSource.kt
+++ b/data/deviceframe/connector/src/main/kotlin/ee/schimke/composeai/daemon/DeviceArtSource.kt
@@ -24,9 +24,9 @@ fun interface DeviceArtSource {
  * The renderer deliberately does **no** network IO: it rides on the render subprocess classpath,
  * where an HTTP client like Ktor would drag a `kotlinx-coroutines` version that skews Compose
  * (`runBlockingK$default NoSuchMethodError` — see docs/RENDERER_COMPATIBILITY.md). Fetching is done
- * off the subprocess by `DeviceArtPrefetch` (Ktor/OkHttp) in the Gradle plugin, which fills this
- * cache before the render runs. A cache miss returns null, so framing degrades to "no frame" rather
- * than breaking the render.
+ * off the subprocess by `DeviceArtPrefetch` (OkHttp) in the Gradle plugin, which fills this cache
+ * before the render runs. A cache miss returns null, so framing degrades to "no frame" rather than
+ * breaking the render.
  */
 class CachedDeviceArtSource(
   cacheDir: String?,

--- a/docs/DEVICE_FRAMES.md
+++ b/docs/DEVICE_FRAMES.md
@@ -72,11 +72,12 @@ runs; pre-seed `cacheDir` with `<artId>/port_<resource>.png` files for fully off
   (shadow → back → screen, anti-aliased rounded-rect/circle clip → notch redraw → glare). Runs
   unchanged on the Robolectric host JVM and the Desktop renderer.
 - [`DeviceArtPrefetch`](../gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DeviceArtPrefetch.kt)
-  — downloads the bezel layers into the on-disk cache **before** the render runs, via **Ktor over
-  the OkHttp engine**, in the Gradle daemon JVM. It lives in the plugin, not the renderer, on
-  purpose: the render subprocess classpath can't carry Ktor's transitive `kotlinx-coroutines`
-  without skewing Compose (`runBlockingK$default NoSuchMethodError` — see
-  [RENDERER_COMPATIBILITY.md](RENDERER_COMPATIBILITY.md)).
+  — downloads the bezel layers into the on-disk cache **before** the render runs, via **OkHttp**
+  (synchronous), in the Gradle daemon JVM. It lives in the plugin, not the renderer, on purpose: an
+  HTTP client can't sit on the render subprocess classpath without skewing Compose's
+  `kotlinx-coroutines` (`runBlockingK$default NoSuchMethodError` — see
+  [RENDERER_COMPATIBILITY.md](RENDERER_COMPATIBILITY.md)). OkHttp (not Ktor) because Ktor 3.x needs
+  coroutines ≥ 1.10 while the Gradle daemon ships an older one.
 - [`CachedDeviceArtSource`](../data/deviceframe/connector/src/main/kotlin/ee/schimke/composeai/daemon/DeviceArtSource.kt)
   — the renderer-side layer source. Reads the prefetched cache only (no HTTP libs on the render
   classpath); a cache miss degrades to "no frame".

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -47,12 +47,11 @@ dependencies {
   // ASM walks the preview method's bytecode to extract @Composable call targets — ClassGraph only
   // surfaces annotations + signatures, not method-body invocations. Used by PreviewTargetInference.
   implementation(libs.asm)
-  // Ktor over the OkHttp engine — repo-standard HTTP stack — to prefetch device-art bezels into the
-  // renderer's disk cache (DeviceArtPrefetch). Lives in the plugin (Gradle daemon JVM), NOT the
-  // render subprocess: Ktor's transitive coroutines bump would skew Compose there
-  // (runBlockingK$default NoSuchMethodError; docs/RENDERER_COMPATIBILITY.md).
-  implementation(libs.ktor.client.core)
-  implementation(libs.ktor.client.okhttp)
+  // OkHttp directly (NOT Ktor) to prefetch device-art bezels into the renderer's disk cache
+  // (DeviceArtPrefetch). Ktor 3.x needs kotlinx-coroutines >= 1.10, but the Gradle daemon classpath
+  // ships an older coroutines and Ktor fails at runtime with `Job.invokeOnCompletion$default
+  // NoSuchMethodError`; OkHttp carries no coroutines dependency, so it runs cleanly here.
+  implementation(libs.okhttp)
   compileOnly("com.android.tools.build:gradle:${libs.versions.agp.get()}")
 
   testImplementation(libs.junit)

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DeviceArtPrefetch.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DeviceArtPrefetch.kt
@@ -1,20 +1,18 @@
 package ee.schimke.composeai.plugin
 
-import io.ktor.client.HttpClient
-import io.ktor.client.engine.okhttp.OkHttp
-import io.ktor.client.request.get
-import io.ktor.client.statement.readRawBytes
-import io.ktor.http.isSuccess
 import java.io.File
-import kotlinx.coroutines.runBlocking
+import java.time.Duration
+import okhttp3.OkHttpClient
+import okhttp3.Request
 import org.gradle.api.logging.Logger
 
 /**
  * Downloads device-art bezel layers into the on-disk cache the renderer reads
- * (`ee.schimke.composeai.daemon.CachedDeviceArtSource`). Runs in the Gradle daemon JVM via **Ktor
- * over the OkHttp engine** — the repo-standard HTTP stack — deliberately *off* the render
- * subprocess, whose classpath can't carry Ktor's `kotlinx-coroutines` without skewing Compose
- * (`runBlockingK$default NoSuchMethodError`; see docs/RENDERER_COMPATIBILITY.md).
+ * (`ee.schimke.composeai.daemon.CachedDeviceArtSource`). Runs in the Gradle daemon JVM via **OkHttp
+ * directly** — deliberately *off* the render subprocess (whose classpath can't carry an HTTP
+ * client's `kotlinx-coroutines` without skewing Compose). Not Ktor: Ktor 3.x needs coroutines >=
+ * 1.10, but the Gradle daemon ships an older coroutines and Ktor fails with
+ * `Job.invokeOnCompletion$default NoSuchMethodError`; OkHttp has no coroutines dependency.
  *
  * The frame → layers table is a small mirror of `DeviceArtCatalog` (the renderer-side source of
  * truth) kept here so the plugin build doesn't take a cross-build project dependency. Keep the two
@@ -61,27 +59,45 @@ object DeviceArtPrefetch {
   ) {
     val needed = artIds.filter { FRAMES.containsKey(it) }
     if (needed.isEmpty()) return
-    HttpClient(OkHttp).use { client ->
-      runBlocking {
-        for (artId in needed) {
-          for (resource in FRAMES.getValue(artId)) {
-            val dest = File(File(cacheDir, artId), "port_$resource.png")
-            if (dest.isFile && dest.length() > 0) continue
-            try {
-              val response = client.get("$baseUrl/$artId/port_$resource.png")
-              if (!response.status.isSuccess()) {
-                logger?.info(
-                  "device-art prefetch: HTTP ${response.status.value} for $artId/$resource"
-                )
-                continue
-              }
-              val bytes = response.readRawBytes()
-              dest.parentFile?.mkdirs()
-              dest.writeBytes(bytes)
-            } catch (t: Throwable) {
-              logger?.info("device-art prefetch failed for $artId/$resource: ${t.message}")
+    // OkHttp directly (synchronous), NOT Ktor: Ktor 3.x needs kotlinx-coroutines >= 1.10, but the
+    // Gradle daemon classpath ships an older coroutines and Ktor blows up with
+    // `Job.invokeOnCompletion$default NoSuchMethodError`. OkHttp has no coroutines dependency, so
+    // it
+    // works in both the Gradle JVM here and (if ever needed) the render subprocess.
+    val timeout = Duration.ofSeconds(20)
+    val client =
+      OkHttpClient.Builder()
+        .connectTimeout(timeout)
+        .readTimeout(timeout)
+        .callTimeout(timeout)
+        .retryOnConnectionFailure(true)
+        .build()
+    for (artId in needed) {
+      for (resource in FRAMES.getValue(artId)) {
+        val dest = File(File(cacheDir, artId), "port_$resource.png")
+        if (dest.isFile && dest.length() > 0) continue
+        try {
+          val request =
+            Request.Builder()
+              .url("$baseUrl/$artId/port_$resource.png")
+              .header("User-Agent", "compose-preview-device-frame")
+              .build()
+          client.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) {
+              logger?.warn("device-art prefetch: HTTP ${response.code} for $artId/$resource")
+              return@use
             }
+            val bytes = response.body.bytes()
+            dest.parentFile?.mkdirs()
+            dest.writeBytes(bytes)
           }
+        } catch (t: Throwable) {
+          // Visible by default: a silent prefetch failure means previews render un-framed with no
+          // hint why.
+          logger?.warn(
+            "device-art prefetch failed for $artId/$resource: " +
+              "${t.javaClass.simpleName}: ${t.message}"
+          )
         }
       }
     }

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -1192,7 +1192,11 @@ abstract class RobolectricRenderTestBase(
                                     (outputDir.parentFile ?: outputDir).resolve("data")
                                 DeviceFrameDataProducer.writeArtifacts(
                                     rootDir = frameDataDir,
-                                    previewId = preview.id,
+                                    // Key on the capture's file stem, not preview.id: a preview can
+                                    // emit several captures (manual-clock fan-out, TOP/END scroll,
+                                    // focus/animated) and preview.id would make later captures
+                                    // overwrite earlier framed siblings. Matches the desktop path.
+                                    previewId = outputFile.nameWithoutExtension,
                                     pngFile = outputFile,
                                     device = preview.params.device,
                                     settings = deviceFrame,

--- a/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRendererMain.kt
+++ b/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRendererMain.kt
@@ -373,7 +373,13 @@ fun main(args: Array<String>) {
       val deviceFrame = DeviceFrameConfig.fromSystemProperties()
       if (deviceFrame != null) {
         try {
-          val dataDir = (targetFile.parentFile?.parentFile ?: targetFile.parentFile).resolve("data")
+          // Resolve the previews-root `data/` dir. For a normal `renders/<id>.png` capture that's
+          // the sibling `data/`; for a data-product output already under `data/<kind>/<id>.png`
+          // (LONG/GIF scroll products) the grandparent IS `data/`, so don't nest a second `data/`.
+          val captureDir = targetFile.parentFile
+          val dataDir =
+            if (captureDir?.parentFile?.name == "data") captureDir.parentFile!!
+            else (captureDir?.parentFile ?: captureDir ?: targetFile).resolve("data")
           DeviceFrameDataProducer.writeArtifacts(
             rootDir = dataDir,
             previewId = targetFile.nameWithoutExtension,


### PR DESCRIPTION
Follow-up hotfix to #1981, which merged with a red **Bundle Render E2E** and a feature that didn't actually fetch bezels.

## What was broken on `main`

1. **CI red — `Bundle Render E2E`.** `renderer-desktop` now depends on `data-deviceframe-connector`, but `build.gradle.kts` didn't list the two new modules in `bundleRenderFunctionalTestPublishTargets`, so the desktop functional test couldn't resolve `data-deviceframe-connector:…-SNAPSHOT` from mavenLocal. → Added `:data-deviceframe-connector` + `:data-deviceframe-core` to the publish set.

2. **Prefetch never worked.** `DeviceArtPrefetch` used **Ktor**, which throws `Job.invokeOnCompletion$default NoSuchMethodError` in the Gradle daemon — its bundled `kotlinx-coroutines` is older than Ktor 3.x requires (the same class of skew that keeps Ktor off the render subprocess). Bezels were only ever present from a stale cache left by earlier direct-OkHttp code, so frames silently stopped being produced. → Switched the prefetch to **OkHttp directly** (no coroutines dependency) and bumped fetch-failure logging from `info` to `warn` so a silent failure can't hide again.

3. **Code review (Codex P2s).**
   - Desktop wrote framed artifacts to `…/data/data/<id>/` for scroll LONG/GIF products (their grandparent dir is already `data/`). Now resolves the previews-root `data/` correctly → `…/data/<stem>/`.
   - Android keyed every framed PNG on `preview.id`, so a preview with multiple captures (manual-clock fan-out, TOP/END scroll, focus/animated) overwrote earlier framed siblings. Now keyed on the capture file stem, matching desktop.

## Why direct OkHttp (not "OkHttp via Ktor")

Concrete `NoSuchMethodError` evidence shows Ktor 3.x can't run in **either** viable location here: the render subprocess (`runBlockingK$default`) *or* the Gradle daemon (`Job.invokeOnCompletion$default`). Both ship `kotlinx-coroutines` older than Ktor needs. OkHttp carries no coroutines dependency, so it's the only client that works in both. Comments/docs updated accordingly.

## Test plan

- `data-deviceframe-core` + `data-deviceframe-connector` unit tests pass; `ktfmtCheck` clean across touched modules; gradle-plugin and both renderers compile (Android `compileDebugKotlin` incl.).
- Both new modules `publishToMavenLocal` cleanly (fixes the functional-test resolution).
- **Cold-cache end-to-end**: `rm -rf` the device-art cache, then `:samples:cmp:composePreviewRenderAll -PcomposePreview.deviceFrame.device=wear_round --rerun-tasks` → prefetch logs no failures, **32 framed PNGs produced**, all under `data/<stem>/` (no `data/data/` nesting).


---
_Generated by [Claude Code](https://claude.ai/code/session_01VD9KvNxf4Np8wbf7K31bn6)_