### PR TITLE
fix: honour @AnimatedPreview durationMs=0 auto-detect on the desktop renderer

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderPreviewsTask.kt
@@ -332,13 +332,19 @@ abstract class RenderPreviewsTask : DefaultTask() {
           preview.params.showSystemUi.toString(),
           preview.params.uiMode.toString(),
           preview.params.device.orEmpty(),
-          // 25th–27th — `@AnimatedPreview` window. `0` durationMs signals "no animation intent"
-          // (the renderer falls through to scroll / single-frame). A positive durationMs dispatches
-          // to `renderAnimatedPreview` (a `runSkikoComposeUiTest` paused-clock loop that advances
-          // `mainClock` by frameIntervalMs across the window and encodes the frames as a GIF) —
-          // the desktop counterpart of the Android renderer's `@AnimatedPreview` path. `showCurves`
-          // is forwarded for parity; the desktop path emits a screenshot-only GIF (no curve strip).
-          (animation?.durationMs ?: 0).toString(),
+          // 25th–27th — `@AnimatedPreview` window. `-1` durationMs signals "no animation intent"
+          // (the renderer falls through to scroll / single-frame). `>= 0` means the annotation is
+          // present and dispatches to `renderAnimatedPreview` (a `runSkikoComposeUiTest`
+          // paused-clock loop that advances `mainClock` by frameIntervalMs across the window and
+          // encodes the frames as a GIF) — the desktop counterpart of the Android renderer's
+          // `@AnimatedPreview` path. `0` is the annotation's auto-detect sentinel and must NOT be
+          // collapsed into "no animation": a default-args `@AnimatedPreview` still needs the
+          // animated path or the `.gif` renderOutput gets a single PNG frame (issue #2190). An
+          // older renderer that predates the `-1` protocol parses it via `takeIf { it > 0 } ?: 0`,
+          // so the sentinel degrades to the old "no animation" behaviour rather than breaking.
+          // `showCurves` is forwarded for parity; the desktop path emits a screenshot-only GIF (no
+          // curve strip).
+          (animation?.durationMs ?: -1).toString(),
           (animation?.frameIntervalMs ?: 0).toString(),
           (animation?.showCurves ?: false).toString(),
         )

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderPreviewsTask.kt
@@ -341,7 +341,11 @@ abstract class RenderPreviewsTask : DefaultTask() {
           // collapsed into "no animation": a default-args `@AnimatedPreview` still needs the
           // animated path or the `.gif` renderOutput gets a single PNG frame (issue #2190). An
           // older renderer that predates the `-1` protocol parses it via `takeIf { it > 0 } ?: 0`,
-          // so the sentinel degrades to the old "no animation" behaviour rather than breaking.
+          // so the sentinel degrades to the old "no animation" behaviour rather than breaking. The
+          // reverse skew (an older plugin driving a newer renderer pinned on the
+          // `composePreviewRenderer` configuration) is guarded renderer-side: a bare `0` is only
+          // read as auto-detect when the capture is animation-shaped (a `.gif` output with no
+          // scroll intent).
           // `showCurves` is forwarded for parity; the desktop path emits a screenshot-only GIF (no
           // curve strip).
           (animation?.durationMs ?: -1).toString(),

--- a/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopAnimatedRenderer.kt
+++ b/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopAnimatedRenderer.kt
@@ -37,6 +37,17 @@ private const val MAX_ANIMATION_DURATION_MS = 5000
 private const val DEFAULT_ANIMATION_FRAME_INTERVAL_MS = 33
 
 /**
+ * Window used when `durationMs == 0` (the annotation's auto-detect sentinel). The Android renderer
+ * answers auto-detect by asking `PreviewAnimationClock` how long the discovered animations run and
+ * falls back to 1500ms when nothing was measured; the desktop test harness doesn't expose that
+ * inspection surface (see the [renderAnimatedPreview] note on [showCurves]), so auto-detect here
+ * always resolves to the same fallback the Android path uses when measurement comes up empty.
+ * Matches `DEFAULT_ANIMATION_DURATION_MS` in the `preview-annotations` KDoc and Android's
+ * `AUTO_DURATION_FALLBACK_MS`.
+ */
+private const val AUTO_DURATION_FALLBACK_MS = 1500
+
+/**
  * Renders an `@AnimatedPreview` capture on Compose Desktop as an animated GIF — the desktop
  * counterpart of the Android renderer's paused-clock animation path.
  *
@@ -50,6 +61,10 @@ private const val DEFAULT_ANIMATION_FRAME_INTERVAL_MS = 33
  *
  * Unlike the scroll path there's no "no scrollable found" decline — any composable produces frames
  * (a static one just yields identical frames) — so this always writes [outputFile] or throws.
+ *
+ * [durationMs] follows the annotation contract: a positive value is the explicit window; `0` (the
+ * auto-detect sentinel, and the annotation default) captures [AUTO_DURATION_FALLBACK_MS] because
+ * this backend can't measure the discovered animations — see the constant's KDoc.
  *
  * `LocalInspectionMode` is provided as `false` here (the scroll / single-frame paths use `true`):
  * some components short-circuit their animations when they detect preview/inspection mode, and an
@@ -96,7 +111,20 @@ fun renderAnimatedPreview(
 
   val frameInterval =
     if (frameIntervalMs > 0) frameIntervalMs else DEFAULT_ANIMATION_FRAME_INTERVAL_MS
-  val totalDuration = durationMs.coerceIn(frameInterval, MAX_ANIMATION_DURATION_MS)
+  // `0` is the annotation's auto-detect sentinel. Desktop can't measure the animation (no
+  // PreviewAnimationClock inspection on this harness), so it takes the same fallback window the
+  // Android path uses when measurement finds nothing — a real multi-frame GIF rather than the
+  // single PNG frame this case used to degrade to (issue #2190).
+  val autoDetect = durationMs <= 0
+  if (autoDetect) {
+    System.err.println(
+      "@AnimatedPreview(durationMs = 0) on ${outputFile.name}: duration auto-detection isn't " +
+        "supported on the desktop backend — capturing the ${AUTO_DURATION_FALLBACK_MS}ms fallback " +
+        "window (set an explicit durationMs to override)."
+    )
+  }
+  val requestedDuration = if (autoDetect) AUTO_DURATION_FALLBACK_MS else durationMs
+  val totalDuration = requestedDuration.coerceIn(frameInterval, MAX_ANIMATION_DURATION_MS)
   val frameCount = (totalDuration / frameInterval).coerceAtLeast(1)
 
   val pseudolocale = ee.schimke.composeai.data.pseudolocale.Pseudolocale.fromTag(localeTag)

--- a/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRendererMain.kt
+++ b/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRendererMain.kt
@@ -155,12 +155,15 @@ fun main(args: Array<String>) {
   val showSystemUi = args.getOrNull(21)?.toBoolean() ?: false
   val uiMode = args.getOrNull(22)?.toIntOrNull() ?: 0
   val device = args.getOrNull(23)?.takeIf { it.isNotBlank() }
-  // Args 25–27 — `@AnimatedPreview` window. A positive `animDurationMs` is the animation intent; it
-  // dispatches to [renderAnimatedPreview] (paused-clock GIF) ahead of the scroll / single-frame
-  // paths. `0` (the default for non-animated previews) leaves the existing behaviour untouched.
-  // Mutually exclusive with `@ScrollingPreview` in discovery, so no precedence ambiguity in
-  // practice; the renderer still checks animation first defensively.
-  val animDurationMs = args.getOrNull(24)?.toIntOrNull()?.takeIf { it > 0 } ?: 0
+  // Args 25–27 — `@AnimatedPreview` window. `-1` (or missing/unparseable, for older callers) means
+  // "no animation intent". `>= 0` means the annotation is present and dispatches to
+  // [renderAnimatedPreview] (paused-clock GIF) ahead of the scroll / single-frame paths — `0` is
+  // the annotation's auto-detect sentinel, NOT "no animation": collapsing it into the single-frame
+  // path wrote PNG bytes into the `.gif` renderOutput (issue #2190). Mutually exclusive with
+  // `@ScrollingPreview` in discovery, so no precedence ambiguity in practice; the renderer still
+  // checks animation first defensively.
+  val animDurationMs = args.getOrNull(24)?.toIntOrNull() ?: -1
+  val hasAnimation = animDurationMs >= 0
   val animFrameIntervalMs = args.getOrNull(25)?.toIntOrNull()?.coerceAtLeast(0) ?: 0
   val animShowCurves = args.getOrNull(26)?.toBoolean() ?: false
   if (previewKind == "LOTTIE") {
@@ -259,10 +262,10 @@ fun main(args: Array<String>) {
       // VS Code would surface yesterday's exception as if it were current.
       val sidecar = errorSidecarFor(targetFile)
       if (sidecar.exists()) sidecar.delete()
-      if (animDurationMs > 0) {
+      if (hasAnimation) {
         // `@AnimatedPreview` — advance a paused clock across the window and encode a GIF. Always
         // produces output (an animation has no "no scrollable" decline path), so no fallback to the
-        // single-frame render is needed.
+        // single-frame render is needed. durationMs == 0 asks the renderer to auto-detect.
         renderAnimatedPreview(
           className = className,
           functionName = functionName,

--- a/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRendererMain.kt
+++ b/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRendererMain.kt
@@ -162,8 +162,22 @@ fun main(args: Array<String>) {
   // path wrote PNG bytes into the `.gif` renderOutput (issue #2190). Mutually exclusive with
   // `@ScrollingPreview` in discovery, so no precedence ambiguity in practice; the renderer still
   // checks animation first defensively.
-  val animDurationMs = args.getOrNull(24)?.toIntOrNull() ?: -1
-  val hasAnimation = animDurationMs >= 0
+  //
+  // Version skew: a *pre-fix* plugin (a consumer can pin a newer renderer on the
+  // `composePreviewRenderer` configuration while its plugin lags) sent `0` for EVERY preview
+  // without an `@AnimatedPreview`, so a bare `0` is ambiguous between "legacy: no animation" and
+  // "new: auto-detect". Disambiguate by the capture's other intent signals: an animated capture
+  // never carries scroll intent and discovery always points its renderOutput at a `.gif`, while a
+  // legacy caller's `0` accompanies a `.png` output (static) or a scroll mode (scroll GIF). A `0`
+  // that fails that shape check falls through to the scroll / single-frame paths — exactly the
+  // legacy behaviour those callers expect.
+  val animDurationArg = args.getOrNull(24)?.toIntOrNull() ?: -1
+  val hasAnimation =
+    animDurationArg > 0 ||
+      (animDurationArg == 0 &&
+        scrollDispatchMode == null &&
+        outputFile.extension.equals("gif", ignoreCase = true))
+  val animDurationMs = animDurationArg.coerceAtLeast(0)
   val animFrameIntervalMs = args.getOrNull(25)?.toIntOrNull()?.coerceAtLeast(0) ?: 0
   val animShowCurves = args.getOrNull(26)?.toBoolean() ?: false
   if (previewKind == "LOTTIE") {

--- a/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/AnimatedRenderTestFixtures.kt
+++ b/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/AnimatedRenderTestFixtures.kt
@@ -1,0 +1,42 @@
+package ee.schimke.composeai.renderer
+
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+
+/**
+ * Test fixture for [DesktopAnimatedRendererTest] — a white dot sweeping left-to-right across a
+ * black field once per second, so successive captured frames are visually distinct at any frame
+ * interval ≥ ~30ms. Top-level so the renderer can reflect it the way it reflects a consumer's
+ * `@Preview` (`Class.forName("…AnimatedRenderTestFixturesKt")` + `getDeclaredComposableMethod`).
+ */
+@Composable
+fun SweepingDot() {
+  val transition = rememberInfiniteTransition(label = "sweep")
+  val fraction by
+    transition.animateFloat(
+      initialValue = 0f,
+      targetValue = 1f,
+      animationSpec =
+        infiniteRepeatable(tween(durationMillis = 1000, easing = LinearEasing), RepeatMode.Restart),
+      label = "fraction",
+    )
+  Box(modifier = Modifier.size(64.dp).background(Color.Black)) {
+    Box(
+      modifier =
+        Modifier.offset(x = 48.dp * fraction, y = 24.dp).size(16.dp).background(Color.White)
+    )
+  }
+}

--- a/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/DesktopAnimatedRendererTest.kt
+++ b/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/DesktopAnimatedRendererTest.kt
@@ -104,6 +104,20 @@ class DesktopAnimatedRendererTest {
     assertTrue("no-animation renders stay PNG", isPng(outputFile))
   }
 
+  @Test
+  fun `main keeps a legacy caller's zero on the single-frame path for png outputs`() {
+    // A pre-fix RenderPreviewsTask (possible when a consumer pins a newer renderer on the
+    // `composePreviewRenderer` configuration while its plugin lags) sent `0` for every preview
+    // without an `@AnimatedPreview`. That `0` must not be read as auto-detect intent when the
+    // capture's shape says "static preview" — a `.png` renderOutput.
+    val outputFile = File(tempFolder.newFolder("renders"), "legacy.png")
+
+    main(rendererArgs(outputFile, animDurationMs = "0"))
+
+    assertTrue("PNG must exist and be non-empty", outputFile.exists() && outputFile.length() > 0)
+    assertTrue("legacy zero + .png output must stay a single-frame PNG", isPng(outputFile))
+  }
+
   /**
    * Builds the full 27-slot positional arg list `RenderPreviewsTask.invokeRenderer` sends, with
    * everything defaulted except the output path and the 25th (`animDurationMs`) slot under test.

--- a/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/DesktopAnimatedRendererTest.kt
+++ b/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/DesktopAnimatedRendererTest.kt
@@ -1,0 +1,174 @@
+package ee.schimke.composeai.renderer
+
+import java.io.ByteArrayInputStream
+import java.io.File
+import javax.imageio.ImageIO
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * Covers [renderAnimatedPreview]'s duration contract and, at the [main] level, the
+ * animated-vs-single-frame dispatch. The regression pinned here is issue #2190: `durationMs = 0` is
+ * `@AnimatedPreview`'s auto-detect sentinel (and its default), but the renderer used to gate the
+ * animated path on `durationMs > 0` — so a default-args `@AnimatedPreview` fell through to the
+ * single-frame path and PNG bytes were written into the `.gif`-named output.
+ */
+class DesktopAnimatedRendererTest {
+
+  @get:Rule val tempFolder: TemporaryFolder = TemporaryFolder()
+
+  private val fixtureClass = "ee.schimke.composeai.renderer.AnimatedRenderTestFixturesKt"
+  private val fixtureFunction = "SweepingDot"
+
+  @Test
+  fun `auto-detect sentinel captures the fallback window as a real multi-frame gif`() {
+    val outputFile = File(tempFolder.newFolder("renders"), "auto.gif")
+
+    renderAnimatedPreview(
+      className = fixtureClass,
+      functionName = fixtureFunction,
+      widthPx = 64,
+      heightPx = 64,
+      density = 1.0f,
+      showBackground = false,
+      backgroundColor = 0L,
+      outputFile = outputFile,
+      wrapperClassName = null,
+      previewArgs = emptyList(),
+      localeTag = null,
+      durationMs = 0,
+      frameIntervalMs = 100,
+      showCurves = false,
+    )
+
+    assertTrue("GIF must exist and be non-empty", outputFile.exists() && outputFile.length() > 0)
+    assertTrue("output must be GIF-encoded, not PNG", isGif(outputFile))
+    // 1500ms fallback window / 100ms interval → 15 frames.
+    assertEquals(15, readGifFrameCount(outputFile))
+    assertTrue("frames 0 and 5 should differ across the sweep", framesDiffer(outputFile, 0, 5))
+  }
+
+  @Test
+  fun `explicit duration overrides the fallback`() {
+    val outputFile = File(tempFolder.newFolder("renders"), "explicit.gif")
+
+    renderAnimatedPreview(
+      className = fixtureClass,
+      functionName = fixtureFunction,
+      widthPx = 64,
+      heightPx = 64,
+      density = 1.0f,
+      showBackground = false,
+      backgroundColor = 0L,
+      outputFile = outputFile,
+      wrapperClassName = null,
+      previewArgs = emptyList(),
+      localeTag = null,
+      durationMs = 500,
+      frameIntervalMs = 100,
+      showCurves = false,
+    )
+
+    assertEquals(5, readGifFrameCount(outputFile))
+  }
+
+  @Test
+  fun `main dispatches the auto-detect sentinel to the animated path`() {
+    val outputFile = File(tempFolder.newFolder("renders"), "dispatch.gif")
+
+    main(rendererArgs(outputFile, animDurationMs = "0"))
+
+    val sidecar = File(outputFile.parentFile, outputFile.name + ".error.json")
+    assertTrue(
+      "render must not fail: ${if (sidecar.exists()) sidecar.readText() else ""}",
+      !sidecar.exists(),
+    )
+    assertTrue("GIF must exist and be non-empty", outputFile.exists() && outputFile.length() > 0)
+    assertTrue(
+      "durationMs=0 (@AnimatedPreview default) must produce GIF bytes, not a PNG frame",
+      isGif(outputFile),
+    )
+    assertTrue("auto-detect must capture multiple frames", readGifFrameCount(outputFile) > 1)
+  }
+
+  @Test
+  fun `main keeps previews without animation intent on the single-frame path`() {
+    val outputFile = File(tempFolder.newFolder("renders"), "static.png")
+
+    main(rendererArgs(outputFile, animDurationMs = "-1"))
+
+    assertTrue("PNG must exist and be non-empty", outputFile.exists() && outputFile.length() > 0)
+    assertTrue("no-animation renders stay PNG", isPng(outputFile))
+  }
+
+  /**
+   * Builds the full 27-slot positional arg list `RenderPreviewsTask.invokeRenderer` sends, with
+   * everything defaulted except the output path and the 25th (`animDurationMs`) slot under test.
+   */
+  private fun rendererArgs(outputFile: File, animDurationMs: String): Array<String> =
+    arrayOf(
+      fixtureClass,
+      fixtureFunction,
+      "64",
+      "64",
+      "1.0",
+      "false",
+      "0",
+      outputFile.absolutePath,
+      "", // wrapperClassName
+      "false", // wrapWidth
+      "false", // wrapHeight
+      "", // previewParameterProviderFqn
+      "0", // previewParameterLimit
+      "", // localeTag
+      "", // scrollMode
+      "", // scrollAxis
+      "0", // scrollMaxScrollPx
+      "0", // scrollFrameIntervalMs
+      "COMPOSE", // previewKind
+      "", // assetPath
+      "1.0", // fontScale
+      "false", // showSystemUi
+      "0", // uiMode
+      "", // device
+      animDurationMs,
+      "33", // animFrameIntervalMs
+      "false", // animShowCurves
+    )
+
+  private fun isGif(file: File): Boolean {
+    val header = file.inputStream().use { it.readNBytes(6) }
+    return header.size == 6 &&
+      String(header, Charsets.US_ASCII).let { it == "GIF87a" || it == "GIF89a" }
+  }
+
+  private fun isPng(file: File): Boolean {
+    val header = file.inputStream().use { it.readNBytes(8) }
+    val pngMagic = byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A)
+    return header.contentEquals(pngMagic)
+  }
+
+  private fun readGifFrameCount(file: File): Int {
+    val reader = ImageIO.getImageReadersByFormatName("gif").next()
+    ImageIO.createImageInputStream(ByteArrayInputStream(file.readBytes())).use { stream ->
+      reader.input = stream
+      return reader.getNumImages(true)
+    }
+  }
+
+  private fun framesDiffer(file: File, a: Int, b: Int): Boolean {
+    val reader = ImageIO.getImageReadersByFormatName("gif").next()
+    ImageIO.createImageInputStream(ByteArrayInputStream(file.readBytes())).use { stream ->
+      reader.input = stream
+      val imgA = reader.read(a)
+      val imgB = reader.read(b)
+      for (y in 0 until imgA.height) for (x in 0 until imgA.width) {
+        if (imgA.getRGB(x, y) != imgB.getRGB(x, y)) return true
+      }
+      return false
+    }
+  }
+}

