### PR TITLE
ci: point @claude sessions at the compose-preview-review skill

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -80,9 +80,15 @@ jobs:
           settings: |
             {
               "includeCoAuthoredBy": false,
-              "attribution": { "commit": "", "pr": "" }
+              "attribution": { "commit": "", "pr": "" },
+              "extraKnownMarketplaces": {
+                "yschimke-skills": {
+                  "source": { "source": "github", "repo": "yschimke/skills" }
+                }
+              },
+              "enabledPlugins": { "yschimke-skills@yschimke-skills": true }
             }
           claude_args: >-
             --max-turns 100
             --allowedTools "Bash(./gradlew:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(javap:*)"
-            --append-system-prompt "Follow CLAUDE.md and docs/AGENTS.md conventions strictly. Visual evidence is mandatory for any UI-affecting request: render the affected @Preview composables before and after your change with the compose-preview pipeline (./gradlew :samples:android:composePreviewRenderAll, :samples:cmp:composePreviewRenderAll, or the specific module render task), commit the PNGs you cite to your working branch, push, and only then embed them inline in your comment and PR text as markdown images whose URLs are commit-SHA-pinned raw.githubusercontent.com links to those pushed files. Describing an image is not evidence; the reviewer must see pixels inline. When reviewing an existing PR, reuse renders already published on the compose-preview/pr and compose-preview/main branches where possible instead of re-rendering. Use conventional commit subjects (feat:, fix:, ci:, docs:, test:). Never add Co-authored-by trailers or any agent attribution to commits, PR titles, or PR bodies."
+            --append-system-prompt "Follow CLAUDE.md and docs/AGENTS.md conventions strictly. Visual evidence is mandatory for any UI-affecting request: render the affected @Preview composables before and after your change with the compose-preview pipeline (./gradlew :samples:android:composePreviewRenderAll, :samples:cmp:composePreviewRenderAll, or the specific module render task), commit the PNGs you cite to your working branch, push, and only then embed them inline in your comment and PR text as markdown images whose URLs are commit-SHA-pinned raw.githubusercontent.com links to those pushed files. Describing an image is not evidence; the reviewer must see pixels inline. When reviewing an existing PR, reuse renders already published on the compose-preview/pr and compose-preview/main branches where possible instead of re-rendering. The compose-preview-review skill (from the yschimke-skills plugin enabled in settings) covers this workflow: consult its ci-agent-sessions and stability references when reviewing or authoring UI changes. Before rendering anything, scan .github/workflows for the preview-diff CI this repo already runs and read the sticky <!-- preview-diff --> PR comment; cite and reuse those renders where they cover the change. Treat changed previews whose source the PR does not touch - clocks and timestamps, randomness, animation frames, network-loaded images - as instability to triage and flag per the stability reference, not regressions to rubber-stamp, and verify a suspected flake by rendering twice on the same commit. Use conventional commit subjects (feat:, fix:, ci:, docs:, test:). Never add Co-authored-by trailers or any agent attribution to commits, PR titles, or PR bodies."

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -77,18 +77,20 @@ jobs:
           # conventions"). Branch commits land as claude[bot], which the gate
           # deliberately allows; squash-merge from PR title + body keeps main
           # human-authored.
+          # Install the skills plugin (compose-preview-review and friends)
+          # before the session starts. Plugins install via these action
+          # inputs; enabledPlugins in `settings` alone would not install
+          # anything on the runner.
+          plugin_marketplaces: |
+            https://github.com/yschimke/skills.git
+          plugins: |
+            yschimke-skills@yschimke-skills
           settings: |
             {
               "includeCoAuthoredBy": false,
-              "attribution": { "commit": "", "pr": "" },
-              "extraKnownMarketplaces": {
-                "yschimke-skills": {
-                  "source": { "source": "github", "repo": "yschimke/skills" }
-                }
-              },
-              "enabledPlugins": { "yschimke-skills@yschimke-skills": true }
+              "attribution": { "commit": "", "pr": "" }
             }
           claude_args: >-
             --max-turns 100
             --allowedTools "Bash(./gradlew:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(javap:*)"
