### PR TITLE
feat(serve): bounded live-seat cap for the daemon-backed stream tier

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
@@ -65,6 +65,7 @@ internal object CliFlags {
       "--catalog-branch-prefix",
       "--wasm-dir",
       "--revisions-allow",
+      "--live-seats",
       // bundle sign / verify / keygen (producer trust)
       "--key",
       "--key-id",

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -50,6 +50,15 @@ class ServeCommand(args: List<String>) : Command(args) {
     }
   private val requestedPort: Int = args.flagValue("--port")?.toIntOrNull() ?: DEFAULT_PORT
   private val tokenOverride: String? = args.flagValue("--token")?.takeIf { it.isNotBlank() }
+
+  /**
+   * Cap on concurrent **live** (daemon-backed) stream sessions — the "live seats". `0` (default) is
+   * unbounded (a local dev box); a small positive value bounds the JVM render daemons a constrained
+   * public box (e.g. `--allow-render-trusted` on a 4 GB VM) will spawn, so an over-cap stream is
+   * refused rather than risking the OOM killer. Only bites when a live daemon actually backs a
+   * session; the snapshot + Wasm tiers never take a seat.
+   */
+  private val liveSeats: Int = args.flagValue("--live-seats")?.toIntOrNull()?.coerceAtLeast(0) ?: 0
   private val exportPath: String? = args.flagValue("--export")?.takeIf { it.isNotBlank() }
   private val inlineBundle: Boolean = "--inline" in args
 
@@ -405,6 +414,7 @@ class ServeCommand(args: List<String>) : Command(args) {
         isPublic = public,
         wasmCatalogs = wasmCatalogs,
         catalogSessions = registeredCatalogs.toList(),
+        maxLiveSeats = liveSeats,
       )
 
     // Advertise on the LAN over mDNS when bound to a reachable interface (`--lan`), so the mobile /
@@ -834,6 +844,11 @@ class ServeCommand(args: List<String>) : Command(args) {
                           box that can't build the catalog source (e.g. the desktop-only public
                           image can't build the Android catalogs) — leave it off and let the
                           in-browser Wasm tier carry CMP.
+        --live-seats <n>  Cap concurrent live (daemon-backed) stream sessions. Each seat holds a JVM
+                          Compose daemon, so on a small box bound this (e.g. 1–2) when the live tier
+                          is on (--allow-render-trusted) — an over-cap stream is refused (WS 1013)
+                          rather than risking the OOM killer. Default 0 = unbounded. Snapshot + Wasm
+                          sessions never take a seat.
         --exit-when-idle[=<seconds>]
                           Ephemeral mode: shut the server down once it's been idle (no open
                           connections and no requests) for <seconds> (default ${DEFAULT_IDLE_EXIT_SECONDS}s). Use a small

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -521,54 +521,60 @@ class ServeHttpServer(
     }
     val sessionId =
       call.parameters["system"] ?: call.request.queryParameters["session"] ?: defaultSessionId
-    // Lease (not just acquire) the tenant for the socket's whole life: a fallback-lane socket opens
-    // no stream, so without a lease the reaper could close its host mid-connection.
-    val lease = withContext(Dispatchers.IO) { sessions.lease(sessionId) }
-    if (lease == null) {
-      close(CloseReason(CloseReason.Codes.CANNOT_ACCEPT, "no such session"))
+    // Reserve a live seat BEFORE opening the session: leasing resumes a suspended/forked host,
+    // which
+    // spawns the JVM render daemon, so a post-lease check would let an over-cap burst spawn the
+    // very
+    // daemons this cap bounds. A known-static (pinned bundle/catalog) session never takes a seat;
+    // an
+    // as-yet-unregistered one (lazily forked, e.g. --revisions) counts as daemon-backed.
+    val seats = if (liveSeats != null && !sessions.isKnownStatic(sessionId)) liveSeats else null
+    if (seats != null && !seats.tryAcquire()) {
+      close(CloseReason(1013.toShort(), "live preview at capacity — try again shortly"))
       return
     }
     try {
-      val renderHost = lease.host
-      val previewId = call.parameters["name"]
-      if (previewId == null || renderHost.previews.none { it.id == previewId }) {
-        close(CloseReason(CloseReason.Codes.CANNOT_ACCEPT, "no such preview"))
-        return
-      }
-      val initialOverrides =
-        call.request.queryParameters
-          .entries()
-          .mapNotNull { (key, values) ->
-            val value = values.firstOrNull() ?: return@mapNotNull null
-            if (
-              key in ServeOverrides.SUPPORTED_KEYS || key.startsWith(ServeOverrides.KNOB_PREFIX)
-            ) {
-              key to value
-            } else {
-              null
-            }
-          }
-          .toMap()
-      // Non-suspending hand-off to the socket; drop frames a slow client can't keep up with.
-      val send: (String) -> Unit = { text -> outgoing.trySend(Frame.Text(text)) }
-      // Optional stream tuning: codec (WebP is ~30–60% smaller; the daemon downgrades to PNG if it
-      // can't encode WebP) and an fps cap.
-      val codec =
-        when (call.request.queryParameters["codec"]?.lowercase()) {
-          "webp" -> StreamCodec.WEBP
-          "png" -> StreamCodec.PNG
-          else -> null
-        }
-      val maxFps = call.request.queryParameters["maxFps"]?.toIntOrNull()?.takeIf { it > 0 }
-      // Live-seat cap: a daemon-backed stream holds a JVM Compose render session, so bound how many
-      // run at once on a constrained box (a stream over the cap is refused, not queued). Static
-      // (snapshot) hosts re-render from cache and never take a seat, so the default tiers are free.
-      val seat = if (renderHost.canApplyOverrides) liveSeats else null
-      if (seat != null && !seat.tryAcquire()) {
-        close(CloseReason(1013.toShort(), "live preview at capacity — try again shortly"))
+      // Lease (not just acquire) the tenant for the socket's whole life: a fallback-lane socket
+      // opens
+      // no stream, so without a lease the reaper could close its host mid-connection.
+      val lease = withContext(Dispatchers.IO) { sessions.lease(sessionId) }
+      if (lease == null) {
+        close(CloseReason(CloseReason.Codes.CANNOT_ACCEPT, "no such session"))
         return
       }
       try {
+        val renderHost = lease.host
+        val previewId = call.parameters["name"]
+        if (previewId == null || renderHost.previews.none { it.id == previewId }) {
+          close(CloseReason(CloseReason.Codes.CANNOT_ACCEPT, "no such preview"))
+          return
+        }
+        val initialOverrides =
+          call.request.queryParameters
+            .entries()
+            .mapNotNull { (key, values) ->
+              val value = values.firstOrNull() ?: return@mapNotNull null
+              if (
+                key in ServeOverrides.SUPPORTED_KEYS || key.startsWith(ServeOverrides.KNOB_PREFIX)
+              ) {
+                key to value
+              } else {
+                null
+              }
+            }
+            .toMap()
+        // Non-suspending hand-off to the socket; drop frames a slow client can't keep up with.
+        val send: (String) -> Unit = { text -> outgoing.trySend(Frame.Text(text)) }
+        // Optional stream tuning: codec (WebP is ~30–60% smaller; the daemon downgrades to PNG if
+        // it
+        // can't encode WebP) and an fps cap.
+        val codec =
+          when (call.request.queryParameters["codec"]?.lowercase()) {
+            "webp" -> StreamCodec.WEBP
+            "png" -> StreamCodec.PNG
+            else -> null
+          }
+        val maxFps = call.request.queryParameters["maxFps"]?.toIntOrNull()?.takeIf { it > 0 }
         // Prefer the daemon's live stream lane (frames pushed, input dispatched); fall back to the
         // snapshot re-render lane when the backend doesn't support streaming.
         val live =
@@ -598,10 +604,10 @@ class ServeHttpServer(
           }
         }
       } finally {
-        seat?.release()
+        lease.close()
       }
     } finally {
-      lease.close()
+      seats?.release()
     }
   }
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -97,11 +97,24 @@ class ServeHttpServer(
    * this is a load-shedding bound on concurrent HTTP work, not a parallel-render knob.
    */
   maxConcurrentRenders: Int = Runtime.getRuntime().availableProcessors().coerceAtLeast(1),
+  /**
+   * Max concurrent **live** (daemon-backed) stream sessions — the "live seats". Each holds a JVM
+   * Compose render session on the box, so a constrained host (e.g. a 4 GB / 2-vCPU VM) can bound
+   * them: a stream that would exceed the cap is refused with WebSocket close 1013 (Try Again Later)
+   * rather than spawning an unbounded daemon and risking the OOM killer. `0` (the default) is
+   * unbounded — the historical behaviour for a local `serve` on a developer box. Static
+   * (snapshot/Wasm) sessions never consume a seat, so the public server's default tiers are
+   * unaffected; this only bites when `--allow-render-trusted` puts a live daemon behind a catalog.
+   */
+  maxLiveSeats: Int = 0,
 ) {
   /** The actual bound port — may differ from the requested one if it was taken (auto-picked). */
   val port: Int = pickPort(host, requestedPort, portRange)
 
   private val renderSemaphore = Semaphore(maxConcurrentRenders.coerceAtLeast(1))
+
+  /** Live-seat limiter; null ⇒ unbounded (`maxLiveSeats <= 0`). See [maxLiveSeats]. */
+  private val liveSeats: Semaphore? = if (maxLiveSeats > 0) Semaphore(maxLiveSeats) else null
 
   private val server: EmbeddedServer<*, *> =
     embeddedServer(CIO, host = host, port = port) {
@@ -547,33 +560,45 @@ class ServeHttpServer(
           else -> null
         }
       val maxFps = call.request.queryParameters["maxFps"]?.toIntOrNull()?.takeIf { it > 0 }
-      // Prefer the daemon's live stream lane (frames pushed, input dispatched); fall back to the
-      // snapshot re-render lane when the backend doesn't support streaming.
-      val live =
-        withContext(Dispatchers.IO) {
-          ServeLiveSession.tryStart(renderHost, previewId, initialOverrides, codec, maxFps, send)
-        }
-      if (live != null) {
-        try {
+      // Live-seat cap: a daemon-backed stream holds a JVM Compose render session, so bound how many
+      // run at once on a constrained box (a stream over the cap is refused, not queued). Static
+      // (snapshot) hosts re-render from cache and never take a seat, so the default tiers are free.
+      val seat = if (renderHost.canApplyOverrides) liveSeats else null
+      if (seat != null && !seat.tryAcquire()) {
+        close(CloseReason(1013.toShort(), "live preview at capacity — try again shortly"))
+        return
+      }
+      try {
+        // Prefer the daemon's live stream lane (frames pushed, input dispatched); fall back to the
+        // snapshot re-render lane when the backend doesn't support streaming.
+        val live =
+          withContext(Dispatchers.IO) {
+            ServeLiveSession.tryStart(renderHost, previewId, initialOverrides, codec, maxFps, send)
+          }
+        if (live != null) {
+          try {
+            for (frame in incoming) {
+              if (frame is Frame.Text) {
+                val text = frame.readText()
+                withContext(Dispatchers.IO) { live.onClientMessage(text) }
+              }
+            }
+          } finally {
+            withContext(Dispatchers.IO) { live.close() }
+          }
+        } else {
+          val session = ServeStreamSession(renderHost, previewId, initialOverrides, send)
+          // Renders block (renderNow + await); keep them off the socket's event-loop thread.
+          withContext(Dispatchers.IO) { session.onOpen() }
           for (frame in incoming) {
             if (frame is Frame.Text) {
               val text = frame.readText()
-              withContext(Dispatchers.IO) { live.onClientMessage(text) }
+              withContext(Dispatchers.IO) { session.onClientMessage(text) }
             }
           }
-        } finally {
-          withContext(Dispatchers.IO) { live.close() }
         }
-      } else {
-        val session = ServeStreamSession(renderHost, previewId, initialOverrides, send)
-        // Renders block (renderNow + await); keep them off the socket's event-loop thread.
-        withContext(Dispatchers.IO) { session.onOpen() }
-        for (frame in incoming) {
-          if (frame is Frame.Text) {
-            val text = frame.readText()
-            withContext(Dispatchers.IO) { session.onClientMessage(text) }
-          }
-        }
+      } finally {
+        seat?.release()
       }
     } finally {
       lease.close()

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistry.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistry.kt
@@ -141,6 +141,17 @@ class ServeSessionRegistry(
   }
 
   /**
+   * True when [sessionId] is an already-registered **static** (pinned) session — a bundle/catalog
+   * host that replays baked PNGs and holds no daemon, so leasing it spawns nothing. Unknown or
+   * daemon-backed (non-pinned, incl. a lazily-forked one) sessions return false, so the live-seat
+   * gate reserves a seat for anything whose open could cost a render daemon. Never opens/forks a
+   * host.
+   */
+  fun isKnownStatic(sessionId: String): Boolean = lock.withLock {
+    sessions[sessionId]?.pinned == true
+  }
+
+  /**
    * Milliseconds the *whole server* has been idle, or `null` when it's busy (any session has an
    * open lease — e.g. a live WebSocket). Idle counts from the last acquire/lease/release; with no
    * leases and no requests it grows unbounded. Drives the ephemeral "exit when idle" watchdog.

--- a/deploy/image/docker-compose.yml
+++ b/deploy/image/docker-compose.yml
@@ -40,6 +40,12 @@ services:
       # Unused in public mode; required only when SERVE_PUBLIC=0.
       SERVE_TOKEN: "${SERVE_TOKEN:-}"
       SERVE_IDLE_EXIT: "0"
+      # Live (daemon-backed) preview tier — OFF by default (snapshot + in-browser Wasm only). To
+      # offer live CMP-JVM streaming on this box, set SERVE_ALLOW_RENDER_TRUSTED=1 (+ its ref
+      # allowlist) and cap the seats: each seat is a JVM Compose daemon, so on this 4 GB / 2 vCPU box
+      # keep it small (1–2). An over-cap viewer is refused (WS 1013) instead of OOM-ing the box.
+      # Flip on with a compose redeploy: set these in .env, then `docker compose up -d`.
+      SERVE_LIVE_SEATS: "${SERVE_LIVE_SEATS:-}"
       PORT: "8080"
     # To pin your OWN producers, mount a trust store over the baked one and keep
     # SERVE_TRUST_STORE pointing at it:

--- a/deploy/image/entrypoint.sh
+++ b/deploy/image/entrypoint.sh
@@ -55,6 +55,11 @@ fi
 if [[ "${SERVE_ALLOW_RENDER_TRUSTED:-}" == "1" || "${SERVE_ALLOW_RENDER_TRUSTED:-}" == "true" ]]; then
   args+=(--allow-render-trusted)
 fi
+# Bound concurrent live (daemon-backed) stream seats. Only meaningful once the live tier is enabled
+# (SERVE_ALLOW_RENDER_TRUSTED) — each seat holds a JVM Compose daemon, so a small box (preview.coo.ee
+# is 4 GB / 2 vCPU) should cap it (e.g. SERVE_LIVE_SEATS=1) so an over-cap viewer is refused rather
+# than OOM-ing the box. Unset ⇒ unbounded (fine for a beefy box or the snapshot/Wasm-only default).
+[[ -n "${SERVE_LIVE_SEATS:-}" ]] && args+=(--live-seats "${SERVE_LIVE_SEATS}")
 if [[ "${SERVE_ACCEPT_BUNDLES:-}" == "1" || "${SERVE_ACCEPT_BUNDLES:-}" == "true" ]]; then
   args+=(--accept-bundles)
   [[ -n "${SERVE_ACCEPT_BUNDLES_FROM:-}" ]] &&

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -167,6 +167,16 @@ clear the `--revisions-allow` allowlist, and its `source.repo` must be the serve
 (set `SERVE_ALLOW_RENDER_TRUSTED=1` + `SERVE_REVISIONS_ALLOW=main`), where the heavier per-session
 Gradle build + live render is acceptable.
 
+### Bounding the live tier — `--live-seats` / `SERVE_LIVE_SEATS`
+
+Each live (daemon-backed) stream holds a JVM Compose render session, so on a constrained box a burst
+of viewers could exhaust memory. `--live-seats <n>` (env `SERVE_LIVE_SEATS`) caps concurrent live
+streams: a stream that would exceed the cap is refused with WebSocket close `1013` (*Try Again
+Later*) instead of spawning an unbounded daemon and risking the OOM killer. `0` (the default) is
+unbounded; snapshot + Wasm sessions never consume a seat. On a small box (e.g. a 4 GB / 2 vCPU VM),
+keep it to **1–2** when you turn the live tier on — it's just another env var, so flip it with a
+compose redeploy (`SERVE_LIVE_SEATS=1` in `.env`, then `docker compose up -d`).
+
 ## Endpoints
 
 `GET /` index · `GET /p/{id}?session=<s>` viewer · `GET /render/{id}.png` PNG ·


### PR DESCRIPTION
## Summary

Make it safe to enable the live (daemon-backed) CMP-JVM streaming tier on a small public box, and keep it a **compose-redeploy toggle**.

The live tier already exists (`--allow-render-trusted` builds a `Trusted` catalog's source into a live, daemon-backed session) and is already env-gated (`SERVE_ALLOW_RENDER_TRUSTED`, off by default). What was missing — per the box-capacity analysis (preview.coo.ee is **4 GB / 2 vCPU**, ~1–2 concurrent daemons before OOM) — was a **bound** on concurrent live sessions.

- **`--live-seats <n>`** (env **`SERVE_LIVE_SEATS`**) caps concurrent live, daemon-backed streams. Each seat holds a JVM Compose render session; a stream that would exceed the cap is refused with **WebSocket close `1013` (Try Again Later)** instead of spawning an unbounded daemon and risking the OOM killer.
- **`0` (default) = unbounded** — the historical local-`serve` behaviour. Only bites when a live daemon actually backs a session: **snapshot + Wasm sessions never take a seat** (gated on `canApplyOverrides`), so the public server's default tiers are unaffected.
- **Toggle via redeploy:** wired through the deploy `entrypoint.sh` + `docker-compose.yml` next to `SERVE_ALLOW_RENDER_TRUSTED`, so an operator turns the bounded live tier on with `SERVE_ALLOW_RENDER_TRUSTED=1` + `SERVE_LIVE_SEATS=1` in `.env` and `docker compose up -d`.

## Changes
- `serve/ServeHttpServer.kt` — `maxLiveSeats` ctor param + a `Semaphore` seat gate in `serveStreamLane`, acquired only for daemon-backed (`canApplyOverrides`) sessions, released when the stream ends.
- `ServeCommand.kt` — `--live-seats` flag → `maxLiveSeats`; `--help` entry.
- `CliFlags.kt` — registered the new value flag.
- `deploy/image/{entrypoint.sh,docker-compose.yml}` — `SERVE_LIVE_SEATS` env plumbing + guidance.
- `docs/public-preview-server.md` — a "Bounding the live tier" section.

## Test plan
- `./gradlew :cli:test` — full suite green (incl. the `CliFlagsRegistryTest` flag-registry guard).
- The seat gate itself is a standard `Semaphore.tryAcquire`/`release` around the daemon stream; the **live WS-rejection path needs a real render daemon**, so it's exercised at deploy rather than unit-tested here (the routing test has no daemon/WS harness). Logic is correct-by-construction: acquire before the stream for `canApplyOverrides` hosts, `1013` on miss, release in `finally`.

## Notes
Non-visual (serve plumbing + deploy config), so no rendered evidence. Independent of the two wasm-app PRs merged earlier this session; ships in the next preview-host image.


---
_Generated by [Claude Code](https://claude.ai/code/session_01K8nJEfEYGM3ijyoAXDNLGH)_