### PR TITLE
docs(cli): describe MCP by capability, not as "MCP-first vs cold-shell"

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
@@ -166,10 +166,12 @@ private fun printFullUsage() {
       version          Print the installed bundle version and exit
       help             Show this help message
 
-    MCP-first workflows:
-      Structured data products, extension command routing, live preview state, and history
-      inspection are exposed through MCP (`compose-preview mcp install|serve`) rather than the
-      main cold-shell CLI.
+    For agents (MCP):
+      `compose-preview mcp install|serve` drives the same renders as a push-based, token-frugal
+      loop and adds structured data products — accessibility, semantics, layout trees,
+      recomposition, live preview state, history. Those data products are also reachable one-shot
+      from the commands above (a11y, diff-semantics, history, extensions, record), so MCP is the
+      richer surface for an agent loop, not the only way to get the data.
 
     Options:
       --module <name>      Target module (default: auto-detect all)


### PR DESCRIPTION
Item 2 of #1995 — the user-facing-language half.

## Problem

The full-help `MCP-first workflows` block told users that structured data products, extension routing, live state, and history are "exposed through MCP … rather than the main **cold-shell CLI**." That leaks an internal architecture seam into the user's mental model — *which surface is primary* — and it's also inaccurate: `a11y`, `diff-semantics`, `history`, `extensions`, and `record` are all first-class CLI commands that produce that data.

## Change

Reword the block (now `For agents (MCP):`) to describe **what MCP adds** — a push-based, token-frugal loop over the same renders plus structured data products — and note the same data is reachable one-shot from the CLI commands. No more "cold-shell" / "MCP-first vs the CLI" framing.

```
For agents (MCP):
  `compose-preview mcp install|serve` drives the same renders as a push-based, token-frugal
  loop and adds structured data products — accessibility, semantics, layout trees,
  recomposition, live preview state, history. Those data products are also reachable one-shot
  from the commands above (a11y, diff-semantics, history, extensions, record), so MCP is the
  richer surface for an agent loop, not the only way to get the data.
```

## Scope

This is the language/UX half of item 2. The behavioural half — the CLI transparently using a warm daemon when it helps — overlaps item 3 (single data-product producer) and is deferred to that work rather than bolted on here.

## Test plan

- [x] `./gradlew :cli:ktfmtFormatMain :cli:compileKotlin` — BUILD SUCCESSFUL.
- [x] No test pins the help text (confirmed in prior help-tiering work).

Text-only help-string change; no rendered surface affected.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JAcNgg7dRjyCmuX3uk4VdE)_