### PR TITLE
fix: reject path-traversal crop names in the design-catalog figma-raster carry

### DIFF
--- a/scripts/design-artifacts/figma-svg-catalog.test.mjs
+++ b/scripts/design-artifacts/figma-svg-catalog.test.mjs
@@ -77,6 +77,20 @@ test("figmaRastersForId returns only that preview's crops", () => {
   assert.deepEqual([...crops.keys()].sort(), ["node-1.png", "node-2.png"]);
 });
 
+test("figmaRastersForId rejects path-traversal / nested crop names (zip-slip guard)", () => {
+  const bundle = {
+    entries: {
+      "previews/Fab_Light.figma-raster/node-1.png": enc("ok"),
+      "previews/Fab_Light.figma-raster/../../README.md": enc("evil"),
+      "previews/Fab_Light.figma-raster/nested/x.png": enc("evil"),
+      "previews/Fab_Light.figma-raster/..": enc("evil"),
+    },
+  };
+  const crops = figmaRastersForId(bundle, "Fab_Light");
+  // Only the bare filename survives; anything with a separator or a `..` segment is dropped.
+  assert.deepEqual([...crops.keys()], ["node-1.png"]);
+});
+
 test("rewriteRasterHrefs re-points hrefs to a per-slug dir (no cross-slug collisions)", () => {
   const svg = '<image href="figma-raster/node-1.png"/><image href="figma-raster/node-2.png"/>';
   const out = rewriteRasterHrefs(svg, "fab");

--- a/scripts/design-artifacts/figma-svg-emit.mjs
+++ b/scripts/design-artifacts/figma-svg-emit.mjs
@@ -36,7 +36,14 @@ export function figmaRastersForId(bundle, id) {
   const out = new Map();
   const prefix = `previews/${id}.figma-raster/`;
   for (const [path, bytes] of Object.entries(bundle.entries ?? {})) {
-    if (path.startsWith(prefix)) out.set(path.slice(prefix.length), bytes);
+    if (!path.startsWith(prefix)) continue;
+    const name = path.slice(prefix.length);
+    // Zip-slip guard: the driver writes each crop to figma/<slug>.figma-raster/<name>, so a hostile
+    // bundle carrying `..`/absolute/nested crop names could escape that dir. The daemon only ever
+    // emits a bare `<node>.png` filename (see FigmaSvgModel.defaultRasterHref), so accept exactly
+    // that — reject anything with a path separator or a `.`/`..` segment.
+    if (!name || name === "." || name === ".." || /[\\/]/.test(name)) continue;
+    out.set(name, bytes);
   }
   return out;
 }


### PR DESCRIPTION
## Summary

Follow-up to #2225 addressing [Codex's P2 zip-slip](https://github.com/yschimke/compose-ai-tools/pull/2225) — the comment landed as #2225 was already merging, so the guard wasn't in that PR.

`figmaRastersForId` returned the bundle entry's suffix after `previews/<id>.figma-raster/` **verbatim**, and the export writes each crop via `join(figmaDir, \`${slug}.figma-raster\`, name)`. A hostile `--renders` bundle carrying an entry like `previews/<id>.figma-raster/../../README.md` (or enough `..` to reach `--out`) could make that write **escape the per-slug output dir**.

The daemon only ever emits a bare `<node>.png` filename (`FigmaSvgModel.defaultRasterHref` — no separators), so the tight, correct guard is to accept exactly that and drop any name with a path separator or a `.`/`..` segment. Fixed in the reader (`figmaRastersForId`), the single source both the write and any future consumer flow through.

```js
if (!name || name === "." || name === ".." || /[\\/]/.test(name)) continue;
```

## Test plan

- New `figma-svg-catalog.test.mjs` case: `figmaRastersForId rejects path-traversal / nested crop names (zip-slip guard)` — a bundle with `../../README.md`, `nested/x.png`, and `..` entries yields only the bare `node-1.png`. ✅
- Full `node --test scripts/design-artifacts/` green.

JS-only, defense-in-depth; no behavior change for the trusted design-artifacts pipeline (the daemon's crop names already pass the guard).


---
_Generated by [Claude Code](https://claude.ai/code/session_01QnJbgJ8mQguZWPgveufGCW)_