### PR TITLE
feat(fake-emulator): impersonate an Android emulator over ADB + emulator gRPC

### DIFF
--- a/docs/fake-emulator/DESIGN.md
+++ b/docs/fake-emulator/DESIGN.md
@@ -125,9 +125,18 @@ Studio's embedded view + a screenshot video stream:
 - `sendKey` / `sendTouch` — mapped onto `RenderSession` interactive input where
   available (future: full pointer routing).
 
-The proto is vendored (not a runtime dep on the SDK) and compiled with the
-protobuf Gradle plugin + grpc-kotlin. Generated sources land under `build/` so
-ktfmt never sees them.
+The proto is vendored (not a runtime dep on the SDK). Square **Wire** generates
+the message classes (pure-Kotlin codegen, no `protoc`); the gRPC service is bound
+by hand into grpc-netty via grpc-java's `ServerCalls` + a small Wire
+`MethodDescriptor.Marshaller` (Wire dropped its own server-side gRPC artifact
+after 4.9.11). Generated sources land under `build/` so ktfmt never sees them.
+
+The vendored proto is a *subset* of the canonical `emulator_controller.proto`,
+but the field **numbers and types** of the messages it defines are kept
+wire-compatible with the real schema (cross-checked against `google-deepmind/
+android_env`, AOSP `external/qemu`, and `yschimke/emulator-tools`) so a real
+Studio client decodes our responses — e.g. `EmulatorStatus.booted = 3`,
+`Image.image = 4`. Fields we don't model are omitted, not renumbered.
 
 ## Frame source
 

--- a/docs/fake-emulator/DESIGN.md
+++ b/docs/fake-emulator/DESIGN.md
@@ -1,0 +1,194 @@
+# Fake Android emulator — design
+
+A standalone module that **impersonates a running Android emulator** so that
+the compose-preview render pipeline can be driven by the same tools that drive
+a real device: `adb`, Android Studio's device list, and (later) Studio's
+embedded "Running Devices" panel.
+
+It is *not* an Android runtime. There is no ART, no system server, no real
+`am`. Instead the fake emulator answers the wire protocols a real emulator
+exposes and routes the handful of requests that matter — "launch this preview",
+"give me the screen" — into the existing daemon / `serve` render path. The
+emulator's "screen" is whatever the renderer last produced for the launched
+`@Preview`.
+
+```
+        ┌─────────────────┐   adb (transport)         ┌──────────────────────────┐
+        │ adb server /    │◀────TCP, CNXN/OPEN/…──────▶│ FakeEmulator              │
+        │ Android Studio  │                            │                          │
+        │ dadb / Adam     │   emulator console (5554)  │  ┌────────────────────┐  │
+        └─────────────────┘◀────TCP, text protocol────▶│  │ AdbTransportServer │  │
+                  │                                     │  │  shell,v2 / sync / │  │
+                  │         emulator gRPC               │  │  screencap         │  │
+                  └─────────gRPC, EmulatorController────▶│  └─────────┬──────────┘  │
+                            getScreenshot / stream      │            │ am start    │
+                                                        │            ▼             │
+                                                        │   PreviewLauncher ───────┼──┐
+                                                        │   FrameSource ◀──frames──┼─┐│
+                                                        └──────────────────────────┘ ││
+                                                                                      ││
+                                          ┌───────────────────────────────────────┐  ││
+                                          │ RenderSession (:render-session-api)    │◀─┘│
+                                          │  streamStart + streamFrame  →  PNG     │◀──┘
+                                          │  (daemon subprocess, serve)            │
+                                          └───────────────────────────────────────┘
+```
+
+## Why build on the remote-daemon / `serve` work
+
+`compose-preview serve` already turns a `RenderSession` into a stream of PNG /
+WebP frames over a WebSocket (`/ws/{previewId}`), with a held interactive
+composition behind it (`stream/start` + `streamFrame`, see
+`docs/daemon/STREAMING.md`). The fake emulator reuses exactly that frame source.
+The only new surface is the *device-shaped* front end (ADB + console + gRPC)
+that re-publishes those frames as an emulator display and maps `am start
+… PreviewActivity --es composable <fqn>` onto a preview switch.
+
+A direct consequence (and an explicit future goal): because the frame source is
+the same `RenderSession` abstraction `serve` consumes, the fake emulator can be
+fronted by the `serve` HTTP streaming lane too — start an emulator locally, then
+**share a URL** that streams the same display. See "Sharing a URL" below.
+
+## Modules
+
+| Gradle path            | Directory             | What it is |
+|------------------------|-----------------------|------------|
+| `:fake-emulator-core`  | `fake-emulator/core`  | Pure-Kotlin ADB transport (adbd), emulator console, screencap, the `am start` preview-launch intent parser, the `FrameSource` / `PreviewLauncher` SPIs, and the Studio discovery-file writer. No render, no gRPC, no Android deps — unit-testable with `dadb`. |
+| `:fake-emulator-grpc`  | `fake-emulator/grpc`  | The emulator `EmulatorController` gRPC service (subset) + screenshot video stream, generated from a vendored `emulator_controller.proto`, backed by a `FrameSource`. Isolated so the protobuf/grpc toolchain stays out of the core. |
+| `:fake-emulator`       | `fake-emulator/app`   | Runnable launcher. Wires core + gRPC + a `RenderSessionFrameSource` (real frames from a daemon/`serve` session) and writes the discovery files so the process shows up as a device. |
+
+The split keeps the **verifiable ADB core** free of the heavyweight
+protobuf/gRPC toolchain and the render classpath, so its `dadb` tests run fast
+and hermetically.
+
+## ADB device transport (`:fake-emulator-core`)
+
+We implement the *device* side of the adb transport protocol (what adbd
+speaks), so an adb client connects to us directly (`adb connect host:port`, or
+dadb / Adam pointed at our TCP port). 24-byte message header
+(`command,arg0,arg1,data_length,data_crc32,magic`), commands `CNXN`, `OPEN`,
+`OKAY`, `WRTE`, `CLSE`, (`AUTH`/`STLS` negotiated away — we connect un-authed,
+the simplest interop path that dadb and `adb` both accept).
+
+Per-OPEN we allocate a remote stream id and dispatch on the destination string:
+
+| Destination            | Handling |
+|------------------------|----------|
+| `shell,v2:<cmd>`       | Shell-protocol framed (id+len+payload; stdout/stderr/exit). The modern path dadb/`adb` prefer. |
+| `shell:<cmd>`          | Legacy raw shell (no framing). |
+| `sync:`                | Minimal file-sync (STAT/SEND/RECV/QUIT) so install-shaped flows don't hang. |
+| `framebuffer:`         | Reserved; `screencap` is the supported screenshot path. |
+
+The shell command interpreter is deliberately small — a real device runs
+thousands of commands, we answer the few that matter for *device detection* and
+*preview launch*:
+
+- `getprop [name]` — a fixed property map (`ro.product.*`, `ro.build.version.*`,
+  `ro.kernel.qemu=1`, …) so clients classify us as an emulator.
+- `am start -n <app>/androidx.compose.ui.tooling.PreviewActivity --es composable
+  <fqn> [--es parameterProviderClassName <fqn>]` — parsed into a
+  `PreviewLaunchRequest` and handed to the injected `PreviewLauncher`. This is
+  the exact argv Android Studio's "Deploy Preview to Device" and the VS Code
+  extension already emit (`vscode-extension/src/launchOnDevice.ts`).
+- `screencap [-p]` — returns the current `FrameSource` frame as PNG bytes.
+- Common detection no-ops (`wm size`, `echo`, `id`, …) answered plausibly;
+  everything else returns empty output + exit 0.
+
+## Emulator console (`:fake-emulator-core`)
+
+A small text-protocol server on the console port (default 5554). Emits the
+emulator banner + `OK`, accepts un-authed sessions, and answers `help`, `avd
+name`, `avd path`, `redir list`, `kill`, `quit`. This is what classic
+`adb`-emulator auto-detection probes; pairing the console port (5554) with the
+adb port (5555) is what makes a real emulator appear as `emulator-5554`.
+
+## Discovery (`:fake-emulator`)
+
+Android Studio finds running emulators by reading registration files the
+emulator drops in its discovery directory (`$XDG_RUNTIME_DIR/avd/running/` →
+`$TMPDIR/avd/running/` → `~/.android/avd/running/`), named `pid_<pid>.ini`,
+carrying `port.serial`, `port.adb`, `avd.name`, `grpc.port`, and `grpc.token`.
+We write the same file (and delete it on shutdown) so the embedded-emulator
+catalog lists us and knows where our gRPC lives.
+
+## Emulator gRPC (`:fake-emulator-grpc`)
+
+A subset of `android.emulation.control.EmulatorController` sufficient for
+Studio's embedded view + a screenshot video stream:
+
+- `getStatus`, `getVmConfiguration` — identity / liveness.
+- `getDisplayConfigurations` — our display size (from the `FrameSource`).
+- `getScreenshot` — one frame (PNG) from the `FrameSource`.
+- `streamScreenshot` — the **video** stream: a server-streaming RPC that
+  forwards every `FrameSource` frame as an `Image` message. This is the same
+  frame feed the ADB `screencap` path serves, just pushed continuously.
+- `sendKey` / `sendTouch` — mapped onto `RenderSession` interactive input where
+  available (future: full pointer routing).
+
+The proto is vendored (not a runtime dep on the SDK) and compiled with the
+protobuf Gradle plugin + grpc-kotlin. Generated sources land under `build/` so
+ktfmt never sees them.
+
+## Frame source
+
+```kotlin
+interface FrameSource {
+  val display: DisplaySize
+  fun latest(): EmulatorFrame?               // pull (screencap / getScreenshot)
+  fun subscribe(sink: (EmulatorFrame) -> Unit): AutoCloseable  // push (video)
+}
+```
+
+- `:fake-emulator-core` ships an in-memory `MutableFrameSource` (tests, and the
+  "no preview launched yet" placeholder).
+- `:fake-emulator` ships `RenderSessionFrameSource`, which opens a
+  `RenderSession`, calls `streamStart` on preview launch, and republishes
+  `streamFrame` notifications as `EmulatorFrame`s — i.e. the real preview
+  pixels. This is the "wire to serve/daemon" path.
+
+## Preview launch flow
+
+1. `adb shell am start -n …/PreviewActivity --es composable com.x.FooKt.Bar`
+2. ADB shell interpreter parses it → `PreviewLaunchRequest("com.x.FooKt.Bar")`.
+3. `RenderSessionFrameSource` maps the FQN to a preview id and calls
+   `session.streamStart(previewId)`.
+4. `streamFrame` notifications flow → `EmulatorFrame`s → become the emulator
+   display (ADB `screencap`, gRPC `getScreenshot`/`streamScreenshot`).
+
+## Sharing a URL (future)
+
+Because the display is a `FrameSource` and `serve` already streams a
+`RenderSession` over HTTP/WS, a follow-up wires the *same* `FrameSource` into a
+`serve` lane: run `compose-preview fake-emulator --serve`, get a
+`composeai://session` / `http://…/p/{previewId}` URL, and the emulator screen is
+viewable remotely with the existing mobile/wear clients. No new streaming code —
+just point `serve`'s frame producer at the emulator's `FrameSource`.
+
+## What this PR delivers vs. defers
+
+**Delivered:** the module layout + build wiring; the ADB transport core
+(CNXN/OPEN/OKAY/WRTE/CLSE, shell v2 + v1, minimal sync, screencap), the `am
+start` preview-launch parser, the console, the discovery writer, the
+`FrameSource`/`PreviewLauncher` SPIs, the `RenderSessionFrameSource` bridge, the
+gRPC `EmulatorController` subset + screenshot stream, a runnable launcher, and
+`dadb`-driven tests for the ADB + preview-launch path.
+
+**Deferred:** full sync (large APK install), authenticated adb (RSA/TLS),
+complete `EmulatorController` surface, pointer/key fidelity, and the `serve`
+URL-sharing wire-up above.
+
+## Testing
+
+The ADB core is verified with **`dadb`** (`dev.mobile:dadb`), which speaks the
+device transport directly — no real `adb` binary or device required. Tests:
+
+- connect handshake → `dadb` reports the device online + banner props;
+- `dadb.shell("getprop ro.kernel.qemu")` → `1`;
+- `dadb.shell("am start -n app/androidx.compose.ui.tooling.PreviewActivity --es
+  composable com.x.FooKt.Bar")` → the injected `PreviewLauncher` receives
+  `com.x.FooKt.Bar`;
+- `screencap -p` → the bytes of the current `FrameSource` frame.
+
+Integration against a real `RenderSession` (full daemon + Robolectric) and a
+real Android Studio is manual / CI-gated; it is not exercised by the unit
+suite.

--- a/docs/fake-emulator/README.md
+++ b/docs/fake-emulator/README.md
@@ -1,0 +1,58 @@
+# Fake Android emulator
+
+A standalone module set that **impersonates a running Android emulator** so the
+compose-preview render pipeline can be driven by the tools that drive a real
+device — `adb`, Android Studio's device list, and Studio's embedded "Running
+Devices" view — and a preview launched on it with the same intent Studio's
+"Deploy Preview to Device" uses.
+
+It is not an Android runtime. It answers the wire protocols a real emulator
+exposes and routes the requests that matter (`am start … PreviewActivity`,
+screenshot, screenshot stream) into the existing daemon / `serve` render path.
+The emulator's "screen" is whatever the renderer last produced for the launched
+`@Preview`.
+
+See [DESIGN.md](DESIGN.md) for the architecture and the full scope /
+deferred-work breakdown.
+
+## Modules
+
+- **`:fake-emulator-core`** — pure-Kotlin ADB device transport (adbd), emulator
+  console, `screencap`, the `am start … PreviewActivity` preview-launch parser,
+  the `FrameSource` / `PreviewLauncher` SPIs, and the Studio discovery-file
+  writer. `dadb`-tested.
+- **`:fake-emulator-grpc`** — the emulator `EmulatorController` gRPC subset +
+  screenshot video stream, from a vendored `emulator_controller.proto`.
+- **`:fake-emulator`** — runnable launcher wiring core + gRPC + a
+  RenderSession-backed `FrameSource`.
+
+## Run it
+
+```bash
+# Placeholder screen (no project), good for ADB / Studio bring-up:
+./gradlew :fake-emulator:run --args="--adb-port 5555 --console-port 5554"
+
+# Driven by a real render session (preview pixels become the screen):
+./gradlew :fake-emulator:run --args="\
+  --descriptor samples/android/build/compose-previews/daemon-launch.json \
+  --adb-port 5555 --console-port 5554"
+```
+
+Then:
+
+```bash
+adb connect localhost:5555
+adb -s emulator-5554 shell am start \
+  -n com.example.app/androidx.compose.ui.tooling.PreviewActivity \
+  --es composable com.example.PreviewsKt.MyPreview
+adb -s emulator-5554 exec-out screencap -p > screen.png
+```
+
+## Test
+
+```bash
+./gradlew :fake-emulator-core:test
+```
+
+The ADB transport + preview-launch path is verified with `dadb`, which speaks
+the device protocol directly — no real `adb` or device required.

