### PR TITLE
fix(serve): bridge catalog ids to the live daemon so deep links keep resolving

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -7,6 +7,7 @@ import ee.schimke.composeai.cli.serve.ServeBundle
 import ee.schimke.composeai.cli.serve.ServeBundleDaemon
 import ee.schimke.composeai.cli.serve.ServeBundleHost
 import ee.schimke.composeai.cli.serve.ServeBundleStore
+import ee.schimke.composeai.cli.serve.ServeCatalogLiveHost
 import ee.schimke.composeai.cli.serve.ServeCatalogStore
 import ee.schimke.composeai.cli.serve.ServeHost
 import ee.schimke.composeai.cli.serve.ServeHttpServer
@@ -323,14 +324,23 @@ class ServeCommand(args: List<String>) : Command(args) {
     // saved state, so a long-lived server doesn't keep daemons running forever.
     val openHost: (ServeSessionState) -> ServeHost? = { state ->
       runCatching {
-          ServeRenderHost.open(
-            descriptorPath = state.descriptor,
-            workspaceRoot = state.workspaceRoot,
-            workspaceName = state.workspaceName,
-            previews = state.previews,
-            label = state.label,
-            onLog = { System.err.println("[daemon serve] $it") },
-          )
+          val daemon =
+            ServeRenderHost.open(
+              descriptorPath = state.descriptor,
+              workspaceRoot = state.workspaceRoot,
+              workspaceName = state.workspaceName,
+              previews = state.previews,
+              label = state.label,
+              onLog = { System.err.println("[daemon serve] $it") },
+            )
+          // A trusted-catalog live session carries a baked-PNG fallback + a catalog-id→daemon-id
+          // alias: front the daemon with the baked catalog so the published /p/<id> deep links and
+          // /render/<id>.png thumbnails resolve (and the Android-only variants fall back to baked),
+          // while the mapped ids gain a live lane. Rebuilt here on every resume, so suspend/resume
+          // works unchanged. Plain project / revision sessions carry no fallback → the bare daemon.
+          val fallback = state.bakedFallback
+          if (fallback != null) ServeCatalogLiveHost(state.previewAliases, daemon, fallback())
+          else daemon
         }
         .getOrNull()
     }
@@ -616,11 +626,19 @@ class ServeCommand(args: List<String>) : Command(args) {
             "serve: catalog $system carries an in-browser Wasm app (/wasm/$system/)"
           )
         },
