### PR TITLE
feat(deploy): public preview-server profile for preview.coo.ee

### DIFF
--- a/deploy/cloudrun/Dockerfile
+++ b/deploy/cloudrun/Dockerfile
@@ -59,7 +59,10 @@ COPY . /app
 # NOTE: deliberately no BuildKit cache mount here — the warmed Gradle cache must
 # land in a real image layer so `COPY --from=build /root/.gradle` carries it into
 # the runtime image (cache-mount contents are not persisted into layers).
-RUN ./gradlew --no-daemon :cli:installDist \
+# `:samples:cmp-wasm-catalog:wasmCatalogDist` assembles the in-browser CMP app
+# (build/wasmDist) so the from-source public server can serve it via
+# `--wasm-dir` without a CLI release or a populated design-artifacts branch.
+RUN ./gradlew --no-daemon :cli:installDist :samples:cmp-wasm-catalog:wasmCatalogDist \
  && ./cli/build/install/compose-preview/bin/compose-preview serve \
         --module "${SERVE_MODULE}" \
         --export /tmp/warm-bundle \

--- a/deploy/cloudrun/entrypoint.sh
+++ b/deploy/cloudrun/entrypoint.sh
@@ -12,21 +12,46 @@ PORT="${PORT:-8080}"
 SERVE_MODULE="${SERVE_MODULE:-:samples:cmp}"
 BIN=/app/cli/build/install/compose-preview/bin/compose-preview
 
-# A public endpoint must be token-gated. Cloud Run surfaces the secret as $SERVE_TOKEN.
-# Fail closed rather than expose an unauthenticated renderer.
-if [[ -z "${SERVE_TOKEN:-}" ]]; then
-  echo "entrypoint: SERVE_TOKEN is unset — refusing to start an unauthenticated public server." >&2
-  echo "            Set it (e.g. from Secret Manager) before deploying. See deploy/cloudrun/README.md." >&2
-  exit 64
-fi
-
 args=(
   serve
   --module "${SERVE_MODULE}"
   --host 0.0.0.0
   --port "${PORT}"
-  --token "${SERVE_TOKEN}"
 )
+
+# Two auth postures, chosen by SERVE_PUBLIC:
+#   - SERVE_PUBLIC=1  → the open public preview server (preview.coo.ee): every
+#     route is unauthenticated. Safe by construction — no server-side code exec,
+#     untrusted re-render refused, uploads (if enabled) capped + SSRF-gated.
+#   - otherwise       → token-gated; SERVE_TOKEN is required (fail closed rather
+#     than expose an unauthenticated renderer). Cloud Run surfaces it as a secret.
+if [[ "${SERVE_PUBLIC:-}" == "1" || "${SERVE_PUBLIC:-}" == "true" ]]; then
+  args+=(--public)
+else
+  if [[ -z "${SERVE_TOKEN:-}" ]]; then
+    echo "entrypoint: SERVE_TOKEN is unset and SERVE_PUBLIC is off — refusing to start an" >&2
+    echo "            unauthenticated server. Set SERVE_TOKEN, or SERVE_PUBLIC=1 for the open" >&2
+    echo "            public profile. See deploy/cloudrun/README.md." >&2
+    exit 64
+  fi
+  args+=(--token "${SERVE_TOKEN}")
+fi
+
+# The published design systems, their producer-trust store, and the in-browser
+# CMP Wasm app — the public-server pillars. All optional: unset = off.
+#   SERVE_CATALOGS=compose-m3,wear-m3
+#   SERVE_TRUST_STORE=trust/producers.json
+#   SERVE_WASM_DIR=compose-m3=samples/cmp-wasm-catalog/build/wasmDist
+[[ -n "${SERVE_CATALOGS:-}" ]] && args+=(--catalogs "${SERVE_CATALOGS}")
+[[ -n "${SERVE_TRUST_STORE:-}" ]] && args+=(--trust-store "${SERVE_TRUST_STORE}")
+[[ -n "${SERVE_WASM_DIR:-}" ]] && args+=(--wasm-dir "${SERVE_WASM_DIR}")
+# Client uploads (POST /bundles) — off unless SERVE_ACCEPT_BUNDLES=1; a host
+# allowlist for ?url= fetches is opt-in on top (SSRF stays fail-closed).
+if [[ "${SERVE_ACCEPT_BUNDLES:-}" == "1" || "${SERVE_ACCEPT_BUNDLES:-}" == "true" ]]; then
+  args+=(--accept-bundles)
+  [[ -n "${SERVE_ACCEPT_BUNDLES_FROM:-}" ]] &&
+    args+=(--accept-bundles-from "${SERVE_ACCEPT_BUNDLES_FROM}")
+fi
 
 # Optional: exit after N idle seconds so the Cloud Run instance scales to zero.
 # Set SERVE_IDLE_EXIT=0 (or unset) to run until terminated.

