### PR TITLE
feat(design-artifacts): publish the CMP Wasm app into the catalog branch

### DIFF
--- a/.github/workflows/design-artifacts.yml
+++ b/.github/workflows/design-artifacts.yml
@@ -35,6 +35,11 @@ jobs:
           - system: compose-m3
             module: 'samples:design-catalog-m3'
             spec: 'samples/design-catalog-m3/catalog.spec.json'
+            # The in-browser CMP tier: this system gets its `material3` catalog
+            # compiled to Kotlin/Wasm and carried in the branch under web/wasm/.
+            # Wear has no wasm target (androidx.wear.compose), so it's omitted.
+            wasmModule: 'samples:cmp-wasm-catalog'
+            wasmDist: 'samples/cmp-wasm-catalog/build/wasmDist'
           - system: wear-m3
             module: 'samples:design-catalog-wear-m3'
             spec: 'samples/design-catalog-wear-m3/catalog.spec.json'
@@ -71,6 +76,17 @@ jobs:
           compose-preview bundle pack --module "$MODULE" --with-semantics \
             -o "$GITHUB_WORKSPACE/$SYSTEM-bundle.png"
 
+      # In-browser CMP tier: assemble the Kotlin/Wasm catalog app (webpack-free —
+      # no Node/Binaryen toolchain, builds under FAIL_ON_PROJECT_REPOS). Its
+      # build/wasmDist is bundled into the branch by the generator below so
+      # `serve --catalogs` can fetch the live renderer from the same trusted
+      # origin. Only for systems that declare a wasmModule (compose-m3, not Wear).
+      - name: Assemble in-browser Wasm app
+        if: ${{ matrix.wasmModule != '' }}
+        env:
+          WASM_MODULE: ${{ matrix.wasmModule }}
+        run: ./gradlew ":${WASM_MODULE}:wasmCatalogDist"
+
       # The exporter gates on a complete render: `bundle pack --with-semantics`
       # is best-effort (exits 0 even if the daemon failed or captured zero
       # semantics), so the driver exits non-zero when any preview is missing or
@@ -81,13 +97,17 @@ jobs:
         env:
           SYSTEM: ${{ matrix.system }}
           SPEC: ${{ matrix.spec }}
+          # Set only for systems with an in-browser tier; the generator copies
+          # this dir into out/web/wasm/ and writes the catalog.json webRender.
+          WASM_DIST: ${{ matrix.wasmDist }}
         run: |
           set -euo pipefail
           node scripts/design-artifacts/generate-design-catalog.mjs \
             --spec "$SPEC" \
             --renders "$GITHUB_WORKSPACE/$SYSTEM-bundle.png" \
             --out "$GITHUB_WORKSPACE/out" \
-            --renderer "$(compose-preview --version | head -1)"
+            --renderer "$(compose-preview --version | head -1)" \
+            ${WASM_DIST:+--wasm-dist "$GITHUB_WORKSPACE/$WASM_DIST"}
 
       - name: Publish to design-artifacts/${{ matrix.system }}
         env:

--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -31,8 +31,8 @@
  * The caller (the weekly workflow) commits the result to the system's
  * `design-artifacts/<system>` branch.
  */
-import { mkdir, readFile, writeFile } from "node:fs/promises";
-import { dirname, resolve, join } from "node:path";
+import { cp, mkdir, readFile, readdir, writeFile } from "node:fs/promises";
+import { dirname, resolve, join, relative } from "node:path";
 import { parseArgs } from "node:util";
 
 import { readPreviewBundle, bundleToCandidates } from "@design-parity/candidate";
@@ -43,6 +43,17 @@ import { renderReadmeMd } from "./render-readme-md.mjs";
 import { renderWireframeSvg, slug } from "./render-wireframe-svg.mjs";
 import { renderLayoutWireframeSvg } from "./render-layout-wireframe-svg.mjs";
 import { DEFAULT_PREVIEW_BASE, livePreviewUrl } from "./live-preview.mjs";
