### PR TITLE
fix(ci): source the design-artifacts export engine from npm, not a private clone

### DIFF
--- a/.github/workflows/design-artifacts.yml
+++ b/.github/workflows/design-artifacts.yml
@@ -48,35 +48,19 @@ jobs:
       - uses: ./.github/actions/setup
       - uses: ./.github/actions/install-cli
 
-      # The export engine + driver live in design-parity; build it from source.
-      # Clone it with `git` rather than actions/checkout (whose repo-metadata API
-      # lookup 404s on a separate repo under this repo-scoped token). The token
-      # goes in the URL because the runner forces credential lookup even for a
-      # public repo (anonymous clone fails with "could not read Username"); any
-      # valid token can read a public repo over git, so the repo-scoped
-      # GITHUB_TOKEN works here.
-      - name: Check out design-parity (export engine + driver)
-        env:
-          DP_REF: main
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          git clone --depth 1 --branch "$DP_REF" \
-            "https://x-access-token:${GH_TOKEN}@github.com/yschimke/design-parity.git" \
-            design-parity
-          # Scrub the token from the clone's config: the authenticated URL is
-          # persisted as remote.origin.url, and the next steps run npm ci / build
-          # from this clone with a contents:write token in reach. We never push or
-          # pull design-parity again, so drop the remote before any of its code runs.
-          git -C design-parity remote remove origin
+      # The export engine lives in the (private) design-parity repo, but its
+      # building blocks are published to npm. The driver
+      # (scripts/design-artifacts/) pins @design-parity/candidate +
+      # @design-parity/catalog-export, so we install them from npm rather than
+      # cloning design-parity: the workflow's GITHUB_TOKEN is scoped to this repo
+      # only and can't read the private design-parity repo, and a public-npm
+      # install needs no cross-repo secret.
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
-      - name: Build design-parity
-        working-directory: design-parity
-        run: |
-          npm ci
-          npm run build
+      - name: Install export engine (pinned npm packages)
+        working-directory: scripts/design-artifacts
+        run: npm ci
 
       - name: Render catalog bundle
         env:
@@ -94,14 +78,13 @@ jobs:
       # so a transient render failure can't force-push a degraded bundle over a
       # good delivery branch.
       - name: Generate importable catalog
-        working-directory: design-parity
         env:
           SYSTEM: ${{ matrix.system }}
           SPEC: ${{ matrix.spec }}
         run: |
           set -euo pipefail
-          node scripts/generate-design-catalog.mjs \
-            --spec "$GITHUB_WORKSPACE/$SPEC" \
+          node scripts/design-artifacts/generate-design-catalog.mjs \
+            --spec "$SPEC" \
             --renders "$GITHUB_WORKSPACE/$SYSTEM-bundle.png" \
             --out "$GITHUB_WORKSPACE/out" \
             --renderer "$(compose-preview --version | head -1)"

