### PR TITLE
fix: cap PR comment body to GitHub's 65,536-char limit

### DIFF
--- a/.github/actions/apply/action.yml
+++ b/.github/actions/apply/action.yml
@@ -653,15 +653,15 @@ runs:
         # resolved body, no-diff+no-prior → only post resolved if
         # comment-on-empty-diff=true.
         RESOLVED_BODY="${MARKER}"$'\n'"## Resource Changes"$'\n\n'"_No resource changes in this PR's latest render._"
-        # Stream body via file when present — large resource diffs would
-        # otherwise blow ARG_MAX. RESOLVED_BODY is small and stays inline.
+        # Route the populated-body path through post-comment.sh so a large
+        # resource diff gets the same ARG_MAX streaming *and* the
+        # 65,536-char truncation guard as every other comment (the helper
+        # re-resolves the sticky comment by MARKER and PATCHes/posts).
+        # RESOLVED_BODY is small and stays inline.
         if [ -s _comment_body_resources.md ]; then
-          if [ -n "$COMMENT_ID" ]; then
-            gh api "repos/${REPO}/issues/comments/${COMMENT_ID}" \
-              -X PATCH -f "body=@_comment_body_resources.md"
-          else
-            gh pr comment "$PR_NUMBER" --body-file _comment_body_resources.md
-          fi
+          export PR_NUMBER MARKER
+          export BODY_FILE="_comment_body_resources.md"
+          bash "$ACTION_PATH/lib/post-comment.sh"
         elif [ -n "$COMMENT_ID" ]; then
           gh api "repos/${REPO}/issues/comments/${COMMENT_ID}" \
             -X PATCH -f body="$RESOLVED_BODY"

--- a/.github/actions/apply/lib/post-comment.sh
+++ b/.github/actions/apply/lib/post-comment.sh
@@ -25,6 +25,30 @@ set -euo pipefail
 # `gh pr comment --body-file` and `gh api -f key=@file` both stream from
 # the file instead of expanding it into the command line.
 
+# GitHub's comment API caps a single body at 65,536 characters ("Body is
+# too long"). Streaming from a file dodges ARG_MAX but *not* this ceiling,
+# so truncate an over-long body here — defence in depth for every comment
+# the action posts (e.g. a large module's a11y report). The budget is in
+# bytes; a UTF-8 string's byte length is >= its character count, so keeping
+# under the byte budget guarantees we're under the character cap, with
+# headroom for the truncation notice. We keep the head of the body (the
+# marker + summary live at the top) and cut on a line boundary.
+MAX_BYTES="${COMMENT_MAX_BYTES:-60000}"
+BODY_BYTES=$(wc -c < "$BODY_FILE")
+if [ "$BODY_BYTES" -gt "$MAX_BYTES" ]; then
+  NOTICE=$'\n\n---\n> ⚠️ This comment was truncated because it exceeded GitHub'\''s 65,536-character limit. See the full report in the render branch / workflow artifacts.'
+  NOTICE_BYTES=$(printf '%s' "$NOTICE" | wc -c)
+  BUDGET=$((MAX_BYTES - NOTICE_BYTES))
+  TRUNCATED=$(mktemp)
+  # Cut to the byte budget, then drop the final (possibly partial) line so
+  # we always end on a clean line boundary and never leave a half-written
+  # multi-byte character.
+  head -c "$BUDGET" "$BODY_FILE" | sed '$d' > "$TRUNCATED"
+  printf '%s\n' "$NOTICE" >> "$TRUNCATED"
+  echo "post-comment: body was ${BODY_BYTES} bytes; truncated to fit GitHub's 65,536-char comment limit." >&2
+  BODY_FILE="$TRUNCATED"
+fi
+
 COMMENT_ID=$(gh api \
   "repos/${REPO}/issues/${PR_NUMBER}/comments" \
   --paginate \


### PR DESCRIPTION
## Summary

The `apply` composite action's a11y comment overflows GitHub's per-comment **65,536-character** API cap for large-preview modules, failing the render check with:

```
GraphQL: Body is too long (maximum is 65536 characters) (addComment)
```

The renders themselves succeed — only the a11y comment overflows. Streaming the body from a file (in `post-comment.sh`) already guards **ARG_MAX** (~128 KB) but not this *separate* comment-API ceiling, which streaming doesn't help with.

## Fix

Add a generic truncation guard in `.github/actions/apply/lib/post-comment.sh` — defence in depth for **every** comment the action posts (a11y, preview-diff, resources, notifications), not just a11y:

- If the body exceeds the budget, truncate it on a **line boundary** and append a truncation notice pointing to the render branch / workflow artifacts for the full report.
- Budget is **60,000 bytes** (overridable via `COMMENT_MAX_BYTES`). Since a UTF-8 string's byte length is `>=` its character count, staying under the byte budget guarantees we're under the 65,536-character cap, with headroom for the notice.
- The marker + summary at the **head** of the body are preserved (the sticky-comment marker must remain at the start), and dropping the final partial line avoids leaving a half-written multi-byte character.

## Test plan

- `bash -n` passes on the modified script.
- Verified the truncation logic in isolation against a ~469 KB body: output is 59,979 bytes / chars (well under the 65,536 cap), the `<!-- marker -->` is preserved at the top, the notice is appended on a clean line boundary, and no partial line remains.
- Bodies under the budget are passed through unchanged (the guard is a no-op).

Non-visual change (CI/tooling plumbing), so no rendered evidence applies.

Fixes #2143

---
_Generated by [Claude Code](https://claude.ai/code/session_01HripkmaVVdZqvWxNj8ypCa)_