### PR TITLE
fix(samples): make Wear EdgeButton sticker render deterministic

### DIFF
--- a/samples/design-catalog-wear-m3/src/main/kotlin/com/example/designcatalogwearm3/CatalogPreviews.kt
+++ b/samples/design-catalog-wear-m3/src/main/kotlin/com/example/designcatalogwearm3/CatalogPreviews.kt
@@ -26,7 +26,6 @@ import androidx.wear.compose.material3.OutlinedButton
 import androidx.wear.compose.material3.ScreenScaffold
 import androidx.wear.compose.material3.SwitchButton
 import androidx.wear.compose.material3.Text
-import androidx.wear.compose.material3.TimeText
 import androidx.wear.compose.material3.TitleCard
 
 // ---------------------------------------------------------------------------
@@ -58,7 +57,10 @@ fun ChildButtonSticker() = WearSticker { ChildButton(onClick = {}) { Text("Child
 @Composable
 fun EdgeButtonSticker() =
   MaterialTheme {
-    AppScaffold(timeText = { TimeText() }) {
+    // No TimeText: it renders the live wall clock, which would make the sticker
+    // non-deterministic (and churn the weekly design-artifacts bundle). The edge
+    // slot is what this sticker documents.
+    AppScaffold(timeText = {}) {
       ScreenScaffold(
         scrollState = rememberLazyListState(),
         edgeButton = {


### PR DESCRIPTION
## Summary

The Wear `EdgeButtonSticker` rendered its `AppScaffold` with the default `TimeText` — the **live wall clock** — so its capture changed on every render. The preview-diff bot flagged it as "changed" on an unrelated PR (#2050), and the upcoming weekly `design-artifacts/wear-m3` bundle would churn every run purely on the clock.

Suppress the scaffold's `TimeText` (`timeText = {}`); the edge slot is what this sticker documents, and the time is irrelevant chrome. Render is now deterministic.

## Test plan

- `./gradlew :samples:design-catalog-wear-m3:ktfmtCheck :samples:design-catalog-wear-m3:compileDebugKotlin` → **BUILD SUCCESSFUL**.
- The preview-diff bot should now show `EdgeButtonSticker` stable across renders (no more clock-driven diff).


---
_Generated by [Claude Code](https://claude.ai/code/session_017oE242kFmDN2ibrj44HiM3)_