### PR TITLE
feat(cli): share one daemon stream across watchers + preview switch

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -6,6 +6,7 @@ import ee.schimke.composeai.cli.serve.ServeHttpServer
 import ee.schimke.composeai.cli.serve.ServeMdnsAdvertiser
 import ee.schimke.composeai.cli.serve.ServePreview
 import ee.schimke.composeai.cli.serve.ServeRenderHost
+import ee.schimke.composeai.cli.serve.ServeSessionRegistry
 import ee.schimke.composeai.cli.serve.ServeUrls
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.render.session.RenderSessionException
@@ -91,6 +92,7 @@ class ServeCommand(args: List<String>) : Command(args) {
           workspaceRoot = module.projectDir,
           workspaceName = module.projectDir.name,
           previews = previews,
+          label = module.gradlePath,
           onLog = { System.err.println("[daemon serve] $it") },
         )
       } catch (e: RenderSessionException) {
@@ -108,13 +110,18 @@ class ServeCommand(args: List<String>) : Command(args) {
     }
 
     val token = tokenOverride ?: ServeUrls.generateToken()
+    // One shared server fronts a session registry rather than a single host: the current module is
+    // the pinned default session, and additional tenants (e.g. other modules / PR revisions) can be
+    // forked behind the registry's factory in future without spawning another server.
+    val registry = ServeSessionRegistry()
+    registry.register(module.gradlePath, renderHost)
     val server =
       ServeHttpServer(
         host = host,
         requestedPort = requestedPort,
         token = token,
-        renderHost = renderHost,
-        moduleLabel = module.gradlePath,
+        sessions = registry,
+        defaultSessionId = module.gradlePath,
       )
 
     // Advertise on the LAN over mDNS when bound to a reachable interface (`--lan`), so the mobile /
@@ -140,7 +147,7 @@ class ServeCommand(args: List<String>) : Command(args) {
           System.err.println("\nserve: shutting down…")
           runCatching { advertiser?.close() }
           runCatching { server.stop() }
-          runCatching { renderHost.close() }
+          runCatching { registry.close() }
           done.countDown()
         }
       )

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBroadcastHub.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBroadcastHub.kt
@@ -1,0 +1,143 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.daemon.protocol.InteractiveInputKind
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.daemon.protocol.StreamCodec
+import ee.schimke.composeai.daemon.protocol.StreamFrameParams
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+
+/** Opens one upstream daemon stream. Matches [ServeRenderHost.startStream]. */
+fun interface StreamOpener {
+  fun open(
+    previewId: String,
+    overrides: PreviewOverrides,
+    codec: StreamCodec?,
+    maxFps: Int?,
+    onFrame: (StreamFrameParams) -> Unit,
+  ): StreamHandle?
+}
+
+/**
+ * Shares **one** upstream daemon stream across every watcher of the same preview + overrides +
+ * codec + fps. Without it, N browsers watching the same preview would open N held daemon sessions
+ * (N `stream/start`s); with it they ride a single held session whose frames fan out to all of them,
+ * and any watcher's input drives the shared composition.
+ *
+ * Keyed by [keyOf]: distinct overrides (or codec / fps) are distinct streams, so a viewer changing
+ * theme transparently moves to its own shared lane without disturbing the others. The upstream is
+ * opened lazily on the first subscriber for a key and torn down when the last one leaves
+ * (ref-counted), so an idle hub holds no daemon sessions.
+ *
+ * Late joiners are replayed the last *painted* frame immediately, so a watcher that connects
+ * between recompositions sees the current picture instead of a blank canvas until the next frame.
+ *
+ * Each [subscribe] returns a per-watcher [StreamHandle]: its [StreamHandle.input] forwards into the
+ * shared session and its [StreamHandle.close] drops just that watcher (closing the shared upstream
+ * only when it was the last).
+ */
+class ServeBroadcastHub(private val opener: StreamOpener) {
+
+  private val lock = ReentrantLock()
+  private val broadcasts = HashMap<String, Broadcast>()
+
+  /**
+   * Join the shared stream for [previewId] at these overrides/codec/fps, opening the upstream if
+   * this is the first watcher. Returns `null` (and opens nothing) when the backend can't stream, so
+   * the caller falls back to the snapshot lane — same contract as [ServeRenderHost.startStream].
+   */
+  fun subscribe(
+    previewId: String,
+    overrides: PreviewOverrides,
+    codec: StreamCodec? = null,
+    maxFps: Int? = null,
+    onFrame: (StreamFrameParams) -> Unit,
+  ): StreamHandle? = lock.withLock {
+    val key = keyOf(previewId, overrides, codec, maxFps)
+    val broadcast =
+      broadcasts[key]
+        ?: run {
+          val fresh = Broadcast(key)
+          // Hold the lock across the open so two racing first-subscribers can't open two upstreams
+          // for one key; opens are cheap relative to a dev server's client count.
+          val handle =
+            opener.open(previewId, overrides, codec, maxFps, fresh::onUpstreamFrame)
+              ?: return@withLock null
+          fresh.handle = handle
+          broadcasts[key] = fresh
+          fresh
+        }
+    broadcast.addWatcher(onFrame)
+  }
+
+  /** Live shared upstream streams (one per distinct key). For tests / diagnostics. */
+  fun activeStreamCount(): Int = lock.withLock { broadcasts.size }
+
+  private fun release(broadcast: Broadcast, onFrame: (StreamFrameParams) -> Unit) {
+    lock.withLock {
+      if (broadcast.removeWatcher(onFrame) == 0) {
+        broadcasts.remove(broadcast.key, broadcast)
+        broadcast.handle?.close()
+      }
+    }
+  }
+
+  private inner class Broadcast(val key: String) {
+    @Volatile var handle: StreamHandle? = null
+    private val watchers = CopyOnWriteArrayList<(StreamFrameParams) -> Unit>()
+    @Volatile private var lastPainted: StreamFrameParams? = null
+
+    /**
+     * Fan an upstream frame out to every watcher; cache it if it paints (for late-joiner replay).
+     */
+    fun onUpstreamFrame(frame: StreamFrameParams) {
+      // Payload-less `unchanged` heartbeats don't paint, so they don't become the replay frame.
+      if (frame.payloadBase64 != null) lastPainted = frame
+      watchers.forEach { it(frame) }
+    }
+
+    /** Add a watcher and replay the current picture to it. Caller holds [lock]. */
+    fun addWatcher(onFrame: (StreamFrameParams) -> Unit): StreamHandle {
+      lastPainted?.let(onFrame)
+      watchers.add(onFrame)
+      return object : StreamHandle {
+        private val closed = AtomicBoolean(false)
+
+        override fun input(
+          kind: InteractiveInputKind,
+          pixelX: Int?,
+          pixelY: Int?,
+          pointerId: Int?,
+          scrollDeltaY: Float?,
+          keyCode: String?,
+        ) {
+          if (closed.get()) return
+          handle?.input(kind, pixelX, pixelY, pointerId, scrollDeltaY, keyCode)
+        }
+
+        override fun close() {
+          if (closed.compareAndSet(false, true)) release(this@Broadcast, onFrame)
+        }
+      }
+    }
+
+    /** Remove a watcher; returns the remaining count. Caller holds [lock]. */
+    fun removeWatcher(onFrame: (StreamFrameParams) -> Unit): Int {
+      watchers.remove(onFrame)
+      return watchers.size
+    }
+  }
+
+  private companion object {
+    /** Same identity the snapshot cache uses, plus the stream-only knobs (codec, fps). */
+    fun keyOf(
+      previewId: String,
+      overrides: PreviewOverrides,
+      codec: StreamCodec?,
+      maxFps: Int?,
+    ): String =
+      "${ServeOverrides.cacheKey(previewId, overrides)}|c=${codec?.name ?: "-"}|f=${maxFps ?: "-"}"
+  }
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBroadcastHub.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBroadcastHub.kt
@@ -100,8 +100,12 @@ class ServeBroadcastHub(private val opener: StreamOpener) {
 
     /** Add a watcher and replay the current picture to it. Caller holds [lock]. */
     fun addWatcher(onFrame: (StreamFrameParams) -> Unit): StreamHandle {
-      lastPainted?.let(onFrame)
+      // Register *before* replaying: onUpstreamFrame is lock-free, so a frame painted between the
+      // replay and the add would otherwise reach neither the live fan-out (not yet a watcher) nor
+      // the replay (already read) and leave a static preview blank. Registering first means the
+      // worst case is a harmless duplicate of the current frame (newest-wins paint), never a miss.
       watchers.add(onFrame)
+      lastPainted?.let(onFrame)
       return object : StreamHandle {
         private val closed = AtomicBoolean(false)
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -27,15 +27,20 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 
 /**
- * The embedded Ktor (CIO) HTTP server fronting a [ServeRenderHost]. Thin IO shell: a token gate,
- * the five routes, and the query-param → [ServeOverrides] → render → PNG glue. All shared,
- * concurrency safe state lives in [ServeRenderHost]; this class adds none of its own per-request
- * state, so it serves any number of clients.
+ * The embedded Ktor (CIO) HTTP server fronting a [ServeSessionRegistry]. Thin IO shell: a token
+ * gate, the routes, and the query-param → [ServeOverrides] → render → PNG glue. All shared,
+ * concurrency-safe state lives in the per-tenant [ServeRenderHost]s; this class adds none of its
+ * own per-request state, so it serves any number of clients.
+ *
+ * **Multi-tenant:** one server fronts many sessions instead of one per module. Every route resolves
+ * a [ServeRenderHost] from the registry by the request's `?session=` (falling back to
+ * [defaultSessionId]); the registry forks the tenant behind its factory on first use. Unknown
+ * sessions 404 like a bad token.
  *
  * Endpoints (all token-gated except `/healthz`):
  * - `GET /` landing page, `GET /p/{id}` viewer page,
  * - `GET /render/{id}.png` PNG bytes, `GET /api/previews` JSON, `GET /healthz` liveness,
- * - `GET /bundle.zip` portable bundle, `WS /ws/{id}` streamed-frame lane (tier-2 spike).
+ * - `GET /bundle.zip` portable bundle, `WS /ws/{id}` streamed-frame lane.
  *
  * A bad/missing token returns **404** (not 401) so the server's existence isn't confirmed to a
  * scanner; the token is compared in constant time ([ServeUrls.tokensMatch]).
@@ -44,8 +49,8 @@ class ServeHttpServer(
   private val host: String,
   requestedPort: Int,
   private val token: String,
-  private val renderHost: ServeRenderHost,
-  private val moduleLabel: String,
+  private val sessions: ServeSessionRegistry,
+  private val defaultSessionId: String,
   portRange: Int = DEFAULT_PORT_RANGE,
 ) {
   /** The actual bound port — may differ from the requested one if it was taken (auto-picked). */
@@ -58,14 +63,19 @@ class ServeHttpServer(
         // `/healthz` is the only ungated route — liveness only, leaks nothing.
         get("/healthz") { call.respondText("ok") }
 
-        // Tier-2 streaming spike: a persistent frame lane. The browser opens this, receives PNG
-        // frames as JSON ([ServeStreamProtocol]), and sends override/refresh messages back; each
-        // drives a re-render through the shared [ServeRenderHost]. Token is checked post-handshake
-        // (can't 404 after upgrade) — a bad token closes immediately.
+        // A persistent frame lane. The browser opens this, receives frames as JSON
+        // ([ServeStreamProtocol]), and sends override / switch / input messages back. Token is
+        // checked post-handshake (can't 404 after upgrade) — a bad token closes immediately.
         webSocket("/ws/{name}") {
           val provided = call.request.queryParameters["token"] ?: call.request.headers[TOKEN_HEADER]
           if (!ServeUrls.tokensMatch(token, provided)) {
             close(CloseReason(CloseReason.Codes.VIOLATED_POLICY, "unauthorized"))
+            return@webSocket
+          }
+          val sessionId = call.request.queryParameters["session"] ?: defaultSessionId
+          val renderHost = withContext(Dispatchers.IO) { sessions.acquire(sessionId) }
+          if (renderHost == null) {
+            close(CloseReason(CloseReason.Codes.CANNOT_ACCEPT, "no such session"))
             return@webSocket
           }
           val previewId = call.parameters["name"]
@@ -129,17 +139,19 @@ class ServeHttpServer(
 
         get("/") {
           if (rejectBadToken()) return@get
+          val renderHost = resolveHost() ?: return@get
           call.respondText(
-            ServeWeb.landingPage(moduleLabel, renderHost.previews, token),
+            ServeWeb.landingPage(renderHost.label, renderHost.previews, token),
             ContentType.Text.Html,
           )
         }
 
         get("/api/previews") {
           if (rejectBadToken()) return@get
+          val renderHost = resolveHost() ?: return@get
           val dto =
             PreviewsResponse(
-              module = moduleLabel,
+              module = renderHost.label,
               previews =
                 renderHost.previews.map { p ->
                   PreviewDto(id = p.id, label = p.label, modes = p.modes.map { it.wire })
@@ -153,6 +165,7 @@ class ServeHttpServer(
 
         get("/bundle.zip") {
           if (rejectBadToken()) return@get
+          val renderHost = resolveHost() ?: return@get
           // Render the whole module once (cache-backed) into the portable WebEmbed gallery and
           // stream it as a zip — the same render output as the live links, downloadable offline.
           val zip =
@@ -160,8 +173,8 @@ class ServeHttpServer(
               val built =
                 ServeBundle.build(
                   previews = renderHost.previews,
-                  title = moduleLabel,
-                  modulePath = moduleLabel,
+                  title = renderHost.label,
+                  modulePath = renderHost.label,
                 ) { preview ->
                   (renderHost.render(preview.id, PreviewOverrides()) as? RenderOutcome.Ok)?.png
                 }
@@ -172,6 +185,7 @@ class ServeHttpServer(
 
         get("/p/{name}") {
           if (rejectBadToken()) return@get
+          val renderHost = resolveHost() ?: return@get
           val previewId = call.parameters["name"]
           val preview = previewId?.let { id -> renderHost.previews.firstOrNull { it.id == id } }
           if (preview == null) {
@@ -183,6 +197,7 @@ class ServeHttpServer(
 
         get("/render/{name}") {
           if (rejectBadToken()) return@get
+          val renderHost = resolveHost() ?: return@get
           val previewId = call.parameters["name"]?.removeSuffix(".png")
           if (previewId.isNullOrBlank()) {
             call.respondText("missing preview id", status = HttpStatusCode.BadRequest)
@@ -221,6 +236,18 @@ class ServeHttpServer(
   /** Stop with a short grace period. Idempotent enough for a shutdown hook. */
   fun stop() {
     server.stop(gracePeriodMillis = 500, timeoutMillis = 2000)
+  }
+
+  /**
+   * Resolve the tenant for this request: `?session=` (else [defaultSessionId]) through the
+   * registry, which forks it on first use. Responds 404 and returns null when the session can't be
+   * created.
+   */
+  private suspend fun RoutingContext.resolveHost(): ServeRenderHost? {
+    val sessionId = call.request.queryParameters["session"] ?: defaultSessionId
+    val renderHost = withContext(Dispatchers.IO) { sessions.acquire(sessionId) }
+    if (renderHost == null) call.respondText("not found", status = HttpStatusCode.NotFound)
+    return renderHost
   }
 
   /**

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -73,67 +73,75 @@ class ServeHttpServer(
             return@webSocket
           }
           val sessionId = call.request.queryParameters["session"] ?: defaultSessionId
-          val renderHost = withContext(Dispatchers.IO) { sessions.acquire(sessionId) }
-          if (renderHost == null) {
+          // Lease (not just acquire) the tenant for the socket's whole life: a fallback-lane socket
+          // opens no stream, so without a lease the reaper could close its host mid-connection.
+          val lease = withContext(Dispatchers.IO) { sessions.lease(sessionId) }
+          if (lease == null) {
             close(CloseReason(CloseReason.Codes.CANNOT_ACCEPT, "no such session"))
             return@webSocket
           }
-          val previewId = call.parameters["name"]
-          if (previewId == null || renderHost.previews.none { it.id == previewId }) {
-            close(CloseReason(CloseReason.Codes.CANNOT_ACCEPT, "no such preview"))
-            return@webSocket
-          }
-          val initialOverrides =
-            ServeOverrides.SUPPORTED_KEYS.mapNotNull { key ->
-                call.request.queryParameters[key]?.let { key to it }
+          try {
+            val renderHost = lease.host
+            val previewId = call.parameters["name"]
+            if (previewId == null || renderHost.previews.none { it.id == previewId }) {
+              close(CloseReason(CloseReason.Codes.CANNOT_ACCEPT, "no such preview"))
+              return@webSocket
+            }
+            val initialOverrides =
+              ServeOverrides.SUPPORTED_KEYS.mapNotNull { key ->
+                  call.request.queryParameters[key]?.let { key to it }
+                }
+                .toMap()
+            // Non-suspending hand-off to the socket; drop frames a slow client can't keep up with.
+            val send: (String) -> Unit = { text -> outgoing.trySend(Frame.Text(text)) }
+            // Optional stream tuning: codec (WebP is ~30–60% smaller; the daemon downgrades to PNG
+            // if
+            // it can't encode WebP) and an fps cap.
+            val codec =
+              when (call.request.queryParameters["codec"]?.lowercase()) {
+                "webp" -> StreamCodec.WEBP
+                "png" -> StreamCodec.PNG
+                else -> null
               }
-              .toMap()
-          // Non-suspending hand-off to the socket; drop frames a slow client can't keep up with.
-          val send: (String) -> Unit = { text -> outgoing.trySend(Frame.Text(text)) }
-          // Optional stream tuning: codec (WebP is ~30–60% smaller; the daemon downgrades to PNG if
-          // it can't encode WebP) and an fps cap.
-          val codec =
-            when (call.request.queryParameters["codec"]?.lowercase()) {
-              "webp" -> StreamCodec.WEBP
-              "png" -> StreamCodec.PNG
-              else -> null
-            }
-          val maxFps = call.request.queryParameters["maxFps"]?.toIntOrNull()?.takeIf { it > 0 }
-          // Prefer the daemon's live stream lane (frames pushed, input dispatched); fall back to
-          // the
-          // snapshot re-render lane when the backend doesn't support streaming.
-          val live =
-            withContext(Dispatchers.IO) {
-              ServeLiveSession.tryStart(
-                renderHost,
-                previewId,
-                initialOverrides,
-                codec,
-                maxFps,
-                send,
-              )
-            }
-          if (live != null) {
-            try {
+            val maxFps = call.request.queryParameters["maxFps"]?.toIntOrNull()?.takeIf { it > 0 }
+            // Prefer the daemon's live stream lane (frames pushed, input dispatched); fall back to
+            // the
+            // snapshot re-render lane when the backend doesn't support streaming.
+            val live =
+              withContext(Dispatchers.IO) {
+                ServeLiveSession.tryStart(
+                  renderHost,
+                  previewId,
+                  initialOverrides,
+                  codec,
+                  maxFps,
+                  send,
+                )
+              }
+            if (live != null) {
+              try {
+                for (frame in incoming) {
+                  if (frame is Frame.Text) {
+                    val text = frame.readText()
+                    withContext(Dispatchers.IO) { live.onClientMessage(text) }
+                  }
+                }
+              } finally {
+                withContext(Dispatchers.IO) { live.close() }
+              }
+            } else {
+              val session = ServeStreamSession(renderHost, previewId, initialOverrides, send)
+              // Renders block (renderNow + await); keep them off the socket's event-loop thread.
+              withContext(Dispatchers.IO) { session.onOpen() }
               for (frame in incoming) {
                 if (frame is Frame.Text) {
                   val text = frame.readText()
-                  withContext(Dispatchers.IO) { live.onClientMessage(text) }
+                  withContext(Dispatchers.IO) { session.onClientMessage(text) }
                 }
               }
-            } finally {
-              withContext(Dispatchers.IO) { live.close() }
             }
-          } else {
-            val session = ServeStreamSession(renderHost, previewId, initialOverrides, send)
-            // Renders block (renderNow + await); keep them off the socket's event-loop thread.
-            withContext(Dispatchers.IO) { session.onOpen() }
-            for (frame in incoming) {
-              if (frame is Frame.Text) {
-                val text = frame.readText()
-                withContext(Dispatchers.IO) { session.onClientMessage(text) }
-              }
-            }
+          } finally {
+            lease.close()
           }
         }
 
@@ -141,7 +149,12 @@ class ServeHttpServer(
           if (rejectBadToken()) return@get
           val renderHost = resolveHost() ?: return@get
           call.respondText(
-            ServeWeb.landingPage(renderHost.label, renderHost.previews, token),
+            ServeWeb.landingPage(
+              renderHost.label,
+              renderHost.previews,
+              token,
+              call.request.queryParameters["session"],
+            ),
             ContentType.Text.Html,
           )
         }
@@ -192,7 +205,10 @@ class ServeHttpServer(
             call.respondText("no such preview", status = HttpStatusCode.NotFound)
             return@get
           }
-          call.respondText(ServeWeb.viewerPage(preview, token), ContentType.Text.Html)
+          call.respondText(
+            ServeWeb.viewerPage(preview, token, call.request.queryParameters["session"]),
+            ContentType.Text.Html,
+          )
         }
 
         get("/render/{name}") {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeLiveSession.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeLiveSession.kt
@@ -18,7 +18,7 @@ import ee.schimke.composeai.daemon.protocol.StreamFrameParams
 class ServeLiveSession
 private constructor(
   private val renderHost: ServeRenderHost,
-  private val previewId: String,
+  private var previewId: String,
   private var overrides: Map<String, String>,
   private val codec: StreamCodec?,
   private val maxFps: Int?,
@@ -39,6 +39,7 @@ private constructor(
           }
         }
       is ServeStreamProtocol.ClientMessage.Input -> dispatchInput(message)
+      is ServeStreamProtocol.ClientMessage.Switch -> switchTo(message)
       // Frames are pushed by the daemon; an explicit refresh is a no-op on the live lane.
       ServeStreamProtocol.ClientMessage.RequestFrame -> Unit
       is ServeStreamProtocol.ClientMessage.Unsupported ->
@@ -71,11 +72,38 @@ private constructor(
   private fun restart(parsed: PreviewOverrides) {
     handle?.close()
     handle =
-      renderHost.startStream(previewId, parsed, codec, maxFps, ::onFrame)
+      renderHost.subscribeStream(previewId, parsed, codec, maxFps, ::onFrame)
         ?: run {
           send(ServeStreamProtocol.errorMessage("live stream ended"))
           null
         }
+  }
+
+  /**
+   * Move this connection to a different preview (optionally with new overrides) without
+   * reconnecting. The new stream is opened *before* the old one is dropped, so a switch to a
+   * missing preview (or a backend that can't stream it) reports an error and leaves the current
+   * view intact rather than going blank.
+   */
+  private fun switchTo(message: ServeStreamProtocol.ClientMessage.Switch) {
+    val nextOverrides = message.overrides ?: overrides
+    val parsed =
+      when (val p = ServeOverrides.parse(nextOverrides)) {
+        is OverrideParse.Invalid -> {
+          send(ServeStreamProtocol.errorMessage(p.message))
+          return
+        }
+        is OverrideParse.Ok -> p.overrides
+      }
+    val next = renderHost.subscribeStream(message.previewId, parsed, codec, maxFps, ::onFrame)
+    if (next == null) {
+      send(ServeStreamProtocol.errorMessage("cannot switch to preview: ${message.previewId}"))
+      return
+    }
+    handle?.close()
+    handle = next
+    previewId = message.previewId
+    overrides = nextOverrides
   }
 
   private fun onFrame(frame: StreamFrameParams) {
@@ -116,7 +144,8 @@ private constructor(
         (ServeOverrides.parse(overrides) as? OverrideParse.Ok)?.overrides ?: PreviewOverrides()
       val session = ServeLiveSession(renderHost, previewId, overrides, codec, maxFps, send)
       session.handle =
-        renderHost.startStream(previewId, initial, codec, maxFps, session::onFrame) ?: return null
+        renderHost.subscribeStream(previewId, initial, codec, maxFps, session::onFrame)
+          ?: return null
       return session
     }
   }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
@@ -115,6 +115,11 @@ internal constructor(
   // one outstanding event per timed-out render here before honouring a fresh one.
   private val staleRenders = ConcurrentHashMap<String, Int>()
 
+  // Fans one upstream daemon stream out to all watchers of the same preview/overrides/codec/fps, so
+  // many browsers cost one held session instead of one each. Built on [startStream]; shared because
+  // there's one host per server.
+  private val broadcast = ServeBroadcastHub(::startStream)
+
   private val closed = AtomicBoolean(false)
   private val notificationHandle: AutoCloseable = session.onNotification { method, params ->
     if (method != "renderFinished" || params == null) return@onNotification
@@ -314,6 +319,27 @@ internal constructor(
       }
     }
   }
+
+  /**
+   * Join the shared live stream for [previewId] (tier-2), opening one upstream daemon stream per
+   * distinct preview + overrides + codec + fps and fanning its frames out to every watcher. This is
+   * the multi-client front door to [startStream]: prefer it over [startStream] for client
+   * connections so N viewers of the same preview ride one held session. Returns `null` when
+   * streaming is unsupported (caller falls back to the snapshot lane).
+   */
+  fun subscribeStream(
+    previewId: String,
+    overrides: PreviewOverrides,
+    codec: StreamCodec? = null,
+    maxFps: Int? = null,
+    onFrame: (StreamFrameParams) -> Unit,
+  ): StreamHandle? {
+    check(!closed.get()) { "ServeRenderHost is closed" }
+    return broadcast.subscribe(previewId, overrides, codec, maxFps, onFrame)
+  }
+
+  /** Live shared upstream streams (one per distinct preview/overrides/codec/fps). Diagnostics. */
+  fun activeStreamCount(): Int = broadcast.activeStreamCount()
 
   override fun close() {
     if (!closed.compareAndSet(false, true)) return

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
@@ -82,6 +82,8 @@ class ServeRenderHost
 internal constructor(
   private val session: RenderSession,
   val previews: List<ServePreview>,
+  /** Human label for this tenant (e.g. the module's Gradle path); shown in the served pages. */
+  val label: String = "",
   private val fileSystem: FileSystem = SystemFileSystem,
   private val onLog: (String) -> Unit = {},
   private val renderTimeoutSeconds: Long = RENDER_TIMEOUT_SECONDS,
@@ -370,6 +372,7 @@ internal constructor(
       workspaceRoot: File,
       workspaceName: String,
       previews: List<ServePreview>,
+      label: String = "",
       onLog: (String) -> Unit = {},
       factory: RenderSessionFactory = SubprocessRenderSessions,
     ): ServeRenderHost {
@@ -382,7 +385,7 @@ internal constructor(
             logSink = onLog,
           )
         )
-      return ServeRenderHost(session = session, previews = previews, onLog = onLog)
+      return ServeRenderHost(session = session, previews = previews, label = label, onLog = onLog)
     }
   }
 }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistry.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistry.kt
@@ -1,0 +1,126 @@
+package ee.schimke.composeai.cli.serve
+
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+
+/**
+ * Builds (forks) a tenant's render host on demand. The fork — discover/build a module, launch a
+ * daemon, open a [ServeRenderHost] — happens behind this seam, so the registry and HTTP layer stay
+ * transport- and policy-agnostic and tests can inject a fake.
+ */
+fun interface ServeSessionFactory {
+  /** Open a render host for [sessionId], or return `null` when no such session can be created. */
+  fun create(sessionId: String): ServeRenderHost?
+}
+
+/**
+ * Multi-tenant registry of [ServeRenderHost]s behind **one** HTTP server, so a shared server fronts
+ * many sessions instead of spawning a server per module. Sessions are created lazily via [factory]
+ * (the fork-behind-the-API seam) on first use, cached by id, and idle-evicted: an unpinned host
+ * with no live streams that hasn't been touched within [idleTimeoutMillis] is closed and its daemon
+ * subprocess released.
+ *
+ * Pre-seeded sessions ([register]) — e.g. the CLI's primary module — are **pinned** and never
+ * evicted.
+ *
+ * Concurrency-safe: [acquire] forks at most once per id even under racing callers, and eviction
+ * never closes a host that still has watchers ([ServeRenderHost.activeStreamCount]).
+ */
+class ServeSessionRegistry(
+  private val factory: ServeSessionFactory = ServeSessionFactory { null },
+  private val idleTimeoutMillis: Long = DEFAULT_IDLE_TIMEOUT_MILLIS,
+  reaperIntervalMillis: Long = idleTimeoutMillis,
+  private val clock: () -> Long = System::currentTimeMillis,
+) : AutoCloseable {
+
+  private class Entry(
+    val host: ServeRenderHost,
+    val pinned: Boolean,
+    @Volatile var lastAccess: Long,
+  )
+
+  private val lock = ReentrantLock()
+  private val sessions = HashMap<String, Entry>()
+  private var closed = false
+
+  // A daemon reaper sweeps idle sessions. Disabled (null) when either knob is non-positive — tests
+  // drive eviction directly with a fake clock instead.
+  private val reaper: ScheduledExecutorService? =
+    if (idleTimeoutMillis > 0 && reaperIntervalMillis > 0) {
+      Executors.newSingleThreadScheduledExecutor { r ->
+          Thread(r, "serve-session-reaper").apply { isDaemon = true }
+        }
+        .also {
+          it.scheduleWithFixedDelay(
+            { runCatching { evictIdle() } },
+            reaperIntervalMillis,
+            reaperIntervalMillis,
+            TimeUnit.MILLISECONDS,
+          )
+        }
+    } else {
+      null
+    }
+
+  /**
+   * Pin an externally-opened [host] under [sessionId] (never evicted). Replaces any prior entry.
+   */
+  fun register(sessionId: String, host: ServeRenderHost) {
+    lock.withLock {
+      check(!closed) { "ServeSessionRegistry is closed" }
+      sessions[sessionId] = Entry(host, pinned = true, lastAccess = clock())
+    }
+  }
+
+  /**
+   * The host for [sessionId], forking one via [factory] on a miss. Returns `null` when the session
+   * doesn't exist and can't be created, so the caller can 404. Touches the session's idle clock.
+   */
+  fun acquire(sessionId: String): ServeRenderHost? = lock.withLock {
+    check(!closed) { "ServeSessionRegistry is closed" }
+    sessions[sessionId]?.let {
+      it.lastAccess = clock()
+      return it.host
+    }
+    // Hold the lock across the fork so racing first-callers for one id can't fork twice. A fork is
+    // slow, but a shared dev/CI server has few tenants and correctness beats fork concurrency.
+    val host = factory.create(sessionId) ?: return null
+    sessions[sessionId] = Entry(host, pinned = false, lastAccess = clock())
+    host
+  }
+
+  /** Close unpinned, watcher-free sessions idle past the timeout. Returns the count evicted. */
+  fun evictIdle(): Int = lock.withLock {
+    if (closed) return 0
+    val now = clock()
+    val dead = sessions.filterValues {
+      !it.pinned && it.host.activeStreamCount() == 0 && now - it.lastAccess >= idleTimeoutMillis
+    }
+    dead.forEach { (id, entry) ->
+      sessions.remove(id)
+      runCatching { entry.host.close() }
+    }
+    dead.size
+  }
+
+  /** Number of live sessions (pinned + forked). */
+  fun activeCount(): Int = lock.withLock { sessions.size }
+
+  override fun close() {
+    val toClose = lock.withLock {
+      if (closed) return
+      closed = true
+      sessions.values.toList().also { sessions.clear() }
+    }
+    reaper?.shutdownNow()
+    toClose.forEach { runCatching { it.host.close() } }
+  }
+
+  private companion object {
+    /** Default idle window before an unused forked session's daemon is released. */
+    const val DEFAULT_IDLE_TIMEOUT_MILLIS = 10 * 60 * 1000L
+  }
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistry.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistry.kt
@@ -3,6 +3,7 @@ package ee.schimke.composeai.cli.serve
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
 
@@ -40,7 +41,21 @@ class ServeSessionRegistry(
     val host: ServeRenderHost,
     val pinned: Boolean,
     @Volatile var lastAccess: Long,
+    /**
+     * Open long-lived holders (e.g. WebSocket connections) pinning this session against eviction.
+     */
+    @Volatile var leases: Int = 0,
   )
+
+  /** A live hold on a session that keeps it from being reaped until [close] (idempotent). */
+  class Lease internal constructor(val host: ServeRenderHost, private val onRelease: () -> Unit) :
+    AutoCloseable {
+    private val released = AtomicBoolean(false)
+
+    override fun close() {
+      if (released.compareAndSet(false, true)) onRelease()
+    }
+  }
 
   private val lock = ReentrantLock()
   private val sessions = HashMap<String, Entry>()
@@ -92,12 +107,38 @@ class ServeSessionRegistry(
     host
   }
 
+  /**
+   * Acquire [sessionId] (forking on a miss) and hold it open for the returned [Lease]'s lifetime,
+   * so a long-lived connection — including a WebSocket on the snapshot fallback lane that opens no
+   * `stream/start` — isn't reaped mid-connection. Returns `null` when the session can't be created;
+   * the holder must [Lease.close] when the connection ends.
+   */
+  fun lease(sessionId: String): Lease? = lock.withLock {
+    check(!closed) { "ServeSessionRegistry is closed" }
+    val entry =
+      sessions[sessionId]
+        ?: (factory.create(sessionId)?.let { host ->
+          Entry(host, pinned = false, lastAccess = clock()).also { sessions[sessionId] = it }
+        } ?: return null)
+    entry.lastAccess = clock()
+    entry.leases++
+    Lease(entry.host) {
+      lock.withLock {
+        entry.leases--
+        entry.lastAccess = clock() // start the idle clock fresh once the holder leaves
+      }
+    }
+  }
+
   /** Close unpinned, watcher-free sessions idle past the timeout. Returns the count evicted. */
   fun evictIdle(): Int = lock.withLock {
     if (closed) return 0
     val now = clock()
     val dead = sessions.filterValues {
-      !it.pinned && it.host.activeStreamCount() == 0 && now - it.lastAccess >= idleTimeoutMillis
+      !it.pinned &&
+        it.leases == 0 &&
+        it.host.activeStreamCount() == 0 &&
+        now - it.lastAccess >= idleTimeoutMillis
     }
     dead.forEach { (id, entry) ->
       sessions.remove(id)

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeStreamProtocol.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeStreamProtocol.kt
@@ -34,6 +34,13 @@ object ServeStreamProtocol {
     data object RequestFrame : ClientMessage
 
     /**
+     * Switch the connection to a different preview without reconnecting. [overrides] is optional —
+     * when omitted the current overrides carry over. Lets one socket walk a module's previews (the
+     * "switch previews" lane) instead of opening a new `/ws/{id}` per preview.
+     */
+    data class Switch(val previewId: String, val overrides: Map<String, String>?) : ClientMessage
+
+    /**
      * A user input event to dispatch into a live (daemon-streamed) composition. [kind] is the wire
      * spelling of an `InteractiveInputKind` (`click`, `pointerDown`, …); coordinates are
      * image-natural pixels. Ignored by the snapshot fallback lane (which can't accept input).
@@ -72,6 +79,16 @@ object ServeStreamProtocol {
           ClientMessage.SetOverrides(overrides.toMap())
         }
         "requestFrame" -> ClientMessage.RequestFrame
+        "switch" -> {
+          val previewId = (obj["previewId"] as? JsonPrimitive)?.contentOrNull
+          // An override block is optional; when present it follows the same shape as setOverrides.
+          val overrides =
+            (obj["overrides"] as? JsonObject)?.entries?.mapNotNull { (k, v) ->
+              (v as? JsonPrimitive)?.contentOrNull?.let { k to it }
+            }
+          if (previewId.isNullOrBlank()) ClientMessage.Unsupported("switch missing previewId")
+          else ClientMessage.Switch(previewId, overrides?.toMap())
+        }
         "input" ->
           ClientMessage.Input(
             kind = (obj["kind"] as? JsonPrimitive)?.contentOrNull ?: "",

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeStreamSession.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeStreamSession.kt
@@ -63,9 +63,21 @@ class ServeStreamSession(
       send(ServeStreamProtocol.errorMessage("cannot switch to preview: ${message.previewId}"))
       return
     }
+    // Validate before committing either field: a bad override must leave the current preview +
+    // overrides intact (so later requestFrame keeps working), mirroring setOverrides / the live
+    // lane.
+    val nextOverrides = message.overrides ?: overrides
+    val parsed =
+      when (val p = ServeOverrides.parse(nextOverrides)) {
+        is OverrideParse.Invalid -> {
+          send(ServeStreamProtocol.errorMessage(p.message))
+          return
+        }
+        is OverrideParse.Ok -> p.overrides
+      }
     previewId = message.previewId
-    message.overrides?.let { overrides = it }
-    renderCurrent()
+    overrides = nextOverrides
+    sendFrame(parsed)
   }
 
   private fun renderCurrent() {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeStreamSession.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeStreamSession.kt
@@ -19,10 +19,11 @@ import java.util.concurrent.atomic.AtomicLong
  */
 class ServeStreamSession(
   private val renderHost: ServeRenderHost,
-  private val previewId: String,
+  previewId: String,
   initialOverrides: Map<String, String> = emptyMap(),
   private val send: (String) -> Unit,
 ) {
+  private var previewId: String = previewId
   private var overrides: Map<String, String> = initialOverrides
   private val seq = AtomicLong(0)
 
@@ -43,6 +44,7 @@ class ServeStreamSession(
           }
         }
       ServeStreamProtocol.ClientMessage.RequestFrame -> renderCurrent()
+      is ServeStreamProtocol.ClientMessage.Switch -> switchTo(message)
       is ServeStreamProtocol.ClientMessage.Input ->
         // The snapshot fallback can't dispatch input into a live composition — only the daemon
         // stream lane ([ServeLiveSession]) can. Report it rather than silently dropping.
@@ -50,6 +52,20 @@ class ServeStreamSession(
       is ServeStreamProtocol.ClientMessage.Unsupported ->
         send(ServeStreamProtocol.errorMessage(message.reason))
     }
+  }
+
+  /**
+   * Switch this connection to another preview (optionally with new overrides) and re-render. An
+   * unknown preview is reported and the current one is kept, mirroring the live lane's behaviour.
+   */
+  private fun switchTo(message: ServeStreamProtocol.ClientMessage.Switch) {
+    if (renderHost.previews.none { it.id == message.previewId }) {
+      send(ServeStreamProtocol.errorMessage("cannot switch to preview: ${message.previewId}"))
+      return
+    }
+    previewId = message.previewId
+    message.overrides?.let { overrides = it }
+    renderCurrent()
   }
 
   private fun renderCurrent() {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -50,9 +50,24 @@ object ServeWeb {
     """
       .trimIndent()
 
+  /**
+   * Query string carrying the token and — only for a non-default tenant ([sessionId] non-null) —
+   * the `session` id, so generated links stay on the same tenant. A null [sessionId] (the default
+   * session) keeps URLs token-only.
+   */
+  private fun queryString(token: String, sessionId: String?): String {
+    val t = "token=" + WebEscaping.urlEncodeSegment(token)
+    return if (sessionId == null) t else t + "&session=" + WebEscaping.urlEncodeSegment(sessionId)
+  }
+
   /** Landing page: the module's preview list, each card linking to its viewer. */
-  fun landingPage(moduleLabel: String, previews: List<ServePreview>, token: String): String {
-    val tokenQ = WebEscaping.urlEncodeSegment(token)
+  fun landingPage(
+    moduleLabel: String,
+    previews: List<ServePreview>,
+    token: String,
+    sessionId: String? = null,
+  ): String {
+    val q = queryString(token, sessionId)
     val cards =
       if (previews.isEmpty()) {
         "<p class=\"cp-sub\">No previews discovered in this module.</p>"
@@ -62,9 +77,9 @@ object ServeWeb {
           val label = WebEscaping.htmlEscape(p.label)
           val idText = WebEscaping.htmlEscape(p.id)
           """
-          <a class="cp-card" href="/p/$idSeg?token=$tokenQ">
+          <a class="cp-card" href="/p/$idSeg?$q">
             <div class="cp-imgwrap">
-              <img loading="lazy" alt="$label" src="/render/$idSeg.png?token=$tokenQ">
+              <img loading="lazy" alt="$label" src="/render/$idSeg.png?$q">
             </div>
             <div class="cp-meta">
               <div class="cp-label" title="$idText">$label</div>
@@ -81,7 +96,7 @@ object ServeWeb {
         """
         <p class="cp-head">${WebEscaping.htmlEscape(moduleLabel)}</p>
         <p class="cp-sub">${previews.size} preview(s) · click one to view with overrides ·
-          <a href="/bundle.zip?token=$tokenQ">download all (.zip)</a></p>
+          <a href="/bundle.zip?$q">download all (.zip)</a></p>
         <div class="cp-grid">
         $cards
         </div>
@@ -91,9 +106,9 @@ object ServeWeb {
   }
 
   /** Viewer page for one preview: an `<img>` driven by the override controls. */
-  fun viewerPage(preview: ServePreview, token: String): String {
+  fun viewerPage(preview: ServePreview, token: String, sessionId: String? = null): String {
     val idSeg = WebEscaping.urlEncodeSegment(preview.id)
-    val tokenQ = WebEscaping.urlEncodeSegment(token)
+    val q = queryString(token, sessionId)
     val label = WebEscaping.htmlEscape(preview.label)
     val idText = WebEscaping.htmlEscape(preview.id)
     val modes = preview.modes.joinToString(",") { it.wire }
@@ -104,7 +119,7 @@ object ServeWeb {
       }
     val body =
       """
-      <p class="cp-head"><a href="/?token=$tokenQ">← previews</a></p>
+      <p class="cp-head"><a href="/?$q">← previews</a></p>
       <p class="cp-sub" title="$idText">$label</p>
       <div class="cp-viewer" data-preview-id="$idText" data-mode="snapshot" data-modes="$modes">
         <div class="cp-stage"><img id="cp-img" alt="$label"><canvas id="cp-canvas" hidden></canvas></div>
@@ -166,6 +181,8 @@ object ServeWeb {
       var live = document.getElementById("cp-live");
       var previewId = root.getAttribute("data-preview-id");
       var token = new URLSearchParams(location.search).get("token") || "";
+      // Carry the tenant through follow-up requests so a non-default ?session= stays on its module.
+      var session = new URLSearchParams(location.search).get("session") || "";
       // The selects + text input are opt-in (empty value = "use the preview's default"). The font
       // scale slider has no empty state, so it's gated separately: we only send fontScale once the
       // user moves it (fontScaleTouched), otherwise the slider's standing 1.0 would override a
@@ -188,6 +205,7 @@ object ServeWeb {
       function query() {
         var o = overrides();
         var q = "token=" + encodeURIComponent(token);
+        if (session) q += "&session=" + encodeURIComponent(session);
         Object.keys(o).forEach(function (k) { q += "&" + k + "=" + encodeURIComponent(o[k]); });
         return q;
       }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBroadcastHubTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBroadcastHubTest.kt
@@ -1,0 +1,172 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.daemon.protocol.InteractiveInputKind
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.daemon.protocol.StreamCodec
+import ee.schimke.composeai.daemon.protocol.StreamFrameParams
+import ee.schimke.composeai.daemon.protocol.UiMode
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class ServeBroadcastHubTest {
+
+  private fun frame(seq: Long, payload: String?): StreamFrameParams =
+    StreamFrameParams(
+      frameStreamId = "fs",
+      seq = seq,
+      ptsMillis = 0,
+      widthPx = 2,
+      heightPx = 2,
+      codec = StreamCodec.PNG,
+      payloadBase64 = payload,
+    )
+
+  /** A single upstream stream: the hub feeds [emit] back as frames; records input + close. */
+  private class FakeUpstream {
+    lateinit var emit: (StreamFrameParams) -> Unit
+    val inputs = CopyOnWriteArrayList<InteractiveInputKind>()
+    val closed = AtomicBoolean(false)
+    val handle =
+      object : StreamHandle {
+        override fun input(
+          kind: InteractiveInputKind,
+          pixelX: Int?,
+          pixelY: Int?,
+          pointerId: Int?,
+          scrollDeltaY: Float?,
+          keyCode: String?,
+        ) {
+          inputs.add(kind)
+        }
+
+        override fun close() {
+          closed.set(true)
+        }
+      }
+  }
+
+  /**
+   * A [StreamOpener] that hands out a fresh [FakeUpstream] per open (or `null` if not streamable).
+   */
+  private class FakeOpener(private val streamable: Boolean = true) : StreamOpener {
+    val opens = CopyOnWriteArrayList<FakeUpstream>()
+
+    override fun open(
+      previewId: String,
+      overrides: PreviewOverrides,
+      codec: StreamCodec?,
+      maxFps: Int?,
+      onFrame: (StreamFrameParams) -> Unit,
+    ): StreamHandle? {
+      if (!streamable) return null
+      val up = FakeUpstream()
+      up.emit = onFrame
+      opens.add(up)
+      return up.handle
+    }
+  }
+
+  @Test
+  fun `watchers of the same key share one upstream and both receive frames`() {
+    val opener = FakeOpener()
+    val hub = ServeBroadcastHub(opener)
+    val a = CopyOnWriteArrayList<Long>()
+    val b = CopyOnWriteArrayList<Long>()
+
+    assertNotNull(hub.subscribe("p", PreviewOverrides()) { a.add(it.seq) })
+    assertNotNull(hub.subscribe("p", PreviewOverrides()) { b.add(it.seq) })
+
+    assertEquals(1, opener.opens.size, "two watchers of one key open a single upstream")
+    assertEquals(1, hub.activeStreamCount())
+
+    opener.opens[0].emit(frame(7, "AA"))
+    assertEquals(listOf(7L), a)
+    assertEquals(listOf(7L), b)
+  }
+
+  @Test
+  fun `a late joiner is replayed the last painted frame`() {
+    val opener = FakeOpener()
+    val hub = ServeBroadcastHub(opener)
+    assertNotNull(hub.subscribe("p", PreviewOverrides()) {})
+    opener.opens[0].emit(frame(3, "AA"))
+
+    val late = CopyOnWriteArrayList<Long>()
+    assertNotNull(hub.subscribe("p", PreviewOverrides()) { late.add(it.seq) })
+    assertEquals(listOf(3L), late, "the newcomer should see the current picture immediately")
+  }
+
+  @Test
+  fun `payload-less heartbeats are not replayed to late joiners`() {
+    val opener = FakeOpener()
+    val hub = ServeBroadcastHub(opener)
+    assertNotNull(hub.subscribe("p", PreviewOverrides()) {})
+    opener.opens[0].emit(frame(1, null)) // unchanged heartbeat — nothing to paint
+
+    val late = CopyOnWriteArrayList<Long>()
+    assertNotNull(hub.subscribe("p", PreviewOverrides()) { late.add(it.seq) })
+    assertTrue(late.isEmpty())
+  }
+
+  @Test
+  fun `closing one of two watchers keeps the upstream, closing the last tears it down`() {
+    val opener = FakeOpener()
+    val hub = ServeBroadcastHub(opener)
+    val h1 = assertNotNull(hub.subscribe("p", PreviewOverrides()) {})
+    val h2 = assertNotNull(hub.subscribe("p", PreviewOverrides()) {})
+    val up = opener.opens[0]
+
+    h1.close()
+    assertFalse(up.closed.get(), "the shared upstream must stay open while a watcher remains")
+    assertEquals(1, hub.activeStreamCount())
+
+    h2.close()
+    assertTrue(up.closed.get(), "the last watcher out tears the upstream down")
+    assertEquals(0, hub.activeStreamCount())
+  }
+
+  @Test
+  fun `distinct overrides open distinct shared streams`() {
+    val opener = FakeOpener()
+    val hub = ServeBroadcastHub(opener)
+    assertNotNull(hub.subscribe("p", PreviewOverrides()) {})
+    assertNotNull(hub.subscribe("p", PreviewOverrides(uiMode = UiMode.DARK)) {})
+
+    assertEquals(2, opener.opens.size)
+    assertEquals(2, hub.activeStreamCount())
+  }
+
+  @Test
+  fun `input from a watcher reaches the shared upstream`() {
+    val opener = FakeOpener()
+    val hub = ServeBroadcastHub(opener)
+    val h = assertNotNull(hub.subscribe("p", PreviewOverrides()) {})
+
+    h.input(InteractiveInputKind.CLICK, pixelX = 1, pixelY = 2)
+    assertEquals(listOf(InteractiveInputKind.CLICK), opener.opens[0].inputs)
+  }
+
+  @Test
+  fun `subscribe returns null and opens nothing when the backend cannot stream`() {
+    val hub = ServeBroadcastHub(FakeOpener(streamable = false))
+    assertNull(hub.subscribe("p", PreviewOverrides()) {})
+    assertEquals(0, hub.activeStreamCount())
+  }
+
+  @Test
+  fun `after the last watcher leaves a new subscribe opens a fresh upstream`() {
+    val opener = FakeOpener()
+    val hub = ServeBroadcastHub(opener)
+    assertNotNull(hub.subscribe("p", PreviewOverrides()) {}).close()
+    assertNotNull(hub.subscribe("p", PreviewOverrides()) {})
+
+    assertEquals(2, opener.opens.size, "a new watcher after teardown opens a fresh upstream")
+    assertEquals(1, hub.activeStreamCount())
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeLiveSessionTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeLiveSessionTest.kt
@@ -164,6 +164,73 @@ class ServeLiveSessionTest {
   }
 
   @Test
+  fun `two live sessions for the same preview share one daemon stream`() {
+    val session = FakeRenderSession(newRenderRoot(), streaming = true)
+    host(session).use { h ->
+      val a = CopyOnWriteArrayList<String>()
+      val b = CopyOnWriteArrayList<String>()
+      assertNotNull(ServeLiveSession.tryStart(h, previewId, emptyMap(), send = a::add))
+      assertNotNull(ServeLiveSession.tryStart(h, previewId, emptyMap(), send = b::add))
+
+      assertEquals(1, session.streamStarts.get(), "two clients should ride one daemon stream/start")
+      assertEquals(1, h.activeStreamCount())
+
+      // One upstream frame fans out to both clients.
+      session.emitStreamFrame(
+        assertNotNull(session.lastFrameStreamId),
+        seq = 4,
+        payloadBase64 = "AA",
+      )
+      assertEquals(1, a.size)
+      assertEquals(1, b.size)
+    }
+  }
+
+  @Test
+  fun `switch moves the connection to another preview`() {
+    val session = FakeRenderSession(newRenderRoot(), streaming = true)
+    val blue = "com.example.Blue"
+    ServeRenderHost(
+        session,
+        listOf(ServePreview(previewId, "Red"), ServePreview(blue, "Blue")),
+        renderTimeoutSeconds = 30,
+      )
+      .use { h ->
+        val live = assertNotNull(ServeLiveSession.tryStart(h, previewId, emptyMap()) {})
+        val firstFsid = assertNotNull(session.lastFrameStreamId)
+        assertEquals(1, session.streamStarts.get())
+
+        live.onClientMessage("""{"type":"switch","previewId":"$blue"}""")
+
+        assertEquals(2, session.streamStarts.get(), "switch opens a stream for the new preview")
+        assertEquals(
+          listOf(firstFsid),
+          session.streamStops,
+          "the previous preview's stream is dropped",
+        )
+      }
+  }
+
+  @Test
+  fun `switching to an unknown preview errors and keeps the current stream`() {
+    val session = FakeRenderSession(newRenderRoot(), streaming = true)
+    host(session).use { h ->
+      val sent = CopyOnWriteArrayList<String>()
+      val live =
+        assertNotNull(ServeLiveSession.tryStart(h, previewId, emptyMap(), send = sent::add))
+      val fsid = assertNotNull(session.lastFrameStreamId)
+
+      live.onClientMessage("""{"type":"switch","previewId":"com.example.Missing"}""")
+
+      assertEquals("error", typeOf(sent.last()))
+      assertTrue(session.streamStops.isEmpty(), "a failed switch must not drop the working stream")
+      // The original stream is still live.
+      session.emitStreamFrame(fsid, seq = 1, payloadBase64 = "AA")
+      assertEquals("frame", typeOf(sent.last()))
+    }
+  }
+
+  @Test
   fun `closing the live session stops the stream`() {
     val session = FakeRenderSession(newRenderRoot(), streaming = true)
     host(session).use { h ->

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistryTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistryTest.kt
@@ -1,0 +1,133 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import java.io.File
+import java.util.concurrent.atomic.AtomicLong
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+class ServeSessionRegistryTest {
+
+  private val previewId = "com.example.Red"
+
+  private fun newRenderRoot(): File =
+    java.nio.file.Files.createTempDirectory("serve-registry").toFile().also { it.deleteOnExit() }
+
+  private fun newHost(streaming: Boolean = false): ServeRenderHost =
+    ServeRenderHost(
+      session = FakeRenderSession(newRenderRoot(), streaming = streaming),
+      previews = listOf(ServePreview(previewId, "Red")),
+      renderTimeoutSeconds = 30,
+    )
+
+  /** A factory that hands out a fresh host per id and records how many times it was called. */
+  private class CountingFactory : ServeSessionFactory {
+    var created = 0
+      private set
+
+    override fun create(sessionId: String): ServeRenderHost? {
+      if (sessionId == "missing") return null
+      created++
+      return ServeRenderHost(
+        session = FakeRenderSession(java.nio.file.Files.createTempDirectory("h").toFile()),
+        previews = listOf(ServePreview("com.example.Red", "Red")),
+        renderTimeoutSeconds = 30,
+      )
+    }
+  }
+
+  @Test
+  fun `acquire forks once per id and caches`() {
+    val factory = CountingFactory()
+    ServeSessionRegistry(factory, reaperIntervalMillis = 0).use { reg ->
+      val first = assertNotNull(reg.acquire("a"))
+      val second = assertNotNull(reg.acquire("a"))
+      assertSame(first, second, "the same id returns the cached host")
+      assertEquals(1, factory.created, "a cached id is not re-forked")
+      assertEquals(1, reg.activeCount())
+
+      reg.acquire("b")
+      assertEquals(2, factory.created, "a new id forks a new host")
+      assertEquals(2, reg.activeCount())
+    }
+  }
+
+  @Test
+  fun `acquire returns null when the factory cannot create the session`() {
+    ServeSessionRegistry(CountingFactory(), reaperIntervalMillis = 0).use { reg ->
+      assertNull(reg.acquire("missing"))
+      assertEquals(0, reg.activeCount())
+    }
+  }
+
+  @Test
+  fun `registered sessions are pinned and never evicted`() {
+    val clock = AtomicLong(0)
+    ServeSessionRegistry(idleTimeoutMillis = 100, reaperIntervalMillis = 0, clock = clock::get)
+      .use { reg ->
+        reg.register("primary", newHost())
+        clock.set(10_000) // well past the idle window
+        assertEquals(0, reg.evictIdle(), "a pinned session is never evicted")
+        assertEquals(1, reg.activeCount())
+      }
+  }
+
+  @Test
+  fun `idle forked sessions are evicted, fresh ones are kept`() {
+    val clock = AtomicLong(0)
+    val factory = CountingFactory()
+    ServeSessionRegistry(
+        factory,
+        idleTimeoutMillis = 100,
+        reaperIntervalMillis = 0,
+        clock = clock::get,
+      )
+      .use { reg ->
+        reg.acquire("old") // lastAccess = 0
+        clock.set(50)
+        reg.acquire("fresh") // lastAccess = 50
+        clock.set(120) // old idle 120ms (≥100 → evict); fresh idle 70ms (<100 → keep)
+        assertEquals(1, reg.evictIdle())
+        assertEquals(1, reg.activeCount())
+        assertNotNull(reg.acquire("fresh"))
+      }
+  }
+
+  @Test
+  fun `a session with live watchers is not evicted`() {
+    val clock = AtomicLong(0)
+    val streamingHost = newHost(streaming = true)
+    val factory = ServeSessionFactory { streamingHost }
+    ServeSessionRegistry(
+        factory,
+        idleTimeoutMillis = 100,
+        reaperIntervalMillis = 0,
+        clock = clock::get,
+      )
+      .use { reg ->
+        val host = assertNotNull(reg.acquire("s"))
+        // Open a live watcher: the host now reports an active stream.
+        val handle = assertNotNull(host.subscribeStream(previewId, PreviewOverrides()) {})
+        clock.set(10_000)
+        assertEquals(0, reg.evictIdle(), "a host with a live watcher must not be evicted")
+        handle.close()
+        assertEquals(1, reg.evictIdle(), "once the watcher leaves it can be evicted")
+      }
+  }
+
+  @Test
+  fun `close releases every host`() {
+    val factory = CountingFactory()
+    val reg = ServeSessionRegistry(factory, reaperIntervalMillis = 0)
+    reg.acquire("a")
+    reg.acquire("b")
+    assertEquals(2, reg.activeCount())
+    reg.close()
+    assertEquals(0, reg.activeCount())
+    assertTrue(runCatching { reg.acquire("c") }.isFailure, "a closed registry rejects acquire")
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistryTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistryTest.kt
@@ -120,6 +120,30 @@ class ServeSessionRegistryTest {
   }
 
   @Test
+  fun `a leased session is not evicted until the lease closes`() {
+    val clock = AtomicLong(0)
+    val factory = CountingFactory()
+    ServeSessionRegistry(
+        factory,
+        idleTimeoutMillis = 100,
+        reaperIntervalMillis = 0,
+        clock = clock::get,
+      )
+      .use { reg ->
+        val lease = assertNotNull(reg.lease("s"))
+        clock.set(10_000)
+        assertEquals(
+          0,
+          reg.evictIdle(),
+          "an open lease keeps the session alive past the idle window",
+        )
+        lease.close()
+        clock.set(10_200) // idle again past the window now that the holder is gone
+        assertEquals(1, reg.evictIdle(), "after the lease closes the idle session is reaped")
+      }
+  }
+
+  @Test
   fun `close releases every host`() {
     val factory = CountingFactory()
     val reg = ServeSessionRegistry(factory, reaperIntervalMillis = 0)

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeStreamProtocolTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeStreamProtocolTest.kt
@@ -69,6 +69,30 @@ class ServeStreamProtocolTest {
   }
 
   @Test
+  fun `parses switch with and without overrides`() {
+    val plain =
+      ServeStreamProtocol.parseClient("""{"type":"switch","previewId":"com.example.Blue"}""")
+    assertTrue(plain is ServeStreamProtocol.ClientMessage.Switch, "got $plain")
+    assertEquals("com.example.Blue", plain.previewId)
+    assertEquals(null, plain.overrides, "omitted overrides should carry the current ones over")
+
+    val withOverrides =
+      ServeStreamProtocol.parseClient(
+        """{"type":"switch","previewId":"com.example.Blue","overrides":{"uiMode":"dark"}}"""
+      )
+    assertTrue(withOverrides is ServeStreamProtocol.ClientMessage.Switch, "got $withOverrides")
+    assertEquals(mapOf("uiMode" to "dark"), withOverrides.overrides)
+  }
+
+  @Test
+  fun `switch without a previewId is Unsupported`() {
+    assertTrue(
+      ServeStreamProtocol.parseClient("""{"type":"switch"}""")
+        is ServeStreamProtocol.ClientMessage.Unsupported
+    )
+  }
+
+  @Test
   fun `unknown type and malformed json are Unsupported, never thrown`() {
     assertTrue(
       ServeStreamProtocol.parseClient("""{"type":"wat"}""")

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeStreamSessionTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeStreamSessionTest.kt
@@ -88,6 +88,37 @@ class ServeStreamSessionTest {
   }
 
   @Test
+  fun `switch re-renders a different preview on the snapshot lane`() {
+    val blue = "com.example.Blue"
+    ServeRenderHost(
+        session = FakeRenderSession(newRenderRoot()),
+        previews = listOf(ServePreview(previewId, "Red"), ServePreview(blue, "Blue")),
+        renderTimeoutSeconds = 30,
+      )
+      .use { h ->
+        val sent = CopyOnWriteArrayList<String>()
+        val session = ServeStreamSession(h, previewId, emptyMap(), sent::add)
+        session.onOpen()
+        session.onClientMessage("""{"type":"switch","previewId":"$blue"}""")
+        assertEquals(2, sent.size)
+        assertEquals("frame", typeOf(sent.last()))
+      }
+  }
+
+  @Test
+  fun `switch to an unknown preview errors and keeps the current one`() {
+    host().use { h ->
+      val sent = CopyOnWriteArrayList<String>()
+      val session = ServeStreamSession(h, previewId, emptyMap(), sent::add)
+      session.onOpen()
+      session.onClientMessage("""{"type":"switch","previewId":"com.example.Missing"}""")
+      assertEquals("error", typeOf(sent.last()))
+      session.onClientMessage("""{"type":"requestFrame"}""")
+      assertEquals("frame", typeOf(sent.last()))
+    }
+  }
+
+  @Test
   fun `unsupported message yields an error`() {
     host().use { h ->
       val sent = CopyOnWriteArrayList<String>()

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeStreamSessionTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeStreamSessionTest.kt
@@ -119,6 +119,22 @@ class ServeStreamSessionTest {
   }
 
   @Test
+  fun `switch with invalid overrides errors and keeps the working view`() {
+    host().use { h ->
+      val sent = CopyOnWriteArrayList<String>()
+      val session = ServeStreamSession(h, previewId, emptyMap(), sent::add)
+      session.onOpen()
+      session.onClientMessage(
+        """{"type":"switch","previewId":"$previewId","overrides":{"uiMode":"chartreuse"}}"""
+      )
+      assertEquals("error", typeOf(sent.last()))
+      // The bad override must not poison the session — the previous view still renders.
+      session.onClientMessage("""{"type":"requestFrame"}""")
+      assertEquals("frame", typeOf(sent.last()))
+    }
+  }
+
+  @Test
   fun `unsupported message yields an error`() {
     host().use { h ->
       val sent = CopyOnWriteArrayList<String>()

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
@@ -89,6 +89,8 @@ a:hover { text-decoration: underline; }
   var live = document.getElementById("cp-live");
   var previewId = root.getAttribute("data-preview-id");
   var token = new URLSearchParams(location.search).get("token") || "";
+  // Carry the tenant through follow-up requests so a non-default ?session= stays on its module.
+  var session = new URLSearchParams(location.search).get("session") || "";
   // The selects + text input are opt-in (empty value = "use the preview's default"). The font
   // scale slider has no empty state, so it's gated separately: we only send fontScale once the
   // user moves it (fontScaleTouched), otherwise the slider's standing 1.0 would override a
@@ -111,6 +113,7 @@ a:hover { text-decoration: underline; }
   function query() {
     var o = overrides();
     var q = "token=" + encodeURIComponent(token);
+    if (session) q += "&session=" + encodeURIComponent(session);
     Object.keys(o).forEach(function (k) { q += "&" + k + "=" + encodeURIComponent(o[k]); });
     return q;
   }


### PR DESCRIPTION
## Summary

Makes the `serve` live lane **multi-client and switchable**, so a single shared HTTP server handles many concurrent viewers cheaply — the concurrency primitive the shared-live-preview-server goal needs.

- **Shared broadcast (`ServeBroadcastHub`)** — fans **one** upstream daemon stream out to every watcher of the same preview + overrides + codec + fps. N browsers now ride a single held session (one `stream/start`) instead of one each. The upstream is opened lazily on the first watcher and **ref-counted** down to teardown when the last leaves, so an idle hub holds no daemon sessions. **Late joiners** are replayed the last *painted* frame so they see the current picture immediately instead of a blank canvas. Any watcher's input drives the shared composition.
- **`ServeRenderHost.subscribeStream`** is the multi-client front door to `startStream`; `ServeLiveSession` routes through it. One hub lives per host, so it composes cleanly under a future multi-tenant registry.
- **Preview switch (`switch` WS message)** — moves a connection to another preview without reconnecting (optional overrides carry over). The live lane opens the new stream **before** dropping the old, so a bad switch keeps the current view intact; the snapshot fallback lane re-renders the new preview. Unknown previews report an error and keep the current one.

Additive and non-breaking: distinct overrides/codec/fps remain distinct streams (a viewer changing theme transparently moves to its own shared lane), and single-watcher behavior is identical to the old per-connection `startStream`.

## Test plan
- `ktfmtFormatAll` clean; `:cli:compileKotlin` / `compileTestKotlin` green; `:cli:checkCliDaemonLibraryBoundary` green.
- Serve suite green (`./gradlew :cli:test --tests 'ee.schimke.composeai.cli.serve.*'`), with new coverage:
  - `ServeBroadcastHubTest` (8) — shared upstream + fan-out, late-joiner replay, heartbeat not replayed, ref-counted teardown, distinct-override isolation, input fan-in, no-stream fallback, fresh upstream after teardown.
  - `ServeLiveSessionTest` — two sessions share one daemon `stream/start`; switch moves preview; bad switch keeps the stream.
  - `ServeStreamSessionTest` — snapshot-lane switch re-renders; bad switch keeps current.
  - `ServeStreamProtocolTest` — `switch` parse (with/without overrides; missing id → Unsupported).

## Visual evidence
Non-visual change — transport/protocol only. The viewer's rendered output is unchanged (broadcast is invisible; `switch` is a new WS message with no markup change). The visual-diff bot re-renders the serve fixtures for the record. A browser preview-switch dropdown is a natural fast-follow.

---
_Generated by [Claude Code](https://claude.ai/code/session_0186JHWqw5dMvUJbfgDXgqGo)_