### PR TITLE
fix(renderers): bring display-filter output paths to parity with device-frame

### DIFF
--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -1231,13 +1231,19 @@ abstract class RobolectricRenderTestBase(
                     // (`<renders>/../data/<previewId>/`) so consumers see the same on-disk
                     // layout whether a render came through the daemon or the gradle plugin.
                     if (job is CaptureRenderJob) {
+                        // Both producers share the previews-root `data/` dir and key on the
+                        // capture's file stem, not preview.id: a preview can emit several
+                        // captures (manual-clock fan-out, TOP/END scroll, focus/animated) and
+                        // preview.id would make later captures overwrite earlier siblings'
+                        // variants. Matches the desktop path.
+                        val productDataDir = (outputDir.parentFile ?: outputDir).resolve("data")
+                        val productPreviewId = outputFile.nameWithoutExtension
                         val displayFilters = DisplayFilterConfig.fromSystemProperties()
                         if (displayFilters.isNotEmpty()) {
                             try {
-                                val dfDataDir = (outputDir.parentFile ?: outputDir).resolve("data")
                                 DisplayFilterDataProducer.writeArtifacts(
-                                    rootDir = dfDataDir,
-                                    previewId = preview.id,
+                                    rootDir = productDataDir,
+                                    previewId = productPreviewId,
                                     pngFile = outputFile,
                                     filters = displayFilters,
                                 )
@@ -1257,15 +1263,9 @@ abstract class RobolectricRenderTestBase(
                         val deviceFrame = DeviceFrameConfig.fromSystemProperties()
                         if (deviceFrame != null) {
                             try {
-                                val frameDataDir =
-                                    (outputDir.parentFile ?: outputDir).resolve("data")
                                 DeviceFrameDataProducer.writeArtifacts(
-                                    rootDir = frameDataDir,
-                                    // Key on the capture's file stem, not preview.id: a preview can
-                                    // emit several captures (manual-clock fan-out, TOP/END scroll,
-                                    // focus/animated) and preview.id would make later captures
-                                    // overwrite earlier framed siblings. Matches the desktop path.
-                                    previewId = outputFile.nameWithoutExtension,
+                                    rootDir = productDataDir,
+                                    previewId = productPreviewId,
                                     pngFile = outputFile,
                                     device = preview.params.device,
                                     settings = deviceFrame,

--- a/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRendererMain.kt
+++ b/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRendererMain.kt
@@ -349,13 +349,13 @@ fun main(args: Array<String>) {
       // simulations). Gated on `composeai.displayfilter.filters` being non-empty; the gradle plugin
       // forwards it from the `composePreview.displayFilter.filters` Gradle property. Wrapped in
       // try/catch so a filter failure does not invalidate the just-rendered PNG. Data dir mirrors
-      // the daemon's convention: `<renders-dir>/../data/<previewId>/`.
+      // the daemon's convention (`<renders-dir>/../data/<previewId>/`), resolved via
+      // [resolveDataDir] so scroll data products don't nest a second `data/`.
       val displayFilters = DisplayFilterConfig.fromSystemProperties()
       if (displayFilters.isNotEmpty()) {
         try {
-          val dataDir = (targetFile.parentFile?.parentFile ?: targetFile.parentFile).resolve("data")
           DisplayFilterDataProducer.writeArtifacts(
-            rootDir = dataDir,
+            rootDir = resolveDataDir(targetFile),
             previewId = targetFile.nameWithoutExtension,
             pngFile = targetFile,
             filters = displayFilters,
@@ -373,15 +373,8 @@ fun main(args: Array<String>) {
       val deviceFrame = DeviceFrameConfig.fromSystemProperties()
       if (deviceFrame != null) {
         try {
-          // Resolve the previews-root `data/` dir. For a normal `renders/<id>.png` capture that's
-          // the sibling `data/`; for a data-product output already under `data/<kind>/<id>.png`
-          // (LONG/GIF scroll products) the grandparent IS `data/`, so don't nest a second `data/`.
-          val captureDir = targetFile.parentFile
-          val dataDir =
-            if (captureDir?.parentFile?.name == "data") captureDir.parentFile!!
-            else (captureDir?.parentFile ?: captureDir ?: targetFile).resolve("data")
           DeviceFrameDataProducer.writeArtifacts(
-            rootDir = dataDir,
+            rootDir = resolveDataDir(targetFile),
             previewId = targetFile.nameWithoutExtension,
             pngFile = targetFile,
             device = device,
@@ -405,6 +398,19 @@ fun main(args: Array<String>) {
       // Continue with the next value — keep exit code 0 below.
     }
   }
+}
+
+/**
+ * Resolve the previews-root `data/` dir for a post-capture data producer (display filters, device
+ * frames). For a normal `renders/<id>.png` capture that's the sibling `data/`; for a data-product
+ * output already under `data/<kind>/<id>.png` (LONG/GIF scroll products) the grandparent IS
+ * `data/`, so don't nest a second `data/`. Shared by both producer call sites so the twin blocks
+ * can't drift.
+ */
+internal fun resolveDataDir(targetFile: File): File {
+  val captureDir = targetFile.parentFile
+  return if (captureDir?.parentFile?.name == "data") captureDir.parentFile!!
+  else (captureDir?.parentFile ?: captureDir ?: targetFile).resolve("data")
 }
 
 /**

--- a/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/ResolveDataDirTest.kt
+++ b/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/ResolveDataDirTest.kt
@@ -1,0 +1,32 @@
+package ee.schimke.composeai.renderer
+
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * [resolveDataDir] is shared by the display-filter and device-frame producer call sites so both
+ * write under the previews-root `data/` regardless of where the capture landed. The regression to
+ * guard against (#2192): a LONG/GIF scroll product already lives under `data/<kind>/<id>.png`, and
+ * a naive `grandparent/data` resolution nests a bogus `data/data/`.
+ */
+class ResolveDataDirTest {
+
+  @Test
+  fun `normal render resolves sibling data dir`() {
+    val target = File("/out/module/renders/MyPreview.png")
+    assertEquals(File("/out/module/data"), resolveDataDir(target))
+  }
+
+  @Test
+  fun `scroll data product does not nest a second data dir`() {
+    val target = File("/out/module/data/render-scroll-long/MyPreview.png")
+    assertEquals(File("/out/module/data"), resolveDataDir(target))
+  }
+
+  @Test
+  fun `gif data product does not nest a second data dir`() {
+    val target = File("/out/module/data/render-scroll-gif/MyPreview_Gif.gif")
+    assertEquals(File("/out/module/data"), resolveDataDir(target))
+  }
+}


### PR DESCRIPTION
Fixes #2192.

The display-filter and device-frame post-capture blocks are structural twins on both render backends, but only device-frame had received the two output-path fixes. This brings display-filter up to parity and shares the resolution logic so the twins can't drift again.

## Summary

- **Android (`RobolectricRenderTest.kt`)**: display-filter artifacts are now keyed on the capture's file stem (`outputFile.nameWithoutExtension`) instead of `preview.id`, so multi-capture previews (manual-clock fan-out, TOP/END scroll, focus/animated) no longer overwrite each other's `displayfilter-variants.json`. The data dir + preview-id are hoisted into shared `productDataDir` / `productPreviewId` locals used by both the display-filter and device-frame producers, and the keying now matches the desktop backend so both land at the same documented `data/<id>/` path.
- **Desktop (`DesktopRendererMain.kt`)**: extracted the device-frame block's grandparent guard into a shared `resolveDataDir(targetFile)` used by both producers. Display-filter variants for LONG/GIF scroll products (already under `data/<kind>/<id>.png`) no longer nest a bogus `data/data/` directory.

## Test plan

- New `ResolveDataDirTest` (`:renderer-desktop`) covers the three shapes: normal `renders/<id>.png` capture → sibling `data/`, and LONG/GIF products under `data/<kind>/` → the existing grandparent `data/` (the #2192 regression).
- Verified the exact `resolveDataDir` source compiles and passes those three cases standalone (the sandbox's egress policy blocks the Gradle 9.6 distribution download, so the full Gradle test task couldn't run locally — CI runs it).
- No visual surface changes — this is data-product output-path plumbing only, so no before/after renders apply.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RnqSXhKLJ3mBha3t121Sjv)_