### PR TITLE
style: apply ktfmt (googleStyle) to doc-streamline follow-up files

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -290,8 +290,7 @@ fun main(args: Array<String>) {
   // `extensions/enable` to opt in to specific contributions.
   val renderOutputDir = System.getProperty(RenderEngine.OUTPUT_DIR_PROP)
   val composeTraceEnabled = renderOutputDir != null && PerfettoTraceDataProducer.enabled()
-  val dataRoot: File? =
-    renderOutputDir?.let { File(it).parentFile?.resolve("data") ?: File(it) }
+  val dataRoot: File? = renderOutputDir?.let { File(it).parentFile?.resolve("data") ?: File(it) }
   val extensions =
     ExtensionRegistry(
       buildList {
@@ -308,8 +307,7 @@ fun main(args: Array<String>) {
             id = "device/background",
             displayName = "Device background",
             dataProductRegistry = DeviceBackgroundDataProductRegistry(previewIndex = previewIndex),
-            previewExtensionDescriptors =
-              listOf(RenderPreviewExtension.deviceBackgroundDescriptor),
+            previewExtensionDescriptors = listOf(RenderPreviewExtension.deviceBackgroundDescriptor),
           )
         }
         tryAdd("render/trace") {
@@ -452,7 +450,8 @@ fun main(args: Array<String>) {
           // do-not-acquire singleton, like `SandboxPermissionsBridge`) carries the declarations
           // across the boundary: the controller forwards each declared knob as JSON, and
           // `PreviewOverridesDataProductRegistry.onRender` reads them back by previewId — so
-          // `data/fetch?kind=compose/overrides` works on Android, matching desktop. (Bundle carriage
+          // `data/fetch?kind=compose/overrides` works on Android, matching desktop. (Bundle
+          // carriage
           // never needed the bridge: `RobolectricRenderTest.writeOverridesSidecar` reads the
           // controller from *within* the same sandbox.)
           Extension(
@@ -568,8 +567,7 @@ fun main(args: Array<String>) {
                 id = "compose/trace",
                 displayName = "Compose Perfetto trace",
                 dataProductRegistry = PerfettoTraceDataProductRegistry(rootDir = dataRoot),
-                previewExtensionDescriptors =
-                  listOf(RenderPreviewExtension.composeTraceDescriptor),
+                previewExtensionDescriptors = listOf(RenderPreviewExtension.composeTraceDescriptor),
               )
             }
           }
@@ -708,20 +706,19 @@ fun main(args: Array<String>) {
 }
 
 /**
- * Adds [build]'s result to the list, catching `LinkageError`
- * (`NoClassDefFoundError` / `ClassNotFoundException`-shaped failures) so one missing connector
- * module's class does not crash the entire daemon process.
+ * Adds [build]'s result to the list, catching `LinkageError` (`NoClassDefFoundError` /
+ * `ClassNotFoundException`-shaped failures) so one missing connector module's class does not crash
+ * the entire daemon process.
  *
  * The classpath the daemon JVM launches with comes from
- * `samples/<module>/build/compose-previews/daemon-launch.json`, materialised by the gradle
- * plugin's `composePreviewDaemonStart` task. A stale descriptor produced before a connector
- * module was wired in — e.g. after pulling PR #1226's extraction of
- * `NavigationDataProductRegistry` into `:data-navigation-connector` without re-running the
- * bootstrap — leaves the registry class off the classpath but DaemonMain still references it
- * directly, exploding the process on the very first registration. With this helper the spawn
- * survives one missing connector: the affected extension is skipped with a stderr line naming
- * the kind, so the user sees which classpath entry is missing and which `extensions/list` chip
- * will disappear until the descriptor refreshes.
+ * `samples/<module>/build/compose-previews/daemon-launch.json`, materialised by the gradle plugin's
+ * `composePreviewDaemonStart` task. A stale descriptor produced before a connector module was wired
+ * in — e.g. after pulling PR #1226's extraction of `NavigationDataProductRegistry` into
+ * `:data-navigation-connector` without re-running the bootstrap — leaves the registry class off the
+ * classpath but DaemonMain still references it directly, exploding the process on the very first
+ * registration. With this helper the spawn survives one missing connector: the affected extension
+ * is skipped with a stderr line naming the kind, so the user sees which classpath entry is missing
+ * and which `extensions/list` chip will disappear until the descriptor refreshes.
  */
 private inline fun MutableList<Extension>.tryAdd(label: String, build: () -> Extension) {
   try {

--- a/daemon/bta-host/src/test/kotlin/ee/schimke/composeai/daemon/bta/BtaCompilerIncrementalTest.kt
+++ b/daemon/bta-host/src/test/kotlin/ee/schimke/composeai/daemon/bta/BtaCompilerIncrementalTest.kt
@@ -25,8 +25,8 @@ import org.junit.rules.TemporaryFolder
  *
  * - That IC was faster than non-IC for this fixture. The fixture is too small for BTA's
  *   classpath-snapshot reuse to dominate; per-compile cost is mostly compiler-frontend init, which
- *   is amortised across calls regardless of IC. Stage-2 promotion criteria measure that against
- *   a real consumer module.
+ *   is amortised across calls regardless of IC. Stage-2 promotion criteria measure that against a
+ *   real consumer module.
  * - That only the modified source was recompiled. The current `JvmCompilationOperation.compile` API
  *   doesn't surface the recompile-set as a structured return — KGP infers it from the IC working
  *   directory's `caches-jvm/inputs` / `compile-iteration` files, which is a more involved probe

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -202,10 +202,10 @@ class JsonRpcServer(
   /**
    * Experimental gate for `history/diff`. The metadata-mode handler exists (H3) but the broader
    * history surface — pixel mode (H5), git-ref write modes, LFS/squash-GC handling — is incomplete
-   *. For 1.0 the dispatcher returns method-not-found
-   * unless this flag is on, so consumers don't accidentally code against an interface that's still
-   * moving. Defaults to the [HISTORY_DIFF_EXPERIMENTAL_PROP] sysprop (off in production); tests
-   * that assert on the diff handler pass `historyDiffExperimental = true` explicitly.
+   * . For 1.0 the dispatcher returns method-not-found unless this flag is on, so consumers don't
+   * accidentally code against an interface that's still moving. Defaults to the
+   * [HISTORY_DIFF_EXPERIMENTAL_PROP] sysprop (off in production); tests that assert on the diff
+   * handler pass `historyDiffExperimental = true` explicitly.
    *
    * TODO(1.1): land H5 + the remaining roadmap items, flip the default to on, and remove this
    *   parameter.
@@ -246,22 +246,22 @@ class JsonRpcServer(
       ?: DEFAULT_DATA_FETCH_RERENDER_BUDGET_MS,
   private val interactiveFrameIntervalMs: Long = INTERACTIVE_FRAME_INTERVAL_MS,
   /**
-   * Stage-2 in-process compile. When non-null, `compileSources` requests
-   * dispatch through this service; on `Ok` we swap the user classloader the same way
-   * `fileChanged({kind:source})` does. When null (fake-mode harness scenarios, integration tests
-   * that don't opt in, daemons whose launch descriptor lacks `btaCompilerClasspath`) the handler
-   * returns `result=fallback` so the editor falls back to stage 1 / 0 without surface churn.
+   * Stage-2 in-process compile. When non-null, `compileSources` requests dispatch through this
+   * service; on `Ok` we swap the user classloader the same way `fileChanged({kind:source})` does.
+   * When null (fake-mode harness scenarios, integration tests that don't opt in, daemons whose
+   * launch descriptor lacks `btaCompilerClasspath`) the handler returns `result=fallback` so the
+   * editor falls back to stage 1 / 0 without surface churn.
    */
   private val btaCompileService: ee.schimke.composeai.daemon.bta.BtaCompileService? = null,
   private val fileSystem: FileSystem = SystemFileSystem,
   private val onExit: (Int) -> Unit = { code -> System.exit(code) },
   /**
    * Factory for the native XR render server (see the "XR render service" section in
-   * `protocol/Messages.kt`). When non-null the daemon
-   * advertises `capabilities.xr` and serves `xr/start` / `xr/updatePanels` / `xr/stop`, spawning
-   * one `xr-composite --serve` child per session. When null (the in-process integration tests,
-   * fake-mode harness, daemons whose host has no XR binary) the `xr/…` methods reply
-   * `MethodNotFound` — the one-shot composite path is unaffected.
+   * `protocol/Messages.kt`). When non-null the daemon advertises `capabilities.xr` and serves
+   * `xr/start` / `xr/updatePanels` / `xr/stop`, spawning one `xr-composite --serve` child per
+   * session. When null (the in-process integration tests, fake-mode harness, daemons whose host has
+   * no XR binary) the `xr/…` methods reply `MethodNotFound` — the one-shot composite path is
+   * unaffected.
    */
   private val xrServerFactory: XrRenderServerFactory? = null,
 ) {
@@ -487,9 +487,9 @@ class JsonRpcServer(
   private val streamSessions = ConcurrentHashMap<String, InteractiveSession>()
 
   /**
-   * Held native XR render sessions, one per `frameStreamId`, present only
-   * when [xrServerFactory] was wired. The daemon's `xr/…` handlers drive it and feed each returned
-   * frame out as a `streamFrame` notification.
+   * Held native XR render sessions, one per `frameStreamId`, present only when [xrServerFactory]
+   * was wired. The daemon's `xr/…` handlers drive it and feed each returned frame out as a
+   * `streamFrame` notification.
    */
   private val xrSessions: XrSessionManager? = xrServerFactory?.let { XrSessionManager(it) }
 

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/bta/DefaultBtaCompileService.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/bta/DefaultBtaCompileService.kt
@@ -19,12 +19,11 @@ import org.jetbrains.kotlin.buildtools.api.arguments.CompilerPluginOption
  * Three things this adapter owns that the underlying [BtaCompileSession] doesn't:
  *
  * 1. **Eligibility gate.** A non-null [ineligibilityReason] means the consumer's module isn't a
- *    stage-2 candidate (KSP/KAPT detected, AGP variant without resource-jar plumbing yet, etc.;
- *    the gradle plugin's `detectStageTwoIneligibility` is the source of truth for the
- *    predicate). Every compile call short-circuits to
- *    [BtaCompileService.Outcome.Fallback] with that reason verbatim. The gradle plugin decides the
- *    predicate at daemon-bootstrap time; the daemon never re-evaluates (Tier-1 dirty recycles the
- *    whole daemon, and with it this service).
+ *    stage-2 candidate (KSP/KAPT detected, AGP variant without resource-jar plumbing yet, etc.; the
+ *    gradle plugin's `detectStageTwoIneligibility` is the source of truth for the predicate). Every
+ *    compile call short-circuits to [BtaCompileService.Outcome.Fallback] with that reason verbatim.
+ *    The gradle plugin decides the predicate at daemon-bootstrap time; the daemon never
+ *    re-evaluates (Tier-1 dirty recycles the whole daemon, and with it this service).
  *
  * 2. **`SourceChangeSet` → BTA `SourcesChanges` translation.** Editor-supplied known dirty sets
  *    become `SourcesChanges.Known`; null becomes `SourcesChanges.ToBeCalculated` (BTA inspects file
@@ -206,11 +205,10 @@ class DefaultBtaCompileService(
      * `sourceInformation=true` option.
      *
      * The option is load-bearing, not cosmetic. KGP enables `sourceInformation` by default and the
-     * markers it emits (a ~236-byte delta per compiled file) are read by Compose
-     * Inspector / Live Literals / recomposition tooling. Without it, stage-2-emitted classes drift
-     * from the Gradle-emitted classes the daemon's hot-swap diffs against. Returns an empty list when
-     * no plugin
-     * JARs were resolved (plain Kotlin/JVM module with no Compose plugin on the classpath).
+     * markers it emits (a ~236-byte delta per compiled file) are read by Compose Inspector / Live
+     * Literals / recomposition tooling. Without it, stage-2-emitted classes drift from the
+     * Gradle-emitted classes the daemon's hot-swap diffs against. Returns an empty list when no
+     * plugin JARs were resolved (plain Kotlin/JVM module with no Compose plugin on the classpath).
      */
     internal fun composeCompilerPlugins(pluginJars: List<Path>): List<CompilerPlugin> =
       if (pluginJars.isEmpty()) emptyList()

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -172,10 +172,10 @@ data class ServerCapabilities(
   val recording: Boolean = false,
   /**
    * `true` when the daemon can front the native XR render server (`xr-composite --serve`) — see the
-   * "XR render service" section below. `xr/start` opens a held spatial-scene session, `xr/updatePanels`
-   * mutates it per-frame, and frames arrive as `streamFrame` notifications. `false` (the default
-   * for daemons without the native binary, or that pre-date the feature) means the `xr/…` methods
-   * reply `MethodNotFound`; clients fall back to the one-shot composite still.
+   * "XR render service" section below. `xr/start` opens a held spatial-scene session,
+   * `xr/updatePanels` mutates it per-frame, and frames arrive as `streamFrame` notifications.
+   * `false` (the default for daemons without the native binary, or that pre-date the feature) means
+   * the `xr/…` methods reply `MethodNotFound`; clients fall back to the one-shot composite still.
    */
   val xr: Boolean = false,
   /**
@@ -2479,18 +2479,22 @@ data class StreamFrameParams(
 
 // ---- XR render service --------------------------------------------------------------------------
 //
-// The daemon fronts the native `xr-composite --serve` render server so clients only ever talk to the
+// The daemon fronts the native `xr-composite --serve` render server so clients only ever talk to
+// the
 // daemon. `xr-composite --serve` is a long-lived C++ process speaking this same JSON-RPC +
-// LSP-style `Content-Length` framing over stdio; it holds Filament engine/scene state across frames.
+// LSP-style `Content-Length` framing over stdio; it holds Filament engine/scene state across
+// frames.
 // The daemon spawns and multiplexes it: one child fronting many held sessions keyed by
 // `frameStreamId`. `capabilities.xr` (see [ServerCapabilities.xr]) advertises when the daemon was
 // wired with the native binary; when it wasn't, the `xr/…` methods below reply `MethodNotFound` and
 // clients fall back to the one-shot composite still.
 //
-// Lifecycle: `xr/start` opens a session and mints a `frameStreamId`; `xr/updatePanels` mutates panel
+// Lifecycle: `xr/start` opens a session and mints a `frameStreamId`; `xr/updatePanels` mutates
+// panel
 // textures/poses per-frame; `xr/stop` tears the session down. Rendered frames flow back out as
 // `streamFrame` notifications — the same wire shape the interactive/stream surfaces use, so XR
-// reuses the `composestream/1` frame plane wholesale rather than inventing a new one. `xr/structure`
+// reuses the `composestream/1` frame plane wholesale rather than inventing a new one.
+// `xr/structure`
 // returns the held scene's panel tree + poses inline as JSON (mirrors `a11y/hierarchy`).
 
 /**

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/bta/DiagnosticCollectorTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/bta/DiagnosticCollectorTest.kt
@@ -11,8 +11,7 @@ import org.junit.Test
 
 /**
  * Unit tests for [DiagnosticCollector]. Covers the line-shape parser against the BTA diagnostic
- * formats the spike captured in real runs, plus the delegation
- * contract for non-error events.
+ * formats the spike captured in real runs, plus the delegation contract for non-error events.
  *
  * `KotlinLogger.error(msg, throwable)` is the only call that feeds the diagnostic list; everything
  * else (`info`, `debug`, `lifecycle`, `warn`) passes through to the optional delegate logger

--- a/gradle-plugin/daemon-launch-builder/src/main/kotlin/ee/schimke/composeai/daemonlaunch/DaemonClasspathDescriptor.kt
+++ b/gradle-plugin/daemon-launch-builder/src/main/kotlin/ee/schimke/composeai/daemonlaunch/DaemonClasspathDescriptor.kt
@@ -72,12 +72,12 @@ public data class DaemonClasspathDescriptor(
    */
   public val manifestPath: String,
   /**
-   * Stage-2 in-process compile config. When non-null the
-   * daemon constructs a `DefaultBtaCompileService` from these fields at startup and
-   * `JsonRpcServer.compileSources` dispatches through it. `null` (the default) means the consumer
-   * hasn't opted in via `composePreview { daemon { compileInProcess = true } }` and the daemon's
-   * `compileSources` handler returns `result=fallback` for every call — the editor falls back to
-   * stage 1 (`gradle --continuous`) or stage 0 (one-shot Gradle).
+   * Stage-2 in-process compile config. When non-null the daemon constructs a
+   * `DefaultBtaCompileService` from these fields at startup and `JsonRpcServer.compileSources`
+   * dispatches through it. `null` (the default) means the consumer hasn't opted in via
+   * `composePreview { daemon { compileInProcess = true } }` and the daemon's `compileSources`
+   * handler returns `result=fallback` for every call — the editor falls back to stage 1 (`gradle
+   * --continuous`) or stage 0 (one-shot Gradle).
    *
    * Schema-version bumped to 2 when this field landed (the v1 reader in the VS Code extension fails
    * the descriptor on any unknown field, even null-defaulted ones, so adding the field IS a
@@ -87,13 +87,13 @@ public data class DaemonClasspathDescriptor(
 )
 
 /**
- * Stage-2 in-process compile config. Populated by the
- * gradle plugin's `DaemonBootstrapTask` whenever the variant wiring resolved the required inputs
- * (BTA-impl classpath, module name, output dir, IC dir). The daemon reads these into a
- * `DefaultBtaCompileService` once at startup but only loads BTA's classloader lazily — the editor
- * has to call `compileSources` to trigger that, and the call is itself gated by the VS Code
- * workspace setting `composePreview.daemon.compileInProcess`. So a `non-null btaCompile` block in
- * the descriptor costs nothing at the daemon level unless the editor actually opts in.
+ * Stage-2 in-process compile config. Populated by the gradle plugin's `DaemonBootstrapTask`
+ * whenever the variant wiring resolved the required inputs (BTA-impl classpath, module name, output
+ * dir, IC dir). The daemon reads these into a `DefaultBtaCompileService` once at startup but only
+ * loads BTA's classloader lazily — the editor has to call `compileSources` to trigger that, and the
+ * call is itself gated by the VS Code workspace setting `composePreview.daemon.compileInProcess`.
+ * So a `non-null btaCompile` block in the descriptor costs nothing at the daemon level unless the
+ * editor actually opts in.
  */
 @Serializable
 public data class BtaCompileConfig(
@@ -138,8 +138,7 @@ public data class BtaCompileConfig(
   /**
    * Daemon-warm-time decision: non-null means this module is NOT a stage-2 candidate (typically
    * because KSP / KAPT / annotationProcessor is on the classpath). `JsonRpcServer.compileSources`
-   * returns `result=fallback` with this reason
-   * verbatim. `null` means eligible — BTA actually runs.
+   * returns `result=fallback` with this reason verbatim. `null` means eligible — BTA actually runs.
    */
   public val ineligibilityReason: String? = null,
 )

--- a/renderers/xr/src/main/kotlin/ee/schimke/composeai/renderer/xr/SubspaceSceneRecorder.kt
+++ b/renderers/xr/src/main/kotlin/ee/schimke/composeai/renderer/xr/SubspaceSceneRecorder.kt
@@ -13,8 +13,8 @@ import androidx.xr.compose.testing.onSubspaceNodeWithTag
 import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsNode
 import ee.schimke.composeai.xr.OrbitCamera
 import ee.schimke.composeai.xr.Quat
-import ee.schimke.composeai.xr.SizeDp
 import ee.schimke.composeai.xr.Size3dDp
+import ee.schimke.composeai.xr.SizeDp
 import ee.schimke.composeai.xr.SpatialPanel
 import ee.schimke.composeai.xr.SpatialPose
 import ee.schimke.composeai.xr.SpatialScene
@@ -30,8 +30,8 @@ import ee.schimke.composeai.xr.Vec3
  * `SubspaceLayoutPoseTest` for a worked example).
  *
  * This reads each named panel's `poseInRoot` and `size` from the public spatial-semantics tree and
- * maps them to the [SpatialScene] wire shape. It also recovers each panel's live content [View] (see
- * [recordAllWithViews]) so the texture pass ([SubspaceSceneWriter.captureViewTextures]) can
+ * maps them to the [SpatialScene] wire shape. It also recovers each panel's live content [View]
+ * (see [recordAllWithViews]) so the texture pass ([SubspaceSceneWriter.captureViewTextures]) can
  * rasterise the real panel content into the `<tag>.png` the scene references.
  *
  * The caller owns the composition: it must enable the `android.software.xr.api.spatial` system
@@ -52,11 +52,10 @@ public object SubspaceSceneRecorder {
     panelTags: List<String>,
     previewId: String? = null,
   ): SpatialScene {
-    val panels =
-      panelTags.map { tag ->
-        val node = rule.onSubspaceNodeWithTag(tag).fetchSemanticsNode("no subspace node '$tag'")
-        panelFrom(node, id = tag, parentId = null)
-      }
+    val panels = panelTags.map { tag ->
+      val node = rule.onSubspaceNodeWithTag(tag).fetchSemanticsNode("no subspace node '$tag'")
+      panelFrom(node, id = tag, parentId = null)
+    }
     return SpatialScene(previewId = previewId, camera = defaultCamera(panels), panels = panels)
   }
 
@@ -124,16 +123,16 @@ public object SubspaceSceneRecorder {
   }
 
   /**
-   * Records the unified **3D-over-2D** [SpatialSemanticsTree]: the subspace layout (a `subspaceRoot`
-   * with one `panel` child per tagged `SpatialPanel`, each carrying the recovered pose/size) with
-   * every panel's 2D content tree attached as [SpatialSemanticsNode.panelContent].
+   * Records the unified **3D-over-2D** [SpatialSemanticsTree]: the subspace layout (a
+   * `subspaceRoot` with one `panel` child per tagged `SpatialPanel`, each carrying the recovered
+   * pose/size) with every panel's 2D content tree attached as [SpatialSemanticsNode.panelContent].
    *
    * The 2D tree is recovered from each panel's live content [View]: a `SpatialPanel` composes its
    * content into a view whose Compose root implements [RootForTest], so its
    * `semanticsOwner.unmergedRootSemanticsNode` is the ordinary 2D semantics root (proven by
    * `SubspacePanelSemanticsSpikeTest`). That [SemanticsNode] is handed to [projectSemantics] — the
-   * same projection `compose/semantics` and the wireframe use, injected rather than imported so this
-   * renderer module stays free of the daemon-side connector that owns it (the daemon passes
+   * same projection `compose/semantics` and the wireframe use, injected rather than imported so
+   * this renderer module stays free of the daemon-side connector that owns it (the daemon passes
    * `ComposeSemanticsDataProducer.buildPayload(it).root`). A panel whose view or semantics can't be
    * recovered simply gets a null [SpatialSemanticsNode.panelContent] — its geometry still lands, so
    * one unreadable panel degrades to a face without an overlay rather than failing the tree.
@@ -166,7 +165,8 @@ public object SubspaceSceneRecorder {
    * The degenerate **non-XR** case: an ordinary preview is a single `panel` at identity pose whose
    * [SpatialSemanticsNode.panelContent] is the whole 2D tree. Pure (no subspace / Robolectric), so
    * the daemon's normal 2D render path can wrap its `compose/semantics` payload into the same tree
-   * shape the XR path produces — making the per-panel wireframe the leaf renderer for every preview.
+   * shape the XR path produces — making the per-panel wireframe the leaf renderer for every
+   * preview.
    */
   public fun singlePanelTree(
     content: ComposeSemanticsNode,
@@ -181,7 +181,9 @@ public object SubspaceSceneRecorder {
       panelId = panelId,
     )
 
-  /** Wraps [panelNodes] under a `subspaceRoot` at identity pose (poses on children are absolute). */
+  /**
+   * Wraps [panelNodes] under a `subspaceRoot` at identity pose (poses on children are absolute).
+   */
   private fun subspaceRootOf(panelNodes: List<SpatialSemanticsNode>): SpatialSemanticsNode =
     SpatialSemanticsTrees.subspaceRoot(panelNodes)
 
@@ -192,7 +194,9 @@ public object SubspaceSceneRecorder {
     if (this is RootForTest) return this
     if (this is ViewGroup) {
       for (i in 0 until childCount) {
-        getChildAt(i).findRootForTest()?.let { return it }
+        getChildAt(i).findRootForTest()?.let {
+          return it
+        }
       }
     }
     return null
@@ -201,12 +205,12 @@ public object SubspaceSceneRecorder {
   /**
    * Recovers the content [View] hosted by a panel node. A `SpatialPanel`'s
    * [SubspaceSemanticsInfo.getSemanticsEntity] is the public `androidx.xr.scenecore.PanelEntity`,
-   * whose `rtEntity` is the runtime panel — under the fake XR runtime that's a
-   * `FakePanelEntity`, which holds the `android.view.View` the panel composed. Both the
-   * `getRtEntity$scenecore` bridge and `getView` are reached reflectively so this module compiles
-   * without the scenecore-testing fakes on its main classpath (they're a render-time dependency,
-   * mirroring how the node enumeration reaches `compose-testing` internals); the recorder tests are
-   * the canary if either shifts.
+   * whose `rtEntity` is the runtime panel — under the fake XR runtime that's a `FakePanelEntity`,
+   * which holds the `android.view.View` the panel composed. Both the `getRtEntity$scenecore` bridge
+   * and `getView` are reached reflectively so this module compiles without the scenecore-testing
+   * fakes on its main classpath (they're a render-time dependency, mirroring how the node
+   * enumeration reaches `compose-testing` internals); the recorder tests are the canary if either
+   * shifts.
    */
   private fun contentView(node: SubspaceSemanticsInfo): View? {
     val entity: Any = node.semanticsEntity ?: return null
@@ -222,7 +226,8 @@ public object SubspaceSceneRecorder {
     rule: AndroidComposeTestRule<*, ComponentActivity>
   ): List<SubspaceSemanticsInfo> {
     // alpha15 made SubspaceTestContext's constructor `internal` (it's still JVM-public); build it
-    // reflectively, matching how the enumeration below reaches `getAllSemanticsNodes$compose_testing`.
+    // reflectively, matching how the enumeration below reaches
+    // `getAllSemanticsNodes$compose_testing`.
     val context =
       Class.forName("androidx.xr.compose.testing.SubspaceTestContext")
         .getDeclaredConstructor(AndroidComposeTestRule::class.java)
@@ -235,7 +240,7 @@ public object SubspaceSceneRecorder {
           Boolean::class.javaPrimitiveType,
         )
       method.isAccessible = true
-      (method.invoke(context, /* useUnmergedTree = */ true) as Iterable<SubspaceSemanticsInfo>)
+      (method.invoke(context, /* useUnmergedTree= */ true) as Iterable<SubspaceSemanticsInfo>)
         .toList()
     } catch (e: ReflectiveOperationException) {
       throw IllegalStateException(
@@ -290,11 +295,26 @@ public object SubspaceSceneRecorder {
    */
   internal fun defaultCamera(panels: List<SpatialPanel>): OrbitCamera {
     if (panels.isEmpty()) {
-      return OrbitCamera(target = Vec3(0.0, 0.0, 0.0), distance = 1200.0, yawDeg = 0.0, pitchDeg = -6.0)
+      return OrbitCamera(
+        target = Vec3(0.0, 0.0, 0.0),
+        distance = 1200.0,
+        yawDeg = 0.0,
+        pitchDeg = -6.0,
+      )
     }
     // Combined axis-aligned bounds of every panel (centre ± half-size on each axis).
-    val xs = panels.flatMap { listOf(it.poseInRoot.translation.x - it.sizeDp.width / 2.0, it.poseInRoot.translation.x + it.sizeDp.width / 2.0) }
-    val ys = panels.flatMap { listOf(it.poseInRoot.translation.y - it.sizeDp.height / 2.0, it.poseInRoot.translation.y + it.sizeDp.height / 2.0) }
+    val xs = panels.flatMap {
+      listOf(
+        it.poseInRoot.translation.x - it.sizeDp.width / 2.0,
+        it.poseInRoot.translation.x + it.sizeDp.width / 2.0,
+      )
+    }
+    val ys = panels.flatMap {
+      listOf(
+        it.poseInRoot.translation.y - it.sizeDp.height / 2.0,
+        it.poseInRoot.translation.y + it.sizeDp.height / 2.0,
+      )
+    }
     val boundsW = xs.max() - xs.min()
     val boundsH = ys.max() - ys.min()
     val centreX = (xs.min() + xs.max()) / 2.0

--- a/samples/xr-glimmer/src/main/kotlin/com/example/samplexrglimmer/GlimmerFocusStatePreviews.kt
+++ b/samples/xr-glimmer/src/main/kotlin/com/example/samplexrglimmer/GlimmerFocusStatePreviews.kt
@@ -17,40 +17,40 @@ import androidx.xr.glimmer.Text
 import ee.schimke.composeai.preview.FocusedPreview
 
 /**
- * Sample previews replicating two of the three visual states the Jetpack Compose Glimmer
- * focus documentation calls out — `developer.android.com/develop/xr/jetpack-xr-sdk/jetpack-compose-glimmer/focus`.
+ * Sample previews replicating two of the three visual states the Jetpack Compose Glimmer focus
+ * documentation calls out —
+ * `developer.android.com/develop/xr/jetpack-xr-sdk/jetpack-compose-glimmer/focus`.
  *
- * Each capture is driven by *real* interactions through the preview-rendering pipeline:
- * `@Preview` for the default-state capture, `@FocusedPreview` for the focused-state capture
- * (which the renderer translates into a real `FocusManager.moveFocus(Enter)` + `moveFocus(Next)`
- * call under `LocalInputModeManager provides KeyboardInputModeManager`, mirroring what a Glasses
- * device's focus traversal does). Nothing here forges interaction events onto a
- * `MutableInteractionSource` to fake a visual state — Glimmer's `Modifier.surface` ignores
- * `FocusInteraction.Focus` emitted to a held source and only renders its focus border for a node
- * the focus system actually owns. A faked-focus capture matches a no-focus capture byte-for-byte
- * and is worse than useless.
+ * Each capture is driven by *real* interactions through the preview-rendering pipeline: `@Preview`
+ * for the default-state capture, `@FocusedPreview` for the focused-state capture (which the
+ * renderer translates into a real `FocusManager.moveFocus(Enter)` + `moveFocus(Next)` call under
+ * `LocalInputModeManager provides KeyboardInputModeManager`, mirroring what a Glasses device's
+ * focus traversal does). Nothing here forges interaction events onto a `MutableInteractionSource`
+ * to fake a visual state — Glimmer's `Modifier.surface` ignores `FocusInteraction.Focus` emitted to
+ * a held source and only renders its focus border for a node the focus system actually owns. A
+ * faked-focus capture matches a no-focus capture byte-for-byte and is worse than useless.
  *
  * **States covered here:**
  *
- *  1. **Default** ([GlimmerListItemDefault]) — plain `@Preview`, no focus annotation. A reviewer
- *     reading the captured PNG sees the un-styled `ListItem` baseline: surface fill from
- *     `GlimmerTheme.colors.surface`, default border width, no focused-state overlays.
+ * 1. **Default** ([GlimmerListItemDefault]) — plain `@Preview`, no focus annotation. A reviewer
+ *    reading the captured PNG sees the un-styled `ListItem` baseline: surface fill from
+ *    `GlimmerTheme.colors.surface`, default border width, no focused-state overlays.
  *
- *  2. **Focused** ([GlimmerListItemFocused]) — `@Preview` + `@FocusedPreview(indices = [0])`.
- *     The renderer's focus walk lands real focus on the single `ListItem`; Glimmer's surface draws
- *     its focused-state border (the doc's "border width increased to communicate focus"). No
- *     interaction-source fakery — Glimmer's own focusable wiring is what raises the state.
+ * 2. **Focused** ([GlimmerListItemFocused]) — `@Preview` + `@FocusedPreview(indices = [0])`. The
+ *    renderer's focus walk lands real focus on the single `ListItem`; Glimmer's surface draws its
+ *    focused-state border (the doc's "border width increased to communicate focus"). No
+ *    interaction-source fakery — Glimmer's own focusable wiring is what raises the state.
  *
- *  3. **Focused + Pressed** — *not captured here.* Reaching this state requires a synthetic
- *     down-event landing on the focused item (Glimmer's pressed-overlay listens to
- *     `interactionSource.collectIsPressedAsState()` against its real source, and Robolectric's
- *     renderer has no touchpad). The clean path is to extend `@FocusedPreview` with a `pressed`
- *     parameter that the renderer translates into `rule.onAllNodes(hasFocus()).performTouchInput
- *     { down(center) }` after the focus walk settles — tracked as a follow-up, out of scope for
- *     this PR.
+ * 3. **Focused + Pressed** — *not captured here.* Reaching this state requires a synthetic
+ *    down-event landing on the focused item (Glimmer's pressed-overlay listens to
+ *    `interactionSource.collectIsPressedAsState()` against its real source, and Robolectric's
+ *    renderer has no touchpad). The clean path is to extend `@FocusedPreview` with a `pressed`
+ *    parameter that the renderer translates into `rule.onAllNodes(hasFocus()).performTouchInput {
+ *    down(center) }` after the focus walk settles — tracked as a follow-up, out of scope for this
+ *    PR.
  *
- * **focusGroup + order control — investigated, not shipped.** The Glimmer doc's documented
- * pattern —
+ * **focusGroup + order control — investigated, not shipped.** The Glimmer doc's documented pattern
+ * —
  *
  * ```
  * Modifier.focusProperties { onEnter = { initialFocus.requestFocus(); cancelFocusChange() } }.focusGroup()
@@ -61,20 +61,20 @@ import ee.schimke.composeai.preview.FocusedPreview
  * `moveFocus(Enter)` ran, but the focus ring rendered on the *last* `ListItem` rather than the
  * `initialFocus`-requested middle one. Added a `println` inside `onEnter` to verify dispatch — it
  * didn't fire at all, meaning `focusProperties.onEnter` wasn't called by Compose 1.11's
- * `focusGroup()` in this setup despite matching the official sample's modifier order. Real
- * upstream investigation; the demo is parked until either Compose's behavior changes or a
- * renderer-side workaround surfaces.
+ * `focusGroup()` in this setup despite matching the official sample's modifier order. Real upstream
+ * investigation; the demo is parked until either Compose's behavior changes or a renderer-side
+ * workaround surfaces.
  *
- * The plumbing that *would* support a working `focusGroup` demo did land alongside this PR
- * for forward-compatibility:
+ * The plumbing that *would* support a working `focusGroup` demo did land alongside this PR for
+ * forward-compatibility:
  *
- *  - New `@FocusedPreview(enterPlacesFocus = …)` boolean parameter — opt-in for previews whose
- *    root carries the `focusGroup` + `onEnter` pattern. Tells the renderer's focus walk to skip
- *    its historical `+1 Next` compensation after `moveFocus(Enter)`, because in that pattern
- *    Enter is supposed to place focus directly on the chosen child.
- *  - Wired annotation → discovery (`PreviewDiscovery.readFocusSteps`) → wire-shape
- *    (`FocusOverride.enterPlacesFocus`) → connector
- *    (`:data-focus-connector`'s `FocusOverrideExtension`).
+ * - New `@FocusedPreview(enterPlacesFocus = …)` boolean parameter — opt-in for previews whose root
+ *   carries the `focusGroup` + `onEnter` pattern. Tells the renderer's focus walk to skip its
+ *   historical `+1 Next` compensation after `moveFocus(Enter)`, because in that pattern Enter is
+ *   supposed to place focus directly on the chosen child.
+ * - Wired annotation → discovery (`PreviewDiscovery.readFocusSteps`) → wire-shape
+ *   (`FocusOverride.enterPlacesFocus`) → connector (`:data-focus-connector`'s
+ *   `FocusOverrideExtension`).
  *
  * When the upstream `onEnter` dispatch is unblocked, the demo composable + a single
  * `@FocusedPreview(indices = [0], enterPlacesFocus = true)` annotation will produce the doc's
@@ -83,32 +83,32 @@ import ee.schimke.composeai.preview.FocusedPreview
  * **`ComposeUiFlags.isInitialFocusOnFocusableAvailable` is set per-preview, Glimmer-sample-only.**
  * The Glimmer doc calls this a *temporary requirement* for real Glasses activities — set in
  * `Activity.onCreate` before `super.onCreate(savedInstanceState)` so the system auto-focuses the
- * first focusable on screen load. The flag is a process-wide `var` on `androidx.compose.ui.ComposeUiFlags`,
- * so naively flipping it once in a class-load static initializer would leak across previews
- * within this module (Robolectric shares one JVM per `:test` task), and a renderer-wide setting
- * in `RobolectricRenderTest` would leak across other modules' previews (notification, glance,
- * splash, Wear) — none of which expect auto-focus on the first focusable.
+ * first focusable on screen load. The flag is a process-wide `var` on
+ * `androidx.compose.ui.ComposeUiFlags`, so naively flipping it once in a class-load static
+ * initializer would leak across previews within this module (Robolectric shares one JVM per `:test`
+ * task), and a renderer-wide setting in `RobolectricRenderTest` would leak across other modules'
+ * previews (notification, glance, splash, Wear) — none of which expect auto-focus on the first
+ * focusable.
  *
  * Resolution: each Glimmer preview here assigns the flag explicitly at the top of its composable
  * body, before any focusable composes. Reads happen during `focusable()` modifier creation
  * downstream, so the value the composable wrote takes effect for this render. Different previews
- * can therefore exercise different flag states deterministically without coupling to JVM-load
- * order or test ordering — [GlimmerListItemDefault] runs with the flag *off* to capture the
- * "nothing has focus" baseline, [GlimmerListItemFocused] runs with the flag *on* mirroring the
- * on-device experience. The `@FocusedPreview(indices = [0])` walk on [GlimmerListItemFocused]
- * then still works whether the flag was on or off — explicit focus drive overrides auto-focus —
- * but with the flag on it documents that on-device Glimmer apps see the same focused-on-load
- * behavior the renderer captures.
+ * can therefore exercise different flag states deterministically without coupling to JVM-load order
+ * or test ordering — [GlimmerListItemDefault] runs with the flag *off* to capture the "nothing has
+ * focus" baseline, [GlimmerListItemFocused] runs with the flag *on* mirroring the on-device
+ * experience. The `@FocusedPreview(indices = [0])` walk on [GlimmerListItemFocused] then still
+ * works whether the flag was on or off — explicit focus drive overrides auto-focus — but with the
+ * flag on it documents that on-device Glimmer apps see the same focused-on-load behavior the
+ * renderer captures.
  *
  * **Indirect-pointer interaction** — out of scope for a static `@Preview`. Glimmer's
  * `Modifier.onIndirectPointerGesture(enabled, onSwipeForward, onSwipeBackward, onClick)`
- * (`developer.android.com/develop/xr/jetpack-xr-sdk/jetpack-compose-glimmer/indirect-pointer`)
- * only fires from real Glasses-touchpad input, which Robolectric can't synthesise. The renderer's
+ * (`developer.android.com/develop/xr/jetpack-xr-sdk/jetpack-compose-glimmer/indirect-pointer`) only
+ * fires from real Glasses-touchpad input, which Robolectric can't synthesise. The renderer's
  * focus-walk path (`@FocusedPreview`) already covers the *effect* of a `onSwipeForward` /
  * `onSwipeBackward` gesture on the focused composable, which is the part previews can capture.
  * Annotating which gesture drove each step would be a follow-up on top of that focus walk.
  */
-
 @Preview(
   name = "Glimmer · Default",
   device = AI_GLASSES_DEVICE_SPEC,

--- a/samples/xr-glimmer/src/main/kotlin/com/example/samplexrglimmer/GlimmerInteractiveMenuPreviews.kt
+++ b/samples/xr-glimmer/src/main/kotlin/com/example/samplexrglimmer/GlimmerInteractiveMenuPreviews.kt
@@ -33,31 +33,28 @@ import ee.schimke.composeai.preview.FocusedPreview
 /**
  * Interactive XR navigation demo — a Glimmer menu captured as an animated GIF per environment
  * backdrop (one per planned `:data-glimmer-environment-connector` env). Each frame shows focus on a
- * different menu item;
- * the four-frame focus walk is the entire navigation signal.
+ * different menu item; the four-frame focus walk is the entire navigation signal.
  *
- * Glimmer's display model is **additive**: pure black pixels render as 100% transparent on-
- * device, lit pixels add light to whatever the wearer is looking at. The env compositor
- * module the design names will eventually be a post-render step, but until it exists the
- * sample paints both pieces inline:
+ * Glimmer's display model is **additive**: pure black pixels render as 100% transparent on- device,
+ * lit pixels add light to whatever the wearer is looking at. The env compositor module the design
+ * names will eventually be a post-render step, but until it exists the sample paints both pieces
+ * inline:
  *
- *  1. The env backdrop ([EnvironmentBackdrop]) — a real photo for Dark / Busy /
- *     VeniceCanalCats and a procedurally-drawn Compose `Canvas` scene for Light, opaque RGB
- *     in both cases.
- *  2. The Glimmer UI on top — `GlimmerTheme` with `ListItem`s drawn on a `Color.Black`
- *     additive-zero base and composited with `BlendMode.Plus`, so the display *adds* its lit
- *     pixels onto the env exactly as on-device: black contributes nothing (the env shows
- *     through a `ListItem` untouched), the dark Glimmer surface tint brightens the env where
- *     items sit, and white text / focus borders add full light. When
- *     `:data-glimmer-environment-connector` lands the per-env [EnvironmentBackdrop] moves into
- *     the connector and the sample reverts to plain additive-RGB captures (Encoding B) on a
- *     black background — the `ADD`-blend then happens post-render on the captured PNG instead
- *     of inline.
+ * 1. The env backdrop ([EnvironmentBackdrop]) — a real photo for Dark / Busy / VeniceCanalCats and
+ *    a procedurally-drawn Compose `Canvas` scene for Light, opaque RGB in both cases.
+ * 2. The Glimmer UI on top — `GlimmerTheme` with `ListItem`s drawn on a `Color.Black` additive-zero
+ *    base and composited with `BlendMode.Plus`, so the display *adds* its lit pixels onto the env
+ *    exactly as on-device: black contributes nothing (the env shows through a `ListItem`
+ *    untouched), the dark Glimmer surface tint brightens the env where items sit, and white text /
+ *    focus borders add full light. When `:data-glimmer-environment-connector` lands the per-env
+ *    [EnvironmentBackdrop] moves into the connector and the sample reverts to plain additive-RGB
+ *    captures (Encoding B) on a black background — the `ADD`-blend then happens post-render on the
+ *    captured PNG instead of inline.
  *
- * The four GIFs (Light / Dark / Busy / VeniceCanalCats) are **visually distinct today** because
- * the env compositing happens at render time — they're not pixel-identical placeholders. The
- * test asserts that explicitly so a future regression (e.g. an env backdrop accidentally falling
- * back to opaque black) surfaces here rather than in a downstream skill.
+ * The four GIFs (Light / Dark / Busy / VeniceCanalCats) are **visually distinct today** because the
+ * env compositing happens at render time — they're not pixel-identical placeholders. The test
+ * asserts that explicitly so a future regression (e.g. an env backdrop accidentally falling back to
+ * opaque black) surfaces here rather than in a downstream skill.
  *
  * The 1-D touchpad-gesture model is documented in SKILL.md § "Map input controls" but isn't
  * surfaced visually in these captures — Studio's own Glimmer previews don't paint a persistent
@@ -65,21 +62,20 @@ import ee.schimke.composeai.preview.FocusedPreview
  * affordance on screen. When `@GlimmerPreviewInput` + `:data-glimmer-input-connector` land the
  * planner's per-frame gesture override paints through that connector.
  *
- * Item count: four — the AI Glasses canvas (960×720dp at density 1.0) seats four `ListItem`s with 16-dp
- * inter-item spacing and 24-dp insets cleanly. A header chip over the menu was the first cut
- * but ate the focus ring on the fourth item; standalone chips live in the `NowPlayingCard`
- * sample.
+ * Item count: four — the AI Glasses canvas (960×720dp at density 1.0) seats four `ListItem`s with
+ * 16-dp inter-item spacing and 24-dp insets cleanly. A header chip over the menu was the first cut
+ * but ate the focus ring on the fourth item; standalone chips live in the `NowPlayingCard` sample.
  *
  * Discovery side: `@FocusedPreview` flips `LocalInputModeManager` to Keyboard so Compose's
- * focusable system honours the renderer's `moveFocus(...)` calls — Robolectric's host
- * environment is permanently Touch otherwise and Glimmer's `ListItem(onClick)` focusables
- * would refuse focus. `indices` mode lands one capture per focus index; `gif = true` stitches
- * the captures into a single `<basename>.gif` instead of writing four PNG siblings.
+ * focusable system honours the renderer's `moveFocus(...)` calls — Robolectric's host environment
+ * is permanently Touch otherwise and Glimmer's `ListItem(onClick)` focusables would refuse focus.
+ * `indices` mode lands one capture per focus index; `gif = true` stitches the captures into a
+ * single `<basename>.gif` instead of writing four PNG siblings.
  *
- * One top-level function per env so discovery generates a distinct `PreviewInfo.id` per
- * capture (a single function with four stacked `@Preview` annotations would land four captures
- * that all render the same content because the composable can't read its own preview name to
- * pick an env). Each function delegates to [InteractiveMenuOnEnv] with the env value.
+ * One top-level function per env so discovery generates a distinct `PreviewInfo.id` per capture (a
+ * single function with four stacked `@Preview` annotations would land four captures that all render
+ * the same content because the composable can't read its own preview name to pick an env). Each
+ * function delegates to [InteractiveMenuOnEnv] with the env value.
  */
 @Preview(name = "Light", device = AI_GLASSES_DEVICE_SPEC)
 @FocusedPreview(indices = [0, 1, 2, 3], gif = true)
@@ -104,10 +100,7 @@ fun GlimmerXrMenuVeniceCanalCats() = InteractiveMenuOnEnv(GlimmerEnvironment.Ven
 @Composable
 private fun InteractiveMenuOnEnv(env: GlimmerEnvironment) {
   GlimmerEnvSurface(env) {
-    Column(
-      modifier = Modifier.fillMaxWidth(),
-      verticalArrangement = Arrangement.spacedBy(16.dp),
-    ) {
+    Column(modifier = Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(16.dp)) {
       ListItem(onClick = {}) { Text("Next track") }
       ListItem(onClick = {}) { Text("Previous track") }
       ListItem(onClick = {}) { Text("Add to favourites") }
@@ -123,12 +116,11 @@ private fun InteractiveMenuOnEnv(env: GlimmerEnvironment) {
  *
  * Two layers in a `Box`:
  *
- *  1. [EnvironmentBackdrop] — the opaque world the wearer is looking at.
- *  2. The Glimmer UI on a `Color.Black` additive-zero base, wrapped in
- *     `Modifier.drawWithContent { saveLayer(BlendMode.Plus) }` so the whole layer is `ADD`-
- *     blended onto the backdrop. Black pixels add nothing (the env shows through a `ListItem`
- *     untouched), the dark Glimmer surface tint brightens the env where items sit, and white
- *     text / focus borders add full light.
+ * 1. [EnvironmentBackdrop] — the opaque world the wearer is looking at.
+ * 2. The Glimmer UI on a `Color.Black` additive-zero base, wrapped in `Modifier.drawWithContent {
+ *    saveLayer(BlendMode.Plus) }` so the whole layer is `ADD`- blended onto the backdrop. Black
+ *    pixels add nothing (the env shows through a `ListItem` untouched), the dark Glimmer surface
+ *    tint brightens the env where items sit, and white text / focus borders add full light.
  *
  * `BlendMode.Plus` **does** survive Robolectric's hardware-rendering screenshot path — verified
  * empirically (an earlier revision of this sample wrongly assumed it was dropped and fell back to
@@ -138,8 +130,8 @@ private fun InteractiveMenuOnEnv(env: GlimmerEnvironment) {
  * overlapping translucent Glimmer draws don't double-count against the backdrop.
  *
  * When `:data-glimmer-environment-connector` lands, this inline `ADD`-blend moves to a post-render
- * pass over the captured PNG and `GlimmerEnvSurface` reverts to the plain `Color.Black` base of
- * the static [NowPlayingCard] previews (Encoding B).
+ * pass over the captured PNG and `GlimmerEnvSurface` reverts to the plain `Color.Black` base of the
+ * static [NowPlayingCard] previews (Encoding B).
  */
 @Composable
 private fun GlimmerEnvSurface(env: GlimmerEnvironment, content: @Composable () -> Unit) {
@@ -166,19 +158,18 @@ private fun GlimmerEnvSurface(env: GlimmerEnvironment, content: @Composable () -
 /**
  * Backdrop per env. Mixes two source modes:
  *
- *  - **Dark / Busy / VeniceCanalCats**: bitmap drawables in `res/drawable-nodpi/` (Unsplash
- *    License photos cropped to 960×720 to match the AI Glasses 4:3 canvas — 960×720 dp at the
- *    calibrated density 1.0, see `AI_GLASSES_DEVICE_SPEC`).
- *    Drawn via `Image(painter = painterResource(...), contentScale = ContentScale.Crop)` so
- *    the photo fills the box at any device size.
- *  - **Light**: still procedurally drawn (sky gradient + grass + sun). No clean Unsplash photo
- *    for the bright-outdoor preset landed in the first asset pass; swapping in a JPEG when one
- *    arrives is one `Image(painterResource(R.drawable.env_light))` line. The procedural
- *    fallback at least keeps the four envs visually distinct.
+ * - **Dark / Busy / VeniceCanalCats**: bitmap drawables in `res/drawable-nodpi/` (Unsplash License
+ *   photos cropped to 960×720 to match the AI Glasses 4:3 canvas — 960×720 dp at the calibrated
+ *   density 1.0, see `AI_GLASSES_DEVICE_SPEC`). Drawn via `Image(painter = painterResource(...),
+ *   contentScale = ContentScale.Crop)` so the photo fills the box at any device size.
+ * - **Light**: still procedurally drawn (sky gradient + grass + sun). No clean Unsplash photo for
+ *   the bright-outdoor preset landed in the first asset pass; swapping in a JPEG when one arrives
+ *   is one `Image(painterResource(R.drawable.env_light))` line. The procedural fallback at least
+ *   keeps the four envs visually distinct.
  *
- * `drawable-nodpi/` (not `drawable/`) so AGP doesn't bake density-specific variants — the
- * AI Glasses preview always renders at a fixed canvas size and the renderer doesn't carry
- * a density qualifier when resolving resources.
+ * `drawable-nodpi/` (not `drawable/`) so AGP doesn't bake density-specific variants — the AI
+ * Glasses preview always renders at a fixed canvas size and the renderer doesn't carry a density
+ * qualifier when resolving resources.
  */
 @Composable
 private fun EnvironmentBackdrop(env: GlimmerEnvironment, modifier: Modifier = Modifier) {
@@ -224,8 +215,8 @@ private fun DrawScope.drawLight() {
 
 /**
  * Environment backdrops the interactive demo composites against. Matches the per-env names the
- * design doc and the `NowPlayingCard` sample's `@Preview` family already use — Studio's
- * Light / Dark / Busy contrast presets plus the VeniceCanalCats delight scene.
+ * design doc and the `NowPlayingCard` sample's `@Preview` family already use — Studio's Light /
+ * Dark / Busy contrast presets plus the VeniceCanalCats delight scene.
  */
 internal enum class GlimmerEnvironment {
   Light,

--- a/samples/xr-glimmer/src/main/kotlin/com/example/samplexrglimmer/GlimmerPreviews.kt
+++ b/samples/xr-glimmer/src/main/kotlin/com/example/samplexrglimmer/GlimmerPreviews.kt
@@ -25,19 +25,17 @@ import androidx.xr.glimmer.TitleChip
  * Sample Glimmer composables exercised by `:samples:xr-glimmer:composePreviewRenderAll`.
  *
  * Glimmer (`androidx.xr.glimmer:glimmer`) renders for additive display AI glasses — pure black
- * pixels render as 100% transparent on-device, so the SKILL.md mandates a `Color.Black`
- * background on the root projected-activity container. Captures here mirror that intent:
- * `showBackground = true, backgroundColor = 0xFF000000` so the rendered PNG is opaque RGB
- * (Encoding B) with `RGB == (0, 0, 0)` everywhere the
- * Glimmer UI didn't paint — that's the additive-zero baseline an env compositor would later
- * `ADD`-blend onto a Light / Dark / Busy / Venice-canal-cats backdrop.
+ * pixels render as 100% transparent on-device, so the SKILL.md mandates a `Color.Black` background
+ * on the root projected-activity container. Captures here mirror that intent: `showBackground =
+ * true, backgroundColor = 0xFF000000` so the rendered PNG is opaque RGB (Encoding B) with `RGB ==
+ * (0, 0, 0)` everywhere the Glimmer UI didn't paint — that's the additive-zero baseline an env
+ * compositor would later `ADD`-blend onto a Light / Dark / Busy / Venice-canal-cats backdrop.
  *
- * Preview `name` values track the per-env family proposed by the design doc
- * (`Glimmer · Light`, `Glimmer · Dark`, `Glimmer · Busy`, `Glimmer · VeniceCanalCats`,
- * `Glimmer · Input`) so when the `@GlimmerPreview*` meta-annotations from
- * `:glimmer-preview-runtime` land, this file's previews fold in as a drop-in replacement. The
- * four card variants produce identical captures today — they will diverge once
- * `:data-glimmer-environment-connector` wires the env compositor in.
+ * Preview `name` values track the per-env family proposed by the design doc (`Glimmer · Light`,
+ * `Glimmer · Dark`, `Glimmer · Busy`, `Glimmer · VeniceCanalCats`, `Glimmer · Input`) so when the
+ * `@GlimmerPreview*` meta-annotations from `:glimmer-preview-runtime` land, this file's previews
+ * fold in as a drop-in replacement. The four card variants produce identical captures today — they
+ * will diverge once `:data-glimmer-environment-connector` wires the env compositor in.
  */
 
 // Wraps content in `GlimmerTheme` against an additive-zero `Color.Black` base. Standalone helper
@@ -83,10 +81,7 @@ fun NowPlayingCard() {
     // and its associated card; hard-coded as a literal here to avoid pulling the composable
     // accessor (it's a @Composable getter that can't be inlined from a regular `val`) and
     // to keep the sample's dependency list to Glimmer + Compose foundation only.
-    Column(
-      modifier = Modifier.fillMaxWidth(),
-      horizontalAlignment = Alignment.CenterHorizontally,
-    ) {
+    Column(modifier = Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
       TitleChip { Text("NOW PLAYING") }
       Spacer(Modifier.height(8.dp))
       Card(
@@ -102,12 +97,12 @@ fun NowPlayingCard() {
 }
 
 /**
- * Focusable-menu scenario. Drawn as three `ListItem`s stacked vertically (not a
- * `GlimmerLazyColumn` — the lazy container plays games with focus delegation that the static
- * `@Preview` clock can't drive deterministically; the design's `@GlimmerPreviewInput` overlay
- * is the right surface for that). Same additive-zero encoding as [NowPlayingCard]; SKILL.md's
- * documented `verticalArrangement = Arrangement.spacedBy(20.dp)` for `VerticalList` is the
- * source of the 20-dp gap here.
+ * Focusable-menu scenario. Drawn as three `ListItem`s stacked vertically (not a `GlimmerLazyColumn`
+ * — the lazy container plays games with focus delegation that the static `@Preview` clock can't
+ * drive deterministically; the design's `@GlimmerPreviewInput` overlay is the right surface for
+ * that). Same additive-zero encoding as [NowPlayingCard]; SKILL.md's documented
+ * `verticalArrangement = Arrangement.spacedBy(20.dp)` for `VerticalList` is the source of the 20-dp
+ * gap here.
  */
 @Preview(
   name = "Glimmer · Input",
@@ -118,10 +113,7 @@ fun NowPlayingCard() {
 @Composable
 fun FocusableMenu() {
   GlimmerSurface {
-    Column(
-      modifier = Modifier.fillMaxSize(),
-      verticalArrangement = Arrangement.spacedBy(20.dp),
-    ) {
+    Column(modifier = Modifier.fillMaxSize(), verticalArrangement = Arrangement.spacedBy(20.dp)) {
       ListItem(onClick = {}) { Text("Next track") }
       ListItem(onClick = {}) { Text("Add to favourites") }
       ListItem(onClick = {}) { Text("Send to phone") }

--- a/samples/xr-glimmer/src/test/kotlin/com/example/samplexrglimmer/GlimmerCaptureAdditivePixelTest.kt
+++ b/samples/xr-glimmer/src/test/kotlin/com/example/samplexrglimmer/GlimmerCaptureAdditivePixelTest.kt
@@ -6,26 +6,25 @@ import javax.imageio.ImageIO
 import org.junit.Test
 
 /**
- * Asserts the additive-RGB capture contract that `:samples:xr-glimmer:composePreviewRenderAll`
- * is supposed to deliver — the renderer mirror of
- * `:samples:android`'s `TransparentBackgroundPreviewPixelTest`, on the other channel.
+ * Asserts the additive-RGB capture contract that `:samples:xr-glimmer:composePreviewRenderAll` is
+ * supposed to deliver — the renderer mirror of `:samples:android`'s
+ * `TransparentBackgroundPreviewPixelTest`, on the other channel.
  *
- * Glimmer's display model is additive: pure black pixels render as 100% transparent on-device,
- * so the capture uses **Encoding B** —
- * opaque RGB on a `Color.Black` background, then `ADD`-blend onto an environment image to
- * recover what a wearer sees. The contract this test guards:
+ * Glimmer's display model is additive: pure black pixels render as 100% transparent on-device, so
+ * the capture uses **Encoding B** — opaque RGB on a `Color.Black` background, then `ADD`-blend onto
+ * an environment image to recover what a wearer sees. The contract this test guards:
  *
- *  - The captured PNG carries an alpha plane (i.e. it's loaded as RGBA, not RGB-flattened).
- *  - Alpha is fully opaque in every pixel (`0xFF`) — Encoding B is NOT a transparent capture.
- *  - The four outer corners read `RGB == (0, 0, 0)` — additive-zero. These pixels sit well
- *    outside the centred title chip / card, so any drift away from black would mean either
- *    (a) the background-fill path lost the explicit `backgroundColor = 0xFF000000` from
- *    `@Preview`, or (b) a future env compositor mutated the original capture in place
- *    (it must write a sibling file instead).
+ * - The captured PNG carries an alpha plane (i.e. it's loaded as RGBA, not RGB-flattened).
+ * - Alpha is fully opaque in every pixel (`0xFF`) — Encoding B is NOT a transparent capture.
+ * - The four outer corners read `RGB == (0, 0, 0)` — additive-zero. These pixels sit well outside
+ *   the centred title chip / card, so any drift away from black would mean either (a) the
+ *   background-fill path lost the explicit `backgroundColor = 0xFF000000` from `@Preview`, or (b) a
+ *   future env compositor mutated the original capture in place (it must write a sibling file
+ *   instead).
  *
- * Without this test, Encoding-B drift slips through silently: an opaque-grey background still
- * looks "fine" in a manual review, but breaks the eventual `ADD`-blend env compositor because
- * grey + scene > 0 everywhere and the scene gets washed out across every pixel.
+ * Without this test, Encoding-B drift slips through silently: an opaque-grey background still looks
+ * "fine" in a manual review, but breaks the eventual `ADD`-blend env compositor because grey +
+ * scene > 0 everywhere and the scene gets washed out across every pixel.
  */
 class GlimmerCaptureAdditivePixelTest {
 
@@ -73,11 +72,11 @@ class GlimmerCaptureAdditivePixelTest {
   }
 
   /**
-   * The four `NowPlayingCard` captures are pixel-identical today — Encoding B doesn't see
-   * the env name at render time; the future `:data-glimmer-environment-connector` is what
-   * differentiates them by writing a sibling composited PNG. If a regression starts varying
-   * the captures across env names (e.g. the renderer accidentally reads `Preview.name` and
-   * synthesises something env-specific in-process), this test catches it.
+   * The four `NowPlayingCard` captures are pixel-identical today — Encoding B doesn't see the env
+   * name at render time; the future `:data-glimmer-environment-connector` is what differentiates
+   * them by writing a sibling composited PNG. If a regression starts varying the captures across
+   * env names (e.g. the renderer accidentally reads `Preview.name` and synthesises something
+   * env-specific in-process), this test catches it.
    */
   @Test
   fun `four NowPlayingCard env variants land at pixel-identical captures`() {

--- a/samples/xr-spatial/src/test/kotlin/com/example/samplexrspatial/SubspaceLayoutPoseTest.kt
+++ b/samples/xr-spatial/src/test/kotlin/com/example/samplexrspatial/SubspaceLayoutPoseTest.kt
@@ -28,22 +28,21 @@ import org.robolectric.annotation.Config
  * offline, with no headset, no OpenXR, and no SceneCore native code.
  *
  * This is the proof-of-concept behind the "harvest poses → project to 2D" path implemented by
- * `SubspaceSceneRecorder` (see its KDoc). It
- * also doubles as the **canary** for the alpha XR testing stack: if a future
- * `androidx.xr.*:…-testing` release changes how the fake runtime is discovered, how spatial UI is
- * gated, or the subspace semantics surface, this test fails loudly instead of the capability
- * silently regressing.
+ * `SubspaceSceneRecorder` (see its KDoc). It also doubles as the **canary** for the alpha XR
+ * testing stack: if a future `androidx.xr.*:…-testing` release changes how the fake runtime is
+ * discovered, how spatial UI is gated, or the subspace semantics surface, this test fails loudly
+ * instead of the capability silently regressing.
  *
  * How it works — entirely public API plus one Robolectric shadow:
- *  1. `FakeSceneRuntimeFactory` / `FakeRenderingRuntimeFactory` (from `scenecore-testing`) are
- *     registered for `ServiceLoader` via `src/test/resources/META-INF/services/…`, so
- *     `Session.create(activity)` yields a fake, JVM-only XR session.
- *  2. `Subspace` only takes its spatial path when
- *     `packageManager.hasSystemFeature("android.software.xr.api.spatial")` is true. Robolectric
- *     reports `false`, so we shadow it on with [ShadowPackageManager.setSystemFeature]. The
- *     session and `LocalComposeXrOwners` then auto-wire from the activity.
- *  3. The panel transforms are read from the public spatial-semantics tree
- *     (`onSubspaceNodeWithTag(tag).fetchSemanticsNode().poseInRoot` / `.size`).
+ * 1. `FakeSceneRuntimeFactory` / `FakeRenderingRuntimeFactory` (from `scenecore-testing`) are
+ *    registered for `ServiceLoader` via `src/test/resources/META-INF/services/…`, so
+ *    `Session.create(activity)` yields a fake, JVM-only XR session.
+ * 2. `Subspace` only takes its spatial path when
+ *    `packageManager.hasSystemFeature("android.software.xr.api.spatial")` is true. Robolectric
+ *    reports `false`, so we shadow it on with [ShadowPackageManager.setSystemFeature]. The session
+ *    and `LocalComposeXrOwners` then auto-wire from the activity.
+ * 3. The panel transforms are read from the public spatial-semantics tree
+ *    (`onSubspaceNodeWithTag(tag).fetchSemanticsNode().poseInRoot` / `.size`).
  *
  * Poses/sizes are in dp. A `SpatialColumn` of a 200dp-tall panel over a 160dp-tall panel resolves
  * to a 360dp-tall column with the top panel above the bottom one — which is what we assert.
@@ -54,8 +53,7 @@ class SubspaceLayoutPoseTest {
 
   // v2 rule API (StandardTestDispatcher) is not on the compat compile classpath yet;
   // suppress until the floor moves up. See renderer-android RobolectricRenderTest.
-  @Suppress("DEPRECATION")
-  @get:Rule val rule = createAndroidComposeRule<ComponentActivity>()
+  @Suppress("DEPRECATION") @get:Rule val rule = createAndroidComposeRule<ComponentActivity>()
 
   @Test
   fun recoversSubspacePanelPosesOffline() {


### PR DESCRIPTION
## Summary

Follow-up to #2291, which merged with the `ktfmt (Google style)` check red — so the KDoc/comment edits from the doc streamline landed on `main` unformatted, leaving the format gate red (and `ktfmtCheckAll` aborts on the first offender, so it nags every subsequent PR).

This runs **ktfmt 0.62** — the exact version `com.ncorti.ktfmt.gradle:0.26.0` bundles (read from the plugin jar's `ktfmt-version.txt`) — with `--google-style` over the affected files, matching the project's `KtfmtExtension { googleStyle() }` config.

**Pure formatting, no code changes:** KDoc comments re-wrapped to 100 columns and numbered-list indentation normalised (`*  1.` → `* 1.`). 13 files.

## Test plan

- [x] Formatted with the pinned ktfmt 0.62 + `--google-style` (the sandbox can't run the project's Gradle — wrapper download is proxy-blocked — so I invoked the bundled formatter directly).
- [x] **Verified the CLI matches the plugin**: ran `ktfmt --google-style` on several untouched files that are known-clean on `main` → **zero** diff, confirming `--google-style` == `googleStyle()` output byte-for-byte.
- [x] Diff is whitespace/comment-wrapping only; no logic touched.
- [x] Expected effect: `ktfmt (Google style)` goes green.

_Note: the separate `Analyze (java-kotlin)` (CodeQL) failure is unrelated and pre-existing — Kotlin 2.4.0 exceeds CodeQL's supported ≤2.3.30, repo-wide._


---
_Generated by [Claude Code](https://claude.ai/code/session_012FH6Xeaxk9xbmG1vFM1vdH)_