### PR TITLE
feat: extract and serve named preview slots

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHost.kt
@@ -40,6 +40,15 @@ interface ServeHost : AutoCloseable {
   fun renderSvg(previewId: String, overrides: PreviewOverrides): SvgOutcome = SvgOutcome.NotFound
 
   /**
+   * Render [previewId] at [overrides] and return its declared preview slots as JSON, or
+   * [SlotsOutcome.NotFound] when this host can't extract them. Defaults to `NotFound`: only the
+   * daemon-backed [ServeRenderHost] overrides this — a static [ServeBundleHost] has no daemon to
+   * capture a semantics tree.
+   */
+  fun renderSlots(previewId: String, overrides: PreviewOverrides): SlotsOutcome =
+    SlotsOutcome.NotFound
+
+  /**
    * Join the shared live stream for [previewId], or `null` when this host has no live lane (the
    * snapshot fallback is used instead — always the case for [ServeBundleHost]).
    */

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -497,9 +497,9 @@ class ServeHttpServer(
 
   /**
    * `GET /render/{name}` (query) and `GET /{system}/render/{name}` (path): a preview's rendered
-   * bytes — a PNG for `<id>.png` (or no suffix), or the figma-svg export for `<id>.svg`. Both take
-   * the same override query params; SVG is only produced by a daemon-backed host (a static bundle
-   * 404s it).
+   * bytes — a PNG for `<id>.png` (or no suffix), the figma-svg export for `<id>.svg`, or the
+   * declared preview slots as JSON for `<id>.slots`. All take the same override query params; SVG
+   * and slots are only produced by a daemon-backed host (a static bundle 404s them).
    */
   private suspend fun RoutingContext.handleRender(sessionInPath: Boolean) {
     if (rejectBadToken()) return
@@ -510,7 +510,8 @@ class ServeHttpServer(
         return@withLeasedSession
       }
       val wantSvg = rawName.endsWith(".svg")
-      val previewId = rawName.removeSuffix(".png").removeSuffix(".svg")
+      val wantSlots = rawName.endsWith(".slots")
+      val previewId = rawName.removeSuffix(".png").removeSuffix(".svg").removeSuffix(".slots")
       // Forward the fixed render axes plus any author-declared knob params (`knob.<key>=…`, dynamic
       // keys not in SUPPORTED_KEYS) so a live knob edit reaches ServeOverrides.parse instead of
       // being
@@ -535,6 +536,10 @@ class ServeHttpServer(
         is OverrideParse.Ok -> {
           if (wantSvg) {
             renderSvgResponse(renderHost, previewId, parsed.overrides)
+            return@withLeasedSession
+          }
+          if (wantSlots) {
+            renderSlotsResponse(renderHost, previewId, parsed.overrides)
             return@withLeasedSession
           }
           // The render is blocking (renderNow + await); keep it off the request dispatcher. Cap
@@ -602,6 +607,39 @@ class ServeHttpServer(
         call.respondBytes(outcome.svg, ContentType.parse(ComposeFigmaSvgProduct.MEDIA_TYPE_SVG))
       SvgOutcome.NotFound -> call.respondText("no such preview", status = HttpStatusCode.NotFound)
       is SvgOutcome.Failed ->
+        call.respondText(outcome.reason, status = HttpStatusCode.InternalServerError)
+    }
+  }
+
+  /** Slots lane of [handleRender]: load-shed like the PNG lane, then respond the slots JSON. */
+  private suspend fun RoutingContext.renderSlotsResponse(
+    renderHost: ServeHost,
+    previewId: String,
+    overrides: PreviewOverrides,
+  ) {
+    val outcome =
+      withContext(Dispatchers.IO) {
+        if (!renderSemaphore.tryAcquire(RENDER_QUEUE_WAIT_SECONDS, TimeUnit.SECONDS)) {
+          null
+        } else {
+          try {
+            renderHost.renderSlots(previewId, overrides)
+          } finally {
+            renderSemaphore.release()
+          }
+        }
+      }
+    when (outcome) {
+      null -> {
+        call.response.headers.append(HttpHeaders.RetryAfter, "2")
+        call.respondText(
+          "render queue saturated; retry shortly",
+          status = HttpStatusCode.ServiceUnavailable,
+        )
+      }
+      is SlotsOutcome.Ok -> call.respondBytes(outcome.json, ContentType.Application.Json)
+      SlotsOutcome.NotFound -> call.respondText("no such preview", status = HttpStatusCode.NotFound)
+      is SlotsOutcome.Failed ->
         call.respondText(outcome.reason, status = HttpStatusCode.InternalServerError)
     }
   }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
@@ -5,6 +5,10 @@ import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.daemon.protocol.StreamCodec
 import ee.schimke.composeai.daemon.protocol.StreamFrameParams
 import ee.schimke.composeai.data.layoutinspector.ComposeFigmaSvgProduct
+import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsPayload
+import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsProduct
+import ee.schimke.composeai.data.layoutinspector.PreviewSlots
+import ee.schimke.composeai.data.layoutinspector.PreviewSlotsPayload
 import ee.schimke.composeai.io.SystemFileSystem
 import ee.schimke.composeai.render.session.RenderSession
 import ee.schimke.composeai.render.session.RenderSessionConfig
@@ -79,6 +83,20 @@ sealed interface SvgOutcome {
 }
 
 /**
+ * Result of a preview-slots request — the [PreviewSlotsPayload] JSON counterpart of
+ * [RenderOutcome].
+ */
+sealed interface SlotsOutcome {
+  data class Ok(val json: ByteArray) : SlotsOutcome
+
+  /** No such preview id, or this host can't extract slots (a static bundle has no daemon). */
+  data object NotFound : SlotsOutcome
+
+  /** The render or semantics fetch was attempted but failed. [reason] is human-readable. */
+  data class Failed(val reason: String) : SlotsOutcome
+}
+
+/**
  * Long-lived, thread-safe wrapper around **one** [RenderSession], fronting it for the
  * `compose-preview serve` HTTP server. The long-lived sibling of
  * [ee.schimke.composeai.cli.MatrixRenderFetcher]: same `renderNow` + await-`renderFinished` +
@@ -123,6 +141,13 @@ internal constructor(
 
   // The figma-svg counterpart of [cache], keyed the same way (previewId × overrides).
   private val svgCache = LruByteCache(MAX_CACHE_ENTRIES)
+
+  // The preview-slots counterpart of [cache], keyed the same way (previewId × overrides).
+  private val slotsCache = LruByteCache(MAX_CACHE_ENTRIES)
+
+  // Decodes a fetched compose/semantics payload and encodes the slots response; tolerant of the
+  // schema's additive fields (a v7 file read by this v-agnostic slot extractor).
+  private val dataJson = Json { ignoreUnknownKeys = true }
 
   private val renderLock = ReentrantLock()
 
@@ -327,6 +352,74 @@ internal constructor(
   private fun inlineRasters(svgPath: okio.Path, raw: ByteArray): ByteArray {
     val dir = svgPath.parent ?: return raw
     return inlineFigmaRasters(fileSystem, dir, raw.decodeToString()).encodeToByteArray()
+  }
+
+  /**
+   * Render [previewId] at [overrides] and return its declared **preview slots** as
+   * [PreviewSlotsPayload] JSON, serving a cached result when one exists. Thread-safe.
+   *
+   * The slots are the `dp-slot:<name>` markers the preview's author placed (see [PreviewSlots]);
+   * they're captured into the `compose/semantics` tree of the *same* render that produces the PNG,
+   * with their absolute-to-root bounds. Like [renderSvg] this renders (reusing [render] and its
+   * retry/timeout handling) then fetches the just-written product, both under [renderLock] with the
+   * PNG cache entry evicted first — the semantics file is shared per preview and overwritten by
+   * every render, so it must be read in the same critical section as the render that produced it.
+   */
+  override fun renderSlots(previewId: String, overrides: PreviewOverrides): SlotsOutcome {
+    check(!closed.get()) { "ServeRenderHost is closed" }
+    if (previewId !in previewIds) return SlotsOutcome.NotFound
+
+    val key = ServeOverrides.cacheKey(previewId, overrides)
+    slotsCache.get(key)?.let {
+      return SlotsOutcome.Ok(it)
+    }
+
+    return renderLock.withLock {
+      slotsCache.get(key)?.let {
+        return@withLock SlotsOutcome.Ok(it)
+      }
+
+      // Force a fresh render of these overrides so the shared per-preview semantics file on disk is
+      // theirs; the held lock keeps any other render from overwriting it before the fetch below.
+      cache.remove(key)
+      when (val pngOutcome = render(previewId, overrides)) {
+        RenderOutcome.NotFound -> return@withLock SlotsOutcome.NotFound
+        is RenderOutcome.Failed -> return@withLock SlotsOutcome.Failed(pngOutcome.reason)
+        is RenderOutcome.Ok -> {} // rendered; the semantics for these overrides is now on disk
+      }
+
+      val payload =
+        try {
+          fetchSemantics(previewId)
+        } catch (e: Exception) {
+          val reason = "compose/semantics fetch failed: ${e.message}"
+          onLog(reason)
+          return@withLock SlotsOutcome.Failed(reason)
+        } ?: return@withLock SlotsOutcome.Failed("render produced no semantics")
+
+      val slots = PreviewSlots.extractSlots(payload)
+      val json =
+        dataJson
+          .encodeToString(PreviewSlotsPayload.serializer(), PreviewSlotsPayload(previewId, slots))
+          .encodeToByteArray()
+      slotsCache.put(key, json)
+      SlotsOutcome.Ok(json)
+    }
+  }
+
+  /**
+   * Fetch and decode the freshly written `compose/semantics` tree for [previewId] from whichever
+   * transport the session used (inline payload or an on-disk path); null when the fetch yielded
+   * neither. Callers hold [renderLock] so the file read matches the render that produced it.
+   */
+  private fun fetchSemantics(previewId: String): ComposeSemanticsPayload? {
+    val result = session.fetchData(previewId, ComposeSemanticsProduct.KIND)
+    result.payload?.let {
+      return dataJson.decodeFromJsonElement(ComposeSemanticsPayload.serializer(), it)
+    }
+    val path = result.path?.toPath()?.takeIf { fileSystem.exists(it) } ?: return null
+    val text = fileSystem.read(path) { readUtf8() }
+    return dataJson.decodeFromString(ComposeSemanticsPayload.serializer(), text)
   }
 
   /**

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/FakeRenderSession.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/FakeRenderSession.kt
@@ -30,6 +30,10 @@ import ee.schimke.composeai.daemon.protocol.StreamCodec
 import ee.schimke.composeai.daemon.protocol.StreamFrameParams
 import ee.schimke.composeai.daemon.protocol.StreamStartResult
 import ee.schimke.composeai.data.layoutinspector.ComposeFigmaSvgProduct
+import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsNode
+import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsPayload
+import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsProduct
+import ee.schimke.composeai.data.layoutinspector.PreviewSlots
 import ee.schimke.composeai.render.session.NotificationListener
 import ee.schimke.composeai.render.session.RenderSession
 import ee.schimke.composeai.render.session.RenderSessionBackend
@@ -189,6 +193,9 @@ internal class FakeRenderSession(
       // Model the daemon writing the figma-svg to a shared per-preview path as a side effect of the
       // same render — overwritten each time, so distinct overrides overwrite one another's SVG.
       writeFigmaSvg(id, overrides)
+      // Likewise the compose/semantics tree, carrying two `dp-slot:` markers so the slots lane has
+      // something to extract.
+      writeSemantics(id)
     }
     return RenderNowResult(queued = previewIds, rejected = emptyList())
   }
@@ -206,6 +213,33 @@ internal class FakeRenderSession(
     }
   }
 
+  private fun writeSemantics(id: String) {
+    val previewDir = File(renderRoot, id).apply { mkdirs() }
+    val payload =
+      ComposeSemanticsPayload(
+        root =
+          ComposeSemanticsNode(
+            nodeId = "0",
+            boundsInRoot = "0,0,200,100",
+            children =
+              listOf(
+                ComposeSemanticsNode(
+                  nodeId = "1",
+                  boundsInRoot = "8,8,40,40",
+                  testTag = "${PreviewSlots.SLOT_TAG_PREFIX}leadingIcon",
+                ),
+                ComposeSemanticsNode(
+                  nodeId = "2",
+                  boundsInRoot = "48,44,192,64",
+                  testTag = "${PreviewSlots.SLOT_TAG_PREFIX}supporting",
+                ),
+              ),
+          )
+      )
+    File(previewDir, ComposeSemanticsProduct.FILE)
+      .writeText(streamJson.encodeToString(ComposeSemanticsPayload.serializer(), payload))
+  }
+
   override fun fetchData(
     previewId: String,
     kind: String,
@@ -218,6 +252,14 @@ internal class FakeRenderSession(
       return DataFetchResult(
         kind = kind,
         schemaVersion = ComposeFigmaSvgProduct.SCHEMA_VERSION,
+        path = file.absolutePath,
+      )
+    }
+    if (kind == ComposeSemanticsProduct.KIND) {
+      val file = File(renderRoot, "$previewId/${ComposeSemanticsProduct.FILE}")
+      return DataFetchResult(
+        kind = kind,
+        schemaVersion = ComposeSemanticsProduct.SCHEMA_VERSION,
         path = file.absolutePath,
       )
     }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
@@ -139,6 +139,15 @@ class ServeHttpRoutingTest {
   }
 
   @Test
+  fun `a static bundle 404s the slots render lane`() {
+    // The .slots lane is routed and dispatched, but a bundle host has no daemon to capture a
+    // semantics tree, so it resolves to NotFound (only a daemon-backed ServeRenderHost extracts
+    // slots).
+    val (code, _) = get("/compose-m3/render/$previewId.slots")
+    assertEquals(404, code)
+  }
+
+  @Test
   fun `api previews advertises v2 and carries author override declarations`() {
     val (code, api) = get("/compose-m3/api/previews")
     assertEquals(200, code)

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHostTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHostTest.kt
@@ -2,6 +2,8 @@ package ee.schimke.composeai.cli.serve
 
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.daemon.protocol.UiMode
+import ee.schimke.composeai.data.layoutinspector.PreviewSlotsPayload
+import ee.schimke.composeai.data.layoutinspector.SlotBounds
 import ee.schimke.composeai.render.session.RenderSession
 import java.io.File
 import java.util.concurrent.CopyOnWriteArrayList
@@ -12,6 +14,7 @@ import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import kotlinx.serialization.json.Json
 
 class ServeRenderHostTest {
 
@@ -81,6 +84,46 @@ class ServeRenderHostTest {
       val out = h.renderSvg(previewId, PreviewOverrides(uiMode = UiMode.DARK))
       assertTrue(out is SvgOutcome.Ok)
       assertEquals("svg:DARK:null:null", (out as SvgOutcome.Ok).svg.decodeToString())
+    }
+  }
+
+  @Test
+  fun `renderSlots returns the declared dp-slot markers for the given overrides`() {
+    val session = FakeRenderSession(newRenderRoot())
+    host(session).use { h ->
+      val out = h.renderSlots(previewId, PreviewOverrides(uiMode = UiMode.DARK))
+      assertTrue(out is SlotsOutcome.Ok)
+      val payload =
+        Json.decodeFromString(
+          PreviewSlotsPayload.serializer(),
+          (out as SlotsOutcome.Ok).json.decodeToString(),
+        )
+      assertEquals(previewId, payload.previewId)
+      assertEquals(listOf("leadingIcon", "supporting"), payload.slots.map { it.name })
+      assertEquals(SlotBounds(8, 8, 40, 40), payload.slots.first().bounds)
+      assertEquals(32, payload.slots.first().width)
+    }
+  }
+
+  @Test
+  fun `renderSlots serves identical requests from cache`() {
+    val session = FakeRenderSession(newRenderRoot())
+    host(session).use { h ->
+      h.renderSlots(previewId, PreviewOverrides(uiMode = UiMode.DARK))
+      h.renderSlots(previewId, PreviewOverrides(uiMode = UiMode.DARK))
+      assertEquals(
+        1,
+        session.renderCount.get(),
+        "second identical slots request must hit the cache",
+      )
+    }
+  }
+
+  @Test
+  fun `renderSlots is NotFound for an unknown preview`() {
+    val session = FakeRenderSession(newRenderRoot())
+    host(session).use { h ->
+      assertTrue(h.renderSlots("nope", PreviewOverrides()) is SlotsOutcome.NotFound)
     }
   }
 

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/PreviewSlots.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/PreviewSlots.kt
@@ -38,6 +38,13 @@ object PreviewSlots {
   }
 }
 
+/**
+ * The wire response of the `/render/<id>.slots` serve route: the [slots] a preview declared, in
+ * depth-first order, tagged with the [previewId] they came from. A structured-screen builder reads
+ * this to lay out slot regions and size children to fill them.
+ */
+@Serializable data class PreviewSlotsPayload(val previewId: String, val slots: List<PreviewSlot>)
+
 /** One named slot region — its author-declared name and its box (absolute-to-root px). */
 @Serializable
 data class PreviewSlot(val name: String, val bounds: SlotBounds) {

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/PreviewSlots.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/PreviewSlots.kt
@@ -1,0 +1,63 @@
+package ee.schimke.composeai.data.layoutinspector
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Preview **slots** — named, bounded regions an author marks in a preview so a structured-screen
+ * builder can fill them with child components.
+ *
+ * A slot is declared by tagging the region's node with `testTag = "<SLOT_TAG_PREFIX><name>"` (e.g.
+ * `dp-slot:leadingIcon`), typically via a `PreviewSlot(name) { … }` marker composable. `testTag` is
+ * a semantics property, so the marked node is captured into the semantics tree with its bounds —
+ * slots are therefore **explicit and named**, not guessed from a layout heuristic. [extractSlots]
+ * distils a captured [ComposeSemanticsPayload] down to just those markers; the box each returns
+ * (absolute-to-root px) is the size a child rendered to fill the slot should be given.
+ */
+object PreviewSlots {
+  /** The `testTag` prefix a slot marker applies; the slot name is the suffix (`dp-slot:<name>`). */
+  const val SLOT_TAG_PREFIX: String = "dp-slot:"
+
+  /**
+   * The slot markers in [payload], in depth-first order: each node whose `testTag` starts with
+   * [SLOT_TAG_PREFIX], as its name (the suffix) + box (its `boundsInRoot`). Nodes with a blank name
+   * or malformed bounds are skipped, so a partial/garbled tree never throws.
+   */
+  fun extractSlots(payload: ComposeSemanticsPayload): List<PreviewSlot> {
+    val out = mutableListOf<PreviewSlot>()
+    fun walk(node: ComposeSemanticsNode) {
+      val tag = node.testTag
+      if (tag != null && tag.startsWith(SLOT_TAG_PREFIX)) {
+        val name = tag.removePrefix(SLOT_TAG_PREFIX)
+        val bounds = SlotBounds.parse(node.boundsInRoot)
+        if (name.isNotBlank() && bounds != null) out.add(PreviewSlot(name, bounds))
+      }
+      node.children.forEach(::walk)
+    }
+    walk(payload.root)
+    return out
+  }
+}
+
+/** One named slot region — its author-declared name and its box (absolute-to-root px). */
+@Serializable
+data class PreviewSlot(val name: String, val bounds: SlotBounds) {
+  val width: Int
+    get() = bounds.right - bounds.left
+
+  val height: Int
+    get() = bounds.bottom - bounds.top
+}
+
+/** A slot's box in absolute-to-root px, mirroring the semantics `boundsInRoot` wire form. */
+@Serializable
+data class SlotBounds(val left: Int, val top: Int, val right: Int, val bottom: Int) {
+  companion object {
+    /** Parse the `"left,top,right,bottom"` int wire form; null when malformed. */
+    fun parse(wire: String): SlotBounds? {
+      val parts = wire.split(",")
+      if (parts.size != 4) return null
+      val ints = parts.map { it.trim().toIntOrNull() ?: return null }
+      return SlotBounds(ints[0], ints[1], ints[2], ints[3])
+    }
+  }
+}

--- a/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/PreviewSlotsTest.kt
+++ b/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/PreviewSlotsTest.kt
@@ -1,0 +1,71 @@
+package ee.schimke.composeai.data.layoutinspector
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class PreviewSlotsTest {
+
+  private fun node(
+    tag: String? = null,
+    bounds: String = "0,0,0,0",
+    children: List<ComposeSemanticsNode> = emptyList(),
+  ) = ComposeSemanticsNode(nodeId = "0", boundsInRoot = bounds, testTag = tag, children = children)
+
+  @Test
+  fun `extracts named, bounded slots from dp-slot testTags, depth-first`() {
+    val tree =
+      ComposeSemanticsPayload(
+        node(
+          children =
+            listOf(
+              node(tag = "dp-slot:leadingIcon", bounds = "8,8,40,40"),
+              node(
+                tag = "notASlot",
+                bounds = "0,40,200,80",
+                children = listOf(node(tag = "dp-slot:headline", bounds = "48,44,192,64")),
+              ),
+              node(tag = "dp-slot:supporting", bounds = "48,68,192,88"),
+            )
+        )
+      )
+
+    val slots = PreviewSlots.extractSlots(tree)
+    assertEquals(listOf("leadingIcon", "headline", "supporting"), slots.map { it.name })
+    val icon = slots.first()
+    assertEquals(SlotBounds(8, 8, 40, 40), icon.bounds)
+    assertEquals(32, icon.width)
+    assertEquals(32, icon.height)
+  }
+
+  @Test
+  fun `skips blank names and malformed bounds, never throws`() {
+    val tree =
+      ComposeSemanticsPayload(
+        node(
+          children =
+            listOf(
+              node(tag = "dp-slot:", bounds = "0,0,10,10"), // blank name → skipped
+              node(tag = "dp-slot:bad", bounds = "0,0,oops"), // malformed bounds → skipped
+              node(tag = "dp-slot:ok", bounds = "1,2,3,4"),
+            )
+        )
+      )
+    assertEquals(listOf("ok"), PreviewSlots.extractSlots(tree).map { it.name })
+  }
+
+  @Test
+  fun `is empty for a tree with no slot markers`() {
+    assertEquals(
+      emptyList<PreviewSlot>(),
+      PreviewSlots.extractSlots(ComposeSemanticsPayload(node())),
+    )
+  }
+
+  @Test
+  fun `parses and rejects bounds wire forms`() {
+    assertEquals(SlotBounds(0, 0, 200, 100), SlotBounds.parse("0,0,200,100"))
+    assertNull(SlotBounds.parse("1,2,3"))
+    assertNull(SlotBounds.parse("a,b,c,d"))
+  }
+}


### PR DESCRIPTION
## Summary

The **foundation + first server lane** for a structured-screen builder — the plugin work I'm about to do lets you drop a slotted container (an M3 Card, a Scaffold) in Figma, see its **named slots**, and fill each by picking another component rendered to fit the slot. This PR turns a preview's author-marked slots into `{ name, bounds }` (commit 1) and exposes them over HTTP (commit 2).

A slot is declared by tagging its region `testTag = "dp-slot:<name>"` (via a `PreviewSlot(name) { … }` marker composable, next PR). Because **`testTag` is a semantics property**, the marked node is captured into the `compose/semantics` tree *with its bounds* — so slots are **explicit and named, not guessed** from a layout heuristic.

### 1. Extractor (`data-layoutinspector-core`, pure Kotlin)

- **`PreviewSlots.extractSlots(payload)`** walks a captured `ComposeSemanticsPayload`, collects every node whose `testTag` starts with `dp-slot:`, and returns `[{ name, bounds }]` in depth-first order. The box (absolute-to-root px, from `boundsInRoot`) is the size a child rendered to *fill* the slot should be given.
- **`PreviewSlot` / `SlotBounds`** — the serializable wire model (`SlotBounds.parse` reads the `"l,t,r,b"` form the semantics tree already emits). `width`/`height` convenience.
- Defensive: blank names and malformed bounds are skipped, so a partial/garbled tree never throws.

### 2. Serve route (`cli`, mirrors the `renderSvg` lane)

- **`GET /render/<id>.slots`** (and `/<system>/render/<id>.slots`) — takes the same override query params as `.png`/`.svg`, renders at those overrides, fetches the `compose/semantics` tree written by that *same* render, runs `extractSlots`, and responds a **`PreviewSlotsPayload`** JSON: `{ previewId, slots: [{ name, bounds }] }`.
- **`ServeRenderHost.renderSlots`** renders + fetches semantics under `renderLock` with the PNG cache entry evicted first (the semantics file is shared per preview and overwritten by every render, so it must be read in the same critical section as the render that produced it), and caches by the same `(previewId × overrides)` key as the PNG/SVG lanes.
- **`ServeHost.renderSlots`** defaults to `SlotsOutcome.NotFound`; only the daemon-backed host overrides it — a static `ServeBundleHost` has no daemon to capture semantics, so it 404s the lane (same as `.svg`).

## Where it fits

```
PreviewSlot(name){…}  →  testTag "dp-slot:name"  →  compose/semantics tree (node + bounds)
                                                          │
                                          PreviewSlots.extractSlots  →  [{name, bounds}]
                                                          │
                                    GET /render/<id>.slots  →  { previewId, slots:[…] }
                                                          │  (next: marker composable + SlotFit)
                                              plugin: place container → show/fill slots
```

## Test plan

- `PreviewSlotsTest`: extracts named slots depth-first (nested + non-slot siblings ignored); skips blank names / malformed bounds without throwing; empty for a marker-free tree; `SlotBounds.parse` accepts `"0,0,200,100"` and rejects short/non-numeric forms.
- `ServeRenderHostTest`: `renderSlots` returns the declared markers with correct bounds/width for the given overrides; serves identical requests from cache (one render); `NotFound` for an unknown preview.
- `ServeHttpRoutingTest`: a static bundle 404s the `.slots` lane (routed + dispatched, no daemon to capture semantics).
- `FakeRenderSession` now writes a `compose-semantics.json` with `dp-slot:` markers per render and serves it via `fetchData`.
- Non-visual change (data-product plumbing + route); text-only evidence is correct here. ktfmt verified locally against the pinned tool; relying on CI for compile + test.

## Follow-ups (the rest of the slice)

- **`PreviewSlot` marker composable + `SlotFit` fill-wrapper** (runtime module) + mark one M3 Card sample's slots — the end-to-end proof.
- **design-parity**: a `slots.ts` parser (consume the `.slots` response) + place-container-and-show-slots, then fill-a-slot (renders a child at the slot's size, reusing the live-render + refresh machinery).

---
_Generated by [Claude Code](https://claude.ai/code/session_018uTv78jpPEKSEyScXoCdYD)_