### PR TITLE
feat(serve): render any fetched preview bundle live without a module

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
@@ -57,6 +57,7 @@ internal object CliFlags {
       "--token",
       "--export",
       "--bundles",
+      "--bundle",
       "--accept-bundles-from",
       "--trust-store",
       "--catalogs",

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -462,9 +462,13 @@ class ServeCommand(args: List<String>) : Command(args) {
     // Pick a landing session so `/` resolves: the first registered catalog, else the first bundle.
     val defaultSessionId =
       registeredCatalogs.firstOrNull() ?: registeredStartup.firstOrNull() ?: registry.anySessionId()
-    if (defaultSessionId == null) {
+    // An `--accept-bundles` server legitimately starts with no sessions — they arrive at runtime
+    // via
+    // POST /bundles — so only bail when there's genuinely nothing to serve and no way to add any.
+    if (defaultSessionId == null && !acceptBundles) {
       System.err.println(
-        "serve: nothing to serve — no --bundle / --bundles / --catalogs registered a session."
+        "serve: nothing to serve — no --bundle / --bundles / --catalogs registered a session, and " +
+          "--accept-bundles is off."
       )
       exitProcess(3)
     }
@@ -472,7 +476,8 @@ class ServeCommand(args: List<String>) : Command(args) {
     bringUpServer(
       registry = registry,
       token = token,
-      defaultSessionId = defaultSessionId,
+      // Upload-only server: no landing session yet (routes 404 until the first upload lands).
+      defaultSessionId = defaultSessionId ?: "",
       bundleStore = bundleStore,
       wasmCatalogs = wasmCatalogs,
       bannerLabel = "(no module — hosting fetched bundles/catalogs)",
@@ -746,7 +751,13 @@ class ServeCommand(args: List<String>) : Command(args) {
       val bytes = obtainBundleBytes(spec) ?: continue
       // Branch-origin trust for a raw.githubusercontent.com URL (a bundle pulled from a trusted
       // branch); null for any other URL / a local path (then only a signature can make it Trusted).
-      val origin = ServeStartupBundles.originOf(spec.source)
+      // A raw URL's ref can span slashes (`design-artifacts/compose-m3`), so try each candidate
+      // split and prefer the one the trust store actually trusts; else fall back to the shortest
+      // (harmless — an untrusted-branch origin just adds no basis).
+      val origins = ServeStartupBundles.candidateOrigins(spec.source)
+      val origin =
+        origins.firstOrNull { resolvedTrust.trustsBranch(it.repo, it.branch) }
+          ?: origins.firstOrNull()
       val bundleFile = File(root, "${spec.name}.bundle")
       try {
         bundleFile.writeBytes(bytes)

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.cli
 
+import ee.schimke.composeai.cli.serve.BundleVerifier
 import ee.schimke.composeai.cli.serve.GitWorktrees
 import ee.schimke.composeai.cli.serve.GradleRevisionBuilder
 import ee.schimke.composeai.cli.serve.RenderOutcome
@@ -19,6 +20,7 @@ import ee.schimke.composeai.cli.serve.ServeRevisionFactory
 import ee.schimke.composeai.cli.serve.ServeSessionFactory
 import ee.schimke.composeai.cli.serve.ServeSessionRegistry
 import ee.schimke.composeai.cli.serve.ServeSessionState
+import ee.schimke.composeai.cli.serve.ServeStartupBundles
 import ee.schimke.composeai.cli.serve.ServeUrls
 import ee.schimke.composeai.cli.serve.TrustStore
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
@@ -125,6 +127,20 @@ class ServeCommand(args: List<String>) : Command(args) {
    * or build — the bundle's `previews/<id>.png` files are served directly.
    */
   private val bundlesDir: String? = args.flagValue("--bundles")?.takeIf { it.isNotBlank() }
+
+  /**
+   * Serve one or more **fetched** preview bundles directly (`--bundle <url|path>` / `--bundle
+   * <name>=<url|path>`, repeatable) — no `--module`, no local project, no Gradle build. A URL is
+   * fetched at startup (operator-supplied, so no SSRF gate — same trust level as `--catalogs`); a
+   * local path is read as-is. Each becomes a `/<name>/` session. A bundle that verifies `Trusted`
+   * (Ed25519 signature, or fetched from a trusted branch origin) is served **live** from a render
+   * daemon when `--allow-render-trusted` is set (desktop bundles); otherwise it's served read-only
+   * as its baked PNGs. This is what lets a public server live-render any trusted bundle pulled from
+   * a GitHub branch without knowing the module upfront.
+   */
+  private val bundleSpecs: List<ServeStartupBundles.Spec> by lazy {
+    ServeStartupBundles.parse(args.flagValuesAll("--bundle"))
+  }
 
   /**
    * Shared/public mode ingestion: enable `POST /bundles/{name}` so clients can contribute bundles
@@ -253,6 +269,18 @@ class ServeCommand(args: List<String>) : Command(args) {
       return
     }
 
+    // Module-less mode: no --module and no local Gradle project to build, but there ARE hosted
+    // sources (fetched --bundle(s) / --catalogs / --accept-bundles). Serve them directly with no
+    // discover/build — the "render any fetched bundle live from a trusted server" path. When run
+    // from inside a project (findProjectRoot != null), the module is still served as before and the
+    // hosted sources ride alongside it.
+    val hasHostedSources =
+      bundleSpecs.isNotEmpty() || bundlesDir != null || catalogRefs.isNotEmpty() || acceptBundles
+    if (explicitModule == null && hasHostedSources && findProjectRoot() == null) {
+      runBundleServer()
+      return
+    }
+
     // Discover + build the module(s) so manifests exist and previews resolve. `--module` scopes it.
     val outcome = renderAllModules(silenceStdout = false)
     if (!outcome.buildOk) {
@@ -322,28 +350,7 @@ class ServeCommand(args: List<String>) : Command(args) {
     // is
     // the default session; the registry suspends idle daemons and resumes them on demand from their
     // saved state, so a long-lived server doesn't keep daemons running forever.
-    val openHost: (ServeSessionState) -> ServeHost? = { state ->
-      runCatching {
-          val daemon =
-            ServeRenderHost.open(
-              descriptorPath = state.descriptor,
-              workspaceRoot = state.workspaceRoot,
-              workspaceName = state.workspaceName,
-              previews = state.previews,
-              label = state.label,
-              onLog = { System.err.println("[daemon serve] $it") },
-            )
-          // A trusted-catalog live session carries a baked-PNG fallback + a catalog-id→daemon-id
-          // alias: front the daemon with the baked catalog so the published /p/<id> deep links and
-          // /render/<id>.png thumbnails resolve (and the Android-only variants fall back to baked),
-          // while the mapped ids gain a live lane. Rebuilt here on every resume, so suspend/resume
-          // works unchanged. Plain project / revision sessions carry no fallback → the bare daemon.
-          val fallback = state.bakedFallback
-          if (fallback != null) ServeCatalogLiveHost(state.previewAliases, daemon, fallback())
-          else daemon
-        }
-        .getOrNull()
-    }
+    val openHost: (ServeSessionState) -> ServeHost? = ::openHost
     // Project mode forks a session per git revision behind the registry's factory; off by default
     // the factory yields nothing, so only the pinned current checkout is served. These worktrees
     // are
@@ -388,6 +395,9 @@ class ServeCommand(args: List<String>) : Command(args) {
     registerBundles().forEach { (id, bundleHost) ->
       registry.register(id, host = bundleHost, pinned = true)
     }
+    // Serve any operator-supplied `--bundle <url|path>` fetched bundles alongside the module — live
+    // from a daemon when Trusted + --allow-render-trusted, else read-only baked PNGs.
+    registerStartupBundles(registry)
     // Serve our published design systems from their trusted `design-artifacts/<system>` branches.
     // A catalog that carries a `web/wasm/` app yields a system→dir entry so the in-browser tier
     // rides the same trusted branch (no local --wasm-dir build needed).
@@ -396,56 +406,166 @@ class ServeCommand(args: List<String>) : Command(args) {
       else emptyMap()
     // Runtime ingestion (--accept-bundles): clients POST a bundle (or a ?url= to one) and it's
     // registered as a pinned session. Unpacked under a temp dir for this server's lifetime.
-    val bundleStore =
-      if (acceptBundles) {
-        val uploads =
-          java.nio.file.Files.createTempDirectory("serve-uploads").toFile().also {
-            it.deleteOnExit()
-          }
-        if (acceptBundlesFrom.isEmpty()) {
-          System.err.println(
-            "serve: --accept-bundles accepts uploads only; no ?url= host is allowed (SSRF fail " +
-              "closed). Pass --accept-bundles-from <host>[,<host>…] to permit URL fetches."
-          )
-        }
-        ServeBundleStore(
-          root = uploads,
-          register = { id, bundleHost -> registry.register(id, host = bundleHost, pinned = true) },
-          allowedHosts = acceptBundlesFrom,
-          trust = resolvedTrust,
-        )
-      } else {
-        null
-      }
-    // In-browser CMP tier: keep only the `--wasm-dir` entries whose directory actually holds the
-    // assembled app (index.html), warning on the rest, so a typo'd path doesn't silently advertise
-    // a
-    // broken "Run in browser" toggle.
-    val localWasm = wasmDirs.filter { (system, dir) ->
-      val ok = File(dir, "index.html").isFile
-      if (!ok) {
-        System.err.println(
-          "serve: --wasm-dir $system=${dir.path} has no index.html — skipping (build it with " +
-            ":samples:cmp-wasm-catalog:wasmCatalogDist)."
-        )
-      }
-      ok
-    }
+    val bundleStore = if (acceptBundles) openUploadStore(registry) else null
     // Merge the apps fetched from the catalog branches with the explicit `--wasm-dir` paths; a
-    // local
-    // `--wasm-dir` wins for a system so an operator can override the published app with a local
-    // build.
+    // local `--wasm-dir` wins for a system so an operator can override the published app.
+    val wasmCatalogs = catalogWasm + filterLocalWasm()
+    if (wasmCatalogs.isNotEmpty()) {
+      System.err.println("serve: in-browser Wasm tier for: ${wasmCatalogs.keys.joinToString(", ")}")
+    }
+    bringUpServer(
+      registry = registry,
+      token = token,
+      defaultSessionId = module.gradlePath,
+      bundleStore = bundleStore,
+      wasmCatalogs = wasmCatalogs,
+      bannerLabel = module.gradlePath,
+      bannerPreviewCount = previews.size,
+      mdnsModuleLabel = module.gradlePath,
+      mdnsPreviewIds = previews.map { it.id },
+      closeables = listOf(worktrees, catalogWorktrees.takeIf { it !== worktrees }),
+    )
+  }
+
+  /**
+   * Module-less mode: run a **pure preview server** — no `--module`, no local project, no Gradle
+   * build. Reached from [run] when there's nothing to build locally but there are hosted sources
+   * (`--bundle` / `--bundles` / `--catalogs` / `--accept-bundles`). This is the "render any fetched
+   * bundle live from a trusted server" path: `serve --bundle <github-branch-url> --public
+   * --allow-render-trusted` stands up a server that fetches the bundle and, if it verifies Trusted,
+   * live-renders it from a daemon — without ever knowing the module upfront.
+   *
+   * Trusted-catalog *source* builds (the Gradle fallback) are unavailable here (no repo to worktree
+   * from), so a `--catalogs` system that can't be served from its carried `liveBundle` falls back
+   * to baked PNGs — fail-closed, exactly like the desktop-only public image.
+   */
+  private fun runBundleServer() {
+    val token = tokenOverride ?: ServeUrls.generateToken()
+    val registry = ServeSessionRegistry(open = ::openHost)
+
+    registerBundles().forEach { (id, bundleHost) ->
+      registry.register(id, host = bundleHost, pinned = true)
+    }
+    val registeredStartup = registerStartupBundles(registry)
+    // No worktrees in module-less mode — catalogs live-render only from their carried `liveBundle`.
+    val catalogWasm =
+      if (catalogRefs.isNotEmpty()) registerCatalogs(registry, worktrees = null, ::openHost)
+      else emptyMap()
+    val bundleStore = if (acceptBundles) openUploadStore(registry) else null
+
+    val localWasm = filterLocalWasm()
     val wasmCatalogs = catalogWasm + localWasm
     if (wasmCatalogs.isNotEmpty()) {
       System.err.println("serve: in-browser Wasm tier for: ${wasmCatalogs.keys.joinToString(", ")}")
     }
+
+    // Pick a landing session so `/` resolves: the first registered catalog, else the first bundle.
+    val defaultSessionId =
+      registeredCatalogs.firstOrNull() ?: registeredStartup.firstOrNull() ?: registry.anySessionId()
+    if (defaultSessionId == null) {
+      System.err.println(
+        "serve: nothing to serve — no --bundle / --bundles / --catalogs registered a session."
+      )
+      exitProcess(3)
+    }
+
+    bringUpServer(
+      registry = registry,
+      token = token,
+      defaultSessionId = defaultSessionId,
+      bundleStore = bundleStore,
+      wasmCatalogs = wasmCatalogs,
+      bannerLabel = "(no module — hosting fetched bundles/catalogs)",
+      bannerPreviewCount = registry.activeCount(),
+      // No module previews to advertise; discovery is a module-session nicety, so skip it here.
+      mdnsModuleLabel = null,
+      mdnsPreviewIds = null,
+      closeables = emptyList(),
+    )
+  }
+
+  /**
+   * Reopen a session's daemon-backed host from its [ServeSessionState] — the registry's `open`
+   * callback, used by every serve mode. A trusted-catalog / live-bundle session carries a baked-PNG
+   * fallback + a catalog-id→daemon-id alias, so the daemon is fronted by [ServeCatalogLiveHost]
+   * (published deep links + thumbnails keep resolving, Android-only variants fall back to baked,
+   * mapped ids gain a live lane). Rebuilt on every resume, so suspend/resume works unchanged. Plain
+   * project / revision / plain-bundle sessions carry no fallback → the bare daemon.
+   */
+  private fun openHost(state: ServeSessionState): ServeHost? =
+    runCatching {
+        val daemon =
+          ServeRenderHost.open(
+            descriptorPath = state.descriptor,
+            workspaceRoot = state.workspaceRoot,
+            workspaceName = state.workspaceName,
+            previews = state.previews,
+            label = state.label,
+            onLog = { System.err.println("[daemon serve] $it") },
+          )
+        val fallback = state.bakedFallback
+        if (fallback != null) ServeCatalogLiveHost(state.previewAliases, daemon, fallback())
+        else daemon
+      }
+      .getOrNull()
+
+  /** Build the `--accept-bundles` upload store (temp-dir backed), wired to [registry]. */
+  private fun openUploadStore(registry: ServeSessionRegistry): ServeBundleStore {
+    val uploads =
+      java.nio.file.Files.createTempDirectory("serve-uploads").toFile().also { it.deleteOnExit() }
+    if (acceptBundlesFrom.isEmpty()) {
+      System.err.println(
+        "serve: --accept-bundles accepts uploads only; no ?url= host is allowed (SSRF fail " +
+          "closed). Pass --accept-bundles-from <host>[,<host>…] to permit URL fetches."
+      )
+    }
+    return ServeBundleStore(
+      root = uploads,
+      register = { id, bundleHost -> registry.register(id, host = bundleHost, pinned = true) },
+      allowedHosts = acceptBundlesFrom,
+      trust = resolvedTrust,
+    )
+  }
+
+  /**
+   * Keep only `--wasm-dir` entries whose directory actually holds the assembled app (index.html).
+   */
+  private fun filterLocalWasm(): Map<String, File> = wasmDirs.filter { (system, dir) ->
+    val ok = File(dir, "index.html").isFile
+    if (!ok) {
+      System.err.println(
+        "serve: --wasm-dir $system=${dir.path} has no index.html — skipping (build it with " +
+          ":samples:cmp-wasm-catalog:wasmCatalogDist)."
+      )
+    }
+    ok
+  }
+
+  /**
+   * Construct the [ServeHttpServer], start it, advertise over mDNS (when [mdnsPreviewIds] is
+   * non-null and the bind is exposed), print the banner, and block until shutdown. Shared by the
+   * module-backed [run] and the module-less [runBundleServer]. [closeables] are extra resources
+   * (worktrees) closed on shutdown; nulls are ignored.
+   */
+  private fun bringUpServer(
+    registry: ServeSessionRegistry,
+    token: String,
+    defaultSessionId: String,
+    bundleStore: ServeBundleStore?,
+    wasmCatalogs: Map<String, File>,
+    bannerLabel: String,
+    bannerPreviewCount: Int,
+    mdnsModuleLabel: String?,
+    mdnsPreviewIds: List<String>?,
+    closeables: List<AutoCloseable?>,
+  ) {
     val server =
       ServeHttpServer(
         host = host,
         requestedPort = requestedPort,
         token = token,
         sessions = registry,
-        defaultSessionId = module.gradlePath,
+        defaultSessionId = defaultSessionId,
         bundleStore = bundleStore,
         isPublic = public,
         wasmCatalogs = wasmCatalogs,
@@ -457,11 +577,11 @@ class ServeCommand(args: List<String>) : Command(args) {
     // wear session-viewer clients can discover this server without a typed URL. Best-effort: a null
     // advertiser (no multicast / sandbox) just means discovery stays dark — the server is fine.
     val advertiser =
-      if (ServeUrls.isExposed(host)) {
+      if (mdnsModuleLabel != null && mdnsPreviewIds != null && ServeUrls.isExposed(host)) {
         ServeMdnsAdvertiser.start(
-          moduleLabel = module.gradlePath,
+          moduleLabel = mdnsModuleLabel,
           port = server.port,
-          previewIds = previews.map { it.id },
+          previewIds = mdnsPreviewIds,
           secure = false,
           onLog = { System.err.println("[serve] $it") },
         )
@@ -477,14 +597,13 @@ class ServeCommand(args: List<String>) : Command(args) {
           runCatching { advertiser?.close() }
           runCatching { server.stop() }
           runCatching { registry.close() }
-          runCatching { worktrees?.close() }
-          runCatching { if (catalogWorktrees !== worktrees) catalogWorktrees?.close() }
+          closeables.forEach { c -> runCatching { c?.close() } }
           done.countDown()
         }
       )
 
     server.start()
-    printBanner(module.gradlePath, server.port, token, previews.size)
+    printBanner(bannerLabel, server.port, token, bannerPreviewCount)
     val watchdog = if (exitWhenIdle) startIdleWatchdog(registry, done) else null
     done.await()
     watchdog?.shutdownNow()
@@ -597,6 +716,102 @@ class ServeCommand(args: List<String>) : Command(args) {
       )
     }
     return result
+  }
+
+  /**
+   * Register every `--bundle <url|path>` bundle as its own session. Each is fetched (URL) or read
+   * (local path), then served **live** from a render daemon when it verifies `Trusted` (signature
+   * or trusted branch origin) AND `--allow-render-trusted` is set AND it's a desktop bundle
+   * [ServeBundleDaemon.materialize] can stand up — otherwise served read-only as its baked PNGs
+   * ([ServeBundleStore.add]). Returns the ids that registered, so the module-less landing can pick
+   * a default session. Best-effort per bundle — one failing doesn't sink the others or the server.
+   *
+   * The live gate is the same fail-closed model as a catalog's `liveBundle`: an `Unverified` bundle
+   * is never re-rendered server-side (no RCE lever), it just serves its baked images.
+   */
+  private fun registerStartupBundles(registry: ServeSessionRegistry): List<String> {
+    if (bundleSpecs.isEmpty()) return emptyList()
+    val root =
+      java.nio.file.Files.createTempDirectory("serve-startup-bundles").toFile().also {
+        it.deleteOnExit()
+      }
+    val bakedStore =
+      ServeBundleStore(
+        root = File(root, "baked").apply { mkdirs() },
+        register = { id, host -> registry.register(id, host = host, pinned = true) },
+        trust = resolvedTrust,
+      )
+    val registered = mutableListOf<String>()
+    for (spec in bundleSpecs) {
+      val bytes = obtainBundleBytes(spec) ?: continue
+      // Branch-origin trust for a raw.githubusercontent.com URL (a bundle pulled from a trusted
+      // branch); null for any other URL / a local path (then only a signature can make it Trusted).
+      val origin = ServeStartupBundles.originOf(spec.source)
+      val bundleFile = File(root, "${spec.name}.bundle")
+      try {
+        bundleFile.writeBytes(bytes)
+      } catch (e: Exception) {
+        System.err.println("serve: bundle ${spec.name} could not be staged (${e.message})")
+        continue
+      }
+      val verdict = BundleVerifier.verify(bundleFile, resolvedTrust, origin)
+      // Live lane: Trusted + operator opt-in. A desktop bundle materialises a daemon straight from
+      // the bundle (no build); a non-desktop/foreign/empty bundle returns null → falls to baked.
+      if (allowRenderTrusted && verdict is BundleVerifier.Verdict.Trusted) {
+        val destDir = File(root, "${spec.name}-live").apply { mkdirs() }
+        val state = ServeBundleDaemon.materialize(bundleFile, destDir, spec.name)
+        val host = state?.let { openHost(it) }
+        if (state != null && host != null) {
+          registry.register(spec.name, state, host = host)
+          System.err.println(
+            "serve: bundle ${spec.name} → LIVE from bundle (no build), " +
+              "trust=${BundleVerifier.summary(verdict)} (/${spec.name}/)"
+          )
+          registered += spec.name
+          continue
+        }
+      } else if (allowRenderTrusted) {
+        System.err.println(
+          "serve: bundle ${spec.name} is ${BundleVerifier.summary(verdict)} — not live-rendering; " +
+            "serving baked PNGs"
+        )
+      }
+      // Read-only fallback: serve the bundle's baked previews/<id>.png (executes no code).
+      when (val r = bakedStore.add(spec.name, bytes, isSecurityChecked = true, origin = origin)) {
+        is ServeBundleStore.Result.Ok -> {
+          registered += r.name
+          System.err.println(
+            "serve: bundle ${r.name} → ${r.previewCount} baked preview(s), trust=${r.trust} " +
+              "(/${r.name}/)"
+          )
+        }
+        is ServeBundleStore.Result.Failed ->
+          System.err.println("serve: bundle ${spec.name} not served: ${r.reason}")
+      }
+    }
+    return registered
+  }
+
+  /** Fetch (URL) or read (local path) a `--bundle` spec's bytes; null (logged) on any failure. */
+  private fun obtainBundleBytes(spec: ServeStartupBundles.Spec): ByteArray? {
+    if (ServeStartupBundles.isUrl(spec.source)) {
+      val bytes = ServeStartupBundles.fetch(spec.source)
+      if (bytes == null) {
+        System.err.println("serve: bundle ${spec.name} fetch failed (${spec.source})")
+      }
+      return bytes
+    }
+    val f = File(spec.source)
+    if (!f.isFile) {
+      System.err.println("serve: bundle ${spec.name} path not found: ${spec.source}")
+      return null
+    }
+    return try {
+      f.readBytes()
+    } catch (e: Exception) {
+      System.err.println("serve: bundle ${spec.name} read failed (${e.message})")
+      null
+    }
   }
 
   /**
@@ -920,7 +1135,17 @@ class ServeCommand(args: List<String>) : Command(args) {
       Read-only today; bound to loopback unless you opt into LAN exposure.
 
       Options:
-        --module <path>   Module to serve (required when the project has more than one).
+        --module <path>   Module to serve. Optional: when omitted outside a Gradle project, serve
+                          runs module-less — a pure server hosting only the fetched --bundle(s) /
+                          --catalogs / uploaded bundles, with no local discover/build.
+        --bundle <url|path>[, --bundle <name>=<url|path>, …]
+                          Serve one or more fetched preview bundles directly — no --module, no
+                          build. A URL is fetched at startup (operator-supplied, so no SSRF gate;
+                          e.g. a raw.githubusercontent.com/<owner>/<repo>/<branch>/… link); a local
+                          path is read. Each is served at /<name>/. A bundle that verifies Trusted
+                          (Ed25519 signature, or fetched from a trusted branch in --trust-store) is
+                          served LIVE from a render daemon when --allow-render-trusted is set
+                          (desktop bundles); otherwise read-only as its baked PNGs. Repeatable.
         --id <exact>      Only serve this exact preview id.
         --filter <substr> Only serve previews whose id contains this substring.
         --host <addr>     Bind address (default 127.0.0.1 — loopback only).

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleStore.kt
@@ -66,8 +66,18 @@ class ServeBundleStore(
    * passes `true` only once the request has cleared policy (here: token-gated `POST /bundles`). The
    * unpack itself is defended in depth — name sanitisation, zip-slip containment, size cap — but
    * the marker records that the *entry point* was authorised before risky bytes were processed.
+   *
+   * [origin] is non-null only when the *server itself* fetched the bundle from a known branch (the
+   * operator-supplied `--bundle <raw.githubusercontent…>` startup path), so a branch it trusts
+   * badges `Trusted(Branch)` even for an unsigned bundle. Client uploads pass `null` (origin trust
+   * is for server-fetched bundles, not arbitrary uploads).
    */
-  fun add(name: String, zipBytes: ByteArray, isSecurityChecked: Boolean): Result {
+  fun add(
+    name: String,
+    zipBytes: ByteArray,
+    isSecurityChecked: Boolean,
+    origin: BundleVerifier.Origin? = null,
+  ): Result {
     val safe = sanitizeName(name) ?: return Result.Failed("invalid bundle name: '$name'")
     val dir = File(root, safe)
     dir.deleteRecursively()
@@ -88,7 +98,7 @@ class ServeBundleStore(
     // Attribute the upload to a trusted producer if it carries a verifiable signature (origin trust
     // is for server-fetched catalogs, not client uploads, so no Origin here). The verdict travels
     // with the host for display; it never blocks serving the already-extracted data tiers.
-    val verdict = BundleVerifier.verify(zip, trust)
+    val verdict = BundleVerifier.verify(zip, trust, origin)
     val host = ServeBundleHost(dir, safe, verdict)
     register(safe, host)
     return Result.Ok(safe, host.previews.size, BundleVerifier.summary(verdict))

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistry.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistry.kt
@@ -184,6 +184,13 @@ class ServeSessionRegistry(
   /** Total known sessions (resident + suspended). */
   fun activeCount(): Int = lock.withLock { sessions.size }
 
+  /**
+   * Any registered session id, or null when none are — used by the module-less server to pick a
+   * landing session so `/` resolves to something. Insertion order isn't guaranteed (HashMap), so
+   * the caller prefers a specific id (a catalog / the first bundle) and only falls back to this.
+   */
+  fun anySessionId(): String? = lock.withLock { sessions.keys.firstOrNull() }
+
   /** Sessions with a live daemon right now (resident, not suspended). */
   fun residentCount(): Int = lock.withLock { sessions.values.count { it.host != null } }
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeStartupBundles.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeStartupBundles.kt
@@ -81,20 +81,35 @@ internal object ServeStartupBundles {
     runCatching { URI(source).scheme?.lowercase() in setOf("http", "https") }.getOrDefault(false)
 
   /**
-   * Derive a branch [BundleVerifier.Origin] from a
+   * Candidate branch [BundleVerifier.Origin]s for a
    * `raw.githubusercontent.com/<owner>/<repo>/<ref>/…` URL — the same host `--catalogs` fetches
    * from — so a bundle pulled from a trusted branch earns `Trusted(Branch)` without a signature.
-   * Any other host (or a local path) yields `null`, so trust then rests solely on a pinned Ed25519
+   *
+   * A raw URL is `.../<owner>/<repo>/<ref>/<path…>`, but `<ref>` may itself contain slashes (a
+   * branch like `design-artifacts/compose-m3`), and the boundary between the ref and the file path
+   * isn't recoverable from the string alone (GitHub resolves it server-side). So this enumerates
+   * every split that leaves at least one path segment — `design-artifacts`, then
+   * `design-artifacts/compose-m3`, … — shortest ref first. The caller picks the one the trust store
+   * actually trusts (a `design-artifacts/<slug>` branch glob matches the two-segment branch, not
+   * the bare `design-artifacts`), which is what disambiguates the split. A non-github host / local
+   * path / too-short URL yields an empty list, so trust then rests solely on a pinned Ed25519
    * signature.
    */
-  fun originOf(source: String): BundleVerifier.Origin? {
-    val uri = runCatching { URI(source) }.getOrNull() ?: return null
-    if (uri.host?.lowercase() != RAW_GITHUB_HOST) return null
-    val segments = uri.path.trim('/').split('/')
-    if (segments.size < 4) return null
-    val (owner, repo, ref) = Triple(segments[0], segments[1], segments[2])
-    if (owner.isBlank() || repo.isBlank() || ref.isBlank()) return null
-    return BundleVerifier.Origin(repo = "$owner/$repo", branch = ref)
+  fun candidateOrigins(source: String): List<BundleVerifier.Origin> {
+    val uri = runCatching { URI(source) }.getOrNull() ?: return emptyList()
+    if (uri.host?.lowercase() != RAW_GITHUB_HOST) return emptyList()
+    val segments = (uri.path ?: "").trim('/').split('/').filter { it.isNotEmpty() }
+    if (segments.size < 4) return emptyList()
+    val owner = segments[0]
+    val repo = segments[1]
+    if (owner.isBlank() || repo.isBlank()) return emptyList()
+    // ref spans segments[2..refEnd]; leave ≥1 trailing path segment (refEnd ≤ size-2).
+    return (2..(segments.size - 2)).map { refEnd ->
+      BundleVerifier.Origin(
+        repo = "$owner/$repo",
+        branch = segments.subList(2, refEnd + 1).joinToString("/"),
+      )
+    }
   }
 
   /** Fetch [url] into memory, http/https only, capped + time-bounded; null on any failure. */

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeStartupBundles.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeStartupBundles.kt
@@ -1,0 +1,136 @@
+package ee.schimke.composeai.cli.serve
+
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+import java.net.URI
+import java.util.concurrent.TimeUnit
+import okhttp3.OkHttpClient
+import okhttp3.Request
+
+/**
+ * Parses and fetches the **operator-supplied** preview bundles a public/shared server is started
+ * with (`--bundle <url|path>` / `--bundle <name>=<url|path>`, repeatable). Unlike the client `POST
+ * /bundles?url=` upload path ([ServeBundleStore]), these URLs come from the operator's own command
+ * line (the same trust level as `--catalogs`), so there is **no SSRF allowlist** here — the
+ * operator chose the address. Whether a fetched bundle is *live-rendered* is still gated exactly
+ * like a catalog's `liveBundle`: it must verify `Trusted` (signature or trusted branch origin) and
+ * the operator must pass `--allow-render-trusted`; otherwise it is served read-only as baked PNGs.
+ *
+ * This class only turns a spec into (name, bytes, origin) — the live-vs-baked decision and the
+ * registry wiring live in [ServeCommand] alongside the catalog machinery it mirrors.
+ */
+internal object ServeStartupBundles {
+
+  /**
+   * One `--bundle` entry: the [source] (an `http(s)://…` URL or a local filesystem path) and the
+   * session [name] it registers under (`/<name>/`, `?session=<name>`).
+   */
+  data class Spec(val name: String, val source: String)
+
+  /**
+   * Parse each raw `--bundle` value into a [Spec]. Two forms:
+   * - `<url|path>` — the session name is derived from the file's basename (extension stripped,
+   *   sanitised to the same charset [ServeBundleStore.sanitizeName] accepts).
+   * - `<name>=<url|path>` — an explicit name, used only when the part before the first `=` is a
+   *   safe bare name (so `https://…` URLs, whose scheme carries no `=`, are never mis-split).
+   *
+   * A spec whose name can't be sanitised is dropped with a warning via [onWarn] rather than failing
+   * the whole server.
+   */
+  fun parse(
+    raw: List<String>,
+    onWarn: (String) -> Unit = { System.err.println("serve: $it") },
+  ): List<Spec> = raw.mapNotNull { entry ->
+    val trimmed = entry.trim()
+    if (trimmed.isEmpty()) return@mapNotNull null
+    val eq = trimmed.indexOf('=')
+    val explicit =
+      if (eq > 0) {
+        val candidate = trimmed.substring(0, eq)
+        // Only treat `foo=…` as name=source when `foo` is a bare safe name (no scheme / slash),
+        // so a `?a=b` query or a `key=val` in a URL never hijacks the name.
+        if (ServeBundleStore.sanitizeName(candidate) != null && "://" !in candidate) candidate
+        else null
+      } else null
+    val source = if (explicit != null) trimmed.substring(eq + 1).trim() else trimmed
+    if (source.isEmpty()) {
+      onWarn("--bundle '$entry' has no source — skipping")
+      return@mapNotNull null
+    }
+    val rawName = explicit ?: deriveName(source)
+    val name = ServeBundleStore.sanitizeName(rawName)
+    if (name == null) {
+      onWarn("--bundle '$entry' has no usable name (from '$rawName') — skipping")
+      return@mapNotNull null
+    }
+    Spec(name, source)
+  }
+
+  /**
+   * The session name a bare `--bundle <source>` uses: the basename with a known extension stripped.
+   */
+  private fun deriveName(source: String): String {
+    val last = source.trimEnd('/').substringAfterLast('/').substringBefore('?').substringBefore('#')
+    return last.removeSuffix(".bundle").removeSuffix(".png").removeSuffix(".zip").ifBlank {
+      "bundle"
+    }
+  }
+
+  /** True when [source] is an `http`/`https` URL (vs. a local filesystem path). */
+  fun isUrl(source: String): Boolean =
+    runCatching { URI(source).scheme?.lowercase() in setOf("http", "https") }.getOrDefault(false)
+
+  /**
+   * Derive a branch [BundleVerifier.Origin] from a
+   * `raw.githubusercontent.com/<owner>/<repo>/<ref>/…` URL — the same host `--catalogs` fetches
+   * from — so a bundle pulled from a trusted branch earns `Trusted(Branch)` without a signature.
+   * Any other host (or a local path) yields `null`, so trust then rests solely on a pinned Ed25519
+   * signature.
+   */
+  fun originOf(source: String): BundleVerifier.Origin? {
+    val uri = runCatching { URI(source) }.getOrNull() ?: return null
+    if (uri.host?.lowercase() != RAW_GITHUB_HOST) return null
+    val segments = uri.path.trim('/').split('/')
+    if (segments.size < 4) return null
+    val (owner, repo, ref) = Triple(segments[0], segments[1], segments[2])
+    if (owner.isBlank() || repo.isBlank() || ref.isBlank()) return null
+    return BundleVerifier.Origin(repo = "$owner/$repo", branch = ref)
+  }
+
+  /** Fetch [url] into memory, http/https only, capped + time-bounded; null on any failure. */
+  fun fetch(url: String, maxBytes: Long = DEFAULT_MAX_BYTES): ByteArray? {
+    if (!isUrl(url)) return null
+    return runCatching {
+        httpClient.newCall(Request.Builder().url(url).build()).execute().use { response ->
+          if (!response.isSuccessful) return@use null
+          val body = response.body ?: return@use null
+          readCapped(body.byteStream(), maxBytes)
+        }
+      }
+      .getOrNull()
+  }
+
+  private const val RAW_GITHUB_HOST = "raw.githubusercontent.com"
+  private const val DEFAULT_MAX_BYTES = 100L * 1024 * 1024 // 100 MB — matches ServeBundleStore.
+
+  private val httpClient: OkHttpClient by lazy {
+    OkHttpClient.Builder()
+      .connectTimeout(10, TimeUnit.SECONDS)
+      .readTimeout(60, TimeUnit.SECONDS)
+      .build()
+  }
+
+  private fun readCapped(input: InputStream, max: Long): ByteArray {
+    val out = ByteArrayOutputStream()
+    val buffer = ByteArray(64 * 1024)
+    var total = 0L
+    while (true) {
+      val n = input.read(buffer)
+      if (n < 0) break
+      total += n
+      require(total <= max) { "remote bundle exceeds ${max / (1024 * 1024)}MB" }
+      out.write(buffer, 0, n)
+    }
+    return out.toByteArray()
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeStartupBundlesTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeStartupBundlesTest.kt
@@ -3,7 +3,6 @@ package ee.schimke.composeai.cli.serve
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
-import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class ServeStartupBundlesTest {
@@ -62,20 +61,46 @@ class ServeStartupBundlesTest {
   }
 
   @Test
-  fun `origin is derived only from a raw githubusercontent url`() {
-    val origin =
-      ServeStartupBundles.originOf(
-        "https://raw.githubusercontent.com/yschimke/compose-ai-tools/design-artifacts/compose-m3/bundle/app.bundle"
+  fun `candidate origins are enumerated only for a raw githubusercontent url`() {
+    val origins =
+      ServeStartupBundles.candidateOrigins(
+        "https://raw.githubusercontent.com/o/r/main/bundle/app.bundle"
       )
-    assertEquals("yschimke/compose-ai-tools", origin?.repo)
-    assertEquals("design-artifacts", origin?.branch)
+    // ref splits leaving ≥1 path segment: "main", "main/bundle".
+    assertEquals(listOf("o/r"), origins.map { it.repo }.distinct())
+    assertEquals(listOf("main", "main/bundle"), origins.map { it.branch })
   }
 
   @Test
-  fun `origin is null for a non-github host or a local path`() {
-    assertNull(ServeStartupBundles.originOf("https://example.com/o/r/main/app.bundle"))
-    assertNull(ServeStartupBundles.originOf("/tmp/app.bundle"))
-    assertNull(ServeStartupBundles.originOf("https://raw.githubusercontent.com/only/two"))
+  fun `candidate origins is empty for a non-github host or a local path`() {
+    assertTrue(
+      ServeStartupBundles.candidateOrigins("https://example.com/o/r/main/app.bundle").isEmpty()
+    )
+    assertTrue(ServeStartupBundles.candidateOrigins("/tmp/app.bundle").isEmpty())
+    assertTrue(
+      ServeStartupBundles.candidateOrigins("https://raw.githubusercontent.com/only/two").isEmpty()
+    )
+  }
+
+  @Test
+  fun `a slash-containing branch matches a branch glob in the trust store`() {
+    // Regression: design-artifacts URLs are published from branches like
+    // `design-artifacts/compose-m3`
+    // (the branch name itself has a slash). The trust store globs are `design-artifacts/*`, so the
+    // caller must be able to pick the two-segment branch, not the bare `design-artifacts`.
+    val trust =
+      TrustStore(
+        branches =
+          listOf(TrustedBranch(repo = "yschimke/compose-ai-tools", branch = "design-artifacts/*"))
+      )
+    val origins =
+      ServeStartupBundles.candidateOrigins(
+        "https://raw.githubusercontent.com/yschimke/compose-ai-tools/design-artifacts/compose-m3/bundle/app.bundle"
+      )
+    // The caller's selection: first candidate the trust store trusts.
+    val trusted = origins.firstOrNull { trust.trustsBranch(it.repo, it.branch) }
+    assertEquals("design-artifacts/compose-m3", trusted?.branch)
+    assertEquals("yschimke/compose-ai-tools", trusted?.repo)
   }
 
   @Test
@@ -84,7 +109,10 @@ class ServeStartupBundlesTest {
     // gate the startup --bundle live path reuses. Verify the verdict the branch origin produces.
     val trust = TrustStore(branches = listOf(TrustedBranch(repo = "o/r", branch = "*")))
     val origin =
-      ServeStartupBundles.originOf("https://raw.githubusercontent.com/o/r/main/b/app.bundle")!!
+      ServeStartupBundles.candidateOrigins(
+          "https://raw.githubusercontent.com/o/r/main/b/app.bundle"
+        )
+        .first { trust.trustsBranch(it.repo, it.branch) }
     // An unsigned bundle (no signatures.json); origin alone must still make it Trusted (branch
     // basis), which is what unlocks the live lane for a branch-fetched bundle.
     val bundle = ServeBundle.zip(linkedMapOf("previews/x.png" to byteArrayOf(1)))
@@ -96,7 +124,10 @@ class ServeStartupBundlesTest {
   @Test
   fun `without a matching trusted branch a fetched bundle stays Unverified`() {
     val origin =
-      ServeStartupBundles.originOf("https://raw.githubusercontent.com/o/r/main/b/app.bundle")!!
+      ServeStartupBundles.candidateOrigins(
+          "https://raw.githubusercontent.com/o/r/main/b/app.bundle"
+        )
+        .first()
     val bundle = ServeBundle.zip(linkedMapOf("previews/x.png" to byteArrayOf(1)))
     val verdict = BundleVerifier.verify(bundle, TrustStore.EMPTY, origin)
     assertTrue(verdict is BundleVerifier.Verdict.Unverified)

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeStartupBundlesTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeStartupBundlesTest.kt
@@ -1,0 +1,104 @@
+package ee.schimke.composeai.cli.serve
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class ServeStartupBundlesTest {
+
+  @Test
+  fun `bare url spec derives the session name from the file basename`() {
+    val specs =
+      ServeStartupBundles.parse(
+        listOf("https://raw.githubusercontent.com/o/r/main/bundle/compose-m3.bundle")
+      )
+    assertEquals(1, specs.size)
+    assertEquals("compose-m3", specs.single().name)
+    assertEquals(
+      "https://raw.githubusercontent.com/o/r/main/bundle/compose-m3.bundle",
+      specs.single().source,
+    )
+  }
+
+  @Test
+  fun `bare path spec strips a known extension for the name`() {
+    assertEquals("demo", ServeStartupBundles.parse(listOf("/tmp/demo.bundle")).single().name)
+    assertEquals("demo", ServeStartupBundles.parse(listOf("/tmp/demo.png")).single().name)
+    assertEquals("demo", ServeStartupBundles.parse(listOf("/tmp/demo.zip")).single().name)
+  }
+
+  @Test
+  fun `explicit name=source form sets the name`() {
+    val spec = ServeStartupBundles.parse(listOf("mine=https://host/x/y/z.bundle")).single()
+    assertEquals("mine", spec.name)
+    assertEquals("https://host/x/y/z.bundle", spec.source)
+  }
+
+  @Test
+  fun `a url with a query is not mis-split on its equals sign`() {
+    // The `=` lives in the query, not a `name=` prefix — the whole URL must stay the source.
+    val spec = ServeStartupBundles.parse(listOf("https://host/b.bundle?token=abc")).single()
+    assertEquals("https://host/b.bundle?token=abc", spec.source)
+    assertEquals("b", spec.name)
+  }
+
+  @Test
+  fun `an unusable name prefix falls back to treating the whole entry as a source path`() {
+    // "§§§" fails the name charset, so the entry is NOT split on `=`; the whole string is the
+    // source and the name is derived from its basename ("x").
+    val specs = ServeStartupBundles.parse(listOf("§§§=/tmp/x.bundle"))
+    assertEquals("x", specs.single().name)
+    assertEquals("§§§=/tmp/x.bundle", specs.single().source)
+  }
+
+  @Test
+  fun `isUrl distinguishes http(s) from local paths`() {
+    assertTrue(ServeStartupBundles.isUrl("https://host/x.bundle"))
+    assertTrue(ServeStartupBundles.isUrl("http://host/x.bundle"))
+    assertFalse(ServeStartupBundles.isUrl("/tmp/x.bundle"))
+    assertFalse(ServeStartupBundles.isUrl("./rel/x.bundle"))
+  }
+
+  @Test
+  fun `origin is derived only from a raw githubusercontent url`() {
+    val origin =
+      ServeStartupBundles.originOf(
+        "https://raw.githubusercontent.com/yschimke/compose-ai-tools/design-artifacts/compose-m3/bundle/app.bundle"
+      )
+    assertEquals("yschimke/compose-ai-tools", origin?.repo)
+    assertEquals("design-artifacts", origin?.branch)
+  }
+
+  @Test
+  fun `origin is null for a non-github host or a local path`() {
+    assertNull(ServeStartupBundles.originOf("https://example.com/o/r/main/app.bundle"))
+    assertNull(ServeStartupBundles.originOf("/tmp/app.bundle"))
+    assertNull(ServeStartupBundles.originOf("https://raw.githubusercontent.com/only/two"))
+  }
+
+  @Test
+  fun `a branch origin badges a fetched bundle Trusted(Branch) without a signature`() {
+    // A bundle pulled from a branch in the trust store is trusted-by-origin even unsigned — the
+    // gate the startup --bundle live path reuses. Verify the verdict the branch origin produces.
+    val trust = TrustStore(branches = listOf(TrustedBranch(repo = "o/r", branch = "*")))
+    val origin =
+      ServeStartupBundles.originOf("https://raw.githubusercontent.com/o/r/main/b/app.bundle")!!
+    // An unsigned bundle (no signatures.json); origin alone must still make it Trusted (branch
+    // basis), which is what unlocks the live lane for a branch-fetched bundle.
+    val bundle = ServeBundle.zip(linkedMapOf("previews/x.png" to byteArrayOf(1)))
+    val verdict = BundleVerifier.verify(bundle, trust, origin)
+    assertTrue(verdict is BundleVerifier.Verdict.Trusted)
+    assertEquals("branch:o/r@main", BundleVerifier.summary(verdict))
+  }
+
+  @Test
+  fun `without a matching trusted branch a fetched bundle stays Unverified`() {
+    val origin =
+      ServeStartupBundles.originOf("https://raw.githubusercontent.com/o/r/main/b/app.bundle")!!
+    val bundle = ServeBundle.zip(linkedMapOf("previews/x.png" to byteArrayOf(1)))
+    val verdict = BundleVerifier.verify(bundle, TrustStore.EMPTY, origin)
+    assertTrue(verdict is BundleVerifier.Verdict.Unverified)
+  }
+}

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -112,6 +112,44 @@ compose-preview serve \
   construction**: rendering a bundle/catalog executes no code, re-rendering untrusted Compose is
   refused, uploads are size-capped, and the `?url=` fetch is SSRF-gated (`--accept-bundles-from`).
 
+### Serving any fetched bundle — no module upfront (`--bundle`)
+
+A catalog is the *packaged* form of "a trusted producer publishes a branch". When you just have a
+**preview bundle** — the executable `.bundle` the export pipeline emits, sitting on a GitHub branch or
+a local disk — you don't need a `catalog.json` wrapper (or a local module to build) to render it
+live. `--bundle <url|path>` (repeatable, `--bundle <name>=<url|path>` to name the session) fetches
+the bundle at startup and stands it up as its own `/<name>/` session:
+
+```bash
+# A pure preview server — no --module, no local checkout, no Gradle build.
+compose-preview serve \
+  --public \
+  --allow-render-trusted \
+  --trust-store trust/producers.json \
+  --bundle https://raw.githubusercontent.com/yschimke/compose-ai-tools/design-artifacts/compose-m3/bundle/compose-m3-bundle.png
+# Opens the fetched bundle live at http://localhost:8723/compose-m3-bundle/
+```
+
+Same **trust × format** rules as a catalog, and the same fail-closed gate — a fetched bundle earns
+the **live** (server-side re-render) lane only when it verifies `Trusted` **and** the operator passed
+`--allow-render-trusted`:
+
+- **Trusted by branch origin.** A `raw.githubusercontent.com/<owner>/<repo>/<ref>/…` URL is attributed
+  to `<owner>/<repo>@<ref>`; if that branch is in the `--trust-store`, the bundle is
+  `Trusted(Branch)` with no signature needed (same origin trust the `--catalogs` fetch uses).
+- **Trusted by signature.** Any bundle (including a local `--bundle /path/app.bundle`) carrying an
+  Ed25519 `signatures.json` signed by a key in the store is `Trusted(Signature)`.
+- **Otherwise `Unverified`** → served **read-only as its baked PNGs**; its executable Compose is never
+  re-rendered on the server (no RCE lever). The data tiers serve either way.
+
+Desktop-backend only for the live lane (it rides the same `liveBundle` daemon path `compose-m3` uses:
+`ServeBundleDaemon.materialize` extracts the bundle, resolves its classpath, and launches the render
+daemon straight from it — no build). An Android bundle falls back to baked PNGs, fail-closed. A URL is
+fetched from the operator's own command line, so — unlike the client `?url=` upload path — it is **not**
+SSRF-gated (`--accept-bundles-from` doesn't apply); the operator chose the address. `--bundle` also
+works **alongside** a `--module` (both are served); run it with no `--module` outside a Gradle project
+to get the pure module-less server above.
+
 ## Deploying `preview.coo.ee`
 
 Both container profiles take this config from env (the entrypoint maps `SERVE_PUBLIC`,


### PR DESCRIPTION
## Summary

Makes the local/public preview **live** server work for **any** preview bundle instead of needing a module specified upfront — the ask in the [`public-preview-server.md` "Running one"](https://github.com/yschimke/compose-ai-tools/blob/main/docs/public-preview-server.md#running-one) thread: *"if we can fetch the preview bundle, say from a GitHub branch, then we should be able to render it live from a trusted preview server."*

The live-from-a-fetched-bundle engine already existed (`ServeBundleDaemon.materialize` — extract a bundle, resolve its classpath, launch the render daemon with **no Gradle build**), but it was reachable only through the `--catalogs` machinery (a `design-artifacts/<system>` branch + `catalog.json` + a mandatory local `--module` to boot the server). This PR exposes that engine directly and drops the module requirement.

### What's new

- **`serve --bundle <url|path>`** (repeatable; `--bundle <name>=<url|path>` to name the session). A URL is fetched at startup; a local path is read. Each becomes a `/<name>/` session.
- **Module-less serve.** With no `--module` and no local Gradle project but at least one hosted source (`--bundle` / `--catalogs` / `--bundles` / `--accept-bundles`), `serve` runs a pure server — no discover, no build. `--bundle` also works *alongside* a `--module` when run inside a project.

```bash
# A pure preview server: no --module, no checkout, no Gradle build.
compose-preview serve --public --allow-render-trusted --trust-store trust/producers.json \
  --bundle https://raw.githubusercontent.com/yschimke/compose-ai-tools/design-artifacts/compose-m3/bundle/compose-m3-bundle.png
# → live at http://localhost:8723/compose-m3-bundle/
```

### Security (unchanged fail-closed model)

A fetched bundle earns the **server-side live re-render** lane only when it verifies **`Trusted`** *and* the operator passed `--allow-render-trusted` — the exact gate a catalog's `liveBundle` already uses:

- **Trusted by branch origin** — a `raw.githubusercontent.com/<owner>/<repo>/<ref>/…` URL is attributed to `<owner>/<repo>@<ref>`; trusted if that branch is in `--trust-store` (no signature needed).
- **Trusted by signature** — any bundle (incl. a local path) with an Ed25519 `signatures.json` signed by a pinned key.
- **Otherwise `Unverified`** → served **read-only as baked PNGs**; executable Compose is never re-rendered on the server. Desktop-backend only for the live lane (Android bundles fall back to baked, fail-closed).

Startup `--bundle` URLs come from the operator's command line, so — unlike the client `POST /bundles?url=` upload path — they are **not** SSRF-gated (`--accept-bundles-from` does not apply); the operator chose the address, same trust level as `--catalogs`.

### Changes

- `ServeStartupBundles` (new) — parse specs, fetch, derive a branch `Origin` from `raw.githubusercontent.com` URLs.
- `ServeCommand` — module-less `runBundleServer`, `--bundle` wiring (`registerStartupBundles`), and a shared `bringUpServer` helper reused by both the module-backed and module-less paths (`openHost` hoisted to a method).
- `ServeBundleStore.add` — optional `origin` so a branch-fetched *baked* bundle badges `Trusted(Branch)` too.
- `ServeSessionRegistry.anySessionId` — landing session for module-less mode.
- Docs (`public-preview-server.md`) + `ServeStartupBundlesTest`.

## Test plan

- [x] `ServeStartupBundlesTest` — spec parsing (bare/named/query-URL/local), branch-origin derivation, and the `Trusted(Branch)` vs `Unverified` verdict a fetched bundle produces.
- [x] Formatting confirmed clean with the repo's ktfmt (0.62, verified against `main`).
- [ ] **CI to confirm `:cli` compile + `./gradlew check`** — the sandbox's egress policy blocks `services.gradle.org`, so the Gradle 9.6.1 wrapper couldn't run locally (system Gradle is 8.14.3, too old). Code was reviewed manually against the real APIs; CI is the compile/test gate.

## Follow-up (not in this PR)

Wiring the existing `POST /bundles` **upload** + `?url=` path to the same live daemon lane for `Trusted` uploads (today they're baked-PNG only) — a natural extension using the same `materialize` call, kept out to bound this diff.

_Generated by [Claude Code]_

---
_Generated by [Claude Code](https://claude.ai/code/session_018S67ouGFwxPQkcURocZJND)_