### PR TITLE
fix(serve): keep a live catalog static-snapshot + trusted, live on demand

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
@@ -5,8 +5,9 @@ import ee.schimke.composeai.daemon.protocol.StreamCodec
 import ee.schimke.composeai.daemon.protocol.StreamFrameParams
 
 /**
- * A [ServeHost] that fronts a trusted design-system catalog with **both** its baked-PNG render and
- * a live daemon lane, bridging the two id namespaces so the published catalog URLs keep working.
+ * A [ServeHost] that fronts a trusted design-system catalog with its baked-PNG render **and** an
+ * opt-in live daemon stream, bridging the two id namespaces so the published catalog URLs keep
+ * working.
  *
  * ## Why
  *
@@ -14,24 +15,23 @@ import ee.schimke.composeai.daemon.protocol.StreamFrameParams
  * (`FilledButton_Dark`), but the published `design-artifacts/<system>` catalog links + image routes
  * use the componentId-slug id (`button-filled__ideal__default__dark`) — and the two don't match.
  * Registering a bare [ServeRenderHost] for a catalog therefore 404s every published `/p/<id>` deep
- * link and `/render/<id>.png` thumbnail. It also can't serve the ids the desktop daemon simply
- * doesn't have (the Android-only inset focus-ring variant, rendered by a separate supplement and
- * baked in, with no runnable desktop preview).
+ * link and `/render/<id>.png` thumbnail, drops the catalog's title/trust badge (only a
+ * [ServeBundleHost] carries those), and — because a daemon host reports `canApplyOverrides = true`
+ * — flips the viewer into dynamic mode, so ordinary browsing renders every preview through the
+ * daemon (cold-start "rendering…") instead of showing the instant baked PNG.
  *
  * ## What
  *
- * This composite keeps the [baked] [ServeBundleHost] as the browse surface — so [previews], the
- * grid, deep links, and thumbnails resolve to the baked catalog **exactly as before** — and layers
- * the [live] daemon underneath for the ids [alias] maps (catalog id → daemon preview id):
- * - **Plain snapshot** (no overrides): served from the baked PNG, so ordinary browsing never wakes
- *   the daemon (thumbnails, deep-link default view).
- * - **Overridden snapshot** on an aliased id: routed to the daemon for a fresh render of the edit.
- * - **Live stream** on an aliased id: routed to the daemon; an unmapped id has no stream (the
- *   caller transparently falls back to the snapshot lane, i.e. the baked PNG).
+ * This composite keeps the [baked] [ServeBundleHost] as the whole **snapshot** surface —
+ * [previews], the grid, deep links, thumbnails, title, and trust badge all resolve to the baked
+ * catalog exactly as a static catalog would, and every snapshot is the baked PNG (so browsing never
+ * wakes the daemon). The [live] daemon is offered only through the **"Live (stream)"** toggle:
+ * [hasLiveStream] is true, so the viewer enables the checkbox, and [subscribeStream] maps the
+ * catalog id to the daemon preview id via [alias] and streams it. An id with no alias (an
+ * Android-only variant the desktop daemon can't render) simply has no stream and stays baked.
  *
- * The result: the whole published catalog resolves under its own ids, and the CMP components the
- * desktop daemon can run gain a live, interactive lane — while the Android-only variants degrade
- * gracefully to their baked pixels.
+ * The net effect: the published catalog behaves exactly as before (static, trusted, instant), plus
+ * the CMP components the desktop daemon can run gain an interactive live stream on demand.
  */
 class ServeCatalogLiveHost(
   /**
@@ -40,44 +40,39 @@ class ServeCatalogLiveHost(
   private val alias: Map<String, String>,
   /** The daemon-backed host, keyed by daemon preview ids (the [alias] values). */
   private val live: ServeHost,
-  /** The static baked-PNG host, keyed by catalog ids (the browse surface + fallback). */
+  /** The static baked-PNG host, keyed by catalog ids (the browse + snapshot surface). */
   private val baked: ServeHost,
 ) : ServeHost {
 
-  /** Browse surface is the baked catalog — its ids are the published catalog ids. */
+  /** Browse + snapshot surface is the baked catalog — its ids are the published catalog ids. */
   override val previews: List<ServePreview> = baked.previews
 
   override val label: String = baked.label
 
-  /** Some ids (the aliased ones) re-render live, so the viewer should offer editable knobs. */
-  override val canApplyOverrides: Boolean = true
+  /**
+   * Snapshots stay static (baked PNGs) so browsing is instant and the viewer shows the published
+   * pixels + trust badge — the live daemon is opt-in via [hasLiveStream], not the snapshot lane.
+   */
+  override val canApplyOverrides: Boolean = false
+
+  /** The "Live (stream)" toggle is offered (unlike a plain static catalog). */
+  override val hasLiveStream: Boolean = true
 
   /**
-   * Plain (no-override) snapshots come from the baked PNG so browsing never spins the daemon; an
-   * override edit on an aliased id renders fresh through the daemon. An unmapped id always serves
-   * baked (it has no runnable preview).
+   * The underlying baked catalog host, so the HTTP layer can read its title / subtitle / trust
+   * verdict (which only a [ServeBundleHost] carries) even though the session is fronted by this
+   * composite. See `ServeHttpServer.catalogBundleHost`.
    */
-  override fun render(previewId: String, overrides: PreviewOverrides): RenderOutcome {
-    val daemonId = alias[previewId]
-    return if (daemonId != null && overrides != EMPTY_OVERRIDES) {
-      live.render(daemonId, overrides)
-    } else {
-      baked.render(previewId, overrides)
-    }
-  }
+  internal val bakedHost: ServeHost = baked
 
-  override fun renderSvg(previewId: String, overrides: PreviewOverrides): SvgOutcome {
-    val daemonId = alias[previewId]
-    return if (daemonId != null && overrides != EMPTY_OVERRIDES) {
-      live.renderSvg(daemonId, overrides)
-    } else {
-      baked.renderSvg(previewId, overrides)
-    }
-  }
+  /** Snapshots are the baked catalog PNGs — the daemon is reserved for the live stream lane. */
+  override fun render(previewId: String, overrides: PreviewOverrides): RenderOutcome =
+    baked.render(previewId, overrides)
 
-  /**
-   * Live streaming is available only for aliased ids; others have no stream (snapshot fallback).
-   */
+  override fun renderSvg(previewId: String, overrides: PreviewOverrides): SvgOutcome =
+    baked.renderSvg(previewId, overrides)
+
+  /** Live streaming is available only for aliased ids; others have no stream (snapshot only). */
   override fun subscribeStream(
     previewId: String,
     overrides: PreviewOverrides,
@@ -97,10 +92,5 @@ class ServeCatalogLiveHost(
     } finally {
       baked.close()
     }
-  }
-
-  private companion object {
-    /** All-default overrides = "no override" (what the snapshot lane passes for a plain view). */
-    private val EMPTY_OVERRIDES = PreviewOverrides()
   }
 }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHost.kt
