### PR TITLE
feat(deploy): add Oracle Cloud Always Free hosting for the preview server

### DIFF
--- a/deploy/oracle/.gitignore
+++ b/deploy/oracle/.gitignore
@@ -1,0 +1,2 @@
+# setup.sh writes this with a generated token — never commit it.
+.env

--- a/deploy/oracle/Caddyfile
+++ b/deploy/oracle/Caddyfile
@@ -1,0 +1,23 @@
+# Caddy reverse proxy for the compose-preview server.
+#
+# {$DOMAIN} is read from the environment (set in .env via docker-compose). With a
+# public DNS A record pointing at the VM, Caddy provisions and renews a Let's
+# Encrypt certificate automatically — no manual cert handling.
+#
+# The app's token (?token= / X-Compose-Preview-Token) remains the auth gate; this
+# block only adds TLS and forwards to the internal server.
+{$DOMAIN} {
+	encode zstd gzip
+
+	reverse_proxy preview:8080 {
+		# Renders can take a few seconds on a cold daemon; don't cut them short.
+		transport http {
+			read_timeout 120s
+		}
+	}
+
+	# Optional hardening: uncomment to drop requests with no token early, before
+	# they reach the app. The app still enforces it either way.
+	# @notoken not query token=* header X-Compose-Preview-Token *
+	# respond @notoken 404
+}

--- a/deploy/oracle/README.md
+++ b/deploy/oracle/README.md
@@ -67,8 +67,8 @@ Endpoints (token via `?token=` or `X-Compose-Preview-Token`):
 ```bash
 sudo docker compose logs -f preview      # server logs
 sudo docker compose restart preview      # restart the renderer
-sudo docker compose pull && \
-  sudo docker compose up -d --build      # rebuild after a git pull
+sudo docker compose up -d --build        # rebuild + recreate after a git pull
+sudo docker compose pull caddy           # refresh just the proxy image (optional)
 sudo docker compose down                 # stop everything
 cat .env                                  # recover the token
 ```

