### PR TITLE
ci: move heavy drift-detector jobs off the PR critical path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,15 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Nightly full run. The heavy "anti-bit-rot" jobs below (XR composite render,
+  # the two bundle E2Es, agent-audit-samples) are drift detectors that rarely
+  # fail on an ordinary code PR but cost 6–12 min each and dominate the PR
+  # critical path. They're gated off `pull_request` (see the per-job `if:`s) and
+  # instead run here nightly + on every push to main (i.e. immediately
+  # post-merge), so a regression is still caught within minutes of landing
+  # without making every PR wait on them.
+  schedule:
+    - cron: "23 4 * * *"
 
 # Workflow-level default: minimum viable scope. Individual jobs can widen if
 # they need it (none here do — all jobs are read-only builds + artifact upload,
@@ -174,7 +183,10 @@ jobs:
   # rot. The graceful no-binary path is covered by the plugin unit/functional tests.
   render-xr-composite:
     name: Render XR composite (sample)
-    if: ${{ !(startsWith(github.head_ref, 'release-please--') && github.event.pull_request.user.login == 'github-actions[bot]') }}
+    # Heavy (builds the native clang compositor + Xvfb render, ~6 min). Drift
+    # detector, not a PR gate — runs on push-to-main + nightly, skipped on PRs
+    # (a skipped required check counts as passing for branch protection).
+    if: ${{ github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -322,7 +334,10 @@ jobs:
 
   bundle-render:
     name: Bundle Render E2E
-    if: ${{ !(startsWith(github.head_ref, 'release-please--') && github.event.pull_request.user.login == 'github-actions[bot]') }}
+    # Heavy E2E (~7 min, cold-starts Compose Desktop per preview). Drift
+    # detector — runs on push-to-main + nightly, skipped on PRs (skipped
+    # required check == passing).
+    if: ${{ github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -354,7 +369,10 @@ jobs:
 
   android-bundle-daemon-e2e:
     name: Android Bundle Daemon E2E
-    if: ${{ !(startsWith(github.head_ref, 'release-please--') && github.event.pull_request.user.login == 'github-actions[bot]') }}
+    # Heavy E2E (~9 min, cold-starts a daemon JVM per bundle). Drift detector —
+    # runs on push-to-main + nightly, skipped on PRs (skipped required check ==
+    # passing).
+    if: ${{ github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -413,7 +431,10 @@ jobs:
 
   agent-audit-samples:
     name: Agent Audit Samples
-    if: ${{ !(startsWith(github.head_ref, 'release-please--') && github.event.pull_request.user.login == 'github-actions[bot]') }}
+    # Longest single job (~12 min; one external-fetched audit script). Drift
+    # detector — runs on push-to-main + nightly, skipped on PRs (skipped
+    # required check == passing).
+    if: ${{ github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3


### PR DESCRIPTION
## Summary

PRs were taking **~10–12 min on a quiet repo but 20–25 min under runner contention** to go green. Investigation of recent runs showed the cost was concentrated in a few heavy "anti-bit-rot" jobs that rarely fail on an ordinary code change, plus self-inflicted runner queueing (in one 25-min `ci.yml` run, several jobs sat **13–15 min in the queue** before starting).

This moves those jobs off the PR critical path without losing coverage — they still run on **push-to-main (immediately post-merge)** and on a **new nightly schedule**.

### `ci.yml`
- Add a nightly `schedule` trigger.
- Gate the four long-pole jobs on `github.event_name != 'pull_request'`:
  - `agent-audit-samples` (~12 min — the single longest job)
  - `android-bundle-daemon-e2e` (~9 min)
  - `bundle-render` (~7 min)
  - `render-xr-composite` (~6 min, builds the native compositor + Xvfb)

They **skip on PRs** (a skipped required check counts as passing for branch protection) and run on push-to-main + nightly. **No check names are added or removed**, so branch-protection required checks are unaffected — the only change is *when* these jobs run.

### Verified on this PR
The four long-pole jobs report **`skipped`** on this PR exactly as intended; the remaining required checks run normally.

### Expected effect
PR-blocking `ci.yml` critical path drops from ~25 min worst-case toward ~8–10 min, and the four heavy jobs stop competing for runners on every PR, which removes much of the queueing behind the bad cases.

## Test plan
- `python3 -c "import yaml; yaml.safe_load(...)"` passes for the edited workflow.
- On this PR, the four `ci` long-pole jobs report **skipped**; remaining required checks run and gate the merge.
- After merge, the push-to-main run and the nightly schedule execute the full suite.

## Deferred (was in this PR, now pulled out)
The first revision also trimmed `integration.yml`'s 8-cell PR matrix to 3 representative cells via a `matrix.pr_blocking` flag in the **job-level `if:`**. Codex correctly flagged this as a P1 bug: the `matrix` context is **not available** in `jobs.<job_id>.if` (it's evaluated before the matrix expands), so the whole `integration` workflow errored out. That change has been **reverted** from this PR.

Doing it correctly needs a **dynamic matrix** (a setup job emitting the cell list as JSON, gated on `github.event_name`). That approach makes trimmed cells *absent* on PRs rather than *skipped*, so — unlike the `ci.yml` change here — it only stays branch-protection-safe if the individual integration matrix cells are **not** required status checks (the stable `build-plugin` / `agp8-min` jobs likely are; the volatile per-repo cells likely aren't). Tracking as a follow-up pending confirmation of the required-check list.

## Also deferred
Merging the tiny `ci` jobs (`spatial-scene-codegen`, `actions-tests`) and path-filtering surface-specific required workflows — both remove/rename check names and need the branch-protection ruleset updated in lockstep.
