### PR TITLE
fix(renderer): concise RenderPreviewEntry.toString so preview test filenames don't overflow

### DIFF
--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RenderManifest.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RenderManifest.kt
@@ -183,7 +183,18 @@ data class RenderPreviewEntry(
      * See [RenderPreviewArtifact]. The wire field name stays `dataProducts` for back-compat.
      */
     val dataProducts: List<RenderPreviewArtifact> = emptyList(),
-)
+) {
+    /**
+     * Concise, stable label — the (already-unique, fan-out-suffixed) preview [id]. This is
+     * load-bearing, not cosmetic: [RobolectricRenderTest]'s `@Parameters(name = "{0}")` names each
+     * parameterized case by this `toString()`, and Gradle's JUnit XML writer turns that name into a
+     * `TEST-<name>.xml` filename. The data-class default dumped every field (params, captures,
+     * dataProducts), producing ~600-char names that overflow the filesystem's 255-byte filename
+     * limit (`FileNotFoundException: … (File name too long)`) on the per-case-file reporting path.
+     * The `id` keeps test reports readable while staying well under the limit.
+     */
+    override fun toString(): String = id
+}
 
 @Serializable
 data class RenderPreviewCapture(


### PR DESCRIPTION
## What

`RobolectricRenderTest` declares `@Parameters(name = "{0}")`, so each parameterized render case is named by `RenderPreviewEntry.toString()`, and Gradle's JUnit XML writer turns that name into a `TEST-<name>.xml` filename. The data-class default `toString()` dumps every field (`id`, `params`, `captures`, `dataProducts`, …) — ~600 chars — which overflows the filesystem's 255-byte filename limit on the per-case-file reporting path:

```
java.io.FileNotFoundException: …/TEST-[RenderPreviewEntry(id=…, params=RenderPreviewParams(…), captures=[…])].xml (File name too long)
```

That's what fails the **`agp8-min`** check and (via an empty `previews.json` from the crashed render) **`Apply compose-preview`**.

## Fix

Override `RenderPreviewEntry.toString()` to return the already-unique, fan-out-suffixed preview `id`. Case names stay readable (the id is the meaningful label) and drop well under the limit. No code depended on the verbose form.

## Test plan

- `:renderer-android:compileDebugKotlin` green; `ktfmt` clean.
- `:clients:mobile:composePreviewRenderAll` green — parameterized case names are now e.g. `renderPreview[…SessionViewerAppKt.ConnectScreenDiscoveredPreview_Connect — discovered]` (~115 chars) instead of the ~600-char dump.
- `:renderer-android:testDebugUnitTest`: the suite passes **except** `LayoutInspectorFixtureTest` (`expected 1 but was 2`), which is **pre-existing on `main`** — it reproduces on a clean tree with this change stashed, so it's unrelated to this fix (a separate duplicate layout-inspector capability registration worth its own look).

Non-visual change (test/report naming); rendered PNG output is unchanged.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FWArgtvAa6qagyCFSwP1nw)_