### PR TITLE
feat(serve): live-edit declared knobs on daemon sessions

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -255,8 +255,18 @@ class ServeHttpServer(
               return@webSocket
             }
             val initialOverrides =
-              ServeOverrides.SUPPORTED_KEYS.mapNotNull { key ->
-                  call.request.queryParameters[key]?.let { key to it }
+              call.request.queryParameters
+                .entries()
+                .mapNotNull { (key, values) ->
+                  val value = values.firstOrNull() ?: return@mapNotNull null
+                  if (
+                    key in ServeOverrides.SUPPORTED_KEYS ||
+                      key.startsWith(ServeOverrides.KNOB_PREFIX)
+                  ) {
+                    key to value
+                  } else {
+                    null
+                  }
                 }
                 .toMap()
             // Non-suspending hand-off to the socket; drop frames a slow client can't keep up with.
@@ -415,9 +425,22 @@ class ServeHttpServer(
               call.respondText("missing preview id", status = HttpStatusCode.BadRequest)
               return@withLeasedSession
             }
+            // Forward the fixed render axes plus any author-declared knob params
+            // (`knob.<key>=…`, dynamic keys not in SUPPORTED_KEYS) so a live knob edit reaches
+            // ServeOverrides.parse instead of being silently dropped.
             val overrideParams =
-              ServeOverrides.SUPPORTED_KEYS.mapNotNull { key ->
-                  call.request.queryParameters[key]?.let { key to it }
+              call.request.queryParameters
+                .entries()
+                .mapNotNull { (key, values) ->
+                  val value = values.firstOrNull() ?: return@mapNotNull null
+                  if (
+                    key in ServeOverrides.SUPPORTED_KEYS ||
+                      key.startsWith(ServeOverrides.KNOB_PREFIX)
+                  ) {
+                    key to value
+                  } else {
+                    null
+                  }
                 }
                 .toMap()
             when (val parsed = ServeOverrides.parse(overrideParams)) {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeOverrides.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeOverrides.kt
@@ -1,6 +1,7 @@
 package ee.schimke.composeai.cli.serve
 
 import ee.schimke.composeai.daemon.protocol.Orientation
+import ee.schimke.composeai.daemon.protocol.PreviewOverrideValue
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.daemon.protocol.UiMode
 import java.security.MessageDigest
@@ -54,6 +55,16 @@ object ServeOverrides {
       "orientation",
       "inspectionMode",
     )
+
+  /**
+   * Prefix for author-declared named-override knobs: `knob.<wireKey>=<kind>:<value>`, e.g.
+   * `knob.label=string:Tap me` or `knob.count=int:3`. `wireKey` is the declaration key (indexed
+   * knobs use `key[index]`); `kind` is one of string/int/float/bool/color, matching
+   * [PreviewOverrideValue]. The daemon's named-override planner seeds the preview's declared knobs
+   * from these, so editing one re-renders the composable (only on a daemon-backed session — a
+   * static bundle / the Wasm tier ignore them). Dynamic keys, so not listed in [SUPPORTED_KEYS].
+   */
+  const val KNOB_PREFIX = "knob."
 
   /**
    * Parse [params] (one value per key — the ktor layer collapses multi-values to the first) into a
@@ -134,6 +145,41 @@ object ServeOverrides {
           }
         }
 
+    // Named-override knobs (`knob.<key>=<kind>:<value>`). A malformed typed value is a hard
+    // Invalid (mirrors the numeric fields) rather than a silently-dropped edit.
+    val namedOverrides = mutableMapOf<String, PreviewOverrideValue>()
+    for ((rawKey, raw) in params) {
+      if (!rawKey.startsWith(KNOB_PREFIX)) continue
+      val wireKey = rawKey.removePrefix(KNOB_PREFIX)
+      if (wireKey.isBlank() || raw.isBlank()) continue
+      val sep = raw.indexOf(':')
+      if (sep <= 0) {
+        return OverrideParse.Invalid("knob '$wireKey' must be '<kind>:<value>', got '$raw'")
+      }
+      val kind = raw.substring(0, sep)
+      val value = raw.substring(sep + 1)
+      namedOverrides[wireKey] =
+        when (kind) {
+          "string" -> PreviewOverrideValue.StringValue(value)
+          "int" ->
+            value.toIntOrNull()?.let { PreviewOverrideValue.IntValue(it) }
+              ?: return OverrideParse.Invalid(
+                "knob '$wireKey' int must be an integer, got '$value'"
+              )
+          "float" ->
+            value.toFloatOrNull()?.let { PreviewOverrideValue.FloatValue(it) }
+              ?: return OverrideParse.Invalid(
+                "knob '$wireKey' float must be a number, got '$value'"
+              )
+          "bool" ->
+            PreviewOverrideValue.BooleanValue(
+              value.equals("true", ignoreCase = true) || value == "1"
+            )
+          "color" -> PreviewOverrideValue.ColorValue(value)
+          else -> return OverrideParse.Invalid("knob '$wireKey' has unknown kind '$kind'")
+        }
+    }
+
     return OverrideParse.Ok(
       PreviewOverrides(
         widthPx = widthPx,
@@ -145,6 +191,7 @@ object ServeOverrides {
         orientation = orientation,
         device = params["device"]?.takeIf { it.isNotBlank() },
         inspectionMode = inspectionMode,
+        namedOverrides = namedOverrides.ifEmpty { null },
       )
     )
   }
@@ -166,7 +213,13 @@ object ServeOverrides {
       append("ui=").append(o.uiMode).append('|')
       append("or=").append(o.orientation).append('|')
       append("dev=").append(o.device).append('|')
-      append("insp=").append(o.inspectionMode)
+      append("insp=").append(o.inspectionMode).append('|')
+      // Named overrides participate so a knob edit isn't coalesced onto the prior render. Sorted by
+      // key for order-independence; the value data classes have stable toString.
+      append("named=")
+      o.namedOverrides?.toSortedMap()?.forEach { (k, v) ->
+        append(k).append('=').append(v).append(';')
+      }
     }
     return MessageDigest.getInstance("SHA-256")
       .digest(canonical.toByteArray(Charsets.UTF_8))

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -364,6 +364,16 @@ object ServeWeb {
         var q = "token=" + encodeURIComponent(token);
         if (session) q += "&session=" + encodeURIComponent(session);
         Object.keys(o).forEach(function (k) { q += "&" + k + "=" + encodeURIComponent(o[k]); });
+        // Author-declared knobs (enabled only on a daemon session): knob.<key>=<kind>:<value>.
+        document.querySelectorAll(".cp-knob").forEach(function (el) {
+          if (el.disabled) return;
+          var key = el.getAttribute("data-knob-key");
+          var kind = el.getAttribute("data-knob-kind") || "string";
+          if (!key) return;
+          var val = (el.type === "checkbox") ? (el.checked ? "true" : "false") : el.value;
+          if (val === "") return;
+          q += "&knob." + encodeURIComponent(key) + "=" + encodeURIComponent(kind + ":" + val);
+        });
         return q;
       }
       function refreshSnapshot() {
@@ -580,6 +590,10 @@ object ServeWeb {
         var el = document.getElementById("cp-" + f);
         if (el) el.addEventListener("change", onControlsChanged);
       });
+      // Author-declared knobs re-render on edit (text/number debounce via "input", toggles "change").
+      document.querySelectorAll(".cp-knob").forEach(function (el) {
+        el.addEventListener(el.type === "checkbox" ? "change" : "input", onControlsChanged);
+      });
       refreshSnapshot();
     })();
     """
@@ -613,31 +627,35 @@ object ServeWeb {
    */
   private fun overrideKnobsHtml(preview: ServePreview, canApplyOverrides: Boolean): String {
     if (preview.overrides.isEmpty()) return ""
+    // Editable only on a daemon-backed session (canApplyOverrides) — a static bundle / the Wasm
+    // tier
+    // can't re-render with new knob values, so there the controls show *what* is editable but stay
+    // disabled. The viewer JS collects `.cp-knob` values into `knob.<key>=<kind>:<value>` params.
+    val dis = if (canApplyOverrides) "" else " disabled"
     val rows =
       preview.overrides.joinToString("\n") { d ->
         val name = if (d.index == null) d.key else "${d.key} #${d.index}"
         val label = WebEscaping.htmlEscape(name)
+        // Daemon map key: base key, plus `[index]` for an indexed (per-item) knob.
+        val wireKey = WebEscaping.htmlEscape(if (d.index == null) d.key else "${d.key}[${d.index}]")
+        val kind = knobKind(d.type)
         val value = WebEscaping.htmlEscape(overrideValueText(d.current ?: d.default))
-        val inputType =
-          when (d.type) {
-            "int",
-            "float" -> "number"
-            "color" -> "text"
-            else -> "text"
-          }
-        // Disabled regardless of host for now: a bundle can't re-render, and the live re-render
-        // wiring
-        // for named overrides is a follow-up. The control still shows *what* is editable + its
-        // value.
-        """
-        <label>${label}
-          <input type="$inputType" value="$value" disabled>
-        </label>
-        """
-          .trimIndent()
+        val attrs = "class=\"cp-knob\" data-knob-key=\"$wireKey\" data-knob-kind=\"$kind\""
+        if (kind == "bool") {
+          val checked = if (value == "true" || value == "1") " checked" else ""
+          "<label class=\"cp-live-row\"><input type=\"checkbox\" $attrs$checked$dis> $label</label>"
+        } else {
+          val inputType = if (d.type == "int" || d.type == "float") "number" else "text"
+          """
+          <label>${label}
+            <input type="$inputType" $attrs value="$value"$dis>
+          </label>
+          """
+            .trimIndent()
+        }
       }
     val note =
-      if (canApplyOverrides) "Declared overrides (live editing coming soon)."
+      if (canApplyOverrides) "Declared overrides — edit a value to re-render."
       else "Declared overrides — static bundle, values are baked in."
     return """
       <div class="cp-knobs">
@@ -647,6 +665,20 @@ object ServeWeb {
       """
       .trimIndent()
   }
+
+  /**
+   * Map a declaration's `type` string to the [PreviewOverrideValue] wire kind the daemon expects.
+   */
+  private fun knobKind(type: String): String =
+    when (type.lowercase()) {
+      "int" -> "int"
+      "float",
+      "dp" -> "float"
+      "bool",
+      "boolean" -> "bool"
+      "color" -> "color"
+      else -> "string"
+    }
 
   /** Human text for a [ee.schimke.composeai.daemon.protocol.PreviewOverrideValue] in the viewer. */
   private fun overrideValueText(

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeOverridesTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeOverridesTest.kt
@@ -1,10 +1,12 @@
 package ee.schimke.composeai.cli.serve
 
 import ee.schimke.composeai.daemon.protocol.Orientation
+import ee.schimke.composeai.daemon.protocol.PreviewOverrideValue
 import ee.schimke.composeai.daemon.protocol.UiMode
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -105,6 +107,86 @@ class ServeOverridesTest {
       ServeOverrides.cacheKey("preview.A", base),
       ServeOverrides.cacheKey("preview.B", base),
     )
+  }
+
+  @Test
+  fun `knob params parse to typed named overrides`() {
+    val o =
+      ok(
+        mapOf(
+          "knob.label" to "string:Tap me",
+          "knob.count" to "int:3",
+          "knob.weight" to "float:1.5",
+          "knob.enabled" to "bool:true",
+          "knob.tint" to "color:#FF0000",
+        )
+      )
+    val named = o.namedOverrides
+    assertNotNull(named)
+    assertEquals(PreviewOverrideValue.StringValue("Tap me"), named["label"])
+    assertEquals(PreviewOverrideValue.IntValue(3), named["count"])
+    assertEquals(PreviewOverrideValue.FloatValue(1.5f), named["weight"])
+    assertEquals(PreviewOverrideValue.BooleanValue(true), named["enabled"])
+    assertEquals(PreviewOverrideValue.ColorValue("#FF0000"), named["tint"])
+  }
+
+  @Test
+  fun `bool knob accepts 1 and is false otherwise`() {
+    val o = ok(mapOf("knob.a" to "bool:1", "knob.b" to "bool:0", "knob.c" to "bool:nope"))
+    assertEquals(PreviewOverrideValue.BooleanValue(true), o.namedOverrides!!["a"])
+    assertEquals(PreviewOverrideValue.BooleanValue(false), o.namedOverrides!!["b"])
+    assertEquals(PreviewOverrideValue.BooleanValue(false), o.namedOverrides!!["c"])
+  }
+
+  @Test
+  fun `indexed knob key keeps its bracketed wire key`() {
+    val o = ok(mapOf("knob.rowLabel[2]" to "string:Hi"))
+    assertEquals(PreviewOverrideValue.StringValue("Hi"), o.namedOverrides!!["rowLabel[2]"])
+  }
+
+  @Test
+  fun `no knob params leave named overrides null`() {
+    val o = ok(mapOf("uiMode" to "dark"))
+    assertNull(o.namedOverrides)
+  }
+
+  @Test
+  fun `blank knob key or value is ignored`() {
+    val o = ok(mapOf("knob." to "string:x", "knob.label" to ""))
+    assertNull(o.namedOverrides)
+  }
+
+  @Test
+  fun `malformed knob values are rejected with a reason`() {
+    for (bad in
+      listOf(
+        mapOf("knob.label" to "Tap me"), // missing kind:value separator
+        mapOf("knob.label" to ":Tap me"), // empty kind
+        mapOf("knob.count" to "int:three"), // not an integer
+        mapOf("knob.weight" to "float:heavy"), // not a number
+        mapOf("knob.x" to "mystery:y"), // unknown kind
+      )) {
+      val parsed = ServeOverrides.parse(bad)
+      assertTrue(parsed is OverrideParse.Invalid, "expected Invalid for $bad, got $parsed")
+      assertTrue(parsed.message.isNotBlank())
+    }
+  }
+
+  @Test
+  fun `cache key differs when a knob value changes`() {
+    val a = ok(mapOf("knob.label" to "string:Tap me"))
+    val b = ok(mapOf("knob.label" to "string:Press me"))
+    assertNotEquals(
+      ServeOverrides.cacheKey("preview.A", a),
+      ServeOverrides.cacheKey("preview.A", b),
+    )
+  }
+
+  @Test
+  fun `cache key is knob-order independent`() {
+    val a = ok(mapOf("knob.label" to "string:Hi", "knob.count" to "int:2"))
+    val b = ok(mapOf("knob.count" to "int:2", "knob.label" to "string:Hi"))
+    assertEquals(ServeOverrides.cacheKey("preview.A", a), ServeOverrides.cacheKey("preview.A", b))
   }
 
   @Test

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
@@ -150,6 +150,16 @@ a:hover { text-decoration: underline; }
     var q = "token=" + encodeURIComponent(token);
     if (session) q += "&session=" + encodeURIComponent(session);
     Object.keys(o).forEach(function (k) { q += "&" + k + "=" + encodeURIComponent(o[k]); });
+    // Author-declared knobs (enabled only on a daemon session): knob.<key>=<kind>:<value>.
+    document.querySelectorAll(".cp-knob").forEach(function (el) {
+      if (el.disabled) return;
+      var key = el.getAttribute("data-knob-key");
+      var kind = el.getAttribute("data-knob-kind") || "string";
+      if (!key) return;
+      var val = (el.type === "checkbox") ? (el.checked ? "true" : "false") : el.value;
+      if (val === "") return;
+      q += "&knob." + encodeURIComponent(key) + "=" + encodeURIComponent(kind + ":" + val);
+    });
     return q;
   }
   function refreshSnapshot() {
@@ -365,6 +375,10 @@ a:hover { text-decoration: underline; }
   fields.forEach(function (f) {
     var el = document.getElementById("cp-" + f);
     if (el) el.addEventListener("change", onControlsChanged);
+  });
+  // Author-declared knobs re-render on edit (text/number debounce via "input", toggles "change").
+  document.querySelectorAll(".cp-knob").forEach(function (el) {
+    el.addEventListener(el.type === "checkbox" ? "change" : "input", onControlsChanged);
   });
   refreshSnapshot();
 })();</script>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
@@ -150,6 +150,16 @@ a:hover { text-decoration: underline; }
     var q = "token=" + encodeURIComponent(token);
     if (session) q += "&session=" + encodeURIComponent(session);
     Object.keys(o).forEach(function (k) { q += "&" + k + "=" + encodeURIComponent(o[k]); });
+    // Author-declared knobs (enabled only on a daemon session): knob.<key>=<kind>:<value>.
+    document.querySelectorAll(".cp-knob").forEach(function (el) {
+      if (el.disabled) return;
+      var key = el.getAttribute("data-knob-key");
+      var kind = el.getAttribute("data-knob-kind") || "string";
+      if (!key) return;
+      var val = (el.type === "checkbox") ? (el.checked ? "true" : "false") : el.value;
+      if (val === "") return;
+      q += "&knob." + encodeURIComponent(key) + "=" + encodeURIComponent(kind + ":" + val);
+    });
     return q;
   }
   function refreshSnapshot() {
@@ -365,6 +375,10 @@ a:hover { text-decoration: underline; }
   fields.forEach(function (f) {
     var el = document.getElementById("cp-" + f);
     if (el) el.addEventListener("change", onControlsChanged);
+  });
+  // Author-declared knobs re-render on edit (text/number debounce via "input", toggles "change").
+  document.querySelectorAll(".cp-knob").forEach(function (el) {
+    el.addEventListener(el.type === "checkbox" ? "change" : "input", onControlsChanged);
   });
   refreshSnapshot();
 })();</script>


