### PR TITLE
feat: emit @ColorCatalog/@TypographyCatalog tokens as a data product

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -1327,6 +1327,17 @@ internal object ComposePreviewTasks {
         // here we keep every `<stem>_*<ext>` match rather than
         // second-guessing the provider values.
         cleanStaleRenders(previewOutputDir.get().asFile.resolve("renders"), manifest, logger)
+        // Same staleness problem for the `data/catalog-tokens/` sidecars (issue #2167): the
+        // renderer
+        // writes one per current CATALOG sheet but never removes those for renamed/deleted sheets,
+        // so
+        // an importer scanning the tree would keep seeing tokens absent from the current manifest.
+        // Prune by the same manifest-derived id set.
+        cleanStaleCatalogTokens(
+          previewOutputDir.get().asFile.resolve("data/catalog-tokens"),
+          manifest,
+          logger,
+        )
         // Each preview can produce multiple captures (`@RoboComposePreviewOptions`
         // time fan-out, future scroll / dimension fan-outs). Verify each
         // capture's renderOutput lands on disk — report back one missing
@@ -1595,6 +1606,39 @@ internal object ComposePreviewTasks {
    * Anything else (PNGs or GIFs that were produced for a now-removed preview) gets removed so
    * downstream tools compare the manifest against a clean directory.
    */
+  /**
+   * Prune `data/catalog-tokens/<id>.catalog.json` sidecars whose sheet is no longer in [manifest] —
+   * the data-product analogue of [cleanStaleRenders]. Keeps exactly the files the current
+   * `PreviewKind.CATALOG` previews would (re)write, so a renamed or deleted `@ColorCatalog` /
+   * `@TypographyCatalog` group doesn't leave orphaned tokens for a downstream importer. The
+   * expected filename mirrors the renderer's `CatalogTokenSidecar` (`sanitize(id) +
+   * ".catalog.json"`).
+   */
+  internal fun cleanStaleCatalogTokens(
+    catalogTokensDir: java.io.File,
+    manifest: PreviewManifest,
+    logger: org.gradle.api.logging.Logger,
+  ) {
+    if (!catalogTokensDir.isDirectory) return
+    val expected =
+      manifest.previews
+        .filter { it.params.kind == PreviewKind.CATALOG }
+        .map { sanitizeCatalogTokenId(it.id) + ".catalog.json" }
+        .toSet()
+    catalogTokensDir
+      .listFiles { f -> f.isFile && f.name.endsWith(".catalog.json") }
+      ?.forEach { f ->
+        if (f.name in expected) return@forEach
+        if (!f.delete()) {
+          logger.warn("compose-preview: couldn't delete stale catalog-token sidecar $f")
+        }
+      }
+  }
+
+  // Mirror of `CatalogTokenSidecar.sanitize` so the expected filenames match the renderer's.
+  private fun sanitizeCatalogTokenId(id: String): String =
+    id.replace(Regex("""[/\\:*?"<>|\s]"""), "_")
+
   private fun cleanStaleRenders(
     rendersDir: java.io.File,
     manifest: PreviewManifest,

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/CleanStaleRendersTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/CleanStaleRendersTest.kt
@@ -41,6 +41,52 @@ class CleanStaleRendersTest {
   }
 
   @Test
+  fun `prunes catalog-token sidecars for sheets absent from the manifest`() {
+    val catalogDir = tempDir.root.resolve("build/compose-previews/data/catalog-tokens")
+    catalogDir.mkdirs()
+    // Two sheets are current; one (`typographycatalog__Removed`) was renamed/deleted, plus an
+    // unrelated file that must be left alone.
+    val current1 = catalogDir.resolve("colorcatalog__Brand.catalog.json").apply { writeText("{}") }
+    val current2 =
+      catalogDir.resolve("typographycatalog__Body.catalog.json").apply { writeText("{}") }
+    val stale =
+      catalogDir.resolve("typographycatalog__Removed.catalog.json").apply { writeText("{}") }
+    val unrelated = catalogDir.resolve("notes.txt").apply { writeText("keep") }
+
+    val manifest =
+      PreviewManifest(
+        module = "app",
+        variant = "debug",
+        previews =
+          listOf(
+            PreviewInfo(
+              id = "colorcatalog__Brand",
+              functionName = "colorcatalog__Brand",
+              className = "com.example.ColorTokensKt",
+              params = PreviewParams(kind = PreviewKind.CATALOG),
+            ),
+            PreviewInfo(
+              id = "typographycatalog__Body",
+              functionName = "typographycatalog__Body",
+              className = "com.example.TypographyTokensKt",
+              params = PreviewParams(kind = PreviewKind.CATALOG),
+            ),
+          ),
+      )
+
+    ComposePreviewTasks.cleanStaleCatalogTokens(
+      catalogDir,
+      manifest,
+      org.gradle.api.logging.Logging.getLogger(CleanStaleRendersTest::class.java),
+    )
+
+    assertThat(current1.exists()).isTrue()
+    assertThat(current2.exists()).isTrue()
+    assertThat(stale.exists()).isFalse()
+    assertThat(unrelated.exists()).isTrue()
+  }
+
+  @Test
   fun `missing output check includes scroll data products`() {
     val outDir = tempDir.root.resolve("build/compose-previews")
     // `@ScrollingPreview(modes = [LONG])` alone produces ONLY a data product — discovery

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/CatalogTokenSidecar.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/CatalogTokenSidecar.kt
@@ -1,0 +1,144 @@
+package ee.schimke.composeai.renderer
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.isSpecified
+import ee.schimke.composeai.io.SystemFileSystem
+import java.io.File
+import java.util.Locale
+import okio.FileSystem
+import okio.Path.Companion.toPath
+
+/**
+ * Per-sheet structured-token sidecar for `@ColorCatalog` / `@TypographyCatalog` renders. Sibling of
+ * the specimen PNG, placed under `<renders-parent>/data/catalog-tokens/<sanitized-id>.catalog.json`
+ * — the same `<outputDir>/data/<kind>/` convention [NotificationSidecar] uses.
+ *
+ * Where the PNG shows the tokens as *pixels*, this carries their **resolved values** — the exact
+ * `#AARRGGBB` a `@ColorCatalog` colour reflects to, and the resolved `fontSize` / `fontWeight` /
+ * metrics a `@TypographyCatalog` `TextStyle` reflects to. That turns an annotation-declared palette
+ * or type scale into importable data (design-parity's `catalog-export`, the `design-artifacts`
+ * kits), not just a viewable sheet — see issue #2167. Correct by construction: the values come from
+ * the very reflection the specimen sheet already runs ([CatalogValueReflection]).
+ *
+ * Hand-rolled JSON, best-effort — same rationale as [NotificationSidecar]: the renderer-android
+ * runtime classpath deliberately omits `kotlinx-serialization`, and a per-token failure must not
+ * derail the PNG render path. The group is implicit in [previewId] (`typographycatalog__Display`),
+ * so it isn't repeated per token.
+ */
+internal object CatalogTokenSidecar {
+
+  const val SCHEMA = "compose-preview-catalog-tokens/v1"
+
+  /** `<outputDir>/data/catalog-tokens/<id>.catalog.json`, mirroring [NotificationSidecar.pathFor]. */
+  fun pathFor(rendersDir: File, previewId: String): File =
+    File(
+      File(rendersDir.parentFile ?: rendersDir, "data/catalog-tokens"),
+      sanitize(previewId) + ".catalog.json",
+    )
+
+  /**
+   * Write the resolved-token sidecar for [previewId] from its [tokens]. Resolves the output dir from
+   * the `composeai.render.outputDir` system property the PNG path uses; silently no-ops when it's
+   * unset (unit-test invocations that don't run through the plugin's render task) or when [tokens]
+   * is empty. A token whose value can't be reflected is skipped, not fatal.
+   */
+  fun write(previewId: String, tokens: List<CatalogToken>, fileSystem: FileSystem = SystemFileSystem) {
+    if (tokens.isEmpty()) return
+    try {
+      val rendersDirPath = System.getProperty("composeai.render.outputDir") ?: return
+      val json = buildJson(previewId, tokens) ?: return
+      val sidecar = pathFor(File(rendersDirPath), previewId)
+      sidecar.parentFile?.mkdirs()
+      fileSystem.write(sidecar.path.toPath()) { writeUtf8(json) }
+    } catch (e: Throwable) {
+      System.err.println("Failed to write catalog-token sidecar for $previewId: ${e.message}")
+    }
+  }
+
+  /** Returns the sidecar JSON, or null when no token resolved (nothing worth writing). */
+  private fun buildJson(previewId: String, tokens: List<CatalogToken>): String? {
+    val entries = tokens.mapNotNull { tokenJson(it) }
+    if (entries.isEmpty()) return null
+    val sb = StringBuilder()
+    sb.append('{')
+    sb.append("\"schema\":").append(jsonString(SCHEMA)).append(',')
+    sb.append("\"previewId\":").append(jsonString(previewId)).append(',')
+    sb.append("\"tokens\":[")
+    entries.forEachIndexed { i, e ->
+      if (i > 0) sb.append(',')
+      sb.append(e)
+    }
+    sb.append("]}")
+    return sb.toString()
+  }
+
+  /** One token object, or null if its value couldn't be reflected. */
+  private fun tokenJson(token: CatalogToken): String? {
+    val value =
+      when (token.tokenKind) {
+        CatalogTokenKind.COLOR ->
+          runCatching { colorJson(CatalogValueReflection.reflectColor(token.className, token.member)) }
+            .getOrNull()
+        CatalogTokenKind.TEXT_STYLE ->
+          runCatching {
+              textStyleJson(CatalogValueReflection.reflectTextStyle(token.className, token.member))
+            }
+            .getOrNull()
+      } ?: return null
+    val sb = StringBuilder()
+    sb.append('{')
+    sb.append("\"label\":").append(jsonString(token.label)).append(',')
+    sb.append("\"className\":").append(jsonString(token.className)).append(',')
+    sb.append("\"member\":").append(jsonString(token.member)).append(',')
+    sb.append("\"kind\":").append(jsonString(token.tokenKind.name)).append(',')
+    sb.append(value)
+    sb.append('}')
+    return sb.toString()
+  }
+
+  /** `"color":{"hex":"#AARRGGBB","argb":<int>}` — hex matches the sheet's swatch label. */
+  private fun colorJson(color: Color): String {
+    val argb = color.toArgb()
+    val hex = String.format(Locale.ROOT, "#%08X", argb)
+    return "\"color\":{\"hex\":${jsonString(hex)},\"argb\":$argb}"
+  }
+
+  /** `"textStyle":{...}` — only the metrics that are actually specified are emitted. */
+  private fun textStyleJson(style: TextStyle): String {
+    val fields = mutableListOf<String>()
+    spField(style.fontSize)?.let { fields += "\"fontSizeSp\":$it" }
+    style.fontWeight?.weight?.let { fields += "\"fontWeight\":$it" }
+    style.fontStyle?.let { fields += "\"fontStyle\":${jsonString(it.toString())}" }
+    spField(style.letterSpacing)?.let { fields += "\"letterSpacingSp\":$it" }
+    spField(style.lineHeight)?.let { fields += "\"lineHeightSp\":$it" }
+    style.fontFamily?.let { fields += "\"fontFamily\":${jsonString(it.toString())}" }
+    return "\"textStyle\":{${fields.joinToString(",")}}"
+  }
+
+  /** The `.sp` magnitude of a [TextUnit], or null when unspecified or not in sp. */
+  private fun spField(unit: TextUnit): Float? =
+    if (unit.isSpecified && unit.isSp) unit.value else null
+
+  private fun sanitize(s: String): String = s.replace(Regex("""[/\\:*?"<>|\s]"""), "_")
+
+  private fun jsonString(s: String): String {
+    val sb = StringBuilder(s.length + 2)
+    sb.append('"')
+    for (c in s) {
+      when (c) {
+        '"' -> sb.append("\\\"")
+        '\\' -> sb.append("\\\\")
+        '\b' -> sb.append("\\b")
+        '\n' -> sb.append("\\n")
+        '\r' -> sb.append("\\r")
+        '\t' -> sb.append("\\t")
+        else -> if (c < ' ') sb.append("\\u%04x".format(c.code)) else sb.append(c)
+      }
+    }
+    sb.append('"')
+    return sb.toString()
+  }
+}

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/PreviewRenderStrategy.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/PreviewRenderStrategy.kt
@@ -285,6 +285,9 @@ private object CatalogPreviewStrategy : PreviewRenderStrategy {
                     .getOrNull()
             }
         }
+        // Emit the resolved-token sidecar (issue #2167) once per sheet, alongside the PNG. Keyed by
+        // `preview.id` so it fires on first composition only — the render composes exactly once.
+        remember(preview.id) { CatalogTokenSidecar.write(preview.id, preview.params.catalogTokens) }
         Box(Modifier.fillMaxSize().background(CATALOG_SHEET_BACKGROUND).padding(16.dp)) {
             Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
                 for (row in rows) {

--- a/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/CatalogTokenSidecarTest.kt
+++ b/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/CatalogTokenSidecarTest.kt
@@ -1,0 +1,69 @@
+package ee.schimke.composeai.renderer
+
+import java.nio.file.Files
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Exercises the resolved-token sidecar end to end (issue #2167): reflect a `@ColorCatalog` colour
+ * and a `@TypographyCatalog` `TextStyle` — reusing the probe `val`s from the reflection probe
+ * tests — and assert the emitted `data/catalog-tokens/<id>.catalog.json` carries their resolved
+ * values (hex for the colour, size/weight metrics for the type style).
+ */
+class CatalogTokenSidecarTest {
+
+  private val colorOwner = "ee.schimke.composeai.renderer.ColorValueReflectionProbeTestKt"
+  private val textOwner = "ee.schimke.composeai.renderer.TextStyleValueReflectionProbeTestKt"
+
+  @Test
+  fun `writes resolved colour and type-style tokens to the sidecar`() {
+    val renders = Files.createTempDirectory("catalog-sidecar").resolve("renders").toFile()
+    val previous = System.getProperty("composeai.render.outputDir")
+    System.setProperty("composeai.render.outputDir", renders.path)
+    try {
+      val tokens =
+        listOf(
+          // `ProbeOpaque = Color(0xFF3366CC)`, `ProbeAlpha = Color(0x80112233)`.
+          CatalogToken(colorOwner, "ProbeOpaque", "Brand", CatalogTokenKind.COLOR),
+          CatalogToken(colorOwner, "ProbeAlpha", "Scrim", CatalogTokenKind.COLOR),
+          // `ProbeDisplay = TextStyle(fontSize = 57.sp, fontWeight = FontWeight.Medium)`.
+          CatalogToken(textOwner, "ProbeDisplay", "Display", CatalogTokenKind.TEXT_STYLE),
+        )
+      CatalogTokenSidecar.write("mixed__all", tokens)
+
+      val sidecar = CatalogTokenSidecar.pathFor(renders, "mixed__all")
+      assertTrue("sidecar not written at ${sidecar.path}", sidecar.exists())
+      val json = sidecar.readText()
+
+      assertTrue(json.contains("\"schema\":\"${CatalogTokenSidecar.SCHEMA}\""))
+      assertTrue(json.contains("\"previewId\":\"mixed__all\""))
+      // Colour tokens: uppercase #AARRGGBB, alpha preserved.
+      assertTrue(json.contains("\"kind\":\"COLOR\""))
+      assertTrue(json.contains("\"hex\":\"#FF3366CC\""))
+      assertTrue(json.contains("\"hex\":\"#80112233\""))
+      // Type token: resolved size + weight.
+      assertTrue(json.contains("\"kind\":\"TEXT_STYLE\""))
+      assertTrue(json.contains("\"fontSizeSp\":57.0"))
+      assertTrue(json.contains("\"fontWeight\":500"))
+      assertTrue(json.contains("\"member\":\"ProbeDisplay\""))
+    } finally {
+      if (previous == null) System.clearProperty("composeai.render.outputDir")
+      else System.setProperty("composeai.render.outputDir", previous)
+    }
+  }
+
+  @Test
+  fun `no-ops for empty tokens`() {
+    val renders = Files.createTempDirectory("catalog-sidecar-empty").resolve("renders").toFile()
+    val previous = System.getProperty("composeai.render.outputDir")
+    System.setProperty("composeai.render.outputDir", renders.path)
+    try {
+      CatalogTokenSidecar.write("empty__all", emptyList())
+      assertFalse(CatalogTokenSidecar.pathFor(renders, "empty__all").exists())
+    } finally {
+      if (previous == null) System.clearProperty("composeai.render.outputDir")
+      else System.setProperty("composeai.render.outputDir", previous)
+    }
+  }
+}


### PR DESCRIPTION
## Summary

First cut of #2167. `@ColorCatalog` / `@TypographyCatalog` (#2135) currently surface their tokens only as **pixels** on a specimen sheet — the resolved values stay locked in the render pipeline. This emits them as a **data product** so an annotation-declared palette / type scale becomes *importable*, not just *viewable*.

For each catalog sheet, the renderer now writes a sidecar next to the PNG:

```
<renders-parent>/data/catalog-tokens/<sheet-id>.catalog.json
```

carrying each token's **resolved value** — `#AARRGGBB` for colours, `fontSize` / `fontWeight` / metrics for type styles — plus `name` / `className` / `member` coordinates. The values come from the very reflection the specimen sheet already runs (`CatalogValueReflection`), so the product is **correct by construction** — the same principle design-parity's `catalog-export` relies on for theme tokens.

Mirrors the existing `NotificationSidecar` pattern: hand-rolled JSON (renderer-android omits `kotlinx-serialization` by design), best-effort (a per-token reflection failure is skipped, never fatal), keyed off the `composeai.render.outputDir` system property.

### Changes
- **renderer**: new `CatalogTokenSidecar`; emitted from `CatalogPreviewStrategy` (once per sheet).
- **test**: `CatalogTokenSidecarTest` — reflect a colour + a `TextStyle` (reusing the existing probe `val`s) and assert the emitted values, plus the empty-tokens no-op.

## Evidence — emitted from `:samples:android:composePreviewRenderAll`

Both catalog kinds produce sidecars alongside their PNGs. Type styles (`fontSizeSp` 45/32/16/12/11, `fontWeight` 400/500/400/400/300 = Normal/Medium/Normal/Normal/Light) match `TypographyTokens.kt` exactly:

```json
// data/catalog-tokens/typographycatalog__all.catalog.json  (excerpt)
{
  "schema": "compose-preview-catalog-tokens/v1",
  "previewId": "typographycatalog__all",
  "tokens": [
    { "label": "DisplayLarge", "className": "com.example.sampleandroid.TypographyTokensKt",
      "member": "DisplayLarge", "kind": "TEXT_STYLE",
      "textStyle": { "fontSizeSp": 45.0, "fontWeight": 400 } },
    { "label": "Body Large", "member": "BodyL", "kind": "TEXT_STYLE",
      "textStyle": { "fontSizeSp": 16.0, "fontWeight": 400 } },
    { "label": "Caption", "member": "Caption", "kind": "TEXT_STYLE",
      "textStyle": { "fontSizeSp": 11.0, "fontWeight": 300 } }
  ]
}
```

```json
// data/catalog-tokens/colorcatalog__Brand.catalog.json  (excerpt)
{
  "schema": "compose-preview-catalog-tokens/v1",
  "previewId": "colorcatalog__Brand",
  "tokens": [
    { "label": "BrandCoral", "member": "BrandCoral", "kind": "COLOR",
      "color": { "hex": "#FFFF6F61", "argb": -37023 } },
    { "label": "Brand Gold", "member": "BrandGold", "kind": "COLOR",
      "color": { "hex": "#FFFFD700", "argb": -10496 } }
  ]
}
```

*(Data-product plumbing — no visual surface changes, so text/JSON evidence per the repo's visual-evidence rule.)*

## Scope / follow-ups (tracked in #2167)
- **Bundle carriage** — the sidecar is emitted and tracked as a render output, but bundle packing is selective (not an automatic `data/**` sweep), so travelling it in `.previewbundle` is a deliberate next step.
- **design-parity `catalog-export` ingestion** — consume this product as a `DesignTokens` source (separate repo/issue).
- **Desktop** — Android first; desktop renders catalogs `optional` today.

## Test plan
- [x] `:renderer-android:testDebugUnitTest --tests '*CatalogTokenSidecarTest*'` — green.
- [x] `:samples:android:composePreviewRenderAll` — emits six sidecars (3 colour, 3 type) with correct resolved values; render output unchanged otherwise.
- [x] `ktfmtFormatAll` — clean.

Follow-up to #2135. Refs #2167.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RAVWZ5FWyr4gqbYSfaRvyk)_