### PR TITLE
ci: skip non-representative integration cells' build work on PRs

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -157,6 +157,16 @@ jobs:
             ref: main
             workdir: ComposeStarter
             module: app
+            # PR-blocking sample. All matrix cells run on the daily cron (drift
+            # signal against live upstream repos); on `pull_request` only the
+            # cells flagged `pr_blocking: true` do their build/discover/render
+            # work (gated at step level — see the `Discover`/`Verify`/`Render`
+            # steps below). The other cells still spin up but skip the expensive
+            # gradle steps, so their check still reports (branch-protection-safe)
+            # while ~5 external builds drop off the PR critical path. This cell is
+            # the widest coverage: full render pipeline + daemon round-trip +
+            # IP/CC end-to-end.
+            pr_blocking: true
             # ComposeStarter enables isolated-projects + configuration-cache. The plugin used to
             # need `-Dorg.gradle.unsafe.isolated-projects=false -Dorg.gradle.isolated-projects
             # =false --no-configuration-cache` here because of `rootProject.findProject` walks +
@@ -235,6 +245,8 @@ jobs:
             ref: main
             workdir: .
             module: app
+            # PR-blocking sample: a large modern single-module app.
+            pr_blocking: true
             # No opt-outs after #1546's IP-cleanup pass (#1549 tracks the cross-project-metadata
             # follow-up). Re-add specific flags here (with a fresh comment naming the regression)
             # if the consumer's build surfaces a new CC / IP gap.
@@ -272,6 +284,9 @@ jobs:
             repo: android/nowinandroid
             ref: main
             workdir: .
+            # PR-blocking sample: flavored multi-module discovery (guards the
+            # #1546 variant-matching fix against a large real project).
+            pr_blocking: true
             # `:app` declares productFlavors `demo` / `prod` with build types
             # `debug` / `release`, so its variants are `demoDebug`, `prodDebug`,
             # `demoRelease`, `prodRelease` — no plain `debug`. `:app-nia-catalog`
@@ -708,7 +723,11 @@ jobs:
         run: ${{ matrix.pre_gradle_script }}
 
       - name: Discover previews via Gradle
-        if: ${{ !matrix.use_cli }}
+        # On PRs only `pr_blocking` cells do the expensive gradle work; the rest
+        # are covered by the daily cron + push-to-main. `matrix` is available at
+        # step level (unlike at `jobs.<id>.if`), so the cell still reports its
+        # check — it just skips the build.
+        if: ${{ !matrix.use_cli && (github.event_name != 'pull_request' || matrix.pr_blocking) }}
         working-directory: external/${{ matrix.workdir }}
         env:
           COMPOSE_PREVIEW_INIT_USE_MAVEN_LOCAL: "1"
@@ -722,7 +741,7 @@ jobs:
             --stacktrace
 
       - name: CLI — list previews (${{ matrix.module }})
-        if: matrix.use_cli
+        if: ${{ matrix.use_cli && (github.event_name != 'pull_request' || matrix.pr_blocking) }}
         working-directory: external/${{ matrix.workdir }}
         env:
           COMPOSE_PREVIEW_INIT_USE_MAVEN_LOCAL: "1"
@@ -735,6 +754,9 @@ jobs:
           compose-preview list --module "${{ matrix.module }}"
 
       - name: Verify previews.json was produced
+        # Skip the assertion on cells whose discovery was skipped above, else it
+        # would fail on a missing manifest.
+        if: ${{ github.event_name != 'pull_request' || matrix.pr_blocking }}
         working-directory: external/${{ matrix.workdir }}
         run: |
           set -euo pipefail
@@ -756,7 +778,7 @@ jobs:
           fi
 
       - name: Render previews via Gradle
-        if: ${{ matrix.render && !matrix.use_cli }}
+        if: ${{ matrix.render && !matrix.use_cli && (github.event_name != 'pull_request' || matrix.pr_blocking) }}
         working-directory: external/${{ matrix.workdir }}
         env:
           COMPOSE_PREVIEW_INIT_USE_MAVEN_LOCAL: "1"
@@ -771,7 +793,7 @@ jobs:
             --stacktrace
 
       - name: CLI — render previews (${{ matrix.module }})
