### PR TITLE
fix: treat optional captures as expected skips in the missing-render gate and diff bot

### DIFF
--- a/.github/actions/apply/pipelines/a11y.sh
+++ b/.github/actions/apply/pipelines/a11y.sh
@@ -56,6 +56,14 @@ fi
 if [ -n "${MISSING_RENDERS:-}" ]; then
   cli_args+=(--missing-renders "${MISSING_RENDERS}")
 fi
+# Same per-Gradle-invocation ceiling the compose/resources pipelines get.
+# Without it the a11y run sits on the CLI's 300s default, which cannot fit
+# the full re-render this command triggers (`activeExtensions=a11y` changes
+# every render task's inputs) — a below-median runner times the build out,
+# the pipeline silently self-skips, and the a11y baseline never updates.
+if [ -n "${RENDER_TIMEOUT:-}" ]; then
+  cli_args+=(--timeout "${RENDER_TIMEOUT}")
+fi
 
 # Use the same CLI that the install step put on $PATH (release tarball or
 # source build); the legacy `:cli:installDist` rebuild was a leftover from

--- a/.github/actions/lib/compare-previews.py
+++ b/.github/actions/lib/compare-previews.py
@@ -180,12 +180,17 @@ def _collect_failures(rows: dict) -> list[tuple[str, dict]]:
     state. Sorted by key so the markdown output is deterministic.
 
     Previews whose kind never emits a PNG (see [NON_PNG_PREVIEW_KINDS]) are
