### PR TITLE
feat(serve): serve figma-svg per preview via /render/&lt;id&gt;.svg

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHost.kt
@@ -33,6 +33,13 @@ interface ServeHost : AutoCloseable {
   fun render(previewId: String, overrides: PreviewOverrides): RenderOutcome
 
   /**
+   * Render [previewId] at [overrides] and return its figma-svg export, or [SvgOutcome.NotFound]
+   * when this host can't produce SVG. Defaults to `NotFound`: only the daemon-backed
+   * [ServeRenderHost] overrides this — a static [ServeBundleHost] has no daemon to export one.
+   */
+  fun renderSvg(previewId: String, overrides: PreviewOverrides): SvgOutcome = SvgOutcome.NotFound
+
+  /**
    * Join the shared live stream for [previewId], or `null` when this host has no live lane (the
    * snapshot fallback is used instead — always the case for [ServeBundleHost]).
    */

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -3,6 +3,7 @@ package ee.schimke.composeai.cli.serve
 import ee.schimke.composeai.cli.BUNDLE_VERSION
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.daemon.protocol.StreamCodec
+import ee.schimke.composeai.data.layoutinspector.ComposeFigmaSvgProduct
 import ee.schimke.composeai.data.overrides.PreviewOverrideDeclaration
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
@@ -495,16 +496,21 @@ class ServeHttpServer(
   }
 
   /**
-   * `GET /render/{name}` (query) and `GET /{system}/render/{name}` (path): a preview's PNG bytes.
+   * `GET /render/{name}` (query) and `GET /{system}/render/{name}` (path): a preview's rendered
+   * bytes — a PNG for `<id>.png` (or no suffix), or the figma-svg export for `<id>.svg`. Both take
+   * the same override query params; SVG is only produced by a daemon-backed host (a static bundle
+   * 404s it).
    */
   private suspend fun RoutingContext.handleRender(sessionInPath: Boolean) {
     if (rejectBadToken()) return
     withLeasedSession(selectedSessionId(sessionInPath)) { renderHost ->
-      val previewId = call.parameters["name"]?.removeSuffix(".png")
-      if (previewId.isNullOrBlank()) {
+      val rawName = call.parameters["name"]
+      if (rawName.isNullOrBlank()) {
         call.respondText("missing preview id", status = HttpStatusCode.BadRequest)
         return@withLeasedSession
       }
+      val wantSvg = rawName.endsWith(".svg")
+      val previewId = rawName.removeSuffix(".png").removeSuffix(".svg")
       // Forward the fixed render axes plus any author-declared knob params (`knob.<key>=…`, dynamic
       // keys not in SUPPORTED_KEYS) so a live knob edit reaches ServeOverrides.parse instead of
       // being
@@ -527,6 +533,10 @@ class ServeHttpServer(
         is OverrideParse.Invalid ->
           call.respondText(parsed.message, status = HttpStatusCode.BadRequest)
         is OverrideParse.Ok -> {
+          if (wantSvg) {
+            renderSvgResponse(renderHost, previewId, parsed.overrides)
+            return@withLeasedSession
+          }
           // The render is blocking (renderNow + await); keep it off the request dispatcher. Cap
           // concurrent renders (default = CPU count) so a small box sheds a storm instead of
           // thrashing: wait briefly for a slot, else 503 + Retry-After. A null outcome signals the
@@ -559,6 +569,40 @@ class ServeHttpServer(
           }
         }
       }
+    }
+  }
+
+  /** SVG lane of [handleRender]: load-shed like the PNG lane, then respond the figma-svg bytes. */
+  private suspend fun RoutingContext.renderSvgResponse(
+    renderHost: ServeHost,
+    previewId: String,
+    overrides: PreviewOverrides,
+  ) {
+    val outcome =
+      withContext(Dispatchers.IO) {
+        if (!renderSemaphore.tryAcquire(RENDER_QUEUE_WAIT_SECONDS, TimeUnit.SECONDS)) {
+          null
+        } else {
+          try {
+            renderHost.renderSvg(previewId, overrides)
+          } finally {
+            renderSemaphore.release()
+          }
+        }
+      }
+    when (outcome) {
+      null -> {
+        call.response.headers.append(HttpHeaders.RetryAfter, "2")
+        call.respondText(
+          "render queue saturated; retry shortly",
+          status = HttpStatusCode.ServiceUnavailable,
+        )
+      }
+      is SvgOutcome.Ok ->
+        call.respondBytes(outcome.svg, ContentType.parse(ComposeFigmaSvgProduct.MEDIA_TYPE_SVG))
+      SvgOutcome.NotFound -> call.respondText("no such preview", status = HttpStatusCode.NotFound)
+      is SvgOutcome.Failed ->
+        call.respondText(outcome.reason, status = HttpStatusCode.InternalServerError)
     }
   }
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
@@ -4,6 +4,7 @@ import ee.schimke.composeai.daemon.protocol.InteractiveInputKind
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.daemon.protocol.StreamCodec
 import ee.schimke.composeai.daemon.protocol.StreamFrameParams
+import ee.schimke.composeai.data.layoutinspector.ComposeFigmaSvgProduct
 import ee.schimke.composeai.io.SystemFileSystem
 import ee.schimke.composeai.render.session.RenderSession
 import ee.schimke.composeai.render.session.RenderSessionConfig
@@ -66,6 +67,17 @@ sealed interface RenderOutcome {
   data class Failed(val reason: String) : RenderOutcome
 }
 
+/** Result of a figma-svg render request — the SVG counterpart of [RenderOutcome]. */
+sealed interface SvgOutcome {
+  data class Ok(val svg: ByteArray) : SvgOutcome
+
+  /** No such preview id, or this host can't produce SVG (a static bundle has no daemon). */
+  data object NotFound : SvgOutcome
+
+  /** The render or SVG export was attempted but failed. [reason] is human-readable. */
+  data class Failed(val reason: String) : SvgOutcome
+}
+
 /**
  * Long-lived, thread-safe wrapper around **one** [RenderSession], fronting it for the
  * `compose-preview serve` HTTP server. The long-lived sibling of
@@ -108,6 +120,9 @@ internal constructor(
   // Bounded LRU of rendered PNGs keyed by ServeOverrides.cacheKey. A dev-facing server fronting one
   // module won't accumulate many distinct (preview × overrides) combos, so a small cap is plenty.
   private val cache = LruByteCache(MAX_CACHE_ENTRIES)
+
+  // The figma-svg counterpart of [cache], keyed the same way (previewId × overrides).
+  private val svgCache = LruByteCache(MAX_CACHE_ENTRIES)
 
   private val renderLock = ReentrantLock()
 
@@ -240,6 +255,64 @@ internal constructor(
 
       cache.put(key, bytes)
       RenderOutcome.Ok(bytes)
+    }
+  }
+
+  /**
+   * Render [previewId] at [overrides] and return its **figma-svg** export (`compose/figma-svg`),
+   * serving a cached result when one exists. Thread-safe.
+   *
+   * The daemon writes the SVG to a per-preview path as a side effect of the *same* render that
+   * produces the PNG, so this renders (reusing [render] and its retry/timeout handling) and then
+   * fetches the just-written SVG. Both happen under [renderLock] with the PNG cache entry evicted
+   * first: the SVG file is shared per preview and overwritten by every render, so it must be
+   * fetched in the same critical section as the render that produced it — a PNG cache hit would
+   * otherwise skip the render and leave a prior render's (stale) SVG on disk.
+   */
+  override fun renderSvg(previewId: String, overrides: PreviewOverrides): SvgOutcome {
+    check(!closed.get()) { "ServeRenderHost is closed" }
+    if (previewId !in previewIds) return SvgOutcome.NotFound
+
+    val key = ServeOverrides.cacheKey(previewId, overrides)
+    svgCache.get(key)?.let {
+      return SvgOutcome.Ok(it)
+    }
+
+    return renderLock.withLock {
+      svgCache.get(key)?.let {
+        return@withLock SvgOutcome.Ok(it)
+      }
+
+      // Force a fresh render of these overrides so the shared per-preview SVG file on disk is
+      // theirs; the held lock keeps any other render from overwriting it before the fetch below.
+      cache.remove(key)
+      when (val pngOutcome = render(previewId, overrides)) {
+        RenderOutcome.NotFound -> return@withLock SvgOutcome.NotFound
+        is RenderOutcome.Failed -> return@withLock SvgOutcome.Failed(pngOutcome.reason)
+        is RenderOutcome.Ok -> {} // rendered; the SVG for these overrides is now on disk
+      }
+
+      val bytes =
+        try {
+          session
+            .fetchData(previewId, ComposeFigmaSvgProduct.KIND)
+            .path
+            ?.toPath()
+            ?.takeIf { fileSystem.exists(it) }
+            ?.let { p -> fileSystem.read(p) { readByteArray() } }
+        } catch (e: Exception) {
+          val reason = "figma-svg fetch failed: ${e.message}"
+          onLog(reason)
+          return@withLock SvgOutcome.Failed(reason)
+        }
+      if (bytes == null) {
+        val reason = "render produced no SVG"
+        onLog(reason)
+        return@withLock SvgOutcome.Failed(reason)
+      }
+
+      svgCache.put(key, bytes)
+      SvgOutcome.Ok(bytes)
     }
   }
 
@@ -450,5 +523,10 @@ private class LruByteCache(private val maxEntries: Int) {
   @Synchronized
   fun put(key: String, value: ByteArray) {
     map[key] = value
+  }
+
+  @Synchronized
+  fun remove(key: String) {
+    map.remove(key)
   }
 }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
@@ -12,6 +12,7 @@ import ee.schimke.composeai.render.session.RenderSessionException
 import ee.schimke.composeai.render.session.RenderSessionFactory
 import ee.schimke.composeai.render.session.subprocess.SubprocessRenderSessions
 import java.io.File
+import java.util.Base64
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
@@ -292,28 +293,51 @@ internal constructor(
         is RenderOutcome.Ok -> {} // rendered; the SVG for these overrides is now on disk
       }
 
-      val bytes =
+      val svgPath =
         try {
-          session
-            .fetchData(previewId, ComposeFigmaSvgProduct.KIND)
-            .path
-            ?.toPath()
-            ?.takeIf { fileSystem.exists(it) }
-            ?.let { p -> fileSystem.read(p) { readByteArray() } }
+          session.fetchData(previewId, ComposeFigmaSvgProduct.KIND).path?.toPath()
         } catch (e: Exception) {
           val reason = "figma-svg fetch failed: ${e.message}"
           onLog(reason)
           return@withLock SvgOutcome.Failed(reason)
         }
-      if (bytes == null) {
+      val raw =
+        svgPath
+          ?.takeIf { fileSystem.exists(it) }
+          ?.let { p -> fileSystem.read(p) { readByteArray() } }
+      if (raw == null || svgPath == null) {
         val reason = "render produced no SVG"
         onLog(reason)
         return@withLock SvgOutcome.Failed(reason)
       }
 
+      // Inline any hybrid figma-raster crops so the served SVG is self-contained (a vector-only SVG
+      // passes through untouched); Figma's importer can't resolve external hrefs.
+      val bytes = inlineRasters(svgPath, raw)
       svgCache.put(key, bytes)
       SvgOutcome.Ok(bytes)
     }
+  }
+
+  /**
+   * Inline a hybrid SVG's sibling `figma-raster/<node>.png` crops as `data:` URIs so the served SVG
+   * is self-contained — the Figma importer (and any consumer that can't resolve external hrefs)
+   * needs every layer embedded. A vector-only SVG has no such refs and passes through; a crop
+   * that's missing on disk is left as a plain ref rather than dropped.
+   */
+  private fun inlineRasters(svgPath: okio.Path, raw: ByteArray): ByteArray {
+    val svg = raw.decodeToString()
+    val dir = svgPath.parent
+    if (dir == null || !svg.contains("\"figma-raster/")) return raw
+    val inlined =
+      RASTER_HREF.replace(svg) { match ->
+        val href = match.groupValues[1]
+        val cropPath = "$dir/$href".toPath()
+        if (!fileSystem.exists(cropPath)) return@replace match.value
+        val crop = fileSystem.read(cropPath) { readByteArray() }
+        "href=\"data:image/png;base64,${Base64.getEncoder().encodeToString(crop)}\""
+      }
+    return inlined.encodeToByteArray()
   }
 
   /**
@@ -481,6 +505,11 @@ internal constructor(
     private const val COALESCED_RETRY_BACKOFF_MS = 100L
 
     private const val MAX_CACHE_ENTRIES = 256
+
+    /**
+     * `<image href="figma-raster/<node>.png">` refs a hybrid SVG carries, for data-URI inlining.
+     */
+    private val RASTER_HREF = Regex("href=\"(figma-raster/[^\"]+)\"")
 
     /**
      * Open a long-lived session against a daemon launch descriptor and wrap it. Mirrors

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/FakeRenderSession.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/FakeRenderSession.kt
@@ -68,6 +68,11 @@ internal class FakeRenderSession(
    * serve normally), modelling the override-in-flight coalescing the serve host must retry through.
    */
   private val coalescedOverrideRejections: Int = 0,
+  /**
+   * When true, the figma-svg written per render is a hybrid: an `<image href="figma-raster/…">`
+   * plus the sibling crop on disk, to exercise serve-side raster inlining.
+   */
+  private val hybridSvg: Boolean = false,
 ) : RenderSession {
   val renderCount = AtomicInteger(0)
   private val coalesceRemaining = AtomicInteger(coalescedOverrideRejections)
@@ -189,10 +194,15 @@ internal class FakeRenderSession(
   }
 
   private fun writeFigmaSvg(id: String, overrides: PreviewOverrides?) {
-    val svg = "svg:${overrides?.uiMode}:${overrides?.localeTag}:${overrides?.device}"
-    File(renderRoot, "$id/${ComposeFigmaSvgProduct.FILE_SVG}").apply {
-      parentFile?.mkdirs()
-      writeText(svg)
+    val previewDir = File(renderRoot, id).apply { mkdirs() }
+    if (hybridSvg) {
+      File(previewDir, "figma-raster").mkdirs()
+      File(previewDir, "figma-raster/node0.png").writeBytes(byteArrayOf(1, 2, 3))
+      File(previewDir, ComposeFigmaSvgProduct.FILE_SVG)
+        .writeText("<svg><image href=\"figma-raster/node0.png\"/></svg>")
+    } else {
+      val svg = "svg:${overrides?.uiMode}:${overrides?.localeTag}:${overrides?.device}"
+      File(previewDir, ComposeFigmaSvgProduct.FILE_SVG).writeText(svg)
     }
   }
 

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/FakeRenderSession.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/FakeRenderSession.kt
@@ -29,6 +29,7 @@ import ee.schimke.composeai.daemon.protocol.ServerCapabilities
 import ee.schimke.composeai.daemon.protocol.StreamCodec
 import ee.schimke.composeai.daemon.protocol.StreamFrameParams
 import ee.schimke.composeai.daemon.protocol.StreamStartResult
+import ee.schimke.composeai.data.layoutinspector.ComposeFigmaSvgProduct
 import ee.schimke.composeai.render.session.NotificationListener
 import ee.schimke.composeai.render.session.RenderSession
 import ee.schimke.composeai.render.session.RenderSessionBackend
@@ -180,8 +181,19 @@ internal class FakeRenderSession(
     } else {
       val content = "png:${overrides?.uiMode}:${overrides?.localeTag}:${overrides?.device}"
       emitFinished(id, content.toByteArray())
+      // Model the daemon writing the figma-svg to a shared per-preview path as a side effect of the
+      // same render — overwritten each time, so distinct overrides overwrite one another's SVG.
+      writeFigmaSvg(id, overrides)
     }
     return RenderNowResult(queued = previewIds, rejected = emptyList())
+  }
+
+  private fun writeFigmaSvg(id: String, overrides: PreviewOverrides?) {
+    val svg = "svg:${overrides?.uiMode}:${overrides?.localeTag}:${overrides?.device}"
+    File(renderRoot, "$id/${ComposeFigmaSvgProduct.FILE_SVG}").apply {
+      parentFile?.mkdirs()
+      writeText(svg)
+    }
   }
 
   override fun fetchData(
@@ -190,7 +202,17 @@ internal class FakeRenderSession(
     inline: Boolean,
     params: JsonElement?,
     timeout: kotlin.time.Duration,
-  ): DataFetchResult = error("unused")
+  ): DataFetchResult {
+    if (kind == ComposeFigmaSvgProduct.KIND) {
+      val file = File(renderRoot, "$previewId/${ComposeFigmaSvgProduct.FILE_SVG}")
+      return DataFetchResult(
+        kind = kind,
+        schemaVersion = ComposeFigmaSvgProduct.SCHEMA_VERSION,
+        path = file.absolutePath,
+      )
+    }
+    error("unused")
+  }
 
   override fun subscribeData(
     previewId: String,

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
@@ -131,6 +131,14 @@ class ServeHttpRoutingTest {
   }
 
   @Test
+  fun `a static bundle 404s the svg render lane`() {
+    // The .svg lane is routed and dispatched, but a bundle host has no daemon to run the figma-svg
+    // export, so it resolves to NotFound (only a daemon-backed ServeRenderHost produces SVG).
+    val (code, _) = get("/compose-m3/render/$previewId.svg")
+    assertEquals(404, code)
+  }
+
+  @Test
   fun `api previews advertises v2 and carries author override declarations`() {
     val (code, api) = get("/compose-m3/api/previews")
     assertEquals(200, code)

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHostTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHostTest.kt
@@ -51,6 +51,40 @@ class ServeRenderHostTest {
   }
 
   @Test
+  fun `renderSvg returns the figma-svg for the given overrides`() {
+    val session = FakeRenderSession(newRenderRoot())
+    host(session).use { h ->
+      val out = h.renderSvg(previewId, PreviewOverrides(uiMode = UiMode.DARK))
+      assertTrue(out is SvgOutcome.Ok)
+      assertEquals("svg:DARK:null:null", (out as SvgOutcome.Ok).svg.decodeToString())
+    }
+  }
+
+  @Test
+  fun `renderSvg serves identical requests from cache`() {
+    val session = FakeRenderSession(newRenderRoot())
+    host(session).use { h ->
+      h.renderSvg(previewId, PreviewOverrides(uiMode = UiMode.DARK))
+      h.renderSvg(previewId, PreviewOverrides(uiMode = UiMode.DARK))
+      assertEquals(1, session.renderCount.get(), "second identical SVG request must hit the cache")
+    }
+  }
+
+  @Test
+  fun `renderSvg is not stale when the png for those overrides is already cached`() {
+    val session = FakeRenderSession(newRenderRoot())
+    host(session).use { h ->
+      // Cache the dark PNG, then render light — the shared per-preview SVG file is now light's.
+      h.render(previewId, PreviewOverrides(uiMode = UiMode.DARK))
+      h.render(previewId, PreviewOverrides(uiMode = UiMode.LIGHT))
+      // A dark SVG request must re-render dark, not return the shared file's stale light SVG.
+      val out = h.renderSvg(previewId, PreviewOverrides(uiMode = UiMode.DARK))
+      assertTrue(out is SvgOutcome.Ok)
+      assertEquals("svg:DARK:null:null", (out as SvgOutcome.Ok).svg.decodeToString())
+    }
+  }
+
+  @Test
   fun `concurrent identical requests coalesce to a single render`() {
     val session = FakeRenderSession(newRenderRoot())
     host(session).use { h ->

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHostTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHostTest.kt
@@ -85,6 +85,19 @@ class ServeRenderHostTest {
   }
 
   @Test
+  fun `renderSvg inlines hybrid figma-raster crops as data URIs`() {
+    val session = FakeRenderSession(newRenderRoot(), hybridSvg = true)
+    host(session).use { h ->
+      val out = h.renderSvg(previewId, PreviewOverrides())
+      assertTrue(out is SvgOutcome.Ok)
+      val svg = (out as SvgOutcome.Ok).svg.decodeToString()
+      val expected = java.util.Base64.getEncoder().encodeToString(byteArrayOf(1, 2, 3))
+      assertTrue(svg.contains("data:image/png;base64,$expected"), "raster inlined: $svg")
+      assertTrue(!svg.contains("figma-raster/"), "no dangling external ref remains: $svg")
+    }
+  }
+
+  @Test
   fun `concurrent identical requests coalesce to a single render`() {
     val session = FakeRenderSession(newRenderRoot())
     host(session).use { h ->


### PR DESCRIPTION
## Summary

`compose-preview serve`'s render lane produces **PNG only**. This adds an **SVG lane**: `GET /render/<id>.svg` returns a preview's `compose/figma-svg` export (the layered, editable SVG), taking the **same override query params** as the PNG lane (`uiMode`/`fontScale`/`knob.*`/…).

This unblocks the design-parity Figma plugin's "editable SVG component" import mode — a live, overridable, refreshable vector export, not just a raster snapshot.

### Why it's cheap

The daemon writes the figma-svg to a per-preview path **as a side effect of the same render that produces the PNG** — it lands on disk before `renderFinished` fires. So `ServeRenderHost.renderSvg` just:
1. renders these overrides (reusing `render()` and its retry/timeout/coalesce handling), then
2. `session.fetchData(previewId, compose/figma-svg)` — which returns the just-written file's path with **no re-render** (`requiresRerender = false`, PATH transport), and
3. reads the bytes.

Overrides need no separate wiring: the SVG is generated from the **same overridden captured tree** as the PNG, and `ServeOverrides.cacheKey` is reused for an svg-keyed LRU.

### The correctness subtlety

The figma-svg file is **shared per preview** (`<previewId>/compose-figma.svg`) and overwritten by every render. So `renderSvg` forces a fresh render (evicting the PNG cache entry) and fetches the SVG **in the same `renderLock` critical section** — otherwise a PNG cache hit would skip the render and a concurrent render of other overrides could leave a *stale* SVG on disk. The `renderSvg is not stale …` test pins exactly this.

### Self-contained SVG (hybrid rasters)

A hybrid export references sibling `figma-raster/<node>.png` crops via `<image href>`. `renderSvg` **inlines each crop as a `data:image/png;base64` URI** so the served SVG is self-contained — required because the consumer (Figma's `createNodeFromSvg`) can't resolve external hrefs. Vector-only exports pass through untouched; a crop missing on disk is left as a plain ref.

### Scope

- **Daemon-backed hosts** (`ServeRenderHost`) produce SVG.
- **Static bundles** (`ServeBundleHost`) have no daemon, so `renderSvg` defaults to `NotFound` (404). Serving SVG from a bundle payload is a possible follow-up.

## Test plan

- `ServeRenderHostTest`: `renderSvg` returns the figma-svg for given overrides; identical requests hit the svg cache (one render); **not stale when the PNG for those overrides is already cached** (the shared-file race); **hybrid `figma-raster` crops inline as data URIs** (no dangling external ref).
- `ServeHttpRoutingTest`: a static bundle 404s the `.svg` lane (route is wired + dispatched).
- `FakeRenderSession` models the shared per-preview SVG file, `fetchData(compose/figma-svg)`, and (via `hybridSvg`) a hybrid SVG + sibling crop.
- Not runnable in this environment (no Gradle); ktfmt verified locally against the pinned tool; relying on CI for compile + test.

## Follow-ups

- design-parity Figma plugin: offer SVG in the override editor (fetch `.svg`, place via `figma.createNodeFromSvg`) + Refresh.
- Optional: static-bundle SVG from the bundle payload.

---
_Generated by [Claude Code](https://claude.ai/code/session_018uTv78jpPEKSEyScXoCdYD)_