### PR TITLE
feat(serve): recompose the Wasm tier in place instead of reloading the iframe

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -560,26 +560,21 @@ object ServeWeb {
       // then a control change re-points ?query (initial load); after, it posts an override patch so
       // the app recomposes in place instead of reloading the whole ~20 MB Wasm bundle.
       var wasmReady = false;
-      function wasmUrl() {
+      function wasmBaseSrc() {
         if (!wasmSrc) return "";
         // The src comes from a server-set data- attribute, but resolve it against our own origin and
         // refuse anything not same-origin http(s) anyway — so a `javascript:`/`data:` URL can never
-        // reach the iframe even if the attribute were ever mis-set (defuses DOM-text-as-HTML).
+        // reach the iframe even if the attribute were ever mis-set (defuses DOM-text-as-HTML). The
+        // query is left as the server baked it (the variant's default theme) — session overrides
+        // never go in it, so it stays the app's clean base to revert to when a control is cleared.
         var u;
         try { u = new URL(wasmSrc, location.origin); } catch (e) { return ""; }
         if (u.origin !== location.origin) return "";
-        var el = document.getElementById("cp-uiMode");
-        if (el && el.value) u.searchParams.set("uiMode", el.value);
-        // The Wasm app also honours font scale (density) + locale (layout direction); device /
-        // orientation are server-render-only, so they're not forwarded.
-        var loc = document.getElementById("cp-localeTag");
-        if (loc && loc.value) u.searchParams.set("localeTag", loc.value);
-        if (fontScaleTouched && fs) u.searchParams.set("fontScale", fs.value);
         return u.href;
       }
-      // The override patch (theme / font scale / locale) the running app merges over its load-time
-      // params — the same fields wasmUrl() re-points, as a bare `a=b&c=d` query with no base. An
-      // absent key falls back to the app's baked default (e.g. cleared Theme → the variant's uiMode).
+      // The override patch (theme / font scale / locale) the running app merges over its baked base —
+      // a bare `a=b&c=d` query. An absent key falls back to the app's baked default (e.g. cleared
+      // Theme → the variant's uiMode). Device / orientation are server-render-only, so not forwarded.
       function wasmOverridePatch() {
         var parts = [];
         var el = document.getElementById("cp-uiMode");
@@ -589,13 +584,21 @@ object ServeWeb {
         if (fontScaleTouched && fs) parts.push("fontScale=" + encodeURIComponent(fs.value));
         return parts.join("&");
       }
+      // Initial iframe URL: the baked base plus the current overrides in the `#…` fragment, so the
+      // app's first paint honours them yet keeps the query as its true base (a later clear reverts).
+      function wasmInitialSrc() {
+        var base = wasmBaseSrc();
+        if (!base) return "";
+        var patch = wasmOverridePatch();
+        return patch ? base + "#" + patch : base;
+      }
       function openWasm() {
         // Wasm and the daemon stream are mutually exclusive — only one transport drives the stage.
         if (live.checked) { live.checked = false; closeStream(); }
         root.setAttribute("data-mode", "wasm");
         img.hidden = true; canvas.hidden = true; wasmFrame.hidden = false;
         wasmReady = false;
-        wasmFrame.src = wasmUrl();
+        wasmFrame.src = wasmInitialSrc();
         status.textContent = "";
       }
       function closeWasm() {
@@ -608,11 +611,12 @@ object ServeWeb {
 
       function onControlsChanged() {
         if (wasmActive()) {
-          // Recompose in place once the app is up; only fall back to a src reload before it's ready.
+          // Recompose in place once the app is up; before it's ready, re-point the initial src (the
+          // fragment carries the overrides) — the load handler re-syncs the final state either way.
           if (wasmReady && wasmFrame.contentWindow) {
             wasmFrame.contentWindow.postMessage(wasmOverridePatch(), "*");
           } else {
-            wasmFrame.src = wasmUrl();
+            wasmFrame.src = wasmInitialSrc();
           }
           return;
         }
@@ -645,7 +649,12 @@ object ServeWeb {
         });
         // The app registers its message listener during startup; mark ready on iframe load so
         // subsequent control changes recompose in place rather than reloading the bundle.
-        wasmFrame.addEventListener("load", function () { wasmReady = true; });
+        wasmFrame.addEventListener("load", function () {
+          wasmReady = true;
+          // Re-sync any control changed during load (the fragment only captured open-time state).
+          var patch = wasmOverridePatch();
+          if (patch) wasmFrame.contentWindow.postMessage(patch, "*");
+        });
       }
       if (fs) {
         fs.addEventListener("input", function () {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -556,6 +556,10 @@ object ServeWeb {
       var wasmFrame = document.getElementById("cp-wasm");
       var wasmToggle = document.getElementById("cp-wasm-toggle");
       var wasmSrc = root.getAttribute("data-wasm-src") || "";
+      // Set once the iframe's Wasm app has loaded and registered its postMessage listener. Until
+      // then a control change re-points ?query (initial load); after, it posts an override patch so
+      // the app recomposes in place instead of reloading the whole ~20 MB Wasm bundle.
+      var wasmReady = false;
       function wasmUrl() {
         if (!wasmSrc) return "";
         // The src comes from a server-set data- attribute, but resolve it against our own origin and
@@ -573,23 +577,45 @@ object ServeWeb {
         if (fontScaleTouched && fs) u.searchParams.set("fontScale", fs.value);
         return u.href;
       }
+      // The override patch (theme / font scale / locale) the running app merges over its load-time
+      // params — the same fields wasmUrl() re-points, as a bare `a=b&c=d` query with no base. An
+      // absent key falls back to the app's baked default (e.g. cleared Theme → the variant's uiMode).
+      function wasmOverridePatch() {
+        var parts = [];
+        var el = document.getElementById("cp-uiMode");
+        if (el && el.value) parts.push("uiMode=" + encodeURIComponent(el.value));
+        var loc = document.getElementById("cp-localeTag");
+        if (loc && loc.value) parts.push("localeTag=" + encodeURIComponent(loc.value));
+        if (fontScaleTouched && fs) parts.push("fontScale=" + encodeURIComponent(fs.value));
+        return parts.join("&");
+      }
       function openWasm() {
         // Wasm and the daemon stream are mutually exclusive — only one transport drives the stage.
         if (live.checked) { live.checked = false; closeStream(); }
         root.setAttribute("data-mode", "wasm");
         img.hidden = true; canvas.hidden = true; wasmFrame.hidden = false;
+        wasmReady = false;
         wasmFrame.src = wasmUrl();
         status.textContent = "";
       }
       function closeWasm() {
         root.setAttribute("data-mode", "snapshot");
+        wasmReady = false;
         wasmFrame.hidden = true; wasmFrame.removeAttribute("src");
         img.hidden = false;
       }
       function wasmActive() { return wasmToggle && wasmToggle.checked; }
 
       function onControlsChanged() {
-        if (wasmActive()) { wasmFrame.src = wasmUrl(); return; }
+        if (wasmActive()) {
+          // Recompose in place once the app is up; only fall back to a src reload before it's ready.
+          if (wasmReady && wasmFrame.contentWindow) {
+            wasmFrame.contentWindow.postMessage(wasmOverridePatch(), "*");
+          } else {
+            wasmFrame.src = wasmUrl();
+          }
+          return;
+        }
         if (live.checked && ws && ws.readyState === 1) {
           ws.send(JSON.stringify({ type: "setOverrides", overrides: overrides() }));
         } else if (live.disabled && wasmToggle) {
@@ -617,6 +643,9 @@ object ServeWeb {
           if (wasmToggle.checked) openWasm();
           else { closeWasm(); refreshSnapshot(); }
         });
+        // The app registers its message listener during startup; mark ready on iframe load so
+        // subsequent control changes recompose in place rather than reloading the bundle.
+        wasmFrame.addEventListener("load", function () { wasmReady = true; });
       }
       if (fs) {
         fs.addEventListener("input", function () {

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -283,12 +283,10 @@ class ServeWebFixtureTest {
     assertTrue(wasmView.contains("autocomplete=\"off\">"), "locale enabled with a Wasm app")
     assertTrue(wasmView.contains("id=\"cp-device\" disabled"), "device stays server-only")
     assertTrue(wasmView.contains("id=\"cp-orientation\" disabled"), "orientation stays server-only")
-    // The Wasm iframe URL builder forwards the honoured params (theme/font scale/locale).
-    assertTrue(
-      wasmView.contains("u.searchParams.set(\"fontScale\""),
-      "font scale forwarded to Wasm",
-    )
-    assertTrue(wasmView.contains("u.searchParams.set(\"localeTag\""), "locale forwarded to Wasm")
+    // The Wasm override-patch builder forwards the honoured params (theme/font scale/locale) to the
+    // running app (via postMessage / the initial `#…` fragment), not the iframe query.
+    assertTrue(wasmView.contains("\"fontScale=\""), "font scale forwarded to Wasm")
+    assertTrue(wasmView.contains("\"localeTag=\""), "locale forwarded to Wasm")
     // On a static snapshot, a wasm-honoured control change auto-enables the Wasm tier (rather than
     // firing a /render the published catalog can't serve), so the control actually takes effect.
     assertTrue(

--- a/samples/cmp-wasm-catalog/src/wasmJsMain/kotlin/com/example/cmpwasmcatalog/Main.kt
+++ b/samples/cmp-wasm-catalog/src/wasmJsMain/kotlin/com/example/cmpwasmcatalog/Main.kt
@@ -32,8 +32,13 @@ private var baseParams: Map<String, String> = emptyMap()
 private val renderParams = mutableStateOf<Map<String, String>>(emptyMap())
 
 fun main() {
+  // The `?…` query is the clean baked default (the viewer's `data-wasm-src`); the viewer carries
+  // its
+  // initial session overrides in the `#…` fragment instead, so [baseParams] stays the true default
+  // and clearing a control later (an empty [applyOverrides] patch) reverts to it rather than
+  // sticking.
   baseParams = parseQuery(locationSearch())
-  renderParams.value = baseParams
+  renderParams.value = baseParams + parseQuery(locationHash())
   ComposeViewport(viewportContainerId = "composeApp") {
     val params by renderParams
     val id = params["id"] ?: catalogComponents.keys.first()
@@ -68,6 +73,9 @@ internal fun isRtlLocale(localeTag: String?): Boolean {
 
 /** The raw `?…` query string, read straight from the browser's `window.location`. */
 private fun locationSearch(): String = js("window.location.search")
+
+/** The `#…` fragment without its leading `#` — the viewer's initial session overrides at load. */
+private fun locationHash(): String = js("window.location.hash.replace(/^#/, '')")
 
 /** Minimal `?a=b&c=d` parser — avoids a `kotlinx-browser` / URLSearchParams dependency. */
 internal fun parseQuery(search: String): Map<String, String> {

--- a/samples/cmp-wasm-catalog/src/wasmJsMain/kotlin/com/example/cmpwasmcatalog/Main.kt
+++ b/samples/cmp-wasm-catalog/src/wasmJsMain/kotlin/com/example/cmpwasmcatalog/Main.kt
@@ -1,7 +1,13 @@
-@file:OptIn(ExperimentalComposeUiApi::class, kotlin.js.ExperimentalWasmJsInterop::class)
+@file:OptIn(
+  ExperimentalComposeUiApi::class,
+  kotlin.js.ExperimentalWasmJsInterop::class,
+  kotlin.js.ExperimentalJsExport::class,
+)
 
 package com.example.cmpwasmcatalog
 
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.window.ComposeViewport
 
@@ -14,15 +20,39 @@ import androidx.compose.ui.window.ComposeViewport
  * browser sandbox, so it's safe to execute even for an unverified session (no code runs on our
  * server). The viewer's theme / font-scale / locale controls re-point these params, so they drive
  * the in-browser render live (device/orientation are server-render-only and stay disabled there).
+ *
+ * Those controls update the render **in place** rather than reloading the iframe: the page's
+ * initial query is the [baseParams] floor and [applyOverrides] (called by the embedding viewer via
+ * `postMessage`) merges a `?a=b` patch over it into [renderParams], which recomposes the live tree.
+ * Recomputing from [baseParams] every time means an absent key reverts to the deep-link default
+ * (e.g. clearing the Theme control falls back to the baked variant's `uiMode`), with no full
+ * reload.
  */
+private var baseParams: Map<String, String> = emptyMap()
+private val renderParams = mutableStateOf<Map<String, String>>(emptyMap())
+
 fun main() {
-  val params = parseQuery(locationSearch())
-  val id = params["id"] ?: catalogComponents.keys.first()
-  val dark = params["uiMode"] == "dark"
-  // Clamp to the viewer slider's range so a crafted query can't blow up layout.
-  val fontScale = params["fontScale"]?.toFloatOrNull()?.coerceIn(0.5f, 2.0f) ?: 1f
-  val rtl = isRtlLocale(params["localeTag"])
-  ComposeViewport(viewportContainerId = "composeApp") { CatalogApp(id, dark, fontScale, rtl) }
+  baseParams = parseQuery(locationSearch())
+  renderParams.value = baseParams
+  ComposeViewport(viewportContainerId = "composeApp") {
+    val params by renderParams
+    val id = params["id"] ?: catalogComponents.keys.first()
+    val dark = params["uiMode"] == "dark"
+    // Clamp to the viewer slider's range so a crafted query can't blow up layout.
+    val fontScale = params["fontScale"]?.toFloatOrNull()?.coerceIn(0.5f, 2.0f) ?: 1f
+    val rtl = isRtlLocale(params["localeTag"])
+    CatalogApp(id, dark, fontScale, rtl)
+  }
+}
+
+/**
+ * Apply a live override patch (`?a=b&c=d`, no leading `?`) pushed by the embedding viewer through
+ * `window.postMessage`. Exported to JS so the host page's message listener can forward it; merges
+ * over [baseParams] so absent keys revert to the deep-link defaults, then recomposes in place.
+ */
+@JsExport
+fun applyOverrides(query: String) {
+  renderParams.value = baseParams + parseQuery(query)
 }
 
 /**

--- a/samples/cmp-wasm-catalog/src/wasmJsMain/resources/index.html
+++ b/samples/cmp-wasm-catalog/src/wasmJsMain/resources/index.html
@@ -33,5 +33,20 @@
     <!-- ComposeViewport mounts the catalog component named by ?id=… here. -->
     <div id="composeApp"></div>
     <script type="module" src="composeApp.mjs"></script>
+    <!--
+      Live overrides without an iframe reload: the embedding `serve` viewer posts a `?a=b` override
+      patch (theme / font scale / locale) via postMessage; forward it to the Wasm app's exported
+      `applyOverrides`, which recomposes in place. Importing the same module is a no-op re-use (ES
+      modules are singletons), and the export may not exist until the Wasm instance has initialised,
+      so each message re-checks it. Data is a plain string, so no structured-clone / origin surface.
+    -->
+    <script type="module">
+      import * as catalog from "./composeApp.mjs";
+      window.addEventListener("message", function (e) {
+        if (typeof e.data === "string" && typeof catalog.applyOverrides === "function") {
+          catalog.applyOverrides(e.data);
+        }
+      });
+    </script>
   </body>
 </html>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
@@ -321,26 +321,21 @@ a:hover { text-decoration: underline; }
   // then a control change re-points ?query (initial load); after, it posts an override patch so
   // the app recomposes in place instead of reloading the whole ~20 MB Wasm bundle.
   var wasmReady = false;
-  function wasmUrl() {
+  function wasmBaseSrc() {
     if (!wasmSrc) return "";
     // The src comes from a server-set data- attribute, but resolve it against our own origin and
     // refuse anything not same-origin http(s) anyway — so a `javascript:`/`data:` URL can never
-    // reach the iframe even if the attribute were ever mis-set (defuses DOM-text-as-HTML).
+    // reach the iframe even if the attribute were ever mis-set (defuses DOM-text-as-HTML). The
+    // query is left as the server baked it (the variant's default theme) — session overrides
+    // never go in it, so it stays the app's clean base to revert to when a control is cleared.
     var u;
     try { u = new URL(wasmSrc, location.origin); } catch (e) { return ""; }
     if (u.origin !== location.origin) return "";
-    var el = document.getElementById("cp-uiMode");
-    if (el && el.value) u.searchParams.set("uiMode", el.value);
-    // The Wasm app also honours font scale (density) + locale (layout direction); device /
-    // orientation are server-render-only, so they're not forwarded.
-    var loc = document.getElementById("cp-localeTag");
-    if (loc && loc.value) u.searchParams.set("localeTag", loc.value);
-    if (fontScaleTouched && fs) u.searchParams.set("fontScale", fs.value);
     return u.href;
   }
-  // The override patch (theme / font scale / locale) the running app merges over its load-time
-  // params — the same fields wasmUrl() re-points, as a bare `a=b&c=d` query with no base. An
-  // absent key falls back to the app's baked default (e.g. cleared Theme → the variant's uiMode).
+  // The override patch (theme / font scale / locale) the running app merges over its baked base —
+  // a bare `a=b&c=d` query. An absent key falls back to the app's baked default (e.g. cleared
+  // Theme → the variant's uiMode). Device / orientation are server-render-only, so not forwarded.
   function wasmOverridePatch() {
     var parts = [];
     var el = document.getElementById("cp-uiMode");
@@ -350,13 +345,21 @@ a:hover { text-decoration: underline; }
     if (fontScaleTouched && fs) parts.push("fontScale=" + encodeURIComponent(fs.value));
     return parts.join("&");
   }
+  // Initial iframe URL: the baked base plus the current overrides in the `#…` fragment, so the
+  // app's first paint honours them yet keeps the query as its true base (a later clear reverts).
+  function wasmInitialSrc() {
+    var base = wasmBaseSrc();
+    if (!base) return "";
+    var patch = wasmOverridePatch();
+    return patch ? base + "#" + patch : base;
+  }
   function openWasm() {
     // Wasm and the daemon stream are mutually exclusive — only one transport drives the stage.
     if (live.checked) { live.checked = false; closeStream(); }
     root.setAttribute("data-mode", "wasm");
     img.hidden = true; canvas.hidden = true; wasmFrame.hidden = false;
     wasmReady = false;
-    wasmFrame.src = wasmUrl();
+    wasmFrame.src = wasmInitialSrc();
     status.textContent = "";
   }
   function closeWasm() {
@@ -369,11 +372,12 @@ a:hover { text-decoration: underline; }
 
   function onControlsChanged() {
     if (wasmActive()) {
-      // Recompose in place once the app is up; only fall back to a src reload before it's ready.
+      // Recompose in place once the app is up; before it's ready, re-point the initial src (the
+      // fragment carries the overrides) — the load handler re-syncs the final state either way.
       if (wasmReady && wasmFrame.contentWindow) {
         wasmFrame.contentWindow.postMessage(wasmOverridePatch(), "*");
       } else {
-        wasmFrame.src = wasmUrl();
+        wasmFrame.src = wasmInitialSrc();
       }
       return;
     }
@@ -406,7 +410,12 @@ a:hover { text-decoration: underline; }
     });
     // The app registers its message listener during startup; mark ready on iframe load so
     // subsequent control changes recompose in place rather than reloading the bundle.
-    wasmFrame.addEventListener("load", function () { wasmReady = true; });
+    wasmFrame.addEventListener("load", function () {
+      wasmReady = true;
+      // Re-sync any control changed during load (the fragment only captured open-time state).
+      var patch = wasmOverridePatch();
+      if (patch) wasmFrame.contentWindow.postMessage(patch, "*");
+    });
   }
   if (fs) {
     fs.addEventListener("input", function () {

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
@@ -317,6 +317,10 @@ a:hover { text-decoration: underline; }
   var wasmFrame = document.getElementById("cp-wasm");
   var wasmToggle = document.getElementById("cp-wasm-toggle");
   var wasmSrc = root.getAttribute("data-wasm-src") || "";
+  // Set once the iframe's Wasm app has loaded and registered its postMessage listener. Until
+  // then a control change re-points ?query (initial load); after, it posts an override patch so
+  // the app recomposes in place instead of reloading the whole ~20 MB Wasm bundle.
+  var wasmReady = false;
   function wasmUrl() {
     if (!wasmSrc) return "";
     // The src comes from a server-set data- attribute, but resolve it against our own origin and
@@ -334,23 +338,45 @@ a:hover { text-decoration: underline; }
     if (fontScaleTouched && fs) u.searchParams.set("fontScale", fs.value);
     return u.href;
   }
+  // The override patch (theme / font scale / locale) the running app merges over its load-time
+  // params — the same fields wasmUrl() re-points, as a bare `a=b&c=d` query with no base. An
+  // absent key falls back to the app's baked default (e.g. cleared Theme → the variant's uiMode).
+  function wasmOverridePatch() {
+    var parts = [];
+    var el = document.getElementById("cp-uiMode");
+    if (el && el.value) parts.push("uiMode=" + encodeURIComponent(el.value));
+    var loc = document.getElementById("cp-localeTag");
+    if (loc && loc.value) parts.push("localeTag=" + encodeURIComponent(loc.value));
+    if (fontScaleTouched && fs) parts.push("fontScale=" + encodeURIComponent(fs.value));
+    return parts.join("&");
+  }
   function openWasm() {
     // Wasm and the daemon stream are mutually exclusive — only one transport drives the stage.
     if (live.checked) { live.checked = false; closeStream(); }
     root.setAttribute("data-mode", "wasm");
     img.hidden = true; canvas.hidden = true; wasmFrame.hidden = false;
+    wasmReady = false;
     wasmFrame.src = wasmUrl();
     status.textContent = "";
   }
   function closeWasm() {
     root.setAttribute("data-mode", "snapshot");
+    wasmReady = false;
     wasmFrame.hidden = true; wasmFrame.removeAttribute("src");
     img.hidden = false;
   }
   function wasmActive() { return wasmToggle && wasmToggle.checked; }
 
   function onControlsChanged() {
-    if (wasmActive()) { wasmFrame.src = wasmUrl(); return; }
+    if (wasmActive()) {
+      // Recompose in place once the app is up; only fall back to a src reload before it's ready.
+      if (wasmReady && wasmFrame.contentWindow) {
+        wasmFrame.contentWindow.postMessage(wasmOverridePatch(), "*");
+      } else {
+        wasmFrame.src = wasmUrl();
+      }
+      return;
+    }
     if (live.checked && ws && ws.readyState === 1) {
       ws.send(JSON.stringify({ type: "setOverrides", overrides: overrides() }));
     } else if (live.disabled && wasmToggle) {
@@ -378,6 +404,9 @@ a:hover { text-decoration: underline; }
       if (wasmToggle.checked) openWasm();
       else { closeWasm(); refreshSnapshot(); }
     });
+    // The app registers its message listener during startup; mark ready on iframe load so
+    // subsequent control changes recompose in place rather than reloading the bundle.
+    wasmFrame.addEventListener("load", function () { wasmReady = true; });
   }
   if (fs) {
     fs.addEventListener("input", function () {

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
@@ -321,26 +321,21 @@ a:hover { text-decoration: underline; }
   // then a control change re-points ?query (initial load); after, it posts an override patch so
   // the app recomposes in place instead of reloading the whole ~20 MB Wasm bundle.
   var wasmReady = false;
-  function wasmUrl() {
+  function wasmBaseSrc() {
     if (!wasmSrc) return "";
     // The src comes from a server-set data- attribute, but resolve it against our own origin and
     // refuse anything not same-origin http(s) anyway — so a `javascript:`/`data:` URL can never
-    // reach the iframe even if the attribute were ever mis-set (defuses DOM-text-as-HTML).
+    // reach the iframe even if the attribute were ever mis-set (defuses DOM-text-as-HTML). The
+    // query is left as the server baked it (the variant's default theme) — session overrides
+    // never go in it, so it stays the app's clean base to revert to when a control is cleared.
     var u;
     try { u = new URL(wasmSrc, location.origin); } catch (e) { return ""; }
     if (u.origin !== location.origin) return "";
-    var el = document.getElementById("cp-uiMode");
-    if (el && el.value) u.searchParams.set("uiMode", el.value);
-    // The Wasm app also honours font scale (density) + locale (layout direction); device /
-    // orientation are server-render-only, so they're not forwarded.
-    var loc = document.getElementById("cp-localeTag");
-    if (loc && loc.value) u.searchParams.set("localeTag", loc.value);
-    if (fontScaleTouched && fs) u.searchParams.set("fontScale", fs.value);
     return u.href;
   }
-  // The override patch (theme / font scale / locale) the running app merges over its load-time
-  // params — the same fields wasmUrl() re-points, as a bare `a=b&c=d` query with no base. An
-  // absent key falls back to the app's baked default (e.g. cleared Theme → the variant's uiMode).
+  // The override patch (theme / font scale / locale) the running app merges over its baked base —
+  // a bare `a=b&c=d` query. An absent key falls back to the app's baked default (e.g. cleared
+  // Theme → the variant's uiMode). Device / orientation are server-render-only, so not forwarded.
   function wasmOverridePatch() {
     var parts = [];
     var el = document.getElementById("cp-uiMode");
@@ -350,13 +345,21 @@ a:hover { text-decoration: underline; }
     if (fontScaleTouched && fs) parts.push("fontScale=" + encodeURIComponent(fs.value));
     return parts.join("&");
   }
+  // Initial iframe URL: the baked base plus the current overrides in the `#…` fragment, so the
+  // app's first paint honours them yet keeps the query as its true base (a later clear reverts).
+  function wasmInitialSrc() {
+    var base = wasmBaseSrc();
+    if (!base) return "";
+    var patch = wasmOverridePatch();
+    return patch ? base + "#" + patch : base;
+  }
   function openWasm() {
     // Wasm and the daemon stream are mutually exclusive — only one transport drives the stage.
     if (live.checked) { live.checked = false; closeStream(); }
     root.setAttribute("data-mode", "wasm");
     img.hidden = true; canvas.hidden = true; wasmFrame.hidden = false;
     wasmReady = false;
-    wasmFrame.src = wasmUrl();
+    wasmFrame.src = wasmInitialSrc();
     status.textContent = "";
   }
   function closeWasm() {
@@ -369,11 +372,12 @@ a:hover { text-decoration: underline; }
 
   function onControlsChanged() {
     if (wasmActive()) {
-      // Recompose in place once the app is up; only fall back to a src reload before it's ready.
+      // Recompose in place once the app is up; before it's ready, re-point the initial src (the
+      // fragment carries the overrides) — the load handler re-syncs the final state either way.
       if (wasmReady && wasmFrame.contentWindow) {
         wasmFrame.contentWindow.postMessage(wasmOverridePatch(), "*");
       } else {
-        wasmFrame.src = wasmUrl();
+        wasmFrame.src = wasmInitialSrc();
       }
       return;
     }
@@ -406,7 +410,12 @@ a:hover { text-decoration: underline; }
     });
     // The app registers its message listener during startup; mark ready on iframe load so
     // subsequent control changes recompose in place rather than reloading the bundle.
-    wasmFrame.addEventListener("load", function () { wasmReady = true; });
+    wasmFrame.addEventListener("load", function () {
+      wasmReady = true;
+      // Re-sync any control changed during load (the fragment only captured open-time state).
+      var patch = wasmOverridePatch();
+      if (patch) wasmFrame.contentWindow.postMessage(patch, "*");
+    });
   }
   if (fs) {
     fs.addEventListener("input", function () {

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
@@ -317,6 +317,10 @@ a:hover { text-decoration: underline; }
   var wasmFrame = document.getElementById("cp-wasm");
   var wasmToggle = document.getElementById("cp-wasm-toggle");
   var wasmSrc = root.getAttribute("data-wasm-src") || "";
+  // Set once the iframe's Wasm app has loaded and registered its postMessage listener. Until
+  // then a control change re-points ?query (initial load); after, it posts an override patch so
+  // the app recomposes in place instead of reloading the whole ~20 MB Wasm bundle.
+  var wasmReady = false;
   function wasmUrl() {
     if (!wasmSrc) return "";
     // The src comes from a server-set data- attribute, but resolve it against our own origin and
@@ -334,23 +338,45 @@ a:hover { text-decoration: underline; }
     if (fontScaleTouched && fs) u.searchParams.set("fontScale", fs.value);
     return u.href;
   }
+  // The override patch (theme / font scale / locale) the running app merges over its load-time
+  // params — the same fields wasmUrl() re-points, as a bare `a=b&c=d` query with no base. An
+  // absent key falls back to the app's baked default (e.g. cleared Theme → the variant's uiMode).
+  function wasmOverridePatch() {
+    var parts = [];
+    var el = document.getElementById("cp-uiMode");
+    if (el && el.value) parts.push("uiMode=" + encodeURIComponent(el.value));
+    var loc = document.getElementById("cp-localeTag");
+    if (loc && loc.value) parts.push("localeTag=" + encodeURIComponent(loc.value));
+    if (fontScaleTouched && fs) parts.push("fontScale=" + encodeURIComponent(fs.value));
+    return parts.join("&");
+  }
   function openWasm() {
     // Wasm and the daemon stream are mutually exclusive — only one transport drives the stage.
     if (live.checked) { live.checked = false; closeStream(); }
     root.setAttribute("data-mode", "wasm");
     img.hidden = true; canvas.hidden = true; wasmFrame.hidden = false;
+    wasmReady = false;
     wasmFrame.src = wasmUrl();
     status.textContent = "";
   }
   function closeWasm() {
     root.setAttribute("data-mode", "snapshot");
+    wasmReady = false;
     wasmFrame.hidden = true; wasmFrame.removeAttribute("src");
     img.hidden = false;
   }
   function wasmActive() { return wasmToggle && wasmToggle.checked; }
 
   function onControlsChanged() {
-    if (wasmActive()) { wasmFrame.src = wasmUrl(); return; }
+    if (wasmActive()) {
+      // Recompose in place once the app is up; only fall back to a src reload before it's ready.
+      if (wasmReady && wasmFrame.contentWindow) {
+        wasmFrame.contentWindow.postMessage(wasmOverridePatch(), "*");
+      } else {
+        wasmFrame.src = wasmUrl();
+      }
+      return;
+    }
     if (live.checked && ws && ws.readyState === 1) {
       ws.send(JSON.stringify({ type: "setOverrides", overrides: overrides() }));
     } else if (live.disabled && wasmToggle) {
@@ -378,6 +404,9 @@ a:hover { text-decoration: underline; }
       if (wasmToggle.checked) openWasm();
       else { closeWasm(); refreshSnapshot(); }
     });
+    // The app registers its message listener during startup; mark ready on iframe load so
+    // subsequent control changes recompose in place rather than reloading the bundle.
+    wasmFrame.addEventListener("load", function () { wasmReady = true; });
   }
   if (fs) {
     fs.addEventListener("input", function () {

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
@@ -321,26 +321,21 @@ a:hover { text-decoration: underline; }
   // then a control change re-points ?query (initial load); after, it posts an override patch so
   // the app recomposes in place instead of reloading the whole ~20 MB Wasm bundle.
   var wasmReady = false;
-  function wasmUrl() {
+  function wasmBaseSrc() {
     if (!wasmSrc) return "";
     // The src comes from a server-set data- attribute, but resolve it against our own origin and
     // refuse anything not same-origin http(s) anyway — so a `javascript:`/`data:` URL can never
-    // reach the iframe even if the attribute were ever mis-set (defuses DOM-text-as-HTML).
+    // reach the iframe even if the attribute were ever mis-set (defuses DOM-text-as-HTML). The
+    // query is left as the server baked it (the variant's default theme) — session overrides
+    // never go in it, so it stays the app's clean base to revert to when a control is cleared.
     var u;
     try { u = new URL(wasmSrc, location.origin); } catch (e) { return ""; }
     if (u.origin !== location.origin) return "";
-    var el = document.getElementById("cp-uiMode");
-    if (el && el.value) u.searchParams.set("uiMode", el.value);
-    // The Wasm app also honours font scale (density) + locale (layout direction); device /
-    // orientation are server-render-only, so they're not forwarded.
-    var loc = document.getElementById("cp-localeTag");
-    if (loc && loc.value) u.searchParams.set("localeTag", loc.value);
-    if (fontScaleTouched && fs) u.searchParams.set("fontScale", fs.value);
     return u.href;
   }
-  // The override patch (theme / font scale / locale) the running app merges over its load-time
-  // params — the same fields wasmUrl() re-points, as a bare `a=b&c=d` query with no base. An
-  // absent key falls back to the app's baked default (e.g. cleared Theme → the variant's uiMode).
+  // The override patch (theme / font scale / locale) the running app merges over its baked base —
+  // a bare `a=b&c=d` query. An absent key falls back to the app's baked default (e.g. cleared
+  // Theme → the variant's uiMode). Device / orientation are server-render-only, so not forwarded.
   function wasmOverridePatch() {
     var parts = [];
     var el = document.getElementById("cp-uiMode");
@@ -350,13 +345,21 @@ a:hover { text-decoration: underline; }
     if (fontScaleTouched && fs) parts.push("fontScale=" + encodeURIComponent(fs.value));
     return parts.join("&");
   }
+  // Initial iframe URL: the baked base plus the current overrides in the `#…` fragment, so the
+  // app's first paint honours them yet keeps the query as its true base (a later clear reverts).
+  function wasmInitialSrc() {
+    var base = wasmBaseSrc();
+    if (!base) return "";
+    var patch = wasmOverridePatch();
+    return patch ? base + "#" + patch : base;
+  }
   function openWasm() {
     // Wasm and the daemon stream are mutually exclusive — only one transport drives the stage.
     if (live.checked) { live.checked = false; closeStream(); }
     root.setAttribute("data-mode", "wasm");
     img.hidden = true; canvas.hidden = true; wasmFrame.hidden = false;
     wasmReady = false;
-    wasmFrame.src = wasmUrl();
+    wasmFrame.src = wasmInitialSrc();
     status.textContent = "";
   }
   function closeWasm() {
@@ -369,11 +372,12 @@ a:hover { text-decoration: underline; }
 
   function onControlsChanged() {
     if (wasmActive()) {
-      // Recompose in place once the app is up; only fall back to a src reload before it's ready.
+      // Recompose in place once the app is up; before it's ready, re-point the initial src (the
+      // fragment carries the overrides) — the load handler re-syncs the final state either way.
       if (wasmReady && wasmFrame.contentWindow) {
         wasmFrame.contentWindow.postMessage(wasmOverridePatch(), "*");
       } else {
-        wasmFrame.src = wasmUrl();
+        wasmFrame.src = wasmInitialSrc();
       }
       return;
     }
@@ -406,7 +410,12 @@ a:hover { text-decoration: underline; }
     });
     // The app registers its message listener during startup; mark ready on iframe load so
     // subsequent control changes recompose in place rather than reloading the bundle.
-    wasmFrame.addEventListener("load", function () { wasmReady = true; });
+    wasmFrame.addEventListener("load", function () {
+      wasmReady = true;
+      // Re-sync any control changed during load (the fragment only captured open-time state).
+      var patch = wasmOverridePatch();
+      if (patch) wasmFrame.contentWindow.postMessage(patch, "*");
+    });
   }
   if (fs) {
     fs.addEventListener("input", function () {

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
@@ -317,6 +317,10 @@ a:hover { text-decoration: underline; }
   var wasmFrame = document.getElementById("cp-wasm");
   var wasmToggle = document.getElementById("cp-wasm-toggle");
   var wasmSrc = root.getAttribute("data-wasm-src") || "";
+  // Set once the iframe's Wasm app has loaded and registered its postMessage listener. Until
+  // then a control change re-points ?query (initial load); after, it posts an override patch so
+  // the app recomposes in place instead of reloading the whole ~20 MB Wasm bundle.
+  var wasmReady = false;
   function wasmUrl() {
     if (!wasmSrc) return "";
     // The src comes from a server-set data- attribute, but resolve it against our own origin and
@@ -334,23 +338,45 @@ a:hover { text-decoration: underline; }
     if (fontScaleTouched && fs) u.searchParams.set("fontScale", fs.value);
     return u.href;
   }
+  // The override patch (theme / font scale / locale) the running app merges over its load-time
+  // params — the same fields wasmUrl() re-points, as a bare `a=b&c=d` query with no base. An
+  // absent key falls back to the app's baked default (e.g. cleared Theme → the variant's uiMode).
+  function wasmOverridePatch() {
+    var parts = [];
+    var el = document.getElementById("cp-uiMode");
+    if (el && el.value) parts.push("uiMode=" + encodeURIComponent(el.value));
+    var loc = document.getElementById("cp-localeTag");
+    if (loc && loc.value) parts.push("localeTag=" + encodeURIComponent(loc.value));
+    if (fontScaleTouched && fs) parts.push("fontScale=" + encodeURIComponent(fs.value));
+    return parts.join("&");
+  }
   function openWasm() {
     // Wasm and the daemon stream are mutually exclusive — only one transport drives the stage.
     if (live.checked) { live.checked = false; closeStream(); }
     root.setAttribute("data-mode", "wasm");
     img.hidden = true; canvas.hidden = true; wasmFrame.hidden = false;
+    wasmReady = false;
     wasmFrame.src = wasmUrl();
     status.textContent = "";
   }
   function closeWasm() {
     root.setAttribute("data-mode", "snapshot");
+    wasmReady = false;
     wasmFrame.hidden = true; wasmFrame.removeAttribute("src");
     img.hidden = false;
   }
   function wasmActive() { return wasmToggle && wasmToggle.checked; }
 
   function onControlsChanged() {
-    if (wasmActive()) { wasmFrame.src = wasmUrl(); return; }
+    if (wasmActive()) {
+      // Recompose in place once the app is up; only fall back to a src reload before it's ready.
+      if (wasmReady && wasmFrame.contentWindow) {
+        wasmFrame.contentWindow.postMessage(wasmOverridePatch(), "*");
+      } else {
+        wasmFrame.src = wasmUrl();
+      }
+      return;
+    }
     if (live.checked && ws && ws.readyState === 1) {
       ws.send(JSON.stringify({ type: "setOverrides", overrides: overrides() }));
     } else if (live.disabled && wasmToggle) {
@@ -378,6 +404,9 @@ a:hover { text-decoration: underline; }
       if (wasmToggle.checked) openWasm();
       else { closeWasm(); refreshSnapshot(); }
     });
+    // The app registers its message listener during startup; mark ready on iframe load so
+    // subsequent control changes recompose in place rather than reloading the bundle.
+    wasmFrame.addEventListener("load", function () { wasmReady = true; });
   }
   if (fs) {
     fs.addEventListener("input", function () {


### PR DESCRIPTION
## Summary

Make the in-browser "Run in browser (Wasm)" tier update **in place** on a control change instead of reloading the whole iframe.

Before: while Wasm was active, a Theme / Font-scale / Locale change reassigned the iframe `src`, which reloaded the entire ~20 MB Wasm bundle + re-init'd Skiko + recomposed from scratch — a blank flash / "the preview disappears" on every control move. Now the viewer posts an override patch to the already-running app, which recomposes live.

## Changes
- **`samples/cmp-wasm-catalog` (app side)** — hoist the render params into Compose state and add an exported `applyOverrides(query)` entrypoint; `index.html` registers a `postMessage` listener that forwards `?a=b` patches to it. Recomputes from the page's load-time params, so an absent key reverts to the deep-link default (e.g. clearing Theme → the baked variant's `uiMode`). Backward compatible: the app still reads the initial params from the URL.
- **`ServeWeb.kt` (viewer side)** — on a control change while Wasm is active, `postMessage` the override patch to the running iframe instead of reassigning `src`; only the initial open (before the app has loaded and registered its listener, tracked by `wasmReady`) still uses `src`.

## Stacking
Stacked on **#2125** (`claude/design-system-reports-publish-iup592`) at your request — both touch `ServeWeb.kt` + the viewer fixtures. Net diff here is only the recompose work; the rebase's auto-merge was re-verified by regenerating **all** viewer fixtures from the combined code (it had left #2125's new `serve-viewer-path.html` without the postMessage JS). After #2125 merges I'll rebase this onto `main`.

## Test plan
- `:samples:cmp-wasm-catalog:wasmCatalogDist` — **builds**, and the generated `composeApp.mjs` exports `applyOverrides` (verified the `@JsExport` bridge is reachable).
- `./gradlew :cli:test --tests '*ServeWebFixtureTest*'` — **green**; all viewer fixtures (incl. the path-mounted one) regenerated from the merged `ServeWeb`.
- Manual: open a `?session=compose-m3` preview, tick "Run in browser (Wasm)", move Font scale → recomposes live, no reload flash.

## Notes
- **No pixel change** — the change is behavioral (the JS embedded in the page differs; rendered chrome is identical), so there's no before/after image; the visual-diff bot will show the page unchanged. This is the non-visual case.
- **Deploy:** the app-side change ships to preview.coo.ee only after a `design-artifacts/compose-m3` regen (the live server fetches the Wasm bundle from that branch); the viewer-JS side ships in the next preview-host image.


---
_Generated by [Claude Code](https://claude.ai/code/session_01K8nJEfEYGM3ijyoAXDNLGH)_