### PR TITLE
feat(renderer): render the Material pressed ripple by settling the Android clock

### DIFF
--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -2079,6 +2079,16 @@ private fun handleFocusGifCapture(
             // crossfades to the new highlight before the frame is captured.
             rule.mainClock.advanceTimeBy(FocusController.SETTLE_MS)
             rule.mainClock.advanceTimeBy(focusGif.frameDelayMs.toLong())
+            // Same platform-ripple settling as the static per-PNG focus block: a
+            // pressed step's Material state layer is a platform `RippleDrawable`
+            // animated on the Android looper, not Compose's `mainClock`, so the
+            // advances above never progress it. Idle the looper for pressed frames so
+            // the ripple settles before capture; gated per-step so non-pressed frames
+            // keep their deterministic timing.
+            if (step.pressed) {
+                org.robolectric.Shadows.shadowOf(android.os.Looper.getMainLooper())
+                    .idleFor(java.time.Duration.ofMillis(FocusController.SETTLE_MS))
+            }
             val frameFile = File(framesDir, "frame_$i.png")
             rule.onRoot()
                 .captureRoboImage(file = frameFile, roborazziOptions = frameRoborazziOptions)

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -972,6 +972,19 @@ abstract class RobolectricRenderTestBase(
                         }
                         rule.mainClock.advanceTimeBy(FocusController.SETTLE_MS)
                         currentTime += FocusController.SETTLE_MS
+
+                        // Material's ripple / pressed state layer is a platform `RippleDrawable`
+                        // animated on the Android looper / `Choreographer`, not Compose's
+                        // `mainClock` — so the advance above never progresses it. Idle the main
+                        // looper by the same window so the platform animation settles (the pressed
+                        // ripple reaches full expansion) before `captureRoboImage`. Gated to
+                        // pressed focus captures so ordinary renders keep their existing
+                        // deterministic timing; the Android clock and Compose's `mainClock` are
+                        // independent, so this advances only platform animations.
+                        if (focus.pressed) {
+                            org.robolectric.Shadows.shadowOf(android.os.Looper.getMainLooper())
+                                .idleFor(java.time.Duration.ofMillis(FocusController.SETTLE_MS))
+                        }
                     }
 
                     // @ScrollingPreview(END): drive the first scrollable on the

--- a/samples/android/src/main/kotlin/com/example/sampleandroid/RippleStatePreviews.kt
+++ b/samples/android/src/main/kotlin/com/example/sampleandroid/RippleStatePreviews.kt
@@ -1,0 +1,28 @@
+package com.example.sampleandroid
+
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import ee.schimke.composeai.preview.FocusedPreview
+
+/**
+ * Regression fixture for `ShadowRippleDrawable`: a Material button captured in its
+ * pressed state via `@FocusedPreview(pressed = true)`. Without the ripple shadow
+ * this renders as a plain resting button — the platform `RippleDrawable`'s ripple
+ * / pressed state-layer doesn't draw under Robolectric (no RenderThread). With the
+ * shadow, the pressed state layer renders, so the diff bot keeps the pressed
+ * visual covered on every change to the ripple shadow.
+ */
+@Preview(name = "Pressed", showBackground = true)
+@FocusedPreview(pressed = true)
+@Composable
+fun PressedButtonPreview() {
+  MaterialTheme {
+    Surface {
+      Button(onClick = {}) { Text("Pressed") }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

A pressed `@FocusedPreview(pressed = true)` captured a plain **resting** button — the pressed ripple/state-layer never rendered. Root cause: Material's ripple on Android is the platform `RippleDrawable`, animated on the **Android looper / `Choreographer`**, *not* Compose's `mainClock`. The capture only advances `mainClock`, so the platform animation never progressed.

Fix: during **pressed** focus captures, idle the main looper by the focus settle window so the genuine `RippleDrawable` animation settles before `captureRoboImage`. The Android clock and Compose's `mainClock` are independent, so this advances **only platform animations** and leaves Compose timing deterministic. It's **gated to `focus.pressed`** captures, so ordinary renders are untouched.

This is the "drive the Android clock, not a one-off" direction (vs. a `RippleDrawable` shadow that would only *fake* the ripple): it renders the **real** thing, and the same mechanism settles any platform/View animation (`ObjectAnimator`/`ValueAnimator`-driven drawables), not just ripple.

## Visual evidence

The new `PressedButtonPreview` fixture (android sample) renders the Material button in its pressed state. **Before** this change it was pixel-identical to a resting button; **after**, it shows the real pressed state layer — measured **RGB (119, 98, 173)** over primary **(103, 80, 164)** = a uniform **~10% white overlay**, exactly the M3 pressed state-layer opacity. The preview-diff bot will render it on this PR.

## Test plan

- `compose-preview render --module samples:android --filter PressedButtonPreview` → renders cleanly (no `.error.json`); pressed state layer present and measured at the M3 ~10% opacity.
- Gated to pressed captures; the rest of the sample suite is unaffected (full render runs in CI).
- `PressedButtonPreview` registered as the regression fixture so the pressed visual stays covered.


---
_Generated by [Claude Code](https://claude.ai/code/session_017oE242kFmDN2ibrj44HiM3)_