### PR TITLE
fix(deploy): bake a branch-trust store into the prebuilt image

### DIFF
--- a/deploy/image/Dockerfile
+++ b/deploy/image/Dockerfile
@@ -95,6 +95,11 @@ COPY --from=build /project /project
 COPY --from=build /root/.gradle /root/.gradle
 COPY --from=build /root/.m2 /root/.m2
 
+# Bake the branch-trust store so a public deploy badges the published
+# design-artifacts catalogs as Trusted(Branch) out of the box (SERVE_TRUST_STORE
+# defaults to /trust/producers.json). Override by mounting your own there.
+COPY trust/ /trust/
+
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 

--- a/deploy/image/docker-compose.yml
+++ b/deploy/image/docker-compose.yml
@@ -23,11 +23,13 @@ services:
       # SERVE_PUBLIC=0 and SERVE_TOKEN in .env.
       SERVE_PUBLIC: "${SERVE_PUBLIC:-1}"
       SERVE_CATALOGS: "${SERVE_CATALOGS:-compose-m3,wear-m3}"
-      # The image bakes a branch-trust store at /trust/producers.json, so the
-      # published design-artifacts catalogs badge as Trusted(Branch) by default.
-      # Point this at your own file (mount it via volumes below) to pin different
-      # producers, or set it empty to run with no trust store (all Unverified).
-      SERVE_TRUST_STORE: "${SERVE_TRUST_STORE:-/trust/producers.json}"
+      # The image bakes a branch-trust store at /trust/producers.json and the
+      # entrypoint defaults to it, so the published design-artifacts catalogs badge
+      # as Trusted(Branch) out of the box — leave this unset. Set your own path to
+      # pin different producers (mount it via volumes below), or the literal `none`
+      # to run trustless. (Empty is NOT trustless — it falls back to the baked
+      # default; use `none`.)
+      SERVE_TRUST_STORE: "${SERVE_TRUST_STORE:-}"
       # Unused in public mode; required only when SERVE_PUBLIC=0.
       SERVE_TOKEN: "${SERVE_TOKEN:-}"
       SERVE_IDLE_EXIT: "0"

--- a/deploy/image/docker-compose.yml
+++ b/deploy/image/docker-compose.yml
@@ -23,17 +23,17 @@ services:
       # SERVE_PUBLIC=0 and SERVE_TOKEN in .env.
       SERVE_PUBLIC: "${SERVE_PUBLIC:-1}"
       SERVE_CATALOGS: "${SERVE_CATALOGS:-compose-m3,wear-m3}"
-      # Optional: badge the catalogs as Trusted(Branch) instead of Unverified.
-      # Mount your trust store (see the volume below) and point this at it.
-      SERVE_TRUST_STORE: "${SERVE_TRUST_STORE:-}"
+      # The image bakes a branch-trust store at /trust/producers.json, so the
+      # published design-artifacts catalogs badge as Trusted(Branch) by default.
+      # Point this at your own file (mount it via volumes below) to pin different
+      # producers, or set it empty to run with no trust store (all Unverified).
+      SERVE_TRUST_STORE: "${SERVE_TRUST_STORE:-/trust/producers.json}"
       # Unused in public mode; required only when SERVE_PUBLIC=0.
       SERVE_TOKEN: "${SERVE_TOKEN:-}"
       SERVE_IDLE_EXIT: "0"
       PORT: "8080"
-    # Uncomment to badge our published catalogs as trusted (download it onto the
-    # host first: curl -o producers.json \
-    #   https://raw.githubusercontent.com/yschimke/compose-ai-tools/main/trust/producers.json
-    # then set SERVE_TRUST_STORE=/trust/producers.json in .env).
+    # To pin your OWN producers, mount a trust store over the baked one and keep
+    # SERVE_TRUST_STORE pointing at it:
     # volumes:
     #   - ./producers.json:/trust/producers.json:ro
     expose:

--- a/deploy/image/entrypoint.sh
+++ b/deploy/image/entrypoint.sh
@@ -27,7 +27,14 @@ fi
 # `serve` fetches each system's web/wasm/ from the trusted design-artifacts
 # branch. (--wasm-dir is for the from-source image's local build.)
 [[ -n "${SERVE_CATALOGS:-}" ]] && args+=(--catalogs "${SERVE_CATALOGS}")
-[[ -n "${SERVE_TRUST_STORE:-}" ]] && args+=(--trust-store "${SERVE_TRUST_STORE}")
+# Default to the baked branch-trust store so the published design-artifacts catalogs
+# badge as Trusted(Branch) out of the box. `:=` fills it when SERVE_TRUST_STORE is
+# unset OR empty (an older host compose passes ""), so a bare image pull self-heals a
+# box without editing compose. Override with your own path to pin different
+# producers, or the literal `none` to run trustless (catalogs then show Unverified).
+# NB opt-out is `none`, not empty — empty deliberately falls back to the default.
+: "${SERVE_TRUST_STORE:=/trust/producers.json}"
+[[ "${SERVE_TRUST_STORE}" != "none" ]] && args+=(--trust-store "${SERVE_TRUST_STORE}")
 [[ -n "${SERVE_WASM_DIR:-}" ]] && args+=(--wasm-dir "${SERVE_WASM_DIR}")
 if [[ "${SERVE_ACCEPT_BUNDLES:-}" == "1" || "${SERVE_ACCEPT_BUNDLES:-}" == "true" ]]; then
   args+=(--accept-bundles)

