### PR TITLE
fix(design-catalog): inline @Preview on the Android focus-ring supplement

### DIFF
--- a/samples/design-catalog-m3-android/src/main/kotlin/com/example/designcatalogm3android/FocusRing.kt
+++ b/samples/design-catalog-m3-android/src/main/kotlin/com/example/designcatalogm3android/FocusRing.kt
@@ -55,16 +55,6 @@ private fun FocusRingSticker(content: @Composable () -> Unit) {
   }
 }
 
-/** Light + dark, matching the CMP catalog's `@CatalogModes` so the folded variant carries both. */
-@Preview(name = "Light", showBackground = true, group = "modes")
-@Preview(
-  name = "Dark",
-  showBackground = true,
-  uiMode = Configuration.UI_MODE_NIGHT_YES,
-  group = "modes",
-)
-private annotation class FocusModes
-
 /** Seed a held [FocusInteraction.Focus] so the resting capture shows the focus ring active. */
 @Composable
 private fun focusedSource(): MutableInteractionSource {
@@ -78,7 +68,16 @@ private fun focusedSource(): MutableInteractionSource {
  * The function name **must** stay `FilledButtonFocused` — the generator folds this render onto the
  * `Button/Filled` component's `keyboard-focus` variant in `catalog.spec.json` by matching it.
  */
-@FocusModes
+// Light + dark, matching the CMP catalog's `@CatalogModes` so the folded variant carries both.
+// The `@Preview`s are inlined (not a shared multipreview annotation) so discovery reliably resolves
+// them on this single-preview module.
+@Preview(name = "Light", showBackground = true, group = "modes")
+@Preview(
+  name = "Dark",
+  showBackground = true,
+  uiMode = Configuration.UI_MODE_NIGHT_YES,
+  group = "modes",
+)
 @Composable
 fun FilledButtonFocused() =
   FocusRingSticker { Button(onClick = {}, interactionSource = focusedSource()) { Text("Focused") } }


### PR DESCRIPTION
## Summary

The `design-artifacts.yml` regeneration for `compose-m3` (dispatched after #2239 merged) **failed** — the `compose-m3` delivery branch was **not** regenerated and still carries the pre-CMP catalog.

**Cause:** the Android focus-ring supplement (`:samples:design-catalog-m3-android`, added in #2239) used a **file-private** multipreview annotation, `private annotation class FocusModes`. Preview discovery (ClassGraph) doesn't resolve a non-public multipreview container, so the module discovered **zero previews** and its `bundle pack` step failed:

```
FAILURE: composePreviewBundle: previews.json is empty — nothing to bundle. Run composePreviewDiscover first.
```

That failed the whole `compose-m3` matrix row before the generate/publish steps. (The CMP catalog render itself succeeded — 64 previews, all semantics/figma-svg.)

**Fix:** inline the two `@Preview` annotations directly on the public `FilledButtonFocused` (the canonical form used across the catalogs, e.g. `TextMaxLinesTruncated`), dropping the private multipreview annotation. Discovery then reliably finds the single preview and the `--extra-renders` fold folds its focus-ring render onto the `keyboard-focus` variant.

## Test plan

- The change is the standard inline-`@Preview` pattern the other catalogs use, so discovery finds `FilledButtonFocused` (× Light/Dark). The Robolectric render is CI-only (no Android SDK in the build sandbox).
- After merge: re-dispatch `design-artifacts.yml` (ref `main`) — the `compose-m3` row should now render + fold + publish, regenerating `design-artifacts/compose-m3` from the CMP catalog.

Text-only fix (no rendered-surface change to the CMP sheet; restores the previously-intended focus-ring variant render).

---
_Generated by [Claude Code](https://claude.ai/code/session_01WGVyWcXTvsYbmCtLEXU7tn)_