### PR TITLE
refactor(renderer): use OkHttp instead of HttpURLConnection for Google Fonts

### DIFF
--- a/renderers/android/build.gradle.kts
+++ b/renderers/android/build.gradle.kts
@@ -19,6 +19,8 @@ android {
 
 dependencies {
   implementation(project(":common-io"))
+  // Google Fonts CSS/TTF fetch in GoogleFontInterceptor (replaces java.net.HttpURLConnection).
+  implementation(libs.okhttp)
   // D2.2 — `AccessibilityChecker`, `AccessibilityOverlay`, and the
   // `AccessibilityFinding` / `AccessibilityNode` / `AccessibilityEntry` model classes used to
   // live in this module. They moved to `:data-a11y-core` (published as

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/GoogleFontInterceptor.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/GoogleFontInterceptor.kt
@@ -5,10 +5,11 @@ import okio.FileSystem
 import okio.Path.Companion.toPath
 import androidx.compose.ui.text.font.FontWeight
 import java.io.File
-import java.net.HttpURLConnection
-import java.net.URL
 import java.net.URLDecoder
 import java.net.URLEncoder
+import java.util.concurrent.TimeUnit
+import okhttp3.OkHttpClient
+import okhttp3.Request
 
 /**
  * Cache and CSS-API helpers that underpin [ShadowFontsContractCompat].
@@ -235,25 +236,22 @@ internal fun pickClosestTruetypeUrl(css: String, requestedWeight: Int): String? 
         ?.groupValues?.get(2)
 }
 
-private fun httpGet(url: String, userAgent: String): String? = runCatching {
-    val conn = openConnection(url, userAgent)
-    conn.inputStream.use { it.readBytes().toString(Charsets.UTF_8) }
-}.getOrNull()
+private val fontHttpClient: OkHttpClient by lazy {
+    OkHttpClient.Builder()
+        .connectTimeout(10, TimeUnit.SECONDS)
+        .readTimeout(15, TimeUnit.SECONDS)
+        .build()
+}
+
+private fun httpGet(url: String, userAgent: String): String? =
+    httpGetBytes(url, userAgent)?.toString(Charsets.UTF_8)
 
 private fun httpGetBytes(url: String, userAgent: String): ByteArray? = runCatching {
-    val conn = openConnection(url, userAgent)
-    conn.inputStream.use { it.readBytes() }
+    val request = Request.Builder().url(url).header("User-Agent", userAgent).build()
+    fontHttpClient.newCall(request).execute().use { response ->
+        if (response.isSuccessful) response.body?.bytes() else null
+    }
 }.getOrNull()
-
-private fun openConnection(url: String, userAgent: String): HttpURLConnection {
-    val conn = URL(url).openConnection() as HttpURLConnection
-    conn.requestMethod = "GET"
-    conn.connectTimeout = 10_000
-    conn.readTimeout = 15_000
-    conn.setRequestProperty("User-Agent", userAgent)
-    conn.instanceFollowRedirects = true
-    return conn
-}
 
 /**
  * Parses the `FontRequest.query` wire format that Compose's `GoogleFont.kt`


### PR DESCRIPTION
## Summary

Removes the last `java.net.HttpURLConnection` use in favour of OkHttp (per the "always use OkHttp" directive). `GoogleFontInterceptor`'s Google Fonts CSS + TTF fetch now goes through a shared `OkHttpClient` (same 10s connect / 15s read timeouts, redirects enabled) instead of `HttpURLConnection`.

- Adds `implementation(libs.okhttp)` to `:renderer-android`.
- `httpGet`/`httpGetBytes` use `OkHttpClient` + `Request`; `openConnection` removed.
- Behaviour unchanged.

(The other former `HttpURLConnection` site, `ServeBundleStore`'s `?url=` fetch, was already converted to OkHttp in #2027.)

## Test plan
- `ktfmtFormatAll` clean.
- `GoogleFontInterceptorTest` is unaffected — it stubs the download path with a canned byte array (no network), so it exercises the cache/CSS/parse helpers, not the HTTP client.
- ⚠️ `:renderer-android` is an Android library; this sandbox has no Android SDK, so I could not compile it locally — **CI compiles it**. The change is a direct, mechanical swap mirroring the already-compiling cli conversion (`response.body`, `ResponseBody.bytes()`).

## Visual evidence
Non-visual — network client swap in font fetching; rendered output unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_0186JHWqw5dMvUJbfgDXgqGo)_