### PR TITLE
feat(cli): shared mode — host pre-rendered portable bundles

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
@@ -56,6 +56,7 @@ internal object CliFlags {
       "--port",
       "--token",
       "--export",
+      "--bundles",
       // Required-reason escape hatch. Usually written attached (`--force=<reason>`), but the space
       // form `--force <reason>` is supported (ForceFlagTest), so the reason must be skipped or it's
       // mistaken for the command.

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -4,6 +4,8 @@ import ee.schimke.composeai.cli.serve.GitWorktrees
 import ee.schimke.composeai.cli.serve.GradleRevisionBuilder
 import ee.schimke.composeai.cli.serve.RenderOutcome
 import ee.schimke.composeai.cli.serve.ServeBundle
+import ee.schimke.composeai.cli.serve.ServeBundleHost
+import ee.schimke.composeai.cli.serve.ServeHost
 import ee.schimke.composeai.cli.serve.ServeHttpServer
 import ee.schimke.composeai.cli.serve.ServeMdnsAdvertiser
 import ee.schimke.composeai.cli.serve.ServeModuleRef
@@ -67,6 +69,13 @@ class ServeCommand(args: List<String>) : Command(args) {
   private val idleExitSeconds: Long =
     args.flagValue("--exit-when-idle")?.toLongOrNull()?.takeIf { it > 0 }
       ?: DEFAULT_IDLE_EXIT_SECONDS
+
+  /**
+   * Shared mode: a directory of pre-rendered portable bundles (or a single bundle) to host
+   * read-only alongside the live session, each reachable at `?session=<bundle-name>`. No checkout
+   * or build — the bundle's `previews/<id>.png` files are served directly.
+   */
+  private val bundlesDir: String? = args.flagValue("--bundles")?.takeIf { it.isNotBlank() }
 
   override fun run() {
     if ("--help" in args || "-h" in args) {
@@ -143,7 +152,7 @@ class ServeCommand(args: List<String>) : Command(args) {
     // is
     // the default session; the registry suspends idle daemons and resumes them on demand from their
     // saved state, so a long-lived server doesn't keep daemons running forever.
-    val openHost: (ServeSessionState) -> ServeRenderHost? = { state ->
+    val openHost: (ServeSessionState) -> ServeHost? = { state ->
       runCatching {
           ServeRenderHost.open(
             descriptorPath = state.descriptor,
@@ -171,6 +180,13 @@ class ServeCommand(args: List<String>) : Command(args) {
         label = module.gradlePath,
       )
     registry.register(module.gradlePath, defaultState, host = renderHost)
+    // Shared mode: register any pre-rendered portable bundles under `--bundles <dir>` as read-only
+    // sessions (no daemon), reachable at ?session=<bundle-name>. Pinned — a bundle host is cheap
+    // and
+    // has nothing to reclaim, so it's never suspended.
+    registerBundles().forEach { (id, bundleHost) ->
+      registry.register(id, host = bundleHost, pinned = true)
+    }
     val server =
       ServeHttpServer(
         host = host,
@@ -284,6 +300,35 @@ class ServeCommand(args: List<String>) : Command(args) {
       module = ServeModuleRef(module.gradlePath, relativePath),
       onLog = { System.err.println("[serve] $it") },
     )
+  }
+
+  /**
+   * Discover portable bundles under `--bundles`. A directory that itself looks like a bundle is
+   * served under its own name; otherwise each immediate sub-directory that looks like a bundle
+   * becomes a session keyed by its name.
+   */
+  private fun registerBundles(): Map<String, ServeBundleHost> {
+    val root = bundlesDir?.let { File(it) }?.takeIf { it.isDirectory } ?: return emptyMap()
+    val result = LinkedHashMap<String, ServeBundleHost>()
+    if (ServeBundleHost.looksLikeBundle(root)) {
+      result[root.name] = ServeBundleHost(root, root.name)
+    } else {
+      root
+        .listFiles { f -> f.isDirectory }
+        ?.sortedBy { it.name }
+        ?.forEach { sub ->
+          if (ServeBundleHost.looksLikeBundle(sub))
+            result[sub.name] = ServeBundleHost(sub, sub.name)
+        }
+    }
+    if (result.isEmpty()) {
+      System.err.println("serve: --bundles ${root.path} held no bundles (previews/*.png).")
+    } else {
+      System.err.println(
+        "serve: serving ${result.size} bundle session(s): ${result.keys.joinToString(", ")}"
+      )
+    }
+    return result
   }
 
   /**
@@ -407,6 +452,9 @@ class ServeCommand(args: List<String>) : Command(args) {
                           Ephemeral mode: shut the server down once it's been idle (no open
                           connections and no requests) for <seconds> (default ${DEFAULT_IDLE_EXIT_SECONDS}s). Use a small
                           value to exit shortly after the last client disconnects.
+        --bundles <dir>   Shared mode: also host pre-rendered portable bundles (no build/daemon). A
+                          bundle dir, or a directory of them, is served read-only — each reachable at
+                          ?session=<bundle-name>. Bundles are what --export / GET /bundle.zip produce.
 
       The shareable link carries an unguessable token; requests without it get 404.
       """

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
@@ -20,10 +20,15 @@ class ServeBundleHost(private val bundleDir: File, override val label: String) :
   private val previewsDir = File(bundleDir, PREVIEWS_SUBDIR)
 
   override val previews: List<ServePreview> =
-    (previewsDir.listFiles { f -> f.isFile && f.name.endsWith(PNG_SUFFIX) } ?: emptyArray())
-      .map { it.name.removeSuffix(PNG_SUFFIX) }
+    // Walk recursively: a preview id may contain '/', stored as a nested `previews/<id>.png`. Ids
+    // are reconstructed relative to `previews/` with '/' separators (matching the bundle layout).
+    previewsDir
+      .walkTopDown()
+      .filter { it.isFile && it.name.endsWith(PNG_SUFFIX) }
+      .map { it.relativeTo(previewsDir).invariantSeparatorsPath.removeSuffix(PNG_SUFFIX) }
       .sorted()
       .map { id -> ServePreview(id = id, label = id) }
+      .toList()
 
   private val previewIds: Set<String> = previews.map { it.id }.toHashSet()
 
@@ -55,8 +60,11 @@ class ServeBundleHost(private val bundleDir: File, override val label: String) :
     private const val PREVIEWS_SUBDIR = "previews"
     private const val PNG_SUFFIX = ".png"
 
-    /** True when [dir] looks like a servable bundle (has a non-empty `previews/` directory). */
-    fun looksLikeBundle(dir: File): Boolean =
-      File(dir, PREVIEWS_SUBDIR).listFiles()?.any { it.name.endsWith(PNG_SUFFIX) } == true
+    /** True when [dir] looks like a servable bundle (a `previews/` tree with at least one PNG). */
+    fun looksLikeBundle(dir: File): Boolean {
+      val previews = File(dir, PREVIEWS_SUBDIR)
+      return previews.isDirectory &&
+        previews.walkTopDown().any { it.isFile && it.name.endsWith(PNG_SUFFIX) }
+    }
   }
 }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
@@ -1,0 +1,62 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.daemon.protocol.StreamCodec
+import ee.schimke.composeai.daemon.protocol.StreamFrameParams
+import java.io.File
+
+/**
+ * A [ServeHost] backed by a **portable bundle** on disk (the `ServeBundle` / WebEmbed layout:
+ * `previews/<id>.png` beside an `index.html`), not a daemon. This is the shared/public mode: a
+ * pre-rendered bundle is uploaded once and served read-only, with no checkout, build, or render
+ * session. Overrides are ignored (the bundle is whatever was baked); there is no live stream lane,
+ * so connections transparently use the snapshot fallback that returns these PNGs.
+ *
+ * Cheap and stateless (just file reads), so the registry pins it resident rather than suspending
+ * it.
+ */
+class ServeBundleHost(private val bundleDir: File, override val label: String) : ServeHost {
+
+  private val previewsDir = File(bundleDir, PREVIEWS_SUBDIR)
+
+  override val previews: List<ServePreview> =
+    (previewsDir.listFiles { f -> f.isFile && f.name.endsWith(PNG_SUFFIX) } ?: emptyArray())
+      .map { it.name.removeSuffix(PNG_SUFFIX) }
+      .sorted()
+      .map { id -> ServePreview(id = id, label = id) }
+
+  private val previewIds: Set<String> = previews.map { it.id }.toHashSet()
+
+  override fun render(previewId: String, overrides: PreviewOverrides): RenderOutcome {
+    if (previewId !in previewIds) return RenderOutcome.NotFound
+    val png = File(previewsDir, "$previewId$PNG_SUFFIX")
+    if (!png.isFile) return RenderOutcome.NotFound
+    return RenderOutcome.Ok(png.readBytes())
+  }
+
+  /**
+   * A bundle has no daemon, so no live lane — callers fall back to the snapshot ([render]) lane.
+   */
+  override fun subscribeStream(
+    previewId: String,
+    overrides: PreviewOverrides,
+    codec: StreamCodec?,
+    maxFps: Int?,
+    onFrame: (StreamFrameParams) -> Unit,
+  ): StreamHandle? = null
+
+  override fun activeStreamCount(): Int = 0
+
+  override fun close() {
+    // Nothing to release — a bundle host owns no daemon or sockets.
+  }
+
+  companion object {
+    private const val PREVIEWS_SUBDIR = "previews"
+    private const val PNG_SUFFIX = ".png"
+
+    /** True when [dir] looks like a servable bundle (has a non-empty `previews/` directory). */
+    fun looksLikeBundle(dir: File): Boolean =
+      File(dir, PREVIEWS_SUBDIR).listFiles()?.any { it.name.endsWith(PNG_SUFFIX) } == true
+  }
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHost.kt
@@ -1,0 +1,40 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.daemon.protocol.StreamCodec
+import ee.schimke.composeai.daemon.protocol.StreamFrameParams
+
+/**
+ * A servable preview session behind the multi-tenant registry + HTTP layer. Two implementations:
+ * - [ServeRenderHost] — live daemon-backed snapshot renders + a streaming lane;
+ * - [ServeBundleHost] — a static, pre-rendered portable bundle (no daemon), for the shared/public
+ *   "host bundles, don't build" mode.
+ *
+ * The HTTP routes and the registry only need this surface, so either kind can be served at
+ * `?session=<id>` uniformly.
+ */
+interface ServeHost : AutoCloseable {
+  /** The whole servable preview set for this session. */
+  val previews: List<ServePreview>
+
+  /** Human label for the tenant (module Gradle path, `module@rev`, or a bundle name). */
+  val label: String
+
+  /** Render [previewId] at [overrides] (cached where possible). */
+  fun render(previewId: String, overrides: PreviewOverrides): RenderOutcome
+
+  /**
+   * Join the shared live stream for [previewId], or `null` when this host has no live lane (the
+   * snapshot fallback is used instead — always the case for [ServeBundleHost]).
+   */
+  fun subscribeStream(
+    previewId: String,
+    overrides: PreviewOverrides,
+    codec: StreamCodec?,
+    maxFps: Int?,
+    onFrame: (StreamFrameParams) -> Unit,
+  ): StreamHandle?
+
+  /** Count of live upstream streams (0 for hosts without a live lane). */
+  fun activeStreamCount(): Int
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -265,7 +265,7 @@ class ServeHttpServer(
    * reaper can't suspend the daemon mid-request (e.g. a long `/bundle.zip` that renders every
    * preview). Responds 404 when the session can't be created/opened. The lease is always released.
    */
-  private suspend fun RoutingContext.withLeasedSession(block: suspend (ServeRenderHost) -> Unit) {
+  private suspend fun RoutingContext.withLeasedSession(block: suspend (ServeHost) -> Unit) {
     val sessionId = call.request.queryParameters["session"] ?: defaultSessionId
     val lease = withContext(Dispatchers.IO) { sessions.lease(sessionId) }
     if (lease == null) {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeLiveSession.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeLiveSession.kt
@@ -17,7 +17,7 @@ import ee.schimke.composeai.daemon.protocol.StreamFrameParams
  */
 class ServeLiveSession
 private constructor(
-  private val renderHost: ServeRenderHost,
+  private val renderHost: ServeHost,
   private var previewId: String,
   private var overrides: Map<String, String>,
   private val codec: StreamCodec?,
@@ -133,7 +133,7 @@ private constructor(
      * preview's defaults (the bad value would otherwise block the whole live session at connect).
      */
     fun tryStart(
-      renderHost: ServeRenderHost,
+      renderHost: ServeHost,
       previewId: String,
       overrides: Map<String, String>,
       codec: StreamCodec? = null,

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
@@ -81,13 +81,13 @@ sealed interface RenderOutcome {
 class ServeRenderHost
 internal constructor(
   private val session: RenderSession,
-  val previews: List<ServePreview>,
+  override val previews: List<ServePreview>,
   /** Human label for this tenant (e.g. the module's Gradle path); shown in the served pages. */
-  val label: String = "",
+  override val label: String = "",
   private val fileSystem: FileSystem = SystemFileSystem,
   private val onLog: (String) -> Unit = {},
   private val renderTimeoutSeconds: Long = RENDER_TIMEOUT_SECONDS,
-) : AutoCloseable {
+) : ServeHost {
 
   private val previewIds: Set<String> = previews.map { it.id }.toHashSet()
 
@@ -139,7 +139,7 @@ internal constructor(
   }
 
   /** Render [previewId] at [overrides], serving a cached result when one exists. Thread-safe. */
-  fun render(previewId: String, overrides: PreviewOverrides): RenderOutcome {
+  override fun render(previewId: String, overrides: PreviewOverrides): RenderOutcome {
     check(!closed.get()) { "ServeRenderHost is closed" }
     if (previewId !in previewIds) return RenderOutcome.NotFound
 
@@ -329,11 +329,11 @@ internal constructor(
    * connections so N viewers of the same preview ride one held session. Returns `null` when
    * streaming is unsupported (caller falls back to the snapshot lane).
    */
-  fun subscribeStream(
+  override fun subscribeStream(
     previewId: String,
     overrides: PreviewOverrides,
-    codec: StreamCodec? = null,
-    maxFps: Int? = null,
+    codec: StreamCodec?,
+    maxFps: Int?,
     onFrame: (StreamFrameParams) -> Unit,
   ): StreamHandle? {
     check(!closed.get()) { "ServeRenderHost is closed" }
@@ -341,7 +341,7 @@ internal constructor(
   }
 
   /** Live shared upstream streams (one per distinct preview/overrides/codec/fps). Diagnostics. */
-  fun activeStreamCount(): Int = broadcast.activeStreamCount()
+  override fun activeStreamCount(): Int = broadcast.activeStreamCount()
 
   override fun close() {
     if (!closed.compareAndSet(false, true)) return

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistry.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistry.kt
@@ -32,7 +32,7 @@ fun interface ServeSessionFactory {
  * streams. Concurrency-safe: at most one build per id under racing callers.
  */
 class ServeSessionRegistry(
-  private val open: (ServeSessionState) -> ServeRenderHost?,
+  private val open: (ServeSessionState) -> ServeHost?,
   private val factory: ServeSessionFactory = ServeSessionFactory { null },
   private val idleTimeoutMillis: Long = DEFAULT_IDLE_TIMEOUT_MILLIS,
   reaperIntervalMillis: Long = idleTimeoutMillis,
@@ -40,16 +40,19 @@ class ServeSessionRegistry(
 ) : AutoCloseable {
 
   private class Entry(
-    val state: ServeSessionState,
-    /** The live daemon host, or null while suspended. */
-    @Volatile var host: ServeRenderHost?,
+    /** How to (re)open the host on resume; null for pinned sessions that are never suspended. */
+    val state: ServeSessionState?,
+    /** The live host, or null while suspended. */
+    @Volatile var host: ServeHost?,
+    /** Pinned sessions (e.g. static bundle hosts — no daemon to reclaim) are never suspended. */
+    val pinned: Boolean,
     @Volatile var lastAccess: Long,
     /** Open long-lived holders (e.g. WebSocket connections) keeping this session resident. */
     @Volatile var leases: Int = 0,
   )
 
   /** A live hold on a session that keeps it from being suspended until [close] (idempotent). */
-  class Lease internal constructor(val host: ServeRenderHost, private val onRelease: () -> Unit) :
+  class Lease internal constructor(val host: ServeHost, private val onRelease: () -> Unit) :
     AutoCloseable {
     private val released = AtomicBoolean(false)
 
@@ -91,10 +94,15 @@ class ServeSessionRegistry(
    * already-open [host]. Replaces any prior entry. The session participates in suspend/resume like
    * a forked one — its daemon is released when idle and reopened from [state] on demand.
    */
-  fun register(sessionId: String, state: ServeSessionState, host: ServeRenderHost? = null) {
+  fun register(
+    sessionId: String,
+    state: ServeSessionState? = null,
+    host: ServeHost? = null,
+    pinned: Boolean = false,
+  ) {
     lock.withLock {
       check(!closed) { "ServeSessionRegistry is closed" }
-      sessions[sessionId] = Entry(state, host, lastAccess = clock())
+      sessions[sessionId] = Entry(state, host, pinned, lastAccess = clock())
     }
   }
 
@@ -103,7 +111,7 @@ class ServeSessionRegistry(
    * [factory]. Returns `null` when the session can't be created/opened, so the caller can 404.
    * Touches the idle clock.
    */
-  fun acquire(sessionId: String): ServeRenderHost? = lock.withLock {
+  fun acquire(sessionId: String): ServeHost? = lock.withLock {
     check(!closed) { "ServeSessionRegistry is closed" }
     val entry = entryFor(sessionId) ?: return null
     entry.lastAccess = clock()
@@ -149,7 +157,8 @@ class ServeSessionRegistry(
     for (entry in sessions.values) {
       val host = entry.host ?: continue
       if (
-        entry.leases == 0 &&
+        !entry.pinned &&
+          entry.leases == 0 &&
           host.activeStreamCount() == 0 &&
           now - entry.lastAccess >= idleTimeoutMillis
       ) {
@@ -186,15 +195,18 @@ class ServeSessionRegistry(
     // is
     // slow, but a shared dev/CI server has few tenants and correctness beats build concurrency.
     val state = factory.create(sessionId) ?: return null
-    return Entry(state, host = null, lastAccess = clock()).also { sessions[sessionId] = it }
+    return Entry(state, host = null, pinned = false, lastAccess = clock()).also {
+      sessions[sessionId] = it
+    }
   }
 
   /** The entry's live host, resuming (re-opening) from its state if it was suspended. */
-  private fun liveHost(entry: Entry): ServeRenderHost? {
+  private fun liveHost(entry: Entry): ServeHost? {
     entry.host?.let {
       return it
     }
-    val resumed = open(entry.state) ?: return null
+    val state = entry.state ?: return null
+    val resumed = open(state) ?: return null
     entry.host = resumed
     return resumed
   }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeStreamSession.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeStreamSession.kt
@@ -18,7 +18,7 @@ import java.util.concurrent.atomic.AtomicLong
  * also arrive *unprompted* as the composition changes) without changing [send]'s wire shape.
  */
 class ServeStreamSession(
-  private val renderHost: ServeRenderHost,
+  private val renderHost: ServeHost,
   previewId: String,
   initialOverrides: Map<String, String> = emptyMap(),
   private val send: (String) -> Unit,

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHostTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHostTest.kt
@@ -14,8 +14,18 @@ class ServeBundleHostTest {
     val dir = java.nio.file.Files.createTempDirectory("bundle").toFile().also { it.deleteOnExit() }
     File(dir, "index.html").writeText("<html></html>")
     val previewsDir = File(dir, "previews").apply { mkdirs() }
-    previews.forEach { (id, png) -> File(previewsDir, "$id.png").writeBytes(png) }
+    previews.forEach { (id, png) ->
+      File(previewsDir, "$id.png").apply { parentFile?.mkdirs() }.writeBytes(png)
+    }
     return dir
+  }
+
+  @Test
+  fun `nested preview ids (with slashes) are discovered and rendered`() {
+    val host = ServeBundleHost(bundle("group/com.example.Red" to byteArrayOf(4, 2)), label = "b")
+    assertEquals(listOf("group/com.example.Red"), host.previews.map { it.id })
+    val ok = host.render("group/com.example.Red", PreviewOverrides()) as RenderOutcome.Ok
+    assertTrue(byteArrayOf(4, 2).contentEquals(ok.png))
   }
 
   @Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHostTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHostTest.kt
@@ -1,0 +1,55 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class ServeBundleHostTest {
+
+  private fun bundle(vararg previews: Pair<String, ByteArray>): File {
+    val dir = java.nio.file.Files.createTempDirectory("bundle").toFile().also { it.deleteOnExit() }
+    File(dir, "index.html").writeText("<html></html>")
+    val previewsDir = File(dir, "previews").apply { mkdirs() }
+    previews.forEach { (id, png) -> File(previewsDir, "$id.png").writeBytes(png) }
+    return dir
+  }
+
+  @Test
+  fun `previews are discovered from the bundle's png files, sorted`() {
+    val host =
+      ServeBundleHost(
+        bundle("com.example.Red" to byteArrayOf(1), "com.example.Blue" to byteArrayOf(2)),
+        label = "demo@abc",
+      )
+    assertEquals(listOf("com.example.Blue", "com.example.Red"), host.previews.map { it.id })
+    assertEquals("demo@abc", host.label)
+  }
+
+  @Test
+  fun `render returns the baked png and NotFound for unknown ids`() {
+    val host = ServeBundleHost(bundle("com.example.Red" to byteArrayOf(9, 8, 7)), label = "b")
+
+    val ok = host.render("com.example.Red", PreviewOverrides()) as RenderOutcome.Ok
+    assertTrue(byteArrayOf(9, 8, 7).contentEquals(ok.png))
+    assertEquals(RenderOutcome.NotFound, host.render("com.example.Missing", PreviewOverrides()))
+  }
+
+  @Test
+  fun `a bundle host has no live lane`() {
+    val host = ServeBundleHost(bundle("p" to byteArrayOf(1)), label = "b")
+    assertNull(host.subscribeStream("p", PreviewOverrides(), null, null) {})
+    assertEquals(0, host.activeStreamCount())
+    host.close() // no-op, must not throw
+  }
+
+  @Test
+  fun `looksLikeBundle detects a previews directory with pngs`() {
+    assertTrue(ServeBundleHost.looksLikeBundle(bundle("p" to byteArrayOf(1))))
+    val empty = java.nio.file.Files.createTempDirectory("empty").toFile().also { it.deleteOnExit() }
+    assertFalse(ServeBundleHost.looksLikeBundle(empty))
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistryTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistryTest.kt
@@ -159,7 +159,8 @@ class ServeSessionRegistryTest {
       )
       .use { reg ->
         val host = assertNotNull(reg.acquire("a"))
-        val handle = assertNotNull(host.subscribeStream(previewId, PreviewOverrides()) {})
+        val handle =
+          assertNotNull(host.subscribeStream(previewId, PreviewOverrides(), null, null) {})
         clock.set(10_000)
         assertEquals(0, reg.suspendIdle(), "a host with a live watcher must stay resident")
         handle.close()


### PR DESCRIPTION
## Summary

Adds **shared/public mode**: `serve --bundles <dir>` hosts pre-rendered **portable bundles** read-only alongside the live session, each reachable at `?session=<bundle-name>` — with **no checkout, build, or daemon**. This is the deployable, static surface (the difference from project mode, which forks a live daemon per revision): a bundle is rendered once and just served.

- **`ServeHost` interface** extracted (previews, label, render, subscribeStream, activeStreamCount, close), implemented by the existing `ServeRenderHost`. The registry and HTTP routes now work against it, so any host kind serves uniformly at `?session=`.
- **`ServeBundleHost`** serves a bundle's `previews/<id>.png` directly (the `ServeBundle`/WebEmbed layout that `--export` / `GET /bundle.zip` already produce). Overrides are ignored; no live lane, so connections transparently use the snapshot fallback that returns the baked PNG.
- **Registry `pinned` flag**: a bundle host is cheap and has no daemon to reclaim, so it's registered pinned (never suspended); daemon sessions remain suspendable. `state` is nullable for pinned sessions.
- **`ServeCommand`** registers each bundle under `--bundles` (a single bundle dir, or a directory of them) keyed by its name.

Off by default. Implements the shared/public mode tracked in #2020.

## Test plan
- `ktfmtFormatAll` clean; full **`:cli:test`** green (the `ServeHost` refactor touches the registry, HTTP, and both session lanes — the whole suite passing confirms no regression); `:cli:checkCliDaemonLibraryBoundary` green.
- New `ServeBundleHostTest`: previews discovered from `previews/*.png` (sorted), `render` returns the baked PNG / `NotFound`, no live lane, `looksLikeBundle` detection.
- `CliFlagsRegistryTest` green (`--bundles` registered as a value flag).

## Visual evidence
Non-visual — host/registry plumbing. Served pages and rendered output are unchanged (a bundle session serves the PNGs that were already rendered into the bundle).

---
_Generated by [Claude Code](https://claude.ai/code/session_0186JHWqw5dMvUJbfgDXgqGo)_