### PR TITLE
feat(serve): live-render a trusted catalog from its carried bundle, no build

### DIFF
--- a/.github/workflows/design-artifacts.yml
+++ b/.github/workflows/design-artifacts.yml
@@ -158,6 +158,11 @@ jobs:
           WASM_DIST: ${{ matrix.wasmDist }}
           # Presence flag: fold the Android-only supplement render in (see above).
           EXTRA_RENDERS: ${{ matrix.androidExtraModule }}
+          # Carry the executable bundle onto the branch so a trusted serve can launch
+          # a render daemon from it (no build). Only for the DESKTOP CMP catalog
+          # (compose-m3, the only row with a wasm tier) — the Android catalogs' bundle
+          # can't run on the desktop-only public box, so they stay baked-PNG.
+          PUBLISH_LIVE_BUNDLE: ${{ matrix.wasmModule != '' && '1' || '' }}
           # Buildable source for trusted server-side re-render: catalog.json gets a
           # `source: {repo, ref, module}` so a `serve --allow-render-trusted` box can
           # rebuild + re-render this catalog live. Inert on the public desktop box,
@@ -174,6 +179,7 @@ jobs:
             --renderer "$(compose-preview --version | head -1)" \
             ${WASM_DIST:+--wasm-dist "$GITHUB_WORKSPACE/$WASM_DIST"} \
             ${EXTRA_RENDERS:+--extra-renders "$GITHUB_WORKSPACE/$SYSTEM-extra-bundle.png"} \