--- a/deploy/image/docker-compose.yml
+++ b/deploy/image/docker-compose.yml
@@ -14,9 +14,28 @@ services:
     restart: always
     pull_policy: always
     environment:
-      SERVE_TOKEN: "${SERVE_TOKEN:?set SERVE_TOKEN in .env}"
+      # Public preview server by default (preview.coo.ee): open, serving our
+      # published design systems. The in-browser CMP Wasm tier rides --catalogs —
+      # `serve` fetches each system's web/wasm/ from the trusted branch (the
+      # prebuilt image has no catalog modules to build a local app from), so this
+      # needs a CLI release that carries the branch-fetch + an up-to-date
+      # design-artifacts/<system> branch. For a token-gated box instead, set
+      # SERVE_PUBLIC=0 and SERVE_TOKEN in .env.
+      SERVE_PUBLIC: "${SERVE_PUBLIC:-1}"
+      SERVE_CATALOGS: "${SERVE_CATALOGS:-compose-m3,wear-m3}"
+      # Optional: badge the catalogs as Trusted(Branch) instead of Unverified.
+      # Mount your trust store (see the volume below) and point this at it.
+      SERVE_TRUST_STORE: "${SERVE_TRUST_STORE:-}"
+      # Unused in public mode; required only when SERVE_PUBLIC=0.
+      SERVE_TOKEN: "${SERVE_TOKEN:-}"
       SERVE_IDLE_EXIT: "0"
       PORT: "8080"
+    # Uncomment to badge our published catalogs as trusted (download it onto the
+    # host first: curl -o producers.json \
+    #   https://raw.githubusercontent.com/yschimke/compose-ai-tools/main/trust/producers.json
+    # then set SERVE_TRUST_STORE=/trust/producers.json in .env).
+    # volumes:
+    #   - ./producers.json:/trust/producers.json:ro
     expose:
       - "8080"
     # The baked warm cache makes renders incremental; this just caps a render storm.

--- a/deploy/image/entrypoint.sh
+++ b/deploy/image/entrypoint.sh
@@ -6,12 +6,34 @@ cd /project
 
 PORT="${PORT:-8080}"
 
-if [[ -z "${SERVE_TOKEN:-}" ]]; then
-  echo "entrypoint: SERVE_TOKEN unset — refusing to start an unauthenticated public server." >&2
-  exit 64
+args=(serve --host 0.0.0.0 --port "${PORT}")
+
+# Auth posture (see deploy/cloudrun/entrypoint.sh): SERVE_PUBLIC=1 → the open
+# public preview server (preview.coo.ee); otherwise token-gated (SERVE_TOKEN
+# required, fail closed).
+if [[ "${SERVE_PUBLIC:-}" == "1" || "${SERVE_PUBLIC:-}" == "true" ]]; then
+  args+=(--public)
+else
+  if [[ -z "${SERVE_TOKEN:-}" ]]; then
+    echo "entrypoint: SERVE_TOKEN unset and SERVE_PUBLIC off — refusing to start an" >&2
+    echo "            unauthenticated server. Set SERVE_TOKEN, or SERVE_PUBLIC=1." >&2
+    exit 64
+  fi
+  args+=(--token "${SERVE_TOKEN}")
 fi
 
-args=(serve --host 0.0.0.0 --port "${PORT}" --token "${SERVE_TOKEN}")
+# The public-server pillars (all optional). The prebuilt image has no catalog
+# modules to build a Wasm app from, so its in-browser tier rides --catalogs:
+# `serve` fetches each system's web/wasm/ from the trusted design-artifacts
+# branch. (--wasm-dir is for the from-source image's local build.)
+[[ -n "${SERVE_CATALOGS:-}" ]] && args+=(--catalogs "${SERVE_CATALOGS}")
+[[ -n "${SERVE_TRUST_STORE:-}" ]] && args+=(--trust-store "${SERVE_TRUST_STORE}")
+[[ -n "${SERVE_WASM_DIR:-}" ]] && args+=(--wasm-dir "${SERVE_WASM_DIR}")
+if [[ "${SERVE_ACCEPT_BUNDLES:-}" == "1" || "${SERVE_ACCEPT_BUNDLES:-}" == "true" ]]; then
+  args+=(--accept-bundles)
+  [[ -n "${SERVE_ACCEPT_BUNDLES_FROM:-}" ]] &&
+    args+=(--accept-bundles-from "${SERVE_ACCEPT_BUNDLES_FROM}")
+fi
 
 # Generous render/build timeout so a slow host's first render doesn't trip the
 # CLI's 300s default (the warm cache is baked in, so it's normally fast anyway).

