### PR TITLE
fix(samples): opt in to ExperimentalRotateToLookAtUserApi in xr-spatial

### DIFF
--- a/samples/xr-spatial/src/main/kotlin/com/example/samplexrspatial/XrModifierPreviews.kt
+++ b/samples/xr-spatial/src/main/kotlin/com/example/samplexrspatial/XrModifierPreviews.kt
@@ -1,3 +1,8 @@
+// rotateToLookAtUser was marked @ExperimentalRotateToLookAtUserApi (opt-in, error-level) in
+// androidx.xr.compose 1.0.0-alpha15; this sample intentionally demonstrates it, so opt in
+// file-wide rather than at each call site.
+@file:OptIn(ExperimentalRotateToLookAtUserApi::class)
+
 package com.example.samplexrspatial
 
 import androidx.compose.runtime.Composable
@@ -6,6 +11,7 @@ import androidx.xr.compose.spatial.Subspace
 import androidx.xr.compose.subspace.SpatialBox
 import androidx.xr.compose.subspace.SpatialPanel
 import androidx.xr.compose.subspace.SpatialRow
+import androidx.xr.compose.subspace.layout.ExperimentalRotateToLookAtUserApi
 import androidx.xr.compose.subspace.layout.SpatialArrangement
 import androidx.xr.compose.subspace.layout.SubspaceModifier
 import androidx.xr.compose.subspace.layout.absoluteOffset


### PR DESCRIPTION
## Summary

`androidx.xr.compose` **1.0.0-alpha15** marked the `rotateToLookAtUser` subspace modifier as an **experimental, opt-in-required (error-level)** API. `:samples:xr-spatial` uses it in `XrModifierPreviews.kt`, so `compileReleaseKotlin` / `compileDebugKotlin` started failing — which broke the **full-project** checks on *every* PR and `main`:
- **CodeQL "Analyze (java-kotlin)"** (builds the whole repo), and
- **"Apply compose-preview"** (builds the repo to render previews).

This is dependency drift surfaced by the held-compose Gradle bump (#2104), unrelated to the serve/catalog work it was blocking.

**Fix:** add a file-level `@file:OptIn(ExperimentalRotateToLookAtUserApi::class)` to `XrModifierPreviews.kt` (the sample intentionally demonstrates the modifier). The exact marker FQN — `androidx.xr.compose.subspace.layout.ExperimentalRotateToLookAtUserApi` — was read out of the resolved `compose-1.0.0-alpha15.aar`, not guessed.

## Test plan

Verified locally with `ANDROID_HOME` set:
- `./gradlew :samples:xr-spatial:compileReleaseKotlin :samples:xr-spatial:compileDebugKotlin` → **BUILD SUCCESSFUL** (both were the failing tasks).
- `./gradlew :samples:xr-spatial:ktfmtCheck` → **BUILD SUCCESSFUL**.

Unblocks CodeQL + Apply-compose-preview on all open PRs (incl. #2113).

---
_Generated by [Claude Code](https://claude.ai/code/session_01K8nJEfEYGM3ijyoAXDNLGH)_