+            ${PUBLISH_LIVE_BUNDLE:+--publish-live-bundle} \
             --source-repo "$SOURCE_REPO" \
             --source-ref "$SOURCE_REF" \
             --source-module ":$SOURCE_MODULE"

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleDaemonCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleDaemonCommand.kt
@@ -74,12 +74,13 @@ class BundleDaemonCommand(args: List<String>) : Command(args) {
     // still has a class-backed preview must carry it, so gate on whether any preview id is NOT
     // covered by an intermediate representation rather than merely "has some IR".
     val irPreviewIds = manifest.intermediateRepresentations.mapTo(mutableSetOf()) { it.previewId }
-    expandAppJarAndManifest(
+    extractBundleClassesAndManifest(
       zipBytes,
       classesDir,
       previewsJson,
       file,
       requireAppJar = manifest.previewIds.any { it !in irPreviewIds },
+      fileSystem = fileSystem,
     )
     // Consumer classpath for the daemon's `userClassDirs` holder (dirs-before-jars ordered, see
     // UserClassLoaderHolder) — the extracted app classes plus the bundle's third-party deps. NOT
@@ -244,19 +245,19 @@ class BundleDaemonCommand(args: List<String>) : Command(args) {
   )
 
   private fun desktopDaemonLaunch(): DaemonLaunch {
-    val daemonJars = locateSidecarJars("lib-daemon-desktop")
+    val daemonJars = locateBundleSidecarJars("lib-daemon-desktop")
     if (daemonJars.isEmpty()) {
       System.err.println(
-        "bundle daemon: no daemon jars found. Looked in `${sidecarSearchDescription("lib-daemon-desktop")}`; " +
+        "bundle daemon: no daemon jars found. Looked in `${bundleSidecarSearchDescription("lib-daemon-desktop")}`; " +
           "either build the CLI via `./gradlew :cli:installDist` or set " +
           "`-Dcomposeai.cli.libDaemonDesktopDir=<install-root/lib-daemon-desktop>`."
       )
       exitProcess(1)
     }
-    val rendererJars = locateSidecarJars("lib-renderer")
+    val rendererJars = locateBundleSidecarJars("lib-renderer")
     if (rendererJars.isEmpty()) {
       System.err.println(
-        "bundle daemon: no renderer jars found. Looked in `${sidecarSearchDescription("lib-renderer")}`; " +
+        "bundle daemon: no renderer jars found. Looked in `${bundleSidecarSearchDescription("lib-renderer")}`; " +
           "either build the CLI via `./gradlew :cli:installDist` or set " +
           "`-Dcomposeai.cli.libRendererDir=<install-root/lib-renderer>`."
       )
@@ -291,14 +292,14 @@ class BundleDaemonCommand(args: List<String>) : Command(args) {
    * coverage lives in the SDK-gated `AndroidBundleDaemonRenderFunctionalTest`.
    */
   private fun androidDaemonLaunch(): DaemonLaunch {
-    val daemonJars = locateSidecarJars("lib-daemon-android")
+    val daemonJars = locateBundleSidecarJars("lib-daemon-android")
     if (daemonJars.isEmpty()) {
       System.err.println(
         "bundle daemon: backend=android needs the Android daemon sidecar (`lib-daemon-android/`), " +
           "which ships separately as `compose-preview-android-daemon-<version>.zip` (it's too large " +
           "to bundle in the CLI tarball). Download + unpack it and point at it via " +
           "`-Dcomposeai.cli.libDaemonAndroidDir=<dir>/lib-daemon-android`. Looked in " +
-          "`${sidecarSearchDescription("lib-daemon-android")}`."
+          "`${bundleSidecarSearchDescription("lib-daemon-android")}`."
       )
       exitProcess(1)
     }
@@ -366,16 +367,11 @@ class BundleDaemonCommand(args: List<String>) : Command(args) {
   }
 
   /**
-   * Extract `classes/app.jar` into [classesDir] and `previews.json` into [previewsJson]. Throws if
-   * either is missing — both are required for the daemon to come up against a usable preview index.
-   * Embedded `libs/` jars are extracted separately via [BundleReader.extractEmbeddedLibs].
-   */
-  /**
    * Extract the v5 IR artefacts from [zipBytes]: every `ir/<leaf>` entry into [irDir] (flattened to
    * its basename, since `BundleIr.path` is `ir/<previewId>.<ext>` and the daemon resolves by leaf),
    * plus `bundle.json` into [manifestFile] so the daemon can read `intermediateRepresentations`.
    * Each `ir/` destination is verified to live inside [irDir] — defeats Zip Slip on a hostile
-   * bundle, same guard as [extractEmbeddedLibs] / [expandJarBytesSafely].
+   * bundle, same guard as [extractEmbeddedLibs] / [expandBundleJarBytesSafely].
    */
   private fun extractIrArtifacts(
     zipBytes: ByteArray,
@@ -488,131 +484,9 @@ class BundleDaemonCommand(args: List<String>) : Command(args) {
     return root
   }
 
-  private fun expandAppJarAndManifest(
-    zipBytes: ByteArray,
-    classesDir: File,
-    previewsJson: File,
-    bundleFile: File,
-    requireAppJar: Boolean,
-  ) {
-    var sawAppJar = false
-    var sawPreviewsJson = false
-    ZipInputStream(ByteArrayInputStream(zipBytes)).use { zin ->
-      while (true) {
-        val entry = zin.nextEntry ?: break
-        when (entry.name) {
-          "previews.json" -> {
-            fileSystem.write(previewsJson.path.toPath()) { write(zin.readBytes()) }
-            sawPreviewsJson = true
-          }
-          "classes/app.jar" -> {
-            val appJarBytes = zin.readBytes()
-            expandJarBytesSafely(appJarBytes, classesDir)
-            sawAppJar = true
-          }
-        }
-        zin.closeEntry()
-      }
-    }
-    require(sawAppJar || !requireAppJar) {
-      "bundle daemon: classes/app.jar missing in ${bundleFile.path} — not a packed bundle"
-    }
-    require(sawPreviewsJson) {
-      "bundle daemon: previews.json missing in ${bundleFile.path} — not a packed bundle"
-    }
-  }
-
-  /**
-   * Unpack the bundled app jar, rejecting Zip Slip. Shared shape with `BundleRenderer`'s
-   * `expandJarBytes` — duplicated here to avoid widening that class's surface for a single caller;
-   * the helper is small enough that the duplication is cheaper than a refactor.
-   */
-  private fun expandJarBytesSafely(appJarBytes: ByteArray, targetDir: File) {
-    val targetPath = targetDir.canonicalFile.toPath()
-    ZipInputStream(ByteArrayInputStream(appJarBytes)).use { zin ->
-      while (true) {
-        val entry = zin.nextEntry ?: break
-        // Resolve + normalize the entry against the target and verify containment via
-        // Path.startsWith — the form CodeQL's java/zipslip recognizes as sanitization (the prior
-        // canonicalFile + String.startsWith guard was equally safe but flagged as a false
-        // positive).
-        val resolved = targetPath.resolve(entry.name).normalize()
-        if (!resolved.startsWith(targetPath)) {
-          throw SecurityException(
-            "bundle daemon: app jar entry escapes target dir: ${entry.name} → $resolved"
-          )
-        }
-        val candidate = resolved.toFile()
-        if (entry.isDirectory) {
-          candidate.mkdirs()
-        } else {
-          candidate.parentFile?.mkdirs()
-          fileSystem.write(candidate.path.toPath()) { writeAll(zin.source()) }
-        }
-        zin.closeEntry()
-      }
-    }
-  }
-
   private fun createTempWorkDir(): File {
     val base = System.getProperty("java.io.tmpdir") ?: "/tmp"
     return File(base, "compose-preview-bundle-daemon-${System.nanoTime()}").also { it.mkdirs() }
-  }
-
-  /**
-   * Locate a sidecar jar dir inside the CLI install. In order: explicit sysprop override
-   * (`composeai.cli.libDaemonDesktopDir` / `composeai.cli.libRendererDir`), `$APP_HOME/<name>`,
-   * `<jar-parent>/../<name>` (IDE / `JavaExec` runs).
-   */
-  private fun locateSidecarJars(sidecarName: String): List<File> {
-    val sysprop =
-      when (sidecarName) {
-        "lib-daemon-desktop" -> "composeai.cli.libDaemonDesktopDir"
-        "lib-daemon-android" -> "composeai.cli.libDaemonAndroidDir"
-        "lib-renderer" -> "composeai.cli.libRendererDir"
-        else -> "composeai.cli.${sidecarName.replace('-', '.')}Dir"
-      }
-    val override = System.getProperty(sysprop)
-    val appHome = System.getProperty("composeai.cli.appHome") ?: System.getenv("APP_HOME")
-    val candidates =
-      listOfNotNull(
-          override?.let { File(it) },
-          appHome?.let { File(it, sidecarName) },
-          inferSidecarFromClasspath(sidecarName),
-        )
-        .distinct()
-    val firstExistingDir = candidates.firstOrNull { it.isDirectory } ?: return emptyList()
-    return firstExistingDir
-      .listFiles { f -> f.isFile && f.name.endsWith(".jar") }
-      ?.sortedBy { it.name }
-      .orEmpty()
-  }
-
-  private fun sidecarSearchDescription(sidecarName: String): String {
-    val sysprop =
-      when (sidecarName) {
-        "lib-daemon-desktop" -> "composeai.cli.libDaemonDesktopDir"
-        "lib-daemon-android" -> "composeai.cli.libDaemonAndroidDir"
-        "lib-renderer" -> "composeai.cli.libRendererDir"
-        else -> "composeai.cli.${sidecarName.replace('-', '.')}Dir"
-      }
-    val override = System.getProperty(sysprop)
-    val appHome = System.getProperty("composeai.cli.appHome") ?: System.getenv("APP_HOME")
-    return listOfNotNull(
-        override?.let { "-D$sysprop=$it" },
-        appHome?.let { "$it/$sidecarName" },
-        "<classpath-parent>/../$sidecarName",
-      )
-      .joinToString(" or ")
-  }
-
-  private fun inferSidecarFromClasspath(sidecarName: String): File? {
-    val cp = System.getProperty("java.class.path") ?: return null
-    val firstEntry = cp.split(File.pathSeparator).firstOrNull { it.endsWith(".jar") } ?: return null
-    val libDir = File(firstEntry).parentFile ?: return null
-    val installRoot = libDir.parentFile ?: return null
-    val candidate = File(installRoot, sidecarName)
-    return candidate.takeIf { it.isDirectory }
   }
 
   private fun locateJava(): String {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleDaemonSupport.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleDaemonSupport.kt
@@ -1,0 +1,145 @@
+package ee.schimke.composeai.cli
+
+import ee.schimke.composeai.io.SystemFileSystem
+import java.io.ByteArrayInputStream
+import java.io.File
+import java.util.zip.ZipInputStream
+import okio.FileSystem
+import okio.Path.Companion.toPath
+import okio.source
+
+/**
+ * Bundle → daemon-launch plumbing shared by every consumer that spawns a preview daemon straight
+ * from a packed bundle with no Gradle build in between: [BundleDaemonCommand] (`bundle daemon`,
+ * stdio-driven subprocess for the VS Code bundle viewer) and
+ * [ee.schimke.composeai.cli.serve.ServeBundleDaemon] (`serve --catalogs --allow-render-trusted`'s
+ * in-process `daemon-launch.json` synthesis). Kept as plain top-level functions — the two callers
+ * extract/launch differently enough (inherited stdio vs. a written descriptor file) that a shared
+ * class would just be a bag of parameters.
+ */
+
+/**
+ * Extract `classes/app.jar` → [classesDir] and `previews.json` → [previewsJson] from a bundle's
+ * [zipBytes]. Throws if `previews.json` is missing; `classes/app.jar` is required only when
+ * [requireAppJar] is true (false for a v5+ bundle whose previews are all IR-only — a fully
+ * IR-backed bundle legitimately carries no consumer classes).
+ */
+internal fun extractBundleClassesAndManifest(
+  zipBytes: ByteArray,
+  classesDir: File,
+  previewsJson: File,
+  bundleFile: File,
+  requireAppJar: Boolean,
+  fileSystem: FileSystem = SystemFileSystem,
+) {
+  var sawAppJar = false
+  var sawPreviewsJson = false
+  ZipInputStream(ByteArrayInputStream(zipBytes)).use { zin ->
+    while (true) {
+      val entry = zin.nextEntry ?: break
+      when (entry.name) {
+        "previews.json" -> {
+          fileSystem.write(previewsJson.path.toPath()) { write(zin.readBytes()) }
+          sawPreviewsJson = true
+        }
+        "classes/app.jar" -> {
+          val appJarBytes = zin.readBytes()
+          expandBundleJarBytesSafely(appJarBytes, classesDir, fileSystem)
+          sawAppJar = true
+        }
+      }
+      zin.closeEntry()
+    }
+  }
+  require(sawAppJar || !requireAppJar) {
+    "classes/app.jar missing in ${bundleFile.path} — not a packed bundle"
+  }
+  require(sawPreviewsJson) { "previews.json missing in ${bundleFile.path} — not a packed bundle" }
+}
+
+/**
+ * Unpack an app jar's bytes into [targetDir], rejecting Zip Slip. Shares its containment-check
+ * shape with `BundleCommand`'s `safeExtractZip` (a bundle's own zip) — duplicated rather than
+ * reused since this one unpacks an in-memory *jar's* bytes, a different call shape.
+ */
+internal fun expandBundleJarBytesSafely(
+  appJarBytes: ByteArray,
+  targetDir: File,
+  fileSystem: FileSystem = SystemFileSystem,
+) {
+  val targetPath = targetDir.canonicalFile.toPath()
+  ZipInputStream(ByteArrayInputStream(appJarBytes)).use { zin ->
+    while (true) {
+      val entry = zin.nextEntry ?: break
+      // Resolve + normalize the entry against the target and verify containment via
+      // Path.startsWith — the form CodeQL's java/zipslip recognizes as sanitization.
+      val resolved = targetPath.resolve(entry.name).normalize()
+      if (!resolved.startsWith(targetPath)) {
+        throw SecurityException(
+          "bundle: app jar entry escapes target dir: ${entry.name} → $resolved"
+        )
+      }
+      val candidate = resolved.toFile()
+      if (entry.isDirectory) {
+        candidate.mkdirs()
+      } else {
+        candidate.parentFile?.mkdirs()
+        fileSystem.write(candidate.path.toPath()) { writeAll(zin.source()) }
+      }
+      zin.closeEntry()
+    }
+  }
+}
+
+/**
+ * Locate a sidecar jar dir (`lib-daemon-desktop` / `lib-renderer` / `lib-daemon-android`) inside
+ * the CLI install. In order: explicit sysprop override (`composeai.cli.lib<Name>Dir`),
+ * `$APP_HOME/<name>`, `<jar-parent>/../<name>` (IDE / `JavaExec` runs).
+ */
+internal fun locateBundleSidecarJars(sidecarName: String): List<File> {
+  val sysprop = bundleSidecarSysprop(sidecarName)
+  val override = System.getProperty(sysprop)
+  val appHome = System.getProperty("composeai.cli.appHome") ?: System.getenv("APP_HOME")
+  val candidates =
+    listOfNotNull(
+        override?.let { File(it) },
+        appHome?.let { File(it, sidecarName) },
+        inferBundleSidecarFromClasspath(sidecarName),
+      )
+      .distinct()
+  val firstExistingDir = candidates.firstOrNull { it.isDirectory } ?: return emptyList()
+  return firstExistingDir
+    .listFiles { f -> f.isFile && f.name.endsWith(".jar") }
+    ?.sortedBy { it.name }
+    .orEmpty()
+}
+
+/** Human-readable description of where [locateBundleSidecarJars] looked, for error messages. */
+internal fun bundleSidecarSearchDescription(sidecarName: String): String {
+  val sysprop = bundleSidecarSysprop(sidecarName)
+  val override = System.getProperty(sysprop)
+  val appHome = System.getProperty("composeai.cli.appHome") ?: System.getenv("APP_HOME")
+  return listOfNotNull(
+      override?.let { "-D$sysprop=$it" },
+      appHome?.let { "$it/$sidecarName" },
+      "<classpath-parent>/../$sidecarName",
+    )
+    .joinToString(" or ")
+}
+
+private fun bundleSidecarSysprop(sidecarName: String): String =
+  when (sidecarName) {
+    "lib-daemon-desktop" -> "composeai.cli.libDaemonDesktopDir"
+    "lib-daemon-android" -> "composeai.cli.libDaemonAndroidDir"
+    "lib-renderer" -> "composeai.cli.libRendererDir"
+    else -> "composeai.cli.${sidecarName.replace('-', '.')}Dir"
+  }
+
+private fun inferBundleSidecarFromClasspath(sidecarName: String): File? {
+  val cp = System.getProperty("java.class.path") ?: return null
+  val firstEntry = cp.split(File.pathSeparator).firstOrNull { it.endsWith(".jar") } ?: return null
+  val libDir = File(firstEntry).parentFile ?: return null
+  val installRoot = libDir.parentFile ?: return null
+  val candidate = File(installRoot, sidecarName)
+  return candidate.takeIf { it.isDirectory }
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -4,6 +4,7 @@ import ee.schimke.composeai.cli.serve.GitWorktrees
 import ee.schimke.composeai.cli.serve.GradleRevisionBuilder
 import ee.schimke.composeai.cli.serve.RenderOutcome
 import ee.schimke.composeai.cli.serve.ServeBundle
+import ee.schimke.composeai.cli.serve.ServeBundleDaemon
 import ee.schimke.composeai.cli.serve.ServeBundleHost
 import ee.schimke.composeai.cli.serve.ServeBundleStore
 import ee.schimke.composeai.cli.serve.ServeCatalogStore
@@ -615,6 +616,9 @@ class ServeCommand(args: List<String>) : Command(args) {
             "serve: catalog $system carries an in-browser Wasm app (/wasm/$system/)"
           )
         },
+        buildTrustedBundle = { system, bundleFile ->
+          buildTrustedCatalogBundle(system, bundleFile, registry, openHost)
+        },
         buildTrustedSource = { system, source ->
           buildTrustedCatalogSource(system, source, registry, worktrees, openHost)
         },
@@ -635,6 +639,35 @@ class ServeCommand(args: List<String>) : Command(args) {
       }
     }
     return wasm
+  }
+
+  /**
+   * Build a `Trusted` catalog's carried `liveBundle` into a daemon-backed, re-renderable session —
+   * the executable-bundle counterpart of [buildTrustedCatalogSource], and the store's preferred
+   * path when a catalog declares one: [ServeBundleDaemon.materialize] extracts the fetched bundle,
+   * resolves its classpath, and synthesises a `daemon-launch.json` directly — no Gradle build, no
+   * worktree, no repo clone. The store only calls this for an already-`Trusted` catalog whose
+   * bundle fetched cleanly; here we add the remaining fail-closed gate: `--allow-render-trusted`
+   * must be set, same as the source path. Returns true once a daemon session is registered under
+   * [system] (the store then skips both the Gradle source path and the static baked-PNG host);
+   * false ⇒ caller falls back to `buildTrustedSource`, then the static host.
+   */
+  private fun buildTrustedCatalogBundle(
+    system: String,
+    bundleFile: File,
+    registry: ServeSessionRegistry,
+    openHost: (ServeSessionState) -> ServeHost?,
+  ): Boolean {
+    if (!allowRenderTrusted) return false
+    val destDir =
+      java.nio.file.Files.createTempDirectory("serve-catalog-bundle-$system").toFile().also {
+        it.deleteOnExit()
+      }
+    val state = ServeBundleDaemon.materialize(bundleFile, destDir, system) ?: return false
+    val host = openHost(state) ?: return false
+    registry.register(system, state, host = host)
+    System.err.println("serve: catalog $system → LIVE from bundle (no build) (?session=$system)")
+    return true
   }
 
   /**

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt
@@ -1,0 +1,204 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.cli.BundleReader
+import ee.schimke.composeai.cli.CoordinateResolver
+import ee.schimke.composeai.cli.PreviewManifest
+import ee.schimke.composeai.cli.bundleSidecarSearchDescription
+import ee.schimke.composeai.cli.extractBundleClassesAndManifest
+import ee.schimke.composeai.cli.locateBundleSidecarJars
+import ee.schimke.composeai.io.SystemFileSystem
+import ee.schimke.composeai.mcp.DaemonLaunchDescriptor
+import java.io.File
+import kotlinx.serialization.json.Json
+import okio.FileSystem
+import okio.Path.Companion.toPath
+
+/**
+ * Materialises a daemon-backed [ServeSessionState] straight from a **packed preview bundle** — no
+ * Gradle build, no worktree, no repo clone. This is the engine behind serving a `--catalogs`
+ * system's `liveBundle` ([ServeCatalogStore]): extract the bundle's `classes/app.jar` +
+ * `previews.json` (+ any embedded `libs/`), resolve its `maven` classpath entries via
+ * [CoordinateResolver], locate the CLI install's `lib-daemon-desktop`/`lib-renderer` sidecar jars
+ * (same lookup `bundle daemon` uses), and write a `daemon-launch.json` in the exact shape
+ * `SubprocessRenderSessions.open` reads. Writing it as a **file** (rather than constructing the
+ * descriptor purely in-memory, the way
+ * [ee.schimke.composeai.render.session.subprocess.SubprocessRenderSessions.openBundleDaemon] does)
+ * is what lets this session ride the existing `ServeSessionState → openHost → ServeRenderHost.open
+ * → registry.register` path unmodified — [ServeSessionRegistry] resumes a suspended session by
+ * re-opening the same descriptor path, so suspend/resume works for free.
+ *
+ * Desktop-only for now — mirrors `bundle daemon`'s desktop launch (`DaemonMain` +
+ * `lib-daemon-desktop` + `lib-renderer`). An `android`-backend bundle would need the Robolectric
+ * sidecar + `ANDROID_HOME` wiring `bundle daemon` also does for that backend; out of scope here —
+ * [materialize] returns `null` (logging why) so the caller falls back to the catalog's baked PNGs
+ * or its Gradle `source` build.
+ */
+internal object ServeBundleDaemon {
+
+  /**
+   * Extract [bundleFile] into [destDir] and synthesise a working [ServeSessionState] for it, or
+   * `null` (logging a clear reason via [onLog]) on any failure — a bad/foreign bundle, a
+   * non-desktop backend, missing sidecar jars, or an empty preview manifest. [offline] forces
+   * classpath resolution to skip the network (mirrors `-Dcomposeai.bundle.offline`); default
+   * `false` still honours that sysprop / `COMPOSE_PREVIEW_OFFLINE` via [CoordinateResolver]'s own
+   * default.
+   */
+  fun materialize(
+    bundleFile: File,
+    destDir: File,
+    system: String,
+    offline: Boolean = false,
+    fileSystem: FileSystem = SystemFileSystem,
+    onLog: (String) -> Unit = { System.err.println("[serve bundle] $it") },
+  ): ServeSessionState? {
+    destDir.mkdirs()
+
+    val manifest =
+      try {
+        BundleReader.readMetadata(bundleFile).manifest
+      } catch (e: Exception) {
+        onLog("catalog $system: could not read bundle metadata (${e.message})")
+        return null
+      }
+    if (manifest.backend != "desktop") {
+      onLog(
+        "catalog $system: bundle backend '${manifest.backend}' is not 'desktop' — live daemon " +
+          "from bundle is desktop-only for now"
+      )
+      return null
+    }
+
+    val zipBytes =
+      try {
+        BundleReader.extractZipBytes(bundleFile, fileSystem)
+      } catch (e: Exception) {
+        onLog("catalog $system: could not read bundle zip (${e.message})")
+        return null
+      }
+
+    val classesDir = File(destDir, "classes").apply { mkdirs() }
+    val libsDir = File(destDir, "libs").apply { mkdirs() }
+    val previewsJson = File(destDir, "previews.json")
+    // A fully IR-backed bundle (schema v5+) legitimately carries no classes/app.jar — mirrors
+    // BundleDaemonCommand's gate. Serve's live path doesn't replay IR (that's the Android/tile
+    // story), but a mixed bundle with at least one class-backed preview must still carry its jar.
+    val irPreviewIds = manifest.intermediateRepresentations.mapTo(mutableSetOf()) { it.previewId }
+    val requireAppJar = manifest.previewIds.any { it !in irPreviewIds }
+    try {
+      extractBundleClassesAndManifest(
+        zipBytes,
+        classesDir,
+        previewsJson,
+        bundleFile,
+        requireAppJar,
+        fileSystem,
+      )
+    } catch (e: Exception) {
+      onLog("catalog $system: bundle extraction failed (${e.message})")
+      return null
+    }
+
+    val libJars = BundleReader.extractEmbeddedLibs(zipBytes, libsDir, fileSystem)
+    val mavenCoords = manifest.classpath.filterIsInstance<BundleReader.ClasspathEntry.Maven>()
+    val resolvedJars =
+      CoordinateResolver(
+          warn = { onLog("catalog $system: $it") },
+          networkEnabled = if (offline) false else CoordinateResolver.defaultNetworkEnabled(),
+        )
+        .resolveAll(mavenCoords)
+        .mapNotNull { it.file }
+    val userClassPath =
+      (listOf(classesDir) + libJars + resolvedJars).joinToString(File.pathSeparator) {
+        it.absolutePath
+      }
+
+    val daemonJars = locateBundleSidecarJars("lib-daemon-desktop")
+    if (daemonJars.isEmpty()) {
+      onLog(
+        "catalog $system: no daemon jars found (looked in " +
+          "${bundleSidecarSearchDescription("lib-daemon-desktop")}) — is this a " +
+          "`:cli:installDist` build?"
+      )
+      return null
+    }
+    val rendererJars = locateBundleSidecarJars("lib-renderer")
+    if (rendererJars.isEmpty()) {
+      onLog(
+        "catalog $system: no renderer jars found (looked in " +
+          "${bundleSidecarSearchDescription("lib-renderer")})"
+      )
+      return null
+    }
+    val daemonClasspath = (daemonJars + rendererJars).map { it.absolutePath }
+
+    val descriptor =
+      DaemonLaunchDescriptor(
+        schemaVersion = DAEMON_LAUNCH_SCHEMA_VERSION,
+        modulePath = ":catalog",
+        variant = "desktop",
+        enabled = true,
+        mainClass = DESKTOP_DAEMON_MAIN_CLASS,
+        javaLauncher = null,
+        classpath = daemonClasspath,
+        jvmArgs = listOf("--enable-native-access=ALL-UNNAMED"),
+        systemProperties =
+          mapOf(
+            "composeai.daemon.userClassDirs" to userClassPath,
+            "composeai.daemon.previewsJsonPath" to previewsJson.absolutePath,
+          ),
+        workingDirectory = destDir.absolutePath,
+        manifestPath = previewsJson.absolutePath,
+      )
+    val descriptorFile = File(destDir, "daemon-launch.json")
+    try {
+      fileSystem.write(descriptorFile.path.toPath()) {
+        writeUtf8(json.encodeToString(DaemonLaunchDescriptor.serializer(), descriptor))
+      }
+    } catch (e: Exception) {
+      onLog("catalog $system: could not write daemon-launch.json (${e.message})")
+      return null
+    }
+
+    val previews = readPreviews(previewsJson, fileSystem)
+    if (previews.isEmpty()) {
+      onLog("catalog $system: bundle previews.json carried no previews")
+      return null
+    }
+
+    return ServeSessionState(
+      descriptor = descriptorFile,
+      workspaceRoot = destDir,
+      workspaceName = destDir.name.ifBlank { system },
+      previews = previews,
+      label = system,
+    )
+  }
+
+  /** Read the bundle's extracted `previews.json` into the [ServePreview] shape serve expects. */
+  private fun readPreviews(previewsJson: File, fileSystem: FileSystem): List<ServePreview> {
+    val text =
+      try {
+        fileSystem.read(previewsJson.path.toPath()) { readUtf8() }
+      } catch (_: Exception) {
+        return emptyList()
+      }
+    val manifest =
+      runCatching { previewsManifestJson.decodeFromString(PreviewManifest.serializer(), text) }
+        .getOrNull() ?: return emptyList()
+    return manifest.previews.map {
+      ServePreview(id = it.id, label = it.functionName.ifBlank { it.id })
+    }
+  }
+
+  private val json = Json { encodeDefaults = true }
+  private val previewsManifestJson = Json {
+    ignoreUnknownKeys = true
+    isLenient = true
+  }
+
+  /** `ee.schimke.composeai.daemon.DaemonMain` — the desktop daemon entrypoint a bundle spawns. */
+  private const val DESKTOP_DAEMON_MAIN_CLASS = "ee.schimke.composeai.daemon.DaemonMain"
+
+  /** Descriptor schema version — mirrors `SubprocessRenderSessions.openBundleDaemon`. */
+  private const val DAEMON_LAUNCH_SCHEMA_VERSION = 2
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
@@ -43,6 +43,18 @@ class ServeCatalogStore(
    */
   private val registerWasm: (system: String, dir: File) -> Unit = { _, _ -> },
   /**
+   * Trusted server-side re-render from a carried **executable bundle** (opt-in,
+   * `--allow-render-trusted`). When a catalog is `Trusted` AND declares a `liveBundle` (`{path,
+   * file}`), the bundle is fetched and this is invoked to stand up a daemon-backed, re-renderable
+   * session built straight from it — no Gradle build, no worktree, no repo clone. Preferred over
+   * [buildTrustedSource] (tried first): returns true when it registered such a session (then both
+   * the Gradle source path and the static [ServeBundleHost] are skipped); false ⇒ fall back to
+   * [buildTrustedSource], then the static catalog. Default ⇒ never. The callback owns the
+   * `--allow-render-trusted` gate; this store only reaches it for an already-`Trusted` catalog, and
+   * only after the whole declared bundle file fetched cleanly (fail-closed, like [fetchWasmApp]).
+   */
+  private val buildTrustedBundle: (system: String, bundleFile: File) -> Boolean = { _, _ -> false },
+  /**
    * Trusted server-side re-render (opt-in, `--allow-render-trusted`). When a catalog is `Trusted`
    * AND declares a `source` (`{repo, ref, module}`), this is invoked to stand up a **daemon-backed,
    * re-renderable** session built from that source — so the viewer's controls re-render live at
@@ -136,10 +148,23 @@ class ServeCatalogStore(
         BundleVerifier.Verdict.Trusted(listOf(BundleVerifier.Basis.Branch(repo, branch)))
       else BundleVerifier.Verdict.Unverified("branch $repo@$branch is not trusted")
 
-    // Trusted server-side re-render (opt-in): only a Trusted catalog that declares a source is even
-    // offered to the builder — an Unverified catalog NEVER reaches it, so a compromised/spoofed
-    // catalog can't trigger a build. When the builder takes over it registers a daemon-backed
-    // (re-renderable) session under this id, so we skip the static host below.
+    // Trusted server-side re-render from a carried EXECUTABLE BUNDLE (opt-in,
+    // --allow-render-trusted) — tried FIRST, ahead of the Gradle `source` build below: no clone, no
+    // worktree, no per-request Gradle invocation. Only a Trusted catalog that declares `liveBundle`
+    // is even offered to the builder — an Unverified catalog NEVER reaches it — and only once the
+    // whole declared bundle file has fetched cleanly (fail-closed, like fetchWasmApp above).
+    val liveBundle = catalog.liveBundle
+    if (verdict is BundleVerifier.Verdict.Trusted && liveBundle != null) {
+      val bundleFile = fetchLiveBundle(liveBundle, base, dir, safe)
+      if (bundleFile != null && buildTrustedBundle(safe, bundleFile)) {
+        return Result.Ok(safe, count, "${BundleVerifier.summary(verdict)} (live bundle)")
+      }
+    }
+
+    // Trusted server-side re-render from SOURCE (opt-in): only a Trusted catalog that declares a
+    // source is even offered to the builder — an Unverified catalog NEVER reaches it, so a
+    // compromised/spoofed catalog can't trigger a build. When the builder takes over it registers
+    // a daemon-backed (re-renderable) session under this id, so we skip the static host below.
     val src = catalog.source
     if (
       verdict is BundleVerifier.Verdict.Trusted &&
@@ -206,6 +231,44 @@ class ServeCatalogStore(
   }
 
   /**
+   * Fetch a catalog's `liveBundle` (`{path, file}`) — the executable preview bundle
+   * (`<system>-bundle.png`) `design-artifacts.yml` carries alongside the baked PNGs — from
+   * `<base><path>/<file>` into `<dir>/$LIVE_BUNDLE_DIR/<file>`. Fail-closed like [fetchWasmApp]: an
+   * invalid/escaping file entry or a fetch miss aborts and returns null, so the caller falls back
+   * to the Gradle `source` build (or, failing that, the static host). The file list is a single
+   * entry from the trusted catalog itself, not client input.
+   */
+  private fun fetchLiveBundle(
+    liveBundle: LiveBundle,
+    base: String,
+    dir: File,
+    system: String,
+  ): File? {
+    val name = liveBundle.file.trim('/')
+    if (name.isEmpty() || ".." in name.split("/")) {
+      System.err.println("serve: $system liveBundle has an invalid file entry — skipping")
+      return null
+    }
+    val bundleDir = File(dir, LIVE_BUNDLE_DIR)
+    val bundleRoot = bundleDir.canonicalFile.toPath()
+    val target = File(bundleDir, name)
+    if (!target.canonicalFile.toPath().startsWith(bundleRoot)) {
+      System.err.println("serve: $system liveBundle escaping entry '$name' — skipping")
+      return null
+    }
+    val prefix = liveBundle.path.trim('/')
+    val url = if (prefix.isEmpty()) "$base$name" else "$base$prefix/$name"
+    val bytes = runCatching { fetch(url) }.getOrNull()
+    if (bytes == null) {
+      System.err.println("serve: $system liveBundle fetch failed ($url) — skipping")
+      return null
+    }
+    target.parentFile?.mkdirs()
+    target.writeBytes(bytes)
+    return target
+  }
+
+  /**
    * Fetch the catalog's baked `figma/<slug>.svg` exports (+ each hybrid SVG's external
    * `<slug>.figma-raster/<node>.png` crops) from [base] into `<dir>/figma/`, so the static host can
    * serve an editable vector per preview. Best-effort per slug (a missing SVG just means that
@@ -254,7 +317,16 @@ class ServeCatalogStore(
     val webRender: WebRender? = null,
     /** Optional buildable source for trusted server-side re-render (`--allow-render-trusted`). */
     val source: Source? = null,
+    /**
+     * Optional executable preview bundle carried alongside the baked PNGs (desktop-CMP systems only
+     * — see `scripts/design-artifacts/generate-design-catalog.mjs`), preferred over [source] for
+     * trusted server-side re-render: no Gradle build, no worktree.
+     */
+    val liveBundle: LiveBundle? = null,
   )
+
+  /** `catalog.json`'s `liveBundle`: the executable bundle at `<path><file>` on this branch. */
+  @Serializable private data class LiveBundle(val path: String = "", val file: String = "")
 
   /** `catalog.json`'s `source`: the repo/ref/module to build to re-render this catalog live. */
   @Serializable
@@ -285,6 +357,8 @@ class ServeCatalogStore(
     const val WEB_WASM_DIR = "web/wasm"
     const val WEB_RENDER_COMPOSE_WASM = "compose-wasm"
     private const val MAX_WASM_FILES = 64
+    /** Local subdir a catalog's `liveBundle` file is fetched into (`<dir>/bundle/<file>`). */
+    const val LIVE_BUNDLE_DIR = "bundle"
 
     /**
      * The single-path-segment preview id for a catalog image path. The serve routes (`/p/{name}`,

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemonTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemonTest.kt
@@ -1,0 +1,194 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.daemon.protocol.RenderTier
+import ee.schimke.composeai.mcp.DaemonLaunchDescriptor
+import ee.schimke.composeai.render.session.RenderSessionConfig
+import ee.schimke.composeai.render.session.subprocess.SubprocessRenderSessions
+import java.io.File
+import java.nio.file.Files
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * Exercises [ServeBundleDaemon.materialize] against a real **packed desktop bundle** — the same
+ * shape `serve --catalogs --allow-render-trusted` fetches for a catalog's `liveBundle`. Needs a
+ * bundle on disk (produced by `compose-preview bundle pack --module :samples:design-catalog-m3 -o
+ * <path>`, e.g. via `NonGradleContractTest`'s pattern) plus the CLI's own `:cli:installDist`
+ * sidecars (`lib-daemon-desktop` / `lib-renderer`) to resolve a real daemon classpath — neither is
+ * produced by a normal `:cli:test` run, so this self-skips (same convention as
+ * `NonGradleContractTest` in `:render-session-subprocess`) rather than failing when they're
+ * missing.
+ *
+ * Point `-Dcomposeai.test.bundlePath=<file>` at a pre-packed bundle (defaults to
+ * `/tmp/m3-bundle.png`, the path this feature's own verification pass packs to). The
+ * `lib-daemon-desktop`/`lib-renderer` sidecars are auto-discovered from this checkout's
+ * `cli/build/install/compose-preview/` when present (i.e. after `./gradlew :cli:installDist`);
+ * override via `-Dcomposeai.cli.appHome=<install-root>` to point elsewhere.
+ */
+class ServeBundleDaemonTest {
+
+  @Test
+  fun `materialize produces a valid descriptor plus previews from a packed desktop bundle`() {
+    val state = materializeOrSkip("descriptor-shape") ?: return
+
+    val descriptorFile = state.descriptor
+    assertTrue(descriptorFile.isFile, "daemon-launch.json should exist at ${descriptorFile.path}")
+    val parsed =
+      descriptorJson.decodeFromString(
+        DaemonLaunchDescriptor.serializer(),
+        descriptorFile.readText(),
+      )
+
+    assertEquals("ee.schimke.composeai.daemon.DaemonMain", parsed.mainClass)
+    assertEquals("desktop", parsed.variant)
+    assertEquals(":catalog", parsed.modulePath)
+    assertTrue(parsed.enabled)
+    assertTrue(parsed.classpath.isNotEmpty(), "daemon classpath should not be empty")
+    assertTrue(
+      parsed.classpath.all { File(it).isFile },
+      "every daemon classpath entry should exist on disk: ${parsed.classpath}",
+    )
+    assertEquals(listOf("--enable-native-access=ALL-UNNAMED"), parsed.jvmArgs)
+
+    val userClassDirs = parsed.systemProperties["composeai.daemon.userClassDirs"]
+    assertTrue(!userClassDirs.isNullOrBlank(), "userClassDirs sysprop should be set")
+    assertTrue(
+      userClassDirs.split(File.pathSeparator).all { File(it).exists() },
+      "every userClassDirs entry should exist on disk: $userClassDirs",
+    )
+    val previewsJsonPath = parsed.systemProperties["composeai.daemon.previewsJsonPath"]
+    assertTrue(!previewsJsonPath.isNullOrBlank())
+    assertTrue(File(previewsJsonPath).isFile)
+    assertEquals(previewsJsonPath, parsed.manifestPath)
+    assertEquals(state.workspaceRoot.absolutePath, parsed.workingDirectory)
+
+    assertTrue(state.previews.isNotEmpty(), "materialize should discover at least one preview")
+    assertEquals("compose-m3", state.label)
+  }
+
+  @Test
+  fun `materialized bundle renders one preview through a real daemon`() {
+    val state = materializeOrSkip("live-render") ?: return
+    val targetId = state.previews.first().id
+
+    val session =
+      try {
+        SubprocessRenderSessions.open(
+          RenderSessionConfig(
+            descriptorPath = state.descriptor,
+            workspaceRoot = state.workspaceRoot,
+            workspaceName = state.workspaceName,
+            logSink = { line -> System.err.println("[daemon] $line") },
+          )
+        )
+      } catch (e: Exception) {
+        System.err.println(
+          "[ServeBundleDaemonTest] skipping live render — daemon failed to open (${e.message}). " +
+            "Needs a display (run under xvfb-run + LIBGL_ALWAYS_SOFTWARE=1) and the CLI's " +
+            "installDist sidecars."
+        )
+        return
+      }
+
+    session.use {
+      val finished = AtomicReference<String?>(null)
+      val latch = CountDownLatch(1)
+      session
+        .onNotification { method, params ->
+          if (method == "renderFinished" && params != null) {
+            val id = params["id"]?.jsonPrimitive?.contentOrNull
+            if (id == targetId) {
+              finished.set(params["pngPath"]?.jsonPrimitive?.contentOrNull)
+              latch.countDown()
+            }
+          }
+        }
+        .use {
+          val ack = session.renderNow(previewIds = listOf(targetId), tier = RenderTier.FULL)
+          assertTrue(
+            ack.rejected.none { it.id == targetId },
+            "renderNow should queue $targetId, got rejected=${ack.rejected}",
+          )
+          assertTrue(
+            latch.await(90, TimeUnit.SECONDS),
+            "daemon should emit renderFinished for $targetId within 90s",
+          )
+        }
+
+      val pngPath = finished.get()
+      assertTrue(!pngPath.isNullOrBlank(), "renderFinished should carry a pngPath")
+      val png = File(pngPath)
+      assertTrue(png.isFile, "rendered PNG must exist on disk: $pngPath")
+      assertTrue(png.length() > 0L)
+    }
+  }
+
+  /**
+   * Locates the bundle + sidecars and calls [ServeBundleDaemon.materialize] into a fresh temp dir
+   * under [label], or logs why and returns `null` so the caller self-skips.
+   */
+  private fun materializeOrSkip(label: String): ServeSessionState? {
+    val bundlePath = System.getProperty(BUNDLE_PATH_PROPERTY) ?: DEFAULT_BUNDLE_PATH
+    val bundleFile = File(bundlePath)
+    if (!bundleFile.isFile) {
+      System.err.println(
+        "[ServeBundleDaemonTest] skipping ($label) — no bundle at $bundlePath. Pack one via " +
+          "`compose-preview bundle pack --module :samples:design-catalog-m3 -o $bundlePath`."
+      )
+      return null
+    }
+
+    ensureAppHomeConfigured()
+
+    val destDir = Files.createTempDirectory("serve-bundle-daemon-test-$label").toFile()
+    val state = ServeBundleDaemon.materialize(bundleFile, destDir, "compose-m3")
+    if (state == null) {
+      System.err.println(
+        "[ServeBundleDaemonTest] skipping ($label) — materialize returned null (see log above); " +
+          "likely missing lib-daemon-desktop/lib-renderer sidecars. Run `:cli:installDist` and/or " +
+          "pass -Dcomposeai.cli.appHome=<install-root>."
+      )
+      return null
+    }
+    return state
+  }
+
+  /**
+   * If no explicit `-Dcomposeai.cli.appHome` override is set, point it at this checkout's own
+   * `cli/build/install/compose-preview/` when that `:cli:installDist` output exists — lets the test
+   * run end to end in a normal dev/CI checkout without extra flags, while still respecting an
+   * explicit override.
+   */
+  private fun ensureAppHomeConfigured() {
+    if (System.getProperty(APP_HOME_PROPERTY) != null) return
+    val installDir = File(locateRepoRoot(), "cli/build/install/compose-preview")
+    if (installDir.isDirectory) {
+      System.setProperty(APP_HOME_PROPERTY, installDir.absolutePath)
+    }
+  }
+
+  /** Walk up from the test JVM's working dir to find the repo root (has `settings.gradle.kts`). */
+  private fun locateRepoRoot(): File {
+    var dir: File? = File(".").canonicalFile
+    while (dir != null) {
+      if (File(dir, "settings.gradle.kts").isFile) return dir
+      dir = dir.parentFile
+    }
+    error("Could not locate repo root above ${File(".").canonicalFile}")
+  }
+
+  private companion object {
+    const val BUNDLE_PATH_PROPERTY = "composeai.test.bundlePath"
+    const val APP_HOME_PROPERTY = "composeai.cli.appHome"
+    const val DEFAULT_BUNDLE_PATH = "/tmp/m3-bundle.png"
+
+    val descriptorJson = Json { ignoreUnknownKeys = true }
+  }
+}

--- a/deploy/image/docker-compose.yml
+++ b/deploy/image/docker-compose.yml
@@ -40,20 +40,17 @@ services:
       # Unused in public mode; required only when SERVE_PUBLIC=0.
       SERVE_TOKEN: "${SERVE_TOKEN:-}"
       SERVE_IDLE_EXIT: "0"
-      # Live (daemon-backed) preview tier — OFF by default (snapshot + in-browser Wasm only, which
-      # already makes the CMP screens interactive). To offer server-side live CMP-JVM streaming on
-      # this prebuilt box, set ALL of:
-      #   SERVE_ALLOW_RENDER_TRUSTED=1
-      #   SERVE_REVISIONS_ALLOW=main               # the trusted source-ref allowlist
-      #   SERVE_CATALOG_SOURCE_REPO=yschimke/compose-ai-tools   # cloned at startup to build from
-      #   SERVE_LIVE_SEATS=1                        # each seat is a JVM daemon; cap it on a 4 GB box
-      # The image serves a standalone /project, so the entrypoint CLONES the catalog's source repo
-      # and points serve at it (--catalog-source-root); only the CMP `compose-m3` catalog is
-      # desktop-buildable here (the Android catalogs stay baked-PNG, fail-closed). NOTE: the trusted
-      # build runs at startup, so the first boot after enabling — and after each image update —
-      # does a one-time cold Gradle build of the catalog (minutes) before serving. Needs a CLI
-      # release carrying --catalog-source-root (this image's CP_VERSION). Flip on via .env, then
-      # `docker compose up -d`. Leave unset to keep the fast snapshot+Wasm posture.
+      # Live (daemon-backed) preview tier — ON by default and build-free. For a Trusted catalog that
+      # carries an executable `liveBundle` (the desktop CMP `compose-m3`), serve fetches that bundle
+      # from the trusted branch and launches a render daemon straight from it — no checkout, no
+      # Gradle build. So a bare image pull "just works" with live CMP; the entrypoint defaults
+      # SERVE_ALLOW_RENDER_TRUSTED=1 + SERVE_LIVE_SEATS=1 (bound for the 4 GB box). Fail-closed: only
+      # Trusted catalogs execute; the Android wear/remote catalogs have no runnable bundle → baked
+      # PNG. Set SERVE_ALLOW_RENDER_TRUSTED=0 in .env to opt out (Wasm still carries CMP).
+      #
+      # SERVE_CATALOG_SOURCE_REPO is the OPTIONAL source-build fallback only (a catalog with a Gradle
+      # `source` but no bundle): setting it makes the entrypoint clone that repo and pay a one-time
+      # cold Gradle build at startup. Not needed for the published catalogs — leave it unset.
       SERVE_ALLOW_RENDER_TRUSTED: "${SERVE_ALLOW_RENDER_TRUSTED:-}"
       SERVE_REVISIONS_ALLOW: "${SERVE_REVISIONS_ALLOW:-}"
       SERVE_CATALOG_SOURCE_REPO: "${SERVE_CATALOG_SOURCE_REPO:-}"

--- a/deploy/image/entrypoint.sh
+++ b/deploy/image/entrypoint.sh
@@ -47,24 +47,23 @@ fi
 : "${SERVE_TRUST_STORE:=/trust/producers.json}"
 [[ "${SERVE_TRUST_STORE}" != "none" ]] && args+=(--trust-store "${SERVE_TRUST_STORE}")
 [[ -n "${SERVE_WASM_DIR:-}" ]] && args+=(--wasm-dir "${SERVE_WASM_DIR}")
-# Trusted server-side re-render (opt-in, OFF by default). Only enable on a box that
-# can BUILD the catalog source — this desktop image CANNOT build the Android
-# catalogs, so leave SERVE_ALLOW_RENDER_TRUSTED unset on the public preview server.
-# Needs SERVE_REVISIONS_ALLOW (the trusted ref allowlist) to build anything.
+# Trusted server-side re-render — ON by default, and cheap: for a Trusted catalog
+# that carries an executable `liveBundle` (the desktop CMP `compose-m3` does), serve
+# fetches that bundle from the trusted branch and launches a render daemon straight
+# from it — NO source checkout, NO Gradle build. So a bare image pull "just works"
+# with live CMP; set SERVE_ALLOW_RENDER_TRUSTED=0 to opt out (Wasm still carries CMP).
+# Safe/fail-closed: only Trusted catalogs execute, and a catalog with no runnable
+# bundle (the Android wear/remote) simply falls back to baked PNG.
+: "${SERVE_ALLOW_RENDER_TRUSTED:=1}"
 [[ -n "${SERVE_REVISIONS_ALLOW:-}" ]] && args+=(--revisions-allow "${SERVE_REVISIONS_ALLOW}")
-if [[ "${SERVE_ALLOW_RENDER_TRUSTED:-}" == "1" || "${SERVE_ALLOW_RENDER_TRUSTED:-}" == "true" ]]; then
+if [[ "${SERVE_ALLOW_RENDER_TRUSTED}" == "1" || "${SERVE_ALLOW_RENDER_TRUSTED}" == "true" ]]; then
   args+=(--allow-render-trusted)
-  # The prebuilt image serves a standalone /project, not a checkout of a catalog's
-  # source repo — so the trusted builder has nothing to worktree from by default.
-  # When SERVE_CATALOG_SOURCE_REPO is set, clone that repo here and point serve at it
-  # with --catalog-source-root, so a Trusted catalog whose source.repo matches can be
-  # built + live-rendered. Only the CMP `compose-m3` catalog is desktop-buildable on
-  # this Android-less image; the Android catalogs stay baked-PNG (fail-closed).
-  #
-  # COST: the trusted build runs at startup (and after each image update), so the
-  # first boot with this on does a one-time cold Gradle build of the catalog
-  # (minutes) before serving. Leave SERVE_CATALOG_SOURCE_REPO unset to keep the
-  # lightweight snapshot+Wasm posture (CMP stays interactive via the Wasm tier).
+  # Optional SOURCE-BUILD FALLBACK (not needed for the bundle path above). For a
+  # catalog that declares a Gradle `source` but no `liveBundle`, the prebuilt image
+  # has no checkout to worktree from; set SERVE_CATALOG_SOURCE_REPO to clone one and
+  # point serve at it with --catalog-source-root. This DOES pay a one-time cold Gradle
+  # build at startup — leave it unset (the default) unless you specifically need the
+  # source path; the bundle path covers the published catalogs with no build.
   if [[ -n "${SERVE_CATALOG_SOURCE_REPO:-}" ]]; then
     src_root="${SERVE_CATALOG_SOURCE_ROOT:-/catalog-src}"
     src_ref="${SERVE_CATALOG_SOURCE_REF:-main}"
@@ -79,11 +78,12 @@ if [[ "${SERVE_ALLOW_RENDER_TRUSTED:-}" == "1" || "${SERVE_ALLOW_RENDER_TRUSTED:
     args+=(--catalog-source-root "${src_root}")
   fi
 fi
-# Bound concurrent live (daemon-backed) stream seats. Only meaningful once the live tier is enabled
-# (SERVE_ALLOW_RENDER_TRUSTED) — each seat holds a JVM Compose daemon, so a small box (preview.coo.ee
-# is 4 GB / 2 vCPU) should cap it (e.g. SERVE_LIVE_SEATS=1) so an over-cap viewer is refused rather
-# than OOM-ing the box. Unset ⇒ unbounded (fine for a beefy box or the snapshot/Wasm-only default).
-[[ -n "${SERVE_LIVE_SEATS:-}" ]] && args+=(--live-seats "${SERVE_LIVE_SEATS}")
+# Bound concurrent live (daemon-backed) stream seats — each seat holds a JVM Compose daemon, so with
+# the live tier on by default we default the cap to 1 for the reference 4 GB / 2 vCPU box
+# (preview.coo.ee): an over-cap viewer is refused (WS 1013) rather than OOM-ing the box. Raise it on
+# a beefier box (SERVE_LIVE_SEATS=4), or set 0 for unbounded.
+: "${SERVE_LIVE_SEATS:=1}"
+[[ -n "${SERVE_LIVE_SEATS}" ]] && args+=(--live-seats "${SERVE_LIVE_SEATS}")
 if [[ "${SERVE_ACCEPT_BUNDLES:-}" == "1" || "${SERVE_ACCEPT_BUNDLES:-}" == "true" ]]; then
   args+=(--accept-bundles)
   [[ -n "${SERVE_ACCEPT_BUNDLES_FROM:-}" ]] &&

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -156,35 +156,34 @@ current).
 
 By default a catalog serves **baked PNGs** — the viewer's device/orientation/etc. controls can't
 re-render a static image (they're disabled, with the in-browser Wasm tier carrying theme/font-scale/
-locale for CMP). For **full-fidelity** server-side overrides, a catalog can declare a buildable
-`source: { repo, ref, module }` in its `catalog.json` (the design-artifacts pipeline emits it), and
-an operator can opt in with `--allow-render-trusted`: a catalog that verifies **`Trusted`** *and*
-declares a `source` is then served by a live, daemon-backed session built from that source, so every
-control re-renders for real.
+locale for CMP). For **full-fidelity** server-side overrides, a **`Trusted`** catalog can be served
+by a live, daemon-backed session (`--allow-render-trusted`), so every control re-renders for real.
+There are two ways to stand that daemon up, both fail-closed on the `Trusted` verdict (an
+`Unverified`/spoofed catalog never reaches either — no RCE lever):
 
-It is **off by default** and gated three ways, all fail-closed: the catalog must be `Trusted`
-(an `Unverified`/spoofed catalog never reaches the builder — no RCE lever), its `source.ref` must
-clear the `--revisions-allow` allowlist, and its `source.repo` must be the server's own repo.
+1. **From a carried executable bundle (`liveBundle`) — no build (preferred, and now the default).**
+   The design-artifacts pipeline publishes the executable preview bundle (minimized module classes +
+   `previews.json` + classpath manifest) onto the branch under `bundle/` and records a `liveBundle`
+   in `catalog.json`. `serve` fetches that bundle like it fetches the Wasm app, resolves its
+   classpath from the local Maven/Gradle caches (or Central), and launches the render daemon
+   **straight from it** — no repo checkout, no Gradle build, no per-request compile. This is what the
+   public server uses for `compose-m3`. Desktop-backend only for now (the daemon is the Skiko desktop
+   renderer); a catalog whose bundle isn't a desktop bundle falls through to (2) or baked PNGs.
 
-**Never enable it on a box that can't build the catalog source.** Building runs the source's Gradle
-(code execution). The **`compose-m3`** catalog is a Compose **Multiplatform (desktop)** module
-(`:samples:design-catalog-m3`), so it builds and live-renders with just the JVM/Skiko desktop daemon
-— **no Android toolchain** — which is exactly why the from-source public box (`deploy/vps`,
-`preview.coo.ee`) now turns this on for it (`SERVE_ALLOW_RENDER_TRUSTED=1` +
-`SERVE_REVISIONS_ALLOW=main` + a `SERVE_LIVE_SEATS` cap). The other published catalogs
-(`wear-m3`, `remote-m3`) are still **Android** modules; on the desktop-only box their trusted build
-isn't attempted and they fall back to baked PNG (fail-closed) — no error, just no live tier for them.
-The prebuilt released image (`deploy/image`) serves a standalone `sample-project`, not a checkout of
-the catalog's source repo, so the trusted builder has nothing to worktree from by default. It can
-still opt in: set `SERVE_ALLOW_RENDER_TRUSTED=1` + `SERVE_REVISIONS_ALLOW=main` +
-`SERVE_CATALOG_SOURCE_REPO=yschimke/compose-ai-tools` (+ a `SERVE_LIVE_SEATS` cap), and the entrypoint
-**clones that repo at startup** and points `serve` at it with **`--catalog-source-root`** — so the
-CMP `compose-m3` catalog live-renders while the Android catalogs stay baked-PNG (fail-closed). The
-trade-off: the trusted build runs at startup, so the first boot after enabling (and after each
-Watchtower image update) does a one-time cold Gradle build of the catalog (minutes) before serving,
-and it needs a CLI release carrying `--catalog-source-root`. Left off, the image keeps its fast
-snapshot + in-browser-Wasm posture (CMP stays interactive via the Wasm tier). Only enable it where
-that per-boot build + live render is affordable.
+2. **From source (`source: { repo, ref, module }`) — Gradle build fallback.** For a catalog that
+   declares a buildable `source` but no `liveBundle`. This runs the source's Gradle (code execution),
+   so it's gated additionally by the `--revisions-allow` ref allowlist and a `source.repo` ==
+   server-repo check, and the box must have a checkout to worktree from — on the prebuilt image, set
+   `SERVE_CATALOG_SOURCE_REPO` so the entrypoint clones one and passes `--catalog-source-root`, which
+   pays a **one-time cold Gradle build at startup**. Not needed for the published catalogs; the
+   bundle path (1) covers them with no build.
+
+Because path (1) is cheap and safe, both public profiles turn it **on by default**: `deploy/vps`
+(from source) and the prebuilt `deploy/image` (`preview.coo.ee`) both default
+`SERVE_ALLOW_RENDER_TRUSTED=1` + `SERVE_LIVE_SEATS=1` — a bare image pull "just works" with live CMP,
+no clone and no build. Set `SERVE_ALLOW_RENDER_TRUSTED=0` to opt out (the Wasm tier still carries
+CMP). The other published catalogs (`wear-m3`, `remote-m3`) are **Android** — no desktop-runnable
+bundle — so they fall back to baked PNG (fail-closed): no error, just no daemon tier for them.
 
 ### Bounding the live tier — `--live-seats` / `SERVE_LIVE_SEATS`
 

--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -32,7 +32,7 @@
  * `design-artifacts/<system>` branch.
  */
 import { cp, mkdir, readFile, readdir, writeFile } from "node:fs/promises";
-import { dirname, resolve, join, relative } from "node:path";
+import { basename, dirname, resolve, join, relative } from "node:path";
 import { parseArgs } from "node:util";
 
 import {
@@ -282,6 +282,13 @@ const { values } = parseArgs({
     // `FilledButtonFocused`, and this replaces the CMP module's ring-less render of
     // that function so the keyboard-focus variant shows the real ring.
     "extra-renders": { type: "string" },
+    // When set, copy the `--renders` executable bundle onto the branch under
+    // `out/bundle/<file>` and record `liveBundle: {path, file}` in catalog.json.
+    // `compose-preview serve --catalogs --allow-render-trusted` then fetches that
+    // bundle and launches a render daemon straight from it (no source build /
+    // checkout). Only for systems whose bundle is a DESKTOP bundle serve can run
+    // (compose-m3); the Android catalogs (wear/remote) stay baked-PNG.
+    "publish-live-bundle": { type: "boolean", default: false },
     // Optional buildable source for TRUSTED server-side re-render. When
     // --source-module is given, a `source: {repo, ref, module}` is written into
     // catalog.json so a `serve --allow-render-trusted` box (one with the toolchain
@@ -428,6 +435,23 @@ if (values["wasm-dist"]) {
   console.log(`[${spec.system}] bundled web/wasm/ (${files.length} files)`);
 }
 
+// Carry the executable bundle (the `--renders` portable bundle: minimized module
+// classes + previews.json + classpath manifest) onto the branch so a trusted
+// `serve --catalogs --allow-render-trusted` can fetch it and launch a render
+// daemon straight from it — no source checkout / Gradle build. Only when the
+// caller opts in (`--publish-live-bundle`), which the pipeline sets only for
+// systems whose bundle is a DESKTOP bundle serve can run (compose-m3); the
+// Android catalogs stay baked-PNG.
+let liveBundle = null;
+if (values["publish-live-bundle"]) {
+  const file = basename(rendersPath);
+  const dest = join(outPath, "bundle", file);
+  await mkdir(dirname(dest), { recursive: true });
+  await cp(rendersPath, dest);
+  liveBundle = { path: "bundle/", file };
+  console.log(`[${spec.system}] carried live bundle → bundle/${file}`);
+}
+
 {
   const catalogJsonPath = join(outPath, "catalog.json");
   const manifest = JSON.parse(await readFile(catalogJsonPath, "utf8"));
@@ -437,6 +461,7 @@ if (values["wasm-dist"]) {
     }
   }
   if (webRender) manifest.webRender = webRender;
+  if (liveBundle) manifest.liveBundle = liveBundle;
   // Buildable source for trusted server-side re-render (opt-in consumer side).
   if (values["source-module"]) {
     manifest.source = {


### PR DESCRIPTION
## Summary

The live daemon tier on the public preview box (`deploy/image`) previously required a Gradle build at startup — either clone the catalog repo and build from source. Two consequences:

1. A config-less deploy can't serve live CMP (nothing to build from).
2. A build-gated server can never serve a **newer or forked** bundle than the one it was built from.

The executable bundle already carries everything a daemon needs — minimized module classes, embedded dependency jars, and Maven coordinates for the rest. So `serve` can launch a render daemon **straight from the bundle**, no Gradle.

### What changed

- **`ServeBundleDaemon.materialize`** — extracts a bundle's classes/libs/previews, resolves Maven coordinates via `CoordinateResolver`, locates the sidecar daemon + renderer jars, synthesizes a `daemon-launch.json` descriptor, and returns a `ServeSessionState` that the existing `openHost`/registry path drives unchanged (so suspend/resume, `--live-seats`, etc. all work as-is).
- **`ServeCommand.buildTrustedCatalogBundle`** — wired ahead of the source-build path: a catalog's `liveBundle` is tried first, Gradle source second.
- **`ServeCatalogStore`** — gains `liveBundle` metadata + a fail-closed fetch of the carried bundle from the trusted branch.
- **`BundleDaemonSupport`** — factors the class/manifest/sidecar helpers out of `BundleDaemonCommand` so both callers share one implementation (~140 lines de-duplicated).
- **design-artifacts publish pipeline** — carries the executable bundle onto the `compose-m3` branch as `liveBundle` (previously produced in CI and discarded), so the fetch has something to launch. Desktop CMP catalog only; the Android catalogs stay baked-PNG.
- **`deploy/image`** — defaults the live tier **ON and build-free**: a bare image pull serves live CMP with no source checkout. The source-build clone is demoted to an optional fallback for a catalog that declares a Gradle `source` but carries no bundle.

### Safety

Fail-closed throughout: only `Trusted(Branch)` catalogs execute, and a catalog with no runnable bundle (the Android wear/remote systems, which can't run on the desktop-only public box) simply falls back to baked PNG.

## Test plan

- New `ServeBundleDaemonTest` renders `FilledButton_Dark` end-to-end through a **real spawned daemon subprocess** materialized from a bundle (no Gradle) — self-skipping when the sidecar jars aren't present.
- `./gradlew :cli:test` green; `:cli:compileKotlin :cli:compileTestKotlin` + `ktfmt` clean.

Text-only PR: this is serve-subsystem plumbing, deploy config, and docs — no rendered-surface change. The `liveBundle` it launches produces the same pixels the baked catalog already ships.

## Follow-up after merge

Dispatch `design-artifacts.yml` (ref `main`) so `design-artifacts/compose-m3` gets the `liveBundle` under `bundle/`; only then does the config-less live CMP tier have a bundle to fetch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WGVyWcXTvsYbmCtLEXU7tn)_