### PR TITLE
feat(samples): add component States group (pressed/focused/disabled/toggle) to catalogs

### DIFF
--- a/samples/design-catalog-m3/catalog.spec.json
+++ b/samples/design-catalog-m3/catalog.spec.json
@@ -65,6 +65,18 @@
       ]
     },
     {
+      "name": "States",
+      "components": [
+        { "componentId": "Button/Filled-Pressed", "preview": "FilledButtonPressed", "caption": "Held PressInteraction → pressed state layer." },
+        { "componentId": "Button/Filled-Focused", "preview": "FilledButtonFocused", "caption": "Held FocusInteraction → focus state layer." },
+        { "componentId": "Button/Outlined-Disabled", "preview": "OutlinedButtonDisabled" },
+        { "componentId": "Switch/Off", "preview": "SwitchOff" },
+        { "componentId": "Checkbox/Unchecked", "preview": "CheckboxUnchecked" },
+        { "componentId": "Chip/Filter-Unselected", "preview": "FilterChipUnselected" },
+        { "componentId": "SegmentedButton", "preview": "SegmentedToggle", "caption": "Single-choice toggle: selected + unselected segments." }
+      ]
+    },
+    {
       "name": "Text options",
       "components": [
         { "componentId": "Text/MaxLines-Truncated", "preview": "TextMaxLinesTruncated", "caption": "maxLines=2 + ellipsis overflow — exercises the textOverflow product." }

--- a/samples/design-catalog-m3/src/main/kotlin/com/example/designcatalogm3/CatalogPreviews.kt
+++ b/samples/design-catalog-m3/src/main/kotlin/com/example/designcatalogm3/CatalogPreviews.kt
@@ -3,6 +3,9 @@
 package com.example.designcatalogm3
 
 import android.content.res.Configuration
+import androidx.compose.foundation.interaction.FocusInteraction
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.PressInteraction
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -23,13 +26,19 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.RadioButton
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -178,4 +187,75 @@ fun TextMaxLinesTruncated() =
       maxLines = 2,
       overflow = TextOverflow.Ellipsis,
     )
+  }
+
+// ---------------------------------------------------------------------------
+// States — interaction (pressed / focused), disabled, and toggle off↔on.
+// A held interaction is seeded into the InteractionSource so the static capture
+// shows that state's resting state-layer (the design contract for the state),
+// not the default resting button.
+// ---------------------------------------------------------------------------
+
+@Composable
+private fun pressedSource(): MutableInteractionSource {
+  val source = remember { MutableInteractionSource() }
+  LaunchedEffect(source) { source.emit(PressInteraction.Press(Offset.Zero)) }
+  return source
+}
+
+@Composable
+private fun focusedSource(): MutableInteractionSource {
+  val source = remember { MutableInteractionSource() }
+  LaunchedEffect(source) { source.emit(FocusInteraction.Focus()) }
+  return source
+}
+
+@CatalogModes
+@Composable
+fun FilledButtonPressed() =
+  CatalogSticker { Button(onClick = {}, interactionSource = pressedSource()) { Text("Pressed") } }
+
+@CatalogModes
+@Composable
+fun FilledButtonFocused() =
+  CatalogSticker { Button(onClick = {}, interactionSource = focusedSource()) { Text("Focused") } }
+
+@CatalogModes
+@Composable
+fun OutlinedButtonDisabled() =
+  CatalogSticker { OutlinedButton(onClick = {}, enabled = false) { Text("Disabled") } }
+
+@CatalogModes
+@Composable
+fun SwitchOff() = CatalogSticker { Switch(checked = false, onCheckedChange = {}) }
+
+@CatalogModes
+@Composable
+fun CheckboxUnchecked() = CatalogSticker { Checkbox(checked = false, onCheckedChange = {}) }
+
+@CatalogModes
+@Composable
+fun FilterChipUnselected() =
+  CatalogSticker { FilterChip(selected = false, onClick = {}, label = { Text("Filter") }) }
+
+@CatalogModes
+@Composable
+fun SegmentedToggle() =
+  CatalogSticker {
+    SingleChoiceSegmentedButtonRow {
+      SegmentedButton(
+        selected = true,
+        onClick = {},
+        shape = SegmentedButtonDefaults.itemShape(index = 0, count = 2),
+      ) {
+        Text("On")
+      }
+      SegmentedButton(
+        selected = false,
+        onClick = {},
+        shape = SegmentedButtonDefaults.itemShape(index = 1, count = 2),
+      ) {
+        Text("Off")
+      }
+    }
   }