--- a/samples/cmp/src/main/kotlin/com/example/samplecmp/AnimatedPreviews.kt
+++ b/samples/cmp/src/main/kotlin/com/example/samplecmp/AnimatedPreviews.kt
@@ -1,0 +1,73 @@
+package com.example.samplecmp
+
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import ee.schimke.composeai.preview.AnimatedPreview
+
+/**
+ * Default-args `@AnimatedPreview` — the auto-detect sentinel (`durationMs = 0`) exercised
+ * end-to-end on the CMP/desktop backend.
+ *
+ * This fixture exists as the regression guard for issue #2190: the desktop renderer used to treat
+ * `durationMs = 0` as "no animation" and PNG-encode a single frame into the `.gif` renderOutput.
+ * With the fix, a default-args annotation dispatches to the animated path and the desktop backend
+ * captures its auto-detect fallback window (1500ms — this harness can't measure the animation, see
+ * `AUTO_DURATION_FALLBACK_MS` in `DesktopAnimatedRenderer`). The dot bounces once per second, so a
+ * correct capture shows visible motion across ~1.5 periods; a regressed capture is a frozen frame.
+ *
+ * Everything on the annotation is deliberately left at its default (`durationMs = 0`,
+ * `frameIntervalMs = 33`, `showCurves = true` — which the desktop backend degrades to a
+ * screenshot-only GIF with a logged note).
+ */
+@Preview(name = "Animated — Auto-Detect Duration", widthDp = 220, heightDp = 80)
+@AnimatedPreview
+@Composable
+fun AutoDetectDurationAnimatedPreview() {
+  val transition = rememberInfiniteTransition(label = "auto-detect-slider")
+  val fraction by
+    transition.animateFloat(
+      initialValue = 0f,
+      targetValue = 1f,
+      animationSpec =
+        infiniteRepeatable(tween(durationMillis = 1000, easing = LinearEasing), RepeatMode.Reverse),
+      label = "fraction",
+    )
+  Box(modifier = Modifier.fillMaxSize().background(Color(0xFF102030)).padding(16.dp)) {
+    Box(
+      modifier =
+        Modifier.fillMaxWidth()
+          .height(6.dp)
+          .align(Alignment.CenterStart)
+          .background(Color(0xFF2A4A6A), RoundedCornerShape(3.dp))
+    )
+    Box(
+      modifier =
+        Modifier.align(Alignment.CenterStart)
+          // Track is 220dp minus 32dp padding; the 24dp dot sweeps the remaining 164dp.
+          .offset(x = 164.dp * fraction)
+          .size(24.dp)
+          .background(Color(0xFF64D2FF), CircleShape)
+    )
+  }
+}


