### PR TITLE
fix: keep Android @ColorCatalog renders required in the render gate

### DIFF
--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
@@ -643,13 +643,12 @@ object PreviewDiscovery {
               CatalogToken(className = it.className, member = it.member, label = it.name)
             },
         ),
-      // Optional so the `composePreviewRenderAll` required-output gate doesn't fail on backends
-      // that
-      // can't draw catalog sheets yet: the Android backend renders them, but the desktop backend
-      // skips `CATALOG` (see `RenderPreviewsTask`) until #2135 adds desktop support. `optional`
-      // doesn't stop the Android render — the PNG is still produced and shown; it only means "don't
-      // fail if absent." Mirrors how the XR composite capture is marked optional.
-      captures = listOf(Capture(renderOutput = "renders/$id.png", optional = true)),
+      // Required (not optional): the Android backend renders catalog sheets, so a missing PNG there
+      // is a real regression the `composePreviewRenderAll` gate must catch. The desktop backend
+      // can't draw them yet (#2135) — rather than weaken the gate for every backend, the desktop
+      // render task skips CATALOG (see `RenderPreviewsTask`) and the desktop-only validation pass
+      // excludes it from the required set (see `registerRenderAllPreviews(requireCatalog = false)`).
+      captures = listOf(Capture(renderOutput = "renders/$id.png")),
     )
 
   /**

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -261,7 +261,15 @@ internal object ComposePreviewTasks {
         dependsOn(renderClasspathGuard)
         dependsOn(project.tasks.matching { it.name in DESKTOP_RESOURCE_TASK_CANDIDATES })
       }
-    registerRenderAllPreviews(project, extension, renderTask, previewOutputDir)
+    // Desktop backend: `requireCatalog = false` — the desktop render task skips CATALOG sheets
+    // (it can't forward the token list yet, #2135), so the gate must not require their PNGs.
+    registerRenderAllPreviews(
+      project,
+      extension,
+      renderTask,
+      previewOutputDir,
+      requireCatalog = false,
+    )
 
     registerBundleTask(
       project = project,
@@ -1257,6 +1265,13 @@ internal object ComposePreviewTasks {
     extension: PreviewExtension,
     renderTask: TaskProvider<*>,
     previewOutputDir: Provider<Directory>,
+    // `false` on the desktop backend, which can't render `PreviewKind.CATALOG` sheets yet (#2135):
+    // the desktop render task skips them, so the required-output gate must not demand their PNGs.
+    // The Android backend renders catalog sheets, so it keeps the default `true` — a missing
+    // catalog
+    // PNG there is a real regression the gate must catch (rather than weakening the capture to
+    // `optional`, which would blind the gate on every backend).
+    requireCatalog: Boolean = true,
   ) {
     // Post-condition check: every entry in the manifest must have a PNG
     // on disk after the render dependency ran. We ship the renderer
@@ -1328,7 +1343,7 @@ internal object ComposePreviewTasks {
         // from the `<stem>_*` glob so a `Foo_header.png` that
         // belongs to a different preview never gets treated as
         // part of `Foo`'s fan-out.
-        val missing = missingPreviewOutputIds(manifest, outDir, isFastTier)
+        val missing = missingPreviewOutputIds(manifest, outDir, isFastTier, requireCatalog)
         if (missing.isNotEmpty()) {
           val sidecars = readErrorSidecarsFor(manifest, missing, outDir)
           val message = formatMissingPreviewsMessage(manifest, missing, sidecars)
@@ -1508,9 +1523,16 @@ internal object ComposePreviewTasks {
     manifest: PreviewManifest,
     outDir: java.io.File,
     isFastTier: Boolean,
+    // When `false` (the desktop backend), `PreviewKind.CATALOG` sheets are excluded from the
+    // required-output check — the desktop render task skips them (#2135). Android passes `true`, so
+    // a missing catalog PNG there is still flagged.
+    requireCatalog: Boolean = true,
   ): List<String> {
+    val candidates =
+      if (requireCatalog) manifest.previews
+      else manifest.previews.filter { it.params.kind.name != "CATALOG" }
     val siblingNames =
-      manifest.previews
+      candidates
         .filter { it.params.previewParameterProviderClassName == null }
         .flatMap { p ->
           p.captures.map { c -> c.renderOutput } + p.dataProducts.map { product -> product.output }
@@ -1519,7 +1541,7 @@ internal object ComposePreviewTasks {
         .map { java.io.File(outDir, it).name }
         .toSet()
 
-    return manifest.previews
+    return candidates
       .filter { p ->
         val captureMissing =
           p.captures.any { c ->

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/CleanStaleRendersTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/CleanStaleRendersTest.kt
@@ -143,4 +143,49 @@ class CleanStaleRendersTest {
     assertThat(ComposePreviewTasks.missingPreviewOutputIds(manifest, outDir, isFastTier = false))
       .isEmpty()
   }
+
+  @Test
+  fun `catalog render required on android, excluded on desktop`() {
+    val outDir = tempDir.root.resolve("build/compose-previews")
+    // A CATALOG sheet with no PNG on disk. The Android backend renders catalog sheets, so a missing
+    // one is a real regression and must be flagged (requireCatalog = true, the default). The
+    // desktop
+    // backend can't render them yet (#2135) — its render task skips them, so its validation pass
+    // must not demand the PNG (requireCatalog = false). This is the split that replaced marking the
+    // capture globally `optional`, which would have blinded the Android gate too.
+    val manifest =
+      PreviewManifest(
+        module = "app",
+        variant = "debug",
+        previews =
+          listOf(
+            PreviewInfo(
+              id = "colorcatalog__Brand",
+              functionName = "Brand colours",
+              className = "com.example.TokensKt",
+              params = PreviewParams(kind = PreviewKind.CATALOG),
+              captures = listOf(Capture(renderOutput = "renders/colorcatalog__Brand.png")),
+            )
+          ),
+      )
+
+    assertThat(
+        ComposePreviewTasks.missingPreviewOutputIds(
+          manifest,
+          outDir,
+          isFastTier = false,
+          requireCatalog = true,
+        )
+      )
+      .containsExactly("colorcatalog__Brand")
+    assertThat(
+        ComposePreviewTasks.missingPreviewOutputIds(
+          manifest,
+          outDir,
+          isFastTier = false,
+          requireCatalog = false,
+        )
+      )
+      .isEmpty()
+  }
 }


### PR DESCRIPTION
## Summary

Follow-up to #2154, addressing a Codex P2 review point ([thread](https://github.com/yschimke/compose-ai-tools/pull/2154#discussion_r3507793306)).

#2154 fixed the desktop crash on `@ColorCatalog` sheets by marking the catalog capture `optional`. But `optional` is a discovery-side, **backend-agnostic** flag, and `missingPreviewOutputIds` skips any optional capture — so a genuine **Android** catalog-render regression (an `.error.json` sidecar or missing PNG) would no longer fail `composePreviewRenderAll`. That silenced the gate on the one backend that actually renders these sheets.

## Fix — make the skip backend-scoped instead of global

- **Catalog captures are required again** (reverted `optional`).
- **`registerRenderAllPreviews` / `missingPreviewOutputIds` take a `requireCatalog` flag.** The **desktop** caller passes `false` — its render task already skips `CATALOG` (it can't forward the token list yet, #2135), so the gate must not demand the PNG. The **Android** caller keeps the default `true`, so a missing Android catalog PNG is still flagged as a real regression.

Net: desktop stays green without weakening the Android gate.

## Test plan

- [x] New unit test in `CleanStaleRendersTest` pins both directions: a missing `CATALOG` PNG is flagged when `requireCatalog = true` (Android) and ignored when `false` (desktop).
- [x] `:samples:cmp:composePreviewRenderAll` — **green** (`Rendered 30 preview(s)`, catalog excluded from the desktop gate rather than via `optional`).
- [x] Android render path unchanged — catalog sheets still render (and are now required by the gate again).
- [x] `ktfmtFormatAll`; gradle-plugin + preview-discovery compile.

Non-visual (gate-wiring) change. Part of #2135.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RAVWZ5FWyr4gqbYSfaRvyk)_