### PR TITLE
fix(tiles): render tile images registered via ProtoLayoutScope

### DIFF
--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/TilePreviewRenderer.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/TilePreviewRenderer.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.viewinterop.AndroidView
 import androidx.wear.protolayout.DeviceParametersBuilders
 import androidx.wear.protolayout.DeviceParametersBuilders.DeviceParameters
 import androidx.wear.protolayout.LayoutElementBuilders
+import androidx.wear.protolayout.ProtoLayoutScope
 import androidx.wear.protolayout.ResourceBuilders
 import androidx.wear.protolayout.proto.LayoutElementProto
 import androidx.wear.protolayout.proto.ResourceProto
@@ -111,7 +112,14 @@ private fun renderTileInto(
       .setVersion(tile.resourcesVersion.ifEmpty { "1" })
       .setDeviceConfiguration(deviceParams)
       .build()
-  val resources = data.onTileResourceRequest(resourcesRequest)
+  // Merge the two ways a tile supplies images so both render: the classic
+  // `onTileResourceRequest` id -> ImageResource map, and images the modern scope API
+  // (`materialScopeWithResources` / `avatarImage` / `basicImage`) registers into the
+  // TileRequest's ProtoLayoutScope during `onTileRequest`. `TilePreviewData`'s default
+  // `onTileResourceRequest` returns an empty bundle and `TileRenderer` only inflates the
+  // `Resources` we pass it, so unharvested scope images (contact avatars) render blank.
+  val resources =
+    mergeScopeResources(data.onTileResourceRequest(resourcesRequest), tileRequest.scope)
 
   val layout =
     tile.tileTimeline?.timelineEntries?.firstOrNull()?.layout
@@ -133,6 +141,27 @@ private fun renderTileInto(
   }
 
   inflateLayoutInto(context, layout, resources, parent, "preview '$functionName'")
+}
+
+/**
+ * Combines the resources returned by `onTileResourceRequest` ([requested]) with any images the
+ * layout registered into the TileRequest's [scope] during `onTileRequest` — the modern
+ * `ProtoLayoutScope` image API (`materialScopeWithResources` / `avatarImage` / `basicImage`). Scope
+ * images are merged on top of the requested map (proto map merge is last-wins per id). Returns
+ * [requested] unchanged when the scope holds nothing, so the classic explicit-mapping path is
+ * byte-for-byte untouched.
+ */
+private fun mergeScopeResources(
+  requested: ResourceBuilders.Resources,
+  scope: ProtoLayoutScope,
+): ResourceBuilders.Resources {
+  if (!scope.hasResources()) return requested
+  val merged =
+    ResourceProto.Resources.newBuilder()
+      .mergeFrom(requested.toProto())
+      .mergeFrom(scope.collectResources().toProto())
+      .build()
+  return ResourceBuilders.Resources.fromProto(merged)
 }
 
 /**

--- a/samples/wear/src/main/kotlin/com/example/samplewear/TileImagePreviews.kt
+++ b/samples/wear/src/main/kotlin/com/example/samplewear/TileImagePreviews.kt
@@ -15,6 +15,9 @@ import androidx.wear.protolayout.ResourceBuilders.IMAGE_FORMAT_ARGB_8888
 import androidx.wear.protolayout.ResourceBuilders.ImageResource
 import androidx.wear.protolayout.ResourceBuilders.InlineImageResource
 import androidx.wear.protolayout.ResourceBuilders.Resources
+import androidx.wear.protolayout.material3.avatarImage
+import androidx.wear.protolayout.material3.materialScopeWithResources
+import androidx.wear.protolayout.material3.primaryLayout
 import androidx.wear.tiles.tooling.preview.Preview
 import androidx.wear.tiles.tooling.preview.TilePreviewData
 import androidx.wear.tiles.tooling.preview.TilePreviewHelper
@@ -67,6 +70,19 @@ private fun heroImageBytes(): ByteArray {
   return buffer.array()
 }
 
+/** The [heroImageBytes] pixels wrapped as a self-contained inline [ImageResource]. */
+private fun heroImageResource(): ImageResource =
+  ImageResource.Builder()
+    .setInlineResource(
+      InlineImageResource.Builder()
+        .setData(heroImageBytes())
+        .setWidthPx(INLINE_IMAGE_PX)
+        .setHeightPx(INLINE_IMAGE_PX)
+        .setFormat(IMAGE_FORMAT_ARGB_8888)
+        .build()
+    )
+    .build()
+
 /**
  * Centres an `Image` of [imageId] on the watchface substrate. Shared by both variants so the only
  * thing that differs is how the resource id is backed in `onTileResourceRequest`.
@@ -105,19 +121,7 @@ fun InlineImageTilePreview(context: Context): TilePreviewData =
     onTileResourceRequest = {
       Resources.Builder()
         .setVersion("1")
-        .addIdToImageMapping(
-          INLINE_IMAGE_ID,
-          ImageResource.Builder()
-            .setInlineResource(
-              InlineImageResource.Builder()
-                .setData(heroImageBytes())
-                .setWidthPx(INLINE_IMAGE_PX)
-                .setHeightPx(INLINE_IMAGE_PX)
-                .setFormat(IMAGE_FORMAT_ARGB_8888)
-                .build()
-            )
-            .build(),
-        )
+        .addIdToImageMapping(INLINE_IMAGE_ID, heroImageResource())
         .build()
     },
     onTileRequest = { imageTile(INLINE_IMAGE_ID, INLINE_IMAGE_PX.toFloat()) },
@@ -146,3 +150,25 @@ fun DrawableImageTilePreview(context: Context): TilePreviewData =
     },
     onTileRequest = { imageTile(DRAWABLE_IMAGE_ID, 88f) },
   )
+
+/**
+ * Scope-registered image tile — the modern protolayout image API (`materialScopeWithResources` +
+ * `avatarImage`) that real Wear tiles use. The image is registered into the `TileRequest`'s
+ * `ProtoLayoutScope` during `onTileRequest` rather than through an `onTileResourceRequest` map, so
+ * `TilePreviewComposable` has to harvest the scope (see `mergeScopeResources`) to serve it. Before
+ * that harvest this rendered blank — the exact reason the wear-os-samples contact avatars
+ * (`avatarImage` + `materialScopeWithResources`) came out empty.
+ */
+@Preview(device = WearDevices.LARGE_ROUND, name = "Scope Image")
+fun ScopeImageTilePreview(context: Context): TilePreviewData = TilePreviewData { request ->
+  TilePreviewHelper.singleTimelineEntryTileBuilder(
+      materialScopeWithResources(context, request.scope, request.deviceConfiguration) {
+        primaryLayout(
+          mainSlot = {
+            avatarImage(resource = heroImageResource(), width = expand(), height = expand())
+          }
+        )
+      }
+    )
+    .build()
+}


