### PR TITLE
fix(samples): opt in to ExperimentalRotateToLookAtUserApi in xr-spatial test

### DIFF
--- a/samples/xr-spatial/src/test/kotlin/com/example/samplexrspatial/RotateToLookAtUserPoseTest.kt
+++ b/samples/xr-spatial/src/test/kotlin/com/example/samplexrspatial/RotateToLookAtUserPoseTest.kt
@@ -1,3 +1,8 @@
+// rotateToLookAtUser was marked @ExperimentalRotateToLookAtUserApi (opt-in, error-level) in
+// androidx.xr.compose 1.0.0-alpha15; this test exercises it, so opt in file-wide rather than at
+// each call site (mirrors XrModifierPreviews.kt).
+@file:OptIn(ExperimentalRotateToLookAtUserApi::class)
+
 package com.example.samplexrspatial
 
 import android.content.Context
@@ -9,6 +14,7 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.xr.compose.spatial.Subspace
 import androidx.xr.compose.subspace.SpatialBox
 import androidx.xr.compose.subspace.SpatialPanel
+import androidx.xr.compose.subspace.layout.ExperimentalRotateToLookAtUserApi
 import androidx.xr.compose.subspace.layout.SubspaceModifier
 import androidx.xr.compose.subspace.layout.height
 import androidx.xr.compose.subspace.layout.offset


### PR DESCRIPTION
## Summary

The **`compose-preview` render pipeline has been failing on every PR and every `main` commit** (it's red on the release-only commits #2110/#2117/#2118 too), which is why the "Apply compose-preview" check kept coming back as `rc=2`. Root cause from the failing job log:

```
e: …/samples/xr-spatial/src/test/kotlin/com/example/samplexrspatial/RotateToLookAtUserPoseTest.kt:126:82 This is an experimental API…
e: …/RotateToLookAtUserPoseTest.kt:136:16 This is an experimental API…
FAILURE: Build failed with an exception. (BuildToolsApiCompilationWork)
```

`rotateToLookAtUser` became `@ExperimentalRotateToLookAtUserApi` (opt-in, **error-level**) in androidx.xr.compose 1.0.0-alpha15. PR #2114 added the file-wide opt-in to the *main* previews file (`XrModifierPreviews.kt`), but the **test** `RotateToLookAtUserPoseTest.kt` calls the same modifier (lines 126/136) without opt-in — so its source failed to compile and took the whole render (compose/resources/a11y all `Render failed`) down with it.

This adds the same `@file:OptIn(ExperimentalRotateToLookAtUserApi::class)` + import to the test, mirroring #2114.

## Test plan
- `:samples:xr-spatial:compileDebugUnitTestKotlin` now compiles (was failing). `:samples:xr-spatial:ktfmtFormat` clean.
- The real proof is CI: the **`compose-preview` / Apply compose-preview** check should go green on this PR for the first time in a while (and start producing visual diffs again).

Text-only change (a test-source opt-in annotation) — it doesn't alter any rendered `@Preview` output; it just lets the module compile so the render pipeline runs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01K8nJEfEYGM3ijyoAXDNLGH)_