### PR TITLE
fix(ci): authenticate the design-parity clone in design-artifacts job

### DIFF
--- a/.github/workflows/design-artifacts.yml
+++ b/.github/workflows/design-artifacts.yml
@@ -64,6 +64,11 @@ jobs:
           git clone --depth 1 --branch "$DP_REF" \
             "https://x-access-token:${GH_TOKEN}@github.com/yschimke/design-parity.git" \
             design-parity
+          # Scrub the token from the clone's config: the authenticated URL is
+          # persisted as remote.origin.url, and the next steps run npm ci / build
+          # from this clone with a contents:write token in reach. We never push or
+          # pull design-parity again, so drop the remote before any of its code runs.
+          git -C design-parity remote remove origin
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22

--- a/.github/workflows/design-artifacts.yml
+++ b/.github/workflows/design-artifacts.yml
@@ -49,17 +49,21 @@ jobs:
       - uses: ./.github/actions/install-cli
 
       # The export engine + driver live in design-parity; build it from source.
-      # Clone it anonymously rather than via actions/checkout: the workflow's
-      # GITHUB_TOKEN is scoped to this repo only, so checkout's repo-metadata API
-      # lookup 404s on the separate design-parity repo. A plain clone of the
-      # public repo needs no token.
+      # Clone it with `git` rather than actions/checkout (whose repo-metadata API
+      # lookup 404s on a separate repo under this repo-scoped token). The token
+      # goes in the URL because the runner forces credential lookup even for a
+      # public repo (anonymous clone fails with "could not read Username"); any
+      # valid token can read a public repo over git, so the repo-scoped
+      # GITHUB_TOKEN works here.
       - name: Check out design-parity (export engine + driver)
         env:
           DP_REF: main
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           git clone --depth 1 --branch "$DP_REF" \
-            https://github.com/yschimke/design-parity.git design-parity
+            "https://x-access-token:${GH_TOKEN}@github.com/yschimke/design-parity.git" \
+            design-parity
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22


### PR DESCRIPTION
## Summary

Follow-up to #2053. The anonymous `git clone` of design-parity failed on the hosted runner:

```
Cloning into 'design-parity'...
fatal: could not read Username for 'https://github.com': No such device or address
```

The runner forces a credential lookup even for a public repo, so an anonymous clone prompts for a username and dies non-interactively. Fix: put the repo-scoped `GITHUB_TOKEN` in the clone URL. Any valid token can read a **public** repo over git, and a raw `git clone` skips the permission-gated `GET /repos/{owner}/{repo}` API that broke `actions/checkout` in the first place (#2053's root cause).

With this, the render → driver → publish steps finally run and the `design-artifacts/<system>` branches get created.

## Test plan

- `yaml.safe_load` — workflow parses.
- Will re-dispatch after merge and confirm `design-artifacts/compose-m3` + `design-artifacts/wear-m3` appear.


---
_Generated by [Claude Code](https://claude.ai/code/session_017oE242kFmDN2ibrj44HiM3)_