### PR TITLE
fix(ci): guard null widthDp in the design-artifacts driver

### DIFF
--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -35,8 +35,39 @@ import { readFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { parseArgs } from "node:util";
 
-import { loadPreviewBundle } from "@design-parity/candidate";
+import { readPreviewBundle, bundleToCandidates } from "@design-parity/candidate";
 import { buildCatalog, writeCatalog } from "@design-parity/catalog-export";
+
+/**
+ * Read a preview bundle into CandidateRenders, resolving each candidate's
+ * componentId to its `@Preview` functionName so the join folds theme/size
+ * variants (see the vendored join below).
+ *
+ * Split out of `loadPreviewBundle` to sanitize params first: the published
+ * `@design-parity/core` normalizeSize (≤ 0.1.21) throws on a `null` `widthDp`,
+ * which a `@Preview` with no pinned width serializes as JSON `null` (e.g. the
+ * compose-m3 stickers; the wear catalog pins a device width and is unaffected).
+ * Dropping the null width/height params is equivalent to "unset" and avoids the
+ * crash. Fixed upstream (design-parity normalizeSize null-guard); once that
+ * ships to npm and the pin is bumped, this can revert to a plain
+ * `loadPreviewBundle(path, resolver)`.
+ */
+async function loadCandidates(path) {
+  const bundle = await readPreviewBundle(path);
+  for (const preview of bundle.previews) {
+    sanitizeNullSizes(preview.params);
+    for (const capture of preview.captures ?? []) sanitizeNullSizes(capture.params);
+  }
+  return bundleToCandidates(bundle, (entry) => entry.functionName ?? entry.id);
+}
+
+/** Drop `widthDp`/`heightDp` when serialized as JSON null so the published
+ *  normalizeSize doesn't `.trim()` a null. */
+function sanitizeNullSizes(params) {
+  if (!params) return;
+  if (params.widthDp == null) delete params.widthDp;
+  if (params.heightDp == null) delete params.heightDp;
+}
 
 // --- vendored from design-parity packages/catalog-export/src/spec.ts ----------
 // Pure join of rendered CandidateRenders to a catalog spec, wrapping the
@@ -161,10 +192,11 @@ const rendersPath = resolve(values.renders);
 const outPath = resolve(values.out);
 
 const spec = JSON.parse(await readFile(specPath, "utf8"));
-// Resolve each candidate's componentId to its `@Preview` function name so the
-// join folds a function's theme/size multipreview variants (whose ids differ
-// only by an appended `_<mode>`) onto one component. See the vendored join above.
-const candidates = await loadPreviewBundle(rendersPath, (entry) => entry.functionName ?? entry.id);
+// Read candidates with componentId resolved to the `@Preview` function name so
+// the join folds a function's theme/size multipreview variants (whose ids differ
+// only by an appended `_<mode>`) onto one component. See `loadCandidates` (which
+// also works around the published null-widthDp crash) and the vendored join.
+const candidates = await loadCandidates(rendersPath);
 
 const { catalog, missing, withoutSemantics } = catalogFromCandidates(candidates, spec, {
   ...(values.renderer ? { renderer: values.renderer } : {}),


### PR DESCRIPTION
## Summary

The first real run of the npm-driver Design Artifacts job (after #2056) **created `design-artifacts/wear-m3` successfully** but the **compose-m3** matrix leg crashed at the driver step:

```
TypeError: Cannot read properties of null (reading 'trim')
  at normalizeSize (@design-parity/core/dist/size.js:40)
  at toImage (@design-parity/candidate/dist/bundle.js:151)
  at previewToCandidate / bundleToCandidates / loadPreviewBundle
```

A `@Preview` with no pinned width serializes `widthDp` as JSON `null`, and the published `@design-parity/core` `normalizeSize` (≤ 0.1.21) only guarded `undefined`. The compose-m3 stickers pin no width (so `widthDp: null`); the wear catalog pins a device width, which is why wear published and compose-m3 didn't.

Fix: split `loadPreviewBundle` into `readPreviewBundle` → sanitize → `bundleToCandidates`, dropping `null` `widthDp`/`heightDp` before candidates are built (the same `functionName` resolver still folds theme variants). Uses only already-installed published exports — **no dependency or lockfile change**.

## Validation

Reproduced and fixed against the **published** packages with a synthetic bundle carrying `widthDp: null`:

```
NO-SANITIZE  crashes as expected: TypeError - Cannot read properties of null (reading 'trim')
WITH-SANITIZE candidates = 2 | componentIds = FilledButton,FilledButton   (→ folds to 1 component, 2 themes)
```

`node --check` passes; `--help` path loads the module cleanly.

## Test plan

- Re-dispatch `design-artifacts.yml` after merge; expect `design-artifacts/compose-m3` to be created alongside the already-published `design-artifacts/wear-m3`.

The root cause is also fixed upstream as a `normalizeSize` null-guard (yschimke/design-parity); once that ships to npm and the pin is bumped, this splits back to a plain `loadPreviewBundle(path, resolver)`. CI/build-wiring change — text-only evidence is appropriate.

---
_Generated by [Claude Code](https://claude.ai/code/session_017oE242kFmDN2ibrj44HiM3)_