### PR TITLE
feat(samples): blank Wear list-layout template at the breakpoints

### DIFF
--- a/samples/design-catalog-wear-m3/catalog.spec.json
+++ b/samples/design-catalog-wear-m3/catalog.spec.json
@@ -42,6 +42,12 @@
       ]
     },
     {
+      "name": "Layouts",
+      "components": [
+        { "componentId": "Layout/List", "preview": "BlankListLayout", "caption": "Blank list-screen skeleton at each breakpoint — adopt the responsive structure (margins, slots, edge button)." }
+      ]
+    },
+    {
       "name": "Communication",
       "components": [
         { "componentId": "Progress/Circular", "preview": "CircularProgressSticker" }

--- a/samples/design-catalog-wear-m3/src/main/kotlin/com/example/designcatalogwearm3/CatalogPreviews.kt
+++ b/samples/design-catalog-wear-m3/src/main/kotlin/com/example/designcatalogwearm3/CatalogPreviews.kt
@@ -187,7 +187,13 @@ fun ScalingListSticker() =
 // bounds/padding so the layout reads as a real spec, not just a picture.
 // ---------------------------------------------------------------------------
 
+// @ScrollingPreview(END): like EdgeButtonSticker, the ScreenScaffold edge button
+// is collapsed at the resting top and only reveals once the list settles at the
+// bottom — so the skeleton scrolls to the end (the renderer settles the reveal)
+// to actually show the edge-button slot. The slot count overflows the viewport on
+// every breakpoint so the button lands at its resting size.
 @CatalogWearBreakpoints
+@ScrollingPreview(modes = [ScrollMode.END])
 @Composable
 fun BlankListLayout() =
   FullScreenWear {
@@ -210,7 +216,7 @@ fun BlankListLayout() =
             Text("")
           }
         }
-        items(4) {
+        items(10) {
           TitleCard(
             onClick = {},
             title = { Text("") },

--- a/samples/design-catalog-wear-m3/src/main/kotlin/com/example/designcatalogwearm3/CatalogPreviews.kt
+++ b/samples/design-catalog-wear-m3/src/main/kotlin/com/example/designcatalogwearm3/CatalogPreviews.kt
@@ -180,6 +180,49 @@ fun ScalingListSticker() =
   }
 
 // ---------------------------------------------------------------------------
+// Layout templates — a blank skeleton of the common Wear list screen at every
+// breakpoint: empty ListHeader + TitleCard slots and an empty EdgeButton, no
+// content. Apps adopt the responsive structure (screen margins, slot sizing,
+// edge-button placement) at each size; the export's redlines annotate the slot
+// bounds/padding so the layout reads as a real spec, not just a picture.
+// ---------------------------------------------------------------------------
+
+@CatalogWearBreakpoints
+@Composable
+fun BlankListLayout() =
+  FullScreenWear {
+    val listState = rememberTransformingLazyColumnState()
+    val spec = rememberTransformationSpec()
+    ScreenScaffold(
+      scrollState = listState,
+      edgeButton = { EdgeButton(onClick = {}, buttonSize = EdgeButtonSize.Large) {} },
+    ) { contentPadding ->
+      TransformingLazyColumn(
+        state = listState,
+        contentPadding = contentPadding,
+        modifier = Modifier.fillMaxSize(),
+      ) {
+        item {
+          ListHeader(
+            modifier = Modifier.transformedHeight(this, spec),
+            transformation = SurfaceTransformation(spec),
+          ) {
+            Text("")
+          }
+        }
+        items(4) {
+          TitleCard(
+            onClick = {},
+            title = { Text("") },
+            modifier = Modifier.fillMaxWidth().transformedHeight(this, spec),
+            transformation = SurfaceTransformation(spec),
+          ) {}
+        }
+      }
+    }
+  }
+
+// ---------------------------------------------------------------------------
 // Selection controls.
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Adds a **blank layout template** to the Wear catalog — a starting point for "real sticker pack" adoption: an empty skeleton of the common Wear list screen rendered at every breakpoint, so an app can adopt the responsive structure (screen margins, slot sizing, edge-button placement) at each size.

- **`BlankListLayout`** — `FullScreenWear` + `ScreenScaffold` + `TransformingLazyColumn` with an empty `ListHeader`, empty `TitleCard` slots, and an empty `EdgeButton` (no content), at `@CatalogWearBreakpoints` (192/227/240 round). Reuses the proven full-screen pattern from #2060.
- New **Layouts** group in `catalog.spec.json`. The export's redlines annotate the slot bounds/padding, so the layout reads as a spec, not just a picture.

## Visual evidence

The preview-diff bot renders `BlankListLayout` at the three breakpoints. **I'll embed the actual rendered PNGs in this body once the diff bot publishes them** (per the visual-evidence rule in #2062) — they aren't available until CI renders, and I can't render Wear in this container. Expect: a black round screen with empty header + card slots and a blank edge button, at 192/227/240.

## Test plan

- `Build Samples` compiles; diff bot renders `BlankListLayout` ×3 breakpoints (I'll confirm + embed images).
- `jq` validates `catalog.spec.json`.
- After merge, the Design Artifacts run includes the blank layout template + its redlines.

---
_Generated by [Claude Code](https://claude.ai/code/session_017oE242kFmDN2ibrj44HiM3)_