### PR TITLE
fix(serve): share previewOverride runtime across the live-daemon classloader split

### DIFF
--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/UserClassLoaderHolder.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/UserClassLoaderHolder.kt
@@ -163,6 +163,14 @@ class UserClassLoaderHolder(
    * `build/intermediates/...`), the child falls through to the parent. Per CLASSLOADER.md the
    * Compose runtime, AndroidX, and the daemon's helpers stay on the parent.
    *
+   * **Shared process-static bridges are forced to the parent even when the child's URLs carry
+   * them.** [mustDelegateToParent] lists the framework packages *plus*
+   * `ee.schimke.composeai.daemon.*` and `ee.schimke.composeai.overrides.*` — the latter is the
+   * `previewOverride*` named-override runtime, whose `PreviewOverrideController` static the daemon
+   * seeds and the preview reads. On the bundle-backed live daemon the runtime jar is on the child's
+   * URLs, so a bare child-first lookup would load a *second* copy and split the shared static; the
+   * explicit delegation keeps it a singleton. See [mustDelegateToParent] for the full rationale.
+   *
    * **Loaded-class cache discipline.** The JVM's `findLoadedClass` is checked first so a user class
    * loaded via the child stays the same `Class<?>` instance for repeated lookups within the
    * loader's lifetime — only [swap] rotates it.
@@ -178,22 +186,7 @@ class UserClassLoaderHolder(
           if (resolve) resolveClass(cached)
           return cached
         }