--- a/fake-emulator/app/build.gradle.kts
+++ b/fake-emulator/app/build.gradle.kts
@@ -1,0 +1,29 @@
+plugins {
+  id("composeai.base-conventions")
+  id("composeai.jvm-conventions")
+  alias(libs.plugins.kotlin.jvm)
+  application
+}
+
+// Runnable launcher for the fake Android emulator. Wires the ADB core + the emulator gRPC service +
+// a RenderSession-backed FrameSource so a launched @Preview becomes the emulator display, and
+// writes
+// the Studio discovery file. Unpublished tooling. See docs/fake-emulator/DESIGN.md.
+dependencies {
+  implementation(project(":fake-emulator-core"))
+  implementation(project(":fake-emulator-grpc"))
+  implementation(project(":render-session-api"))
+  implementation(project(":render-session-subprocess"))
+  implementation(project(":daemon:core"))
+  implementation(libs.kotlinx.coroutines.core)
+  implementation(libs.kotlinx.serialization.json)
+  implementation(libs.okio)
+
+  testImplementation(libs.junit)
+  testImplementation(libs.truth)
+}
+
+application {
+  applicationName = "fake-emulator"
+  mainClass.set("ee.schimke.composeai.fakeemulator.app.MainKt")
+}

--- a/fake-emulator/app/src/main/kotlin/ee/schimke/composeai/fakeemulator/app/Main.kt
+++ b/fake-emulator/app/src/main/kotlin/ee/schimke/composeai/fakeemulator/app/Main.kt
@@ -1,0 +1,152 @@
+package ee.schimke.composeai.fakeemulator.app
+
+import ee.schimke.composeai.fakeemulator.DisplaySize
+import ee.schimke.composeai.fakeemulator.FakeEmulator
+import ee.schimke.composeai.fakeemulator.FakeEmulatorConfig
+import ee.schimke.composeai.fakeemulator.FrameSource
+import ee.schimke.composeai.fakeemulator.MutableFrameSource
+import ee.schimke.composeai.fakeemulator.PlaceholderImage
+import ee.schimke.composeai.fakeemulator.PreviewLauncher
+import ee.schimke.composeai.fakeemulator.grpc.EmulatorControllerService
+import ee.schimke.composeai.fakeemulator.grpc.FakeEmulatorGrpcServer
+import ee.schimke.composeai.render.session.RenderSessionConfig
+import ee.schimke.composeai.render.session.subprocess.SubprocessRenderSessions
+import java.io.File
+
+/**
+ * Launches a fake Android emulator. With `--descriptor <daemon-launch.json>` the display is driven
+ * by a real [RenderSession][ee.schimke.composeai.render.session.RenderSession] (preview pixels via
+ * the daemon stream); without it the emulator runs against a placeholder screen — handy for ADB /
+ * Studio bring-up with no project to render.
+ *
+ * ```
+ * fake-emulator --descriptor build/compose-previews/daemon-launch.json \
+ *   --adb-port 5555 --console-port 5554
+ * # then: adb connect localhost:5555
+ * #       adb -s emulator-5554 shell am start -n app/androidx.compose.ui.tooling.PreviewActivity \
+ * #            --es composable com.example.PreviewsKt.MyPreview
+ * ```
+ */
+fun main(args: Array<String>) {
+  val options = Options.parse(args)
+  val display = DisplaySize(options.width, options.height, options.dpi)
+
+  val frameSource: FrameSource
+  val launcher: PreviewLauncher
+  val extraClose: AutoCloseable
+
+  if (options.descriptor != null) {
+    val session =
+      SubprocessRenderSessions.open(RenderSessionConfig(descriptorPath = File(options.descriptor)))
+    val bridge = RenderSessionFrameSource(session, display)
+    frameSource = bridge
+    launcher = bridge
+    extraClose = AutoCloseable {
+      bridge.close()
+      session.close()
+    }
+  } else {
+    val mutable = MutableFrameSource(display)
+    mutable.push(PlaceholderImage.solidPng(display.width, display.height, PLACEHOLDER_ARGB), 0)
+    frameSource = mutable
+    launcher = PreviewLauncher.NOOP
+    extraClose = AutoCloseable {}
+  }
+
+  val grpc =
+    FakeEmulatorGrpcServer(options.grpcPort, EmulatorControllerService(frameSource).bindService())
+      .start()
+
+  val emulator =
+    FakeEmulator(
+        FakeEmulatorConfig(
+          display = display,
+          consolePort = options.consolePort,
+          adbPort = options.adbPort,
+          avdName = options.avdName,
+          enableConsole = !options.noConsole,
+          writeDiscovery = !options.noDiscovery,
+          grpcPort = grpc.boundPort,
+        ),
+        frameSource = frameSource,
+        previewLauncher = launcher,
+      )
+      .start()
+
+  println("fake-emulator started")
+  println("  serial:  ${emulator.serial}")
+  println("  adb:     localhost:${emulator.adbPort}  (adb connect localhost:${emulator.adbPort})")
+  if (emulator.consolePort > 0) println("  console: localhost:${emulator.consolePort}")
+  println("  grpc:    localhost:${grpc.boundPort}")
+
+  Runtime.getRuntime()
+    .addShutdownHook(
+      Thread {
+        runCatching { emulator.close() }
+        runCatching { grpc.close() }
+        runCatching { extraClose.close() }
+      }
+    )
+
+  grpc.awaitTermination()
+}
+
+private const val PLACEHOLDER_ARGB = 0xFF202124.toInt()
+
+private class Options(
+  val descriptor: String?,
+  val adbPort: Int,
+  val consolePort: Int,
+  val grpcPort: Int,
+  val width: Int,
+  val height: Int,
+  val dpi: Int,
+  val avdName: String,
+  val noConsole: Boolean,
+  val noDiscovery: Boolean,
+) {
+  companion object {
+    fun parse(args: Array<String>): Options {
+      var descriptor: String? = null
+      var adbPort = 0
+      var consolePort = 0
+      var grpcPort = 0
+      var width = 1080
+      var height = 2340
+      var dpi = 420
+      var avdName = "Compose_Preview"
+      var noConsole = false
+      var noDiscovery = false
+      var i = 0
+      fun next(): String = args.getOrNull(++i) ?: error("missing value for ${args[i - 1]}")
+      while (i < args.size) {
+        when (val arg = args[i]) {
+          "--descriptor" -> descriptor = next()
+          "--adb-port" -> adbPort = next().toInt()
+          "--console-port" -> consolePort = next().toInt()
+          "--grpc-port" -> grpcPort = next().toInt()
+          "--width" -> width = next().toInt()
+          "--height" -> height = next().toInt()
+          "--dpi" -> dpi = next().toInt()
+          "--avd-name" -> avdName = next()
+          "--no-console" -> noConsole = true
+          "--no-discovery" -> noDiscovery = true
+          else -> error("unknown argument: $arg")
+        }
+        i++
+      }
+      return Options(
+        descriptor,
+        adbPort,
+        consolePort,
+        grpcPort,
+        width,
+        height,
+        dpi,
+        avdName,
+        noConsole,
+        noDiscovery,
+      )
+    }
+  }
+}

--- a/fake-emulator/app/src/main/kotlin/ee/schimke/composeai/fakeemulator/app/RenderSessionFrameSource.kt
+++ b/fake-emulator/app/src/main/kotlin/ee/schimke/composeai/fakeemulator/app/RenderSessionFrameSource.kt
@@ -1,0 +1,83 @@
+package ee.schimke.composeai.fakeemulator.app
+
+import ee.schimke.composeai.daemon.protocol.StreamCodec
+import ee.schimke.composeai.daemon.protocol.StreamFrameParams
+import ee.schimke.composeai.fakeemulator.DisplaySize
+import ee.schimke.composeai.fakeemulator.EmulatorFrame
+import ee.schimke.composeai.fakeemulator.FrameSource
+import ee.schimke.composeai.fakeemulator.MutableFrameSource
+import ee.schimke.composeai.fakeemulator.PreviewLaunchRequest
+import ee.schimke.composeai.fakeemulator.PreviewLaunchResult
+import ee.schimke.composeai.fakeemulator.PreviewLauncher
+import ee.schimke.composeai.render.session.RenderSession
+import java.util.Base64
+import java.util.concurrent.atomic.AtomicLong
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+
+/**
+ * Bridges a [RenderSession] (the daemon / `serve` render path) to the emulator's display. It is
+ * both the [FrameSource] the ADB `screencap` + gRPC screenshot lanes read and the [PreviewLauncher]
+ * the `am start … PreviewActivity` intent drives:
+ *
+ * 1. `launch(request)` maps the composable FQN to a preview id and calls
+ *    [RenderSession.streamStart].
+ * 2. The daemon then pushes `streamFrame` notifications; we decode each into an [EmulatorFrame] and
+ *    publish it — so the launched preview's pixels become the emulator screen.
+ *
+ * This is the "wire to serve/daemon" path: no new streaming machinery, just the existing
+ * held-stream frame feed re-published as a device display.
+ */
+class RenderSessionFrameSource(
+  private val session: RenderSession,
+  override val display: DisplaySize,
+  private val json: Json = Json { ignoreUnknownKeys = true },
+) : FrameSource, PreviewLauncher, AutoCloseable {
+  private val delegate = MutableFrameSource(display)
+  private val seq = AtomicLong(0)
+  @Volatile private var currentStreamId: String? = null
+
+  private val subscription = session.onNotification { method, params ->
+    if (method == "streamFrame" && params != null) onStreamFrame(params)
+  }
+
+  override fun latest(): EmulatorFrame? = delegate.latest()
+
+  override fun subscribe(sink: (EmulatorFrame) -> Unit): AutoCloseable = delegate.subscribe(sink)
+
+  override fun launch(request: PreviewLaunchRequest): PreviewLaunchResult {
+    val previewId = previewIdFor(request)
+    return try {
+      currentStreamId?.let { runCatching { session.streamStop(it) } }
+      val result = session.streamStart(previewId, codec = StreamCodec.PNG)
+      currentStreamId = result.frameStreamId
+      PreviewLaunchResult.Launched
+    } catch (e: Exception) {
+      PreviewLaunchResult.Rejected(e.message ?: "stream start failed for $previewId")
+    }
+  }
+
+  private fun onStreamFrame(params: JsonObject) {
+    val frame =
+      runCatching { json.decodeFromJsonElement(StreamFrameParams.serializer(), params) }.getOrNull()
+        ?: return
+    if (frame.frameStreamId != currentStreamId) return
+    val payload = frame.payloadBase64 ?: return // unchanged-heartbeat: nothing to paint
+    val bytes = runCatching { Base64.getDecoder().decode(payload) }.getOrNull() ?: return
+    delegate.push(EmulatorFrame(frame.widthPx, frame.heightPx, bytes, seq.incrementAndGet()))
+  }
+
+  override fun close() {
+    subscription.close()
+    currentStreamId?.let { runCatching { session.streamStop(it) } }
+  }
+
+  private companion object {
+    /**
+     * The preview id is, by convention in this repo, the `className.functionName` FQN — which is
+     * exactly what the `composable` intent extra carries. Use it directly; a richer mapping
+     * (manifest lookup, parameter-provider suffixes) is future work.
+     */
+    fun previewIdFor(request: PreviewLaunchRequest): String = request.composableFqn
+  }
+}

--- a/fake-emulator/core/build.gradle.kts
+++ b/fake-emulator/core/build.gradle.kts
@@ -1,0 +1,21 @@
+plugins {
+  id("composeai.base-conventions")
+  id("composeai.jvm-conventions")
+  alias(libs.plugins.kotlin.jvm)
+}
+
+// Unpublished tooling module (like :daemon:harness) — a fake Android emulator's ADB transport,
+// console, screencap, the `am start … PreviewActivity` preview-launch parser, and the
+// FrameSource / PreviewLauncher SPIs. Deliberately dependency-light (coroutines + okio only) and
+// free of the render classpath + protobuf/grpc toolchain so its `dadb` tests run fast and
+// hermetically. See docs/fake-emulator/DESIGN.md.
+dependencies {
+  implementation(libs.kotlinx.coroutines.core)
+  implementation(libs.okio)
+
+  testImplementation(libs.junit)
+  testImplementation(libs.truth)
+  // dadb speaks the device transport protocol directly to our fake adbd — no real `adb` / device.
+  testImplementation(libs.dadb)
+  testImplementation(libs.kotlinx.coroutines.core)
+}

