### PR TITLE
feat(catalog): generate the wasm tier's fonts.json from recorded font usage

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -136,6 +136,9 @@ dependencies {
   // Semantics text-diff engine + payload model for the `diff-semantics` command (issue #1785).
   implementation(project(":data-layoutinspector-core"))
 
+  // `fonts/used` sidecar file name for `bundle pack --with-semantics` font carriage.
+  implementation(project(":data-fonts-core"))
+
   // Ktor client (OkHttp engine) for downloading a bundle when the open arg is a URL. The explicit
   // okhttp dep pins the engine to OkHttp 5.x — ktor-client-okhttp 3.0.3 only declares a transitive
   // 4.12.0, so without this the catalog's okhttp 5 version is never selected.

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
@@ -125,9 +125,11 @@ class BundleCommand(args: List<String>) : Command(args) {
                             the shape design-parity reads for contrast/a11y + token checks. Also
                             carries the layout-inspector tree (full LayoutNode walk with per-node
                             bounds + resolved design tokens) as previews/<id>.layout.json, for
-                            slot-level redlines/wireframes. Produced by a short-lived daemon render
-                            (no separate --with-extension pass needed). Off by default; ignored with
-                            --no-render.
+                            slot-level redlines/wireframes, and the fonts/used record (requested vs
+                            resolved font families) as previews/<id>.fonts.json, from which the
+                            design-catalog export generates the in-browser tier's fonts.json.
+                            Produced by a short-lived daemon render (no separate --with-extension
+                            pass needed). Off by default; ignored with --no-render.
 
       Inspect / extract / render flags:
         -o, --output <dir>  Directory to extract / render into. Default: alongside the bundle.
@@ -317,14 +319,26 @@ private class PackSubcommand(private val args: List<String>) {
         // that produced a tree gets `previews/<id>.layout.json` so a consumer can build slot-level
         // redlines/wireframes. Injected after semantics so its byte count is reflected too.
         val layoutWritten = injectLayoutIntoBundle(bundleFile, outcome.layoutById)
+        // The fonts/used record rides the same render (best-effort, Android daemon only): carried
+        // so the design-catalog export can generate the Wasm tier's fonts.json from actual usage.
+        val fontsWritten = injectFontsIntoBundle(bundleFile, outcome.fontsById)
         val semanticsLine =
           "  semantics:     $written / ${previewIds.size} preview(s) carried as " +
             "previews/<id>$BUNDLE_SEMANTICS_SUFFIX" +
             if (missing > 0) " ($missing without a captured tree)" else ""
-        return if (layoutWritten > 0)
-          "$semanticsLine\n  layout:        $layoutWritten / ${previewIds.size} preview(s) carried " +
-            "as previews/<id>$BUNDLE_LAYOUT_SUFFIX"
-        else semanticsLine
+        val extraLines = buildString {
+          if (layoutWritten > 0)
+            append(
+              "\n  layout:        $layoutWritten / ${previewIds.size} preview(s) carried " +
+                "as previews/<id>$BUNDLE_LAYOUT_SUFFIX"
+            )
+          if (fontsWritten > 0)
+            append(
+              "\n  fonts:         $fontsWritten / ${previewIds.size} preview(s) carried " +
+                "as previews/<id>$BUNDLE_FONTS_SUFFIX"
+            )
+        }
+        return semanticsLine + extraLines
       }
       is DaemonSemanticsFetcher.Outcome.DescriptorMissing ->
         System.err.println(
@@ -657,6 +671,16 @@ internal const val BUNDLE_SEMANTICS_SUFFIX: String = ".semantics.json"
 internal const val BUNDLE_LAYOUT_SUFFIX: String = ".layout.json"
 
 /**
+ * Suffix for the per-preview font-usage blob carried beside `previews/<id>.png`. The payload is the
+ * `fonts/used` [ee.schimke.composeai.data.fonts.FontsUsedPayload] — every font resolution the
+ * render made (requested vs resolved family, weight, style, fallback chain) — recorded by the
+ * daemon's always-on FontsRecorderExtension. Carried so the design-catalog export can generate the
+ * in-browser Wasm tier's `fonts.json` from what the previews actually resolved instead of a
+ * hand-authored manifest.
+ */
+internal const val BUNDLE_FONTS_SUFFIX: String = ".fonts.json"
+
+/**
  * Inject `previews/<id>.semantics.json` entries (id → `compose-semantics.json` bytes) into
  * [bundleFile]'s zip portion **in place**, preserving the leading PNG cover and every existing
  * entry. Re-injecting replaces any prior semantics entry for the same id, so a second
@@ -682,6 +706,19 @@ internal fun injectLayoutIntoBundle(
   layoutById: Map<String, ByteArray>,
   fileSystem: FileSystem = SystemFileSystem,
 ): Int = injectSidecarsIntoBundle(bundleFile, layoutById, BUNDLE_LAYOUT_SUFFIX, fileSystem)
+
+/**
+ * Inject `previews/<id>.fonts.json` entries (id → `fonts-used.json` bytes) into [bundleFile] — the
+ * per-preview `fonts/used` record the daemon bakes alongside the semantics blob. Carried so the
+ * design-catalog export can generate the in-browser tier's font manifest from recorded usage. Same
+ * in-place, idempotent, byte-stable contract as [injectSemanticsIntoBundle]. Returns the number of
+ * entries written.
+ */
+internal fun injectFontsIntoBundle(
+  bundleFile: File,
+  fontsById: Map<String, ByteArray>,
+  fileSystem: FileSystem = SystemFileSystem,
+): Int = injectSidecarsIntoBundle(bundleFile, fontsById, BUNDLE_FONTS_SUFFIX, fileSystem)
 
 /**
  * Inject `previews/<id><suffix>` entries (id → bytes) into [bundleFile]'s zip portion **in place**,

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DaemonSemanticsFetcher.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DaemonSemanticsFetcher.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.cli
 
+import ee.schimke.composeai.data.fonts.FontsUsedDataProducer
 import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsProduct
 import ee.schimke.composeai.data.layoutinspector.LayoutInspectorProduct
 import ee.schimke.composeai.io.SystemFileSystem
@@ -90,6 +91,7 @@ internal class DaemonSemanticsFetcher(
       for (previewId in previewIds) {
         sidecarFile(projectDir, previewId).delete()
         layoutSidecarFile(projectDir, previewId).delete()
+        fontsSidecarFile(projectDir, previewId).delete()
       }
 
       val pending = ConcurrentHashMap.newKeySet<String>().apply { addAll(previewIds) }
@@ -131,6 +133,7 @@ internal class DaemonSemanticsFetcher(
 
       val byId = LinkedHashMap<String, ByteArray>()
       val layoutById = LinkedHashMap<String, ByteArray>()
+      val fontsById = LinkedHashMap<String, ByteArray>()
       for (previewId in previewIds) {
         val file = sidecarFile(projectDir, previewId)
         if (file.isFile && file.length() > 0) {
@@ -146,8 +149,16 @@ internal class DaemonSemanticsFetcher(
         if (layout.isFile && layout.length() > 0) {
           layoutById[previewId] = fileSystem.read(layout.path.toPath()) { readByteArray() }
         }
+        // The `fonts/used` record (requested vs resolved family, weight, style per font
+        // resolution) is baked by the same always-on daemon render (FontsRecorderExtension); carry
+        // it so the design-catalog export can generate the in-browser tier's fonts.json from what
+        // the previews actually resolved. Best-effort — absent on backends without the recorder.
+        val fonts = fontsSidecarFile(projectDir, previewId)
+        if (fonts.isFile && fonts.length() > 0) {
+          fontsById[previewId] = fileSystem.read(fonts.path.toPath()) { readByteArray() }
+        }
       }
-      Outcome.Ok(semanticsById = byId, layoutById = layoutById)
+      Outcome.Ok(semanticsById = byId, layoutById = layoutById, fontsById = fontsById)
     }
   }
 
@@ -157,16 +168,22 @@ internal class DaemonSemanticsFetcher(
   private fun layoutSidecarFile(projectDir: File, previewId: String): File =
     File(projectDir, "build/compose-previews/data/$previewId/${LayoutInspectorProduct.FILE}")
 
+  private fun fontsSidecarFile(projectDir: File, previewId: String): File =
+    File(projectDir, "build/compose-previews/data/$previewId/${FontsUsedDataProducer.FILE}")
+
   sealed interface Outcome {
     /**
      * Session opened and renders attempted. [semanticsById] holds one entry per preview whose
      * `compose-semantics.json` materialised — possibly empty if every render failed. [layoutById]
      * holds the matching `layout-inspector.json` (the full LayoutNode tree) for each preview that
-     * produced one; a preview may have semantics but no layout tree, or vice versa.
+     * produced one; a preview may have semantics but no layout tree, or vice versa. [fontsById]
+     * holds the matching `fonts-used.json` (`fonts/used` — requested vs resolved font families) for
+     * each preview whose backend runs the fonts recorder.
      */
     data class Ok(
       val semanticsById: Map<String, ByteArray>,
       val layoutById: Map<String, ByteArray> = emptyMap(),
+      val fontsById: Map<String, ByteArray> = emptyMap(),
     ) : Outcome
 
     data class DescriptorMissing(val expected: File) : Outcome

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleSemanticsInjectTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleSemanticsInjectTest.kt
@@ -144,6 +144,38 @@ class BundleSemanticsInjectTest {
   }
 
   @Test
+  fun `injects fonts sidecars beside semantics without disturbing either`() {
+    val cover = png(4, 8)
+    val file =
+      polyglot(
+        cover,
+        linkedMapOf(
+          "bundle.json" to "{}".toByteArray(),
+          "previews/a.png" to cover,
+          "previews/a.semantics.json" to """{"root":{"nodeId":"1"}}""".toByteArray(),
+        ),
+      )
+
+    val written =
+      injectFontsIntoBundle(
+        file,
+        mapOf("a" to """{"fonts":[{"requestedFamily":"serif","weight":400}]}""".toByteArray()),
+      )
+
+    assertEquals(1, written)
+    val names = entries(BundleReader.extractZipBytes(file))
+    // Semantics blob untouched; the fonts/used record lands beside it under .fonts.json.
+    assertEquals(
+      """{"root":{"nodeId":"1"}}""",
+      names.getValue("previews/a.semantics.json").toString(Charsets.UTF_8),
+    )
+    assertEquals(
+      """{"fonts":[{"requestedFamily":"serif","weight":400}]}""",
+      names.getValue("previews/a.fonts.json").toString(Charsets.UTF_8),
+    )
+  }
+
+  @Test
   fun `re-injection replaces a stale semantics entry without duplicating it`() {
     val cover = png()
     val file =

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/DaemonSemanticsFetcherTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/DaemonSemanticsFetcherTest.kt
@@ -84,6 +84,41 @@ class DaemonSemanticsFetcherTest {
   }
 
   @Test
+  fun `carries the fonts-used sidecar for previews whose backend records it`() {
+    val projectDir = newTempFolder("semantics-fonts")
+    writeDescriptor(projectDir)
+
+    val fonts = mapOf("AlphaPreview" to """{"fonts":[{"requestedFamily":"serif","weight":400}]}""")
+    val fetcher =
+      DaemonSemanticsFetcher(
+        factory =
+          FakeFactory(
+            produced =
+              mapOf(
+                "AlphaPreview" to """{"root":{"nodeId":"1","boundsInRoot":"0,0,4,8"}}""",
+                "BetaPreview" to """{"root":{"nodeId":"2","boundsInRoot":"0,0,6,6"}}""",
+              ),
+            fontsProduced = fonts,
+          )
+      )
+
+    val outcome =
+      fetcher.fetch(
+        projectDir = projectDir,
+        moduleName = "sample",
+        previewIds = listOf("AlphaPreview", "BetaPreview"),
+      )
+
+    assertTrue(outcome is DaemonSemanticsFetcher.Outcome.Ok, "expected Ok, got $outcome")
+    // Only Alpha's backend recorded font usage; Beta simply has no fonts entry.
+    assertEquals(setOf("AlphaPreview"), outcome.fontsById.keys)
+    assertEquals(
+      fonts.getValue("AlphaPreview"),
+      outcome.fontsById.getValue("AlphaPreview").toString(Charsets.UTF_8),
+    )
+  }
+
+  @Test
   fun `previews whose sidecar never materialised are simply absent`() {
     val projectDir = newTempFolder("semantics-partial")
     writeDescriptor(projectDir)
@@ -172,13 +207,17 @@ class DaemonSemanticsFetcherTest {
   // -------------------------------------------------------------------------
   // Fake factory + session
 
-  private class FakeFactory(private val produced: Map<String, String>) : RenderSessionFactory {
+  private class FakeFactory(
+    private val produced: Map<String, String>,
+    private val fontsProduced: Map<String, String> = emptyMap(),
+  ) : RenderSessionFactory {
     override val backendKind: RenderSessionBackend = RenderSessionBackend.Subprocess
 
     override fun open(config: RenderSessionConfig): RenderSession =
       FakeSession(
         workspaceRoot = config.workspaceRoot.absolutePath,
         produced = produced,
+        fontsProduced = fontsProduced,
         dataRoot = File(config.workspaceRoot, "build/compose-previews/data"),
       )
   }
@@ -200,6 +239,7 @@ class DaemonSemanticsFetcherTest {
     override val workspaceRoot: String,
     private val produced: Map<String, String>,
     private val dataRoot: File,
+    private val fontsProduced: Map<String, String> = emptyMap(),
   ) : RenderSession {
     private val listeners = java.util.concurrent.CopyOnWriteArrayList<NotificationListener>()
 
@@ -237,6 +277,10 @@ class DaemonSemanticsFetcherTest {
         produced[id]?.let { content ->
           val dir = File(dataRoot, id).also { it.mkdirs() }
           File(dir, "compose-semantics.json").writeText(content)
+        }
+        fontsProduced[id]?.let { content ->
+          val dir = File(dataRoot, id).also { it.mkdirs() }
+          File(dir, "fonts-used.json").writeText(content)
         }
         // Emit renderFinished for *every* requested id — including ones that wrote no sidecar — so
         // the fetcher's wait completes (a failed render still finishes) rather than timing out.

--- a/docs/wasm-cmp-spike.md
+++ b/docs/wasm-cmp-spike.md
@@ -65,6 +65,11 @@ Text matches because the app fetches **the same font files the Android renderer 
 (extracted from Robolectric's `nativeruntime-dist-compat`, vendored under `fonts/` in the dist,
 declared by the `fonts.json` manifest) by URL at startup and holds the first-frame signal until
 they resolve — `?fontsBase=` re-points the fetch, and a failure degrades to the CMP bundled font.
+The published manifest is **generated from recorded usage**: the daemon's always-on
+`FontsRecorderExtension` writes a `fonts/used` record per preview, `bundle pack --with-semantics`
+carries it as `previews/<id>.fonts.json`, and the design-catalog export regenerates `fonts.json`
+from what the catalog's previews actually resolved (`render-fonts-manifest.mjs`) — the committed
+manifest is only the dev-time fallback.
 Generic families (`FontFamily.Serif` / `Monospace` in the Android stickers) resolve through
 `genericFontFamily(...)` lookups against the manifest's `role: "generic"` entries — a composition
 local, because CMP's `FontFamily.Resolver` is sealed and can't be wrapped by apps. See

--- a/samples/cmp-wasm-catalog/src/wasmJsMain/resources/fonts/README.md
+++ b/samples/cmp-wasm-catalog/src/wasmJsMain/resources/fonts/README.md
@@ -13,6 +13,11 @@ classic Roboto 2.x and CMP's bundled default both differ measurably (see PR hist
   consumed by `genericFontFamily(...)` lookups in catalog components — CMP's
   `FontFamily.Resolver` is sealed, so resolver-level interception isn't available to apps).
 
+The committed [`fonts.json`](fonts.json) is the **dev-time default**; the design-catalog export
+regenerates it from the per-preview `fonts/used` records (`previews/<id>.fonts.json` in the packed
+bundle → `scripts/design-artifacts/render-fonts-manifest.mjs`), so the published manifest tracks
+what the catalog's previews actually resolve.
+
 Loading is driven by [`fonts.json`](fonts.json): each `role: "default"` family's files are
 fetched **by URL** and become the app's whole M3 type scale (`Main.kt` → `loadCatalogFonts()`,
 default base `./fonts/`, overridable via `?fontsBase=`; a base without a manifest falls back to

--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -47,6 +47,7 @@ import { renderReadmeMd } from "./render-readme-md.mjs";
 import { renderWireframeSvg, slug } from "./render-wireframe-svg.mjs";
 import { renderLayoutWireframeSvg } from "./render-layout-wireframe-svg.mjs";
 import { DEFAULT_PREVIEW_BASE, livePreviewUrl } from "./live-preview.mjs";
+import { buildFontsManifest, fontsPayloadsFromBundle } from "./render-fonts-manifest.mjs";
 
 /** Relative paths of every file under `dir` (forward-slashed), for the webRender manifest. */
 async function listFilesRecursive(dir) {
@@ -360,6 +361,26 @@ let webRender = null;
 if (values["wasm-dist"]) {
   const dest = join(outPath, "web", "wasm");
   await cp(resolve(values["wasm-dist"]), dest, { recursive: true });
+  // Regenerate the app's fonts.json from the recorded `fonts/used` sidecars, so the published
+  // manifest reflects what this catalog's previews actually resolved (the manifest committed in
+  // the dist is the dev-time fallback). No sidecars (older CLI / non-Android backend) ⇒ keep it.
+  const fontsDir = join(dest, "fonts");
+  const fontsPayloads = fontsPayloadsFromBundle(bundle);
+  if (fontsPayloads.length > 0) {
+    const available = new Set(await readdir(fontsDir).catch(() => []));
+    const { manifest: fontsManifest, warnings } = buildFontsManifest(fontsPayloads, available);
+    for (const warning of warnings) console.warn(`[${spec.system}] fonts: ${warning}`);
+    if (fontsManifest) {
+      await writeFile(
+        join(fontsDir, "fonts.json"),
+        JSON.stringify(fontsManifest, null, 2) + "\n",
+      );
+      console.log(
+        `[${spec.system}] generated fonts.json from ${fontsPayloads.length} preview font ` +
+          `record(s): ${fontsManifest.families.map((f) => f.name).join(", ")}`,
+      );
+    }
+  }
   const files = (await listFilesRecursive(dest)).sort();
   webRender = { kind: "compose-wasm", path: "web/wasm/", files };
   console.log(`[${spec.system}] bundled web/wasm/ (${files.length} files)`);

--- a/scripts/design-artifacts/render-fonts-manifest.mjs
+++ b/scripts/design-artifacts/render-fonts-manifest.mjs
@@ -1,0 +1,124 @@
+/**
+ * Generate the in-browser Wasm tier's `fonts.json` from the per-preview `fonts/used` records
+ * (`previews/<id>.fonts.json`, carried by `compose-preview bundle pack --with-semantics`).
+ *
+ * The wasm dist ships a hand-authored manifest as the dev-time default; the export regenerates it
+ * from what this catalog's previews *actually resolved*, so the published manifest tracks the
+ * component set instead of needing manual upkeep. Families map onto the font files vendored in the
+ * dist (extracted from Robolectric's nativeruntime — the exact files the snapshot renderer
+ * rasterizes with); a recorded family with no vendored file is reported and dropped, so the app
+ * falls back to its bundled font for it, exactly as if the manifest had never listed it.
+ */
+
+/**
+ * Vendored files by manifest family and design weight, mirroring Android's own `fonts.xml`
+ * mapping for the generic families (`serif` → Noto Serif, `monospace` → Droid Sans Mono) and the
+ * M3 default (Roboto). The recorder reports `FontFamily.Default` for theme text; `sans-serif` is
+ * Android's name for the same Roboto stack, kept as a generic entry so an explicit
+ * `FontFamily.SansSerif` request also resolves to the exact files.
+ */
+const FAMILY_FILES = {
+  Roboto: { role: "default", files: { 400: "Roboto-Regular.ttf", 500: "Roboto-Medium.ttf" } },
+  serif: { role: "generic", files: { 400: "NotoSerif-Regular.ttf" } },
+  monospace: { role: "generic", files: { 400: "DroidSansMono.ttf" } },
+  "sans-serif": {
+    role: "generic",
+    files: { 400: "Roboto-Regular.ttf", 500: "Roboto-Medium.ttf" },
+  },
+};
+
+/** Map a recorded `requestedFamily` onto a [FAMILY_FILES] key, or null when unknown. */
+function familyKey(requestedFamily) {
+  if (!requestedFamily || requestedFamily === "FontFamily.Default") return "Roboto";
+  return Object.hasOwn(FAMILY_FILES, requestedFamily) ? requestedFamily : null;
+}
+
+/**
+ * Parse every `previews/<id>.fonts.json` entry out of a read preview bundle into an array of
+ * `fonts/used` payloads (`{fonts: [{requestedFamily, weight, style, …}]}`). Unparseable entries
+ * are skipped — the record is best-effort by design.
+ */
+export function fontsPayloadsFromBundle(bundle) {
+  const out = [];
+  for (const preview of bundle.previews ?? []) {
+    const bytes = bundle.entries?.[`previews/${preview.id}.fonts.json`];
+    if (!bytes) continue;
+    try {
+      out.push(JSON.parse(new TextDecoder().decode(bytes)));
+    } catch {
+      // best-effort sidecar; a corrupt record just doesn't contribute
+    }
+  }
+  return out;
+}
+
+/**
+ * Build the manifest from [payloads] (an array of `fonts/used` payloads), keeping only files
+ * present in [availableFiles] (the dist's `fonts/` directory listing, a Set). Returns
+ * `{ manifest, warnings }`; `manifest` is null when nothing usable was recorded (callers keep the
+ * committed manifest in that case). The default (Roboto) family is always included when its files
+ * are available — the app's whole M3 type scale hangs off it even for previews that render no
+ * text of their own.
+ */
+export function buildFontsManifest(payloads, availableFiles) {
+  const warnings = [];
+  const wanted = new Map(); // familyKey -> Map(weight -> file)
+  const unknown = new Set();
+  const missing = new Set();
+  let recorded = 0;
+
+  const want = (key, weight) => {
+    const table = FAMILY_FILES[key].files;
+    const weights = Object.keys(table).map(Number);
+    const w = Number(weight) || 400;
+    const nearest = weights.reduce((a, b) => (Math.abs(b - w) < Math.abs(a - w) ? b : a));
+    const file = table[nearest];
+    if (!availableFiles.has(file)) {
+      if (!missing.has(file)) {
+        missing.add(file);
+        warnings.push(`'${key}' needs ${file}, which the dist fonts/ does not carry — dropped`);
+      }
+      return;
+    }
+    if (!wanted.has(key)) wanted.set(key, new Map());
+    wanted.get(key).set(nearest, file);
+  };
+
+  for (const payload of payloads) {
+    for (const entry of payload?.fonts ?? []) {
+      recorded++;
+      const key = familyKey(entry.requestedFamily);
+      if (key === null) {
+        if (!unknown.has(entry.requestedFamily)) {
+          unknown.add(entry.requestedFamily);
+          warnings.push(
+            `recorded family '${entry.requestedFamily}' has no vendored file — the wasm tier ` +
+              `falls back to its bundled font for it`,
+          );
+        }
+        continue;
+      }
+      want(key, entry.weight);
+    }
+  }
+  if (recorded === 0) return { manifest: null, warnings };
+
+  // The M3 typography always needs the default family, even if every recorded resolution was a
+  // generic one (a text-less catalog still themes its diagnostics through it).
+  if (!wanted.has("Roboto")) {
+    for (const weight of Object.keys(FAMILY_FILES.Roboto.files)) want("Roboto", weight);
+  }
+  if (wanted.size === 0) return { manifest: null, warnings };
+
+  const roleOrder = (key) => (FAMILY_FILES[key].role === "default" ? 0 : 1);
+  const families = [...wanted.entries()]
+    .sort(([a], [b]) => roleOrder(a) - roleOrder(b) || a.localeCompare(b))
+    .map(([key, byWeight]) => ({
+      name: key,
+      role: FAMILY_FILES[key].role,
+      fonts: [...byWeight.entries()]
+        .sort(([a], [b]) => a - b)
+        .map(([weight, file]) => ({ file, weight })),
+    }));
+  return { manifest: { version: 1, families }, warnings };
+}

--- a/scripts/design-artifacts/render-fonts-manifest.test.mjs
+++ b/scripts/design-artifacts/render-fonts-manifest.test.mjs
@@ -1,0 +1,121 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { buildFontsManifest, fontsPayloadsFromBundle } from "./render-fonts-manifest.mjs";
+
+const ALL_FILES = new Set([
+  "Roboto-Regular.ttf",
+  "Roboto-Medium.ttf",
+  "NotoSerif-Regular.ttf",
+  "DroidSansMono.ttf",
+]);
+
+const entry = (requestedFamily, weight = 400, style = "normal") => ({
+  requestedFamily,
+  resolvedFamily: requestedFamily,
+  weight,
+  style,
+});
+
+test("default + generic families map onto the vendored files", () => {
+  const payloads = [
+    { fonts: [entry("FontFamily.Default", 400), entry("FontFamily.Default", 500)] },
+    { fonts: [entry("serif", 400)] },
+    { fonts: [entry("monospace", 400)] },
+  ];
+  const { manifest, warnings } = buildFontsManifest(payloads, ALL_FILES);
+  assert.equal(warnings.length, 0);
+  assert.deepEqual(manifest, {
+    version: 1,
+    families: [
+      {
+        name: "Roboto",
+        role: "default",
+        fonts: [
+          { file: "Roboto-Regular.ttf", weight: 400 },
+          { file: "Roboto-Medium.ttf", weight: 500 },
+        ],
+      },
+      {
+        name: "monospace",
+        role: "generic",
+        fonts: [{ file: "DroidSansMono.ttf", weight: 400 }],
+      },
+      {
+        name: "serif",
+        role: "generic",
+        fonts: [{ file: "NotoSerif-Regular.ttf", weight: 400 }],
+      },
+    ],
+  });
+});
+
+test("weights snap to the nearest vendored file and dedupe", () => {
+  const payloads = [
+    { fonts: [entry("FontFamily.Default", 700), entry("FontFamily.Default", 600)] },
+  ];
+  const { manifest } = buildFontsManifest(payloads, ALL_FILES);
+  assert.deepEqual(manifest.families[0].fonts, [{ file: "Roboto-Medium.ttf", weight: 500 }]);
+});
+
+test("unknown families warn once and drop; the rest of the manifest survives", () => {
+  const payloads = [
+    {
+      fonts: [
+        entry("FontFamily.Default"),
+        entry("res/font/inter_regular"),
+        entry("res/font/inter_regular", 700),
+      ],
+    },
+  ];
+  const { manifest, warnings } = buildFontsManifest(payloads, ALL_FILES);
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /inter_regular/);
+  assert.deepEqual(
+    manifest.families.map((f) => f.name),
+    ["Roboto"],
+  );
+});
+
+test("a vendored-file gap warns and drops just that family", () => {
+  const payloads = [{ fonts: [entry("FontFamily.Default"), entry("serif")] }];
+  const files = new Set(["Roboto-Regular.ttf", "Roboto-Medium.ttf"]);
+  const { manifest, warnings } = buildFontsManifest(payloads, files);
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /NotoSerif-Regular\.ttf/);
+  assert.deepEqual(
+    manifest.families.map((f) => f.name),
+    ["Roboto"],
+  );
+});
+
+test("the default family is always included when anything was recorded", () => {
+  const payloads = [{ fonts: [entry("monospace")] }];
+  const { manifest } = buildFontsManifest(payloads, ALL_FILES);
+  assert.deepEqual(
+    manifest.families.map((f) => [f.name, f.role]),
+    [
+      ["Roboto", "default"],
+      ["monospace", "generic"],
+    ],
+  );
+});
+
+test("no recorded usage keeps the committed manifest (null)", () => {
+  assert.equal(buildFontsManifest([], ALL_FILES).manifest, null);
+  assert.equal(buildFontsManifest([{ fonts: [] }], ALL_FILES).manifest, null);
+});
+
+test("fontsPayloadsFromBundle reads sidecars and skips corrupt ones", () => {
+  const enc = (s) => new TextEncoder().encode(s);
+  const bundle = {
+    previews: [{ id: "A" }, { id: "B" }, { id: "C" }],
+    entries: {
+      "previews/A.fonts.json": enc('{"fonts":[{"requestedFamily":"serif","weight":400}]}'),
+      "previews/B.fonts.json": enc("not json"),
+    },
+  };
+  const payloads = fontsPayloadsFromBundle(bundle);
+  assert.equal(payloads.length, 1);
+  assert.equal(payloads[0].fonts[0].requestedFamily, "serif");
+});


### PR DESCRIPTION
## Summary

The final piece of the font pipeline. The daemon has recorded every font resolution per preview for a while (`FontsRecorderExtension` → `fonts/used` → `data/<id>/fonts-used.json`, always-on in `RobolectricHost`) — but nothing carried or consumed the record. Now the published catalog's `fonts.json` is **generated from what the previews actually resolved** instead of hand-authored:

- **Carriage:** `bundle pack --with-semantics` now also injects `previews/<id>.fonts.json` — `DaemonSemanticsFetcher` reads the `fonts-used.json` sidecar exactly like the semantics/layout ones (stale-cleared before render, best-effort after), and `injectFontsIntoBundle` mirrors the existing sidecar injectors. Additive: older readers ignore the entries.
- **Generation:** the design-catalog export (`render-fonts-manifest.mjs`, wired into `generate-design-catalog.mjs`'s `--wasm-dist` block) aggregates the recorded `(requestedFamily, weight)` pairs and maps them onto the dist's vendored files, using Android's own `fonts.xml` mapping: `FontFamily.Default`/`sans-serif` → Roboto, `serif` → Noto Serif, `monospace` → Droid Sans Mono. Weights snap to the nearest vendored file; unknown families (e.g. a future resource font) and vendored-file gaps **warn and drop** — the app then falls back to its bundled font for exactly that family, thanks to #2186's fail-soft loading. The default family is always included since the whole M3 type scale hangs off it.
- **Fallback:** a bundle without font records (older CLI, non-Android backend) leaves the committed manifest untouched — that file is now documented as the dev-time default (`fonts/README.md`, spike doc, `bundle pack` help).

## Test plan

Unit tests on all three seams (this environment can't run the Android daemon, so the seams are covered individually and the first post-merge `design-artifacts` run exercises the chain end-to-end — its log now prints the generated family list, which I'll verify when I dispatch it):

- `DaemonSemanticsFetcherTest` — fonts sidecar read alongside semantics/layout; absent for previews whose backend recorded nothing.
- `BundleSemanticsInjectTest` — `previews/<id>.fonts.json` lands beside the semantics blob without disturbing it.
- `render-fonts-manifest.test.mjs` (7 cases, `node --test`) — default+generic mapping, nearest-weight snapping + dedupe, unknown-family warn/drop, missing-file warn/drop, default-family backstop, empty-record null (keep committed manifest), corrupt-sidecar skip.
- `./gradlew :cli:test` green.

Text-only change (build plumbing + export driver) — no visual surface affected; the published manifest's first generated output gets checked against the current hand-authored one on the next catalog publish (expected identical for compose-m3: Roboto 400/500 + serif + monospace).

---
_Generated by [Claude Code](https://claude.ai/code/session_01NsbJzAuJeztCUJ2Mn6qJaV)_