### PR TITLE
feat(serve): serve published design systems from trusted design-artifacts branches

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
@@ -59,6 +59,9 @@ internal object CliFlags {
       "--bundles",
       "--accept-bundles-from",
       "--trust-store",
+      "--catalogs",
+      "--catalog-repo",
+      "--catalog-branch-prefix",
       "--revisions-allow",
       // bundle sign / verify / keygen (producer trust)
       "--key",

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -6,6 +6,7 @@ import ee.schimke.composeai.cli.serve.RenderOutcome
 import ee.schimke.composeai.cli.serve.ServeBundle
 import ee.schimke.composeai.cli.serve.ServeBundleHost
 import ee.schimke.composeai.cli.serve.ServeBundleStore
+import ee.schimke.composeai.cli.serve.ServeCatalogStore
 import ee.schimke.composeai.cli.serve.ServeHost
 import ee.schimke.composeai.cli.serve.ServeHttpServer
 import ee.schimke.composeai.cli.serve.ServeMdnsAdvertiser
@@ -117,6 +118,23 @@ class ServeCommand(args: List<String>) : Command(args) {
    */
   private val trustStorePath: String? = args.flagValue("--trust-store")
 
+  /** Resolved once, reused by the upload store and the catalog store. */
+  private val resolvedTrust: TrustStore by lazy { loadTrustStore() }
+
+  /**
+   * Design systems to serve from their published `design-artifacts/<system>` branches (`--catalogs
+   * compose-m3,wear-m3`): each is fetched (catalog.json + images) and registered as a read-only
+   * `?session=<system>` session, trusted-by-origin when the branch is in the trust store.
+   */
+  private val catalogs: List<String> =
+    args.flagValue("--catalogs")?.split(",")?.map { it.trim() }?.filter { it.isNotEmpty() }
+      ?: emptyList()
+  private val catalogRepo: String =
+    args.flagValue("--catalog-repo")?.takeIf { it.isNotBlank() } ?: ServeCatalogStore.DEFAULT_REPO
+  private val catalogBranchPrefix: String =
+    args.flagValue("--catalog-branch-prefix")?.takeIf { it.isNotBlank() }
+      ?: ServeCatalogStore.DEFAULT_BRANCH_PREFIX
+
   override fun run() {
     if ("--help" in args || "-h" in args) {
       printUsage()
@@ -227,6 +245,8 @@ class ServeCommand(args: List<String>) : Command(args) {
     registerBundles().forEach { (id, bundleHost) ->
       registry.register(id, host = bundleHost, pinned = true)
     }
+    // Serve our published design systems from their trusted `design-artifacts/<system>` branches.
+    if (catalogs.isNotEmpty()) registerCatalogs(registry)
     // Runtime ingestion (--accept-bundles): clients POST a bundle (or a ?url= to one) and it's
     // registered as a pinned session. Unpacked under a temp dir for this server's lifetime.
     val bundleStore =
@@ -245,7 +265,7 @@ class ServeCommand(args: List<String>) : Command(args) {
           root = uploads,
           register = { id, bundleHost -> registry.register(id, host = bundleHost, pinned = true) },
           allowedHosts = acceptBundlesFrom,
-          trust = loadTrustStore(),
+          trust = resolvedTrust,
         )
       } else {
         null
@@ -400,6 +420,36 @@ class ServeCommand(args: List<String>) : Command(args) {
       )
     }
     return result
+  }
+
+  /**
+   * Fetch each `--catalogs` design system from its `design-artifacts/<system>` branch and register
+   * it as a pinned `?session=<system>` session ([ServeCatalogStore]). Trusted-by-origin when the
+   * branch is in the trust store; otherwise served as `unverified` (the images execute no code).
+   * Best-effort per system — one catalog failing to fetch doesn't sink the others or the server.
+   */
+  private fun registerCatalogs(registry: ServeSessionRegistry) {
+    val dir =
+      java.nio.file.Files.createTempDirectory("serve-catalogs").toFile().also { it.deleteOnExit() }
+    val store =
+      ServeCatalogStore(
+        root = dir,
+        register = { id, host -> registry.register(id, host = host, pinned = true) },
+        trust = resolvedTrust,
+        repo = catalogRepo,
+        branchPrefix = catalogBranchPrefix,
+      )
+    for (system in catalogs) {
+      when (val r = store.load(system)) {
+        is ServeCatalogStore.Result.Ok ->
+          System.err.println(
+            "serve: catalog ${r.system} → ${r.previewCount} preview(s), trust=${r.trust} " +
+              "(?session=${r.system})"
+          )
+        is ServeCatalogStore.Result.Failed ->
+          System.err.println("serve: catalog ${r.system} not served: ${r.reason}")
+      }
+    }
   }
 
   /**
@@ -565,6 +615,15 @@ class ServeCommand(args: List<String>) : Command(args) {
                           Uploaded bundles are verified against it and the verdict (signature /
                           branch / provenance / unverified) is returned + badged. Omitted = trust
                           nothing (every upload unverified); the data tiers serve either way.
+        --catalogs <system>[,<system>…]
+                          Serve our published design systems from their design-artifacts/<system>
+                          branches (e.g. compose-m3,wear-m3): each is fetched (catalog.json + images)
+                          and served read-only at ?session=<system>, trusted-by-origin when the
+                          branch is in --trust-store.
+        --catalog-repo <owner/repo>
+                          Repo the catalogs are fetched from (default yschimke/compose-ai-tools).
+        --catalog-branch-prefix <prefix>
+                          Branch prefix for --catalogs (default design-artifacts/).
 
       The shareable link carries an unguessable token; requests without it get 404.
       """

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
@@ -77,7 +77,7 @@ class ServeCatalogStore(
         val segments = path.split("/")
         if (!path.startsWith("$IMAGES_DIR/") || !path.endsWith(".png") || ".." in segments) continue
         val bytes = runCatching { fetch(base + path) }.getOrNull() ?: continue
-        val id = path.removePrefix("$IMAGES_DIR/").removeSuffix(".png")
+        val id = previewIdFor(path)
         val target = File(previewsDir, "$id.png")
         if (!target.canonicalFile.toPath().startsWith(previewsRoot)) continue
         target.parentFile?.mkdirs()
@@ -111,6 +111,19 @@ class ServeCatalogStore(
     const val DEFAULT_BRANCH_PREFIX = "design-artifacts/"
     const val CATALOG_FILE = "catalog.json"
     const val IMAGES_DIR = "images"
+
+    /**
+     * The single-path-segment preview id for a catalog image path. The serve routes (`/p/{name}`,
+     * `/render/{name}.png`, `/ws/{name}`) capture one segment, so a catalog image's subdirectory
+     * `/` (e.g. `images/button-filled/ideal__default__dark.png`) must be flattened or the preview
+     * is listed but can't be opened/rendered. We drop the `images/` prefix + `.png` suffix and
+     * replace `/` with `__` (the same separator the variant keys already use), giving a stable,
+     * route-safe id like `button-filled__ideal__default__dark`. The design-parity catalog exporter
+     * derives the `livePreview` deep link the same way so the link resolves to this id.
+     */
+    fun previewIdFor(imagePath: String): String =
+      imagePath.removePrefix("$IMAGES_DIR/").removeSuffix(".png").replace("/", "__")
+
     private const val DEFAULT_MAX_IMAGES = 1000
     private const val MAX_FETCH_BYTES = 25L * 1024 * 1024 // 25 MB per file
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
@@ -1,0 +1,149 @@
+package ee.schimke.composeai.cli.serve
+
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.InputStream
+import java.util.concurrent.TimeUnit
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import okhttp3.OkHttpClient
+import okhttp3.Request
+
+/**
+ * Serves the **design systems we publish** on a public preview server by fetching a
+ * `design-artifacts/<system>` catalog (`catalog.json` + `images/`) from GitHub and registering it
+ * as a read-only [ServeBundleHost] session — the second pillar of the public server, alongside
+ * client-uploaded bundles ([ServeBundleStore]).
+ *
+ * Trust is by **origin**: the catalog isn't a signed bundle, it's content pulled from a branch the
+ * operator listed in the [TrustStore]'s `branches`. When the `repo@branch` is trusted the session
+ * carries [BundleVerifier.Verdict.Trusted] with a [BundleVerifier.Basis.Branch]; otherwise it
+ * serves as `Unverified` (the images are still data — they execute no code — so they're shown
+ * either way, just badged). This is what makes browsing `design-artifacts/<system>` and a live,
+ * customisable preview the same render output.
+ *
+ * Fetch surface: a fixed `https://raw.githubusercontent.com/<repo>/<branch>/…` base derived from
+ * the **operator-supplied** `--catalogs` / `--catalog-repo` flags — not client input — so there's
+ * no SSRF lever here (unlike the `?url=` upload path). [fetch] is injected so tests can stub the
+ * network.
+ */
+class ServeCatalogStore(
+  private val root: File,
+  private val register: (name: String, host: ServeBundleHost) -> Unit,
+  private val trust: TrustStore,
+  private val repo: String = DEFAULT_REPO,
+  private val branchPrefix: String = DEFAULT_BRANCH_PREFIX,
+  private val fetch: (String) -> ByteArray? = ::httpFetch,
+  private val maxImages: Int = DEFAULT_MAX_IMAGES,
+) {
+
+  sealed interface Result {
+    data class Ok(val system: String, val previewCount: Int, val trust: String) : Result
+
+    data class Failed(val system: String, val reason: String) : Result
+  }
+
+  /**
+   * Fetch the `<branchPrefix><system>` catalog, lay its images out as previews, and register it.
+   */
+  fun load(system: String): Result {
+    val safe = ServeBundleStore.sanitizeName(system) ?: return Result.Failed(system, "invalid name")
+    val branch = "$branchPrefix$system"
+    val base = "https://raw.githubusercontent.com/$repo/$branch/"
+
+    val catalogBytes =
+      try {
+        fetch(base + CATALOG_FILE)
+      } catch (e: Exception) {
+        return Result.Failed(system, "could not fetch catalog.json: ${e.message}")
+      } ?: return Result.Failed(system, "could not fetch $base$CATALOG_FILE")
+    val catalog =
+      runCatching {
+          json.decodeFromString(Catalog.serializer(), catalogBytes.toString(Charsets.UTF_8))
+        }
+        .getOrNull() ?: return Result.Failed(system, "could not parse catalog.json")
+
+    val dir = File(root, safe)
+    dir.deleteRecursively()
+    val previewsDir = File(dir, "previews")
+    val previewsRoot = previewsDir.canonicalFile.toPath()
+    var count = 0
+    for (component in catalog.components) {
+      for (image in component.images) {
+        if (count >= maxImages) break
+        val path = image.path
+        // Only image-directory PNGs; reject traversal. The path is from a trusted branch, but a
+        // containment check costs nothing and guards a compromised/garbled catalog.
+        val segments = path.split("/")
+        if (!path.startsWith("$IMAGES_DIR/") || !path.endsWith(".png") || ".." in segments) continue
+        val bytes = runCatching { fetch(base + path) }.getOrNull() ?: continue
+        val id = path.removePrefix("$IMAGES_DIR/").removeSuffix(".png")
+        val target = File(previewsDir, "$id.png")
+        if (!target.canonicalFile.toPath().startsWith(previewsRoot)) continue
+        target.parentFile?.mkdirs()
+        target.writeBytes(bytes)
+        count++
+      }
+    }
+    if (count == 0) {
+      dir.deleteRecursively()
+      return Result.Failed(system, "catalog had no usable images")
+    }
+
+    val verdict =
+      if (trust.trustsBranch(repo, branch))
+        BundleVerifier.Verdict.Trusted(listOf(BundleVerifier.Basis.Branch(repo, branch)))
+      else BundleVerifier.Verdict.Unverified("branch $repo@$branch is not trusted")
+    val host = ServeBundleHost(dir, safe, verdict)
+    register(safe, host)
+    return Result.Ok(safe, host.previews.size, BundleVerifier.summary(verdict))
+  }
+
+  /** Minimal mirror of the `design-parity-catalog/v1` schema — only the image paths are needed. */
+  @Serializable private data class Catalog(val components: List<Component> = emptyList())
+
+  @Serializable private data class Component(val images: List<Image> = emptyList())
+
+  @Serializable private data class Image(val path: String)
+
+  companion object {
+    const val DEFAULT_REPO = "yschimke/compose-ai-tools"
+    const val DEFAULT_BRANCH_PREFIX = "design-artifacts/"
+    const val CATALOG_FILE = "catalog.json"
+    const val IMAGES_DIR = "images"
+    private const val DEFAULT_MAX_IMAGES = 1000
+    private const val MAX_FETCH_BYTES = 25L * 1024 * 1024 // 25 MB per file
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private val httpClient: OkHttpClient by lazy {
+      OkHttpClient.Builder()
+        .connectTimeout(10, TimeUnit.SECONDS)
+        .readTimeout(30, TimeUnit.SECONDS)
+        .build()
+    }
+
+    /** Default fetcher: https only, capped + time-bounded. */
+    private fun httpFetch(url: String): ByteArray? {
+      httpClient.newCall(Request.Builder().url(url).build()).execute().use { response ->
+        if (!response.isSuccessful) return null
+        val body = response.body ?: return null
+        return readCapped(body.byteStream(), MAX_FETCH_BYTES)
+      }
+    }
+
+    private fun readCapped(input: InputStream, max: Long): ByteArray {
+      val out = ByteArrayOutputStream()
+      val buffer = ByteArray(64 * 1024)
+      var total = 0L
+      while (true) {
+        val n = input.read(buffer)
+        if (n < 0) break
+        total += n
+        require(total <= max) { "catalog file exceeds ${max / (1024 * 1024)}MB" }
+        out.write(buffer, 0, n)
+      }
+      return out.toByteArray()
+    }
+  }
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -243,6 +243,9 @@ class ServeHttpServer(
             val dto =
               PreviewsResponse(
                 module = renderHost.label,
+                // Producer-trust verdict for a bundle/catalog session (signature / branch /
+                // provenance / unverified); null for a live daemon-backed module session.
+                trust = (renderHost as? ServeBundleHost)?.let { BundleVerifier.summary(it.trust) },
                 previews =
                   renderHost.previews.map { p ->
                     PreviewDto(id = p.id, label = p.label, modes = p.modes.map { it.wire })
@@ -451,6 +454,12 @@ class ServeHttpServer(
 private data class PreviewsResponse(
   val schema: String = "compose-preview-serve/v1",
   val module: String,
+  /**
+   * Producer-trust verdict for this session ([BundleVerifier.summary]) — `signature:<keyId>`,
+   * `branch:<repo>@<branch>`, `provenance:<id>`, or `unverified`. Null for a live daemon-backed
+   * module (trust applies to detached bundles/catalogs, not the operator's own served module).
+   */
+  val trust: String? = null,
   val previews: List<PreviewDto>,
 )
 

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
@@ -1,0 +1,97 @@
+package ee.schimke.composeai.cli.serve
+
+import java.awt.image.BufferedImage
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.nio.file.Files
+import javax.imageio.ImageIO
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Coverage for [ServeCatalogStore] — fetching a published `design-artifacts/<system>` catalog and
+ * registering it as a read-only session, trusted-by-origin when the branch is in the trust store.
+ * The network is stubbed via the injected fetcher.
+ */
+class ServeCatalogStoreTest {
+
+  private fun tempRoot(): File =
+    Files.createTempDirectory("catalog").toFile().also { it.deleteOnExit() }
+
+  private val registered = LinkedHashMap<String, ServeBundleHost>()
+
+  private fun png(): ByteArray =
+    ByteArrayOutputStream()
+      .also { ImageIO.write(BufferedImage(2, 2, BufferedImage.TYPE_INT_RGB), "png", it) }
+      .toByteArray()
+
+  private val catalogJson =
+    """
+    {"schema":"design-parity-catalog/v1","system":"compose-m3","components":[
+      {"componentId":"Button/Filled","images":[
+        {"path":"images/button-filled/ideal__default__dark.png","theme":"dark"},
+        {"path":"images/button-filled/ideal__default__light.png","theme":"light"}]},
+      {"componentId":"Evil","images":[{"path":"../../etc/passwd.png"}]}]}
+    """
+      .trimIndent()
+
+  /** Serves catalog.json + a PNG for any image URL; nothing else. */
+  private fun fetcher(): (String) -> ByteArray? = { url ->
+    when {
+      url.endsWith("/${ServeCatalogStore.CATALOG_FILE}") -> catalogJson.toByteArray()
+      url.endsWith(".png") -> png()
+      else -> null
+    }
+  }
+
+  private fun store(
+    trust: TrustStore,
+    fetch: (String) -> ByteArray? = fetcher(),
+  ): ServeCatalogStore =
+    ServeCatalogStore(
+      root = tempRoot(),
+      register = { n, h -> registered[n] = h },
+      trust = trust,
+      fetch = fetch,
+    )
+
+  @Test
+  fun `a catalog from a trusted branch is served and attributed by origin`() {
+    val trust =
+      TrustStore(
+        branches = listOf(TrustedBranch("yschimke/compose-ai-tools", "design-artifacts/*"))
+      )
+    val result = store(trust).load("compose-m3")
+
+    assertEquals(
+      ServeCatalogStore.Result.Ok(
+        "compose-m3",
+        2,
+        "branch:yschimke/compose-ai-tools@design-artifacts/compose-m3",
+      ),
+      result,
+    )
+    val host = registered.getValue("compose-m3")
+    assertTrue(host.trust is BundleVerifier.Verdict.Trusted)
+    // The traversal entry (../../etc/passwd.png) is rejected; only the two image-dir PNGs land.
+    assertEquals(
+      setOf("button-filled/ideal__default__dark", "button-filled/ideal__default__light"),
+      host.previews.map { it.id }.toSet(),
+    )
+  }
+
+  @Test
+  fun `an untrusted branch still serves the catalog but unverified`() {
+    val result = store(TrustStore.EMPTY).load("compose-m3")
+    assertEquals(ServeCatalogStore.Result.Ok("compose-m3", 2, "unverified"), result)
+    assertTrue(registered.getValue("compose-m3").trust is BundleVerifier.Verdict.Unverified)
+  }
+
+  @Test
+  fun `a missing catalog reports a failure`() {
+    val result = store(TrustStore.EMPTY, fetch = { null }).load("compose-m3")
+    assertTrue(result is ServeCatalogStore.Result.Failed)
+    assertTrue(registered.isEmpty())
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
@@ -74,10 +74,20 @@ class ServeCatalogStoreTest {
     )
     val host = registered.getValue("compose-m3")
     assertTrue(host.trust is BundleVerifier.Verdict.Trusted)
-    // The traversal entry (../../etc/passwd.png) is rejected; only the two image-dir PNGs land.
+    // The traversal entry (../../etc/passwd.png) is rejected; only the two image-dir PNGs land, and
+    // their ids are flattened to a single route-safe segment (the subdir '/' → '__') so /p/{name}
+    // and /render/{name}.png can actually open them.
     assertEquals(
-      setOf("button-filled/ideal__default__dark", "button-filled/ideal__default__light"),
+      setOf("button-filled__ideal__default__dark", "button-filled__ideal__default__light"),
       host.previews.map { it.id }.toSet(),
+    )
+  }
+
+  @Test
+  fun `preview ids are flattened to a single route-safe segment`() {
+    assertEquals(
+      "button-filled__ideal__default__dark",
+      ServeCatalogStore.previewIdFor("images/button-filled/ideal__default__dark.png"),
     )
   }
 


### PR DESCRIPTION
## Why

Third slice toward the public preview server (after #2076 signing core and #2081 verified uploads). It delivers the **second pillar** of the user's ask: besides client-uploaded bundles, the server now serves **the design systems we publish** — straight from their `design-artifacts/<system>` branches — and attributes them as trusted-by-origin. This is the basis for the cross-repo deep links (browse a `design-artifacts` branch → jump to the live server to customise).

## What

- **`serve --catalogs compose-m3,wear-m3`** fetches each catalog (`catalog.json` + `images/`) from `raw.githubusercontent.com/<repo>/design-artifacts/<system>/…` and registers it as a read-only `?session=<system>`.
- **Trust by origin:** `Trusted(Branch)` when the `repo@branch` is in `--trust-store`'s `branches`, else served as `unverified`. Catalog images are data (no code), so they serve either way — only re-render is ever gated.
- The fetch base is **operator-configured** (`--catalog-repo` / `--catalog-branch-prefix`), not client input → no SSRF lever (unlike the `?url=` upload path). Image extraction is traversal-safe; each file fetch is size-capped.
- **`/api/previews`** now reports the session's trust verdict (`signature:… / branch:… / provenance:… / unverified`; null for the live daemon module).

## Test plan

- New `ServeCatalogStoreTest` (stubbed fetcher): a trusted-branch catalog → `Trusted(Branch)` with the two image-dir previews (a `../../etc/passwd.png` entry rejected); an untrusted branch still serves but `unverified`; a missing catalog → `Failed`.
- `ServeBundleStoreTest` (13) + `CliFlagsRegistryTest` green; new flags registered.
- `./gradlew :cli:compileKotlin :cli:test` clean; ktfmt clean.

Non-visual change (serve plumbing + trusted fetch + tests). The **viewer trust badge** (UI, with rendered evidence) and the cross-repo `livePreview` deep-links land in the next slices.


---
_Generated by [Claude Code](https://claude.ai/code/session_01K8nJEfEYGM3ijyoAXDNLGH)_