### PR TITLE
fix(release): don't let clients-v* releases claim GitHub "latest"

### DIFF
--- a/.github/workflows/clients-release.yml
+++ b/.github/workflows/clients-release.yml
@@ -141,6 +141,13 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ env.TAG_NAME }}
+          # The mobile/wear apps are a side artifact line, not the headline
+          # release. Never let a `clients-v*` release claim GitHub's "latest"
+          # pointer: `/releases/latest` must keep resolving to the CLI's `v*`
+          # release, which is what the `curl | bash` installer parses a version
+          # from (a `clients-v…` tag has no `…/v…` to strip, so it can't). With
+          # this release excluded, GitHub recomputes "latest" back to the CLI.
+          make_latest: false
           files: |
             _release/*.apk
             _release/*.aab


### PR DESCRIPTION
## Problem

The `curl … skills/main/scripts/install.sh | bash` installer (and the environment setup script that wraps it) broke:

```
==> resolving latest release of yschimke/compose-ai-tools
error: could not parse version from https://github.com/yschimke/compose-ai-tools/releases/tag/clients-v0.2.0
```

**Root cause:** release-please cuts the CLI release (`v0.16.1`) and the mobile/wear `clients` release (`clients-v0.2.0`) back-to-back. `clients-v0.2.0` published ~2s after `v0.16.1`, so GitHub's **"latest release" pointer moved to it**. The shell installer resolves the CLI version by following `/releases/latest` and stripping to the last `/v`:

```bash
RESOLVED=".../releases/tag/clients-v0.2.0"
VERSION="${RESOLVED##*/v}"        # no "/v" in "clients-v0.2.0" → unchanged → die
```

A `clients-v…` tag has no `…/v…` segment to strip, so it dies.

## Fix

Mark the `clients` release **`make_latest: false`** in `clients-release.yml`. The mobile/wear apps are a side artifact line, not the headline release; with this release excluded, GitHub recomputes "latest" back to the CLI's `v*` release and `/releases/latest` resolves correctly again.

The in-repo install **Action** (`.github/actions/install/resolve-version.py`) was already immune — it walks `/releases` and matches the `compose-preview-{ver}.tar.gz` asset, so it skips a `clients-*` release on its own. This brings the shell-installer path back in line.

## Scope / limits

- This prevents **recurrence** from the next release onward.
- It does **not** retroactively flip the already-published `clients-v0.2.0` off "latest" — that needs a one-off `gh release edit v0.16.1 --latest` (or `gh release edit clients-v0.2.0 --latest=false`) by a maintainer, which the next CLI release would also correct.
- The deeper hardening belongs in `yschimke/skills/scripts/install.sh` (stop trusting `/releases/latest`; resolve the newest `v*`/CLI-tarball release like `resolve-version.py` does) — out of this repo.

## Test plan

- [x] `clients-release.yml` is valid YAML.
- [x] `make_latest` is a supported `softprops/action-gh-release@v3` input.
- [ ] Verified on the next release that `/releases/latest` → the CLI `v*` tag.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NLAk5HYR1oxujE75fkMJ3g)_