### PR TITLE
feat(serve): carry the CMP Wasm app on the trusted catalog branch + cache it

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -270,7 +270,9 @@ class ServeCommand(args: List<String>) : Command(args) {
       registry.register(id, host = bundleHost, pinned = true)
     }
     // Serve our published design systems from their trusted `design-artifacts/<system>` branches.
-    if (catalogs.isNotEmpty()) registerCatalogs(registry)
+    // A catalog that carries a `web/wasm/` app yields a system→dir entry so the in-browser tier
+    // rides the same trusted branch (no local --wasm-dir build needed).
+    val catalogWasm = if (catalogs.isNotEmpty()) registerCatalogs(registry) else emptyMap()
     // Runtime ingestion (--accept-bundles): clients POST a bundle (or a ?url= to one) and it's
     // registered as a pinned session. Unpacked under a temp dir for this server's lifetime.
     val bundleStore =
@@ -298,7 +300,7 @@ class ServeCommand(args: List<String>) : Command(args) {
     // assembled app (index.html), warning on the rest, so a typo'd path doesn't silently advertise
     // a
     // broken "Run in browser" toggle.
-    val wasmCatalogs = wasmDirs.filter { (system, dir) ->
+    val localWasm = wasmDirs.filter { (system, dir) ->
       val ok = File(dir, "index.html").isFile
       if (!ok) {
         System.err.println(
@@ -308,6 +310,11 @@ class ServeCommand(args: List<String>) : Command(args) {
       }
       ok
     }
+    // Merge the apps fetched from the catalog branches with the explicit `--wasm-dir` paths; a
+    // local
+    // `--wasm-dir` wins for a system so an operator can override the published app with a local
+    // build.
+    val wasmCatalogs = catalogWasm + localWasm
     if (wasmCatalogs.isNotEmpty()) {
       System.err.println("serve: in-browser Wasm tier for: ${wasmCatalogs.keys.joinToString(", ")}")
     }
@@ -471,9 +478,10 @@ class ServeCommand(args: List<String>) : Command(args) {
    * branch is in the trust store; otherwise served as `unverified` (the images execute no code).
    * Best-effort per system — one catalog failing to fetch doesn't sink the others or the server.
    */
-  private fun registerCatalogs(registry: ServeSessionRegistry) {
+  private fun registerCatalogs(registry: ServeSessionRegistry): Map<String, File> {
     val dir =
       java.nio.file.Files.createTempDirectory("serve-catalogs").toFile().also { it.deleteOnExit() }
+    val wasm = linkedMapOf<String, File>()
     val store =
       ServeCatalogStore(
         root = dir,
@@ -481,6 +489,12 @@ class ServeCommand(args: List<String>) : Command(args) {
         trust = resolvedTrust,
         repo = catalogRepo,
         branchPrefix = catalogBranchPrefix,
+        registerWasm = { system, wasmDir ->
+          wasm[system] = wasmDir
+          System.err.println(
+            "serve: catalog $system carries an in-browser Wasm app (/wasm/$system/)"
+          )
+        },
       )
     for (system in catalogs) {
       when (val r = store.load(system)) {
@@ -493,6 +507,7 @@ class ServeCommand(args: List<String>) : Command(args) {
           System.err.println("serve: catalog ${r.system} not served: ${r.reason}")
       }
     }
+    return wasm
   }
 
   /**

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
@@ -125,19 +125,30 @@ class ServeCatalogStore(
     val prefix = render.path.trim('/')
     if (prefix.isEmpty() || render.files.isEmpty()) return
     val wasmDir = File(dir, WEB_WASM_DIR)
+    // **Fail closed, all-or-nothing.** Register the app only if *every* declared file is fetched
+    // and
+    // an index.html is present — a partial app (a 404/timeout on composeApp.wasm or skiko.wasm, a
+    // traversal/escaping entry, or a list longer than the cap) would make the viewer advertise "Run
+    // in browser (Wasm)" only for the iframe to 404 its module/wasm fetches. The file list is the
+    // trusted catalog's complete manifest, so any missing/invalid entry means "don't offer it".
+    fun fail(reason: String) {
+      wasmDir.deleteRecursively()
+      System.err.println("serve: $system web/wasm/ incomplete ($reason) — in-browser tier disabled")
+    }
+    if (render.files.size > MAX_WASM_FILES) return fail("more than $MAX_WASM_FILES files declared")
     val wasmRoot = wasmDir.canonicalFile.toPath()
-    var written = 0
-    for (name in render.files.take(MAX_WASM_FILES)) {
+    for (name in render.files) {
       val rel = name.trim('/')
-      if (rel.isEmpty() || ".." in rel.split("/")) continue
+      if (rel.isEmpty() || ".." in rel.split("/")) return fail("invalid entry '$name'")
       val target = File(wasmDir, rel)
-      if (!target.canonicalFile.toPath().startsWith(wasmRoot)) continue
-      val bytes = runCatching { fetch("$base$prefix/$rel") }.getOrNull() ?: continue
+      if (!target.canonicalFile.toPath().startsWith(wasmRoot)) return fail("escaping entry '$name'")
+      val bytes =
+        runCatching { fetch("$base$prefix/$rel") }.getOrNull() ?: return fail("missing $rel")
       target.parentFile?.mkdirs()
       target.writeBytes(bytes)
-      written++
     }
-    if (written > 0 && File(wasmDir, "index.html").isFile) registerWasm(system, wasmDir)
+    if (!File(wasmDir, "index.html").isFile) return fail("no index.html")
+    registerWasm(system, wasmDir)
   }
 
   /**

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
@@ -35,6 +35,13 @@ class ServeCatalogStore(
   private val branchPrefix: String = DEFAULT_BRANCH_PREFIX,
   private val fetch: (String) -> ByteArray? = ::httpFetch,
   private val maxImages: Int = DEFAULT_MAX_IMAGES,
+  /**
+   * Called when the catalog declares an in-browser Wasm app (`webRender` in `catalog.json`) and its
+   * files were fetched: the system id → the local directory the app was written to. The server then
+   * serves it at `/wasm/<system>/`, so the **CMP-Wasm tier rides the same trusted branch as the
+   * catalog** — a deployed public server needs no local `--wasm-dir` build, just `--catalogs`.
+   */
+  private val registerWasm: (system: String, dir: File) -> Unit = { _, _ -> },
 ) {
 
   sealed interface Result {
@@ -90,6 +97,14 @@ class ServeCatalogStore(
       return Result.Failed(system, "catalog had no usable images")
     }
 
+    // Optional in-browser Wasm tier: when the catalog declares a `compose-wasm` webRender, fetch
+    // its
+    // app files from the same branch into `<dir>/web/wasm/` and register that as the system's Wasm
+    // dir. Best-effort — a fetch failure just leaves the catalog without the in-browser tier (the
+    // PNG + data tiers still serve). The file list is enumerated by the trusted catalog, not the
+    // client, and each file is path-contained + size-capped like the images.
+    fetchWasmApp(catalog.webRender, base, dir, safe)
+
     val verdict =
       if (trust.trustsBranch(repo, branch))
         BundleVerifier.Verdict.Trusted(listOf(BundleVerifier.Basis.Branch(repo, branch)))
@@ -99,18 +114,64 @@ class ServeCatalogStore(
     return Result.Ok(safe, host.previews.size, BundleVerifier.summary(verdict))
   }
 
-  /** Minimal mirror of the `design-parity-catalog/v1` schema — only the image paths are needed. */
-  @Serializable private data class Catalog(val components: List<Component> = emptyList())
+  /**
+   * Fetch a `compose-wasm` [WebRender] app's files from [base] into `<dir>/web/wasm/` and register
+   * the dir. The file list comes from the trusted [render] (not a client); each entry is confined
+   * to the declared `path`, rejected on traversal, and size-capped by [fetch]. Needs at least an
+   * `index.html` to be usable. No-op for a null / non-`compose-wasm` descriptor.
+   */
+  private fun fetchWasmApp(render: WebRender?, base: String, dir: File, system: String) {
+    if (render == null || render.kind != WEB_RENDER_COMPOSE_WASM) return
+    val prefix = render.path.trim('/')
+    if (prefix.isEmpty() || render.files.isEmpty()) return
+    val wasmDir = File(dir, WEB_WASM_DIR)
+    val wasmRoot = wasmDir.canonicalFile.toPath()
+    var written = 0
+    for (name in render.files.take(MAX_WASM_FILES)) {
+      val rel = name.trim('/')
+      if (rel.isEmpty() || ".." in rel.split("/")) continue
+      val target = File(wasmDir, rel)
+      if (!target.canonicalFile.toPath().startsWith(wasmRoot)) continue
+      val bytes = runCatching { fetch("$base$prefix/$rel") }.getOrNull() ?: continue
+      target.parentFile?.mkdirs()
+      target.writeBytes(bytes)
+      written++
+    }
+    if (written > 0 && File(wasmDir, "index.html").isFile) registerWasm(system, wasmDir)
+  }
+
+  /**
+   * Minimal mirror of the `design-parity-catalog/v1` schema — only the bits we serve are needed.
+   */
+  @Serializable
+  private data class Catalog(
+    val components: List<Component> = emptyList(),
+    /** Optional in-browser render descriptor (the CMP-Wasm app carried in the branch). */
+    val webRender: WebRender? = null,
+  )
 
   @Serializable private data class Component(val images: List<Image> = emptyList())
 
   @Serializable private data class Image(val path: String)
+
+  /**
+   * `catalog.json`'s `webRender`: an app under [path] (e.g. `web/wasm/`) with its [files] listed.
+   */
+  @Serializable
+  private data class WebRender(
+    val kind: String = "",
+    val path: String = "",
+    val files: List<String> = emptyList(),
+  )
 
   companion object {
     const val DEFAULT_REPO = "yschimke/compose-ai-tools"
     const val DEFAULT_BRANCH_PREFIX = "design-artifacts/"
     const val CATALOG_FILE = "catalog.json"
     const val IMAGES_DIR = "images"
+    const val WEB_WASM_DIR = "web/wasm"
+    const val WEB_RENDER_COMPOSE_WASM = "compose-wasm"
+    private const val MAX_WASM_FILES = 64
 
     /**
      * The single-path-segment preview id for a catalog image path. The serve routes (`/p/{name}`,

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -10,6 +10,7 @@ import io.ktor.server.cio.CIO
 import io.ktor.server.engine.EmbeddedServer
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.request.receiveStream
+import io.ktor.server.response.respond
 import io.ktor.server.response.respondBytes
 import io.ktor.server.response.respondText
 import io.ktor.server.routing.RoutingContext
@@ -125,12 +126,23 @@ class ServeHttpServer(
               call.respondText("not found", status = HttpStatusCode.NotFound)
               return@get
             }
-            val bytes = withContext(Dispatchers.IO) { file.readBytes() }
             // The viewer mounts this app in a `sandbox="allow-scripts"` iframe, which has an opaque
             // (null) origin — so the app's own ES-module + wasm fetches count as cross-origin and
             // need CORS. `*` is safe: these are public static client assets with no session data,
             // and keeping the strong sandbox (no `allow-same-origin`) isolates even untrusted wasm.
             call.response.headers.append(HttpHeaders.AccessControlAllowOrigin, "*")
+            // Cache the heavy payload (skiko + app wasm ≈ 8 MB gzipped). The filenames aren't
+            // content-hashed, so pair a moderate max-age with a size+mtime ETag: within the window
+            // the browser serves from cache (no request); after it, a conditional request gets a
+            // cheap 304 instead of re-downloading megabytes.
+            val etag = "\"${file.length().toString(16)}-${file.lastModified().toString(16)}\""
+            call.response.headers.append(HttpHeaders.CacheControl, "public, max-age=3600")
+            call.response.headers.append(HttpHeaders.ETag, etag)
+            if (call.request.headers[HttpHeaders.IfNoneMatch] == etag) {
+              call.respond(HttpStatusCode.NotModified)
+              return@get
+            }
+            val bytes = withContext(Dispatchers.IO) { file.readBytes() }
             call.respondBytes(bytes, wasmContentType(file.name))
           }
         }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
@@ -107,34 +107,61 @@ class ServeCatalogStoreTest {
     assertTrue(registered.isEmpty())
   }
 
-  @Test
-  fun `a catalog webRender fetches the wasm app from the branch and registers its dir`() {
-    // catalog.json declaring a compose-wasm app under web/wasm/, including a traversal entry that
-    // must be rejected.
-    val withWasm =
-      """
-      {"schema":"design-parity-catalog/v1","system":"compose-m3","components":[
-        {"componentId":"Button/Filled","images":[
-          {"path":"images/button-filled/ideal__default__dark.png","theme":"dark"}]}],
-       "webRender":{"kind":"compose-wasm","path":"web/wasm/",
-         "files":["index.html","composeApp.wasm","skiko.wasm","../../escape.html"]}}
-      """
-        .trimIndent()
-    val fetch: (String) -> ByteArray? = { url ->
-      when {
-        url.endsWith("/${ServeCatalogStore.CATALOG_FILE}") -> withWasm.toByteArray()
-        url.endsWith(".png") -> png()
-        url.contains("/web/wasm/") -> "x".toByteArray()
-        else -> null
-      }
+  private fun wasmCatalog(files: String): String =
+    """
+    {"schema":"design-parity-catalog/v1","system":"compose-m3","components":[
+      {"componentId":"Button/Filled","images":[
+        {"path":"images/button-filled/ideal__default__dark.png","theme":"dark"}]}],
+     "webRender":{"kind":"compose-wasm","path":"web/wasm/","files":[$files]}}
+    """
+      .trimIndent()
+
+  private fun wasmFetcher(
+    catalog: String,
+    missing: Set<String> = emptySet(),
+  ): (String) -> ByteArray? = { url ->
+    when {
+      url.endsWith("/${ServeCatalogStore.CATALOG_FILE}") -> catalog.toByteArray()
+      url.endsWith(".png") -> png()
+      url.contains("/web/wasm/") ->
+        if (missing.any { url.endsWith(it) }) null else "x".toByteArray()
+      else -> null
     }
-    store(TrustStore.EMPTY, fetch).load("compose-m3")
+  }
+
+  @Test
+  fun `a complete catalog webRender fetches the wasm app and registers its dir`() {
+    val catalog = wasmCatalog("\"index.html\",\"composeApp.wasm\",\"skiko.wasm\"")
+    store(TrustStore.EMPTY, wasmFetcher(catalog)).load("compose-m3")
 
     val wasmDir = registeredWasm.getValue("compose-m3")
     assertTrue(File(wasmDir, "index.html").isFile, "index.html landed")
     assertTrue(File(wasmDir, "composeApp.wasm").isFile && File(wasmDir, "skiko.wasm").isFile)
-    // The `../../escape.html` traversal entry must not write outside web/wasm/.
-    assertTrue(!File(wasmDir.parentFile.parentFile, "escape.html").exists(), "traversal rejected")
+  }
+
+  @Test
+  fun `a webRender with a failed required-file fetch registers nothing (fail closed)`() {
+    val catalog = wasmCatalog("\"index.html\",\"composeApp.wasm\",\"skiko.wasm\"")
+    // composeApp.wasm 404s → the app is incomplete → don't advertise a tier whose iframe would 404.
+    store(TrustStore.EMPTY, wasmFetcher(catalog, missing = setOf("composeApp.wasm")))
+      .load("compose-m3")
+    assertTrue(registeredWasm.isEmpty(), "incomplete app must not register")
+  }
+
+  @Test
+  fun `a webRender with a traversal entry fails closed and writes nothing outside the dir`() {
+    val catalog = wasmCatalog("\"index.html\",\"composeApp.wasm\",\"../../escape.html\"")
+    val root = tempRoot()
+    ServeCatalogStore(
+        root = root,
+        register = { n, h -> registered[n] = h },
+        trust = TrustStore.EMPTY,
+        fetch = wasmFetcher(catalog),
+        registerWasm = { s, d -> registeredWasm[s] = d },
+      )
+      .load("compose-m3")
+    assertTrue(registeredWasm.isEmpty(), "malformed manifest must not register")
+    assertTrue(!File(root, "compose-m3/escape.html").exists(), "traversal write rejected")
   }
 
   @Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
@@ -20,6 +20,7 @@ class ServeCatalogStoreTest {
     Files.createTempDirectory("catalog").toFile().also { it.deleteOnExit() }
 
   private val registered = LinkedHashMap<String, ServeBundleHost>()
+  private val registeredWasm = LinkedHashMap<String, File>()
 
   private fun png(): ByteArray =
     ByteArrayOutputStream()
@@ -54,6 +55,7 @@ class ServeCatalogStoreTest {
       register = { n, h -> registered[n] = h },
       trust = trust,
       fetch = fetch,
+      registerWasm = { s, d -> registeredWasm[s] = d },
     )
 
   @Test
@@ -103,5 +105,41 @@ class ServeCatalogStoreTest {
     val result = store(TrustStore.EMPTY, fetch = { null }).load("compose-m3")
     assertTrue(result is ServeCatalogStore.Result.Failed)
     assertTrue(registered.isEmpty())
+  }
+
+  @Test
+  fun `a catalog webRender fetches the wasm app from the branch and registers its dir`() {
+    // catalog.json declaring a compose-wasm app under web/wasm/, including a traversal entry that
+    // must be rejected.
+    val withWasm =
+      """
+      {"schema":"design-parity-catalog/v1","system":"compose-m3","components":[
+        {"componentId":"Button/Filled","images":[
+          {"path":"images/button-filled/ideal__default__dark.png","theme":"dark"}]}],
+       "webRender":{"kind":"compose-wasm","path":"web/wasm/",
+         "files":["index.html","composeApp.wasm","skiko.wasm","../../escape.html"]}}
+      """
+        .trimIndent()
+    val fetch: (String) -> ByteArray? = { url ->
+      when {
+        url.endsWith("/${ServeCatalogStore.CATALOG_FILE}") -> withWasm.toByteArray()
+        url.endsWith(".png") -> png()
+        url.contains("/web/wasm/") -> "x".toByteArray()
+        else -> null
+      }
+    }
+    store(TrustStore.EMPTY, fetch).load("compose-m3")
+
+    val wasmDir = registeredWasm.getValue("compose-m3")
+    assertTrue(File(wasmDir, "index.html").isFile, "index.html landed")
+    assertTrue(File(wasmDir, "composeApp.wasm").isFile && File(wasmDir, "skiko.wasm").isFile)
+    // The `../../escape.html` traversal entry must not write outside web/wasm/.
+    assertTrue(!File(wasmDir.parentFile.parentFile, "escape.html").exists(), "traversal rejected")
+  }
+
+  @Test
+  fun `no webRender means no wasm dir is registered`() {
+    store(TrustStore.EMPTY).load("compose-m3")
+    assertTrue(registeredWasm.isEmpty())
   }
 }

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -56,9 +56,19 @@ PNG** is the universal fallback when an image is needed. Remote Compose / Protol
 data-only* formats — the safest uploads.
 
 The CMP-Wasm tier is built (`:samples:cmp-wasm-catalog`, see
-[`wasm-cmp-spike.md`](wasm-cmp-spike.md)): with `--wasm-dir <system>=<dist>`, a CMP catalog session's
-viewer shows a **"Run in browser (Wasm)"** toggle that mounts the M3 components client-side in a
-sandboxed iframe — no server round-trip, so safe even for an unverified session.
+[`wasm-cmp-spike.md`](wasm-cmp-spike.md)): a CMP catalog session's viewer shows a **"Run in browser
+(Wasm)"** toggle that mounts the M3 components client-side in a sandboxed iframe — no server
+round-trip, so safe even for an unverified session. The app is sourced two ways:
+
+- **From the trusted branch (default).** When the `design-artifacts/<system>` catalog declares a
+  `webRender` (a `web/wasm/` app committed to the branch), `--catalogs` fetches it alongside
+  `catalog.json` + `images/` and serves it at `/wasm/<system>/` — **trusted by the same branch
+  origin**, no local build needed.
+- **From a local build.** `--wasm-dir <system>=<dist>` points at a `wasmCatalogDist` output, which
+  overrides the branch app for that system (handy when iterating locally).
+
+The `/wasm/` assets are sent with `Cache-Control` + an `ETag`, so the heavy skiko + app wasm (≈ 8 MB
+gzipped) is cached and revalidated cheaply (304) instead of re-downloaded each viewer load.
 
 ## Running one
 
@@ -66,8 +76,7 @@ sandboxed iframe — no server round-trip, so safe even for an unverified sessio
 compose-preview serve \
   --module :samples:design-catalog-m3 \   # a base module is the default session
   --public \                              # open every route (no token)
-  --catalogs compose-m3,wear-m3 \         # serve the published design systems
-  --wasm-dir compose-m3=build/wasmDist \  # in-browser CMP tier (./gradlew :samples:cmp-wasm-catalog:wasmCatalogDist)
+  --catalogs compose-m3,wear-m3 \         # serve the published design systems (Wasm app rides the branch)
   --accept-bundles \                      # accept client bundle uploads
   --trust-store trust/producers.json \    # who we trust
   --host 0.0.0.0 --port 8080


### PR DESCRIPTION
## Summary

Answers "can the Wasm be served from the target branches, and cached?" — **yes to both**, server half here. The in-browser CMP tier can now be delivered from the `design-artifacts/<system>` branch (the same trust anchor as the catalog) instead of requiring a local `--wasm-dir`, and the heavy payload is cached.

- **Branch-sourced Wasm.** When a fetched `catalog.json` declares a `webRender` (`kind: "compose-wasm"`, a `path`, and a `files` list), `ServeCatalogStore` fetches the app from the same branch into `<dir>/web/wasm/` — each file path-contained, size-capped, and traversal-rejected exactly like the catalog images — and registers it so the server serves it at `/wasm/<system>/`, **trusted by the same branch origin**. A deployed `--public --catalogs` server then needs **no local wasm build**; `--wasm-dir` still overrides per-system for local iteration.
- **Caching.** The `/wasm/` route now sends `Cache-Control: public, max-age=…` + a size+mtime `ETag` and answers `If-None-Match` with `304`, so the ~8 MB-gzipped skiko + app wasm is cached and revalidated cheaply instead of re-downloaded on every viewer load.

Why not jsDelivr in this PR: the *dev* wasm is 21 MB raw (at/over jsDelivr's per-file limit), so the server route is the robust delivery; jsDelivr/Pages over the branch is a documented option for the smaller `wasm-opt` build, covered in the follow-up.

## Test plan

- `./gradlew :cli:test` — new `ServeCatalogStore` coverage: a `webRender` catalog fetches + registers the `web/wasm/` dir; a `../../escape.html` entry in the `files` list is rejected (stays out of the dir); no `webRender` registers no wasm dir. Existing catalog/auth/fixture tests still pass.
- Content-type + viewer-mount coverage from the prior PRs still applies; the route change is additive (cache validators).

## Follow-up (PR-2)

`design-artifacts.yml` + the catalog generator build `wasmCatalogDist` and publish `web/wasm/` + the `webRender` descriptor into the branch (git content-addressing makes an unchanged re-push ~free), the gallery links it, and jsDelivr serves the `wasm-opt` build. Text-only PR (server/data-plumbing; no rendered-surface change).


---
_Generated by [Claude Code](https://claude.ai/code/session_01K8nJEfEYGM3ijyoAXDNLGH)_