### PR TITLE
feat(design-catalog): declare the icon+label content variant + fold props in regen

### DIFF
--- a/samples/design-catalog-m3/catalog.spec.json
+++ b/samples/design-catalog-m3/catalog.spec.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "Phase-0 catalog spec for Compose Material 3. Code-led: this declares the component inventory, grouping, captions, primary modes, and breakpoints the sticker sheet covers, plus the published-kit frame each component seeds from. The kit reference is for the one-off import only — our render is authoritative. Consumed by @design-parity/catalog-export to populate ComponentSource group/caption/reference. A component's `variants` fold extra state renders (pressed/focused/disabled/off/…) onto the same sticker: the default preview is what the grid shows, and each variant's render becomes a secondary image (tagged with its `state`) surfaced when you open the single-component view. Interaction/state stickers therefore live under their parent instead of a flat 'States' group.",
+  "$comment": "Phase-0 catalog spec for Compose Material 3. Code-led: this declares the component inventory, grouping, captions, primary modes, and breakpoints the sticker sheet covers, plus the published-kit frame each component seeds from. The kit reference is for the one-off import only — our render is authoritative. Consumed by @design-parity/catalog-export to populate ComponentSource group/caption/reference. A component's `variants` fold extra renders onto the same sticker: the default preview is what the grid shows, and each variant's render becomes a secondary image surfaced when you open the single-component view. A variant is tagged either by `state` (pressed/focused/disabled/off/…) or by named `props` content axes (e.g. `content: icon+label` — the same button with a leading icon vs the label-only default). Interaction/state and content stickers therefore live under their parent instead of a flat 'States' group.",
   "system": "compose-m3",
   "title": "Compose Material 3",
   "library": [
@@ -25,7 +25,8 @@
           "variants": [
             { "state": "pressed", "preview": "FilledButtonPressed", "caption": "Held PressInteraction → pressed state layer." },
             { "state": "keyboard-focus", "preview": "FilledButtonFocused", "caption": "Keyboard focus (focus-visible) → M3 inset focus ring. This is the directional/keyboard focus indicator, not the pointer/hover state layer." },
-            { "state": "disabled", "preview": "FilledButtonDisabled", "caption": "Disabled state." }
+            { "state": "disabled", "preview": "FilledButtonDisabled", "caption": "Disabled state." },
+            { "props": { "content": "icon+label" }, "preview": "FilledButtonIconLabel", "caption": "Content axis (not a state): leading icon + label, vs the label-only default." }
           ]
         },
         { "componentId": "Button/Tonal", "preview": "FilledTonalButtonSticker", "caption": "Secondary, still prominent." },

