### PR TITLE
fix(plugin): keep scenecore-spatial backends off the composePreviewRenderXr classpath

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -2063,10 +2063,21 @@ internal object AndroidPreviewSupport {
         testClassesDirs = xrRendererClassDirs + (agpTestTask?.testClassesDirs ?: project.files())
         val agpTestClasspath = agpTestTask?.classpath ?: project.files()
         classpath =
-          resolvedClasspath +
-            xrRendererClassDirs +
-            (agpTestTask?.testClassesDirs ?: project.files()) +
-            agpTestClasspath
+          (resolvedClasspath +
+              xrRendererClassDirs +
+              (agpTestTask?.testClassesDirs ?: project.files()) +
+              agpTestClasspath)
+            // Drop scenecore's on-device spatial backends (`scenecore-spatial-core` /
+            // `scenecore-spatial-rendering`, runtime deps of `androidx.xr.scenecore:scenecore`
+            // since alpha16). Their `SpatialCoreXrExtensionsHolderProvider`'s static init
+            // references the device-only `com.android.extensions.xr.XrExtensions`, and
+            // `XrExtensionsHolderAccessor` (probed by xr-compose alpha15's `Meter.DP_PER_METER`
+            // on the first `Subspace` layout) only catches `ClassNotFoundException` — a present
+            // class whose <clinit> throws `NoClassDefFoundError` fails the whole render. With
+            // the artifacts absent the probe misses cleanly and falls back to
+            // `scenecore-testing`'s `FakeXrExtensionsHolderProvider`, matching the fake
+            // scene/rendering/perception runtimes this classpath already runs on.
+            .filter { file -> !file.path.contains("scenecore-spatial-") }
         include("**/XrSubspaceRenderTest.class")
         useJUnit()
 

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -49,6 +49,18 @@ internal object AndroidPreviewSupport {
   internal const val RENDERER_COMPOSE_FLOOR_VERSION: String = "1.9.5"
 
   /**
+   * Path segments that identify `androidx.xr.scenecore`'s on-device spatial backend artifacts on a
+   * resolved classpath — the bare module-cache dir (`scenecore-spatial-core`) or an
+   * artifact-with-version file/dir (`scenecore-spatial-core-1.0.0-alpha16[.aar]`,
+   * `…-alpha16-runtime.jar`, the extracted-AAR transform dir). Anchored so consumer directories
+   * that merely contain the prefix (e.g. a checkout named `scenecore-spatial-demo`) never match.
+   * See the `composePreviewRenderXr` classpath filter for why these must stay off the render
+   * classpath.
+   */
+  internal val SCENECORE_SPATIAL_BACKEND_SEGMENT: Regex =
+    Regex("scenecore-spatial-(core|rendering)([-.][0-9].*)?")
+
+  /**
    * Platform token for the auto-provisioned `xr-composite` cache, matching the Release asset matrix
    * in `.github/workflows/release.yml` and the CLI writer's `XrCompositeProvision.platformToken`.
    * `null` for any OS/arch combination that has no published asset (e.g. linux-arm64) — the cache
@@ -2077,7 +2089,18 @@ internal object AndroidPreviewSupport {
             // the artifacts absent the probe misses cleanly and falls back to
             // `scenecore-testing`'s `FakeXrExtensionsHolderProvider`, matching the fake
             // scene/rendering/perception runtimes this classpath already runs on.
-            .filter { file -> !file.path.contains("scenecore-spatial-") }
+            //
+            // Matched per path segment against the artifact naming shapes Gradle produces
+            // (`scenecore-spatial-core-<version>.aar`, the extracted-AAR dir
+            // `…/transformed/scenecore-spatial-core-<version>/jars/classes.jar`, the
+            // module-cache dir `…/scenecore-spatial-core/<version>/…`) rather than a bare
+            // substring of the absolute path, so a consumer checkout or module directory
+            // that merely contains "scenecore-spatial-" in its name is never filtered out.
+            .filter { file ->
+              file.toPath().none { segment ->
+                SCENECORE_SPATIAL_BACKEND_SEGMENT.matches(segment.toString())
+              }
+            }
         include("**/XrSubspaceRenderTest.class")
         useJUnit()
 

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/ScenecoreSpatialBackendSegmentTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/ScenecoreSpatialBackendSegmentTest.kt
@@ -1,0 +1,51 @@
+package ee.schimke.composeai.plugin
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Pins the contract of [AndroidPreviewSupport.SCENECORE_SPATIAL_BACKEND_SEGMENT] — the per-segment
+ * matcher the `composePreviewRenderXr` classpath filter uses to drop scenecore's on-device spatial
+ * backends (whose `SpatialCoreXrExtensionsHolderProvider.<clinit>` needs the device-only
+ * `com.android.extensions.xr.*` classes) while leaving every consumer file alone.
+ *
+ * The matcher must cover the artifact shapes Gradle actually puts on a resolved test classpath
+ * (module-cache dirs, transformed AAR dirs, transformed runtime jars) and must NOT match consumer
+ * checkout/module directories that merely contain the prefix — matching the raw absolute path would
+ * silently strip a consumer's own build outputs (Codex review on #2183).
+ */
+class ScenecoreSpatialBackendSegmentTest {
+
+  private fun matchesAnySegment(path: String): Boolean =
+    path.split('/').any { AndroidPreviewSupport.SCENECORE_SPATIAL_BACKEND_SEGMENT.matches(it) }
+
+  @Test
+  fun `matches module cache and transform artifact shapes`() {
+    val paths =
+      listOf(
+        "modules-2/files-2.1/androidx.xr.scenecore/scenecore-spatial-core/1.0.0-alpha16/415387e/scenecore-spatial-core-1.0.0-alpha16.aar",
+        "modules-2/files-2.1/androidx.xr.scenecore/scenecore-spatial-rendering/1.0.0-alpha16/66e0561/scenecore-spatial-rendering-1.0.0-alpha16.aar",
+        "9.6.0/transforms/691435c/transformed/scenecore-spatial-core-1.0.0-alpha16/jars/classes.jar",
+        "9.6.0/transforms/3f01318/transformed/scenecore-spatial-rendering-1.0.0-alpha16-runtime.jar",
+      )
+    for (path in paths) {
+      assertThat(matchesAnySegment(path)).isTrue()
+    }
+  }
+
+  @Test
+  fun `does not match consumer directories that merely contain the prefix`() {
+    val paths =
+      listOf(
+        "home/dev/scenecore-spatial-demo/app/build/intermediates/classes/debug",
+        "home/dev/checkouts/scenecore-spatial-demo-app/build/libs/app.jar",
+        "work/my-scenecore-spatial-core-fork/build/classes",
+        "work/scenecore-spatial-core-fork/build/classes",
+        "androidx.xr.scenecore/scenecore-testing/1.0.0-alpha16/39aef67/scenecore-testing-1.0.0-alpha16.aar",
+        "androidx.xr.scenecore/scenecore-runtime/1.0.0-alpha16/f67473c/scenecore-runtime-1.0.0-alpha16.aar",
+      )
+    for (path in paths) {
+      assertThat(matchesAnySegment(path)).isFalse()
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Fixes the `Apply compose-preview` job that has been red on every completed run since the #2104 renovate bump (last green: `df570f1d`, Jun 29 20:03 — the `compose-preview/main` and `compose-preview/a11y/main` baseline branches have been frozen since).

**Root cause.** xr-compose `1.0.0-alpha15`'s `Meter.DP_PER_METER` now probes `XrExtensionsHolderAccessor` on the first `Subspace` layout. The accessor's provider scan `Class.forName`s the on-device `androidx.xr.scenecore.spatial.core.SpatialCoreXrExtensionsHolderProvider` first, and scenecore `1.0.0-alpha16` ships `scenecore-spatial-core` as a *runtime* dep — so the provider class **is** on the render classpath, but its static init references the device-only `com.android.extensions.xr.XrExtensions`. The accessor only catches `ClassNotFoundException`; the resulting `NoClassDefFoundError` escapes, all 12 XR subspace renders fail, `compose-preview show`/`a11y` exit 2 ("Render failed"), `_previews.json` comes out empty, and the job fails at RC aggregation with `rc=2`. This is the previously-unidentified failure noted in #2159's follow-up comment (the `missing-renders: warn` mitigations from #2151/#2156 couldn't cure it because it's a hard build failure, not a null-PNG).

**Fix.** Filter `scenecore-spatial-*` (`-core`, `-rendering`) out of the `composePreviewRenderXr` task classpath. The accessor's probe then misses cleanly (`ClassNotFoundException`, caught) and falls back to `scenecore-testing`'s `FakeXrExtensionsHolderProvider` — the same fake runtime family (scene/rendering/perception) this classpath already runs on via the plugin-injected `*-testing` artifacts. Scoped to the render task only; consumer app/device classpaths are untouched.

## Test plan

- Before (main @ `0d878da`): `./gradlew :samples:xr-spatial:composePreviewRenderXr` → 12/12 fail with `NoClassDefFoundError: com/android/extensions/xr/XrExtensions` (via `SpatialCoreXrExtensionsHolderProvider.<clinit>`), which is exactly the failure `compose-preview show` turns into "Render failed"/rc=2 in CI.
- After: same task → `BUILD SUCCESSFUL`, 12/12 pass, `scene.json` + panel textures written per `@XrSubspacePreview` under `samples/xr-spatial/build/compose-previews/renders/`.
- Full `./gradlew composePreviewRenderAll -PcomposePreview.missingRenders=warn` (the CI configuration) run locally across all modules with the fix in place.
- `:gradle-plugin:ktfmtCheck` passes.
- The Compose Preview workflow on this PR is the end-to-end check: with this fix the compose pipeline should get past the render and post/refresh the preview-diff comment again.

Non-visual change (render-pipeline classpath wiring): the rendered pixels are unchanged — this restores the previously-green XR `scene.json` output path rather than altering any render output. Once merged, the next push to `main` should also unfreeze the `compose-preview/main` / `compose-preview/a11y/main` baselines. The remaining null-PNG cleanup and the flip back to `missing-renders: fail` stay tracked in #2159.

---
_Generated by [Claude Code](https://claude.ai/code/session_015fvQmahdfbyTqUFiEnrfzW)_