### PR TITLE
ci: add @claude mention-triggered agent sessions with visual evidence

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -57,6 +57,12 @@ jobs:
       - uses: anthropics/claude-code-action@769e3bdff9bb7ecfb51bad4c9cba23d6f5fc5ea5 # v1.0.163
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Request the CI-read scope on the Claude App token the action
+          # mints for itself — the job-level `actions: read` grant above only
+          # covers the workflow token, and the get_ci_status /
+          # download_job_log tools key off this input.
+          additional_permissions: |
+            actions: read
           # House style (and meshcore CI) reject agent-named branch prefixes.
           branch_prefix: agent/
           # The No Agent Attribution gate rejects agent Co-authored-by

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,75 @@
+name: Claude
+
+# Mention-triggered agent sessions: comment `@claude <request>` on any issue,
+# PR, or review thread and a Claude Code session runs on this runner with the
+# full thread as context. A follow-up `@claude` reply starts a fresh run that
+# re-reads the entire conversation plus the branch it already pushed, so a
+# thread behaves like one resumable session (on an open PR, repeated mentions
+# keep stacking commits onto the same branch). Only users with write access
+# to the repo can trigger it — the action enforces this at runtime in
+# addition to the `if:` gate below.
+#
+# One-time setup per repo: install the Claude GitHub App
+# (https://github.com/apps/claude) and add an ANTHROPIC_API_KEY secret (or
+# swap the input for `claude_code_oauth_token`). Full design, the visual-
+# evidence contract, and how to adopt this in another repo:
+# docs/AGENT_INVOCATION.md.
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  issues:
+    types: [opened, assigned]
+
+jobs:
+  claude:
+    name: Claude agent session
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    # Queue (don't cancel) concurrent mentions on the same thread so two runs
+    # never race pushes to the same working branch.
+    concurrency:
+      group: claude-${{ github.event.issue.number || github.event.pull_request.number }}
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      # Exchanged by the action for a short-lived Claude GitHub App token.
+      id-token: write
+      # Lets Claude read CI results on the PR it is working on.
+      actions: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Full history so Claude can diff against main and reason about
+          # base-vs-head when rendering before/after evidence.
+          fetch-depth: 0
+      - uses: ./.github/actions/setup
+      - uses: anthropics/claude-code-action@769e3bdff9bb7ecfb51bad4c9cba23d6f5fc5ea5 # v1.0.163
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # House style (and meshcore CI) reject agent-named branch prefixes.
+          branch_prefix: agent/
+          # The No Agent Attribution gate rejects agent Co-authored-by
+          # trailers — never let the CLI append one (CLAUDE.md "Git
+          # conventions"). Branch commits land as claude[bot], which the gate
+          # deliberately allows; squash-merge from PR title + body keeps main
+          # human-authored.
+          settings: |
+            {
+              "includeCoAuthoredBy": false,
+              "attribution": { "coAuthoredBy": false }
+            }
+          claude_args: >-
+            --max-turns 100
+            --allowedTools "Bash(./gradlew:*),Bash(git:*),Bash(python3:*)"
+            --append-system-prompt "Follow CLAUDE.md and docs/AGENTS.md conventions strictly. Visual evidence is mandatory for any UI-affecting request: render the affected @Preview composables before and after your change with the compose-preview pipeline (./gradlew :samples:android:composePreviewRenderAll, :samples:cmp:composePreviewRenderAll, or the specific module render task), commit the PNGs you cite to your working branch, push, and only then embed them inline in your comment and PR text as markdown images whose URLs are commit-SHA-pinned raw.githubusercontent.com links to those pushed files. Describing an image is not evidence; the reviewer must see pixels inline. When reviewing an existing PR, reuse renders already published on the compose-preview/pr and compose-preview/main branches where possible instead of re-rendering. Use conventional commit subjects (feat:, fix:, ci:, docs:, test:). Never add Co-authored-by trailers or any agent attribution to commits, PR titles, or PR bodies."

