### PR TITLE
fix(renderer-desktop): refuse single-frame fall-through into scroll data products

### DIFF
--- a/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRendererMain.kt
+++ b/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRendererMain.kt
@@ -281,9 +281,16 @@ fun main(args: Array<String>) {
           fontScale = fontScale,
         )
       } else if (scrollDispatchMode != null) {
-        // @ScrollingPreview(modes = [LONG, GIF]) — drive the dedicated scroll path. Falls
-        // through to the default single-frame render on "no scrollable found" so a misuse
-        // produces SOMETHING on disk rather than a missing file.
+        // @ScrollingPreview(modes = [LONG, GIF]) — drive the dedicated scroll path. For a
+        // primary *capture*, falls through to the default single-frame render on "no
+        // scrollable found" so a misuse produces SOMETHING on disk rather than a missing
+        // file. For a *data product* output (under `data/render-scroll-*/`), mirror the
+        // Android renderer's rule (see RobolectricRenderTest's `productFellThrough`): a
+        // fall-through would write PNG bytes into a `.gif`-named product, or stamp the
+        // unscrolled first viewport into the long-scroll path, and the panel would surface
+        // a still frame under a "scroll gif" / "scroll long" label as if capture succeeded.
+        // Throw instead — the per-value catch below writes the structured `.error.json`
+        // sidecar so the panel surfaces the real failure.
         val didCapture =
           renderScrollPreview(
             className = className,
@@ -304,6 +311,13 @@ fun main(args: Array<String>) {
             fontScale = fontScale,
           )
         if (!didCapture) {
+          if (isDataProductOutput(targetFile)) {
+            throw IllegalStateException(
+              "@ScrollingPreview(${scrollDispatchMode.name}) on $className.$functionName: " +
+                "no scrollable composable found on axis ${scrollAxis.name} — refusing to " +
+                "write a single-frame capture into the data product path."
+            )
+          }
           renderPreview(
             className,
             functionName,
@@ -414,6 +428,15 @@ fun main(args: Array<String>) {
  */
 private fun errorSidecarFor(pngFile: File): File =
   File(pngFile.parentFile, pngFile.name + ".error.json")
+
+/**
+ * True when [outputFile] is a *data product* output — `<previews-root>/data/<kind>/<id>.<ext>`,
+ * e.g. the `data/render-scroll-{long,gif}/` paths `RenderPreviewsTask` resolves from
+ * `PreviewDataProduct.output` — rather than a primary capture (`renders/<id>.png`). Same
+ * grandparent-is-`data` convention the device-frame block in [main] uses to resolve the data dir.
+ */
+internal fun isDataProductOutput(outputFile: File): Boolean =
+  outputFile.parentFile?.parentFile?.name == "data"
 
 private fun writeErrorSidecar(
   pngFile: File,

--- a/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/ScrollProductRefusalTest.kt
+++ b/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/ScrollProductRefusalTest.kt
@@ -1,0 +1,125 @@
+package ee.schimke.composeai.renderer
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import java.io.File
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * Fixture for the refusal tests below: no scrollable anywhere in the composition, so the LONG / GIF
+ * scroll driver's semantics query finds nothing and `renderScrollPreview` declines.
+ */
+@Composable
+fun NoScrollableFixture() {
+  Box(modifier = Modifier.fillMaxSize().background(Color.Red))
+}
+
+/**
+ * Issue #2191 — when `renderScrollPreview` declines ("no scrollable found"), the desktop renderer
+ * must NOT fall through to a single-frame render into a *data product* output
+ * (`data/render-scroll-{long,gif}/`): that writes PNG bytes into a `.gif`-named product, or stamps
+ * the unscrolled first viewport into the long-scroll path, and the panel shows a still frame under
+ * a "scroll gif" label as if capture succeeded. Mirrors the Android renderer's rule
+ * (RobolectricRenderTest's `productFellThrough`): write the structured `.error.json` sidecar
+ * instead. Primary captures (`renders/<id>.png`) keep the "produce SOMETHING on disk" fall-through.
+ */
+class ScrollProductRefusalTest {
+
+  @get:Rule val tempFolder: TemporaryFolder = TemporaryFolder()
+
+  private val fixtureClass = "ee.schimke.composeai.renderer.ScrollProductRefusalTestKt"
+
+  private fun rendererArgs(outputFile: File, scrollMode: String): Array<String> =
+    arrayOf(
+      fixtureClass,
+      "NoScrollableFixture",
+      "100",
+      "160",
+      "1.0",
+      "true",
+      "0",
+      outputFile.absolutePath,
+      "", // wrapperClassName
+      "false", // wrapWidth
+      "false", // wrapHeight
+      "", // previewParameterProviderFqn
+      "0", // previewParameterLimit
+      "", // localeTag
+      scrollMode,
+      "VERTICAL",
+      "0", // scrollMaxScrollPx
+      "0", // scrollFrameIntervalMs
+    )
+
+  @Test
+  fun `gif data product with no scrollable writes an error sidecar, not png bytes into the gif`() {
+    val previewsRoot = tempFolder.newFolder("compose-previews")
+    val outputFile = previewsRoot.resolve("data/render-scroll-gif/NoScrollableFixture.gif")
+
+    main(rendererArgs(outputFile, scrollMode = "GIF"))
+
+    assertFalse("no .gif must be written when capture declined", outputFile.exists())
+    val sidecar = File(outputFile.parentFile, outputFile.name + ".error.json")
+    assertTrue("structured error sidecar must be written", sidecar.exists())
+    val json = sidecar.readText()
+    assertTrue(json.contains("compose-preview-error/v1"))
+    assertTrue(json.contains("no scrollable composable found"))
+    assertTrue(json.contains("refusing to"))
+    assertTrue(json.contains("data product path"))
+  }
+
+  @Test
+  fun `long data product with no scrollable writes an error sidecar, not the unscrolled frame`() {
+    val previewsRoot = tempFolder.newFolder("compose-previews")
+    val outputFile = previewsRoot.resolve("data/render-scroll-long/NoScrollableFixture.png")
+
+    main(rendererArgs(outputFile, scrollMode = "LONG"))
+
+    assertFalse("no long-scroll PNG must be written when capture declined", outputFile.exists())
+    val sidecar = File(outputFile.parentFile, outputFile.name + ".error.json")
+    assertTrue("structured error sidecar must be written", sidecar.exists())
+    assertTrue(sidecar.readText().contains("no scrollable composable found"))
+  }
+
+  @Test
+  fun `refusal deletes a stale product left behind by a previous fall-through`() {
+    val previewsRoot = tempFolder.newFolder("compose-previews")
+    val outputFile = previewsRoot.resolve("data/render-scroll-gif/NoScrollableFixture.gif")
+    outputFile.parentFile.mkdirs()
+    // A PNG-bytes-in-.gif artefact from a run predating the refusal — must not survive.
+    outputFile.writeBytes(byteArrayOf(1, 2, 3))
+
+    main(rendererArgs(outputFile, scrollMode = "GIF"))
+
+    assertFalse("stale mislabelled product must be deleted", outputFile.exists())
+    assertTrue(File(outputFile.parentFile, outputFile.name + ".error.json").exists())
+  }
+
+  @Test
+  fun `primary capture keeps the single-frame fall-through`() {
+    val previewsRoot = tempFolder.newFolder("compose-previews")
+    val outputFile = previewsRoot.resolve("renders/NoScrollableFixture.png")
+
+    main(rendererArgs(outputFile, scrollMode = "LONG"))
+
+    assertTrue("capture path still falls through to a single frame", outputFile.exists())
+    assertTrue(outputFile.length() > 0)
+    assertFalse(File(outputFile.parentFile, outputFile.name + ".error.json").exists())
+  }
+
+  @Test
+  fun `isDataProductOutput matches the data grandparent convention`() {
+    assertTrue(isDataProductOutput(File("/x/data/render-scroll-gif/a.gif")))
+    assertTrue(isDataProductOutput(File("/x/data/render-scroll-long/a.png")))
+    assertFalse(isDataProductOutput(File("/x/renders/a.png")))
+    assertFalse(isDataProductOutput(File("a.png")))
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #2191.

When `renderScrollPreview` declines (`didCapture == false`, e.g. no scrollable found on the requested axis), `DesktopRendererMain` fell through to a plain `renderPreview` into the same output file — including `@ScrollingPreview(modes = [LONG, GIF])` *data-product* outputs under `data/render-scroll-gif/` / `data/render-scroll-long/`. That wrote PNG bytes into a `.gif`-named product, or stamped the unscrolled first viewport into the long-scroll path, with no error sidecar — the exact write the Android renderer explicitly refuses (`RobolectricRenderTest`'s `productFellThrough`).

This mirrors the Android rule on desktop:

- **Primary captures** (`renders/<id>.png`) keep the fall-through — a misuse still produces something on disk.
- **Data-product outputs** (grandparent dir is `data/` — the same path convention the device-frame block in `main()` already uses) now throw instead, so the existing per-value catch writes the structured `.error.json` sidecar and no single-frame product is written. The sidecar writer also deletes any stale mislabelled product left by a previous run, and the error message matches the Android renderer's wording.

The daemon path (`daemon/desktop` `RenderEngine.runScrollScenario`) already errors on this case, so the standalone renderer was the only divergent entry point.

## Test plan

- New `ScrollProductRefusalTest` drives `main()` end-to-end with a scroll-less fixture composable:
  - GIF data product → no `.gif` written, structured `.error.json` sidecar with the refusal message.
  - LONG data product → no PNG written, sidecar written.
  - Stale PNG-bytes-in-`.gif` artefact from a prior run is deleted by the refusal.
  - Primary capture (`renders/…`) keeps the single-frame fall-through, no sidecar.
  - `isDataProductOutput` unit checks for the `data/` grandparent convention.
- Note: this sandbox cannot fetch the Gradle 9.6 distribution (network egress blocks its GitHub-hosted download), so the new tests were not executed locally — CI is the verification gate for this PR. The touched files were formatted with the pinned ktfmt 0.62 (google style) standalone.

Non-visual change (error-path plumbing for data products): successful renders are byte-identical, so there is no before/after render pair to embed. The user-visible effect is the VS Code panel surfacing a structured error instead of a mislabelled still frame; CI runs the new renderer tests that assert the on-disk artefacts.

---
_Generated by [Claude Code](https://claude.ai/code/session_012sQ55gd5XPdiPfMwvr2maK)_