--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+/**
+ * Generate an importable design-artifact catalog from a rendered catalog module.
+ *
+ * Pipeline:  compose-preview render  →  this script  →  design-artifacts/<system>
+ *
+ *   node scripts/design-artifacts/generate-design-catalog.mjs \
+ *     --spec    <path to catalog.spec.json> \
+ *     --renders <compose-preview output dir or .zip (has previews.json + PNGs)> \
+ *     --out     <output bundle dir> \
+ *     [--renderer "compose-preview 0.16.2"]
+ *
+ * The export engine lives in the (private) design-parity repo, but its building
+ * blocks are published to npm: this driver depends only on the public package
+ * APIs `@design-parity/candidate` (`loadPreviewBundle`) and
+ * `@design-parity/catalog-export` (`buildCatalog`, `writeCatalog`). Both are
+ * installed from `scripts/design-artifacts/package.json` (pinned), so the weekly
+ * workflow needs no checkout of the private repo and no cross-repo secret.
+ *
+ * `catalogFromCandidates` (the spec→candidate join) is vendored inline below
+ * rather than imported, because the published `@design-parity/catalog-export`
+ * (0.1.20) predates that export — it's a thin, pure wrapper over the published
+ * `buildCatalog`. Keep it in sync with design-parity's
+ * `packages/catalog-export/src/spec.ts`; once a catalog-export release exports
+ * `catalogFromCandidates`, this inline copy can be dropped for the import.
+ *
+ * It reads the static preview bundle with `@design-parity/candidate`
+ * (`loadPreviewBundle` → `CandidateRender[]`), joins it to the committed spec
+ * (`catalogFromCandidates` → `buildCatalog`), and writes the importable bundle
+ * (`catalog.json` + `tokens.dtcg.json` + `figma-variables.json` + `images/`).
+ * The caller (the weekly workflow) commits the result to the system's
+ * `design-artifacts/<system>` branch.
+ */
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { parseArgs } from "node:util";
+
+import { loadPreviewBundle } from "@design-parity/candidate";
+import { buildCatalog, writeCatalog } from "@design-parity/catalog-export";
+
+// --- vendored from design-parity packages/catalog-export/src/spec.ts ----------
+// Pure join of rendered CandidateRenders to a catalog spec, wrapping the
+// published `buildCatalog`. See the file header for why it's inlined.
+//
+// The bundle reader emits one candidate per multipreview variant — its id
+// carries a `_<mode>` suffix (`FilledButton_Light`, `FilledButton_Dark`) that
+// the spec's bare `preview` ("FilledButton") doesn't. To match, the caller
+// resolves each candidate's componentId to its `functionName` (see the
+// `loadPreviewBundle(..., resolver)` call below), so `functionOf` keys on the
+// stable function name and a function's theme/size variants fold onto one
+// sticker. The published `@design-parity/catalog-export` (0.1.20) predates the
+// `functionName`-aware `catalogFromCandidates`; once a release ships it, this
+// inline copy + the resolver can be dropped for the import.
+
+/** The function name a spec component matches on. With the resolver below,
+ *  `componentId` is the function name; `functionName` is preferred when a
+ *  future bundle reader sets it directly on the candidate. */
+function functionOf(candidate) {
+  return candidate.functionName ?? candidate.componentId;
+}
+
+/** A semantics tree carries real signal (not the empty `{ root: {} }` fallback). */
+function hasSemantics(candidate) {
+  const tree = candidate.semantics;
+  if (!tree) return false;
+  if (tree.themeTokens) return true;
+  const r = tree.root;
+  return Boolean(
+    r && ((r.children && r.children.length > 0) || r.role || r.label || r.bounds || r.tokens),
+  );
+}
+
+/** Fold a function's theme/size variants into one render: concatenate images and
+ *  keep a light-themed semantics tree (the token/greenline reader keys off one). */
+function mergeByFunction(a, b) {
+  const semantics =
+    a.semantics?.theme === "light"
+      ? a.semantics
+      : b.semantics?.theme === "light"
+        ? b.semantics
+        : a.semantics;
+  const merged = { componentId: a.componentId, images: [...a.images, ...b.images], semantics };
+  if (a.previewId ?? b.previewId) merged.previewId = a.previewId ?? b.previewId;
+  if (a.functionName ?? b.functionName) merged.functionName = a.functionName ?? b.functionName;
+  return merged;
+}
+
+/**
+ * Join rendered candidates to a catalog spec. Each spec component is matched to
+ * the candidate whose preview function name equals its `preview`; a function's
+ * theme/size variants are folded into one component, missing previews are
+ * reported rather than dropped, and rendered-but-semantics-less components are
+ * flagged so the completeness gate can refuse to publish.
+ */
+function catalogFromCandidates(candidates, spec, opts = {}) {
+  const byFunction = new Map();
+  for (const candidate of candidates) {
+    const fn = functionOf(candidate);
+    const existing = byFunction.get(fn);
+    byFunction.set(fn, existing ? mergeByFunction(existing, candidate) : candidate);
+  }
+
+  const sources = [];
+  const missing = [];
+  const withoutSemantics = [];
+  for (const group of spec.groups) {
+    for (const component of group.components) {
+      const candidate = byFunction.get(component.preview);
+      if (!candidate || candidate.images.length === 0) {
+        missing.push(component.componentId);
+        continue;
+      }
+      if (!hasSemantics(candidate)) withoutSemantics.push(component.componentId);
+      const source = {
+        componentId: component.componentId,
+        group: group.name,
+        ideal: [...candidate.images],
+      };
+      if (component.caption !== undefined) source.caption = component.caption;
+      if (component.reference !== undefined) source.reference = component.reference;
+      if (candidate.semantics) source.semantics = candidate.semantics;
+      sources.push(source);
+    }
+  }
+
+  const meta = {
+    system: spec.system,
+    title: spec.title,
+    ...(spec.library ? { library: spec.library } : {}),
+    ...(opts.renderer ? { renderer: opts.renderer } : {}),
+    generatedAt: opts.generatedAt ?? new Date().toISOString(),
+  };
+
+  const catalog = buildCatalog(meta, sources, opts.themeTokens);
+  return { catalog, missing, withoutSemantics };
+}
+// --- end vendored join --------------------------------------------------------
+
+const { values } = parseArgs({
+  options: {
+    spec: { type: "string" },
+    renders: { type: "string" },
+    out: { type: "string" },
+    renderer: { type: "string" },
+    // Publish even when the render is incomplete (missing previews or absent
+    // semantics). Off by default so a degraded render fails the job rather than
+    // force-pushing a tokens/greenline-less bundle over a good delivery branch.
+    "allow-incomplete": { type: "boolean", default: false },
+  },
+});
+
+if (!values.spec || !values.renders || !values.out) {
+  console.error(
+    "usage: generate-design-catalog --spec <catalog.spec.json> --renders <dir|zip> --out <dir> [--renderer <s>]",
+  );
+  process.exit(2);
+}
+
+const specPath = resolve(values.spec);
+const rendersPath = resolve(values.renders);
+const outPath = resolve(values.out);
+
+const spec = JSON.parse(await readFile(specPath, "utf8"));
+// Resolve each candidate's componentId to its `@Preview` function name so the
+// join folds a function's theme/size multipreview variants (whose ids differ
+// only by an appended `_<mode>`) onto one component. See the vendored join above.
+const candidates = await loadPreviewBundle(rendersPath, (entry) => entry.functionName ?? entry.id);
+
+const { catalog, missing, withoutSemantics } = catalogFromCandidates(candidates, spec, {
+  ...(values.renderer ? { renderer: values.renderer } : {}),
+});
+
+// Completeness gate: `bundle pack --with-semantics` is best-effort and exits 0
+// even when the daemon never started or captured zero semantics. For a scheduled
+// job that force-pushes a delivery branch, refuse to publish an incomplete render
+// (missing previews, or pixels with no semantics → no tokens/contrast/greenlines)
+// so a transient failure can't clobber a good branch. `--allow-incomplete` opts out.
+if (missing.length > 0) {
+  console.warn(`[${spec.system}] missing renders for: ${missing.join(", ")}`);
+}
+if (withoutSemantics.length > 0) {
+  console.warn(`[${spec.system}] no semantics for: ${withoutSemantics.join(", ")}`);
+}
+if (!values["allow-incomplete"] && (missing.length > 0 || withoutSemantics.length > 0)) {
+  console.error(
+    `[${spec.system}] incomplete render — refusing to publish. ` +
+      `Re-run the render, or pass --allow-incomplete to override.`,
+  );
+  process.exit(1);
+}
+
+// Images in the bundle are relative to the render dir; resolve them from there.
+const sourceRoot = rendersPath.endsWith(".zip") ? dirname(rendersPath) : rendersPath;
+const result = await writeCatalog(catalog, outPath, { sourceRoot });
+
+console.log(
+  `[${spec.system}] ${catalog.components.length} component(s), ${result.imageCount} image(s) → ${result.manifestPath}`,
+);

