### PR TITLE
feat(ci): change-scoped preview renders, parallel pipelines, /rerun PR command

### DIFF
--- a/.github/actions/apply/README.md
+++ b/.github/actions/apply/README.md
@@ -111,6 +111,51 @@ with no plugin pinned in their build — are never tripped.
 | `source` | Build from the current checkout — internal CI only. |
 | `none` | Skip CLI install (pair with `skip-render: true` for non-Gradle build systems). |
 
+## Change-scoped rendering
+
+By default every PR run renders **every** preview module — correct, but the
+full render dominates CI latency even for a one-module change. Drop a JSON
+file at `.github/preview-scope.json` (override the path with the
+`scope-config` input) and PR comment runs classify the diff first:
+
+```json
+{
+  "scopedRoots": ["samples"],
+  "ignorePaths": ["docs/**", "**/*.md"]
+}
+```
+
+| Field | Meaning |
+|---|---|
+| `scopedRoots` | Directory prefixes whose modules are eligible for scoping. A changed file inside a module under one of these roots scopes the render to that module **plus every module that (transitively) depends on it** — the dependency graph is read from Gradle itself (`scope-project-graph.init.gradle`), so a shared-module change can never skip its dependents. |
+| `ignorePaths` | `**`-style globs (repo-relative) for files that provably cannot change a rendered preview (docs, licence, editor config). A PR that only touches these skips the pipelines entirely. Module ownership wins over `ignorePaths`: a markdown file *inside* a scoped module still scopes that module in, since module content can be fixture data. |
+
+Everything else is **fail-open — full render**: a changed file outside the
+scoped roots (build scripts, version catalogs, the plugin/CLI in this repo,
+CI config), a file that can't be attributed to a module (deleted module,
+loose file), a failed or missing Gradle graph probe, or a build with no
+statically applied compose-preview plugin (the CLI auto-inject path, where
+render modules can't be determined statically). Baseline runs (push to the
+development branch) and `workflow_dispatch` reruns always render everything,
+and `scope: full` forces it per invocation.
+
+Semantics of a scoped run:
+
+- Only the **compose** pipeline renders scoped (per-module
+  `compose-preview show --module`, envelopes merged). The resources / a11y /
+  notifications pipelines treat a partial scope as a full run; only the
+  "nothing render-affecting changed" case skips them.
+- The PR comment carries a `Change-scoped run: …` note, and baseline entries
+  for out-of-scope modules are treated as **unchanged**, never "Removed" —
+  they simply weren't rendered. Removals *inside* scoped modules are still
+  detected.
+- When the diff scopes to nothing but a previous push already posted sticky
+  comments, the run falls back to full so the stale comment is refreshed to
+  its resolved state instead of being left behind.
+
+A missing config file turns the feature off (purely additive), matching the
+A/B config pattern below.
+
 ## A/B comparison of preview variants
 
 By default the comment and gallery show one "hero" render per function and

--- a/.github/actions/apply/action.yml
+++ b/.github/actions/apply/action.yml
@@ -900,7 +900,7 @@ runs:
           > _notification_comment.md
 
     - name: Upsert notification PR comment
-      if: steps.scope.outputs.mode == 'comment' && steps.resolve.outputs.notifications == '1' && hashFiles('_notification_comment.md') != ''
+      if: steps.scope.outputs.mode == 'comment' && steps.resolve.outputs.notifications == '1'
       shell: bash
       env:
         GH_TOKEN: ${{ github.token }}
@@ -912,8 +912,25 @@ runs:
         set -euo pipefail
         export PR_NUMBER="${PR_INPUT_NUMBER:-$EVENT_PR_NUMBER}"
         export MARKER="<!-- notification-previews -->"
-        export BODY_FILE="_notification_comment.md"
-        bash "$ACTION_PATH/lib/post-comment.sh"
+        if [ -s _notification_comment.md ]; then
+          export BODY_FILE="_notification_comment.md"
+          bash "$ACTION_PATH/lib/post-comment.sh"
+          exit 0
+        fi
+        # No-diff run. If an earlier push posted a sticky diff that no longer
+        # holds, PATCH it to the resolved state instead of leaving it stale —
+        # same four-state shape the resources comment uses. (PATCH doesn't
+        # notify; a no-diff run with no prior comment stays silent.)
+        [ -z "$PR_NUMBER" ] && exit 0
+        COMMENT_ID=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+          --paginate \
+          --jq ".[] | select(.body | startswith(\"${MARKER}\")) | .id" \
+          | head -1)
+        if [ -n "$COMMENT_ID" ]; then
+          RESOLVED_BODY="${MARKER}"$'\n'"## Notification Previews"$'\n\n'"_No notification preview changes in this PR's latest render._"
+          gh api "repos/${REPO}/issues/comments/${COMMENT_ID}" \
+            -X PATCH -f body="$RESOLVED_BODY" >/dev/null
+        fi
 
     # Surface pipeline failures now that all pushes + comments have run.
     # Final exit code is the worst rc across pipelines: failed renders

--- a/.github/actions/apply/action.yml
+++ b/.github/actions/apply/action.yml
@@ -131,6 +131,27 @@ inputs:
       "Other variants" links. Absent file = feature off (purely additive).
       See `.github/actions/apply/README.md` for the schema.
     default: '.github/preview-abtest.json'
+  scope-config:
+    description: >
+      Path (relative to the checkout) to the change-scope config JSON. When
+      the file exists and the run is a PR comment run, changed files are
+      classified against it: PRs that only touch `ignorePaths` skip the
+      pipelines entirely, and PRs whose changes all live inside modules
+      under `scopedRoots` render only those modules plus their (transitive)
+      Gradle dependents — out-of-scope baselines are carried, never
+      reported as removed. Every ambiguous case (a file outside the scoped
+      roots, a deleted module, a failed dependency-graph probe, no
+      statically applied plugin) falls back to a full render, so scoping
+      can only skip work that provably cannot change a preview. Absent
+      file = feature off (purely additive). Baseline runs always render
+      everything. See `.github/actions/apply/README.md` for the schema.
+    default: '.github/preview-scope.json'
+  scope:
+    description: >
+      Override for change-scoped rendering: `auto` (default — honour
+      `scope-config` when present) or `full` (ignore the config and always
+      render everything; useful for a manual full rerun).
+    default: 'auto'
   skip-render:
     description: >
       When `true`, the compose and resources pipelines reuse pre-staged
@@ -219,6 +240,100 @@ runs:
           echo "::notice::No pipeline applicable for event=$EVENT_NAME ref=$REF_NAME — skipping."
         fi
 
+    # Change-scoped rendering (see compute-scope.py). Always runs so its
+    # `mode` output is the single source of truth downstream: it passes the
+    # resolved mode through unchanged, except when a PR's changed files
+    # provably cannot affect any preview — then mode flips to `skip` before
+    # the CLI install pays any cost. Partial scopes (a module subset) flow
+    # to the pipelines via the `modules` output; only the compose pipeline
+    # renders scoped (the graph probe is skipped for the others), everything
+    # else treats a partial scope as a full run. Fail-open throughout: any
+    # doubt = full render.
+    - name: Resolve change scope
+      id: scope
+      shell: bash
+      env:
+        ACTION_PATH: ${{ github.action_path }}
+        RESOLVE_MODE: ${{ steps.resolve.outputs.mode }}
+        EVENT_NAME: ${{ github.event_name }}
+        BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        HEAD_SHA: ${{ github.sha }}
+        SCOPE_CONFIG: ${{ inputs.scope-config }}
+        SCOPE_OVERRIDE: ${{ inputs.scope }}
+        WANT_COMPOSE: ${{ steps.resolve.outputs.compose }}
+        WANT_RESOURCES: ${{ steps.resolve.outputs.resources }}
+        WANT_A11Y: ${{ steps.resolve.outputs.a11y }}
+        WANT_NOTIFICATIONS: ${{ steps.resolve.outputs.notifications }}
+        GH_TOKEN: ${{ github.token }}
+        REPO: ${{ github.repository }}
+        PR_INPUT_NUMBER: ${{ inputs.pr-number }}
+        EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
+      run: |
+        set -euo pipefail
+        MODE="$RESOLVE_MODE"
+        MODULES="full"
+        if [ "$MODE" = "comment" ] \
+           && [ "$EVENT_NAME" = "pull_request" ] \
+           && [ "$SCOPE_OVERRIDE" != "full" ] \
+           && [ -n "$BASE_SHA" ] \
+           && [ -f "$SCOPE_CONFIG" ]; then
+          # Base must be reachable for the diff; any fetch/diff failure makes
+          # compute-scope.py fall back to a full render. Token in the URL
+          # because the checkout runs with persist-credentials: false.
+          git fetch --no-tags --depth=1 \
+            "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" \
+            "$BASE_SHA" 2>/dev/null || true
+          # Only the compose pipeline renders scoped, so only it needs the
+          # Gradle dependency-graph probe; the other pipelines just need the
+          # none-vs-not-none answer.
+          WANT_GRAPH=0
+          [ "$WANT_COMPOSE" = "1" ] && WANT_GRAPH=1
+          MODULES=$(WORKSPACE="$GITHUB_WORKSPACE" \
+                    SCOPE_CONFIG="$SCOPE_CONFIG" \
+                    BASE_SHA="$BASE_SHA" HEAD_SHA="$HEAD_SHA" \
+                    WANT_GRAPH="$WANT_GRAPH" \
+                    python3 "$ACTION_PATH/compute-scope.py") || MODULES="full"
+          [ -z "$MODULES" ] && MODULES="full"
+
+          if [ "$MODULES" = "none" ]; then
+            # A previous push may have posted sticky comments that now need
+            # refreshing to their resolved state — in that case run full
+            # rather than leaving a stale diff on the PR. Marker set is
+            # limited to the pipelines this invocation owns.
+            PR_NUMBER="${PR_INPUT_NUMBER:-$EVENT_PR_NUMBER}"
+            markers=()
+            [ "$WANT_COMPOSE" = "1" ] && markers+=("<!-- preview-diff -->")
+            [ "$WANT_RESOURCES" = "1" ] && markers+=("<!-- preview-diff-resources -->")
+            [ "$WANT_A11Y" = "1" ] && markers+=("<!-- a11y-report -->")
+            [ "$WANT_NOTIFICATIONS" = "1" ] && markers+=("<!-- notification-previews -->")
+            if [ -z "$PR_NUMBER" ]; then
+              echo "::notice::scope=none but no PR number to check for sticky comments — running full."
+              MODULES="full"
+            elif [ "${#markers[@]}" -gt 0 ]; then
+              # Sticky comments start with their marker, so the first 120
+              # chars of each body are enough to detect one.
+              existing=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+                --paginate --jq '.[].body | .[0:120]' 2>/dev/null || true)
+              for mk in "${markers[@]}"; do
+                if printf '%s' "$existing" | grep -qF "$mk"; then
+                  echo "::notice::scope=none but a sticky comment ($mk) exists — running full so it gets refreshed."
+                  MODULES="full"
+                  break
+                fi
+              done
+            fi
+          fi
+
+          if [ "$MODULES" = "none" ]; then
+            MODE="skip"
+            echo "::notice::compose-preview/apply: no render-affecting changes in this PR — skipping pipelines."
+          elif [ "$MODULES" != "full" ]; then
+            echo "::notice::compose-preview/apply: change-scoped render — modules: $MODULES"
+          fi
+        fi
+        echo "mode=$MODE" >> "$GITHUB_OUTPUT"
+        echo "modules=$MODULES" >> "$GITHUB_OUTPUT"
+
     # Resolve `cli-version: auto` (the default, issue #1920) to a concrete
     # value before any install runs. `auto` pins the CLI to the plugin version
     # detected in the consumer's checkout so a new release can't float the CLI