--- a/deploy/oracle/README.md
+++ b/deploy/oracle/README.md
@@ -1,0 +1,119 @@
+# Hosting the Compose preview server on Oracle Cloud (Always Free)
+
+This deploys `compose-preview serve` on an **Oracle Cloud Always Free Ampere A1**
+VM — genuinely **$0/month** with real always-warm capacity (up to 4 ARM cores +
+24 GB RAM in the free tenancy), unlike a scale-to-zero serverless setup.
+
+It reuses the same desktop-only render image as the Cloud Run deployment
+([`deploy/cloudrun/Dockerfile`](../cloudrun/Dockerfile)) and wraps it with Docker
+Compose + [Caddy](https://caddyserver.com/) for automatic HTTPS.
+
+- **Render target:** Compose **Desktop** only (Skiko software rendering).
+- **Bundle uploads:** disabled — renders only the baked-in module, no untrusted
+  code execution.
+- **Auth:** a shared token (a bad/missing token returns `404`); TLS via Caddy.
+- **Always warm:** the box is always on, so the server stays up (no idle exit) —
+  renders are fast (no cold start).
+
+> **ARM note:** the A1 shape is `aarch64`. The base image, JDK, and Skiko all
+> have arm64 builds, but if you change the served module, sanity-check that its
+> dependencies resolve native arm64 artifacts.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `docker-compose.yml` | `preview` (built from the Cloud Run Dockerfile) + `caddy` (TLS reverse proxy). |
+| `Caddyfile` | Terminates TLS for `$DOMAIN`, proxies to the internal server. |
+| `setup.sh` | Run on the VM: installs Docker, opens the host firewall (80/443), writes `.env` with a generated token, builds + starts. |
+| `.gitignore` | Keeps the generated `.env` (token) out of git. |
+
+## One-time: create the instance
+
+1. **Compute → Create instance.** Shape: **`VM.Standard.A1.Flex`** (Ampere),
+   e.g. 2 OCPU / 12 GB (or up to 4 OCPU / 24 GB — all within Always Free). Image:
+   Ubuntu or Oracle Linux. Add your SSH key.
+2. **Open the ports in the virtual network.** VCN → the instance's subnet →
+   Security List (or an NSG) → add **Ingress** rules: source `0.0.0.0/0`, IP
+   protocol TCP, destination ports **80** and **443**. *This is separate from the
+   host firewall `setup.sh` handles — you need both.*
+3. **Point DNS at the VM.** Create an `A` record for your hostname (e.g.
+   `preview.example.com`) → the instance's public IP. Caddy needs this resolving
+   before it can issue a certificate.
+
+## Deploy
+
+SSH in, get the repo, and run setup from this directory:
+
+```bash
+git clone https://github.com/yschimke/compose-ai-tools.git
+cd compose-ai-tools/deploy/oracle
+DOMAIN=preview.example.com ./setup.sh
+```
+
+The first build runs a full Gradle build inside the image (several minutes on an
+A1); subsequent starts reuse the warmed layers. When it finishes it prints:
+
+```
+https://preview.example.com/?token=<TOKEN>
+```
+
+Endpoints (token via `?token=` or `X-Compose-Preview-Token`):
+`GET /` index · `GET /p/{id}` viewer · `GET /render/{id}.png` PNG · `GET /healthz`
+(unauthenticated).
+
+## Operating it
+
+```bash
+sudo docker compose logs -f preview      # server logs
+sudo docker compose restart preview      # restart the renderer
+sudo docker compose pull && \
+  sudo docker compose up -d --build      # rebuild after a git pull
+sudo docker compose down                 # stop everything
+cat .env                                  # recover the token
+```
+
+`restart: always` plus Docker's systemd integration means the stack comes back
+after a reboot.
+
+## Cost and limits
+
+The A1 instance and its boot volume sit inside Oracle's Always Free allowances,
+so the steady-state cost is **$0**. Because the box is always on, there's no cold
+start — the trade-off versus Cloud Run is that you manage a VM instead of a
+managed service.
+
+Bound resource use through the app rather than the (free, fixed) hardware:
+
+- **`mem_limit: 6g`** on the `preview` service caps a render storm.
+- **`SERVE_IDLE_EXIT`** (set to `0` here to stay warm) — set a positive number of
+  seconds in `docker-compose.yml` if you'd rather the server exit when idle and
+  let `restart: always` bring it back on the next request.
+- For session-length / concurrency caps, run `serve` with the relevant flags (see
+  `compose-preview serve --help`) by extending the `preview` service command.
+
+## Security notes
+
+- **The token rides in the URL** (`?token=`), so treat render links as secrets.
+  Caddy provides TLS so they aren't sent in the clear.
+- **No untrusted code:** bundle uploads stay disabled. Don't enable
+  `--accept-bundles` on a public box without per-session sandbox isolation — on a
+  single shared VM there is none.
+- `.env` holds the token (mode `600`, git-ignored). Rotate by editing it and
+  `sudo docker compose up -d`.
+
+## HTTP-only (quick test, no domain/TLS)
+
+If you just want to poke it without a domain, publish the server's port directly
+and skip Caddy:
+
+```bash
+SERVE_TOKEN=$(openssl rand -hex 24)
+sudo docker run -d --restart always -p 8080:8080 \
+  -e SERVE_TOKEN="$SERVE_TOKEN" -e SERVE_IDLE_EXIT=0 \
+  $(sudo docker build -q -f ../cloudrun/Dockerfile ../..)
+echo "http://<VM_PUBLIC_IP>:8080/?token=$SERVE_TOKEN"
+```
+
+Open TCP **8080** in both the VCN security list and the host firewall. **The token
+travels unencrypted over plain HTTP — use this only for throwaway testing.**

--- a/deploy/oracle/docker-compose.yml
+++ b/deploy/oracle/docker-compose.yml
@@ -1,0 +1,49 @@
+# Docker Compose stack for hosting compose-preview on an Oracle Cloud
+# Always Free Ampere A1 (aarch64) VM.
+#
+# Two services:
+#   - preview: the desktop-only render server, built from the same image as the
+#     Cloud Run deployment (deploy/cloudrun/Dockerfile). Not published to the
+#     host — only Caddy reaches it over the internal compose network.
+#   - caddy:   reverse proxy terminating TLS. With a real DOMAIN it fetches a
+#     Let's Encrypt cert automatically; the app's token stays the auth gate.
+#
+# Config comes from a .env file (setup.sh writes one): DOMAIN, SERVE_TOKEN.
+services:
+  preview:
+    build:
+      # Build context is the repo root (two levels up); reuse the Cloud Run image.
+      context: ../..
+      dockerfile: deploy/cloudrun/Dockerfile
+    image: compose-preview:local
+    restart: always
+    environment:
+      # Always-on free box: keep the server warm (no idle exit).
+      SERVE_MODULE: ":samples:cmp"
+      SERVE_IDLE_EXIT: "0"
+      SERVE_TOKEN: "${SERVE_TOKEN:?set SERVE_TOKEN in .env}"
+      PORT: "8080"
+    expose:
+      - "8080"
+    # One warm Desktop daemon is comfortable well under the A1's 24 GiB; this
+    # cap just keeps a single render storm from eating the whole box.
+    mem_limit: 6g
+
+  caddy:
+    image: caddy:2
+    restart: always
+    depends_on:
+      - preview
+    ports:
+      - "80:80"
+      - "443:443"
+    environment:
+      DOMAIN: "${DOMAIN:?set DOMAIN in .env}"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+
+volumes:
+  caddy_data:
+  caddy_config:

--- a/deploy/oracle/setup.sh
+++ b/deploy/oracle/setup.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# One-shot setup for hosting compose-preview on an Oracle Cloud Always Free
+# Ampere A1 (aarch64) VM. Run it ON the instance, from this directory, e.g.:
+#
+#   DOMAIN=preview.example.com ./setup.sh
+#
+# It is idempotent: installs Docker (if missing), opens the host firewall for
+# 80/443 (Oracle's images block these by default — the #1 "why can't I reach my
+# server" gotcha), writes .env with a generated token (kept if it already
+# exists), then builds and starts the stack.
+#
+# Still required in the OCI Console (this script can't reach it): a VCN security
+# list / NSG ingress rule allowing 0.0.0.0/0 -> TCP 80 and 443. See README.md.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+DOMAIN="${DOMAIN:-}"
+if [[ -z "${DOMAIN}" ]]; then
+  echo "Set DOMAIN to the hostname whose DNS A record points at this VM, e.g.:" >&2
+  echo "  DOMAIN=preview.example.com ./setup.sh" >&2
+  echo "(Caddy needs a real domain to issue a Let's Encrypt cert. For a quick" >&2
+  echo " HTTP-only test without TLS, see the README.)" >&2
+  exit 64
+fi
+
+ARCH="$(uname -m)"
+if [[ "${ARCH}" != "aarch64" && "${ARCH}" != "arm64" ]]; then
+  echo "WARN: this VM is ${ARCH}, not aarch64 — fine, but the Always Free A1 shape is arm64." >&2
+fi
+
+# --- Docker -----------------------------------------------------------------
+if ! command -v docker >/dev/null 2>&1; then
+  echo "==> Installing Docker (get.docker.com handles arm64 + Ubuntu/Oracle Linux)"
+  curl -fsSL https://get.docker.com | sh
+  sudo systemctl enable --now docker
+fi
+# Compose v2 plugin check.
+if ! docker compose version >/dev/null 2>&1; then
+  echo "ERROR: 'docker compose' plugin not available after install." >&2
+  exit 1
+fi
+
+# --- Host firewall: open 80/443 ---------------------------------------------
+# Oracle Linux/Ubuntu OCI images ship a default-deny host firewall. Open the
+# web ports at the OS level (the VCN security-list rule is separate — console).
+if command -v firewall-cmd >/dev/null 2>&1 && sudo firewall-cmd --state >/dev/null 2>&1; then
+  echo "==> Opening 80/443 via firewalld"
+  sudo firewall-cmd --permanent --add-port=80/tcp --add-port=443/tcp
+  sudo firewall-cmd --reload
+else
+  echo "==> Opening 80/443 via iptables"
+  for port in 80 443; do
+    # Insert ACCEPT at the top so it precedes the images' trailing REJECT rule;
+    # -C first so re-runs don't pile up duplicates.
+    sudo iptables -C INPUT -p tcp --dport "${port}" -j ACCEPT 2>/dev/null \
+      || sudo iptables -I INPUT -p tcp --dport "${port}" -j ACCEPT
+  done
+  # Persist across reboots.
+  if command -v netfilter-persistent >/dev/null 2>&1; then
+    sudo netfilter-persistent save
+  elif [[ -d /etc/iptables ]]; then
+    sudo sh -c 'iptables-save > /etc/iptables/rules.v4'
+  else
+    echo "WARN: could not persist iptables rules — they may not survive a reboot." >&2
+  fi
+fi
+
+# --- .env: token + domain ----------------------------------------------------
+if [[ ! -f .env ]]; then
+  TOKEN="$(openssl rand -hex 24)"
+  printf 'DOMAIN=%s\nSERVE_TOKEN=%s\n' "${DOMAIN}" "${TOKEN}" > .env
+  chmod 600 .env
+  echo "==> Wrote .env with a freshly generated token"
+else
+  # Keep the existing token; refresh DOMAIN to the requested value.
+  if grep -q '^DOMAIN=' .env; then
+    sed -i "s#^DOMAIN=.*#DOMAIN=${DOMAIN}#" .env
+  else
+    printf 'DOMAIN=%s\n' "${DOMAIN}" >> .env
+  fi
+  echo "==> Reusing existing .env (token preserved)"
+fi
+
+# --- Build + start -----------------------------------------------------------
+echo "==> Building image and starting the stack (first build runs a full Gradle build — minutes)"
+sudo docker compose up -d --build
+
+TOKEN="$(grep '^SERVE_TOKEN=' .env | cut -d= -f2-)"
+echo
+echo "==> Up. Once DNS for ${DOMAIN} points at this VM and Caddy has a cert:"
+echo "    https://${DOMAIN}/?token=${TOKEN}"
+echo "    (Keep the token secret — it is the only gate on this public endpoint.)"
+echo "    Logs: sudo docker compose logs -f preview"

--- a/deploy/oracle/setup.sh
+++ b/deploy/oracle/setup.sh
@@ -31,7 +31,9 @@ fi
 # --- Docker -----------------------------------------------------------------
 if ! command -v docker >/dev/null 2>&1; then
   echo "==> Installing Docker (get.docker.com handles arm64 + Ubuntu/Oracle Linux)"
-  curl -fsSL https://get.docker.com | sh
+  # The installer does package-manager writes, so it needs root — the default OCI
+  # SSH user (ubuntu/opc) is unprivileged. Pipe into `sudo sh`, not bare `sh`.
+  curl -fsSL https://get.docker.com | sudo sh
   sudo systemctl enable --now docker
 fi
 # Compose v2 plugin check.


### PR DESCRIPTION
## Summary

Adds `deploy/oracle/` to host `compose-preview serve` on an **Oracle Cloud Always Free Ampere A1** (aarch64) VM — genuinely **$0/month** with always-warm capacity (up to 4 ARM cores + 24 GB RAM in the free tenancy), unlike the scale-to-zero Cloud Run setup.

It **reuses the desktop-only image** from `deploy/cloudrun/Dockerfile` and wraps it with Docker Compose + Caddy (automatic Let's Encrypt HTTPS). Same scope as Cloud Run: Desktop-only rendering, bundle uploads disabled (no untrusted-code execution), token-gated. Because the box is always on, the server stays warm (no cold start).

| File | Purpose |
|------|---------|
| `docker-compose.yml` | `preview` (built from the Cloud Run Dockerfile) behind a `caddy` TLS reverse proxy; only Caddy is published. |
| `Caddyfile` | Terminates TLS for `$DOMAIN`, proxies to the internal server; the app token stays the auth gate. |
| `setup.sh` | Run on the VM — installs Docker, opens the **host firewall** for 80/443 (Oracle images default-deny — the usual "can't reach my server" gotcha), writes `.env` with a generated token, builds + starts. Idempotent. |
| `README.md` | Instance creation (A1 shape, **VCN ingress rule**, DNS), arm64 caveat, operations, cost/limits, security, and an HTTP-only quick-test path. |
| `.gitignore` | Keeps the generated `.env` (token) out of git. |

Deploy is: create the A1 instance → add the VCN ingress rule + DNS A record → `DOMAIN=preview.example.com ./setup.sh`.

## Test plan

- Deploy/build plumbing only — no source or UI changes, so no rendered-output diff applies.
- Validated locally: `bash -n setup.sh`; `docker-compose.yml` parses and `docker compose config` resolves the build context (`../..` → repo root) and `deploy/cloudrun/Dockerfile`.
- **Not** validated end-to-end: provisioning a real A1 instance and an aarch64 image build (no OCI account / arm64 builder in the authoring sandbox). The README flags the arm64 validation point for the served module's native deps.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KTCvmWWzVkkK3mUB6Ye7fH)_