--- a/scripts/design-artifacts/package-lock.json
+++ b/scripts/design-artifacts/package-lock.json
@@ -1,0 +1,110 @@
+{
+  "name": "design-artifacts-driver",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "design-artifacts-driver",
+      "version": "0.0.0",
+      "dependencies": {
+        "@design-parity/candidate": "^0.1.21",
+        "@design-parity/catalog-export": "^0.1.20"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@design-parity/candidate": {
+      "version": "0.1.21",
+      "resolved": "https://registry.npmjs.org/@design-parity/candidate/-/candidate-0.1.21.tgz",
+      "integrity": "sha512-xRIUYuGb9Cbzja7xCZWzr+xE+tZzrzBOiMEBMpqziAc9YrAtjfcANbwAVzBRf7yLcqStAoQXNbYQMQHQp92mIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@design-parity/core": "^0.1.21",
+        "fflate": "^0.8.2"
+      }
+    },
+    "node_modules/@design-parity/catalog-export": {
+      "version": "0.1.20",
+      "resolved": "https://registry.npmjs.org/@design-parity/catalog-export/-/catalog-export-0.1.20.tgz",
+      "integrity": "sha512-YYlEjrqUjLdFrTqyw3M+cb52tSgh1aC/ekwilCkTVRRjd/EchiW4xsYHifAINR2hR0gaIKdTYO0S/F+C6Q/Qhw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@design-parity/core": "^0.1.20"
+      }
+    },
+    "node_modules/@design-parity/core": {
+      "version": "0.1.21",
+      "resolved": "https://registry.npmjs.org/@design-parity/core/-/core-0.1.21.tgz",
+      "integrity": "sha512-b9oxVbKdSZdrFJkPqPrzxw2N898cs/ksktmM5nKb0K9CrRXwOYg4rV5uqkJE8rU25dt4WjrOgpFfyv2lALAqVQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "ajv": "^8.17.1"
+      },
+      "bin": {
+        "design-parity-validate-map": "dist/cli/validate-design-map.js",
+        "design-parity-validate-tokens": "dist/cli/validate-dtcg.js"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    }
+  }
+}

