### PR TITLE
feat: add overrideable clearBackground ("crisp outline") preview toggle

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeOverrides.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeOverrides.kt
@@ -55,6 +55,10 @@ object ServeOverrides {
       "orientation",
       "inspectionMode",
       "slotMode",
+      // "crisp outline" toggle. Friendly `background=clear` (aliases below) or the raw
+      // `clearBackground=true`; both map to `PreviewOverrides.clearBackground`.
+      "background",
+      "clearBackground",
     )
 
   /**
@@ -159,6 +163,40 @@ object ServeOverrides {
           }
         }
 
+    // Cleared background ("crisp outline"). Two spellings: the friendly `background=clear`
+    // (aliases `transparent` / `none` / `off`; `default` / `show` mean "keep the preview's
+    // background") and the raw boolean `clearBackground=true`. A present `background` key wins over
+    // `clearBackground`. Absent → null (discovery-time background).
+    val clearBackground: Boolean? =
+      when {
+        !blank("background") ->
+          when (params.getValue("background").lowercase()) {
+            "clear",
+            "transparent",
+            "none",
+            "off" -> true
+            "default",
+            "show",
+            "on" -> false
+            else ->
+              return OverrideParse.Invalid(
+                "background must be 'clear' or 'default', got '${params["background"]}'"
+              )
+          }
+        !blank("clearBackground") ->
+          when (params.getValue("clearBackground").lowercase()) {
+            "true",
+            "1" -> true
+            "false",
+            "0" -> false
+            else ->
+              return OverrideParse.Invalid(
+                "clearBackground must be a boolean, got '${params["clearBackground"]}'"
+              )
+          }
+        else -> null
+      }
+
     // Named-override knobs (`knob.<key>=<kind>:<value>`). A malformed typed value is a hard
     // Invalid (mirrors the numeric fields) rather than a silently-dropped edit.
     val namedOverrides = mutableMapOf<String, PreviewOverrideValue>()
@@ -206,6 +244,7 @@ object ServeOverrides {
         device = params["device"]?.takeIf { it.isNotBlank() },
         inspectionMode = inspectionMode,
         slotMode = slotMode,
+        clearBackground = clearBackground,
         namedOverrides = namedOverrides.ifEmpty { null },
       )
     )
@@ -230,6 +269,7 @@ object ServeOverrides {
       append("dev=").append(o.device).append('|')
       append("insp=").append(o.inspectionMode).append('|')
       append("slot=").append(o.slotMode).append('|')
+      append("clearbg=").append(o.clearBackground).append('|')
       // Named overrides participate so a knob edit isn't coalesced onto the prior render. Sorted by
       // key for order-independence; the value data classes have stable toString.
       append("named=")

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -735,6 +735,12 @@ object ServeWeb {
               <option value="landscape">Landscape</option>
             </select>
           </label>
+          <label>Background
+            <select id="cp-background"$serverDis>
+              <option value="">(default)</option>
+              <option value="clear">Clear (crisp outline)</option>
+            </select>
+          </label>
           ${overrideKnobsHtml(preview, canApplyOverrides)}
           <div class="cp-status" id="cp-status"></div>
         </div>
@@ -784,7 +790,7 @@ object ServeWeb {
       // scale slider has no empty state, so it's gated separately: we only send fontScale once the
       // user moves it (fontScaleTouched), otherwise the slider's standing 1.0 would override a
       // preview's declared default font scale and the first render wouldn't match the thumbnail.
-      var fields = ["uiMode", "device", "localeTag", "orientation"];
+      var fields = ["uiMode", "device", "localeTag", "orientation", "background"];
       var fs = document.getElementById("cp-fontScale");
       var fsVal = document.getElementById("cp-fontScale-val");
       var fontScaleTouched = false;

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeOverridesTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeOverridesTest.kt
@@ -33,6 +33,7 @@ class ServeOverridesTest {
     assertNull(o.density)
     assertNull(o.inspectionMode)
     assertNull(o.slotMode)
+    assertNull(o.clearBackground)
   }
 
   @Test
@@ -85,11 +86,41 @@ class ServeOverridesTest {
         mapOf("widthPx" to "-5"),
         mapOf("inspectionMode" to "maybe"),
         mapOf("slotMode" to "maybe"),
+        mapOf("background" to "polkadot"),
+        mapOf("clearBackground" to "maybe"),
       )) {
       val parsed = ServeOverrides.parse(bad)
       assertTrue(parsed is OverrideParse.Invalid, "expected Invalid for $bad, got $parsed")
       assertTrue(parsed.message.isNotBlank())
     }
+  }
+
+  @Test
+  fun `background clear aliases map to clearBackground true`() {
+    for (v in listOf("clear", "transparent", "none", "off", "CLEAR")) {
+      assertEquals(true, ok(mapOf("background" to v)).clearBackground, "background=$v")
+    }
+    for (v in listOf("default", "show", "on")) {
+      assertEquals(false, ok(mapOf("background" to v)).clearBackground, "background=$v")
+    }
+    // Raw boolean spelling.
+    assertEquals(true, ok(mapOf("clearBackground" to "true")).clearBackground)
+    assertEquals(false, ok(mapOf("clearBackground" to "false")).clearBackground)
+    // `background` wins over `clearBackground` when both are present.
+    assertEquals(
+      true,
+      ok(mapOf("background" to "clear", "clearBackground" to "false")).clearBackground,
+    )
+    // Absent leaves it null (discovery-time background).
+    assertNull(ok(emptyMap()).clearBackground)
+  }
+
+  @Test
+  fun `cache key differs when clearBackground changes`() {
+    assertNotEquals(
+      ServeOverrides.cacheKey("preview.A", ok(emptyMap())),
+      ServeOverrides.cacheKey("preview.A", ok(mapOf("background" to "clear"))),
+    )
   }
 
   @Test

--- a/daemon/android/build.gradle.kts
+++ b/daemon/android/build.gradle.kts
@@ -61,6 +61,9 @@ dependencies {
   // path); the Android registry advertises the kind from a stub that returns NotAvailable
   // until the in-sandbox observer install lands in a follow-up.
   implementation(project(":data-recomposition-core"))
+  // `LocalPreviewBackgroundCleared` — provided around the rendered preview so a composable that
+  // draws its own opaque fill can drop it under the `clearBackground` ("crisp outline") override.
+  implementation(project(":slot-preview-runtime"))
   implementation(project(":data-fonts-connector"))
   implementation(project(":data-render-connector"))
   implementation(project(":data-history-connector"))

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
@@ -132,6 +132,7 @@ class PreviewManifestRouter(
         append("captureAdvanceMs=").append(it).append(';')
       }
       inbound["inspectionMode"]?.let { append("inspectionMode=").append(it).append(';') }
+      inbound["clearBackground"]?.let { append("clearBackground=").append(it).append(';') }
       inbound["overrides"]?.let { append("overrides=").append(it).append(';') }
       inbound["mode"]?.let { append("mode=").append(it).append(';') }
       // Manifest-resolved kind forwards through verbatim; an inbound `kind=` override (rare —

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -356,7 +356,13 @@ class RenderEngine(
                 // through rather than parking under the paused clock — same trade the standalone
                 // renderer already pays in its always-on a11y pass.
                 val inspectionMode = if (effectiveRunAccessibility) false else spec.inspectionMode ?: true
-                CompositionLocalProvider(LocalInspectionMode provides inspectionMode) {
+                CompositionLocalProvider(
+                  LocalInspectionMode provides inspectionMode,
+                  // Cleared background ("crisp outline"): a composable drawing its own opaque fill
+                  // drops it to match the transparent decor-view background. Defaults false.
+                  ee.schimke.composeai.preview.slots.LocalPreviewBackgroundCleared provides
+                    spec.clearBackground,
+                ) {
                   CaptureMaterialTheme { _, typography, shapes, payload ->
                     themeFallbackCapture.capture(typography, shapes)
                     themeFallbackCapture.capture(payload)
@@ -911,7 +917,11 @@ class RenderEngine(
           val bgArgb = resolveBackgroundColor(spec).toArgb()
           val heightDp = pxToDp(spec.heightPx, spec.density)
           rule.setContent {
-            CompositionLocalProvider(LocalInspectionMode provides false) {
+            CompositionLocalProvider(
+              LocalInspectionMode provides false,
+              ee.schimke.composeai.preview.slots.LocalPreviewBackgroundCleared provides
+                spec.clearBackground,
+            ) {
               Box(modifier = Modifier.fillMaxSize().background(Color(bgArgb))) {
                 InvokeComposable(composableMethod)
               }
@@ -998,6 +1008,7 @@ class RenderEngine(
 
   private fun resolveBackgroundColor(spec: RenderSpec): Color =
     when {
+      spec.clearBackground -> Color.Transparent
       spec.backgroundColor != 0L -> Color(spec.backgroundColor.toInt())
       spec.showBackground -> Color.White
       else -> Color.Transparent
@@ -1376,6 +1387,13 @@ data class RenderSpec(
   val showBackground: Boolean = true,
   val backgroundColor: Long = 0L,
   /**
+   * Per-render cleared-background toggle ("crisp outline"). When `true` the harness background is
+   * forced transparent (overriding [showBackground]/[backgroundColor]) and
+   * `LocalPreviewBackgroundCleared = true` is provided around the preview. Default `false` preserves
+   * the discovery-time background.
+   */
+  val clearBackground: Boolean = false,
+  /**
    * Raw `@Preview(device = …)` string when known — `id:wearos_small_round`,
    * `spec:width=…,isRound=true`, `id:pixel_5`, etc. Used by the render body to detect round Wear
    * devices and apply the circular crop / `round` resource qualifier; non-round / null values are
@@ -1484,6 +1502,7 @@ data class RenderSpec(
         density = map["density"]?.toFloatOrNull() ?: defaults.density,
         showBackground = map["showBackground"]?.toBoolean() ?: defaults.showBackground,
         backgroundColor = map["backgroundColor"]?.toLongOrNull() ?: defaults.backgroundColor,
+        clearBackground = map["clearBackground"]?.toBoolean() ?: defaults.clearBackground,
         device = map["device"]?.takeIf { it.isNotBlank() } ?: defaults.device,
         renderMode = map["mode"]?.takeIf { it.isNotBlank() },
         outputBaseName = map["outputBaseName"] ?: defaults.outputBaseName,

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -1316,6 +1316,12 @@ open class RobolectricHost(
           null -> null
         },
       inspectionMode = merged.inspectionMode,
+      // `clearBackground` isn't a `mergePreviewOverrides` display-geometry field, so carry it
+      // straight from the override bag onto the held/recording spec (it then flows into
+      // `InteractiveCommand.Start` and the sandbox render). Without this the live `stream/start`
+      // path keeps the opaque background when the viewer sends `PreviewOverrides(clearBackground =
+      // true)`. Null preserves the discovery-time value.
+      clearBackground = overrides?.clearBackground ?: base.clearBackground,
       overrides = merged.toExtensionOverrides(),
       // Recording sessions consume this on disk (`recordings/<recordingId>/...`); interactive
       // sessions pass `"interactive-$previewId"` and never read the field. The `recording-`

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -1043,6 +1043,7 @@ open class RobolectricHost(
         density = spec.density,
         backgroundColor = spec.backgroundColor,
         showBackground = spec.showBackground,
+        clearBackground = spec.clearBackground,
         device = spec.device,
         outputBaseName = spec.outputBaseName,
         replyLatch = replyLatch,
@@ -2018,6 +2019,7 @@ open class RobolectricHost(
 
       val backgroundArgb =
         when {
+          start.clearBackground -> androidx.compose.ui.graphics.Color.Transparent.toArgb()
           start.backgroundColor != 0L ->
             androidx.compose.ui.graphics.Color(start.backgroundColor.toInt())
               .toArgb()
@@ -2105,6 +2107,8 @@ open class RobolectricHost(
                     androidx.compose.runtime.CompositionLocalProvider(
                       androidx.compose.ui.platform.LocalInspectionMode provides
                         (start.inspectionMode ?: false),
+                      ee.schimke.composeai.preview.slots.LocalPreviewBackgroundCleared provides
+                        start.clearBackground,
                       androidx.compose.runtime.saveable.LocalSaveableStateRegistry provides
                         recreateRegistry,
                     ) {

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/bridge/DaemonHostBridge.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/bridge/DaemonHostBridge.kt
@@ -392,6 +392,9 @@ sealed interface InteractiveCommand {
     val density: Float,
     val backgroundColor: Long,
     val showBackground: Boolean,
+    /** Held-session cleared-background toggle; forces a transparent background and provides
+     * `LocalPreviewBackgroundCleared = true`. `false` preserves the discovery-time background. */
+    val clearBackground: Boolean = false,
     val device: String?,
     val outputBaseName: String,
     val replyLatch: CountDownLatch,

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -1058,6 +1058,10 @@ class JsonRpcServer(
         if (isNotEmpty()) append(';')
         append("slotMode=").append(it)
       }
