### PR TITLE
feat(serve): make the public front page a design-systems index

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
@@ -26,6 +26,17 @@ class ServeBundleHost(
    * `--bundles <dir>` directory, which has no original signed file to verify).
    */
   val trust: BundleVerifier.Verdict = BundleVerifier.Verdict.Unverified("not checked"),
+  /**
+   * Human display title for a design-system catalog (e.g. "Compose Material 3"), taken from
+   * `catalog.json`'s `title`. Null for a plain uploaded bundle (no such metadata). Surfaced on the
+   * public server's home index so each system card reads as a name, not a bare id.
+   */
+  val title: String? = null,
+  /**
+   * Short one-line descriptor for a catalog card — the underlying library coordinate(s) from
+   * `catalog.json`'s `library`. Null when the catalog declares none (or for a plain bundle).
+   */
+  val subtitle: String? = null,
 ) : ServeHost {
 
   private val previewsDir = File(bundleDir, PREVIEWS_SUBDIR)

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
@@ -147,7 +147,15 @@ class ServeCatalogStore(
       return Result.Ok(safe, count, "${BundleVerifier.summary(verdict)} (live)")
     }
 
-    val host = ServeBundleHost(dir, safe, verdict)
+    val host =
+      ServeBundleHost(
+        dir,
+        safe,
+        verdict,
+        title = catalog.title?.takeIf { it.isNotBlank() },
+        subtitle =
+          catalog.library.filter { it.isNotBlank() }.take(2).joinToString(" · ").ifBlank { null },
+      )
     register(safe, host)
     return Result.Ok(safe, host.previews.size, BundleVerifier.summary(verdict))
   }