### PR DESCRIPTION
## Summary

Wear tiles that supply images through the **modern protolayout scope API** — `materialScopeWithResources` + `avatarImage` / `basicImage` — render **blank** in the preview pipeline, while text content renders fine. This is why the wear-os-samples Social tile shows empty contact avatars.

**Root cause:** those APIs register `ImageResource`s into the `TileRequest`'s `ProtoLayoutScope` during `onTileRequest`, *not* through `onTileResourceRequest`. `TilePreviewData`'s default `onTileResourceRequest` returns an empty bundle, and `TileRenderer` only inflates the `Resources` we hand it — so `TilePreviewComposable` dropped every scope-registered image.

**Fix:** after `onTileRequest`, harvest `tileRequest.scope.collectResources()` and merge it on top of the `onTileResourceRequest` map before inflating (and before the IR-sidecar capture, so exported bundles carry the images too). The classic explicit-`onTileResourceRequest` mapping path is byte-for-byte unchanged when the scope is empty.

Adds `ScopeImageTilePreview` to `samples/wear` as regression coverage for the scope path, alongside the inline/drawable previews from #2301.

## Before (the bug)

wear-os-samples Social tile — avatar contacts blank while the text chip renders; and the all-avatar variant fully blank:

<img src="https://raw.githubusercontent.com/yschimke/compose-ai-tools/compose-preview/integration/wear-tiles/renders/app/SocialKt.socialPreview3_Large_Round_1_00f.png" width="180" /> <img src="https://raw.githubusercontent.com/yschimke/compose-ai-tools/compose-preview/integration/wear-tiles/renders/app/LayoutKt.socialPreview6_Large_Round_1_00f.png" width="180" />

## After / verification

I could **not** render locally: this project is on AGP 9.2.1 (needs Gradle 9.x) and the Gradle 9.6.1 distribution is policy-blocked in my environment. What I did verify:

- **`kotlinc` type-check** of both changed files against the real `protolayout` 1.4.0 / `tiles` 1.6.0 jars — clean, 0 errors/warnings.
- Confirmed the renderer resource path and the `ProtoLayoutScope` collect/merge semantics by decompiling `protolayout-renderer` / `tiles-renderer`.

The **Compose Preview** CI workflow renders `ScopeImageTilePreview` on this PR — that is the "after" proof (the avatar fills the tile instead of rendering blank). Once this merges, the wear-tiles integration avatars above fill in too.

## Test plan

- [ ] CI **Compose Preview** renders `ScopeImageTilePreview` with a visible avatar (not blank)
- [ ] `InlineImageTilePreview` and `DrawableImageTilePreview` still render unchanged
- [ ] No change to tiles that use the explicit `onTileResourceRequest` mapping

_Generated by [Claude Code]_

---
_Generated by [Claude Code](https://claude.ai/code/session_01NXcdivu4Qiqb6wEoG6M4YH)_