+      overrides.clearBackground?.let {
+        if (isNotEmpty()) append(';')
+        append("clearBackground=").append(it)
+      }
       // Extension-driven overrides ride along as a single base64-encoded `PreviewOverrides`
       // bag — the renderer's [PreviewOverrideExtensions] hands the bag to every registered
       // planner. New override-driven fields don't need a new wire token; they ride this bag.

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -530,6 +530,18 @@ data class PreviewOverrides(
    */
   val slotMode: Boolean? = null,
   /**
+   * Per-render **cleared background** — the "crisp outline" toggle. When `true`, the renderer
+   * forces a transparent harness background (overriding the discovery-time
+   * `@Preview(showBackground=…)` / `backgroundColor`) AND provides `LocalPreviewBackgroundCleared =
+   * true` around the preview, so a composable that draws its own opaque fill (a Material 3
+   * `Surface`, a catalog sticker) can drop it to match. The result is a component silhouette on
+   * transparency rather than a solid card — the "clean outline" a downstream viewer
+   * (`compose-preview serve`'s `?background=clear`) can toggle with a live re-render.
+   * `null`/`false` preserves the discovery-time background exactly, so an untoggled render is
+   * byte-identical to before. Both backends honour it.
+   */
+  val clearBackground: Boolean? = null,
+  /**
    * Optional Material 3 theme token overrides applied by the renderer as a normal
    * `MaterialTheme(...) { preview() }` wrapper around the invoked preview. This lets callers test
    * components under alternate color, shape, or typography tokens without editing source previews.

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/DeviceOverrideEncodingTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/DeviceOverrideEncodingTest.kt
@@ -103,6 +103,23 @@ class DeviceOverrideEncodingTest {
     assertContainsToken("slotMode=true", captured)
   }
 
+  @Test(timeout = 30_000)
+  fun clearBackgroundOverrideThreadsThroughPayload() {
+    val captured = renderAndCapturePayload(overrides = """{"clearBackground":true}""")
+
+    assertContainsToken("clearBackground=true", captured)
+  }
+
+  @Test(timeout = 30_000)
+  fun noClearBackgroundOverrideLeavesPayloadClean() {
+    val captured = renderAndCapturePayload(overrides = """{"uiMode":"dark"}""")
+
+    assertTrue(
+      "clearBackground must not appear when the override is unset: '$captured'",
+      "clearBackground=" !in captured,
+    )
+  }
+
   private fun assertContainsToken(token: String, payload: String) {
     val tokens = payload.split(';')
     assertTrue(

--- a/daemon/desktop/build.gradle.kts
+++ b/daemon/desktop/build.gradle.kts
@@ -213,6 +213,9 @@ dependencies {
   "testFixturesImplementation"(libs.jetbrains.compose.foundation)
   "testFixturesImplementation"(libs.jetbrains.compose.ui)
   "testFixturesImplementation"(libs.jetbrains.compose.material3)
+  // `LocalPreviewBackgroundCleared` — the `SurfaceCardSquare` fixture reads it to prove the
+  // `clearBackground` override reaches a composable that drops its own opaque fill.
+  "testFixturesImplementation"(project(":slot-preview-runtime"))
 }
 
 // Convenience task — equivalent to `java -cp $(runtimeClasspath) ee.schimke.composeai.daemon

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
@@ -572,6 +572,12 @@ open class DesktopHost(
       uiMode = uiMode,
       orientation = orientation,
       inspectionMode = merged.inspectionMode,
+      // `clearBackground` isn't a `mergePreviewOverrides` field (it's not a display-geometry knob),
+      // so carry it straight from the override bag onto the held/recording spec — otherwise the
+      // live `stream/start` + recording paths would keep the opaque background when the viewer's
+      // Background → Clear toggle sends `PreviewOverrides(clearBackground = true)`. Null preserves
+      // the discovery-time value.
+      clearBackground = overrides?.clearBackground ?: base.clearBackground,
       overrides = merged.toExtensionOverrides(),
       outputBaseName = "recording-$recordingId",
     )

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
@@ -207,6 +207,7 @@ open class DesktopHost(
     add("device")
     add("inspectionMode")
     add("slotMode")
+    add("clearBackground")
     add("material3Theme")
     add("wallpaper")
     // Issue #1205 — `renderNow.overrides.focus` is honoured by the planner registered in
@@ -719,6 +720,7 @@ open class DesktopHost(
       orientation = orientation,
       inspectionMode = map["inspectionMode"]?.toBooleanStrictOrNull() ?: base.inspectionMode,
       slotMode = map["slotMode"]?.toBooleanStrictOrNull() ?: base.slotMode,
+      clearBackground = map["clearBackground"]?.toBoolean() ?: base.clearBackground,
     )
   }
 

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
@@ -148,6 +148,7 @@ class PreviewManifestRouter(
             inbound["captureAdvanceMs"]?.let { append("captureAdvanceMs=").append(it).append(';') }
             inbound["inspectionMode"]?.let { append("inspectionMode=").append(it).append(';') }
             inbound["slotMode"]?.let { append("slotMode=").append(it).append(';') }
+            inbound["clearBackground"]?.let { append("clearBackground=").append(it).append(';') }
             inbound["overrides"]?.let { append("overrides=").append(it).append(';') }
             // `@PreviewWrapper(SomeProvider::class)` FQN sourced from `previews.json` (the
             // gradle plugin's `extractWrapperFqn` reads it off the class-file annotation tables

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -304,6 +304,10 @@ class RenderEngine(
             // Slot mode: a `PreviewSlot` marker renders a labelled placeholder instead of its
             // content, so a structured-screen builder gets a visible slot map. Defaults false.
             ee.schimke.composeai.preview.slots.LocalSlotMode provides (spec.slotMode ?: false),
+            // Cleared background ("crisp outline"): a composable drawing its own opaque fill drops
+            // it to match the transparent harness background below. Defaults false.
+            ee.schimke.composeai.preview.slots.LocalPreviewBackgroundCleared provides
+              spec.clearBackground,
             androidx.compose.ui.LocalSystemTheme provides systemTheme,
             LocalDensity provides density,
             // Interactive Lottie scrubbing: a non-null progress lands the captured frame at that
@@ -324,6 +328,7 @@ class RenderEngine(
             val content: @Composable () -> Unit = {
               val bgColor =
                 when {
+                  spec.clearBackground -> Color.Transparent
                   spec.backgroundColor != 0L -> Color(spec.backgroundColor.toInt())
                   spec.showBackground -> Color.White
                   else -> Color.Transparent
@@ -1069,6 +1074,13 @@ data class RenderSpec(
    */
   val slotMode: Boolean? = null,
   /**
+   * Per-render cleared-background toggle. When `true` the harness background is forced transparent
+   * (overriding [showBackground]/[backgroundColor]) and `LocalPreviewBackgroundCleared = true` is
+   * provided around the preview, so a composable that paints its own opaque fill can drop it for a
+   * crisp transparent outline. Default `false` preserves the discovery-time background.
+   */
+  val clearBackground: Boolean = false,
+  /**
    * Per-call overrides bag, threaded through every registered [PreviewOverrideExtension]. The
    * renderer doesn't read individual fields directly — registered planners decide what to apply.
    * Direct-applied overrides like size, density, and locale stay on this spec's typed fields above
@@ -1157,6 +1169,7 @@ data class RenderSpec(
           },
         inspectionMode = map["inspectionMode"]?.toBooleanStrictOrNull(),
         slotMode = map["slotMode"]?.toBooleanStrictOrNull(),
+        clearBackground = map["clearBackground"]?.toBoolean() ?: defaults.clearBackground,
         overrides = map["overrides"]?.decodePreviewOverrides(),
         wrapperClassName = map["wrapperClassName"]?.takeIf { it.isNotBlank() },
       )

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/RenderEngineClearBackgroundTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/RenderEngineClearBackgroundTest.kt
@@ -1,0 +1,105 @@
+package ee.schimke.composeai.daemon
+
+import java.io.ByteArrayInputStream
+import java.io.File
+import javax.imageio.ImageIO
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * End-to-end proof for the `clearBackground` ("crisp outline") override on the desktop backend.
+ *
+ * Renders [SurfaceCardSquare] — a Material 3 `Surface` that reads `LocalPreviewBackgroundCleared`,
+ * mirroring the design-catalog `CatalogSticker` — twice through the real [RenderEngine] /
+ * [DesktopHost] path:
+ *
+ * * **default** (no override): the harness paints a background AND the `Surface` paints its opaque
+ *   `colorScheme.surface` fill, so the corner pixels are fully opaque.
+ * * **cleared** (`clearBackground=true`): the harness background is forced transparent (Layer 1)
+ *   and the `Surface` drops its own fill (Layer 2, via the provided local), so the corner pixels
+ *   are fully transparent — a component silhouette on transparency.
+ *
+ * The centre purple box is opaque in both, so it's the stable landmark; only the corners move. Both
+ * PNGs are copied to `build/clearbg-evidence/` for the PR's before/after visual evidence.
+ */
+class RenderEngineClearBackgroundTest {
+
+  @get:Rule val tempFolder: TemporaryFolder = TemporaryFolder()
+
+  private fun render(host: DesktopHost, clearBackground: Boolean, baseName: String): File {
+    val payload = buildString {
+      append("className=ee.schimke.composeai.daemon.RedFixturePreviewsKt;")
+      append("functionName=SurfaceCardSquare;")
+      append("widthPx=220;heightPx=96;density=1.0;")
+      if (clearBackground) append("clearBackground=true;")
+      append("outputBaseName=$baseName")
+    }
+    val result = host.submit(RenderRequest.Render(payload = payload), timeoutMs = 60_000)
+    assertNotNull("pngPath must be populated", result.pngPath)
+    val png = File(result.pngPath!!)
+    assertTrue("rendered PNG must exist: ${png.absolutePath}", png.exists())
+    return png
+  }
+
+  /** ARGB of the top-left corner pixel — the background signal. */
+  private fun cornerArgb(png: File): Int {
+    val img = ByteArrayInputStream(png.readBytes()).use { ImageIO.read(it) }
+    assertNotNull("PNG must decode", img)
+    return img.getRGB(2, 2)
+  }
+
+  /** Count of fully-opaque pixels — the amount of "painted" surface in the render. */
+  private fun opaquePixelCount(png: File): Int {
+    val img = ByteArrayInputStream(png.readBytes()).use { ImageIO.read(it) }
+    var n = 0
+    for (y in 0 until img.height) for (x in 0 until img.width) {
+      if (((img.getRGB(x, y) ushr 24) and 0xFF) == 0xFF) n++
+    }
+    return n
+  }
+
+  @Test
+  fun clearBackgroundMakesTheSurfaceTransparent() {
+    val outputDir = tempFolder.newFolder("renders")
+    val engine = RenderEngine(outputDir = outputDir)
+    val host = DesktopHost(engine = engine)
+    host.start()
+    val evidenceDir = File("build/clearbg-evidence").apply { mkdirs() }
+    try {
+      val defaultPng = render(host, clearBackground = false, baseName = "surface-card-default")
+      val clearedPng = render(host, clearBackground = true, baseName = "surface-card-clear")
+
+      defaultPng.copyTo(File(evidenceDir, "surface-card-default.png"), overwrite = true)
+      clearedPng.copyTo(File(evidenceDir, "surface-card-clear.png"), overwrite = true)
+
+      val defaultAlpha = (cornerArgb(defaultPng) ushr 24) and 0xFF
+      val clearedAlpha = (cornerArgb(clearedPng) ushr 24) and 0xFF
+
+      assertEquals("default render corner must be fully opaque", 0xFF, defaultAlpha)
+      assertEquals("cleared render corner must be fully transparent", 0x00, clearedAlpha)
+
+      // The outlined button itself survives clearing — its border stroke + label are still opaque,
+      // so the cleared render is a crisp floating outline, not an empty PNG. But it paints far less
+      // than the default render, whose whole surface card is filled: clearing removes the
+      // background,
+      // not the component.
+      val defaultOpaque = opaquePixelCount(defaultPng)
+      val clearedOpaque = opaquePixelCount(clearedPng)
+      assertTrue(
+        "cleared render must still contain the outlined component (some opaque pixels), got $clearedOpaque",
+        clearedOpaque > 50,
+      )
+      assertTrue(
+        "cleared render ($clearedOpaque opaque px) must paint far less than the filled default " +
+          "($defaultOpaque opaque px) — the surface fill is gone",
+        clearedOpaque < defaultOpaque / 2,
+      )
+    } finally {
+      host.shutdown()
+    }
+  }
+}

--- a/daemon/desktop/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
+++ b/daemon/desktop/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
@@ -547,6 +547,36 @@ fun WallpaperAwareSquare() {
  * backends share the fixture so a wire-level mix-up between interactive and recording paths would
  * surface as the same colour transition test.
  */
+/**
+ * Mirrors the design-catalog `CatalogSticker`: a Material 3 [Surface] that paints an opaque
+ * `colorScheme.surface` fill by default, but drops it to `Color.Transparent` when the render sets
+ * [ee.schimke.composeai.preview.slots.LocalPreviewBackgroundCleared] (the `clearBackground` "crisp
+ * outline" override). The content is a real M3 [OutlinedButton] — a component that is *itself*
+ * mostly transparent (a bordered outline with a text label), so clearing the surface leaves a crisp
+ * floating outline on transparency rather than a button embedded in a solid card. The corner pixels
+ * carry the *background* signal — opaque light surface when not cleared, fully transparent when
+ * cleared. Used by [RenderEngineClearBackgroundTest] to prove the override reaches both the harness
+ * background (Layer 1) and a composable's own fill (Layer 2), and to emit before/after visual
+ * evidence.
+ */
+@Composable
+fun SurfaceCardSquare() {
+  MaterialTheme(colorScheme = lightColorScheme()) {
+    val cleared = ee.schimke.composeai.preview.slots.LocalPreviewBackgroundCleared.current
+    Surface(
+      color = if (cleared) Color.Transparent else MaterialTheme.colorScheme.surface,
+      contentColor = MaterialTheme.colorScheme.onSurface,
+    ) {
+      Box(
+        modifier = Modifier.fillMaxSize().padding(16.dp),
+        contentAlignment = androidx.compose.ui.Alignment.Center,
+      ) {
+        androidx.compose.material3.OutlinedButton(onClick = {}) { Text("Outlined") }
+      }
+    }
+  }
+}
+
 @Composable
 fun KeyPressColorSquare() {
   var pressed by remember { mutableStateOf(false) }

--- a/runtimes/slots/src/commonMain/kotlin/ee/schimke/composeai/preview/slots/PreviewBackground.kt
+++ b/runtimes/slots/src/commonMain/kotlin/ee/schimke/composeai/preview/slots/PreviewBackground.kt
@@ -1,0 +1,26 @@
+package ee.schimke.composeai.preview.slots
+
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.compositionLocalOf
+
+/**
+ * Whether the current render requested a **cleared background** — the "crisp outline" toggle. The
+ * renderer paints its harness background transparent whenever the effective spec resolves to a
+ * transparent fill (see each backend's `RenderEngine`); this local lets a composable that draws its
+ * *own* opaque fill (a Material 3 `Surface`, a `Box(Modifier.background(...))`) drop that fill to
+ * match, so the captured PNG is a component silhouette on transparency instead of a solid card.
+ *
+ * `false` (the default) preserves the composable's normal appearance — an unset render, or one that
+ * shows a background, reads exactly as before. The live `renderNow.overrides.clearBackground` flag
+ * (`compose-preview serve`'s `?background=clear`, the VS Code panel chip) provides `true` around
+ * the rendered preview, mirroring how `LocalSlotMode` is provided for the slot map — so
+ * `/render/<id>.png` and `/render/<id>.png?background=clear` come from one preview with no source
+ * edit.
+ *
+ * A consumer opts in by reading it where it would otherwise hard-code a fill, e.g. `Surface(color =
+ * if (LocalPreviewBackgroundCleared.current) Color.Transparent else colorScheme.surface)`.
+ * Composables that never draw their own background ignore it and stay transparent-by-default.
+ */
+val LocalPreviewBackgroundCleared: ProvidableCompositionLocal<Boolean> = compositionLocalOf {
+  false
+}

--- a/samples/design-catalog-m3/src/main/kotlin/com/example/designcatalogm3/CatalogTheme.kt
+++ b/samples/design-catalog-m3/src/main/kotlin/com/example/designcatalogm3/CatalogTheme.kt
@@ -11,6 +11,7 @@ import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
@@ -19,6 +20,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.example.designcatalogm3.shared.LocalGenericFonts
 import com.example.designcatalogm3.shared.catalogTypography
+import ee.schimke.composeai.preview.slots.LocalPreviewBackgroundCleared
 
 /**
  * The catalog's theme wrapper. Each sticker is a stock [MaterialTheme] — the default light/dark
@@ -39,7 +41,18 @@ fun CatalogSticker(content: @Composable () -> Unit) {
       colorScheme = if (dark) darkColorScheme() else lightColorScheme(),
       typography = catalogTypography(Roboto),
     ) {
-      Surface { Box(Modifier.padding(16.dp)) { content() } }
+      // Honour the renderer's `clearBackground` ("crisp outline") toggle: drop the opaque
+      // `colorScheme.surface` fill for a transparent one so the sticker is a component silhouette,
+      // but keep `onSurface` as the content colour so text/icons stay readable on whatever the
+      // downstream viewer paints behind the transparent PNG. Untoggled, this is pixel-identical to
+      // the previous `Surface { … }` (same default colour + content colour).
+      val cleared = LocalPreviewBackgroundCleared.current
+      Surface(
+        color = if (cleared) Color.Transparent else MaterialTheme.colorScheme.surface,
+        contentColor = MaterialTheme.colorScheme.onSurface,
+      ) {
+        Box(Modifier.padding(16.dp)) { content() }
+      }
     }
   }
 }

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
@@ -141,6 +141,12 @@ a:hover { text-decoration: underline; }
               <option value="landscape">Landscape</option>
             </select>
           </label>
+          <label>Background
+            <select id="cp-background" disabled>
+              <option value="">(default)</option>
+              <option value="clear">Clear (crisp outline)</option>
+            </select>
+          </label>
           
           <div class="cp-status" id="cp-status"></div>
         </div>
@@ -187,7 +193,7 @@ a:hover { text-decoration: underline; }
   // scale slider has no empty state, so it's gated separately: we only send fontScale once the
   // user moves it (fontScaleTouched), otherwise the slider's standing 1.0 would override a
   // preview's declared default font scale and the first render wouldn't match the thumbnail.
-  var fields = ["uiMode", "device", "localeTag", "orientation"];
+  var fields = ["uiMode", "device", "localeTag", "orientation", "background"];
   var fs = document.getElementById("cp-fontScale");
   var fsVal = document.getElementById("cp-fontScale-val");
   var fontScaleTouched = false;

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
@@ -142,6 +142,12 @@ a:hover { text-decoration: underline; }
               <option value="landscape">Landscape</option>
             </select>
           </label>
+          <label>Background
+            <select id="cp-background" disabled>
+              <option value="">(default)</option>
+              <option value="clear">Clear (crisp outline)</option>
+            </select>
+          </label>
           
           <div class="cp-status" id="cp-status"></div>
         </div>
@@ -188,7 +194,7 @@ a:hover { text-decoration: underline; }
   // scale slider has no empty state, so it's gated separately: we only send fontScale once the
   // user moves it (fontScaleTouched), otherwise the slider's standing 1.0 would override a
   // preview's declared default font scale and the first render wouldn't match the thumbnail.
-  var fields = ["uiMode", "device", "localeTag", "orientation"];
+  var fields = ["uiMode", "device", "localeTag", "orientation", "background"];
   var fs = document.getElementById("cp-fontScale");
   var fsVal = document.getElementById("cp-fontScale-val");
   var fontScaleTouched = false;

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
@@ -142,6 +142,12 @@ a:hover { text-decoration: underline; }
               <option value="landscape">Landscape</option>
             </select>
           </label>
+          <label>Background
+            <select id="cp-background" disabled>
+              <option value="">(default)</option>
+              <option value="clear">Clear (crisp outline)</option>
+            </select>
+          </label>
           
           <div class="cp-status" id="cp-status"></div>
         </div>
@@ -188,7 +194,7 @@ a:hover { text-decoration: underline; }
   // scale slider has no empty state, so it's gated separately: we only send fontScale once the
   // user moves it (fontScaleTouched), otherwise the slider's standing 1.0 would override a
   // preview's declared default font scale and the first render wouldn't match the thumbnail.
-  var fields = ["uiMode", "device", "localeTag", "orientation"];
+  var fields = ["uiMode", "device", "localeTag", "orientation", "background"];
   var fs = document.getElementById("cp-fontScale");
   var fsVal = document.getElementById("cp-fontScale-val");
   var fontScaleTouched = false;

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
@@ -141,6 +141,12 @@ a:hover { text-decoration: underline; }
               <option value="landscape">Landscape</option>
             </select>
           </label>
+          <label>Background
+            <select id="cp-background" disabled>
+              <option value="">(default)</option>
+              <option value="clear">Clear (crisp outline)</option>
+            </select>
+          </label>
           
           <div class="cp-status" id="cp-status"></div>
         </div>
@@ -187,7 +193,7 @@ a:hover { text-decoration: underline; }
   // scale slider has no empty state, so it's gated separately: we only send fontScale once the
   // user moves it (fontScaleTouched), otherwise the slider's standing 1.0 would override a
   // preview's declared default font scale and the first render wouldn't match the thumbnail.
-  var fields = ["uiMode", "device", "localeTag", "orientation"];
+  var fields = ["uiMode", "device", "localeTag", "orientation", "background"];
   var fs = document.getElementById("cp-fontScale");
   var fsVal = document.getElementById("cp-fontScale-val");
   var fontScaleTouched = false;

--- a/vscode-extension/src/daemon/daemonProtocol.ts
+++ b/vscode-extension/src/daemon/daemonProtocol.ts
@@ -487,6 +487,14 @@ export interface PreviewOverrides {
      */
     inspectionMode?: boolean;
     /**
+     * Per-render cleared-background ("crisp outline") toggle. `true` forces a transparent harness
+     * background (overriding `@Preview(showBackground=…)` / `backgroundColor`) and provides
+     * `LocalPreviewBackgroundCleared = true` so a composable drawing its own opaque fill (a Material 3
+     * `Surface`) can drop it. Undefined/false preserves the discovery-time background. The panel's
+     * background chip flips this; both daemon backends honour it.
+     */
+    clearBackground?: boolean;
+    /**
      * Opt-in touch-event visualization for live / recording sessions. `true` installs the
      * `TouchOverlayExtension` `AroundComposable` so the captured / streamed frames carry
      * cyan rings at every pressed pointer plus short-lived expanding pulses on down/up —


### PR DESCRIPTION
## Summary

Previews render with their discovery-time background by default, but a downstream viewer can now flip the background to **transparent per-render** for a crisp component outline — no source edit, live re-render. This addresses the fixed backgrounds seen on `preview.coo.ee` stickers (e.g. `compose-m3/p/button-filled__…`).

Two layers move together under one `renderNow.overrides.clearBackground` toggle, honoured by **both the desktop (CMP) and Android daemon backends**:

- **Layer 1 (harness background):** the renderer forces a transparent background, overriding `@Preview(showBackground=…)` / `backgroundColor`.
- **Layer 2 (component fill):** the renderer provides a new `LocalPreviewBackgroundCleared` (in `:slot-preview-runtime`, alongside `LocalSlotMode`). A composable that paints its own opaque fill reads it and drops that fill. The design-catalog `CatalogSticker` opts in, so its Material 3 `Surface` goes transparent while keeping `onSurface` content colour for readability. **Untoggled renders are pixel-identical to before.**

### Surfaces
- **`compose-preview serve` viewer** (powers `preview.coo.ee`): a new "Background → Clear" control plus the `?background=clear` query param (aliases `transparent`/`none`/`off`; raw `clearBackground=true` also accepted), re-rendered server-side on both the snapshot and live lanes. The viewer stage already draws a checkerboard, so cleared transparency reads immediately.
- **Protocol:** `PreviewOverrides.clearBackground` (Kotlin + the extension's TypeScript mirror), encoded into the render payload the same way `slotMode` is.

A **VS Code panel chip** is a planned fast-follow (the TS protocol field is already added here); it's a webview change that warrants its own preview-harness visual verification.

## Visual evidence

End-to-end render of an M3 `OutlinedButton` inside a `Surface` (mirrors `CatalogSticker`) through the real desktop `RenderEngine`, at 220×96:

- **Default:** whole card opaque — **21,120** opaque px; corner pixel `(254,247,255,255)`.
- **`clearBackground=true`:** only **154** opaque px (the button's outline stroke + label) survive on full transparency; corner pixel `(0,0,0,0)`.

The component survives; the background is gone — a crisp floating outline. (Before/after PNGs are produced by `RenderEngineClearBackgroundTest` under `build/clearbg-evidence/` and were shared with the reviewer.)

## Test plan

- [x] `:cli:test --tests ServeOverridesTest` — `background=clear` aliases + raw `clearBackground` parse to `clearBackground`, invalid values rejected, cache key differs. **pass**
- [x] `:daemon:core:test --tests DeviceOverrideEncodingTest` — `clearBackground=true` threads through `JsonRpcServer.encodeRenderPayload`; absent leaves the payload clean. **pass**
- [x] `:daemon:desktop:test --tests RenderEngineClearBackgroundTest` — end-to-end desktop render asserts harness + Surface both clear while the component survives. **pass**
- [x] `:daemon:android:compileDebugKotlin` — Android backend compiles with the parallel wiring. **pass**
- [x] `ktfmtCheck` on all touched modules. **clean**
- [ ] Full `./gradlew check` + Android Robolectric render suite (run in CI).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tcb97ZFBzUhKx2Lp4zjBfr)_