### PR TITLE
fix: stop stale fan-out cleanup deleting sibling previews' renders

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderPreviewsTask.kt
@@ -145,7 +145,7 @@ abstract class RenderPreviewsTask : DefaultTask() {
     val outDir = outputDir.get().asFile
     outDir.mkdirs()
 
-    renderWithCompose(manifest, outDir)
+    renderWithCompose(manifest, rawManifest, outDir)
 
     val tierTag =
       if (isFastTier)
@@ -154,7 +154,11 @@ abstract class RenderPreviewsTask : DefaultTask() {
     logger.lifecycle("Rendered ${manifest.previews.size} preview(s)$tierTag")
   }
 
-  private fun renderWithCompose(manifest: PreviewManifest, outDir: java.io.File) {
+  private fun renderWithCompose(
+    manifest: PreviewManifest,
+    rawManifest: PreviewManifest,
+    outDir: java.io.File,
+  ) {
     // This path is only used for desktop rendering.
     // Android rendering uses a separate Test-type task (see ComposePreviewPlugin).
     val mainClass = "ee.schimke.composeai.renderer.DesktopRendererMainKt"
@@ -165,6 +169,17 @@ abstract class RenderPreviewsTask : DefaultTask() {
     // The `dataProductsDir` task output, when wired by the plugin, points at that same `data/`
     // directory so Gradle tracks the written artifacts for caching / up-to-date checks.
     val previewsRoot = outDir.parentFile
+
+    // Every output file the manifest lays claim to, resolved the same way the render loops below
+    // resolve theirs. Built from the RAW manifest — a tier/kind-filtered preview's files stay on
+    // disk and must still be protected from a sibling's stale fan-out cleanup (issue #2193).
+    val manifestOutputFiles =
+      rawManifest.previews.flatMap { p ->
+        p.captures.map { c ->
+          if (c.renderOutput.isNotEmpty()) previewsRoot.resolve(c.renderOutput)
+          else outDir.resolve("${p.id}.png")
+        } + p.dataProducts.filter { it.output.isNotBlank() }.map { previewsRoot.resolve(it.output) }
+      }
 
     // Device frame — prefetch the needed bezels (Ktor/OkHttp, here in the Gradle JVM) into the
     // shared cache before launching renderer subprocesses, which only read that cache. See
@@ -220,6 +235,7 @@ abstract class RenderPreviewsTask : DefaultTask() {
           outputFile = outputFile,
           scroll = capture.scroll,
           animation = capture.animation,
+          fanoutSiblingStems = fanoutSiblingStems(manifestOutputFiles, outputFile),
         )
       }
 
@@ -241,6 +257,7 @@ abstract class RenderPreviewsTask : DefaultTask() {
           heightPx = heightPx,
           outputFile = outputFile,
           scroll = product.scroll,
+          fanoutSiblingStems = fanoutSiblingStems(manifestOutputFiles, outputFile),
         )
       }
     }
@@ -256,6 +273,7 @@ abstract class RenderPreviewsTask : DefaultTask() {
     outputFile: java.io.File,
     scroll: ScrollCapture?,
     animation: AnimationCapture? = null,
+    fanoutSiblingStems: List<String> = emptyList(),
   ) {
     execOperations.javaexec {
       classpath = renderClasspath
@@ -341,7 +359,36 @@ abstract class RenderPreviewsTask : DefaultTask() {
           (animation?.durationMs ?: 0).toString(),
           (animation?.frameIntervalMs ?: 0).toString(),
           (animation?.showCurves ?: false).toString(),
+          // 28th — sibling stems the renderer's `@PreviewParameter` stale fan-out cleanup must
+          // leave alone (issue #2193): manifest outputs in the same directory whose stem extends
+          // this capture's (`Foo` vs the `@Preview(name = "Dark")` sibling's `Foo_Dark`). The
+          // subprocess has no manifest, so without this it treats every `<stem>_*` file as its
+          // own fan-out and deletes the sibling's renders. Empty string signals "no siblings".
+          fanoutSiblingStems.joinToString("|"),
         )
     }
   }
+}
+
+/**
+ * Stems (filenames without extension) of manifest outputs in the same directory as [outputFile]
+ * whose name extends [outputFile]'s stem with an underscore — exactly the files the desktop
+ * renderer's prefix-greedy `deleteStaleFanoutFiles` would otherwise mistake for its own
+ * `@PreviewParameter` fan-out (issue #2193). `@Preview(name = "Dark")` on `Foo` yields the sibling
+ * stem `Foo_Dark`; both its base PNG and its own fan-out (`Foo_Dark_<label>.png`) match `Foo_*`.
+ *
+ * Joined with `|` on the renderer command line — discovery's `sanitizeForPath` strips `|` from
+ * every stem, so the separator can't collide.
+ */
+internal fun fanoutSiblingStems(
+  manifestOutputFiles: List<java.io.File>,
+  outputFile: java.io.File,
+): List<String> {
+  val prefix = outputFile.nameWithoutExtension + "_"
+  return manifestOutputFiles
+    .filter { it.parentFile == outputFile.parentFile && it != outputFile }
+    .map { it.nameWithoutExtension }
+    .filter { it.startsWith(prefix) }
+    .distinct()
+    .sorted()
 }

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/FanoutSiblingStemsTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/FanoutSiblingStemsTest.kt
@@ -1,0 +1,59 @@
+package ee.schimke.composeai.plugin
+
+import com.google.common.truth.Truth.assertThat
+import java.io.File
+import org.junit.Test
+
+/**
+ * Pins [fanoutSiblingStems] — the plugin-side half of the issue #2193 fix. The desktop renderer's
+ * `@PreviewParameter` stale fan-out cleanup is prefix-greedy inside its own subprocess, so the
+ * plugin must tell it which same-directory manifest outputs extend the current stem (`Foo` vs the
+ * `@Preview(name = "Dark")` sibling's `Foo_Dark…`) and are therefore never stale.
+ */
+class FanoutSiblingStemsTest {
+
+  private val rendersDir = File("/previews/renders")
+
+  private fun render(name: String) = File(rendersDir, name)
+
+  @Test
+  fun `returns same-directory stems extending the output stem`() {
+    val outputs =
+      listOf(
+        render("Foo.png"),
+        render("Foo_Dark.png"),
+        render("Foo_Selected.gif"),
+        render("Bar.png"),
+      )
+    assertThat(fanoutSiblingStems(outputs, render("Foo.png")))
+      .containsExactly("Foo_Dark", "Foo_Selected")
+      .inOrder()
+  }
+
+  @Test
+  fun `ignores outputs in other directories and non-extending stems`() {
+    val outputs =
+      listOf(
+        File("/previews/data/render-scroll-long", "Foo_Dark.png"),
+        render("Foobar.png"),
+        render("Foo.png"),
+      )
+    assertThat(fanoutSiblingStems(outputs, render("Foo.png"))).isEmpty()
+  }
+
+  @Test
+  fun `reverse direction only protects deeper extensions`() {
+    // Rendering the `Foo_Dark` variant: plain `Foo` doesn't match its prefix (nothing to
+    // protect), but a hypothetical deeper `Foo_Dark_TIME_500ms` capture does.
+    val outputs = listOf(render("Foo.png"), render("Foo_Dark_TIME_500ms.png"))
+    assertThat(fanoutSiblingStems(outputs, render("Foo_Dark.png")))
+      .containsExactly("Foo_Dark_TIME_500ms")
+  }
+
+  @Test
+  fun `deduplicates stems shared by several captures`() {
+    // The same sibling stem can appear once per capture (e.g. a PNG and a GIF product).
+    val outputs = listOf(render("Foo_Dark.png"), render("Foo_Dark.gif"))
+    assertThat(fanoutSiblingStems(outputs, render("Foo.png"))).containsExactly("Foo_Dark")
+  }
+}

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -131,12 +131,13 @@ object PreviewManifestLoader {
         // path (`composePreviewRenderLottie`), not Robolectric — there's no Android Lottie player
         // and the asset is portable IR. Drop both before any expansion so they never reach
         // `strategyFor`.
-        val expanded =
+        val expandedByEntry =
             manifest.previews
                 .filter {
                     it.params.kind != PreviewKind.XR_SUBSPACE && it.params.kind != PreviewKind.LOTTIE
                 }
-                .flatMap { expandParameterProvider(it) }
+                .map { it to expandParameterProvider(it) }
+        val expanded = expandedByEntry.flatMap { it.second }
         // Tier filter (set by the plugin via TierSystemPropProvider). When
         // `fast`, drop heavyweight captures and annotation-sourced data
         // products. Heavy outputs keep their previous files on disk and stay
@@ -156,8 +157,21 @@ object PreviewManifestLoader {
                 )
             }
         }
