### PR TITLE
test(vscode): stabilise the flaky font-browser snapshot

### DIFF
--- a/vscode-extension/preview-harness/snapshot.spec.mjs
+++ b/vscode-extension/preview-harness/snapshot.spec.mjs
@@ -25,6 +25,24 @@ for (const fixture of listFixtures()) {
             wireDiagnostics(page, `${fixture}/${theme}`);
             const data = loadFixture(fixture);
 
+            // Deterministic web fonts. The font-browser fixture injects a
+            // `<link href="fonts.googleapis.com/css2?family=…">` per browse
+            // row so each family paints in its real webface. Whether those
+            // sheets (and the `fonts.gstatic.com` woff2 they pull) land
+            // before the screenshot is a network+timing race the in-page
+            // `document.fonts.ready` settle can't close — the request may
+            // still be in flight when it resolves. So the browse list
+            // rendered in the real face on a fast/online run and the
+            // fallback face on a slow/offline one, churning the
+            // fonts-browser baseline every push (and *which* theme variant
+            // lost the race flipped run-to-run). Stub the external font
+            // hosts with an empty sheet so browse rows always paint in the
+            // deterministic fallback, independent of network — same tactic
+            // the pages spec uses to stub the daemon's `/render/` images.
+            await page.route(/fonts\.(googleapis|gstatic)\.com\//, (route) =>
+                route.fulfill({ contentType: "text/css", body: "" }),
+            );
+
             await gotoFixture(page, fixture, theme);
             await replayActions(page, data.actions);
 


### PR DESCRIPTION
## Summary

The preview-harness `snapshot.spec.mjs` captured the `fonts-browser` fixture without pinning its web fonts, so that fixture's baseline churned non-deterministically and the visual-diff bot kept flagging it on unrelated PRs.

**Root cause (reproduced locally):** the font-browser webview injects a `<link href="fonts.googleapis.com/css2?family=…">` per browse row so each family name paints in its *real* Google webface (`main.ts` → `ensureBrowseLink` → `buildCss2BrowseUrl`). Whether that sheet — and the `fonts.gstatic.com` woff2 it pulls — lands before the screenshot is a network + timing race that the in-page `document.fonts.ready` settle can't close (the request can still be in flight when it resolves). So the browse list rendered in the real face on a fast/online run and in the fallback face on a slow/offline one. The fixture is captured for both themes, so *which* variant (`fonts-browser.light` vs `fonts-browser.dark`) lost the race — and got flagged — flipped run-to-run.

I confirmed the mechanism by intercepting the browse `<link>`: fulfilling it (family in a distinct installed serif) vs aborting it (fallback) produced two different PNGs from the identical fixture — proving the captured pixels depend purely on whether the network font won the race.

## Fix

Stub the external font hosts with an empty stylesheet in `snapshot.spec.mjs`, before navigation, so browse rows always paint in the deterministic fallback face regardless of network state:

```js
await page.route(/fonts\.(googleapis|gstatic)\.com\//, (route) =>
    route.fulfill({ contentType: "text/css", body: "" }),
);
```

This is the same tactic the sibling `pages-snapshot.spec.mjs` already uses to stub the daemon's `/render/` images for deterministic capture. Non-font fixtures never hit those hosts, so the route is inert for them.

Note: the customiser specimen (the main subject of the fixture) is unaffected — it renders from the downloaded face served locally at `/media/codicon.ttf`, not the network. Only the browse-list family names change, and only from "sometimes real, sometimes fallback" to "always fallback". Expect a one-time `fonts-browser` baseline shift when this merges and `vscode-preview-baselines` regenerates; it will be stable thereafter.

## Test plan

- Ran `harness:snapshot` for `fonts-browser` (both themes) 3× with the fix — byte-identical PNGs every run (`dark` and `light` each stable).
- Verified `grid-default` (a non-font fixture) is unchanged by the added route.
- Reproduced the pre-fix non-determinism by toggling the browse `<link>` outcome and observing the two divergent captures.


---
_Generated by [Claude Code](https://claude.ai/code/session_015eAU1cgViEs24jy95MGK2a)_