### PR TITLE
feat(bundle): Ed25519 signing + trust verification for portable bundles

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
@@ -64,6 +64,9 @@ class BundleCommand(args: List<String>) : Command(args) {
       "extract" -> ExtractSubcommand(subArgs).run()
       "embed" -> EmbedSubcommand(subArgs).run()
       "render" -> RenderSubcommand(subArgs).run()
+      "keygen" -> KeygenSubcommand(subArgs).run()
+      "sign" -> SignSubcommand(subArgs).run()
+      "verify" -> VerifySubcommand(subArgs).run()
       "daemon" -> BundleDaemonCommand(subArgs).run()
       null,
       "help",
@@ -93,7 +96,17 @@ class BundleCommand(args: List<String>) : Command(args) {
         compose-preview bundle extract <bundle.png | URL> [-o <dir>]
         compose-preview bundle embed   <bundle.png | URL> [-o <dir|file.png>] [--title T] [--external-images] [--in-bundle]
         compose-preview bundle render  <bundle.png | URL> [-o <dir>]   (v1: stub — prints what would render)
+        compose-preview bundle keygen  [-o <key.pem>] [--key-id <id>]  (mint an Ed25519 signing keypair)
+        compose-preview bundle sign    <bundle.png> --key <private-key> --key-id <id> [--producer <name>]
+        compose-preview bundle verify  <bundle.png | URL> [--trust <store.json>] [--origin <repo@branch>]
         compose-preview bundle daemon  <bundle.png | URL> [-v]         (spawn the desktop daemon over stdio)
+
+      Signing (producer trust for the public preview server):
+        keygen  Mint an Ed25519 keypair; prints a ready-to-paste trust-store \"keys\" entry.
+        sign    Append a detached signature over the bundle's canonical digest (idempotent per key-id;
+                multiple producers can each sign). --provenance-identity attaches a CI OIDC identity.
+        verify  Check a bundle against a trust store and print the verdict (signature / branch /
+                provenance, or why it's unverified). Exit 3 when unverified.
 
       Pack flags:
         --id <preview-id>   Preview to include. Repeatable. First is the cover. Default: all.
@@ -692,6 +705,33 @@ internal fun injectSidecarsIntoBundle(
   val newZip = addOrReplaceZipEntries(zip, entries)
 
   val tmp = File(bundleFile.parentFile, "${bundleFile.name}.sidecar-tmp")
+  fileSystem.write(tmp.path.toPath()) {
+    write(prefix)
+    write(newZip)
+  }
+  fileSystem.atomicMove(tmp.path.toPath(), bundleFile.path.toPath())
+  return entries.size
+}
+
+/**
+ * Inject arbitrary top-level entries (posix zip path → bytes) into [bundleFile]'s zip portion **in
+ * place**, preserving the leading PNG cover and every existing entry; an entry with a colliding
+ * path is replaced (idempotent). Unlike [injectSidecarsIntoBundle] the paths are used verbatim (no
+ * `previews/` prefix), so this is the carrier for whole-bundle sidecars like `signatures.json`.
+ * Same temp-sibling + atomic-move + DOS-epoch contract as the other injectors. Returns the count
+ * written.
+ */
+internal fun injectRawZipEntries(
+  bundleFile: File,
+  entries: Map<String, ByteArray>,
+  fileSystem: FileSystem = SystemFileSystem,
+): Int {
+  if (entries.isEmpty()) return 0
+  val full = fileSystem.read(bundleFile.path.toPath()) { readByteArray() }
+  val zip = BundleReader.extractZipBytes(bundleFile)
+  val prefix = full.copyOfRange(0, full.size - zip.size)
+  val newZip = addOrReplaceZipEntries(zip, entries)
+  val tmp = File(bundleFile.parentFile, "${bundleFile.name}.rawentry-tmp")
   fileSystem.write(tmp.path.toPath()) {
     write(prefix)
     write(newZip)

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleSignCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleSignCommand.kt
@@ -1,0 +1,205 @@
+package ee.schimke.composeai.cli
+
+import ee.schimke.composeai.cli.serve.BundleVerifier
+import ee.schimke.composeai.cli.serve.TrustStore
+import java.io.File
+import kotlin.system.exitProcess
+
+/**
+ * `compose-preview bundle <keygen|sign|verify>` — the producer-trust side of portable bundles.
+ *
+ * A public preview server will re-render a bundle's executable Compose only when it can attribute
+ * the bundle to a trusted producer. These three subcommands are how a producer creates that
+ * attribution and how anyone checks it:
+ *
+ * - **keygen** — mint an Ed25519 keypair. The private key signs bundles; the public key (printed as
+ *   a ready-to-paste trust-store entry) goes into the server's `trust/producers.json`.
+ * - **sign** — append a detached signature over the bundle's canonical digest (see
+ *   [BundleSigning]). Idempotent per `--key-id`; multiple producers can each add their own
+ *   signature.
+ * - **verify** — check a bundle against a trust store and print the verdict (which producer, which
+ *   basis — signature / branch / provenance — or why it's unverified).
+ */
+internal class KeygenSubcommand(private val args: List<String>) {
+  fun run() {
+    val out = args.flagValue("--output") ?: args.flagValue("-o")
+    val explicitId = args.flagValue("--key-id")
+    val pair = BundleSigning.generateKeyPair()
+    val keyId =
+      explicitId
+        ?: "key-${BundleSigning.hex(BundleSigning.sha256(BundleSigning.decodeBase64(pair.publicKeyB64))).take(8)}"
+
+    val privatePem =
+      "-----BEGIN PRIVATE KEY-----\n" +
+        pair.privateKeyB64.chunked(64).joinToString("\n") +
+        "\n-----END PRIVATE KEY-----\n"
+
+    if (out != null) {
+      val f = File(out).absoluteFile
+      f.parentFile?.mkdirs()
+      f.writeText(privatePem)
+      // Best-effort lock-down of the private key file.
+      runCatching {
+        f.setReadable(false, false)
+        f.setReadable(true, true)
+      }
+      println("wrote private key → ${f.path}")
+    } else {
+      println(privatePem.trimEnd())
+    }
+
+    println()
+    println("public key (add to your trust store's \"keys\"):")
+    println(
+      """
+      {
+        "keyId": "$keyId",
+        "name": "TODO: producer name",
+        "publicKey": "${pair.publicKeyB64}"
+      }
+      """
+        .trimIndent()
+    )
+    println()
+    println(
+      "sign with:  compose-preview bundle sign <bundle.png> --key <private-key> --key-id $keyId"
+    )
+  }
+}
+
+internal class SignSubcommand(private val args: List<String>) {
+  fun run() {
+    val path = args.firstOrNull { !it.startsWith("-") }
+    val keyArg = args.flagValue("--key")
+    val keyId = args.flagValue("--key-id")
+    val producer = args.flagValue("--producer")
+    val provIdentity = args.flagValue("--provenance-identity")
+    val provType = args.flagValue("--provenance-type") ?: "github-oidc"
+    if (path == null || keyArg == null || keyId == null) {
+      System.err.println(
+        "Usage: compose-preview bundle sign <bundle.png> --key <private-key-file> --key-id <id> " +
+          "[--producer <name>] [--provenance-identity <id> [--provenance-type github-oidc|sigstore]]"
+      )
+      exitProcess(64)
+    }
+    val bundle = resolveLocalBundle(path)
+    val keyFile = File(keyArg)
+    if (!keyFile.isFile) {
+      System.err.println("bundle sign: private key file not found: ${keyFile.path}")
+      exitProcess(1)
+    }
+    val privateKey =
+      try {
+        BundleSigning.parsePrivateKey(keyFile.readText())
+      } catch (e: Exception) {
+        System.err.println("bundle sign: could not parse Ed25519 private key (${e.message})")
+        exitProcess(1)
+      }
+
+    val digest = BundleSigning.canonicalDigest(bundle)
+    val sigBytes = BundleSigning.signEd25519(privateKey, digest)
+    val signature =
+      BundleSigning.Signature(
+        keyId = keyId,
+        algorithm = BundleSigning.ALG_ED25519,
+        digest = BundleSigning.hex(digest),
+        signature = BundleSigning.base64(sigBytes),
+        producer = producer,
+        provenance = provIdentity?.let { BundleSigning.Provenance(type = provType, identity = it) },
+      )
+    val count = BundleSigning.addSignature(bundle, signature)
+    println("signed ${bundle.path}")
+    println("  keyId:   $keyId")
+    println("  digest:  ${BundleSigning.hex(digest)}")
+    println("  signatures now on bundle: $count")
+  }
+}
+
+internal class VerifySubcommand(private val args: List<String>) {
+  fun run() {
+    val path = args.firstOrNull { !it.startsWith("-") }
+    val trustArg = args.flagValue("--trust")
+    val originArg = args.flagValue("--origin") // repo@branch
+    if (path == null) {
+      System.err.println(
+        "Usage: compose-preview bundle verify <bundle.png | URL> [--trust <store.json>] " +
+          "[--origin <repo@branch>]"
+      )
+      exitProcess(64)
+    }
+    val bundle =
+      try {
+        BundleSource.resolveToFile(path)
+      } catch (e: IllegalArgumentException) {
+        System.err.println(e.message)
+        exitProcess(1)
+      }
+    val trust =
+      if (trustArg != null) {
+        val f = File(trustArg)
+        if (!f.isFile) {
+          System.err.println("bundle verify: trust store not found: ${f.path}")
+          exitProcess(1)
+        }
+        try {
+          TrustStore.load(f)
+        } catch (e: Exception) {
+          System.err.println("bundle verify: could not parse trust store (${e.message})")
+          exitProcess(1)
+        }
+      } else TrustStore.EMPTY
+
+    val origin = originArg?.let {
+      val at = it.indexOf('@')
+      if (at < 0) BundleVerifier.Origin(it, "*")
+      else BundleVerifier.Origin(it.substring(0, at), it.substring(at + 1))
+    }
+
+    val digest = BundleSigning.hex(BundleSigning.canonicalDigest(bundle))
+    val sigs = BundleSigning.readSignatures(bundle)?.signatures.orEmpty()
+    println("bundle:  ${bundle.path}")
+    println("digest:  $digest")
+    println("signatures present: ${sigs.size}${if (sigs.isEmpty()) " (unsigned)" else ""}")
+    for (s in sigs) {
+      val provNote = s.provenance?.let { " provenance=${it.type}:${it.identity}" } ?: ""
+      println("  - keyId=${s.keyId} alg=${s.algorithm}$provNote")
+    }
+
+    when (val verdict = BundleVerifier.verify(bundle, trust, origin)) {
+      is BundleVerifier.Verdict.Trusted -> {
+        println("verdict: TRUSTED")
+        for (b in verdict.bases) println("  via ${describe(b)}")
+      }
+      is BundleVerifier.Verdict.Unverified -> {
+        println("verdict: UNVERIFIED (${verdict.reason})")
+        // Non-zero exit so CI / scripts can gate on it.
+        exitProcess(3)
+      }
+    }
+  }
+
+  private fun describe(b: BundleVerifier.Basis): String =
+    when (b) {
+      is BundleVerifier.Basis.Signature ->
+        "signature (keyId=${b.keyId}${b.producer?.let { ", $it" } ?: ""})"
+      is BundleVerifier.Basis.Branch -> "trusted branch (${b.repo}@${b.branch})"
+      is BundleVerifier.Basis.Provenance -> "provenance (${b.type}:${b.identity})"
+    }
+}
+
+/**
+ * Resolve a bundle path for an **in-place** operation (sign rewrites the file), refusing a URL: a
+ * downloaded bundle is a delete-on-exit temp file, so signing it in place would vanish on exit.
+ */
+private fun resolveLocalBundle(path: String): File {
+  if (BundleSource.looksLikeUrl(path)) {
+    System.err.println("bundle sign: the input is a URL; download it to a local file first.")
+    exitProcess(64)
+  }
+  val f = File(path)
+  if (!f.isFile) {
+    System.err.println("bundle sign: bundle not found: ${f.path}")
+    exitProcess(1)
+  }
+  return f
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleSigning.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleSigning.kt
@@ -1,0 +1,196 @@
+package ee.schimke.composeai.cli
+
+import java.io.ByteArrayInputStream
+import java.io.File
+import java.security.KeyFactory
+import java.security.KeyPairGenerator
+import java.security.MessageDigest
+import java.security.PrivateKey
+import java.security.PublicKey
+import java.security.spec.PKCS8EncodedKeySpec
+import java.security.spec.X509EncodedKeySpec
+import java.util.Base64
+import java.util.zip.ZipInputStream
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/**
+ * Ed25519 bundle signing + verification — the reference implementation shared by `compose-preview
+ * bundle sign|verify|keygen` ([BundleSignCommand]) and the public-server trust gate
+ * ([BundleVerifier]).
+ *
+ * The signed bytes are the bundle's **canonical digest**, not the raw `.png` file: zip ordering /
+ * compression aren't byte-stable and `signatures.json` itself must be excluded so a second producer
+ * can append a signature without invalidating the first. See [canonicalDigest] for the exact recipe
+ * (it mirrors the contract documented on `BundleSignatures` in `:gradle-plugin`'s
+ * `PreviewBundleFormat.kt` — the CLI re-declares the wire shape here rather than depend on that
+ * module, same pattern as [BundleReader]).
+ */
+internal object BundleSigning {
+
+  /** Zip path of the detached signatures; excluded from the digest it signs. */
+  const val SIGNATURES_PATH = "signatures.json"
+  const val SIGNATURES_SCHEMA = "compose-preview-bundle/signatures/v1"
+  const val ALG_ED25519 = "ed25519"
+
+  /** CLI-side mirror of `BundleSignatures` in `PreviewBundleFormat.kt`. */
+  @Serializable
+  data class Signatures(val schema: String = SIGNATURES_SCHEMA, val signatures: List<Signature>)
+
+  /** CLI-side mirror of `BundleSignature`. */
+  @Serializable
+  data class Signature(
+    val keyId: String,
+    val algorithm: String = ALG_ED25519,
+    val digest: String,
+    val signature: String,
+    val producer: String? = null,
+    val provenance: Provenance? = null,
+  )
+
+  /** CLI-side mirror of `BundleProvenance`. */
+  @Serializable
+  data class Provenance(val type: String, val identity: String, val attestation: String? = null)
+
+  private val json = Json {
+    ignoreUnknownKeys = true
+    encodeDefaults = true
+    prettyPrint = true
+  }
+
+  // --- canonical digest -------------------------------------------------------------------------
+
+  /**
+   * The SHA-256 over the bundle's logical content (see the class kdoc). Every zip entry except
+   * [SIGNATURES_PATH] and directory entries contributes a `"<path>:<hex-sha256>"` line; the lines
+   * are sorted by path and joined with `\n`, and the digest is the SHA-256 of that string.
+   * Deterministic regardless of zip ordering or compression, and stable when signatures are
+   * appended.
+   */
+  fun canonicalDigest(zipBytes: ByteArray): ByteArray {
+    val lines = ArrayList<String>()
+    ZipInputStream(ByteArrayInputStream(zipBytes)).use { zin ->
+      while (true) {
+        val entry = zin.nextEntry ?: break
+        if (!entry.isDirectory && entry.name != SIGNATURES_PATH) {
+          val sha = sha256(zin.readBytes())
+          lines.add("${entry.name}:${hex(sha)}")
+        }
+        zin.closeEntry()
+      }
+    }
+    lines.sort()
+    return sha256(lines.joinToString("\n").toByteArray(Charsets.UTF_8))
+  }
+
+  /** Canonical digest of a bundle file (polyglot-aware). */
+  fun canonicalDigest(bundle: File): ByteArray =
+    canonicalDigest(BundleReader.extractZipBytes(bundle))
+
+  // --- signatures.json read / write ------------------------------------------------------------
+
+  /** Decode `signatures.json` from a bundle's [zipBytes], or null when the bundle is unsigned. */
+  fun readSignatures(zipBytes: ByteArray): Signatures? {
+    var bytes: ByteArray? = null
+    ZipInputStream(ByteArrayInputStream(zipBytes)).use { zin ->
+      while (true) {
+        val entry = zin.nextEntry ?: break
+        if (!entry.isDirectory && entry.name == SIGNATURES_PATH) bytes = zin.readBytes()
+        zin.closeEntry()
+      }
+    }
+    val raw = bytes ?: return null
+    return runCatching {
+        json.decodeFromString(Signatures.serializer(), raw.toString(Charsets.UTF_8))
+      }
+      .getOrNull()
+  }
+
+  fun readSignatures(bundle: File): Signatures? =
+    readSignatures(BundleReader.extractZipBytes(bundle))
+
+  /**
+   * Append [signature] to [bundle]'s `signatures.json` in place (merging with any signatures
+   * already present, replacing one with the same `keyId`), keeping the leading PNG cover and every
+   * other entry. Idempotent per keyId. Returns the resulting signature count.
+   */
+  fun addSignature(bundle: File, signature: Signature): Int {
+    val existing =
+      readSignatures(bundle)?.signatures.orEmpty().filter { it.keyId != signature.keyId }
+    val merged = Signatures(signatures = existing + signature)
+    val bytes = json.encodeToString(Signatures.serializer(), merged).toByteArray(Charsets.UTF_8)
+    // Reuse the polyglot-preserving zip rewriter the semantics/web injectors use.
+    injectRawZipEntries(bundle, mapOf(SIGNATURES_PATH to bytes))
+    return merged.signatures.size
+  }
+
+  // --- Ed25519 ----------------------------------------------------------------------------------
+
+  /** Sign [digest] with an Ed25519 [privateKey]; returns the raw signature bytes. */
+  fun signEd25519(privateKey: PrivateKey, digest: ByteArray): ByteArray {
+    // Fully qualified — the nested [Signature] data class shadows java.security.Signature here.
+    val sig = java.security.Signature.getInstance("Ed25519")
+    sig.initSign(privateKey)
+    sig.update(digest)
+    return sig.sign()
+  }
+
+  /** Verify [signatureBytes] over [digest] against an Ed25519 [publicKey]. */
+  fun verifyEd25519(publicKey: PublicKey, digest: ByteArray, signatureBytes: ByteArray): Boolean =
+    runCatching {
+        val sig = java.security.Signature.getInstance("Ed25519")
+        sig.initVerify(publicKey)
+        sig.update(digest)
+        sig.verify(signatureBytes)
+      }
+      .getOrDefault(false)
+
+  /** A fresh Ed25519 keypair, base64-encoded: private = PKCS#8 DER, public = X.509 SPKI DER. */
+  data class KeyPairB64(val privateKeyB64: String, val publicKeyB64: String)
+
+  fun generateKeyPair(): KeyPairB64 {
+    val pair = KeyPairGenerator.getInstance("Ed25519").generateKeyPair()
+    return KeyPairB64(
+      privateKeyB64 = Base64.getEncoder().encodeToString(pair.private.encoded),
+      publicKeyB64 = Base64.getEncoder().encodeToString(pair.public.encoded),
+    )
+  }
+
+  /** Parse an Ed25519 private key from PEM (`-----BEGIN PRIVATE KEY-----`) or raw base64 PKCS#8. */
+  fun parsePrivateKey(text: String): PrivateKey {
+    val der = decodePemOrBase64(text, "PRIVATE KEY")
+    return KeyFactory.getInstance("Ed25519").generatePrivate(PKCS8EncodedKeySpec(der))
+  }
+
+  /**
+   * Parse an Ed25519 public key from PEM (`-----BEGIN PUBLIC KEY-----`) or raw base64 X.509 SPKI.
+   */
+  fun parsePublicKey(text: String): PublicKey {
+    val der = decodePemOrBase64(text, "PUBLIC KEY")
+    return KeyFactory.getInstance("Ed25519").generatePublic(X509EncodedKeySpec(der))
+  }
+
+  private fun decodePemOrBase64(text: String, label: String): ByteArray {
+    val trimmed = text.trim()
+    val body =
+      if (trimmed.contains("-----BEGIN")) {
+        trimmed
+          .substringAfter("-----BEGIN $label-----", trimmed)
+          .substringBefore("-----END $label-----")
+          .replace("\\s".toRegex(), "")
+      } else {
+        trimmed.replace("\\s".toRegex(), "")
+      }
+    return Base64.getDecoder().decode(body)
+  }
+
+  // --- helpers ----------------------------------------------------------------------------------
+
+  fun base64(bytes: ByteArray): String = Base64.getEncoder().encodeToString(bytes)
+
+  fun decodeBase64(text: String): ByteArray = Base64.getDecoder().decode(text.trim())
+
+  fun hex(bytes: ByteArray): String = bytes.joinToString("") { "%02x".format(it) }
+
+  fun sha256(bytes: ByteArray): ByteArray = MessageDigest.getInstance("SHA-256").digest(bytes)
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
@@ -59,6 +59,14 @@ internal object CliFlags {
       "--bundles",
       "--accept-bundles-from",
       "--revisions-allow",
+      // bundle sign / verify / keygen (producer trust)
+      "--key",
+      "--key-id",
+      "--producer",
+      "--provenance-identity",
+      "--provenance-type",
+      "--trust",
+      "--origin",
       // Required-reason escape hatch. Usually written attached (`--force=<reason>`), but the space
       // form `--force <reason>` is supported (ForceFlagTest), so the reason must be skipped or it's
       // mistaken for the command.

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/BundleVerifier.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/BundleVerifier.kt
@@ -1,0 +1,99 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.cli.BundleSigning
+import java.io.File
+
+/**
+ * Decides whether a bundle came from a producer the operator trusts, by combining the three
+ * [TrustStore] bases against a bundle's `signatures.json` and (optionally) the [Origin] the server
+ * fetched it from. The result gates whether the public preview server will **re-render** the
+ * bundle's executable Compose — data tiers (baked PNGs, Remote Compose / protolayout / Lottie IR)
+ * serve regardless of the verdict because they execute no code.
+ *
+ * Verification is fail-closed: anything the store can't positively attribute is
+ * [Verdict.Unverified].
+ */
+object BundleVerifier {
+
+  /** Where the server obtained the bundle, when it fetched it itself (vs. a client upload). */
+  data class Origin(val repo: String, val branch: String)
+
+  sealed interface Verdict {
+    /** At least one trust basis matched. [bases] lists every basis that did, strongest first. */
+    data class Trusted(val bases: List<Basis>) : Verdict {
+      val primary: Basis
+        get() = bases.first()
+    }
+
+    /** No basis matched. [reason] is a short human-readable explanation. */
+    data class Unverified(val reason: String) : Verdict
+  }
+
+  sealed interface Basis {
+    /** A pinned Ed25519 key signed the canonical digest and verified. The strongest basis. */
+    data class Signature(val keyId: String, val producer: String?) : Basis
+
+    /** The server fetched the bundle from a trusted branch (origin/TLS trust). */
+    data class Branch(val repo: String, val branch: String) : Basis
+
+    /**
+     * A signature carried a CI provenance attestation whose identity the store trusts, and the
+     * attested digest matches the recomputed canonical digest. Advisory: the binding is the
+     * identity-glob match plus digest integrity, not (yet) a full Sigstore/Rekor proof.
+     */
+    data class Provenance(val identity: String, val type: String) : Basis
+  }
+
+  /** Verify a bundle file. [origin] is non-null only when the server fetched it itself. */
+  fun verify(bundle: File, trust: TrustStore, origin: Origin? = null): Verdict {
+    val digest = BundleSigning.canonicalDigest(bundle)
+    val expectedDigestHex = BundleSigning.hex(digest)
+    val bases = ArrayList<Basis>()
+
+    // 1) Origin trust — the server pulled it from a branch it trusts.
+    if (origin != null && trust.trustsBranch(origin.repo, origin.branch)) {
+      bases.add(Basis.Branch(origin.repo, origin.branch))
+    }
+
+    // 2) Signature trust — a pinned key cryptographically verifies the canonical digest.
+    val signatures = BundleSigning.readSignatures(bundle)?.signatures.orEmpty()
+    for (sig in signatures) {
+      if (sig.algorithm != BundleSigning.ALG_ED25519) continue
+      // The signature's claimed digest must match what we recomputed (no signing a different
+      // bundle).
+      if (sig.digest != expectedDigestHex) continue
+      val key = trust.publicKeyFor(sig.keyId)
+      if (key != null) {
+        val ok =
+          runCatching {
+              BundleSigning.verifyEd25519(key, digest, BundleSigning.decodeBase64(sig.signature))
+            }
+            .getOrDefault(false)
+        if (ok) bases.add(Basis.Signature(sig.keyId, sig.producer ?: trust.keyName(sig.keyId)))
+      }
+    }
+
+    // 3) Provenance trust — a CI identity the store trusts attested this exact digest.
+    for (sig in signatures) {
+      val prov = sig.provenance ?: continue
+      if (sig.digest != expectedDigestHex) continue
+      if (trust.trustsIdentity(prov.identity)) {
+        bases.add(Basis.Provenance(prov.identity, prov.type))
+      }
+    }
+
+    // Order strongest-first: Signature > Branch > Provenance.
+    val ordered = bases.sortedBy {
+      when (it) {
+        is Basis.Signature -> 0
+        is Basis.Branch -> 1
+        is Basis.Provenance -> 2
+      }
+    }
+    return if (ordered.isEmpty())
+      Verdict.Unverified(
+        if (signatures.isEmpty()) "unsigned bundle" else "no trusted signature/branch/provenance"
+      )
+    else Verdict.Trusted(ordered)
+  }
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/BundleVerifier.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/BundleVerifier.kt
@@ -37,9 +37,14 @@ object BundleVerifier {
     data class Branch(val repo: String, val branch: String) : Basis
 
     /**
-     * A signature carried a CI provenance attestation whose identity the store trusts, and the
-     * attested digest matches the recomputed canonical digest. Advisory: the binding is the
-     * identity-glob match plus digest integrity, not (yet) a full Sigstore/Rekor proof.
+     * Supplementary CI-provenance context recorded **only alongside a cryptographically-verified
+     * [Signature]** — never on its own. A `provenance` block is self-asserted data (any uploader
+     * can write any identity), so identity-glob + digest match is *not* proof of origin; granting
+     * trust from it alone would be a bypass (an attacker writes `signatures.json` with the
+     * recomputed digest and a matching identity → `Trusted` → re-render of executable Compose).
+     * Real keyless trust needs Fulcio cert-chain + Rekor verification, which is a follow-up; until
+     * then this basis only annotates a signature a pinned key already verified, so it expands the
+     * displayed provenance but never the trust decision.
      */
     data class Provenance(val identity: String, val type: String) : Basis
   }
@@ -55,29 +60,29 @@ object BundleVerifier {
       bases.add(Basis.Branch(origin.repo, origin.branch))
     }
 
-    // 2) Signature trust — a pinned key cryptographically verifies the canonical digest.
+    // 2) Signature trust — a pinned key cryptographically verifies the canonical digest. This is
+    // the
+    // ONLY path that turns a signature into trust. Provenance is recorded as supplementary context
+    // for a signature that *already* verified — it never grants trust on its own (see
+    // [Basis.Provenance]).
     val signatures = BundleSigning.readSignatures(bundle)?.signatures.orEmpty()
     for (sig in signatures) {
       if (sig.algorithm != BundleSigning.ALG_ED25519) continue
       // The signature's claimed digest must match what we recomputed (no signing a different
       // bundle).
       if (sig.digest != expectedDigestHex) continue
-      val key = trust.publicKeyFor(sig.keyId)
-      if (key != null) {
-        val ok =
-          runCatching {
-              BundleSigning.verifyEd25519(key, digest, BundleSigning.decodeBase64(sig.signature))
-            }
-            .getOrDefault(false)
-        if (ok) bases.add(Basis.Signature(sig.keyId, sig.producer ?: trust.keyName(sig.keyId)))
-      }
-    }
-
-    // 3) Provenance trust — a CI identity the store trusts attested this exact digest.
-    for (sig in signatures) {
-      val prov = sig.provenance ?: continue
-      if (sig.digest != expectedDigestHex) continue
-      if (trust.trustsIdentity(prov.identity)) {
+      val key = trust.publicKeyFor(sig.keyId) ?: continue
+      val ok =
+        runCatching {
+            BundleSigning.verifyEd25519(key, digest, BundleSigning.decodeBase64(sig.signature))
+          }
+          .getOrDefault(false)
+      if (!ok) continue
+      bases.add(Basis.Signature(sig.keyId, sig.producer ?: trust.keyName(sig.keyId)))
+      // Only now — on a cryptographically verified signature — record a trusted CI identity it
+      // carries, as extra provenance context. A pinned key did the actual attesting.
+      val prov = sig.provenance
+      if (prov != null && trust.trustsIdentity(prov.identity)) {
         bases.add(Basis.Provenance(prov.identity, prov.type))
       }
     }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/TrustStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/TrustStore.kt
@@ -17,9 +17,11 @@ import kotlinx.serialization.json.Json
  *   catalogs from. A bundle the server itself pulled from such a branch is **trusted by origin**
  *   (TLS trust in the source, no per-bundle crypto needed). This is how the published
  *   `design-artifacts` catalogs are trusted.
- * - [oidc] — GitHub Actions / Sigstore workload-identity globs. A signature carrying a matching
- *   provenance attestation is **trusted by provenance** (keyless CI identity). Advisory until full
- *   Rekor/Sigstore verification lands — see [BundleVerifier].
+ * - [oidc] — GitHub Actions / Sigstore workload-identity globs. These do **not** by themselves
+ *   grant trust: provenance is self-asserted data, so a real keyless proof needs Fulcio
+ *   cert-chain + Rekor verification (a follow-up). Until that lands, a trusted `oidc` identity only
+ *   *annotates* a signature a pinned [keys] entry already verified — it never expands the trust
+ *   decision, so it can't be a bypass. See [BundleVerifier].
  *
  * An empty store trusts nothing (fail-closed): every bundle verifies as `Unverified`, so a public
  * server with no trust store still serves data tiers but never re-renders untrusted Compose.

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/TrustStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/TrustStore.kt
@@ -1,0 +1,89 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.cli.BundleSigning
+import java.io.File
+import java.security.PublicKey
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/**
+ * The set of producers a verifier ([BundleVerifier]) trusts, loaded from a JSON file the operator
+ * controls (`trust/producers.json`). Three independent bases, matching the three trust mechanisms a
+ * public preview server supports:
+ *
+ * - [keys] — pinned Ed25519 public keys. A bundle signature whose `keyId` is here and that
+ *   cryptographically verifies is **trusted by signature** (the strongest, fully offline basis).
+ * - [branches] — GitHub `repo` + `branch` globs the server is willing to fetch design-system
+ *   catalogs from. A bundle the server itself pulled from such a branch is **trusted by origin**
+ *   (TLS trust in the source, no per-bundle crypto needed). This is how the published
+ *   `design-artifacts` catalogs are trusted.
+ * - [oidc] — GitHub Actions / Sigstore workload-identity globs. A signature carrying a matching
+ *   provenance attestation is **trusted by provenance** (keyless CI identity). Advisory until full
+ *   Rekor/Sigstore verification lands — see [BundleVerifier].
+ *
+ * An empty store trusts nothing (fail-closed): every bundle verifies as `Unverified`, so a public
+ * server with no trust store still serves data tiers but never re-renders untrusted Compose.
+ */
+@Serializable
+data class TrustStore(
+  val keys: List<TrustedKey> = emptyList(),
+  val branches: List<TrustedBranch> = emptyList(),
+  val oidc: List<TrustedIdentity> = emptyList(),
+) {
+
+  /** Resolve the pinned public key for [keyId], or null when the store doesn't trust it. */
+  fun publicKeyFor(keyId: String): PublicKey? {
+    val entry = keys.firstOrNull { it.keyId == keyId } ?: return null
+    return runCatching { BundleSigning.parsePublicKey(entry.publicKey) }.getOrNull()
+  }
+
+  fun keyName(keyId: String): String? = keys.firstOrNull { it.keyId == keyId }?.name
+
+  /** True when the store trusts catalogs fetched from [repo]@[branch] (glob-matched). */
+  fun trustsBranch(repo: String, branch: String): Boolean = branches.any {
+    globMatch(it.repo, repo) && globMatch(it.branch, branch)
+  }
+
+  /** True when the store trusts a CI provenance [identity] (glob-matched). */
+  fun trustsIdentity(identity: String): Boolean = oidc.any { globMatch(it.identity, identity) }
+
+  companion object {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    /** The empty, fail-closed store — trusts nothing. */
+    val EMPTY = TrustStore()
+
+    fun load(file: File): TrustStore =
+      json.decodeFromString(serializer(), file.readText(Charsets.UTF_8))
+
+    fun parse(text: String): TrustStore = json.decodeFromString(serializer(), text)
+
+    /**
+     * Glob match supporting `*` (any run of chars, including `/`) — enough for `repo`/`branch`/
+     * `identity` patterns like `design-artifacts/<glob>` or
+     * `repo:yschimke/compose-ai-tools:ref:...`. Anchored (full-string) and case-sensitive. A
+     * literal pattern with no `*` is exact-match.
+     */
+    fun globMatch(pattern: String, value: String): Boolean {
+      if (!pattern.contains('*')) return pattern == value
+      val regex = buildString {
+        append('^')
+        for (c in pattern) {
+          if (c == '*') append(".*") else append(Regex.escape(c.toString()))
+        }
+        append('$')
+      }
+      return Regex(regex).matches(value)
+    }
+  }
+}
+
+/** A pinned producer public key. [publicKey] is PEM or base64 X.509 SPKI (see [BundleSigning]). */
+@Serializable
+data class TrustedKey(val keyId: String, val publicKey: String, val name: String? = null)
+
+/** A GitHub branch the server may fetch trusted catalogs from. `branch` defaults to "any". */
+@Serializable data class TrustedBranch(val repo: String, val branch: String = "*")
+
+/** A trusted CI workload identity (GitHub OIDC subject / Sigstore identity), glob-matched. */
+@Serializable data class TrustedIdentity(val identity: String)

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleSigningTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleSigningTest.kt
@@ -1,0 +1,242 @@
+package ee.schimke.composeai.cli
+
+import ee.schimke.composeai.cli.serve.BundleVerifier
+import ee.schimke.composeai.cli.serve.TrustStore
+import ee.schimke.composeai.cli.serve.TrustedBranch
+import ee.schimke.composeai.cli.serve.TrustedIdentity
+import ee.schimke.composeai.cli.serve.TrustedKey
+import java.awt.image.BufferedImage
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.nio.file.Files
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+import javax.imageio.ImageIO
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Ed25519 bundle signing + trust verification ([BundleSigning], [TrustStore], [BundleVerifier]) —
+ * the producer-trust core that lets the public preview server attribute a bundle before
+ * re-rendering its executable Compose. Exercises the canonical digest, the sign→verify round trip,
+ * tamper detection, wrong-key rejection, and the branch / provenance trust bases.
+ */
+class BundleSigningTest {
+
+  private val workRoot = Files.createTempDirectory("bundle-signing-test-").toFile()
+
+  @AfterTest
+  fun cleanup() {
+    workRoot.deleteRecursively()
+  }
+
+  private fun png(w: Int = 4, h: Int = 4, rgb: Int = 0x112233): ByteArray {
+    val img = BufferedImage(w, h, BufferedImage.TYPE_INT_RGB)
+    img.setRGB(0, 0, rgb)
+    val baos = ByteArrayOutputStream()
+    ImageIO.write(img, "png", baos)
+    return baos.toByteArray()
+  }
+
+  private fun bundle(name: String, entries: Map<String, ByteArray>): File {
+    // The leading PNG cover is outside the appended zip and excluded from the canonical digest, so
+    // a
+    // fixed valid PNG keeps the polyglot readable without affecting any digest assertion.
+    val cover = png(2, 2)
+    val zip = ByteArrayOutputStream()
+    ZipOutputStream(zip).use { z ->
+      for ((path, bytes) in entries) {
+        z.putNextEntry(ZipEntry(path))
+        z.write(bytes)
+        z.closeEntry()
+      }
+    }
+    val file = File(workRoot, name)
+    file.outputStream().use {
+      it.write(cover)
+      it.write(zip.toByteArray())
+    }
+    return file
+  }
+
+  private fun sampleBundle(name: String = "bundle.png"): File {
+    val cover = png(4, 8)
+    return bundle(
+      name,
+      linkedMapOf(
+        "bundle.json" to
+          """{"schemaVersion":7,"backend":"desktop","previewIds":["a"],"coverPreviewId":"a","classpath":[{"kind":"module","path":"classes/app.jar"}],"modulePath":":app","producedBy":"test"}"""
+            .toByteArray(),
+        "previews/a.png" to cover,
+        "classes/app.jar" to "FAKEJAR".toByteArray(),
+      ),
+    )
+  }
+
+  @Test
+  fun `canonical digest is stable across zip ordering and changes on tamper`() {
+    val a = sampleBundle("a.png")
+    val b =
+      bundle(
+        "b.png",
+        // Same logical content, different insertion order.
+        linkedMapOf(
+          "classes/app.jar" to "FAKEJAR".toByteArray(),
+          "previews/a.png" to png(4, 8),
+          "bundle.json" to
+            """{"schemaVersion":7,"backend":"desktop","previewIds":["a"],"coverPreviewId":"a","classpath":[{"kind":"module","path":"classes/app.jar"}],"modulePath":":app","producedBy":"test"}"""
+              .toByteArray(),
+        ),
+      )
+    assertEquals(
+      BundleSigning.hex(BundleSigning.canonicalDigest(a)),
+      BundleSigning.hex(BundleSigning.canonicalDigest(b)),
+      "digest must be independent of zip entry order",
+    )
+
+    val tampered = sampleBundle("tampered.png")
+    injectRawZipEntries(tampered, mapOf("classes/app.jar" to "EVIL".toByteArray()))
+    assertFalse(
+      BundleSigning.hex(BundleSigning.canonicalDigest(a)) ==
+        BundleSigning.hex(BundleSigning.canonicalDigest(tampered)),
+      "changing a covered entry must change the digest",
+    )
+  }
+
+  @Test
+  fun `sign then verify is trusted by signature`() {
+    val keys = BundleSigning.generateKeyPair()
+    val priv = File(workRoot, "key.b64").apply { writeText(keys.privateKeyB64) }
+    val file = sampleBundle()
+
+    val digest = BundleSigning.canonicalDigest(file)
+    val sig =
+      BundleSigning.Signature(
+        keyId = "ci",
+        digest = BundleSigning.hex(digest),
+        signature =
+          BundleSigning.base64(
+            BundleSigning.signEd25519(BundleSigning.parsePrivateKey(priv.readText()), digest)
+          ),
+        producer = "Test CI",
+      )
+    assertEquals(1, BundleSigning.addSignature(file, sig))
+
+    val trust = TrustStore(keys = listOf(TrustedKey("ci", keys.publicKeyB64, "Test CI")))
+    val verdict = BundleVerifier.verify(file, trust)
+    assertTrue(verdict is BundleVerifier.Verdict.Trusted, "expected trusted, got $verdict")
+    val basis = (verdict as BundleVerifier.Verdict.Trusted).primary
+    assertTrue(basis is BundleVerifier.Basis.Signature && basis.keyId == "ci")
+  }
+
+  @Test
+  fun `tampering after signing fails verification`() {
+    val keys = BundleSigning.generateKeyPair()
+    val file = sampleBundle()
+    val digest = BundleSigning.canonicalDigest(file)
+    BundleSigning.addSignature(
+      file,
+      BundleSigning.Signature(
+        keyId = "ci",
+        digest = BundleSigning.hex(digest),
+        signature =
+          BundleSigning.base64(
+            BundleSigning.signEd25519(BundleSigning.parsePrivateKey(keys.privateKeyB64), digest)
+          ),
+      ),
+    )
+    // Swap the executable jar after the signature was applied.
+    injectRawZipEntries(file, mapOf("classes/app.jar" to "EVIL".toByteArray()))
+
+    val trust = TrustStore(keys = listOf(TrustedKey("ci", keys.publicKeyB64)))
+    assertTrue(BundleVerifier.verify(file, trust) is BundleVerifier.Verdict.Unverified)
+  }
+
+  @Test
+  fun `signature from an untrusted key is unverified`() {
+    val signer = BundleSigning.generateKeyPair()
+    val other = BundleSigning.generateKeyPair()
+    val file = sampleBundle()
+    val digest = BundleSigning.canonicalDigest(file)
+    BundleSigning.addSignature(
+      file,
+      BundleSigning.Signature(
+        keyId = "ci",
+        digest = BundleSigning.hex(digest),
+        signature =
+          BundleSigning.base64(
+            BundleSigning.signEd25519(BundleSigning.parsePrivateKey(signer.privateKeyB64), digest)
+          ),
+      ),
+    )
+    // Trust store pins a DIFFERENT public key under the same keyId.
+    val trust = TrustStore(keys = listOf(TrustedKey("ci", other.publicKeyB64)))
+    assertTrue(BundleVerifier.verify(file, trust) is BundleVerifier.Verdict.Unverified)
+  }
+
+  @Test
+  fun `unsigned bundle is unverified`() {
+    val verdict = BundleVerifier.verify(sampleBundle(), TrustStore.EMPTY)
+    assertTrue(verdict is BundleVerifier.Verdict.Unverified)
+    assertEquals("unsigned bundle", (verdict as BundleVerifier.Verdict.Unverified).reason)
+  }
+
+  @Test
+  fun `trusted branch origin verifies an unsigned catalog`() {
+    val file = sampleBundle()
+    val trust =
+      TrustStore(
+        branches = listOf(TrustedBranch("yschimke/compose-ai-tools", "design-artifacts/*"))
+      )
+    val verdict =
+      BundleVerifier.verify(
+        file,
+        trust,
+        BundleVerifier.Origin("yschimke/compose-ai-tools", "design-artifacts/compose-m3"),
+      )
+    assertTrue(verdict is BundleVerifier.Verdict.Trusted)
+    assertTrue((verdict as BundleVerifier.Verdict.Trusted).primary is BundleVerifier.Basis.Branch)
+  }
+
+  @Test
+  fun `provenance identity is trusted when the digest matches`() {
+    val keys = BundleSigning.generateKeyPair()
+    val file = sampleBundle()
+    val digest = BundleSigning.canonicalDigest(file)
+    BundleSigning.addSignature(
+      file,
+      BundleSigning.Signature(
+        keyId = "ci",
+        digest = BundleSigning.hex(digest),
+        signature =
+          BundleSigning.base64(
+            BundleSigning.signEd25519(BundleSigning.parsePrivateKey(keys.privateKeyB64), digest)
+          ),
+        provenance =
+          BundleSigning.Provenance(
+            type = "github-oidc",
+            identity = "repo:yschimke/compose-ai-tools:ref:refs/heads/main",
+          ),
+      ),
+    )
+    // No pinned key — only the OIDC identity is trusted.
+    val trust = TrustStore(oidc = listOf(TrustedIdentity("repo:yschimke/compose-ai-tools:ref:*")))
+    val verdict = BundleVerifier.verify(file, trust)
+    assertTrue(verdict is BundleVerifier.Verdict.Trusted)
+    assertTrue(
+      (verdict as BundleVerifier.Verdict.Trusted).primary is BundleVerifier.Basis.Provenance
+    )
+  }
+
+  @Test
+  fun `glob match anchors and supports wildcards`() {
+    assertTrue(TrustStore.globMatch("design-artifacts/*", "design-artifacts/compose-m3"))
+    assertFalse(TrustStore.globMatch("design-artifacts/*", "other/compose-m3"))
+    assertTrue(TrustStore.globMatch("repo:org/repo:ref:*", "repo:org/repo:ref:refs/heads/main"))
+    assertFalse(TrustStore.globMatch("exact", "exact-suffix"))
+    assertTrue(TrustStore.globMatch("exact", "exact"))
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleSigningTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleSigningTest.kt
@@ -201,8 +201,14 @@ class BundleSigningTest {
     assertTrue((verdict as BundleVerifier.Verdict.Trusted).primary is BundleVerifier.Basis.Branch)
   }
 
+  /**
+   * Provenance is self-asserted data, so an identity glob + digest match is NOT proof of origin —
+   * granting trust from it alone would let an attacker write a `signatures.json` with the
+   * recomputed digest and a matching identity and have executable Compose re-rendered. With only
+   * the OIDC identity trusted (no pinned key), the verdict must stay Unverified.
+   */
   @Test
-  fun `provenance identity is trusted when the digest matches`() {
+  fun `provenance identity alone does not grant trust`() {
     val keys = BundleSigning.generateKeyPair()
     val file = sampleBundle()
     val digest = BundleSigning.canonicalDigest(file)
@@ -222,13 +228,48 @@ class BundleSigningTest {
           ),
       ),
     )
-    // No pinned key — only the OIDC identity is trusted.
+    // Only the OIDC identity is trusted; the signing key is NOT pinned.
     val trust = TrustStore(oidc = listOf(TrustedIdentity("repo:yschimke/compose-ai-tools:ref:*")))
+    assertTrue(BundleVerifier.verify(file, trust) is BundleVerifier.Verdict.Unverified)
+  }
+
+  /**
+   * Provenance is recorded as supplementary context only on a signature a pinned key already
+   * verified — so it annotates, never expands, the trust decision.
+   */
+  @Test
+  fun `provenance annotates a signature verified by a pinned key`() {
+    val keys = BundleSigning.generateKeyPair()
+    val file = sampleBundle()
+    val digest = BundleSigning.canonicalDigest(file)
+    BundleSigning.addSignature(
+      file,
+      BundleSigning.Signature(
+        keyId = "ci",
+        digest = BundleSigning.hex(digest),
+        signature =
+          BundleSigning.base64(
+            BundleSigning.signEd25519(BundleSigning.parsePrivateKey(keys.privateKeyB64), digest)
+          ),
+        provenance =
+          BundleSigning.Provenance(
+            type = "github-oidc",
+            identity = "repo:yschimke/compose-ai-tools:ref:refs/heads/main",
+          ),
+      ),
+    )
+    // Both the pinned key AND the OIDC identity are trusted.
+    val trust =
+      TrustStore(
+        keys = listOf(TrustedKey("ci", keys.publicKeyB64)),
+        oidc = listOf(TrustedIdentity("repo:yschimke/compose-ai-tools:ref:*")),
+      )
     val verdict = BundleVerifier.verify(file, trust)
     assertTrue(verdict is BundleVerifier.Verdict.Trusted)
-    assertTrue(
-      (verdict as BundleVerifier.Verdict.Trusted).primary is BundleVerifier.Basis.Provenance
-    )
+    val bases = (verdict as BundleVerifier.Verdict.Trusted).bases
+    // The cryptographic signature is the trust basis; provenance rides along as context.
+    assertTrue(bases.first() is BundleVerifier.Basis.Signature)
+    assertTrue(bases.any { it is BundleVerifier.Basis.Provenance })
   }
 
   @Test

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewBundleFormat.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewBundleFormat.kt
@@ -55,6 +55,13 @@ import kotlinx.serialization.json.JsonClassDiscriminator
  *                            runtime — it needs neither the consumer's `@Preview` bytecode nor the
  *                            full Compose graph that produced it. See [BundleIr] and
  *                            [BundleManifest.intermediateRepresentations].
+ * signatures.json          — (v8, optional) one or more detached producer signatures over the
+ *                            bundle's **canonical digest** (see [BundleSignatures]). Lets a verifier
+ *                            (the public preview server) prove a bundle came from a producer it
+ *                            trusts before it will re-render the bundle's executable Compose. Purely
+ *                            additive and **excluded from the digest it signs**, so a second producer
+ *                            can append its own signature without invalidating the first. Absent on
+ *                            an unsigned bundle.
  * extensions/<id>.json     — (v7, optional) a data extension's report (a11y findings, theme tokens,
  *                            drawn strings, …) **sliced to the cover (default) preview** — the one
  *                            shown as the leading PNG — so the headline image carries its detailed
@@ -261,6 +268,88 @@ data class BundleIr(
   val resourcesPath: String? = null,
 )
 
+/**
+ * (v8) The detached producer signatures carried in `signatures.json` ([BUNDLE_SIGNATURES_PATH]).
+ *
+ * # Why a public preview server needs this
+ *
+ * A portable bundle's baked PNGs and IR (`previews/<id>.png`, `ir/<id>.rcdoc`, …) are **data** —
+ * replaying them executes no consumer code, so a public server renders them safely from any
+ * uploader. But a bundle that carries `classes/app.jar` can be **re-rendered**, which runs the
+ * producer's Kotlin on the server. A public server must therefore only re-render a bundle it can
+ * attribute to a producer it trusts. A signature is that attribution: the producer signs the
+ * bundle's canonical digest with a private key, and the server verifies it against an allowlist of
+ * trusted public keys (multiple producers, each with a `keyId`). Unsigned / untrusted bundles still
+ * serve their data tiers; only server-side re-render is gated.
+ *
+ * # Canonical digest (what a signature signs)
+ *
+ * The signed bytes are **not** the raw file (zip ordering / compression aren't stable and
+ * `signatures.json` itself must be excluded so signatures can be appended independently). Instead
+ * the digest is computed over the bundle's logical content:
+ * 1. Enumerate every zip entry **except** `signatures.json` and directory entries.
+ * 2. For each, form the line `"<posix-path>:<lowercase-hex-sha256-of-bytes>"`.
+ * 3. Sort the lines by path (UTF-8 byte order), join with `"\n"`.
+ * 4. The **canonical digest** is the SHA-256 of that joined string's UTF-8 bytes.
+ *
+ * A signature is `Ed25519(privateKey, canonicalDigest)`. Verification recomputes the digest from
+ * the received bundle and checks each signature against the trusted public key named by its
+ * `keyId`. Tampering with any covered entry changes a per-entry hash → changes the digest → every
+ * signature fails. The reference implementation lives in `:cli` (`BundleSigning`), which the
+ * `compose-preview bundle sign` / `verify` commands and the serve verifier share.
+ */
+@Serializable
+data class BundleSignatures(
+  /** Schema id, pinned so a verifier can detect a format break. [BUNDLE_SIGNATURES_SCHEMA]. */
+  val schema: String = BUNDLE_SIGNATURES_SCHEMA,
+  /** One entry per producer that signed this bundle. At least one on a signed bundle. */
+  val signatures: List<BundleSignature>,
+)
+
+/** One producer's detached signature over the bundle's canonical digest. See [BundleSignatures]. */
+@Serializable
+data class BundleSignature(
+  /**
+   * Stable id of the signing key, e.g. `"compose-ai-tools-ci"`. The verifier's trust store maps
+   * this to a trusted public key; it's also how a second producer's signature is told apart from
+   * the first. Free-form but conventionally `[A-Za-z0-9._@-]+`.
+   */
+  val keyId: String,
+  /** Signature algorithm. Only [SIGNATURE_ALG_ED25519] is defined today. */
+  val algorithm: String = SIGNATURE_ALG_ED25519,
+  /**
+   * Lowercase-hex SHA-256 canonical digest the signature was computed over (see
+   * [BundleSignatures]).
+   */
+  val digest: String,
+  /** Base64 (standard, padded) of the raw Ed25519 signature bytes over [digest]'s raw bytes. */
+  val signature: String,
+  /** Human-readable producer label for diagnostics, e.g. `"Compose AI Tools CI"`. Optional. */
+  val producer: String? = null,
+  /**
+   * Optional keyless-provenance attestation (GitHub OIDC / Sigstore). When present the verifier can
+   * trust the signature by matching [BundleProvenance.identity] against its OIDC allowlist instead
+   * of (or in addition to) a pinned public key — useful for CI-produced bundles with no long-lived
+   * key.
+   */
+  val provenance: BundleProvenance? = null,
+)
+
+/** Keyless-provenance attestation attached to a [BundleSignature] (GitHub OIDC / Sigstore). */
+@Serializable
+data class BundleProvenance(
+  /** Provenance flavour: [PROVENANCE_GITHUB_OIDC] or [PROVENANCE_SIGSTORE]. */
+  val type: String,
+  /**
+   * The workload identity that produced the bundle, e.g. a GitHub Actions subject like
+   * `repo:yschimke/compose-ai-tools:ref:refs/heads/main`. The verifier matches this against its
+   * trusted-identity globs.
+   */
+  val identity: String,
+  /** Optional opaque attestation bundle / certificate (Sigstore) for full offline verification. */
+  val attestation: String? = null,
+)
+
 /** Discriminator field `kind`, values: `module`, `maven`, `project`. */
 @OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
 @Serializable
@@ -367,6 +456,20 @@ const val IR_FORMAT_LOTTIE: String = "lottie"
 /** Well-known directory inside the bundle zip holding per-preview IR bytes (`ir/<id>.<ext>`). */
 const val BUNDLE_IR_DIR: String = "ir"
 
+/** Well-known zip path of the detached producer signatures (v8). See [BundleSignatures]. */
+const val BUNDLE_SIGNATURES_PATH: String = "signatures.json"
+
+/** Schema id stamped into [BundleSignatures.schema]. */
+const val BUNDLE_SIGNATURES_SCHEMA: String = "compose-preview-bundle/signatures/v1"
+
+/** [BundleSignature.algorithm] value for an Ed25519 signature (the only one defined today). */
+const val SIGNATURE_ALG_ED25519: String = "ed25519"
+
+/** [BundleProvenance.type] values. */
+const val PROVENANCE_GITHUB_OIDC: String = "github-oidc"
+
+const val PROVENANCE_SIGSTORE: String = "sigstore"
+
 /** File extension for a captured Remote Compose document byte stream. */
 const val IR_EXT_REMOTECOMPOSE: String = "rcdoc"
 
@@ -454,6 +557,13 @@ val CONVENTIONAL_DATA_EXTENSION_REPORTS: Map<String, String> = mapOf("a11y" to "
  *   field), present only for previews that opted in. Additive — the sidecar is ignored by older
  *   readers and absent for previews that declare no knobs, so a v7 reader opening a v8 bundle still
  *   works; only a reader that wants the editable knobs needs to be v8-aware.
+ *
+ * Orthogonal to the version sequence above, the optional `signatures.json`
+ * ([BUNDLE_SIGNATURES_PATH], [BundleSignatures]) carries detached producer signatures over the
+ * bundle's canonical digest so a public preview server can attribute a bundle to a trusted producer
+ * before re-rendering its executable Compose. It is excluded from the digest it signs and does
+ * **not** bump [schemaVersion] (signing is a post-pack step, like `bundle embed`); an unsigned
+ * bundle has no such entry and an unaware reader ignores it.
  */
 const val BUNDLE_SCHEMA_VERSION: Int = 8
 


### PR DESCRIPTION
## Why

Foundation for making **preview.coo.ee** a public preview server. A public server can safely serve a bundle's **data tiers** (baked PNGs, Remote Compose / Protolayout / Lottie IR — these execute no code) from any uploader, but it must **not** re-render a bundle's executable Compose (Compose Android via Robolectric, Compose MP via desktop Skiko) unless it can attribute the bundle to a producer it trusts. There was no way to express or check that trust. This PR adds it.

This is the first of a stacked series toward the public-server vision (signing → verified serving → cross-repo deep links → public deploy profile → in-browser CMP/Wasm). It changes **no existing server behavior** — it only adds the signing/verification primitives.

## What

- **`signatures.json`** (`compose-preview-bundle/signatures/v1`, documented in `PreviewBundleFormat.kt`): one or more detached producer signatures over a **canonical digest** — sorted per-entry SHA-256 over every zip entry *except* the signatures file itself, so multiple producers can each append a signature without invalidating the others, and tampering with any covered entry flips the verdict.
- **`compose-preview bundle keygen | sign | verify`**: mint an Ed25519 keypair (JDK, no new deps), append a signature (idempotent per `--key-id`, optional `--provenance-identity` for CI), and check a bundle against a trust store (exit 3 when unverified).
- **`TrustStore`** (`keys` / `branches` / `oidc`) + **`BundleVerifier`**: three trust bases — pinned-key signature (strongest, offline), trusted-branch origin (how the published `design-artifacts` catalogs are trusted), and CI provenance identity (advisory until full Sigstore/Rekor lands). Fail-closed: anything unattributed is `Unverified`.

## Test plan

- `BundleSigningTest` (8 cases, green): canonical-digest stability across zip ordering + tamper detection, sign→verify round trip, untrusted-key rejection, unsigned → unverified, trusted-branch origin, provenance identity, glob matching.
- `CliFlagsRegistryTest` green with the new value-flags.
- `./gradlew :gradle-plugin:compileKotlin :cli:compileKotlin :cli:compileTestKotlin` clean; ktfmt clean.

Non-visual change (crypto/trust plumbing + tests), so no rendered evidence applies.


---
_Generated by [Claude Code](https://claude.ai/code/session_01K8nJEfEYGM3ijyoAXDNLGH)_