### PR TITLE
feat(deploy): bake the published catalog set into the prebuilt image

### DIFF
--- a/.github/workflows/preview-host-image.yml
+++ b/.github/workflows/preview-host-image.yml
@@ -15,7 +15,10 @@ on:
       cli_version:
         description: Released compose-preview version to bundle (leading v optional)
         required: true
-        default: "0.16.5"
+        # Keep >= the release that introduced the flags the entrypoint defaults
+        # (--catalogs-unlisted landed in 0.16.9); an older bundled CLI would
+        # silently ignore them and drop the baked meshcore/HA catalog paths.
+        default: "0.16.9"
   # Called from release-please.yml when a CLI release is cut. A bot-created
   # release won't fire the `release` trigger below (the GITHUB_TOKEN-doesn't-
   # trigger-workflows limitation the rest of the release chain already works

--- a/deploy/image/Dockerfile
+++ b/deploy/image/Dockerfile
@@ -8,7 +8,7 @@
 # Maven Central. No build-logic, no gradle-plugin, no ~50 data modules to compile
 # — just a download + one warm render. Built once in CI and pushed to GHCR, so
 # hosts pull it and never build at all.
-ARG CP_VERSION=0.16.5
+ARG CP_VERSION=0.16.9
 
 # ---------------------------------------------------------------------------
 # Stage 0: base — JDK + Skiko's native deps (same rationale as the cloudrun image:

--- a/deploy/image/docker-compose.yml
+++ b/deploy/image/docker-compose.yml
@@ -22,12 +22,14 @@ services:
       # design-artifacts/<system> branch. For a token-gated box instead, set
       # SERVE_PUBLIC=0 and SERVE_TOKEN in .env.
       SERVE_PUBLIC: "${SERVE_PUBLIC:-1}"
-      SERVE_CATALOGS: "${SERVE_CATALOGS:-compose-m3,wear-m3}"
-      # App design systems published from their OWN repos, served but hidden from the
-      # front-page nav — reachable at /<system>/ (and ?session=<system>). The
-      # <system>@<owner>/<repo> suffix points serve at each app's design-artifacts/<system>
-      # branch; the baked trust store trusts those branches so they badge Trusted(Branch).
-      SERVE_CATALOGS_UNLISTED: "${SERVE_CATALOGS_UNLISTED:-meshcore-mobile@yschimke/meshcore-mobile,homeassistant-remotecompose@yschimke/homeassistant-remotecompose}"
+      # The catalog set is BAKED INTO THE IMAGE (entrypoint): the front-page systems
+      # (compose-m3,wear-m3) and the app systems served unlisted from their own repos
+      # (meshcore-mobile, homeassistant-remotecompose). Leave these empty to inherit the
+      # baked defaults — so a bare image pull self-heals without editing this compose.
+      # Set your own comma list to override, or the literal `none` to serve none of that
+      # kind. (Empty is NOT `none` — it falls back to the baked default.)
+      SERVE_CATALOGS: "${SERVE_CATALOGS:-}"
+      SERVE_CATALOGS_UNLISTED: "${SERVE_CATALOGS_UNLISTED:-}"
       # The image bakes a branch-trust store at /trust/producers.json and the
       # entrypoint defaults to it, so the published design-artifacts catalogs badge
       # as Trusted(Branch) out of the box — leave this unset. Set your own path to

--- a/deploy/image/entrypoint.sh
+++ b/deploy/image/entrypoint.sh
@@ -22,16 +22,22 @@ else
   args+=(--token "${SERVE_TOKEN}")
 fi
 
