### PR TITLE
feat(catalog): add a slotted M3 Card demonstrating PreviewSlot

### DIFF
--- a/samples/design-catalog-m3-shared/build.gradle.kts
+++ b/samples/design-catalog-m3-shared/build.gradle.kts
@@ -62,6 +62,10 @@ kotlin {
       @Suppress("DEPRECATION") implementation(compose.foundation)
       @Suppress("DEPRECATION") implementation(compose.material3)
       @Suppress("DEPRECATION") implementation(compose.ui)
+      // `PreviewSlot` / `LocalSlotMode` for the slotted-card component. `api` so the desktop
+      // sticker
+      // sheet (`:samples:design-catalog-m3`) can provide `LocalSlotMode` for its slot-mode sticker.
+      api(project(":slot-preview-runtime"))
     }
   }
 }

--- a/samples/design-catalog-m3-shared/src/commonMain/kotlin/com/example/designcatalogm3/shared/CatalogComponents.kt
+++ b/samples/design-catalog-m3-shared/src/commonMain/kotlin/com/example/designcatalogm3/shared/CatalogComponents.kt
@@ -209,6 +209,7 @@ val catalogComponentIds: List<String> =
     "card-elevated",
     "card-outlined",
     "card-filled",
+    "card-slots",
     "fab",
     "progress-linear",
     "progress-circular",

