### PR TITLE
feat(cli): suspend/resume serve sessions instead of running daemons forever

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -721,7 +721,7 @@ abstract class Command(
     }
   }
 
-  private fun findProjectRoot(): File? {
+  protected fun findProjectRoot(): File? {
     var dir: File? = File(".").absoluteFile
     while (dir != null) {
       if (File(dir, "gradlew").exists()) return dir

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -7,6 +7,7 @@ import ee.schimke.composeai.cli.serve.ServeMdnsAdvertiser
 import ee.schimke.composeai.cli.serve.ServePreview
 import ee.schimke.composeai.cli.serve.ServeRenderHost
 import ee.schimke.composeai.cli.serve.ServeSessionRegistry
+import ee.schimke.composeai.cli.serve.ServeSessionState
 import ee.schimke.composeai.cli.serve.ServeUrls
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.render.session.RenderSessionException
@@ -110,11 +111,33 @@ class ServeCommand(args: List<String>) : Command(args) {
     }
 
     val token = tokenOverride ?: ServeUrls.generateToken()
-    // One shared server fronts a session registry rather than a single host: the current module is
-    // the pinned default session, and additional tenants (e.g. other modules / PR revisions) can be
-    // forked behind the registry's factory in future without spawning another server.
-    val registry = ServeSessionRegistry()
-    registry.register(module.gradlePath, renderHost)
+    // One shared server fronts a session registry rather than a single host. The current checkout
+    // is
+    // the default session; the registry suspends idle daemons and resumes them on demand from their
+    // saved state, so a long-lived server doesn't keep daemons running forever.
+    val openHost: (ServeSessionState) -> ServeRenderHost? = { state ->
+      runCatching {
+          ServeRenderHost.open(
+            descriptorPath = state.descriptor,
+            workspaceRoot = state.workspaceRoot,
+            workspaceName = state.workspaceName,
+            previews = state.previews,
+            label = state.label,
+            onLog = { System.err.println("[daemon serve] $it") },
+          )
+        }
+        .getOrNull()
+    }
+    val registry = ServeSessionRegistry(open = openHost)
+    val defaultState =
+      ServeSessionState(
+        descriptor = descriptor,
+        workspaceRoot = module.projectDir,
+        workspaceName = module.projectDir.name,
+        previews = previews,
+        label = module.gradlePath,
+      )
+    registry.register(module.gradlePath, defaultState, host = renderHost)
     val server =
       ServeHttpServer(
         host = host,

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -1,11 +1,16 @@
 package ee.schimke.composeai.cli
 
+import ee.schimke.composeai.cli.serve.GitWorktrees
+import ee.schimke.composeai.cli.serve.GradleRevisionBuilder
 import ee.schimke.composeai.cli.serve.RenderOutcome
 import ee.schimke.composeai.cli.serve.ServeBundle
 import ee.schimke.composeai.cli.serve.ServeHttpServer
 import ee.schimke.composeai.cli.serve.ServeMdnsAdvertiser
+import ee.schimke.composeai.cli.serve.ServeModuleRef
 import ee.schimke.composeai.cli.serve.ServePreview
 import ee.schimke.composeai.cli.serve.ServeRenderHost
+import ee.schimke.composeai.cli.serve.ServeRevisionFactory
+import ee.schimke.composeai.cli.serve.ServeSessionFactory
 import ee.schimke.composeai.cli.serve.ServeSessionRegistry
 import ee.schimke.composeai.cli.serve.ServeSessionState
 import ee.schimke.composeai.cli.serve.ServeUrls
@@ -39,6 +44,13 @@ class ServeCommand(args: List<String>) : Command(args) {
   private val tokenOverride: String? = args.flagValue("--token")?.takeIf { it.isNotBlank() }
   private val exportPath: String? = args.flagValue("--export")?.takeIf { it.isNotBlank() }
   private val inlineBundle: Boolean = "--inline" in args
+
+  /**
+   * Project mode: besides the current checkout (the default session), fork a daemon-backed session
+   * per git revision requested via `?session=<rev>`, each built in its own worktree and suspended /
+   * resumed by the registry. Off by default (just the current module).
+   */
+  private val revisions: Boolean = "--revisions" in args
 
   override fun run() {
     if ("--help" in args || "-h" in args) {
@@ -128,7 +140,12 @@ class ServeCommand(args: List<String>) : Command(args) {
         }
         .getOrNull()
     }
-    val registry = ServeSessionRegistry(open = openHost)
+    // Project mode forks a session per git revision behind the registry's factory; off by default
+    // the factory yields nothing, so only the pinned current checkout is served.
+    val worktrees: GitWorktrees? = if (revisions) openWorktrees(module) else null
+    val factory =
+      if (worktrees != null) revisionFactory(module, worktrees) else ServeSessionFactory { null }
+    val registry = ServeSessionRegistry(open = openHost, factory = factory)
     val defaultState =
       ServeSessionState(
         descriptor = descriptor,
@@ -171,6 +188,7 @@ class ServeCommand(args: List<String>) : Command(args) {
           runCatching { advertiser?.close() }
           runCatching { server.stop() }
           runCatching { registry.close() }
+          runCatching { worktrees?.close() }
           done.countDown()
         }
       )
@@ -178,6 +196,45 @@ class ServeCommand(args: List<String>) : Command(args) {
     server.start()
     printBanner(module.gradlePath, server.port, token, previews.size)
     done.await()
+  }
+
+  /** Open the worktree manager rooted at the repo (project mode). */
+  private fun openWorktrees(module: PreviewModule): GitWorktrees {
+    val repoRoot =
+      findProjectRoot() ?: module.projectDir.absoluteFile.parentFile ?: module.projectDir
+    return GitWorktrees(
+      repoRoot = repoRoot,
+      cacheRoot = File(repoRoot, "build/serve-worktrees"),
+      onLog = { System.err.println("[serve worktree] $it") },
+    )
+  }
+
+  /** The project-mode factory: a git revision (`?session=<rev>`) → a built [ServeSessionState]. */
+  private fun revisionFactory(
+    module: PreviewModule,
+    worktrees: GitWorktrees,
+  ): ServeRevisionFactory {
+    val repoRoot =
+      findProjectRoot() ?: module.projectDir.absoluteFile.parentFile ?: module.projectDir
+    val relativePath =
+      module.projectDir.absoluteFile.relativeToOrNull(repoRoot.absoluteFile)?.path ?: ""
+    // Match the bootstrap args the normal build path (Command.withGradle) applies, so a worktree
+    // build sees the auto-injected plugin and the right variant — otherwise composePreviewDiscover
+    // can run without the plugin/tasks or against the wrong variant and every ?session=<rev> fails.
+    val bootstrapArgs =
+      autoInjectInitScriptArgs(args, projectRoot = repoRoot) +
+        variantGradleArgs() +
+        gradleArgsWithForce()
+    return ServeRevisionFactory(
+      worktrees = worktrees,
+      builder =
+        GradleRevisionBuilder(
+          extraArgs = bootstrapArgs,
+          onLog = { System.err.println("[serve build] $it") },
+        ),
+      module = ServeModuleRef(module.gradlePath, relativePath),
+      onLog = { System.err.println("[serve] $it") },
+    )
   }
 
   /**
@@ -294,6 +351,9 @@ class ServeCommand(args: List<String>) : Command(args) {
                           GET /bundle.zip.
         --inline          With --export, bake the PNGs into the gallery for a single self-contained
                           index.html (vs. separate previews/<id>.png files).
+        --revisions       Project mode: also serve other git revisions of this repo on demand. A
+                          request with ?session=<rev> checks that revision out into a worktree,
+                          builds it, and serves it as its own session (suspended/resumed when idle).
 
       The shareable link carries an unguessable token; requests without it get 404.
       """

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/GitWorktrees.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/GitWorktrees.kt
@@ -1,0 +1,100 @@
+package ee.schimke.composeai.cli.serve
+
+import java.io.File
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+
+/**
+ * Runs a `git` subcommand in [workdir]. Injected so [GitWorktrees] is testable without a real repo.
+ */
+fun interface GitRunner {
+  fun run(workdir: File, args: List<String>): GitResult
+}
+
+data class GitResult(val exitCode: Int, val stdout: String) {
+  val ok: Boolean
+    get() = exitCode == 0
+}
+
+/**
+ * Manages git **worktrees** for serving multiple revisions of one repo from a single server. Each
+ * resolved commit gets one detached worktree under [cacheRoot] (`<cacheRoot>/<sha>`), reused on
+ * later requests — so a revision is checked out at most once. Resolution + add are serialised so
+ * two concurrent first-requests for the same revision don't race to add the same worktree.
+ *
+ * Worktrees share the repo's object store, so they're cheap; they outlive the [ServeRenderHost]s
+ * built from them (the registry evicts hosts, not checkouts) and are cleaned up on [close] / `git
+ * worktree prune`.
+ */
+class GitWorktrees(
+  private val repoRoot: File,
+  private val cacheRoot: File,
+  private val git: GitRunner = RealGitRunner,
+  private val onLog: (String) -> Unit = {},
+) : AutoCloseable {
+
+  private val lock = ReentrantLock()
+  private val prepared = HashSet<File>()
+
+  /**
+   * Resolve [rev] to a commit and ensure a worktree for it exists; returns the worktree directory,
+   * or `null` when the revision can't be resolved or the worktree can't be created.
+   */
+  fun prepare(rev: String): File? = lock.withLock {
+    val sha = resolve(rev) ?: return null
+    val dir = File(cacheRoot, sha)
+    // A `.git` file/dir in the worktree means it's already a valid checkout — reuse it.
+    if (File(dir, ".git").exists()) {
+      prepared.add(dir)
+      return dir
+    }
+    cacheRoot.mkdirs()
+    val add =
+      git.run(repoRoot, listOf("worktree", "add", "--detach", "--force", dir.absolutePath, sha))
+    if (!add.ok) {
+      onLog("serve: 'git worktree add' failed for $sha")
+      return null
+    }
+    prepared.add(dir)
+    dir
+  }
+
+  /** Resolve [rev] to a full commit sha, or null when it isn't a valid revision. */
+  private fun resolve(rev: String): String? {
+    val res = git.run(repoRoot, listOf("rev-parse", "--verify", "--quiet", "$rev^{commit}"))
+    val sha = res.stdout.trim()
+    return if (res.ok && sha.isNotEmpty()) sha else null
+  }
+
+  /** Remove the worktrees this instance created and prune stale registrations. Best-effort. */
+  override fun close() {
+    val dirs = lock.withLock { prepared.toList().also { prepared.clear() } }
+    dirs.forEach { dir ->
+      runCatching { git.run(repoRoot, listOf("worktree", "remove", "--force", dir.absolutePath)) }
+    }
+    runCatching { git.run(repoRoot, listOf("worktree", "prune")) }
+  }
+
+  /** Default [GitRunner] backed by the `git` CLI. */
+  object RealGitRunner : GitRunner {
+    override fun run(workdir: File, args: List<String>): GitResult {
+      return try {
+        val process =
+          ProcessBuilder(listOf("git") + args).directory(workdir).redirectErrorStream(true).start()
+        val output = process.inputStream.bufferedReader().readText()
+        val finished = process.waitFor(GIT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        if (!finished) {
+          process.destroyForcibly()
+          GitResult(exitCode = -1, stdout = output)
+        } else {
+          GitResult(exitCode = process.exitValue(), stdout = output)
+        }
+      } catch (e: Exception) {
+        GitResult(exitCode = -1, stdout = e.message ?: "")
+      }
+    }
+
+    private const val GIT_TIMEOUT_SECONDS = 120L
+  }
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/GradleRevisionBuilder.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/GradleRevisionBuilder.kt
@@ -1,0 +1,87 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.cli.PreviewModule
+import ee.schimke.composeai.cli.PreviewResultBuilder
+import java.io.File
+import java.util.concurrent.TimeUnit
+
+/**
+ * Production [RevisionBuilder]: runs the checkout's own Gradle wrapper to discover previews and
+ * start the daemon for one module, then reads the resulting `daemon-launch.json` + `previews.json`.
+ *
+ * Each worktree is a full checkout, so its `./gradlew` builds that revision in isolation; the
+ * daemon renders on demand from the descriptor, so we only need discovery (for the preview menu) +
+ * daemon start (for the descriptor) here, not a full render.
+ */
+class GradleRevisionBuilder(
+  private val extraArgs: List<String> = emptyList(),
+  private val timeoutSeconds: Long = DEFAULT_TIMEOUT_SECONDS,
+  private val onLog: (String) -> Unit = {},
+) : RevisionBuilder {
+
+  override fun build(worktreeDir: File, module: ServeModuleRef): BuiltRevision? {
+    val moduleDir = File(worktreeDir, module.relativePath)
+    val gradlew = File(worktreeDir, "gradlew")
+    if (!gradlew.canExecute()) {
+      onLog("serve: no executable gradlew in ${worktreeDir.absolutePath}")
+      return null
+    }
+    val tasks =
+      listOf(
+        ":${module.gradlePath}:composePreviewDiscover",
+        ":${module.gradlePath}:composePreviewDaemonStart",
+      )
+    if (!runGradle(worktreeDir, gradlew, tasks + extraArgs)) return null
+
+    val descriptor = File(moduleDir, "build/compose-previews/daemon-launch.json")
+    if (!descriptor.isFile) {
+      onLog("serve: missing daemon-launch.json at ${descriptor.absolutePath}")
+      return null
+    }
+    val manifest = PreviewResultBuilder.readManifest(PreviewModule(module.gradlePath, moduleDir))
+    val previews =
+      manifest?.previews?.map {
+        ServePreview(id = it.id, label = it.functionName.ifBlank { it.id })
+      } ?: emptyList()
+    if (previews.isEmpty()) {
+      onLog("serve: no previews discovered for ${module.gradlePath}")
+      return null
+    }
+    return BuiltRevision(moduleDir = moduleDir, descriptor = descriptor, previews = previews)
+  }
+
+  private fun runGradle(worktreeDir: File, gradlew: File, args: List<String>): Boolean {
+    return try {
+      val process =
+        ProcessBuilder(listOf(gradlew.absolutePath) + args)
+          .directory(worktreeDir)
+          .redirectErrorStream(true)
+          .start()
+      // Drain output on a daemon thread: a stalled build that never closes stdout (dependency
+      // resolution, a held lock) would otherwise block here forever and the waitFor timeout would
+      // never be reached — hanging the request while it holds the registry build lock.
+      // destroyForcibly() on timeout closes the stream, ending this thread.
+      val drain =
+        Thread { process.inputStream.bufferedReader().forEachLine { onLog("[gradle] $it") } }
+          .apply {
+            isDaemon = true
+            start()
+          }
+      if (!process.waitFor(timeoutSeconds, TimeUnit.SECONDS)) {
+        process.destroyForcibly()
+        onLog("serve: gradle build timed out after ${timeoutSeconds}s")
+        return false
+      }
+      drain.join(DRAIN_FLUSH_MILLIS) // let any buffered tail flush to the log
+      process.exitValue() == 0
+    } catch (e: Exception) {
+      onLog("serve: gradle build failed to launch (${e.message})")
+      false
+    }
+  }
+
+  private companion object {
+    const val DEFAULT_TIMEOUT_SECONDS = 600L
+    const val DRAIN_FLUSH_MILLIS = 2000L
+  }
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -147,96 +147,101 @@ class ServeHttpServer(
 
         get("/") {
           if (rejectBadToken()) return@get
-          val renderHost = resolveHost() ?: return@get
-          call.respondText(
-            ServeWeb.landingPage(
-              renderHost.label,
-              renderHost.previews,
-              token,
-              call.request.queryParameters["session"],
-            ),
-            ContentType.Text.Html,
-          )
+          withLeasedSession { renderHost ->
+            call.respondText(
+              ServeWeb.landingPage(
+                renderHost.label,
+                renderHost.previews,
+                token,
+                call.request.queryParameters["session"],
+              ),
+              ContentType.Text.Html,
+            )
+          }
         }
 
         get("/api/previews") {
           if (rejectBadToken()) return@get
-          val renderHost = resolveHost() ?: return@get
-          val dto =
-            PreviewsResponse(
-              module = renderHost.label,
-              previews =
-                renderHost.previews.map { p ->
-                  PreviewDto(id = p.id, label = p.label, modes = p.modes.map { it.wire })
-                },
+          withLeasedSession { renderHost ->
+            val dto =
+              PreviewsResponse(
+                module = renderHost.label,
+                previews =
+                  renderHost.previews.map { p ->
+                    PreviewDto(id = p.id, label = p.label, modes = p.modes.map { it.wire })
+                  },
+              )
+            call.respondText(
+              JSON.encodeToString(PreviewsResponse.serializer(), dto),
+              ContentType.Application.Json,
             )
-          call.respondText(
-            JSON.encodeToString(PreviewsResponse.serializer(), dto),
-            ContentType.Application.Json,
-          )
+          }
         }
 
         get("/bundle.zip") {
           if (rejectBadToken()) return@get
-          val renderHost = resolveHost() ?: return@get
-          // Render the whole module once (cache-backed) into the portable WebEmbed gallery and
-          // stream it as a zip — the same render output as the live links, downloadable offline.
-          val zip =
-            withContext(Dispatchers.IO) {
-              val built =
-                ServeBundle.build(
-                  previews = renderHost.previews,
-                  title = renderHost.label,
-                  modulePath = renderHost.label,
-                ) { preview ->
-                  (renderHost.render(preview.id, PreviewOverrides()) as? RenderOutcome.Ok)?.png
-                }
-              ServeBundle.zip(built.files)
-            }
-          call.respondBytes(zip, ContentType.Application.Zip)
+          withLeasedSession { renderHost ->
+            // Render the whole module once (cache-backed) into the portable WebEmbed gallery and
+            // stream it as a zip — the same render output as the live links, downloadable offline.
+            val zip =
+              withContext(Dispatchers.IO) {
+                val built =
+                  ServeBundle.build(
+                    previews = renderHost.previews,
+                    title = renderHost.label,
+                    modulePath = renderHost.label,
+                  ) { preview ->
+                    (renderHost.render(preview.id, PreviewOverrides()) as? RenderOutcome.Ok)?.png
+                  }
+                ServeBundle.zip(built.files)
+              }
+            call.respondBytes(zip, ContentType.Application.Zip)
+          }
         }
 
         get("/p/{name}") {
           if (rejectBadToken()) return@get
-          val renderHost = resolveHost() ?: return@get
-          val previewId = call.parameters["name"]
-          val preview = previewId?.let { id -> renderHost.previews.firstOrNull { it.id == id } }
-          if (preview == null) {
-            call.respondText("no such preview", status = HttpStatusCode.NotFound)
-            return@get
+          withLeasedSession { renderHost ->
+            val previewId = call.parameters["name"]
+            val preview = previewId?.let { id -> renderHost.previews.firstOrNull { it.id == id } }
+            if (preview == null) {
+              call.respondText("no such preview", status = HttpStatusCode.NotFound)
+              return@withLeasedSession
+            }
+            call.respondText(
+              ServeWeb.viewerPage(preview, token, call.request.queryParameters["session"]),
+              ContentType.Text.Html,
+            )
           }
-          call.respondText(
-            ServeWeb.viewerPage(preview, token, call.request.queryParameters["session"]),
-            ContentType.Text.Html,
-          )
         }
 
         get("/render/{name}") {
           if (rejectBadToken()) return@get
-          val renderHost = resolveHost() ?: return@get
-          val previewId = call.parameters["name"]?.removeSuffix(".png")
-          if (previewId.isNullOrBlank()) {
-            call.respondText("missing preview id", status = HttpStatusCode.BadRequest)
-            return@get
-          }
-          val overrideParams =
-            ServeOverrides.SUPPORTED_KEYS.mapNotNull { key ->
-                call.request.queryParameters[key]?.let { key to it }
-              }
-              .toMap()
-          when (val parsed = ServeOverrides.parse(overrideParams)) {
-            is OverrideParse.Invalid ->
-              call.respondText(parsed.message, status = HttpStatusCode.BadRequest)
-            is OverrideParse.Ok -> {
-              // The render is blocking (renderNow + await); keep it off the request dispatcher.
-              val outcome =
-                withContext(Dispatchers.IO) { renderHost.render(previewId, parsed.overrides) }
-              when (outcome) {
-                is RenderOutcome.Ok -> call.respondBytes(outcome.png, ContentType.Image.PNG)
-                RenderOutcome.NotFound ->
-                  call.respondText("no such preview", status = HttpStatusCode.NotFound)
-                is RenderOutcome.Failed ->
-                  call.respondText(outcome.reason, status = HttpStatusCode.InternalServerError)
+          withLeasedSession { renderHost ->
+            val previewId = call.parameters["name"]?.removeSuffix(".png")
+            if (previewId.isNullOrBlank()) {
+              call.respondText("missing preview id", status = HttpStatusCode.BadRequest)
+              return@withLeasedSession
+            }
+            val overrideParams =
+              ServeOverrides.SUPPORTED_KEYS.mapNotNull { key ->
+                  call.request.queryParameters[key]?.let { key to it }
+                }
+                .toMap()
+            when (val parsed = ServeOverrides.parse(overrideParams)) {
+              is OverrideParse.Invalid ->
+                call.respondText(parsed.message, status = HttpStatusCode.BadRequest)
+              is OverrideParse.Ok -> {
+                // The render is blocking (renderNow + await); keep it off the request dispatcher.
+                val outcome =
+                  withContext(Dispatchers.IO) { renderHost.render(previewId, parsed.overrides) }
+                when (outcome) {
+                  is RenderOutcome.Ok -> call.respondBytes(outcome.png, ContentType.Image.PNG)
+                  RenderOutcome.NotFound ->
+                    call.respondText("no such preview", status = HttpStatusCode.NotFound)
+                  is RenderOutcome.Failed ->
+                    call.respondText(outcome.reason, status = HttpStatusCode.InternalServerError)
+                }
               }
             }
           }
@@ -255,15 +260,23 @@ class ServeHttpServer(
   }
 
   /**
-   * Resolve the tenant for this request: `?session=` (else [defaultSessionId]) through the
-   * registry, which forks it on first use. Responds 404 and returns null when the session can't be
-   * created.
+   * Resolve the tenant for this request (`?session=`, else [defaultSessionId]) and run [block] with
+   * its host while holding a [ServeSessionRegistry.Lease] for the request's whole duration — so the
+   * reaper can't suspend the daemon mid-request (e.g. a long `/bundle.zip` that renders every
+   * preview). Responds 404 when the session can't be created/opened. The lease is always released.
    */
-  private suspend fun RoutingContext.resolveHost(): ServeRenderHost? {
+  private suspend fun RoutingContext.withLeasedSession(block: suspend (ServeRenderHost) -> Unit) {
     val sessionId = call.request.queryParameters["session"] ?: defaultSessionId
-    val renderHost = withContext(Dispatchers.IO) { sessions.acquire(sessionId) }
-    if (renderHost == null) call.respondText("not found", status = HttpStatusCode.NotFound)
-    return renderHost
+    val lease = withContext(Dispatchers.IO) { sessions.lease(sessionId) }
+    if (lease == null) {
+      call.respondText("not found", status = HttpStatusCode.NotFound)
+      return
+    }
+    try {
+      block(lease.host)
+    } finally {
+      withContext(Dispatchers.IO) { lease.close() }
+    }
   }
 
   /**

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRevisionFactory.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRevisionFactory.kt
@@ -1,0 +1,65 @@
+package ee.schimke.composeai.cli.serve
+
+import java.io.File
+
+/** A module to serve, identified by its Gradle path and its directory relative to the repo root. */
+data class ServeModuleRef(val gradlePath: String, val relativePath: String)
+
+/** A revision built into a daemon-ready module: where its descriptor + previews live. */
+data class BuiltRevision(
+  /** The module's project directory inside the checkout (holds `build/compose-previews/`). */
+  val moduleDir: File,
+  /** `build/compose-previews/daemon-launch.json` for the built module. */
+  val descriptor: File,
+  val previews: List<ServePreview>,
+)
+
+/**
+ * Builds [module] inside an already-checked-out [worktreeDir]; null when the build/discovery fails.
+ */
+fun interface RevisionBuilder {
+  fun build(worktreeDir: File, module: ServeModuleRef): BuiltRevision?
+}
+
+/**
+ * "Project mode" [ServeSessionFactory]: resolves a session id — a git revision (sha/ref/tag) of the
+ * **same project** — to a [ServeSessionState], so one shared server can serve any revision of a
+ * repo on demand (the building block for live PR-preview links). The state is what the registry
+ * caches, suspends, and resumes, so each revision is *built* at most once (this factory runs once
+ * per id) even as its daemon is suspended and resumed.
+ *
+ * The pieces are injected so the orchestration is unit-testable without git or Gradle: [worktrees]
+ * checks the revision out into a cache directory (one worktree per resolved commit) and [builder]
+ * builds + discovers the module in that checkout.
+ */
+class ServeRevisionFactory(
+  private val worktrees: GitWorktrees,
+  private val builder: RevisionBuilder,
+  private val module: ServeModuleRef,
+  private val onLog: (String) -> Unit = {},
+) : ServeSessionFactory {
+
+  override fun create(sessionId: String): ServeSessionState? {
+    val rev = sessionId.trim()
+    if (rev.isEmpty()) return null
+    val worktree =
+      worktrees.prepare(rev)
+        ?: run {
+          onLog("serve: could not check out revision '$rev'")
+          return null
+        }
+    val built =
+      builder.build(worktree, module)
+        ?: run {
+          onLog("serve: build/discovery failed for ${module.gradlePath} at '$rev'")
+          return null
+        }
+    return ServeSessionState(
+      descriptor = built.descriptor,
+      workspaceRoot = built.moduleDir,
+      workspaceName = built.moduleDir.name,
+      previews = built.previews,
+      label = "${module.gradlePath}@$rev",
+    )
+  }
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistry.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistry.kt
@@ -8,29 +8,31 @@ import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
 
 /**
- * Builds (forks) a tenant's render host on demand. The fork — discover/build a module, launch a
- * daemon, open a [ServeRenderHost] — happens behind this seam, so the registry and HTTP layer stay
- * transport- and policy-agnostic and tests can inject a fake.
+ * Builds (forks) a tenant's *session state* on demand — the expensive discover/build step. The fork
+ * happens behind this seam, so the registry and HTTP layer stay transport- and policy-agnostic and
+ * tests can inject a fake. Returns `null` when no such session can be created.
  */
 fun interface ServeSessionFactory {
-  /** Open a render host for [sessionId], or return `null` when no such session can be created. */
-  fun create(sessionId: String): ServeRenderHost?
+  fun create(sessionId: String): ServeSessionState?
 }
 
 /**
- * Multi-tenant registry of [ServeRenderHost]s behind **one** HTTP server, so a shared server fronts
- * many sessions instead of spawning a server per module. Sessions are created lazily via [factory]
- * (the fork-behind-the-API seam) on first use, cached by id, and idle-evicted: an unpinned host
- * with no live streams that hasn't been touched within [idleTimeoutMillis] is closed and its daemon
- * subprocess released.
+ * Multi-tenant registry of serve sessions behind **one** HTTP server, so a shared server fronts
+ * many sessions instead of spawning a server per module.
  *
- * Pre-seeded sessions ([register]) — e.g. the CLI's primary module — are **pinned** and never
- * evicted.
+ * Sessions follow an **Activity-style lifecycle** so daemons don't run forever:
+ * - **created** lazily via [factory] (the expensive build) on first use, keyed by id;
+ * - **opened** into a live daemon-backed [ServeRenderHost] via [open] (cheap — relaunches from the
+ *   built descriptor);
+ * - **suspended** when idle ([suspendIdle]): the daemon subprocess is closed but the cheap
+ *   [ServeSessionState] is kept, so the session can be **resumed** on the next request by
+ *   re-[open]ing from that state — no rebuild.
  *
- * Concurrency-safe: [acquire] forks at most once per id even under racing callers, and eviction
- * never closes a host that still has watchers ([ServeRenderHost.activeStreamCount]).
+ * A session is never suspended while it has an open [lease] (e.g. a live WebSocket) or active
+ * streams. Concurrency-safe: at most one build per id under racing callers.
  */
 class ServeSessionRegistry(
+  private val open: (ServeSessionState) -> ServeRenderHost?,
   private val factory: ServeSessionFactory = ServeSessionFactory { null },
   private val idleTimeoutMillis: Long = DEFAULT_IDLE_TIMEOUT_MILLIS,
   reaperIntervalMillis: Long = idleTimeoutMillis,
@@ -38,16 +40,15 @@ class ServeSessionRegistry(
 ) : AutoCloseable {
 
   private class Entry(
-    val host: ServeRenderHost,
-    val pinned: Boolean,
+    val state: ServeSessionState,
+    /** The live daemon host, or null while suspended. */
+    @Volatile var host: ServeRenderHost?,
     @Volatile var lastAccess: Long,
-    /**
-     * Open long-lived holders (e.g. WebSocket connections) pinning this session against eviction.
-     */
+    /** Open long-lived holders (e.g. WebSocket connections) keeping this session resident. */
     @Volatile var leases: Int = 0,
   )
 
-  /** A live hold on a session that keeps it from being reaped until [close] (idempotent). */
+  /** A live hold on a session that keeps it from being suspended until [close] (idempotent). */
   class Lease internal constructor(val host: ServeRenderHost, private val onRelease: () -> Unit) :
     AutoCloseable {
     private val released = AtomicBoolean(false)
@@ -61,8 +62,9 @@ class ServeSessionRegistry(
   private val sessions = HashMap<String, Entry>()
   private var closed = false
 
-  // A daemon reaper sweeps idle sessions. Disabled (null) when either knob is non-positive — tests
-  // drive eviction directly with a fake clock instead.
+  // A daemon reaper suspends idle sessions. Disabled (null) when either knob is non-positive —
+  // tests
+  // drive suspension directly with a fake clock instead.
   private val reaper: ScheduledExecutorService? =
     if (idleTimeoutMillis > 0 && reaperIntervalMillis > 0) {
       Executors.newSingleThreadScheduledExecutor { r ->
@@ -70,7 +72,7 @@ class ServeSessionRegistry(
         }
         .also {
           it.scheduleWithFixedDelay(
-            { runCatching { evictIdle() } },
+            { runCatching { suspendIdle() } },
             reaperIntervalMillis,
             reaperIntervalMillis,
             TimeUnit.MILLISECONDS,
@@ -81,48 +83,41 @@ class ServeSessionRegistry(
     }
 
   /**
-   * Pin an externally-opened [host] under [sessionId] (never evicted). Replaces any prior entry.
+   * Seed a session from already-known [state] (e.g. the CLI's current checkout), optionally with an
+   * already-open [host]. Replaces any prior entry. The session participates in suspend/resume like
+   * a forked one — its daemon is released when idle and reopened from [state] on demand.
    */
-  fun register(sessionId: String, host: ServeRenderHost) {
+  fun register(sessionId: String, state: ServeSessionState, host: ServeRenderHost? = null) {
     lock.withLock {
       check(!closed) { "ServeSessionRegistry is closed" }
-      sessions[sessionId] = Entry(host, pinned = true, lastAccess = clock())
+      sessions[sessionId] = Entry(state, host, lastAccess = clock())
     }
   }
 
   /**
-   * The host for [sessionId], forking one via [factory] on a miss. Returns `null` when the session
-   * doesn't exist and can't be created, so the caller can 404. Touches the session's idle clock.
+   * The live host for [sessionId] — resuming a suspended session or forking a new one via
+   * [factory]. Returns `null` when the session can't be created/opened, so the caller can 404.
+   * Touches the idle clock.
    */
   fun acquire(sessionId: String): ServeRenderHost? = lock.withLock {
     check(!closed) { "ServeSessionRegistry is closed" }
-    sessions[sessionId]?.let {
-      it.lastAccess = clock()
-      return it.host
-    }
-    // Hold the lock across the fork so racing first-callers for one id can't fork twice. A fork is
-    // slow, but a shared dev/CI server has few tenants and correctness beats fork concurrency.
-    val host = factory.create(sessionId) ?: return null
-    sessions[sessionId] = Entry(host, pinned = false, lastAccess = clock())
-    host
+    val entry = entryFor(sessionId) ?: return null
+    entry.lastAccess = clock()
+    liveHost(entry)
   }
 
   /**
-   * Acquire [sessionId] (forking on a miss) and hold it open for the returned [Lease]'s lifetime,
-   * so a long-lived connection — including a WebSocket on the snapshot fallback lane that opens no
-   * `stream/start` — isn't reaped mid-connection. Returns `null` when the session can't be created;
-   * the holder must [Lease.close] when the connection ends.
+   * Acquire [sessionId] and hold it resident for the returned [Lease]'s lifetime, so a long-lived
+   * connection — including a WebSocket on the snapshot fallback lane that opens no stream — isn't
+   * suspended mid-connection. Returns `null` when the session can't be created/opened.
    */
   fun lease(sessionId: String): Lease? = lock.withLock {
     check(!closed) { "ServeSessionRegistry is closed" }
-    val entry =
-      sessions[sessionId]
-        ?: (factory.create(sessionId)?.let { host ->
-          Entry(host, pinned = false, lastAccess = clock()).also { sessions[sessionId] = it }
-        } ?: return null)
+    val entry = entryFor(sessionId) ?: return null
     entry.lastAccess = clock()
+    val host = liveHost(entry) ?: return null
     entry.leases++
-    Lease(entry.host) {
+    Lease(host) {
       lock.withLock {
         entry.leases--
         entry.lastAccess = clock() // start the idle clock fresh once the holder leaves
@@ -130,38 +125,66 @@ class ServeSessionRegistry(
     }
   }
 
-  /** Close unpinned, watcher-free sessions idle past the timeout. Returns the count evicted. */
-  fun evictIdle(): Int = lock.withLock {
+  /** Suspend (close the daemon of, keep the state of) resident sessions idle past the timeout. */
+  fun suspendIdle(): Int = lock.withLock {
     if (closed) return 0
     val now = clock()
-    val dead = sessions.filterValues {
-      !it.pinned &&
-        it.leases == 0 &&
-        it.host.activeStreamCount() == 0 &&
-        now - it.lastAccess >= idleTimeoutMillis
+    var suspended = 0
+    for (entry in sessions.values) {
+      val host = entry.host ?: continue
+      if (
+        entry.leases == 0 &&
+          host.activeStreamCount() == 0 &&
+          now - entry.lastAccess >= idleTimeoutMillis
+      ) {
+        entry.host = null
+        runCatching { host.close() }
+        suspended++
+      }
     }
-    dead.forEach { (id, entry) ->
-      sessions.remove(id)
-      runCatching { entry.host.close() }
-    }
-    dead.size
+    suspended
   }
 
-  /** Number of live sessions (pinned + forked). */
+  /** Total known sessions (resident + suspended). */
   fun activeCount(): Int = lock.withLock { sessions.size }
 
+  /** Sessions with a live daemon right now (resident, not suspended). */
+  fun residentCount(): Int = lock.withLock { sessions.values.count { it.host != null } }
+
   override fun close() {
-    val toClose = lock.withLock {
+    val hosts = lock.withLock {
       if (closed) return
       closed = true
-      sessions.values.toList().also { sessions.clear() }
+      sessions.values.mapNotNull { it.host }.also { sessions.clear() }
     }
     reaper?.shutdownNow()
-    toClose.forEach { runCatching { it.host.close() } }
+    hosts.forEach { runCatching { it.close() } }
+  }
+
+  /** Existing entry, or one forked via [factory]. Caller holds [lock]. */
+  private fun entryFor(sessionId: String): Entry? {
+    sessions[sessionId]?.let {
+      return it
+    }
+    // Hold the lock across the build so racing first-callers for one id can't build twice. A build
+    // is
+    // slow, but a shared dev/CI server has few tenants and correctness beats build concurrency.
+    val state = factory.create(sessionId) ?: return null
+    return Entry(state, host = null, lastAccess = clock()).also { sessions[sessionId] = it }
+  }
+
+  /** The entry's live host, resuming (re-opening) from its state if it was suspended. */
+  private fun liveHost(entry: Entry): ServeRenderHost? {
+    entry.host?.let {
+      return it
+    }
+    val resumed = open(entry.state) ?: return null
+    entry.host = resumed
+    return resumed
   }
 
   private companion object {
-    /** Default idle window before an unused forked session's daemon is released. */
+    /** Default idle window before a resident session's daemon is suspended. */
     const val DEFAULT_IDLE_TIMEOUT_MILLIS = 10 * 60 * 1000L
   }
 }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionState.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionState.kt
@@ -1,0 +1,23 @@
+package ee.schimke.composeai.cli.serve
+
+import java.io.File
+
+/**
+ * The cheap, durable "instance state" of a serve session — everything needed to (re)open its
+ * daemon-backed [ServeRenderHost] *without* rebuilding. Produced once by a [ServeSessionFactory]
+ * (the expensive discover/build step) and retained across suspend/resume, so an idle session can
+ * release its daemon subprocess and be brought back from this state alone — like an Activity
+ * restoring from saved instance state rather than being recreated from scratch.
+ *
+ * Everything here already persists on disk (the `daemon-launch.json` descriptor + the discovered
+ * preview list), so holding it costs almost nothing while the daemon is suspended.
+ */
+data class ServeSessionState(
+  /** `build/compose-previews/daemon-launch.json` the daemon relaunches from. */
+  val descriptor: File,
+  val workspaceRoot: File,
+  val workspaceName: String,
+  val previews: List<ServePreview>,
+  /** Human label for the tenant (e.g. the module's Gradle path, or `module@rev`). */
+  val label: String,
+)

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/GitWorktreesTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/GitWorktreesTest.kt
@@ -1,0 +1,73 @@
+package ee.schimke.composeai.cli.serve
+
+import java.io.File
+import java.util.concurrent.CopyOnWriteArrayList
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class GitWorktreesTest {
+
+  private fun tempDir(prefix: String): File =
+    java.nio.file.Files.createTempDirectory(prefix).toFile().also { it.deleteOnExit() }
+
+  /** Records git invocations and simulates rev-parse + worktree add (creating a `.git` marker). */
+  private class FakeGit(var resolveSha: String? = "abc123def") : GitRunner {
+    val calls = CopyOnWriteArrayList<List<String>>()
+
+    fun count(prefix: List<String>): Int = calls.count { it.take(prefix.size) == prefix }
+
+    override fun run(workdir: File, args: List<String>): GitResult {
+      calls.add(args)
+      return when {
+        args.take(1) == listOf("rev-parse") ->
+          resolveSha?.let { GitResult(0, "$it\n") } ?: GitResult(1, "")
+        args.take(2) == listOf("worktree", "add") -> {
+          val dir = File(args[args.size - 2])
+          dir.mkdirs()
+          File(dir, ".git").writeText("gitdir: elsewhere")
+          GitResult(0, "")
+        }
+        else -> GitResult(0, "")
+      }
+    }
+  }
+
+  @Test
+  fun `prepare resolves the commit and adds a worktree once, reusing it after`() {
+    val git = FakeGit()
+    val cache = tempDir("wt-cache")
+    GitWorktrees(repoRoot = tempDir("repo"), cacheRoot = cache, git = git).use { wt ->
+      val dir = assertNotNull(wt.prepare("HEAD"))
+      assertEquals(File(cache, "abc123def"), dir)
+      assertTrue(File(dir, ".git").exists())
+      assertEquals(1, git.count(listOf("worktree", "add")))
+
+      // Second request for the same revision reuses the existing worktree — no second add.
+      val again = assertNotNull(wt.prepare("HEAD"))
+      assertEquals(dir, again)
+      assertEquals(1, git.count(listOf("worktree", "add")), "an existing worktree is reused")
+    }
+  }
+
+  @Test
+  fun `prepare returns null when the revision cannot be resolved`() {
+    val git = FakeGit(resolveSha = null)
+    GitWorktrees(repoRoot = tempDir("repo"), cacheRoot = tempDir("wt-cache"), git = git).use { wt ->
+      assertNull(wt.prepare("does-not-exist"))
+      assertEquals(0, git.count(listOf("worktree", "add")), "no worktree added for a bad revision")
+    }
+  }
+
+  @Test
+  fun `close removes the worktrees it created`() {
+    val git = FakeGit()
+    GitWorktrees(repoRoot = tempDir("repo"), cacheRoot = tempDir("wt-cache"), git = git).use { wt ->
+      wt.prepare("HEAD")
+    }
+    assertEquals(1, git.count(listOf("worktree", "remove")))
+    assertEquals(1, git.count(listOf("worktree", "prune")))
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeRevisionFactoryTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeRevisionFactoryTest.kt
@@ -1,0 +1,69 @@
+package ee.schimke.composeai.cli.serve
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class ServeRevisionFactoryTest {
+
+  private fun tempDir(prefix: String): File =
+    java.nio.file.Files.createTempDirectory(prefix).toFile().also { it.deleteOnExit() }
+
+  /** A [GitRunner] that resolves any rev to [sha] and "checks out" a `.git`-marked worktree. */
+  private class FakeGit(private val sha: String?) : GitRunner {
+    override fun run(workdir: File, args: List<String>): GitResult =
+      when {
+        args.take(1) == listOf("rev-parse") -> sha?.let { GitResult(0, it) } ?: GitResult(1, "")
+        args.take(2) == listOf("worktree", "add") -> {
+          val dir = File(args[args.size - 2])
+          dir.mkdirs()
+          File(dir, ".git").writeText("x")
+          GitResult(0, "")
+        }
+        else -> GitResult(0, "")
+      }
+  }
+
+  private fun worktrees(sha: String?): GitWorktrees =
+    GitWorktrees(repoRoot = tempDir("repo"), cacheRoot = tempDir("cache"), git = FakeGit(sha))
+
+  private val module = ServeModuleRef(gradlePath = "samples:cmp", relativePath = "samples/cmp")
+
+  @Test
+  fun `create builds a session state labelled module at rev`() {
+    val builder = RevisionBuilder { worktreeDir, m ->
+      val moduleDir = File(worktreeDir, m.relativePath)
+      BuiltRevision(
+        moduleDir = moduleDir,
+        descriptor = File(moduleDir, "build/compose-previews/daemon-launch.json"),
+        previews = listOf(ServePreview("com.example.Red", "Red")),
+      )
+    }
+    val factory = ServeRevisionFactory(worktrees("abcdef0"), builder, module)
+
+    val state = assertNotNull(factory.create("HEAD"))
+    assertEquals("samples:cmp@HEAD", state.label)
+    assertEquals(listOf(ServePreview("com.example.Red", "Red")), state.previews)
+    assertEquals("daemon-launch.json", state.descriptor.name)
+  }
+
+  @Test
+  fun `create returns null when the revision cannot be checked out`() {
+    val builder = RevisionBuilder { _, _ -> error("builder must not run for an unresolved rev") }
+    assertNull(ServeRevisionFactory(worktrees(sha = null), builder, module).create("bogus"))
+  }
+
+  @Test
+  fun `create returns null when the build fails`() {
+    val builder = RevisionBuilder { _, _ -> null }
+    assertNull(ServeRevisionFactory(worktrees("abcdef0"), builder, module).create("HEAD"))
+  }
+
+  @Test
+  fun `create returns null for a blank revision`() {
+    val builder = RevisionBuilder { _, _ -> error("builder must not run for a blank rev") }
+    assertNull(ServeRevisionFactory(worktrees("abcdef0"), builder, module).create("  "))
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistryTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistryTest.kt
@@ -2,10 +2,12 @@ package ee.schimke.composeai.cli.serve
 
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import java.io.File
+import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertNotSame
 import kotlin.test.assertNull
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
@@ -17,139 +19,170 @@ class ServeSessionRegistryTest {
   private fun newRenderRoot(): File =
     java.nio.file.Files.createTempDirectory("serve-registry").toFile().also { it.deleteOnExit() }
 
-  private fun newHost(streaming: Boolean = false): ServeRenderHost =
-    ServeRenderHost(
-      session = FakeRenderSession(newRenderRoot(), streaming = streaming),
+  private fun stateFor(label: String): ServeSessionState =
+    ServeSessionState(
+      descriptor = File("daemon-launch.json"),
+      workspaceRoot = newRenderRoot(),
+      workspaceName = "w",
       previews = listOf(ServePreview(previewId, "Red")),
-      renderTimeoutSeconds = 30,
+      label = label,
     )
 
-  /** A factory that hands out a fresh host per id and records how many times it was called. */
-  private class CountingFactory : ServeSessionFactory {
-    var created = 0
-      private set
+  /** Opens a fresh fake host per call; records how many times it ran. */
+  private inner class Opener(private val streaming: Boolean = false) :
+    (ServeSessionState) -> ServeRenderHost? {
+    val opened = AtomicInteger(0)
 
-    override fun create(sessionId: String): ServeRenderHost? {
-      if (sessionId == "missing") return null
-      created++
+    override fun invoke(state: ServeSessionState): ServeRenderHost {
+      opened.incrementAndGet()
       return ServeRenderHost(
-        session = FakeRenderSession(java.nio.file.Files.createTempDirectory("h").toFile()),
-        previews = listOf(ServePreview("com.example.Red", "Red")),
+        session = FakeRenderSession(newRenderRoot(), streaming = streaming),
+        previews = state.previews,
+        label = state.label,
         renderTimeoutSeconds = 30,
       )
     }
   }
 
+  /** A factory that builds a state per id (except "missing") and counts builds. */
+  private inner class CountingFactory : ServeSessionFactory {
+    val built = AtomicInteger(0)
+
+    override fun create(sessionId: String): ServeSessionState? {
+      if (sessionId == "missing") return null
+      built.incrementAndGet()
+      return stateFor(sessionId)
+    }
+  }
+
   @Test
-  fun `acquire forks once per id and caches`() {
+  fun `acquire builds once, opens once, and caches the live host`() {
+    val opener = Opener()
     val factory = CountingFactory()
-    ServeSessionRegistry(factory, reaperIntervalMillis = 0).use { reg ->
+    ServeSessionRegistry(open = opener, factory = factory, reaperIntervalMillis = 0).use { reg ->
       val first = assertNotNull(reg.acquire("a"))
       val second = assertNotNull(reg.acquire("a"))
-      assertSame(first, second, "the same id returns the cached host")
-      assertEquals(1, factory.created, "a cached id is not re-forked")
+      assertSame(first, second, "a resident session returns the same host")
+      assertEquals(1, factory.built.get())
+      assertEquals(1, opener.opened.get())
       assertEquals(1, reg.activeCount())
-
-      reg.acquire("b")
-      assertEquals(2, factory.created, "a new id forks a new host")
-      assertEquals(2, reg.activeCount())
+      assertEquals(1, reg.residentCount())
     }
+  }
+
+  @Test
+  fun `a suspended session resumes from saved state without rebuilding`() {
+    val clock = AtomicLong(0)
+    val opener = Opener()
+    val factory = CountingFactory()
+    ServeSessionRegistry(
+        open = opener,
+        factory = factory,
+        idleTimeoutMillis = 100,
+        reaperIntervalMillis = 0,
+        clock = clock::get,
+      )
+      .use { reg ->
+        val live = assertNotNull(reg.acquire("a"))
+        clock.set(200)
+        assertEquals(1, reg.suspendIdle(), "the idle daemon is suspended")
+        assertEquals(0, reg.residentCount(), "no daemon resident while suspended")
+        assertEquals(1, reg.activeCount(), "but the session (its state) is retained")
+
+        val resumed = assertNotNull(reg.acquire("a"))
+        assertNotSame(live, resumed, "resume opens a fresh daemon from the saved state")
+        assertEquals(1, factory.built.get(), "resume must NOT rebuild")
+        assertEquals(2, opener.opened.get(), "resume re-opens from state")
+        assertEquals(1, reg.residentCount())
+      }
+  }
+
+  @Test
+  fun `a registered session resumes from its state, never rebuilding`() {
+    val clock = AtomicLong(0)
+    val opener = Opener()
+    val factory = CountingFactory()
+    ServeSessionRegistry(
+        open = opener,
+        factory = factory,
+        idleTimeoutMillis = 100,
+        reaperIntervalMillis = 0,
+        clock = clock::get,
+      )
+      .use { reg ->
+        val eager =
+          ServeRenderHost(
+            FakeRenderSession(newRenderRoot()),
+            listOf(ServePreview(previewId, "Red")),
+          )
+        reg.register("primary", stateFor("primary"), host = eager)
+        assertSame(eager, reg.acquire("primary"), "the eager host is served while resident")
+
+        clock.set(200)
+        assertEquals(1, reg.suspendIdle())
+        val resumed = assertNotNull(reg.acquire("primary"))
+        assertNotSame(eager, resumed)
+        assertEquals(0, factory.built.get(), "a registered session is never built by the factory")
+        assertEquals(1, opener.opened.get(), "resumed via the opener")
+      }
+  }
+
+  @Test
+  fun `a leased session is not suspended until the lease closes`() {
+    val clock = AtomicLong(0)
+    ServeSessionRegistry(
+        open = Opener(),
+        factory = CountingFactory(),
+        idleTimeoutMillis = 100,
+        reaperIntervalMillis = 0,
+        clock = clock::get,
+      )
+      .use { reg ->
+        val lease = assertNotNull(reg.lease("a"))
+        clock.set(10_000)
+        assertEquals(0, reg.suspendIdle(), "an open lease keeps the daemon resident")
+        lease.close()
+        clock.set(20_000)
+        assertEquals(1, reg.suspendIdle(), "after the lease closes the idle daemon suspends")
+      }
+  }
+
+  @Test
+  fun `a session with live watchers is not suspended`() {
+    val clock = AtomicLong(0)
+    ServeSessionRegistry(
+        open = Opener(streaming = true),
+        factory = CountingFactory(),
+        idleTimeoutMillis = 100,
+        reaperIntervalMillis = 0,
+        clock = clock::get,
+      )
+      .use { reg ->
+        val host = assertNotNull(reg.acquire("a"))
+        val handle = assertNotNull(host.subscribeStream(previewId, PreviewOverrides()) {})
+        clock.set(10_000)
+        assertEquals(0, reg.suspendIdle(), "a host with a live watcher must stay resident")
+        handle.close()
+        assertEquals(1, reg.suspendIdle(), "once the watcher leaves it can suspend")
+      }
   }
 
   @Test
   fun `acquire returns null when the factory cannot create the session`() {
-    ServeSessionRegistry(CountingFactory(), reaperIntervalMillis = 0).use { reg ->
-      assertNull(reg.acquire("missing"))
-      assertEquals(0, reg.activeCount())
-    }
-  }
-
-  @Test
-  fun `registered sessions are pinned and never evicted`() {
-    val clock = AtomicLong(0)
-    ServeSessionRegistry(idleTimeoutMillis = 100, reaperIntervalMillis = 0, clock = clock::get)
+    ServeSessionRegistry(open = Opener(), factory = CountingFactory(), reaperIntervalMillis = 0)
       .use { reg ->
-        reg.register("primary", newHost())
-        clock.set(10_000) // well past the idle window
-        assertEquals(0, reg.evictIdle(), "a pinned session is never evicted")
-        assertEquals(1, reg.activeCount())
+        assertNull(reg.acquire("missing"))
+        assertEquals(0, reg.activeCount())
       }
   }
 
   @Test
-  fun `idle forked sessions are evicted, fresh ones are kept`() {
-    val clock = AtomicLong(0)
-    val factory = CountingFactory()
-    ServeSessionRegistry(
-        factory,
-        idleTimeoutMillis = 100,
-        reaperIntervalMillis = 0,
-        clock = clock::get,
-      )
-      .use { reg ->
-        reg.acquire("old") // lastAccess = 0
-        clock.set(50)
-        reg.acquire("fresh") // lastAccess = 50
-        clock.set(120) // old idle 120ms (≥100 → evict); fresh idle 70ms (<100 → keep)
-        assertEquals(1, reg.evictIdle())
-        assertEquals(1, reg.activeCount())
-        assertNotNull(reg.acquire("fresh"))
-      }
-  }
-
-  @Test
-  fun `a session with live watchers is not evicted`() {
-    val clock = AtomicLong(0)
-    val streamingHost = newHost(streaming = true)
-    val factory = ServeSessionFactory { streamingHost }
-    ServeSessionRegistry(
-        factory,
-        idleTimeoutMillis = 100,
-        reaperIntervalMillis = 0,
-        clock = clock::get,
-      )
-      .use { reg ->
-        val host = assertNotNull(reg.acquire("s"))
-        // Open a live watcher: the host now reports an active stream.
-        val handle = assertNotNull(host.subscribeStream(previewId, PreviewOverrides()) {})
-        clock.set(10_000)
-        assertEquals(0, reg.evictIdle(), "a host with a live watcher must not be evicted")
-        handle.close()
-        assertEquals(1, reg.evictIdle(), "once the watcher leaves it can be evicted")
-      }
-  }
-
-  @Test
-  fun `a leased session is not evicted until the lease closes`() {
-    val clock = AtomicLong(0)
-    val factory = CountingFactory()
-    ServeSessionRegistry(
-        factory,
-        idleTimeoutMillis = 100,
-        reaperIntervalMillis = 0,
-        clock = clock::get,
-      )
-      .use { reg ->
-        val lease = assertNotNull(reg.lease("s"))
-        clock.set(10_000)
-        assertEquals(
-          0,
-          reg.evictIdle(),
-          "an open lease keeps the session alive past the idle window",
-        )
-        lease.close()
-        clock.set(10_200) // idle again past the window now that the holder is gone
-        assertEquals(1, reg.evictIdle(), "after the lease closes the idle session is reaped")
-      }
-  }
-
-  @Test
-  fun `close releases every host`() {
-    val factory = CountingFactory()
-    val reg = ServeSessionRegistry(factory, reaperIntervalMillis = 0)
+  fun `close releases every resident host and rejects further acquire`() {
+    val reg =
+      ServeSessionRegistry(open = Opener(), factory = CountingFactory(), reaperIntervalMillis = 0)
     reg.acquire("a")
     reg.acquire("b")
-    assertEquals(2, reg.activeCount())
+    assertEquals(2, reg.residentCount())
     reg.close()
     assertEquals(0, reg.activeCount())
     assertTrue(runCatching { reg.acquire("c") }.isFailure, "a closed registry rejects acquire")


### PR DESCRIPTION
## Summary

Stacked on #2010. Gives serve sessions an **Activity-style lifecycle** so a long-lived shared server doesn't keep every daemon running — idle sessions **suspend** (release the daemon subprocess) but keep cheap, durable state, and **resume** on demand from that state instead of rebuilding.

The registry now separates the *expensive build* from the *cheap daemon open*:

- **`ServeSessionFactory`** produces a **`ServeSessionState`** (descriptor + workspace + previews + label) — the durable "saved instance state", built once. Everything in it already persists on disk (`daemon-launch.json` + the preview list), so holding it while suspended costs almost nothing.
- An injected **opener** turns state into a live `ServeRenderHost` (relaunches the daemon from the descriptor).
- **`suspendIdle()`** closes the daemon of idle sessions but keeps their state; the next **`acquire()` resumes** by re-opening from state — **no rebuild**. Sessions with an open `lease` (a live WebSocket) or active streams are never suspended.

`ServeCommand` registers the current checkout as the default session with its state + eager host. `ServeHttpServer` is **unchanged**: `acquire()`/`lease()` still return a host and transparently resume a suspended session. This is the foundation the project-mode revision factory builds on (a built revision is just a `ServeSessionState`, so an idle PR-preview daemon suspends and resumes without re-running Gradle).

## Test plan
- `ktfmtFormatAll` clean; `:cli:compileKotlin` / `compileTestKotlin` green; `:cli:checkCliDaemonLibraryBoundary` green.
- Serve suite green (`./gradlew :cli:test --tests 'ee.schimke.composeai.cli.serve.*'`), with a rewritten `ServeSessionRegistryTest` (8): build-once + cache, **suspend then resume from state without rebuilding** (factory not re-invoked, opener re-invoked, fresh host), registered session resumes via opener and is never built, leased session not suspended, session with live watchers not suspended, null when factory can't create, `close()` releases resident hosts + rejects further acquire.

## Visual evidence
Non-visual — session lifecycle / server wiring only. The served pages and rendered output are unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_0186JHWqw5dMvUJbfgDXgqGo)_