### PR TITLE
feat: portable SVG bundles + SvgPreview authoring composable

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -134,6 +134,7 @@ tasks.register("functionalTestWithAndroid") {
 //     implementation :data-deviceframe-connector (device-art bezel compositing — post-capture)
 //       api :data-deviceframe-core
 //     implementation :lottie-preview-runtime (Compottie-backed kind=LOTTIE render path)
+//     implementation :svg-preview-runtime (Skia loadSvgPainter kind=SVG render path)
 //   plus :common-io (the Okio file-IO foundation those modules read/write through).
 val bundleRenderFunctionalTestPublishTargets =
   listOf(
@@ -151,6 +152,7 @@ val bundleRenderFunctionalTestPublishTargets =
     ":data-layoutinspector-core",
     ":data-theme-core",
     ":lottie-preview-runtime",
+    ":svg-preview-runtime",
     ":common-io",
   )
 

--- a/bundle-viewer/src/main/kotlin/ee/schimke/composeai/viewer/Schema.kt
+++ b/bundle-viewer/src/main/kotlin/ee/schimke/composeai/viewer/Schema.kt
@@ -48,8 +48,9 @@ data class BundleManifest(
 data class BundleIr(
   val previewId: String,
   /**
-   * `remotecompose` (RC doc), `protolayout` (Wear tile Layout proto), or `lottie` (a Lottie
-   * animation asset packed straight from the module resources).
+   * `remotecompose` (RC doc), `protolayout` (Wear tile Layout proto), `lottie` (a Lottie animation
+   * asset packed straight from the module resources), or `svg` (a static SVG asset, likewise packed
+   * from the module resources).
    */
   val format: String,
   val path: String,

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/BundleFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/BundleFunctionalTest.kt
@@ -291,6 +291,48 @@ class BundleFunctionalTest {
   }
 
   @Test
+  fun `composePreviewBundle packs a discovered SVG as raw svg IR`() {
+    val projectDir = createTestProject()
+    // Drop an SVG under the module resources — discovery turns it into a `kind=SVG` preview, and
+    // the
+    // bundle must carry the raw `.svg` as IR (self-contained, like Lottie) rather than dropping it.
+    val svg =
+      """<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect width="24" height="24"/></svg>"""
+    File(projectDir, "src/main/resources/svg").apply { mkdirs() }
+    File(projectDir, "src/main/resources/svg/badge.svg").writeText(svg)
+    val svgId = "svg__svg_badge"
+
+    // Discover in its own invocation so `processResources` stages the `.svg` into the processed
+    // resources dir before the resource scan runs (the same dir the bundle later reads its IR
+    // from).
+    GradleRunner.create()
+      .withProjectDir(projectDir)
+      .withArguments("composePreviewDiscover")
+      .withPluginClasspath()
+      .build()
+
+    val previewsJson = File(projectDir, "build/compose-previews/previews.json")
+    val manifest = json.decodeFromString(PreviewManifest.serializer(), previewsJson.readText())
+    val svgPreview = manifest.previews.singleOrNull { it.id == svgId }
+    assertThat(svgPreview).isNotNull()
+    assertThat(svgPreview!!.params.kind).isEqualTo(PreviewKind.SVG)
+
+    val result =
+      GradleRunner.create()
+        .withProjectDir(projectDir)
+        .withArguments("composePreviewBundle", "-PbundlePreviewIds=$svgId", "--stacktrace")
+        .withPluginClasspath()
+        .build()
+    assertThat(result.task(":composePreviewBundle")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+
+    val bundle = File(projectDir, "build/compose-previews/bundle.png")
+    // The raw SVG travels verbatim under `ir/<id>.svg`, so a player can re-render it with zero
+    // consumer bytecode.
+    assertThat(listEntries(bundle)).contains("ir/$svgId.svg")
+    assertThat(String(readZipEntry(bundle, "ir/$svgId.svg")!!, Charsets.UTF_8)).isEqualTo(svg)
+  }
+
+  @Test
   fun `composePreviewBundle packs the per-sheet catalog-token sidecar`() {
     val projectDir = createTestProject()
 

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
@@ -613,27 +613,30 @@ abstract class BundlePreviewTask : DefaultTask() {
    */
   private fun resolvePreviewPng(preview: PreviewInfo): ByteArray? {
     val rendersRoot = rendersDir.orNull?.asFile ?: return null
-    // `renderOutput` is module-relative under `build/compose-previews/`, e.g. `renders/<id>.png`.
-    // The rendersDir input points at the `renders/` dir itself.
+    // `renderOutput` is relative to the compose-previews ROOT (the parent of `renders/`), e.g.
+    // `renders/<id>.png` — or `svg-renders/<id>.png` / `lottie-renders/<id>.png` for the JVM asset
+    // passes whose disjoint output dirs keep them build-cacheable. Resolve against that root (not
+    // the
+    // `renders/` leaf), the same way the renderer resolves `renderOutput`, so a cover living in a
+    // sibling subdir isn't missed and silently replaced by the stub gray cover.
+    val previewsRoot = rendersRoot.parentFile ?: rendersRoot
     val rel =
       preview.captures.firstOrNull()?.renderOutput?.takeIf { it.isNotEmpty() } ?: return null
-    val name = rel.substringAfterLast('/')
+    val primary = File(previewsRoot, rel)
+    val subdir = primary.parentFile ?: rendersRoot
+    val name = primary.name
     val base = name.substringBeforeLast('.')
 
     // Only read the primary-capture file directly when it's a PNG. A GIF (or any non-PNG) primary
     // capture is skipped here so its bytes never become the cover; the sibling search below is
     // already PNG-filtered.
-    if (name.endsWith(".png")) {
-      val exact = File(rendersRoot, name)
-      if (exact.isFile && exact.length() > 0) return exact.readBytes()
-    }
+    if (name.endsWith(".png") && primary.isFile && primary.length() > 0) return primary.readBytes()
 
     // No usable PNG at the primary capture's path: @PreviewParameter / multi-variant previews fan
-    // out into siblings (`<base>_<param>.png`, `<base>--<dimension>.png`). Bake the first sibling
-    // as
-    // a representative cover so the preview isn't silently dropped from the bundle.
-    if (!rendersRoot.isDirectory) return null
-    return rendersRoot
+    // out into siblings (`<base>_<param>.png`, `<base>--<dimension>.png`) in the same subdir. Bake
+    // the first sibling as a representative cover so the preview isn't silently dropped.
+    if (!subdir.isDirectory) return null
+    return subdir
       .listFiles { f ->
         f.isFile &&
           f.length() > 0 &&
@@ -716,6 +719,21 @@ abstract class BundlePreviewTask : DefaultTask() {
       return ResolvedIr(
         format = IR_FORMAT_LOTTIE,
         ext = assetPath.substringAfterLast('.', missingDelimiterValue = "json"),
+        bytes = assetFile.readBytes(),
+      )
+    }
+
+    // kind=SVG: same self-contained shape as LOTTIE — the IR is the raw `.svg` read off the module
+    // resources, so the bundle carries the source artwork regardless of which render subdir
+    // (`svg-renders/` on Android) the still PNG landed in.
+    if (preview.params.kind == PreviewKind.SVG) {
+      val assetPath = preview.params.assetPath ?: return null
+      val resourcesRoot = moduleResourcesDir.orNull?.asFile ?: return null
+      val assetFile = File(resourcesRoot, assetPath)
+      if (!assetFile.isFile || assetFile.length() == 0L) return null
+      return ResolvedIr(
+        format = IR_FORMAT_SVG,
+        ext = assetPath.substringAfterLast('.', missingDelimiterValue = "svg"),
         bytes = assetFile.readBytes(),
       )
     }

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -487,6 +487,14 @@ internal object ComposePreviewTasks {
       // bundle.
       rendersDir.set(previewOutputDir.map { it.dir("renders") })
       renderFiles.from(previewOutputDir.map { it.dir("renders") })
+      // The JVM asset passes render into disjoint sibling dirs (kept out of `renders/` so they
+      // don't
+      // fight the Robolectric render for build-cache); their covers/IR are resolved relative to the
+      // previews root, so track them as inputs too. Absent on desktop (SVG/Lottie land in
+      // `renders/`
+      // there) — an absent dir snapshots as empty, so this is a harmless no-op on that backend.
+      renderFiles.from(previewOutputDir.map { it.dir(AndroidPreviewSupport.SVG_RENDER_SUBDIR) })
+      renderFiles.from(previewOutputDir.map { it.dir(AndroidPreviewSupport.LOTTIE_RENDER_SUBDIR) })
       // Catalog-token sidecars live under `data/catalog-tokens/` (a sibling of `renders/`), outside
       // `renderFiles`' tree — track them as their own input so the bundle re-packs when a sidecar
       // appears/changes (see `catalogTokenFiles` on the task).

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewBundleFormat.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewBundleFormat.kt
@@ -264,7 +264,10 @@ data class BundleAndroidResources(
 data class BundleIr(
   /** Preview id this IR renders; matches an entry in [BundleManifest.previewIds]. */
   val previewId: String,
-  /** IR flavour: [IR_FORMAT_REMOTECOMPOSE], [IR_FORMAT_PROTOLAYOUT], or [IR_FORMAT_LOTTIE]. */
+  /**
+   * IR flavour: [IR_FORMAT_REMOTECOMPOSE], [IR_FORMAT_PROTOLAYOUT], [IR_FORMAT_LOTTIE], or
+   * [IR_FORMAT_SVG].
+   */
   val format: String,
   /** Posix zip path of the IR bytes, e.g. `ir/<id>.rcdoc` or `ir/<id>.tilelayout`. */
   val path: String,
@@ -460,6 +463,15 @@ const val IR_FORMAT_PROTOLAYOUT: String = "protolayout"
  * (`ir/<id>.json` or `ir/<id>.lottie`); `format` is what the replayer keys on.
  */
 const val IR_FORMAT_LOTTIE: String = "lottie"
+
+/**
+ * [BundleIr.format] for an SVG image asset. Like [IR_FORMAT_LOTTIE] its IR is the asset file itself
+ * — the raw `.svg` read straight off the module resources at pack time — so the bundle is
+ * self-contained and travels the source artwork regardless of which render subdir the still PNG
+ * landed in. The zip entry keeps the `.svg` extension (`ir/<id>.svg`); `format` is what a replayer
+ * keys on. Static, so there is no animated companion (contrast [IR_FORMAT_LOTTIE]).
+ */
+const val IR_FORMAT_SVG: String = "svg"
 
 /** Well-known directory inside the bundle zip holding per-preview IR bytes (`ir/<id>.<ext>`). */
 const val BUNDLE_IR_DIR: String = "ir"

--- a/renderers/desktop/build.gradle.kts
+++ b/renderers/desktop/build.gradle.kts
@@ -34,6 +34,9 @@ dependencies {
   // `kind=LOTTIE` previews: DesktopRendererMain inflates a discovered Lottie asset via the
   // `LottiePreview` helper (brings Compottie + Compose foundation transitively).
   implementation(project(":lottie-preview-runtime"))
+  // `kind=SVG` previews: DesktopRendererMain draws a discovered SVG asset via the `SvgPreview`
+  // helper (Skia-backed `loadSvgPainter`, shared with the consumer-facing authoring path).
+  implementation(project(":svg-preview-runtime"))
   // Pure-JVM accent / bidi transforms + the `Pseudolocale` enum used to detect `en-XA` / `ar-XB`
   // tags. Renderer applies the around-composable inline (LocalLayoutDirection.Rtl for ar-XB) and
   // rewrites the locale tag before it reaches `LocaleList`.

--- a/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRendererMain.kt
+++ b/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRendererMain.kt
@@ -1,6 +1,5 @@
 package ee.schimke.composeai.renderer
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
@@ -17,7 +16,6 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.layout
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalInspectionMode
-import androidx.compose.ui.res.loadSvgPainter
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntSize
@@ -28,6 +26,8 @@ import ee.schimke.composeai.daemon.DisplayFilterConfig
 import ee.schimke.composeai.daemon.DisplayFilterDataProducer
 import ee.schimke.composeai.io.SystemFileSystem
 import ee.schimke.composeai.preview.lottie.LottiePreview
+import ee.schimke.composeai.preview.svg.SvgPreview
+import ee.schimke.composeai.preview.svg.loadSvgAsset
 import ee.schimke.composeai.scroll.ScrollAxis as ProductScrollAxis
 import java.io.ByteArrayInputStream
 import java.io.File
@@ -950,11 +950,12 @@ private fun renderLottieAsset(
 }
 
 /**
- * Render a directly-discovered `.svg` asset to a single still PNG. No consumer composable is
- * involved — [loadSvgPainter] (Skia-backed, part of Compose Desktop) parses the bytes loaded off
- * the render classpath (the plugin links the processed-resources dir there) into a [Painter], drawn
- * inside a fixed sandbox with [ContentScale.Fit] so the artwork keeps its aspect ratio. Sibling of
- * [renderLottieAsset]; SVG is static, so there is no animated companion. `internal` (not `private`
+ * Render a directly-discovered `.svg` asset to a single still PNG. The consumer-facing [SvgPreview]
+ * runtime helper does the drawing (Skia-backed `loadSvgPainter` → `Painter` → `Image` at
+ * [ContentScale.Fit]), the same way [renderLottieAsset] delegates to `LottiePreview`. The asset is
+ * loaded **eagerly** via [loadSvgAsset] before composition so a missing file surfaces a clear
+ * [IllegalArgumentException] the caller can turn into an error sidecar, rather than throwing deep
+ * inside `render()`. SVG is static, so there is no animated companion. `internal` (not `private`
  * like [renderLottieAsset]) so the desktop renderer's unit test can drive it directly.
  */
 internal fun renderSvgAsset(
@@ -967,10 +968,8 @@ internal fun renderSvgAsset(
   outputFile: File,
   fileSystem: FileSystem = SystemFileSystem,
 ) {
-  val svgBytes = loadClasspathAsset(assetPath)
-  val densityObj = Density(density)
-  val painter = loadSvgPainter(ByteArrayInputStream(svgBytes), densityObj)
-  val scene = ImageComposeScene(width = widthPx, height = heightPx, density = densityObj)
+  val svgBytes = loadSvgAsset(assetPath)
+  val scene = ImageComposeScene(width = widthPx, height = heightPx, density = Density(density))
   try {
     scene.setContent {
       CompositionLocalProvider(LocalInspectionMode provides true) {
@@ -981,8 +980,8 @@ internal fun renderSvgAsset(
             else -> Color.Transparent
           }
         Box(modifier = Modifier.fillMaxSize().background(bgColor)) {
-          Image(
-            painter = painter,
+          SvgPreview(
+            bytes = svgBytes,
             contentDescription = assetPath,
             modifier = Modifier.fillMaxSize(),
             contentScale = ContentScale.Fit,
@@ -1000,30 +999,6 @@ internal fun renderSvgAsset(
   } finally {
     scene.close()
   }
-}
-
-/**
- * Read a resource off the render classpath as raw bytes. Tries the thread context classloader first
- * (the render subprocess installs the consumer's classes/resources there), then this file's own
- * loader as a fallback for plain JVM tests. A leading slash is tolerated. Mirrors the Lottie
- * runtime's `loadLottieAsset`, but returns bytes (SVG is XML text, but the painter reads a stream).
- *
- * @throws IllegalArgumentException when the resource is not on the classpath — a clear authoring
- *   error ("did you put it under src/main/resources?") rather than a downstream parse failure.
- */
-private fun loadClasspathAsset(assetPath: String): ByteArray {
-  val normalized = assetPath.removePrefix("/")
-  val loaders =
-    listOfNotNull(Thread.currentThread().contextClassLoader, object {}.javaClass.classLoader)
-  for (loader in loaders) {
-    loader.getResourceAsStream(normalized)?.use { stream ->
-      return stream.readBytes()
-    }
-  }
-  throw IllegalArgumentException(
-    "Asset '$assetPath' not found on the classpath. Put it under src/main/resources " +
-      "(e.g. src/main/resources/$normalized) so the preview plugin links and bundles it."
-  )
 }
 
 @Composable

--- a/runtimes/svg/build.gradle.kts
+++ b/runtimes/svg/build.gradle.kts
@@ -1,0 +1,44 @@
+// `:svg-preview-runtime` — composable-helper authoring path for SVG image previews. Sister to
+// `:lottie-preview-runtime`, and JVM/Desktop-flavoured for the same reason: it leans on Compose
+// Desktop's Skia-backed `androidx.compose.ui.res.loadSvgPainter`, which turns raw SVG bytes into a
+// first-class Compose `Painter` on the `ImageComposeScene` renderer with no platform image APIs.
+//
+// `SvgPreview(asset = "svg/badge.svg", colorFilter = ColorFilter.tint(Color.Red))` loads an SVG
+// from a classpath resource (the consumer ships the `.svg` under `src/main/resources/`, which the
+// preview plugin links onto the render classpath and packs into the bundle) and draws it, so an
+// author can tint / scale / place the artwork inside a larger `@Preview`. Unlike Lottie there is no
+// timeline — SVG is static, so there is no `progress` knob.
+//
+// Standalone on purpose — no compile dep on `:renderer-desktop` so the helper can be used in plain
+// JVM unit tests or Bazel modules that don't carry the renderer.
+
+plugins {
+  id("composeai.base-conventions")
+  id("composeai.maven-publishing")
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.compose.multiplatform)
+  alias(libs.plugins.compose.compiler)
+}
+
+dependencies {
+  api(libs.jetbrains.compose.runtime)
+  api(libs.jetbrains.compose.foundation)
+  // `compose.ui` carries `androidx.compose.ui.res.loadSvgPainter` (Skia-backed) — the whole point
+  // of
+  // this module — so it's `api` rather than `implementation`.
+  api(libs.jetbrains.compose.ui)
+
+  testImplementation(libs.junit)
+}
+
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "svg-preview-runtime",
+    displayName = "Compose Preview — SVG Runtime",
+    description =
+      "Composable helper that renders an SVG image asset inside a Compose `@Preview` (with optional " +
+        "tint / content-scale), so authors can capture `.svg` artwork through the compose-preview " +
+        "pipeline (Desktop renderer via Skia's loadSvgPainter).",
+  )
+  inceptionYear.set("2026")
+}

--- a/runtimes/svg/src/main/kotlin/ee/schimke/composeai/preview/svg/SvgPreview.kt
+++ b/runtimes/svg/src/main/kotlin/ee/schimke/composeai/preview/svg/SvgPreview.kt
@@ -1,0 +1,107 @@
+package ee.schimke.composeai.preview.svg
+
+import androidx.compose.foundation.Image
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.loadSvgPainter
+import java.io.ByteArrayInputStream
+
+/**
+ * Renders an SVG image [asset] inside a regular Compose `@Preview`.
+ *
+ * Authoring path for SVG previews, sibling to `LottiePreview` — the customization escape hatch over
+ * the zero-config "just drop a `.svg` under resources" discovery. The consumer ships the artwork
+ * under `src/main/resources/` (e.g. `svg/badge.svg`); the compose-preview plugin links the
+ * processed-resources dir onto the render classpath, so [asset] is resolved by the classloader at
+ * render time, and packs the same file into bundles so the artwork travels with the preview.
+ *
+ * The SVG is parsed **synchronously** via [loadSvgPainter] (Skia-backed, part of Compose Desktop)
+ * so the first composed frame already has the full document — the Desktop renderer captures after
+ * only two `scene.render()` passes and does not pump coroutines, so an async load would render
+ * blank.
+ *
+ * Unlike Lottie there is no timeline: SVG is static (SMIL/CSS animation isn't replayed by
+ * `loadSvgPainter`), so there is no `progress` knob — just how the artwork is fitted and tinted.
+ *
+ * @param asset classpath resource path of the SVG (leading slash optional), e.g. `"svg/badge.svg"`.
+ * @param contentScale how the artwork is fitted into [modifier]'s bounds. Defaults to
+ *   [ContentScale.Fit] so the SVG keeps its aspect ratio.
+ * @param colorFilter optional tint applied to the whole drawing — `ColorFilter.tint(color)`
+ *   recolors a monochrome icon. Defaults to `null` (draw the SVG's own colors).
+ */
+@Composable
+fun SvgPreview(
+  asset: String,
+  modifier: Modifier = Modifier,
+  contentScale: ContentScale = ContentScale.Fit,
+  colorFilter: ColorFilter? = null,
+) {
+  val bytes = remember(asset) { loadSvgAsset(asset) }
+  SvgPreview(
+    bytes = bytes,
+    contentDescription = asset,
+    modifier = modifier,
+    contentScale = contentScale,
+    colorFilter = colorFilter,
+  )
+}
+
+/**
+ * Pre-loaded-bytes overload: draws [bytes] (a raw SVG document) rather than resolving a classpath
+ * resource. This is the seam the Desktop renderer's zero-config `kind=SVG` path uses — it loads the
+ * asset eagerly (so a missing file surfaces a clear [IllegalArgumentException] before composition)
+ * and hands the bytes here, keeping a single draw implementation shared with the [asset] overload.
+ *
+ * @param bytes the raw SVG document.
+ * @param contentScale how the artwork is fitted into [modifier]'s bounds. Defaults to
+ *   [ContentScale.Fit].
+ * @param colorFilter optional tint applied to the whole drawing. Defaults to `null`.
+ */
+@Composable
+fun SvgPreview(
+  bytes: ByteArray,
+  modifier: Modifier = Modifier,
+  contentDescription: String? = null,
+  contentScale: ContentScale = ContentScale.Fit,
+  colorFilter: ColorFilter? = null,
+) {
+  val density = LocalDensity.current
+  val painter = remember(bytes, density) { loadSvgPainter(ByteArrayInputStream(bytes), density) }
+  Image(
+    painter = painter,
+    contentDescription = contentDescription,
+    modifier = modifier,
+    contentScale = contentScale,
+    colorFilter = colorFilter,
+  )
+}
+
+/**
+ * Reads an SVG asset from the classpath as raw bytes. Tries the thread context classloader first
+ * (the render subprocess installs the consumer's classes/resources there), then this class's own
+ * loader as a fallback for plain JVM unit tests. A leading slash is tolerated.
+ *
+ * @throws IllegalArgumentException when the resource is not on the classpath — a clear authoring
+ *   error ("did you put it under src/main/resources?") rather than a downstream parse failure.
+ */
+fun loadSvgAsset(asset: String): ByteArray {
+  val normalized = asset.removePrefix("/")
+  val loaders =
+    listOfNotNull(Thread.currentThread().contextClassLoader, SvgAssetMarker::class.java.classLoader)
+  for (loader in loaders) {
+    loader.getResourceAsStream(normalized)?.use { stream ->
+      return stream.readBytes()
+    }
+  }
+  throw IllegalArgumentException(
+    "SVG asset '$asset' not found on the classpath. Put it under src/main/resources " +
+      "(e.g. src/main/resources/$normalized) so the preview plugin links and bundles it."
+  )
+}
+
+/** Stable anchor for `::class.java.classLoader`; avoids depending on the inline lambda's loader. */
+private object SvgAssetMarker

--- a/runtimes/svg/src/test/kotlin/ee/schimke/composeai/preview/svg/SvgAssetTest.kt
+++ b/runtimes/svg/src/test/kotlin/ee/schimke/composeai/preview/svg/SvgAssetTest.kt
@@ -1,0 +1,29 @@
+package ee.schimke.composeai.preview.svg
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SvgAssetTest {
+  @Test
+  fun loadsAssetFromClasspath() {
+    val bytes = loadSvgAsset("svg/test-badge.svg")
+    assertTrue("expected SVG content", bytes.decodeToString().contains("<svg"))
+  }
+
+  @Test
+  fun toleratesLeadingSlash() {
+    assertArrayEquals(loadSvgAsset("svg/test-badge.svg"), loadSvgAsset("/svg/test-badge.svg"))
+  }
+
+  @Test
+  fun missingAssetThrowsHelpfully() {
+    val ex =
+      assertThrows(IllegalArgumentException::class.java) { loadSvgAsset("svg/does-not-exist.svg") }
+    assertTrue(
+      "message should point at src/main/resources",
+      ex.message!!.contains("src/main/resources"),
+    )
+  }
+}

--- a/runtimes/svg/src/test/resources/svg/test-badge.svg
+++ b/runtimes/svg/src/test/resources/svg/test-badge.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 240" role="img" aria-label="compose-preview SVG sample badge">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#6C5CE7"/>
+      <stop offset="1" stop-color="#00B894"/>
+    </linearGradient>
+  </defs>
+  <rect x="8" y="8" width="224" height="224" rx="44" fill="url(#g)"/>
+  <circle cx="120" cy="120" r="72" fill="none" stroke="#FFFFFF" stroke-width="12" stroke-opacity="0.85"/>
+  <path d="M120 66 L167 148 L73 148 Z" fill="#FFFFFF"/>
+  <circle cx="120" cy="120" r="14" fill="#2D3436"/>
+</svg>

--- a/samples/cmp/build.gradle.kts
+++ b/samples/cmp/build.gradle.kts
@@ -24,6 +24,9 @@ dependencies {
   // `LottiePreview(...)` — renders a Lottie `.json` asset (from src/main/resources) at a fixed
   // progress through the desktop renderer. Brings Compottie transitively.
   implementation(project(":lottie-preview-runtime"))
+  // `SvgPreview(...)` — draws an SVG `.svg` asset (from src/main/resources), optionally tinted,
+  // through the desktop renderer (Skia's loadSvgPainter).
+  implementation(project(":svg-preview-runtime"))
   // `previewOverride*` — opt-in editable knobs (label / list length / per-item indexed values) the
   // daemon can seed and a served bundle can present as editable controls.
   implementation(project(":data-preview-overrides-runtime"))

--- a/samples/cmp/src/main/kotlin/com/example/samplecmp/SvgPreviews.kt
+++ b/samples/cmp/src/main/kotlin/com/example/samplecmp/SvgPreviews.kt
@@ -1,0 +1,34 @@
+package com.example.samplecmp
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import ee.schimke.composeai.preview.svg.SvgPreview
+
+/**
+ * SVG image previews driven by `:svg-preview-runtime`'s [SvgPreview] helper — the customization
+ * escape hatch over the zero-config discovery (the same `svg/badge.svg` also surfaces as a
+ * `kind=SVG` still just by living under `src/main/resources/`). The plugin links the asset onto the
+ * render classpath and packs it into bundles. Below: the full-color badge at its own colors, and a
+ * monochrome `star.svg` icon recolored via `ColorFilter.tint` — `tint` keeps alpha, so on a
+ * transparent-background icon it visibly recolors the shape (the intended use).
+ */
+@Preview
+@Composable
+fun SvgBadgePreview() {
+  SvgPreview(asset = "svg/badge.svg", modifier = Modifier.size(200.dp))
+}
+
+@Preview
+@Composable
+fun SvgStarTintedPreview() {
+  SvgPreview(
+    asset = "svg/star.svg",
+    modifier = Modifier.size(200.dp),
+    colorFilter = ColorFilter.tint(Color(0xFFEA4335)),
+  )
+}

--- a/samples/cmp/src/main/resources/svg/star.svg
+++ b/samples/cmp/src/main/resources/svg/star.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#2D3436" role="img" aria-label="star icon">
+  <path d="M12 2.2l2.95 5.98 6.6.96-4.77 4.65 1.13 6.57L12 17.98l-5.9 3.1 1.12-6.57L2.45 9.14l6.6-.96z"/>
+</svg>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -168,6 +168,10 @@ include(":lottie-preview-runtime")
 
 project(":lottie-preview-runtime").projectDir = file("runtimes/lottie")
 
+include(":svg-preview-runtime")
+
+project(":svg-preview-runtime").projectDir = file("runtimes/svg")
+
 include(":samples:android")
 
 // Compose Material 3 **design catalog** — one `@Preview` per component in its


### PR DESCRIPTION
Two follow-ups to #2207 (SVG asset discovery + rendering), addressing the review comments left there.

## 1. Portable SVG bundles (Codex P2 on #2207)

Bundling a module that contains an SVG previously dropped the artwork: the still landed under `svg-renders/` (Android) but the bundle only resolved covers under `renders/`, so it fell back to the stub gray cover.

- **Cover PNG** — resolved via the capture's full `renderOutput` path under the compose-previews root (not the `renders/` leaf), so covers in the disjoint `svg-renders/` and `lottie-renders/` subdirs are found rather than silently stubbed. This is the user-visible fix and it works on **both backends** (Android + desktop). Fixes the same latent gap for Lottie-on-Android too.
- **Portable IR** — carry the raw `.svg` as `IR_FORMAT_SVG` → `ir/<id>.svg`, read off the module resources at pack time (same self-contained shape as Lottie). This travels on the **desktop** backend, where `moduleResourcesDir` resolves the processed resources. On **Android** the IR is currently a no-op — `moduleResourcesDir` is wired from the JVM processed-resource candidates, which an Android module doesn't populate, so `resolvePreviewIr` returns null. This is a **pre-existing limitation shared with Lottie** (identical branch, identical null), not introduced here; the Android bundle still shows the correct cover via the fix above. Wiring the Android source / AGP `java_res` dirs into the bundle task (fixing IR self-containment for both SVG **and** Lottie on Android) is a good separate follow-up — it's a shared-bundle change untestable without an Android SDK in the authoring sandbox.
- Track those sibling render dirs as bundle inputs so incremental packs stay correct.

## 2. `SvgPreview` authoring composable

The customization escape hatch over zero-config discovery, sibling to `LottiePreview`:

```kotlin
SvgPreview(asset = "svg/star.svg", colorFilter = ColorFilter.tint(Color.Red))
```

- New `:svg-preview-runtime` module (JVM/Desktop, mirrors `:lottie-preview-runtime`) with the `SvgPreview` composable (`asset` + pre-loaded-`bytes` overloads, a `ColorFilter` tint knob, `ContentScale`) and a `loadSvgAsset` classpath loader. SVG is static — no `progress` knob.
- Unified the merged zero-config `kind=SVG` renderer to draw through `SvgPreview` (bytes overload) + reuse `loadSvgAsset`, the same way `renderLottieAsset` delegates to `LottiePreview` — one shared draw path, no duplicated inline painter.
- `:renderer-desktop` gains the new dep, so `:svg-preview-runtime` is added to the `bundleRenderFunctionalTestPublishTargets` prepublish closure.
- Sample `SvgPreviews.kt`: the full-color `badge.svg` at its own colors, and a monochrome `star.svg` recolored via `ColorFilter.tint`.

## Visual evidence

New committed fixtures (`samples/cmp/.../svg/badge.svg`, `star.svg`) + `@Preview` functions are wired into the preview harness, so the CI visual-diff bot renders and diffs them inline on this PR automatically (`SvgBadgePreview`, `SvgStarTintedPreview`, and the zero-config `svg__svg_badge` / `svg__svg_star` stills). Locally verified: `star.svg` renders as a dark star, and the tinted preview recolors it to solid red while preserving the transparent background — confirming the `colorFilter` knob. (The rendered PNGs live under `build/` so they can't be embedded via commit-pinned raw URLs from this branch; the bot comment carries the pixels.)

## Test plan

- `:svg-preview-runtime:test` — `SvgAssetTest` (classpath load, leading-slash tolerance, helpful missing-asset error) ✅
- `:renderer-desktop:test` — `DesktopSvgRendererTest` still green after the `SvgPreview` unification ✅
- `:gradle-plugin:functionalTest` — `BundleFunctionalTest` new case packs a discovered SVG as raw `ir/<id>.svg`; the other 13 bundle cases stay green (shared `resolvePreviewPng` / `renderFiles` changes are regression-free) ✅
- `:samples:cmp:composePreviewRenderAll` — all SVG previews (composable + zero-config stills) render end-to-end ✅

_The Android renderer compile is CI-only (no SDK in the authoring sandbox); no Android-specific source changed in this PR beyond bundle input wiring._