### PR TITLE
feat(serve): add the slotMode render override (desktop path)

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeOverrides.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeOverrides.kt
@@ -54,6 +54,7 @@ object ServeOverrides {
       "heightPx",
       "orientation",
       "inspectionMode",
+      "slotMode",
     )
 
   /**
@@ -145,6 +146,19 @@ object ServeOverrides {
           }
         }
 
+    val slotMode =
+      params["slotMode"]
+        ?.takeIf { it.isNotBlank() }
+        ?.let {
+          when (it.lowercase()) {
+            "true",
+            "1" -> true
+            "false",
+            "0" -> false
+            else -> return OverrideParse.Invalid("slotMode must be a boolean, got '$it'")
+          }
+        }
+
     // Named-override knobs (`knob.<key>=<kind>:<value>`). A malformed typed value is a hard
     // Invalid (mirrors the numeric fields) rather than a silently-dropped edit.
     val namedOverrides = mutableMapOf<String, PreviewOverrideValue>()
@@ -191,6 +205,7 @@ object ServeOverrides {
         orientation = orientation,
         device = params["device"]?.takeIf { it.isNotBlank() },
         inspectionMode = inspectionMode,
+        slotMode = slotMode,
         namedOverrides = namedOverrides.ifEmpty { null },
       )
     )
@@ -214,6 +229,7 @@ object ServeOverrides {
       append("or=").append(o.orientation).append('|')
       append("dev=").append(o.device).append('|')
       append("insp=").append(o.inspectionMode).append('|')
+      append("slot=").append(o.slotMode).append('|')
       // Named overrides participate so a knob edit isn't coalesced onto the prior render. Sorted by
       // key for order-independence; the value data classes have stable toString.
       append("named=")

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeOverridesTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeOverridesTest.kt
@@ -32,6 +32,7 @@ class ServeOverridesTest {
     assertNull(o.heightPx)
     assertNull(o.density)
     assertNull(o.inspectionMode)
+    assertNull(o.slotMode)
   }
 
   @Test
@@ -48,6 +49,7 @@ class ServeOverridesTest {
           "heightPx" to "800",
           "orientation" to "landscape",
           "inspectionMode" to "true",
+          "slotMode" to "true",
         )
       )
     assertEquals(UiMode.DARK, o.uiMode)
@@ -59,6 +61,7 @@ class ServeOverridesTest {
     assertEquals(800, o.heightPx)
     assertEquals(Orientation.LANDSCAPE, o.orientation)
     assertEquals(true, o.inspectionMode)
+    assertEquals(true, o.slotMode)
   }
 
   @Test
@@ -81,6 +84,7 @@ class ServeOverridesTest {
         mapOf("widthPx" to "wide"),
         mapOf("widthPx" to "-5"),
         mapOf("inspectionMode" to "maybe"),
+        mapOf("slotMode" to "maybe"),
       )) {
       val parsed = ServeOverrides.parse(bad)
       assertTrue(parsed is OverrideParse.Invalid, "expected Invalid for $bad, got $parsed")
@@ -106,6 +110,11 @@ class ServeOverridesTest {
     assertNotEquals(
       ServeOverrides.cacheKey("preview.A", base),
       ServeOverrides.cacheKey("preview.B", base),
+    )
+    // slotMode participates, so a slot-map render isn't coalesced onto the normal render's cache.
+    assertNotEquals(
+      ServeOverrides.cacheKey("preview.A", ok(mapOf("slotMode" to "true"))),
+      ServeOverrides.cacheKey("preview.A", ok(emptyMap())),
     )
   }
 

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -1054,6 +1054,10 @@ class JsonRpcServer(
         if (isNotEmpty()) append(';')
         append("inspectionMode=").append(it)
       }
+      overrides.slotMode?.let {
+        if (isNotEmpty()) append(';')
+        append("slotMode=").append(it)
+      }
       // Extension-driven overrides ride along as a single base64-encoded `PreviewOverrides`
       // bag — the renderer's [PreviewOverrideExtensions] hands the bag to every registered
       // planner. New override-driven fields don't need a new wire token; they ride this bag.

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -522,6 +522,14 @@ data class PreviewOverrides(
    */
   val inspectionMode: Boolean? = null,
   /**
+   * Per-render **slot mode** for one-shot renders. When `true`, a `PreviewSlot(name) { … }` marker
+   * (`:slot-preview-runtime`) renders a labelled placeholder in place of its content, so a
+   * structured-screen builder gets a visible slot map; `null`/`false` renders the content normally.
+   * The renderer applies it by providing `LocalSlotMode` around the preview. Backends that don't
+   * provide the local ignore it (the marker defaults to content).
+   */
+  val slotMode: Boolean? = null,
+  /**
    * Optional Material 3 theme token overrides applied by the renderer as a normal
    * `MaterialTheme(...) { preview() }` wrapper around the invoked preview. This lets callers test
    * components under alternate color, shape, or typography tokens without editing source previews.

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/DeviceOverrideEncodingTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/DeviceOverrideEncodingTest.kt
@@ -96,6 +96,13 @@ class DeviceOverrideEncodingTest {
     assertContainsToken("inspectionMode=false", captured)
   }
 
+  @Test(timeout = 30_000)
+  fun slotModeOverrideThreadsThroughPayload() {
+    val captured = renderAndCapturePayload(overrides = """{"slotMode":true}""")
+
+    assertContainsToken("slotMode=true", captured)
+  }
+
   private fun assertContainsToken(token: String, payload: String) {
     val tokens = payload.split(';')
     assertTrue(

--- a/daemon/desktop/build.gradle.kts
+++ b/daemon/desktop/build.gradle.kts
@@ -132,6 +132,9 @@ dependencies {
   // (brings Compottie transitively). Direct dep — `:renderer-desktop` carries it only as
   // `implementation`, so it isn't on this module's compile classpath otherwise.
   implementation(project(":lottie-preview-runtime"))
+  // Slot mode: RenderEngine provides `LocalSlotMode` (from `:slot-preview-runtime`) around the
+  // rendered content, so a `PreviewSlot` marker draws a placeholder when `slotMode` is set.
+  implementation(project(":slot-preview-runtime"))
 
   // Compose runtime / foundation / ui — the B-desktop.1.4 RenderEngine body
   // imports `ImageComposeScene`, `@Composable`, `currentComposer`,

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
@@ -206,6 +206,7 @@ open class DesktopHost(
     add("orientation")
     add("device")
     add("inspectionMode")
+    add("slotMode")
     add("material3Theme")
     add("wallpaper")
     // Issue #1205 — `renderNow.overrides.focus` is honoured by the planner registered in

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
@@ -718,6 +718,7 @@ open class DesktopHost(
         },
       orientation = orientation,
       inspectionMode = map["inspectionMode"]?.toBooleanStrictOrNull() ?: base.inspectionMode,
+      slotMode = map["slotMode"]?.toBooleanStrictOrNull() ?: base.slotMode,
     )
   }
 

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
@@ -147,6 +147,7 @@ class PreviewManifestRouter(
             inbound["orientation"]?.let { append("orientation=").append(it).append(';') }
             inbound["captureAdvanceMs"]?.let { append("captureAdvanceMs=").append(it).append(';') }
             inbound["inspectionMode"]?.let { append("inspectionMode=").append(it).append(';') }
+            inbound["slotMode"]?.let { append("slotMode=").append(it).append(';') }
             inbound["overrides"]?.let { append("overrides=").append(it).append(';') }
             // `@PreviewWrapper(SomeProvider::class)` FQN sourced from `previews.json` (the
             // gradle plugin's `extractWrapperFqn` reads it off the class-file annotation tables

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -301,6 +301,9 @@ class RenderEngine(
             }
           CompositionLocalProvider(
             LocalInspectionMode provides inspectionMode,
+            // Slot mode: a `PreviewSlot` marker renders a labelled placeholder instead of its
+            // content, so a structured-screen builder gets a visible slot map. Defaults false.
+            ee.schimke.composeai.preview.slots.LocalSlotMode provides (spec.slotMode ?: false),
             androidx.compose.ui.LocalSystemTheme provides systemTheme,
             LocalDensity provides density,
             // Interactive Lottie scrubbing: a non-null progress lands the captured frame at that
@@ -1060,6 +1063,12 @@ data class RenderSpec(
    */
   val inspectionMode: Boolean? = null,
   /**
+   * Per-render slot mode. When `true` the renderer provides `LocalSlotMode = true`, so a
+   * `PreviewSlot` marker renders a labelled placeholder instead of its content. Null/false renders
+   * content normally.
+   */
+  val slotMode: Boolean? = null,
+  /**
    * Per-call overrides bag, threaded through every registered [PreviewOverrideExtension]. The
    * renderer doesn't read individual fields directly — registered planners decide what to apply.
    * Direct-applied overrides like size, density, and locale stay on this spec's typed fields above
@@ -1147,6 +1156,7 @@ data class RenderSpec(
             else -> null
           },
         inspectionMode = map["inspectionMode"]?.toBooleanStrictOrNull(),
+        slotMode = map["slotMode"]?.toBooleanStrictOrNull(),
         overrides = map["overrides"]?.decodePreviewOverrides(),
         wrapperClassName = map["wrapperClassName"]?.takeIf { it.isNotBlank() },
       )


### PR DESCRIPTION
## Summary

A new boolean **`slotMode`** render override: when `true`, the desktop renderer provides `LocalSlotMode = true` around the preview, so a `PreviewSlot` marker (`:slot-preview-runtime`) draws a labelled placeholder instead of its content. `GET /render/<id>.png?slotMode=true` now returns the **slot map** (the visible boxes a structured-screen builder drops children into); the plain render is unchanged. Completes the loop: author marks slots → `/render/<id>.slots` gives the bounds → `?slotMode=true` gives the matching visual.

It's threaded end-to-end on the serve `renderNow` path, mirroring `inspectionMode` at **every** link so nothing silently drops it (I traced the whole chain — the router rewrite is a link the initial design missed):

- **`PreviewOverrides.slotMode`** — the wire field.
- **`ServeOverrides`** — `SUPPORTED_KEYS` + boolean parse (rejects non-booleans) + `cacheKey` (so a slot-map render isn't coalesced onto the normal render's cache) + constructor.
- **`JsonRpcServer.encodeRenderPayload`** appends `slotMode`; **`PreviewManifestRouter` (desktop)** re-appends it when it rewrites the payload — *the link that would otherwise drop it*; **`RenderSpec.parseFromPayload`** reads it; **`RenderEngine`** provides `LocalSlotMode` from `spec.slotMode`.
- **`DesktopHost`** advertises `slotMode` in `supportedOverrides` (so MCP/clients don't flag it as ignored).
- **`daemon-desktop`** depends on `:slot-preview-runtime`.

## Scope

**Desktop only.** The Android backend doesn't yet depend on a preview-runtime, and the recording / interactive-session paths and the MCP `render` tool schema also carry `inspectionMode` — those are follow-ups. A backend that doesn't provide `LocalSlotMode` simply renders content (the marker's graceful default), so nothing breaks. Desktop is the render source of truth for the design catalog + the serve host, which is what the plugin/demo uses.

## Test plan

- `ServeOverridesTest`: `slotMode` parses to the typed field, is `null` when absent, is rejected when non-boolean, and participates in the cache key (so `?slotMode=true` doesn't collide with the normal render).
- `DeviceOverrideEncodingTest.slotModeOverrideThreadsThroughPayload`: a full `initialize → renderNow` round-trip asserts `slotMode=true` reaches the host payload via `encodeRenderPayload` (mirrors the existing `inspectionMode` payload test).
- Non-visual plumbing change (no rendered surface changes in this PR — nothing yet sets `slotMode` in a committed preview). The *visual* payoff lands in the fast-follow that marks a slotted M3 Card and renders it with `?slotMode=true` / a slot-mode sticker, with before/after evidence through the preview harness. ktfmt verified locally against the pinned tool; relying on CI for the compile.

## Follow-ups

- **design-parity `render.ts`** — add `slotMode` to `SUPPORTED_OVERRIDE_KEYS` so the plugin can request it (tiny, separate PR).
- **Marked slotted M3 Card + visual evidence** — the shared `commonMain` catalog body, normal vs slot-mode, wired into the preview harness.
- **Android + recording/interactive + MCP schema** — extend `slotMode` to the remaining `inspectionMode` surfaces.

---
_Generated by [Claude Code](https://claude.ai/code/session_018uTv78jpPEKSEyScXoCdYD)_