### PR TITLE
ci: bill @claude sessions to the Claude subscription OAuth token

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,10 +10,11 @@ name: Claude
 # addition to the `if:` gate below.
 #
 # One-time setup per repo: install the Claude GitHub App
-# (https://github.com/apps/claude) and add an ANTHROPIC_API_KEY secret (or
-# swap the input for `claude_code_oauth_token`). Full design, the visual-
-# evidence contract, and how to adopt this in another repo:
-# docs/AGENT_INVOCATION.md.
+# (https://github.com/apps/claude) and add a CLAUDE_CODE_OAUTH_TOKEN secret
+# (generate with `claude setup-token`; runs bill the Claude subscription's
+# included usage — swap the input to `anthropic_api_key` for metered API
+# billing instead). Full design, the visual-evidence contract, and how to
+# adopt this in another repo: docs/AGENT_INVOCATION.md.
 
 on:
   issue_comment:
@@ -56,7 +57,9 @@ jobs:
       - uses: ./.github/actions/setup
       - uses: anthropics/claude-code-action@769e3bdff9bb7ecfb51bad4c9cba23d6f5fc5ea5 # v1.0.163
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Bills the Claude subscription's included usage (shared with
+          # interactive Claude Code sessions) rather than per-token API spend.
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # Request the CI-read scope on the Claude App token the action
           # mints for itself — the job-level `actions: read` grant above only
           # covers the workflow token, and the get_ci_status /

--- a/docs/AGENT_INVOCATION.md
+++ b/docs/AGENT_INVOCATION.md
@@ -108,9 +108,13 @@ Two one-time admin steps, then copy one file:
 1. **Install the Claude GitHub App** on the repo:
    <https://github.com/apps/claude> (or run `/install-github-app` from the
    Claude Code CLI, which walks through both steps).
-2. **Add the `ANTHROPIC_API_KEY` secret** (or use a Claude subscription via a
-   `CLAUDE_CODE_OAUTH_TOKEN` secret and the `claude_code_oauth_token` input
-   instead).
+2. **Add the `CLAUDE_CODE_OAUTH_TOKEN` secret** — generate it with
+   `claude setup-token` (requires a Claude Pro/Max subscription). Runs then
+   bill the subscription's included usage, sharing its rolling rate windows
+   with your interactive Claude Code sessions. To meter against API credits
+   instead (independent of personal usage, cappable via a dedicated
+   workspace), add an `ANTHROPIC_API_KEY` secret and swap the workflow input
+   to `anthropic_api_key`.
 3. **Copy `.github/workflows/claude.yml`** and adjust three things:
    - the toolchain setup step (this repo: JDK 17 + Gradle via
      `./.github/actions/setup`);


### PR DESCRIPTION
## Summary

Follow-up to #2194: switch the `claude.yml` auth input from `anthropic_api_key` to `claude_code_oauth_token`, so `@claude` mention-triggered sessions draw on the Claude Pro/Max subscription's included usage (token generated via `claude setup-token`, stored as the `CLAUDE_CODE_OAUTH_TOKEN` repo secret) instead of metered, prepaid API credits.

- Subscription runs share the plan's rolling usage windows with interactive Claude Code sessions — free with the plan, but capped by it.
- API-key billing stays documented as the swap-back for anyone wanting spend that's independent of personal usage (cappable via a dedicated Console workspace): add `ANTHROPIC_API_KEY` and flip the input back.
- `docs/AGENT_INVOCATION.md` setup step updated to lead with the subscription path and explain the trade-off.

Matching commits pushed to the `meshcore-mobile` and `design-parity` branches.

## Test plan

- YAML parsed and the action `with:` block validated locally (asserts `claude_code_oauth_token` present, `anthropic_api_key` absent).
- `claude_code_oauth_token` is the action's documented first-class alternative input to `anthropic_api_key` (vendor `examples/claude.yml` and inputs reference).
- Non-visual change (CI wiring + docs), so text-only evidence is correct per repo convention.
- After merge: run `claude setup-token` locally, add the `CLAUDE_CODE_OAUTH_TOKEN` secret, then smoke-test with an `@claude` comment on a scratch issue.