+
+/** Relative paths of every file under `dir` (forward-slashed), for the webRender manifest. */
+async function listFilesRecursive(dir) {
+  const out = [];
+  for (const entry of await readdir(dir, { recursive: true, withFileTypes: true })) {
+    if (entry.isFile()) {
+      out.push(relative(dir, join(entry.parentPath ?? entry.path, entry.name)).split("\\").join("/"));
+    }
+  }
+  return out;
+}
 
 /**
  * Read a preview bundle into CandidateRenders, resolving each candidate's
@@ -216,6 +227,12 @@ const { values } = parseArgs({
     // `livePreview` fields + README "Customise live" links). Falls back to
     // $PREVIEW_SERVER_BASE, then the public default.
     "preview-base": { type: "string" },
+    // Optional assembled in-browser CMP Wasm app (the
+    // `:samples:cmp-wasm-catalog:wasmCatalogDist` output, e.g. `build/wasmDist`).
+    // When given, its files are copied under `out/web/wasm/` and a `webRender`
+    // descriptor is written into catalog.json — so the branch carries the live
+    // renderer and `serve --catalogs` fetches it from the same trusted origin.
+    "wasm-dist": { type: "string" },
     // Publish even when the render is incomplete (missing previews or absent
     // semantics). Off by default so a degraded render fails the job rather than
     // force-pushing a tokens/greenline-less bundle over a good delivery branch.
@@ -278,6 +295,22 @@ const result = await writeCatalog(catalog, outPath, { sourceRoot });
 // two ends of one workflow.
 const previewBase =
   values["preview-base"] || process.env.PREVIEW_SERVER_BASE || DEFAULT_PREVIEW_BASE;
+
+// Bundle the in-browser CMP Wasm app into the branch (out/web/wasm/) and record
+// a `webRender` descriptor in catalog.json. `compose-preview serve --catalogs`
+// reads that descriptor and fetches these exact files from the same trusted
+// branch — so the live renderer rides the catalog's origin, no separate hosting.
+// The `files` list IS the manifest the server fetches; an incomplete fetch fails
+// closed there, so list every file the app needs.
+let webRender = null;
+if (values["wasm-dist"]) {
+  const dest = join(outPath, "web", "wasm");
+  await cp(resolve(values["wasm-dist"]), dest, { recursive: true });
+  const files = (await listFilesRecursive(dest)).sort();
+  webRender = { kind: "compose-wasm", path: "web/wasm/", files };
+  console.log(`[${spec.system}] bundled web/wasm/ (${files.length} files)`);
+}
+
 {
   const catalogJsonPath = join(outPath, "catalog.json");
   const manifest = JSON.parse(await readFile(catalogJsonPath, "utf8"));
@@ -286,6 +319,7 @@ const previewBase =
       if (image.path) image.livePreview = livePreviewUrl(previewBase, manifest.system, image.path);
     }
   }
+  if (webRender) manifest.webRender = webRender;
   await writeFile(catalogJsonPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
 }
 


### PR DESCRIPTION
## Summary

The **producer** half of the branch-served in-browser tier (the consumer landed in #2099). A CMP catalog's `design-artifacts/<system>` branch now carries the Kotlin/Wasm app, so `compose-preview serve --catalogs` fetches the live renderer from the same trusted origin — which is what lets the **prebuilt** `deploy/image` serve the in-browser tier with no local build.

- **`generate-design-catalog.mjs`** — a new `--wasm-dist <dir>` copies the assembled app (`wasmCatalogDist` output) into `out/web/wasm/` and writes a `webRender` descriptor into `catalog.json` (`kind: "compose-wasm"`, `path`, and the **file list** the server fetches; an incomplete fetch fails closed there, per #2099).
- **`design-artifacts.yml`** — CMP systems (`compose-m3`, not Wear) build `:samples:cmp-wasm-catalog:wasmCatalogDist` (webpack-free — no Node/Binaryen, builds under `FAIL_ON_PROJECT_REPOS`) and pass `--wasm-dist`. Git content-addresses blobs, so re-pushing an **unchanged** app to the force-pushed orphan branch transfers ~nothing.

## How this closes the loop

#2099 (server) fetches `web/wasm/` from a catalog branch that declares a `webRender`. This PR makes the branch declare + carry it. After this merges and `design-artifacts.yml` regenerates `design-artifacts/compose-m3`, a `--public --catalogs compose-m3` server (including the prebuilt `deploy/image`) serves the in-browser CMP tier straight from the trusted branch.

## Test plan

- Generator + workflow parse (`node --check`, `yaml.safe_load`).
- The `webRender.files` manifest the generator writes was validated against the **real** `wasmCatalogDist` output (10 files: `index.html`, `composeApp.wasm`, `skiko.wasm`, `js-joda.esm.js`, the `.mjs` glue, …) — exactly the set #2099's `ServeCatalogStore` fail-closed fetch expects (covered by `ServeCatalogStoreTest`).
- End-to-end producer run needs the design-parity export engine + a real render (the weekly `design-artifacts.yml` is the integration gate); the `wasmCatalogDist` build itself is exercised by the merged `:samples:cmp-wasm-catalog` tests.

Text/data-plumbing only — no rendered-surface change. After merge, dispatch `design-artifacts.yml` to regenerate the branches with the Wasm app.


---
_Generated by [Claude Code](https://claude.ai/code/session_01K8nJEfEYGM3ijyoAXDNLGH)_