### PR TITLE
feat: carry @ColorCatalog/@TypographyCatalog tokens in the preview bundle

### DIFF
--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/BundleFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/BundleFunctionalTest.kt
@@ -335,7 +335,8 @@ class BundleFunctionalTest {
         .id
         .also { assertThat(it).isEqualTo("colorcatalog__Brand") }
 
-    // `--build-cache` so a warm cache is exercised too — assert on bundle CONTENT (not task outcome)
+    // `--build-cache` so a warm cache is exercised too — assert on bundle CONTENT (not task
+    // outcome)
     // so the assertion holds whether the second pack is SUCCESS or FROM_CACHE.
     fun pack() {
       GradleRunner.create()

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/BundleFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/BundleFunctionalTest.kt
@@ -291,6 +291,75 @@ class BundleFunctionalTest {
   }
 
   @Test
+  fun `composePreviewBundle packs the per-sheet catalog-token sidecar`() {
+    val projectDir = createTestProject()
+
+    // Plant a `@ColorCatalog` token so discovery emits a real `PreviewKind.CATALOG` sheet (the
+    // annotation is matched by FQN, declared locally so the test needs no external artifact).
+    val annDir = File(projectDir, "src/main/kotlin/ee/schimke/composeai/preview").apply { mkdirs() }
+    File(annDir, "ColorCatalog.kt")
+      .writeText(
+        """
+        package ee.schimke.composeai.preview
+
+        @Retention(AnnotationRetention.BINARY)
+        @Target(AnnotationTarget.FIELD)
+        annotation class ColorCatalog(val name: String = "", val group: String = "")
+        """
+          .trimIndent()
+      )
+    File(projectDir, "src/main/kotlin/test/Tokens.kt")
+      .writeText(
+        """
+        package test
+
+        import androidx.compose.ui.graphics.Color
+        import ee.schimke.composeai.preview.ColorCatalog
+
+        @ColorCatalog(group = "Brand") val Coral: Color = Color(0xFFFF6F61)
+        """
+          .trimIndent()
+      )
+
+    GradleRunner.create()
+      .withProjectDir(projectDir)
+      .withArguments("composePreviewDiscover")
+      .withPluginClasspath()
+      .build()
+
+    val previewsJson = File(projectDir, "build/compose-previews/previews.json")
+    val manifest = json.decodeFromString(PreviewManifest.serializer(), previewsJson.readText())
+    val catalogId =
+      manifest.previews
+        .first { it.params.kind == PreviewKind.CATALOG }
+        .id
+        .also { assertThat(it).isEqualTo("colorcatalog__Brand") }
+
+    // Seed the resolved-token sidecar as the renderer's `CatalogTokenSidecar` would, under the
+    // `data/catalog-tokens/` tree (a sibling of `renders/`, keyed by the sheet id).
+    val catalogJson =
+      """{"schema":"compose-preview-catalog-tokens/v1","previewId":"$catalogId",""" +
+        """"tokens":[{"label":"Coral","className":"test.TokensKt","member":"Coral",""" +
+        """"kind":"COLOR","color":{"hex":"#FFFF6F61","argb":-37023}}]}"""
+    File(projectDir, "build/compose-previews/data/catalog-tokens")
+      .apply { mkdirs() }
+      .also { File(it, "$catalogId.catalog.json").writeText(catalogJson) }
+
+    val result =
+      GradleRunner.create()
+        .withProjectDir(projectDir)
+        .withArguments("composePreviewBundle", "-PbundlePreviewIds=$catalogId", "--stacktrace")
+        .withPluginClasspath()
+        .build()
+    assertThat(result.task(":composePreviewBundle")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+
+    val bundle = File(projectDir, "build/compose-previews/bundle.png")
+    assertThat(listEntries(bundle)).contains("previews/$catalogId.catalog.json")
+    assertThat(String(readZipEntry(bundle, "previews/$catalogId.catalog.json")!!, Charsets.UTF_8))
+      .isEqualTo(catalogJson)
+  }
+
+  @Test
   fun `composePreviewBundle re-packs when renders appear after a render-less pack`() {
     val projectDir = createTestProject()
     val redId = "test.RedKt.RedBoxPreview"

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/BundleFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/BundleFunctionalTest.kt
@@ -335,8 +335,25 @@ class BundleFunctionalTest {
         .id
         .also { assertThat(it).isEqualTo("colorcatalog__Brand") }
 
+    // `--build-cache` so a warm cache is exercised too — assert on bundle CONTENT (not task outcome)
+    // so the assertion holds whether the second pack is SUCCESS or FROM_CACHE.
+    fun pack() {
+      GradleRunner.create()
+        .withProjectDir(projectDir)
+        .withArguments("composePreviewBundle", "-PbundlePreviewIds=$catalogId", "--build-cache")
+        .withPluginClasspath()
+        .build()
+    }
+
+    // Pack once BEFORE the sidecar exists: the bundle carries no catalog-token entry.
+    pack()
+    var bundle = File(projectDir, "build/compose-previews/bundle.png")
+    assertThat(listEntries(bundle)).doesNotContain("previews/$catalogId.catalog.json")
+
     // Seed the resolved-token sidecar as the renderer's `CatalogTokenSidecar` would, under the
-    // `data/catalog-tokens/` tree (a sibling of `renders/`, keyed by the sheet id).
+    // `data/catalog-tokens/` tree (a sibling of `renders/`, keyed by the sheet id), then re-pack.
+    // Because the tree is a tracked input (`catalogTokenFiles`), the task must NOT be UP-TO-DATE /
+    // restored FROM-CACHE — it re-packs and carries the now-present sidecar.
     val catalogJson =
       """{"schema":"compose-preview-catalog-tokens/v1","previewId":"$catalogId",""" +
         """"tokens":[{"label":"Coral","className":"test.TokensKt","member":"Coral",""" +
@@ -345,15 +362,8 @@ class BundleFunctionalTest {
       .apply { mkdirs() }
       .also { File(it, "$catalogId.catalog.json").writeText(catalogJson) }
 
-    val result =
-      GradleRunner.create()
-        .withProjectDir(projectDir)
-        .withArguments("composePreviewBundle", "-PbundlePreviewIds=$catalogId", "--stacktrace")
-        .withPluginClasspath()
-        .build()
-    assertThat(result.task(":composePreviewBundle")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
-
-    val bundle = File(projectDir, "build/compose-previews/bundle.png")
+    pack()
+    bundle = File(projectDir, "build/compose-previews/bundle.png")
     assertThat(listEntries(bundle)).contains("previews/$catalogId.catalog.json")
     assertThat(String(readZipEntry(bundle, "previews/$catalogId.catalog.json")!!, Charsets.UTF_8))
       .isEqualTo(catalogJson)

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
@@ -478,6 +478,19 @@ abstract class BundlePreviewTask : DefaultTask() {
       }
     }
 
+    // Per-sheet catalog-token sidecars (issue #2167): the resolved `@ColorCatalog` /
+    // `@TypographyCatalog` values the renderer wrote under `data/catalog-tokens/<id>.catalog.json`,
+    // packed by convention under `previews/<id>.catalog.json` — same shape as the override sidecars
+    // so a detached reader (design-parity's `catalog-export`) can import the palette / type scale
+    // without re-rendering. Only `PreviewKind.CATALOG` sheets carry one.
+    val catalogTokenFiles = LinkedHashMap<String, ByteArray>()
+    for (preview in selected) {
+      resolvePreviewCatalogTokens(preview)?.let {
+        catalogTokenFiles["$BUNDLE_PREVIEWS_DIR/${preview.id}.$BUNDLE_CATALOG_TOKENS_SIDECAR_EXT"] =
+          it
+      }
+    }
+
     val filteredManifest =
       if (includeDataExtensions.getOrElse(false)) {
         // When carrying extension data, rewrite the bundled manifest's `dataExtensionReports` to
@@ -507,6 +520,7 @@ abstract class BundlePreviewTask : DefaultTask() {
         irFiles = irZipFiles,
         dataExtensionFiles = dataExtensionZipFiles,
         overrideFiles = overrideFiles,
+        catalogTokenFiles = catalogTokenFiles,
       )
 
     // The cover (first selected preview) forms the polyglot's leading bytes. Reuse its baked PNG
@@ -653,6 +667,27 @@ abstract class BundlePreviewTask : DefaultTask() {
     val f = File(rendersRoot, "$stem.$BUNDLE_OVERRIDES_SIDECAR_EXT")
     return if (f.isFile && f.length() > 0) f.readBytes() else null
   }
+
+  /**
+   * Look for the per-sheet catalog-token sidecar the render step wrote for a `PreviewKind.CATALOG`
+   * [preview] (`<rendersRoot>/../data/catalog-tokens/<id>.catalog.json`, issue #2167). Unlike the
+   * override / IR sidecars, it lives under the `data/` tree keyed by the sheet id (not the PNG
+   * stem), so resolution mirrors the renderer's `CatalogTokenSidecar` path + sanitize. Returns the
+   * raw bytes (copied verbatim — the producer never parses them) or `null` for non-catalog previews
+   * and sheets that resolved no tokens.
+   */
+  private fun resolvePreviewCatalogTokens(preview: PreviewInfo): ByteArray? {
+    if (preview.params.kind != PreviewKind.CATALOG) return null
+    val rendersRoot = rendersDir.orNull?.asFile ?: return null
+    val dataDir = File(rendersRoot.parentFile ?: rendersRoot, "data/catalog-tokens")
+    val name = sanitizeCatalogTokenId(preview.id) + ".$BUNDLE_CATALOG_TOKENS_SIDECAR_EXT"
+    val f = File(dataDir, name)
+    return if (f.isFile && f.length() > 0) f.readBytes() else null
+  }
+
+  // Mirror of the renderer's `CatalogTokenSidecar.sanitize` so the on-disk filename matches.
+  private fun sanitizeCatalogTokenId(id: String): String =
+    id.replace(Regex("""[/\\:*?"<>|\s]"""), "_")
 
   private fun resolvePreviewIr(preview: PreviewInfo): ResolvedIr? {
     // kind=LOTTIE: the IR is the discovered asset file itself (no render-time capture). Read it
@@ -1077,6 +1112,7 @@ abstract class BundlePreviewTask : DefaultTask() {
     irFiles: Map<String, ByteArray>,
     dataExtensionFiles: Map<String, ByteArray>,
     overrideFiles: Map<String, ByteArray>,
+    catalogTokenFiles: Map<String, ByteArray>,
   ): ByteArray {
     val baos = ByteArrayOutputStream()
     ZipOutputStream(baos).use { zip ->
@@ -1086,6 +1122,8 @@ abstract class BundlePreviewTask : DefaultTask() {
       previewPngs.forEach { (id, bytes) -> zip.writeFile("$BUNDLE_PREVIEWS_DIR/$id.png", bytes) }
       // (v8) Per-preview override sidecars under `previews/<id>.overrides.json`.
       overrideFiles.forEach { (path, bytes) -> zip.writeFile(path, bytes) }
+      // Per-sheet catalog-token sidecars under `previews/<id>.catalog.json` (issue #2167).
+      catalogTokenFiles.forEach { (path, bytes) -> zip.writeFile(path, bytes) }
       // Captured IR bytes (Remote Compose doc / protolayout proto) under `ir/`.
       irFiles.forEach { (path, bytes) -> zip.writeFile(path, bytes) }
       // (v7) Optional per-extension data reports under `extensions/<id>.json`.

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
@@ -216,6 +216,20 @@ abstract class BundlePreviewTask : DefaultTask() {
   abstract val renderFiles: ConfigurableFileCollection
 
   /**
+   * The per-sheet catalog-token sidecars under `<rendersDir>/../data/catalog-tokens/`, tracked as a
+   * real input for the same reason as [renderFiles]: they live OUTSIDE the `renders/` tree, so
+   * without this the task could be UP-TO-DATE / restored FROM-CACHE and keep emitting a bundle with
+   * a missing or stale `previews/<id>.catalog.json` when a sidecar is created or updated after a
+   * render-less pack, with no PNG change to invalidate the cache key (Codex review, PR #2172).
+   * `@InputFiles @Optional` so an absent `data/catalog-tokens/` dir snapshots as empty rather than
+   * failing the build.
+   */
+  @get:InputFiles
+  @get:Optional
+  @get:PathSensitive(PathSensitivity.RELATIVE)
+  abstract val catalogTokenFiles: ConfigurableFileCollection
+
+  /**
    * Preview ids to include. First entry is the cover. Empty means "all previews in the manifest";
    * passing the empty list intentionally — most callers will populate this from CLI input.
    */
@@ -483,11 +497,11 @@ abstract class BundlePreviewTask : DefaultTask() {
     // packed by convention under `previews/<id>.catalog.json` — same shape as the override sidecars
     // so a detached reader (design-parity's `catalog-export`) can import the palette / type scale
     // without re-rendering. Only `PreviewKind.CATALOG` sheets carry one.
-    val catalogTokenFiles = LinkedHashMap<String, ByteArray>()
+    val catalogTokenEntries = LinkedHashMap<String, ByteArray>()
     for (preview in selected) {
       resolvePreviewCatalogTokens(preview)?.let {
-        catalogTokenFiles["$BUNDLE_PREVIEWS_DIR/${preview.id}.$BUNDLE_CATALOG_TOKENS_SIDECAR_EXT"] =
-          it
+        catalogTokenEntries[
+          "$BUNDLE_PREVIEWS_DIR/${preview.id}.$BUNDLE_CATALOG_TOKENS_SIDECAR_EXT"] = it
       }
     }
 
@@ -520,7 +534,7 @@ abstract class BundlePreviewTask : DefaultTask() {
         irFiles = irZipFiles,
         dataExtensionFiles = dataExtensionZipFiles,
         overrideFiles = overrideFiles,
-        catalogTokenFiles = catalogTokenFiles,
+        catalogTokenFiles = catalogTokenEntries,
       )
 
     // The cover (first selected preview) forms the polyglot's leading bytes. Reuse its baked PNG

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -487,6 +487,10 @@ internal object ComposePreviewTasks {
       // bundle.
       rendersDir.set(previewOutputDir.map { it.dir("renders") })
       renderFiles.from(previewOutputDir.map { it.dir("renders") })
+      // Catalog-token sidecars live under `data/catalog-tokens/` (a sibling of `renders/`), outside
+      // `renderFiles`' tree — track them as their own input so the bundle re-packs when a sidecar
+      // appears/changes (see `catalogTokenFiles` on the task).
+      catalogTokenFiles.from(previewOutputDir.map { it.dir("data/catalog-tokens") })
       previewIds.set(previewIdsProperty.orElse(emptyList()))
       embedDeps.set(embedDepsProperty.orElse(false))
       includeDataExtensions.set(includeDataExtensionsProperty.orElse(false))

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewBundleFormat.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewBundleFormat.kt
@@ -39,6 +39,14 @@ import kotlinx.serialization.json.JsonClassDiscriminator
  *                            render, present only for previews that opted in, so a detached viewer can
  *                            offer the editable controls without a live daemon. Convention-discovered
  *                            (no manifest pointer), like the optional semantics sidecar.
+ * previews/<id>.catalog.json — the resolved `@ColorCatalog` / `@TypographyCatalog` token values for a
+ *                            `PreviewKind.CATALOG` sheet (a verbatim `compose-preview-catalog-tokens`
+ *                            payload the renderer wrote under `data/catalog-tokens/`; copied byte for
+ *                            byte, never parsed): hex per colour, size/weight metrics per type style.
+ *                            Present only for catalog sheets, so a detached reader (design-parity's
+ *                            `catalog-export`) can import an annotation-declared palette / type scale
+ *                            without re-rendering. Convention-discovered (no manifest pointer). See
+ *                            [BUNDLE_CATALOG_TOKENS_SIDECAR_EXT] and issue #2167.
  * classes/app.jar          — consumer module bytecode, MINIMIZED to classes reachable from the
  *                            selected previews (plus all module resources). For an IR-backed
  *                            preview (see below) the enclosing class is NOT a closure seed, so its
@@ -574,6 +582,17 @@ const val BUNDLE_SCHEMA_VERSION: Int = 8
  * in lockstep with the consumer runtime's writer.
  */
 const val BUNDLE_OVERRIDES_SIDECAR_EXT: String = "overrides.json"
+
+/**
+ * File extension of the per-sheet catalog-token sidecar the render step writes under
+ * `data/catalog-tokens/<id>.catalog.json` (issue #2167) and the bundle packs under
+ * `previews/<id>.catalog.json`. Holds the resolved `@ColorCatalog` / `@TypographyCatalog` token
+ * values (hex / type metrics) so a detached reader — e.g. design-parity's `catalog-export` — can
+ * import an annotation-declared palette or type scale without re-rendering. Only
+ * `PreviewKind.CATALOG` sheets carry one. Kept in lockstep with the renderer's
+ * `CatalogTokenSidecar` writer.
+ */
+const val BUNDLE_CATALOG_TOKENS_SIDECAR_EXT: String = "catalog.json"
 
 /**
  * Well-known directory inside the bundle zip holding one rendered PNG per selected preview, keyed


### PR DESCRIPTION
## Summary

Next increment of #2167. #2168 landed the renderer-side data product (`data/catalog-tokens/<id>.catalog.json` with resolved colour/type values), but the **bundle didn't carry it** — so a detached reader couldn't see an annotation-declared palette or type scale. This packs it.

Each `PreviewKind.CATALOG` sheet's sidecar is now packed into the bundle under:

```
previews/<id>.catalog.json
```

mirroring the **v8 override-sidecar** carriage exactly: convention-discovered (no manifest pointer), copied **verbatim** (the producer never parses it), present only for catalog sheets. This is the input design-parity's [`catalog-export`](https://github.com/yschimke/design-parity/tree/main/packages/catalog-export) needs to import the tokens as a `DesignTokens` source — the same way it already reads theme tokens from the carried `compose/semantics` product — **without re-rendering**.

### Changes
- **`PreviewBundleFormat`**: `BUNDLE_CATALOG_TOKENS_SIDECAR_EXT` + ZIP-layout doc entry.
- **`BundlePreviewTask`**: `resolvePreviewCatalogTokens` (reads the sheet's `data/catalog-tokens/<id>.catalog.json`, sanitize matching the renderer's `CatalogTokenSidecar`), a pack loop, and carriage through `buildZip`.
- **test**: functional coverage — plants a real `@ColorCatalog` token so discovery emits a `colorcatalog__Brand` sheet, seeds its sidecar, and asserts the bundle carries `previews/colorcatalog__Brand.catalog.json` **byte-for-byte**.

## Scope / remaining follow-ups (tracked in #2167)
- **design-parity `catalog-export` ingestion** — read `previews/<id>.catalog.json` from the bundle and fold it into `DesignTokens` (separate repo; this PR is the prerequisite that puts the data in the bundle).
- **Desktop** — extend the renderer-side emission (Android emits today; desktop renders catalogs `optional`).

## Test plan
- [x] `:gradle-plugin:functionalTest --tests '*packs the per-sheet catalog-token sidecar*'` — green (sidecar carried verbatim under `previews/<id>.catalog.json`).
- [x] `:gradle-plugin:compileKotlin` — clean.
- [x] `ktfmtFormatAll` — clean.

*(Bundle/data-product plumbing — no visual surface change, so text/JSON evidence per the repo's visual-evidence rule.)*

Refs #2167.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RAVWZ5FWyr4gqbYSfaRvyk)_