### PR DESCRIPTION
Fixes #2190.

## Summary

A CMP `@AnimatedPreview` with default args (`durationMs = 0`, the documented auto-detect sentinel) silently degraded to a single-frame render: the desktop renderer gated the animated path on `durationMs > 0`, so `renderPreview` PNG-encoded one frame into the `.gif`-named renderOutput — frozen frame or decode failure, no error sidecar, exit 0.

- **Arg protocol** (`RenderPreviewsTask` → `DesktopRendererMain`): the plugin previously collapsed "no `@AnimatedPreview`" and "auto-detect requested" both to `0`. It now sends `-1` for "no animation intent"; `>= 0` means the annotation is present and dispatches to `renderAnimatedPreview`. Version-skew safe both ways: an older renderer parses `-1` via `takeIf { it > 0 } ?: 0` (old behaviour), and a newer renderer treats a missing arg as `-1`. For the reverse skew (a pre-fix plugin driving a newer renderer pinned on the `composePreviewRenderer` configuration, which sent `0` for every non-animated preview), a bare `0` is only read as auto-detect when the capture is animation-shaped — a `.gif` output with no scroll intent — so legacy static previews stay on the single-frame path and legacy scroll GIFs keep the scroll path.
- **Auto-detect on desktop** (`DesktopAnimatedRenderer`): `durationMs == 0` now captures a 1500 ms fallback window — the same fallback the Android renderer uses when `PreviewAnimationClock` measurement finds nothing. The desktop test harness doesn't expose that inspection surface (same limitation already documented for `showCurves`), so auto-detect always resolves to the fallback there, with a logged note and override hint.
- **Regression fixture**: `samples/cmp/.../AnimatedPreviews.kt` adds a default-args `@AnimatedPreview` (sweeping-dot slider) so the auto-detect path is rendered by the preview pipeline on every PR from now on.

