### PR TITLE
feat(design-catalog): render an icon+label FilledButton (content-axis groundwork)

### DIFF
--- a/samples/design-catalog-m3-shared/src/commonMain/kotlin/com/example/designcatalogm3/shared/CatalogComponents.kt
+++ b/samples/design-catalog-m3-shared/src/commonMain/kotlin/com/example/designcatalogm3/shared/CatalogComponents.kt
@@ -6,11 +6,13 @@ import androidx.compose.foundation.interaction.FocusInteraction
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.PressInteraction
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.Badge
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CircularProgressIndicator
@@ -20,6 +22,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedCard
@@ -42,6 +45,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 
@@ -117,6 +124,17 @@ fun CatalogComponent(id: String, interactive: Boolean) {
       Button(onClick = {}, interactionSource = pressedSource()) { Text("Pressed") }
     "button-filled-focused" ->
       Button(onClick = {}, interactionSource = focusedSource()) { Text("Focused") }
+    // Content axis (not a state): the same Filled button with a leading icon + label, so the
+    // catalog shows the icon-and-text configuration alongside the label-only default. The icon is
+    // an inline `ImageVector` (a plus glyph) — this module deliberately carries no icon library,
+    // and
+    // `Icon` tints it with the button's content color regardless of the vector's own fill.
+    "button-filled-icon-label" ->
+      Button(onClick = {}) {
+        Icon(addGlyph, contentDescription = null, modifier = Modifier.size(ButtonDefaults.IconSize))
+        Spacer(Modifier.size(ButtonDefaults.IconSpacing))
+        Text("Filled")
+      }
     "button-outlined-disabled" -> OutlinedButton(onClick = {}, enabled = false) { Text("Disabled") }
     "switch-off" ->
       if (interactive) StatefulSwitch(false) else Switch(checked = false, onCheckedChange = {})
@@ -175,6 +193,7 @@ val catalogComponentIds: List<String> =
     "textfield-outlined",
     "button-filled-pressed",
     "button-filled-focused",
+    "button-filled-icon-label",
     "button-outlined-disabled",
     "switch-off",
     "checkbox-unchecked",
@@ -184,6 +203,39 @@ val catalogComponentIds: List<String> =
     "text-serif",
     "text-monospace",
   )
+
+/**
+ * A minimal "add" (plus) glyph as an inline [ImageVector], for the `button-filled-icon-label`
+ * content variant. Built by hand because this catalog module carries no `material-icons`
+ * dependency; `Icon` recolors it to the button's content color, so the vector's own fill is
+ * irrelevant. A 12×12 plus centered in the standard 24dp icon viewport.
+ */
+private val addGlyph: ImageVector =
+  ImageVector.Builder(
+      name = "Add",
+      defaultWidth = 24.dp,
+      defaultHeight = 24.dp,
+      viewportWidth = 24f,
+      viewportHeight = 24f,
+    )
+    .apply {
+      path(fill = SolidColor(Color.Black)) {
+        moveTo(11f, 5f)
+        lineTo(13f, 5f)
+        lineTo(13f, 11f)
+        lineTo(19f, 11f)
+        lineTo(19f, 13f)
+        lineTo(13f, 13f)
+        lineTo(13f, 19f)
+        lineTo(11f, 19f)
+        lineTo(11f, 13f)
+        lineTo(5f, 13f)
+        lineTo(5f, 11f)
+        lineTo(11f, 11f)
+        close()
+      }
+    }
+    .build()
 
 // --- Interactive state holders: a browser visitor can actually toggle these. ---
 

--- a/samples/design-catalog-m3/src/main/kotlin/com/example/designcatalogm3/CatalogPreviews.kt
+++ b/samples/design-catalog-m3/src/main/kotlin/com/example/designcatalogm3/CatalogPreviews.kt
@@ -92,6 +92,8 @@ import com.example.designcatalogm3.shared.CatalogComponent
 
 @CatalogModes @Composable fun FilledButtonFocused() = Sticker("button-filled-focused")
 
+@CatalogModes @Composable fun FilledButtonIconLabel() = Sticker("button-filled-icon-label")
+
 @CatalogModes @Composable fun OutlinedButtonDisabled() = Sticker("button-outlined-disabled")
 
 @CatalogModes @Composable fun SwitchOff() = Sticker("switch-off")


### PR DESCRIPTION
## Summary

Adds an **icon+label** configuration of the M3 filled button to the render set: a `button-filled-icon-label` shared component (`Button` with a leading `Icon` sized to `ButtonDefaults.IconSize` + `IconSpacing` + label) and a `FilledButtonIconLabel` `@CatalogModes @Preview`. The glyph is an inline plus `ImageVector` — this module deliberately carries **no `material-icons` dependency**, and `Icon` tints it to the button's content color regardless of the vector's own fill. The id is registered in `catalogComponentIds` so the wasm tier resolves it too.

This lands the **render only**. It's the groundwork for a content-axis (`props`) catalog variant; the actual `catalog.spec.json` declaration is deferred — see below.

## Visual evidence

The compose-preview CI check rendered the real Compose preview in both modes:

| Light | Dark |
|---|---|
| ![FilledButtonIconLabel light](``https://raw.githubusercontent.com/yschimke/compose-ai-tools/e399f68240ac0e778d4c09e1fade117f2b0bd197/renders/samples:design-catalog-m3/FilledButtonIconLabel_Light.png)`` | ![FilledButtonIconLabel dark](``https://raw.githubusercontent.com/yschimke/compose-ai-tools/e399f68240ac0e778d4c09e1fade117f2b0bd197/renders/samples:design-catalog-m3/FilledButtonIconLabel_Dark.png)`` |

A filled button with a leading plus icon + "Filled" label, visually distinct from the label-only default — the `content: icon+label` axis.

## Why the catalog declaration is deferred

Declaring this in `catalog.spec.json` as a `{ props: { content: "icon+label" } }` variant is intentionally **not** in this PR. The regeneration path (`scripts/design-artifacts`) pins `@design-parity/catalog-export@^0.1.20`, and that published engine folds variants by `state` only (`foldVariants` re-tags every variant image with `variant.state`, and `bridgeLivePreviewIds` keys solely on state). A `props`-only variant would be emitted as another `default`-state image and collide with the label-only default's path / live-preview mapping — exactly the failure the Codex review flagged.

The `props` model exists in the design-parity source but isn't published to npm yet (latest is `0.1.24`, still state-only). Once a props-capable `catalog-export` is released and pinned here, a fast-follow adds the one-line `variants` entry. Landing the render now keeps the preview under CI diff coverage in the meantime.

## Test plan

- `ktfmt --google-style` clean on both touched Kotlin files (verified locally).
- compose-preview CI renders + diffs `FilledButtonIconLabel` (light + dark) — see above.
- No `catalog.spec.json` change, so `design-artifacts.yml` regeneration is unaffected.