### PR TITLE
fix: restrict fan-out sibling protection to same-extension outputs

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderPreviewsTask.kt
@@ -381,11 +381,17 @@ abstract class RenderPreviewsTask : DefaultTask() {
 }
 
 /**
- * Stems (filenames without extension) of manifest outputs in the same directory as [outputFile]
- * whose name extends [outputFile]'s stem with an underscore — exactly the files the desktop
- * renderer's prefix-greedy `deleteStaleFanoutFiles` would otherwise mistake for its own
- * `@PreviewParameter` fan-out (issue #2193). `@Preview(name = "Dark")` on `Foo` yields the sibling
- * stem `Foo_Dark`; both its base PNG and its own fan-out (`Foo_Dark_<label>.png`) match `Foo_*`.
+ * Stems (filenames without extension) of manifest outputs in the same directory as [outputFile],
+ * with the same extension, whose name extends [outputFile]'s stem with an underscore — exactly the
+ * files the desktop renderer's prefix-greedy `deleteStaleFanoutFiles` would otherwise mistake for
+ * its own `@PreviewParameter` fan-out (issue #2193). `@Preview(name = "Dark")` on `Foo` yields the
+ * sibling stem `Foo_Dark`; both its base PNG and its own fan-out (`Foo_Dark_<label>.png`) match
+ * `Foo_*`.
+ *
+ * The same-extension restriction matters in both directions: the cleanup only scans files with
+ * [outputFile]'s extension, so a different-extension sibling (`Foo_Dark.gif`) needs no protection —
+ * and shielding its stem anyway would keep a genuinely stale `Foo_Dark.png`, left from before that
+ * sibling's capture became a GIF, on disk forever.
  *
  * Joined with `|` on the renderer command line — discovery's `sanitizeForPath` strips `|` from
  * every stem, so the separator can't collide.
@@ -396,7 +402,11 @@ internal fun fanoutSiblingStems(
 ): List<String> {
   val prefix = outputFile.nameWithoutExtension + "_"
   return manifestOutputFiles
-    .filter { it.parentFile == outputFile.parentFile && it != outputFile }
+    .filter {
+      it.parentFile == outputFile.parentFile &&
+        it != outputFile &&
+        it.extension == outputFile.extension
+    }
     .map { it.nameWithoutExtension }
     .filter { it.startsWith(prefix) }
     .distinct()

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/FanoutSiblingStemsTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/FanoutSiblingStemsTest.kt
@@ -17,17 +17,26 @@ class FanoutSiblingStemsTest {
   private fun render(name: String) = File(rendersDir, name)
 
   @Test
-  fun `returns same-directory stems extending the output stem`() {
+  fun `returns same-directory same-extension stems extending the output stem`() {
     val outputs =
       listOf(
         render("Foo.png"),
         render("Foo_Dark.png"),
-        render("Foo_Selected.gif"),
+        render("Foo_Selected.png"),
         render("Bar.png"),
       )
     assertThat(fanoutSiblingStems(outputs, render("Foo.png")))
       .containsExactly("Foo_Dark", "Foo_Selected")
       .inOrder()
+  }
+
+  @Test
+  fun `excludes siblings with a different extension`() {
+    // The cleanup for `Foo.png` only scans `.png` files, so a `.gif` sibling needs no
+    // protection — and shielding its stem would keep a stale `Foo_Dark.png` (left from before
+    // that sibling's capture became a GIF) on disk forever.
+    val outputs = listOf(render("Foo_Dark.gif"))
+    assertThat(fanoutSiblingStems(outputs, render("Foo.png"))).isEmpty()
   }
 
   @Test
@@ -52,8 +61,9 @@ class FanoutSiblingStemsTest {
 
   @Test
   fun `deduplicates stems shared by several captures`() {
-    // The same sibling stem can appear once per capture (e.g. a PNG and a GIF product).
-    val outputs = listOf(render("Foo_Dark.png"), render("Foo_Dark.gif"))
+    // The same output file can be claimed by several manifest rows (e.g. multi-mode captures
+    // resolving to the same path); the stem is still passed once.
+    val outputs = listOf(render("Foo_Dark.png"), render("Foo_Dark.png"))
     assertThat(fanoutSiblingStems(outputs, render("Foo.png"))).containsExactly("Foo_Dark")
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to #2198, addressing the Codex review comment that landed just before merge: `fanoutSiblingStems` collected sibling stems extension-blind, so a sibling whose current capture is `Foo_Dark.gif` made the `Foo.png` render pass `Foo_Dark` as protected — shielding a genuinely stale `Foo_Dark.png` (left from before that sibling's capture became a GIF) from deletion forever, and `cleanStaleRenders` preserves `Foo_*` fan-out too, so nothing would ever remove it.

Since the renderer's cleanup only scans files with the template's extension, a different-extension sibling needs no protection in the first place. The stem collection now filters manifest outputs to `outputFile`'s extension.

## Test plan

- `FanoutSiblingStemsTest` updated: new case pinning that a `.gif` sibling contributes no protected stem to a `.png` sweep; existing cases adjusted to same-extension inputs.
- gradle-plugin `:test` and `:ktfmtCheck` pass locally.

Non-visual change (cleanup semantics only), so text-only evidence per the repo convention.

---
_Generated by [Claude Code](https://claude.ai/code/session_012oTKowktJxESx7qSj17Tj8)_