### PR TITLE
fix(deploy): move Watchtower to maintained fork

### DIFF
--- a/deploy/image/README.md
+++ b/deploy/image/README.md
@@ -57,9 +57,10 @@ Pin a version with `IMAGE_TAG=0.16.5` in `.env` (a bare tag; defaults to the
 
 ## Auto-updates (Watchtower)
 
-`docker-compose.yml` includes a [Watchtower](https://containrrr.dev/watchtower/)
-service that **watches the `:latest` tag and updates the `preview` container when a
-new release image is published** — so the chain is hands-off:
+`docker-compose.yml` includes a
+[Watchtower](https://github.com/nicholas-fedor/watchtower) service that **watches the
+`:latest` tag and updates the `preview` container when a new release image is
+published** — so the chain is hands-off:
 
 > merge → cut a `v*` release → `preview-host-image.yml` publishes `:latest` →
 > Watchtower pulls it → server updates
@@ -67,6 +68,14 @@ new release image is published** — so the chain is hands-off:
 It polls hourly (`--interval 3600`), is scoped to the labelled `preview` service
 (`--label-enable`, so it leaves Caddy alone), and `--cleanup` prunes the old image.
 It needs the Docker socket (root-equivalent on the host — fine for your own box).
+
+> **Image:** this uses the maintained
+> [`nicholas-fedor/watchtower`](https://github.com/nicholas-fedor/watchtower) fork,
+> pinned by tag+digest. The original `containrrr/watchtower` is effectively
+> unmaintained and its baked Docker SDK negotiates API 1.25, which modern engines
+> reject (`client version 1.25 is too old. Minimum supported API version is 1.40`) —
+> so it silently never updates. Bump the tag **and** digest together to adopt a newer
+> release.
 
 Requirements / options:
 - **Leave `IMAGE_TAG` unset (it defaults to the `latest` tag)** — Watchtower only

--- a/deploy/image/docker-compose.yml
+++ b/deploy/image/docker-compose.yml
@@ -52,7 +52,12 @@ services:
   # updates manually (docker compose pull && up -d). For a private GHCR package, mount
   # a registry config: `- ~/.docker/config.json:/config.json:ro`. See README.md.
   watchtower:
-    image: containrrr/watchtower
+    # Maintained fork of the (now-stale) containrrr/watchtower: the upstream image's
+    # baked Docker SDK negotiates API 1.25, which modern engines reject ("client
+    # version 1.25 is too old. Minimum supported API version is 1.40"), so it silently
+    # never updates anything. The fork is rebuilt against a current SDK. Pinned by
+    # tag+digest; bump both together when adopting a newer release.
+    image: ghcr.io/nicholas-fedor/watchtower:1.19.0@sha256:c1dfdf27fe805dcfefe1cf048cee6960a511c097a99aa355b0bc4be6e6bb3bdf
     restart: always
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
## Summary

The `watchtower` service on the preview host has been silently failing to auto-update the `preview` container. Its logs are nothing but:

```
level=error msg="Error response from daemon: client version 1.25 is too old. Minimum supported API version is 1.40, please upgrade your client to a newer version"
```

The original `containrrr/watchtower` image is effectively unmaintained and its baked Docker SDK negotiates **API 1.25**, which modern Docker engines reject (minimum **1.40**). It never gets past the handshake, so the release → `:latest` → auto-update chain has been dead.

This swaps it for the actively-maintained [`nicholas-fedor/watchtower`](https://github.com/nicholas-fedor/watchtower) fork (rebuilt against a current Docker SDK), pinned by **tag + digest** (`1.19.0@sha256:c1dfdf…`). README's Watchtower section is updated to point at the fork and explain the pin / the API-version failure mode.

## Changes
- `deploy/image/docker-compose.yml` — `watchtower.image` → `ghcr.io/nicholas-fedor/watchtower:1.19.0@sha256:c1dfdf27fe805dcfefe1cf048cee6960a511c097a99aa355b0bc4be6e6bb3bdf`, with an inline comment on why.
- `deploy/image/README.md` — link + note: maintained fork, pinned by tag+digest, bump both together.

## Test plan
- Config-only change; no app code touched. On the host: `docker compose pull && docker compose up -d watchtower`, then `docker logs image-watchtower-1` should show a clean session (`Checking all containers…` / `Found … to update`) with **no** "client version 1.25 is too old" errors.
- A one-time `docker compose pull && docker compose up -d` is worth running to catch `preview` up, since auto-updates have been stalled.

Non-visual (deploy infra), so no rendered evidence.


---
_Generated by [Claude Code](https://claude.ai/code/session_01K8nJEfEYGM3ijyoAXDNLGH)_