### PR TITLE
fix(slots): autosize the slot placeholder label to fit its box

### DIFF
--- a/runtimes/slots/src/commonMain/kotlin/ee/schimke/composeai/preview/slots/PreviewSlot.kt
+++ b/runtimes/slots/src/commonMain/kotlin/ee/schimke/composeai/preview/slots/PreviewSlot.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.text.BasicText
+import androidx.compose.foundation.text.TextAutoSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.compositionLocalOf
@@ -76,13 +77,23 @@ fun SlotPlaceholder(name: String, modifier: Modifier = Modifier) {
     modifier.fillMaxSize().background(SLOT_PLACEHOLDER_COLOR),
     contentAlignment = Alignment.Center,
   ) {
-    BasicText(name, style = SLOT_PLACEHOLDER_TEXT_STYLE)
+    BasicText(
+      name,
+      style = SLOT_PLACEHOLDER_TEXT_STYLE,
+      maxLines = 1,
+      // Scale the label down to fit the slot box on one line — a small icon slot's name won't fit
+      // at a fixed size (and wrapping mid-word reads worse than a smaller, whole label).
+      autoSize = TextAutoSize.StepBased(minFontSize = 6.sp, maxFontSize = 12.sp),
+    )
   }
 }
 
 /** The slot placeholder's fill — a distinct accent at 50% opacity (`0x80` alpha). */
 private val SLOT_PLACEHOLDER_COLOR: Color = Color(0x804F46E5)
 
-/** The slot label's text style — white, centred, small, so it reads on the translucent fill. */
+/**
+ * The slot label's text style — white + centred so it reads on the translucent fill. The size is
+ * driven by the `autoSize` on the [BasicText] (it scales to fit the slot box), not set here.
+ */
 private val SLOT_PLACEHOLDER_TEXT_STYLE: TextStyle =
-  TextStyle(color = Color.White, fontSize = 12.sp, textAlign = TextAlign.Center)
+  TextStyle(color = Color.White, textAlign = TextAlign.Center)


### PR DESCRIPTION
## Summary

The `SlotPlaceholder` label used a fixed 12sp, which wrapped mid-word in a small slot — a 40px icon slot renders `leadingIcon` as "leadin gIcon". Drive the size with `BasicText`'s `autoSize` (`TextAutoSize.StepBased(6..12sp)`, `maxLines = 1`) so the label scales down to fit the slot on one line, adaptive to any slot size instead of a fixed size that overflows small boxes. (`autoSize`/`TextAutoSize` is used without opt-in in `samples/wear`, so it's available in this Compose version.)

## Visual evidence

**Before** (live on preview.coo.ee — note the icon slot's "leadin gIcon" mid-word wrap):

[before — slot placeholders at fixed 12sp, icon label wraps](https://preview.coo.ee/compose-m3/render/card-slots__ideal__slot-mode__light.png)

**After:** the same three placeholders (`leadingIcon`, `headline`, `supporting`), but each label auto-scaled to fit its box on one line (the icon slot's label shrinks rather than wrapping). I can't run the Skiko render pipeline in this headless container, so the after pixels come from CI's visual-diff bot on this PR (`SlottedCardSlotsSticker`, light + dark) — and I'll drop the rendered after-image here once the deployed catalog refreshes.

## Test plan

- Behaviour-preserving visual tweak to the placeholder text; the slot marker's semantics (`dp-slot:` testTag, bounds) are unchanged, so the `PreviewSlotTest` drift guard still holds.
- ktfmt verified locally against the pinned tool. `SlottedCardSlotsSticker` is already registered in `catalog.spec.json`, so CI renders + diffs the before/after automatically.
- After merge: dispatch `design-artifacts.yml` to refresh the delivery branch.

---
_Generated by [Claude Code](https://claude.ai/code/session_018uTv78jpPEKSEyScXoCdYD)_