### PR TITLE
feat(serve): verify uploaded bundles against a producer trust store

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleSigning.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleSigning.kt
@@ -193,4 +193,29 @@ internal object BundleSigning {
   fun hex(bytes: ByteArray): String = bytes.joinToString("") { "%02x".format(it) }
 
   fun sha256(bytes: ByteArray): ByteArray = MessageDigest.getInstance("SHA-256").digest(bytes)
+
+  /**
+   * Normalize raw bundle bytes to the appended ZIP portion: a plain zip (`PK\x03\x04`) is returned
+   * as-is; a PNG+ZIP polyglot has its leading PNG stripped (seek past the IEND chunk). The
+   * byte-array twin of [BundleReader.extractZipBytes] for the in-memory upload path. Returns the
+   * input unchanged when it matches neither signature (best effort — callers treat it as zip
+   * bytes).
+   */
+  fun zipBytesOf(raw: ByteArray): ByteArray {
+    if (raw.size >= 2 && raw[0] == 0x50.toByte() && raw[1] == 0x4B.toByte()) return raw
+    val pngSig = byteArrayOf(-119, 80, 78, 71, 13, 10, 26, 10)
+    if (raw.size < pngSig.size || !pngSig.indices.all { raw[it] == pngSig[it] }) return raw
+    var offset = pngSig.size
+    while (offset + 8 <= raw.size) {
+      val length =
+        ((raw[offset].toInt() and 0xff) shl 24) or
+          ((raw[offset + 1].toInt() and 0xff) shl 16) or
+          ((raw[offset + 2].toInt() and 0xff) shl 8) or
+          (raw[offset + 3].toInt() and 0xff)
+      val type = String(raw, offset + 4, 4, Charsets.US_ASCII)
+      offset += 4 + 4 + length + 4
+      if (type == "IEND") return raw.copyOfRange(offset.coerceAtMost(raw.size), raw.size)
+    }
+    return raw
+  }
 }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleSigning.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleSigning.kt
@@ -212,9 +212,22 @@ internal object BundleSigning {
           ((raw[offset + 1].toInt() and 0xff) shl 16) or
           ((raw[offset + 2].toInt() and 0xff) shl 8) or
           (raw[offset + 3].toInt() and 0xff)
+      // These bytes are client-controlled (the token-gated upload path). A negative length — e.g. a
+      // hostile chunk header like 0xfffffff4, which reads as a negative signed Int — would make the
+      // advance below stall or move backwards (spin forever / throw on a bad index). A real PNG
+      // chunk
+      // length is < 2^31, so reject anything negative and bail (treat as not-a-polyglot → the
+      // caller
+      // hands the bytes to ZipInputStream, which yields nothing → the upload fails cleanly).
+      if (length < 0) return raw
       val type = String(raw, offset + 4, 4, Charsets.US_ASCII)
-      offset += 4 + 4 + length + 4
-      if (type == "IEND") return raw.copyOfRange(offset.coerceAtMost(raw.size), raw.size)
+      // 12 = 4 (length) + 4 (type) + 4 (crc). Compute in Long so a huge length can't overflow Int
+      // into a negative offset; require strict forward progress within bounds.
+      val next = offset.toLong() + 12L + length.toLong()
+      if (type == "IEND")
+        return if (next in 0..raw.size.toLong()) raw.copyOfRange(next.toInt(), raw.size) else raw
+      if (next <= offset || next > raw.size) return raw
+      offset = next.toInt()
     }
     return raw
   }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