--- a/samples/design-catalog-m3-shared/src/commonMain/kotlin/com/example/designcatalogm3/shared/CatalogComponents.kt
+++ b/samples/design-catalog-m3-shared/src/commonMain/kotlin/com/example/designcatalogm3/shared/CatalogComponents.kt
@@ -2,11 +2,15 @@
 
 package com.example.designcatalogm3.shared
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.interaction.FocusInteraction
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.PressInteraction
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.AssistChip
@@ -43,6 +47,7 @@ import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
@@ -51,6 +56,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.path
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import ee.schimke.composeai.preview.slots.PreviewSlot
 
 /**
  * The **authoritative** Compose Material 3 catalog component set, shared by the desktop `@Preview`
@@ -101,6 +107,24 @@ fun CatalogComponent(id: String, interactive: Boolean) {
     "card-elevated" -> ElevatedCard { Box(Modifier.size(160.dp, 80.dp)) { Text("Elevated card") } }
     "card-outlined" -> OutlinedCard { Box(Modifier.size(160.dp, 80.dp)) { Text("Outlined card") } }
     "card-filled" -> Card { Box(Modifier.size(160.dp, 80.dp)) { Text("Filled card") } }
+    // A **slotted** card: each region is wrapped in `PreviewSlot(name) { … }`, a no-op in a normal
+    // render (draws the content, tagged `dp-slot:<name>`) that swaps to a labelled placeholder
+    // under
+    // slot mode. Each slot carries an explicit size, so the box a child fills — and the placeholder
+    // shown under slot mode — is well-defined. The structured-screen builder reads these slots from
+    // `/render/card-slots.slots` and fills each by rendering another component to that size.
+    "card-slots" ->
+      ElevatedCard {
+        Row(Modifier.padding(12.dp), verticalAlignment = Alignment.CenterVertically) {
+          PreviewSlot("leadingIcon", Modifier.size(40.dp)) {
+            Box(Modifier.size(40.dp).background(Color(0xFF6750A4)))
+          }
+          Column(Modifier.padding(start = 12.dp)) {
+            PreviewSlot("headline", Modifier.size(140.dp, 20.dp)) { Text("Headline") }
+            PreviewSlot("supporting", Modifier.size(140.dp, 16.dp)) { Text("Supporting text") }
+          }
+        }
+      }
     "fab" -> FloatingActionButton(onClick = {}) { Text("+") }
 
     // Communication — progress + badge. The baked sticker keeps the deterministic `0.6` frame; the

--- a/samples/design-catalog-m3/catalog.spec.json
+++ b/samples/design-catalog-m3/catalog.spec.json
@@ -59,6 +59,18 @@
         { "componentId": "Card/Elevated", "preview": "ElevatedCardSticker" },
         { "componentId": "Card/Outlined", "preview": "OutlinedCardSticker" },
         { "componentId": "Card/Filled", "preview": "FilledCardSticker" },
+        {
+          "componentId": "Card/Slots",
+          "preview": "SlottedCardSticker",
+          "caption": "A card with named PreviewSlot regions a structured-screen builder fills.",
+          "variants": [
+            {
+              "state": "slot-mode",
+              "preview": "SlottedCardSlotsSticker",
+              "caption": "Slot mode: each PreviewSlot draws its labelled placeholder."
+            }
+          ]
+        },
         { "componentId": "FAB", "preview": "FabSticker" }
       ]
     },

--- a/samples/design-catalog-m3/src/main/kotlin/com/example/designcatalogm3/CatalogPreviews.kt
+++ b/samples/design-catalog-m3/src/main/kotlin/com/example/designcatalogm3/CatalogPreviews.kt
@@ -14,8 +14,10 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import com.example.designcatalogm3.shared.CatalogComponent
+import ee.schimke.composeai.preview.slots.LocalSlotMode
 
 // The M3 catalog sticker sheet: one `@Preview` per component, in light + dark (`@CatalogModes`).
 // Each is a thin wrapper — `CatalogSticker { CatalogComponent("<slug>", interactive = false) }` —
@@ -61,6 +63,19 @@ import com.example.designcatalogm3.shared.CatalogComponent
 @CatalogModes @Composable fun OutlinedCardSticker() = Sticker("card-outlined")
 
 @CatalogModes @Composable fun FilledCardSticker() = Sticker("card-filled")
+
+// A slotted card: its regions are `PreviewSlot` markers. The plain sticker renders normally (the
+// markers are no-ops); `SlottedCardSlots` provides `LocalSlotMode = true` so each marker draws its
+// labelled placeholder — the slot map a structured-screen builder fills. Same body, two modes.
+@CatalogModes @Composable fun SlottedCardSticker() = Sticker("card-slots")
+
+@CatalogModes
+@Composable
+fun SlottedCardSlotsSticker() = CatalogSticker {
+  CompositionLocalProvider(LocalSlotMode provides true) {
+    CatalogComponent("card-slots", interactive = false)
+  }
+}
 
 @CatalogModes @Composable fun FabSticker() = Sticker("fab")
 


### PR DESCRIPTION
## Summary

The **visual payoff** of the structured-screen slot work: a `Card/Slots` catalog component whose regions are `PreviewSlot` markers, so you can actually *see* the slots. Two stickers render the **same body** in the two modes:

- **`SlottedCardSticker`** (normal) — the `PreviewSlot` markers are no-ops, so it renders as an ordinary card: a purple leading-icon box + "Headline" / "Supporting text".
- **`SlottedCardSlotsSticker`** — provides `LocalSlotMode = true`, so each marker draws its **labelled translucent placeholder** (50%-opacity indigo + the slot name): `leadingIcon`, `headline`, `supporting`. This is the slot map a structured-screen builder fills — each box is the size a child rendered to fill it is given (via `/render/card-slots.slots`).

The card body lives in the shared `commonMain` catalog (`:samples:design-catalog-m3-shared`), which is exactly why `:slot-preview-runtime` was made multiplatform (#2253) — so the slots show on both the desktop render sheet **and** the wasm tier. Registered in `catalog.spec.json` (a `Card/Slots` component + a `slot-mode` variant), so the CI visual-diff bot renders and diffs both stickers on every subsequent PR — future coverage is automatic.

## Where it fits

This closes the loop end-to-end:

```
PreviewSlot("headline"){Text(…)}  ──normal──▶  the card as authored           (SlottedCardSticker)
                                  ──slotMode─▶  translucent "headline" box     (SlottedCardSlotsSticker)
                                        │
                     /render/card-slots.slots  →  { leadingIcon, headline, supporting + bounds }
                                        │
                        plugin: place the card → show the slots → fill each with a component
```

## Visual evidence

⚠️ **I could not render these in the session's environment** — it's a headless container where the Gradle distribution download is proxy-blocked and the system Gradle has a Kotlin-toolchain mismatch, so the Compose (Skiko) render pipeline can't run here. This is the "genuinely can't capture locally" case.

Both stickers **are** wired into the preview harness via `catalog.spec.json`, so CI's render pipeline + visual-diff bot will render `SlottedCardSticker` (light/dark) and `SlottedCardSlotsSticker` (light/dark) on this PR. **I'll edit this PR body to embed the rendered before/after PNGs as soon as CI produces them.** Until then, here's precisely what each render should show:

- **`SlottedCardSticker`** — an `ElevatedCard`: a 40dp purple square (the leading-icon slot content), then a column with "Headline" (20dp) over "Supporting text" (16dp). Indistinguishable from a hand-built icon+text card — proving the marker is a true no-op normally.
- **`SlottedCardSlotsSticker`** — the same layout, but the three regions are now translucent indigo boxes with white centred labels "leadingIcon" (40×40), "headline" (140×20), "supporting" (140×16) — the exact boxes `/render/card-slots.slots` reports.

## Test plan

- No unit tests — this is a rendered fixture; its "test" is the visual-diff render CI produces. New `card-slots` branch in the shared `CatalogComponent`, two stickers, and the spec entries.
- ktfmt verified locally against the pinned tool; `catalog.spec.json` validated. Relying on CI for the multiplatform compile (`Build Samples`, both desktop + wasm compilations of the shared body) and the render.
- After merge, the delivery branches want a `design-artifacts.yml` regen (a catalog changed) — I'll dispatch it.

---
_Generated by [Claude Code](https://claude.ai/code/session_018uTv78jpPEKSEyScXoCdYD)_