### PR TITLE
ci: gate integration patch/setup steps off PRs for non-blocking cells

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -637,7 +637,12 @@ jobs:
         run: chmod +x ./gradlew
 
       - name: Apply consumer patches (idempotent)
-        if: matrix.patch_file != ''
+        # Skip on PRs for non-pr_blocking cells too: a stale upstream patch makes
+        # `git apply` exit 1, which would otherwise block unrelated PRs via a
+        # non-representative drift cell. The discover/render steps that consume
+        # the patch are already PR-gated the same way, so there's nothing to
+        # patch for on a skipped cell. (Drift still surfaces on cron/push.)
+        if: ${{ matrix.patch_file != '' && (github.event_name != 'pull_request' || matrix.pr_blocking) }}
         # Runs from the external checkout root so each patch's
         # repo-root-relative paths (e.g. AdaptiveJetStream/jetstream/...)
         # line up with `git apply -p1`. The bundle was extracted into
@@ -667,7 +672,7 @@ jobs:
           done
 
       - name: Add preview-annotations dependency for the XR overlay
-        if: matrix.render_xr
+        if: ${{ matrix.render_xr && (github.event_name != 'pull_request' || matrix.pr_blocking) }}
         # The @XrSubspacePreview overlay needs the preview-annotations artifact
         # (which defines @XrSubspacePreview) on the module's compile classpath.
         # That's an ordinary library dependency, not plugin configuration: the
@@ -718,7 +723,7 @@ jobs:
           PY
 
       - name: Repo-specific pre-Gradle patches
-        if: matrix.pre_gradle_script != ''
+        if: ${{ matrix.pre_gradle_script != '' && (github.event_name != 'pull_request' || matrix.pr_blocking) }}
         working-directory: external/${{ matrix.workdir }}
         run: ${{ matrix.pre_gradle_script }}
 


### PR DESCRIPTION
## Summary

Follow-up to #2000, addressing a P2 [Codex flagged](https://github.com/yschimke/compose-ai-tools/pull/2000#discussion_r3446907640) there.

#2000 gated the integration cells' **discover/render** steps on `pr_blocking`, but left the earlier **setup** steps running for every cell on PRs. The `adaptive-apps-samples (AdaptiveJetStream)` cell has a `patch_file` and **no** `continue_on_error`, so a stale upstream patch would make `git apply` exit 1 during **"Apply consumer patches"** and block unrelated PRs — via a non-representative upstream-drift cell, which is exactly the failure mode the trim set out to remove.

This gates the three drift-prone setup steps with the same predicate used for the build steps:
- **Apply consumer patches (idempotent)** — `matrix.patch_file != ''`
- **Add preview-annotations dependency for the XR overlay** — `matrix.render_xr`
- **Repo-specific pre-Gradle patches** — `matrix.pre_gradle_script != ''`

→ `&& (github.event_name != 'pull_request' || matrix.pr_blocking)`

On PRs, non-`pr_blocking` cells now fully no-op their drift-prone work (there's nothing to patch for, since the steps that consume the patch are already PR-gated the same way) while still reporting their check. Drift still surfaces on the daily cron + push-to-main. The other non-blocking cells with patch/drift risk (`cadence`, `meshcore-mobile`) already carry `continue_on_error: true`, so they were never PR-blocking.

## Test plan
- `python3 -c "import yaml; yaml.safe_load(...)"` passes.
- All new conditions are at **step level** (where `matrix` is available), consistent with #2000.
- On this PR: the adaptive-apps-samples cell should skip its patch/XR-overlay/pre-Gradle steps (and its already-gated render) and complete green without depending on upstream patch state.
- On cron/push: all cells run their setup + build fully.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WogXt1KdcLWyAeC9ddkkA7)_