### PR TITLE
fix(plugin): compile render shards at release 17, not 21

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -1746,7 +1746,12 @@ internal object AndroidPreviewSupport {
           source(generateShardsTask.map { it.outputDir.asFileTree })
           classpath = resolvedClasspath
           destinationDirectory.set(shardClassesDir)
-          options.release.set(21)
+          // Target JDK 17: the toolchain that builds this repo (and the common consumer floor —
+          // AGP requires JDK 17+) runs javac 17, which rejects `--release 21` with
+          // "release version 21 not supported". The generated shards are trivial JUnit
+          // subclasses with no need for a newer language level, and release-17 bytecode still
+          // loads on the (17-or-newer) render test JVM.
+          options.release.set(17)
           dependsOn(generateShardsTask)
           // Reads AGP's unit-test-config dir via `resolvedClasspath` (see unitTestConfigProducer).
           dependsOn(unitTestConfigProducer)


### PR DESCRIPTION
## Summary

The **Apply compose-preview** job (and the render jobs in CI / Integration / external E2E) fails with:

```
* What went wrong:
    error: release version 21 not supported
  > Task :samples:android:composePreviewCompileRenderShards FAILED  →  BUILD FAILED  →  rc=1
```

`composePreviewCompileRenderShards` (`JavaCompile`) sets `options.release.set(21)`, but this repo builds with **JDK 17** — `.github/actions/setup` installs `java-version: 17` and `gradle/gradle-daemon-jvm.properties` pins `toolchainVersion=17`. JDK 17's `javac` can't target `--release 21`, so the shard compile fails, no previews render, and the compose pipeline returns `rc=1`.

This is the residual failure behind the still-red **Compose Preview** check on `main` even after the render-shards dependency fixes (#2162, #2166) — those let the task *run*, at which point it immediately hits this release mismatch. It's the same wall on every JDK-17 runner (CI `samples:android`, Integration/external samples), previously masked because the `WorkValidationException` failed first.

## Fix

Target **17** instead of 21. The generated shards are trivial JUnit `@Parameters` subclasses of `RobolectricRenderTestBase` — no need for a newer language level — and release-17 bytecode still loads on the 17-or-newer render test JVM. 17 matches the repo's toolchain and the common consumer floor (AGP requires JDK 17+).

```kotlin
options.release.set(17)   // was 21
```

## Test plan

- CI on this PR verifies: `composePreviewCompileRenderShards` should compile under the JDK-17 toolchain, shards render, and the compose pipeline returns 0.
- Combined with #2162 + #2166 (dependency declarations) and #2151 + #2156 (`missing-renders: warn`), this should take the **Compose Preview** / CI / Integration / external-E2E render surface green.
- Could not run Gradle locally (distribution + Android SDK unreachable in this environment), so relying on this PR's CI. Root cause was read from the full run logs of the `main` @ `b9785fe` Compose Preview run (`release version 21 not supported`).

Non-visual build-wiring change (bytecode target only); no render-output change, so no visual evidence applies.

---
_Generated by [Claude Code](https://claude.ai/code/session_016X4T4H2pieiZAfU9Xg9Dgs)_