-            --append-system-prompt "Follow CLAUDE.md and docs/AGENTS.md conventions strictly. Visual evidence is mandatory for any UI-affecting request: render the affected @Preview composables before and after your change with the compose-preview pipeline (./gradlew :samples:android:composePreviewRenderAll, :samples:cmp:composePreviewRenderAll, or the specific module render task), commit the PNGs you cite to your working branch, push, and only then embed them inline in your comment and PR text as markdown images whose URLs are commit-SHA-pinned raw.githubusercontent.com links to those pushed files. Describing an image is not evidence; the reviewer must see pixels inline. When reviewing an existing PR, reuse renders already published on the compose-preview/pr and compose-preview/main branches where possible instead of re-rendering. The compose-preview-review skill (from the yschimke-skills plugin enabled in settings) covers this workflow: consult its ci-agent-sessions and stability references when reviewing or authoring UI changes. Before rendering anything, scan .github/workflows for the preview-diff CI this repo already runs and read the sticky <!-- preview-diff --> PR comment; cite and reuse those renders where they cover the change. Treat changed previews whose source the PR does not touch - clocks and timestamps, randomness, animation frames, network-loaded images - as instability to triage and flag per the stability reference, not regressions to rubber-stamp, and verify a suspected flake by rendering twice on the same commit. Use conventional commit subjects (feat:, fix:, ci:, docs:, test:). Never add Co-authored-by trailers or any agent attribution to commits, PR titles, or PR bodies."
+            --append-system-prompt "Follow CLAUDE.md and docs/AGENTS.md conventions strictly. Visual evidence is mandatory for any UI-affecting request: render the affected @Preview composables before and after your change with the compose-preview pipeline (./gradlew :samples:android:composePreviewRenderAll, :samples:cmp:composePreviewRenderAll, or the specific module render task), commit the PNGs you cite to your working branch, push, and only then embed them inline in your comment and PR text as markdown images whose URLs are commit-SHA-pinned raw.githubusercontent.com links to those pushed files. Describing an image is not evidence; the reviewer must see pixels inline. When reviewing an existing PR, reuse renders already published on the compose-preview/pr and compose-preview/main branches where possible instead of re-rendering. The compose-preview-review skill (from the yschimke-skills plugin the workflow installs) covers this workflow: consult its ci-agent-sessions and stability references when reviewing or authoring UI changes. Before rendering anything, scan .github/workflows for the preview-diff CI this repo already runs and read the sticky <!-- preview-diff --> PR comment; cite and reuse those renders where they cover the change. Treat changed previews whose source the PR does not touch - clocks and timestamps, randomness, animation frames, network-loaded images - as instability to triage and flag per the stability reference, not regressions to rubber-stamp, and verify a suspected flake by rendering twice on the same commit. Use conventional commit subjects (feat:, fix:, ci:, docs:, test:). Never add Co-authored-by trailers or any agent attribution to commits, PR titles, or PR bodies."

--- a/docs/AGENT_INVOCATION.md
+++ b/docs/AGENT_INVOCATION.md
@@ -86,11 +86,14 @@ run to put pixels inline. It's also already this repo's convention.
 
 ### The compose-preview-review skill
 
-The workflow's `settings` block enables the
-[`yschimke-skills`](https://github.com/yschimke/skills) plugin
-(`extraKnownMarketplaces` + `enabledPlugins`), so every agent session
-loads the **compose-preview-review** skill, and the appended system
-prompt points at the two references written for this environment:
+The workflow installs the
+[`yschimke-skills`](https://github.com/yschimke/skills) plugin via the
+action's `plugin_marketplaces` / `plugins` inputs (the action installs
+plugins from these inputs before the session starts; `enabledPlugins`
+in `settings` alone would not install anything on the runner), so every
+agent session loads the **compose-preview-review** skill, and the
+appended system prompt points at the two references written for this
+environment:
 
 - `references/ci-agent-sessions.md` — running the review workflow on an
   Actions runner: Gradle-only rendering, commit-SHA-pinned embedding,

--- a/docs/AGENT_INVOCATION.md
+++ b/docs/AGENT_INVOCATION.md
@@ -84,6 +84,26 @@ GitHub comments can't carry file attachments via the API, so committed
 files + `raw.githubusercontent.com` is the only durable way for an Actions
 run to put pixels inline. It's also already this repo's convention.
 
+### The compose-preview-review skill
+
+The workflow's `settings` block enables the
+[`yschimke-skills`](https://github.com/yschimke/skills) plugin
+(`extraKnownMarketplaces` + `enabledPlugins`), so every agent session
+loads the **compose-preview-review** skill, and the appended system
+prompt points at the two references written for this environment:
+
+- `references/ci-agent-sessions.md` — running the review workflow on an
+  Actions runner: Gradle-only rendering, commit-SHA-pinned embedding,
+  and **discovering the repo's existing preview CI** (the sticky
+  `<!-- preview-diff -->` comment, `compose-preview/{main,pr}`
+  baselines, design-parity/design-artifacts pipelines) so the agent
+  cites renders CI already produced instead of re-rendering.
+- `references/stability.md` — triaging flaky previews: changed previews
+  whose source the PR doesn't touch (clocks/timestamps, randomness,
+  animation frames, network-loaded images) are treated as instability —
+  verified by rendering twice on the same commit and flagged with a
+  proposed fixture fix — not reported as regressions.
+
 ### Attribution
 
 Branch commits land as `claude[bot]` via the Claude GitHub App. That is


### PR DESCRIPTION
## Summary
- `claude.yml`: enable the [`yschimke-skills`](https://github.com/yschimke/skills) plugin in the action `settings` (`extraKnownMarketplaces` + `enabledPlugins`) so mention-triggered agent sessions load the **compose-preview-review** skill, and extend `--append-system-prompt` to follow its new `ci-agent-sessions` and `stability` references: scan `.github/workflows/` for the preview-diff CI this repo already runs, reuse the sticky `<!-- preview-diff -->` comment renders, and treat time-/randomness-/animation-driven preview churn as flakes to triage (verified by rendering twice) rather than regressions.
- `docs/AGENT_INVOCATION.md`: new "The compose-preview-review skill" subsection documenting the plugin wiring and both references.

Companion to yschimke/skills PR adding the two references; same change applied to design-parity, meshcore-mobile, homeassistant-remotecompose, and cadence.

## Test plan
- Workflow + docs only (non-visual). YAML parsed and the embedded `settings` JSON validated locally (`enabledPlugins` / `extraKnownMarketplaces` shape asserted).
- End-to-end verification is the next real `@claude` mention: the run log should show the `yschimke-skills` plugin installing and the skill listed; if plugin install were ever unavailable, the inline visual-evidence contract in the prompt still stands on its own.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SThVExRiUTasR9ehW9gFSv)_