### PR TITLE
fix(renderer): settle END scroll captures so the Wear EdgeButton renders at rest

### DIFF
--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -1129,6 +1129,13 @@ abstract class RobolectricRenderTestBase(
                                     "@ScrollingPreview on '${preview.id}' but no scrollable " +
                                         "composable found on axis ${scroll.axis} — capturing initial frame.",
                                 )
+                            } else {
+                                // Let animations that begin once the scroll lands settle to their
+                                // resting state before capture — notably Wear `ScreenScaffold`'s
+                                // `EdgeButton`, which reveals/expands on reaching the end. Without
+                                // this, END snapshots the button mid-reveal (overscroll-stretched).
+                                // Mirrors the LONG final-frame path (see [handleLongCapture]).
+                                settlePostScrollAnimations(rule)
                             }
                         }
                         onRoot.captureRoboImage(

--- a/samples/design-catalog-wear-m3/build.gradle.kts
+++ b/samples/design-catalog-wear-m3/build.gradle.kts
@@ -47,5 +47,9 @@ dependencies {
   implementation(libs.wear.compose.foundation)
   implementation(libs.wear.compose.ui.tooling)
   implementation(libs.compose.ui.tooling.preview)
+  // @ScrollingPreview(END) — full-screen Wear components (EdgeButton, scaling
+  // lists) reveal their bottom-anchored chrome only after the scroll settles, so
+  // the catalog captures them scrolled to the end rather than at the resting top.
+  implementation(project(":preview-annotations"))
   debugImplementation("androidx.compose.ui:ui-tooling")
 }

--- a/samples/design-catalog-wear-m3/src/main/kotlin/com/example/designcatalogwearm3/CatalogPreviews.kt
+++ b/samples/design-catalog-wear-m3/src/main/kotlin/com/example/designcatalogwearm3/CatalogPreviews.kt
@@ -58,9 +58,28 @@ fun OutlinedButtonSticker() =
 @Composable
 fun ChildButtonSticker() = WearSticker { ChildButton(onClick = {}) { Text("Child") } }
 
-// A short workout menu the EdgeButton sticker scrolls through so the list
-// overflows the viewport — see [EdgeButtonSticker].
-private val edgeButtonMenu = listOf("Run", "Walk", "Cycle", "Swim", "Yoga", "Row")
+// A workout menu the EdgeButton sticker scrolls through. It's deliberately long
+// (≈ the proven samples/wear fixture): the content must overflow the viewport by
+// a few screens so that, scrolled to the end, the list fills the space above the
+// edge button and the button settles at its own EdgeButtonSize.Large height —
+// too few items leave slack the scaffold lets the button expand into.
+private val edgeButtonMenu =
+  listOf(
+    "Run",
+    "Walk",
+    "Cycle",
+    "Swim",
+    "Yoga",
+    "Row",
+    "Hike",
+    "Strength",
+    "Pilates",
+    "Elliptical",
+    "Stretch",
+    "Boxing",
+    "Dance",
+    "Climb",
+  )
 
 // EdgeButton hugs the bottom edge of the round screen via the
 // ScreenScaffold(edgeButton = …) slot — its curved shape *is* that placement, so

--- a/samples/design-catalog-wear-m3/src/main/kotlin/com/example/designcatalogwearm3/CatalogPreviews.kt
+++ b/samples/design-catalog-wear-m3/src/main/kotlin/com/example/designcatalogwearm3/CatalogPreviews.kt
@@ -30,9 +30,12 @@ import androidx.wear.compose.material3.ListHeader
 import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.OutlinedButton
 import androidx.wear.compose.material3.ScreenScaffold
+import androidx.wear.compose.material3.SurfaceTransformation
 import androidx.wear.compose.material3.SwitchButton
 import androidx.wear.compose.material3.Text
 import androidx.wear.compose.material3.TitleCard
+import androidx.wear.compose.material3.lazy.rememberTransformationSpec
+import androidx.wear.compose.material3.lazy.transformedHeight
 import ee.schimke.composeai.preview.ScrollMode
 import ee.schimke.composeai.preview.ScrollingPreview
 
@@ -58,41 +61,37 @@ fun OutlinedButtonSticker() =
 @Composable
 fun ChildButtonSticker() = WearSticker { ChildButton(onClick = {}) { Text("Child") } }
 
-// A workout menu the EdgeButton sticker scrolls through. It's deliberately long
-// (≈ the proven samples/wear fixture): the content must overflow the viewport by
-// a few screens so that, scrolled to the end, the list fills the space above the
-// edge button and the button settles at its own EdgeButtonSize.Large height —
-// too few items leave slack the scaffold lets the button expand into.
-private val edgeButtonMenu =
+// A workout history the EdgeButton sticker scrolls through. Long enough to
+// overflow the viewport by a few screens so, scrolled to the end, the list fills
+// the space above the edge button.
+private val edgeButtonHistory =
   listOf(
-    "Run",
-    "Walk",
-    "Cycle",
-    "Swim",
-    "Yoga",
-    "Row",
-    "Hike",
-    "Strength",
-    "Pilates",
-    "Elliptical",
-    "Stretch",
-    "Boxing",
-    "Dance",
-    "Climb",
+    "Morning run" to "5.2 km · 28 min",
+    "Heart rate" to "72 bpm",
+    "Sleep" to "7h 14m",
+    "Steps" to "6,482",
+    "Calories" to "412 kcal",
+    "Cycle" to "18 km · 41 min",
+    "Swim" to "1.2 km · 32 min",
+    "Hike" to "9.4 km · 1h 52m",
+    "Strength" to "45 min",
+    "Stretch" to "12 min",
+    "Yoga" to "30 min",
+    "Row" to "2.0 km · 9 min",
   )
 
 // EdgeButton hugs the bottom edge of the round screen via the
 // ScreenScaffold(edgeButton = …) slot — its curved shape *is* that placement, so
-// it's placed in a real ScreenScaffold + TransformingLazyColumn (the official
-// Wear M3 pattern, as in samples/wear) rather than a centred frame.
+// it's placed in a real ScreenScaffold + TransformingLazyColumn with the Wear M3
+// scaling transformation (SurfaceTransformation), exactly mirroring the official
+// samples/wear ActivityListScreen so the button measures at its resting size.
 //
 // ScreenScaffold reveals the edge button from its scroll state: at the resting
-// top it's collapsed/hidden, and it expands to EdgeButtonSize.Large only once the
-// list settles at the bottom. A static capture freezes the hidden initial frame
-// (the renderer pauses the clock), so the sticker uses @ScrollingPreview(END) —
-// scroll to the end of an overflowing list, then capture the single settled
-// frame with the button fully revealed. The overflow content also keeps the
-// button at its standard height instead of stretching to fill an empty viewport.
+// top it's collapsed, expanding only once the list settles at the bottom. A
+// static capture freezes the hidden initial frame (the renderer pauses the
+// clock), so the sticker uses @ScrollingPreview(END) — scroll the overflowing
+// list to the end (the renderer now settles post-scroll animations, so the
+// EdgeButton reveal lands at rest) and capture the single settled frame.
 @CatalogWearModes
 @ScrollingPreview(modes = [ScrollMode.END])
 @Composable
@@ -103,6 +102,7 @@ fun EdgeButtonSticker() =
     // slot is what this sticker documents.
     AppScaffold(timeText = {}) {
       val listState = rememberTransformingLazyColumnState()
+      val spec = rememberTransformationSpec()
       ScreenScaffold(
         scrollState = listState,
         edgeButton = {
@@ -114,9 +114,22 @@ fun EdgeButtonSticker() =
           contentPadding = contentPadding,
           modifier = Modifier.fillMaxSize(),
         ) {
-          item { ListHeader { Text("Workout") } }
-          items(edgeButtonMenu) { label ->
-            Button(onClick = {}, modifier = Modifier.fillMaxWidth()) { Text(label) }
+          item {
+            ListHeader(
+              modifier = Modifier.transformedHeight(this, spec),
+              transformation = SurfaceTransformation(spec),
+            ) {
+              Text("Workout")
+            }
+          }
+          items(edgeButtonHistory) { (title, subtitle) ->
+            TitleCard(
+              onClick = {},
+              title = { Text(title) },
+              subtitle = { Text(subtitle) },
+              modifier = Modifier.fillMaxWidth().transformedHeight(this, spec),
+              transformation = SurfaceTransformation(spec),
+            )
           }
         }
       }

--- a/samples/design-catalog-wear-m3/src/main/kotlin/com/example/designcatalogwearm3/CatalogPreviews.kt
+++ b/samples/design-catalog-wear-m3/src/main/kotlin/com/example/designcatalogwearm3/CatalogPreviews.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.interaction.FocusInteraction
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.PressInteraction
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
@@ -14,6 +15,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.wear.compose.foundation.lazy.TransformingLazyColumn
+import androidx.wear.compose.foundation.lazy.items
 import androidx.wear.compose.foundation.lazy.rememberTransformingLazyColumnState
 import androidx.wear.compose.material3.AppScaffold
 import androidx.wear.compose.material3.Button
@@ -31,6 +33,8 @@ import androidx.wear.compose.material3.ScreenScaffold
 import androidx.wear.compose.material3.SwitchButton
 import androidx.wear.compose.material3.Text
 import androidx.wear.compose.material3.TitleCard
+import ee.schimke.composeai.preview.ScrollMode
+import ee.schimke.composeai.preview.ScrollingPreview
 
 // ---------------------------------------------------------------------------
 // Buttons — the Wear M3 emphasis levels plus the screen-hugging EdgeButton.
@@ -54,14 +58,24 @@ fun OutlinedButtonSticker() =
 @Composable
 fun ChildButtonSticker() = WearSticker { ChildButton(onClick = {}) { Text("Child") } }
 
+// A short workout menu the EdgeButton sticker scrolls through so the list
+// overflows the viewport — see [EdgeButtonSticker].
+private val edgeButtonMenu = listOf("Run", "Walk", "Cycle", "Swim", "Yoga", "Row")
+
 // EdgeButton hugs the bottom edge of the round screen via the
-// ScreenScaffold(edgeButton = …) slot — its curved shape *is* that placement.
-// ScreenScaffold reveals the edge button from its scroll state, so the content
-// must be a real `TransformingLazyColumn` bound to the same state (a static Box
-// leaves the scaffold with no list to anchor, and the button never draws — the
-// shape this sticker exists to document). Mirrors the official Wear M3
-// `ScreenScaffold` + `TransformingLazyColumn` sample (see samples/wear).
+// ScreenScaffold(edgeButton = …) slot — its curved shape *is* that placement, so
+// it's placed in a real ScreenScaffold + TransformingLazyColumn (the official
+// Wear M3 pattern, as in samples/wear) rather than a centred frame.
+//
+// ScreenScaffold reveals the edge button from its scroll state: at the resting
+// top it's collapsed/hidden, and it expands to EdgeButtonSize.Large only once the
+// list settles at the bottom. A static capture freezes the hidden initial frame
+// (the renderer pauses the clock), so the sticker uses @ScrollingPreview(END) —
+// scroll to the end of an overflowing list, then capture the single settled
+// frame with the button fully revealed. The overflow content also keeps the
+// button at its standard height instead of stretching to fill an empty viewport.
 @CatalogWearModes
+@ScrollingPreview(modes = [ScrollMode.END])
 @Composable
 fun EdgeButtonSticker() =
   MaterialTheme {
@@ -82,6 +96,9 @@ fun EdgeButtonSticker() =
           modifier = Modifier.fillMaxSize(),
         ) {
           item { ListHeader { Text("Workout") } }
+          items(edgeButtonMenu) { label ->
+            Button(onClick = {}, modifier = Modifier.fillMaxWidth()) { Text(label) }
+          }
         }
       }
     }

--- a/samples/design-catalog-wear-m3/src/main/kotlin/com/example/designcatalogwearm3/CatalogPreviews.kt
+++ b/samples/design-catalog-wear-m3/src/main/kotlin/com/example/designcatalogwearm3/CatalogPreviews.kt
@@ -3,20 +3,18 @@ package com.example.designcatalogwearm3
 import androidx.compose.foundation.interaction.FocusInteraction
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.PressInteraction
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.wear.compose.foundation.lazy.TransformingLazyColumn
+import androidx.wear.compose.foundation.lazy.rememberTransformingLazyColumnState
 import androidx.wear.compose.material3.AppScaffold
 import androidx.wear.compose.material3.Button
 import androidx.wear.compose.material3.Card
@@ -56,9 +54,13 @@ fun OutlinedButtonSticker() =
 @Composable
 fun ChildButtonSticker() = WearSticker { ChildButton(onClick = {}) { Text("Child") } }
 
-// EdgeButton is anchored to the bottom edge of the round screen via
-// ScreenScaffold(edgeButton = …) — its shape *is* that placement, so it gets a
-// real scaffold (not the centered WearSticker frame) to seed the right geometry.
+// EdgeButton hugs the bottom edge of the round screen via the
+// ScreenScaffold(edgeButton = …) slot — its curved shape *is* that placement.
+// ScreenScaffold reveals the edge button from its scroll state, so the content
+// must be a real `TransformingLazyColumn` bound to the same state (a static Box
+// leaves the scaffold with no list to anchor, and the button never draws — the
+// shape this sticker exists to document). Mirrors the official Wear M3
+// `ScreenScaffold` + `TransformingLazyColumn` sample (see samples/wear).
 @CatalogWearModes
 @Composable
 fun EdgeButtonSticker() =
@@ -67,17 +69,19 @@ fun EdgeButtonSticker() =
     // non-deterministic (and churn the weekly design-artifacts bundle). The edge
     // slot is what this sticker documents.
     AppScaffold(timeText = {}) {
+      val listState = rememberTransformingLazyColumnState()
       ScreenScaffold(
-        scrollState = rememberLazyListState(),
+        scrollState = listState,
         edgeButton = {
           EdgeButton(onClick = {}, buttonSize = EdgeButtonSize.Large) { Text("Start") }
-        }
+        },
       ) { contentPadding ->
-        Box(
-          Modifier.fillMaxSize().padding(contentPadding),
-          contentAlignment = Alignment.Center,
+        TransformingLazyColumn(
+          state = listState,
+          contentPadding = contentPadding,
+          modifier = Modifier.fillMaxSize(),
         ) {
-          ListHeader { Text("Workout") }
+          item { ListHeader { Text("Workout") } }
         }
       }
     }


### PR DESCRIPTION
## Summary

The Wear M3 **EdgeButton** catalog sticker rendered wrong — first empty, then (once revealed) overscroll-stretched to ~40% of the screen. Two real causes, fixed here:

1. **Renderer (root cause):** `@ScrollingPreview(END)` drove the scroll then captured *immediately*, with no settle. A Wear `ScreenScaffold` `EdgeButton` reveals/expands once the scroll lands, so END snapshotted it mid-reveal (stretched). The LONG path already settles its final frame via `settlePostScrollAnimations` — whose own doc cites *"Wear `ScreenScaffold`'s `EdgeButton` reveal"* as the reason — but END wasn't wired to it. Now END settles too. Static END content is unaffected (nothing to settle).

2. **Sample:** the EdgeButton can't be captured at the resting top (the scaffold reveals it on scroll), so the sticker uses `@ScrollingPreview(END)` over a real `ScreenScaffold` + `TransformingLazyColumn` (the official Wear pattern, as in `samples/wear`) with enough menu items to overflow, so scrolling to the end reveals the button at the bottom edge.

Adds `:preview-annotations` to the wear catalog for `@ScrollingPreview`.

## Visual evidence

The preview-diff bot renders `EdgeButtonSticker` on this PR. Progression across commits: empty screen → button revealed but stretched (~40%) → **settled at its `EdgeButtonSize.Large` band at the bottom edge** with the list filling above it. (Confirmed against `samples/wear`'s known-good scrolled EdgeButton.)

## Test plan

- Diff bot re-renders `EdgeButtonSticker` (small + large round, scroll-end): expect the button settled at its standard height, not stretched.
- Other `@ScrollingPreview(END)` samples (`samples/android` RedToBlue) have static post-scroll content → identical renders (settle is a no-op); diff bot confirms no regressions.
- After merge, the weekly Design Artifacts run regenerates `design-artifacts/wear-m3` with the corrected sticker.