### PR TITLE
fix(release): seed the prebuilt image from same-run Maven artifacts

### DIFF
--- a/.github/workflows/preview-host-image.yml
+++ b/.github/workflows/preview-host-image.yml
@@ -56,33 +56,56 @@ jobs:
           v="${RAW_VERSION#v}"
           echo "version=${v}" >> "$GITHUB_OUTPUT"
 
-      # Smooth out the release race. When this is chained right after release.yml
-      # (release-please cuts a release), the image's two inputs publish on their
-      # own clocks: the CLI tarball uploads to the GitHub Release after the tag,
-      # and the Gradle plugin reaches Maven Central only after the slow per-OS
-      # viewer builds gate `publish-gradle-plugin` AND Central finishes syncing.
-      # The warm render needs the plugin, so build would fail on a propagation
-      # race. Poll both until resolvable (HEAD, ~60 min ceiling) before building,
-      # so the whole release → image → Watchtower chain is hands-off.
-      - name: Wait for the released artifacts to be resolvable
+      # Seed Maven local from the same release run so the warm render resolves the
+      # plugin + runtime modules from local jars instead of waiting on Central.
+      # release.yml's publish-gradle-plugin job uploads `preview-host-maven` (the
+      # published `ee` tree) within THIS run, so download-artifact finds it on the
+      # release-chain path. On manual workflow_dispatch / on:release there's no such
+      # upstream artifact — continue-on-error leaves the dir empty and the Dockerfile
+      # falls back to Central (the warm-render retry loop rides out propagation lag).
+      # The dir always exists (.keep) so the Dockerfile's `COPY m2/` never fails.
+      - name: Prepare local Maven dir
+        run: |
+          mkdir -p deploy/image/m2
+          touch deploy/image/m2/.keep
+      - name: Download published modules (same-run release chain)
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: preview-host-maven
+          path: deploy/image/m2-dl
+      - name: Unpack published modules into the build context
+        run: |
+          if [ -f deploy/image/m2-dl/maven-local-ee.tgz ]; then
+            tar -xzf deploy/image/m2-dl/maven-local-ee.tgz -C deploy/image/m2
+            echo "seeded Maven local with $(find deploy/image/m2/ee -name '*.jar' 2>/dev/null | wc -l) jars"
+          else
+            echo "no preview-host-maven artifact — Dockerfile will resolve from Maven Central."
+          fi
+
+      # Smooth out the release race for the CLI TARBALL (a GitHub Release asset
+      # release.yml uploads after the tag — always needed, m2 or not). The plugin no
+      # longer gates this poll: on the release chain it comes from the local m2 above,
+      # and on the manual path the Dockerfile's warm-render retry handles Central lag.
+      # 1-byte range GET, ~60 min ceiling.
+      - name: Wait for the released CLI tarball to be resolvable
         env:
           V: ${{ steps.ver.outputs.version }}
         run: |
           set -u
-          plugin="https://repo.maven.apache.org/maven2/ee/schimke/composeai/preview/ee.schimke.composeai.preview.gradle.plugin/${V}/ee.schimke.composeai.preview.gradle.plugin-${V}.pom"
           tarball="https://github.com/${GITHUB_REPOSITORY}/releases/download/v${V}/compose-preview-${V}.tar.gz"
           # 1-byte range GET: cheap (never pulls the 180 MB tarball), no HEAD
           # dependency — 200 (range ignored) or 206 (partial) both mean "present".
           ok() { c=$(curl -sSL -o /dev/null -w '%{http_code}' -r 0-0 "$1" 2>/dev/null); [ "$c" = "200" ] || [ "$c" = "206" ]; }
           for i in $(seq 1 40); do
-            if ok "$plugin" && ok "$tarball"; then
-              echo "plugin + CLI ${V} are resolvable — building."
+            if ok "$tarball"; then
+              echo "CLI ${V} tarball is resolvable — building."
               exit 0
             fi
-            echo "waiting for plugin/CLI ${V} to publish (attempt ${i}/40)…"
+            echo "waiting for CLI ${V} tarball to publish (attempt ${i}/40)…"
             sleep 90
           done
-          echo "::error::plugin/CLI ${V} not resolvable after ~60 min — re-run later." >&2
+          echo "::error::CLI ${V} tarball not resolvable after ~60 min — re-run later." >&2
           exit 1
 
       - uses: docker/setup-buildx-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,6 +114,26 @@ jobs:
           ./gradlew \
             :gradle-plugin:publishAndReleaseToMavenCentral \
             publishAndReleaseToMavenCentral
+      # Stage the same modules into Maven local and ship them as a build artifact.
+      # The prebuilt preview-host image (preview-host-image.yml) downloads this and
+      # warm-renders against it, so the image build resolves the plugin + runtime
+      # modules from local jars INSTEAD of waiting on Maven Central propagation.
+      # Same `publish*` task set, so the local repo carries exactly what Central got
+      # (plugin marker + renderer-*/data-*/daemon-*/preview-annotations/mcp).
+      - name: Stage published modules into Maven local for the prebuilt image
+        run: |
+          ./gradlew \
+            :gradle-plugin:publishToMavenLocal \
+            publishToMavenLocal
+          # Tar just the `ee` tree we publish — never the rest of ~/.m2 (transitive
+          # deps the image's Gradle cache resolves on its own).
+          tar -czf maven-local-ee.tgz -C "${HOME}/.m2/repository" ee
+      - name: Upload Maven local artifact for the prebuilt image
+        uses: actions/upload-artifact@v4
+        with:
+          name: preview-host-maven
+          path: maven-local-ee.tgz
+          retention-days: 7
 
   # Build the runnable applications shipped on each GitHub Release: the CLI
   # (`compose-preview-*`), the standalone MCP server (`compose-preview-mcp-*`),

