### PR TITLE
feat(recording): assert.pixels golden-image check against a committed baseline (#1967)

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/RecordPreviewCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/RecordPreviewCommand.kt
@@ -71,6 +71,12 @@ class RecordPreviewCommand(args: List<String>) : Command(args) {
       .map { it.trim() }
       .filter { it.isNotEmpty() }
 
+  /**
+   * Directory holding committed baseline PNGs for `assert.pixels` events (issue #1967). Relative
+   * `inputText` baseline paths are resolved against it; defaults to the current directory.
+   */
+  private val baselineDir: String? = args.flagValue("--baseline-dir")
+
   override fun run() {
     val previewRef = requireFlag(previewRef, "--preview", "a preview reference")
     val scriptPath = requireFlag(scriptPath, "--script", "a session-script JSON file")
@@ -80,7 +86,7 @@ class RecordPreviewCommand(args: List<String>) : Command(args) {
     if (!scriptFile.isFile) {
       fail("script file not found: ${scriptFile.absolutePath}")
     }
-    val events = parseScript(scriptFile)
+    val events = resolveBaselines(parseScript(scriptFile))
     if (events.isEmpty()) {
       System.err.println(
         "compose-preview record: warning — script '$scriptPath' contained no events; " +
@@ -232,6 +238,23 @@ class RecordPreviewCommand(args: List<String>) : Command(args) {
         "could not parse script '${scriptFile.path}' as a JSON array of RecordingScriptEvent: " +
           (e.message ?: e.javaClass.simpleName)
       )
+    }
+  }
+
+  /**
+   * Resolve `assert.pixels` baseline paths (issue #1967). The baseline PNG path rides each event's
+   * existing `inputText` field; the daemon reads it off the shared local filesystem. Relative paths
+   * are made absolute against `--baseline-dir` (default: the current directory) so resolution is
+   * independent of the daemon's working directory. Absolute paths and non-pixel events pass through
+   * unchanged. (`"assert.pixels"` mirrors `RecordingScriptDataExtensions.ASSERT_PIXELS_EVENT`; the
+   * literal avoids pulling `:data-render-core` onto the CLI classpath.)
+   */
+  private fun resolveBaselines(events: List<RecordingScriptEvent>): List<RecordingScriptEvent> {
+    val base = File(baselineDir ?: ".")
+    return events.map { e ->
+      val path = e.inputText
+      if (e.kind != "assert.pixels" || path.isNullOrBlank() || File(path).isAbsolute) e
+      else e.copy(inputText = File(base, path).absolutePath)
     }
   }
 

--- a/daemon/desktop/build.gradle.kts
+++ b/daemon/desktop/build.gradle.kts
@@ -50,6 +50,11 @@ dependencies {
   // core module re-exposes kotlinx-serialization-json as `api`, so we don't
   // re-declare it here.
   implementation(project(":daemon:core"))
+  // `assert.pixels` (issue #1967) reuses the `PixelDiff` golden-image comparator.
+  // `:daemon:harness`'s
+  // production classpath depends only on `:daemon:core` + `:common-io`, so this edge introduces no
+  // cycle (harness's dependency on `:daemon:desktop` is test-only).
+  implementation(project(":daemon:harness"))
   implementation(project(":common-io"))
   implementation(project(":data-render-connector"))
   implementation(project(":data-history-connector"))

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSession.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSession.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.scene.ComposeScenePointer
 import ee.schimke.composeai.cli.AccessibilityNode
 import ee.schimke.composeai.cli.TalkBackOverlayFrames
 import ee.schimke.composeai.cli.TalkBackTraversal
+import ee.schimke.composeai.daemon.harness.PixelDiff
 import ee.schimke.composeai.daemon.protocol.RecordingFormat
 import ee.schimke.composeai.daemon.protocol.RecordingInputParams
 import ee.schimke.composeai.daemon.protocol.RecordingScriptEvent
@@ -207,19 +208,35 @@ class DesktopRecordingSession(
     val startNs = System.nanoTime()
     var nextEventIdx = 0
     val evidence = mutableListOf<RecordingScriptEvidence>()
+    // `assert.pixels` events are evaluated in a post-loop pass: the frame they compare against is
+    // the one rendered *after* this dispatch pass, so we can't diff it while dispatching. Each
+    // pending entry reserves its evidence slot (placeholder below) so timeline order is preserved.
+    val pendingPixels = mutableListOf<PendingPixelAssert>()
     for (frameIndex in 0 until totalFrames) {
       val tNanos: Long = frameIndex.toLong() * 1_000_000_000L / fps.toLong()
       val tMs: Long = tNanos / 1_000_000L
 
       while (nextEventIdx < sortedEvents.size && sortedEvents[nextEventIdx].tMs <= tMs) {
         val e = sortedEvents[nextEventIdx]
-        val ctx = SimpleRecordingDispatchContext(tNanos = tNanos, tMs = tMs)
-        evidence.add(scriptHandlers.dispatch(e, ctx))
+        if (e.kind == RecordingScriptDataExtensions.ASSERT_PIXELS_EVENT) {
+          // Defer to the post-loop diff. The placeholder is FAILED so a (bug) skipped finalization
+          // fails closed rather than reporting a false pass.
+          pendingPixels.add(PendingPixelAssert(evidence.size, frameIndex, e))
+          evidence.add(failedEvidence(e, "assert.pixels: not evaluated"))
+        } else {
+          val ctx = SimpleRecordingDispatchContext(tNanos = tNanos, tMs = tMs)
+          evidence.add(scriptHandlers.dispatch(e, ctx))
+        }
         nextEventIdx++
       }
 
       val image = state.scene.render(nanoTime = tNanos)
       writeFramePng(image, frameIndex, virtualTimeMs = tMs)
+    }
+    // Post-loop: every frame is now on disk, so diff each deferred assert.pixels against its
+    // baseline.
+    for (p in pendingPixels) {
+      evidence[p.evidenceIndex] = evaluatePixelAssert(p.event, p.frameIndex)
     }
     val tookMs = (System.nanoTime() - startNs) / 1_000_000L
     System.err.println(
@@ -235,6 +252,60 @@ class DesktopRecordingSession(
       frameHeightPx = frameHeightPx,
       scriptEvents = evidence,
     )
+  }
+
+  /**
+   * A deferred `assert.pixels` event (issue #1967): the diff against the recorded frame at
+   * [frameIndex] is run after the playback loop has written every frame, and the result replaces
+   * the placeholder evidence at [evidenceIndex] so the event keeps its timeline position.
+   */
+  private data class PendingPixelAssert(
+    val evidenceIndex: Int,
+    val frameIndex: Int,
+    val event: RecordingScriptEvent,
+  )
+
+  /**
+   * Golden-image assertion (issue #1967): diff the recorded `frame-NNNNN.png` for [frameIndex]
+   * against the committed baseline PNG named by the event's `inputText` (resolved CLI-side against
+   * `--baseline-dir`). The pure verdict lives in [pixelAssertVerdict] (reusing `:daemon:harness`'s
+   * `PixelDiff`); this wrapper does the file IO, turns the verdict into `RecordingScriptEvidence`,
+   * and on failure writes actual/expected/diff PNGs next to the encoded output so the drift is
+   * inspectable without re-running.
+   */
+  private fun evaluatePixelAssert(
+    event: RecordingScriptEvent,
+    frameIndex: Int,
+  ): RecordingScriptEvidence {
+    val baselinePath =
+      event.inputText
+        ?: return failedEvidence(
+          event,
+          "assert.pixels requires the baseline PNG path in the 'inputText' field",
+        )
+    val baselineBytes = File(baselinePath).takeIf { it.isFile }?.readBytes()
+    val frameFile = File(framesDir, "frame-${"%05d".format(frameIndex)}.png")
+    val actualBytes = frameFile.takeIf { it.isFile }?.readBytes()
+    return when (val verdict = pixelAssertVerdict(actualBytes, baselineBytes)) {
+      AssertionVerdict.Passed ->
+        appliedEvidence(event, "assert.pixels matched baseline '${File(baselinePath).name}'")
+      is AssertionVerdict.Failed -> {
+        if (actualBytes != null && baselineBytes != null) {
+          // Best-effort diagnostics — never let an artefact-write failure mask the real verdict.
+          try {
+            val diffDir =
+              File(encodedDir, "pixel-diff-${"%05d".format(frameIndex)}").apply { mkdirs() }
+            PixelDiff.writeDiffArtefacts(actualBytes, baselineBytes, diffDir)
+          } catch (t: Throwable) {
+            System.err.println(
+              "compose-ai-daemon: assert.pixels diff-artefact write failed for frame " +
+                "$frameIndex: ${t.javaClass.simpleName}: ${t.message}"
+            )
+          }
+        }
+        failedEvidence(event, verdict.reason)
+      }
+    }
   }
 
   /**

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/PixelAssertions.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/PixelAssertions.kt
@@ -1,0 +1,39 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.harness.PixelDiff
+import ee.schimke.composeai.daemon.harness.PixelDiffTolerance
+
+/**
+ * Pure verdict logic for the `assert.pixels` recording event (issue #1967): diff a recorded frame
+ * against a committed baseline PNG and decide pass/fail, reusing the [PixelDiff] comparator that
+ * the preview-review pipeline already uses. Kept free of file IO and the recording session so it's
+ * unit-testable from raw PNG bytes — the session ([DesktopRecordingSession]) handles reading the
+ * frame + baseline off disk and turning this verdict into `RecordingScriptEvidence`.
+ *
+ * Fail-closed: a missing baseline or a missing recorded frame is a [AssertionVerdict.Failed], never
+ * a silent pass — the script asked to pin pixels, so an un-runnable check is a failure. `PixelDiff`
+ * itself reports a dimension mismatch (different-sized baseline) as a non-`ok` result, so that path
+ * also fails with a clear message.
+ */
+fun pixelAssertVerdict(
+  actualPng: ByteArray?,
+  baselinePng: ByteArray?,
+  tolerance: PixelDiffTolerance = PixelDiffTolerance.DEFAULT,
+): AssertionVerdict {
+  if (baselinePng == null) {
+    return AssertionVerdict.Failed(
+      "assert.pixels: baseline PNG not found (set inputText / --baseline-dir)"
+    )
+  }
+  if (actualPng == null) {
+    return AssertionVerdict.Failed("assert.pixels: no recorded frame was captured for this tMs")
+  }
+  val result = PixelDiff.compare(actualPng, baselinePng, tolerance)
+  if (result.ok) {
+    return AssertionVerdict.Passed
+  }
+  return AssertionVerdict.Failed(
+    "assert.pixels: ${result.message} " +
+      "(offending=${result.offendingPixelCount}/${result.totalPixels}, maxDelta=${result.maxDelta})"
+  )
+}

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSessionTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSessionTest.kt
@@ -184,6 +184,101 @@ class DesktopRecordingSessionTest {
     }
   }
 
+  /**
+   * Issue #1967 — `assert.pixels` diffs the recorded frame at its `tMs` against a committed
+   * baseline PNG (path in `inputText`), reusing `PixelDiff`. Captures a baseline from a first
+   * deterministic render, then asserts: a matching baseline → APPLIED; a same-size but
+   * different-coloured baseline → FAILED with a pixel-diff message. The diff runs in the session's
+   * post-playback pass.
+   */
+  @Test
+  fun assert_pixels_matches_baseline_and_fails_on_drift() {
+    val outputDir = tempFolder.newFolder("assert-pixels-renders")
+    val recordingsRoot = tempFolder.newFolder("assert-pixels-recordings-root")
+    savedRecordingsDir = System.getProperty(DesktopHost.RECORDINGS_DIR_PROP)
+    System.setProperty(DesktopHost.RECORDINGS_DIR_PROP, recordingsRoot.absolutePath)
+
+    val engine = RenderEngine(outputDir = outputDir)
+    val host =
+      DesktopHost(
+        engine = engine,
+        previewSpecResolver = { previewId ->
+          if (previewId == FIXTURE_PREVIEW_ID) {
+            RenderSpec(
+              className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+              functionName = "TristateClickSquare",
+              widthPx = COMPONENT_WIDTH_PX,
+              heightPx = COMPONENT_HEIGHT_PX,
+              density = 1.0f,
+              outputBaseName = "tristate-click-square",
+            )
+          } else null
+        },
+      )
+    host.start()
+    try {
+      val cl =
+        DesktopRecordingSessionTest::class.java.classLoader ?: ClassLoader.getSystemClassLoader()
+      val baselineDir = tempFolder.newFolder("baselines")
+
+      // Phase A: capture frame 0 (deterministic — no clicks → state 0) as the golden baseline.
+      val baselineFile = File(baselineDir, "frame0.png")
+      host.acquireRecordingSession(FIXTURE_PREVIEW_ID, "rec-baseline", cl, FPS, 1.0f, null).use { s
+        ->
+        s.postScript(listOf(RecordingScriptEvent(tMs = 0L, kind = "recording.probe")))
+        val r = s.stop()
+        File(r.framesDir, "frame-00000.png").copyTo(baselineFile, overwrite = true)
+      }
+      assertTrue("baseline frame captured", baselineFile.isFile && baselineFile.length() > 0)
+
+      // A same-dimension but different-coloured baseline for the failure case.
+      val wrongBaseline = File(baselineDir, "wrong.png")
+      ImageIO.write(
+        java.awt.image
+          .BufferedImage(
+            COMPONENT_WIDTH_PX,
+            COMPONENT_HEIGHT_PX,
+            java.awt.image.BufferedImage.TYPE_INT_RGB,
+          )
+          .apply { for (y in 0 until height) for (x in 0 until width) setRGB(x, y, 0x123456) },
+        "png",
+        wrongBaseline,
+      )
+
+      // Phase B: assert.pixels against the matching baseline → APPLIED.
+      val pass = recordSingleAssertPixels(host, cl, "rec-pass", baselineFile.absolutePath)
+      assertEquals(
+        "matching baseline should pass; got ${pass.status} / ${pass.message}",
+        RecordingScriptEventStatus.APPLIED,
+        pass.status,
+      )
+
+      // Phase C: assert.pixels against the mismatching baseline → FAILED with a pixel-diff message.
+      val fail = recordSingleAssertPixels(host, cl, "rec-fail", wrongBaseline.absolutePath)
+      assertEquals(
+        "drifted baseline should fail; got ${fail.status} / ${fail.message}",
+        RecordingScriptEventStatus.FAILED,
+        fail.status,
+      )
+      assertTrue(
+        "failure message should name the assertion; got ${fail.message}",
+        fail.message?.contains("assert.pixels") == true,
+      )
+
+      // A missing baseline path fails closed rather than silently passing.
+      val missing =
+        recordSingleAssertPixels(
+          host,
+          cl,
+          "rec-missing",
+          File(baselineDir, "nope.png").absolutePath,
+        )
+      assertEquals(RecordingScriptEventStatus.FAILED, missing.status)
+    } finally {
+      host.shutdown()
+    }
+  }
+
   @Test
   fun scale_changes_output_frame_size_but_not_pointer_coords() {
     val outputDir = tempFolder.newFolder("scale-engine-renders")
@@ -1033,6 +1128,26 @@ class DesktopRecordingSessionTest {
       host.shutdown()
     }
   }
+
+  /**
+   * Drive a one-event `assert.pixels` recording against the fixture and return the single
+   * assertion's evidence. The baseline path rides the event's `inputText` (issue #1967), as the CLI
+   * would resolve it against `--baseline-dir`.
+   */
+  private fun recordSingleAssertPixels(
+    host: DesktopHost,
+    classLoader: ClassLoader,
+    recordingId: String,
+    baselinePath: String,
+  ): ee.schimke.composeai.daemon.protocol.RecordingScriptEvidence =
+    host
+      .acquireRecordingSession(FIXTURE_PREVIEW_ID, recordingId, classLoader, FPS, 1.0f, null)
+      .use { s ->
+        s.postScript(
+          listOf(RecordingScriptEvent(tMs = 0L, kind = "assert.pixels", inputText = baselinePath))
+        )
+        s.stop().scriptEvents.single { it.kind == "assert.pixels" }
+      }
 
   private fun readPng(file: File): java.awt.image.BufferedImage {
     assertTrue("rendered PNG must exist on disk: ${file.absolutePath}", file.exists())

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/PixelAssertionsTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/PixelAssertionsTest.kt
@@ -1,0 +1,63 @@
+package ee.schimke.composeai.daemon
+
+import java.awt.image.BufferedImage
+import java.io.ByteArrayOutputStream
+import javax.imageio.ImageIO
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for the pure [pixelAssertVerdict] golden-image verdict logic (issue #1967) — the part
+ * of the `assert.pixels` recording handler that doesn't need a held scene or file IO. The wired
+ * handler (deferred post-loop diff against the frame the session wrote) is covered by the
+ * integration test in `DesktopRecordingSessionTest`.
+ */
+class PixelAssertionsTest {
+
+  @Test
+  fun fails_closed_when_baseline_missing() {
+    val verdict = pixelAssertVerdict(actualPng = solidPng(8, 8, 0xFFFFFF), baselinePng = null)
+    assertTrue(verdict is AssertionVerdict.Failed)
+    assertTrue((verdict as AssertionVerdict.Failed).reason.contains("baseline"))
+  }
+
+  @Test
+  fun fails_closed_when_recorded_frame_missing() {
+    val verdict = pixelAssertVerdict(actualPng = null, baselinePng = solidPng(8, 8, 0xFFFFFF))
+    assertTrue(verdict is AssertionVerdict.Failed)
+    assertTrue((verdict as AssertionVerdict.Failed).reason.contains("frame"))
+  }
+
+  @Test
+  fun passes_on_identical_frames() {
+    val a = solidPng(8, 8, 0x3366CC)
+    val b = solidPng(8, 8, 0x3366CC)
+    assertEquals(AssertionVerdict.Passed, pixelAssertVerdict(a, b))
+  }
+
+  @Test
+  fun fails_on_drift_beyond_tolerance_and_reports_delta() {
+    // Solid black vs solid white: every channel maxed out, far beyond PixelDiff's default cap.
+    val verdict = pixelAssertVerdict(solidPng(8, 8, 0x000000), solidPng(8, 8, 0xFFFFFF))
+    assertTrue(verdict is AssertionVerdict.Failed)
+    val reason = (verdict as AssertionVerdict.Failed).reason
+    assertTrue("reports maxDelta; got $reason", reason.contains("maxDelta"))
+  }
+
+  @Test
+  fun fails_on_dimension_mismatch() {
+    val verdict = pixelAssertVerdict(solidPng(4, 4, 0xFFFFFF), solidPng(8, 8, 0xFFFFFF))
+    assertTrue(verdict is AssertionVerdict.Failed)
+    assertTrue((verdict as AssertionVerdict.Failed).reason.contains("dimension"))
+  }
+
+  private fun solidPng(width: Int, height: Int, rgb: Int): ByteArray {
+    val img = BufferedImage(width, height, BufferedImage.TYPE_INT_RGB)
+    for (y in 0 until height) for (x in 0 until width) img.setRGB(x, y, rgb)
+    return ByteArrayOutputStream().use {
+      ImageIO.write(img, "png", it)
+      it.toByteArray()
+    }
+  }
+}

--- a/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/extensions/DataExtensionPlan.kt
+++ b/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/extensions/DataExtensionPlan.kt
@@ -288,6 +288,15 @@ object RecordingScriptDataExtensions {
   const val ASSERT_A11Y_EVENT: String = "assert.a11y"
 
   /**
+   * `assert.pixels` — golden-image assertion (issue #1967). Diffs the recorded frame at the event's
+   * `tMs` against a committed baseline PNG and fails the recording when the diff exceeds tolerance,
+   * reusing the `PixelDiff` comparator from `:daemon:harness`. The baseline path rides the event's
+   * existing `inputText` field (no new wire field), resolved by the CLI against `--baseline-dir`.
+   * Desktop-only today (it reads the frames the desktop session wrote); Android is a follow-up.
+   */
+  const val ASSERT_PIXELS_EVENT: String = "assert.pixels"
+
+  /**
    * `recording.probe` descriptor with `supported = true`. Returned from each
    * `RenderHost.recordingScriptEventDescriptors()` that wires a real probe handler in its
    * recording-session registry (today: both desktop and android backends).
@@ -338,6 +347,14 @@ object RecordingScriptDataExtensions {
             summary =
               "Fails the recording unless the target node's text equals the expected " +
                 "string (carried in the event's inputText field).",
+            supported = true,
+          ),
+          RecordingScriptEventDescriptor(
+            id = ASSERT_PIXELS_EVENT,
+            displayName = "Assert pixels",
+            summary =
+              "Fails the recording unless the recorded frame at this tMs matches the baseline " +
+                "PNG (path in the event's inputText field) within PixelDiff tolerance.",
             supported = true,
           ),
         ),

--- a/docs/daemon/RECORDING-ASSERTIONS.md
+++ b/docs/daemon/RECORDING-ASSERTIONS.md
@@ -17,6 +17,11 @@ event's `tMs`:
 | `assert.notVisible` | the `target` matches no node          | the target matches ≥ 1 node         |
 | `assert.textEquals` | the `target` resolves and its text == the expected string | the text differs, or the target matches 0 / >1 nodes |
 | `assert.a11y`       | the held scene has no ATF findings at the threshold | an ATF error (or warning, at `warnings`) is present |
+| `assert.pixels`     | the recorded frame at this `tMs` matches the baseline PNG within tolerance | the frame drifts beyond tolerance, or the baseline / frame is missing |
+
+`assert.pixels` carries no `target` either — it pins the **rendered frame** against a committed
+baseline PNG whose path rides the existing `inputText` field. See
+[Pixel assertions](#pixel-assertions-assertpixels) below.
 
 `assert.a11y` carries no `target` — it checks the **whole held scene**. Its severity threshold rides
 the existing `inputText` field (`errors`, the default, or `warnings`); `errors` fails only on ATF
@@ -59,10 +64,10 @@ recording as a gating check.
 
 ### Backend support
 
-| Backend | `assert.visible` / `assert.notVisible` | `assert.textEquals` | `assert.a11y` |
-|---------|----------------------------------------|---------------------|---------------|
-| Desktop | ✅ (resolved against the live unmerged semantics tree) | ✅ | ❌ — desktop a11y is overlay-only (no ATF findings); not advertised |
-| Android | ✅ (resolved against the probe-semantics snapshot, by `testTag` only) | ❌ — `record_preview` rejects it | ✅ (ATF against the held View hierarchy) |
+| Backend | `assert.visible` / `assert.notVisible` | `assert.textEquals` | `assert.a11y` | `assert.pixels` |
+|---------|----------------------------------------|---------------------|---------------|-----------------|
+| Desktop | ✅ (resolved against the live unmerged semantics tree) | ✅ | ❌ — desktop a11y is overlay-only (no ATF findings); not advertised | ✅ (diffs the frame it wrote against the baseline) |
+| Android | ✅ (resolved against the probe-semantics snapshot, by `testTag` only) | ❌ — `record_preview` rejects it | ✅ (ATF against the held View hierarchy) | ❌ — not advertised yet (follow-up) |
 
 Desktop advertises `RecordingScriptDataExtensions.assertionDescriptor` (all three) and resolves via
 `state.scene.composeSemanticsRoot()`. Android (issue #1964) advertises the narrower
@@ -107,6 +112,45 @@ event's `tMs`, so the check is coupled to the rendered scene rather than to a se
   `captureProbeSemantics`. The verdict (`evaluateA11yAssertion`) is pure and lives in `:daemon:core`,
   so it's unit-tested without a Robolectric scene.
 
+### Pixel assertions (`assert.pixels`)
+
+`assert.pixels` (issue #1967) gates a recording on a **golden image** — the Robo / screenshot-test
+"diff against a baseline" model, applied to a recorded frame. It diffs the frame the recording wrote
+at the event's `tMs` against a committed baseline PNG, failing when the diff exceeds tolerance.
+
+```json
+[
+  { "tMs": 0,    "kind": "input.click",   "target": { "testTag": "submit" } },
+  { "tMs": 500,  "kind": "assert.pixels", "inputText": "submitted.png" }
+]
+```
+
+```
+compose-preview record --preview MyForm --script form.json --out form.gif --baseline-dir baselines/
+# diffs frame@500ms against baselines/submitted.png; exits 2 if it drifts beyond tolerance
+```
+
+- **Reuses `PixelDiff`.** The comparison is the same `PixelDiff` comparator (per-pixel +
+  aggregate-fraction + absolute-cap tolerance) the preview-review pipeline uses — no new comparator.
+  Tolerance is `PixelDiffTolerance.DEFAULT` today; a per-event override is a follow-up. A baseline
+  whose dimensions differ from the frame fails as a dimension mismatch.
+- **Baseline path rides `inputText`** (no new wire field, like `assert.textEquals`). The CLI's
+  `--baseline-dir` makes relative paths absolute before the script is posted, so resolution is
+  independent of the daemon's working directory; the daemon reads the PNG off the shared local
+  filesystem.
+- **Evaluated in a post-playback pass.** The frame an `assert.pixels` event compares is rendered
+  *after* the event is dispatched, so the desktop session defers the diff: it reserves the evidence
+  slot during dispatch (a placeholder that fails closed) and runs the diff once every frame is on
+  disk. On failure it writes `actual.png` / `expected.png` / `diff.png` next to the encoded output so
+  the drift is inspectable without re-running.
+- **Fail-closed.** A missing baseline, a missing recorded frame, or a dimension mismatch is `FAILED`,
+  never a silent pass — the script asked to pin pixels.
+- **Desktop-only today.** The desktop session reads the frame PNGs it writes; the Android backend
+  writes frames the same way, so extending `assert.pixels` there is a mechanical follow-up, but it's
+  not advertised yet so `record_preview` rejects it on Android. The pure verdict (`pixelAssertVerdict`)
+  lives in `:daemon:desktop` (it needs `PixelDiff` from `:daemon:harness`, which `:daemon:core` can't
+  depend on) and is unit-tested from raw PNG bytes.
+
 ## What we borrowed (and what we deliberately didn't)
 
 Comparison with the emulator-driven UI-test tools this is modelled on:
@@ -118,6 +162,7 @@ Comparison with the emulator-driven UI-test tools this is modelled on:
 | Deterministic virtual clock (vs. emulator wall-clock + idling resources) | Already present | Recordings tick on `frameIndex * 1e9 / fps`; no flakiness, no `IdlingResource` needed — the scene can't run ahead of the script. |
 | Same artifact for human review + machine gate (Maestro recordings, Robo crawl reports) | **Shipped** | One GIF/APNG/MP4 doubles as the visual record and, via assertions, the pass/fail signal. |
 | Assert exact text / value (Maestro `assertTrue`, Espresso `withText`) | **Shipped** | `assert.textEquals` compares the resolved node's `text` to the expected string in the existing `inputText` field. |
+| Golden-image / screenshot diff (Robo, Paparazzi/Roborazzi) | **Shipped (desktop)** | `assert.pixels` diffs the recorded frame against a committed baseline PNG via `PixelDiff`. |
 | Crawl / auto-explore (Robo, Monkey) | Roadmap, narrow | A preview is a single held scene, not an app graph — "crawl" reduces to "fan a tap over every clickable semantics node and snapshot," which the probe machinery could drive. Useful as a smoke check, not a crawl. |
 
 ### Other emulator-test techniques worth borrowing
@@ -137,25 +182,31 @@ land (each is a separate follow-up, not in this PR):
   [above](#accessibility-assertions-asserta11y). Runs ATF against the held View hierarchy and fails
   the recording on findings at the chosen threshold. Desktop has no ATF backend, so it stays
   Android-only for now.
-- **Pixel / golden assertions** — Robo and screenshot tests diff against a baseline. The preview
-  pipeline already has the visual-diff bot + `baselines.json`; an `assert.pixels` event diffing the
-  current frame against a committed PNG would fold golden-image checks into the same script.
+- **Pixel / golden assertions** — **Shipped (desktop)** as `assert.pixels`, see
+  [above](#pixel-assertions-assertpixels). Diffs the recorded frame against a committed baseline PNG
+  via `PixelDiff`. Android is a mechanical follow-up (it writes frames the same way; just not
+  advertised yet).
 
 ## Code map
 
 - Status + evidence: `RecordingScriptEventStatus.FAILED`, `failedEvidence(...)`
   (`daemon/core/.../RecordingScriptHandlerRegistry.kt`).
 - Event kinds + descriptors: `RecordingScriptDataExtensions.ASSERT_VISIBLE_EVENT` /
-  `ASSERT_NOT_VISIBLE_EVENT` / `ASSERT_TEXT_EQUALS_EVENT` / `ASSERT_A11Y_EVENT`; `assertionDescriptor`
-  (desktop, all three text/visibility), `assertionVisibilityDescriptor` (Android, visibility only),
-  and `assertionA11yDescriptor` (Android, a11y) (`data/render/core/.../DataExtensionPlan.kt`).
-- Verdict logic (pure, unit-tested, shared by both backends): `evaluateVisibilityAssertion` /
-  `evaluateTextEqualsAssertion` / `resolvedNodeText` / `evaluateA11yAssertion` + `A11yAssertThreshold`
-  (`daemon/core/.../RecordingAssertions.kt`).
+  `ASSERT_NOT_VISIBLE_EVENT` / `ASSERT_TEXT_EQUALS_EVENT` / `ASSERT_A11Y_EVENT` / `ASSERT_PIXELS_EVENT`;
+  `assertionDescriptor` (desktop — visibility, text, **and pixels**), `assertionVisibilityDescriptor`
+  (Android, visibility only), and `assertionA11yDescriptor` (Android, a11y)
+  (`data/render/core/.../DataExtensionPlan.kt`).
+- Verdict logic (pure, unit-tested): `evaluateVisibilityAssertion` / `evaluateTextEqualsAssertion` /
+  `resolvedNodeText` / `evaluateA11yAssertion` + `A11yAssertThreshold`
+  (`daemon/core/.../RecordingAssertions.kt`); `pixelAssertVerdict` (golden-image, reuses `PixelDiff`)
+  (`daemon/desktop/.../PixelAssertions.kt`).
 - Handler wiring: `DesktopRecordingSession.assertVisibilityHandler` /
   `assertTextEqualsHandler` (advertised by `DesktopHost`); `AndroidRecordingSession`'s
   `assertVisibilityHandler` resolving against `captureProbeSemantics()` and `assertA11yHandler`
   resolving against `captureA11yFindings()` — the latter bridged by the `CaptureA11yFindings`
   interactive command running `AccessibilityChecker.check` sandbox-side in `RobolectricHost`
   (advertised by `RobolectricHost`).
-- CLI gate: `RecordPreviewCommand` — fails any non-`APPLIED` `assert.*` evidence, prints each, exits 2.
+- Pixel-assert wiring: `DesktopRecordingSession.evaluatePixelAssert` (post-playback diff of the
+  written `frame-NNNNN.png` against the baseline, writes `actual/expected/diff.png` on failure).
+- CLI gate: `RecordPreviewCommand` — `--baseline-dir` resolves `assert.pixels` baseline paths; fails
+  any non-`APPLIED` `assert.*` evidence, prints each, exits 2.


### PR DESCRIPTION
## Summary

Closes #1967 with an `assert.pixels` scripted-recording event (desktop) — the Robo / screenshot-test "diff against a baseline" model folded into a recording script. It diffs the recorded frame at the event's `tMs` against a committed baseline PNG and fails the recording when the diff exceeds tolerance.

```json
[
  { "tMs": 0,    "kind": "input.click",   "target": { "testTag": "submit" } },
  { "tMs": 500,  "kind": "assert.pixels", "inputText": "submitted.png" }
]
```

```
compose-preview record --preview MyForm --script form.json --out form.gif --baseline-dir baselines/
# diffs frame@500ms against baselines/submitted.png; exits 2 if it drifts beyond tolerance
```

- **Reuses `PixelDiff`** from `:daemon:harness` (per-pixel + aggregate-fraction + absolute-cap tolerance, `PixelDiffTolerance.DEFAULT`) — no new comparator. A dimension mismatch fails as such. Per-event tolerance override is a follow-up.
- **Baseline path rides the existing `inputText` field** (no new wire field, mirroring `assert.textEquals`). The CLI's new `--baseline-dir` makes relative paths absolute before posting, so resolution is independent of the daemon's cwd; the daemon reads the PNG off the shared local filesystem.
- **Post-playback diff.** The frame an `assert.pixels` event compares is rendered *after* the event is dispatched, so the desktop session defers: it reserves the evidence slot during dispatch (a placeholder that **fails closed**) and runs the diff once every frame is on disk. On failure it writes `actual.png` / `expected.png` / `diff.png` next to the encoded output so the drift is inspectable without re-running.
- **Fail-closed** — a missing baseline, missing frame, or dimension mismatch is `FAILED`, never a silent pass.
- **Desktop-only today.** The session reads the frames it writes; the Android backend writes frames the same way, so it's a mechanical follow-up, but it's not advertised yet so `record_preview` rejects `assert.pixels` on Android.

The pure verdict (`pixelAssertVerdict`) lives in `:daemon:desktop` — it needs `PixelDiff`, which `:daemon:core` can't depend on. Wiring `:daemon:desktop → :daemon:harness` introduces **no cycle**: harness's production classpath depends only on `:daemon:core` + `:common-io` (its dependency on `:daemon:desktop` is test-only).

## Test plan

- `:daemon:desktop:test --tests "*PixelAssertionsTest*"` — pure unit tests for `pixelAssertVerdict`: identical frames pass; drift beyond tolerance fails with a `maxDelta` message; missing baseline / missing frame / dimension mismatch each fail closed. ✅
- `:daemon:desktop:test --tests "*DesktopRecordingSessionTest.assert_pixels_matches_baseline*"` — integration: records the fixture, captures frame 0 as a baseline, then asserts match→`APPLIED`, same-size-but-different-colour baseline→`FAILED` (pixel-diff message), missing path→`FAILED`. ✅
- `ktfmtCheck` + clean compiles of `:data-render-core`, `:daemon:desktop`, `:cli`. ✅

Non-visual change to the renderer surfaces (assertion plumbing + CLI flag + tests + docs); the new diagnostic `diff.png` is produced by the existing `PixelDiff.writeDiffArtefacts`, not a new rendered surface, so no before/after preview capture applies.

---
_Generated by [Claude Code](https://claude.ai/code/session_015XGE7oXG27kAaotihUDCag)_