### PR TITLE
perf(preview-ci): shard renders by default and widen the fork cap

### DIFF
--- a/.github/workflows/compose-preview.yml
+++ b/.github/workflows/compose-preview.yml
@@ -5,7 +5,11 @@ name: Compose Preview
 # Replaces preview-baselines.yml, preview-comment.yml, a11y-report.yml,
 # and notification-previews.yml — the `apply` composite picks baseline-vs-
 # comment from the triggering event and runs the four pipelines (compose /
-# resources / a11y / notifications) concurrently.
+# resources / a11y / notifications) back-to-back — they share the Gradle
+# build lock and the same `.git`, so `apply` serializes them on purpose
+# (see action.yml "Run pipelines"). Concurrency lives *inside* the compose
+# render: `composePreview { shards }` fans previews across parallel JVM
+# forks.
 
 on:
   push:

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -365,21 +365,38 @@ abstract class Command(
    * it explicitly even if cache discovery misfires), else empty. Discovery via the cache path is
    * the general mechanism; passing the property is a belt-and-braces handoff.
    */
+  /**
+   * Run `:<module>:composePreviewDiscover` for every module as its own Gradle invocation, ahead of
+   * the render. This is what makes `composePreview { shards = auto }` size the fork count correctly
+   * on a cold CI runner: the plugin resolves the shard count at *configuration* time by reading
+   * `build/compose-previews/previews.json`, which only exists once discover has run. Because
+   * `composePreviewRenderAll` depends on discover, a *separate* prior discover invocation writes
+   * the manifest, so when the render invocation configures (a distinct task set → its own
+   * configuration-cache entry) it sees a fresh manifest and auto sizing engages on the first run.
+   * On warm builds discover is UP-TO-DATE and near-free. Returns the build result; callers treat
+   * failure as non-fatal (the render re-runs discover as a dependency and surfaces the real error).
+   */
+  protected fun runDiscover(
+    gradle: GradleConnection,
+    modules: List<PreviewModule>,
+    silenceStdout: Boolean,
+  ): Boolean =
+    withGradleStdout(silenceStdout) {
+      val tasks = modules.map { ":${it.gradlePath}:composePreviewDiscover" }.toTypedArray()
+      runGradle(gradle, *tasks)
+    }
+
   protected fun provisionXrCompositeArgs(
     gradle: GradleConnection,
     modules: List<PreviewModule>,
     silenceStdout: Boolean,
+    discoverFirst: Boolean = true,
   ): List<String> {
     if (modules.isEmpty()) return emptyList()
-    // Discover first so previews.json exists; renderAll depends on discover anyway, so on a warm
-    // build this is a no-op UP-TO-DATE pass. A discovery failure isn't fatal here — the subsequent
-    // render will surface it; we just can't gate, so we skip provisioning.
-    val discoverOk =
-      withGradleStdout(silenceStdout) {
-        val tasks = modules.map { ":${it.gradlePath}:composePreviewDiscover" }.toTypedArray()
-        runGradle(gradle, *tasks)
-      }
-    if (!discoverOk) return emptyList()
+    // Discover so previews.json exists before we read it to gate the XR fetch. Callers that already
+    // ran [runDiscover] pass discoverFirst = false to avoid a redundant (UP-TO-DATE) pass. A
+    // discovery failure isn't fatal — the subsequent render surfaces it; we just skip provisioning.
+    if (discoverFirst && !runDiscover(gradle, modules, silenceStdout)) return emptyList()
     val hasXr =
       readAllManifests(modules).any { (_, manifest) ->
         manifest.previews.any { it.params.kind == XrCompositeProvision.XR_SUBSPACE_KIND }
@@ -442,7 +459,13 @@ abstract class Command(
       val buildOk =
         if (modules.isEmpty()) true
         else {
-          val xrArgs = provisionXrCompositeArgs(gradle, modules, silenceStdout)
+          // Explicit discover pass before the render so `shards=auto` sees a fresh previews.json at
+          // render-configuration time (see [runDiscover]). Kept as a first-class step — not an
+          // incidental side effect of XR provisioning — so shard sizing can't regress if the XR
+          // path changes. provisionXr therefore skips its own (now-redundant) discover.
+          runDiscover(gradle, modules, silenceStdout)
+          val xrArgs =
+            provisionXrCompositeArgs(gradle, modules, silenceStdout, discoverFirst = false)
           val tasks = modules.map(taskFor).toTypedArray()
           val ok =
             withGradleStdout(silenceStdout) {

--- a/gradle-plugin/gradle-plugin-config/src/main/kotlin/ee/schimke/composeai/plugin/PreviewExtension.kt
+++ b/gradle-plugin/gradle-plugin-config/src/main/kotlin/ee/schimke/composeai/plugin/PreviewExtension.kt
@@ -28,21 +28,26 @@ abstract class PreviewExtension @Inject constructor(private val objects: ObjectF
   val enabled: Property<Boolean> = objects.property(Boolean::class.java).convention(true)
 
   /**
-   * Number of parallel JVM forks used to render previews. Default 1 (no sharding).
+   * Number of parallel JVM forks used to render previews. Default `0` (auto).
    *
    * Special values:
-   * - `1` (default): no sharding; a single JVM renders every preview.
-   * - `0`: auto — the plugin picks a shard count based on the discovered preview count and
-   *   available CPU cores, using [ShardTuning]'s cost model. Falls back to 1 if previews.json
-   *   hasn't been generated yet.
+   * - `0` (default): auto — the plugin picks a shard count based on the discovered preview cost
+   *   (see [ShardTuning]'s model) and the runner's CPU cores + memory. It only shards when the
+   *   predicted saving clears both an absolute and a relative threshold, so light modules stay on a
+   *   single fork; heavy ones (many previews, GIF/animated captures) fan out. Falls back to 1 if
+   *   `previews.json` hasn't been generated yet — the CLI runs `composePreviewDiscover` as a
+   *   separate Gradle invocation before rendering, so on CI the render's configuration already sees
+   *   a fresh manifest and auto sizing engages on the first run.
+   * - `1`: force no sharding; a single JVM renders every preview.
    * - `≥2`: explicit shard count.
    *
    * Each shard runs a generated `RobolectricRenderTest_ShardN` subclass with its own slice of the
    * manifest (round-robin partition). Within a shard, the Robolectric sandbox is reused across that
    * shard's previews; across shards each JVM pays its own ~3–4s cold-start cost, so sharding is a
-   * net win only when the module has enough previews to amortise that overhead.
+   * net win only when the module has enough previews to amortise that overhead — which is exactly
+   * what the auto model checks before turning it on.
    */
-  val shards: Property<Int> = objects.property(Int::class.java).convention(1)
+  val shards: Property<Int> = objects.property(Int::class.java).convention(0)
 
   /**
    * When `true`, Robolectric instantiates the consumer's manifest-declared `Application` class

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -2735,12 +2735,20 @@ internal object AndroidPreviewSupport {
     val totalCost = explicitCostSum + implicitCostSum
     val maxIndividualCost =
       (costs.maxOrNull() ?: 1.0).coerceAtLeast(if (captureCount > costs.size) 1.0 else 0.0)
-    val resolved = ShardTuning.autoShards(totalCost, maxIndividualCost, captureCount)
+    val hostMemoryMb = ShardTuning.hostMemoryMb()
+    val resolved =
+      ShardTuning.autoShards(
+        totalCost = totalCost,
+        maxIndividualCost = maxIndividualCost,
+        captureCount = captureCount,
+        availableMemoryMb = hostMemoryMb,
+      )
+    val memTag = if (hostMemoryMb == Long.MAX_VALUE) "unknown" else "${hostMemoryMb}MB"
     project.logger.lifecycle(
       "compose-ai-tools: shards=auto → $resolved " +
         "(captures=$captureCount, totalCost=${"%.1f".format(totalCost)}, " +
         "maxCost=${"%.1f".format(maxIndividualCost)}, " +
-        "cores=${Runtime.getRuntime().availableProcessors()})"
+        "cores=${Runtime.getRuntime().availableProcessors()}, mem=$memTag)"
     )
     return resolved
   }

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -2714,40 +2714,33 @@ internal object AndroidPreviewSupport {
       )
       return 1
     }
-    // Cheap regex parse — keeps kotlinx.serialization off the plugin
-    // classpath. Each Capture entry in `previews.json` carries its own
-    // `"renderOutput"` field (so counting those gives the capture
-    // count, not the preview count) and an optional `"cost"` (added
-    // post-0.8.0; older manifests omit it and the renderer treats
-    // missing as 1.0). We feed `(totalCost, maxIndividualCost,
-    // captureCount)` into [ShardTuning.autoShards] so a module with
-    // three GIF captures (cost = 40 each) gets sharded for the right
-    // reason rather than being judged by preview count alone.
+    // Size by preview *row*, not by capture. The renderer shards whole preview
+    // rows (`RobolectricRenderTest.assignToShard`) — every capture of one
+    // preview stays on the same fork — so a preview with many heavy captures
+    // (paused-clock / GIF frames) is one indivisible unit. Counting captures
+    // here would let auto pick more forks than there are rows to spread, so the
+    // extra forks sit idle and the run ends up slower than a single fork.
+    // [ShardTuning.perPreviewRowCosts] groups captures + data products per
+    // preview entry, mirroring the renderer's per-row cost. `@PreviewParameter`
+    // expansion only adds rows in the renderer, so this is a safe lower bound.
     val text = previewsJson.readText()
-    val captureCount = Regex("\"renderOutput\"\\s*:").findAll(text).count()
-    val costs =
-      Regex("\"cost\"\\s*:\\s*([0-9.]+)")
-        .findAll(text)
-        .mapNotNull { it.groupValues[1].toDoubleOrNull() }
-        .toList()
-    val explicitCostSum = costs.sum()
-    val implicitCostSum = (captureCount - costs.size).coerceAtLeast(0).toDouble()
-    val totalCost = explicitCostSum + implicitCostSum
-    val maxIndividualCost =
-      (costs.maxOrNull() ?: 1.0).coerceAtLeast(if (captureCount > costs.size) 1.0 else 0.0)
+    val rowCosts = ShardTuning.perPreviewRowCosts(text)
+    val rowCount = rowCosts.size
+    val totalCost = rowCosts.sum()
+    val maxIndividualCost = rowCosts.maxOrNull() ?: 0.0
     val hostMemoryMb = ShardTuning.hostMemoryMb()
     val resolved =
       ShardTuning.autoShards(
         totalCost = totalCost,
         maxIndividualCost = maxIndividualCost,
-        captureCount = captureCount,
+        shardableRows = rowCount,
         availableMemoryMb = hostMemoryMb,
       )
     val memTag = if (hostMemoryMb == Long.MAX_VALUE) "unknown" else "${hostMemoryMb}MB"
     project.logger.lifecycle(
       "compose-ai-tools: shards=auto → $resolved " +
-        "(captures=$captureCount, totalCost=${"%.1f".format(totalCost)}, " +
-        "maxCost=${"%.1f".format(maxIndividualCost)}, " +
+        "(rows=$rowCount, totalCost=${"%.1f".format(totalCost)}, " +
+        "maxRowCost=${"%.1f".format(maxIndividualCost)}, " +
         "cores=${Runtime.getRuntime().availableProcessors()}, mem=$memTag)"
     )
     return resolved

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ShardTuning.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ShardTuning.kt
@@ -93,15 +93,24 @@ internal object ShardTuning {
    * ([MIN_SAVING_FRACTION]) thresholds. Otherwise returns 1.
    *
    * Upper bound is `min(MAX_SHARDS, cores − 1, availableMemoryMb / PER_FORK_MEMORY_MB,
-   * captureCount)`. We leave a single core for the Gradle daemon + I/O rather than the old `cores /
-   * 2` — while the render task runs it is effectively the *only* Gradle work in flight, so
+   * shardableRows)`. We leave a single core for the Gradle daemon + I/O rather than the old `cores
+   * / 2` — while the render task runs it is effectively the *only* Gradle work in flight, so
    * reserving half the machine left it idle. On the standard GitHub runner ladder that roughly
    * doubles the usable fork count (a 4-vCPU runner goes from 2 → 3). The memory term stops a
-   * many-core-but-low-RAM runner from OOM-ing; never shard below one capture per fork.
+   * many-core-but-low-RAM runner from OOM-ing; never shard below one row per fork.
    *
-   * @param totalCost sum of `Capture.cost` across every capture in the manifest
-   * @param maxIndividualCost largest single `Capture.cost` value (sets the makespan floor)
-   * @param captureCount total number of captures (caps shard count so each fork gets ≥ 1)
+   * **[shardableRows], not capture count.** The renderer partitions whole preview *rows* across
+   * forks (`RobolectricRenderTest.assignToShard`) — every capture of one preview stays on the same
+   * shard, so a preview is indivisible no matter how many captures it has. Sizing by raw capture
+   * count would let this pick more forks than there are rows to spread, leaving the extra forks
+   * idle and making a multi-capture module (paused-clock / GIF frames) *slower* than a single fork.
+   * Callers pass the preview-row count and per-row cost (see [ShardTuning.perPreviewRowCosts]).
+   *
+   * @param totalCost sum of every row's cost across the manifest
+   * @param maxIndividualCost largest single *row* cost (sum of that preview's captures + data
+   *   products) — sets the makespan floor, since no shard can finish before its heaviest row
+   * @param shardableRows number of indivisible preview rows (caps shard count so each fork gets
+   *   ≥ 1)
    * @param cores CPU cores visible to the build (defaults to the runtime processor count)
    * @param availableMemoryMb host physical memory in MB used to bound forks; defaults to
    *   [Long.MAX_VALUE] so unit tests exercise the CPU/cost logic without a machine-dependent memory
@@ -110,18 +119,18 @@ internal object ShardTuning {
   fun autoShards(
     totalCost: Double,
     maxIndividualCost: Double,
-    captureCount: Int,
+    shardableRows: Int,
     cores: Int = Runtime.getRuntime().availableProcessors(),
     availableMemoryMb: Long = Long.MAX_VALUE,
   ): Int {
-    if (captureCount < 2 || totalCost <= 0.0) return 1
+    if (shardableRows < 2 || totalCost <= 0.0) return 1
     val memForks = (availableMemoryMb / PER_FORK_MEMORY_MB).coerceAtLeast(1L)
     val maxK =
       minOf(
           MAX_SHARDS.toLong(),
           (cores - 1).coerceAtLeast(1).toLong(),
           memForks,
-          captureCount.toLong(),
+          shardableRows.toLong(),
         )
         .toInt()
     if (maxK < 2) return 1
@@ -158,4 +167,74 @@ internal object ShardTuning {
     } catch (_: Throwable) {
       Long.MAX_VALUE
     }
+
+  private val COST_FIELD = Regex("\"cost\"\\s*:\\s*([0-9.]+)")
+  private val RENDER_OUTPUT_FIELD = Regex("\"renderOutput\"\\s*:")
+
+  /**
+   * Parse a `previews.json` manifest into one cost per **preview row** — the unit the renderer
+   * actually shards on ([autoShards] docs). Each element is the summed cost of one preview entry's
+   * captures + data products, mirroring the per-row cost `RobolectricRenderTest.assignToShard`
+   * uses. The returned size is the shardable-row count.
+   *
+   * Hand-rolled brace-depth scan rather than `kotlinx.serialization` to keep that dependency off
+   * the plugin classpath (same rationale as the rest of the plugin's manifest reads). It groups by
+   * the top-level objects inside the `"previews"` array, so nested capture/product objects don't
+   * inflate the row count. `@PreviewParameter` expansion happens later in the renderer and only
+   * *adds* rows, so this count is a safe lower bound: we may under-shard a provider-heavy module,
+   * never over-shard it. A capture with no explicit `cost` (pre-0.8.0 manifest) is priced at 1.0,
+   * matching the renderer's default.
+   */
+  fun perPreviewRowCosts(manifestText: String): List<Double> {
+    val previewsKey = manifestText.indexOf("\"previews\"")
+    if (previewsKey < 0) return emptyList()
+    val arrStart = manifestText.indexOf('[', previewsKey)
+    if (arrStart < 0) return emptyList()
+
+    val rows = mutableListOf<Double>()
+    var depth = 0
+    var inString = false
+    var escaped = false
+    var entryStart = -1
+    var i = arrStart + 1
+    while (i < manifestText.length) {
+      val c = manifestText[i]
+      if (inString) {
+        when {
+          escaped -> escaped = false
+          c == '\\' -> escaped = true
+          c == '"' -> inString = false
+        }
+      } else {
+        when (c) {
+          '"' -> inString = true
+          '{' -> {
+            if (depth == 0) entryStart = i
+            depth++
+          }
+          '}' -> {
+            depth--
+            if (depth == 0 && entryStart >= 0) {
+              rows += rowCost(manifestText.substring(entryStart, i + 1))
+              entryStart = -1
+            }
+          }
+          ']' -> if (depth == 0) break // end of the previews array
+        }
+      }
+      i++
+    }
+    return rows
+  }
+
+  /**
+   * Cost of one preview entry: sum of its `cost` fields, or 1.0 per capture on a pre-cost manifest.
+   */
+  private fun rowCost(entryJson: String): Double {
+    val costs =
+      COST_FIELD.findAll(entryJson).mapNotNull { it.groupValues[1].toDoubleOrNull() }.toList()
+    if (costs.isNotEmpty()) return costs.sum()
+    val captures = RENDER_OUTPUT_FIELD.findAll(entryJson).count()
+    return captures.coerceAtLeast(1).toDouble()
+  }
 }

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ShardTuning.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ShardTuning.kt
@@ -49,6 +49,17 @@ internal object ShardTuning {
   const val MAX_SHARDS = 8
 
   /**
+   * Estimated peak memory (MB) a single render fork holds — Robolectric sandbox + Compose runtime +
+   * the forked JVM's own heap/metaspace/native overhead. Used only to bound the fork count on
+   * memory-constrained runners: [autoShards] never asks for more forks than `availableMemoryMb /
+   * PER_FORK_MEMORY_MB`. Deliberately generous (a static-only fork is far lighter) so we err on the
+   * side of not OOM-ing a small runner. GitHub-hosted runners scale RAM with cores (2-vCPU≈7 GB,
+   * 4-vCPU≈16 GB), so on the standard ladder the CPU cap usually binds first and this only bites on
+   * tight self-hosted / container runners.
+   */
+  const val PER_FORK_MEMORY_MB = 2048L
+
+  /**
    * Auto mode only turns sharding on when both thresholds are met versus the single-fork baseline.
    * Rationale: forking is an externally visible cost (more JVMs, more memory, more log noise) — we
    * should only pay it when the gain is unambiguous. A 2s→1s speedup is not worth the complexity.
@@ -81,21 +92,38 @@ internal object ShardTuning {
    * if the improvement over K = 1 clears BOTH the absolute ([MIN_SAVING_SECONDS]) and relative
    * ([MIN_SAVING_FRACTION]) thresholds. Otherwise returns 1.
    *
-   * Upper bound is `min(MAX_SHARDS, cores / 2, captureCount)` — leave CPU headroom for Gradle
-   * workers; never shard below one capture per fork.
+   * Upper bound is `min(MAX_SHARDS, cores − 1, availableMemoryMb / PER_FORK_MEMORY_MB,
+   * captureCount)`. We leave a single core for the Gradle daemon + I/O rather than the old `cores /
+   * 2` — while the render task runs it is effectively the *only* Gradle work in flight, so
+   * reserving half the machine left it idle. On the standard GitHub runner ladder that roughly
+   * doubles the usable fork count (a 4-vCPU runner goes from 2 → 3). The memory term stops a
+   * many-core-but-low-RAM runner from OOM-ing; never shard below one capture per fork.
    *
    * @param totalCost sum of `Capture.cost` across every capture in the manifest
    * @param maxIndividualCost largest single `Capture.cost` value (sets the makespan floor)
    * @param captureCount total number of captures (caps shard count so each fork gets ≥ 1)
+   * @param cores CPU cores visible to the build (defaults to the runtime processor count)
+   * @param availableMemoryMb host physical memory in MB used to bound forks; defaults to
+   *   [Long.MAX_VALUE] so unit tests exercise the CPU/cost logic without a machine-dependent memory
+   *   cap. Production callers pass [hostMemoryMb].
    */
   fun autoShards(
     totalCost: Double,
     maxIndividualCost: Double,
     captureCount: Int,
     cores: Int = Runtime.getRuntime().availableProcessors(),
+    availableMemoryMb: Long = Long.MAX_VALUE,
   ): Int {
     if (captureCount < 2 || totalCost <= 0.0) return 1
-    val maxK = minOf(MAX_SHARDS, (cores / 2).coerceAtLeast(1), captureCount)
+    val memForks = (availableMemoryMb / PER_FORK_MEMORY_MB).coerceAtLeast(1L)
+    val maxK =
+      minOf(
+          MAX_SHARDS.toLong(),
+          (cores - 1).coerceAtLeast(1).toLong(),
+          memForks,
+          captureCount.toLong(),
+        )
+        .toInt()
     if (maxK < 2) return 1
 
     val baseline = predictedSeconds(totalCost, maxIndividualCost, 1)
@@ -113,4 +141,21 @@ internal object ShardTuning {
     return if (bestK >= 2 && saved >= MIN_SAVING_SECONDS && fraction >= MIN_SAVING_FRACTION) bestK
     else 1
   }
+
+  /**
+   * Best-effort host physical memory in MB, for the [autoShards] memory bound. Reads the HotSpot
+   * `com.sun.management.OperatingSystemMXBean`; if that management interface isn't present (non-Sun
+   * JVM), returns [Long.MAX_VALUE] so the memory term simply doesn't bind and the CPU/cost caps
+   * decide. Container memory limits aren't reflected by this bean pre-JDK-uncommon setups, but the
+   * generous [PER_FORK_MEMORY_MB] margin absorbs the slack.
+   */
+  fun hostMemoryMb(): Long =
+    try {
+      val os = java.lang.management.ManagementFactory.getOperatingSystemMXBean()
+      val sunOs = os as? com.sun.management.OperatingSystemMXBean
+      val bytes = sunOs?.totalMemorySize ?: -1L
+      if (bytes > 0L) bytes / (1024L * 1024L) else Long.MAX_VALUE
+    } catch (_: Throwable) {
+      Long.MAX_VALUE
+    }
 }

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/ShardTuningTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/ShardTuningTest.kt
@@ -86,8 +86,10 @@ class ShardTuningTest {
   }
 
   @Test
-  fun `shard count is bounded by half the available cores`() {
-    // Lots of cheap captures, but only 4 cores → cap at K = 2.
+  fun `shard count leaves one core for the Gradle daemon`() {
+    // Lots of cheap captures, but only 4 cores → cap at K = cores - 1 = 3.
+    // (Was cores / 2 = 2 before we stopped reserving half the machine for a
+    // Gradle worker pool that's idle while the render task runs.)
     val k =
       ShardTuning.autoShards(
         totalCost = 1000.0,
@@ -95,7 +97,38 @@ class ShardTuningTest {
         captureCount = 1000,
         cores = 4,
       )
+    assertThat(k).isAtMost(3)
+    // And it genuinely uses the extra headroom: a 2-core cap would return ≤2.
+    assertThat(k).isGreaterThan(2)
+  }
+
+  @Test
+  fun `shard count is bounded by available memory`() {
+    // 16 cores would allow up to MAX_SHARDS, and the cost easily justifies it,
+    // but only ~4 GB of RAM → 4096 / PER_FORK_MEMORY_MB(2048) = 2 forks max.
+    val k =
+      ShardTuning.autoShards(
+        totalCost = 1000.0,
+        maxIndividualCost = 1.0,
+        captureCount = 1000,
+        cores = 16,
+        availableMemoryMb = 4096,
+      )
     assertThat(k).isAtMost(2)
+  }
+
+  @Test
+  fun `unbounded memory default does not cap sharding`() {
+    // Same shape as the memory test but with the default (unbounded) memory:
+    // the CPU/cost caps decide, so we get more than the 2 the 4 GB run allowed.
+    val k =
+      ShardTuning.autoShards(
+        totalCost = 1000.0,
+        maxIndividualCost = 1.0,
+        captureCount = 1000,
+        cores = 16,
+      )
+    assertThat(k).isGreaterThan(2)
   }
 
   @Test

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/ShardTuningTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/ShardTuningTest.kt
@@ -16,7 +16,12 @@ class ShardTuningTest {
   @Test
   fun `single static preview never shards`() {
     val k =
-      ShardTuning.autoShards(totalCost = 1.0, maxIndividualCost = 1.0, captureCount = 1, cores = 16)
+      ShardTuning.autoShards(
+        totalCost = 1.0,
+        maxIndividualCost = 1.0,
+        shardableRows = 1,
+        cores = 16,
+      )
     assertThat(k).isEqualTo(1)
   }
 
@@ -31,7 +36,7 @@ class ShardTuningTest {
       ShardTuning.autoShards(
         totalCost = 40.0,
         maxIndividualCost = 1.0,
-        captureCount = 40,
+        shardableRows = 40,
         cores = 16,
       )
     assertThat(k).isAtMost(2) // model-stable assertion: would be 1 today, 2 if constants ever shift
@@ -48,7 +53,7 @@ class ShardTuningTest {
       ShardTuning.autoShards(
         totalCost = 125.0,
         maxIndividualCost = 40.0,
-        captureCount = 8,
+        shardableRows = 8,
         cores = 16,
       )
     assertThat(k).isAtLeast(2)
@@ -65,7 +70,7 @@ class ShardTuningTest {
       ShardTuning.autoShards(
         totalCost = 54.0,
         maxIndividualCost = 50.0,
-        captureCount = 5,
+        shardableRows = 5,
         cores = 16,
       )
     assertThat(k).isAtMost(2)
@@ -94,7 +99,7 @@ class ShardTuningTest {
       ShardTuning.autoShards(
         totalCost = 1000.0,
         maxIndividualCost = 1.0,
-        captureCount = 1000,
+        shardableRows = 1000,
         cores = 4,
       )
     assertThat(k).isAtMost(3)
@@ -110,7 +115,7 @@ class ShardTuningTest {
       ShardTuning.autoShards(
         totalCost = 1000.0,
         maxIndividualCost = 1.0,
-        captureCount = 1000,
+        shardableRows = 1000,
         cores = 16,
         availableMemoryMb = 4096,
       )
@@ -125,30 +130,120 @@ class ShardTuningTest {
       ShardTuning.autoShards(
         totalCost = 1000.0,
         maxIndividualCost = 1.0,
-        captureCount = 1000,
+        shardableRows = 1000,
         cores = 16,
       )
     assertThat(k).isGreaterThan(2)
   }
 
   @Test
-  fun `shard count never exceeds capture count`() {
-    // 3 captures, 16 cores: even if 8 shards would minimise wall-time,
-    // we never assign fewer than 1 capture per fork.
+  fun `shard count never exceeds shardable row count`() {
+    // 3 rows, 16 cores: even if 8 shards would minimise wall-time,
+    // we never assign fewer than 1 row per fork.
     val k =
       ShardTuning.autoShards(
         totalCost = 90.0,
         maxIndividualCost = 30.0,
-        captureCount = 3,
+        shardableRows = 3,
         cores = 16,
       )
     assertThat(k).isAtMost(3)
   }
 
   @Test
-  fun `module with no captures returns single shard`() {
+  fun `one preview with many heavy captures stays single-fork`() {
+    // The regression this guards: a single paused-clock / GIF preview with
+    // eight cost-40 captures. The renderer keeps all eight captures on one
+    // shard (one indivisible row), so shardableRows = 1 even though there are
+    // eight captures and 320 units of work. Sizing by capture count would have
+    // picked multiple forks that then sit idle — slower than a single fork.
     val k =
-      ShardTuning.autoShards(totalCost = 0.0, maxIndividualCost = 0.0, captureCount = 0, cores = 16)
+      ShardTuning.autoShards(
+        totalCost = 320.0,
+        maxIndividualCost = 320.0,
+        shardableRows = 1,
+        cores = 16,
+      )
     assertThat(k).isEqualTo(1)
+  }
+
+  @Test
+  fun `module with no rows returns single shard`() {
+    val k =
+      ShardTuning.autoShards(
+        totalCost = 0.0,
+        maxIndividualCost = 0.0,
+        shardableRows = 0,
+        cores = 16,
+      )
+    assertThat(k).isEqualTo(1)
+  }
+
+  @Test
+  fun `perPreviewRowCosts sums captures and data products per preview`() {
+    // Two previews: the first is a heavy paused-clock (3 captures + 1 data
+    // product), the second a plain static. Each preview must collapse to ONE
+    // row whose cost is the sum of its captures + products — never one row per
+    // capture.
+    val manifest =
+      """
+      {
+        "schemaVersion": 1,
+        "previews": [
+          {
+            "id": "com.example.Heavy",
+            "functionName": "Heavy",
+            "className": "com.example.HeavyKt",
+            "captures": [
+              { "renderOutput": "a.png", "cost": 40.0 },
+              { "renderOutput": "b.png", "cost": 40.0 },
+              { "renderOutput": "c.png", "cost": 40.0 }
+            ],
+            "dataProducts": [ { "kind": "a11y", "output": "a.json", "cost": 3.0 } ]
+          },
+          {
+            "id": "com.example.Static",
+            "functionName": "Static",
+            "className": "com.example.StaticKt",
+            "captures": [ { "renderOutput": "s.png", "cost": 1.0 } ]
+          }
+        ]
+      }
+      """
+        .trimIndent()
+
+    val rows = ShardTuning.perPreviewRowCosts(manifest)
+    assertThat(rows).hasSize(2)
+    assertThat(rows[0]).isWithin(1e-6).of(123.0) // 40+40+40+3
+    assertThat(rows[1]).isWithin(1e-6).of(1.0)
+  }
+
+  @Test
+  fun `perPreviewRowCosts prices captures without a cost field at 1_0`() {
+    // Pre-0.8.0 manifest: no "cost" fields. Each capture is priced at 1.0, so a
+    // two-capture preview is one row of cost 2.0.
+    val manifest =
+      """
+      {
+        "previews": [
+          {
+            "id": "old",
+            "functionName": "Old",
+            "captures": [ { "renderOutput": "a.png" }, { "renderOutput": "b.png" } ]
+          }
+        ]
+      }
+      """
+        .trimIndent()
+
+    val rows = ShardTuning.perPreviewRowCosts(manifest)
+    assertThat(rows).hasSize(1)
+    assertThat(rows[0]).isWithin(1e-6).of(2.0)
+  }
+
+  @Test
+  fun `perPreviewRowCosts returns empty for a manifest with no previews`() {
+    assertThat(ShardTuning.perPreviewRowCosts("""{ "previews": [] }""")).isEmpty()
+    assertThat(ShardTuning.perPreviewRowCosts("""{ "schemaVersion": 1 }""")).isEmpty()
   }
 }

--- a/site/install.md
+++ b/site/install.md
@@ -178,6 +178,27 @@ There's also a reusable, preview-gated AI PR-review workflow (Codex / Claude
 / Gemini): see
 [PR review workflow](https://github.com/yschimke/compose-ai-tools/blob/main/docs/PR_REVIEW_WORKFLOW.md).
 
+### Speeding up preview CI
+
+Rendering is the long pole. Two levers, both about parallelism:
+
+- **Sharding (on by default).** `composePreview { shards }` fans a module's
+  previews across parallel JVM forks. The default is `0` (auto): the plugin
+  sizes the fork count from the discovered preview cost and the runner's cores
+  + memory, and only shards when the predicted saving is worth the extra JVM
+  cold-starts — so small modules stay single-fork and heavy ones (many
+  previews, GIF/animated captures) fan out automatically. Set `shards = 1` to
+  force it off, or a fixed `≥ 2` to pin it. No workflow changes needed; auto
+  sizing engages on the first CI run because the pipeline discovers previews in
+  a separate Gradle pass before rendering.
+- **Bigger runners.** Auto sharding is capped at `cores − 1` forks (leaving one
+  core for the Gradle daemon), so it can only go as wide as the runner is. The
+  default `runs-on: ubuntu-latest` is 2 vCPU on private repos (no sharding) and
+  4 vCPU on public ones (up to 3 forks). For a large preview suite, point the
+  preview job at a 4- or 8-vCPU runner — that's where the two levers compound
+  into real wall-clock savings. RAM scales with cores on GitHub-hosted runners,
+  which keeps the per-fork memory bound out of the way.
+
 ## Requirements
 
 Java 17+, Gradle 8.13+, AGP 8.13.0+ (Android), Kotlin 2.0.21+, Compose


### PR DESCRIPTION
## Summary

Speeds up the compose-preview CI we ship to consumers (the `apply` composite → `compose-preview.yml`) by letting the render step actually use the runner's parallelism. Today the render is effectively single-fork out of the box, so wall-clock scales with preview count even on multi-core runners.

Four changes, from highest leverage down:

- **Auto-sharding on by default.** `composePreview { shards }` now defaults to `0` (auto) instead of `1`. Auto sizing is already guarded by the cost model's absolute + relative saving thresholds, so light modules stay on a single fork and only heavy ones (many previews, GIF/animated captures) fan out. No consumer opt-in required. Explicit `1` (off) or `≥2` (pinned) still work.
- **Wider fork cap + memory guard.** The auto cap goes from `cores / 2` to `cores - 1` — while the render test task runs it's the only Gradle work in flight, so reserving half the machine left it idle. On the standard GitHub runner ladder that roughly doubles usable forks (a 4-vCPU runner goes 2 → 3). A new per-fork memory bound (`PER_FORK_MEMORY_MB`, fed by `ShardTuning.hostMemoryMb()`) keeps a many-core/low-RAM runner from OOM-ing.
- **Explicit pre-render discover.** `resolveShardCount` reads `previews.json` at *configuration* time, so auto sizing needs the manifest to exist before the render invocation configures. The CLI already discovered in a separate Gradle pass, but only as an incidental side effect of XR provisioning. This promotes it to a first-class `runDiscover` step in the shared `renderModules` pipeline (XR provisioning now skips its redundant pass), so shard sizing can't silently regress and engages on the first cold-CI run.
- **Docs + comment fix.** Corrected the `compose-preview.yml` comment that claimed the four pipelines run "concurrently" (they run back-to-back on purpose — shared Gradle build lock + `.git`), and documented both levers (auto sharding + larger runners) in the install guide.

No behavioral change for modules that don't clear the sharding thresholds; the diff is strictly "large preview suites now fan out."

## Test plan

- `./gradlew :gradle-plugin:test --tests "*ShardTuningTest"` — green. Added cases lock in the new `cores - 1` cap and the memory bound (a 4 GB / 16-core run caps at 2 forks; unbounded memory does not), alongside the existing cost-model decisions.
- `./gradlew :cli:compileKotlin` — green (CLI `runDiscover` refactor).
- `./gradlew :gradle-plugin:ktfmtFormatMain :cli:ktfmtFormatMain` — formatted; ktfmt check passes.
- No functional/integration test or sample pins the old single-fork default, so the `shards` convention flip is safe.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qof5ofnBsBUaWGNogcUaoe)_