### PR TITLE
feat(fake-emulator): full EmulatorController gRPC surface + adb-shell device-setting overrides

### DIFF
--- a/docs/fake-emulator/DESIGN.md
+++ b/docs/fake-emulator/DESIGN.md
@@ -113,17 +113,29 @@ catalog lists us and knows where our gRPC lives.
 
 ## Emulator gRPC (`:fake-emulator-grpc`)
 
-A subset of `android.emulation.control.EmulatorController` sufficient for
-Studio's embedded view + a screenshot video stream:
+The (near-complete) `android.emulation.control.EmulatorController` surface Android
+Studio's embedded "Running Devices" view + the emulator Extended Controls drive —
+implemented so Studio never hits `UNIMPLEMENTED`:
 
-- `getStatus`, `getVmConfiguration` — identity / liveness.
-- `getDisplayConfigurations` — our display size (from the `FrameSource`).
-- `getScreenshot` — one frame (PNG) from the `FrameSource`.
-- `streamScreenshot` — the **video** stream: a server-streaming RPC that
-  forwards every `FrameSource` frame as an `Image` message. This is the same
-  frame feed the ADB `screencap` path serves, just pushed continuously.
-- `sendKey` / `sendTouch` — mapped onto `RenderSession` interactive input where
-  available (future: full pointer routing).
+- **Identity / VM / display** — `getStatus`, `getVmState` / `setVmState`,
+  `getDisplayConfigurations` / `setDisplayConfigurations` (size/density from — and
+  back into — the shared settings).
+- **Screenshots** — `getScreenshot` (one PNG) and `streamScreenshot`, the
+  **video** lane: a server-streaming RPC forwarding every `FrameSource` frame as
+  an `Image`. Same feed the ADB `screencap` path serves, pushed continuously.
+- **Input** — `sendKey` / `sendTouch` / `sendMouse` forward to injectable callbacks.
+- **Rotation / posture** — `setPhysicalModel(ROTATION)` and `setPosture` drive the
+  shared `DeviceSettingsController`, so the preview re-renders rotated/folded;
+  `getPhysicalModel` / `streamPhysicalModel` and `streamNotification` report it
+  (including `adb`-driven rotation — the two paths share one state).
+- **Clipboard** — `get/set/streamClipboard` over an in-memory clipboard.
+- **Extended controls** — `get/setBattery`, `get/setGps`, `get/set/streamSensor`,
+  `sendFingerprint`, `sendPhone` / `sendSms` — in-memory state / sensible defaults.
+- **Audio / logcat / virtual-scene camera** — accepted (empty streams / no-ops).
+
+Studio's `setPhysicalModel(ROTATION)` and an `adb shell settings put system
+user_rotation` both land on the same `DeviceSettingsController.rotation`, so the
+preview rotates the same way regardless of which control the user used.
 
 The proto is vendored (not a runtime dep on the SDK). Square **Wire** generates
 the message classes (pure-Kotlin codegen, no `protoc`); the gRPC service is bound
@@ -137,6 +149,32 @@ wire-compatible with the real schema (cross-checked against `google-deepmind/
 android_env`, AOSP `external/qemu`, and `yschimke/emulator-tools`) so a real
 Studio client decodes our responses — e.g. `EmulatorStatus.booted = 3`,
 `Image.image = 4`. Fields we don't model are omitted, not renumbered.
+
+## Device settings → preview overrides
+
+Android Studio's emulator UI toggles are mostly `adb shell` commands, not gRPC.
+The fake shell interprets the ones that map onto a render override and records
+them in the shared `DeviceSettingsController`; the app maps `DeviceSettings` →
+`PreviewOverrides` and re-opens the held stream (override changes restart the
+stream — the same pattern the `serve` live lane uses), so the preview re-renders
+under whatever the user flipped:
+
+| Studio toggle        | `adb shell`                                             | `DeviceSettings` → `PreviewOverrides` |
+|----------------------|--------------------------------------------------------|---------------------------------------|
+| Dark / light theme   | `cmd uimode night yes\|no`                              | `uiMode`                              |
+| Font size            | `settings put system font_scale <f>`                   | `fontScale`                           |
+| Display density      | `wm density <dpi>\|reset`                               | `density` (`dpi/160`)                 |
+| Display size         | `wm size <WxH>\|reset`                                  | `widthPx` / `heightPx`                |
+| Rotation             | `settings put system user_rotation <0-3>`              | `orientation` (+ gRPC physical model) |
+| App locale           | `cmd locale set-app-locales … --locales <tag>`         | `localeTag`                           |
+| **TalkBack**         | `settings put secure {accessibility_enabled, enabled_accessibility_services}` | a11y data-product subscription (overlay render: follow-up) |
+| Color correction     | `settings put secure accessibility_display_{inversion,daltonizer}…` | `colorMode` (render override: follow-up) |
+| Layout bounds        | `setprop debug.layout true`                            | `showLayoutBounds` (follow-up)        |
+
+Mapped end-to-end today: theme, font scale, density, size, rotation, locale.
+TalkBack toggles the a11y data product (a real daemon effect); color
+correction / layout bounds / posture are captured in `DeviceSettings` and await a
+matching render override.
 
 ## Frame source
 

--- a/fake-emulator/app/src/main/kotlin/ee/schimke/composeai/fakeemulator/app/DeviceOverrides.kt
+++ b/fake-emulator/app/src/main/kotlin/ee/schimke/composeai/fakeemulator/app/DeviceOverrides.kt
@@ -1,0 +1,44 @@
+package ee.schimke.composeai.fakeemulator.app
+
+import ee.schimke.composeai.daemon.protocol.Orientation
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.daemon.protocol.UiMode as ProtocolUiMode
+import ee.schimke.composeai.fakeemulator.DeviceSettings
+import ee.schimke.composeai.fakeemulator.UiMode as DeviceUiMode
+
+/**
+ * Maps the fake emulator's [DeviceSettings] (driven by Android Studio's `adb shell` toggles + the
+ * emulator gRPC) onto a daemon [PreviewOverrides], so a launched preview re-renders under whatever
+ * the user flipped in Studio. Pure function — unit-tested directly.
+ *
+ * Mapped today: dark/light theme, font scale, display density + size, locale, and rotation (→
+ * orientation). [DeviceSettings.talkBack] is handled separately (it drives the a11y data product,
+ * not a render override); [DeviceSettings.colorMode], [DeviceSettings.posture], and
+ * [DeviceSettings.showLayoutBounds] have no `PreviewOverrides` equivalent yet and are carried for a
+ * follow-up.
+ */
+fun DeviceSettings.toPreviewOverrides(): PreviewOverrides =
+  PreviewOverrides(
+    widthPx = widthPx,
+    heightPx = heightPx,
+    density = densityDpi?.let { it / 160f },
+    localeTag = localeTag,
+    fontScale = fontScale,
+    uiMode =
+      when (uiMode) {
+        DeviceUiMode.LIGHT -> ProtocolUiMode.LIGHT
+        DeviceUiMode.DARK -> ProtocolUiMode.DARK
+        DeviceUiMode.UNSET -> null
+      },
+    orientation = if (rotation.isLandscape) Orientation.LANDSCAPE else Orientation.PORTRAIT,
+  )
+
+/** Whether the override-relevant fields are all defaults (nothing to apply). */
+fun PreviewOverrides.isEmpty(): Boolean =
+  widthPx == null &&
+    heightPx == null &&
+    density == null &&
+    localeTag == null &&
+    fontScale == null &&
+    uiMode == null &&
+    orientation == Orientation.PORTRAIT

--- a/fake-emulator/app/src/main/kotlin/ee/schimke/composeai/fakeemulator/app/Main.kt
+++ b/fake-emulator/app/src/main/kotlin/ee/schimke/composeai/fakeemulator/app/Main.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.fakeemulator.app
 
+import ee.schimke.composeai.fakeemulator.DeviceSettingsController
 import ee.schimke.composeai.fakeemulator.DisplaySize
 import ee.schimke.composeai.fakeemulator.FakeEmulator
 import ee.schimke.composeai.fakeemulator.FakeEmulatorConfig
@@ -31,6 +32,10 @@ fun main(args: Array<String>) {
   val options = Options.parse(args)
   val display = DisplaySize(options.width, options.height, options.dpi)
 
+  // One shared settings model: the ADB shell + the gRPC controller mutate it; the render bridge
+  // observes it and re-renders the preview under Studio's toggles.
+  val settings = DeviceSettingsController()
+
   val frameSource: FrameSource
   val launcher: PreviewLauncher
   val extraClose: AutoCloseable
@@ -38,7 +43,7 @@ fun main(args: Array<String>) {
   if (options.descriptor != null) {
     val session =
       SubprocessRenderSessions.open(RenderSessionConfig(descriptorPath = File(options.descriptor)))
-    val bridge = RenderSessionFrameSource(session, display)
+    val bridge = RenderSessionFrameSource(session, display, settings)
     frameSource = bridge
     launcher = bridge
     extraClose = AutoCloseable {
@@ -53,9 +58,8 @@ fun main(args: Array<String>) {
     extraClose = AutoCloseable {}
   }
 
-  val grpc =
-    FakeEmulatorGrpcServer(options.grpcPort, EmulatorControllerService(frameSource).bindService())
-      .start()
+  val controllerService = EmulatorControllerService(frameSource, settings)
+  val grpc = FakeEmulatorGrpcServer(options.grpcPort, controllerService.bindService()).start()
 
   val emulator =
     FakeEmulator(
@@ -70,6 +74,7 @@ fun main(args: Array<String>) {
         ),
         frameSource = frameSource,
         previewLauncher = launcher,
+        settings = settings,
       )
       .start()
 
@@ -84,6 +89,7 @@ fun main(args: Array<String>) {
       Thread {
         runCatching { emulator.close() }
         runCatching { grpc.close() }
+        runCatching { controllerService.close() }
         runCatching { extraClose.close() }
       }
     )

--- a/fake-emulator/app/src/main/kotlin/ee/schimke/composeai/fakeemulator/app/RenderSessionFrameSource.kt
+++ b/fake-emulator/app/src/main/kotlin/ee/schimke/composeai/fakeemulator/app/RenderSessionFrameSource.kt
@@ -2,6 +2,8 @@ package ee.schimke.composeai.fakeemulator.app
 
 import ee.schimke.composeai.daemon.protocol.StreamCodec
 import ee.schimke.composeai.daemon.protocol.StreamFrameParams
+import ee.schimke.composeai.fakeemulator.DeviceSettings
+import ee.schimke.composeai.fakeemulator.DeviceSettingsController
 import ee.schimke.composeai.fakeemulator.DisplaySize
 import ee.schimke.composeai.fakeemulator.EmulatorFrame
 import ee.schimke.composeai.fakeemulator.FrameSource
@@ -20,40 +22,83 @@ import kotlinx.serialization.json.JsonObject
  * both the [FrameSource] the ADB `screencap` + gRPC screenshot lanes read and the [PreviewLauncher]
  * the `am start … PreviewActivity` intent drives:
  *
- * 1. `launch(request)` maps the composable FQN to a preview id and calls
- *    [RenderSession.streamStart].
- * 2. The daemon then pushes `streamFrame` notifications; we decode each into an [EmulatorFrame] and
+ * 1. `launch(request)` maps the composable FQN to a preview id and opens a held stream.
+ * 2. The daemon pushes `streamFrame` notifications; we decode each into an [EmulatorFrame] and
  *    publish it — so the launched preview's pixels become the emulator screen.
+ * 3. When Android Studio flips a device toggle (dark theme, font size, density, rotation, …) it
+ *    arrives as a [DeviceSettings] change; we re-open the held stream with the mapped
+ *    [PreviewOverrides][ee.schimke.composeai.daemon.protocol.PreviewOverrides] so the preview
+ *    re-renders under that override. (`stream/start` fixes overrides for the held session, so an
+ *    override change is a restart — same pattern as the `serve` live lane.)
  *
  * This is the "wire to serve/daemon" path: no new streaming machinery, just the existing
- * held-stream frame feed re-published as a device display.
+ * held-stream frame feed re-published as a device display, re-parameterised by Studio's settings.
  */
 class RenderSessionFrameSource(
   private val session: RenderSession,
   override val display: DisplaySize,
+  private val settings: DeviceSettingsController,
   private val json: Json = Json { ignoreUnknownKeys = true },
 ) : FrameSource, PreviewLauncher, AutoCloseable {
   private val delegate = MutableFrameSource(display)
   private val seq = AtomicLong(0)
-  @Volatile private var currentStreamId: String? = null
+  private val lock = Any()
+  private var currentPreviewId: String? = null
+  private var currentStreamId: String? = null
+  private var a11ySubscribed = false
 
-  private val subscription = session.onNotification { method, params ->
+  private val frameSubscription = session.onNotification { method, params ->
     if (method == "streamFrame" && params != null) onStreamFrame(params)
   }
+
+  // Re-render the held preview whenever Studio changes a device setting.
+  private val settingsSubscription = settings.addListener { onSettingsChanged(it) }
 
   override fun latest(): EmulatorFrame? = delegate.latest()
 
   override fun subscribe(sink: (EmulatorFrame) -> Unit): AutoCloseable = delegate.subscribe(sink)
 
   override fun launch(request: PreviewLaunchRequest): PreviewLaunchResult {
-    val previewId = previewIdFor(request)
+    val previewId = request.composableFqn
     return try {
-      currentStreamId?.let { runCatching { session.streamStop(it) } }
-      val result = session.streamStart(previewId, codec = StreamCodec.PNG)
-      currentStreamId = result.frameStreamId
+      synchronized(lock) {
+        currentPreviewId = previewId
+        restartStream(previewId)
+      }
+      applyA11y(settings.current, previewId)
       PreviewLaunchResult.Launched
     } catch (e: Exception) {
       PreviewLaunchResult.Rejected(e.message ?: "stream start failed for $previewId")
+    }
+  }
+
+  private fun onSettingsChanged(snapshot: DeviceSettings) {
+    val previewId = synchronized(lock) { currentPreviewId } ?: return
+    synchronized(lock) { runCatching { restartStream(previewId) } }
+    applyA11y(snapshot, previewId)
+  }
+
+  /**
+   * Caller holds [lock]. Stops any current held stream and opens a new one with current overrides.
+   */
+  private fun restartStream(previewId: String) {
+    currentStreamId?.let { runCatching { session.streamStop(it) } }
+    val overrides = settings.current.toPreviewOverrides().takeUnless { it.isEmpty() }
+    currentStreamId =
+      session.streamStart(previewId, codec = StreamCodec.PNG, overrides = overrides).frameStreamId
+  }
+
+  /**
+   * TalkBack has no direct render override; instead we subscribe the a11y data product so the
+   * daemon computes accessibility findings for the shown preview while a screen reader is "on" (and
+   * drop it when off). Best-effort — guarded so an older daemon without the kind degrades silently.
+   */
+  private fun applyA11y(snapshot: DeviceSettings, previewId: String) {
+    if (snapshot.talkBack == a11ySubscribed) return
+    a11ySubscribed = snapshot.talkBack
+    runCatching {
+      if (snapshot.talkBack) session.subscribeData(previewId, A11Y_KIND)
+      else session.unsubscribeData(previewId, A11Y_KIND)
     }
   }
 
@@ -61,23 +106,19 @@ class RenderSessionFrameSource(
     val frame =
       runCatching { json.decodeFromJsonElement(StreamFrameParams.serializer(), params) }.getOrNull()
         ?: return
-    if (frame.frameStreamId != currentStreamId) return
+    if (frame.frameStreamId != synchronized(lock) { currentStreamId }) return
     val payload = frame.payloadBase64 ?: return // unchanged-heartbeat: nothing to paint
     val bytes = runCatching { Base64.getDecoder().decode(payload) }.getOrNull() ?: return
     delegate.push(EmulatorFrame(frame.widthPx, frame.heightPx, bytes, seq.incrementAndGet()))
   }
 
   override fun close() {
-    subscription.close()
-    currentStreamId?.let { runCatching { session.streamStop(it) } }
+    frameSubscription.close()
+    settingsSubscription.close()
+    synchronized(lock) { currentStreamId?.let { runCatching { session.streamStop(it) } } }
   }
 
   private companion object {
-    /**
-     * The preview id is, by convention in this repo, the `className.functionName` FQN — which is
-     * exactly what the `composable` intent extra carries. Use it directly; a richer mapping
-     * (manifest lookup, parameter-provider suffixes) is future work.
-     */
-    fun previewIdFor(request: PreviewLaunchRequest): String = request.composableFqn
+    const val A11Y_KIND = "a11y/atf"
   }
 }

--- a/fake-emulator/app/src/test/kotlin/ee/schimke/composeai/fakeemulator/app/DeviceOverridesTest.kt
+++ b/fake-emulator/app/src/test/kotlin/ee/schimke/composeai/fakeemulator/app/DeviceOverridesTest.kt
@@ -1,0 +1,51 @@
+package ee.schimke.composeai.fakeemulator.app
+
+import com.google.common.truth.Truth.assertThat
+import ee.schimke.composeai.daemon.protocol.Orientation
+import ee.schimke.composeai.daemon.protocol.UiMode as ProtocolUiMode
+import ee.schimke.composeai.fakeemulator.DeviceSettings
+import ee.schimke.composeai.fakeemulator.RotationQuadrant
+import ee.schimke.composeai.fakeemulator.UiMode as DeviceUiMode
+import org.junit.Test
+
+class DeviceOverridesTest {
+  @Test
+  fun `defaults map to an empty override`() {
+    assertThat(DeviceSettings().toPreviewOverrides().isEmpty()).isTrue()
+  }
+
+  @Test
+  fun `dark mode, font scale, density, size and locale map through`() {
+    val overrides =
+      DeviceSettings(
+          uiMode = DeviceUiMode.DARK,
+          fontScale = 1.3f,
+          densityDpi = 320,
+          widthPx = 1080,
+          heightPx = 2400,
+          localeTag = "fr-FR",
+        )
+        .toPreviewOverrides()
+    assertThat(overrides.uiMode).isEqualTo(ProtocolUiMode.DARK)
+    assertThat(overrides.fontScale).isEqualTo(1.3f)
+    assertThat(overrides.density).isEqualTo(2.0f) // 320 / 160
+    assertThat(overrides.widthPx).isEqualTo(1080)
+    assertThat(overrides.heightPx).isEqualTo(2400)
+    assertThat(overrides.localeTag).isEqualTo("fr-FR")
+    assertThat(overrides.isEmpty()).isFalse()
+  }
+
+  @Test
+  fun `landscape rotation maps to landscape orientation`() {
+    val portrait = DeviceSettings(rotation = RotationQuadrant.PORTRAIT).toPreviewOverrides()
+    assertThat(portrait.orientation).isEqualTo(Orientation.PORTRAIT)
+    val landscape = DeviceSettings(rotation = RotationQuadrant.LANDSCAPE).toPreviewOverrides()
+    assertThat(landscape.orientation).isEqualTo(Orientation.LANDSCAPE)
+  }
+
+  @Test
+  fun `light mode maps to light`() {
+    assertThat(DeviceSettings(uiMode = DeviceUiMode.LIGHT).toPreviewOverrides().uiMode)
+      .isEqualTo(ProtocolUiMode.LIGHT)
+  }
+}

--- a/fake-emulator/core/src/main/kotlin/ee/schimke/composeai/fakeemulator/DeviceSettings.kt
+++ b/fake-emulator/core/src/main/kotlin/ee/schimke/composeai/fakeemulator/DeviceSettings.kt
@@ -1,0 +1,108 @@
+package ee.schimke.composeai.fakeemulator
+
+import java.util.concurrent.CopyOnWriteArrayList
+
+/** Light/dark UI mode. [UNSET] keeps the preview's own default. */
+enum class UiMode {
+  UNSET,
+  LIGHT,
+  DARK,
+}
+
+/** Screen-rotation quadrant, matching Android's `user_rotation` (0=0°, 1=90°, 2=180°, 3=270°). */
+enum class RotationQuadrant(val degrees: Int) {
+  PORTRAIT(0),
+  LANDSCAPE(90),
+  REVERSE_PORTRAIT(180),
+  REVERSE_LANDSCAPE(270);
+
+  val isLandscape: Boolean
+    get() = this == LANDSCAPE || this == REVERSE_LANDSCAPE
+
+  companion object {
+    fun fromUserRotation(value: Int): RotationQuadrant =
+      when (((value % 4) + 4) % 4) {
+        1 -> LANDSCAPE
+        2 -> REVERSE_PORTRAIT
+        3 -> REVERSE_LANDSCAPE
+        else -> PORTRAIT
+      }
+  }
+}
+
+/** Foldable posture, mirroring the emulator's `Posture.PostureValue`. */
+enum class DevicePosture {
+  UNKNOWN,
+  CLOSED,
+  HALF_OPENED,
+  OPENED,
+  FLIPPED,
+  TENT,
+}
+
+/**
+ * Display color-correction mode — Android Studio's "Color correction" / "Color inversion" toggles.
+ */
+enum class ColorMode {
+  NONE,
+  INVERTED,
+  PROTANOMALY,
+  DEUTERANOMALY,
+  TRITANOMALY,
+  GRAYSCALE,
+}
+
+/**
+ * The render-relevant device settings the fake emulator exposes. These are the knobs Android Studio
+ * flips — via `adb shell` (dark theme, font size, density, locale, TalkBack, color correction) or
+ * the emulator gRPC (rotation, posture) — that the app maps onto a `PreviewOverrides` and
+ * re-renders.
+ *
+ * Immutable snapshot; mutate through [DeviceSettingsController].
+ */
+data class DeviceSettings(
+  val uiMode: UiMode = UiMode.UNSET,
+  val fontScale: Float? = null,
+  val densityDpi: Int? = null,
+  val widthPx: Int? = null,
+  val heightPx: Int? = null,
+  val localeTag: String? = null,
+  val rotation: RotationQuadrant = RotationQuadrant.PORTRAIT,
+  val posture: DevicePosture = DevicePosture.UNKNOWN,
+  /** TalkBack (or any screen reader) enabled — Studio's a11y toggle. */
+  val talkBack: Boolean = false,
+  val colorMode: ColorMode = ColorMode.NONE,
+  /** `setprop debug.layout true` — draw layout bounds. */
+  val showLayoutBounds: Boolean = false,
+)
+
+/**
+ * Thread-safe, observable holder of [DeviceSettings]. The ADB shell interpreter and the emulator
+ * gRPC service both mutate it; the app subscribes once and recomputes the preview overrides
+ * whenever it changes.
+ */
+class DeviceSettingsController(initial: DeviceSettings = DeviceSettings()) {
+  private val lock = Any()
+  private var value = initial
+  private val listeners = CopyOnWriteArrayList<(DeviceSettings) -> Unit>()
+
+  val current: DeviceSettings
+    get() = synchronized(lock) { value }
+
+  /** Apply [transform] under lock; notify listeners only when the value actually changes. */
+  fun update(transform: (DeviceSettings) -> DeviceSettings) {
+    val next: DeviceSettings
+    synchronized(lock) {
+      val prev = value
+      next = transform(prev)
+      if (next == prev) return
+      value = next
+    }
+    for (listener in listeners) runCatching { listener(next) }
+  }
+
+  fun addListener(listener: (DeviceSettings) -> Unit): AutoCloseable {
+    listeners.add(listener)
+    return AutoCloseable { listeners.remove(listener) }
+  }
+}

--- a/fake-emulator/core/src/main/kotlin/ee/schimke/composeai/fakeemulator/FakeEmulator.kt
+++ b/fake-emulator/core/src/main/kotlin/ee/schimke/composeai/fakeemulator/FakeEmulator.kt
@@ -34,6 +34,12 @@ class FakeEmulator(
   private val config: FakeEmulatorConfig,
   val frameSource: FrameSource,
   private val previewLauncher: PreviewLauncher = PreviewLauncher.NOOP,
+  /**
+   * Render-relevant device settings the ADB shell mutates (and the gRPC controller shares). The app
+   * observes this to re-render the preview under Studio's UI toggles. Defaults to a fresh
+   * controller.
+   */
+  val settings: DeviceSettingsController = DeviceSettingsController(),
   private val discovery: DiscoveryRegistration = DiscoveryRegistration(),
 ) : AutoCloseable {
   private var console: EmulatorConsole? = null
@@ -62,7 +68,7 @@ class FakeEmulator(
       LinkedHashMap(DeviceProperties.defaults(serial, config.display)).apply {
         putAll(config.propertyOverrides)
       }
-    val interpreter = ShellInterpreter(properties, frameSource, previewLauncher)
+    val interpreter = ShellInterpreter(properties, frameSource, previewLauncher, settings)
     val resolver = EmulatorAdbServices(interpreter)
     val banner = AdbBanner.build(properties)
     adbServer = AdbTransportServer(config.adbPort, banner, resolver).also { it.start() }

--- a/fake-emulator/core/src/main/kotlin/ee/schimke/composeai/fakeemulator/ShellInterpreter.kt
+++ b/fake-emulator/core/src/main/kotlin/ee/schimke/composeai/fakeemulator/ShellInterpreter.kt
@@ -4,17 +4,24 @@ import java.nio.charset.StandardCharsets
 
 /**
  * The fake emulator's tiny shell. A real device runs thousands of commands; we answer only the few
- * that matter for **device detection** (`getprop`, `wm size`, `echo`, `id`) and **preview launch**
- * (`am start … PreviewActivity`), plus `screencap` for screenshots. Everything else returns empty
- * output with exit 0 so detection scripts don't choke.
+ * that matter for **device detection** (`getprop`, `wm size`, `echo`, `id`), **preview launch**
+ * (`am start … PreviewActivity`), `screencap` for screenshots, and the **device-settings** commands
+ * Android Studio issues to drive its emulator UI toggles (`cmd uimode night`, `settings put system
+ * font_scale`, `wm density|size`, TalkBack via `settings put secure …accessibility…`, color
+ * correction, locale, layout bounds) — each translated into a [DeviceSettings] change so the app
+ * can re-render the preview under that override. Everything else returns empty output with exit 0.
  */
 class ShellInterpreter(
   private val properties: Map<String, String>,
   private val frameSource: FrameSource,
   private val previewLauncher: PreviewLauncher,
+  private val settings: DeviceSettingsController = DeviceSettingsController(),
 ) {
   /** stdout/stderr are raw bytes because `screencap -p` returns binary PNG. */
   class Result(val stdout: ByteArray, val stderr: ByteArray = ByteArray(0), val exitCode: Int = 0)
+
+  /** Backing store for `settings get/put/delete`, keyed `<namespace>.<key>`. */
+  private val settingsStore = java.util.concurrent.ConcurrentHashMap<String, String>()
 
   fun execute(commandLine: String): Result {
     val tokens = tokenize(commandLine)
@@ -24,6 +31,9 @@ class ShellInterpreter(
       "am" -> am(tokens.drop(1))
       "screencap" -> screencap(tokens.drop(1))
       "wm" -> wm(tokens.drop(1))
+      "cmd" -> cmd(tokens.drop(1))
+      "settings" -> settingsCmd(tokens.drop(1))
+      "setprop" -> setprop(tokens.drop(1))
       "echo" -> ok(tokens.drop(1).joinToString(" ") + "\n")
       "id" -> ok("uid=0(root) gid=0(root) groups=0(root) context=u:r:su:s0\n")
       "true" -> ok("")
@@ -80,14 +90,162 @@ class ShellInterpreter(
   }
 
   private fun wm(args: List<String>): Result {
-    if (args.firstOrNull() == "size") {
-      return ok("Physical size: ${frameSource.display.width}x${frameSource.display.height}\n")
+    when (args.firstOrNull()) {
+      "size" -> {
+        val arg = args.getOrNull(1)
+        return when {
+          arg == null -> {
+            val w = settings.current.widthPx ?: frameSource.display.width
+            val h = settings.current.heightPx ?: frameSource.display.height
+            ok("Physical size: ${w}x${h}\n")
+          }
+          arg == "reset" -> {
+            settings.update { it.copy(widthPx = null, heightPx = null) }
+            ok("")
+          }
+          else -> {
+            val wh = parseSize(arg)
+            if (wh != null) settings.update { it.copy(widthPx = wh.first, heightPx = wh.second) }
+            ok("")
+          }
+        }
+      }
+      "density" -> {
+        val arg = args.getOrNull(1)
+        return when {
+          arg == null ->
+            ok(
+              "Physical density: ${settings.current.densityDpi ?: frameSource.display.densityDpi}\n"
+            )
+          arg == "reset" -> {
+            settings.update { it.copy(densityDpi = null) }
+            ok("")
+          }
+          else -> {
+            arg.toIntOrNull()?.let { dpi -> settings.update { s -> s.copy(densityDpi = dpi) } }
+            ok("")
+          }
+        }
+      }
+      else -> return ok("")
     }
-    if (args.firstOrNull() == "density") {
-      return ok("Physical density: ${frameSource.display.densityDpi}\n")
+  }
+
+  /** `cmd uimode night yes|no|auto`, `cmd locale set-app-locales … --locales <tag>`. */
+  private fun cmd(args: List<String>): Result {
+    when (args.firstOrNull()) {
+      "uimode" ->
+        if (args.getOrNull(1) == "night") {
+          val mode =
+            when (args.getOrNull(2)) {
+              "yes" -> UiMode.DARK
+              "no" -> UiMode.LIGHT
+              else -> UiMode.UNSET // "auto"/"custom"
+            }
+          settings.update { it.copy(uiMode = mode) }
+          return ok("Night mode: ${args.getOrNull(2) ?: "auto"}\n")
+        }
+      "locale" ->
+        if (args.getOrNull(1) == "set-app-locales") {
+          val idx = args.indexOf("--locales")
+          val tag = args.getOrNull(idx + 1)?.takeIf { idx >= 0 }?.substringBefore(',')
+          if (!tag.isNullOrBlank()) settings.update { it.copy(localeTag = tag) }
+          return ok("")
+        }
     }
     return ok("")
   }
+
+  /** `settings put|get|delete <namespace> <key> [value]`. */
+  private fun settingsCmd(args: List<String>): Result {
+    val verb = args.getOrNull(0)
+    val namespace = args.getOrNull(1)
+    val key = args.getOrNull(2)
+    return when (verb) {
+      "put" -> {
+        val value = args.getOrNull(3) ?: return ok("")
+        if (namespace != null && key != null) {
+          settingsStore["$namespace.$key"] = value
+          applySetting(namespace, key, value)
+        }
+        ok("")
+      }
+      "delete" -> {
+        if (namespace != null && key != null) {
+          settingsStore.remove("$namespace.$key")
+          applySetting(namespace, key, null)
+        }
+        ok("")
+      }
+      "get" -> ok((settingsStore["$namespace.$key"] ?: "null") + "\n")
+      else -> ok("")
+    }
+  }
+
+  private fun setprop(args: List<String>): Result {
+    val key = args.getOrNull(0)
+    val value = args.getOrNull(1) ?: ""
+    if (key == "debug.layout") settings.update { it.copy(showLayoutBounds = truthy(value)) }
+    return ok("")
+  }
+
+  /** Map one changed `settings` key onto the [DeviceSettings] field it drives. */
+  private fun applySetting(namespace: String, key: String, value: String?) {
+    when (namespace to key) {
+      "system" to "font_scale" -> settings.update { it.copy(fontScale = value?.toFloatOrNull()) }
+      "system" to "user_rotation" ->
+        settings.update {
+          it.copy(rotation = RotationQuadrant.fromUserRotation(value?.toIntOrNull() ?: 0))
+        }
+      "system" to "system_locales" ->
+        settings.update { it.copy(localeTag = value?.substringBefore(',')?.ifBlank { null }) }
+      // Accessibility (TalkBack) + color correction are computed from several secure keys.
+      "secure" to "accessibility_enabled",
+      "secure" to "enabled_accessibility_services",
+      "secure" to "accessibility_display_inversion_enabled",
+      "secure" to "accessibility_display_daltonizer_enabled",
+      "secure" to "accessibility_display_daltonizer" ->
+        settings.update { it.copy(talkBack = computeTalkBack(), colorMode = computeColorMode()) }
+    }
+  }
+
+  private fun computeTalkBack(): Boolean {
+    val enabled = settingsStore["secure.accessibility_enabled"] == "1"
+    val services = settingsStore["secure.enabled_accessibility_services"].orEmpty()
+    val hasReader =
+      services.isNotBlank() &&
+        services != "null" &&
+        services.contains("talkback", ignoreCase = true)
+    return enabled && hasReader
+  }
+
+  private fun computeColorMode(): ColorMode {
+    if (settingsStore["secure.accessibility_display_inversion_enabled"] == "1")
+      return ColorMode.INVERTED
+    if (settingsStore["secure.accessibility_display_daltonizer_enabled"] != "1")
+      return ColorMode.NONE
+    return when (settingsStore["secure.accessibility_display_daltonizer"]) {
+      "0" -> ColorMode.PROTANOMALY
+      "1" -> ColorMode.DEUTERANOMALY
+      "2" -> ColorMode.TRITANOMALY
+      "12",
+      "11" -> ColorMode.GRAYSCALE
+      else -> ColorMode.DEUTERANOMALY
+    }
+  }
+
+  private fun parseSize(value: String): Pair<Int, Int>? {
+    val parts = value.split('x', 'X')
+    if (parts.size != 2) return null
+    val w = parts[0].trim().toIntOrNull() ?: return null
+    val h = parts[1].trim().toIntOrNull() ?: return null
+    return w to h
+  }
+
+  private fun truthy(value: String): Boolean =
+    value.equals("true", ignoreCase = true) ||
+      value == "1" ||
+      value.equals("yes", ignoreCase = true)
 
   private fun ok(text: String) = Result(text.toByteArray(StandardCharsets.UTF_8))
 

--- a/fake-emulator/core/src/test/kotlin/ee/schimke/composeai/fakeemulator/ShellSettingsTest.kt
+++ b/fake-emulator/core/src/test/kotlin/ee/schimke/composeai/fakeemulator/ShellSettingsTest.kt
@@ -1,0 +1,95 @@
+package ee.schimke.composeai.fakeemulator
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * The `adb shell` device-settings commands Android Studio issues to drive its emulator UI toggles
+ * must land as [DeviceSettings] changes the app can re-render under.
+ */
+class ShellSettingsTest {
+  private val settings = DeviceSettingsController()
+  private val interpreter =
+    ShellInterpreter(
+      properties = DeviceProperties.defaults("emulator-5554", DisplaySize(1080, 2340, 420)),
+      frameSource = MutableFrameSource(DisplaySize(1080, 2340, 420)),
+      previewLauncher = PreviewLauncher.NOOP,
+      settings = settings,
+    )
+
+  @Test
+  fun `cmd uimode night toggles dark and light`() {
+    interpreter.execute("cmd uimode night yes")
+    assertThat(settings.current.uiMode).isEqualTo(UiMode.DARK)
+    interpreter.execute("cmd uimode night no")
+    assertThat(settings.current.uiMode).isEqualTo(UiMode.LIGHT)
+    interpreter.execute("cmd uimode night auto")
+    assertThat(settings.current.uiMode).isEqualTo(UiMode.UNSET)
+  }
+
+  @Test
+  fun `font scale, density and size map through`() {
+    interpreter.execute("settings put system font_scale 1.3")
+    assertThat(settings.current.fontScale).isEqualTo(1.3f)
+    interpreter.execute("wm density 560")
+    assertThat(settings.current.densityDpi).isEqualTo(560)
+    interpreter.execute("wm size 1080x2400")
+    assertThat(settings.current.widthPx).isEqualTo(1080)
+    assertThat(settings.current.heightPx).isEqualTo(2400)
+    interpreter.execute("wm density reset")
+    assertThat(settings.current.densityDpi).isNull()
+  }
+
+  @Test
+  fun `user_rotation maps to a rotation quadrant`() {
+    interpreter.execute("settings put system user_rotation 1")
+    assertThat(settings.current.rotation).isEqualTo(RotationQuadrant.LANDSCAPE)
+    assertThat(settings.current.rotation.isLandscape).isTrue()
+    interpreter.execute("settings put system user_rotation 0")
+    assertThat(settings.current.rotation).isEqualTo(RotationQuadrant.PORTRAIT)
+  }
+
+  @Test
+  fun `enabling TalkBack flips the talkBack setting`() {
+    interpreter.execute(
+      "settings put secure enabled_accessibility_services " +
+        "com.google.android.marvin.talkback/com.google.android.marvin.talkback.TalkBackService"
+    )
+    interpreter.execute("settings put secure accessibility_enabled 1")
+    assertThat(settings.current.talkBack).isTrue()
+
+    interpreter.execute("settings put secure accessibility_enabled 0")
+    assertThat(settings.current.talkBack).isFalse()
+  }
+
+  @Test
+  fun `color inversion and daltonizer map to a color mode`() {
+    interpreter.execute("settings put secure accessibility_display_inversion_enabled 1")
+    assertThat(settings.current.colorMode).isEqualTo(ColorMode.INVERTED)
+    interpreter.execute("settings put secure accessibility_display_inversion_enabled 0")
+    interpreter.execute("settings put secure accessibility_display_daltonizer_enabled 1")
+    interpreter.execute("settings put secure accessibility_display_daltonizer 1")
+    assertThat(settings.current.colorMode).isEqualTo(ColorMode.DEUTERANOMALY)
+  }
+
+  @Test
+  fun `setprop debug layout toggles layout bounds`() {
+    interpreter.execute("setprop debug.layout true")
+    assertThat(settings.current.showLayoutBounds).isTrue()
+  }
+
+  @Test
+  fun `locale set-app-locales maps to localeTag`() {
+    interpreter.execute(
+      "cmd locale set-app-locales com.example --user current --locales fr-FR,en-US"
+    )
+    assertThat(settings.current.localeTag).isEqualTo("fr-FR")
+  }
+
+  @Test
+  fun `settings get echoes a put value`() {
+    interpreter.execute("settings put system font_scale 1.15")
+    val out = String(interpreter.execute("settings get system font_scale").stdout).trim()
+    assertThat(out).isEqualTo("1.15")
+  }
+}

--- a/fake-emulator/grpc/build.gradle.kts
+++ b/fake-emulator/grpc/build.gradle.kts
@@ -27,4 +27,5 @@ dependencies {
 
   testImplementation(libs.junit)
   testImplementation(libs.truth)
+  testImplementation(libs.grpc.inprocess)
 }

--- a/fake-emulator/grpc/src/main/kotlin/ee/schimke/composeai/fakeemulator/grpc/EmulatorControllerService.kt
+++ b/fake-emulator/grpc/src/main/kotlin/ee/schimke/composeai/fakeemulator/grpc/EmulatorControllerService.kt
@@ -1,95 +1,236 @@
 package ee.schimke.composeai.fakeemulator.grpc
 
+import android.emulation.control.AudioFormat
+import android.emulation.control.AudioPacket
+import android.emulation.control.BatteryState
+import android.emulation.control.ClipData
 import android.emulation.control.DisplayConfiguration
 import android.emulation.control.DisplayConfigurations
 import android.emulation.control.EmulatorStatus
 import android.emulation.control.Entry
 import android.emulation.control.EntryList
+import android.emulation.control.Fingerprint
+import android.emulation.control.GpsState
 import android.emulation.control.Image
 import android.emulation.control.ImageFormat
 import android.emulation.control.KeyboardEvent
+import android.emulation.control.LogMessage
+import android.emulation.control.MouseEvent
+import android.emulation.control.Notification
+import android.emulation.control.ParameterValue
+import android.emulation.control.PhoneCall
+import android.emulation.control.PhoneResponse
+import android.emulation.control.PhysicalModelValue
+import android.emulation.control.Posture
+import android.emulation.control.RotationRadian
+import android.emulation.control.SensorValue
+import android.emulation.control.SmsMessage
 import android.emulation.control.TouchEvent
+import android.emulation.control.Velocity
 import android.emulation.control.VmRunState
+import ee.schimke.composeai.fakeemulator.DevicePosture
+import ee.schimke.composeai.fakeemulator.DeviceSettingsController
 import ee.schimke.composeai.fakeemulator.EmulatorFrame
 import ee.schimke.composeai.fakeemulator.FrameSource
 import ee.schimke.composeai.fakeemulator.PlaceholderImage
+import ee.schimke.composeai.fakeemulator.RotationQuadrant
 import io.grpc.MethodDescriptor
 import io.grpc.ServerServiceDefinition
 import io.grpc.stub.ServerCallStreamObserver
 import io.grpc.stub.ServerCalls
 import io.grpc.stub.StreamObserver
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicReference
 import okio.ByteString.Companion.toByteString
 
 /**
  * The fake emulator's `android.emulation.control.EmulatorController` service, bound by hand into
- * grpc-java (Wire generates only the messages — see [WireMarshaller]). Identity/liveness + display
- * geometry are synthesised from the [FrameSource]; `getScreenshot` and the `streamScreenshot`
- * "video" lane are served straight off it (the same frames the ADB `screencap` path serves).
- * Key/touch are forwarded to the supplied callbacks.
+ * grpc-java (Wire generates only the messages — see [WireMarshaller]). Implements the surface
+ * Android Studio's embedded "Running Devices" view + Extended Controls drive:
+ *
+ * - **Display + screenshots** — geometry from the [FrameSource]; `getScreenshot` and the
+ *   `streamScreenshot` "video" lane serve its frames.
+ * - **Input** — `sendKey` / `sendTouch` / `sendMouse` forward to the supplied callbacks.
+ * - **Rotation / posture** — `setPhysicalModel(ROTATION)` and `setPosture` drive the shared
+ *   [DeviceSettingsController], so the preview re-renders rotated/folded; `streamPhysicalModel` /
+ *   `streamNotification` emit when that state (or an `adb`-driven one) changes.
+ * - **Clipboard, battery, GPS, sensors** — in-memory state with get/set/stream.
+ * - **Telephony, fingerprint, audio, logcat, virtual-scene camera** — accepted with sensible
+ *   defaults / no-ops so Studio never hits `UNIMPLEMENTED`.
+ *
+ * [close] detaches the settings listener.
  */
 class EmulatorControllerService(
   private val frameSource: FrameSource,
+  private val settings: DeviceSettingsController,
   private val startNanos: Long = System.nanoTime(),
   private val onKey: (KeyboardEvent) -> Unit = {},
   private val onTouch: (TouchEvent) -> Unit = {},
-) {
+  private val onMouse: (MouseEvent) -> Unit = {},
+) : AutoCloseable {
+  private val clipboard = AtomicReference("")
+  private val battery = AtomicReference(defaultBattery())
+  private val gps = AtomicReference(GpsState())
+  private val sensors = ConcurrentHashMap<SensorValue.SensorType, List<Float>>()
+  private val physical = ConcurrentHashMap<PhysicalModelValue.PhysicalType, List<Float>>()
+
+  private val clipboardObservers = CopyOnWriteArrayList<StreamObserver<ClipData>>()
+  private val notificationObservers = CopyOnWriteArrayList<StreamObserver<Notification>>()
+  private val rotationObservers = CopyOnWriteArrayList<StreamObserver<PhysicalModelValue>>()
+
+  // adb- or gRPC-driven rotation/display changes both flow through settings; mirror them onto the
+  // physical-model + notification streams Studio listens on.
+  private val settingsSubscription = settings.addListener {
+    val update = rotationModel(it.rotation)
+    rotationObservers.forEach { obs -> runCatching { obs.onNext(update) } }
+    val notification =
+      Notification(event = Notification.EventType.DISPLAY_CONFIGURATIONS_CHANGED_UI)
+    notificationObservers.forEach { obs -> runCatching { obs.onNext(notification) } }
+  }
+
+  override fun close() {
+    settingsSubscription.close()
+  }
+
   fun bindService(): ServerServiceDefinition =
     ServerServiceDefinition.builder(SERVICE_NAME)
-      .addMethod(
-        getStatusMethod,
-        ServerCalls.asyncUnaryCall { _: Unit, observer: StreamObserver<EmulatorStatus> ->
-          observer.completeWith(status())
-        },
-      )
-      .addMethod(
-        getVmStateMethod,
-        ServerCalls.asyncUnaryCall { _: Unit, observer: StreamObserver<VmRunState> ->
-          observer.completeWith(VmRunState(state = VmRunState.RunState.RUNNING))
-        },
-      )
-      .addMethod(
-        setVmStateMethod,
-        ServerCalls.asyncUnaryCall { _: VmRunState, observer: StreamObserver<Unit> ->
-          observer.completeWith(Unit)
-        },
-      )
-      .addMethod(
-        getDisplayConfigurationsMethod,
-        ServerCalls.asyncUnaryCall { _: Unit, observer: StreamObserver<DisplayConfigurations> ->
-          observer.completeWith(displayConfigurations())
-        },
-      )
-      .addMethod(
-        getScreenshotMethod,
-        ServerCalls.asyncUnaryCall { _: ImageFormat, observer: StreamObserver<Image> ->
-          observer.completeWith(currentImage())
-        },
-      )
-      .addMethod(
-        streamScreenshotMethod,
-        ServerCalls.asyncServerStreamingCall { _: ImageFormat, observer: StreamObserver<Image> ->
-          val serverObserver = observer as ServerCallStreamObserver<Image>
-          val handle = frameSource.subscribe { frame ->
-            if (!serverObserver.isCancelled) runCatching { observer.onNext(toImage(frame)) }
+      // ---- identity / vm / display ----
+      .unary(getStatusMethod) { _: Unit -> status() }
+      .unary(getVmStateMethod) { _: Unit -> VmRunState(state = VmRunState.RunState.RUNNING) }
+      .unary(setVmStateMethod) { _: VmRunState -> Unit }
+      .unary(getDisplayConfigurationsMethod) { _: Unit -> displayConfigurations() }
+      .unary(setDisplayConfigurationsMethod) { request: DisplayConfigurations ->
+        request.displays.firstOrNull()?.let { d ->
+          settings.update {
+            it.copy(
+              widthPx = d.width.takeIf { v -> v > 0 } ?: it.widthPx,
+              heightPx = d.height.takeIf { v -> v > 0 } ?: it.heightPx,
+              densityDpi = d.dpi.takeIf { v -> v > 0 } ?: it.densityDpi,
+            )
           }
-          serverObserver.setOnCancelHandler { handle.close() }
-        },
-      )
-      .addMethod(
-        sendKeyMethod,
-        ServerCalls.asyncUnaryCall { request: KeyboardEvent, observer: StreamObserver<Unit> ->
-          onKey(request)
-          observer.completeWith(Unit)
-        },
-      )
-      .addMethod(
-        sendTouchMethod,
-        ServerCalls.asyncUnaryCall { request: TouchEvent, observer: StreamObserver<Unit> ->
-          onTouch(request)
-          observer.completeWith(Unit)
-        },
-      )
+        }
+        displayConfigurations()
+      }
+      // ---- screenshots ----
+      .unary(getScreenshotMethod) { _: ImageFormat -> currentImage() }
+      .serverStream(streamScreenshotMethod) { _: ImageFormat, observer ->
+        val server = observer as ServerCallStreamObserver<Image>
+        val handle = frameSource.subscribe { frame ->
+          if (!server.isCancelled) runCatching { observer.onNext(toImage(frame)) }
+        }
+        server.setOnCancelHandler { handle.close() }
+      }
+      // ---- input ----
+      .unary(sendKeyMethod) { request: KeyboardEvent -> onKey(request) }
+      .unary(sendTouchMethod) { request: TouchEvent -> onTouch(request) }
+      .unary(sendMouseMethod) { request: MouseEvent -> onMouse(request) }
+      // ---- sensors / physical model / posture ----
+      .unary(getSensorMethod) { request: SensorValue ->
+        SensorValue(
+          target = request.target,
+          status = SensorValue.State.OK,
+          value_ = ParameterValue(data_ = sensors[request.target] ?: emptyList()),
+        )
+      }
+      .unary(setSensorMethod) { request: SensorValue ->
+        sensors[request.target] = request.value_?.data_ ?: emptyList()
+      }
+      .serverStream(streamSensorMethod) { request: SensorValue, observer ->
+        observer.onNext(
+          SensorValue(
+            target = request.target,
+            status = SensorValue.State.OK,
+            value_ = ParameterValue(data_ = sensors[request.target] ?: emptyList()),
+          )
+        )
+        // No change source for raw sensors — leave the stream open until the client cancels.
+      }
+      .unary(getPhysicalModelMethod) { request: PhysicalModelValue ->
+        physicalModel(request.target)
+      }
+      .unary(setPhysicalModelMethod) { request: PhysicalModelValue ->
+        val data = request.value_?.data_ ?: emptyList()
+        physical[request.target] = data
+        if (request.target == PhysicalModelValue.PhysicalType.ROTATION) {
+          // value = [x, y, z] angles in degrees; z is the screen rotation about the view axis.
+          val z = data.getOrNull(2) ?: 0f
+          settings.update {
+            it.copy(rotation = RotationQuadrant.fromUserRotation(Math.round(z / 90f)))
+          }
+        }
+      }
+      .serverStream(streamPhysicalModelMethod) { request: PhysicalModelValue, observer ->
+        val server = observer as ServerCallStreamObserver<PhysicalModelValue>
+        observer.onNext(physicalModel(request.target))
+        if (request.target == PhysicalModelValue.PhysicalType.ROTATION) {
+          rotationObservers.add(observer)
+          server.setOnCancelHandler { rotationObservers.remove(observer) }
+        }
+      }
+      .unary(setPostureMethod) { request: Posture ->
+        settings.update { it.copy(posture = posture(request.value_)) }
+      }
+      // ---- clipboard ----
+      .unary(getClipboardMethod) { _: Unit -> ClipData(text = clipboard.get()) }
+      .unary(setClipboardMethod) { request: ClipData ->
+        clipboard.set(request.text)
+        clipboardObservers.forEach { runCatching { it.onNext(request) } }
+      }
+      .serverStream(streamClipboardMethod) { _: Unit, observer ->
+        val server = observer as ServerCallStreamObserver<ClipData>
+        observer.onNext(ClipData(text = clipboard.get()))
+        clipboardObservers.add(observer)
+        server.setOnCancelHandler { clipboardObservers.remove(observer) }
+      }
+      // ---- extended controls ----
+      .unary(getBatteryMethod) { _: Unit -> battery.get() }
+      .unary(setBatteryMethod) { request: BatteryState -> battery.set(request) }
+      .unary(getGpsMethod) { _: Unit -> gps.get() }
+      .unary(setGpsMethod) { request: GpsState -> gps.set(request) }
+      .unary(sendFingerprintMethod) { _: Fingerprint -> Unit }
+      .unary(sendPhoneMethod) { _: PhoneCall ->
+        PhoneResponse(response = PhoneResponse.Response.OK)
+      }
+      .unary(sendSmsMethod) { _: SmsMessage -> PhoneResponse(response = PhoneResponse.Response.OK) }
+      // ---- notifications ----
+      .serverStream(streamNotificationMethod) { _: Unit, observer ->
+        val server = observer as ServerCallStreamObserver<Notification>
+        notificationObservers.add(observer)
+        server.setOnCancelHandler { notificationObservers.remove(observer) }
+      }
+      // ---- audio / logcat / virtual scene (accepted; minimal behaviour) ----
+      .serverStream(streamAudioMethod) { _: AudioFormat, _ ->
+        // No audio source — keep the stream open until the client cancels.
+      }
+      .clientStream(injectAudioMethod) { responseObserver ->
+        object : StreamObserver<AudioPacket> {
+          override fun onNext(value: AudioPacket) {}
+
+          override fun onError(t: Throwable) {}
+
+          override fun onCompleted() {
+            responseObserver.onNext(Unit)
+            responseObserver.onCompleted()
+          }
+        }
+      }
+      .unary(getLogcatMethod) { request: LogMessage ->
+        LogMessage(
+          contents = "",
+          start = request.start,
+          next = request.start,
+          sort = LogMessage.LogType.Text,
+        )
+      }
+      .serverStream(streamLogcatMethod) { _: LogMessage, _ ->
+        // No serial-console buffer — keep open until cancel.
+      }
+      .unary(rotateVirtualSceneCameraMethod) { _: RotationRadian -> Unit }
+      .unary(setVirtualSceneCameraVelocityMethod) { _: Velocity -> Unit }
       .build()
+
+  // ---- builders --------------------------------------------------------------------------------
 
   private fun status(): EmulatorStatus =
     EmulatorStatus(
@@ -100,9 +241,9 @@ class EmulatorControllerService(
         EntryList(
           entry =
             listOf(
-              Entry(key = "hw.lcd.width", value_ = frameSource.display.width.toString()),
-              Entry(key = "hw.lcd.height", value_ = frameSource.display.height.toString()),
-              Entry(key = "hw.lcd.density", value_ = frameSource.display.densityDpi.toString()),
+              Entry(key = "hw.lcd.width", value_ = displayWidth().toString()),
+              Entry(key = "hw.lcd.height", value_ = displayHeight().toString()),
+              Entry(key = "hw.lcd.density", value_ = displayDensity().toString()),
             )
         ),
     )
@@ -112,24 +253,43 @@ class EmulatorControllerService(
       displays =
         listOf(
           DisplayConfiguration(
-            width = frameSource.display.width,
-            height = frameSource.display.height,
-            dpi = frameSource.display.densityDpi,
+            width = displayWidth(),
+            height = displayHeight(),
+            dpi = displayDensity(),
             display = 0,
           )
         )
     )
 
+  private fun physicalModel(target: PhysicalModelValue.PhysicalType): PhysicalModelValue =
+    if (target == PhysicalModelValue.PhysicalType.ROTATION) {
+      rotationModel(settings.current.rotation)
+    } else {
+      PhysicalModelValue(
+        target = target,
+        status = PhysicalModelValue.State.OK,
+        value_ = ParameterValue(data_ = physical[target] ?: emptyList()),
+      )
+    }
+
+  private fun rotationModel(rotation: RotationQuadrant): PhysicalModelValue =
+    PhysicalModelValue(
+      target = PhysicalModelValue.PhysicalType.ROTATION,
+      status = PhysicalModelValue.State.OK,
+      value_ = ParameterValue(data_ = listOf(0f, 0f, rotation.degrees.toFloat())),
+    )
+
+  private fun displayWidth(): Int = settings.current.widthPx ?: frameSource.display.width
+
+  private fun displayHeight(): Int = settings.current.heightPx ?: frameSource.display.height
+
+  private fun displayDensity(): Int = settings.current.densityDpi ?: frameSource.display.densityDpi
+
   private fun currentImage(): Image {
     val frame = frameSource.latest()
     if (frame != null) return toImage(frame)
-    val png =
-      PlaceholderImage.solidPng(
-        frameSource.display.width,
-        frameSource.display.height,
-        0xFF202124.toInt(),
-      )
-    return toImage(EmulatorFrame(frameSource.display.width, frameSource.display.height, png, 0))
+    val png = PlaceholderImage.solidPng(displayWidth(), displayHeight(), 0xFF202124.toInt())
+    return toImage(EmulatorFrame(displayWidth(), displayHeight(), png, 0))
   }
 
   private fun toImage(frame: EmulatorFrame): Image =
@@ -141,21 +301,63 @@ class EmulatorControllerService(
           height = frame.height,
           display = 0,
         ),
-      seq = frame.seq.toInt(),
       image = frame.png.toByteString(),
+      seq = frame.seq.toInt(),
       timestampUs = System.nanoTime() / 1_000,
     )
 
   private companion object {
     const val SERVICE_NAME = "android.emulation.control.EmulatorController"
 
+    fun defaultBattery(): BatteryState =
+      BatteryState(
+        hasBattery = true,
+        isPresent = true,
+        charger = BatteryState.BatteryCharger.AC,
+        chargeLevel = 100,
+        health = BatteryState.BatteryHealth.GOOD,
+        status = BatteryState.BatteryStatus.FULL,
+      )
+
+    fun posture(value: Posture.PostureValue): DevicePosture =
+      when (value) {
+        Posture.PostureValue.POSTURE_CLOSED -> DevicePosture.CLOSED
+        Posture.PostureValue.POSTURE_HALF_OPENED -> DevicePosture.HALF_OPENED
+        Posture.PostureValue.POSTURE_OPENED -> DevicePosture.OPENED
+        Posture.PostureValue.POSTURE_FLIPPED -> DevicePosture.FLIPPED
+        Posture.PostureValue.POSTURE_TENT -> DevicePosture.TENT
+        else -> DevicePosture.UNKNOWN
+      }
+
+    // -- method descriptors --
     private fun <Req : Any, Resp : Any> unary(
       name: String,
-      reqMarshaller: MethodDescriptor.Marshaller<Req>,
-      respMarshaller: MethodDescriptor.Marshaller<Resp>,
+      req: MethodDescriptor.Marshaller<Req>,
+      resp: MethodDescriptor.Marshaller<Resp>,
+    ): MethodDescriptor<Req, Resp> = method(name, MethodDescriptor.MethodType.UNARY, req, resp)
+
+    private fun <Req : Any, Resp : Any> serverStreaming(
+      name: String,
+      req: MethodDescriptor.Marshaller<Req>,
+      resp: MethodDescriptor.Marshaller<Resp>,
     ): MethodDescriptor<Req, Resp> =
-      MethodDescriptor.newBuilder(reqMarshaller, respMarshaller)
-        .setType(MethodDescriptor.MethodType.UNARY)
+      method(name, MethodDescriptor.MethodType.SERVER_STREAMING, req, resp)
+
+    private fun <Req : Any, Resp : Any> clientStreaming(
+      name: String,
+      req: MethodDescriptor.Marshaller<Req>,
+      resp: MethodDescriptor.Marshaller<Resp>,
+    ): MethodDescriptor<Req, Resp> =
+      method(name, MethodDescriptor.MethodType.CLIENT_STREAMING, req, resp)
+
+    private fun <Req : Any, Resp : Any> method(
+      name: String,
+      type: MethodDescriptor.MethodType,
+      req: MethodDescriptor.Marshaller<Req>,
+      resp: MethodDescriptor.Marshaller<Resp>,
+    ): MethodDescriptor<Req, Resp> =
+      MethodDescriptor.newBuilder(req, resp)
+        .setType(type)
         .setFullMethodName(MethodDescriptor.generateFullMethodName(SERVICE_NAME, name))
         .build()
 
@@ -169,26 +371,120 @@ class EmulatorControllerService(
         EmptyMarshaller,
         WireMarshaller(DisplayConfigurations.ADAPTER),
       )
+    val setDisplayConfigurationsMethod =
+      unary(
+        "setDisplayConfigurations",
+        WireMarshaller(DisplayConfigurations.ADAPTER),
+        WireMarshaller(DisplayConfigurations.ADAPTER),
+      )
     val getScreenshotMethod =
       unary("getScreenshot", WireMarshaller(ImageFormat.ADAPTER), WireMarshaller(Image.ADAPTER))
+    val streamScreenshotMethod =
+      serverStreaming(
+        "streamScreenshot",
+        WireMarshaller(ImageFormat.ADAPTER),
+        WireMarshaller(Image.ADAPTER),
+      )
     val sendKeyMethod = unary("sendKey", WireMarshaller(KeyboardEvent.ADAPTER), EmptyMarshaller)
     val sendTouchMethod = unary("sendTouch", WireMarshaller(TouchEvent.ADAPTER), EmptyMarshaller)
-
-    val streamScreenshotMethod: MethodDescriptor<ImageFormat, Image> =
-      MethodDescriptor.newBuilder(
-          WireMarshaller(ImageFormat.ADAPTER),
-          WireMarshaller(Image.ADAPTER),
-        )
-        .setType(MethodDescriptor.MethodType.SERVER_STREAMING)
-        .setFullMethodName(
-          MethodDescriptor.generateFullMethodName(SERVICE_NAME, "streamScreenshot")
-        )
-        .build()
+    val sendMouseMethod = unary("sendMouse", WireMarshaller(MouseEvent.ADAPTER), EmptyMarshaller)
+    val getSensorMethod =
+      unary("getSensor", WireMarshaller(SensorValue.ADAPTER), WireMarshaller(SensorValue.ADAPTER))
+    val setSensorMethod = unary("setSensor", WireMarshaller(SensorValue.ADAPTER), EmptyMarshaller)
+    val streamSensorMethod =
+      serverStreaming(
+        "streamSensor",
+        WireMarshaller(SensorValue.ADAPTER),
+        WireMarshaller(SensorValue.ADAPTER),
+      )
+    val getPhysicalModelMethod =
+      unary(
+        "getPhysicalModel",
+        WireMarshaller(PhysicalModelValue.ADAPTER),
+        WireMarshaller(PhysicalModelValue.ADAPTER),
+      )
+    val setPhysicalModelMethod =
+      unary("setPhysicalModel", WireMarshaller(PhysicalModelValue.ADAPTER), EmptyMarshaller)
+    val streamPhysicalModelMethod =
+      serverStreaming(
+        "streamPhysicalModel",
+        WireMarshaller(PhysicalModelValue.ADAPTER),
+        WireMarshaller(PhysicalModelValue.ADAPTER),
+      )
+    val setPostureMethod = unary("setPosture", WireMarshaller(Posture.ADAPTER), EmptyMarshaller)
+    val getClipboardMethod =
+      unary("getClipboard", EmptyMarshaller, WireMarshaller(ClipData.ADAPTER))
+    val setClipboardMethod =
+      unary("setClipboard", WireMarshaller(ClipData.ADAPTER), EmptyMarshaller)
+    val streamClipboardMethod =
+      serverStreaming("streamClipboard", EmptyMarshaller, WireMarshaller(ClipData.ADAPTER))
+    val getBatteryMethod =
+      unary("getBattery", EmptyMarshaller, WireMarshaller(BatteryState.ADAPTER))
+    val setBatteryMethod =
+      unary("setBattery", WireMarshaller(BatteryState.ADAPTER), EmptyMarshaller)
+    val getGpsMethod = unary("getGps", EmptyMarshaller, WireMarshaller(GpsState.ADAPTER))
+    val setGpsMethod = unary("setGps", WireMarshaller(GpsState.ADAPTER), EmptyMarshaller)
+    val sendFingerprintMethod =
+      unary("sendFingerprint", WireMarshaller(Fingerprint.ADAPTER), EmptyMarshaller)
+    val sendPhoneMethod =
+      unary("sendPhone", WireMarshaller(PhoneCall.ADAPTER), WireMarshaller(PhoneResponse.ADAPTER))
+    val sendSmsMethod =
+      unary("sendSms", WireMarshaller(SmsMessage.ADAPTER), WireMarshaller(PhoneResponse.ADAPTER))
+    val streamNotificationMethod =
+      serverStreaming("streamNotification", EmptyMarshaller, WireMarshaller(Notification.ADAPTER))
+    val streamAudioMethod =
+      serverStreaming(
+        "streamAudio",
+        WireMarshaller(AudioFormat.ADAPTER),
+        WireMarshaller(AudioPacket.ADAPTER),
+      )
+    val injectAudioMethod =
+      clientStreaming("injectAudio", WireMarshaller(AudioPacket.ADAPTER), EmptyMarshaller)
+    val getLogcatMethod =
+      unary("getLogcat", WireMarshaller(LogMessage.ADAPTER), WireMarshaller(LogMessage.ADAPTER))
+    val streamLogcatMethod =
+      serverStreaming(
+        "streamLogcat",
+        WireMarshaller(LogMessage.ADAPTER),
+        WireMarshaller(LogMessage.ADAPTER),
+      )
+    val rotateVirtualSceneCameraMethod =
+      unary("rotateVirtualSceneCamera", WireMarshaller(RotationRadian.ADAPTER), EmptyMarshaller)
+    val setVirtualSceneCameraVelocityMethod =
+      unary("setVirtualSceneCameraVelocity", WireMarshaller(Velocity.ADAPTER), EmptyMarshaller)
   }
 }
 
-/** Emit one value and complete — the common unary-response shape. */
-private fun <T> StreamObserver<T>.completeWith(value: T) {
-  onNext(value)
-  onCompleted()
-}
+/**
+ * Register a unary handler that returns a response value (Unit response = the Empty marshaller).
+ */
+private fun <Req : Any, Resp : Any> ServerServiceDefinition.Builder.unary(
+  method: MethodDescriptor<Req, Resp>,
+  handler: (Req) -> Resp,
+): ServerServiceDefinition.Builder =
+  addMethod(
+    method,
+    ServerCalls.asyncUnaryCall { request: Req, observer: StreamObserver<Resp> ->
+      observer.onNext(handler(request))
+      observer.onCompleted()
+    },
+  )
+
+/** Register a server-streaming handler; the handler keeps the [StreamObserver] and pushes to it. */
+private fun <Req : Any, Resp : Any> ServerServiceDefinition.Builder.serverStream(
+  method: MethodDescriptor<Req, Resp>,
+  handler: (Req, StreamObserver<Resp>) -> Unit,
+): ServerServiceDefinition.Builder =
+  addMethod(
+    method,
+    ServerCalls.asyncServerStreamingCall { request: Req, observer -> handler(request, observer) },
+  )
+
+/**
+ * Register a client-streaming handler; returns the request observer that consumes the client lane.
+ */
+private fun <Req : Any, Resp : Any> ServerServiceDefinition.Builder.clientStream(
+  method: MethodDescriptor<Req, Resp>,
+  handler: (StreamObserver<Resp>) -> StreamObserver<Req>,
+): ServerServiceDefinition.Builder =
+  addMethod(method, ServerCalls.asyncClientStreamingCall { observer -> handler(observer) })

--- a/fake-emulator/grpc/src/main/proto/emulator_controller.proto
+++ b/fake-emulator/grpc/src/main/proto/emulator_controller.proto
@@ -1,12 +1,9 @@
 // Vendored SUBSET of the Android emulator's `android.emulation.control.EmulatorController` gRPC API
-// (the surface Android Studio's embedded "Running Devices" view + screenshot video stream consume).
-//
-// This is a subset — not every message/field of the shipping proto — but the field NUMBERS and types
-// of the messages it does define are kept wire-compatible with the canonical
-// `emulator_controller.proto` (see google-deepmind/android_env, AOSP external/qemu, and the
-// maintainer's yschimke/emulator-tools), so a real Studio client decodes our responses correctly.
-// Fields/messages we don't need (e.g. ImageFormat.transport/foldedDisplay, EmulatorStatus.vmConfig)
-// are omitted, not renumbered — omission is wire-compatible.
+// (the surface Android Studio's embedded "Running Devices" view + the emulator Extended Controls
+// drive). The field NUMBERS and types of every message here are kept wire-compatible with the
+// canonical `emulator_controller.proto` (google-deepmind/android_env, AOSP external/qemu,
+// yschimke/emulator-tools), so a real Studio/emulator client decodes our responses. Fields/messages
+// we don't model are omitted, not renumbered. See docs/fake-emulator/DESIGN.md.
 syntax = "proto3";
 
 package android.emulation.control;
@@ -18,28 +15,67 @@ option java_outer_classname = "EmulatorControllerProto";
 import "google/protobuf/empty.proto";
 
 service EmulatorController {
-  // Identity + liveness.
-  rpc getStatus(google.protobuf.Empty) returns (EmulatorStatus) {}
+  // Sensors + physical model (rotation, fold/hinge, posture).
+  rpc streamSensor(SensorValue) returns (stream SensorValue) {}
+  rpc getSensor(SensorValue) returns (SensorValue) {}
+  rpc setSensor(SensorValue) returns (google.protobuf.Empty) {}
+  rpc setPhysicalModel(PhysicalModelValue) returns (google.protobuf.Empty) {}
+  rpc getPhysicalModel(PhysicalModelValue) returns (PhysicalModelValue) {}
+  rpc streamPhysicalModel(PhysicalModelValue) returns (stream PhysicalModelValue) {}
+  rpc setPosture(Posture) returns (google.protobuf.Empty) {}
 
-  // VM run state (run / pause / shutdown).
-  rpc getVmState(google.protobuf.Empty) returns (VmRunState) {}
-  rpc setVmState(VmRunState) returns (google.protobuf.Empty) {}
+  // Clipboard sharing.
+  rpc setClipboard(ClipData) returns (google.protobuf.Empty) {}
+  rpc getClipboard(google.protobuf.Empty) returns (ClipData) {}
+  rpc streamClipboard(google.protobuf.Empty) returns (stream ClipData) {}
 
-  // Display geometry.
-  rpc getDisplayConfigurations(google.protobuf.Empty) returns (DisplayConfigurations) {}
-
-  // One screenshot.
-  rpc getScreenshot(ImageFormat) returns (Image) {}
-
-  // The "video" lane: a server-streaming feed of frames as they are produced.
-  rpc streamScreenshot(ImageFormat) returns (stream Image) {}
+  // Extended controls: battery, location, fingerprint.
+  rpc setBattery(BatteryState) returns (google.protobuf.Empty) {}
+  rpc getBattery(google.protobuf.Empty) returns (BatteryState) {}
+  rpc setGps(GpsState) returns (google.protobuf.Empty) {}
+  rpc getGps(google.protobuf.Empty) returns (GpsState) {}
+  rpc sendFingerprint(Fingerprint) returns (google.protobuf.Empty) {}
 
   // Input injection.
   rpc sendKey(KeyboardEvent) returns (google.protobuf.Empty) {}
   rpc sendTouch(TouchEvent) returns (google.protobuf.Empty) {}
+  rpc sendMouse(MouseEvent) returns (google.protobuf.Empty) {}
+
+  // Telephony.
+  rpc sendPhone(PhoneCall) returns (PhoneResponse) {}
+  rpc sendSms(SmsMessage) returns (PhoneResponse) {}
+
+  // Identity + display + screenshots.
+  rpc getStatus(google.protobuf.Empty) returns (EmulatorStatus) {}
+  rpc getScreenshot(ImageFormat) returns (Image) {}
+  rpc streamScreenshot(ImageFormat) returns (stream Image) {}
+
+  // Audio.
+  rpc streamAudio(AudioFormat) returns (stream AudioPacket) {}
+  rpc injectAudio(stream AudioPacket) returns (google.protobuf.Empty) {}
+
+  // Serial / logcat.
+  rpc getLogcat(LogMessage) returns (LogMessage) {}
+  rpc streamLogcat(LogMessage) returns (stream LogMessage) {}
+
+  // VM state.
+  rpc setVmState(VmRunState) returns (google.protobuf.Empty) {}
+  rpc getVmState(google.protobuf.Empty) returns (VmRunState) {}
+
+  // Display configuration.
+  rpc setDisplayConfigurations(DisplayConfigurations) returns (DisplayConfigurations) {}
+  rpc getDisplayConfigurations(google.protobuf.Empty) returns (DisplayConfigurations) {}
+
+  // Notifications (display/posture/camera changes).
+  rpc streamNotification(google.protobuf.Empty) returns (stream Notification) {}
+
+  // Virtual scene camera.
+  rpc rotateVirtualSceneCamera(RotationRadian) returns (google.protobuf.Empty) {}
+  rpc setVirtualSceneCameraVelocity(Velocity) returns (google.protobuf.Empty) {}
 }
 
-// Generic key/value pair + list, used by EmulatorStatus.hardwareConfig.
+// ---- Identity / VM / display -------------------------------------------------------------------
+
 message Entry {
   string key = 1;
   string value = 2;
@@ -50,14 +86,10 @@ message EntryList {
 }
 
 message EmulatorStatus {
-  // The emulator version string.
   string version = 1;
-  // The time the emulator has been active, in ms.
   uint64 uptime = 2;
-  // True if the device has completed booting.
   bool booted = 3;
-  // Field 4 (VmConfiguration vmConfig) is intentionally omitted — we don't model it.
-  // The hardware configuration as key/value pairs.
+  // Field 4 (VmConfiguration vmConfig) is intentionally omitted.
   EntryList hardwareConfig = 5;
 }
 
@@ -88,6 +120,8 @@ message DisplayConfiguration {
   uint32 display = 5;
 }
 
+// ---- Screenshots -------------------------------------------------------------------------------
+
 message Rotation {
   enum SkinRotation {
     PORTRAIT = 0;
@@ -112,17 +146,19 @@ message ImageFormat {
   uint32 width = 3;
   uint32 height = 4;
   uint32 display = 5;
-  // Fields 6 (transport) and 7 (foldedDisplay) are omitted — we don't model them.
+  // Fields 6 (transport) and 7 (foldedDisplay) are omitted.
 }
 
 message Image {
   ImageFormat format = 1;
-  uint32 width = 2 [deprecated = true]; // width is contained in format.
-  uint32 height = 3 [deprecated = true]; // height is contained in format.
+  uint32 width = 2 [deprecated = true];
+  uint32 height = 3 [deprecated = true];
   bytes image = 4;
   uint32 seq = 5;
   uint64 timestampUs = 6;
 }
+
+// ---- Input -------------------------------------------------------------------------------------
 
 message KeyboardEvent {
   enum KeyCodeType {
@@ -157,4 +193,229 @@ message Touch {
 message TouchEvent {
   repeated Touch touches = 1;
   int32 display = 2;
+}
+
+message MouseEvent {
+  int32 x = 1;
+  int32 y = 2;
+  int32 buttons = 3;
+  int32 display = 4;
+}
+
+// ---- Sensors / physical model ------------------------------------------------------------------
+
+message ParameterValue {
+  repeated float data = 1 [packed = true];
+}
+
+message SensorValue {
+  enum State {
+    OK = 0;
+    NO_SERVICE = -3;
+    DISABLED = -2;
+    UNKNOWN = -1;
+  }
+  enum SensorType {
+    ACCELERATION = 0;
+    GYROSCOPE = 1;
+    MAGNETIC_FIELD = 2;
+    ORIENTATION = 3;
+    TEMPERATURE = 4;
+    PROXIMITY = 5;
+    LIGHT = 6;
+    PRESSURE = 7;
+    HUMIDITY = 8;
+    MAGNETIC_FIELD_UNCALIBRATED = 9;
+    GYROSCOPE_UNCALIBRATED = 10;
+  }
+  SensorType target = 1;
+  State status = 2;
+  ParameterValue value = 3;
+}
+
+message PhysicalModelValue {
+  enum State {
+    OK = 0;
+    NO_SERVICE = -3;
+    DISABLED = -2;
+    UNKNOWN = -1;
+  }
+  enum PhysicalType {
+    POSITION = 0;
+    ROTATION = 1;
+    MAGNETIC_FIELD = 2;
+    TEMPERATURE = 3;
+    PROXIMITY = 4;
+    LIGHT = 5;
+    PRESSURE = 6;
+    HUMIDITY = 7;
+    VELOCITY = 8;
+    AMBIENT_MOTION = 9;
+    HINGE_ANGLE0 = 10;
+    HINGE_ANGLE1 = 11;
+    HINGE_ANGLE2 = 12;
+    ROLLABLE0 = 13;
+    ROLLABLE1 = 14;
+    ROLLABLE2 = 15;
+  }
+  PhysicalType target = 1;
+  State status = 2;
+  ParameterValue value = 3;
+}
+
+message Posture {
+  enum PostureValue {
+    POSTURE_UNKNOWN = 0;
+    POSTURE_CLOSED = 1;
+    POSTURE_HALF_OPENED = 2;
+    POSTURE_OPENED = 3;
+    POSTURE_FLIPPED = 4;
+    POSTURE_TENT = 5;
+    POSTURE_MAX = 6;
+  }
+  PostureValue value = 3;
+}
+
+// ---- Clipboard ---------------------------------------------------------------------------------
+
+message ClipData {
+  string text = 1;
+}
+
+// ---- Extended controls -------------------------------------------------------------------------
+
+message BatteryState {
+  enum BatteryStatus {
+    UNKNOWN = 0;
+    CHARGING = 1;
+    DISCHARGING = 2;
+    NOT_CHARGING = 3;
+    FULL = 4;
+  }
+  enum BatteryCharger {
+    NONE = 0;
+    AC = 1;
+    USB = 2;
+    WIRELESS = 3;
+  }
+  enum BatteryHealth {
+    GOOD = 0;
+    FAILED = 1;
+    DEAD = 2;
+    OVERVOLTAGE = 3;
+    OVERHEATED = 4;
+  }
+  bool hasBattery = 1;
+  bool isPresent = 2;
+  BatteryCharger charger = 3;
+  int32 chargeLevel = 4;
+  BatteryHealth health = 5;
+  BatteryStatus status = 6;
+}
+
+message GpsState {
+  bool passiveUpdate = 1;
+  double latitude = 2;
+  double longitude = 3;
+  double speed = 4;
+  double bearing = 5;
+  double altitude = 6;
+  int32 satellites = 7;
+}
+
+message Fingerprint {
+  bool isTouching = 1;
+  int32 touchId = 2;
+}
+
+// ---- Telephony ---------------------------------------------------------------------------------
+
+message PhoneCall {
+  enum Operation {
+    InitCall = 0;
+    AcceptCall = 1;
+    RejectCallExplicit = 2;
+    RejectCallBusy = 3;
+    DisconnectCall = 4;
+    PlaceCallOnHold = 5;
+    TakeCallOffHold = 6;
+  }
+  Operation operation = 1;
+  string number = 2;
+}
+
+message PhoneResponse {
+  enum Response {
+    OK = 0;
+    BadOperation = 1;
+    BadNumber = 2;
+    InvalidAction = 3;
+    ActionFailed = 4;
+    RadioOff = 5;
+  }
+  Response response = 1;
+}
+
+message SmsMessage {
+  string srcAddress = 1;
+  string text = 2;
+}
+
+// ---- Audio -------------------------------------------------------------------------------------
+
+message AudioFormat {
+  enum SampleFormat {
+    AUD_FMT_U8 = 0;
+    AUD_FMT_S16 = 1;
+  }
+  enum Channels {
+    Mono = 0;
+    Stereo = 1;
+  }
+  uint64 samplingRate = 1;
+  Channels channels = 2;
+  SampleFormat format = 3;
+}
+
+message AudioPacket {
+  AudioFormat format = 1;
+  uint64 timestamp = 2;
+  bytes audio = 3;
+}
+
+// ---- Logcat ------------------------------------------------------------------------------------
+
+message LogMessage {
+  string contents = 1;
+  int64 start = 2;
+  int64 next = 3;
+  LogType sort = 4;
+  // Field 5 (repeated LogcatEntry entries) is omitted — we only serve Text logcat.
+  enum LogType {
+    Text = 0;
+    Parsed = 1;
+  }
+}
+
+// ---- Notifications + virtual scene -------------------------------------------------------------
+
+message Notification {
+  enum EventType {
+    VIRTUAL_SCENE_CAMERA_INACTIVE = 0;
+    VIRTUAL_SCENE_CAMERA_ACTIVE = 1;
+    DISPLAY_CONFIGURATIONS_CHANGED_UI = 2;
+  }
+  EventType event = 1;
+}
+
+message RotationRadian {
+  float x = 1;
+  float y = 2;
+  float z = 3;
+}
+
+message Velocity {
+  float x = 1;
+  float y = 2;
+  float z = 3;
 }

--- a/fake-emulator/grpc/src/test/kotlin/ee/schimke/composeai/fakeemulator/grpc/EmulatorControllerServiceTest.kt
+++ b/fake-emulator/grpc/src/test/kotlin/ee/schimke/composeai/fakeemulator/grpc/EmulatorControllerServiceTest.kt
@@ -1,0 +1,149 @@
+package ee.schimke.composeai.fakeemulator.grpc
+
+import android.emulation.control.ClipData
+import android.emulation.control.DisplayConfigurations
+import android.emulation.control.EmulatorStatus
+import android.emulation.control.Image
+import android.emulation.control.ImageFormat
+import android.emulation.control.ParameterValue
+import android.emulation.control.PhysicalModelValue
+import com.google.common.truth.Truth.assertThat
+import ee.schimke.composeai.fakeemulator.DeviceSettingsController
+import ee.schimke.composeai.fakeemulator.DisplaySize
+import ee.schimke.composeai.fakeemulator.MutableFrameSource
+import ee.schimke.composeai.fakeemulator.PlaceholderImage
+import ee.schimke.composeai.fakeemulator.RotationQuadrant
+import io.grpc.CallOptions
+import io.grpc.ManagedChannel
+import io.grpc.MethodDescriptor
+import io.grpc.Server
+import io.grpc.inprocess.InProcessChannelBuilder
+import io.grpc.inprocess.InProcessServerBuilder
+import io.grpc.stub.ClientCalls
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Exercises the full hand-rolled `EmulatorController` binding end-to-end over grpc's in-process
+ * transport (real server + client, Wire marshalling both ways) — proving the method descriptors,
+ * marshallers, and the gRPC→[DeviceSettingsController] bridge actually work.
+ */
+class EmulatorControllerServiceTest {
+  private val display = DisplaySize(1080, 2340, 420)
+  private val frames = MutableFrameSource(display)
+  private val settings = DeviceSettingsController()
+  private lateinit var service: EmulatorControllerService
+  private lateinit var server: Server
+  private lateinit var channel: ManagedChannel
+
+  @Before
+  fun setUp() {
+    frames.push(PlaceholderImage.solidPng(display.width, display.height, 0xFF101010.toInt()), 1)
+    service = EmulatorControllerService(frames, settings)
+    val name = InProcessServerBuilder.generateName()
+    server =
+      InProcessServerBuilder.forName(name)
+        .directExecutor()
+        .addService(service.bindService())
+        .build()
+        .start()
+    channel = InProcessChannelBuilder.forName(name).directExecutor().build()
+  }
+
+  @After
+  fun tearDown() {
+    runCatching { channel.shutdownNow() }
+    runCatching { server.shutdownNow() }
+    runCatching { service.close() }
+  }
+
+  @Test
+  fun `getStatus reports booted`() {
+    val status =
+      unaryCall(method("getStatus", EmptyMarshaller, WireMarshaller(EmulatorStatus.ADAPTER)), Unit)
+    assertThat(status.booted).isTrue()
+  }
+
+  @Test
+  fun `clipboard round-trips`() {
+    unaryCall(
+      method("setClipboard", WireMarshaller(ClipData.ADAPTER), EmptyMarshaller),
+      ClipData(text = "hi there"),
+    )
+    val clip =
+      unaryCall(method("getClipboard", EmptyMarshaller, WireMarshaller(ClipData.ADAPTER)), Unit)
+    assertThat(clip.text).isEqualTo("hi there")
+  }
+
+  @Test
+  fun `getDisplayConfigurations reflects the frame source`() {
+    val configs =
+      unaryCall(
+        method(
+          "getDisplayConfigurations",
+          EmptyMarshaller,
+          WireMarshaller(DisplayConfigurations.ADAPTER),
+        ),
+        Unit,
+      )
+    val d = configs.displays.single()
+    assertThat(d.width).isEqualTo(1080)
+    assertThat(d.height).isEqualTo(2340)
+    assertThat(d.dpi).isEqualTo(420)
+  }
+
+  @Test
+  fun `setPhysicalModel ROTATION drives the shared settings`() {
+    unaryCall(
+      method("setPhysicalModel", WireMarshaller(PhysicalModelValue.ADAPTER), EmptyMarshaller),
+      PhysicalModelValue(
+        target = PhysicalModelValue.PhysicalType.ROTATION,
+        value_ = ParameterValue(data_ = listOf(0f, 0f, 90f)),
+      ),
+    )
+    assertThat(settings.current.rotation).isEqualTo(RotationQuadrant.LANDSCAPE)
+  }
+
+  @Test
+  fun `streamScreenshot emits the current frame`() {
+    val descriptor =
+      MethodDescriptor.newBuilder(
+          WireMarshaller(ImageFormat.ADAPTER),
+          WireMarshaller(Image.ADAPTER),
+        )
+        .setType(MethodDescriptor.MethodType.SERVER_STREAMING)
+        .setFullMethodName(MethodDescriptor.generateFullMethodName(SERVICE, "streamScreenshot"))
+        .build()
+    val frames =
+      ClientCalls.blockingServerStreamingCall(
+        channel,
+        descriptor,
+        CallOptions.DEFAULT,
+        ImageFormat(),
+      )
+    assertThat(frames.hasNext()).isTrue()
+    val image = frames.next()
+    assertThat(image.image.size).isGreaterThan(8)
+    assertThat(image.format?.format).isEqualTo(ImageFormat.ImgFormat.PNG)
+  }
+
+  private fun <Req : Any, Resp : Any> unaryCall(
+    method: MethodDescriptor<Req, Resp>,
+    request: Req,
+  ): Resp = ClientCalls.blockingUnaryCall(channel, method, CallOptions.DEFAULT, request)
+
+  private fun <Req : Any, Resp : Any> method(
+    name: String,
+    req: MethodDescriptor.Marshaller<Req>,
+    resp: MethodDescriptor.Marshaller<Resp>,
+  ): MethodDescriptor<Req, Resp> =
+    MethodDescriptor.newBuilder(req, resp)
+      .setType(MethodDescriptor.MethodType.UNARY)
+      .setFullMethodName(MethodDescriptor.generateFullMethodName(SERVICE, name))
+      .build()
+
+  private companion object {
+    const val SERVICE = "android.emulation.control.EmulatorController"
+  }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -207,6 +207,9 @@ dadb = { module = "dev.mobile:dadb", version.ref = "dadb" }
 # grpc-netty-shaded is the server transport.
 grpc-stub = { module = "io.grpc:grpc-stub", version.ref = "grpc" }
 grpc-netty-shaded = { module = "io.grpc:grpc-netty-shaded", version.ref = "grpc" }
+# In-process transport — used only by `:fake-emulator-grpc` tests to exercise the EmulatorController
+# binding end-to-end (server + client) without a socket.
+grpc-inprocess = { module = "io.grpc:grpc-inprocess", version.ref = "grpc" }
 wire-runtime = { module = "com.squareup.wire:wire-runtime", version.ref = "wire" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }


### PR DESCRIPTION
Follow-up to #2032. Makes the fake emulator drivable end-to-end by Android Studio's embedded "Running Devices" view and its device-settings toggles.

## Emulator gRPC (`:fake-emulator-grpc`)
Grew the vendored `EmulatorController` to the surface Studio + the Extended Controls expect, so Studio never hits `UNIMPLEMENTED`:
- **Identity / VM / display** — `getStatus`, `getVmState`/`setVmState`, `getDisplayConfigurations`/`setDisplayConfigurations`.
- **Screenshots** — `getScreenshot` + the `streamScreenshot` video lane (every `FrameSource` frame as an `Image`).
- **Input** — `sendKey` / `sendTouch` / `sendMouse`.
- **Rotation / posture** — `setPhysicalModel(ROTATION)` + `setPosture` drive the shared settings (preview re-renders rotated/folded); `getPhysicalModel` / `streamPhysicalModel` / `streamNotification` report it, including `adb`-driven rotation (one shared state).
- **Clipboard** (`get/set/streamClipboard`), **battery / GPS / sensors**, **fingerprint**, **phone / SMS**, **audio**, **logcat**, **virtual-scene camera** — in-memory state / sensible defaults / accepted no-ops.

All vendored proto field numbers stay wire-compatible with the canonical `android.emulation.control` schema (the new messages — `MouseEvent`, `PhysicalModelValue`, `Posture`, `ClipData`, `BatteryState`, `GpsState`, `SensorValue`, …— are copied verbatim).

## Device settings → preview overrides (`:fake-emulator-core` + app)
Studio's emulator UI toggles are mostly `adb shell`, not gRPC. The shell now interprets the override-relevant ones into a shared, observable `DeviceSettingsController`; the app maps `DeviceSettings` → `PreviewOverrides` and re-opens the held render stream (override change = restart, same as the `serve` live lane), so the preview re-renders under the toggle:

| Studio toggle | `adb shell` | → override |
|---|---|---|
| Dark/light theme | `cmd uimode night yes\|no` | `uiMode` |
| Font size | `settings put system font_scale` | `fontScale` |
| Density / size | `wm density` / `wm size` | `density` / `widthPx,heightPx` |
| Rotation | `settings put system user_rotation` | `orientation` (shared with gRPC physical model) |
| Locale | `cmd locale set-app-locales … --locales` | `localeTag` |
| **TalkBack** | `settings put secure …accessibility…` | a11y data-product subscription |
| Color correction / layout bounds | `settings put secure …daltonizer…` / `setprop debug.layout` | captured in `DeviceSettings` (render override: follow-up) |

Rotation/posture flip the same shared state whether driven via `adb` or the emulator gRPC.

## Test plan
- **`:fake-emulator-core`** — `ShellSettingsTest`: each settings command → the right `DeviceSettings` field (dark mode, font scale, density, size, rotation, TalkBack on/off, color inversion/daltonizer, layout bounds, locale, `settings get`).
- **`:fake-emulator`** — `DeviceOverridesTest`: the pure `DeviceSettings` → `PreviewOverrides` mapping.
- **`:fake-emulator-grpc`** — `EmulatorControllerServiceTest`: in-process gRPC (real server + client, Wire marshalling both ways) — `getStatus`, clipboard round-trip, display config, the `setPhysicalModel(ROTATION)` → settings bridge, and `streamScreenshot`.

**33 tests pass; all three modules compile and pass `ktfmt`.**

```
./gradlew :fake-emulator-core:test :fake-emulator-grpc:test :fake-emulator:test
```

Non-visual infra (device-shaped protocols in front of the existing renderer) — no rendered-output diff; a launched preview still renders through the unchanged daemon/`serve` path, now re-parameterised by Studio's toggles.

Deferred APK-install/inspection work is tracked in #2033.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JaQXexARmcbaqS4T5PnUJD)_