### PR TITLE
feat(samples): Wear size breakpoints + scaling list sample

### DIFF
--- a/samples/design-catalog-wear-m3/catalog.spec.json
+++ b/samples/design-catalog-wear-m3/catalog.spec.json
@@ -36,6 +36,12 @@
       ]
     },
     {
+      "name": "Lists",
+      "components": [
+        { "componentId": "TransformingLazyColumn", "preview": "ScalingListSticker", "caption": "Scaling list — items scale + fade toward the curved edges (SurfaceTransformation)." }
+      ]
+    },
+    {
       "name": "Communication",
       "components": [
         { "componentId": "Progress/Circular", "preview": "CircularProgressSticker" }

--- a/samples/design-catalog-wear-m3/src/main/kotlin/com/example/designcatalogwearm3/CatalogPreviews.kt
+++ b/samples/design-catalog-wear-m3/src/main/kotlin/com/example/designcatalogwearm3/CatalogPreviews.kt
@@ -17,7 +17,6 @@ import androidx.compose.ui.unit.dp
 import androidx.wear.compose.foundation.lazy.TransformingLazyColumn
 import androidx.wear.compose.foundation.lazy.items
 import androidx.wear.compose.foundation.lazy.rememberTransformingLazyColumnState
-import androidx.wear.compose.material3.AppScaffold
 import androidx.wear.compose.material3.Button
 import androidx.wear.compose.material3.Card
 import androidx.wear.compose.material3.CheckboxButton
@@ -27,7 +26,6 @@ import androidx.wear.compose.material3.EdgeButton
 import androidx.wear.compose.material3.EdgeButtonSize
 import androidx.wear.compose.material3.FilledTonalButton
 import androidx.wear.compose.material3.ListHeader
-import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.OutlinedButton
 import androidx.wear.compose.material3.ScreenScaffold
 import androidx.wear.compose.material3.SurfaceTransformation
@@ -82,55 +80,100 @@ private val edgeButtonHistory =
 
 // EdgeButton hugs the bottom edge of the round screen via the
 // ScreenScaffold(edgeButton = …) slot — its curved shape *is* that placement, so
-// it's placed in a real ScreenScaffold + TransformingLazyColumn with the Wear M3
-// scaling transformation (SurfaceTransformation), exactly mirroring the official
-// samples/wear ActivityListScreen so the button measures at its resting size.
+// it's a full-screen component: placed via [FullScreenWear] + a real
+// ScreenScaffold + TransformingLazyColumn with the Wear M3 scaling transformation
+// (SurfaceTransformation), mirroring samples/wear's ActivityListScreen so the
+// button measures at its resting size, and captured at every size breakpoint.
 //
 // ScreenScaffold reveals the edge button from its scroll state: at the resting
 // top it's collapsed, expanding only once the list settles at the bottom. A
 // static capture freezes the hidden initial frame (the renderer pauses the
 // clock), so the sticker uses @ScrollingPreview(END) — scroll the overflowing
-// list to the end (the renderer now settles post-scroll animations, so the
-// EdgeButton reveal lands at rest) and capture the single settled frame.
-@CatalogWearModes
+// list to the end (the renderer settles post-scroll animations, so the EdgeButton
+// reveal lands at rest) and capture the single settled frame.
+@CatalogWearBreakpoints
 @ScrollingPreview(modes = [ScrollMode.END])
 @Composable
 fun EdgeButtonSticker() =
-  MaterialTheme {
-    // No TimeText: it renders the live wall clock, which would make the sticker
-    // non-deterministic (and churn the weekly design-artifacts bundle). The edge
-    // slot is what this sticker documents.
-    AppScaffold(timeText = {}) {
-      val listState = rememberTransformingLazyColumnState()
-      val spec = rememberTransformationSpec()
-      ScreenScaffold(
-        scrollState = listState,
-        edgeButton = {
-          EdgeButton(onClick = {}, buttonSize = EdgeButtonSize.Large) { Text("Start") }
-        },
-      ) { contentPadding ->
-        TransformingLazyColumn(
-          state = listState,
-          contentPadding = contentPadding,
-          modifier = Modifier.fillMaxSize(),
-        ) {
-          item {
-            ListHeader(
-              modifier = Modifier.transformedHeight(this, spec),
-              transformation = SurfaceTransformation(spec),
-            ) {
-              Text("Workout")
-            }
+  FullScreenWear {
+    val listState = rememberTransformingLazyColumnState()
+    val spec = rememberTransformationSpec()
+    ScreenScaffold(
+      scrollState = listState,
+      edgeButton = {
+        EdgeButton(onClick = {}, buttonSize = EdgeButtonSize.Large) { Text("Start") }
+      },
+    ) { contentPadding ->
+      TransformingLazyColumn(
+        state = listState,
+        contentPadding = contentPadding,
+        modifier = Modifier.fillMaxSize(),
+      ) {
+        item {
+          ListHeader(
+            modifier = Modifier.transformedHeight(this, spec),
+            transformation = SurfaceTransformation(spec),
+          ) {
+            Text("Workout")
           }
-          items(edgeButtonHistory) { (title, subtitle) ->
-            TitleCard(
-              onClick = {},
-              title = { Text(title) },
-              subtitle = { Text(subtitle) },
-              modifier = Modifier.fillMaxWidth().transformedHeight(this, spec),
-              transformation = SurfaceTransformation(spec),
-            )
+        }
+        items(edgeButtonHistory) { (title, subtitle) ->
+          TitleCard(
+            onClick = {},
+            title = { Text(title) },
+            subtitle = { Text(subtitle) },
+            modifier = Modifier.fillMaxWidth().transformedHeight(this, spec),
+            transformation = SurfaceTransformation(spec),
+          )
+        }
+      }
+    }
+  }
+
+// ---------------------------------------------------------------------------
+// Lists — the Wear M3 scaling TransformingLazyColumn. Items scale + fade toward
+// the curved top/bottom edges via the SurfaceTransformation, the signature Wear
+// list treatment. Full-screen, captured at every size breakpoint.
+// ---------------------------------------------------------------------------
+
+private val scalingListItems =
+  listOf(
+    "Morning run" to "5.2 km · 28 min",
+    "Heart rate" to "72 bpm",
+    "Sleep" to "7h 14m",
+    "Steps" to "6,482",
+    "Calories" to "412 kcal",
+    "Cycle" to "18 km · 41 min",
+  )
+
+@CatalogWearBreakpoints
+@Composable
+fun ScalingListSticker() =
+  FullScreenWear {
+    val listState = rememberTransformingLazyColumnState()
+    val spec = rememberTransformationSpec()
+    ScreenScaffold(scrollState = listState) { contentPadding ->
+      TransformingLazyColumn(
+        state = listState,
+        contentPadding = contentPadding,
+        modifier = Modifier.fillMaxSize(),
+      ) {
+        item {
+          ListHeader(
+            modifier = Modifier.transformedHeight(this, spec),
+            transformation = SurfaceTransformation(spec),
+          ) {
+            Text("Activity")
           }
+        }
+        items(scalingListItems) { (title, subtitle) ->
+          TitleCard(
+            onClick = {},
+            title = { Text(title) },
+            subtitle = { Text(subtitle) },
+            modifier = Modifier.fillMaxWidth().transformedHeight(this, spec),
+            transformation = SurfaceTransformation(spec),
+          )
         }
       }
     }

--- a/samples/design-catalog-wear-m3/src/main/kotlin/com/example/designcatalogwearm3/CatalogTheme.kt
+++ b/samples/design-catalog-wear-m3/src/main/kotlin/com/example/designcatalogwearm3/CatalogTheme.kt
@@ -7,7 +7,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.wear.compose.material3.AppScaffold
 import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.ui.tooling.preview.WearPreviewLargeRound
 import androidx.wear.compose.ui.tooling.preview.WearPreviewSmallRound
@@ -38,3 +40,38 @@ fun WearSticker(content: @Composable () -> Unit) {
 @WearPreviewSmallRound
 @WearPreviewLargeRound
 annotation class CatalogWearModes
+
+/**
+ * Frame for **full-screen** Wear components (scaffolds, lists, the EdgeButton) —
+ * as opposed to the centred component [WearSticker]. The Wear dark [MaterialTheme]
+ * fills the round display black and [AppScaffold] supplies the screen structure;
+ * `timeText = {}` drops the status clock so the capture is deterministic (a live
+ * clock would churn the weekly design-artifacts bundle). The content supplies its
+ * own `ScreenScaffold`.
+ */
+@Composable
+fun FullScreenWear(content: @Composable () -> Unit) {
+  MaterialTheme {
+    AppScaffold(timeText = {}) { content() }
+  }
+}
+
+/**
+ * Full-screen **size-breakpoint** multipreview: the three round Wear screen sizes
+ * a layout must adapt to — 192 dp (small round), 227 dp (large round), and 244 dp
+ * (the largest round). 192/227 reuse the Wear tooling's device ids; 244 is an
+ * explicit round `spec:` at the same 2.0× density. Stack on a full-screen
+ * component (placed via [FullScreenWear] + `ScreenScaffold`) to capture it black
+ * on the device shape at each breakpoint — mirrors how the official Wear samples
+ * verify a screen across sizes.
+ */
+@WearPreviewSmallRound
+@WearPreviewLargeRound
+@Preview(
+  name = "Extra Large Round",
+  group = "Devices - Extra Large Round",
+  device = "spec:width=244dp,height=244dp,dpi=320,isRound=true",
+  showBackground = true,
+  backgroundColor = 0xFF000000,
+)
+annotation class CatalogWearBreakpoints

--- a/samples/design-catalog-wear-m3/src/main/kotlin/com/example/designcatalogwearm3/CatalogTheme.kt
+++ b/samples/design-catalog-wear-m3/src/main/kotlin/com/example/designcatalogwearm3/CatalogTheme.kt
@@ -58,17 +58,17 @@ fun FullScreenWear(content: @Composable () -> Unit) {
 
 /**
  * Full-screen **size-breakpoint** multipreview: the three round Wear screen sizes
- * a layout must adapt to — 192 dp (small round), 227 dp (large round), and 244 dp
- * (the largest round) — each black on the device shape. Stack on a full-screen
+ * a layout must adapt to — 192 dp (small round), 227 dp (large round), and 240 dp
+ * (extra-large round) — each black on the device shape. Stack on a full-screen
  * component (placed via [FullScreenWear] + `ScreenScaffold`) to capture it at each
  * breakpoint, mirroring how the official Wear samples verify a screen across sizes.
  *
  * All three are **direct** `@Preview`s rather than the nested `@WearPreviewSmallRound`
  * / `@WearPreviewLargeRound` aliases: `PreviewDiscovery.resolveMultiPreview` returns
  * an annotation class's direct previews without recursing into nested multipreviews,
- * so a mix would silently drop the nested 192/227 and render only 244. 192/227 use
- * the Wear device ids (192×192 / 227×227 @ 2.0×, round); 244 is an explicit round
- * `spec:` at the same density.
+ * so a mix would silently drop the nested 192/227 and render only the last. All
+ * three use the Wear tooling **device ids** (192/227/240, round, 2.0×) — the render
+ * pipeline only exercises named-id devices, not custom `spec:` strings.
  */
 @Preview(
   name = "Small Round",
@@ -87,7 +87,7 @@ fun FullScreenWear(content: @Composable () -> Unit) {
 @Preview(
   name = "Extra Large Round",
   group = "Devices - Extra Large Round",
-  device = "spec:width=244dp,height=244dp,dpi=320,isRound=true",
+  device = "id:wearos_xl_round",
   showBackground = true,
   backgroundColor = 0xFF000000,
 )

--- a/samples/design-catalog-wear-m3/src/main/kotlin/com/example/designcatalogwearm3/CatalogTheme.kt
+++ b/samples/design-catalog-wear-m3/src/main/kotlin/com/example/designcatalogwearm3/CatalogTheme.kt
@@ -59,14 +59,31 @@ fun FullScreenWear(content: @Composable () -> Unit) {
 /**
  * Full-screen **size-breakpoint** multipreview: the three round Wear screen sizes
  * a layout must adapt to — 192 dp (small round), 227 dp (large round), and 244 dp
- * (the largest round). 192/227 reuse the Wear tooling's device ids; 244 is an
- * explicit round `spec:` at the same 2.0× density. Stack on a full-screen
- * component (placed via [FullScreenWear] + `ScreenScaffold`) to capture it black
- * on the device shape at each breakpoint — mirrors how the official Wear samples
- * verify a screen across sizes.
+ * (the largest round) — each black on the device shape. Stack on a full-screen
+ * component (placed via [FullScreenWear] + `ScreenScaffold`) to capture it at each
+ * breakpoint, mirroring how the official Wear samples verify a screen across sizes.
+ *
+ * All three are **direct** `@Preview`s rather than the nested `@WearPreviewSmallRound`
+ * / `@WearPreviewLargeRound` aliases: `PreviewDiscovery.resolveMultiPreview` returns
+ * an annotation class's direct previews without recursing into nested multipreviews,
+ * so a mix would silently drop the nested 192/227 and render only 244. 192/227 use
+ * the Wear device ids (192×192 / 227×227 @ 2.0×, round); 244 is an explicit round
+ * `spec:` at the same density.
  */
-@WearPreviewSmallRound
-@WearPreviewLargeRound
+@Preview(
+  name = "Small Round",
+  group = "Devices - Small Round",
+  device = "id:wearos_small_round",
+  showBackground = true,
+  backgroundColor = 0xFF000000,
+)
+@Preview(
+  name = "Large Round",
+  group = "Devices - Large Round",
+  device = "id:wearos_large_round",
+  showBackground = true,
+  backgroundColor = 0xFF000000,
+)
 @Preview(
   name = "Extra Large Round",
   group = "Devices - Extra Large Round",


### PR DESCRIPTION
## Summary

Builds on the merged EdgeButton/renderer fix (#2058) to add the Wear catalog's **size-breakpoint** coverage and a **scaling list** sample, per the full-screen-component model.

- **`@CatalogWearBreakpoints`** — the three round Wear screen sizes a layout must adapt to: **192 dp** (small round), **227 dp** (large round), **240 dp** (XL round). All three are **direct** `@Preview` named-device entries — `resolveMultiPreview` returns direct previews without recursing into nested multipreviews (so a nested alias would silently drop variants), and the render pipeline only exercises named `id:` devices, not custom `spec:` strings.
- **`FullScreenWear`** frame — `MaterialTheme` + `AppScaffold(timeText = {})`; fills the round display black on the device shape, no clock (deterministic). Content supplies its own `ScreenScaffold`.
- **`EdgeButtonSticker`** → `FullScreenWear` + `@CatalogWearBreakpoints` (now rendered at all three sizes).
- **`ScalingListSticker`** (new) — the Wear M3 scaling `TransformingLazyColumn`: items scale + fade toward the curved edges via `SurfaceTransformation`/`transformedHeight`. New **Lists** group in `catalog.spec.json`.

Component stickers stay on the centred `@CatalogWearModes` frame; the transparent-background flip is a separate follow-up. Wear **dialogs** are a further follow-up.

> Note: 240 dp (`id:wearos_xl_round`) is the largest *standard* Wear round device. An exact 244 dp would need a named device added to the renderer's device table — the render pipeline doesn't support arbitrary `spec:` devices.

## Visual evidence

Diff bot renders `EdgeButtonSticker` and `ScalingListSticker` at all three breakpoints (192/227/240 round). EdgeButton settled at its `Large` band; scaling list shows the edge fade.

## Test plan

- `Build Samples` compiles; diff bot renders the 6 new variants (green).
- `jq` validates `catalog.spec.json`.
- After merge, the Design Artifacts run folds the breakpoint variants per full-screen component and includes the scaling sample.