--- a/docs/AGENT_INVOCATION.md
+++ b/docs/AGENT_INVOCATION.md
@@ -1,0 +1,152 @@
+# Invoking an agent from a GitHub issue or PR
+
+How to summon Claude onto any issue or PR in this repo (and sibling repos)
+with a single comment, have it complete the request in a cloud session with
+**visual evidence**, and continue the conversation by replying to it.
+
+## TL;DR usage
+
+Comment on any issue or PR (requires write access to the repo):
+
+> `@claude` review this PR and test the focus handling — show me before and
+> after visually.
+
+> `@claude` implement the requested changes to the login screen to make it
+> adaptive.
+
+A `Claude` workflow run starts within seconds, posts a single tracking
+comment it keeps updating with progress, does the work (rendering previews,
+editing code, committing to a branch), and finishes with results — including
+inline before/after images for anything visual. Reply with another `@claude`
+comment to steer it, request follow-ups, or push back on its answer: the next
+run re-reads the whole thread and the branch it already pushed, so the
+conversation resumes where it left off.
+
+## How it works
+
+[`.github/workflows/claude.yml`](../.github/workflows/claude.yml) runs
+[`anthropics/claude-code-action@v1`](https://github.com/anthropics/claude-code-action)
+— a full Claude Code session on a GitHub Actions runner ("cloud session" =
+the runner; see [Alternatives](#alternatives-considered) for why not
+claude.ai/code).
+
+- **Trigger**: `@claude` in an issue/PR comment, review body, inline review
+  comment, or a new issue's title/body (also fires on issue assignment).
+  Events: `issue_comment`, `pull_request_review_comment`,
+  `pull_request_review`, `issues`.
+- **Gating**: the action only accepts triggers from users with **write
+  access** to the repository (checked by the action at runtime, on top of the
+  workflow's `if:` filter). Bots are refused by default. So "repo admin
+  replies" is covered; drive-by comments from strangers are not runnable.
+- **Context**: the action feeds Claude the issue/PR body, **all comments**,
+  the diff, and a full checkout. Repo conventions load automatically from
+  `CLAUDE.md` / `docs/AGENTS.md`, and the workflow appends a system prompt
+  enforcing the visual-evidence contract below.
+- **Where changes go**:
+  - mention on an **open PR** → commits pushed directly to the PR's branch;
+  - mention on an **issue** (or closed/merged PR) → a new `agent/…` branch
+    off `main`, finishing with a link to a prefilled PR-creation page (the
+    action deliberately does not open PRs itself, preserving branch
+    protection).
+- **CI awareness**: `actions: read` lets it fetch workflow-run status and job
+  logs for the PR, so "why is CI red?" works.
+
+### "Resuming" the session
+
+Each `@claude` mention is technically a fresh workflow run — there is no
+cross-run `--resume` (runners are ephemeral; the action does expose a
+`session_id` output, but no supported flow persists it). In practice
+continuity comes from **context re-ingestion**: the next run sees every prior
+comment (including Claude's own report) plus the commits it already pushed,
+and on an open PR it keeps working on the same branch. Replying
+`@claude the after screenshot still clips the ring on the small round device`
+behaves exactly like resuming the session.
+
+### Visual evidence contract
+
+The appended system prompt makes the repo rule from `CLAUDE.md` operational
+inside the action:
+
+1. Render affected `@Preview`s **before and after** with the compose-preview
+   pipeline (`./gradlew <module>:composePreviewRenderAll` — the workflow
+   allowlists `./gradlew`, `git`, and `python3` for exactly this).
+2. **Commit the PNGs to the working branch and push first**, then embed them
+   in the comment/PR body as `![](https://raw.githubusercontent.com/<owner>/<repo>/<commit-sha>/<path>.png)`
+   — the same commit-SHA-pinned URL scheme the preview diff bot uses, so the
+   images stay live after merge.
+3. When reviewing an existing PR, reuse renders already published on the
+   `compose-preview/pr` / `compose-preview/main` branches instead of
+   re-rendering.
+4. If the affected surface has no `@Preview`, add one — that also enrolls it
+   in the sticky preview-diff comment on every future PR.
+
+GitHub comments can't carry file attachments via the API, so committed
+files + `raw.githubusercontent.com` is the only durable way for an Actions
+run to put pixels inline. It's also already this repo's convention.
+
+### Attribution
+
+Branch commits land as `claude[bot]` via the Claude GitHub App. That is
+compatible with the attribution rules on purpose:
+
+- The [`No Agent Attribution`](../.github/workflows/no-agent-attribution.yml)
+  gate bans agent **no-reply emails** (`noreply@anthropic.com` /
+  `noreply@openai.com`) and agent `Co-authored-by:` trailers — a
+  `claude[bot]@users.noreply.github.com` GitHub App identity on a **branch**
+  commit is neither, and squash-merging from the PR title + body keeps `main`
+  authored by the human who opens/merges the PR.
+- The workflow sets `includeCoAuthoredBy: false` so the CLI never appends a
+  `Co-authored-by: Claude` trailer to commit messages (which *would* trip the
+  gate — and meshcore's equivalent).
+- `branch_prefix: agent/` keeps branch names within house style
+  (meshcore-mobile's CI hard-rejects `claude/…` branch names).
+
+## Enabling this on another repo (the trivial part)
+
+Two one-time admin steps, then copy one file:
+
+1. **Install the Claude GitHub App** on the repo:
+   <https://github.com/apps/claude> (or run `/install-github-app` from the
+   Claude Code CLI, which walks through both steps).
+2. **Add the `ANTHROPIC_API_KEY` secret** (or use a Claude subscription via a
+   `CLAUDE_CODE_OAUTH_TOKEN` secret and the `claude_code_oauth_token` input
+   instead).
+3. **Copy `.github/workflows/claude.yml`** and adjust three things:
+   - the toolchain setup step (this repo: JDK 17 + Gradle via
+     `./.github/actions/setup`);
+   - the `--allowedTools` Bash allowlist (Bash is denied by default; allow
+     the build/render commands the agent needs);
+   - the `--append-system-prompt` (what "visual evidence" means for that
+     repo's surfaces).
+
+Sibling repos already wired: `meshcore-mobile` (JDK 21 setup, renders via the
+compose-preview `apply` action it already consumes) and `design-parity`
+(Node 22, report-html comparison pages).
+
+## Limits
+
+- Claude cannot merge, approve, or formally review PRs; cannot force-push or
+  push to branches other than its own / the PR's; cannot edit workflow files
+  (the App lacks `workflows` permission).
+- Runs are capped at `--max-turns 100` / 90 minutes; a follow-up `@claude`
+  mention continues from whatever was pushed.
+- `@claude` in a PR **description edit** doesn't fire (only new comments,
+  reviews, and issue open/assign do).
+
+## Alternatives considered
+
+- **Claude Code on the web (claude.ai/code) sessions from a mention** — not
+  supported. Cloud "Routines" can start sessions from GitHub events, but only
+  PR/Release events (no comments/mentions), always fresh sessions. The
+  web-session **Auto-fix PR** feature is the inverse direction: a session you
+  already opened subscribes to a PR's comments/CI and wakes on activity — the
+  right tool for babysitting a PR authored from an interactive session, but
+  not summonable from GitHub. Hence: Actions runner as the cloud session.
+- **Anthropic-hosted Code Review** (`@claude review` on a PR) — zero-workflow
+  managed review with inline comments; review-only (no code changes, no
+  rendering), Team/Enterprise plans, billed per review. Complementary, not a
+  substitute.
+- **The preview-gated AI review pipeline**
+  ([PR_REVIEW_WORKFLOW.md](PR_REVIEW_WORKFLOW.md)) — event-driven (every PR),
+  not conversational. `claude.yml` adds the on-demand, instruction-following
+  path next to it.


### PR DESCRIPTION
## Summary

Makes it trivial to summon an agent onto any issue or PR: commenting `@claude <request>` now runs a full Claude Code session on the Actions runner (via `anthropics/claude-code-action@v1`, SHA-pinned to v1.0.163) with the whole thread as context.

- **Trigger**: `@claude` in issue/PR comments, review bodies, inline review comments, or a new issue's title/body; gated to users with **write access** (enforced by the action at runtime, on top of the workflow `if:`).
- **"Resume" semantics**: each follow-up mention re-ingests the entire conversation plus the branch already pushed (open PR → commits stack on the PR branch), so a thread behaves like one resumable session.
- **Visual evidence contract** (appended system prompt): render affected `@Preview`s before/after via the compose-preview pipeline, commit the PNGs, push, then embed them inline as commit-SHA-pinned `raw.githubusercontent.com` images — reusing renders from `compose-preview/pr` / `compose-preview/main` when reviewing.
- **Attribution-safe by construction**: `includeCoAuthoredBy: false` so the CLI never emits an agent `Co-authored-by:` trailer; `branch_prefix: agent/`; branch commits land as `claude[bot]` (a GitHub App identity the No Agent Attribution gate deliberately allows) and squash-merge from PR title + body keeps `main` human-authored.
- `additional_permissions: actions: read` on the action input so the App token Claude uses can actually read CI runs/logs (the job-level grant only covers the workflow token).
- `docs/AGENT_INVOCATION.md` documents the design, resumption semantics, limits (no merge/approve, no workflow edits), the two one-time admin steps for enabling another repo (install the Claude GitHub App + add `ANTHROPIC_API_KEY`), and the alternatives considered (claude.ai/code Routines/Auto-fix don't support mention triggers; Anthropic-hosted `@claude review` is review-only).

Sibling branches with adapted workflows are pushed to `meshcore-mobile` and `design-parity` (`agent/github-agent-invocation-jg5s0v`).

## Test plan

- YAML parsed and `settings` JSON validated locally (PyYAML/json round-trip).
- Workflow structure mirrors the vendor's canonical `examples/claude.yml` (events, `if:` gate, permissions incl. `id-token: write` / `actions: read`); action pinned to the commit `v1.0.163` resolves to.
- Non-visual change (CI wiring + docs), so text-only evidence is correct per repo convention.
- After merge: install the Claude GitHub App on the repo, add the `ANTHROPIC_API_KEY` secret, then smoke-test with an `@claude` comment on a scratch issue (first run should post the tracking comment; a UI-touching request should come back with inline before/after PNGs).