### PR TITLE
docs(design): reconcile FIGMA_ROUNDTRIP with the shipped compose/figma-svg feature

### DIFF
--- a/docs/design/DESIGN_CATALOGS.md
+++ b/docs/design/DESIGN_CATALOGS.md
@@ -66,10 +66,12 @@ layered `compose/figma-svg` export produced per preview; the catalog pipeline
 carries it in the bundle (`previews/<id>.figma.svg`) and copies it onto the
 branch, exactly as it does the schematic `wireframes/`.
 
-For the programmatic alternative to the manual pull — an agent pushing rendered
-variant matrices and editable layer reconstructions straight onto a Figma
-canvas via the Figma MCP server — see
-[FIGMA_ROUNDTRIP.md](FIGMA_ROUNDTRIP.md).
+For editable Figma layers the per-sticker `figma/<slug>.svg` is the
+`compose/figma-svg` export (see [`figma-svg-example/`](figma-svg-example/) and
+[`design-artifacts-figma-svg/`](design-artifacts-figma-svg/)); the design-parity
+`figma-plugin` imports it as native component sets. For the ad-hoc alternative —
+an agent pushing rendered *variant matrices* onto a Figma canvas via the Figma
+MCP server for live review — see [FIGMA_ROUNDTRIP.md](FIGMA_ROUNDTRIP.md).
 
 ## Rendering a catalog
 

--- a/docs/design/FIGMA_ROUNDTRIP.md
+++ b/docs/design/FIGMA_ROUNDTRIP.md
@@ -1,40 +1,93 @@
-# Figma roundtrip — pushing rendered variants and editable layers into Figma
+# Figma roundtrip — getting Compose renders into Figma
 
-The design catalogs already travel **code → importable bundle → designer pulls
-into Figma** ([DESIGN_CATALOGS.md](DESIGN_CATALOGS.md)). This doc covers the
-*programmatic* import leg: an agent session with the official Figma MCP server
-pushes rendered variants — and editable layer reconstructions — straight onto a
-Figma canvas, no manual branch pull. It documents the workflow proven end to
-end against `samples/design-catalog-m3` (`TextFieldSticker`); the live proof
-sits in the Figma file *Compose M3 Catalog — Roundtrip Proof*.
+There are **two** ways a Compose render reaches a Figma canvas, and they serve
+different needs. Start here to pick the right one.
 
