### PR TITLE
fix(release): stop the prebuilt-image job skipping on the release chain

### DIFF
--- a/.github/workflows/preview-host-image.yml
+++ b/.github/workflows/preview-host-image.yml
@@ -37,9 +37,16 @@ permissions:
 jobs:
   publish:
     # Only CLI releases (tags like v0.16.1) — skip clients-v* and manual non-v tags.
+    #
+    # NB: gate on the INPUT, not github.event_name. Inside a reusable workflow
+    # (workflow_call), github.event_name is the CALLER's triggering event — `push`
+    # for release-please.yml — NOT 'workflow_call'. So a `github.event_name ==
+    # 'workflow_call'` check silently SKIPS this job on the release chain (which is
+    # exactly what dropped the v0.16.6 image). cli_version is a required input on
+    # both workflow_dispatch and workflow_call, so it's set on both paths; the
+    # `release` event carries no inputs and falls through to the tag check.
     if: >-
-      github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'workflow_call' ||
+      inputs.cli_version != '' ||
       startsWith(github.event.release.tag_name, 'v')
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

The v0.16.6 release published the CLI, plugin (→ Maven Central), and VSIX, but **no `0.16.6` Docker image** — the `preview-host-image / publish` job was **skipped**, so Watchtower had nothing to pull and `preview.coo.ee` stayed on 0.16.5.

**Root cause:** the `publish` job gated on `github.event_name == 'workflow_call'`. Inside a reusable workflow, `github.event_name` is the **caller's** triggering event — `push`, for `release-please.yml` — **not** `'workflow_call'`. So when the release chain called the image build, all three OR-branches evaluated false and the job silently skipped. (The manual `workflow_dispatch` path worked because there `github.event_name` really is `workflow_dispatch`, which masked the bug.)

**Fix:** gate on `inputs.cli_version` instead. It's a required input on both `workflow_dispatch` and `workflow_call`, so the job runs on both; the `release` event carries no inputs and falls through to the existing `startsWith(github.event.release.tag_name, 'v')` tag check. No reliance on `github.event_name`.

```yaml
if: >-
  inputs.cli_version != '' ||
  startsWith(github.event.release.tag_name, 'v')
```

## Impact / follow-up

- This makes the release → image → Watchtower chain actually hands-off going forward.
- For the **already-released 0.16.6**, I manually dispatched the image build (which takes the `workflow_dispatch` path and works), so `:0.16.6` will publish regardless of this PR. This PR is what stops it recurring on 0.16.7+.

## Test plan

Workflow-only; can't run a live release here. YAML parses (`yaml.safe_load`). The logic is verified against the observed run: `release / publish-gradle-plugin` succeeded (incl. the new Maven-local staging) while `preview-host-image / publish` reported `skipped` with the old `if` — the new condition's `inputs.cli_version != ''` branch is true on that exact `workflow_call` invocation.

---
_Generated by [Claude Code](https://claude.ai/code/session_01K8nJEfEYGM3ijyoAXDNLGH)_