@@ -230,7 +345,7 @@ runs:
     # reuses the skew guard's tested detection (single source of truth).
     - name: Resolve CLI version
       id: clivers
-      if: steps.resolve.outputs.mode != 'skip'
+      if: steps.scope.outputs.mode != 'skip'
       shell: bash
       env:
         ACTION_PATH: ${{ github.action_path }}
@@ -259,7 +374,7 @@ runs:
     # composite resolves against the consumer's $GITHUB_WORKSPACE, breaking
     # external use). Tag bumped per release by release-please.
     - name: Install CLI from source
-      if: steps.resolve.outputs.mode != 'skip' && steps.clivers.outputs.version == 'source'
+      if: steps.scope.outputs.mode != 'skip' && steps.clivers.outputs.version == 'source'
       # zizmor: ignore[known-vulnerable-actions] same-repo release action trips GitHub Advisories API 403 under GITHUB_TOKEN
       uses: yschimke/compose-ai-tools/.github/actions/install-cli@v0.11.5 # x-release-please-version
 
@@ -269,7 +384,7 @@ runs:
     # cleanly with "command not found" when selected without a CLI.
     - name: Install CLI from release
       id: install-release
-      if: steps.resolve.outputs.mode != 'skip' && steps.clivers.outputs.version != 'source' && steps.clivers.outputs.version != 'none'
+      if: steps.scope.outputs.mode != 'skip' && steps.clivers.outputs.version != 'source' && steps.clivers.outputs.version != 'none'
       # zizmor: ignore[known-vulnerable-actions] same-repo release action trips GitHub Advisories API 403 under GITHUB_TOKEN
       uses: yschimke/compose-ai-tools/.github/actions/install@v0.11.5 # x-release-please-version
       with:
@@ -288,7 +403,7 @@ runs:
     # no Gradle cost — runs before doctor so the headline is the skew, not the
     # confusing symptom.
     - name: Check CLI / plugin version skew
-      if: steps.resolve.outputs.mode != 'skip' && steps.clivers.outputs.version != 'source' && steps.clivers.outputs.version != 'none'
+      if: steps.scope.outputs.mode != 'skip' && steps.clivers.outputs.version != 'source' && steps.clivers.outputs.version != 'none'
       shell: bash
       env:
         ACTION_PATH: ${{ github.action_path }}
@@ -309,7 +424,7 @@ runs:
     # actionable error. A non-zero doctor surfaces as a `::warning::`
     # annotation so it's still visible in the run summary.
     - name: Run compose-preview doctor
-      if: steps.resolve.outputs.mode != 'skip' && steps.clivers.outputs.version != 'none'
+      if: steps.scope.outputs.mode != 'skip' && steps.clivers.outputs.version != 'none'
       shell: bash
       run: |
         echo "::group::compose-preview doctor"
@@ -321,7 +436,7 @@ runs:
         fi
 
     - name: Install perceptual-diff dependencies
-      if: steps.resolve.outputs.mode == 'comment' && (steps.resolve.outputs.compose == '1' || steps.resolve.outputs.resources == '1')
+      if: steps.scope.outputs.mode == 'comment' && (steps.resolve.outputs.compose == '1' || steps.resolve.outputs.resources == '1')
       shell: bash
       run: |
         # pixelmatch collapses sub-pixel rounded-corner noise that Compose's
@@ -334,7 +449,7 @@ runs:
 
     - name: Run pipelines
       id: pipelines
-      if: steps.resolve.outputs.mode != 'skip'
+      if: steps.scope.outputs.mode != 'skip'
       shell: bash
       # Pipelines run back-to-back rather than in parallel: all four
       # invoke Gradle (directly or via the CLI) and all four `git fetch`
@@ -349,7 +464,7 @@ runs:
         ACTION_PATH: ${{ github.action_path }}
         REPO: ${{ github.repository }}
         GITHUB_TOKEN_INLINE: ${{ github.token }}
-        MODE: ${{ steps.resolve.outputs.mode }}
+        MODE: ${{ steps.scope.outputs.mode }}
         RENDER_TIMEOUT: ${{ inputs.timeout }}
         PR_INPUT_NUMBER: ${{ inputs.pr-number }}
         EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -372,6 +487,7 @@ runs:
         WANT_NOTIFICATIONS: ${{ steps.resolve.outputs.notifications }}
         SKIP_RENDER: ${{ inputs.skip-render }}
         AB_CONFIG: ${{ inputs.ab-config }}
+        SCOPE_MODULES: ${{ steps.scope.outputs.modules }}
       run: |
         set +e
         export PR_NUMBER="${PR_INPUT_NUMBER:-$EVENT_PR_NUMBER}"
@@ -456,13 +572,13 @@ runs:
     # GHA's `if:` can gate them per pipeline.
 
     - name: Push compose baseline / PR renders
-      if: steps.resolve.outputs.mode != 'skip' && steps.resolve.outputs.compose == '1'
+      if: steps.scope.outputs.mode != 'skip' && steps.resolve.outputs.compose == '1'
       shell: bash
       env:
         REPO: ${{ github.repository }}
         GITHUB_TOKEN_INLINE: ${{ github.token }}
         ACTION_PATH: ${{ github.action_path }}
-        MODE: ${{ steps.resolve.outputs.mode }}
+        MODE: ${{ steps.scope.outputs.mode }}
       run: |
         set -euo pipefail
         if [ "$MODE" = "baseline" ]; then
@@ -489,13 +605,13 @@ runs:
         bash "$ACTION_PATH/lib/push-branch.sh"
 
     - name: Push resource baseline / PR renders
-      if: steps.resolve.outputs.mode != 'skip' && steps.resolve.outputs.resources == '1'
+      if: steps.scope.outputs.mode != 'skip' && steps.resolve.outputs.resources == '1'
       shell: bash
       env:
         REPO: ${{ github.repository }}
         GITHUB_TOKEN_INLINE: ${{ github.token }}
         ACTION_PATH: ${{ github.action_path }}
-        MODE: ${{ steps.resolve.outputs.mode }}
+        MODE: ${{ steps.scope.outputs.mode }}
       run: |
         set -euo pipefail
         if [ "$MODE" = "baseline" ]; then
@@ -519,7 +635,7 @@ runs:
         bash "$ACTION_PATH/lib/push-branch.sh"
 
     - name: Generate compose PR comment body
-      if: steps.resolve.outputs.mode == 'comment' && steps.resolve.outputs.compose == '1'
+      if: steps.scope.outputs.mode == 'comment' && steps.resolve.outputs.compose == '1'
       shell: bash
       env:
         ACTION_PATH: ${{ github.action_path }}
@@ -527,6 +643,7 @@ runs:
         PR_HEAD_BRANCH: 'compose-preview/pr'
         RESOURCE_HEAD_BRANCH: 'compose-preview/resources/pr'
         AB_CONFIG: ${{ inputs.ab-config }}
+        SCOPE_MODULES: ${{ steps.scope.outputs.modules }}
       run: |
         set -euo pipefail
         # Compose comment is only meaningful when the compose pipeline
@@ -552,6 +669,13 @@ runs:
           AB_ARGS=(--ab-config "$AB_CONFIG")
         fi
 
+        # Change-scoped runs rendered a module subset — tell the comparator
+        # so out-of-scope baselines read as unchanged, not removed.
+        SCOPE_ARGS=()
+        if [ -n "${SCOPE_MODULES:-}" ] && [ "$SCOPE_MODULES" != "full" ]; then
+          SCOPE_ARGS=(--scope-modules "$SCOPE_MODULES")
+        fi
+
         python3 "$ACTION_PATH/../lib/compare-previews.py" compare _previews.json \
           --baselines _baselines/baselines.json \
           --baseline-renders _baselines/renders \
@@ -559,13 +683,14 @@ runs:
           --base-ref "$BASE_REF" \
           --head-ref "$HEAD_REF" \
           "${AB_ARGS[@]}" \
+          "${SCOPE_ARGS[@]}" \
           > _comment_body.md
 
     # Sibling step for the resources comment — separately gated on
     # `resources == '1'` so `only: resources` runs still produce the
     # resource sticky comment when compose is skipped.
     - name: Generate resource PR comment body
-      if: steps.resolve.outputs.mode == 'comment' && steps.resolve.outputs.resources == '1'
+      if: steps.scope.outputs.mode == 'comment' && steps.resolve.outputs.resources == '1'
       shell: bash
       env:
         ACTION_PATH: ${{ github.action_path }}
@@ -596,7 +721,7 @@ runs:
           > _comment_body_resources.md
 
     - name: Post or update compose PR comment
-      if: steps.resolve.outputs.mode == 'comment' && steps.resolve.outputs.compose == '1' && hashFiles('_comment_body.md') != ''
+      if: steps.scope.outputs.mode == 'comment' && steps.resolve.outputs.compose == '1' && hashFiles('_comment_body.md') != ''
       shell: bash
       env:
         GH_TOKEN: ${{ github.token }}
@@ -628,7 +753,7 @@ runs:
         bash "$ACTION_PATH/lib/post-comment.sh"
 
     - name: Post or update resource PR comment
-      if: steps.resolve.outputs.mode == 'comment' && steps.resolve.outputs.resources == '1' && hashFiles('_comment_body_resources.md') != ''
+      if: steps.scope.outputs.mode == 'comment' && steps.resolve.outputs.resources == '1' && hashFiles('_comment_body_resources.md') != ''
       shell: bash
       env:
         GH_TOKEN: ${{ github.token }}
@@ -671,7 +796,7 @@ runs:
 
     - name: Push a11y baseline / PR renders
       id: push-a11y
-      if: steps.resolve.outputs.mode != 'skip' && steps.resolve.outputs.a11y == '1'
+      if: steps.scope.outputs.mode != 'skip' && steps.resolve.outputs.a11y == '1'
       shell: bash
       env:
         REPO: ${{ github.repository }}
@@ -695,7 +820,7 @@ runs:
         echo "head_sha=$(cat "$SHA_OUTPUT_FILE" 2>/dev/null || true)" >> "$GITHUB_OUTPUT"
 
     - name: Re-render a11y comment body with pushed SHA
-      if: steps.resolve.outputs.mode == 'comment' && steps.resolve.outputs.a11y == '1' && hashFiles('_a11y_comment.md') != ''
+      if: steps.scope.outputs.mode == 'comment' && steps.resolve.outputs.a11y == '1' && hashFiles('_a11y_comment.md') != ''
       shell: bash
       env:
         ACTION_PATH: ${{ github.action_path }}
@@ -714,7 +839,7 @@ runs:
           > _a11y_comment.md
 
     - name: Upsert a11y PR comment
-      if: steps.resolve.outputs.mode == 'comment' && steps.resolve.outputs.a11y == '1' && hashFiles('_a11y_comment.md') != ''
+      if: steps.scope.outputs.mode == 'comment' && steps.resolve.outputs.a11y == '1' && hashFiles('_a11y_comment.md') != ''
       shell: bash
       env:
         GH_TOKEN: ${{ github.token }}
@@ -731,7 +856,7 @@ runs:
 
     - name: Push notifications baseline / PR renders
       id: push-notifications
-      if: steps.resolve.outputs.mode != 'skip' && steps.resolve.outputs.notifications == '1'
+      if: steps.scope.outputs.mode != 'skip' && steps.resolve.outputs.notifications == '1'
       shell: bash
       env:
         REPO: ${{ github.repository }}
@@ -755,7 +880,7 @@ runs:
         echo "head_sha=$(cat "$SHA_OUTPUT_FILE" 2>/dev/null || true)" >> "$GITHUB_OUTPUT"
 
     - name: Re-render notification comment body with pushed SHA
-      if: steps.resolve.outputs.mode == 'comment' && steps.resolve.outputs.notifications == '1' && hashFiles('_notification_comment.md') != ''
+      if: steps.scope.outputs.mode == 'comment' && steps.resolve.outputs.notifications == '1' && hashFiles('_notification_comment.md') != ''
       shell: bash
       env:
         ACTION_PATH: ${{ github.action_path }}
