### PR TITLE
feat(vscode): add clear-background (crisp outline) focus-toolbar toggle

### DIFF
--- a/vscode-extension/preview-harness/fixtures/clear-background.gen.mjs
+++ b/vscode-extension/preview-harness/fixtures/clear-background.gen.mjs
@@ -1,0 +1,72 @@
+// Generator for `clear-background.json`. Run with:
+//   node preview-harness/fixtures/clear-background.gen.mjs > preview-harness/fixtures/clear-background.json
+//
+// Exercises the focus-toolbar "clear background" (crisp outline) toggle
+// (`#btn-clear-background`). The fixture focuses a card — which surfaces the
+// focus-controls bar — then clicks the toggle so the snapshot captures the
+// button in its pressed (`aria-pressed="true"`) state alongside the other
+// focus-bar controls. Unlike the touch-overlay / keyboard-band toggles this
+// button is not gated on a daemon-advertised capability (both render backends
+// always honour `renderNow.overrides.clearBackground`), so it shows whenever a
+// card is in focus.
+//
+// The click posts `{ command: "toggleClearBackground", previewId, enabled }` to
+// the host (which re-renders the snapshot with the override); the harness has no
+// host, so the post is captured and the button's local pressed state is what the
+// snapshot records.
+
+import {
+    EARLY_FEATURES_DATASET,
+    buildMobileMock,
+    buildPreviewPair,
+    focusAction,
+} from "./_utils.mjs";
+
+const mock = buildMobileMock();
+const { W, H, png } = mock;
+
+const focusId = "com.example.buttonKt.FilledButtonPreview";
+const { focused, sibling } = buildPreviewPair({
+    focusId,
+    width: W,
+    height: H,
+    fnName: "FilledButtonPreview",
+    file: "ButtonShowcase.kt",
+});
+
+const setPreviews = {
+    command: "setPreviews",
+    moduleDir: "/workspace/sample-android",
+    heavyStaleIds: [],
+    previews: [focused, sibling],
+};
+
+const updateImage = {
+    command: "updateImage",
+    previewId: focusId,
+    captureIndex: 0,
+    imageData: png,
+};
+
+const fixture = {
+    name: "clear-background",
+    description:
+        "Focused card with the focus-controls bar visible; clicks the `#btn-clear-background` (crisp outline) toggle so the snapshot shows the new focus-bar button in its pressed state. The toggle posts `toggleClearBackground` to the host, which re-renders the preview's snapshot with `renderNow.overrides.clearBackground`.",
+    dataset: EARLY_FEATURES_DATASET,
+    messages: [setPreviews, updateImage],
+    actions: [
+        focusAction(focusId),
+        // The toggle is visible only in focus mode (applyClearBackgroundButtonState
+        // gates on `inFocus`), so this click comes after the focus action.
+        { click: `#btn-clear-background` },
+    ],
+    expectedPosts: [
+        {
+            command: "toggleClearBackground",
+            previewId: focusId,
+            enabled: true,
+        },
+    ],
+};
+
+process.stdout.write(JSON.stringify(fixture, null, 2) + "\n");