-        return assignToShard(filtered, shardCount, shardIndex)
-            .map { arrayOf<Any>(it.entry, it.previewArgs) }
+        val ours = assignToShard(filtered, shardCount, shardIndex)
+        // The renderer is authoritative about which fan-out files will exist
+        // for its parameterized previews — delete any `<stem>_*<ext>` files
+        // from prior runs that today's manifest doesn't account for. Guards
+        // against provider renames ("loading" → "busy") and the
+        // `_PARAM_<idx>` → `_<label>` migration leaving a mix of old-shape
+        // and new-shape PNGs on disk. Runs at shard-load time, before any
+        // test body writes to the directory.
+        deleteStaleFanoutFiles(
+            outDir = System.getProperty("composeai.render.outputDir")?.let(::File),
+            allEntries = manifest.previews,
+            expandedByEntry = expandedByEntry,
+            ownedIds = ours.map { it.entry.id }.toSet(),
+        )
+        return ours.map { arrayOf<Any>(it.entry, it.previewArgs) }
     }
 
     internal data class PreviewRow(val entry: RenderPreviewEntry, val previewArgs: List<Any?>)
@@ -245,44 +259,66 @@ object PreviewManifestLoader {
                 listOf(value),
             )
         }
-        // The renderer is authoritative about which fan-out files will exist
-        // for this preview — delete any `<stem>_*<ext>` files from prior runs
-        // that aren't in this run's expected output. Guards against provider
-        // renames ("loading" → "busy") and the `_PARAM_<idx>` → `_<label>`
-        // migration leaving a mix of old-shape and new-shape PNGs on disk.
-        // Runs at shard-load time so it fires once per parameterized preview,
-        // before any test body writes to the directory.
-        deleteStaleFanoutFiles(entry.captures, rows)
         return rows
     }
 
