### PR TITLE
feat(cli): ephemeral mode — exit the server when idle

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
@@ -90,7 +90,7 @@ internal object CliFlags {
    * the following token. Listed only so `CliFlagsRegistryTest` can tell them apart from a missing
    * [VALUE_FLAGS] entry — they are intentionally excluded from command-detection skipping.
    */
-  val ATTACHED_OR_OPTIONAL_FLAGS: Set<String> = setOf("--images")
+  val ATTACHED_OR_OPTIONAL_FLAGS: Set<String> = setOf("--images", "--exit-when-idle")
 
   /**
    * The first positional token in [args] — the bare token that isn't the value of a value-consuming

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -18,6 +18,9 @@ import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.render.session.RenderSessionException
 import java.io.File
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
 import kotlin.system.exitProcess
 
 /**
@@ -51,6 +54,19 @@ class ServeCommand(args: List<String>) : Command(args) {
    * resumed by the registry. Off by default (just the current module).
    */
   private val revisions: Boolean = "--revisions" in args
+
+  /**
+   * Ephemeral mode: shut the whole server down once it's been idle — no open connections and no
+   * requests — for [idleExitSeconds]. `--exit-when-idle` uses the default window;
+   * `--exit-when-idle=<seconds>` sets it (a short value ≈ "exit shortly after the last client
+   * disconnects"). Off by default (runs until Ctrl-C).
+   */
+  private val exitWhenIdle: Boolean = args.any {
+    it == "--exit-when-idle" || it.startsWith("--exit-when-idle=")
+  }
+  private val idleExitSeconds: Long =
+    args.flagValue("--exit-when-idle")?.toLongOrNull()?.takeIf { it > 0 }
+      ?: DEFAULT_IDLE_EXIT_SECONDS
 
   override fun run() {
     if ("--help" in args || "-h" in args) {
@@ -195,7 +211,40 @@ class ServeCommand(args: List<String>) : Command(args) {
 
     server.start()
     printBanner(module.gradlePath, server.port, token, previews.size)
+    val watchdog = if (exitWhenIdle) startIdleWatchdog(registry, done) else null
     done.await()
+    watchdog?.shutdownNow()
+  }
+
+  /**
+   * Poll the registry's server-level idle time; when it crosses [idleExitSeconds] with no open
+   * connections, release [done] so [run] returns and the process exits (the shutdown hook tears the
+   * server + daemons down). Returns the scheduler so the caller can stop it.
+   */
+  private fun startIdleWatchdog(
+    registry: ServeSessionRegistry,
+    done: CountDownLatch,
+  ): ScheduledExecutorService {
+    val timeoutMillis = idleExitSeconds * 1000
+    val interval = (timeoutMillis / 4).coerceIn(1_000, 30_000)
+    val exec = Executors.newSingleThreadScheduledExecutor { r ->
+      Thread(r, "serve-idle-watchdog").apply { isDaemon = true }
+    }
+    exec.scheduleWithFixedDelay(
+      {
+        val idle = registry.idleMillis()
+        if (idle != null && idle >= timeoutMillis) {
+          System.err.println(
+            "serve: idle ${idle / 1000}s (--exit-when-idle=${idleExitSeconds}s) — shutting down."
+          )
+          done.countDown()
+        }
+      },
+      interval,
+      interval,
+      TimeUnit.MILLISECONDS,
+    )
+    return exec
   }
 
   /** Open the worktree manager rooted at the repo (project mode). */
@@ -354,6 +403,10 @@ class ServeCommand(args: List<String>) : Command(args) {
         --revisions       Project mode: also serve other git revisions of this repo on demand. A
                           request with ?session=<rev> checks that revision out into a worktree,
                           builds it, and serves it as its own session (suspended/resumed when idle).
+        --exit-when-idle[=<seconds>]
+                          Ephemeral mode: shut the server down once it's been idle (no open
+                          connections and no requests) for <seconds> (default ${DEFAULT_IDLE_EXIT_SECONDS}s). Use a small
+                          value to exit shortly after the last client disconnects.
 
       The shareable link carries an unguessable token; requests without it get 404.
       """
@@ -363,5 +416,6 @@ class ServeCommand(args: List<String>) : Command(args) {
 
   private companion object {
     const val DEFAULT_PORT = 8723
+    const val DEFAULT_IDLE_EXIT_SECONDS = 60L
   }
 }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistry.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistry.kt
@@ -62,6 +62,10 @@ class ServeSessionRegistry(
   private val sessions = HashMap<String, Entry>()
   private var closed = false
 
+  // Wall-clock of the most recent acquire/lease/release across all sessions — the basis for the
+  // server-level idle check ([idleMillis]) that the ephemeral exit-when-idle watchdog reads.
+  @Volatile private var lastActivity: Long = clock()
+
   // A daemon reaper suspends idle sessions. Disabled (null) when either knob is non-positive —
   // tests
   // drive suspension directly with a fake clock instead.
@@ -103,6 +107,7 @@ class ServeSessionRegistry(
     check(!closed) { "ServeSessionRegistry is closed" }
     val entry = entryFor(sessionId) ?: return null
     entry.lastAccess = clock()
+    lastActivity = clock()
     liveHost(entry)
   }
 
@@ -115,14 +120,25 @@ class ServeSessionRegistry(
     check(!closed) { "ServeSessionRegistry is closed" }
     val entry = entryFor(sessionId) ?: return null
     entry.lastAccess = clock()
+    lastActivity = clock()
     val host = liveHost(entry) ?: return null
     entry.leases++
     Lease(host) {
       lock.withLock {
         entry.leases--
         entry.lastAccess = clock() // start the idle clock fresh once the holder leaves
+        lastActivity = clock()
       }
     }
+  }
+
+  /**
+   * Milliseconds the *whole server* has been idle, or `null` when it's busy (any session has an
+   * open lease — e.g. a live WebSocket). Idle counts from the last acquire/lease/release; with no
+   * leases and no requests it grows unbounded. Drives the ephemeral "exit when idle" watchdog.
+   */
+  fun idleMillis(now: Long = clock()): Long? = lock.withLock {
+    if (sessions.values.any { it.leases > 0 }) null else now - lastActivity
   }
 
   /** Suspend (close the daemon of, keep the state of) resident sessions idle past the timeout. */

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistryTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistryTest.kt
@@ -177,6 +177,26 @@ class ServeSessionRegistryTest {
   }
 
   @Test
+  fun `idleMillis is null while leased and grows from the last activity otherwise`() {
+    val clock = AtomicLong(1_000)
+    ServeSessionRegistry(
+        open = Opener(),
+        factory = CountingFactory(),
+        reaperIntervalMillis = 0,
+        clock = clock::get,
+      )
+      .use { reg ->
+        val lease = assertNotNull(reg.lease("a"))
+        clock.set(5_000)
+        assertNull(reg.idleMillis(), "an open lease means the server is busy, not idle")
+
+        lease.close() // records activity at t=5_000
+        clock.set(8_500)
+        assertEquals(3_500L, reg.idleMillis(), "idle counts from the last activity once unleased")
+      }
+  }
+
+  @Test
   fun `close releases every resident host and rejects further acquire`() {
     val reg =
       ServeSessionRegistry(open = Opener(), factory = CountingFactory(), reaperIntervalMillis = 0)


### PR DESCRIPTION
## Summary

Adds an **ephemeral / single-session lifecycle**: `serve --exit-when-idle[=<seconds>]` shuts the whole server down once it has been idle — no open connections and no requests — for the window (default 60s; a small value ≈ "exit shortly after the last client disconnects"). For short-lived / on-demand / CI use, so an ephemeral server cleans itself up instead of running until Ctrl-C.

Distinct from suspend/resume (#2017): that keeps the *server* up and releases idle *daemons*; this terminates the whole *process*.

- `ServeSessionRegistry` tracks server-level activity (acquire/lease/release) and exposes `idleMillis()` — `null` while any session is leased (a live connection), otherwise time since the last activity.
- `ServeCommand` starts a daemon watchdog that releases the run latch when idle crosses the threshold, so `run()` returns and the existing shutdown hook tears the server + daemons down.

Off by default (runs until Ctrl-C). Implements the ephemeral mode tracked in #2021.

## Test plan
- `ktfmtFormatAll` clean; `:cli:compileKotlin` / `compileTestKotlin` green; `:cli:checkCliDaemonLibraryBoundary` green; `CliFlagsRegistryTest` green (flag registered as attached/optional).
- `ServeSessionRegistryTest`: `idleMillis()` is null while leased and grows from the last activity once unleased.

## Visual evidence
Non-visual — server lifecycle only. No page or rendered-output change.

---
_Generated by [Claude Code](https://claude.ai/code/session_0186JHWqw5dMvUJbfgDXgqGo)_