### PR TITLE
feat(samples): transparent backgrounds for Wear component stickers

### DIFF
--- a/samples/design-catalog-wear-m3/src/main/kotlin/com/example/designcatalogwearm3/CatalogTheme.kt
+++ b/samples/design-catalog-wear-m3/src/main/kotlin/com/example/designcatalogwearm3/CatalogTheme.kt
@@ -1,44 +1,36 @@
 package com.example.designcatalogwearm3
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.wear.compose.material3.AppScaffold
 import androidx.wear.compose.material3.MaterialTheme
-import androidx.wear.compose.ui.tooling.preview.WearPreviewLargeRound
-import androidx.wear.compose.ui.tooling.preview.WearPreviewSmallRound
 
 /**
- * The catalog's sticker frame. Each component is centred on the stock Wear
- * [MaterialTheme] background, so the `compose/theme` token set the renderer
- * extracts is the **real** Wear Material 3 system (which is dark-first).
+ * The catalog's **component** sticker frame: a single component wrapped in the
+ * stock Wear [MaterialTheme] on a **transparent** background, cropped tight to the
+ * component. Transparency lets a designer drop the sticker onto any canvas; the
+ * `compose/theme` tokens the renderer extracts still come from the real Wear
+ * Material 3 system (read from the theme, not the pixels). Full-screen components
+ * use [FullScreenWear] instead, which keeps the black round device shape.
  */
 @Composable
 fun WearSticker(content: @Composable () -> Unit) {
   MaterialTheme {
-    Box(
-      Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background).padding(8.dp),
-      contentAlignment = Alignment.Center,
-    ) {
-      content()
-    }
+    Box(Modifier.padding(8.dp)) { content() }
   }
 }
 
 /**
- * The catalog's primary-mode multipreview. Wear is dark-first, so the primary
- * modes are the two round **size breakpoints** — small round and large round —
- * the Wear preview tooling ships, rather than a light/dark pair. Stacking this on
- * a component yields one capture per round size.
+ * The catalog's **component** multipreview: a single transparent capture, cropped
+ * to the component (no device frame — that's for full-screen components, see
+ * [CatalogWearBreakpoints]). `showBackground = false` keeps the background
+ * transparent so the sticker carries alpha.
  */
-@WearPreviewSmallRound
-@WearPreviewLargeRound
+@Preview(showBackground = false)
 annotation class CatalogWearModes
 
 /**


### PR DESCRIPTION
## Summary

Increment B of the Wear catalog model: **component** stickers get **transparent** backgrounds, cropped tight to the component, so a designer can drop them onto any canvas. **Full-screen** components keep the black round device shape (unchanged, via `FullScreenWear` + `@CatalogWearBreakpoints`).

- `WearSticker` drops its opaque background fill and full-screen `Box` → a tight, transparent wrap.
- `@CatalogWearModes` becomes a single `@Preview(showBackground = false)` instead of the two black round-device captures.
- Theme-token extraction is unaffected (the renderer reads `compose/theme` from the theme, not the pixels).

This is the sweeping-but-mechanical half of the background model the breakpoints PR (#2060) deferred — kept separate so its diff (every component sticker re-renders) stays reviewable.

## Visual evidence

The preview-diff bot re-renders all wear component stickers (buttons, selection, cards, text) — expect each to change from a black round-device shot to a transparent tight crop. Full-screen stickers (`EdgeButtonSticker`, `ScalingListSticker`) are unchanged. The catalog's `index.html` already renders component stickers on a checkerboard so the alpha reads.

## Test plan

- `Build Samples` compiles; diff bot shows the component stickers as transparent crops, full-screen ones unchanged.
- After merge, the Design Artifacts run emits transparent component PNGs; the HTML index's checkerboard surfaces the alpha.

---
_Generated by [Claude Code](https://claude.ai/code/session_017oE242kFmDN2ibrj44HiM3)_