@@ -29,6 +29,18 @@ interface ServeHost : AutoCloseable {
   val canApplyOverrides: Boolean
     get() = false
 
+  /**
+   * Whether a **live daemon stream** ("Live (stream)") is available for this session — distinct
+   * from [canApplyOverrides], which governs whether the *snapshot* lane re-renders on override
+   * edits. The two usually coincide (a plain [ServeRenderHost] has both; a static [ServeBundleHost]
+   * neither), so this defaults to [canApplyOverrides]. A trusted-catalog live session
+   * ([ServeCatalogLiveHost]) is the exception: its snapshots stay baked (so browsing is instant and
+   * stays on the published pixels) while the live stream is still offered on demand —
+   * `canApplyOverrides = false` but `hasLiveStream = true`.
+   */
+  val hasLiveStream: Boolean
+    get() = canApplyOverrides
+
   /** Render [previewId] at [overrides] (cached where possible). */
   fun render(previewId: String, overrides: PreviewOverrides): RenderOutcome
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -360,7 +360,7 @@ class ServeHttpServer(
           renderHost.previews,
           token,
           webSessionId,
-          trust = (renderHost as? ServeBundleHost)?.let { BundleVerifier.summary(it.trust) },
+          trust = catalogBundleHost(renderHost)?.let { BundleVerifier.summary(it.trust) },
           isPublic = isPublic,
           catalogs = catalogSessions,
           basePath = basePath,
@@ -369,6 +369,19 @@ class ServeHttpServer(
       )
     }
   }