@@ -194,6 +202,10 @@ class ServeCatalogStore(
    */
   @Serializable
   private data class Catalog(
+    /** Human display title (e.g. "Compose Material 3"); surfaced on the public home index. */
+    val title: String? = null,
+    /** Underlying library coordinate(s); shown as the one-line descriptor on a system card. */
+    val library: List<String> = emptyList(),
     val components: List<Component> = emptyList(),
     /** Optional in-browser render descriptor (the CMP-Wasm app carried in the branch). */
     val webRender: WebRender? = null,

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -337,6 +337,19 @@ class ServeHttpServer(
   /** `GET /` (query) and `GET /{system}[/]` (path): the session's preview-list landing page. */
   private suspend fun RoutingContext.handleLanding(sessionInPath: Boolean) {
     if (rejectBadToken()) return
+    // Front door: when this server publishes design-system catalogs, the bare `/` (no `?session=`,
+    // no `/<system>` path) is an INDEX of those systems — each with a meaningful preview — rather
+    // than an arbitrary default module's grid. A plain `serve` (no `--catalogs`) keeps the module
+    // landing. A query `?session=` or a `/<system>` path still selects that session's landing
+    // below.
+    if (
+      !sessionInPath &&
+        catalogSessions.isNotEmpty() &&
+        call.request.queryParameters["session"] == null
+    ) {
+      handleHomeIndex()
+      return
+    }
     val (webSessionId, basePath) = webSessionAndBase(sessionInPath)
     withLeasedSession(selectedSessionId(sessionInPath)) { renderHost ->
       call.respondText(
@@ -353,6 +366,40 @@ class ServeHttpServer(
         ContentType.Text.Html,
       )
     }
+  }
+
+  /**
+   * The public server's front-page index of published design-system catalogs ([catalogSessions]).
+   * Leases each catalog in turn (they're cheap, pinned bundle hosts) to read its title, preview
+   * count, trust verdict, and pick a meaningful hero preview — then renders a card per system. A
+   * catalog that can't be leased (e.g. transiently unavailable) is skipped rather than sinking the
+   * whole page.
+   */
+  private suspend fun RoutingContext.handleHomeIndex() {
+    val systems =
+      withContext(Dispatchers.IO) {
+        catalogSessions.mapNotNull { system ->
+          val lease = sessions.lease(system) ?: return@mapNotNull null
+          try {
+            val host = lease.host
+            val bundle = host as? ServeBundleHost
+            ServeWeb.HomeSystem(
+              system = system,
+              title = bundle?.title?.takeIf { it.isNotBlank() } ?: host.label,
+              subtitle = bundle?.subtitle,
+              previewCount = host.previews.size,
+              trust = bundle?.let { BundleVerifier.summary(it.trust) },
+              heroPreviewId = ServeWeb.representativePreviewId(host.previews),
+            )
+          } finally {
+            lease.close()
+          }
+        }
+      }
+    call.respondText(
+      ServeWeb.homeIndexPage(systems, token, isPublic = isPublic),
+      ContentType.Text.Html,
+    )
   }
 
   /**
@@ -434,6 +481,7 @@ class ServeHttpServer(
           trust = (renderHost as? ServeBundleHost)?.let { BundleVerifier.summary(it.trust) },
           wasmSrc = wasmSrc,
           basePath = basePath,
+          isPublic = isPublic,
         ),
         ContentType.Text.Html,
       )

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -50,6 +50,12 @@ object ServeWeb {
     .cp-badge--trusted { background: #e7f4ea; color: #1e7a34; border: 1px solid #b6e0c2; }
     .cp-badge--unverified { background: #fdf0e3; color: #8a5300; border: 1px solid #f0d3a8; }
     .cp-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 16px; }
+    .cp-syslist { grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); }
+    .cp-syslist .cp-imgwrap { min-height: 180px; }
+    .cp-sys-title { font-size: 0.98rem; font-weight: 600; }
+    .cp-sys-desc { margin-top: 4px; font-size: 0.76rem; color: #6b6b70; line-height: 1.4; }
+    .cp-sys-foot { margin-top: 8px; font-size: 0.74rem; color: #6b6b70; }
+    .cp-sys-noimg { font-size: 0.78rem; color: #a0a0a8; }
     .cp-card { border: 1px solid #e3e3e8; border-radius: 10px; overflow: hidden; background: #fff;
       display: block; color: inherit; }
     .cp-card[hidden] { display: none; }
@@ -84,7 +90,7 @@ object ServeWeb {
     .cp-knobs input:disabled { opacity: 0.7; }
     @media (prefers-color-scheme: dark) {
       body { color: #e6e6e9; background: #161618; }
-      .cp-sub, .cp-id, .cp-status, .cp-about-links { color: #a0a0a8; }
+      .cp-sub, .cp-id, .cp-status, .cp-about-links, .cp-sys-desc, .cp-sys-foot { color: #a0a0a8; }
       .cp-card, .cp-stage, .cp-knobs, .cp-about { border-color: #34343a; }
       .cp-card, .cp-about { background: #1d1d20; }
       .cp-about-body { color: #c9c9d0; }
@@ -110,22 +116,41 @@ object ServeWeb {
    * Query string carrying the token and — only for a non-default tenant ([sessionId] non-null) —
    * the `session` id, so generated links stay on the same tenant. A null [sessionId] (the default
    * session) keeps URLs token-only.
+   *
+   * In [isPublic] mode every route is open (the token gates nothing), so the `token=` param is
+   * **omitted** — a public link like `preview.coo.ee/compose-m3/` shouldn't drag a useless token
+   * around. Non-public keeps the token as the only gate. May return an empty string (public + the
+   * default session), so callers wrap it with [querySuffix] to avoid a dangling `?`.
    */
-  private fun queryString(token: String, sessionId: String?): String {
-    val t = "token=" + WebEscaping.urlEncodeSegment(token)
-    return if (sessionId == null) t else t + "&session=" + WebEscaping.urlEncodeSegment(sessionId)
+  private fun queryString(token: String, sessionId: String?, isPublic: Boolean): String {
+    val parts = buildList {
+      if (!isPublic) add("token=" + WebEscaping.urlEncodeSegment(token))
+      if (sessionId != null) add("session=" + WebEscaping.urlEncodeSegment(sessionId))
+    }
+    return parts.joinToString("&")
   }
 
   /**
    * The query string for a same-session link, given the page's [basePath]. When the page is served
    * under a `/<system>` path ([basePath] non-empty) the session is carried by the path, so links
    * are **token-only** — no `&session=`. When it's the root-mounted default/legacy `?session=` form
-   * ([basePath] empty) it falls back to [queryString], preserving the historical link shape (and
-   * byte-identical goldens for the callers that don't pass a basePath).
+   * ([basePath] empty) it falls back to [queryString]. In [isPublic] mode the token is dropped
+   * either way (may return empty — wrap with [querySuffix]).
    */
-  private fun linkQuery(token: String, sessionId: String?, basePath: String): String =
-    if (basePath.isEmpty()) queryString(token, sessionId)
-    else "token=" + WebEscaping.urlEncodeSegment(token)
+  private fun linkQuery(
+    token: String,
+    sessionId: String?,
+    basePath: String,
+    isPublic: Boolean,
+  ): String =
+    if (basePath.isEmpty()) queryString(token, sessionId, isPublic)
+    else if (isPublic) "" else "token=" + WebEscaping.urlEncodeSegment(token)
+
+  /**
+   * Prefix a query with `?` when non-empty, else the empty string (no dangling `?` on token-free
+   * public links).
+   */
+  private fun querySuffix(query: String): String = if (query.isEmpty()) "" else "?$query"
 
   /**
    * Producer-trust badge for a bundle/catalog session ([BundleVerifier.summary]); empty for a live
@@ -139,6 +164,21 @@ object ServeWeb {
     val icon = if (unverified) "⚠" else "✓"
     val label = WebEscaping.htmlEscape(trust)
     return " <span class=\"$cls\" title=\"producer trust: $label\">$icon $label</span>"
+  }
+
+  /**
+   * A compact trust badge for a home-index card: the icon + a one-word verdict (`trusted` /
+   * `unverified`) rather than the full basis string, which is too long for a narrow card title. The
+   * full basis is kept in the `title` tooltip and shown in full on the system's own landing.
+   */
+  private fun compactTrustBadge(trust: String?): String {
+    if (trust.isNullOrBlank()) return ""
+    val unverified = trust == "unverified"
+    val cls = if (unverified) "cp-badge cp-badge--unverified" else "cp-badge cp-badge--trusted"
+    val icon = if (unverified) "⚠" else "✓"
+    val word = if (unverified) "unverified" else "trusted"
+    val full = WebEscaping.htmlEscape(trust)
+    return " <span class=\"$cls\" title=\"producer trust: $full\">$icon $word</span>"
   }
 
   /**
@@ -170,16 +210,22 @@ object ServeWeb {
    * the query. The current session (when it is one of the catalogs) renders as a non-link,
    * current-marked pill. Empty [catalogs] ⇒ no row.
    */
-  private fun catalogNav(catalogs: List<String>, token: String, sessionId: String?): String {
+  private fun catalogNav(
+    catalogs: List<String>,
+    token: String,
+    sessionId: String?,
+    isPublic: Boolean,
+  ): String {
     if (catalogs.isEmpty()) return ""
-    val tokenQuery = "token=" + WebEscaping.urlEncodeSegment(token)
+    // Public routes are open, so a nav pill needs no token; token-gated boxes keep it.
+    val suffix = querySuffix(if (isPublic) "" else "token=" + WebEscaping.urlEncodeSegment(token))
     val links =
       catalogs.joinToString("\n") { sys ->
         val name = WebEscaping.htmlEscape(sys)
         if (sys == sessionId) {
           "<span class=\"cp-systems-cur\" aria-current=\"page\">$name</span>"
         } else {
-          "<a href=\"/${WebEscaping.urlEncodeSegment(sys)}/?$tokenQuery\">$name</a>"
+          "<a href=\"/${WebEscaping.urlEncodeSegment(sys)}/$suffix\">$name</a>"
         }
       }
     return """
@@ -354,6 +400,121 @@ object ServeWeb {
     """
       .trimIndent()
 
+  /**
+   * One design system's summary on the public [homeIndexPage]: its [system] id, human [title], an
+   * optional one-line [subtitle] (the library coordinate), how many [previewCount] previews it
+   * carries, its producer-[trust] verdict, and a [heroPreviewId] to render as the card's meaningful
+   * preview (null ⇒ the system has no renderable preview, shown as a placeholder).
+   */
+  data class HomeSystem(
+    val system: String,
+    val title: String,
+    val subtitle: String?,
+    val previewCount: Int,
+    val trust: String?,
+    val heroPreviewId: String?,
+  )
+
+  /**
+   * The public preview server's **front door**: an index of the design systems it publishes, each a
+   * card carrying a meaningful preview, the system's title + library, its trust badge, and a link
+   * to its `/<system>/` catalog. This replaces showing an arbitrary default module's previews at
+   * `/` (the point of `preview.coo.ee` is the catalogs, so the landing lists them rather than
+   * hiding them behind a nav pill). Non-catalog `serve` (no `--catalogs`) keeps the plain
+   * [landingPage].
+   */
+  fun homeIndexPage(systems: List<HomeSystem>, token: String, isPublic: Boolean = false): String {
+    val about = if (isPublic) aboutSection() + "\n" else ""
+    // Public routes are open — no token param on the cards; a token-gated box keeps it.
+    val suffix = querySuffix(if (isPublic) "" else "token=" + WebEscaping.urlEncodeSegment(token))
+    val body =
+      if (systems.isEmpty()) {
+        "<p class=\"cp-sub\">No design systems are configured on this server.</p>"
+      } else {
+        val cards =
+          systems.joinToString("\n") { s ->
+            val sysSeg = WebEscaping.urlEncodeSegment(s.system)
+            val title = WebEscaping.htmlEscape(s.title)
+            val sysId = WebEscaping.htmlEscape(s.system)
+            val img =
+              if (s.heroPreviewId != null) {
+                val idSeg = WebEscaping.urlEncodeSegment(s.heroPreviewId)
+                "<img loading=\"lazy\" alt=\"$title preview\" src=\"/$sysSeg/render/$idSeg.png$suffix\">"
+              } else {
+                "<span class=\"cp-sys-noimg\">no preview</span>"
+              }
+            val desc =
+              s.subtitle
+                ?.takeIf { it.isNotBlank() }
+                ?.let {
+                  "\n            <div class=\"cp-sys-desc\">${WebEscaping.htmlEscape(it)}</div>"
+                } ?: ""
+            """
+            <a class="cp-card cp-sys" href="/$sysSeg/$suffix">
+              <div class="cp-imgwrap">$img</div>
+              <div class="cp-meta">
+                <div class="cp-sys-title">$title${compactTrustBadge(s.trust)}</div>
+                <div class="cp-id">$sysId</div>$desc
+                <div class="cp-sys-foot">${s.previewCount} preview(s)</div>
+              </div>
+            </a>
+            """
+              .trimIndent()
+          }
+        """
+        <p class="cp-sub">${systems.size} design system(s) · pick one to browse its components and
+          open a live, customisable preview.</p>
+        <div class="cp-grid cp-syslist" id="cp-grid">
+        $cards
+        </div>
+        """
+          .trimIndent()
+      }
+    return document(
+      title = "Design systems — compose-preview",
+      body =
+        """
+        $about<p class="cp-head">Design systems</p>
+        $body
+        """
+          .trimIndent(),
+    )
+  }
+
+  /**
+   * Pick a **meaningful** representative preview from a catalog's flattened ids for the home index
+   * — one recognisable, default-state light render rather than an arbitrary (often alphabetically
+   * first) edge case. Scores each id: light beats dark; a canonical button/filled hero is
+   * preferred; disabled/error/pressed/… state variants are pushed down. Ties break on the id so the
+   * choice is deterministic (stable goldens). Null when there are no previews.
+   */
+  fun representativePreviewId(previews: List<ServePreview>): String? {
+    if (previews.isEmpty()) return null
+    val demote =
+      listOf(
+        "disabled",
+        "error",
+        "pressed",
+        "focused",
+        "hover",
+        "dragged",
+        "unchecked",
+        "indeterminate",
+        "empty",
+        "loading",
+      )
+    fun score(id: String): Int {
+      val lower = id.lowercase()
+      var s = 0
+      if ("dark" in lower) s += 4
+      demote.forEach { if (it in lower) s += 8 }
+      if ("button" in lower) s -= 3
+      if ("filled" in lower) s -= 2
+      return s
+    }
+    return previews.map { it.id }.sortedWith(compareBy({ score(it) }, { it })).first()
+  }
+
   /** Landing page: the module's preview list, each card linking to its viewer. */
   fun landingPage(
     moduleLabel: String,
@@ -370,7 +531,7 @@ object ServeWeb {
      */
     basePath: String = "",
   ): String {
-    val q = linkQuery(token, sessionId, basePath)
+    val q = querySuffix(linkQuery(token, sessionId, basePath, isPublic))
     val cards =
       if (previews.isEmpty()) {
         "<p class=\"cp-sub\">No previews discovered in this module.</p>"
@@ -381,9 +542,9 @@ object ServeWeb {
           val idText = WebEscaping.htmlEscape(p.id)
           val themeAttr = cardTheme(p.id)?.let { " data-card-theme=\"$it\"" } ?: ""
           """
-          <a class="cp-card"$themeAttr href="$basePath/p/$idSeg?$q">
+          <a class="cp-card"$themeAttr href="$basePath/p/$idSeg$q">
             <div class="cp-imgwrap">
-              <img loading="lazy" alt="$label" src="$basePath/render/$idSeg.png?$q">
+              <img loading="lazy" alt="$label" src="$basePath/render/$idSeg.png$q">
             </div>
             <div class="cp-meta">
               <div class="cp-label" title="$idText">$label</div>
@@ -395,7 +556,8 @@ object ServeWeb {
         }
       }
     val about = if (isPublic) aboutSection() + "\n" else ""
-    val nav = if (catalogs.isNotEmpty()) catalogNav(catalogs, token, sessionId) + "\n" else ""
+    val nav =
+      if (catalogs.isNotEmpty()) catalogNav(catalogs, token, sessionId, isPublic) + "\n" else ""
     // The theme toggle only makes sense when the catalog carries per-theme variants to filter.
     val hasThemes = previews.any { cardTheme(it.id) != null }
     val themeToggle = if (hasThemes) themeToggleHtml() + "\n" else ""
@@ -415,7 +577,7 @@ object ServeWeb {
         """
         $about$nav<p class="cp-head">${WebEscaping.htmlEscape(moduleLabel)}${trustBadge(trust)}</p>
         $themeToggle<p class="cp-sub">${previews.size} preview(s) · click one to view with overrides ·
-          <a href="$basePath/bundle.zip?$q">download all (.zip)</a></p>
+          <a href="$basePath/bundle.zip$q">download all (.zip)</a></p>
         $searchBox<div class="cp-grid" id="cp-grid">
         $cards
         </div>$emptyState$filterScript
@@ -449,6 +611,13 @@ object ServeWeb {
      */
     basePath: String = "",
     /**
+     * Public mode: drop the `token=` param from the server-rendered "← previews" link (every route
+     * is open, so the token gates nothing). The viewer's own `/render` + `/ws` requests read the
+     * token from the page URL at runtime, so they're naturally token-free too when the page arrived
+     * without one. Off by default so a token-gated box keeps the token in links.
+     */
+    isPublic: Boolean = false,
+    /**
      * Label for the corner "backend" badge while showing the baked snapshot — the renderer that
      * produced the PNG (e.g. `Android` for the design catalogs). The in-browser Wasm tier always
      * reads `CMP-WASM`; the daemon stream reads [liveBackend]. Null ⇒ a generic `Snapshot`.
@@ -463,7 +632,7 @@ object ServeWeb {
     liveBackend: String? = null,
   ): String {
     val idSeg = WebEscaping.urlEncodeSegment(preview.id)
-    val q = linkQuery(token, sessionId, basePath)
+    val q = querySuffix(linkQuery(token, sessionId, basePath, isPublic))
     val label = WebEscaping.htmlEscape(preview.label)
     val idText = WebEscaping.htmlEscape(preview.id)
     val modes = preview.modes.joinToString(",") { it.wire }
@@ -516,7 +685,7 @@ object ServeWeb {
     val liveLabel = WebEscaping.htmlEscape(liveBackend ?: "Live")
     val body =
       """
-      <p class="cp-head"><a href="$basePath/?$q">← previews</a>${trustBadge(trust)}</p>
+      <p class="cp-head"><a href="$basePath/$q">← previews</a>${trustBadge(trust)}</p>
       <p class="cp-sub" title="$idText">$label</p>
       <div class="cp-viewer" data-preview-id="$idText" data-mode="snapshot" data-modes="$modes" data-snapshot-backend="$backendLabel" data-live-backend="$liveLabel"$wasmAttr>
         <div class="cp-stage"><span class="cp-backend" id="cp-backend"></span><img id="cp-img" alt="$label"><canvas id="cp-canvas" hidden></canvas>$wasmFrame</div>
@@ -611,9 +780,12 @@ object ServeWeb {
       }
       function query() {
         var o = overrides();
-        var q = "token=" + encodeURIComponent(token);
-        if (session) q += "&session=" + encodeURIComponent(session);
-        Object.keys(o).forEach(function (k) { q += "&" + k + "=" + encodeURIComponent(o[k]); });
+        // Public routes are open, so a page that arrived without a token stays token-free — only
+        // carry token= when this page's own URL had one (a token-gated box).
+        var parts = [];
+        if (token) parts.push("token=" + encodeURIComponent(token));
+        if (session) parts.push("session=" + encodeURIComponent(session));
+        Object.keys(o).forEach(function (k) { parts.push(k + "=" + encodeURIComponent(o[k])); });
         // Author-declared knobs (enabled only on a daemon session): knob.<key>=<kind>:<value>.
         document.querySelectorAll(".cp-knob").forEach(function (el) {
           if (el.disabled) return;
@@ -622,13 +794,14 @@ object ServeWeb {
           if (!key) return;
           var val = (el.type === "checkbox") ? (el.checked ? "true" : "false") : el.value;
           if (val === "") return;
-          q += "&knob." + encodeURIComponent(key) + "=" + encodeURIComponent(kind + ":" + val);
+          parts.push("knob." + encodeURIComponent(key) + "=" + encodeURIComponent(kind + ":" + val));
         });
-        return q;
+        return parts.join("&");
       }
       function refreshSnapshot() {
         status.textContent = "rendering…";
-        var url = base + "/render/" + encodeURIComponent(previewId) + ".png?" + query();
+        var qs = query();
+        var url = base + "/render/" + encodeURIComponent(previewId) + ".png" + (qs ? "?" + qs : "");
         var next = new Image();
         next.onload = function () { img.src = url; status.textContent = ""; };
         next.onerror = function () { status.textContent = "render failed"; };
@@ -753,8 +926,9 @@ object ServeWeb {
         var proto = location.protocol === "https:" ? "wss:" : "ws:";
         // Request WebP frames (smaller; the browser decodes them via the data URL, and the daemon
         // downgrades to PNG when it can't encode WebP — each frame carries its actual codec).
+        var qs = query();
         ws = new WebSocket(proto + "//" + location.host + base + "/ws/" +
-          encodeURIComponent(previewId) + "?" + query() + "&codec=webp");
+          encodeURIComponent(previewId) + "?" + (qs ? qs + "&codec=webp" : "codec=webp"));
         ws.onmessage = function (ev) {
           var m;
           try { m = JSON.parse(ev.data); } catch (e) { return; }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
@@ -81,8 +81,10 @@ class ServeHttpRoutingTest {
   fun `a catalog is reachable under its canonical path`() {
     val (landingCode, landing) = get("/compose-m3/")
     assertEquals(200, landingCode)
-    // The landing's own links stay on the path (no &session=).
-    assertTrue(landing.contains("/compose-m3/p/$previewId?token="), "path card link: $landing")
+    // The landing's own links stay on the path (no &session=). Public mode is open, so the link
+    // also carries no ?token — the route needs none.
+    assertTrue(landing.contains("href=\"/compose-m3/p/$previewId\""), "path card link: $landing")
+    assertTrue(!landing.contains("token="), "public path landing links are token-free: $landing")
 
     val (viewerCode, viewer) = get("/compose-m3/p/$previewId")
     assertEquals(200, viewerCode)
@@ -101,6 +103,21 @@ class ServeHttpRoutingTest {
     val (apiCode, api) = get("/compose-m3/api/previews")
     assertEquals(200, apiCode)
     assertTrue(api.contains("\"module\":\"compose-m3\""), "api for the path session: $api")
+  }
+
+  @Test
+  fun `the bare root serves the design-systems home index, not the default module`() {
+    val (code, body) = get("/")
+    assertEquals(200, code)
+    assertTrue(body.contains("Design systems"), "root is the systems index: $body")
+    // A card links to the catalog's canonical path and shows a hero preview from its /render lane.
+    assertTrue(body.contains("href=\"/compose-m3/\""), "index card links to the system: $body")
+    assertTrue(
+      body.contains("/compose-m3/render/$previewId.png"),
+      "index card renders a hero preview: $body",
+    )
+    // It is NOT the default module's own preview grid.
+    assertTrue(!body.contains("default-mod"), "root is the index, not the default module: $body")
   }
 
   @Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -90,6 +90,41 @@ class ServeWebFixtureTest {
         isPublic = true,
         catalogs = listOf("compose-m3", "wear-m3"),
       )
+    // The public preview server's FRONT DOOR: an index of the published design systems, each a card
+    // with a meaningful hero preview, its title + library, trust badge, and a link to /<system>/.
+    // This is what `/` serves now (instead of an arbitrary default module's grid), so the harness
+    // captures it per theme.
+    val homeIndex =
+      ServeWeb.homeIndexPage(
+        listOf(
+          ServeWeb.HomeSystem(
+            system = "compose-m3",
+            title = "Compose Material 3",
+            subtitle = "androidx.compose.material3:material3",
+            previewCount = 42,
+            trust = "branch:yschimke/compose-ai-tools@design-artifacts/compose-m3",
+            heroPreviewId = "button-filled__ideal__default__light",
+          ),
+          ServeWeb.HomeSystem(
+            system = "wear-m3",
+            title = "Wear Compose Material 3",
+            subtitle = "androidx.wear.compose:compose-material3",
+            previewCount = 18,
+            trust = "branch:yschimke/compose-ai-tools@design-artifacts/wear-m3",
+            heroPreviewId = "button-filled__ideal__default__light",
+          ),
+          ServeWeb.HomeSystem(
+            system = "remote-m3",
+            title = "Remote Compose Material 3",
+            subtitle = "androidx.wear.compose.remote:remote-material3",
+            previewCount = 6,
+            trust = "branch:yschimke/compose-ai-tools@design-artifacts/remote-m3",
+            heroPreviewId = "Button-Filled__ideal__default__light",
+          ),
+        ),
+        token,
+        isPublic = true,
+      )
     val viewer =
       ServeWeb.viewerPage(
         previews.first { it.id.endsWith("ProfileScreenPreview") },
@@ -144,6 +179,7 @@ class ServeWebFixtureTest {
       pagesDir.mkdirs()
       File(pagesDir, "serve-landing.html").writeText(landing)
       File(pagesDir, "serve-landing-public.html").writeText(landingPublic)
+      File(pagesDir, "serve-home-index.html").writeText(homeIndex)
       File(pagesDir, "serve-viewer.html").writeText(viewer)
       File(pagesDir, "serve-viewer-wasm.html").writeText(wasmViewer)
       File(pagesDir, "serve-landing-path.html").writeText(landingPath)
@@ -155,6 +191,7 @@ class ServeWebFixtureTest {
 
     assertGolden(File(pagesDir, "serve-landing.html"), landing)
     assertGolden(File(pagesDir, "serve-landing-public.html"), landingPublic)
+    assertGolden(File(pagesDir, "serve-home-index.html"), homeIndex)
     assertGolden(File(pagesDir, "serve-viewer.html"), viewer)
     assertGolden(File(pagesDir, "serve-viewer-wasm.html"), wasmViewer)
     assertGolden(File(pagesDir, "serve-landing-path.html"), landingPath)
@@ -163,6 +200,64 @@ class ServeWebFixtureTest {
     assertTrue(
       File(pagesDir, "_render-placeholder.png").isFile,
       "missing _render-placeholder.png — regenerate with UPDATE_SERVE_WEB_FIXTURES=true",
+    )
+
+    // The home index lists every published system as a card linking to its /<system>/ catalog —
+    // including remote-m3 — each carrying a hero preview img from that system's /render endpoint.
+    assertTrue(homeIndex.contains("Design systems"), "home index is headed 'Design systems'")
+    assertTrue(
+      homeIndex.contains("href=\"/compose-m3/\"") &&
+        homeIndex.contains("href=\"/wear-m3/\"") &&
+        homeIndex.contains("href=\"/remote-m3/\""),
+      "home index cards link to each system's canonical /<system>/ path",
+    )
+    assertTrue(
+      homeIndex.contains("Remote Compose Material 3"),
+      "remote-m3 appears in the index with its human title",
+    )
+    assertTrue(
+      homeIndex.contains("src=\"/remote-m3/render/Button-Filled__ideal__default__light.png\""),
+      "each system card renders a meaningful hero preview from its /render endpoint",
+    )
+    assertTrue(
+      homeIndex.contains("cp-badge--trusted"),
+      "the index badges each system's producer trust",
+    )
+    // Public mode opens every route, so server-rendered links carry NO ?token param.
+    assertFalse(homeIndex.contains("token="), "public home index links are token-free")
+    assertFalse(landingPublic.contains("token="), "public landing drops the token from its links")
+    // A token-gated (non-public) landing keeps the token as the only gate.
+    assertTrue(
+      landing.contains("?token=$token"),
+      "a token-gated landing keeps the token in its links",
+    )
+    // The public viewer's back-link is token-free, and its request-building JS only sends a token
+    // when the page URL itself carried one (so a public page stays token-free end to end).
+    val publicViewer =
+      ServeWeb.viewerPage(
+        previews.first(),
+        token,
+        sessionId = "compose-m3",
+        basePath = "/compose-m3",
+        isPublic = true,
+      )
+    assertFalse(publicViewer.contains("?token="), "public viewer back-link carries no token")
+    assertTrue(
+      publicViewer.contains("if (token) parts.push(\"token=\""),
+      "viewer JS only appends a token when the page URL carried one",
+    )
+    // The representative pick prefers a default-state light hero over dark / disabled edge cases.
+    assertEquals(
+      "button-filled__ideal__default__light",
+      ServeWeb.representativePreviewId(
+        listOf(
+          ServePreview("badge__ideal__default__dark", "Badge dark"),
+          ServePreview("button-filled__ideal__disabled__light", "Filled disabled"),
+          ServePreview("button-filled__ideal__default__light", "Filled default"),
+          ServePreview("button-filled__ideal__default__dark", "Filled dark"),
+        )
+      ),
+      "the hero pick prefers a default-state, light, filled-button render",
     )
 
     // The sticky theme toggle appears only for a catalog with per-theme variants, and each themed

--- a/deploy/image/docker-compose.yml
+++ b/deploy/image/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       # SERVE_PUBLIC=0 and SERVE_TOKEN in .env.
       SERVE_PUBLIC: "${SERVE_PUBLIC:-1}"
       # The catalog set is BAKED INTO THE IMAGE (entrypoint): the front-page systems
-      # (compose-m3,wear-m3) and the app systems served unlisted from their own repos
+      # (compose-m3,wear-m3,remote-m3) and the app systems served unlisted from their own repos
       # (meshcore-mobile, homeassistant-remotecompose). Leave these empty to inherit the
       # baked defaults — so a bare image pull self-heals without editing this compose.
       # Set your own comma list to override, or the literal `none` to serve none of that

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -7,11 +7,17 @@
    `?url=`) and get a shareable `?session=<name>` link. The server shows the bundle's **data tiers**
    (baked PNGs, Remote Compose / Protolayout / Lottie IR) for any uploader, and reports a **trust
    verdict** so you can tell a bundle from a producer you trust from an anonymous one.
-2. **The design systems we publish** — `--catalogs compose-m3,wear-m3` fetches each published
-   `design-artifacts/<system>` catalog and serves it read-only at its canonical path `/<system>/`
-   (the legacy `?session=<system>` form still works). Browsing that branch and opening a live,
-   customisable render are then two ends of one workflow (the branch's README + `catalog.json` carry
-   `livePreview` deep links back here).
+2. **The design systems we publish** — `--catalogs compose-m3,wear-m3,remote-m3` fetches each
+   published `design-artifacts/<system>` catalog and serves it read-only at its canonical path
+   `/<system>/` (the legacy `?session=<system>` form still works). Browsing that branch and opening a
+   live, customisable render are then two ends of one workflow (the branch's README + `catalog.json`
+   carry `livePreview` deep links back here).
+
+   When a server publishes catalogs, its **front door (`/`) is an index of those design systems** —
+   one card per listed system carrying a meaningful hero preview, the system's title + library, its
+   trust badge, and a link to `/<system>/`. (A plain `serve` with no `--catalogs` still shows the
+   served module's own preview grid at `/`.) This replaces showing an arbitrary default module at the
+   root — the point of the public server is the catalogs, so the landing leads with them.
 
    A catalog entry may name a **per-system source repo** as `<system>@<owner>/<repo>`, so one server
    can serve systems published to *different* repos — e.g. `compose-m3,wear-m3` from this repo
@@ -90,9 +96,9 @@ gzipped) is cached and revalidated cheaply (304) instead of re-downloaded each v
 
 ```bash
 compose-preview serve \
-  --module :samples:design-catalog-m3 \   # a base module is the default session
+  --module :samples:design-catalog-m3 \   # a base module (used only for ?session=/legacy; `/` is the index)
   --public \                              # open every route (no token)
-  --catalogs compose-m3,wear-m3 \         # published design systems, listed on the front-page nav
+  --catalogs compose-m3,wear-m3,remote-m3 \  # published design systems, listed on the front-page index
   --catalogs-unlisted \                   # served at /<system>/ but hidden from the nav; each from its own repo
       meshcore-mobile@yschimke/meshcore-mobile,homeassistant-remotecompose@yschimke/homeassistant-remotecompose \
   --trust-store trust/producers.json \    # who we trust (must list every catalog's branch/repo)
@@ -111,7 +117,7 @@ compose-preview serve \
 Both container profiles take this config from env (the entrypoint maps `SERVE_PUBLIC`,
 `SERVE_CATALOGS`, `SERVE_CATALOGS_UNLISTED`, `SERVE_TRUST_STORE`, `SERVE_WASM_DIR`,
 `SERVE_ACCEPT_BUNDLES` → flags) and put **Caddy** in front for TLS. They default to the **open public
-profile** (`SERVE_PUBLIC=1`, catalogs `compose-m3,wear-m3` on the nav, plus the app systems
+profile** (`SERVE_PUBLIC=1`, catalogs `compose-m3,wear-m3,remote-m3` on the front-page index, plus the app systems
 `meshcore-mobile` / `homeassistant-remotecompose` served unlisted at `/<system>/` from their own
 repos via `SERVE_CATALOGS_UNLISTED`); set `SERVE_PUBLIC=0` + `SERVE_TOKEN` for a token-gated box.
 
@@ -124,7 +130,7 @@ Mount your own over that path (or set `SERVE_TRUST_STORE` to it) to pin differen
 out — which also means a bare image pull self-heals a box without editing its compose.)
 
 The **catalog set is baked into the image the same way**: the entrypoint defaults `SERVE_CATALOGS`
-to `compose-m3,wear-m3` (front-page nav) and `SERVE_CATALOGS_UNLISTED` to
+to `compose-m3,wear-m3,remote-m3` (front-page index) and `SERVE_CATALOGS_UNLISTED` to
 `meshcore-mobile@yschimke/meshcore-mobile,homeassistant-remotecompose@yschimke/homeassistant-remotecompose`
 (served at `/<system>/`, off the nav). So a bare `docker pull` / Watchtower update serves them
 without editing the box's compose. Override either with your own comma list, or `none` to serve none
@@ -179,11 +185,13 @@ compose redeploy (`SERVE_LIVE_SEATS=1` in `.env`, then `docker compose up -d`).
 
 ## Endpoints
 
-`GET /` index · `GET /p/{id}?session=<s>` viewer · `GET /render/{id}.png` PNG ·
+`GET /` — with `--catalogs`, the **design-systems index** (one card per listed system); otherwise
+the served module's preview grid · `GET /p/{id}?session=<s>` viewer · `GET /render/{id}.png` PNG ·
 `GET /api/previews` JSON (now includes `trust`) · `POST /bundles/{name}` upload (returns `trust`) ·
 `GET /wasm/{system}/…` in-browser CMP app (ungated static assets) · `GET /healthz` ·
-`GET /version`. In `--public` mode all are open; otherwise the token gates everything but
-`/healthz`, `/version`, and `/wasm/` (static, no session data).
+`GET /version`. In `--public` mode all are open **and links carry no `?token`** (the token gates
+nothing); otherwise the token gates everything but `/healthz`, `/version`, and `/wasm/` (static, no
+session data) and is threaded through every generated link.
 
 Every session-selecting route also has a **path form** where the leading `/{system}` segment picks
 the session instead of `?session=`: `GET /{system}/` index · `GET /{system}/p/{id}` viewer ·

--- a/vscode-extension/preview-harness/fixtures/pages/serve-home-index.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-home-index.html
@@ -3,7 +3,7 @@
       <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <title>:samples:cmp — compose-preview</title>
+        <title>Design systems — compose-preview</title>
         <style>:root { color-scheme: light dark; }
 * { box-sizing: border-box; }
 body { margin: 0; padding: 24px; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
@@ -114,103 +114,37 @@ a:hover { text-decoration: underline; }
     <a href="/version">/version</a>
   </p>
 </section>
-      <nav class="cp-systems" aria-label="Design systems">
-        <span class="cp-systems-label">Design systems</span>
-        <a href="/compose-m3/">compose-m3</a>
-<a href="/wear-m3/">wear-m3</a>
-      </nav>
-<p class="cp-head">:samples:cmp <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/compose-ai-tools@design-artifacts/compose-m3">✓ branch:yschimke/compose-ai-tools@design-artifacts/compose-m3</span></p>
-        <p class="cp-sub">6 preview(s) · click one to view with overrides ·
-          <a href="/bundle.zip">download all (.zip)</a></p>
-        <div class="cp-searchbar">
-  <input id="cp-search" class="cp-search" type="search" placeholder="Filter previews…"
-    autocomplete="off" spellcheck="false" aria-label="Filter previews" aria-controls="cp-grid">
-  <span id="cp-count" class="cp-count" role="status" aria-live="polite" data-total="6"></span>
-</div>
-<div class="cp-grid" id="cp-grid">
-        <a class="cp-card" href="/p/com.example.ButtonPreview">
-  <div class="cp-imgwrap">
-    <img loading="lazy" alt="Button" src="/render/com.example.ButtonPreview.png">
-  </div>
+<p class="cp-head">Design systems</p>
+                <p class="cp-sub">3 design system(s) · pick one to browse its components and
+          open a live, customisable preview.</p>
+        <div class="cp-grid cp-syslist" id="cp-grid">
+        <a class="cp-card cp-sys" href="/compose-m3/">
+  <div class="cp-imgwrap"><img loading="lazy" alt="Compose Material 3 preview" src="/compose-m3/render/button-filled__ideal__default__light.png"></div>
   <div class="cp-meta">
-    <div class="cp-label" title="com.example.ButtonPreview">Button</div>
-    <div class="cp-id">com.example.ButtonPreview</div>
+    <div class="cp-sys-title">Compose Material 3 <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/compose-ai-tools@design-artifacts/compose-m3">✓ trusted</span></div>
+    <div class="cp-id">compose-m3</div>
+<div class="cp-sys-desc">androidx.compose.material3:material3</div>
+    <div class="cp-sys-foot">42 preview(s)</div>
   </div>
 </a>
-<a class="cp-card" href="/p/com.example.CardPreview">
-  <div class="cp-imgwrap">
-    <img loading="lazy" alt="Card" src="/render/com.example.CardPreview.png">
-  </div>
+<a class="cp-card cp-sys" href="/wear-m3/">
+  <div class="cp-imgwrap"><img loading="lazy" alt="Wear Compose Material 3 preview" src="/wear-m3/render/button-filled__ideal__default__light.png"></div>
   <div class="cp-meta">
-    <div class="cp-label" title="com.example.CardPreview">Card</div>
-    <div class="cp-id">com.example.CardPreview</div>
+    <div class="cp-sys-title">Wear Compose Material 3 <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/compose-ai-tools@design-artifacts/wear-m3">✓ trusted</span></div>
+    <div class="cp-id">wear-m3</div>
+<div class="cp-sys-desc">androidx.wear.compose:compose-material3</div>
+    <div class="cp-sys-foot">18 preview(s)</div>
   </div>
 </a>
-<a class="cp-card" href="/p/com.example.DialogPreview">
-  <div class="cp-imgwrap">
-    <img loading="lazy" alt="Dialog" src="/render/com.example.DialogPreview.png">
-  </div>
+<a class="cp-card cp-sys" href="/remote-m3/">
+  <div class="cp-imgwrap"><img loading="lazy" alt="Remote Compose Material 3 preview" src="/remote-m3/render/Button-Filled__ideal__default__light.png"></div>
   <div class="cp-meta">
-    <div class="cp-label" title="com.example.DialogPreview">Dialog</div>
-    <div class="cp-id">com.example.DialogPreview</div>
-  </div>
-</a>
-<a class="cp-card" href="/p/com.example.ListScreenPreview">
-  <div class="cp-imgwrap">
-    <img loading="lazy" alt="List screen" src="/render/com.example.ListScreenPreview.png">
-  </div>
-  <div class="cp-meta">
-    <div class="cp-label" title="com.example.ListScreenPreview">List screen</div>
-    <div class="cp-id">com.example.ListScreenPreview</div>
-  </div>
-</a>
-<a class="cp-card" href="/p/com.example.ProfileScreenPreview">
-  <div class="cp-imgwrap">
-    <img loading="lazy" alt="Profile screen" src="/render/com.example.ProfileScreenPreview.png">
-  </div>
-  <div class="cp-meta">
-    <div class="cp-label" title="com.example.ProfileScreenPreview">Profile screen</div>
-    <div class="cp-id">com.example.ProfileScreenPreview</div>
-  </div>
-</a>
-<a class="cp-card" href="/p/com.example.SettingsScreenPreview">
-  <div class="cp-imgwrap">
-    <img loading="lazy" alt="Settings screen" src="/render/com.example.SettingsScreenPreview.png">
-  </div>
-  <div class="cp-meta">
-    <div class="cp-label" title="com.example.SettingsScreenPreview">Settings screen</div>
-    <div class="cp-id">com.example.SettingsScreenPreview</div>
+    <div class="cp-sys-title">Remote Compose Material 3 <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/compose-ai-tools@design-artifacts/remote-m3">✓ trusted</span></div>
+    <div class="cp-id">remote-m3</div>
+<div class="cp-sys-desc">androidx.wear.compose.remote:remote-material3</div>
+    <div class="cp-sys-foot">6 preview(s)</div>
   </div>
 </a>
         </div>
-<p id="cp-empty" class="cp-empty" hidden>No previews match your filter.</p>
-<script>(function () {
-  var cards = document.querySelectorAll(".cp-card");
-  var input = document.getElementById("cp-search");
-  var count = document.getElementById("cp-count");
-  var empty = document.getElementById("cp-empty");
-  var total = cards.length;
-  
-  function apply() {
-    
-    var q = input ? input.value.trim().toLowerCase() : "";
-    var shown = 0;
-    cards.forEach(function (c) {
-      var ct = c.getAttribute("data-card-theme");
-      var lab = c.querySelector(".cp-label");
-      var idn = c.querySelector(".cp-id");
-      var hay = ((lab ? lab.textContent : "") + " " + (idn ? idn.textContent : "")).toLowerCase();
-      var searchOk = q === "" || hay.indexOf(q) !== -1;
-      var visible = true && searchOk;
-      c.hidden = !visible;
-      if (visible) shown++;
-    });
-    if (count) count.textContent = q === "" ? "" : (shown + " of " + total);
-    if (empty) empty.hidden = shown !== 0;
-  }
-  if (input) input.addEventListener("input", apply);
-  
-  apply();
-})();</script>
       </body>
     </html>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-path.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-path.html
@@ -41,6 +41,12 @@ a:hover { text-decoration: underline; }
 .cp-badge--trusted { background: #e7f4ea; color: #1e7a34; border: 1px solid #b6e0c2; }
 .cp-badge--unverified { background: #fdf0e3; color: #8a5300; border: 1px solid #f0d3a8; }
 .cp-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 16px; }
+.cp-syslist { grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); }
+.cp-syslist .cp-imgwrap { min-height: 180px; }
+.cp-sys-title { font-size: 0.98rem; font-weight: 600; }
+.cp-sys-desc { margin-top: 4px; font-size: 0.76rem; color: #6b6b70; line-height: 1.4; }
+.cp-sys-foot { margin-top: 8px; font-size: 0.74rem; color: #6b6b70; }
+.cp-sys-noimg { font-size: 0.78rem; color: #a0a0a8; }
 .cp-card { border: 1px solid #e3e3e8; border-radius: 10px; overflow: hidden; background: #fff;
   display: block; color: inherit; }
 .cp-card[hidden] { display: none; }
@@ -75,7 +81,7 @@ a:hover { text-decoration: underline; }
 .cp-knobs input:disabled { opacity: 0.7; }
 @media (prefers-color-scheme: dark) {
   body { color: #e6e6e9; background: #161618; }
-  .cp-sub, .cp-id, .cp-status, .cp-about-links { color: #a0a0a8; }
+  .cp-sub, .cp-id, .cp-status, .cp-about-links, .cp-sys-desc, .cp-sys-foot { color: #a0a0a8; }
   .cp-card, .cp-stage, .cp-knobs, .cp-about { border-color: #34343a; }
   .cp-card, .cp-about { background: #1d1d20; }
   .cp-about-body { color: #c9c9d0; }
@@ -110,66 +116,66 @@ a:hover { text-decoration: underline; }
 </section>
       <nav class="cp-systems" aria-label="Design systems">
         <span class="cp-systems-label">Design systems</span>
-        <a href="/compose-m3/?token=demo-token-fixture">compose-m3</a>
-<a href="/wear-m3/?token=demo-token-fixture">wear-m3</a>
+        <a href="/compose-m3/">compose-m3</a>
+<a href="/wear-m3/">wear-m3</a>
       </nav>
 <p class="cp-head">meshcore-mobile <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/meshcore-mobile@design-artifacts/meshcore-mobile">✓ branch:yschimke/meshcore-mobile@design-artifacts/meshcore-mobile</span></p>
         <p class="cp-sub">6 preview(s) · click one to view with overrides ·
-          <a href="/meshcore-mobile/bundle.zip?token=demo-token-fixture">download all (.zip)</a></p>
+          <a href="/meshcore-mobile/bundle.zip">download all (.zip)</a></p>
         <div class="cp-searchbar">
   <input id="cp-search" class="cp-search" type="search" placeholder="Filter previews…"
     autocomplete="off" spellcheck="false" aria-label="Filter previews" aria-controls="cp-grid">
   <span id="cp-count" class="cp-count" role="status" aria-live="polite" data-total="6"></span>
 </div>
 <div class="cp-grid" id="cp-grid">
-        <a class="cp-card" href="/meshcore-mobile/p/com.example.ButtonPreview?token=demo-token-fixture">
+        <a class="cp-card" href="/meshcore-mobile/p/com.example.ButtonPreview">
   <div class="cp-imgwrap">
-    <img loading="lazy" alt="Button" src="/meshcore-mobile/render/com.example.ButtonPreview.png?token=demo-token-fixture">
+    <img loading="lazy" alt="Button" src="/meshcore-mobile/render/com.example.ButtonPreview.png">
   </div>
   <div class="cp-meta">
     <div class="cp-label" title="com.example.ButtonPreview">Button</div>
     <div class="cp-id">com.example.ButtonPreview</div>
   </div>
 </a>
-<a class="cp-card" href="/meshcore-mobile/p/com.example.CardPreview?token=demo-token-fixture">
+<a class="cp-card" href="/meshcore-mobile/p/com.example.CardPreview">
   <div class="cp-imgwrap">
-    <img loading="lazy" alt="Card" src="/meshcore-mobile/render/com.example.CardPreview.png?token=demo-token-fixture">
+    <img loading="lazy" alt="Card" src="/meshcore-mobile/render/com.example.CardPreview.png">
   </div>
   <div class="cp-meta">
     <div class="cp-label" title="com.example.CardPreview">Card</div>
     <div class="cp-id">com.example.CardPreview</div>
   </div>
 </a>
-<a class="cp-card" href="/meshcore-mobile/p/com.example.DialogPreview?token=demo-token-fixture">
+<a class="cp-card" href="/meshcore-mobile/p/com.example.DialogPreview">
   <div class="cp-imgwrap">
-    <img loading="lazy" alt="Dialog" src="/meshcore-mobile/render/com.example.DialogPreview.png?token=demo-token-fixture">
+    <img loading="lazy" alt="Dialog" src="/meshcore-mobile/render/com.example.DialogPreview.png">
   </div>
   <div class="cp-meta">
     <div class="cp-label" title="com.example.DialogPreview">Dialog</div>
     <div class="cp-id">com.example.DialogPreview</div>
   </div>
 </a>
-<a class="cp-card" href="/meshcore-mobile/p/com.example.ListScreenPreview?token=demo-token-fixture">
+<a class="cp-card" href="/meshcore-mobile/p/com.example.ListScreenPreview">
   <div class="cp-imgwrap">
-    <img loading="lazy" alt="List screen" src="/meshcore-mobile/render/com.example.ListScreenPreview.png?token=demo-token-fixture">
+    <img loading="lazy" alt="List screen" src="/meshcore-mobile/render/com.example.ListScreenPreview.png">
   </div>
   <div class="cp-meta">
     <div class="cp-label" title="com.example.ListScreenPreview">List screen</div>
     <div class="cp-id">com.example.ListScreenPreview</div>
   </div>
 </a>
-<a class="cp-card" href="/meshcore-mobile/p/com.example.ProfileScreenPreview?token=demo-token-fixture">
+<a class="cp-card" href="/meshcore-mobile/p/com.example.ProfileScreenPreview">
   <div class="cp-imgwrap">
-    <img loading="lazy" alt="Profile screen" src="/meshcore-mobile/render/com.example.ProfileScreenPreview.png?token=demo-token-fixture">
+    <img loading="lazy" alt="Profile screen" src="/meshcore-mobile/render/com.example.ProfileScreenPreview.png">
   </div>
   <div class="cp-meta">
     <div class="cp-label" title="com.example.ProfileScreenPreview">Profile screen</div>
     <div class="cp-id">com.example.ProfileScreenPreview</div>
   </div>
 </a>
-<a class="cp-card" href="/meshcore-mobile/p/com.example.SettingsScreenPreview?token=demo-token-fixture">
+<a class="cp-card" href="/meshcore-mobile/p/com.example.SettingsScreenPreview">
   <div class="cp-imgwrap">
-    <img loading="lazy" alt="Settings screen" src="/meshcore-mobile/render/com.example.SettingsScreenPreview.png?token=demo-token-fixture">
+    <img loading="lazy" alt="Settings screen" src="/meshcore-mobile/render/com.example.SettingsScreenPreview.png">
   </div>
   <div class="cp-meta">
     <div class="cp-label" title="com.example.SettingsScreenPreview">Settings screen</div>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-themed.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-themed.html
@@ -41,6 +41,12 @@ a:hover { text-decoration: underline; }
 .cp-badge--trusted { background: #e7f4ea; color: #1e7a34; border: 1px solid #b6e0c2; }
 .cp-badge--unverified { background: #fdf0e3; color: #8a5300; border: 1px solid #f0d3a8; }
 .cp-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 16px; }
+.cp-syslist { grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); }
+.cp-syslist .cp-imgwrap { min-height: 180px; }
+.cp-sys-title { font-size: 0.98rem; font-weight: 600; }
+.cp-sys-desc { margin-top: 4px; font-size: 0.76rem; color: #6b6b70; line-height: 1.4; }
+.cp-sys-foot { margin-top: 8px; font-size: 0.74rem; color: #6b6b70; }
+.cp-sys-noimg { font-size: 0.78rem; color: #a0a0a8; }
 .cp-card { border: 1px solid #e3e3e8; border-radius: 10px; overflow: hidden; background: #fff;
   display: block; color: inherit; }
 .cp-card[hidden] { display: none; }
@@ -75,7 +81,7 @@ a:hover { text-decoration: underline; }
 .cp-knobs input:disabled { opacity: 0.7; }
 @media (prefers-color-scheme: dark) {
   body { color: #e6e6e9; background: #161618; }
-  .cp-sub, .cp-id, .cp-status, .cp-about-links { color: #a0a0a8; }
+  .cp-sub, .cp-id, .cp-status, .cp-about-links, .cp-sys-desc, .cp-sys-foot { color: #a0a0a8; }
   .cp-card, .cp-stage, .cp-knobs, .cp-about { border-color: #34343a; }
   .cp-card, .cp-about { background: #1d1d20; }
   .cp-about-body { color: #c9c9d0; }
@@ -110,8 +116,8 @@ a:hover { text-decoration: underline; }
 </section>
       <nav class="cp-systems" aria-label="Design systems">
         <span class="cp-systems-label">Design systems</span>
-        <a href="/compose-m3/?token=demo-token-fixture">compose-m3</a>
-<a href="/wear-m3/?token=demo-token-fixture">wear-m3</a>
+        <a href="/compose-m3/">compose-m3</a>
+<a href="/wear-m3/">wear-m3</a>
       </nav>
 <p class="cp-head">compose-m3 <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/compose-ai-tools@design-artifacts/compose-m3">✓ branch:yschimke/compose-ai-tools@design-artifacts/compose-m3</span></p>
         <div class="cp-toolbar">
@@ -121,52 +127,52 @@ a:hover { text-decoration: underline; }
   </span>
 </div>
 <p class="cp-sub">5 preview(s) · click one to view with overrides ·
-          <a href="/bundle.zip?token=demo-token-fixture">download all (.zip)</a></p>
+          <a href="/bundle.zip">download all (.zip)</a></p>
         <div class="cp-searchbar">
   <input id="cp-search" class="cp-search" type="search" placeholder="Filter previews…"
     autocomplete="off" spellcheck="false" aria-label="Filter previews" aria-controls="cp-grid">
   <span id="cp-count" class="cp-count" role="status" aria-live="polite" data-total="5"></span>
 </div>
 <div class="cp-grid" id="cp-grid">
-        <a class="cp-card" data-card-theme="light" href="/p/button-filled__ideal__default__light?token=demo-token-fixture">
+        <a class="cp-card" data-card-theme="light" href="/p/button-filled__ideal__default__light">
   <div class="cp-imgwrap">
-    <img loading="lazy" alt="Button · Filled (light)" src="/render/button-filled__ideal__default__light.png?token=demo-token-fixture">
+    <img loading="lazy" alt="Button · Filled (light)" src="/render/button-filled__ideal__default__light.png">
   </div>
   <div class="cp-meta">
     <div class="cp-label" title="button-filled__ideal__default__light">Button · Filled (light)</div>
     <div class="cp-id">button-filled__ideal__default__light</div>
   </div>
 </a>
-<a class="cp-card" data-card-theme="dark" href="/p/button-filled__ideal__default__dark?token=demo-token-fixture">
+<a class="cp-card" data-card-theme="dark" href="/p/button-filled__ideal__default__dark">
   <div class="cp-imgwrap">
-    <img loading="lazy" alt="Button · Filled (dark)" src="/render/button-filled__ideal__default__dark.png?token=demo-token-fixture">
+    <img loading="lazy" alt="Button · Filled (dark)" src="/render/button-filled__ideal__default__dark.png">
   </div>
   <div class="cp-meta">
     <div class="cp-label" title="button-filled__ideal__default__dark">Button · Filled (dark)</div>
     <div class="cp-id">button-filled__ideal__default__dark</div>
   </div>
 </a>
-<a class="cp-card" data-card-theme="light" href="/p/switch-on__ideal__default__light?token=demo-token-fixture">
+<a class="cp-card" data-card-theme="light" href="/p/switch-on__ideal__default__light">
   <div class="cp-imgwrap">
-    <img loading="lazy" alt="Switch · On (light)" src="/render/switch-on__ideal__default__light.png?token=demo-token-fixture">
+    <img loading="lazy" alt="Switch · On (light)" src="/render/switch-on__ideal__default__light.png">
   </div>
   <div class="cp-meta">
     <div class="cp-label" title="switch-on__ideal__default__light">Switch · On (light)</div>
     <div class="cp-id">switch-on__ideal__default__light</div>
   </div>
 </a>
-<a class="cp-card" data-card-theme="dark" href="/p/switch-on__ideal__default__dark?token=demo-token-fixture">
+<a class="cp-card" data-card-theme="dark" href="/p/switch-on__ideal__default__dark">
   <div class="cp-imgwrap">
-    <img loading="lazy" alt="Switch · On (dark)" src="/render/switch-on__ideal__default__dark.png?token=demo-token-fixture">
+    <img loading="lazy" alt="Switch · On (dark)" src="/render/switch-on__ideal__default__dark.png">
   </div>
   <div class="cp-meta">
     <div class="cp-label" title="switch-on__ideal__default__dark">Switch · On (dark)</div>
     <div class="cp-id">switch-on__ideal__default__dark</div>
   </div>
 </a>
-<a class="cp-card" href="/p/badge?token=demo-token-fixture">
+<a class="cp-card" href="/p/badge">
   <div class="cp-imgwrap">
-    <img loading="lazy" alt="Badge" src="/render/badge.png?token=demo-token-fixture">
+    <img loading="lazy" alt="Badge" src="/render/badge.png">
   </div>
   <div class="cp-meta">
     <div class="cp-label" title="badge">Badge</div>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing.html
@@ -41,6 +41,12 @@ a:hover { text-decoration: underline; }
 .cp-badge--trusted { background: #e7f4ea; color: #1e7a34; border: 1px solid #b6e0c2; }
 .cp-badge--unverified { background: #fdf0e3; color: #8a5300; border: 1px solid #f0d3a8; }
 .cp-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 16px; }
+.cp-syslist { grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); }
+.cp-syslist .cp-imgwrap { min-height: 180px; }
+.cp-sys-title { font-size: 0.98rem; font-weight: 600; }
+.cp-sys-desc { margin-top: 4px; font-size: 0.76rem; color: #6b6b70; line-height: 1.4; }
+.cp-sys-foot { margin-top: 8px; font-size: 0.74rem; color: #6b6b70; }
+.cp-sys-noimg { font-size: 0.78rem; color: #a0a0a8; }
 .cp-card { border: 1px solid #e3e3e8; border-radius: 10px; overflow: hidden; background: #fff;
   display: block; color: inherit; }
 .cp-card[hidden] { display: none; }
@@ -75,7 +81,7 @@ a:hover { text-decoration: underline; }
 .cp-knobs input:disabled { opacity: 0.7; }
 @media (prefers-color-scheme: dark) {
   body { color: #e6e6e9; background: #161618; }
-  .cp-sub, .cp-id, .cp-status, .cp-about-links { color: #a0a0a8; }
+  .cp-sub, .cp-id, .cp-status, .cp-about-links, .cp-sys-desc, .cp-sys-foot { color: #a0a0a8; }
   .cp-card, .cp-stage, .cp-knobs, .cp-about { border-color: #34343a; }
   .cp-card, .cp-about { background: #1d1d20; }
   .cp-about-body { color: #c9c9d0; }

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
@@ -41,6 +41,12 @@ a:hover { text-decoration: underline; }
 .cp-badge--trusted { background: #e7f4ea; color: #1e7a34; border: 1px solid #b6e0c2; }
 .cp-badge--unverified { background: #fdf0e3; color: #8a5300; border: 1px solid #f0d3a8; }
 .cp-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 16px; }
+.cp-syslist { grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); }
+.cp-syslist .cp-imgwrap { min-height: 180px; }
+.cp-sys-title { font-size: 0.98rem; font-weight: 600; }
+.cp-sys-desc { margin-top: 4px; font-size: 0.76rem; color: #6b6b70; line-height: 1.4; }
+.cp-sys-foot { margin-top: 8px; font-size: 0.74rem; color: #6b6b70; }
+.cp-sys-noimg { font-size: 0.78rem; color: #a0a0a8; }
 .cp-card { border: 1px solid #e3e3e8; border-radius: 10px; overflow: hidden; background: #fff;
   display: block; color: inherit; }
 .cp-card[hidden] { display: none; }
@@ -75,7 +81,7 @@ a:hover { text-decoration: underline; }
 .cp-knobs input:disabled { opacity: 0.7; }
 @media (prefers-color-scheme: dark) {
   body { color: #e6e6e9; background: #161618; }
-  .cp-sub, .cp-id, .cp-status, .cp-about-links { color: #a0a0a8; }
+  .cp-sub, .cp-id, .cp-status, .cp-about-links, .cp-sys-desc, .cp-sys-foot { color: #a0a0a8; }
   .cp-card, .cp-stage, .cp-knobs, .cp-about { border-color: #34343a; }
   .cp-card, .cp-about { background: #1d1d20; }
   .cp-about-body { color: #c9c9d0; }
@@ -193,9 +199,12 @@ a:hover { text-decoration: underline; }
   }
   function query() {
     var o = overrides();
-    var q = "token=" + encodeURIComponent(token);
-    if (session) q += "&session=" + encodeURIComponent(session);
-    Object.keys(o).forEach(function (k) { q += "&" + k + "=" + encodeURIComponent(o[k]); });
+    // Public routes are open, so a page that arrived without a token stays token-free — only
+    // carry token= when this page's own URL had one (a token-gated box).
+    var parts = [];
+    if (token) parts.push("token=" + encodeURIComponent(token));
+    if (session) parts.push("session=" + encodeURIComponent(session));
+    Object.keys(o).forEach(function (k) { parts.push(k + "=" + encodeURIComponent(o[k])); });
     // Author-declared knobs (enabled only on a daemon session): knob.<key>=<kind>:<value>.
     document.querySelectorAll(".cp-knob").forEach(function (el) {
       if (el.disabled) return;
@@ -204,13 +213,14 @@ a:hover { text-decoration: underline; }
       if (!key) return;
       var val = (el.type === "checkbox") ? (el.checked ? "true" : "false") : el.value;
       if (val === "") return;
-      q += "&knob." + encodeURIComponent(key) + "=" + encodeURIComponent(kind + ":" + val);
+      parts.push("knob." + encodeURIComponent(key) + "=" + encodeURIComponent(kind + ":" + val));
     });
-    return q;
+    return parts.join("&");
   }
   function refreshSnapshot() {
     status.textContent = "rendering…";
-    var url = base + "/render/" + encodeURIComponent(previewId) + ".png?" + query();
+    var qs = query();
+    var url = base + "/render/" + encodeURIComponent(previewId) + ".png" + (qs ? "?" + qs : "");
     var next = new Image();
     next.onload = function () { img.src = url; status.textContent = ""; };
     next.onerror = function () { status.textContent = "render failed"; };
@@ -335,8 +345,9 @@ a:hover { text-decoration: underline; }
     var proto = location.protocol === "https:" ? "wss:" : "ws:";
     // Request WebP frames (smaller; the browser decodes them via the data URL, and the daemon
     // downgrades to PNG when it can't encode WebP — each frame carries its actual codec).
+    var qs = query();
     ws = new WebSocket(proto + "//" + location.host + base + "/ws/" +
-      encodeURIComponent(previewId) + "?" + query() + "&codec=webp");
+      encodeURIComponent(previewId) + "?" + (qs ? qs + "&codec=webp" : "codec=webp"));
     ws.onmessage = function (ev) {
       var m;
       try { m = JSON.parse(ev.data); } catch (e) { return; }

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
@@ -41,6 +41,12 @@ a:hover { text-decoration: underline; }
 .cp-badge--trusted { background: #e7f4ea; color: #1e7a34; border: 1px solid #b6e0c2; }
 .cp-badge--unverified { background: #fdf0e3; color: #8a5300; border: 1px solid #f0d3a8; }
 .cp-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 16px; }
+.cp-syslist { grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); }
+.cp-syslist .cp-imgwrap { min-height: 180px; }
+.cp-sys-title { font-size: 0.98rem; font-weight: 600; }
+.cp-sys-desc { margin-top: 4px; font-size: 0.76rem; color: #6b6b70; line-height: 1.4; }
+.cp-sys-foot { margin-top: 8px; font-size: 0.74rem; color: #6b6b70; }
+.cp-sys-noimg { font-size: 0.78rem; color: #a0a0a8; }
 .cp-card { border: 1px solid #e3e3e8; border-radius: 10px; overflow: hidden; background: #fff;
   display: block; color: inherit; }
 .cp-card[hidden] { display: none; }
@@ -75,7 +81,7 @@ a:hover { text-decoration: underline; }
 .cp-knobs input:disabled { opacity: 0.7; }
 @media (prefers-color-scheme: dark) {
   body { color: #e6e6e9; background: #161618; }
-  .cp-sub, .cp-id, .cp-status, .cp-about-links { color: #a0a0a8; }
+  .cp-sub, .cp-id, .cp-status, .cp-about-links, .cp-sys-desc, .cp-sys-foot { color: #a0a0a8; }
   .cp-card, .cp-stage, .cp-knobs, .cp-about { border-color: #34343a; }
   .cp-card, .cp-about { background: #1d1d20; }
   .cp-about-body { color: #c9c9d0; }
@@ -194,9 +200,12 @@ a:hover { text-decoration: underline; }
   }
   function query() {
     var o = overrides();
-    var q = "token=" + encodeURIComponent(token);
-    if (session) q += "&session=" + encodeURIComponent(session);
-    Object.keys(o).forEach(function (k) { q += "&" + k + "=" + encodeURIComponent(o[k]); });
+    // Public routes are open, so a page that arrived without a token stays token-free — only
+    // carry token= when this page's own URL had one (a token-gated box).
+    var parts = [];
+    if (token) parts.push("token=" + encodeURIComponent(token));
+    if (session) parts.push("session=" + encodeURIComponent(session));
+    Object.keys(o).forEach(function (k) { parts.push(k + "=" + encodeURIComponent(o[k])); });
     // Author-declared knobs (enabled only on a daemon session): knob.<key>=<kind>:<value>.
     document.querySelectorAll(".cp-knob").forEach(function (el) {
       if (el.disabled) return;
@@ -205,13 +214,14 @@ a:hover { text-decoration: underline; }
       if (!key) return;
       var val = (el.type === "checkbox") ? (el.checked ? "true" : "false") : el.value;
       if (val === "") return;
-      q += "&knob." + encodeURIComponent(key) + "=" + encodeURIComponent(kind + ":" + val);
+      parts.push("knob." + encodeURIComponent(key) + "=" + encodeURIComponent(kind + ":" + val));
     });
-    return q;
+    return parts.join("&");
   }
   function refreshSnapshot() {
     status.textContent = "rendering…";
-    var url = base + "/render/" + encodeURIComponent(previewId) + ".png?" + query();
+    var qs = query();
+    var url = base + "/render/" + encodeURIComponent(previewId) + ".png" + (qs ? "?" + qs : "");
     var next = new Image();
     next.onload = function () { img.src = url; status.textContent = ""; };
     next.onerror = function () { status.textContent = "render failed"; };
@@ -336,8 +346,9 @@ a:hover { text-decoration: underline; }
     var proto = location.protocol === "https:" ? "wss:" : "ws:";
     // Request WebP frames (smaller; the browser decodes them via the data URL, and the daemon
     // downgrades to PNG when it can't encode WebP — each frame carries its actual codec).
+    var qs = query();
     ws = new WebSocket(proto + "//" + location.host + base + "/ws/" +
-      encodeURIComponent(previewId) + "?" + query() + "&codec=webp");
+      encodeURIComponent(previewId) + "?" + (qs ? qs + "&codec=webp" : "codec=webp"));
     ws.onmessage = function (ev) {
       var m;
       try { m = JSON.parse(ev.data); } catch (e) { return; }

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
@@ -41,6 +41,12 @@ a:hover { text-decoration: underline; }
 .cp-badge--trusted { background: #e7f4ea; color: #1e7a34; border: 1px solid #b6e0c2; }
 .cp-badge--unverified { background: #fdf0e3; color: #8a5300; border: 1px solid #f0d3a8; }
 .cp-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 16px; }
+.cp-syslist { grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); }
+.cp-syslist .cp-imgwrap { min-height: 180px; }
+.cp-sys-title { font-size: 0.98rem; font-weight: 600; }
+.cp-sys-desc { margin-top: 4px; font-size: 0.76rem; color: #6b6b70; line-height: 1.4; }
+.cp-sys-foot { margin-top: 8px; font-size: 0.74rem; color: #6b6b70; }
+.cp-sys-noimg { font-size: 0.78rem; color: #a0a0a8; }
 .cp-card { border: 1px solid #e3e3e8; border-radius: 10px; overflow: hidden; background: #fff;
   display: block; color: inherit; }
 .cp-card[hidden] { display: none; }
@@ -75,7 +81,7 @@ a:hover { text-decoration: underline; }
 .cp-knobs input:disabled { opacity: 0.7; }
 @media (prefers-color-scheme: dark) {
   body { color: #e6e6e9; background: #161618; }
-  .cp-sub, .cp-id, .cp-status, .cp-about-links { color: #a0a0a8; }
+  .cp-sub, .cp-id, .cp-status, .cp-about-links, .cp-sys-desc, .cp-sys-foot { color: #a0a0a8; }
   .cp-card, .cp-stage, .cp-knobs, .cp-about { border-color: #34343a; }
   .cp-card, .cp-about { background: #1d1d20; }
   .cp-about-body { color: #c9c9d0; }
@@ -193,9 +199,12 @@ a:hover { text-decoration: underline; }
   }
   function query() {
     var o = overrides();
-    var q = "token=" + encodeURIComponent(token);
-    if (session) q += "&session=" + encodeURIComponent(session);
-    Object.keys(o).forEach(function (k) { q += "&" + k + "=" + encodeURIComponent(o[k]); });
+    // Public routes are open, so a page that arrived without a token stays token-free — only
+    // carry token= when this page's own URL had one (a token-gated box).
+    var parts = [];
+    if (token) parts.push("token=" + encodeURIComponent(token));
+    if (session) parts.push("session=" + encodeURIComponent(session));
+    Object.keys(o).forEach(function (k) { parts.push(k + "=" + encodeURIComponent(o[k])); });
     // Author-declared knobs (enabled only on a daemon session): knob.<key>=<kind>:<value>.
     document.querySelectorAll(".cp-knob").forEach(function (el) {
       if (el.disabled) return;
@@ -204,13 +213,14 @@ a:hover { text-decoration: underline; }
       if (!key) return;
       var val = (el.type === "checkbox") ? (el.checked ? "true" : "false") : el.value;
       if (val === "") return;
-      q += "&knob." + encodeURIComponent(key) + "=" + encodeURIComponent(kind + ":" + val);
+      parts.push("knob." + encodeURIComponent(key) + "=" + encodeURIComponent(kind + ":" + val));
     });
-    return q;
+    return parts.join("&");
   }
   function refreshSnapshot() {
     status.textContent = "rendering…";
-    var url = base + "/render/" + encodeURIComponent(previewId) + ".png?" + query();
+    var qs = query();
+    var url = base + "/render/" + encodeURIComponent(previewId) + ".png" + (qs ? "?" + qs : "");
     var next = new Image();
     next.onload = function () { img.src = url; status.textContent = ""; };
     next.onerror = function () { status.textContent = "render failed"; };
@@ -335,8 +345,9 @@ a:hover { text-decoration: underline; }
     var proto = location.protocol === "https:" ? "wss:" : "ws:";
     // Request WebP frames (smaller; the browser decodes them via the data URL, and the daemon
     // downgrades to PNG when it can't encode WebP — each frame carries its actual codec).
+    var qs = query();
     ws = new WebSocket(proto + "//" + location.host + base + "/ws/" +
-      encodeURIComponent(previewId) + "?" + query() + "&codec=webp");
+      encodeURIComponent(previewId) + "?" + (qs ? qs + "&codec=webp" : "codec=webp"));
     ws.onmessage = function (ev) {
       var m;
       try { m = JSON.parse(ev.data); } catch (e) { return; }


### PR DESCRIPTION
The public preview server (preview.coo.ee) served an arbitrary default
module (a placeholder host app with three foundation-only previews) at
`/`. Replace that with a proper index of the published design systems:
when a server has `--catalogs`, the bare `/` now renders one card per
listed system carrying a meaningful hero preview, the system's title +
library, a trust badge, and a link to its `/<system>/` catalog. A plain
`serve` with no catalogs keeps the module's own preview grid.

- Capture `title` + `library` from each catalog.json and surface them on
  ServeBundleHost so the index card reads as a name, not a bare id.
- Pick a representative hero preview (prefers a default-state, light,
  filled-button render over dark/disabled edge cases).
- Drop the `?token` param from every generated link in `--public` mode:
  the token gates nothing there, so public links (and the viewer's own
  render/ws requests) are now token-free. Token-gated boxes are
  unchanged.
- List remote-m3 alongside compose-m3/wear-m3 in the docs + image compose
  comment so the published set matches the entrypoint default.

Wire the new surface into the preview-harness (serve-home-index.html)
so the CI visual-diff bot captures it on every PR.