-    excluded — their empty `sha256` is expected, not a render failure.
+    excluded — their empty `sha256` is expected, not a render failure. So are
+    `optional` captures (the CLI envelope's mirror of the manifest
+    `Capture.optional` flag): best-effort artefacts like a `@ColorCatalog`
+    sheet on the desktop backend, whose missing PNG is by design.
     """
     return [
         (key, info)
         for key, info in sorted(rows.items())
-        if not info.get("sha256") and info.get("kind") not in NON_PNG_PREVIEW_KINDS
+        if not info.get("sha256")
+        and info.get("kind") not in NON_PNG_PREVIEW_KINDS
+        and not info.get("optional")
     ]
 
 
@@ -373,6 +378,9 @@ def load_cli_output(cli_json_path: Path) -> dict[str, dict]:
                 "captureIndex": idx,
                 "captureLabel": _capture_label(capture),
                 "renderBasename": _render_basename(png, preview_id),
+                # Best-effort capture — a missing PNG is expected, not a
+                # render failure (see _collect_failures).
+                "optional": bool(capture.get("optional")),
             }
     return result
 

--- a/.github/actions/lib/test_compare_previews.py
+++ b/.github/actions/lib/test_compare_previews.py
@@ -56,13 +56,15 @@ def _entry(*, id: str, module: str = "app", function: str = "Fn",
 
 def _capture(*, png: str | None = None, sha: str | None = None,
              advanceTimeMillis: int | None = None,
-             scroll: dict | None = None) -> dict:
+             scroll: dict | None = None,
+             optional: bool = False) -> dict:
     """Build a CaptureResult-shaped dict for use in `_entry(captures=[…])`."""
     return {
         "pngPath": png,
         "sha256": sha,
         "advanceTimeMillis": advanceTimeMillis,
         "scroll": scroll,
+        "optional": optional,
     }
 
 
@@ -180,6 +182,40 @@ class LoadCliOutputTest(unittest.TestCase):
         out = cp.load_cli_output(path)
         self.assertEqual(out["app/X"]["sha256"], "")
         self.assertEqual(out["app/X"]["pngPath"], "")
+
+
+class OptionalCaptureFailureTest(unittest.TestCase):
+    """`optional` captures (desktop `@ColorCatalog` sheets, #2135) must not
+    read as render failures — the flag is the CLI-envelope mirror of the
+    manifest `Capture.optional` the render gate already honours (#2159)."""
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.tmp)
+
+    def _load(self, entries) -> dict:
+        p = self.tmp / "cli.json"
+        p.write_text(json.dumps({"schema": "compose-preview-show/v2", "previews": entries}))
+        return cp.load_cli_output(p)
+
+    def test_optional_flag_round_trips_through_load(self):
+        rows = self._load([
+            _entry(id="Sheet", captures=[_capture(optional=True)]),
+        ])
+        self.assertTrue(rows["app/Sheet"]["optional"])
+
+    def test_optional_missing_capture_is_not_a_failure(self):
+        rows = self._load([
+            _entry(id="Sheet", captures=[_capture(optional=True)]),
+            _entry(id="Ok", captures=[_capture(png="/r/ok.png", sha="abc")]),
+        ])
+        self.assertEqual(cp._collect_failures(rows), [])
+
+    def test_required_missing_capture_still_fails(self):
+        rows = self._load([
+            _entry(id="Broken", captures=[_capture()]),
+        ])
+        self.assertEqual([key for key, _ in cp._collect_failures(rows)], ["app/Broken"])
 
 
 class VariantLabelTest(unittest.TestCase):

--- a/.github/workflows/compose-preview.yml
+++ b/.github/workflows/compose-preview.yml
@@ -58,10 +58,9 @@ jobs:
           a11y-module: ''
           a11y-skip-modules: ''
           notifications-module: 'samples:android'
-          # Don't hard-fail this repo's own CI on individual previews/resources
-          # that render no PNG (e.g. the launcher-icon rasterizer jitter tracked
-          # in #2133): log them and keep going instead of gating every push +
-          # PR. Scoped to this caller — the action's default stays `fail` for
-          # external consumers. The underlying missing renders are tracked
-          # separately; flip back to `fail` once they're fixed.
-          missing-renders: warn
+          # No `missing-renders` override: the action's default `fail` gates
+          # every push + PR on all required renders producing a PNG. The one
+          # legitimately unrenderable capture (the desktop `@ColorCatalog`
+          # sheet, #2135) is marked `optional` at discovery, which the gate,
+          # the CLI, and the diff bot all honour — see #2159 for the history
+          # of the `warn` override this replaces.

--- a/.github/workflows/compose-preview.yml
+++ b/.github/workflows/compose-preview.yml
@@ -58,6 +58,15 @@ jobs:
           a11y-module: ''
           a11y-skip-modules: ''
           notifications-module: 'samples:android'
+          # Per-Gradle-invocation ceiling for the render pipelines. The
+          # action's 600s default is marginal for this repo's own all-module
+          # render: identical jobs swing 23–32 minutes across runners, and on
+          # a below-median runner the compose `show` (and the a11y re-render,
+          # which used to run on the CLI's 300s default) got cancelled mid
+          # build — surfacing as "Render failed" / rc=2 with the baselines
+          # frozen. This is a safety ceiling against a hung build, not a
+          # budget, so keep it comfortably above the slowest observed run.
+          timeout: '1800'
           # No `missing-renders` override: the action's default `fail` gates
           # every push + PR on all required renders producing a PNG. The one
           # legitimately unrenderable capture (the desktop `@ColorCatalog`

--- a/api/gradle-preview-driver/src/main/kotlin/ee/schimke/composeai/cli/PreviewResultBuilder.kt
+++ b/api/gradle-preview-driver/src/main/kotlin/ee/schimke/composeai/cli/PreviewResultBuilder.kt
@@ -109,6 +109,7 @@ object PreviewResultBuilder {
             pngPath = pngFile?.absolutePath,
             sha256 = sha,
             changed = null,
+            optional = capture.optional,
           )
         }
         val first = captureResults.firstOrNull()

