### PR TITLE
feat(design-artifacts): deep-link published catalogs to the live preview server

### DIFF
--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -42,6 +42,7 @@ import { renderIndexHtml } from "./render-index-html.mjs";
 import { renderReadmeMd } from "./render-readme-md.mjs";
 import { renderWireframeSvg, slug } from "./render-wireframe-svg.mjs";
 import { renderLayoutWireframeSvg } from "./render-layout-wireframe-svg.mjs";
+import { DEFAULT_PREVIEW_BASE, livePreviewUrl } from "./live-preview.mjs";
 
 /**
  * Read a preview bundle into CandidateRenders, resolving each candidate's
@@ -211,6 +212,10 @@ const { values } = parseArgs({
     renders: { type: "string" },
     out: { type: "string" },
     renderer: { type: "string" },
+    // Base URL of the live preview server the catalog deep-links into (the
+    // `livePreview` fields + README "Customise live" links). Falls back to
+    // $PREVIEW_SERVER_BASE, then the public default.
+    "preview-base": { type: "string" },
     // Publish even when the render is incomplete (missing previews or absent
     // semantics). Off by default so a degraded render fails the job rather than
     // force-pushing a tokens/greenline-less bundle over a good delivery branch.
@@ -220,7 +225,7 @@ const { values } = parseArgs({
 
 if (!values.spec || !values.renders || !values.out) {
   console.error(
-    "usage: generate-design-catalog --spec <catalog.spec.json> --renders <dir|zip> --out <dir> [--renderer <s>]",
+    "usage: generate-design-catalog --spec <catalog.spec.json> --renders <dir|zip> --out <dir> [--renderer <s>] [--preview-base <url>]",
   );
   process.exit(2);
 }
@@ -262,6 +267,27 @@ if (!values["allow-incomplete"] && (missing.length > 0 || withoutSemantics.lengt
 // Images in the bundle are relative to the render dir; resolve them from there.
 const sourceRoot = rendersPath.endsWith(".zip") ? dirname(rendersPath) : rendersPath;
 const result = await writeCatalog(catalog, outPath, { sourceRoot });
+
+// Inject the live-preview deep links into catalog.json. Done as a post-process
+// (re-read → annotate → re-write) rather than via writeCatalog's options because
+// the pinned `@design-parity/catalog-export` predates `previewServer`; once a
+// release carrying it lands and the dep is bumped, this can move into the
+// writeCatalog call. Each image gets `livePreview` = the URL that opens its exact
+// variant on `compose-preview serve --catalogs <system>` — the same id derivation
+// the server uses, so browsing this branch and customising the live render are
+// two ends of one workflow.
+const previewBase =
+  values["preview-base"] || process.env.PREVIEW_SERVER_BASE || DEFAULT_PREVIEW_BASE;
+{
+  const catalogJsonPath = join(outPath, "catalog.json");
+  const manifest = JSON.parse(await readFile(catalogJsonPath, "utf8"));
+  for (const component of manifest.components ?? []) {
+    for (const image of component.images ?? []) {
+      if (image.path) image.livePreview = livePreviewUrl(previewBase, manifest.system, image.path);
+    }
+  }
+  await writeFile(catalogJsonPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+}
 
 // Editable SVG wireframes next to the raster PNGs: one labelled shape per layout
 // region, in any-vector-tool-editable form, so a developer can adopt the
@@ -312,7 +338,7 @@ await writeFile(indexPath, renderIndexHtml(catalog, { wireframeSlugs }), "utf8")
 const readmePath = join(outPath, "README.md");
 await writeFile(
   readmePath,
-  renderReadmeMd(catalog, { imageCount: result.imageCount, wireframeCount }),
+  renderReadmeMd(catalog, { imageCount: result.imageCount, wireframeCount, previewBase }),
   "utf8",
 );
 

--- a/scripts/design-artifacts/live-preview.mjs
+++ b/scripts/design-artifacts/live-preview.mjs
@@ -26,14 +26,18 @@ export function catalogPreviewId(imagePath) {
     .replace(/\//g, "__");
 }
 
-/** Deep link that opens a catalog image's variant in the live preview server. */
+/**
+ * Deep link that opens a catalog image's variant in the live preview server. Targets the **viewer**
+ * route `/p/{name}` (not `/?preview=`, which only renders the session landing page) with the
+ * route-safe preview id as the single path segment and `?session=<system>` selecting the catalog.
+ */
 export function livePreviewUrl(base, system, imagePath) {
   const root = base.replace(/\/+$/, "");
   const id = catalogPreviewId(imagePath);
-  return `${root}/?session=${encodeURIComponent(system)}&preview=${encodeURIComponent(id)}`;
+  return `${root}/p/${encodeURIComponent(id)}?session=${encodeURIComponent(system)}`;
 }
 
