### PR TITLE
feat(deploy): add Cloud Run hosting for the preview server

### DIFF
--- a/deploy/cloudrun/Dockerfile
+++ b/deploy/cloudrun/Dockerfile
@@ -1,0 +1,82 @@
+# syntax=docker/dockerfile:1.7
+
+# Cloud Run image for `compose-preview serve` (public mode, Desktop-only).
+#
+# What this serves: a long-lived HTTP server that renders the @Preview functions
+# of one Compose Multiplatform *Desktop* module (`:samples:cmp` by default) on
+# demand and returns PNGs. Desktop rendering uses Skiko software rasterization —
+# no Android SDK, no GPU, no X server.
+#
+# Why a fat image: `compose-preview serve` builds its module through the Gradle
+# Tooling API at startup and keeps a warm render daemon. So the runtime needs the
+# JDK, the repo, and a warmed Gradle cache. We pre-build at image-build time so the
+# container's first render is incremental (warm) rather than a cold full build.
+#
+# The repo toolchain is pinned to JDK 17 (gradle/gradle-daemon-jvm.properties), so
+# we base on Temurin 17 — Gradle's toolchain auto-detection then finds a matching
+# JDK with none of the JDK-17-vs-21 gymnastics docs/CLOUD-TESTING.md describes.
+
+# ---------------------------------------------------------------------------
+# Stage 1: build the CLI distribution and warm the render path.
+# ---------------------------------------------------------------------------
+FROM eclipse-temurin:17-jdk AS build
+
+ENV GRADLE_USER_HOME=/root/.gradle \
+    SERVE_MODULE=:samples:cmp
+
+WORKDIR /app
+
+# Copy the whole repo. A live preview server needs the module under render plus
+# its build-logic, gradle-plugin, and settings to resolve — there is no useful
+# smaller subset. .dockerignore trims build outputs, .git, node_modules, etc.
+COPY . /app
+
+# Build the installable CLI dist (bin/compose-preview + lib/ + desktop sidecars),
+# then exercise the full build → daemon → render path once via `--export`. That
+# one render populates the Gradle dependency cache, downloads the Gradle
+# distribution, and emits the module's daemon-launch.json, so the runtime
+# container starts warm instead of paying a cold full build on first request.
+# NOTE: deliberately no BuildKit cache mount here — the warmed Gradle cache must
+# land in a real image layer so `COPY --from=build /root/.gradle` carries it into
+# the runtime image (cache-mount contents are not persisted into layers).
+RUN ./gradlew --no-daemon :cli:installDist \
+ && ./cli/build/install/compose-preview/bin/compose-preview serve \
+        --module "${SERVE_MODULE}" \
+        --export /tmp/warm-bundle \
+ && rm -rf /tmp/warm-bundle
+
+# ---------------------------------------------------------------------------
+# Stage 2: runtime.
+# ---------------------------------------------------------------------------
+FROM eclipse-temurin:17-jdk AS runtime
+
+# Skiko (Compose Desktop's renderer) needs fontconfig + freetype to lay out and
+# rasterize text, and at least one font family for non-empty glyphs. Without
+# these, text in rendered previews comes out blank.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      libfreetype6 libfontconfig1 fontconfig fonts-dejavu-core \
+ && rm -rf /var/lib/apt/lists/*
+
+ENV GRADLE_USER_HOME=/root/.gradle \
+    SERVE_MODULE=:samples:cmp \
+    # Scale-to-zero friendliness: shut the server down after this many idle
+    # seconds so Cloud Run's instance can be reclaimed. Tune via env / service.yaml.
+    SERVE_IDLE_EXIT=900 \
+    # JVM heap ceiling for the CLI process; the render daemon is a child JVM.
+    JAVA_TOOL_OPTIONS="-XX:MaxRAMPercentage=70"
+
+WORKDIR /app
+
+# Carry over the repo, the built CLI dist, and — crucially — the warmed Gradle
+# cache and module build outputs from the build stage.
+COPY --from=build /app /app
+COPY --from=build /root/.gradle /root/.gradle
+
+COPY deploy/cloudrun/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+# Documentation only — Cloud Run injects the real port via $PORT (default 8080).
+EXPOSE 8080
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/deploy/cloudrun/Dockerfile.dockerignore
+++ b/deploy/cloudrun/Dockerfile.dockerignore
@@ -1,0 +1,13 @@
+# Keep the Docker build context (and thus the image) lean. Build outputs and
+# caches are regenerated inside the image; .git / IDE / node_modules are noise.
+.git
+**/build/
+**/.gradle/
+**/node_modules/
+**/.idea/
+**/*.iml
+deploy/cloudrun/README.md
+vscode-extension/out/
+vscode-extension/.vscode-test/
+site/build/
+**/.DS_Store

