### PR TITLE
feat(vscode): read configured variant/enabled from the applied marker

### DIFF
--- a/vscode-extension/src/gradleService.ts
+++ b/vscode-extension/src/gradleService.ts
@@ -165,6 +165,15 @@ export interface ModuleInfo {
      *  `:samples:wear`). Used as the prefix for every gradle task name and
      *  as the cache / lookup key. */
     readonly modulePath: string;
+    /** Configured `composePreview.variant` recorded in the module's
+     *  `applied.json` marker, when present. Lets module-aware UI show the
+     *  committed render intent without querying the Tooling model. `undefined`
+     *  for modules discovered via the build-script scan fallback (no marker
+     *  yet) or markers written before the field existed. */
+    readonly variant?: string;
+    /** Configured `composePreview.enabled` recorded in the marker, when
+     *  present. Same provenance/caveats as [variant]. */
+    readonly enabled?: boolean;
 }
 
 /** Synthesises a Gradle project path from a workspace-relative directory.
@@ -179,13 +188,19 @@ const APPLIED_MARKER_SCHEMA = "compose-preview-applied/v1";
 interface AppliedMarker {
     readonly schema: string;
     readonly modulePath: string;
+    /** Configured `composePreview.variant`. Optional: markers written before
+     *  the field existed omit it, so readers must tolerate its absence. */
+    readonly variant?: string;
+    /** Configured `composePreview.enabled`. Optional, same as [variant]. */
+    readonly enabled?: boolean;
 }
 
 /**
  * Reads a `build/compose-previews/applied.json` marker and returns the
- * canonical `modulePath` recorded there, or `null` if the file is missing,
- * malformed, or has an unrecognised schema. Callers fall back to the
- * projectDir-derived path on `null`.
+ * canonical `modulePath` recorded there (plus the configured `variant` /
+ * `enabled` intent when present), or `null` if the file is missing, malformed,
+ * or has an unrecognised schema. Callers fall back to the projectDir-derived
+ * path on `null`.
  */
 function readAppliedMarker(file: string): AppliedMarker | null {
     let raw: string;
@@ -201,7 +216,18 @@ function readAppliedMarker(file: string): AppliedMarker | null {
             typeof parsed.modulePath === "string" &&
             parsed.modulePath.startsWith(":")
         ) {
-            return { schema: parsed.schema, modulePath: parsed.modulePath };
+            return {
+                schema: parsed.schema,
+                modulePath: parsed.modulePath,
+                variant:
+                    typeof parsed.variant === "string"
+                        ? parsed.variant
+                        : undefined,
+                enabled:
+                    typeof parsed.enabled === "boolean"
+                        ? parsed.enabled
+                        : undefined,
+            };
         }
     } catch {
         /* fall through */
@@ -1080,12 +1106,33 @@ export class GradleService {
                 let recorded = false;
                 if (fs.existsSync(marker)) {
                     const parsed = readAppliedMarker(marker);
+                    const modulePath =
+                        parsed?.modulePath ??
+                        modulePathFromProjectDir(childRel);
+                    // Only attach variant/enabled when the marker actually
+                    // carries them — an `undefined`-valued key is still an own
+                    // property, which would change the shape callers (and
+                    // tests) compare against for markerless / legacy modules.
                     found.set(childRel, {
                         projectDir: childRel,
-                        modulePath:
-                            parsed?.modulePath ??
-                            modulePathFromProjectDir(childRel),
+                        modulePath,
+                        ...(parsed?.variant !== undefined
+                            ? { variant: parsed.variant }
+                            : {}),
+                        ...(parsed?.enabled !== undefined
+                            ? { enabled: parsed.enabled }
+                            : {}),
                     });
+                    // Surface a committed non-default render intent in the
+                    // output channel — the marker is the only runtime-free
+                    // record of it (the config-only plugin registers no Tooling
+                    // model). Skipped for the `debug` default so typical setups
+                    // stay quiet.
+                    if (parsed?.variant && parsed.variant !== "debug") {
+                        this.logger.appendLine(
+                            `compose-preview: ${modulePath} configured for variant '${parsed.variant}'`,
+                        );
+                    }
                     recorded = true;
                 }
                 if (!recorded) {

--- a/vscode-extension/src/test/gradleService.test.ts
+++ b/vscode-extension/src/test/gradleService.test.ts
@@ -500,6 +500,72 @@ describe("GradleService", () => {
         );
 
         it(
+            "surfaces configured variant and enabled from the marker",
+            withTempDir((dir, api) => {
+                fs.mkdirSync(path.join(dir, "app"));
+                fs.writeFileSync(
+                    path.join(dir, "app", "build.gradle.kts"),
+                    'plugins { id("my-convention-plugin") }',
+                );
+                const markerDir = path.join(
+                    dir,
+                    "app",
+                    "build",
+                    "compose-previews",
+                );
+                fs.mkdirSync(markerDir, { recursive: true });
+                fs.writeFileSync(
+                    path.join(markerDir, "applied.json"),
+                    '{"schema":"compose-preview-applied/v1","modulePath":":app","moduleName":"app","pluginVersion":"0.7.2","variant":"demoRelease","enabled":false}',
+                );
+
+                const service = new GradleService(dir, api);
+                assert.deepStrictEqual(service.findPreviewModules(), [
+                    {
+                        projectDir: "app",
+                        modulePath: ":app",
+                        variant: "demoRelease",
+                        enabled: false,
+                    },
+                ]);
+            }),
+        );
+
+        it(
+            "omits variant/enabled when the marker does not carry them",
+            withTempDir((dir, api) => {
+                // A marker written before the fields existed: the shape must
+                // stay exactly { projectDir, modulePath } so callers comparing
+                // module identity aren't disturbed.
+                fs.mkdirSync(path.join(dir, "legacy"));
+                fs.writeFileSync(
+                    path.join(dir, "legacy", "build.gradle.kts"),
+                    'plugins { id("my-convention-plugin") }',
+                );
+                const markerDir = path.join(
+                    dir,
+                    "legacy",
+                    "build",
+                    "compose-previews",
+                );
+                fs.mkdirSync(markerDir, { recursive: true });
+                fs.writeFileSync(
+                    path.join(markerDir, "applied.json"),
+                    '{"schema":"compose-preview-applied/v1","modulePath":":legacy","moduleName":"legacy","pluginVersion":"0.7.2"}',
+                );
+
+                const service = new GradleService(dir, api);
+                const [info] = service.findPreviewModules();
+                assert.deepStrictEqual(info, {
+                    projectDir: "legacy",
+                    modulePath: ":legacy",
+                });
+                assert.ok(!("variant" in info));
+                assert.ok(!("enabled" in info));
+            }),
+        );
+
+        it(
             "unions marker-detected and scan-detected modules",
             withTempDir((dir, api) => {
                 fs.mkdirSync(path.join(dir, "app"));


### PR DESCRIPTION
## Summary

Consumer side of the marker intent landed in #2001: the `composePreviewApplied` marker now records the configured `composePreview { variant; enabled }`, and this teaches the VS Code extension to read it.

- `readAppliedMarker` parses `variant` / `enabled` (optional — markers written before the fields existed omit them, so absence is tolerated).
- `ModuleInfo` gains optional `variant` / `enabled`, populated from the marker in `findPreviewModules`. The fields are attached **only when present**, so the object shape for markerless / legacy / scan-detected modules is unchanged (callers comparing module identity, and existing `deepStrictEqual` tests, aren't disturbed).
- A committed **non-default** variant is logged to the "Compose Preview" output channel at discovery — the marker is the only runtime-free record of it (the config-only plugin registers no Tooling model). The `debug` default stays quiet.

This completes the producer→consumer loop for the marker intent: the extension's module model now carries the configured variant, ready for richer in-UI display as a follow-up.

### Scope note
This extension is webview-based — there's no module *tree* to annotate — so the change is **data plumbing into `ModuleInfo` + an output-channel log line** (a text surface). No webview / preview / rendered surface changes, so there's nothing visual to capture here. A richer in-UI display (e.g. a webview chip showing the configured variant) is a natural fast-follow now that the model carries the data.

## Test plan

- `npm test` (tsc compile + mocha) → **1578 passing** (1576 baseline + 2 new):
  - a marker with `variant` / `enabled` surfaces them on `ModuleInfo`;
  - a legacy marker without the fields yields exactly `{ projectDir, modulePath }` (no `variant` / `enabled` keys), guarding the unchanged shape.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EZERsJRAD5Pvjgpjr83CX6)_