--- a/samples/design-catalog-wear-m3/catalog.spec.json
+++ b/samples/design-catalog-wear-m3/catalog.spec.json
@@ -42,6 +42,16 @@
       ]
     },
     {
+      "name": "States",
+      "components": [
+        { "componentId": "Button/Pressed", "preview": "ButtonPressed", "caption": "Held PressInteraction → pressed state layer." },
+        { "componentId": "Button/Focused", "preview": "ButtonFocused", "caption": "Held FocusInteraction → focus indicator (rotary / D-pad)." },
+        { "componentId": "Button/Disabled", "preview": "ButtonDisabled" },
+        { "componentId": "SwitchButton/Off", "preview": "SwitchButtonOff" },
+        { "componentId": "CheckboxButton/Unchecked", "preview": "CheckboxButtonUnchecked" }
+      ]
+    },
+    {
       "name": "Text options",
       "components": [
         { "componentId": "Text/MaxLines-Truncated", "preview": "TextMaxLinesTruncated", "caption": "maxLines=2 + ellipsis on a round screen." }

--- a/samples/design-catalog-wear-m3/src/main/kotlin/com/example/designcatalogwearm3/CatalogPreviews.kt
+++ b/samples/design-catalog-wear-m3/src/main/kotlin/com/example/designcatalogwearm3/CatalogPreviews.kt
@@ -1,5 +1,8 @@
 package com.example.designcatalogwearm3
 
+import androidx.compose.foundation.interaction.FocusInteraction
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.PressInteraction
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -7,8 +10,11 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.wear.compose.material3.AppScaffold
@@ -137,4 +143,53 @@ fun TextMaxLinesTruncated() =
       maxLines = 2,
       overflow = TextOverflow.Ellipsis,
     )
+  }
+
+// ---------------------------------------------------------------------------
+// States — interaction (pressed / focused; focus matters on Wear for rotary /
+// D-pad), disabled, and toggle off↔on. A held interaction is seeded into the
+// InteractionSource so the static capture shows that state's resting state-layer.
+// ---------------------------------------------------------------------------
+
+@Composable
+private fun pressedSource(): MutableInteractionSource {
+  val source = remember { MutableInteractionSource() }
+  LaunchedEffect(source) { source.emit(PressInteraction.Press(Offset.Zero)) }
+  return source
+}
+
+@Composable
+private fun focusedSource(): MutableInteractionSource {
+  val source = remember { MutableInteractionSource() }
+  LaunchedEffect(source) { source.emit(FocusInteraction.Focus()) }
+  return source
+}
+
+@CatalogWearModes
+@Composable
+fun ButtonPressed() =
+  WearSticker { Button(onClick = {}, interactionSource = pressedSource()) { Text("Pressed") } }
+
+@CatalogWearModes
+@Composable
+fun ButtonFocused() =
+  WearSticker { Button(onClick = {}, interactionSource = focusedSource()) { Text("Focused") } }
+
+@CatalogWearModes
+@Composable
+fun ButtonDisabled() =
+  WearSticker { Button(onClick = {}, enabled = false) { Text("Disabled") } }
+
+@CatalogWearModes
+@Composable
+fun SwitchButtonOff() =
+  WearSticker {
+    SwitchButton(checked = false, onCheckedChange = {}, label = { Text("Wifi") })
+  }
+
+@CatalogWearModes
+@Composable
+fun CheckboxButtonUnchecked() =
+  WearSticker {
+    CheckboxButton(checked = false, onCheckedChange = {}, label = { Text("Sync") })
   }


### PR DESCRIPTION
## Summary

Adds a **States** group to the M3 and Wear M3 catalogs, so the sticker sheets document interaction and toggle states — not just the resting component.

- **Interaction states** — `pressed` and `focused`, by seeding a held `PressInteraction` / `FocusInteraction` into the component's `InteractionSource` so the static capture shows that state's resting **state layer** (focus is especially meaningful on Wear for rotary / D-pad).
- **Disabled** — added across a second archetype (M3 `OutlinedButton`, Wear `Button`) to complement the existing filled-disabled sticker.
- **Toggle off↔on pairs** — `Switch` off, `Checkbox` unchecked, M3 `FilterChip` unselected, sitting alongside the existing on-state stickers.
- **Toggle button** — a single-choice `SegmentedButton` row (M3).

Each new preview is registered in the module's `catalog.spec.json` under a `States` group, so they flow straight into the weekly `design-artifacts/*` bundles.

## Visual evidence

The preview-diff bot renders every new `@Preview` it adds (in both modes / round sizes) and posts the captures as a PR comment — that's the before/after for these stickers. Locally verified **`ktfmtCheck` + `compileDebugKotlin` → BUILD SUCCESSFUL** for both modules.

Note on `pressed`: it's a held interaction (no release), so the ripple settles to a steady full state layer; I'll eyeball the bot's pressed captures for determinism and pin the clock in a follow-up if any flicker shows.

## Test plan

- `./gradlew :samples:design-catalog-m3:compileDebugKotlin :samples:design-catalog-wear-m3:compileDebugKotlin` → **BUILD SUCCESSFUL**; `ktfmtCheck` clean.
- `jq .` valid on both updated `catalog.spec.json`.


---
_Generated by [Claude Code](https://claude.ai/code/session_017oE242kFmDN2ibrj44HiM3)_