### PR TITLE
feat(cli): negotiate stream codec (WebP) for serve live lane

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -1,6 +1,7 @@
 package ee.schimke.composeai.cli.serve
 
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.daemon.protocol.StreamCodec
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.install
@@ -79,12 +80,28 @@ class ServeHttpServer(
               .toMap()
           // Non-suspending hand-off to the socket; drop frames a slow client can't keep up with.
           val send: (String) -> Unit = { text -> outgoing.trySend(Frame.Text(text)) }
+          // Optional stream tuning: codec (WebP is ~30–60% smaller; the daemon downgrades to PNG if
+          // it can't encode WebP) and an fps cap.
+          val codec =
+            when (call.request.queryParameters["codec"]?.lowercase()) {
+              "webp" -> StreamCodec.WEBP
+              "png" -> StreamCodec.PNG
+              else -> null
+            }
+          val maxFps = call.request.queryParameters["maxFps"]?.toIntOrNull()?.takeIf { it > 0 }
           // Prefer the daemon's live stream lane (frames pushed, input dispatched); fall back to
           // the
           // snapshot re-render lane when the backend doesn't support streaming.
           val live =
             withContext(Dispatchers.IO) {
-              ServeLiveSession.tryStart(renderHost, previewId, initialOverrides, send)
+              ServeLiveSession.tryStart(
+                renderHost,
+                previewId,
+                initialOverrides,
+                codec,
+                maxFps,
+                send,
+              )
             }
           if (live != null) {
             try {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeLiveSession.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeLiveSession.kt
@@ -2,6 +2,7 @@ package ee.schimke.composeai.cli.serve
 
 import ee.schimke.composeai.daemon.protocol.InteractiveInputKind
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.daemon.protocol.StreamCodec
 import ee.schimke.composeai.daemon.protocol.StreamFrameParams
 
 /**
@@ -19,6 +20,8 @@ private constructor(
   private val renderHost: ServeRenderHost,
   private val previewId: String,
   private var overrides: Map<String, String>,
+  private val codec: StreamCodec?,
+  private val maxFps: Int?,
   private val send: (String) -> Unit,
 ) {
   @Volatile private var handle: StreamHandle? = null
@@ -68,7 +71,7 @@ private constructor(
   private fun restart(parsed: PreviewOverrides) {
     handle?.close()
     handle =
-      renderHost.startStream(previewId, parsed, ::onFrame)
+      renderHost.startStream(previewId, parsed, codec, maxFps, ::onFrame)
         ?: run {
           send(ServeStreamProtocol.errorMessage("live stream ended"))
           null
@@ -105,12 +108,15 @@ private constructor(
       renderHost: ServeRenderHost,
       previewId: String,
       overrides: Map<String, String>,
+      codec: StreamCodec? = null,
+      maxFps: Int? = null,
       send: (String) -> Unit,
     ): ServeLiveSession? {
       val initial =
         (ServeOverrides.parse(overrides) as? OverrideParse.Ok)?.overrides ?: PreviewOverrides()
-      val session = ServeLiveSession(renderHost, previewId, overrides, send)
-      session.handle = renderHost.startStream(previewId, initial, session::onFrame) ?: return null
+      val session = ServeLiveSession(renderHost, previewId, overrides, codec, maxFps, send)
+      session.handle =
+        renderHost.startStream(previewId, initial, codec, maxFps, session::onFrame) ?: return null
       return session
     }
   }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
@@ -2,6 +2,7 @@ package ee.schimke.composeai.cli.serve
 
 import ee.schimke.composeai.daemon.protocol.InteractiveInputKind
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.daemon.protocol.StreamCodec
 import ee.schimke.composeai.daemon.protocol.StreamFrameParams
 import ee.schimke.composeai.io.SystemFileSystem
 import ee.schimke.composeai.render.session.RenderSession
@@ -211,6 +212,8 @@ internal constructor(
   fun startStream(
     previewId: String,
     overrides: PreviewOverrides,
+    codec: StreamCodec? = null,
+    maxFps: Int? = null,
     onFrame: (StreamFrameParams) -> Unit,
   ): StreamHandle? {
     check(!closed.get()) { "ServeRenderHost is closed" }
@@ -247,7 +250,12 @@ internal constructor(
 
     val result =
       try {
-        session.streamStart(previewId = previewId, overrides = overrides)
+        session.streamStart(
+          previewId = previewId,
+          codec = codec,
+          maxFps = maxFps,
+          overrides = overrides,
+        )
       } catch (e: Exception) {
         // UnsupportedOperationException (no streaming on this backend) or a daemon error — degrade.
         onLog("stream/start unavailable for $previewId (${e.message}); falling back to snapshots")

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -316,8 +316,10 @@ object ServeWeb {
         canvas.hidden = false;
         status.textContent = "connecting…";
         var proto = location.protocol === "https:" ? "wss:" : "ws:";
+        // Request WebP frames (smaller; the browser decodes them via the data URL, and the daemon
+        // downgrades to PNG when it can't encode WebP — each frame carries its actual codec).
         ws = new WebSocket(proto + "//" + location.host + "/ws/" +
-          encodeURIComponent(previewId) + "?" + query());
+          encodeURIComponent(previewId) + "?" + query() + "&codec=webp");
         ws.onmessage = function (ev) {
           var m;
           try { m = JSON.parse(ev.data); } catch (e) { return; }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/FakeRenderSession.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/FakeRenderSession.kt
@@ -75,10 +75,23 @@ internal class FakeRenderSession(
   var lastFrameStreamId: String? = null
     private set
 
+  @Volatile
+  var lastCodec: StreamCodec? = null
+    private set
+
+  @Volatile
+  var lastMaxFps: Int? = null
+    private set
+
   private val streamJson = Json { ignoreUnknownKeys = true }
 
   /** Fire a `streamFrame` notification to registered listeners (test driver for the live lane). */
-  fun emitStreamFrame(frameStreamId: String, seq: Long, payloadBase64: String?) {
+  fun emitStreamFrame(
+    frameStreamId: String,
+    seq: Long,
+    payloadBase64: String?,
+    codec: StreamCodec = StreamCodec.PNG,
+  ) {
     val params =
       streamJson
         .encodeToJsonElement(
@@ -89,7 +102,7 @@ internal class FakeRenderSession(
             ptsMillis = 0,
             widthPx = 2,
             heightPx = 2,
-            codec = StreamCodec.PNG,
+            codec = codec,
             payloadBase64 = payloadBase64,
           ),
         )
@@ -236,11 +249,13 @@ internal class FakeRenderSession(
     if (!streaming) throw UnsupportedOperationException("streaming not supported")
     val fsid = "fs-${streamStarts.incrementAndGet()}"
     lastFrameStreamId = fsid
+    lastCodec = codec
+    lastMaxFps = maxFps
     // Model a daemon that emits the initial keyframe before the RPC response returns.
     emitKeyframeOnStart?.let { emitStreamFrame(fsid, seq = 0, payloadBase64 = it) }
     return StreamStartResult(
       frameStreamId = fsid,
-      codec = StreamCodec.PNG,
+      codec = codec ?: StreamCodec.PNG,
       heldSession = heldSession,
     )
   }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeLiveSessionTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeLiveSessionTest.kt
@@ -1,6 +1,7 @@
 package ee.schimke.composeai.cli.serve
 
 import ee.schimke.composeai.daemon.protocol.InteractiveInputKind
+import ee.schimke.composeai.daemon.protocol.StreamCodec
 import java.io.File
 import java.util.Base64
 import java.util.concurrent.CopyOnWriteArrayList
@@ -37,7 +38,7 @@ class ServeLiveSessionTest {
     val session = FakeRenderSession(newRenderRoot(), streaming = true)
     host(session).use { h ->
       val sent = CopyOnWriteArrayList<String>()
-      assertNotNull(ServeLiveSession.tryStart(h, previewId, emptyMap(), sent::add))
+      assertNotNull(ServeLiveSession.tryStart(h, previewId, emptyMap(), send = sent::add))
       val fsid = assertNotNull(session.lastFrameStreamId)
       val payload = Base64.getEncoder().encodeToString("xy".toByteArray())
 
@@ -52,11 +53,31 @@ class ServeLiveSessionTest {
   }
 
   @Test
+  fun `requested codec is forwarded to stream start and webp frames keep their codec`() {
+    val session = FakeRenderSession(newRenderRoot(), streaming = true)
+    host(session).use { h ->
+      val sent = CopyOnWriteArrayList<String>()
+      assertNotNull(
+        ServeLiveSession.tryStart(h, previewId, emptyMap(), StreamCodec.WEBP, null, sent::add)
+      )
+      assertEquals(StreamCodec.WEBP, session.lastCodec)
+      session.emitStreamFrame(
+        assertNotNull(session.lastFrameStreamId),
+        seq = 1,
+        payloadBase64 = "AA",
+        codec = StreamCodec.WEBP,
+      )
+      val obj = Json.parseToJsonElement(sent.last()).jsonObject
+      assertEquals("webp", obj.getValue("codec").jsonPrimitive.content)
+    }
+  }
+
+  @Test
   fun `unchanged heartbeat frames (no payload) are not forwarded`() {
     val session = FakeRenderSession(newRenderRoot(), streaming = true)
     host(session).use { h ->
       val sent = CopyOnWriteArrayList<String>()
-      assertNotNull(ServeLiveSession.tryStart(h, previewId, emptyMap(), sent::add))
+      assertNotNull(ServeLiveSession.tryStart(h, previewId, emptyMap(), send = sent::add))
       session.emitStreamFrame(
         assertNotNull(session.lastFrameStreamId),
         seq = 0,
@@ -119,7 +140,8 @@ class ServeLiveSessionTest {
     val session = FakeRenderSession(newRenderRoot(), streaming = true)
     host(session).use { h ->
       val sent = CopyOnWriteArrayList<String>()
-      val live = assertNotNull(ServeLiveSession.tryStart(h, previewId, emptyMap(), sent::add))
+      val live =
+        assertNotNull(ServeLiveSession.tryStart(h, previewId, emptyMap(), send = sent::add))
       live.onClientMessage("""{"type":"input","kind":"telepathy"}""")
       assertEquals("error", typeOf(sent.last()))
       assertTrue(session.interactiveInputs.isEmpty())

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHostStreamTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHostStreamTest.kt
@@ -2,6 +2,7 @@ package ee.schimke.composeai.cli.serve
 
 import ee.schimke.composeai.daemon.protocol.InteractiveInputKind
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.daemon.protocol.StreamCodec
 import ee.schimke.composeai.daemon.protocol.StreamFrameParams
 import java.io.File
 import java.util.concurrent.CopyOnWriteArrayList
@@ -83,6 +84,16 @@ class ServeRenderHostStreamTest {
       assertNotNull(h.startStream(previewId, PreviewOverrides()) { frames.add(it) })
       assertEquals(1, frames.size, "the pre-response keyframe must be replayed, not lost")
       assertEquals(0L, frames[0].seq)
+    }
+  }
+
+  @Test
+  fun `codec and maxFps are forwarded to stream start`() {
+    val session = FakeRenderSession(newRenderRoot(), streaming = true)
+    host(session).use { h ->
+      assertNotNull(h.startStream(previewId, PreviewOverrides(), StreamCodec.WEBP, 30) {})
+      assertEquals(StreamCodec.WEBP, session.lastCodec)
+      assertEquals(30, session.lastMaxFps)
     }
   }
 

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
@@ -239,8 +239,10 @@ a:hover { text-decoration: underline; }
     canvas.hidden = false;
     status.textContent = "connecting…";
     var proto = location.protocol === "https:" ? "wss:" : "ws:";
+    // Request WebP frames (smaller; the browser decodes them via the data URL, and the daemon
+    // downgrades to PNG when it can't encode WebP — each frame carries its actual codec).
     ws = new WebSocket(proto + "//" + location.host + "/ws/" +
-      encodeURIComponent(previewId) + "?" + query());
+      encodeURIComponent(previewId) + "?" + query() + "&codec=webp");
     ws.onmessage = function (ev) {
       var m;
       try { m = JSON.parse(ev.data); } catch (e) { return; }


### PR DESCRIPTION
## Summary

Stacked on #2003. Lets the `serve` live stream lane negotiate a frame codec and an fps cap, moving off the implicit PNG-per-frame default toward the research-backed staged transport path (PNG → WebP → WebCodecs/WebRTC).

- **Codec negotiation** — `ServeRenderHost.startStream` and `ServeLiveSession.tryStart` thread an optional `codec` + `maxFps` through to `RenderSession.streamStart`.
- **WS query parsing** — `ServeHttpServer` reads `?codec=webp|png` and `?maxFps=` from the WebSocket query (ignored / clamped when absent or non-positive).
- **Viewer** — requests `&codec=webp` (WebP is ~30–60% smaller than PNG). The daemon downgrades to PNG when it can't encode WebP, and **each frame carries its actual codec**, so the viewer picks the right `data:image/<codec>` mime type per frame rather than assuming the requested one.

Additive and non-breaking: `codec`/`maxFps` are optional with defaults, so the snapshot fallback and existing callers are untouched.

## Test plan
- `ktfmtFormatAll` clean; `:cli:compileKotlin` / `compileTestKotlin` green; `:cli:checkCliDaemonLibraryBoundary` green.
- Serve suite green (`./gradlew :cli:test --tests 'ee.schimke.composeai.cli.serve.*'`), including new coverage:
  - `ServeRenderHostStreamTest` — "codec and maxFps are forwarded to stream start".
  - `ServeLiveSessionTest` — "requested codec is forwarded to stream start and webp frames keep their codec" (asserts the forwarded frame message keeps `codec: "webp"`).
- Viewer fixture (`serve-viewer.html`) regenerated for the `&codec=webp` WS URL; the visual-diff bot re-renders it for the record.

## Visual evidence
The viewer's **rendered output is unchanged** — the change is the WS URL query (`&codec=webp`) and the per-frame mime-type selection, both JS/transport-only with no markup change. The codec path itself needs a real daemon (CI daemon-harness lanes), not the headless fixture; the fixture diff captures the WS URL change.

---
_Generated by [Claude Code](https://claude.ai/code/session_0186JHWqw5dMvUJbfgDXgqGo)_