### PR TITLE
fix: don't crash desktop renders on @ColorCatalog catalog sheets

### DIFF
--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
@@ -296,7 +296,8 @@ object PreviewDiscovery {
         .enableMethodInfo()
         // Field scanning powers `@ColorCatalog` design-token discovery — the annotation lands on a
         // `Color` property's backing field, so we need field metadata + annotations to see it.
-        // `ignoreFieldVisibility()` is required because a top-level `val`'s backing field is private
+        // `ignoreFieldVisibility()` is required because a top-level `val`'s backing field is
+        // private
         // static (mirrors `ignoreMethodVisibility()` for private `@Preview` functions).
         .enableFieldInfo()
         .ignoreFieldVisibility()
@@ -579,26 +580,29 @@ object PreviewDiscovery {
   )
 
   /**
-   * Reads a `String` annotation parameter, falling back to [fallback] when absent or blank — this is
-   * how `@ColorCatalog.name` defaults to the property name and `.group` to the enclosing class, the
-   * same defaulting Showkase applies.
+   * Reads a `String` annotation parameter, falling back to [fallback] when absent or blank — this
+   * is how `@ColorCatalog.name` defaults to the property name and `.group` to the enclosing class,
+   * the same defaulting Showkase applies.
    */
   private fun annStringOrDefault(ann: AnnotationInfo, param: String, fallback: String): String {
     val raw = runCatching { ann.parameterValues.getValue(param) as? String }.getOrNull()
     return raw?.takeIf { it.isNotBlank() } ?: fallback
   }
 
-  /** Default group for a token: the enclosing class simple name, with a file class's `Kt` suffix dropped. */
+  /**
+   * Default group for a token: the enclosing class simple name, with a file class's `Kt` suffix
+   * dropped.
+   */
   private fun defaultCatalogGroup(className: String): String {
     val simple = className.substringAfterLast('.')
     return simple.removeSuffix("Kt").ifBlank { simple }
   }
 
   /**
-   * Aggregates the collected `@ColorCatalog` tokens into synthetic [PreviewKind.CATALOG] sheets: one
-   * per `group`, plus a module-wide "All colours" sheet when there is more than one group (a single
-   * group would just duplicate itself). Appended after [normalizeRenderOutputs] with render outputs
-   * already shell-safe, like the Lottie assets.
+   * Aggregates the collected `@ColorCatalog` tokens into synthetic [PreviewKind.CATALOG] sheets:
+   * one per `group`, plus a module-wide "All colours" sheet when there is more than one group (a
+   * single group would just duplicate itself). Appended after [normalizeRenderOutputs] with render
+   * outputs already shell-safe, like the Lottie assets.
    */
   private fun buildColorCatalogPreviews(tokens: List<RawCatalogToken>): List<PreviewInfo> {
     if (tokens.isEmpty()) return emptyList()
@@ -615,7 +619,8 @@ object PreviewDiscovery {
         )
     }
     if (byGroup.size > 1) {
-      entries += colorCatalogPreview(id = "colorcatalog__all", displayName = "All colours", tokens = tokens)
+      entries +=
+        colorCatalogPreview(id = "colorcatalog__all", displayName = "All colours", tokens = tokens)
     }
     return entries
   }
@@ -634,9 +639,17 @@ object PreviewDiscovery {
           name = displayName,
           kind = PreviewKind.CATALOG,
           catalogTokens =
-            tokens.map { CatalogToken(className = it.className, member = it.member, label = it.name) },
+            tokens.map {
+              CatalogToken(className = it.className, member = it.member, label = it.name)
+            },
         ),