@@ -775,7 +900,7 @@ runs:
           > _notification_comment.md
 
     - name: Upsert notification PR comment
-      if: steps.resolve.outputs.mode == 'comment' && steps.resolve.outputs.notifications == '1' && hashFiles('_notification_comment.md') != ''
+      if: steps.scope.outputs.mode == 'comment' && steps.resolve.outputs.notifications == '1' && hashFiles('_notification_comment.md') != ''
       shell: bash
       env:
         GH_TOKEN: ${{ github.token }}
@@ -795,7 +920,7 @@ runs:
     # still get their artifacts uploaded + the PR diff posted before this
     # flips the workflow red.
     - name: Surface pipeline failures
-      if: steps.resolve.outputs.mode != 'skip'
+      if: steps.scope.outputs.mode != 'skip'
       shell: bash
       env:
         WORST_RC: ${{ steps.pipelines.outputs.worst }}

--- a/.github/actions/apply/compute-scope.py
+++ b/.github/actions/apply/compute-scope.py
@@ -1,0 +1,399 @@
+#!/usr/bin/env python3
+"""Change-scoped preview rendering: decide which modules a PR run must render.
+
+Reads the PR's changed files and a committed scope config
+(`.github/preview-scope.json` by default) and prints a single line:
+
+    full             render everything (default / any doubt)
+    none             nothing render-affecting changed — skip the pipelines
+    mod1,mod2,...    render only these Gradle modules (comma-separated,
+                     no leading colon)
+
+The contract is *fail-open*: every ambiguous, unexpected, or error path
+resolves to `full`, so scoping can only ever skip work that provably cannot
+change a rendered preview. The cases that scope:
+
+* Every changed file is matched by `ignorePaths` -> `none`.
+* Every changed file is either ignored or lives inside a module under one of
+  the `scopedRoots` -> the changed modules are expanded to all (transitive)
+  dependent modules via the Gradle project graph, then intersected with the
+  modules that apply the compose-preview plugin -> that set (or `none` when
+  it is empty).
+
+Anything else — a file outside the scoped roots (build scripts, version
+catalogs, CI, the plugin itself, ...), a file that cannot be attributed to a
+module, a missing/failed Gradle graph, a build with no statically applied
+preview plugin (the CLI auto-inject path), renames we cannot follow — is
+`full`.
+
+Config schema (all paths repo-relative, `**`-style globs):
+
+    {
+      "scopedRoots": ["samples"],
+      "ignorePaths": ["docs/**", "**/*.md"]
+    }
+
+Classification precedence per file: scoped-module ownership first, then
+`ignorePaths`, then global. Module ownership winning over `ignorePaths` means
+a `samples/wear/fixture.md` still scopes `samples:wear` in, even though
+`**/*.md` would ignore the same file elsewhere — content inside a module is
+always treated as able to affect that module's renders.
+
+Environment (set by the apply action):
+    WORKSPACE            checkout root (default: cwd)
+    SCOPE_CONFIG         path to the scope config JSON
+    BASE_SHA / HEAD_SHA  PR diff endpoints (base must already be fetched)
+    WANT_GRAPH           "1" when the caller renders scoped (compose
+                         pipeline); anything else skips the Gradle graph and
+                         collapses partial scopes to `full` (the a11y /
+                         notifications pipelines only distinguish
+                         none-vs-not-none)
+    SCOPE_GRAPH_TIMEOUT  seconds for the Gradle graph invocation (default 300)
+
+Pure stdlib; unit-tested by test_compute_scope.py.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+FULL = "full"
+NONE = "none"
+
+PREVIEW_PLUGIN_IDS = (
+    "ee.schimke.composeai.preview",
+    "ee.schimke.composeai.preview.config",
+)
+
+
+def _log(msg: str) -> None:
+    print(f"compute-scope: {msg}", file=sys.stderr)
+
+
+def glob_to_regex(pattern: str) -> re.Pattern:
+    """Convert a `**`-style glob to a regex over repo-relative POSIX paths.
+
+    `**` crosses directory separators (including matching nothing), `*` and
+    `?` do not. A pattern without a `/` is treated as `**/<pattern>` so bare
+    basename patterns (`*.md`) match at any depth. A trailing `/**` also
+    matches the bare directory itself.
+    """
+    pat = pattern.strip().lstrip("/")
+    if "/" not in pat.replace("/**", ""):
+        # Bare basename pattern (no directory component besides a possible
+        # trailing /**): anchor at any depth.
+        if not pat.startswith("**/") and not pat.startswith("**"):
+            pat = "**/" + pat
+    out = []
+    i = 0
+    while i < len(pat):
+        c = pat[i]
+        if c == "*":
+            if pat[i : i + 2] == "**":
+                # Collapse `**/` and `/**` so they can match zero segments.
+                if pat[i : i + 3] == "**/":
+                    out.append("(?:[^/]+/)*")
+                    i += 3
+                    continue
+                out.append(".*")
+                i += 2
+                continue
+            out.append("[^/]*")
+            i += 1
+            continue
+        if c == "?":
+            out.append("[^/]")
+            i += 1
+            continue
+        out.append(re.escape(c))
+        i += 1
+    regex = "".join(out)
+    # `dir/**` should also match `dir` itself.
+    if regex.endswith("/.*"):
+        regex = regex[: -len("/.*")] + "(?:/.*)?"
+    return re.compile("^" + regex + "$")
+
+
+class ScopeConfig:
+    def __init__(self, scoped_roots: list[str], ignore_paths: list[str]):
+        self.scoped_roots = [r.strip().strip("/") for r in scoped_roots if r.strip()]
+        self.ignore_regexes = [glob_to_regex(p) for p in ignore_paths]
+
+    @staticmethod
+    def load(path: Path) -> "ScopeConfig | None":
+        try:
+            raw = json.loads(path.read_text())
+        except FileNotFoundError:
+            return None
+        except (OSError, json.JSONDecodeError) as e:
+            _log(f"unreadable scope config {path}: {e} — full render")
+            raise ScopeError from e
+        roots = raw.get("scopedRoots") or []
+        if not isinstance(roots, list) or not roots:
+            _log(f"{path} has no scopedRoots — full render")
+            raise ScopeError
+        ignores = raw.get("ignorePaths") or []
+        if not isinstance(ignores, list):
+            raise ScopeError
+        return ScopeConfig(roots, [str(p) for p in ignores])
+
+    def root_of(self, rel_path: str) -> str | None:
+        for root in self.scoped_roots:
+            if rel_path == root or rel_path.startswith(root + "/"):
+                return root
+        return None
+
+    def is_ignored(self, rel_path: str) -> bool:
+        return any(rx.match(rel_path) for rx in self.ignore_regexes)
+
+
+class ScopeError(Exception):
+    """Any condition that must resolve to a full render."""
+
+
+def changed_files(workspace: Path, base_sha: str, head_sha: str) -> list[str]:
+    """`git diff --name-only` between the PR base and head/merge commit.
+
+    `--no-renames` so a rename surfaces as delete+add and both sides get
+    classified. Any git failure raises ScopeError (-> full render).
+    """
+    try:
+        proc = subprocess.run(
+            ["git", "diff", "--name-only", "--no-renames", base_sha, head_sha],
+            cwd=workspace,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+    except (OSError, subprocess.TimeoutExpired) as e:
+        _log(f"git diff failed: {e}")
+        raise ScopeError from e
+    if proc.returncode != 0:
+        _log(f"git diff exited {proc.returncode}: {proc.stderr.strip()[:500]}")
+        raise ScopeError
+    return [line.strip() for line in proc.stdout.splitlines() if line.strip()]
+
+
+def partition_files(
+    files: list[str], config: ScopeConfig
+) -> tuple[list[str], list[str]]:
+    """Split changed files into (scoped, ignored). Any global file raises.
+
+    Precedence: scoped-root containment first, then ignorePaths, then global
+    (ScopeError -> full). Note scoped files are attributed to modules later,
+    against the real Gradle project graph — this step only decides that the
+    file is *allowed* to scope.
+    """
+    scoped: list[str] = []
+    ignored: list[str] = []
+    for f in files:
+        if config.root_of(f) is not None:
+            scoped.append(f)
+        elif config.is_ignored(f):
+            ignored.append(f)
+        else:
+            _log(f"global path changed: {f}")
+            raise ScopeError
+    return scoped, ignored
+
+
+def load_graph(graph_path: Path) -> list[dict]:
+    try:
+        raw = json.loads(graph_path.read_text())
+    except (OSError, json.JSONDecodeError) as e:
+        _log(f"unreadable project graph {graph_path}: {e}")
+        raise ScopeError from e
+    projects = raw.get("projects")
+    if not isinstance(projects, list) or not projects:
+        _log("project graph is empty")
+        raise ScopeError
+    for p in projects:
+        if "?" in (p.get("dependencies") or []):
+            # The init script could not resolve a project dependency's path
+            # on this Gradle version — the closure would be incomplete.
+            _log(f"project {p.get('path')} has an unresolvable project dependency")
+            raise ScopeError
+    return projects
+
+
+def map_files_to_projects(
+    scoped_files: list[str],
+    projects: list[dict],
+    config: ScopeConfig,
+    workspace: Path,
+) -> set[str]:
+    """Attribute each scoped file to the deepest project whose dir contains it.
+
+    The owning project must itself live under a scoped root (the root project
+    trivially contains everything and must never win). Unattributable files
+    raise (-> full render): e.g. a file in a module that was deleted in this
+    PR, or loose files directly under a scoped root.
+    """
+    ws = workspace.resolve()
+    dirs: list[tuple[str, str]] = []  # (rel dir, project path)
+    for p in projects:
+        try:
+            rel = Path(p["dir"]).resolve().relative_to(ws).as_posix()
+        except ValueError:
+            continue
+        if rel == ".":
+            continue  # root project — never an owner
+        if config.root_of(rel) is None:
+            continue  # project outside the scoped roots
+        dirs.append((rel, p["path"]))
+    # Deepest match first.
+    dirs.sort(key=lambda d: d[0].count("/"), reverse=True)
+
+    owners: set[str] = set()
+    for f in scoped_files:
+        owner = next(
+            (path for rel, path in dirs if f == rel or f.startswith(rel + "/")),
+            None,
+        )
+        if owner is None:
+            _log(f"no module owns changed file {f} (deleted module or loose file)")
+            raise ScopeError
+        owners.add(owner)
+    return owners
+
+
+def reverse_closure(changed: set[str], projects: list[dict]) -> set[str]:
+    """Changed projects plus every project that (transitively) depends on them."""
+    rdeps: dict[str, set[str]] = {}
+    for p in projects:
+        for dep in p.get("dependencies") or []:
+            rdeps.setdefault(dep, set()).add(p["path"])
+    affected = set(changed)
+    frontier = list(changed)
+    while frontier:
+        cur = frontier.pop()
+        for dependent in rdeps.get(cur, ()):
+            if dependent not in affected:
+                affected.add(dependent)
+                frontier.append(dependent)
+    return affected
+
+
+def resolve_scope(
+    files: list[str],
+    config: ScopeConfig,
+    workspace: Path,
+    want_graph: bool,
+    graph_loader,
+) -> str:
+    """Pure decision core. graph_loader() -> list[dict] (projects), called at
+    most once and only when a partial scope needs the dependency closure.
+    Every ScopeError resolves to a full render here so callers only ever see
+    the three-value result."""
+    try:
+        if not files:
+            # An empty PR diff is unexpected — don't guess.
+            _log("empty diff — full render")
+            return FULL
+        scoped, ignored = partition_files(files, config)
+        if not scoped:
+            _log(f"all {len(ignored)} changed file(s) ignored — nothing to render")
+            return NONE
+        if not want_graph:
+            # This pipeline doesn't render scoped; it only needed the none-check.
+            return FULL
+        projects = graph_loader()
+        preview_modules = {p["path"] for p in projects if p.get("hasPreviewPlugin")}
+        if not preview_modules:
+            # No statically applied plugin (CLI auto-inject consumer): we can't
+            # know which modules render, so we can't scope.
+            _log("no module statically applies the compose-preview plugin — full render")
+            return FULL
+        changed_projects = map_files_to_projects(scoped, projects, config, workspace)
+        affected = reverse_closure(changed_projects, projects)
+        scope = sorted(m.lstrip(":") for m in affected & preview_modules)
+        if not scope:
+            _log(
+                f"changed module(s) {sorted(changed_projects)} have no preview-module "
+                "dependents — nothing to render"
+            )
+            return NONE
+        _log(f"scoped to {len(scope)} module(s): {', '.join(scope)}")
+        return ",".join(scope)
+    except ScopeError:
+        return FULL
+
+
+def run_gradle_graph(workspace: Path, init_script: Path, timeout: int) -> list[dict]:
+    out = Path(tempfile.mkstemp(prefix="scope-graph-", suffix=".json")[1])
+    gradlew = workspace / "gradlew"
+    if not gradlew.exists():
+        _log("no ./gradlew in workspace")
+        raise ScopeError
+    cmd = [
+        str(gradlew),
+        "--no-configuration-cache",
+        "-q",
+        "-I",
+        str(init_script),
+        f"-Dcomposeai.scope.graph.out={out}",
+        "help",
+    ]
+    try:
+        proc = subprocess.run(
+            cmd, cwd=workspace, capture_output=True, text=True, timeout=timeout
+        )
+    except (OSError, subprocess.TimeoutExpired) as e:
+        _log(f"gradle graph run failed: {e}")
+        raise ScopeError from e
+    if proc.returncode != 0:
+        _log(f"gradle graph run exited {proc.returncode}: {proc.stderr.strip()[-800:]}")
+        raise ScopeError
+    return load_graph(out)
+
+
+def main() -> int:
+    workspace = Path(os.environ.get("WORKSPACE") or os.getcwd())
+    config_path = Path(
+        os.environ.get("SCOPE_CONFIG") or ".github/preview-scope.json"
+    )
+    if not config_path.is_absolute():
+        config_path = workspace / config_path
+    base_sha = os.environ.get("BASE_SHA", "")
+    head_sha = os.environ.get("HEAD_SHA", "")
+    want_graph = os.environ.get("WANT_GRAPH") == "1"
+    timeout = int(os.environ.get("SCOPE_GRAPH_TIMEOUT") or "300")
+    init_script = Path(__file__).resolve().parent / "scope-project-graph.init.gradle"
+
+    try:
+        config = ScopeConfig.load(config_path)
+    except ScopeError:
+        print(FULL)
+        return 0
+    if config is None:
+        _log(f"no scope config at {config_path} — scoping off, full render")
+        print(FULL)
+        return 0
+    if not base_sha or not head_sha:
+        _log("missing BASE_SHA/HEAD_SHA — full render")
+        print(FULL)
+        return 0
+
+    try:
+        files = changed_files(workspace, base_sha, head_sha)
+        result = resolve_scope(
+            files,
+            config,
+            workspace,
+            want_graph,
+            lambda: run_gradle_graph(workspace, init_script, timeout),
+        )
+    except ScopeError:
+        result = FULL
+    print(result)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/actions/apply/merge-envelopes.py
+++ b/.github/actions/apply/merge-envelopes.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Merge per-module `compose-preview show --json` envelopes into one.
+
+Change-scoped runs invoke `show --module :<m>` once per affected module;
+this concatenates the resulting envelopes so the rest of the compose
+pipeline (compare-previews.py) sees the same `_previews.json` shape a full
+`show` run produces.
+
+    merge-envelopes.py OUT IN1 [IN2 ...]
+
+* `schema` is taken from the first valid input.
+* `counts` is dropped — it describes a single run and nothing downstream
+  reads it.
+* An empty (zero-byte) input is a module with no previews — skipped.
+* An unparseable input is skipped with a warning and flips the exit code to
+  1, mirroring a failed module render: the caller records it in
+  `_compose_render_rc` so the job still ends red after the partial diff is
+  posted.
+* Duplicate preview ids across inputs (impossible for disjoint modules)
+  keep the first occurrence and warn.
+
+Exit codes: 0 = all inputs merged; 1 = some inputs skipped (partial
+envelope written when at least one input was valid); 2 = nothing valid, no
+output written.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 3:
+        print(f"usage: {argv[0]} OUT IN1 [IN2 ...]", file=sys.stderr)
+        return 2
+
+    out_path = Path(argv[1])
+    schema = None
+    previews: list[dict] = []
+    seen_keys: set[tuple[str, str]] = set()
+    bad = 0
+    valid = 0
+
+    for name in argv[2:]:
+        p = Path(name)
+        try:
+            text = p.read_text()
+        except OSError as e:
+            print(f"merge-envelopes: cannot read {p}: {e}", file=sys.stderr)
+            bad += 1
+            continue
+        if not text.strip():
+            # `show --module` on a module with zero previews can emit nothing.
+            valid += 1
+            continue
+        try:
+            raw = json.loads(text)
+        except json.JSONDecodeError as e:
+            print(f"merge-envelopes: {p} is not valid JSON ({e.msg})", file=sys.stderr)
+            bad += 1
+            continue
+        if not isinstance(raw, dict) or not isinstance(raw.get("previews"), list):
+            print(
+                f"merge-envelopes: {p} is not a show envelope "
+                f"(expected {{schema, previews}})",
+                file=sys.stderr,
+            )
+            bad += 1
+            continue
+        valid += 1
+        if schema is None and raw.get("schema"):
+            schema = raw["schema"]
+        for entry in raw["previews"]:
+            key = (str(entry.get("module")), str(entry.get("id")))
+            if key in seen_keys:
+                print(f"merge-envelopes: duplicate preview {key}, keeping first",
+                      file=sys.stderr)
+                continue
+            seen_keys.add(key)
+            previews.append(entry)
+
+    if valid == 0:
+        print("merge-envelopes: no valid inputs, not writing output", file=sys.stderr)
+        return 2
+
+    envelope: dict = {"previews": previews}
+    if schema is not None:
+        envelope = {"schema": schema, "previews": previews}
+    out_path.write_text(json.dumps(envelope))
+    return 1 if bad else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.github/actions/apply/pipelines/compose.sh
+++ b/.github/actions/apply/pipelines/compose.sh
@@ -22,6 +22,12 @@
 #                          non-Gradle build systems drive the baseline /
 #                          comment half of this pipeline with envelopes
 #                          produced by the Phase A CLIs.
+#   SCOPE_MODULES        — change-scoped runs: empty or "full" renders every
+#                          module (historical behaviour); a comma-separated
+#                          module list renders only those modules via
+#                          per-module `show --module` invocations and merges
+#                          the envelopes. "none" never reaches this script
+#                          (the action skips the pipelines entirely).
 set +e
 
 if [ "${SKIP_RENDER:-false}" = "true" ]; then
@@ -36,6 +42,40 @@ if [ "${SKIP_RENDER:-false}" = "true" ]; then
   fi
   echo "compose pipeline: skip-render=true; reusing pre-staged _previews.json."
   echo "0" > "$GITHUB_WORKSPACE/_compose_render_rc"
+elif [ -n "${SCOPE_MODULES:-}" ] && [ "${SCOPE_MODULES}" != "full" ]; then
+  # Change-scoped render: one `show --module` per affected module, envelopes
+  # merged into the same _previews.json shape a full run produces. The
+  # compare step passes the same scope so out-of-scope baselines are treated
+  # as unchanged rather than removed. A failed module keeps the loop going —
+  # like the full-run path, a partial envelope still drives the diff and the
+  # non-zero rc flips the job red at the end.
+  echo "compose pipeline: change-scoped render (${SCOPE_MODULES})."
+  WORST_RC=0
+  scope_inputs=()
+  i=0
+  IFS=',' read -r -a scope_arr <<< "$SCOPE_MODULES"
+  for m in "${scope_arr[@]}"; do
+    m="$(echo "$m" | xargs)"
+    [ -z "$m" ] && continue
+    out="_previews_scope_${i}.json"
+    i=$((i + 1))
+    show_args=(show --json --timeout "$RENDER_TIMEOUT" --module ":${m#:}")
+    if [ -n "${MISSING_RENDERS:-}" ]; then
+      show_args+=(--missing-renders "${MISSING_RENDERS}")
+    fi
+    compose-preview "${show_args[@]}" > "$out"
+    rc=$?
+    if [ "$rc" -ne 0 ] && [ "$WORST_RC" -eq 0 ]; then
+      WORST_RC=$rc
+    fi
+    scope_inputs+=("$out")
+  done
+  python3 "$ACTION_PATH/merge-envelopes.py" _previews.json "${scope_inputs[@]}"
+  merge_rc=$?
+  if [ "$merge_rc" -ne 0 ] && [ "$WORST_RC" -eq 0 ]; then
+    WORST_RC=$merge_rc
+  fi
+  echo "$WORST_RC" > "$GITHUB_WORKSPACE/_compose_render_rc"
 else
   # Render. Don't fail on non-zero — partial envelope still drives the rest.
   show_args=(show --json --timeout "$RENDER_TIMEOUT")

--- a/.github/actions/apply/scope-project-graph.init.gradle
+++ b/.github/actions/apply/scope-project-graph.init.gradle
@@ -1,0 +1,56 @@
+// Init script for the apply action's change-scoped rendering (compute-scope.py).
+//
+// Dumps the main build's project graph — project path, project directory,
+// whether the compose-preview plugin is applied, and declared project
+// dependencies — as JSON to the file named by the `composeai.scope.graph.out`
+// system property. compute-scope.py uses it to expand a PR's changed modules
+// into the full set of preview modules that could be affected (reverse
+// dependency closure), so a scoped render can never miss a downstream module.
+//
+// Runs at projectsEvaluated (configuration time, all projects), so invoke with
+// any task (`help`) and `--no-configuration-cache` — on a configuration-cache
+// hit the callback would never fire and the output file would be missing,
+// which compute-scope.py treats as "fall back to a full render" (fail-open).
+//
+// Included builds are deliberately not walked: their sources can't be mapped
+// to main-build modules, so changes there must be classified as global (full
+// render) by the caller's path rules.
+def outPath = System.getProperty('composeai.scope.graph.out')
+if (outPath != null) {
+  gradle.projectsEvaluated { g ->
+    def projects = []
+    g.rootProject.allprojects { p ->
+      def deps = new LinkedHashSet()
+      p.configurations.each { c ->
+        c.dependencies.each { d ->
+          if (d instanceof org.gradle.api.artifacts.ProjectDependency) {
+            def depPath = null
+            try {
+              // Gradle 8.11+ / 9: ProjectDependency.getPath()
+              depPath = d.path
+            } catch (Throwable ignored) {
+              try {
+                // Older Gradle: via the (since removed) dependencyProject
+                depPath = d.dependencyProject.path
+              } catch (Throwable alsoIgnored) {
+                // Unresolvable — leave null; compute-scope.py fails open on
+                // a project with a null dependency marker.
+              }
+            }
+            deps.add(depPath == null ? '?' : depPath)
+          }
+        }
+      }
+      def hasPlugin = p.plugins.hasPlugin('ee.schimke.composeai.preview') ||
+          p.plugins.hasPlugin('ee.schimke.composeai.preview.config')
+      projects.add([
+        path: p.path,
+        dir: p.projectDir.absolutePath,
+        hasPreviewPlugin: hasPlugin,
+        dependencies: deps.toList(),
+      ])
+    }
+    def json = groovy.json.JsonOutput.toJson([projects: projects])
+    new File(outPath).text = json
+  }
+}

--- a/.github/actions/apply/test_compute_scope.py
+++ b/.github/actions/apply/test_compute_scope.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""Tests for compute-scope.py and merge-envelopes.py.
+
+Pure stdlib (unittest), no Gradle — the project graph is injected as data.
+Run directly:
+
+    python3 .github/actions/apply/test_compute_scope.py -v
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+
+
+def _load(name: str, filename: str):
+    spec = importlib.util.spec_from_file_location(name, _HERE / filename)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+cs = _load("compute_scope", "compute-scope.py")
+me = _load("merge_envelopes", "merge-envelopes.py")
+
+
+class GlobToRegexTest(unittest.TestCase):
+    def _m(self, pattern: str, path: str) -> bool:
+        return cs.glob_to_regex(pattern).match(path) is not None
+
+    def test_double_star_crosses_directories(self):
+        self.assertTrue(self._m("docs/**", "docs/a/b/c.txt"))
+        self.assertTrue(self._m("docs/**", "docs/a.txt"))
+        self.assertTrue(self._m("docs/**", "docs"))
+        self.assertFalse(self._m("docs/**", "docs2/a.txt"))
+
+    def test_single_star_stays_in_segment(self):
+        self.assertTrue(self._m("docs/*.md", "docs/a.md"))
+        self.assertFalse(self._m("docs/*.md", "docs/sub/a.md"))
+
+    def test_bare_basename_matches_any_depth(self):
+        self.assertTrue(self._m("*.md", "README.md"))
+        self.assertTrue(self._m("*.md", "a/b/README.md"))
+        self.assertFalse(self._m("*.md", "a/b/README.txt"))
+
+    def test_leading_double_star(self):
+        self.assertTrue(self._m("**/*.md", "README.md"))
+        self.assertTrue(self._m("**/*.md", "a/b/c.md"))
+
+
+def _config(roots=("samples",), ignores=("docs/**", "**/*.md")) -> "cs.ScopeConfig":
+    return cs.ScopeConfig(list(roots), list(ignores))
+
+
+def _graph(ws: Path, *projects) -> list[dict]:
+    """projects: (path, rel_dir, has_plugin, deps)."""
+    out = []
+    for path, rel_dir, has_plugin, deps in projects:
+        out.append({
+            "path": path,
+            "dir": str(ws / rel_dir),
+            "hasPreviewPlugin": has_plugin,
+            "dependencies": list(deps),
+        })
+    return out
+
+
+class ResolveScopeTest(unittest.TestCase):
+    def setUp(self):
+        self.ws = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.ws)
+        self.graph = _graph(
+            self.ws,
+            (":", ".", False, []),
+            (":samples:app", "samples/app", True, [":samples:shared"]),
+            (":samples:wear", "samples/wear", True, [":samples:shared"]),
+            (":samples:shared", "samples/shared", False, []),
+        )
+        self.graph_calls = 0
+
+    def _resolve(self, files, want_graph=True, config=None):
+        def loader():
+            self.graph_calls += 1
+            return self.graph
+
+        return cs.resolve_scope(
+            files, config or _config(), self.ws, want_graph, loader
+        )
+
+    def test_docs_only_pr_is_none_without_touching_gradle(self):
+        self.assertEqual(self._resolve(["docs/setup.md", "README.md"]), "none")
+        self.assertEqual(self.graph_calls, 0)
+
+    def test_global_file_forces_full_without_touching_gradle(self):
+        self.assertEqual(
+            self._resolve(["gradle/libs.versions.toml", "docs/x.md"]), "full"
+        )
+        self.assertEqual(self.graph_calls, 0)
+
+    def test_module_change_scopes_to_that_module(self):
+        self.assertEqual(self._resolve(["samples/app/src/Main.kt"]), "samples:app")
+
+    def test_shared_module_expands_to_dependents(self):
+        self.assertEqual(
+            self._resolve(["samples/shared/src/Ui.kt"]),
+            "samples:app,samples:wear",
+        )
+
+    def test_mixed_ignored_and_module_changes_scope(self):
+        self.assertEqual(
+            self._resolve(["docs/x.md", "samples/wear/src/W.kt"]), "samples:wear"
+        )
+
+    def test_markdown_inside_module_still_scopes_the_module(self):
+        # Module ownership beats ignorePaths: content in a module can be a
+        # fixture the previews read.
+        self.assertEqual(self._resolve(["samples/app/notes.md"]), "samples:app")
+
+    def test_file_in_deleted_module_falls_back_to_full(self):
+        # samples/gone is not a project dir in the graph.
+        self.assertEqual(self._resolve(["samples/gone/Main.kt"]), "full")
+
+    def test_loose_file_under_scoped_root_falls_back_to_full(self):
+        self.assertEqual(self._resolve(["samples/orphan.txt"]), "full")
+
+    def test_without_graph_partial_scope_collapses_to_full(self):
+        self.assertEqual(
+            self._resolve(["samples/app/src/Main.kt"], want_graph=False), "full"
+        )
+        self.assertEqual(self.graph_calls, 0)
+
+    def test_no_plugin_modules_means_full(self):
+        self.graph = _graph(
+            self.ws,
+            (":", ".", False, []),
+            (":samples:app", "samples/app", False, []),
+        )
+        self.assertEqual(self._resolve(["samples/app/src/Main.kt"]), "full")
+
+    def test_changed_module_with_no_preview_dependents_is_none(self):
+        self.graph = _graph(
+            self.ws,
+            (":", ".", False, []),
+            (":samples:tool", "samples/tool", False, []),
+            (":samples:app", "samples/app", True, []),
+        )
+        self.assertEqual(self._resolve(["samples/tool/src/T.kt"]), "none")
+
+    def test_unresolvable_project_dependency_marker_fails_open(self):
+        self.graph = _graph(
+            self.ws,
+            (":samples:app", "samples/app", True, ["?"]),
+        )
+        with self.assertRaises(cs.ScopeError):
+            cs.load_graph(self._write_graph(self.graph))
+
+    def _write_graph(self, projects) -> Path:
+        p = self.ws / "graph.json"
+        p.write_text(json.dumps({"projects": projects}))
+        return p
+
+    def test_empty_diff_is_full(self):
+        self.assertEqual(self._resolve([]), "full")
+
+    def test_nested_project_dirs_pick_deepest_owner(self):
+        self.graph = _graph(
+            self.ws,
+            (":", ".", False, []),
+            (":samples:app", "samples/app", True, []),
+            (":samples:app:nested", "samples/app/nested", True, []),
+        )
+        self.assertEqual(
+            self._resolve(["samples/app/nested/src/N.kt"]), "samples:app:nested"
+        )
+        self.assertEqual(self._resolve(["samples/app/src/A.kt"]), "samples:app")
+
+
+class ScopeConfigLoadTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.tmp)
+
+    def test_missing_config_returns_none(self):
+        self.assertIsNone(cs.ScopeConfig.load(self.tmp / "absent.json"))
+
+    def test_malformed_config_raises(self):
+        p = self.tmp / "bad.json"
+        p.write_text("{nope")
+        with self.assertRaises(cs.ScopeError):
+            cs.ScopeConfig.load(p)
+
+    def test_empty_roots_raises(self):
+        p = self.tmp / "empty.json"
+        p.write_text(json.dumps({"scopedRoots": []}))
+        with self.assertRaises(cs.ScopeError):
+            cs.ScopeConfig.load(p)
+
+
+class MergeEnvelopesTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.tmp)
+
+    def _write(self, name: str, payload) -> Path:
+        p = self.tmp / name
+        p.write_text(payload if isinstance(payload, str) else json.dumps(payload))
+        return p
+
+    def _entry(self, module: str, pid: str) -> dict:
+        return {"id": pid, "module": module, "functionName": "F", "className": "K"}
+
+    def test_merges_previews_and_keeps_first_schema(self):
+        a = self._write("a.json", {
+            "schema": "compose-preview-show/v2",
+            "previews": [self._entry("samples:app", "A")],
+            "counts": {"total": 1, "changed": 1, "unchanged": 0, "missing": 0},
+        })
+        b = self._write("b.json", {
+            "schema": "compose-preview-show/v2",
+            "previews": [self._entry("samples:wear", "W")],
+        })
+        out = self.tmp / "out.json"
+        rc = me.main(["merge-envelopes.py", str(out), str(a), str(b)])
+        self.assertEqual(rc, 0)
+        merged = json.loads(out.read_text())
+        self.assertEqual(merged["schema"], "compose-preview-show/v2")
+        self.assertEqual([e["id"] for e in merged["previews"]], ["A", "W"])
+        self.assertNotIn("counts", merged)
+
+    def test_empty_input_is_tolerated(self):
+        a = self._write("a.json", {"schema": "s", "previews": [self._entry("m", "A")]})
+        b = self._write("b.json", "")
+        out = self.tmp / "out.json"
+        rc = me.main(["merge-envelopes.py", str(out), str(a), str(b)])
+        self.assertEqual(rc, 0)
+        self.assertEqual(len(json.loads(out.read_text())["previews"]), 1)
+
+    def test_bad_input_skipped_with_exit_1(self):
+        a = self._write("a.json", {"schema": "s", "previews": [self._entry("m", "A")]})
+        b = self._write("b.json", "{garbage")
+        out = self.tmp / "out.json"
+        rc = me.main(["merge-envelopes.py", str(out), str(a), str(b)])
+        self.assertEqual(rc, 1)
+        self.assertEqual(len(json.loads(out.read_text())["previews"]), 1)
+
+    def test_all_bad_inputs_exit_2_and_no_output(self):
+        b = self._write("b.json", "{garbage")
+        out = self.tmp / "out.json"
+        rc = me.main(["merge-envelopes.py", str(out), str(b)])
+        self.assertEqual(rc, 2)
+        self.assertFalse(out.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/actions/lib/compare-previews.py
+++ b/.github/actions/lib/compare-previews.py
@@ -863,6 +863,32 @@ def _emit_ab_comparisons(
             lines.append("")
 
 
+def _parse_scope_modules(args: argparse.Namespace) -> set[str] | None:
+    """Parse `--scope-modules` into a set of Gradle module paths, or None.
+
+    None means "full run" — every baseline entry participates in removed
+    detection. A set means the render was scoped to those modules only
+    (change-scoped PR run), so baseline entries for other modules must be
+    treated as unchanged rather than removed: their previews were simply
+    never rendered this run. Module paths are normalised without the
+    leading `:` to match the `module` field the CLI envelope carries.
+    """
+    raw = getattr(args, "scope_modules", None)
+    if not raw:
+        return None
+    modules = {m.strip().lstrip(":") for m in raw.split(",") if m.strip()}
+    return modules or None
+
+
+def _scope_note(scope_modules: set[str]) -> str:
+    mods = ", ".join(f"`{m}`" for m in sorted(scope_modules))
+    return (
+        f"_Change-scoped run: only {len(scope_modules)} module(s) rendered "
+        f"({mods}); other modules were unaffected by this PR's changes and "
+        f"kept their baselines._"
+    )
+
+
 def cmd_compare(args: argparse.Namespace) -> int:
     cli_json = Path(args.cli_json)
     baselines_path = Path(args.baselines)
@@ -872,6 +898,7 @@ def cmd_compare(args: argparse.Namespace) -> int:
     baseline_renders = (
         Path(args.baseline_renders) if getattr(args, "baseline_renders", None) else None
     )
+    scope_modules = _parse_scope_modules(args)
 
     current = load_cli_output(cli_json)
     baselines = _load_baselines(baselines_path)
@@ -943,6 +970,12 @@ def cmd_compare(args: argparse.Namespace) -> int:
     for key, bl_info in sorted(baselines.items()):
         if key in ab_keys:
             continue
+        # Change-scoped runs render a subset of modules; a baseline entry
+        # for an out-of-scope module is absent from `current` because it was
+        # never rendered, not because the preview went away — never report
+        # it as removed.
+        if scope_modules is not None and bl_info.get("module") not in scope_modules:
+            continue
         if key not in current:
             removed.append((key, bl_info))
 
@@ -957,8 +990,15 @@ def cmd_compare(args: argparse.Namespace) -> int:
         lines.append("")
         if unchanged:
             lines.append(f"_{len(unchanged)} preview(s) unchanged._")
+        if scope_modules is not None:
+            lines.append("")
+            lines.append(_scope_note(scope_modules))
         print("\n".join(lines))
         return 0
+
+    if scope_modules is not None:
+        lines.append(_scope_note(scope_modules))
+        lines.append("")
 
     if ab_groups:
         _emit_ab_comparisons(lines, ab_groups, repo, base_ref, head_ref)
@@ -1670,6 +1710,12 @@ def main() -> int:
                      help="Path to the A/B comparison config JSON "
                           "(default off; the apply action passes "
                           ".github/preview-abtest.json when present).")
+    cmp.add_argument("--scope-modules",
+                     help="Comma-separated Gradle module paths the render was "
+                          "scoped to (change-scoped PR runs). Baseline entries "
+                          "for modules outside this set are treated as "
+                          "unchanged instead of removed — they were never "
+                          "rendered this run. Omit for full runs.")
 
     cp = sub.add_parser("copy-changed", help="Copy new/changed PNGs to output dir")
     cp.add_argument("cli_json", help="Path to compose-preview show --json output")

--- a/.github/actions/lib/compare-previews.py
+++ b/.github/actions/lib/compare-previews.py
@@ -457,6 +457,11 @@ def cmd_generate(args: argparse.Namespace) -> int:
             "sourceFile": info["sourceFile"],
             "renderBasename": info["renderBasename"],
             "captureLabel": info["captureLabel"],
+            # Also encoded in the key (`<module>/<id>`); persisted explicitly
+            # so scoped compares don't have to parse it back out. Entries
+            # carried over from pre-field baselines may lack it — readers
+            # must fall back to the key (see _baseline_module).
+            "module": info["module"],
         }
         for key, info in previews.items()
         if info["sha256"]  # skip entries without a rendered PNG
@@ -880,6 +885,20 @@ def _parse_scope_modules(args: argparse.Namespace) -> set[str] | None:
     return modules or None
 
 
+def _baseline_module(key: str, bl_info: dict) -> str:
+    """Module of a baseline entry.
+
+    Baselines written before `module` was persisted (and the composable
+    baselines generally — see cmd_generate) only encode the module in the
+    key, `<module>/<previewId>[#idx]`. Module gradle paths use `:` and never
+    contain `/`, so the first segment is always the module.
+    """
+    mod = bl_info.get("module")
+    if mod:
+        return mod
+    return key.split("/", 1)[0]
+
+
 def _scope_note(scope_modules: set[str]) -> str:
     mods = ", ".join(f"`{m}`" for m in sorted(scope_modules))
     return (
@@ -974,7 +993,7 @@ def cmd_compare(args: argparse.Namespace) -> int:
         # for an out-of-scope module is absent from `current` because it was
         # never rendered, not because the preview went away — never report
         # it as removed.
-        if scope_modules is not None and bl_info.get("module") not in scope_modules:
+        if scope_modules is not None and _baseline_module(key, bl_info) not in scope_modules:
             continue
         if key not in current:
             removed.append((key, bl_info))

--- a/.github/actions/lib/test_compare_previews.py
+++ b/.github/actions/lib/test_compare_previews.py
@@ -783,6 +783,107 @@ class CompareMarkdownTest(unittest.TestCase):
         self.assertNotIn("NowPlayingSpatialPreview", out)
 
 
+class ScopedCompareTest(unittest.TestCase):
+    """`--scope-modules` marks the render as partial: baseline entries for
+    out-of-scope modules were never rendered this run, so they must never be
+    reported as removed."""
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.tmp)
+
+    def _run(self, current_payload, baselines_payload, scope: str | None) -> str:
+        cli_path = self.tmp / "cli.json"
+        cli_path.write_text(json.dumps(current_payload))
+        bl_path = self.tmp / "baselines.json"
+        bl_path.write_text(json.dumps(baselines_payload))
+
+        import io
+        import contextlib
+        from types import SimpleNamespace
+
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            cp.cmd_compare(SimpleNamespace(
+                cli_json=str(cli_path),
+                baselines=str(bl_path),
+                repo="owner/repo",
+                base_ref="deadbeef",
+                head_ref="cafef00d",
+                scope_modules=scope,
+            ))
+        return buf.getvalue()
+
+    def test_out_of_scope_baselines_are_not_removed(self):
+        # Render scoped to `app`; the `wear` baselines were never rendered.
+        out = self._run(
+            {"previews": [_entry(id="X", module="app", sha="s1", png="/p.png")]},
+            {
+                "app/X": {"sha256": "s1", "functionName": "Fn", "module": "app"},
+                "wear/Y": {"sha256": "s2", "functionName": "WearFn", "module": "wear"},
+            },
+            scope="app",
+        )
+        self.assertNotIn("### Removed", out)
+        self.assertIn("No visual changes detected.", out)
+        self.assertIn("Change-scoped run", out)
+
+    def test_unscoped_run_still_reports_removed(self):
+        out = self._run(
+            {"previews": [_entry(id="X", module="app", sha="s1", png="/p.png")]},
+            {
+                "app/X": {"sha256": "s1", "functionName": "Fn", "module": "app"},
+                "wear/Y": {"sha256": "s2", "functionName": "WearFn", "module": "wear"},
+            },
+            scope=None,
+        )
+        self.assertIn("### Removed", out)
+        self.assertIn("WearFn", out)
+
+    def test_in_scope_removal_still_detected(self):
+        # A preview deleted inside a scoped module must still show as removed.
+        out = self._run(
+            {"previews": [_entry(id="X", module="app", sha="s1", png="/p.png")]},
+            {
+                "app/X": {"sha256": "s1", "functionName": "Fn", "module": "app"},
+                "app/Gone": {"sha256": "s3", "functionName": "GoneFn", "module": "app"},
+                "wear/Y": {"sha256": "s2", "functionName": "WearFn", "module": "wear"},
+            },
+            scope="app",
+        )
+        self.assertIn("### Removed", out)
+        self.assertIn("GoneFn", out)
+        self.assertNotIn("WearFn", out)
+        self.assertIn("Change-scoped run", out)
+
+    def test_scope_accepts_colon_prefixed_csv(self):
+        out = self._run(
+            {"previews": [_entry(id="X", module="samples:app", sha="s1", png="/p.png")]},
+            {
+                "samples:app/X": {"sha256": "s1", "functionName": "Fn",
+                                  "module": "samples:app"},
+                "samples:wear/Y": {"sha256": "s2", "functionName": "WearFn",
+                                   "module": "samples:wear"},
+            },
+            scope=":samples:app, :samples:phone",
+        )
+        self.assertNotIn("### Removed", out)
+        self.assertIn("No visual changes detected.", out)
+
+    def test_changes_inside_scope_carry_scope_note(self):
+        out = self._run(
+            {"previews": [_entry(id="X", module="app", sha="new", png="/p.png")]},
+            {
+                "app/X": {"sha256": "old", "functionName": "Fn", "module": "app"},
+                "wear/Y": {"sha256": "s2", "functionName": "WearFn", "module": "wear"},
+            },
+            scope="app",
+        )
+        self.assertIn("### Changed", out)
+        self.assertNotIn("### Removed", out)
+        self.assertIn("Change-scoped run", out)
+
+
 class MultiCaptureLoadTest(unittest.TestCase):
     """`@ScrollingPreview(modes = [TOP, END])` / time fan-out: one preview
     must surface as one row per capture so each PNG shows up in the diff."""

--- a/.github/actions/lib/test_compare_previews.py
+++ b/.github/actions/lib/test_compare_previews.py
@@ -814,13 +814,18 @@ class ScopedCompareTest(unittest.TestCase):
             ))
         return buf.getvalue()
 
+    # The baseline fixtures below deliberately omit the `module` field: real
+    # composable baselines written before it was persisted only encode the
+    # module in the key (`<module>/<id>`), so scope filtering must work from
+    # the key alone (Codex review on PR #2195).
+
     def test_out_of_scope_baselines_are_not_removed(self):
         # Render scoped to `app`; the `wear` baselines were never rendered.
         out = self._run(
             {"previews": [_entry(id="X", module="app", sha="s1", png="/p.png")]},
             {
-                "app/X": {"sha256": "s1", "functionName": "Fn", "module": "app"},
-                "wear/Y": {"sha256": "s2", "functionName": "WearFn", "module": "wear"},
+                "app/X": {"sha256": "s1", "functionName": "Fn"},
+                "wear/Y": {"sha256": "s2", "functionName": "WearFn"},
             },
             scope="app",
         )
@@ -832,16 +837,34 @@ class ScopedCompareTest(unittest.TestCase):
         out = self._run(
             {"previews": [_entry(id="X", module="app", sha="s1", png="/p.png")]},
             {
-                "app/X": {"sha256": "s1", "functionName": "Fn", "module": "app"},
-                "wear/Y": {"sha256": "s2", "functionName": "WearFn", "module": "wear"},
+                "app/X": {"sha256": "s1", "functionName": "Fn"},
+                "wear/Y": {"sha256": "s2", "functionName": "WearFn"},
             },
             scope=None,
         )
         self.assertIn("### Removed", out)
         self.assertIn("WearFn", out)
 
-    def test_in_scope_removal_still_detected(self):
-        # A preview deleted inside a scoped module must still show as removed.
+    def test_in_scope_removal_still_detected_without_module_field(self):
+        # A preview deleted inside a scoped module must still show as removed,
+        # even though pre-field baselines carry no `module` value — the module
+        # is parsed from the key.
+        out = self._run(
+            {"previews": [_entry(id="X", module="app", sha="s1", png="/p.png")]},
+            {
+                "app/X": {"sha256": "s1", "functionName": "Fn"},
+                "app/Gone": {"sha256": "s3", "functionName": "GoneFn"},
+                "wear/Y": {"sha256": "s2", "functionName": "WearFn"},
+            },
+            scope="app",
+        )
+        self.assertIn("### Removed", out)
+        self.assertIn("GoneFn", out)
+        self.assertNotIn("WearFn", out)
+        self.assertIn("Change-scoped run", out)
+
+    def test_in_scope_removal_detected_with_module_field(self):
+        # Baselines written after `module` was persisted use the field directly.
         out = self._run(
             {"previews": [_entry(id="X", module="app", sha="s1", png="/p.png")]},
             {
@@ -854,16 +877,13 @@ class ScopedCompareTest(unittest.TestCase):
         self.assertIn("### Removed", out)
         self.assertIn("GoneFn", out)
         self.assertNotIn("WearFn", out)
-        self.assertIn("Change-scoped run", out)
 
     def test_scope_accepts_colon_prefixed_csv(self):
         out = self._run(
             {"previews": [_entry(id="X", module="samples:app", sha="s1", png="/p.png")]},
             {
-                "samples:app/X": {"sha256": "s1", "functionName": "Fn",
-                                  "module": "samples:app"},
-                "samples:wear/Y": {"sha256": "s2", "functionName": "WearFn",
-                                   "module": "samples:wear"},
+                "samples:app/X": {"sha256": "s1", "functionName": "Fn"},
+                "samples:wear/Y": {"sha256": "s2", "functionName": "WearFn"},
             },
             scope=":samples:app, :samples:phone",
         )
@@ -874,14 +894,38 @@ class ScopedCompareTest(unittest.TestCase):
         out = self._run(
             {"previews": [_entry(id="X", module="app", sha="new", png="/p.png")]},
             {
-                "app/X": {"sha256": "old", "functionName": "Fn", "module": "app"},
-                "wear/Y": {"sha256": "s2", "functionName": "WearFn", "module": "wear"},
+                "app/X": {"sha256": "old", "functionName": "Fn"},
+                "wear/Y": {"sha256": "s2", "functionName": "WearFn"},
             },
             scope="app",
         )
         self.assertIn("### Changed", out)
         self.assertNotIn("### Removed", out)
         self.assertIn("Change-scoped run", out)
+
+    def test_generate_persists_module_in_baselines(self):
+        # New baselines carry `module` explicitly so future readers don't
+        # need the key parse (old baselines still go through it).
+        import io
+        import contextlib
+        from types import SimpleNamespace
+
+        cli_path = self.tmp / "cli.json"
+        png = self.tmp / "p.png"
+        png.write_bytes(b"png")
+        cli_path.write_text(json.dumps(
+            {"previews": [_entry(id="X", module="app", sha="s1", png=str(png))]}
+        ))
+        out_dir = self.tmp / "out"
+        with contextlib.redirect_stdout(io.StringIO()):
+            cp.cmd_generate(SimpleNamespace(
+                cli_json=str(cli_path),
+                output_dir=str(out_dir),
+                repo="owner/repo",
+                branch="compose-preview/main",
+            ))
+        baselines = json.loads((out_dir / "baselines.json").read_text())
+        self.assertEqual(baselines["app/X"]["module"], "app")
 
 
 class MultiCaptureLoadTest(unittest.TestCase):

--- a/.github/preview-scope.json
+++ b/.github/preview-scope.json
@@ -1,0 +1,15 @@
+{
+  "//": "Change-scope config for the compose-preview apply action (see .github/actions/apply/README.md). PRs whose changes all live inside modules under scopedRoots render only those modules plus their Gradle dependents; PRs that only touch ignorePaths skip the preview pipelines. Anything else — the plugin, CLI, renderers, build wiring, CI — always triggers a full render.",
+  "scopedRoots": ["samples"],
+  "ignorePaths": [
+    "docs/**",
+    "**/*.md",
+    "vscode-extension/**",
+    ".githooks/**",
+    ".idea/**",
+    ".vscode/**",
+    "LICENSE",
+    ".gitignore",
+    ".gitattributes"
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -484,6 +484,8 @@ jobs:
         run: python3 .github/actions/lib/test_xr_gallery.py -v
       - name: Run apply skew-guard tests
         run: python3 .github/actions/apply/test_check_skew.py -v
+      - name: Run apply change-scope tests
+        run: python3 .github/actions/apply/test_compute_scope.py -v
 
   # VS Code extension tests — both the existing in-process Mocha suite and
   # the @vscode/test-electron integration tests. The latter download a

--- a/.github/workflows/compose-preview.yml
+++ b/.github/workflows/compose-preview.yml
@@ -4,9 +4,9 @@ name: Compose Preview
 # push-to-main, sticky diff comments on PRs, manual reruns via dispatch
 # (or the `/rerun previews` PR command — see pr-commands.yml).
 #
-# The four pipelines run as THREE PARALLEL JOBS (compose+resources / a11y /
-# notifications) rather than one serial `apply` invocation. They are
-# independent by construction — disjoint baseline/PR branches
+# The four pipelines run as TWO PARALLEL JOBS (compose+resources /
+# a11y+notifications) rather than one serial `apply` invocation. The two
+# jobs are independent — disjoint baseline/PR branches
 # (`compose-preview/{,resources/,a11y/,notifications/}…`) and disjoint
 # sticky-comment markers — and the old back-to-back ordering existed only
 # because one job shares a Gradle build lock and `.git`; separate runners
@@ -15,6 +15,14 @@ name: Compose Preview
 # used to serialize at 25–32 min; in parallel the PR gate is the slower of
 # the two). Compose and resources stay together: resources is cheap and its
 # comment reuses the compose run's `_base_sha` when available.
+# Notifications MUST stay in the same job as (and run after) a11y: its
+# staging globs whatever `*Notification*.png` the workspace accumulated,
+# and the FQN-named notification surface captures + `.notification.json`
+# sidecars in the notifications baseline come from the CLI/daemon-driven
+# a11y re-render, not from the raw `composePreviewRenderAll` invocation the
+# notifications pipeline itself makes. Running notifications on its own
+# runner stages only the two short-stem standard renders and falsely
+# reports every daemon-produced capture as removed (see PR #2195).
 #
 # Change-scoped rendering (.github/preview-scope.json): PR runs classify the
 # diff first — docs-only PRs skip all pipelines in under a minute, and PRs
@@ -44,9 +52,9 @@ concurrency:
 
 jobs:
   # Keeps the historical job id + check name ("Apply compose-preview") so
-  # existing branch-protection required checks continue to match. The a11y /
-  # notifications jobs below are new check names — add them to branch
-  # protection if they should gate merges too.
+  # existing branch-protection required checks continue to match. The
+  # a11y+notifications job below is a new check name — add it to branch
+  # protection if it should gate merges too.
   apply:
     if: ${{ !(startsWith(github.head_ref, 'release-please--') && github.event.pull_request.user.login == 'github-actions[bot]') }}
     name: Apply compose-preview
@@ -83,7 +91,7 @@ jobs:
 
   a11y:
     if: ${{ !(startsWith(github.head_ref, 'release-please--') && github.event.pull_request.user.login == 'github-actions[bot]') }}
-    name: A11y previews
+    name: A11y + notification previews
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -93,7 +101,10 @@ jobs:
       - uses: ./.github/actions/apply
         with:
           cli-version: source
-          only: a11y
+          # Order matters: `apply` runs a11y before notifications, and the
+          # notifications staging depends on the renders the a11y pass
+          # leaves in the shared workspace (see header comment).
+          only: a11y,notifications
           # Empty = auto-detect every module the CLI knows about, so the a11y
           # baseline covers the whole sample suite (overlays + legends on each
           # preview) instead of just one module. CMP / desktop modules are
@@ -104,20 +115,5 @@ jobs:
           # stamp the misleading global "ATF data unavailable" banner.
           a11y-module: ''
           a11y-skip-modules: ''
-          timeout: '1800'
-
-  notifications:
-    if: ${{ !(startsWith(github.head_ref, 'release-please--') && github.event.pull_request.user.login == 'github-actions[bot]') }}
-    name: Notification previews
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-      - uses: ./.github/actions/setup
-      - uses: ./.github/actions/apply
-        with:
-          cli-version: source
-          only: notifications
           notifications-module: 'samples:android'
           timeout: '1800'

--- a/.github/workflows/compose-preview.yml
+++ b/.github/workflows/compose-preview.yml
@@ -1,15 +1,28 @@
 name: Compose Preview
 
 # Single entry point for the compose-preview CI surface: baselines on
-# push-to-main, sticky diff comments on PRs, manual reruns via dispatch.
-# Replaces preview-baselines.yml, preview-comment.yml, a11y-report.yml,
-# and notification-previews.yml — the `apply` composite picks baseline-vs-
-# comment from the triggering event and runs the four pipelines (compose /
-# resources / a11y / notifications) back-to-back — they share the Gradle
-# build lock and the same `.git`, so `apply` serializes them on purpose
-# (see action.yml "Run pipelines"). Concurrency lives *inside* the compose
-# render: `composePreview { shards }` fans previews across parallel JVM
-# forks.
+# push-to-main, sticky diff comments on PRs, manual reruns via dispatch
+# (or the `/rerun previews` PR command — see pr-commands.yml).
+#
+# The four pipelines run as THREE PARALLEL JOBS (compose+resources / a11y /
+# notifications) rather than one serial `apply` invocation. They are
+# independent by construction — disjoint baseline/PR branches
+# (`compose-preview/{,resources/,a11y/,notifications/}…`) and disjoint
+# sticky-comment markers — and the old back-to-back ordering existed only
+# because one job shares a Gradle build lock and `.git`; separate runners
+# remove that constraint. Wall time drops from the sum of the pipelines to
+# the slowest one (the two full renders — compose and the a11y re-render —
+# used to serialize at 25–32 min; in parallel the PR gate is the slower of
+# the two). Compose and resources stay together: resources is cheap and its
+# comment reuses the compose run's `_base_sha` when available.
+#
+# Change-scoped rendering (.github/preview-scope.json): PR runs classify the
+# diff first — docs-only PRs skip all pipelines in under a minute, and PRs
+# that only touch `samples/**` render just the affected modules (plus Gradle
+# dependents) in the compose job. Anything touching the plugin / CLI /
+# renderers / build wiring renders everything, and baseline pushes on main
+# always render everything. Concurrency *within* a render is unchanged:
+# `composePreview { shards }` fans previews across parallel JVM forks.
 
 on:
   push:
@@ -30,6 +43,10 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Keeps the historical job id + check name ("Apply compose-preview") so
+  # existing branch-protection required checks continue to match. The a11y /
+  # notifications jobs below are new check names — add them to branch
+  # protection if they should gate merges too.
   apply:
     if: ${{ !(startsWith(github.head_ref, 'release-please--') && github.event.pull_request.user.login == 'github-actions[bot]') }}
     name: Apply compose-preview
@@ -47,17 +64,7 @@ jobs:
           # that change the previews.json schema don't render against a
           # stale released CLI. External consumers omit this input.
           cli-version: source
-          # Empty = auto-detect every module the CLI knows about, so the a11y
-          # baseline covers the whole sample suite (overlays + legends on each
-          # preview) instead of just one module. CMP / desktop modules are
-          # included too: ATF itself is Android-only, but the desktop daemon now
-          # produces an overlay-only a11y pass (the "what a screen reader sees"
-          # overlay + legend extracted from Compose semantics) with empty
-          # findings and `status=null`, so they show real overlays and never
-          # stamp the misleading global "ATF data unavailable" banner.
-          a11y-module: ''
-          a11y-skip-modules: ''
-          notifications-module: 'samples:android'
+          only: compose,resources
           # Per-Gradle-invocation ceiling for the render pipelines. The
           # action's 600s default is marginal for this repo's own all-module
           # render: identical jobs swing 23–32 minutes across runners, and on
@@ -73,3 +80,44 @@ jobs:
           # sheet, #2135) is marked `optional` at discovery, which the gate,
           # the CLI, and the diff bot all honour — see #2159 for the history
           # of the `warn` override this replaces.
+
+  a11y:
+    if: ${{ !(startsWith(github.head_ref, 'release-please--') && github.event.pull_request.user.login == 'github-actions[bot]') }}
+    name: A11y previews
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup
+      - uses: ./.github/actions/apply
+        with:
+          cli-version: source
+          only: a11y
+          # Empty = auto-detect every module the CLI knows about, so the a11y
+          # baseline covers the whole sample suite (overlays + legends on each
+          # preview) instead of just one module. CMP / desktop modules are
+          # included too: ATF itself is Android-only, but the desktop daemon now
+          # produces an overlay-only a11y pass (the "what a screen reader sees"
+          # overlay + legend extracted from Compose semantics) with empty
+          # findings and `status=null`, so they show real overlays and never
+          # stamp the misleading global "ATF data unavailable" banner.
+          a11y-module: ''
+          a11y-skip-modules: ''
+          timeout: '1800'
+
+  notifications:
+    if: ${{ !(startsWith(github.head_ref, 'release-please--') && github.event.pull_request.user.login == 'github-actions[bot]') }}
+    name: Notification previews
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup
+      - uses: ./.github/actions/apply
+        with:
+          cli-version: source
+          only: notifications
+          notifications-module: 'samples:android'
+          timeout: '1800'

--- a/.github/workflows/pr-commands.yml
+++ b/.github/workflows/pr-commands.yml
@@ -1,0 +1,145 @@
+name: PR Commands
+
+# Slash commands in PR comments, for maintainers. GitHub Actions has no
+# trigger for comment *reactions*, so commands are the available shape —
+# the workflow ACKs with a 🚀 reaction so the comment thread stays clean.
+#
+#   /rerun               re-run the failed jobs of every failed / cancelled
+#                        run on the PR's current head SHA (flaky render,
+#                        stale baseline race, runner hiccup)
+#   /rerun <target>      full re-run of the latest run of one workflow on
+#                        the head SHA. <target> is a workflow file stem
+#                        (`compose-preview`, `ci`, ...) or an alias:
+#                        previews -> compose-preview, vscode ->
+#                        vscode-preview-comment
+#   /rerun all           full re-run of every completed run on the head SHA
+#
+# Re-runs execute against the same commit the original run used, which is
+# exactly right for the common cases: a flaked render, or re-diffing after
+# the baseline branches moved (baselines are fetched at run time, not baked
+# into the trigger). A new push still supersedes everything via the normal
+# pull_request trigger + per-PR concurrency groups.
+#
+# issue_comment workflows always run the workflow file from the default
+# branch, so a PR cannot smuggle changes into this logic; the author gate
+# below additionally restricts commands to owners / members / collaborators.
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions: {}
+
+concurrency:
+  # One command at a time per PR; later commands queue rather than cancel.
+  group: pr-commands-${{ github.event.issue.number }}
+
+jobs:
+  rerun:
+    name: Rerun workflows
+    if: >-
+      ${{
+        github.event.issue.pull_request != null &&
+        startsWith(github.event.comment.body, '/rerun') &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+      }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write        # POST .../runs/{id}/rerun
+      issues: write         # reaction ACK + fallback reply comment
+      pull-requests: read   # resolve the PR head SHA
+    steps:
+      - name: Acknowledge command
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+        run: |
+          set -euo pipefail
+          gh api "repos/${REPO}/issues/comments/${COMMENT_ID}/reactions" \
+            -f content=rocket >/dev/null
+
+      - name: Rerun matching workflow runs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        run: |
+          set -euo pipefail
+
+          # First line only; everything after `/rerun` is the target.
+          cmd=$(printf '%s\n' "$COMMENT_BODY" | head -1 | tr -d '\r')
+          target=$(printf '%s' "$cmd" | sed -E 's|^/rerun[[:space:]]*||' \
+                   | tr '[:upper:]' '[:lower:]' | awk '{print $1}')
+
+          case "$target" in
+            previews) target="compose-preview" ;;
+            vscode)   target="vscode-preview-comment" ;;
+          esac
+
+          HEAD_SHA=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.head.sha')
+          echo "PR #${PR_NUMBER} head: ${HEAD_SHA}, target: '${target:-<failed>}'"
+
+          # Latest attempt of each workflow run on the head SHA.
+          runs=$(gh api "repos/${REPO}/actions/runs?head_sha=${HEAD_SHA}&per_page=100" \
+            --jq '[.workflow_runs[] | {id, path, status, conclusion, name}]')
+
+          reply() {
+            gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" -f body="$1" >/dev/null
+          }
+
+          count=$(printf '%s' "$runs" | jq 'length')
+          if [ "$count" -eq 0 ]; then
+            reply "\`/rerun\`: no workflow runs found for head \`${HEAD_SHA:0:8}\`."
+            exit 0
+          fi
+
+          rerun_one() {
+            local id="$1" mode="$2" name="$3"
+            if gh api -X POST "repos/${REPO}/actions/runs/${id}/${mode}" >/dev/null 2>&1; then
+              echo "re-ran ${name} (run ${id}, ${mode})"
+              return 0
+            fi
+            echo "could not re-run ${name} (run ${id}) — likely still in progress"
+            return 1
+          }
+
+          triggered=0
+          skipped=""
+          if [ -z "$target" ]; then
+            # Bare /rerun: failed jobs of failed / cancelled / timed-out runs.
+            while IFS=$'\t' read -r id status conclusion name; do
+              [ "$status" = "completed" ] || { skipped="$skipped $name(in-progress)"; continue; }
+              case "$conclusion" in
+                failure|cancelled|timed_out)
+                  rerun_one "$id" rerun-failed-jobs "$name" && triggered=$((triggered+1)) ;;
+              esac
+            done < <(printf '%s' "$runs" | jq -r '.[] | [.id, .status, .conclusion // "", .name] | @tsv')
+            if [ "$triggered" -eq 0 ]; then
+              reply "\`/rerun\`: nothing to re-run — no failed runs on head \`${HEAD_SHA:0:8}\`.${skipped:+ Still running:$skipped.} Use \`/rerun <workflow>\` (e.g. \`/rerun previews\`) to force a full re-run of a green workflow."
+            fi
+          elif [ "$target" = "all" ]; then
+            while IFS=$'\t' read -r id status conclusion name; do
+              [ "$status" = "completed" ] || { skipped="$skipped $name(in-progress)"; continue; }
+              rerun_one "$id" rerun "$name" && triggered=$((triggered+1))
+            done < <(printf '%s' "$runs" | jq -r '.[] | [.id, .status, .conclusion // "", .name] | @tsv')
+            [ "$triggered" -eq 0 ] && reply "\`/rerun all\`: nothing eligible — every run on head \`${HEAD_SHA:0:8}\` is still in progress."
+          else
+            # Named workflow: match the file stem under .github/workflows/.
+            match=$(printf '%s' "$runs" | jq -r --arg t "$target" \
+              '[.[] | select((.path | sub(".*/"; "") | sub("\\.ya?ml$"; "")) == $t)] | first // empty | [.id, .status, .name] | @tsv')
+            if [ -z "$match" ]; then
+              available=$(printf '%s' "$runs" | jq -r '[.[] | .path | sub(".*/"; "") | sub("\\.ya?ml$"; "")] | unique | join(", ")')
+              reply "\`/rerun ${target}\`: no run of that workflow on head \`${HEAD_SHA:0:8}\`. Workflows with runs on this commit: ${available}. Aliases: \`previews\`, \`vscode\`, \`all\`."
+              exit 0
+            fi
+            IFS=$'\t' read -r id status name <<< "$match"
+            if [ "$status" != "completed" ]; then
+              reply "\`/rerun ${target}\`: the latest **${name}** run is still in progress — wait for it to finish (or push again to restart it via the normal trigger)."
+              exit 0
+            fi
+            rerun_one "$id" rerun "$name" && triggered=$((triggered+1)) \
+              || reply "\`/rerun ${target}\`: GitHub refused to re-run **${name}** (run ${id}); see the Actions tab."
+          fi
+          echo "triggered: $triggered"


### PR DESCRIPTION
## Summary

Cuts compose-preview PR latency (currently ~25 min per PR push, ~30 min per baseline run — the single serial `apply` job dominates every PR) three ways:

### 1. Parallel pipeline jobs
`compose-preview.yml` now runs **two parallel jobs** — `Apply compose-preview` (compose+resources) and `A11y + notification previews` — instead of one serial `apply`. The two jobs are independent (disjoint baseline/PR branches, disjoint sticky-comment markers); the old back-to-back ordering only existed because a single job shares one Gradle build lock and one `.git`. Wall time drops from the *sum* of the two full renders to the *slower* one.

Notifications deliberately stays in the a11y job, ordered after it: its staging globs whatever `*Notification*.png` the workspace accumulated, and the FQN-named notification surface captures + `.notification.json` sidecars on the notifications baseline come from the CLI/daemon-driven a11y re-render, not from the raw `composePreviewRenderAll` the notifications pipeline itself invokes. An early revision of this PR ran notifications on its own runner and it staged only the two short-stem standard renders, falsely reporting all 22 daemon-produced captures as removed (visible in this PR's earlier notification sticky comment — since fixed, and the upsert now PATCHes a stale sticky comment to its resolved state on no-diff runs, mirroring the resources comment's four-state handling).

> **Branch protection:** the `Apply compose-preview` check name is preserved so the existing required check keeps matching. `A11y + notification previews` is a new name — add it to required checks if it should gate merges.

### 2. Change-scoped rendering (filter previews without missing things)
New `.github/preview-scope.json` + `scope-config` input on the apply action. PR comment runs classify the diff first:

- **docs-only PRs** (`ignorePaths`) skip the pipelines in under a minute;
- PRs whose changes all live under `samples/**` render **only the affected modules plus their transitive Gradle dependents** — the dependency graph is read from Gradle itself (`scope-project-graph.init.gradle`), so a shared-module change can never skip a dependent;
- **everything else fails open to a full render**: any file outside the scoped roots (plugin, CLI, renderers, build wiring, CI), unmappable/deleted-module files, a failed graph probe, or a build with no statically applied plugin (the auto-inject path).

`compare-previews.py` grows `--scope-modules`: out-of-scope baselines read as *unchanged*, never "Removed" (removals inside scoped modules are still detected — the module is parsed from the baseline key since older baselines don't persist a `module` field; new baselines now do), and the comment carries a "Change-scoped run" note. When a scoped-to-nothing push follows one that already posted sticky comments, the run falls back to full so the stale comment refreshes to its resolved state. Baseline runs on `main` and `workflow_dispatch` reruns always render everything. Only the compose pipeline renders scoped in v1 — resources/a11y/notifications treat a partial scope as full (they still benefit from the none-skip and the job split).

Per-preview (function-level) filtering is deliberately *not* attempted: any change inside a module can affect any preview in it (themes, resources, shared composables), so module granularity + Gradle dependency closure is the finest filter that provably misses nothing. (#2066 tracks name-level filtering as a CLI/dev feature, which is a different, correctness-unsafe-for-CI axis.)

### 3. `/rerun` PR commands
New `pr-commands.yml` (`issue_comment` trigger; GitHub has no trigger for comment *reactions*, so commands + a 🚀 reaction ACK is the available shape). Maintainers (OWNER/MEMBER/COLLABORATOR) can comment:

- `/rerun` — re-run failed jobs of every failed/cancelled run on the PR head SHA (flaked render, baseline race, runner hiccup)
- `/rerun previews` / `/rerun ci` / `/rerun <workflow-stem>` — full re-run of that workflow's latest run
- `/rerun all` — full re-run of every completed run on the head SHA

Re-runs execute against the same commit but fetch baselines fresh, which is exactly what a "baselines moved under me" rerun needs. The workflow file always runs from `main` (issue_comment semantics), so PRs can't alter the command logic.

## Test plan

- [x] `test_compare_previews.py` — 87 pass, incl. new `ScopedCompareTest` cases (out-of-scope not removed; unscoped still removes; in-scope removals detected from key-only baselines *and* module-field baselines; colon/csv parsing; scope note; `generate` persists `module`)
- [x] New `test_compute_scope.py` — 25 tests covering glob conversion, classification precedence, dependency-closure expansion, all fail-open paths, and envelope merging
- [x] `scope-project-graph.init.gradle` exercised end-to-end against a real Gradle build (project deps + dirs captured correctly, `ProjectDependency.getPath()` with legacy fallback)
- [x] `compute-scope.py` exercised end-to-end against a synthetic git repo: docs-only → `none`, module change without graph → `full`, global file → `full`, missing config → `full`, real `./gradlew` graph probe with no plugin markers → `full`
- [x] All other actions-lib suites still green; every embedded `run:` script passes `bash -n`; all changed YAML parses; zizmor reports no new findings on the changed files
- [x] Codex P1 (baselines don't persist `module`) confirmed and fixed — module parsed from the baseline key
- [x] Notifications-split regression caught on this PR's own run (bogus "22 removed" comment), root-caused via the staged findings on `compose-preview/notifications/pr` vs the baseline branch, fixed by grouping notifications after a11y
- [ ] On this PR's latest run: confirm the two jobs run in parallel and the notification sticky comment resolves
- [ ] First samples-only PR after merge: confirm the compose render scopes

Non-visual change (CI/build wiring only), so no before/after renders.