### PR TITLE
feat(slots): add slot-preview-runtime with the PreviewSlot marker

### DIFF
--- a/runtimes/slots/build.gradle.kts
+++ b/runtimes/slots/build.gradle.kts
@@ -1,0 +1,45 @@
+// `:slot-preview-runtime` — composable-helper authoring path for **structured-screen slots**.
+//
+// `PreviewSlot("leadingIcon") { … }` marks a named region of a preview so a structured-screen
+// builder (the design-parity Figma plugin) can fill it with a child component. It is a **no-op in a
+// normal render** — it just draws its content, tagged with `testTag = "dp-slot:<name>"` so the
+// region is captured into the semantics tree with its bounds (which the `/render/<id>.slots` route
+// reads). Under `LocalSlotMode` (the daemon's `slotMode` render override, follow-up) it renders a
+// translucent labelled `SlotPlaceholder` instead, so a designer sees exactly where each slot is and
+// drops a composable into that precise box.
+//
+// Standalone on purpose — no compile dep on `:renderer-desktop`. The renderer/daemon depend *onto*
+// this module to `CompositionLocalProvider(LocalSlotMode provides …)` around the rendered content,
+// exactly as they do for `:lottie-preview-runtime`'s `LocalLottieProgress`.
+
+plugins {
+  id("composeai.base-conventions")
+  id("composeai.maven-publishing")
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.compose.multiplatform)
+  alias(libs.plugins.compose.compiler)
+}
+
+dependencies {
+  api(libs.jetbrains.compose.runtime)
+  api(libs.jetbrains.compose.foundation)
+  api(libs.jetbrains.compose.ui)
+
+  // The `dp-slot:` tag prefix has a single source of truth in the reader
+  // (`PreviewSlots.SLOT_TAG_PREFIX`); a test asserts this module's copy agrees so the two can't
+  // drift. Test-only so the marker's runtime classpath stays serialization-free.
+  testImplementation(project(":data-layoutinspector-core"))
+  testImplementation(libs.junit)
+}
+
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "slot-preview-runtime",
+    displayName = "Compose Preview — Slot Runtime",
+    description =
+      "Composable helper that marks a named slot region of a Compose `@Preview` (a `dp-slot:` " +
+        "testTag captured with its bounds) so a structured-screen builder can fill it with a child " +
+        "component; under a slot-mode override it renders a labelled placeholder for the designer.",
+  )
+  inceptionYear.set("2026")
+}

