### PR TITLE
fix(ci): skip compose PR comment when previews.json is empty

### DIFF
--- a/.github/actions/apply/action.yml
+++ b/.github/actions/apply/action.yml
@@ -530,8 +530,12 @@ runs:
       run: |
         set -euo pipefail
         # Compose comment is only meaningful when the compose pipeline
-        # actually produced previews.json + a baseline dir.
-        if [ ! -f _previews.json ] || [ ! -d _baselines ]; then
+        # actually produced a non-empty previews.json + a baseline dir.
+        # `pipelines/compose.sh` already treats an empty _previews.json as a
+        # clean skip (no compose modules / zero previews), so match that here
+        # with `-s` — otherwise a docs-only PR leaves an empty file that slips
+        # past `-f` and errors in compare-previews.py.
+        if [ ! -s _previews.json ] || [ ! -d _baselines ]; then
           echo "compose comment: nothing to compare, skipping."
           exit 0
         fi


### PR DESCRIPTION
## Summary

The "Generate compose PR comment body" step in `.github/actions/apply/action.yml` guards on `_previews.json` being **missing** (`[ ! -f _previews.json ]`) but not on it being **present-but-empty**. A docs-only PR (no renderable surfaces) leaves an empty `_previews.json`, which slips past the `-f` guard and then errors in `compare-previews.py` with `_previews.json is empty — the upstream compose-preview show --json step produced no output`, turning the **Apply compose-preview** check red on PRs that changed nothing visual.

The rest of the pipeline already settled the semantics: `pipelines/compose.sh` treats an empty `_previews.json` as a **clean skip** ("no compose modules, skipping" → `exit 0`) in two places, and the render step's own exit code is tracked separately in `_compose_render_rc`. So empty = "nothing to compare" is the intended behavior; the comment step's `-f` guard was just inconsistent with it.

Fix: guard on **non-empty** (`[ ! -s _previews.json ]`) so the comment step skips cleanly on an empty envelope, matching `compose.sh`. A genuinely broken render is still surfaced via the separate render RC, so this doesn't mask real failures.

Observed on #2138 (a docs-only PR), where this check was the sole red — non-blocking there (`mergeable_state: unstable`), but it's noise on every docs-only PR.

## Test plan

- CI plumbing change; exercised by the **Apply compose-preview** check on this PR (itself a non-visual change, so the empty-`_previews.json` path is now taken → the step should skip cleanly instead of erroring).
- Reasoning cross-checked against `pipelines/compose.sh` (lines 31, 53 — empty `_previews.json` is already a clean skip) and `compare-previews.py:261` (the error this avoids reaching).

---
_Generated by [Claude Code](https://claude.ai/code/session_016X4T4H2pieiZAfU9Xg9Dgs)_