### PR TITLE
fix(ci): clone design-parity anonymously in design-artifacts job

### DIFF
--- a/.github/workflows/design-artifacts.yml
+++ b/.github/workflows/design-artifacts.yml
@@ -48,13 +48,18 @@ jobs:
       - uses: ./.github/actions/setup
       - uses: ./.github/actions/install-cli
 
-      # The export engine + driver live in design-parity; build it from source
-      # (the @design-parity/catalog-export package isn't on npm yet).
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          repository: yschimke/design-parity
-          path: design-parity
-          persist-credentials: false
+      # The export engine + driver live in design-parity; build it from source.
+      # Clone it anonymously rather than via actions/checkout: the workflow's
+      # GITHUB_TOKEN is scoped to this repo only, so checkout's repo-metadata API
+      # lookup 404s on the separate design-parity repo. A plain clone of the
+      # public repo needs no token.
+      - name: Check out design-parity (export engine + driver)
+        env:
+          DP_REF: main
+        run: |
+          set -euo pipefail
+          git clone --depth 1 --branch "$DP_REF" \
+            https://github.com/yschimke/design-parity.git design-parity
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22


### PR DESCRIPTION
## Summary

The first `workflow_dispatch` run of the weekly design-artifacts job failed in both matrix jobs at the **design-parity checkout** step:

```
##[error]Not Found - https://docs.github.com/rest/repos/repos#get-a-repository
```

`actions/checkout` does a repo-metadata API lookup to resolve the default branch, and the workflow's `GITHUB_TOKEN` is scoped to **this** repo only — so the lookup 404s on the separate `design-parity` repo (the token won't fall back to anonymous even though the repo is public).

Fix: clone the public `design-parity` repo directly with `git clone` (no token needed), instead of `actions/checkout`. The render → driver → publish steps then run.

## Test plan

- `yaml.safe_load` — workflow parses.
- Will re-dispatch after merge and confirm `design-artifacts/compose-m3` + `design-artifacts/wear-m3` are created.


---
_Generated by [Claude Code](https://claude.ai/code/session_017oE242kFmDN2ibrj44HiM3)_