--- a/runtimes/slots/src/main/kotlin/ee/schimke/composeai/preview/slots/PreviewSlot.kt
+++ b/runtimes/slots/src/main/kotlin/ee/schimke/composeai/preview/slots/PreviewSlot.kt
@@ -1,0 +1,88 @@
+package ee.schimke.composeai.preview.slots
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.sp
+
+/**
+ * The `testTag` prefix a [PreviewSlot] applies; the slot name is the suffix (`dp-slot:<name>`).
+ *
+ * The **reader** side (`data-layoutinspector-core`'s `PreviewSlots.SLOT_TAG_PREFIX`) is the single
+ * source of truth; this module keeps its own copy so its runtime classpath stays free of the
+ * serialization dependency, and a test asserts the two agree so they can't drift.
+ */
+const val SLOT_TAG_PREFIX: String = "dp-slot:"
+
+/** The `testTag` a `PreviewSlot(name)` applies: `dp-slot:<name>`. */
+fun slotTag(name: String): String = "$SLOT_TAG_PREFIX$name"
+
+/**
+ * Whether the composition is rendering in **slot mode** — the "author a screen" pass. When `true`,
+ * a [PreviewSlot] renders a labelled [SlotPlaceholder] in place of its content; when `false` (the
+ * default) it renders its content unchanged.
+ *
+ * The daemon's `slotMode` render override provides this around the rendered preview (follow-up),
+ * the same way `LocalLottieProgress` is provided for the Lottie runtime — so `/render/<id>.png`
+ * shows the real preview and `/render/<id>.png?slotMode=true` shows the slot map, both from one
+ * preview.
+ */
+val LocalSlotMode: ProvidableCompositionLocal<Boolean> = compositionLocalOf { false }
+
+/**
+ * Marks [content] as a named slot region a structured-screen builder can fill with a child.
+ *
+ * **A no-op in a normal render**: it draws [content] inside a [Box] carrying `testTag =
+ * "[SLOT_TAG_PREFIX]<name>"`. `testTag` is a semantics property (no visual/layout effect of its
+ * own), so the region is captured into the `compose/semantics` tree with its `boundsInRoot` — which
+ * the `/render/<id>.slots` route distils into `{ name, bounds }`. Under [LocalSlotMode] it renders
+ * a translucent [SlotPlaceholder] labelled [name] instead of [content], so a designer sees exactly
+ * where the slot is and drops a composable into that precise box.
+ *
+ * Give the slot a size (via [modifier], or by placing it in a sized parent — a fixed icon box, a
+ * `Row` weight): that box is both what the placeholder fills and the constraint a child rendered to
+ * fill the slot is given.
+ *
+ * @param name the slot's author-declared name (the `dp-slot:` suffix); should be non-blank.
+ */
+@Composable
+fun PreviewSlot(name: String, modifier: Modifier = Modifier, content: @Composable () -> Unit) {
+  Box(modifier.testTag(slotTag(name))) {
+    if (LocalSlotMode.current) SlotPlaceholder(name) else content()
+  }
+}
+
+/**
+ * A translucent, labelled stand-in for an empty slot — a 50%-opacity fill with the slot [name]
+ * centred on it, filling its box. This is what a [PreviewSlot] renders under [LocalSlotMode]: the
+ * self-evident target a designer selects to place a different composable in precise position.
+ *
+ * Fills its parent's constraints ([fillMaxSize]), so it takes the size the slot's box gives it — a
+ * slot with no size collapses to nothing, which is why a slot should carry one (see [PreviewSlot]).
+ */
+@Composable
+fun SlotPlaceholder(name: String, modifier: Modifier = Modifier) {
+  Box(
+    modifier.fillMaxSize().background(SLOT_PLACEHOLDER_COLOR),
+    contentAlignment = Alignment.Center,
+  ) {
+    BasicText(name, style = SLOT_PLACEHOLDER_TEXT_STYLE)
+  }
+}
+
+/** The slot placeholder's fill — a distinct accent at 50% opacity (`0x80` alpha). */
+private val SLOT_PLACEHOLDER_COLOR: Color = Color(0x804F46E5)
+
+/** The slot label's text style — white, centred, small, so it reads on the translucent fill. */
+private val SLOT_PLACEHOLDER_TEXT_STYLE: TextStyle =
+  TextStyle(color = Color.White, fontSize = 12.sp, textAlign = TextAlign.Center)