-# The public-server pillars (all optional). The prebuilt image has no catalog
-# modules to build a Wasm app from, so its in-browser tier rides --catalogs:
-# `serve` fetches each system's web/wasm/ from the trusted design-artifacts
-# branch. (--wasm-dir is for the from-source image's local build.)
-[[ -n "${SERVE_CATALOGS:-}" ]] && args+=(--catalogs "${SERVE_CATALOGS}")
-# Design systems served but hidden from the front-page nav — reachable at /<system>/
-# (and ?session=<system>). Each entry may carry a per-repo source as <system>@<owner>/<repo>
-# (e.g. meshcore-mobile@yschimke/meshcore-mobile). Their web/wasm/ (if any) still rides the
-# branch, and their branch must be trusted (see the trust store below) to badge Trusted.
-[[ -n "${SERVE_CATALOGS_UNLISTED:-}" ]] && args+=(--catalogs-unlisted "${SERVE_CATALOGS_UNLISTED}")
+# The public-server pillars. The prebuilt image has no catalog modules to build a
+# Wasm app from, so its in-browser tier rides --catalogs: `serve` fetches each
+# system's web/wasm/ from the trusted design-artifacts branch. (--wasm-dir is for
+# the from-source image's local build.)
+#
+# The published catalog set is BAKED INTO THE IMAGE (same `:=` + `none` convention
+# as SERVE_TRUST_STORE below), so a bare `docker pull` / Watchtower auto-update
+# self-heals without editing the box's compose. Front-page systems:
+: "${SERVE_CATALOGS:=compose-m3,wear-m3}"
+[[ "${SERVE_CATALOGS}" != "none" ]] && args+=(--catalogs "${SERVE_CATALOGS}")
+# …and the app design systems we publish UNLISTED from their own repos — reachable at
+# /<system>/ (and ?session=<system>) but off the front-page nav. <system>@<owner>/<repo>
+# points at a per-repo design-artifacts branch, which must be trusted (see the store
+# below) to badge Trusted. Override with your own list, or `none` to serve none.
+: "${SERVE_CATALOGS_UNLISTED:=meshcore-mobile@yschimke/meshcore-mobile,homeassistant-remotecompose@yschimke/homeassistant-remotecompose}"
+[[ "${SERVE_CATALOGS_UNLISTED}" != "none" ]] && args+=(--catalogs-unlisted "${SERVE_CATALOGS_UNLISTED}")
 # Default to the baked branch-trust store so the published design-artifacts catalogs
 # badge as Trusted(Branch) out of the box. `:=` fills it when SERVE_TRUST_STORE is
 # unset OR empty (an older host compose passes ""), so a bare image pull self-heals a

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -123,6 +123,15 @@ Mount your own over that path (or set `SERVE_TRUST_STORE` to it) to pin differen
 `SERVE_TRUST_STORE=none` to run trustless. (Empty falls back to the baked default — use `none` to opt
 out — which also means a bare image pull self-heals a box without editing its compose.)
 
+The **catalog set is baked into the image the same way**: the entrypoint defaults `SERVE_CATALOGS`
+to `compose-m3,wear-m3` (front-page nav) and `SERVE_CATALOGS_UNLISTED` to
+`meshcore-mobile@yschimke/meshcore-mobile,homeassistant-remotecompose@yschimke/homeassistant-remotecompose`
+(served at `/<system>/`, off the nav). So a bare `docker pull` / Watchtower update serves them
+without editing the box's compose. Override either with your own comma list, or `none` to serve none
+of that kind (empty inherits the baked default). The `deploy/vps` from-source path still sets these
+in its compose (it builds `main`, so the flags exist immediately; the prebuilt image needs a CLI
+release that carries `--catalogs-unlisted`).
+
 | | [`deploy/vps`](../deploy/vps) (from source) | [`deploy/image`](../deploy/image) (prebuilt) |
 |---|---|---|
 | CLI | compiled from this checkout (~8 min build) | the **released** tarball (`docker pull`, no build) + Watchtower auto-update |


### PR DESCRIPTION
## Summary

Make the prebuilt `deploy/image` (preview.coo.ee) serve the published design systems **by default**, without anyone setting env on the box — so a `docker pull` / Watchtower auto-update self-heals. Moves the catalog defaults out of the box's compose and into the image entrypoint, exactly mirroring how `SERVE_TRUST_STORE` is already baked.

- **`deploy/image/entrypoint.sh`** — the entrypoint now defaults (with the `:=` + `none` convention):
  - `SERVE_CATALOGS` → `compose-m3,wear-m3` (front-page nav)
  - `SERVE_CATALOGS_UNLISTED` → `meshcore-mobile@yschimke/meshcore-mobile,homeassistant-remotecompose@yschimke/homeassistant-remotecompose` (served at `/<system>/`, off the nav)
  - Empty inherits the baked default; `none` opts out.
- **`deploy/image/docker-compose.yml`** — both vars now pass through empty (`${…:-}`), so the image is the single source of truth (same as `SERVE_TRUST_STORE`).
- **`docs/public-preview-server.md`** — documents the baked catalog set + the `none` opt-out.

The baked trust store (from the prior PR) already trusts all three repos' `design-artifacts/*`, so the app catalogs badge `Trusted(Branch)`.

### Safety / ordering

Verified from the CLI source: `serve` reads flags opt-in via `flagValue` and has **no positional args**, so an older *released* CLI simply **ignores** an unknown `--catalogs-unlisted …` (no crash) — it activates when a CLI release carries the flag (bump `CP_VERSION`). The from-source `deploy/vps` path builds `main`, so it has the flag immediately (its compose still sets these explicitly).

## Test plan

- `bash -n deploy/image/entrypoint.sh` — clean.
- Compose YAML parses.
- Config-only (entrypoint + compose + docs); no code paths changed. On deploy, `/compose-m3/`, `/wear-m3/`, `/meshcore-mobile/`, `/homeassistant-remotecompose/` resolve with no env set.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vh2DezRdwpjddGGEZ3nveE)_