### PR TITLE
fix: make @ColorCatalog capture optionality backend-aware at discovery

### DIFF
--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
@@ -39,18 +39,20 @@ enum class PreviewKind {
   CATALOG,
 }
 
-/** Which kind of design token a [CatalogToken] points at — drives which specimen layout renders it. */
+/**
+ * Which kind of design token a [CatalogToken] points at — drives which specimen layout renders it.
+ */
 enum class CatalogTokenKind {
   /** An `androidx.compose.ui.graphics.Color` property → a labelled swatch row. */
-  COLOR,
+  COLOR
 }
 
 /**
  * One design-token property aggregated into a [PreviewKind.CATALOG] sheet. Discovery records only
  * the *coordinates* (the declaring class + member name) and the display [label] — never the value,
  * because the plugin's scan classpath doesn't carry the consumer's Compose runtime. The renderer
- * reflects the value out of the loaded consumer class at render time (a `Color` property compiles to
- * an erased `long` backing field, reboxed via the synthetic `Color.box-impl`).
+ * reflects the value out of the loaded consumer class at render time (a `Color` property compiles
+ * to an erased `long` backing field, reboxed via the synthetic `Color.box-impl`).
  */
 @Serializable
 data class CatalogToken(

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
@@ -85,10 +85,10 @@ object PreviewDiscovery {
      */
     val projectClassJars: List<File> = emptyList(),
     /**
-     * Whether this module's render backend can draw `@ColorCatalog` sheets. `true` (the default) for
-     * the Android backend, which renders them; `false` for the desktop backend, which can't yet
-     * (#2135). When `false`, the synthetic `CATALOG` captures are emitted `optional` so a missing PNG
-     * is treated as expected — by the render gate AND every downstream consumer that reads
+     * Whether this module's render backend can draw `@ColorCatalog` sheets. `true` (the default)
+     * for the Android backend, which renders them; `false` for the desktop backend, which can't yet
+     * (#2135). When `false`, the synthetic `CATALOG` captures are emitted `optional` so a missing
+     * PNG is treated as expected — by the render gate AND every downstream consumer that reads
      * `Capture.optional` (VS Code's consistency check, its render UI). Keeping the flag on the
      * capture, rather than only in the Gradle gate, is what makes the desktop skip consistent
      * everywhere.
@@ -664,9 +664,11 @@ object PreviewDiscovery {
             },
         ),
       // The capture is `optional` exactly when the backend can't render catalog sheets. On Android
-      // ([renderSupported] = true) it's required, so a missing PNG is flagged as a regression by the
+      // ([renderSupported] = true) it's required, so a missing PNG is flagged as a regression by
+      // the
       // gate. On desktop ([renderSupported] = false) it's optional, so every consumer that reads
-      // `Capture.optional` — the render gate, VS Code's consistency check, its render UI — treats the
+      // `Capture.optional` — the render gate, VS Code's consistency check, its render UI — treats
+      // the
       // (deliberately skipped, #2135) sheet as expected-absent rather than drift. One flag, all
       // consumers.
       captures = listOf(Capture(renderOutput = "renders/$id.png", optional = !renderSupported)),

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
@@ -84,6 +84,16 @@ object PreviewDiscovery {
      * types that expose the module's classes only as directories. See issue #1924.
      */
     val projectClassJars: List<File> = emptyList(),
+    /**
+     * Whether this module's render backend can draw `@ColorCatalog` sheets. `true` (the default) for
+     * the Android backend, which renders them; `false` for the desktop backend, which can't yet
+     * (#2135). When `false`, the synthetic `CATALOG` captures are emitted `optional` so a missing PNG
+     * is treated as expected — by the render gate AND every downstream consumer that reads
+     * `Capture.optional` (VS Code's consistency check, its render UI). Keeping the flag on the
+     * capture, rather than only in the Gradle gate, is what makes the desktop skip consistent
+     * everywhere.
+     */
+    val catalogRenderSupported: Boolean = true,
   )
 
   /** Outcome of a [discover] call. */
@@ -387,7 +397,7 @@ object PreviewDiscovery {
     val normalized =
       normalizeRenderOutputs(deduped) +
         discoverLottieAssets(input) +
-        buildColorCatalogPreviews(rawColorCatalogTokens)
+        buildColorCatalogPreviews(rawColorCatalogTokens, input.catalogRenderSupported)
 
     // The generic per-extension reports map is empty on the standalone Gradle path — a11y
     // (today's only canned-report producer) writes its artefacts exclusively through the
@@ -604,7 +614,10 @@ object PreviewDiscovery {
    * single group would just duplicate itself). Appended after [normalizeRenderOutputs] with render
    * outputs already shell-safe, like the Lottie assets.
    */
-  private fun buildColorCatalogPreviews(tokens: List<RawCatalogToken>): List<PreviewInfo> {
+  private fun buildColorCatalogPreviews(
+    tokens: List<RawCatalogToken>,
+    renderSupported: Boolean,
+  ): List<PreviewInfo> {
     if (tokens.isEmpty()) return emptyList()
     val byGroup = LinkedHashMap<String, MutableList<RawCatalogToken>>()
     for (t in tokens) byGroup.getOrPut(t.group) { mutableListOf() }.add(t)
@@ -616,11 +629,17 @@ object PreviewDiscovery {
           id = "colorcatalog__${group.replace(SANITIZE_RENDER_STEM, "_")}",
           displayName = "$group colours",
           tokens = groupTokens,
+          renderSupported = renderSupported,
         )
     }
     if (byGroup.size > 1) {
       entries +=
-        colorCatalogPreview(id = "colorcatalog__all", displayName = "All colours", tokens = tokens)
+        colorCatalogPreview(
+          id = "colorcatalog__all",
+          displayName = "All colours",
+          tokens = tokens,
+          renderSupported = renderSupported,
+        )
     }
     return entries
   }
@@ -629,6 +648,7 @@ object PreviewDiscovery {
     id: String,
     displayName: String,
     tokens: List<RawCatalogToken>,
+    renderSupported: Boolean,
   ): PreviewInfo =
     PreviewInfo(
       id = id,
@@ -643,12 +663,13 @@ object PreviewDiscovery {
               CatalogToken(className = it.className, member = it.member, label = it.name)
             },
         ),
-      // Required (not optional): the Android backend renders catalog sheets, so a missing PNG there
-      // is a real regression the `composePreviewRenderAll` gate must catch. The desktop backend
-      // can't draw them yet (#2135) — rather than weaken the gate for every backend, the desktop
-      // render task skips CATALOG (see `RenderPreviewsTask`) and the desktop-only validation pass
-      // excludes it from the required set (see `registerRenderAllPreviews(requireCatalog = false)`).
-      captures = listOf(Capture(renderOutput = "renders/$id.png")),
+      // The capture is `optional` exactly when the backend can't render catalog sheets. On Android
+      // ([renderSupported] = true) it's required, so a missing PNG is flagged as a regression by the
+      // gate. On desktop ([renderSupported] = false) it's optional, so every consumer that reads
+      // `Capture.optional` — the render gate, VS Code's consistency check, its render UI — treats the
+      // (deliberately skipped, #2135) sheet as expected-absent rather than drift. One flag, all
+      // consumers.
+      captures = listOf(Capture(renderOutput = "renders/$id.png", optional = !renderSupported)),
     )
 
   /**

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscoveryCli.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscoveryCli.kt
@@ -87,6 +87,7 @@ public object PreviewDiscoveryCli {
     var variantName: String? = null
     var projectDirectory: File? = null
     var failOnEmpty = false
+    var catalogRenderSupported = true
     var outPath: File? = null
 
     var i = 0
@@ -101,6 +102,10 @@ public object PreviewDiscoveryCli {
         "--variant" -> variantName = requireValue(args, i)
         "--project-directory" -> projectDirectory = File(requireValue(args, i))
         "--out" -> outPath = File(requireValue(args, i))
+        "--catalog-render-supported" ->
+          catalogRenderSupported =
+            requireValue(args, i).toBooleanStrictOrNull()
+              ?: throw ArgError("--catalog-render-supported must be 'true' or 'false'")
         "--fail-on-empty" -> {
           failOnEmpty = true
           i++
@@ -131,6 +136,7 @@ public object PreviewDiscoveryCli {
           variantName = variant,
           projectDirectory = projectDir,
           failOnEmpty = failOnEmpty,
+          catalogRenderSupported = catalogRenderSupported,
         ),
       outFile = out,
     )
@@ -164,6 +170,11 @@ public object PreviewDiscoveryCli {
 
       Flags:
         --fail-on-empty   Exit non-zero with diagnostics when zero previews are discovered.
+        --catalog-render-supported <true|false>
+                          Whether this backend renders @ColorCatalog sheets. Default true
+                          (Android). Pass false for desktop/JVM backends that skip catalog
+                          rendering, so the emitted CATALOG captures are marked optional and
+                          downstream consumers don't treat the skipped sheet as missing (#2135).
         --help, -h        Print this message.
 
       Exit codes: 0 = success, 1 = discovery failure, 2 = argument parsing failure.

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewDiscoveryCliTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewDiscoveryCliTest.kt
@@ -74,6 +74,30 @@ class PreviewDiscoveryCliTest {
     assertThat(parsed.input.failOnEmpty).isFalse()
   }
 
+  private val baseArgs =
+    arrayOf("--module", "m", "--variant", "v", "--project-directory", "/proj", "--out", "/out")
+
+  @Test
+  fun `--catalog-render-supported defaults to true (Android semantics)`() {
+    assertThat(PreviewDiscoveryCli.parse(baseArgs).input.catalogRenderSupported).isTrue()
+  }
+
+  @Test
+  fun `--catalog-render-supported false marks the desktop backend`() {
+    val parsed =
+      PreviewDiscoveryCli.parse(baseArgs + arrayOf("--catalog-render-supported", "false"))
+    assertThat(parsed.input.catalogRenderSupported).isFalse()
+  }
+
+  @Test
+  fun `--catalog-render-supported rejects a non-boolean value`() {
+    val error =
+      assertThrows(PreviewDiscoveryCli.ArgError::class.java) {
+        PreviewDiscoveryCli.parse(baseArgs + arrayOf("--catalog-render-supported", "maybe"))
+      }
+    assertThat(error.message).contains("must be 'true' or 'false'")
+  }
+
   @Test
   fun `missing --module errors with a clear message`() {
     val error =

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -204,6 +204,9 @@ internal object ComposePreviewTasks {
         // allow discovery to go lenient *for that config only* so `compose-preview list` never
         // aborts on such a module. JVM/desktop configs stay strict.
         lenientWhenAndroidOnlyFallback = true,
+        // Desktop can't render `@ColorCatalog` sheets yet (#2135) — mark their captures optional so
+        // the render skip is consistent across the gate and VS Code consumers.
+        catalogRenderSupported = false,
       ) {
         onlyIf { extension.enabled.get() }
         // `compileAndroidMain` is the lifecycle task for the KMP-Android target's `main`
@@ -261,15 +264,7 @@ internal object ComposePreviewTasks {
         dependsOn(renderClasspathGuard)
         dependsOn(project.tasks.matching { it.name in DESKTOP_RESOURCE_TASK_CANDIDATES })
       }
-    // Desktop backend: `requireCatalog = false` — the desktop render task skips CATALOG sheets
-    // (it can't forward the token list yet, #2135), so the gate must not require their PNGs.
-    registerRenderAllPreviews(
-      project,
-      extension,
-      renderTask,
-      previewOutputDir,
-      requireCatalog = false,
-    )
+    registerRenderAllPreviews(project, extension, renderTask, previewOutputDir)
 
     registerBundleTask(
       project = project,
@@ -1167,11 +1162,16 @@ internal object ComposePreviewTasks {
     // (and the entire Android path, which passes `false`) stay STRICT so a genuinely unresolvable
     // dependency still surfaces loudly.
     lenientWhenAndroidOnlyFallback: Boolean = false,
+    // `false` on the desktop backend, which can't render `@ColorCatalog` sheets yet (#2135): its
+    // discovered CATALOG captures are emitted `optional` so the render gate and every consumer that
+    // reads `Capture.optional` (VS Code) treat the skipped sheet as expected. Android keeps `true`.
+    catalogRenderSupported: Boolean = true,
     configureDeps: DiscoverPreviewsTask.() -> Unit,
   ): TaskProvider<DiscoverPreviewsTask> {
     val artifactType = Attribute.of("artifactType", String::class.java)
 
     return project.tasks.register("composePreviewDiscover", DiscoverPreviewsTask::class.java) {
+      this.catalogRenderSupported.set(catalogRenderSupported)
       classDirs.from(sourceClassDirs)
       sourceFiles.from(
         project.fileTree("src") {
@@ -1265,13 +1265,6 @@ internal object ComposePreviewTasks {
     extension: PreviewExtension,
     renderTask: TaskProvider<*>,
     previewOutputDir: Provider<Directory>,
-    // `false` on the desktop backend, which can't render `PreviewKind.CATALOG` sheets yet (#2135):
-    // the desktop render task skips them, so the required-output gate must not demand their PNGs.
-    // The Android backend renders catalog sheets, so it keeps the default `true` — a missing
-    // catalog
-    // PNG there is a real regression the gate must catch (rather than weakening the capture to
-    // `optional`, which would blind the gate on every backend).
-    requireCatalog: Boolean = true,
   ) {
     // Post-condition check: every entry in the manifest must have a PNG
     // on disk after the render dependency ran. We ship the renderer
@@ -1343,7 +1336,7 @@ internal object ComposePreviewTasks {
         // from the `<stem>_*` glob so a `Foo_header.png` that
         // belongs to a different preview never gets treated as
         // part of `Foo`'s fan-out.
-        val missing = missingPreviewOutputIds(manifest, outDir, isFastTier, requireCatalog)
+        val missing = missingPreviewOutputIds(manifest, outDir, isFastTier)
         if (missing.isNotEmpty()) {
           val sidecars = readErrorSidecarsFor(manifest, missing, outDir)
           val message = formatMissingPreviewsMessage(manifest, missing, sidecars)
@@ -1523,16 +1516,9 @@ internal object ComposePreviewTasks {
     manifest: PreviewManifest,
     outDir: java.io.File,
     isFastTier: Boolean,
-    // When `false` (the desktop backend), `PreviewKind.CATALOG` sheets are excluded from the
-    // required-output check — the desktop render task skips them (#2135). Android passes `true`, so
-    // a missing catalog PNG there is still flagged.
-    requireCatalog: Boolean = true,
   ): List<String> {
-    val candidates =
-      if (requireCatalog) manifest.previews
-      else manifest.previews.filter { it.params.kind.name != "CATALOG" }
     val siblingNames =
-      candidates
+      manifest.previews
         .filter { it.params.previewParameterProviderClassName == null }
         .flatMap { p ->
           p.captures.map { c -> c.renderOutput } + p.dataProducts.map { product -> product.output }
@@ -1541,7 +1527,7 @@ internal object ComposePreviewTasks {
         .map { java.io.File(outDir, it).name }
         .toSet()
 
-    return candidates
+    return manifest.previews
       .filter { p ->
         val captureMissing =
           p.captures.any { c ->

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
@@ -112,6 +112,15 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
    */
   @get:Input abstract val lottieRenderSubdir: Property<String>
 
+  /**
+   * Whether this module's render backend can draw `@ColorCatalog` sheets. The Android backend can
+   * (default `true`); the desktop backend can't yet (#2135), so it passes `false` and discovery
+   * marks the synthetic `CATALOG` captures `optional` — the single flag every consumer reads (the
+   * render gate, VS Code's consistency check + render UI) to know a missing catalog PNG is expected
+   * on that backend rather than a regression.
+   */
+  @get:Input abstract val catalogRenderSupported: Property<Boolean>
+
   private val json = Json {
     prettyPrint = true
     encodeDefaults = true
@@ -138,6 +147,7 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
         resourceDirs = resourceDirs.files.toList(),
         lottieRenderSubdir = lottieRenderSubdir.getOrElse("renders"),
         projectClassJars = scopedClassJars,
+        catalogRenderSupported = catalogRenderSupported.getOrElse(true),
       )
     when (val outcome = PreviewDiscovery.discover(input)) {
       is PreviewDiscovery.Outcome.Success -> {

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/CleanStaleRendersTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/CleanStaleRendersTest.kt
@@ -143,49 +143,4 @@ class CleanStaleRendersTest {
     assertThat(ComposePreviewTasks.missingPreviewOutputIds(manifest, outDir, isFastTier = false))
       .isEmpty()
   }
-
-  @Test
-  fun `catalog render required on android, excluded on desktop`() {
-    val outDir = tempDir.root.resolve("build/compose-previews")
-    // A CATALOG sheet with no PNG on disk. The Android backend renders catalog sheets, so a missing
-    // one is a real regression and must be flagged (requireCatalog = true, the default). The
-    // desktop
-    // backend can't render them yet (#2135) — its render task skips them, so its validation pass
-    // must not demand the PNG (requireCatalog = false). This is the split that replaced marking the
-    // capture globally `optional`, which would have blinded the Android gate too.
-    val manifest =
-      PreviewManifest(
-        module = "app",
-        variant = "debug",
-        previews =
-          listOf(
-            PreviewInfo(
-              id = "colorcatalog__Brand",
-              functionName = "Brand colours",
-              className = "com.example.TokensKt",
-              params = PreviewParams(kind = PreviewKind.CATALOG),
-              captures = listOf(Capture(renderOutput = "renders/colorcatalog__Brand.png")),
-            )
-          ),
-      )
-
-    assertThat(
-        ComposePreviewTasks.missingPreviewOutputIds(
-          manifest,
-          outDir,
-          isFastTier = false,
-          requireCatalog = true,
-        )
-      )
-      .containsExactly("colorcatalog__Brand")
-    assertThat(
-        ComposePreviewTasks.missingPreviewOutputIds(
-          manifest,
-          outDir,
-          isFastTier = false,
-          requireCatalog = false,
-        )
-      )
-      .isEmpty()
-  }
 }


### PR DESCRIPTION
## Summary

Follow-up to #2158, resolving Codex review points ([1](https://github.com/yschimke/compose-ai-tools/pull/2158#discussion_r3508033592), [2](https://github.com/yschimke/compose-ai-tools/pull/2160#discussion_r3508196673)) at their root.

#2158 taught only the Gradle render gate that the desktop backend skips `CATALOG` (via a `requireCatalog` param), while keeping the capture non-optional. But **other consumers read `Capture.optional` directly** — VS Code's consistency check (`previewConsistency.ts`) and its forced-render UI (`extension.ts`) — so a desktop `@ColorCatalog` entry advertising a *required* PNG it never renders was reported as drift / a render failure there.

## Fix — one flag, correct at the source

Rather than patch each consumer, make the flag they all read correct in discovery:

- Thread `catalogRenderSupported` from the **per-backend** discover-task registration into `PreviewDiscovery`.
- Emit the synthetic `CATALOG` captures with `optional = !catalogRenderSupported`.
  - **Desktop** passes `false` → `optional = true`: every consumer (render gate, VS Code consistency, render UI) treats the deliberately-skipped sheet as expected-absent. (Real desktop rendering is tracked in #2135.)
  - **Android** keeps the default `true` → `optional = false`: a missing Android catalog PNG is still a real regression the gate catches.
- The `requireCatalog` gate param added in #2158 is **removed as redundant** — the capture flag now carries the distinction everywhere.
- **Standalone CLI parity:** the published `PreviewDiscoveryCli` (non-Gradle path for Bazel/Amper in `compose-ai-contrib`) gains a `--catalog-render-supported <true|false>` flag (default `true`), so non-Gradle desktop builds emit the same `optional=true` captures the Gradle path does.

## Test plan

- [x] `:samples:cmp:composePreviewRenderAll` — **green** (`Rendered 30 preview(s)`); the CMP module's `colorcatalog__Brand` entry now carries `optional: true` in `previews.json`.
- [x] `PreviewDiscoveryCliTest` — new cases: `--catalog-render-supported` defaults to `true`, parses `false`, and rejects a non-boolean value.
- [x] Android path unchanged — catalog captures stay `optional: false` (required); the sheets still render (validated in #2148) so the gate passes.
- [x] `gradle-plugin` + `preview-discovery` compile; `ktfmtFormatAll` clean.

Non-visual (discovery/plumbing) change. Part of #2135. Closes the optional/required consumer-consistency question at the source across Gradle **and** the standalone CLI.