### PR TITLE
feat: add SVG asset discovery and rendering support

### DIFF
--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
@@ -30,6 +30,18 @@ enum class PreviewKind {
    */
   LOTTIE,
   /**
+   * An SVG image asset discovered directly as a file (no `@Preview`, no consumer composable): a
+   * `.svg` under the module's resources. Like [LOTTIE] the asset bytes *are* the preview's
+   * intermediate representation — the renderer inflates them via the Skia-backed `loadSvgPainter`
+   * (Compose Desktop), and a bundle can carry the bytes and replay them with zero consumer
+   * bytecode. Static (no timeline), so it captures a single still PNG — no animated companion. The
+   * asset's classpath-relative path travels on [PreviewParams.assetPath]; the declared `viewBox` /
+   * `width` / `height` seed [PreviewParams.widthDp] / [PreviewParams.heightDp] so the canvas
+   * matches the artwork's intrinsic aspect ratio. Rendered on the JVM/desktop backend (Skia has
+   * native SVG; Robolectric does not), mirroring the Lottie routing.
+   */
+  SVG,
+  /**
    * A synthetic design-token catalog sheet aggregated from `@ColorCatalog` (and, later,
    * `@TypographyCatalog`) properties — no `@Preview`, no consumer composable. Like [LOTTIE] this is
    * data-driven: the tokens to render travel on [PreviewParams.catalogTokens], and the renderer
@@ -54,7 +66,9 @@ enum class PreviewKind {
 enum class CatalogTokenKind {
   /** An `androidx.compose.ui.graphics.Color` property → a labelled swatch row. */
   COLOR,
-  /** An `androidx.compose.ui.text.TextStyle` property → a labelled sample-text row in that style. */
+  /**
+   * An `androidx.compose.ui.text.TextStyle` property → a labelled sample-text row in that style.
+   */
   TEXT_STYLE,
 }
 

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
@@ -9,6 +9,7 @@ import io.github.classgraph.MethodInfo
 import io.github.classgraph.MethodParameterInfo
 import io.github.classgraph.ScanResult
 import java.io.File