--- a/fake-emulator/core/src/main/kotlin/ee/schimke/composeai/fakeemulator/AdbConnection.kt
+++ b/fake-emulator/core/src/main/kotlin/ee/schimke/composeai/fakeemulator/AdbConnection.kt
@@ -1,0 +1,204 @@
+package ee.schimke.composeai.fakeemulator
+
+import java.io.InputStream
+import java.io.OutputStream
+import java.net.Socket
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.Semaphore
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Resolves an OPEN destination string (`shell,v2:…`, `sync:`, …) to a handler, or `null` to reject.
+ */
+interface AdbServiceResolver {
+  fun resolve(destination: String): AdbService?
+}
+
+/**
+ * One ADB device service. Runs on its own thread; [io] is closed automatically after [run] returns.
+ */
+interface AdbService {
+  fun run(io: AdbStreamIo)
+}
+
+/**
+ * Byte duplex for one ADB stream. [write] is flow-controlled; [read] returns `null` at peer close.
+ */
+interface AdbStreamIo {
+  val destination: String
+
+  fun write(bytes: ByteArray)
+
+  fun read(): ByteArray?
+
+  fun close()
+}
+
+/**
+ * One accepted ADB transport connection (one socket). Owns the read loop, the CNXN handshake, and
+ * the per-OPEN stream multiplex with the protocol's one-outstanding-write flow control.
+ */
+internal class AdbConnection(
+  private val socket: Socket,
+  private val banner: ByteArray,
+  private val resolver: AdbServiceResolver,
+  private val spawn: (Runnable) -> Unit,
+) {
+  private val input: InputStream = socket.getInputStream()
+  private val output: OutputStream = socket.getOutputStream()
+  private val writeLock = Any()
+  private val streams = ConcurrentHashMap<Int, Stream>()
+  private val nextLocalId = AtomicInteger(1)
+  @Volatile private var peerMaxData = AdbProtocol.MAX_PAYLOAD
+
+  fun run() {
+    try {
+      while (true) {
+        val message = AdbProtocol.read(input) ?: break
+        dispatch(message)
+      }
+    } catch (_: Exception) {
+      // Peer disconnected or framing error — fall through to teardown.
+    } finally {
+      for (stream in streams.values) stream.forceClose()
+      streams.clear()
+      runCatching { socket.close() }
+    }
+  }
+
+  private fun dispatch(message: AdbMessage) {
+    when (message.command) {
+      AdbProtocol.A_CNXN -> {
+        if (message.arg1 in 1..(64 * 1024 * 1024)) peerMaxData = message.arg1
+        send(AdbMessage(AdbProtocol.A_CNXN, AdbProtocol.A_VERSION, AdbProtocol.MAX_PAYLOAD, banner))
+      }
+      AdbProtocol.A_OPEN -> open(peerLocalId = message.arg0, destination = cstr(message.payload))
+      AdbProtocol.A_OKAY -> streams[message.arg1]?.grantWrite()
+      AdbProtocol.A_WRTE -> {
+        val stream = streams[message.arg1]
+        if (stream != null) {
+          stream.deliver(message.payload)
+          // Ack so the peer may send its next WRTE.
+          send(AdbMessage(AdbProtocol.A_OKAY, stream.localId, stream.peerLocalId))
+        }
+      }
+      AdbProtocol.A_CLSE -> streams.remove(message.arg1)?.peerClosed()
+      // AUTH / STLS: we connect un-authed and advertise no TLS, so we never negotiate either.
+      else -> Unit
+    }
+  }
+
+  private fun open(peerLocalId: Int, destination: String) {
+    val service = resolver.resolve(destination)
+    if (service == null) {
+      // Reject: CLSE with local-id 0 tells the opener the stream was refused.
+      send(AdbMessage(AdbProtocol.A_CLSE, 0, peerLocalId))
+      return
+    }
+    val localId = nextLocalId.getAndIncrement()
+    val stream = Stream(localId, peerLocalId, destination)
+    streams[localId] = stream
+    send(AdbMessage(AdbProtocol.A_OKAY, localId, peerLocalId))
+    spawn {
+      try {
+        service.run(stream)
+      } catch (_: Exception) {
+        // Service blew up — just close the stream below.
+      } finally {
+        stream.close()
+      }
+    }
+  }
+
+  private fun send(message: AdbMessage) {
+    synchronized(writeLock) { AdbProtocol.write(output, message) }
+  }
+
+  private fun cstr(bytes: ByteArray): String {
+    val end = bytes.indexOf(0).let { if (it < 0) bytes.size else it }
+    return String(bytes, 0, end, StandardCharsets.UTF_8)
+  }
+
+  private fun ByteArray.indexOf(b: Int): Int {
+    for (i in indices) if (this[i].toInt() == b) return i
+    return -1
+  }
+
+  /** One logical ADB stream within this connection. */
+  private inner class Stream(
+    val localId: Int,
+    val peerLocalId: Int,
+    override val destination: String,
+  ) : AdbStreamIo {
+    // Protocol flow control: at most one un-acked WRTE in flight. Starts ready (1 permit).
+    private val writeReady = Semaphore(1)
+    private val inbound = LinkedBlockingQueue<ByteArray>()
+    private val closed = AtomicBoolean(false)
+    private val sentClose = AtomicBoolean(false)
+
+    override fun write(bytes: ByteArray) {
+      var offset = 0
+      val chunkSize = peerMaxData.coerceAtMost(AdbProtocol.MAX_PAYLOAD)
+      while (offset < bytes.size && !closed.get()) {
+        val end = (offset + chunkSize).coerceAtMost(bytes.size)
+        val chunk = bytes.copyOfRange(offset, end)
+        writeReady.acquire()
+        if (closed.get()) return
+        send(AdbMessage(AdbProtocol.A_WRTE, localId, peerLocalId, chunk))
+        offset = end
+      }
+    }
+
+    override fun read(): ByteArray? {
+      val chunk = inbound.take()
+      return if (chunk === EOF) null else chunk
+    }
+
+    override fun close() {
+      if (closed.compareAndSet(false, true)) {
+        if (sentClose.compareAndSet(false, true)) {
+          send(AdbMessage(AdbProtocol.A_CLSE, localId, peerLocalId))
+        }
+        streams.remove(localId)
+        inbound.offer(EOF)
+        // Unblock a writer parked on flow control.
+        if (writeReady.availablePermits() == 0) writeReady.release()
+      }
+    }
+
+    fun grantWrite() {
+      if (writeReady.availablePermits() == 0) writeReady.release()
+    }
+
+    fun deliver(payload: ByteArray) {
+      if (payload.isNotEmpty()) inbound.offer(payload)
+    }
+
+    /** Peer sent CLSE: ack with our CLSE (once) and tear down. */
+    fun peerClosed() {
+      if (closed.compareAndSet(false, true)) {
+        if (sentClose.compareAndSet(false, true)) {
+          send(AdbMessage(AdbProtocol.A_CLSE, localId, peerLocalId))
+        }
+        inbound.offer(EOF)
+        if (writeReady.availablePermits() == 0) writeReady.release()
+      }
+    }
+
+    /** Connection teardown: stop blocking readers/writers without emitting more packets. */
+    fun forceClose() {
+      closed.set(true)
+      sentClose.set(true)
+      inbound.offer(EOF)
+      if (writeReady.availablePermits() == 0) writeReady.release()
+    }
+  }
+
+  private companion object {
+    /** Identity sentinel queued to signal "no more inbound data" to [Stream.read]. */
+    val EOF = ByteArray(0)
+  }
+}

--- a/fake-emulator/core/src/main/kotlin/ee/schimke/composeai/fakeemulator/AdbProtocol.kt
+++ b/fake-emulator/core/src/main/kotlin/ee/schimke/composeai/fakeemulator/AdbProtocol.kt
@@ -1,0 +1,104 @@
+package ee.schimke.composeai.fakeemulator
+
+import java.io.DataInputStream
+import java.io.EOFException
+import java.io.InputStream
+import java.io.OutputStream
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+/**
+ * The ADB transport ("smart socket") wire format — the protocol an adbd device speaks to an adb
+ * host. We implement the device side so a host (`adb connect`, dadb, Adam) talks to us directly.
+ *
+ * Every packet is a 24-byte little-endian header optionally followed by a payload:
+ * ```
+ * struct message {
+ *   u32 command;      // A_CNXN / A_OPEN / A_OKAY / A_WRTE / A_CLSE / A_AUTH / A_STLS
+ *   u32 arg0;
+ *   u32 arg1;
+ *   u32 data_length;  // payload length
+ *   u32 data_check;   // sum of payload bytes (modern adb ignores it; we still write it)
+ *   u32 magic;        // command ^ 0xffffffff
+ * };
+ * ```
+ *
+ * See AOSP `system/core/adb/protocol.txt`.
+ */
+internal object AdbProtocol {
+  // Command constants are the little-endian u32 reading of the 4 ASCII bytes (e.g. "CNXN").
+  const val A_CNXN = 0x4e584e43
+  const val A_OPEN = 0x4e45504f
+  const val A_OKAY = 0x59414b4f
+  const val A_CLSE = 0x45534c43
+  const val A_WRTE = 0x45545257
+  const val A_AUTH = 0x48545541
+  const val A_STLS = 0x534c5453
+
+  /** Protocol version we advertise in the CNXN handshake. */
+  const val A_VERSION = 0x01000000
+
+  /** Max payload we accept / advertise. The effective chunk size is min(ours, peer's). */
+  const val MAX_PAYLOAD = 256 * 1024
+
+  fun checksum(payload: ByteArray): Int {
+    var sum = 0
+    for (b in payload) sum += b.toInt() and 0xff
+    return sum
+  }
+
+  /** Read one message from [input], or `null` on a clean EOF before any header byte. */
+  fun read(input: InputStream): AdbMessage? {
+    val data = DataInputStream(input)
+    val header = ByteArray(24)
+    var read = 0
+    while (read < 24) {
+      val n = data.read(header, read, 24 - read)
+      if (n < 0) {
+        if (read == 0) return null
+        throw EOFException("truncated adb header ($read/24 bytes)")
+      }
+      read += n
+    }
+    val bb = ByteBuffer.wrap(header).order(ByteOrder.LITTLE_ENDIAN)
+    val command = bb.int
+    val arg0 = bb.int
+    val arg1 = bb.int
+    val length = bb.int
+    bb.int // data_check — ignored, modern adb leaves it 0
+    bb.int // magic — ignored
+    val payload =
+      if (length > 0) {
+        require(length <= 64 * 1024 * 1024) { "implausible adb payload length: $length" }
+        ByteArray(length).also { data.readFully(it) }
+      } else {
+        EMPTY
+      }
+    return AdbMessage(command, arg0, arg1, payload)
+  }
+
+  /** Serialize [message] onto [output]. Caller must hold the connection's write lock. */
+  fun write(output: OutputStream, message: AdbMessage) {
+    val payload = message.payload
+    val bb = ByteBuffer.allocate(24).order(ByteOrder.LITTLE_ENDIAN)
+    bb.putInt(message.command)
+    bb.putInt(message.arg0)
+    bb.putInt(message.arg1)
+    bb.putInt(payload.size)
+    bb.putInt(checksum(payload))
+    bb.putInt(message.command.inv())
+    output.write(bb.array())
+    if (payload.isNotEmpty()) output.write(payload)
+    output.flush()
+  }
+
+  val EMPTY = ByteArray(0)
+}
+
+/** One decoded ADB transport packet. [payload] is empty (not null) when there is no body. */
+internal class AdbMessage(
+  val command: Int,
+  val arg0: Int,
+  val arg1: Int,
+  val payload: ByteArray = ByteArray(0),
+)

--- a/fake-emulator/core/src/main/kotlin/ee/schimke/composeai/fakeemulator/AdbServices.kt
+++ b/fake-emulator/core/src/main/kotlin/ee/schimke/composeai/fakeemulator/AdbServices.kt
@@ -1,0 +1,183 @@
+package ee.schimke.composeai.fakeemulator
+
+import java.io.InputStream
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.nio.charset.StandardCharsets
+
+/** Maps OPEN destinations to the handful of device services we implement. */
+class EmulatorAdbServices(private val interpreter: ShellInterpreter) : AdbServiceResolver {
+  override fun resolve(destination: String): AdbService? =
+    when {
+      destination.startsWith("shell") -> ShellService(interpreter, destination)
+      destination.startsWith("sync:") -> SyncService()
+      // framebuffer:/reverse:/jdwp:/tcp: aren't implemented — screencap is the screenshot path.
+      else -> null
+    }
+}
+
+/**
+ * Handles both `shell:` (legacy, raw byte stream) and `shell,v2:` (framed: id+len+payload, with a
+ * trailing exit packet). The destination may carry options between the first comma and the colon
+ * (`shell,v2,raw:`, `shell,v2,TERM=xterm:`); the command is everything after the first colon.
+ */
+class ShellService(private val interpreter: ShellInterpreter, private val destination: String) :
+  AdbService {
+  override fun run(io: AdbStreamIo) {
+    val colon = destination.indexOf(':')
+    val options = if (colon >= 0) destination.substring(0, colon) else destination
+    val command = if (colon >= 0) destination.substring(colon + 1) else ""
+    val v2 = options.split(',').contains("v2")
+
+    val result = interpreter.execute(command)
+    if (v2) {
+      writeShellV2(io, ID_STDOUT, result.stdout)
+      writeShellV2(io, ID_STDERR, result.stderr)
+      writeShellV2(io, ID_EXIT, byteArrayOf(result.exitCode.toByte()))
+    } else {
+      if (result.stdout.isNotEmpty()) io.write(result.stdout)
+      if (result.stderr.isNotEmpty()) io.write(result.stderr)
+    }
+  }
+
+  private fun writeShellV2(io: AdbStreamIo, id: Int, payload: ByteArray) {
+    if (id != ID_EXIT && payload.isEmpty()) return
+    var offset = 0
+    do {
+      val end = (offset + PACKET_CHUNK).coerceAtMost(payload.size)
+      val slice = payload.copyOfRange(offset, end)
+      val header =
+        ByteBuffer.allocate(5).order(ByteOrder.LITTLE_ENDIAN).put(id.toByte()).putInt(slice.size)
+      io.write(header.array() + slice)
+      offset = end
+    } while (offset < payload.size)
+  }
+
+  private companion object {
+    const val ID_STDOUT = 1
+    const val ID_STDERR = 2
+    const val ID_EXIT = 3
+    const val PACKET_CHUNK = 64 * 1024
+  }
+}
+
+/**
+ * Minimal ADB sync service (`sync:`). Enough that file-transfer-shaped flows (e.g. an install
+ * pushing an APK) don't hang: STAT reports "not present", SEND is consumed and OKAY'd, RECV fails
+ * cleanly, QUIT ends. Full sync (real pull, v2 stat/list) is out of scope — see DESIGN.md.
+ */
+class SyncService : AdbService {
+  override fun run(io: AdbStreamIo) {
+    val input = AdbStreamInputStream(io)
+    while (true) {
+      val id = readId(input) ?: return
+      val arg = readLe32(input) ?: return
+      when (id) {
+        "STAT" -> {
+          skip(input, arg) // path
+          io.write("STAT".toByteArray(US_ASCII) + le32(0) + le32(0) + le32(0))
+        }
+        "LIST" -> {
+          skip(input, arg) // path
+          io.write("DONE".toByteArray(US_ASCII) + ByteArray(16))
+        }
+        "SEND" -> {
+          skip(input, arg) // "path,mode"
+          drainSend(input)
+          io.write("OKAY".toByteArray(US_ASCII) + le32(0))
+        }
+        "RECV" -> {
+          skip(input, arg) // path
+          val msg = "not supported".toByteArray(US_ASCII)
+          io.write("FAIL".toByteArray(US_ASCII) + le32(msg.size) + msg)
+          return
+        }
+        "QUIT" -> return
+        else -> return
+      }
+    }
+  }
+
+  /** Consume DATA chunks until DONE (whose arg is the mtime, not a length). */
+  private fun drainSend(input: InputStream) {
+    while (true) {
+      val id = readId(input) ?: return
+      val arg = readLe32(input) ?: return
+      when (id) {
+        "DATA" -> skip(input, arg)
+        "DONE" -> return
+        else -> return
+      }
+    }
+  }
+
+  private fun readId(input: InputStream): String? {
+    val b = ByteArray(4)
+    if (!readFully(input, b)) return null
+    return String(b, US_ASCII)
+  }
+
+  private fun readLe32(input: InputStream): Int? {
+    val b = ByteArray(4)
+    if (!readFully(input, b)) return null
+    return ByteBuffer.wrap(b).order(ByteOrder.LITTLE_ENDIAN).int
+  }
+
+  private fun le32(value: Int): ByteArray =
+    ByteBuffer.allocate(4).order(ByteOrder.LITTLE_ENDIAN).putInt(value).array()
+
+  private fun skip(input: InputStream, count: Int) {
+    var remaining = count
+    val buf = ByteArray(8192)
+    while (remaining > 0) {
+      val n = input.read(buf, 0, remaining.coerceAtMost(buf.size))
+      if (n < 0) return
+      remaining -= n
+    }
+  }
+
+  private fun readFully(input: InputStream, b: ByteArray): Boolean {
+    var read = 0
+    while (read < b.size) {
+      val n = input.read(b, read, b.size - read)
+      if (n < 0) return false
+      read += n
+    }
+    return true
+  }
+
+  private companion object {
+    val US_ASCII = StandardCharsets.US_ASCII
+  }
+}
+
+/**
+ * Adapts the chunked [AdbStreamIo.read] into a blocking [InputStream] for byte-oriented services.
+ */
+class AdbStreamInputStream(private val io: AdbStreamIo) : InputStream() {
+  private var buffer: ByteArray = ByteArray(0)
+  private var position = 0
+
+  override fun read(): Int {
+    if (!ensure()) return -1
+    return buffer[position++].toInt() and 0xff
+  }
+
+  override fun read(b: ByteArray, off: Int, len: Int): Int {
+    if (len == 0) return 0
+    if (!ensure()) return -1
+    val n = (buffer.size - position).coerceAtMost(len)
+    System.arraycopy(buffer, position, b, off, n)
+    position += n
+    return n
+  }
+
+  private fun ensure(): Boolean {
+    while (position >= buffer.size) {
+      val next = io.read() ?: return false
+      buffer = next
+      position = 0
+    }
+    return true
+  }
+}

