### PR TITLE
fix(serve): retry coalesced renders, cap concurrency, bound frame time

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -3,6 +3,7 @@ package ee.schimke.composeai.cli.serve
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.daemon.protocol.StreamCodec
 import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.install
 import io.ktor.server.cio.CIO
@@ -25,6 +26,8 @@ import java.io.ByteArrayOutputStream
 import java.io.InputStream
 import java.net.InetAddress
 import java.net.ServerSocket
+import java.util.concurrent.Semaphore
+import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.Serializable
@@ -58,9 +61,18 @@ class ServeHttpServer(
   /** When non-null, enables `POST /bundles/{name}` for clients to contribute bundles at runtime. */
   private val bundleStore: ServeBundleStore? = null,
   portRange: Int = DEFAULT_PORT_RANGE,
+  /**
+   * Max renders in flight across the HTTP `/render` lane. Defaults to the host's CPU count so a
+   * small box (1–2 vCPU) sheds a render storm instead of thrashing; excess requests wait briefly
+   * for a slot, then get `503 + Retry-After`. Renders also serialise inside [ServeRenderHost], so
+   * this is a load-shedding bound on concurrent HTTP work, not a parallel-render knob.
+   */
+  maxConcurrentRenders: Int = Runtime.getRuntime().availableProcessors().coerceAtLeast(1),
 ) {
   /** The actual bound port — may differ from the requested one if it was taken (auto-picked). */
   val port: Int = pickPort(host, requestedPort, portRange)
+
+  private val renderSemaphore = Semaphore(maxConcurrentRenders.coerceAtLeast(1))
 
   private val server: EmbeddedServer<*, *> =
     embeddedServer(CIO, host = host, port = port) {
@@ -297,9 +309,29 @@ class ServeHttpServer(
                 call.respondText(parsed.message, status = HttpStatusCode.BadRequest)
               is OverrideParse.Ok -> {
                 // The render is blocking (renderNow + await); keep it off the request dispatcher.
+                // Cap concurrent renders (default = CPU count) so a small box sheds a storm instead
+                // of thrashing: wait briefly for a slot, else 503 + Retry-After. A null outcome
+                // signals the wait timed out.
                 val outcome =
-                  withContext(Dispatchers.IO) { renderHost.render(previewId, parsed.overrides) }
+                  withContext(Dispatchers.IO) {
+                    if (!renderSemaphore.tryAcquire(RENDER_QUEUE_WAIT_SECONDS, TimeUnit.SECONDS)) {
+                      null
+                    } else {
+                      try {
+                        renderHost.render(previewId, parsed.overrides)
+                      } finally {
+                        renderSemaphore.release()
+                      }
+                    }
+                  }
                 when (outcome) {
+                  null -> {
+                    call.response.headers.append(HttpHeaders.RetryAfter, "2")
+                    call.respondText(
+                      "render queue saturated; retry shortly",
+                      status = HttpStatusCode.ServiceUnavailable,
+                    )
+                  }
                   is RenderOutcome.Ok -> call.respondBytes(outcome.png, ContentType.Image.PNG)
                   RenderOutcome.NotFound ->
                     call.respondText("no such preview", status = HttpStatusCode.NotFound)
@@ -357,6 +389,11 @@ class ServeHttpServer(
   companion object {
     const val TOKEN_HEADER: String = "X-Compose-Preview-Token"
     private const val DEFAULT_PORT_RANGE = 32
+
+    /**
+     * How long a `/render` request waits for a concurrency slot before getting 503 + Retry-After.
+     */
+    private const val RENDER_QUEUE_WAIT_SECONDS = 30L
 
     /** Max accepted upload-body size for `POST /bundles` (matches the store's extraction cap). */
     private const val MAX_UPLOAD_BYTES = 100L * 1024 * 1024

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
@@ -87,6 +87,7 @@ internal constructor(
   private val fileSystem: FileSystem = SystemFileSystem,
   private val onLog: (String) -> Unit = {},
   private val renderTimeoutSeconds: Long = RENDER_TIMEOUT_SECONDS,
+  private val frameRenderTimeoutSeconds: Long = FRAME_RENDER_TIMEOUT_SECONDS,
 ) : ServeHost {
 
   private val previewIds: Set<String> = previews.map { it.id }.toHashSet()
@@ -116,6 +117,12 @@ internal constructor(
   // order per session (the S4 harness tests assert none are lost / reordered), so we drain exactly
   // one outstanding event per timed-out render here before honouring a fresh one.
   private val staleRenders = ConcurrentHashMap<String, Int>()
+
+  // The first render after the session opens pays Skiko/JVM cold start, so it gets the generous
+  // [renderTimeoutSeconds] budget; once one render has succeeded, each subsequent frame is capped
+  // at
+  // [frameRenderTimeoutSeconds] so a single wedged render can't hold the only render slot.
+  private val warmedUp = AtomicBoolean(false)
 
   // Fans one upstream daemon stream out to all watchers of the same preview/overrides/codec/fps, so
   // many browsers cost one held session instead of one each. Built on [startStream]; shared because
@@ -154,40 +161,59 @@ internal constructor(
         return@withLock RenderOutcome.Ok(it)
       }
 
-      val latch = CountDownLatch(1)
-      pendingLatch.set(latch)
-      pendingPreviewId.set(previewId)
-      pendingPngPath.set(null)
+      // The daemon coalesces an override-bearing `renderNow` whose previewId already has one in
+      // flight, expecting the client to resubmit once it clears. Because the daemon clears that
+      // flag
+      // on (just after) `renderFinished`, the very next serialised render here can momentarily race
+      // the not-yet-cleared flag and get rejected. Honour the daemon's retry contract with a
+      // bounded
+      // backoff instead of surfacing it to the browser as a 500.
+      var attempt = 0
+      while (true) {
+        val latch = CountDownLatch(1)
+        pendingLatch.set(latch)
+        pendingPreviewId.set(previewId)
+        pendingPngPath.set(null)
 
-      val ack =
-        try {
-          session.renderNow(
-            previewIds = listOf(previewId),
-            reason = "serve",
-            overrides = overrides,
-            timeout = RENDER_ACK_TIMEOUT,
-          )
-        } catch (e: RenderSessionException) {
-          val reason = "renderNow failed: ${e.message}"
+        val ack =
+          try {
+            session.renderNow(
+              previewIds = listOf(previewId),
+              reason = "serve",
+              overrides = overrides,
+              timeout = RENDER_ACK_TIMEOUT,
+            )
+          } catch (e: RenderSessionException) {
+            val reason = "renderNow failed: ${e.message}"
+            onLog(reason)
+            return@withLock RenderOutcome.Failed(reason)
+          }
+
+        val rejected = ack.rejected.firstOrNull { it.id == previewId }
+        if (rejected != null) {
+          if (rejected.reason.startsWith("coalesced") && attempt++ < MAX_COALESCED_RETRIES) {
+            Thread.sleep(COALESCED_RETRY_BACKOFF_MS)
+            continue
+          }
+          val reason = "render rejected: ${rejected.reason}"
           onLog(reason)
           return@withLock RenderOutcome.Failed(reason)
         }
 
-      ack.rejected
-        .firstOrNull { it.id == previewId }
-        ?.let {
-          val reason = "render rejected: ${it.reason}"
+        // Cold start gets the generous budget; every frame after the first is capped so a wedged
+        // render can't pin the slot.
+        val budget = if (warmedUp.get()) frameRenderTimeoutSeconds else renderTimeoutSeconds
+        if (!latch.await(budget, TimeUnit.SECONDS)) {
+          // The daemon still owes this queued render a `renderFinished`; record it so the late
+          // event
+          // is drained instead of completing a future same-id render with a stale PNG.
+          staleRenders.merge(previewId, 1, Int::plus)
+          val reason = "timed out after ${budget}s waiting for render"
           onLog(reason)
           return@withLock RenderOutcome.Failed(reason)
         }
-
-      if (!latch.await(renderTimeoutSeconds, TimeUnit.SECONDS)) {
-        // The daemon still owes this queued render a `renderFinished`; record it so the late event
-        // is drained instead of completing a future same-id render with a stale PNG.
-        staleRenders.merge(previewId, 1, Int::plus)
-        val reason = "timed out after ${renderTimeoutSeconds}s waiting for render"
-        onLog(reason)
-        return@withLock RenderOutcome.Failed(reason)
+        warmedUp.set(true)
+        break
       }
 
       val path = pendingPngPath.get()
@@ -357,8 +383,19 @@ internal constructor(
     /** RPC ack budget for the (fast, queue-only) `renderNow` call itself. */
     private val RENDER_ACK_TIMEOUT = 60.seconds
 
-    /** Per-render budget for the queued render to emit `renderFinished` (first pays cold start). */
+    /** Cold-start render budget — the first render pays Skiko/JVM warm-up. */
     private const val RENDER_TIMEOUT_SECONDS = 180L
+
+    /** Per-frame render budget once warm; a wedged render can't hold the slot past this. */
+    private const val FRAME_RENDER_TIMEOUT_SECONDS = 10L
+
+    /**
+     * Bounded retries when the daemon coalesces an override-bearing render already in flight. The
+     * window only needs to outlast the daemon clearing its in-flight flag right after
+     * `renderFinished`, so a handful of short backoffs is ample.
+     */
+    private const val MAX_COALESCED_RETRIES = 50
+    private const val COALESCED_RETRY_BACKOFF_MS = 100L
 
     private const val MAX_CACHE_ENTRIES = 256
 

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/FakeRenderSession.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/FakeRenderSession.kt
@@ -62,8 +62,14 @@ internal class FakeRenderSession(
   private val heldSession: Boolean = true,
   /** When set, [streamStart] emits a keyframe with this base64 payload *before* it returns. */
   private val emitKeyframeOnStart: String? = null,
+  /**
+   * Reject the first N override-bearing [renderNow]s with the daemon's `coalesced` reason (then
+   * serve normally), modelling the override-in-flight coalescing the serve host must retry through.
+   */
+  private val coalescedOverrideRejections: Int = 0,
 ) : RenderSession {
   val renderCount = AtomicInteger(0)
+  private val coalesceRemaining = AtomicInteger(coalescedOverrideRejections)
   private val listeners = CopyOnWriteArrayList<NotificationListener>()
   private val counter = AtomicInteger(0)
 
@@ -155,6 +161,18 @@ internal class FakeRenderSession(
     val id = previewIds.single()
     if (rejectAll) {
       return RenderNowResult(queued = emptyList(), rejected = listOf(RejectedRender(id, "nope")))
+    }
+    if (overrides != null && coalesceRemaining.getAndUpdate { (it - 1).coerceAtLeast(0) } > 0) {
+      return RenderNowResult(
+        queued = emptyList(),
+        rejected =
+          listOf(
+            RejectedRender(
+              id,
+              "coalesced: override-bearing render already in flight for this previewId",
+            )
+          ),
+      )
     }
     val hook = renderHook
     if (hook != null) {

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHostTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHostTest.kt
@@ -84,6 +84,19 @@ class ServeRenderHostTest {
   }
 
   @Test
+  fun `a coalesced override render is retried until accepted, not failed`() {
+    // The daemon coalesce-rejects an override-bearing render whose previewId is already in flight,
+    // expecting the client to resubmit. ServeRenderHost must retry rather than surface a 500.
+    val session = FakeRenderSession(newRenderRoot(), coalescedOverrideRejections = 2)
+    host(session).use { h ->
+      val outcome = h.render(previewId, PreviewOverrides(uiMode = UiMode.DARK))
+      assertTrue(outcome is RenderOutcome.Ok, "coalesced rejections must be retried until accepted")
+      // 2 coalesced rejections + 1 accepted render = 3 renderNow calls.
+      assertEquals(3, session.renderCount.get())
+    }
+  }
+
+  @Test
   fun `a late renderFinished from a timed-out render does not corrupt the next render`() {
     // Render 1 emits nothing → it times out (the daemon still owes a late renderFinished). Render 2
     // (the daemon catching up) emits the timed-out render's STALE event first, then its own FRESH

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -1180,10 +1180,6 @@ class JsonRpcServer(
     val isUnchanged =
       frameHash != null && lastFrameHashes[previewId] == frameHash && firstRenderFinishedSeen.get()
     val outboundFinished = if (isUnchanged) finished.copy(unchanged = true) else finished
-    // Clear the override-in-flight flag BEFORE announcing renderFinished so a client that resubmits
-    // the instant it sees the notification (e.g. the serve HTTP lane re-requesting the same <img>)
-    // can't lose a race against the not-yet-cleared flag and get its render coalesced-rejected.
-    previewIdsWithOverridesInFlight.remove(previewId)
     sendNotification("renderFinished", encode(RenderFinishedParams.serializer(), outboundFinished))
     // Live-frame streaming (`composestream/1`). The streaming layer is a *consumer* of the
     // renderFinished above, not a replacement for it: legacy clients keep painting via
@@ -1223,7 +1219,11 @@ class JsonRpcServer(
     // that skip, so a truly-redundant frame still emits no `historyAdded` and adds no sidecar.
     recordHistoryForRender(previewId = previewId, result = result, finished = finished)
     inFlightRenders.remove(result.id)
-    // previewIdsWithOverridesInFlight is cleared above, before renderFinished is sent.
+    // Cleared only after the frame's history/data-product snapshot above, so the next same-preview
+    // render can't overwrite per-preview artifacts before this frame's sidecar is recorded. The
+    // brief window where this flag stays set after renderFinished is covered by the serve host's
+    // bounded coalesced-retry (ServeRenderHost), so no client loses a render to it.
+    previewIdsWithOverridesInFlight.remove(previewId)
     // D3 — wake any `data/fetch` waiter that queued this render. The waiter re-invokes
     // `dataProducts.fetch` to materialise the payload. We complete the future regardless of
     // dedup (`unchanged: true`): the producer's payload may have changed even when the bytes

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -1180,6 +1180,10 @@ class JsonRpcServer(
     val isUnchanged =
       frameHash != null && lastFrameHashes[previewId] == frameHash && firstRenderFinishedSeen.get()
     val outboundFinished = if (isUnchanged) finished.copy(unchanged = true) else finished
+    // Clear the override-in-flight flag BEFORE announcing renderFinished so a client that resubmits
+    // the instant it sees the notification (e.g. the serve HTTP lane re-requesting the same <img>)
+    // can't lose a race against the not-yet-cleared flag and get its render coalesced-rejected.
+    previewIdsWithOverridesInFlight.remove(previewId)
     sendNotification("renderFinished", encode(RenderFinishedParams.serializer(), outboundFinished))
     // Live-frame streaming (`composestream/1`). The streaming layer is a *consumer* of the
     // renderFinished above, not a replacement for it: legacy clients keep painting via
@@ -1219,7 +1223,7 @@ class JsonRpcServer(
     // that skip, so a truly-redundant frame still emits no `historyAdded` and adds no sidecar.
     recordHistoryForRender(previewId = previewId, result = result, finished = finished)
     inFlightRenders.remove(result.id)
-    previewIdsWithOverridesInFlight.remove(previewId)
+    // previewIdsWithOverridesInFlight is cleared above, before renderFinished is sent.
     // D3 — wake any `data/fetch` waiter that queued this render. The waiter re-invokes
     // `dataProducts.fetch` to materialise the payload. We complete the future regardless of
     // dedup (`unchanged: true`): the producer's payload may have changed even when the bytes


### PR DESCRIPTION
## Summary

The live `serve` `/render` path returned **HTTP 500** whenever two override-bearing renders for the same `previewId` overlapped. The daemon coalesce-rejects the duplicate (`coalesced: override-bearing render already in flight for this previewId`), expecting the client to resubmit on the next `renderFinished` — but `ServeRenderHost` surfaced that rejection as a terminal `RenderOutcome.Failed` → 500. A browser re-requesting an ``'&lt;img src=/render/...?fontScale=1.2&gt;'`` mid-render hit this on essentially every page load (found while hosting a live desktop preview server).

The render itself succeeds; only the *coalesced duplicate* failed. `attachments=[]` in the daemon logs was a red herring (data-product attachments, not the image).

### Changes
- **`ServeRenderHost` — retry coalesced, don't 500.** A `coalesced` rejection is now bounded-retried (50 × 100 ms) instead of failing, honoring the daemon's documented "resubmit on `renderFinished`" contract. This is the actual fix.
- **`ServeRenderHost` — per-frame 10s timeout, cold-start aware.** The first render keeps the generous 180s cold-start budget; once warm, each frame is capped at `FRAME_RENDER_TIMEOUT_SECONDS = 10s` so a wedged render can't pin the single render slot.
- **`ServeHttpServer` — hardware-sized concurrency cap.** A `Semaphore` defaulting to `availableProcessors()` bounds concurrent `/render` work; excess requests wait up to 30s for a slot, then get **503 + `Retry-After`**. Auto-sizes from hardware (1–2 vCPU → 1–2), so a small box sheds a render storm instead of thrashing.
- **Tests.** `FakeRenderSession` can now model `coalesced` rejections; `ServeRenderHostTest` asserts a coalesced render is **retried to `Ok`**, not failed — closing a real gap (the fake previously couldn't reproduce the coalescing race, so the live `/render` coalescing path had zero coverage).

> Note: an earlier commit reordered the daemon's `previewIdsWithOverridesInFlight` clear to before `renderFinished`; that was reverted (per review) because it opened the next render window before the frame's history/data-product snapshot completed. The daemon keeps its original frame-snapshot serialization, and the serve-side bounded retry covers the brief post-`renderFinished` window on its own.

## Test plan
- `./gradlew :daemon:core:compileKotlin :cli:compileKotlin :cli:compileTestKotlin` — green.
- `./gradlew :cli:test --tests "ee.schimke.composeai.cli.serve.ServeRenderHostTest"` — green (incl. the new `a coalesced override render is retried until accepted, not failed`).
- `:cli:ktfmtFormat` / `:daemon:core:ktfmtFormat` applied.
- Not a UI change — no rendered-output diff applies (this is serve/daemon plumbing).

Reproduced from a live desktop `serve` deployment; this is the fix for the per-`<img>` 500s on concurrent/retried override renders.