### PR TITLE
fix(cli): gate project-mode revisions behind a ref allowlist (RCE)

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
@@ -58,6 +58,7 @@ internal object CliFlags {
       "--export",
       "--bundles",
       "--accept-bundles-from",
+      "--revisions-allow",
       // Required-reason escape hatch. Usually written attached (`--force=<reason>`), but the space
       // form `--force <reason>` is supported (ForceFlagTest), so the reason must be skipped or it's
       // mistaken for the command.

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -59,6 +59,16 @@ class ServeCommand(args: List<String>) : Command(args) {
   private val revisions: Boolean = "--revisions" in args
 
   /**
+   * Project mode revision policy (SECURITY/RCE): comma-separated refs whose history a requested
+   * `?session=<rev>` must be reachable from to be checked out and built. Empty = nothing builds
+   * (fail closed), since building runs that revision's Gradle. e.g. `--revisions-allow
+   * main,release`.
+   */
+  private val revisionAllowRefs: List<String> =
+    args.flagValue("--revisions-allow")?.split(",")?.map { it.trim() }?.filter { it.isNotEmpty() }
+      ?: emptyList()
+
+  /**
    * Ephemeral mode: shut the whole server down once it's been idle — no open connections and no
    * requests — for [idleExitSeconds]. `--exit-when-idle` uses the default window;
    * `--exit-when-idle=<seconds>` sets it (a short value ≈ "exit shortly after the last client
@@ -306,13 +316,20 @@ class ServeCommand(args: List<String>) : Command(args) {
     return exec
   }
 
-  /** Open the worktree manager rooted at the repo (project mode). */
+  /** Open the worktree manager rooted at the repo (project mode), gated to the allowed refs. */
   private fun openWorktrees(module: PreviewModule): GitWorktrees {
     val repoRoot =
       findProjectRoot() ?: module.projectDir.absoluteFile.parentFile ?: module.projectDir
+    if (revisionAllowRefs.isEmpty()) {
+      System.err.println(
+        "serve: --revisions has no --revisions-allow refs; no revision will build (fail closed). " +
+          "Pass --revisions-allow <ref>[,<ref>…] (e.g. main,release/*) to enable trusted revs."
+      )
+    }
     return GitWorktrees(
       repoRoot = repoRoot,
       cacheRoot = File(repoRoot, "build/serve-worktrees"),
+      allowedRefs = revisionAllowRefs,
       onLog = { System.err.println("[serve worktree] $it") },
     )
   }
@@ -491,6 +508,11 @@ class ServeCommand(args: List<String>) : Command(args) {
         --revisions       Project mode: also serve other git revisions of this repo on demand. A
                           request with ?session=<rev> checks that revision out into a worktree,
                           builds it, and serves it as its own session (suspended/resumed when idle).
+        --revisions-allow <ref>[,<ref>…]
+                          Project mode SECURITY gate: only revisions reachable from these trusted
+                          refs (e.g. main,release) are checked out and built — building runs that
+                          revision's own Gradle (code execution). Omitted/empty = nothing builds
+                          (fail closed), so arbitrary ?session=<rev> can't run code on the server.
         --exit-when-idle[=<seconds>]
                           Ephemeral mode: shut the server down once it's been idle (no open
                           connections and no requests) for <seconds> (default ${DEFAULT_IDLE_EXIT_SECONDS}s). Use a small

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/GitWorktrees.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/GitWorktrees.kt
@@ -31,10 +31,16 @@ class GitWorktrees(
   private val repoRoot: File,
   private val cacheRoot: File,
   /**
-   * Refs (branches/tags) whose history a requested revision must be reachable from to be served.
-   * Empty = nothing is allowed (project mode fails closed): a client-supplied `?session=<rev>` is
-   * only checked out when it's an ancestor of one of these operator-trusted refs, so arbitrary
-   * fetched PR/fork commits can't be materialized or (downstream) built.
+   * Refs whose history a requested revision must be reachable from to be served. Empty = nothing is
+   * allowed (project mode fails closed): a client-supplied `?session=<rev>` is only checked out
+   * when it's an ancestor of one of these operator-trusted refs, so arbitrary fetched PR/fork
+   * commits can't be materialized or (downstream) built.
+   *
+   * A short name like `main` or `origin/main` is **qualified** to `refs/heads/…` / `refs/remotes/…`
+   * before the ancestry check (see [qualify]): gitrevisions resolves an ambiguous `<name>` as
+   * `refs/tags/<name>` *before* the branch, so a same-named malicious tag could otherwise satisfy
+   * the allowlist for commits reachable only from that tag. Tags are never auto-matched — to allow
+   * one, pass it fully qualified as `refs/tags/<name>`.
    */
   private val allowedRefs: List<String> = emptyList(),
   private val git: GitRunner = RealGitRunner,
@@ -72,10 +78,26 @@ class GitWorktrees(
   }
 
   /** True when [sha] is reachable from (an ancestor of, or equal to) at least one allowed ref. */
-  private fun isAllowed(sha: String): Boolean =
-    allowedRefs.any { ref ->
-      git.run(repoRoot, listOf("merge-base", "--is-ancestor", sha, "$ref^{commit}")).ok
-    }
+  private fun isAllowed(sha: String): Boolean = allowedRefs.any { ref ->
+    val qualified = qualify(ref) ?: return@any false
+    git.run(repoRoot, listOf("merge-base", "--is-ancestor", sha, "$qualified^{commit}")).ok
+  }
+
+  /**
+   * Qualify an allowlist [ref] to an unambiguous fully-qualified ref, or null if it doesn't exist.
+   * A `refs/…` ref is verified as-is (so a tag can be allowed explicitly via `refs/tags/<name>`); a
+   * short name is tried as a branch then a remote-tracking branch only — never a tag — so a
+   * same-named tag can't hijack the allowlist.
+   */
+  private fun qualify(ref: String): String? {
+    val candidates =
+      if (ref.startsWith("refs/")) listOf(ref) else listOf("refs/heads/$ref", "refs/remotes/$ref")
+    return candidates.firstOrNull { exists(it) }
+  }
+
+  /** True when [fullRef] resolves to a commit. */
+  private fun exists(fullRef: String): Boolean =
+    git.run(repoRoot, listOf("rev-parse", "--verify", "--quiet", "$fullRef^{commit}")).ok
 
   /** Resolve [rev] to a full commit sha, or null when it isn't a valid revision. */
   private fun resolve(rev: String): String? {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/GitWorktrees.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/GitWorktrees.kt
@@ -30,6 +30,13 @@ data class GitResult(val exitCode: Int, val stdout: String) {
 class GitWorktrees(
   private val repoRoot: File,
   private val cacheRoot: File,
+  /**
+   * Refs (branches/tags) whose history a requested revision must be reachable from to be served.
+   * Empty = nothing is allowed (project mode fails closed): a client-supplied `?session=<rev>` is
+   * only checked out when it's an ancestor of one of these operator-trusted refs, so arbitrary
+   * fetched PR/fork commits can't be materialized or (downstream) built.
+   */
+  private val allowedRefs: List<String> = emptyList(),
   private val git: GitRunner = RealGitRunner,
   private val onLog: (String) -> Unit = {},
 ) : AutoCloseable {
@@ -39,10 +46,14 @@ class GitWorktrees(
 
   /**
    * Resolve [rev] to a commit and ensure a worktree for it exists; returns the worktree directory,
-   * or `null` when the revision can't be resolved or the worktree can't be created.
+   * or `null` when the revision can't be resolved, isn't allowed by policy, or can't be created.
    */
   fun prepare(rev: String): File? = lock.withLock {
     val sha = resolve(rev) ?: return null
+    if (!isAllowed(sha)) {
+      onLog("serve: revision '$rev' ($sha) is not reachable from an allowed ref; refusing")
+      return null
+    }
     val dir = File(cacheRoot, sha)
     // A `.git` file/dir in the worktree means it's already a valid checkout — reuse it.
     if (File(dir, ".git").exists()) {
@@ -59,6 +70,12 @@ class GitWorktrees(
     prepared.add(dir)
     dir
   }
+
+  /** True when [sha] is reachable from (an ancestor of, or equal to) at least one allowed ref. */
+  private fun isAllowed(sha: String): Boolean =
+    allowedRefs.any { ref ->
+      git.run(repoRoot, listOf("merge-base", "--is-ancestor", sha, "$ref^{commit}")).ok
+    }
 
   /** Resolve [rev] to a full commit sha, or null when it isn't a valid revision. */
   private fun resolve(rev: String): String? {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/GradleRevisionBuilder.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/GradleRevisionBuilder.kt
@@ -19,13 +19,15 @@ class GradleRevisionBuilder(
   private val onLog: (String) -> Unit = {},
 ) : RevisionBuilder {
 
-  override fun build(worktreeDir: File, module: ServeModuleRef): BuiltRevision? {
-    // SECURITY (RCE): this runs the *checked-out revision's* own `./gradlew` (and its build
-    // scripts), so a client that can name a resolvable revision via `?session=<rev>` in project
-    // mode
-    // gets arbitrary code execution as the server user. Fail closed until project mode gates which
-    // revisions may be built (e.g. an allowlist of trusted refs) and isolates the build.
-    TODO("secure this")
+  override fun build(
+    worktreeDir: File,
+    module: ServeModuleRef,
+    isSecurityChecked: Boolean,
+  ): BuiltRevision? {
+    // SECURITY (RCE): this runs the checked-out revision's own `./gradlew` + build scripts = code
+    // execution as the server user. [isSecurityChecked] must be true — the caller asserts the
+    // revision cleared policy (ServeRevisionFactory only builds revs allowed by GitWorktrees' ref
+    // allowlist). The gate itself lives upstream; this flag is the audit marker at the exec point.
     val moduleDir = File(worktreeDir, module.relativePath)
     val gradlew = File(worktreeDir, "gradlew")
     if (!gradlew.canExecute()) {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRevisionFactory.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRevisionFactory.kt
@@ -16,9 +16,13 @@ data class BuiltRevision(
 
 /**
  * Builds [module] inside an already-checked-out [worktreeDir]; null when the build/discovery fails.
+ *
+ * [isSecurityChecked] is a required, greppable audit marker (no runtime enforcement): the caller
+ * passes `true` only once the revision has cleared policy (here: [GitWorktrees]' ref allowlist),
+ * because building runs the checked-out revision's own Gradle = code execution.
  */
 fun interface RevisionBuilder {
-  fun build(worktreeDir: File, module: ServeModuleRef): BuiltRevision?
+  fun build(worktreeDir: File, module: ServeModuleRef, isSecurityChecked: Boolean): BuiltRevision?
 }
 
 /**
@@ -40,21 +44,20 @@ class ServeRevisionFactory(
 ) : ServeSessionFactory {
 
   override fun create(sessionId: String): ServeSessionState? {
-    // SECURITY (RCE): a client-supplied `?session=<rev>` reaches here in project mode. Fail closed
-    // *before* worktrees.prepare() — which would `git worktree add` an arbitrary fetched revision
-    // (and downstream run its build, RCE) — until revision policy (allowlist of trusted refs) and
-    // build isolation are in place. The builder's exec point is also guarded as defence in depth.
-    TODO("secure this")
     val rev = sessionId.trim()
     if (rev.isEmpty()) return null
+    // worktrees.prepare() enforces the ref allowlist (SECURITY/RCE): it only checks out a revision
+    // reachable from an operator-trusted ref, so an arbitrary client-supplied `?session=<rev>` is
+    // refused before any checkout. A null here means "not resolvable or not allowed".
     val worktree =
       worktrees.prepare(rev)
         ?: run {
-          onLog("serve: could not check out revision '$rev'")
+          onLog("serve: revision '$rev' is unavailable (unresolvable or not allowed)")
           return null
         }
+    // isSecurityChecked = true: the rev passed the allowlist above, so building it is sanctioned.
     val built =
-      builder.build(worktree, module)
+      builder.build(worktree, module, isSecurityChecked = true)
         ?: run {
           onLog("serve: build/discovery failed for ${module.gradlePath} at '$rev'")
           return null

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/GitWorktreesTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/GitWorktreesTest.kt
@@ -13,8 +13,15 @@ class GitWorktreesTest {
   private fun tempDir(prefix: String): File =
     java.nio.file.Files.createTempDirectory(prefix).toFile().also { it.deleteOnExit() }
 
-  /** Records git invocations and simulates rev-parse + worktree add (creating a `.git` marker). */
-  private class FakeGit(var resolveSha: String? = "abc123def") : GitRunner {
+  /**
+   * Records git invocations and simulates rev-parse + worktree add (creating a `.git` marker).
+   * [ancestorOf] decides `merge-base --is-ancestor <sha> <ref>^{commit}`: it returns the set of refs
+   * the resolved sha is reachable from, so the allowlist gate can be exercised without a real repo.
+   */
+  private class FakeGit(
+    var resolveSha: String? = "abc123def",
+    val ancestorOf: Set<String> = emptySet(),
+  ) : GitRunner {
     val calls = CopyOnWriteArrayList<List<String>>()
 
     fun count(prefix: List<String>): Int = calls.count { it.take(prefix.size) == prefix }
@@ -24,6 +31,11 @@ class GitWorktreesTest {
       return when {
         args.take(1) == listOf("rev-parse") ->
           resolveSha?.let { GitResult(0, "$it\n") } ?: GitResult(1, "")
+        args.take(2) == listOf("merge-base", "--is-ancestor") -> {
+          // args: [merge-base, --is-ancestor, <sha>, <ref>^{commit}]
+          val ref = args[3].removeSuffix("^{commit}")
+          if (ref in ancestorOf) GitResult(0, "") else GitResult(1, "")
+        }
         args.take(2) == listOf("worktree", "add") -> {
           val dir = File(args[args.size - 2])
           dir.mkdirs()
@@ -37,36 +49,96 @@ class GitWorktreesTest {
 
   @Test
   fun `prepare resolves the commit and adds a worktree once, reusing it after`() {
-    val git = FakeGit()
+    val git = FakeGit(ancestorOf = setOf("main"))
     val cache = tempDir("wt-cache")
-    GitWorktrees(repoRoot = tempDir("repo"), cacheRoot = cache, git = git).use { wt ->
-      val dir = assertNotNull(wt.prepare("HEAD"))
-      assertEquals(File(cache, "abc123def"), dir)
-      assertTrue(File(dir, ".git").exists())
-      assertEquals(1, git.count(listOf("worktree", "add")))
+    GitWorktrees(
+        repoRoot = tempDir("repo"),
+        cacheRoot = cache,
+        allowedRefs = listOf("main"),
+        git = git,
+      )
+      .use { wt ->
+        val dir = assertNotNull(wt.prepare("HEAD"))
+        assertEquals(File(cache, "abc123def"), dir)
+        assertTrue(File(dir, ".git").exists())
+        assertEquals(1, git.count(listOf("worktree", "add")))
 
-      // Second request for the same revision reuses the existing worktree — no second add.
-      val again = assertNotNull(wt.prepare("HEAD"))
-      assertEquals(dir, again)
-      assertEquals(1, git.count(listOf("worktree", "add")), "an existing worktree is reused")
-    }
+        // Second request for the same revision reuses the existing worktree — no second add.
+        val again = assertNotNull(wt.prepare("HEAD"))
+        assertEquals(dir, again)
+        assertEquals(1, git.count(listOf("worktree", "add")), "an existing worktree is reused")
+      }
   }
 
   @Test
   fun `prepare returns null when the revision cannot be resolved`() {
-    val git = FakeGit(resolveSha = null)
-    GitWorktrees(repoRoot = tempDir("repo"), cacheRoot = tempDir("wt-cache"), git = git).use { wt ->
-      assertNull(wt.prepare("does-not-exist"))
-      assertEquals(0, git.count(listOf("worktree", "add")), "no worktree added for a bad revision")
-    }
+    val git = FakeGit(resolveSha = null, ancestorOf = setOf("main"))
+    GitWorktrees(
+        repoRoot = tempDir("repo"),
+        cacheRoot = tempDir("wt-cache"),
+        allowedRefs = listOf("main"),
+        git = git,
+      )
+      .use { wt ->
+        assertNull(wt.prepare("does-not-exist"))
+        assertEquals(0, git.count(listOf("worktree", "add")), "no worktree added for a bad revision")
+      }
+  }
+
+  @Test
+  fun `prepare refuses a revision not reachable from any allowed ref`() {
+    // Resolves fine, but the sha is an ancestor of 'feature', which is not in the allowlist.
+    val git = FakeGit(ancestorOf = setOf("feature"))
+    GitWorktrees(
+        repoRoot = tempDir("repo"),
+        cacheRoot = tempDir("wt-cache"),
+        allowedRefs = listOf("main", "release"),
+        git = git,
+      )
+      .use { wt ->
+        assertNull(wt.prepare("deadbeef"))
+        assertEquals(0, git.count(listOf("worktree", "add")), "no checkout for a disallowed rev")
+      }
+  }
+
+  @Test
+  fun `prepare fails closed when no refs are allowed`() {
+    // Even a resolvable sha that is an ancestor of refs is refused when the allowlist is empty.
+    val git = FakeGit(ancestorOf = setOf("main"))
+    GitWorktrees(
+        repoRoot = tempDir("repo"),
+        cacheRoot = tempDir("wt-cache"),
+        allowedRefs = emptyList(),
+        git = git,
+      )
+      .use { wt ->
+        assertNull(wt.prepare("HEAD"))
+        assertEquals(0, git.count(listOf("worktree", "add")))
+      }
+  }
+
+  @Test
+  fun `prepare allows a revision reachable from any one of several allowed refs`() {
+    val git = FakeGit(ancestorOf = setOf("release"))
+    GitWorktrees(
+        repoRoot = tempDir("repo"),
+        cacheRoot = tempDir("wt-cache"),
+        allowedRefs = listOf("main", "release"),
+        git = git,
+      )
+      .use { wt -> assertNotNull(wt.prepare("HEAD")) }
   }
 
   @Test
   fun `close removes the worktrees it created`() {
-    val git = FakeGit()
-    GitWorktrees(repoRoot = tempDir("repo"), cacheRoot = tempDir("wt-cache"), git = git).use { wt ->
-      wt.prepare("HEAD")
-    }
+    val git = FakeGit(ancestorOf = setOf("main"))
+    GitWorktrees(
+        repoRoot = tempDir("repo"),
+        cacheRoot = tempDir("wt-cache"),
+        allowedRefs = listOf("main"),
+        git = git,
+      )
+      .use { wt -> wt.prepare("HEAD") }
     assertEquals(1, git.count(listOf("worktree", "remove")))
     assertEquals(1, git.count(listOf("worktree", "prune")))
   }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/GitWorktreesTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/GitWorktreesTest.kt
@@ -14,13 +14,18 @@ class GitWorktreesTest {
     java.nio.file.Files.createTempDirectory(prefix).toFile().also { it.deleteOnExit() }
 
   /**
-   * Records git invocations and simulates rev-parse + worktree add (creating a `.git` marker).
-   * [ancestorOf] decides `merge-base --is-ancestor <sha> <ref>^{commit}`: it returns the set of refs
-   * the resolved sha is reachable from, so the allowlist gate can be exercised without a real repo.
+   * Records git invocations and simulates the three calls [GitWorktrees] makes:
+   * - `rev-parse <rev>^{commit}` resolves a requested revision to [resolveSha];
+   * - `rev-parse <refs/…>^{commit}` (ref qualification) succeeds only for refs in [existingRefs];
+   * - `merge-base --is-ancestor <sha> <ref>^{commit}` succeeds only for refs in [ancestorRefs].
+   *
+   * Refs are modelled fully-qualified so the qualification gate (short name → `refs/heads`/
+   * `refs/remotes`, never `refs/tags`) can be exercised without a real repo.
    */
   private class FakeGit(
     var resolveSha: String? = "abc123def",
-    val ancestorOf: Set<String> = emptySet(),
+    val existingRefs: Set<String> = setOf("refs/heads/main", "refs/heads/release"),
+    val ancestorRefs: Set<String> = emptySet(),
   ) : GitRunner {
     val calls = CopyOnWriteArrayList<List<String>>()
 
@@ -29,12 +34,17 @@ class GitWorktreesTest {
     override fun run(workdir: File, args: List<String>): GitResult {
       calls.add(args)
       return when {
-        args.take(1) == listOf("rev-parse") ->
-          resolveSha?.let { GitResult(0, "$it\n") } ?: GitResult(1, "")
+        args.take(1) == listOf("rev-parse") -> {
+          val token = args.last().removeSuffix("^{commit}")
+          if (token.startsWith("refs/")) {
+            if (token in existingRefs) GitResult(0, "$token\n") else GitResult(1, "")
+          } else {
+            resolveSha?.let { GitResult(0, "$it\n") } ?: GitResult(1, "")
+          }
+        }
         args.take(2) == listOf("merge-base", "--is-ancestor") -> {
-          // args: [merge-base, --is-ancestor, <sha>, <ref>^{commit}]
           val ref = args[3].removeSuffix("^{commit}")
-          if (ref in ancestorOf) GitResult(0, "") else GitResult(1, "")
+          if (ref in ancestorRefs) GitResult(0, "") else GitResult(1, "")
         }
         args.take(2) == listOf("worktree", "add") -> {
           val dir = File(args[args.size - 2])
@@ -49,7 +59,7 @@ class GitWorktreesTest {
 
   @Test
   fun `prepare resolves the commit and adds a worktree once, reusing it after`() {
-    val git = FakeGit(ancestorOf = setOf("main"))
+    val git = FakeGit(ancestorRefs = setOf("refs/heads/main"))
     val cache = tempDir("wt-cache")
     GitWorktrees(
         repoRoot = tempDir("repo"),
@@ -72,7 +82,7 @@ class GitWorktreesTest {
 
   @Test
   fun `prepare returns null when the revision cannot be resolved`() {
-    val git = FakeGit(resolveSha = null, ancestorOf = setOf("main"))
+    val git = FakeGit(resolveSha = null, ancestorRefs = setOf("refs/heads/main"))
     GitWorktrees(
         repoRoot = tempDir("repo"),
         cacheRoot = tempDir("wt-cache"),
@@ -81,14 +91,18 @@ class GitWorktreesTest {
       )
       .use { wt ->
         assertNull(wt.prepare("does-not-exist"))
-        assertEquals(0, git.count(listOf("worktree", "add")), "no worktree added for a bad revision")
+        assertEquals(
+          0,
+          git.count(listOf("worktree", "add")),
+          "no worktree added for a bad revision",
+        )
       }
   }
 
   @Test
   fun `prepare refuses a revision not reachable from any allowed ref`() {
-    // Resolves fine, but the sha is an ancestor of 'feature', which is not in the allowlist.
-    val git = FakeGit(ancestorOf = setOf("feature"))
+    // Resolves fine, but the sha is reachable only from 'feature', which is not in the allowlist.
+    val git = FakeGit(ancestorRefs = setOf("refs/heads/feature"))
     GitWorktrees(
         repoRoot = tempDir("repo"),
         cacheRoot = tempDir("wt-cache"),
@@ -103,8 +117,8 @@ class GitWorktreesTest {
 
   @Test
   fun `prepare fails closed when no refs are allowed`() {
-    // Even a resolvable sha that is an ancestor of refs is refused when the allowlist is empty.
-    val git = FakeGit(ancestorOf = setOf("main"))
+    // Even a resolvable sha that is reachable from refs is refused when the allowlist is empty.
+    val git = FakeGit(ancestorRefs = setOf("refs/heads/main"))
     GitWorktrees(
         repoRoot = tempDir("repo"),
         cacheRoot = tempDir("wt-cache"),
@@ -119,7 +133,7 @@ class GitWorktreesTest {
 
   @Test
   fun `prepare allows a revision reachable from any one of several allowed refs`() {
-    val git = FakeGit(ancestorOf = setOf("release"))
+    val git = FakeGit(ancestorRefs = setOf("refs/heads/release"))
     GitWorktrees(
         repoRoot = tempDir("repo"),
         cacheRoot = tempDir("wt-cache"),
@@ -130,8 +144,40 @@ class GitWorktreesTest {
   }
 
   @Test
+  fun `prepare does not let a same-named tag satisfy a short branch allowlist`() {
+    // Only a TAG 'main' exists (no refs/heads/main), and the sha is reachable from it. A short
+    // allowlist entry 'main' must qualify to a branch/remote only, so this is refused — closing the
+    // tag-shadowing hole where gitrevisions resolves refs/tags/<name> before the branch.
+    val git =
+      FakeGit(existingRefs = setOf("refs/tags/main"), ancestorRefs = setOf("refs/tags/main"))
+    GitWorktrees(
+        repoRoot = tempDir("repo"),
+        cacheRoot = tempDir("wt-cache"),
+        allowedRefs = listOf("main"),
+        git = git,
+      )
+      .use { wt ->
+        assertNull(wt.prepare("deadbeef"))
+        assertEquals(0, git.count(listOf("worktree", "add")))
+      }
+  }
+
+  @Test
+  fun `prepare honours an explicitly fully-qualified tag ref`() {
+    // An operator can still opt a tag in deliberately by qualifying it as refs/tags/<name>.
+    val git = FakeGit(existingRefs = setOf("refs/tags/v1"), ancestorRefs = setOf("refs/tags/v1"))
+    GitWorktrees(
+        repoRoot = tempDir("repo"),
+        cacheRoot = tempDir("wt-cache"),
+        allowedRefs = listOf("refs/tags/v1"),
+        git = git,
+      )
+      .use { wt -> assertNotNull(wt.prepare("deadbeef")) }
+  }
+
+  @Test
   fun `close removes the worktrees it created`() {
-    val git = FakeGit(ancestorOf = setOf("main"))
+    val git = FakeGit(ancestorRefs = setOf("refs/heads/main"))
     GitWorktrees(
         repoRoot = tempDir("repo"),
         cacheRoot = tempDir("wt-cache"),

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeRevisionFactoryTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeRevisionFactoryTest.kt
@@ -2,9 +2,12 @@ package ee.schimke.composeai.cli.serve
 
 import java.io.File
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.test.Test
-import kotlin.test.assertFailsWith
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 
 class ServeRevisionFactoryTest {
 
@@ -13,31 +16,84 @@ class ServeRevisionFactoryTest {
 
   private val module = ServeModuleRef(gradlePath = "samples:cmp", relativePath = "samples/cmp")
 
+  /**
+   * A [GitWorktrees] whose git both resolves any rev to [sha] and reports it reachable from the
+   * given [allowedRefs], so the allowlist gate passes and a worktree is created — letting us drive
+   * the factory's orchestration without a real repo.
+   */
+  private fun allowingWorktrees(sha: String = "deadbeef"): GitWorktrees =
+    GitWorktrees(
+      repoRoot = tempDir("repo"),
+      cacheRoot = tempDir("cache"),
+      allowedRefs = listOf("main"),
+      git = { _, args ->
+        when {
+          args.take(1) == listOf("rev-parse") -> GitResult(0, "$sha\n")
+          args.take(2) == listOf("merge-base", "--is-ancestor") -> GitResult(0, "")
+          args.take(2) == listOf("worktree", "add") -> {
+            File(args[args.size - 2]).mkdirs()
+            File(File(args[args.size - 2]), ".git").writeText("gitdir: x")
+            GitResult(0, "")
+          }
+          else -> GitResult(0, "")
+        }
+      },
+    )
+
+  /** A [GitWorktrees] that refuses everything (empty allowlist, fails closed). */
+  private fun refusingWorktrees(): GitWorktrees =
+    GitWorktrees(
+      repoRoot = tempDir("repo"),
+      cacheRoot = tempDir("cache"),
+      allowedRefs = emptyList(),
+      git = { _, _ -> GitResult(0, "deadbeef\n") },
+    )
+
   @Test
-  fun `project mode is failed closed before any checkout (RCE stopgap)`() {
-    // create() must fail closed BEFORE resolving / checking out the client-supplied revision and
-    // before invoking the builder — see ServeRevisionFactory's TODO("secure this"). When project
-    // mode is hardened (revision allowlist + build isolation) this is replaced with real coverage.
-    val gitInvoked = AtomicBoolean(false)
-    val worktrees =
-      GitWorktrees(
-        repoRoot = tempDir("repo"),
-        cacheRoot = tempDir("cache"),
-        git = { _, _ ->
-          gitInvoked.set(true)
-          GitResult(0, "deadbeef")
-        },
+  fun `create builds an allowed revision and marks it security-checked`() {
+    val securityFlag = AtomicReference<Boolean?>(null)
+    val builder = RevisionBuilder { worktreeDir, _, isSecurityChecked ->
+      securityFlag.set(isSecurityChecked)
+      BuiltRevision(
+        moduleDir = File(worktreeDir, module.relativePath),
+        descriptor = File(worktreeDir, "daemon-launch.json"),
+        previews = listOf(ServePreview(id = "p1", label = "P1")),
       )
+    }
+
+    val state =
+      assertNotNull(ServeRevisionFactory(allowingWorktrees(), builder, module).create("HEAD"))
+    assertEquals(true, securityFlag.get(), "the builder is told the rev cleared the allowlist")
+    assertEquals("samples:cmp@HEAD", state.label)
+    assertEquals(listOf("p1"), state.previews.map { it.id })
+  }
+
+  @Test
+  fun `create returns null and never builds a revision refused by the allowlist`() {
     val builderInvoked = AtomicBoolean(false)
-    val builder = RevisionBuilder { _, _ ->
+    val builder = RevisionBuilder { _, _, _ ->
       builderInvoked.set(true)
       null
     }
 
-    assertFailsWith<NotImplementedError> {
-      ServeRevisionFactory(worktrees, builder, module).create("HEAD")
+    assertNull(ServeRevisionFactory(refusingWorktrees(), builder, module).create("HEAD"))
+    assertFalse(builderInvoked.get(), "the builder must not run for a disallowed revision")
+  }
+
+  @Test
+  fun `create returns null when the builder fails`() {
+    val builder = RevisionBuilder { _, _, _ -> null }
+    assertNull(ServeRevisionFactory(allowingWorktrees(), builder, module).create("HEAD"))
+  }
+
+  @Test
+  fun `create returns null for a blank session id without touching git`() {
+    val builderInvoked = AtomicBoolean(false)
+    val builder = RevisionBuilder { _, _, _ ->
+      builderInvoked.set(true)
+      null
     }
-    assertFalse(gitInvoked.get(), "no revision is checked out while project mode is failed closed")
-    assertFalse(builderInvoked.get(), "the builder must not run while failed closed")
+    assertNull(ServeRevisionFactory(refusingWorktrees(), builder, module).create("   "))
+    assertFalse(builderInvoked.get())
   }
 }


### PR DESCRIPTION
## Summary

Replaces the fail-closed `TODO` stopgap from #2029 with the real project-mode hardening for `compose-preview serve --revisions`.

Building a requested revision runs that checkout's **own Gradle** (code execution as the server user), so an arbitrary client-supplied `?session=<rev>` must never be buildable. This PR makes the server only check out and build a revision that is **reachable from an operator-trusted ref**.

- `GitWorktrees` takes an `allowedRefs` list. `prepare()` resolves the rev to a sha, then refuses any sha that isn't an ancestor of an allowed ref (`git merge-base --is-ancestor <sha> <ref>^{commit}`). An **empty allowlist means nothing builds** (fail closed).
- **Refs are qualified to branches/remote-tracking branches, never tags.** A short entry like `main`/`origin/main` is resolved to `refs/heads/<name>` then `refs/remotes/<name>` before the ancestry check — gitrevisions resolves an ambiguous `<name>` as `refs/tags/<name>` *first*, so a same-named malicious tag could otherwise satisfy a branch allowlist. An already-qualified `refs/…` ref is honoured verbatim, so a tag can be opted in deliberately as `refs/tags/<name>`. (Addresses the Codex P1 review.)
- `ServeCommand` parses `--revisions-allow <ref>[,<ref>…]` and prints a fail-closed warning when `--revisions` is set without it. Usage text documents the security gate.
- `RevisionBuilder.build` gains a required `isSecurityChecked` audit marker (documented, no runtime enforcement per the agreed convention); the factory passes `true` only after the allowlist has cleared the rev.

This is the "Allowlist of refs" policy decision for project mode.

## Test plan
- `GitWorktreesTest`: allow (reachable from an allowed ref), refuse (reachable only from a non-allowed ref), fail-closed (empty allowlist), multi-ref allow, **tag-shadow rejected** (only a tag named `main` exists → refused), **explicit `refs/tags/<name>` honoured**, plus resolve/reuse/close paths.
- `ServeRevisionFactoryTest`: builds an allowed rev and asserts the builder is told `isSecurityChecked = true`; returns null without invoking the builder for a refused rev; null on builder failure; null on blank id.
- `./gradlew :cli:test` + `:cli:ktfmtCheck*` green.

Non-visual change (CLI security plumbing), so no rendered evidence.