### PR TITLE
ci: reconcile the next release PR so the phantom 0.17.0 self-clears

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -178,3 +178,34 @@ jobs:
     secrets: inherit
     permissions:
       contents: write
+
+  # Reconcile the "next release" PR after a release fully publishes.
+  #
+  # The `release-please` job above opens the next release PR in the SAME run that
+  # cuts the release — but at that moment the just-cut version is invisible to
+  # release-please: it's a *draft* GitHub Release (config `"draft": true`), which
+  # carries no git tag, and the tag is only written by the later "Ensure the
+  # release tag exists" step. So release-please falls back to the PREVIOUS
+  # published release as its baseline, re-lists the just-released commits, and
+  # opens a phantom next-version PR (e.g. a spurious 0.17.0 with duplicated notes)
+  # that only clears on the next release-please run.
+  #
+  # This job IS that next run: it fires after finalize-release (so both the tag
+  # and the now-published release exist), re-runs release-please with the same
+  # config, sees the correct baseline, and closes the phantom PR automatically.
+  # It cannot cut a release itself — the merged release PR is already labelled
+  # `autorelease: tagged`, so there is nothing pending to release and no
+  # downstream chain fires (no loop). If genuinely new commits landed while the
+  # release was publishing, it opens the correct next PR instead of the phantom.
+  reconcile-release-pr:
+    needs: [release-please, finalize-release]
+    if: needs.release-please.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write        # update the release branch
+      pull-requests: write   # close/open the next release PR
+    steps:
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
+        with:
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## Summary

Stops release-please from prompting a phantom next-version release PR (the recurring **0.17.0 with duplicated "too large to preview" notes**) after every release.

**Why it happens every release:** release-please opens the *next* release PR in the **same run** that cuts the current one. But the release is created as a **draft** (`"draft": true`, for atomic publishing), and a draft carries **no git tag** — the tag is written by the later *"Ensure the release tag exists"* step. So at the moment release-please computes the next PR, the version it just cut is invisible (no published release, no tag yet). It falls back to the **previous** published release as the baseline, re-lists the just-released commits, and proposes a spurious next-**minor** (the `feat:` commits drive a minor off that stale baseline → 0.17.0). It only cleared on the *next* release-please run — which is the manual dispatch that's been done by hand each release.

**Fix:** a new `reconcile-release-pr` job runs release-please **once more after `finalize-release`**, when the tag and the published release both exist. It sees the correct baseline and **closes the phantom PR automatically** (or opens the correct next PR if real commits landed while the release was publishing).

It's safe by construction: the merged release PR is already `autorelease: tagged`, so there's nothing pending to release — the job never cuts a release and never triggers the downstream chain, so no loop.

### Trade-off

The draft-until-verified design (which prevents the "release not found" install race) is kept as-is; this reconciles *after* rather than removing drafts. The phantom PR may still flicker into existence during the ~release window, but it now auto-closes at the end of the chain instead of lingering until the next release.

## Test plan

- [x] `release-please.yml` parses; new `reconcile-release-pr` job present.
- [x] Job gated on `release_created == 'true'`, `needs: [release-please, finalize-release]`; same action pin + config as the main job.
- [ ] Next release: confirm the phantom next-version PR is auto-closed by `reconcile-release-pr` and no stale 0.17.0-style PR remains.

Related: #2164 (self-recovery guard for half-*published* releases — a separate reliability gap on the publish side).

---
_Generated by [Claude Code](https://claude.ai/code/session_01TqqGqqRg9bMDkdq6brBvT8)_