### PR TITLE
fix(serve): honor display-axis overrides on the published catalog

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
@@ -3,6 +3,7 @@ package ee.schimke.composeai.cli.serve
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.daemon.protocol.StreamCodec
 import ee.schimke.composeai.daemon.protocol.StreamFrameParams
+import ee.schimke.composeai.daemon.protocol.UiMode
 
 /**
  * A [ServeHost] that fronts a trusted design-system catalog with its baked-PNG render **and** an
@@ -88,14 +89,14 @@ class ServeCatalogLiveHost(
   internal val bakedHost: ServeHost = baked
 
   /**
-   * Ordinary browsing serves the baked catalog PNG — instant, and never wakes the daemon (a viewer
-   * that replays a sticky theme override into the snapshot URL must still land on baked pixels).
-   * The one exception is an **author-declared knob** edit ([PreviewOverrides.namedOverrides]):
-   * those knobs (`label`, a color, …) can only be honoured by re-running the composable, which the
-   * baked PNG can't do, so a knob-bearing render on a mapped id is routed to the [live] daemon
-   * (which also applies any display axes carried alongside). Display-axis-only overrides stay baked
-   * — the published variant already encodes its theme, and keeping them baked preserves instant
-   * browsing.
+   * Ordinary browsing serves the baked catalog PNG — instant, and never wakes the daemon: an
+   * override-free render (or one carrying only a `uiMode` that matches the variant's baked theme,
+   * as the viewer replays from its sticky theme) lands on baked pixels. Any override that would
+   * change those pixels — a named knob, a font scale, device, locale, orientation, a feature
+   * override, … — is routed to the [live] daemon to re-render, since the baked PNG can't represent
+   * it ([overridesAffectRender]). So a `/render?fontScale=…` or `?knob.label=…` URL returns fresh
+   * pixels, while the default browse stays baked-instant. Only the mapped (daemon-twinned) ids can
+   * re-render; an unmapped Android-only variant always replays baked.
    */
   override fun render(previewId: String, overrides: PreviewOverrides): RenderOutcome {
     val daemonId = daemonIdForOverrideRender(previewId, overrides)
@@ -123,11 +124,38 @@ class ServeCatalogLiveHost(
 
   /**
    * The daemon preview id to route a [render] / [renderSvg] to, or null to stay baked. Non-null
-   * only when [previewId] is a mapped (daemon-renderable) id AND the request carries an
-   * author-declared knob override — the sole case the baked PNG can't satisfy.
+   * only when [previewId] is a mapped (daemon-renderable) id AND the request carries an override
+   * the baked PNG can't satisfy ([overridesAffectRender]).
    */
-  private fun daemonIdForOverrideRender(previewId: String, overrides: PreviewOverrides): String? =
-    if (overrides.namedOverrides.isNullOrEmpty()) null else alias[previewId]
+  private fun daemonIdForOverrideRender(previewId: String, overrides: PreviewOverrides): String? {
+    // No daemon twin (an Android-only variant) ⇒ always baked; it has no live lane.
+    val daemonId = alias[previewId] ?: return null
+    return if (overridesAffectRender(previewId, overrides)) daemonId else null
+  }
+
+  /**
+   * Whether [overrides] would change pixels vs the preview's baked sticker, so the render must go
+   * to the daemon rather than replay the baked PNG. The baked variant already encodes its **theme**
+   * (the `…__light` / `…__dark` id segment) and every other axis at its discovery-time default, so
+   * a bare `uiMode` that matches the variant is a no-op and stays baked (keeping browsing instant);
+   * anything else — a font scale, device, locale, orientation, a named knob, a feature override
+   * (gestures / focus / keyboard / …) — needs a re-render. Uses data-class equality against a
+   * defaults instance so a newly added override field is covered without touching this predicate.
+   */
+  private fun overridesAffectRender(previewId: String, o: PreviewOverrides): Boolean {
+    val bakedTheme =
+      previewId.split("__").let { segments ->
+        when {
+          "dark" in segments -> UiMode.DARK
+          "light" in segments -> UiMode.LIGHT
+          else -> null
+        }
+      }
+    // A uiMode matching the baked variant is a no-op; drop it, then any remaining set field
+    // (including a *differing* uiMode) means a re-render is required.
+    val uiModeIsNoOp = o.uiMode == null || o.uiMode == bakedTheme
+    return if (uiModeIsNoOp) o.copy(uiMode = null) != PreviewOverrides() else true
+  }
 
   /** Live streaming is available only for aliased ids; others have no stream (snapshot only). */
   override fun subscribeStream(

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
@@ -143,13 +143,15 @@ class ServeCatalogLiveHost(
    * defaults instance so a newly added override field is covered without touching this predicate.
    */
   private fun overridesAffectRender(previewId: String, o: PreviewOverrides): Boolean {
+    // The theme is the LAST `light`/`dark` id segment (past the component slug) — matching
+    // `ServeUrls.wasmAppSrc` / `ServeWeb.cardTheme`. Scanning for `dark` first would misread a
+    // non-theme segment named `dark` in an otherwise-light variant, wrongly treating `uiMode=dark`
+    // as a no-op and dropping the override.
     val bakedTheme =
-      previewId.split("__").let { segments ->
-        when {
-          "dark" in segments -> UiMode.DARK
-          "light" in segments -> UiMode.LIGHT
-          else -> null
-        }
+      when (previewId.split("__").drop(1).lastOrNull { it == "light" || it == "dark" }) {
+        "dark" -> UiMode.DARK
+        "light" -> UiMode.LIGHT
+        else -> null
       }
     // A uiMode matching the baked variant is a no-op; drop it, then any remaining set field
     // (including a *differing* uiMode) means a re-render is required.

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -370,12 +370,17 @@ object ServeWeb {
     (function () {
       var el = document.getElementById("cp-uiMode");
       if (!el) return;
-      // Inherit the catalog's sticky theme on the first render — matters for theme-less previews the
-      // catalog shows under either filter, which would otherwise open at (default). This runs before
-      // viewerScript()'s initial render, so the snapshot / Wasm path picks it up.
+      // Inherit the catalog's sticky theme on the first render — but ONLY for a theme-less preview
+      // (id carries no __light/__dark segment), which would otherwise open at (default). A themed
+      // variant's theme is explicit in its deep link, so it opens on its baked (instant) pixels and
+      // is not overridden by a remembered theme — seeding it would force a daemon re-render on a
+      // fresh deep link, defeating baked-until-changed. Runs before viewerScript()'s initial render.
+      var root = document.querySelector(".cp-viewer");
+      var pid = (root && root.getAttribute("data-preview-id")) || "";
+      var themed = pid.split("__").some(function (s) { return s === "light" || s === "dark"; });
       try {
         var stored = localStorage.getItem("cp-theme");
-        if (!el.value && (stored === "light" || stored === "dark")) el.value = stored;
+        if (!themed && !el.value && (stored === "light" || stored === "dark")) el.value = stored;
       } catch (e) {}
       // Round-trip: a Theme change writes the shared key so the catalog remembers it.
       el.addEventListener("change", function () {

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
@@ -5,6 +5,7 @@ import ee.schimke.composeai.daemon.protocol.PreviewOverrideValue
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.daemon.protocol.StreamCodec
 import ee.schimke.composeai.daemon.protocol.StreamFrameParams
+import ee.schimke.composeai.daemon.protocol.UiMode
 import ee.schimke.composeai.data.overrides.PreviewOverrideDeclaration
 import ee.schimke.composeai.data.overrides.PreviewOverrideType
 import kotlin.test.Test
@@ -14,12 +15,13 @@ import kotlin.test.assertTrue
 
 /**
  * The catalog-id bridge: [ServeCatalogLiveHost] fronts the baked catalog with an opt-in daemon
- * stream. Every **snapshot** is the baked PNG (browsing stays instant and never wakes the daemon,
- * even when the viewer replays a sticky theme override); the daemon is reached only via the **live
- * stream**, mapping the catalog id to its daemon-preview id. An unmapped id (an Android-only
- * variant) has no stream. The composite reports itself as a static-snapshot host
- * ([canApplyOverrides] false) that still offers Live ([hasLiveStream] true), and exposes its baked
- * host so the trust badge + card title survive.
+ * stream. An override-free snapshot (or one replaying only the variant's own sticky theme) is the
+ * baked PNG — browsing stays instant and never wakes the daemon. A snapshot carrying a
+ * pixel-changing override (a knob, font scale, device, a differing theme, …) re-renders on the
+ * daemon, mapping the catalog id to its daemon-preview id; an unmapped id (an Android-only variant)
+ * has no daemon twin and always replays baked. The composite reports itself as a static-snapshot
+ * host ([canApplyOverrides] false) that still offers Live ([hasLiveStream] true), and exposes its
+ * baked host so the trust badge + card title survive.
  */
 class ServeCatalogLiveHostTest {
 
@@ -231,15 +233,40 @@ class ServeCatalogLiveHostTest {
   }
 
   @Test
-  fun `snapshots stay baked even with overrides on a mapped id`() {
-    // The viewer replays a sticky theme override into the snapshot URL; the composite must still
-    // serve the baked PNG (never cold-start the daemon on the snapshot lane) — the daemon is the
-    // live-stream lane only.
+  fun `a variant-matching uiMode (sticky-theme replay) stays baked`() {
+    // The viewer replays its sticky theme into the snapshot URL. catalogId is the `…__dark`
+    // variant, so a uiMode=dark override is a no-op the baked PNG already encodes — it must NOT
+    // cold-start the daemon.
     val (composite, live, baked) = host()
-    val out = composite.render(catalogId, PreviewOverrides(density = 2.0f)) as RenderOutcome.Ok
+    val out =
+      composite.render(catalogId, PreviewOverrides(uiMode = UiMode.DARK)) as RenderOutcome.Ok
     assertEquals("baked:$catalogId", out.png.decodeToString())
     assertEquals(catalogId, baked.lastRenderId)
     assertNull(live.lastRenderId)
+  }
+
+  @Test
+  fun `a display-axis override on a mapped id routes to the daemon`() {
+    // A font scale (like device / locale / orientation) can't be replayed from the baked sticker,
+    // so it must re-render on the daemon — the correctness fix for standalone
+    // `/render?fontScale=…`.
+    val (composite, live, baked) = host()
+    val out = composite.render(catalogId, PreviewOverrides(fontScale = 1.5f)) as RenderOutcome.Ok
+    assertEquals("live:$daemonId", out.png.decodeToString())
+    assertEquals(daemonId, live.lastRenderId)
+    assertEquals(1.5f, live.lastRenderOverrides?.fontScale)
+    assertNull(baked.lastRenderId)
+  }
+
+  @Test
+  fun `a uiMode differing from the baked variant routes to the daemon`() {
+    // catalogId is the `…__dark` variant; asking for light is a real re-render, not a no-op.
+    val (composite, live, baked) = host()
+    val out =
+      composite.render(catalogId, PreviewOverrides(uiMode = UiMode.LIGHT)) as RenderOutcome.Ok
+    assertEquals("live:$daemonId", out.png.decodeToString())
+    assertEquals(daemonId, live.lastRenderId)
+    assertNull(baked.lastRenderId)
   }
 
   @Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
@@ -270,6 +270,27 @@ class ServeCatalogLiveHostTest {
   }
 
   @Test
+  fun `baked theme is the last theme segment, not a stray earlier one`() {
+    // A `dark` STATE segment sits before the real `light` theme segment. Detection must take the
+    // last theme segment (matching wasmAppSrc / cardTheme), so this variant reads as LIGHT: a
+    // uiMode=light is the no-op (baked) and uiMode=dark is the real re-render (daemon). A naive
+    // "dark in segments" check would flip both.
+    val trickyId = "toggle__dark__default__light"
+    val daemon = "ToggleLight"
+    val baked = RecordingHost(previews = listOf(ServePreview(trickyId, trickyId)), tag = "baked")
+    val live =
+      RecordingHost(previews = listOf(ServePreview(daemon, daemon)), tag = "live", streaming = true)
+    val composite = ServeCatalogLiveHost(mapOf(trickyId to daemon), live, baked)
+
+    composite.render(trickyId, PreviewOverrides(uiMode = UiMode.LIGHT))
+    assertEquals(trickyId, baked.lastRenderId) // light == variant theme → baked
+    assertNull(live.lastRenderId)
+
+    composite.render(trickyId, PreviewOverrides(uiMode = UiMode.DARK))
+    assertEquals(daemon, live.lastRenderId) // dark != variant theme → daemon
+  }
+
+  @Test
   fun `an unmapped id serves baked, even with overrides`() {
     val (composite, live, baked) = host()
     val out = composite.render(androidOnlyId, PreviewOverrides(density = 2.0f)) as RenderOutcome.Ok

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
@@ -190,12 +190,17 @@ a:hover { text-decoration: underline; }
       <script>(function () {
   var el = document.getElementById("cp-uiMode");
   if (!el) return;
-  // Inherit the catalog's sticky theme on the first render — matters for theme-less previews the
-  // catalog shows under either filter, which would otherwise open at (default). This runs before
-  // viewerScript()'s initial render, so the snapshot / Wasm path picks it up.
+  // Inherit the catalog's sticky theme on the first render — but ONLY for a theme-less preview
+  // (id carries no __light/__dark segment), which would otherwise open at (default). A themed
+  // variant's theme is explicit in its deep link, so it opens on its baked (instant) pixels and
+  // is not overridden by a remembered theme — seeding it would force a daemon re-render on a
+  // fresh deep link, defeating baked-until-changed. Runs before viewerScript()'s initial render.
+  var root = document.querySelector(".cp-viewer");
+  var pid = (root && root.getAttribute("data-preview-id")) || "";
+  var themed = pid.split("__").some(function (s) { return s === "light" || s === "dark"; });
   try {
     var stored = localStorage.getItem("cp-theme");
-    if (!el.value && (stored === "light" || stored === "dark")) el.value = stored;
+    if (!themed && !el.value && (stored === "light" || stored === "dark")) el.value = stored;
   } catch (e) {}
   // Round-trip: a Theme change writes the shared key so the catalog remembers it.
   el.addEventListener("change", function () {

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
@@ -175,12 +175,17 @@ a:hover { text-decoration: underline; }
       <script>(function () {
   var el = document.getElementById("cp-uiMode");
   if (!el) return;
-  // Inherit the catalog's sticky theme on the first render — matters for theme-less previews the
-  // catalog shows under either filter, which would otherwise open at (default). This runs before
-  // viewerScript()'s initial render, so the snapshot / Wasm path picks it up.
+  // Inherit the catalog's sticky theme on the first render — but ONLY for a theme-less preview
+  // (id carries no __light/__dark segment), which would otherwise open at (default). A themed
+  // variant's theme is explicit in its deep link, so it opens on its baked (instant) pixels and
+  // is not overridden by a remembered theme — seeding it would force a daemon re-render on a
+  // fresh deep link, defeating baked-until-changed. Runs before viewerScript()'s initial render.
+  var root = document.querySelector(".cp-viewer");
+  var pid = (root && root.getAttribute("data-preview-id")) || "";
+  var themed = pid.split("__").some(function (s) { return s === "light" || s === "dark"; });
   try {
     var stored = localStorage.getItem("cp-theme");
-    if (!el.value && (stored === "light" || stored === "dark")) el.value = stored;
+    if (!themed && !el.value && (stored === "light" || stored === "dark")) el.value = stored;
   } catch (e) {}
   // Round-trip: a Theme change writes the shared key so the catalog remembers it.
   el.addEventListener("change", function () {

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
@@ -176,12 +176,17 @@ a:hover { text-decoration: underline; }
       <script>(function () {
   var el = document.getElementById("cp-uiMode");
   if (!el) return;
-  // Inherit the catalog's sticky theme on the first render — matters for theme-less previews the
-  // catalog shows under either filter, which would otherwise open at (default). This runs before
-  // viewerScript()'s initial render, so the snapshot / Wasm path picks it up.
+  // Inherit the catalog's sticky theme on the first render — but ONLY for a theme-less preview
+  // (id carries no __light/__dark segment), which would otherwise open at (default). A themed
+  // variant's theme is explicit in its deep link, so it opens on its baked (instant) pixels and
+  // is not overridden by a remembered theme — seeding it would force a daemon re-render on a
+  // fresh deep link, defeating baked-until-changed. Runs before viewerScript()'s initial render.
+  var root = document.querySelector(".cp-viewer");
+  var pid = (root && root.getAttribute("data-preview-id")) || "";
+  var themed = pid.split("__").some(function (s) { return s === "light" || s === "dark"; });
   try {
     var stored = localStorage.getItem("cp-theme");
-    if (!el.value && (stored === "light" || stored === "dark")) el.value = stored;
+    if (!themed && !el.value && (stored === "light" || stored === "dark")) el.value = stored;
   } catch (e) {}
   // Round-trip: a Theme change writes the shared key so the catalog remembers it.
   el.addEventListener("change", function () {

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
@@ -176,12 +176,17 @@ a:hover { text-decoration: underline; }
       <script>(function () {
   var el = document.getElementById("cp-uiMode");
   if (!el) return;
-  // Inherit the catalog's sticky theme on the first render — matters for theme-less previews the
-  // catalog shows under either filter, which would otherwise open at (default). This runs before
-  // viewerScript()'s initial render, so the snapshot / Wasm path picks it up.
+  // Inherit the catalog's sticky theme on the first render — but ONLY for a theme-less preview
+  // (id carries no __light/__dark segment), which would otherwise open at (default). A themed
+  // variant's theme is explicit in its deep link, so it opens on its baked (instant) pixels and
+  // is not overridden by a remembered theme — seeding it would force a daemon re-render on a
+  // fresh deep link, defeating baked-until-changed. Runs before viewerScript()'s initial render.
+  var root = document.querySelector(".cp-viewer");
+  var pid = (root && root.getAttribute("data-preview-id")) || "";
+  var themed = pid.split("__").some(function (s) { return s === "light" || s === "dark"; });
   try {
     var stored = localStorage.getItem("cp-theme");
-    if (!el.value && (stored === "light" || stored === "dark")) el.value = stored;
+    if (!themed && !el.value && (stored === "light" || stored === "dark")) el.value = stored;
   } catch (e) {}
   // Round-trip: a Theme change writes the shared key so the catalog remembers it.
   el.addEventListener("change", function () {

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
@@ -175,12 +175,17 @@ a:hover { text-decoration: underline; }
       <script>(function () {
   var el = document.getElementById("cp-uiMode");
   if (!el) return;
-  // Inherit the catalog's sticky theme on the first render — matters for theme-less previews the
-  // catalog shows under either filter, which would otherwise open at (default). This runs before
-  // viewerScript()'s initial render, so the snapshot / Wasm path picks it up.
+  // Inherit the catalog's sticky theme on the first render — but ONLY for a theme-less preview
+  // (id carries no __light/__dark segment), which would otherwise open at (default). A themed
+  // variant's theme is explicit in its deep link, so it opens on its baked (instant) pixels and
+  // is not overridden by a remembered theme — seeding it would force a daemon re-render on a
+  // fresh deep link, defeating baked-until-changed. Runs before viewerScript()'s initial render.
+  var root = document.querySelector(".cp-viewer");
+  var pid = (root && root.getAttribute("data-preview-id")) || "";
+  var themed = pid.split("__").some(function (s) { return s === "light" || s === "dark"; });
   try {
     var stored = localStorage.getItem("cp-theme");
-    if (!el.value && (stored === "light" || stored === "dark")) el.value = stored;
+    if (!themed && !el.value && (stored === "light" || stored === "dark")) el.value = stored;
   } catch (e) {}
   // Round-trip: a Theme change writes the shared key so the catalog remembers it.
   el.addEventListener("change", function () {


### PR DESCRIPTION
## Summary

A `/render?fontScale=…` (or `device` / `localeTag` / `orientation` / a differing `uiMode`) on a published catalog was **silently served the baked sticker PNG** — the override was dropped. `ServeCatalogLiveHost` only routed to the live daemon when a `knob.*` override was present, so display-axis overrides alone did nothing; adding a knob was the only way to make e.g. `fontScale` take effect.

Live evidence of the old behavior (before this change), same server:

| URL | Result |
|---|---|
| `…button-filled…light.png?fontScale=1.1` | 301×210, **identical to default** — fontScale ignored |
| `…?knob.label=Hello` | 320×320 — daemon re-render |
| `…?fontScale=2.0&knob.label=Hello` | 320×320, big text — fontScale applied only because the knob woke the daemon |

## Fix

- **`overridesAffectRender`** routes a render to the daemon whenever the overrides would change pixels vs the baked sticker — i.e. any set field other than a `uiMode` that matches the variant's own baked theme (the sticky-theme replay, which stays baked/instant). It compares against a `PreviewOverrides()` defaults instance via data-class equality, so **a newly added override field is covered automatically** (no enumerating fields).
- **Baked-until-actually-changed** is preserved: the sticky catalog theme now seeds `uiMode` **only for theme-less previews**. A themed `…__light` / `…__dark` deep link opens on its baked variant rather than cold-starting the daemon to honor a remembered theme. Together with the existing default-knob and untouched-fontScale guards, a fresh deep link stays instant-baked until the visitor changes something.

## Test plan

- `./gradlew :cli:test --tests '*ServeCatalogLiveHostTest*' --tests '*ServeWebFixtureTest*'` — green.
- New `ServeCatalogLiveHostTest` cases: a variant-matching `uiMode` (sticky replay) stays baked; a `fontScale` override routes to the daemon (carried through); a `uiMode` differing from the baked variant routes to the daemon. Existing "unmapped id always baked" and "empty overrides baked" cases still pass.
- Viewer golden fixtures regenerated (`UPDATE_SERVE_WEB_FIXTURES=true`) for the sticky-theme-seed guard.

## Visual evidence

No change to the viewer's rendered chrome — the sticky-seed guard is invisible JS and the routing change is server-side behavior; the regenerated golden HTML fixtures are the reviewable diff. The user-visible effect is *which lane serves the image* (now: `fontScale`/`device`/… actually re-render), a property of the live server. After deploy, verify: `…?fontScale=2.0` alone now returns a re-rendered (larger-text) image instead of the baked default.

## Known follow-up (out of scope)

A daemon re-render comes out at the daemon's raw `@Preview` canvas size (e.g. 320×320) rather than the baked sticker's framed size (301×210) — so any override-driven render also changes size/framing. Reconciling the daemon render with the sticker framing is a separate, deeper change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MkDr2hzvkuW9yrs16eFCyj)_