### PR TITLE
feat(overrides): surface declared compose/overrides knobs on Android via sandbox bridge

### DIFF
--- a/daemon/android/build.gradle.kts
+++ b/daemon/android/build.gradle.kts
@@ -233,6 +233,10 @@ dependencies {
   "testFixturesImplementation"(libs.compose.foundation)
   "testFixturesImplementation"(libs.compose.material3)
   "testFixturesImplementation"(libs.compose.ui)
+  // `previewOverride*` — the fixture `OverridableSquare` declares editable knobs so
+  // `PreviewOverridesDataFetchE2ETest` can prove the sandbox→host bridge surfaces them via
+  // `data/fetch?kind=compose/overrides`.
+  "testFixturesImplementation"(project(":data-preview-overrides-runtime"))
 }
 
 // D-harness.v2 — the spawned daemon's runtime classpath is built from the daemon module's

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -444,21 +444,21 @@ fun main(args: Array<String>) {
           // per-item values). The planner is wired into `RobolectricHost.previewOverrideExtensions`
           // (always-on, so `LocalPreviewOverrideHost` is installed on every render and
           // `renderNow.overrides.namedOverrides` seeds apply); this entry carries the discoverable
-          // descriptor.
+          // descriptor plus the `compose/overrides` data-product registry.
           //
-          // **No `compose/overrides` data-product registry on Android (unlike `:daemon:desktop`).**
           // The `previewOverride*` lookups record their declarations into the process-static
-          // `PreviewOverrideController` *inside the Robolectric sandbox classloader*, but a host-side
-          // registry runs in the host classloader and would read a different (empty) copy of that
-          // static — Robolectric re-loads project classes per sandbox (see `DaemonHostBridge`'s
-          // do-not-acquire rationale). So `data/fetch?kind=compose/overrides` is desktop-only until a
-          // sandbox→host bridge for the declarations lands. This does **not** affect bundle carriage:
-          // the standalone Robolectric render in `RobolectricRenderTest.writeOverridesSidecar` reads
-          // the controller from *within* the same sandbox, so `previews/<id>.overrides.json` is
-          // captured correctly on Android too.
+          // `PreviewOverrideController` *inside the Robolectric sandbox classloader*, a different
+          // copy from the host-classloader registry here. `SandboxPreviewOverridesBridge` (a
+          // do-not-acquire singleton, like `SandboxPermissionsBridge`) carries the declarations
+          // across the boundary: the controller forwards each declared knob as JSON, and
+          // `PreviewOverridesDataProductRegistry.onRender` reads them back by previewId — so
+          // `data/fetch?kind=compose/overrides` works on Android, matching desktop. (Bundle carriage
+          // never needed the bridge: `RobolectricRenderTest.writeOverridesSidecar` reads the
+          // controller from *within* the same sandbox.)
           Extension(
             id = "data/overrides",
             displayName = "Named preview overrides",
+            dataProductRegistry = PreviewOverridesDataProductRegistry(),
             dataExtensionDescriptors =
               listOf(
                 DataExtensionDescriptor(

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/bridge/SandboxPreviewOverridesBridge.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/bridge/SandboxPreviewOverridesBridge.kt
@@ -1,0 +1,104 @@
+package ee.schimke.composeai.daemon.bridge
+
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Cross-classloader handoff for the plain-Compose named-override declarations (`compose/overrides`).
+ *
+ * **Why a sibling of [DaemonHostBridge] / [SandboxPermissionsBridge].** A preview's
+ * `previewOverride*` lookups call `PreviewOverrideController.record(...)` from *inside* the
+ * Robolectric sandbox — the controller is loaded fresh per-sandbox (the `ee.schimke.composeai`
+ * namespace is acquired by the sandbox classloader by default), so the daemon-host
+ * `PreviewOverridesDataProductRegistry` (constructed once on the host thread, in the host
+ * classloader) reads a different — empty — copy of the controller's static state when it answers
+ * `data/fetch?kind=compose/overrides`. The desktop backend has no sandbox and needs no bridge.
+ *
+ * This bridge is registered as a do-not-acquire package on [SandboxHoldingRunner], so the same
+ * single instance is visible from both sides of the sandbox boundary. The controller's `record`
+ * pushes here; the host registry drains via [snapshot]; [reset] is the per-preview cleanup the
+ * controller's `clearDeclarations` / `resetForNewSession` call.
+ *
+ * **Strict bridge-package rules.** Only `java.util.concurrent.*` types, primitives, and `String`.
+ * No Compose, no Robolectric, no `ee.schimke.composeai.*` imports — those would drag the bridge back
+ * into the instrumented graph and break the single-instance invariant. The declarations therefore
+ * cross as **JSON strings** (the controller serialises each [PreviewOverrideDeclaration] before
+ * forwarding, the host registry decodes them): a typed object built in the sandbox classloader could
+ * not be cast to the host classloader's copy of the same class.
+ *
+ * **Per-preview scoping.** State is keyed by previewId (mirroring [SandboxPermissionsBridge]) so a
+ * pooled-sandbox run (`sandboxCount > 1`) where preview A and preview B compose concurrently doesn't
+ * leak A's knobs into B's `snapshot`. Writers stamp their active previewId (the controller forwards
+ * it from the around-composable's `ExtensionComposeContext.previewId`); the host reads back by the
+ * same previewId. A render with no previewId scopes under [NO_PREVIEW_SCOPE].
+ */
+object SandboxPreviewOverridesBridge {
+
+  /** Scope key used when a render carries no previewId (legacy stub-render payloads). */
+  const val NO_PREVIEW_SCOPE: String = ""
+
+  private val arrivalCounter: AtomicLong = AtomicLong(0L)
+
+  /**
+   * previewId -> (declaration seedKey -> [Slot]). Both maps are [ConcurrentHashMap] so writes from
+   * any sandbox thread race-free and concurrent previews each own a private inner map. The seedKey
+   * keying mirrors the controller's own de-dup: re-declaring a key (recomposition) replaces its JSON
+   * in place while keeping the first-seen arrival order.
+   */
+  private val byPreview: ConcurrentHashMap<String, ConcurrentHashMap<String, Slot>> =
+    ConcurrentHashMap()
+
+  /** First-seen arrival order + the latest JSON for a declaration. Never crosses the boundary. */
+  private class Slot(@JvmField val order: Long, @JvmField @Volatile var json: String)
+
+  /**
+   * Sandbox-side: record (or replace) [previewId]'s declaration [seedKey] with its serialised
+   * [json]. First call for a (previewId, seedKey) stamps an arrival counter so [snapshot] preserves
+   * declaration order; a later call for the same key updates the JSON in place (a recomposition with
+   * a fresh effective value) without reordering.
+   */
+  @JvmStatic
+  fun record(previewId: String, seedKey: String, json: String) {
+    byPreview
+      .computeIfAbsent(previewId) { ConcurrentHashMap() }
+      .compute(seedKey) { _, existing ->
+        if (existing == null) Slot(arrivalCounter.incrementAndGet(), json)
+        else existing.also { it.json = json }
+      }
+  }
+
+  /**
+   * Host-side: snapshot [previewId]'s declarations as serialised JSON strings, in declaration order.
+   * Returns a primitive `String[]` so the cross-loader transport stays in JLS types only — neither
+   * side reinterprets a `kotlin.collections.List` from the other's classloader. A previewId the
+   * bridge never saw (or one whose declarations were [reset]) returns an empty array.
+   */
+  @JvmStatic
+  fun snapshot(previewId: String): Array<String> {
+    val inner = byPreview[previewId] ?: return emptyArray()
+    if (inner.isEmpty()) return emptyArray()
+    val sorted = inner.values.sortedBy { it.order }
+    return Array(sorted.size) { sorted[it].json }
+  }
+
+  /**
+   * Both sides: drop the recorded declarations for [previewId] only. Called by
+   * `PreviewOverrideController.clearDeclarations` at the start of each render (so a shrinking list's
+   * stale indexed knobs drop) and by `resetForNewSession`. Scoped to the one preview so a
+   * concurrently-held preview's declarations survive — a JVM-wide `clear()` would reintroduce the
+   * cross-preview leak the per-preview keying fixes.
+   */
+  @JvmStatic
+  fun reset(previewId: String) {
+    byPreview.remove(previewId)
+  }
+
+  /**
+   * Both sides: drop every recorded declaration across all previews. Used by host-restart paths and
+   * test isolation where a full wipe is the intent. Per-render/-session cleanup must use [reset].
+   */
+  @JvmStatic
+  fun resetAll() {
+    byPreview.clear()
+  }
+}

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/PreviewOverridesDataFetchE2ETest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/PreviewOverridesDataFetchE2ETest.kt
@@ -1,0 +1,135 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.bridge.SandboxPreviewOverridesBridge
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * End-to-end verification that the opt-in `previewOverride*` knobs a screen declares *inside the
+ * Robolectric sandbox* surface in the host-side `compose/overrides` data product the panel / MCP read
+ * via `data/fetch`. This is the Android leg the merged feature deferred — the desktop daemon (no
+ * sandbox) already worked, but on Android the declarations were stranded in the sandbox classloader.
+ *
+ * **Why a cross-classloader bridge.** `PreviewOverrideController` is loaded by the Robolectric sandbox
+ * classloader (the `ee.schimke.composeai` namespace is acquired), so the host-side
+ * `PreviewOverridesDataProductRegistry` reads a *different, empty* static copy. The fixture's
+ * `previewOverride*` calls record into the sandbox-CL controller; `SandboxPreviewOverridesBridge` —
+ * in the `ee.schimke.composeai.daemon.bridge` do-not-acquire package (single instance across the
+ * boundary, like `SandboxPermissionsBridge`) — carries them across, and the registry reads them back.
+ *
+ * Mirrors [PermissionsDataFetchE2ETest]; exercises the registry directly with the same render-result
+ * wire shape `JsonRpcServer.handleRenderFinished` feeds `extensions.activeDataProducts().onRender(...)`.
+ */
+class PreviewOverridesDataFetchE2ETest {
+
+  @get:Rule val tempFolder: TemporaryFolder = TemporaryFolder()
+
+  @After
+  fun resetBridge() {
+    // JVM-wide singleton; sibling test classes / methods that exercised the sandbox can leak
+    // declarations into ours. Wipe every preview scope so each assertion sees only its own render.
+    SandboxPreviewOverridesBridge.resetAll()
+  }
+
+  @Test
+  fun `dataFetch returns the knobs the rendered screen declared`() {
+    val outputDir = tempFolder.newFolder("renders-overrides-fetch")
+    System.setProperty(RenderEngine.OUTPUT_DIR_PROP, outputDir.absolutePath)
+    System.setProperty("roborazzi.test.record", "true")
+    val previewId = "overridable-square-fetch"
+    val manifest =
+      PreviewManifest(
+        previews =
+          listOf(
+            PreviewManifestEntry(
+              id = previewId,
+              className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+              functionName = "OverridableSquare",
+              widthPx = 32,
+              heightPx = 32,
+              density = 1.0f,
+              outputBaseName = previewId,
+            )
+          )
+      )
+    val host = PreviewManifestRouter(manifest = manifest)
+    val registry = PreviewOverridesDataProductRegistry()
+    host.start()
+    SandboxPreviewOverridesBridge.resetAll()
+    try {
+      // Plain render (no override seed): the always-on `data/overrides` planner installs
+      // `LocalPreviewOverrideHost`, and `OverridableSquare`'s `previewOverride*` calls record `fill`
+      // + `label` into the sandbox-CL controller, which forwards them to the bridge.
+      val result =
+        host.submit(RenderRequest.Render(payload = "previewId=$previewId"), timeoutMs = 120_000)
+      assertNotNull("pngPath must be populated", result.pngPath)
+
+      // Hand the result to the registry the way `JsonRpcServer.handleRenderFinished` does. The
+      // registry's `onRender` reads the bridge snapshot (host-CL read of the sandbox-CL declarations).
+      registry.onRender(previewId, result, overrides = null, previewContext = result.previewContext)
+
+      val outcome = registry.fetch(previewId, "compose/overrides", params = null, inline = true)
+      val ok = outcome as DataProductRegistry.Outcome.Ok
+      val declarations = ok.result.payload!!.jsonObject["declarations"]!!.jsonArray
+
+      // The two declared knobs cross the sandbox boundary, in declaration order, with their types.
+      // If this drops, either the controller's bridge forward stopped (`PreviewOverrideController
+      // .record`), the bridge package isn't do-not-acquire (`SandboxHoldingRunner`), or the registry's
+      // bridge read regressed (`readDeclarationsAcrossClassloaders`).
+      val keys = declarations.map { it.jsonObject["key"]!!.jsonPrimitive.content }
+      val types = declarations.map { it.jsonObject["type"]!!.jsonPrimitive.content }
+      assertEquals(listOf("fill", "label"), keys)
+      assertEquals(listOf("color", "string"), types)
+    } finally {
+      host.shutdown()
+    }
+  }
+
+  @Test
+  fun `dataFetch is NotAvailable for a preview that declared no knobs`() {
+    val outputDir = tempFolder.newFolder("renders-overrides-empty")
+    System.setProperty(RenderEngine.OUTPUT_DIR_PROP, outputDir.absolutePath)
+    System.setProperty("roborazzi.test.record", "true")
+    val previewId = "red-square-no-knobs"
+    val manifest =
+      PreviewManifest(
+        previews =
+          listOf(
+            PreviewManifestEntry(
+              id = previewId,
+              className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+              functionName = "RedSquare",
+              widthPx = 16,
+              heightPx = 16,
+              density = 1.0f,
+              outputBaseName = previewId,
+            )
+          )
+      )
+    val host = PreviewManifestRouter(manifest = manifest)
+    val registry = PreviewOverridesDataProductRegistry()
+    host.start()
+    SandboxPreviewOverridesBridge.resetAll()
+    try {
+      val result =
+        host.submit(RenderRequest.Render(payload = "previewId=$previewId"), timeoutMs = 120_000)
+      assertNotNull("pngPath must be populated", result.pngPath)
+      registry.onRender(previewId, result, overrides = null, previewContext = result.previewContext)
+      assertTrue(
+        "a preview with no previewOverride* calls must not advertise compose/overrides",
+        registry.fetch(previewId, "compose/overrides", params = null, inline = true)
+          is DataProductRegistry.Outcome.NotAvailable,
+      )
+    } finally {
+      host.shutdown()
+    }
+  }
+}

--- a/daemon/android/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
+++ b/daemon/android/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
@@ -55,6 +55,22 @@ fun RedSquare() {
   Box(modifier = Modifier.fillMaxSize().background(Color(0xFFEF5350)))
 }
 
+/**
+ * Fixture for `PreviewOverridesDataFetchE2ETest`: declares two opt-in `previewOverride*` knobs (a
+ * colour `fill` and a string `label`) so a render through the sandbox records them into the
+ * sandbox-classloader `PreviewOverrideController`. The test then asserts the host-side
+ * `compose/overrides` data product surfaces them via `data/fetch` — i.e. that
+ * `SandboxPreviewOverridesBridge` carried the declarations across the classloader boundary. The
+ * `fill` knob drives the rendered colour, so a seeded override also visibly changes the pixels.
+ */
+@Composable
+fun OverridableSquare() {
+  val fill =
+    ee.schimke.composeai.overrides.previewOverrideColor("fill", default = Color(0xFFEF5350))
+  ee.schimke.composeai.overrides.previewOverrideString("label", default = "hi")
+  Box(modifier = Modifier.fillMaxSize().background(fill))
+}
+
 @Composable
 fun BlueSquare() {
   Box(modifier = Modifier.fillMaxSize().background(Color(0xFF42A5F5)))

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewOverrideExtensions.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewOverrideExtensions.kt
@@ -26,6 +26,29 @@ import ee.schimke.composeai.data.render.extensions.PlannedDataExtension
 typealias PreviewOverrideExtension = DataExtension<PreviewOverrides>
 
 /**
+ * Opt-in marker for a [PreviewOverrideExtension] that must be planned on **every** render,
+ * including renders that carry no `renderNow.overrides` bag at all (`plan(null)`).
+ *
+ * Most override-driven planners abstain when their field is absent, so [PreviewOverrideExtensions]
+ * short-circuits and plans nothing when the whole bag is null — a cheap, behaviour-preserving fast
+ * path. A few planners, though, install a composition local or stamp per-render bookkeeping that
+ * has to be present whether or not the client sent an override. The plain-Compose named-override
+ * planner is the canonical case: its around-composable both installs `LocalPreviewOverrideHost` and
+ * stamps the active previewId into `PreviewOverrideController` so the Android sandbox bridge keys
+ * the preview's declared knobs under the right scope. Without running on a no-override render the
+ * very first `data/fetch?kind=compose/overrides` (before any knob has been edited) would find the
+ * declarations stranded under the no-preview scope and report nothing.
+ *
+ * Marking a planner here makes [PreviewOverrideExtensions.plan] hand it an empty [PreviewOverrides]
+ * on the null-bag path. Implementors MUST therefore treat an empty bag as "no seed" (the named
+ * override planner already does — `request.namedOverrides` is null, so it seeds nothing and only
+ * installs the host + stamps the scope). Do NOT mark a planner whose around-composable mutates
+ * shared interactive state (keyboard visibility, permission grants) on an empty bag — running those
+ * on every no-override render would reset state a held session still depends on.
+ */
+interface AlwaysOnPreviewOverrideExtension
+
+/**
  * Aggregator of registered [PreviewOverrideExtension]s, injected into the renderer.
  *
  * Used to keep render-engine call sites generic: instead of hardcoding `spec.wallpaper?.let(...)`
@@ -42,7 +65,17 @@ class PreviewOverrideExtensions(
   private val isActive: (PreviewOverrideExtension) -> Boolean = { true },
 ) {
   fun plan(overrides: PreviewOverrides?): List<PlannedDataExtension> {
-    if (overrides == null || extensions.isEmpty()) return emptyList()
+    if (extensions.isEmpty()) return emptyList()
+    // No override bag on this render: most planners would abstain, so skip them — but the
+    // always-on planners (e.g. the named-override host + scope stamper) still have to run. Hand
+    // them an empty bag so they seed nothing yet install their composition local / per-render
+    // bookkeeping. See [AlwaysOnPreviewOverrideExtension].
+    if (overrides == null) {
+      val emptyBag = PreviewOverrides()
+      return extensions.mapNotNull {
+        if (it is AlwaysOnPreviewOverrideExtension && isActive(it)) it.plan(emptyBag) else null
+      }
+    }
     return extensions.mapNotNull { if (isActive(it)) it.plan(overrides) else null }
   }
 

--- a/data/preview-overrides/connector/src/main/kotlin/ee/schimke/composeai/daemon/PreviewOverridesDataProduct.kt
+++ b/data/preview-overrides/connector/src/main/kotlin/ee/schimke/composeai/daemon/PreviewOverridesDataProduct.kt
@@ -9,16 +9,19 @@ import ee.schimke.composeai.daemon.protocol.DataProductCapability
 import ee.schimke.composeai.daemon.protocol.DataProductTransport
 import ee.schimke.composeai.daemon.protocol.PreviewOverrideValue
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.data.overrides.PreviewOverrideDeclaration
 import ee.schimke.composeai.data.overrides.PreviewOverridesPayload
 import ee.schimke.composeai.data.overrides.PreviewOverridesProduct
 import ee.schimke.composeai.data.render.PreviewContext
 import ee.schimke.composeai.data.render.extensions.DataExtension
 import ee.schimke.composeai.data.render.extensions.DataExtensionCapability
 import ee.schimke.composeai.data.render.extensions.DataExtensionConstraints
+import ee.schimke.composeai.data.render.extensions.DataExtensionHookKind
 import ee.schimke.composeai.data.render.extensions.DataExtensionId
 import ee.schimke.composeai.data.render.extensions.DataExtensionPhase
 import ee.schimke.composeai.data.render.extensions.PlannedDataExtension
-import ee.schimke.composeai.data.render.extensions.compose.AroundComposableExtension
+import ee.schimke.composeai.data.render.extensions.compose.AroundComposableHook
+import ee.schimke.composeai.data.render.extensions.compose.ExtensionComposeContext
 import ee.schimke.composeai.overrides.ControllerPreviewOverrideHost
 import ee.schimke.composeai.overrides.LocalPreviewOverrideHost
 import ee.schimke.composeai.overrides.PreviewOverrideController
@@ -45,21 +48,37 @@ import kotlinx.serialization.json.JsonElement
  */
 class PreviewOverridesOverrideExtension(
   private val seed: Map<String, PreviewOverrideValue>? = null
-) :
-  AroundComposableExtension(
-    id = ID,
-    constraints =
-      DataExtensionConstraints(
-        phase = DataExtensionPhase.OuterEnvironment,
-        provides = setOf(DataExtensionCapability(PreviewOverridesProduct.KIND)),
-      ),
-  ) {
+) : AroundComposableHook {
+
+  override val id: DataExtensionId = ID
+
+  override val hooks: Set<DataExtensionHookKind> = setOf(DataExtensionHookKind.AroundComposable)
+
+  override val constraints: DataExtensionConstraints =
+    DataExtensionConstraints(
+      phase = DataExtensionPhase.OuterEnvironment,
+      provides = setOf(DataExtensionCapability(PreviewOverridesProduct.KIND)),
+    )
+
   @Composable
-  override fun AroundComposable(content: @Composable () -> Unit) {
+  override fun Around(context: ExtensionComposeContext, content: @Composable () -> Unit) {
+    // Stamp the active previewId before content composes so the sandbox-side `record` forwards land
+    // in this preview's bridge scope, not a concurrently-rendering preview's (pooled sandboxes).
+    // Plain call (not a SideEffect) so it runs during composition, ahead of any `previewOverride*`
+    // lookup in `content()`.
+    PreviewOverrideController.beginRender(context.previewId)
     DisposableEffect(seed) {
       PreviewOverrideController.set(seed)
+      // Reset the bridge scope at render *start* (not on dispose): a render's declarations must
+      // survive until the host-side registry reads them post-render. `clearDeclarations` resets
+      // this
+      // preview's bridge entries, then the `record` SideEffects repopulate them. On dispose only
+      // the
+      // seed is cleared (mirrors `PermissionsOverrideExtension`) — disposing the bridge here would
+      // race the host's `data/fetch` read and drop the declarations (caught by
+      // `PreviewOverridesDataFetchE2ETest`).
       PreviewOverrideController.clearDeclarations()
-      onDispose { PreviewOverrideController.resetForNewSession() }
+      onDispose { PreviewOverrideController.set(null) }
     }
     CompositionLocalProvider(LocalPreviewOverrideHost provides ControllerPreviewOverrideHost) {
       content()
@@ -77,7 +96,8 @@ class PreviewOverridesOverrideExtension(
  * composition local is installed on every render — a preview that only later begins calling
  * `previewOverride*` still finds the host wired without needing a fresh override.
  */
-class PreviewOverridesPreviewOverrideExtension : DataExtension<PreviewOverrides> {
+class PreviewOverridesPreviewOverrideExtension :
+  DataExtension<PreviewOverrides>, AlwaysOnPreviewOverrideExtension {
   override val id: DataExtensionId = PreviewOverridesOverrideExtension.ID
 
   override fun plan(request: PreviewOverrides): PlannedDataExtension =
@@ -150,12 +170,95 @@ class PreviewOverridesDataProductRegistry : DataProductRegistry {
     overrides: PreviewOverrides?,
     previewContext: PreviewContext?,
   ) {
-    val declarations = PreviewOverrideController.declarations()
+    // Read the declarations the sandbox stamped under the render's own previewId (the exact key the
+    // controller's bridge forward used); fall back to the registry's `previewId` argument when no
+    // context is attached (connector-only tests, where the bridge is absent and the in-CL
+    // controller
+    // answers). Mirrors `PermissionsDataProductRegistry.onRender`.
+    val scope = previewContext?.previewId ?: previewId
+    val declarations = readDeclarationsAcrossClassloaders(scope)
     if (declarations.isEmpty()) {
       latest.remove(previewId)
       return
     }
     latest[previewId] = PreviewOverridesPayload(declarations = declarations)
+  }
+
+  /**
+   * Read the declared knobs with cross-classloader awareness. On the Android daemon the registry
+   * runs in the host classloader while `previewOverride*`-driven `record` writes land in the
+   * *sandbox* classloader's [PreviewOverrideController] static state — a different `static` per
+   * classloader, so the host-CL controller's `declarations()` is empty even though knobs were
+   * declared. The do-not-acquire `SandboxPreviewOverridesBridge` is shared across the boundary, so
+   * we prefer it when reachable (its JSON snapshot is decoded back into typed declarations). The
+   * fallback to [PreviewOverrideController.declarations] keeps connector-only unit tests and the
+   * desktop daemon (no sandbox, no bridge) working unchanged — there the in-CL controller IS the
+   * source of truth.
+   */
+  private fun readDeclarationsAcrossClassloaders(scope: String): List<PreviewOverrideDeclaration> {
+    val bridge = SandboxPreviewOverridesBridgeReader.tryLoad()
+    val controllerDeclarations = PreviewOverrideController.declarations()
+    if (bridge == null) return controllerDeclarations
+    val bridgeJson = bridge.snapshot(scope)
+    if (bridgeJson.isEmpty()) return controllerDeclarations
+    return bridgeJson.mapNotNull { entry ->
+      try {
+        json.decodeFromString(PreviewOverrideDeclaration.serializer(), entry)
+      } catch (_: Exception) {
+        null
+      }
+    }
+  }
+
+  /**
+   * Reflective lookup of `ee.schimke.composeai.daemon.bridge.SandboxPreviewOverridesBridge`. Cached
+   * per JVM. `null` means the bridge isn't on the classpath (connector-only unit tests; the desktop
+   * daemon) — the registry falls back to the in-classloader controller state. Mirrors
+   * `PermissionsDataProductRegistry`'s `SandboxPermissionsBridgeReader`.
+   */
+  private class SandboxPreviewOverridesBridgeReader(
+    private val snapshotMethod: java.lang.reflect.Method
+  ) {
+    fun snapshot(scope: String): List<String> =
+      try {
+        @Suppress("UNCHECKED_CAST") (snapshotMethod.invoke(null, scope) as Array<String>).toList()
+      } catch (_: ReflectiveOperationException) {
+        emptyList()
+      }
+
+    companion object {
+      private const val BRIDGE_FQN: String =
+        "ee.schimke.composeai.daemon.bridge.SandboxPreviewOverridesBridge"
+
+      @Volatile private var resolved: SandboxPreviewOverridesBridgeReader? = null
+      @Volatile private var resolutionAttempted: Boolean = false
+
+      fun tryLoad(): SandboxPreviewOverridesBridgeReader? {
+        if (resolutionAttempted) return resolved
+        synchronized(this) {
+          if (resolutionAttempted) return resolved
+          val r =
+            try {
+              val cls =
+                Class.forName(
+                  BRIDGE_FQN,
+                  true,
+                  PreviewOverridesDataProductRegistry::class.java.classLoader,
+                )
+              SandboxPreviewOverridesBridgeReader(
+                snapshotMethod = cls.getMethod("snapshot", String::class.java)
+              )
+            } catch (_: ClassNotFoundException) {
+              null
+            } catch (_: NoSuchMethodException) {
+              null
+            }
+          resolved = r
+          resolutionAttempted = true
+          return r
+        }
+      }
+    }
   }
 
   companion object {
@@ -165,6 +268,7 @@ class PreviewOverridesDataProductRegistry : DataProductRegistry {
     private val json = Json {
       encodeDefaults = true
       prettyPrint = false
+      ignoreUnknownKeys = true
     }
   }
 }

--- a/data/preview-overrides/runtime/src/main/kotlin/ee/schimke/composeai/overrides/PreviewOverrideController.kt
+++ b/data/preview-overrides/runtime/src/main/kotlin/ee/schimke/composeai/overrides/PreviewOverrideController.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.mutableStateOf
 import ee.schimke.composeai.daemon.protocol.PreviewOverrideValue
 import ee.schimke.composeai.data.overrides.PreviewOverrideDeclaration
 import java.util.concurrent.CopyOnWriteArrayList
+import kotlinx.serialization.json.Json
 
 /**
  * Process-static state holder for the plain-Compose named-override surface — the counterpart to
@@ -29,19 +30,41 @@ import java.util.concurrent.CopyOnWriteArrayList
  *
  * Writers can be on any thread — the daemon's render thread for seeding, the composition thread for
  * [record]. Snapshot-state + a copy-on-write listener list carry cross-thread propagation.
+ *
+ * **Android sandbox bridge.** On the Android daemon a preview composes inside a Robolectric sandbox
+ * classloader, so the controller's static state is a *different instance* from the one the
+ * host-side `PreviewOverridesDataProductRegistry` reads. To make
+ * `data/fetch?kind=compose/overrides` work there, every [record] / [clearDeclarations] /
+ * [resetForNewSession] also forwards to the do-not-acquire `SandboxPreviewOverridesBridge`
+ * singleton — reached **reflectively** so this consumer-facing runtime keeps its
+ * no-`:daemon:android` dependency shape. When the bridge class isn't on the classpath (a plain app,
+ * the desktop daemon, connector unit tests) the forward is a cheap no-op and the in-classloader
+ * state is the only source of truth. Mirrors `PermissionsController`'s `SandboxPermissionsBridge`
+ * forwarding.
  */
 object PreviewOverrideController {
+
+  /** Bridge scope key for a render that carries no previewId; mirrors the bridge's own sentinel. */
+  private const val NO_PREVIEW_SCOPE: String = ""
 
   private val seededValuesState: MutableState<Map<String, PreviewOverrideValue>> =
     mutableStateOf(emptyMap())
 
   // Insertion-ordered, deduped by seedKey. A LinkedHashMap snapshot keeps declaration order stable
-  // for
-  // the viewer while letting a re-declared key (recomposition) replace its prior entry in place.
+  // for the viewer while letting a re-declared key (recomposition) replace its prior entry in
+  // place.
   private val declarationsState: MutableState<Map<String, PreviewOverrideDeclaration>> =
     mutableStateOf(emptyMap())
 
   private val listeners: MutableList<() -> Unit> = CopyOnWriteArrayList()
+
+  /**
+   * previewId of the render currently composing, stamped by the around-composable via
+   * [beginRender].
+   */
+  @Volatile private var activePreviewId: String? = null
+
+  private val json = Json { encodeDefaults = true }
 
   val seededValues: State<Map<String, PreviewOverrideValue>>
     get() = seededValuesState
@@ -63,6 +86,19 @@ object PreviewOverrideController {
   }
 
   /**
+   * Stamp the previewId whose composition is about to run, so subsequent [record] /
+   * [clearDeclarations] forwards land in this preview's bridge scope (not a concurrently-rendering
+   * preview's, under a pooled sandbox). Called by the around-composable before preview content
+   * composes; `null` (a render with no previewId) maps to the bridge's no-preview scope.
+   */
+  fun beginRender(previewId: String?) {
+    activePreviewId = previewId
+  }
+
+  /** Bridge scope key for the active render — the no-preview sentinel when unset. */
+  private fun bridgeScope(): String = activePreviewId ?: NO_PREVIEW_SCOPE
+
+  /**
    * Record a knob the preview just declared. Keyed by [PreviewOverrideDeclaration.seedKey]; a
    * repeat declaration of the same key (recomposition) replaces the prior entry while keeping its
    * position, so the viewer's control list is stable across recompositions.
@@ -76,6 +112,13 @@ object PreviewOverrideController {
     next[declaration.seedKey] = declaration
     declarationsState.value = next
     listeners.toList().forEach { it() }
+    // Cross-classloader forward for the Android sandbox. Serialise only when the bridge is present
+    // (a plain app / desktop daemon skips this entirely).
+    bridgeForwarder?.record(
+      bridgeScope(),
+      declaration.seedKey,
+      json.encodeToString(PreviewOverrideDeclaration.serializer(), declaration),
+    )
   }
 
   /** The knobs declared so far this render, in declaration order. */
@@ -92,17 +135,76 @@ object PreviewOverrideController {
    * interactive-session boundary. Mirrors `RemoteComposeController.resetForNewSession`.
    */
   fun resetForNewSession() {
+    val scope = bridgeScope()
     seededValuesState.value = emptyMap()
     declarationsState.value = emptyMap()
+    activePreviewId = null
+    bridgeForwarder?.reset(scope)
   }
 
   /**
    * Clear only the recorded declarations, keeping any seeded values, so a fresh composition
    * re-declares its current set without losing the daemon's seed. Used at the start of each render
-   * pass.
+   * pass. Always resets the bridge scope (even when the in-classloader set is already empty) so a
+   * shrinking list's stale indexed knobs drop from a reused sandbox's bridge entries.
    */
   fun clearDeclarations() {
+    bridgeForwarder?.reset(bridgeScope())
     if (declarationsState.value.isEmpty()) return
     declarationsState.value = emptyMap()
+  }
+
+  /**
+   * Resolved once per JVM, cached even on failure. `null` means the bridge class isn't on the
+   * classpath (plain apps, the desktop daemon, connector unit tests) — every forward no-ops.
+   */
+  private val bridgeForwarder: BridgeForwarder? by lazy { BridgeForwarder.tryLoad() }
+
+  /**
+   * Reflective handle to `ee.schimke.composeai.daemon.bridge.SandboxPreviewOverridesBridge`, which
+   * lives in `:daemon:android` (a downstream module this runtime does NOT depend on). Reached via
+   * `Class.forName` — same shape as `PermissionsController`'s `BridgeForwarder`. In the production
+   * Android daemon the controller is sandbox-loaded, and the bridge package is do-not-acquire on
+   * the sandbox classloader, so both sides observe the same single bridge instance.
+   */
+  private class BridgeForwarder(
+    private val recordMethod: java.lang.reflect.Method,
+    private val resetMethod: java.lang.reflect.Method,
+  ) {
+    fun record(previewId: String, seedKey: String, json: String) {
+      try {
+        recordMethod.invoke(null, previewId, seedKey, json)
+      } catch (_: ReflectiveOperationException) {
+        // Drop — the in-classloader controller state still serves the same-CL fast path.
+      }
+    }
+
+    fun reset(previewId: String) {
+      try {
+        resetMethod.invoke(null, previewId)
+      } catch (_: ReflectiveOperationException) {
+        // Same defensive drop.
+      }
+    }
+
+    companion object {
+      private const val BRIDGE_FQN: String =
+        "ee.schimke.composeai.daemon.bridge.SandboxPreviewOverridesBridge"
+
+      fun tryLoad(): BridgeForwarder? =
+        try {
+          val cls =
+            Class.forName(BRIDGE_FQN, true, PreviewOverrideController::class.java.classLoader)
+          BridgeForwarder(
+            recordMethod =
+              cls.getMethod("record", String::class.java, String::class.java, String::class.java),
+            resetMethod = cls.getMethod("reset", String::class.java),
+          )
+        } catch (_: ClassNotFoundException) {
+          null
+        } catch (_: NoSuchMethodException) {
+          null
+        }
+    }
   }
 }


### PR DESCRIPTION
## Summary

The plain-Compose named-override data product (`compose/overrides`) worked on the desktop daemon but not on Android. A preview's `previewOverride*` lookups record their declared knobs into the process-static `PreviewOverrideController` from *inside* the Robolectric sandbox classloader, while the host-side `PreviewOverridesDataProductRegistry` reads a *different, empty* static copy — so `data/fetch?kind=compose/overrides` reported nothing on Android. This is the Android leg #2074 deferred (desktop already worked because it has no sandbox boundary).

Two changes close the gap:

**1. Cross-classloader bridge.** New do-not-acquire `SandboxPreviewOverridesBridge` (a sibling of `SandboxPermissionsBridge`) carries the declarations across the sandbox→host boundary:
- the controller forwards each declaration to the bridge as JSON, reached **reflectively**, so the consumer runtime keeps its no-`:daemon:android` dependency shape;
- the registry reads the bridge snapshot back, decoding to typed declarations, and falls back to the in-classloader controller for the desktop daemon and connector-only unit tests;
- declarations are keyed **per-preview** so pooled sandboxes (the production Android daemon runs `sandboxCount=5`) don't leak knobs between concurrently-rendering previews;
- the bridge package is registered as do-not-acquire on `SandboxHoldingRunner`, so both sides observe one instance.

**2. Always-on planner on no-override renders.** A render with no `renderNow.overrides` bag at all — the common *first* render, before any knob is edited — previously short-circuited `PreviewOverrideExtensions.plan` and never installed the around-composable, so the active previewId was never stamped and the declarations stranded under the no-preview scope. An opt-in `AlwaysOnPreviewOverrideExtension` marker now lets **only** the named-override planner run on the null-bag path; keyboard / permissions keep their gated behaviour, so no held-session interactive state (keyboard visibility, permission grants) is reset on a no-override render. The wrapper only installs the default `LocalPreviewOverrideHost` composition local, so no-override renders stay **pixel-identical**.

## Test plan

- `:daemon:android:testDebugUnitTest --tests "*PreviewOverridesDataFetchE2ETest*"` — new end-to-end test (mirrors `PermissionsDataFetchE2ETest`) renders the new `OverridableSquare` fixture through the sandbox and asserts the host-side `compose/overrides` `data/fetch` returns the two declared knobs (`fill`/`color`, `label`/`string`) in declaration order; a second case asserts `NotAvailable` for a preview that declares none. ✅
- `:daemon:android:testDebugUnitTest --tests "*PermissionsDataFetchE2ETest*"` — the sibling bridge path still passes (no regression to the shared sandbox-bridge wiring). ✅
- `:daemon:desktop:test` / `:daemon:android:testDebugUnitTest --tests "*OverrideIntegrationTest*"` — override application unchanged on both backends. ✅
- `:data-preview-overrides-connector:test`, `:daemon:core:test --tests "*PreviewOverride*"` — connector + planner unit tests pass. ✅
- ktfmt check across the touched modules. ✅

Non-visual change (data-product plumbing + tests), so no rendered before/after is included.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UmLZxummhKzjEp7vcgLzFv)_