### PR TITLE
fix(deploy): install Mesa software GL so Skiko renders headless

### DIFF
--- a/deploy/cloudrun/Dockerfile
+++ b/deploy/cloudrun/Dockerfile
@@ -22,8 +22,10 @@
 # ---------------------------------------------------------------------------
 # Both the build-stage warm render and the runtime server invoke Skiko, so the
 # native deps must live in BOTH — hence a shared base. Skiko dlopens libskiko,
-# which links libGL.so.1 (provided by Mesa here) and libX11 (pulled in by
-# libglx-mesa0); fontconfig + freetype + a font family give non-empty text. We
+# which links libGL.so.1 (owned by libgl1 — install it explicitly; the mesa
+# packages don't pull it on a minimal base) and libX11 (pulled in by
+# libglx-mesa0, which with libgl1-mesa-dri provides Mesa's software GLX/DRI);
+# fontconfig + freetype + a font family give non-empty text. We
 # rasterize on the CPU, so LIBGL_ALWAYS_SOFTWARE=1 forces Mesa's software path
 # (no GPU on the host). This mirrors what the repo's own CI installs for headless
 # desktop renders (.github/workflows/ci.yml).
@@ -31,7 +33,7 @@ FROM eclipse-temurin:17.0.18_8-jdk AS base
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
       libfreetype6 libfontconfig1 fontconfig fonts-dejavu-core \
-      libgl1-mesa-dri libglx-mesa0 \
+      libgl1 libglx-mesa0 libgl1-mesa-dri \
  && rm -rf /var/lib/apt/lists/*
 ENV LIBGL_ALWAYS_SOFTWARE=1 \
     GRADLE_USER_HOME=/root/.gradle \

--- a/deploy/cloudrun/Dockerfile
+++ b/deploy/cloudrun/Dockerfile
@@ -4,8 +4,9 @@
 #
 # What this serves: a long-lived HTTP server that renders the @Preview functions
 # of one Compose Multiplatform *Desktop* module (`:samples:cmp` by default) on
-# demand and returns PNGs. Desktop rendering uses Skiko software rasterization —
-# no Android SDK, no GPU, no X server.
+# demand and returns PNGs. Desktop rendering uses Skiko on a CPU raster surface —
+# no GPU and no X server/Xvfb, but Skiko's native lib is still dynamically linked
+# against libGL.so.1, so Mesa's software GL must be present (see the base stage).
 #
 # Why a fat image: `compose-preview serve` builds its module through the Gradle
 # Tooling API at startup and keeps a warm render daemon. So the runtime needs the
@@ -17,12 +18,29 @@
 # JDK with none of the JDK-17-vs-21 gymnastics docs/CLOUD-TESTING.md describes.
 
 # ---------------------------------------------------------------------------
+# Stage 0: base — JDK plus the native libraries Skiko needs to render.
+# ---------------------------------------------------------------------------
+# Both the build-stage warm render and the runtime server invoke Skiko, so the
+# native deps must live in BOTH — hence a shared base. Skiko dlopens libskiko,
+# which links libGL.so.1 (provided by Mesa here) and libX11 (pulled in by
+# libglx-mesa0); fontconfig + freetype + a font family give non-empty text. We
+# rasterize on the CPU, so LIBGL_ALWAYS_SOFTWARE=1 forces Mesa's software path
+# (no GPU on the host). This mirrors what the repo's own CI installs for headless
+# desktop renders (.github/workflows/ci.yml).
+FROM eclipse-temurin:17.0.18_8-jdk AS base
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      libfreetype6 libfontconfig1 fontconfig fonts-dejavu-core \
+      libgl1-mesa-dri libglx-mesa0 \
+ && rm -rf /var/lib/apt/lists/*
+ENV LIBGL_ALWAYS_SOFTWARE=1 \
+    GRADLE_USER_HOME=/root/.gradle \
+    SERVE_MODULE=:samples:cmp
+
+# ---------------------------------------------------------------------------
 # Stage 1: build the CLI distribution and warm the render path.
 # ---------------------------------------------------------------------------
-FROM eclipse-temurin:17.0.18_8-jdk AS build
-
-ENV GRADLE_USER_HOME=/root/.gradle \
-    SERVE_MODULE=:samples:cmp
+FROM base AS build
 
 WORKDIR /app
 
@@ -48,21 +66,9 @@ RUN ./gradlew --no-daemon :cli:installDist \
 # ---------------------------------------------------------------------------
 # Stage 2: runtime.
 # ---------------------------------------------------------------------------
-FROM eclipse-temurin:17.0.18_8-jdk AS runtime
+FROM base AS runtime
 
-# Skiko (Compose Desktop's renderer) needs fontconfig + freetype to lay out and
-# rasterize text, and at least one font family for non-empty glyphs. Without
-# these, text in rendered previews comes out blank.
-RUN apt-get update \
- && apt-get install -y --no-install-recommends \
-      libfreetype6 libfontconfig1 fontconfig fonts-dejavu-core \
- && rm -rf /var/lib/apt/lists/*
-
-ENV GRADLE_USER_HOME=/root/.gradle \
-    SERVE_MODULE=:samples:cmp \
-    # Scale-to-zero friendliness: shut the server down after this many idle
-    # seconds so Cloud Run's instance can be reclaimed. Tune via env / service.yaml.
-    SERVE_IDLE_EXIT=900 \
+ENV SERVE_IDLE_EXIT=900 \
     # JVM heap ceiling for the CLI process; the render daemon is a child JVM.
     JAVA_TOOL_OPTIONS="-XX:MaxRAMPercentage=70"
 


### PR DESCRIPTION
## Summary

The deploy image rendered **nothing** — every desktop preview failed with:

```
UnsatisfiedLinkError: …/libskiko-linux-x64.so: libGL.so.1: cannot open shared object file
```

Skiko (the Compose Desktop renderer) dlopens `libskiko`, which is dynamically linked against **`libGL.so.1`**. The image never installed it:
- the warm `--export` render runs in the **build stage**, which installed *no* native libs at all;
- the **runtime stage** installed fontconfig/freetype but **not** libGL — so real renders would have failed at runtime too.

This affected **all three deploy targets** (cloudrun, oracle, vps), surfaced while bringing up a real VPS.

### Fix
Add a shared `base` stage (JDK + native libs) used by **both** build and runtime:
- `libgl1-mesa-dri libglx-mesa0` — Mesa's software GL providing `libGL.so.1` (and pulling `libX11`), alongside the existing `libfreetype6 libfontconfig1 fontconfig fonts-dejavu-core`.
- `ENV LIBGL_ALWAYS_SOFTWARE=1` to force CPU software rendering (no GPU on these hosts).

No Xvfb/DISPLAY is needed — the desktop path is CPU raster (`ImageComposeScene`), which is how the repo's own CI renders desktop headless (`.github/workflows/ci.yml` installs the same `libgl1-mesa-dri libglx-mesa0` for its render jobs).

## Test plan

- Verified against a live failure: a Hetzner VPS build reached `BUILD SUCCESSFUL` then failed the warm render with the `libGL.so.1` error above; this adds exactly the missing libraries (matched to the packages the repo's CI uses for headless desktop rendering).
- Deploy/build plumbing — no app source or UI changes. Full end-to-end (a successful render PNG out of the running container) is being confirmed on the VPS rebuild now; will note the result on the PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KTCvmWWzVkkK3mUB6Ye7fH)_