--- a/fake-emulator/core/src/main/kotlin/ee/schimke/composeai/fakeemulator/AdbServices.kt
+++ b/fake-emulator/core/src/main/kotlin/ee/schimke/composeai/fakeemulator/AdbServices.kt
@@ -9,7 +9,11 @@ import java.nio.charset.StandardCharsets
 class EmulatorAdbServices(private val interpreter: ShellInterpreter) : AdbServiceResolver {
   override fun resolve(destination: String): AdbService? =
     when {
+      // `adb shell` (legacy + shell,v2) and `adb exec-out <cmd>` (which opens `exec:<cmd>`). Both
+      // run a command; ShellService emits framed output only for shell,v2 — `exec:`/`shell:` are
+      // raw, which is exactly what `exec-out screencap -p > screen.png` needs.
       destination.startsWith("shell") -> ShellService(interpreter, destination)
+      destination.startsWith("exec:") -> ShellService(interpreter, destination)
       destination.startsWith("sync:") -> SyncService()
       // framebuffer:/reverse:/jdwp:/tcp: aren't implemented — screencap is the screenshot path.
       else -> null

--- a/fake-emulator/core/src/main/kotlin/ee/schimke/composeai/fakeemulator/AdbTransportServer.kt
+++ b/fake-emulator/core/src/main/kotlin/ee/schimke/composeai/fakeemulator/AdbTransportServer.kt
@@ -1,0 +1,52 @@
+package ee.schimke.composeai.fakeemulator
+
+import java.net.InetAddress
+import java.net.ServerSocket
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Listens for ADB host connections and runs an [AdbConnection] per socket. Bind to port 0 for an
+ * ephemeral port (read it back from [boundPort]); the emulator convention is the odd port paired
+ * with an even console port (e.g. console 5554 ↔ adb 5555).
+ */
+class AdbTransportServer(
+  private val requestedPort: Int,
+  private val banner: ByteArray,
+  private val resolver: AdbServiceResolver,
+  private val bindAddress: InetAddress = InetAddress.getLoopbackAddress(),
+) : AutoCloseable {
+  private val running = AtomicBoolean(false)
+  private val threads = Executors.newCachedThreadPool { r ->
+    Thread(r, "fake-adb").apply { isDaemon = true }
+  }
+  private lateinit var serverSocket: ServerSocket
+
+  val boundPort: Int
+    get() = serverSocket.localPort
+
+  fun start() {
+    check(running.compareAndSet(false, true)) { "already started" }
+    serverSocket = ServerSocket(requestedPort, 50, bindAddress)
+    threads.execute {
+      while (running.get()) {
+        val socket =
+          try {
+            serverSocket.accept()
+          } catch (_: Exception) {
+            break
+          }
+        socket.tcpNoDelay = true
+        val connection = AdbConnection(socket, banner, resolver) { threads.execute(it) }
+        threads.execute { connection.run() }
+      }
+    }
+  }
+
+  override fun close() {
+    if (running.compareAndSet(true, false)) {
+      runCatching { serverSocket.close() }
+      threads.shutdownNow()
+    }
+  }
+}

--- a/fake-emulator/core/src/main/kotlin/ee/schimke/composeai/fakeemulator/DeviceProperties.kt
+++ b/fake-emulator/core/src/main/kotlin/ee/schimke/composeai/fakeemulator/DeviceProperties.kt
@@ -1,0 +1,42 @@
+package ee.schimke.composeai.fakeemulator
+
+import java.nio.charset.StandardCharsets
+
+/**
+ * Default `getprop` map. Tuned so a host classifies us as an emulator (`ro.kernel.qemu=1`, etc.).
+ */
+object DeviceProperties {
+  fun defaults(serial: String, display: DisplaySize): Map<String, String> =
+    linkedMapOf(
+      "ro.product.name" to "sdk_gphone_compose_preview",
+      "ro.product.model" to "Compose Preview Emulator",
+      "ro.product.device" to "compose_preview",
+      "ro.product.brand" to "google",
+      "ro.product.manufacturer" to "Compose AI Tools",
+      "ro.product.cpu.abi" to "arm64-v8a",
+      "ro.product.cpu.abilist" to "arm64-v8a",
+      "ro.build.version.sdk" to "36",
+      "ro.build.version.release" to "16",
+      "ro.build.characteristics" to "emulator",
+      "ro.build.product" to "compose_preview",
+      "ro.hardware" to "ranchu",
+      "ro.kernel.qemu" to "1",
+      "ro.serialno" to serial,
+      "service.adb.root" to "1",
+      "qemu.sf.lcd_density" to display.densityDpi.toString(),
+    )
+}
+
+/** Builds the CNXN banner an adbd device sends: `device::<key=val;…>features=<csv>`. */
+object AdbBanner {
+  /** Features we actually honour. `shell_v2` makes hosts use the framed shell protocol. */
+  val FEATURES = listOf("shell_v2")
+
+  fun build(properties: Map<String, String>, features: List<String> = FEATURES): ByteArray {
+    val sb = StringBuilder("device::")
+    for ((k, v) in properties) sb.append(k).append('=').append(v).append(';')
+    sb.append("features=").append(features.joinToString(","))
+    // adbd null-terminates the banner payload; include the terminator in the bytes.
+    return sb.toString().toByteArray(StandardCharsets.UTF_8) + 0.toByte()
+  }
+}

--- a/fake-emulator/core/src/main/kotlin/ee/schimke/composeai/fakeemulator/Discovery.kt
+++ b/fake-emulator/core/src/main/kotlin/ee/schimke/composeai/fakeemulator/Discovery.kt
@@ -1,0 +1,63 @@
+package ee.schimke.composeai.fakeemulator
+
+import okio.FileSystem
+import okio.Path
+import okio.Path.Companion.toPath
+
+/**
+ * Writes the running-emulator registration file Android Studio reads to discover live emulators and
+ * their gRPC endpoint. A real emulator drops `pid_<pid>.ini` in its discovery directory; Studio's
+ * `RunningEmulatorCatalog` scans that directory, so writing the same file makes the fake emulator
+ * appear in "Running Devices" and tells Studio where our gRPC + token live.
+ *
+ * Linux discovery dir: `$XDG_RUNTIME_DIR/avd/running`, falling back to `<tmp>/avd/running`.
+ */
+class DiscoveryRegistration(
+  private val fileSystem: FileSystem = FileSystem.SYSTEM,
+  private val env: (String) -> String? = System::getenv,
+  private val tmpDir: String = System.getProperty("java.io.tmpdir"),
+  /** Override the discovery directory outright (tests, non-Linux hosts). */
+  private val overrideDir: Path? = null,
+) {
+  data class Registration(
+    val pid: Long,
+    val consolePort: Int,
+    val adbPort: Int,
+    val avdName: String,
+    val avdDir: String,
+    val grpcPort: Int?,
+    val grpcToken: String?,
+  )
+
+  fun discoveryDir(): Path {
+    overrideDir?.let {
+      return it
+    }
+    val xdg = env("XDG_RUNTIME_DIR")
+    val base = if (!xdg.isNullOrBlank()) xdg else tmpDir
+    return base.toPath() / "avd" / "running"
+  }
+
+  fun registrationFile(pid: Long): Path = discoveryDir() / "pid_$pid.ini"
+
+  /** Write the registration; returns the file written so the caller can delete it on shutdown. */
+  fun write(registration: Registration): Path {
+    val dir = discoveryDir()
+    fileSystem.createDirectories(dir)
+    val file = dir / "pid_${registration.pid}.ini"
+    val text = buildString {
+      appendLine("port.serial=${registration.consolePort}")
+      appendLine("port.adb=${registration.adbPort}")
+      appendLine("avd.name=${registration.avdName}")
+      appendLine("avd.dir=${registration.avdDir}")
+      registration.grpcPort?.let { appendLine("grpc.port=$it") }
+      registration.grpcToken?.let { appendLine("grpc.token=$it") }
+    }
+    fileSystem.write(file) { writeUtf8(text) }
+    return file
+  }
+
+  fun delete(file: Path) {
+    runCatching { fileSystem.delete(file) }
+  }
+}

--- a/fake-emulator/core/src/main/kotlin/ee/schimke/composeai/fakeemulator/EmulatorConsole.kt
+++ b/fake-emulator/core/src/main/kotlin/ee/schimke/composeai/fakeemulator/EmulatorConsole.kt
@@ -1,0 +1,106 @@
+package ee.schimke.composeai.fakeemulator
+
+import java.io.BufferedReader
+import java.io.InputStreamReader
+import java.net.InetAddress
+import java.net.ServerSocket
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * The emulator console — the small line-oriented text protocol a real emulator serves on its even
+ * console port (e.g. 5554). Classic `adb`-emulator auto-detection probes this port; pairing it with
+ * the odd adb port (5555) is what makes a device appear as `emulator-5554`. We answer un-authed and
+ * implement just the handful of commands detection and tooling use.
+ */
+class EmulatorConsole(
+  private val requestedPort: Int,
+  private val avdName: String,
+  private val onKill: () -> Unit = {},
+  private val bindAddress: InetAddress = InetAddress.getLoopbackAddress(),
+) : AutoCloseable {
+  private val running = AtomicBoolean(false)
+  private val threads = Executors.newCachedThreadPool { r ->
+    Thread(r, "fake-console").apply { isDaemon = true }
+  }
+  private lateinit var serverSocket: ServerSocket
+
+  val boundPort: Int
+    get() = serverSocket.localPort
+
+  fun start() {
+    check(running.compareAndSet(false, true)) { "already started" }
+    serverSocket = ServerSocket(requestedPort, 50, bindAddress)
+    threads.execute {
+      while (running.get()) {
+        val socket =
+          try {
+            serverSocket.accept()
+          } catch (_: Exception) {
+            break
+          }
+        threads.execute { serve(socket) }
+      }
+    }
+  }
+
+  private fun serve(socket: java.net.Socket) {
+    socket.use {
+      val out = socket.getOutputStream()
+      val reader =
+        BufferedReader(InputStreamReader(socket.getInputStream(), StandardCharsets.UTF_8))
+      fun send(text: String) {
+        out.write(text.toByteArray(StandardCharsets.UTF_8))
+        out.flush()
+      }
+      send(
+        "Android Console: Copyright (C) Compose AI Tools fake emulator\r\n" +
+          "Android Console: type 'help' for a list of commands\r\n" +
+          "OK\r\n"
+      )
+      while (running.get()) {
+        val line = reader.readLine() ?: break
+        when (val command = line.trim()) {
+          "" -> send("OK\r\n")
+          "help",
+          "?" -> send(HELP + "OK\r\n")
+          "avd name" -> send("$avdName\r\nOK\r\n")
+          "avd status" -> send("virtual device is running\r\nOK\r\n")
+          "redir list" -> send("OK\r\n")
+          "quit",
+          "exit" -> {
+            send("OK\r\n")
+            return
+          }
+          "kill" -> {
+            send("OK: killing emulator, bye bye\r\n")
+            onKill()
+            return
+          }
+          else ->
+            if (command.startsWith("auth ")) send("OK\r\n")
+            else if (command.startsWith("avd ")) send("OK\r\n")
+            else send("KO: unknown command, try 'help'\r\n")
+        }
+      }
+    }
+  }
+
+  override fun close() {
+    if (running.compareAndSet(true, false)) {
+      runCatching { serverSocket.close() }
+      threads.shutdownNow()
+    }
+  }
+
+  private companion object {
+    val HELP = buildString {
+      append("Android console command help:\r\n")
+      append("    help|?           print a list of commands\r\n")
+      append("    avd name         query virtual device name\r\n")
+      append("    kill             kill the emulator instance\r\n")
+      append("    quit|exit        quit this console session\r\n")
+    }
+  }
+}

--- a/fake-emulator/core/src/main/kotlin/ee/schimke/composeai/fakeemulator/FakeEmulator.kt
+++ b/fake-emulator/core/src/main/kotlin/ee/schimke/composeai/fakeemulator/FakeEmulator.kt
@@ -1,0 +1,95 @@
+package ee.schimke.composeai.fakeemulator
+
+import okio.Path
+
+/**
+ * Tunables for a [FakeEmulator]. Ports default to 0 (ephemeral); read the bound ports back after
+ * start.
+ */
+data class FakeEmulatorConfig(
+  val display: DisplaySize = DisplaySize(1080, 2340, 420),
+  /** Even console port; 0 = ephemeral. Real emulators use 5554, 5556, … */
+  val consolePort: Int = 0,
+  /** Odd adb port; 0 = ephemeral. Real emulators use 5555, 5557, … */
+  val adbPort: Int = 0,
+  val avdName: String = "Compose_Preview",
+  val propertyOverrides: Map<String, String> = emptyMap(),
+  val enableConsole: Boolean = true,
+  /** Write the Studio discovery file. Off by default — it touches user runtime dirs. */
+  val writeDiscovery: Boolean = false,
+  /** Recorded in the discovery file so Studio can reach our gRPC control endpoint. */
+  val grpcPort: Int? = null,
+  val grpcToken: String? = null,
+  val avdDir: String = ".",
+)
+
+/**
+ * A fake Android emulator: an ADB device transport, an emulator console, and (optionally) a Studio
+ * discovery registration, all fronting a [FrameSource] (the display) and a [PreviewLauncher] (what
+ * `am start … PreviewActivity` drives). The gRPC control surface lives in `:fake-emulator-grpc` and
+ * is layered on top via the same [FrameSource]; its port is passed in [FakeEmulatorConfig.grpcPort]
+ * purely so it lands in the discovery file.
+ */
+class FakeEmulator(
+  private val config: FakeEmulatorConfig,
+  val frameSource: FrameSource,
+  private val previewLauncher: PreviewLauncher = PreviewLauncher.NOOP,
+  private val discovery: DiscoveryRegistration = DiscoveryRegistration(),
+) : AutoCloseable {
+  private var console: EmulatorConsole? = null
+  private var adbServer: AdbTransportServer? = null
+  private var registrationFile: Path? = null
+
+  var serial: String = "fake-emulator"
+    private set
+
+  val adbPort: Int
+    get() = adbServer?.boundPort ?: error("not started")
+
+  val consolePort: Int
+    get() = console?.boundPort ?: -1
+
+  fun start(): FakeEmulator {
+    if (config.enableConsole) {
+      console =
+        EmulatorConsole(config.consolePort, config.avdName, onKill = { close() }).also {
+          it.start()
+        }
+    }
+    serial = if (console != null) "emulator-${console!!.boundPort}" else "fake-${config.adbPort}"
+
+    val properties =
+      LinkedHashMap(DeviceProperties.defaults(serial, config.display)).apply {
+        putAll(config.propertyOverrides)
+      }
+    val interpreter = ShellInterpreter(properties, frameSource, previewLauncher)
+    val resolver = EmulatorAdbServices(interpreter)
+    val banner = AdbBanner.build(properties)
+    adbServer = AdbTransportServer(config.adbPort, banner, resolver).also { it.start() }
+
+    // Now that adb port is bound, fix the serial to the emulator-<console> form (already set) and
+    // write discovery referencing both ports + the gRPC endpoint.
+    if (config.writeDiscovery) {
+      registrationFile =
+        discovery.write(
+          DiscoveryRegistration.Registration(
+            pid = ProcessHandle.current().pid(),
+            consolePort = console?.boundPort ?: adbServer!!.boundPort,
+            adbPort = adbServer!!.boundPort,
+            avdName = config.avdName,
+            avdDir = config.avdDir,
+            grpcPort = config.grpcPort,
+            grpcToken = config.grpcToken,
+          )
+        )
+    }
+    return this
+  }
+
+  override fun close() {
+    registrationFile?.let { discovery.delete(it) }
+    registrationFile = null
+    runCatching { adbServer?.close() }
+    runCatching { console?.close() }
+  }
+}

--- a/fake-emulator/core/src/main/kotlin/ee/schimke/composeai/fakeemulator/FrameSource.kt
+++ b/fake-emulator/core/src/main/kotlin/ee/schimke/composeai/fakeemulator/FrameSource.kt
@@ -1,0 +1,80 @@
+package ee.schimke.composeai.fakeemulator
+
+import java.awt.image.BufferedImage
+import java.io.ByteArrayOutputStream
+import java.util.concurrent.CopyOnWriteArrayList
+import javax.imageio.ImageIO
+
+/** Logical display geometry the fake emulator advertises (ADB `wm size`, gRPC display config). */
+data class DisplaySize(val width: Int, val height: Int, val densityDpi: Int = 420)
+
+/**
+ * One display frame. [png] is the encoded image; [seq] is monotonic per source so consumers can
+ * drop stale frames. This is the unit both the ADB `screencap` path and the gRPC screenshot stream
+ * serve.
+ */
+class EmulatorFrame(val width: Int, val height: Int, val png: ByteArray, val seq: Long)
+
+/**
+ * The emulator's "screen". Pull the latest frame ([latest], used by `screencap` / `getScreenshot`)
+ * or [subscribe] to pushed frames (used by the gRPC `streamScreenshot` video lane). Implementations
+ * must be safe for concurrent calls.
+ *
+ * `:fake-emulator-core` ships the in-memory [MutableFrameSource]; `:fake-emulator` ships a
+ * RenderSession-backed source that republishes daemon `streamFrame`s as [EmulatorFrame]s.
+ */
+interface FrameSource {
+  val display: DisplaySize
+
+  /** The most recent frame, or `null` if none has been produced yet. */
+  fun latest(): EmulatorFrame?
+
+  /**
+   * Register [sink] for subsequent frames. The current [latest] (if any) is delivered synchronously
+   * before returning so a new subscriber paints immediately. Closing the returned handle detaches.
+   */
+  fun subscribe(sink: (EmulatorFrame) -> Unit): AutoCloseable
+}
+
+/** Thread-safe in-memory [FrameSource]. Producers call [push]; consumers pull/subscribe. */
+class MutableFrameSource(override val display: DisplaySize) : FrameSource {
+  @Volatile private var current: EmulatorFrame? = null
+  private val sinks = CopyOnWriteArrayList<(EmulatorFrame) -> Unit>()
+
+  fun push(frame: EmulatorFrame) {
+    current = frame
+    for (sink in sinks) runCatching { sink(frame) }
+  }
+
+  /** Convenience: encode [png] as the next frame using [display]'s geometry. */
+  fun push(png: ByteArray, seq: Long) {
+    push(EmulatorFrame(display.width, display.height, png, seq))
+  }
+
+  override fun latest(): EmulatorFrame? = current
+
+  override fun subscribe(sink: (EmulatorFrame) -> Unit): AutoCloseable {
+    sinks.add(sink)
+    current?.let { runCatching { sink(it) } }
+    return AutoCloseable { sinks.remove(sink) }
+  }
+}
+
+/**
+ * Tiny placeholder PNGs for the "no preview launched yet" / fallback screen. AWT works headless.
+ */
+object PlaceholderImage {
+  fun solidPng(width: Int, height: Int, argb: Int): ByteArray {
+    val image = BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB)
+    val g = image.createGraphics()
+    try {
+      g.color = java.awt.Color(argb, true)
+      g.fillRect(0, 0, width, height)
+    } finally {
+      g.dispose()
+    }
+    val out = ByteArrayOutputStream()
+    ImageIO.write(image, "png", out)
+    return out.toByteArray()
+  }
+}

--- a/fake-emulator/core/src/main/kotlin/ee/schimke/composeai/fakeemulator/PreviewLaunch.kt
+++ b/fake-emulator/core/src/main/kotlin/ee/schimke/composeai/fakeemulator/PreviewLaunch.kt
@@ -1,0 +1,42 @@
+package ee.schimke.composeai.fakeemulator
+
+/**
+ * A request to display one preview, produced by parsing the `am start … PreviewActivity` intent the
+ * fake emulator receives over ADB shell. [composableFqn] is the fully-qualified composable name
+ * (file class + function, e.g. `com.example.PreviewsKt.MyPreview`) carried in the `composable`
+ * intent extra — the exact contract Android Studio's "Deploy Preview to Device" and the VS Code
+ * extension emit (`vscode-extension/src/launchOnDevice.ts`).
+ */
+data class PreviewLaunchRequest(
+  val composableFqn: String,
+  val parameterProviderClassName: String? = null,
+  /**
+   * The component the intent targeted, e.g. `app.id/androidx.compose.ui.tooling.PreviewActivity`.
+   */
+  val component: String? = null,
+  /** All `--es` string extras, verbatim. */
+  val extras: Map<String, String> = emptyMap(),
+)
+
+/** Outcome of a [PreviewLauncher.launch]. */
+sealed interface PreviewLaunchResult {
+  /** The preview was accepted; its frames should start flowing through the [FrameSource]. */
+  data object Launched : PreviewLaunchResult
+
+  /** The launcher could not honour the request (unknown preview, no session, …). */
+  data class Rejected(val reason: String) : PreviewLaunchResult
+}
+
+/**
+ * Sink for preview-launch intents. Implementations route the request into a render backend — the
+ * `:fake-emulator` app's implementation opens / switches a `RenderSession` stream so the named
+ * preview becomes the emulator display. A no-op default is handy for tests and the bare ADB core.
+ */
+fun interface PreviewLauncher {
+  fun launch(request: PreviewLaunchRequest): PreviewLaunchResult
+
+  companion object {
+    /** Accepts every request and does nothing — for tests and console-only bring-up. */
+    val NOOP: PreviewLauncher = PreviewLauncher { PreviewLaunchResult.Launched }
+  }
+}

--- a/fake-emulator/core/src/main/kotlin/ee/schimke/composeai/fakeemulator/ShellInterpreter.kt
+++ b/fake-emulator/core/src/main/kotlin/ee/schimke/composeai/fakeemulator/ShellInterpreter.kt
@@ -1,0 +1,190 @@
+package ee.schimke.composeai.fakeemulator
+
+import java.nio.charset.StandardCharsets
+
+/**
+ * The fake emulator's tiny shell. A real device runs thousands of commands; we answer only the few
+ * that matter for **device detection** (`getprop`, `wm size`, `echo`, `id`) and **preview launch**
+ * (`am start … PreviewActivity`), plus `screencap` for screenshots. Everything else returns empty
+ * output with exit 0 so detection scripts don't choke.
+ */
+class ShellInterpreter(
+  private val properties: Map<String, String>,
+  private val frameSource: FrameSource,
+  private val previewLauncher: PreviewLauncher,
+) {
+  /** stdout/stderr are raw bytes because `screencap -p` returns binary PNG. */
+  class Result(val stdout: ByteArray, val stderr: ByteArray = ByteArray(0), val exitCode: Int = 0)
+
+  fun execute(commandLine: String): Result {
+    val tokens = tokenize(commandLine)
+    if (tokens.isEmpty()) return ok("")
+    return when (tokens[0]) {
+      "getprop" -> getprop(tokens.drop(1))
+      "am" -> am(tokens.drop(1))
+      "screencap" -> screencap(tokens.drop(1))
+      "wm" -> wm(tokens.drop(1))
+      "echo" -> ok(tokens.drop(1).joinToString(" ") + "\n")
+      "id" -> ok("uid=0(root) gid=0(root) groups=0(root) context=u:r:su:s0\n")
+      "true" -> ok("")
+      "false" -> Result(ByteArray(0), exitCode = 1)
+      else -> ok("") // unknown command — succeed quietly
+    }
+  }
+
+  private fun getprop(args: List<String>): Result {
+    if (args.isNotEmpty()) {
+      // `getprop <name>` prints just that value (empty line if unset).
+      return ok((properties[args[0]] ?: "") + "\n")
+    }
+    // `getprop` (no args) prints every prop in `[key]: [value]` form.
+    val sb = StringBuilder()
+    for ((k, v) in properties.toSortedMap()) sb
+      .append("[")
+      .append(k)
+      .append("]: [")
+      .append(v)
+      .append("]\n")
+    return ok(sb.toString())
+  }
+
+  private fun am(args: List<String>): Result {
+    if (args.firstOrNull() != "start") return ok("")
+    val intent = AmStart.parse(args.drop(1))
+    val sb = StringBuilder()
+    sb.append("Starting: Intent { ")
+    intent.component?.let { sb.append("cmp=").append(it).append(' ') }
+    sb.append("}\n")
+    val launch = AmStart.toPreviewLaunch(intent)
+    if (launch != null) {
+      when (val result = previewLauncher.launch(launch)) {
+        is PreviewLaunchResult.Launched -> Unit
+        is PreviewLaunchResult.Rejected ->
+          sb.append("Warning: preview launch rejected: ").append(result.reason).append('\n')
+      }
+    }
+    return ok(sb.toString())
+  }
+
+  private fun screencap(args: List<String>): Result {
+    // We only ever produce PNG; `-p` is the PNG flag, anything else still gets PNG.
+    val frame = frameSource.latest()
+    val png =
+      frame?.png
+        ?: PlaceholderImage.solidPng(
+          frameSource.display.width,
+          frameSource.display.height,
+          0xFF202124.toInt(),
+        )
+    return Result(png)
+  }
+
+  private fun wm(args: List<String>): Result {
+    if (args.firstOrNull() == "size") {
+      return ok("Physical size: ${frameSource.display.width}x${frameSource.display.height}\n")
+    }
+    if (args.firstOrNull() == "density") {
+      return ok("Physical density: ${frameSource.display.densityDpi}\n")
+    }
+    return ok("")
+  }
+
+  private fun ok(text: String) = Result(text.toByteArray(StandardCharsets.UTF_8))
+
+  companion object {
+    /**
+     * Split a shell command line into argv, honouring single and double quotes and backslash
+     * escapes. Good enough for the argv `adb shell` / Studio actually send; not a full POSIX shell.
+     */
+    fun tokenize(line: String): List<String> {
+      val tokens = mutableListOf<String>()
+      val current = StringBuilder()
+      var inSingle = false
+      var inDouble = false
+      var started = false
+      var i = 0
+      while (i < line.length) {
+        val c = line[i]
+        when {
+          inSingle -> if (c == '\'') inSingle = false else current.append(c).also { started = true }
+          inDouble ->
+            when (c) {
+              '"' -> inDouble = false
+              '\\' ->
+                if (i + 1 < line.length) {
+                  current.append(line[++i])
+                  started = true
+                } else current.append(c).also { started = true }
+              else -> current.append(c).also { started = true }
+            }
+          c == '\'' -> {
+            inSingle = true
+            started = true
+          }
+          c == '"' -> {
+            inDouble = true
+            started = true
+          }
+          c == '\\' ->
+            if (i + 1 < line.length) {
+              current.append(line[++i])
+              started = true
+            } else current.append(c).also { started = true }
+          c.isWhitespace() -> {
+            if (started) {
+              tokens.add(current.toString())
+              current.setLength(0)
+              started = false
+            }
+          }
+          else -> current.append(c).also { started = true }
+        }
+        i++
+      }
+      if (started) tokens.add(current.toString())
+      return tokens
+    }
+  }
+}
+
+/** Parses the `am start` argv into the intent fields we care about. */
+object AmStart {
+  const val PREVIEW_ACTIVITY = "androidx.compose.ui.tooling.PreviewActivity"
+
+  data class Intent(val component: String?, val stringExtras: Map<String, String>)
+
+  fun parse(args: List<String>): Intent {
+    var component: String? = null
+    val extras = LinkedHashMap<String, String>()
+    var i = 0
+    while (i < args.size) {
+      when (args[i]) {
+        "-n" -> if (i + 1 < args.size) component = args[++i]
+        "--es" ->
+          if (i + 2 < args.size) {
+            extras[args[i + 1]] = args[i + 2]
+            i += 2
+          }
+        else -> Unit
+      }
+      i++
+    }
+    return Intent(component, extras)
+  }
+
+  /**
+   * Build a [PreviewLaunchRequest] from a parsed intent, or `null` when it isn't a PreviewActivity
+   * launch carrying a `composable` extra.
+   */
+  fun toPreviewLaunch(intent: Intent): PreviewLaunchRequest? {
+    val activity = intent.component?.substringAfter('/', "") ?: return null
+    if (!activity.endsWith("PreviewActivity")) return null
+    val fqn = intent.stringExtras["composable"] ?: return null
+    return PreviewLaunchRequest(
+      composableFqn = fqn,
+      parameterProviderClassName = intent.stringExtras["parameterProviderClassName"],
+      component = intent.component,
+      extras = intent.stringExtras,
+    )
+  }
+}

--- a/fake-emulator/core/src/test/kotlin/ee/schimke/composeai/fakeemulator/DiscoveryRegistrationTest.kt
+++ b/fake-emulator/core/src/test/kotlin/ee/schimke/composeai/fakeemulator/DiscoveryRegistrationTest.kt
@@ -1,0 +1,40 @@
+package ee.schimke.composeai.fakeemulator
+
+import com.google.common.truth.Truth.assertThat
+import okio.FileSystem
+import okio.Path.Companion.toOkioPath
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class DiscoveryRegistrationTest {
+  @get:Rule val tmp = TemporaryFolder()
+
+  @Test
+  fun `writes a pid ini Studio can read and deletes it`() {
+    val dir = tmp.newFolder("avd-running").toOkioPath()
+    val discovery = DiscoveryRegistration(overrideDir = dir)
+    val file =
+      discovery.write(
+        DiscoveryRegistration.Registration(
+          pid = 4242,
+          consolePort = 5554,
+          adbPort = 5555,
+          avdName = "Compose_Preview",
+          avdDir = "/tmp/avd",
+          grpcPort = 8554,
+          grpcToken = "secret-token",
+        )
+      )
+
+    assertThat(file.name).isEqualTo("pid_4242.ini")
+    val text = FileSystem.SYSTEM.read(file) { readUtf8() }
+    assertThat(text).contains("port.serial=5554")
+    assertThat(text).contains("port.adb=5555")
+    assertThat(text).contains("grpc.port=8554")
+    assertThat(text).contains("grpc.token=secret-token")
+
+    discovery.delete(file)
+    assertThat(FileSystem.SYSTEM.exists(file)).isFalse()
+  }
+}

--- a/fake-emulator/core/src/test/kotlin/ee/schimke/composeai/fakeemulator/EmulatorAdbServicesTest.kt
+++ b/fake-emulator/core/src/test/kotlin/ee/schimke/composeai/fakeemulator/EmulatorAdbServicesTest.kt
@@ -1,0 +1,65 @@
+package ee.schimke.composeai.fakeemulator
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class EmulatorAdbServicesTest {
+  private val display = DisplaySize(1080, 2340, 420)
+  private val resolver =
+    EmulatorAdbServices(
+      ShellInterpreter(
+        DeviceProperties.defaults("emulator-5554", display),
+        MutableFrameSource(display),
+        PreviewLauncher.NOOP,
+      )
+    )
+
+  @Test
+  fun `routes shell, exec, and sync destinations`() {
+    assertThat(resolver.resolve("shell,v2:getprop")).isInstanceOf(ShellService::class.java)
+    assertThat(resolver.resolve("shell:ls")).isInstanceOf(ShellService::class.java)
+    // adb exec-out <cmd> opens exec:<cmd> — must be handled (raw, un-framed) for screencap piping.
+    assertThat(resolver.resolve("exec:screencap -p")).isInstanceOf(ShellService::class.java)
+    assertThat(resolver.resolve("sync:")).isInstanceOf(SyncService::class.java)
+  }
+
+  @Test
+  fun `rejects unimplemented destinations`() {
+    assertThat(resolver.resolve("framebuffer:")).isNull()
+    assertThat(resolver.resolve("jdwp:1234")).isNull()
+  }
+
+  @Test
+  fun `exec runs the command un-framed so screencap returns raw PNG bytes`() {
+    // exec: output is raw (no shell-v2 packet framing), so the first bytes are the PNG signature.
+    val io = CollectingStreamIo("exec:screencap -p")
+    ShellService(
+        ShellInterpreter(
+          DeviceProperties.defaults("emulator-5554", display),
+          MutableFrameSource(display),
+          PreviewLauncher.NOOP,
+        ),
+        "exec:screencap -p",
+      )
+      .run(io)
+    val out = io.written()
+    assertThat(out.size).isGreaterThan(8)
+    assertThat(out[0].toInt() and 0xff).isEqualTo(0x89) // PNG signature, not a shell-v2 id byte
+    assertThat(out[1].toInt() and 0xff).isEqualTo(0x50)
+  }
+
+  /** Captures everything a service writes; [read] returns EOF immediately (no inbound data). */
+  private class CollectingStreamIo(override val destination: String) : AdbStreamIo {
+    private val buffer = java.io.ByteArrayOutputStream()
+
+    override fun write(bytes: ByteArray) {
+      buffer.write(bytes)
+    }
+
+    override fun read(): ByteArray? = null
+
+    override fun close() {}
+
+    fun written(): ByteArray = buffer.toByteArray()
+  }
+}

--- a/fake-emulator/core/src/test/kotlin/ee/schimke/composeai/fakeemulator/FakeEmulatorAdbTest.kt
+++ b/fake-emulator/core/src/test/kotlin/ee/schimke/composeai/fakeemulator/FakeEmulatorAdbTest.kt
@@ -1,0 +1,69 @@
+package ee.schimke.composeai.fakeemulator
+
+import com.google.common.truth.Truth.assertThat
+import dadb.Dadb
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Drives the fake emulator's ADB transport with **dadb**, which speaks the device protocol directly
+ * (no real `adb` binary or device). Proves the connect handshake, shell-v2 framing, flow control,
+ * and the `am start … PreviewActivity` preview-launch intent all work end-to-end over a socket.
+ */
+class FakeEmulatorAdbTest {
+  private val display = DisplaySize(1080, 2340, 420)
+  private val frames = MutableFrameSource(display)
+  @Volatile private var launched: PreviewLaunchRequest? = null
+
+  private lateinit var emulator: FakeEmulator
+  private lateinit var dadb: Dadb
+
+  @Before
+  fun setUp() {
+    emulator =
+      FakeEmulator(
+          // Console off + no discovery keeps the test to a single ephemeral adb port.
+          FakeEmulatorConfig(display = display, enableConsole = false, writeDiscovery = false),
+          frameSource = frames,
+          previewLauncher = { request ->
+            launched = request
+            PreviewLaunchResult.Launched
+          },
+        )
+        .start()
+    dadb = Dadb.create("localhost", emulator.adbPort)
+  }
+
+  @After
+  fun tearDown() {
+    runCatching { dadb.close() }
+    runCatching { emulator.close() }
+  }
+
+  @Test
+  fun `getprop over adb returns the emulator marker`() {
+    val response = dadb.shell("getprop ro.kernel.qemu")
+    assertThat(response.exitCode).isEqualTo(0)
+    assertThat(response.output.trim()).isEqualTo("1")
+  }
+
+  @Test
+  fun `am start over adb launches the named preview`() {
+    val response =
+      dadb.shell(
+        "am start -n com.example.app/androidx.compose.ui.tooling.PreviewActivity " +
+          "--es composable com.example.PreviewsKt.MyPreview"
+      )
+    assertThat(response.exitCode).isEqualTo(0)
+    assertThat(response.output).contains("Starting:")
+    assertThat(launched).isNotNull()
+    assertThat(launched!!.composableFqn).isEqualTo("com.example.PreviewsKt.MyPreview")
+  }
+
+  @Test
+  fun `wm size over adb reports the display geometry`() {
+    val response = dadb.shell("wm size")
+    assertThat(response.output.trim()).isEqualTo("Physical size: 1080x2340")
+  }
+}

--- a/fake-emulator/core/src/test/kotlin/ee/schimke/composeai/fakeemulator/ShellInterpreterTest.kt
+++ b/fake-emulator/core/src/test/kotlin/ee/schimke/composeai/fakeemulator/ShellInterpreterTest.kt
@@ -1,0 +1,95 @@
+package ee.schimke.composeai.fakeemulator
+
+import com.google.common.truth.Truth.assertThat
+import java.nio.charset.StandardCharsets
+import org.junit.Test
+
+class ShellInterpreterTest {
+  private val display = DisplaySize(1080, 2340, 420)
+  private val frames = MutableFrameSource(display)
+  private var launched: PreviewLaunchRequest? = null
+  private val interpreter =
+    ShellInterpreter(
+      properties = DeviceProperties.defaults("emulator-5554", display),
+      frameSource = frames,
+      previewLauncher = { request ->
+        launched = request
+        PreviewLaunchResult.Launched
+      },
+    )
+
+  @Test
+  fun `getprop returns single value`() {
+    val result = interpreter.execute("getprop ro.kernel.qemu")
+    assertThat(result.exitCode).isEqualTo(0)
+    assertThat(stdout(result).trim()).isEqualTo("1")
+  }
+
+  @Test
+  fun `getprop with no args lists all props`() {
+    val out = stdout(interpreter.execute("getprop"))
+    assertThat(out).contains("[ro.product.model]: [Compose Preview Emulator]")
+  }
+
+  @Test
+  fun `am start PreviewActivity routes to the launcher`() {
+    val result =
+      interpreter.execute(
+        "am start -n com.example.app/androidx.compose.ui.tooling.PreviewActivity " +
+          "--es composable com.example.PreviewsKt.MyPreview"
+      )
+    assertThat(stdout(result)).contains("Starting:")
+    assertThat(launched).isNotNull()
+    assertThat(launched!!.composableFqn).isEqualTo("com.example.PreviewsKt.MyPreview")
+    assertThat(launched!!.component)
+      .isEqualTo("com.example.app/androidx.compose.ui.tooling.PreviewActivity")
+  }
+
+  @Test
+  fun `am start carries the parameter provider extra`() {
+    interpreter.execute(
+      "am start -n app/androidx.compose.ui.tooling.PreviewActivity " +
+        "--es composable com.x.FooKt.Bar --es parameterProviderClassName com.x.Provider"
+    )
+    assertThat(launched!!.parameterProviderClassName).isEqualTo("com.x.Provider")
+  }
+
+  @Test
+  fun `am start for a non-preview activity does not launch a preview`() {
+    interpreter.execute("am start -n com.example.app/.MainActivity")
+    assertThat(launched).isNull()
+  }
+
+  @Test
+  fun `screencap returns PNG bytes`() {
+    val png = interpreter.execute("screencap -p").stdout
+    assertThat(png.size).isGreaterThan(8)
+    // PNG signature: 89 50 4E 47 0D 0A 1A 0A
+    assertThat(png[0].toInt() and 0xff).isEqualTo(0x89)
+    assertThat(png[1].toInt() and 0xff).isEqualTo(0x50)
+    assertThat(png[2].toInt() and 0xff).isEqualTo(0x4E)
+    assertThat(png[3].toInt() and 0xff).isEqualTo(0x47)
+  }
+
+  @Test
+  fun `wm size reports the display`() {
+    assertThat(stdout(interpreter.execute("wm size")).trim()).isEqualTo("Physical size: 1080x2340")
+  }
+
+  @Test
+  fun `unknown command succeeds quietly`() {
+    val result = interpreter.execute("definitely-not-a-real-command --flags")
+    assertThat(result.exitCode).isEqualTo(0)
+    assertThat(result.stdout).isEmpty()
+  }
+
+  @Test
+  fun `tokenize honours quotes`() {
+    assertThat(ShellInterpreter.tokenize("am start --es k 'hello world'"))
+      .containsExactly("am", "start", "--es", "k", "hello world")
+      .inOrder()
+  }
+
+  private fun stdout(result: ShellInterpreter.Result): String =
+    String(result.stdout, StandardCharsets.UTF_8)
+}

--- a/fake-emulator/grpc/build.gradle.kts
+++ b/fake-emulator/grpc/build.gradle.kts
@@ -1,0 +1,30 @@
+plugins {
+  id("composeai.base-conventions")
+  id("composeai.jvm-conventions")
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.wire)
+}
+
+// The emulator `EmulatorController` gRPC service (a subset) + screenshot video stream. Square Wire
+// generates the protobuf message classes from the vendored
+// `src/main/proto/emulator_controller.proto`
+// (pure-Kotlin, no protoc); the gRPC server is bound by hand into grpc-netty via grpc-java's
+// `ServerCalls` + a small Wire `MethodDescriptor.Marshaller`. Isolated here so the codegen
+// toolchain
+// stays out of every other module. Unpublished tooling. See docs/fake-emulator/DESIGN.md.
+wire {
+  kotlin {
+    // Messages only — we hand-roll the gRPC service binding, so skip Wire's service codegen.
+    rpcRole = "none"
+  }
+}
+
+dependencies {
+  api(project(":fake-emulator-core"))
+  api(libs.wire.runtime)
+  api(libs.grpc.stub)
+  implementation(libs.grpc.netty.shaded)
+
+  testImplementation(libs.junit)
+  testImplementation(libs.truth)
+}

