### PR TITLE
feat(serve): trusted server-side re-render for catalogs (--allow-render-trusted)

### DIFF
--- a/.github/workflows/design-artifacts.yml
+++ b/.github/workflows/design-artifacts.yml
@@ -100,6 +100,13 @@ jobs:
           # Set only for systems with an in-browser tier; the generator copies
           # this dir into out/web/wasm/ and writes the catalog.json webRender.
           WASM_DIST: ${{ matrix.wasmDist }}
+          # Buildable source for trusted server-side re-render: catalog.json gets a
+          # `source: {repo, ref, module}` so a `serve --allow-render-trusted` box can
+          # rebuild + re-render this catalog live. Inert on the public desktop box,
+          # which never sets that flag (it can't build the Android catalogs anyway).
+          SOURCE_REPO: ${{ github.repository }}
+          SOURCE_REF: main
+          SOURCE_MODULE: ${{ matrix.module }}
         run: |
           set -euo pipefail
           node scripts/design-artifacts/generate-design-catalog.mjs \
@@ -107,7 +114,10 @@ jobs:
             --renders "$GITHUB_WORKSPACE/$SYSTEM-bundle.png" \
             --out "$GITHUB_WORKSPACE/out" \
             --renderer "$(compose-preview --version | head -1)" \
-            ${WASM_DIST:+--wasm-dist "$GITHUB_WORKSPACE/$WASM_DIST"}
+            ${WASM_DIST:+--wasm-dist "$GITHUB_WORKSPACE/$WASM_DIST"} \
+            --source-repo "$SOURCE_REPO" \
+            --source-ref "$SOURCE_REF" \
+            --source-module ":$SOURCE_MODULE"
 
       - name: Publish to design-artifacts/${{ matrix.system }}
         env:

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -272,8 +272,15 @@ class ServeCommand(args: List<String>) : Command(args) {
     // opens them (gated by the same --revisions-allow ref allowlist).
     val worktrees: GitWorktrees? =
       if (revisions || allowRenderTrusted) openWorktrees(module) else null
+    // The `?session=<rev>` factory (project mode) is gated on --revisions ONLY — NOT merely on
+    // worktrees existing. Otherwise `--allow-render-trusted` (which also opens worktrees, but just
+    // to
+    // build a fixed catalog source) would silently let clients trigger Gradle builds for arbitrary
+    // revisions reachable from the allowlist. The catalog builder uses `worktrees` directly, so it
+    // doesn't need the factory.
     val factory =
-      if (worktrees != null) revisionFactory(module, worktrees) else ServeSessionFactory { null }
+      if (revisions && worktrees != null) revisionFactory(module, worktrees)
+      else ServeSessionFactory { null }
     val registry = ServeSessionRegistry(open = openHost, factory = factory)
     val defaultState =
       ServeSessionState(
@@ -577,7 +584,11 @@ class ServeCommand(args: List<String>) : Command(args) {
           )
           return false
         }
-    val relativePath = source.module.removePrefix(":").replace(":", "/")
+    // GradleRevisionBuilder builds task names as ":${gradlePath}:…", so gradlePath must be the
+    // colon-less form (e.g. `samples:design-catalog-m3`); a catalog's `source.module` is the
+    // conventional `:samples:…` path, so strip the leading colon (a double `::` fails every build).
+    val gradlePath = source.module.removePrefix(":")
+    val relativePath = gradlePath.replace(":", "/")
     val bootstrapArgs =
       autoInjectInitScriptArgs(args, projectRoot = repoRoot) +
         variantGradleArgs() +
@@ -588,7 +599,7 @@ class ServeCommand(args: List<String>) : Command(args) {
         onLog = { System.err.println("[serve build] $it") },
       )
     val built =
-      builder.build(worktree, ServeModuleRef(source.module, relativePath), isSecurityChecked = true)
+      builder.build(worktree, ServeModuleRef(gradlePath, relativePath), isSecurityChecked = true)
         ?: run {
           System.err.println(
             "serve: catalog $system build of ${source.module}@${source.ref} failed — serving baked PNGs"

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -61,10 +61,23 @@ class ServeCommand(args: List<String>) : Command(args) {
   private val revisions: Boolean = "--revisions" in args
 
   /**
+   * Trusted server-side re-render (SECURITY/RCE, opt-in, default off). When set, a `--catalogs`
+   * catalog that verifies as `Trusted` AND declares a `source` is served by a **daemon-backed,
+   * re-renderable** session built from that source (full-fidelity overrides) instead of static
+   * baked PNGs. Building runs the source's Gradle = code execution, so it's gated three ways: the
+   * catalog must be Trusted, its `source.ref` must clear the [revisionAllowRefs] allowlist
+   * (fail-closed), and its `source.repo` must be the server's own [catalogRepo]. NEVER enable on a
+   * box that can't build the catalog source (e.g. the desktop-only public image can't build the
+   * Android catalogs) — leave it off there and let the in-browser Wasm tier carry CMP. Reuses
+   * `--revisions-allow` as the ref allowlist.
+   */
+  private val allowRenderTrusted: Boolean = "--allow-render-trusted" in args
+
+  /**
    * Project mode revision policy (SECURITY/RCE): comma-separated refs whose history a requested
    * `?session=<rev>` must be reachable from to be checked out and built. Empty = nothing builds
    * (fail closed), since building runs that revision's Gradle. e.g. `--revisions-allow
-   * main,release`.
+   * main,release`. Also gates the trusted-catalog source build ([allowRenderTrusted]).
    */
   private val revisionAllowRefs: List<String> =
     args.flagValue("--revisions-allow")?.split(",")?.map { it.trim() }?.filter { it.isNotEmpty() }
@@ -255,7 +268,10 @@ class ServeCommand(args: List<String>) : Command(args) {
     }
     // Project mode forks a session per git revision behind the registry's factory; off by default
     // the factory yields nothing, so only the pinned current checkout is served.
-    val worktrees: GitWorktrees? = if (revisions) openWorktrees(module) else null
+    // Worktrees back both project-mode revisions and the trusted-catalog source build; either flag
+    // opens them (gated by the same --revisions-allow ref allowlist).
+    val worktrees: GitWorktrees? =
+      if (revisions || allowRenderTrusted) openWorktrees(module) else null
     val factory =
       if (worktrees != null) revisionFactory(module, worktrees) else ServeSessionFactory { null }
     val registry = ServeSessionRegistry(open = openHost, factory = factory)
@@ -278,7 +294,8 @@ class ServeCommand(args: List<String>) : Command(args) {
     // Serve our published design systems from their trusted `design-artifacts/<system>` branches.
     // A catalog that carries a `web/wasm/` app yields a system→dir entry so the in-browser tier
     // rides the same trusted branch (no local --wasm-dir build needed).
-    val catalogWasm = if (catalogs.isNotEmpty()) registerCatalogs(registry) else emptyMap()
+    val catalogWasm =
+      if (catalogs.isNotEmpty()) registerCatalogs(registry, worktrees, openHost) else emptyMap()
     // Runtime ingestion (--accept-bundles): clients POST a bundle (or a ?url= to one) and it's
     // registered as a pinned session. Unpacked under a temp dir for this server's lifetime.
     val bundleStore =
@@ -485,7 +502,11 @@ class ServeCommand(args: List<String>) : Command(args) {
    * branch is in the trust store; otherwise served as `unverified` (the images execute no code).
    * Best-effort per system — one catalog failing to fetch doesn't sink the others or the server.
    */
-  private fun registerCatalogs(registry: ServeSessionRegistry): Map<String, File> {
+  private fun registerCatalogs(
+    registry: ServeSessionRegistry,
+    worktrees: GitWorktrees?,
+    openHost: (ServeSessionState) -> ServeHost?,
+  ): Map<String, File> {
     val dir =
       java.nio.file.Files.createTempDirectory("serve-catalogs").toFile().also { it.deleteOnExit() }
     val wasm = linkedMapOf<String, File>()
@@ -502,6 +523,9 @@ class ServeCommand(args: List<String>) : Command(args) {
             "serve: catalog $system carries an in-browser Wasm app (/wasm/$system/)"
           )
         },
+        buildTrustedSource = { system, source ->
+          buildTrustedCatalogSource(system, source, registry, worktrees, openHost)
+        },
       )
     for (system in catalogs) {
       when (val r = store.load(system)) {
@@ -517,6 +541,75 @@ class ServeCommand(args: List<String>) : Command(args) {
       }
     }
     return wasm
+  }
+
+  /**
+   * Build a `Trusted` catalog's source into a daemon-backed, re-renderable session — the engine
+   * behind `--allow-render-trusted`. The store only calls this for an already-`Trusted` catalog;
+   * here we add the remaining fail-closed gates: the flag is set, the source repo (when given) is
+   * the server's own [catalogRepo], and the source ref clears the worktree ref allowlist (enforced
+   * inside [GitWorktrees.prepare]). Returns true once a daemon session is registered under [system]
+   * (the store then skips the static baked-PNG host); false ⇒ fall back to baked PNGs.
+   */
+  private fun buildTrustedCatalogSource(
+    system: String,
+    source: ServeCatalogStore.CatalogSource,
+    registry: ServeSessionRegistry,
+    worktrees: GitWorktrees?,
+    openHost: (ServeSessionState) -> ServeHost?,
+  ): Boolean {
+    if (!allowRenderTrusted || worktrees == null) return false
+    if (source.repo.isNotBlank() && source.repo != catalogRepo) {
+      System.err.println(
+        "serve: catalog $system source repo '${source.repo}' != '$catalogRepo' — not live-rendering"
+      )
+      return false
+    }
+    if (source.ref.isBlank() || source.module.isBlank()) return false
+    val repoRoot = findProjectRoot() ?: return false
+    // The ref allowlist is enforced here (fail-closed): null = unresolvable or not in
+    // --revisions-allow.
+    val worktree =
+      worktrees.prepare(source.ref)
+        ?: run {
+          System.err.println(
+            "serve: catalog $system ref '${source.ref}' not allowed/resolvable — serving baked PNGs"
+          )
+          return false
+        }
+    val relativePath = source.module.removePrefix(":").replace(":", "/")
+    val bootstrapArgs =
+      autoInjectInitScriptArgs(args, projectRoot = repoRoot) +
+        variantGradleArgs() +
+        gradleArgsWithForce()
+    val builder =
+      GradleRevisionBuilder(
+        extraArgs = bootstrapArgs,
+        onLog = { System.err.println("[serve build] $it") },
+      )
+    val built =
+      builder.build(worktree, ServeModuleRef(source.module, relativePath), isSecurityChecked = true)
+        ?: run {
+          System.err.println(
+            "serve: catalog $system build of ${source.module}@${source.ref} failed — serving baked PNGs"
+          )
+          return false
+        }
+    val state =
+      ServeSessionState(
+        descriptor = built.descriptor,
+        workspaceRoot = built.moduleDir,
+        workspaceName = built.moduleDir.name,
+        previews = built.previews,
+        label = "$system@${source.ref}",
+      )
+    val host = openHost(state) ?: return false
+    registry.register(system, state, host = host)
+    System.err.println(
+      "serve: catalog $system → LIVE server-render from ${source.module}@${source.ref} " +
+        "(?session=$system)"
+    )
+    return true
   }
 
   /**
@@ -672,6 +765,16 @@ class ServeCommand(args: List<String>) : Command(args) {
                           refs (e.g. main,release) are checked out and built — building runs that
                           revision's own Gradle (code execution). Omitted/empty = nothing builds
                           (fail closed), so arbitrary ?session=<rev> can't run code on the server.
+                          Also gates --allow-render-trusted (the catalog source ref allowlist).
+        --allow-render-trusted
+                          SECURITY gate, opt-in (default off): serve a --catalogs catalog that is
+                          Trusted AND declares a source as a live, re-renderable session built from
+                          that source (full-fidelity overrides) instead of static baked PNGs. Runs
+                          the source's Gradle = code execution, so it's gated by trust + the
+                          --revisions-allow ref allowlist + a same-repo check. NEVER set this on a
+                          box that can't build the catalog source (e.g. the desktop-only public
+                          image can't build the Android catalogs) — leave it off and let the
+                          in-browser Wasm tier carry CMP.
         --exit-when-idle[=<seconds>]
                           Ephemeral mode: shut the server down once it's been idle (no open
                           connections and no requests) for <seconds> (default ${DEFAULT_IDLE_EXIT_SECONDS}s). Use a small

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
@@ -42,7 +42,22 @@ class ServeCatalogStore(
    * catalog** — a deployed public server needs no local `--wasm-dir` build, just `--catalogs`.
    */
   private val registerWasm: (system: String, dir: File) -> Unit = { _, _ -> },
+  /**
+   * Trusted server-side re-render (opt-in, `--allow-render-trusted`). When a catalog is `Trusted`
+   * AND declares a `source` (`{repo, ref, module}`), this is invoked to stand up a **daemon-backed,
+   * re-renderable** session built from that source — so the viewer's controls re-render live at
+   * full fidelity instead of replaying baked PNGs. Returns true when it registered such a session
+   * (then the static [ServeBundleHost] is skipped); false ⇒ fall back to the static catalog.
+   * Default ⇒ never (the safe default + what every public deploy uses). The callback owns the
+   * ref-allowlist + build gates; this store only reaches it for an already-`Trusted` catalog.
+   */
+  private val buildTrustedSource: (system: String, source: CatalogSource) -> Boolean = { _, _ ->
+    false
+  },
 ) {
+
+  /** A catalog's buildable source — where to check out + build to re-render it live. */
+  data class CatalogSource(val repo: String, val ref: String, val module: String)
 
   sealed interface Result {
     data class Ok(val system: String, val previewCount: Int, val trust: String) : Result
@@ -109,6 +124,21 @@ class ServeCatalogStore(
       if (trust.trustsBranch(repo, branch))
         BundleVerifier.Verdict.Trusted(listOf(BundleVerifier.Basis.Branch(repo, branch)))
       else BundleVerifier.Verdict.Unverified("branch $repo@$branch is not trusted")
+
+    // Trusted server-side re-render (opt-in): only a Trusted catalog that declares a source is even
+    // offered to the builder — an Unverified catalog NEVER reaches it, so a compromised/spoofed
+    // catalog can't trigger a build. When the builder takes over it registers a daemon-backed
+    // (re-renderable) session under this id, so we skip the static host below.
+    val src = catalog.source
+    if (
+      verdict is BundleVerifier.Verdict.Trusted &&
+        src != null &&
+        src.module.isNotBlank() &&
+        buildTrustedSource(safe, CatalogSource(src.repo, src.ref, src.module))
+    ) {
+      return Result.Ok(safe, count, "${BundleVerifier.summary(verdict)} (live)")
+    }
+
     val host = ServeBundleHost(dir, safe, verdict)
     register(safe, host)
     return Result.Ok(safe, host.previews.size, BundleVerifier.summary(verdict))
@@ -159,7 +189,13 @@ class ServeCatalogStore(
     val components: List<Component> = emptyList(),
     /** Optional in-browser render descriptor (the CMP-Wasm app carried in the branch). */
     val webRender: WebRender? = null,
+    /** Optional buildable source for trusted server-side re-render (`--allow-render-trusted`). */
+    val source: Source? = null,
   )
+
+  /** `catalog.json`'s `source`: the repo/ref/module to build to re-render this catalog live. */
+  @Serializable
+  private data class Source(val repo: String = "", val ref: String = "", val module: String = "")
 
   @Serializable private data class Component(val images: List<Image> = emptyList())
 

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
@@ -169,4 +169,81 @@ class ServeCatalogStoreTest {
     store(TrustStore.EMPTY).load("compose-m3")
     assertTrue(registeredWasm.isEmpty())
   }
+
+  // --- Trusted server-side re-render (--allow-render-trusted) gating ---
+
+  private val buildCalls = mutableListOf<Pair<String, ServeCatalogStore.CatalogSource>>()
+
+  private val catalogWithSource =
+    """
+    {"schema":"design-parity-catalog/v1","system":"compose-m3","components":[
+      {"componentId":"Button/Filled","images":[
+        {"path":"images/button-filled/ideal__default__dark.png","theme":"dark"}]}],
+     "source":{"repo":"yschimke/compose-ai-tools","ref":"main",
+               "module":":samples:design-catalog-m3"}}
+    """
+      .trimIndent()
+
+  private val trustBranches =
+    TrustStore(branches = listOf(TrustedBranch("yschimke/compose-ai-tools", "design-artifacts/*")))
+
+  private fun storeWithBuilder(
+    trust: TrustStore,
+    catalog: String,
+    builderResult: Boolean,
+  ): ServeCatalogStore =
+    ServeCatalogStore(
+      root = tempRoot(),
+      register = { n, h -> registered[n] = h },
+      trust = trust,
+      fetch = { url ->
+        when {
+          url.endsWith("/${ServeCatalogStore.CATALOG_FILE}") -> catalog.toByteArray()
+          url.endsWith(".png") -> png()
+          else -> null
+        }
+      },
+      buildTrustedSource = { system, source ->
+        buildCalls += system to source
+        builderResult
+      },
+    )
+
+  @Test
+  fun `a trusted catalog with a source builds a live session and skips the static host`() {
+    val result =
+      storeWithBuilder(trustBranches, catalogWithSource, builderResult = true).load("compose-m3")
+    assertEquals(1, buildCalls.size, "builder invoked for a trusted catalog with a source")
+    assertEquals(":samples:design-catalog-m3", buildCalls.single().second.module)
+    assertEquals("main", buildCalls.single().second.ref)
+    assertTrue(registered.isEmpty(), "static host skipped once the live session takes over")
+    assertTrue(
+      result is ServeCatalogStore.Result.Ok && result.trust.endsWith("(live)"),
+      "result marked live",
+    )
+  }
+
+  @Test
+  fun `an untrusted catalog with a source never reaches the builder (no RCE on spoof)`() {
+    storeWithBuilder(TrustStore.EMPTY, catalogWithSource, builderResult = true).load("compose-m3")
+    assertTrue(buildCalls.isEmpty(), "an unverified catalog must never trigger a build")
+    assertTrue(registered.getValue("compose-m3").trust is BundleVerifier.Verdict.Unverified)
+  }
+
+  @Test
+  fun `a trusted catalog with no source serves the static host`() {
+    storeWithBuilder(trustBranches, catalogJson, builderResult = true).load("compose-m3")
+    assertTrue(buildCalls.isEmpty(), "no source means no build")
+    assertTrue(registered.containsKey("compose-m3"))
+  }
+
+  @Test
+  fun `when the builder declines (ref not allowed) the catalog falls back to baked PNGs`() {
+    storeWithBuilder(trustBranches, catalogWithSource, builderResult = false).load("compose-m3")
+    assertEquals(1, buildCalls.size, "builder consulted")
+    assertTrue(
+      registered.containsKey("compose-m3"),
+      "fall back to the static host when the build is refused",
+    )
+  }
 }

--- a/deploy/cloudrun/entrypoint.sh
+++ b/deploy/cloudrun/entrypoint.sh
@@ -45,6 +45,13 @@ fi
 [[ -n "${SERVE_CATALOGS:-}" ]] && args+=(--catalogs "${SERVE_CATALOGS}")
 [[ -n "${SERVE_TRUST_STORE:-}" ]] && args+=(--trust-store "${SERVE_TRUST_STORE}")
 [[ -n "${SERVE_WASM_DIR:-}" ]] && args+=(--wasm-dir "${SERVE_WASM_DIR}")
+# Trusted server-side re-render (opt-in, OFF by default). Only enable on a box that
+# can BUILD the catalog source (the Android catalogs need the Android toolchain).
+# Reuses SERVE_REVISIONS_ALLOW as the trusted ref allowlist (fail-closed).
+[[ -n "${SERVE_REVISIONS_ALLOW:-}" ]] && args+=(--revisions-allow "${SERVE_REVISIONS_ALLOW}")
+if [[ "${SERVE_ALLOW_RENDER_TRUSTED:-}" == "1" || "${SERVE_ALLOW_RENDER_TRUSTED:-}" == "true" ]]; then
+  args+=(--allow-render-trusted)
+fi
 # Client uploads (POST /bundles) — off unless SERVE_ACCEPT_BUNDLES=1; a host
 # allowlist for ?url= fetches is opt-in on top (SSRF stays fail-closed).
 if [[ "${SERVE_ACCEPT_BUNDLES:-}" == "1" || "${SERVE_ACCEPT_BUNDLES:-}" == "true" ]]; then

--- a/deploy/image/entrypoint.sh
+++ b/deploy/image/entrypoint.sh
@@ -36,6 +36,14 @@ fi
 : "${SERVE_TRUST_STORE:=/trust/producers.json}"
 [[ "${SERVE_TRUST_STORE}" != "none" ]] && args+=(--trust-store "${SERVE_TRUST_STORE}")
 [[ -n "${SERVE_WASM_DIR:-}" ]] && args+=(--wasm-dir "${SERVE_WASM_DIR}")
+# Trusted server-side re-render (opt-in, OFF by default). Only enable on a box that
+# can BUILD the catalog source — this desktop image CANNOT build the Android
+# catalogs, so leave SERVE_ALLOW_RENDER_TRUSTED unset on the public preview server.
+# Needs SERVE_REVISIONS_ALLOW (the trusted ref allowlist) to build anything.
+[[ -n "${SERVE_REVISIONS_ALLOW:-}" ]] && args+=(--revisions-allow "${SERVE_REVISIONS_ALLOW}")
+if [[ "${SERVE_ALLOW_RENDER_TRUSTED:-}" == "1" || "${SERVE_ALLOW_RENDER_TRUSTED:-}" == "true" ]]; then
+  args+=(--allow-render-trusted)
+fi
 if [[ "${SERVE_ACCEPT_BUNDLES:-}" == "1" || "${SERVE_ACCEPT_BUNDLES:-}" == "true" ]]; then
   args+=(--accept-bundles)
   [[ -n "${SERVE_ACCEPT_BUNDLES_FROM:-}" ]] &&

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -120,6 +120,27 @@ current).
 - **Re-render of trusted Compose** stays off unless the operator opts in; a public box should leave
   `--revisions` *off* (that path runs arbitrary Gradle = RCE).
 
+## Trusted server-side re-render (`--allow-render-trusted`)
+
+By default a catalog serves **baked PNGs** — the viewer's device/orientation/etc. controls can't
+re-render a static image (they're disabled, with the in-browser Wasm tier carrying theme/font-scale/
+locale for CMP). For **full-fidelity** server-side overrides, a catalog can declare a buildable
+`source: { repo, ref, module }` in its `catalog.json` (the design-artifacts pipeline emits it), and
+an operator can opt in with `--allow-render-trusted`: a catalog that verifies **`Trusted`** *and*
+declares a `source` is then served by a live, daemon-backed session built from that source, so every
+control re-renders for real.
+
+It is **off by default** and gated three ways, all fail-closed: the catalog must be `Trusted`
+(an `Unverified`/spoofed catalog never reaches the builder — no RCE lever), its `source.ref` must
+clear the `--revisions-allow` allowlist, and its `source.repo` must be the server's own repo.
+
+**Never enable it on a box that can't build the catalog source.** Building runs the source's Gradle
+(code execution), and the published catalogs are **Android** modules — the desktop-only public image
+(`deploy/image`, `preview.coo.ee`) has no Android toolchain, so it leaves `SERVE_ALLOW_RENDER_TRUSTED`
+**unset** and relies on the Wasm tier for CMP. Enable it only on a box with the matching toolchain
+(set `SERVE_ALLOW_RENDER_TRUSTED=1` + `SERVE_REVISIONS_ALLOW=main`), where the heavier per-session
+Gradle build + live render is acceptable.
+
 ## Endpoints
 
 `GET /` index · `GET /p/{id}?session=<s>` viewer · `GET /render/{id}.png` PNG ·

--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -233,6 +233,15 @@ const { values } = parseArgs({
     // descriptor is written into catalog.json — so the branch carries the live
     // renderer and `serve --catalogs` fetches it from the same trusted origin.
     "wasm-dist": { type: "string" },
+    // Optional buildable source for TRUSTED server-side re-render. When
+    // --source-module is given, a `source: {repo, ref, module}` is written into
+    // catalog.json so a `serve --allow-render-trusted` box (one with the toolchain
+    // to build it) can stand up a live, full-fidelity re-render of this catalog
+    // instead of replaying baked PNGs. Inert on the public desktop box (which never
+    // sets that flag).
+    "source-repo": { type: "string" },
+    "source-ref": { type: "string" },
+    "source-module": { type: "string" },
     // Publish even when the render is incomplete (missing previews or absent
     // semantics). Off by default so a degraded render fails the job rather than
     // force-pushing a tokens/greenline-less bundle over a good delivery branch.
@@ -320,6 +329,15 @@ if (values["wasm-dist"]) {
     }
   }
   if (webRender) manifest.webRender = webRender;
+  // Buildable source for trusted server-side re-render (opt-in consumer side).
+  if (values["source-module"]) {
+    manifest.source = {
+      repo: values["source-repo"] ?? "",
+      ref: values["source-ref"] ?? "",
+      module: values["source-module"],
+    };
+    console.log(`[${spec.system}] source → ${manifest.source.module}@${manifest.source.ref}`);
+  }
   await writeFile(catalogJsonPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
 }
 


### PR DESCRIPTION
## Summary

Track ④ of the catalog-controls work. A catalog normally serves **baked PNGs** — the viewer's device/orientation/etc. controls can't re-render a static image (disabled; the Wasm tier carries theme/font-scale/locale for CMP via #2115). With the opt-in **`--allow-render-trusted`** flag, a catalog that verifies as **`Trusted`** *and* declares a buildable `source` is instead served by a **daemon-backed, re-renderable** session built from that source, so every control re-renders live at full fidelity.

### How it's gated (all fail-closed)
1. **Trusted only** — an `Unverified`/spoofed catalog **never reaches the builder** (no RCE lever). Unit-tested.
2. **Ref allowlist** — `source.ref` must clear `--revisions-allow` (the same gate as project-mode revisions; enforced inside `GitWorktrees.prepare`).
3. **Same repo** — `source.repo` must equal the server's own catalog repo.
4. **Opt-in** — off by default everywhere.

### Pieces
- **Format:** `catalog.json` gains `source: {repo, ref, module}`; `generate-design-catalog.mjs` emits it (`--source-*`), and `design-artifacts.yml` passes the catalog's source module.
- **`ServeCatalogStore`:** a Trusted catalog with a source is handed to a builder callback; if it takes over, the static host is skipped (`…(live)`).
- **`ServeCommand`:** `--allow-render-trusted` builds `source.module` at `source.ref` via the existing worktree + `GradleRevisionBuilder` machinery → daemon session (reuses the `--revisions` path).
- **Deploy:** entrypoints map `SERVE_ALLOW_RENDER_TRUSTED` + `SERVE_REVISIONS_ALLOW`, but it stays **OFF on every public profile**. The desktop-only public image **can't build the Android catalogs**, so `preview.coo.ee` leaves it unset and the Wasm tier carries CMP — documented loudly in `docs/public-preview-server.md`.

## Test plan

- **Gating (security-critical) unit tests** in `ServeCatalogStoreTest`: a Trusted catalog with a source → builder invoked, static host skipped, result marked live; an **Unverified catalog with a source → builder never called** (no RCE on spoof); no source → static host; builder declines → falls back to baked PNGs. Green.
- `:cli:test --tests '*serve*' --tests '*CliFlags*'` green; `ktfmt` clean; `node --check` the generator; `bash -n` both entrypoints; YAML parses.
- **End-to-end** (actually building + live-rendering an Android catalog) needs a box with the Android toolchain — can't be exercised on this desktop CI runner, which is exactly why it's off-by-default and off-on-public. The gating that prevents misuse is fully unit-tested.

Text-only: no viewer change (the controls already exist from #2115) — this only changes what *backs* a trusted catalog session on an opted-in box.

---
_Generated by [Claude Code](https://claude.ai/code/session_01K8nJEfEYGM3ijyoAXDNLGH)_