-        buildTrustedBundle = { system, bundleFile ->
-          buildTrustedCatalogBundle(system, bundleFile, registry, openHost)
+        buildTrustedBundle = { system, bundleFile, alias, bakedFallback ->
+          buildTrustedCatalogBundle(system, bundleFile, alias, bakedFallback, registry, openHost)
         },
-        buildTrustedSource = { system, source ->
-          buildTrustedCatalogSource(system, source, registry, worktrees, openHost)
+        buildTrustedSource = { system, source, alias, bakedFallback ->
+          buildTrustedCatalogSource(
+            system,
+            source,
+            alias,
+            bakedFallback,
+            registry,
+            worktrees,
+            openHost,
+          )
         },
       )
     for (ref in catalogRefs) {
@@ -655,6 +673,8 @@ class ServeCommand(args: List<String>) : Command(args) {
   private fun buildTrustedCatalogBundle(
     system: String,
     bundleFile: File,
+    alias: Map<String, String>,
+    bakedFallback: () -> ServeHost,
     registry: ServeSessionRegistry,
     openHost: (ServeSessionState) -> ServeHost?,
   ): Boolean {
@@ -663,7 +683,14 @@ class ServeCommand(args: List<String>) : Command(args) {
       java.nio.file.Files.createTempDirectory("serve-catalog-bundle-$system").toFile().also {
         it.deleteOnExit()
       }
-    val state = ServeBundleDaemon.materialize(bundleFile, destDir, system) ?: return false
+    // Carry the catalog-id→daemon-id alias + the baked-PNG fallback on the state so openHost fronts
+    // the daemon with the baked catalog: the published /p/<id> deep links + /render/<id>.png
+    // thumbnails keep resolving (Android-only variants fall back to baked), while the mapped ids
+    // get
+    // a live lane. See ServeCatalogLiveHost.
+    val state =
+      ServeBundleDaemon.materialize(bundleFile, destDir, system)
+        ?.copy(previewAliases = alias, bakedFallback = bakedFallback) ?: return false
     val host = openHost(state) ?: return false
     registry.register(system, state, host = host)
     System.err.println("serve: catalog $system → LIVE from bundle (no build) (?session=$system)")
@@ -681,6 +708,8 @@ class ServeCommand(args: List<String>) : Command(args) {
   private fun buildTrustedCatalogSource(
     system: String,
     source: ServeCatalogStore.CatalogSource,
+    alias: Map<String, String>,
+    bakedFallback: () -> ServeHost,
     registry: ServeSessionRegistry,
     worktrees: GitWorktrees?,
     openHost: (ServeSessionState) -> ServeHost?,
@@ -733,6 +762,11 @@ class ServeCommand(args: List<String>) : Command(args) {
         workspaceName = built.moduleDir.name,
         previews = built.previews,
         label = "$system@${source.ref}",
+        // Same catalog-id bridge + baked fallback as the bundle path (a source build's daemon uses
+        // the same function-based ids), so a live source-rebuilt catalog also answers the published
+        // URLs and falls back to baked PNGs for ids it can't render.
+        previewAliases = alias,
+        bakedFallback = bakedFallback,
       )
     val host = openHost(state) ?: return false
     registry.register(system, state, host = host)

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
@@ -1,0 +1,106 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.daemon.protocol.StreamCodec
+import ee.schimke.composeai.daemon.protocol.StreamFrameParams
+
+/**
+ * A [ServeHost] that fronts a trusted design-system catalog with **both** its baked-PNG render and
+ * a live daemon lane, bridging the two id namespaces so the published catalog URLs keep working.
+ *
+ * ## Why
+ *
+ * A daemon knows its previews by the function-based descriptor id it discovered
+ * (`FilledButton_Dark`), but the published `design-artifacts/<system>` catalog links + image routes
+ * use the componentId-slug id (`button-filled__ideal__default__dark`) — and the two don't match.
+ * Registering a bare [ServeRenderHost] for a catalog therefore 404s every published `/p/<id>` deep
+ * link and `/render/<id>.png` thumbnail. It also can't serve the ids the desktop daemon simply
+ * doesn't have (the Android-only inset focus-ring variant, rendered by a separate supplement and
+ * baked in, with no runnable desktop preview).
+ *
+ * ## What
+ *
+ * This composite keeps the [baked] [ServeBundleHost] as the browse surface — so [previews], the
+ * grid, deep links, and thumbnails resolve to the baked catalog **exactly as before** — and layers
+ * the [live] daemon underneath for the ids [alias] maps (catalog id → daemon preview id):
+ * - **Plain snapshot** (no overrides): served from the baked PNG, so ordinary browsing never wakes
+ *   the daemon (thumbnails, deep-link default view).
+ * - **Overridden snapshot** on an aliased id: routed to the daemon for a fresh render of the edit.
+ * - **Live stream** on an aliased id: routed to the daemon; an unmapped id has no stream (the
+ *   caller transparently falls back to the snapshot lane, i.e. the baked PNG).
+ *
+ * The result: the whole published catalog resolves under its own ids, and the CMP components the
+ * desktop daemon can run gain a live, interactive lane — while the Android-only variants degrade
+ * gracefully to their baked pixels.
+ */
+class ServeCatalogLiveHost(
+  /**
+   * Catalog id (`button-filled__ideal__default__dark`) → daemon preview id (`FilledButton_Dark`).
+   */
+  private val alias: Map<String, String>,
+  /** The daemon-backed host, keyed by daemon preview ids (the [alias] values). */
+  private val live: ServeHost,
+  /** The static baked-PNG host, keyed by catalog ids (the browse surface + fallback). */
+  private val baked: ServeHost,
+) : ServeHost {
+
+  /** Browse surface is the baked catalog — its ids are the published catalog ids. */
+  override val previews: List<ServePreview> = baked.previews
+
+  override val label: String = baked.label
+
+  /** Some ids (the aliased ones) re-render live, so the viewer should offer editable knobs. */
+  override val canApplyOverrides: Boolean = true
+
+  /**
+   * Plain (no-override) snapshots come from the baked PNG so browsing never spins the daemon; an
+   * override edit on an aliased id renders fresh through the daemon. An unmapped id always serves
+   * baked (it has no runnable preview).
+   */
+  override fun render(previewId: String, overrides: PreviewOverrides): RenderOutcome {
+    val daemonId = alias[previewId]
+    return if (daemonId != null && overrides != EMPTY_OVERRIDES) {
+      live.render(daemonId, overrides)
+    } else {
+      baked.render(previewId, overrides)
+    }
+  }
+
+  override fun renderSvg(previewId: String, overrides: PreviewOverrides): SvgOutcome {
+    val daemonId = alias[previewId]
+    return if (daemonId != null && overrides != EMPTY_OVERRIDES) {
+      live.renderSvg(daemonId, overrides)
+    } else {
+      baked.renderSvg(previewId, overrides)
+    }
+  }
+
+  /**
+   * Live streaming is available only for aliased ids; others have no stream (snapshot fallback).
+   */
+  override fun subscribeStream(
+    previewId: String,
+    overrides: PreviewOverrides,
+    codec: StreamCodec?,
+    maxFps: Int?,
+    onFrame: (StreamFrameParams) -> Unit,
+  ): StreamHandle? {
+    val daemonId = alias[previewId] ?: return null
+    return live.subscribeStream(daemonId, overrides, codec, maxFps, onFrame)
+  }
+
+  override fun activeStreamCount(): Int = live.activeStreamCount()
+
+  override fun close() {
+    try {
+      live.close()
+    } finally {
+      baked.close()
+    }
+  }
+
+  private companion object {
+    /** All-default overrides = "no override" (what the snapshot lane passes for a plain view). */
+    private val EMPTY_OVERRIDES = PreviewOverrides()
+  }
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
@@ -46,30 +46,66 @@ class ServeCatalogStore(
    * Trusted server-side re-render from a carried **executable bundle** (opt-in,
    * `--allow-render-trusted`). When a catalog is `Trusted` AND declares a `liveBundle` (`{path,
    * file}`), the bundle is fetched and this is invoked to stand up a daemon-backed, re-renderable
-   * session built straight from it — no Gradle build, no worktree, no repo clone. Preferred over
-   * [buildTrustedSource] (tried first): returns true when it registered such a session (then both
-   * the Gradle source path and the static [ServeBundleHost] are skipped); false ⇒ fall back to
-   * [buildTrustedSource], then the static catalog. Default ⇒ never. The callback owns the
-   * `--allow-render-trusted` gate; this store only reaches it for an already-`Trusted` catalog, and
-   * only after the whole declared bundle file fetched cleanly (fail-closed, like [fetchWasmApp]).
+   * session built straight from it — no Gradle build, no worktree, no repo clone. It's handed the
+   * catalog-id→daemon-id `alias` and a `bakedFallback` factory so it can front the baked catalog
+   * with the daemon ([ServeCatalogLiveHost]) rather than replace it — the published `/p/<id>` links
+   * keep resolving and unmapped ids fall back to baked PNGs. Preferred over [buildTrustedSource]
+   * (tried first): returns true when it registered such a session (then both the Gradle source path
+   * and the plain static registration are skipped); false ⇒ fall back to [buildTrustedSource], then
+   * the static catalog. Default ⇒ never. The callback owns the `--allow-render-trusted` gate; this
+   * store only reaches it for an already-`Trusted` catalog, and only after the whole declared
+   * bundle file fetched cleanly (fail-closed, like [fetchWasmApp]).
    */
-  private val buildTrustedBundle: (system: String, bundleFile: File) -> Boolean = { _, _ -> false },
+  private val buildTrustedBundle:
+    (
+      system: String, bundleFile: File, alias: Map<String, String>, bakedFallback: () -> ServeHost,
+    ) -> Boolean =
+    { _, _, _, _ ->
+      false
+    },
   /**
    * Trusted server-side re-render (opt-in, `--allow-render-trusted`). When a catalog is `Trusted`
    * AND declares a `source` (`{repo, ref, module}`), this is invoked to stand up a **daemon-backed,
    * re-renderable** session built from that source — so the viewer's controls re-render live at
-   * full fidelity instead of replaying baked PNGs. Returns true when it registered such a session
-   * (then the static [ServeBundleHost] is skipped); false ⇒ fall back to the static catalog.
-   * Default ⇒ never (the safe default + what every public deploy uses). The callback owns the
-   * ref-allowlist + build gates; this store only reaches it for an already-`Trusted` catalog.
+   * full fidelity instead of replaying baked PNGs. Like [buildTrustedBundle] it's handed the
+   * catalog-id→daemon-id `alias` + a `bakedFallback` factory and fronts the baked catalog with the
+   * daemon rather than replacing it. Returns true when it registered such a session (then the plain
+   * static registration is skipped); false ⇒ fall back to the static catalog. Default ⇒ never (the
+   * safe default + what every public deploy uses). The callback owns the ref-allowlist + build
+   * gates; this store only reaches it for an already-`Trusted` catalog.
    */
-  private val buildTrustedSource: (system: String, source: CatalogSource) -> Boolean = { _, _ ->
-    false
-  },
+  private val buildTrustedSource:
+    (
+      system: String,
+      source: CatalogSource,
+      alias: Map<String, String>,
+      bakedFallback: () -> ServeHost,
+    ) -> Boolean =
+    { _, _, _, _ ->
+      false
+    },
 ) {
 
   /** A catalog's buildable source — where to check out + build to re-render it live. */
   data class CatalogSource(val repo: String, val ref: String, val module: String)
+
+  /**
+   * Build the **catalog-id → daemon-preview-id** alias from a catalog's images: each image's
+   * route-safe id ([previewIdFor] of its `path`) mapped to the `previewId` the exporter recorded.
+   * Images with no `previewId` (Android-only variants, older catalogs) are skipped — they have no
+   * live lane. Later duplicates keep the first mapping (the theme/state variants are distinct ids,
+   * so collisions shouldn't arise).
+   */
+  private fun previewAliasFor(catalog: Catalog): Map<String, String> {
+    val alias = LinkedHashMap<String, String>()
+    for (component in catalog.components) {
+      for (image in component.images) {
+        val daemonId = image.previewId?.takeIf { it.isNotBlank() } ?: continue
+        alias.putIfAbsent(previewIdFor(image.path), daemonId)
+      }
+    }
+    return alias
+  }
 
   sealed interface Result {
     data class Ok(val system: String, val previewCount: Int, val trust: String) : Result
@@ -148,38 +184,15 @@ class ServeCatalogStore(
         BundleVerifier.Verdict.Trusted(listOf(BundleVerifier.Basis.Branch(repo, branch)))
       else BundleVerifier.Verdict.Unverified("branch $repo@$branch is not trusted")
 
-    // Trusted server-side re-render from a carried EXECUTABLE BUNDLE (opt-in,
-    // --allow-render-trusted) — tried FIRST, ahead of the Gradle `source` build below: no clone, no
-    // worktree, no per-request Gradle invocation. Only a Trusted catalog that declares `liveBundle`
-    // is even offered to the builder — an Unverified catalog NEVER reaches it — and only once the
-    // whole declared bundle file has fetched cleanly (fail-closed, like fetchWasmApp above).
-    val liveBundle = catalog.liveBundle
-    if (verdict is BundleVerifier.Verdict.Trusted && liveBundle != null) {
-      val bundleFile = fetchLiveBundle(liveBundle, base, dir, safe)
-      if (bundleFile != null && buildTrustedBundle(safe, bundleFile)) {
-        return Result.Ok(safe, count, "${BundleVerifier.summary(verdict)} (live bundle)")
-      }
-    }
-
-    // Trusted server-side re-render from SOURCE (opt-in): only a Trusted catalog that declares a
-    // source is even offered to the builder — an Unverified catalog NEVER reaches it, so a
-    // compromised/spoofed catalog can't trigger a build. When the builder takes over it registers
-    // a daemon-backed (re-renderable) session under this id, so we skip the static host below.
-    val src = catalog.source
-    if (
-      verdict is BundleVerifier.Verdict.Trusted &&
-        src != null &&
-        src.module.isNotBlank() &&
-        buildTrustedSource(safe, CatalogSource(src.repo, src.ref, src.module))
-    ) {
-      return Result.Ok(safe, count, "${BundleVerifier.summary(verdict)} (live)")
-    }
-
     // Fetch the catalog's baked editable vectors (figma/<slug>.svg + crops) so the host can serve
     // an SVG per preview; null when the branch carried none (host then 404s the .svg lane).
     val figmaDir = fetchFigmaSvgs(slugs, base, dir)
 
-    val host =
+    // The static baked-PNG host — the browse surface (grid, deep links, thumbnails), keyed by the
+    // catalog ids. This is ALWAYS what a viewer sees; a live builder below fronts it with a daemon
+    // rather than replacing it, so the published /p/<id> links keep resolving. Built lazily so the
+    // registry can rebuild it on each resume of a live session.
+    val bakedFallback: () -> ServeBundleHost = {
       ServeBundleHost(
         dir,
         safe,
@@ -189,6 +202,47 @@ class ServeCatalogStore(
           catalog.library.filter { it.isNotBlank() }.take(2).joinToString(" · ").ifBlank { null },
         figmaDir = figmaDir,
       )
+    }
+
+    // The catalog-id → daemon-preview-id bridge: a live daemon knows previews by their
+    // function-based
+    // descriptor id (`FilledButton_Dark`), but the published links/routes use the catalog id
+    // (`button-filled__ideal__default__dark`). The exporter records each image's source daemon id
+    // in
+    // `previewId`; map it against the route-safe catalog id so a live host can answer the published
+    // URLs (and unmapped ids — the Android-only variants — fall back to baked PNGs).
+    val alias = previewAliasFor(catalog)
+
+    // Trusted server-side re-render from a carried EXECUTABLE BUNDLE (opt-in,
+    // --allow-render-trusted) — tried FIRST, ahead of the Gradle `source` build below: no clone, no
+    // worktree, no per-request Gradle invocation. Only a Trusted catalog that declares `liveBundle`
+    // is even offered to the builder — an Unverified catalog NEVER reaches it — and only once the
+    // whole declared bundle file has fetched cleanly (fail-closed, like fetchWasmApp above). The
+    // builder fronts [bakedFallback] with the daemon (see ServeCatalogLiveHost), so the baked
+    // catalog still serves browsing + the ids the daemon can't render.
+    val liveBundle = catalog.liveBundle
+    if (verdict is BundleVerifier.Verdict.Trusted && liveBundle != null) {
+      val bundleFile = fetchLiveBundle(liveBundle, base, dir, safe)
+      if (bundleFile != null && buildTrustedBundle(safe, bundleFile, alias, bakedFallback)) {
+        return Result.Ok(safe, count, "${BundleVerifier.summary(verdict)} (live bundle)")
+      }
+    }
+
+    // Trusted server-side re-render from SOURCE (opt-in): only a Trusted catalog that declares a
+    // source is even offered to the builder — an Unverified catalog NEVER reaches it, so a
+    // compromised/spoofed catalog can't trigger a build. Like the bundle path, the builder fronts
+    // the baked host with the daemon rather than replacing it.
+    val src = catalog.source
+    if (
+      verdict is BundleVerifier.Verdict.Trusted &&
+        src != null &&
+        src.module.isNotBlank() &&
+        buildTrustedSource(safe, CatalogSource(src.repo, src.ref, src.module), alias, bakedFallback)
+    ) {
+      return Result.Ok(safe, count, "${BundleVerifier.summary(verdict)} (live)")
+    }
+
+    val host = bakedFallback()
     register(safe, host)
     return Result.Ok(safe, host.previews.size, BundleVerifier.summary(verdict))
   }
@@ -334,7 +388,17 @@ class ServeCatalogStore(
 
   @Serializable private data class Component(val images: List<Image> = emptyList())
 
-  @Serializable private data class Image(val path: String)
+  @Serializable
+  private data class Image(
+    val path: String,
+    /**
+     * The **daemon preview id** that produced this image (`FilledButton_Dark`), recorded by the
+     * exporter so a live host can bridge the route-safe catalog id ([previewIdFor] of [path]) to
+     * it. Null when the exporter couldn't map it (an older catalog, or an Android-only variant with
+     * no runnable desktop preview) — then the id has no live lane and stays baked-PNG.
+     */
+    val previewId: String? = null,
+  )
 
   /**
    * `catalog.json`'s `webRender`: an app under [path] (e.g. `web/wasm/`) with its [files] listed.

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionState.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionState.kt
@@ -20,4 +20,22 @@ data class ServeSessionState(
   val previews: List<ServePreview>,
   /** Human label for the tenant (e.g. the module's Gradle path, or `module@rev`). */
   val label: String,
+  /**
+   * Optional **catalog-id → daemon-preview-id** alias map, set only for a trusted-catalog live
+   * session ([ServeCatalogStore] / [ServeBundleDaemon]). The daemon knows previews by their
+   * function-based descriptor id (`FilledButton_Dark`), but the published catalog links and image
+   * routes use the componentId-slug id (`button-filled__ideal__default__dark`). This maps the
+   * latter to the former so the live host answers the published URLs. Empty for plain project /
+   * revision sessions (whose ids already match). See [bakedFallback].
+   */
+  val previewAliases: Map<String, String> = emptyMap(),
+  /**
+   * Optional factory for a **baked-PNG fallback host** covering catalog ids the daemon can't render
+   * (e.g. the Android-only inset focus-ring variant, absent from the desktop bundle). Set only for
+   * a trusted-catalog live session: [openHost][ServeCommand] wraps the daemon [ServeRenderHost] and
+   * this fallback in a [ServeCatalogLiveHost] so browsing, deep links, and thumbnails resolve to
+   * the baked catalog exactly as before while the mapped ids gain a live lane. Rebuilt on each
+   * resume (the baked dir persists), so suspend/resume is preserved. Null for plain sessions.
+   */
+  val bakedFallback: (() -> ServeHost)? = null,
 )

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
@@ -1,0 +1,145 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.daemon.protocol.InteractiveInputKind
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.daemon.protocol.StreamCodec
+import ee.schimke.composeai.daemon.protocol.StreamFrameParams
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * The catalog-id bridge: [ServeCatalogLiveHost] must front the baked catalog with the daemon so the
+ * published catalog ids resolve — plain browsing stays baked (never wakes the daemon), an override
+ * edit / live stream on a mapped id goes to the daemon under its daemon-preview id, and an unmapped
+ * id (an Android-only variant) falls back to baked.
+ */
+class ServeCatalogLiveHostTest {
+
+  /** Records the (id, overrides) of the last call and whether it was reached at all. */
+  private class RecordingHost(
+    override val previews: List<ServePreview>,
+    private val tag: String,
+    private val streaming: Boolean = false,
+  ) : ServeHost {
+    override val label: String = tag
+    override val canApplyOverrides: Boolean = streaming
+    var lastRenderId: String? = null
+    var lastStreamId: String? = null
+    var closed = false
+
+    override fun render(previewId: String, overrides: PreviewOverrides): RenderOutcome {
+      lastRenderId = previewId
+      return RenderOutcome.Ok("$tag:$previewId".encodeToByteArray())
+    }
+
+    override fun subscribeStream(
+      previewId: String,
+      overrides: PreviewOverrides,
+      codec: StreamCodec?,
+      maxFps: Int?,
+      onFrame: (StreamFrameParams) -> Unit,
+    ): StreamHandle? {
+      lastStreamId = previewId
+      if (!streaming) return null
+      return object : StreamHandle {
+        override fun input(
+          kind: InteractiveInputKind,
+          pixelX: Int?,
+          pixelY: Int?,
+          pointerId: Int?,
+          scrollDeltaY: Float?,
+          keyCode: String?,
+        ) {}
+
+        override fun close() {}
+      }
+    }
+
+    override fun activeStreamCount(): Int = if (streaming) 1 else 0
+
+    override fun close() {
+      closed = true
+    }
+  }
+
+  private val catalogId = "button-filled__ideal__default__dark"
+  private val daemonId = "FilledButton_Dark"
+  private val androidOnlyId = "button-filled__ideal__keyboard-focus__dark"
+
+  private fun host(): Triple<ServeCatalogLiveHost, RecordingHost, RecordingHost> {
+    val baked =
+      RecordingHost(
+        previews =
+          listOf(ServePreview(catalogId, catalogId), ServePreview(androidOnlyId, androidOnlyId)),
+        tag = "baked",
+      )
+    val live =
+      RecordingHost(
+        previews = listOf(ServePreview(daemonId, daemonId)),
+        tag = "live",
+        streaming = true,
+      )
+    val composite = ServeCatalogLiveHost(mapOf(catalogId to daemonId), live, baked)
+    return Triple(composite, live, baked)
+  }
+
+  @Test
+  fun `browse surface and knobs come from the baked catalog`() {
+    val (composite, _, baked) = host()
+    assertEquals(baked.previews, composite.previews)
+    // Mapped ids can re-render live, so the viewer should offer editable controls.
+    assertTrue(composite.canApplyOverrides)
+  }
+
+  @Test
+  fun `plain snapshot of a mapped id serves the baked PNG, never the daemon`() {
+    val (composite, live, baked) = host()
+    val out = composite.render(catalogId, PreviewOverrides()) as RenderOutcome.Ok
+    assertEquals("baked:$catalogId", out.png.decodeToString())
+    assertEquals(catalogId, baked.lastRenderId)
+    assertNull(live.lastRenderId) // daemon untouched by ordinary browsing
+  }
+
+  @Test
+  fun `overridden snapshot of a mapped id renders live under the daemon id`() {
+    val (composite, live, _) = host()
+    val out = composite.render(catalogId, PreviewOverrides(density = 2.0f)) as RenderOutcome.Ok
+    assertEquals("live:$daemonId", out.png.decodeToString())
+    assertEquals(daemonId, live.lastRenderId)
+  }
+
+  @Test
+  fun `an unmapped id always serves baked, even with overrides`() {
+    val (composite, live, baked) = host()
+    val out = composite.render(androidOnlyId, PreviewOverrides(density = 2.0f)) as RenderOutcome.Ok
+    assertEquals("baked:$androidOnlyId", out.png.decodeToString())
+    assertEquals(androidOnlyId, baked.lastRenderId)
+    assertNull(live.lastRenderId)
+  }
+
+  @Test
+  fun `live stream is offered for a mapped id under the daemon id`() {
+    val (composite, live, _) = host()
+    val handle = composite.subscribeStream(catalogId, PreviewOverrides(), null, null) {}
+    assertTrue(handle != null)
+    assertEquals(daemonId, live.lastStreamId)
+  }
+
+  @Test
+  fun `an unmapped id has no live stream and never reaches the daemon`() {
+    val (composite, live, _) = host()
+    val handle = composite.subscribeStream(androidOnlyId, PreviewOverrides(), null, null) {}
+    assertNull(handle)
+    assertNull(live.lastStreamId)
+  }
+
+  @Test
+  fun `closing the composite closes both lanes`() {
+    val (composite, live, baked) = host()
+    composite.close()
+    assertTrue(live.closed)
+    assertTrue(baked.closed)
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
@@ -121,6 +121,53 @@ class ServeCatalogStoreTest {
   }
 
   @Test
+  fun `a trusted liveBundle catalog hands the builder the catalog-id to daemon-id alias`() {
+    // A catalog that carries a liveBundle and per-image previewId: the store fetches the bundle and
+    // invokes the live builder with the catalog-id → daemon-id alias so it can bridge the two id
+    // namespaces (see ServeCatalogLiveHost). Only the image that declares a previewId is aliased.
+    val json =
+      """
+      {"schema":"design-parity-catalog/v1","system":"compose-m3",
+       "liveBundle":{"path":"bundle/","file":"compose-m3-bundle.png"},
+       "components":[{"componentId":"Button/Filled","images":[
+         {"path":"images/button-filled/ideal__default__dark.png","theme":"dark","previewId":"FilledButton_Dark"},
+         {"path":"images/button-filled/ideal__keyboard-focus__dark.png","theme":"dark"}]}]}
+      """
+        .trimIndent()
+    val fetch: (String) -> ByteArray? = { url ->
+      when {
+        url.endsWith("/${ServeCatalogStore.CATALOG_FILE}") -> json.toByteArray()
+        url.endsWith("bundle/compose-m3-bundle.png") -> byteArrayOf(1, 2, 3)
+        url.endsWith(".png") -> png()
+        else -> null
+      }
+    }
+    val trust =
+      TrustStore(
+        branches = listOf(TrustedBranch("yschimke/compose-ai-tools", "design-artifacts/*"))
+      )
+    var captured: Map<String, String>? = null
+    val store =
+      ServeCatalogStore(
+        root = tempRoot(),
+        register = { n, h -> registered[n] = h },
+        trust = trust,
+        fetch = fetch,
+        buildTrustedBundle = { _, _, alias, _ ->
+          captured = alias
+          true // pretend the live host took over, so no static host is registered
+        },
+      )
+    val result = store.load("compose-m3")
+
+    assertTrue(result is ServeCatalogStore.Result.Ok)
+    // Only the previewId-bearing image is aliased; the keyboard-focus (Android-only) image is not.
+    assertEquals(mapOf("button-filled__ideal__default__dark" to "FilledButton_Dark"), captured)
+    // The live builder claimed the session, so nothing was registered as a plain static host.
+    assertTrue(registered["compose-m3"] == null)
+  }
+
+  @Test
   fun `an untrusted branch still serves the catalog but unverified`() {
     val result = store(TrustStore.EMPTY).load("compose-m3")
     assertEquals(ServeCatalogStore.Result.Ok("compose-m3", 2, "unverified"), result)
@@ -263,7 +310,7 @@ class ServeCatalogStoreTest {
           else -> null
         }
       },
-      buildTrustedSource = { system, source ->
+      buildTrustedSource = { system, source, _, _ ->
         buildCalls += system to source
         builderResult
       },

--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -527,10 +527,7 @@ if (values["publish-live-bundle"]) {
     }
   }
   if (webRender) manifest.webRender = webRender;
-  if (liveBundle) {
-    manifest.liveBundle = liveBundle;
-    bridgeLivePreviewIds(manifest, spec, bundle, overriddenFunctions);
-  }
+  if (liveBundle) manifest.liveBundle = liveBundle;
   // Buildable source for trusted server-side re-render (opt-in consumer side).
   if (values["source-module"]) {
     manifest.source = {
@@ -539,6 +536,13 @@ if (values["publish-live-bundle"]) {
       module: values["source-module"],
     };
     console.log(`[${spec.system}] source → ${manifest.source.module}@${manifest.source.ref}`);
+  }
+  // Emit the catalog-id → daemon-id bridge whenever a live path can serve this catalog — a carried
+  // liveBundle OR a buildable source. A source-only catalog (wear-m3 / remote-m3) needs the aliases
+  // too: `ServeCatalogStore` builds the alias solely from `image.previewId`, so without this a
+  // `--allow-render-trusted` box would pay the Gradle build yet reach the daemon for no catalog id.
+  if (liveBundle || values["source-module"]) {
+    bridgeLivePreviewIds(manifest, spec, bundle, overriddenFunctions);
   }
   await writeFile(catalogJsonPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
 }

--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -259,6 +259,67 @@ function catalogFromCandidates(candidates, spec, opts = {}) {
 }
 // --- end vendored join --------------------------------------------------------
 
+/**
+ * Theme of a daemon preview id. The catalog's multipreview (`@CatalogModes` /
+ * `@CatalogTemplate`) renders each function in `name = "Light"` / `name = "Dark"`
+ * variants, so the discovered preview id ends with the mode
+ * (`FilledButton_Light` / `FilledButton_Dark`) — the same signal `layoutByFunction`
+ * keys off. Returns "light"/"dark", or null for an un-themed id.
+ */
+function themeOfPreviewId(id) {
+  const s = String(id ?? "").toLowerCase();
+  if (s.endsWith("dark")) return "dark";
+  if (s.endsWith("light")) return "light";
+  return null;
+}
+
+/**
+ * Bridge the two id namespaces so a trusted live serve can answer the published
+ * catalog URLs. A daemon knows previews by their function-based descriptor id
+ * (`FilledButton_Dark`); the published links/routes use the componentId-slug id
+ * derived from `image.path` (`button-filled__ideal__default__dark`). For each
+ * catalog image, resolve `(componentId, state)` → the spec's `@Preview` function,
+ * then `(function, theme)` → the desktop daemon preview id in the bundle, and
+ * record it as `image.previewId`. `ServeCatalogStore.previewAliasFor` reads it back.
+ *
+ * Skips images with no desktop source: a state whose function isn't in the bundle
+ * (nothing to run) and any function replaced by the Android-only supplement
+ * (`overriddenFunctions` — its baked pixels, e.g. the inset focus ring, differ from
+ * what the desktop daemon would draw). Those stay baked-PNG only, with no live lane.
+ */
+function bridgeLivePreviewIds(manifest, spec, bundle, overriddenFunctions) {
+  const previewForState = new Map();
+  for (const group of spec.groups ?? []) {
+    for (const component of group.components ?? []) {
+      previewForState.set(`${component.componentId} default`, component.preview);
+      for (const v of component.variants ?? []) {
+        if (v.state && v.preview) {
+          previewForState.set(`${component.componentId} ${v.state}`, v.preview);
+        }
+      }
+    }
+  }
+  const daemonIdFor = new Map();
+  for (const preview of bundle.previews ?? []) {
+    const fn = preview.functionName ?? preview.id;
+    const theme = themeOfPreviewId(preview.id);
+    if (theme) daemonIdFor.set(`${fn} ${theme}`, preview.id);
+  }
+  let mapped = 0;
+  for (const component of manifest.components ?? []) {
+    for (const image of component.images ?? []) {
+      const fn = previewForState.get(`${component.componentId} ${image.state ?? "default"}`);
+      if (!fn || overriddenFunctions.has(fn)) continue;
+      const daemonId = image.theme ? daemonIdFor.get(`${fn} ${image.theme}`) : undefined;
+      if (daemonId) {
+        image.previewId = daemonId;
+        mapped++;
+      }
+    }
+  }
+  console.log(`[${spec.system}] bridged ${mapped} live preview id(s) → daemon`);
+}
+
 const { values } = parseArgs({
   options: {
     spec: { type: "string" },
@@ -327,9 +388,14 @@ const { candidates, bundle } = await loadCandidates(rendersPath);
 // Android-only render (the material3 1.5.0-alpha inset focus ring, which CMP can't
 // draw) replace the CMP module's render of that function — so a mostly-CMP catalog
 // still carries the real focus-ring variant. The supplement's render + semantics win.
+// Functions whose render was replaced by the Android-only supplement. Their baked pixels differ
+// from what the desktop daemon (`bundle.previews`) would draw (e.g. the focus ring CMP can't paint),
+// so the live-preview bridge below MUST NOT map them to a desktop preview — they stay baked-only.
+const overriddenFunctions = new Set();
 if (values["extra-renders"]) {
   const { candidates: extra } = await loadCandidates(resolve(values["extra-renders"]));
   const overridden = new Set(extra.map(functionOf));
+  for (const fn of overridden) overriddenFunctions.add(fn);
   for (let i = candidates.length - 1; i >= 0; i--) {
     if (overridden.has(functionOf(candidates[i]))) candidates.splice(i, 1);
   }
@@ -461,7 +527,10 @@ if (values["publish-live-bundle"]) {
     }
   }
   if (webRender) manifest.webRender = webRender;
-  if (liveBundle) manifest.liveBundle = liveBundle;
+  if (liveBundle) {
+    manifest.liveBundle = liveBundle;
+    bridgeLivePreviewIds(manifest, spec, bundle, overriddenFunctions);
+  }
   // Buildable source for trusted server-side re-render (opt-in consumer side).
   if (values["source-module"]) {
     manifest.source = {


### PR DESCRIPTION
## Summary

Follow-up to #2246, fixing the **P1 raised in its review**.

The live daemon tier keys previews by their function-based descriptor id (`FilledButton_Dark`), but every published `design-artifacts/<system>` catalog link and image route uses the componentId-slug id (`button-filled__ideal__default__dark`). So registering a bare daemon host for a catalog would **404 every published `/compose-m3/p/<id>` deep link and `/render/<id>.png` thumbnail** — and it can't serve the ids the desktop daemon doesn't have at all (the Android-only inset focus-ring variant, baked in from a separate supplement).

This was latent until #2246: the source-build path fails closed on the desktop-only public box, so no daemon catalog session ever actually registered. The bundle path #2246 added is the first that succeeds by default — activating the bug the moment a `liveBundle` is published. **No `liveBundle` is on the branches yet, so production is currently unaffected** (it falls back to baked PNG); this must land before the `design-artifacts` branches are regenerated.

### Fix: front the daemon with the baked catalog, don't replace it

- **`ServeCatalogLiveHost`** composes the static baked-PNG host (the browse surface — grid, deep links, thumbnails, all unchanged) with the daemon live lane:
  - **Plain snapshot** → baked PNG, so ordinary browsing never wakes the daemon.
  - **Override edit / live stream on a mapped id** → daemon, under its daemon-preview id.
  - **Unmapped id** (Android-only focus ring) → baked PNG, no live lane.
- The bridge is a **catalog-id → daemon-id alias** the exporter records per image. `generate-design-catalog.mjs` joins the spec's `(componentId, state) → function` with each desktop preview's `(function, theme)` and writes `image.previewId`. Android-overridden functions (the focus ring) are deliberately left **unmapped** so their live render can't contradict the baked pixels.
- **`ServeCatalogStore`** parses `image.previewId`, builds the alias, and hands both live builders (bundle + source) the alias plus a baked-fallback factory. **`ServeSessionState`** carries both, so `openHost` rebuilds the composite on every resume — suspend/resume preserved.

## Test plan

- `ServeCatalogLiveHostTest` — routing: plain snapshot → baked (daemon untouched); override snapshot → daemon under daemon id; unmapped id → baked even with overrides; stream only for mapped ids; close closes both lanes.
- `ServeCatalogStoreTest` — a trusted `liveBundle` catalog hands the builder the correct `{catalog-id → daemon-id}` alias, and only `previewId`-bearing images are aliased.
- `./gradlew :cli:test` green; ktfmt clean; generator `node --check` clean.

Text-only: serve-subsystem id plumbing + the exporter's alias emission. No rendered-surface change — the baked pixels the catalog ships are unchanged; this only makes the published ids resolve (and adds a live lane for the CMP ids the desktop daemon can run).

## Ordering

After this merges, dispatch `design-artifacts.yml` (ref `main`) so `design-artifacts/compose-m3` gets both the `liveBundle` **and** the per-image `previewId` map. Only then does the config-less live CMP tier have a bundle to launch — and it resolves the published URLs correctly from the first request.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WGVyWcXTvsYbmCtLEXU7tn)_