--- a/runtimes/slots/src/test/kotlin/ee/schimke/composeai/preview/slots/PreviewSlotTest.kt
+++ b/runtimes/slots/src/test/kotlin/ee/schimke/composeai/preview/slots/PreviewSlotTest.kt
@@ -1,0 +1,20 @@
+package ee.schimke.composeai.preview.slots
+
+import ee.schimke.composeai.data.layoutinspector.PreviewSlots
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class PreviewSlotTest {
+
+  @Test
+  fun `slotTag prefixes the name with the dp-slot marker`() {
+    assertEquals("dp-slot:leadingIcon", slotTag("leadingIcon"))
+    assertEquals("dp-slot:", slotTag(""))
+  }
+
+  @Test
+  fun `the marker prefix agrees with the reader's source of truth`() {
+    // The extractor keys off this exact prefix; if the two drift, slots stop being discovered.
+    assertEquals(PreviewSlots.SLOT_TAG_PREFIX, SLOT_TAG_PREFIX)
+  }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -172,6 +172,10 @@ include(":svg-preview-runtime")
 
 project(":svg-preview-runtime").projectDir = file("runtimes/svg")
 
+include(":slot-preview-runtime")
+
+project(":slot-preview-runtime").projectDir = file("runtimes/slots")
+
 include(":samples:android")
 
 // Compose Material 3 **design catalog** — one `@Preview` per component in its


### PR DESCRIPTION
## Summary

The **author-facing half** of the structured-screen builder: a new `:slot-preview-runtime` module (sibling of `:lottie-preview-runtime`) that lets a preview author mark named slot regions a designer can fill with child components. Pairs with the `/render/<id>.slots` route + extractor that just merged (#2248).

`PreviewSlot("leadingIcon"){ … }` is **a wrapper that's a no-op in a normal render and swaps its content for a placeholder only under slot-mode** — exactly the shape we settled on:

```kotlin
@Composable
fun PreviewSlot(name: String, modifier: Modifier = Modifier, content: @Composable () -> Unit) {
  Box(modifier.testTag("dp-slot:$name")) {
    if (LocalSlotMode.current) SlotPlaceholder(name) else content()
  }
}
```

- **Normal render:** draws `content` in a `Box` carrying `testTag = "dp-slot:<name>"`. `testTag` is a semantics-only property (no visual/layout effect), so the region is captured into the `compose/semantics` tree with its `boundsInRoot` — which `/render/<id>.slots` distils into `{ name, bounds }`. So slot *discovery* works against the plain render; wrapping a predictable label costs nothing visible.
- **Slot mode:** under `LocalSlotMode`, renders a translucent (`0x80` alpha) labelled `SlotPlaceholder` filling the slot's box — the self-evident target a designer selects to place a different composable in precise position.
- **`LocalSlotMode`** is the `slotMode` CompositionLocal the render harness will provide around the rendered preview (follow-up), mirroring how `:lottie-preview-runtime` provides `LocalLottieProgress`. Default `false`, so a plain `@Preview` is unaffected.
- **`SLOT_TAG_PREFIX`** is kept module-local so the marker's runtime classpath stays serialization-free; a test asserts it equals the reader's `PreviewSlots.SLOT_TAG_PREFIX` (`data-layoutinspector-core`) so the two can't drift.

**Module type:** standalone `kotlin.jvm` + `compose.multiplatform`, matching the sibling desktop/JVM runtimes (`:lottie-preview-runtime`, `:svg-preview-runtime`) — no dep on the renderer; the renderer/daemon depend *onto* this module to `CompositionLocalProvider(LocalSlotMode provides …)`, exactly as they do for Lottie's `LocalLottieProgress`. It's consumed from **JVM source sets** — the desktop `@Preview` sheet (`:samples:design-catalog-m3`, the render source of truth) and Android — so the slotted-card sample is marked there, not in a KMP `commonMain` body. (Per Codex review: a `kotlin.jvm` module publishes no metadata variant, so it can't be a KMP `commonMain` dependency. Making the shared `commonMain` catalog bodies — and thus the wasm tier — carry slots would require converting this to a true KMP module; tracked as a follow-up rather than making slots the lone KMP runtime.)

## Where it fits

```
author: PreviewSlot(name){content}   ──normal──▶  content, tagged dp-slot:<name>  ──▶  /render/<id>.slots → {name,bounds}
                                     ──slotMode─▶  translucent SlotPlaceholder("name")   (designer sees + selects the box)
```

## Test plan

- `PreviewSlotTest` (JVM): `slotTag(name)` prefixes `dp-slot:`; the module's `SLOT_TAG_PREFIX` equals the reader's `PreviewSlots.SLOT_TAG_PREFIX` (drift guard).
- Mirrors the CI-clean `:lottie-preview-runtime` build wiring (plugins, publishing coordinates, settings registration). ktfmt verified locally against the pinned tool.

## Visual evidence

Text-only intentionally: this PR adds the composable **primitive** but no `@Preview` renders `SlotPlaceholder` yet, so there is no changed rendered surface to diff. The marked sample that exercises `PreviewSlot`/`SlotPlaceholder` — with before/after (normal vs slot-mode) render evidence — lands in the fast-follow that also registers it with the preview harness, closing the visual-coverage gap there. (Rendering isn't possible in this headless container regardless; CI's render pipeline captures it once a preview uses it.)

## Follow-ups

- **`slotMode` render override** — thread a `Boolean? slotMode` through `PreviewOverrides` → `ServeOverrides` (+ design-parity `render.ts` key) → `JsonRpcServer` → both `RenderEngine`s as `CompositionLocalProvider(LocalSlotMode provides …)`, so `/render/<id>.png?slotMode=true` flips it per-request (mirrors `inspectionMode` end-to-end).
- **Marked sample + visual evidence** — a slotted M3 Card in the JVM desktop `@Preview` sheet, normal vs slot-mode, wired into the preview harness.
- **(If wanted) KMP conversion** — make `:slot-preview-runtime` a true `kotlin.multiplatform` module so the shared `commonMain` catalog bodies (and the wasm tier) can call `PreviewSlot`.
- **design-parity**: place a frame per slot from `/render/<id>.slots`, then fill each by live-rendering a child at the slot's exact size.

---
_Generated by [Claude Code](https://claude.ai/code/session_018uTv78jpPEKSEyScXoCdYD)_