### PR TITLE
feat(daemon): capture coordinate-free script from live recordings

### DIFF
--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -3205,6 +3205,7 @@ class JsonRpcServer(
                   frameWidthPx = r.frameWidthPx,
                   frameHeightPx = r.frameHeightPx,
                   scriptEvents = r.scriptEvents,
+                  capturedScript = r.capturedScript,
                 ),
               ),
             )

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -707,6 +707,7 @@ class JsonRpcServer(
       "recording/start" -> handleRecordingStart(req)
       "recording/stop" -> handleRecordingStop(req)
       "recording/encode" -> handleRecordingEncode(req)
+      "recording/generateTest" -> handleRecordingGenerateTest(req)
       else ->
         sendErrorResponse(
           id = req.id,
@@ -3224,6 +3225,61 @@ class JsonRpcServer(
       )
       .apply { isDaemon = true }
       .start()
+  }
+
+  /**
+   * `recording/generateTest` (issue #2047) — turn a captured live-recording timeline into a
+   * runnable Compose UI test, so the VS Code Record toggle (and any other client holding a
+   * [RecordingStopResult.capturedScript]) can offer "generate test" without porting
+   * [RecordingTestGenerator] to TypeScript. The daemon resolves the composable's real function name
+   * from its [previewIndex] (load-bearing for named/variant previews, whose synthetic id isn't the
+   * function name) and falls back to a sanitised heuristic when the id isn't in the catalog.
+   * Explicit identifier overrides on the params win over the derived defaults.
+   */
+  private fun handleRecordingGenerateTest(req: JsonRpcRequest) {
+    val params =
+      try {
+        decodeParams(
+          req.params,
+          ee.schimke.composeai.daemon.protocol.RecordingGenerateTestParams.serializer(),
+        )
+      } catch (e: Throwable) {
+        sendErrorResponse(
+          id = req.id,
+          code = ERR_INVALID_PARAMS,
+          message = "invalid recording/generateTest params: ${e.message}",
+        )
+        return
+      }
+    try {
+      val info = previewIndex.byId(params.previewId)
+      val spec =
+        RecordingTestGenerator.defaultSpec(
+          previewId = params.previewId,
+          functionName = info?.methodName,
+          classFqn = info?.className,
+          events = params.events,
+          classNameOverride = params.className,
+          methodNameOverride = params.methodName,
+          composableInvocationOverride = params.composableInvocation,
+          packageNameOverride = params.packageName,
+        )
+      sendResponse(
+        req.id,
+        encode(
+          ee.schimke.composeai.daemon.protocol.RecordingGenerateTestResult.serializer(),
+          ee.schimke.composeai.daemon.protocol.RecordingGenerateTestResult(
+            source = RecordingTestGenerator.generate(spec)
+          ),
+        ),
+      )
+    } catch (t: Throwable) {
+      sendErrorResponse(
+        id = req.id,
+        code = ERR_INTERNAL,
+        message = "recording/generateTest: ${t.javaClass.simpleName}: ${t.message}",
+      )
+    }
   }
 
   private fun handleRecordingEncode(req: JsonRpcRequest) {

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RecordingSession.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RecordingSession.kt
@@ -122,6 +122,12 @@ data class RecordingResult(
   val frameWidthPx: Int,
   val frameHeightPx: Int,
   val scriptEvents: List<RecordingScriptEvidence> = emptyList(),
+  /**
+   * Coordinate-free timeline captured from a `live = true` recording (the record-live bridge,
+   * issue #2047). Empty for scripted recordings. See [RecordingStopResult.capturedScript] for the
+   * wire contract — this is its in-process source.
+   */
+  val capturedScript: List<RecordingScriptEvent> = emptyList(),
 )
 
 /** Metadata returned by [RecordingSession.encode]. */

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RecordingTestGenerator.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RecordingTestGenerator.kt
@@ -54,6 +54,54 @@ object RecordingTestGenerator {
   /** Wrap raw events as all-applied steps — for callers without recording evidence. */
   fun stepsOf(events: List<RecordingScriptEvent>): List<Step> = events.map { Step(it) }
 
+  /**
+   * Build a [Spec] for a recording captured against [previewId] (issue #2047, the record-live
+   * bridge), deriving sensible identifiers so a client holding only the captured timeline (the VS
+   * Code Record toggle) gets a compilable test without authoring names by hand.
+   *
+   * [functionName] / [classFqn] come from the daemon's preview catalog when available —
+   * load-bearing for named/variant previews, whose synthetic id (`…WeatherForecast_Light`) is not
+   * the function name. When the id isn't in the catalog, the base name is sanitised out of
+   * [previewId]. Any `*Override` wins over the derived default, so a caller that knows better can
+   * pin exact names. Events are wrapped as all-applied steps (panel clicks dispatched); callers
+   * with per-event evidence build [Step]s themselves and call [generate] directly.
+   */
+  fun defaultSpec(
+    previewId: String,
+    functionName: String?,
+    classFqn: String?,
+    events: List<RecordingScriptEvent>,
+    classNameOverride: String? = null,
+    methodNameOverride: String? = null,
+    composableInvocationOverride: String? = null,
+    packageNameOverride: String? = null,
+  ): Spec {
+    val base = sanitizeIdentifier(functionName ?: previewId.substringAfterLast('.')) ?: "Preview"
+    val pascal = base.replaceFirstChar { it.uppercaseChar() }
+    val camel = base.replaceFirstChar { it.lowercaseChar() }
+    val derivedPackage =
+      classFqn?.substringBeforeLast('.', missingDelimiterValue = "")?.takeIf { it.isNotBlank() }
+    return Spec(
+      className = classNameOverride?.takeIf { it.isNotBlank() } ?: "Generated${pascal}Test",
+      methodName = methodNameOverride?.takeIf { it.isNotBlank() } ?: "${camel}Interaction",
+      composableInvocation = composableInvocationOverride?.takeIf { it.isNotBlank() } ?: "$base()",
+      packageName = packageNameOverride?.takeIf { it.isNotBlank() } ?: derivedPackage,
+      steps = stepsOf(events),
+    )
+  }
+
+  /**
+   * Reduce an arbitrary string to a legal Kotlin identifier (letters/digits/underscore, not
+   * starting with a digit) or `null` when nothing usable remains. Strips the variant suffix marker
+   * (`#…`) and any FQN/package punctuation a synthetic preview id carries.
+   */
+  private fun sanitizeIdentifier(raw: String): String? {
+    val cleaned =
+      raw.substringAfterLast('.').substringBefore('#').filter { it.isLetterOrDigit() || it == '_' }
+    val trimmed = cleaned.trimStart { it.isDigit() }
+    return trimmed.takeIf { it.isNotBlank() }
+  }
+
   fun generate(spec: Spec): String = buildString {
     val sortedSteps = spec.steps.sortedBy { it.event.tMs }
     // Probe snapshots opt the assertion finders/imports in; without any, the output stays

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -2197,6 +2197,33 @@ data class RecordingStopResult(
 )
 
 /**
+ * `recording/generateTest` request (issue #2047) — turn a captured live-recording timeline into a
+ * runnable Compose UI test, so a client holding a [RecordingStopResult.capturedScript] (the VS Code
+ * Record toggle) can offer "generate test" without porting `RecordingTestGenerator` to its own
+ * language. The daemon resolves the composable's real function name from its preview catalog (so
+ * the generated `setContent { … }` compiles for named/variant previews, whose synthetic id is not
+ * the function name), deriving the rest; any non-null identifier override below wins over the
+ * derived default.
+ */
+@Serializable
+data class RecordingGenerateTestParams(
+  /** Preview the recording was driven against. Used to resolve the composable's function name. */
+  val previewId: String,
+  /** The captured timeline — typically [RecordingStopResult.capturedScript]. */
+  val events: List<RecordingScriptEvent>,
+  /** Override the generated class name. Default `Generated<Preview>Test`. */
+  val className: String? = null,
+  /** Override the generated `@Test` method name. Default `<preview>Interaction`. */
+  val methodName: String? = null,
+  /** Override the `setContent { … }` call. Default `<FunctionName>()` from the catalog. */
+  val composableInvocation: String? = null,
+  /** Override the generated file's package. Default the preview class's package. */
+  val packageName: String? = null,
+)
+
+@Serializable data class RecordingGenerateTestResult(val source: String)
+
+/**
  * v1 supports only animated PNG (pure JVM, no native deps, plays in every browser/webview). mp4 /
  * webm via `ffmpeg` shell-out land in v2 — the enum is open so new values don't bump
  * `protocolVersion` per PROTOCOL.md § 7.

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -1934,6 +1934,18 @@ data class RecordingInputParams(
   val pixelX: Int? = null,
   val pixelY: Int? = null,
   /**
+   * Stable semantic handle for the node this input targets (issue #1784), mirroring
+   * [InteractiveInputParams.target]. Lets an agent driving a `live = true` recording act by ref /
+   * testTag / role+text instead of pixel coordinates; the daemon resolves it to the node's centre.
+   * When set, the captured-script timeline ([RecordingStopResult.capturedScript]) records the
+   * handle verbatim — already coordinate-free. When null and [pixelX]/[pixelY] are set, the live
+   * tick loop resolves the pixel back to the node it hit and records *that* handle, so panel clicks
+   * also produce a coordinate-free, replayable script (the record-live bridge). Explicit pixels
+   * still win for the actual dispatch when both are present (the escape hatch for canvas /
+   * custom-drawn surfaces).
+   */
+  val target: SemanticsInputTarget? = null,
+  /**
    * Per-pointer identifier for multi-touch dispatch in live recordings — distinct pointers (e.g. a
    * two-finger pinch) share the current virtual `tMs` boundary while carrying their own id.
    * Defaults to `0` for backwards compatibility, so existing single-pointer scripts (the vast
@@ -2171,6 +2183,17 @@ data class RecordingStopResult(
   val frameHeightPx: Int,
   /** Per-script-event execution evidence for input, lifecycle, state, and probe events. */
   val scriptEvents: List<RecordingScriptEvidence> = emptyList(),
+  /**
+   * The coordinate-free timeline captured from a `live = true` recording (the record-live bridge,
+   * issue #2047) — empty for scripted recordings, where the client already holds the events it
+   * posted via `recording/script`. Each entry is the [RecordingScriptEvent] the live tick loop
+   * dispatched, with pixel coordinates resolved back to the stable semantic handle of the node they
+   * hit (see [RecordingInputParams.target]). This is the Trailblaze "blaze live, capture as you go"
+   * artifact: it feeds `RecordingTestGenerator` directly so an exploratory live session becomes a
+   * durable Compose UI test, and can be replayed verbatim as a `recording/script` timeline. Paired
+   * with [scriptEvents] (same order) for per-event applied/unsupported status.
+   */
+  val capturedScript: List<RecordingScriptEvent> = emptyList(),
 )
 
 /**

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/RecordingTestGeneratorTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/RecordingTestGeneratorTest.kt
@@ -274,4 +274,67 @@ class RecordingTestGeneratorTest {
     assertTrue("click (tMs=0) must precede keyDown (tMs=500)\n$source", clickIdx in 0 until keyIdx)
     assertTrue(source, source.contains("// input.keyDown — not yet generated"))
   }
+
+  // --- defaultSpec: identifier derivation for the record-live bridge (issue #2047) ---
+
+  @Test
+  fun defaultSpecUsesCatalogFunctionNameAndPackage() {
+    val spec =
+      RecordingTestGenerator.defaultSpec(
+        previewId = "com.example.WeatherForecast_Light",
+        functionName = "WeatherForecast",
+        classFqn = "com.example.WeatherScreenKt",
+        events =
+          listOf(
+            RecordingScriptEvent(
+              tMs = 0L,
+              kind = "input.click",
+              target = SemanticsInputTarget(testTag = "refresh"),
+            )
+          ),
+      )
+    assertEquals("GeneratedWeatherForecastTest", spec.className)
+    assertEquals("weatherForecastInteraction", spec.methodName)
+    // Load-bearing for named/variant previews: invocation is the real function, not the id suffix.
+    assertEquals("WeatherForecast()", spec.composableInvocation)
+    assertEquals("com.example", spec.packageName)
+
+    val source = RecordingTestGenerator.generate(spec)
+    assertTrue(source, source.contains("setContent { WeatherForecast() }"))
+    assertTrue(source, source.contains("onNodeWithTag(\"refresh\").performClick()"))
+  }
+
+  @Test
+  fun defaultSpecFallsBackToSanitizedPreviewIdWhenCatalogMisses() {
+    val spec =
+      RecordingTestGenerator.defaultSpec(
+        previewId = "com.example.TogglePreview#dark",
+        functionName = null,
+        classFqn = null,
+        events = emptyList(),
+      )
+    assertEquals("GeneratedTogglePreviewTest", spec.className)
+    assertEquals("togglePreviewInteraction", spec.methodName)
+    assertEquals("TogglePreview()", spec.composableInvocation)
+    assertEquals(null, spec.packageName)
+  }
+
+  @Test
+  fun defaultSpecHonoursExplicitOverrides() {
+    val spec =
+      RecordingTestGenerator.defaultSpec(
+        previewId = "com.example.Foo",
+        functionName = "Foo",
+        classFqn = "com.example.FooKt",
+        events = emptyList(),
+        classNameOverride = "MyTest",
+        methodNameOverride = "myFlow",
+        composableInvocationOverride = "Foo(modifier = Modifier)",
+        packageNameOverride = "com.acme.test",
+      )
+    assertEquals("MyTest", spec.className)
+    assertEquals("myFlow", spec.methodName)
+    assertEquals("Foo(modifier = Modifier)", spec.composableInvocation)
+    assertEquals("com.acme.test", spec.packageName)
+  }
 }

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSession.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSession.kt
@@ -21,8 +21,10 @@ import ee.schimke.composeai.daemon.protocol.RecordingFormat
 import ee.schimke.composeai.daemon.protocol.RecordingInputParams
 import ee.schimke.composeai.daemon.protocol.RecordingScriptEvent
 import ee.schimke.composeai.daemon.protocol.RecordingScriptEvidence
+import ee.schimke.composeai.daemon.protocol.SemanticsInputTarget
 import ee.schimke.composeai.daemon.protocol.SemanticsTargetUnresolvedCode
 import ee.schimke.composeai.daemon.protocol.SemanticsTargetUnresolvedReason
+import ee.schimke.composeai.data.layoutinspector.SemanticsTarget
 import ee.schimke.composeai.data.layoutinspector.SemanticsTargets
 import ee.schimke.composeai.data.layoutinspector.TargetResolution
 import ee.schimke.composeai.data.render.extensions.RecordingScriptDataExtensions
@@ -91,6 +93,11 @@ class DesktopRecordingSession(
   // ConcurrentLinkedQueue so postInput callers (notification handler thread) and the tick
   // thread don't contend on a lock — adds and polls are wait-free.
   private val liveInputs = ConcurrentLinkedQueue<RecordingInputParams>()
+
+  // Coordinate-free timeline captured from live inputs (the record-live bridge, issue #2047).
+  // Appended by the tick thread as it dispatches each input; read by stopLive() after the join.
+  // Guarded for the belt-and-suspenders case where a reader races the tick thread's last append.
+  private val capturedLiveScript = mutableListOf<RecordingScriptEvent>()
 
   @Volatile private var stopped: Boolean = false
 
@@ -358,6 +365,7 @@ class DesktopRecordingSession(
       framesDir = framesDir.absolutePath,
       frameWidthPx = frameWidthPx,
       frameHeightPx = frameHeightPx,
+      capturedScript = synchronized(capturedLiveScript) { capturedLiveScript.toList() },
     )
   }
 
@@ -834,6 +842,31 @@ class DesktopRecordingSession(
    * the same nanoTime) so `Modifier.clickable {}` and other tap-gesture-detecting modifiers see a
    * clean down→up sequence.
    */
+  /**
+   * Record one dispatched live input into the coordinate-free [capturedLiveScript] (issue #2047 —
+   * the record-live bridge). When the event already carries a semantic
+   * [RecordingScriptEvent.target] (an agent drove the live recording by handle), keep it verbatim.
+   * Otherwise, when it carries pixel coordinates, resolve them back to the stable handle of the
+   * node under that point against the held scene's live semantics tree and record *that* — dropping
+   * the pixels — so a panel click also becomes a coordinate-free, layout-resilient step. Falls back
+   * to the raw pixel event when no targetable node is hit (canvas / custom-drawn surfaces) so the
+   * timeline still reflects what happened. Non-pointer events (keys) pass through unchanged.
+   */
+  private fun captureLiveEvent(event: RecordingScriptEvent) {
+    val px = event.pixelX
+    val py = event.pixelY
+    val resolved =
+      if (event.target == null && px != null && py != null) {
+        val handle = state.scene.composeSemanticsRoot()?.let { SemanticsTargets.nodeAt(it, px, py) }
+        if (handle != null)
+          event.copy(target = handle.toInputTarget(), pixelX = null, pixelY = null)
+        else event
+      } else {
+        event
+      }
+    synchronized(capturedLiveScript) { capturedLiveScript.add(resolved) }
+  }
+
   private fun runLiveTickLoop() {
     liveStartNs = System.nanoTime()
     val frameIntervalNs: Long = 1_000_000_000L / fps.toLong()
@@ -852,7 +885,9 @@ class DesktopRecordingSession(
         val ctx = SimpleRecordingDispatchContext(tNanos = tNanos, tMs = tMs)
         while (true) {
           val next = liveInputs.poll() ?: break
-          scriptHandlers.dispatch(next.toScriptEvent(tMs), ctx)
+          val scriptEvent = next.toScriptEvent(tMs)
+          scriptHandlers.dispatch(scriptEvent, ctx)
+          captureLiveEvent(scriptEvent)
         }
 
         val image = state.scene.render(nanoTime = tNanos)
@@ -1138,7 +1173,19 @@ internal fun RecordingInputParams.toScriptEvent(tMs: Long): RecordingScriptEvent
     kind = kind.wireName(),
     pixelX = pixelX,
     pixelY = pixelY,
+    target = target,
     pointerId = pointerId,
     scrollDeltaY = scrollDeltaY,
     keyCode = keyCode,
   )
+
+/**
+ * Project a resolved [SemanticsTarget] (from [SemanticsTargets.nodeAt]) onto the wire-level
+ * [SemanticsInputTarget] recorded in the coordinate-free captured script (issue #2047).
+ */
+internal fun SemanticsTarget.toInputTarget(): SemanticsInputTarget =
+  when (this) {
+    is SemanticsTarget.Tag -> SemanticsInputTarget(testTag = testTag)
+    is SemanticsTarget.RoleText -> SemanticsInputTarget(role = role, text = text)
+    is SemanticsTarget.Ref -> SemanticsInputTarget(ref = ref)
+  }

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSessionLiveInputTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSessionLiveInputTest.kt
@@ -2,6 +2,8 @@ package ee.schimke.composeai.daemon
 
 import ee.schimke.composeai.daemon.protocol.InteractiveInputKind
 import ee.schimke.composeai.daemon.protocol.RecordingInputParams
+import ee.schimke.composeai.daemon.protocol.SemanticsInputTarget
+import ee.schimke.composeai.data.layoutinspector.SemanticsTarget
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Test
@@ -102,5 +104,43 @@ class DesktopRecordingSessionLiveInputTest {
     assertEquals("input.keyDown", keyEvent.kind)
     assertEquals(1.5f, scrollEvent.scrollDeltaY!!, 0.0001f)
     assertEquals("input.rotaryScroll", scrollEvent.kind)
+  }
+
+  @Test
+  fun `toScriptEvent threads a semantic target through for agent-driven live recordings`() {
+    // The record-live bridge (issue #2047): an agent driving a live recording by handle posts a
+    // target on the wire, which must survive into the captured script verbatim (no pixel math).
+    val byHandle =
+      RecordingInputParams(
+        recordingId = "live-rec",
+        kind = InteractiveInputKind.CLICK,
+        target = SemanticsInputTarget(testTag = "submit"),
+      )
+
+    val event = byHandle.toScriptEvent(tMs = 5L)
+
+    assertEquals(SemanticsInputTarget(testTag = "submit"), event.target)
+    assertEquals(null, event.pixelX)
+    assertEquals("input.click", event.kind)
+  }
+
+  @Test
+  fun `toInputTarget projects each resolved handle variant onto the wire target`() {
+    assertEquals(
+      SemanticsInputTarget(testTag = "submit"),
+      SemanticsTarget.Tag("submit").toInputTarget(),
+    )
+    assertEquals(
+      SemanticsInputTarget(text = "Save"),
+      SemanticsTarget.RoleText(text = "Save").toInputTarget(),
+    )
+    assertEquals(
+      SemanticsInputTarget(role = "Button", text = "Save"),
+      SemanticsTarget.RoleText(role = "Button", text = "Save").toInputTarget(),
+    )
+    assertEquals(
+      SemanticsInputTarget(ref = "r/role:Button"),
+      SemanticsTarget.Ref("r/role:Button").toInputTarget(),
+    )
   }
 }

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/SemanticsTargets.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/SemanticsTargets.kt
@@ -54,6 +54,67 @@ object SemanticsTargets {
       .sortedByDescending { it.testTag != null }
       .take(limit)
 
+  /**
+   * Pixel→handle resolution for the record-live bridge (issue #2047): given a point in the
+   * root-pixel space of [ComposeSemanticsNode.boundsInRoot] (the same space `interactive/input` /
+   * `recording/input` pixel coordinates arrive in), return the strongest *stable* handle for the
+   * node under that point, or `null` when no targetable node contains it.
+   *
+   * "Strongest" mirrors [RecordingTestGenerator]'s finder preference so the captured handle
+   * round-trips into a clean Compose-test selector: [SemanticsTarget.Tag] (`testTag`) first, then
+   * [SemanticsTarget.RoleText] (visible text / label), then [SemanticsTarget.Ref] (the stable ref —
+   * always replayable, even when the node carries no human-readable handle). Among overlapping
+   * targetable nodes the **smallest-area** one wins — the deepest / topmost hit, matching what a
+   * real pointer would land on rather than an enclosing container.
+   *
+   * Reassigns refs defensively (same contract as [resolve]) so a raw tree still yields a stable
+   * ref.
+   */
+  fun nodeAt(root: ComposeSemanticsNode, x: Int, y: Int): SemanticsTarget? {
+    val hit =
+      SemanticsRefs.assign(root)
+        .flatten()
+        .mapNotNull { node ->
+          val bounds = SemanticsBounds.parse(node.boundsInRoot) ?: return@mapNotNull null
+          if (x < bounds.left || x > bounds.right || y < bounds.top || y > bounds.bottom) {
+            return@mapNotNull null
+          }
+          val handle = strongestHandle(node) ?: return@mapNotNull null
+          handle to bounds.area
+        }
+        .minByOrNull { (_, area) -> area }
+    return hit?.first
+  }
+
+  /**
+   * The strongest stable handle for one node, or `null` when it carries nothing worth pinning.
+   * Order matches [nodeAt]'s contract: `testTag` → visible text/label → `ref`. The `ref` fallback
+   * fires only for genuinely interactive nodes (`clickable` or carrying a `role`) — every node has
+   * a ref after [SemanticsRefs.assign], so without this guard a click on inert padding would
+   * resolve to an enclosing structural container. This mirrors [targetableNodes]' targetability
+   * filter.
+   */
+  private fun strongestHandle(node: ComposeSemanticsNode): SemanticsTarget? {
+    node.testTag
+      ?.takeIf { it.isNotBlank() }
+      ?.let {
+        return SemanticsTarget.Tag(it)
+      }
+    (node.text ?: node.label ?: node.layoutText)
+      ?.takeIf { it.isNotBlank() }
+      ?.let {
+        return SemanticsTarget.RoleText(text = it)
+      }
+    if (node.clickable || node.role != null) {
+      node.ref
+        ?.takeIf { it.isNotBlank() }
+        ?.let {
+          return SemanticsTarget.Ref(it)
+        }
+    }
+    return null
+  }
+
   private fun resolvedAt(node: ComposeSemanticsNode): TargetResolution {
     val bounds = SemanticsBounds.parse(node.boundsInRoot)
     return if (bounds == null) TargetResolution.NotFound
@@ -118,6 +179,10 @@ data class SemanticsBounds(val left: Int, val top: Int, val right: Int, val bott
 
   val centerY: Int
     get() = (top + bottom) / 2
+
+  /** Bounding-box area in px²; used to pick the deepest/topmost node under a point in [nodeAt]. */
+  val area: Long
+    get() = (right - left).toLong().coerceAtLeast(0) * (bottom - top).toLong().coerceAtLeast(0)
 
   companion object {
     fun parse(wire: String): SemanticsBounds? {

--- a/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/SemanticsTargetsTest.kt
+++ b/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/SemanticsTargetsTest.kt
@@ -102,4 +102,52 @@ class SemanticsTargetsTest {
     val root = node(children = (1..10).map { node(role = "Button", text = "B$it") })
     assertEquals(3, SemanticsTargets.targetableNodes(root, limit = 3).size)
   }
+
+  // --- nodeAt: pixel → strongest stable handle (issue #2047, record-live bridge) ---
+
+  @Test
+  fun nodeAtPrefersTestTag() {
+    val root = node(children = listOf(node(bounds = "100,40,140,80", testTag = "submit")))
+    assertEquals(SemanticsTarget.Tag("submit"), SemanticsTargets.nodeAt(root, 120, 60))
+  }
+
+  @Test
+  fun nodeAtFallsBackToTextThenRef() {
+    val textRoot = node(children = listOf(node(bounds = "0,0,50,20", text = "Save")))
+    assertEquals(SemanticsTarget.RoleText(text = "Save"), SemanticsTargets.nodeAt(textRoot, 25, 10))
+
+    // A node with no testTag/text/label but a real position still gets a replayable ref handle.
+    val refRoot = node(children = listOf(node(bounds = "0,0,50,20", role = "Button")))
+    val hit = SemanticsTargets.nodeAt(refRoot, 25, 10)
+    assertTrue("expected a ref handle, got $hit", hit is SemanticsTarget.Ref)
+  }
+
+  @Test
+  fun nodeAtPicksDeepestSmallestNodeUnderPoint() {
+    // A small tagged child sits inside a larger tagged container; a click inside the child should
+    // resolve to the child (smallest area), matching what a real pointer lands on.
+    val root =
+      node(
+        bounds = "0,0,200,200",
+        testTag = "screen",
+        children =
+          listOf(
+            node(
+              bounds = "0,0,200,100",
+              testTag = "card",
+              children = listOf(node(bounds = "10,10,40,40", testTag = "icon")),
+            )
+          ),
+      )
+    assertEquals(SemanticsTarget.Tag("icon"), SemanticsTargets.nodeAt(root, 25, 25))
+    // A point inside the card but outside the icon resolves to the card.
+    assertEquals(SemanticsTarget.Tag("card"), SemanticsTargets.nodeAt(root, 150, 50))
+  }
+
+  @Test
+  fun nodeAtReturnsNullWhenNoTargetableNodeContainsThePoint() {
+    val root = node(bounds = "0,0,200,200", children = listOf(node(bounds = "0,0,40,40")))
+    // (180,180) is inside the bare root but no targetable node covers it.
+    assertEquals(null, SemanticsTargets.nodeAt(root, 180, 180))
+  }
 }

--- a/docs/daemon/RECORDING-LIVE.md
+++ b/docs/daemon/RECORDING-LIVE.md
@@ -1,0 +1,64 @@
+# Record-live capture (the Trailblaze bridge)
+
+Live recording mode (`recording/start { live: true }` + `recording/input` +
+`recording/stop`) drives a held scene in real time and writes one frame per
+tick, producing a GIF/APNG/MP4. Issue #2047 adds the missing half: the live
+session now **captures the inputs it dispatched as a coordinate-free script**
+and returns it from `recording/stop`. That timeline replays verbatim as a
+`recording/script` and feeds [`RecordingTestGenerator`](../../daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RecordingTestGenerator.kt)
+to emit a runnable Compose UI test — so an exploratory live session becomes
+durable regression coverage. This is the "blaze live, capture as you go" loop
+Block's Trailblaze records into `.trail.yaml`, done in-process against a
+`@Preview` with no device.
+
+## What changed
+
+Live mode already routed every `recording/input` through the same
+script-handler registry the scripted path uses (the typed `RecordingInputParams`
+→ synthetic `RecordingScriptEvent`). It just **discarded** the result —
+"only the scripted stop result carries `scriptEvents`." Now the desktop session
+accumulates each dispatched event into `RecordingStopResult.capturedScript`:
+
+- `RecordingInputParams.target` (new) — an agent driving a live recording by
+  semantic handle (`ref` / `testTag` / `role`+`text`, mirroring
+  `interactive/input`) posts the target on the wire; it is recorded verbatim.
+- For panel clicks that carry only **pixel coordinates**, the tick loop resolves
+  the pixel back to the node it hit via
+  [`SemanticsTargets.nodeAt`](../../data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/SemanticsTargets.kt)
+  against the held scene's live semantics tree and records *that* handle —
+  dropping the pixels — so even a mouse click becomes a layout-resilient,
+  coordinate-free step.
+- A click that lands on no targetable node (canvas / custom-drawn surface) keeps
+  its raw pixels, so the timeline still reflects what happened.
+
+## Coordinate-free resolution
+
+`SemanticsTargets.nodeAt(root, x, y)` returns the strongest **stable** handle
+for the node under a point, mirroring `RecordingTestGenerator`'s finder
+preference so the captured handle round-trips into a clean selector:
+
+1. `testTag` → `onNodeWithTag(...)`
+2. visible text / label → `onNodeWithText(...)` / `onNodeWithContentDescription(...)`
+3. `ref` → replayable handle for an interactive node (clickable / has a role)
+   that carries no human-readable handle.
+
+Among overlapping nodes the **smallest-area** one wins — the deepest/topmost
+hit, matching what a real pointer lands on rather than an enclosing container.
+Pure structural containers (a ref but nothing targetable) are never hit targets.
+
+## Backends
+
+| Backend | `capturedScript` |
+|---------|------------------|
+| Desktop | ✅ coordinate-free, via the held `ImageComposeScene`'s `composeSemanticsRoot()` |
+| Android | ⬜ default empty for now (Android live recording is a follow-up; interactive needs `sandboxCount ≥ 2`) |
+
+## Surfaces
+
+- **Daemon** (this change) — `recording/stop` returns `capturedScript`. Wire
+  contract: [`RecordingStopResult.capturedScript`](../../daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt).
+- **VS Code** (follow-up) — a Record toggle on a LIVE card drives a live
+  recording, then offers "save script" / "generate test" from `capturedScript`.
+- **MCP / web** (follow-up) — a live-interaction tool so an agent can blaze one
+  input at a time (observe `compose/semantics` → act by handle → repeat) and get
+  the captured script + generated test at stop.

--- a/docs/daemon/RECORDING-LIVE.md
+++ b/docs/daemon/RECORDING-LIVE.md
@@ -53,12 +53,29 @@ Pure structural containers (a ref but nothing targetable) are never hit targets.
 | Desktop | ✅ coordinate-free, via the held `ImageComposeScene`'s `composeSemanticsRoot()` |
 | Android | ⬜ default empty for now (Android live recording is a follow-up; interactive needs `sandboxCount ≥ 2`) |
 
+## From timeline to test
+
+`recording/generateTest` turns a captured timeline into a runnable Compose UI
+test without a client porting [`RecordingTestGenerator`](../../daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RecordingTestGenerator.kt)
+to its own language. The client sends `{ previewId, events }`; the daemon
+resolves the composable's real function name from its preview catalog
+(`previewIndex.byId` — load-bearing for named/variant previews, whose synthetic
+id is not the function name), derives the class/method names, and returns the
+generated source. Identifier overrides (`className`, `methodName`,
+`composableInvocation`, `packageName`) win over the derived defaults. Wire
+contract: [`RecordingGenerateTestParams` / `RecordingGenerateTestResult`](../../daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt).
+
 ## Surfaces
 
-- **Daemon** (this change) — `recording/stop` returns `capturedScript`. Wire
-  contract: [`RecordingStopResult.capturedScript`](../../daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt).
-- **VS Code** (follow-up) — a Record toggle on a LIVE card drives a live
-  recording, then offers "save script" / "generate test" from `capturedScript`.
+- **Daemon** — `recording/stop` returns `capturedScript`; `recording/generateTest`
+  turns it into a test. Wire contract:
+  [`RecordingStopResult.capturedScript`](../../daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt).
+- **VS Code** — the panel's Record toggle (`focusToolbar` REC button) already
+  drives a parallel live recording while a card is LIVE; on stop, when the
+  session captured a coordinate-free timeline, the extension offers **Generate
+  test** and opens the generated source in an untitled Kotlin editor for review
+  (`handleSetRecording` → `generateRecordingTest` in `extension.ts`). No new
+  webview chrome — the affordance is a native notification + editor.
 - **MCP / web** (follow-up) — a live-interaction tool so an agent can blaze one
   input at a time (observe `compose/semantics` → act by handle → repeat) and get
   the captured script + generated test at stop.

--- a/vscode-extension/src/daemon/daemonClient.ts
+++ b/vscode-extension/src/daemon/daemonClient.ts
@@ -40,6 +40,8 @@ import {
     PROTOCOL_VERSION,
     RecordingEncodeParams,
     RecordingEncodeResult,
+    RecordingGenerateTestParams,
+    RecordingGenerateTestResult,
     RecordingInputParams,
     RecordingStartParams,
     RecordingStartResult,
@@ -386,6 +388,15 @@ export class DaemonClient {
         params: RecordingEncodeParams,
     ): Promise<RecordingEncodeResult> {
         return this.request<RecordingEncodeResult>("recording/encode", params);
+    }
+
+    recordingGenerateTest(
+        params: RecordingGenerateTestParams,
+    ): Promise<RecordingGenerateTestResult> {
+        return this.request<RecordingGenerateTestResult>(
+            "recording/generateTest",
+            params,
+        );
     }
 
     /** Drains in-flight renders, then resolves. Daemon will not exit until `exit` fires. */

--- a/vscode-extension/src/daemon/daemonProtocol.ts
+++ b/vscode-extension/src/daemon/daemonProtocol.ts
@@ -1166,11 +1166,27 @@ export interface RecordingStartResult {
     recordingId: string;
 }
 
+/**
+ * Stable handle for the node an interaction targets, resolved server-side against the live
+ * semantics tree (issue #1784). Set exactly one of `ref` / `testTag` / (`role` and/or `text`).
+ * The daemon back-resolves panel pixel clicks into one of these for the captured live script
+ * (issue #2047) so a recorded session is coordinate-free.
+ */
+export interface SemanticsInputTarget {
+    ref?: string;
+    testTag?: string;
+    role?: string;
+    text?: string;
+}
+
 export interface RecordingInputParams {
     recordingId: string;
     kind: InteractiveInputKind;
     pixelX?: number;
     pixelY?: number;
+    /** Optional semantic handle — lets an agent drive a live recording by ref/testTag/role+text. */
+    target?: SemanticsInputTarget;
+    pointerId?: number;
     scrollDeltaY?: number;
     keyCode?: string;
 }
@@ -1180,6 +1196,9 @@ export interface RecordingScriptEvent {
     kind: string;
     pixelX?: number;
     pixelY?: number;
+    /** Coordinate-free handle the live tick loop resolved this event's pixel to (issue #2047). */
+    target?: SemanticsInputTarget;
+    pointerId?: number;
     scrollDeltaY?: number;
     keyCode?: string;
     label?: string;
@@ -1210,6 +1229,28 @@ export interface RecordingStopResult {
     frameWidthPx: number;
     frameHeightPx: number;
     scriptEvents?: RecordingScriptEvidence[];
+    /**
+     * Coordinate-free timeline captured from a `live = true` recording (the record-live bridge,
+     * issue #2047). Empty/absent for scripted recordings. Feeds `recording/generateTest`.
+     */
+    capturedScript?: RecordingScriptEvent[];
+}
+
+/**
+ * `recording/generateTest` request (issue #2047) — turn a captured live timeline into a runnable
+ * Compose UI test. The daemon resolves the composable's real function name from its preview catalog.
+ */
+export interface RecordingGenerateTestParams {
+    previewId: string;
+    events: RecordingScriptEvent[];
+    className?: string;
+    methodName?: string;
+    composableInvocation?: string;
+    packageName?: string;
+}
+
+export interface RecordingGenerateTestResult {
+    source: string;
 }
 
 export interface RecordingEncodeParams {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -67,7 +67,9 @@ import {
 import {
     DataProductAttachment,
     DiscoveryUpdatedParams,
+    RecordingScriptEvent,
 } from "./daemon/daemonProtocol";
+import type { DaemonClient } from "./daemon/daemonClient";
 import {
     A11Y_OVERLAY_KINDS,
     DaemonScheduler,
@@ -7730,13 +7732,25 @@ async function handleSetRecording(
                 recordingId,
                 format: encodeFormat,
             });
+            const captured = stopped.capturedScript ?? [];
             logLine(
                 `[recording] saved ${previewId}: ${encoded.videoPath} ` +
-                    `(${stopped.frameCount} frames, ${stopped.durationMs}ms)`,
+                    `(${stopped.frameCount} frames, ${stopped.durationMs}ms, ` +
+                    `${captured.length} captured step(s))`,
             );
-            void vscode.window.showInformationMessage(
+            // Record-live bridge (issue #2047): when the live session captured a coordinate-free
+            // timeline, offer to turn it into a runnable Compose UI test. The GIF/APNG is still the
+            // primary artifact; codegen is an opt-in follow-up action so the common "just record a
+            // clip" flow is unchanged.
+            const generateTest =
+                captured.length > 0 ? "Generate test" : undefined;
+            const choice = await vscode.window.showInformationMessage(
                 `Compose preview recording saved: ${encoded.videoPath}`,
+                ...(generateTest ? [generateTest] : []),
             );
+            if (choice === generateTest && generateTest) {
+                await generateRecordingTest(client, previewId, captured);
+            }
         } catch (err) {
             logLine(
                 `[recording] stop failed for ${previewId}: ${(err as Error).message}`,
@@ -7774,6 +7788,37 @@ async function handleSetRecording(
         panel?.postMessage({ command: "clearRecording", previewId });
         void vscode.window.showErrorMessage(
             `Compose preview recording failed: ${(err as Error).message}`,
+        );
+    }
+}
+
+/**
+ * Record-live bridge (issue #2047): ask the daemon to turn a captured coordinate-free timeline into
+ * a Compose UI test, then open it in an untitled Kotlin editor for the author to review and Save As.
+ * Untitled (rather than writing into the workspace) keeps the action reversible — nothing lands on
+ * disk without the author's explicit save — and sidesteps guessing the module's test source root.
+ */
+async function generateRecordingTest(
+    client: DaemonClient,
+    previewId: string,
+    events: RecordingScriptEvent[],
+): Promise<void> {
+    try {
+        const { source } = await client.recordingGenerateTest({
+            previewId,
+            events,
+        });
+        const doc = await vscode.workspace.openTextDocument({
+            language: "kotlin",
+            content: source,
+        });
+        await vscode.window.showTextDocument(doc, { preview: false });
+    } catch (err) {
+        logLine(
+            `[recording] generateTest failed for ${previewId}: ${(err as Error).message}`,
+        );
+        void vscode.window.showErrorMessage(
+            `Compose preview: could not generate test: ${(err as Error).message}`,
         );
     }
 }

--- a/vscode-extension/src/test/daemonClient.test.ts
+++ b/vscode-extension/src/test/daemonClient.test.ts
@@ -229,6 +229,43 @@ describe("DaemonClient", () => {
         client.exit();
     });
 
+    it("recordingGenerateTest sends a request carrying the captured timeline and awaits the source", async () => {
+        const { toServer, toClient } = bidiPair();
+        const frames = captureFrames(toServer);
+        const client = new DaemonClient(toServer, toClient, {});
+        const promise = client.recordingGenerateTest({
+            previewId: "com.example.TogglePreview",
+            events: [
+                {
+                    tMs: 0,
+                    kind: "input.click",
+                    target: { testTag: "submit" },
+                },
+            ],
+        });
+        const sent = (await frames.take()) as JsonRpcRequest;
+        assert.strictEqual(sent.method, "recording/generateTest");
+        assert.deepStrictEqual(sent.params, {
+            previewId: "com.example.TogglePreview",
+            events: [
+                { tMs: 0, kind: "input.click", target: { testTag: "submit" } },
+            ],
+        });
+        toClient.write(
+            encodeFrame({
+                jsonrpc: "2.0",
+                id: sent.id,
+                result: { source: "class GeneratedTogglePreviewTest {}" },
+            }),
+        );
+        const result = await promise;
+        assert.strictEqual(
+            result.source,
+            "class GeneratedTogglePreviewTest {}",
+        );
+        client.exit();
+    });
+
     it("interactiveStop emits a notification (no id) carrying the stream id", async () => {
         const { toServer, toClient } = bidiPair();
         const frames = captureFrames(toServer);

--- a/vscode-extension/src/webview/shared/semanticsDiff.ts
+++ b/vscode-extension/src/webview/shared/semanticsDiff.ts
@@ -136,7 +136,10 @@ const COMPARED_FIELDS: Array<[string, Extractor]> = [
     ["layoutLineCount", (n) => asNum(n.textOverflow?.lineCount)],
     ["layoutMaxLines", (n) => asNum(n.textOverflow?.maxLines)],
     ["layoutDidOverflowWidth", (n) => asBool(n.textOverflow?.didOverflowWidth)],
-    ["layoutDidOverflowHeight", (n) => asBool(n.textOverflow?.didOverflowHeight)],
+    [
+        "layoutDidOverflowHeight",
+        (n) => asBool(n.textOverflow?.didOverflowHeight),
+    ],
 ];
 
 function byRef(root: SemanticsNode): Map<string, SemanticsNode> {


### PR DESCRIPTION
Live recording mode (`recording/start { live: true }`) already dispatched
each `recording/input` through the script-handler registry but discarded the
resulting timeline. This is the record-live bridge (issue #2047): the desktop
session now accumulates those inputs into `RecordingStopResult.capturedScript`,
resolving pixel clicks back to the stable semantic handle of the node they hit
so the captured timeline is coordinate-free and replayable — and feeds
`RecordingTestGenerator` to turn an exploratory live session into a durable
Compose UI test. This is Block Trailblaze's "blaze live, capture as you go"
loop, in-process against a `@Preview` with no device.

- `SemanticsTargets.nodeAt(root, x, y)` resolves a point to the strongest
  stable handle (testTag → text/label → ref), smallest-area node wins; ref
  only for genuinely interactive nodes so inert padding isn't a hit target.
- `RecordingInputParams.target` lets an agent drive a live recording by handle
  (recorded verbatim); panel pixel clicks get back-resolved.
- Android live capture left as a follow-up (default empty `capturedScript`).
- VS Code Record toggle and the live MCP tool are follow-ups (PR 2+).

🤖 Generated with [Claude Code](https://claude.ai/code)