--- a/deploy/image/.gitignore
+++ b/deploy/image/.gitignore
@@ -1,2 +1,8 @@
 # setup.sh writes this with a generated token — never commit it.
 .env
+
+# CI seeds the local Maven tree here from the `preview-host-maven` artifact.
+# Keep the dir (so the Dockerfile COPY works) but never commit the jars.
+m2/*
+!m2/.keep
+m2-dl/

--- a/deploy/image/Dockerfile
+++ b/deploy/image/Dockerfile
@@ -43,6 +43,17 @@ ENV PATH="/opt/compose-preview/bin:${PATH}"
 
 WORKDIR /project
 COPY sample-project/ /project/
+
+# Seed Maven local from the same release run (preview-host-image.yml downloads the
+# `preview-host-maven` artifact published by release.yml into deploy/image/m2/).
+# With COMPOSE_PREVIEW_INIT_USE_MAVEN_LOCAL=1 the CLI's auto-inject seeds
+# mavenLocal() additively, so the warm render resolves the plugin + runtime modules
+# from these local jars and never has to wait on Maven Central propagation. The dir
+# always exists (.keep); on the manual workflow_dispatch path it's empty and the
+# render falls back to Central via the retry loop below.
+COPY m2/ /root/.m2/repository/
+ENV COMPOSE_PREVIEW_INIT_USE_MAVEN_LOCAL=1
+
 # Warm render: builds the module via the project's Gradle wrapper, pulling the
 # published plugin + Compose from Maven, then renders every preview once. Populates
 # ~/.gradle + /project/build so the runtime container starts warm. A long --timeout
@@ -73,13 +84,16 @@ RUN ln -s "/opt/compose-preview-${CP_VERSION}" /opt/compose-preview
 ENV PATH="/opt/compose-preview/bin:${PATH}" \
     SERVE_IDLE_EXIT=0 \
     SERVE_TIMEOUT=1800 \
+    COMPOSE_PREVIEW_INIT_USE_MAVEN_LOCAL=1 \
     JAVA_TOOL_OPTIONS="-XX:MaxRAMPercentage=70"
 
 WORKDIR /project
 # Carry the project + warmed Gradle cache + module build outputs so the first
-# runtime render is incremental, not a cold rebuild.
+# runtime render is incremental, not a cold rebuild. Carry Maven local too so a
+# cold runtime re-resolve still finds the plugin without reaching Central.
 COPY --from=build /project /project
 COPY --from=build /root/.gradle /root/.gradle
+COPY --from=build /root/.m2 /root/.m2
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh

--- a/deploy/image/m2/.keep
+++ b/deploy/image/m2/.keep
@@ -1,0 +1,4 @@
+Placeholder so the Dockerfile `COPY m2/` always has a directory.
+CI (preview-host-image.yml) drops the published `ee` Maven tree here from the
+`preview-host-maven` artifact; locally it stays empty and the warm render
+resolves from Maven Central.


### PR DESCRIPTION
## Summary

Follow-up to #2105. That PR made the prebuilt preview-host image **wait** for the plugin to reach Maven Central before warm-rendering. This removes the wait entirely for the release-chain path by **reusing the artifacts we already built in the same run** instead of round-tripping through Central.

- **`release.yml`** — the `publish-gradle-plugin` job now also `publishToMavenLocal` (same task set as the Central publish) and uploads the published `ee` Maven tree as the `preview-host-maven` artifact.
- **`preview-host-image.yml`** — downloads that artifact (`continue-on-error`) into `deploy/image/m2/`, so the build context carries the exact plugin + runtime modules the release just produced. The wait-poll now covers **only the CLI tarball** (a GitHub Release asset that's always needed regardless of Maven); the plugin dropped out of the poll because it comes from the local tree.
- **`deploy/image/Dockerfile`** — `COPY m2/ /root/.m2/repository/` in the build stage and `COMPOSE_PREVIEW_INIT_USE_MAVEN_LOCAL=1` so the CLI's auto-inject seeds `mavenLocal()` additively. The warm render then resolves from the local jars and never waits on Central propagation. The local Maven tree + env are carried into the runtime stage too, so a cold runtime re-resolve is also covered.

### Fallbacks preserved
- **Manual `workflow_dispatch` / `on: release`** has no upstream artifact in the run → `download-artifact` is `continue-on-error`, `deploy/image/m2/` stays empty (committed `.keep` keeps the `COPY` valid), and the Dockerfile's existing warm-render retry loop rides out Central propagation. So the manual escape hatch still works without any local artifact.
- The CLI tarball wait-poll is unchanged in spirit (1-byte range GET, ~60 min ceiling) — it just no longer blocks on the plugin.

## Test plan

Workflow + Dockerfile only; can't exercise a live release run here. Validated statically:
- All three workflow YAMLs parse (`yaml.safe_load`).
- Every `run:` block passes `bash -n`.
- `deploy/image/m2/.keep` is committed and `m2/*` (except `.keep`) + `m2-dl/` are git-ignored, so downloaded jars never get committed.

The real gate is the next release: the chained `preview-host-image` job should build the image from the same-run local artifacts with no Central wait. Worst case (artifact missing) it degrades to the previous Central-resolve-with-retry path, so this is strictly safer than the current race window.

---
_Generated by [Claude Code](https://claude.ai/code/session_01K8nJEfEYGM3ijyoAXDNLGH)_