### PR TITLE
ci: weekly design-artifacts job publishing per-system catalog branches

### DIFF
--- a/.github/workflows/design-artifacts.yml
+++ b/.github/workflows/design-artifacts.yml
@@ -73,6 +73,12 @@ jobs:
           compose-preview bundle pack --module "$MODULE" --with-semantics \
             -o "$GITHUB_WORKSPACE/$SYSTEM-bundle.png"
 
+      # The exporter gates on a complete render: `bundle pack --with-semantics`
+      # is best-effort (exits 0 even if the daemon failed or captured zero
+      # semantics), so the driver exits non-zero when any preview is missing or
+      # lacks semantics. With `set -e` that fails the job before the publish step,
+      # so a transient render failure can't force-push a degraded bundle over a
+      # good delivery branch.
       - name: Generate importable catalog
         working-directory: design-parity
         env:

--- a/.github/workflows/design-artifacts.yml
+++ b/.github/workflows/design-artifacts.yml
@@ -1,0 +1,106 @@
+name: Design Artifacts
+
+# Weekly job: render each design-catalog module and publish its importable
+# sticker-sheet bundle (catalog.json + DTCG tokens + Figma variables + PNGs) to a
+# clean `design-artifacts/<system>` branch a designer can pull into Figma /
+# Stitch / Claude Design. The render is the source of truth — these branches are
+# regenerated from the committed @Preview catalogs every Monday.
+#
+# Pipeline: compose-preview bundle pack  →  @design-parity/catalog-export driver
+#           →  force-push out/ to design-artifacts/<system>.
+
+on:
+  schedule:
+    # Mondays 06:00 UTC.
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: design-artifacts-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  generate:
+    name: ${{ matrix.system }}
+    # Don't run on forks — the publish step pushes branches into this repo.
+    if: ${{ github.repository == 'yschimke/compose-ai-tools' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - system: compose-m3
+            module: 'samples:design-catalog-m3'
+            spec: 'samples/design-catalog-m3/catalog.spec.json'
+          - system: wear-m3
+            module: 'samples:design-catalog-wear-m3'
+            spec: 'samples/design-catalog-wear-m3/catalog.spec.json'
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      # JDK + Gradle, then build the compose-preview CLI from this checkout so the
+      # render matches the in-repo plugin/renderer schema.
+      - uses: ./.github/actions/setup
+      - uses: ./.github/actions/install-cli
+
+      # The export engine + driver live in design-parity; build it from source
+      # (the @design-parity/catalog-export package isn't on npm yet).
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: yschimke/design-parity
+          path: design-parity
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+      - name: Build design-parity
+        working-directory: design-parity
+        run: |
+          npm ci
+          npm run build
+
+      - name: Render catalog bundle
+        env:
+          MODULE: ${{ matrix.module }}
+          SYSTEM: ${{ matrix.system }}
+        run: |
+          set -euo pipefail
+          compose-preview bundle pack --module "$MODULE" --with-semantics \
+            -o "$GITHUB_WORKSPACE/$SYSTEM-bundle.png"
+
+      - name: Generate importable catalog
+        working-directory: design-parity
+        env:
+          SYSTEM: ${{ matrix.system }}
+          SPEC: ${{ matrix.spec }}
+        run: |
+          set -euo pipefail
+          node scripts/generate-design-catalog.mjs \
+            --spec "$GITHUB_WORKSPACE/$SPEC" \
+            --renders "$GITHUB_WORKSPACE/$SYSTEM-bundle.png" \
+            --out "$GITHUB_WORKSPACE/out" \
+            --renderer "$(compose-preview --version | head -1)"
+
+      - name: Publish to design-artifacts/${{ matrix.system }}
+        env:
+          SYSTEM: ${{ matrix.system }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          cd "$GITHUB_WORKSPACE/out"
+          git init -q
+          git checkout -q -b "design-artifacts/$SYSTEM"
+          # Generated delivery branch — attributed to the repo owner, not a bot
+          # (mirrors the release job's human-authorship rule).
+          git config user.name 'Yuri Schimke'
+          git config user.email 'yuri@schimke.ee'
+          git add -A
+          git commit -q -m "chore(design-artifacts): regenerate $SYSTEM catalog ($(date -u +%F))"
+          git push --force \
+            "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+            "HEAD:refs/heads/design-artifacts/$SYSTEM"

--- a/docs/design/DESIGN_CATALOGS.md
+++ b/docs/design/DESIGN_CATALOGS.md
@@ -28,12 +28,25 @@ and breakpoints that matter.
 | Module | System | Status |
 | --- | --- | --- |
 | `samples/design-catalog-m3` | Compose Material 3 (+ Adaptive, planned) | ✅ template |
-| `samples/design-catalog-wear-m3` | Wear Compose M3 | planned |
+| `samples/design-catalog-wear-m3` | Wear Compose M3 | ✅ |
 | `samples/design-catalog-glimmer` | Glimmer (Android XR) | planned (see `samples/xr-glimmer`) |
 | `samples/design-catalog-glance` | Glance app widgets + Wear widgets | planned |
 
 Each module carries a `catalog.spec.json` (the Phase-0 inventory: groups,
 captions, primary modes, breakpoints, and the seed-kit frame per component).
+
+## Weekly delivery branches
+
+The [`design-artifacts`](../../.github/workflows/design-artifacts.yml) workflow
+runs every Monday (and on demand via `workflow_dispatch`): it renders each
+catalog module with `compose-preview bundle pack --with-semantics`, runs the
+`@design-parity/catalog-export` driver
+(`scripts/generate-design-catalog.mjs`), and force-pushes the importable bundle
+to a clean **`design-artifacts/<system>`** branch — `design-artifacts/compose-m3`,
+`design-artifacts/wear-m3`, … — that a designer pulls into Figma / Stitch /
+Claude Design. The branch holds only the generated bundle (`catalog.json`,
+`tokens.dtcg.json`, `figma-variables.json`, `images/`), regenerated from the
+code each week so it never drifts.
 
 ## Rendering a catalog
 


### PR DESCRIPTION
## Summary

Adds the **weekly design-artifacts job** — the delivery side of the catalog pipeline. Every Monday (and on demand via `workflow_dispatch`) it:

1. renders each design-catalog module with `compose-preview bundle pack --module … --with-semantics` (CLI built from source via `install-cli`);
2. runs the `@design-parity/catalog-export` driver (`scripts/generate-design-catalog.mjs`, from a source build of `design-parity`); and
3. force-pushes the importable bundle (`catalog.json` + `tokens.dtcg.json` + `figma-variables.json` + `images/`) to a clean **`design-artifacts/<system>`** branch a designer pulls into Figma / Stitch / Claude Design.

Covers `compose-m3` and `wear-m3`; the render is the source of truth, so the delivery branches regenerate from the committed catalogs each week and never drift. Also flips the Wear M3 row to ✅ and documents the delivery branches in `DESIGN_CATALOGS.md`.

## Notes

- Gated to `github.repository == 'yschimke/compose-ai-tools'` (the publish step pushes branches into this repo); commits the generated branch as the repo owner, mirroring the release job's human-authorship rule. Actions pinned to SHAs; matrix values passed via `env` (zizmor-safe).
- First validation is a `workflow_dispatch` run (a cron schedule can't be dry-run); I'll trigger it and watch.

## Test plan

- `python -c yaml.safe_load` — workflow parses.
- Driver + mapper unit-tested and smoke-tested in the companion design-parity PR.
- End-to-end render + publish validated on the first manual dispatch.


---
_Generated by [Claude Code](https://claude.ai/code/session_017oE242kFmDN2ibrj44HiM3)_