-The render is authoritative throughout: pixels come from `compose-preview`,
-structure and text metrics come from its data products. Figma is a *view* of
-the code, never the source of truth (the same stance as the catalogs).
+| | **`compose/figma-svg`** (canonical) | **Agent MCP push** (this doc, below) |
+|---|---|---|
+| Output | Editable, layered vectors — one named layer per composable | Rendered variant PNGs (a matrix/sticker sheet) |
+| Editability | Full: fills, strokes, corner radius, text are live Figma layers | Raster; text/geometry not editable |
+| How it runs | Deterministic data product, in every `--with-semantics` render | Ad-hoc, in a live Figma-MCP agent session |
+| Import | design-parity **`figma-plugin`** (native component sets, refresh, override editor) | `upload_assets` + `use_figma` |
+| Best for | The real component library / screens as editable Figma | Quick multi-variant review sheets (theme × locale × font-scale) |
+
+**If you want editable Figma layers, use `compose/figma-svg` — not the MCP push
+below.** The MCP push predates the exporter; it stays documented because
+pushing a *variant matrix* onto a canvas for live design review is a genuinely
+different job that the exporter doesn't do.
+
+The render is authoritative for both: pixels and structure come from
+`compose-preview`; Figma is a *view* of the code, never the source of truth
+(the same stance as the [catalogs](DESIGN_CATALOGS.md)).
+
+## The canonical path: `compose/figma-svg`
+
+The `compose/figma-svg` data product (`FigmaLayeredSvg` in
+`:data-layoutinspector-core`, wired up by `ComposeFigmaSvgDataProduct`) emits a
+**layered, editable SVG** from the layout-inspector tree + semantics + theme:
+
+- **Every composable is a named `<g id="…">`**, nested as the composables nest —
+  so a Figma import lands each component/screen as its own named layer.
+- **Container tokens become real vector shapes** — `background` → filled `<rect>`
+  (or a `<path>` for non-uniform corners), `border` → stroke, resolved radius →
+  Figma's editable corner radius, `CircleShape` → a max-radius rounded rect.
+- **Text is editable `<text>`** carrying family/size/weight/colour.
+- **Named theme colours ride along** as `<title>` + `data-token` per layer, to
+  bind fills to variables from the sibling `figma-variables.json`.
+- **Hybrid capture** — components that can't be faithful vectors (`Image`,
+  `Icon`, `Canvas`, gradients, charts) are classified opaque and emitted as an
+  `<image>` placeholder over a background-free raster crop; everything else stays
+  editable vector. A **fidelity harness** scores render-vs-SVG to drive the
+  vector/raster split from evidence.
+
+See [`figma-svg-example/`](figma-svg-example/) for the exact document shape (a
+Material card, plus a hybrid screen) and the fidelity harness, and
+[`design-artifacts-figma-svg/`](design-artifacts-figma-svg/) for how it ships in
+the catalog bundles.
+
+**How to get the SVG:**
+
+- **Per preview, on disk:** any `--with-semantics` render drops
+  `previews/<id>.figma.svg` —
+  `compose-preview bundle pack --module <m> --with-semantics` carries it (look
+  for the `figma-svg: N / N preview(s) carried` line).
+- **Over HTTP:** `compose-preview serve` exposes `/render/<id>.svg`
+  (`ServeFigmaSvg`) — a placed node can be re-fetched to refresh it.
+- **In the catalog delivery branches:** `design-artifacts/<system>` ships
+  `figma/<slug>.svg` next to the raster `images/<slug>.png`, per sticker.
+
+**How to import it:** the design-parity **`figma-plugin`**
+([`packages/figma-plugin`](https://github.com/yschimke/design-parity/tree/main/packages/figma-plugin),
+docs: [`FIGMA_IMPORT.md`](https://github.com/yschimke/design-parity/blob/main/docs/design-artifacts/FIGMA_IMPORT.md)
+/ [`FIGMA_IMPORT_V2.md`](https://github.com/yschimke/design-parity/blob/main/docs/design-artifacts/FIGMA_IMPORT_V2.md))
+imports the catalog as **native Figma component sets**, imports a component as an
+**editable SVG**, **places + refreshes** live-rendered previews against the
+latest code, routes theme foundations to a **Themes/Tokens** page, lays out
+**per-screen pages** from the screen graph, and emits a `design-map.json`
+correspondence so design-parity can diff code vs canvas. A plain
+`figma.createNodeFromSvg()` also works for a one-off (the group names and
+editable radius/text survive), but the plugin is what makes it a maintained,
+refreshable library.
+
+## The agent MCP path: variant sheets on a canvas
+
+This is for a live **Figma-MCP agent session** that wants rendered variants
+arranged on a canvas for quick review — *not* editable layers.
 
 Evidence from the proven run:
 
 ![variant matrix contact sheet](figma-roundtrip-matrix-evidence.png)
 
-*The 8-cell `render-matrix` contact sheet (uiMode × fontScale × locale) — note
-the 1.5× cells catching real overflow: the field's value text wraps and clips
-in the fixed sticker bounds.*
+*An 8-cell `render-matrix` contact sheet (uiMode × fontScale × locale) — the
+1.5× cells catch real overflow: the field's value text wraps and clips in the
+fixed sticker bounds.*
 
 ![variant sheet arranged in Figma](figma-roundtrip-canvas-evidence.png)
 
 *The same cells pushed through `upload_assets` and arranged into a captioned
 auto-layout sheet on the Figma canvas.*
 
-![editable reconstruction beside ground truth](figma-roundtrip-recon-evidence.png)
-
-*Leg 3: left is the rendered PNG, right is native Figma layers (frames,
-rectangles, text) built from `layout.json` bounds + `semantics.json`
-typography/colors — same geometry, same tokens, fully editable.*
-
-## Leg 1 — render the variant matrix
-
-One command produces every variant a designer wants on canvas plus per-cell
-files for the importer:
+### 1 — render the variant matrix
 
 ```sh
 compose-preview render-matrix \
@@ -45,82 +98,52 @@ compose-preview render-matrix \
 ```
 
 - `--cells-dir` writes one PNG per cell (`en--light--1.0x.png`, …) and echoes
-  each path as `pngPath` in the JSON summary — these are the files the import
-  step uploads. The contact sheet is the human/PR-comment artifact. The
-  directory is cleared of stale `.png` files first, so a re-run with narrowed
-  axes (or a failed cell) never leaves an earlier variant behind for a globbing
-  importer to pick up.
-- Bounded at 24 cells; axes follow `render_matrix` (MCP) semantics exactly.
+  each path as `pngPath` in the JSON summary — the files the import step uploads.
+  The directory is cleared of stale `.png` files first, so a re-run with narrowed
+  axes never leaves an earlier variant behind. `--contact-sheet` is the
+  human/PR-comment artifact. Bounded at 24 cells; axes follow the `render_matrix`
+  MCP tool exactly.
 
-For the editable-layer leg, also extract the data products:
-
-```sh
-compose-preview bundle pack --module samples:design-catalog-m3 \
-  --id <preview-id> --with-semantics -o /tmp/sticker.png
-compose-preview bundle extract /tmp/sticker.png -o /tmp/sticker-bundle
-# → previews/<id>.layout.json  (layout-inspector tree: exact px bounds per node)
-# → previews/<id>.semantics.json (text, typography in sp, colors, tokens)
-```
-
-## Leg 2 — push PNG variants onto the canvas
-
-With the Figma MCP server connected (agent session):
+### 2 — push the PNGs onto the canvas
 
 1. `create_new_file` (or target an existing file key).
-2. `upload_assets` with `count = <cells>` → POST each cell PNG
-   (multipart, `file=` keeps the filename as the layer name) → each response
-   returns `placedOnNodeId`.
+2. `upload_assets` with `count = <cells>` → POST each cell PNG (multipart,
+   `file=` keeps the filename as the layer name) → each response returns
+   `placedOnNodeId`.
 3. One or two `use_figma` scripts arrange the placed frames into a titled
-   auto-layout grid with per-cell captions (uiMode row × fontScale/locale
-   columns worked well) and set frame names from the cell labels.
-4. `get_screenshot` on the container to verify the sheet visually.
+   auto-layout grid with per-cell captions and set frame names from the labels.
+4. `get_screenshot` on the container to verify.
 
 Notes from the proven run:
 
 - The upload URLs live on `mcp.figma.com`; the sandbox's network allowlist must
-  include it or every POST fails at CONNECT with a 403 (see the environment's
-  network policy — this is separate from enabling the Figma MCP connector).
+  include it or every POST fails at CONNECT with a 403 (separate from enabling
+  the Figma MCP connector).
 - `use_figma` can fall back to `figma.createImage(bytes)` with base64-embedded
-  PNGs (≈5 KB per sticker cell) when raw HTTPS egress is blocked entirely.
+  PNGs (≈5 KB per cell) when raw HTTPS egress is blocked entirely.
 
-## Leg 3 — editable Figma layers from the data products
+### Editable layers by hand (fallback only)
 
-`layout.json` + `semantics.json` carry enough to rebuild a sticker as **native
-Figma nodes** (frames, rectangles, text) rather than a flat image:
+Before `compose/figma-svg` existed, this path also reconstructed editable Figma
+nodes by hand in `use_figma` from `previews/<id>.layout.json` (bounds) +
+`previews/<id>.semantics.json` (text, typography, colours):
 
-| Figma property | Source |
-| --- | --- |
-| Node bounds (x/y/w/h, px) | `layout.json` per-node `bounds` (already in render px) |
-| Text content | `semantics.json` `layoutText` / `editableText` / `label` |
-| Font size / line height / letter spacing | `semantics.json` `typography` (sp) × the preview `density` (px = sp × density; density is in `previews.json` params, 2.625 for the default device) |
-| Text color | `semantics.json` `textColor.foreground` |
-| Container / background fills | `semantics.json` `tokens` where present; otherwise sample the authoritative PNG at a point inside the node's bounds |
-| Font family | Compose `sans-serif` → Roboto (available in Figma); keep the substitution explicit in the layer description |
+![editable reconstruction beside ground truth](figma-roundtrip-recon-evidence.png)
 
-Build the reconstruction in one `use_figma` script: a fixed-size frame at the
-render's px size, children placed at absolute `layout.json` bounds, text nodes
-with the density-scaled typography. Place it beside a frame filled with the
-uploaded render (`fills = [{type:'IMAGE', imageHash}]` from the upload
-response) so the designer — and `get_screenshot` — can compare ground truth vs
-editable copy directly.
+*Left: rendered PNG. Right: native Figma layers rebuilt by hand from the data
+products — the prototype that became `FigmaLayeredSvg`.*
 
-Known limits (state them in the Figma file rather than papering over):
-
-- Canvas-drawn content (shadows, ripples, arbitrary `Canvas` draws) is not in
-  the tree — it stays image-only.
-- Text metrics are near-exact, not glyph-exact: Roboto ≈ sans-serif, and
-  Compose's baseline layout differs subtly from Figma's.
-- The reconstruction is one variant; it does not (yet) bind Figma variables.
-  `figma-variables.json` from the catalog export is the intended token source —
-  applying it via `figma.variables.createVariableCollection` in `use_figma` is
-  the natural next step, then binding reconstruction fills to those variables.
+That reconstruction is exactly what the exporter now does deterministically, with
+hybrid raster, theme tokens, and a fidelity score. **Prefer `compose/figma-svg`.**
+Reach for the manual rebuild only when you genuinely can't run the exporter and
+need a single frame reconstructed in an ad-hoc session.
 
 ## Iteration loop
 
-The roundtrip composes with the existing PR machinery: the agent generates or
-edits catalog code on a branch, `compose-preview.yml` posts the before/after
-diff, and once merged the `design-artifacts` workflow refreshes the delivery
-branches. The Figma push is the last mile — re-run legs 1–2 against the merged
-`main` (or a PR head for design review) and re-upload; `upload_assets` with a
-`nodeId` swaps the fill on the existing frame in place, so a variant sheet can
-be refreshed without re-arranging the canvas.
+Both paths compose with the PR machinery: an agent edits catalog code on a
+branch, `compose-preview.yml` posts the before/after diff, and once merged the
+`design-artifacts` workflow refreshes the delivery branches — including the
+`figma/<slug>.svg` vectors. On the Figma side, the plugin's **refresh** re-fetches
+a placed node's `/render/<id>.svg` against the latest code, so a designer updates
+a whole imported library without re-arranging the canvas; the MCP path refreshes
+a raster sheet in place by re-`upload_assets`-ing onto the existing `nodeId`.

--- a/docs/design/FIGMA_ROUNDTRIP.md
+++ b/docs/design/FIGMA_ROUNDTRIP.md
@@ -32,8 +32,13 @@ The `compose/figma-svg` data product (`FigmaLayeredSvg` in
   (or a `<path>` for non-uniform corners), `border` → stroke, resolved radius →
   Figma's editable corner radius, `CircleShape` → a max-radius rounded rect.
 - **Text is editable `<text>`** carrying family/size/weight/colour.
-- **Named theme colours ride along** as `<title>` + `data-token` per layer, to
-  bind fills to variables from the sibling `figma-variables.json`.
+- **Named theme colours** *can* ride along as `<title>` + `data-token` per layer
+  (to bind fills to variables from the sibling `figma-variables.json`) — but only
+  when the render is given a colour-name map. The normal
+  `bundle pack --with-semantics` / catalog path calls `writeSvg` with no map
+  today (`colorNames` defaults empty), so shipped `figma/<slug>.svg` carries no
+  `data-token` yet; wiring the live `compose/theme` map into the render path is a
+  tracked follow-up.
 - **Hybrid capture** — components that can't be faithful vectors (`Image`,
   `Icon`, `Canvas`, gradients, charts) are classified opaque and emitted as an
   `<image>` placeholder over a background-free raster crop; everything else stays


### PR DESCRIPTION
## Summary

`docs/design/FIGMA_ROUNDTRIP.md` predated the `compose/figma-svg` exporter and still framed hand-built `use_figma` reconstruction (from `layout.json` + `semantics.json`) as the way to get editable Figma layers. That job is now automated and surpassed by the shipped feature — `FigmaLayeredSvg` (`:data-layoutinspector-core`) → per-preview `previews/<id>.figma.svg`, `serve /render/<id>.svg` (`ServeFigmaSvg`), catalog `figma/<slug>.svg` — and the design-parity `figma-plugin` importer. The doc read as if that were still a manual agent chore.

This is a **docs-only reconciliation** (no code):

- **Reframe `FIGMA_ROUNDTRIP.md`** around two clearly-separated paths with a which-path table:
  - **Canonical — `compose/figma-svg`**: the editable, layered-vector path. New section documenting the exporter, how to obtain the SVG (bundle `--with-semantics`, `serve /render/<id>.svg`, catalog `figma/<slug>.svg`), and import via the design-parity `figma-plugin`, with links to [`figma-svg-example/`](../design/figma-svg-example/), [`design-artifacts-figma-svg/`](../design/design-artifacts-figma-svg/), and the plugin's `FIGMA_IMPORT.md` / `FIGMA_IMPORT_V2.md`.
  - **Agent MCP push**: kept, but scoped to what it *uniquely* still does — arranging rendered **variant matrices** (`render-matrix --cells-dir` → `upload_assets`) on a canvas for live review. The hand reconstruction is demoted to an explicit fallback ("prefer `compose/figma-svg`").
- **Fix the `DESIGN_CATALOGS.md` cross-reference** so it points at `compose/figma-svg` for editable layers and at the roundtrip doc only for the ad-hoc variant-matrix push (it previously claimed the roundtrip doc did "editable layer reconstructions").

Existing evidence images are retained where still accurate (variant matrix + canvas push for the MCP path; the hand-reconstruction shot now labelled as the prototype that became `FigmaLayeredSvg`).

## Test plan

Docs only — no build/behaviour change. Verified every referenced path exists on this branch (`figma-svg-example/`, `design-artifacts-figma-svg/`, the three roundtrip evidence PNGs) and that the sibling-repo links point at real `packages/figma-plugin` / `docs/design-artifacts/FIGMA_IMPORT*.md` files.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M7sMfKC1CR9vBSCFjSqr9z)_