### PR TITLE
fix(deploy): only print the ?token= URL when the box is token-gated

### DIFF
--- a/deploy/image/setup.sh
+++ b/deploy/image/setup.sh
@@ -42,9 +42,16 @@ sudo docker compose pull
 sudo docker compose up -d
 
 TOKEN="$(grep '^SERVE_TOKEN=' .env | cut -d= -f2-)"
+# Match the compose default (SERVE_PUBLIC defaults to 1) so we print the URL this
+# box actually serves: open in public mode, the ?token= gate only when SERVE_PUBLIC=0.
+SERVE_PUBLIC="$( (grep '^SERVE_PUBLIC=' .env || true) | cut -d= -f2- )"
+SERVE_PUBLIC="${SERVE_PUBLIC:-1}"
 echo
 echo "==> Up. Once DNS for ${DOMAIN} resolves here and Caddy has a cert:"
-echo "    https://${DOMAIN}/        (public mode — open; SERVE_PUBLIC defaults to 1)"
-echo "    For a token-gated box, set SERVE_PUBLIC=0 in .env; the gate is then:"
-echo "    https://${DOMAIN}/?token=${TOKEN}"
+if [[ "${SERVE_PUBLIC}" == "1" ]]; then
+  echo "    https://${DOMAIN}/        (public mode — open, no token needed)"
+  echo "    To lock it down: set SERVE_PUBLIC=0 in .env, re-run, and use the ?token= URL it prints."
+else
+  echo "    https://${DOMAIN}/?token=${TOKEN}   (token-gated — SERVE_PUBLIC=0)"
+fi
 echo "    Logs: sudo docker compose logs -f preview"

--- a/deploy/vps/setup.sh
+++ b/deploy/vps/setup.sh
@@ -69,9 +69,16 @@ echo "==> Building image and starting the stack (first build runs a full Gradle 
 sudo docker compose up -d --build
 
 TOKEN="$(grep '^SERVE_TOKEN=' .env | cut -d= -f2-)"
+# Match the compose default (SERVE_PUBLIC defaults to 1) so we print the URL this
+# box actually serves: open in public mode, the ?token= gate only when SERVE_PUBLIC=0.
+SERVE_PUBLIC="$( (grep '^SERVE_PUBLIC=' .env || true) | cut -d= -f2- )"
+SERVE_PUBLIC="${SERVE_PUBLIC:-1}"
 echo
 echo "==> Up. Once DNS for ${DOMAIN} points at this VM and Caddy has a cert:"
-echo "    https://${DOMAIN}/        (public mode — open; SERVE_PUBLIC defaults to 1)"
-echo "    For a token-gated box, set SERVE_PUBLIC=0 in .env; the gate is then:"
-echo "    https://${DOMAIN}/?token=${TOKEN}"
+if [[ "${SERVE_PUBLIC}" == "1" ]]; then
+  echo "    https://${DOMAIN}/        (public mode — open, no token needed)"
+  echo "    To lock it down: set SERVE_PUBLIC=0 in .env, re-run, and use the ?token= URL it prints."
+else
+  echo "    https://${DOMAIN}/?token=${TOKEN}   (token-gated — SERVE_PUBLIC=0)"
+fi
 echo "    Logs: sudo docker compose logs -f preview"


### PR DESCRIPTION
## Summary

A default public deploy (`SERVE_PUBLIC=1`) printed a `?token=…` URL that the server doesn't use — public mode ignores the token entirely — which reads as "you need this token" when you don't.

`setup.sh` now reads `SERVE_PUBLIC` from `.env` (defaulting to `1` to match the compose file's `${SERVE_PUBLIC:-1}`) and prints:
- **public mode** → the open `https://<domain>/` URL, no token;
- **token-gated** (`SERVE_PUBLIC=0`) → the `https://<domain>/?token=…` gate.

Applied to both `deploy/image` (prebuilt) and `deploy/vps` (from-source) so the two stay consistent. The token is still generated and stored in `.env` either way, so flipping to `SERVE_PUBLIC=0` later still has a gate ready.

## Test plan

`bash -n` clean on both scripts. Simulated the print branch against a temp `.env`:
- no `SERVE_PUBLIC` (default) → `https://preview.coo.ee/  (no token)` ✅
- `SERVE_PUBLIC=0` → `https://preview.coo.ee/?token=…` ✅

Output-only change — no behavioral change to the running stack.

---
_Generated by [Claude Code](https://claude.ai/code/session_01K8nJEfEYGM3ijyoAXDNLGH)_