-        if: ${{ matrix.render && matrix.use_cli }}
+        if: ${{ matrix.render && matrix.use_cli && (github.event_name != 'pull_request' || matrix.pr_blocking) }}
         working-directory: external/${{ matrix.workdir }}
         env:
           COMPOSE_PREVIEW_INIT_USE_MAVEN_LOCAL: "1"
@@ -783,7 +805,7 @@ jobs:
           compose-preview render --module "${{ matrix.module }}"
 
       - name: Verify PNGs were produced
-        if: matrix.render
+        if: ${{ matrix.render && (github.event_name != 'pull_request' || matrix.pr_blocking) }}
         working-directory: external/${{ matrix.workdir }}
         run: |
           set -euo pipefail
@@ -801,7 +823,7 @@ jobs:
           printf '  %s\n' "${pngs[@]}"
 
       - name: Render XR subspace previews (composePreviewRenderXr)
-        if: matrix.render_xr
+        if: ${{ matrix.render_xr && (github.event_name != 'pull_request' || matrix.pr_blocking) }}
         working-directory: external/${{ matrix.workdir }}
         env:
           COMPOSE_PREVIEW_INIT_USE_MAVEN_LOCAL: "1"
@@ -818,7 +840,7 @@ jobs:
             --stacktrace
 
       - name: Verify XR scene.json was produced
-        if: matrix.render_xr
+        if: ${{ matrix.render_xr && (github.event_name != 'pull_request' || matrix.pr_blocking) }}
         working-directory: external/${{ matrix.workdir }}
         run: |
           set -euo pipefail
@@ -1068,7 +1090,7 @@ jobs:
           retention-days: 7
 
       - name: Verify at least one TILE preview was rendered
-        if: matrix.render && matrix.require_tile_render
+        if: ${{ matrix.render && matrix.require_tile_render && (github.event_name != 'pull_request' || matrix.pr_blocking) }}
         working-directory: external/${{ matrix.workdir }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary

Follow-up to #1998 (which moved the heavy `ci.yml` jobs off the PR path). This trims `integration.yml`'s per-PR cost.

The 8 external-repo integration cells all run on the **daily cron** as a drift signal against live upstream projects. On PRs we only need a representative sample to prove plugin discovery/render still works against real projects. This gates the expensive gradle steps (discover, render, render-xr) and their assertions on a new `pr_blocking` matrix flag:

- **ComposeStarter** — widest coverage (full render + daemon round-trip + IP/CC)
- **androidify** — large modern single-module app
- **nowinandroid** — flavored multi-module discovery (guards the #1546 variant fix)

The other ~5 cells still spin up on PRs but **skip the build work**, so they remain covered by the cron + push-to-main runs.

## Why step-level, not job-level

The first attempt (in #1998, reverted) put `matrix.pr_blocking` in the **job-level `if:`**. Codex correctly flagged this as a P1 bug: the `matrix` context is **not available** in `jobs.<job_id>.if` — it's evaluated *before* the matrix expands — so the whole `integration` workflow errored out (confirmed: that run failed in ~0s with a workflow-validation error).

Step-level `if:` **can** see `matrix`, so the gating lives on the individual work/assert steps instead. A bonus: every cell still runs (just skips its build steps), so **every check name still reports** on PRs — branch-protection-safe, no required check can go missing. The trade-off vs a dynamic matrix is that skipped cells still claim a runner briefly (checkout + setup), so this saves build time rather than fully eliminating the runner slot.

## Test plan
- `python3 -c "import yaml; yaml.safe_load(...)"` passes.
- Verified no `matrix` reference remains in any job-level `if:`.
- On this PR, expect the 3 `pr_blocking` cells to run discovery/render fully and the other ~5 cells to complete quickly (build steps skipped) while still reporting their checks.
- After merge: the daily cron + push-to-main runs exercise all 8 cells fully.

## Context
This is the "step-level skip (safe, less gain)" option chosen after #1998 merged. The alternative — a dynamic matrix that omits cells entirely on PRs — would also drop the runner slots but makes trimmed cells *absent* (not skipped), which is only safe if those per-repo cells aren't required status checks. This approach avoids that question.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WogXt1KdcLWyAeC9ddkkA7)_