--- a/deploy/image/trust/producers.json
+++ b/deploy/image/trust/producers.json
@@ -1,0 +1,9 @@
+{
+  "_comment": "Trust store baked into the prebuilt preview-host image so a public deploy badges the published design-system catalogs as Trusted(Branch) out of the box, instead of Unverified. Branch (origin) trust only — the image carries no signing key, and branch trust is exactly what the --catalogs fetch needs: a catalog the server itself pulled from one of these branches is trusted by TLS origin, no per-bundle crypto. SERVE_TRUST_STORE defaults to this file (deploy/image/docker-compose.yml); override it, or mount your own at /trust/producers.json, to pin different producers. See docs/public-preview-server.md.",
+  "branches": [
+    {
+      "repo": "yschimke/compose-ai-tools",
+      "branch": "design-artifacts/*"
+    }
+  ]
+}

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -100,9 +100,11 @@ Both container profiles take this config from env (the entrypoint maps `SERVE_PU
 `compose-m3,wear-m3`); set `SERVE_PUBLIC=0` + `SERVE_TOKEN` for a token-gated box.
 
 The prebuilt `deploy/image` **bakes a branch-trust store** at `/trust/producers.json` (trusting
-`yschimke/compose-ai-tools` `design-artifacts/*`) and defaults `SERVE_TRUST_STORE` to it, so the
-published catalogs badge as `Trusted(Branch)` out of the box rather than `unverified`. Mount your own
-over that path to pin different producers, or set `SERVE_TRUST_STORE=` empty to run trustless.
+`yschimke/compose-ai-tools` `design-artifacts/*`) and the entrypoint defaults `SERVE_TRUST_STORE` to
+it, so the published catalogs badge as `Trusted(Branch)` out of the box rather than `unverified`.
+Mount your own over that path (or set `SERVE_TRUST_STORE` to it) to pin different producers, or set
+`SERVE_TRUST_STORE=none` to run trustless. (Empty falls back to the baked default — use `none` to opt
+out — which also means a bare image pull self-heals a box without editing its compose.)
 
 | | [`deploy/vps`](../deploy/vps) (from source) | [`deploy/image`](../deploy/image) (prebuilt) |
 |---|---|---|

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -99,6 +99,11 @@ Both container profiles take this config from env (the entrypoint maps `SERVE_PU
 **Caddy** in front for TLS. They default to the **open public profile** (`SERVE_PUBLIC=1`, catalogs
 `compose-m3,wear-m3`); set `SERVE_PUBLIC=0` + `SERVE_TOKEN` for a token-gated box.
 
+The prebuilt `deploy/image` **bakes a branch-trust store** at `/trust/producers.json` (trusting
+`yschimke/compose-ai-tools` `design-artifacts/*`) and defaults `SERVE_TRUST_STORE` to it, so the
+published catalogs badge as `Trusted(Branch)` out of the box rather than `unverified`. Mount your own
+over that path to pin different producers, or set `SERVE_TRUST_STORE=` empty to run trustless.
+
 | | [`deploy/vps`](../deploy/vps) (from source) | [`deploy/image`](../deploy/image) (prebuilt) |
 |---|---|---|
 | CLI | compiled from this checkout (~8 min build) | the **released** tarball (`docker pull`, no build) + Watchtower auto-update |


### PR DESCRIPTION
## Summary

On `preview.coo.ee` (the prebuilt `deploy/image` deploy) the published `compose-m3` / `wear-m3` catalogs showed as **`unverified`** instead of `Trusted(Branch)`.

**Root cause:** the prebuilt image ships **no trust store**, and `SERVE_TRUST_STORE` defaulted empty — so `serve` ran with the empty, fail-closed `TrustStore`, and `ServeCatalogStore` never matched the `design-artifacts/*` branch → every catalog session is `Unverified`. (The data tiers still serve, which is why browsing works; only the badge was wrong.)

**Fix:**
- Bake a minimal **branch-trust store** at `/trust/producers.json` trusting `yschimke/compose-ai-tools` `design-artifacts/*` (`COPY trust/ /trust/`).
- **Default `SERVE_TRUST_STORE` to it in the entrypoint** (`:= /trust/producers.json`), so the catalogs badge as `Trusted(Branch)` out of the box.

Branch (origin) trust is exactly what `--catalogs` needs — a catalog the server itself pulled from that branch is trusted by TLS origin, no signing key required.

**Override / opt-out:**
- Set `SERVE_TRUST_STORE` to your own path (or mount a store over `/trust/producers.json`) to pin different producers.
- Set `SERVE_TRUST_STORE=none` to run trustless. **Empty does *not* opt out** — it deliberately falls back to the baked default (Compose `:-` and the entrypoint `:=` both treat empty as "use default"). Putting the default in the entrypoint means **empty/unset both resolve to the baked store, so a bare image pull self-heals a box whose older compose passes `""` — no compose edit needed.**

## Test plan

- `deploy/image/trust/producers.json` parses; `docker-compose.yml` is valid YAML; `entrypoint.sh` passes `bash -n`.
- Simulated `TrustStore.globMatch` against the actual fetched branches (`ServeCatalogStore` repo `yschimke/compose-ai-tools`, prefix `design-artifacts/`): `trustsBranch(repo, design-artifacts/compose-m3)` and `…/wear-m3` → **true**.
- Simulated the entrypoint resolution: empty/unset → `--trust-store /trust/producers.json`; `none` → flag omitted (trustless); custom path → passed through.
- `TrustStore.load` ignores unknown keys and decodes pinned keys lazily, so the branch-only store loads cleanly (no signing key needed).

After merge, rebuilding the image (the change is in the image build context, not the CLI) and a Watchtower pull is enough for `preview.coo.ee` to badge the catalogs `Trusted(Branch)` — no host compose edit required.

---
_Generated by [Claude Code](https://claude.ai/code/session_01K8nJEfEYGM3ijyoAXDNLGH)_