--- a/vscode-extension/preview-harness/fixtures/clear-background.json
+++ b/vscode-extension/preview-harness/fixtures/clear-background.json
@@ -1,0 +1,92 @@
+{
+  "name": "clear-background",
+  "description": "Focused card with the focus-controls bar visible; clicks the `#btn-clear-background` (crisp outline) toggle so the snapshot shows the new focus-bar button in its pressed state. The toggle posts `toggleClearBackground` to the host, which re-renders the preview's snapshot with `renderNow.overrides.clearBackground`.",
+  "dataset": {
+    "earlyFeatures": "true",
+    "minimalMode": "false"
+  },
+  "messages": [
+    {
+      "command": "setPreviews",
+      "moduleDir": "/workspace/sample-android",
+      "heavyStaleIds": [],
+      "previews": [
+        {
+          "id": "com.example.buttonKt.FilledButtonPreview",
+          "functionName": "FilledButtonPreview",
+          "className": "ButtonShowcaseKt",
+          "sourceFile": "ButtonShowcase.kt",
+          "params": {
+            "name": null,
+            "device": null,
+            "widthDp": 360,
+            "heightDp": 600,
+            "fontScale": 1,
+            "showSystemUi": false,
+            "showBackground": true,
+            "backgroundColor": 0,
+            "uiMode": 0,
+            "locale": null,
+            "group": null
+          },
+          "captures": [
+            {
+              "advanceTimeMillis": null,
+              "scroll": null,
+              "renderOutput": "renders/com.example.buttonKt.FilledButtonPreview.png",
+              "label": ""
+            }
+          ]
+        },
+        {
+          "id": "com.example.buttonKt.FilledButtonPreviewSibling",
+          "functionName": "FilledButtonPreviewSibling",
+          "className": "ButtonShowcaseKt",
+          "sourceFile": "ButtonShowcase.kt",
+          "params": {
+            "name": null,
+            "device": null,
+            "widthDp": 360,
+            "heightDp": 600,
+            "fontScale": 1,
+            "showSystemUi": false,
+            "showBackground": true,
+            "backgroundColor": 0,
+            "uiMode": 0,
+            "locale": null,
+            "group": null
+          },
+          "captures": [
+            {
+              "advanceTimeMillis": null,
+              "scroll": null,
+              "renderOutput": "renders/com.example.buttonKt.FilledButtonPreviewSibling.png",
+              "label": ""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "command": "updateImage",
+      "previewId": "com.example.buttonKt.FilledButtonPreview",
+      "captureIndex": 0,
+      "imageData": "iVBORw0KGgoAAAANSUhEUgAAAWgAAAJYCAIAAADAFeuyAAAH9UlEQVR4nO3UQQ2DUBRFwa+gilDSbW1VAFIQURuwYIWGs+GHdG5GwEtecsbyXgGSMf0C4HGEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8jGfpwAiXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAA2bRwvD5fbjDrvz+7ZcKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5QkHwmF5woFwWJ5wIByWJxwIh+UJB8JhecKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5QkHwmF5woFwWJ5wIByWJxwIh+UJB8JhecKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5QkHwmF5woFwWJ5wIByWJxwIh+UJB8JhecKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5QkHwmF5woFwWJ5wIByWJxwIh+UJB8JhecKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5f1dOIDnEg4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gG5uZWZxwmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFneBUZcMccpTkvCAAAAAElFTkSuQmCC"
+    }
+  ],
+  "actions": [
+    {
+      "click": ".preview-card[data-preview-id=\"com.example.buttonKt.FilledButtonPreview\"] .card-focus-btn"
+    },
+    {
+      "click": "#btn-clear-background"
+    }
+  ],
+  "expectedPosts": [
+    {
+      "command": "toggleClearBackground",
+      "previewId": "com.example.buttonKt.FilledButtonPreview",
+      "enabled": true
+    }
+  ]
+}

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -5971,6 +5971,15 @@ function handleWebviewMessage(msg: WebviewToExtension) {
                 void handleSetPermissionsOverride(msg.previewId, msg.change);
             }
             break;
+        case "toggleClearBackground":
+            // Focus-toolbar "clear background" (crisp outline) toggle. Re-renders the
+            // focused preview's snapshot with `renderNow.overrides.clearBackground`, so
+            // the daemon forces a transparent harness background AND provides
+            // `LocalPreviewBackgroundCleared`. Always available (not gated on early
+            // features) — it's a stable display override both backends honour, so the
+            // focus-bar button never sits dead.
+            void handleToggleClearBackground(msg.previewId, msg.enabled);
+            break;
         case "openResourceFile":
             void openResourceFile(
                 {
@@ -6418,6 +6427,38 @@ async function handleSetPermissionsOverride(
         "fast",
         "permissions-edit",
         { permissions: next },
+    );
+}
+
+/**
+ * Focus-toolbar "clear background" toggle. Re-renders the preview's snapshot with
+ * `renderNow.overrides.clearBackground = enabled`, so the daemon forces a transparent
+ * harness background and provides `LocalPreviewBackgroundCleared` for the crisp-outline
+ * capture. The webview owns the sticky per-preview toggle state (it reflects the button's
+ * pressed state and carries the override into a live stream restart via
+ * `overridesForPreview`); this host handler just dispatches the snapshot render. `enabled
+ * = false` sends `undefined` so the render reverts to the discovery-time background.
+ */
+async function handleToggleClearBackground(
+    previewId: string,
+    enabled: boolean,
+): Promise<void> {
+    if (!daemonScheduler) {
+        return;
+    }
+    const moduleInfo = previewModuleIndex.get(previewId);
+    if (!moduleInfo) {
+        return;
+    }
+    logInfo(
+        `[panel] clearBackground ${enabled ? "on" : "off"} for ${previewId} via renderNow`,
+    );
+    void daemonScheduler.renderNow(
+        moduleInfo,
+        [previewId],
+        "fast",
+        "clear-background-toggle",
+        { clearBackground: enabled || undefined },
     );
 }
 

--- a/vscode-extension/src/test/liveState.test.ts
+++ b/vscode-extension/src/test/liveState.test.ts
@@ -178,3 +178,46 @@ describe("LiveStateController — launcher-widget override", () => {
         assert.strictEqual(changes.length, 0);
     });
 });
+
+describe("LiveStateController — clear-background toggle", () => {
+    it("is off by default", () => {
+        const live = makeController();
+        assert.strictEqual(live.isClearBackgroundEnabled("preview:A"), false);
+        assert.strictEqual(live.overridesForPreview("preview:A"), undefined);
+    });
+
+    it("toggleClearBackgroundForCard surfaces clearBackground in overridesForPreview", () => {
+        const live = makeController();
+        const card = makeCard("preview:A");
+        live.toggleClearBackgroundForCard(card, true);
+        assert.strictEqual(live.isClearBackgroundEnabled("preview:A"), true);
+        assert.deepStrictEqual(live.overridesForPreview("preview:A"), {
+            clearBackground: true,
+        });
+    });
+
+    it("toggling off removes the override branch", () => {
+        const live = makeController();
+        const card = makeCard("preview:A");
+        live.toggleClearBackgroundForCard(card, true);
+        live.toggleClearBackgroundForCard(card, false);
+        assert.strictEqual(live.isClearBackgroundEnabled("preview:A"), false);
+        assert.strictEqual(live.overridesForPreview("preview:A"), undefined);
+    });
+
+    it("scopes the toggle per-preview", () => {
+        const live = makeController();
+        live.toggleClearBackgroundForCard(makeCard("preview:A"), true);
+        assert.deepStrictEqual(live.overridesForPreview("preview:A"), {
+            clearBackground: true,
+        });
+        assert.strictEqual(live.overridesForPreview("preview:B"), undefined);
+    });
+
+    it("is a no-op when card has no previewId", () => {
+        const live = makeController();
+        const card = document.createElement("div");
+        live.toggleClearBackgroundForCard(card, true);
+        assert.strictEqual(live.overridesForPreview(""), undefined);
+    });
+});

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -1222,7 +1222,16 @@ export type WebviewToExtension =
           command: "setPermissionsOverride";
           previewId: string;
           change: PermissionsChangeDetail;
-      };
+      }
+    /**
+     * Focus-toolbar "clear background" (crisp outline) toggle. Re-renders the
+     * focused preview's snapshot with `renderNow.overrides.clearBackground`, so the
+     * daemon forces a transparent harness background and provides
+     * `LocalPreviewBackgroundCleared` — a composable drawing its own opaque fill (a
+     * Material 3 `Surface`) drops it for a crisp component silhouette. `enabled =
+     * false` reverts to the discovery-time background.
+     */
+    | { command: "toggleClearBackground"; previewId: string; enabled: boolean };
 
 /**
  * Narrow shape the History panel reads off each sidecar JSON entry. The

--- a/vscode-extension/src/webview/preview/focusController.ts
+++ b/vscode-extension/src/webview/preview/focusController.ts
@@ -218,8 +218,11 @@ export class FocusController {
             inFocus,
             focusedPreviewId: previewId,
             // Not capability-gated — both backends honour clearBackground — so the
-            // button shows whenever a card is focused (advertised is ignored).
+            // button shows whenever a card is focused (advertised is ignored)...
             advertised: true,
+            // ...except in a bundle viewer, whose message switch can't route the
+            // toggle to a daemon; hidden there rather than shown dead.
+            bundleMode: this.config.bundleMode?.() ?? false,
             enabled:
                 previewId !== null && live.isClearBackgroundEnabled(previewId),
         });

--- a/vscode-extension/src/webview/preview/focusController.ts
+++ b/vscode-extension/src/webview/preview/focusController.ts
@@ -214,6 +214,15 @@ export class FocusController {
             enabled:
                 previewId !== null && live.isTouchOverlayEnabled(previewId),
         });
+        this.config.focusToolbar.applyClearBackgroundButtonState({
+            inFocus,
+            focusedPreviewId: previewId,
+            // Not capability-gated — both backends honour clearBackground — so the
+            // button shows whenever a card is focused (advertised is ignored).
+            advertised: true,
+            enabled:
+                previewId !== null && live.isClearBackgroundEnabled(previewId),
+        });
         this.config.focusToolbar.applyKeyboardBandButtonState({
             inFocus,
             focusedPreviewId: previewId,

--- a/vscode-extension/src/webview/preview/focusToolbar.ts
+++ b/vscode-extension/src/webview/preview/focusToolbar.ts
@@ -98,6 +98,14 @@ export interface FocusedToggleButtonState {
     advertised: boolean;
     /** Current per-preview toggle state for the focused card. */
     enabled: boolean;
+    /**
+     * True in a bundle-viewer panel. The bundle viewer's message switch handles
+     * none of the per-preview override edits (permissions / lottie / clear-background),
+     * so a toggle that re-renders via a host `renderNow` is inert there — the button is
+     * hidden rather than shown dead. Only consumed by the clear-background toggle today
+     * (the others are already capability-gated off in bundle mode). Absent ⇒ not bundle.
+     */
+    bundleMode?: boolean;
 }
 
 export class FocusToolbarController {
@@ -270,7 +278,10 @@ export class FocusToolbarController {
      * is ignored here.
      */
     applyClearBackgroundButtonState(s: FocusedToggleButtonState): void {
-        const visible = s.inFocus && s.focusedPreviewId !== null;
+        // Hidden in bundle viewers — that panel's message switch has no
+        // `toggleClearBackground` handler, so the toggle can't reach a daemon there.
+        const visible =
+            s.inFocus && s.focusedPreviewId !== null && !s.bundleMode;
         this.el.btnClearBackground.hidden = !visible;
         if (!visible) {
             this.el.btnClearBackground.setAttribute("aria-pressed", "false");

--- a/vscode-extension/src/webview/preview/focusToolbar.ts
+++ b/vscode-extension/src/webview/preview/focusToolbar.ts
@@ -30,6 +30,7 @@ export interface FocusToolbarElements {
     btnRecording: HTMLButtonElement;
     btnTouchOverlay: HTMLButtonElement;
     btnKeyboardBand: HTMLButtonElement;
+    btnClearBackground: HTMLButtonElement;
     btnControls: HTMLButtonElement;
     btnLauncherWidget: HTMLButtonElement;
     btnExportBundle: HTMLButtonElement;
@@ -258,6 +259,33 @@ export class FocusToolbarController {
         this.el.btnTouchOverlay.setAttribute(
             "aria-label",
             this.el.btnTouchOverlay.title,
+        );
+    }
+
+    /**
+     * "Clear background" (crisp outline) toggle for the focused preview. Unlike the
+     * touch-overlay / keyboard-band toggles this is **not** gated on a daemon-advertised
+     * capability — `clearBackground` is a display override both backends always honour —
+     * so the button shows whenever a card is in focus. [FocusedToggleButtonState.advertised]
+     * is ignored here.
+     */
+    applyClearBackgroundButtonState(s: FocusedToggleButtonState): void {
+        const visible = s.inFocus && s.focusedPreviewId !== null;
+        this.el.btnClearBackground.hidden = !visible;
+        if (!visible) {
+            this.el.btnClearBackground.setAttribute("aria-pressed", "false");
+            return;
+        }
+        this.el.btnClearBackground.setAttribute(
+            "aria-pressed",
+            s.enabled ? "true" : "false",
+        );
+        this.el.btnClearBackground.title = s.enabled
+            ? "Restore preview background"
+            : "Clear background (render a crisp transparent outline)";
+        this.el.btnClearBackground.setAttribute(
+            "aria-label",
+            this.el.btnClearBackground.title,
         );
     }
 

--- a/vscode-extension/src/webview/preview/liveState.ts
+++ b/vscode-extension/src/webview/preview/liveState.ts
@@ -151,6 +151,11 @@ export class LiveStateController {
     // stops live, and starts again gets the same overlay back.
     private touchOverlayEnabledPreviewIds: Set<string> = new Set<string>();
     private keyboardBandForcedPreviewIds: Set<string> = new Set<string>();
+    // Per-preview "clear background" (crisp outline) toggle. Sticky across live
+    // tear-down like the overlay toggles; carried into a live stream restart via
+    // `overridesForPreview` (`overrides.clearBackground`), and mirrored to the host
+    // as a snapshot `renderNow` from the focus-bar click handler in `main.ts`.
+    private clearBackgroundEnabledPreviewIds: Set<string> = new Set<string>();
     // Per-preview launcher-widget cell-size override. Read by `overridesForPreview`
     // when building the `requestStreamStart` payload so the daemon's session
     // installs a `LauncherWidgetExtension` planning to the chosen cells. The
@@ -349,6 +354,11 @@ export class LiveStateController {
         return this.touchOverlayEnabledPreviewIds.has(previewId);
     }
 
+    /** Current per-preview "clear background" (crisp outline) toggle state. */
+    isClearBackgroundEnabled(previewId: string): boolean {
+        return this.clearBackgroundEnabledPreviewIds.has(previewId);
+    }
+
     /** Current per-preview soft-keyboard band override state. */
     isKeyboardBandForced(previewId: string): boolean {
         return this.keyboardBandForcedPreviewIds.has(previewId);
@@ -433,6 +443,24 @@ export class LiveStateController {
         this.applyControlsToggleButtons();
     }
 
+    /**
+     * Per-card "clear background" (crisp outline) toggle. Updates the sticky per-preview
+     * state and refreshes the focus-bar button. If the card is live, restarts the stream
+     * so the daemon picks up `overrides.clearBackground` (via [overridesForPreview]); the
+     * snapshot re-render for the non-live case is dispatched host-side by the click
+     * handler in `main.ts` (`toggleClearBackground` message → `renderNow`).
+     */
+    toggleClearBackgroundForCard(card: HTMLElement, enabled: boolean): void {
+        const previewId = card.dataset.previewId;
+        if (!previewId) return;
+        const was = this.clearBackgroundEnabledPreviewIds.has(previewId);
+        if (was === enabled) return;
+        if (enabled) this.clearBackgroundEnabledPreviewIds.add(previewId);
+        else this.clearBackgroundEnabledPreviewIds.delete(previewId);
+        this.restartLiveIfActive(previewId);
+        this.applyControlsToggleButtons();
+    }
+
     /** Daemon advertises the launcher-widget container-size extension on any known module. */
     isLauncherWidgetAdvertised(): boolean {
         return this.anyModuleAdvertisesExtension(LAUNCHER_WIDGET_EXTENSION_ID);
@@ -509,12 +537,15 @@ export class LiveStateController {
     overridesForPreview(previewId: string): PreviewOverrides | undefined {
         const touch = this.touchOverlayEnabledPreviewIds.has(previewId);
         const keyboardOn = this.keyboardBandForcedPreviewIds.has(previewId);
+        const clearBg = this.clearBackgroundEnabledPreviewIds.has(previewId);
         const launcherCells =
             this.launcherWidgetCellsByPreviewId.get(previewId);
-        if (!touch && !keyboardOn && !launcherCells) return undefined;
+        if (!touch && !keyboardOn && !clearBg && !launcherCells)
+            return undefined;
         const overrides: PreviewOverrides = {};
         if (touch) overrides.touchOverlay = true;
         if (keyboardOn) overrides.keyboard = { visible: true };
+        if (clearBg) overrides.clearBackground = true;
         if (launcherCells) overrides.launcherWidget = { cells: launcherCells };
         return overrides;
     }

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -262,6 +262,8 @@ export class PreviewApp extends LitElement {
     @query("#recording-format") private _recordingFormat!: HTMLSelectElement;
     @query("#btn-touch-overlay") private _btnTouchOverlay!: HTMLButtonElement;
     @query("#btn-keyboard-band") private _btnKeyboardBand!: HTMLButtonElement;
+    @query("#btn-clear-background")
+    private _btnClearBackground!: HTMLButtonElement;
     @query("#btn-controls") private _btnControls!: HTMLButtonElement;
     @query("#btn-launcher-widget")
     private _btnLauncherWidget!: HTMLButtonElement;
@@ -414,6 +416,19 @@ export class PreviewApp extends LitElement {
                 >
                     <i
                         class="codicon codicon-symbol-keyword"
+                        aria-hidden="true"
+                    ></i>
+                </button>
+                <button
+                    class="icon-button"
+                    id="btn-clear-background"
+                    title="Clear background (render a crisp transparent outline)"
+                    aria-label="Clear background (render a crisp transparent outline)"
+                    aria-pressed="false"
+                    hidden
+                >
+                    <i
+                        class="codicon codicon-color-mode"
                         aria-hidden="true"
                     ></i>
                 </button>
@@ -673,6 +688,7 @@ export class PreviewApp extends LitElement {
         const recordingFormat = this._recordingFormat;
         const btnTouchOverlay = this._btnTouchOverlay;
         const btnKeyboardBand = this._btnKeyboardBand;
+        const btnClearBackground = this._btnClearBackground;
         const btnControls = this._btnControls;
         const btnLauncherWidget = this._btnLauncherWidget;
         const launcherWidgetPickerPopover = this._launcherWidgetPickerPopover;
@@ -686,6 +702,7 @@ export class PreviewApp extends LitElement {
             btnRecording,
             btnTouchOverlay,
             btnKeyboardBand,
+            btnClearBackground,
             btnControls,
             btnLauncherWidget,
             btnExportBundle,
@@ -3057,6 +3074,23 @@ export class PreviewApp extends LitElement {
             const enabled =
                 btnKeyboardBand.getAttribute("aria-pressed") === "true";
             liveState.toggleKeyboardBandForCard(card, !enabled);
+        });
+        btnClearBackground.addEventListener("click", () => {
+            const card = focusController.focusedCard();
+            if (!card) return;
+            const previewId = card.dataset.previewId;
+            if (!previewId) return;
+            const next =
+                btnClearBackground.getAttribute("aria-pressed") !== "true";
+            // Update the sticky per-preview state + button (and restart a live
+            // stream to pick up the override), then ask the host to re-render the
+            // snapshot with `renderNow.overrides.clearBackground` for the non-live case.
+            liveState.toggleClearBackgroundForCard(card, next);
+            vscode.postMessage({
+                command: "toggleClearBackground",
+                previewId,
+                enabled: next,
+            });
         });
         btnControls.addEventListener("click", () => {
             const card = focusController.focusedCard();


### PR DESCRIPTION
## Summary

Fast-follow to #2284, which added the overrideable `clearBackground` ("crisp outline") toggle to the daemon + `compose-preview serve` viewer. This wires the **third surface** we scoped: a per-preview toggle in the VS Code panel.

Adds a **"Clear background"** button to the panel's focus-controls bar (the ◐ `color-mode` icon), mirroring the existing touch-overlay / keyboard-band toggles. Clicking it re-renders the focused preview's snapshot with `renderNow.overrides.clearBackground = true` — the daemon forces a transparent harness background and provides `LocalPreviewBackgroundCleared`, so a composable painting its own opaque fill (a Material 3 `Surface`) drops it for a crisp component silhouette. Toggling off reverts to the discovery-time background.

Unlike the capability-gated overlay toggles, the button shows **whenever a card is in focus** — `clearBackground` is a display override both backends always honour, so it never sits dead.

### Wiring (mirrors the existing permissions / lottie per-preview override edits)
- New `toggleClearBackground` webview→host message (`src/types.ts`) + `handleToggleClearBackground` host handler that dispatches the snapshot `renderNow` (`src/extension.ts`).
- `LiveStateController.toggleClearBackgroundForCard` + `isClearBackgroundEnabled`, and `overridesForPreview` now carries `clearBackground` so a live-stream restart picks it up too (`liveState.ts`). The webview owns the sticky per-preview state (reflected in `aria-pressed`).
- Focus-toolbar button + state method (`focusToolbar.ts`, `focusController.ts`, `main.ts`).
- Consumes `PreviewOverrides.clearBackground` (added to the TS protocol mirror in #2284).

## Visual evidence

A new `clear-background` preview-harness fixture (focus a card, click the toggle) renders the focus-controls bar with the new button in its pressed state, in light + dark. The `vscode-preview-diff` bot will render + diff it against the `vscode-preview/main` baseline on this PR, so the new button surfaces automatically. Rendered light/dark PNGs were shared with the reviewer.

## Test plan

- [x] `npm run compile` (host + webview bundle). **pass**
- [x] `npm test` — 1584 passing, incl. 5 new `LiveStateController — clear-background toggle` cases (toggle/scoping/no-op). **pass**
- [x] `npm run harness:contract` — 8 passing, incl. the `clear-background` fixture asserting the `toggleClearBackground` post fires on click. **pass**
- [x] `npm run harness:snapshot` (light + dark) renders the new focus-bar button. **pass**
- [ ] `npm run test:electron` (xvfb) — run in CI.

Note: CI does not gate the extension on `prettier`/`eslint`; the added lines follow the file's existing style. The repo's committed source is currently not clean under the lockfile's `prettier@3.9.1` (a bump landed without a repo-wide reformat) — deliberately **not** swept into this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tcb97ZFBzUhKx2Lp4zjBfr)_