### PR TITLE
feat(cli): multi-tenant serve via a shared session registry

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -6,6 +6,7 @@ import ee.schimke.composeai.cli.serve.ServeHttpServer
 import ee.schimke.composeai.cli.serve.ServeMdnsAdvertiser
 import ee.schimke.composeai.cli.serve.ServePreview
 import ee.schimke.composeai.cli.serve.ServeRenderHost
+import ee.schimke.composeai.cli.serve.ServeSessionRegistry
 import ee.schimke.composeai.cli.serve.ServeUrls
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.render.session.RenderSessionException
@@ -91,6 +92,7 @@ class ServeCommand(args: List<String>) : Command(args) {
           workspaceRoot = module.projectDir,
           workspaceName = module.projectDir.name,
           previews = previews,
+          label = module.gradlePath,
           onLog = { System.err.println("[daemon serve] $it") },
         )
       } catch (e: RenderSessionException) {
@@ -108,13 +110,18 @@ class ServeCommand(args: List<String>) : Command(args) {
     }
 
     val token = tokenOverride ?: ServeUrls.generateToken()
+    // One shared server fronts a session registry rather than a single host: the current module is
+    // the pinned default session, and additional tenants (e.g. other modules / PR revisions) can be
+    // forked behind the registry's factory in future without spawning another server.
+    val registry = ServeSessionRegistry()
+    registry.register(module.gradlePath, renderHost)
     val server =
       ServeHttpServer(
         host = host,
         requestedPort = requestedPort,
         token = token,
-        renderHost = renderHost,
-        moduleLabel = module.gradlePath,
+        sessions = registry,
+        defaultSessionId = module.gradlePath,
       )
 
     // Advertise on the LAN over mDNS when bound to a reachable interface (`--lan`), so the mobile /
@@ -140,7 +147,7 @@ class ServeCommand(args: List<String>) : Command(args) {
           System.err.println("\nserve: shutting down…")
           runCatching { advertiser?.close() }
           runCatching { server.stop() }
-          runCatching { renderHost.close() }
+          runCatching { registry.close() }
           done.countDown()
         }
       )

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -27,15 +27,20 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 
 /**
- * The embedded Ktor (CIO) HTTP server fronting a [ServeRenderHost]. Thin IO shell: a token gate,
- * the five routes, and the query-param → [ServeOverrides] → render → PNG glue. All shared,
- * concurrency safe state lives in [ServeRenderHost]; this class adds none of its own per-request
- * state, so it serves any number of clients.
+ * The embedded Ktor (CIO) HTTP server fronting a [ServeSessionRegistry]. Thin IO shell: a token
+ * gate, the routes, and the query-param → [ServeOverrides] → render → PNG glue. All shared,
+ * concurrency-safe state lives in the per-tenant [ServeRenderHost]s; this class adds none of its
+ * own per-request state, so it serves any number of clients.
+ *
+ * **Multi-tenant:** one server fronts many sessions instead of one per module. Every route resolves
+ * a [ServeRenderHost] from the registry by the request's `?session=` (falling back to
+ * [defaultSessionId]); the registry forks the tenant behind its factory on first use. Unknown
+ * sessions 404 like a bad token.
  *
  * Endpoints (all token-gated except `/healthz`):
  * - `GET /` landing page, `GET /p/{id}` viewer page,
  * - `GET /render/{id}.png` PNG bytes, `GET /api/previews` JSON, `GET /healthz` liveness,
- * - `GET /bundle.zip` portable bundle, `WS /ws/{id}` streamed-frame lane (tier-2 spike).
+ * - `GET /bundle.zip` portable bundle, `WS /ws/{id}` streamed-frame lane.
  *
  * A bad/missing token returns **404** (not 401) so the server's existence isn't confirmed to a
  * scanner; the token is compared in constant time ([ServeUrls.tokensMatch]).
@@ -44,8 +49,8 @@ class ServeHttpServer(
   private val host: String,
   requestedPort: Int,
   private val token: String,
-  private val renderHost: ServeRenderHost,
-  private val moduleLabel: String,
+  private val sessions: ServeSessionRegistry,
+  private val defaultSessionId: String,
   portRange: Int = DEFAULT_PORT_RANGE,
 ) {
   /** The actual bound port — may differ from the requested one if it was taken (auto-picked). */
