### PR TITLE
feat: carry figma-raster crops for hybrid figma-svg catalog stickers

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
@@ -328,6 +328,10 @@ private class PackSubcommand(private val args: List<String>) {
         // the
         // design-catalog export can ship an editable vector per sticker beside the raster PNG.
         val figmaSvgWritten = injectFigmaSvgIntoBundle(bundleFile, outcome.figmaSvgById)
+        // A hybrid figma-svg references `figma-raster/<node>.png` crops; carry them verbatim as
+        // `previews/<id>.figma-raster/<node>.png` so the SVG's `<image>` layers resolve once the
+        // export copies the SVG onto the delivery branch. Empty for the common vector-only case.
+        val figmaRasterWritten = injectFigmaRasterIntoBundle(bundleFile, outcome.figmaRasterById)
         val semanticsLine =
           "  semantics:     $written / ${previewIds.size} preview(s) carried as " +
             "previews/<id>$BUNDLE_SEMANTICS_SUFFIX" +
@@ -347,6 +351,11 @@ private class PackSubcommand(private val args: List<String>) {
             append(
               "\n  figma-svg:     $figmaSvgWritten / ${previewIds.size} preview(s) carried " +
                 "as previews/<id>$BUNDLE_FIGMA_SVG_SUFFIX"
+            )
+          if (figmaRasterWritten > 0)
+            append(
+              "\n  figma-raster:  $figmaRasterWritten crop(s) carried as " +
+                "previews/<id>$BUNDLE_FIGMA_RASTER_DIR_SUFFIX/<node>.png"
             )
         }
         return semanticsLine + extraLines
@@ -701,6 +710,15 @@ internal const val BUNDLE_FONTS_SUFFIX: String = ".fonts.json"
 internal const val BUNDLE_FIGMA_SVG_SUFFIX: String = ".figma.svg"
 
 /**
+ * Directory suffix for a hybrid figma-svg's per-node raster crops, carried beside its
+ * `previews/<id>.figma.svg` as `previews/<id>.figma-raster/<node>.png`. Mirrors the
+ * `figma-raster/<node>.png` hrefs the SVG's `<image>` layers reference so they resolve once the
+ * design-catalog export copies the SVG (and rewrites those hrefs) onto the delivery branch. Absent
+ * for a vector-only export.
+ */
+internal const val BUNDLE_FIGMA_RASTER_DIR_SUFFIX: String = ".figma-raster"
+
+/**
  * Inject `previews/<id>.semantics.json` entries (id → `compose-semantics.json` bytes) into
  * [bundleFile]'s zip portion **in place**, preserving the leading PNG cover and every existing
  * entry. Re-injecting replaces any prior semantics entry for the same id, so a second
@@ -752,6 +770,29 @@ internal fun injectFigmaSvgIntoBundle(
   figmaSvgById: Map<String, ByteArray>,
   fileSystem: FileSystem = SystemFileSystem,
 ): Int = injectSidecarsIntoBundle(bundleFile, figmaSvgById, BUNDLE_FIGMA_SVG_SUFFIX, fileSystem)
+
+/**
+ * Inject a hybrid figma-svg's per-node raster crops ([figmaRasterById]: preview id → (crop filename
+ * → PNG bytes)) into [bundleFile] as `previews/<id>.figma-raster/<node>.png`, so the SVG's `<image
+ * href="figma-raster/<node>.png">` layers resolve after the export carries them. Same in-place,
+ * idempotent, byte-stable contract as the other injectors. Returns the number of crops written
+ * across all previews.
+ */
+internal fun injectFigmaRasterIntoBundle(
+  bundleFile: File,
+  figmaRasterById: Map<String, Map<String, ByteArray>>,
+  fileSystem: FileSystem = SystemFileSystem,
+): Int {
+  val entries =
+    figmaRasterById.entries
+      .flatMap { (id, crops) ->
+        crops.map { (name, bytes) ->
+          "$BUNDLE_PREVIEWS_DIR/$id$BUNDLE_FIGMA_RASTER_DIR_SUFFIX/$name" to bytes
+        }
+      }
+      .toMap()
+  return injectRawZipEntries(bundleFile, entries, fileSystem)
+}
 
 /**
  * Inject `previews/<id><suffix>` entries (id → bytes) into [bundleFile]'s zip portion **in place**,

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DaemonSemanticsFetcher.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DaemonSemanticsFetcher.kt
@@ -94,6 +94,7 @@ internal class DaemonSemanticsFetcher(
         layoutSidecarFile(projectDir, previewId).delete()
         fontsSidecarFile(projectDir, previewId).delete()
         figmaSvgSidecarFile(projectDir, previewId).delete()
+        figmaRasterDir(projectDir, previewId).deleteRecursively()
       }
 
       val pending = ConcurrentHashMap.newKeySet<String>().apply { addAll(previewIds) }
@@ -137,6 +138,7 @@ internal class DaemonSemanticsFetcher(
       val layoutById = LinkedHashMap<String, ByteArray>()
       val fontsById = LinkedHashMap<String, ByteArray>()
       val figmaSvgById = LinkedHashMap<String, ByteArray>()
+      val figmaRasterById = LinkedHashMap<String, Map<String, ByteArray>>()
       for (previewId in previewIds) {
         val file = sidecarFile(projectDir, previewId)
         if (file.isFile && file.length() > 0) {
@@ -167,6 +169,17 @@ internal class DaemonSemanticsFetcher(
         val figmaSvg = figmaSvgSidecarFile(projectDir, previewId)
         if (figmaSvg.isFile && figmaSvg.length() > 0) {
           figmaSvgById[previewId] = fileSystem.read(figmaSvg.path.toPath()) { readByteArray() }
+          // A hybrid figma-svg (opaque Image/Icon/Canvas node) references `figma-raster/<node>.png`
+          // crops the daemon wrote beside it. Carry them too so the SVG's `<image>` layers resolve
+          // once the export copies the SVG onto the delivery branch — else they'd dangle. Absent
+          // (empty) for a pure-vector export, which is the common case for a component catalog.
+          val crops =
+            figmaRasterDir(projectDir, previewId)
+              .listFiles { f -> f.isFile && f.name.endsWith(".png") }
+              ?.sortedBy { it.name }
+              ?.associate { it.name to fileSystem.read(it.path.toPath()) { readByteArray() } }
+              .orEmpty()
+          if (crops.isNotEmpty()) figmaRasterById[previewId] = crops
         }
       }
       Outcome.Ok(
@@ -174,6 +187,7 @@ internal class DaemonSemanticsFetcher(
         layoutById = layoutById,
         fontsById = fontsById,
         figmaSvgById = figmaSvgById,
+        figmaRasterById = figmaRasterById,
       )
     }
   }
@@ -190,6 +204,9 @@ internal class DaemonSemanticsFetcher(
   private fun figmaSvgSidecarFile(projectDir: File, previewId: String): File =
     File(projectDir, "build/compose-previews/data/$previewId/${ComposeFigmaSvgProduct.FILE_SVG}")
 
+  private fun figmaRasterDir(projectDir: File, previewId: String): File =
+    File(projectDir, "build/compose-previews/data/$previewId/${ComposeFigmaSvgProduct.RASTER_DIR}")
+
   sealed interface Outcome {
     /**
      * Session opened and renders attempted. [semanticsById] holds one entry per preview whose
@@ -199,13 +216,17 @@ internal class DaemonSemanticsFetcher(
      * holds the matching `fonts-used.json` (`fonts/used` — requested vs resolved font families) for
      * each preview whose backend runs the fonts recorder. [figmaSvgById] holds the matching
      * `compose-figma.svg` (the layered editable `compose/figma-svg` export) for each preview that
-     * produced drawing layers.
+     * produced drawing layers. [figmaRasterById] holds, for each preview whose figma-svg is
+     * **hybrid** (opaque Image/Icon/Canvas node), its `figma-raster/<node>.png` crops (filename →
+     * bytes) so the SVG's `<image>` layers still resolve once carried; empty for a vector-only
+     * export.
      */
     data class Ok(
       val semanticsById: Map<String, ByteArray>,
       val layoutById: Map<String, ByteArray> = emptyMap(),
       val fontsById: Map<String, ByteArray> = emptyMap(),
       val figmaSvgById: Map<String, ByteArray> = emptyMap(),
+      val figmaRasterById: Map<String, Map<String, ByteArray>> = emptyMap(),
     ) : Outcome
 
     data class DescriptorMissing(val expected: File) : Outcome

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleSemanticsInjectTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleSemanticsInjectTest.kt
@@ -202,6 +202,32 @@ class BundleSemanticsInjectTest {
   }
 
   @Test
+  fun `injects hybrid figma-raster crops under a per-preview dir`() {
+    val cover = png(4, 8)
+    val file =
+      polyglot(
+        cover,
+        linkedMapOf(
+          "bundle.json" to "{}".toByteArray(),
+          "previews/a.png" to cover,
+          "previews/a.figma.svg" to
+            """<svg><image href="figma-raster/n1.png"/></svg>""".toByteArray(),
+        ),
+      )
+
+    val crop = png(6, 6)
+    val written = injectFigmaRasterIntoBundle(file, mapOf("a" to linkedMapOf("n1.png" to crop)))
+
+    assertEquals(1, written)
+    val names = entries(BundleReader.extractZipBytes(file))
+    // The crop lands under previews/<id>.figma-raster/, beside the SVG that references it.
+    assertTrue("previews/a.figma-raster/n1.png" in names.keys)
+    assertEquals(crop.toList(), names.getValue("previews/a.figma-raster/n1.png").toList())
+    // SVG untouched.
+    assertTrue("previews/a.figma.svg" in names.keys)
+  }
+
+  @Test
   fun `re-injection replaces a stale semantics entry without duplicating it`() {
     val cover = png()
     val file =

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/ComposeSemanticsModels.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/ComposeSemanticsModels.kt
@@ -74,6 +74,14 @@ object ComposeFigmaSvgProduct {
   const val SCHEMA_VERSION: Int = 1
   const val FILE_SVG: String = "compose-figma.svg"
   const val MEDIA_TYPE_SVG: String = "image/svg+xml"
+
+  /**
+   * Directory (relative to the preview's output dir) holding the per-node `<node>.png` crops a
+   * **hybrid** export references via `<image href="figma-raster/<node>.png">`. Empty for a
+   * vector-only export. The single source of truth for the prefix [FigmaSvgModel.defaultRasterHref]
+   * emits and consumers (the design-catalog carrier) collect.
+   */
+  const val RASTER_DIR: String = "figma-raster"
 }
 
 @Serializable data class ComposeSemanticsPayload(val root: ComposeSemanticsNode)

--- a/scripts/design-artifacts/figma-svg-catalog.test.mjs
+++ b/scripts/design-artifacts/figma-svg-catalog.test.mjs
@@ -11,6 +11,11 @@ import { test } from "node:test";
 
 import { renderIndexHtml } from "./render-index-html.mjs";
 import { renderReadmeMd } from "./render-readme-md.mjs";
+import {
+  figmaRastersForId,
+  figmaSvgByFunction,
+  rewriteRasterHrefs,
+} from "./figma-svg-emit.mjs";
 
 const catalog = {
   system: "compose-m3",
@@ -39,4 +44,46 @@ test("README glance reports the editable design-vector (figma-svg) count", () =>
   const md = renderReadmeMd(catalog, { imageCount: 4, wireframeCount: 2, figmaSvgCount: 2 });
   assert.match(md, /Editable design vectors \(figma-svg\)/);
   assert.match(md, /Editable design vectors \(figma-svg\)[^\n]*\*\*2\*\*/);
+});
+
+const enc = (s) => new TextEncoder().encode(s);
+
+test("figmaSvgByFunction prefers the light variant and keeps the preview id", () => {
+  const bundle = {
+    previews: [
+      { id: "Fab_Dark", functionName: "Fab" },
+      { id: "Fab_Light", functionName: "Fab" },
+    ],
+    entries: {
+      "previews/Fab_Dark.figma.svg": enc("<svg><!--dark--></svg>"),
+      "previews/Fab_Light.figma.svg": enc("<svg><!--light--></svg>"),
+    },
+  };
+  const byFn = figmaSvgByFunction(bundle);
+  assert.equal(byFn.get("Fab").id, "Fab_Light");
+  assert.match(byFn.get("Fab").svg, /light/);
+});
+
+test("figmaRastersForId returns only that preview's crops", () => {
+  const bundle = {
+    entries: {
+      "previews/Fab_Light.figma-raster/node-1.png": enc("A"),
+      "previews/Fab_Light.figma-raster/node-2.png": enc("B"),
+      "previews/Other_Light.figma-raster/node-1.png": enc("C"),
+      "previews/Fab_Light.figma.svg": enc("<svg/>"),
+    },
+  };
+  const crops = figmaRastersForId(bundle, "Fab_Light");
+  assert.deepEqual([...crops.keys()].sort(), ["node-1.png", "node-2.png"]);
+});
+
+test("rewriteRasterHrefs re-points hrefs to a per-slug dir (no cross-slug collisions)", () => {
+  const svg = '<image href="figma-raster/node-1.png"/><image href="figma-raster/node-2.png"/>';
+  const out = rewriteRasterHrefs(svg, "fab");
+  assert.equal(
+    out,
+    '<image href="fab.figma-raster/node-1.png"/><image href="fab.figma-raster/node-2.png"/>',
+  );
+  // A vector-only SVG is untouched.
+  assert.equal(rewriteRasterHrefs("<svg><rect/></svg>", "fab"), "<svg><rect/></svg>");
 });

--- a/scripts/design-artifacts/figma-svg-emit.mjs
+++ b/scripts/design-artifacts/figma-svg-emit.mjs
@@ -1,0 +1,51 @@
+/**
+ * Helpers for shipping the layered `compose/figma-svg` export per sticker on the design-catalog
+ * delivery branch. The SVG bytes are produced Kotlin-side and carried in the bundle
+ * (`previews/<id>.figma.svg`); a **hybrid** sticker (opaque Image/Icon/Canvas node) also carries
+ * `previews/<id>.figma-raster/<node>.png` crops its `<image>` layers reference. These readers pull
+ * both out of the bundle so the driver can copy them onto the branch verbatim (no re-render).
+ *
+ * Extracted from `generate-design-catalog.mjs` so the carry + href-rewrite logic is unit-testable
+ * without running the whole export (which needs the private `@design-parity/catalog-export`).
+ */
+
+/**
+ * Map componentFunction → `{ id, svg }` for each preview that carried a `compose/figma-svg`. Prefer
+ * the light variant so a single deterministic sticker is emitted per component; the `id` is kept so
+ * the caller can find the sticker's hybrid `figma-raster/` crops.
+ */
+export function figmaSvgByFunction(bundle) {
+  const out = new Map();
+  const prefer = (id) => /(_|\b)light$/i.test(id);
+  for (const preview of bundle.previews ?? []) {
+    const bytes = bundle.entries?.[`previews/${preview.id}.figma.svg`];
+    if (!bytes) continue;
+    const fn = preview.functionName ?? preview.id;
+    if (out.has(fn) && !prefer(preview.id)) continue;
+    const svg = new TextDecoder().decode(bytes);
+    if (svg.includes("<svg")) out.set(fn, { id: preview.id, svg });
+  }
+  return out;
+}
+
+/**
+ * The hybrid raster crops carried for preview [id] as `previews/<id>.figma-raster/<node>.png`.
+ * Returns a Map name→bytes; empty for the common vector-only sticker.
+ */
+export function figmaRastersForId(bundle, id) {
+  const out = new Map();
+  const prefix = `previews/${id}.figma-raster/`;
+  for (const [path, bytes] of Object.entries(bundle.entries ?? {})) {
+    if (path.startsWith(prefix)) out.set(path.slice(prefix.length), bytes);
+  }
+  return out;
+}
+
+/**
+ * Rewrite a hybrid SVG's relative `figma-raster/<node>.png` `<image>` hrefs to a per-slug directory
+ * (`<slug>.figma-raster/<node>.png`) so they resolve next to `figma/<slug>.svg` and never collide
+ * across components (two stickers can each have a `node-3.png`). A no-op for a vector-only SVG.
+ */
+export function rewriteRasterHrefs(svg, componentSlug) {
+  return svg.replaceAll("figma-raster/", `${componentSlug}.figma-raster/`);
+}

--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -44,6 +44,11 @@ import { buildCatalog, writeCatalog } from "@design-parity/catalog-export";
 
 import { renderIndexHtml } from "./render-index-html.mjs";
 import { renderReadmeMd } from "./render-readme-md.mjs";
+import {
+  figmaRastersForId,
+  figmaSvgByFunction,
+  rewriteRasterHrefs,
+} from "./figma-svg-emit.mjs";
 import { renderWireframeSvg, slug } from "./render-wireframe-svg.mjs";
 import { renderLayoutWireframeSvg } from "./render-layout-wireframe-svg.mjs";
 import { DEFAULT_PREVIEW_BASE, livePreviewUrl } from "./live-preview.mjs";
@@ -116,26 +121,6 @@ function layoutByFunction(bundle) {
   return out;
 }
 
-/**
- * Map componentFunction → the layered `compose/figma-svg` export bytes carried in the bundle as
- * `previews/<id>.figma.svg` (baked by `bundle pack --with-semantics`). Unlike the wireframe — which
- * this driver *renders* from `layout.json` — the figma-svg is a complete SVG produced Kotlin-side
- * (real fills/strokes/corner radii + editable text), so we carry its bytes verbatim. Prefer the
- * light variant so a single deterministic sticker is emitted per component.
- */
-function figmaSvgByFunction(bundle) {
-  const out = new Map();
-  const prefer = (id) => /(_|\b)light$/i.test(id);
-  for (const preview of bundle.previews) {
-    const bytes = bundle.entries?.[`previews/${preview.id}.figma.svg`];
-    if (!bytes) continue;
-    const fn = preview.functionName ?? preview.id;
-    if (out.has(fn) && !prefer(preview.id)) continue;
-    const svg = new TextDecoder().decode(bytes);
-    if (svg.includes("<svg")) out.set(fn, svg);
-  }
-  return out;
-}
 
 /** Drop `widthDp`/`heightDp` when serialized as JSON null so the published
  *  normalizeSize doesn't `.trim()` a null. */
@@ -476,12 +461,28 @@ const figmaDir = join(outPath, "figma");
 await mkdir(figmaDir, { recursive: true });
 const figmaSvgSlugs = new Set();
 let figmaSvgCount = 0;
+let figmaRasterCount = 0;
 for (const component of catalog.components) {
   const fn = fnByComponentId.get(component.componentId);
-  const svg = fn ? figmaSvgByFn.get(fn) : undefined;
-  if (!svg) continue;
-  await writeFile(join(figmaDir, `${slug(component.componentId)}.svg`), svg, "utf8");
-  figmaSvgSlugs.add(slug(component.componentId));
+  const carried = fn ? figmaSvgByFn.get(fn) : undefined;
+  if (!carried) continue;
+  const componentSlug = slug(component.componentId);
+  let svg = carried.svg;
+  // A hybrid sticker's `<image href="figma-raster/<node>.png">` layers reference crops carried in
+  // the bundle. Copy them under a per-slug dir and rewrite the href prefix so they resolve next to
+  // figma/<slug>.svg (per-slug avoids <node>.png name collisions across components).
+  const rasters = figmaRastersForId(bundle, carried.id);
+  if (rasters.size) {
+    const rasterDir = `${componentSlug}.figma-raster`;
+    svg = rewriteRasterHrefs(svg, componentSlug);
+    await mkdir(join(figmaDir, rasterDir), { recursive: true });
+    for (const [name, bytes] of rasters) {
+      await writeFile(join(figmaDir, rasterDir, name), Buffer.from(bytes));
+      figmaRasterCount += 1;
+    }
+  }
+  await writeFile(join(figmaDir, `${componentSlug}.svg`), svg, "utf8");
+  figmaSvgSlugs.add(componentSlug);
   figmaSvgCount += 1;
 }
 
@@ -509,8 +510,8 @@ await writeFile(
 console.log(
   `[${spec.system}] ${catalog.components.length} component(s), ${result.imageCount} image(s), ` +
     `${wireframeCount} wireframe(s) (${layoutWireframeCount} from layout-inspector, ` +
-    `${wireframeCount - layoutWireframeCount} greenline), ${figmaSvgCount} figma-svg → ` +
-    `${result.manifestPath}`,
+    `${wireframeCount - layoutWireframeCount} greenline), ${figmaSvgCount} figma-svg ` +
+    `(${figmaRasterCount} raster crop(s)) → ${result.manifestPath}`,
 );
 console.log(`[${spec.system}] index → ${indexPath}`);
 console.log(`[${spec.system}] readme → ${readmePath}`);


### PR DESCRIPTION
## Summary

Follow-up to #2223 addressing [Codex's P2](https://github.com/yschimke/compose-ai-tools/pull/2223): a **hybrid** `compose/figma-svg` (a sticker with an opaque `Image` / `AsyncImage` / `Icon` / `Canvas` node — the daemon passes `frameImage`, turning on hybrid raster) emits ``'&lt;image href="figma-raster/&lt;node&gt;.png"&gt;'`` plus sibling PNG crops. #2223 carried only the SVG, so a published `figma/<slug>.svg` for such a sticker would import with **broken image layers**. This carries the crops too.

- **core** — single-source the dir name as `ComposeFigmaSvgProduct.RASTER_DIR` (`"figma-raster"`), the prefix `FigmaSvgModel.defaultRasterHref` emits and the carrier collects.
- **`cli` `DaemonSemanticsFetcher`** — read each preview's `figma-raster/*.png` crops into `figmaRasterById`; clear the dir pre-render.
- **`cli` `BundleCommand`** — inject them verbatim as `previews/<id>.figma-raster/<node>.png` (`injectFigmaRasterIntoBundle`, via the existing `injectRawZipEntries`) and report the crop count.
- **`scripts/design-artifacts`** — extract `figmaSvgByFunction` / `figmaRastersForId` / `rewriteRasterHrefs` into a testable `figma-svg-emit.mjs`; the emit loop copies a sticker's crops to `figma/<slug>.figma-raster/<node>.png` and rewrites the SVG's `figma-raster/` href prefix to that **per-slug** dir (so two stickers' `node-3.png` can't collide).

## Exposure

**Zero on the current m3 / wear-m3 catalogs** — I verified by packing icon-bearing stickers (`FilledButton`, and the selected `FilterChip` with its auto checkmark `Icon`): both export **pure vector**, no `figma-raster` produced. So nothing published today is affected; this makes the feature correct for any future raster-backed sticker (a photographic `Image`, a `Canvas` chart).

## Test plan

- **CLI unit**: new `BundleSemanticsInjectTest.injects hybrid figma-raster crops under a per-preview dir` — round-trips a crop through the polyglot bundle as `previews/<id>.figma-raster/<node>.png`, leaving the SVG + cover intact. ✅
- **JS unit**: new cases in `figma-svg-catalog.test.mjs` — `figmaSvgByFunction` prefers light + keeps the id; `figmaRastersForId` returns only that preview's crops; `rewriteRasterHrefs` re-points hrefs to `<slug>.figma-raster/` and leaves a vector-only SVG untouched. Full `node --test scripts/design-artifacts/` green (19). ✅
- **Daemon crop write** is already exercised by `RenderEngineTest.figmaSvgExportRastersOpaqueImage`; the fetcher reads exactly the path it writes (`build/compose-previews/data/<id>/figma-raster/`).
- **Regression**: re-packed `FilledButton_Light` with `--with-semantics` — still `figma-svg: 1 / 1 carried`, no `figma-raster` line (vector-only unaffected). ✅

## Note

Once this + #2223 are on `main`, I'll dispatch `design-artifacts.yml` **once** to regenerate the `design-artifacts/{compose-m3,wear-m3}` delivery branches so they pick up the new `figma/` vectors (correct + raster-safe), rather than running the full-catalog render twice.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QnJbgJ8mQguZWPgveufGCW)_