### PR TITLE
feat: editable preview overrides for plain Compose, carried in bundles and served

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -158,7 +158,8 @@ dependencies {
   // Renderer-agnostic daemon core helpers that are safe to use as a local library from CLI
   // commands. Keep renderer backends (`:daemon:android`, `:daemon:desktop`) out of this module.
   implementation(project(":daemon:core"))
-  // Wire-shape of the `compose/overrides` data product (`PreviewOverrideDeclaration`) — the editable
+  // Wire-shape of the `compose/overrides` data product (`PreviewOverrideDeclaration`) — the
+  // editable
   // knobs `compose-preview serve` reads from a bundle's `previews/<id>.overrides.json` sidecar to
   // present controls. Pure JVM (depends only on `:daemon:core`), not a renderer artifact.
   implementation(project(":data-preview-overrides-core"))

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -158,6 +158,10 @@ dependencies {
   // Renderer-agnostic daemon core helpers that are safe to use as a local library from CLI
   // commands. Keep renderer backends (`:daemon:android`, `:daemon:desktop`) out of this module.
   implementation(project(":daemon:core"))
+  // Wire-shape of the `compose/overrides` data product (`PreviewOverrideDeclaration`) — the editable
+  // knobs `compose-preview serve` reads from a bundle's `previews/<id>.overrides.json` sidecar to
+  // present controls. Pure JVM (depends only on `:daemon:core`), not a renderer artifact.
+  implementation(project(":data-preview-overrides-core"))
   // Public render-session library — the CLI consumes its own published API for daemon-driven
   // commands (`compose-preview a11y` etc.) instead of touching DaemonClient directly. We eat
   // our own dog food: anything the CLI can do, a third-party tooling consumer can do via the

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
@@ -3,7 +3,9 @@ package ee.schimke.composeai.cli.serve
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.daemon.protocol.StreamCodec
 import ee.schimke.composeai.daemon.protocol.StreamFrameParams
+import ee.schimke.composeai.data.overrides.PreviewOverridesPayload
 import java.io.File
+import kotlinx.serialization.json.Json
 
 /**
  * A [ServeHost] backed by a **portable bundle** on disk (the `ServeBundle` / WebEmbed layout:
@@ -27,8 +29,27 @@ class ServeBundleHost(private val bundleDir: File, override val label: String) :
       .filter { it.isFile && it.name.endsWith(PNG_SUFFIX) }
       .map { it.relativeTo(previewsDir).invariantSeparatorsPath.removeSuffix(PNG_SUFFIX) }
       .sorted()
-      .map { id -> ServePreview(id = id, label = id) }
+      .map { id -> ServePreview(id = id, label = id, overrides = readOverrides(id)) }
       .toList()
+
+  /**
+   * Read the editable knobs carried for [id] in the bundle's `previews/<id>.overrides.json` sidecar
+   * (the `compose/overrides` payload the producer packed). Absent / unreadable → no knobs. The host
+   * can't re-render (it replays baked PNGs), so [canApplyOverrides] stays false and the viewer shows
+   * these as disabled, informational controls.
+   */
+  private fun readOverrides(
+    id: String
+  ): List<ee.schimke.composeai.data.overrides.PreviewOverrideDeclaration> {
+    val sidecar = File(previewsDir, "$id$OVERRIDES_SUFFIX")
+    if (!sidecar.isFile) return emptyList()
+    return try {
+      OVERRIDES_JSON.decodeFromString(PreviewOverridesPayload.serializer(), sidecar.readText())
+        .declarations
+    } catch (e: Exception) {
+      emptyList()
+    }
+  }
 
   private val previewIds: Set<String> = previews.map { it.id }.toHashSet()
 
@@ -59,6 +80,8 @@ class ServeBundleHost(private val bundleDir: File, override val label: String) :
   companion object {
     private const val PREVIEWS_SUBDIR = "previews"
     private const val PNG_SUFFIX = ".png"
+    private const val OVERRIDES_SUFFIX = ".overrides.json"
+    private val OVERRIDES_JSON = Json { ignoreUnknownKeys = true }
 
     /** True when [dir] looks like a servable bundle (a `previews/` tree with at least one PNG). */
     fun looksLikeBundle(dir: File): Boolean {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
@@ -35,8 +35,8 @@ class ServeBundleHost(private val bundleDir: File, override val label: String) :
   /**
    * Read the editable knobs carried for [id] in the bundle's `previews/<id>.overrides.json` sidecar
    * (the `compose/overrides` payload the producer packed). Absent / unreadable → no knobs. The host
-   * can't re-render (it replays baked PNGs), so [canApplyOverrides] stays false and the viewer shows
-   * these as disabled, informational controls.
+   * can't re-render (it replays baked PNGs), so [canApplyOverrides] stays false and the viewer
+   * shows these as disabled, informational controls.
    */
   private fun readOverrides(
     id: String

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleStore.kt
@@ -119,8 +119,10 @@ class ServeBundleStore(
       while (entry != null) {
         val name = entry.name.replace('\\', '/')
         val segments = name.split("/")
-        // Keep the baked PNGs (the servable images) and, since v8, the per-preview override sidecars
-        // (`previews/<id>.overrides.json`) so a served bundle can present its declared editable knobs.
+        // Keep the baked PNGs (the servable images) and, since v8, the per-preview override
+        // sidecars
+        // (`previews/<id>.overrides.json`) so a served bundle can present its declared editable
+        // knobs.
         val underPreviews = name.startsWith("$PREVIEWS_SUBDIR/") && ".." !in segments
         val isPng = underPreviews && name.endsWith(PNG_SUFFIX)
         val isOverrides = underPreviews && name.endsWith(OVERRIDES_SUFFIX)

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleStore.kt
@@ -119,12 +119,12 @@ class ServeBundleStore(
       while (entry != null) {
         val name = entry.name.replace('\\', '/')
         val segments = name.split("/")
-        val keep =
-          !entry.isDirectory &&
-            name.startsWith("$PREVIEWS_SUBDIR/") &&
-            name.endsWith(PNG_SUFFIX) &&
-            ".." !in segments
-        if (keep) {
+        // Keep the baked PNGs (the servable images) and, since v8, the per-preview override sidecars
+        // (`previews/<id>.overrides.json`) so a served bundle can present its declared editable knobs.
+        val underPreviews = name.startsWith("$PREVIEWS_SUBDIR/") && ".." !in segments
+        val isPng = underPreviews && name.endsWith(PNG_SUFFIX)
+        val isOverrides = underPreviews && name.endsWith(OVERRIDES_SUFFIX)
+        if (!entry.isDirectory && (isPng || isOverrides)) {
           val target = File(dir, name)
           // Zip-slip guard: the resolved path must stay under the bundle dir.
           if (target.canonicalFile.toPath().startsWith(rootPath)) {
@@ -132,7 +132,9 @@ class ServeBundleStore(
             // Copy in bounded chunks so a huge / zip-bomb entry can't be fully allocated before the
             // cap rejects it — abort the moment the running total crosses maxBytes.
             total += copyCapped(zin, target, remaining = maxBytes - total)
-            count++
+            // Only PNGs count toward "does this bundle have any servable previews?" — an override
+            // sidecar without a PNG isn't a renderable preview.
+            if (isPng) count++
           }
         }
         zin.closeEntry()
@@ -161,6 +163,7 @@ class ServeBundleStore(
   companion object {
     private const val PREVIEWS_SUBDIR = "previews"
     private const val PNG_SUFFIX = ".png"
+    private const val OVERRIDES_SUFFIX = ".overrides.json"
     private const val DEFAULT_MAX_BYTES = 100L * 1024 * 1024 // 100 MB
 
     /** A session name safe to use as a path segment + URL value; null if it can't be made safe. */

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHost.kt
@@ -20,6 +20,15 @@ interface ServeHost : AutoCloseable {
   /** Human label for the tenant (module Gradle path, `module@rev`, or a bundle name). */
   val label: String
 
+  /**
+   * Whether editing an override actually re-renders. `true` for a daemon-backed host
+   * ([ServeRenderHost]); `false` for a static pre-rendered bundle ([ServeBundleHost]) that can only
+   * replay the baked PNGs — the viewer then shows the preview's declared knobs as disabled,
+   * informational controls.
+   */
+  val canApplyOverrides: Boolean
+    get() = false
+
   /** Render [previewId] at [overrides] (cached where possible). */
   fun render(previewId: String, overrides: PreviewOverrides): RenderOutcome
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -273,7 +273,12 @@ class ServeHttpServer(
               return@withLeasedSession
             }
             call.respondText(
-              ServeWeb.viewerPage(preview, token, call.request.queryParameters["session"]),
+              ServeWeb.viewerPage(
+                preview,
+                token,
+                call.request.queryParameters["session"],
+                canApplyOverrides = renderHost.canApplyOverrides,
+              ),
               ContentType.Text.Html,
             )
           }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
@@ -46,6 +46,13 @@ data class ServePreview(
   val label: String,
   /** Delivery transports available for this preview. Tier 1 is always [PreviewMode.SNAPSHOT]. */
   val modes: List<PreviewMode> = listOf(PreviewMode.SNAPSHOT),
+  /**
+   * The author-declared editable knobs this preview exposed via `previewOverride*` (the
+   * `compose/overrides` payload). Populated from a bundle's `previews/<id>.overrides.json` sidecar so
+   * the viewer can present editable controls (label / list length / per-item indexed values). Empty
+   * when the preview declared none (or the host doesn't carry them).
+   */
+  val overrides: List<ee.schimke.composeai.data.overrides.PreviewOverrideDeclaration> = emptyList(),
 )
 
 /** Result of a snapshot render request. */
@@ -88,6 +95,9 @@ internal constructor(
   private val onLog: (String) -> Unit = {},
   private val renderTimeoutSeconds: Long = RENDER_TIMEOUT_SECONDS,
 ) : ServeHost {
+
+  // A daemon backs this host, so an override edit actually re-renders (unlike a static bundle).
+  override val canApplyOverrides: Boolean = true
 
   private val previewIds: Set<String> = previews.map { it.id }.toHashSet()
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
@@ -48,9 +48,9 @@ data class ServePreview(
   val modes: List<PreviewMode> = listOf(PreviewMode.SNAPSHOT),
   /**
    * The author-declared editable knobs this preview exposed via `previewOverride*` (the
-   * `compose/overrides` payload). Populated from a bundle's `previews/<id>.overrides.json` sidecar so
-   * the viewer can present editable controls (label / list length / per-item indexed values). Empty
-   * when the preview declared none (or the host doesn't carry them).
+   * `compose/overrides` payload). Populated from a bundle's `previews/<id>.overrides.json` sidecar
+   * so the viewer can present editable controls (label / list length / per-item indexed values).
+   * Empty when the preview declared none (or the host doesn't carry them).
    */
   val overrides: List<ee.schimke.composeai.data.overrides.PreviewOverrideDeclaration> = emptyList(),
 )

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -408,12 +408,13 @@ object ServeWeb {
       .trimIndent() + "\n"
 
   /**
-   * Renders the preview's author-declared editable knobs (the `compose/overrides` payload carried in a
-   * bundle's `previews/<id>.overrides.json`) as a labelled control list. Indexed knobs (per-item values
-   * on a repeated component) are grouped under their base key with a `#<index>` suffix. The controls are
-   * disabled when [canApplyOverrides] is false — a static bundle replays baked PNGs and can't re-render —
-   * with a one-line note explaining why; the live daemon-backed re-render loop for these knobs is a
-   * follow-up. Empty string when the preview declared no knobs (the common case).
+   * Renders the preview's author-declared editable knobs (the `compose/overrides` payload carried
+   * in a bundle's `previews/<id>.overrides.json`) as a labelled control list. Indexed knobs
+   * (per-item values on a repeated component) are grouped under their base key with a `#<index>`
+   * suffix. The controls are disabled when [canApplyOverrides] is false — a static bundle replays
+   * baked PNGs and can't re-render — with a one-line note explaining why; the live daemon-backed
+   * re-render loop for these knobs is a follow-up. Empty string when the preview declared no knobs
+   * (the common case).
    */
   private fun overrideKnobsHtml(preview: ServePreview, canApplyOverrides: Boolean): String {
     if (preview.overrides.isEmpty()) return ""
@@ -429,8 +430,10 @@ object ServeWeb {
             "color" -> "text"
             else -> "text"
           }
-        // Disabled regardless of host for now: a bundle can't re-render, and the live re-render wiring
-        // for named overrides is a follow-up. The control still shows *what* is editable + its value.
+        // Disabled regardless of host for now: a bundle can't re-render, and the live re-render
+        // wiring
+        // for named overrides is a follow-up. The control still shows *what* is editable + its
+        // value.
         """
         <label>${label}
           <input type="$inputType" value="$value" disabled>
@@ -458,7 +461,8 @@ object ServeWeb {
       is ee.schimke.composeai.daemon.protocol.PreviewOverrideValue.StringValue -> v.value
       is ee.schimke.composeai.daemon.protocol.PreviewOverrideValue.IntValue -> v.value.toString()
       is ee.schimke.composeai.daemon.protocol.PreviewOverrideValue.FloatValue -> v.value.toString()
-      is ee.schimke.composeai.daemon.protocol.PreviewOverrideValue.BooleanValue -> v.value.toString()
+      is ee.schimke.composeai.daemon.protocol.PreviewOverrideValue.BooleanValue ->
+        v.value.toString()
       is ee.schimke.composeai.daemon.protocol.PreviewOverrideValue.ColorValue -> v.argb
     }
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -40,10 +40,13 @@ object ServeWeb {
     .cp-controls label { display: flex; flex-direction: column; gap: 4px; font-size: 0.8rem; }
     .cp-controls input, .cp-controls select { padding: 5px 6px; font-size: 0.85rem; }
     .cp-status { font-size: 0.75rem; color: #6b6b70; min-height: 1em; }
+    .cp-knobs { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
+    .cp-knobs-head { font-size: 0.72rem; color: #6b6b70; }
+    .cp-knobs input:disabled { opacity: 0.7; }
     @media (prefers-color-scheme: dark) {
       body { color: #e6e6e9; background: #161618; }
       .cp-sub, .cp-id, .cp-status { color: #a0a0a8; }
-      .cp-card, .cp-stage { border-color: #34343a; }
+      .cp-card, .cp-stage, .cp-knobs { border-color: #34343a; }
       .cp-card { background: #1d1d20; }
       .cp-imgwrap, .cp-stage { background: repeating-conic-gradient(#26262b 0% 25%, #1d1d20 0% 50%) 50% / 16px 16px; }
     }
@@ -106,7 +109,12 @@ object ServeWeb {
   }
 
   /** Viewer page for one preview: an `<img>` driven by the override controls. */
-  fun viewerPage(preview: ServePreview, token: String, sessionId: String? = null): String {
+  fun viewerPage(
+    preview: ServePreview,
+    token: String,
+    sessionId: String? = null,
+    canApplyOverrides: Boolean = false,
+  ): String {
     val idSeg = WebEscaping.urlEncodeSegment(preview.id)
     val q = queryString(token, sessionId)
     val label = WebEscaping.htmlEscape(preview.label)
@@ -151,6 +159,7 @@ object ServeWeb {
               <option value="landscape">Landscape</option>
             </select>
           </label>
+          ${overrideKnobsHtml(preview, canApplyOverrides)}
           <div class="cp-status" id="cp-status"></div>
         </div>
       </div>
@@ -397,6 +406,61 @@ object ServeWeb {
     </html>
     """
       .trimIndent() + "\n"
+
+  /**
+   * Renders the preview's author-declared editable knobs (the `compose/overrides` payload carried in a
+   * bundle's `previews/<id>.overrides.json`) as a labelled control list. Indexed knobs (per-item values
+   * on a repeated component) are grouped under their base key with a `#<index>` suffix. The controls are
+   * disabled when [canApplyOverrides] is false — a static bundle replays baked PNGs and can't re-render —
+   * with a one-line note explaining why; the live daemon-backed re-render loop for these knobs is a
+   * follow-up. Empty string when the preview declared no knobs (the common case).
+   */
+  private fun overrideKnobsHtml(preview: ServePreview, canApplyOverrides: Boolean): String {
+    if (preview.overrides.isEmpty()) return ""
+    val rows =
+      preview.overrides.joinToString("\n") { d ->
+        val name = if (d.index == null) d.key else "${d.key} #${d.index}"
+        val label = WebEscaping.htmlEscape(name)
+        val value = WebEscaping.htmlEscape(overrideValueText(d.current ?: d.default))
+        val inputType =
+          when (d.type) {
+            "int",
+            "float" -> "number"
+            "color" -> "text"
+            else -> "text"
+          }
+        // Disabled regardless of host for now: a bundle can't re-render, and the live re-render wiring
+        // for named overrides is a follow-up. The control still shows *what* is editable + its value.
+        """
+        <label>${label}
+          <input type="$inputType" value="$value" disabled>
+        </label>
+        """
+          .trimIndent()
+      }
+    val note =
+      if (canApplyOverrides) "Declared overrides (live editing coming soon)."
+      else "Declared overrides — static bundle, values are baked in."
+    return """
+      <div class="cp-knobs">
+        <div class="cp-knobs-head">$note</div>
+        $rows
+      </div>
+      """
+      .trimIndent()
+  }
+
+  /** Human text for a [ee.schimke.composeai.daemon.protocol.PreviewOverrideValue] in the viewer. */
+  private fun overrideValueText(
+    v: ee.schimke.composeai.daemon.protocol.PreviewOverrideValue
+  ): String =
+    when (v) {
+      is ee.schimke.composeai.daemon.protocol.PreviewOverrideValue.StringValue -> v.value
+      is ee.schimke.composeai.daemon.protocol.PreviewOverrideValue.IntValue -> v.value.toString()
+      is ee.schimke.composeai.daemon.protocol.PreviewOverrideValue.FloatValue -> v.value.toString()
+      is ee.schimke.composeai.daemon.protocol.PreviewOverrideValue.BooleanValue -> v.value.toString()
+      is ee.schimke.composeai.daemon.protocol.PreviewOverrideValue.ColorValue -> v.argb
+    }
 
   /**
    * A small built-in device menu for the viewer dropdown. Pairs are `device-token` → display name;

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleStoreTest.kt
@@ -53,6 +53,27 @@ class ServeBundleStoreTest {
   }
 
   @Test
+  fun `override sidecars are extracted and surfaced as a preview's declared knobs`() {
+    val overrides =
+      """{"declarations":[{"key":"label","type":"string",""" +
+        """"default":{"kind":"string","value":"Tap me"},""" +
+        """"current":{"kind":"string","value":"Tap me"}},""" +
+        """{"key":"rowLabel","type":"string","index":0,""" +
+        """"default":{"kind":"string","value":"Item 1"}}]}"""
+    val zip =
+      zipOf(
+        "previews/com.example.Red.png" to byteArrayOf(1, 2, 3),
+        "previews/com.example.Red.overrides.json" to overrides.toByteArray(),
+      )
+    val result = store().add("demo", zip, isSecurityChecked = true)
+    assertEquals(ServeBundleStore.Result.Ok("demo", 1), result)
+
+    val preview = registered.getValue("demo").previews.single { it.id == "com.example.Red" }
+    assertEquals(listOf("label", "rowLabel"), preview.overrides.map { it.key })
+    assertEquals(0, preview.overrides[1].index)
+  }
+
+  @Test
   fun `a bundle without previews is rejected`() {
     val result = store().add("demo", zipOf("notes.txt" to byteArrayOf(1)), isSecurityChecked = true)
     assertTrue(result is ServeBundleStore.Result.Failed)

--- a/daemon/android/build.gradle.kts
+++ b/daemon/android/build.gradle.kts
@@ -121,6 +121,10 @@ dependencies {
   // shared JVM module works on both backends (no Android/desktop fork needed, unlike
   // `:data-keyboard-connector` which forks for Android-specific `WindowInsetsCompat`).
   implementation(project(":data-touch-overlay-connector"))
+  // Plain-Compose named-override connector — same portable module `:daemon:desktop` consumes. Seeds
+  // `renderNow.overrides.namedOverrides` into the `previewOverride*` lookups and produces the
+  // `compose/overrides` data product (the preview's declared editable knobs).
+  implementation(project(":data-preview-overrides-connector"))
   // Launcher-widget container-size connector — same shape as `:data-touch-overlay-connector`
   // (single shared JVM module on both backends). `LauncherWidgetExtension` wraps the preview in
   // a sized `Box` matching the clamped whole-cell footprint, driven from

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -439,6 +439,27 @@ fun main(args: Array<String>) {
               ),
           )
         }
+        tryAdd("data/overrides") {
+          // Plain-Compose named overrides (`previewOverride*` knobs: label, list length, indexed
+          // per-item values). Same shape as the touch-overlay / launcher-widget registrations: the
+          // planner is wired into `RobolectricHost.previewOverrideExtensions` (always-on, so
+          // `LocalPreviewOverrideHost` is installed on every render and seeds apply), while this entry
+          // carries the discoverable descriptor and the `compose/overrides` data product registry that
+          // captures the preview's declared knobs. Same portable connector is registered on
+          // `:daemon:desktop`.
+          Extension(
+            id = "data/overrides",
+            displayName = "Named preview overrides",
+            dataProductRegistry = PreviewOverridesDataProductRegistry(),
+            dataExtensionDescriptors =
+              listOf(
+                DataExtensionDescriptor(
+                  id = PreviewOverridesOverrideExtension.ID,
+                  displayName = "Named preview overrides",
+                )
+              ),
+          )
+        }
         tryAdd("data/launcher-widget") {
           // Launcher-widget container-size override — same shape as the touch-overlay registration
           // above. The actual planner is wired into `RobolectricHost.previewOverrideExtensions`;

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -441,16 +441,24 @@ fun main(args: Array<String>) {
         }
         tryAdd("data/overrides") {
           // Plain-Compose named overrides (`previewOverride*` knobs: label, list length, indexed
-          // per-item values). Same shape as the touch-overlay / launcher-widget registrations: the
-          // planner is wired into `RobolectricHost.previewOverrideExtensions` (always-on, so
-          // `LocalPreviewOverrideHost` is installed on every render and seeds apply), while this entry
-          // carries the discoverable descriptor and the `compose/overrides` data product registry that
-          // captures the preview's declared knobs. Same portable connector is registered on
-          // `:daemon:desktop`.
+          // per-item values). The planner is wired into `RobolectricHost.previewOverrideExtensions`
+          // (always-on, so `LocalPreviewOverrideHost` is installed on every render and
+          // `renderNow.overrides.namedOverrides` seeds apply); this entry carries the discoverable
+          // descriptor.
+          //
+          // **No `compose/overrides` data-product registry on Android (unlike `:daemon:desktop`).**
+          // The `previewOverride*` lookups record their declarations into the process-static
+          // `PreviewOverrideController` *inside the Robolectric sandbox classloader*, but a host-side
+          // registry runs in the host classloader and would read a different (empty) copy of that
+          // static — Robolectric re-loads project classes per sandbox (see `DaemonHostBridge`'s
+          // do-not-acquire rationale). So `data/fetch?kind=compose/overrides` is desktop-only until a
+          // sandbox→host bridge for the declarations lands. This does **not** affect bundle carriage:
+          // the standalone Robolectric render in `RobolectricRenderTest.writeOverridesSidecar` reads
+          // the controller from *within* the same sandbox, so `previews/<id>.overrides.json` is
+          // captured correctly on Android too.
           Extension(
             id = "data/overrides",
             displayName = "Named preview overrides",
-            dataProductRegistry = PreviewOverridesDataProductRegistry(),
             dataExtensionDescriptors =
               listOf(
                 DataExtensionDescriptor(

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -1585,6 +1585,12 @@ open class RobolectricHost(
                 // today — the daemon-side resize-loop orchestrator that walks intermediate stops
                 // is tracked as a follow-up.
                 LauncherWidgetPreviewOverrideExtension(),
+                // Plain-Compose named overrides. Always-on (like keyboard / permissions): the planner
+                // installs `LocalPreviewOverrideHost` on every render so `previewOverride*` lookups
+                // resolve and record their declarations, and seeds `renderNow.overrides.namedOverrides`
+                // when present. The `compose/overrides` data product (registered in `DaemonMain`)
+                // surfaces the declared knobs.
+                PreviewOverridesPreviewOverrideExtension(),
                 // Runtime pseudolocale: when `localeTag` is `en-XA` / `ar-XB`, wrap LocalContext
                 // with a Resources subclass that pseudolocalises `getString*` returns. The
                 // planner returns null for any other tag, so non-pseudo locales keep going through

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -365,6 +365,9 @@ open class RobolectricHost(
       "launcherWidget",
       "permissions",
       "remoteCompose",
+      // `renderNow.overrides.namedOverrides` seeds the plain-Compose `previewOverride*` knobs via
+      // the `PreviewOverridesPreviewOverrideExtension` planner wired into `previewOverrideExtensions`.
+      "namedOverrides",
     )
 
   /** PROTOCOL.md § 3 — android backend identifier surfaced via `capabilities.backend`. */

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -1071,12 +1071,19 @@ class JsonRpcServer(
           // desktop `RenderEngine`, which provides it as `LocalLottieProgress` — the interactive
           // Lottie timeline scrub path. No new wire token needed.
           lottie = overrides.lottie,
+          // `namedOverrides` rides the bag so `renderNow.overrides.namedOverrides` reaches the
+          // `PreviewOverridesPreviewOverrideExtension` planner, which seeds
+          // `PreviewOverrideController`
+          // so a preview's `previewOverride*("title", …)` returns the requested value, not its
+          // default.
+          namedOverrides = overrides.namedOverrides,
         )
       if (
         extensionBag.material3Theme != null ||
           extensionBag.wallpaper != null ||
           extensionBag.permissions != null ||
-          extensionBag.lottie != null
+          extensionBag.lottie != null ||
+          !extensionBag.namedOverrides.isNullOrEmpty()
       ) {
         if (isNotEmpty()) append(';')
         append("overrides=")

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewOverrideMerge.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewOverrideMerge.kt
@@ -7,6 +7,7 @@ import ee.schimke.composeai.daemon.protocol.LauncherWidgetOverride
 import ee.schimke.composeai.daemon.protocol.Material3ThemeOverrides
 import ee.schimke.composeai.daemon.protocol.Orientation
 import ee.schimke.composeai.daemon.protocol.PermissionsOverride
+import ee.schimke.composeai.daemon.protocol.PreviewOverrideValue
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.daemon.protocol.RemoteComposeOverride
 import ee.schimke.composeai.daemon.protocol.UiMode
@@ -38,6 +39,7 @@ data class PreviewOverrideBaseSpec(
   val permissions: PermissionsOverride? = null,
   val remoteCompose: RemoteComposeOverride? = null,
   val launcherWidget: LauncherWidgetOverride? = null,
+  val namedOverrides: Map<String, PreviewOverrideValue>? = null,
 )
 
 data class MergedPreviewOverrides(
@@ -59,6 +61,7 @@ data class MergedPreviewOverrides(
   val permissions: PermissionsOverride?,
   val remoteCompose: RemoteComposeOverride?,
   val launcherWidget: LauncherWidgetOverride?,
+  val namedOverrides: Map<String, PreviewOverrideValue>?,
 ) {
   /**
    * Project the merged overrides down to a [PreviewOverrides] bag that only carries fields
@@ -85,6 +88,7 @@ data class MergedPreviewOverrides(
         permissions == null &&
         remoteCompose == null &&
         launcherWidget == null &&
+        namedOverrides.isNullOrEmpty() &&
         !isPseudolocale
     ) {
       return null
@@ -100,6 +104,7 @@ data class MergedPreviewOverrides(
       permissions = permissions,
       remoteCompose = remoteCompose,
       launcherWidget = launcherWidget,
+      namedOverrides = namedOverrides,
     )
   }
 }
@@ -148,6 +153,7 @@ fun mergePreviewOverrides(
       permissions = base.permissions,
       remoteCompose = base.remoteCompose,
       launcherWidget = base.launcherWidget,
+      namedOverrides = base.namedOverrides,
     )
   }
   val deviceOverride = overrides.device?.takeIf { it.isNotBlank() }
@@ -178,5 +184,11 @@ fun mergePreviewOverrides(
     permissions = overrides.permissions ?: base.permissions,
     remoteCompose = overrides.remoteCompose ?: base.remoteCompose,
     launcherWidget = overrides.launcherWidget ?: base.launcherWidget,
+    // Per-key merge (not whole-map replace): editing one knob in a follow-up render must not drop
+    // the
+    // others the caller already set. Override entries win over base entries with the same key.
+    namedOverrides =
+      if (base.namedOverrides == null && overrides.namedOverrides == null) null
+      else (base.namedOverrides ?: emptyMap()) + (overrides.namedOverrides ?: emptyMap()),
   )
 }

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -646,7 +646,59 @@ data class PreviewOverrides(
    * `renderNow.overrides.lottie`. Desktop-only today; the Android backend ignores it.
    */
   val lottie: LottieOverride? = null,
+  /**
+   * Optional plain-Compose **named** overrides — the opt-in, author-declared editable knobs a
+   * preview exposes through the `previewOverride*` keyed lookups (see
+   * `:data-preview-overrides-runtime`). Maps a declaration key to the daemon-supplied
+   * [PreviewOverrideValue]; the around-composable (`PreviewOverridesOverrideExtension` in
+   * `:data-preview-overrides-connector`) seeds these into the process-static
+   * `PreviewOverrideController`, and a consumer's `previewOverrideString("label", default)` call
+   * returns the seeded value (or its author default when no entry is present).
+   *
+   * Unlike [remoteCompose], this needs no Remote Compose runtime — it is portable across the
+   * Android and desktop backends. Indexed knobs for repeated components (lists) use composite keys
+   * that suffix the base key with the bracketed index (the third `rowLabel` seeds against the key
+   * `rowLabel` then `2` in brackets); the item count is itself just an int knob the author feeds
+   * into `repeat(n)`. Defaults to null so existing renders are byte-identical.
+   */
+  val namedOverrides: Map<String, PreviewOverrideValue>? = null,
 )
+
+/**
+ * Preview-neutral typed value for an author-declared [PreviewOverrides.namedOverrides] knob.
+ *
+ * Deliberately **not** [RemoteNamedValue]: that sum is Remote-Compose-flavoured (a `dp` variant
+ * wrapped with `.rdp`, mapped onto the `RcPlatformProfiles` creation DSL). These values seed plain
+ * Compose `previewOverride*` lookups, so the variant set is the small JVM/Compose-native one
+ * (string / int / float / bool / color). A `Dp` knob is carried as [FloatValue] — the runtime
+ * helper wraps the float in `.dp` at the API edge.
+ *
+ * `@JsonClassDiscriminator("kind")` so payloads read `{ "kind": "string", "value": "Tap me" }`
+ * rather than carrying the polymorphic class name.
+ */
+@OptIn(ExperimentalSerializationApi::class)
+@Serializable
+@kotlinx.serialization.json.JsonClassDiscriminator("kind")
+sealed class PreviewOverrideValue {
+  @Serializable
+  @SerialName("string")
+  data class StringValue(val value: String) : PreviewOverrideValue()
+
+  @Serializable @SerialName("int") data class IntValue(val value: Int) : PreviewOverrideValue()
+
+  @Serializable
+  @SerialName("float")
+  data class FloatValue(val value: Float) : PreviewOverrideValue()
+
+  @Serializable
+  @SerialName("bool")
+  data class BooleanValue(val value: Boolean) : PreviewOverrideValue()
+
+  /** Color as `#AARRGGBB`. The runtime helper parses it back to a Compose `Color`. */
+  @Serializable
+  @SerialName("color")
+  data class ColorValue(val argb: String) : PreviewOverrideValue()
+}
 
 /**
  * Optional Lottie timeline override. Drives the interactive "scrub the animation" path for

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/PreviewOverrideMergeTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/PreviewOverrideMergeTest.kt
@@ -5,6 +5,7 @@ import ee.schimke.composeai.daemon.protocol.FocusOverride
 import ee.schimke.composeai.daemon.protocol.Orientation
 import ee.schimke.composeai.daemon.protocol.PermissionGrantStateOverride
 import ee.schimke.composeai.daemon.protocol.PermissionsOverride
+import ee.schimke.composeai.daemon.protocol.PreviewOverrideValue
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.daemon.protocol.RemoteComposeOverride
 import ee.schimke.composeai.daemon.protocol.RemoteComposeProfile
@@ -227,5 +228,39 @@ class PreviewOverrideMergeTest {
       "non-pseudo locales must not project into the extension bag — the renderer applies them via qualifiers / LocaleList directly",
       realLocale,
     )
+  }
+
+  @Test
+  fun `namedOverrides per-key merge over base and flow through toExtensionOverrides`() {
+    val base =
+      PreviewOverrideBaseSpec(
+        widthPx = 320,
+        heightPx = 480,
+        density = 2.0f,
+        device = null,
+        localeTag = null,
+        fontScale = null,
+        uiMode = null,
+        orientation = null,
+        inspectionMode = null,
+        namedOverrides =
+          mapOf(
+            "rowCount" to PreviewOverrideValue.IntValue(3),
+            "label" to PreviewOverrideValue.StringValue("base"),
+          ),
+      )
+
+    // A follow-up render that only edits `label` must keep `rowCount` (per-key merge, not replace).
+    val merged =
+      mergePreviewOverrides(
+        base,
+        PreviewOverrides(
+          namedOverrides = mapOf("label" to PreviewOverrideValue.StringValue("edited"))
+        ),
+      )
+
+    assertEquals(PreviewOverrideValue.StringValue("edited"), merged.namedOverrides?.get("label"))
+    assertEquals(PreviewOverrideValue.IntValue(3), merged.namedOverrides?.get("rowCount"))
+    assertEquals(merged.namedOverrides, merged.toExtensionOverrides()?.namedOverrides)
   }
 }

--- a/daemon/desktop/build.gradle.kts
+++ b/daemon/desktop/build.gradle.kts
@@ -75,6 +75,10 @@ dependencies {
   // `:daemon:android` (the extension's source is pure Compose foundation/runtime — portable).
   // Activated by `renderNow.overrides.touchOverlay = true` or for live recording sessions.
   implementation(project(":data-touch-overlay-connector"))
+  // Plain-Compose named-override connector — same portable module `:daemon:android` consumes. Seeds
+  // `renderNow.overrides.namedOverrides` into the `previewOverride*` lookups and produces the
+  // `compose/overrides` data product (the preview's declared editable knobs).
+  implementation(project(":data-preview-overrides-connector"))
   // Launcher-widget container-size connector — same module Android consumes. The around-composable
   // wraps the preview body in a sized `Box` matching the clamped whole-cell footprint, driven
   // from `renderNow.overrides.launcherWidget`.

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -675,6 +675,19 @@ internal fun buildDesktopExtensions(
       previewOverrideExtensions = listOf(PseudolocalePreviewOverrideExtensionDesktop()),
     )
   }
+  tryAdd("data/overrides") {
+    // Plain-Compose named overrides — the opt-in `previewOverride*` knobs a preview declares (label,
+    // list length, per-item indexed values, …). The planner is always-on so `LocalPreviewOverrideHost`
+    // is installed on every render; the data product surfaces the declared knobs as `compose/overrides`
+    // so a client (and, carried into a bundle, a detached viewer) can present editable controls. Same
+    // portable connector is registered on `:daemon:android`.
+    Extension(
+      id = "data/overrides",
+      displayName = "Named preview overrides",
+      dataProductRegistry = PreviewOverridesDataProductRegistry(),
+      previewOverrideExtensions = listOf(PreviewOverridesPreviewOverrideExtension()),
+    )
+  }
   tryAdd("data/touch-overlay") {
     // Touch-event visualization overlay (`AroundComposableHook`) — paints a translucent ring at
     // every active pointer plus short-lived expanding pulses on down / up, same shape as Android's

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -676,10 +676,14 @@ internal fun buildDesktopExtensions(
     )
   }
   tryAdd("data/overrides") {
-    // Plain-Compose named overrides — the opt-in `previewOverride*` knobs a preview declares (label,
-    // list length, per-item indexed values, …). The planner is always-on so `LocalPreviewOverrideHost`
-    // is installed on every render; the data product surfaces the declared knobs as `compose/overrides`
-    // so a client (and, carried into a bundle, a detached viewer) can present editable controls. Same
+    // Plain-Compose named overrides — the opt-in `previewOverride*` knobs a preview declares
+    // (label,
+    // list length, per-item indexed values, …). The planner is always-on so
+    // `LocalPreviewOverrideHost`
+    // is installed on every render; the data product surfaces the declared knobs as
+    // `compose/overrides`
+    // so a client (and, carried into a bundle, a detached viewer) can present editable controls.
+    // Same
     // portable connector is registered on `:daemon:android`.
     Extension(
       id = "data/overrides",

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
@@ -221,6 +221,9 @@ open class DesktopHost(
     // DesktopRecordingSession.writeTalkBackFrame.
     add("talkBack")
     add("launcherWidget")
+    // `renderNow.overrides.namedOverrides` seeds the plain-Compose `previewOverride*` knobs via the
+    // `data/overrides` planner (`PreviewOverridesPreviewOverrideExtension`).
+    add("namedOverrides")
   }
 
   /** PROTOCOL.md § 3 — desktop backend identifier surfaced via `capabilities.backend`. */

--- a/data/preview-overrides/connector/build.gradle.kts
+++ b/data/preview-overrides/connector/build.gradle.kts
@@ -1,9 +1,13 @@
-// `:data-preview-overrides-connector` — daemon-side glue for the plain-Compose named-override surface.
+// `:data-preview-overrides-connector` — daemon-side glue for the plain-Compose named-override
+// surface.
 // Mirrors `:data-touch-overlay-connector` (a shared Compose Multiplatform module consumed by BOTH
 // `:daemon:desktop` and `:daemon:android`) because nothing here is backend-specific: it seeds the
-// process-static `PreviewOverrideController` from `renderNow.overrides.namedOverrides`, installs the
-// `LocalPreviewOverrideHost` composition local, and produces the `compose/overrides` data product (the
-// set of editable knobs the preview declared). Unlike `:data-remotecompose-connector` there is no alpha
+// process-static `PreviewOverrideController` from `renderNow.overrides.namedOverrides`, installs
+// the
+// `LocalPreviewOverrideHost` composition local, and produces the `compose/overrides` data product
+// (the
+// set of editable knobs the preview declared). Unlike `:data-remotecompose-connector` there is no
+// alpha
 // runtime to gate on, so a single shared module suffices.
 
 plugins {

--- a/data/preview-overrides/connector/build.gradle.kts
+++ b/data/preview-overrides/connector/build.gradle.kts
@@ -1,0 +1,48 @@
+// `:data-preview-overrides-connector` — daemon-side glue for the plain-Compose named-override surface.
+// Mirrors `:data-touch-overlay-connector` (a shared Compose Multiplatform module consumed by BOTH
+// `:daemon:desktop` and `:daemon:android`) because nothing here is backend-specific: it seeds the
+// process-static `PreviewOverrideController` from `renderNow.overrides.namedOverrides`, installs the
+// `LocalPreviewOverrideHost` composition local, and produces the `compose/overrides` data product (the
+// set of editable knobs the preview declared). Unlike `:data-remotecompose-connector` there is no alpha
+// runtime to gate on, so a single shared module suffices.
+
+plugins {
+  id("composeai.base-conventions")
+  id("composeai.maven-publishing")
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.compose.multiplatform)
+  alias(libs.plugins.compose.compiler)
+  alias(libs.plugins.kotlin.serialization)
+}
+
+dependencies {
+  // Wire-shape + product kind (`compose/overrides`), re-exported so `:daemon:*` can register the
+  // extension by referring to the connector's classes only.
+  api(project(":data-preview-overrides-core"))
+  // The consumer runtime — the connector seeds + reads the same `PreviewOverrideController` the
+  // `previewOverride*` lookups use, and provides `LocalPreviewOverrideHost`.
+  api(project(":data-preview-overrides-runtime"))
+
+  // DataProductRegistry, DataExtension, AroundComposableExtension.
+  api(project(":daemon:core"))
+  api(project(":data-render-core"))
+  api(project(":data-render-compose"))
+
+  implementation(libs.jetbrains.compose.runtime)
+  implementation(libs.jetbrains.compose.ui)
+
+  testImplementation(libs.jetbrains.compose.runtime)
+  testImplementation(libs.jetbrains.compose.ui)
+  testImplementation(libs.junit)
+  testImplementation(libs.kotlinx.serialization.json)
+}
+
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "data-preview-overrides-connector",
+    displayName = "Compose Preview - Named Override Data Product Connector",
+    description =
+      "Daemon-side connector for plain-Compose named overrides: seeds `renderNow.overrides.namedOverrides` into the `previewOverride*` lookups and surfaces the preview's declared editable knobs through `data/fetch?kind=compose/overrides`.",
+  )
+  inceptionYear.set("2026")
+}

--- a/data/preview-overrides/connector/src/main/kotlin/ee/schimke/composeai/daemon/PreviewOverridesDataProduct.kt
+++ b/data/preview-overrides/connector/src/main/kotlin/ee/schimke/composeai/daemon/PreviewOverridesDataProduct.kt
@@ -1,0 +1,170 @@
+package ee.schimke.composeai.daemon
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
+import ee.schimke.composeai.daemon.protocol.DataFetchResult
+import ee.schimke.composeai.daemon.protocol.DataProductAttachment
+import ee.schimke.composeai.daemon.protocol.DataProductCapability
+import ee.schimke.composeai.daemon.protocol.DataProductTransport
+import ee.schimke.composeai.daemon.protocol.PreviewOverrideValue
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.data.overrides.PreviewOverridesPayload
+import ee.schimke.composeai.data.overrides.PreviewOverridesProduct
+import ee.schimke.composeai.data.render.PreviewContext
+import ee.schimke.composeai.data.render.extensions.DataExtension
+import ee.schimke.composeai.data.render.extensions.DataExtensionCapability
+import ee.schimke.composeai.data.render.extensions.DataExtensionConstraints
+import ee.schimke.composeai.data.render.extensions.DataExtensionId
+import ee.schimke.composeai.data.render.extensions.DataExtensionPhase
+import ee.schimke.composeai.data.render.extensions.PlannedDataExtension
+import ee.schimke.composeai.data.render.extensions.compose.AroundComposableExtension
+import ee.schimke.composeai.overrides.ControllerPreviewOverrideHost
+import ee.schimke.composeai.overrides.LocalPreviewOverrideHost
+import ee.schimke.composeai.overrides.PreviewOverrideController
+import java.util.concurrent.ConcurrentHashMap
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+
+/**
+ * `AroundComposable` extension that owns the plain-Compose named-override surface. **Always
+ * active** — the planner emits an instance for every render so [LocalPreviewOverrideHost] is in
+ * scope whether or not the client sent `renderNow.overrides.namedOverrides`. Mirrors
+ * `RemoteComposeOverrideExtension`.
+ *
+ * On enter (and whenever [seed] changes) it seeds the process-static [PreviewOverrideController]
+ * with the daemon-supplied replacement values and clears any declarations recorded by a prior
+ * render. The clear lives in a [DisposableEffect] (a `RememberObserver`); Compose invokes every
+ * `RememberObserver` before any `SideEffect`, and the `previewOverride*` lookups record their
+ * declarations from a `SideEffect`, so the clear always precedes this render's declarations — even
+ * when a held interactive session re-renders with a smaller list (stale indexed knobs drop). On
+ * dispose it resets the controller so the next preview starts fresh.
+ *
+ * Runs in [DataExtensionPhase.OuterEnvironment] so the composition local is in place before user
+ * preview content reaches a `previewOverride*` call.
+ */
+class PreviewOverridesOverrideExtension(
+  private val seed: Map<String, PreviewOverrideValue>? = null
+) :
+  AroundComposableExtension(
+    id = ID,
+    constraints =
+      DataExtensionConstraints(
+        phase = DataExtensionPhase.OuterEnvironment,
+        provides = setOf(DataExtensionCapability(PreviewOverridesProduct.KIND)),
+      ),
+  ) {
+  @Composable
+  override fun AroundComposable(content: @Composable () -> Unit) {
+    DisposableEffect(seed) {
+      PreviewOverrideController.set(seed)
+      PreviewOverrideController.clearDeclarations()
+      onDispose { PreviewOverrideController.resetForNewSession() }
+    }
+    CompositionLocalProvider(LocalPreviewOverrideHost provides ControllerPreviewOverrideHost) {
+      content()
+    }
+  }
+
+  companion object {
+    val ID: DataExtensionId = DataExtensionId(PreviewOverridesProduct.KIND)
+  }
+}
+
+/**
+ * Planner mapping `renderNow.overrides.namedOverrides` to a [PreviewOverridesOverrideExtension].
+ * **Always** returns a non-null extension (like `RemoteComposePreviewOverrideExtension`) so the
+ * composition local is installed on every render — a preview that only later begins calling
+ * `previewOverride*` still finds the host wired without needing a fresh override.
+ */
+class PreviewOverridesPreviewOverrideExtension : DataExtension<PreviewOverrides> {
+  override val id: DataExtensionId = PreviewOverridesOverrideExtension.ID
+
+  override fun plan(request: PreviewOverrides): PlannedDataExtension =
+    PreviewOverridesOverrideExtension(seed = request.namedOverrides)
+}
+
+/**
+ * Daemon-side registry for `compose/overrides`. After a render it snapshots the editable knobs the
+ * preview declared (from [PreviewOverrideController]) into a per-preview [PreviewOverridesPayload];
+ * a `data/fetch` then returns that set so a client (or, once carried into a bundle sidecar, a
+ * detached viewer) can present editable controls. Before any render — or after a render that
+ * declared nothing — it returns [DataProductRegistry.Outcome.NotAvailable]. Mirrors
+ * `RemoteComposeDataProductRegistry`.
+ */
+class PreviewOverridesDataProductRegistry : DataProductRegistry {
+  private val latest = ConcurrentHashMap<String, PreviewOverridesPayload>()
+
+  override val capabilities: List<DataProductCapability> =
+    listOf(
+      DataProductCapability(
+        kind = KIND,
+        schemaVersion = SCHEMA_VERSION,
+        transport = DataProductTransport.INLINE,
+        attachable = true,
+        fetchable = true,
+        // Editing a knob sends a fresh `renderNow.overrides.namedOverrides`, which re-renders
+        // anyway;
+        // the declarations themselves are a by-product of that render, not something to re-render
+        // for.
+        requiresRerender = false,
+      )
+    )
+
+  override fun fetch(
+    previewId: String,
+    kind: String,
+    params: JsonElement?,
+    inline: Boolean,
+  ): DataProductRegistry.Outcome {
+    if (kind != KIND) return DataProductRegistry.Outcome.Unknown
+    val payload = latest[previewId] ?: return DataProductRegistry.Outcome.NotAvailable
+    return DataProductRegistry.Outcome.Ok(
+      DataFetchResult(
+        kind = KIND,
+        schemaVersion = SCHEMA_VERSION,
+        payload = json.encodeToJsonElement(PreviewOverridesPayload.serializer(), payload),
+      )
+    )
+  }
+
+  override fun attachmentsFor(previewId: String, kinds: Set<String>): List<DataProductAttachment> {
+    if (KIND !in kinds) return emptyList()
+    val payload = latest[previewId] ?: return emptyList()
+    return listOf(
+      DataProductAttachment(
+        kind = KIND,
+        schemaVersion = SCHEMA_VERSION,
+        payload = json.encodeToJsonElement(PreviewOverridesPayload.serializer(), payload),
+      )
+    )
+  }
+
+  override fun onRender(previewId: String, result: RenderResult) {
+    onRender(previewId, result, overrides = null, previewContext = result.previewContext)
+  }
+
+  override fun onRender(
+    previewId: String,
+    result: RenderResult,
+    overrides: PreviewOverrides?,
+    previewContext: PreviewContext?,
+  ) {
+    val declarations = PreviewOverrideController.declarations()
+    if (declarations.isEmpty()) {
+      latest.remove(previewId)
+      return
+    }
+    latest[previewId] = PreviewOverridesPayload(declarations = declarations)
+  }
+
+  companion object {
+    const val KIND: String = PreviewOverridesProduct.KIND
+    const val SCHEMA_VERSION: Int = PreviewOverridesProduct.SCHEMA_VERSION
+
+    private val json = Json {
+      encodeDefaults = true
+      prettyPrint = false
+    }
+  }
+}

--- a/data/preview-overrides/connector/src/test/kotlin/ee/schimke/composeai/daemon/PreviewOverridesDataProductTest.kt
+++ b/data/preview-overrides/connector/src/test/kotlin/ee/schimke/composeai/daemon/PreviewOverridesDataProductTest.kt
@@ -1,0 +1,191 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.protocol.DataProductTransport
+import ee.schimke.composeai.daemon.protocol.PreviewOverrideValue
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.data.overrides.PreviewOverrideDeclaration
+import ee.schimke.composeai.data.overrides.PreviewOverrideType
+import ee.schimke.composeai.data.render.PreviewContext
+import ee.schimke.composeai.data.render.extensions.DataExtensionHookKind
+import ee.schimke.composeai.data.render.extensions.DataExtensionId
+import ee.schimke.composeai.data.render.extensions.DataExtensionPhase
+import ee.schimke.composeai.data.render.extensions.compose.AroundComposableHook
+import ee.schimke.composeai.data.render.extensions.compose.hasAroundComposableHook
+import ee.schimke.composeai.overrides.PreviewOverrideController
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PreviewOverridesDataProductTest {
+
+  @After
+  fun reset() {
+    PreviewOverrideController.resetForNewSession()
+  }
+
+  @Test
+  fun extension_declares_around_composable_hook_in_outer_environment() {
+    val extension = PreviewOverridesOverrideExtension()
+    val hook: AroundComposableHook = extension
+
+    assertEquals(DataExtensionId("compose/overrides"), extension.id)
+    assertEquals(setOf(DataExtensionHookKind.AroundComposable), extension.hooks)
+    assertEquals(DataExtensionPhase.OuterEnvironment, extension.constraints.phase)
+    assertTrue(extension.hasAroundComposableHook)
+    assertEquals(extension, hook)
+  }
+
+  @Test
+  fun planner_always_returns_extension_even_without_override() {
+    val planned = PreviewOverridesPreviewOverrideExtension().plan(PreviewOverrides())
+    assertTrue("expected planner to always produce a hook", planned is AroundComposableHook)
+    assertEquals(DataExtensionId("compose/overrides"), planned.id)
+  }
+
+  @Test
+  fun planner_threads_named_overrides_through_to_extension() {
+    val overrides =
+      PreviewOverrides(
+        namedOverrides = mapOf("label" to PreviewOverrideValue.StringValue("Tap me"))
+      )
+    val planned = PreviewOverridesPreviewOverrideExtension().plan(overrides)
+    assertTrue(planned is PreviewOverridesOverrideExtension)
+  }
+
+  @Test
+  fun capabilities_advertise_compose_overrides_as_inline_no_rerender_product() {
+    val cap = PreviewOverridesDataProductRegistry().capabilities.single()
+    assertEquals("compose/overrides", cap.kind)
+    assertEquals(1, cap.schemaVersion)
+    assertEquals(DataProductTransport.INLINE, cap.transport)
+    assertTrue(cap.attachable)
+    assertTrue(cap.fetchable)
+    assertEquals(false, cap.requiresRerender)
+  }
+
+  @Test
+  fun fetch_before_any_render_returns_not_available() {
+    val registry = PreviewOverridesDataProductRegistry()
+    assertEquals(
+      DataProductRegistry.Outcome.NotAvailable,
+      registry.fetch("preview-1", "compose/overrides", params = null, inline = true),
+    )
+  }
+
+  @Test
+  fun fetch_unknown_kind_returns_unknown() {
+    val registry = PreviewOverridesDataProductRegistry()
+    assertEquals(
+      DataProductRegistry.Outcome.Unknown,
+      registry.fetch("preview-1", "compose/theme", params = null, inline = true),
+    )
+  }
+
+  @Test
+  fun controller_set_replaces_seeded_values() {
+    val c = PreviewOverrideController
+    c.set(
+      mapOf(
+        "label" to PreviewOverrideValue.StringValue("hi"),
+        "rowCount" to PreviewOverrideValue.IntValue(4),
+      )
+    )
+    assertEquals(PreviewOverrideValue.StringValue("hi"), c.valueOf("label"))
+    assertEquals(PreviewOverrideValue.IntValue(4), c.valueOf("rowCount"))
+
+    c.set(mapOf("rowCount" to PreviewOverrideValue.IntValue(2)))
+    assertNull("dropped key must not linger", c.valueOf("label"))
+    assertEquals(PreviewOverrideValue.IntValue(2), c.valueOf("rowCount"))
+  }
+
+  @Test
+  fun controller_record_dedupes_by_seed_key_and_preserves_order() {
+    val c = PreviewOverrideController
+    c.record(decl("rowCount", PreviewOverrideType.INT, PreviewOverrideValue.IntValue(3)))
+    c.record(
+      decl("rowLabel", PreviewOverrideType.STRING, PreviewOverrideValue.StringValue("a"), index = 0)
+    )
+    c.record(
+      decl("rowLabel", PreviewOverrideType.STRING, PreviewOverrideValue.StringValue("b"), index = 1)
+    )
+    // Re-declare rowCount (a recomposition): replaces in place, no duplicate, order kept.
+    c.record(decl("rowCount", PreviewOverrideType.INT, PreviewOverrideValue.IntValue(3)))
+
+    val keys = c.declarations().map { it.seedKey }
+    assertEquals(listOf("rowCount", "rowLabel[0]", "rowLabel[1]"), keys)
+  }
+
+  @Test
+  fun controller_clearDeclarations_keeps_seeds() {
+    val c = PreviewOverrideController
+    c.set(mapOf("label" to PreviewOverrideValue.StringValue("seed")))
+    c.record(decl("label", PreviewOverrideType.STRING, PreviewOverrideValue.StringValue("def")))
+    c.clearDeclarations()
+    assertTrue(c.declarations().isEmpty())
+    assertEquals(PreviewOverrideValue.StringValue("seed"), c.valueOf("label"))
+  }
+
+  @Test
+  fun on_render_captures_declarations_then_clears_when_empty() {
+    val registry = PreviewOverridesDataProductRegistry()
+    PreviewOverrideController.record(
+      decl("label", PreviewOverrideType.STRING, PreviewOverrideValue.StringValue("Tap me"))
+    )
+
+    registry.onRender(
+      "preview-1",
+      stubRenderResult(),
+      overrides = null,
+      previewContext = stubContext(),
+    )
+    assertTrue(
+      registry.fetch("preview-1", "compose/overrides", params = null, inline = true)
+        is DataProductRegistry.Outcome.Ok
+    )
+
+    // A subsequent render that declared nothing must drop the stale payload.
+    PreviewOverrideController.clearDeclarations()
+    registry.onRender(
+      "preview-1",
+      stubRenderResult(),
+      overrides = null,
+      previewContext = stubContext(),
+    )
+    assertEquals(
+      DataProductRegistry.Outcome.NotAvailable,
+      registry.fetch("preview-1", "compose/overrides", params = null, inline = true),
+    )
+  }
+
+  private fun decl(
+    key: String,
+    type: String,
+    default: PreviewOverrideValue,
+    index: Int? = null,
+  ): PreviewOverrideDeclaration =
+    PreviewOverrideDeclaration(
+      key = key,
+      type = type,
+      default = default,
+      current = default,
+      index = index,
+    )
+
+  private fun stubRenderResult(): RenderResult =
+    RenderResult(
+      id = 1L,
+      classLoaderHashCode = 0,
+      classLoaderName = "test",
+      previewContext = stubContext(),
+    )
+
+  private fun stubContext(): PreviewContext =
+    PreviewContext(
+      previewId = "preview-1",
+      backend = "test",
+      renderMode = null,
+      outputBaseName = null,
+    )
+}

--- a/data/preview-overrides/core/build.gradle.kts
+++ b/data/preview-overrides/core/build.gradle.kts
@@ -1,0 +1,35 @@
+// `:data-preview-overrides-core` — wire-shape for the plain-Compose **named override** data product
+// (`compose/overrides`). Mirrors `:data-remotecompose-core`: the product-kind constant + payload
+// classes live on a tiny JVM module so MCP clients and the bundle producer can depend on the payload
+// schema without dragging in the connector, Compose, or any backend.
+//
+// The author-declared knobs a preview exposes through the `previewOverride*` lookups
+// (`:data-preview-overrides-runtime`) are captured here as [PreviewOverrideDeclaration]s and carried in
+// the `compose/overrides` payload — the data both a live daemon (`data/fetch`) and a portable bundle
+// surface so a viewer can present editable controls.
+
+plugins {
+  id("composeai.base-conventions")
+  id("composeai.maven-publishing")
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.kotlin.serialization)
+}
+
+dependencies {
+  // `daemon:core` carries `PreviewOverrideValue` (the typed value variant the declaration and the
+  // `renderNow.overrides.namedOverrides` seed share). Re-exported via `api` so consumers refer to it
+  // without a second `project` dependency.
+  api(project(":daemon:core"))
+  api(libs.kotlinx.serialization.json)
+  testImplementation(libs.junit)
+}
+
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "data-preview-overrides-core",
+    displayName = "Compose Preview - Named Override Data Product Core",
+    description =
+      "Shared model classes for the plain-Compose named-override data product (`compose/overrides`): the author-declared editable knobs (`previewOverride*`) a preview exposes, carried both live (`data/fetch`) and inside a portable bundle so a viewer can present editable controls.",
+  )
+  inceptionYear.set("2026")
+}

--- a/data/preview-overrides/core/build.gradle.kts
+++ b/data/preview-overrides/core/build.gradle.kts
@@ -1,11 +1,14 @@
 // `:data-preview-overrides-core` — wire-shape for the plain-Compose **named override** data product
 // (`compose/overrides`). Mirrors `:data-remotecompose-core`: the product-kind constant + payload
-// classes live on a tiny JVM module so MCP clients and the bundle producer can depend on the payload
+// classes live on a tiny JVM module so MCP clients and the bundle producer can depend on the
+// payload
 // schema without dragging in the connector, Compose, or any backend.
 //
 // The author-declared knobs a preview exposes through the `previewOverride*` lookups
-// (`:data-preview-overrides-runtime`) are captured here as [PreviewOverrideDeclaration]s and carried in
-// the `compose/overrides` payload — the data both a live daemon (`data/fetch`) and a portable bundle
+// (`:data-preview-overrides-runtime`) are captured here as [PreviewOverrideDeclaration]s and
+// carried in
+// the `compose/overrides` payload — the data both a live daemon (`data/fetch`) and a portable
+// bundle
 // surface so a viewer can present editable controls.
 
 plugins {
@@ -17,7 +20,8 @@ plugins {
 
 dependencies {
   // `daemon:core` carries `PreviewOverrideValue` (the typed value variant the declaration and the
-  // `renderNow.overrides.namedOverrides` seed share). Re-exported via `api` so consumers refer to it
+  // `renderNow.overrides.namedOverrides` seed share). Re-exported via `api` so consumers refer to
+  // it
   // without a second `project` dependency.
   api(project(":daemon:core"))
   api(libs.kotlinx.serialization.json)

--- a/data/preview-overrides/core/src/main/kotlin/ee/schimke/composeai/data/overrides/PreviewOverrideModels.kt
+++ b/data/preview-overrides/core/src/main/kotlin/ee/schimke/composeai/data/overrides/PreviewOverrideModels.kt
@@ -1,0 +1,82 @@
+package ee.schimke.composeai.data.overrides
+
+import ee.schimke.composeai.daemon.protocol.PreviewOverrideValue
+import kotlinx.serialization.Serializable
+
+/**
+ * Stable identity of the `compose/overrides` data product. Lifted out of the daemon-side registry
+ * (as `RemoteComposeProduct` is) so the bundle producer and MCP clients can depend on the payload
+ * schema without pulling in the connector, Compose, or any backend.
+ */
+object PreviewOverridesProduct {
+  const val KIND: String = "compose/overrides"
+  const val SCHEMA_VERSION: Int = 1
+}
+
+/**
+ * Type tags for a [PreviewOverrideDeclaration] — what kind of control a viewer renders for the
+ * knob. Kept as small string constants (rather than an enum on the wire) so an older reader
+ * tolerates a future type it doesn't recognise. Matches the [PreviewOverrideValue] variants the
+ * runtime emits.
+ */
+object PreviewOverrideType {
+  const val STRING: String = "string"
+  const val INT: String = "int"
+  const val FLOAT: String = "float"
+  const val BOOL: String = "bool"
+  const val COLOR: String = "color"
+}
+
+/**
+ * One author-declared editable knob a preview exposes through a `previewOverride*` lookup.
+ *
+ * Named distinctly from the protocol's [ee.schimke.composeai.daemon.protocol.PreviewOverrides] (the
+ * display-knob bag — size / theme / locale) to avoid confusion: a *declaration* is "this preview
+ * offers an editable string named `label`, default `Tap me`", produced by the preview itself,
+ * whereas `PreviewOverrides.namedOverrides` is the daemon's seed of *replacement values* for those
+ * declarations.
+ *
+ * **Repeated components.** A scalar knob (the common case) has [index] = null. A knob declared
+ * inside a repeat (a per-item value on a list) is recorded once per item with [index] = 0, 1, 2, …;
+ * the on-wire key the daemon seeds against is then [seedKey] — the base key with the index appended
+ * in brackets. The item count is itself just an ordinary int knob the author feeds into
+ * `repeat(n)`.
+ */
+@Serializable
+data class PreviewOverrideDeclaration(
+  /**
+   * Author-chosen key, e.g. `"label"` or `"rowCount"`. Stable across renders for the same call
+   * site.
+   */
+  val key: String,
+  /** One of [PreviewOverrideType]. The viewer picks the control widget from this. */
+  val type: String,
+  /** Human label for the control; defaults to [key]. */
+  val label: String = key,
+  /** The author-supplied fallback value (what renders with no override applied). */
+  val default: PreviewOverrideValue,
+  /**
+   * The effective value after the latest render — the daemon-seeded replacement, or the [default]
+   * when none was seeded. Null in a bundle sidecar captured by a standalone (non-daemon) render
+   * that only knows the declared default. A viewer shows this as the control's current state.
+   */
+  val current: PreviewOverrideValue? = null,
+  /** Non-null for one instance of a repeated/indexed knob; the wire key is then [seedKey]. */
+  val index: Int? = null,
+) {
+  /**
+   * The composite key the daemon seeds against: the bare [key] for a scalar knob, or the key with
+   * the [index] appended in square brackets (`rowLabel` at index 2 seeds against `rowLabel` then
+   * `2` in brackets) when indexed.
+   */
+  val seedKey: String
+    get() = if (index == null) key else "$key[$index]"
+}
+
+/**
+ * Wire shape returned by `data/fetch?kind=compose/overrides` and carried in a bundle's
+ * `previews/<id>.overrides.json` sidecar: the set of editable knobs the preview declared during its
+ * latest render, in declaration order.
+ */
+@Serializable
+data class PreviewOverridesPayload(val declarations: List<PreviewOverrideDeclaration> = emptyList())

--- a/data/preview-overrides/runtime/build.gradle.kts
+++ b/data/preview-overrides/runtime/build.gradle.kts
@@ -1,0 +1,44 @@
+// `:data-preview-overrides-runtime` — the consumer-facing opt-in API for plain-Compose named overrides.
+// A preview author adds this as `implementation(...)` and wraps editable values in `previewOverride*`
+// keyed lookups (`previewOverrideString("label", "Tap me")`, `previewOverrideInt("rowCount", 3)`, indexed
+// per-item knobs for repeated components). Each lookup returns the daemon-seeded value (or the author
+// default) and records its declaration into the process-static `PreviewOverrideController` so a producer
+// can enumerate "what is editable" on the preview.
+//
+// Compose Multiplatform JVM (works for both Android and CMP-desktop previews). Compose itself is
+// `compileOnly`: the consumer brings its own Compose (androidx OR jetbrains — same FQNs), so this artifact
+// never forces a Compose flavour onto a consumer's classpath. Mirrors the `compileOnly` Compose pattern in
+// `:data-remotecompose-connector`.
+
+plugins {
+  id("composeai.base-conventions")
+  id("composeai.maven-publishing")
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.compose.multiplatform)
+  alias(libs.plugins.compose.compiler)
+}
+
+dependencies {
+  // Wire-shape (declaration + product kind) and, transitively, `PreviewOverrideValue`. `api` so a
+  // consumer test or the connector can refer to them without a second dependency.
+  api(project(":data-preview-overrides-core"))
+
+  // Compose runtime (`@Composable`, `compositionLocalOf`, `SideEffect`) + UI (`Color`, `toArgb`, `Dp`).
+  // `compileOnly` — the consumer supplies the matching Compose at runtime.
+  compileOnly(libs.jetbrains.compose.runtime)
+  compileOnly(libs.jetbrains.compose.ui)
+
+  testImplementation(libs.jetbrains.compose.runtime)
+  testImplementation(libs.jetbrains.compose.ui)
+  testImplementation(libs.junit)
+}
+
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "data-preview-overrides-runtime",
+    displayName = "Compose Preview - Named Override Runtime",
+    description =
+      "Opt-in consumer API for plain-Compose preview overrides: `previewOverride*` keyed lookups (string/int/float/bool/color/dp, with indexed knobs for repeated components) that a preview uses to expose editable values, resolved against daemon seeds and recorded for the `compose/overrides` data product.",
+  )
+  inceptionYear.set("2026")
+}

--- a/data/preview-overrides/runtime/build.gradle.kts
+++ b/data/preview-overrides/runtime/build.gradle.kts
@@ -1,13 +1,20 @@
-// `:data-preview-overrides-runtime` — the consumer-facing opt-in API for plain-Compose named overrides.
-// A preview author adds this as `implementation(...)` and wraps editable values in `previewOverride*`
-// keyed lookups (`previewOverrideString("label", "Tap me")`, `previewOverrideInt("rowCount", 3)`, indexed
-// per-item knobs for repeated components). Each lookup returns the daemon-seeded value (or the author
-// default) and records its declaration into the process-static `PreviewOverrideController` so a producer
+// `:data-preview-overrides-runtime` — the consumer-facing opt-in API for plain-Compose named
+// overrides.
+// A preview author adds this as `implementation(...)` and wraps editable values in
+// `previewOverride*`
+// keyed lookups (`previewOverrideString("label", "Tap me")`, `previewOverrideInt("rowCount", 3)`,
+// indexed
+// per-item knobs for repeated components). Each lookup returns the daemon-seeded value (or the
+// author
+// default) and records its declaration into the process-static `PreviewOverrideController` so a
+// producer
 // can enumerate "what is editable" on the preview.
 //
 // Compose Multiplatform JVM (works for both Android and CMP-desktop previews). Compose itself is
-// `compileOnly`: the consumer brings its own Compose (androidx OR jetbrains — same FQNs), so this artifact
-// never forces a Compose flavour onto a consumer's classpath. Mirrors the `compileOnly` Compose pattern in
+// `compileOnly`: the consumer brings its own Compose (androidx OR jetbrains — same FQNs), so this
+// artifact
+// never forces a Compose flavour onto a consumer's classpath. Mirrors the `compileOnly` Compose
+// pattern in
 // `:data-remotecompose-connector`.
 
 plugins {
@@ -23,7 +30,8 @@ dependencies {
   // consumer test or the connector can refer to them without a second dependency.
   api(project(":data-preview-overrides-core"))
 
-  // Compose runtime (`@Composable`, `compositionLocalOf`, `SideEffect`) + UI (`Color`, `toArgb`, `Dp`).
+  // Compose runtime (`@Composable`, `compositionLocalOf`, `SideEffect`) + UI (`Color`, `toArgb`,
+  // `Dp`).
   // `compileOnly` — the consumer supplies the matching Compose at runtime.
   compileOnly(libs.jetbrains.compose.runtime)
   compileOnly(libs.jetbrains.compose.ui)

--- a/data/preview-overrides/runtime/src/main/kotlin/ee/schimke/composeai/overrides/PreviewOverrideController.kt
+++ b/data/preview-overrides/runtime/src/main/kotlin/ee/schimke/composeai/overrides/PreviewOverrideController.kt
@@ -1,0 +1,108 @@
+package ee.schimke.composeai.overrides
+
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
+import ee.schimke.composeai.daemon.protocol.PreviewOverrideValue
+import ee.schimke.composeai.data.overrides.PreviewOverrideDeclaration
+import java.util.concurrent.CopyOnWriteArrayList
+
+/**
+ * Process-static state holder for the plain-Compose named-override surface — the counterpart to
+ * `RemoteComposeController`, minus the Remote-Compose-specific facets (host actions, platform
+ * profile).
+ *
+ * Two responsibilities:
+ *
+ * 1. **Seeded values** — the daemon-supplied `name -> [PreviewOverrideValue]` map for the current
+ *    render (`renderNow.overrides.namedOverrides`, keyed by [PreviewOverrideDeclaration.seedKey]).
+ *    Snapshot-state so a `previewOverride*` lookup recomposes when the daemon pushes a fresh seed.
+ * 2. **Declarations** — the ordered set of knobs the preview declared *this render* via its
+ *    `previewOverride*` calls. Accumulated as the composition runs (deduped by `seedKey`,
+ *    declaration order preserved) so a producer — the daemon's `compose/overrides` data product, or
+ *    a standalone render's bundle-sidecar drain — can read back "what is editable on this preview".
+ *
+ * The controller is **always** the fallback host (see [LocalPreviewOverrideHost]) so a plain Gradle
+ * render with no daemon still records declarations (with no seeds, every lookup returns its author
+ * default). When the connector's around-composable is active it seeds values through [set] before
+ * the preview composes.
+ *
+ * Writers can be on any thread — the daemon's render thread for seeding, the composition thread for
+ * [record]. Snapshot-state + a copy-on-write listener list carry cross-thread propagation.
+ */
+object PreviewOverrideController {
+
+  private val seededValuesState: MutableState<Map<String, PreviewOverrideValue>> =
+    mutableStateOf(emptyMap())
+
+  // Insertion-ordered, deduped by seedKey. A LinkedHashMap snapshot keeps declaration order stable
+  // for
+  // the viewer while letting a re-declared key (recomposition) replace its prior entry in place.
+  private val declarationsState: MutableState<Map<String, PreviewOverrideDeclaration>> =
+    mutableStateOf(emptyMap())
+
+  private val listeners: MutableList<() -> Unit> = CopyOnWriteArrayList()
+
+  val seededValues: State<Map<String, PreviewOverrideValue>>
+    get() = seededValuesState
+
+  /** Current seeded value for [seedKey], or null when no override bound it. */
+  fun valueOf(seedKey: String): PreviewOverrideValue? = seededValuesState.value[seedKey]
+
+  /**
+   * Seed the replacement values for this render. Replaces the whole map — a follow-up render
+   * carrying a subset drops anything not present (the daemon's [mergePreviewOverrides] does per-key
+   * merging before this point, so the map handed here is already the effective set). `null` / empty
+   * clears all seeds.
+   */
+  fun set(values: Map<String, PreviewOverrideValue>?) {
+    val next = values ?: emptyMap()
+    if (seededValuesState.value == next) return
+    seededValuesState.value = next
+    listeners.toList().forEach { it() }
+  }
+
+  /**
+   * Record a knob the preview just declared. Keyed by [PreviewOverrideDeclaration.seedKey]; a
+   * repeat declaration of the same key (recomposition) replaces the prior entry while keeping its
+   * position, so the viewer's control list is stable across recompositions.
+   */
+  fun record(declaration: PreviewOverrideDeclaration) {
+    val current = declarationsState.value
+    val prior = current[declaration.seedKey]
+    if (prior == declaration) return
+    // LinkedHashMap to preserve first-seen order even when replacing an existing key's value.
+    val next = LinkedHashMap(current)
+    next[declaration.seedKey] = declaration
+    declarationsState.value = next
+    listeners.toList().forEach { it() }
+  }
+
+  /** The knobs declared so far this render, in declaration order. */
+  fun declarations(): List<PreviewOverrideDeclaration> = declarationsState.value.values.toList()
+
+  /** Register a callback fired on every state change. Returns an unregister handle. */
+  fun addChangeListener(listener: () -> Unit): () -> Unit {
+    listeners.add(listener)
+    return { listeners.remove(listener) }
+  }
+
+  /**
+   * Drop seeds and recorded declarations so the next preview starts fresh. Called on a new render /
+   * interactive-session boundary. Mirrors `RemoteComposeController.resetForNewSession`.
+   */
+  fun resetForNewSession() {
+    seededValuesState.value = emptyMap()
+    declarationsState.value = emptyMap()
+  }
+
+  /**
+   * Clear only the recorded declarations, keeping any seeded values, so a fresh composition
+   * re-declares its current set without losing the daemon's seed. Used at the start of each render
+   * pass.
+   */
+  fun clearDeclarations() {
+    if (declarationsState.value.isEmpty()) return
+    declarationsState.value = emptyMap()
+  }
+}

--- a/data/preview-overrides/runtime/src/main/kotlin/ee/schimke/composeai/overrides/PreviewOverrideHost.kt
+++ b/data/preview-overrides/runtime/src/main/kotlin/ee/schimke/composeai/overrides/PreviewOverrideHost.kt
@@ -1,0 +1,235 @@
+package ee.schimke.composeai.overrides
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import ee.schimke.composeai.daemon.protocol.PreviewOverrideValue
+import ee.schimke.composeai.data.overrides.PreviewOverrideDeclaration
+import ee.schimke.composeai.data.overrides.PreviewOverrideType
+
+/**
+ * Composition local exposing the live named-override surface to a preview. Wired to
+ * [ControllerPreviewOverrideHost] by default — the process-static [PreviewOverrideController] — so
+ * the `previewOverride*` lookups work in a plain Gradle render with no daemon (every lookup returns
+ * its author default and records its declaration). The connector's around-composable
+ * (`:data-preview-overrides-connector`) seeds the same controller before the preview composes, so
+ * the lookups then return the daemon-supplied values. Tests can provide a fake host.
+ */
+val LocalPreviewOverrideHost:
+  androidx.compose.runtime.ProvidableCompositionLocal<PreviewOverrideHost> =
+  compositionLocalOf {
+    ControllerPreviewOverrideHost
+  }
+
+/**
+ * Resolves an author-declared, keyed editable knob to its effective value, recording the
+ * declaration so a producer can enumerate "what is editable" on this preview. The
+ * `previewOverride*` top-level helpers delegate here.
+ */
+interface PreviewOverrideHost {
+  @Composable fun string(key: String, default: String, index: Int?): String
+
+  @Composable fun int(key: String, default: Int, index: Int?): Int
+
+  @Composable fun float(key: String, default: Float, index: Int?): Float
+
+  @Composable fun boolean(key: String, default: Boolean, index: Int?): Boolean
+
+  @Composable fun color(key: String, default: Color, index: Int?): Color
+
+  @Composable fun dp(key: String, default: Dp, index: Int?): Dp
+}
+
+/**
+ * Default [PreviewOverrideHost] backed by the process-static [PreviewOverrideController]. Each read
+ * (a) resolves the controller's seeded value for the (key, index) — falling back to [default] when
+ * none is bound or the bound value's type doesn't match — and (b) records the declaration (with its
+ * resolved `current`) into the controller so the `compose/overrides` producer can surface it.
+ */
+object ControllerPreviewOverrideHost : PreviewOverrideHost {
+
+  @Composable
+  override fun string(key: String, default: String, index: Int?): String {
+    val seeded by PreviewOverrideController.seededValues
+    val effective =
+      (seeded[seedKey(key, index)] as? PreviewOverrideValue.StringValue)?.value ?: default
+    declare(
+      key,
+      index,
+      PreviewOverrideType.STRING,
+      PreviewOverrideValue.StringValue(default),
+      PreviewOverrideValue.StringValue(effective),
+    )
+    return effective
+  }
+
+  @Composable
+  override fun int(key: String, default: Int, index: Int?): Int {
+    val seeded by PreviewOverrideController.seededValues
+    val effective =
+      (seeded[seedKey(key, index)] as? PreviewOverrideValue.IntValue)?.value ?: default
+    declare(
+      key,
+      index,
+      PreviewOverrideType.INT,
+      PreviewOverrideValue.IntValue(default),
+      PreviewOverrideValue.IntValue(effective),
+    )
+    return effective
+  }
+
+  @Composable
+  override fun float(key: String, default: Float, index: Int?): Float {
+    val seeded by PreviewOverrideController.seededValues
+    val effective =
+      (seeded[seedKey(key, index)] as? PreviewOverrideValue.FloatValue)?.value ?: default
+    declare(
+      key,
+      index,
+      PreviewOverrideType.FLOAT,
+      PreviewOverrideValue.FloatValue(default),
+      PreviewOverrideValue.FloatValue(effective),
+    )
+    return effective
+  }
+
+  @Composable
+  override fun boolean(key: String, default: Boolean, index: Int?): Boolean {
+    val seeded by PreviewOverrideController.seededValues
+    val effective =
+      (seeded[seedKey(key, index)] as? PreviewOverrideValue.BooleanValue)?.value ?: default
+    declare(
+      key,
+      index,
+      PreviewOverrideType.BOOL,
+      PreviewOverrideValue.BooleanValue(default),
+      PreviewOverrideValue.BooleanValue(effective),
+    )
+    return effective
+  }
+
+  @Composable
+  override fun color(key: String, default: Color, index: Int?): Color {
+    val seeded by PreviewOverrideController.seededValues
+    val seededArgb = (seeded[seedKey(key, index)] as? PreviewOverrideValue.ColorValue)?.argb
+    val effective = seededArgb?.let(::parseColorOrNull) ?: default
+    declare(
+      key,
+      index,
+      PreviewOverrideType.COLOR,
+      PreviewOverrideValue.ColorValue(default.toArgbHex()),
+      PreviewOverrideValue.ColorValue(effective.toArgbHex()),
+    )
+    return effective
+  }
+
+  @Composable
+  override fun dp(key: String, default: Dp, index: Int?): Dp {
+    // Dp carried as a plain float (its `.value`); no Remote-style dp wrapper.
+    val seeded by PreviewOverrideController.seededValues
+    val effective =
+      (seeded[seedKey(key, index)] as? PreviewOverrideValue.FloatValue)?.value ?: default.value
+    declare(
+      key,
+      index,
+      PreviewOverrideType.FLOAT,
+      PreviewOverrideValue.FloatValue(default.value),
+      PreviewOverrideValue.FloatValue(effective),
+    )
+    return effective.dp
+  }
+
+  @Composable
+  private fun declare(
+    key: String,
+    index: Int?,
+    type: String,
+    default: PreviewOverrideValue,
+    current: PreviewOverrideValue,
+  ) {
+    val declaration =
+      PreviewOverrideDeclaration(
+        key = key,
+        type = type,
+        label = key,
+        default = default,
+        current = current,
+        index = index,
+      )
+    // Record on commit, not mid-composition: keeps the controller mutation a side effect of a
+    // successful composition (idempotent — the controller de-dupes by seedKey).
+    SideEffect { PreviewOverrideController.record(declaration) }
+  }
+}
+
+private fun seedKey(key: String, index: Int?): String = if (index == null) key else "$key[$index]"
+
+/** `#AARRGGBB` for a Compose [Color] (converted to sRGB by [toArgb]). */
+internal fun Color.toArgbHex(): String = "#%08X".format(toArgb())
+
+/** Parse `#AARRGGBB` / `#RRGGBB` (or without `#`) to a [Color], or null when malformed. */
+internal fun parseColorOrNull(hex: String): Color? {
+  val raw = hex.removePrefix("#")
+  val v = raw.toLongOrNull(16) ?: return null
+  return when (raw.length) {
+    8 -> Color((v and 0xFFFFFFFF).toInt())
+    6 -> Color((0xFF000000 or v).toInt())
+    else -> null
+  }
+}
+
+// --- Public opt-in lookups
+// -------------------------------------------------------------------------
+
+/**
+ * Declare and resolve an editable **string** knob keyed by [key]. In a daemon-backed render the
+ * daemon's `renderNow.overrides.namedOverrides` entry for [key] (or the bracket-indexed key when
+ * [index] is set) replaces [default]; otherwise [default] is returned. Either way the knob is
+ * recorded so a viewer can present an editable control. Opt-in: only previews that call this expose
+ * the knob.
+ *
+ * Example (a list whose length and per-row label are both editable):
+ * ```
+ * val rows = previewOverrideInt("rowCount", 3)
+ * Column { repeat(rows) { i -> Text(previewOverrideString("rowLabel", "Item ${i + 1}", index = i)) } }
+ * ```
+ */
+@Composable
+fun previewOverrideString(key: String, default: String, index: Int? = null): String =
+  LocalPreviewOverrideHost.current.string(key, default, index)
+
+/**
+ * Editable **int** knob. The natural type for a list length / item count. See
+ * [previewOverrideString].
+ */
+@Composable
+fun previewOverrideInt(key: String, default: Int, index: Int? = null): Int =
+  LocalPreviewOverrideHost.current.int(key, default, index)
+
+/** Editable **float** knob. See [previewOverrideString]. */
+@Composable
+fun previewOverrideFloat(key: String, default: Float, index: Int? = null): Float =
+  LocalPreviewOverrideHost.current.float(key, default, index)
+
+/** Editable **boolean** knob. See [previewOverrideString]. */
+@Composable
+fun previewOverrideBoolean(key: String, default: Boolean, index: Int? = null): Boolean =
+  LocalPreviewOverrideHost.current.boolean(key, default, index)
+
+/** Editable **color** knob, carried on the wire as `#AARRGGBB`. See [previewOverrideString]. */
+@Composable
+fun previewOverrideColor(key: String, default: Color, index: Int? = null): Color =
+  LocalPreviewOverrideHost.current.color(key, default, index)
+
+/**
+ * Editable **Dp** knob (e.g. a component size), carried on the wire as a float. See
+ * [previewOverrideString].
+ */
+@Composable
+fun previewOverrideDp(key: String, default: Dp, index: Int? = null): Dp =
+  LocalPreviewOverrideHost.current.dp(key, default, index)

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/BundleFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/BundleFunctionalTest.kt
@@ -244,6 +244,53 @@ class BundleFunctionalTest {
   }
 
   @Test
+  fun `composePreviewBundle packs the per-preview override sidecar (v8)`() {
+    val projectDir = createTestProject()
+    val redId = "test.RedKt.RedBoxPreview"
+
+    // Discover so previews.json (and each capture's renderOutput stem) exists.
+    GradleRunner.create()
+      .withProjectDir(projectDir)
+      .withArguments("composePreviewDiscover")
+      .withPluginClasspath()
+      .build()
+
+    val previewsJson = File(projectDir, "build/compose-previews/previews.json")
+    val manifest = json.decodeFromString(PreviewManifest.serializer(), previewsJson.readText())
+    val rendersDir = File(projectDir, "build/compose-previews/renders").apply { mkdirs() }
+
+    // Seed the red preview's PNG plus an `<stem>.overrides.json` sidecar (as the render step would
+    // for a preview that called `previewOverride*`); the blue preview gets only a PNG (no knobs).
+    val overridesJson =
+      """{"declarations":[{"key":"label","type":"string","label":"label",""" +
+        """"default":{"kind":"string","value":"Tap me"},""" +
+        """"current":{"kind":"string","value":"Tap me"}}]}"""
+    for (preview in manifest.previews) {
+      val stem =
+        preview.captures.first().renderOutput.substringAfterLast('/').removeSuffix(".png").ifEmpty {
+          preview.id
+        }
+      File(rendersDir, "$stem.png").writeBytes(solidPng(0x202020))
+      if (preview.id == redId) {
+        File(rendersDir, "$stem.overrides.json").writeText(overridesJson)
+      }
+    }
+
+    val result =
+      GradleRunner.create()
+        .withProjectDir(projectDir)
+        .withArguments("composePreviewBundle", "-PbundlePreviewIds=$redId", "--stacktrace")
+        .withPluginClasspath()
+        .build()
+    assertThat(result.task(":composePreviewBundle")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+
+    val bundle = File(projectDir, "build/compose-previews/bundle.png")
+    assertThat(listEntries(bundle)).contains("previews/$redId.overrides.json")
+    assertThat(String(readZipEntry(bundle, "previews/$redId.overrides.json")!!, Charsets.UTF_8))
+      .isEqualTo(overridesJson)
+  }
+
+  @Test
   fun `composePreviewBundle re-packs when renders appear after a render-less pack`() {
     val projectDir = createTestProject()
     val redId = "test.RedKt.RedBoxPreview"

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
@@ -465,6 +465,19 @@ abstract class BundlePreviewTask : DefaultTask() {
       resolvePreviewPng(preview)?.let { previewPngs[preview.id] = it }
     }
 
+    // (v8) Per-preview override sidecars: the editable knobs a preview declared via
+    // `previewOverride*`,
+    // captured during the render as `renders/<stem>.overrides.json`. Packed verbatim under
+    // `previews/<id>.overrides.json` so a detached viewer can present the controls. Absent for
+    // previews
+    // that declared none.
+    val overrideFiles = LinkedHashMap<String, ByteArray>()
+    for (preview in selected) {
+      resolvePreviewOverrides(preview)?.let {
+        overrideFiles["$BUNDLE_PREVIEWS_DIR/${preview.id}.$BUNDLE_OVERRIDES_SIDECAR_EXT"] = it
+      }
+    }
+
     val filteredManifest =
       if (includeDataExtensions.getOrElse(false)) {
         // When carrying extension data, rewrite the bundled manifest's `dataExtensionReports` to
@@ -493,6 +506,7 @@ abstract class BundlePreviewTask : DefaultTask() {
         previewPngs = previewPngs,
         irFiles = irZipFiles,
         dataExtensionFiles = dataExtensionZipFiles,
+        overrideFiles = overrideFiles,
       )
 
     // The cover (first selected preview) forms the polyglot's leading bytes. Reuse its baked PNG
@@ -623,6 +637,23 @@ abstract class BundlePreviewTask : DefaultTask() {
    * `@PreviewParameter` variants (a tile / remote document is a single artefact), so unlike the PNG
    * path there's no sibling search.
    */
+  /**
+   * Look for the per-preview override sidecar the render step wrote next to [preview]'s PNG
+   * (`renders/<stem>.overrides.json`) — the serialized `compose/overrides` payload of the editable
+   * knobs the preview declared via `previewOverride*`. Resolution mirrors [resolvePreviewIr]: the
+   * stem comes from the primary capture's `renderOutput`, the file lives under [rendersDir].
+   * Returns the raw bytes (copied verbatim into the bundle — the producer never parses them) or
+   * `null` when the preview declared no knobs (the common case).
+   */
+  private fun resolvePreviewOverrides(preview: PreviewInfo): ByteArray? {
+    val rendersRoot = rendersDir.orNull?.asFile ?: return null
+    val rel =
+      preview.captures.firstOrNull()?.renderOutput?.takeIf { it.isNotEmpty() } ?: return null
+    val stem = rel.substringAfterLast('/').removeSuffix(".png")
+    val f = File(rendersRoot, "$stem.$BUNDLE_OVERRIDES_SIDECAR_EXT")
+    return if (f.isFile && f.length() > 0) f.readBytes() else null
+  }
+
   private fun resolvePreviewIr(preview: PreviewInfo): ResolvedIr? {
     // kind=LOTTIE: the IR is the discovered asset file itself (no render-time capture). Read it
     // straight off the module resources by the path discovery recorded, so the bundle carries the
@@ -1045,6 +1076,7 @@ abstract class BundlePreviewTask : DefaultTask() {
     previewPngs: Map<String, ByteArray>,
     irFiles: Map<String, ByteArray>,
     dataExtensionFiles: Map<String, ByteArray>,
+    overrideFiles: Map<String, ByteArray>,
   ): ByteArray {
     val baos = ByteArrayOutputStream()
     ZipOutputStream(baos).use { zip ->
@@ -1052,6 +1084,8 @@ abstract class BundlePreviewTask : DefaultTask() {
       zip.writeFile("previews.json", previewsJson.toByteArray(Charsets.UTF_8))
       // One baked PNG per selected preview under the well-known `previews/` directory.
       previewPngs.forEach { (id, bytes) -> zip.writeFile("$BUNDLE_PREVIEWS_DIR/$id.png", bytes) }
+      // (v8) Per-preview override sidecars under `previews/<id>.overrides.json`.
+      overrideFiles.forEach { (path, bytes) -> zip.writeFile(path, bytes) }
       // Captured IR bytes (Remote Compose doc / protolayout proto) under `ir/`.
       irFiles.forEach { (path, bytes) -> zip.writeFile(path, bytes) }
       // (v7) Optional per-extension data reports under `extensions/<id>.json`.

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewBundleFormat.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewBundleFormat.kt
@@ -31,6 +31,14 @@ import kotlinx.serialization.json.JsonClassDiscriminator
  *                            The cover's leading-bytes PNG is mirrored here under its own id so
  *                            iterating the well-known directory yields every preview uniformly.
  *                            A preview with no render on disk is simply absent from this directory.
+ * previews/<id>.overrides.json — (v8) the author-declared editable knobs the preview exposed via the
+ *                            `previewOverride*` lookups (a verbatim `compose/overrides` payload —
+ *                            `PreviewOverridesPayload` from `:data-preview-overrides-core`, copied byte
+ *                            for byte; the producer never parses it): label / list-length / per-item
+ *                            indexed values. Captured during the normal
+ *                            render, present only for previews that opted in, so a detached viewer can
+ *                            offer the editable controls without a live daemon. Convention-discovered
+ *                            (no manifest pointer), like the optional semantics sidecar.
  * classes/app.jar          — consumer module bytecode, MINIMIZED to classes reachable from the
  *                            selected previews (plus all module resources). For an IR-backed
  *                            preview (see below) the enclosing class is NOT a closure seed, so its
@@ -439,8 +447,23 @@ val CONVENTIONAL_DATA_EXTENSION_REPORTS: Map<String, String> = mapOf("a11y" to "
  *   re-rendering. Additive — the field defaults to empty and `ignoreUnknownKeys` readers skip the
  *   `extensions/` entries, so a v6 reader opening a v7 bundle still works; only a reader that wants
  *   the carried data needs to be v7-aware.
+ * - v8 — adds the `previews/<id>.overrides.json` sidecar: the author-declared editable knobs a
+ *   preview exposed via the `previewOverride*` lookups (the `compose/overrides` payload), captured
+ *   during the normal render so a detached viewer can present editable controls (label / list
+ *   length / per-item indexed values) with no live daemon. Convention-discovered (no manifest
+ *   field), present only for previews that opted in. Additive — the sidecar is ignored by older
+ *   readers and absent for previews that declare no knobs, so a v7 reader opening a v8 bundle still
+ *   works; only a reader that wants the editable knobs needs to be v8-aware.
  */
-const val BUNDLE_SCHEMA_VERSION: Int = 7
+const val BUNDLE_SCHEMA_VERSION: Int = 8
+
+/**
+ * File extension of the per-preview override sidecar the render step writes next to the PNG
+ * (`renders/<stem>.overrides.json`) and the bundle packs under `previews/<id>.overrides.json`.
+ * Holds the serialized `compose/overrides` payload — the editable knobs the preview declared. Kept
+ * in lockstep with the consumer runtime's writer.
+ */
+const val BUNDLE_OVERRIDES_SIDECAR_EXT: String = "overrides.json"
 
 /**
  * Well-known directory inside the bundle zip holding one rendered PNG per selected preview, keyed

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/PreviewBundleFormatTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/PreviewBundleFormatTest.kt
@@ -23,8 +23,8 @@ class PreviewBundleFormatTest {
   }
 
   @Test
-  fun `current schema version is 7`() {
-    assertThat(BUNDLE_SCHEMA_VERSION).isEqualTo(7)
+  fun `current schema version is 8`() {
+    assertThat(BUNDLE_SCHEMA_VERSION).isEqualTo(8)
   }
 
   @Test

--- a/renderers/android/build.gradle.kts
+++ b/renderers/android/build.gradle.kts
@@ -97,6 +97,15 @@ dependencies {
   // successful capture and calls `DeviceFrameDataProducer.writeArtifacts(...)` to composite the PNG
   // into a real device-art bezel. Renderer-agnostic (BufferedImage / ImageIO + Ktor/OkHttp fetch).
   implementation(project(":data-deviceframe-connector"))
+  // Plain-Compose named overrides — RobolectricRenderTest drains `PreviewOverrideController` after
+  // each
+  // capture and writes the `renders/<stem>.overrides.json` sidecar `BundlePreviewTask` packs. The
+  // consumer's `previewOverride*` calls resolve to the same controller; depending on the runtime
+  // here
+  // guarantees the class is present even when the consumer didn't add it (then nothing is declared
+  // and
+  // no sidecar is written). `core` (re-exported) carries the payload serializer.
+  implementation(project(":data-preview-overrides-runtime"))
 
   implementation(libs.robolectric)
   implementation(libs.junit)

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -480,6 +480,9 @@ abstract class RobolectricRenderTestBase(
         // Arm the IR channel for this preview so a Remote Compose / protolayout producer can offer
         // its captured intermediate representation during composition; drained post-render below.
         ee.schimke.composeai.data.render.IrSidecarChannel.setCurrentPreviewId(preview.id)
+        // Drop any named-override knobs a prior preview declared so this preview's `previewOverride*`
+        // lookups accumulate a clean set (drained into the overrides sidecar below).
+        ee.schimke.composeai.overrides.PreviewOverrideController.clearDeclarations()
         try {
             renderDefault(
                 params = params,
@@ -495,6 +498,9 @@ abstract class RobolectricRenderTestBase(
             // Render succeeded: if the preview's flavour captured an IR, write it beside the PNG as
             // the `renders/<stem>.<ext>` sidecar `BundlePreviewTask.resolvePreviewIr` packs.
             writeIrSidecar(pngFile, preview.id)
+            // Write the editable knobs the preview declared via `previewOverride*` as the
+            // `renders/<stem>.overrides.json` sidecar `BundlePreviewTask.resolvePreviewOverrides` packs.
+            writeOverridesSidecar(pngFile)
         } catch (e: Throwable) {
             System.err.println(
                 "Render failed for ${preview.className}.${preview.functionName}: ${e.message}"
@@ -549,6 +555,42 @@ abstract class RobolectricRenderTestBase(
             }
         } catch (e: Throwable) {
             System.err.println("Failed to write IR sidecar for $previewId: ${e.message}")
+        }
+    }
+
+    /**
+     * Write the editable knobs the preview declared via `previewOverride*` during the just-finished
+     * render as the `renders/<stem>.overrides.json` sidecar `BundlePreviewTask.resolvePreviewOverrides`
+     * packs. An empty set deletes any stale sidecar so a preview that stopped declaring knobs doesn't
+     * keep an old one. Best-effort — a write failure must not derail the PNG render path. The
+     * `overrides.json` suffix is kept in lockstep with `PreviewBundleFormat.BUNDLE_OVERRIDES_SIDECAR_EXT`.
+     */
+    private fun writeOverridesSidecar(pngFile: File) {
+        val declarations =
+            ee.schimke.composeai.overrides.PreviewOverrideController.declarations()
+        val dir = pngFile.parentFile ?: return
+        val sidecar = File(dir, "${pngFile.nameWithoutExtension}.overrides.json")
+        try {
+            if (declarations.isEmpty()) {
+                if (sidecar.isFile && !sidecar.delete()) {
+                    System.err.println(
+                        "Failed to delete stale overrides sidecar: ${sidecar.absolutePath}"
+                    )
+                }
+                return
+            }
+            val payload =
+                ee.schimke.composeai.data.overrides.PreviewOverridesPayload(
+                    declarations = declarations
+                )
+            sidecar.writeText(
+                json.encodeToString(
+                    ee.schimke.composeai.data.overrides.PreviewOverridesPayload.serializer(),
+                    payload,
+                )
+            )
+        } catch (e: Throwable) {
+            System.err.println("Failed to write overrides sidecar: ${e.message}")
         }
     }
 

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -88,6 +88,13 @@ private fun ScrollAxis.toProductAxis(): ProductScrollAxis =
     }
 
 /**
+ * Encoder for the `renders/<stem>.overrides.json` sidecar (the `compose/overrides` payload). File-level
+ * so the render class's `writeOverridesSidecar` can reach it. `encodeDefaults = true` to match the
+ * desktop renderer's sidecar writer so the format is identical across backends.
+ */
+private val overridesSidecarJson = Json { encodeDefaults = true }
+
+/**
  * Loads the previews manifest and returns the subset assigned to `shardIndex`
  * out of `shardCount` shards. Generated shard subclasses delegate their
  * `@Parameters` method here (see the plugin's `generateShardTests` task).
@@ -584,7 +591,7 @@ abstract class RobolectricRenderTestBase(
                     declarations = declarations
                 )
             sidecar.writeText(
-                json.encodeToString(
+                overridesSidecarJson.encodeToString(
                     ee.schimke.composeai.data.overrides.PreviewOverridesPayload.serializer(),
                     payload,
                 )

--- a/renderers/desktop/build.gradle.kts
+++ b/renderers/desktop/build.gradle.kts
@@ -47,6 +47,12 @@ dependencies {
   // render and calls `DeviceFrameDataProducer.writeArtifacts(...)` to composite the PNG into a real
   // device-art bezel. Renderer-agnostic (BufferedImage / ImageIO + Ktor/OkHttp fetch).
   implementation(project(":data-deviceframe-connector"))
+  // Plain-Compose named overrides — DesktopRendererMain drains `PreviewOverrideController` after each
+  // render and writes the `renders/<stem>.overrides.json` sidecar `BundlePreviewTask` packs. The
+  // consumer's `previewOverride*` calls resolve to the same controller, so depending on the runtime
+  // here guarantees the class is present even when the consumer didn't add it (then nothing is
+  // declared and no sidecar is written). `core` (re-exported) carries the payload serializer.
+  implementation(project(":data-preview-overrides-runtime"))
 
   testImplementation(libs.junit)
 }

--- a/renderers/desktop/build.gradle.kts
+++ b/renderers/desktop/build.gradle.kts
@@ -47,7 +47,8 @@ dependencies {
   // render and calls `DeviceFrameDataProducer.writeArtifacts(...)` to composite the PNG into a real
   // device-art bezel. Renderer-agnostic (BufferedImage / ImageIO + Ktor/OkHttp fetch).
   implementation(project(":data-deviceframe-connector"))
-  // Plain-Compose named overrides — DesktopRendererMain drains `PreviewOverrideController` after each
+  // Plain-Compose named overrides — DesktopRendererMain drains `PreviewOverrideController` after
+  // each
   // render and writes the `renders/<stem>.overrides.json` sidecar `BundlePreviewTask` packs. The
   // consumer's `previewOverride*` calls resolve to the same controller, so depending on the runtime
   // here guarantees the class is present even when the consumer didn't add it (then nothing is

--- a/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRendererMain.kt
+++ b/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRendererMain.kt
@@ -602,6 +602,10 @@ private fun renderPreview(
       findComposableMethodWithArgs(clazz, functionName, previewArgs)
     }
 
+  // Arm the named-override capture for this render: drop any knobs a prior preview declared so this
+  // preview's `previewOverride*` lookups accumulate a clean set (drained into the sidecar below).
+  ee.schimke.composeai.overrides.PreviewOverrideController.clearDeclarations()
+
   // `@Preview(fontScale = ...)` rides on `Density.fontScale`. Threading it through the scene's
   // constructor makes the override visible to layout (sp → px) before the first measure pass; we
   // also re-provide the same `Density` as `LocalDensity` below since some ui-text/text-foundation
@@ -757,6 +761,44 @@ private fun renderPreview(
   }
 
   scene.close()
+
+  // After a successful render, write the editable knobs this preview declared via
+  // `previewOverride*`
+  // as the `renders/<stem>.overrides.json` sidecar `BundlePreviewTask` packs into the bundle.
+  writePreviewOverridesSidecar(outputFile, fileSystem)
+}
+
+private val overridesSidecarJson =
+  kotlinx.serialization.json.Json {
+    encodeDefaults = true
+    prettyPrint = false
+  }
+
+/**
+ * Drain the named-override declarations captured during the just-finished render (if any) and write
+ * them beside [outputFile] as `<stem>.overrides.json`, the serialized `compose/overrides` payload
+ * `BundlePreviewTask.resolvePreviewOverrides` reads. Best-effort; an empty set deletes any stale
+ * sidecar so a preview that stopped declaring knobs doesn't keep an old one. The `overrides.json`
+ * suffix is kept in lockstep with `PreviewBundleFormat.BUNDLE_OVERRIDES_SIDECAR_EXT`.
+ */
+private fun writePreviewOverridesSidecar(outputFile: File, fileSystem: FileSystem) {
+  val declarations = ee.schimke.composeai.overrides.PreviewOverrideController.declarations()
+  val parent = outputFile.parentFile ?: return
+  val sidecar = File(parent, "${outputFile.nameWithoutExtension}.overrides.json").path.toPath()
+  if (declarations.isEmpty()) {
+    if (fileSystem.exists(sidecar)) fileSystem.delete(sidecar)
+    return
+  }
+  val payload =
+    ee.schimke.composeai.data.overrides.PreviewOverridesPayload(declarations = declarations)
+  val bytes =
+    overridesSidecarJson
+      .encodeToString(
+        ee.schimke.composeai.data.overrides.PreviewOverridesPayload.serializer(),
+        payload,
+      )
+      .toByteArray(Charsets.UTF_8)
+  fileSystem.write(sidecar) { write(bytes) }
 }
 
 /**

--- a/samples/cmp/build.gradle.kts
+++ b/samples/cmp/build.gradle.kts
@@ -24,4 +24,7 @@ dependencies {
   // `LottiePreview(...)` — renders a Lottie `.json` asset (from src/main/resources) at a fixed
   // progress through the desktop renderer. Brings Compottie transitively.
   implementation(project(":lottie-preview-runtime"))
+  // `previewOverride*` — opt-in editable knobs (label / list length / per-item indexed values) the
+  // daemon can seed and a served bundle can present as editable controls.
+  implementation(project(":data-preview-overrides-runtime"))
 }

--- a/samples/cmp/src/main/kotlin/com/example/samplecmp/OverridablePreviews.kt
+++ b/samples/cmp/src/main/kotlin/com/example/samplecmp/OverridablePreviews.kt
@@ -1,0 +1,45 @@
+package com.example.samplecmp
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import ee.schimke.composeai.overrides.previewOverrideColor
+import ee.schimke.composeai.overrides.previewOverrideInt
+import ee.schimke.composeai.overrides.previewOverrideString
+
+/**
+ * Demonstrates the opt-in named-override surface (`previewOverride*`): a whole-screen list whose
+ * **title**, **accent colour**, **item count**, and **per-row label** are all editable. The item count
+ * is an ordinary int knob fed into `repeat(...)`; the row label is an *indexed* knob so each row gets
+ * its own editable value. A daemon (or a served bundle) can seed replacements for any of these and the
+ * declared set travels in the bundle as `previews/<id>.overrides.json`.
+ */
+@Preview(name = "Overridable List", showBackground = true)
+@Composable
+fun OverridableListPreview() {
+  val title = previewOverrideString("title", default = "Shopping list")
+  val accent = previewOverrideColor("accent", default = Color(0xFF3366FF))
+  val itemCount = previewOverrideInt("itemCount", default = 3)
+
+  Surface {
+    Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+      Text(title, style = MaterialTheme.typography.titleLarge, color = accent)
+      repeat(itemCount) { i ->
+        val label = previewOverrideString("rowLabel", default = "Item ${i + 1}", index = i)
+        Card(modifier = Modifier.fillMaxWidth()) {
+          Text(label, modifier = Modifier.padding(12.dp))
+        }
+      }
+    }
+  }
+}

--- a/samples/cmp/src/main/kotlin/com/example/samplecmp/OverridablePreviews.kt
+++ b/samples/cmp/src/main/kotlin/com/example/samplecmp/OverridablePreviews.kt
@@ -19,10 +19,10 @@ import ee.schimke.composeai.overrides.previewOverrideString
 
 /**
  * Demonstrates the opt-in named-override surface (`previewOverride*`): a whole-screen list whose
- * **title**, **accent colour**, **item count**, and **per-row label** are all editable. The item count
- * is an ordinary int knob fed into `repeat(...)`; the row label is an *indexed* knob so each row gets
- * its own editable value. A daemon (or a served bundle) can seed replacements for any of these and the
- * declared set travels in the bundle as `previews/<id>.overrides.json`.
+ * **title**, **accent colour**, **item count**, and **per-row label** are all editable. The item
+ * count is an ordinary int knob fed into `repeat(...)`; the row label is an *indexed* knob so each
+ * row gets its own editable value. A daemon (or a served bundle) can seed replacements for any of
+ * these and the declared set travels in the bundle as `previews/<id>.overrides.json`.
  */
 @Preview(name = "Overridable List", showBackground = true)
 @Composable
@@ -36,9 +36,7 @@ fun OverridableListPreview() {
       Text(title, style = MaterialTheme.typography.titleLarge, color = accent)
       repeat(itemCount) { i ->
         val label = previewOverrideString("rowLabel", default = "Item ${i + 1}", index = i)
-        Card(modifier = Modifier.fillMaxWidth()) {
-          Text(label, modifier = Modifier.padding(12.dp))
-        }
+        Card(modifier = Modifier.fillMaxWidth()) { Text(label, modifier = Modifier.padding(12.dp)) }
       }
     }
   }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -438,6 +438,22 @@ include(":data-remotecompose-connector")
 
 project(":data-remotecompose-connector").projectDir = file("data/remotecompose/connector")
 
+// Plain-Compose named overrides — opt-in author-declared editable knobs (`previewOverride*`). Unlike
+// Remote Compose this needs no alpha runtime, so the runtime + connector are portable Compose
+// Multiplatform JVM modules consumed by both daemon backends. `core` carries the wire-shape; `runtime`
+// is the consumer-facing lookup API; `connector` seeds values + produces the `compose/overrides` data.
+include(":data-preview-overrides-core")
+
+project(":data-preview-overrides-core").projectDir = file("data/preview-overrides/core")
+
+include(":data-preview-overrides-runtime")
+
+project(":data-preview-overrides-runtime").projectDir = file("data/preview-overrides/runtime")
+
+include(":data-preview-overrides-connector")
+
+project(":data-preview-overrides-connector").projectDir = file("data/preview-overrides/connector")
+
 // UIAutomator-shaped query/action API for the Compose preview renderer. Carries the matcher,
 // the Selector DSL, and the JSON wire format — consumed by `:daemon:android` for
 // `record_preview`'s `uia.*` script events.

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing.html
@@ -31,10 +31,13 @@ a:hover { text-decoration: underline; }
 .cp-controls label { display: flex; flex-direction: column; gap: 4px; font-size: 0.8rem; }
 .cp-controls input, .cp-controls select { padding: 5px 6px; font-size: 0.85rem; }
 .cp-status { font-size: 0.75rem; color: #6b6b70; min-height: 1em; }
+.cp-knobs { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
+.cp-knobs-head { font-size: 0.72rem; color: #6b6b70; }
+.cp-knobs input:disabled { opacity: 0.7; }
 @media (prefers-color-scheme: dark) {
   body { color: #e6e6e9; background: #161618; }
   .cp-sub, .cp-id, .cp-status { color: #a0a0a8; }
-  .cp-card, .cp-stage { border-color: #34343a; }
+  .cp-card, .cp-stage, .cp-knobs { border-color: #34343a; }
   .cp-card { background: #1d1d20; }
   .cp-imgwrap, .cp-stage { background: repeating-conic-gradient(#26262b 0% 25%, #1d1d20 0% 50%) 50% / 16px 16px; }
 }</style>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
@@ -31,10 +31,13 @@ a:hover { text-decoration: underline; }
 .cp-controls label { display: flex; flex-direction: column; gap: 4px; font-size: 0.8rem; }
 .cp-controls input, .cp-controls select { padding: 5px 6px; font-size: 0.85rem; }
 .cp-status { font-size: 0.75rem; color: #6b6b70; min-height: 1em; }
+.cp-knobs { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
+.cp-knobs-head { font-size: 0.72rem; color: #6b6b70; }
+.cp-knobs input:disabled { opacity: 0.7; }
 @media (prefers-color-scheme: dark) {
   body { color: #e6e6e9; background: #161618; }
   .cp-sub, .cp-id, .cp-status { color: #a0a0a8; }
-  .cp-card, .cp-stage { border-color: #34343a; }
+  .cp-card, .cp-stage, .cp-knobs { border-color: #34343a; }
   .cp-card { background: #1d1d20; }
   .cp-imgwrap, .cp-stage { background: repeating-conic-gradient(#26262b 0% 25%, #1d1d20 0% 50%) 50% / 16px 16px; }
 }</style>
@@ -77,6 +80,7 @@ a:hover { text-decoration: underline; }
               <option value="landscape">Landscape</option>
             </select>
           </label>
+          
           <div class="cp-status" id="cp-status"></div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Generalises the "label" override mechanism — which previously existed **only for Remote Compose** (`rememberNamedRemoteString` seeded via `renderNow.overrides.remoteCompose`) — to **plain Compose** previews, then carries the declared overrides into the portable bundle and surfaces them when serving.

A preview deliberately opts in by wrapping editable values in keyed lookups:

```kotlin
val title = previewOverrideString("title", "Shopping list")
val accent = previewOverrideColor("accent", Color(0xFF3366FF))
val count = previewOverrideInt("itemCount", 3)             // list length
Column { repeat(count) { i ->
  Text(previewOverrideString("rowLabel", "Item ${i + 1}", index = i))  // per-item, indexed
} }
```

This covers **whole screens that repeat components**: the item count is an ordinary int knob fed into `repeat(...)`, and per-row values are *indexed* knobs (`index = i`, wire key `rowLabel[2]`) so each repeated instance has its own editable value.

### What's included (three phases)

1. **Mechanism** — `PreviewOverrides.namedOverrides` + a preview-neutral `PreviewOverrideValue` type (string/int/float/bool/color — deliberately **not** the Remote-Compose `RemoteNamedValue`); the consumer `previewOverride*` lookups in a new `:data-preview-overrides-runtime`; a process-static `PreviewOverrideController`; the `compose/overrides` data product (`:data-preview-overrides-{core,connector}`); registered as `data/overrides` on both desktop and Android daemons, with `namedOverrides` wired through `encodeRenderPayload` + `supportedOverrides` so seeds actually reach the planner.
2. **Bundle carriage** (schema **v8**) — both renderers drain the declared knobs after each render into a `renders/<stem>.overrides.json` sidecar; `BundlePreviewTask` packs it as `previews/<id>.overrides.json` (convention-discovered, additive — older readers ignore it).
3. **Serve** — `ServeBundleStore` extracts the sidecars; `ServeBundleHost` reads them into `ServePreview.overrides`; `ServeHost.canApplyOverrides` distinguishes a daemon-backed host from a static bundle; `ServeWeb` renders the declared knobs as controls (disabled with a note on a baked bundle that can't re-render).

Honours the repo's "no per-feature branches in the renderer/daemon" rule: everything flows through the `PreviewOverrideExtension` SPI + `DataProductRegistry`, mirroring the Remote Compose connector.

## Test plan

- `:data-preview-overrides-connector:test` — controller seed/record/clear/reset, planner threading, `compose/overrides` capability + capture. ✅
- `:daemon:core:test` (`PreviewOverrideMergeTest`) — `namedOverrides` per-key merge + `toExtensionOverrides` projection. ✅
- `:gradle-plugin:test` (`PreviewBundleFormatTest`) — schema is v8. ✅
- `:gradle-plugin:functionalTest` (`BundleFunctionalTest`) — the override sidecar lands as `previews/<id>.overrides.json` in the packed bundle. ✅
- `:cli:test` (`ServeBundleStoreTest` / `ServeBundleHostTest` / `ServeOverridesTest` / `ServeWebFixtureTest`) — sidecar extraction + a served bundle surfacing its declared knobs (incl. an indexed one) + refreshed golden HTML. ✅
- Both daemons (`:daemon:desktop`, `:daemon:android`) and both renderers compile; `ktfmtCheckAll` clean. ✅

## Visual evidence

The one new rendered surface is the sample `OverridableListPreview` in `:samples:cmp` (a committed `@Preview`, so the CI visual-diff bot renders and diffs it on every future PR automatically). It renders at its knob defaults — "Shopping list" title in the `accent` blue, three "Item N" cards — and the captured `previews/<id>.overrides.json` records `title`, `accent` (`#FF3366FF`), `itemCount`, and `rowLabel[0..2]`:

![OverridableListPreview](``https://raw.githubusercontent.com/yschimke/compose-ai-tools/ab7710a57a374782a5319852e9d3bf6b16969740/renders/samples:cmp/OverridableListPreview_Overridable_List.png)``

The serve-viewer HTML change (the declared-knobs control list) has no `@Preview` path; its golden fixtures (`serve-landing.html` / `serve-viewer.html`) are covered by `ServeWebFixtureTest`. On a static bundle the knobs render disabled with a note.

## Scope notes

- **Live re-render of named overrides on the daemon-backed serve path** (the JS → `ServeOverrides` → re-render loop) is a deliberate follow-up. Seeding through `renderNow` is wired; the browser-side edit loop is not yet.
- **`data/fetch?kind=compose/overrides` is desktop-only.** On Android the `previewOverride*` calls record into the Robolectric sandbox classloader's copy of the static controller, which a host-side registry can't read; a sandbox→host bridge is follow-up. Bundle carriage is unaffected — the Android sidecar is captured in-sandbox by `RobolectricRenderTest`.