### PR TITLE
feat(samples): add design-catalog-wear-m3 sticker-sheet module

### DIFF
--- a/samples/design-catalog-wear-m3/build.gradle.kts
+++ b/samples/design-catalog-wear-m3/build.gradle.kts
@@ -1,0 +1,51 @@
+// `:samples:design-catalog-wear-m3` — a Wear Compose Material 3 **design catalog**:
+// one `@Preview` per component in its primary modes, authored so the upstream
+// `compose-preview` renderer can export the module as an importable sticker sheet
+// (see `@design-parity/catalog-export` in yschimke/design-parity, and the M3
+// sibling `:samples:design-catalog-m3`).
+//
+// Code-led source of truth for the Wear M3 sheet. Wear is dark-first, so the
+// primary "modes" are the round size breakpoints (small + large round) supplied
+// by the `@WearPreviewSmallRound` / `@WearPreviewLargeRound` multipreviews rather
+// than a light/dark pair. Kept thin — `wear.compose.material3` + the Wear preview
+// tooling — so it builds against the stable Compose BOM.
+plugins {
+  id("composeai.base-conventions")
+  id("composeai.android-conventions")
+  alias(libs.plugins.android.application)
+  alias(libs.plugins.compose.compiler)
+  id("ee.schimke.composeai.preview")
+}
+
+composePreview {
+  // Pin Robolectric to SDK 35; see `:samples:wear` for the JDK 17 toolchain
+  // rationale (Robolectric SDK 36 requires JDK 21+).
+  sdkVersion.set(35)
+}
+
+android {
+  namespace = "com.example.designcatalogwearm3"
+
+  defaultConfig {
+    applicationId = "com.example.designcatalogwearm3"
+    minSdk = 30
+    targetSdk = 36
+    versionCode = 1
+    versionName = "1.0"
+  }
+
+  buildFeatures { compose = true }
+
+  testOptions { unitTests.all { it.jvmArgs("-Xmx2048m") } }
+}
+
+dependencies {
+  implementation(platform(libs.compose.bom.stable))
+  implementation(libs.compose.ui)
+  implementation(libs.compose.foundation)
+  implementation(libs.wear.compose.material3)
+  implementation(libs.wear.compose.foundation)
+  implementation(libs.wear.compose.ui.tooling)
+  implementation(libs.compose.ui.tooling.preview)
+  debugImplementation("androidx.compose.ui:ui-tooling")
+}

--- a/samples/design-catalog-wear-m3/catalog.spec.json
+++ b/samples/design-catalog-wear-m3/catalog.spec.json
@@ -1,0 +1,51 @@
+{
+  "$comment": "Phase-0 catalog spec for Wear Compose Material 3. Code-led: the render is authoritative; the kit references are for the one-off seed import only. Wear is dark-first, so the primary modes are the round size breakpoints (small/large round) rather than light/dark.",
+  "system": "wear-m3",
+  "title": "Wear Compose Material 3",
+  "library": ["androidx.wear.compose:compose-material3"],
+  "module": "samples:design-catalog-wear-m3",
+  "modes": ["smallRound", "largeRound"],
+  "referenceKits": [
+    "https://www.figma.com/community/file/1506418396052412186/m3-wear-os-apps-design-kit",
+    "https://www.figma.com/community/file/1507852095734722321/m3-wear-os-tiles-design-kit"
+  ],
+  "groups": [
+    {
+      "name": "Buttons",
+      "components": [
+        { "componentId": "Button/Filled", "preview": "FilledButton" },
+        { "componentId": "Button/Tonal", "preview": "FilledTonalButtonSticker" },
+        { "componentId": "Button/Outlined", "preview": "OutlinedButtonSticker" },
+        { "componentId": "Button/Child", "preview": "ChildButtonSticker" },
+        { "componentId": "EdgeButton", "preview": "EdgeButtonSticker", "caption": "Screen-hugging bottom action unique to Wear." }
+      ]
+    },
+    {
+      "name": "Selection",
+      "components": [
+        { "componentId": "SwitchButton/On", "preview": "SwitchButtonOn" },
+        { "componentId": "CheckboxButton/Checked", "preview": "CheckboxButtonChecked" }
+      ]
+    },
+    {
+      "name": "Containment",
+      "components": [
+        { "componentId": "Card", "preview": "CardSticker" },
+        { "componentId": "TitleCard", "preview": "TitleCardSticker" },
+        { "componentId": "ListHeader", "preview": "ListHeaderSticker" }
+      ]
+    },
+    {
+      "name": "Communication",
+      "components": [
+        { "componentId": "Progress/Circular", "preview": "CircularProgressSticker" }
+      ]
+    },
+    {
+      "name": "Text options",
+      "components": [
+        { "componentId": "Text/MaxLines-Truncated", "preview": "TextMaxLinesTruncated", "caption": "maxLines=2 + ellipsis on a round screen." }
+      ]
+    }
+  ]
+}

