### PR TITLE
fix: carry SVG/Lottie asset IR in Android bundles

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -2404,6 +2404,15 @@ internal object AndroidPreviewSupport {
         },
       )
 
+    // Resolve `kind=SVG` / `kind=LOTTIE` asset IR off the Android source resource roots. AGP
+    // doesn't
+    // stage java resources into the JVM `build/resources/main` dir the shared bundle task probes
+    // for `moduleResourcesDir`, so without these roots the Android bundle drops the raw `.svg` /
+    // `.json` even though discovery found it under the same dirs. Same source set the Android
+    // render
+    // classpath links (`androidLottieResourceDirs`), so the assetPath discovery recorded resolves.
+    bundleTask.configure { moduleResourceRoots.from(androidLottieResourceDirs(project)) }
+
     // Feed the variant's OWN compiled classes into the bundle packer via AGP's scoped-artifact API,
     // mirroring the identical `forScope(PROJECT).toGet(CLASSES, …)` wiring `composePreviewDiscover`
     // uses (issue #1924). Discovery resolves previews from the scoped artifact, so without this the

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
@@ -130,6 +130,22 @@ abstract class BundlePreviewTask : DefaultTask() {
   abstract val moduleResourcesDir: DirectoryProperty
 
   /**
+   * Additional module resource ROOT dirs to resolve data-driven asset IR (`kind=LOTTIE` /
+   * `kind=SVG`) against, tried after [moduleResourcesDir]. The Android path wires its source
+   * resource roots here (`src/main/resources`, `src/commonMain/resources`,
+   * `src/androidMain/resources` — the same dirs discovery scans and the JVM render classpath
+   * links), because AGP does not stage java resources into the JVM `build/resources/main` dir
+   * [moduleResourcesDir] probes — so without this an Android bundle drops the raw `.svg` / `.json`
+   * asset even though it was discovered and rendered. Empty on desktop (the processed-resources dir
+   * handles it), so this is a no-op there. `@InputFiles @Optional` so absent roots snapshot as
+   * empty rather than failing the build.
+   */
+  @get:InputFiles
+  @get:Optional
+  @get:PathSensitive(PathSensitivity.RELATIVE)
+  abstract val moduleResourceRoots: ConfigurableFileCollection
+
+  /**
    * Third-party runtime classpath jars. Used to drive the ClassGraph closure walk and to look up
    * source coordinates via [dependencyCoordinates] — jars themselves are NOT inlined into the
    * bundle (apart from project-dep fallbacks).
@@ -706,36 +722,46 @@ abstract class BundlePreviewTask : DefaultTask() {
   private fun sanitizeCatalogTokenId(id: String): String =
     id.replace(Regex("""[/\\:*?"<>|\s]"""), "_")
 
-  private fun resolvePreviewIr(preview: PreviewInfo): ResolvedIr? {
-    // kind=LOTTIE: the IR is the discovered asset file itself (no render-time capture). Read it
-    // straight off the module resources by the path discovery recorded, so the bundle carries the
-    // animation and replays it with zero consumer bytecode — same self-contained shape as a
-    // captured Remote Compose document.
-    if (preview.params.kind == PreviewKind.LOTTIE) {
-      val assetPath = preview.params.assetPath ?: return null
-      val resourcesRoot = moduleResourcesDir.orNull?.asFile ?: return null
-      val assetFile = File(resourcesRoot, assetPath)
-      if (!assetFile.isFile || assetFile.length() == 0L) return null
-      return ResolvedIr(
-        format = IR_FORMAT_LOTTIE,
-        ext = assetPath.substringAfterLast('.', missingDelimiterValue = "json"),
-        bytes = assetFile.readBytes(),
-      )
+  /**
+   * Resolve a data-driven asset preview's IR — the raw asset file itself ([PreviewKind.LOTTIE] /
+   * [PreviewKind.SVG]), read off the module resources by the path discovery recorded on
+   * [PreviewParams.assetPath]. Tries [moduleResourcesDir] (the desktop processed-resources dir)
+   * first, then each root in [moduleResourceRoots] (the Android source resource dirs), returning
+   * the first that holds a non-empty file at the asset path. Returns `null` when the asset has no
+   * path or isn't found under any root — the bundle then omits the IR rather than failing.
+   */
+  private fun resolveAssetIr(
+    preview: PreviewInfo,
+    format: String,
+    defaultExt: String,
+  ): ResolvedIr? {
+    val assetPath = preview.params.assetPath ?: return null
+    val roots = buildList {
+      moduleResourcesDir.orNull?.asFile?.let(::add)
+      addAll(moduleResourceRoots.files)
     }
+    for (root in roots) {
+      val assetFile = File(root, assetPath)
+      if (assetFile.isFile && assetFile.length() > 0L) {
+        return ResolvedIr(
+          format = format,
+          ext = assetPath.substringAfterLast('.', missingDelimiterValue = defaultExt),
+          bytes = assetFile.readBytes(),
+        )
+      }
+    }
+    return null
+  }
 
-    // kind=SVG: same self-contained shape as LOTTIE — the IR is the raw `.svg` read off the module
-    // resources, so the bundle carries the source artwork regardless of which render subdir
-    // (`svg-renders/` on Android) the still PNG landed in.
-    if (preview.params.kind == PreviewKind.SVG) {
-      val assetPath = preview.params.assetPath ?: return null
-      val resourcesRoot = moduleResourcesDir.orNull?.asFile ?: return null
-      val assetFile = File(resourcesRoot, assetPath)
-      if (!assetFile.isFile || assetFile.length() == 0L) return null
-      return ResolvedIr(
-        format = IR_FORMAT_SVG,
-        ext = assetPath.substringAfterLast('.', missingDelimiterValue = "svg"),
-        bytes = assetFile.readBytes(),
-      )
+  private fun resolvePreviewIr(preview: PreviewInfo): ResolvedIr? {
+    // kind=LOTTIE / kind=SVG: the IR is the discovered asset file itself (no render-time capture).
+    // Read it straight off the module resources by the path discovery recorded, so the bundle
+    // carries the animation / artwork and replays it with zero consumer bytecode — same
+    // self-contained shape as a captured Remote Compose document.
+    when (preview.params.kind) {
+      PreviewKind.LOTTIE -> return resolveAssetIr(preview, IR_FORMAT_LOTTIE, defaultExt = "json")
+      PreviewKind.SVG -> return resolveAssetIr(preview, IR_FORMAT_SVG, defaultExt = "svg")
+      else -> {}
     }
 
     val rendersRoot = rendersDir.orNull?.asFile ?: return null


### PR DESCRIPTION
Follow-up to #2215 — closes the Android asset-IR gap Codex flagged there.

## Problem

Android bundles dropped the raw `.svg` / `.json` asset IR. `resolvePreviewIr` reads the asset from the bundle task's `moduleResourcesDir`, which is the JVM processed-resources dir (`build/resources/main` / `processedResources/jvm/main`). AGP never stages java resources there for an Android module, so the lookup returned null and `ir/<id>.svg` / `ir/<id>.json` was omitted — even though discovery found the asset and the render produced its still. **Pre-existing for Lottie**; the SVG work in #2215 inherited the same branch, and Codex called it out.

## Fix

- Add a `moduleResourceRoots` bundle input, tried **after** `moduleResourcesDir`, and fold the LOTTIE + SVG branches into a shared `resolveAssetIr(preview, format, defaultExt)` helper that returns the first root holding the asset.
- Wire the Android bundle task's `moduleResourceRoots` to `androidLottieResourceDirs` — the same source roots (`src/main/resources`, `src/commonMain/resources`, `src/androidMain/resources`) discovery scans and the JVM render classpath links, so the `assetPath` discovery recorded resolves against them.
- No-op on desktop: `moduleResourceRoots` is empty there and the processed-resources dir already resolves the asset, so `resolveAssetIr` behaves exactly as before.

## Verification — reproduced and fixed on a real Android build

Using the merged `samples/android` (which has both `svg/badge.svg` and `lottie/spin.json`):

**Before** (`main`) — `:samples:android:composePreviewBundle`:
```
ir/ entries: []
```

**After** (this branch):
```
ir/ entries: ['ir/lottie__lottie_spin.json', 'ir/svg__svg_badge.svg']
  ir bytes: b'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 240" ...'
```

So both SVG **and** the previously-broken Lottie IR now travel in the Android bundle. (This session's sandbox does have the Android SDK at `/opt/android-sdk`; I built the Android modules directly with `ANDROID_HOME` pointed at it.)

## Test plan

- `:gradle-plugin:functionalTest` — full `BundleFunctionalTest` green after the `resolveAssetIr` refactor; the SVG-IR case still covers the primary (`moduleResourcesDir`) path ✅
- `:samples:android:composePreviewBundle` (real Android, `ANDROID_HOME=/opt/android-sdk`) — before/after above; `ir/` goes from empty to carrying both assets ✅

The Android-specific carriage is verified via `samples/android` (built in CI) rather than a bespoke gated test — the daemon Android bundle e2e asserts IR **re-rendering** (protolayout / remotecompose), which doesn't apply to SVG (carried for self-containment + cover, not daemon-replayed). Text-only PR — no rendered-output change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MQisk9C45huv8QBt7pgnE1)_