### PR TITLE
chore(deploy): poll Watchtower every 20 minutes instead of hourly

### DIFF
--- a/deploy/image/docker-compose.yml
+++ b/deploy/image/docker-compose.yml
@@ -84,7 +84,7 @@ services:
     restart: always
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-    command: --label-enable --cleanup --interval 3600
+    command: --label-enable --cleanup --interval 1200
 
   caddy:
     image: caddy:2


### PR DESCRIPTION
## Summary

Drop the `deploy/image` Watchtower auto-update poll interval from `--interval 3600` (1 h) to `--interval 1200` (20 min), so a freshly released `preview-host` image reaches the box within ~20 minutes instead of up to an hour.

Single-line change to `deploy/image/docker-compose.yml`.

## Test plan

Config-only; no code paths affected. Takes effect on the box on the next `docker compose up -d` (recreates the `watchtower` service with the new interval).

---
_Generated by [Claude Code](https://claude.ai/code/session_01WGVyWcXTvsYbmCtLEXU7tn)_