### PR TITLE
feat(cli): group non-core commands under inspect/capture/share/setup

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
@@ -52,14 +52,19 @@ import okio.source
 class BundleCommand(args: List<String>) : Command(args) {
 
   override fun run() {
-    val sub = args.firstOrNull { !it.startsWith("-") }
+    // Find the subcommand skipping any leading valued flags (`bundle --module :app pack`), then
+    // hand the subcommand its args with only the subcommand token removed (the leading flags stay).
+    val subIndex = CliFlags.firstPositionalIndex(args)
+    val sub = if (subIndex >= 0) args[subIndex] else null
+    val subArgs =
+      if (subIndex >= 0) args.toMutableList().apply { removeAt(subIndex) } else emptyList()
     when (sub) {
-      "pack" -> PackSubcommand(args.drop(args.indexOf(sub) + 1)).run()
-      "inspect" -> InspectSubcommand(args.drop(args.indexOf(sub) + 1)).run()
-      "extract" -> ExtractSubcommand(args.drop(args.indexOf(sub) + 1)).run()
-      "embed" -> EmbedSubcommand(args.drop(args.indexOf(sub) + 1)).run()
-      "render" -> RenderSubcommand(args.drop(args.indexOf(sub) + 1)).run()
-      "daemon" -> BundleDaemonCommand(args.drop(args.indexOf(sub) + 1)).run()
+      "pack" -> PackSubcommand(subArgs).run()
+      "inspect" -> InspectSubcommand(subArgs).run()
+      "extract" -> ExtractSubcommand(subArgs).run()
+      "embed" -> EmbedSubcommand(subArgs).run()
+      "render" -> RenderSubcommand(subArgs).run()
+      "daemon" -> BundleDaemonCommand(subArgs).run()
       null,
       "help",
       "--help",

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
@@ -93,6 +93,17 @@ internal object CliFlags {
   val ATTACHED_OR_OPTIONAL_FLAGS: Set<String> = setOf("--images")
 
   /**
+   * The first positional token in [args] — the bare token that isn't the value of a value-consuming
+   * flag — or `null` if there is none. Used by commands with a nested positional subcommand
+   * (`bundle pack`, `history list`) so a leading `--module :app` isn't mistaken for the subcommand.
+   */
+  fun firstPositional(args: List<String>): String? =
+    firstPositionalIndex(args).let { if (it >= 0) args[it] else null }
+
+  /** Index of [firstPositional] in [args], or `-1`. */
+  fun firstPositionalIndex(args: List<String>): Int = findCommandIndex(args.toTypedArray())
+
+  /**
    * Index of the subcommand token in [args], or `-1` if argv is entirely flags and their values.
    * The first bare (non-`-`) token that isn't the value of a [VALUE_FLAGS] flag.
    */

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CliRouter.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CliRouter.kt
@@ -1,0 +1,90 @@
+package ee.schimke.composeai.cli
+
+/**
+ * Command routing: the top-level verbs, the command *groups* (`compose-preview <group> <command>`),
+ * and the pure [route] that turns argv into a [Route] decision.
+ *
+ * 19 flat commands had grown a wide, flat namespace. Groups give the top level a short, honest
+ * shape (a few core verbs + four groups) while **every command stays callable by its original flat
+ * name** — the grouped form is additive, the flat name is a permanent back-compat alias, so
+ * existing scripts and the published skill keep working unchanged.
+ *
+ * [route] is deliberately side-effect-free (no printing, no `exitProcess`, no command construction)
+ * so `CliRouterTest` can exercise every dispatch path directly. `Main` maps the [Route] onto the
+ * actual command factories; `CliRouterTest` also pins that the factory table and this router agree
+ * on the command set, so the two can't drift.
+ */
+internal object CliRouter {
+  /** Top-level commands shown first and not nested under a group. */
+  val CORE: List<String> = listOf("render", "show", "list", "show-resources", "doctor", "mcp")
+
+  /**
+   * Command groups, in display order. `compose-preview <group> <command>` dispatches to the
+   * command; each command is also reachable by its bare flat name. A group named with no (or an
+   * unknown) subcommand prints the group's listing.
+   */
+  val GROUPS: Map<String, List<String>> =
+    linkedMapOf(
+      "inspect" to listOf("a11y", "diff-semantics", "devices", "extensions", "history", "profile"),
+      "capture" to listOf("render-matrix", "record", "bundle"),
+      "share" to listOf("serve", "share-preview"),
+      "setup" to listOf("update", "init-script"),
+    )
+
+  /** Pseudo-commands that aren't backed by a `Command` class but are valid flat verbs. */
+  val META: List<String> = listOf("version", "help")
+
+  val GROUP_NAMES: Set<String> = GROUPS.keys
+
+  /** Every command reachable by flat name (core + grouped + meta). */
+  val KNOWN_FLAT: Set<String> = (CORE + GROUPS.values.flatten() + META).toSet()
+
+  fun subcommandsOf(group: String): List<String> = GROUPS[group].orEmpty()
+
+  /** The group a flat command belongs to, or `null` for core/meta commands. */
+  fun groupOf(command: String): String? = GROUPS.entries.firstOrNull { command in it.value }?.key
+
+  /**
+   * A routing decision for argv that has already passed the `--version` / empty-args short-circuit.
+   */
+  sealed interface Route {
+    /** Run [command] with [args] (the command token, and any consumed group token, removed). */
+    data class Run(val command: String, val args: List<String>) : Route
+
+    /** Print a group's command listing. [isError] when an unknown subcommand was given (exit 1). */
+    data class GroupUsage(val group: String, val isError: Boolean) : Route
+
+    /** Top-level `--help` with no command. */
+    data class TopUsage(val full: Boolean) : Route
+
+    /** No command token and not a help request (exit 1). */
+    data object NoCommand : Route
+
+    /** A leading token that isn't a known command or group (exit 1). */
+    data class Unknown(val command: String) : Route
+  }
+
+  fun route(args: Array<String>): Route {
+    val commandIndex = CliFlags.findCommandIndex(args)
+    if (commandIndex < 0) {
+      return if ("--help" in args || "-h" in args) Route.TopUsage(full = "--all" in args)
+      else Route.NoCommand
+    }
+
+    val command = args[commandIndex]
+    val rest = args.toMutableList().apply { removeAt(commandIndex) }
+
+    if (command in GROUP_NAMES) {
+      val subIndex = CliFlags.findCommandIndex(rest.toTypedArray())
+      val sub = if (subIndex >= 0) rest[subIndex] else null
+      if (sub != null && sub in subcommandsOf(command)) {
+        val subArgs = rest.toMutableList().apply { removeAt(subIndex) }
+        return Route.Run(sub, subArgs)
+      }
+      // Group named alone → its listing (exit 0); group + unknown subcommand → listing + exit 1.
+      return Route.GroupUsage(command, isError = sub != null)
+    }
+
+    return if (command in KNOWN_FLAT) Route.Run(command, rest) else Route.Unknown(command)
+  }
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/HistoryCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/HistoryCommand.kt
@@ -44,15 +44,13 @@ import kotlinx.serialization.json.JsonElement
 class HistoryCommand(private val args: List<String>) {
 
   fun run() {
-    when (args.firstOrNull { !it.startsWith("-") } ?: "help") {
+    when (CliFlags.firstPositional(args) ?: "help") {
       "list" -> list()
       "read" -> read()
       "diff" -> diff()
       "help" -> printUsage()
       else -> {
-        System.err.println(
-          "Unknown history subcommand: ${args.firstOrNull { !it.startsWith("-") }}"
-        )
+        System.err.println("Unknown history subcommand: ${CliFlags.firstPositional(args)}")
         printUsage()
         exitProcess(1)
       }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
@@ -2,6 +2,37 @@ package ee.schimke.composeai.cli
 
 import kotlin.system.exitProcess
 
+/**
+ * Flat command dispatch table — the single source of truth for which verbs exist and how each is
+ * constructed. [CliRouter] decides *what* to run (including group routing and back-compat aliases);
+ * this map turns that decision into a command invocation. `CliRouterTest` pins that the keys here
+ * match [CliRouter.KNOWN_FLAT], so the router and the dispatcher can't drift.
+ */
+internal val COMMANDS: Map<String, (List<String>) -> Unit> =
+  mapOf(
+    "show" to { a -> ShowCommand(a).run() },
+    "show-resources" to { a -> ShowResourcesCommand(a).run() },
+    "list" to { a -> ListCommand(a).run() },
+    "render" to { a -> RenderCommand(a).run() },
+    "render-matrix" to { a -> RenderMatrixCommand(a).run() },
+    "record" to { a -> RecordPreviewCommand(a).run() },
+    "a11y" to { a -> A11yCommand(a).run() },
+    "diff-semantics" to { a -> SemanticsDiffCommand(a).run() },
+    "history" to { a -> HistoryCommand(a).run() },
+    "extensions" to { a -> ExtensionsCommand(a).run() },
+    "profile" to { a -> ProfileCommand(a).run() },
+    "doctor" to { a -> DoctorCommand(a).run() },
+    "devices" to { a -> DevicesCommand(a).run() },
+    "serve" to { a -> ServeCommand(a).run() },
+    "share-preview" to { a -> SharePreviewCommand(a).run() },
+    "bundle" to { a -> BundleCommand(a).run() },
+    "mcp" to { a -> McpCommand(a).run() },
+    "update" to { a -> UpdateCommand(a).run() },
+    "init-script" to { a -> InitScriptCommand(a).run() },
+    "version" to { _ -> println("compose-preview $BUNDLE_VERSION") },
+    "help" to { a -> printUsage(full = "--all" in a) },
+  )
+
 fun main(args: Array<String>) {
   if (args.isEmpty()) {
     printUsage()
@@ -16,52 +47,42 @@ fun main(args: Array<String>) {
     exitProcess(0)
   }
 
-  // Find the command — first bare token that isn't the value of a value-consuming flag. The
-  // classification of which flags consume the following token lives in [CliFlags] (single source of
-  // truth, guarded by CliFlagsRegistryTest).
-  val commandIndex = CliFlags.findCommandIndex(args)
-
-  if (commandIndex < 0) {
-    if ("--help" in args || "-h" in args) {
-      printUsage(full = "--all" in args)
-      exitProcess(0)
+  when (val route = CliRouter.route(args)) {
+    is CliRouter.Route.Run -> COMMANDS.getValue(route.command).invoke(route.args)
+    is CliRouter.Route.GroupUsage -> {
+      printGroupUsage(route.group)
+      exitProcess(if (route.isError) 1 else 0)
     }
-    System.err.println("No command specified.")
-    printUsage()
-    exitProcess(1)
-  }
-
-  val command = args[commandIndex]
-  val allArgs = args.toMutableList().apply { removeAt(commandIndex) }
-
-  when (command) {
-    "show" -> ShowCommand(allArgs).run()
-    "show-resources" -> ShowResourcesCommand(allArgs).run()
-    "list" -> ListCommand(allArgs).run()
-    "render" -> RenderCommand(allArgs).run()
-    "render-matrix" -> RenderMatrixCommand(allArgs).run()
-    "record" -> RecordPreviewCommand(allArgs).run()
-    "a11y" -> A11yCommand(allArgs).run()
-    "diff-semantics" -> SemanticsDiffCommand(allArgs).run()
-    "history" -> HistoryCommand(allArgs).run()
-    "extensions" -> ExtensionsCommand(allArgs).run()
-    "profile" -> ProfileCommand(allArgs).run()
-    "doctor" -> DoctorCommand(allArgs).run()
-    "devices" -> DevicesCommand(allArgs).run()
-    "serve" -> ServeCommand(allArgs).run()
-    "share-preview" -> SharePreviewCommand(allArgs).run()
-    "bundle" -> BundleCommand(allArgs).run()
-    "mcp" -> McpCommand(allArgs).run()
-    "update" -> UpdateCommand(allArgs).run()
-    "init-script" -> InitScriptCommand(allArgs).run()
-    "version" -> println("compose-preview $BUNDLE_VERSION")
-    "help" -> printUsage(full = "--all" in allArgs)
-    else -> {
-      System.err.println("Unknown command: $command")
+    is CliRouter.Route.TopUsage -> printUsage(full = route.full)
+    CliRouter.Route.NoCommand -> {
+      System.err.println("No command specified.")
+      printUsage()
+      exitProcess(1)
+    }
+    is CliRouter.Route.Unknown -> {
+      System.err.println("Unknown command: ${route.command}")
       printUsage()
       exitProcess(1)
     }
   }
+}
+
+/**
+ * Print a single group's command listing (`compose-preview <group>` with no/unknown subcommand).
+ */
+private fun printGroupUsage(group: String) {
+  val subs = CliRouter.subcommandsOf(group)
+  println(
+    """
+    compose-preview $group — ${subs.joinToString(", ")}
+
+    Usage: compose-preview $group <command> [options]
+           (each is also callable directly, e.g. `compose-preview ${subs.firstOrNull() ?: ""}`)
+
+    Run `compose-preview help --all` for the full command + flag reference.
+    """
+      .trimIndent()
+  )
 }
 
 /**
@@ -92,9 +113,12 @@ private fun printUsage(full: Boolean = false) {
       version          Print the installed bundle version and exit
       help             Show this message (`help --all` for every command + flag)
 
-    More commands: render-matrix, record, a11y, diff-semantics, history, extensions,
-      profile, devices, serve, share-preview, bundle, update, init-script.
-      Run `compose-preview help --all` for the full command + flag reference.
+    Command groups (each command is also callable directly by its name):
+      inspect   a11y · diff-semantics · devices · extensions · history · profile
+      capture   render-matrix · record · bundle
+      share     serve · share-preview
+      setup     update · init-script
+    Run `compose-preview <group>` to list a group, or `help --all` for every command + flag.
 
     Common options: --module <name>, --filter <pattern>, --id <exact>, --json,
       --output <path>, --verbose/-v. Full list under `help --all`.
@@ -109,6 +133,9 @@ private fun printFullUsage() {
     compose-preview — Compose Preview CLI
 
     Usage: compose-preview [options] <command> [options]
+
+    Commands are grouped (inspect · capture · share · setup); run `compose-preview <group>` to
+    list one. Every command below is also reachable as `compose-preview <group> <command>`.
 
     Commands:
       show             Discover and render previews; print id, path, sha256, changed flag

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/CliFlagsRegistryTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/CliFlagsRegistryTest.kt
@@ -69,6 +69,16 @@ class CliFlagsRegistryTest {
     assertEquals(-1, CliFlags.findCommandIndex(arrayOf("--module", ":app")))
   }
 
+  @Test
+  fun `firstPositional skips leading valued flags so nested subcommands resolve`() {
+    // The grouped form `capture --module :app bundle pack` hands BundleCommand
+    // ["--module", ":app", "pack"]; its subcommand is `pack`, not the flag value `:app`.
+    assertEquals("pack", CliFlags.firstPositional(listOf("--module", ":app", "pack")))
+    assertEquals(2, CliFlags.firstPositionalIndex(listOf("--module", ":app", "pack")))
+    assertEquals("list", CliFlags.firstPositional(listOf("list", "--json")))
+    assertEquals(null, CliFlags.firstPositional(listOf("--module", ":app")))
+  }
+
   private val sourceDir: File
     get() = File(repoRoot(), "cli/src/main/kotlin/ee/schimke/composeai/cli")
 

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/CliRouterTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/CliRouterTest.kt
@@ -1,0 +1,86 @@
+package ee.schimke.composeai.cli
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Pins the command router: groups partition the non-core/meta commands cleanly, the flat dispatch
+ * table and the router agree on the command set (no drift), and routing resolves both the grouped
+ * form and the flat back-compat aliases.
+ */
+class CliRouterTest {
+  @Test
+  fun `dispatch table matches the router's known commands`() {
+    assertEquals(
+      CliRouter.KNOWN_FLAT,
+      COMMANDS.keys,
+      "COMMANDS and CliRouter.KNOWN_FLAT disagree — add/remove the command in both",
+    )
+  }
+
+  @Test
+  fun `groups are disjoint and don't collide with core, meta, or group names`() {
+    val grouped = CliRouter.GROUPS.values.flatten()
+    assertEquals(grouped.size, grouped.toSet().size, "a command appears in two groups")
+
+    val core = CliRouter.CORE.toSet()
+    val meta = CliRouter.META.toSet()
+    assertTrue((grouped.toSet() intersect core).isEmpty(), "a grouped command is also core")
+    assertTrue((grouped.toSet() intersect meta).isEmpty(), "a grouped command is also meta")
+    // A group name must not also be a flat command, or `compose-preview <name>` is ambiguous.
+    assertTrue(
+      (CliRouter.GROUP_NAMES intersect CliRouter.KNOWN_FLAT).isEmpty(),
+      "a group name collides with a command name",
+    )
+  }
+
+  @Test
+  fun `grouped form dispatches to the subcommand with the group token stripped`() {
+    assertEquals(
+      CliRouter.Route.Run("a11y", listOf("--json")),
+      CliRouter.route(arrayOf("inspect", "a11y", "--json")),
+    )
+    // A flag may precede the subcommand.
+    assertEquals(
+      CliRouter.Route.Run("record", listOf("--module", ":app", "--out", "r.gif")),
+      CliRouter.route(arrayOf("capture", "--module", ":app", "record", "--out", "r.gif")),
+    )
+  }
+
+  @Test
+  fun `flat names remain valid back-compat aliases`() {
+    assertEquals(CliRouter.Route.Run("a11y", emptyList()), CliRouter.route(arrayOf("a11y")))
+    assertEquals(
+      CliRouter.Route.Run("render", listOf("--output", "out.png")),
+      CliRouter.route(arrayOf("render", "--output", "out.png")),
+    )
+  }
+
+  @Test
+  fun `group named alone or with an unknown subcommand prints its listing`() {
+    assertEquals(
+      CliRouter.Route.GroupUsage("inspect", isError = false),
+      CliRouter.route(arrayOf("inspect")),
+    )
+    assertEquals(
+      CliRouter.Route.GroupUsage("inspect", isError = true),
+      CliRouter.route(arrayOf("inspect", "bogus")),
+    )
+  }
+
+  @Test
+  fun `unknown command and no command are distinguished`() {
+    assertEquals(CliRouter.Route.Unknown("frobnicate"), CliRouter.route(arrayOf("frobnicate")))
+    assertEquals(CliRouter.Route.NoCommand, CliRouter.route(arrayOf("--json")))
+    assertEquals(CliRouter.Route.TopUsage(full = false), CliRouter.route(arrayOf("--help")))
+    assertEquals(CliRouter.Route.TopUsage(full = true), CliRouter.route(arrayOf("--help", "--all")))
+  }
+
+  @Test
+  fun `every non-core, non-meta command lives in exactly one group`() {
+    val ungrouped = (COMMANDS.keys - CliRouter.CORE.toSet() - CliRouter.META.toSet())
+    val grouped = CliRouter.GROUPS.values.flatten().toSet()
+    assertEquals(grouped, ungrouped, "commands missing from a group (or grouped but undispatched)")
+  }
+}


### PR DESCRIPTION
Item 6 of #1995 — you chose the "subcommand namespace + back-compat aliases" direction.

## Problem

19 flat top-level commands gave the CLI no shape — the appraisal's "top level isn't honest about the one-command pitch."

## Change

Four command groups, dispatched as `compose-preview <group> <command>`:

| Group | Commands |
|---|---|
| *(core, top-level)* | `render` `show` `list` `show-resources` `doctor` `mcp` |
| **inspect** | `a11y` `diff-semantics` `devices` `extensions` `history` `profile` |
| **capture** | `render-matrix` `record` `bundle` |
| **share** | `serve` `share-preview` |
| **setup** | `update` `init-script` |

- **Every command stays callable by its original flat name** as a permanent back-compat alias — `compose-preview a11y` and `compose-preview inspect a11y` both work. The grouped form is purely additive, so existing scripts and the published [`compose-preview` skill](https://github.com/yschimke/skills) need no changes.
- Naming a group alone (`compose-preview inspect`) lists its commands.
- Concise `help` now shows core verbs + the four groups instead of a flat "More commands" line.

## Mechanics (drift-proof)

- **`CliRouter`** owns the groups and a side-effect-free `route(argv): Route` (no printing, no `exitProcess`, no command construction) — so every dispatch path is unit-tested directly.
- The dispatch `when` becomes a **`COMMANDS` factory map**. `CliRouterTest` pins `COMMANDS.keys == CliRouter.KNOWN_FLAT` and that every non-core/meta command lives in exactly one group — routing and dispatch can't silently diverge.

## Test plan

- [x] `./gradlew :cli:test` — full suite green (BUILD SUCCESSFUL).
- [x] `CliRouterTest`: grouped form strips the group token (`inspect a11y --json` → run `a11y`), flat aliases still resolve, group-alone vs unknown-subcommand vs unknown-command vs no-command all distinguished, and the registry/router agree on the command set.

Independent of #2007 (de-doctrine) — different help regions, no conflict. Non-visual change (argv routing + help text).

---
_Generated by [Claude Code](https://claude.ai/code/session_01JAcNgg7dRjyCmuX3uk4VdE)_