--- a/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/cli/PreviewData.kt
+++ b/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/cli/PreviewData.kt
@@ -138,6 +138,13 @@ data class CaptureResult(
   val pngPath: String? = null,
   val sha256: String? = null,
   val changed: Boolean? = null,
+  /**
+   * Mirror of the manifest [Capture.optional] flag: `true` → best-effort capture whose missing PNG
+   * is expected (e.g. a `@ColorCatalog` sheet on the desktop backend, which can't draw them yet
+   * — #2135). Carried into the CLI envelope so `--missing-renders` gating and the CI diff bot treat
+   * the skip as expected instead of reporting a render failure.
+   */
+  val optional: Boolean = false,
 )
 
 /**

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -705,12 +705,15 @@ abstract class Command(
       total = results.size,
       changed = results.count { it.anyChanged() },
       unchanged = results.count { !it.anyChanged() && it.captures.any { c -> c.pngPath != null } },
-      // Exclude kinds that never emit a PNG (see [NON_PNG_PREVIEW_KINDS]) so `counts.missing`
-      // matches what `--missing-renders` actually gates on — an `@XrSubspacePreview` with no
-      // composite still isn't a render failure.
+      // Exclude kinds that never emit a PNG (see [NON_PNG_PREVIEW_KINDS]) and `optional` captures
+      // so `counts.missing` matches what `--missing-renders` actually gates on — an
+      // `@XrSubspacePreview` with no composite or a desktop `@ColorCatalog` sheet still isn't a
+      // render failure.
       missing =
-        results.count {
-          it.params.kind !in NON_PNG_PREVIEW_KINDS && it.captures.all { c -> c.pngPath == null }
+        results.count { r ->
+          r.params.kind !in NON_PNG_PREVIEW_KINDS &&
+            r.captures.all { c -> c.pngPath == null } &&
+            r.captures.any { c -> !c.optional }
         },
     )
 
@@ -871,12 +874,14 @@ internal val NON_PNG_PREVIEW_KINDS = setOf("XR_SUBSPACE")
 /**
  * Previews that finished rendering but produced no PNG for at least one capture — the set
  * `--missing-renders` gates on and the diagnostic enumerates. Excludes [NON_PNG_PREVIEW_KINDS],
- * whose empty `pngPath` is by design. Pulled out as a pure function so the policy is unit-testable
- * without standing up a Gradle render.
+ * whose empty `pngPath` is by design, and `optional` captures, whose missing PNG is expected
+ * (best-effort artefacts like a `@ColorCatalog` sheet on the desktop backend — see
+ * `Capture.optional`). Pulled out as a pure function so the policy is unit-testable without
+ * standing up a Gradle render.
  */
 internal fun previewsMissingPng(results: List<PreviewResult>): List<PreviewResult> =
   results.filter { r ->
-    r.params.kind !in NON_PNG_PREVIEW_KINDS && r.captures.any { it.pngPath == null }
+    r.params.kind !in NON_PNG_PREVIEW_KINDS && r.captures.any { it.pngPath == null && !it.optional }
   }
 
 /**
@@ -994,7 +999,7 @@ class ShowCommand(args: List<String>) : Command(args) {
       for (r in missing) {
         val nullCoords =
           r.captures
-            .filter { it.pngPath == null }
+            .filter { it.pngPath == null && !it.optional }
             .joinToString(", ") { captureCoordLabel(it) }
             .ifEmpty { "default" }
         val moduleTag = if (r.module.isNotBlank()) " (${r.module})" else ""
@@ -1120,7 +1125,7 @@ class RenderCommand(args: List<String>) : Command(args) {
         exitProcess(3)
       }
 
-      val missing = filtered.filter { r -> r.captures.any { it.pngPath == null } }
+      val missing = previewsMissingPng(filtered)
 
       if (output != null) {
         if (filtered.size != 1) {

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/MissingRendersPolicyTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/MissingRendersPolicyTest.kt
@@ -101,6 +101,34 @@ class MissingRendersPolicyTest {
   }
 
   @Test
+  fun `previewsMissingPng skips optional captures whose PNG is expected to be absent`() {
+    // A desktop `@ColorCatalog` sheet is discovered with a single `optional` capture (the desktop
+    // backend can't draw them yet — #2135); its missing PNG is by design, not a render failure.
+    val results =
+      listOf(
+        result(
+          "p.CatalogSheet",
+          kind = "CATALOG",
+          captures = listOf(CaptureResult(pngPath = null, optional = true)),
+        )
+      )
+    assertTrue(previewsMissingPng(results).isEmpty())
+  }
+
+  @Test
+  fun `previewsMissingPng still flags a required null capture next to an optional one`() {
+    val results =
+      listOf(
+        result(
+          "p.Mixed",
+          captures =
+            listOf(CaptureResult(pngPath = null, optional = true), CaptureResult(pngPath = null)),
+        )
+      )
+    assertEquals(listOf("p.Mixed"), previewsMissingPng(results).map { it.id })
+  }
+
+  @Test
   fun `previewsMissingPng catches a partially-rendered fan-out`() {
     val results =
       listOf(


### PR DESCRIPTION
## Summary

Closes the remaining half of #2159 — two independent reasons the Compose Preview check couldn't be flipped back to `missing-renders: fail`:

### 1. Optional captures were counted as render failures

The last "missing render" (`samples:cmp/colorcatalog__Brand`) was never a failure — the desktop backend can't draw `@ColorCatalog` sheets yet (#2135), so discovery marks those captures `optional` (#2160) and the Gradle render gate honours the flag. But the CLI envelope **dropped** `optional` on the manifest→`CaptureResult` mapping, so `compose-preview show` under the default `fail` policy exited 2 for the sheet, and the CI diff bot listed it under **Render Failures** on every PR.

- `CaptureResult.optional` (new field, default `false` — envelope back-compat), populated in `PreviewResultBuilder`.
- CLI: `previewsMissingPng` (the exit-2 gate), `counts.missing`, the per-preview offender diagnostic, and `render`'s missing list all skip optional captures.
- Diff bot: `compare-previews.py` parses `optional` per capture row and `_collect_failures` excludes them. Resource rows don't carry the key — behaviour there unchanged.
- `@TypographyCatalog` / `@ThemeCatalog` sheets share the same `catalogRenderSupported` discovery gating, so future CMP catalog tokens stay covered.

### 2. Render timeouts were marginal, and the a11y pipeline never got one at all

Identical "Apply compose-preview" jobs swing 23–32 minutes across runners. The compose/resources pipelines run under the action's 600s per-Gradle-invocation default, and **`a11y.sh` never forwarded `--timeout`**, leaving the a11y re-render (which invalidates every render task via `activeExtensions=a11y`) on the CLI's 300s default. On a below-median runner the builds get cancelled mid-render — surfacing as "Render failed" / rc=2 with frozen baselines. That's why the post-#2183 main run (`9cfbba9`) still failed while the same-code PR run passed on a faster runner, and why `compose-preview/a11y/main` has been frozen since Jun 29.

- `a11y.sh` now forwards `RENDER_TIMEOUT` as `--timeout`.
- This repo's caller sets `timeout: '1800'` — a hung-build safety ceiling, not a budget.

### Flips the check back to hard-fail

Removes the `missing-renders: warn` override from `compose-preview.yml` (#2151), restoring the default `fail` gate per #2159's exit criteria.

Non-visual change (gating/report/CI plumbing) — no rendered output differs; the Compose Preview run on this PR is the end-to-end proof, now under the restored `fail` policy.

## Test plan

- `:cli:test --tests MissingRendersPolicyTest` — 2 new cases: an optional-only null capture is not missing; a required null capture next to an optional one still flags.
- `python3 .github/actions/lib/test_compare_previews.py` — 80 tests pass, 3 new in `OptionalCaptureFailureTest`: `optional` round-trips through `load_cli_output`, optional missing capture is not a failure, required missing capture still is.
- End-to-end with the source-built CLI under the **default `fail` policy** (no `--missing-renders`):
  - `compose-preview show --json --module samples:cmp` → exit 0, `counts.missing: 0`, envelope carries `"optional": true` for `colorcatalog__Brand`.
  - `compose-preview show-resources --json` across all Android modules → exit 0 (no latent resource offenders hiding behind the old `warn`).
- `bash -n` on the edited pipeline script; this PR's own Compose Preview check runs under the restored `fail` default with the new timeout plumbing.