### PR TITLE
fix(serve): surface catalog knobs + copyable PNG/SVG override URLs

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt
@@ -167,7 +167,16 @@ internal object ServeBundleDaemon {
       return null
     }
 
-    val previews = readPreviews(previewsJson, fileSystem)
+    // The author-declared knob sidecars (`previews/<id>.overrides.json`) ride alongside the PNGs in
+    // the bundle. Extract them so [readPreviews] can advertise each preview's editable knobs — the
+    // `compose/overrides` payload the viewer renders as live knob controls (and that
+    // ServeCatalogLiveHost grafts onto the baked browse surface). Best-effort: a bundle that
+    // carried
+    // none simply yields previews with no knobs.
+    val previewsDir = File(destDir, "previews").apply { mkdirs() }
+    extractOverrideSidecars(zipBytes, previewsDir, fileSystem)
+
+    val previews = readPreviews(previewsJson, previewsDir, fileSystem)
     if (previews.isEmpty()) {
       onLog("catalog $system: bundle previews.json carried no previews")
       return null
@@ -182,8 +191,17 @@ internal object ServeBundleDaemon {
     )
   }
 
-  /** Read the bundle's extracted `previews.json` into the [ServePreview] shape serve expects. */
-  private fun readPreviews(previewsJson: File, fileSystem: FileSystem): List<ServePreview> {
+  /**
+   * Read the bundle's extracted `previews.json` into the [ServePreview] shape serve expects,
+   * folding in each preview's author-declared knobs from its extracted
+   * `previews/<id>.overrides.json` sidecar (in [previewsDir]) so the daemon-backed session
+   * advertises what's editable.
+   */
+  private fun readPreviews(
+    previewsJson: File,
+    previewsDir: File,
+    fileSystem: FileSystem,
+  ): List<ServePreview> {
     val text =
       try {
         fileSystem.read(previewsJson.path.toPath()) { readUtf8() }
@@ -194,11 +212,75 @@ internal object ServeBundleDaemon {
       runCatching { previewsManifestJson.decodeFromString(PreviewManifest.serializer(), text) }
         .getOrNull() ?: return emptyList()
     return manifest.previews.map {
-      ServePreview(id = it.id, label = it.functionName.ifBlank { it.id })
+      ServePreview(
+        id = it.id,
+        label = it.functionName.ifBlank { it.id },
+        overrides = readOverrideSidecar(previewsDir, it.id, fileSystem),
+      )
     }
   }
 
+  /**
+   * Extract only the `previews/<id>.overrides.json` sidecars from [zipBytes] into [previewsDir]
+   * (zip-slip safe). Mirrors the PNG-side extraction in [ServeBundleStore]; other bundle entries
+   * are handled elsewhere ([extractBundleClassesAndManifest]).
+   */
+  private fun extractOverrideSidecars(
+    zipBytes: ByteArray,
+    previewsDir: File,
+    fileSystem: FileSystem,
+  ) {
+    val root = previewsDir.canonicalFile.toPath()
+    java.util.zip.ZipInputStream(java.io.ByteArrayInputStream(zipBytes)).use { zin ->
+      while (true) {
+        val entry = zin.nextEntry ?: break
+        val name = entry.name.replace('\\', '/')
+        if (
+          !entry.isDirectory &&
+            name.startsWith("previews/") &&
+            name.endsWith(OVERRIDES_SUFFIX) &&
+            ".." !in name.split("/")
+        ) {
+          // Strip the leading `previews/` so the file lands directly under previewsDir (keyed by
+          // id).
+          val target = File(previewsDir, name.removePrefix("previews/"))
+          if (target.canonicalFile.toPath().startsWith(root)) {
+            target.parentFile?.mkdirs()
+            val bytes = zin.readBytes()
+            fileSystem.write(target.path.toPath()) { write(bytes) }
+          }
+        }
+        zin.closeEntry()
+      }
+    }
+  }
+
+  /** Read [id]'s extracted `<id>.overrides.json` sidecar (the `compose/overrides` payload). */
+  private fun readOverrideSidecar(
+    previewsDir: File,
+    id: String,
+    fileSystem: FileSystem,
+  ): List<ee.schimke.composeai.data.overrides.PreviewOverrideDeclaration> {
+    val sidecar = File(previewsDir, "$id$OVERRIDES_SUFFIX").path.toPath()
+    if (!fileSystem.exists(sidecar)) return emptyList()
+    return try {
+      val text = fileSystem.read(sidecar) { readUtf8() }
+      overridesJson
+        .decodeFromString(
+          ee.schimke.composeai.data.overrides.PreviewOverridesPayload.serializer(),
+          text,
+        )
+        .declarations
+    } catch (_: Exception) {
+      emptyList()
+    }
+  }
+
+  /** Suffix of the per-preview knob sidecar; lockstep with `PreviewBundleFormat`'s. */
+  private const val OVERRIDES_SUFFIX = ".overrides.json"
+
   private val json = Json { encodeDefaults = true }
+  private val overridesJson = Json { ignoreUnknownKeys = true }
   private val previewsManifestJson = Json {
     ignoreUnknownKeys = true
     isLenient = true

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
@@ -49,6 +49,10 @@ class ServeBundleHost(
   private val fileSystem: FileSystem = SystemFileSystem,
 ) : ServeHost {
 
+  // A catalog bundle that carried baked `figma/<slug>.svg` vectors can serve an SVG per preview; a
+  // plain uploaded bundle (no figmaDir) 404s the `.svg` lane, so it offers no SVG download link.
+  override val hasSvgExport: Boolean = figmaDir != null
+
   private val previewsDir = File(bundleDir, PREVIEWS_SUBDIR)
 
   override val previews: List<ServePreview> =

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
@@ -103,10 +103,22 @@ class ServeCatalogLiveHost(
     else baked.render(previewId, overrides)
   }
 
+  /**
+   * SVG export mirrors [render]'s knob routing, plus a fallback: the SVG row is advertised whenever
+   * *either* lane can export ([hasSvgExport]), but a specific mapped preview may have no baked
+   * `figma/<slug>.svg` (or the whole catalog carried none and only the daemon exports). So when the
+   * baked lane can't produce the vector, fall back to the daemon for a mapped id rather than 404
+   * the advertised link. Unlike PNG browsing, an SVG export is an explicit user action (the
+   * Download / Copy link), so waking the daemon here is fine.
+   */
   override fun renderSvg(previewId: String, overrides: PreviewOverrides): SvgOutcome {
-    val daemonId = daemonIdForOverrideRender(previewId, overrides)
-    return if (daemonId != null) live.renderSvg(daemonId, overrides)
-    else baked.renderSvg(previewId, overrides)
+    daemonIdForOverrideRender(previewId, overrides)?.let {
+      return live.renderSvg(it, overrides)
+    }
+    val bakedOutcome = baked.renderSvg(previewId, overrides)
+    if (bakedOutcome !is SvgOutcome.NotFound) return bakedOutcome
+    val daemonId = alias[previewId] ?: return bakedOutcome
+    return live.renderSvg(daemonId, overrides)
   }
 
   /**

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
@@ -44,8 +44,15 @@ class ServeCatalogLiveHost(
   private val baked: ServeHost,
 ) : ServeHost {
 
-  /** Browse + snapshot surface is the baked catalog — its ids are the published catalog ids. */
-  override val previews: List<ServePreview> = baked.previews
+  /**
+   * Browse + snapshot surface is the baked catalog — its ids are the published catalog ids. The
+   * author-declared knobs ([ServePreview.overrides]), however, are carried by the *daemon* previews
+   * (read from the live bundle's `previews/<daemon-id>.overrides.json` sidecars, keyed by the
+   * daemon descriptor id), not by the baked catalog images. So graft each mapped catalog preview's
+   * knob declarations across from its daemon twin via [alias]; an unmapped (Android-only) preview
+   * keeps the baked entry as-is (no live lane, no editable knobs).
+   */
+  override val previews: List<ServePreview> = mergeDeclaredKnobs(baked.previews, live.previews)
 
   override val label: String = baked.label
 
@@ -54,6 +61,21 @@ class ServeCatalogLiveHost(
    * pixels + trust badge — the live daemon is opt-in via [hasLiveStream], not the snapshot lane.
    */
   override val canApplyOverrides: Boolean = false
+
+  /**
+   * The carried daemon CAN re-render a snapshot on demand, so an override-bearing `/render` (a
+   * `?knob.<key>=…` edit, or a display-axis change on a mapped id) returns fresh pixels — see
+   * [render] / [renderSvg]. This leaves [canApplyOverrides] false (ordinary browsing never wakes
+   * the daemon) while enabling the viewer's knob controls as live rather than baked-and-disabled.
+   */
+  override val canRenderOverrides: Boolean = true
+
+  /**
+   * SVG is exportable when either lane can produce it — the baked catalog carries
+   * `figma/<slug>.svg` vectors, and the daemon exports a `compose/figma-svg` for a knob-bearing
+   * render.
+   */
+  override val hasSvgExport: Boolean = baked.hasSvgExport || live.hasSvgExport
 
   /** The "Live (stream)" toggle is offered (unlike a plain static catalog). */
   override val hasLiveStream: Boolean = true
@@ -65,12 +87,35 @@ class ServeCatalogLiveHost(
    */
   internal val bakedHost: ServeHost = baked
 
-  /** Snapshots are the baked catalog PNGs — the daemon is reserved for the live stream lane. */
-  override fun render(previewId: String, overrides: PreviewOverrides): RenderOutcome =
-    baked.render(previewId, overrides)
+  /**
+   * Ordinary browsing serves the baked catalog PNG — instant, and never wakes the daemon (a viewer
+   * that replays a sticky theme override into the snapshot URL must still land on baked pixels).
+   * The one exception is an **author-declared knob** edit ([PreviewOverrides.namedOverrides]):
+   * those knobs (`label`, a color, …) can only be honoured by re-running the composable, which the
+   * baked PNG can't do, so a knob-bearing render on a mapped id is routed to the [live] daemon
+   * (which also applies any display axes carried alongside). Display-axis-only overrides stay baked
+   * — the published variant already encodes its theme, and keeping them baked preserves instant
+   * browsing.
+   */
+  override fun render(previewId: String, overrides: PreviewOverrides): RenderOutcome {
+    val daemonId = daemonIdForOverrideRender(previewId, overrides)
+    return if (daemonId != null) live.render(daemonId, overrides)
+    else baked.render(previewId, overrides)
+  }
 
-  override fun renderSvg(previewId: String, overrides: PreviewOverrides): SvgOutcome =
-    baked.renderSvg(previewId, overrides)
+  override fun renderSvg(previewId: String, overrides: PreviewOverrides): SvgOutcome {
+    val daemonId = daemonIdForOverrideRender(previewId, overrides)
+    return if (daemonId != null) live.renderSvg(daemonId, overrides)
+    else baked.renderSvg(previewId, overrides)
+  }
+
+  /**
+   * The daemon preview id to route a [render] / [renderSvg] to, or null to stay baked. Non-null
+   * only when [previewId] is a mapped (daemon-renderable) id AND the request carries an
+   * author-declared knob override — the sole case the baked PNG can't satisfy.
+   */
+  private fun daemonIdForOverrideRender(previewId: String, overrides: PreviewOverrides): String? =
+    if (overrides.namedOverrides.isNullOrEmpty()) null else alias[previewId]
 
   /** Live streaming is available only for aliased ids; others have no stream (snapshot only). */
   override fun subscribeStream(
@@ -85,6 +130,25 @@ class ServeCatalogLiveHost(
   }
 
   override fun activeStreamCount(): Int = live.activeStreamCount()
+
+  /**
+   * Graft the daemon previews' author-declared knobs onto the baked browse surface. The daemon
+   * knows its previews by descriptor id (`FilledButton_Dark`) and carries their
+   * [ServePreview.overrides] (from the bundle sidecars); the baked catalog keys by catalog id
+   * (`button-filled__ideal__default__dark`) and carries none. For each mapped baked preview, copy
+   * its daemon twin's declarations across so `/api/previews` + the viewer advertise the editable
+   * knobs. Unmapped previews (Android-only variants with no daemon lane) are returned unchanged.
+   */
+  private fun mergeDeclaredKnobs(
+    bakedPreviews: List<ServePreview>,
+    livePreviews: List<ServePreview>,
+  ): List<ServePreview> {
+    val knobsByDaemonId = livePreviews.associate { it.id to it.overrides }
+    return bakedPreviews.map { p ->
+      val knobs = alias[p.id]?.let { knobsByDaemonId[it] }
+      if (knobs.isNullOrEmpty()) p else p.copy(overrides = knobs)
+    }
+  }
 
   override fun close() {
     try {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHost.kt
@@ -30,6 +30,28 @@ interface ServeHost : AutoCloseable {
     get() = false
 
   /**
+   * Whether the host can produce a **freshly rendered** snapshot when an override is supplied —
+   * even if the *default* (override-free) snapshot lane is baked. Governs whether the viewer offers
+   * the author-declared knob controls as live (an edit re-renders via `/render`) rather than
+   * disabled, informational ones. It defaults to [canApplyOverrides], so a plain daemon host (both
+   * true) and a plain static bundle (both false) are unchanged. A trusted-catalog live session
+   * ([ServeCatalogLiveHost]) is the exception: `canApplyOverrides = false` (browsing stays baked
+   * and instant) but `canRenderOverrides = true` — an override-bearing `/render` re-renders through
+   * the carried daemon on demand, so a `?knob.<key>=…` (or display-axis) URL returns fresh pixels.
+   */
+  val canRenderOverrides: Boolean
+    get() = canApplyOverrides
+
+  /**
+   * Whether [renderSvg] can actually produce a `compose/figma-svg` export for this session's
+   * previews — a daemon-backed host always can, a static bundle only when it carried baked
+   * `figma/<slug>.svg` vectors (a design catalog). Drives whether the viewer offers a copyable SVG
+   * download URL alongside the PNG one. Defaults to false (a plain bundle 404s the `.svg` lane).
+   */
+  val hasSvgExport: Boolean
+    get() = false
+
+  /**
    * Whether a **live daemon stream** ("Live (stream)") is available for this session — distinct
    * from [canApplyOverrides], which governs whether the *snapshot* lane re-renders on override
    * edits. The two usually coincide (a plain [ServeRenderHost] has both; a static [ServeBundleHost]

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -498,6 +498,8 @@ class ServeHttpServer(
           token,
           webSessionId,
           canApplyOverrides = renderHost.canApplyOverrides,
+          canRenderOverrides = renderHost.canRenderOverrides,
+          hasSvgExport = renderHost.hasSvgExport,
           hasLiveStream = renderHost.hasLiveStream,
           trust = catalogBundleHost(renderHost)?.let { BundleVerifier.summary(it.trust) },
           wasmSrc = wasmSrc,

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
@@ -130,6 +130,10 @@ internal constructor(
   // A daemon backs this host, so an override edit actually re-renders (unlike a static bundle).
   override val canApplyOverrides: Boolean = true
 
+  // The daemon can export a `compose/figma-svg` for any preview, so the viewer can offer an SVG
+  // download link alongside the PNG.
+  override val hasSvgExport: Boolean = true
+
   private val previewIds: Set<String> = previews.map { it.id }.toHashSet()
 
   // Decodes streamFrame notification params for the live-stream lane (startStream).

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -88,10 +88,22 @@ object ServeWeb {
     .cp-knobs { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
     .cp-knobs-head { font-size: 0.72rem; color: #6b6b70; }
     .cp-knobs input:disabled { opacity: 0.7; }
+    .cp-links { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
+    .cp-link-row { display: flex; align-items: center; gap: 6px; }
+    .cp-link-kind { font-size: 0.72rem; font-weight: 600; color: #6b6b70; width: 30px; flex: none; }
+    .cp-url { flex: 1; min-width: 0; font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 0.72rem; padding: 4px 6px; border: 1px solid #d7d7de; border-radius: 6px;
+      background: #fff; color: #1b1b1f; }
+    .cp-copy, .cp-dl { font-size: 0.72rem; padding: 4px 8px; border-radius: 6px; border: 1px solid #d7d7de;
+      background: #fff; color: #5b5bd6; cursor: pointer; text-decoration: none; flex: none; }
+    .cp-copy:hover, .cp-dl:hover { background: #f0f0f3; }
     @media (prefers-color-scheme: dark) {
       body { color: #e6e6e9; background: #161618; }
       .cp-sub, .cp-id, .cp-status, .cp-about-links, .cp-sys-desc, .cp-sys-foot { color: #a0a0a8; }
-      .cp-card, .cp-stage, .cp-knobs, .cp-about { border-color: #34343a; }
+      .cp-card, .cp-stage, .cp-knobs, .cp-links, .cp-about { border-color: #34343a; }
+      .cp-url { background: #1d1d20; color: #e6e6e9; border-color: #34343a; }
+      .cp-copy, .cp-dl { background: #1d1d20; border-color: #34343a; }
+      .cp-copy:hover, .cp-dl:hover { background: #26262b; }
       .cp-card, .cp-about { background: #1d1d20; }
       .cp-about-body { color: #c9c9d0; }
       .cp-about-body code { background: #2a2a30; }
@@ -609,6 +621,21 @@ object ServeWeb {
      * baked snapshots) with `hasLiveStream = true` (Live still offered on demand).
      */
     hasLiveStream: Boolean = canApplyOverrides,
+    /**
+     * Whether an override-bearing `/render` returns fresh pixels even though the *default* snapshot
+     * lane is baked ([canApplyOverrides] false) — true for a trusted-catalog live session
+     * ([ServeCatalogLiveHost]), whose carried daemon re-renders author-declared knob edits on
+     * demand. Drives whether the declared knob controls are live (an edit re-renders via `/render`)
+     * or disabled + informational. Defaults to [canApplyOverrides] so plain daemon / static
+     * sessions are unchanged.
+     */
+    canRenderOverrides: Boolean = canApplyOverrides,
+    /**
+     * Whether the session can export a `compose/figma-svg` for its previews (a daemon-backed host
+     * or a catalog that carried baked vectors). Drives whether the copyable-links panel offers an
+     * SVG download URL alongside the PNG one. Defaults to false (a plain bundle has no SVG lane).
+     */
+    hasSvgExport: Boolean = false,
     trust: String? = null,
     wasmSrc: String? = null,
     /**
@@ -703,7 +730,7 @@ object ServeWeb {
       """
       <p class="cp-head"><a href="$basePath/$q">← previews</a>${trustBadge(trust)}</p>
       <p class="cp-sub" title="$idText">$label</p>
-      <div class="cp-viewer" data-preview-id="$idText" data-mode="snapshot" data-modes="$modes" data-static-snapshot="$staticSnapshot" data-snapshot-backend="$backendLabel" data-live-backend="$liveLabel"$wasmAttr>
+      <div class="cp-viewer" data-preview-id="$idText" data-mode="snapshot" data-modes="$modes" data-static-snapshot="$staticSnapshot" data-can-render-overrides="$canRenderOverrides" data-snapshot-backend="$backendLabel" data-live-backend="$liveLabel"$wasmAttr>
         <div class="cp-stage"><span class="cp-backend" id="cp-backend"></span><img id="cp-img" alt="$label"><canvas id="cp-canvas" hidden></canvas>$wasmFrame</div>
         <div class="cp-controls">
           $snapshotNote
@@ -741,7 +768,8 @@ object ServeWeb {
               <option value="clear">Clear (crisp outline)</option>
             </select>
           </label>
-          ${overrideKnobsHtml(preview, canApplyOverrides)}
+          ${overrideKnobsHtml(preview, canApplyOverrides || canRenderOverrides)}
+          ${downloadLinksHtml(hasSvgExport)}
           <div class="cp-status" id="cp-status"></div>
         </div>
       </div>
@@ -777,6 +805,10 @@ object ServeWeb {
       // static snapshots yet leaves the Live toggle enabled, so `live.disabled` no longer implies
       // "static".
       var staticSnapshot = root.getAttribute("data-static-snapshot") === "true";
+      // Whether an override-bearing /render returns fresh pixels even on a static snapshot lane (a
+      // trusted-catalog live session: its carried daemon re-renders author-declared knob edits on
+      // demand). When true, a knob edit re-points the snapshot /render URL rather than sitting dead.
+      var canRenderOverrides = root.getAttribute("data-can-render-overrides") === "true";
       var previewId = root.getAttribute("data-preview-id");
       // The session path prefix ("/<system>") when this viewer is served under a path — it sits at
       // "<base>/p/<id>", so stripping the trailing "/p/<id>" recovers the base ("" for the root
@@ -833,7 +865,44 @@ object ServeWeb {
         next.onload = function () { img.src = url; status.textContent = ""; };
         next.onerror = function () { status.textContent = "render failed"; };
         next.src = url;
+        refreshLinks();
       }
+      // The copyable direct-link panel: rebuild the absolute /render URLs (PNG + optional SVG) from
+      // the current controls so a copied/downloaded link reproduces exactly what's on screen. Built
+      // on location.origin so the link is absolute (curl-able / shareable), and kept in sync on
+      // every control or knob change — even the ones that don't re-render the snapshot themselves.
+      function renderUrl(ext) {
+        var qs = query();
+        return location.origin + base + "/render/" + encodeURIComponent(previewId) + ext +
+          (qs ? "?" + qs : "");
+      }
+      function refreshLinks() {
+        [["png", ".png"], ["svg", ".svg"]].forEach(function (pair) {
+          var field = document.getElementById("cp-url-" + pair[0]);
+          if (!field) return;
+          var url = renderUrl(pair[1]);
+          field.value = url;
+          var dl = document.getElementById("cp-dl-" + pair[0]);
+          if (dl) dl.href = url;
+        });
+      }
+      document.querySelectorAll(".cp-copy").forEach(function (btn) {
+        btn.addEventListener("click", function () {
+          var field = document.getElementById(btn.getAttribute("data-copy-target"));
+          if (!field) return;
+          var done = function () {
+            var was = btn.textContent;
+            btn.textContent = "Copied";
+            setTimeout(function () { btn.textContent = was; }, 1200);
+          };
+          if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(field.value).then(done, function () { field.select(); });
+          } else {
+            field.select();
+            try { document.execCommand("copy"); done(); } catch (e) {}
+          }
+        });
+      });
       function drawFrame(b64, codec) {
         var im = new Image();
         im.onload = function () {
@@ -1103,6 +1172,8 @@ object ServeWeb {
       function wasmActive() { return wasmToggle && wasmToggle.checked; }
 
       function onControlsChanged() {
+        // Keep the copyable direct links current no matter which transport handles the change.
+        refreshLinks();
         if (wasmActive()) {
           // Recompose in place once the app is up; before it's ready, re-point the initial src (the
           // fragment carries the overrides) — the load handler re-syncs the final state either way.
@@ -1180,8 +1251,19 @@ object ServeWeb {
         if (el) el.addEventListener("change", onControlsChanged);
       });
       // Author-declared knobs re-render on edit (text/number debounce via "input", toggles "change").
+      // They route differently from the display axes: a named knob (label, a color, …) is honoured
+      // ONLY by the server daemon — the in-browser Wasm tier's `catalogOverride*` returns the author
+      // default — so a knob edit must hit /render (onKnobChanged), never the wasm auto-enable path.
+      function onKnobChanged() {
+        refreshLinks();
+        if (live.checked && ws && ws.readyState === 1) {
+          ws.send(JSON.stringify({ type: "setOverrides", overrides: overrides() }));
+        } else if (canRenderOverrides) {
+          refreshSnapshot();
+        }
+      }
       document.querySelectorAll(".cp-knob").forEach(function (el) {
-        el.addEventListener(el.type === "checkbox" ? "change" : "input", onControlsChanged);
+        el.addEventListener(el.type === "checkbox" ? "change" : "input", onKnobChanged);
       });
       refreshSnapshot();
     })();
@@ -1204,6 +1286,36 @@ object ServeWeb {
     </html>
     """
       .trimIndent() + "\n"
+
+  /**
+   * The copyable direct-link panel: the `/render/<id>.png` (and, when [hasSvgExport], `.svg`) URL
+   * for the preview **with the current overrides applied**. Each row shows a read-only URL field, a
+   * Copy button, and a Download link (`<a download>`). The viewer JS keeps the URLs in sync as the
+   * controls / knobs change (see `refreshLinks`), so the copied URL always reflects the on-screen
+   * state — a shareable, scriptable handle on the exact render (a `curl`-able PNG/SVG). The URLs
+   * are built client-side from `location.origin` + the session base, so they're absolute and work
+   * from anywhere; the fields start empty and are filled on first render.
+   */
+  private fun downloadLinksHtml(hasSvgExport: Boolean): String {
+    fun row(kind: String, ext: String): String =
+      """
+      <div class="cp-link-row">
+        <span class="cp-link-kind">$kind</span>
+        <input id="cp-url-$ext" class="cp-url" type="text" readonly aria-label="$kind URL">
+        <button type="button" class="cp-copy" data-copy-target="cp-url-$ext">Copy</button>
+        <a id="cp-dl-$ext" class="cp-dl" download>Download</a>
+      </div>
+      """
+        .trimIndent()
+    val svgRow = if (hasSvgExport) "\n" + row("SVG", "svg") else ""
+    return """
+      <div class="cp-links">
+        <div class="cp-knobs-head">Direct links — the current view as a URL (overrides applied)</div>
+        ${row("PNG", "png")}$svgRow
+      </div>
+      """
+      .trimIndent()
+  }
 
   /**
    * Renders the preview's author-declared editable knobs (the `compose/overrides` payload carried

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -837,6 +837,25 @@ object ServeWeb {
         if (fontScaleTouched && fs) o.fontScale = fs.value;
         return o;
       }
+      // The live-stream override map: the display fields PLUS the author-declared knob values as
+      // `knob.<key>` entries (the daemon's setOverrides parses the same map /render does, and
+      // ServeOverrides reads knob.* keys). Kept separate from overrides() so query() and the Wasm
+      // patch — which append/ignore knobs their own way — are unaffected; without this a knob edit
+      // during an active Live (stream) would send only the display fields and the daemon would reset
+      // the knob to its default.
+      function liveOverrides() {
+        var o = overrides();
+        document.querySelectorAll(".cp-knob").forEach(function (el) {
+          if (el.disabled) return;
+          var key = el.getAttribute("data-knob-key");
+          var kind = el.getAttribute("data-knob-kind") || "string";
+          if (!key) return;
+          var val = (el.type === "checkbox") ? (el.checked ? "true" : "false") : el.value;
+          if (val === "") return;
+          o["knob." + key] = kind + ":" + val;
+        });
+        return o;
+      }
       function query() {
         var o = overrides();
         // Public routes are open, so a page that arrived without a token stays token-free — only
@@ -1185,7 +1204,7 @@ object ServeWeb {
           return;
         }
         if (live.checked && ws && ws.readyState === 1) {
-          ws.send(JSON.stringify({ type: "setOverrides", overrides: overrides() }));
+          ws.send(JSON.stringify({ type: "setOverrides", overrides: liveOverrides() }));
         } else if (staticSnapshot && wasmToggle) {
           // Static snapshot backed by a Wasm app: the baked PNG can't honour theme/font-scale/locale
           // (only the in-browser tier can), and /render can't re-render a published catalog. So a
@@ -1257,7 +1276,7 @@ object ServeWeb {
       function onKnobChanged() {
         refreshLinks();
         if (live.checked && ws && ws.readyState === 1) {
-          ws.send(JSON.stringify({ type: "setOverrides", overrides: overrides() }));
+          ws.send(JSON.stringify({ type: "setOverrides", overrides: liveOverrides() }));
         } else if (canRenderOverrides) {
           refreshSnapshot();
         }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemonTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemonTest.kt
@@ -71,6 +71,19 @@ class ServeBundleDaemonTest {
 
     assertTrue(state.previews.isNotEmpty(), "materialize should discover at least one preview")
     assertEquals("compose-m3", state.label)
+
+    // The author-declared knob sidecars (`previews/<id>.overrides.json`) must be folded into the
+    // ServePreview set so the daemon-backed session (and, via ServeCatalogLiveHost, the baked
+    // browse
+    // surface) can advertise the editable knobs. The M3 catalog's FilledButton declares a `label`
+    // string knob; assert it round-trips from the packed bundle.
+    val filled = state.previews.firstOrNull { it.id.endsWith("FilledButton_Light") }
+    if (filled != null) {
+      assertTrue(
+        filled.overrides.any { it.key == "label" },
+        "FilledButton should carry its declared `label` knob, got ${filled.overrides}",
+      )
+    }
   }
 
   @Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
@@ -28,6 +28,8 @@ class ServeCatalogLiveHostTest {
     override val previews: List<ServePreview>,
     private val tag: String,
     private val streaming: Boolean = false,
+    /** When true, `renderSvg` reports `NotFound` (a baked catalog missing this slug's vector). */
+    private val svgNotFound: Boolean = false,
   ) : ServeHost {
     override val label: String = tag
     override val canApplyOverrides: Boolean = streaming
@@ -46,6 +48,7 @@ class ServeCatalogLiveHostTest {
     override fun renderSvg(previewId: String, overrides: PreviewOverrides): SvgOutcome {
       lastSvgId = previewId
       lastRenderOverrides = overrides
+      if (svgNotFound) return SvgOutcome.NotFound
       return SvgOutcome.Ok("$tag-svg:$previewId".encodeToByteArray())
     }
 
@@ -159,6 +162,53 @@ class ServeCatalogLiveHostTest {
     val out = composite.renderSvg(catalogId, knobOverride()) as SvgOutcome.Ok
     assertEquals("live-svg:$daemonId", out.svg.decodeToString())
     assertEquals(daemonId, live.lastSvgId)
+  }
+
+  @Test
+  fun `a plain SVG export falls back to the daemon when the baked vector is absent`() {
+    // The SVG row is advertised because a lane can export, but this mapped preview has no baked
+    // figma/<slug>.svg — the baked lane 404s. Rather than 404 the advertised link, a plain
+    // (no-knob)
+    // SVG export falls back to the daemon (an explicit action, so waking it is fine).
+    val baked =
+      RecordingHost(
+        previews = listOf(ServePreview(catalogId, catalogId)),
+        tag = "baked",
+        svgNotFound = true,
+      )
+    val live =
+      RecordingHost(
+        previews = listOf(ServePreview(daemonId, daemonId)),
+        tag = "live",
+        streaming = true,
+      )
+    val composite = ServeCatalogLiveHost(mapOf(catalogId to daemonId), live, baked)
+
+    val out = composite.renderSvg(catalogId, PreviewOverrides()) as SvgOutcome.Ok
+    assertEquals("live-svg:$daemonId", out.svg.decodeToString())
+    assertEquals(daemonId, live.lastSvgId)
+  }
+
+  @Test
+  fun `a plain SVG export of an unmapped id with no baked vector stays NotFound`() {
+    // No daemon twin → nothing to fall back to; surface the baked NotFound rather than inventing
+    // one.
+    val baked =
+      RecordingHost(
+        previews = listOf(ServePreview(androidOnlyId, androidOnlyId)),
+        tag = "baked",
+        svgNotFound = true,
+      )
+    val live =
+      RecordingHost(
+        previews = listOf(ServePreview(daemonId, daemonId)),
+        tag = "live",
+        streaming = true,
+      )
+    val composite = ServeCatalogLiveHost(mapOf(catalogId to daemonId), live, baked)
+
+    assertEquals(SvgOutcome.NotFound, composite.renderSvg(androidOnlyId, PreviewOverrides()))
+    assertNull(live.lastSvgId)
   }
 
   @Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
@@ -1,9 +1,12 @@
 package ee.schimke.composeai.cli.serve
 
 import ee.schimke.composeai.daemon.protocol.InteractiveInputKind
+import ee.schimke.composeai.daemon.protocol.PreviewOverrideValue
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.daemon.protocol.StreamCodec
 import ee.schimke.composeai.daemon.protocol.StreamFrameParams
+import ee.schimke.composeai.data.overrides.PreviewOverrideDeclaration
+import ee.schimke.composeai.data.overrides.PreviewOverrideType
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
@@ -29,12 +32,21 @@ class ServeCatalogLiveHostTest {
     override val label: String = tag
     override val canApplyOverrides: Boolean = streaming
     var lastRenderId: String? = null
+    var lastRenderOverrides: PreviewOverrides? = null
+    var lastSvgId: String? = null
     var lastStreamId: String? = null
     var closed = false
 
     override fun render(previewId: String, overrides: PreviewOverrides): RenderOutcome {
       lastRenderId = previewId
+      lastRenderOverrides = overrides
       return RenderOutcome.Ok("$tag:$previewId".encodeToByteArray())
+    }
+
+    override fun renderSvg(previewId: String, overrides: PreviewOverrides): SvgOutcome {
+      lastSvgId = previewId
+      lastRenderOverrides = overrides
+      return SvgOutcome.Ok("$tag-svg:$previewId".encodeToByteArray())
     }
 
     override fun subscribeStream(
@@ -80,7 +92,7 @@ class ServeCatalogLiveHostTest {
       )
     val live =
       RecordingHost(
-        previews = listOf(ServePreview(daemonId, daemonId)),
+        previews = listOf(ServePreview(daemonId, daemonId, overrides = listOf(labelKnob))),
         tag = "live",
         streaming = true,
       )
@@ -88,17 +100,75 @@ class ServeCatalogLiveHostTest {
     return Triple(composite, live, baked)
   }
 
+  /** An author-declared `label` knob the daemon carries for the mapped preview. */
+  private val labelKnob =
+    PreviewOverrideDeclaration(
+      key = "label",
+      type = PreviewOverrideType.STRING,
+      default = PreviewOverrideValue.StringValue("Filled"),
+    )
+
+  /** A knob-bearing override — the sole case the baked PNG can't satisfy. */
+  private fun knobOverride() =
+    PreviewOverrides(namedOverrides = mapOf("label" to PreviewOverrideValue.StringValue("Tap me")))
+
   @Test
   fun `presents as a static-snapshot host that still offers Live`() {
     val (composite, _, baked) = host()
-    assertEquals(baked.previews, composite.previews)
+    // Same ids + order as the baked browse surface (deep links + grid resolve unchanged).
+    assertEquals(baked.previews.map { it.id }, composite.previews.map { it.id })
     // Snapshots stay static (baked, instant) so the viewer shows the published pixels + trust
     // badge…
     assertEquals(false, composite.canApplyOverrides)
-    // …but the "Live (stream)" toggle is still offered.
+    // …but the carried daemon CAN re-render an override on demand, so the knob controls are live…
+    assertTrue(composite.canRenderOverrides)
+    // …and the "Live (stream)" toggle is still offered.
     assertTrue(composite.hasLiveStream)
     // The baked host is exposed so the HTTP layer can read its title / subtitle / trust verdict.
     assertEquals(baked, composite.bakedHost)
+  }
+
+  @Test
+  fun `grafts the daemon's declared knobs onto the mapped baked preview`() {
+    val (composite, _, _) = host()
+    // The baked catalog images carry no knob declarations; the daemon does. The composite exposes
+    // the daemon's declarations on the browse surface so /api/previews + the viewer advertise them.
+    val mapped = composite.previews.first { it.id == catalogId }
+    assertEquals(listOf(labelKnob), mapped.overrides)
+    // An unmapped (Android-only) preview has no daemon twin, so it stays knob-free.
+    val unmapped = composite.previews.first { it.id == androidOnlyId }
+    assertTrue(unmapped.overrides.isEmpty())
+  }
+
+  @Test
+  fun `a knob-bearing render on a mapped id routes to the daemon`() {
+    val (composite, live, baked) = host()
+    val out = composite.render(catalogId, knobOverride()) as RenderOutcome.Ok
+    // A named-override edit can only be honoured by re-running the composable — routed to the
+    // daemon
+    // under its daemon id, with the override carried through.
+    assertEquals("live:$daemonId", out.png.decodeToString())
+    assertEquals(daemonId, live.lastRenderId)
+    assertEquals(knobOverride().namedOverrides, live.lastRenderOverrides?.namedOverrides)
+    assertNull(baked.lastRenderId)
+  }
+
+  @Test
+  fun `a knob-bearing SVG render on a mapped id routes to the daemon`() {
+    val (composite, live, _) = host()
+    val out = composite.renderSvg(catalogId, knobOverride()) as SvgOutcome.Ok
+    assertEquals("live-svg:$daemonId", out.svg.decodeToString())
+    assertEquals(daemonId, live.lastSvgId)
+  }
+
+  @Test
+  fun `a knob-bearing render on an unmapped id stays baked`() {
+    // No daemon twin → nothing can honour the knob; serve the baked PNG rather than 404.
+    val (composite, live, baked) = host()
+    val out = composite.render(androidOnlyId, knobOverride()) as RenderOutcome.Ok
+    assertEquals("baked:$androidOnlyId", out.png.decodeToString())
+    assertEquals(androidOnlyId, baked.lastRenderId)
+    assertNull(live.lastRenderId)
   }
 
   @Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -662,6 +662,19 @@ class ServeWebFixtureTest {
       catalogKnobs.contains("function onKnobChanged()"),
       "knob edits have a dedicated handler that hits /render",
     )
+    // During an active Live (stream), the override map sent over the WebSocket must carry the knob
+    // values too (as knob.<key> entries), not just the display fields — otherwise the daemon resets
+    // an edited knob to its default. The setOverrides sends use liveOverrides(), which folds them
+    // in.
+    assertTrue(
+      catalogKnobs.contains("function liveOverrides()") &&
+        catalogKnobs.contains("o[\"knob.\" + key]"),
+      "the live-stream override map includes the declared knob values",
+    )
+    assertFalse(
+      catalogKnobs.contains("setOverrides\", overrides: overrides()"),
+      "live-stream setOverrides sends liveOverrides() (knobs included), not the display-only map",
+    )
     // A plain static bundle (no daemon) still shows the knobs as DISABLED, informational controls.
     val staticKnobs = ServeWeb.viewerPage(knobPreview, token)
     assertTrue(

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -1,5 +1,8 @@
 package ee.schimke.composeai.cli.serve
 
+import ee.schimke.composeai.daemon.protocol.PreviewOverrideValue
+import ee.schimke.composeai.data.overrides.PreviewOverrideDeclaration
+import ee.schimke.composeai.data.overrides.PreviewOverrideType
 import java.awt.Color
 import java.awt.Font
 import java.awt.GradientPaint
@@ -66,6 +69,28 @@ class ServeWebFixtureTest {
       ServePreview("switch-on__ideal__default__light", "Switch · On (light)"),
       ServePreview("switch-on__ideal__default__dark", "Switch · On (dark)"),
       ServePreview("badge", "Badge"),
+    )
+
+  // A trusted-catalog preview that declares author knobs (a `label` string + an accent `color`) —
+  // the `compose/overrides` payload PR #2281 added across the M3 catalog. On a live catalog session
+  // (ServeCatalogLiveHost) these render as LIVE controls that re-render via `/render` on edit.
+  private val knobPreview =
+    ServePreview(
+      "button-filled__ideal__default__light",
+      "Button · Filled (light)",
+      overrides =
+        listOf(
+          PreviewOverrideDeclaration(
+            key = "label",
+            type = PreviewOverrideType.STRING,
+            default = PreviewOverrideValue.StringValue("Filled"),
+          ),
+          PreviewOverrideDeclaration(
+            key = "iconColor",
+            type = PreviewOverrideType.COLOR,
+            default = PreviewOverrideValue.ColorValue("#FF6750A4"),
+          ),
+        ),
     )
 
   @Test
@@ -156,6 +181,24 @@ class ServeWebFixtureTest {
         trust = "branch:yschimke/compose-ai-tools@design-artifacts/compose-m3",
         wasmSrc = "/wasm/compose-m3/?id=card-filled",
       )
+    // A trusted catalog served LIVE (ServeCatalogLiveHost) whose preview declares author knobs:
+    // snapshots stay baked (canApplyOverrides=false) but the carried daemon CAN re-render an
+    // override on demand (canRenderOverrides=true), so the declared knob controls render ENABLED
+    // and
+    // an edit re-renders via /render. This is the surface PR #2281's overrides feed into — captured
+    // so the visual-diff bot covers the knob panel.
+    val viewerCatalogKnobs =
+      ServeWeb.viewerPage(
+        knobPreview,
+        token,
+        sessionId = "compose-m3",
+        canApplyOverrides = false,
+        canRenderOverrides = true,
+        hasSvgExport = true,
+        hasLiveStream = true,
+        trust = "branch:yschimke/compose-ai-tools@design-artifacts/compose-m3",
+        wasmSrc = "/wasm/compose-m3/?id=button-filled",
+      )
     // A catalog served under its canonical path (/meshcore-mobile/) rather than ?session=: same
     // pages, but links stay on the path (basePath) and drop the &session= param. Captures the
     // path-mounted landing + viewer the public server now serves these design systems at.
@@ -198,6 +241,7 @@ class ServeWebFixtureTest {
       File(pagesDir, "serve-viewer.html").writeText(viewer)
       File(pagesDir, "serve-viewer-wasm.html").writeText(wasmViewer)
       File(pagesDir, "serve-viewer-wasm-live.html").writeText(wasmViewerLive)
+      File(pagesDir, "serve-viewer-catalog-knobs.html").writeText(viewerCatalogKnobs)
       File(pagesDir, "serve-landing-path.html").writeText(landingPath)
       File(pagesDir, "serve-viewer-path.html").writeText(viewerPath)
       File(pagesDir, "serve-landing-themed.html").writeText(landingThemed)
@@ -211,6 +255,7 @@ class ServeWebFixtureTest {
     assertGolden(File(pagesDir, "serve-viewer.html"), viewer)
     assertGolden(File(pagesDir, "serve-viewer-wasm.html"), wasmViewer)
     assertGolden(File(pagesDir, "serve-viewer-wasm-live.html"), wasmViewerLive)
+    assertGolden(File(pagesDir, "serve-viewer-catalog-knobs.html"), viewerCatalogKnobs)
     assertGolden(File(pagesDir, "serve-landing-path.html"), landingPath)
     assertGolden(File(pagesDir, "serve-viewer-path.html"), viewerPath)
     assertGolden(File(pagesDir, "serve-landing-themed.html"), landingThemed)
@@ -574,6 +619,84 @@ class ServeWebFixtureTest {
     assertTrue(
       liveCatalogWasm.contains("id=\"cp-device\" disabled"),
       "server-render-only controls stay disabled on a live catalog's static snapshot",
+    )
+
+    // Trusted catalog served LIVE whose preview declares author knobs (ServeCatalogLiveHost with
+    // canRenderOverrides): snapshots stay baked, but the carried daemon re-renders a knob edit on
+    // demand, so the declared knob controls render ENABLED (not the disabled, informational form a
+    // plain static bundle shows) and route knob edits to /render.
+    val catalogKnobs =
+      ServeWeb.viewerPage(
+        knobPreview,
+        token,
+        sessionId = "compose-m3",
+        canApplyOverrides = false,
+        canRenderOverrides = true,
+        hasSvgExport = true,
+        hasLiveStream = true,
+        trust = "branch:yschimke/compose-ai-tools@design-artifacts/compose-m3",
+      )
+    assertTrue(catalogKnobs.contains("cp-knobs"), "declared knobs render as a control list")
+    assertTrue(
+      catalogKnobs.contains("data-knob-key=\"label\"") &&
+        catalogKnobs.contains("data-knob-key=\"iconColor\""),
+      "each declared knob gets a labelled control",
+    )
+    assertTrue(
+      catalogKnobs.contains("data-can-render-overrides=\"true\""),
+      "the viewer is flagged as override-renderable",
+    )
+    // The knobs are ENABLED — a live control, not the disabled/informational form. The `label` knob
+    // is a text input; assert it renders enabled (no trailing ` disabled`).
+    assertTrue(
+      catalogKnobs.contains("data-knob-key=\"label\" data-knob-kind=\"string\" value=\"Filled\">"),
+      "declared knobs are enabled on an override-renderable session",
+    )
+    assertTrue(
+      catalogKnobs.contains("edit a value to re-render"),
+      "the knob note invites editing rather than saying values are baked in",
+    )
+    // A knob edit routes to the server /render (the only tier that honours a named override — the
+    // Wasm tier's catalogOverride* returns the author default), never the wasm auto-enable path.
+    assertTrue(
+      catalogKnobs.contains("function onKnobChanged()"),
+      "knob edits have a dedicated handler that hits /render",
+    )
+    // A plain static bundle (no daemon) still shows the knobs as DISABLED, informational controls.
+    val staticKnobs = ServeWeb.viewerPage(knobPreview, token)
+    assertTrue(
+      staticKnobs.contains(
+        "data-knob-key=\"label\" data-knob-kind=\"string\" value=\"Filled\" disabled"
+      ),
+      "a plain static bundle leaves declared knobs disabled",
+    )
+    assertTrue(
+      staticKnobs.contains("static bundle, values are baked in"),
+      "a plain static bundle keeps the baked-in note",
+    )
+
+    // Copyable direct links: every viewer offers a PNG URL row (copy + download); a session that
+    // can
+    // export SVG (a catalog / daemon) also offers an SVG row. The URLs are built client-side from
+    // location.origin with the current overrides so a copied link reproduces the on-screen render.
+    assertTrue(catalogKnobs.contains("class=\"cp-links\""), "the direct-links panel is shown")
+    assertTrue(
+      catalogKnobs.contains("id=\"cp-url-png\"") && catalogKnobs.contains("id=\"cp-dl-png\""),
+      "the PNG URL row has a copyable field and a download link",
+    )
+    assertTrue(
+      catalogKnobs.contains("id=\"cp-url-svg\"") && catalogKnobs.contains("id=\"cp-dl-svg\""),
+      "an SVG-exporting session also offers an SVG URL row",
+    )
+    assertTrue(
+      catalogKnobs.contains("function refreshLinks()") && catalogKnobs.contains("location.origin"),
+      "the links are rebuilt from location.origin as the controls change",
+    )
+    // A plain static bundle can't export SVG, so it shows the PNG row but not the SVG one.
+    assertTrue(staticKnobs.contains("id=\"cp-url-png\""), "PNG URL row shows on any viewer")
+    assertFalse(
+      staticKnobs.contains("id=\"cp-url-svg\""),
+      "no SVG URL row when the session can't export SVG",
     )
 
     // Live daemon session (canApplyOverrides = true): everything enabled, no note.

--- a/vscode-extension/preview-harness/fixtures/pages/serve-home-index.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-home-index.html
@@ -79,10 +79,22 @@ a:hover { text-decoration: underline; }
 .cp-knobs { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
 .cp-knobs-head { font-size: 0.72rem; color: #6b6b70; }
 .cp-knobs input:disabled { opacity: 0.7; }
+.cp-links { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
+.cp-link-row { display: flex; align-items: center; gap: 6px; }
+.cp-link-kind { font-size: 0.72rem; font-weight: 600; color: #6b6b70; width: 30px; flex: none; }
+.cp-url { flex: 1; min-width: 0; font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.72rem; padding: 4px 6px; border: 1px solid #d7d7de; border-radius: 6px;
+  background: #fff; color: #1b1b1f; }
+.cp-copy, .cp-dl { font-size: 0.72rem; padding: 4px 8px; border-radius: 6px; border: 1px solid #d7d7de;
+  background: #fff; color: #5b5bd6; cursor: pointer; text-decoration: none; flex: none; }
+.cp-copy:hover, .cp-dl:hover { background: #f0f0f3; }
 @media (prefers-color-scheme: dark) {
   body { color: #e6e6e9; background: #161618; }
   .cp-sub, .cp-id, .cp-status, .cp-about-links, .cp-sys-desc, .cp-sys-foot { color: #a0a0a8; }
-  .cp-card, .cp-stage, .cp-knobs, .cp-about { border-color: #34343a; }
+  .cp-card, .cp-stage, .cp-knobs, .cp-links, .cp-about { border-color: #34343a; }
+  .cp-url { background: #1d1d20; color: #e6e6e9; border-color: #34343a; }
+  .cp-copy, .cp-dl { background: #1d1d20; border-color: #34343a; }
+  .cp-copy:hover, .cp-dl:hover { background: #26262b; }
   .cp-card, .cp-about { background: #1d1d20; }
   .cp-about-body { color: #c9c9d0; }
   .cp-about-body code { background: #2a2a30; }

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-path.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-path.html
@@ -79,10 +79,22 @@ a:hover { text-decoration: underline; }
 .cp-knobs { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
 .cp-knobs-head { font-size: 0.72rem; color: #6b6b70; }
 .cp-knobs input:disabled { opacity: 0.7; }
+.cp-links { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
+.cp-link-row { display: flex; align-items: center; gap: 6px; }
+.cp-link-kind { font-size: 0.72rem; font-weight: 600; color: #6b6b70; width: 30px; flex: none; }
+.cp-url { flex: 1; min-width: 0; font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.72rem; padding: 4px 6px; border: 1px solid #d7d7de; border-radius: 6px;
+  background: #fff; color: #1b1b1f; }
+.cp-copy, .cp-dl { font-size: 0.72rem; padding: 4px 8px; border-radius: 6px; border: 1px solid #d7d7de;
+  background: #fff; color: #5b5bd6; cursor: pointer; text-decoration: none; flex: none; }
+.cp-copy:hover, .cp-dl:hover { background: #f0f0f3; }
 @media (prefers-color-scheme: dark) {
   body { color: #e6e6e9; background: #161618; }
   .cp-sub, .cp-id, .cp-status, .cp-about-links, .cp-sys-desc, .cp-sys-foot { color: #a0a0a8; }
-  .cp-card, .cp-stage, .cp-knobs, .cp-about { border-color: #34343a; }
+  .cp-card, .cp-stage, .cp-knobs, .cp-links, .cp-about { border-color: #34343a; }
+  .cp-url { background: #1d1d20; color: #e6e6e9; border-color: #34343a; }
+  .cp-copy, .cp-dl { background: #1d1d20; border-color: #34343a; }
+  .cp-copy:hover, .cp-dl:hover { background: #26262b; }
   .cp-card, .cp-about { background: #1d1d20; }
   .cp-about-body { color: #c9c9d0; }
   .cp-about-body code { background: #2a2a30; }

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-public.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-public.html
@@ -79,10 +79,22 @@ a:hover { text-decoration: underline; }
 .cp-knobs { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
 .cp-knobs-head { font-size: 0.72rem; color: #6b6b70; }
 .cp-knobs input:disabled { opacity: 0.7; }
+.cp-links { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
+.cp-link-row { display: flex; align-items: center; gap: 6px; }
+.cp-link-kind { font-size: 0.72rem; font-weight: 600; color: #6b6b70; width: 30px; flex: none; }
+.cp-url { flex: 1; min-width: 0; font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.72rem; padding: 4px 6px; border: 1px solid #d7d7de; border-radius: 6px;
+  background: #fff; color: #1b1b1f; }
+.cp-copy, .cp-dl { font-size: 0.72rem; padding: 4px 8px; border-radius: 6px; border: 1px solid #d7d7de;
+  background: #fff; color: #5b5bd6; cursor: pointer; text-decoration: none; flex: none; }
+.cp-copy:hover, .cp-dl:hover { background: #f0f0f3; }
 @media (prefers-color-scheme: dark) {
   body { color: #e6e6e9; background: #161618; }
   .cp-sub, .cp-id, .cp-status, .cp-about-links, .cp-sys-desc, .cp-sys-foot { color: #a0a0a8; }
-  .cp-card, .cp-stage, .cp-knobs, .cp-about { border-color: #34343a; }
+  .cp-card, .cp-stage, .cp-knobs, .cp-links, .cp-about { border-color: #34343a; }
+  .cp-url { background: #1d1d20; color: #e6e6e9; border-color: #34343a; }
+  .cp-copy, .cp-dl { background: #1d1d20; border-color: #34343a; }
+  .cp-copy:hover, .cp-dl:hover { background: #26262b; }
   .cp-card, .cp-about { background: #1d1d20; }
   .cp-about-body { color: #c9c9d0; }
   .cp-about-body code { background: #2a2a30; }

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-themed.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-themed.html
@@ -79,10 +79,22 @@ a:hover { text-decoration: underline; }
 .cp-knobs { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
 .cp-knobs-head { font-size: 0.72rem; color: #6b6b70; }
 .cp-knobs input:disabled { opacity: 0.7; }
+.cp-links { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
+.cp-link-row { display: flex; align-items: center; gap: 6px; }
+.cp-link-kind { font-size: 0.72rem; font-weight: 600; color: #6b6b70; width: 30px; flex: none; }
+.cp-url { flex: 1; min-width: 0; font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.72rem; padding: 4px 6px; border: 1px solid #d7d7de; border-radius: 6px;
+  background: #fff; color: #1b1b1f; }
+.cp-copy, .cp-dl { font-size: 0.72rem; padding: 4px 8px; border-radius: 6px; border: 1px solid #d7d7de;
+  background: #fff; color: #5b5bd6; cursor: pointer; text-decoration: none; flex: none; }
+.cp-copy:hover, .cp-dl:hover { background: #f0f0f3; }
 @media (prefers-color-scheme: dark) {
   body { color: #e6e6e9; background: #161618; }
   .cp-sub, .cp-id, .cp-status, .cp-about-links, .cp-sys-desc, .cp-sys-foot { color: #a0a0a8; }
-  .cp-card, .cp-stage, .cp-knobs, .cp-about { border-color: #34343a; }
+  .cp-card, .cp-stage, .cp-knobs, .cp-links, .cp-about { border-color: #34343a; }
+  .cp-url { background: #1d1d20; color: #e6e6e9; border-color: #34343a; }
+  .cp-copy, .cp-dl { background: #1d1d20; border-color: #34343a; }
+  .cp-copy:hover, .cp-dl:hover { background: #26262b; }
   .cp-card, .cp-about { background: #1d1d20; }
   .cp-about-body { color: #c9c9d0; }
   .cp-about-body code { background: #2a2a30; }

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing.html
@@ -79,10 +79,22 @@ a:hover { text-decoration: underline; }
 .cp-knobs { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
 .cp-knobs-head { font-size: 0.72rem; color: #6b6b70; }
 .cp-knobs input:disabled { opacity: 0.7; }
+.cp-links { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
+.cp-link-row { display: flex; align-items: center; gap: 6px; }
+.cp-link-kind { font-size: 0.72rem; font-weight: 600; color: #6b6b70; width: 30px; flex: none; }
+.cp-url { flex: 1; min-width: 0; font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.72rem; padding: 4px 6px; border: 1px solid #d7d7de; border-radius: 6px;
+  background: #fff; color: #1b1b1f; }
+.cp-copy, .cp-dl { font-size: 0.72rem; padding: 4px 8px; border-radius: 6px; border: 1px solid #d7d7de;
+  background: #fff; color: #5b5bd6; cursor: pointer; text-decoration: none; flex: none; }
+.cp-copy:hover, .cp-dl:hover { background: #f0f0f3; }
 @media (prefers-color-scheme: dark) {
   body { color: #e6e6e9; background: #161618; }
   .cp-sub, .cp-id, .cp-status, .cp-about-links, .cp-sys-desc, .cp-sys-foot { color: #a0a0a8; }
-  .cp-card, .cp-stage, .cp-knobs, .cp-about { border-color: #34343a; }
+  .cp-card, .cp-stage, .cp-knobs, .cp-links, .cp-about { border-color: #34343a; }
+  .cp-url { background: #1d1d20; color: #e6e6e9; border-color: #34343a; }
+  .cp-copy, .cp-dl { background: #1d1d20; border-color: #34343a; }
+  .cp-copy:hover, .cp-dl:hover { background: #26262b; }
   .cp-card, .cp-about { background: #1d1d20; }
   .cp-about-body { color: #c9c9d0; }
   .cp-about-body code { background: #2a2a30; }

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
@@ -154,6 +154,12 @@ a:hover { text-decoration: underline; }
               <option value="landscape">Landscape</option>
             </select>
           </label>
+          <label>Background
+            <select id="cp-background" disabled>
+              <option value="">(default)</option>
+              <option value="clear">Clear (crisp outline)</option>
+            </select>
+          </label>
                 <div class="cp-knobs">
         <div class="cp-knobs-head">Declared overrides — edit a value to re-render.</div>
         <label>label
@@ -227,7 +233,7 @@ a:hover { text-decoration: underline; }
   // scale slider has no empty state, so it's gated separately: we only send fontScale once the
   // user moves it (fontScaleTouched), otherwise the slider's standing 1.0 would override a
   // preview's declared default font scale and the first render wouldn't match the thumbnail.
-  var fields = ["uiMode", "device", "localeTag", "orientation"];
+  var fields = ["uiMode", "device", "localeTag", "orientation", "background"];
   var fs = document.getElementById("cp-fontScale");
   var fsVal = document.getElementById("cp-fontScale-val");
   var fontScaleTouched = false;
@@ -240,6 +246,25 @@ a:hover { text-decoration: underline; }
       if (el && el.value) o[f] = el.value;
     });
     if (fontScaleTouched && fs) o.fontScale = fs.value;
+    return o;
+  }
+  // The live-stream override map: the display fields PLUS the author-declared knob values as
+  // `knob.<key>` entries (the daemon's setOverrides parses the same map /render does, and
+  // ServeOverrides reads knob.* keys). Kept separate from overrides() so query() and the Wasm
+  // patch — which append/ignore knobs their own way — are unaffected; without this a knob edit
+  // during an active Live (stream) would send only the display fields and the daemon would reset
+  // the knob to its default.
+  function liveOverrides() {
+    var o = overrides();
+    document.querySelectorAll(".cp-knob").forEach(function (el) {
+      if (el.disabled) return;
+      var key = el.getAttribute("data-knob-key");
+      var kind = el.getAttribute("data-knob-kind") || "string";
+      if (!key) return;
+      var val = (el.type === "checkbox") ? (el.checked ? "true" : "false") : el.value;
+      if (val === "") return;
+      o["knob." + key] = kind + ":" + val;
+    });
     return o;
   }
   function query() {
@@ -590,7 +615,7 @@ a:hover { text-decoration: underline; }
       return;
     }
     if (live.checked && ws && ws.readyState === 1) {
-      ws.send(JSON.stringify({ type: "setOverrides", overrides: overrides() }));
+      ws.send(JSON.stringify({ type: "setOverrides", overrides: liveOverrides() }));
     } else if (staticSnapshot && wasmToggle) {
       // Static snapshot backed by a Wasm app: the baked PNG can't honour theme/font-scale/locale
       // (only the in-browser tier can), and /render can't re-render a published catalog. So a
@@ -662,7 +687,7 @@ a:hover { text-decoration: underline; }
   function onKnobChanged() {
     refreshLinks();
     if (live.checked && ws && ws.readyState === 1) {
-      ws.send(JSON.stringify({ type: "setOverrides", overrides: overrides() }));
+      ws.send(JSON.stringify({ type: "setOverrides", overrides: liveOverrides() }));
     } else if (canRenderOverrides) {
       refreshSnapshot();
     }

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
@@ -3,7 +3,7 @@
       <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <title>Profile screen — compose-preview</title>
+        <title>Button · Filled (light) — compose-preview</title>
         <style>:root { color-scheme: light dark; }
 * { box-sizing: border-box; }
 body { margin: 0; padding: 24px; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
@@ -114,16 +114,17 @@ a:hover { text-decoration: underline; }
 }</style>
       </head>
       <body>
-              <p class="cp-head"><a href="/meshcore-mobile/?token=demo-token-fixture">← previews</a> <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/meshcore-mobile@design-artifacts/meshcore-mobile">✓ branch:yschimke/meshcore-mobile@design-artifacts/meshcore-mobile</span></p>
-      <p class="cp-sub" title="com.example.ProfileScreenPreview">Profile screen</p>
-      <div class="cp-viewer" data-preview-id="com.example.ProfileScreenPreview" data-mode="snapshot" data-modes="snapshot,live" data-static-snapshot="true" data-can-render-overrides="false" data-snapshot-backend="Snapshot" data-live-backend="Live">
-        <div class="cp-stage"><span class="cp-backend" id="cp-backend"></span><img id="cp-img" alt="Profile screen"><canvas id="cp-canvas" hidden></canvas></div>
+              <p class="cp-head"><a href="/?token=demo-token-fixture&session=compose-m3">← previews</a> <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/compose-ai-tools@design-artifacts/compose-m3">✓ branch:yschimke/compose-ai-tools@design-artifacts/compose-m3</span></p>
+      <p class="cp-sub" title="button-filled__ideal__default__light">Button · Filled (light)</p>
+      <div class="cp-viewer" data-preview-id="button-filled__ideal__default__light" data-mode="snapshot" data-modes="snapshot" data-static-snapshot="true" data-can-render-overrides="true" data-snapshot-backend="Snapshot" data-live-backend="Live" data-wasm-src="/wasm/compose-m3/?id=button-filled">
+        <div class="cp-stage"><span class="cp-backend" id="cp-backend"></span><img id="cp-img" alt="Button · Filled (light)"><canvas id="cp-canvas" hidden></canvas><iframe id="cp-wasm" hidden sandbox="allow-scripts" title="Button · Filled (light) (Wasm)"></iframe></div>
         <div class="cp-controls">
-          <div class="cp-note">Pre-rendered snapshot — overrides (device, locale, font scale, orientation) need the live server, not a published catalog. <a href="https://github.com/yschimke/compose-ai-tools/blob/main/docs/public-preview-server.md#running-one">Enable a local preview server.</a></div>
-          <label class="cp-live-row"><input id="cp-live" type="checkbox" disabled> Live (stream)</label>
-          
+          <div class="cp-note">Pre-rendered snapshot — tick “Run in browser (Wasm)” to interact: Theme, Font scale, Locale &amp; background apply in the browser. Device/Orientation need the live server. <a href="https://github.com/yschimke/compose-ai-tools/blob/main/docs/public-preview-server.md#running-one">Enable a local preview server.</a></div>
+          <label class="cp-live-row"><input id="cp-live" type="checkbox"> Live (stream)</label>
+          <label class="cp-live-row"><input id="cp-wasm-toggle" type="checkbox"> Run in browser (Wasm)</label>
+          <label class="cp-live-row"><input id="cp-wasm-bg" type="checkbox"> Component only (no background)</label>
           <label>Theme
-            <select id="cp-uiMode" disabled>
+            <select id="cp-uiMode">
               <option value="">(default)</option>
               <option value="light">Light</option>
               <option value="dark">Dark</option>
@@ -141,10 +142,10 @@ a:hover { text-decoration: underline; }
             </select>
           </label>
           <label>Locale (BCP-47)
-            <input id="cp-localeTag" type="text" placeholder="e.g. ar, ja-JP" autocomplete="off" disabled>
+            <input id="cp-localeTag" type="text" placeholder="e.g. ar, ja-JP" autocomplete="off">
           </label>
           <label>Font scale: <span id="cp-fontScale-val">default</span>
-            <input id="cp-fontScale" type="range" min="0.5" max="2.0" step="0.1" value="1.0" disabled>
+            <input id="cp-fontScale" type="range" min="0.5" max="2.0" step="0.1" value="1.0">
           </label>
           <label>Orientation
             <select id="cp-orientation" disabled>
@@ -153,13 +154,15 @@ a:hover { text-decoration: underline; }
               <option value="landscape">Landscape</option>
             </select>
           </label>
-          <label>Background
-            <select id="cp-background" disabled>
-              <option value="">(default)</option>
-              <option value="clear">Clear (crisp outline)</option>
-            </select>
-          </label>
-          
+                <div class="cp-knobs">
+        <div class="cp-knobs-head">Declared overrides — edit a value to re-render.</div>
+        <label>label
+  <input type="text" class="cp-knob" data-knob-key="label" data-knob-kind="string" value="Filled">
+</label>
+<label>iconColor
+  <input type="text" class="cp-knob" data-knob-key="iconColor" data-knob-kind="color" value="#FF6750A4">
+</label>
+      </div>
                 <div class="cp-links">
         <div class="cp-knobs-head">Direct links — the current view as a URL (overrides applied)</div>
         <div class="cp-link-row">
@@ -167,6 +170,12 @@ a:hover { text-decoration: underline; }
   <input id="cp-url-png" class="cp-url" type="text" readonly aria-label="PNG URL">
   <button type="button" class="cp-copy" data-copy-target="cp-url-png">Copy</button>
   <a id="cp-dl-png" class="cp-dl" download>Download</a>
+</div>
+<div class="cp-link-row">
+  <span class="cp-link-kind">SVG</span>
+  <input id="cp-url-svg" class="cp-url" type="text" readonly aria-label="SVG URL">
+  <button type="button" class="cp-copy" data-copy-target="cp-url-svg">Copy</button>
+  <a id="cp-dl-svg" class="cp-dl" download>Download</a>
 </div>
       </div>
           <div class="cp-status" id="cp-status"></div>
@@ -218,7 +227,7 @@ a:hover { text-decoration: underline; }
   // scale slider has no empty state, so it's gated separately: we only send fontScale once the
   // user moves it (fontScaleTouched), otherwise the slider's standing 1.0 would override a
   // preview's declared default font scale and the first render wouldn't match the thumbnail.
-  var fields = ["uiMode", "device", "localeTag", "orientation", "background"];
+  var fields = ["uiMode", "device", "localeTag", "orientation"];
   var fs = document.getElementById("cp-fontScale");
   var fsVal = document.getElementById("cp-fontScale-val");
   var fontScaleTouched = false;

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
@@ -233,6 +233,25 @@ a:hover { text-decoration: underline; }
     if (fontScaleTouched && fs) o.fontScale = fs.value;
     return o;
   }
+  // The live-stream override map: the display fields PLUS the author-declared knob values as
+  // `knob.<key>` entries (the daemon's setOverrides parses the same map /render does, and
+  // ServeOverrides reads knob.* keys). Kept separate from overrides() so query() and the Wasm
+  // patch — which append/ignore knobs their own way — are unaffected; without this a knob edit
+  // during an active Live (stream) would send only the display fields and the daemon would reset
+  // the knob to its default.
+  function liveOverrides() {
+    var o = overrides();
+    document.querySelectorAll(".cp-knob").forEach(function (el) {
+      if (el.disabled) return;
+      var key = el.getAttribute("data-knob-key");
+      var kind = el.getAttribute("data-knob-kind") || "string";
+      if (!key) return;
+      var val = (el.type === "checkbox") ? (el.checked ? "true" : "false") : el.value;
+      if (val === "") return;
+      o["knob." + key] = kind + ":" + val;
+    });
+    return o;
+  }
   function query() {
     var o = overrides();
     // Public routes are open, so a page that arrived without a token stays token-free — only
@@ -581,7 +600,7 @@ a:hover { text-decoration: underline; }
       return;
     }
     if (live.checked && ws && ws.readyState === 1) {
-      ws.send(JSON.stringify({ type: "setOverrides", overrides: overrides() }));
+      ws.send(JSON.stringify({ type: "setOverrides", overrides: liveOverrides() }));
     } else if (staticSnapshot && wasmToggle) {
       // Static snapshot backed by a Wasm app: the baked PNG can't honour theme/font-scale/locale
       // (only the in-browser tier can), and /render can't re-render a published catalog. So a
@@ -653,7 +672,7 @@ a:hover { text-decoration: underline; }
   function onKnobChanged() {
     refreshLinks();
     if (live.checked && ws && ws.readyState === 1) {
-      ws.send(JSON.stringify({ type: "setOverrides", overrides: overrides() }));
+      ws.send(JSON.stringify({ type: "setOverrides", overrides: liveOverrides() }));
     } else if (canRenderOverrides) {
       refreshSnapshot();
     }

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
@@ -234,6 +234,25 @@ a:hover { text-decoration: underline; }
     if (fontScaleTouched && fs) o.fontScale = fs.value;
     return o;
   }
+  // The live-stream override map: the display fields PLUS the author-declared knob values as
+  // `knob.<key>` entries (the daemon's setOverrides parses the same map /render does, and
+  // ServeOverrides reads knob.* keys). Kept separate from overrides() so query() and the Wasm
+  // patch — which append/ignore knobs their own way — are unaffected; without this a knob edit
+  // during an active Live (stream) would send only the display fields and the daemon would reset
+  // the knob to its default.
+  function liveOverrides() {
+    var o = overrides();
+    document.querySelectorAll(".cp-knob").forEach(function (el) {
+      if (el.disabled) return;
+      var key = el.getAttribute("data-knob-key");
+      var kind = el.getAttribute("data-knob-kind") || "string";
+      if (!key) return;
+      var val = (el.type === "checkbox") ? (el.checked ? "true" : "false") : el.value;
+      if (val === "") return;
+      o["knob." + key] = kind + ":" + val;
+    });
+    return o;
+  }
   function query() {
     var o = overrides();
     // Public routes are open, so a page that arrived without a token stays token-free — only
@@ -582,7 +601,7 @@ a:hover { text-decoration: underline; }
       return;
     }
     if (live.checked && ws && ws.readyState === 1) {
-      ws.send(JSON.stringify({ type: "setOverrides", overrides: overrides() }));
+      ws.send(JSON.stringify({ type: "setOverrides", overrides: liveOverrides() }));
     } else if (staticSnapshot && wasmToggle) {
       // Static snapshot backed by a Wasm app: the baked PNG can't honour theme/font-scale/locale
       // (only the in-browser tier can), and /render can't re-render a published catalog. So a
@@ -654,7 +673,7 @@ a:hover { text-decoration: underline; }
   function onKnobChanged() {
     refreshLinks();
     if (live.checked && ws && ws.readyState === 1) {
-      ws.send(JSON.stringify({ type: "setOverrides", overrides: overrides() }));
+      ws.send(JSON.stringify({ type: "setOverrides", overrides: liveOverrides() }));
     } else if (canRenderOverrides) {
       refreshSnapshot();
     }

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
@@ -79,10 +79,22 @@ a:hover { text-decoration: underline; }
 .cp-knobs { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
 .cp-knobs-head { font-size: 0.72rem; color: #6b6b70; }
 .cp-knobs input:disabled { opacity: 0.7; }
+.cp-links { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
+.cp-link-row { display: flex; align-items: center; gap: 6px; }
+.cp-link-kind { font-size: 0.72rem; font-weight: 600; color: #6b6b70; width: 30px; flex: none; }
+.cp-url { flex: 1; min-width: 0; font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.72rem; padding: 4px 6px; border: 1px solid #d7d7de; border-radius: 6px;
+  background: #fff; color: #1b1b1f; }
+.cp-copy, .cp-dl { font-size: 0.72rem; padding: 4px 8px; border-radius: 6px; border: 1px solid #d7d7de;
+  background: #fff; color: #5b5bd6; cursor: pointer; text-decoration: none; flex: none; }
+.cp-copy:hover, .cp-dl:hover { background: #f0f0f3; }
 @media (prefers-color-scheme: dark) {
   body { color: #e6e6e9; background: #161618; }
   .cp-sub, .cp-id, .cp-status, .cp-about-links, .cp-sys-desc, .cp-sys-foot { color: #a0a0a8; }
-  .cp-card, .cp-stage, .cp-knobs, .cp-about { border-color: #34343a; }
+  .cp-card, .cp-stage, .cp-knobs, .cp-links, .cp-about { border-color: #34343a; }
+  .cp-url { background: #1d1d20; color: #e6e6e9; border-color: #34343a; }
+  .cp-copy, .cp-dl { background: #1d1d20; border-color: #34343a; }
+  .cp-copy:hover, .cp-dl:hover { background: #26262b; }
   .cp-card, .cp-about { background: #1d1d20; }
   .cp-about-body { color: #c9c9d0; }
   .cp-about-body code { background: #2a2a30; }
@@ -104,7 +116,7 @@ a:hover { text-decoration: underline; }
       <body>
               <p class="cp-head"><a href="/?token=demo-token-fixture&session=compose-m3">← previews</a> <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/compose-ai-tools@design-artifacts/compose-m3">✓ branch:yschimke/compose-ai-tools@design-artifacts/compose-m3</span></p>
       <p class="cp-sub" title="com.example.CardPreview">Card</p>
-      <div class="cp-viewer" data-preview-id="com.example.CardPreview" data-mode="snapshot" data-modes="snapshot,live" data-static-snapshot="true" data-snapshot-backend="Snapshot" data-live-backend="Live" data-wasm-src="/wasm/compose-m3/?id=card-filled">
+      <div class="cp-viewer" data-preview-id="com.example.CardPreview" data-mode="snapshot" data-modes="snapshot,live" data-static-snapshot="true" data-can-render-overrides="false" data-snapshot-backend="Snapshot" data-live-backend="Live" data-wasm-src="/wasm/compose-m3/?id=card-filled">
         <div class="cp-stage"><span class="cp-backend" id="cp-backend"></span><img id="cp-img" alt="Card"><canvas id="cp-canvas" hidden></canvas><iframe id="cp-wasm" hidden sandbox="allow-scripts" title="Card (Wasm)"></iframe></div>
         <div class="cp-controls">
           <div class="cp-note">Pre-rendered snapshot — tick “Run in browser (Wasm)” to interact: Theme, Font scale, Locale &amp; background apply in the browser. Device/Orientation need the live server. <a href="https://github.com/yschimke/compose-ai-tools/blob/main/docs/public-preview-server.md#running-one">Enable a local preview server.</a></div>
@@ -149,6 +161,15 @@ a:hover { text-decoration: underline; }
             </select>
           </label>
           
+                <div class="cp-links">
+        <div class="cp-knobs-head">Direct links — the current view as a URL (overrides applied)</div>
+        <div class="cp-link-row">
+  <span class="cp-link-kind">PNG</span>
+  <input id="cp-url-png" class="cp-url" type="text" readonly aria-label="PNG URL">
+  <button type="button" class="cp-copy" data-copy-target="cp-url-png">Copy</button>
+  <a id="cp-dl-png" class="cp-dl" download>Download</a>
+</div>
+      </div>
           <div class="cp-status" id="cp-status"></div>
         </div>
       </div>
@@ -181,6 +202,10 @@ a:hover { text-decoration: underline; }
   // static snapshots yet leaves the Live toggle enabled, so `live.disabled` no longer implies
   // "static".
   var staticSnapshot = root.getAttribute("data-static-snapshot") === "true";
+  // Whether an override-bearing /render returns fresh pixels even on a static snapshot lane (a
+  // trusted-catalog live session: its carried daemon re-renders author-declared knob edits on
+  // demand). When true, a knob edit re-points the snapshot /render URL rather than sitting dead.
+  var canRenderOverrides = root.getAttribute("data-can-render-overrides") === "true";
   var previewId = root.getAttribute("data-preview-id");
   // The session path prefix ("/<system>") when this viewer is served under a path — it sits at
   // "<base>/p/<id>", so stripping the trailing "/p/<id>" recovers the base ("" for the root
@@ -237,7 +262,44 @@ a:hover { text-decoration: underline; }
     next.onload = function () { img.src = url; status.textContent = ""; };
     next.onerror = function () { status.textContent = "render failed"; };
     next.src = url;
+    refreshLinks();
   }
+  // The copyable direct-link panel: rebuild the absolute /render URLs (PNG + optional SVG) from
+  // the current controls so a copied/downloaded link reproduces exactly what's on screen. Built
+  // on location.origin so the link is absolute (curl-able / shareable), and kept in sync on
+  // every control or knob change — even the ones that don't re-render the snapshot themselves.
+  function renderUrl(ext) {
+    var qs = query();
+    return location.origin + base + "/render/" + encodeURIComponent(previewId) + ext +
+      (qs ? "?" + qs : "");
+  }
+  function refreshLinks() {
+    [["png", ".png"], ["svg", ".svg"]].forEach(function (pair) {
+      var field = document.getElementById("cp-url-" + pair[0]);
+      if (!field) return;
+      var url = renderUrl(pair[1]);
+      field.value = url;
+      var dl = document.getElementById("cp-dl-" + pair[0]);
+      if (dl) dl.href = url;
+    });
+  }
+  document.querySelectorAll(".cp-copy").forEach(function (btn) {
+    btn.addEventListener("click", function () {
+      var field = document.getElementById(btn.getAttribute("data-copy-target"));
+      if (!field) return;
+      var done = function () {
+        var was = btn.textContent;
+        btn.textContent = "Copied";
+        setTimeout(function () { btn.textContent = was; }, 1200);
+      };
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(field.value).then(done, function () { field.select(); });
+      } else {
+        field.select();
+        try { document.execCommand("copy"); done(); } catch (e) {}
+      }
+    });
+  });
   function drawFrame(b64, codec) {
     var im = new Image();
     im.onload = function () {
@@ -507,6 +569,8 @@ a:hover { text-decoration: underline; }
   function wasmActive() { return wasmToggle && wasmToggle.checked; }
 
   function onControlsChanged() {
+    // Keep the copyable direct links current no matter which transport handles the change.
+    refreshLinks();
     if (wasmActive()) {
       // Recompose in place once the app is up; before it's ready, re-point the initial src (the
       // fragment carries the overrides) — the load handler re-syncs the final state either way.
@@ -584,8 +648,19 @@ a:hover { text-decoration: underline; }
     if (el) el.addEventListener("change", onControlsChanged);
   });
   // Author-declared knobs re-render on edit (text/number debounce via "input", toggles "change").
+  // They route differently from the display axes: a named knob (label, a color, …) is honoured
+  // ONLY by the server daemon — the in-browser Wasm tier's `catalogOverride*` returns the author
+  // default — so a knob edit must hit /render (onKnobChanged), never the wasm auto-enable path.
+  function onKnobChanged() {
+    refreshLinks();
+    if (live.checked && ws && ws.readyState === 1) {
+      ws.send(JSON.stringify({ type: "setOverrides", overrides: overrides() }));
+    } else if (canRenderOverrides) {
+      refreshSnapshot();
+    }
+  }
   document.querySelectorAll(".cp-knob").forEach(function (el) {
-    el.addEventListener(el.type === "checkbox" ? "change" : "input", onControlsChanged);
+    el.addEventListener(el.type === "checkbox" ? "change" : "input", onKnobChanged);
   });
   refreshSnapshot();
 })();</script>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
@@ -234,6 +234,25 @@ a:hover { text-decoration: underline; }
     if (fontScaleTouched && fs) o.fontScale = fs.value;
     return o;
   }
+  // The live-stream override map: the display fields PLUS the author-declared knob values as
+  // `knob.<key>` entries (the daemon's setOverrides parses the same map /render does, and
+  // ServeOverrides reads knob.* keys). Kept separate from overrides() so query() and the Wasm
+  // patch — which append/ignore knobs their own way — are unaffected; without this a knob edit
+  // during an active Live (stream) would send only the display fields and the daemon would reset
+  // the knob to its default.
+  function liveOverrides() {
+    var o = overrides();
+    document.querySelectorAll(".cp-knob").forEach(function (el) {
+      if (el.disabled) return;
+      var key = el.getAttribute("data-knob-key");
+      var kind = el.getAttribute("data-knob-kind") || "string";
+      if (!key) return;
+      var val = (el.type === "checkbox") ? (el.checked ? "true" : "false") : el.value;
+      if (val === "") return;
+      o["knob." + key] = kind + ":" + val;
+    });
+    return o;
+  }
   function query() {
     var o = overrides();
     // Public routes are open, so a page that arrived without a token stays token-free — only
@@ -582,7 +601,7 @@ a:hover { text-decoration: underline; }
       return;
     }
     if (live.checked && ws && ws.readyState === 1) {
-      ws.send(JSON.stringify({ type: "setOverrides", overrides: overrides() }));
+      ws.send(JSON.stringify({ type: "setOverrides", overrides: liveOverrides() }));
     } else if (staticSnapshot && wasmToggle) {
       // Static snapshot backed by a Wasm app: the baked PNG can't honour theme/font-scale/locale
       // (only the in-browser tier can), and /render can't re-render a published catalog. So a
@@ -654,7 +673,7 @@ a:hover { text-decoration: underline; }
   function onKnobChanged() {
     refreshLinks();
     if (live.checked && ws && ws.readyState === 1) {
-      ws.send(JSON.stringify({ type: "setOverrides", overrides: overrides() }));
+      ws.send(JSON.stringify({ type: "setOverrides", overrides: liveOverrides() }));
     } else if (canRenderOverrides) {
       refreshSnapshot();
     }

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
@@ -79,10 +79,22 @@ a:hover { text-decoration: underline; }
 .cp-knobs { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
 .cp-knobs-head { font-size: 0.72rem; color: #6b6b70; }
 .cp-knobs input:disabled { opacity: 0.7; }
+.cp-links { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
+.cp-link-row { display: flex; align-items: center; gap: 6px; }
+.cp-link-kind { font-size: 0.72rem; font-weight: 600; color: #6b6b70; width: 30px; flex: none; }
+.cp-url { flex: 1; min-width: 0; font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.72rem; padding: 4px 6px; border: 1px solid #d7d7de; border-radius: 6px;
+  background: #fff; color: #1b1b1f; }
+.cp-copy, .cp-dl { font-size: 0.72rem; padding: 4px 8px; border-radius: 6px; border: 1px solid #d7d7de;
+  background: #fff; color: #5b5bd6; cursor: pointer; text-decoration: none; flex: none; }
+.cp-copy:hover, .cp-dl:hover { background: #f0f0f3; }
 @media (prefers-color-scheme: dark) {
   body { color: #e6e6e9; background: #161618; }
   .cp-sub, .cp-id, .cp-status, .cp-about-links, .cp-sys-desc, .cp-sys-foot { color: #a0a0a8; }
-  .cp-card, .cp-stage, .cp-knobs, .cp-about { border-color: #34343a; }
+  .cp-card, .cp-stage, .cp-knobs, .cp-links, .cp-about { border-color: #34343a; }
+  .cp-url { background: #1d1d20; color: #e6e6e9; border-color: #34343a; }
+  .cp-copy, .cp-dl { background: #1d1d20; border-color: #34343a; }
+  .cp-copy:hover, .cp-dl:hover { background: #26262b; }
   .cp-card, .cp-about { background: #1d1d20; }
   .cp-about-body { color: #c9c9d0; }
   .cp-about-body code { background: #2a2a30; }
@@ -104,7 +116,7 @@ a:hover { text-decoration: underline; }
       <body>
               <p class="cp-head"><a href="/?token=demo-token-fixture&session=compose-m3">← previews</a> <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/compose-ai-tools@design-artifacts/compose-m3">✓ branch:yschimke/compose-ai-tools@design-artifacts/compose-m3</span></p>
       <p class="cp-sub" title="com.example.CardPreview">Card</p>
-      <div class="cp-viewer" data-preview-id="com.example.CardPreview" data-mode="snapshot" data-modes="snapshot,live" data-static-snapshot="true" data-snapshot-backend="Snapshot" data-live-backend="Live" data-wasm-src="/wasm/compose-m3/?id=card-filled">
+      <div class="cp-viewer" data-preview-id="com.example.CardPreview" data-mode="snapshot" data-modes="snapshot,live" data-static-snapshot="true" data-can-render-overrides="false" data-snapshot-backend="Snapshot" data-live-backend="Live" data-wasm-src="/wasm/compose-m3/?id=card-filled">
         <div class="cp-stage"><span class="cp-backend" id="cp-backend"></span><img id="cp-img" alt="Card"><canvas id="cp-canvas" hidden></canvas><iframe id="cp-wasm" hidden sandbox="allow-scripts" title="Card (Wasm)"></iframe></div>
         <div class="cp-controls">
           <div class="cp-note">Pre-rendered snapshot — tick “Run in browser (Wasm)” to interact: Theme, Font scale, Locale &amp; background apply in the browser. Device/Orientation need the live server. <a href="https://github.com/yschimke/compose-ai-tools/blob/main/docs/public-preview-server.md#running-one">Enable a local preview server.</a></div>
@@ -149,6 +161,15 @@ a:hover { text-decoration: underline; }
             </select>
           </label>
           
+                <div class="cp-links">
+        <div class="cp-knobs-head">Direct links — the current view as a URL (overrides applied)</div>
+        <div class="cp-link-row">
+  <span class="cp-link-kind">PNG</span>
+  <input id="cp-url-png" class="cp-url" type="text" readonly aria-label="PNG URL">
+  <button type="button" class="cp-copy" data-copy-target="cp-url-png">Copy</button>
+  <a id="cp-dl-png" class="cp-dl" download>Download</a>
+</div>
+      </div>
           <div class="cp-status" id="cp-status"></div>
         </div>
       </div>
@@ -181,6 +202,10 @@ a:hover { text-decoration: underline; }
   // static snapshots yet leaves the Live toggle enabled, so `live.disabled` no longer implies
   // "static".
   var staticSnapshot = root.getAttribute("data-static-snapshot") === "true";
+  // Whether an override-bearing /render returns fresh pixels even on a static snapshot lane (a
+  // trusted-catalog live session: its carried daemon re-renders author-declared knob edits on
+  // demand). When true, a knob edit re-points the snapshot /render URL rather than sitting dead.
+  var canRenderOverrides = root.getAttribute("data-can-render-overrides") === "true";
   var previewId = root.getAttribute("data-preview-id");
   // The session path prefix ("/<system>") when this viewer is served under a path — it sits at
   // "<base>/p/<id>", so stripping the trailing "/p/<id>" recovers the base ("" for the root
@@ -237,7 +262,44 @@ a:hover { text-decoration: underline; }
     next.onload = function () { img.src = url; status.textContent = ""; };
     next.onerror = function () { status.textContent = "render failed"; };
     next.src = url;
+    refreshLinks();
   }
+  // The copyable direct-link panel: rebuild the absolute /render URLs (PNG + optional SVG) from
+  // the current controls so a copied/downloaded link reproduces exactly what's on screen. Built
+  // on location.origin so the link is absolute (curl-able / shareable), and kept in sync on
+  // every control or knob change — even the ones that don't re-render the snapshot themselves.
+  function renderUrl(ext) {
+    var qs = query();
+    return location.origin + base + "/render/" + encodeURIComponent(previewId) + ext +
+      (qs ? "?" + qs : "");
+  }
+  function refreshLinks() {
+    [["png", ".png"], ["svg", ".svg"]].forEach(function (pair) {
+      var field = document.getElementById("cp-url-" + pair[0]);
+      if (!field) return;
+      var url = renderUrl(pair[1]);
+      field.value = url;
+      var dl = document.getElementById("cp-dl-" + pair[0]);
+      if (dl) dl.href = url;
+    });
+  }
+  document.querySelectorAll(".cp-copy").forEach(function (btn) {
+    btn.addEventListener("click", function () {
+      var field = document.getElementById(btn.getAttribute("data-copy-target"));
+      if (!field) return;
+      var done = function () {
+        var was = btn.textContent;
+        btn.textContent = "Copied";
+        setTimeout(function () { btn.textContent = was; }, 1200);
+      };
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(field.value).then(done, function () { field.select(); });
+      } else {
+        field.select();
+        try { document.execCommand("copy"); done(); } catch (e) {}
+      }
+    });
+  });
   function drawFrame(b64, codec) {
     var im = new Image();
     im.onload = function () {
@@ -507,6 +569,8 @@ a:hover { text-decoration: underline; }
   function wasmActive() { return wasmToggle && wasmToggle.checked; }
 
   function onControlsChanged() {
+    // Keep the copyable direct links current no matter which transport handles the change.
+    refreshLinks();
     if (wasmActive()) {
       // Recompose in place once the app is up; before it's ready, re-point the initial src (the
       // fragment carries the overrides) — the load handler re-syncs the final state either way.
@@ -584,8 +648,19 @@ a:hover { text-decoration: underline; }
     if (el) el.addEventListener("change", onControlsChanged);
   });
   // Author-declared knobs re-render on edit (text/number debounce via "input", toggles "change").
+  // They route differently from the display axes: a named knob (label, a color, …) is honoured
+  // ONLY by the server daemon — the in-browser Wasm tier's `catalogOverride*` returns the author
+  // default — so a knob edit must hit /render (onKnobChanged), never the wasm auto-enable path.
+  function onKnobChanged() {
+    refreshLinks();
+    if (live.checked && ws && ws.readyState === 1) {
+      ws.send(JSON.stringify({ type: "setOverrides", overrides: overrides() }));
+    } else if (canRenderOverrides) {
+      refreshSnapshot();
+    }
+  }
   document.querySelectorAll(".cp-knob").forEach(function (el) {
-    el.addEventListener(el.type === "checkbox" ? "change" : "input", onControlsChanged);
+    el.addEventListener(el.type === "checkbox" ? "change" : "input", onKnobChanged);
   });
   refreshSnapshot();
 })();</script>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
@@ -233,6 +233,25 @@ a:hover { text-decoration: underline; }
     if (fontScaleTouched && fs) o.fontScale = fs.value;
     return o;
   }
+  // The live-stream override map: the display fields PLUS the author-declared knob values as
+  // `knob.<key>` entries (the daemon's setOverrides parses the same map /render does, and
+  // ServeOverrides reads knob.* keys). Kept separate from overrides() so query() and the Wasm
+  // patch — which append/ignore knobs their own way — are unaffected; without this a knob edit
+  // during an active Live (stream) would send only the display fields and the daemon would reset
+  // the knob to its default.
+  function liveOverrides() {
+    var o = overrides();
+    document.querySelectorAll(".cp-knob").forEach(function (el) {
+      if (el.disabled) return;
+      var key = el.getAttribute("data-knob-key");
+      var kind = el.getAttribute("data-knob-kind") || "string";
+      if (!key) return;
+      var val = (el.type === "checkbox") ? (el.checked ? "true" : "false") : el.value;
+      if (val === "") return;
+      o["knob." + key] = kind + ":" + val;
+    });
+    return o;
+  }
   function query() {
     var o = overrides();
     // Public routes are open, so a page that arrived without a token stays token-free — only
@@ -581,7 +600,7 @@ a:hover { text-decoration: underline; }
       return;
     }
     if (live.checked && ws && ws.readyState === 1) {
-      ws.send(JSON.stringify({ type: "setOverrides", overrides: overrides() }));
+      ws.send(JSON.stringify({ type: "setOverrides", overrides: liveOverrides() }));
     } else if (staticSnapshot && wasmToggle) {
       // Static snapshot backed by a Wasm app: the baked PNG can't honour theme/font-scale/locale
       // (only the in-browser tier can), and /render can't re-render a published catalog. So a
@@ -653,7 +672,7 @@ a:hover { text-decoration: underline; }
   function onKnobChanged() {
     refreshLinks();
     if (live.checked && ws && ws.readyState === 1) {
-      ws.send(JSON.stringify({ type: "setOverrides", overrides: overrides() }));
+      ws.send(JSON.stringify({ type: "setOverrides", overrides: liveOverrides() }));
     } else if (canRenderOverrides) {
       refreshSnapshot();
     }

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
@@ -79,10 +79,22 @@ a:hover { text-decoration: underline; }
 .cp-knobs { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
 .cp-knobs-head { font-size: 0.72rem; color: #6b6b70; }
 .cp-knobs input:disabled { opacity: 0.7; }
+.cp-links { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
+.cp-link-row { display: flex; align-items: center; gap: 6px; }
+.cp-link-kind { font-size: 0.72rem; font-weight: 600; color: #6b6b70; width: 30px; flex: none; }
+.cp-url { flex: 1; min-width: 0; font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.72rem; padding: 4px 6px; border: 1px solid #d7d7de; border-radius: 6px;
+  background: #fff; color: #1b1b1f; }
+.cp-copy, .cp-dl { font-size: 0.72rem; padding: 4px 8px; border-radius: 6px; border: 1px solid #d7d7de;
+  background: #fff; color: #5b5bd6; cursor: pointer; text-decoration: none; flex: none; }
+.cp-copy:hover, .cp-dl:hover { background: #f0f0f3; }
 @media (prefers-color-scheme: dark) {
   body { color: #e6e6e9; background: #161618; }
   .cp-sub, .cp-id, .cp-status, .cp-about-links, .cp-sys-desc, .cp-sys-foot { color: #a0a0a8; }
-  .cp-card, .cp-stage, .cp-knobs, .cp-about { border-color: #34343a; }
+  .cp-card, .cp-stage, .cp-knobs, .cp-links, .cp-about { border-color: #34343a; }
+  .cp-url { background: #1d1d20; color: #e6e6e9; border-color: #34343a; }
+  .cp-copy, .cp-dl { background: #1d1d20; border-color: #34343a; }
+  .cp-copy:hover, .cp-dl:hover { background: #26262b; }
   .cp-card, .cp-about { background: #1d1d20; }
   .cp-about-body { color: #c9c9d0; }
   .cp-about-body code { background: #2a2a30; }
@@ -104,7 +116,7 @@ a:hover { text-decoration: underline; }
       <body>
               <p class="cp-head"><a href="/?token=demo-token-fixture">← previews</a> <span class="cp-badge cp-badge--unverified" title="producer trust: unverified">⚠ unverified</span></p>
       <p class="cp-sub" title="com.example.ProfileScreenPreview">Profile screen</p>
-      <div class="cp-viewer" data-preview-id="com.example.ProfileScreenPreview" data-mode="snapshot" data-modes="snapshot,live" data-static-snapshot="true" data-snapshot-backend="Snapshot" data-live-backend="Live">
+      <div class="cp-viewer" data-preview-id="com.example.ProfileScreenPreview" data-mode="snapshot" data-modes="snapshot,live" data-static-snapshot="true" data-can-render-overrides="false" data-snapshot-backend="Snapshot" data-live-backend="Live">
         <div class="cp-stage"><span class="cp-backend" id="cp-backend"></span><img id="cp-img" alt="Profile screen"><canvas id="cp-canvas" hidden></canvas></div>
         <div class="cp-controls">
           <div class="cp-note">Pre-rendered snapshot — overrides (device, locale, font scale, orientation) need the live server, not a published catalog. <a href="https://github.com/yschimke/compose-ai-tools/blob/main/docs/public-preview-server.md#running-one">Enable a local preview server.</a></div>
@@ -148,6 +160,15 @@ a:hover { text-decoration: underline; }
             </select>
           </label>
           
+                <div class="cp-links">
+        <div class="cp-knobs-head">Direct links — the current view as a URL (overrides applied)</div>
+        <div class="cp-link-row">
+  <span class="cp-link-kind">PNG</span>
+  <input id="cp-url-png" class="cp-url" type="text" readonly aria-label="PNG URL">
+  <button type="button" class="cp-copy" data-copy-target="cp-url-png">Copy</button>
+  <a id="cp-dl-png" class="cp-dl" download>Download</a>
+</div>
+      </div>
           <div class="cp-status" id="cp-status"></div>
         </div>
       </div>
@@ -180,6 +201,10 @@ a:hover { text-decoration: underline; }
   // static snapshots yet leaves the Live toggle enabled, so `live.disabled` no longer implies
   // "static".
   var staticSnapshot = root.getAttribute("data-static-snapshot") === "true";
+  // Whether an override-bearing /render returns fresh pixels even on a static snapshot lane (a
+  // trusted-catalog live session: its carried daemon re-renders author-declared knob edits on
+  // demand). When true, a knob edit re-points the snapshot /render URL rather than sitting dead.
+  var canRenderOverrides = root.getAttribute("data-can-render-overrides") === "true";
   var previewId = root.getAttribute("data-preview-id");
   // The session path prefix ("/<system>") when this viewer is served under a path — it sits at
   // "<base>/p/<id>", so stripping the trailing "/p/<id>" recovers the base ("" for the root
@@ -236,7 +261,44 @@ a:hover { text-decoration: underline; }
     next.onload = function () { img.src = url; status.textContent = ""; };
     next.onerror = function () { status.textContent = "render failed"; };
     next.src = url;
+    refreshLinks();
   }
+  // The copyable direct-link panel: rebuild the absolute /render URLs (PNG + optional SVG) from
+  // the current controls so a copied/downloaded link reproduces exactly what's on screen. Built
+  // on location.origin so the link is absolute (curl-able / shareable), and kept in sync on
+  // every control or knob change — even the ones that don't re-render the snapshot themselves.
+  function renderUrl(ext) {
+    var qs = query();
+    return location.origin + base + "/render/" + encodeURIComponent(previewId) + ext +
+      (qs ? "?" + qs : "");
+  }
+  function refreshLinks() {
+    [["png", ".png"], ["svg", ".svg"]].forEach(function (pair) {
+      var field = document.getElementById("cp-url-" + pair[0]);
+      if (!field) return;
+      var url = renderUrl(pair[1]);
+      field.value = url;
+      var dl = document.getElementById("cp-dl-" + pair[0]);
+      if (dl) dl.href = url;
+    });
+  }
+  document.querySelectorAll(".cp-copy").forEach(function (btn) {
+    btn.addEventListener("click", function () {
+      var field = document.getElementById(btn.getAttribute("data-copy-target"));
+      if (!field) return;
+      var done = function () {
+        var was = btn.textContent;
+        btn.textContent = "Copied";
+        setTimeout(function () { btn.textContent = was; }, 1200);
+      };
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(field.value).then(done, function () { field.select(); });
+      } else {
+        field.select();
+        try { document.execCommand("copy"); done(); } catch (e) {}
+      }
+    });
+  });
   function drawFrame(b64, codec) {
     var im = new Image();
     im.onload = function () {
@@ -506,6 +568,8 @@ a:hover { text-decoration: underline; }
   function wasmActive() { return wasmToggle && wasmToggle.checked; }
 
   function onControlsChanged() {
+    // Keep the copyable direct links current no matter which transport handles the change.
+    refreshLinks();
     if (wasmActive()) {
       // Recompose in place once the app is up; before it's ready, re-point the initial src (the
       // fragment carries the overrides) — the load handler re-syncs the final state either way.
@@ -583,8 +647,19 @@ a:hover { text-decoration: underline; }
     if (el) el.addEventListener("change", onControlsChanged);
   });
   // Author-declared knobs re-render on edit (text/number debounce via "input", toggles "change").
+  // They route differently from the display axes: a named knob (label, a color, …) is honoured
+  // ONLY by the server daemon — the in-browser Wasm tier's `catalogOverride*` returns the author
+  // default — so a knob edit must hit /render (onKnobChanged), never the wasm auto-enable path.
+  function onKnobChanged() {
+    refreshLinks();
+    if (live.checked && ws && ws.readyState === 1) {
+      ws.send(JSON.stringify({ type: "setOverrides", overrides: overrides() }));
+    } else if (canRenderOverrides) {
+      refreshSnapshot();
+    }
+  }
   document.querySelectorAll(".cp-knob").forEach(function (el) {
-    el.addEventListener(el.type === "checkbox" ? "change" : "input", onControlsChanged);
+    el.addEventListener(el.type === "checkbox" ? "change" : "input", onKnobChanged);
   });
   refreshSnapshot();
 })();</script>


### PR DESCRIPTION
## Summary

The published design catalogs (`preview.coo.ee`) showed **no configurable preview items** even after the M3 / Wear M3 catalogs declared exhaustive `previewOverride*` knobs (#2281), and a `?knob.*` URL was silently ignored.

Root cause: the browse surface is the **baked catalog** (`ServeBundleHost` over the branch's `images/*.png`), which carries **no** `overrides.json` sidecars, and `ServeCatalogLiveHost.render` replayed the baked PNG for every request. The knob declarations *are* shipped — inside the live-bundle (`bundle/compose-m3-bundle.png`) as `previews/<id>.overrides.json`, keyed by the **daemon** descriptor id — but that metadata never bridged to the baked catalog's id-space. Verified against the live site: `/api/previews` returned `"overrides": []`, and `/render/<id>.png?knob.label=…` came back byte-identical to the plain PNG.

This is a **serve-side** change; no catalog regeneration is needed since the sidecars are already in the published bundle. It takes effect when the server carries the live-bundle (`--allow-render-trusted`, which `preview.coo.ee` runs).

## Changes

- **`ServeBundleDaemon`** — extract the `previews/<id>.overrides.json` sidecars and fold the declared knobs into the daemon session's `ServePreview` set.
- **`ServeCatalogLiveHost`** — graft the daemon's declared knobs onto the baked browse surface via the catalog-id → daemon-id `alias`, and route a **knob-bearing** `render`/`renderSvg` to the daemon. Display-axis-only overrides stay baked, so ordinary browsing never wakes the daemon (preserves instant browsing + the sticky-theme behavior).
- **`ServeHost`** — new `canRenderOverrides` + `hasSvgExport` capabilities (with `ServeRenderHost` / `ServeBundleHost` overrides).
- **Viewer (`ServeWeb`)** — enable the declared knob controls on an override-renderable catalog session (a knob edit hits `/render`, the only tier that honours named knobs — Wasm's `catalogOverride*` returns author defaults), **and** add a copyable **"Direct links"** panel: the `/render/<id>.png` (and `.svg` when exportable) URL for the current overrides, each with **Copy** + **Download**, rebuilt live from `location.origin` (so links are same-origin `https://` on the deployed server).

## Visual evidence

New `serve-viewer-catalog-knobs` fixture — enabled `label` / `iconColor` knobs under "Declared overrides", plus the copyable **Direct links** (PNG + SVG) panel. (The URL fields show the harness's local `http://127.0.0.1` origin here; on `preview.coo.ee` they render as `https://preview.coo.ee/compose-m3/render/…png?knob.…`.)

![serve-viewer-catalog-knobs (light)](https://raw.githubusercontent.com/yschimke/compose-ai-tools/d5094cf82e4f1d2ab9a66ff35ed41cef1f60b7b2/renders/serve-viewer-catalog-knobs.light.png)

Before → after on an existing viewer (`serve-viewer`), showing the new Direct-links panel added to every viewer page:

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/yschimke/compose-ai-tools/8f1219e46477e70b89e4845c90c5b3c5577472a7/renders/serve-viewer.light.png) | ![after](https://raw.githubusercontent.com/yschimke/compose-ai-tools/d5094cf82e4f1d2ab9a66ff35ed41cef1f60b7b2/renders/serve-viewer.light.png) |

The fixture is wired into the preview-harness, so the visual-diff bot renders and diffs it on every future PR.

## Test plan

- `:cli:test` green — new/updated `ServeCatalogLiveHostTest` (knob-merge + knob-bearing render/SVG routes to the daemon; display-axis-only + unmapped ids stay baked), `ServeWebFixtureTest` (golden fixtures + assertions for enabled knobs, the copy/download link rows, and PNG-always / SVG-when-exportable), and `ServeBundleDaemonTest` (sidecar round-trip).
- `:cli:ktfmtCheck` clean.