### PR TITLE
ci: merge passing PRs on a schedule

### DIFF
--- a/.github/workflows/scheduled-merge.yml
+++ b/.github/workflows/scheduled-merge.yml
@@ -1,0 +1,87 @@
+name: Scheduled Merge
+
+# Merges open PRs automatically once they pass the "Protect Main" merge
+# gates: every 30 minutes, any non-draft PR whose mergeable state is `clean`
+# (all required status checks green, no conflicts) is squash-merged.
+#
+# Opt-outs, checked per PR:
+#   - draft PRs are skipped
+#   - the `no-automerge` label blocks merging
+#   - release-please PRs (`autorelease: pending` label) are skipped so
+#     cutting a release stays a deliberate human action
+#
+# GITHUB_TOKEN merges don't fire push-to-main workflows, so after merging
+# this dispatches compose-preview.yml to refresh the render baselines.
+
+on:
+  schedule:
+    - cron: '*/30 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: write
+
+concurrency:
+  group: scheduled-merge
+  cancel-in-progress: false
+
+jobs:
+  merge:
+    name: Merge passing PRs
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/github-script@v8.0.0
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const skipLabels = new Set(['no-automerge', 'autorelease: pending']);
+            // Only PRs targeting main — the CI gates this relies on are
+            // filtered to pull_request against main.
+            const prs = await github.paginate(github.rest.pulls.list, {
+              owner, repo, state: 'open', base: 'main', per_page: 100,
+            });
+            let merged = 0;
+            for (const stub of prs) {
+              if (stub.draft) continue;
+              if (stub.labels.some((l) => skipLabels.has(l.name))) {
+                core.info(`#${stub.number}: opt-out label — skip`);
+                continue;
+              }
+              // pulls.list doesn't populate mergeable_state; fetch the PR.
+              const { data: pr } = await github.rest.pulls.get({
+                owner, repo, pull_number: stub.number,
+              });
+              if (pr.mergeable_state !== 'clean') {
+                core.info(`#${pr.number}: ${pr.mergeable_state} — skip`);
+                continue;
+              }
+              try {
+                // sha guard: reject the merge if the head moved after the
+                // mergeable_state check (race with a new push).
+                await github.rest.pulls.merge({
+                  owner, repo, pull_number: pr.number, merge_method: 'squash',
+                  sha: pr.head.sha,
+                });
+                core.notice(`Merged #${pr.number}: ${pr.title}`);
+                merged++;
+              } catch (e) {
+                core.warning(`#${pr.number}: merge failed — ${e.message}`);
+              }
+            }
+            if (merged > 0) {
+              // GITHUB_TOKEN merges don't trigger push workflows; explicitly
+              // refresh the render baselines and the release-please PR.
+              for (const wf of ['compose-preview.yml', 'vscode-preview-baselines.yml', 'release-please.yml', 'design-artifacts.yml']) {
+                try {
+                  await github.rest.actions.createWorkflowDispatch({
+                    owner, repo, workflow_id: wf, ref: 'main',
+                  });
+                  core.info(`Dispatched ${wf}`);
+                } catch (e) {
+                  core.warning(`${wf} dispatch failed: ${e.message}`);
+                }
+              }
+            }


### PR DESCRIPTION
## Summary

Brings the scheduled auto-merge workflow (already merged in cadence#115, meshcore-mobile#174, homeassistant-remotecompose#450, in flight in design-parity#171) to this repo: every 30 minutes, squash-merges open non-draft PRs targeting `main` whose `mergeable_state` is `clean` — i.e. all required checks from the existing "Protect Main" ruleset pass and there are no conflicts — with a `sha` guard so a push after the green-check snapshot rejects the merge.

Opt-outs: drafts, a `no-automerge` label, and release-please PRs (`autorelease: pending`) so cutting a release stays a deliberate action.

Because `GITHUB_TOKEN` merges don't fire push-to-main workflows, after merging it dispatches the four push-driven surfaces: `compose-preview.yml` and `vscode-preview-baselines.yml` (render baselines), `release-please.yml` (release PR), and `design-artifacts.yml` (delivery branches, per the CLAUDE.md regeneration rule).

## Test plan

- YAML parsed locally; script identical to the copies already merged in the sibling repos (only the dispatch list differs), which incorporate the Codex review hardening (base-main filter, head-SHA guard, release automation dispatch).
- Non-visual change (CI wiring only).
- After merge: trigger via workflow_dispatch and confirm it skips open PRs correctly; the existing ruleset's required checks are what `clean` gates on.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SThVExRiUTasR9ehW9gFSv)_