--- a/scripts/design-artifacts/catalog-variants.mjs
+++ b/scripts/design-artifacts/catalog-variants.mjs
@@ -1,29 +1,33 @@
 /**
- * Fold a catalog spec component's state `variants` onto its default render.
+ * Fold a catalog spec component's `variants` onto its default render.
  *
  * A catalog spec component names one default `preview` plus, optionally, a list
- * of `variants` — extra state renders (`pressed`, `focused`, `disabled`, `off`,
- * `unchecked`, …), each its own `@Preview` function. This helper joins them:
+ * of `variants` — each its own `@Preview` function, tagged by one of two axes:
+ * a `state` (`pressed`, `focused`, `disabled`, `off`, `unchecked`, …) or named
+ * `props` (a content axis, e.g. `content: icon+label`). This helper joins them:
  * the default preview's images stay first (they keep their own `state`, usually
  * `"default"`, so the grid hero is the resting component), and every variant's
- * images are appended, **re-tagged** with the variant's `state`. The result is
- * one sticker that carries the default plus each state, distinguished by
- * `Image.state` — so the catalog manifest gives each a collision-free path
- * (`images/<id>/ideal__<state>[__theme][__size].png`) and the single-component
- * view can surface the states as secondary previews.
+ * images are appended, **re-tagged** — a `state` variant replaces `Image.state`,
+ * a `props` variant merges onto `Image.props` while keeping the default state.
+ * The result is one sticker whose variants the catalog manifest gives
+ * collision-free paths (`images/<id>/ideal__<state>[__theme][__size][__k-v…].png`,
+ * the props segment keeping a props-only variant distinct from the default), and
+ * that the single-component view can surface as secondary previews.
  *
  * Pure and dependency-free (no `@design-parity/*`, no I/O) so it unit-tests
  * without an `npm ci`. Consumed by the vendored `catalogFromCandidates` join in
- * `generate-design-catalog.mjs`.
+ * `generate-design-catalog.mjs`. Mirrors the `@design-parity/catalog-export`
+ * fold so the workflow render matches the parity flow.
  *
  * @param {Array<{state?: string}>} defaultImages the default preview's images.
- * @param {{componentId: string, variants?: Array<{state: string, preview: string}>}} component
+ * @param {{componentId: string, variants?: Array<{state?: string, props?: Record<string,string>, preview: string}>}} component
  *   the spec component (its `variants` drive the fold).
  * @param {Map<string, {images: Array<object>}>} byFunction rendered candidates
  *   keyed by `@Preview` function name.
  * @returns {{ideal: Array<object>, missing: string[]}} the merged image list and
- *   any variant previews that produced no render (as `"<componentId> [<state>]"`),
- *   so the caller's completeness gate can still refuse a half-rendered sticker.
+ *   any variant previews that produced no render (as `"<componentId> [<label>]"`
+ *   where the label is the variant's state and/or `k=v` props), so the caller's
+ *   completeness gate can still refuse a half-rendered sticker.
  */
 export function foldVariants(defaultImages, component, byFunction) {
   const ideal = [...defaultImages];
@@ -31,10 +35,24 @@ export function foldVariants(defaultImages, component, byFunction) {
   for (const variant of component.variants ?? []) {
     const candidate = byFunction.get(variant.preview);
     if (!candidate || candidate.images.length === 0) {
-      missing.push(`${component.componentId} [${variant.state}]`);
+      missing.push(`${component.componentId} [${variantLabel(variant)}]`);
       continue;
     }
-    for (const image of candidate.images) ideal.push({ ...image, state: variant.state });
+    for (const image of candidate.images) {
+      const tagged = { ...image };
+      if (variant.state !== undefined) tagged.state = variant.state;
+      if (variant.props) tagged.props = { ...image.props, ...variant.props };
+      ideal.push(tagged);
+    }
   }
   return { ideal, missing };
+}
+
+/** A short label for a variant, for the missing-render report: its state and/or props. */
+function variantLabel(variant) {
+  const parts = [
+    ...(variant.state ? [variant.state] : []),
+    ...Object.entries(variant.props ?? {}).map(([k, v]) => `${k}=${v}`),
+  ];
+  return parts.join(", ") || variant.preview;
 }

--- a/scripts/design-artifacts/catalog-variants.test.mjs
+++ b/scripts/design-artifacts/catalog-variants.test.mjs
@@ -154,3 +154,30 @@ test("a component with only a default state gets no states chip", () => {
   // but it still has a zoom overlay (to see light + dark larger)
   assert.match(html, /id="d-card-filled"/);
 });
+
+test("a content-axis (props) variant never wins the hero and is labelled in the zoom view", () => {
+  const catalog = {
+    meta: { system: "compose-m3", title: "Compose M3" },
+    components: [
+      {
+        componentId: "Button/Filled",
+        group: "Buttons",
+        greenlines: [],
+        images: [
+          // the label-only default is NARROWER than the icon+label render below,
+          // so the old "largest default-state" hero would have picked icon+label.
+          { variant: "ideal", state: "default", theme: "light", path: "images/button-filled/ideal__default__light.png", width: 120, height: 40 },
+          { variant: "ideal", state: "default", theme: "light", props: { content: "icon+label" }, path: "images/button-filled/ideal__default__light__content-icon-label.png", width: 168, height: 40 },
+        ],
+      },
+    ],
+  };
+  const html = renderIndexHtml(catalog);
+  // Hero is the label-only default, not the wider props render.
+  const shot = html.match(/<a class="shot"[^>]*>\s*<img[^>]*src="([^"]+)"/);
+  assert.ok(shot, "expected a card shot image");
+  assert.match(shot[1], /ideal__default__light\.png$/);
+  // The chip counts it as a variant (not a "state"), and the zoom view labels the axis.
+  assert.match(html, /class="statechip"[^>]*>\+1 variant</);
+  assert.match(html, /<figcaption>content=icon\+label<\/figcaption>/);
+});

