### PR TITLE
fix(serve): serve baked snapshot on load, drop knob type prefix

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -546,7 +546,11 @@ class ServeHttpServer(
             }
           }
           .toMap()
-      when (val parsed = ServeOverrides.parse(overrideParams)) {
+      // Type a bare `knob.<key>=<value>` from the preview's declared knobs (an explicit
+      // `<kind>:<value>` still wins) so the viewer never has to spell the type in the URL.
+      val knobKinds =
+        ServeOverrides.declaredKnobKinds(renderHost.previews.firstOrNull { it.id == previewId })
+      when (val parsed = ServeOverrides.parse(overrideParams, knobKinds)) {
         is OverrideParse.Invalid ->
           call.respondText(parsed.message, status = HttpStatusCode.BadRequest)
         is OverrideParse.Ok -> {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeLiveSession.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeLiveSession.kt
@@ -30,7 +30,7 @@ private constructor(
   fun onClientMessage(text: String) {
     when (val message = ServeStreamProtocol.parseClient(text)) {
       is ServeStreamProtocol.ClientMessage.SetOverrides ->
-        when (val parsed = ServeOverrides.parse(message.overrides)) {
+        when (val parsed = ServeOverrides.parse(message.overrides, knobKindsFor(previewId))) {
           is OverrideParse.Invalid -> send(ServeStreamProtocol.errorMessage(parsed.message))
           is OverrideParse.Ok -> {
             // stream/start fixes overrides for the held session, so an override change restarts it.
@@ -88,7 +88,7 @@ private constructor(
   private fun switchTo(message: ServeStreamProtocol.ClientMessage.Switch) {
     val nextOverrides = message.overrides ?: overrides
     val parsed =
-      when (val p = ServeOverrides.parse(nextOverrides)) {
+      when (val p = ServeOverrides.parse(nextOverrides, knobKindsFor(message.previewId))) {
         is OverrideParse.Invalid -> {
           send(ServeStreamProtocol.errorMessage(p.message))
           return
@@ -105,6 +105,12 @@ private constructor(
     previewId = message.previewId
     overrides = nextOverrides
   }
+
+  /**
+   * Declared knob kinds for [id], so a bare `knob.<key>=<value>` message is typed from the preview.
+   */
+  private fun knobKindsFor(id: String): Map<String, String> =
+    ServeOverrides.declaredKnobKinds(renderHost.previews.firstOrNull { it.id == id })
 
   private fun onFrame(frame: StreamFrameParams) {
     // `unchanged` heartbeats carry no payload — nothing to paint.
@@ -140,8 +146,11 @@ private constructor(
       maxFps: Int? = null,
       send: (String) -> Unit,
     ): ServeLiveSession? {
+      val knobKinds =
+        ServeOverrides.declaredKnobKinds(renderHost.previews.firstOrNull { it.id == previewId })
       val initial =
-        (ServeOverrides.parse(overrides) as? OverrideParse.Ok)?.overrides ?: PreviewOverrides()
+        (ServeOverrides.parse(overrides, knobKinds) as? OverrideParse.Ok)?.overrides
+          ?: PreviewOverrides()
       val session = ServeLiveSession(renderHost, previewId, overrides, codec, maxFps, send)
       session.handle =
         renderHost.subscribeStream(previewId, initial, codec, maxFps, session::onFrame)

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeOverrides.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeOverrides.kt
@@ -62,22 +62,63 @@ object ServeOverrides {
     )
 
   /**
-   * Prefix for author-declared named-override knobs: `knob.<wireKey>=<kind>:<value>`, e.g.
-   * `knob.label=string:Tap me` or `knob.count=int:3`. `wireKey` is the declaration key (indexed
-   * knobs use `key[index]`); `kind` is one of string/int/float/bool/color, matching
-   * [PreviewOverrideValue]. The daemon's named-override planner seeds the preview's declared knobs
-   * from these, so editing one re-renders the composable (only on a daemon-backed session — a
-   * static bundle / the Wasm tier ignore them). Dynamic keys, so not listed in [SUPPORTED_KEYS].
+   * Prefix for author-declared named-override knobs: `knob.<wireKey>=<value>`, e.g. `knob.label=Tap
+   * me` or `knob.count=3`. `wireKey` is the declaration key (indexed knobs use `key[index]`). The
+   * value's **type is inferred from the preview's declaration** (the `knobKinds` map passed to
+   * [parse]) — a viewer never has to spell it. An explicit `<kind>:<value>` prefix
+   * (`knob.count=int:3`, `kind` one of string/int/float/bool/color) is still honoured for older
+   * shared links and keys the server has no declaration for; absent a declaration and a recognised
+   * prefix, a bare value parses as a string. The daemon's named-override planner seeds the
+   * preview's declared knobs from these, so editing one re-renders the composable (only on a
+   * daemon-backed session — a static bundle / the Wasm tier ignore them). Dynamic keys, so not
+   * listed in [SUPPORTED_KEYS].
    */
   const val KNOB_PREFIX = "knob."
+
+  /**
+   * The `<kind>` tags an explicit `knob.<key>=<kind>:<value>` may carry (legacy /
+   * declaration-less).
+   */
+  private val KNOWN_KINDS: Set<String> = setOf("string", "int", "float", "bool", "color")
+
+  /**
+   * Map a `compose/overrides` declaration `type` to the [PreviewOverrideValue] wire kind. Shared
+   * with the viewer's control rendering so the inferred type always matches the widget shown.
+   */
+  fun knobKind(type: String): String =
+    when (type.lowercase()) {
+      "int" -> "int"
+      "float",
+      "dp" -> "float"
+      "bool",
+      "boolean" -> "bool"
+      "color" -> "color"
+      else -> "string"
+    }
+
+  /**
+   * The `wireKey → kind` map [parse] uses to type a bare `knob.<key>=<value>`, built from a
+   * preview's declared knobs (keyed by
+   * [ee.schimke.composeai.data.overrides.PreviewOverrideDeclaration.seedKey]). Empty when the
+   * preview is unknown or declares no knobs — a bare value then falls back to string.
+   */
+  fun declaredKnobKinds(preview: ServePreview?): Map<String, String> =
+    preview?.overrides?.associate { it.seedKey to knobKind(it.type) } ?: emptyMap()
 
   /**
    * Parse [params] (one value per key — the ktor layer collapses multi-values to the first) into a
    * [PreviewOverrides]. Returns [OverrideParse.Invalid] with a human reason on malformed values
    * (bad number, unknown enum) rather than rendering with a silent default. Absent / blank keys
    * leave the corresponding field null (the preview's discovery-time value).
+   *
+   * [knobKinds] maps a knob's `wireKey` to its declared kind so a bare `knob.<key>=<value>` is
+   * typed without the caller spelling it (see [declaredKnobKinds]); an explicit `<kind>:<value>`
+   * prefix still wins, and an undeclared key with a bare value falls back to a string.
    */
-  fun parse(params: Map<String, String>): OverrideParse {
+  fun parse(
+    params: Map<String, String>,
+    knobKinds: Map<String, String> = emptyMap(),
+  ): OverrideParse {
     fun blank(key: String): Boolean = params[key]?.isBlank() ?: true
 
     val uiMode =
@@ -197,19 +238,21 @@ object ServeOverrides {
         else -> null
       }
 
-    // Named-override knobs (`knob.<key>=<kind>:<value>`). A malformed typed value is a hard
-    // Invalid (mirrors the numeric fields) rather than a silently-dropped edit.
+    // Named-override knobs (`knob.<key>=<value>`, type inferred from the declaration; a legacy
+    // `<kind>:<value>` prefix still wins). A malformed typed value is a hard Invalid (mirrors the
+    // numeric fields) rather than a silently-dropped edit.
     val namedOverrides = mutableMapOf<String, PreviewOverrideValue>()
     for ((rawKey, raw) in params) {
       if (!rawKey.startsWith(KNOB_PREFIX)) continue
       val wireKey = rawKey.removePrefix(KNOB_PREFIX)
       if (wireKey.isBlank() || raw.isBlank()) continue
+      // Split an explicit `<kind>:<value>` only when the prefix is a recognised kind; otherwise the
+      // whole string is the value and its type comes from the preview's declaration (default
+      // string). This keeps old typed links working while letting a viewer send bare values.
       val sep = raw.indexOf(':')
-      if (sep <= 0) {
-        return OverrideParse.Invalid("knob '$wireKey' must be '<kind>:<value>', got '$raw'")
-      }
-      val kind = raw.substring(0, sep)
-      val value = raw.substring(sep + 1)
+      val explicitKind = if (sep > 0) raw.substring(0, sep).takeIf { it in KNOWN_KINDS } else null
+      val kind = explicitKind ?: knobKinds[wireKey] ?: "string"
+      val value = if (explicitKind != null) raw.substring(sep + 1) else raw
       namedOverrides[wireKey] =
         when (kind) {
           "string" -> PreviewOverrideValue.StringValue(value)

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeOverrides.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeOverrides.kt
@@ -246,12 +246,16 @@ object ServeOverrides {
       if (!rawKey.startsWith(KNOB_PREFIX)) continue
       val wireKey = rawKey.removePrefix(KNOB_PREFIX)
       if (wireKey.isBlank() || raw.isBlank()) continue
-      // Split an explicit `<kind>:<value>` only when the prefix is a recognised kind; otherwise the
-      // whole string is the value and its type comes from the preview's declaration (default
-      // string). This keeps old typed links working while letting a viewer send bare values.
+      // Type the value. A bare value takes its type from the preview's declaration (default
+      // string). A legacy `<kind>:<value>` prefix is honoured ONLY when the knob is undeclared or
+      // the prefix matches its declared kind — otherwise a declared *string* knob could never hold
+      // a value that happens to start with `int:` / `color:` / … (the type-free viewer submits such
+      // text verbatim), which would silently mistype the seed or strip a legitimate prefix.
+      val declaredKind = knobKinds[wireKey]
       val sep = raw.indexOf(':')
-      val explicitKind = if (sep > 0) raw.substring(0, sep).takeIf { it in KNOWN_KINDS } else null
-      val kind = explicitKind ?: knobKinds[wireKey] ?: "string"
+      val prefix = if (sep > 0) raw.substring(0, sep).takeIf { it in KNOWN_KINDS } else null
+      val explicitKind = prefix?.takeIf { declaredKind == null || it == declaredKind }
+      val kind = explicitKind ?: declaredKind ?: "string"
       val value = if (explicitKind != null) raw.substring(sep + 1) else raw
       namedOverrides[wireKey] =
         when (kind) {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeStreamSession.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeStreamSession.kt
@@ -36,7 +36,7 @@ class ServeStreamSession(
       is ServeStreamProtocol.ClientMessage.SetOverrides ->
         // Validate before committing: a bad override message is reported but must not poison the
         // session — the previous (valid) overrides stay in effect for subsequent frames.
-        when (val parsed = ServeOverrides.parse(message.overrides)) {
+        when (val parsed = ServeOverrides.parse(message.overrides, knobKindsFor(previewId))) {
           is OverrideParse.Invalid -> send(ServeStreamProtocol.errorMessage(parsed.message))
           is OverrideParse.Ok -> {
             overrides = message.overrides
@@ -68,7 +68,7 @@ class ServeStreamSession(
     // lane.
     val nextOverrides = message.overrides ?: overrides
     val parsed =
-      when (val p = ServeOverrides.parse(nextOverrides)) {
+      when (val p = ServeOverrides.parse(nextOverrides, knobKindsFor(message.previewId))) {
         is OverrideParse.Invalid -> {
           send(ServeStreamProtocol.errorMessage(p.message))
           return
@@ -80,8 +80,14 @@ class ServeStreamSession(
     sendFrame(parsed)
   }
 
+  /**
+   * Declared knob kinds for [id], so a bare `knob.<key>=<value>` frame is typed from the preview.
+   */
+  private fun knobKindsFor(id: String): Map<String, String> =
+    ServeOverrides.declaredKnobKinds(renderHost.previews.firstOrNull { it.id == id })
+
   private fun renderCurrent() {
-    when (val parsed = ServeOverrides.parse(overrides)) {
+    when (val parsed = ServeOverrides.parse(overrides, knobKindsFor(previewId))) {
       is OverrideParse.Invalid -> send(ServeStreamProtocol.errorMessage(parsed.message))
       is OverrideParse.Ok -> sendFrame(parsed.overrides)
     }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -838,21 +838,21 @@ object ServeWeb {
         return o;
       }
       // The live-stream override map: the display fields PLUS the author-declared knob values as
-      // `knob.<key>` entries (the daemon's setOverrides parses the same map /render does, and
-      // ServeOverrides reads knob.* keys). Kept separate from overrides() so query() and the Wasm
-      // patch — which append/ignore knobs their own way — are unaffected; without this a knob edit
-      // during an active Live (stream) would send only the display fields and the daemon would reset
-      // the knob to its default.
+      // `knob.<key>=<value>` entries (the daemon's setOverrides parses the same map /render does,
+      // typing each from the preview's declaration). Kept separate from overrides() so query() and
+      // the Wasm patch — which append/ignore knobs their own way — are unaffected; without this a
+      // knob edit during an active Live (stream) would send only the display fields and the daemon
+      // would reset the others to their defaults. Unlike query(), every knob is sent (not just
+      // changed ones) for exactly that reason, so defaults are not filtered here.
       function liveOverrides() {
         var o = overrides();
         document.querySelectorAll(".cp-knob").forEach(function (el) {
           if (el.disabled) return;
           var key = el.getAttribute("data-knob-key");
-          var kind = el.getAttribute("data-knob-kind") || "string";
           if (!key) return;
           var val = (el.type === "checkbox") ? (el.checked ? "true" : "false") : el.value;
           if (val === "") return;
-          o["knob." + key] = kind + ":" + val;
+          o["knob." + key] = val;
         });
         return o;
       }
@@ -864,15 +864,18 @@ object ServeWeb {
         if (token) parts.push("token=" + encodeURIComponent(token));
         if (session) parts.push("session=" + encodeURIComponent(session));
         Object.keys(o).forEach(function (k) { parts.push(k + "=" + encodeURIComponent(o[k])); });
-        // Author-declared knobs (enabled only on a daemon session): knob.<key>=<kind>:<value>.
+        // Author-declared knobs: knob.<key>=<value>. The server infers the type from the preview's
+        // declaration, so no <kind>: prefix. A knob still at its declared default is omitted — that
+        // keeps the URL on the instant baked snapshot (any knob.* param routes a published catalog
+        // to the daemon for a fresh re-render); only an actually-changed knob is sent.
         document.querySelectorAll(".cp-knob").forEach(function (el) {
           if (el.disabled) return;
           var key = el.getAttribute("data-knob-key");
-          var kind = el.getAttribute("data-knob-kind") || "string";
           if (!key) return;
           var val = (el.type === "checkbox") ? (el.checked ? "true" : "false") : el.value;
           if (val === "") return;
-          parts.push("knob." + encodeURIComponent(key) + "=" + encodeURIComponent(kind + ":" + val));
+          if (val === (el.getAttribute("data-knob-initial") || "")) return;
+          parts.push("knob." + encodeURIComponent(key) + "=" + encodeURIComponent(val));
         });
         return parts.join("&");
       }
@@ -1360,8 +1363,17 @@ object ServeWeb {
         val wireKey = WebEscaping.htmlEscape(if (d.index == null) d.key else "${d.key}[${d.index}]")
         val kind = knobKind(d.type)
         val value = WebEscaping.htmlEscape(overrideValueText(d.current ?: d.default))
-        val attrs = "class=\"cp-knob\" data-knob-key=\"$wireKey\" data-knob-kind=\"$kind\""
-        if (kind == "bool") {
+        // `data-knob-initial` is the value the control opens on (the author default / seeded
+        // current). The viewer omits a knob still equal to it, so the first render carries no
+        // `knob.*` and the published catalog serves the instant baked PNG rather than waking the
+        // daemon for a fresh (slower, subtly different) re-render.
+        val bool = kind == "bool"
+        val initial =
+          if (bool) (if (value == "true" || value == "1") "true" else "false") else value
+        val attrs =
+          "class=\"cp-knob\" data-knob-key=\"$wireKey\" data-knob-kind=\"$kind\" " +
+            "data-knob-initial=\"$initial\""
+        if (bool) {
           val checked = if (value == "true" || value == "1") " checked" else ""
           "<label class=\"cp-live-row\"><input type=\"checkbox\" $attrs$checked$dis> $label</label>"
         } else {
@@ -1389,16 +1401,7 @@ object ServeWeb {
   /**
    * Map a declaration's `type` string to the [PreviewOverrideValue] wire kind the daemon expects.
    */
-  private fun knobKind(type: String): String =
-    when (type.lowercase()) {
-      "int" -> "int"
-      "float",
-      "dp" -> "float"
-      "bool",
-      "boolean" -> "bool"
-      "color" -> "color"
-      else -> "string"
-    }
+  private fun knobKind(type: String): String = ServeOverrides.knobKind(type)
 
   /** Human text for a [ee.schimke.composeai.daemon.protocol.PreviewOverrideValue] in the viewer. */
   private fun overrideValueText(

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeOverridesTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeOverridesTest.kt
@@ -228,9 +228,35 @@ class ServeOverridesTest {
   }
 
   @Test
-  fun `an explicit kind prefix still wins over the declared kind`() {
-    // Legacy `<kind>:<value>` links keep working even when a declaration would type it otherwise.
+  fun `an explicit kind prefix still wins for an undeclared knob`() {
+    // Legacy `<kind>:<value>` links keep working when nothing declares the knob's type.
     val o = ok(mapOf("knob.count" to "int:7"))
+    assertEquals(PreviewOverrideValue.IntValue(7), o.namedOverrides!!["count"])
+  }
+
+  @Test
+  fun `a declared string knob keeps a value that looks like a typed prefix`() {
+    // A string knob edited to `int:3` / `color:#fff` must survive verbatim: the prefix does not
+    // match the declared kind, so it is not stripped or retyped.
+    val kinds = mapOf("label" to "string")
+    val o =
+      (ServeOverrides.parse(
+          mapOf("knob.label" to "int:3", "knob.label2" to "color:#fff"),
+          kinds + ("label2" to "string"),
+        ) as OverrideParse.Ok)
+        .overrides
+    val named = o.namedOverrides!!
+    assertEquals(PreviewOverrideValue.StringValue("int:3"), named["label"])
+    assertEquals(PreviewOverrideValue.StringValue("color:#fff"), named["label2"])
+  }
+
+  @Test
+  fun `a matching kind prefix on a declared knob is still honoured`() {
+    // An old `knob.label=string:Hi` link (prefix matches the declared kind) keeps meaning "Hi".
+    val o =
+      (ServeOverrides.parse(mapOf("knob.count" to "int:7"), mapOf("count" to "int"))
+          as OverrideParse.Ok)
+        .overrides
     assertEquals(PreviewOverrideValue.IntValue(7), o.namedOverrides!!["count"])
   }
 

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeOverridesTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeOverridesTest.kt
@@ -197,19 +197,60 @@ class ServeOverridesTest {
   }
 
   @Test
-  fun `malformed knob values are rejected with a reason`() {
+  fun `bare knob value without a kind prefix parses as a string`() {
+    // A colon-less value (the viewer's default wire form) is a string when nothing types it.
+    val o = ok(mapOf("knob.label" to "Tap me"))
+    assertEquals(PreviewOverrideValue.StringValue("Tap me"), o.namedOverrides!!["label"])
+    // A value whose prefix is not a recognised kind is taken whole, not split on the colon.
+    val o2 = ok(mapOf("knob.label" to "mystery:y"))
+    assertEquals(PreviewOverrideValue.StringValue("mystery:y"), o2.namedOverrides!!["label"])
+  }
+
+  @Test
+  fun `bare knob value is typed from the declared kinds`() {
+    val kinds = mapOf("count" to "int", "weight" to "float", "enabled" to "bool", "tint" to "color")
+    val o =
+      (ServeOverrides.parse(
+          mapOf(
+            "knob.count" to "3",
+            "knob.weight" to "1.5",
+            "knob.enabled" to "true",
+            "knob.tint" to "#FF0000",
+          ),
+          kinds,
+        ) as OverrideParse.Ok)
+        .overrides
+    val named = o.namedOverrides!!
+    assertEquals(PreviewOverrideValue.IntValue(3), named["count"])
+    assertEquals(PreviewOverrideValue.FloatValue(1.5f), named["weight"])
+    assertEquals(PreviewOverrideValue.BooleanValue(true), named["enabled"])
+    assertEquals(PreviewOverrideValue.ColorValue("#FF0000"), named["tint"])
+  }
+
+  @Test
+  fun `an explicit kind prefix still wins over the declared kind`() {
+    // Legacy `<kind>:<value>` links keep working even when a declaration would type it otherwise.
+    val o = ok(mapOf("knob.count" to "int:7"))
+    assertEquals(PreviewOverrideValue.IntValue(7), o.namedOverrides!!["count"])
+  }
+
+  @Test
+  fun `malformed typed knob values are rejected with a reason`() {
     for (bad in
       listOf(
-        mapOf("knob.label" to "Tap me"), // missing kind:value separator
-        mapOf("knob.label" to ":Tap me"), // empty kind
-        mapOf("knob.count" to "int:three"), // not an integer
-        mapOf("knob.weight" to "float:heavy"), // not a number
-        mapOf("knob.x" to "mystery:y"), // unknown kind
+        mapOf("knob.count" to "int:three"), // explicit int, not an integer
+        mapOf("knob.weight" to "float:heavy"), // explicit float, not a number
       )) {
       val parsed = ServeOverrides.parse(bad)
       assertTrue(parsed is OverrideParse.Invalid, "expected Invalid for $bad, got $parsed")
       assertTrue(parsed.message.isNotBlank())
     }
+  }
+
+  @Test
+  fun `a bare value declared as a number must still be numeric`() {
+    val parsed = ServeOverrides.parse(mapOf("knob.count" to "three"), mapOf("count" to "int"))
+    assertTrue(parsed is OverrideParse.Invalid, "expected Invalid, got $parsed")
   }
 
   @Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -649,7 +649,10 @@ class ServeWebFixtureTest {
     // The knobs are ENABLED — a live control, not the disabled/informational form. The `label` knob
     // is a text input; assert it renders enabled (no trailing ` disabled`).
     assertTrue(
-      catalogKnobs.contains("data-knob-key=\"label\" data-knob-kind=\"string\" value=\"Filled\">"),
+      catalogKnobs.contains(
+        "data-knob-key=\"label\" data-knob-kind=\"string\" data-knob-initial=\"Filled\" " +
+          "value=\"Filled\">"
+      ),
       "declared knobs are enabled on an override-renderable session",
     )
     assertTrue(
@@ -679,7 +682,8 @@ class ServeWebFixtureTest {
     val staticKnobs = ServeWeb.viewerPage(knobPreview, token)
     assertTrue(
       staticKnobs.contains(
-        "data-knob-key=\"label\" data-knob-kind=\"string\" value=\"Filled\" disabled"
+        "data-knob-key=\"label\" data-knob-kind=\"string\" data-knob-initial=\"Filled\" " +
+          "value=\"Filled\" disabled"
       ),
       "a plain static bundle leaves declared knobs disabled",
     )

--- a/daemon/desktop/build.gradle.kts
+++ b/daemon/desktop/build.gradle.kts
@@ -216,6 +216,10 @@ dependencies {
   // `LocalPreviewBackgroundCleared` — the `SurfaceCardSquare` fixture reads it to prove the
   // `clearBackground` override reaches a composable that drops its own opaque fill.
   "testFixturesImplementation"(project(":slot-preview-runtime"))
+  // `previewOverride*` — the `OverridableSquare` fixture declares a `fill` colour knob so
+  // `OverrideIntegrationTest` can prove a `namedOverrides` seed reaches the composition and
+  // changes the rendered pixels (the end-to-end named-override render path).
+  "testFixturesImplementation"(project(":data-preview-overrides-runtime"))
 }
 
 // Convenience task — equivalent to `java -cp $(runtimeClasspath) ee.schimke.composeai.daemon

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/OverrideIntegrationTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/OverrideIntegrationTest.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.daemon
 
+import ee.schimke.composeai.daemon.protocol.PreviewOverrideValue
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.daemon.protocol.WallpaperOverride
 import java.io.ByteArrayInputStream
@@ -413,6 +414,78 @@ class OverrideIntegrationTest {
     }
   }
 
+  /**
+   * End-to-end proof that a **named override** (`knob.<key>`) reaches the composition and changes
+   * the rendered pixels — the render side of the `/render?knob.<key>=…` serve URL. Renders
+   * [OverridableSquare] with no seed (its `fill` knob returns the author-default red) and with a
+   * `namedOverrides` seed of blue (the same map the serve layer builds from a knob URL), then
+   * asserts the fill actually repainted. Requires the `PreviewOverridesPreviewOverrideExtension`
+   * planner registered on the engine — without it the seed never reaches `previewOverrideColor`.
+   */
+  @Test
+  fun namedOverrideChangesRenderedFill() {
+    val outputDir = tempFolder.newFolder("renders-named-override")
+    System.setProperty(RenderEngine.OUTPUT_DIR_PROP, outputDir.absolutePath)
+    val manifest =
+      PreviewManifest(
+        previews =
+          listOf(
+            PreviewManifestEntry(
+              id = "overridable",
+              className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+              functionName = "OverridableSquare",
+              widthPx = 32,
+              heightPx = 32,
+              density = 1.0f,
+              outputBaseName = "overridable",
+            )
+          )
+      )
+    val host =
+      PreviewManifestRouter(
+        manifest = manifest,
+        engine =
+          RenderEngine(
+            previewOverrideExtensions =
+              PreviewOverrideExtensions(listOf(PreviewOverridesPreviewOverrideExtension()))
+          ),
+      )
+    host.start()
+    try {
+      // No seed: the `fill` knob returns its author default (red).
+      val default = renderAndDecode(host, "previewId=overridable", "named-default")
+      val defaultRedPct = pixelMatchPct(default, expectedRgb = 0xEF5350, perChannelTolerance = 8)
+      assertTrue(
+        "unseeded fill should be the author-default red; got ${"%.2f".format(defaultRedPct * 100)}%",
+        defaultRedPct >= 0.95,
+      )
+
+      // Seed `fill = #FF42A5F5` (blue) via the namedOverrides bag — the same map a
+      // `/render?knob.fill=…` URL builds. It must reach `previewOverrideColor` and repaint the
+      // fill.
+      val seeded =
+        renderAndDecode(
+          host,
+          "previewId=overridable;overrides=${encodeNamedBag("fill", "#FF42A5F5")}",
+          "named-seeded",
+        )
+      val seededBluePct = pixelMatchPct(seeded, expectedRgb = 0x42A5F5, perChannelTolerance = 8)
+      assertTrue(
+        "seeded fill should repaint blue; got ${"%.2f".format(seededBluePct * 100)}%",
+        seededBluePct >= 0.95,
+      )
+      // The crux of the "does knob.label=Ground actually change anything?" question: the seed must
+      // change pixels vs the author default, not silently fall back to it.
+      assertNotEquals(
+        "a named override must change the render vs the author default",
+        default.getRGB(default.width / 2, default.height / 2),
+        seeded.getRGB(seeded.width / 2, seeded.height / 2),
+      )
+    } finally {
+      host.shutdown()
+    }
+  }
+
   private fun renderAndDecode(
     host: PreviewManifestRouter,
     payload: String,
@@ -435,6 +508,17 @@ class OverrideIntegrationTest {
   private fun encodeWallpaperBag(seedColor: String): String {
     val json = Json { encodeDefaults = false }
     val bag = PreviewOverrides(wallpaper = WallpaperOverride(seedColor = seedColor))
+    return Base64.getUrlEncoder()
+      .withoutPadding()
+      .encodeToString(
+        json.encodeToString(PreviewOverrides.serializer(), bag).toByteArray(Charsets.UTF_8)
+      )
+  }
+
+  /** A base64 `overrides=` bag carrying a single named colour knob (`key = argb`). */
+  private fun encodeNamedBag(key: String, argb: String): String {
+    val json = Json { encodeDefaults = false }
+    val bag = PreviewOverrides(namedOverrides = mapOf(key to PreviewOverrideValue.ColorValue(argb)))
     return Base64.getUrlEncoder()
       .withoutPadding()
       .encodeToString(

--- a/daemon/desktop/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
+++ b/daemon/desktop/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
@@ -55,6 +55,21 @@ fun BlueSquare() {
 }
 
 /**
+ * Declares an opt-in `previewOverride*` colour knob (`fill`) driving a solid fill, plus a string
+ * `label` knob. [OverrideIntegrationTest.namedOverrideChangesRenderedFill] renders this with no
+ * seed (fill = default red) and with a `namedOverrides` seed (fill = blue) to prove a named
+ * override reaches the composition and changes the rendered pixels — the render side of what the
+ * `/render?knob.<key>=…` serve URL feeds. Mirrors `:daemon:android`'s fixture of the same name.
+ */
+@Composable
+fun OverridableSquare() {
+  val fill =
+    ee.schimke.composeai.overrides.previewOverrideColor("fill", default = Color(0xFFEF5350))
+  ee.schimke.composeai.overrides.previewOverrideString("label", default = "hi")
+  Box(modifier = Modifier.fillMaxSize().background(fill))
+}
+
+/**
  * Identical fill to [RedSquare] but declared `private`, so it compiles to a JVM-private static
  * method on `RedFixturePreviewsKt`. Kotlin `private fun` previews are a real, supported shape
  * (`samples/android/.../Previews.kt`'s `RedBoxPreview` ships one on purpose). [RenderEngine]

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
@@ -163,10 +163,10 @@ a:hover { text-decoration: underline; }
                 <div class="cp-knobs">
         <div class="cp-knobs-head">Declared overrides — edit a value to re-render.</div>
         <label>label
-  <input type="text" class="cp-knob" data-knob-key="label" data-knob-kind="string" value="Filled">
+  <input type="text" class="cp-knob" data-knob-key="label" data-knob-kind="string" data-knob-initial="Filled" value="Filled">
 </label>
 <label>iconColor
-  <input type="text" class="cp-knob" data-knob-key="iconColor" data-knob-kind="color" value="#FF6750A4">
+  <input type="text" class="cp-knob" data-knob-key="iconColor" data-knob-kind="color" data-knob-initial="#FF6750A4" value="#FF6750A4">
 </label>
       </div>
                 <div class="cp-links">
@@ -249,21 +249,21 @@ a:hover { text-decoration: underline; }
     return o;
   }
   // The live-stream override map: the display fields PLUS the author-declared knob values as
-  // `knob.<key>` entries (the daemon's setOverrides parses the same map /render does, and
-  // ServeOverrides reads knob.* keys). Kept separate from overrides() so query() and the Wasm
-  // patch — which append/ignore knobs their own way — are unaffected; without this a knob edit
-  // during an active Live (stream) would send only the display fields and the daemon would reset
-  // the knob to its default.
+  // `knob.<key>=<value>` entries (the daemon's setOverrides parses the same map /render does,
+  // typing each from the preview's declaration). Kept separate from overrides() so query() and
+  // the Wasm patch — which append/ignore knobs their own way — are unaffected; without this a
+  // knob edit during an active Live (stream) would send only the display fields and the daemon
+  // would reset the others to their defaults. Unlike query(), every knob is sent (not just
+  // changed ones) for exactly that reason, so defaults are not filtered here.
   function liveOverrides() {
     var o = overrides();
     document.querySelectorAll(".cp-knob").forEach(function (el) {
       if (el.disabled) return;
       var key = el.getAttribute("data-knob-key");
-      var kind = el.getAttribute("data-knob-kind") || "string";
       if (!key) return;
       var val = (el.type === "checkbox") ? (el.checked ? "true" : "false") : el.value;
       if (val === "") return;
-      o["knob." + key] = kind + ":" + val;
+      o["knob." + key] = val;
     });
     return o;
   }
@@ -275,15 +275,18 @@ a:hover { text-decoration: underline; }
     if (token) parts.push("token=" + encodeURIComponent(token));
     if (session) parts.push("session=" + encodeURIComponent(session));
     Object.keys(o).forEach(function (k) { parts.push(k + "=" + encodeURIComponent(o[k])); });
-    // Author-declared knobs (enabled only on a daemon session): knob.<key>=<kind>:<value>.
+    // Author-declared knobs: knob.<key>=<value>. The server infers the type from the preview's
+    // declaration, so no <kind>: prefix. A knob still at its declared default is omitted — that
+    // keeps the URL on the instant baked snapshot (any knob.* param routes a published catalog
+    // to the daemon for a fresh re-render); only an actually-changed knob is sent.
     document.querySelectorAll(".cp-knob").forEach(function (el) {
       if (el.disabled) return;
       var key = el.getAttribute("data-knob-key");
-      var kind = el.getAttribute("data-knob-kind") || "string";
       if (!key) return;
       var val = (el.type === "checkbox") ? (el.checked ? "true" : "false") : el.value;
       if (val === "") return;
-      parts.push("knob." + encodeURIComponent(key) + "=" + encodeURIComponent(kind + ":" + val));
+      if (val === (el.getAttribute("data-knob-initial") || "")) return;
+      parts.push("knob." + encodeURIComponent(key) + "=" + encodeURIComponent(val));
     });
     return parts.join("&");
   }

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
@@ -234,21 +234,21 @@ a:hover { text-decoration: underline; }
     return o;
   }
   // The live-stream override map: the display fields PLUS the author-declared knob values as
-  // `knob.<key>` entries (the daemon's setOverrides parses the same map /render does, and
-  // ServeOverrides reads knob.* keys). Kept separate from overrides() so query() and the Wasm
-  // patch — which append/ignore knobs their own way — are unaffected; without this a knob edit
-  // during an active Live (stream) would send only the display fields and the daemon would reset
-  // the knob to its default.
+  // `knob.<key>=<value>` entries (the daemon's setOverrides parses the same map /render does,
+  // typing each from the preview's declaration). Kept separate from overrides() so query() and
+  // the Wasm patch — which append/ignore knobs their own way — are unaffected; without this a
+  // knob edit during an active Live (stream) would send only the display fields and the daemon
+  // would reset the others to their defaults. Unlike query(), every knob is sent (not just
+  // changed ones) for exactly that reason, so defaults are not filtered here.
   function liveOverrides() {
     var o = overrides();
     document.querySelectorAll(".cp-knob").forEach(function (el) {
       if (el.disabled) return;
       var key = el.getAttribute("data-knob-key");
-      var kind = el.getAttribute("data-knob-kind") || "string";
       if (!key) return;
       var val = (el.type === "checkbox") ? (el.checked ? "true" : "false") : el.value;
       if (val === "") return;
-      o["knob." + key] = kind + ":" + val;
+      o["knob." + key] = val;
     });
     return o;
   }
@@ -260,15 +260,18 @@ a:hover { text-decoration: underline; }
     if (token) parts.push("token=" + encodeURIComponent(token));
     if (session) parts.push("session=" + encodeURIComponent(session));
     Object.keys(o).forEach(function (k) { parts.push(k + "=" + encodeURIComponent(o[k])); });
-    // Author-declared knobs (enabled only on a daemon session): knob.<key>=<kind>:<value>.
+    // Author-declared knobs: knob.<key>=<value>. The server infers the type from the preview's
+    // declaration, so no <kind>: prefix. A knob still at its declared default is omitted — that
+    // keeps the URL on the instant baked snapshot (any knob.* param routes a published catalog
+    // to the daemon for a fresh re-render); only an actually-changed knob is sent.
     document.querySelectorAll(".cp-knob").forEach(function (el) {
       if (el.disabled) return;
       var key = el.getAttribute("data-knob-key");
-      var kind = el.getAttribute("data-knob-kind") || "string";
       if (!key) return;
       var val = (el.type === "checkbox") ? (el.checked ? "true" : "false") : el.value;
       if (val === "") return;
-      parts.push("knob." + encodeURIComponent(key) + "=" + encodeURIComponent(kind + ":" + val));
+      if (val === (el.getAttribute("data-knob-initial") || "")) return;
+      parts.push("knob." + encodeURIComponent(key) + "=" + encodeURIComponent(val));
     });
     return parts.join("&");
   }

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
@@ -235,21 +235,21 @@ a:hover { text-decoration: underline; }
     return o;
   }
   // The live-stream override map: the display fields PLUS the author-declared knob values as
-  // `knob.<key>` entries (the daemon's setOverrides parses the same map /render does, and
-  // ServeOverrides reads knob.* keys). Kept separate from overrides() so query() and the Wasm
-  // patch — which append/ignore knobs their own way — are unaffected; without this a knob edit
-  // during an active Live (stream) would send only the display fields and the daemon would reset
-  // the knob to its default.
+  // `knob.<key>=<value>` entries (the daemon's setOverrides parses the same map /render does,
+  // typing each from the preview's declaration). Kept separate from overrides() so query() and
+  // the Wasm patch — which append/ignore knobs their own way — are unaffected; without this a
+  // knob edit during an active Live (stream) would send only the display fields and the daemon
+  // would reset the others to their defaults. Unlike query(), every knob is sent (not just
+  // changed ones) for exactly that reason, so defaults are not filtered here.
   function liveOverrides() {
     var o = overrides();
     document.querySelectorAll(".cp-knob").forEach(function (el) {
       if (el.disabled) return;
       var key = el.getAttribute("data-knob-key");
-      var kind = el.getAttribute("data-knob-kind") || "string";
       if (!key) return;
       var val = (el.type === "checkbox") ? (el.checked ? "true" : "false") : el.value;
       if (val === "") return;
-      o["knob." + key] = kind + ":" + val;
+      o["knob." + key] = val;
     });
     return o;
   }
@@ -261,15 +261,18 @@ a:hover { text-decoration: underline; }
     if (token) parts.push("token=" + encodeURIComponent(token));
     if (session) parts.push("session=" + encodeURIComponent(session));
     Object.keys(o).forEach(function (k) { parts.push(k + "=" + encodeURIComponent(o[k])); });
-    // Author-declared knobs (enabled only on a daemon session): knob.<key>=<kind>:<value>.
+    // Author-declared knobs: knob.<key>=<value>. The server infers the type from the preview's
+    // declaration, so no <kind>: prefix. A knob still at its declared default is omitted — that
+    // keeps the URL on the instant baked snapshot (any knob.* param routes a published catalog
+    // to the daemon for a fresh re-render); only an actually-changed knob is sent.
     document.querySelectorAll(".cp-knob").forEach(function (el) {
       if (el.disabled) return;
       var key = el.getAttribute("data-knob-key");
-      var kind = el.getAttribute("data-knob-kind") || "string";
       if (!key) return;
       var val = (el.type === "checkbox") ? (el.checked ? "true" : "false") : el.value;
       if (val === "") return;
-      parts.push("knob." + encodeURIComponent(key) + "=" + encodeURIComponent(kind + ":" + val));
+      if (val === (el.getAttribute("data-knob-initial") || "")) return;
+      parts.push("knob." + encodeURIComponent(key) + "=" + encodeURIComponent(val));
     });
     return parts.join("&");
   }

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
@@ -235,21 +235,21 @@ a:hover { text-decoration: underline; }
     return o;
   }
   // The live-stream override map: the display fields PLUS the author-declared knob values as
-  // `knob.<key>` entries (the daemon's setOverrides parses the same map /render does, and
-  // ServeOverrides reads knob.* keys). Kept separate from overrides() so query() and the Wasm
-  // patch — which append/ignore knobs their own way — are unaffected; without this a knob edit
-  // during an active Live (stream) would send only the display fields and the daemon would reset
-  // the knob to its default.
+  // `knob.<key>=<value>` entries (the daemon's setOverrides parses the same map /render does,
+  // typing each from the preview's declaration). Kept separate from overrides() so query() and
+  // the Wasm patch — which append/ignore knobs their own way — are unaffected; without this a
+  // knob edit during an active Live (stream) would send only the display fields and the daemon
+  // would reset the others to their defaults. Unlike query(), every knob is sent (not just
+  // changed ones) for exactly that reason, so defaults are not filtered here.
   function liveOverrides() {
     var o = overrides();
     document.querySelectorAll(".cp-knob").forEach(function (el) {
       if (el.disabled) return;
       var key = el.getAttribute("data-knob-key");
-      var kind = el.getAttribute("data-knob-kind") || "string";
       if (!key) return;
       var val = (el.type === "checkbox") ? (el.checked ? "true" : "false") : el.value;
       if (val === "") return;
-      o["knob." + key] = kind + ":" + val;
+      o["knob." + key] = val;
     });
     return o;
   }
@@ -261,15 +261,18 @@ a:hover { text-decoration: underline; }
     if (token) parts.push("token=" + encodeURIComponent(token));
     if (session) parts.push("session=" + encodeURIComponent(session));
     Object.keys(o).forEach(function (k) { parts.push(k + "=" + encodeURIComponent(o[k])); });
-    // Author-declared knobs (enabled only on a daemon session): knob.<key>=<kind>:<value>.
+    // Author-declared knobs: knob.<key>=<value>. The server infers the type from the preview's
+    // declaration, so no <kind>: prefix. A knob still at its declared default is omitted — that
+    // keeps the URL on the instant baked snapshot (any knob.* param routes a published catalog
+    // to the daemon for a fresh re-render); only an actually-changed knob is sent.
     document.querySelectorAll(".cp-knob").forEach(function (el) {
       if (el.disabled) return;
       var key = el.getAttribute("data-knob-key");
-      var kind = el.getAttribute("data-knob-kind") || "string";
       if (!key) return;
       var val = (el.type === "checkbox") ? (el.checked ? "true" : "false") : el.value;
       if (val === "") return;
-      parts.push("knob." + encodeURIComponent(key) + "=" + encodeURIComponent(kind + ":" + val));
+      if (val === (el.getAttribute("data-knob-initial") || "")) return;
+      parts.push("knob." + encodeURIComponent(key) + "=" + encodeURIComponent(val));
     });
     return parts.join("&");
   }

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
@@ -234,21 +234,21 @@ a:hover { text-decoration: underline; }
     return o;
   }
   // The live-stream override map: the display fields PLUS the author-declared knob values as
-  // `knob.<key>` entries (the daemon's setOverrides parses the same map /render does, and
-  // ServeOverrides reads knob.* keys). Kept separate from overrides() so query() and the Wasm
-  // patch — which append/ignore knobs their own way — are unaffected; without this a knob edit
-  // during an active Live (stream) would send only the display fields and the daemon would reset
-  // the knob to its default.
+  // `knob.<key>=<value>` entries (the daemon's setOverrides parses the same map /render does,
+  // typing each from the preview's declaration). Kept separate from overrides() so query() and
+  // the Wasm patch — which append/ignore knobs their own way — are unaffected; without this a
+  // knob edit during an active Live (stream) would send only the display fields and the daemon
+  // would reset the others to their defaults. Unlike query(), every knob is sent (not just
+  // changed ones) for exactly that reason, so defaults are not filtered here.
   function liveOverrides() {
     var o = overrides();
     document.querySelectorAll(".cp-knob").forEach(function (el) {
       if (el.disabled) return;
       var key = el.getAttribute("data-knob-key");
-      var kind = el.getAttribute("data-knob-kind") || "string";
       if (!key) return;
       var val = (el.type === "checkbox") ? (el.checked ? "true" : "false") : el.value;
       if (val === "") return;
-      o["knob." + key] = kind + ":" + val;
+      o["knob." + key] = val;
     });
     return o;
   }
@@ -260,15 +260,18 @@ a:hover { text-decoration: underline; }
     if (token) parts.push("token=" + encodeURIComponent(token));
     if (session) parts.push("session=" + encodeURIComponent(session));
     Object.keys(o).forEach(function (k) { parts.push(k + "=" + encodeURIComponent(o[k])); });
-    // Author-declared knobs (enabled only on a daemon session): knob.<key>=<kind>:<value>.
+    // Author-declared knobs: knob.<key>=<value>. The server infers the type from the preview's
+    // declaration, so no <kind>: prefix. A knob still at its declared default is omitted — that
+    // keeps the URL on the instant baked snapshot (any knob.* param routes a published catalog
+    // to the daemon for a fresh re-render); only an actually-changed knob is sent.
     document.querySelectorAll(".cp-knob").forEach(function (el) {
       if (el.disabled) return;
       var key = el.getAttribute("data-knob-key");
-      var kind = el.getAttribute("data-knob-kind") || "string";
       if (!key) return;
       var val = (el.type === "checkbox") ? (el.checked ? "true" : "false") : el.value;
       if (val === "") return;
-      parts.push("knob." + encodeURIComponent(key) + "=" + encodeURIComponent(kind + ":" + val));
+      if (val === (el.getAttribute("data-knob-initial") || "")) return;
+      parts.push("knob." + encodeURIComponent(key) + "=" + encodeURIComponent(val));
     });
     return parts.join("&");
   }


### PR DESCRIPTION
## Summary

Opening the viewer for a preview with author-declared knobs (e.g. `/compose-m3/p/button-elevated__ideal__default__light`) showed the image only after a delay, and the image differed from the bare `/compose-m3/render/button-elevated__ideal__default__light.png`.

**Cause.** The viewer seeds each knob control with its declared default and `query()` emitted **every** enabled knob on the first render, so the initial image URL carried `?knob.label=string:Elevated`. On a published catalog (`ServeCatalogLiveHost`) *any* `knob.*` param routes to the live daemon for an on-demand re-render — `daemonIdForOverrideRender` only checks that `namedOverrides` is non-empty, not whether the value is still the default. So the page woke the daemon and painted fresh pixels that differ from the instant baked PNG, for a knob nobody had changed.

## Changes

- **Skip default-valued knobs.** `overrideKnobsHtml` stamps each control with `data-knob-initial`; `query()` omits a knob still equal to it (mirrors the existing `fontScaleTouched` guard). On load no `knob.*` is emitted → the baked snapshot is served instantly and is pixel-identical to the bare `/render/<id>.png`. Only an edited knob wakes the daemon.
- **Drop the `<kind>:` wire prefix.** The URL is now `knob.<key>=<value>`; `ServeOverrides.parse` infers the type from the preview's declaration (`declaredKnobKinds`), wired through the `/render`, WebSocket, stream, and live parse sites. The legacy `knob.count=int:3` form still parses for older shared links.

## Test plan

- `./gradlew :cli:test --tests '*ServeOverridesTest*' --tests '*ServeWebFixtureTest*'` — green.
- New `ServeOverridesTest` cases: bare value parses as string; bare value typed from declared kinds; explicit `<kind>:` still wins; declared-numeric bare value must still be numeric.
- Golden viewer fixtures regenerated (`UPDATE_SERVE_WEB_FIXTURES=true`) — they now carry `data-knob-initial`, the default-skipping `query()`, and the type-free `knob.<key>=<value>` wire form.

## Visual evidence

The viewer's rendered **chrome is unchanged** — the only DOM delta is an invisible `data-knob-initial` attribute plus JS behavior; the regenerated golden HTML fixtures in `vscode-extension/preview-harness/fixtures/pages/` are the reviewable diff. The user-visible effect is *which lane serves the preview image* (instant baked PNG vs a daemon re-render), which is a property of the live server and can't be captured in a headless container. To verify manually: open `…/p/button-elevated__ideal__default__light` and confirm the image appears immediately and matches `…/render/button-elevated__ideal__default__light.png`.

## Out of scope / follow-up

A manual `?knob.label=Ground` still routing to the daemon but not visibly changing the render is a **separate** question (whether that preview is aliased to a daemon twin and whether the `label` knob is wired to its visible text — `ServeCatalogLiveHost.alias` / the named-override planner, not the URL grammar). Not addressed here; happy to investigate as a follow-up.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MkDr2hzvkuW9yrs16eFCyj)_