### PR TITLE
feat(design-artifacts): editable SVG wireframes in the export bundle

### DIFF
--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -31,7 +31,7 @@
  * The caller (the weekly workflow) commits the result to the system's
  * `design-artifacts/<system>` branch.
  */
-import { readFile, writeFile } from "node:fs/promises";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, resolve, join } from "node:path";
 import { parseArgs } from "node:util";
 
@@ -39,6 +39,7 @@ import { readPreviewBundle, bundleToCandidates } from "@design-parity/candidate"
 import { buildCatalog, writeCatalog } from "@design-parity/catalog-export";
 
 import { renderIndexHtml } from "./render-index-html.mjs";
+import { renderWireframeSvg, slug } from "./render-wireframe-svg.mjs";
 
 /**
  * Read a preview bundle into CandidateRenders, resolving each candidate's
@@ -227,13 +228,27 @@ if (!values["allow-incomplete"] && (missing.length > 0 || withoutSemantics.lengt
 const sourceRoot = rendersPath.endsWith(".zip") ? dirname(rendersPath) : rendersPath;
 const result = await writeCatalog(catalog, outPath, { sourceRoot });
 
+// Editable SVG wireframes next to the raster PNGs: one labelled rect per
+// semantic region, in any-vector-tool-editable form, so a developer can adopt
+// the structure rather than trace a screenshot. Written under wireframes/<slug>.svg;
+// the index links them. Components with no drawable regions are skipped.
+const wireframesDir = join(outPath, "wireframes");
+await mkdir(wireframesDir, { recursive: true });
+let wireframeCount = 0;
+for (const component of catalog.components) {
+  const svg = renderWireframeSvg(component);
+  if (!svg) continue;
+  await writeFile(join(wireframesDir, `${slug(component.componentId)}.svg`), svg, "utf8");
+  wireframeCount += 1;
+}
+
 // Browsable index next to catalog.json + images/ — a designer can open this
-// straight from the branch to skim every component (and its a11y greenlines)
-// before importing the tokens/images into a design tool.
+// straight from the branch to skim every component (its a11y greenlines and the
+// editable wireframe) before importing the tokens/images into a design tool.
 const indexPath = join(outPath, "index.html");
 await writeFile(indexPath, renderIndexHtml(catalog), "utf8");
 
 console.log(
-  `[${spec.system}] ${catalog.components.length} component(s), ${result.imageCount} image(s) → ${result.manifestPath}`,
+  `[${spec.system}] ${catalog.components.length} component(s), ${result.imageCount} image(s), ${wireframeCount} wireframe(s) → ${result.manifestPath}`,
 );
 console.log(`[${spec.system}] index → ${indexPath}`);

--- a/scripts/design-artifacts/render-index-html.mjs
+++ b/scripts/design-artifacts/render-index-html.mjs
@@ -11,6 +11,8 @@
  * from the branch checkout. No external assets, no script — just inline CSS.
  */
 