### PR DESCRIPTION
## Summary

Wires the viewer's override controls to the daemon's named-override planner, so editing a preview's **declared knob** (e.g. a component's label or count) re-renders the composable for real — answering "do overrides work? changing the label?".

Knobs are live **only on daemon-backed sessions** (your own `--module`, a project `--revisions` session, or a `--allow-render-trusted` catalog). Static catalog bundles and the in-browser Wasm tier still ignore knobs and keep their controls disabled, consistent with the earlier control-gating work.

### Changes
- **`ServeOverrides`** — parses `knob.<wireKey>=<kind>:<value>` query params into `PreviewOverrides.namedOverrides` (kinds `string`/`int`/`float`/`bool`/`color`, mirroring `PreviewOverrideValue`). A malformed typed value (`int:three`, missing `kind:`, unknown kind) is a hard `OverrideParse.Invalid` rather than a silently-dropped edit, matching the numeric fields. Named overrides participate in the render `cacheKey` (sorted by key) so a knob edit isn't coalesced onto the prior render.
- **`ServeWeb`** — `overrideKnobsHtml` enables the declared-knob inputs when `canApplyOverrides`, tags each with `class="cp-knob" data-knob-key data-knob-kind` (bool → checkbox), and the viewer `query()` collects them into `knob.<key>=<kind>:<value>` with change/input listeners so an edit triggers a re-render.
- Tests + regenerated viewer fixtures.

The wire format is `knob.<wireKey>=<kind>:<value>`, where `wireKey` is the declaration key (indexed knobs use `key[index]`). The WS live-override path is unchanged; this PR covers the snapshot (`/render`) path only.

## Test plan
- `:cli:test --tests '*ServeOverridesTest*'` — added cases: each kind parses to the right `PreviewOverrideValue`; `bool:1`/`bool:0`; indexed `rowLabel[2]`; blank key/value ignored; malformed values → `Invalid`; cache key changes on knob-value change and is knob-order-independent.
- `:cli:test --tests '*serve*'` green; viewer/wasm-viewer HTML fixtures regenerated (`UPDATE_SERVE_WEB_FIXTURES=true`).
- `:cli:compileKotlin` + `:cli:ktfmtFormat` clean.

No visual change to rendered previews: the test fixtures declare no knobs, so `overrideKnobsHtml` emits nothing for them — only the embedded viewer JS changed (collecting `.cp-knob` controls). The live behaviour is the daemon re-rendering a component when its declared label/count is edited.

---
_Generated by [Claude Code](https://claude.ai/code/session_01K8nJEfEYGM3ijyoAXDNLGH)_