### PR TITLE
chore: allowlist github mcp tools for agent sessions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -26,7 +26,18 @@
       "mcp__claude-code-remote__delete_trigger",
       "mcp__claude-code-remote__list_triggers",
       "mcp__claude-code-remote__fire_trigger",
-      "mcp__Figma"
+      "mcp__Figma",
+      "mcp__github__pull_request_read",
+      "mcp__github__get_job_logs",
+      "mcp__github__create_pull_request",
+      "mcp__github__update_pull_request",
+      "mcp__github__resolve_review_thread",
+      "mcp__github__add_reply_to_pull_request_comment",
+      "mcp__github__add_issue_comment",
+      "mcp__github__issue_write",
+      "mcp__github__subscribe_pr_activity",
+      "mcp__github__search_issues",
+      "mcp__github__list_pull_requests"
     ]
   }
 }


### PR DESCRIPTION
Adds the specific GitHub MCP tools the agent PR/issue workflow uses to `.claude/settings.json` `permissions.allow`, so they stop prompting each session (and cover the `@claude` CI sessions running in this repo):

`pull_request_read`, `get_job_logs`, `create_pull_request`, `update_pull_request`, `resolve_review_thread`, `add_reply_to_pull_request_comment`, `add_issue_comment`, `issue_write`, `subscribe_pr_activity`, `search_issues`, `list_pull_requests`.

**Specific tools only — no broad `mcp__github` prefix**, which would sweep in destructive ones like `merge_pull_request` / `delete_file` / `push_files`. Figma stays covered by the existing `mcp__Figma` entry; the remote-cron entries and `SessionStart` hooks are untouched.

## Test plan
Settings-only. `permissions.allow` grows from 13 → 24 entries; `$schema`, `hooks`, and existing entries preserved.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M7sMfKC1CR9vBSCFjSqr9z)_