+
+  /**
+   * The [ServeBundleHost] carrying a catalog's browse metadata (title / subtitle / trust verdict) —
+   * the host itself for a static catalog, or the baked host a [ServeCatalogLiveHost] fronts when
+   * the catalog is served live. Null for a plain daemon module session (no bundle metadata). Lets
+   * the trust badge + card title survive a catalog being fronted by the live composite.
+   */
+  private fun catalogBundleHost(host: ServeHost): ServeBundleHost? =
+    when (host) {
+      is ServeBundleHost -> host
+      is ServeCatalogLiveHost -> host.bakedHost as? ServeBundleHost
+      else -> null
+    }
 
   /**
    * The public server's front-page index of published design-system catalogs ([catalogSessions]).
@@ -384,7 +397,7 @@ class ServeHttpServer(
           val lease = sessions.lease(system) ?: return@mapNotNull null
           try {
             val host = lease.host
-            val bundle = host as? ServeBundleHost
+            val bundle = catalogBundleHost(host)
             ServeWeb.HomeSystem(
               system = system,
               title = bundle?.title?.takeIf { it.isNotBlank() } ?: host.label,
@@ -416,7 +429,7 @@ class ServeHttpServer(
           module = renderHost.label,
           // Producer-trust verdict for a bundle/catalog session (signature / branch / provenance /
           // unverified); null for a live daemon-backed module session.
-          trust = (renderHost as? ServeBundleHost)?.let { BundleVerifier.summary(it.trust) },
+          trust = catalogBundleHost(renderHost)?.let { BundleVerifier.summary(it.trust) },
           previews =
             renderHost.previews.map { p ->
               PreviewDto(
@@ -485,7 +498,8 @@ class ServeHttpServer(
           token,
           webSessionId,
           canApplyOverrides = renderHost.canApplyOverrides,
-          trust = (renderHost as? ServeBundleHost)?.let { BundleVerifier.summary(it.trust) },
+          hasLiveStream = renderHost.hasLiveStream,
+          trust = catalogBundleHost(renderHost)?.let { BundleVerifier.summary(it.trust) },
           wasmSrc = wasmSrc,
           basePath = basePath,
           isPublic = isPublic,

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -703,7 +703,7 @@ object ServeWeb {
       """
       <p class="cp-head"><a href="$basePath/$q">← previews</a>${trustBadge(trust)}</p>
       <p class="cp-sub" title="$idText">$label</p>
-      <div class="cp-viewer" data-preview-id="$idText" data-mode="snapshot" data-modes="$modes" data-snapshot-backend="$backendLabel" data-live-backend="$liveLabel"$wasmAttr>
+      <div class="cp-viewer" data-preview-id="$idText" data-mode="snapshot" data-modes="$modes" data-static-snapshot="$staticSnapshot" data-snapshot-backend="$backendLabel" data-live-backend="$liveLabel"$wasmAttr>
         <div class="cp-stage"><span class="cp-backend" id="cp-backend"></span><img id="cp-img" alt="$label"><canvas id="cp-canvas" hidden></canvas>$wasmFrame</div>
         <div class="cp-controls">
           $snapshotNote
@@ -766,6 +766,11 @@ object ServeWeb {
       var canvas = document.getElementById("cp-canvas");
       var status = document.getElementById("cp-status");
       var live = document.getElementById("cp-live");
+      // Whether the snapshot lane is static (baked PNGs, no /render re-render) — the explicit signal
+      // for the wasm auto-enable below. NOT `live.disabled`: a trusted-catalog live session serves
+      // static snapshots yet leaves the Live toggle enabled, so `live.disabled` no longer implies
+      // "static".
+      var staticSnapshot = root.getAttribute("data-static-snapshot") === "true";
       var previewId = root.getAttribute("data-preview-id");
       // The session path prefix ("/<system>") when this viewer is served under a path — it sits at
       // "<base>/p/<id>", so stripping the trailing "/p/<id>" recovers the base ("" for the root
@@ -1092,13 +1097,13 @@ object ServeWeb {
         }
         if (live.checked && ws && ws.readyState === 1) {
           ws.send(JSON.stringify({ type: "setOverrides", overrides: overrides() }));
-        } else if (live.disabled && wasmToggle) {
+        } else if (staticSnapshot && wasmToggle) {
           // Static snapshot backed by a Wasm app: the baked PNG can't honour theme/font-scale/locale
           // (only the in-browser tier can), and /render can't re-render a published catalog. So a
           // wasm-honoured control change auto-enables the Wasm tier and applies there, instead of
-          // firing a dead refreshSnapshot the user sees as "the control does nothing". (live.disabled
-          // marks a non-renderable session; device/orientation stay disabled, so only the
-          // wasm-honoured controls reach here.)
+          // firing a dead refreshSnapshot the user sees as "the control does nothing". (staticSnapshot
+          // marks a non-renderable snapshot lane — true even for a live catalog whose Live toggle is
+          // enabled; device/orientation stay disabled, so only the wasm-honoured controls reach here.)
           wasmToggle.checked = true;
           openWasm();
         } else if (!live.checked) {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -601,6 +601,14 @@ object ServeWeb {
     token: String,
     sessionId: String? = null,
     canApplyOverrides: Boolean = false,
+    /**
+     * Whether the "Live (stream)" toggle is offered — the daemon live lane, distinct from
+     * [canApplyOverrides] (which drives whether *snapshots* re-render on override edits). Defaults
+     * to [canApplyOverrides] so plain daemon / static sessions are unchanged; a trusted-catalog
+     * live session ([ServeCatalogLiveHost]) passes `canApplyOverrides = false` (static, instant
+     * baked snapshots) with `hasLiveStream = true` (Live still offered on demand).
+     */
+    hasLiveStream: Boolean = canApplyOverrides,
     trust: String? = null,
     wasmSrc: String? = null,
     /**
@@ -667,6 +675,12 @@ object ServeWeb {
     val staticSnapshot = !canApplyOverrides
     // Server-render-only controls (no client-side path): disabled on a static snapshot.
     val serverDis = if (staticSnapshot) " disabled" else ""
+    // The "Live (stream)" toggle keys off [hasLiveStream], NOT staticSnapshot: a trusted-catalog
+    // live session serves static baked snapshots (staticSnapshot=true) yet still offers the daemon
+    // stream on demand. For plain daemon / static sessions hasLiveStream tracks canApplyOverrides,
+    // so
+    // this is unchanged there.
+    val liveDis = if (hasLiveStream) "" else " disabled"
     // Controls the in-browser Wasm app also honours — theme (uiMode), font scale (density), locale
     // (layout direction): live whenever the server can render OR a Wasm app backs the session.
     val wasmDis = if (staticSnapshot && wasmSrc == null) " disabled" else ""
@@ -693,7 +707,7 @@ object ServeWeb {
         <div class="cp-stage"><span class="cp-backend" id="cp-backend"></span><img id="cp-img" alt="$label"><canvas id="cp-canvas" hidden></canvas>$wasmFrame</div>
         <div class="cp-controls">
           $snapshotNote
-          <label class="cp-live-row"><input id="cp-live" type="checkbox"$serverDis> Live (stream)</label>
+          <label class="cp-live-row"><input id="cp-live" type="checkbox"$liveDis> Live (stream)</label>
           $wasmToggle
           <label>Theme
             <select id="cp-uiMode"$wasmDis>

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
@@ -10,10 +10,13 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 /**
- * The catalog-id bridge: [ServeCatalogLiveHost] must front the baked catalog with the daemon so the
- * published catalog ids resolve — plain browsing stays baked (never wakes the daemon), an override
- * edit / live stream on a mapped id goes to the daemon under its daemon-preview id, and an unmapped
- * id (an Android-only variant) falls back to baked.
+ * The catalog-id bridge: [ServeCatalogLiveHost] fronts the baked catalog with an opt-in daemon
+ * stream. Every **snapshot** is the baked PNG (browsing stays instant and never wakes the daemon,
+ * even when the viewer replays a sticky theme override); the daemon is reached only via the **live
+ * stream**, mapping the catalog id to its daemon-preview id. An unmapped id (an Android-only
+ * variant) has no stream. The composite reports itself as a static-snapshot host
+ * ([canApplyOverrides] false) that still offers Live ([hasLiveStream] true), and exposes its baked
+ * host so the trust badge + card title survive.
  */
 class ServeCatalogLiveHostTest {
 
@@ -86,11 +89,16 @@ class ServeCatalogLiveHostTest {
   }
 
   @Test
-  fun `browse surface and knobs come from the baked catalog`() {
+  fun `presents as a static-snapshot host that still offers Live`() {
     val (composite, _, baked) = host()
     assertEquals(baked.previews, composite.previews)
-    // Mapped ids can re-render live, so the viewer should offer editable controls.
-    assertTrue(composite.canApplyOverrides)
+    // Snapshots stay static (baked, instant) so the viewer shows the published pixels + trust
+    // badge…
+    assertEquals(false, composite.canApplyOverrides)
+    // …but the "Live (stream)" toggle is still offered.
+    assertTrue(composite.hasLiveStream)
+    // The baked host is exposed so the HTTP layer can read its title / subtitle / trust verdict.
+    assertEquals(baked, composite.bakedHost)
   }
 
   @Test
@@ -103,15 +111,19 @@ class ServeCatalogLiveHostTest {
   }
 
   @Test
-  fun `overridden snapshot of a mapped id renders live under the daemon id`() {
-    val (composite, live, _) = host()
+  fun `snapshots stay baked even with overrides on a mapped id`() {
+    // The viewer replays a sticky theme override into the snapshot URL; the composite must still
+    // serve the baked PNG (never cold-start the daemon on the snapshot lane) — the daemon is the
+    // live-stream lane only.
+    val (composite, live, baked) = host()
     val out = composite.render(catalogId, PreviewOverrides(density = 2.0f)) as RenderOutcome.Ok
-    assertEquals("live:$daemonId", out.png.decodeToString())
-    assertEquals(daemonId, live.lastRenderId)
+    assertEquals("baked:$catalogId", out.png.decodeToString())
+    assertEquals(catalogId, baked.lastRenderId)
+    assertNull(live.lastRenderId)
   }
 
   @Test
-  fun `an unmapped id always serves baked, even with overrides`() {
+  fun `an unmapped id serves baked, even with overrides`() {
     val (composite, live, baked) = host()
     val out = composite.render(androidOnlyId, PreviewOverrides(density = 2.0f)) as RenderOutcome.Ok
     assertEquals("baked:$androidOnlyId", out.png.decodeToString())

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -141,6 +141,21 @@ class ServeWebFixtureTest {
         trust = "branch:yschimke/compose-ai-tools@design-artifacts/compose-m3",
         wasmSrc = "/wasm/compose-m3/?id=card-filled",
       )
+    // A trusted catalog served LIVE (ServeCatalogLiveHost): static baked snapshots
+    // (canApplyOverrides=false) yet the "Live (stream)" toggle is enabled (hasLiveStream=true), and
+    // it also carries the in-browser Wasm tier. Captures the chrome where Live is on AND Wasm is
+    // available AND snapshots stay static — the case the `staticSnapshot` (not `live.disabled`)
+    // wasm auto-enable signal exists for.
+    val wasmViewerLive =
+      ServeWeb.viewerPage(
+        previews.first { it.id.endsWith("CardPreview") },
+        token,
+        sessionId = "compose-m3",
+        canApplyOverrides = false,
+        hasLiveStream = true,
+        trust = "branch:yschimke/compose-ai-tools@design-artifacts/compose-m3",
+        wasmSrc = "/wasm/compose-m3/?id=card-filled",
+      )
     // A catalog served under its canonical path (/meshcore-mobile/) rather than ?session=: same
     // pages, but links stay on the path (basePath) and drop the &session= param. Captures the
     // path-mounted landing + viewer the public server now serves these design systems at.
@@ -182,6 +197,7 @@ class ServeWebFixtureTest {
       File(pagesDir, "serve-home-index.html").writeText(homeIndex)
       File(pagesDir, "serve-viewer.html").writeText(viewer)
       File(pagesDir, "serve-viewer-wasm.html").writeText(wasmViewer)
+      File(pagesDir, "serve-viewer-wasm-live.html").writeText(wasmViewerLive)
       File(pagesDir, "serve-landing-path.html").writeText(landingPath)
       File(pagesDir, "serve-viewer-path.html").writeText(viewerPath)
       File(pagesDir, "serve-landing-themed.html").writeText(landingThemed)
@@ -194,6 +210,7 @@ class ServeWebFixtureTest {
     assertGolden(File(pagesDir, "serve-home-index.html"), homeIndex)
     assertGolden(File(pagesDir, "serve-viewer.html"), viewer)
     assertGolden(File(pagesDir, "serve-viewer-wasm.html"), wasmViewer)
+    assertGolden(File(pagesDir, "serve-viewer-wasm-live.html"), wasmViewerLive)
     assertGolden(File(pagesDir, "serve-landing-path.html"), landingPath)
     assertGolden(File(pagesDir, "serve-viewer-path.html"), viewerPath)
     assertGolden(File(pagesDir, "serve-landing-themed.html"), landingThemed)
@@ -518,9 +535,45 @@ class ServeWebFixtureTest {
     assertTrue(wasmView.contains("\"localeTag=\""), "locale forwarded to Wasm")
     // On a static snapshot, a wasm-honoured control change auto-enables the Wasm tier (rather than
     // firing a /render the published catalog can't serve), so the control actually takes effect.
+    // The
+    // signal is the explicit `staticSnapshot` flag, NOT `live.disabled` — a live catalog serves
+    // static snapshots yet leaves the Live toggle enabled.
     assertTrue(
-      wasmView.contains("else if (live.disabled && wasmToggle) {"),
+      wasmView.contains("data-static-snapshot=\"true\""),
+      "static-snapshot flag on the viewer",
+    )
+    assertTrue(
+      wasmView.contains("else if (staticSnapshot && wasmToggle) {"),
       "static-snapshot wasm controls auto-enable the in-browser tier",
+    )
+
+    // Trusted catalog served LIVE + Wasm (ServeCatalogLiveHost): snapshots stay static (so the wasm
+    // auto-enable + note still apply) but the Live toggle is ENABLED — the exact case
+    // `live.disabled`
+    // could no longer stand in for `staticSnapshot`.
+    val liveCatalogWasm =
+      ServeWeb.viewerPage(
+        previews.first { it.id.endsWith("CardPreview") },
+        token,
+        canApplyOverrides = false,
+        hasLiveStream = true,
+        wasmSrc = "/wasm/compose-m3/?id=card-filled",
+      )
+    assertTrue(
+      liveCatalogWasm.contains("id=\"cp-live\" type=\"checkbox\"> Live"),
+      "live catalog leaves the Live toggle enabled",
+    )
+    assertTrue(
+      liveCatalogWasm.contains("data-static-snapshot=\"true\""),
+      "live catalog still marks its snapshot lane static",
+    )
+    assertTrue(
+      liveCatalogWasm.contains("Pre-rendered snapshot"),
+      "live catalog keeps the static note",
+    )
+    assertTrue(
+      liveCatalogWasm.contains("id=\"cp-device\" disabled"),
+      "server-render-only controls stay disabled on a live catalog's static snapshot",
     )
 
     // Live daemon session (canApplyOverrides = true): everything enabled, no note.
@@ -528,6 +581,7 @@ class ServeWebFixtureTest {
     assertTrue(!liveView.contains("Pre-rendered snapshot"), "no static note on a live session")
     assertTrue(!liveView.contains("value=\"1.0\" disabled"), "font scale enabled on a live session")
     assertTrue(!liveView.contains("id=\"cp-device\" disabled"), "device enabled on a live session")
+    assertTrue(liveView.contains("data-static-snapshot=\"false\""), "live session is not static")
   }
 
   @Test

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
@@ -104,7 +104,7 @@ a:hover { text-decoration: underline; }
       <body>
               <p class="cp-head"><a href="/meshcore-mobile/?token=demo-token-fixture">← previews</a> <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/meshcore-mobile@design-artifacts/meshcore-mobile">✓ branch:yschimke/meshcore-mobile@design-artifacts/meshcore-mobile</span></p>
       <p class="cp-sub" title="com.example.ProfileScreenPreview">Profile screen</p>
-      <div class="cp-viewer" data-preview-id="com.example.ProfileScreenPreview" data-mode="snapshot" data-modes="snapshot,live" data-snapshot-backend="Snapshot" data-live-backend="Live">
+      <div class="cp-viewer" data-preview-id="com.example.ProfileScreenPreview" data-mode="snapshot" data-modes="snapshot,live" data-static-snapshot="true" data-snapshot-backend="Snapshot" data-live-backend="Live">
         <div class="cp-stage"><span class="cp-backend" id="cp-backend"></span><img id="cp-img" alt="Profile screen"><canvas id="cp-canvas" hidden></canvas></div>
         <div class="cp-controls">
           <div class="cp-note">Pre-rendered snapshot — overrides (device, locale, font scale, orientation) need the live server, not a published catalog. <a href="https://github.com/yschimke/compose-ai-tools/blob/main/docs/public-preview-server.md#running-one">Enable a local preview server.</a></div>
@@ -169,6 +169,11 @@ a:hover { text-decoration: underline; }
   var canvas = document.getElementById("cp-canvas");
   var status = document.getElementById("cp-status");
   var live = document.getElementById("cp-live");
+  // Whether the snapshot lane is static (baked PNGs, no /render re-render) — the explicit signal
+  // for the wasm auto-enable below. NOT `live.disabled`: a trusted-catalog live session serves
+  // static snapshots yet leaves the Live toggle enabled, so `live.disabled` no longer implies
+  // "static".
+  var staticSnapshot = root.getAttribute("data-static-snapshot") === "true";
   var previewId = root.getAttribute("data-preview-id");
   // The session path prefix ("/<system>") when this viewer is served under a path — it sits at
   // "<base>/p/<id>", so stripping the trailing "/p/<id>" recovers the base ("" for the root
@@ -495,13 +500,13 @@ a:hover { text-decoration: underline; }
     }
     if (live.checked && ws && ws.readyState === 1) {
       ws.send(JSON.stringify({ type: "setOverrides", overrides: overrides() }));
-    } else if (live.disabled && wasmToggle) {
+    } else if (staticSnapshot && wasmToggle) {
       // Static snapshot backed by a Wasm app: the baked PNG can't honour theme/font-scale/locale
       // (only the in-browser tier can), and /render can't re-render a published catalog. So a
       // wasm-honoured control change auto-enables the Wasm tier and applies there, instead of
-      // firing a dead refreshSnapshot the user sees as "the control does nothing". (live.disabled
-      // marks a non-renderable session; device/orientation stay disabled, so only the
-      // wasm-honoured controls reach here.)
+      // firing a dead refreshSnapshot the user sees as "the control does nothing". (staticSnapshot
+      // marks a non-renderable snapshot lane — true even for a live catalog whose Live toggle is
+      // enabled; device/orientation stay disabled, so only the wasm-honoured controls reach here.)
       wasmToggle.checked = true;
       openWasm();
     } else if (!live.checked) {

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
@@ -108,7 +108,7 @@ a:hover { text-decoration: underline; }
         <div class="cp-stage"><span class="cp-backend" id="cp-backend"></span><img id="cp-img" alt="Card"><canvas id="cp-canvas" hidden></canvas><iframe id="cp-wasm" hidden sandbox="allow-scripts" title="Card (Wasm)"></iframe></div>
         <div class="cp-controls">
           <div class="cp-note">Pre-rendered snapshot — tick “Run in browser (Wasm)” to interact: Theme, Font scale, Locale &amp; background apply in the browser. Device/Orientation need the live server. <a href="https://github.com/yschimke/compose-ai-tools/blob/main/docs/public-preview-server.md#running-one">Enable a local preview server.</a></div>
-          <label class="cp-live-row"><input id="cp-live" type="checkbox" disabled> Live (stream)</label>
+          <label class="cp-live-row"><input id="cp-live" type="checkbox"> Live (stream)</label>
           <label class="cp-live-row"><input id="cp-wasm-toggle" type="checkbox"> Run in browser (Wasm)</label>
           <label class="cp-live-row"><input id="cp-wasm-bg" type="checkbox"> Component only (no background)</label>
           <label>Theme

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
@@ -104,7 +104,7 @@ a:hover { text-decoration: underline; }
       <body>
               <p class="cp-head"><a href="/?token=demo-token-fixture">← previews</a> <span class="cp-badge cp-badge--unverified" title="producer trust: unverified">⚠ unverified</span></p>
       <p class="cp-sub" title="com.example.ProfileScreenPreview">Profile screen</p>
-      <div class="cp-viewer" data-preview-id="com.example.ProfileScreenPreview" data-mode="snapshot" data-modes="snapshot,live" data-snapshot-backend="Snapshot" data-live-backend="Live">
+      <div class="cp-viewer" data-preview-id="com.example.ProfileScreenPreview" data-mode="snapshot" data-modes="snapshot,live" data-static-snapshot="true" data-snapshot-backend="Snapshot" data-live-backend="Live">
         <div class="cp-stage"><span class="cp-backend" id="cp-backend"></span><img id="cp-img" alt="Profile screen"><canvas id="cp-canvas" hidden></canvas></div>
         <div class="cp-controls">
           <div class="cp-note">Pre-rendered snapshot — overrides (device, locale, font scale, orientation) need the live server, not a published catalog. <a href="https://github.com/yschimke/compose-ai-tools/blob/main/docs/public-preview-server.md#running-one">Enable a local preview server.</a></div>
@@ -169,6 +169,11 @@ a:hover { text-decoration: underline; }
   var canvas = document.getElementById("cp-canvas");
   var status = document.getElementById("cp-status");
   var live = document.getElementById("cp-live");
+  // Whether the snapshot lane is static (baked PNGs, no /render re-render) — the explicit signal
+  // for the wasm auto-enable below. NOT `live.disabled`: a trusted-catalog live session serves
+  // static snapshots yet leaves the Live toggle enabled, so `live.disabled` no longer implies
+  // "static".
+  var staticSnapshot = root.getAttribute("data-static-snapshot") === "true";
   var previewId = root.getAttribute("data-preview-id");
   // The session path prefix ("/<system>") when this viewer is served under a path — it sits at
   // "<base>/p/<id>", so stripping the trailing "/p/<id>" recovers the base ("" for the root
@@ -495,13 +500,13 @@ a:hover { text-decoration: underline; }
     }
     if (live.checked && ws && ws.readyState === 1) {
       ws.send(JSON.stringify({ type: "setOverrides", overrides: overrides() }));
-    } else if (live.disabled && wasmToggle) {
+    } else if (staticSnapshot && wasmToggle) {
       // Static snapshot backed by a Wasm app: the baked PNG can't honour theme/font-scale/locale
       // (only the in-browser tier can), and /render can't re-render a published catalog. So a
       // wasm-honoured control change auto-enables the Wasm tier and applies there, instead of
-      // firing a dead refreshSnapshot the user sees as "the control does nothing". (live.disabled
-      // marks a non-renderable session; device/orientation stay disabled, so only the
-      // wasm-honoured controls reach here.)
+      // firing a dead refreshSnapshot the user sees as "the control does nothing". (staticSnapshot
+      // marks a non-renderable snapshot lane — true even for a live catalog whose Live toggle is
+      // enabled; device/orientation stay disabled, so only the wasm-honoured controls reach here.)
       wasmToggle.checked = true;
       openWasm();
     } else if (!live.checked) {


### PR DESCRIPTION
## Summary

Once `--allow-render-trusted` stood a daemon up for `compose-m3` on preview.coo.ee, two regressions showed up in the browser:

- **compose-m3 lost its ✓ Trusted badge and its title** (showed the bare id `compose-m3`, no card title). Trust/title/subtitle are read only off a `ServeBundleHost` (`host as? ServeBundleHost`), and the catalog is now fronted by `ServeCatalogLiveHost`, so the cast missed. The catalog *is* trusted — an unverified catalog never reaches the live path at all.
- **Every preview showed "rendering…" with a broken PNG before Live was even ticked.** `ServeCatalogLiveHost` reported `canApplyOverrides = true`, which flips the viewer out of static-snapshot mode into daemon-render mode. The theme-sticky script replays a `uiMode` override into the snapshot URL, so the "snapshot" cold-started the daemon and hung on the first paint. Browsing a published catalog should be the instant baked PNG.

Both trace to one flag (`canApplyOverrides`) doing two jobs. This splits them:

- **`ServeHost.hasLiveStream`** (new) — whether the "Live (stream)" toggle is offered, distinct from `canApplyOverrides` (whether *snapshots* re-render on override edits). Defaults to `canApplyOverrides`, so plain daemon / static sessions are **unchanged**. The viewer's Live checkbox now gates on `hasLiveStream`; `staticSnapshot`/knob-disabling stays on `canApplyOverrides`.
- **`ServeCatalogLiveHost`** now reports `canApplyOverrides = false` + `hasLiveStream = true`: every snapshot is the baked PNG (the daemon is the live-stream lane only), and it exposes its baked host so the HTTP layer reads title / subtitle / trust from it.
- **`catalogBundleHost()`** unwraps the composite at the four metadata sites (landing, home index, `/api/previews`, viewer).
- **Wasm auto-enable** (follow-up on review): the viewer keyed its "static snapshot → auto-enable the in-browser tier on a theme/font/locale change" heuristic off `live.disabled`. Enabling the Live toggle for a live catalog broke that inference, so it now reads an explicit `data-static-snapshot` flag instead.

**Net:** a live catalog browses exactly like a static one — instant baked snapshots, ✓ Trusted badge, real title — and the daemon is reached only via the **Live (stream)** toggle, as originally intended.

## Visual evidence

New `serve-viewer-wasm-live` fixture — a trusted catalog served **live + Wasm**: static baked snapshot, ✓ Trusted badge, and the **Live (stream)** toggle enabled (not greyed out). This is the chrome the fix produces; the daemon-render "rendering…" state no longer appears on load.

| Light | Dark |
| --- | --- |
| ![serve-viewer-wasm-live (light)](https://raw.githubusercontent.com/yschimke/compose-ai-tools/2cfdce4b1e15b92275831540fd89bb4cbb511ab5/renders/serve-viewer-wasm-live.light.png) | ![serve-viewer-wasm-live (dark)](https://raw.githubusercontent.com/yschimke/compose-ai-tools/2cfdce4b1e15b92275831540fd89bb4cbb511ab5/renders/serve-viewer-wasm-live.dark.png) |

The other viewer fixtures changed only by the invisible `data-static-snapshot` attribute (no pixel delta — the diff bot reports 0 regressions across the existing 50 captures).

## Test plan

- `ServeCatalogLiveHostTest`: composite is `canApplyOverrides == false` + `hasLiveStream == true`, exposes `bakedHost`, serves baked snapshots even when a sticky override is replayed, streams only aliased ids.
- `ServeWebFixtureTest`: new live-catalog-with-Wasm fixture + assertions that Live stays enabled, the snapshot lane is marked static, and the Wasm auto-enable keys off `staticSnapshot`.
- `./gradlew :cli:test` green; ktfmt clean. `hasLiveStream` defaults preserve existing viewer HTML except the new `data-static-snapshot` attribute (goldens refreshed).

## Follow-up

No branch regen needed (data unchanged). Once this releases and the box updates, `compose-m3` shows ✓ Trusted + instant baked previews again, with Live-on-demand working via the checkbox.