### PR TITLE
fix(release): split release-please into separate PRs so the root release tags on merge

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "simple",
+  "separate-pull-requests": true,
   "include-v-in-tag": true,
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,


### PR DESCRIPTION
Since the `clients` package was added to the manifest (#2011), merging the
release PR stopped cutting the root release. release-please's Merge plugin
combines the packages into one `chore: release main` PR whose root section is
headed by version only (no component); on merge it parses the root component as
`undefined`, fails to match it against the configured `compose-ai-tools`
package ("PR component: undefined does not match configured component:
compose-ai-tools" -> "Missing 1 paths: ."), so `release_created` stays false
and no tag/Release/publish happens. It only bites when the root changes alone
(clients unchanged) — which is why v0.16.1 (root+clients together) released but
v0.16.2 and v0.16.3 had to be tagged by hand.

`separate-pull-requests: true` disables the Merge plugin: each package gets its
own PR (`chore(main): release X.Y.Z` for the root — the version-in-title form
docs/RELEASING.md already documents), and the root release matches and tags on
merge. The workflow already has per-component plumbing (`clients--release_created`,
the `release-clients` job), so independent PRs fit the existing design.