### PR TITLE
fix(serve): font-scale/theme/locale controls work on first interaction on catalog pages

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -562,6 +562,15 @@ object ServeWeb {
         if (wasmActive()) { wasmFrame.src = wasmUrl(); return; }
         if (live.checked && ws && ws.readyState === 1) {
           ws.send(JSON.stringify({ type: "setOverrides", overrides: overrides() }));
+        } else if (live.disabled && wasmToggle) {
+          // Static snapshot backed by a Wasm app: the baked PNG can't honour theme/font-scale/locale
+          // (only the in-browser tier can), and /render can't re-render a published catalog. So a
+          // wasm-honoured control change auto-enables the Wasm tier and applies there, instead of
+          // firing a dead refreshSnapshot the user sees as "the control does nothing". (live.disabled
+          // marks a non-renderable session; device/orientation stay disabled, so only the
+          // wasm-honoured controls reach here.)
+          wasmToggle.checked = true;
+          openWasm();
         } else if (!live.checked) {
           refreshSnapshot();
         }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -214,6 +214,12 @@ class ServeWebFixtureTest {
       "font scale forwarded to Wasm",
     )
     assertTrue(wasmView.contains("u.searchParams.set(\"localeTag\""), "locale forwarded to Wasm")
+    // On a static snapshot, a wasm-honoured control change auto-enables the Wasm tier (rather than
+    // firing a /render the published catalog can't serve), so the control actually takes effect.
+    assertTrue(
+      wasmView.contains("else if (live.disabled && wasmToggle) {"),
+      "static-snapshot wasm controls auto-enable the in-browser tier",
+    )
 
     // Live daemon session (canApplyOverrides = true): everything enabled, no note.
     val liveView = ServeWeb.viewerPage(previews.first(), token, canApplyOverrides = true)

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
@@ -348,6 +348,15 @@ a:hover { text-decoration: underline; }
     if (wasmActive()) { wasmFrame.src = wasmUrl(); return; }
     if (live.checked && ws && ws.readyState === 1) {
       ws.send(JSON.stringify({ type: "setOverrides", overrides: overrides() }));
+    } else if (live.disabled && wasmToggle) {
+      // Static snapshot backed by a Wasm app: the baked PNG can't honour theme/font-scale/locale
+      // (only the in-browser tier can), and /render can't re-render a published catalog. So a
+      // wasm-honoured control change auto-enables the Wasm tier and applies there, instead of
+      // firing a dead refreshSnapshot the user sees as "the control does nothing". (live.disabled
+      // marks a non-renderable session; device/orientation stay disabled, so only the
+      // wasm-honoured controls reach here.)
+      wasmToggle.checked = true;
+      openWasm();
     } else if (!live.checked) {
       refreshSnapshot();
     }

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
@@ -348,6 +348,15 @@ a:hover { text-decoration: underline; }
     if (wasmActive()) { wasmFrame.src = wasmUrl(); return; }
     if (live.checked && ws && ws.readyState === 1) {
       ws.send(JSON.stringify({ type: "setOverrides", overrides: overrides() }));
+    } else if (live.disabled && wasmToggle) {
+      // Static snapshot backed by a Wasm app: the baked PNG can't honour theme/font-scale/locale
+      // (only the in-browser tier can), and /render can't re-render a published catalog. So a
+      // wasm-honoured control change auto-enables the Wasm tier and applies there, instead of
+      // firing a dead refreshSnapshot the user sees as "the control does nothing". (live.disabled
+      // marks a non-renderable session; device/orientation stay disabled, so only the
+      // wasm-honoured controls reach here.)
+      wasmToggle.checked = true;
+      openWasm();
     } else if (!live.checked) {
       refreshSnapshot();
     }


### PR DESCRIPTION
## Summary

On a public catalog page (e.g. `preview.coo.ee/p/…?session=compose-m3`), the **Font scale** slider (and Theme / Locale) appeared to do nothing. The page is a pre-rendered snapshot of a published catalog (`canApplyOverrides=false`) backed by a Wasm app, so those controls are *enabled* (the in-browser Wasm tier can honour them) — but moving one routed through `onControlsChanged → refreshSnapshot()`, which rebuilds a `/render/<id>.png` request the **static catalog can't serve**. So the control silently no-op'd until the user separately ticked **"Run in browser (Wasm)"**.

This routes a wasm-honoured control change on a non-renderable session straight to the in-browser tier: it auto-ticks the Wasm toggle and re-points the iframe, so font scale / theme / locale take effect on the **first** interaction.

```js
} else if (live.disabled && wasmToggle) {   // static catalog + Wasm app
  wasmToggle.checked = true; openWasm();     // drive the in-browser tier instead of a dead /render
}
```

`live.disabled` marks a non-renderable (published-catalog) session; device/orientation are server-render-only and stay disabled, so only the wasm-honoured controls reach this branch. Live daemon sessions (`canApplyOverrides=true`) and plain snapshots with no Wasm app are unaffected.

I confirmed the deployed `compose-m3` Wasm bundle already honours `?fontScale` (`CatalogApp` re-points `Density(fontScale=…)`), so this is purely the viewer wiring — no catalog regeneration needed.

## Changes
- `cli/.../serve/ServeWeb.kt` — `onControlsChanged` auto-enables the Wasm tier for static-snapshot sessions that have a Wasm app.
- `cli/.../serve/ServeWebFixtureTest.kt` — assert the auto-enable branch is emitted for a wasm-backed viewer.
- `vscode-extension/preview-harness/fixtures/pages/serve-viewer{,-wasm}.html` — regenerated golden fixtures.

## Test plan
- `./gradlew :cli:test --tests '*ServeWebFixtureTest*'` — **passing locally** (golden fixtures + the new behavioural assertion).
- Manual: open a `?session=compose-m3` preview, move the Font scale slider → the component now re-renders scaled immediately (previously: no change until "Run in browser (Wasm)" was ticked).

## Visual evidence
No static pixel change: the page chrome is byte-identical (the regenerated golden fixtures differ only in the embedded `<script>` JS, which the visual-diff harness screenshots identically). The payoff is *dynamic* — the in-browser Wasm component re-rendering at the chosen font scale — which the static `@Preview` PNG pipeline can't capture, and which only manifests once this build is deployed to the public server. Verified instead by the `ServeWebFixtureTest` assertion above and the manual step. The destination tier's font-scale support is pre-existing (`CatalogApp`/`Density(fontScale=…)`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01K8nJEfEYGM3ijyoAXDNLGH)_