### PR TITLE
ci: land release PRs without an admin bypass

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -135,6 +135,43 @@ jobs:
           path: compose-ai-bundle.tar.gz
           retention-days: 7
 
+  # Release-please PRs only bump the version manifest / CHANGELOG / version
+  # strings, so the integration matrix below is skipped on them (the `if:` on
+  # `build-plugin` + `integration`). But a skipped *matrix* job posts NO per-leg
+  # check run — unlike a skipped plain job, which still reports "skipped" and so
+  # counts as passing for branch protection. That's the asymmetry that bit us:
+  # the CI workflow's plain jobs skip green, but the two PR-blocking matrix legs
+  # `wear-os-samples (ComposeStarter)` and `wear-os-samples (WearTilesKotlin)` —
+  # both REQUIRED status checks — emit nothing, so they sit on "Expected —
+  # Waiting for status to be reported" forever and force the admin "bypass rules"
+  # checkbox to land every release.
+  #
+  # This gate runs ONLY on those bot release PRs and re-emits check runs with the
+  # SAME names (via the matrix `name`, exactly as the real `integration` job
+  # does), reporting them green — so the release PR clears branch protection with
+  # no bypass. Its `if:` is the exact inverse of the matrix job's guard, so on
+  # any given event exactly one of the two posts each context, never both: the
+  # real matrix on normal PRs / pushes / the nightly cron, this gate on release
+  # PRs. Keep the two names in lockstep with the `pr_blocking: true` matrix cells.
+  release-please-gate:
+    if: ${{ startsWith(github.head_ref, 'release-please--') && github.event.pull_request.user.login == 'github-actions[bot]' }}
+    name: ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        name:
+          - "wear-os-samples (ComposeStarter)"
+          - "wear-os-samples (WearTilesKotlin)"
+    steps:
+      - name: Report green (version-only release PR — integration not applicable)
+        env:
+          LEG: ${{ matrix.name }}
+        run: |
+          echo "Release-please PR (version manifest / CHANGELOG only) — the"
+          echo "integration matrix is skipped, so this required leg"
+          echo "'${LEG}' is reported green here to satisfy branch"
+          echo "protection without an admin bypass."
+
   integration:
     if: ${{ !(startsWith(github.head_ref, 'release-please--') && github.event.pull_request.user.login == 'github-actions[bot]') }}
     name: ${{ matrix.name }}

--- a/.github/workflows/release-thumbs-up-merge.yml
+++ b/.github/workflows/release-thumbs-up-merge.yml
@@ -24,11 +24,13 @@ on:
     - cron: "*/10 * * * *"
   workflow_dispatch:
 
-# Least privilege: merge the PR (contents + pull-requests) and dispatch
-# release-please.yml afterwards (actions: write). Nothing else.
+# Least privilege: read PR reactions (issues: read — reactions live on the
+# issues endpoint, and omitted permissions default to `none`), merge the PR
+# (contents + pull-requests), and dispatch release-please.yml (actions: write).
 permissions:
   contents: write
   pull-requests: write
+  issues: read
   actions: write
 
 concurrency:
