### PR TITLE
test(renderer): fix stale layout/inspector schema assertion (expected 1, now 2)

### DIFF
--- a/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/LayoutInspectorFixtureTest.kt
+++ b/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/LayoutInspectorFixtureTest.kt
@@ -107,11 +107,13 @@ class LayoutInspectorFixtureTest {
   }
 
   @Test
-  fun `registry capability advertises layout-inspector at schema 1 and path transport`() {
+  fun `registry capability advertises layout-inspector at its current schema and path transport`() {
     val registry = LayoutInspectorDataProductRegistry(rootDir)
     val cap = registry.capabilities.single()
     assertEquals("layout/inspector", cap.kind)
-    assertEquals(1, cap.schemaVersion)
+    // Assert against the producer's constant rather than a literal so a deliberate schema bump
+    // (e.g. #1941 / #1945) updates the contract in one place instead of rotting this test.
+    assertEquals(LayoutInspectorDataProducer.SCHEMA_VERSION, cap.schemaVersion)
     assertTrue(cap.attachable)
     assertTrue(cap.fetchable)
   }


### PR DESCRIPTION
## What

`LayoutInspectorFixtureTest` is failing on `main`:

```
registry capability advertises layout-inspector at schema 1 and path transport
java.lang.AssertionError: expected:<1> but was:<2>  (LayoutInspectorFixtureTest.kt:114)
```

The `layout/inspector` product schema was bumped to **2** (`LayoutInspectorProduct.SCHEMA_VERSION`; the `feat!` consolidation in #1941 / #1945), but the test still hard-coded `assertEquals(1, cap.schemaVersion)`.

## Fix

Assert against `LayoutInspectorDataProducer.SCHEMA_VERSION` instead of a literal (and rename the test off "schema 1"), matching the pattern the UiAutomator / Navigation registry tests already use — so a deliberate schema bump updates the contract in one place rather than rotting this test.

## Test plan

- `:renderer-android:testDebugUnitTest --tests "*LayoutInspectorFixtureTest*"` → green.
- `ktfmt` clean.

Test-only change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FWArgtvAa6qagyCFSwP1nw)_