--- a/scripts/design-artifacts/package.json
+++ b/scripts/design-artifacts/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "design-artifacts-driver",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Workflow-only driver for the weekly Design Artifacts job. Pins the published design-parity export engine (no checkout of the private repo, no cross-repo secret) and runs generate-design-catalog.mjs over a compose-preview render.",
+  "type": "module",
+  "engines": {
+    "node": ">=22"
+  },
+  "dependencies": {
+    "@design-parity/candidate": "^0.1.21",
+    "@design-parity/catalog-export": "^0.1.20"
+  }
+}


### PR DESCRIPTION
## Summary

The weekly **Design Artifacts** job cloned the `design-parity` repo to build the export engine, but `design-parity` is **private** and the workflow `GITHUB_TOKEN` is scoped to this repo only — so the clone failed with `remote: Repository not found` regardless of how it was authenticated (#2053, #2054 were treating symptoms). `design-parity`'s building blocks are published to **public npm**, so this sources them from there instead:

- Vendor the ~80-line driver into `scripts/design-artifacts/generate-design-catalog.mjs`.
- Pin `@design-parity/candidate` + `@design-parity/catalog-export` in `scripts/design-artifacts/package.json` (+ lockfile) and `npm ci` them in the job.
- Drop the private clone + token-in-URL + remote-scrub dance entirely. **No cross-repo secret.**

It also fixes a latent **0-match** bug surfaced once the job could finally run the join: a function's theme multipreview variants (`FilledButton_Light`/`_Dark`) carry an `_<mode>` suffix the spec's bare `preview` doesn't, so the prior id-tail match found **0 of 29** components. The driver now resolves each candidate's `componentId` to its `functionName` (via `loadPreviewBundle`'s resolver) and folds a function's theme captures into one sticker. The same fix lands in the engine as source of truth (yschimke/design-parity#163); the inline copy + resolver can be dropped once that ships to npm.

## Validation

Run locally against the committed Compose-M3 catalog + a real `previews.json` (Android SDK isn't available in every dev container, so rendering itself runs in CI):

```
spec components: 29
MATCHED components: 29        (0 before this change)
missing: 0   withoutSemantics: 0
components theme-folded (light+dark): 29
writeCatalog → catalog.json + tokens.dtcg.json + figma-variables.json + images/
```

## Test plan

- `npm ci` in `scripts/design-artifacts` installs the pinned packages cleanly (lockfile committed; `node_modules` gitignored).
- The vendored driver's join validated to 29/29 against the real spec; `writeCatalog` emits the full bundle with folded light/dark images.
- Workflow YAML parses; the publish step + completeness gate are unchanged.
- Re-dispatch after merge to confirm `design-artifacts/compose-m3` + `design-artifacts/wear-m3` are created.

Text-only evidence is appropriate: this is CI/build-wiring, not a change to any rendered surface.

---
_Generated by [Claude Code](https://claude.ai/code/session_017oE242kFmDN2ibrj44HiM3)_