### PR TITLE
fix(samples): build design-catalog-m3-android at compileSdk 37 for material3 alpha22

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -47,15 +47,12 @@ compose-multiplatform = "1.10.3"
 # material3 1.5.0-alpha18. The catalog documents the focus indicator the design
 # system now ships, so it needs the real API; the override is scoped to that one
 # module (its build.gradle.kts) and nothing else in the repo rides the alpha.
-# Pinned to alpha18 specifically: it's the release that ADDED the inset ring while
-# still building on Compose 1.11.0-beta02 (compileSdk 36). alpha19+ jump to Compose
-# 1.12.0-alpha, which requires compileSdk 37 and would drag the whole module's
-# floor forward. Drop this and revert to `libs.compose.material3` once material3
-# 1.5.0 is stable in `compose-bom-stable`.
-#  * Renovate's `gradle-minorpatch` bump to alpha22 crossed that boundary and
-#    pulled `androidx.compose.animation:animation-core-android:1.12.0-alpha03`
-#    (minCompileSdk 37), failing `:samples:design-catalog-m3-android`'s
-#    `checkDebugAarMetadata` at compileSdk 36 — so the pin stays at alpha18.
+# alpha19+ jump to the Compose 1.12.0-alpha line, whose AAR metadata declares
+# minCompileSdk 37 (via `androidx.compose.animation:animation-core-android:1.12.0-alpha03`).
+# `:samples:design-catalog-m3-android` therefore builds at `compileSdk = 37` (see its
+# build.gradle.kts) rather than the repo default 36 — a scoped divergence, like
+# `:samples:design-catalog-remote-m3`. Drop this pin and revert to `libs.compose.material3`
+# once material3 1.5.0 is stable in `compose-bom-stable`.
 compose-material3-catalog = "1.5.0-alpha22"
 # JetBrains Compose Multiplatform material3 tracks its own line: the
 # `org.jetbrains.compose` 1.10.3 plugin pins `compose.material3` to 1.9.0

--- a/samples/design-catalog-m3-android/build.gradle.kts
+++ b/samples/design-catalog-m3-android/build.gradle.kts
@@ -27,10 +27,15 @@ composePreview {
 
 android {
   namespace = "com.example.designcatalogm3android"
+  // material3 1.5.0-alpha22 (the inset-focus-ring artifact this supplement rides) jumped onto the
+  // Compose 1.12.0-alpha line, whose AAR metadata declares minCompileSdk 37 — so this module
+  // diverges from the repo's default `compileSdk = 36` (Robolectric stays pinned to 35 above, since
+  // the project toolchain is JDK 17). Same divergence as `:samples:design-catalog-remote-m3`.
+  compileSdk = 37
 
   defaultConfig {
     applicationId = "com.example.designcatalogm3android"
-    targetSdk = 36
+    targetSdk = 37
     versionCode = 1
     versionName = "1.0"
   }


### PR DESCRIPTION
## Why

Renovate (#2270, `dc9248f5`) bumped `compose-material3-catalog` `1.5.0-alpha18 → 1.5.0-alpha22`, which moved onto the Compose `1.12.0-alpha` line. That artifact's AAR metadata declares **minCompileSdk 37** (via `androidx.compose.animation:animation-core-android:1.12.0-alpha03`), so `:samples:design-catalog-m3-android` — the only consumer of the pin — fails `checkDebugAarMetadata` at the repo's default `compileSdk 36`:

```
> A failure occurred while executing
  com.android.build.gradle.internal.tasks.CheckAarMetadataWorkAction
```

The version catalog's own comment already documented this boundary (*"alpha19+ jump to Compose 1.12.0-alpha, which requires compileSdk 37"*) but the value was bumped past it anyway. This broke:
- the **design-artifacts `compose-m3`** render (the job packs this module as the Android sticker supplement), and
- the **Apply compose-preview** Android render — both on `main` since the bump.

## Fix

Follow the bump rather than revert it: build this one module at `compileSdk = 37` / `targetSdk = 37` — the same scoped divergence `:samples:design-catalog-remote-m3` already uses for the same reason. Robolectric stays pinned to SDK 35 (the JDK-17 toolchain), unchanged. Refreshed the version-catalog note, which still described the old alpha18 pin.

No other module references `compose-material3-catalog`, so the divergence stays scoped to this Android supplement.

## Test plan

- `:samples:design-catalog-m3-android:checkDebugAarMetadata` — **green** at `compileSdk 37` (the exact task that was failing at 36; verified locally).
- CI: the **Apply compose-preview** Android render and the design-artifacts `compose-m3` job (which packs this module) exercise the full Robolectric render at 37.

Non-visual build-config change — the rendered stickers are unchanged (same material3 focus-ring previews, just compiled against a higher SDK), so no before/after pixels apply.

_Generated by [Claude Code](https://claude.ai/code/session_01WGVyWcXTvsYbmCtLEXU7tn)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01WGVyWcXTvsYbmCtLEXU7tn)_