--- a/deploy/image/setup.sh
+++ b/deploy/image/setup.sh
@@ -44,5 +44,7 @@ sudo docker compose up -d
 TOKEN="$(grep '^SERVE_TOKEN=' .env | cut -d= -f2-)"
 echo
 echo "==> Up. Once DNS for ${DOMAIN} resolves here and Caddy has a cert:"
+echo "    https://${DOMAIN}/        (public mode — open; SERVE_PUBLIC defaults to 1)"
+echo "    For a token-gated box, set SERVE_PUBLIC=0 in .env; the gate is then:"
 echo "    https://${DOMAIN}/?token=${TOKEN}"
 echo "    Logs: sudo docker compose logs -f preview"

--- a/deploy/vps/docker-compose.yml
+++ b/deploy/vps/docker-compose.yml
@@ -21,7 +21,15 @@ services:
       # Always-on box: keep the server warm (no idle exit).
       SERVE_MODULE: ":samples:cmp"
       SERVE_IDLE_EXIT: "0"
-      SERVE_TOKEN: "${SERVE_TOKEN:?set SERVE_TOKEN in .env}"
+      # Public preview server by default (preview.coo.ee). Built from source, so
+      # it has the new serve features immediately (no CLI release needed) and
+      # serves the in-browser CMP tier from the image's local wasm build via
+      # SERVE_WASM_DIR. For a token-gated box, set SERVE_PUBLIC=0 + SERVE_TOKEN.
+      SERVE_PUBLIC: "${SERVE_PUBLIC:-1}"
+      SERVE_CATALOGS: "${SERVE_CATALOGS:-compose-m3,wear-m3}"
+      SERVE_TRUST_STORE: "${SERVE_TRUST_STORE:-trust/producers.json}"
+      SERVE_WASM_DIR: "${SERVE_WASM_DIR:-compose-m3=samples/cmp-wasm-catalog/build/wasmDist}"
+      SERVE_TOKEN: "${SERVE_TOKEN:-}"
       PORT: "8080"
     expose:
       - "8080"

--- a/deploy/vps/setup.sh
+++ b/deploy/vps/setup.sh
@@ -71,6 +71,7 @@ sudo docker compose up -d --build
 TOKEN="$(grep '^SERVE_TOKEN=' .env | cut -d= -f2-)"
 echo
 echo "==> Up. Once DNS for ${DOMAIN} points at this VM and Caddy has a cert:"
+echo "    https://${DOMAIN}/        (public mode — open; SERVE_PUBLIC defaults to 1)"
+echo "    For a token-gated box, set SERVE_PUBLIC=0 in .env; the gate is then:"
 echo "    https://${DOMAIN}/?token=${TOKEN}"
-echo "    (Keep the token secret — it is the only gate on this public endpoint.)"
 echo "    Logs: sudo docker compose logs -f preview"

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -77,7 +77,6 @@ compose-preview serve \
   --module :samples:design-catalog-m3 \   # a base module is the default session
   --public \                              # open every route (no token)
   --catalogs compose-m3,wear-m3 \         # serve the published design systems (Wasm app rides the branch)
