### PR TITLE
ci: path-filter VS Code Extension Tests to vscode-extension changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -499,18 +499,52 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
+      # Path filter at STEP level, not a trigger `paths:` filter: this is a
+      # required check, so a `paths:`-filtered workflow that didn't run would
+      # leave it stuck pending and block the merge. Instead the job always runs
+      # (so the required check always reports), and the npm steps below only
+      # execute when the PR touches the extension. The TS unit/integration tests
+      # can't be affected by anything outside `vscode-extension/`, so skipping
+      # them on unrelated PRs is safe. Pushes to main + the nightly run always
+      # execute the full suite.
+      - name: Detect vscode-extension changes
+        id: changes
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          MERGE_SHA: ${{ github.sha }}
+        run: |
+          set -uo pipefail
+          # Fail open: any problem computing the diff -> run the full suite.
+          git fetch --no-tags --depth=1 origin "$BASE_SHA" 2>/dev/null || true
+          if ! changed=$(git diff --name-only "$BASE_SHA" "$MERGE_SHA" 2>/dev/null); then
+            echo "::warning::Could not diff against base; running VS Code Extension Tests to be safe."
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if printf '%s\n' "$changed" | grep -qE '^vscode-extension/'; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No vscode-extension/** changes in this PR — skipping the npm build/test steps (this required check still reports)."
+          fi
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        if: ${{ github.event_name != 'pull_request' || steps.changes.outputs.run == 'true' }}
         with:
           node-version: 20
       - name: Install dependencies
+        if: ${{ github.event_name != 'pull_request' || steps.changes.outputs.run == 'true' }}
         working-directory: vscode-extension
         run: npm ci
       - name: Compile
+        if: ${{ github.event_name != 'pull_request' || steps.changes.outputs.run == 'true' }}
         working-directory: vscode-extension
         run: npm run compile
       - name: Run unit tests
+        if: ${{ github.event_name != 'pull_request' || steps.changes.outputs.run == 'true' }}
         working-directory: vscode-extension
         run: npm test
       - name: Run integration tests (xvfb)
+        if: ${{ github.event_name != 'pull_request' || steps.changes.outputs.run == 'true' }}
         working-directory: vscode-extension
         run: xvfb-run -a npm run test:electron


### PR DESCRIPTION
## Summary

`VS Code Extension Tests` runs `npm ci` + compile + unit + electron tests on **every** PR (~1 min + a runner slot), but its TypeScript tests can only be affected by changes under `vscode-extension/`. This skips the npm steps on PRs that don't touch that subtree — which is most PRs (Kotlin/plugin/daemon work).

### Why step-level, not a `paths:` trigger filter
`VS Code Extension Tests` is a **required status check**. A trigger-level `paths:` filter would make the workflow not run on unrelated PRs, leaving the required check stuck **pending** and blocking the merge forever. So instead:
- The **job always runs** → the required check always reports.
- A `Detect vscode-extension changes` step diffs the PR against its base (`git diff base.sha…merge.sha`) and the npm steps are gated on `github.event_name != 'pull_request' || steps.changes.outputs.run == 'true'`.
- **Fails open:** any problem computing the diff runs the full suite. Pushes to `main` and the nightly run always run everything.

This mirrors the existing repo idiom (hand-rolled `git diff` rather than a third-party path-filter action, per the zizmor pinning constraints).

### Scope note
This is the one cleanly-isolated required surface check. The other unfiltered workflows were left alone on purpose: `daemon-harness` / `compose-preview` have broad input surfaces (renderer/plugin/common changes affect their output), and `format` (ktfmt) must run on any Kotlin change — filtering those risks letting regressions through. The well-isolated workflows (`xr-composite-build`, `samples-sdk21`, `vscode-preview-comment`, `preview-bundle-ascii`, `install-action-test`) already have `paths:` filters.

## Test plan
- `python3 -c "import yaml; yaml.safe_load(...)"` passes.
- On **this** PR (no `vscode-extension/**` changes): expect `VS Code Extension Tests` to report **success** with the npm steps skipped and a `notice` annotation explaining why.
- On a PR that touches `vscode-extension/**`: the detect step sets `run=true` and all npm steps execute as before.
- On push to `main` / nightly: full suite always runs (the detect step is PR-only; the gate's first clause is true).

## Branch-protection
No settings change needed — the check name `VS Code Extension Tests` still reports on every PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WogXt1KdcLWyAeC9ddkkA7)_