--- a/fake-emulator/grpc/src/main/kotlin/ee/schimke/composeai/fakeemulator/grpc/EmulatorControllerService.kt
+++ b/fake-emulator/grpc/src/main/kotlin/ee/schimke/composeai/fakeemulator/grpc/EmulatorControllerService.kt
@@ -1,0 +1,189 @@
+package ee.schimke.composeai.fakeemulator.grpc
+
+import android.emulation.control.DisplayConfiguration
+import android.emulation.control.DisplayConfigurations
+import android.emulation.control.EmulatorStatus
+import android.emulation.control.Image
+import android.emulation.control.ImageFormat
+import android.emulation.control.KeyboardEvent
+import android.emulation.control.TouchEvent
+import android.emulation.control.VmRunState
+import ee.schimke.composeai.fakeemulator.EmulatorFrame
+import ee.schimke.composeai.fakeemulator.FrameSource
+import ee.schimke.composeai.fakeemulator.PlaceholderImage
+import io.grpc.MethodDescriptor
+import io.grpc.ServerServiceDefinition
+import io.grpc.stub.ServerCallStreamObserver
+import io.grpc.stub.ServerCalls
+import io.grpc.stub.StreamObserver
+import okio.ByteString.Companion.toByteString
+
+/**
+ * The fake emulator's `android.emulation.control.EmulatorController` service, bound by hand into
+ * grpc-java (Wire generates only the messages — see [WireMarshaller]). Identity/liveness + display
+ * geometry are synthesised from the [FrameSource]; `getScreenshot` and the `streamScreenshot`
+ * "video" lane are served straight off it (the same frames the ADB `screencap` path serves).
+ * Key/touch are forwarded to the supplied callbacks.
+ */
+class EmulatorControllerService(
+  private val frameSource: FrameSource,
+  private val startNanos: Long = System.nanoTime(),
+  private val onKey: (KeyboardEvent) -> Unit = {},
+  private val onTouch: (TouchEvent) -> Unit = {},
+) {
+  fun bindService(): ServerServiceDefinition =
+    ServerServiceDefinition.builder(SERVICE_NAME)
+      .addMethod(
+        getStatusMethod,
+        ServerCalls.asyncUnaryCall { _: Unit, observer: StreamObserver<EmulatorStatus> ->
+          observer.completeWith(status())
+        },
+      )
+      .addMethod(
+        getVmStateMethod,
+        ServerCalls.asyncUnaryCall { _: Unit, observer: StreamObserver<VmRunState> ->
+          observer.completeWith(VmRunState(state = VmRunState.RunState.RUNNING))
+        },
+      )
+      .addMethod(
+        setVmStateMethod,
+        ServerCalls.asyncUnaryCall { _: VmRunState, observer: StreamObserver<Unit> ->
+          observer.completeWith(Unit)
+        },
+      )
+      .addMethod(
+        getDisplayConfigurationsMethod,
+        ServerCalls.asyncUnaryCall { _: Unit, observer: StreamObserver<DisplayConfigurations> ->
+          observer.completeWith(displayConfigurations())
+        },
+      )
+      .addMethod(
+        getScreenshotMethod,
+        ServerCalls.asyncUnaryCall { _: ImageFormat, observer: StreamObserver<Image> ->
+          observer.completeWith(currentImage())
+        },
+      )
+      .addMethod(
+        streamScreenshotMethod,
+        ServerCalls.asyncServerStreamingCall { _: ImageFormat, observer: StreamObserver<Image> ->
+          val serverObserver = observer as ServerCallStreamObserver<Image>
+          val handle = frameSource.subscribe { frame ->
+            if (!serverObserver.isCancelled) runCatching { observer.onNext(toImage(frame)) }
+          }
+          serverObserver.setOnCancelHandler { handle.close() }
+        },
+      )
+      .addMethod(
+        sendKeyMethod,
+        ServerCalls.asyncUnaryCall { request: KeyboardEvent, observer: StreamObserver<Unit> ->
+          onKey(request)
+          observer.completeWith(Unit)
+        },
+      )
+      .addMethod(
+        sendTouchMethod,
+        ServerCalls.asyncUnaryCall { request: TouchEvent, observer: StreamObserver<Unit> ->
+          onTouch(request)
+          observer.completeWith(Unit)
+        },
+      )
+      .build()
+
+  private fun status(): EmulatorStatus =
+    EmulatorStatus(
+      uptime = (System.nanoTime() - startNanos) / 1_000_000,
+      booted = true,
+      hardwareConfig =
+        mapOf(
+          "hw.lcd.width" to frameSource.display.width.toString(),
+          "hw.lcd.height" to frameSource.display.height.toString(),
+          "hw.lcd.density" to frameSource.display.densityDpi.toString(),
+        ),
+    )
+
+  private fun displayConfigurations(): DisplayConfigurations =
+    DisplayConfigurations(
+      displays =
+        listOf(
+          DisplayConfiguration(
+            width = frameSource.display.width,
+            height = frameSource.display.height,
+            dpi = frameSource.display.densityDpi,
+            display = 0,
+          )
+        ),
+      maxDisplays = 1,
+    )
+
+  private fun currentImage(): Image {
+    val frame = frameSource.latest()
+    if (frame != null) return toImage(frame)
+    val png =
+      PlaceholderImage.solidPng(
+        frameSource.display.width,
+        frameSource.display.height,
+        0xFF202124.toInt(),
+      )
+    return toImage(EmulatorFrame(frameSource.display.width, frameSource.display.height, png, 0))
+  }
+
+  private fun toImage(frame: EmulatorFrame): Image =
+    Image(
+      format =
+        ImageFormat(
+          format = ImageFormat.ImgFormat.PNG,
+          width = frame.width,
+          height = frame.height,
+          display = 0,
+        ),
+      seq = frame.seq.toInt(),
+      image = frame.png.toByteString(),
+      timestampUs = System.nanoTime() / 1_000,
+    )
+
+  private companion object {
+    const val SERVICE_NAME = "android.emulation.control.EmulatorController"
+
+    private fun <Req : Any, Resp : Any> unary(
+      name: String,
+      reqMarshaller: MethodDescriptor.Marshaller<Req>,
+      respMarshaller: MethodDescriptor.Marshaller<Resp>,
+    ): MethodDescriptor<Req, Resp> =
+      MethodDescriptor.newBuilder(reqMarshaller, respMarshaller)
+        .setType(MethodDescriptor.MethodType.UNARY)
+        .setFullMethodName(MethodDescriptor.generateFullMethodName(SERVICE_NAME, name))
+        .build()
+
+    val getStatusMethod =
+      unary("getStatus", EmptyMarshaller, WireMarshaller(EmulatorStatus.ADAPTER))
+    val getVmStateMethod = unary("getVmState", EmptyMarshaller, WireMarshaller(VmRunState.ADAPTER))
+    val setVmStateMethod = unary("setVmState", WireMarshaller(VmRunState.ADAPTER), EmptyMarshaller)
+    val getDisplayConfigurationsMethod =
+      unary(
+        "getDisplayConfigurations",
+        EmptyMarshaller,
+        WireMarshaller(DisplayConfigurations.ADAPTER),
+      )
+    val getScreenshotMethod =
+      unary("getScreenshot", WireMarshaller(ImageFormat.ADAPTER), WireMarshaller(Image.ADAPTER))
+    val sendKeyMethod = unary("sendKey", WireMarshaller(KeyboardEvent.ADAPTER), EmptyMarshaller)
+    val sendTouchMethod = unary("sendTouch", WireMarshaller(TouchEvent.ADAPTER), EmptyMarshaller)
+
+    val streamScreenshotMethod: MethodDescriptor<ImageFormat, Image> =
+      MethodDescriptor.newBuilder(
+          WireMarshaller(ImageFormat.ADAPTER),
+          WireMarshaller(Image.ADAPTER),
+        )
+        .setType(MethodDescriptor.MethodType.SERVER_STREAMING)
+        .setFullMethodName(
+          MethodDescriptor.generateFullMethodName(SERVICE_NAME, "streamScreenshot")
+        )
+        .build()
+  }
+}
+
+/** Emit one value and complete — the common unary-response shape. */
+private fun <T> StreamObserver<T>.completeWith(value: T) {
+  onNext(value)
+  onCompleted()
+}