## Visual evidence

Before this fix, a default-args `@AnimatedPreview` produced a *file with PNG bytes under a `.gif` name* — a single frozen frame that GIF decoders reject, so there is no "before" animation to show; that broken output is the bug.

After the fix, the CI preview pipeline rendered the new default-args fixture as a real animated GIF, verified byte-level: GIF89a, 45 frames (= the 1500 ms fallback window ÷ 33 ms default frame interval), dot visibly sweeping. **The rendered GIF is embedded inline in the preview-diff bot's "Preview Changes" comment directly below** (section "New", `AutoDetectDurationAnimatedPreview`, pinned to render commit `4701aa3`). It is not repeated here only because this PR body was authored through a tool layer that defangs embedded URLs — the pixels are one scroll down on this page.

## Test plan

- New `DesktopAnimatedRendererTest` (renderers/desktop):
  - `durationMs = 0` via `renderAnimatedPreview` → real multi-frame GIF spanning the 1500 ms fallback (exact frame count, frames visibly differ across the sweep).
  - explicit `durationMs` still overrides.
  - `main()`-level dispatch with the full 27-slot arg vector: `"0"` + `.gif` output → GIF magic bytes + multi-frame (the exact regression); `"-1"` → single-frame PNG path unchanged; legacy `"0"` + `.png` output → stays a single-frame PNG (pre-fix-plugin skew guard).
- Existing explicit-duration sample previews (`ShaderPreviews`, `ShaderGalleryPreviews`) cover the `durationMs > 0` path end-to-end.
- CI preview pipeline renders the new fixture on every PR (see the preview-diff comment).