### PR TITLE
fix(cli): keep auto-inject on when only the config-only plugin is convention-supplied

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/AutoInject.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/AutoInject.kt
@@ -652,16 +652,24 @@ private val COMPOSE_AI_PREVIEW_SCAN_SKIP_DIRS =
 
 /**
  * Walks [buildDir] for any `build.gradle[.kts]` whose (comment-stripped) text references the
- * `ee.schimke.composeai.preview` coordinate. Iterative DFS over [fileSystem] that prunes
- * generated/output dirs and caps the number of directories visited so it stays cheap on large or
- * adversarial trees. Used only by [includedBuildProvidesComposeAiPreviewPlugin].
+ * **runtime** `ee.schimke.composeai.preview` plugin coordinate. Iterative DFS over [fileSystem]
+ * that prunes generated/output dirs and caps the number of directories visited so it stays cheap on
+ * large or adversarial trees. Used only by [includedBuildProvidesComposeAiPreviewPlugin].
+ *
+ * The negative lookahead excludes the **configuration-only** plugin
+ * (`ee.schimke.composeai.preview.config` / `…preview.config.gradle.plugin`), of which the runtime
+ * id is a prefix. A convention build that supplies only the config-only plugin does NOT supply the
+ * runtime — auto-inject must stay ON so the CLI still injects the runtime; treating it as
+ * convention-provided would wrongly disable injection and leave the build with no render tasks. The
+ * config impl artifact (`compose-preview-config`) contains no `ee.schimke.composeai.preview`
+ * substring, so only the dotted-id forms need excluding.
  */
 private fun buildScriptsReferenceComposeAiPreview(
   buildDir: File,
   fileSystem: FileSystem,
   maxDirs: Int = 500,
 ): Boolean {
-  val coordinate = Regex("""ee\.schimke\.composeai\.preview""")
+  val coordinate = Regex("""ee\.schimke\.composeai\.preview(?!\.config)""")
   val root = buildDir.path.toPath()
   if (fileSystem.metadataOrNull(root)?.isDirectory != true) return false
   val stack = ArrayDeque<okio.Path>().apply { addLast(root) }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/AutoInjectTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/AutoInjectTest.kt
@@ -923,6 +923,38 @@ class AutoInjectTest {
   }
 
   @Test
+  fun `includedBuildProvidesComposeAiPreviewPlugin is false when build-logic supplies only the config-only plugin`() {
+    // A convention build that stages ONLY the configuration-only plugin marker
+    // (`ee.schimke.composeai.preview.config.gradle.plugin`) does not supply the rendering runtime.
+    // The runtime id `ee.schimke.composeai.preview` is a prefix of the config id, so a naive
+    // substring scan would false-positive here and wrongly disable auto-inject — leaving the build
+    // with the config DSL but no render tasks. Auto-inject must stay ON so the CLI injects the
+    // runtime.
+    val projectRoot = tempDir()
+    seedConventionPluginBuild(
+      projectRoot,
+      buildLogicScript =
+        "implementation(\"ee.schimke.composeai.preview.config:ee.schimke.composeai.preview.config.gradle.plugin:0.15.12\")",
+    )
+    assertFalse(includedBuildProvidesComposeAiPreviewPlugin(projectRoot))
+  }
+
+  @Test
+  fun `includedBuildProvidesComposeAiPreviewPlugin still detects runtime when both plugins are referenced`() {
+    // A convention build that supplies BOTH the config-only plugin and the runtime must still be
+    // detected as providing the runtime (the `.config` exclusion must not swallow a real runtime
+    // reference sitting alongside it).
+    val projectRoot = tempDir()
+    seedConventionPluginBuild(
+      projectRoot,
+      buildLogicScript =
+        "implementation(\"ee.schimke.composeai.preview.config:ee.schimke.composeai.preview.config.gradle.plugin:0.15.12\")\n" +
+          "  implementation(\"ee.schimke.composeai.preview:ee.schimke.composeai.preview.gradle.plugin:0.15.12\")",
+    )
+    assertTrue(includedBuildProvidesComposeAiPreviewPlugin(projectRoot))
+  }
+
+  @Test
   fun `includedBuildProvidesComposeAiPreviewPlugin detects the dep in an included-build subproject`() {
     // Multi-project convention build: the plugin dep lives in build-logic/conventions, not the
     // build-logic root script (PR #1939 review). The recursive scan must still find it.


### PR DESCRIPTION
## Summary

Follow-up to #1985 (the configuration-only plugin). Fixes an auto-inject correctness bug that the config-only plugin's id introduced.

`buildScriptsReferenceComposeAiPreview` — used by `includedBuildProvidesComposeAiPreviewPlugin` to detect when an included **convention build** supplies the rendering runtime on its classpath — matched the bare substring `ee.schimke.composeai.preview`. That string is a **prefix of the config-only plugin id** `ee.schimke.composeai.preview.config`. So a convention build (`build-logic`) that staged only the config-only plugin marker was mistaken for supplying the runtime, and the CLI disabled auto-inject — leaving the build with the `composePreview { }` DSL but **no render tasks**, because the runtime was never injected.

This directly undermines the config-only plugin's purpose ("apply config, have the CLI pick it up and inject the runtime").

### Fix
Exclude the config plugin from the runtime-coordinate scan with a negative lookahead: `ee\.schimke\.composeai\.preview(?!\.config)`. The config impl artifact (`compose-preview-config`) contains no `ee.schimke.composeai.preview` substring, so only the dotted-id forms (`…preview.config`, `…preview.config.gradle.plugin`) need excluding.

The sibling scans are already config-safe via their quote/colon boundaries, verified by inspection:
- `scanForComposeAiPreviewDeclaration` — `id("ee.schimke.composeai.preview")` requires a closing quote right after `preview`.
- `composeAiPreviewCatalogAccessors` — `"ee.schimke.composeai.preview"` / `"…preview:version"` are quote/colon bounded.
- the init-script's embedded copies of both — same boundaries.

So `buildScriptsReferenceComposeAiPreview` was the only substring hazard.

## Test plan

- `:cli:test --tests AutoInjectTest` — green, including two new regression tests:
  - a convention build supplying **only** the config-only plugin keeps auto-inject **on** (`includedBuildProvidesComposeAiPreviewPlugin` → false);
  - a convention build supplying **both** the config-only plugin and the runtime still detects the runtime (→ true).
- `ktfmtCheck` on the touched CLI sources. ✅

Non-visual change (CLI auto-inject plumbing), so text-only evidence.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EZERsJRAD5Pvjgpjr83CX6)_