### PR TITLE
fix(cli): honor --missing-renders in show-resources

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ResourceCommands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ResourceCommands.kt
@@ -224,12 +224,30 @@ class ShowResourcesCommand(args: List<String>) : Command(args) {
 
     val missing = filtered.filter { r -> r.captures.any { it.pngPath == null } }
     if (missing.isNotEmpty()) {
+      // Mirror ShowCommand: honour `--missing-renders`. The diagnostic (including the per-variant
+      // offender list) always prints so the CI log is self-diagnosing, but only the default `fail`
+      // policy bumps the exit to 2 — `warn`/`ignore` opt that down. Without this, `show-resources`
+      // hard-failed on every null-PNG resource regardless of policy (e.g. the launcher-icon
+      // rasterizer jitter), keeping the Compose Preview check red even under
+      // `missing-renders=warn`.
+      val policy = missingRendersPolicy?.lowercase()
+      val prefix =
+        if (policy in setOf("warn", "ignore")) "missing-renders policy=$policy — " else ""
       System.err.println(
-        "Resource render completed but produced no PNG for ${missing.size} of " +
-          "${filtered.size} resource preview(s)."
+        "${prefix}Resource render completed but produced no PNG for ${missing.size} of " +
+          "${filtered.size} resource preview(s):"
       )
+      for (r in missing) {
+        val nullVariants =
+          r.captures
+            .filter { it.pngPath == null }
+            .joinToString(", ") { it.renderOutput.ifBlank { "default" } }
+            .ifEmpty { "default" }
+        val moduleTag = if (r.module.isNotBlank()) " (${r.module})" else ""
+        System.err.println("  - ${r.id}$moduleTag — no PNG for: $nullVariants")
+      }
       System.out.flush()
-      exitProcess(2)
+      if (shouldFailOnMissingRenders()) exitProcess(2)
     }
     System.out.flush()
   }


### PR DESCRIPTION
## Summary

`ShowResourcesCommand` hard-exited `2` on **any** resource preview that rendered no PNG (`ResourceCommands.kt`), ignoring the `--missing-renders` policy that `ShowCommand` honors (`Commands.kt:987`, guarded by `shouldFailOnMissingRenders()`). So `compose-preview show-resources --missing-renders warn` still exited 2 — which is why the **Compose Preview** CI check stayed red on every run with a null-PNG resource variant (e.g. the launcher-icon rasterizer jitter from #2133) **even after** #2151 opted the workflow into `missing-renders: warn`. The `warn` policy fixed compose but silently did nothing for resources.

This mirrors `ShowCommand`'s behavior in `ShowResourcesCommand`:
- **Always** print the diagnostic — now with a **per-variant offender list** (`<id> (<module>) — no PNG for: <renderOutput>, …`), so the CI log names exactly which resource/variant is missing a PNG without downloading the reports artifact.
- Only `exitProcess(2)` under the default `fail` policy; `warn` / `ignore` opt the exit code down (keeping the diagnostic).

### Why this pairs with #2151

#2151 set `missing-renders: warn` on this repo's caller of the `apply` action; this PR makes `show-resources` actually respect that value. Together they take the Compose Preview check from chronically-red to green on stubborn/jittery resource renders, while the per-variant log lines make the underlying missing renders enumerable so they can be fixed and the policy flipped back to `fail`.

## Test plan

- Mirrors the already-tested `ShowCommand` policy path; the base-class helpers (`missingRendersPolicy`, `shouldFailOnMissingRenders()`) are covered by `MissingRendersPolicyTest` — this change routes `show-resources` through the same helper it was previously bypassing.
- Exercised end-to-end by the **Apply compose-preview** check on this PR: with the fix, a null-PNG resource under the default `fail` policy still exits 2 (and now lists the offenders); under `warn` (as on `main` post-#2151) it logs and continues.
- Behavior for the common no-missing-renders case is unchanged (the `missing.isNotEmpty()` branch isn't entered).

Note: this is a non-visual CLI/behavioral change (exit-code policy + log text), so no render evidence applies.

---
_Generated by [Claude Code](https://claude.ai/code/session_016X4T4H2pieiZAfU9Xg9Dgs)_