--- a/scripts/design-artifacts/catalog-variants.test.mjs
+++ b/scripts/design-artifacts/catalog-variants.test.mjs
@@ -52,6 +52,41 @@ test("foldVariants is a no-op for a component without variants", () => {
   assert.deepEqual(ideal, defaults);
 });
 
+test("foldVariants folds a content-axis (props) variant, keeping the default state", () => {
+  const byFunction = new Map([
+    ["FilledButtonIconLabel", { images: [img("default", "light"), img("default", "dark")] }],
+  ]);
+  const component = {
+    componentId: "Button/Filled",
+    variants: [{ props: { content: "icon+label" }, preview: "FilledButtonIconLabel" }],
+  };
+  const { ideal, missing } = foldVariants(
+    [img("default", "light"), img("default", "dark")],
+    component,
+    byFunction,
+  );
+  assert.deepEqual(missing, []);
+  // 2 default (no props) + 2 icon+label (default state, content prop).
+  assert.equal(ideal.length, 4);
+  assert.equal(ideal[0].props, undefined);
+  assert.deepEqual(ideal[2].props, { content: "icon+label" });
+  assert.equal(ideal[2].state, "default"); // props variant keeps the default state
+  assert.equal(ideal[2].theme, "light");
+  assert.equal(ideal[3].theme, "dark");
+});
+
+test("foldVariants reports a props-only variant that did not render, labelled by its axes", () => {
+  const { missing } = foldVariants(
+    [img("default", "light")],
+    {
+      componentId: "Button/Filled",
+      variants: [{ props: { content: "icon+label" }, preview: "Missing" }],
+    },
+    new Map(),
+  );
+  assert.deepEqual(missing, ["Button/Filled [content=icon+label]"]);
+});
+
 // --- index.html: default in the grid, states in the zoom view -----------------
 
 const catalogWithStates = () => ({

--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -287,14 +287,31 @@ function themeOfPreviewId(id) {
  * (`overriddenFunctions` — its baked pixels, e.g. the inset focus ring, differ from
  * what the desktop daemon would draw). Those stay baked-PNG only, with no live lane.
  */
+// Key an image/variant by componentId + state + sorted `props` — so a props-only
+// variant (e.g. `content: icon+label`, which keeps the default `state`) resolves to
+// its own `@Preview` function instead of colliding with the label-only default.
+// State-only variants carry no props, so the key stays `${id}\0${state}`, unchanged.
+function variantKey(componentId, state, props) {
+  const propsPart = Object.entries(props ?? {})
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([k, v]) => `${k}=${v}`)
+    .join(",");
+  return propsPart
+    ? `${componentId}${String.fromCharCode(0)}${state}${String.fromCharCode(0)}${propsPart}`
+    : `${componentId}${String.fromCharCode(0)}${state}`;
+}
+
 function bridgeLivePreviewIds(manifest, spec, bundle, overriddenFunctions) {
   const previewForState = new Map();
   for (const group of spec.groups ?? []) {
     for (const component of group.components ?? []) {
-      previewForState.set(`${component.componentId} default`, component.preview);
+      previewForState.set(variantKey(component.componentId, "default"), component.preview);
       for (const v of component.variants ?? []) {
-        if (v.state && v.preview) {
-          previewForState.set(`${component.componentId} ${v.state}`, v.preview);
+        if (v.preview && (v.state || v.props)) {
+          previewForState.set(
+            variantKey(component.componentId, v.state ?? "default", v.props),
+            v.preview,
+          );
         }
       }
     }
@@ -308,7 +325,9 @@ function bridgeLivePreviewIds(manifest, spec, bundle, overriddenFunctions) {
   let mapped = 0;
   for (const component of manifest.components ?? []) {
     for (const image of component.images ?? []) {
-      const fn = previewForState.get(`${component.componentId} ${image.state ?? "default"}`);
+      const fn = previewForState.get(
+        variantKey(component.componentId, image.state ?? "default", image.props),
+      );
       if (!fn || overriddenFunctions.has(fn)) continue;
       const daemonId = image.theme ? daemonIdFor.get(`${fn} ${image.theme}`) : undefined;
       if (daemonId) {

--- a/scripts/design-artifacts/package-lock.json
+++ b/scripts/design-artifacts/package-lock.json
@@ -8,36 +8,36 @@
       "name": "design-artifacts-driver",
       "version": "0.0.0",
       "dependencies": {
-        "@design-parity/candidate": "^0.1.24",
-        "@design-parity/catalog-export": "^0.1.20"
+        "@design-parity/candidate": "^0.1.25",
+        "@design-parity/catalog-export": "^0.1.25"
       },
       "engines": {
         "node": ">=22"
       }
     },
     "node_modules/@design-parity/candidate": {
-      "version": "0.1.24",
-      "resolved": "https://registry.npmjs.org/@design-parity/candidate/-/candidate-0.1.24.tgz",
-      "integrity": "sha512-4pToJMTCYQnPJVsMaBet76k7v2VYIeBM3L5t5glg8r99ux4c/7oH9qWgD72c5XcSEmZpgVAV1RKNXBJPBtG4rQ==",
+      "version": "0.1.25",
+      "resolved": "https://registry.npmjs.org/@design-parity/candidate/-/candidate-0.1.25.tgz",
+      "integrity": "sha512-vf/YtvG0H3PFjdbL4zPkmxlm7Vf7ZybcJgM/govVX++SWluQ67pk5tnmTcfxcIEep+MfhYKJq4ToX3MpWIjOkA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@design-parity/core": "^0.1.24",
+        "@design-parity/core": "^0.1.25",
         "fflate": "^0.8.2"
       }
     },
     "node_modules/@design-parity/catalog-export": {
-      "version": "0.1.20",
-      "resolved": "https://registry.npmjs.org/@design-parity/catalog-export/-/catalog-export-0.1.20.tgz",
-      "integrity": "sha512-YYlEjrqUjLdFrTqyw3M+cb52tSgh1aC/ekwilCkTVRRjd/EchiW4xsYHifAINR2hR0gaIKdTYO0S/F+C6Q/Qhw==",
+      "version": "0.1.25",
+      "resolved": "https://registry.npmjs.org/@design-parity/catalog-export/-/catalog-export-0.1.25.tgz",
+      "integrity": "sha512-U9HJ6cwUxNEeJGCmSzA2huVStce4F/zB33x1TeFAbMe0YYANAx196UiS4Km80Fq5g5LD8OuesVcHYCVD10bTxQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@design-parity/core": "^0.1.20"
+        "@design-parity/core": "^0.1.25"
       }
     },
     "node_modules/@design-parity/core": {
-      "version": "0.1.24",
-      "resolved": "https://registry.npmjs.org/@design-parity/core/-/core-0.1.24.tgz",
-      "integrity": "sha512-Bj2Xl5jPTEjrJnOuv4xLxHFnRBBWhhwgoCHym0OdNLI/uX9nxa1OKyLyPQAf0911Z2LFsKlgt+hP2IVrjkJftQ==",
+      "version": "0.1.25",
+      "resolved": "https://registry.npmjs.org/@design-parity/core/-/core-0.1.25.tgz",
+      "integrity": "sha512-lyeng/0SnX1zL59xBk7yuPhEmytPJJ5D0IzNZ+VDBmm2s+b46YuQKgy9n7tTJIUIYwWZ5rW2wxLWX7Jffzv/Iw==",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.17.1"
@@ -70,9 +70,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
       "funding": [
         {
           "type": "github",

--- a/scripts/design-artifacts/package.json
+++ b/scripts/design-artifacts/package.json
@@ -8,7 +8,7 @@
     "node": ">=22"
   },
   "dependencies": {
-    "@design-parity/candidate": "^0.1.24",
-    "@design-parity/catalog-export": "^0.1.20"
+    "@design-parity/candidate": "^0.1.25",
+    "@design-parity/catalog-export": "^0.1.25"
   }
 }

--- a/scripts/design-artifacts/render-index-html.mjs
+++ b/scripts/design-artifacts/render-index-html.mjs
@@ -51,32 +51,49 @@ function idealImages(component) {
   return (component.images ?? []).filter((i) => i.variant === "ideal");
 }
 
-/** One representative image for the grid — the **default** state (largest first),
- *  so folded state variants (pressed / focused / disabled / …) never win the hero.
- *  Falls back to the largest ideal image, then to whatever exists. */
+/** The variant axis an image belongs to — a folded `state` (pressed / disabled / …)
+ *  or a content-axis `props` set (e.g. `content: icon+label`). The label-only,
+ *  resting render is `state:default` with no props; every other axis is a secondary
+ *  variant. `key` groups images; `label` captions the group; `kind` drives wording. */
+function variantOf(image) {
+  const entries = Object.entries(image.props ?? {}).sort(([a], [b]) => a.localeCompare(b));
+  if (entries.length) {
+    const label = entries.map(([k, v]) => `${k}=${v}`).join(", ");
+    return { key: `props:${label}`, label, kind: "props" };
+  }
+  const state = image.state ?? "default";
+  return { key: `state:${state}`, label: state, kind: "state" };
+}
+
+const DEFAULT_KEY = "state:default";
+
+/** One representative image for the grid — the **default** render (largest first),
+ *  so neither a folded state (pressed / …) nor a content variant (icon+label, which
+ *  can be wider) ever wins the hero. Falls back to the largest ideal, then whatever. */
 function heroImage(component) {
   const ideal = idealImages(component);
   const pool = ideal.length ? ideal : component.images ?? [];
-  const defaults = pool.filter((i) => (i.state ?? "default") === "default");
+  const defaults = pool.filter((i) => variantOf(i).key === DEFAULT_KEY);
   const chooseFrom = defaults.length ? defaults : pool;
   return [...chooseFrom].sort((a, b) => (b.width ?? 0) - (a.width ?? 0))[0];
 }
 
-/** The component's ideal images grouped by `state`, default first, each state's
- *  theme/size captures kept together — the single-component zoom view walks this. */
-function statesOf(component) {
+/** The component's ideal images grouped by variant (state or props), default first,
+ *  each group's theme/size captures kept together — the single-component zoom view
+ *  walks this. Each group carries `{ key, label, kind, images }`. */
+function variantGroups(component) {
   const order = [];
-  const byState = new Map();
+  const byKey = new Map();
   for (const image of idealImages(component)) {
-    const state = image.state ?? "default";
-    if (!byState.has(state)) {
-      byState.set(state, []);
-      order.push(state);
+    const v = variantOf(image);
+    if (!byKey.has(v.key)) {
+      byKey.set(v.key, { key: v.key, label: v.label, kind: v.kind, images: [] });
+      order.push(v.key);
     }
-    byState.get(state).push(image);
+    byKey.get(v.key).images.push(image);
   }
-  order.sort((a, b) => (a === "default" ? -1 : b === "default" ? 1 : 0));
-  return order.map((state) => ({ state, images: byState.get(state) }));
+  order.sort((a, b) => (a === DEFAULT_KEY ? -1 : b === DEFAULT_KEY ? 1 : 0));
+  return order.map((k) => byKey.get(k));
 }
 
 /** A short per-image label — the theme, then size, else the state. */
@@ -101,13 +118,14 @@ function componentCard(component, wireframeSlugs, figmaSvgSlugs) {
   const img = heroImage(component);
   const id = component.componentId ?? "(unnamed)";
   const dims = img ? `${img.width}×${img.height}` : "";
-  // States beyond the default (pressed / focused / disabled / …), folded onto this
-  // sticker by the spec's `variants`. The grid shows only the default; the extras
-  // surface in the zoom view, hinted here by a chip.
-  const states = statesOf(component);
-  const extraStates = states.filter((s) => s.state !== "default").length;
-  const stateChip = extraStates
-    ? `<a class="statechip" href="#d-${slug(id)}">+${extraStates} state${extraStates > 1 ? "s" : ""}</a>`
+  // Variants beyond the default — folded states (pressed / focused / disabled / …)
+  // and content axes (icon+label) declared by the spec's `variants`. The grid shows
+  // only the default; the extras surface in the zoom view, hinted here by a chip.
+  // Wording stays "state(s)" when they're all states, else the general "variant(s)".
+  const extras = variantGroups(component).filter((g) => g.key !== DEFAULT_KEY);
+  const noun = extras.every((g) => g.kind === "state") ? "state" : "variant";
+  const stateChip = extras.length
+    ? `<a class="statechip" href="#d-${slug(id)}">+${extras.length} ${noun}${extras.length > 1 ? "s" : ""}</a>`
     : "";
   const figure = img
     ? `<a class="shot" href="#d-${slug(id)}" aria-label="Zoom ${esc(id)}"><img loading="lazy" src="${esc(img.path)}" alt="${esc(id)}" /></a>`
@@ -134,15 +152,15 @@ function componentDetail(component) {
   const caption = component.caption
     ? `<div class="detail-caption">${esc(component.caption)}</div>`
     : "";
-  const stateBlocks = statesOf(component)
+  const stateBlocks = variantGroups(component)
     .map((group) => {
       const shots = group.images
         .map(
           (image) =>
-            `<div class="state-shot"><img loading="lazy" src="${esc(image.path)}" alt="${esc(id)} ${esc(group.state)}" /><span>${imageLabel(image)}</span></div>`,
+            `<div class="state-shot"><img loading="lazy" src="${esc(image.path)}" alt="${esc(id)} ${esc(group.label)}" /><span>${imageLabel(image)}</span></div>`,
         )
         .join("");
-      return `<figure class="state"><figcaption>${esc(group.state)}</figcaption><div class="state-shots">${shots}</div></figure>`;
+      return `<figure class="state"><figcaption>${esc(group.label)}</figcaption><div class="state-shots">${shots}</div></figure>`;
     })
     .join("");
   return `<div class="detail" id="d-${slug(id)}" role="dialog" aria-label="${esc(id)}">


### PR DESCRIPTION
## Summary

Fast-follow to #2252 (which landed the `FilledButtonIconLabel` render). Now that **`@design-parity/catalog-export@0.1.25` (props-capable) is published**, this declares `Button/Filled`'s `{ props: { content: "icon+label" } }` content-axis variant and teaches the **vendored** `scripts/design-artifacts` regeneration path to carry `props` through — the gap the Codex review on #2252 flagged.

- **deps**: bump `@design-parity/{catalog-export,candidate}` `^0.1.20 → ^0.1.25` (+ lockfile), so `buildCatalog` encodes `props` into distinct image paths.
- **`catalog-variants.mjs`**: `foldVariants` re-tags a variant by `state` **or** merges `props` (keeping the default state), mirroring the `catalog-export` fold; missing-render labels now use state and/or `k=v` props. + 2 unit tests.
- **`generate-design-catalog.mjs`**: `bridgeLivePreviewIds` keys the live-preview mapping by a props-aware `variantKey`, so a props-only variant resolves to its own `@Preview` instead of colliding with the label-only default's daemon id.
- **`catalog.spec.json`**: `Button/Filled` gains the icon+label variant; header comment notes variants fold by `state` **or** `props`.

## Why this is safe now (Codex's concern, resolved)

The prior blocker was that the pinned `0.1.20` folded by `state` only, so a props-only variant became a duplicate `default`-state image and collided with the default's path. With `0.1.25` + the vendored fold/bridge updates, I verified the full chain end-to-end (`foldVariants` → `buildCatalog@0.1.25` → manifest):

```
default   null                    -> images/button-filled/ideal__default__light.png
default   null                    -> images/button-filled/ideal__default__dark.png
default   {"content":"icon+label"} -> images/button-filled/ideal__default__light__content-icon-label.png
default   {"content":"icon+label"} -> images/button-filled/ideal__default__dark__content-icon-label.png
```

All four paths unique — the icon+label variant is a distinct render, not a collision.

## Visual evidence

Data-plumbing + spec declaration; no render changes (the sticker itself merged in #2252). For context, the variant this now folds into the catalog:

| Light | Dark |
|---|---|
| ![icon+label light](``https://raw.githubusercontent.com/yschimke/compose-ai-tools/e399f68240ac0e778d4c09e1fade117f2b0bd197/renders/samples:design-catalog-m3/FilledButtonIconLabel_Light.png)`` | ![icon+label dark](``https://raw.githubusercontent.com/yschimke/compose-ai-tools/e399f68240ac0e778d4c09e1fade117f2b0bd197/renders/samples:design-catalog-m3/FilledButtonIconLabel_Dark.png)`` |

## Test plan

- `node --test` in `scripts/design-artifacts`: **31/31 pass** (incl. 2 new props fold tests).
- End-to-end path-encoding check against installed `0.1.25` (output above).
- `jq` validates `catalog.spec.json`.
- After merge: dispatch `design-artifacts.yml` to republish the `design-artifacts/compose-m3` branch with the new variant.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DgXE6qsEXDv91WPag1evuz)_