### PR TITLE
chore(deploy): automate + tidy the prebuilt preview-host deploy (image trigger, CP_VERSION, mem)

### DIFF
--- a/.github/workflows/preview-host-image.yml
+++ b/.github/workflows/preview-host-image.yml
@@ -13,9 +13,20 @@ on:
   workflow_dispatch:
     inputs:
       cli_version:
-        description: Released compose-preview version to bundle (no leading v)
+        description: Released compose-preview version to bundle (leading v optional)
         required: true
-        default: "0.16.1"
+        default: "0.16.5"
+  # Called from release-please.yml when a CLI release is cut. A bot-created
+  # release won't fire the `release` trigger below (the GITHUB_TOKEN-doesn't-
+  # trigger-workflows limitation the rest of the release chain already works
+  # around), so the reliable path is this workflow_call after release.yml.
+  workflow_call:
+    inputs:
+      cli_version:
+        description: Released compose-preview version to bundle (leading v optional)
+        required: true
+        type: string
+  # Kept as a manual escape hatch for human-published releases (which DO fire it).
   release:
     types: [published]
 
@@ -28,6 +39,7 @@ jobs:
     # Only CLI releases (tags like v0.16.1) — skip clients-v* and manual non-v tags.
     if: >-
       github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'workflow_call' ||
       startsWith(github.event.release.tag_name, 'v')
     runs-on: ubuntu-latest
     steps:
@@ -35,13 +47,13 @@ jobs:
 
       - name: Resolve bundled CLI version
         id: ver
+        env:
+          # release event → the tag; workflow_call / workflow_dispatch → the
+          # input (the `inputs` context covers both). Strip a leading `v` either
+          # way so a `v0.16.5` tag and a bare `0.16.5` input both work.
+          RAW_VERSION: ${{ github.event.release.tag_name || inputs.cli_version }}
         run: |
-          if [ "${{ github.event_name }}" = "release" ]; then
-            v="${{ github.event.release.tag_name }}"
-            v="${v#v}"
-          else
-            v="${{ github.event.inputs.cli_version }}"
-          fi
+          v="${RAW_VERSION#v}"
           echo "version=${v}" >> "$GITHUB_OUTPUT"
 
       - uses: docker/setup-buildx-action@v3

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -61,6 +61,21 @@ jobs:
     permissions:
       contents: write   # needed by the called workflow's `release` job
 
+  # Publish the prebuilt preview-host image (deploy/image) for the released CLI.
+  # Same workflow_call chaining as `release`: a bot-created release won't fire
+  # preview-host-image.yml's own `on: release` trigger. `needs: release` so the
+  # CLI tarball the image downloads is already uploaded to the Release.
+  preview-host-image:
+    needs: [release-please, release]
+    if: needs.release-please.outputs.release_created == 'true'
+    uses: ./.github/workflows/preview-host-image.yml
+    with:
+      cli_version: ${{ needs.release-please.outputs.tag_name }}
+    secrets: inherit
+    permissions:
+      contents: read
+      packages: write
+
   # Build + publish the mobile / wear client apps when the `clients` component is released.
   # Same GITHUB_TOKEN-doesn't-trigger-workflows reason as above: invoked via workflow_call rather
   # than relying on the `clients-v*` tag push.

--- a/deploy/image/Dockerfile
+++ b/deploy/image/Dockerfile
@@ -8,7 +8,7 @@
 # Maven Central. No build-logic, no gradle-plugin, no ~50 data modules to compile
 # — just a download + one warm render. Built once in CI and pushed to GHCR, so
 # hosts pull it and never build at all.
-ARG CP_VERSION=0.16.1
+ARG CP_VERSION=0.16.5
 
 # ---------------------------------------------------------------------------
 # Stage 0: base — JDK + Skiko's native deps (same rationale as the cloudrun image:

--- a/deploy/image/README.md
+++ b/deploy/image/README.md
@@ -33,7 +33,7 @@ workflow builds and pushes to GHCR. Trigger it either way:
 
 - **On a CLI release** (`v*` tag) — automatic; bundles that version + tags `latest`.
 - **Manually** — Actions → *Publish preview-host image* → run with a `cli_version`
