### PR TITLE
feat(serve): expose per-preview override declarations on /api/previews

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -3,6 +3,7 @@ package ee.schimke.composeai.cli.serve
 import ee.schimke.composeai.cli.BUNDLE_VERSION
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.daemon.protocol.StreamCodec
+import ee.schimke.composeai.data.overrides.PreviewOverrideDeclaration
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
@@ -417,7 +418,12 @@ class ServeHttpServer(
           trust = (renderHost as? ServeBundleHost)?.let { BundleVerifier.summary(it.trust) },
           previews =
             renderHost.previews.map { p ->
-              PreviewDto(id = p.id, label = p.label, modes = p.modes.map { it.wire })
+              PreviewDto(
+                id = p.id,
+                label = p.label,
+                modes = p.modes.map { it.wire },
+                overrides = p.overrides,
+              )
             },
         )
       call.respondText(
@@ -752,15 +758,18 @@ private data class VersionResponse(
   val schema: String = "compose-preview-serve/version/v1",
   /** The host CLI's released version ([BUNDLE_VERSION]). */
   val version: String,
-  /** The schema id the `/api/previews` + page surface speaks, so a client can feature-detect. */
-  val serveSchema: String = "compose-preview-serve/v1",
+  /**
+   * The schema id the `/api/previews` + page surface speaks, so a client can feature-detect. `v2`
+   * adds the per-preview `overrides` (author knob declarations) to `/api/previews`.
+   */
+  val serveSchema: String = "compose-preview-serve/v2",
   /** True when the box serves token-free (public preview server); false for a token-gated serve. */
   val public: Boolean,
 )
 
 @Serializable
 private data class PreviewsResponse(
-  val schema: String = "compose-preview-serve/v1",
+  val schema: String = "compose-preview-serve/v2",
   val module: String,
   /**
    * Producer-trust verdict for this session ([BundleVerifier.summary]) — `signature:<keyId>`,
@@ -772,7 +781,18 @@ private data class PreviewsResponse(
 )
 
 @Serializable
-private data class PreviewDto(val id: String, val label: String, val modes: List<String>)
+private data class PreviewDto(
+  val id: String,
+  val label: String,
+  val modes: List<String>,
+  /**
+   * The author-declared editable knobs this preview exposes (`compose/overrides`) — key, type,
+   * label, default/current value, and repeat index. Lets a programmatic client (the Figma plugin's
+   * override editor) present the controls without scraping the viewer HTML. Empty when the preview
+   * declares none (or the host doesn't carry them). Additive since `compose-preview-serve/v2`.
+   */
+  val overrides: List<PreviewOverrideDeclaration> = emptyList(),
+)
 
 @Serializable
 private data class BundleAcceptedResponse(

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
@@ -1,5 +1,9 @@
 package ee.schimke.composeai.cli.serve
 
+import ee.schimke.composeai.daemon.protocol.PreviewOverrideValue
+import ee.schimke.composeai.data.overrides.PreviewOverrideDeclaration
+import ee.schimke.composeai.data.overrides.PreviewOverrideType
+import ee.schimke.composeai.data.overrides.PreviewOverridesPayload
 import java.awt.image.BufferedImage
 import java.io.ByteArrayOutputStream
 import java.io.File
@@ -9,6 +13,7 @@ import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import kotlinx.serialization.json.Json
 import okhttp3.OkHttpClient
 import okhttp3.Request
 
@@ -30,18 +35,36 @@ class ServeHttpRoutingTest {
       .also { ImageIO.write(BufferedImage(2, 2, BufferedImage.TYPE_INT_RGB), "png", it) }
       .toByteArray()
 
-  private fun bundle(label: String): ServeBundleHost {
+  /** An author-declared string knob, carried into the bundle as an `overrides.json` sidecar. */
+  private val labelKnob =
+    PreviewOverrideDeclaration(
+      key = "label",
+      type = PreviewOverrideType.STRING,
+      label = "Label",
+      default = PreviewOverrideValue.StringValue("Tap me"),
+    )
+
+  private fun bundle(
+    label: String,
+    overrides: List<PreviewOverrideDeclaration> = emptyList(),
+  ): ServeBundleHost {
     val dir = Files.createTempDirectory("routing-$label").toFile().also { it.deleteOnExit() }
     File(dir, "index.html").writeText("<html></html>")
     File(dir, "previews").apply { mkdirs() }
     File(dir, "previews/$previewId.png").writeBytes(png())
+    if (overrides.isNotEmpty()) {
+      File(dir, "previews/$previewId.overrides.json")
+        .writeText(
+          Json.encodeToString(PreviewOverridesPayload.serializer(), PreviewOverridesPayload(overrides))
+        )
+    }
     return ServeBundleHost(dir, label = label)
   }
 
   private val registry = ServeSessionRegistry(open = { null })
   private val server: ServeHttpServer by lazy {
     registry.register("default-mod", host = bundle("default-mod"), pinned = true)
-    registry.register("compose-m3", host = bundle("compose-m3"), pinned = true)
+    registry.register("compose-m3", host = bundle("compose-m3", listOf(labelKnob)), pinned = true)
     ServeHttpServer(
         host = "127.0.0.1",
         requestedPort = 0,
@@ -103,6 +126,18 @@ class ServeHttpRoutingTest {
     val (apiCode, api) = get("/compose-m3/api/previews")
     assertEquals(200, apiCode)
     assertTrue(api.contains("\"module\":\"compose-m3\""), "api for the path session: $api")
+  }
+
+  @Test
+  fun `api previews advertises v2 and carries author override declarations`() {
+    val (code, api) = get("/compose-m3/api/previews")
+    assertEquals(200, code)
+    // v2 = the payload now carries per-preview override declarations.
+    assertTrue(api.contains("\"schema\":\"compose-preview-serve/v2\""), "schema v2: $api")
+    // The declared `label` knob (from the overrides.json sidecar) surfaces to a programmatic client.
+    assertTrue(api.contains("\"overrides\":["), "overrides array present: $api")
+    assertTrue(api.contains("\"key\":\"label\""), "declared knob key: $api")
+    assertTrue(api.contains("\"value\":\"Tap me\""), "declared knob default value: $api")
   }
 
   @Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
@@ -53,10 +53,12 @@ class ServeHttpRoutingTest {
     File(dir, "previews").apply { mkdirs() }
     File(dir, "previews/$previewId.png").writeBytes(png())
     if (overrides.isNotEmpty()) {
-      File(dir, "previews/$previewId.overrides.json")
-        .writeText(
-          Json.encodeToString(PreviewOverridesPayload.serializer(), PreviewOverridesPayload(overrides))
+      val sidecar =
+        Json.encodeToString(
+          PreviewOverridesPayload.serializer(),
+          PreviewOverridesPayload(overrides),
         )
+      File(dir, "previews/$previewId.overrides.json").writeText(sidecar)
     }
     return ServeBundleHost(dir, label = label)
   }
@@ -134,7 +136,7 @@ class ServeHttpRoutingTest {
     assertEquals(200, code)
     // v2 = the payload now carries per-preview override declarations.
     assertTrue(api.contains("\"schema\":\"compose-preview-serve/v2\""), "schema v2: $api")
-    // The declared `label` knob (from the overrides.json sidecar) surfaces to a programmatic client.
+    // The declared `label` knob (from the sidecar) surfaces to a programmatic client.
     assertTrue(api.contains("\"overrides\":["), "overrides array present: $api")
     assertTrue(api.contains("\"key\":\"label\""), "declared knob key: $api")
     assertTrue(api.contains("\"value\":\"Tap me\""), "declared knob default value: $api")


### PR DESCRIPTION
## Summary

A programmatic client — the design-parity Figma plugin's override editor — needs a component's author-declared editable knobs to render its controls, but `/api/previews` returned only `id`/`label`/`modes`; the knobs were viewer-HTML only. This exposes them.

- Add `overrides: List<PreviewOverrideDeclaration>` to the `/api/previews` `PreviewDto`, populated from the `ServePreview.overrides` already loaded from a bundle's `previews/<id>.overrides.json` sidecar (and the daemon's `compose/overrides`). Empty when a preview declares none.
- Bump the serve schema to **`compose-preview-serve/v2`** so clients feature-detect the richer payload. Additive — older readers ignore the new field.

## Test

`ServeHttpRoutingTest` now seeds a declared `label` string knob into the `compose-m3` bundle fixture (via a `previews/<id>.overrides.json` sidecar built from the real `PreviewOverridesPayload`) and asserts `/api/previews` advertises `v2` and carries the declaration (key + default value).

## Verification note

I could **not build/test this locally** in the agent sandbox: the Gradle 9.6.0 distribution is only reachable via `github.com/gradle/gradle-distributions` (every `services.gradle.org` / `downloads.gradle.org` URL 307-redirects there), which this session's egress policy blocks, and the system Gradle (8.14.3) is too old for the repo's Kotlin 2.3.20. **CI is the verification** for compile + ktfmt + the new test — I'll babysit it to green. The change is deliberately small and mechanical (a serializable field on an existing DTO, populated from an existing property; a fixture-backed test).

Text-only PR: no rendered/visual surface changes — this is data-product API plumbing.


---
_Generated by [Claude Code](https://claude.ai/code/session_018uTv78jpPEKSEyScXoCdYD)_