### PR TITLE
feat(deploy): auto-update the prebuilt image via Watchtower

### DIFF
--- a/deploy/image/README.md
+++ b/deploy/image/README.md
@@ -54,6 +54,34 @@ DOMAIN=preview.example.com ./setup.sh
 
 Pin a version with `IMAGE_TAG=0.16.1` in `.env` (defaults to `:latest`).
 
+## Auto-updates (Watchtower)
+
+`docker-compose.yml` includes a [Watchtower](https://containrrr.dev/watchtower/)
+service that **watches the `:latest` tag and updates the `preview` container when a
+new release image is published** — so the chain is hands-off:
+
+> merge → cut a `v*` release → `preview-host-image.yml` publishes `:latest` →
+> Watchtower pulls it → server updates
+
+It polls hourly (`--interval 3600`), is scoped to the labelled `preview` service
+(`--label-enable`, so it leaves Caddy alone), and `--cleanup` prunes the old image.
+It needs the Docker socket (root-equivalent on the host — fine for your own box).
+
+Requirements / options:
+- **Keep `IMAGE_TAG` at `:latest`** — Watchtower only tracks a moving tag. A pinned
+  `IMAGE_TAG=0.16.2` won't auto-update (by design).
+- **Brief downtime on update:** recreating `preview` restarts it (a ~1 min window
+  where it does its startup render and Caddy 502s), then it's back. Fine for a
+  single-instance host; not zero-downtime.
+- **Private GHCR package:** mount registry creds — add
+  `- ~/.docker/config.json:/config.json:ro` to the `watchtower` service (after
+  `docker login ghcr.io`). Public packages need nothing.
+- **Notify instead of auto-update:** add `--monitor-only` to the `command` (plus a
+  [shoutrrr](https://containrrr.dev/shoutrrr/) `WATCHTOWER_NOTIFICATION_URL`) to get
+  pinged on a new version and pull manually.
+- **Don't want it at all:** comment out the `watchtower` service and update by hand
+  with `docker compose pull && docker compose up -d`.
+
 ### Even simpler (no Caddy/TLS — quick test)
 
 ```bash
@@ -71,7 +99,7 @@ docker run -d --restart always -p 8080:8080 \
 | `Dockerfile` | Downloads the released CLI, warm-renders `sample-project/`. |
 | `sample-project/` | Self-contained Compose Desktop module (foundation-only previews) + Gradle wrapper. Applies the published plugin via auto-inject. |
 | `entrypoint.sh` | Maps `$PORT`/`$SERVE_TOKEN` onto serve flags; generous `--timeout`. |
-| `docker-compose.yml` + `Caddyfile` | Pull the image + Caddy auto-HTTPS. |
+| `docker-compose.yml` + `Caddyfile` | Pull the image + Caddy auto-HTTPS + Watchtower auto-updates. |
 | `setup.sh` | Install Docker, write `.env`, pull + start. |
 
 ## Serving a different project

--- a/deploy/image/README.md
+++ b/deploy/image/README.md
@@ -52,7 +52,8 @@ DOMAIN=preview.example.com ./setup.sh
 `docker compose pull && up -d` — **no build**. It prints your
 `https://preview.example.com/?token=<TOKEN>` link once Caddy has a cert.
 
-Pin a version with `IMAGE_TAG=0.16.1` in `.env` (defaults to `:latest`).
+Pin a version with `IMAGE_TAG=0.16.1` in `.env` (a bare tag; defaults to the
+`latest` tag when unset).
 
 ## Auto-updates (Watchtower)
 
@@ -68,8 +69,10 @@ It polls hourly (`--interval 3600`), is scoped to the labelled `preview` service
 It needs the Docker socket (root-equivalent on the host — fine for your own box).
 
 Requirements / options:
-- **Keep `IMAGE_TAG` at `:latest`** — Watchtower only tracks a moving tag. A pinned
-  `IMAGE_TAG=0.16.2` won't auto-update (by design).
+- **Leave `IMAGE_TAG` unset (it defaults to the `latest` tag)** — Watchtower only
+  tracks a moving tag. A pinned `IMAGE_TAG=0.16.2` won't auto-update (by design).
+  The value is a bare tag like `latest`, not `:latest` — the compose image string
+  already supplies the colon (`…host:${IMAGE_TAG:-latest}`).
 - **Brief downtime on update:** recreating `preview` restarts it (a ~1 min window
   where it does its startup render and Caddy 502s), then it's back. Fine for a
   single-instance host; not zero-downtime.

--- a/deploy/image/docker-compose.yml
+++ b/deploy/image/docker-compose.yml
@@ -3,11 +3,11 @@
 # Set DOMAIN + SERVE_TOKEN in .env (setup.sh writes one), then:
 #   docker compose up -d
 #
-# Pin a version with IMAGE_TAG=0.16.1 in .env; defaults to :latest.
+# Pin a version with IMAGE_TAG=0.16.1 in .env (a bare tag); defaults to the latest tag.
 #
 # Auto-updates: the optional `watchtower` service (below) watches the :latest tag
 # and pulls + recreates `preview` when a new release image is published. Leave
-# IMAGE_TAG at :latest for that to work. See README.md ("Auto-updates").
+# IMAGE_TAG unset (it defaults to `latest`) for that to work. See README.md.
 services:
   preview:
     image: "ghcr.io/yschimke/compose-preview-host:${IMAGE_TAG:-latest}"

--- a/deploy/image/docker-compose.yml
+++ b/deploy/image/docker-compose.yml
@@ -4,6 +4,10 @@
 #   docker compose up -d
 #
 # Pin a version with IMAGE_TAG=0.16.1 in .env; defaults to :latest.
+#
+# Auto-updates: the optional `watchtower` service (below) watches the :latest tag
+# and pulls + recreates `preview` when a new release image is published. Leave
+# IMAGE_TAG at :latest for that to work. See README.md ("Auto-updates").
 services:
   preview:
     image: "ghcr.io/yschimke/compose-preview-host:${IMAGE_TAG:-latest}"
@@ -17,6 +21,21 @@ services:
       - "8080"
     # The baked warm cache makes renders incremental; this just caps a render storm.
     mem_limit: 4g
+    # Opt this service in to Watchtower auto-updates (caddy is intentionally left out).
+    labels:
+      com.centurylinklabs.watchtower.enable: "true"
+
+  # Auto-update: poll GHCR for a new :latest digest and recreate `preview` when the
+  # release workflow publishes one. --label-enable scopes it to the labelled service
+  # above; --cleanup prunes the superseded image. Comment this service out to manage
+  # updates manually (docker compose pull && up -d). For a private GHCR package, mount
+  # a registry config: `- ~/.docker/config.json:/config.json:ro`. See README.md.
+  watchtower:
+    image: containrrr/watchtower
+    restart: always
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    command: --label-enable --cleanup --interval 3600
 
   caddy:
     image: caddy:2


### PR DESCRIPTION
## Summary

Makes the hosted preview server **self-update** when a new release image is published. Adds a [Watchtower](https://containrrr.dev/watchtower/) service to `deploy/image/docker-compose.yml` that watches the `:latest` tag and recreates the `preview` container on a new digest, so the whole pipeline is hands-off:

> merge → cut a `v*` release → `preview-host-image.yml` publishes `:latest` → Watchtower pulls it → host updates

- Scoped to the labelled `preview` service (`--label-enable`; Caddy is intentionally left out), polls hourly (`--interval 3600`), `--cleanup` prunes the superseded image. Mounts the Docker socket (root-equivalent on the host — fine for a single-owner box).
- `preview` gets `com.centurylinklabs.watchtower.enable: "true"`.
- README gains an **Auto-updates** section: keep `IMAGE_TAG=:latest` (Watchtower only tracks a moving tag), the brief recreate downtime (~1 min, Caddy 502s then back), private-GHCR creds mount, `--monitor-only` notify-instead-of-update mode, and how to opt out (comment the service, update manually).

## Test plan

- Deploy/build plumbing only — no app source or UI changes.
- Validated: `docker-compose.yml` parses and `docker compose config` resolves with the new `watchtower` service + the `preview` label.
- **Not** validated end-to-end: an actual Watchtower update cycle (needs a live host + a second published image). Behavior is the standard Watchtower `--label-enable` flow.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KTCvmWWzVkkK3mUB6Ye7fH)_