### PR TITLE
fix(serve): preserve the baked variant theme when opening the Wasm tier

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -393,16 +393,12 @@ class ServeHttpServer(
               return@withLeasedSession
             }
             // Offer the in-browser Wasm tier when this catalog session has a Wasm app registered.
-            // The catalog preview id is `<component-slug>__<variant>…`; the Wasm app keys its
-            // registry by the component slug, so take the segment before the first `__`.
+            // ServeUrls.wasmAppSrc strips the variant to the component slug the Wasm registry keys
+            // by, and bakes the variant's theme into `uiMode` so the live render opens on the same
+            // theme as the baked snapshot the visitor deep-linked to.
             val wasmSrc =
-              if (wasmCatalogs.containsKey(sessionId)) {
-                val componentId = preview.id.substringBefore("__")
-                "/wasm/${WebEscaping.urlEncodeSegment(sessionId)}/" +
-                  "?id=${WebEscaping.urlEncodeSegment(componentId)}"
-              } else {
-                null
-              }
+              if (wasmCatalogs.containsKey(sessionId)) ServeUrls.wasmAppSrc(sessionId, preview.id)
+              else null
             call.respondText(
               ServeWeb.viewerPage(
                 preview,

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeUrls.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeUrls.kt
@@ -51,6 +51,26 @@ object ServeUrls {
     "$origin/p/${WebEscaping.urlEncodeSegment(previewId)}?token=${WebEscaping.urlEncodeSegment(token)}"
 
   /**
+   * Relative src for the in-browser Wasm app backing a catalog [previewId] in [system]
+   * (`/wasm/<system>/?id=<component>[&uiMode=<theme>]`). The catalog preview id is
+   * `<component-slug>__<axis>…` and the Wasm app keys its component registry by the slug, so the
+   * variant is stripped for `id`. The variant's M3 theme **is** forwarded as `uiMode`, though: the
+   * app defaults to light, so without it a deep link to a `…__dark` snapshot would flip to light
+   * the moment the viewer hands the render to the in-browser tier (e.g. on a font-scale change).
+   * The theme axis surfaces as a `light`/`dark` segment; absent one, no `uiMode` is forced and the
+   * app uses its own default. The viewer's Theme control still overrides this when set.
+   */
+  fun wasmAppSrc(system: String, previewId: String): String {
+    val component = previewId.substringBefore("__")
+    val theme = previewId.split("__").drop(1).lastOrNull { it == "light" || it == "dark" }
+    return buildString {
+      append("/wasm/").append(WebEscaping.urlEncodeSegment(system)).append("/?id=")
+      append(WebEscaping.urlEncodeSegment(component))
+      if (theme != null) append("&uiMode=").append(theme)
+    }
+  }
+
+  /**
    * Render (PNG) URL for one preview at the given overrides. [overrides] is an already-validated
    * map of `ServeOverrides.SUPPORTED_KEYS` → value; the token and each value are percent-encoded.
    */

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeUrlsTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeUrlsTest.kt
@@ -56,4 +56,23 @@ class ServeUrlsTest {
     // Blank override values are dropped.
     assertFalse("device=" in render, render)
   }
+
+  @Test
+  fun `wasm app src strips the variant to the component slug but bakes its theme`() {
+    // The Wasm registry keys by component slug, so the variant is dropped from `id` — but the
+    // variant's theme rides along as uiMode so the in-browser app opens on the same theme as the
+    // baked snapshot (the app itself defaults to light).
+    assertEquals(
+      "/wasm/compose-m3/?id=button-filled&uiMode=dark",
+      ServeUrls.wasmAppSrc("compose-m3", "button-filled__ideal__default__dark"),
+    )
+    assertEquals(
+      "/wasm/compose-m3/?id=button-filled&uiMode=light",
+      ServeUrls.wasmAppSrc("compose-m3", "button-filled__ideal__default__light"),
+    )
+    // No theme axis → no uiMode forced (the app uses its own default).
+    assertEquals("/wasm/wear-m3/?id=chip", ServeUrls.wasmAppSrc("wear-m3", "chip__compact"))
+    // A bare component id (no variant) is passed through unchanged.
+    assertEquals("/wasm/compose-m3/?id=switch", ServeUrls.wasmAppSrc("compose-m3", "switch"))
+  }
 }


### PR DESCRIPTION
## Summary

Follow-up to #2123, addressing the Codex review on that PR (the fix landed locally just after #2123 was merged, so it needs its own PR).

A catalog deep link to a **dark** variant (e.g. `button-filled-focused__ideal__default__dark`) shows a dark baked snapshot, but the in-browser Wasm app keys its component registry by the slug only (`?id=button-filled-focused`) and **defaults to light**. So when the viewer hands the render to the Wasm tier with the Theme select still at "(default)", the preview flipped from dark → light. #2123 made this more visible by auto-opening Wasm on a font-scale change, but it also affects the pre-existing manual "Run in browser (Wasm)" toggle on `main` today.

Fix: bake the variant's theme into the wasm app `src` as `uiMode` at the server (`ServeUrls.wasmAppSrc`), so the in-browser render opens on the same theme as the snapshot. `wasmUrl()` already preserves an existing `uiMode` unless the user explicitly picks a theme, so the Theme control still overrides it.

## Changes
- `cli/.../serve/ServeUrls.kt` — new `wasmAppSrc(system, previewId)`: strips the variant to the component slug for `?id=`, and forwards the variant's `light`/`dark` theme axis as `&uiMode=`. No theme segment → no `uiMode` forced.
- `cli/.../serve/ServeHttpServer.kt` — the `/p/` route builds `wasmSrc` via the helper instead of inline.
- `cli/.../serve/ServeUrlsTest.kt` — covers dark/light/no-theme/bare-id.

## Test plan
- `./gradlew :cli:test --tests '*ServeUrlsTest*' --tests '*ServeWebFixtureTest*'` — **passing locally**.
- Manual: open a `?session=compose-m3` dark-variant preview, tick "Run in browser (Wasm)" (or just move Font scale) → the in-browser render stays dark instead of flipping to light.

## Visual evidence
No static pixel change — this only affects the query string of the sandboxed Wasm iframe (`data-wasm-src`), so the page chrome the visual-diff harness screenshots is unchanged. The payoff (the in-browser render keeping the dark theme) is dynamic and only manifests once deployed; verified by the `ServeUrlsTest` cases and the manual step above.


---
_Generated by [Claude Code](https://claude.ai/code/session_01K8nJEfEYGM3ijyoAXDNLGH)_