@@ -58,14 +63,19 @@ class ServeHttpServer(
         // `/healthz` is the only ungated route — liveness only, leaks nothing.
         get("/healthz") { call.respondText("ok") }
 
-        // Tier-2 streaming spike: a persistent frame lane. The browser opens this, receives PNG
-        // frames as JSON ([ServeStreamProtocol]), and sends override/refresh messages back; each
-        // drives a re-render through the shared [ServeRenderHost]. Token is checked post-handshake
-        // (can't 404 after upgrade) — a bad token closes immediately.
+        // A persistent frame lane. The browser opens this, receives frames as JSON
+        // ([ServeStreamProtocol]), and sends override / switch / input messages back. Token is
+        // checked post-handshake (can't 404 after upgrade) — a bad token closes immediately.
         webSocket("/ws/{name}") {
           val provided = call.request.queryParameters["token"] ?: call.request.headers[TOKEN_HEADER]
           if (!ServeUrls.tokensMatch(token, provided)) {
             close(CloseReason(CloseReason.Codes.VIOLATED_POLICY, "unauthorized"))
+            return@webSocket
+          }
+          val sessionId = call.request.queryParameters["session"] ?: defaultSessionId
+          val renderHost = withContext(Dispatchers.IO) { sessions.acquire(sessionId) }
+          if (renderHost == null) {
+            close(CloseReason(CloseReason.Codes.CANNOT_ACCEPT, "no such session"))
             return@webSocket
           }
           val previewId = call.parameters["name"]
@@ -129,17 +139,19 @@ class ServeHttpServer(
 
         get("/") {
           if (rejectBadToken()) return@get
+          val renderHost = resolveHost() ?: return@get
           call.respondText(
-            ServeWeb.landingPage(moduleLabel, renderHost.previews, token),
+            ServeWeb.landingPage(renderHost.label, renderHost.previews, token),
             ContentType.Text.Html,
           )
         }
 
         get("/api/previews") {
           if (rejectBadToken()) return@get
+          val renderHost = resolveHost() ?: return@get
           val dto =
             PreviewsResponse(
-              module = moduleLabel,
+              module = renderHost.label,
               previews =
                 renderHost.previews.map { p ->
                   PreviewDto(id = p.id, label = p.label, modes = p.modes.map { it.wire })
@@ -153,6 +165,7 @@ class ServeHttpServer(
 
         get("/bundle.zip") {
           if (rejectBadToken()) return@get
+          val renderHost = resolveHost() ?: return@get
           // Render the whole module once (cache-backed) into the portable WebEmbed gallery and
           // stream it as a zip — the same render output as the live links, downloadable offline.
           val zip =
@@ -160,8 +173,8 @@ class ServeHttpServer(
               val built =
                 ServeBundle.build(
                   previews = renderHost.previews,
-                  title = moduleLabel,
-                  modulePath = moduleLabel,
+                  title = renderHost.label,
+                  modulePath = renderHost.label,
                 ) { preview ->
                   (renderHost.render(preview.id, PreviewOverrides()) as? RenderOutcome.Ok)?.png
                 }
@@ -172,6 +185,7 @@ class ServeHttpServer(
 
         get("/p/{name}") {
           if (rejectBadToken()) return@get
+          val renderHost = resolveHost() ?: return@get
           val previewId = call.parameters["name"]
           val preview = previewId?.let { id -> renderHost.previews.firstOrNull { it.id == id } }
           if (preview == null) {
@@ -183,6 +197,7 @@ class ServeHttpServer(
 
         get("/render/{name}") {
           if (rejectBadToken()) return@get
+          val renderHost = resolveHost() ?: return@get
           val previewId = call.parameters["name"]?.removeSuffix(".png")
           if (previewId.isNullOrBlank()) {
             call.respondText("missing preview id", status = HttpStatusCode.BadRequest)
@@ -221,6 +236,18 @@ class ServeHttpServer(
   /** Stop with a short grace period. Idempotent enough for a shutdown hook. */
   fun stop() {
     server.stop(gracePeriodMillis = 500, timeoutMillis = 2000)
+  }
+
+  /**
+   * Resolve the tenant for this request: `?session=` (else [defaultSessionId]) through the
+   * registry, which forks it on first use. Responds 404 and returns null when the session can't be
+   * created.
+   */
+  private suspend fun RoutingContext.resolveHost(): ServeRenderHost? {
+    val sessionId = call.request.queryParameters["session"] ?: defaultSessionId
+    val renderHost = withContext(Dispatchers.IO) { sessions.acquire(sessionId) }
+    if (renderHost == null) call.respondText("not found", status = HttpStatusCode.NotFound)
+    return renderHost
   }
 
   /**

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
@@ -82,6 +82,8 @@ class ServeRenderHost
 internal constructor(
   private val session: RenderSession,
   val previews: List<ServePreview>,
+  /** Human label for this tenant (e.g. the module's Gradle path); shown in the served pages. */
+  val label: String = "",
   private val fileSystem: FileSystem = SystemFileSystem,
   private val onLog: (String) -> Unit = {},
   private val renderTimeoutSeconds: Long = RENDER_TIMEOUT_SECONDS,
@@ -370,6 +372,7 @@ internal constructor(
       workspaceRoot: File,
       workspaceName: String,
       previews: List<ServePreview>,
+      label: String = "",
       onLog: (String) -> Unit = {},
       factory: RenderSessionFactory = SubprocessRenderSessions,
     ): ServeRenderHost {
@@ -382,7 +385,7 @@ internal constructor(
             logSink = onLog,
           )
         )
-      return ServeRenderHost(session = session, previews = previews, onLog = onLog)
+      return ServeRenderHost(session = session, previews = previews, label = label, onLog = onLog)
     }
   }
 }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistry.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistry.kt
@@ -1,0 +1,126 @@
+package ee.schimke.composeai.cli.serve
+
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+
+/**
+ * Builds (forks) a tenant's render host on demand. The fork — discover/build a module, launch a
+ * daemon, open a [ServeRenderHost] — happens behind this seam, so the registry and HTTP layer stay
+ * transport- and policy-agnostic and tests can inject a fake.
+ */
+fun interface ServeSessionFactory {
+  /** Open a render host for [sessionId], or return `null` when no such session can be created. */
+  fun create(sessionId: String): ServeRenderHost?
+}
+
+/**
+ * Multi-tenant registry of [ServeRenderHost]s behind **one** HTTP server, so a shared server fronts
+ * many sessions instead of spawning a server per module. Sessions are created lazily via [factory]
+ * (the fork-behind-the-API seam) on first use, cached by id, and idle-evicted: an unpinned host
+ * with no live streams that hasn't been touched within [idleTimeoutMillis] is closed and its daemon
+ * subprocess released.
+ *
+ * Pre-seeded sessions ([register]) — e.g. the CLI's primary module — are **pinned** and never
+ * evicted.
+ *
+ * Concurrency-safe: [acquire] forks at most once per id even under racing callers, and eviction
+ * never closes a host that still has watchers ([ServeRenderHost.activeStreamCount]).
+ */
+class ServeSessionRegistry(
+  private val factory: ServeSessionFactory = ServeSessionFactory { null },
+  private val idleTimeoutMillis: Long = DEFAULT_IDLE_TIMEOUT_MILLIS,
+  reaperIntervalMillis: Long = idleTimeoutMillis,
+  private val clock: () -> Long = System::currentTimeMillis,
+) : AutoCloseable {
+
+  private class Entry(
+    val host: ServeRenderHost,
+    val pinned: Boolean,
+    @Volatile var lastAccess: Long,
+  )
+
+  private val lock = ReentrantLock()
+  private val sessions = HashMap<String, Entry>()
+  private var closed = false
+
+  // A daemon reaper sweeps idle sessions. Disabled (null) when either knob is non-positive — tests
+  // drive eviction directly with a fake clock instead.
+  private val reaper: ScheduledExecutorService? =
+    if (idleTimeoutMillis > 0 && reaperIntervalMillis > 0) {
+      Executors.newSingleThreadScheduledExecutor { r ->
+          Thread(r, "serve-session-reaper").apply { isDaemon = true }
+        }
+        .also {
+          it.scheduleWithFixedDelay(
+            { runCatching { evictIdle() } },
+            reaperIntervalMillis,
+            reaperIntervalMillis,
+            TimeUnit.MILLISECONDS,
+          )
+        }
+    } else {
+      null
+    }
+
+  /**
+   * Pin an externally-opened [host] under [sessionId] (never evicted). Replaces any prior entry.
+   */
+  fun register(sessionId: String, host: ServeRenderHost) {
+    lock.withLock {
+      check(!closed) { "ServeSessionRegistry is closed" }
+      sessions[sessionId] = Entry(host, pinned = true, lastAccess = clock())
+    }
+  }
+
+  /**
+   * The host for [sessionId], forking one via [factory] on a miss. Returns `null` when the session
+   * doesn't exist and can't be created, so the caller can 404. Touches the session's idle clock.
+   */
+  fun acquire(sessionId: String): ServeRenderHost? = lock.withLock {
+    check(!closed) { "ServeSessionRegistry is closed" }
+    sessions[sessionId]?.let {
+      it.lastAccess = clock()
+      return it.host
+    }
+    // Hold the lock across the fork so racing first-callers for one id can't fork twice. A fork is
+    // slow, but a shared dev/CI server has few tenants and correctness beats fork concurrency.
+    val host = factory.create(sessionId) ?: return null
+    sessions[sessionId] = Entry(host, pinned = false, lastAccess = clock())
+    host
+  }
+
+  /** Close unpinned, watcher-free sessions idle past the timeout. Returns the count evicted. */
+  fun evictIdle(): Int = lock.withLock {
+    if (closed) return 0
+    val now = clock()
+    val dead = sessions.filterValues {
+      !it.pinned && it.host.activeStreamCount() == 0 && now - it.lastAccess >= idleTimeoutMillis
+    }
+    dead.forEach { (id, entry) ->
+      sessions.remove(id)
+      runCatching { entry.host.close() }
+    }
+    dead.size
+  }
+
+  /** Number of live sessions (pinned + forked). */
+  fun activeCount(): Int = lock.withLock { sessions.size }
+
+  override fun close() {
+    val toClose = lock.withLock {
+      if (closed) return
+      closed = true
+      sessions.values.toList().also { sessions.clear() }
+    }
+    reaper?.shutdownNow()
+    toClose.forEach { runCatching { it.host.close() } }
+  }
+
+  private companion object {
+    /** Default idle window before an unused forked session's daemon is released. */
+    const val DEFAULT_IDLE_TIMEOUT_MILLIS = 10 * 60 * 1000L
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistryTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistryTest.kt
@@ -1,0 +1,133 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import java.io.File
+import java.util.concurrent.atomic.AtomicLong
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+class ServeSessionRegistryTest {
+
+  private val previewId = "com.example.Red"
+
+  private fun newRenderRoot(): File =
+    java.nio.file.Files.createTempDirectory("serve-registry").toFile().also { it.deleteOnExit() }
+
+  private fun newHost(streaming: Boolean = false): ServeRenderHost =
+    ServeRenderHost(
+      session = FakeRenderSession(newRenderRoot(), streaming = streaming),
+      previews = listOf(ServePreview(previewId, "Red")),
+      renderTimeoutSeconds = 30,
+    )
+
+  /** A factory that hands out a fresh host per id and records how many times it was called. */
+  private class CountingFactory : ServeSessionFactory {
+    var created = 0
+      private set
+
+    override fun create(sessionId: String): ServeRenderHost? {
+      if (sessionId == "missing") return null
+      created++
+      return ServeRenderHost(
+        session = FakeRenderSession(java.nio.file.Files.createTempDirectory("h").toFile()),
+        previews = listOf(ServePreview("com.example.Red", "Red")),
+        renderTimeoutSeconds = 30,
+      )
+    }
+  }
+
+  @Test
+  fun `acquire forks once per id and caches`() {
+    val factory = CountingFactory()
+    ServeSessionRegistry(factory, reaperIntervalMillis = 0).use { reg ->
+      val first = assertNotNull(reg.acquire("a"))
+      val second = assertNotNull(reg.acquire("a"))
+      assertSame(first, second, "the same id returns the cached host")
+      assertEquals(1, factory.created, "a cached id is not re-forked")
+      assertEquals(1, reg.activeCount())
+
+      reg.acquire("b")
+      assertEquals(2, factory.created, "a new id forks a new host")
+      assertEquals(2, reg.activeCount())
+    }
+  }
+
+  @Test
+  fun `acquire returns null when the factory cannot create the session`() {
+    ServeSessionRegistry(CountingFactory(), reaperIntervalMillis = 0).use { reg ->
+      assertNull(reg.acquire("missing"))
+      assertEquals(0, reg.activeCount())
+    }
+  }
+
+  @Test
+  fun `registered sessions are pinned and never evicted`() {
+    val clock = AtomicLong(0)
+    ServeSessionRegistry(idleTimeoutMillis = 100, reaperIntervalMillis = 0, clock = clock::get)
+      .use { reg ->
+        reg.register("primary", newHost())
+        clock.set(10_000) // well past the idle window
+        assertEquals(0, reg.evictIdle(), "a pinned session is never evicted")
+        assertEquals(1, reg.activeCount())
+      }
+  }
+
+  @Test
+  fun `idle forked sessions are evicted, fresh ones are kept`() {
+    val clock = AtomicLong(0)
+    val factory = CountingFactory()
+    ServeSessionRegistry(
+        factory,
+        idleTimeoutMillis = 100,
+        reaperIntervalMillis = 0,
+        clock = clock::get,
+      )
+      .use { reg ->
+        reg.acquire("old") // lastAccess = 0
+        clock.set(50)
+        reg.acquire("fresh") // lastAccess = 50
+        clock.set(120) // old idle 120ms (≥100 → evict); fresh idle 70ms (<100 → keep)
+        assertEquals(1, reg.evictIdle())
+        assertEquals(1, reg.activeCount())
+        assertNotNull(reg.acquire("fresh"))
+      }
+  }
+
+  @Test
+  fun `a session with live watchers is not evicted`() {
+    val clock = AtomicLong(0)
+    val streamingHost = newHost(streaming = true)
+    val factory = ServeSessionFactory { streamingHost }
+    ServeSessionRegistry(
+        factory,
+        idleTimeoutMillis = 100,
+        reaperIntervalMillis = 0,
+        clock = clock::get,
+      )
+      .use { reg ->
+        val host = assertNotNull(reg.acquire("s"))
+        // Open a live watcher: the host now reports an active stream.
+        val handle = assertNotNull(host.subscribeStream(previewId, PreviewOverrides()) {})
+        clock.set(10_000)
+        assertEquals(0, reg.evictIdle(), "a host with a live watcher must not be evicted")
+        handle.close()
+        assertEquals(1, reg.evictIdle(), "once the watcher leaves it can be evicted")
+      }
+  }
+
+  @Test
+  fun `close releases every host`() {
+    val factory = CountingFactory()
+    val reg = ServeSessionRegistry(factory, reaperIntervalMillis = 0)
+    reg.acquire("a")
+    reg.acquire("b")
+    assertEquals(2, reg.activeCount())
+    reg.close()
+    assertEquals(0, reg.activeCount())
+    assertTrue(runCatching { reg.acquire("c") }.isFailure, "a closed registry rejects acquire")
+  }
+}


### PR DESCRIPTION
## Summary

Stacked on #2010. Makes the `serve` HTTP server **multi-tenant**: one shared, concurrent server fronts a **session registry** instead of binding to a single render host, so we don't spawn a server per module — and when we need to fork a session, it happens behind the registry's factory seam.

- **`ServeSessionRegistry`** holds `ServeRenderHost`s keyed by session id. Sessions are created **lazily via a `ServeSessionFactory`** (the fork-behind-the-API seam) on first use and cached. Unpinned, watcher-free sessions idle past a timeout are **evicted** (their daemon subprocess released) by a background reaper; **registered** (CLI primary) sessions are **pinned** and never evicted. Concurrency-safe: at most one fork per id under racing callers, and a host with live streams (`activeStreamCount() > 0`) is never reaped.
- **`ServeHttpServer`** resolves a tenant per request from `?session=` (falling back to the default session) through the registry; unknown sessions 404 like a bad token. Each `ServeRenderHost` now carries its own `label`, so the served pages describe their tenant rather than a single server-wide module name.
- **`ServeCommand`** registers the current module as the **pinned default session** and closes the registry (all hosts) on shutdown.

Additive / non-breaking: with no `?session=` every route targets the default session, so existing single-module behaviour is unchanged. The production fork factory — e.g. resolving a PR revision (`?rev=<sha>`) or another module to a session — plugs into the same `ServeSessionFactory` seam as a follow-up, without spawning another server.

## Test plan
- `ktfmtFormatAll` clean; `:cli:compileKotlin` / `compileTestKotlin` green; `:cli:checkCliDaemonLibraryBoundary` green.
- Serve suite green (`./gradlew :cli:test --tests 'ee.schimke.composeai.cli.serve.*'`), with new `ServeSessionRegistryTest` (6): fork-once-per-id + cache, null when the factory can't create, pinned sessions never evicted, idle forked sessions evicted while fresh ones are kept, a host with a live watcher is not evicted (then is once the watcher leaves), and `close()` releases every host + rejects further `acquire`.

## Visual evidence
Non-visual change — server wiring + lifecycle only. The served pages are unchanged (the default session renders exactly as before; the only page-level change is that the tenant label now comes from the host). The visual-diff bot re-renders the serve fixtures for the record.

---
_Generated by [Claude Code](https://claude.ai/code/session_0186JHWqw5dMvUJbfgDXgqGo)_