### PR TITLE
feat(design-artifacts): fold @ColorCatalog/@TypographyCatalog tokens into the kit

### DIFF
--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -171,6 +171,25 @@ function mergeByFunction(a, b) {
 }
 
 /**
+ * Deep-merge two token sets, layering `extra` over `base` per category (spacing /
+ * colors / radius / typography). Folds `@ColorCatalog`/`@TypographyCatalog` tokens
+ * on top of the MaterialTheme table lifted from component semantics, so a bundle
+ * carrying both keeps every token instead of one replacing the other. Returns the
+ * single defined side when only one exists, or `undefined` when neither does.
+ */
+function mergeDesignTokens(base, extra) {
+  if (!base) return extra;
+  if (!extra) return base;
+  const out = { ...base };
+  for (const cat of ["spacing", "colors", "radius", "typography"]) {
+    if (base[cat] || extra[cat]) {
+      out[cat] = { ...(base[cat] ?? {}), ...(extra[cat] ?? {}) };
+    }
+  }
+  return out;
+}
+
+/**
  * Join rendered candidates to a catalog spec. Each spec component is matched to
  * the candidate whose preview function name equals its `preview`; a function's
  * theme/size variants are folded into one component, missing previews are
@@ -274,17 +293,27 @@ const { candidates, bundle } = await loadCandidates(rendersPath);
 // System tokens declared via `@ColorCatalog` / `@TypographyCatalog` — carried in the
 // bundle as `previews/<id>.catalog.json` sidecars (compose-ai-tools#2167), which the
 // screen-render `compose/theme` never sees (an ad-hoc palette / type scale has no
-// MaterialTheme). Feed them as the catalog's `themeTokens` so they land in the exported
-// DTCG token set + sticker kit. `undefined` for a bundle with no catalog sheets (today's
-// `@CatalogModes` design-catalog modules), so `buildCatalog` keeps lifting theme tokens
-// from component semantics — behaviour is unchanged until a module adds the annotations.
-// (Merging both a MaterialTheme table AND catalog tokens is a future refinement — no
-// current module carries both.)
+// MaterialTheme). Fold them into the catalog's exported `themeTokens` so they land in
+// the DTCG token set + sticker kit.
+//
+// When a bundle carries BOTH — a MaterialTheme system (whose tokens `buildCatalog` lifts
+// from component `semantics.themeTokens`) AND catalog sidecars — the two are MERGED, not
+// replaced: lift the semantic table here (the same first-component-with-themeTokens rule
+// `buildCatalog` uses) and layer the catalog tokens on top, so adding a catalog sheet to
+// an M3/Wear module augments its token set instead of dropping the MaterialTheme one.
+// When there are no catalog tokens we pass nothing, so `buildCatalog` lifts exactly as
+// before — zero behaviour change for today's `@CatalogModes` design-catalog modules.
 const catalogTokens = catalogTokensFromBundle(bundle);
+const themeTokens = catalogTokens
+  ? mergeDesignTokens(
+      candidates.find((c) => c.semantics?.themeTokens)?.semantics?.themeTokens,
+      catalogTokens,
+    )
+  : undefined;
 
 const { catalog, missing, withoutSemantics } = catalogFromCandidates(candidates, spec, {
   ...(values.renderer ? { renderer: values.renderer } : {}),
-  ...(catalogTokens ? { themeTokens: catalogTokens } : {}),
+  ...(themeTokens ? { themeTokens } : {}),
 });
 
 // Completeness gate: `bundle pack --with-semantics` is best-effort and exits 0

--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -35,7 +35,11 @@ import { cp, mkdir, readFile, readdir, writeFile } from "node:fs/promises";
 import { dirname, resolve, join, relative } from "node:path";
 import { parseArgs } from "node:util";
 
-import { readPreviewBundle, bundleToCandidates } from "@design-parity/candidate";
+import {
+  readPreviewBundle,
+  bundleToCandidates,
+  catalogTokensFromBundle,
+} from "@design-parity/candidate";
 import { buildCatalog, writeCatalog } from "@design-parity/catalog-export";
 
 import { renderIndexHtml } from "./render-index-html.mjs";
@@ -267,8 +271,20 @@ const spec = JSON.parse(await readFile(specPath, "utf8"));
 // also works around the published null-widthDp crash) and the vendored join.
 const { candidates, bundle } = await loadCandidates(rendersPath);
 
+// System tokens declared via `@ColorCatalog` / `@TypographyCatalog` — carried in the
+// bundle as `previews/<id>.catalog.json` sidecars (compose-ai-tools#2167), which the
+// screen-render `compose/theme` never sees (an ad-hoc palette / type scale has no
+// MaterialTheme). Feed them as the catalog's `themeTokens` so they land in the exported
+// DTCG token set + sticker kit. `undefined` for a bundle with no catalog sheets (today's
+// `@CatalogModes` design-catalog modules), so `buildCatalog` keeps lifting theme tokens
+// from component semantics — behaviour is unchanged until a module adds the annotations.
+// (Merging both a MaterialTheme table AND catalog tokens is a future refinement — no
+// current module carries both.)
+const catalogTokens = catalogTokensFromBundle(bundle);
+
 const { catalog, missing, withoutSemantics } = catalogFromCandidates(candidates, spec, {
   ...(values.renderer ? { renderer: values.renderer } : {}),
+  ...(catalogTokens ? { themeTokens: catalogTokens } : {}),
 });
 
 // Completeness gate: `bundle pack --with-semantics` is best-effort and exits 0

--- a/scripts/design-artifacts/package-lock.json
+++ b/scripts/design-artifacts/package-lock.json
@@ -8,7 +8,7 @@
       "name": "design-artifacts-driver",
       "version": "0.0.0",
       "dependencies": {
-        "@design-parity/candidate": "^0.1.21",
+        "@design-parity/candidate": "^0.1.24",
         "@design-parity/catalog-export": "^0.1.20"
       },
       "engines": {
@@ -16,12 +16,12 @@
       }
     },
     "node_modules/@design-parity/candidate": {
-      "version": "0.1.21",
-      "resolved": "https://registry.npmjs.org/@design-parity/candidate/-/candidate-0.1.21.tgz",
-      "integrity": "sha512-xRIUYuGb9Cbzja7xCZWzr+xE+tZzrzBOiMEBMpqziAc9YrAtjfcANbwAVzBRf7yLcqStAoQXNbYQMQHQp92mIA==",
+      "version": "0.1.24",
+      "resolved": "https://registry.npmjs.org/@design-parity/candidate/-/candidate-0.1.24.tgz",
+      "integrity": "sha512-4pToJMTCYQnPJVsMaBet76k7v2VYIeBM3L5t5glg8r99ux4c/7oH9qWgD72c5XcSEmZpgVAV1RKNXBJPBtG4rQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@design-parity/core": "^0.1.21",
+        "@design-parity/core": "^0.1.24",
         "fflate": "^0.8.2"
       }
     },
@@ -35,9 +35,9 @@
       }
     },
     "node_modules/@design-parity/core": {
-      "version": "0.1.21",
-      "resolved": "https://registry.npmjs.org/@design-parity/core/-/core-0.1.21.tgz",
-      "integrity": "sha512-b9oxVbKdSZdrFJkPqPrzxw2N898cs/ksktmM5nKb0K9CrRXwOYg4rV5uqkJE8rU25dt4WjrOgpFfyv2lALAqVQ==",
+      "version": "0.1.24",
+      "resolved": "https://registry.npmjs.org/@design-parity/core/-/core-0.1.24.tgz",
+      "integrity": "sha512-Bj2Xl5jPTEjrJnOuv4xLxHFnRBBWhhwgoCHym0OdNLI/uX9nxa1OKyLyPQAf0911Z2LFsKlgt+hP2IVrjkJftQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.17.1"

--- a/scripts/design-artifacts/package.json
+++ b/scripts/design-artifacts/package.json
@@ -8,7 +8,7 @@
     "node": ">=22"
   },
   "dependencies": {
-    "@design-parity/candidate": "^0.1.21",
+    "@design-parity/candidate": "^0.1.24",
     "@design-parity/catalog-export": "^0.1.20"
   }
 }


### PR DESCRIPTION
## Summary

The **final piece** of `#2167` — closes the loop end-to-end. Wires the design-artifact export driver to the reader shipped in `@design-parity/candidate@0.1.24` (design-parity#167): `generate-design-catalog.mjs` now reads the bundle's `previews/<id>.catalog.json` sidecars via `catalogTokensFromBundle` and passes the aggregated palette / type scale as the catalog's `themeTokens`.

### Why

An ad-hoc palette or type scale declared with `@ColorCatalog` / `@TypographyCatalog` carries no `MaterialTheme`, so it never appeared in the `compose/theme` `themeTokens` a *screen render* exposes — and thus never reached the exported DTCG token file or the Figma/Stitch/Claude-Design sticker kit. Now it does.

Safe by construction: `catalogTokensFromBundle` returns `undefined` for a bundle with no catalog sheets (today's `@CatalogModes` `design-catalog-*` modules), so `buildCatalog` keeps lifting theme tokens from component semantics — **behaviour is unchanged until a module adds the annotations.** (Merging *both* a MaterialTheme table and catalog tokens is a noted future refinement; no current module carries both.)

### Changes
- **`scripts/design-artifacts/package.json`** — bump pinned `@design-parity/candidate` to `^0.1.24` (the reader's first release); lockfile updated to match.
- **`generate-design-catalog.mjs`** — import `catalogTokensFromBundle`, merge its result into `catalogFromCandidates`' `themeTokens`.

### Verification

Ran against the **published** `@design-parity/candidate@0.1.24`:
```
$ node -e 'import { catalogTokensFromBundle } … '
type: function
{"colors":{"BrandCoral":"#ff6f61ff"},"typography":{"DisplayLarge":{"fontSize":45,"fontWeight":400}}}
empty -> undefined
```
i.e. a catalog bundle yields the aggregated tokens; a non-catalog bundle yields `undefined` (fallback preserved).

*(Build/data-plumbing for the weekly `design-artifacts.yml` driver — no visual surface change, so text evidence per the repo's visual-evidence rule. `design-artifacts.yml` runs on schedule/dispatch, not on PR, so this doesn't affect PR CI.)*

## The full #2167 loop, now complete
1. **Renderer emits** tokens — #2168 ✅
2. **Bundle carries** them (cache-tracked) — #2172 ✅
3. **design-parity reads** them (`catalogTokensFromBundle`, 0.1.24) — design-parity#167 ✅
4. **Kit export folds** them into `themeTokens` — **this PR**

## Follow-up
After merge, dispatch `design-artifacts.yml` so the `design-artifacts/*` delivery branches regenerate with the wired driver (and to smoke-test the pipeline end-to-end against a real bundle).

Closes #2167.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RAVWZ5FWyr4gqbYSfaRvyk)_