### PR TITLE
feat(cli): serve streamed-frame WebSocket lane — snapshot + live daemon streaming

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -145,6 +145,8 @@ dependencies {
   // so the strict slf4j pin in the `constraints {}` block below covers the server too.
   implementation(libs.ktor.server.core)
   implementation(libs.ktor.server.cio)
+  // WebSockets plugin: the `serve` streamed-frame lane (`/ws/{id}`) — tier-2 streaming spike.
+  implementation(libs.ktor.server.websockets)
 
   // Bundle the MCP server so `compose-preview mcp serve` can invoke it in-process —
   // the consumer install story stays a single tarball + a single launcher.

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -77,18 +77,35 @@ class ServeHttpServer(
                 call.request.queryParameters[key]?.let { key to it }
               }
               .toMap()
-          val session =
-            ServeStreamSession(renderHost, previewId, initialOverrides) { text ->
-              // Non-suspending hand-off to the socket; drop frames a slow client can't keep up
-              // with.
-              outgoing.trySend(Frame.Text(text))
+          // Non-suspending hand-off to the socket; drop frames a slow client can't keep up with.
+          val send: (String) -> Unit = { text -> outgoing.trySend(Frame.Text(text)) }
+          // Prefer the daemon's live stream lane (frames pushed, input dispatched); fall back to
+          // the
+          // snapshot re-render lane when the backend doesn't support streaming.
+          val live =
+            withContext(Dispatchers.IO) {
+              ServeLiveSession.tryStart(renderHost, previewId, initialOverrides, send)
             }
-          // Renders block (renderNow + await); keep them off the socket's event-loop thread.
-          withContext(Dispatchers.IO) { session.onOpen() }
-          for (frame in incoming) {
-            if (frame is Frame.Text) {
-              val text = frame.readText()
-              withContext(Dispatchers.IO) { session.onClientMessage(text) }
+          if (live != null) {
+            try {
+              for (frame in incoming) {
+                if (frame is Frame.Text) {
+                  val text = frame.readText()
+                  withContext(Dispatchers.IO) { live.onClientMessage(text) }
+                }
+              }
+            } finally {
+              withContext(Dispatchers.IO) { live.close() }
+            }
+          } else {
+            val session = ServeStreamSession(renderHost, previewId, initialOverrides, send)
+            // Renders block (renderNow + await); keep them off the socket's event-loop thread.
+            withContext(Dispatchers.IO) { session.onOpen() }
+            for (frame in incoming) {
+              if (frame is Frame.Text) {
+                val text = frame.readText()
+                withContext(Dispatchers.IO) { session.onClientMessage(text) }
+              }
             }
           }
         }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -3,6 +3,7 @@ package ee.schimke.composeai.cli.serve
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.install
 import io.ktor.server.cio.CIO
 import io.ktor.server.engine.EmbeddedServer
 import io.ktor.server.engine.embeddedServer
@@ -11,6 +12,12 @@ import io.ktor.server.response.respondText
 import io.ktor.server.routing.RoutingContext
 import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
+import io.ktor.server.websocket.WebSockets
+import io.ktor.server.websocket.webSocket
+import io.ktor.websocket.CloseReason
+import io.ktor.websocket.Frame
+import io.ktor.websocket.close
+import io.ktor.websocket.readText
 import java.net.InetAddress
 import java.net.ServerSocket
 import kotlinx.coroutines.Dispatchers
@@ -26,7 +33,8 @@ import kotlinx.serialization.json.Json
  *
  * Endpoints (all token-gated except `/healthz`):
  * - `GET /` landing page, `GET /p/{id}` viewer page,
- * - `GET /render/{id}.png` PNG bytes, `GET /api/previews` JSON, `GET /healthz` liveness.
+ * - `GET /render/{id}.png` PNG bytes, `GET /api/previews` JSON, `GET /healthz` liveness,
+ * - `GET /bundle.zip` portable bundle, `WS /ws/{id}` streamed-frame lane (tier-2 spike).
  *
  * A bad/missing token returns **404** (not 401) so the server's existence isn't confirmed to a
  * scanner; the token is compared in constant time ([ServeUrls.tokensMatch]).
@@ -44,9 +52,46 @@ class ServeHttpServer(
 
   private val server: EmbeddedServer<*, *> =
     embeddedServer(CIO, host = host, port = port) {
+      install(WebSockets)
       routing {
         // `/healthz` is the only ungated route — liveness only, leaks nothing.
         get("/healthz") { call.respondText("ok") }
+
+        // Tier-2 streaming spike: a persistent frame lane. The browser opens this, receives PNG
+        // frames as JSON ([ServeStreamProtocol]), and sends override/refresh messages back; each
+        // drives a re-render through the shared [ServeRenderHost]. Token is checked post-handshake
+        // (can't 404 after upgrade) — a bad token closes immediately.
+        webSocket("/ws/{name}") {
+          val provided = call.request.queryParameters["token"] ?: call.request.headers[TOKEN_HEADER]
+          if (!ServeUrls.tokensMatch(token, provided)) {
+            close(CloseReason(CloseReason.Codes.VIOLATED_POLICY, "unauthorized"))
+            return@webSocket
+          }
+          val previewId = call.parameters["name"]
+          if (previewId == null || renderHost.previews.none { it.id == previewId }) {
+            close(CloseReason(CloseReason.Codes.CANNOT_ACCEPT, "no such preview"))
+            return@webSocket
+          }
+          val initialOverrides =
+            ServeOverrides.SUPPORTED_KEYS.mapNotNull { key ->
+                call.request.queryParameters[key]?.let { key to it }
+              }
+              .toMap()
+          val session =
+            ServeStreamSession(renderHost, previewId, initialOverrides) { text ->
+              // Non-suspending hand-off to the socket; drop frames a slow client can't keep up
+              // with.
+              outgoing.trySend(Frame.Text(text))
+            }
+          // Renders block (renderNow + await); keep them off the socket's event-loop thread.
+          withContext(Dispatchers.IO) { session.onOpen() }
+          for (frame in incoming) {
+            if (frame is Frame.Text) {
+              val text = frame.readText()
+              withContext(Dispatchers.IO) { session.onClientMessage(text) }
+            }
+          }
+        }
 
         get("/") {
           if (rejectBadToken()) return@get

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeLiveSession.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeLiveSession.kt
@@ -1,0 +1,116 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.daemon.protocol.InteractiveInputKind
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.daemon.protocol.StreamFrameParams
+
+/**
+ * One **live** streamed-frame connection backed by the daemon's `stream/start` +
+ * `interactive/input` protocol (tier-2). Frames are *pushed* by the daemon (animations,
+ * recomposition, input results) — not re-requested per client message — and decoded inline (no
+ * disk), which is the real upgrade over the [ServeStreamSession] snapshot fallback.
+ *
+ * Created via [tryStart], which returns `null` when the backend doesn't support streaming so the
+ * WebSocket route can fall back to [ServeStreamSession]. Like that class it's transport-agnostic:
+ * frames + errors go out through the [send] callback, so it's unit-testable without a socket.
+ */
+class ServeLiveSession
+private constructor(
+  private val renderHost: ServeRenderHost,
+  private val previewId: String,
+  private var overrides: Map<String, String>,
+  private val send: (String) -> Unit,
+) {
+  @Volatile private var handle: StreamHandle? = null
+
+  /** Handle one client text message: forward input, restart the stream on new overrides, etc. */
+  fun onClientMessage(text: String) {
+    when (val message = ServeStreamProtocol.parseClient(text)) {
+      is ServeStreamProtocol.ClientMessage.SetOverrides ->
+        when (val parsed = ServeOverrides.parse(message.overrides)) {
+          is OverrideParse.Invalid -> send(ServeStreamProtocol.errorMessage(parsed.message))
+          is OverrideParse.Ok -> {
+            // stream/start fixes overrides for the held session, so an override change restarts it.
+            overrides = message.overrides
+            restart(parsed.overrides)
+          }
+        }
+      is ServeStreamProtocol.ClientMessage.Input -> dispatchInput(message)
+      // Frames are pushed by the daemon; an explicit refresh is a no-op on the live lane.
+      ServeStreamProtocol.ClientMessage.RequestFrame -> Unit
+      is ServeStreamProtocol.ClientMessage.Unsupported ->
+        send(ServeStreamProtocol.errorMessage(message.reason))
+    }
+  }
+
+  /** Tear down the daemon stream. Idempotent. */
+  fun close() {
+    handle?.close()
+    handle = null
+  }
+
+  private fun dispatchInput(input: ServeStreamProtocol.ClientMessage.Input) {
+    val kind = parseKind(input.kind)
+    if (kind == null) {
+      send(ServeStreamProtocol.errorMessage("unknown input kind: ${input.kind}"))
+      return
+    }
+    handle?.input(
+      kind = kind,
+      pixelX = input.pixelX,
+      pixelY = input.pixelY,
+      scrollDeltaY = input.scrollDeltaY,
+      keyCode = input.keyCode,
+    )
+  }
+
+  private fun restart(parsed: PreviewOverrides) {
+    handle?.close()
+    handle =
+      renderHost.startStream(previewId, parsed, ::onFrame)
+        ?: run {
+          send(ServeStreamProtocol.errorMessage("live stream ended"))
+          null
+        }
+  }
+
+  private fun onFrame(frame: StreamFrameParams) {
+    // `unchanged` heartbeats carry no payload — nothing to paint.
+    val payload = frame.payloadBase64 ?: return
+    val codec = frame.codec?.name?.lowercase() ?: "png"
+    send(ServeStreamProtocol.frameMessage(frame.seq, frame.widthPx, frame.heightPx, payload, codec))
+  }
+
+  companion object {
+    /** Wire spellings of the input kinds a browser can produce. */
+    private fun parseKind(wire: String): InteractiveInputKind? =
+      when (wire) {
+        "click" -> InteractiveInputKind.CLICK
+        "pointerDown" -> InteractiveInputKind.POINTER_DOWN
+        "pointerMove" -> InteractiveInputKind.POINTER_MOVE
+        "pointerUp" -> InteractiveInputKind.POINTER_UP
+        "rotaryScroll" -> InteractiveInputKind.ROTARY_SCROLL
+        "keyDown" -> InteractiveInputKind.KEY_DOWN
+        "keyUp" -> InteractiveInputKind.KEY_UP
+        else -> null
+      }
+
+    /**
+     * Try to open a daemon-backed live stream. Returns `null` when streaming is unsupported, so the
+     * caller falls back to the snapshot lane. An invalid initial-overrides query degrades to the
+     * preview's defaults (the bad value would otherwise block the whole live session at connect).
+     */
+    fun tryStart(
+      renderHost: ServeRenderHost,
+      previewId: String,
+      overrides: Map<String, String>,
+      send: (String) -> Unit,
+    ): ServeLiveSession? {
+      val initial =
+        (ServeOverrides.parse(overrides) as? OverrideParse.Ok)?.overrides ?: PreviewOverrides()
+      val session = ServeLiveSession(renderHost, previewId, overrides, send)
+      session.handle = renderHost.startStream(previewId, initial, session::onFrame) ?: return null
+      return session
+    }
+  }
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
@@ -202,9 +202,10 @@ internal constructor(
    * Try to open a daemon-backed live stream for [previewId] (tier-2). On success the daemon pushes
    * `streamFrame` notifications; each is decoded and handed to [onFrame], and the returned
    * [StreamHandle] forwards input + tears the stream down on close. Returns **null** when streaming
-   * is unsupported (older daemon / backend without held compositions) so the caller falls back to
-   * the [render]-per-frame lane. Independent of the snapshot render lock — a held stream runs
-   * concurrently with snapshot renders.
+   * is unsupported (older daemon / backend without held compositions, or a `stream/start` that
+   * couldn't allocate a held session) so the caller falls back to the [render]-per-frame lane.
+   * Independent of the snapshot render lock — a held stream runs concurrently with snapshot
+   * renders.
    */
   fun startStream(
     previewId: String,
@@ -214,16 +215,12 @@ internal constructor(
     check(!closed.get()) { "ServeRenderHost is closed" }
     if (previewId !in previewIds) return null
 
-    val result =
-      try {
-        session.streamStart(previewId = previewId, overrides = overrides)
-      } catch (e: Exception) {
-        // UnsupportedOperationException (no streaming on this backend) or a daemon error — degrade.
-        onLog("stream/start unavailable for $previewId (${e.message}); falling back to snapshots")
-        return null
-      }
-
-    val frameStreamId = result.frameStreamId
+    // Register the listener BEFORE stream/start: the daemon's frame loop can emit the initial
+    // keyframe before the RPC response returns, and missing it leaves static previews blank (later
+    // frames are payload-less `unchanged` heartbeats). We don't know the frameStreamId yet, so
+    // buffer frames until it's known, then replay the matching ones.
+    val frameStreamIdRef = AtomicReference<String?>(null)
+    val pending = ArrayList<StreamFrameParams>()
     val listener = session.onNotification { method, params ->
       if (method != "streamFrame" || params == null) return@onNotification
       val frame =
@@ -232,8 +229,49 @@ internal constructor(
         } catch (_: Exception) {
           return@onNotification
         }
-      if (frame.frameStreamId == frameStreamId) onFrame(frame)
+      val known = frameStreamIdRef.get()
+      if (known != null) {
+        if (frame.frameStreamId == known) onFrame(frame)
+        return@onNotification
+      }
+      // id not yet known — buffer under lock, re-checking in case it was just set.
+      synchronized(pending) {
+        if (frameStreamIdRef.get() == null) {
+          pending.add(frame)
+          return@onNotification
+        }
+      }
+      if (frame.frameStreamId == frameStreamIdRef.get()) onFrame(frame)
     }
+
+    val result =
+      try {
+        session.streamStart(previewId = previewId, overrides = overrides)
+      } catch (e: Exception) {
+        // UnsupportedOperationException (no streaming on this backend) or a daemon error — degrade.
+        onLog("stream/start unavailable for $previewId (${e.message}); falling back to snapshots")
+        runCatching { listener.close() }
+        return null
+      }
+
+    if (!result.heldSession) {
+      // The daemon accepted stream/start but couldn't hold an interactive session, so it won't run
+      // the live frame loop — fall back to the snapshot lane rather than open a frameless stream.
+      onLog("stream/start for $previewId has no held session; falling back to snapshots")
+      runCatching { listener.close() }
+      runCatching { session.streamStop(result.frameStreamId) }
+      return null
+    }
+
+    val frameStreamId = result.frameStreamId
+    // Publish the id and replay any frames that arrived before it was known.
+    val replay: List<StreamFrameParams>
+    synchronized(pending) {
+      frameStreamIdRef.set(frameStreamId)
+      replay = pending.filter { it.frameStreamId == frameStreamId }
+      pending.clear()
+    }
+    replay.forEach(onFrame)
 
     return object : StreamHandle {
       private val handleClosed = AtomicBoolean(false)

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
@@ -1,6 +1,8 @@
 package ee.schimke.composeai.cli.serve
 
+import ee.schimke.composeai.daemon.protocol.InteractiveInputKind
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.daemon.protocol.StreamFrameParams
 import ee.schimke.composeai.io.SystemFileSystem
 import ee.schimke.composeai.render.session.RenderSession
 import ee.schimke.composeai.render.session.RenderSessionConfig
@@ -16,10 +18,25 @@ import java.util.concurrent.atomic.AtomicReference
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
 import kotlin.time.Duration.Companion.seconds
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonPrimitive
 import okio.FileSystem
 import okio.Path.Companion.toPath
+
+/**
+ * A live daemon-backed frame stream. Forward input into the held composition via [input]; [close]
+ * tears the stream down. Obtained from [ServeRenderHost.startStream].
+ */
+interface StreamHandle : AutoCloseable {
+  fun input(
+    kind: InteractiveInputKind,
+    pixelX: Int? = null,
+    pixelY: Int? = null,
+    scrollDeltaY: Float? = null,
+    keyCode: String? = null,
+  )
+}
 
 /** One servable preview: its id, a human label, and which delivery modes it supports. */
 data class ServePreview(
@@ -69,6 +86,9 @@ internal constructor(
 ) : AutoCloseable {
 
   private val previewIds: Set<String> = previews.map { it.id }.toHashSet()
+
+  // Decodes streamFrame notification params for the live-stream lane (startStream).
+  private val streamJson = Json { ignoreUnknownKeys = true }
 
   // Bounded LRU of rendered PNGs keyed by ServeOverrides.cacheKey. A dev-facing server fronting one
   // module won't accumulate many distinct (preview × overrides) combos, so a small cap is plenty.
@@ -175,6 +195,67 @@ internal constructor(
 
       cache.put(key, bytes)
       RenderOutcome.Ok(bytes)
+    }
+  }
+
+  /**
+   * Try to open a daemon-backed live stream for [previewId] (tier-2). On success the daemon pushes
+   * `streamFrame` notifications; each is decoded and handed to [onFrame], and the returned
+   * [StreamHandle] forwards input + tears the stream down on close. Returns **null** when streaming
+   * is unsupported (older daemon / backend without held compositions) so the caller falls back to
+   * the [render]-per-frame lane. Independent of the snapshot render lock — a held stream runs
+   * concurrently with snapshot renders.
+   */
+  fun startStream(
+    previewId: String,
+    overrides: PreviewOverrides,
+    onFrame: (StreamFrameParams) -> Unit,
+  ): StreamHandle? {
+    check(!closed.get()) { "ServeRenderHost is closed" }
+    if (previewId !in previewIds) return null
+
+    val result =
+      try {
+        session.streamStart(previewId = previewId, overrides = overrides)
+      } catch (e: Exception) {
+        // UnsupportedOperationException (no streaming on this backend) or a daemon error — degrade.
+        onLog("stream/start unavailable for $previewId (${e.message}); falling back to snapshots")
+        return null
+      }
+
+    val frameStreamId = result.frameStreamId
+    val listener = session.onNotification { method, params ->
+      if (method != "streamFrame" || params == null) return@onNotification
+      val frame =
+        try {
+          streamJson.decodeFromJsonElement(StreamFrameParams.serializer(), params)
+        } catch (_: Exception) {
+          return@onNotification
+        }
+      if (frame.frameStreamId == frameStreamId) onFrame(frame)
+    }
+
+    return object : StreamHandle {
+      private val handleClosed = AtomicBoolean(false)
+
+      override fun input(
+        kind: InteractiveInputKind,
+        pixelX: Int?,
+        pixelY: Int?,
+        scrollDeltaY: Float?,
+        keyCode: String?,
+      ) {
+        if (handleClosed.get()) return
+        runCatching {
+          session.interactiveInput(frameStreamId, kind, pixelX, pixelY, scrollDeltaY, keyCode)
+        }
+      }
+
+      override fun close() {
+        if (!handleClosed.compareAndSet(false, true)) return
+        runCatching { listener.close() }
+        runCatching { session.streamStop(frameStreamId) }
+      }
     }
   }
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeStreamProtocol.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeStreamProtocol.kt
@@ -1,0 +1,85 @@
+package ee.schimke.composeai.cli.serve
+
+import java.util.Base64
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+
+/**
+ * The tiny JSON message protocol for the `serve` streamed-frame lane (`/ws/{previewId}`) — the
+ * tier-2 streaming spike. Pure (no ktor / IO), so the wire format is unit-tested directly and the
+ * WebSocket route stays a thin adapter.
+ *
+ * Client → server: `setOverrides` (replace the display overrides and re-render) and `requestFrame`
+ * (re-render at the current overrides). Server → client: `frame` (a rendered PNG, base64, with its
+ * pixel size and a monotonic `seq`) and `error`.
+ *
+ * This deliberately mirrors the daemon's native streaming protocol (`stream/start` + `streamFrame`,
+ * `docs/daemon/STREAMING.md`): base64 frame payloads + a `codec` tag + a monotonic sequence, so the
+ * follow-on that swaps the re-render backend for real `streamFrame` notifications keeps the same
+ * browser-facing shape.
+ */
+object ServeStreamProtocol {
+
+  /** A message from the browser. Unknown / malformed input is surfaced as [Unsupported]. */
+  sealed interface ClientMessage {
+    /** Replace the override set (same keys as `/render`) and push a fresh frame. */
+    data class SetOverrides(val overrides: Map<String, String>) : ClientMessage
+
+    /** Re-render and push a frame at the current overrides. */
+    data object RequestFrame : ClientMessage
+
+    /** Unrecognised message; [reason] is echoed back as an error rather than crashing the lane. */
+    data class Unsupported(val reason: String) : ClientMessage
+  }
+
+  private val json = Json { ignoreUnknownKeys = true }
+
+  /** Parse a client text frame. Never throws — bad input becomes [ClientMessage.Unsupported]. */
+  fun parseClient(text: String): ClientMessage {
+    val obj =
+      try {
+        json.parseToJsonElement(text).jsonObject
+      } catch (e: Exception) {
+        return ClientMessage.Unsupported("invalid JSON: ${e.message}")
+      }
+    return when (val type = obj["type"]?.jsonPrimitive?.contentOrNull) {
+      "setOverrides" -> {
+        val overrides =
+          obj["overrides"]?.jsonObject?.entries?.mapNotNull { (k, v) ->
+            v.jsonPrimitive.contentOrNull?.let { k to it }
+          } ?: emptyList()
+        ClientMessage.SetOverrides(overrides.toMap())
+      }
+      "requestFrame" -> ClientMessage.RequestFrame
+      else -> ClientMessage.Unsupported("unknown message type: $type")
+    }
+  }
+
+  /** A rendered frame: PNG bytes base64-encoded, with pixel size and a per-connection [seq]. */
+  fun frameMessage(seq: Long, widthPx: Int, heightPx: Int, png: ByteArray): String {
+    val obj = buildJsonObject {
+      put("type", "frame")
+      put("seq", seq)
+      put("codec", "png")
+      put("widthPx", widthPx)
+      put("heightPx", heightPx)
+      put("dataBase64", Base64.getEncoder().encodeToString(png))
+    }
+    return obj.toString()
+  }
+
+  /**
+   * A non-fatal error (bad overrides, render failure); the lane stays open for the next message.
+   */
+  fun errorMessage(message: String): String {
+    val obj = buildJsonObject {
+      put("type", "error")
+      put("message", message)
+    }
+    return obj.toString()
+  }
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeStreamProtocol.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeStreamProtocol.kt
@@ -33,6 +33,19 @@ object ServeStreamProtocol {
     /** Re-render and push a frame at the current overrides. */
     data object RequestFrame : ClientMessage
 
+    /**
+     * A user input event to dispatch into a live (daemon-streamed) composition. [kind] is the wire
+     * spelling of an `InteractiveInputKind` (`click`, `pointerDown`, …); coordinates are
+     * image-natural pixels. Ignored by the snapshot fallback lane (which can't accept input).
+     */
+    data class Input(
+      val kind: String,
+      val pixelX: Int?,
+      val pixelY: Int?,
+      val scrollDeltaY: Float?,
+      val keyCode: String?,
+    ) : ClientMessage
+
     /** Unrecognised message; [reason] is echoed back as an error rather than crashing the lane. */
     data class Unsupported(val reason: String) : ClientMessage
   }
@@ -58,6 +71,14 @@ object ServeStreamProtocol {
           ClientMessage.SetOverrides(overrides.toMap())
         }
         "requestFrame" -> ClientMessage.RequestFrame
+        "input" ->
+          ClientMessage.Input(
+            kind = (obj["kind"] as? JsonPrimitive)?.contentOrNull ?: "",
+            pixelX = (obj["pixelX"] as? JsonPrimitive)?.contentOrNull?.toIntOrNull(),
+            pixelY = (obj["pixelY"] as? JsonPrimitive)?.contentOrNull?.toIntOrNull(),
+            scrollDeltaY = (obj["scrollDeltaY"] as? JsonPrimitive)?.contentOrNull?.toFloatOrNull(),
+            keyCode = (obj["keyCode"] as? JsonPrimitive)?.contentOrNull,
+          )
         else -> ClientMessage.Unsupported("unknown message type: $type")
       }
     } catch (e: Exception) {
@@ -65,15 +86,28 @@ object ServeStreamProtocol {
     }
   }
 
-  /** A rendered frame: PNG bytes base64-encoded, with pixel size and a per-connection [seq]. */
-  fun frameMessage(seq: Long, widthPx: Int, heightPx: Int, png: ByteArray): String {
+  /** A rendered frame from raw PNG bytes (snapshot lane) — base64-encodes them as a `png` frame. */
+  fun frameMessage(seq: Long, widthPx: Int, heightPx: Int, png: ByteArray): String =
+    frameMessage(seq, widthPx, heightPx, Base64.getEncoder().encodeToString(png), "png")
+
+  /**
+   * A rendered frame from an already-base64 payload (live daemon-stream lane), tagged with [codec]
+   * (`png`/`webp`) so the browser builds the right `data:` URL. Pixel size + per-connection [seq].
+   */
+  fun frameMessage(
+    seq: Long,
+    widthPx: Int,
+    heightPx: Int,
+    dataBase64: String,
+    codec: String,
+  ): String {
     val obj = buildJsonObject {
       put("type", "frame")
       put("seq", seq)
-      put("codec", "png")
+      put("codec", codec)
       put("widthPx", widthPx)
       put("heightPx", heightPx)
-      put("dataBase64", Base64.getEncoder().encodeToString(png))
+      put("dataBase64", dataBase64)
     }
     return obj.toString()
   }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeStreamProtocol.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeStreamProtocol.kt
@@ -2,10 +2,11 @@ package ee.schimke.composeai.cli.serve
 
 import java.util.Base64
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonObject
-import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 
 /**
@@ -38,24 +39,29 @@ object ServeStreamProtocol {
 
   private val json = Json { ignoreUnknownKeys = true }
 
-  /** Parse a client text frame. Never throws — bad input becomes [ClientMessage.Unsupported]. */
+  /**
+   * Parse a client text frame. Never throws — malformed JSON *and* well-formed JSON of the wrong
+   * shape (`{"type":{}}`, `{"overrides":[]}`, a non-string override value) both become
+   * [ClientMessage.Unsupported] or degrade gracefully, so a bad message reports a non-fatal error
+   * rather than tearing down the live stream. All element access uses `as?` and is guarded by a
+   * catch-all for defence in depth.
+   */
   fun parseClient(text: String): ClientMessage {
-    val obj =
-      try {
-        json.parseToJsonElement(text).jsonObject
-      } catch (e: Exception) {
-        return ClientMessage.Unsupported("invalid JSON: ${e.message}")
+    return try {
+      val obj = json.parseToJsonElement(text).jsonObject
+      when (val type = (obj["type"] as? JsonPrimitive)?.contentOrNull) {
+        "setOverrides" -> {
+          val overrides =
+            (obj["overrides"] as? JsonObject)?.entries?.mapNotNull { (k, v) ->
+              (v as? JsonPrimitive)?.contentOrNull?.let { k to it }
+            } ?: emptyList()
+          ClientMessage.SetOverrides(overrides.toMap())
+        }
+        "requestFrame" -> ClientMessage.RequestFrame
+        else -> ClientMessage.Unsupported("unknown message type: $type")
       }
-    return when (val type = obj["type"]?.jsonPrimitive?.contentOrNull) {
-      "setOverrides" -> {
-        val overrides =
-          obj["overrides"]?.jsonObject?.entries?.mapNotNull { (k, v) ->
-            v.jsonPrimitive.contentOrNull?.let { k to it }
-          } ?: emptyList()
-        ClientMessage.SetOverrides(overrides.toMap())
-      }
-      "requestFrame" -> ClientMessage.RequestFrame
-      else -> ClientMessage.Unsupported("unknown message type: $type")
+    } catch (e: Exception) {
+      ClientMessage.Unsupported("malformed message: ${e.message}")
     }
   }
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeStreamSession.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeStreamSession.kt
@@ -43,6 +43,10 @@ class ServeStreamSession(
           }
         }
       ServeStreamProtocol.ClientMessage.RequestFrame -> renderCurrent()
+      is ServeStreamProtocol.ClientMessage.Input ->
+        // The snapshot fallback can't dispatch input into a live composition — only the daemon
+        // stream lane ([ServeLiveSession]) can. Report it rather than silently dropping.
+        send(ServeStreamProtocol.errorMessage("input requires a live stream"))
       is ServeStreamProtocol.ClientMessage.Unsupported ->
         send(ServeStreamProtocol.errorMessage(message.reason))
     }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeStreamSession.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeStreamSession.kt
@@ -1,0 +1,68 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * One streamed-frame connection's logic, independent of the WebSocket transport — the tier-2
+ * streaming spike's core. Holds the current overrides for a single preview, renders through the
+ * shared [ServeRenderHost] (so the tier-1 mutex + cache + multi-client serialisation are reused),
+ * and emits frames via the [send] callback. The Ktor `webSocket` route is a thin adapter that wires
+ * [send] to the socket's outgoing channel and feeds incoming text to [onClientMessage].
+ *
+ * Keeping the transport out means this is unit-testable headlessly: drive it with raw client
+ * messages and a capturing [send], and assert the frames/errors emitted — no socket, no browser.
+ *
+ * This re-renders on every client message (input → frame), which is the spike's proof of the
+ * transport. The follow-on swaps this backend for the daemon's native `streamFrame` push (so frames
+ * also arrive *unprompted* as the composition changes) without changing [send]'s wire shape.
+ */
+class ServeStreamSession(
+  private val renderHost: ServeRenderHost,
+  private val previewId: String,
+  initialOverrides: Map<String, String> = emptyMap(),
+  private val send: (String) -> Unit,
+) {
+  private var overrides: Map<String, String> = initialOverrides
+  private val seq = AtomicLong(0)
+
+  /** Push the first frame at the initial overrides when the connection opens. */
+  fun onOpen() = renderCurrent()
+
+  /** Handle one client text message: update overrides / re-render, or echo a protocol error. */
+  fun onClientMessage(text: String) {
+    when (val message = ServeStreamProtocol.parseClient(text)) {
+      is ServeStreamProtocol.ClientMessage.SetOverrides ->
+        // Validate before committing: a bad override message is reported but must not poison the
+        // session — the previous (valid) overrides stay in effect for subsequent frames.
+        when (val parsed = ServeOverrides.parse(message.overrides)) {
+          is OverrideParse.Invalid -> send(ServeStreamProtocol.errorMessage(parsed.message))
+          is OverrideParse.Ok -> {
+            overrides = message.overrides
+            sendFrame(parsed.overrides)
+          }
+        }
+      ServeStreamProtocol.ClientMessage.RequestFrame -> renderCurrent()
+      is ServeStreamProtocol.ClientMessage.Unsupported ->
+        send(ServeStreamProtocol.errorMessage(message.reason))
+    }
+  }
+
+  private fun renderCurrent() {
+    when (val parsed = ServeOverrides.parse(overrides)) {
+      is OverrideParse.Invalid -> send(ServeStreamProtocol.errorMessage(parsed.message))
+      is OverrideParse.Ok -> sendFrame(parsed.overrides)
+    }
+  }
+
+  private fun sendFrame(overrides: PreviewOverrides) {
+    when (val outcome = renderHost.render(previewId, overrides)) {
+      is RenderOutcome.Ok -> {
+        val (w, h) = WebEscaping.pngDimensions(outcome.png)
+        send(ServeStreamProtocol.frameMessage(seq.getAndIncrement(), w, h, outcome.png))
+      }
+      RenderOutcome.NotFound -> send(ServeStreamProtocol.errorMessage("no such preview"))
+      is RenderOutcome.Failed -> send(ServeStreamProtocol.errorMessage(outcome.reason))
+    }
+  }
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -34,7 +34,8 @@ object ServeWeb {
     .cp-stage { flex: 1 1 360px; min-width: 280px; border: 1px solid #e3e3e8; border-radius: 10px;
       background: repeating-conic-gradient(#f4f4f6 0% 25%, #fff 0% 50%) 50% / 16px 16px; padding: 12px;
       display: flex; align-items: center; justify-content: center; min-height: 320px; }
-    .cp-stage img { max-width: 100%; height: auto; }
+    .cp-stage img, .cp-stage canvas { max-width: 100%; height: auto; }
+    .cp-live-row { flex-direction: row !important; align-items: center; gap: 6px !important; }
     .cp-controls { flex: 0 0 240px; display: flex; flex-direction: column; gap: 14px; }
     .cp-controls label { display: flex; flex-direction: column; gap: 4px; font-size: 0.8rem; }
     .cp-controls input, .cp-controls select { padding: 5px 6px; font-size: 0.85rem; }
@@ -106,8 +107,9 @@ object ServeWeb {
       <p class="cp-head"><a href="/?token=$tokenQ">← previews</a></p>
       <p class="cp-sub" title="$idText">$label</p>
       <div class="cp-viewer" data-preview-id="$idText" data-mode="snapshot" data-modes="$modes">
-        <div class="cp-stage"><img id="cp-img" alt="$label"></div>
+        <div class="cp-stage"><img id="cp-img" alt="$label"><canvas id="cp-canvas" hidden></canvas></div>
         <div class="cp-controls">
+          <label class="cp-live-row"><input id="cp-live" type="checkbox"> Live (stream)</label>
           <label>Theme
             <select id="cp-uiMode">
               <option value="">(default)</option>
@@ -144,9 +146,13 @@ object ServeWeb {
   }
 
   /**
-   * Viewer JS: read the token from the URL, rebuild the `/render` URL from the controls on every
-   * change, and swap `img.src`. Snapshot transport only today; the `data-mode` hook is where the
-   * future `live` (CMP→JS) path branches.
+   * Viewer JS. Two transports behind one set of controls (the `data-mode` seam):
+   * - **snapshot** (default): rebuild the `/render` URL from the controls and swap `img.src`.
+   * - **live** (tier-2 streaming spike): when "Live (stream)" is on, open the `/ws/{id}` WebSocket,
+   *   paint pushed PNG frames onto a `<canvas>`, and send `setOverrides` as controls change.
+   *
+   * Override collection ([overrides]) is shared by both, so an opt-in field stays opt-in either way
+   * (notably fontScale, which is only sent once the slider is moved).
    */
   private fun viewerScript(): String =
     """
@@ -154,47 +160,100 @@ object ServeWeb {
       "use strict";
       var root = document.querySelector(".cp-viewer");
       var img = document.getElementById("cp-img");
+      var canvas = document.getElementById("cp-canvas");
       var status = document.getElementById("cp-status");
+      var live = document.getElementById("cp-live");
       var previewId = root.getAttribute("data-preview-id");
       var token = new URLSearchParams(location.search).get("token") || "";
       // The selects + text input are opt-in (empty value = "use the preview's default"). The font
       // scale slider has no empty state, so it's gated separately: we only send fontScale once the
-      // user moves it (see fontScaleTouched), otherwise the slider's standing 1.0 would override a
+      // user moves it (fontScaleTouched), otherwise the slider's standing 1.0 would override a
       // preview's declared default font scale and the first render wouldn't match the thumbnail.
       var fields = ["uiMode", "device", "localeTag", "orientation"];
       var fs = document.getElementById("cp-fontScale");
       var fsVal = document.getElementById("cp-fontScale-val");
       var fontScaleTouched = false;
+      var ws = null;
 
-      function renderUrl() {
-        var q = "token=" + encodeURIComponent(token);
+      function overrides() {
+        var o = {};
         fields.forEach(function (f) {
           var el = document.getElementById("cp-" + f);
-          if (el && el.value) q += "&" + f + "=" + encodeURIComponent(el.value);
+          if (el && el.value) o[f] = el.value;
         });
-        if (fontScaleTouched && fs) q += "&fontScale=" + encodeURIComponent(fs.value);
-        return "/render/" + encodeURIComponent(previewId) + ".png?" + q;
+        if (fontScaleTouched && fs) o.fontScale = fs.value;
+        return o;
       }
-      function refresh() {
+      function query() {
+        var o = overrides();
+        var q = "token=" + encodeURIComponent(token);
+        Object.keys(o).forEach(function (k) { q += "&" + k + "=" + encodeURIComponent(o[k]); });
+        return q;
+      }
+      function refreshSnapshot() {
         status.textContent = "rendering…";
-        var url = renderUrl();
+        var url = "/render/" + encodeURIComponent(previewId) + ".png?" + query();
         var next = new Image();
         next.onload = function () { img.src = url; status.textContent = ""; };
         next.onerror = function () { status.textContent = "render failed"; };
         next.src = url;
       }
+      function drawFrame(b64) {
+        var im = new Image();
+        im.onload = function () {
+          canvas.width = im.naturalWidth;
+          canvas.height = im.naturalHeight;
+          canvas.getContext("2d").drawImage(im, 0, 0);
+        };
+        im.src = "data:image/png;base64," + b64;
+      }
+      function openStream() {
+        root.setAttribute("data-mode", "live");
+        img.hidden = true;
+        canvas.hidden = false;
+        status.textContent = "connecting…";
+        var proto = location.protocol === "https:" ? "wss:" : "ws:";
+        ws = new WebSocket(proto + "//" + location.host + "/ws/" +
+          encodeURIComponent(previewId) + "?" + query());
+        ws.onmessage = function (ev) {
+          var m;
+          try { m = JSON.parse(ev.data); } catch (e) { return; }
+          if (m.type === "frame") { drawFrame(m.dataBase64); status.textContent = ""; }
+          else if (m.type === "error") { status.textContent = m.message || "error"; }
+        };
+        ws.onerror = function () { status.textContent = "stream error"; };
+        ws.onclose = function () { ws = null; };
+      }
+      function closeStream() {
+        root.setAttribute("data-mode", "snapshot");
+        if (ws) { ws.close(); ws = null; }
+        canvas.hidden = true;
+        img.hidden = false;
+      }
+      function onControlsChanged() {
+        if (live.checked && ws && ws.readyState === 1) {
+          ws.send(JSON.stringify({ type: "setOverrides", overrides: overrides() }));
+        } else if (!live.checked) {
+          refreshSnapshot();
+        }
+      }
+
+      live.addEventListener("change", function () {
+        if (live.checked) openStream();
+        else { closeStream(); refreshSnapshot(); }
+      });
       if (fs) {
         fs.addEventListener("input", function () {
           fsVal.textContent = fs.value;
           fontScaleTouched = true;
-          refresh();
+          onControlsChanged();
         });
       }
       fields.forEach(function (f) {
         var el = document.getElementById("cp-" + f);
-        if (el) el.addEventListener("change", refresh);
+        if (el) el.addEventListener("change", onControlsChanged);
       });
-      refresh();
+      refreshSnapshot();
     })();
     """
       .trimIndent()

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -198,15 +198,25 @@ object ServeWeb {
         next.onerror = function () { status.textContent = "render failed"; };
         next.src = url;
       }
-      function drawFrame(b64) {
+      function drawFrame(b64, codec) {
         var im = new Image();
         im.onload = function () {
           canvas.width = im.naturalWidth;
           canvas.height = im.naturalHeight;
           canvas.getContext("2d").drawImage(im, 0, 0);
         };
-        im.src = "data:image/png;base64," + b64;
+        im.src = "data:image/" + (codec || "png") + ";base64," + b64;
       }
+      // Forward clicks on the live canvas as input (image-natural pixels). No-op on the snapshot
+      // lane (it has no live stream and reports "input requires a live stream").
+      canvas.addEventListener("click", function (ev) {
+        if (!ws || ws.readyState !== 1 || !canvas.width) return;
+        var rect = canvas.getBoundingClientRect();
+        if (!rect.width || !rect.height) return;
+        var px = Math.round((ev.clientX - rect.left) / rect.width * canvas.width);
+        var py = Math.round((ev.clientY - rect.top) / rect.height * canvas.height);
+        ws.send(JSON.stringify({ type: "input", kind: "click", pixelX: px, pixelY: py }));
+      });
       function openStream() {
         root.setAttribute("data-mode", "live");
         img.hidden = true;
@@ -218,7 +228,7 @@ object ServeWeb {
         ws.onmessage = function (ev) {
           var m;
           try { m = JSON.parse(ev.data); } catch (e) { return; }
-          if (m.type === "frame") { drawFrame(m.dataBase64); status.textContent = ""; }
+          if (m.type === "frame") { drawFrame(m.dataBase64, m.codec); status.textContent = ""; }
           else if (m.type === "error") { status.textContent = m.message || "error"; }
         };
         ws.onerror = function () { status.textContent = "stream error"; };

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/FakeRenderSession.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/FakeRenderSession.kt
@@ -13,6 +13,8 @@ import ee.schimke.composeai.daemon.protocol.HistoryListParams
 import ee.schimke.composeai.daemon.protocol.HistoryListResult
 import ee.schimke.composeai.daemon.protocol.HistoryReadResultDto
 import ee.schimke.composeai.daemon.protocol.InitializeResult
+import ee.schimke.composeai.daemon.protocol.InteractiveInputKind
+import ee.schimke.composeai.daemon.protocol.InteractiveInputParams
 import ee.schimke.composeai.daemon.protocol.Manifest
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.daemon.protocol.RecordingEncodeResult
@@ -24,14 +26,19 @@ import ee.schimke.composeai.daemon.protocol.RejectedRender
 import ee.schimke.composeai.daemon.protocol.RenderNowResult
 import ee.schimke.composeai.daemon.protocol.RenderTier
 import ee.schimke.composeai.daemon.protocol.ServerCapabilities
+import ee.schimke.composeai.daemon.protocol.StreamCodec
+import ee.schimke.composeai.daemon.protocol.StreamFrameParams
+import ee.schimke.composeai.daemon.protocol.StreamStartResult
 import ee.schimke.composeai.render.session.NotificationListener
 import ee.schimke.composeai.render.session.RenderSession
 import ee.schimke.composeai.render.session.RenderSessionBackend
 import java.io.File
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.put
 
 /**
@@ -47,10 +54,42 @@ internal class FakeRenderSession(
   private val renderRoot: File,
   private val rejectAll: Boolean = false,
   private val renderHook: ((call: Int, emit: (ByteArray) -> Unit) -> Unit)? = null,
+  /** When false (default), the streaming methods throw (mimicking a non-streaming backend). */
+  private val streaming: Boolean = false,
 ) : RenderSession {
   val renderCount = AtomicInteger(0)
   private val listeners = CopyOnWriteArrayList<NotificationListener>()
   private val counter = AtomicInteger(0)
+
+  // Streaming spies (only meaningful when streaming = true).
+  val streamStarts = AtomicInteger(0)
+  val interactiveInputs = CopyOnWriteArrayList<InteractiveInputParams>()
+  val streamStops = CopyOnWriteArrayList<String>()
+  @Volatile
+  var lastFrameStreamId: String? = null
+    private set
+
+  private val streamJson = Json { ignoreUnknownKeys = true }
+
+  /** Fire a `streamFrame` notification to registered listeners (test driver for the live lane). */
+  fun emitStreamFrame(frameStreamId: String, seq: Long, payloadBase64: String?) {
+    val params =
+      streamJson
+        .encodeToJsonElement(
+          StreamFrameParams.serializer(),
+          StreamFrameParams(
+            frameStreamId = frameStreamId,
+            seq = seq,
+            ptsMillis = 0,
+            widthPx = 2,
+            heightPx = 2,
+            codec = StreamCodec.PNG,
+            payloadBase64 = payloadBase64,
+          ),
+        )
+        .jsonObject
+    listeners.forEach { it.onNotification("streamFrame", params) }
+  }
 
   private fun emitFinished(id: String, bytes: ByteArray) {
     renderRoot.mkdirs()
@@ -180,6 +219,43 @@ internal class FakeRenderSession(
     format: RecordingFormat,
     timeout: kotlin.time.Duration,
   ): RecordingEncodeResult = error("unused")
+
+  override fun streamStart(
+    previewId: String,
+    codec: StreamCodec?,
+    maxFps: Int?,
+    overrides: PreviewOverrides?,
+    timeout: kotlin.time.Duration,
+  ): StreamStartResult {
+    if (!streaming) throw UnsupportedOperationException("streaming not supported")
+    val fsid = "fs-${streamStarts.incrementAndGet()}"
+    lastFrameStreamId = fsid
+    return StreamStartResult(frameStreamId = fsid, codec = StreamCodec.PNG, heldSession = true)
+  }
+
+  override fun streamStop(frameStreamId: String) {
+    streamStops.add(frameStreamId)
+  }
+
+  override fun interactiveInput(
+    frameStreamId: String,
+    kind: InteractiveInputKind,
+    pixelX: Int?,
+    pixelY: Int?,
+    scrollDeltaY: Float?,
+    keyCode: String?,
+  ) {
+    interactiveInputs.add(
+      InteractiveInputParams(
+        frameStreamId = frameStreamId,
+        kind = kind,
+        pixelX = pixelX,
+        pixelY = pixelY,
+        scrollDeltaY = scrollDeltaY,
+        keyCode = keyCode,
+      )
+    )
+  }
 
   override fun onNotification(listener: NotificationListener): AutoCloseable {
     listeners.add(listener)

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/FakeRenderSession.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/FakeRenderSession.kt
@@ -1,0 +1,190 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.daemon.protocol.ChangeType
+import ee.schimke.composeai.daemon.protocol.DataFetchResult
+import ee.schimke.composeai.daemon.protocol.DataSubscribeResult
+import ee.schimke.composeai.daemon.protocol.ExtensionsDisableResult
+import ee.schimke.composeai.daemon.protocol.ExtensionsEnableResult
+import ee.schimke.composeai.daemon.protocol.ExtensionsListResult
+import ee.schimke.composeai.daemon.protocol.FileKind
+import ee.schimke.composeai.daemon.protocol.HistoryDiffMode
+import ee.schimke.composeai.daemon.protocol.HistoryDiffResult
+import ee.schimke.composeai.daemon.protocol.HistoryListParams
+import ee.schimke.composeai.daemon.protocol.HistoryListResult
+import ee.schimke.composeai.daemon.protocol.HistoryReadResultDto
+import ee.schimke.composeai.daemon.protocol.InitializeResult
+import ee.schimke.composeai.daemon.protocol.Manifest
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.daemon.protocol.RecordingEncodeResult
+import ee.schimke.composeai.daemon.protocol.RecordingFormat
+import ee.schimke.composeai.daemon.protocol.RecordingScriptEvent
+import ee.schimke.composeai.daemon.protocol.RecordingStartResult
+import ee.schimke.composeai.daemon.protocol.RecordingStopResult
+import ee.schimke.composeai.daemon.protocol.RejectedRender
+import ee.schimke.composeai.daemon.protocol.RenderNowResult
+import ee.schimke.composeai.daemon.protocol.RenderTier
+import ee.schimke.composeai.daemon.protocol.ServerCapabilities
+import ee.schimke.composeai.render.session.NotificationListener
+import ee.schimke.composeai.render.session.RenderSession
+import ee.schimke.composeai.render.session.RenderSessionBackend
+import java.io.File
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+/**
+ * Shared test [RenderSession]: each [renderNow] writes a PNG (bytes encode the overrides, so
+ * distinct overrides → distinct bytes) and synchronously emits the `renderFinished` callers await.
+ *
+ * [renderHook] (when set) overrides the default emit-immediately behaviour: it receives the 1-based
+ * call index and an `emit` that writes given bytes to a fresh PNG and fires `renderFinished`. A
+ * hook that emits nothing models a render that times out (the daemon owes a late event), which
+ * drives the stale-event path. [rejectAll] rejects every render.
+ */
+internal class FakeRenderSession(
+  private val renderRoot: File,
+  private val rejectAll: Boolean = false,
+  private val renderHook: ((call: Int, emit: (ByteArray) -> Unit) -> Unit)? = null,
+) : RenderSession {
+  val renderCount = AtomicInteger(0)
+  private val listeners = CopyOnWriteArrayList<NotificationListener>()
+  private val counter = AtomicInteger(0)
+
+  private fun emitFinished(id: String, bytes: ByteArray) {
+    renderRoot.mkdirs()
+    val file = File(renderRoot, "$id-${counter.incrementAndGet()}.png").apply { writeBytes(bytes) }
+    val params = buildJsonObject {
+      put("id", id)
+      put("pngPath", file.absolutePath)
+    }
+    listeners.forEach { it.onNotification("renderFinished", params) }
+  }
+
+  override val workspaceRoot: String = renderRoot.absolutePath
+  override val modulePath: String = ":sample"
+  override val initializeResult: InitializeResult =
+    InitializeResult(
+      protocolVersion = 2,
+      daemonVersion = "fake",
+      pid = 0,
+      capabilities =
+        ServerCapabilities(
+          incrementalDiscovery = false,
+          sandboxRecycle = false,
+          leakDetection = emptyList(),
+        ),
+      classpathFingerprint = "",
+      manifest = Manifest(path = "", previewCount = 0),
+    )
+  override val backendKind: RenderSessionBackend = RenderSessionBackend.Subprocess
+
+  override fun setVisible(previewIds: List<String>) = Unit
+
+  override fun setFocus(previewIds: List<String>) = Unit
+
+  override fun fileChanged(path: String, kind: FileKind, changeType: ChangeType) = Unit
+
+  override fun renderNow(
+    previewIds: List<String>,
+    tier: RenderTier,
+    reason: String?,
+    overrides: PreviewOverrides?,
+    timeout: kotlin.time.Duration,
+  ): RenderNowResult {
+    val call = renderCount.incrementAndGet()
+    val id = previewIds.single()
+    if (rejectAll) {
+      return RenderNowResult(queued = emptyList(), rejected = listOf(RejectedRender(id, "nope")))
+    }
+    val hook = renderHook
+    if (hook != null) {
+      hook(call) { bytes -> emitFinished(id, bytes) }
+    } else {
+      val content = "png:${overrides?.uiMode}:${overrides?.localeTag}:${overrides?.device}"
+      emitFinished(id, content.toByteArray())
+    }
+    return RenderNowResult(queued = previewIds, rejected = emptyList())
+  }
+
+  override fun fetchData(
+    previewId: String,
+    kind: String,
+    inline: Boolean,
+    params: JsonElement?,
+    timeout: kotlin.time.Duration,
+  ): DataFetchResult = error("unused")
+
+  override fun subscribeData(
+    previewId: String,
+    kind: String,
+    params: JsonElement?,
+    timeout: kotlin.time.Duration,
+  ): DataSubscribeResult = error("unused")
+
+  override fun unsubscribeData(
+    previewId: String,
+    kind: String,
+    timeout: kotlin.time.Duration,
+  ): DataSubscribeResult = error("unused")
+
+  override fun listExtensions(timeout: kotlin.time.Duration): ExtensionsListResult = error("unused")
+
+  override fun enableExtensions(
+    ids: List<String>,
+    timeout: kotlin.time.Duration,
+  ): ExtensionsEnableResult = error("unused")
+
+  override fun disableExtensions(
+    ids: List<String>,
+    timeout: kotlin.time.Duration,
+  ): ExtensionsDisableResult = error("unused")
+
+  override fun historyList(
+    params: HistoryListParams,
+    timeout: kotlin.time.Duration,
+  ): HistoryListResult = error("unused")
+
+  override fun historyRead(
+    entryId: String,
+    inline: Boolean,
+    timeout: kotlin.time.Duration,
+  ): HistoryReadResultDto = error("unused")
+
+  override fun historyDiff(
+    fromId: String,
+    toId: String,
+    mode: HistoryDiffMode,
+    timeout: kotlin.time.Duration,
+  ): HistoryDiffResult = error("unused")
+
+  override fun recordingStart(
+    previewId: String,
+    fps: Int?,
+    scale: Float?,
+    overrides: PreviewOverrides?,
+    timeout: kotlin.time.Duration,
+  ): RecordingStartResult = error("unused")
+
+  override fun recordingScript(recordingId: String, events: List<RecordingScriptEvent>) =
+    error("unused")
+
+  override fun recordingStop(
+    recordingId: String,
+    timeout: kotlin.time.Duration,
+  ): RecordingStopResult = error("unused")
+
+  override fun recordingEncode(
+    recordingId: String,
+    format: RecordingFormat,
+    timeout: kotlin.time.Duration,
+  ): RecordingEncodeResult = error("unused")
+
+  override fun onNotification(listener: NotificationListener): AutoCloseable {
+    listeners.add(listener)
+    return AutoCloseable { listeners.remove(listener) }
+  }
+
+  override fun close() = Unit
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/FakeRenderSession.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/FakeRenderSession.kt
@@ -56,6 +56,12 @@ internal class FakeRenderSession(
   private val renderHook: ((call: Int, emit: (ByteArray) -> Unit) -> Unit)? = null,
   /** When false (default), the streaming methods throw (mimicking a non-streaming backend). */
   private val streaming: Boolean = false,
+  /**
+   * `StreamStartResult.heldSession` value when [streaming]; false models a non-interactive host.
+   */
+  private val heldSession: Boolean = true,
+  /** When set, [streamStart] emits a keyframe with this base64 payload *before* it returns. */
+  private val emitKeyframeOnStart: String? = null,
 ) : RenderSession {
   val renderCount = AtomicInteger(0)
   private val listeners = CopyOnWriteArrayList<NotificationListener>()
@@ -230,7 +236,13 @@ internal class FakeRenderSession(
     if (!streaming) throw UnsupportedOperationException("streaming not supported")
     val fsid = "fs-${streamStarts.incrementAndGet()}"
     lastFrameStreamId = fsid
-    return StreamStartResult(frameStreamId = fsid, codec = StreamCodec.PNG, heldSession = true)
+    // Model a daemon that emits the initial keyframe before the RPC response returns.
+    emitKeyframeOnStart?.let { emitStreamFrame(fsid, seq = 0, payloadBase64 = it) }
+    return StreamStartResult(
+      frameStreamId = fsid,
+      codec = StreamCodec.PNG,
+      heldSession = heldSession,
+    )
   }
 
   override fun streamStop(frameStreamId: String) {

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeLiveSessionTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeLiveSessionTest.kt
@@ -1,0 +1,120 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.daemon.protocol.InteractiveInputKind
+import java.io.File
+import java.util.Base64
+import java.util.concurrent.CopyOnWriteArrayList
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+class ServeLiveSessionTest {
+
+  private val previewId = "com.example.Red"
+
+  private fun newRenderRoot(): File =
+    java.nio.file.Files.createTempDirectory("serve-live").toFile().also { it.deleteOnExit() }
+
+  private fun host(session: FakeRenderSession): ServeRenderHost =
+    ServeRenderHost(session, listOf(ServePreview(previewId, "Red")), renderTimeoutSeconds = 30)
+
+  private fun typeOf(text: String): String =
+    Json.parseToJsonElement(text).jsonObject.getValue("type").jsonPrimitive.content
+
+  @Test
+  fun `tryStart returns null when streaming is unsupported`() {
+    val session = FakeRenderSession(newRenderRoot()) // streaming = false
+    host(session).use { h -> assertNull(ServeLiveSession.tryStart(h, previewId, emptyMap()) {}) }
+  }
+
+  @Test
+  fun `daemon-pushed frames are forwarded as frame messages`() {
+    val session = FakeRenderSession(newRenderRoot(), streaming = true)
+    host(session).use { h ->
+      val sent = CopyOnWriteArrayList<String>()
+      assertNotNull(ServeLiveSession.tryStart(h, previewId, emptyMap(), sent::add))
+      val fsid = assertNotNull(session.lastFrameStreamId)
+      val payload = Base64.getEncoder().encodeToString("xy".toByteArray())
+
+      session.emitStreamFrame(fsid, seq = 5, payloadBase64 = payload)
+
+      assertEquals(1, sent.size)
+      val obj = Json.parseToJsonElement(sent[0]).jsonObject
+      assertEquals("frame", obj.getValue("type").jsonPrimitive.content)
+      assertEquals("5", obj.getValue("seq").jsonPrimitive.content)
+      assertEquals(payload, obj.getValue("dataBase64").jsonPrimitive.content)
+    }
+  }
+
+  @Test
+  fun `unchanged heartbeat frames (no payload) are not forwarded`() {
+    val session = FakeRenderSession(newRenderRoot(), streaming = true)
+    host(session).use { h ->
+      val sent = CopyOnWriteArrayList<String>()
+      assertNotNull(ServeLiveSession.tryStart(h, previewId, emptyMap(), sent::add))
+      session.emitStreamFrame(
+        assertNotNull(session.lastFrameStreamId),
+        seq = 0,
+        payloadBase64 = null,
+      )
+      assertTrue(sent.isEmpty())
+    }
+  }
+
+  @Test
+  fun `input messages dispatch interactive input`() {
+    val session = FakeRenderSession(newRenderRoot(), streaming = true)
+    host(session).use { h ->
+      val live = assertNotNull(ServeLiveSession.tryStart(h, previewId, emptyMap()) {})
+      live.onClientMessage("""{"type":"input","kind":"click","pixelX":10,"pixelY":20}""")
+      assertEquals(1, session.interactiveInputs.size)
+      val input = session.interactiveInputs[0]
+      assertEquals(InteractiveInputKind.CLICK, input.kind)
+      assertEquals(10, input.pixelX)
+      assertEquals(20, input.pixelY)
+    }
+  }
+
+  @Test
+  fun `an unknown input kind yields an error and dispatches nothing`() {
+    val session = FakeRenderSession(newRenderRoot(), streaming = true)
+    host(session).use { h ->
+      val sent = CopyOnWriteArrayList<String>()
+      val live = assertNotNull(ServeLiveSession.tryStart(h, previewId, emptyMap(), sent::add))
+      live.onClientMessage("""{"type":"input","kind":"telepathy"}""")
+      assertEquals("error", typeOf(sent.last()))
+      assertTrue(session.interactiveInputs.isEmpty())
+    }
+  }
+
+  @Test
+  fun `setOverrides restarts the held stream`() {
+    val session = FakeRenderSession(newRenderRoot(), streaming = true)
+    host(session).use { h ->
+      val live = assertNotNull(ServeLiveSession.tryStart(h, previewId, emptyMap()) {})
+      val first = assertNotNull(session.lastFrameStreamId)
+      assertEquals(1, session.streamStarts.get())
+
+      live.onClientMessage("""{"type":"setOverrides","overrides":{"uiMode":"dark"}}""")
+
+      assertEquals(2, session.streamStarts.get(), "new overrides should restart the stream")
+      assertEquals(listOf(first), session.streamStops, "the previous stream should be stopped")
+    }
+  }
+
+  @Test
+  fun `closing the live session stops the stream`() {
+    val session = FakeRenderSession(newRenderRoot(), streaming = true)
+    host(session).use { h ->
+      val live = assertNotNull(ServeLiveSession.tryStart(h, previewId, emptyMap()) {})
+      val fsid = assertNotNull(session.lastFrameStreamId)
+      live.close()
+      assertEquals(listOf(fsid), session.streamStops)
+    }
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHostStreamTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHostStreamTest.kt
@@ -1,0 +1,74 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.daemon.protocol.InteractiveInputKind
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.daemon.protocol.StreamFrameParams
+import java.io.File
+import java.util.concurrent.CopyOnWriteArrayList
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class ServeRenderHostStreamTest {
+
+  private val previewId = "com.example.Red"
+
+  private fun newRenderRoot(): File =
+    java.nio.file.Files.createTempDirectory("serve-host-stream").toFile().also { it.deleteOnExit() }
+
+  private fun host(session: FakeRenderSession): ServeRenderHost =
+    ServeRenderHost(session, listOf(ServePreview(previewId, "Red")), renderTimeoutSeconds = 30)
+
+  @Test
+  fun `startStream returns null when the backend does not support streaming`() {
+    val session = FakeRenderSession(newRenderRoot()) // streaming = false
+    host(session).use { h -> assertNull(h.startStream(previewId, PreviewOverrides()) {}) }
+  }
+
+  @Test
+  fun `startStream forwards frames for its own frameStreamId only`() {
+    val session = FakeRenderSession(newRenderRoot(), streaming = true)
+    host(session).use { h ->
+      val frames = CopyOnWriteArrayList<StreamFrameParams>()
+      val handle = assertNotNull(h.startStream(previewId, PreviewOverrides()) { frames.add(it) })
+      val fsid = assertNotNull(session.lastFrameStreamId)
+
+      session.emitStreamFrame(fsid, seq = 0, payloadBase64 = "AAAA")
+      session.emitStreamFrame("some-other-stream", seq = 1, payloadBase64 = "BBBB")
+
+      assertEquals(1, frames.size, "only this stream's frames should be delivered")
+      assertEquals(0L, frames[0].seq)
+      handle.close()
+    }
+  }
+
+  @Test
+  fun `closing the handle stops the stream and unsubscribes`() {
+    val session = FakeRenderSession(newRenderRoot(), streaming = true)
+    host(session).use { h ->
+      val frames = CopyOnWriteArrayList<StreamFrameParams>()
+      val handle = assertNotNull(h.startStream(previewId, PreviewOverrides()) { frames.add(it) })
+      val fsid = assertNotNull(session.lastFrameStreamId)
+
+      handle.input(InteractiveInputKind.CLICK, pixelX = 3, pixelY = 4)
+      assertEquals(1, session.interactiveInputs.size)
+      assertEquals(InteractiveInputKind.CLICK, session.interactiveInputs[0].kind)
+
+      handle.close()
+      assertEquals(listOf(fsid), session.streamStops)
+
+      session.emitStreamFrame(fsid, seq = 9, payloadBase64 = "CCCC")
+      assertTrue(frames.isEmpty(), "frames after close must not be delivered")
+    }
+  }
+
+  @Test
+  fun `unknown preview id yields no stream`() {
+    val session = FakeRenderSession(newRenderRoot(), streaming = true)
+    host(session).use { h ->
+      assertNull(h.startStream("com.example.Missing", PreviewOverrides()) {})
+    }
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHostStreamTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHostStreamTest.kt
@@ -71,4 +71,27 @@ class ServeRenderHostStreamTest {
       assertNull(h.startStream("com.example.Missing", PreviewOverrides()) {})
     }
   }
+
+  @Test
+  fun `a keyframe emitted before stream-start returns is not lost`() {
+    // The daemon's frame loop can emit the initial keyframe before stream/start's RPC response —
+    // the listener must already be registered (and buffer it) so it isn't dropped.
+    val session =
+      FakeRenderSession(newRenderRoot(), streaming = true, emitKeyframeOnStart = "KEYFRAME")
+    host(session).use { h ->
+      val frames = CopyOnWriteArrayList<StreamFrameParams>()
+      assertNotNull(h.startStream(previewId, PreviewOverrides()) { frames.add(it) })
+      assertEquals(1, frames.size, "the pre-response keyframe must be replayed, not lost")
+      assertEquals(0L, frames[0].seq)
+    }
+  }
+
+  @Test
+  fun `no held session falls back (null) and stops the stream`() {
+    val session = FakeRenderSession(newRenderRoot(), streaming = true, heldSession = false)
+    host(session).use { h ->
+      assertNull(h.startStream(previewId, PreviewOverrides()) {})
+      assertEquals(1, session.streamStops.size, "the frameless stream must be torn down")
+    }
+  }
 }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHostTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHostTest.kt
@@ -1,46 +1,17 @@
 package ee.schimke.composeai.cli.serve
 
-import ee.schimke.composeai.daemon.protocol.ChangeType
-import ee.schimke.composeai.daemon.protocol.DataFetchResult
-import ee.schimke.composeai.daemon.protocol.DataSubscribeResult
-import ee.schimke.composeai.daemon.protocol.ExtensionsDisableResult
-import ee.schimke.composeai.daemon.protocol.ExtensionsEnableResult
-import ee.schimke.composeai.daemon.protocol.ExtensionsListResult
-import ee.schimke.composeai.daemon.protocol.FileKind
-import ee.schimke.composeai.daemon.protocol.HistoryDiffMode
-import ee.schimke.composeai.daemon.protocol.HistoryDiffResult
-import ee.schimke.composeai.daemon.protocol.HistoryListParams
-import ee.schimke.composeai.daemon.protocol.HistoryListResult
-import ee.schimke.composeai.daemon.protocol.HistoryReadResultDto
-import ee.schimke.composeai.daemon.protocol.InitializeResult
-import ee.schimke.composeai.daemon.protocol.Manifest
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
-import ee.schimke.composeai.daemon.protocol.RecordingEncodeResult
-import ee.schimke.composeai.daemon.protocol.RecordingFormat
-import ee.schimke.composeai.daemon.protocol.RecordingScriptEvent
-import ee.schimke.composeai.daemon.protocol.RecordingStartResult
-import ee.schimke.composeai.daemon.protocol.RecordingStopResult
-import ee.schimke.composeai.daemon.protocol.RejectedRender
-import ee.schimke.composeai.daemon.protocol.RenderNowResult
-import ee.schimke.composeai.daemon.protocol.RenderTier
-import ee.schimke.composeai.daemon.protocol.ServerCapabilities
 import ee.schimke.composeai.daemon.protocol.UiMode
-import ee.schimke.composeai.render.session.NotificationListener
 import ee.schimke.composeai.render.session.RenderSession
-import ee.schimke.composeai.render.session.RenderSessionBackend
 import java.io.File
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 
 class ServeRenderHostTest {
 
@@ -58,7 +29,7 @@ class ServeRenderHostTest {
 
   @Test
   fun `identical requests are served from cache after one render`() {
-    val session = FakeSession(newRenderRoot())
+    val session = FakeRenderSession(newRenderRoot())
     host(session).use { h ->
       val first = h.render(previewId, PreviewOverrides(uiMode = UiMode.DARK))
       val second = h.render(previewId, PreviewOverrides(uiMode = UiMode.DARK))
@@ -71,7 +42,7 @@ class ServeRenderHostTest {
 
   @Test
   fun `different overrides each render`() {
-    val session = FakeSession(newRenderRoot())
+    val session = FakeRenderSession(newRenderRoot())
     host(session).use { h ->
       h.render(previewId, PreviewOverrides(uiMode = UiMode.LIGHT))
       h.render(previewId, PreviewOverrides(uiMode = UiMode.DARK))
@@ -81,7 +52,7 @@ class ServeRenderHostTest {
 
   @Test
   fun `concurrent identical requests coalesce to a single render`() {
-    val session = FakeSession(newRenderRoot())
+    val session = FakeRenderSession(newRenderRoot())
     host(session).use { h ->
       val threads = 16
       val pool = Executors.newFixedThreadPool(threads)
@@ -105,7 +76,7 @@ class ServeRenderHostTest {
 
   @Test
   fun `unknown preview id is NotFound without rendering`() {
-    val session = FakeSession(newRenderRoot())
+    val session = FakeRenderSession(newRenderRoot())
     host(session).use { h ->
       assertEquals(RenderOutcome.NotFound, h.render("com.example.Missing", PreviewOverrides()))
       assertEquals(0, session.renderCount.get())
@@ -118,7 +89,7 @@ class ServeRenderHostTest {
     // (the daemon catching up) emits the timed-out render's STALE event first, then its own FRESH
     // event. The stale one must be drained, not cached/served under render 2's override key.
     val session =
-      FakeSession(
+      FakeRenderSession(
         newRenderRoot(),
         renderHook = { call, emit ->
           if (call == 2) {
@@ -149,168 +120,10 @@ class ServeRenderHostTest {
 
   @Test
   fun `a rejected render surfaces as Failed`() {
-    val session = FakeSession(newRenderRoot(), rejectAll = true)
+    val session = FakeRenderSession(newRenderRoot(), rejectAll = true)
     host(session).use { h ->
       val outcome = h.render(previewId, PreviewOverrides())
       assertTrue(outcome is RenderOutcome.Failed, "expected Failed, got $outcome")
     }
-  }
-
-  // -------------------------------------------------------------------------
-
-  /**
-   * Minimal [RenderSession]: writes a PNG whose bytes encode the overrides, emits renderFinished.
-   *
-   * [renderHook] (when set) overrides the default emit-immediately behaviour: it receives the
-   * 1-based call index and an `emit` that writes given bytes to a fresh PNG and fires
-   * `renderFinished` for the preview. A hook that emits nothing models a render that times out (the
-   * daemon owes a late event), letting tests drive the stale-event path.
-   */
-  private class FakeSession(
-    private val renderRoot: File,
-    private val rejectAll: Boolean = false,
-    private val renderHook: ((call: Int, emit: (ByteArray) -> Unit) -> Unit)? = null,
-  ) : RenderSession {
-    val renderCount = AtomicInteger(0)
-    private val listeners = CopyOnWriteArrayList<NotificationListener>()
-    private val counter = AtomicInteger(0)
-
-    private fun emitFinished(id: String, bytes: ByteArray) {
-      renderRoot.mkdirs()
-      val file =
-        File(renderRoot, "$id-${counter.incrementAndGet()}.png").apply { writeBytes(bytes) }
-      val params = buildJsonObject {
-        put("id", id)
-        put("pngPath", file.absolutePath)
-      }
-      listeners.forEach { it.onNotification("renderFinished", params) }
-    }
-
-    override val workspaceRoot: String = renderRoot.absolutePath
-    override val modulePath: String = ":sample"
-    override val initializeResult: InitializeResult =
-      InitializeResult(
-        protocolVersion = 2,
-        daemonVersion = "fake",
-        pid = 0,
-        capabilities =
-          ServerCapabilities(
-            incrementalDiscovery = false,
-            sandboxRecycle = false,
-            leakDetection = emptyList(),
-          ),
-        classpathFingerprint = "",
-        manifest = Manifest(path = "", previewCount = 0),
-      )
-    override val backendKind: RenderSessionBackend = RenderSessionBackend.Subprocess
-
-    override fun setVisible(previewIds: List<String>) = Unit
-
-    override fun setFocus(previewIds: List<String>) = Unit
-
-    override fun fileChanged(path: String, kind: FileKind, changeType: ChangeType) = Unit
-
-    override fun renderNow(
-      previewIds: List<String>,
-      tier: RenderTier,
-      reason: String?,
-      overrides: PreviewOverrides?,
-      timeout: kotlin.time.Duration,
-    ): RenderNowResult {
-      val call = renderCount.incrementAndGet()
-      val id = previewIds.single()
-      if (rejectAll) {
-        return RenderNowResult(queued = emptyList(), rejected = listOf(RejectedRender(id, "nope")))
-      }
-      val hook = renderHook
-      if (hook != null) {
-        hook(call) { bytes -> emitFinished(id, bytes) }
-      } else {
-        val content = "png:${overrides?.uiMode}:${overrides?.localeTag}:${overrides?.device}"
-        emitFinished(id, content.toByteArray())
-      }
-      return RenderNowResult(queued = previewIds, rejected = emptyList())
-    }
-
-    override fun fetchData(
-      previewId: String,
-      kind: String,
-      inline: Boolean,
-      params: JsonElement?,
-      timeout: kotlin.time.Duration,
-    ): DataFetchResult = error("unused")
-
-    override fun subscribeData(
-      previewId: String,
-      kind: String,
-      params: JsonElement?,
-      timeout: kotlin.time.Duration,
-    ): DataSubscribeResult = error("unused")
-
-    override fun unsubscribeData(
-      previewId: String,
-      kind: String,
-      timeout: kotlin.time.Duration,
-    ): DataSubscribeResult = error("unused")
-
-    override fun listExtensions(timeout: kotlin.time.Duration): ExtensionsListResult =
-      error("unused")
-
-    override fun enableExtensions(
-      ids: List<String>,
-      timeout: kotlin.time.Duration,
-    ): ExtensionsEnableResult = error("unused")
-
-    override fun disableExtensions(
-      ids: List<String>,
-      timeout: kotlin.time.Duration,
-    ): ExtensionsDisableResult = error("unused")
-
-    override fun historyList(
-      params: HistoryListParams,
-      timeout: kotlin.time.Duration,
-    ): HistoryListResult = error("unused")
-
-    override fun historyRead(
-      entryId: String,
-      inline: Boolean,
-      timeout: kotlin.time.Duration,
-    ): HistoryReadResultDto = error("unused")
-
-    override fun historyDiff(
-      fromId: String,
-      toId: String,
-      mode: HistoryDiffMode,
-      timeout: kotlin.time.Duration,
-    ): HistoryDiffResult = error("unused")
-
-    override fun recordingStart(
-      previewId: String,
-      fps: Int?,
-      scale: Float?,
-      overrides: PreviewOverrides?,
-      timeout: kotlin.time.Duration,
-    ): RecordingStartResult = error("unused")
-
-    override fun recordingScript(recordingId: String, events: List<RecordingScriptEvent>) =
-      error("unused")
-
-    override fun recordingStop(
-      recordingId: String,
-      timeout: kotlin.time.Duration,
-    ): RecordingStopResult = error("unused")
-
-    override fun recordingEncode(
-      recordingId: String,
-      format: RecordingFormat,
-      timeout: kotlin.time.Duration,
-    ): RecordingEncodeResult = error("unused")
-
-    override fun onNotification(listener: NotificationListener): AutoCloseable {
-      listeners.add(listener)
-      return AutoCloseable { listeners.remove(listener) }
-    }
-
-    override fun close() = Unit
   }
 }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeStreamProtocolTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeStreamProtocolTest.kt
@@ -48,6 +48,30 @@ class ServeStreamProtocolTest {
   }
 
   @Test
+  fun `well-formed JSON of the wrong shape never throws`() {
+    // type is not a string → unknown type → Unsupported (not a ClassCastException).
+    assertTrue(
+      ServeStreamProtocol.parseClient("""{"type":{}}""")
+        is ServeStreamProtocol.ClientMessage.Unsupported
+    )
+    // a non-object root.
+    assertTrue(
+      ServeStreamProtocol.parseClient("[]") is ServeStreamProtocol.ClientMessage.Unsupported
+    )
+    // overrides as an array → degrade to empty, don't throw.
+    val arr = ServeStreamProtocol.parseClient("""{"type":"setOverrides","overrides":[]}""")
+    assertTrue(arr is ServeStreamProtocol.ClientMessage.SetOverrides, "got $arr")
+    assertTrue(arr.overrides.isEmpty())
+    // a non-string override value is skipped, valid ones kept.
+    val mixed =
+      ServeStreamProtocol.parseClient(
+        """{"type":"setOverrides","overrides":{"uiMode":"dark","bad":{}}}"""
+      )
+    assertTrue(mixed is ServeStreamProtocol.ClientMessage.SetOverrides, "got $mixed")
+    assertEquals(mapOf("uiMode" to "dark"), mixed.overrides)
+  }
+
+  @Test
   fun `frame message carries seq, size, codec and base64 payload`() {
     val png = byteArrayOf(1, 2, 3, 4, 5)
     val obj = Json.parseToJsonElement(ServeStreamProtocol.frameMessage(7, 320, 640, png)).jsonObject

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeStreamProtocolTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeStreamProtocolTest.kt
@@ -36,6 +36,16 @@ class ServeStreamProtocolTest {
   }
 
   @Test
+  fun `parses input with pixel coordinates`() {
+    val msg =
+      ServeStreamProtocol.parseClient("""{"type":"input","kind":"click","pixelX":10,"pixelY":20}""")
+    assertTrue(msg is ServeStreamProtocol.ClientMessage.Input, "got $msg")
+    assertEquals("click", msg.kind)
+    assertEquals(10, msg.pixelX)
+    assertEquals(20, msg.pixelY)
+  }
+
+  @Test
   fun `unknown type and malformed json are Unsupported, never thrown`() {
     assertTrue(
       ServeStreamProtocol.parseClient("""{"type":"wat"}""")

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeStreamProtocolTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeStreamProtocolTest.kt
@@ -1,0 +1,72 @@
+package ee.schimke.composeai.cli.serve
+
+import java.util.Base64
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+class ServeStreamProtocolTest {
+
+  @Test
+  fun `parses setOverrides into a string map`() {
+    val msg =
+      ServeStreamProtocol.parseClient(
+        """{"type":"setOverrides","overrides":{"uiMode":"dark","device":"id:pixel_5"}}"""
+      )
+    assertTrue(msg is ServeStreamProtocol.ClientMessage.SetOverrides, "got $msg")
+    assertEquals(mapOf("uiMode" to "dark", "device" to "id:pixel_5"), msg.overrides)
+  }
+
+  @Test
+  fun `setOverrides with no overrides object yields an empty map`() {
+    val msg = ServeStreamProtocol.parseClient("""{"type":"setOverrides"}""")
+    assertTrue(msg is ServeStreamProtocol.ClientMessage.SetOverrides, "got $msg")
+    assertTrue(msg.overrides.isEmpty())
+  }
+
+  @Test
+  fun `parses requestFrame`() {
+    assertEquals(
+      ServeStreamProtocol.ClientMessage.RequestFrame,
+      ServeStreamProtocol.parseClient("""{"type":"requestFrame"}"""),
+    )
+  }
+
+  @Test
+  fun `unknown type and malformed json are Unsupported, never thrown`() {
+    assertTrue(
+      ServeStreamProtocol.parseClient("""{"type":"wat"}""")
+        is ServeStreamProtocol.ClientMessage.Unsupported
+    )
+    assertTrue(
+      ServeStreamProtocol.parseClient("not json at all")
+        is ServeStreamProtocol.ClientMessage.Unsupported
+    )
+  }
+
+  @Test
+  fun `frame message carries seq, size, codec and base64 payload`() {
+    val png = byteArrayOf(1, 2, 3, 4, 5)
+    val obj = Json.parseToJsonElement(ServeStreamProtocol.frameMessage(7, 320, 640, png)).jsonObject
+    assertEquals("frame", obj.getValue("type").jsonPrimitive.content)
+    assertEquals("7", obj.getValue("seq").jsonPrimitive.content)
+    assertEquals("png", obj.getValue("codec").jsonPrimitive.content)
+    assertEquals("320", obj.getValue("widthPx").jsonPrimitive.content)
+    assertEquals("640", obj.getValue("heightPx").jsonPrimitive.content)
+    assertContentEqualsB64(png, obj.getValue("dataBase64").jsonPrimitive.content)
+  }
+
+  @Test
+  fun `error message carries the reason`() {
+    val obj = Json.parseToJsonElement(ServeStreamProtocol.errorMessage("bad")).jsonObject
+    assertEquals("error", obj.getValue("type").jsonPrimitive.content)
+    assertEquals("bad", obj.getValue("message").jsonPrimitive.content)
+  }
+
+  private fun assertContentEqualsB64(expected: ByteArray, b64: String) {
+    assertEquals(expected.toList(), Base64.getDecoder().decode(b64).toList())
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeStreamSessionTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeStreamSessionTest.kt
@@ -1,0 +1,98 @@
+package ee.schimke.composeai.cli.serve
+
+import java.io.File
+import java.util.Base64
+import java.util.concurrent.CopyOnWriteArrayList
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+class ServeStreamSessionTest {
+
+  private val previewId = "com.example.Red"
+
+  private fun newRenderRoot(): File =
+    java.nio.file.Files.createTempDirectory("serve-stream").toFile().also { it.deleteOnExit() }
+
+  private fun host(): ServeRenderHost =
+    ServeRenderHost(
+      session = FakeRenderSession(newRenderRoot()),
+      previews = listOf(ServePreview(previewId, "Red")),
+      renderTimeoutSeconds = 30,
+    )
+
+  private fun typeOf(text: String): String =
+    Json.parseToJsonElement(text).jsonObject.getValue("type").jsonPrimitive.content
+
+  private fun frameBytes(text: String): ByteArray =
+    Base64.getDecoder()
+      .decode(Json.parseToJsonElement(text).jsonObject.getValue("dataBase64").jsonPrimitive.content)
+
+  @Test
+  fun `onOpen pushes one frame`() {
+    host().use { h ->
+      val sent = CopyOnWriteArrayList<String>()
+      ServeStreamSession(h, previewId, emptyMap(), sent::add).onOpen()
+      assertEquals(1, sent.size)
+      assertEquals("frame", typeOf(sent[0]))
+    }
+  }
+
+  @Test
+  fun `setOverrides re-renders and the frame reflects the new overrides`() {
+    host().use { h ->
+      val sent = CopyOnWriteArrayList<String>()
+      val session = ServeStreamSession(h, previewId, emptyMap(), sent::add)
+      session.onOpen()
+      session.onClientMessage("""{"type":"setOverrides","overrides":{"uiMode":"dark"}}""")
+
+      assertEquals(2, sent.size)
+      assertTrue(sent.all { typeOf(it) == "frame" })
+      // The fake encodes overrides into the PNG bytes, so different overrides → different frame.
+      assertTrue(
+        !frameBytes(sent[0]).contentEquals(frameBytes(sent[1])),
+        "frame after setOverrides should differ from the default frame",
+      )
+    }
+  }
+
+  @Test
+  fun `seq is monotonic across frames`() {
+    host().use { h ->
+      val sent = CopyOnWriteArrayList<String>()
+      val session = ServeStreamSession(h, previewId, emptyMap(), sent::add)
+      session.onOpen()
+      session.onClientMessage("""{"type":"requestFrame"}""")
+      session.onClientMessage("""{"type":"requestFrame"}""")
+      val seqs = sent.map {
+        Json.parseToJsonElement(it).jsonObject.getValue("seq").jsonPrimitive.content.toLong()
+      }
+      assertEquals(listOf(0L, 1L, 2L), seqs)
+    }
+  }
+
+  @Test
+  fun `invalid overrides produce an error frame, not a crash, and the lane stays open`() {
+    host().use { h ->
+      val sent = CopyOnWriteArrayList<String>()
+      val session = ServeStreamSession(h, previewId, emptyMap(), sent::add)
+      session.onClientMessage("""{"type":"setOverrides","overrides":{"uiMode":"chartreuse"}}""")
+      assertEquals("error", typeOf(sent.last()))
+      // Still usable afterwards.
+      session.onClientMessage("""{"type":"requestFrame"}""")
+      assertEquals("frame", typeOf(sent.last()))
+    }
+  }
+
+  @Test
+  fun `unsupported message yields an error`() {
+    host().use { h ->
+      val sent = CopyOnWriteArrayList<String>()
+      ServeStreamSession(h, previewId, emptyMap(), sent::add).onClientMessage("""{"type":"nope"}""")
+      assertEquals("error", typeOf(sent.single()))
+    }
+  }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -187,6 +187,9 @@ ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "kto
 # can't skew and re-trip the strict slf4j pin in :cli (see cli/build.gradle.kts constraints).
 ktor-server-core = { module = "io.ktor:ktor-server-core", version.ref = "ktor" }
 ktor-server-cio = { module = "io.ktor:ktor-server-cio", version.ref = "ktor" }
+# WebSockets plugin for the embedded server — backs the `serve` streamed-frame lane (`/ws/{id}`).
+# Same `ktor` version ref so it can't skew the slf4j pin in :cli.
+ktor-server-websockets = { module = "io.ktor:ktor-server-websockets", version.ref = "ktor" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 classgraph = { module = "io.github.classgraph:classgraph", version.ref = "classgraph" }

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonClient.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonClient.kt
@@ -22,6 +22,8 @@ import ee.schimke.composeai.daemon.protocol.HistoryReadParams
 import ee.schimke.composeai.daemon.protocol.HistoryReadResultDto
 import ee.schimke.composeai.daemon.protocol.InitializeParams
 import ee.schimke.composeai.daemon.protocol.InitializeResult
+import ee.schimke.composeai.daemon.protocol.InteractiveInputKind
+import ee.schimke.composeai.daemon.protocol.InteractiveInputParams
 import ee.schimke.composeai.daemon.protocol.JsonRpcNotification
 import ee.schimke.composeai.daemon.protocol.JsonRpcRequest
 import ee.schimke.composeai.daemon.protocol.Options
@@ -40,6 +42,10 @@ import ee.schimke.composeai.daemon.protocol.RenderNowResult
 import ee.schimke.composeai.daemon.protocol.RenderTier
 import ee.schimke.composeai.daemon.protocol.SetFocusParams
 import ee.schimke.composeai.daemon.protocol.SetVisibleParams
+import ee.schimke.composeai.daemon.protocol.StreamCodec
+import ee.schimke.composeai.daemon.protocol.StreamStartParams
+import ee.schimke.composeai.daemon.protocol.StreamStartResult
+import ee.schimke.composeai.daemon.protocol.StreamStopParams
 import java.io.ByteArrayOutputStream
 import java.io.Closeable
 import java.io.IOException
@@ -470,6 +476,79 @@ class DaemonClient(
     val resultElem = response["result"] ?: error("recording/encode: no result — full=$response")
     return json.decodeFromJsonElement(RecordingEncodeResult.serializer(), resultElem)
   }
+
+  /**
+   * Drives `stream/start`: opens a held interactive session and attaches a frame-stream consumer.
+   * The daemon then pushes `streamFrame` notifications (observed via [onNotification]) carrying
+   * inline base64 frames keyed by the returned [StreamStartResult.frameStreamId]. Throws (via
+   * [sendAndAwait] / the error branch) when the daemon doesn't implement streaming — callers fall
+   * back to per-frame renders.
+   */
+  fun streamStart(
+    previewId: String,
+    codec: StreamCodec? = null,
+    maxFps: Int? = null,
+    overrides: PreviewOverrides? = null,
+    timeout: Duration = 30.seconds,
+  ): StreamStartResult {
+    val id = nextId.getAndIncrement()
+    val params =
+      StreamStartParams(
+        previewId = previewId,
+        codec = codec,
+        maxFps = maxFps,
+        overrides = overrides,
+      )
+    val request =
+      JsonRpcRequest(
+        id = id,
+        method = "stream/start",
+        params = json.encodeToJsonElement(StreamStartParams.serializer(), params),
+      )
+    val response = sendAndAwait(id, request, timeout)
+    val errorElem = response["error"] as? JsonObject
+    if (errorElem != null) {
+      val message = errorElem["message"]?.jsonPrimitive?.contentOrNull ?: "stream/start failed"
+      error(message)
+    }
+    val resultElem = response["result"] ?: error("stream/start: no result — full=$response")
+    return json.decodeFromJsonElement(StreamStartResult.serializer(), resultElem)
+  }
+
+  /** Drives `stream/stop` (notification — no response). Tears down the held stream. */
+  fun streamStop(frameStreamId: String) =
+    sendNotification(
+      "stream/stop",
+      json.encodeToJsonElement(StreamStopParams.serializer(), StreamStopParams(frameStreamId)),
+    )
+
+  /**
+   * Drives `interactive/input` (notification — fire-and-forget) against a held stream's
+   * [frameStreamId]; the daemon dispatches the input into the live composition and emits the
+   * resulting `streamFrame`.
+   */
+  fun interactiveInput(
+    frameStreamId: String,
+    kind: InteractiveInputKind,
+    pixelX: Int? = null,
+    pixelY: Int? = null,
+    scrollDeltaY: Float? = null,
+    keyCode: String? = null,
+  ) =
+    sendNotification(
+      "interactive/input",
+      json.encodeToJsonElement(
+        InteractiveInputParams.serializer(),
+        InteractiveInputParams(
+          frameStreamId = frameStreamId,
+          kind = kind,
+          pixelX = pixelX,
+          pixelY = pixelY,
+          scrollDeltaY = scrollDeltaY,
+          keyCode = keyCode,
+        ),
+      ),
+    )
 
   /**
    * Sends `shutdown` (drains in-flight renders) then `exit`. Does not wait for process exit — the

--- a/render-session/api/src/main/kotlin/ee/schimke/composeai/render/session/RenderSession.kt
+++ b/render-session/api/src/main/kotlin/ee/schimke/composeai/render/session/RenderSession.kt
@@ -13,6 +13,7 @@ import ee.schimke.composeai.daemon.protocol.HistoryListParams
 import ee.schimke.composeai.daemon.protocol.HistoryListResult
 import ee.schimke.composeai.daemon.protocol.HistoryReadResultDto
 import ee.schimke.composeai.daemon.protocol.InitializeResult
+import ee.schimke.composeai.daemon.protocol.InteractiveInputKind
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.daemon.protocol.RecordingEncodeResult
 import ee.schimke.composeai.daemon.protocol.RecordingFormat
@@ -21,6 +22,8 @@ import ee.schimke.composeai.daemon.protocol.RecordingStartResult
 import ee.schimke.composeai.daemon.protocol.RecordingStopResult
 import ee.schimke.composeai.daemon.protocol.RenderNowResult
 import ee.schimke.composeai.daemon.protocol.RenderTier
+import ee.schimke.composeai.daemon.protocol.StreamCodec
+import ee.schimke.composeai.daemon.protocol.StreamStartResult
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
@@ -218,6 +221,43 @@ interface RenderSession : AutoCloseable {
     format: RecordingFormat = RecordingFormat.APNG,
     timeout: Duration = 60.seconds,
   ): RecordingEncodeResult
+
+  // ---------------------------------------------------------------------------
+  // Streaming (optional — daemon `stream/start` + `streamFrame` + `interactive/input`).
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Start a held streamed-frame session for one preview (daemon `stream/start`). The renderer then
+   * pushes `streamFrame` notifications — observe via [onNotification] — carrying inline base64
+   * frames keyed by [StreamStartResult.frameStreamId]. The default throws
+   * [UnsupportedOperationException]; callers that want graceful degradation catch it (or any
+   * failure) and fall back to [renderNow]-per-frame. Only the subprocess/daemon backend overrides
+   * this.
+   */
+  fun streamStart(
+    previewId: String,
+    codec: StreamCodec? = null,
+    maxFps: Int? = null,
+    overrides: PreviewOverrides? = null,
+    timeout: Duration = 30.seconds,
+  ): StreamStartResult = throw UnsupportedOperationException("streaming not supported")
+
+  /** Stop a held stream (daemon `stream/stop`, fire-and-forget). Default throws. */
+  fun streamStop(frameStreamId: String): Unit =
+    throw UnsupportedOperationException("streaming not supported")
+
+  /**
+   * Dispatch an input event into a held stream's live composition (daemon `interactive/input`,
+   * fire-and-forget); the resulting frame arrives as a `streamFrame`. Default throws.
+   */
+  fun interactiveInput(
+    frameStreamId: String,
+    kind: InteractiveInputKind,
+    pixelX: Int? = null,
+    pixelY: Int? = null,
+    scrollDeltaY: Float? = null,
+    keyCode: String? = null,
+  ): Unit = throw UnsupportedOperationException("streaming not supported")
 
   // ---------------------------------------------------------------------------
   // Notifications.

--- a/render-session/subprocess/src/main/kotlin/ee/schimke/composeai/render/session/subprocess/DaemonClientRenderSession.kt
+++ b/render-session/subprocess/src/main/kotlin/ee/schimke/composeai/render/session/subprocess/DaemonClientRenderSession.kt
@@ -13,6 +13,7 @@ import ee.schimke.composeai.daemon.protocol.HistoryListParams
 import ee.schimke.composeai.daemon.protocol.HistoryListResult
 import ee.schimke.composeai.daemon.protocol.HistoryReadResultDto
 import ee.schimke.composeai.daemon.protocol.InitializeResult
+import ee.schimke.composeai.daemon.protocol.InteractiveInputKind
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.daemon.protocol.RecordingEncodeResult
 import ee.schimke.composeai.daemon.protocol.RecordingFormat
@@ -21,6 +22,8 @@ import ee.schimke.composeai.daemon.protocol.RecordingStartResult
 import ee.schimke.composeai.daemon.protocol.RecordingStopResult
 import ee.schimke.composeai.daemon.protocol.RenderNowResult
 import ee.schimke.composeai.daemon.protocol.RenderTier
+import ee.schimke.composeai.daemon.protocol.StreamCodec
+import ee.schimke.composeai.daemon.protocol.StreamStartResult
 import ee.schimke.composeai.mcp.DaemonClient
 import ee.schimke.composeai.mcp.DataProductWireException
 import ee.schimke.composeai.render.session.DataProductException
@@ -214,6 +217,47 @@ class DaemonClientRenderSession(
   ): RecordingEncodeResult {
     checkOpen()
     return client.recordingEncode(recordingId = recordingId, format = format, timeout = timeout)
+  }
+
+  override fun streamStart(
+    previewId: String,
+    codec: StreamCodec?,
+    maxFps: Int?,
+    overrides: PreviewOverrides?,
+    timeout: Duration,
+  ): StreamStartResult {
+    checkOpen()
+    return client.streamStart(
+      previewId = previewId,
+      codec = codec,
+      maxFps = maxFps,
+      overrides = overrides,
+      timeout = timeout,
+    )
+  }
+
+  override fun streamStop(frameStreamId: String) {
+    checkOpen()
+    client.streamStop(frameStreamId)
+  }
+
+  override fun interactiveInput(
+    frameStreamId: String,
+    kind: InteractiveInputKind,
+    pixelX: Int?,
+    pixelY: Int?,
+    scrollDeltaY: Float?,
+    keyCode: String?,
+  ) {
+    checkOpen()
+    client.interactiveInput(
+      frameStreamId = frameStreamId,
+      kind = kind,
+      pixelX = pixelX,
+      pixelY = pixelY,
+      scrollDeltaY = scrollDeltaY,
+      keyCode = keyCode,
+    )
   }
 
   override fun onNotification(listener: NotificationListener): AutoCloseable {

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing.html
@@ -25,7 +25,8 @@ a:hover { text-decoration: underline; }
 .cp-stage { flex: 1 1 360px; min-width: 280px; border: 1px solid #e3e3e8; border-radius: 10px;
   background: repeating-conic-gradient(#f4f4f6 0% 25%, #fff 0% 50%) 50% / 16px 16px; padding: 12px;
   display: flex; align-items: center; justify-content: center; min-height: 320px; }
-.cp-stage img { max-width: 100%; height: auto; }
+.cp-stage img, .cp-stage canvas { max-width: 100%; height: auto; }
+.cp-live-row { flex-direction: row !important; align-items: center; gap: 6px !important; }
 .cp-controls { flex: 0 0 240px; display: flex; flex-direction: column; gap: 14px; }
 .cp-controls label { display: flex; flex-direction: column; gap: 4px; font-size: 0.8rem; }
 .cp-controls input, .cp-controls select { padding: 5px 6px; font-size: 0.85rem; }

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
@@ -122,15 +122,25 @@ a:hover { text-decoration: underline; }
     next.onerror = function () { status.textContent = "render failed"; };
     next.src = url;
   }
-  function drawFrame(b64) {
+  function drawFrame(b64, codec) {
     var im = new Image();
     im.onload = function () {
       canvas.width = im.naturalWidth;
       canvas.height = im.naturalHeight;
       canvas.getContext("2d").drawImage(im, 0, 0);
     };
-    im.src = "data:image/png;base64," + b64;
+    im.src = "data:image/" + (codec || "png") + ";base64," + b64;
   }
+  // Forward clicks on the live canvas as input (image-natural pixels). No-op on the snapshot
+  // lane (it has no live stream and reports "input requires a live stream").
+  canvas.addEventListener("click", function (ev) {
+    if (!ws || ws.readyState !== 1 || !canvas.width) return;
+    var rect = canvas.getBoundingClientRect();
+    if (!rect.width || !rect.height) return;
+    var px = Math.round((ev.clientX - rect.left) / rect.width * canvas.width);
+    var py = Math.round((ev.clientY - rect.top) / rect.height * canvas.height);
+    ws.send(JSON.stringify({ type: "input", kind: "click", pixelX: px, pixelY: py }));
+  });
   function openStream() {
     root.setAttribute("data-mode", "live");
     img.hidden = true;
@@ -142,7 +152,7 @@ a:hover { text-decoration: underline; }
     ws.onmessage = function (ev) {
       var m;
       try { m = JSON.parse(ev.data); } catch (e) { return; }
-      if (m.type === "frame") { drawFrame(m.dataBase64); status.textContent = ""; }
+      if (m.type === "frame") { drawFrame(m.dataBase64, m.codec); status.textContent = ""; }
       else if (m.type === "error") { status.textContent = m.message || "error"; }
     };
     ws.onerror = function () { status.textContent = "stream error"; };

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
@@ -25,7 +25,8 @@ a:hover { text-decoration: underline; }
 .cp-stage { flex: 1 1 360px; min-width: 280px; border: 1px solid #e3e3e8; border-radius: 10px;
   background: repeating-conic-gradient(#f4f4f6 0% 25%, #fff 0% 50%) 50% / 16px 16px; padding: 12px;
   display: flex; align-items: center; justify-content: center; min-height: 320px; }
-.cp-stage img { max-width: 100%; height: auto; }
+.cp-stage img, .cp-stage canvas { max-width: 100%; height: auto; }
+.cp-live-row { flex-direction: row !important; align-items: center; gap: 6px !important; }
 .cp-controls { flex: 0 0 240px; display: flex; flex-direction: column; gap: 14px; }
 .cp-controls label { display: flex; flex-direction: column; gap: 4px; font-size: 0.8rem; }
 .cp-controls input, .cp-controls select { padding: 5px 6px; font-size: 0.85rem; }
@@ -42,8 +43,9 @@ a:hover { text-decoration: underline; }
               <p class="cp-head"><a href="/?token=demo-token-fixture">← previews</a></p>
       <p class="cp-sub" title="com.example.ProfileScreenPreview">Profile screen</p>
       <div class="cp-viewer" data-preview-id="com.example.ProfileScreenPreview" data-mode="snapshot" data-modes="snapshot,live">
-        <div class="cp-stage"><img id="cp-img" alt="Profile screen"></div>
+        <div class="cp-stage"><img id="cp-img" alt="Profile screen"><canvas id="cp-canvas" hidden></canvas></div>
         <div class="cp-controls">
+          <label class="cp-live-row"><input id="cp-live" type="checkbox"> Live (stream)</label>
           <label>Theme
             <select id="cp-uiMode">
               <option value="">(default)</option>
@@ -82,47 +84,100 @@ a:hover { text-decoration: underline; }
   "use strict";
   var root = document.querySelector(".cp-viewer");
   var img = document.getElementById("cp-img");
+  var canvas = document.getElementById("cp-canvas");
   var status = document.getElementById("cp-status");
+  var live = document.getElementById("cp-live");
   var previewId = root.getAttribute("data-preview-id");
   var token = new URLSearchParams(location.search).get("token") || "";
   // The selects + text input are opt-in (empty value = "use the preview's default"). The font
   // scale slider has no empty state, so it's gated separately: we only send fontScale once the
-  // user moves it (see fontScaleTouched), otherwise the slider's standing 1.0 would override a
+  // user moves it (fontScaleTouched), otherwise the slider's standing 1.0 would override a
   // preview's declared default font scale and the first render wouldn't match the thumbnail.
   var fields = ["uiMode", "device", "localeTag", "orientation"];
   var fs = document.getElementById("cp-fontScale");
   var fsVal = document.getElementById("cp-fontScale-val");
   var fontScaleTouched = false;
+  var ws = null;
 
-  function renderUrl() {
-    var q = "token=" + encodeURIComponent(token);
+  function overrides() {
+    var o = {};
     fields.forEach(function (f) {
       var el = document.getElementById("cp-" + f);
-      if (el && el.value) q += "&" + f + "=" + encodeURIComponent(el.value);
+      if (el && el.value) o[f] = el.value;
     });
-    if (fontScaleTouched && fs) q += "&fontScale=" + encodeURIComponent(fs.value);
-    return "/render/" + encodeURIComponent(previewId) + ".png?" + q;
+    if (fontScaleTouched && fs) o.fontScale = fs.value;
+    return o;
   }
-  function refresh() {
+  function query() {
+    var o = overrides();
+    var q = "token=" + encodeURIComponent(token);
+    Object.keys(o).forEach(function (k) { q += "&" + k + "=" + encodeURIComponent(o[k]); });
+    return q;
+  }
+  function refreshSnapshot() {
     status.textContent = "rendering…";
-    var url = renderUrl();
+    var url = "/render/" + encodeURIComponent(previewId) + ".png?" + query();
     var next = new Image();
     next.onload = function () { img.src = url; status.textContent = ""; };
     next.onerror = function () { status.textContent = "render failed"; };
     next.src = url;
   }
+  function drawFrame(b64) {
+    var im = new Image();
+    im.onload = function () {
+      canvas.width = im.naturalWidth;
+      canvas.height = im.naturalHeight;
+      canvas.getContext("2d").drawImage(im, 0, 0);
+    };
+    im.src = "data:image/png;base64," + b64;
+  }
+  function openStream() {
+    root.setAttribute("data-mode", "live");
+    img.hidden = true;
+    canvas.hidden = false;
+    status.textContent = "connecting…";
+    var proto = location.protocol === "https:" ? "wss:" : "ws:";
+    ws = new WebSocket(proto + "//" + location.host + "/ws/" +
+      encodeURIComponent(previewId) + "?" + query());
+    ws.onmessage = function (ev) {
+      var m;
+      try { m = JSON.parse(ev.data); } catch (e) { return; }
+      if (m.type === "frame") { drawFrame(m.dataBase64); status.textContent = ""; }
+      else if (m.type === "error") { status.textContent = m.message || "error"; }
+    };
+    ws.onerror = function () { status.textContent = "stream error"; };
+    ws.onclose = function () { ws = null; };
+  }
+  function closeStream() {
+    root.setAttribute("data-mode", "snapshot");
+    if (ws) { ws.close(); ws = null; }
+    canvas.hidden = true;
+    img.hidden = false;
+  }
+  function onControlsChanged() {
+    if (live.checked && ws && ws.readyState === 1) {
+      ws.send(JSON.stringify({ type: "setOverrides", overrides: overrides() }));
+    } else if (!live.checked) {
+      refreshSnapshot();
+    }
+  }
+
+  live.addEventListener("change", function () {
+    if (live.checked) openStream();
+    else { closeStream(); refreshSnapshot(); }
+  });
   if (fs) {
     fs.addEventListener("input", function () {
       fsVal.textContent = fs.value;
       fontScaleTouched = true;
-      refresh();
+      onControlsChanged();
     });
   }
   fields.forEach(function (f) {
     var el = document.getElementById("cp-" + f);
-    if (el) el.addEventListener("change", refresh);
+    if (el) el.addEventListener("change", onControlsChanged);
   });
-  refresh();
+  refreshSnapshot();
 })();</script>
       </body>
     </html>


### PR DESCRIPTION
## Summary

Tier-2 streaming for `compose-preview serve`: a persistent `WS /ws/{previewId}` lane with two backends behind one browser-facing wire shape, plus a "Live (stream)" toggle in the viewer that paints frames to a `<canvas>`.

> Scope note: this PR consolidated the tier-2 work — it began as the WebSocket *spike* and now also carries the **live daemon-streaming** follow-on (originally #1993, merged into this branch) and its review fixes. `main` still has only tier-1.

**Snapshot lane** (`ServeStreamSession`): reuses the tier-1 `ServeRenderHost` — re-renders on client message and pushes PNG frames. No daemon protocol change; fully headless-testable. Used as the fallback.

**Live lane** (`ServeLiveSession`, preferred): adopts the daemon's native `stream/start` + `streamFrame` + `interactive/input` so frames are *pushed* (animations, recomposition, input results) and clicks dispatch into the live composition.
- Public API: `RenderSession.streamStart/streamStop/interactiveInput` (default-throwing — non-breaking for other implementers), overridden in `DaemonClientRenderSession` → new `DaemonClient` methods.
- `ServeRenderHost.startStream` opens a held stream, routes `streamFrame` (filtered by `frameStreamId`) to a callback, returns a `StreamHandle`; **registers the listener before `stream/start`** (buffers + replays so the initial keyframe isn't lost) and **falls back to snapshots when `heldSession=false`**.
- The WS route prefers live, transparently falls back to snapshot.
- Viewer forwards canvas clicks as `input` and honours each frame's `codec` (WebP-aware).
- `ServeStreamProtocol`: pure JSON message layer (`setOverrides`/`requestFrame`/`input` → `frame`/`error`), mirroring the daemon wire shape (base64 + codec + monotonic `seq`); parses defensively (malformed/wrong-shape JSON never throws).

`ktor-server-websockets` added against the same `ktor` ref (slf4j pin holds).

## Test plan
- `:cli:compileKotlin` / `compileTestKotlin` green; `ktfmtFormatAll` clean; `:cli:checkCliDaemonLibraryBoundary` green.
- Serve unit suite green (49): `ServeStreamProtocolTest`, `ServeStreamSessionTest`, `ServeLiveSessionTest`, `ServeRenderHostStreamTest` (incl. keyframe-before-response replay, `heldSession=false` fallback), plus the tier-1 host/override/url/bundle tests.
- **Visual evidence:** visual-diff bot re-renders `serve-viewer` (Live toggle); the live path itself is exercised by CI's daemon-harness lanes (needs a real daemon), not the headless fixture.