### PR TITLE
fix(renderer): re-capture animation/scroll/focus frames that fail to decode

### DIFF
--- a/.github/workflows/sdk-matrix.yml
+++ b/.github/workflows/sdk-matrix.yml
@@ -43,13 +43,17 @@ jobs:
           # ----- JDK 17, auto-detect -----
           # Baseline: compileSdk=35 lands within Robolectric's JDK 17 ceiling, renders cleanly.
           - { label: "jdk17 / compileSdk=35 / target=35 / min=24 / auto", jdk: "17", compileSdk: 35, targetSdk: 35, minSdk: 24, sdkVersion: "", robolectric: "", maxSupportedSdk: "", expect: pass }
-          # JDK 17 + compileSdk≥36 fails at sandbox bootstrap: Robolectric refuses SDK 36
-          # without JDK 21. The minSdk axis is moot here; this is purely a JDK constraint.
-          - { label: "jdk17 / compileSdk=36 / target=36 / min=24 / auto", jdk: "17", compileSdk: 36, targetSdk: 36, minSdk: 24, sdkVersion: "", robolectric: "", maxSupportedSdk: "", expect: fail }
-          # JDK 17 + compileSdk=37 auto-detect clamps to sdk=36; JDK 17 still refuses sdk=36
-          # afterwards. The clamp warning fires regardless. Expect fail because of the JDK
-          # constraint, not the clamp.
-          - { label: "jdk17 / compileSdk=37 / target=37 / min=24 / auto (clamp)", jdk: "17", compileSdk: 37, targetSdk: 37, minSdk: 24, sdkVersion: "", robolectric: "", maxSupportedSdk: "", expect: fail }
+          # JDK 17 + compileSdk=36 auto-detect: the plugin's clamp is JDK-aware
+          # (GenerateRobolectricPropertiesTask.resolveSdk → MAX_SUPPORTED_SDK_BELOW_JAVA_21). On
+          # JDK 17 the effective ceiling is 35, so a compileSdk=36 consumer renders at sdk=35 with
+          # a "needs JDK 21+ to render … clamping the Robolectric sandbox to 35" warning instead of
+          # failing at sandbox bootstrap. minSdk=24 parses cleanly against the framework-35 APK.
+          # (Was expect:fail before the JDK-aware clamp landed; the matrix surfaced that drift.)
+          - { label: "jdk17 / compileSdk=36 / target=36 / min=24 / auto", jdk: "17", compileSdk: 36, targetSdk: 36, minSdk: 24, sdkVersion: "", robolectric: "", maxSupportedSdk: "", expect: pass }
+          # JDK 17 + compileSdk=37 auto-detect clamps the same way: ceiling = min(jar=36, JDK17=35)
+          # = 35, so it renders at sdk=35 (the warning notes the APK may still fail if <uses-sdk>
+          # is newer — here minSdk=24 is fine). Same JDK-aware-clamp improvement as the row above.
+          - { label: "jdk17 / compileSdk=37 / target=37 / min=24 / auto (clamp)", jdk: "17", compileSdk: 37, targetSdk: 37, minSdk: 24, sdkVersion: "", robolectric: "", maxSupportedSdk: "", expect: pass }
           # ----- JDK 17, sdkVersion=35 override -----
           # The rescue path consumers on JDK 17 + compileSdk=36 take. APK's minSdk=24 parses
           # cleanly against the SDK 35 framework Robolectric synthesizes.
@@ -143,8 +147,14 @@ jobs:
             # `Execution failed` line, which beats falling back to "see build.log". The pattern
             # set covers the four documented failure shapes (#1248 PackageParser, JDK 21
             # requirement, missing SDK jar, plus a generic Gradle exception fallback).
