### PR TITLE
feat(bundle): externalize fonts from the bundle, rehydrate from a server cache

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
@@ -63,6 +63,7 @@ class BundleCommand(args: List<String>) : Command(args) {
       "inspect" -> InspectSubcommand(subArgs).run()
       "extract" -> ExtractSubcommand(subArgs).run()
       "embed" -> EmbedSubcommand(subArgs).run()
+      "externalize" -> ExternalizeSubcommand(subArgs).run()
       "render" -> RenderSubcommand(subArgs).run()
       "keygen" -> KeygenSubcommand(subArgs).run()
       "sign" -> SignSubcommand(subArgs).run()
@@ -95,6 +96,7 @@ class BundleCommand(args: List<String>) : Command(args) {
         compose-preview bundle inspect <bundle.png | URL>
         compose-preview bundle extract <bundle.png | URL> [-o <dir>]
         compose-preview bundle embed   <bundle.png | URL> [-o <dir|file.png>] [--title T] [--external-images] [--in-bundle]
+        compose-preview bundle externalize <bundle.png | URL> --res-out <dir> [-o <file.png>] [--ext ttf,otf,woff,woff2] [--json]
         compose-preview bundle render  <bundle.png | URL> [-o <dir>]   (v1: stub — prints what would render)
         compose-preview bundle keygen  [-o <key.pem>] [--key-id <id>]  (mint an Ed25519 signing keypair)
         compose-preview bundle sign    <bundle.png> --key <private-key> --key-id <id> [--producer <name>]
@@ -145,6 +147,17 @@ class BundleCommand(args: List<String>) : Command(args) {
         --in-bundle         Embed the web resources into the bundle's own zip under web/ instead of
                             a loose directory — the .png stays a valid polyglot and now carries a
                             web/index.html you can open after unzipping. Idempotent.
+
+      Externalize flags:
+        --res-out <dir>     Directory the lifted resources are written to, content-addressed by
+                            sha256 (`<dir>/<sha256>`). Required. The publish pipeline carries this
+                            pool once per branch and a re-rendering server rehydrates from it.
+        -o, --output <file> Write the externalized bundle here instead of rewriting in place
+                            (required for a URL input, which is a temp file).
+        --ext <list>        Comma-separated file extensions to lift out. Default: ttf,otf,woff,woff2
+                            (the fonts that dominate a catalog bundle).
+        --json              Print a machine-readable summary (bundle path, res dir, externalized
+                            {path,sha256,size} list) instead of the human summary.
       """
         .trimIndent()
     )
@@ -1011,7 +1024,16 @@ internal object BundleReader {
      * `BundleDataExtension` in `PreviewBundleFormat.kt`.
      */
     val dataExtensions: List<DataExtension> = emptyList(),
+    /**
+     * v8 post-pack: resources lifted out of `classes/app.jar` by `bundle externalize` and fetched
+     * on demand (fonts, …). Empty on a normal self-contained bundle. See `BundleExternalResource`
+     * in `PreviewBundleFormat.kt`.
+     */
+    val externalResources: List<ExternalResource> = emptyList(),
   )
+
+  /** v8 mirror of `BundleExternalResource` in `PreviewBundleFormat.kt`. */
+  @Serializable data class ExternalResource(val path: String, val sha256: String, val size: Long)
 
   /** v7+ mirror of `BundleDataExtension` in `PreviewBundleFormat.kt`. */
   @Serializable data class DataExtension(val extensionId: String, val path: String)

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleExternalize.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleExternalize.kt
@@ -1,0 +1,306 @@
+package ee.schimke.composeai.cli
+
+import ee.schimke.composeai.io.SystemFileSystem
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.security.MessageDigest
+import java.util.zip.ZipEntry
+import java.util.zip.ZipInputStream
+import java.util.zip.ZipOutputStream
+import kotlin.system.exitProcess
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonArray
+import okio.FileSystem
+import okio.Path.Companion.toPath
+
+/**
+ * `compose-preview bundle externalize` — lift large binary resources (fonts by default) **out** of
+ * a packed bundle's `classes/app.jar` and publish them content-addressed beside the bundle,
+ * shrinking the carried `.png` from ~600 KB to ~30 KB.
+ *
+ * # Why
+ *
+ * A desktop-CMP catalog bundle (`compose-m3`) embeds its real font faces (Roboto / Noto Serif /
+ * Droid Sans Mono, ~570 KB) inside `classes/app.jar` so the live daemon can rasterise text with the
+ * same faces the baked stickers used. Carrying those bytes on **every** `design-artifacts/<system>`
+ * branch — re-fetched by the public server on each catalog reload — is wasteful: the fonts rarely
+ * change and are identical across variants. This step lifts them out, records each in the
+ * manifest's [BundleReader.Manifest.externalResources] by name + sha256 + size, and writes the
+ * bytes to a content-addressed pool (`<res-out>/<sha256>`) the publish pipeline carries once per
+ * branch. The server rehydrates them into a shared hash-keyed cache and back onto the daemon
+ * classpath at their recorded path, so `getResourceAsStream("/fonts/…")` resolves exactly as
+ * before.
+ *
+ * # What it does
+ *
+ * 1. Reads the bundle's `classes/app.jar`, splitting each entry into *kept* (classes + small
+ *    resources) vs *externalized* (a resource whose path matches one of [extensions]).
+ * 2. Writes each externalized resource's bytes to `<res-out>/<sha256>` (deduped — identical bytes
+ *    share a file), and records `{path, sha256, size}`.
+ * 3. Rebuilds `classes/app.jar` without the externalized entries and merges the records into
+ *    `bundle.json`'s `externalResources` (idempotent by path — re-running is a no-op).
+ * 4. Rewrites the bundle in place (or to `-o`) via [injectRawZipEntries], preserving the polyglot
+ *    PNG cover and every other entry.
+ *
+ * The manifest is edited as a **raw JSON tree** rather than a typed round-trip so fields the CLI's
+ * [BundleReader.Manifest] mirror doesn't model (future schema additions) survive untouched.
+ *
+ * Idempotent: a second run finds the entries already gone from the jar and already recorded, and
+ * changes nothing.
+ */
+internal object BundleExternalize {
+
+  /** Default resource extensions lifted out — the font faces that dominate a catalog bundle. */
+  val DEFAULT_EXTENSIONS: List<String> = listOf("ttf", "otf", "woff", "woff2")
+
+  data class Externalized(val path: String, val sha256: String, val size: Long)
+
+  data class Result(val bundleFile: File, val resDir: File, val externalized: List<Externalized>)
+
+  /**
+   * Externalize [extensions]-matching resources out of [bundleFile]'s `classes/app.jar` into
+   * [resDir], rewriting the bundle in place (the polyglot PNG cover + all other entries preserved)
+   * and merging the records into `bundle.json`. Returns the resources externalized on **this** run
+   * (already-externalized ones on a re-run count as zero new work but stay recorded). Throws
+   * [IllegalArgumentException] if the bundle carries no `classes/app.jar`.
+   */
+  fun externalize(
+    bundleFile: File,
+    resDir: File,
+    extensions: List<String> = DEFAULT_EXTENSIONS,
+    fileSystem: FileSystem = SystemFileSystem,
+  ): Result {
+    val exts = extensions.map { it.trim().lowercase().removePrefix(".") }.filter { it.isNotEmpty() }
+    val zip = BundleReader.extractZipBytes(bundleFile, fileSystem)
+
+    val appJar =
+      readZipEntry(zip, "classes/app.jar")
+        ?: throw IllegalArgumentException(
+          "classes/app.jar missing in ${bundleFile.path} — not a packed class-backed bundle"
+        )
+
+    resDir.mkdirs()
+    val externalized = LinkedHashMap<String, Externalized>()
+    val strippedJar =
+      rewriteJar(appJar) { name, bytes ->
+        if (matchesExtension(name, exts)) {
+          val sha = sha256Hex(bytes)
+          fileSystem.write(File(resDir, sha).path.toPath()) { write(bytes) }
+          externalized[name] = Externalized(path = name, sha256 = sha, size = bytes.size.toLong())
+          false // drop from the jar
+        } else {
+          true // keep
+        }
+      }
+
+    // Merge the records into bundle.json's externalResources as a raw JSON tree so unmodelled
+    // fields
+    // survive. Idempotent by path — a re-run replaces the same-path entry with an identical one.
+    val manifestBytes =
+      readZipEntry(zip, "bundle.json")
+        ?: throw IllegalArgumentException("bundle.json missing in ${bundleFile.path}")
+    val newManifest = mergeExternalResources(manifestBytes, externalized.values)
+
+    injectRawZipEntries(
+      bundleFile,
+      mapOf("classes/app.jar" to strippedJar, "bundle.json" to newManifest),
+      fileSystem,
+    )
+    return Result(bundleFile, resDir, externalized.values.toList())
+  }
+
+  private fun matchesExtension(name: String, exts: List<String>): Boolean {
+    val dot = name.lastIndexOf('.')
+    if (dot < 0) return false
+    return name.substring(dot + 1).lowercase() in exts
+  }
+
+  /** Read one entry's bytes out of a raw zip, or null if absent. */
+  private fun readZipEntry(zip: ByteArray, name: String): ByteArray? {
+    ZipInputStream(ByteArrayInputStream(zip)).use { zin ->
+      while (true) {
+        val entry = zin.nextEntry ?: break
+        if (entry.name == name) return zin.readBytes()
+        zin.closeEntry()
+      }
+    }
+    return null
+  }
+
+  /**
+   * Rebuild a jar keeping only entries for which [keep] returns true. Entry order + directory
+   * entries are preserved; times are pinned to [ZIP_DOS_EPOCH_MS] so the stripped jar stays
+   * byte-stable across runs.
+   */
+  private fun rewriteJar(
+    jarBytes: ByteArray,
+    keep: (name: String, bytes: ByteArray) -> Boolean,
+  ): ByteArray {
+    val baos = ByteArrayOutputStream()
+    ZipOutputStream(baos).use { zout ->
+      ZipInputStream(ByteArrayInputStream(jarBytes)).use { zin ->
+        while (true) {
+          val entry = zin.nextEntry ?: break
+          if (entry.isDirectory) {
+            zout.putNextEntry(ZipEntry(entry.name).apply { time = ZIP_DOS_EPOCH_MS })
+            zout.closeEntry()
+          } else {
+            val bytes = zin.readBytes()
+            if (keep(entry.name, bytes)) {
+              zout.putNextEntry(ZipEntry(entry.name).apply { time = ZIP_DOS_EPOCH_MS })
+              zout.write(bytes)
+              zout.closeEntry()
+            }
+          }
+          zin.closeEntry()
+        }
+      }
+    }
+    return baos.toByteArray()
+  }
+
+  /**
+   * Return [manifestBytes] with [records] merged into its `externalResources` array — existing
+   * entries whose `path` collides are replaced (idempotent), the rest preserved, and every other
+   * top-level field left untouched. New entries are appended in [records] order after the
+   * survivors.
+   */
+  private fun mergeExternalResources(
+    manifestBytes: ByteArray,
+    records: Collection<Externalized>,
+  ): ByteArray {
+    val root = json.parseToJsonElement(manifestBytes.toString(Charsets.UTF_8)) as JsonObject
+    val recordByPath = records.associateBy { it.path }
+    val existing = (root["externalResources"] as? JsonArray).orEmpty()
+    val merged = buildJsonArray {
+      for (element in existing) {
+        val path = (element as? JsonObject)?.get("path")?.jsonPrimitiveContentOrNull()
+        if (path != null && path in recordByPath) continue // replaced below
+        add(element)
+      }
+      for (record in records) {
+        add(
+          buildJsonObject {
+            put("path", record.path)
+            put("sha256", record.sha256)
+            put("size", record.size)
+          }
+        )
+      }
+    }
+    val newRoot = JsonObject(root.toMutableMap().apply { put("externalResources", merged) })
+    return json.encodeToString(JsonObject.serializer(), newRoot).toByteArray(Charsets.UTF_8)
+  }
+
+  private fun sha256Hex(bytes: ByteArray): String =
+    MessageDigest.getInstance("SHA-256").digest(bytes).joinToString("") { "%02x".format(it) }
+
+  private val json = Json {
+    ignoreUnknownKeys = true
+    prettyPrint = false
+  }
+}
+
+private fun JsonArray?.orEmpty(): JsonArray = this ?: JsonArray(emptyList())
+
+private fun kotlinx.serialization.json.JsonElement.jsonPrimitiveContentOrNull(): String? =
+  (this as? kotlinx.serialization.json.JsonPrimitive)?.content
+
+/**
+ * `compose-preview bundle externalize <bundle.png> --res-out <dir> [-o <file.png>] [--ext ttf,otf]`
+ * — the CLI wrapper around [BundleExternalize.externalize]. Rewrites the bundle in place by
+ * default; `-o` writes a copy first and externalizes that. Prints a one-line-per-resource summary;
+ * with `--json` prints a machine-readable summary the publish pipeline consumes.
+ */
+internal class ExternalizeSubcommand(
+  private val args: List<String>,
+  private val fileSystem: FileSystem = SystemFileSystem,
+) {
+  fun run() {
+    val path = args.firstOrNull { !it.startsWith("-") }
+    val resOut = args.flagValue("--res-out")
+    val outArg = args.flagValue("--output") ?: args.flagValue("-o")
+    val extArg = args.flagValue("--ext")
+    val asJson = "--json" in args
+    if (path == null || resOut == null) {
+      System.err.println(
+        "Usage: compose-preview bundle externalize <bundle.png | URL> --res-out <dir> " +
+          "[-o <file.png>] [--ext ttf,otf,woff,woff2] [--json]"
+      )
+      exitProcess(64)
+    }
+    val source =
+      try {
+        BundleSource.resolveToFile(path)
+      } catch (e: IllegalArgumentException) {
+        System.err.println(e.message)
+        exitProcess(1)
+      }
+
+    // A URL input resolved to a delete-on-exit temp file — rewriting it "in place" would vanish on
+    // exit, so require -o for a downloaded bundle (same guard as `bundle embed --in-bundle`).
+    val target =
+      if (outArg != null) {
+        val t = File(outArg).absoluteFile
+        t.parentFile?.mkdirs()
+        val bytes = fileSystem.read(source.path.toPath()) { readByteArray() }
+        fileSystem.write(t.path.toPath()) { write(bytes) }
+        t
+      } else if (BundleSource.looksLikeUrl(path)) {
+        System.err.println(
+          "bundle externalize: the input is a downloaded URL (a temporary file). " +
+            "Pass -o <file.png> so the externalized bundle is written somewhere durable."
+        )
+        exitProcess(64)
+      } else {
+        source
+      }
+
+    val extensions =
+      extArg?.split(',')?.map { it.trim() }?.filter { it.isNotEmpty() }
+        ?: BundleExternalize.DEFAULT_EXTENSIONS
+
+    val result =
+      try {
+        BundleExternalize.externalize(target, File(resOut), extensions, fileSystem)
+      } catch (e: IllegalArgumentException) {
+        System.err.println("bundle externalize: ${e.message}")
+        exitProcess(1)
+      }
+
+    if (asJson) {
+      val summary = buildJsonObject {
+        put("bundle", result.bundleFile.absolutePath)
+        put("resDir", result.resDir.absolutePath)
+        put("size", result.bundleFile.length())
+        putJsonArray("externalized") {
+          for (r in result.externalized) {
+            add(
+              buildJsonObject {
+                put("path", r.path)
+                put("sha256", r.sha256)
+                put("size", r.size)
+              }
+            )
+          }
+        }
+      }
+      println(summaryJson.encodeToString(JsonObject.serializer(), summary))
+    } else {
+      val total = result.externalized.sumOf { it.size }
+      println(
+        "externalized ${result.externalized.size} resource(s) (${total} bytes) from " +
+          "${target.name} → ${result.resDir.path}/  (bundle now ${target.length()} bytes)"
+      )
+      for (r in result.externalized) println("  ${r.path}  →  ${r.sha256.take(12)}…  (${r.size} B)")
+    }
+  }
+
+  private val summaryJson = Json { prettyPrint = false }
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
@@ -102,6 +102,9 @@ internal object CliFlags {
       "--locale",
       "--ui-mode",
       "--font-scale",
+      // bundle externalize
+      "--res-out",
+      "--ext",
     )
 
   /**

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -626,8 +626,16 @@ class ServeCommand(args: List<String>) : Command(args) {
             "serve: catalog $system carries an in-browser Wasm app (/wasm/$system/)"
           )
         },
-        buildTrustedBundle = { system, bundleFile, alias, bakedFallback ->
-          buildTrustedCatalogBundle(system, bundleFile, alias, bakedFallback, registry, openHost)
+        buildTrustedBundle = { system, bundleFile, externalResourcesDir, alias, bakedFallback ->
+          buildTrustedCatalogBundle(
+            system,
+            bundleFile,
+            externalResourcesDir,
+            alias,
+            bakedFallback,
+            registry,
+            openHost,
+          )
         },
         buildTrustedSource = { system, source, alias, bakedFallback ->
           buildTrustedCatalogSource(
@@ -673,6 +681,7 @@ class ServeCommand(args: List<String>) : Command(args) {
   private fun buildTrustedCatalogBundle(
     system: String,
     bundleFile: File,
+    externalResourcesDir: File?,
     alias: Map<String, String>,
     bakedFallback: () -> ServeHost,
     registry: ServeSessionRegistry,
@@ -687,9 +696,16 @@ class ServeCommand(args: List<String>) : Command(args) {
     // the daemon with the baked catalog: the published /p/<id> deep links + /render/<id>.png
     // thumbnails keep resolving (Android-only variants fall back to baked), while the mapped ids
     // get
-    // a live lane. See ServeCatalogLiveHost.
+    // a live lane. See ServeCatalogLiveHost. The rehydrated external-resource pool (fonts lifted
+    // out
+    // of classes/app.jar) joins the daemon classpath so text rasterises with the same faces.
     val state =
-      ServeBundleDaemon.materialize(bundleFile, destDir, system)
+      ServeBundleDaemon.materialize(
+          bundleFile,
+          destDir,
+          system,
+          extraClasspathDirs = listOfNotNull(externalResourcesDir),
+        )
         ?.copy(previewAliases = alias, bakedFallback = bakedFallback) ?: return false
     val host = openHost(state) ?: return false
     registry.register(system, state, host = host)

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt
@@ -48,6 +48,13 @@ internal object ServeBundleDaemon {
     destDir: File,
     system: String,
     offline: Boolean = false,
+    /**
+     * Extra classpath directories prepended after the bundle's own `classes/` — the rehydrated
+     * [BundleReader.Manifest.externalResources] pool (fonts lifted out of `classes/app.jar` by
+     * `bundle externalize`, materialized at their original resource paths so
+     * `getResourceAsStream("/fonts/…")` resolves). Empty for a self-contained bundle.
+     */
+    extraClasspathDirs: List<File> = emptyList(),
     fileSystem: FileSystem = SystemFileSystem,
     onLog: (String) -> Unit = { System.err.println("[serve bundle] $it") },
   ): ServeSessionState? {
@@ -107,10 +114,11 @@ internal object ServeBundleDaemon {
         )
         .resolveAll(mavenCoords)
         .mapNotNull { it.file }
+    // The rehydrated external-resource dirs go right after the bundle's own classes so a lifted
+    // font resolves at the same `/fonts/…` classpath path it did when carried inline.
     val userClassPath =
-      (listOf(classesDir) + libJars + resolvedJars).joinToString(File.pathSeparator) {
-        it.absolutePath
-      }
+      (listOf(classesDir) + extraClasspathDirs.filter { it.isDirectory } + libJars + resolvedJars)
+        .joinToString(File.pathSeparator) { it.absolutePath }
 
     val daemonJars = locateBundleSidecarJars("lib-daemon-desktop")
     if (daemonJars.isEmpty()) {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
@@ -402,10 +402,19 @@ class ServeCatalogStore(
         )
         return ResRehydrate.Unavailable
       }
-      // Content-addressed cache: fetch once, reuse across systems + reloads. A cache hit is trusted
-      // by (sha, size); a corrupt/short file is refetched.
+      // Content-addressed cache: fetch once, reuse across systems + reloads. The cache key IS the
+      // sha256, so a hit is only trusted after its bytes hash back to that key — a same-length but
+      // corrupt entry (partial write, disk fault) must be refetched, not silently put on the
+      // classpath. Verifying on read is cheap (fonts are small, reloads infrequent) and is the
+      // whole
+      // point of a content-addressed store.
       val cached = File(cacheDir, sha)
-      if (!cached.isFile || cached.length() != res.size) {
+      val cacheValid =
+        cached.isFile &&
+          cached.length() == res.size &&
+          runCatching { sha256Hex(cached.readBytes()) == sha }.getOrDefault(false)
+      if (!cacheValid) {
+        cached.delete()
         val url =
           if (prefix.isEmpty()) "$base$RES_POOL_DIR/$sha" else "$base$prefix/$RES_POOL_DIR/$sha"
         val bytes = runCatching { fetch(url) }.getOrNull()

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
@@ -1,8 +1,10 @@
 package ee.schimke.composeai.cli.serve
 
+import ee.schimke.composeai.cli.BundleReader
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.InputStream
+import java.security.MessageDigest
 import java.util.concurrent.TimeUnit
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
@@ -54,13 +56,20 @@ class ServeCatalogStore(
    * and the plain static registration are skipped); false ⇒ fall back to [buildTrustedSource], then
    * the static catalog. Default ⇒ never. The callback owns the `--allow-render-trusted` gate; this
    * store only reaches it for an already-`Trusted` catalog, and only after the whole declared
-   * bundle file fetched cleanly (fail-closed, like [fetchWasmApp]).
+   * bundle file fetched cleanly (fail-closed, like [fetchWasmApp]). `externalResourcesDir` is the
+   * rehydrated font/resource pool the daemon adds to its classpath (see
+   * [rehydrateExternalResources]) — null when the bundle carried its resources inline (a
+   * self-contained pack).
    */
   private val buildTrustedBundle:
     (
-      system: String, bundleFile: File, alias: Map<String, String>, bakedFallback: () -> ServeHost,
+      system: String,
+      bundleFile: File,
+      externalResourcesDir: File?,
+      alias: Map<String, String>,
+      bakedFallback: () -> ServeHost,
     ) -> Boolean =
-    { _, _, _, _ ->
+    { _, _, _, _, _ ->
       false
     },
   /**
@@ -223,8 +232,22 @@ class ServeCatalogStore(
     val liveBundle = catalog.liveBundle
     if (verdict is BundleVerifier.Verdict.Trusted && liveBundle != null) {
       val bundleFile = fetchLiveBundle(liveBundle, base, dir, safe)
-      if (bundleFile != null && buildTrustedBundle(safe, bundleFile, alias, bakedFallback)) {
-        return Result.Ok(safe, count, "${BundleVerifier.summary(verdict)} (live bundle)")
+      if (bundleFile != null) {
+        // Rehydrate any resources the bundle externalized (fonts lifted out of classes/app.jar)
+        // from
+        // the branch's content-addressed pool into a shared cache + a materialized classpath dir.
+        // Fail-closed: a declared-but-unfetchable resource means the daemon would render with the
+        // fonts missing (the exact ExceptionInInitializerError this feature exists to avoid), so we
+        // skip the live bundle and fall through to the source/static path rather than serve a
+        // broken
+        // live tier.
+        when (val res = rehydrateExternalResources(bundleFile, base, liveBundle.path, dir, safe)) {
+          is ResRehydrate.Ready ->
+            if (buildTrustedBundle(safe, bundleFile, res.dir, alias, bakedFallback)) {
+              return Result.Ok(safe, count, "${BundleVerifier.summary(verdict)} (live bundle)")
+            }
+          ResRehydrate.Unavailable -> {} // fall through to source/static
+        }
       }
     }
 
@@ -320,6 +343,105 @@ class ServeCatalogStore(
     target.parentFile?.mkdirs()
     target.writeBytes(bytes)
     return target
+  }
+
+  /**
+   * Outcome of rehydrating a live bundle's externalized resources. See
+   * [rehydrateExternalResources].
+   */
+  private sealed interface ResRehydrate {
+    /**
+     * Ready to serve: [dir] is the materialized classpath dir, or null when nothing was external.
+     */
+    data class Ready(val dir: File?) : ResRehydrate
+
+    /**
+     * A resource was declared but couldn't be fetched/verified — the live bundle must be skipped.
+     */
+    data object Unavailable : ResRehydrate
+  }
+
+  /**
+   * Rehydrate the resources [bundleFile]'s manifest lifted out with `bundle externalize` (fonts,
+   * recorded in `externalResources` by name+sha256+size). Each is fetched — once, shared across
+   * systems + catalog reloads — into a content-addressed cache under `<root>/$RES_CACHE_DIR/<sha>`,
+   * verified against its sha256, then materialized at its recorded classpath [path] under
+   * `<dir>/$RES_MATERIALIZED_DIR/` so the daemon's classloader resolves `/fonts/…` exactly as it
+   * did with the fonts inline. The pool lives beside the bundle on the trusted branch
+   * (`<liveBundle.path>/$RES_POOL_DIR/<sha>`), enumerated by the trusted manifest (not client
+   * input) and each write path-contained.
+   *
+   * Returns [ResRehydrate.Ready] with a null dir when the bundle externalized nothing
+   * (self-contained — the caller passes no extra classpath), the materialized dir when it did, or
+   * [ResRehydrate.Unavailable] (fail-closed) if any declared resource has a bad sha/path or can't
+   * be fetched/verified — the caller then skips the live bundle rather than run the daemon with the
+   * fonts missing.
+   */
+  private fun rehydrateExternalResources(
+    bundleFile: File,
+    base: String,
+    bundlePathPrefix: String,
+    dir: File,
+    system: String,
+  ): ResRehydrate {
+    val resources =
+      runCatching { BundleReader.readMetadata(bundleFile).manifest.externalResources }.getOrNull()
+        ?: emptyList()
+    if (resources.isEmpty()) return ResRehydrate.Ready(null)
+
+    val cacheDir = File(root, RES_CACHE_DIR).apply { mkdirs() }
+    val materialized = File(dir, RES_MATERIALIZED_DIR)
+    val matRoot = materialized.canonicalFile.toPath()
+    val prefix = bundlePathPrefix.trim('/')
+
+    for (res in resources) {
+      val sha = res.sha256
+      if (sha.length != 64 || sha.any { it !in '0'..'9' && it !in 'a'..'f' }) {
+        System.err.println(
+          "serve: $system external resource '$sha' is not a sha256 — skipping live bundle"
+        )
+        return ResRehydrate.Unavailable
+      }
+      // Content-addressed cache: fetch once, reuse across systems + reloads. A cache hit is trusted
+      // by (sha, size); a corrupt/short file is refetched.
+      val cached = File(cacheDir, sha)
+      if (!cached.isFile || cached.length() != res.size) {
+        val url =
+          if (prefix.isEmpty()) "$base$RES_POOL_DIR/$sha" else "$base$prefix/$RES_POOL_DIR/$sha"
+        val bytes = runCatching { fetch(url) }.getOrNull()
+        if (bytes == null) {
+          System.err.println(
+            "serve: $system external resource fetch failed ($url) — skipping live bundle"
+          )
+          return ResRehydrate.Unavailable
+        }
+        if (sha256Hex(bytes) != sha) {
+          System.err.println(
+            "serve: $system external resource sha256 mismatch ($url) — skipping live bundle"
+          )
+          return ResRehydrate.Unavailable
+        }
+        cached.parentFile?.mkdirs()
+        cached.writeBytes(bytes)
+      }
+      // Materialize at the recorded classpath path (path-contained — reject traversal/absolute).
+      if (res.path.isBlank() || res.path.startsWith("/") || ".." in res.path.split("/")) {
+        System.err.println(
+          "serve: $system external resource path '${res.path}' is invalid — skipping live bundle"
+        )
+        return ResRehydrate.Unavailable
+      }
+      val dest = File(materialized, res.path)
+      if (!dest.canonicalFile.toPath().startsWith(matRoot)) {
+        System.err.println(
+          "serve: $system external resource path '${res.path}' escapes — skipping live bundle"
+        )
+        return ResRehydrate.Unavailable
+      }
+      dest.parentFile?.mkdirs()
+      cached.copyTo(dest, overwrite = true)
+    }
+    return ResRehydrate.Ready(materialized)
   }
 
   /**
@@ -423,6 +545,29 @@ class ServeCatalogStore(
     private const val MAX_WASM_FILES = 64
     /** Local subdir a catalog's `liveBundle` file is fetched into (`<dir>/bundle/<file>`). */
     const val LIVE_BUNDLE_DIR = "bundle"
+
+    /**
+     * Branch-relative subdir (under the `liveBundle.path`) holding the bundle's externalized
+     * resources, content-addressed by sha256 (`<liveBundle.path>/res/<sha>`). Written by `bundle
+     * externalize`'s `--res-out` publish step; fetched by [rehydrateExternalResources].
+     */
+    const val RES_POOL_DIR = "res"
+
+    /**
+     * Shared, content-addressed on-disk cache for externalized resources, under the store root
+     * (`<root>/.res-cache/<sha>`). Shared across systems + reloads so a font fetched for one
+     * catalog is reused by the next.
+     */
+    const val RES_CACHE_DIR = ".res-cache"
+
+    /**
+     * Per-system subdir the rehydrated resources are materialized into at their classpath paths.
+     */
+    const val RES_MATERIALIZED_DIR = "bundle-res"
+
+    /** Lowercase-hex SHA-256 of [bytes] — the content-address a rehydrated resource is keyed by. */
+    private fun sha256Hex(bytes: ByteArray): String =
+      MessageDigest.getInstance("SHA-256").digest(bytes).joinToString("") { "%02x".format(it) }
 
     /**
      * The single-path-segment preview id for a catalog image path. The serve routes (`/p/{name}`,

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleExternalizeTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleExternalizeTest.kt
@@ -1,0 +1,210 @@
+package ee.schimke.composeai.cli
+
+import java.awt.image.BufferedImage
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.nio.file.Files
+import java.security.MessageDigest
+import java.util.zip.ZipEntry
+import java.util.zip.ZipInputStream
+import java.util.zip.ZipOutputStream
+import javax.imageio.ImageIO
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Coverage for [BundleExternalize] — lifting the heavy font resources out of a bundle's
+ * `classes/app.jar`, publishing them content-addressed by sha256, recording them in the manifest,
+ * and staying idempotent + byte-stable across re-runs.
+ */
+class BundleExternalizeTest {
+
+  private val workRoot = Files.createTempDirectory("bundle-externalize-test-").toFile()
+
+  @AfterTest
+  fun cleanup() {
+    workRoot.deleteRecursively()
+  }
+
+  private fun png(w: Int = 4, h: Int = 4): ByteArray {
+    val img = BufferedImage(w, h, BufferedImage.TYPE_INT_RGB)
+    img.setRGB(0, 0, 0x112233)
+    val baos = ByteArrayOutputStream()
+    ImageIO.write(img, "png", baos)
+    return baos.toByteArray()
+  }
+
+  /** Build a jar (raw zip) from name→bytes entries. */
+  private fun jar(entries: Map<String, ByteArray>): ByteArray {
+    val baos = ByteArrayOutputStream()
+    ZipOutputStream(baos).use { z ->
+      for ((path, bytes) in entries) {
+        z.putNextEntry(ZipEntry(path))
+        z.write(bytes)
+        z.closeEntry()
+      }
+    }
+    return baos.toByteArray()
+  }
+
+  /** Build a PNG+ZIP polyglot bundle from a cover + top-level entries. */
+  private fun polyglot(cover: ByteArray, entries: Map<String, ByteArray>): File {
+    val zip = ByteArrayOutputStream()
+    ZipOutputStream(zip).use { z ->
+      for ((path, bytes) in entries) {
+        z.putNextEntry(ZipEntry(path))
+        z.write(bytes)
+        z.closeEntry()
+      }
+    }
+    val file = File(workRoot, "bundle-${entries.hashCode()}-${cover.size}.png")
+    file.outputStream().use {
+      it.write(cover)
+      it.write(zip.toByteArray())
+    }
+    return file
+  }
+
+  private fun jarEntries(bundle: File, jarPath: String): Map<String, ByteArray> {
+    val zip = BundleReader.extractZipBytes(bundle)
+    var jarBytes: ByteArray? = null
+    ZipInputStream(ByteArrayInputStream(zip)).use { zin ->
+      while (true) {
+        val e = zin.nextEntry ?: break
+        if (e.name == jarPath) jarBytes = zin.readBytes()
+        zin.closeEntry()
+      }
+    }
+    val out = LinkedHashMap<String, ByteArray>()
+    ZipInputStream(ByteArrayInputStream(jarBytes!!)).use { zin ->
+      while (true) {
+        val e = zin.nextEntry ?: break
+        if (!e.isDirectory) out[e.name] = zin.readBytes()
+        zin.closeEntry()
+      }
+    }
+    return out
+  }
+
+  private fun sha256(bytes: ByteArray) =
+    MessageDigest.getInstance("SHA-256").digest(bytes).joinToString("") { "%02x".format(it) }
+
+  private val manifestJson =
+    """
+    {"schemaVersion":8,"backend":"desktop","previewIds":["a"],"coverPreviewId":"a",
+     "classpath":[{"kind":"module","path":"classes/app.jar"}],
+     "modulePath":":samples:design-catalog-m3","producedBy":"test"}
+    """
+      .trimIndent()
+
+  private fun bundleWith(font: ByteArray, extraJar: Map<String, ByteArray> = emptyMap()): File {
+    val cover = png(4, 8)
+    val appJar =
+      jar(
+        mapOf(
+          "com/example/CatalogKt.class" to byteArrayOf(0xCA.toByte(), 0xFE.toByte(), 0, 0),
+          "fonts/Roboto-Regular.ttf" to font,
+        ) + extraJar
+      )
+    return polyglot(
+      cover,
+      linkedMapOf(
+        "bundle.json" to manifestJson.toByteArray(),
+        "previews.json" to """{"previews":[{"id":"a","functionName":"A"}]}""".toByteArray(),
+        "classes/app.jar" to appJar,
+        "previews/a.png" to cover,
+      ),
+    )
+  }
+
+  @Test
+  fun `strips fonts, writes them content-addressed, records them in the manifest, and shrinks`() {
+    val font = ByteArray(4000) { (it % 251).toByte() }
+    val bundle = bundleWith(font)
+    val before = bundle.length()
+    val resDir = File(workRoot, "res")
+
+    val result = BundleExternalize.externalize(bundle, resDir)
+
+    // One font lifted out, recorded by path + sha256 + size.
+    assertEquals(1, result.externalized.size)
+    val rec = result.externalized.single()
+    assertEquals("fonts/Roboto-Regular.ttf", rec.path)
+    assertEquals(sha256(font), rec.sha256)
+    assertEquals(4000L, rec.size)
+
+    // The bytes are written content-addressed under res/<sha256> and match the original.
+    val poolFile = File(resDir, rec.sha256)
+    assertTrue(poolFile.isFile)
+    assertEquals(font.toList(), poolFile.readBytes().toList())
+
+    // The font is gone from classes/app.jar; the class stays.
+    val jarNames = jarEntries(bundle, "classes/app.jar").keys
+    assertFalse("fonts/Roboto-Regular.ttf" in jarNames)
+    assertTrue("com/example/CatalogKt.class" in jarNames)
+
+    // The manifest records it in externalResources (parsed via the CLI mirror).
+    val manifest = BundleReader.readMetadata(bundle).manifest
+    assertEquals(1, manifest.externalResources.size)
+    assertEquals("fonts/Roboto-Regular.ttf", manifest.externalResources.single().path)
+    assertEquals(sha256(font), manifest.externalResources.single().sha256)
+    // Other manifest fields survive the raw-JSON edit.
+    assertEquals("desktop", manifest.backend)
+    assertEquals(":samples:design-catalog-m3", manifest.modulePath)
+
+    // The bundle shrank by roughly the font size.
+    assertTrue(bundle.length() < before, "expected the bundle to shrink after externalizing")
+  }
+
+  @Test
+  fun `dedupes identical fonts to a single content-addressed file`() {
+    val font = ByteArray(2000) { (it % 97).toByte() }
+    // Two entries with identical bytes → one pool file.
+    val bundle = bundleWith(font, extraJar = mapOf("fonts/Roboto-Medium.ttf" to font))
+    val resDir = File(workRoot, "res")
+
+    val result = BundleExternalize.externalize(bundle, resDir)
+
+    assertEquals(2, result.externalized.size)
+    assertEquals(1, result.externalized.map { it.sha256 }.toSet().size)
+    // Only one physical file in the pool (deduped by content address).
+    assertEquals(listOf(sha256(font)), resDir.listFiles()!!.map { it.name })
+  }
+
+  @Test
+  fun `re-running externalize is idempotent`() {
+    val font = ByteArray(1500) { (it % 61).toByte() }
+    val bundle = bundleWith(font)
+    val resDir = File(workRoot, "res")
+
+    BundleExternalize.externalize(bundle, resDir)
+    val afterFirst = bundle.readBytes()
+    // A second run finds the font already gone from the jar → externalizes nothing new, and the
+    // bundle bytes are unchanged (byte-stable).
+    val second = BundleExternalize.externalize(bundle, resDir)
+    assertEquals(0, second.externalized.size)
+    assertEquals(afterFirst.toList(), bundle.readBytes().toList())
+    // The manifest still records exactly one resource (not duplicated).
+    assertEquals(1, BundleReader.readMetadata(bundle).manifest.externalResources.size)
+  }
+
+  @Test
+  fun `respects a custom extension list`() {
+    val font = ByteArray(800) { it.toByte() }
+    val bundle =
+      bundleWith(font, extraJar = mapOf("data/strings.bin" to ByteArray(500) { it.toByte() }))
+    val resDir = File(workRoot, "res")
+
+    // Only lift .bin — the ttf stays inline.
+    val result = BundleExternalize.externalize(bundle, resDir, extensions = listOf("bin"))
+
+    assertEquals(listOf("data/strings.bin"), result.externalized.map { it.path })
+    val jarNames = jarEntries(bundle, "classes/app.jar").keys
+    assertTrue("fonts/Roboto-Regular.ttf" in jarNames)
+    assertFalse("data/strings.bin" in jarNames)
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
@@ -8,6 +8,7 @@ import java.nio.file.Files
 import javax.imageio.ImageIO
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 /**
@@ -153,7 +154,7 @@ class ServeCatalogStoreTest {
         register = { n, h -> registered[n] = h },
         trust = trust,
         fetch = fetch,
-        buildTrustedBundle = { _, _, alias, _ ->
+        buildTrustedBundle = { _, _, _, alias, _ ->
           captured = alias
           true // pretend the live host took over, so no static host is registered
         },
@@ -165,6 +166,165 @@ class ServeCatalogStoreTest {
     assertEquals(mapOf("button-filled__ideal__default__dark" to "FilledButton_Dark"), captured)
     // The live builder claimed the session, so nothing was registered as a plain static host.
     assertTrue(registered["compose-m3"] == null)
+  }
+
+  @Test
+  fun `a trusted liveBundle's externalized fonts are fetched into a cache and materialized`() {
+    // The bundle's manifest declares an externalized font (lifted out of classes/app.jar by
+    // `bundle externalize`); the store must fetch it from bundle/res/<sha>, verify the hash, cache
+    // it under <root>/.res-cache/, and hand the builder a materialized classpath dir where the font
+    // sits at its recorded path so the daemon's `getResourceAsStream("/fonts/…")` resolves.
+    val font = ByteArray(2048) { (it % 131).toByte() }
+    val sha =
+      java.security.MessageDigest.getInstance("SHA-256").digest(font).joinToString("") {
+        "%02x".format(it)
+      }
+    val bundleBytes =
+      polyglotBundle(
+        manifest =
+          """
+          {"schemaVersion":8,"backend":"desktop","previewIds":["a"],"coverPreviewId":"a",
+           "classpath":[{"kind":"module","path":"classes/app.jar"}],
+           "modulePath":":samples:design-catalog-m3","producedBy":"test",
+           "externalResources":[{"path":"fonts/Roboto-Regular.ttf","sha256":"$sha","size":2048}]}
+          """
+            .trimIndent()
+      )
+    val catalog =
+      """
+      {"schema":"design-parity-catalog/v1","system":"compose-m3",
+       "liveBundle":{"path":"bundle/","file":"compose-m3-bundle.png"},
+       "components":[{"componentId":"Button/Filled","images":[
+         {"path":"images/button-filled/ideal__default__dark.png","theme":"dark","previewId":"FilledButton_Dark"}]}]}
+      """
+        .trimIndent()
+    val fetch: (String) -> ByteArray? = { url ->
+      when {
+        url.endsWith("/${ServeCatalogStore.CATALOG_FILE}") -> catalog.toByteArray()
+        url.endsWith("bundle/compose-m3-bundle.png") -> bundleBytes
+        url.endsWith("bundle/res/$sha") -> font
+        url.endsWith(".png") -> png()
+        else -> null
+      }
+    }
+    val trust =
+      TrustStore(
+        branches = listOf(TrustedBranch("yschimke/compose-ai-tools", "design-artifacts/*"))
+      )
+    val root = tempRoot()
+    var capturedDir: File? = null
+    val store =
+      ServeCatalogStore(
+        root = root,
+        register = { n, h -> registered[n] = h },
+        trust = trust,
+        fetch = fetch,
+        buildTrustedBundle = { _, _, externalResourcesDir, _, _ ->
+          capturedDir = externalResourcesDir
+          true
+        },
+      )
+    val result = store.load("compose-m3")
+
+    assertTrue(result is ServeCatalogStore.Result.Ok)
+    // The builder got a materialized dir with the font at its recorded classpath path.
+    val dir = capturedDir
+    assertTrue(dir != null && dir.isDirectory, "expected a materialized external-resources dir")
+    val materializedFont = File(dir, "fonts/Roboto-Regular.ttf")
+    assertTrue(materializedFont.isFile, "font materialized at its classpath path")
+    assertEquals(font.toList(), materializedFont.readBytes().toList())
+    // It was cached content-addressed under the shared cache dir.
+    assertTrue(File(root, "${ServeCatalogStore.RES_CACHE_DIR}/$sha").isFile)
+  }
+
+  @Test
+  fun `a liveBundle whose externalized font fails to fetch skips the live bundle`() {
+    // Fail-closed: a declared external resource that can't be fetched must NOT stand up a live
+    // daemon (it would render with the font missing) — the store falls through to the static host.
+    val sha = "a".repeat(64)
+    val bundleBytes =
+      polyglotBundle(
+        manifest =
+          """
+          {"schemaVersion":8,"backend":"desktop","previewIds":["a"],"coverPreviewId":"a",
+           "classpath":[{"kind":"module","path":"classes/app.jar"}],
+           "modulePath":":m","producedBy":"test",
+           "externalResources":[{"path":"fonts/x.ttf","sha256":"$sha","size":10}]}
+          """
+            .trimIndent()
+      )
+    val catalog =
+      """
+      {"schema":"design-parity-catalog/v1","system":"compose-m3",
+       "liveBundle":{"path":"bundle/","file":"compose-m3-bundle.png"},
+       "components":[{"componentId":"Button/Filled","images":[
+         {"path":"images/button-filled/ideal__default__dark.png","theme":"dark"}]}]}
+      """
+        .trimIndent()
+    val fetch: (String) -> ByteArray? = { url ->
+      when {
+        url.endsWith("/${ServeCatalogStore.CATALOG_FILE}") -> catalog.toByteArray()
+        url.endsWith("bundle/compose-m3-bundle.png") -> bundleBytes
+        // bundle/res/<sha> intentionally 404s
+        url.endsWith(".png") -> png()
+        else -> null
+      }
+    }
+    val trust =
+      TrustStore(
+        branches = listOf(TrustedBranch("yschimke/compose-ai-tools", "design-artifacts/*"))
+      )
+    var builderCalled = false
+    val store =
+      ServeCatalogStore(
+        root = tempRoot(),
+        register = { n, h -> registered[n] = h },
+        trust = trust,
+        fetch = fetch,
+        buildTrustedBundle = { _, _, _, _, _ ->
+          builderCalled = true
+          true
+        },
+      )
+    val result = store.load("compose-m3")
+
+    assertTrue(result is ServeCatalogStore.Result.Ok)
+    // The builder was never reached (fail-closed), and the static baked host serves instead.
+    assertFalse(builderCalled, "live builder must not run when a declared font can't be fetched")
+    assertTrue(registered["compose-m3"] != null, "static host registered as the fallback")
+  }
+
+  /** Build a minimal desktop-bundle polyglot (PNG cover + zip) with the given bundle.json. */
+  private fun polyglotBundle(manifest: String): ByteArray {
+    val cover = png()
+    val appJar =
+      ByteArrayOutputStream()
+        .also { baos ->
+          java.util.zip.ZipOutputStream(baos).use { z ->
+            z.putNextEntry(java.util.zip.ZipEntry("com/example/CatalogKt.class"))
+            z.write(byteArrayOf(0xCA.toByte(), 0xFE.toByte(), 0, 0))
+            z.closeEntry()
+          }
+        }
+        .toByteArray()
+    val zip =
+      ByteArrayOutputStream()
+        .also { baos ->
+          java.util.zip.ZipOutputStream(baos).use { z ->
+            for ((name, bytes) in
+              linkedMapOf(
+                "bundle.json" to manifest.toByteArray(),
+                "previews.json" to """{"previews":[{"id":"a","functionName":"A"}]}""".toByteArray(),
+                "classes/app.jar" to appJar,
+              )) {
+              z.putNextEntry(java.util.zip.ZipEntry(name))
+              z.write(bytes)
+              z.closeEntry()
+            }
+          }
+        }
+        .toByteArray()
+    return cover + zip
   }
 
   @Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
@@ -294,6 +294,82 @@ class ServeCatalogStoreTest {
     assertTrue(registered["compose-m3"] != null, "static host registered as the fallback")
   }
 
+  @Test
+  fun `a same-size but corrupt cache entry is re-fetched, not trusted`() {
+    // The cache key is a sha256, so a pre-existing cache file with the right size but wrong bytes
+    // (a partial write / disk fault) must be re-fetched and repaired — not silently materialized.
+    val font = ByteArray(2048) { (it % 131).toByte() }
+    val sha = shaHex(font)
+    val bundleBytes =
+      polyglotBundle(
+        manifest =
+          """
+          {"schemaVersion":8,"backend":"desktop","previewIds":["a"],"coverPreviewId":"a",
+           "classpath":[{"kind":"module","path":"classes/app.jar"}],
+           "modulePath":":m","producedBy":"test",
+           "externalResources":[{"path":"fonts/Roboto-Regular.ttf","sha256":"$sha","size":2048}]}
+          """
+            .trimIndent()
+      )
+    val catalog =
+      """
+      {"schema":"design-parity-catalog/v1","system":"compose-m3",
+       "liveBundle":{"path":"bundle/","file":"compose-m3-bundle.png"},
+       "components":[{"componentId":"Button/Filled","images":[
+         {"path":"images/button-filled/ideal__default__dark.png","theme":"dark","previewId":"FilledButton_Dark"}]}]}
+      """
+        .trimIndent()
+    var resFetches = 0
+    val fetch: (String) -> ByteArray? = { url ->
+      when {
+        url.endsWith("/${ServeCatalogStore.CATALOG_FILE}") -> catalog.toByteArray()
+        url.endsWith("bundle/compose-m3-bundle.png") -> bundleBytes
+        url.endsWith("bundle/res/$sha") -> {
+          resFetches++
+          font
+        }
+        url.endsWith(".png") -> png()
+        else -> null
+      }
+    }
+    val trust =
+      TrustStore(
+        branches = listOf(TrustedBranch("yschimke/compose-ai-tools", "design-artifacts/*"))
+      )
+    val root = tempRoot()
+    // Pre-seed the shared cache with a same-size but WRONG-content entry.
+    val cacheFile =
+      File(root, "${ServeCatalogStore.RES_CACHE_DIR}/$sha").apply {
+        parentFile.mkdirs()
+        writeBytes(ByteArray(2048) { 0 })
+      }
+    var capturedDir: File? = null
+    val store =
+      ServeCatalogStore(
+        root = root,
+        register = { n, h -> registered[n] = h },
+        trust = trust,
+        fetch = fetch,
+        buildTrustedBundle = { _, _, externalResourcesDir, _, _ ->
+          capturedDir = externalResourcesDir
+          true
+        },
+      )
+    store.load("compose-m3")
+
+    // The corrupt entry was refetched (not trusted by size alone) and the cache repaired.
+    assertEquals(1, resFetches)
+    assertEquals(font.toList(), cacheFile.readBytes().toList())
+    // The materialized font on the classpath is the correct bytes.
+    val materializedFont = File(capturedDir!!, "fonts/Roboto-Regular.ttf")
+    assertEquals(font.toList(), materializedFont.readBytes().toList())
+  }
+
+  private fun shaHex(bytes: ByteArray) =
+    java.security.MessageDigest.getInstance("SHA-256").digest(bytes).joinToString("") {
+      "%02x".format(it)
+    }
+
   /** Build a minimal desktop-bundle polyglot (PNG cover + zip) with the given bundle.json. */
   private fun polyglotBundle(manifest: String): ByteArray {
     val cover = png()

--- a/docs/portable-bundles.md
+++ b/docs/portable-bundles.md
@@ -138,6 +138,37 @@ The minimizer (`BundlePreviewTask.closureWalk`) already takes a flat
 `scanPaths = classDirs + jars` — it has **no Gradle dependency**, so a contrib
 producer can reuse the same reachability pruning over Bazel/Amper outputs.
 
+### Externalized resources (post-pack, opt-in) — fonts fetched, not carried
+
+A desktop-CMP catalog embeds its real font faces (Roboto / Noto Serif / Droid
+Sans Mono, ~570 KB) inside `classes/app.jar` so the live daemon rasterises text
+with the same faces the baked stickers used. Carrying those bytes on **every**
+`design-artifacts/<system>` branch — re-fetched on each catalog reload — bloats
+the ~600 KB bundle for data that rarely changes and is identical across variants.
+
+`compose-preview bundle externalize <bundle.png> --res-out <dir>` lifts them out:
+
+```
+classes/app.jar        # fonts/*.ttf REMOVED (only classes + small resources remain) → ~30 KB
+bundle.json            # externalResources: [{path, sha256, size}] records each lifted resource
+<res-out>/<sha256>     # each font's bytes, content-addressed (identical fonts dedupe to one file)
+```
+
+The publish pipeline (`generate-design-catalog.mjs`) runs it after copying the
+live bundle and carries the pool once per branch at `bundle/res/<sha256>`. A
+trusted, re-rendering server (`serve --allow-render-trusted`) reads
+`externalResources` from the fetched bundle, fetches each `bundle/res/<sha256>`
+into a **shared, content-addressed on-disk cache** (`<root>/.res-cache/`), and
+materializes them at their recorded classpath path onto the daemon classpath, so
+`getResourceAsStream("/fonts/…")` resolves exactly as it did with the fonts
+inline. Fail-closed: a declared-but-unfetchable resource skips the live tier
+(serving baked PNGs) rather than render with the font missing.
+
+Additive + post-pack (like signing): a normal `bundle pack` stays
+self-contained (`externalResources` empty), the step doesn't bump
+`schemaVersion`, and a pre-externalize reader just finds fewer resources in the
+jar. Idempotent — re-running finds the fonts already gone and changes nothing.
+
 ### Proposed additive schema (v3) for cross-build-system portability
 
 Today `ClasspathEntry` (in both `PreviewBundleFormat.kt` and the viewer's mirror

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewBundleFormat.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewBundleFormat.kt
@@ -212,6 +212,42 @@ data class BundleManifest(
    * both resolve inside the bundle (the producer's original module-relative report paths don't).
    */
   val dataExtensions: List<BundleDataExtension> = emptyList(),
+  /**
+   * (v8, post-pack) Large binary resources (fonts, …) that were **lifted out** of `classes/app.jar`
+   * by the `compose-preview bundle externalize` step and are fetched on demand instead of carried
+   * inline. Each entry records the resource's original classpath path (e.g.
+   * `fonts/Roboto-Regular.ttf`), the lowercase-hex SHA-256 of its bytes, and its size. The
+   * externalize step publishes the bytes content-addressed (by [BundleExternalResource.sha256])
+   * beside the bundle, and a re-rendering server rehydrates them into a shared hash-keyed cache and
+   * back onto the daemon classpath at their recorded [BundleExternalResource.path], so
+   * `getResourceAsStream("/fonts/…")` resolves exactly as it did with the fonts inline. Empty on a
+   * normal pack (the bundle stays self-contained) — populated only after an explicit externalize,
+   * which is why it's additive and doesn't bump [schemaVersion] (a post-pack transform, like
+   * signing). A pre-externalize reader ignores it and just finds fewer resources in the jar; a
+   * font-parity render needs the rehydration. See [BundleExternalResource].
+   */
+  val externalResources: List<BundleExternalResource> = emptyList(),
+)
+
+/**
+ * One resource lifted out of `classes/app.jar` by `bundle externalize` and fetched on demand. See
+ * [BundleManifest.externalResources]. The bytes are published content-addressed by [sha256] beside
+ * the bundle (`bundle/res/<sha256>` on the design-artifacts branch); a server rehydrates them onto
+ * the daemon classpath at [path] so resource lookups resolve unchanged.
+ */
+@Serializable
+data class BundleExternalResource(
+  /**
+   * The resource's classpath-relative path inside the original jar, e.g.
+   * `fonts/Roboto-Regular.ttf`.
+   */
+  val path: String,
+  /**
+   * Lowercase-hex SHA-256 of the resource bytes — the content-addressed key it's published under.
+   */
+  val sha256: String,
+  /** Size of the resource in bytes, for diagnostics + a fetch sanity check. */
+  val size: Long,
 )
 
 /**

--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -31,6 +31,7 @@
  * The caller (the weekly workflow) commits the result to the system's
  * `design-artifacts/<system>` branch.
  */
+import { execFileSync } from "node:child_process";
 import { cp, mkdir, readFile, readdir, writeFile } from "node:fs/promises";
 import { basename, dirname, resolve, join, relative } from "node:path";
 import { parseArgs } from "node:util";
@@ -535,6 +536,33 @@ if (values["publish-live-bundle"]) {
   await cp(rendersPath, dest);
   liveBundle = { path: "bundle/", file };
   console.log(`[${spec.system}] carried live bundle → bundle/${file}`);
+
+  // Lift the heavy font resources out of the carried bundle's classes/app.jar and publish them
+  // content-addressed under bundle/res/<sha256>, so the ~600 KB bundle drops to ~30 KB and the
+  // fonts (which rarely change and are identical across variants) are fetched once per branch. The
+  // `bundle externalize` step records each in the bundle's own manifest by name+sha256+size; a
+  // trusted `serve --allow-render-trusted` box rehydrates them from bundle/res/ into a shared cache
+  // and back onto the daemon classpath. Non-fatal: if the CLI can't externalize (older CLI, no
+  // fonts), the self-contained bundle is still published as-is.
+  try {
+    const resOut = join(outPath, "bundle", "res");
+    const out = execFileSync(
+      "compose-preview",
+      ["bundle", "externalize", dest, "--res-out", resOut, "--json"],
+      { encoding: "utf8" },
+    );
+    const summary = JSON.parse(out);
+    const total = (summary.externalized ?? []).reduce((n, r) => n + (r.size ?? 0), 0);
+    console.log(
+      `[${spec.system}] externalized ${(summary.externalized ?? []).length} font resource(s) ` +
+        `(${total} B) → bundle/res/  (bundle now ${summary.size} B)`,
+    );
+  } catch (err) {
+    console.warn(
+      `[${spec.system}] bundle externalize skipped (${err.message?.split("\n")[0] ?? err}) — ` +
+        `publishing the self-contained bundle`,
+    );
+  }
 }
 
 {


### PR DESCRIPTION
## Why

The published `compose-m3` `liveBundle` (`app.jar`) was **598,916 B**, ~570 KB of it the embedded font faces (Roboto‑Regular/Medium, NotoSerif‑Regular, DroidSansMono) that the live desktop daemon needs so text rasterises with the same faces the baked stickers used. Carrying those bytes on **every** `design-artifacts/<system>` branch — re‑fetched by the public server on each catalog reload — is wasteful: fonts rarely change and are identical across variants. 600 KB is too big.

This lifts the fonts **out** of the bundle and loads them from a shared, content‑addressed server cache (the "trusted branch" approach). The current Live fix (#2269, shipped in v0.16.24) still makes Live work with fonts inline; this shrinks what's published.

## What changed

**Bundle format** — `bundle.json` gains `externalResources: [{path, sha256, size}]` (plugin `BundleManifest` + CLI `BundleReader.Manifest` mirror). Additive and post‑pack (like signing), so it does **not** bump `schemaVersion`; a normal `bundle pack` stays fully self‑contained (empty list).

**`compose-preview bundle externalize <bundle.png> --res-out <dir>`** (new CLI subcommand) — strips `.ttf/.otf/.woff/.woff2` entries out of `classes/app.jar`, writes each font content‑addressed to `<dir>/<sha256>` (identical fonts dedupe to one file), records `{path, sha256, size}` in the manifest (edited as a raw JSON tree, so no unmodelled fields are lost), and rewrites the polyglot in place preserving the PNG cover. Idempotent and byte‑stable.

**Server** (`ServeCatalogStore` + `ServeBundleDaemon`) — after fetching a Trusted `liveBundle`, reads `externalResources`, fetches each `bundle/res/<sha256>` into a **shared, content‑addressed on‑disk cache** (`<root>/.res-cache/`, reused across systems + reloads), verifies the sha256, materializes each at its recorded classpath path, and adds that dir to the daemon classpath — so `getResourceAsStream("/fonts/…")` resolves exactly as it did with the fonts inline. **Fail‑closed:** a declared‑but‑unfetchable/mismatched resource skips the live tier (serving baked PNGs) instead of running the daemon with fonts missing (which is the `ExceptionInInitializerError` #2269 fixed).

**Publish pipeline** (`generate-design-catalog.mjs`) — shells out to `bundle externalize` right after copying the live bundle, publishing the pool once per branch under `bundle/res/<sha256>`. The workflow's `cd out && git add -A` carries it automatically. Non‑fatal: if the CLI can't externalize, the self‑contained bundle is published as‑is.

## Size impact

`app.jar` (fonts inline) → **~599 KB**; after externalize → **~30 KB carried in the bundle** + the fonts once per branch under `bundle/res/`, fetched once and cached server‑side.

## Visual evidence

Non‑visual / plumbing change — **rendered output is unchanged by design**. The point is that the fonts still resolve at the same `/fonts/…` classpath path after rehydration, so live renders (and the baked stickers, which are untouched) look identical; if rehydration ever failed, the fail‑closed path serves the same baked PNGs rather than a font‑less render. Correctness is covered by unit tests rather than pixels: `BundleExternalizeTest` asserts the byte‑exact font is restored from the content‑addressed pool, and `ServeCatalogStoreTest` asserts the server materializes the exact font bytes onto the classpath and falls back closed on a fetch miss.

## Test plan

- `./gradlew :cli:test --tests "*BundleExternalizeTest" --tests "*ServeCatalogStoreTest" :gradle-plugin:compileKotlin` — green.
  - `BundleExternalizeTest`: strip + content‑address + record + shrink; dedupe identical fonts to one pool file; idempotent + byte‑stable re‑run; custom `--ext` list.
  - `ServeCatalogStoreTest`: a trusted liveBundle's externalized font is fetched into the shared cache and materialized at its classpath path; a fetch miss is fail‑closed (static host serves instead).
- `:cli:ktfmtCheck` / `:gradle-plugin:ktfmtCheck` — clean.

Follow‑up after merge: dispatch `design-artifacts.yml` (ref `main`) so `design-artifacts/compose-m3` re‑publishes the slimmed bundle + `bundle/res/` pool, then confirm the box serves Live from the smaller bundle.

_Generated by [Claude Code]_

---
_Generated by [Claude Code](https://claude.ai/code/session_01WGVyWcXTvsYbmCtLEXU7tn)_