### PR TITLE
feat(serve): serve a catalog's baked figma-svg via /render/&lt;id&gt;.svg

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
@@ -4,8 +4,11 @@ import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.daemon.protocol.StreamCodec
 import ee.schimke.composeai.daemon.protocol.StreamFrameParams
 import ee.schimke.composeai.data.overrides.PreviewOverridesPayload
+import ee.schimke.composeai.io.SystemFileSystem
 import java.io.File
 import kotlinx.serialization.json.Json
+import okio.FileSystem
+import okio.Path.Companion.toOkioPath
 
 /**
  * A [ServeHost] backed by a **portable bundle** on disk (the `ServeBundle` / WebEmbed layout:
@@ -37,6 +40,13 @@ class ServeBundleHost(
    * `catalog.json`'s `library`. Null when the catalog declares none (or for a plain bundle).
    */
   val subtitle: String? = null,
+  /**
+   * The local dir holding a catalog's `figma/<slug>.svg` exports (+ `<slug>.figma-raster/` crops),
+   * populated by [ServeCatalogStore]. When set, {@link renderSvg} serves the baked editable vector
+   * per preview; null for a plain uploaded bundle (which then 404s the `.svg` lane).
+   */
+  private val figmaDir: File? = null,
+  private val fileSystem: FileSystem = SystemFileSystem,
 ) : ServeHost {
 
   private val previewsDir = File(bundleDir, PREVIEWS_SUBDIR)
@@ -61,11 +71,11 @@ class ServeBundleHost(
   private fun readOverrides(
     id: String
   ): List<ee.schimke.composeai.data.overrides.PreviewOverrideDeclaration> {
-    val sidecar = File(previewsDir, "$id$OVERRIDES_SUFFIX")
-    if (!sidecar.isFile) return emptyList()
+    val sidecar = File(previewsDir, "$id$OVERRIDES_SUFFIX").toOkioPath()
+    if (!fileSystem.exists(sidecar)) return emptyList()
     return try {
-      OVERRIDES_JSON.decodeFromString(PreviewOverridesPayload.serializer(), sidecar.readText())
-        .declarations
+      val json = fileSystem.read(sidecar) { readUtf8() }
+      OVERRIDES_JSON.decodeFromString(PreviewOverridesPayload.serializer(), json).declarations
     } catch (e: Exception) {
       emptyList()
     }
@@ -75,9 +85,29 @@ class ServeBundleHost(
 
   override fun render(previewId: String, overrides: PreviewOverrides): RenderOutcome {
     if (previewId !in previewIds) return RenderOutcome.NotFound
-    val png = File(previewsDir, "$previewId$PNG_SUFFIX")
-    if (!png.isFile) return RenderOutcome.NotFound
-    return RenderOutcome.Ok(png.readBytes())
+    val png = File(previewsDir, "$previewId$PNG_SUFFIX").toOkioPath()
+    if (!fileSystem.exists(png)) return RenderOutcome.NotFound
+    return RenderOutcome.Ok(fileSystem.read(png) { readByteArray() })
+  }
+
+  /**
+   * Serve the baked `compose/figma-svg` export for [previewId] from the catalog's [figmaDir], with
+   * its hybrid raster crops inlined so the SVG is self-contained. The SVG is per component **slug**
+   * (`figma/<slug>.svg`) and a preview id folds the slug + variant (`<slug>__<variant>`), so the
+   * slug is the id up to the first `__`. [SvgOutcome.NotFound] for a plain bundle (no [figmaDir]),
+   * an unknown id, or a preview whose component carried no figma-svg. Overrides don't apply
+   * (static).
+   */
+  override fun renderSvg(previewId: String, overrides: PreviewOverrides): SvgOutcome {
+    val figma = figmaDir ?: return SvgOutcome.NotFound
+    if (previewId !in previewIds) return SvgOutcome.NotFound
+    val svgFile =
+      File(figma, "${previewId.substringBefore(SLUG_SEPARATOR)}$SVG_SUFFIX").toOkioPath()
+    if (!fileSystem.exists(svgFile)) return SvgOutcome.NotFound
+    val svg = fileSystem.read(svgFile) { readUtf8() }
+    return SvgOutcome.Ok(
+      inlineFigmaRasters(fileSystem, figma.toOkioPath(), svg).encodeToByteArray()
+    )
   }
 
   /**
@@ -100,6 +130,9 @@ class ServeBundleHost(
   companion object {
     private const val PREVIEWS_SUBDIR = "previews"
     private const val PNG_SUFFIX = ".png"
+    private const val SVG_SUFFIX = ".svg"
+    /** A preview id folds the component slug and variant as `<slug>__<variant>`. */
+    private const val SLUG_SEPARATOR = "__"
     private const val OVERRIDES_SUFFIX = ".overrides.json"
     private val OVERRIDES_JSON = Json { ignoreUnknownKeys = true }
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
@@ -98,6 +98,8 @@ class ServeCatalogStore(
     val previewsDir = File(dir, "previews")
     val previewsRoot = previewsDir.canonicalFile.toPath()
     var count = 0
+    // The component slugs whose baked figma-svg to fetch (a slug is the preview id up to `__`).
+    val slugs = LinkedHashSet<String>()
     for (component in catalog.components) {
       for (image in component.images) {
         if (count >= maxImages) break
@@ -112,6 +114,7 @@ class ServeCatalogStore(
         if (!target.canonicalFile.toPath().startsWith(previewsRoot)) continue
         target.parentFile?.mkdirs()
         target.writeBytes(bytes)
+        slugs.add(id.substringBefore(SLUG_SEPARATOR))
         count++
       }
     }
@@ -147,6 +150,10 @@ class ServeCatalogStore(
       return Result.Ok(safe, count, "${BundleVerifier.summary(verdict)} (live)")
     }
 
+    // Fetch the catalog's baked editable vectors (figma/<slug>.svg + crops) so the host can serve
+    // an SVG per preview; null when the branch carried none (host then 404s the .svg lane).
+    val figmaDir = fetchFigmaSvgs(slugs, base, dir)
+
     val host =
       ServeBundleHost(
         dir,
@@ -155,6 +162,7 @@ class ServeCatalogStore(
         title = catalog.title?.takeIf { it.isNotBlank() },
         subtitle =
           catalog.library.filter { it.isNotBlank() }.take(2).joinToString(" · ").ifBlank { null },
+        figmaDir = figmaDir,
       )
     register(safe, host)
     return Result.Ok(safe, host.previews.size, BundleVerifier.summary(verdict))
@@ -198,6 +206,41 @@ class ServeCatalogStore(
   }
 
   /**
+   * Fetch the catalog's baked `figma/<slug>.svg` exports (+ each hybrid SVG's external
+   * `<slug>.figma-raster/<node>.png` crops) from [base] into `<dir>/figma/`, so the static host can
+   * serve an editable vector per preview. Best-effort per slug (a missing SVG just means that
+   * component carried none); each write is path-contained like the images. Returns the local
+   * `figma/` dir when at least one SVG was written, else null.
+   */
+  private fun fetchFigmaSvgs(slugs: Set<String>, base: String, dir: File): File? {
+    val figmaDir = File(dir, FIGMA_DIR)
+    val figmaRoot = figmaDir.canonicalFile.toPath()
+    var wrote = 0
+    for (slug in slugs) {
+      if (slug.isEmpty() || "/" in slug || ".." in slug) continue
+      val svgBytes = runCatching { fetch("$base$FIGMA_DIR/$slug.svg") }.getOrNull() ?: continue
+      val svgFile = File(figmaDir, "$slug.svg")
+      if (!svgFile.canonicalFile.toPath().startsWith(figmaRoot)) continue
+      svgFile.parentFile?.mkdirs()
+      svgFile.writeBytes(svgBytes)
+      wrote++
+      // A hybrid SVG references external `figma-raster/<node>.png` crops; carry them so the host
+      // can
+      // inline them. Enumerate from the SVG itself (raw.githubusercontent has no directory
+      // listing).
+      for (href in figmaRasterHrefs(svgBytes.toString(Charsets.UTF_8))) {
+        if (href.isEmpty() || ".." in href.split("/")) continue
+        val cropFile = File(figmaDir, href)
+        if (!cropFile.canonicalFile.toPath().startsWith(figmaRoot)) continue
+        val cropBytes = runCatching { fetch("$base$FIGMA_DIR/$href") }.getOrNull() ?: continue
+        cropFile.parentFile?.mkdirs()
+        cropFile.writeBytes(cropBytes)
+      }
+    }
+    return if (wrote > 0) figmaDir else null
+  }
+
+  /**
    * Minimal mirror of the `design-parity-catalog/v1` schema — only the bits we serve are needed.
    */
   @Serializable
@@ -236,6 +279,9 @@ class ServeCatalogStore(
     const val DEFAULT_BRANCH_PREFIX = "design-artifacts/"
     const val CATALOG_FILE = "catalog.json"
     const val IMAGES_DIR = "images"
+    const val FIGMA_DIR = "figma"
+    /** A preview id folds the component slug + variant as `<slug>__<variant>`. */
+    const val SLUG_SEPARATOR = "__"
     const val WEB_WASM_DIR = "web/wasm"
     const val WEB_RENDER_COMPOSE_WASM = "compose-wasm"
     private const val MAX_WASM_FILES = 64

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeFigmaSvg.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeFigmaSvg.kt
@@ -1,0 +1,58 @@
+package ee.schimke.composeai.cli.serve
+
+import java.util.Base64
+import okio.FileSystem
+import okio.Path
+import okio.Path.Companion.toPath
+
+/**
+ * Shared helpers for serving a catalog's baked `compose/figma-svg` exports. A hybrid export
+ * references its per-node raster crops as **external** hrefs (`figma-raster/<node>.png`, or the
+ * delivery branch's slug-prefixed `<slug>.figma-raster/<node>.png`), so both fetching (enumerate
+ * the crops to download) and serving (inline them so the SVG is self-contained, since Figma's
+ * importer can't resolve external hrefs) walk those hrefs. Used by both the daemon path
+ * ([ServeRenderHost]) and the static catalog path ([ServeCatalogStore] / [ServeBundleHost]).
+ */
+
+/**
+ * `<image href="…figma-raster/<node>.png">` refs a hybrid figma-svg carries (bare or
+ * slug-prefixed).
+ */
+private val FIGMA_RASTER_HREF = Regex("href=\"([^\"]*figma-raster/[^\"]+)\"")
+
+/**
+ * The figma-raster hrefs a hybrid SVG references (external crop paths, relative to the SVG's dir).
+ */
+internal fun figmaRasterHrefs(svg: String): List<String> =
+  FIGMA_RASTER_HREF.findAll(svg).map { it.groupValues[1] }.toList()
+
+/**
+ * Inline an SVG's `figma-raster/<node>.png` crops as `data:image/png;base64` URIs, reading each
+ * crop (relative to [dir], where its href resolves) via [fileSystem], so the served SVG is
+ * self-contained. A vector-only SVG passes through; a crop missing on disk is left as a plain ref.
+ */
+internal fun inlineFigmaRasters(fileSystem: FileSystem, dir: Path, svg: String): String {
+  if (!svg.contains("figma-raster/")) return svg
+  val root = dir.normalized()
+  return FIGMA_RASTER_HREF.replace(svg) { match ->
+    val href = match.groupValues[1]
+    // Resolve + contain: an untrusted catalog SVG must not read outside `dir` via `..`/absolute
+    // hrefs — a crop that would escape is left as a plain ref, never followed.
+    val cropPath = "$dir/$href".toPath().normalized()
+    if (!cropPath.isUnder(root) || !fileSystem.exists(cropPath)) return@replace match.value
+    val crop = fileSystem.read(cropPath) { readByteArray() }
+    "href=\"data:image/png;base64,${Base64.getEncoder().encodeToString(crop)}\""
+  }
+}
+
+/**
+ * True when this path is [root] or a descendant of it (both normalized) — traversal containment.
+ */
+private fun Path.isUnder(root: Path): Boolean {
+  var p: Path? = this
+  while (p != null) {
+    if (p == root) return true
+    p = p.parent
+  }
+  return false
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
@@ -12,7 +12,6 @@ import ee.schimke.composeai.render.session.RenderSessionException
 import ee.schimke.composeai.render.session.RenderSessionFactory
 import ee.schimke.composeai.render.session.subprocess.SubprocessRenderSessions
 import java.io.File
-import java.util.Base64
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
@@ -322,22 +321,12 @@ internal constructor(
   /**
    * Inline a hybrid SVG's sibling `figma-raster/<node>.png` crops as `data:` URIs so the served SVG
    * is self-contained — the Figma importer (and any consumer that can't resolve external hrefs)
-   * needs every layer embedded. A vector-only SVG has no such refs and passes through; a crop
-   * that's missing on disk is left as a plain ref rather than dropped.
+   * needs every layer embedded. A vector-only SVG has no such refs and passes through. Shares the
+   * inlining with the static catalog path via {@link inlineFigmaRasters}.
    */
   private fun inlineRasters(svgPath: okio.Path, raw: ByteArray): ByteArray {
-    val svg = raw.decodeToString()
-    val dir = svgPath.parent
-    if (dir == null || !svg.contains("\"figma-raster/")) return raw
-    val inlined =
-      RASTER_HREF.replace(svg) { match ->
-        val href = match.groupValues[1]
-        val cropPath = "$dir/$href".toPath()
-        if (!fileSystem.exists(cropPath)) return@replace match.value
-        val crop = fileSystem.read(cropPath) { readByteArray() }
-        "href=\"data:image/png;base64,${Base64.getEncoder().encodeToString(crop)}\""
-      }
-    return inlined.encodeToByteArray()
+    val dir = svgPath.parent ?: return raw
+    return inlineFigmaRasters(fileSystem, dir, raw.decodeToString()).encodeToByteArray()
   }
 
   /**
@@ -505,11 +494,6 @@ internal constructor(
     private const val COALESCED_RETRY_BACKOFF_MS = 100L
 
     private const val MAX_CACHE_ENTRIES = 256
-
-    /**
-     * `<image href="figma-raster/<node>.png">` refs a hybrid SVG carries, for data-URI inlining.
-     */
-    private val RASTER_HREF = Regex("href=\"(figma-raster/[^\"]+)\"")
 
     /**
      * Open a long-lived session against a daemon launch descriptor and wrap it. Mirrors

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHostTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHostTest.kt
@@ -49,6 +49,63 @@ class ServeBundleHostTest {
   }
 
   @Test
+  fun `renderSvg serves the baked figma svg with hybrid rasters inlined`() {
+    val dir = bundle("button-filled__ideal__default__dark" to byteArrayOf(1))
+    val figma = File(dir, "figma").apply { mkdirs() }
+    File(figma, "button-filled.svg")
+      .writeText("<svg><image href=\"button-filled.figma-raster/n0.png\"/></svg>")
+    File(figma, "button-filled.figma-raster").mkdirs()
+    File(figma, "button-filled.figma-raster/n0.png").writeBytes(byteArrayOf(1, 2, 3))
+
+    val host = ServeBundleHost(dir, label = "compose-m3", figmaDir = figma)
+    val ok =
+      host.renderSvg("button-filled__ideal__default__dark", PreviewOverrides()) as SvgOutcome.Ok
+    val svg = ok.svg.decodeToString()
+    val expected = java.util.Base64.getEncoder().encodeToString(byteArrayOf(1, 2, 3))
+    assertTrue(svg.contains("data:image/png;base64,$expected"), "raster inlined: $svg")
+    assertFalse(svg.contains("figma-raster/"), "no dangling external ref: $svg")
+  }
+
+  @Test
+  fun `renderSvg is NotFound without a figma dir, for unknown ids, and for missing svgs`() {
+    val dir =
+      bundle("button-filled__ideal__default__dark" to byteArrayOf(1), "badge__x" to byteArrayOf(2))
+    val overrides = PreviewOverrides()
+
+    // A plain bundle (no figmaDir) 404s the .svg lane.
+    val plain = ServeBundleHost(dir, label = "b")
+    assertEquals(
+      SvgOutcome.NotFound,
+      plain.renderSvg("button-filled__ideal__default__dark", overrides),
+    )
+
+    // With a figma dir: a known id whose slug carried no svg, and an unknown id, both 404.
+    val figma = File(dir, "figma").apply { mkdirs() }
+    File(figma, "button-filled.svg").writeText("<svg/>")
+    val host = ServeBundleHost(dir, label = "b", figmaDir = figma)
+    assertEquals(SvgOutcome.NotFound, host.renderSvg("badge__x", overrides)) // slug badge: no svg
+    assertEquals(SvgOutcome.NotFound, host.renderSvg("nope__x", overrides)) // unknown id
+  }
+
+  @Test
+  fun `renderSvg does not inline a raster href that escapes the figma dir`() {
+    val dir = bundle("button-filled__ideal__default__dark" to byteArrayOf(1))
+    val figma = File(dir, "figma").apply { mkdirs() }
+    // A secret file OUTSIDE the figma dir; a traversal href must not read it.
+    File(dir, "secret.png").writeBytes(byteArrayOf(9, 9, 9))
+    File(figma, "button-filled.svg")
+      .writeText("<svg><image href=\"button-filled.figma-raster/../../secret.png\"/></svg>")
+
+    val host = ServeBundleHost(dir, label = "b", figmaDir = figma)
+    val ok =
+      host.renderSvg("button-filled__ideal__default__dark", PreviewOverrides()) as SvgOutcome.Ok
+    val svg = ok.svg.decodeToString()
+    val leaked = java.util.Base64.getEncoder().encodeToString(byteArrayOf(9, 9, 9))
+    assertFalse(svg.contains(leaked), "must not inline a file outside the figma dir: $svg")
+    assertTrue(svg.contains("../../secret.png"), "the escaping href is left as a plain ref: $svg")
+  }
+
+  @Test
   fun `a bundle host has no live lane`() {
     val host = ServeBundleHost(bundle("p" to byteArrayOf(1)), label = "b")
     assertNull(host.subscribeStream("p", PreviewOverrides(), null, null) {})

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.cli.serve
 
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import java.awt.image.BufferedImage
 import java.io.ByteArrayOutputStream
 import java.io.File
@@ -82,6 +83,32 @@ class ServeCatalogStoreTest {
     assertEquals(
       setOf("button-filled__ideal__default__dark", "button-filled__ideal__default__light"),
       host.previews.map { it.id }.toSet(),
+    )
+  }
+
+  @Test
+  fun `a catalog's baked figma svgs are fetched and served self-contained`() {
+    val svg = "<svg><image href=\"button-filled.figma-raster/n0.png\"/></svg>"
+    val crop = byteArrayOf(7, 7, 7)
+    val fetch: (String) -> ByteArray? = { url ->
+      when {
+        url.endsWith("/${ServeCatalogStore.CATALOG_FILE}") -> catalogJson.toByteArray()
+        url.endsWith("figma/button-filled.svg") -> svg.toByteArray()
+        url.endsWith("figma/button-filled.figma-raster/n0.png") -> crop
+        url.endsWith(".png") -> png()
+        else -> null
+      }
+    }
+    store(TrustStore.EMPTY, fetch).load("compose-m3")
+
+    val host = registered.getValue("compose-m3")
+    val ok =
+      host.renderSvg("button-filled__ideal__default__dark", PreviewOverrides()) as SvgOutcome.Ok
+    val out = ok.svg.decodeToString()
+    val expected = java.util.Base64.getEncoder().encodeToString(crop)
+    assertTrue(
+      out.contains("data:image/png;base64,$expected"),
+      "crop inlined into served svg: $out",
     )
   }
 


### PR DESCRIPTION
## Summary

The SVG render lane (`GET /render/<id>.svg`, #2240) only produced SVG on a **daemon-backed** host. A **static catalog** (`design-artifacts/<system>`, which the public `preview.coo.ee` serves via `ServeBundleHost` built by `ServeCatalogStore`) 404'd it. This makes the public server serve the **editable vector per preview** from the catalog's already-baked `figma/<slug>.svg` — so the Figma plugin's SVG import mode works against `preview.coo.ee`, not only a local daemon.

- **`ServeCatalogStore.load`** now also fetches `figma/<slug>.svg` (+ each hybrid SVG's external `<slug>.figma-raster/<node>.png` crops, enumerated from the SVG text since raw.githubusercontent has no dir listing) into the local bundle — path-contained exactly like the images — and passes a `figmaDir` to the host.
- **`ServeBundleHost.renderSvg`** reads `figma/<slug>.svg` (slug = preview id up to the first `__` — one component SVG folds its theme/variant sticker ids) and **inlines its raster crops** so the served SVG is self-contained (Figma's `createNodeFromSvg` can't resolve external hrefs). `NotFound` for a plain uploaded bundle (no `figmaDir`), an unknown id, or a slug that carried no SVG.
- **Shared okio helper** (`ServeFigmaSvg`): the raster-inlining is hoisted out of `ServeRenderHost` into `inlineFigmaRasters` / `figmaRasterHrefs`, now used by both the daemon and static-catalog paths; `ServeBundleHost`'s file reads move to okio to match.

Overrides still don't apply on a static catalog (it replays baked output) — the full live experience (overrides + refresh) needs a daemon-backed serve. This just lights up **static editable-SVG import** from the public server.

## Test plan

- `ServeBundleHostTest`: `renderSvg` serves the baked `figma/<slug>.svg` with hybrid crops inlined (data URI, no dangling ref); `NotFound` without a `figmaDir`, for an unknown id, and for a slug with no SVG.
- `ServeCatalogStoreTest`: a catalog's `figma/<slug>.svg` (+ crop) is fetched and the registered host serves it self-contained.
- Existing `ServeRenderHost` hybrid-inlining test still covers the shared helper (daemon path unchanged in behavior).
- Not runnable in this environment (no Gradle); ktfmt verified locally against the pinned tool; relying on CI for compile + test.

## Follow-ups

- SVG refresh in the plugin (re-render a placed SVG node) — a design-parity follow-up, unrelated to this serve change.

---
_Generated by [Claude Code](https://claude.ai/code/session_018uTv78jpPEKSEyScXoCdYD)_