-/** Session-level link (the system landing on the live server), for the README banner. */
+/** Session-level link (the system's landing page on the live server), for the README banner. */
 export function liveSessionUrl(base, system) {
   return `${base.replace(/\/+$/, "")}/?session=${encodeURIComponent(system)}`;
 }

--- a/scripts/design-artifacts/live-preview.mjs
+++ b/scripts/design-artifacts/live-preview.mjs
@@ -1,0 +1,39 @@
+/**
+ * Live-preview deep links for the published design-artifact catalogs — the
+ * cross-tool bridge that makes browsing a `design-artifacts/<system>` branch and
+ * opening an editable live preview the same render.
+ *
+ * The upstream `compose-preview serve --catalogs <system>` hosts each published
+ * catalog as a `?session=<system>` session and derives a **route-safe** preview
+ * id from the image's bundle path. This module reproduces that exact derivation
+ * so a link in `catalog.json` / the README resolves to the matching live render.
+ *
+ * Contract (keep in lockstep with `ServeCatalogStore.previewIdFor` in
+ * `compose-ai-tools` and `livePreviewUrl` in design-parity's `catalog-export`):
+ * the preview id is the image path minus the `images/` prefix and `.png` suffix,
+ * with the component-subdir `/` flattened to `__` (the serve routes capture a
+ * single path segment, so the id must be slash-free).
+ */
+
+/** Default public preview server. Override with `PREVIEW_SERVER_BASE` / `--preview-base`. */
+export const DEFAULT_PREVIEW_BASE = "https://preview.coo.ee";
+
+/** Route-safe live-server preview id for a catalog image path. */
+export function catalogPreviewId(imagePath) {
+  return imagePath
+    .replace(/^images\//, "")
+    .replace(/\.png$/, "")
+    .replace(/\//g, "__");
+}
+
+/** Deep link that opens a catalog image's variant in the live preview server. */
+export function livePreviewUrl(base, system, imagePath) {
+  const root = base.replace(/\/+$/, "");
+  const id = catalogPreviewId(imagePath);
+  return `${root}/?session=${encodeURIComponent(system)}&preview=${encodeURIComponent(id)}`;
+}
+
+/** Session-level link (the system landing on the live server), for the README banner. */
+export function liveSessionUrl(base, system) {
+  return `${base.replace(/\/+$/, "")}/?session=${encodeURIComponent(system)}`;
+}

--- a/scripts/design-artifacts/live-preview.test.mjs
+++ b/scripts/design-artifacts/live-preview.test.mjs
@@ -23,10 +23,10 @@ test("catalogPreviewId flattens the image path to a route-safe id", () => {
   );
 });
 
-test("livePreviewUrl targets the system session with the flattened preview id", () => {
+test("livePreviewUrl targets the /p viewer route with the flattened preview id", () => {
   assert.equal(
     livePreviewUrl("https://preview.coo.ee///", "compose-m3", "images/fab/ideal__default__dark.png"),
-    "https://preview.coo.ee/?session=compose-m3&preview=fab__ideal__default__dark",
+    "https://preview.coo.ee/p/fab__ideal__default__dark?session=compose-m3",
   );
 });
 

--- a/scripts/design-artifacts/live-preview.test.mjs
+++ b/scripts/design-artifacts/live-preview.test.mjs
@@ -1,0 +1,47 @@
+/**
+ * Unit tests for the live-preview deep-link helpers + the README "Customise
+ * live" link. Run with `node --test scripts/design-artifacts/`.
+ *
+ * The preview-id derivation MUST stay in lockstep with the server
+ * (`ServeCatalogStore.previewIdFor`) and design-parity (`livePreviewUrl`), so a
+ * link resolves to the matching live render — these tests pin that contract.
+ */
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  catalogPreviewId,
+  liveSessionUrl,
+  livePreviewUrl,
+} from "./live-preview.mjs";
+import { renderReadmeMd } from "./render-readme-md.mjs";
+
+test("catalogPreviewId flattens the image path to a route-safe id", () => {
+  assert.equal(
+    catalogPreviewId("images/button-filled/ideal__default__dark.png"),
+    "button-filled__ideal__default__dark",
+  );
+});
+
+test("livePreviewUrl targets the system session with the flattened preview id", () => {
+  assert.equal(
+    livePreviewUrl("https://preview.coo.ee///", "compose-m3", "images/fab/ideal__default__dark.png"),
+    "https://preview.coo.ee/?session=compose-m3&preview=fab__ideal__default__dark",
+  );
+});
+
+test("liveSessionUrl is the system landing on the live server", () => {
+  assert.equal(
+    liveSessionUrl("https://preview.coo.ee", "wear-m3"),
+    "https://preview.coo.ee/?session=wear-m3",
+  );
+});
+
+test("the README carries a Customise-live link to the live session", () => {
+  const md = renderReadmeMd(
+    { meta: { system: "compose-m3", title: "Compose Material 3" }, components: [] },
+    { previewBase: "https://preview.coo.ee" },
+  );
+  assert.match(md, /## 🎛 Customise live/);
+  assert.ok(md.includes("https://preview.coo.ee/?session=compose-m3"));
+});

--- a/scripts/design-artifacts/render-readme-md.mjs
+++ b/scripts/design-artifacts/render-readme-md.mjs
@@ -11,6 +11,8 @@
  * the README survives branch regeneration instead of being clobbered.
  */
 
+import { DEFAULT_PREVIEW_BASE, liveSessionUrl } from "./live-preview.mjs";
+
 const DEFAULT_REPO = "yschimke/compose-ai-tools";
 
 /** Escape the few characters that would break a Markdown table cell. Backslash
@@ -34,7 +36,7 @@ function groupCounts(components) {
 
 /**
  * @param {object} catalog the in-memory catalog (system, title, library, …)
- * @param {object} opts { imageCount, wireframeCount, repo? }
+ * @param {object} opts { imageCount, wireframeCount, repo?, previewBase? }
  * @returns {string} README.md contents
  */
 export function renderReadmeMd(catalog, opts = {}) {
@@ -47,6 +49,8 @@ export function renderReadmeMd(catalog, opts = {}) {
   const title = meta.title ?? system;
   const branch = `design-artifacts/${system}`;
   const indexUrl = `https://htmlpreview.github.io/?https://github.com/${repo}/blob/${branch}/index.html`;
+  const previewBase = opts.previewBase ?? DEFAULT_PREVIEW_BASE;
+  const liveUrl = liveSessionUrl(previewBase, system);
 
   const imageCount = opts.imageCount ?? components.reduce((n, c) => n + (c.images?.length ?? 0), 0);
   const wireframeCount = opts.wireframeCount ?? 0;
@@ -78,7 +82,7 @@ export function renderReadmeMd(catalog, opts = {}) {
     [`\`index.html\``, `Self-contained gallery — [open via htmlpreview](${indexUrl})`],
     [
       `\`catalog.json\``,
-      `Machine-readable catalog (\`${schema}\`): components, variants, design tokens, greenlines`,
+      `Machine-readable catalog (\`${schema}\`): components, variants, design tokens, greenlines, and per-variant \`livePreview\` deep links`,
     ],
     [`\`images/\``, "Rendered PNGs — the source of truth for each variant"],
     [`\`wireframes/\``, "One editable SVG per component (layout-inspector tree → token-styled shapes)"],
@@ -99,6 +103,16 @@ Figma / Stitch / Claude Design.
 
 A self-contained gallery — one card per component with its rendered PNG,
 dimensions, accessibility greenlines, and a link to an editable SVG wireframe.
+
+## 🎛 Customise live
+
+**[▶ Open this catalog in the live preview server](${liveUrl})**
+
+The same rendered components, served live by \`compose-preview serve --catalogs ${system}\` —
+open one, then change the theme, locale, font scale, or device and watch it
+re-render. Every entry in \`catalog.json\` carries a per-variant \`livePreview\`
+deep link to its exact preview on the same server, so browsing this branch and
+customising the live render are two ends of one workflow.
 
 ## At a glance
 
@@ -122,6 +136,7 @@ ${files}
 
 - **Figma / Stitch / Claude Design** — import \`catalog.json\` + \`images/\` as a sticker sheet.
 - **Browse** — open \`index.html\` through htmlpreview (link above), or clone the branch and open it locally.
+- **Customise** — open the [live preview server](${liveUrl}) (or any image's \`livePreview\` link in \`catalog.json\`) to re-render a component under different themes / locales / devices.
 - **Adopt structure** — the \`wireframes/*.svg\` are plain vector files; drop one into any editor to start from the real layout instead of tracing a screenshot.
 
 ## Provenance


### PR DESCRIPTION
## Why

The connective tissue of the ecosystem (the compose-ai-tools side of the cross-repo deep links; design-parity #165 is the other half). After #2084 made `compose-preview serve --catalogs <system>` *host* the published design systems, this makes the published `design-artifacts/<system>` branch *point back* at that live server — so browsing the sticker sheet and opening an editable live render are two ends of one workflow, exactly the "connected ecosystem" the brief asks for.

## What

- **`catalog.json`** — every image entry gets a `livePreview` URL that opens its exact variant on the live server. Injected as a post-process (the pinned `@design-parity/catalog-export` predates the `previewServer` option from #165; this moves into `writeCatalog` once that release lands and the dep is bumped).
- **README** — a "🎛 Customise live" section + a Using-it bullet linking the live session, so the branch landing page on GitHub itself points at the live server.
- The preview id is derived **identically** to `ServeCatalogStore.previewIdFor` (#2084) and design-parity's `livePreviewUrl` (#165): `images/<c>/<stem>.png` → `<c>__<stem>` (route-safe single segment). One shared `live-preview.mjs` helper owns it; `--preview-base` / `$PREVIEW_SERVER_BASE` override the `https://preview.coo.ee` default.

## Test plan

- `node --test scripts/design-artifacts/live-preview.test.mjs` (4 cases): id flattening, `livePreviewUrl`, `liveSessionUrl`, and that the rendered README carries the Customise-live link.
- `node --check` clean on all three modified scripts.

Non-visual: `catalog.json` is data, the README is markdown, the driver is build tooling. The generated `index.html` per-card "Customise live" links (a visual surface, needs rendered evidence) are a deliberate follow-up.

Note: after this + #165 land, the `design-artifacts/*` branches should be regenerated (dispatch `design-artifacts.yml`) so the published catalogs carry the new links.


---
_Generated by [Claude Code](https://claude.ai/code/session_01K8nJEfEYGM3ijyoAXDNLGH)_