--- a/fake-emulator/grpc/src/main/kotlin/ee/schimke/composeai/fakeemulator/grpc/EmulatorControllerService.kt
+++ b/fake-emulator/grpc/src/main/kotlin/ee/schimke/composeai/fakeemulator/grpc/EmulatorControllerService.kt
@@ -3,6 +3,8 @@ package ee.schimke.composeai.fakeemulator.grpc
 import android.emulation.control.DisplayConfiguration
 import android.emulation.control.DisplayConfigurations
 import android.emulation.control.EmulatorStatus
+import android.emulation.control.Entry
+import android.emulation.control.EntryList
 import android.emulation.control.Image
 import android.emulation.control.ImageFormat
 import android.emulation.control.KeyboardEvent
@@ -91,13 +93,17 @@ class EmulatorControllerService(
 
   private fun status(): EmulatorStatus =
     EmulatorStatus(
+      version = "compose-preview-fake-emulator",
       uptime = (System.nanoTime() - startNanos) / 1_000_000,
       booted = true,
       hardwareConfig =
-        mapOf(
-          "hw.lcd.width" to frameSource.display.width.toString(),
-          "hw.lcd.height" to frameSource.display.height.toString(),
-          "hw.lcd.density" to frameSource.display.densityDpi.toString(),
+        EntryList(
+          entry =
+            listOf(
+              Entry(key = "hw.lcd.width", value_ = frameSource.display.width.toString()),
+              Entry(key = "hw.lcd.height", value_ = frameSource.display.height.toString()),
+              Entry(key = "hw.lcd.density", value_ = frameSource.display.densityDpi.toString()),
+            )
         ),
     )
 
@@ -111,8 +117,7 @@ class EmulatorControllerService(
             dpi = frameSource.display.densityDpi,
             display = 0,
           )
-        ),
-      maxDisplays = 1,
+        )
     )
 
   private fun currentImage(): Image {

--- a/fake-emulator/grpc/src/main/kotlin/ee/schimke/composeai/fakeemulator/grpc/FakeEmulatorGrpcServer.kt
+++ b/fake-emulator/grpc/src/main/kotlin/ee/schimke/composeai/fakeemulator/grpc/FakeEmulatorGrpcServer.kt
@@ -1,0 +1,33 @@
+package ee.schimke.composeai.fakeemulator.grpc
+
+import io.grpc.Server
+import io.grpc.ServerBuilder
+import io.grpc.ServerServiceDefinition
+
+/**
+ * Hosts the emulator-control [ServerServiceDefinition] on a gRPC port (grpc-netty-shaded). Bind to
+ * port 0 for an ephemeral port and read it back from [boundPort] (record it in the Studio discovery
+ * file so the embedded-emulator catalog can reach the control endpoint).
+ */
+class FakeEmulatorGrpcServer(
+  private val requestedPort: Int,
+  private val service: ServerServiceDefinition,
+) : AutoCloseable {
+  private lateinit var server: Server
+
+  val boundPort: Int
+    get() = server.port
+
+  fun start(): FakeEmulatorGrpcServer {
+    server = ServerBuilder.forPort(requestedPort).addService(service).build().start()
+    return this
+  }
+
+  fun awaitTermination() {
+    server.awaitTermination()
+  }
+
+  override fun close() {
+    if (::server.isInitialized) server.shutdownNow()
+  }
+}

--- a/fake-emulator/grpc/src/main/kotlin/ee/schimke/composeai/fakeemulator/grpc/WireMarshaller.kt
+++ b/fake-emulator/grpc/src/main/kotlin/ee/schimke/composeai/fakeemulator/grpc/WireMarshaller.kt
@@ -1,0 +1,30 @@
+package ee.schimke.composeai.fakeemulator.grpc
+
+import com.squareup.wire.ProtoAdapter
+import io.grpc.MethodDescriptor
+import java.io.InputStream
+
+/**
+ * A grpc [MethodDescriptor.Marshaller] backed by a Wire [ProtoAdapter]. This is the bridge that
+ * lets Wire-generated message classes ride grpc-java's transport: encode/decode is the same
+ * protobuf wire format any gRPC peer (including Android Studio's emulator client) speaks.
+ */
+class WireMarshaller<T : Any>(private val adapter: ProtoAdapter<T>) :
+  MethodDescriptor.Marshaller<T> {
+  override fun stream(value: T): InputStream = adapter.encode(value).inputStream()
+
+  override fun parse(stream: InputStream): T = adapter.decode(stream.readBytes())
+}
+
+/**
+ * Marshaller for `google.protobuf.Empty` — a zero-field message that is always zero bytes on the
+ * wire. Wire doesn't generate the well-known `Empty` type (we generate messages only), so we model
+ * it as [Unit]: encode to no bytes, drain and ignore on decode.
+ */
+object EmptyMarshaller : MethodDescriptor.Marshaller<Unit> {
+  override fun stream(value: Unit): InputStream = ByteArray(0).inputStream()
+
+  override fun parse(stream: InputStream) {
+    stream.readBytes()
+  }
+}

--- a/fake-emulator/grpc/src/main/proto/emulator_controller.proto
+++ b/fake-emulator/grpc/src/main/proto/emulator_controller.proto
@@ -1,11 +1,12 @@
 // Vendored SUBSET of the Android emulator's `android.emulation.control.EmulatorController` gRPC API
 // (the surface Android Studio's embedded "Running Devices" view + screenshot video stream consume).
 //
-// This is a faithful-shaped subset sufficient for: identity/liveness, display geometry, a single
-// screenshot, the continuous screenshot ("video") stream, and key/touch injection. It is NOT the
-// complete shipping proto. Field numbers mirror the real proto's intent but should be reconciled
-// against the canonical `emulator_controller.proto` from the emulator SDK before relying on
-// byte-level interop with a specific Android Studio build. See docs/fake-emulator/DESIGN.md.
+// This is a subset — not every message/field of the shipping proto — but the field NUMBERS and types
+// of the messages it does define are kept wire-compatible with the canonical
+// `emulator_controller.proto` (see google-deepmind/android_env, AOSP external/qemu, and the
+// maintainer's yschimke/emulator-tools), so a real Studio client decodes our responses correctly.
+// Fields/messages we don't need (e.g. ImageFormat.transport/foldedDisplay, EmulatorStatus.vmConfig)
+// are omitted, not renumbered — omission is wire-compatible.
 syntax = "proto3";
 
 package android.emulation.control;
@@ -38,10 +39,26 @@ service EmulatorController {
   rpc sendTouch(TouchEvent) returns (google.protobuf.Empty) {}
 }
 
+// Generic key/value pair + list, used by EmulatorStatus.hardwareConfig.
+message Entry {
+  string key = 1;
+  string value = 2;
+}
+
+message EntryList {
+  repeated Entry entry = 1;
+}
+
 message EmulatorStatus {
-  int64 uptime = 1;
-  bool booted = 2;
-  map<string, string> hardwareConfig = 3;
+  // The emulator version string.
+  string version = 1;
+  // The time the emulator has been active, in ms.
+  uint64 uptime = 2;
+  // True if the device has completed booting.
+  bool booted = 3;
+  // Field 4 (VmConfiguration vmConfig) is intentionally omitted — we don't model it.
+  // The hardware configuration as key/value pairs.
+  EntryList hardwareConfig = 5;
 }
 
 message VmRunState {
@@ -52,16 +69,15 @@ message VmRunState {
     PAUSED = 3;
     SAVE_VM = 4;
     SHUTDOWN = 5;
-    TERMINATE = 6;
-    RESET = 7;
-    INTERNAL_ERROR = 8;
+    TERMINATE = 7;
+    RESET = 9;
+    INTERNAL_ERROR = 10;
   }
   RunState state = 1;
 }
 
 message DisplayConfigurations {
   repeated DisplayConfiguration displays = 1;
-  uint32 maxDisplays = 2;
 }
 
 message DisplayConfiguration {
@@ -69,7 +85,7 @@ message DisplayConfiguration {
   uint32 height = 2;
   uint32 dpi = 3;
   uint32 flags = 4;
-  uint32 display = 6;
+  uint32 display = 5;
 }
 
 message Rotation {
@@ -91,30 +107,41 @@ message ImageFormat {
     RGBA8888 = 1;
     RGB888 = 2;
   }
-  ImgFormat format = 2;
-  Rotation rotation = 3;
-  uint32 width = 4;
-  uint32 height = 5;
-  uint32 display = 6;
+  ImgFormat format = 1;
+  Rotation rotation = 2;
+  uint32 width = 3;
+  uint32 height = 4;
+  uint32 display = 5;
+  // Fields 6 (transport) and 7 (foldedDisplay) are omitted — we don't model them.
 }
 
 message Image {
   ImageFormat format = 1;
-  uint32 seq = 2;
-  bytes image = 3;
-  uint64 timestampUs = 4;
+  uint32 width = 2 [deprecated = true]; // width is contained in format.
+  uint32 height = 3 [deprecated = true]; // height is contained in format.
+  bytes image = 4;
+  uint32 seq = 5;
+  uint64 timestampUs = 6;
 }
 
 message KeyboardEvent {
+  enum KeyCodeType {
+    Usb = 0;
+    Evdev = 1;
+    XKB = 2;
+    Win = 3;
+    Mac = 4;
+  }
   enum KeyEventType {
     keydown = 0;
     keyup = 1;
     keypress = 2;
   }
-  KeyEventType eventType = 1;
-  int32 keyCode = 2;
-  string key = 5;
-  string text = 6;
+  KeyCodeType codeType = 1;
+  KeyEventType eventType = 2;
+  int32 keyCode = 3;
+  string key = 4;
+  string text = 5;
 }
 
 message Touch {
@@ -124,6 +151,7 @@ message Touch {
   int32 pressure = 4;
   int32 touch_major = 5;
   int32 touch_minor = 6;
+  // Field 7 (EventExpiration expiration) is omitted.
 }
 
 message TouchEvent {

--- a/fake-emulator/grpc/src/main/proto/emulator_controller.proto
+++ b/fake-emulator/grpc/src/main/proto/emulator_controller.proto
@@ -1,0 +1,132 @@
+// Vendored SUBSET of the Android emulator's `android.emulation.control.EmulatorController` gRPC API
+// (the surface Android Studio's embedded "Running Devices" view + screenshot video stream consume).
+//
+// This is a faithful-shaped subset sufficient for: identity/liveness, display geometry, a single
+// screenshot, the continuous screenshot ("video") stream, and key/touch injection. It is NOT the
+// complete shipping proto. Field numbers mirror the real proto's intent but should be reconciled
+// against the canonical `emulator_controller.proto` from the emulator SDK before relying on
+// byte-level interop with a specific Android Studio build. See docs/fake-emulator/DESIGN.md.
+syntax = "proto3";
+
+package android.emulation.control;
+
+option java_multiple_files = true;
+option java_package = "android.emulation.control";
+option java_outer_classname = "EmulatorControllerProto";
+
+import "google/protobuf/empty.proto";
+
+service EmulatorController {
+  // Identity + liveness.
+  rpc getStatus(google.protobuf.Empty) returns (EmulatorStatus) {}
+
+  // VM run state (run / pause / shutdown).
+  rpc getVmState(google.protobuf.Empty) returns (VmRunState) {}
+  rpc setVmState(VmRunState) returns (google.protobuf.Empty) {}
+
+  // Display geometry.
+  rpc getDisplayConfigurations(google.protobuf.Empty) returns (DisplayConfigurations) {}
+
+  // One screenshot.
+  rpc getScreenshot(ImageFormat) returns (Image) {}
+
+  // The "video" lane: a server-streaming feed of frames as they are produced.
+  rpc streamScreenshot(ImageFormat) returns (stream Image) {}
+
+  // Input injection.
+  rpc sendKey(KeyboardEvent) returns (google.protobuf.Empty) {}
+  rpc sendTouch(TouchEvent) returns (google.protobuf.Empty) {}
+}
+
+message EmulatorStatus {
+  int64 uptime = 1;
+  bool booted = 2;
+  map<string, string> hardwareConfig = 3;
+}
+
+message VmRunState {
+  enum RunState {
+    UNKNOWN = 0;
+    RUNNING = 1;
+    RESTORE_VM = 2;
+    PAUSED = 3;
+    SAVE_VM = 4;
+    SHUTDOWN = 5;
+    TERMINATE = 6;
+    RESET = 7;
+    INTERNAL_ERROR = 8;
+  }
+  RunState state = 1;
+}
+
+message DisplayConfigurations {
+  repeated DisplayConfiguration displays = 1;
+  uint32 maxDisplays = 2;
+}
+
+message DisplayConfiguration {
+  uint32 width = 1;
+  uint32 height = 2;
+  uint32 dpi = 3;
+  uint32 flags = 4;
+  uint32 display = 6;
+}
+
+message Rotation {
+  enum SkinRotation {
+    PORTRAIT = 0;
+    LANDSCAPE = 1;
+    REVERSE_PORTRAIT = 2;
+    REVERSE_LANDSCAPE = 3;
+  }
+  SkinRotation rotation = 1;
+  double xAxis = 2;
+  double yAxis = 3;
+  double zAxis = 4;
+}
+
+message ImageFormat {
+  enum ImgFormat {
+    PNG = 0;
+    RGBA8888 = 1;
+    RGB888 = 2;
+  }
+  ImgFormat format = 2;
+  Rotation rotation = 3;
+  uint32 width = 4;
+  uint32 height = 5;
+  uint32 display = 6;
+}
+
+message Image {
+  ImageFormat format = 1;
+  uint32 seq = 2;
+  bytes image = 3;
+  uint64 timestampUs = 4;
+}
+
+message KeyboardEvent {
+  enum KeyEventType {
+    keydown = 0;
+    keyup = 1;
+    keypress = 2;
+  }
+  KeyEventType eventType = 1;
+  int32 keyCode = 2;
+  string key = 5;
+  string text = 6;
+}
+
+message Touch {
+  int32 x = 1;
+  int32 y = 2;
+  int32 identifier = 3;
+  int32 pressure = 4;
+  int32 touch_major = 5;
+  int32 touch_minor = 6;
+}
+
+message TouchEvent {
+  repeated Touch touches = 1;
+  int32 display = 2;
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -185,8 +185,29 @@ okhttp = "5.3.2"
 # `_composeai._tcp` service the mobile/wear clients browse for. No slf4j dep (uses java.util.logging),
 # so it doesn't perturb the strict slf4j pin in :cli.
 jmdns = "3.5.12"
+# dadb — Maestro's pure-Kotlin ADB client. Speaks the device transport protocol (CNXN/OPEN/…)
+# DIRECTLY to a device's adbd over TCP, with no `adb` binary or real device required. Used as a
+# `testImplementation` in `:fake-emulator-core` to drive the fake emulator's ADB server end-to-end
+# (connect handshake, `shell,v2`, `screencap`, the `am start … PreviewActivity` preview-launch
+# intent) in a hermetic unit test.
+dadb = "1.2.10"
+# gRPC + Wire — only `:fake-emulator-grpc`, which serves a subset of the Android emulator's
+# `android.emulation.control.EmulatorController` gRPC API (the surface Studio's embedded "Running
+# Devices" view + screenshot video stream consume) from a vendored `emulator_controller.proto`.
+# Kept out of every other module so the codegen toolchain stays contained. Square Wire generates the
+# protobuf message classes (pure-Kotlin codegen — no `protoc` — `rpcRole = none`, messages only); the
+# gRPC server is bound by hand into grpc-netty via grpc-java's `ServerCalls` + a tiny Wire
+# `MethodDescriptor.Marshaller`. (Wire dropped its own server-side gRPC artifact after 4.9.11.)
+grpc = "1.69.0"
+wire = "6.4.0"
 
 [libraries]
+dadb = { module = "dev.mobile:dadb", version.ref = "dadb" }
+# grpc-stub carries ServerCalls + StreamObserver + MethodDescriptor (grpc-api is transitive);
+# grpc-netty-shaded is the server transport.
+grpc-stub = { module = "io.grpc:grpc-stub", version.ref = "grpc" }
+grpc-netty-shaded = { module = "io.grpc:grpc-netty-shaded", version.ref = "grpc" }
+wire-runtime = { module = "com.squareup.wire:wire-runtime", version.ref = "wire" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
 # WebSocket client plugin for the streamed-frame lane the mobile/wear session-viewer clients consume
@@ -311,3 +332,6 @@ tapmoc = { id = "com.gradleup.tapmoc", version.ref = "tapmoc" }
 # get `@DependencyGraph` / `@Inject` / `@ContributesIntoMap` codegen.
 metro = { id = "dev.zacsweers.metro", version.ref = "metro" }
 play-publisher = { id = "com.github.triplet.play", version.ref = "play-publisher" }
+# Square Wire — pure-Kotlin protobuf codegen for `:fake-emulator-grpc` (no protoc binary; friendlier
+# with the repo's strict configuration cache). Generates the emulator-control message classes.
+wire = { id = "com.squareup.wire", version.ref = "wire" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -493,6 +493,30 @@ include(":render-cli")
 
 project(":render-cli").projectDir = file("render-session/cli")
 
+// Fake Android emulator — impersonates a running emulator (ADB device transport, emulator console,
+// emulator gRPC control + screenshot video) so the compose-preview render pipeline can be driven by
+// `adb` / Android Studio and a preview launched via the `am start … PreviewActivity` intent. See
+// docs/fake-emulator/DESIGN.md. Split so the verifiable, dependency-light ADB core stays free of the
+// protobuf/grpc toolchain and the render classpath.
+//
+//  * `:fake-emulator-core` — pure-Kotlin ADB transport + console + screencap + the `am start`
+//    preview-launch parser + the FrameSource/PreviewLauncher SPIs + the Studio discovery writer.
+//    `dadb`-tested.
+//  * `:fake-emulator-grpc` — the `EmulatorController` gRPC subset + screenshot stream (vendored
+//    proto; protobuf/grpc codegen lives only here).
+//  * `:fake-emulator` — runnable launcher wiring core + gRPC + a RenderSession-backed FrameSource.
+include(":fake-emulator-core")
+
+project(":fake-emulator-core").projectDir = file("fake-emulator/core")
+
+include(":fake-emulator-grpc")
+
+project(":fake-emulator-grpc").projectDir = file("fake-emulator/grpc")
+
+include(":fake-emulator")
+
+project(":fake-emulator").projectDir = file("fake-emulator/app")
+
 // JDK 21+ samples. Each module here pulls in tooling whose own gradle plugin
 // is compiled to Java 21 bytecode and therefore can't load on this repo's
 // default JDK 17 build daemon (see `gradle/gradle-daemon-jvm.properties`,


### PR DESCRIPTION
## Summary

Adds a **fake Android emulator** that answers the wire protocols a real emulator exposes and routes the requests that matter into the existing daemon / `serve` render path — so the compose-preview pipeline can be driven by `adb` / Android Studio, and a preview launched via the same `am start … PreviewActivity` intent Studio's "Deploy Preview to Device" and the VS Code extension already emit. The emulator's "screen" is whatever the renderer last produced for the launched `@Preview`.

Builds on the remote-daemon / `serve` streaming work: the display is a `FrameSource`, and the real implementation republishes the daemon's `streamFrame` feed as the device screen — the same frames `serve` streams. (Future: front that same `FrameSource` with the `serve` HTTP lane to start locally and share a URL — see DESIGN.md.)

### Modules (all unpublished tooling)
- **`:fake-emulator-core`** — pure-Kotlin ADB device transport (`CNXN/OPEN/OKAY/WRTE/CLSE` with the protocol's one-outstanding-write flow control), `shell:` + `shell,v2:` + `exec:` services, minimal `sync:`, `screencap`, the emulator console, the Studio discovery-file writer, and the `am start … PreviewActivity --es composable <fqn>` preview-launch parser. Exposes the `FrameSource` / `PreviewLauncher` SPIs. No render or gRPC deps.
- **`:fake-emulator-grpc`** — the emulator `EmulatorController` gRPC subset (status, vm-state, display config, `getScreenshot`, the `streamScreenshot` "video" lane, key/touch) bound by hand into grpc-netty. **Square Wire** generates the protobuf messages from the vendored `emulator_controller.proto` (pure-Kotlin, no `protoc`); a small Wire `MethodDescriptor.Marshaller` bridges them onto grpc-java. The vendored proto's field numbers are kept wire-compatible with the canonical `android.emulation.control` schema. (Wire dropped its own server-side gRPC artifact after 4.9.11, so the server binding is hand-rolled.)
- **`:fake-emulator`** — runnable launcher wiring core + gRPC + a `RenderSession`-backed `FrameSource` and writing the discovery file.

## Test plan
Verified end-to-end with **dadb** (drives the device transport directly — no real `adb` or device):
- connect handshake → device reported online with emulator props;
- `getprop ro.kernel.qemu` → `1`; `wm size` → the configured geometry;
- `am start -n …/PreviewActivity --es composable com.example.PreviewsKt.MyPreview` → the injected `PreviewLauncher` receives the FQN.

Plus shell/`screencap`-PNG unit tests, the `exec:`/`shell:`/`sync:` resolver + raw-`exec-out` output tests, and a discovery-file round-trip. All three modules compile and pass `ktfmt`.

```
./gradlew :fake-emulator-core:test
./gradlew :fake-emulator-grpc:compileKotlin :fake-emulator:compileKotlin
```

This change is non-visual infrastructure (device-shaped protocols in front of the existing renderer), so there's no rendered-output diff to show; the launched preview itself renders through the unchanged daemon/`serve` path.

## Deferred (see `docs/fake-emulator/DESIGN.md`)
Full sync (large APK install), authenticated adb (RSA/TLS), the complete `EmulatorController` surface, pointer/key fidelity, and fronting the same `FrameSource` with the `serve` HTTP lane for share-a-URL streaming.