### PR TITLE
fix: render the hero image in the design-catalog index (not "no render")

### DIFF
--- a/scripts/design-artifacts/figma-svg-catalog.test.mjs
+++ b/scripts/design-artifacts/figma-svg-catalog.test.mjs
@@ -40,6 +40,39 @@ test("index emits no figma links when none were carried", () => {
   assert.doesNotMatch(html, /figma svg ↗/);
 });
 
+test("index renders the hero <img> when the catalog carries images (not 'no render')", () => {
+  // Regression: renderIndexHtml must be fed the serialized catalog (which carries component.images),
+  // not the in-memory one — else every card falls back to the shot--missing "no render" placeholder.
+  const withImages = {
+    system: "compose-m3",
+    title: "Compose M3",
+    components: [
+      {
+        componentId: "button-filled",
+        group: "Buttons",
+        images: [
+          {
+            path: "images/button-filled/ideal__default__light.png",
+            variant: "ideal",
+            width: 200,
+            height: 100,
+          },
+        ],
+      },
+    ],
+  };
+  const html = renderIndexHtml(withImages, {});
+  assert.match(html, /<img[^>]*src="images\/button-filled\/ideal__default__light\.png"/);
+  // The card figure must be the rendered `shot`, not the `shot shot--missing` "no render" fallback
+  // (the bare `.shot--missing` CSS class still appears in the <style> block — match the card only).
+  assert.doesNotMatch(html, /class="shot shot--missing"/);
+});
+
+test("index shows 'no render' only when a component truly has no images", () => {
+  const html = renderIndexHtml({ components: [{ componentId: "x", group: "G", images: [] }] }, {});
+  assert.match(html, /class="shot shot--missing"/);
+});
+
 test("README glance reports the editable design-vector (figma-svg) count", () => {
   const md = renderReadmeMd(catalog, { imageCount: 4, wireframeCount: 2, figmaSvgCount: 2 });
   assert.match(md, /Editable design vectors \(figma-svg\)/);

--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -490,7 +490,17 @@ for (const component of catalog.components) {
 // straight from the branch to skim every component (its a11y greenlines and the
 // editable wireframe) before importing the tokens/images into a design tool.
 const indexPath = join(outPath, "index.html");
-await writeFile(indexPath, renderIndexHtml(catalog, { wireframeSlugs, figmaSvgSlugs }), "utf8");
+// `renderIndexHtml`'s `heroImage` reads `component.images`, but the private `buildCatalog` keeps the
+// resolved image list off the in-memory `catalog` — it's only materialised on the serialized
+// `catalog.json` (by `writeCatalog`, then annotated with `livePreview` above). Feed the index the
+// serialized catalog so every card shows its render instead of a "no render" placeholder. The
+// wireframe/figma links keyed by `componentId` still match (same components).
+const indexCatalog = JSON.parse(await readFile(join(outPath, "catalog.json"), "utf8"));
+await writeFile(
+  indexPath,
+  renderIndexHtml(indexCatalog, { wireframeSlugs, figmaSvgSlugs }),
+  "utf8",
+);
 
 // Branch landing page: htmlpreview link to index.html + a summary table. Written
 // into out/ so the publish step's force-push republishes it every run — the


### PR DESCRIPTION
## Summary

Every card in the published catalog `index.html` (e.g. [`design-artifacts/compose-m3`](https://htmlpreview.github.io/?https://github.com/yschimke/compose-ai-tools/blob/design-artifacts/compose-m3/index.html)) shows a **"no render"** placeholder — even though the PNGs are committed under `images/` and `catalog.json` lists them per component.

**Root cause:** `renderIndexHtml` was handed the **in-memory** `catalog` from the private `buildCatalog`, which keeps the resolved image list *off* the object — the images are only materialised on the **serialized `catalog.json`** (by `writeCatalog`, then annotated with `livePreview`). So `heroImage(component.images)` was always `null` → every card fell back to `shot--missing`. Pre-existing; the hero images have never rendered. The `wireframe ↗` / `figma svg ↗` links were unaffected (they key off `componentId`), which is why only the images were blank.

**Fix:** feed `renderIndexHtml` the serialized catalog (re-read from `catalog.json`, which carries `.images` + the `livePreview` deep links), instead of the in-memory one. Wireframe/figma-svg slug sets still match (same `componentId`s).

## Test plan

- New `figma-svg-catalog.test.mjs` cases:
  - `renderIndexHtml` with a component that carries `images` emits the hero ``'&lt;img src="images/…"&gt;'`` and **not** the `class="shot shot--missing"` card.
  - a component with `images: []` still shows the `shot--missing` placeholder (fallback intact).
- Full `node --test scripts/design-artifacts/` green (22).

## Follow-up

Once merged I'll re-dispatch `design-artifacts.yml` so the published `design-artifacts/{compose-m3, wear-m3, remote-m3}` branches regenerate with the renders actually showing.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QnJbgJ8mQguZWPgveufGCW)_