### PR TITLE
feat(cli): accept client-contributed bundles at runtime (shared/public mode)

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
@@ -57,6 +57,7 @@ internal object CliFlags {
       "--token",
       "--export",
       "--bundles",
+      "--accept-bundles-from",
       // Required-reason escape hatch. Usually written attached (`--force=<reason>`), but the space
       // form `--force <reason>` is supported (ForceFlagTest), so the reason must be skipped or it's
       // mistaken for the command.

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -85,6 +85,18 @@ class ServeCommand(args: List<String>) : Command(args) {
    */
   private val acceptBundles: Boolean = "--accept-bundles" in args
 
+  /**
+   * SSRF allowlist for `POST /bundles/{name}?url=` fetches: comma-separated hostnames the server
+   * may fetch a bundle from. Empty = no URL fetch is allowed (fail closed), so `--accept-bundles`
+   * alone only accepts uploads; a host must be explicitly trusted before the server will reach out.
+   */
+  private val acceptBundlesFrom: List<String> =
+    args
+      .flagValue("--accept-bundles-from")
+      ?.split(",")
+      ?.map { it.trim() }
+      ?.filter { it.isNotEmpty() } ?: emptyList()
+
   override fun run() {
     if ("--help" in args || "-h" in args) {
       printUsage()
@@ -203,9 +215,16 @@ class ServeCommand(args: List<String>) : Command(args) {
           java.nio.file.Files.createTempDirectory("serve-uploads").toFile().also {
             it.deleteOnExit()
           }
+        if (acceptBundlesFrom.isEmpty()) {
+          System.err.println(
+            "serve: --accept-bundles accepts uploads only; no ?url= host is allowed (SSRF fail " +
+              "closed). Pass --accept-bundles-from <host>[,<host>…] to permit URL fetches."
+          )
+        }
         ServeBundleStore(
           root = uploads,
           register = { id, bundleHost -> registry.register(id, host = bundleHost, pinned = true) },
+          allowedHosts = acceptBundlesFrom,
         )
       } else {
         null
@@ -482,7 +501,11 @@ class ServeCommand(args: List<String>) : Command(args) {
         --accept-bundles  Shared mode (public): enable POST /bundles/<name> so clients can contribute
                           bundles at runtime — upload the zip as the body, or pass ?url=<link> to a
                           build-results artifact. Pair with --lan + a strong --token for a shared
-                          instance; the server then fetches the URL you give it (SSRF — trust the token).
+                          instance. Uploads only by default; ?url= fetches need --accept-bundles-from.
+        --accept-bundles-from <host>[,<host>…]
+                          SSRF allowlist for POST /bundles?url=: hostnames the server may fetch a
+                          bundle from. Omitted/empty = no URL fetch is allowed (fail closed), so a
+                          client can't steer the server at an arbitrary or internal address.
 
       The shareable link carries an unguessable token; requests without it get 404.
       """

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -5,6 +5,7 @@ import ee.schimke.composeai.cli.serve.GradleRevisionBuilder
 import ee.schimke.composeai.cli.serve.RenderOutcome
 import ee.schimke.composeai.cli.serve.ServeBundle
 import ee.schimke.composeai.cli.serve.ServeBundleHost
+import ee.schimke.composeai.cli.serve.ServeBundleStore
 import ee.schimke.composeai.cli.serve.ServeHost
 import ee.schimke.composeai.cli.serve.ServeHttpServer
 import ee.schimke.composeai.cli.serve.ServeMdnsAdvertiser
@@ -76,6 +77,13 @@ class ServeCommand(args: List<String>) : Command(args) {
    * or build — the bundle's `previews/<id>.png` files are served directly.
    */
   private val bundlesDir: String? = args.flagValue("--bundles")?.takeIf { it.isNotBlank() }
+
+  /**
+   * Shared/public mode ingestion: enable `POST /bundles/{name}` so clients can contribute bundles
+   * at runtime — upload a zip, or pass `?url=` to a build-results artifact. Off by default;
+   * intended for a deployed shared instance (combine with `--lan` + a strong `--token`).
+   */
+  private val acceptBundles: Boolean = "--accept-bundles" in args
 
   override fun run() {
     if ("--help" in args || "-h" in args) {
@@ -187,6 +195,21 @@ class ServeCommand(args: List<String>) : Command(args) {
     registerBundles().forEach { (id, bundleHost) ->
       registry.register(id, host = bundleHost, pinned = true)
     }
+    // Runtime ingestion (--accept-bundles): clients POST a bundle (or a ?url= to one) and it's
+    // registered as a pinned session. Unpacked under a temp dir for this server's lifetime.
+    val bundleStore =
+      if (acceptBundles) {
+        val uploads =
+          java.nio.file.Files.createTempDirectory("serve-uploads").toFile().also {
+            it.deleteOnExit()
+          }
+        ServeBundleStore(
+          root = uploads,
+          register = { id, bundleHost -> registry.register(id, host = bundleHost, pinned = true) },
+        )
+      } else {
+        null
+      }
     val server =
       ServeHttpServer(
         host = host,
@@ -194,6 +217,7 @@ class ServeCommand(args: List<String>) : Command(args) {
         token = token,
         sessions = registry,
         defaultSessionId = module.gradlePath,
+        bundleStore = bundleStore,
       )
 
     // Advertise on the LAN over mDNS when bound to a reachable interface (`--lan`), so the mobile /
@@ -455,6 +479,10 @@ class ServeCommand(args: List<String>) : Command(args) {
         --bundles <dir>   Shared mode: also host pre-rendered portable bundles (no build/daemon). A
                           bundle dir, or a directory of them, is served read-only — each reachable at
                           ?session=<bundle-name>. Bundles are what --export / GET /bundle.zip produce.
+        --accept-bundles  Shared mode (public): enable POST /bundles/<name> so clients can contribute
+                          bundles at runtime — upload the zip as the body, or pass ?url=<link> to a
+                          build-results artifact. Pair with --lan + a strong --token for a shared
+                          instance; the server then fetches the URL you give it (SSRF — trust the token).
 
       The shareable link carries an unguessable token; requests without it get 404.
       """

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleStore.kt
@@ -1,7 +1,9 @@
 package ee.schimke.composeai.cli.serve
 
 import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
 import java.io.File
+import java.io.InputStream
 import java.net.URI
 import java.util.zip.ZipInputStream
 
@@ -81,11 +83,10 @@ class ServeBundleStore(
           val target = File(dir, name)
           // Zip-slip guard: the resolved path must stay under the bundle dir.
           if (target.canonicalFile.toPath().startsWith(rootPath)) {
-            val bytes = zin.readBytes()
-            total += bytes.size
-            check(total <= maxBytes) { "bundle exceeds ${maxBytes / (1024 * 1024)}MB" }
             target.parentFile?.mkdirs()
-            target.writeBytes(bytes)
+            // Copy in bounded chunks so a huge / zip-bomb entry can't be fully allocated before the
+            // cap rejects it — abort the moment the running total crosses maxBytes.
+            total += copyCapped(zin, target, remaining = maxBytes - total)
             count++
           }
         }
@@ -96,6 +97,22 @@ class ServeBundleStore(
     return count
   }
 
+  /** Stream [input] into [target], throwing once more than [remaining] bytes have been written. */
+  private fun copyCapped(input: InputStream, target: File, remaining: Long): Long {
+    var written = 0L
+    val buffer = ByteArray(64 * 1024)
+    target.outputStream().use { out ->
+      while (true) {
+        val n = input.read(buffer)
+        if (n < 0) break
+        written += n
+        check(written <= remaining) { "bundle exceeds ${maxBytes / (1024 * 1024)}MB" }
+        out.write(buffer, 0, n)
+      }
+    }
+    return written
+  }
+
   companion object {
     private const val PREVIEWS_SUBDIR = "previews"
     private const val PNG_SUFFIX = ".png"
@@ -104,7 +121,11 @@ class ServeBundleStore(
     /** A session name safe to use as a path segment + URL value; null if it can't be made safe. */
     fun sanitizeName(name: String): String? {
       val trimmed = name.trim()
-      return trimmed.takeIf { it.isNotEmpty() && it.matches(Regex("[A-Za-z0-9._@-]{1,128}")) }
+      // Reject empty and dot-only names ('.', '..', '...') even though they match the char class:
+      // File(root, ".")/File(root, "..") resolve to the upload root or its parent, and add() calls
+      // deleteRecursively() on that path before unpacking — which would wipe the wrong directory.
+      if (trimmed.isEmpty() || trimmed.all { it == '.' }) return null
+      return trimmed.takeIf { it.matches(Regex("[A-Za-z0-9._@-]{1,128}")) }
     }
 
     /** Default URL fetcher: http/https only, capped + time-bounded. SSRF is the operator's call. */
@@ -114,7 +135,24 @@ class ServeBundleStore(
       val conn = uri.toURL().openConnection()
       conn.connectTimeout = 10_000
       conn.readTimeout = 30_000
-      return conn.getInputStream().use { it.readBytes() }
+      return conn.getInputStream().use { readCapped(it, DEFAULT_MAX_BYTES) }
+    }
+
+    /**
+     * Read at most [max] bytes into memory, aborting (not buffering further) once it's exceeded.
+     */
+    private fun readCapped(input: InputStream, max: Long): ByteArray {
+      val out = ByteArrayOutputStream()
+      val buffer = ByteArray(64 * 1024)
+      var total = 0L
+      while (true) {
+        val n = input.read(buffer)
+        if (n < 0) break
+        total += n
+        require(total <= max) { "remote bundle exceeds ${max / (1024 * 1024)}MB" }
+        out.write(buffer, 0, n)
+      }
+      return out.toByteArray()
     }
   }
 }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleStore.kt
@@ -19,14 +19,23 @@ import okhttp3.Request
  *
  * Safety: only `previews/<id>.png` entries are extracted (everything else in the zip is ignored),
  * each written under a per-bundle directory with a zip-slip containment check, and the total
- * extracted size is capped. [fetch] (the URL case) is injected so it can be stubbed in tests and
- * gated/over policy in production (SSRF: a public server fetching arbitrary URLs).
+ * extracted size is capped. The URL case ([addFromUrl]) is an **SSRF** surface — a public server
+ * fetching arbitrary URLs could be steered at internal metadata/services — so it is gated by
+ * [allowedHosts]: only a URL whose host is on that operator-supplied allowlist is fetched, and an
+ * empty allowlist refuses every URL (fail closed). [fetch] is injected so it can be stubbed in
+ * tests; the host gate runs in [addFromUrl] regardless of which fetcher is wired.
  */
 class ServeBundleStore(
   private val root: File,
   private val register: (name: String, host: ServeBundleHost) -> Unit,
   private val fetch: (String) -> ByteArray? = ::httpFetch,
   private val maxBytes: Long = DEFAULT_MAX_BYTES,
+  /**
+   * SSRF allowlist for [addFromUrl]: hostnames (case-insensitive, exact match) a `?url=` fetch is
+   * permitted to reach. Empty = no URL fetch is allowed (fail closed), so enabling
+   * `--accept-bundles` alone never lets a client make the server fetch an arbitrary address.
+   */
+  private val allowedHosts: List<String> = emptyList(),
 ) {
 
   sealed interface Result {
@@ -35,8 +44,15 @@ class ServeBundleStore(
     data class Failed(val reason: String) : Result
   }
 
-  /** Unpack [zipBytes] under [name] and register it as a bundle session. */
-  fun add(name: String, zipBytes: ByteArray): Result {
+  /**
+   * Unpack [zipBytes] under [name] and register it as a bundle session.
+   *
+   * [isSecurityChecked] is a required, greppable audit marker (no runtime enforcement): the caller
+   * passes `true` only once the request has cleared policy (here: token-gated `POST /bundles`). The
+   * unpack itself is defended in depth — name sanitisation, zip-slip containment, size cap — but
+   * the marker records that the *entry point* was authorised before risky bytes were processed.
+   */
+  fun add(name: String, zipBytes: ByteArray, isSecurityChecked: Boolean): Result {
     val safe = sanitizeName(name) ?: return Result.Failed("invalid bundle name: '$name'")
     val dir = File(root, safe)
     dir.deleteRecursively()
@@ -56,15 +72,41 @@ class ServeBundleStore(
     return Result.Ok(safe, host.previews.size)
   }
 
-  /** Fetch a bundle zip from [url] (the "link to build results" case), then [add] it. */
-  fun addFromUrl(name: String, url: String): Result {
+  /**
+   * Fetch a bundle zip from [url] (the "link to build results" case), then [add] it.
+   *
+   * SSRF gate: the URL must be http/https and its host must be on [allowedHosts] (empty = refuse
+   * everything), checked here before [fetch] runs, so a client can't steer the server at an
+   * internal address. [isSecurityChecked] is the same documented audit marker as [add] — the caller
+   * asserts the entry point was authorised (token-gated). The host allowlist is the actual SSRF
+   * enforcement.
+   */
+  fun addFromUrl(name: String, url: String, isSecurityChecked: Boolean): Result {
+    if (!isAllowedUrl(url)) {
+      return Result.Failed(
+        "refusing to fetch $url: host is not on the --accept-bundles-from allowlist"
+      )
+    }
     val bytes =
       try {
         fetch(url)
       } catch (e: Exception) {
         return Result.Failed("could not fetch $url: ${e.message}")
       } ?: return Result.Failed("could not fetch $url")
-    return add(name, bytes)
+    return add(name, bytes, isSecurityChecked = isSecurityChecked)
+  }
+
+  /** True when [url] is http/https and its host is on the [allowedHosts] SSRF allowlist. */
+  private fun isAllowedUrl(url: String): Boolean {
+    val uri =
+      try {
+        URI(url)
+      } catch (e: Exception) {
+        return false
+      }
+    if (uri.scheme?.lowercase() !in setOf("http", "https")) return false
+    val host = uri.host?.lowercase() ?: return false
+    return allowedHosts.any { it.equals(host, ignoreCase = true) }
   }
 
   /** Extract only `previews/<id>.png` entries into [dir] (zip-slip safe, size-capped). */

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleStore.kt
@@ -1,0 +1,120 @@
+package ee.schimke.composeai.cli.serve
+
+import java.io.ByteArrayInputStream
+import java.io.File
+import java.net.URI
+import java.util.zip.ZipInputStream
+
+/**
+ * Runtime ingestion of **client-provided** portable bundles for the shared/public mode: a client
+ * uploads a bundle zip (or points at a URL of one — a CI "build results" artifact), and the store
+ * unpacks it and registers a read-only [ServeBundleHost] session via [register]. This is what makes
+ * a deployed public server useful without it building anything: clients contribute pre-rendered
+ * results and get a shareable `?session=<name>` link back.
+ *
+ * Safety: only `previews/<id>.png` entries are extracted (everything else in the zip is ignored),
+ * each written under a per-bundle directory with a zip-slip containment check, and the total
+ * extracted size is capped. [fetch] (the URL case) is injected so it can be stubbed in tests and
+ * gated/over policy in production (SSRF: a public server fetching arbitrary URLs).
+ */
+class ServeBundleStore(
+  private val root: File,
+  private val register: (name: String, host: ServeBundleHost) -> Unit,
+  private val fetch: (String) -> ByteArray? = ::httpFetch,
+  private val maxBytes: Long = DEFAULT_MAX_BYTES,
+) {
+
+  sealed interface Result {
+    data class Ok(val name: String, val previewCount: Int) : Result
+
+    data class Failed(val reason: String) : Result
+  }
+
+  /** Unpack [zipBytes] under [name] and register it as a bundle session. */
+  fun add(name: String, zipBytes: ByteArray): Result {
+    val safe = sanitizeName(name) ?: return Result.Failed("invalid bundle name: '$name'")
+    val dir = File(root, safe)
+    dir.deleteRecursively()
+    val count =
+      try {
+        extractPreviews(zipBytes, dir)
+      } catch (e: Exception) {
+        dir.deleteRecursively()
+        return Result.Failed("could not unpack bundle: ${e.message}")
+      }
+    if (count == 0) {
+      dir.deleteRecursively()
+      return Result.Failed("bundle had no previews/*.png entries")
+    }
+    val host = ServeBundleHost(dir, safe)
+    register(safe, host)
+    return Result.Ok(safe, host.previews.size)
+  }
+
+  /** Fetch a bundle zip from [url] (the "link to build results" case), then [add] it. */
+  fun addFromUrl(name: String, url: String): Result {
+    val bytes =
+      try {
+        fetch(url)
+      } catch (e: Exception) {
+        return Result.Failed("could not fetch $url: ${e.message}")
+      } ?: return Result.Failed("could not fetch $url")
+    return add(name, bytes)
+  }
+
+  /** Extract only `previews/<id>.png` entries into [dir] (zip-slip safe, size-capped). */
+  private fun extractPreviews(zipBytes: ByteArray, dir: File): Int {
+    val rootPath = dir.canonicalFile.toPath()
+    var count = 0
+    var total = 0L
+    ZipInputStream(ByteArrayInputStream(zipBytes)).use { zin ->
+      var entry = zin.nextEntry
+      while (entry != null) {
+        val name = entry.name.replace('\\', '/')
+        val segments = name.split("/")
+        val keep =
+          !entry.isDirectory &&
+            name.startsWith("$PREVIEWS_SUBDIR/") &&
+            name.endsWith(PNG_SUFFIX) &&
+            ".." !in segments
+        if (keep) {
+          val target = File(dir, name)
+          // Zip-slip guard: the resolved path must stay under the bundle dir.
+          if (target.canonicalFile.toPath().startsWith(rootPath)) {
+            val bytes = zin.readBytes()
+            total += bytes.size
+            check(total <= maxBytes) { "bundle exceeds ${maxBytes / (1024 * 1024)}MB" }
+            target.parentFile?.mkdirs()
+            target.writeBytes(bytes)
+            count++
+          }
+        }
+        zin.closeEntry()
+        entry = zin.nextEntry
+      }
+    }
+    return count
+  }
+
+  companion object {
+    private const val PREVIEWS_SUBDIR = "previews"
+    private const val PNG_SUFFIX = ".png"
+    private const val DEFAULT_MAX_BYTES = 100L * 1024 * 1024 // 100 MB
+
+    /** A session name safe to use as a path segment + URL value; null if it can't be made safe. */
+    fun sanitizeName(name: String): String? {
+      val trimmed = name.trim()
+      return trimmed.takeIf { it.isNotEmpty() && it.matches(Regex("[A-Za-z0-9._@-]{1,128}")) }
+    }
+
+    /** Default URL fetcher: http/https only, capped + time-bounded. SSRF is the operator's call. */
+    private fun httpFetch(url: String): ByteArray? {
+      val uri = URI(url)
+      if (uri.scheme?.lowercase() !in setOf("http", "https")) return null
+      val conn = uri.toURL().openConnection()
+      conn.connectTimeout = 10_000
+      conn.readTimeout = 30_000
+      return conn.getInputStream().use { it.readBytes() }
+    }
+  }
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleStore.kt
@@ -5,7 +5,10 @@ import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.InputStream
 import java.net.URI
+import java.util.concurrent.TimeUnit
 import java.util.zip.ZipInputStream
+import okhttp3.OkHttpClient
+import okhttp3.Request
 
 /**
  * Runtime ingestion of **client-provided** portable bundles for the shared/public mode: a client
@@ -128,14 +131,21 @@ class ServeBundleStore(
       return trimmed.takeIf { it.matches(Regex("[A-Za-z0-9._@-]{1,128}")) }
     }
 
+    private val httpClient: OkHttpClient by lazy {
+      OkHttpClient.Builder()
+        .connectTimeout(10, TimeUnit.SECONDS)
+        .readTimeout(30, TimeUnit.SECONDS)
+        .build()
+    }
+
     /** Default URL fetcher: http/https only, capped + time-bounded. SSRF is the operator's call. */
     private fun httpFetch(url: String): ByteArray? {
-      val uri = URI(url)
-      if (uri.scheme?.lowercase() !in setOf("http", "https")) return null
-      val conn = uri.toURL().openConnection()
-      conn.connectTimeout = 10_000
-      conn.readTimeout = 30_000
-      return conn.getInputStream().use { readCapped(it, DEFAULT_MAX_BYTES) }
+      if (URI(url).scheme?.lowercase() !in setOf("http", "https")) return null
+      httpClient.newCall(Request.Builder().url(url).build()).execute().use { response ->
+        if (!response.isSuccessful) return null
+        val body = response.body ?: return null
+        return readCapped(body.byteStream(), DEFAULT_MAX_BYTES)
+      }
     }
 
     /**

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -100,7 +100,12 @@ class ServeHttpServer(
               }
             val result =
               withContext(Dispatchers.IO) {
-                if (url != null) store.addFromUrl(name, url) else store.add(name, body!!)
+                // isSecurityChecked = true: this route is token-gated (rejectBadToken above) and
+                // the
+                // store still defends in depth (name sanitisation, zip-slip, size cap; SSRF host
+                // allowlist for the url case). The marker records the entry point was authorised.
+                if (url != null) store.addFromUrl(name, url, isSecurityChecked = true)
+                else store.add(name, body!!, isSecurityChecked = true)
               }
             when (result) {
               is ServeBundleStore.Result.Ok ->

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -8,10 +8,12 @@ import io.ktor.server.application.install
 import io.ktor.server.cio.CIO
 import io.ktor.server.engine.EmbeddedServer
 import io.ktor.server.engine.embeddedServer
+import io.ktor.server.request.receive
 import io.ktor.server.response.respondBytes
 import io.ktor.server.response.respondText
 import io.ktor.server.routing.RoutingContext
 import io.ktor.server.routing.get
+import io.ktor.server.routing.post
 import io.ktor.server.routing.routing
 import io.ktor.server.websocket.WebSockets
 import io.ktor.server.websocket.webSocket
@@ -51,6 +53,8 @@ class ServeHttpServer(
   private val token: String,
   private val sessions: ServeSessionRegistry,
   private val defaultSessionId: String,
+  /** When non-null, enables `POST /bundles/{name}` for clients to contribute bundles at runtime. */
+  private val bundleStore: ServeBundleStore? = null,
   portRange: Int = DEFAULT_PORT_RANGE,
 ) {
   /** The actual bound port — may differ from the requested one if it was taken (auto-picked). */
@@ -62,6 +66,43 @@ class ServeHttpServer(
       routing {
         // `/healthz` is the only ungated route — liveness only, leaks nothing.
         get("/healthz") { call.respondText("ok") }
+
+        // Shared/public mode ingestion: a client contributes a pre-rendered bundle (upload the zip
+        // as the body, or pass `?url=` to a build-results artifact) and gets back a ?session= link.
+        // Only registered when the operator opts in (a bundle store is supplied).
+        bundleStore?.let { store ->
+          post("/bundles/{name}") {
+            if (rejectBadToken()) return@post
+            val name = call.parameters["name"]
+            if (name.isNullOrBlank()) {
+              call.respondText("missing bundle name", status = HttpStatusCode.BadRequest)
+              return@post
+            }
+            val url = call.request.queryParameters["url"]
+            val body = if (url == null) call.receive<ByteArray>() else null
+            val result =
+              withContext(Dispatchers.IO) {
+                if (url != null) store.addFromUrl(name, url) else store.add(name, body!!)
+              }
+            when (result) {
+              is ServeBundleStore.Result.Ok ->
+                call.respondText(
+                  JSON.encodeToString(
+                    BundleAcceptedResponse.serializer(),
+                    BundleAcceptedResponse(
+                      session = result.name,
+                      previews = result.previewCount,
+                      path = "/?session=${result.name}",
+                    ),
+                  ),
+                  ContentType.Application.Json,
+                  HttpStatusCode.Created,
+                )
+              is ServeBundleStore.Result.Failed ->
+                call.respondText(result.reason, status = HttpStatusCode.BadRequest)
+            }
+          }
+        }
 
         // A persistent frame lane. The browser opens this, receives frames as JSON
         // ([ServeStreamProtocol]), and sends override / switch / input messages back. Token is
@@ -329,3 +370,12 @@ private data class PreviewsResponse(
 
 @Serializable
 private data class PreviewDto(val id: String, val label: String, val modes: List<String>)
+
+@Serializable
+private data class BundleAcceptedResponse(
+  val schema: String = "compose-preview-serve/bundle/v1",
+  val session: String,
+  val previews: Int,
+  /** Relative viewer link for the new session (append your token). */
+  val path: String,
+)

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -8,7 +8,7 @@ import io.ktor.server.application.install
 import io.ktor.server.cio.CIO
 import io.ktor.server.engine.EmbeddedServer
 import io.ktor.server.engine.embeddedServer
-import io.ktor.server.request.receive
+import io.ktor.server.request.receiveStream
 import io.ktor.server.response.respondBytes
 import io.ktor.server.response.respondText
 import io.ktor.server.routing.RoutingContext
@@ -21,6 +21,8 @@ import io.ktor.websocket.CloseReason
 import io.ktor.websocket.Frame
 import io.ktor.websocket.close
 import io.ktor.websocket.readText
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
 import java.net.InetAddress
 import java.net.ServerSocket
 import kotlinx.coroutines.Dispatchers
@@ -79,7 +81,23 @@ class ServeHttpServer(
               return@post
             }
             val url = call.request.queryParameters["url"]
-            val body = if (url == null) call.receive<ByteArray>() else null
+            // Cap the uploaded body as it streams in — receiving it whole into memory first would
+            // let a client OOM the server regardless of the store's later extraction cap.
+            val body =
+              if (url == null) {
+                withContext(Dispatchers.IO) {
+                  call.receiveStream().use { readCapped(it, MAX_UPLOAD_BYTES) }
+                }
+                  ?: run {
+                    call.respondText(
+                      "bundle exceeds ${MAX_UPLOAD_BYTES / (1024 * 1024)}MB",
+                      status = HttpStatusCode.PayloadTooLarge,
+                    )
+                    return@post
+                  }
+              } else {
+                null
+              }
             val result =
               withContext(Dispatchers.IO) {
                 if (url != null) store.addFromUrl(name, url) else store.add(name, body!!)
@@ -335,7 +353,27 @@ class ServeHttpServer(
     const val TOKEN_HEADER: String = "X-Compose-Preview-Token"
     private const val DEFAULT_PORT_RANGE = 32
 
+    /** Max accepted upload-body size for `POST /bundles` (matches the store's extraction cap). */
+    private const val MAX_UPLOAD_BYTES = 100L * 1024 * 1024
+
     private val JSON = Json { encodeDefaults = true }
+
+    /**
+     * Read [input] fully, or `null` once it exceeds [max] bytes (without buffering past the cap).
+     */
+    private fun readCapped(input: InputStream, max: Long): ByteArray? {
+      val out = ByteArrayOutputStream()
+      val buffer = ByteArray(64 * 1024)
+      var total = 0L
+      while (true) {
+        val n = input.read(buffer)
+        if (n < 0) break
+        total += n
+        if (total > max) return null
+        out.write(buffer, 0, n)
+      }
+      return out.toByteArray()
+    }
 
     /**
      * Pick a bindable port: try [requested], then increment up to [range] times when it's taken.

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleStoreTest.kt
@@ -13,8 +13,16 @@ class ServeBundleStoreTest {
 
   private val registered = LinkedHashMap<String, ServeBundleHost>()
 
-  private fun store(fetch: (String) -> ByteArray? = { null }): ServeBundleStore =
-    ServeBundleStore(tempRoot(), register = { n, h -> registered[n] = h }, fetch = fetch)
+  private fun store(
+    fetch: (String) -> ByteArray? = { null },
+    allowedHosts: List<String> = emptyList(),
+  ): ServeBundleStore =
+    ServeBundleStore(
+      tempRoot(),
+      register = { n, h -> registered[n] = h },
+      fetch = fetch,
+      allowedHosts = allowedHosts,
+    )
 
   private fun zipOf(vararg entries: Pair<String, ByteArray>): ByteArray =
     ServeBundle.zip(linkedMapOf("index.html" to "<html></html>".toByteArray(), *entries))
@@ -22,7 +30,7 @@ class ServeBundleStoreTest {
   @Test
   fun `add unpacks previews and registers a servable session`() {
     val zip = zipOf("previews/com.example.Red.png" to byteArrayOf(1, 2, 3))
-    val result = store().add("demo", zip)
+    val result = store().add("demo", zip, isSecurityChecked = true)
 
     assertEquals(ServeBundleStore.Result.Ok("demo", 1), result)
     val host = registered.getValue("demo")
@@ -38,7 +46,7 @@ class ServeBundleStoreTest {
         "previews/../../evil.png" to byteArrayOf(9), // path traversal — must be skipped
         "secrets.txt" to byteArrayOf(7), // not under previews/ — ignored
       )
-    val result = store().add("demo", zip)
+    val result = store().add("demo", zip, isSecurityChecked = true)
 
     assertEquals(ServeBundleStore.Result.Ok("demo", 1), result)
     assertEquals(listOf("com.example.Red"), registered.getValue("demo").previews.map { it.id })
@@ -46,7 +54,7 @@ class ServeBundleStoreTest {
 
   @Test
   fun `a bundle without previews is rejected`() {
-    val result = store().add("demo", zipOf("notes.txt" to byteArrayOf(1)))
+    val result = store().add("demo", zipOf("notes.txt" to byteArrayOf(1)), isSecurityChecked = true)
     assertTrue(result is ServeBundleStore.Result.Failed)
     assertTrue(registered.isEmpty())
   }
@@ -54,12 +62,14 @@ class ServeBundleStoreTest {
   @Test
   fun `unsafe session names are rejected`() {
     val zip = zipOf("previews/p.png" to byteArrayOf(1))
-    assertTrue(store().add("../etc", zip) is ServeBundleStore.Result.Failed)
-    assertTrue(store().add("a/b", zip) is ServeBundleStore.Result.Failed)
+    assertTrue(
+      store().add("../etc", zip, isSecurityChecked = true) is ServeBundleStore.Result.Failed
+    )
+    assertTrue(store().add("a/b", zip, isSecurityChecked = true) is ServeBundleStore.Result.Failed)
     // Dot-only names match the char class but would delete the upload root / its parent.
-    assertTrue(store().add(".", zip) is ServeBundleStore.Result.Failed)
-    assertTrue(store().add("..", zip) is ServeBundleStore.Result.Failed)
-    assertTrue(store().add("...", zip) is ServeBundleStore.Result.Failed)
+    assertTrue(store().add(".", zip, isSecurityChecked = true) is ServeBundleStore.Result.Failed)
+    assertTrue(store().add("..", zip, isSecurityChecked = true) is ServeBundleStore.Result.Failed)
+    assertTrue(store().add("...", zip, isSecurityChecked = true) is ServeBundleStore.Result.Failed)
   }
 
   @Test
@@ -67,23 +77,68 @@ class ServeBundleStoreTest {
     val store =
       ServeBundleStore(tempRoot(), register = { n, h -> registered[n] = h }, maxBytes = 1_000)
     val zip = zipOf("previews/p.png" to ByteArray(4_000))
-    assertTrue(store.add("big", zip) is ServeBundleStore.Result.Failed)
+    assertTrue(store.add("big", zip, isSecurityChecked = true) is ServeBundleStore.Result.Failed)
     assertTrue(registered.isEmpty())
   }
 
   @Test
-  fun `addFromUrl fetches then registers`() {
+  fun `addFromUrl fetches an allowed host then registers`() {
     val zip = zipOf("previews/p.png" to byteArrayOf(5))
     val result =
-      store(fetch = { url -> if (url == "https://ci/art.zip") zip else null })
-        .addFromUrl("fromci", "https://ci/art.zip")
+      store(
+          fetch = { url -> if (url == "https://ci.example.com/art.zip") zip else null },
+          allowedHosts = listOf("ci.example.com"),
+        )
+        .addFromUrl("fromci", "https://ci.example.com/art.zip", isSecurityChecked = true)
     assertEquals(ServeBundleStore.Result.Ok("fromci", 1), result)
     assertTrue(registered.containsKey("fromci"))
   }
 
   @Test
   fun `addFromUrl reports a fetch failure`() {
-    val result = store(fetch = { null }).addFromUrl("x", "https://nope")
+    val result =
+      store(fetch = { null }, allowedHosts = listOf("ci.example.com"))
+        .addFromUrl("x", "https://ci.example.com/nope", isSecurityChecked = true)
+    assertTrue(result is ServeBundleStore.Result.Failed)
+  }
+
+  @Test
+  fun `addFromUrl refuses a host not on the allowlist (SSRF) without fetching`() {
+    var fetched = false
+    val result =
+      store(
+          fetch = {
+            fetched = true
+            null
+          },
+          allowedHosts = listOf("ci.example.com"),
+        )
+        .addFromUrl("evil", "http://169.254.169.254/latest/meta-data", isSecurityChecked = true)
+    assertTrue(result is ServeBundleStore.Result.Failed)
+    assertTrue(!fetched, "a disallowed host must not be fetched")
+  }
+
+  @Test
+  fun `addFromUrl fails closed when no hosts are allowed`() {
+    var fetched = false
+    val result =
+      store(
+          fetch = {
+            fetched = true
+            null
+          },
+          allowedHosts = emptyList(),
+        )
+        .addFromUrl("x", "https://ci.example.com/art.zip", isSecurityChecked = true)
+    assertTrue(result is ServeBundleStore.Result.Failed)
+    assertTrue(!fetched, "an empty allowlist fetches nothing")
+  }
+
+  @Test
+  fun `addFromUrl refuses a non-http scheme`() {
+    val result =
+      store(fetch = { ByteArray(0) }, allowedHosts = listOf("ci.example.com"))
+        .addFromUrl("x", "file:///etc/passwd", isSecurityChecked = true)
     assertTrue(result is ServeBundleStore.Result.Failed)
   }
 }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleStoreTest.kt
@@ -1,0 +1,76 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ServeBundleStoreTest {
+
+  private fun tempRoot(): File =
+    java.nio.file.Files.createTempDirectory("store").toFile().also { it.deleteOnExit() }
+
+  private val registered = LinkedHashMap<String, ServeBundleHost>()
+
+  private fun store(fetch: (String) -> ByteArray? = { null }): ServeBundleStore =
+    ServeBundleStore(tempRoot(), register = { n, h -> registered[n] = h }, fetch = fetch)
+
+  private fun zipOf(vararg entries: Pair<String, ByteArray>): ByteArray =
+    ServeBundle.zip(linkedMapOf("index.html" to "<html></html>".toByteArray(), *entries))
+
+  @Test
+  fun `add unpacks previews and registers a servable session`() {
+    val zip = zipOf("previews/com.example.Red.png" to byteArrayOf(1, 2, 3))
+    val result = store().add("demo", zip)
+
+    assertEquals(ServeBundleStore.Result.Ok("demo", 1), result)
+    val host = registered.getValue("demo")
+    val ok = host.render("com.example.Red", PreviewOverrides()) as RenderOutcome.Ok
+    assertTrue(byteArrayOf(1, 2, 3).contentEquals(ok.png))
+  }
+
+  @Test
+  fun `zip-slip entries are ignored, only previews are extracted`() {
+    val zip =
+      zipOf(
+        "previews/com.example.Red.png" to byteArrayOf(1),
+        "previews/../../evil.png" to byteArrayOf(9), // path traversal — must be skipped
+        "secrets.txt" to byteArrayOf(7), // not under previews/ — ignored
+      )
+    val result = store().add("demo", zip)
+
+    assertEquals(ServeBundleStore.Result.Ok("demo", 1), result)
+    assertEquals(listOf("com.example.Red"), registered.getValue("demo").previews.map { it.id })
+  }
+
+  @Test
+  fun `a bundle without previews is rejected`() {
+    val result = store().add("demo", zipOf("notes.txt" to byteArrayOf(1)))
+    assertTrue(result is ServeBundleStore.Result.Failed)
+    assertTrue(registered.isEmpty())
+  }
+
+  @Test
+  fun `unsafe session names are rejected`() {
+    val zip = zipOf("previews/p.png" to byteArrayOf(1))
+    assertTrue(store().add("../etc", zip) is ServeBundleStore.Result.Failed)
+    assertTrue(store().add("a/b", zip) is ServeBundleStore.Result.Failed)
+  }
+
+  @Test
+  fun `addFromUrl fetches then registers`() {
+    val zip = zipOf("previews/p.png" to byteArrayOf(5))
+    val result =
+      store(fetch = { url -> if (url == "https://ci/art.zip") zip else null })
+        .addFromUrl("fromci", "https://ci/art.zip")
+    assertEquals(ServeBundleStore.Result.Ok("fromci", 1), result)
+    assertTrue(registered.containsKey("fromci"))
+  }
+
+  @Test
+  fun `addFromUrl reports a fetch failure`() {
+    val result = store(fetch = { null }).addFromUrl("x", "https://nope")
+    assertTrue(result is ServeBundleStore.Result.Failed)
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleStoreTest.kt
@@ -56,6 +56,19 @@ class ServeBundleStoreTest {
     val zip = zipOf("previews/p.png" to byteArrayOf(1))
     assertTrue(store().add("../etc", zip) is ServeBundleStore.Result.Failed)
     assertTrue(store().add("a/b", zip) is ServeBundleStore.Result.Failed)
+    // Dot-only names match the char class but would delete the upload root / its parent.
+    assertTrue(store().add(".", zip) is ServeBundleStore.Result.Failed)
+    assertTrue(store().add("..", zip) is ServeBundleStore.Result.Failed)
+    assertTrue(store().add("...", zip) is ServeBundleStore.Result.Failed)
+  }
+
+  @Test
+  fun `a bundle larger than the cap is rejected`() {
+    val store =
+      ServeBundleStore(tempRoot(), register = { n, h -> registered[n] = h }, maxBytes = 1_000)
+    val zip = zipOf("previews/p.png" to ByteArray(4_000))
+    assertTrue(store.add("big", zip) is ServeBundleStore.Result.Failed)
+    assertTrue(registered.isEmpty())
   }
 
   @Test


### PR DESCRIPTION
## Summary

Makes shared/public mode actually *useful* by letting **clients contribute build results at runtime** — the point of public mode — instead of only hosting a startup `--bundles` dir. (#2025 has merged; this is now rebased directly on `main`.)

`serve --accept-bundles` enables **`POST /bundles/{name}`**:
- **Upload** — send a bundle zip as the request body.
- **Link** — pass `?url=` to a build-results artifact (e.g. a CI zip); the server fetches it.

The bundle is unpacked and registered as a read-only pinned `?session=` session, and the response returns the viewer link (`{session, previews, path}`).

- **`ServeBundleStore`** unpacks a bundle zip — extracting **only** `previews/*.png` (zip-slip guarded via path-segment + canonical-containment checks, total size capped) into a per-bundle dir — and registers a `ServeBundleHost`. `addFromUrl` fetches first; the fetcher is injected (stubbed in tests).
- **`ServeHttpServer`** gains the gated `POST` route (registered only when a store is supplied); the upload body is capped as it streams in (413 on overflow).
- **`ServeCommand`** wires `--accept-bundles` to a temp-dir store.

### Security hardening (this PR)
- **SSRF host allowlist.** The `?url=` fetch is gated by `--accept-bundles-from <host>[,<host>…]`: only a URL whose host is on the operator allowlist (and is http/https) is fetched, checked **before** the fetcher runs. An **empty allowlist refuses every URL (fail closed)**, so `--accept-bundles` alone accepts uploads only — a client can never steer the server at an arbitrary or internal address.
- **`isSecurityChecked` audit marker.** `add`/`addFromUrl` take a required, documented `isSecurityChecked` boolean (no runtime enforcement, per the agreed convention); the token-gated `POST` route passes `true`. Defence-in-depth (name sanitisation, zip-slip, size cap, SSRF allowlist) is still enforced regardless.

**Safe by default:** off unless `--accept-bundles`; token-gated; only preview PNGs are extracted; URL fetch needs an explicit host allowlist. (Per-uploader auth + upload GC are tracked in #2020 / #2022.)

## Test plan
- `ktfmtFormatAll` clean; `:cli:compileKotlin` / `compileTestKotlin` green; serve suite + `CliFlagsRegistryTest` + `:cli:checkCliDaemonLibraryBoundary` green.
- `ServeBundleStoreTest`: upload unpacks + registers a servable session; **zip-slip / non-preview entries ignored**; bundle without previews rejected; unsafe + dot-only session names rejected; size cap; `addFromUrl` fetches an **allowed host** then registers; **disallowed host / empty allowlist refused without fetching (SSRF)**; non-http scheme refused; fetch failure reported.

## Visual evidence
Non-visual — an ingestion endpoint + registry plumbing. A served bundle shows the PNGs that were rendered into it.