--- a/samples/design-catalog-wear-m3/src/main/AndroidManifest.xml
+++ b/samples/design-catalog-wear-m3/src/main/AndroidManifest.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Preview-only module: no launcher activity (see :samples:design-catalog-m3). -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application android:label="Design Catalog Wear M3" />
+</manifest>

--- a/samples/design-catalog-wear-m3/src/main/kotlin/com/example/designcatalogwearm3/CatalogPreviews.kt
+++ b/samples/design-catalog-wear-m3/src/main/kotlin/com/example/designcatalogwearm3/CatalogPreviews.kt
@@ -1,11 +1,17 @@
 package com.example.designcatalogwearm3
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.wear.compose.material3.AppScaffold
 import androidx.wear.compose.material3.Button
 import androidx.wear.compose.material3.Card
 import androidx.wear.compose.material3.CheckboxButton
@@ -15,9 +21,12 @@ import androidx.wear.compose.material3.EdgeButton
 import androidx.wear.compose.material3.EdgeButtonSize
 import androidx.wear.compose.material3.FilledTonalButton
 import androidx.wear.compose.material3.ListHeader
+import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.OutlinedButton
+import androidx.wear.compose.material3.ScreenScaffold
 import androidx.wear.compose.material3.SwitchButton
 import androidx.wear.compose.material3.Text
+import androidx.wear.compose.material3.TimeText
 import androidx.wear.compose.material3.TitleCard
 
 // ---------------------------------------------------------------------------
@@ -42,10 +51,29 @@ fun OutlinedButtonSticker() =
 @Composable
 fun ChildButtonSticker() = WearSticker { ChildButton(onClick = {}) { Text("Child") } }
 
+// EdgeButton is anchored to the bottom edge of the round screen via
+// ScreenScaffold(edgeButton = …) — its shape *is* that placement, so it gets a
+// real scaffold (not the centered WearSticker frame) to seed the right geometry.
 @CatalogWearModes
 @Composable
 fun EdgeButtonSticker() =
-  WearSticker { EdgeButton(onClick = {}, buttonSize = EdgeButtonSize.Large) { Text("Edge") } }
+  MaterialTheme {
+    AppScaffold(timeText = { TimeText() }) {
+      ScreenScaffold(
+        scrollState = rememberLazyListState(),
+        edgeButton = {
+          EdgeButton(onClick = {}, buttonSize = EdgeButtonSize.Large) { Text("Start") }
+        }
+      ) { contentPadding ->
+        Box(
+          Modifier.fillMaxSize().padding(contentPadding),
+          contentAlignment = Alignment.Center,
+        ) {
+          ListHeader { Text("Workout") }
+        }
+      }
+    }
+  }
 
 // ---------------------------------------------------------------------------
 // Selection controls.