-  --accept-bundles \                      # accept client bundle uploads
   --trust-store trust/producers.json \    # who we trust
   --host 0.0.0.0 --port 8080
 ```
@@ -85,9 +84,25 @@ compose-preview serve \
 - **`--public`** drops the token gate (the deployed server is meant to be open). It is **safe by
   construction**: rendering a bundle/catalog executes no code, re-rendering untrusted Compose is
   refused, uploads are size-capped, and the `?url=` fetch is SSRF-gated (`--accept-bundles-from`).
-- Put **Caddy** (or Cloudflare) in front for TLS on `preview.coo.ee` — see
-  [`deploy/vps`](../deploy/vps) / [`deploy/image`](../deploy/image) for the container + reverse-proxy
-  pattern (run the command above in place of the token-gated default).
+
+## Deploying `preview.coo.ee`
+
+Both container profiles take this config from env (the entrypoint maps `SERVE_PUBLIC`,
+`SERVE_CATALOGS`, `SERVE_TRUST_STORE`, `SERVE_WASM_DIR`, `SERVE_ACCEPT_BUNDLES` → flags) and put
+**Caddy** in front for TLS. They default to the **open public profile** (`SERVE_PUBLIC=1`, catalogs
+`compose-m3,wear-m3`); set `SERVE_PUBLIC=0` + `SERVE_TOKEN` for a token-gated box.
+
+| | [`deploy/vps`](../deploy/vps) (from source) | [`deploy/image`](../deploy/image) (prebuilt) |
+|---|---|---|
+| CLI | compiled from this checkout (~8 min build) | the **released** tarball (`docker pull`, no build) + Watchtower auto-update |
+| Has the latest serve features? | **immediately** (built from `main`) | only once they're in a **published CLI release** (bump `CP_VERSION`) |
+| In-browser Wasm tier | local build, `SERVE_WASM_DIR=compose-m3=samples/cmp-wasm-catalog/build/wasmDist` | branch-fetch: `--catalogs` pulls each system's `web/wasm/` from the trusted branch (needs the branch to carry it) |
+
+So **today** (before a release), deploy from source: `cd deploy/vps && DOMAIN=preview.coo.ee ./setup.sh`
+— it builds the current `main`, including the Wasm app, and comes up public. **After** the serve
+features ship in a CLI release *and* the `design-artifacts/compose-m3` branch carries `web/wasm/`,
+the prebuilt `deploy/image` path serves the same thing with no host build (and Watchtower keeps it
+current).
 - **Re-render of trusted Compose** stays off unless the operator opts in; a public box should leave
   `--revisions` *off* (that path runs arbitrary Gradle = RCE).
 


### PR DESCRIPTION
## Summary

Makes the container deploys run the **open public catalog server** (`preview.coo.ee`) via env, instead of only the token-gated default. Both profiles now map env → `serve` flags in their entrypoint, so deploying is config, not a code edit.

- **`entrypoint.sh`** (`deploy/cloudrun` + `deploy/image`): `SERVE_PUBLIC` selects `--public` vs token-gated (fail closed without a token); `SERVE_CATALOGS` / `SERVE_TRUST_STORE` / `SERVE_WASM_DIR` / `SERVE_ACCEPT_BUNDLES` map to flags (all optional).
- **`deploy/vps` (from source):** defaults to the public profile; the cloudrun image also builds `:samples:cmp-wasm-catalog:wasmCatalogDist` and serves the in-browser CMP tier locally via `SERVE_WASM_DIR`. So a checkout deploys the new serve features **immediately** — no CLI release needed.
- **`deploy/image` (prebuilt):** defaults to the public profile; its in-browser tier rides `--catalogs` — `serve` fetches each system's `web/wasm/` from the trusted branch (the prebuilt image has no catalog modules to build a local app from). Gated on a CLI release carrying branch-fetch + a populated `design-artifacts` branch.
- **`setup.sh`** (both): print the public URL; note `SERVE_PUBLIC=0` for a token gate.
- **Docs:** a "Deploying preview.coo.ee" table — from-source (works now) vs prebuilt (after a release), and where the Wasm app comes from in each.

No uploads by default (`SERVE_ACCEPT_BUNDLES` unset) per the chosen profile.

## Why two paths (context for the "do we need to build?" question)

The prebuilt `deploy/image` (#2070) pulls a **released** CLI — so it only gains the new serve features (public/catalogs/wasm/caching/branch-fetch) once they're in a `v*` release, then `CP_VERSION` is bumped and Watchtower (#2072) auto-pulls. Until then, `deploy/vps` builds from `main` and has them now. This PR wires both so the switch is just env + (for prebuilt) a version bump.

## Test plan

- Deploy plumbing only — no app source or UI change.
- Validated: `bash -n` on the four entrypoint/setup scripts; both `docker-compose.yml` files parse (`yaml.safe_load`).
- Not validated end-to-end (needs Docker + a live host): an actual image build / `docker compose up`. The flag mapping is a straight env→args translation; the serve flags themselves are covered by the CLI's own tests.


---
_Generated by [Claude Code](https://claude.ai/code/session_01K8nJEfEYGM3ijyoAXDNLGH)_