+            # `UnknownSdk` is the literal Robolectric raises when a sandbox SDK has no
+            # `android-all-instrumented-N.jar` (`IllegalArgumentException at UnknownSdk.java:45`) —
+            # the missing-SDK-jar shape the `robolectric=4.17-SNAPSHOT` API-37 probes hit. Without
+            # it the match falls through to the generic "N tests failed" summary, so the
+            # `expectedReason: UnknownSdk` gate below would flag a correctly-failing cell as
+            # "failed for the wrong reason".
             reason=$(grep -m1 -E \
-              "Requires newer sdk version|Android SDK [0-9]+ requires Java|API level [0-9]+ is not available|UnsupportedOperationException|Could not resolve all files|composeai.matrix" \
+              "Requires newer sdk version|Android SDK [0-9]+ requires Java|API level [0-9]+ is not available|UnsupportedOperationException|Could not resolve all files|UnknownSdk|composeai.matrix" \
               build.log | head -c 400 || true)
             if [ -z "$reason" ]; then
               reason=$(grep -m1 -E "^.*[Ff]ailed|FAILURE: " build.log | head -c 400 || true)

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -1702,7 +1702,9 @@ private fun handleGifCaptureInternal(
 
     fun captureFrame(delayMs: Int) {
         val frameFile = File(framesDir, "frame_${frameFiles.size}.png")
-        rule.onRoot().captureRoboImage(file = frameFile, roborazziOptions = frameRoborazziOptions)
+        captureDecodableFrame(frameFile, role = "scroll GIF") { f ->
+            rule.onRoot().captureRoboImage(file = f, roborazziOptions = frameRoborazziOptions)
+        }
         frameFiles += frameFile
         frameDelays += delayMs
     }
@@ -1889,6 +1891,57 @@ private const val MAX_TAIL_FLINGS = 4
 private const val TAIL_FLING_EPSILON_PX = 1f
 
 /**
+ * How many times the multi-frame capture paths re-issue a single frame's
+ * `captureRoboImage` when the written PNG won't decode — one initial attempt
+ * plus retries.
+ */
+internal const val FRAME_CAPTURE_ATTEMPTS = 3
+
+/**
+ * Capture one GIF frame to [file] and re-capture if the written PNG won't
+ * decode.
+ *
+ * Robolectric's NATIVE graphics backend very occasionally flushes a per-frame
+ * PNG whose 8-byte signature and IEND trailer are both intact but whose
+ * interior IDAT stream `ImageIO` then refuses ("ImageIO could not read it") — a
+ * transient encode glitch under the rapid write cadence of the multi-frame
+ * paths (`@AnimatedPreview` GIF, scroll GIF, focus GIF). A single such frame
+ * turns an otherwise-green multi-frame render red even though re-issuing the
+ * capture at the same clock state re-encodes the identical frame cleanly — see
+ * the Compose Preview `ShaderRaymarchAnimatedPreview … frame_39 … ImageIO could
+ * not read it` failure.
+ *
+ * [capture] writes [file] (overwriting any prior attempt); [FramePngReader]
+ * then validates it. A frame that still won't decode after
+ * [FRAME_CAPTURE_ATTEMPTS] re-throws the last decode error, so a genuinely
+ * undecodable frame keeps the render red with the same diagnostic as before —
+ * the retry only absorbs a glitch that clears on a fresh encode.
+ */
+internal fun captureDecodableFrame(
+    file: File,
+    role: String,
+    capture: (File) -> Unit,
+) {
+    var lastFailure: IllegalStateException? = null
+    repeat(FRAME_CAPTURE_ATTEMPTS) { attempt ->
+        capture(file)
+        try {
+            FramePngReader.decode(file, role = role)
+            return
+        } catch (e: IllegalStateException) {
+            lastFailure = e
+            System.err.println(
+                "$role: captured frame ${file.name} did not decode " +
+                    "(attempt ${attempt + 1}/$FRAME_CAPTURE_ATTEMPTS); re-capturing. " +
+                    "Cause: ${e.message}",
+            )
+        }
+    }
+    throw lastFailure
+        ?: IllegalStateException("Failed to capture a decodable frame: ${file.path}")
+}
+
+/**
  * Handles `@AnimatedPreview` captures.
  *
  * Single-pass with an inline measure step:
@@ -1992,7 +2045,9 @@ private fun handleAnimatedCapture(
 
     fun captureFrame(virtualTimeMs: Long) {
         val frameFile = File(framesDir, "frame_${frameFiles.size}.png")
-        rule.onRoot().captureRoboImage(file = frameFile, roborazziOptions = frameRoborazziOptions)
+        captureDecodableFrame(frameFile, role = "animation") { f ->
+            rule.onRoot().captureRoboImage(file = f, roborazziOptions = frameRoborazziOptions)
+        }
         frameFiles += frameFile
         frameTimes += virtualTimeMs
 
@@ -2146,8 +2201,9 @@ private fun handleFocusGifCapture(
                     .idleFor(java.time.Duration.ofMillis(FocusController.SETTLE_MS))
             }
             val frameFile = File(framesDir, "frame_$i.png")
-            rule.onRoot()
-                .captureRoboImage(file = frameFile, roborazziOptions = frameRoborazziOptions)
+            captureDecodableFrame(frameFile, role = "focus GIF") { f ->
+                rule.onRoot().captureRoboImage(file = f, roborazziOptions = frameRoborazziOptions)
+            }
             frameFiles += frameFile
         }
 

--- a/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/CaptureDecodableFrameTest.kt
+++ b/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/CaptureDecodableFrameTest.kt
@@ -1,0 +1,70 @@
+package ee.schimke.composeai.renderer
+
+import java.awt.image.BufferedImage
+import java.io.File
+import javax.imageio.ImageIO
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure-JVM cover for [captureDecodableFrame] — the bounded re-capture the
+ * multi-frame paths wrap around `captureRoboImage` so a single undecodable
+ * frame PNG from Robolectric's NATIVE graphics backend doesn't fail an
+ * otherwise-green render (the Compose Preview
+ * `ShaderRaymarchAnimatedPreview … frame_39 … ImageIO could not read it`
+ * flake). The `capture` lambda stands in for `captureRoboImage`; no
+ * Robolectric required.
+ */
+class CaptureDecodableFrameTest {
+
+    private fun writeGoodPng(file: File) {
+        ImageIO.write(BufferedImage(8, 6, BufferedImage.TYPE_INT_ARGB), "png", file)
+    }
+
+    @Test
+    fun `returns on the first attempt when the frame decodes`() {
+        val file = File.createTempFile("frame_ok_", ".png").apply { deleteOnExit() }
+        var attempts = 0
+        captureDecodableFrame(file, role = "animation") { f ->
+            attempts++
+            writeGoodPng(f)
+        }
+        assertEquals(1, attempts)
+    }
+
+    @Test
+    fun `re-captures past a transient undecodable frame`() {
+        val file = File.createTempFile("frame_flaky_", ".png").apply { deleteOnExit() }
+        var attempts = 0
+        captureDecodableFrame(file, role = "animation") { f ->
+            attempts++
+            // First write lands a corrupt frame (no PNG signature); the
+            // re-capture produces a clean one, mirroring the glitch clearing
+            // on a fresh encode.
+            if (attempts == 1) f.writeBytes("not a png".toByteArray()) else writeGoodPng(f)
+        }
+        assertEquals(2, attempts)
+        // The good frame is what survives on disk.
+        assertEquals(8, FramePngReader.decode(file, role = "animation").width)
+    }
+
+    @Test
+    fun `re-throws the decode error after attempts are exhausted`() {
+        val file = File.createTempFile("frame_bad_", ".png").apply { deleteOnExit() }
+        var attempts = 0
+        val error = try {
+            captureDecodableFrame(file, role = "focus GIF") { f ->
+                attempts++
+                f.writeBytes(ByteArray(0)) // every attempt writes an empty frame
+            }
+            null
+        } catch (e: IllegalStateException) {
+            e
+        }
+        assertEquals(FRAME_CAPTURE_ATTEMPTS, attempts)
+        assertTrue("expected a decode error", error != null)
+        assertTrue(error!!.message, error.message!!.contains("focus GIF"))
+        assertTrue(error.message, error.message!!.contains("empty"))
+    }
+}


### PR DESCRIPTION
Robolectric's NATIVE graphics backend very occasionally flushes a per-frame
PNG whose signature and IEND trailer are intact but whose interior IDAT
stream ImageIO then refuses ("ImageIO could not read it"). A single such
frame turned an otherwise-green multi-frame render red — the Compose Preview
push gate failed on ShaderRaymarchAnimatedPreview frame_39 even though the
commit it failed on never touched the render pipeline.

Re-issuing captureRoboImage at the same clock state re-encodes the identical
frame cleanly, so wrap the three multi-frame capture sites (@AnimatedPreview
GIF, scroll GIF, focus GIF) in a bounded capture-and-verify retry. A frame
that still won't decode after the attempts are spent re-throws the same
diagnostic, so a genuinely undecodable frame keeps the render red.