-      captures = listOf(Capture(renderOutput = "renders/$id.png")),
+      // Optional so the `composePreviewRenderAll` required-output gate doesn't fail on backends
+      // that
+      // can't draw catalog sheets yet: the Android backend renders them, but the desktop backend
+      // skips `CATALOG` (see `RenderPreviewsTask`) until #2135 adds desktop support. `optional`
+      // doesn't stop the Android render — the PNG is still produced and shown; it only means "don't
+      // fail if absent." Mirrors how the XR composite capture is marked optional.
+      captures = listOf(Capture(renderOutput = "renders/$id.png", optional = true)),
     )
 
   /**

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderPreviewsTask.kt
@@ -120,10 +120,20 @@ abstract class RenderPreviewsTask : DefaultTask() {
     // Empty
     // keeps every kind.
     val kinds = includeKinds.getOrElse(emptySet())
-    val previews =
+    val kindFiltered =
       if (kinds.isEmpty()) tierFiltered else tierFiltered.filter { it.params.kind.name in kinds }
-    val manifest =
-      if (isFastTier || kinds.isNotEmpty()) rawManifest.copy(previews = previews) else rawManifest
+    // `CATALOG` sheets carry their tokens as structured data (`params.catalogTokens`), which this
+    // desktop path's flat positional-arg protocol doesn't forward — and their display
+    // `functionName`
+    // ("Brand colours") isn't a real composable, so `getDeclaredComposableMethod` would throw and
+    // sink `composePreviewRenderAll` on any CMP/desktop module using `@ColorCatalog`. Catalog
+    // sheets
+    // render on the Android backend today; desktop catalog support is tracked in #2135. Skip them
+    // here rather than crash.
+    val previews = kindFiltered.filter { it.params.kind.name != "CATALOG" }
+    // Always rebuild from the filtered list now that the CATALOG skip applies unconditionally (the
+    // old fast-path reused `rawManifest` verbatim, which would leave catalog entries in).
+    val manifest = rawManifest.copy(previews = previews)
 
     if (manifest.previews.isEmpty()) {
       logger.lifecycle("No previews to render.")

--- a/samples/cmp/src/main/kotlin/com/example/samplecmp/ColorTokens.kt
+++ b/samples/cmp/src/main/kotlin/com/example/samplecmp/ColorTokens.kt
@@ -1,0 +1,15 @@
+package com.example.samplecmp
+
+import androidx.compose.ui.graphics.Color
+import ee.schimke.composeai.preview.ColorCatalog
+
+/**
+ * `@ColorCatalog` tokens on the CMP/Desktop sample. Discovery emits `CATALOG` sheets for these just
+ * as it does on Android, but the desktop render backend can't draw them yet (its flat-arg protocol
+ * doesn't forward the token list), so `RenderPreviewsTask` skips catalog kinds rather than crash.
+ * Their presence here guards that skip: `:samples:cmp:composePreviewRenderAll` must stay green.
+ * Desktop catalog rendering is tracked in #2135.
+ */
+@ColorCatalog(group = "Brand") val CmpBrandPrimary: Color = Color(0xFF3D5AFE)
+
+@ColorCatalog(group = "Brand") val CmpBrandAccent: Color = Color(0xFF00BFA5)


### PR DESCRIPTION
## Summary

Fast-follow to #2148 (auto-discovered `@ColorCatalog` sheets). That PR added `PreviewKind.CATALOG` and the **Android** render strategy, but discovery emits catalog entries for **every** module — and the **desktop** backend has no catalog strategy. `RenderPreviewsTask` fell through to `getDeclaredComposableMethod(spec.functionName)` on the sheet's display name (`"Brand colours"`), which throws, sinking `composePreviewRenderAll` on any CMP/JVM/desktop module that uses `@ColorCatalog`.

Caught by Codex review on #2148 (P1). #2148's own CI stayed green only because its sample tokens were in `:samples:android` — the desktop path was never exercised. It auto-merged before this fix could land, so `main` currently has the bug; hence this follow-up.

## Fix

- **`RenderPreviewsTask` (desktop-only) skips `CATALOG` entries.** The desktop renderer's flat positional-arg protocol doesn't forward the structured `catalogTokens` list, so it can't draw the sheets yet — full desktop rendering is tracked in #2135. Clean skip (no error sidecars) rather than a per-preview throw.
- **Catalog captures are marked `optional`** so the `composePreviewRenderAll` required-output gate doesn't fail on the desktop skip — mirroring how the XR composite capture is optional. `optional` does **not** stop the Android render: the PNG is still produced and shown there; it only means "don't fail if absent."
- **`:samples:cmp` gains `@ColorCatalog` tokens** as a regression guard, so a desktop module using the annotation is now part of the sample matrix and `:samples:cmp:composePreviewRenderAll` must stay green.

## Test plan

- [x] `:samples:cmp:composePreviewRenderAll` — **green** (`Rendered 30 preview(s)`, catalog correctly skipped; previously crashed with "render produced no output file for colorcatalog__Brand").
- [x] `:samples:android:composePreviewRenderAll` — still renders the catalog sheets (Android path unchanged; `optional` doesn't block rendering).
- [x] `ktfmtFormatAll`.

Non-visual (build-behaviour) fix — the rendered catalog sheets are unchanged from #2148, and the desktop backend intentionally produces no catalog PNG for now.

Part of #2135.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RAVWZ5FWyr4gqbYSfaRvyk)_