### PR TITLE
feat(wasm-catalog): manifest-driven fonts, prefetched in parallel with the Wasm boot

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -794,6 +794,11 @@ object ServeWeb {
         if (u.origin !== location.origin) return "";
         return u.href;
       }
+      // NOTE: don't "preload" the app's fonts from this page — the sandboxed iframe has an opaque
+      // origin, and Chrome partitions the HTTP cache by frame origin, so nothing fetched here is
+      // reusable inside it (measured: every font was fetched twice). The prefetch that actually
+      // works lives in the app's own index.html, which starts the manifest+font fetches at
+      // document load, in parallel with the Wasm boot.
       // The override patch (theme / font scale / locale) the running app merges over its baked base —
       // a bare `a=b&c=d` query. An absent key falls back to the app's baked default (e.g. cleared
       // Theme → the variant's uiMode). Device / orientation are server-render-only, so not forwarded.

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -259,6 +259,13 @@ class ServeWebFixtureTest {
       "iframe is positioned over the snapshot's rendered box",
     )
     assertTrue(withWasm.contains("loading Wasm…"), "load state keeps the snapshot with a status")
+    // Guard against re-adding a page-side font preload: the sandboxed iframe's opaque origin gets
+    // its own HTTP-cache partition, so nothing this page fetches is reusable inside it. The real
+    // prefetch lives in the app's index.html (parallel with the Wasm boot).
+    assertFalse(
+      withWasm.contains("preloadWasmFonts"),
+      "no page-side font preload (cache-partitioned away from the sandboxed iframe)",
+    )
     // The in-browser tier can drop the sticker background (component only on the checkerboard).
     assertTrue(
       withWasm.contains("id=\"cp-wasm-bg\"") && withWasm.contains("Component only (no background)"),

--- a/samples/cmp-wasm-catalog/src/wasmJsMain/kotlin/com/example/cmpwasmcatalog/Main.kt
+++ b/samples/cmp-wasm-catalog/src/wasmJsMain/kotlin/com/example/cmpwasmcatalog/Main.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.platform.Font
 import androidx.compose.ui.window.ComposeViewport
@@ -55,15 +56,15 @@ fun main() {
   baseParams = parseQuery(locationSearch())
   renderParams.value = baseParams + parseQuery(locationHash())
   ComposeViewport(viewportContainerId = "composeApp") {
-    // Text parity with the baked snapshot needs the same typeface the Android renderer
-    // rasterizes:
-    // fetch Roboto by URL (self-hosted beside the app, `?fontsBase=` overridable) and hold the
-    // catalog composition — and therefore the first-frame signal the embedding viewer swaps on —
-    // until the fonts resolve, so the first revealed frame is already Roboto-shaped. A fetch
-    // failure or the timeout degrades to the CMP bundled font instead of blocking the reveal.
+    // Text parity with the baked snapshot needs the same typefaces the Android renderer
+    // rasterizes: load the fonts the `fonts.json` manifest declares (self-hosted beside the app,
+    // `?fontsBase=` overridable) and hold the catalog composition — and therefore the first-frame
+    // signal the embedding viewer swaps on — until they resolve, so the first revealed frame is
+    // already shaped by the right fonts. A fetch failure or the timeout degrades to the CMP
+    // bundled font instead of blocking the reveal.
     var fonts by remember { mutableStateOf<FontsState>(FontsState.Loading) }
     LaunchedEffect(Unit) {
-      fonts = FontsState.Ready(withTimeoutOrNull(FONT_LOAD_TIMEOUT_MS) { loadRobotoFamily() })
+      fonts = FontsState.Ready(withTimeoutOrNull(FONT_LOAD_TIMEOUT_MS) { loadCatalogFonts() })
     }
     val loaded = fonts as? FontsState.Ready ?: return@ComposeViewport
     val params by renderParams
@@ -101,32 +102,118 @@ private sealed interface FontsState {
 }
 
 /**
- * Fetch Roboto (Regular 400 + Medium 500 — the two weights M3's type scale uses) **by URL** and
- * build a [FontFamily] from the raw bytes. The default base is `./fonts/` — vendored beside the app
- * (self-hosted, Apache 2.0), so the bundle stays offline-clean behind an egress proxy — and an
- * operator can point `?fontsBase=` at any http(s) origin that serves the same filenames with CORS
- * (the sandboxed iframe has an opaque origin, so cross-origin fonts need `ACAO`). Null on any
- * failure ⇒ the caller falls back to the CMP bundled font.
+ * Load the catalog's fonts **by URL**, driven by the `fonts.json` manifest served beside them: for
+ * each `role: "default"` family entry, fetch its files and build one [FontFamily] used for the
+ * whole M3 type scale. The default base is `./fonts/` — vendored beside the app (self-hosted,
+ * Apache 2.0), so the bundle stays offline-clean behind an egress proxy — and an operator can point
+ * `?fontsBase=` at any http(s) origin that serves the same layout with CORS (the sandboxed iframe
+ * has an opaque origin, so cross-origin fonts need `ACAO`). A base without a manifest falls back to
+ * the fixed Roboto pair (the pre-manifest `?fontsBase=` contract); null on any failure ⇒ the caller
+ * falls back to the CMP bundled font.
+ *
+ * The host `index.html` starts these same fetches at document load (`__cpPrefetch*`), in parallel
+ * with the Wasm boot, and the fetch bridge below consumes those in-flight promises — so by the time
+ * this runs the bytes are usually already here. (It must be the *iframe's own* prefetch: the
+ * sandbox's opaque origin gets its own HTTP-cache partition, so the embedding viewer page can't
+ * warm anything for it.)
  */
-private suspend fun loadRobotoFamily(): FontFamily? {
+private suspend fun loadCatalogFonts(): FontFamily? {
   val raw = baseParams["fontsBase"] ?: "./fonts/"
   // A fetch URL, not code — but still refuse non-http(s) absolute schemes (javascript:, data:).
   val base =
     (if (raw.endsWith("/")) raw else "$raw/").takeIf {
       !it.contains(":") || it.startsWith("http:") || it.startsWith("https:")
     } ?: "./fonts/"
+  val entries =
+    runCatching { parseFontsManifest(fetchText(base + "fonts.json")) }
+      .getOrDefault(emptyList())
+      .filter { it.role == "default" }
   return try {
-    val regular = fetchBytes(base + "Roboto-Regular.ttf")
-    val medium = fetchBytes(base + "Roboto-Medium.ttf")
-    FontFamily(
-      Font(identity = "Roboto-Regular", data = regular, weight = FontWeight.Normal),
-      Font(identity = "Roboto-Medium", data = medium, weight = FontWeight.Medium),
-    )
+    if (entries.isEmpty()) {
+      // Legacy layout: a fontsBase serving bare TTFs without a manifest (the #2174 contract).
+      FontFamily(
+        Font(identity = "Roboto-Regular", data = fetchBytes(base + "Roboto-Regular.ttf")),
+        Font(
+          identity = "Roboto-Medium",
+          data = fetchBytes(base + "Roboto-Medium.ttf"),
+          weight = FontWeight.Medium,
+        ),
+      )
+    } else {
+      FontFamily(
+        entries.map { e ->
+          Font(
+            identity = e.file,
+            data = fetchBytes(base + e.file),
+            weight = FontWeight(e.weight),
+            style = if (e.italic) FontStyle.Italic else FontStyle.Normal,
+          )
+        }
+      )
+    }
   } catch (e: Throwable) {
     consoleWarn("compose-ai wasm catalog: font load failed (${e.message}); using bundled font")
     null
   }
 }
+
+/** One font file declared by `fonts.json`, flattened out of its family entry. */
+internal data class ManifestFont(
+  val role: String,
+  val family: String,
+  val file: String,
+  val weight: Int,
+  val italic: Boolean,
+)
+
+/**
+ * Parse `fonts.json` (`{families: [{name, role, fonts: [{file, weight, style}]}]}`). JSON parsing
+ * happens on the JS side ([flattenFontsManifest] — no serialization dependency for one small
+ * manifest); this validates each flattened row. Rows with a missing/unsafe `file` (path traversal,
+ * absolute scheme) are dropped; unknown roles are kept for the caller to filter, so future roles
+ * (generic-family mappings, named families) stay additive.
+ */
+internal fun parseFontsManifest(json: String?): List<ManifestFont> {
+  val flat = json?.let { flattenFontsManifest(it) }?.toString() ?: return emptyList()
+  if (flat.isEmpty()) return emptyList()
+  return flat.split(ROW_SEP).mapNotNull { row ->
+    val f = row.split(FIELD_SEP)
+    if (f.size != 5) return@mapNotNull null
+    val file =
+      f[2].takeIf { it.isNotEmpty() && ".." !in it.split("/") && !it.contains(":") }
+        ?: return@mapNotNull null
+    ManifestFont(
+      role = f[0],
+      family = f[1],
+      file = file,
+      weight = f[3].toIntOrNull()?.coerceIn(1, 1000) ?: 400,
+      italic = f[4] == "italic",
+    )
+  }
+}
+
+private const val FIELD_SEP = "\u0000"
+private const val ROW_SEP = "\u0001"
+
+/**
+ * `JSON.parse` the manifest and flatten it to `role␀name␀file␀weight␀style` rows (␁-joined) — the
+ * shape that crosses the Wasm↔JS boundary as one string. Null/empty on malformed JSON.
+ */
+private fun flattenFontsManifest(json: String): JsString? =
+  js(
+    """(function () {
+      try {
+        var m = JSON.parse(json), out = [];
+        (m.families || []).forEach(function (fam) {
+          (fam.fonts || []).forEach(function (f) {
+            out.push([fam.role || 'default', fam.name || '', String(f.file || ''),
+              String(f.weight || 400), String(f.style || 'normal')].join('\u0000'));
+          });
+        });
+        return out.join('\u0001');
+      } catch (e) { return null; }
+    })()"""
+  )
 
 /**
  * `fetch(url)` → base64 of the response body. Base64 is the bridge shape because Kotlin/Wasm can't
@@ -135,8 +222,9 @@ private suspend fun loadRobotoFamily(): FontFamily? {
  */
 private fun fetchAsBase64(url: String, timeoutMs: Int): Promise<JsString> =
   js(
-    """fetch(url, { signal: AbortSignal.timeout(timeoutMs) })
-      .then(function (r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.arrayBuffer(); })
+    """((window.__cpPrefetchBuf && window.__cpPrefetchBuf[url]) ||
+      fetch(url, { signal: AbortSignal.timeout(timeoutMs) })
+        .then(function (r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.arrayBuffer(); }))
       .then(function (buf) {
         var bytes = new Uint8Array(buf), chunks = [], CHUNK = 0x8000;
         for (var i = 0; i < bytes.length; i += CHUNK)
@@ -155,6 +243,27 @@ private suspend fun fetchBytes(url: String): ByteArray = suspendCancellableCorou
   fetchAsBase64(url, timeoutMs = (FONT_LOAD_TIMEOUT_MS + 2_000L).toInt())
     .then { s ->
       if (cont.isActive) cont.resume(Base64.decode(s.toString()))
+      null
+    }
+    .catch { e ->
+      if (cont.isActive)
+        cont.resumeWithException(IllegalStateException(e?.toString() ?: "fetch failed"))
+      null
+    }
+}
+
+private fun fetchAsText(url: String, timeoutMs: Int): Promise<JsString> =
+  js(
+    """((window.__cpPrefetchText && window.__cpPrefetchText[url]) ||
+      fetch(url, { signal: AbortSignal.timeout(timeoutMs) })
+        .then(function (r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.text(); }))"""
+  )
+
+/** `fetch(url)` → response text; cancellable like [fetchBytes] so timeouts genuinely unblock. */
+private suspend fun fetchText(url: String): String = suspendCancellableCoroutine { cont ->
+  fetchAsText(url, timeoutMs = (FONT_LOAD_TIMEOUT_MS + 2_000L).toInt())
+    .then { s ->
+      if (cont.isActive) cont.resume(s.toString())
       null
     }
     .catch { e ->

--- a/samples/cmp-wasm-catalog/src/wasmJsMain/resources/fonts/README.md
+++ b/samples/cmp-wasm-catalog/src/wasmJsMain/resources/fonts/README.md
@@ -7,8 +7,20 @@ under Robolectric's native graphics. Using the same bytes is what makes the in-b
 tier's text wrap, truncate, and measure identically to the baked catalog PNGs; classic
 Roboto 2.x and CMP's bundled default both differ measurably (see PR history).
 
-Fetched by the app **by URL** at startup (`Main.kt` → `loadRobotoFamily()`, default base
-`./fonts/`, overridable via `?fontsBase=`); self-hosted beside the app so the bundle stays
-offline-clean behind an egress proxy. A fetch failure degrades to the CMP bundled font.
+Loading is driven by [`fonts.json`](fonts.json): each `role: "default"` family's files are
+fetched **by URL** and become the app's whole M3 type scale (`Main.kt` → `loadCatalogFonts()`,
+default base `./fonts/`, overridable via `?fontsBase=`; a base without a manifest falls back to
+the fixed Roboto pair). Self-hosted beside the app so the bundle stays offline-clean behind an
+egress proxy; on the public server the serve process is the cache — it fetches these files once
+from the trusted `design-artifacts` branch and serves them locally. A fetch failure or timeout
+degrades to the CMP bundled font.
+
+`index.html` starts the manifest + font fetches at document load, in parallel with the Wasm boot,
+and the app consumes those in-flight promises — so fonts add no latency to the first frame. The
+prefetch must live in the iframe itself: the sandbox's opaque origin has its own HTTP-cache
+partition, so the embedding viewer page cannot warm fonts for it.
+
+The manifest is additive: future roles (named families, generic-family mappings like `serif`)
+can be declared per family without breaking older apps, which only consume `role: "default"`.
 
 License: Apache 2.0 (Roboto, Google) — see [LICENSE.txt](LICENSE.txt).

--- a/samples/cmp-wasm-catalog/src/wasmJsMain/resources/fonts/fonts.json
+++ b/samples/cmp-wasm-catalog/src/wasmJsMain/resources/fonts/fonts.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "families": [
+    {
+      "name": "Roboto",
+      "role": "default",
+      "fonts": [
+        { "file": "Roboto-Regular.ttf", "weight": 400 },
+        { "file": "Roboto-Medium.ttf", "weight": 500 }
+      ]
+    }
+  ]
+}

--- a/samples/cmp-wasm-catalog/src/wasmJsMain/resources/index.html
+++ b/samples/cmp-wasm-catalog/src/wasmJsMain/resources/index.html
@@ -32,6 +32,47 @@
   <body>
     <!-- ComposeViewport mounts the catalog component named by ?id=… here. -->
     <div id="composeApp"></div>
+    <!--
+      Font prefetch, started at document load so it runs IN PARALLEL with the multi-second Wasm
+      boot: fetch fonts.json and every file it lists, stashing the in-flight promises where the
+      app's fetch bridge picks them up (Main.kt consults __cpPrefetchText/__cpPrefetchBuf before
+      issuing its own fetch). This must live in the iframe, not the embedding viewer page — the
+      sandbox gives this document an opaque origin with its own HTTP-cache partition, so nothing
+      the parent page fetches is reusable here. A rejected prefetch deletes its entry so the app
+      retries fresh; any error just means the app fetches cold, exactly as before.
+    -->
+    <script>
+      window.__cpPrefetchText = {};
+      window.__cpPrefetchBuf = {};
+      (function () {
+        try {
+          var base = new URLSearchParams(location.search).get("fontsBase") || "./fonts/";
+          if (base.indexOf(":") !== -1 && !/^https?:/.test(base)) return;
+          if (base.charAt(base.length - 1) !== "/") base += "/";
+          function stash(map, url, promise) {
+            map[url] = promise;
+            promise.catch(function () { delete map[url]; });
+          }
+          var manifest = fetch(base + "fonts.json").then(function (r) {
+            if (!r.ok) throw new Error("HTTP " + r.status);
+            return r.text();
+          });
+          stash(window.__cpPrefetchText, base + "fonts.json", manifest);
+          manifest.then(function (t) {
+            (JSON.parse(t).families || []).forEach(function (fam) {
+              (fam.fonts || []).forEach(function (f) {
+                var file = String(f.file || "");
+                if (!file || file.indexOf("..") !== -1 || file.indexOf(":") !== -1) return;
+                stash(window.__cpPrefetchBuf, base + file, fetch(base + file).then(function (r) {
+                  if (!r.ok) throw new Error("HTTP " + r.status);
+                  return r.arrayBuffer();
+                }));
+              });
+            });
+          }).catch(function () {});
+        } catch (e) {}
+      })();
+    </script>
     <script type="module" src="composeApp.mjs"></script>
     <!--
       Live overrides without an iframe reload: the embedding `serve` viewer posts a `?a=b` override

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
@@ -376,6 +376,11 @@ a:hover { text-decoration: underline; }
     if (u.origin !== location.origin) return "";
     return u.href;
   }
+  // NOTE: don't "preload" the app's fonts from this page — the sandboxed iframe has an opaque
+  // origin, and Chrome partitions the HTTP cache by frame origin, so nothing fetched here is
+  // reusable inside it (measured: every font was fetched twice). The prefetch that actually
+  // works lives in the app's own index.html, which starts the manifest+font fetches at
+  // document load, in parallel with the Wasm boot.
   // The override patch (theme / font scale / locale) the running app merges over its baked base —
   // a bare `a=b&c=d` query. An absent key falls back to the app's baked default (e.g. cleared
   // Theme → the variant's uiMode). Device / orientation are server-render-only, so not forwarded.

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
@@ -377,6 +377,11 @@ a:hover { text-decoration: underline; }
     if (u.origin !== location.origin) return "";
     return u.href;
   }
+  // NOTE: don't "preload" the app's fonts from this page — the sandboxed iframe has an opaque
+  // origin, and Chrome partitions the HTTP cache by frame origin, so nothing fetched here is
+  // reusable inside it (measured: every font was fetched twice). The prefetch that actually
+  // works lives in the app's own index.html, which starts the manifest+font fetches at
+  // document load, in parallel with the Wasm boot.
   // The override patch (theme / font scale / locale) the running app merges over its baked base —
   // a bare `a=b&c=d` query. An absent key falls back to the app's baked default (e.g. cleared
   // Theme → the variant's uiMode). Device / orientation are server-render-only, so not forwarded.

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
@@ -376,6 +376,11 @@ a:hover { text-decoration: underline; }
     if (u.origin !== location.origin) return "";
     return u.href;
   }
+  // NOTE: don't "preload" the app's fonts from this page — the sandboxed iframe has an opaque
+  // origin, and Chrome partitions the HTTP cache by frame origin, so nothing fetched here is
+  // reusable inside it (measured: every font was fetched twice). The prefetch that actually
+  // works lives in the app's own index.html, which starts the manifest+font fetches at
+  // document load, in parallel with the Wasm boot.
   // The override patch (theme / font scale / locale) the running app merges over its baked base —
   // a bare `a=b&c=d` query. An absent key falls back to the app's baked default (e.g. cleared
   // Theme → the variant's uiMode). Device / orientation are server-render-only, so not forwarded.


### PR DESCRIPTION
## Summary

First slice of the general font pipeline discussed after #2174: fonts become **data** (a manifest the catalog carries) instead of names hardcoded in the app, and their load cost disappears into the Wasm boot.

- **`fonts.json` manifest** served beside the app: families (`name`/`role`) and files (`file`/`weight`/`style`). The app fetches every `role: "default"` file by URL and builds the whole M3 `Typography` from them. Unknown roles parse and are kept additive — the seam for the planned named/generic-family mappings (`serif`, per-preview font indexes from the renderer). A `?fontsBase=` origin without a manifest falls back to the fixed Roboto pair, preserving the #2174 contract.
- **Prefetch in parallel with the boot:** `index.html` starts the manifest + font fetches at document load and stashes the in-flight promises; the app's fetch bridge consumes them. Measured through a counting proxy: `fonts.json` is requested **5 ms after `composeApp.mjs`, before `skiko.wasm`/`composeApp.wasm` even start downloading**, each file exactly once — previously the font load only began after wasm instantiation, as pure added latency.
- **Negative finding, guarded in code:** a page-side preload in the serve viewer does *not* work — the sandboxed iframe's opaque origin gets its own HTTP-cache partition, so nothing the viewer page fetches is reusable inside it (measured server-side: every font fetched twice). The viewer carries a comment and the golden test asserts no `preloadWasmFonts` sneaks back in.
- **Server as the font cache** (as discussed): already true and verified — the `design-artifacts` branch's `webRender.files` lists `fonts/` (checked on the published branch), `ServeCatalogStore` fetches them once from the trusted branch, and `/wasm/<system>/fonts/…` serves them locally with `max-age` + ETag. Upstream is hit once per catalog load, not per client.

## Evidence

Server-side request log (counting proxy, ms-relative), one Wasm enable — fonts in flight before the wasm payloads, no duplicates:

```
13883 composeApp.mjs
13888 fonts/fonts.json          ← manifest, 5ms after the app module
13902 fonts/Roboto-Regular.ttf
13904 fonts/Roboto-Medium.ttf
13957 skiko.mjs
14027 skiko.wasm                ← heavy payloads start after fonts are in flight
14045 composeApp.wasm
```

Rendering parity is unchanged vs #2174 (same pixel-diff numbers re-measured against the published compose-m3 catalog: text sticker 1.698 %, button 0.535 % — all glyph anti-aliasing). This PR is plumbing, not pixels; the visual surface it touches (`serve-viewer-wasm` fixture) churns only by the removed-preload comment and is covered by the CI visual-diff bot.

## Test plan

- `./gradlew :cli:test` — green (goldens regenerated; new assertion guards against a page-side preload).
- `./gradlew :samples:cmp-wasm-catalog:wasmCatalogDist` — builds; `fonts.json` ships in the dist.
- End-to-end in headless Chromium via a counting reverse proxy: request order/counts above; parity re-measured; `?fontsBase=` fallback and stalled-origin timeout behavior unchanged from #2176.

## Follow-ups (the rest of the pipeline)

- Renderer-side font-usage recording (`LocalFontFamilyResolver` wrap) → per-preview font index data product.
- Catalog export writes `fonts.json` from that index (per design system) instead of the hand-authored one.
- Named/generic-family roles consumed by a resolver interceptor in the app, once a catalog component exercises a non-default family.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NsbJzAuJeztCUJ2Mn6qJaV)_