### PR TITLE
fix(plugin): declare render tasks depend on generateUnitTestConfig

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -1593,6 +1593,16 @@ internal object AndroidPreviewSupport {
         "intermediates/unit_test_config_directory/${variantName}UnitTest/generate${capVariant}UnitTestConfig/out"
       )
 
+    // `unitTestConfigDir` is a bare buildDir path with no producer wired in, but it IS the output
+    // of AGP's `generate${capVariant}UnitTestConfig` task. Any task that reads it via the render
+    // classpath (`composePreviewCompileRenderShards`, `composePreviewRender`) must therefore
+    // declare a dependency on that generator, or Gradle's strict task-dependency validation
+    // (AGP 9 / Gradle 9) fails the build with a `WorkValidationException` ("uses this output …
+    // without declaring an explicit or implicit dependency"). Match by name so it's empty-safe:
+    // modules with unit tests disabled have no such task, and then nothing consumes the dir either.
+    val unitTestConfigProducer =
+      project.tasks.matching { it.name == "generate${capVariant}UnitTestConfig" }
+
     // Generates `ee/schimke/composeai/renderer/robolectric.properties`
     // onto the render classpath so Robolectric overrides the consumer's
     // `Application` with a stub by default — see
@@ -1728,6 +1738,8 @@ internal object AndroidPreviewSupport {
           destinationDirectory.set(shardClassesDir)
           options.release.set(21)
           dependsOn(generateShardsTask)
+          // Reads AGP's unit-test-config dir via `resolvedClasspath` (see unitTestConfigProducer).
+          dependsOn(unitTestConfigProducer)
           if (useLocalRenderer) {
             dependsOn(":renderer-android:compile${capVariant}Kotlin")
           }
@@ -1742,6 +1754,8 @@ internal object AndroidPreviewSupport {
         // resolved runtime classpath doesn't actually reach a preview-tooling coord (issue #1549).
         // Null when direct tooling was found (validator wasn't registered — nothing to depend on).
         validatePreviewToolingPresentTask?.let { dependsOn(it) }
+        // Reads AGP's unit-test-config dir via `resolvedClasspath` (see unitTestConfigProducer).
+        dependsOn(unitTestConfigProducer)
         val agpTestTask = project.tasks.findByName("test${capVariant}UnitTest") as? Test
         testClassesDirs =
           if (compileShardsTask != null) {


### PR DESCRIPTION
## Summary

The render tasks fail under **AGP 9 / Gradle 9 strict task-dependency validation**, which is the dominant cause of CI being red across many workflows.

`composePreviewCompileRenderShards` (`JavaCompile`) and `composePreviewRender` (`Test`) both read AGP's `generate<Variant>UnitTestConfig` output directory (`unitTestConfigDir`) via the shared `resolvedClasspath` (it's added with `from(unitTestConfigDir)` in `AndroidPreviewClasspath`). But `unitTestConfigDir` was a bare `buildDirectory.dir(…)` path with **no producing task wired in**, so Gradle can't infer the dependency and hard-fails:

```
A problem was found with the configuration of task ':app:composePreviewCompileRenderShards' (type 'JavaCompile').
  Reason: Task ':app:composePreviewCompileRenderShards' uses this output of task
  ':app:generateDebugUnitTestConfig' without declaring an explicit or implicit dependency.
→ org.gradle.internal.execution.WorkValidationException  →  BUILD FAILED (exit 1)
```

With the render-shards compile failing, no shards compile → no previews render → the cascade of `##[warning]No files were found … renders/*.png` and downstream failures seen across **CI** (Render XR composite, Bundle Render E2E, Agent Audit Samples), **Integration** (external `WearTilesKotlin`, `AdaptiveJetStream`), and **VS Code Extension E2E (external consumer)**.

## Fix

Wire both render tasks to depend on the generator, matched by name so it's **empty-safe** — modules with unit tests disabled have no such task, and in that case nothing consumes the dir either:

```kotlin
val unitTestConfigProducer =
  project.tasks.matching { it.name == "generate${capVariant}UnitTestConfig" }
// …in composePreviewCompileRenderShards and composePreviewRender:
dependsOn(unitTestConfigProducer)
```

This is Gradle's own recommended remedy (declare the missing dependency) and mirrors the existing `dependsOn(generateShardsTask)` wiring.

## Test plan

- CI on this PR is the verification: the **Integration** / **CI** / external-**E2E** render jobs that were failing with the `WorkValidationException` should now compile the shards and produce renders. (This diagnosis came from the `WearTilesKotlin` Integration job on the 0.16.11 release commit, which failed in 14s with exactly this validation error.)
- Empty-safe by construction: `tasks.matching { … }` yields no dependency when the unit-test-config task is absent, so modules without unit tests are unaffected.
- I could not run Gradle locally in this environment (the distribution download and Android SDK aren't reachable here), so I'm relying on this PR's CI to confirm; the change is a minimal, additive dependency declaration.

Note: non-visual build-wiring change (no `@Preview` output changes), so no render evidence applies. Does not address the separate launcher-icon missing-render (`rc=2`) or the `rc=1` surface tracked in #2159.

---
_Generated by [Claude Code](https://claude.ai/code/session_016X4T4H2pieiZAfU9Xg9Dgs)_