--- a/samples/design-catalog-wear-m3/src/main/kotlin/com/example/designcatalogwearm3/CatalogPreviews.kt
+++ b/samples/design-catalog-wear-m3/src/main/kotlin/com/example/designcatalogwearm3/CatalogPreviews.kt
@@ -1,0 +1,110 @@
+package com.example.designcatalogwearm3
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.wear.compose.material3.Button
+import androidx.wear.compose.material3.Card
+import androidx.wear.compose.material3.CheckboxButton
+import androidx.wear.compose.material3.ChildButton
+import androidx.wear.compose.material3.CircularProgressIndicator
+import androidx.wear.compose.material3.EdgeButton
+import androidx.wear.compose.material3.EdgeButtonSize
+import androidx.wear.compose.material3.FilledTonalButton
+import androidx.wear.compose.material3.ListHeader
+import androidx.wear.compose.material3.OutlinedButton
+import androidx.wear.compose.material3.SwitchButton
+import androidx.wear.compose.material3.Text
+import androidx.wear.compose.material3.TitleCard
+
+// ---------------------------------------------------------------------------
+// Buttons — the Wear M3 emphasis levels plus the screen-hugging EdgeButton.
+// ---------------------------------------------------------------------------
+
+@CatalogWearModes
+@Composable
+fun FilledButton() = WearSticker { Button(onClick = {}) { Text("Filled") } }
+
+@CatalogWearModes
+@Composable
+fun FilledTonalButtonSticker() =
+  WearSticker { FilledTonalButton(onClick = {}) { Text("Tonal") } }
+
+@CatalogWearModes
+@Composable
+fun OutlinedButtonSticker() =
+  WearSticker { OutlinedButton(onClick = {}) { Text("Outlined") } }
+
+@CatalogWearModes
+@Composable
+fun ChildButtonSticker() = WearSticker { ChildButton(onClick = {}) { Text("Child") } }
+
+@CatalogWearModes
+@Composable
+fun EdgeButtonSticker() =
+  WearSticker { EdgeButton(onClick = {}, buttonSize = EdgeButtonSize.Large) { Text("Edge") } }
+
+// ---------------------------------------------------------------------------
+// Selection controls.
+// ---------------------------------------------------------------------------
+
+@CatalogWearModes
+@Composable
+fun SwitchButtonOn() =
+  WearSticker {
+    SwitchButton(checked = true, onCheckedChange = {}, label = { Text("Wifi") })
+  }
+
+@CatalogWearModes
+@Composable
+fun CheckboxButtonChecked() =
+  WearSticker {
+    CheckboxButton(checked = true, onCheckedChange = {}, label = { Text("Sync") })
+  }
+
+// ---------------------------------------------------------------------------
+// Containment + headers.
+// ---------------------------------------------------------------------------
+
+@CatalogWearModes
+@Composable
+fun CardSticker() = WearSticker { Card(onClick = {}) { Text("Card") } }
+
+@CatalogWearModes
+@Composable
+fun TitleCardSticker() =
+  WearSticker {
+    TitleCard(onClick = {}, title = { Text("Morning run") }) { Text("5.2 km · 28 min") }
+  }
+
+@CatalogWearModes
+@Composable
+fun ListHeaderSticker() = WearSticker { ListHeader { Text("Today") } }
+
+// ---------------------------------------------------------------------------
+// Communication.
+// ---------------------------------------------------------------------------
+
+@CatalogWearModes
+@Composable
+fun CircularProgressSticker() =
+  WearSticker { CircularProgressIndicator(modifier = Modifier.size(48.dp)) }
+
+// ---------------------------------------------------------------------------
+// Text options — exercises the maxLines / overflow product on a round screen.
+// ---------------------------------------------------------------------------
+
+@CatalogWearModes
+@Composable
+fun TextMaxLinesTruncated() =
+  WearSticker {
+    Text(
+      "This Wear body text is long enough to overflow two lines and truncate.",
+      modifier = Modifier.width(140.dp),
+      maxLines = 2,
+      overflow = TextOverflow.Ellipsis,
+    )
+  }

