### PR TITLE
feat(design-artifacts): emit a browsable index.html per catalog

### DIFF
--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -31,12 +31,14 @@
  * The caller (the weekly workflow) commits the result to the system's
  * `design-artifacts/<system>` branch.
  */
-import { readFile } from "node:fs/promises";
-import { dirname, resolve } from "node:path";
+import { readFile, writeFile } from "node:fs/promises";
+import { dirname, resolve, join } from "node:path";
 import { parseArgs } from "node:util";
 
 import { readPreviewBundle, bundleToCandidates } from "@design-parity/candidate";
 import { buildCatalog, writeCatalog } from "@design-parity/catalog-export";
+
+import { renderIndexHtml } from "./render-index-html.mjs";
 
 /**
  * Read a preview bundle into CandidateRenders, resolving each candidate's
@@ -225,6 +227,13 @@ if (!values["allow-incomplete"] && (missing.length > 0 || withoutSemantics.lengt
 const sourceRoot = rendersPath.endsWith(".zip") ? dirname(rendersPath) : rendersPath;
 const result = await writeCatalog(catalog, outPath, { sourceRoot });
 
+// Browsable index next to catalog.json + images/ — a designer can open this
+// straight from the branch to skim every component (and its a11y greenlines)
+// before importing the tokens/images into a design tool.
+const indexPath = join(outPath, "index.html");
+await writeFile(indexPath, renderIndexHtml(catalog), "utf8");
+
 console.log(
   `[${spec.system}] ${catalog.components.length} component(s), ${result.imageCount} image(s) → ${result.manifestPath}`,
 );
+console.log(`[${spec.system}] index → ${indexPath}`);

--- a/scripts/design-artifacts/render-index-html.mjs
+++ b/scripts/design-artifacts/render-index-html.mjs
@@ -1,0 +1,185 @@
+/**
+ * Render a self-contained `index.html` for a design-artifact catalog: every
+ * component grouped, with its rendered sticker, an a11y "greenline" summary, and
+ * a jump-to index. Committed into each `design-artifacts/<system>` branch next to
+ * `catalog.json` and `images/`, so a designer can browse the system in a browser
+ * before importing into Figma / Stitch / Claude Design.
+ *
+ * Pure + dependency-free: takes the in-memory `catalog` object the driver already
+ * built (see generate-design-catalog.mjs) and returns an HTML string. Image refs
+ * are the catalog's own relative `images/...` paths, so the page works straight
+ * from the branch checkout. No external assets, no script — just inline CSS.
+ */
+
+/** Minimal HTML-escape for text interpolated into the page. */
+function esc(s) {
+  return String(s ?? "").replace(
+    /[&<>"']/g,
+    (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c],
+  );
+}
+
+/** A stable anchor/id fragment from arbitrary text. */
+function slug(s) {
+  return String(s ?? "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "");
+}
+
+/** One representative image per component — the first `ideal` variant (largest
+ *  first), falling back to whatever exists. Dedupes the size-duplicated entries. */
+function heroImage(component) {
+  const images = component.images ?? [];
+  const ideal = images.filter((i) => i.variant === "ideal");
+  const pool = ideal.length ? ideal : images;
+  return [...pool].sort((a, b) => (b.width ?? 0) - (a.width ?? 0))[0];
+}
+
+/** The component's a11y greenlines collapsed to short role/severity chips. */
+function greenlineChips(component) {
+  const lines = component.greenlines ?? [];
+  if (!lines.length) return "";
+  const chips = lines
+    .map((g) => {
+      const role = g.detail?.role ?? g.message ?? g.kind ?? "a11y";
+      return `<span class="chip chip--${esc(g.severity ?? "info")}">${esc(role)}</span>`;
+    })
+    .join("");
+  return `<div class="greenlines" title="accessibility greenlines">${chips}</div>`;
+}
+
+function componentCard(component) {
+  const img = heroImage(component);
+  const id = component.componentId ?? "(unnamed)";
+  const dims = img ? `${img.width}×${img.height}` : "";
+  const figure = img
+    ? `<figure class="shot"><img loading="lazy" src="${esc(img.path)}" alt="${esc(id)}" /></figure>`
+    : `<figure class="shot shot--missing">no render</figure>`;
+  return `<article class="card" id="c-${slug(id)}">
+  ${figure}
+  <div class="meta">
+    <h3>${esc(id)}</h3>
+    <div class="sub">${esc(dims)}</div>
+    ${greenlineChips(component)}
+  </div>
+</article>`;
+}
+
+/**
+ * Render the catalog to a complete HTML document.
+ * @param {object} catalog the in-memory catalog (system, title, components, …)
+ * @returns {string} a self-contained index.html
+ */
+export function renderIndexHtml(catalog) {
+  const components = catalog.components ?? [];
+
+  // Group preserving first-seen group order.
+  const groupOrder = [];
+  const byGroup = new Map();
+  for (const c of components) {
+    const g = c.group ?? "Components";
+    if (!byGroup.has(g)) {
+      byGroup.set(g, []);
+      groupOrder.push(g);
+    }
+    byGroup.get(g).push(c);
+  }
+
+  const nav = groupOrder
+    .map((g) => {
+      const items = byGroup
+        .get(g)
+        .map(
+          (c) =>
+            `<li><a href="#c-${slug(c.componentId)}">${esc(c.componentId)}</a></li>`,
+        )
+        .join("");
+      return `<section class="nav-group">
+      <a class="nav-head" href="#g-${slug(g)}">${esc(g)} <span>${byGroup.get(g).length}</span></a>
+      <ul>${items}</ul>
+    </section>`;
+    })
+    .join("");
+
+  const main = groupOrder
+    .map((g) => {
+      const cards = byGroup.get(g).map(componentCard).join("\n");
+      return `<section class="group" id="g-${slug(g)}">
+      <h2>${esc(g)}</h2>
+      <div class="grid">${cards}</div>
+    </section>`;
+    })
+    .join("\n");
+
+  const title = catalog.title ?? catalog.system ?? "Design catalog";
+  const subtitleParts = [
+    catalog.system && `system <code>${esc(catalog.system)}</code>`,
+    catalog.library && esc(catalog.library),
+    catalog.renderer && `rendered by ${esc(catalog.renderer)}`,
+    catalog.generatedAt && `${esc(catalog.generatedAt)}`,
+    `${components.length} components`,
+  ].filter(Boolean);
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>${esc(title)} — design catalog</title>
+<style>
+  :root { color-scheme: light dark; --bg:#0f0f10; --panel:#1b1b1d; --fg:#e8e8ea; --muted:#9b9ba1; --line:#2a2a2d; --accent:#7dd87d; }
+  * { box-sizing: border-box; }
+  body { margin:0; font:14px/1.5 system-ui, -apple-system, Segoe UI, Roboto, sans-serif; background:var(--bg); color:var(--fg); }
+  header.top { padding:24px clamp(16px,4vw,40px); border-bottom:1px solid var(--line); }
+  header.top h1 { margin:0 0 6px; font-size:22px; }
+  header.top .subtitle { color:var(--muted); font-size:13px; }
+  header.top code { background:var(--panel); padding:1px 6px; border-radius:5px; }
+  .layout { display:grid; grid-template-columns:240px 1fr; align-items:start; }
+  nav.index { position:sticky; top:0; align-self:start; max-height:100vh; overflow:auto; padding:20px 12px; border-right:1px solid var(--line); }
+  nav.index .nav-head { display:flex; justify-content:space-between; font-weight:600; text-decoration:none; color:var(--fg); padding:6px 8px; border-radius:6px; }
+  nav.index .nav-head span { color:var(--muted); font-weight:400; }
+  nav.index .nav-head:hover { background:var(--panel); }
+  nav.index ul { list-style:none; margin:2px 0 14px; padding:0 0 0 8px; }
+  nav.index li a { display:block; color:var(--muted); text-decoration:none; padding:3px 8px; border-radius:5px; font-size:13px; }
+  nav.index li a:hover { color:var(--fg); background:var(--panel); }
+  main { padding:8px clamp(16px,4vw,40px) 64px; min-width:0; }
+  .group { padding-top:24px; }
+  .group h2 { font-size:16px; border-bottom:1px solid var(--line); padding-bottom:8px; position:sticky; top:0; background:var(--bg); }
+  .grid { display:grid; grid-template-columns:repeat(auto-fill, minmax(180px,1fr)); gap:16px; }
+  .card { background:var(--panel); border:1px solid var(--line); border-radius:12px; overflow:hidden; }
+  /* Checkerboard so transparent component stickers read clearly; full-screen
+     stickers carry their own black round and just sit on top of it. */
+  .shot { margin:0; display:grid; place-items:center; min-height:180px; padding:12px;
+    background-color:#161617;
+    background-image:
+      linear-gradient(45deg,#202022 25%,transparent 25%),
+      linear-gradient(-45deg,#202022 25%,transparent 25%),
+      linear-gradient(45deg,transparent 75%,#202022 75%),
+      linear-gradient(-45deg,transparent 75%,#202022 75%);
+    background-size:16px 16px; background-position:0 0,0 8px,8px -8px,-8px 0; }
+  .shot img { max-width:100%; max-height:240px; height:auto; display:block; }
+  .shot--missing { color:var(--muted); font-style:italic; }
+  .meta { padding:10px 12px 12px; border-top:1px solid var(--line); }
+  .meta h3 { margin:0; font-size:13px; font-weight:600; word-break:break-word; }
+  .meta .sub { color:var(--muted); font-size:12px; margin-top:2px; }
+  .greenlines { margin-top:8px; display:flex; flex-wrap:wrap; gap:4px; }
+  .chip { font-size:11px; padding:1px 7px; border-radius:999px; border:1px solid var(--accent); color:var(--accent); }
+  .chip--warn { border-color:#e0c060; color:#e0c060; }
+  .chip--error { border-color:#e08080; color:#e08080; }
+  @media (max-width:720px){ .layout{ grid-template-columns:1fr; } nav.index{ position:static; max-height:none; border-right:0; border-bottom:1px solid var(--line);} }
+</style>
+</head>
+<body>
+<header class="top">
+  <h1>${esc(title)}</h1>
+  <div class="subtitle">${subtitleParts.join(" · ")}</div>
+</header>
+<div class="layout">
+  <nav class="index">${nav}</nav>
+  <main>${main}</main>
+</div>
+</body>
+</html>
+`;
+}


### PR DESCRIPTION
## Summary

Each `design-artifacts/<system>` branch now carries an **`index.html`** next to `catalog.json` + `images/`, so a designer can open the system in a browser and skim every component — grouped, with its rendered sticker, dimensions, and a11y "greenline" chips, plus a jump-to index — before importing tokens/images into Figma / Stitch / Claude Design.

- `scripts/design-artifacts/render-index-html.mjs` — pure, dependency-free: turns the in-memory catalog into one self-contained HTML string (inline CSS, no external assets), referencing the catalog's own relative `images/...` paths. Transparent component stickers render on a checkerboard so their alpha reads; full-screen stickers carry their own black round.
- The driver writes `index.html` after `writeCatalog`.

Per-system (one index per delivery branch). A cross-system landing page is an easy follow-up if you want one.

## Visual evidence

Rendered from the **real** published `design-artifacts/wear-m3` catalog (17 components, 6 groups) with images inlined — see the preview I attached in the session. The index lists each group with counts, links to every component, and shows the greenline role chips.

## Test plan

- `node --check` on both files; rendered against the live wear-m3 `catalog.json` (17 anchors, 6 nav groups, greenline chips present, correct relative image paths).
- After merge, the next Design Artifacts run writes `index.html` into both `design-artifacts/{compose-m3,wear-m3}`.

Build/data wiring on the JS side — text + the attached preview are the appropriate evidence (no Compose surface changed).

---
_Generated by [Claude Code](https://claude.ai/code/session_017oE242kFmDN2ibrj44HiM3)_