@@ -58,6 +58,7 @@ internal object CliFlags {
       "--export",
       "--bundles",
       "--accept-bundles-from",
+      "--trust-store",
       "--revisions-allow",
       // bundle sign / verify / keygen (producer trust)
       "--key",

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -17,6 +17,7 @@ import ee.schimke.composeai.cli.serve.ServeSessionFactory
 import ee.schimke.composeai.cli.serve.ServeSessionRegistry
 import ee.schimke.composeai.cli.serve.ServeSessionState
 import ee.schimke.composeai.cli.serve.ServeUrls
+import ee.schimke.composeai.cli.serve.TrustStore
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.render.session.RenderSessionException
 import java.io.File
@@ -106,6 +107,15 @@ class ServeCommand(args: List<String>) : Command(args) {
       ?.split(",")
       ?.map { it.trim() }
       ?.filter { it.isNotEmpty() } ?: emptyList()
+
+  /**
+   * Path to the producer-trust store (`--trust-store <file>`): the JSON allowlist of trusted
+   * signing keys / branches / CI identities ([TrustStore]). Uploaded bundles are verified against
+   * it and the verdict is surfaced in the API + viewer. Absent ⇒ the empty, fail-closed store
+   * (every upload `unverified`), which is correct for a private box; a public server points it at
+   * `trust/producers.json`.
+   */
+  private val trustStorePath: String? = args.flagValue("--trust-store")
 
   override fun run() {
     if ("--help" in args || "-h" in args) {
@@ -235,6 +245,7 @@ class ServeCommand(args: List<String>) : Command(args) {
           root = uploads,
           register = { id, bundleHost -> registry.register(id, host = bundleHost, pinned = true) },
           allowedHosts = acceptBundlesFrom,
+          trust = loadTrustStore(),
         )
       } else {
         null
@@ -392,6 +403,27 @@ class ServeCommand(args: List<String>) : Command(args) {
   }
 
   /**
+   * Load the `--trust-store` JSON, or the empty fail-closed store when the flag is absent. A bad
+   * path or unparseable file is a hard error: a public operator who *meant* to pin trusted
+   * producers shouldn't silently fall back to trusting nothing (or, worse, think they configured it
+   * when they didn't).
+   */
+  private fun loadTrustStore(): TrustStore {
+    val path = trustStorePath ?: return TrustStore.EMPTY
+    val f = File(path)
+    if (!f.isFile) {
+      System.err.println("serve: --trust-store not found: ${f.path}")
+      exitProcess(1)
+    }
+    return try {
+      TrustStore.load(f)
+    } catch (e: Exception) {
+      System.err.println("serve: could not parse --trust-store ${f.path}: ${e.message}")
+      exitProcess(1)
+    }
+  }
+
+  /**
    * Match a preview id against `--id` (exact) / `--filter` (substring); all when neither is set.
    */
   private fun matches(id: String): Boolean =
@@ -528,6 +560,11 @@ class ServeCommand(args: List<String>) : Command(args) {
                           SSRF allowlist for POST /bundles?url=: hostnames the server may fetch a
                           bundle from. Omitted/empty = no URL fetch is allowed (fail closed), so a
                           client can't steer the server at an arbitrary or internal address.
+        --trust-store <file>
+                          Producer-trust allowlist (JSON: signing keys / branches / CI identities).
+                          Uploaded bundles are verified against it and the verdict (signature /
+                          branch / provenance / unverified) is returned + badged. Omitted = trust
+                          nothing (every upload unverified); the data tiers serve either way.
 
       The shareable link carries an unguessable token; requests without it get 404.
       """

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/BundleVerifier.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/BundleVerifier.kt
@@ -50,8 +50,49 @@ object BundleVerifier {
   }
 
   /** Verify a bundle file. [origin] is non-null only when the server fetched it itself. */
-  fun verify(bundle: File, trust: TrustStore, origin: Origin? = null): Verdict {
-    val digest = BundleSigning.canonicalDigest(bundle)
+  fun verify(bundle: File, trust: TrustStore, origin: Origin? = null): Verdict =
+    verifyCore(
+      BundleSigning.canonicalDigest(bundle),
+      BundleSigning.readSignatures(bundle)?.signatures.orEmpty(),
+      trust,
+      origin,
+    )
+
+  /**
+   * Verify in-memory bundle bytes — the runtime upload path ([ServeBundleStore]) has the bytes, not
+   * a file. Accepts either a plain zip or a PNG+ZIP polyglot ([BundleSigning.zipBytesOf]
+   * normalizes).
+   */
+  fun verify(rawBundleBytes: ByteArray, trust: TrustStore, origin: Origin? = null): Verdict {
+    val zip = BundleSigning.zipBytesOf(rawBundleBytes)
+    return verifyCore(
+      BundleSigning.canonicalDigest(zip),
+      BundleSigning.readSignatures(zip)?.signatures.orEmpty(),
+      trust,
+      origin,
+    )
+  }
+
+  /**
+   * Short one-line label for logs / API / UI badge, e.g. `signature:ci`, `branch`, `unverified`.
+   */
+  fun summary(verdict: Verdict): String =
+    when (verdict) {
+      is Verdict.Trusted ->
+        when (val b = verdict.primary) {
+          is Basis.Signature -> "signature:${b.keyId}"
+          is Basis.Branch -> "branch:${b.repo}@${b.branch}"
+          is Basis.Provenance -> "provenance:${b.identity}"
+        }
+      is Verdict.Unverified -> "unverified"
+    }
+
+  private fun verifyCore(
+    digest: ByteArray,
+    signatures: List<BundleSigning.Signature>,
+    trust: TrustStore,
+    origin: Origin?,
+  ): Verdict {
     val expectedDigestHex = BundleSigning.hex(digest)
     val bases = ArrayList<Basis>()
 
@@ -65,7 +106,6 @@ object BundleVerifier {
     // ONLY path that turns a signature into trust. Provenance is recorded as supplementary context
     // for a signature that *already* verified — it never grants trust on its own (see
     // [Basis.Provenance]).
-    val signatures = BundleSigning.readSignatures(bundle)?.signatures.orEmpty()
     for (sig in signatures) {
       if (sig.algorithm != BundleSigning.ALG_ED25519) continue
       // The signature's claimed digest must match what we recomputed (no signing a different

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
@@ -17,7 +17,16 @@ import kotlinx.serialization.json.Json
  * Cheap and stateless (just file reads), so the registry pins it resident rather than suspending
  * it.
  */
-class ServeBundleHost(private val bundleDir: File, override val label: String) : ServeHost {
+class ServeBundleHost(
+  private val bundleDir: File,
+  override val label: String,
+  /**
+   * Producer-trust verdict for this bundle, attached at ingestion ([ServeBundleStore]) so the API /
+   * viewer can badge it. Defaults to `Unverified` for bundles registered without a check (e.g. a
+   * `--bundles <dir>` directory, which has no original signed file to verify).
+   */
+  val trust: BundleVerifier.Verdict = BundleVerifier.Verdict.Unverified("not checked"),
+) : ServeHost {
 
   private val previewsDir = File(bundleDir, PREVIEWS_SUBDIR)
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleStore.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.cli.serve
 
+import ee.schimke.composeai.cli.BundleSigning
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.File
@@ -36,10 +37,24 @@ class ServeBundleStore(
    * `--accept-bundles` alone never lets a client make the server fetch an arbitrary address.
    */
   private val allowedHosts: List<String> = emptyList(),
+  /**
+   * Producer-trust store. An uploaded bundle is verified against it ([BundleVerifier]) and the
+   * resulting verdict is attached to the registered [ServeBundleHost] + returned in [Result.Ok].
+   * Data tiers (the extracted `previews/<id>.png`) are served regardless — the verdict gates only
+   * whether the operator would later re-render the bundle's executable Compose. Defaults to the
+   * empty (fail-closed) store, so without `--trust-store` every upload is `unverified`.
+   */
+  private val trust: TrustStore = TrustStore.EMPTY,
 ) {
 
   sealed interface Result {
-    data class Ok(val name: String, val previewCount: Int) : Result
+    /**
+     * [trust] is the [BundleVerifier.summary] of the verdict, e.g. `signature:ci` or `unverified`.
+     * Defaults to `unverified` — the value for an upload checked against the empty store (no
+     * `--trust-store`) — so a caller that doesn't care about trust can ignore it.
+     */
+    data class Ok(val name: String, val previewCount: Int, val trust: String = "unverified") :
+      Result
 
     data class Failed(val reason: String) : Result
   }
@@ -56,9 +71,12 @@ class ServeBundleStore(
     val safe = sanitizeName(name) ?: return Result.Failed("invalid bundle name: '$name'")
     val dir = File(root, safe)
     dir.deleteRecursively()
+    // Normalize once: an uploaded bundle may be a plain zip or a PNG+ZIP polyglot (a signed bundle
+    // is a polyglot). Both the preview extraction and the trust digest operate on the zip portion.
+    val zip = BundleSigning.zipBytesOf(zipBytes)
     val count =
       try {
-        extractPreviews(zipBytes, dir)
+        extractPreviews(zip, dir)
       } catch (e: Exception) {
         dir.deleteRecursively()
         return Result.Failed("could not unpack bundle: ${e.message}")
@@ -67,9 +85,13 @@ class ServeBundleStore(
       dir.deleteRecursively()
       return Result.Failed("bundle had no previews/*.png entries")
     }
-    val host = ServeBundleHost(dir, safe)
+    // Attribute the upload to a trusted producer if it carries a verifiable signature (origin trust
+    // is for server-fetched catalogs, not client uploads, so no Origin here). The verdict travels
+    // with the host for display; it never blocks serving the already-extracted data tiers.
+    val verdict = BundleVerifier.verify(zip, trust)
+    val host = ServeBundleHost(dir, safe, verdict)
     register(safe, host)
-    return Result.Ok(safe, host.previews.size)
+    return Result.Ok(safe, host.previews.size, BundleVerifier.summary(verdict))
   }
 
   /**

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -128,6 +128,7 @@ class ServeHttpServer(
                       session = result.name,
                       previews = result.previewCount,
                       path = "/?session=${result.name}",
+                      trust = result.trust,
                     ),
                   ),
                   ContentType.Application.Json,
@@ -463,4 +464,10 @@ private data class BundleAcceptedResponse(
   val previews: Int,
   /** Relative viewer link for the new session (append your token). */
   val path: String,
+  /**
+   * Producer-trust verdict for the upload ([BundleVerifier.summary]): `signature:<keyId>`,
+   * `branch:<repo>@<branch>`, `provenance:<id>`, or `unverified`. The data tiers serve either way;
+   * this tells the uploader whether the server would treat the bundle as trusted.
+   */
+  val trust: String,
 )

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleSigningTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleSigningTest.kt
@@ -280,4 +280,28 @@ class BundleSigningTest {
     assertFalse(TrustStore.globMatch("exact", "exact-suffix"))
     assertTrue(TrustStore.globMatch("exact", "exact"))
   }
+
+  @Test
+  fun `zipBytesOf matches the file extractor on a polyglot`() {
+    val file = sampleBundle("poly.png")
+    assertTrue(
+      BundleSigning.zipBytesOf(file.readBytes()).contentEquals(BundleReader.extractZipBytes(file)),
+      "the in-memory twin must strip the PNG cover identically to the file-based extractor",
+    )
+  }
+
+  @Test
+  fun `zipBytesOf rejects a hostile PNG chunk length without spinning`() {
+    // PNG signature + a chunk header whose length is 0xfffffff4 (a negative signed Int) — a
+    // malicious
+    // upload that, before the fix, made the offset stall / move backwards (infinite loop or throw).
+    val pngSig = byteArrayOf(-119, 80, 78, 71, 13, 10, 26, 10)
+    val hostile =
+      pngSig +
+        byteArrayOf(0xff.toByte(), 0xff.toByte(), 0xff.toByte(), 0xf4.toByte()) +
+        "IDAT".toByteArray() +
+        ByteArray(16)
+    // Returns promptly (no hang) and, being no valid polyglot, hands the bytes back unchanged.
+    assertTrue(BundleSigning.zipBytesOf(hostile).contentEquals(hostile))
+  }
 }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleStoreTest.kt
@@ -1,7 +1,11 @@
 package ee.schimke.composeai.cli.serve
 
+import ee.schimke.composeai.cli.BundleSigning
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import java.awt.image.BufferedImage
+import java.io.ByteArrayOutputStream
 import java.io.File
+import javax.imageio.ImageIO
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -161,5 +165,64 @@ class ServeBundleStoreTest {
       store(fetch = { ByteArray(0) }, allowedHosts = listOf("ci.example.com"))
         .addFromUrl("x", "file:///etc/passwd", isSecurityChecked = true)
     assertTrue(result is ServeBundleStore.Result.Failed)
+  }
+
+  // --- producer-trust verification on ingestion -------------------------------------------------
+
+  /** A minimal valid PNG to front the signed polyglot the store must accept and strip. */
+  private fun pngCover(): ByteArray {
+    val baos = ByteArrayOutputStream()
+    ImageIO.write(BufferedImage(2, 2, BufferedImage.TYPE_INT_RGB), "png", baos)
+    return baos.toByteArray()
+  }
+
+  /** Build a signed PNG+ZIP polyglot upload (cover + previews + a real Ed25519 signature). */
+  private fun signedPolyglot(name: String): Pair<ByteArray, BundleSigning.KeyPairB64> {
+    val keys = BundleSigning.generateKeyPair()
+    val zip = zipOf("previews/com.example.Red.png" to byteArrayOf(1, 2, 3))
+    val file =
+      File(tempRoot(), name).also {
+        it.outputStream().use { o ->
+          o.write(pngCover())
+          o.write(zip)
+        }
+      }
+    val digest = BundleSigning.canonicalDigest(file)
+    BundleSigning.addSignature(
+      file,
+      BundleSigning.Signature(
+        keyId = "ci",
+        digest = BundleSigning.hex(digest),
+        signature =
+          BundleSigning.base64(
+            BundleSigning.signEd25519(BundleSigning.parsePrivateKey(keys.privateKeyB64), digest)
+          ),
+      ),
+    )
+    return file.readBytes() to keys
+  }
+
+  @Test
+  fun `a signed bundle from a trusted key is attributed by signature`() {
+    val (bytes, keys) = signedPolyglot("signed.png")
+    val store =
+      ServeBundleStore(
+        tempRoot(),
+        register = { n, h -> registered[n] = h },
+        trust = TrustStore(keys = listOf(TrustedKey("ci", keys.publicKeyB64))),
+      )
+    val result = store.add("signed", bytes, isSecurityChecked = true)
+    assertEquals(ServeBundleStore.Result.Ok("signed", 1, "signature:ci"), result)
+    assertTrue(registered.getValue("signed").trust is BundleVerifier.Verdict.Trusted)
+  }
+
+  @Test
+  fun `a signed bundle is unverified when its key is not trusted`() {
+    val (bytes, _) = signedPolyglot("untrusted.png")
+    // The default store has the empty (fail-closed) trust store — the signature is present but the
+    // key isn't pinned, so the bundle still serves its data tiers as unverified.
+    val result = store().add("u", bytes, isSecurityChecked = true)
+    assertEquals(ServeBundleStore.Result.Ok("u", 1, "unverified"), result)
+    assertTrue(registered.getValue("u").trust is BundleVerifier.Verdict.Unverified)
   }
 }


### PR DESCRIPTION
## Why

Second slice of the public preview-server work (builds on #2076, the signing/trust core). It makes the trust verdict *do* something on the serve side: when a bundle is uploaded to a public `compose-preview serve`, the server now attributes it to a trusted producer (or marks it unverified) instead of accepting everything blindly. Data tiers (the extracted pre-rendered previews) still serve for any uploader — the verdict only gates a would-be re-render of executable Compose, and is surfaced so a client/operator can see it.

## What

- **`serve --trust-store <file>`** loads the JSON allowlist (`keys` / `branches` / `oidc`) and threads it into the `/bundles` upload path.
- **`BundleVerifier`** gains an in-memory `verify(bytes)` overload (the upload path has bytes, not a file) and a `summary()` label; **`BundleSigning.zipBytesOf`** normalizes a PNG+ZIP polyglot upload to its zip portion so *signed* bundles verify correctly.
- **`ServeBundleStore`** computes the verdict at ingestion and attaches it to the registered **`ServeBundleHost`**; `Result.Ok` carries the trust summary (defaults to `unverified`, so the empty/no-flag store is fail-closed).
- **`ServeHttpServer`** returns `trust` in the bundle-accepted response.

Per-format safety is unchanged from the design: Remote Compose / Protolayout / Lottie / baked PNG are data-only and serve regardless; only Compose Android (server) / CMP-desktop re-render is what the verdict would gate.

## Test plan

- New `ServeBundleStoreTest` cases: a signed polyglot from a **trusted** key → `Result.Ok(trust = "signature:ci")` and a `Trusted` host; the **same** signature with the key **not** pinned → `unverified`. (13 store tests green.)
- `BundleSigningTest` (9) and `CliFlagsRegistryTest` green; `--trust-store` registered.
- `./gradlew :cli:compileKotlin :cli:test` clean; ktfmt clean.

Non-visual change (serve plumbing + trust verification + tests); no rendered evidence applies. The viewer trust badge + `/api/previews` exposure + trusted-branch catalog loading land in the next slice.


---
_Generated by [Claude Code](https://claude.ai/code/session_01K8nJEfEYGM3ijyoAXDNLGH)_