--- a/samples/design-catalog-wear-m3/src/main/kotlin/com/example/designcatalogwearm3/CatalogTheme.kt
+++ b/samples/design-catalog-wear-m3/src/main/kotlin/com/example/designcatalogwearm3/CatalogTheme.kt
@@ -1,0 +1,40 @@
+package com.example.designcatalogwearm3
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.wear.compose.material3.MaterialTheme
+import androidx.wear.compose.ui.tooling.preview.WearPreviewLargeRound
+import androidx.wear.compose.ui.tooling.preview.WearPreviewSmallRound
+
+/**
+ * The catalog's sticker frame. Each component is centred on the stock Wear
+ * [MaterialTheme] background, so the `compose/theme` token set the renderer
+ * extracts is the **real** Wear Material 3 system (which is dark-first).
+ */
+@Composable
+fun WearSticker(content: @Composable () -> Unit) {
+  MaterialTheme {
+    Box(
+      Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background).padding(8.dp),
+      contentAlignment = Alignment.Center,
+    ) {
+      content()
+    }
+  }
+}
+
+/**
+ * The catalog's primary-mode multipreview. Wear is dark-first, so the primary
+ * modes are the two round **size breakpoints** — small round and large round —
+ * the Wear preview tooling ships, rather than a light/dark pair. Stacking this on
+ * a component yields one capture per round size.
+ */
+@WearPreviewSmallRound
+@WearPreviewLargeRound
+annotation class CatalogWearModes

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -178,6 +178,11 @@ include(":samples:sdk-matrix")
 
 include(":samples:wear")
 
+// Wear Compose Material 3 **design catalog** — one `@Preview` per component in its
+// primary (round size) modes, exported as a sticker sheet (see
+// `docs/design/DESIGN_CATALOGS.md` and the M3 sibling `:samples:design-catalog-m3`).
+include(":samples:design-catalog-wear-m3")
+
 include(":samples:xr-glimmer")
 
 include(":samples:xr-spatial")


### PR DESCRIPTION
## Summary

Adds `samples/design-catalog-wear-m3`: a Wear Compose Material 3 **design catalog**, following the M3 template (#2048), whose `@Preview`s are exported as an importable **sticker sheet** by `@design-parity/catalog-export`.

- **One `@Preview` per component in its primary modes.** Wear is dark-first, so the primary modes are the round **size breakpoints** — small + large round, via the `@WearPreviewSmallRound` / `@WearPreviewLargeRound` multipreviews — rather than a light/dark pair.
- Covers buttons (filled, tonal, outlined, child, and the Wear-unique `EdgeButton`), selection (`SwitchButton`, `CheckboxButton`), containment (`Card`, `TitleCard`, `ListHeader`), circular progress, and a `maxLines`/overflow demo on a round screen.
- `catalog.spec.json` — the Phase-0 inventory (groups, captions, round-size modes, seed-kit frames: the M3 Wear OS Apps + Tiles design kits).
- Registered in `settings.gradle.kts`; kept to `wear.compose.material3` + the Wear preview tooling so it builds on the stable Compose BOM.

Code-led source of truth for the Wear M3 sheet — captures, theme tokens, the semantics-wireframe layout variant, and a11y findings all derive from these previews.

## Visual evidence

The module is registered with the preview harness, so the CI visual-diff bot (`preview-comment`) renders and diffs every `@Preview` it adds — the Wear sticker captures (small + large round) post as an automated PR comment. Locally I verified **`:samples:design-catalog-wear-m3:ktfmtCheck` + `compileDebugKotlin` → BUILD SUCCESSFUL** (against `/opt/android-sdk`, android-36).

## Test plan

- `./gradlew :samples:design-catalog-wear-m3:ktfmtCheck :samples:design-catalog-wear-m3:compileDebugKotlin` → **BUILD SUCCESSFUL**.
- `jq . samples/design-catalog-wear-m3/catalog.spec.json` — valid.
- New module only; no changes to existing samples or build logic.


---
_Generated by [Claude Code](https://claude.ai/code/session_017oE242kFmDN2ibrj44HiM3)_