+import kotlin.math.roundToInt
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
@@ -72,6 +73,14 @@ object PreviewDiscovery {
      * relative to the `compose-previews` root, so any subdir validates uniformly.
      */
     val lottieRenderSubdir: String = "renders",
+    /**
+     * Subdirectory (under the `compose-previews` root) that [PreviewKind.SVG] capture
+     * `renderOutput` paths are placed in. Same rationale as [lottieRenderSubdir]: defaults to
+     * `"renders"` on the desktop backend (the desktop renderer is the only writer) and is
+     * overridden to a disjoint dir (e.g. `"svg-renders"`) on the Android backend so the JVM SVG
+     * render task doesn't share `renders/` with the Robolectric render.
+     */
+    val svgRenderSubdir: String = "renders",
     /**
      * JARs of compiled `.class` files belonging to the consumer module itself — the module's *own*
      * classes packaged as a jar rather than laid out in a [classDirs] directory. Unlike
@@ -376,7 +385,8 @@ object PreviewDiscovery {
                 warnings,
               )
             }
-            // `@ColorCatalog` / `@TypographyCatalog` design tokens: an annotated `Color` / `TextStyle`
+            // `@ColorCatalog` / `@TypographyCatalog` design tokens: an annotated `Color` /
+            // `TextStyle`
             // property's backing field. Collect the coordinates + display metadata here; the values
             // are reflected at render time.
             for (field in classInfo.fieldInfo) {
@@ -418,6 +428,7 @@ object PreviewDiscovery {
     val normalized =
       normalizeRenderOutputs(deduped) +
         discoverLottieAssets(input) +
+        discoverSvgAssets(input) +
         buildCatalogPreviews(
           rawColorCatalogTokens,
           input.catalogRenderSupported,
@@ -616,6 +627,101 @@ object PreviewDiscovery {
 
   private data class LottieDims(val width: Int?, val height: Int?)
 
+  /**
+   * Scan [Input.resourceDirs] for `.svg` image assets and turn each into a [PreviewKind.SVG]
+   * preview — no `@Preview`, no consumer composable, "just having the file is enough" (mirrors
+   * [discoverLottieAssets]). A `.svg` qualifies by extension when its content carries an `<svg`
+   * root element (the cheapest reliable fingerprint — guards against a stray file that merely ends
+   * in `.svg`). The asset's resource-relative path is recorded on [PreviewParams.assetPath] so the
+   * desktop renderer can load it off the classpath; the declared `viewBox` / `width` / `height`
+   * seed the canvas dimensions so the still matches the artwork's intrinsic aspect ratio.
+   *
+   * Unlike Lottie there is no animated companion — SVG is static (SMIL/CSS animation isn't replayed
+   * by `loadSvgPainter`), so each preview ships a single required still PNG.
+   *
+   * Best-effort and side-effect-free: unreadable / non-SVG files are skipped silently. Returns a
+   * list deduped by preview id and ordered by relative path for stable output.
+   */
+  private fun discoverSvgAssets(input: Input): List<PreviewInfo> {
+    if (input.resourceDirs.isEmpty()) return emptyList()
+    val found = LinkedHashMap<String, PreviewInfo>()
+    for (root in input.resourceDirs) {
+      if (!root.isDirectory) continue
+      root
+        .walkTopDown()
+        .filter { it.isFile }
+        .sortedBy { it.relativeTo(root).invariantSeparatorsPath }
+        .forEach { file ->
+          if (!file.extension.equals("svg", ignoreCase = true)) return@forEach
+          val relPath = file.relativeTo(root).invariantSeparatorsPath
+          val dims = svgDimensionsOrNull(file) ?: return@forEach
+          // Filename-safe id (see the Lottie note): lands verbatim in zip entry / render paths, so
+          // `:` / `/` from the resource path can't survive. The `svg__` prefix keeps it from
+          // colliding with a class-derived preview id or a `lottie__` asset id.
+          val safe = relPath.removeSuffix(".${file.extension}").replace(SANITIZE_RENDER_STEM, "_")
+          val stem = "svg__$safe"
+          val id = stem
+          if (found.containsKey(id)) return@forEach
+          found[id] =
+            PreviewInfo(
+              id = id,
+              functionName = relPath,
+              className = "",
+              params =
+                PreviewParams(
+                  name = file.nameWithoutExtension,
+                  kind = PreviewKind.SVG,
+                  assetPath = relPath,
+                  widthDp = dims.width,
+                  heightDp = dims.height,
+                ),
+              // Single required still — no animated companion (SVG has no replayed timeline).
+              captures = listOf(Capture(renderOutput = "${input.svgRenderSubdir}/$stem.png")),
+            )
+        }
+    }
+    return found.values.toList()
+  }
+
+  private data class SvgDims(val width: Int?, val height: Int?)
+
+  /**
+   * Read [file]'s intrinsic dimensions when it is an SVG, or `null` when it is not (no `<svg` root
+   * — a file that merely ends in `.svg`). Prefers an explicit `width`/`height` on the root element,
+   * falling back to the `viewBox`'s width/height (the common case for icon SVGs, which declare only
+   * a `viewBox`). Dimensions are rounded to whole pixels and used only to seed the render canvas'
+   * aspect ratio; a value of `null` on either axis lets the renderer fall back to its default size.
+   */
+  private fun svgDimensionsOrNull(file: File): SvgDims? {
+    val text = runCatching { file.readText() }.getOrNull() ?: return null
+    // Cheapest reliable SVG fingerprint: a `<svg` element tag. Guards against a mis-named file.
+    val svgTag = Regex("<svg\\b[^>]*>", RegexOption.IGNORE_CASE).find(text) ?: return null
+    val attrs = svgTag.value
+    fun lengthAttr(name: String): Int? {
+      val raw =
+        Regex("\\b$name\\s*=\\s*[\"']([^\"']+)[\"']", RegexOption.IGNORE_CASE)
+          .find(attrs)
+          ?.groupValues
+          ?.get(1) ?: return null
+      // Strip a unit suffix (px, pt, mm, %, …) — only the leading number seeds the canvas ratio.
+      return Regex("[-+]?\\d*\\.?\\d+").find(raw)?.value?.toFloatOrNull()?.roundToInt()
+    }
+    val explicitW = lengthAttr("width")?.takeIf { it > 0 }
+    val explicitH = lengthAttr("height")?.takeIf { it > 0 }
+    if (explicitW != null && explicitH != null) return SvgDims(explicitW, explicitH)
+    // Fall back to viewBox = "minX minY width height".
+    val viewBox =
+      Regex("\\bviewBox\\s*=\\s*[\"']([^\"']+)[\"']", RegexOption.IGNORE_CASE)
+        .find(attrs)
+        ?.groupValues
+        ?.get(1)
+        ?.trim()
+        ?.split(Regex("[\\s,]+"))
+    val vbW = viewBox?.getOrNull(2)?.toFloatOrNull()?.roundToInt()?.takeIf { it > 0 }
+    val vbH = viewBox?.getOrNull(3)?.toFloatOrNull()?.roundToInt()?.takeIf { it > 0 }
+    return SvgDims(explicitW ?: vbW, explicitH ?: vbH)
+  }
+
   /** Raw `@ColorCatalog` hit collected during the scan, before aggregation into sheets. */
   private data class RawCatalogToken(
     val className: String,
@@ -624,14 +730,15 @@ object PreviewDiscovery {
     val group: String,
   )
 
-  /** Raw `@ThemeCatalog` hit: the annotated `PreviewWrapperProvider` class + its display metadata. */
-  private data class RawThemeCatalog(
-    val className: String,
-    val name: String,
-    val group: String,
-  )
+  /**
+   * Raw `@ThemeCatalog` hit: the annotated `PreviewWrapperProvider` class + its display metadata.
+   */
+  private data class RawThemeCatalog(val className: String, val name: String, val group: String)
 
-  /** Builds a [RawCatalogToken] from an annotated field, applying Showkase-style name/group defaults. */
+  /**
+   * Builds a [RawCatalogToken] from an annotated field, applying Showkase-style name/group
+   * defaults.
+   */
   private fun rawCatalogToken(
     classInfo: ClassInfo,
     field: io.github.classgraph.FieldInfo,
@@ -746,12 +853,13 @@ object PreviewDiscovery {
   /**
    * Aggregates the collected `@ThemeCatalog` providers into synthetic [PreviewKind.THEME_CATALOG]
    * sheets — one per provider, keyed `themecatalog__<name>`. Because each provider is its own sheet
-   * (not aggregated like the token catalogs), the id must be unique per provider: two providers that
-   * share a display `name` (e.g. `"Light"` in different groups/packages) would otherwise derive the
-   * same id and `renders/<id>.png` and clobber each other, so a collision falls back to appending
-   * the provider's (unique) FQN. The provider FQN travels on [PreviewParams.wrapperClassName]; the
-   * renderer resolves it and composes its `Wrap(content)` around a canned specimen. `optional`
-   * exactly when the backend can't render (desktop), like the token catalogs.
+   * (not aggregated like the token catalogs), the id must be unique per provider: two providers
+   * that share a display `name` (e.g. `"Light"` in different groups/packages) would otherwise
+   * derive the same id and `renders/<id>.png` and clobber each other, so a collision falls back to
+   * appending the provider's (unique) FQN. The provider FQN travels on
+   * [PreviewParams.wrapperClassName]; the renderer resolves it and composes its `Wrap(content)`
+   * around a canned specimen. `optional` exactly when the backend can't render (desktop), like the
+   * token catalogs.
    */
   private fun buildThemeCatalogPreviews(
     themes: List<RawThemeCatalog>,
@@ -779,8 +887,7 @@ object PreviewDiscovery {
             kind = PreviewKind.THEME_CATALOG,
             wrapperClassName = theme.className,
           ),
-        captures =
-          listOf(Capture(renderOutput = "renders/$id.png", optional = !renderSupported)),
+        captures = listOf(Capture(renderOutput = "renders/$id.png", optional = !renderSupported)),
       )
     }
   }

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
@@ -698,8 +698,12 @@ object PreviewDiscovery {
     val svgTag = Regex("<svg\\b[^>]*>", RegexOption.IGNORE_CASE).find(text) ?: return null
     val attrs = svgTag.value
     fun lengthAttr(name: String): Int? {
+      // Anchor to a real attribute boundary: the name must NOT be preceded by a name char or `-`,
+      // so `stroke-width` / `stroke-height` don't masquerade as the root `width`/`height`. A plain
+      // `\b` word boundary matches the `-width` suffix and would size the canvas off the stroke
+      // (e.g. `<svg viewBox="0 0 24 24" stroke-width="2">` → a 2dp-wide canvas instead of 24dp).
       val raw =
-        Regex("\\b$name\\s*=\\s*[\"']([^\"']+)[\"']", RegexOption.IGNORE_CASE)
+        Regex("(?<![\\w-])$name\\s*=\\s*[\"']([^\"']+)[\"']", RegexOption.IGNORE_CASE)
           .find(attrs)
           ?.groupValues
           ?.get(1) ?: return null

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/SvgAssetDiscoveryTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/SvgAssetDiscoveryTest.kt
@@ -1,0 +1,96 @@
+package ee.schimke.composeai.discovery
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * Coverage for direct SVG-asset discovery: a `.svg` file under a resource root becomes a
+ * [PreviewKind.SVG] preview with no `@Preview` / consumer composable, sized from its `viewBox` or
+ * explicit `width`/`height`, while files that merely end in `.svg` without an `<svg` root are
+ * ignored. Sibling of [LottieAssetDiscoveryTest].
+ */
+class SvgAssetDiscoveryTest {
+
+  @get:Rule val tempDir = TemporaryFolder()
+
+  private fun discover(resourceDir: java.io.File): PreviewManifest {
+    val outcome =
+      PreviewDiscovery.discover(
+        PreviewDiscovery.Input(
+          classDirs = emptyList(),
+          dependencyJars = emptyList(),
+          sourceFiles = emptyList(),
+          moduleName = ":app",
+          variantName = "desktop",
+          projectDirectory = resourceDir,
+          failOnEmpty = false,
+          resourceDirs = listOf(resourceDir),
+        )
+      )
+    assertThat(outcome).isInstanceOf(PreviewDiscovery.Outcome.Success::class.java)
+    return (outcome as PreviewDiscovery.Outcome.Success).manifest
+  }
+
+  @Test
+  fun `svg with viewBox is discovered with dimensions, non-svg is ignored`() {
+    val res = tempDir.newFolder("resources")
+    res.resolve("icons").mkdirs()
+    res
+      .resolve("icons/badge.svg")
+      .writeText(
+        """<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 120"><rect width="240" height="120"/></svg>"""
+      )
+    // A file that ends in `.svg` but carries no `<svg` root — must be skipped.
+    res.resolve("not-really.svg").writeText("just some text, not markup")
+
+    val previews = discover(res).previews
+    assertThat(previews).hasSize(1)
+    val p = previews.single()
+    assertThat(p.params.kind).isEqualTo(PreviewKind.SVG)
+    assertThat(p.params.assetPath).isEqualTo("icons/badge.svg")
+    assertThat(p.params.widthDp).isEqualTo(240)
+    assertThat(p.params.heightDp).isEqualTo(120)
+    // Id + render output are filename-safe (no `:` / `/` to corrupt zip paths).
+    assertThat(p.id).doesNotContain("/")
+    assertThat(p.id).doesNotContain(":")
+    assertThat(p.id).startsWith("svg__")
+    // SVG is static — a single required still PNG, no animated companion (unlike Lottie).
+    assertThat(p.captures).hasSize(1)
+    val still = p.captures.single()
+    assertThat(still.renderOutput.substringAfterLast('.')).isEqualTo("png")
+    assertThat(still.optional).isFalse()
+  }
+
+  @Test
+  fun `explicit width and height win over viewBox`() {
+    val res = tempDir.newFolder("resources")
+    res
+      .resolve("logo.svg")
+      .writeText(
+        """<svg xmlns="http://www.w3.org/2000/svg" width="64px" height="48px" viewBox="0 0 240 120"/>"""
+      )
+
+    val p = discover(res).previews.single()
+    assertThat(p.params.widthDp).isEqualTo(64)
+    assertThat(p.params.heightDp).isEqualTo(48)
+  }
+
+  @Test
+  fun `svg with neither dimensions nor viewBox still discovers with null size`() {
+    val res = tempDir.newFolder("resources")
+    res.resolve("bare.svg").writeText("""<svg xmlns="http://www.w3.org/2000/svg"><rect/></svg>""")
+
+    val p = discover(res).previews.single()
+    assertThat(p.params.kind).isEqualTo(PreviewKind.SVG)
+    assertThat(p.params.widthDp).isNull()
+    assertThat(p.params.heightDp).isNull()
+  }
+
+  @Test
+  fun `no resource dirs yields no svg previews`() {
+    val res = tempDir.newFolder("empty")
+    assertThat(discover(res).previews).isEmpty()
+  }
+}

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/SvgAssetDiscoveryTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/SvgAssetDiscoveryTest.kt
@@ -78,6 +78,22 @@ class SvgAssetDiscoveryTest {
   }
 
   @Test
+  fun `stroke-width on the root does not masquerade as an explicit width`() {
+    val res = tempDir.newFolder("resources")
+    // A common icon shape: no explicit width/height, a 24-unit viewBox, and a stroke-width. The
+    // canvas must come from the viewBox (24x24), not the stroke (2).
+    res
+      .resolve("icon.svg")
+      .writeText(
+        """<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M4 12h16"/></svg>"""
+      )
+
+    val p = discover(res).previews.single()
+    assertThat(p.params.widthDp).isEqualTo(24)
+    assertThat(p.params.heightDp).isEqualTo(24)
+  }
+
+  @Test
   fun `svg with neither dimensions nor viewBox still discovers with null size`() {
     val res = tempDir.newFolder("resources")
     res.resolve("bare.svg").writeText("""<svg xmlns="http://www.w3.org/2000/svg"><rect/></svg>""")

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -37,6 +37,15 @@ internal object AndroidPreviewSupport {
   internal const val LOTTIE_RENDER_SUBDIR: String = "lottie-renders"
 
   /**
+   * Output subdirectory (under `build/compose-previews/`) for `kind=SVG` renders on the Android
+   * backend. Same rationale as [LOTTIE_RENDER_SUBDIR]: kept disjoint from the Robolectric
+   * `renders/` so the JVM SVG render (`composePreviewRenderSvg`) and the Robolectric render don't
+   * share an output directory. Used as the discovery `svgRenderSubdir` and as the render task's
+   * output dir.
+   */
+  internal const val SVG_RENDER_SUBDIR: String = "svg-renders"
+
+  /**
    * Floor version pinned on every plugin-injected `androidx.compose.*` coordinate that doesn't have
    * its own version source (`ui-test-manifest`, `ui-test-junit4`). Matches the Compose line that
    * `:renderer-android` compiles against (`compose-bom-compat` 2025.11.01 → Compose 1.9.5); the
@@ -620,6 +629,7 @@ internal object AndroidPreviewSupport {
         // (`composePreviewRenderLottie`) doesn't share an output directory with the Robolectric
         // `composePreviewRender` — overlapping task outputs disable Gradle's build cache for both.
         lottieRenderSubdir.set(LOTTIE_RENDER_SUBDIR)
+        svgRenderSubdir.set(SVG_RENDER_SUBDIR)
         if (screenshotTestEnabled) {
           dependsOn(project.tasks.matching { it.name in screenshotCompileTaskNames })
           screenshotTestRuntimeConfig?.let { stConfig ->
@@ -2292,10 +2302,41 @@ internal object AndroidPreviewSupport {
         dependsOn(discoverTask)
       }
 
+    // SVG assets discovered in an Android module render through the JVM desktop path too — Skia's
+    // `loadSvgPainter` inflates the portable `.svg`, and Robolectric has no SVG decoder (the
+    // Robolectric `composePreviewRender` skips `kind=SVG`, see `RobolectricRenderTest`). Mirrors
+    // the
+    // Lottie pass exactly: same `:renderer-desktop` classpath + the module's Java-resource dirs
+    // (where the `.svg` lives), a disjoint `svg-renders/` output dir so it never shares `renders/`
+    // with the Robolectric render, and folded into `composePreviewRenderAll` so the still is
+    // present
+    // when the missing-render gate validates.
+    val svgRendererConfig =
+      ComposePreviewTasks.ensureRendererDesktopConfig(project, "composePreviewSvgRenderer")
+    val svgRenderTask =
+      project.tasks.register("composePreviewRenderSvg", RenderPreviewsTask::class.java) {
+        group = "compose preview"
+        description = "Render kind=SVG previews via the desktop Skia renderer"
+        onlyIf { extension.enabled.get() }
+        previewsJson.set(previewOutputDir.map { it.file("previews.json") })
+        renderBackend.set("desktop")
+        tier.set(resolveTier(project))
+        displayFilterFilters.set(resolveDisplayFilterFilters(project))
+        deviceFrameDevice.set(resolveDeviceFrameDevice(project))
+        includeKinds.add(PreviewKind.SVG.name)
+        renderClasspath.from(svgRendererConfig.incoming.artifactView {}.files)
+        renderClasspath.from(androidLottieResourceDirs(project))
+        outputDir.set(previewOutputDir.map { it.dir(SVG_RENDER_SUBDIR) })
+        dataProductsDir.set(dataProductsDirectory)
+        dependsOn(discoverTask)
+      }
+
     ComposePreviewTasks.registerRenderAllPreviews(project, extension, renderTask, previewOutputDir)
     // Fold the JVM Lottie render into the aggregate so a `kind=LOTTIE` asset's PNG is produced
     // before the missing-render gate validates the manifest.
     project.tasks.named("composePreviewRenderAll").configure { dependsOn(lottieRenderTask) }
+    // Same for the JVM SVG render — a `kind=SVG` asset's PNG must exist before the gate validates.
+    project.tasks.named("composePreviewRenderAll").configure { dependsOn(svgRenderTask) }
     // Fold the XR render + composite into the user-facing aggregate so `composePreviewRenderAll`
     // produces scene.json alongside the PNGs, then bakes the composite stills (only when the XR
     // path is enabled / the tasks exist). `composePreviewCompositeXr` itself `dependsOn`

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -1216,6 +1216,10 @@ internal object ComposePreviewTasks {
       // so
       // its JVM Lottie render doesn't share `renders/` with the Robolectric render.
       lottieRenderSubdir.convention("renders")
+      // Same default as Lottie: SVG stills land in the shared `renders/` dir on desktop; the
+      // Android task overrides this in [configureDeps] to a disjoint dir so its JVM SVG render
+      // doesn't share `renders/` with the Robolectric render.
+      svgRenderSubdir.convention("renders")
       // `-PcomposePreview.failOnEmpty=true` wins over the extension, so
       // CI profiles and one-off triage runs can flip the gate without
       // touching build.gradle(.kts). Same pattern as

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
@@ -113,6 +113,14 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
   @get:Input abstract val lottieRenderSubdir: Property<String>
 
   /**
+   * Subdirectory for `kind=SVG` capture `renderOutput` paths (see
+   * [PreviewDiscovery.Input.svgRenderSubdir]). Defaults to `"renders"`; the Android task sets a
+   * disjoint dir so its JVM SVG render doesn't share the `renders/` output with the Robolectric
+   * render.
+   */
+  @get:Input abstract val svgRenderSubdir: Property<String>
+
+  /**
    * Whether this module's render backend can draw `@ColorCatalog` sheets. The Android backend can
    * (default `true`); the desktop backend can't yet (#2135), so it passes `false` and discovery
    * marks the synthetic `CATALOG` captures `optional` — the single flag every consumer reads (the
@@ -146,6 +154,7 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
         failOnEmpty = failOnEmpty.get(),
         resourceDirs = resourceDirs.files.toList(),
         lottieRenderSubdir = lottieRenderSubdir.getOrElse("renders"),
+        svgRenderSubdir = svgRenderSubdir.getOrElse("renders"),
         projectClassJars = scopedClassJars,
         catalogRenderSupported = catalogRenderSupported.getOrElse(true),
       )

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RenderManifest.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RenderManifest.kt
@@ -13,6 +13,10 @@ enum class PreviewKind {
     // rendered here — the JVM desktop Compottie path (`composePreviewRenderLottie`) owns it, and
     // `RobolectricRenderTest` filters it out. There is no Android Lottie player.
     LOTTIE,
+    // An SVG asset discovered in this module. Carried so `previews.json` deserialises, but never
+    // rendered here — the JVM desktop path (`composePreviewRenderSvg`) inflates it via Skia's
+    // `loadSvgPainter`, and `RobolectricRenderTest` filters it out. There is no Android SVG decoder.
+    SVG,
     // A synthetic design-token catalog sheet aggregated from `@ColorCatalog` properties. Rendered
     // here by `CatalogPreviewStrategy`, which reflects each token's value off the loaded consumer
     // class and lays them out as a labelled swatch sheet. Payload travels on

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -129,12 +129,15 @@ object PreviewManifestLoader {
         // this Android image renderer (there's no `PreviewRenderStrategy` for them, by design).
         // LOTTIE assets discovered in an Android module are rendered by the JVM desktop Compottie
         // path (`composePreviewRenderLottie`), not Robolectric — there's no Android Lottie player
-        // and the asset is portable IR. Drop both before any expansion so they never reach
-        // `strategyFor`.
+        // and the asset is portable IR. SVG assets likewise render on the JVM desktop path
+        // (`composePreviewRenderSvg`) via Skia's `loadSvgPainter` — Robolectric has no SVG decoder.
+        // Drop all three before any expansion so they never reach `strategyFor`.
         val expandedByEntry =
             manifest.previews
                 .filter {
-                    it.params.kind != PreviewKind.XR_SUBSPACE && it.params.kind != PreviewKind.LOTTIE
+                    it.params.kind != PreviewKind.XR_SUBSPACE &&
+                        it.params.kind != PreviewKind.LOTTIE &&
+                        it.params.kind != PreviewKind.SVG
                 }
                 .map { it to expandParameterProvider(it) }
         val expanded = expandedByEntry.flatMap { it.second }

--- a/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRendererMain.kt
+++ b/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRendererMain.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.renderer
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
@@ -12,9 +13,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.ImageComposeScene
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.layout
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.res.loadSvgPainter
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntSize
@@ -221,6 +224,31 @@ fun main(args: Array<String>) {
           outputFile = outputFile,
         )
       }
+    } catch (e: Throwable) {
+      writeErrorSidecar(outputFile, className, functionName, e)
+    }
+    return
+  }
+
+  // kind=SVG — a directly-discovered `.svg` asset, not a `@Composable`. Inflate the asset (arg 20,
+  // a
+  // classpath-relative path) via the Skia-backed `loadSvgPainter` and capture a single still frame.
+  // Static — no GIF companion, unlike LOTTIE. Short-circuits the reflection / scroll machinery.
+  if (previewKind == "SVG") {
+    val assetPath = args.getOrNull(19)?.takeIf { it.isNotBlank() }
+    val sidecar = errorSidecarFor(outputFile)
+    if (sidecar.exists()) sidecar.delete()
+    try {
+      requireNotNull(assetPath) { "kind=SVG preview is missing its asset path (renderer arg 20)" }
+      renderSvgAsset(
+        assetPath = assetPath,
+        widthPx = widthPx,
+        heightPx = heightPx,
+        density = density,
+        showBackground = showBackground,
+        backgroundColor = backgroundColor,
+        outputFile = outputFile,
+      )
     } catch (e: Throwable) {
       writeErrorSidecar(outputFile, className, functionName, e)
     }
@@ -919,6 +947,83 @@ private fun renderLottieAsset(
   } finally {
     scene.close()
   }
+}
+
+/**
+ * Render a directly-discovered `.svg` asset to a single still PNG. No consumer composable is
+ * involved — [loadSvgPainter] (Skia-backed, part of Compose Desktop) parses the bytes loaded off
+ * the render classpath (the plugin links the processed-resources dir there) into a [Painter], drawn
+ * inside a fixed sandbox with [ContentScale.Fit] so the artwork keeps its aspect ratio. Sibling of
+ * [renderLottieAsset]; SVG is static, so there is no animated companion. `internal` (not `private`
+ * like [renderLottieAsset]) so the desktop renderer's unit test can drive it directly.
+ */
+internal fun renderSvgAsset(
+  assetPath: String,
+  widthPx: Int,
+  heightPx: Int,
+  density: Float,
+  showBackground: Boolean,
+  backgroundColor: Long,
+  outputFile: File,
+  fileSystem: FileSystem = SystemFileSystem,
+) {
+  val svgBytes = loadClasspathAsset(assetPath)
+  val densityObj = Density(density)
+  val painter = loadSvgPainter(ByteArrayInputStream(svgBytes), densityObj)
+  val scene = ImageComposeScene(width = widthPx, height = heightPx, density = densityObj)
+  try {
+    scene.setContent {
+      CompositionLocalProvider(LocalInspectionMode provides true) {
+        val bgColor =
+          when {
+            backgroundColor != 0L -> Color(backgroundColor.toInt())
+            showBackground -> Color.White
+            else -> Color.Transparent
+          }
+        Box(modifier = Modifier.fillMaxSize().background(bgColor)) {
+          Image(
+            painter = painter,
+            contentDescription = assetPath,
+            modifier = Modifier.fillMaxSize(),
+            contentScale = ContentScale.Fit,
+          )
+        }
+      }
+    }
+    scene.render()
+    val image = scene.render()
+    val pngData =
+      image.encodeToData(EncodedImageFormat.PNG)
+        ?: throw IllegalStateException("Failed to encode SVG frame to PNG")
+    outputFile.parentFile?.mkdirs()
+    fileSystem.write(outputFile.path.toPath()) { write(pngData.bytes) }
+  } finally {
+    scene.close()
+  }
+}
+
+/**
+ * Read a resource off the render classpath as raw bytes. Tries the thread context classloader first
+ * (the render subprocess installs the consumer's classes/resources there), then this file's own
+ * loader as a fallback for plain JVM tests. A leading slash is tolerated. Mirrors the Lottie
+ * runtime's `loadLottieAsset`, but returns bytes (SVG is XML text, but the painter reads a stream).
+ *
+ * @throws IllegalArgumentException when the resource is not on the classpath — a clear authoring
+ *   error ("did you put it under src/main/resources?") rather than a downstream parse failure.
+ */
+private fun loadClasspathAsset(assetPath: String): ByteArray {
+  val normalized = assetPath.removePrefix("/")
+  val loaders =
+    listOfNotNull(Thread.currentThread().contextClassLoader, object {}.javaClass.classLoader)
+  for (loader in loaders) {
+    loader.getResourceAsStream(normalized)?.use { stream ->
+      return stream.readBytes()
+    }
+  }
+  throw IllegalArgumentException(
+    "Asset '$assetPath' not found on the classpath. Put it under src/main/resources " +
+      "(e.g. src/main/resources/$normalized) so the preview plugin links and bundles it."
+  )
 }
 
 @Composable

--- a/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/DesktopSvgRendererTest.kt
+++ b/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/DesktopSvgRendererTest.kt
@@ -1,0 +1,64 @@
+package ee.schimke.composeai.renderer
+
+import java.io.ByteArrayInputStream
+import java.io.File
+import javax.imageio.ImageIO
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * Covers the still SVG capture: [renderSvgAsset] inflates a discovered `.svg` off the render
+ * classpath via Skia's `loadSvgPainter` and encodes a single PNG. The fixture `svg/badge.svg` is a
+ * gradient-filled rounded square with a white ring + triangle, so a correct render is opaque and
+ * multi-coloured (not a blank/transparent frame).
+ */
+class DesktopSvgRendererTest {
+
+  @get:Rule val tempFolder: TemporaryFolder = TemporaryFolder()
+
+  @Test
+  fun `renders a non-empty multi-colour png from a classpath svg`() {
+    val outputFile = File(tempFolder.newFolder("renders"), "badge.png")
+    renderSvgAsset(
+      assetPath = "svg/badge.svg",
+      widthPx = 120,
+      heightPx = 120,
+      density = 1.0f,
+      showBackground = false,
+      backgroundColor = 0L,
+      outputFile = outputFile,
+    )
+
+    assertTrue(
+      "rendered PNG must exist and be non-empty",
+      outputFile.exists() && outputFile.length() > 0,
+    )
+
+    val image = ImageIO.read(ByteArrayInputStream(outputFile.readBytes()))
+    assertTrue("PNG must decode", image != null)
+    // The badge fills the frame with a gradient plus white/dark accents — a correct render has many
+    // distinct colours. A blank or single-fill frame (a decode/draw failure) would have ≤ 2.
+    val distinct = buildSet {
+      for (y in 0 until image.height) for (x in 0 until image.width) add(image.getRGB(x, y))
+    }
+    assertTrue(
+      "expected a multi-colour render, got ${distinct.size} colour(s)",
+      distinct.size > 100,
+    )
+  }
+
+  @Test(expected = IllegalArgumentException::class)
+  fun `missing classpath svg fails with a clear error`() {
+    renderSvgAsset(
+      assetPath = "svg/does-not-exist.svg",
+      widthPx = 32,
+      heightPx = 32,
+      density = 1.0f,
+      showBackground = false,
+      backgroundColor = 0L,
+      outputFile = File(tempFolder.newFolder("out"), "x.png"),
+    )
+  }
+}

--- a/renderers/desktop/src/test/resources/svg/badge.svg
+++ b/renderers/desktop/src/test/resources/svg/badge.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 240" role="img" aria-label="compose-preview SVG sample badge">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#6C5CE7"/>
+      <stop offset="1" stop-color="#00B894"/>
+    </linearGradient>
+  </defs>
+  <rect x="8" y="8" width="224" height="224" rx="44" fill="url(#g)"/>
+  <circle cx="120" cy="120" r="72" fill="none" stroke="#FFFFFF" stroke-width="12" stroke-opacity="0.85"/>
+  <path d="M120 66 L167 148 L73 148 Z" fill="#FFFFFF"/>
+  <circle cx="120" cy="120" r="14" fill="#2D3436"/>
+</svg>

--- a/samples/android/src/main/resources/svg/badge.svg
+++ b/samples/android/src/main/resources/svg/badge.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 240" role="img" aria-label="compose-preview SVG sample badge">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#6C5CE7"/>
+      <stop offset="1" stop-color="#00B894"/>
+    </linearGradient>
+  </defs>
+  <rect x="8" y="8" width="224" height="224" rx="44" fill="url(#g)"/>
+  <circle cx="120" cy="120" r="72" fill="none" stroke="#FFFFFF" stroke-width="12" stroke-opacity="0.85"/>
+  <path d="M120 66 L167 148 L73 148 Z" fill="#FFFFFF"/>
+  <circle cx="120" cy="120" r="14" fill="#2D3436"/>
+</svg>

--- a/samples/cmp/src/main/resources/svg/badge.svg
+++ b/samples/cmp/src/main/resources/svg/badge.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 240" role="img" aria-label="compose-preview SVG sample badge">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#6C5CE7"/>
+      <stop offset="1" stop-color="#00B894"/>
+    </linearGradient>
+  </defs>
+  <rect x="8" y="8" width="224" height="224" rx="44" fill="url(#g)"/>
+  <circle cx="120" cy="120" r="72" fill="none" stroke="#FFFFFF" stroke-width="12" stroke-opacity="0.85"/>
+  <path d="M120 66 L167 148 L73 148 Z" fill="#FFFFFF"/>
+  <circle cx="120" cy="120" r="14" fill="#2D3436"/>
+</svg>


### PR DESCRIPTION
## Summary
Add direct SVG asset discovery and rendering to the preview pipeline, mirroring the existing Lottie asset flow. SVG files in resource directories are now automatically discovered as `PreviewKind.SVG` previews and rendered to PNG via Compose Desktop's Skia-backed `loadSvgPainter`.

## Key Changes

**Discovery & Data Model**
- Add `PreviewKind.SVG` enum value to represent directly-discovered SVG assets (no `@Preview` annotation required)
- Add `svgRenderSubdir` configuration property to `PreviewDiscovery.Input` (defaults to `"renders"`, overridden to `"svg-renders"` on Android to avoid output directory conflicts with Robolectric)
- Implement `discoverSvgAssets()` to scan resource directories for `.svg` files, validate they contain an `<svg>` root element, extract dimensions from `viewBox` or explicit `width`/`height` attributes, and generate `PreviewInfo` entries with filename-safe IDs (prefixed `svg__`)

**Desktop Renderer**
- Implement `renderSvgAsset()` to load SVG bytes from the classpath via `loadClasspathAsset()`, parse them with `loadSvgPainter`, and render to a single still PNG (SVG is static, no animated companion like Lottie)
- Add SVG rendering branch in `DesktopRendererMain.main()` to handle `kind=SVG` previews
- Add `loadClasspathAsset()` utility to load resources from the render classpath with clear error messages

**Android Integration**
- Add `SVG_RENDER_SUBDIR` constant (`"svg-renders"`) to keep JVM SVG renders separate from Robolectric output
- Register `composePreviewRenderSvg` task in Android plugin to render discovered SVG assets via the desktop renderer (Robolectric has no SVG decoder)
- Wire SVG render task into `composePreviewRenderAll` aggregate so stills are produced before manifest validation
- Update `RobolectricRenderTest` to skip `kind=SVG` previews (rendered by JVM path instead)

**Gradle Plugin**
- Add `svgRenderSubdir` property to `DiscoverPreviewsTask` and `ComposePreviewTasks`
- Pass `svgRenderSubdir` to discovery input in both desktop and Android configurations

**Tests & Fixtures**
- Add `SvgAssetDiscoveryTest` covering discovery of SVG files with `viewBox`, explicit dimensions, missing dimensions, and rejection of non-SVG files
- Add `DesktopSvgRendererTest` validating PNG output from classpath SVG rendering
- Add sample `svg/badge.svg` fixture (gradient-filled rounded square with accents) to renderer tests and sample modules

## Implementation Details
- SVG dimension parsing uses regex to extract `width`/`height` attributes and `viewBox` values, with fallback chain: explicit dimensions → `viewBox` → `null`
- Dimensions are rounded to integers via `Float.roundToInt()` and used only to seed canvas aspect ratio
- Asset paths are sanitized by removing file extensions and replacing path separators with underscores to ensure filename-safe render output paths
- SVG rendering uses `ContentScale.Fit` to preserve artwork aspect ratio within the canvas
- Mirrors Lottie asset flow exactly: classpath-relative asset path on `PreviewParams.assetPath`, single required still PNG capture, JVM/desktop-only rendering

https://claude.ai/code/session_01MQisk9C45huv8QBt7pgnE1