### PR TITLE
fix(design-artifacts): load compare-page images cross-origin so scores work on htmlpreview

### DIFF
--- a/scripts/design-artifacts/render-compare-html.mjs
+++ b/scripts/design-artifacts/render-compare-html.mjs
@@ -89,6 +89,14 @@ const SCORER = String.raw`
     return new Promise((res, rej) => {
       const img = new Image();
       img.decoding = "async";
+      // Request the pixels with CORS so drawing them to a canvas doesn't taint it. On htmlpreview the
+      // page origin is htmlpreview.github.io while the images load cross-origin from
+      // raw.githubusercontent.com (which allows cross-origin reads); without this the canvas taints
+      // and every getImageData throws, so no row scores. Set for relative / http(s) srcs (a relative
+      // images/... path resolves cross-origin against the injected base on htmlpreview) but NOT for
+      // the same-origin-clean blob: URLs the hybrid path builds, nor data: URLs (some engines refuse
+      // to load those under a crossOrigin request).
+      if (!/^(data|blob):/i.test(src)) img.crossOrigin = "anonymous";
       img.onload = () => res(img);
       img.onerror = () => rej(new Error("load failed: " + src));
       img.src = src;
@@ -485,10 +493,11 @@ export function renderCompareHtml(catalog, opts = {}) {
   daemon's fidelity harness), so the score reflects real vector drift, not a constant inset. Hybrid stickers'
   raster crop layers are inlined so their score reflects the full sticker. <strong>Rows sort largest-diff-first
   once scored</strong>, so the worst offenders come to the top.</p>
-  <p class="taintwarn" id="taintwarn">⚠ The match scores need to read pixels from a canvas, which the
-  browser blocks over <code>file://</code> (opaque origin). Open this page over <strong>http</strong> —
-  via the README's htmlpreview link, or a local server (<code>python3 -m http.server</code> in the branch)
-  — and the scores compute.</p>
+  <p class="taintwarn" id="taintwarn">⚠ The match scores read pixels back from a canvas, which the browser
+  blocks when the images can't be read cross-origin — over <code>file://</code> (opaque origin), or from a
+  host that doesn't send CORS headers for the PNGs. Open this page over <strong>http</strong> from a
+  CORS-enabled host: the README's htmlpreview link (images come from <code>raw.githubusercontent.com</code>,
+  which allows it) or a local server (<code>python3 -m http.server</code> in the branch).</p>
 </header>
 <main>
   <table>

--- a/scripts/design-artifacts/render-compare-html.test.mjs
+++ b/scripts/design-artifacts/render-compare-html.test.mjs
@@ -58,6 +58,15 @@ test("the in-page SSIM scorer is embedded", () => {
   assert.match(html, /querySelectorAll\("tr\[data-png\]\[data-svg\]"\)/);
 });
 
+test("images load with crossOrigin so the canvas isn't tainted on htmlpreview", () => {
+  // htmlpreview serves the page from htmlpreview.github.io but the PNGs from raw.githubusercontent
+  // (cross-origin); without a CORS request the canvas taints and no row scores. Pin the fix.
+  const html = renderCompareHtml(catalog, { figmaSvgSlugs: new Set(["button-filled"]) });
+  assert.match(html, /img\.crossOrigin = "anonymous"/);
+  // …but not for the same-origin blob: / data: URLs the hybrid inline path builds.
+  assert.match(html, /\/\^\(data\|blob\):\/i\.test\(src\)/);
+});
+
 test("the scorer aligns the SVG's export padding out before scoring (translate crop)", () => {
   // The export pads the canvas + wraps the tree in translate(tx,ty); the scorer must crop
   // that back to the PNG's padding-free space (mirroring FigmaSvgFidelity.alignToRender),


### PR DESCRIPTION
## Summary

The `compare.html` page computes its match scores by drawing each PNG/SVG into a canvas and reading the pixels back. On **htmlpreview**, the page runs on `htmlpreview.github.io` while the PNGs load **cross-origin** from `raw.githubusercontent.com` — so without a CORS request the canvas **taints** and every `getImageData` throws. The page showed **"scored 0/26"** and the *"open over http"* banner **even though it was already over http** (see below).

**Fix:** load the images with `crossOrigin="anonymous"` (raw.githubusercontent allows cross-origin reads), so the canvas stays clean and the rows score. It's skipped for the same-origin `blob:` URLs the hybrid inline path builds and for `data:` URLs (some engines refuse a `crossOrigin` request on those). The banner text now names the real cause — a non-CORS image host, not just `file://`.

## Repro (before)

The screenshot the bug was reported from: htmlpreview, `avg structural match —`, `scored 0/26`, banner showing — the canvas was tainted by the cross-origin images.

## Validation

Two-origin harness (page served on one port; CORS-enabled images on another; page carries a `<base>` pointing at the image origin — exactly the htmlpreview shape):

- **before:** 0/26 scored, taint banner shown
- **after:** **26/26 scored, avg 84.9%, no banner, no page errors**

Same-origin (a local server / branch checkout) is unaffected; `file://` still shows the (now clearer) banner.

## Changes

- `render-compare-html.mjs` — `crossOrigin="anonymous"` on image loads (except `blob:`/`data:`); clearer banner copy
- `render-compare-html.test.mjs` — regression test pinning the crossOrigin behavior

## Test plan

- [x] `node --test scripts/design-artifacts/render-compare-html.test.mjs` → 12/12 pass
- [x] Two-origin (cross-origin + CORS) Playwright harness scores 26/26 with no taint banner

---
_Generated by [Claude Code](https://claude.ai/code/session_014nC2f2D5MWRPnJeqnrrq5Y)_