### PR TITLE
fix(plugin): render tasks also depend on compileScreenshotTestKotlin

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -1740,6 +1740,12 @@ internal object AndroidPreviewSupport {
           dependsOn(generateShardsTask)
           // Reads AGP's unit-test-config dir via `resolvedClasspath` (see unitTestConfigProducer).
           dependsOn(unitTestConfigProducer)
+          // …and the screenshotTest classes dir, which `sourceClassDirs` adds to the render
+          // classpath when the screenshot plugin is applied — same strict-validation requirement,
+          // matched by name like `composePreviewDiscover` above.
+          if (screenshotTestEnabled) {
+            dependsOn(project.tasks.matching { it.name in screenshotCompileTaskNames })
+          }
           if (useLocalRenderer) {
             dependsOn(":renderer-android:compile${capVariant}Kotlin")
           }
@@ -1756,6 +1762,11 @@ internal object AndroidPreviewSupport {
         validatePreviewToolingPresentTask?.let { dependsOn(it) }
         // Reads AGP's unit-test-config dir via `resolvedClasspath` (see unitTestConfigProducer).
         dependsOn(unitTestConfigProducer)
+        // …and the screenshotTest classes dir on the render classpath (see the compile-shards
+        // task).
+        if (screenshotTestEnabled) {
+          dependsOn(project.tasks.matching { it.name in screenshotCompileTaskNames })
+        }
         val agpTestTask = project.tasks.findByName("test${capVariant}UnitTest") as? Test
         testClassesDirs =
           if (compileShardsTask != null) {

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -565,13 +565,23 @@ internal object AndroidPreviewSupport {
     val mainCompileTaskNames =
       if (isKmp) listOf("compile${capVariant}Kotlin", "compile${capVariant}KotlinAndroid")
       else listOf("compile${capVariant}Kotlin")
+    // Includes the screenshotTest *javac* task: `sourceClassDirs` adds both the Kotlin
+    // (`built_in_kotlinc/…ScreenshotTest/…Kotlin/classes`) and the javac
+    // (`intermediates/javac/${variantName}ScreenshotTest/classes`) outputs to the render classpath,
+    // so consumers must depend on both compile tasks or Gradle's strict validation fails for a
+    // module with Java sources under `src/screenshotTest/java`. Empty-safe via `tasks.matching`.
     val screenshotCompileTaskNames =
       if (isKmp)
         listOf(
           "compile${capVariant}ScreenshotTestKotlin",
           "compile${capVariant}ScreenshotTestKotlinAndroid",
+          "compile${capVariant}ScreenshotTestJavaWithJavac",
         )
-      else listOf("compile${capVariant}ScreenshotTestKotlin")
+      else
+        listOf(
+          "compile${capVariant}ScreenshotTestKotlin",
+          "compile${capVariant}ScreenshotTestJavaWithJavac",
+        )
     val discoverTask =
       ComposePreviewTasks.registerDiscoverTask(
         project,


### PR DESCRIPTION
## Summary

Follow-up to #2162. That PR fixed one of **two** undeclared-dependency violations on the render tasks; this fixes the second, which still breaks **screenshot-test-enabled** modules.

When `com.android.compose.screenshot` is applied, `sourceClassDirs` adds the screenshotTest classes dir (`intermediates/built_in_kotlinc/<variant>ScreenshotTest/compile<Variant>ScreenshotTestKotlin/classes`) to the render classpath. So `composePreviewCompileRenderShards` and `composePreviewRender` consume `compile<Variant>ScreenshotTestKotlin`'s output and hit the same Gradle-9 strict-validation failure #2162 fixed for `generateUnitTestConfig`:

```
Task ':jetstream:composePreviewCompileRenderShards' uses this output of task
':jetstream:compileDebugScreenshotTestKotlin' without declaring an explicit or implicit dependency.
→ WorkValidationException → BUILD FAILED
```

`composePreviewDiscover` already declares this dependency (via `screenshotCompileTaskNames`); this mirrors that onto the two render tasks — guarded by `screenshotTestEnabled`, empty-safe via `tasks.matching`.

## Verified on the live main run (post-#2162)

I checked the CI run on the #2162 merge commit (`e1698bd`):
- ✅ **#2162 worked** — `VS Code Extension E2E (external consumer)` and the non-screenshot Integration sample (`WearTilesKotlin`) now pass.
- ❌ **Still red** — `Integration` (AdaptiveJetStream XR spatial), `CI`, `Compose Preview` — all on this *second* violation (`compileDebugScreenshotTestKotlin`), which this PR addresses.

Together, #2162 + this PR should clear the render-shards `WorkValidationException` for both screenshot-test and non-screenshot modules.

## Test plan

- CI on this PR is the verification: the `Integration` / `CI` / `Compose Preview` render jobs on screenshot-test modules should now get past the `compileScreenshotTestKotlin` validation and produce renders.
- I couldn't run Gradle locally (distribution + Android SDK aren't reachable in this environment), so I'm relying on this PR's CI; the change is a minimal, additive dependency declaration mirroring the existing `composePreviewDiscover` wiring.

Note: build-wiring only (no `@Preview` output change), so no render evidence applies. The separate launcher-icon missing-render (`rc=2`) is still `warn`-tolerated per #2151 and tracked in #2159.

---
_Generated by [Claude Code](https://claude.ai/code/session_016X4T4H2pieiZAfU9Xg9Dgs)_