-    private fun deleteStaleFanoutFiles(
-        templateCaptures: List<RenderPreviewCapture>,
-        expanded: List<PreviewRow>,
+    /**
+     * Deletes stale `<stem>_*<ext>` fan-out files for the parameterized previews in
+     * [expandedByEntry].
+     *
+     * Two guards keep the prefix match from destroying correct sibling output (issue #2193):
+     * - **Manifest-wide expected set.** `@Preview(name = …)` / `@Preview(group = …)` variant
+     *   suffixes make a sibling preview's stem an underscore-extension of the base stem
+     *   (`Foo` vs `Foo_Dark`), so the sibling's base render and its own fan-out
+     *   (`Foo_Dark_<label>.png`) match `Foo_*`. The exclusion set therefore spans every manifest
+     *   entry's outputs — declared ([allEntries]) and expanded ([expandedByEntry]) — not just the
+     *   preview whose prefix is being swept.
+     * - **Shard-owned pass.** Every parallel fork (`maxParallelForks = shardCount`) expands the
+     *   whole manifest at shard load, at a time when sibling forks may already be rendering —
+     *   under the old per-entry expected set a late-loading fork would delete fan-out PNGs
+     *   another fork had just written. The manifest-wide set makes that impossible (every fork's
+     *   outputs are expected), and gating the sweep on [ownedIds] additionally keeps forks whose
+     *   shard was assigned none of a preview's fan-out from redundantly re-sweeping its prefix.
+     */
+    internal fun deleteStaleFanoutFiles(
+        outDir: File?,
+        allEntries: List<RenderPreviewEntry>,
+        expandedByEntry: List<Pair<RenderPreviewEntry, List<PreviewRow>>>,
+        ownedIds: Set<String>,
     ) {
-        val outDirPath = System.getProperty("composeai.render.outputDir") ?: return
-        val outDir = File(outDirPath)
-        if (!outDir.isDirectory) return
-        val expectedNames = expanded.flatMap { it.entry.captures }
-            .mapNotNull { fanoutLeaf(it.renderOutput) }
-            .toSet()
-        for (template in templateCaptures) {
-            val templateFile = File(outDir, template.renderOutput.substringAfter("renders/"))
-            val dir = templateFile.parentFile ?: continue
-            val stem = templateFile.nameWithoutExtension
-            val ext = ".${templateFile.extension}"
-            val prefix = stem + "_"
-            dir.listFiles()
-                ?.filter { f ->
-                    f.name.startsWith(prefix) &&
-                        f.name.endsWith(ext) &&
-                        f.name !in expectedNames
-                }
-                ?.forEach { f ->
-                    if (!f.delete()) {
-                        System.err.println("Failed to delete stale fan-out file: ${f.absolutePath}")
+        if (outDir == null || !outDir.isDirectory) return
+        val expectedNames = buildSet {
+            allEntries
+                .flatMap { it.captures }
+                .mapNotNullTo(this) { fanoutLeaf(it.renderOutput) }
+            expandedByEntry
+                .flatMap { it.second }
+                .flatMap { it.entry.captures }
+                .mapNotNullTo(this) { fanoutLeaf(it.renderOutput) }
+        }
+        for ((entry, rows) in expandedByEntry) {
+            if (entry.params.previewParameterProviderClassName == null) continue
+            if (rows.none { it.entry.id in ownedIds }) continue
+            for (template in entry.captures) {
+                val templateFile = File(outDir, template.renderOutput.substringAfter("renders/"))
+                val dir = templateFile.parentFile ?: continue
+                val stem = templateFile.nameWithoutExtension
+                val ext = ".${templateFile.extension}"
+                val prefix = stem + "_"
+                dir.listFiles()
+                    ?.filter { f ->
+                        f.name.startsWith(prefix) &&
+                            f.name.endsWith(ext) &&
+                            f.name !in expectedNames
                     }
-                }
+                    ?.forEach { f ->
+                        if (!f.delete()) {
+                            System.err.println(
+                                "Failed to delete stale fan-out file: ${f.absolutePath}",
+                            )
+                        }
+                    }
+            }
         }
     }
 

--- a/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/PreviewManifestLoaderStaleFanoutTest.kt
+++ b/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/PreviewManifestLoaderStaleFanoutTest.kt
@@ -1,0 +1,133 @@
+package ee.schimke.composeai.renderer
+
+import ee.schimke.composeai.renderer.PreviewManifestLoader.PreviewRow
+import java.io.File
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * Pins the stale fan-out cleanup in [PreviewManifestLoader.deleteStaleFanoutFiles], in particular
+ * the two issue #2193 guards:
+ * - the expected set spans the whole manifest, so a sibling preview whose stem underscore-extends
+ *   the swept one's (`Foo` vs the `@Preview(name = "Dark")` variant `Foo_Dark`) never has its
+ *   base render or fan-out classified as stale;
+ * - the sweep only runs for previews with a row assigned to this shard, so a fork that owns none
+ *   of a preview's fan-out doesn't touch its prefix.
+ */
+class PreviewManifestLoaderStaleFanoutTest {
+
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    private fun entry(
+        id: String,
+        parameterized: Boolean,
+        vararg renderOutputs: String,
+    ): RenderPreviewEntry =
+        RenderPreviewEntry(
+            id = id,
+            functionName = id,
+            className = "com.example.PreviewsKt",
+            params = RenderPreviewParams(
+                previewParameterProviderClassName =
+                    if (parameterized) "com.example.UserProvider" else null,
+            ),
+            captures = renderOutputs.map { RenderPreviewCapture(renderOutput = it) },
+        )
+
+    /** An expanded (suffixed) row of [base], the shape `expandParameterProvider` produces. */
+    private fun fanoutRow(base: RenderPreviewEntry, suffix: String): PreviewRow =
+        PreviewRow(
+            base.copy(
+                id = base.id + suffix,
+                captures = base.captures.map {
+                    it.copy(
+                        renderOutput = PreviewManifestLoader.insertBeforeExtension(
+                            it.renderOutput,
+                            suffix,
+                        ),
+                    )
+                },
+            ),
+            listOf(Any()),
+        )
+
+    @Test
+    fun `deletes stale fan-out but keeps expected, sibling base and sibling fan-out files`() {
+        val foo = entry("Foo", parameterized = true, "renders/Foo.png")
+        val fooDark = entry("Foo_Dark", parameterized = true, "renders/Foo_Dark.png")
+        val fooSelected = entry("Foo_Selected", parameterized = false, "renders/Foo_Selected.png")
+        val expandedByEntry = listOf(
+            foo to listOf(fanoutRow(foo, "_Alice"), fanoutRow(foo, "_Bob")),
+            fooDark to listOf(fanoutRow(fooDark, "_Alice"), fanoutRow(fooDark, "_Bob")),
+            fooSelected to listOf(PreviewRow(fooSelected, emptyList())),
+        )
+
+        tmp.newFile("Foo_Alice.png") // expected fan-out of Foo
+        tmp.newFile("Foo_Dark_Alice.png") // sibling's fan-out — matches Foo_* but isn't ours
+        tmp.newFile("Foo_Selected.png") // non-parameterized sibling's base render
+        tmp.newFile("Foo_PARAM_0.png") // stale: pre-label-migration shape
+        tmp.newFile("Foo_stale.png") // stale: renamed provider value
+        tmp.newFile("Foo_Dark_stale.png") // stale under the sibling's prefix
+
+        PreviewManifestLoader.deleteStaleFanoutFiles(
+            outDir = tmp.root,
+            allEntries = listOf(foo, fooDark, fooSelected),
+            expandedByEntry = expandedByEntry,
+            ownedIds = expandedByEntry.flatMap { it.second }.map { it.entry.id }.toSet(),
+        )
+
+        assertTrue(File(tmp.root, "Foo_Alice.png").exists())
+        assertTrue(File(tmp.root, "Foo_Dark_Alice.png").exists())
+        assertTrue(File(tmp.root, "Foo_Selected.png").exists())
+        assertFalse(File(tmp.root, "Foo_PARAM_0.png").exists())
+        assertFalse(File(tmp.root, "Foo_stale.png").exists())
+        assertFalse(File(tmp.root, "Foo_Dark_stale.png").exists())
+    }
+
+    @Test
+    fun `sweeps only previews with a row assigned to this shard`() {
+        val foo = entry("Foo", parameterized = true, "renders/Foo.png")
+        val fooDark = entry("Foo_Dark", parameterized = true, "renders/Foo_Dark.png")
+        val expandedByEntry = listOf(
+            foo to listOf(fanoutRow(foo, "_Alice")),
+            fooDark to listOf(fanoutRow(fooDark, "_Alice")),
+        )
+
+        tmp.newFile("Foo_stale.png")
+        tmp.newFile("Foo_Dark_stale.png")
+
+        PreviewManifestLoader.deleteStaleFanoutFiles(
+            outDir = tmp.root,
+            allEntries = listOf(foo, fooDark),
+            expandedByEntry = expandedByEntry,
+            // This fork's shard was assigned only the Foo_Dark fan-out.
+            ownedIds = setOf("Foo_Dark_Alice"),
+        )
+
+        // Foo's prefix belongs to another shard: left alone (including files that would be stale
+        // in a full sweep). Foo_Dark's prefix is ours: its stale file goes.
+        assertTrue(File(tmp.root, "Foo_stale.png").exists())
+        assertFalse(File(tmp.root, "Foo_Dark_stale.png").exists())
+    }
+
+    @Test
+    fun `non-parameterized previews never trigger a sweep`() {
+        val plain = entry("Foo", parameterized = false, "renders/Foo.png")
+        val expandedByEntry = listOf(plain to listOf(PreviewRow(plain, emptyList())))
+
+        tmp.newFile("Foo_anything.png")
+
+        PreviewManifestLoader.deleteStaleFanoutFiles(
+            outDir = tmp.root,
+            allEntries = listOf(plain),
+            expandedByEntry = expandedByEntry,
+            ownedIds = setOf("Foo"),
+        )
+
+        assertTrue(File(tmp.root, "Foo_anything.png").exists())
+    }
+}

--- a/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRendererMain.kt
+++ b/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRendererMain.kt
@@ -68,6 +68,12 @@ import org.jetbrains.skia.EncodedImageFormat
  * inside a single JVM — instead of spawning one subprocess per value — avoids N× Compose cold-start
  * cost; the same `ImageComposeScene` is reused across values.
  *
+ * The optional 28th argument is a `|`-joined list of sibling stems: filenames (without extension)
+ * of OTHER manifest outputs in the same directory whose stem extends this preview's (`@Preview(name
+ * = "Dark")` on `Foo` yields sibling stem `Foo_Dark`). The `@PreviewParameter` stale fan-out
+ * cleanup must leave those siblings' files alone — see [deleteStaleFanoutFiles] (issue #2193). `|`
+ * is safe as a separator because discovery's `sanitizeForPath` strips it from every stem.
+ *
  * Args 15–18 carry `@ScrollingPreview` intent. When [scrollMode] is `"LONG"` or `"GIF"` the
  * renderer leaves the [ImageComposeScene] path and dispatches to [renderScrollPreview] (which uses
  * `runComposeUiTest` for paused-clock + semantic scroll). `"TOP"` / `"END"` / empty are handled by
@@ -163,6 +169,9 @@ fun main(args: Array<String>) {
   val animDurationMs = args.getOrNull(24)?.toIntOrNull()?.takeIf { it > 0 } ?: 0
   val animFrameIntervalMs = args.getOrNull(25)?.toIntOrNull()?.coerceAtLeast(0) ?: 0
   val animShowCurves = args.getOrNull(26)?.toBoolean() ?: false
+  // 28th — sibling stems for the stale fan-out cleanup (issue #2193). Missing / blank keeps the
+  // pre-#2193 behaviour (no sibling protection), so older callers stay arg-compatible.
+  val fanoutSiblingStems = args.getOrNull(27)?.split('|')?.filter { it.isNotBlank() } ?: emptyList()
   if (previewKind == "LOTTIE") {
     val assetPath = args.getOrNull(19)?.takeIf { it.isNotBlank() }
     val sidecar = errorSidecarFor(outputFile)
@@ -241,7 +250,7 @@ fun main(args: Array<String>) {
   // expected output. Guards against provider renames and the
   // `_PARAM_<idx>` → `_<label>` migration leaving stale PNGs behind.
   if (values.any { it !== NO_PARAM }) {
-    deleteStaleFanoutFiles(outputFile, targetFiles.map { it.name }.toSet())
+    deleteStaleFanoutFiles(outputFile, targetFiles.map { it.name }.toSet(), fanoutSiblingStems)
   }
   for ((idx, value) in values.withIndex()) {
     val targetFile = targetFiles[idx]
@@ -506,7 +515,22 @@ private fun jsonString(s: String): String {
 // short-circuits the file-path suffix logic instead.
 private val NO_PARAM = Any()
 
-private fun deleteStaleFanoutFiles(template: File, expectedNames: Set<String>) {
+/**
+ * Deletes `<stem>_*<ext>` files from prior runs that this render won't rewrite — stale fan-out left
+ * behind by provider renames ("loading" → "busy") and the `_PARAM_<idx>` → `_<label>` migration.
+ *
+ * The prefix match alone over-reaches (issue #2193): `@Preview(name = …)` / `@Preview(group = …)`
+ * variant suffixes make a sibling preview's stem an underscore-extension of [template]'s (`Foo` vs
+ * `Foo_Dark`), so the sibling's base render and its own fan-out (`Foo_Dark_<label>.png`) both match
+ * `Foo_*` while belonging to a different subprocess. The plugin — which has the manifest this
+ * subprocess doesn't — passes those stems in [protectedSiblingStems]; any file that is
+ * `<sibling>.<ext>` or `<sibling>_*` is theirs, not stale.
+ */
+internal fun deleteStaleFanoutFiles(
+  template: File,
+  expectedNames: Set<String>,
+  protectedSiblingStems: List<String> = emptyList(),
+) {
   val dir = template.parentFile ?: return
   if (!dir.isDirectory) return
   val stem = template.nameWithoutExtension
@@ -514,7 +538,14 @@ private fun deleteStaleFanoutFiles(template: File, expectedNames: Set<String>) {
   val prefix = stem + "_"
   dir
     .listFiles()
-    ?.filter { it.name.startsWith(prefix) && it.name.endsWith(ext) && it.name !in expectedNames }
+    ?.filter { f ->
+      f.name.startsWith(prefix) &&
+        f.name.endsWith(ext) &&
+        f.name !in expectedNames &&
+        protectedSiblingStems.none { sib ->
+          f.name.startsWith("$sib.") || f.name.startsWith("${sib}_")
+        }
+    }
     ?.forEach { f ->
       if (!f.delete()) {
         System.err.println("Failed to delete stale fan-out file: ${f.absolutePath}")

--- a/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/DeleteStaleFanoutFilesTest.kt
+++ b/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/DeleteStaleFanoutFilesTest.kt
@@ -1,0 +1,86 @@
+package ee.schimke.composeai.renderer
+
+import java.io.File
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * Pins the `@PreviewParameter` stale fan-out cleanup in `DesktopRendererMain`, in particular the
+ * sibling protection from issue #2193: `@Preview(name = "Dark")` on `Foo` produces a sibling
+ * preview whose stem (`Foo_Dark`) is an underscore-extension of `Foo`'s, so `Foo`'s prefix-greedy
+ * sweep matched — and deleted — the sibling's base render and fan-out. The plugin now passes the
+ * sibling stems in and [deleteStaleFanoutFiles] must leave their files alone.
+ */
+class DeleteStaleFanoutFilesTest {
+
+  @get:Rule val tmp = TemporaryFolder()
+
+  private fun touch(name: String): File = tmp.newFile(name)
+
+  @Test
+  fun `deletes stale fan-out and keeps expected fan-out`() {
+    val template = File(tmp.root, "Foo.png")
+    touch("Foo_Alice.png")
+    touch("Foo_PARAM_0.png")
+    touch("Foo_renamed label.png")
+
+    deleteStaleFanoutFiles(template, expectedNames = setOf("Foo_Alice.png"))
+
+    assertTrue(File(tmp.root, "Foo_Alice.png").exists())
+    assertFalse(File(tmp.root, "Foo_PARAM_0.png").exists())
+    assertFalse(File(tmp.root, "Foo_renamed label.png").exists())
+  }
+
+  @Test
+  fun `keeps sibling preview base render and its fan-out (issue 2193)`() {
+    val template = File(tmp.root, "Foo.png")
+    // The `@Preview(name = "Dark")` sibling's outputs — underscore-extensions of `Foo`.
+    touch("Foo_Dark.png")
+    touch("Foo_Dark_Alice.png")
+    // Genuinely stale fan-out of `Foo` itself.
+    touch("Foo_stale.png")
+
+    deleteStaleFanoutFiles(
+      template,
+      expectedNames = setOf("Foo_Alice.png"),
+      protectedSiblingStems = listOf("Foo_Dark"),
+    )
+
+    assertTrue(File(tmp.root, "Foo_Dark.png").exists())
+    assertTrue(File(tmp.root, "Foo_Dark_Alice.png").exists())
+    assertFalse(File(tmp.root, "Foo_stale.png").exists())
+  }
+
+  @Test
+  fun `sibling protection does not shield unrelated stems sharing a name prefix`() {
+    val template = File(tmp.root, "Foo.png")
+    // `Foo_Darkish` extends the string `Foo_Dark` but is NOT `Foo_Dark.<ext>` nor `Foo_Dark_*`,
+    // so the sibling stem must not shield it.
+    touch("Foo_Darkish.png")
+
+    deleteStaleFanoutFiles(
+      template,
+      expectedNames = emptySet(),
+      protectedSiblingStems = listOf("Foo_Dark"),
+    )
+
+    assertFalse(File(tmp.root, "Foo_Darkish.png").exists())
+  }
+
+  @Test
+  fun `only files matching the template prefix and extension are candidates`() {
+    val template = File(tmp.root, "Foo.png")
+    touch("Foobar_x.png")
+    touch("Foo_x.gif")
+    touch("Bar_x.png")
+
+    deleteStaleFanoutFiles(template, expectedNames = emptySet())
+
+    assertTrue(File(tmp.root, "Foobar_x.png").exists())
+    assertTrue(File(tmp.root, "Foo_x.gif").exists())
+    assertTrue(File(tmp.root, "Bar_x.png").exists())
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #2193 — the `@PreviewParameter` stale fan-out cleanup treated every `<stem>_*<ext>` file as the current preview's own fan-out, so `@Preview(name = "Dark")` siblings (whose stems are underscore-extensions of the base stem, `Foo` vs `Foo_Dark`) had their base render and fan-out silently deleted by the base preview's cleanup pass.

**Desktop** (`DesktopRendererMain` + `RenderPreviewsTask`): the subprocess has no manifest, so the plugin now derives the same-directory sibling stems that extend each capture's stem (`fanoutSiblingStems`) and passes them as a new optional 28th renderer arg (`|`-joined; `sanitizeForPath` guarantees `|` never appears in a stem). `deleteStaleFanoutFiles` skips any file that is `<sibling>.<ext>` or `<sibling>_*`. Stems are computed from the raw manifest so tier/kind-filtered previews' on-disk files stay protected, and same-entry multi-captures (`Foo_TIME_500ms` etc.) are covered by the same mechanism. Omitting the arg keeps the old behaviour, so older callers (CLI bundle renderer) stay arg-compatible.

**Android** (`PreviewManifestLoader`): the cleanup is hoisted out of `expandParameterProvider` into `loadShard` and made manifest-aware — the expected-name set now spans every entry's declared and expanded captures, so a sibling's outputs are never classified as stale. Because every parallel fork (`maxParallelForks = shardCount`) expands the whole manifest at shard load, the manifest-wide set also stops a late-loading fork from deleting fan-out PNGs another fork just rendered; additionally the sweep only runs for previews with a row assigned to the loading shard.

## Test plan

- New `DeleteStaleFanoutFilesTest` (renderer-desktop): stale fan-out deleted, expected fan-out kept, sibling base + sibling fan-out kept, unrelated stems (`Foo_Darkish`, other ext/prefix) unaffected.
- New `PreviewManifestLoaderStaleFanoutTest` (renderer-android): sibling base/fan-out survive a sweep while genuinely stale files (`_PARAM_0`, renamed labels) are deleted; shard-ownership gate; non-parameterized previews never sweep.
- New `FanoutSiblingStemsTest` (gradle-plugin): sibling-stem derivation (same-dir/prefix filtering, dedup, reverse direction).
- `:renderer-desktop:test`, `:renderer-android:testDebugUnitTest`, gradle-plugin `:test`, and `ktfmtCheck` on the touched modules all pass locally (`DesktopLottieRendererTest`'s multi-frame GIF assertion fails identically on `main` in this container — pre-existing, unrelated).

Non-visual change: no rendered pixels differ — this only changes which files the cleanup pass deletes, so text-only evidence per the repo convention.

---
_Generated by [Claude Code](https://claude.ai/code/session_012oTKowktJxESx7qSj17Tj8)_