### PR TITLE
feat(serve): --catalog-source-root so deploy/image can live-render compose-m3

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
@@ -63,6 +63,7 @@ internal object CliFlags {
       "--catalogs-unlisted",
       "--catalog-repo",
       "--catalog-branch-prefix",
+      "--catalog-source-root",
       "--wasm-dir",
       "--revisions-allow",
       "--live-seats",

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -334,11 +334,23 @@ class ServeCommand(args: List<String>) : Command(args) {
         .getOrNull()
     }
     // Project mode forks a session per git revision behind the registry's factory; off by default
-    // the factory yields nothing, so only the pinned current checkout is served.
-    // Worktrees back both project-mode revisions and the trusted-catalog source build; either flag
-    // opens them (gated by the same --revisions-allow ref allowlist).
-    val worktrees: GitWorktrees? =
-      if (revisions || allowRenderTrusted) openWorktrees(module) else null
+    // the factory yields nothing, so only the pinned current checkout is served. These worktrees
+    // are
+    // rooted at the served module's own project (`?session=<rev>` builds that module).
+    val worktrees: GitWorktrees? = if (revisions) openWorktrees(module) else null
+    // The trusted-catalog builder's worktrees. Rooted at --catalog-source-root when set (a separate
+    // checkout of the catalog's source repo — e.g. a prebuilt image serving a standalone module),
+    // else the served-project root (reusing [worktrees] when --revisions already opened one). Kept
+    // SEPARATE from [worktrees] so combining --revisions with --catalog-source-root still roots
+    // `?session=<rev>` at the served project rather than the catalog checkout. Both are gated by
+    // the
+    // same --revisions-allow ref allowlist.
+    val catalogWorktrees: GitWorktrees? =
+      when {
+        !allowRenderTrusted -> null
+        catalogSourceRoot != null -> openWorktrees(module, rootOverride = catalogSourceRoot)
+        else -> worktrees ?: openWorktrees(module)
+      }
     // The `?session=<rev>` factory (project mode) is gated on --revisions ONLY — NOT merely on
     // worktrees existing. Otherwise `--allow-render-trusted` (which also opens worktrees, but just
     // to
@@ -369,7 +381,8 @@ class ServeCommand(args: List<String>) : Command(args) {
     // A catalog that carries a `web/wasm/` app yields a system→dir entry so the in-browser tier
     // rides the same trusted branch (no local --wasm-dir build needed).
     val catalogWasm =
-      if (catalogRefs.isNotEmpty()) registerCatalogs(registry, worktrees, openHost) else emptyMap()
+      if (catalogRefs.isNotEmpty()) registerCatalogs(registry, catalogWorktrees, openHost)
+      else emptyMap()
     // Runtime ingestion (--accept-bundles): clients POST a bundle (or a ?url= to one) and it's
     // registered as a pinned session. Unpacked under a temp dir for this server's lifetime.
     val bundleStore =
@@ -454,6 +467,7 @@ class ServeCommand(args: List<String>) : Command(args) {
           runCatching { server.stop() }
           runCatching { registry.close() }
           runCatching { worktrees?.close() }
+          runCatching { if (catalogWorktrees !== worktrees) catalogWorktrees?.close() }
           done.countDown()
         }
       )
@@ -497,9 +511,9 @@ class ServeCommand(args: List<String>) : Command(args) {
   }
 
   /** Open the worktree manager rooted at the repo (project mode), gated to the allowed refs. */
-  private fun openWorktrees(module: PreviewModule): GitWorktrees {
+  private fun openWorktrees(module: PreviewModule, rootOverride: File? = null): GitWorktrees {
     val repoRoot =
-      catalogSourceRoot
+      rootOverride
         ?: findProjectRoot()
         ?: module.projectDir.absoluteFile.parentFile
         ?: module.projectDir

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -83,6 +83,18 @@ class ServeCommand(args: List<String>) : Command(args) {
   private val allowRenderTrusted: Boolean = "--allow-render-trusted" in args
 
   /**
+   * Optional git repo root the trusted-catalog builder ([buildTrustedCatalogSource]) and its
+   * [GitWorktrees] use, instead of the served module's own project root ([findProjectRoot]). Lets a
+   * box whose primary `--module` is a standalone project (e.g. the prebuilt `deploy/image`, which
+   * serves a self-contained `sample-project`) still live-render a fetched catalog by pointing this
+   * at a separate checkout of the catalog's `source.repo` (which the entrypoint clones). The
+   * `source.repo == `[catalogRepo] and `--revisions-allow` gates are unchanged — this only moves
+   * the worktree root. Off ⇒ the served module's project root, as before.
+   */
+  private val catalogSourceRoot: File? =
+    args.flagValue("--catalog-source-root")?.takeIf { it.isNotBlank() }?.let { File(it) }
+
+  /**
    * Project mode revision policy (SECURITY/RCE): comma-separated refs whose history a requested
    * `?session=<rev>` must be reachable from to be checked out and built. Empty = nothing builds
    * (fail closed), since building runs that revision's Gradle. e.g. `--revisions-allow
@@ -487,7 +499,10 @@ class ServeCommand(args: List<String>) : Command(args) {
   /** Open the worktree manager rooted at the repo (project mode), gated to the allowed refs. */
   private fun openWorktrees(module: PreviewModule): GitWorktrees {
     val repoRoot =
-      findProjectRoot() ?: module.projectDir.absoluteFile.parentFile ?: module.projectDir
+      catalogSourceRoot
+        ?: findProjectRoot()
+        ?: module.projectDir.absoluteFile.parentFile
+        ?: module.projectDir
     if (revisionAllowRefs.isEmpty()) {
       System.err.println(
         "serve: --revisions has no --revisions-allow refs; no revision will build (fail closed). " +
@@ -631,7 +646,7 @@ class ServeCommand(args: List<String>) : Command(args) {
       return false
     }
     if (source.ref.isBlank() || source.module.isBlank()) return false
-    val repoRoot = findProjectRoot() ?: return false
+    val repoRoot = catalogSourceRoot ?: findProjectRoot() ?: return false
     // The ref allowlist is enforced here (fail-closed): null = unresolvable or not in
     // --revisions-allow.
     val worktree =
@@ -844,6 +859,13 @@ class ServeCommand(args: List<String>) : Command(args) {
                           box that can't build the catalog source (e.g. the desktop-only public
                           image can't build the Android catalogs) — leave it off and let the
                           in-browser Wasm tier carry CMP.
+        --catalog-source-root <dir>
+                          Git repo root the trusted-catalog builder (--allow-render-trusted)
+                          worktrees + builds from, instead of the served --module's own project. Use
+                          when --module is a standalone project but the catalog's source.repo is a
+                          separate checkout (e.g. a prebuilt image serving sample-project that clones
+                          the CMP catalog repo for live render). The trust + same-repo + ref-allowlist
+                          gates are unchanged.
         --live-seats <n>  Cap concurrent live (daemon-backed) stream sessions. Each seat holds a JVM
                           Compose daemon, so on a small box bound this (e.g. 1–2) when the live tier
                           is on (--allow-render-trusted) — an over-cap stream is refused (WS 1013)

--- a/deploy/image/Dockerfile
+++ b/deploy/image/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update \
  && apt-get install -y --no-install-recommends \
       libfreetype6 libfontconfig1 fontconfig fonts-dejavu-core \
       libgl1 libglx-mesa0 libgl1-mesa-dri \
-      curl ca-certificates \
+      curl ca-certificates git \
  && rm -rf /var/lib/apt/lists/*
 ENV LIBGL_ALWAYS_SOFTWARE=1 \
     GRADLE_USER_HOME=/root/.gradle

--- a/deploy/image/docker-compose.yml
+++ b/deploy/image/docker-compose.yml
@@ -40,11 +40,24 @@ services:
       # Unused in public mode; required only when SERVE_PUBLIC=0.
       SERVE_TOKEN: "${SERVE_TOKEN:-}"
       SERVE_IDLE_EXIT: "0"
-      # Live (daemon-backed) preview tier — OFF by default (snapshot + in-browser Wasm only). To
-      # offer live CMP-JVM streaming on this box, set SERVE_ALLOW_RENDER_TRUSTED=1 (+ its ref
-      # allowlist) and cap the seats: each seat is a JVM Compose daemon, so on this 4 GB / 2 vCPU box
-      # keep it small (1–2). An over-cap viewer is refused (WS 1013) instead of OOM-ing the box.
-      # Flip on with a compose redeploy: set these in .env, then `docker compose up -d`.
+      # Live (daemon-backed) preview tier — OFF by default (snapshot + in-browser Wasm only, which
+      # already makes the CMP screens interactive). To offer server-side live CMP-JVM streaming on
+      # this prebuilt box, set ALL of:
+      #   SERVE_ALLOW_RENDER_TRUSTED=1
+      #   SERVE_REVISIONS_ALLOW=main               # the trusted source-ref allowlist
+      #   SERVE_CATALOG_SOURCE_REPO=yschimke/compose-ai-tools   # cloned at startup to build from
+      #   SERVE_LIVE_SEATS=1                        # each seat is a JVM daemon; cap it on a 4 GB box
+      # The image serves a standalone /project, so the entrypoint CLONES the catalog's source repo
+      # and points serve at it (--catalog-source-root); only the CMP `compose-m3` catalog is
+      # desktop-buildable here (the Android catalogs stay baked-PNG, fail-closed). NOTE: the trusted
+      # build runs at startup, so the first boot after enabling — and after each image update —
+      # does a one-time cold Gradle build of the catalog (minutes) before serving. Needs a CLI
+      # release carrying --catalog-source-root (this image's CP_VERSION). Flip on via .env, then
+      # `docker compose up -d`. Leave unset to keep the fast snapshot+Wasm posture.
+      SERVE_ALLOW_RENDER_TRUSTED: "${SERVE_ALLOW_RENDER_TRUSTED:-}"
+      SERVE_REVISIONS_ALLOW: "${SERVE_REVISIONS_ALLOW:-}"
+      SERVE_CATALOG_SOURCE_REPO: "${SERVE_CATALOG_SOURCE_REPO:-}"
+      SERVE_CATALOG_SOURCE_REF: "${SERVE_CATALOG_SOURCE_REF:-}"
       SERVE_LIVE_SEATS: "${SERVE_LIVE_SEATS:-}"
       PORT: "8080"
     # To pin your OWN producers, mount a trust store over the baked one and keep

--- a/deploy/image/entrypoint.sh
+++ b/deploy/image/entrypoint.sh
@@ -54,6 +54,30 @@ fi
 [[ -n "${SERVE_REVISIONS_ALLOW:-}" ]] && args+=(--revisions-allow "${SERVE_REVISIONS_ALLOW}")
 if [[ "${SERVE_ALLOW_RENDER_TRUSTED:-}" == "1" || "${SERVE_ALLOW_RENDER_TRUSTED:-}" == "true" ]]; then
   args+=(--allow-render-trusted)
+  # The prebuilt image serves a standalone /project, not a checkout of a catalog's
+  # source repo — so the trusted builder has nothing to worktree from by default.
+  # When SERVE_CATALOG_SOURCE_REPO is set, clone that repo here and point serve at it
+  # with --catalog-source-root, so a Trusted catalog whose source.repo matches can be
+  # built + live-rendered. Only the CMP `compose-m3` catalog is desktop-buildable on
+  # this Android-less image; the Android catalogs stay baked-PNG (fail-closed).
+  #
+  # COST: the trusted build runs at startup (and after each image update), so the
+  # first boot with this on does a one-time cold Gradle build of the catalog
+  # (minutes) before serving. Leave SERVE_CATALOG_SOURCE_REPO unset to keep the
+  # lightweight snapshot+Wasm posture (CMP stays interactive via the Wasm tier).
+  if [[ -n "${SERVE_CATALOG_SOURCE_REPO:-}" ]]; then
+    src_root="${SERVE_CATALOG_SOURCE_ROOT:-/catalog-src}"
+    src_ref="${SERVE_CATALOG_SOURCE_REF:-main}"
+    if [[ ! -d "${src_root}/.git" ]]; then
+      echo "entrypoint: cloning ${SERVE_CATALOG_SOURCE_REPO}@${src_ref} → ${src_root} for trusted live render" >&2
+      git clone --branch "${src_ref}" "https://github.com/${SERVE_CATALOG_SOURCE_REPO}.git" "${src_root}"
+    else
+      git -C "${src_root}" fetch --quiet origin "${src_ref}" && \
+        git -C "${src_root}" checkout --quiet -B "${src_ref}" "origin/${src_ref}" || \
+        echo "entrypoint: refresh of ${src_root} failed — building from the existing checkout" >&2
+    fi
+    args+=(--catalog-source-root "${src_root}")
+  fi
 fi
 # Bound concurrent live (daemon-backed) stream seats. Only meaningful once the live tier is enabled
 # (SERVE_ALLOW_RENDER_TRUSTED) — each seat holds a JVM Compose daemon, so a small box (preview.coo.ee

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -174,8 +174,17 @@ clear the `--revisions-allow` allowlist, and its `source.repo` must be the serve
 `SERVE_REVISIONS_ALLOW=main` + a `SERVE_LIVE_SEATS` cap). The other published catalogs
 (`wear-m3`, `remote-m3`) are still **Android** modules; on the desktop-only box their trusted build
 isn't attempted and they fall back to baked PNG (fail-closed) — no error, just no live tier for them.
-The prebuilt released image (`deploy/image`) leaves it unset until a CLI release carries these serve
-features. Only enable it where the per-session Gradle build + live render is affordable.
+The prebuilt released image (`deploy/image`) serves a standalone `sample-project`, not a checkout of
+the catalog's source repo, so the trusted builder has nothing to worktree from by default. It can
+still opt in: set `SERVE_ALLOW_RENDER_TRUSTED=1` + `SERVE_REVISIONS_ALLOW=main` +
+`SERVE_CATALOG_SOURCE_REPO=yschimke/compose-ai-tools` (+ a `SERVE_LIVE_SEATS` cap), and the entrypoint
+**clones that repo at startup** and points `serve` at it with **`--catalog-source-root`** — so the
+CMP `compose-m3` catalog live-renders while the Android catalogs stay baked-PNG (fail-closed). The
+trade-off: the trusted build runs at startup, so the first boot after enabling (and after each
+Watchtower image update) does a one-time cold Gradle build of the catalog (minutes) before serving,
+and it needs a CLI release carrying `--catalog-source-root`. Left off, the image keeps its fast
+snapshot + in-browser-Wasm posture (CMP stays interactive via the Wasm tier). Only enable it where
+that per-boot build + live render is affordable.
 
 ### Bounding the live tier — `--live-seats` / `SERVE_LIVE_SEATS`
 


### PR DESCRIPTION
## Summary

Lets the **prebuilt `deploy/image`** (`preview.coo.ee`) offer the **daemon-backed live CMP tier** — previously a from-source (`deploy/vps`) only capability.

**Why it didn't work on `deploy/image`:** the trusted-catalog builder resolves the git root to worktree + build from via the **served module's** project (`ServeCommand.openWorktrees` / `buildTrustedCatalogSource` → `findProjectRoot()`). On `deploy/image` the served project is a standalone `sample-project`, not a checkout of the catalog's `source.repo`, so `git worktree add main` has nothing to work from. (The `source.repo == catalogRepo` same-repo check already passes — the git root was the only blocker.)

**The fix:**
- **`serve --catalog-source-root <dir>`** — points the trusted builder + its `GitWorktrees` at a separate repo checkout instead of the served module's project root. The trust, same-repo, and `--revisions-allow` gates are unchanged; this only moves the worktree root. Off ⇒ prior behaviour.
- **`deploy/image` opt-in:** when `SERVE_ALLOW_RENDER_TRUSTED=1` + `SERVE_CATALOG_SOURCE_REPO=<owner/repo>` are set, the entrypoint **clones that repo at startup** and passes `--catalog-source-root`. The CMP `compose-m3` catalog then live-renders; the Android `wear-m3`/`remote-m3` stay baked-PNG (fail-closed). `git` is now installed in the image.

Off by default — the image keeps its fast snapshot + in-browser **Wasm** posture (which already makes the CMP screens interactive), so nothing changes for existing pulls.

## To enable on preview.coo.ee (`.env`, then `docker compose up -d`)

```
SERVE_ALLOW_RENDER_TRUSTED=1
SERVE_REVISIONS_ALLOW=main
SERVE_CATALOG_SOURCE_REPO=yschimke/compose-ai-tools
SERVE_LIVE_SEATS=1
```

## Trade-offs (documented in `docs/public-preview-server.md`)

- The trusted build runs at **startup**, so the first boot after enabling — and after each Watchtower image update — does a **one-time cold Gradle build** of the catalog (minutes) before serving. Bounded by `--live-seats`.
- Because `deploy/image` runs the **released** CLI, `--catalog-source-root` only takes effect once it ships in a release (bump the image's `CP_VERSION`).

## Test plan

- `:cli:compileKotlin` green; `:cli:test --tests "…serve.*"` green (the flag is a null-safe `?:` override, so the existing trusted-render tests still pass on the default path).
- `bash -n deploy/image/entrypoint.sh` and the compose YAML validate.
- The clone → `--catalog-source-root` → live-render path is exercisable only on a real `deploy/image` container (no Docker in the build sandbox); it reuses the same `GitWorktrees` + `GradleRevisionBuilder` path `deploy/vps` already runs.

Text-only PR: no rendered surface changes (serve flag + deploy wiring + docs).

---
_Generated by [Claude Code](https://claude.ai/code/session_01WGVyWcXTvsYbmCtLEXU7tn)_