-        // System / JDK classes always go through the parent — punching holes here would break the
-        // JVM's bootstrap invariants. `java.*`, `javax.*`, `sun.*`, `jdk.*`, etc.
-        if (
-          name.startsWith("java.") ||
-            name.startsWith("javax.") ||
-            name.startsWith("sun.") ||
-            name.startsWith("jdk.") ||
-            name.startsWith("kotlin.") ||
-            name.startsWith("kotlinx.") ||
-            name.startsWith("androidx.") ||
-            name.startsWith("android.") ||
-            name.startsWith("org.robolectric.") ||
-            name.startsWith("com.github.takahirom.roborazzi.") ||
-            name.startsWith("org.jetbrains.skia.") ||
-            name.startsWith("ee.schimke.composeai.daemon.")
-        ) {
+        if (UserClassLoaderHolder.mustDelegateToParent(name)) {
           return super.loadClass(name, resolve)
         }
         // Try our own URLs first (child-first); fall back to parent if not present locally.
@@ -215,6 +208,46 @@ class UserClassLoaderHolder(
      * and constructs a [UserClassLoaderHolder] with the resolved URLs.
      */
     const val USER_CLASS_DIRS_PROP: String = "composeai.daemon.userClassDirs"
+
+    /**
+     * Whether [name] must be resolved via the parent loader instead of child-first (used by
+     * [ChildFirstURLClassLoader.loadClass]). Two reasons a class is on this list:
+     * 1. **Bootstrap / framework classes** — `java.*`, `kotlin.*`, `androidx.*`, Robolectric, Skiko,
+     *    etc. Punching holes in the JDK packages would break the JVM's bootstrap invariants, and the
+     *    Compose/AndroidX runtime must be the *one* copy the parent bootstrapped (child-loading it
+     *    would fail on classloader-identity skew).
+     * 2. **Process-static bridges shared with the daemon** — `ee.schimke.composeai.daemon.*` (the
+     *    cross-classloader handoff queues) and `ee.schimke.composeai.overrides.*` (the
+     *    `previewOverride*` named-override runtime: `PreviewOverrideController` is a process-static
+     *    the daemon's connector seeds *before* the preview composes, and the preview reads it back
+     *    during composition). These only work when the daemon and the user preview see the **same**
+     *    `Class<?>` — one shared static, not two per-classloader copies.
+     *
+     * The overrides runtime is the load-bearing case for the **bundle-backed live daemon**
+     * (`ServeBundleDaemon`, the engine behind `--catalogs` `liveBundle` / `preview.coo.ee`): there
+     * the bundle's resolved maven classpath — which includes `:data-preview-overrides-runtime` — is
+     * added to the child loader's URLs. Without this delegation the child would resolve
+     * `PreviewOverrideController` child-first from that jar, a *different* copy from the one the
+     * daemon connector seeds, so every `previewOverrideString("label", "Filled")` silently returns
+     * its author default and content overrides no-op. (On the ordinary Gradle-driven daemon the
+     * child URLs are only the module's compiled-class directory, which carries no runtime classes,
+     * so the child already falls through to the parent — this delegation just makes that guarantee
+     * explicit and independent of what's on the child's URLs.)
+     */
+    internal fun mustDelegateToParent(name: String): Boolean =
+      name.startsWith("java.") ||
+        name.startsWith("javax.") ||
+        name.startsWith("sun.") ||
+        name.startsWith("jdk.") ||
+        name.startsWith("kotlin.") ||
+        name.startsWith("kotlinx.") ||
+        name.startsWith("androidx.") ||
+        name.startsWith("android.") ||
+        name.startsWith("org.robolectric.") ||
+        name.startsWith("com.github.takahirom.roborazzi.") ||
+        name.startsWith("org.jetbrains.skia.") ||
+        name.startsWith("ee.schimke.composeai.daemon.") ||
+        name.startsWith("ee.schimke.composeai.overrides.")
 
     /**
      * Resolves [USER_CLASS_DIRS_PROP] into a list of [URL]s, dropping entries that don't exist on

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/UserClassLoaderHolderTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/UserClassLoaderHolderTest.kt
@@ -4,6 +4,7 @@ import java.io.File
 import java.net.URLClassLoader
 import java.nio.file.Files
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNotSame
 import org.junit.Assert.assertTrue
@@ -128,6 +129,41 @@ class UserClassLoaderHolderTest {
       if (previous != null) System.setProperty(UserClassLoaderHolder.USER_CLASS_DIRS_PROP, previous)
       else System.clearProperty(UserClassLoaderHolder.USER_CLASS_DIRS_PROP)
     }
+  }
+
+  @Test
+  fun `mustDelegateToParent keeps framework and shared-static packages on the parent`() {
+    // Framework / bootstrap packages must never be child-loaded.
+    assertTrue(UserClassLoaderHolder.mustDelegateToParent("java.lang.String"))
+    assertTrue(UserClassLoaderHolder.mustDelegateToParent("kotlin.Unit"))
+    assertTrue(UserClassLoaderHolder.mustDelegateToParent("androidx.compose.runtime.Composer"))
+    assertTrue(UserClassLoaderHolder.mustDelegateToParent("org.jetbrains.skia.Image"))
+    // Cross-classloader process-static bridges shared with the daemon.
+    assertTrue(
+      UserClassLoaderHolder.mustDelegateToParent(
+        "ee.schimke.composeai.daemon.bridge.SandboxPreviewOverridesBridge"
+      )
+    )
+    // The `previewOverride*` named-override runtime — PreviewOverrideController is a process-static
+    // the daemon seeds and the preview reads. If this were resolved child-first from a runtime jar
+    // on the bundle-backed live daemon's child URLs (ServeBundleDaemon / preview.coo.ee), the seed
+    // and the read would hit two different Class copies and every content override would no-op.
+    // Regression pin for that bug.
+    assertTrue(
+      UserClassLoaderHolder.mustDelegateToParent(
+        "ee.schimke.composeai.overrides.PreviewOverrideController"
+      )
+    )
+    assertTrue(
+      UserClassLoaderHolder.mustDelegateToParent(
+        "ee.schimke.composeai.overrides.ControllerPreviewOverrideHost"
+      )
+    )
+    // User preview classes (and unrelated app code) stay child-first so recompiles are picked up.
+    assertFalse(UserClassLoaderHolder.mustDelegateToParent("com.example.app.MyPreviewKt"))
+    assertFalse(
+      UserClassLoaderHolder.mustDelegateToParent("ee.schimke.composeai.preview.SomeUserPreview")
+    )
   }
 
   @Test

--- a/docs/daemon/CLASSLOADER.md
+++ b/docs/daemon/CLASSLOADER.md
@@ -131,6 +131,22 @@ queues are loaded once. Bridge classes resolve via the parent's parent
 (the system classloader), unaffected by the child. Verified with a
 unit test that the bridge queues stay shared across child swaps.
 
+The same "shared process-static" rule applies to the `previewOverride*`
+named-override runtime (`ee.schimke.composeai.overrides.*`, notably
+`PreviewOverrideController`): the daemon connector seeds it before the
+preview composes and the preview reads it back during composition, so
+the two must see one `Class<?>`. `UserClassLoaderHolder.mustDelegateToParent`
+forces both `ee.schimke.composeai.daemon.*` and
+`ee.schimke.composeai.overrides.*` to the parent even when the child's
+URLs carry them. This is load-bearing for the **bundle-backed live
+daemon** (`ServeBundleDaemon`, the engine behind `--catalogs`
+`liveBundle` / `preview.coo.ee`), where the bundle's resolved maven
+classpath — including `:data-preview-overrides-runtime` — is on the
+child loader's URLs; without the delegation the child would load a
+second copy of the controller, the daemon's seed and the preview's read
+would land on different statics, and every content override (e.g.
+`previewOverrideString("label", "Filled")`) would silently no-op.
+
 ### Compose compiler plugin's per-class metadata
 
 The Compose compiler emits per-`@Composable` synthetic metadata


### PR DESCRIPTION
The bundle-backed live daemon (ServeBundleDaemon, behind --catalogs
liveBundle / preview.coo.ee) puts the bundle's resolved maven classpath
— including :data-preview-overrides-runtime — on the disposable child
URLClassLoader. ChildFirstURLClassLoader resolved everything outside a
fixed framework allowlist child-first, so PreviewOverrideController was
loaded a second time from that jar: the daemon connector seeded one copy
while the preview read the other (empty) one, and every
previewOverrideString('label', 'Filled') silently returned its author
default — content overrides no-op'd on the public server.

Force ee.schimke.composeai.overrides.* to the parent loader (like the
already-delegated ee.schimke.composeai.daemon.*) so the seeded static is
a single shared Class across the daemon and the user preview. Extract the
delegation predicate as UserClassLoaderHolder.mustDelegateToParent and
pin it with a unit test.

Note: could not run ./gradlew ktfmt/tests in this sandbox (Gradle 9.x and
JDK 17 downloads are network-blocked); formatting matched by hand.