-  (e.g. `0.16.1`).
+  (e.g. `0.16.5`).
 
 First publish makes the GHCR package; set it **public** (Packages → settings) if
 you want hosts to pull without auth.
@@ -52,7 +52,7 @@ DOMAIN=preview.example.com ./setup.sh
 `docker compose pull && up -d` — **no build**. It prints your
 `https://preview.example.com/?token=<TOKEN>` link once Caddy has a cert.
 
-Pin a version with `IMAGE_TAG=0.16.1` in `.env` (a bare tag; defaults to the
+Pin a version with `IMAGE_TAG=0.16.5` in `.env` (a bare tag; defaults to the
 `latest` tag when unset).
 
 ## Auto-updates (Watchtower)

--- a/deploy/image/docker-compose.yml
+++ b/deploy/image/docker-compose.yml
@@ -3,7 +3,7 @@
 # Set DOMAIN + SERVE_TOKEN in .env (setup.sh writes one), then:
 #   docker compose up -d
 #
-# Pin a version with IMAGE_TAG=0.16.1 in .env (a bare tag); defaults to the latest tag.
+# Pin a version with IMAGE_TAG=0.16.5 in .env (a bare tag); defaults to the latest tag.
 #
 # Auto-updates: the optional `watchtower` service (below) watches the :latest tag
 # and pulls + recreates `preview` when a new release image is published. Leave

--- a/deploy/vps/docker-compose.yml
+++ b/deploy/vps/docker-compose.yml
@@ -33,9 +33,10 @@ services:
       PORT: "8080"
     expose:
       - "8080"
-    # One warm Desktop daemon fits comfortably under 8 GB; this cap just keeps a
-    # single render storm from eating the whole box. Lower to ~3g on a 4 GB VM.
-    mem_limit: 6g
+    # One warm Desktop daemon fits comfortably in a few GB; this cap just keeps a
+    # single render storm from eating the whole box. Default sized for a 4 GB VM;
+    # raise to ~6g on an 8 GB box if renders get OOM-killed under load.
+    mem_limit: 3g
 
   caddy:
     image: caddy:2


### PR DESCRIPTION
## Summary

Makes the prebuilt `preview.coo.ee` deploy fully hands-off, plus two small config tidies.

- **Auto-publish the prebuilt image on release** (the important one). `preview-host-image.yml` was only `on: release`, which **never fires for a release-please (bot/`GITHUB_TOKEN`) release** — the same limitation the rest of the release chain already works around with `workflow_call`. So the GHCR image was never rebuilt on a release and had to be dispatched by hand (as I just had to for `v0.16.5`). Fixed the same way `release.yml` + `clients-release.yml` are chained:
  - `preview-host-image.yml` gains a `workflow_call` trigger (`cli_version` input, leading-`v` optional); its version-resolve + job `if:` handle it.
  - `release-please.yml` calls it after the `release` job (gated on `release_created`), so the CLI tarball it downloads is already uploaded.
  - The `on: release` + `workflow_dispatch` triggers stay as escape hatches.

  Net: merging a release PR now publishes the CLI tarball **and** the prebuilt image (`<version>` + `:latest`) in one run → Watchtower updates the host. No manual dispatch.

- **`deploy/image` → `CP_VERSION=0.16.5`** (Dockerfile default + README/compose version examples). `v0.16.5` is the first release with the public-server serve features. The GHCR auto-build resolves the version from the release tag; this just keeps local/manual builds + docs current.

- **`deploy/vps` preview `mem_limit: 6g → 3g`** — default the from-source profile for a 4 GB VM, with a note to raise to ~6g on an 8 GB box if renders OOM.

## Test plan

Workflow + deploy config/docs only — no app source. All three touched workflow YAMLs parse (`yaml.safe_load`); both compose files parse; the version-strip handles `v0.16.5` and `0.16.5`. The real end-to-end gate is the next release PR merge (it should now publish the image with no manual step) — and `v0.16.5`'s image, which I dispatched manually in the meantime.