--- a/deploy/cloudrun/README.md
+++ b/deploy/cloudrun/README.md
@@ -1,0 +1,121 @@
+# Hosting the Compose preview server on Google Cloud Run
+
+This directory deploys `compose-preview serve` as a public, token-gated HTTP
+service on [Cloud Run](https://cloud.google.com/run). It renders the `@Preview`
+functions of one Compose **Desktop** module (`:samples:cmp` by default) on demand
+and serves them as PNGs with display overrides.
+
+- **Render target:** Desktop / Compose Multiplatform only (Skiko software
+  rendering — no Android SDK, no GPU, no X server).
+- **Bundle uploads:** disabled. The server renders only the module baked into the
+  image; it does **not** accept or execute uploaded code.
+- **Auth:** a shared token (Secret Manager). A bad/missing token returns `404`.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `Dockerfile` | Two-stage build: builds the CLI dist and warms the render path, then a runtime image with the warmed Gradle cache + fonts. |
+| `entrypoint.sh` | Maps Cloud Run's `$PORT` / `$SERVE_TOKEN` onto `serve` flags; fails closed if no token. |
+| `service.yaml` | Knative service manifest (2 vCPU / 4Gi, scale-to-zero, 1h timeout). |
+| `cloudbuild.yaml` | Cloud Build: build → push → deploy. |
+| `deploy.sh` | One-shot: enables APIs, creates the Artifact Registry repo + token secret, runs the build, prints the URL + link. |
+| `Dockerfile.dockerignore` | Trims the build context (BuildKit honors this co-located ignore). |
+
+## Quick start
+
+From the **repo root**, with `gcloud` authenticated and a billing-enabled project:
+
+```bash
+PROJECT_ID=your-project REGION=us-central1 deploy/cloudrun/deploy.sh
+```
+
+That prints a URL and a ready-to-open link:
+
+```
+==> Deployed: https://compose-preview-xxxx.a.run.app
+    Open the preview index:   https://compose-preview-xxxx.a.run.app/?token=<TOKEN>
+```
+
+Endpoints (all token-gated except `/healthz`), token via `?token=` or the
+`X-Compose-Preview-Token` header:
+
+- `GET /?token=…` — landing page / preview index
+- `GET /p/{id}?token=…` — viewer page for one preview
+- `GET /render/{id}.png?token=…` — PNG bytes (supports overrides, e.g. `&fontScale=1.3`)
+- `GET /api/previews?token=…` — preview list as JSON
+- `GET /healthz` — liveness (unauthenticated; used by the startup probe)
+
+## Manual deploy (without deploy.sh)
+
+```bash
+# 1. Token secret
+printf '%s' "$(openssl rand -hex 24)" | \
+  gcloud secrets create compose-preview-token --replication-policy=automatic --data-file=-
+
+# 2. Build + push + deploy
+gcloud builds submit --config deploy/cloudrun/cloudbuild.yaml \
+  --substitutions=_REGION=us-central1,_REPO=compose-preview
+
+# …or apply the Knative manifest after building the image yourself:
+sed "s#IMAGE#us-central1-docker.pkg.dev/$PROJECT_ID/compose-preview/compose-preview:latest#" \
+  deploy/cloudrun/service.yaml | gcloud run services replace - --region us-central1
+```
+
+## Cost and sizing
+
+The instance is **2 vCPU / 4 GiB** — comfortable for one warm Desktop render
+daemon (≈1–2 GiB Gradle + render JVM, plus headroom). Cost is bounded two ways:
+
+- **`min-instances=0`** — scales to zero when idle, so you pay nothing between
+  sessions. The trade-off is **cold starts**: the first request after idle runs an
+  incremental (warmed) Gradle build + daemon launch — seconds to a couple of
+  minutes, not the multi-minute cold build the warmed image avoids.
+- **`max-instances=1`** — a traffic spike or abuse can't fan out a surprise bill.
+
+With request-based billing (the default here), Cloud Run's monthly free tier
+(180k vCPU-s + 360k GiB-s + 2M requests) covers roughly **25 hours of active
+2 vCPU / 4 GiB compute** — plenty for a low-traffic public demo that's otherwise
+scaled to zero.
+
+### Free-with-limits knobs
+
+- **`SERVE_IDLE_EXIT`** (default `900`) — the server exits after this many idle
+  seconds, letting the instance be reclaimed. Set `0` to disable.
+- **`timeoutSeconds: 3600`** — hard ceiling on any one request / WebSocket session
+  (Cloud Run's max). Lower it to cap session length more aggressively.
+- **`containerConcurrency: 4`** — simultaneous renders per instance.
+
+### If you want snappy (no cold starts)
+
+Set `min-instances=1` and flip `run.googleapis.com/cpu-throttling` to `"false"`
+(instance-based billing — CPU always allocated, so the warm daemon stays
+responsive between requests). This leaves the free tier and costs roughly the
+price of one always-on 2 vCPU / 4 GiB instance.
+
+## Security notes
+
+- **Untrusted code:** disabled here. Public bundle uploads (`--accept-bundles`)
+  would mean executing arbitrary uploaded JVM code — do **not** enable that on a
+  shared endpoint without per-session sandbox isolation. Cloud Run runs containers
+  under gVisor, but the safe default is to render only the baked-in module.
+- **The token is the only gate.** It rides in the URL (`?token=`), so treat render
+  links like secrets. For stronger auth, drop `--allow-unauthenticated` and put
+  Cloud Run IAM / IAP in front instead.
+- **TLS** is terminated by Cloud Run automatically.
+
+## Changing what's served
+
+Set `SERVE_MODULE` (build arg / env / `service.yaml`) to any Desktop
+(Compose Multiplatform / JVM) module Gradle path in this repo, e.g.
+`:samples:cmp-shared`. To host a *different* repo, change the `COPY . /app` source
+and point `SERVE_MODULE` at that project's module.
+
+## A cheaper, fully-static alternative
+
+If you only need to publish a fixed set of renders (no live overrides /
+re-rendering), skip the live server: render once at build time with
+`compose-preview serve --module … --export <bundle>` and serve the resulting
+portable bundle (HTML + PNGs) from any static host or a tiny `nginx` image. That
+removes the JDK/Gradle runtime entirely — smallest image, instant cold start,
+zero code execution — at the cost of interactivity.

--- a/deploy/cloudrun/cloudbuild.yaml
+++ b/deploy/cloudrun/cloudbuild.yaml
@@ -10,12 +10,18 @@ substitutions:
   _REGION: us-central1
   _REPO: compose-preview
   _SERVICE: compose-preview
-  _IMAGE: ${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_REPO}/compose-preview:${SHORT_SHA}
+  # Tagged with $BUILD_ID (always populated, including for manual `gcloud builds
+  # submit` storage-source builds — unlike $SHORT_SHA, which is empty unless the
+  # build is commit-triggered).
+  _IMAGE: ${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_REPO}/compose-preview:${BUILD_ID}
 
 options:
   machineType: E2_HIGHCPU_8
   # The build runs a full Gradle build + a warm render; give it room and time.
   diskSizeGb: 100
+  # Required for manual builds: _IMAGE references other substitutions, which only
+  # resolve when dynamic substitutions are on (auto-on for triggers, opt-in here).
+  dynamicSubstitutions: true
 
 timeout: 3600s
 

--- a/deploy/cloudrun/cloudbuild.yaml
+++ b/deploy/cloudrun/cloudbuild.yaml
@@ -1,0 +1,61 @@
+# Cloud Build pipeline: build the image, push to Artifact Registry, deploy to
+# Cloud Run. Run from the repo root so the build context is the whole repo:
+#
+#   gcloud builds submit --config deploy/cloudrun/cloudbuild.yaml \
+#     --substitutions=_REGION=us-central1,_REPO=compose-preview
+#
+# Prereqs (one-time): an Artifact Registry Docker repo named $_REPO in $_REGION,
+# and the `compose-preview-token` secret in Secret Manager. deploy.sh sets both up.
+substitutions:
+  _REGION: us-central1
+  _REPO: compose-preview
+  _SERVICE: compose-preview
+  _IMAGE: ${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_REPO}/compose-preview:${SHORT_SHA}
+
+options:
+  machineType: E2_HIGHCPU_8
+  # The build runs a full Gradle build + a warm render; give it room and time.
+  diskSizeGb: 100
+
+timeout: 3600s
+
+steps:
+  - id: build
+    name: gcr.io/cloud-builders/docker
+    args:
+      - build
+      - -f
+      - deploy/cloudrun/Dockerfile
+      - -t
+      - ${_IMAGE}
+      - .
+
+  - id: push
+    name: gcr.io/cloud-builders/docker
+    args: ["push", "${_IMAGE}"]
+
+  - id: deploy
+    name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    entrypoint: gcloud
+    args:
+      - run
+      - deploy
+      - ${_SERVICE}
+      - --image=${_IMAGE}
+      - --region=${_REGION}
+      - --platform=managed
+      - --cpu=2
+      - --memory=4Gi
+      - --min-instances=0
+      - --max-instances=1
+      - --concurrency=4
+      - --timeout=3600
+      - --port=8080
+      - --set-env-vars=SERVE_MODULE=:samples:cmp,SERVE_IDLE_EXIT=900
+      - --set-secrets=SERVE_TOKEN=compose-preview-token:latest
+      # Drop --no-allow-unauthenticated if you front it with IAM instead of the
+      # app token. As written the app token is the only gate (public ingress).
+      - --allow-unauthenticated
+
+images:
+  - ${_IMAGE}

--- a/deploy/cloudrun/deploy.sh
+++ b/deploy/cloudrun/deploy.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# One-shot Cloud Run setup + deploy for the Compose preview server.
+#
+# Usage:
+#   PROJECT_ID=my-proj REGION=us-central1 deploy/cloudrun/deploy.sh
+#
+# What it does (idempotent):
+#   1. Enables the required APIs.
+#   2. Creates an Artifact Registry Docker repo (if missing).
+#   3. Creates the `compose-preview-token` secret with a fresh random token (if missing).
+#   4. Submits the Cloud Build pipeline, which builds the image and deploys it.
+#   5. Prints the service URL and a ready-to-open, token-bearing render link.
+#
+# Run from the repo root. Needs: gcloud (authenticated), an active billing account.
+set -euo pipefail
+
+PROJECT_ID="${PROJECT_ID:?set PROJECT_ID}"
+REGION="${REGION:-us-central1}"
+REPO="${REPO:-compose-preview}"
+SERVICE="${SERVICE:-compose-preview}"
+SECRET="${SECRET:-compose-preview-token}"
+
+gcloud config set project "${PROJECT_ID}" >/dev/null
+
+echo "==> Enabling APIs"
+gcloud services enable \
+  run.googleapis.com \
+  cloudbuild.googleapis.com \
+  artifactregistry.googleapis.com \
+  secretmanager.googleapis.com
+
+echo "==> Ensuring Artifact Registry repo '${REPO}' in ${REGION}"
+gcloud artifacts repositories describe "${REPO}" --location "${REGION}" >/dev/null 2>&1 || \
+  gcloud artifacts repositories create "${REPO}" \
+    --repository-format=docker --location="${REGION}" \
+    --description="compose-preview images"
+
+echo "==> Ensuring secret '${SECRET}'"
+if ! gcloud secrets describe "${SECRET}" >/dev/null 2>&1; then
+  gcloud secrets create "${SECRET}" --replication-policy=automatic
+  TOKEN="$(openssl rand -hex 24)"
+  printf '%s' "${TOKEN}" | gcloud secrets versions add "${SECRET}" --data-file=-
+  echo "    created a new random token (stored in Secret Manager)"
+fi
+
+# Let the Cloud Run runtime service account read the secret.
+PROJECT_NUMBER="$(gcloud projects describe "${PROJECT_ID}" --format='value(projectNumber)')"
+RUNTIME_SA="${PROJECT_NUMBER}-compute@developer.gserviceaccount.com"
+gcloud secrets add-iam-policy-binding "${SECRET}" \
+  --member="serviceAccount:${RUNTIME_SA}" \
+  --role=roles/secretmanager.secretAccessor >/dev/null
+
+echo "==> Building + deploying via Cloud Build"
+gcloud builds submit \
+  --config deploy/cloudrun/cloudbuild.yaml \
+  --substitutions="_REGION=${REGION},_REPO=${REPO},_SERVICE=${SERVICE}"
+
+URL="$(gcloud run services describe "${SERVICE}" --region "${REGION}" --format='value(status.url)')"
+TOKEN="$(gcloud secrets versions access latest --secret="${SECRET}")"
+
+echo
+echo "==> Deployed: ${URL}"
+echo "    Open the preview index:   ${URL}/?token=${TOKEN}"
+echo "    (Keep the token secret — it is the only gate on this public endpoint.)"

--- a/deploy/cloudrun/entrypoint.sh
+++ b/deploy/cloudrun/entrypoint.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Cloud Run entrypoint for `compose-preview serve`.
+#
+# Translates Cloud Run's environment contract (the $PORT it injects, a token from
+# Secret Manager) into `compose-preview serve` flags. Runs from the repo root so
+# the CLI's Gradle Tooling API build finds settings.gradle.kts.
+set -euo pipefail
+
+cd /app
+
+PORT="${PORT:-8080}"
+SERVE_MODULE="${SERVE_MODULE:-:samples:cmp}"
+BIN=/app/cli/build/install/compose-preview/bin/compose-preview
+
+# A public endpoint must be token-gated. Cloud Run surfaces the secret as $SERVE_TOKEN.
+# Fail closed rather than expose an unauthenticated renderer.
+if [[ -z "${SERVE_TOKEN:-}" ]]; then
+  echo "entrypoint: SERVE_TOKEN is unset — refusing to start an unauthenticated public server." >&2
+  echo "            Set it (e.g. from Secret Manager) before deploying. See deploy/cloudrun/README.md." >&2
+  exit 64
+fi
+
+args=(
+  serve
+  --module "${SERVE_MODULE}"
+  --host 0.0.0.0
+  --port "${PORT}"
+  --token "${SERVE_TOKEN}"
+)
+
+# Optional: exit after N idle seconds so the Cloud Run instance scales to zero.
+# Set SERVE_IDLE_EXIT=0 (or unset) to run until terminated.
+if [[ -n "${SERVE_IDLE_EXIT:-}" && "${SERVE_IDLE_EXIT}" != "0" ]]; then
+  args+=("--exit-when-idle=${SERVE_IDLE_EXIT}")
+fi
+
+echo "entrypoint: starting compose-preview serve on 0.0.0.0:${PORT} (module ${SERVE_MODULE})" >&2
+exec "${BIN}" "${args[@]}"

--- a/deploy/cloudrun/service.yaml
+++ b/deploy/cloudrun/service.yaml
@@ -1,0 +1,70 @@
+# Cloud Run service (Knative) manifest for the Compose preview server.
+#
+# Apply with:
+#   gcloud run services replace deploy/cloudrun/service.yaml --region <REGION>
+#
+# Placeholders to substitute before applying (deploy.sh does this for you):
+#   PROJECT_ID, REGION, IMAGE  — e.g. REGION/.../compose-preview:latest
+#
+# Sizing rationale (see README.md): one warm Desktop render daemon is comfortable
+# at 2 vCPU / 4Gi. Cost is bounded by min-scale 0 (scale to zero when idle) and
+# max-scale 1 (a single instance can't fan out a surprise bill). The 3600s timeout
+# is the hard ceiling on any one request/WebSocket session.
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: compose-preview
+  labels:
+    app: compose-preview
+  annotations:
+    run.googleapis.com/ingress: all
+spec:
+  template:
+    metadata:
+      annotations:
+        autoscaling.knative.dev/minScale: "0"
+        autoscaling.knative.dev/maxScale: "1"
+        # Request-based billing (CPU only billed while a request is in flight) is
+        # the cheapest default and pairs with scale-to-zero. If warm-daemon
+        # responsiveness between requests matters more than cost, flip this to
+        # "false" (instance-based billing — CPU always allocated) and consider
+        # minScale "1".
+        run.googleapis.com/cpu-throttling: "true"
+        run.googleapis.com/startup-cpu-boost: "true"
+    spec:
+      # Cap simultaneous renders. The daemon serialises renders anyway; a low
+      # ceiling keeps tail latency and memory predictable on one instance.
+      containerConcurrency: 4
+      timeoutSeconds: 3600
+      containers:
+        - image: IMAGE
+          ports:
+            - name: http1
+              containerPort: 8080
+          env:
+            - name: SERVE_MODULE
+              value: ":samples:cmp"
+            - name: SERVE_IDLE_EXIT
+              value: "900"
+            # The shared auth token, sourced from Secret Manager (see deploy.sh,
+            # which creates the `compose-preview-token` secret).
+            - name: SERVE_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: compose-preview-token
+                  key: latest
+          resources:
+            limits:
+              cpu: "2"
+              memory: 4Gi
+          startupProbe:
+            # `serve` binds its HTTP port only after the initial (incremental,
+            # warmed) Gradle build + daemon launch finishes, so /healthz answering
+            # is an accurate "ready" signal. Allow a generous window for it.
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 30
+            timeoutSeconds: 5


### PR DESCRIPTION
## Summary

Adds deployment scaffolding under `deploy/cloudrun/` to host `compose-preview serve` as a public, token-gated service on Google Cloud Run. It renders one Compose **Desktop** module (`:samples:cmp` by default) on demand and serves the previews as PNGs.

Scope decisions:
- **Desktop-only** render target (Skiko software rendering — no Android SDK, no GPU, no X server), keeping the image and cold-start cost down.
- **Bundle uploads disabled** — the server only renders the baked-in module, so there is no untrusted-code execution surface on the public endpoint.
- **Token-gated**, fail-closed: the entrypoint refuses to start without `SERVE_TOKEN` (sourced from Secret Manager); a bad/missing token returns `404`.

What's included:

| File | Purpose |
|------|---------|
| `Dockerfile` | Two-stage build on Temurin 17; builds the CLI dist and warms the Gradle cache + render path so the runtime starts incremental, not cold. Installs fontconfig/freetype so Skiko renders text. |
| `entrypoint.sh` | Maps Cloud Run `$PORT`/`$SERVE_TOKEN` onto `serve` flags; fails closed without a token. |
| `service.yaml` | Knative manifest: 2 vCPU / 4Gi, scale-to-zero, max 1 instance, 1h timeout, `/healthz` startup probe, token from Secret Manager. |
| `cloudbuild.yaml` + `deploy.sh` | One-shot build → push → deploy, setting up APIs, an Artifact Registry repo, and the token secret. |
| `README.md` | Deploy steps, free-tier cost math, session-limit knobs (`SERVE_IDLE_EXIT`, timeout, concurrency), and security notes. |
| `Dockerfile.dockerignore` | Trims the build context (BuildKit honors this co-located ignore). |

Cost shape: `min-instances=0` (scale to zero, ~$0 when idle) + `max-instances=1` (no surprise fan-out bill). The free tier (~25h/mo of active 2 vCPU / 4 GiB) covers a low-traffic demo; the trade-off is a warm-but-not-instant cold start on first hit after idle. The README documents flipping to `min-instances=1` + CPU-always-allocated for snappiness, and a fully-static `--export` + nginx alternative for a tiny image without interactivity.

## Test plan

- Not a UI change — no rendered-output diff applies; this is deploy/build plumbing.
- Validated locally: `bash -n` on `entrypoint.sh` and `deploy.sh`; `service.yaml` and `cloudbuild.yaml` parse as YAML; the `:samples:cmp` Gradle path and the `installDist` binary path (`cli/build/install/compose-preview/bin/compose-preview`) are confirmed against the repo.
- **Not** validated: an end-to-end image build + `gcloud run deploy` (requires a GCP project and a full Gradle build, neither available in the authoring sandbox). Reviewer should run `deploy/cloudrun/deploy.sh` against a test project to confirm the first live render.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KTCvmWWzVkkK3mUB6Ye7fH)_