### PR TITLE
feat(serve): --public open mode + trust-store starter + public-server docs

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -98,6 +98,14 @@ class ServeCommand(args: List<String>) : Command(args) {
   private val acceptBundles: Boolean = "--accept-bundles" in args
 
   /**
+   * Public mode: serve every route **without** requiring the token (the deployed public preview
+   * server, where browsing the published catalogs + uploaded bundles is the point). Safe by
+   * construction — no server-side code execution, re-render of untrusted Compose refused, uploads
+   * capped + SSRF-gated. Off by default so a normal `serve` stays token-gated.
+   */
+  private val public: Boolean = "--public" in args
+
+  /**
    * SSRF allowlist for `POST /bundles/{name}?url=` fetches: comma-separated hostnames the server
    * may fetch a bundle from. Empty = no URL fetch is allowed (fail closed), so `--accept-bundles`
    * alone only accepts uploads; a host must be explicitly trusted before the server will reach out.
@@ -278,6 +286,7 @@ class ServeCommand(args: List<String>) : Command(args) {
         sessions = registry,
         defaultSessionId = module.gradlePath,
         bundleStore = bundleStore,
+        isPublic = public,
       )
 
     // Advertise on the LAN over mDNS when bound to a reachable interface (`--lan`), so the mobile /
@@ -499,9 +508,15 @@ class ServeCommand(args: List<String>) : Command(args) {
   private fun printBanner(moduleLabel: String, port: Int, token: String, previewCount: Int) {
     val exposed = ServeUrls.isExposed(host)
     val localHost = if (exposed || host == ServeUrls.LOOPBACK) ServeUrls.LOOPBACK else host
-    val localUrl = ServeUrls.landingUrl(ServeUrls.origin(localHost, port), token)
+    // Public mode is open, so the link carries no token; otherwise the token gates every route.
+    val localUrl =
+      if (public) "${ServeUrls.origin(localHost, port)}/"
+      else ServeUrls.landingUrl(ServeUrls.origin(localHost, port), token)
 
     System.err.println("compose-preview serve — module $moduleLabel")
+    if (public) {
+      System.err.println("  ⚠ Public mode — every route is open (no token required).")
+    }
     System.err.println("  Local:   $localUrl")
     if (exposed) {
       val networks = ServeUrls.siteLocalIpv4Addresses()
@@ -581,6 +596,10 @@ class ServeCommand(args: List<String>) : Command(args) {
                           connect. Prints the token-gated network URL and a security warning.
         --port <n>        Preferred port (default $DEFAULT_PORT; auto-picks the next free one).
         --token <value>   Use a fixed token instead of a freshly generated one (stable links).
+        --public          Serve every route WITHOUT a token (open). For a deployed public preview
+                          server — browsing published catalogs / uploaded bundles is the point. Safe
+                          by construction (no server-side code exec; untrusted re-render refused;
+                          uploads capped + SSRF-gated). Off by default.
         --export <path>   Don't serve: render every preview once and write a portable bundle (a
                           self-contained web gallery + PNGs) to <path>. A '.zip' path writes a zip;
                           any other path writes a directory. The live server also offers this at

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -60,6 +60,14 @@ class ServeHttpServer(
   private val defaultSessionId: String,
   /** When non-null, enables `POST /bundles/{name}` for clients to contribute bundles at runtime. */
   private val bundleStore: ServeBundleStore? = null,
+  /**
+   * Public mode: serve **without** requiring the token — every route is open. For a deployed public
+   * preview server (preview.coo.ee) where browsing the published catalogs / uploaded bundles is the
+   * point. Safe by construction: rendering a bundle/catalog executes no code, re-rendering
+   * untrusted Compose is refused, uploads are size-capped + the `?url=` fetch is SSRF-gated. Off by
+   * default, so a normal `serve` stays token-gated (a bad/absent token still 404s).
+   */
+  private val isPublic: Boolean = false,
   portRange: Int = DEFAULT_PORT_RANGE,
   /**
    * Max renders in flight across the HTTP `/render` lane. Defaults to the host's CPU count so a
@@ -145,7 +153,7 @@ class ServeHttpServer(
         // checked post-handshake (can't 404 after upgrade) — a bad token closes immediately.
         webSocket("/ws/{name}") {
           val provided = call.request.queryParameters["token"] ?: call.request.headers[TOKEN_HEADER]
-          if (!ServeUrls.tokensMatch(token, provided)) {
+          if (!isAuthorized(token, provided, isPublic)) {
             close(CloseReason(CloseReason.Codes.VIOLATED_POLICY, "unauthorized"))
             return@webSocket
           }
@@ -390,7 +398,7 @@ class ServeHttpServer(
    */
   private suspend fun RoutingContext.rejectBadToken(): Boolean {
     val provided = call.request.queryParameters["token"] ?: call.request.headers[TOKEN_HEADER]
-    if (ServeUrls.tokensMatch(token, provided)) return false
+    if (isAuthorized(token, provided, isPublic)) return false
     call.respondText("not found", status = HttpStatusCode.NotFound)
     return true
   }
@@ -398,6 +406,14 @@ class ServeHttpServer(
   companion object {
     const val TOKEN_HEADER: String = "X-Compose-Preview-Token"
     private const val DEFAULT_PORT_RANGE = 32
+
+    /**
+     * Authorisation decision for a request: open when [isPublic], otherwise the [provided] token
+     * must match [token] (constant-time). Pure so the gate is unit-testable without standing up the
+     * server. A bad/absent token in non-public mode is rejected (the caller 404s for obscurity).
+     */
+    fun isAuthorized(token: String, provided: String?, isPublic: Boolean): Boolean =
+      isPublic || ServeUrls.tokensMatch(token, provided)
 
     /**
      * How long a `/render` request waits for a concurrency slot before getting 503 + Retry-After.

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeAuthTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeAuthTest.kt
@@ -1,0 +1,29 @@
+package ee.schimke.composeai.cli.serve
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The token gate ([ServeHttpServer.isAuthorized]). In normal mode the provided token must match; in
+ * `--public` mode every request is authorized (the deployed public server, where browsing the
+ * catalogs / bundles is the point and safety is structural, not token-based).
+ */
+class ServeAuthTest {
+
+  private val token = "s3cret-token"
+
+  @Test
+  fun `non-public mode requires the matching token`() {
+    assertTrue(ServeHttpServer.isAuthorized(token, token, isPublic = false))
+    assertFalse(ServeHttpServer.isAuthorized(token, "wrong", isPublic = false))
+    assertFalse(ServeHttpServer.isAuthorized(token, null, isPublic = false))
+  }
+
+  @Test
+  fun `public mode authorizes every request regardless of token`() {
+    assertTrue(ServeHttpServer.isAuthorized(token, null, isPublic = true))
+    assertTrue(ServeHttpServer.isAuthorized(token, "wrong", isPublic = true))
+    assertTrue(ServeHttpServer.isAuthorized(token, token, isPublic = true))
+  }
+}

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -1,0 +1,75 @@
+# The public preview server
+
+`compose-preview serve` can run as a **public** preview server (the deployment behind
+`preview.coo.ee`) with two things to show:
+
+1. **Uploaded bundles** — anyone can `POST /bundles/<name>` a portable bundle (or point at one with
+   `?url=`) and get a shareable `?session=<name>` link. The server shows the bundle's **data tiers**
+   (baked PNGs, Remote Compose / Protolayout / Lottie IR) for any uploader, and reports a **trust
+   verdict** so you can tell a bundle from a producer you trust from an anonymous one.
+2. **The design systems we publish** — `--catalogs compose-m3,wear-m3` fetches each published
+   `design-artifacts/<system>` catalog and serves it read-only at `?session=<system>`. Browsing that
+   branch and opening a live, customisable render are then two ends of one workflow (the branch's
+   README + `catalog.json` carry `livePreview` deep links back here).
+
+## Two axes: trust × format
+
+These are orthogonal. **Trust** decides attribution; **format** decides what draws the pixels. Neither
+ever lets untrusted code run *on the server*.
+
+### Trust
+
+A bundle/catalog is `Trusted(by …)` or `Unverified`. Trust gates only **server-side re-render** of a
+bundle's *executable* Compose; the data tiers serve regardless. Three bases (`--trust-store
+trust/producers.json`):
+
+| Basis | How | Strength |
+|---|---|---|
+| **Signature** | An Ed25519 `signatures.json` signed by a key in the store's `keys` (`bundle sign`). | Strongest — cryptographic, offline. |
+| **Branch** | The server fetched the catalog from a branch in the store's `branches` (e.g. `design-artifacts/*`). | Origin/TLS trust. |
+| **Provenance** | A CI OIDC identity in the store's `oidc`. | Advisory — annotates an already-signature-verified bundle; full Sigstore/Rekor is a follow-up. |
+
+Empty store ⇒ trust nothing (fail-closed). See [`trust/producers.json`](../trust/producers.json) for
+the starter, and `compose-preview bundle keygen | sign | verify` to mint a key, sign a bundle, and
+check a verdict.
+
+### Format (each its own renderer; none executes code on the server)
+
+| Format | In-browser | Server render | Data-only / safe | Server render needs trust |
+|---|---|---|---|---|
+| **Compose Android** | — | Robolectric (daemon) | no (runs Kotlin) | **yes** |
+| **Compose MP (CMP)** | **Kotlin/Wasm** (browser sandbox) | Skiko desktop (daemon) | no (runs Kotlin) | server: **yes**; Wasm: sandboxed |
+| **Remote Compose** | RemoteDocument player | player | **yes** | no |
+| **Protolayout / Lottie** | web player | renderer | **yes** | no |
+| **Baked PNG** | `<img>` | — | **yes** | no |
+
+So: **CMP renders in the browser** (Wasm sandbox), **Compose Android uses the server**, and a **baked
+PNG** is the universal fallback when an image is needed. Remote Compose / Protolayout are *separate,
+data-only* formats — the safest uploads.
+
+## Running one
+
+```bash
+compose-preview serve \
+  --module :samples:design-catalog-m3 \   # a base module is the default session
+  --public \                              # open every route (no token)
+  --catalogs compose-m3,wear-m3 \         # serve the published design systems
+  --accept-bundles \                      # accept client bundle uploads
+  --trust-store trust/producers.json \    # who we trust
+  --host 0.0.0.0 --port 8080
+```
+
+- **`--public`** drops the token gate (the deployed server is meant to be open). It is **safe by
+  construction**: rendering a bundle/catalog executes no code, re-rendering untrusted Compose is
+  refused, uploads are size-capped, and the `?url=` fetch is SSRF-gated (`--accept-bundles-from`).
+- Put **Caddy** (or Cloudflare) in front for TLS on `preview.coo.ee` — see
+  [`deploy/vps`](../deploy/vps) / [`deploy/image`](../deploy/image) for the container + reverse-proxy
+  pattern (run the command above in place of the token-gated default).
+- **Re-render of trusted Compose** stays off unless the operator opts in; a public box should leave
+  `--revisions` *off* (that path runs arbitrary Gradle = RCE).
+
+## Endpoints
+
+`GET /` index · `GET /p/{id}?session=<s>` viewer · `GET /render/{id}.png` PNG ·
+`GET /api/previews` JSON (now includes `trust`) · `POST /bundles/{name}` upload (returns `trust`) ·
+`GET /healthz`. In `--public` mode all are open; otherwise the token gates everything but `/healthz`.

--- a/trust/producers.json
+++ b/trust/producers.json
@@ -1,0 +1,26 @@
+{
+  "_comment": "Producer-trust allowlist for a public `compose-preview serve --trust-store`. Three independent bases — pinned Ed25519 keys, trusted GitHub branches (origin trust), and CI provenance identities. A bundle/catalog the server can attribute to one of these is shown as trusted (and, with operator opt-in, eligible for server-side re-render of its executable Compose); everything else still serves its data tiers as `unverified`. Empty = trust nothing (fail-closed). See docs/public-preview-server.md.",
+
+  "keys": [
+    {
+      "keyId": "compose-ai-tools-ci",
+      "name": "Compose AI Tools CI (REPLACE with the real public key)",
+      "_howto": "Generate with `compose-preview bundle keygen`, keep the private key as a CI secret, and paste the printed public key here. Bundles signed with `bundle sign --key <priv> --key-id compose-ai-tools-ci` then verify as trusted by signature.",
+      "publicKey": "REPLACE_WITH_BASE64_ED25519_PUBLIC_KEY"
+    }
+  ],
+
+  "branches": [
+    {
+      "repo": "yschimke/compose-ai-tools",
+      "branch": "design-artifacts/*"
+    }
+  ],
+
+  "oidc": [
+    {
+      "_comment": "Advisory until full Sigstore/Fulcio+Rekor verification lands — an oidc entry only annotates a signature a pinned key already verified; it does not by itself grant trust.",
+      "identity": "repo:yschimke/compose-ai-tools:ref:refs/heads/main"
+    }
+  ]
+}


### PR DESCRIPTION
## Why

Stands up the **deployable public preview server** (preview.coo.ee) on top of the trust core (#2076) and the verified upload / catalog serving (#2081, #2084, #2086). It's the operator-facing piece: a flag to run the server open, a committed trust allowlist, and a doc that ties the model together.

## What

- **`serve --public`** drops the token gate so every route is open — the deployed public server, where browsing the published catalogs + uploaded bundles is the point. **Safe by construction:** rendering a bundle/catalog executes no code, re-render of untrusted Compose is refused, uploads are size-capped, and the `?url=` fetch is SSRF-gated. Off by default (a normal `serve` stays token-gated; a bad/absent token still 404s). The auth decision is a pure, unit-tested helper `ServeHttpServer.isAuthorized(token, provided, isPublic)`; the startup banner prints an open-mode warning and a token-free URL.
- **`trust/producers.json`** — the starter producer-trust allowlist the `--trust-store` flag points at: a signing-key placeholder + the `design-artifacts/*` branch origins + the Actions OIDC identity.
- **`docs/public-preview-server.md`** — the two pillars (uploads + published catalogs), the trust × format model (incl. the CMP-Wasm / Android-server / baked-PNG render table), and the exact `serve --public --catalogs --accept-bundles --trust-store` command.

## Test plan

- `ServeAuthTest`: non-public mode requires the matching token (wrong/absent → rejected); `--public` authorizes every request.
- `trust/producers.json` is valid JSON and loads through `TrustStore` (unknown `_comment` fields ignored).
- `CliFlagsRegistryTest` green; `./gradlew :cli:compileKotlin :cli:test` clean; ktfmt clean.

Non-visual (serve gating + config + docs). The container `deploy/public/` profile waits on a CLI release that ships these flags (the prebuilt image pins a released CLI); the doc gives the exact command to run against `deploy/vps`/`deploy/image` meanwhile.


---
_Generated by [Claude Code](https://claude.ai/code/session_01K8nJEfEYGM3ijyoAXDNLGH)_