+import { renderWireframeSvg, slug } from "./render-wireframe-svg.mjs";
+
 /** Minimal HTML-escape for text interpolated into the page. */
 function esc(s) {
   return String(s ?? "").replace(
@@ -19,12 +21,10 @@ function esc(s) {
   );
 }
 
-/** A stable anchor/id fragment from arbitrary text. */
-function slug(s) {
-  return String(s ?? "")
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/(^-|-$)/g, "");
+/** A link to the component's editable wireframe SVG, when one was generated. */
+function wireframeLink(component) {
+  if (!renderWireframeSvg(component)) return "";
+  return `<a class="wf" href="wireframes/${slug(component.componentId)}.svg" target="_blank" rel="noopener">wireframe ↗</a>`;
 }
 
 /** One representative image per component — the first `ideal` variant (largest
@@ -60,7 +60,7 @@ function componentCard(component) {
   ${figure}
   <div class="meta">
     <h3>${esc(id)}</h3>
-    <div class="sub">${esc(dims)}</div>
+    <div class="sub">${esc(dims)}${wireframeLink(component)}</div>
     ${greenlineChips(component)}
   </div>
 </article>`;
@@ -162,7 +162,9 @@ export function renderIndexHtml(catalog) {
   .shot--missing { color:var(--muted); font-style:italic; }
   .meta { padding:10px 12px 12px; border-top:1px solid var(--line); }
   .meta h3 { margin:0; font-size:13px; font-weight:600; word-break:break-word; }
-  .meta .sub { color:var(--muted); font-size:12px; margin-top:2px; }
+  .meta .sub { color:var(--muted); font-size:12px; margin-top:2px; display:flex; justify-content:space-between; gap:8px; }
+  .meta .sub .wf { color:#7dd87d; text-decoration:none; white-space:nowrap; }
+  .meta .sub .wf:hover { text-decoration:underline; }
   .greenlines { margin-top:8px; display:flex; flex-wrap:wrap; gap:4px; }
   .chip { font-size:11px; padding:1px 7px; border-radius:999px; border:1px solid var(--accent); color:var(--accent); }
   .chip--warn { border-color:#e0c060; color:#e0c060; }

--- a/scripts/design-artifacts/render-wireframe-svg.mjs
+++ b/scripts/design-artifacts/render-wireframe-svg.mjs
@@ -1,0 +1,104 @@
+/**
+ * Turn a catalog component's semantic regions into an **editable SVG wireframe**:
+ * one labelled `<rect>` per greenline (a11y region), positioned in the render's
+ * pixel space and coloured by role. Unlike the raster PNG, the SVG opens in any
+ * vector tool (Figma / Sketch / Illustrator / Penpot / Inkscape) as discrete,
+ * editable shapes — the layer a developer adopts to rebuild the structure.
+ *
+ * Pure + dependency-free, like render-index-html.mjs: takes the in-memory catalog
+ * component and returns an SVG string (or null when there's nothing to draw).
+ */
+
+/** Stable colour per semantic role; a hash fallback keeps unknown roles distinct. */
+const ROLE_COLORS = {
+  button: "#4f8cff",
+  checkbox: "#3fbf6f",
+  switch: "#a06bff",
+  radiobutton: "#3fbf6f",
+  image: "#e0a040",
+  text: "#9b9ba1",
+  edgebutton: "#4f8cff",
+  card: "#5bbcc8",
+  header: "#c87da0",
+};
+
+function roleColor(role) {
+  const key = String(role ?? "").toLowerCase().replace(/[^a-z]/g, "");
+  if (ROLE_COLORS[key]) return ROLE_COLORS[key];
+  let h = 0;
+  for (const c of key) h = (h * 31 + c.charCodeAt(0)) & 0xffff;
+  return `hsl(${h % 360} 55% 60%)`;
+}
+
+function esc(s) {
+  return String(s ?? "").replace(
+    /[&<>"']/g,
+    (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c],
+  );
+}
+
+/** Stable filename/anchor fragment from arbitrary text — shared by the driver
+ *  (where it writes `wireframes/<slug>.svg`) and the index (where it links it). */
+export function slug(s) {
+  return String(s ?? "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "");
+}
+
+/** The greenlines that carry a drawable rect. */
+function regions(component) {
+  return (component.greenlines ?? []).filter(
+    (g) => g.bounds && g.bounds.width > 0 && g.bounds.height > 0,
+  );
+}
+
+/**
+ * The canvas the region bounds live in. The regions come from one rendered
+ * variant, so prefer the smallest catalog image that contains every region (that
+ * variant's frame, margins included); fall back to the regions' own extent.
+ */
+function canvasFor(component, regs) {
+  const extW = Math.max(0, ...regs.map((g) => g.bounds.x + g.bounds.width));
+  const extH = Math.max(0, ...regs.map((g) => g.bounds.y + g.bounds.height));
+  const images = component.images ?? [];
+  const containing = images
+    .filter((i) => i.width >= extW && i.height >= extH)
+    .sort((a, b) => a.width * a.height - b.width * b.height)[0];
+  if (containing) return { w: containing.width, h: containing.height };
+  if (extW > 0 && extH > 0) return { w: extW, h: extH };
+  const largest = [...images].sort((a, b) => b.width * b.height - a.width * a.height)[0];
+  return largest ? { w: largest.width, h: largest.height } : null;
+}
+
+/**
+ * Render the component's wireframe SVG, or `null` if it has no drawable regions.
+ * @param {object} component a catalog component (componentId, greenlines, images)
+ * @returns {string|null}
+ */
+export function renderWireframeSvg(component) {
+  const regs = regions(component);
+  if (!regs.length) return null;
+  const canvas = canvasFor(component, regs);
+  if (!canvas) return null;
+
+  const shapes = regs
+    .map((g) => {
+      const role = g.detail?.role ?? g.message ?? "element";
+      const color = roleColor(role);
+      const { x, y, width, height } = g.bounds;
+      const labelY = y >= 18 ? y - 5 : y + 15;
+      return `  <g>
+    <rect x="${x}" y="${y}" width="${width}" height="${height}" rx="4" fill="${color}" fill-opacity="0.08" stroke="${color}" stroke-width="2"/>
+    <text x="${x + 4}" y="${labelY}" font-family="system-ui, sans-serif" font-size="12" fill="${color}">${esc(role)}</text>
+  </g>`;
+    })
+    .join("\n");
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${canvas.w} ${canvas.h}" width="${canvas.w}" height="${canvas.h}" role="img" aria-label="${esc(component.componentId)} wireframe">
+  <title>${esc(component.componentId)} — layout wireframe</title>
+  <rect width="${canvas.w}" height="${canvas.h}" fill="none" stroke="#888" stroke-dasharray="4 4"/>
+${shapes}
+</svg>
+`;
+}


### PR DESCRIPTION
## Summary

Wires **editable SVG wireframes** into the export bundle (your "import and edit" ask). Each catalog component now ships `wireframes/<slug>.svg` next to its raster PNG: one labelled, role-coloured `<rect>` per semantic region, positioned in the render's pixel space. Unlike the PNG, the SVG opens in any vector tool (Figma / Sketch / Illustrator / Penpot / Inkscape) as discrete, editable shapes. The `index.html` links each one.

- `render-wireframe-svg.mjs` — pure/dependency-free; catalog component → SVG string (or null when no drawable regions).
- Driver writes the SVGs after `writeCatalog`; index gets a `wireframe ↗` link per component.

**Scope note:** the regions come from the a11y **greenlines**, so simple components map cleanly (a button → its full bounds) but composite ones capture only the a11y control (a `SwitchButton` → the toggle, not the whole row). A richer, full-layout wireframe would need the complete `compose/semantics` tree threaded into the bundle — a follow-up. (And your live-render endpoint idea supersedes static wireframes for real editing.)

## Visual evidence

Generated from the real `wear-m3` catalog — left: the rendered `SwitchButton/On` PNG; middle: the wireframe regions overlaid; right: the standalone editable wireframe. Sent in the session.

## Test plan

- `node --check` on all three modules; validated against the live `wear-m3` `catalog.json`: 11/17 components produce a wireframe (6 have no a11y bounds and are skipped), 11 index links match 11 SVG files, 0 malformed SVGs.
- Data-plumbing change to the JS export driver — the wireframe sample (above) is the visual evidence.

---
_Generated by [Claude Code](https://claude.ai/code/session_017oE242kFmDN2ibrj44HiM3)_