### PR TITLE
fix: use valid attribution settings keys and tighten Bash allowlist

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -80,5 +80,5 @@ jobs:
             }
           claude_args: >-
             --max-turns 100
-            --allowedTools "Bash(./gradlew:*)"
+            --allowedTools "Bash(./gradlew:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*)"
             --append-system-prompt "Follow CLAUDE.md and docs/AGENTS.md conventions strictly. Visual evidence is mandatory for any UI-affecting request: render the affected @Preview composables before and after your change with the compose-preview pipeline (./gradlew :samples:android:composePreviewRenderAll, :samples:cmp:composePreviewRenderAll, or the specific module render task), commit the PNGs you cite to your working branch, push, and only then embed them inline in your comment and PR text as markdown images whose URLs are commit-SHA-pinned raw.githubusercontent.com links to those pushed files. Describing an image is not evidence; the reviewer must see pixels inline. When reviewing an existing PR, reuse renders already published on the compose-preview/pr and compose-preview/main branches where possible instead of re-rendering. Use conventional commit subjects (feat:, fix:, ci:, docs:, test:). Never add Co-authored-by trailers or any agent attribution to commits, PR titles, or PR bodies."

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -76,9 +76,9 @@ jobs:
           settings: |
             {
               "includeCoAuthoredBy": false,
-              "attribution": { "coAuthoredBy": false }
+              "attribution": { "commit": "", "pr": "" }
             }
           claude_args: >-
             --max-turns 100
-            --allowedTools "Bash(./gradlew:*),Bash(git:*),Bash(python3:*)"
+            --allowedTools "Bash(./gradlew:*)"
             --append-system-prompt "Follow CLAUDE.md and docs/AGENTS.md conventions strictly. Visual evidence is mandatory for any UI-affecting request: render the affected @Preview composables before and after your change with the compose-preview pipeline (./gradlew :samples:android:composePreviewRenderAll, :samples:cmp:composePreviewRenderAll, or the specific module render task), commit the PNGs you cite to your working branch, push, and only then embed them inline in your comment and PR text as markdown images whose URLs are commit-SHA-pinned raw.githubusercontent.com links to those pushed files. Describing an image is not evidence; the reviewer must see pixels inline. When reviewing an existing PR, reuse renders already published on the compose-preview/pr and compose-preview/main branches where possible instead of re-rendering. Use conventional commit subjects (feat:, fix:, ci:, docs:, test:). Never add Co-authored-by trailers or any agent attribution to commits, PR titles, or PR bodies."


### PR DESCRIPTION
## Summary

Follow-up to #2194/#2205, applying two Codex review findings from the cadence copy of this workflow:

- `settings.attribution` now uses the valid `{"commit": "", "pr": ""}` keys — the previous `coAuthoredBy` key was invalid, and since the `attribution` object takes precedence over the deprecated `includeCoAuthoredBy`, the default `Co-Authored-By` trailer could have stayed enabled and tripped the No Agent Attribution gate on agent-authored commits.
- Tightened the Bash allowlist to `./gradlew` only: `Bash(git:*)` bypassed the action's hardened git tooling (raw flags like `--receive-pack` / `-c core.sshCommand=…` are arbitrary-execution vectors for prompt-injected PR content), and unrestricted `Bash(python3:*)` has the same exfiltration surface. The action's built-in git add/commit + push wrapper covers the agent's commit-and-push needs.

## Test plan

- YAML parsed and `settings` JSON validated locally.
- `attribution: {commit, pr}` key shape confirmed against the Claude Code settings documentation.
- Non-visual change (CI wiring only), text-only evidence per repo convention.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SThVExRiUTasR9ehW9gFSv)_