@@ -49,12 +51,18 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Open release-please PRs (root + any component share the head-branch
-          # prefix). The 👍 gate below is per-PR, so we can safely consider all.
+          # Open release-please PRs only: bot-authored, `release-please--` head,
+          # targeting main — mirroring the guard in integration.yml so a human/
+          # fork PR that merely borrows the branch prefix can never be treated as
+          # a release PR (the 👍 gate below is a second line of defence, per-PR).
           mapfile -t prs < <(
             gh pr list --repo "$GH_REPO" --state open \
-              --json number,headRefName \
-              --jq '.[] | select(.headRefName | startswith("release-please--")) | .number'
+              --json number,headRefName,baseRefName,author \
+              --jq '.[]
+                    | select((.headRefName | startswith("release-please--"))
+                             and .baseRefName == "main"
+                             and .author.is_bot)
+                    | .number'
           )
           if [ "${#prs[@]}" -eq 0 ]; then
             echo "No open release-please PR — nothing to do."

--- a/.github/workflows/release-thumbs-up-merge.yml
+++ b/.github/workflows/release-thumbs-up-merge.yml
@@ -1,0 +1,97 @@
+name: Release PR thumbs-up merge
+
+# One-tap release, human-gated. The release-please PR sits fully green (the heavy
+# CI jobs skip on it, and the two required integration legs are reported by
+# `release-please-gate` in integration.yml) but is deliberately NOT auto-merged.
+# When the maintainer signs off with a 👍 (`+1`) reaction on the PR, this poller
+# squash-merges it; with no 👍 it leaves the PR untouched for a manual merge.
+#
+# GitHub has no "reaction" event, so this polls on a cron rather than triggering
+# off the reaction. Merging with the built-in GITHUB_TOKEN never ticks the
+# "bypass rules" box, so it only merges once the PR is genuinely green.
+#
+# One wrinkle: a merge performed with GITHUB_TOKEN does NOT start new workflow
+# runs (GitHub's recursion guard), so the push to `main` would not fire
+# `release-please.yml` and the tag + GitHub Release would never be cut. We
+# therefore dispatch `release-please.yml` explicitly after merging — on its next
+# run it sees the merged release commit and cuts the release + chains the
+# publish, exactly as a human web-UI merge would.
+
+on:
+  schedule:
+    # Every ~10 minutes — GitHub has no reaction trigger, so we poll. Latency
+    # between the 👍 and the merge is at most one interval.
+    - cron: "*/10 * * * *"
+  workflow_dispatch:
+
+# Least privilege: merge the PR (contents + pull-requests) and dispatch
+# release-please.yml afterwards (actions: write). Nothing else.
+permissions:
+  contents: write
+  pull-requests: write
+  actions: write
+
+concurrency:
+  group: release-thumbs-up-merge
+  cancel-in-progress: false
+
+jobs:
+  merge-on-thumbs-up:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Merge release PRs the maintainer reacted 👍 to
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          # Only this login's 👍 authorises a merge. The reaction IS the sign-off,
+          # so this is the security gate — keep it to a trusted maintainer.
+          APPROVER: yschimke
+        run: |
+          set -euo pipefail
+
+          # Open release-please PRs (root + any component share the head-branch
+          # prefix). The 👍 gate below is per-PR, so we can safely consider all.
+          mapfile -t prs < <(
+            gh pr list --repo "$GH_REPO" --state open \
+              --json number,headRefName \
+              --jq '.[] | select(.headRefName | startswith("release-please--")) | .number'
+          )
+          if [ "${#prs[@]}" -eq 0 ]; then
+            echo "No open release-please PR — nothing to do."
+            exit 0
+          fi
+
+          merged=0
+          for pr in "${prs[@]}"; do
+            # Require a 👍 (+1) reaction from the approver on the PR itself.
+            approved=$(
+              gh api "repos/$GH_REPO/issues/$pr/reactions" \
+                --jq '[.[] | select(.content == "+1" and .user.login == env.APPROVER)] | length'
+            )
+            if [ "${approved:-0}" -eq 0 ]; then
+              echo "PR #$pr: no 👍 from $APPROVER yet — leaving it for the maintainer."
+              continue
+            fi
+
+            # Only merge when it's actually green — we never bypass. UNSTABLE
+            # (a non-required check failing) is still mergeable; BLOCKED / BEHIND
+            # / DIRTY / UNKNOWN mean wait and retry next run.
+            state=$(gh pr view "$pr" --repo "$GH_REPO" --json mergeStateStatus --jq '.mergeStateStatus')
+            case "$state" in
+              CLEAN|HAS_HOOKS|UNSTABLE)
+                echo "PR #$pr: 👍 from $APPROVER and mergeable ($state) — squash-merging."
+                gh pr merge "$pr" --repo "$GH_REPO" --squash
+                merged=1
+                ;;
+              *)
+                echo "PR #$pr: approved but not mergeable yet ($state) — retrying next run."
+                ;;
+            esac
+          done
+
+          # A GITHUB_TOKEN merge won't re-trigger release-please.yml, so kick it
+          # to cut the tag + GitHub Release for the just-merged version(s).
+          if [ "$merged" -eq 1 ]; then
+            echo "Dispatching release-please.yml to cut the release."
+            gh workflow run release-please.yml --repo "$GH_REPO" --ref main
+          fi


### PR DESCRIPTION
## Summary

Release-please PRs (e.g. #2121) get stuck on **"Expected — Waiting for status to be reported"** and only merge via the red *"Merge without waiting for requirements (bypass rules)"* box. Root cause is an asymmetry in how skipped jobs report checks:

- The **CI** workflow's plain jobs are skipped on release PRs and report `skipped`, which branch protection counts as passing. ✅
- The **Integration** workflow's two PR-blocking legs — `wear-os-samples (ComposeStarter)` and `wear-os-samples (WearTilesKotlin)` — come from a **matrix** job. A skipped *matrix* job emits **no per-leg check run at all**, so those required contexts never report and the PR stays blocked. ❌

(The upstream trigger for the recent stall was separate — the release PR's workflow runs sat in `action_required` needing "Approve and run". Once approved, the two matrix legs are the remaining blocker this PR fixes.)

### Changes

- **`integration.yml`** — add `release-please-gate`, the exact inverse guard of the matrix job's `if:`. On bot release PRs it re-emits check runs with the **same names** (`wear-os-samples (ComposeStarter)` / `wear-os-samples (WearTilesKotlin)`) reporting green, so branch protection clears with no bypass. Exactly one of the two jobs posts each context on any event — the real matrix on normal PRs/pushes/nightly, this gate on release PRs.
- **`release-thumbs-up-merge.yml`** (new) — a `*/10 * * * *` cron poller that squash-merges the open release-please PR **only after `yschimke` reacts 👍** on it, and only when it's genuinely green (never ticks the bypass box). Since a `GITHUB_TOKEN` merge doesn't re-trigger `release-please.yml`, it then dispatches that workflow to cut the tag + Release. No auto-on-green: with no 👍, the PR is left for a manual merge.

Net effect: release PRs go fully green on their own, and land with a single 👍 (or a one-tap manual merge from mobile) instead of an admin bypass. Uses only the built-in `GITHUB_TOKEN` — no new secrets.

## Test plan

- [x] Both workflows parse (`yaml.safe_load`).
- [x] `release-please-gate` `if:` is the strict inverse of the `integration` matrix guard, so no double-posting of the two contexts.
- [ ] After merge: on the next release PR, confirm `wear-os-samples (ComposeStarter/WearTilesKotlin)` report green (from `release-please-gate`) and the PR reaches a mergeable state with no bypass.
- [ ] React 👍 on a release PR and confirm the poller squash-merges within ~10 min and the release is cut via the dispatched `release-please.yml`.

> Note: assumes branch protection requires only status checks (no required approving review) for `main`; if a review is required, the `GITHUB_TOKEN` merge would need a different token.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TqqGqqRg9bMDkdq6brBvT8)_