### PR TITLE
fix(cli): derive command detection from a guarded flag registry

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
@@ -7,9 +7,12 @@ package ee.schimke.composeai.cli
  * Command detection scans argv left-to-right for the first bare (non-`-`) token. A flag that takes
  * its value as the *following* token (`--module foo`) must be listed in [VALUE_FLAGS] so the scan
  * skips the value — otherwise the value is mistaken for the command (`compose-preview --module show
- * list` would pick `show`). Flags whose value is attached (`--images=kitty`) or optional
- * (`--images`, `--force=<reason>`) must NOT be listed: they never consume a following token, so a
- * bare token after them is the command.
+ * list` would pick `show`). Flags whose value is genuinely *optional* (`--images`, which means
+ * "auto" with no value) must NOT be listed: they never consume a following token, so a bare token
+ * after them is the command. A flag whose value is required but may be written attached
+ * (`--force=<reason>`) still belongs in [VALUE_FLAGS] — the attached form is a single argv token
+ * the scan skips anyway, and the space form (`--force <reason>`, supported by `flagValue` and
+ * `ForceFlagTest`) must skip the reason so it isn't mistaken for the command.
  *
  * The invariant — every flag read through the shared [flagValue]/[flagValuesAll] helpers is
  * classified here as either value-consuming or attached/optional — is enforced by
@@ -53,6 +56,10 @@ internal object CliFlags {
       "--port",
       "--token",
       "--export",
+      // Required-reason escape hatch. Usually written attached (`--force=<reason>`), but the space
+      // form `--force <reason>` is supported (ForceFlagTest), so the reason must be skipped or it's
+      // mistaken for the command.
+      "--force",
       // Read via flagValue() but previously absent from the command-detection skip set, so a
       // global-position `--since 2024 history list` mis-detected `2024` as the command.
       "--agent",
@@ -83,7 +90,7 @@ internal object CliFlags {
    * the following token. Listed only so `CliFlagsRegistryTest` can tell them apart from a missing
    * [VALUE_FLAGS] entry — they are intentionally excluded from command-detection skipping.
    */
-  val ATTACHED_OR_OPTIONAL_FLAGS: Set<String> = setOf("--images", "--force")
+  val ATTACHED_OR_OPTIONAL_FLAGS: Set<String> = setOf("--images")
 
   /**
    * Index of the subcommand token in [args], or `-1` if argv is entirely flags and their values.

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
@@ -1,0 +1,108 @@
+package ee.schimke.composeai.cli
+
+/**
+ * Single source of truth for how argv flags consume values, used to locate the subcommand token in
+ * [main] before any command-specific parsing runs.
+ *
+ * Command detection scans argv left-to-right for the first bare (non-`-`) token. A flag that takes
+ * its value as the *following* token (`--module foo`) must be listed in [VALUE_FLAGS] so the scan
+ * skips the value — otherwise the value is mistaken for the command (`compose-preview --module show
+ * list` would pick `show`). Flags whose value is attached (`--images=kitty`) or optional
+ * (`--images`, `--force=<reason>`) must NOT be listed: they never consume a following token, so a
+ * bare token after them is the command.
+ *
+ * The invariant — every flag read through the shared [flagValue]/[flagValuesAll] helpers is
+ * classified here as either value-consuming or attached/optional — is enforced by
+ * `CliFlagsRegistryTest`, which scans the CLI sources. Add new shared-helper flags to one of the
+ * two sets or that test fails. (Commands that parse flags bespoke — e.g. `render-matrix`'s
+ * `axisValues` — are out of the test's scope; their value flags are still listed here so
+ * global-position parsing stays correct, but the compiler/test won't remind you to add them.)
+ */
+internal object CliFlags {
+  /**
+   * Flags whose value is the next argv token; command detection skips both the flag and its value.
+   */
+  val VALUE_FLAGS: Set<String> =
+    setOf(
+      "--module",
+      "--filter",
+      "--id",
+      "--output",
+      "--timeout",
+      "--plugin-version",
+      "--fail-on",
+      "--desc",
+      "--mechanism",
+      "--branch",
+      "--remote",
+      "--pr-number",
+      "--message",
+      "--raw-base",
+      "--with-extension",
+      "--with",
+      "--missing-renders",
+      "--variant",
+      "--preview",
+      "--script",
+      "--out",
+      "--format",
+      "--fps",
+      "--scale",
+      "--overrides",
+      "--host",
+      "--port",
+      "--token",
+      "--export",
+      // Read via flagValue() but previously absent from the command-detection skip set, so a
+      // global-position `--since 2024 history list` mis-detected `2024` as the command.
+      "--agent",
+      "--antigravity-config",
+      "--baseline-dir",
+      "--codex-config",
+      "--commit",
+      "--cursor",
+      "--history-dir",
+      "--limit",
+      "--mode",
+      "--project",
+      "--ref",
+      "--since",
+      "--source",
+      "--title",
+      "--until",
+      // render-matrix axes — parsed bespoke (not via flagValue), value-consuming; listed so
+      // command detection stays correct if ever used in global position.
+      "--device",
+      "--locale",
+      "--ui-mode",
+      "--font-scale",
+    )
+
+  /**
+   * Flags read through [flagValue] whose value is attached (`=`) or optional, so they never consume
+   * the following token. Listed only so `CliFlagsRegistryTest` can tell them apart from a missing
+   * [VALUE_FLAGS] entry — they are intentionally excluded from command-detection skipping.
+   */
+  val ATTACHED_OR_OPTIONAL_FLAGS: Set<String> = setOf("--images", "--force")
+
+  /**
+   * Index of the subcommand token in [args], or `-1` if argv is entirely flags and their values.
+   * The first bare (non-`-`) token that isn't the value of a [VALUE_FLAGS] flag.
+   */
+  fun findCommandIndex(args: Array<String>): Int {
+    var i = 0
+    while (i < args.size) {
+      val arg = args[i]
+      if (arg in VALUE_FLAGS) {
+        i += 2 // skip the flag and its value
+        continue
+      }
+      if (arg.startsWith("-")) {
+        i++
+        continue
+      }
+      return i
+    }
+    return -1
+  }
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
@@ -16,55 +16,10 @@ fun main(args: Array<String>) {
     exitProcess(0)
   }
 
-  // Find the command — first non-flag argument that isn't a flag's value.
-  // Flags that take values: --module, --filter, --id, --output, --timeout, --plugin-version
-  val valuedFlags =
-    setOf(
-      "--module",
-      "--filter",
-      "--id",
-      "--output",
-      "--timeout",
-      "--plugin-version",
-      "--fail-on",
-      "--desc",
-      "--mechanism",
-      "--branch",
-      "--remote",
-      "--pr-number",
-      "--message",
-      "--raw-base",
-      "--with-extension",
-      "--with",
-      "--missing-renders",
-      "--variant",
-      "--preview",
-      "--script",
-      "--out",
-      "--format",
-      "--fps",
-      "--scale",
-      "--overrides",
-      "--host",
-      "--port",
-      "--token",
-      "--export",
-    )
-  var commandIndex = -1
-  var i = 0
-  while (i < args.size) {
-    val arg = args[i]
-    if (arg in valuedFlags) {
-      i += 2 // skip flag and its value
-      continue
-    }
-    if (arg.startsWith("-")) {
-      i++
-      continue
-    }
-    commandIndex = i
-    break
-  }
+  // Find the command — first bare token that isn't the value of a value-consuming flag. The
+  // classification of which flags consume the following token lives in [CliFlags] (single source of
+  // truth, guarded by CliFlagsRegistryTest).
+  val commandIndex = CliFlags.findCommandIndex(args)
 
   if (commandIndex < 0) {
     if ("--help" in args || "-h" in args) {

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/CliFlagsRegistryTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/CliFlagsRegistryTest.kt
@@ -49,13 +49,18 @@ class CliFlagsRegistryTest {
     // Regression: a global-position value flag that used to be unclassified mis-detected its value
     // as the command.
     assertEquals(2, CliFlags.findCommandIndex(arrayOf("--since", "2024", "history", "list")))
+    // --force takes a required reason; the space form must skip the reason (ForceFlagTest pins that
+    // `--force <reason>` is supported), or the reason is mistaken for the command.
+    assertEquals(2, CliFlags.findCommandIndex(arrayOf("--force", "edit didn't reflect", "render")))
+    // Attached form is a single argv token, so it's skipped like any other flag.
+    assertEquals(1, CliFlags.findCommandIndex(arrayOf("--force=stale", "render")))
   }
 
   @Test
-  fun `findCommandIndex treats attached and optional flags as non-consuming`() {
-    // --images is optional-value: a bare token after it is the command, not its value.
+  fun `findCommandIndex treats optional-value flags as non-consuming`() {
+    // --images is optional-value (bare --images means auto): a bare token after it is the command,
+    // not its value.
     assertEquals(1, CliFlags.findCommandIndex(arrayOf("--images", "show")))
-    assertEquals(1, CliFlags.findCommandIndex(arrayOf("--force=stale", "render")))
   }
 
   @Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/CliFlagsRegistryTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/CliFlagsRegistryTest.kt
@@ -1,0 +1,82 @@
+package ee.schimke.composeai.cli
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+/**
+ * Guards the [CliFlags] registry against drift. Every flag read through the shared
+ * [flagValue]/[flagValuesAll] helpers must be classified in [CliFlags] — either as value-consuming
+ * ([CliFlags.VALUE_FLAGS]) or attached/optional ([CliFlags.ATTACHED_OR_OPTIONAL_FLAGS]). A flag
+ * that's read but unclassified silently breaks command detection (the value gets mistaken for the
+ * subcommand), so we make it a compile-of-the-test failure instead of a runtime surprise.
+ */
+class CliFlagsRegistryTest {
+  private val flagCallSite = Regex("""flagValue(?:sAll)?\(\s*"(--[a-z][a-z-]*)"""")
+
+  @Test
+  fun `every flagValue call site is classified in CliFlags`() {
+    val classified = CliFlags.VALUE_FLAGS + CliFlags.ATTACHED_OR_OPTIONAL_FLAGS
+    val used =
+      mainSources()
+        .flatMap { file -> flagCallSite.findAll(file.readText()).map { it.groupValues[1] } }
+        .toSortedSet()
+
+    assertTrue(used.isNotEmpty(), "expected to find flagValue call sites under $sourceDir")
+
+    val unclassified = used - classified
+    if (unclassified.isNotEmpty()) {
+      fail(
+        "Flags read via flagValue()/flagValuesAll() but missing from CliFlags: $unclassified. " +
+          "Add each to CliFlags.VALUE_FLAGS (value is the next argv token, e.g. --foo bar) or " +
+          "CliFlags.ATTACHED_OR_OPTIONAL_FLAGS (value attached/optional, e.g. --foo=bar)."
+      )
+    }
+  }
+
+  @Test
+  fun `value and attached flag sets are disjoint`() {
+    val overlap = CliFlags.VALUE_FLAGS intersect CliFlags.ATTACHED_OR_OPTIONAL_FLAGS
+    assertEquals(emptySet(), overlap, "a flag cannot be both value-consuming and attached/optional")
+  }
+
+  @Test
+  fun `findCommandIndex skips value flags and their values`() {
+    assertEquals(0, CliFlags.findCommandIndex(arrayOf("show")))
+    assertEquals(2, CliFlags.findCommandIndex(arrayOf("--module", ":app", "show")))
+    // Regression: a global-position value flag that used to be unclassified mis-detected its value
+    // as the command.
+    assertEquals(2, CliFlags.findCommandIndex(arrayOf("--since", "2024", "history", "list")))
+  }
+
+  @Test
+  fun `findCommandIndex treats attached and optional flags as non-consuming`() {
+    // --images is optional-value: a bare token after it is the command, not its value.
+    assertEquals(1, CliFlags.findCommandIndex(arrayOf("--images", "show")))
+    assertEquals(1, CliFlags.findCommandIndex(arrayOf("--force=stale", "render")))
+  }
+
+  @Test
+  fun `findCommandIndex returns -1 when argv is all flags`() {
+    assertEquals(-1, CliFlags.findCommandIndex(arrayOf("--json")))
+    assertEquals(-1, CliFlags.findCommandIndex(arrayOf("--module", ":app")))
+  }
+
+  private val sourceDir: File
+    get() = File(repoRoot(), "cli/src/main/kotlin/ee/schimke/composeai/cli")
+
+  private fun mainSources(): List<File> =
+    sourceDir.walkTopDown().filter { it.isFile && it.extension == "kt" }.toList()
+
+  /** Walk up from the test working dir (the `:cli` project dir) to the repo root. */
+  private fun repoRoot(): File {
+    var dir: File? = File(System.getProperty("user.dir")).absoluteFile
+    while (dir != null) {
+      if (File(dir, "settings.gradle.kts").isFile) return dir
+      dir = dir.parentFile
+    }
+    error("could not locate repo root (settings.gradle.kts) from ${System.getProperty("user.dir")}")
+  }
+}


### PR DESCRIPTION
Second slice of #1995 (item 5: generate/derive the flag registry so it can't drift). Fixes a real latent bug found while doing it.

## The bug

`main()` hand-maintained a `valuedFlags` set used to locate the subcommand token (it skips `--flag value` pairs so a flag's value isn't mistaken for the command). That set had **drifted** — ~15 value flags read via `flagValue()` were missing from it:

`--project --since --until --ref --limit --commit --title --agent --mode --source --baseline-dir --history-dir --cursor --codex-config --antigravity-config`

So a value flag in **global position** mis-detected its value as the command:

```
$ compose-preview --since 2024 history list
Unknown command: 2024
```

(Flags after the subcommand were unaffected — command detection stops at the subcommand — which is why this stayed hidden.)

## The fix

- **`CliFlags`** — single source of truth that classifies every shared-helper flag as either **value-consuming** (`VALUE_FLAGS`, skip flag + next token) or **attached/optional** (`ATTACHED_OR_OPTIONAL_FLAGS` = `--images`, `--force`, which must *not* consume the following token). Command detection moves into `CliFlags.findCommandIndex`.
- **`main()`** drops the inline 30-line set and calls `CliFlags.findCommandIndex(args)`.
- **`CliFlagsRegistryTest`** scans the CLI sources for `flagValue()` / `flagValuesAll()` call sites and **fails if any flag is left unclassified** — so the set can't silently drift again. Plus behavioural coverage of `findCommandIndex`, including the `--since` regression.

`render-matrix`'s axis flags (`--device` etc.) are parsed bespoke (`axisValues`), out of the test's scope; they're still listed in `VALUE_FLAGS` for global-position correctness, with a comment noting the test won't enforce them.

## Test plan

- [x] `./gradlew :cli:ktfmtFormat{Main,Test} :cli:test --tests CliFlagsRegistryTest --tests ArgsTest` — green (BUILD SUCCESSFUL).
- [x] New regression test asserts `findCommandIndex(["--since","2024","history","list"]) == 2`.
- [x] Optional/attached flags verified non-consuming (`--images show` → command is `show`).

Non-visual change (argv parsing); no rendered surface affected.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JAcNgg7dRjyCmuX3uk4VdE)_