### PR TITLE
feat: embed Google downloadable fonts in the Android figma-svg export

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/ComposeFigmaSvgExtension.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/ComposeFigmaSvgExtension.kt
@@ -48,6 +48,25 @@ class ComposeFigmaSvgExtension : PostCaptureProcessor {
       semantics = semantics,
       density = density,
       frameImage = frameImage,
+      // Embed the real (Google-downloadable) face so `<text>` renders faithfully — parity with the
+      // desktop export. On Android the render itself is Roboto, so the embedded face is the exact
+      // match. Opt-in; reuses the renderer's own font cache dir / offline switch.
+      fontResolver = figmaFontResolver(),
+    )
+  }
+
+  /**
+   * The Google-Fonts WOFF2 resolver for the export, or null when embedding is off. On when
+   * `composeai.figma.embedFonts=true`, or implicitly under the fidelity harness — matching the
+   * desktop wiring. Reuses the renderer's font cache dir / offline switch so a face is downloaded at
+   * most once per environment.
+   */
+  private fun figmaFontResolver(): FigmaFontResolver? {
+    fun on(prop: String) = System.getProperty(prop)?.lowercase() == "true"
+    if (!on("composeai.figma.embedFonts") && !on("composeai.figma.fidelity")) return null
+    return GoogleFontsWoff2Resolver(
+      cacheDir = System.getProperty("composeai.fonts.cacheDir")?.let { java.io.File(it) },
+      offline = on("composeai.fonts.offline"),
     )
   }
 

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/ComposeFigmaSvgExtension.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/ComposeFigmaSvgExtension.kt
@@ -57,13 +57,15 @@ class ComposeFigmaSvgExtension : PostCaptureProcessor {
 
   /**
    * The Google-Fonts WOFF2 resolver for the export, or null when embedding is off. On when
-   * `composeai.figma.embedFonts=true`, or implicitly under the fidelity harness — matching the
-   * desktop wiring. Reuses the renderer's font cache dir / offline switch so a face is downloaded at
-   * most once per environment.
+   * `composeai.figma.embedFonts=true` — the plugin forwards that flag into the daemon JVM (see
+   * `AndroidPreviewClasspath.buildSystemProperties`). Unlike desktop this doesn't also honour the
+   * fidelity flag: the fidelity harness is desktop-only, so there's nothing to imply embedding for
+   * here. Reuses the renderer's font cache dir / offline switch so a face is downloaded at most once
+   * per environment.
    */
   private fun figmaFontResolver(): FigmaFontResolver? {
     fun on(prop: String) = System.getProperty(prop)?.lowercase() == "true"
-    if (!on("composeai.figma.embedFonts") && !on("composeai.figma.fidelity")) return null
+    if (!on("composeai.figma.embedFonts")) return null
     return GoogleFontsWoff2Resolver(
       cacheDir = System.getProperty("composeai.fonts.cacheDir")?.let { java.io.File(it) },
       offline = on("composeai.fonts.offline"),

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/RenderEngineTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/RenderEngineTest.kt
@@ -124,6 +124,53 @@ class RenderEngineTest {
   }
 
   @Test
+  fun figmaSvgExportEmbedsGoogleFontsWhenEnabled() {
+    // Parity with the desktop export: with `-Dcomposeai.figma.embedFonts=true` the Android export
+    // embeds each text node's face as an `@font-face` WOFF2 so the SVG renders the real typeface. We
+    // pre-seed the shared font cache (`composeai.fonts.cacheDir`) so the resolver serves from disk —
+    // deterministic, no network in CI. On Android the render itself is Roboto, so the embedded face
+    // is the exact match.
+    val outputDir = tempFolder.newFolder("renders-figma-fonts")
+    val fontCache = tempFolder.newFolder("font-cache")
+    // The generic `serif` family maps to the Material default (Roboto); text weight defaults to 400.
+    // Seed all plausible weights with the same sentinel bytes so the assertion is weight-agnostic.
+    val sentinel = byteArrayOf(1, 2, 3)
+    for (w in listOf(400, 500, 700)) File(fontCache, "roboto-$w.woff2").writeBytes(sentinel)
+    System.setProperty(RenderEngine.OUTPUT_DIR_PROP, outputDir.absolutePath)
+    System.setProperty("roborazzi.test.record", "true")
+    System.setProperty("composeai.figma.embedFonts", "true")
+    System.setProperty("composeai.fonts.cacheDir", fontCache.absolutePath)
+    val host = RobolectricHost()
+    host.start()
+    try {
+      host.submit(
+        RenderRequest.Render(
+          payload =
+            "className=ee.schimke.composeai.daemon.RedFixturePreviewsKt;" +
+              "functionName=SerifTextPreview;" +
+              "widthPx=200;heightPx=80;density=1.0;showBackground=true;outputBaseName=figma-fonts"
+        ),
+        timeoutMs = 120_000,
+      )
+
+      val svg =
+        outputDir.parentFile!!
+          .resolve("data")
+          .resolve("figma-fonts")
+          .resolve("compose-figma.svg")
+      assertTrue("figma SVG must be produced: ${svg.absolutePath}", svg.exists())
+      val text = svg.readText()
+      assertTrue("export must embed an @font-face", text.contains("@font-face"))
+      // base64 of {1,2,3} = "AQID" — the seeded face bytes, proving the resolver→embed wiring.
+      assertTrue("must embed the resolved WOFF2 data URI", text.contains("data:font/woff2;base64,AQID"))
+    } finally {
+      host.shutdown()
+      System.clearProperty("composeai.figma.embedFonts")
+      System.clearProperty("composeai.fonts.cacheDir")
+    }
+  }
+
+  @Test
   fun figmaSvgExportRastersOpaqueImage() {
     // Parity with the desktop backend: a real Robolectric render of a screen containing an opaque
     // `Image` must emit the Image as an `<image>` layer in `compose-figma.svg` AND crop the

--- a/docs/design/figma-svg-example/fonts/README.md
+++ b/docs/design/figma-svg-example/fonts/README.md
@@ -19,8 +19,32 @@ embedded `@font-face`. Before, Chromium falls back to its platform sans-serif (h
 face); after, the title renders in Roboto Medium and the body in Roboto Regular — the actual Material
 type. Figma, which ships Roboto, matches by name on import; a browser/Chromium uses the embedded WOFF2.
 
-**Scope note.** This lands the *export* side. The desktop `compose-figma-fidelity` score doesn't move
-yet because the desktop Skiko render doesn't itself draw Roboto — a separate desktop-render-font gap;
-on Android (where the render *is* Roboto) and in Figma the embedded face is the correct match. It's
-opt-in so default renders stay deterministic and offline-safe (a failed/absent fetch degrades to the
-named `sans-serif`, never an error).
+Embedding runs on **both backends** — desktop (`RenderEngine`) and Android (`ComposeFigmaSvgExtension`)
+— so a `data/fetch` for the figma-svg on either target yields the same self-contained SVG. It's opt-in
+so default renders stay deterministic and offline-safe (a failed/absent fetch degrades to the named
+`sans-serif`, never an error).
+
+## Desktop-render font gap (follow-up)
+
+The desktop `compose-figma-fidelity` score doesn't move on the embed alone, because the desktop Skiko
+render doesn't itself draw Roboto: on a headless Linux box `fc-match sans-serif` resolves to **DejaVu
+Sans** (Roboto isn't installed), so `FontFamily.Default` renders DejaVu while the export embeds Roboto.
+It can't be fixed in application code — Compose Desktop casts `LocalFontFamilyResolver.current` to its
+concrete `FontFamilyResolverImpl`, so a resolver that remaps `FontFamily.Default → Roboto` (the trick
+the Android fonts-recorder uses) throws `ClassCastException` on desktop.
+
+The fix is **environmental**: install the Roboto TTFs and make Roboto the fontconfig default —
+
+```
+# Roboto {400,500,700}.ttf → ~/.local/share/fonts, then:
+~/.config/fontconfig/fonts.conf:
+  <alias><family>sans-serif</family><prefer><family>Roboto</family></prefer></alias>
+fc-cache -f
+```
+
+Verified: with that in place the desktop render draws Roboto, matching the embedded face, and the
+composite card's mean per-pixel error drops **4.02 → 1.89** (score → ~95.6%). Because it changes the
+default font of *every* desktop render, adopting it means regenerating all desktop `@Preview`
+baselines — so it belongs in a dedicated PR (render-environment setup: CI + the agent session-start
+hook) rather than riding along with an export change. On Android the render is already Roboto, so the
+embedded face matches there today.

--- a/docs/design/figma-svg-example/fonts/README.md
+++ b/docs/design/figma-svg-example/fonts/README.md
@@ -20,9 +20,13 @@ face); after, the title renders in Roboto Medium and the body in Roboto Regular 
 type. Figma, which ships Roboto, matches by name on import; a browser/Chromium uses the embedded WOFF2.
 
 Embedding runs on **both backends** — desktop (`RenderEngine`) and Android (`ComposeFigmaSvgExtension`)
-— so a `data/fetch` for the figma-svg on either target yields the same self-contained SVG. It's opt-in
-so default renders stay deterministic and offline-safe (a failed/absent fetch degrades to the named
-`sans-serif`, never an error).
+— so a `data/fetch` for the figma-svg on either target yields the same self-contained SVG. The flag is
+read in the **daemon JVM**, so the Gradle plugin forwards `-Dcomposeai.figma.embedFonts=true` (or
+`-PcomposePreview.figmaEmbedFonts=true`) into the daemon's system properties
+(`AndroidPreviewClasspath.buildSystemProperties` + the daemon-start descriptors) — otherwise the flag
+set on the Gradle invocation would never reach the daemon that reads it. It's opt-in so default renders
+stay deterministic and offline-safe (a failed/absent fetch degrades to the named `sans-serif`, never an
+error).
 
 ## Desktop-render font gap (follow-up)
 

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewClasspath.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewClasspath.kt
@@ -236,8 +236,8 @@ internal object AndroidPreviewClasspath {
   /**
    * Static system properties (graphicsMode, looperMode, conscryptMode, pixelCopyRenderMode,
    * roborazzi.test.record, composeai.render.manifest, composeai.render.outputDir,
-   * composeai.fonts.cacheDir, composeai.fonts.offline). Caller passes the resolved values for the
-   * path-bearing ones; the helper returns the full map.
+   * composeai.fonts.cacheDir, composeai.fonts.offline, composeai.figma.embedFonts). Caller passes
+   * the resolved values for the path-bearing / opt-in ones; the helper returns the full map.
    *
    * Note: the dynamic per-task ArgumentProviders (a11y, tier) stay inline because they need lazy
    * `Provider<>` evaluation at task execution time.
@@ -252,6 +252,7 @@ internal object AndroidPreviewClasspath {
     rendersDir: String,
     fontsCacheDir: String,
     fontsOffline: String,
+    figmaEmbedFonts: String = "false",
   ): Map<String, String> =
     linkedMapOf(
       // Belt-and-braces for the graphics/looper modes. Config now
@@ -290,6 +291,11 @@ internal object AndroidPreviewClasspath {
       // shows the fallback font rather than silently fetching from
       // `fonts.googleapis.com`.
       "composeai.fonts.offline" to fontsOffline,
+      // `-Dcomposeai.figma.embedFonts=true` (or `-PcomposePreview.figmaEmbedFonts=true`) opts the
+      // `compose/figma-svg` export into embedding each text node's face as an `@font-face`. Read in
+      // the daemon JVM by `ComposeFigmaSvgExtension`, so it must be forwarded here — else the flag
+      // set on the Gradle invocation never reaches the daemon and the export stays vector-only.
+      "composeai.figma.embedFonts" to figmaEmbedFonts,
     )
 }
 
@@ -313,3 +319,16 @@ internal fun composeAiFontsCacheDir(project: Project): String {
     else File(project.providers.systemProperty("user.home").get(), ".cache/composeai")
   return File(base, "fonts").absolutePath
 }
+
+/**
+ * The resolved value to forward as the daemon JVM's `composeai.figma.embedFonts`, so
+ * `-Dcomposeai.figma.embedFonts=true` on the Gradle invocation reaches the daemon that reads it.
+ * Sourced from that system property first (the documented flag, matching the desktop render), then
+ * a `-PcomposePreview.figmaEmbedFonts` Gradle property, else `"false"`. Provider-based so the
+ * configuration cache records the property reads as inputs.
+ */
+internal fun composeAiFigmaEmbedFonts(project: Project): org.gradle.api.provider.Provider<String> =
+  project.providers
+    .systemProperty("composeai.figma.embedFonts")
+    .orElse(project.providers.gradleProperty("composePreview.figmaEmbedFonts"))
+    .orElse("false")

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -1881,6 +1881,7 @@ internal object AndroidPreviewSupport {
         // `fonts.googleapis.com`.
         val fontsOffline =
           project.providers.gradleProperty("composePreview.fontsOffline").orElse("false")
+        val figmaEmbedFonts = composeAiFigmaEmbedFonts(project)
         // Static system properties (Robolectric modes + the path-bearing composeai.*
         // values) live in [AndroidPreviewClasspath.buildSystemProperties] so the
         // preview daemon can replay the same set when launching its own JVM. The
@@ -1891,6 +1892,7 @@ internal object AndroidPreviewSupport {
             rendersDir = rendersDir.get(),
             fontsCacheDir = fontsCacheDir,
             fontsOffline = fontsOffline.get(),
+            figmaEmbedFonts = figmaEmbedFonts.get(),
           )
           .forEach { (k, v) -> systemProperty(k, v) }
 
@@ -2445,6 +2447,7 @@ internal object AndroidPreviewSupport {
     val daemonFontsCacheDir = composeAiFontsCacheDir(project)
     val daemonFontsOffline =
       project.providers.gradleProperty("composePreview.fontsOffline").orElse("false")
+    val daemonFigmaEmbedFonts = composeAiFigmaEmbedFonts(project)
     // Pre-resolved at configuration time — both feed @Input fields whose Provider chains
     // mustn't capture `project`. The cheap-signal set used to be collected at task-action
     // time so newly-added subproject scripts were seen on the same run, but doing it
@@ -2570,6 +2573,7 @@ internal object AndroidPreviewSupport {
       this.systemProperties.put("composeai.render.outputDir", rendersDir)
       this.systemProperties.put("composeai.fonts.cacheDir", daemonFontsCacheDir)
       this.systemProperties.put("composeai.fonts.offline", daemonFontsOffline)
+      this.systemProperties.put("composeai.figma.embedFonts", daemonFigmaEmbedFonts)
       this.systemProperties.put("composeai.daemon.protocolVersion", "1")
       this.systemProperties.put("composeai.daemon.idleTimeoutMs", "5000")
       this.systemProperties.put(

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -604,6 +604,7 @@ internal object ComposePreviewTasks {
     val daemonFontsCacheDir = composeAiFontsCacheDir(project)
     val daemonFontsOffline =
       project.providers.gradleProperty("composePreview.fontsOffline").orElse("false")
+    val daemonFigmaEmbedFonts = composeAiFigmaEmbedFonts(project)
     val daemonCheapSignalFiles =
       collectDesktopCheapSignalFiles(project).joinToString(java.io.File.pathSeparator) {
         it.absolutePath
@@ -708,6 +709,7 @@ internal object ComposePreviewTasks {
       systemProperties.put("composeai.render.outputDir", rendersDirProvider)
       systemProperties.put("composeai.fonts.cacheDir", daemonFontsCacheDir)
       systemProperties.put("composeai.fonts.offline", daemonFontsOffline)
+      systemProperties.put("composeai.figma.embedFonts", daemonFigmaEmbedFonts)
       systemProperties.put(
         "composeai.daemon.perfettoTrace",
         AndroidPreviewSupport.resolveComposeAiTraceEnabled(project, extension).map { it.toString() },

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/AndroidPreviewClasspathTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/AndroidPreviewClasspathTest.kt
@@ -103,6 +103,32 @@ class AndroidPreviewClasspathTest {
       .contains("--add-opens=java.base/jdk.internal.access=ALL-UNNAMED")
   }
 
+  @Test
+  fun `buildSystemProperties forwards the figma-embed-fonts flag into the daemon jvm`() {
+    // Regression: the daemon JVM only sees the system properties this map forwards, so the
+    // documented `-Dcomposeai.figma.embedFonts=true` must land here or the Android export never
+    // embeds fonts (the flag set on the Gradle invocation wouldn't reach the daemon).
+    val props =
+      AndroidPreviewClasspath.buildSystemProperties(
+        manifestPath = "m.json",
+        rendersDir = "renders",
+        fontsCacheDir = "cache",
+        fontsOffline = "false",
+        figmaEmbedFonts = "true",
+      )
+    assertThat(props).containsEntry("composeai.figma.embedFonts", "true")
+    // Defaulted off when the caller doesn't opt in.
+    assertThat(
+        AndroidPreviewClasspath.buildSystemProperties(
+          manifestPath = "m.json",
+          rendersDir = "renders",
+          fontsCacheDir = "cache",
+          fontsOffline = "false",
+        )
+      )
+      .containsEntry("composeai.figma.embedFonts", "false")
+  }
+
   private fun writeAndroidJar(file: File) {
     writeJar(file, mapOf("android/app/Application.class" to ByteArray(16)))
   }


### PR DESCRIPTION
## Summary

Brings the figma-svg **font embedding** from #2218 to the Android backend, so it runs on both targets, and makes the opt-in flag actually reach the daemon.

- `ComposeFigmaSvgExtension` now passes a `GoogleFontsWoff2Resolver` to `writeSvg` under `-Dcomposeai.figma.embedFonts=true`, gated and cache-dir/offline-wired like the desktop `RenderEngine`. On Android the render itself is Roboto, so the embedded face is the exact match.
- **Daemon flag forwarding** (Codex review P2): the flag is read in the daemon JVM, but the plugin only forwarded `render.outputDir`/`fonts.cacheDir`/`fonts.offline` — so `-Dcomposeai.figma.embedFonts=true` never reached the daemon via the normal `composePreviewDaemonStart`/VS Code path. Now forwarded at every launch site (`AndroidPreviewClasspath.buildSystemProperties` — replayed by the daemon bootstrap for spawned render JVMs — plus the Android and shared `ComposePreviewTasks` daemon-start descriptors; the latter also closes the same gap for the desktop daemon). The Android extension gate is tightened to `embedFonts` only (the fidelity harness is desktop-only).

## Desktop-render font gap (documented follow-up, not in this PR)

The desktop `compose-figma-fidelity` score doesn't move on the embed alone because the desktop Skiko render draws **DejaVu**, not Roboto (`fc-match sans-serif` → DejaVu; Roboto isn't installed). It can't be fixed in application code — Compose Desktop casts `LocalFontFamilyResolver.current` to its concrete impl, so a `FontFamily.Default → Roboto` resolver throws `ClassCastException`. The fix is environmental (install Roboto + fontconfig default); **verified** it drops the composite card's mean error **4.02 → 1.89** (score ~95.6%), but it regenerates every desktop baseline, so it belongs in its own render-environment PR. Recipe + numbers in `docs/design/figma-svg-example/fonts/README.md`.

## Test plan

- `./gradlew :daemon:android:testDebugUnitTest --tests "*RenderEngineTest.figmaSvgExportEmbedsGoogleFontsWhenEnabled"` — Robolectric render with a pre-seeded font cache (no network in CI); the produced SVG carries the `@font-face` and the seeded WOFF2 data URI. ✅
- `./gradlew -p gradle-plugin :test --tests "*AndroidPreviewClasspathTest*"` — new: `buildSystemProperties` forwards `composeai.figma.embedFonts` (on) and defaults it off. ✅
- `./gradlew :data-layoutinspector-connector:test --tests "*FigmaFontEmbedTest*"` + `ktfmtCheckAll` (main and gradle-plugin) — green. ✅
