### PR TITLE
feat(serve): render-mode radio group (PNG / Live Compose / Wasm)

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -78,6 +78,8 @@ object ServeWeb {
       transition: opacity 0.15s ease; pointer-events: none; }
     .cp-stage iframe.cp-wasm-live { opacity: 1; pointer-events: auto; }
     .cp-live-row { flex-direction: row !important; align-items: center; gap: 6px !important; }
+    .cp-modes { display: flex; flex-direction: row; flex-wrap: wrap; gap: 6px 14px;
+      font-size: 0.8rem; }
     .cp-controls { flex: 0 0 240px; display: flex; flex-direction: column; gap: 14px; }
     .cp-controls label { display: flex; flex-direction: column; gap: 4px; font-size: 0.8rem; }
     .cp-controls input, .cp-controls select { padding: 5px 6px; font-size: 0.85rem; }
@@ -704,11 +706,20 @@ object ServeWeb {
       if (wasmSrc != null)
         "<iframe id=\"cp-wasm\" hidden sandbox=\"$wasmSandbox\" title=\"$label (Wasm)\"></iframe>"
       else ""
-    val wasmToggle =
+    // The render mode is a radio group — PNG (baked snapshot, default), Live Compose (daemon
+    // stream), Wasm (in-browser CMP app). The Wasm option + its background checkbox appear only
+    // when
+    // a Wasm app backs the session; the Live radio is present but disabled when no stream is
+    // offered.
+    // Ids `cp-live` / `cp-wasm-toggle` are kept on the radios so the transition JS resolves them.
+    val wasmModeRadio =
       if (wasmSrc != null)
-        "<label class=\"cp-live-row\"><input id=\"cp-wasm-toggle\" type=\"checkbox\"> " +
-          "Run in browser (Wasm)</label>\n" +
-          "          <label class=\"cp-live-row\"><input id=\"cp-wasm-bg\" type=\"checkbox\"> " +
+        "<label class=\"cp-live-row\"><input type=\"radio\" name=\"cp-mode\" value=\"wasm\" " +
+          "id=\"cp-wasm-toggle\"> Wasm</label>"
+      else ""
+    val wasmBgRow =
+      if (wasmSrc != null)
+        "<label class=\"cp-live-row\"><input id=\"cp-wasm-bg\" type=\"checkbox\"> " +
           "Component only (no background)</label>"
       else ""
     val deviceOptions =
@@ -739,7 +750,7 @@ object ServeWeb {
       when {
         !staticSnapshot -> ""
         wasmSrc != null ->
-          "<div class=\"cp-note\">Pre-rendered snapshot — tick “Run in browser (Wasm)” to interact: " +
+          "<div class=\"cp-note\">Pre-rendered snapshot — pick “Wasm” to interact: " +
             "Theme, Font scale, Locale &amp; background apply in the browser. Device/Orientation " +
             "need the live server. <a href=\"$LOCAL_SERVER_DOCS\">Enable a local preview server.</a>" +
             "</div>"
@@ -758,8 +769,12 @@ object ServeWeb {
         <div class="cp-stage"><span class="cp-backend" id="cp-backend"></span><img id="cp-img" alt="$label"><canvas id="cp-canvas" hidden></canvas>$wasmFrame</div>
         <div class="cp-controls">
           $snapshotNote
-          <label class="cp-live-row"><input id="cp-live" type="checkbox"$liveDis> Live (stream)</label>
-          $wasmToggle
+          <div class="cp-modes" role="radiogroup" aria-label="Render mode">
+            <label class="cp-live-row"><input type="radio" name="cp-mode" value="png" id="cp-mode-png" checked> PNG</label>
+            <label class="cp-live-row"><input type="radio" name="cp-mode" value="live" id="cp-live"$liveDis> Live Compose</label>
+            $wasmModeRadio
+          </div>
+          $wasmBgRow
           <label>Theme
             <select id="cp-uiMode"$wasmDis>
               <option value="">(default)</option>
@@ -1196,8 +1211,11 @@ object ServeWeb {
         if (patch && wasmFrame.contentWindow) wasmFrame.contentWindow.postMessage(patch, "*");
       }
       function openWasm() {
-        // Wasm and the daemon stream are mutually exclusive — only one transport drives the stage.
-        if (live.checked) { live.checked = false; closeStream(); }
+        // No-op without a Wasm app (wasmFrame absent): enterMode() calls this unconditionally, but a
+        // non-Wasm daemon/static session has no iframe to drive. Guard so touching it can't throw.
+        if (!wasmFrame) return;
+        // Wasm and the daemon stream are mutually exclusive; the mode switch (enterMode) tears the
+        // stream down before opening Wasm, so there's nothing extra to close here.
         root.setAttribute("data-mode", "wasm");
         canvas.hidden = true;
         // Keep the snapshot visible while the app loads; the iframe mounts over it at opacity 0
@@ -1209,6 +1227,9 @@ object ServeWeb {
         status.textContent = "loading Wasm…";
       }
       function closeWasm() {
+        // No Wasm iframe (non-Wasm session) ⇒ nothing to tear down; enterMode() still calls this
+        // unconditionally when switching to Live/PNG, so guard against the null frame.
+        if (!wasmFrame) return;
         root.setAttribute("data-mode", "snapshot");
         wasmReady = false;
         wasmFrame.classList.remove("cp-wasm-live");
@@ -1241,24 +1262,34 @@ object ServeWeb {
           // firing a dead refreshSnapshot the user sees as "the control does nothing". (staticSnapshot
           // marks a non-renderable snapshot lane — true even for a live catalog whose Live toggle is
           // enabled; device/orientation stay disabled, so only the wasm-honoured controls reach here.)
-          wasmToggle.checked = true;
-          openWasm();
+          setMode("wasm");
         } else if (!live.checked) {
           refreshSnapshot();
         }
       }
 
-      live.addEventListener("change", function () {
-        if (live.checked) {
-          if (wasmToggle && wasmToggle.checked) { wasmToggle.checked = false; closeWasm(); }
-          openStream();
-        } else { closeStream(); refreshSnapshot(); }
-      });
-      if (wasmToggle) {
-        wasmToggle.addEventListener("change", function () {
-          if (wasmToggle.checked) openWasm();
-          else { closeWasm(); refreshSnapshot(); }
+      // Render-mode radio group (PNG / Live Compose / Wasm). Selecting one tears down the other
+      // transport and enters the chosen one; PNG is the baked snapshot. closeStream / closeWasm are
+      // idempotent, so a mode switch can safely tear down both regardless of the prior state.
+      function enterMode(m) {
+        if (m === "live") { closeWasm(); openStream(); }
+        else if (m === "wasm") { closeStream(); openWasm(); }
+        else { closeStream(); closeWasm(); refreshSnapshot(); }
+      }
+      // Programmatic switch (e.g. a wasm-only control auto-enabling Wasm): tick the radio so the UI
+      // reflects it, then run the transition.
+      function setMode(m) {
+        var r = document.getElementById(
+          m === "live" ? "cp-live" : m === "wasm" ? "cp-wasm-toggle" : "cp-mode-png");
+        if (r) r.checked = true;
+        enterMode(m);
+      }
+      Array.prototype.forEach.call(
+        document.querySelectorAll("input[name=\"cp-mode\"]"),
+        function (r) {
+          r.addEventListener("change", function () { if (r.checked) enterMode(r.value); });
         });
+      if (wasmToggle) {
         // The app posts "cp-wasm-ready" once its first frame is on the canvas — the swap signal.
         // Match on source (the known frame's contentWindow), not e.origin — robust regardless of
         // the frame's origin, and the payload is a fixed string so there's no data surface.
@@ -1283,7 +1314,7 @@ object ServeWeb {
         if (wasmBg) {
           wasmBg.addEventListener("change", function () {
             // Background is an in-browser knob: auto-enable the Wasm tier if it isn't on yet.
-            if (!wasmActive()) { wasmToggle.checked = true; openWasm(); return; }
+            if (!wasmActive()) { setMode("wasm"); return; }
             onControlsChanged();
           });
         }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -404,7 +404,14 @@ class ServeWebFixtureTest {
   fun `viewer mounts the Wasm tier only when a wasm app backs the session`() {
     val card = previews.first { it.id.endsWith("CardPreview") }
     val withWasm = ServeWeb.viewerPage(card, token, wasmSrc = "/wasm/compose-m3/?id=card-filled")
-    assertTrue(withWasm.contains("Run in browser (Wasm)"), "expected the Wasm toggle")
+    // The render mode is a radio group: PNG (default) / Live Compose / Wasm — the last only when a
+    // wasm app backs the session.
+    assertTrue(
+      withWasm.contains("name=\"cp-mode\" value=\"png\"") &&
+        withWasm.contains("name=\"cp-mode\" value=\"live\"") &&
+        withWasm.contains("name=\"cp-mode\" value=\"wasm\""),
+      "expected the PNG / Live Compose / Wasm radio group",
+    )
     assertTrue(withWasm.contains("id=\"cp-wasm\""), "expected the Wasm iframe")
     assertTrue(withWasm.contains("data-wasm-src=\"/wasm/compose-m3/?id=card-filled\""))
     // Default (no wasmSameOrigin ⇒ untrusted / unknown): the iframe stays opaque-origin, so an
@@ -456,11 +463,12 @@ class ServeWebFixtureTest {
     )
     assertTrue(withWasm.contains("\"background=off\""), "background knob forwarded to the app")
 
-    // No wasmSrc → snapshot viewer is unchanged: no toggle, no iframe element.
+    // No wasmSrc → snapshot viewer has no Wasm mode: PNG + Live radios only, no Wasm radio/iframe.
     val plain = ServeWeb.viewerPage(card, token)
-    assertTrue(!plain.contains("Run in browser (Wasm)"))
+    assertTrue(!plain.contains("name=\"cp-mode\" value=\"wasm\""))
     assertTrue(!plain.contains("id=\"cp-wasm\""))
     assertTrue(!plain.contains("id=\"cp-wasm-bg\""))
+    assertTrue(plain.contains("name=\"cp-mode\" value=\"png\""), "PNG radio always present")
   }
 
   @Test
@@ -571,10 +579,7 @@ class ServeWebFixtureTest {
     assertTrue(staticView.contains("value=\"1.0\" disabled"), "font scale disabled")
     assertTrue(staticView.contains("id=\"cp-device\" disabled"), "device disabled")
     assertTrue(staticView.contains("id=\"cp-orientation\" disabled"), "orientation disabled")
-    assertTrue(
-      staticView.contains("id=\"cp-live\" type=\"checkbox\" disabled"),
-      "live stream disabled",
-    )
+    assertTrue(staticView.contains("id=\"cp-live\" disabled"), "Live Compose radio disabled")
     assertTrue(
       staticView.contains("id=\"cp-uiMode\" disabled"),
       "theme disabled without a Wasm app",
@@ -631,8 +636,8 @@ class ServeWebFixtureTest {
         wasmSrc = "/wasm/compose-m3/?id=card-filled",
       )
     assertTrue(
-      liveCatalogWasm.contains("id=\"cp-live\" type=\"checkbox\"> Live"),
-      "live catalog leaves the Live toggle enabled",
+      liveCatalogWasm.contains("id=\"cp-live\"> Live Compose"),
+      "live catalog leaves the Live Compose radio enabled (not disabled)",
     )
     assertTrue(
       liveCatalogWasm.contains("data-static-snapshot=\"true\""),

--- a/vscode-extension/preview-harness/fixtures/pages/serve-home-index.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-home-index.html
@@ -69,6 +69,8 @@ a:hover { text-decoration: underline; }
   transition: opacity 0.15s ease; pointer-events: none; }
 .cp-stage iframe.cp-wasm-live { opacity: 1; pointer-events: auto; }
 .cp-live-row { flex-direction: row !important; align-items: center; gap: 6px !important; }
+.cp-modes { display: flex; flex-direction: row; flex-wrap: wrap; gap: 6px 14px;
+  font-size: 0.8rem; }
 .cp-controls { flex: 0 0 240px; display: flex; flex-direction: column; gap: 14px; }
 .cp-controls label { display: flex; flex-direction: column; gap: 4px; font-size: 0.8rem; }
 .cp-controls input, .cp-controls select { padding: 5px 6px; font-size: 0.85rem; }

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-path.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-path.html
@@ -69,6 +69,8 @@ a:hover { text-decoration: underline; }
   transition: opacity 0.15s ease; pointer-events: none; }
 .cp-stage iframe.cp-wasm-live { opacity: 1; pointer-events: auto; }
 .cp-live-row { flex-direction: row !important; align-items: center; gap: 6px !important; }
+.cp-modes { display: flex; flex-direction: row; flex-wrap: wrap; gap: 6px 14px;
+  font-size: 0.8rem; }
 .cp-controls { flex: 0 0 240px; display: flex; flex-direction: column; gap: 14px; }
 .cp-controls label { display: flex; flex-direction: column; gap: 4px; font-size: 0.8rem; }
 .cp-controls input, .cp-controls select { padding: 5px 6px; font-size: 0.85rem; }

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-public.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-public.html
@@ -69,6 +69,8 @@ a:hover { text-decoration: underline; }
   transition: opacity 0.15s ease; pointer-events: none; }
 .cp-stage iframe.cp-wasm-live { opacity: 1; pointer-events: auto; }
 .cp-live-row { flex-direction: row !important; align-items: center; gap: 6px !important; }
+.cp-modes { display: flex; flex-direction: row; flex-wrap: wrap; gap: 6px 14px;
+  font-size: 0.8rem; }
 .cp-controls { flex: 0 0 240px; display: flex; flex-direction: column; gap: 14px; }
 .cp-controls label { display: flex; flex-direction: column; gap: 4px; font-size: 0.8rem; }
 .cp-controls input, .cp-controls select { padding: 5px 6px; font-size: 0.85rem; }

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-themed.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-themed.html
@@ -69,6 +69,8 @@ a:hover { text-decoration: underline; }
   transition: opacity 0.15s ease; pointer-events: none; }
 .cp-stage iframe.cp-wasm-live { opacity: 1; pointer-events: auto; }
 .cp-live-row { flex-direction: row !important; align-items: center; gap: 6px !important; }
+.cp-modes { display: flex; flex-direction: row; flex-wrap: wrap; gap: 6px 14px;
+  font-size: 0.8rem; }
 .cp-controls { flex: 0 0 240px; display: flex; flex-direction: column; gap: 14px; }
 .cp-controls label { display: flex; flex-direction: column; gap: 4px; font-size: 0.8rem; }
 .cp-controls input, .cp-controls select { padding: 5px 6px; font-size: 0.85rem; }

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing.html
@@ -69,6 +69,8 @@ a:hover { text-decoration: underline; }
   transition: opacity 0.15s ease; pointer-events: none; }
 .cp-stage iframe.cp-wasm-live { opacity: 1; pointer-events: auto; }
 .cp-live-row { flex-direction: row !important; align-items: center; gap: 6px !important; }
+.cp-modes { display: flex; flex-direction: row; flex-wrap: wrap; gap: 6px 14px;
+  font-size: 0.8rem; }
 .cp-controls { flex: 0 0 240px; display: flex; flex-direction: column; gap: 14px; }
 .cp-controls label { display: flex; flex-direction: column; gap: 4px; font-size: 0.8rem; }
 .cp-controls input, .cp-controls select { padding: 5px 6px; font-size: 0.85rem; }

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
@@ -69,6 +69,8 @@ a:hover { text-decoration: underline; }
   transition: opacity 0.15s ease; pointer-events: none; }
 .cp-stage iframe.cp-wasm-live { opacity: 1; pointer-events: auto; }
 .cp-live-row { flex-direction: row !important; align-items: center; gap: 6px !important; }
+.cp-modes { display: flex; flex-direction: row; flex-wrap: wrap; gap: 6px 14px;
+  font-size: 0.8rem; }
 .cp-controls { flex: 0 0 240px; display: flex; flex-direction: column; gap: 14px; }
 .cp-controls label { display: flex; flex-direction: column; gap: 4px; font-size: 0.8rem; }
 .cp-controls input, .cp-controls select { padding: 5px 6px; font-size: 0.85rem; }
@@ -119,9 +121,12 @@ a:hover { text-decoration: underline; }
       <div class="cp-viewer" data-preview-id="button-filled__ideal__default__light" data-mode="snapshot" data-modes="snapshot" data-static-snapshot="true" data-can-render-overrides="true" data-snapshot-backend="Snapshot" data-live-backend="Live" data-wasm-src="/wasm/compose-m3/?id=button-filled">
         <div class="cp-stage"><span class="cp-backend" id="cp-backend"></span><img id="cp-img" alt="Button · Filled (light)"><canvas id="cp-canvas" hidden></canvas><iframe id="cp-wasm" hidden sandbox="allow-scripts allow-same-origin" title="Button · Filled (light) (Wasm)"></iframe></div>
         <div class="cp-controls">
-          <div class="cp-note">Pre-rendered snapshot — tick “Run in browser (Wasm)” to interact: Theme, Font scale, Locale &amp; background apply in the browser. Device/Orientation need the live server. <a href="https://github.com/yschimke/compose-ai-tools/blob/main/docs/public-preview-server.md#running-one">Enable a local preview server.</a></div>
-          <label class="cp-live-row"><input id="cp-live" type="checkbox"> Live (stream)</label>
-          <label class="cp-live-row"><input id="cp-wasm-toggle" type="checkbox"> Run in browser (Wasm)</label>
+          <div class="cp-note">Pre-rendered snapshot — pick “Wasm” to interact: Theme, Font scale, Locale &amp; background apply in the browser. Device/Orientation need the live server. <a href="https://github.com/yschimke/compose-ai-tools/blob/main/docs/public-preview-server.md#running-one">Enable a local preview server.</a></div>
+          <div class="cp-modes" role="radiogroup" aria-label="Render mode">
+            <label class="cp-live-row"><input type="radio" name="cp-mode" value="png" id="cp-mode-png" checked> PNG</label>
+            <label class="cp-live-row"><input type="radio" name="cp-mode" value="live" id="cp-live"> Live Compose</label>
+            <label class="cp-live-row"><input type="radio" name="cp-mode" value="wasm" id="cp-wasm-toggle"> Wasm</label>
+          </div>
           <label class="cp-live-row"><input id="cp-wasm-bg" type="checkbox"> Component only (no background)</label>
           <label>Theme
             <select id="cp-uiMode">
@@ -588,8 +593,11 @@ a:hover { text-decoration: underline; }
     if (patch && wasmFrame.contentWindow) wasmFrame.contentWindow.postMessage(patch, "*");
   }
   function openWasm() {
-    // Wasm and the daemon stream are mutually exclusive — only one transport drives the stage.
-    if (live.checked) { live.checked = false; closeStream(); }
+    // No-op without a Wasm app (wasmFrame absent): enterMode() calls this unconditionally, but a
+    // non-Wasm daemon/static session has no iframe to drive. Guard so touching it can't throw.
+    if (!wasmFrame) return;
+    // Wasm and the daemon stream are mutually exclusive; the mode switch (enterMode) tears the
+    // stream down before opening Wasm, so there's nothing extra to close here.
     root.setAttribute("data-mode", "wasm");
     canvas.hidden = true;
     // Keep the snapshot visible while the app loads; the iframe mounts over it at opacity 0
@@ -601,6 +609,9 @@ a:hover { text-decoration: underline; }
     status.textContent = "loading Wasm…";
   }
   function closeWasm() {
+    // No Wasm iframe (non-Wasm session) ⇒ nothing to tear down; enterMode() still calls this
+    // unconditionally when switching to Live/PNG, so guard against the null frame.
+    if (!wasmFrame) return;
     root.setAttribute("data-mode", "snapshot");
     wasmReady = false;
     wasmFrame.classList.remove("cp-wasm-live");
@@ -633,24 +644,34 @@ a:hover { text-decoration: underline; }
       // firing a dead refreshSnapshot the user sees as "the control does nothing". (staticSnapshot
       // marks a non-renderable snapshot lane — true even for a live catalog whose Live toggle is
       // enabled; device/orientation stay disabled, so only the wasm-honoured controls reach here.)
-      wasmToggle.checked = true;
-      openWasm();
+      setMode("wasm");
     } else if (!live.checked) {
       refreshSnapshot();
     }
   }
 
-  live.addEventListener("change", function () {
-    if (live.checked) {
-      if (wasmToggle && wasmToggle.checked) { wasmToggle.checked = false; closeWasm(); }
-      openStream();
-    } else { closeStream(); refreshSnapshot(); }
-  });
-  if (wasmToggle) {
-    wasmToggle.addEventListener("change", function () {
-      if (wasmToggle.checked) openWasm();
-      else { closeWasm(); refreshSnapshot(); }
+  // Render-mode radio group (PNG / Live Compose / Wasm). Selecting one tears down the other
+  // transport and enters the chosen one; PNG is the baked snapshot. closeStream / closeWasm are
+  // idempotent, so a mode switch can safely tear down both regardless of the prior state.
+  function enterMode(m) {
+    if (m === "live") { closeWasm(); openStream(); }
+    else if (m === "wasm") { closeStream(); openWasm(); }
+    else { closeStream(); closeWasm(); refreshSnapshot(); }
+  }
+  // Programmatic switch (e.g. a wasm-only control auto-enabling Wasm): tick the radio so the UI
+  // reflects it, then run the transition.
+  function setMode(m) {
+    var r = document.getElementById(
+      m === "live" ? "cp-live" : m === "wasm" ? "cp-wasm-toggle" : "cp-mode-png");
+    if (r) r.checked = true;
+    enterMode(m);
+  }
+  Array.prototype.forEach.call(
+    document.querySelectorAll("input[name=\"cp-mode\"]"),
+    function (r) {
+      r.addEventListener("change", function () { if (r.checked) enterMode(r.value); });
     });
+  if (wasmToggle) {
     // The app posts "cp-wasm-ready" once its first frame is on the canvas — the swap signal.
     // Match on source (the known frame's contentWindow), not e.origin — robust regardless of
     // the frame's origin, and the payload is a fixed string so there's no data surface.
@@ -675,7 +696,7 @@ a:hover { text-decoration: underline; }
     if (wasmBg) {
       wasmBg.addEventListener("change", function () {
         // Background is an in-browser knob: auto-enable the Wasm tier if it isn't on yet.
-        if (!wasmActive()) { wasmToggle.checked = true; openWasm(); return; }
+        if (!wasmActive()) { setMode("wasm"); return; }
         onControlsChanged();
       });
     }

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
@@ -69,6 +69,8 @@ a:hover { text-decoration: underline; }
   transition: opacity 0.15s ease; pointer-events: none; }
 .cp-stage iframe.cp-wasm-live { opacity: 1; pointer-events: auto; }
 .cp-live-row { flex-direction: row !important; align-items: center; gap: 6px !important; }
+.cp-modes { display: flex; flex-direction: row; flex-wrap: wrap; gap: 6px 14px;
+  font-size: 0.8rem; }
 .cp-controls { flex: 0 0 240px; display: flex; flex-direction: column; gap: 14px; }
 .cp-controls label { display: flex; flex-direction: column; gap: 4px; font-size: 0.8rem; }
 .cp-controls input, .cp-controls select { padding: 5px 6px; font-size: 0.85rem; }
@@ -120,7 +122,11 @@ a:hover { text-decoration: underline; }
         <div class="cp-stage"><span class="cp-backend" id="cp-backend"></span><img id="cp-img" alt="Profile screen"><canvas id="cp-canvas" hidden></canvas></div>
         <div class="cp-controls">
           <div class="cp-note">Pre-rendered snapshot — overrides (device, locale, font scale, orientation) need the live server, not a published catalog. <a href="https://github.com/yschimke/compose-ai-tools/blob/main/docs/public-preview-server.md#running-one">Enable a local preview server.</a></div>
-          <label class="cp-live-row"><input id="cp-live" type="checkbox" disabled> Live (stream)</label>
+          <div class="cp-modes" role="radiogroup" aria-label="Render mode">
+            <label class="cp-live-row"><input type="radio" name="cp-mode" value="png" id="cp-mode-png" checked> PNG</label>
+            <label class="cp-live-row"><input type="radio" name="cp-mode" value="live" id="cp-live" disabled> Live Compose</label>
+            
+          </div>
           
           <label>Theme
             <select id="cp-uiMode" disabled>
@@ -573,8 +579,11 @@ a:hover { text-decoration: underline; }
     if (patch && wasmFrame.contentWindow) wasmFrame.contentWindow.postMessage(patch, "*");
   }
   function openWasm() {
-    // Wasm and the daemon stream are mutually exclusive — only one transport drives the stage.
-    if (live.checked) { live.checked = false; closeStream(); }
+    // No-op without a Wasm app (wasmFrame absent): enterMode() calls this unconditionally, but a
+    // non-Wasm daemon/static session has no iframe to drive. Guard so touching it can't throw.
+    if (!wasmFrame) return;
+    // Wasm and the daemon stream are mutually exclusive; the mode switch (enterMode) tears the
+    // stream down before opening Wasm, so there's nothing extra to close here.
     root.setAttribute("data-mode", "wasm");
     canvas.hidden = true;
     // Keep the snapshot visible while the app loads; the iframe mounts over it at opacity 0
@@ -586,6 +595,9 @@ a:hover { text-decoration: underline; }
     status.textContent = "loading Wasm…";
   }
   function closeWasm() {
+    // No Wasm iframe (non-Wasm session) ⇒ nothing to tear down; enterMode() still calls this
+    // unconditionally when switching to Live/PNG, so guard against the null frame.
+    if (!wasmFrame) return;
     root.setAttribute("data-mode", "snapshot");
     wasmReady = false;
     wasmFrame.classList.remove("cp-wasm-live");
@@ -618,24 +630,34 @@ a:hover { text-decoration: underline; }
       // firing a dead refreshSnapshot the user sees as "the control does nothing". (staticSnapshot
       // marks a non-renderable snapshot lane — true even for a live catalog whose Live toggle is
       // enabled; device/orientation stay disabled, so only the wasm-honoured controls reach here.)
-      wasmToggle.checked = true;
-      openWasm();
+      setMode("wasm");
     } else if (!live.checked) {
       refreshSnapshot();
     }
   }
 
-  live.addEventListener("change", function () {
-    if (live.checked) {
-      if (wasmToggle && wasmToggle.checked) { wasmToggle.checked = false; closeWasm(); }
-      openStream();
-    } else { closeStream(); refreshSnapshot(); }
-  });
-  if (wasmToggle) {
-    wasmToggle.addEventListener("change", function () {
-      if (wasmToggle.checked) openWasm();
-      else { closeWasm(); refreshSnapshot(); }
+  // Render-mode radio group (PNG / Live Compose / Wasm). Selecting one tears down the other
+  // transport and enters the chosen one; PNG is the baked snapshot. closeStream / closeWasm are
+  // idempotent, so a mode switch can safely tear down both regardless of the prior state.
+  function enterMode(m) {
+    if (m === "live") { closeWasm(); openStream(); }
+    else if (m === "wasm") { closeStream(); openWasm(); }
+    else { closeStream(); closeWasm(); refreshSnapshot(); }
+  }
+  // Programmatic switch (e.g. a wasm-only control auto-enabling Wasm): tick the radio so the UI
+  // reflects it, then run the transition.
+  function setMode(m) {
+    var r = document.getElementById(
+      m === "live" ? "cp-live" : m === "wasm" ? "cp-wasm-toggle" : "cp-mode-png");
+    if (r) r.checked = true;
+    enterMode(m);
+  }
+  Array.prototype.forEach.call(
+    document.querySelectorAll("input[name=\"cp-mode\"]"),
+    function (r) {
+      r.addEventListener("change", function () { if (r.checked) enterMode(r.value); });
     });
+  if (wasmToggle) {
     // The app posts "cp-wasm-ready" once its first frame is on the canvas — the swap signal.
     // Match on source (the known frame's contentWindow), not e.origin — robust regardless of
     // the frame's origin, and the payload is a fixed string so there's no data surface.
@@ -660,7 +682,7 @@ a:hover { text-decoration: underline; }
     if (wasmBg) {
       wasmBg.addEventListener("change", function () {
         // Background is an in-browser knob: auto-enable the Wasm tier if it isn't on yet.
-        if (!wasmActive()) { wasmToggle.checked = true; openWasm(); return; }
+        if (!wasmActive()) { setMode("wasm"); return; }
         onControlsChanged();
       });
     }

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
@@ -69,6 +69,8 @@ a:hover { text-decoration: underline; }
   transition: opacity 0.15s ease; pointer-events: none; }
 .cp-stage iframe.cp-wasm-live { opacity: 1; pointer-events: auto; }
 .cp-live-row { flex-direction: row !important; align-items: center; gap: 6px !important; }
+.cp-modes { display: flex; flex-direction: row; flex-wrap: wrap; gap: 6px 14px;
+  font-size: 0.8rem; }
 .cp-controls { flex: 0 0 240px; display: flex; flex-direction: column; gap: 14px; }
 .cp-controls label { display: flex; flex-direction: column; gap: 4px; font-size: 0.8rem; }
 .cp-controls input, .cp-controls select { padding: 5px 6px; font-size: 0.85rem; }
@@ -119,9 +121,12 @@ a:hover { text-decoration: underline; }
       <div class="cp-viewer" data-preview-id="com.example.CardPreview" data-mode="snapshot" data-modes="snapshot,live" data-static-snapshot="true" data-can-render-overrides="false" data-snapshot-backend="Snapshot" data-live-backend="Live" data-wasm-src="/wasm/compose-m3/?id=card-filled">
         <div class="cp-stage"><span class="cp-backend" id="cp-backend"></span><img id="cp-img" alt="Card"><canvas id="cp-canvas" hidden></canvas><iframe id="cp-wasm" hidden sandbox="allow-scripts allow-same-origin" title="Card (Wasm)"></iframe></div>
         <div class="cp-controls">
-          <div class="cp-note">Pre-rendered snapshot — tick “Run in browser (Wasm)” to interact: Theme, Font scale, Locale &amp; background apply in the browser. Device/Orientation need the live server. <a href="https://github.com/yschimke/compose-ai-tools/blob/main/docs/public-preview-server.md#running-one">Enable a local preview server.</a></div>
-          <label class="cp-live-row"><input id="cp-live" type="checkbox"> Live (stream)</label>
-          <label class="cp-live-row"><input id="cp-wasm-toggle" type="checkbox"> Run in browser (Wasm)</label>
+          <div class="cp-note">Pre-rendered snapshot — pick “Wasm” to interact: Theme, Font scale, Locale &amp; background apply in the browser. Device/Orientation need the live server. <a href="https://github.com/yschimke/compose-ai-tools/blob/main/docs/public-preview-server.md#running-one">Enable a local preview server.</a></div>
+          <div class="cp-modes" role="radiogroup" aria-label="Render mode">
+            <label class="cp-live-row"><input type="radio" name="cp-mode" value="png" id="cp-mode-png" checked> PNG</label>
+            <label class="cp-live-row"><input type="radio" name="cp-mode" value="live" id="cp-live"> Live Compose</label>
+            <label class="cp-live-row"><input type="radio" name="cp-mode" value="wasm" id="cp-wasm-toggle"> Wasm</label>
+          </div>
           <label class="cp-live-row"><input id="cp-wasm-bg" type="checkbox"> Component only (no background)</label>
           <label>Theme
             <select id="cp-uiMode">
@@ -574,8 +579,11 @@ a:hover { text-decoration: underline; }
     if (patch && wasmFrame.contentWindow) wasmFrame.contentWindow.postMessage(patch, "*");
   }
   function openWasm() {
-    // Wasm and the daemon stream are mutually exclusive — only one transport drives the stage.
-    if (live.checked) { live.checked = false; closeStream(); }
+    // No-op without a Wasm app (wasmFrame absent): enterMode() calls this unconditionally, but a
+    // non-Wasm daemon/static session has no iframe to drive. Guard so touching it can't throw.
+    if (!wasmFrame) return;
+    // Wasm and the daemon stream are mutually exclusive; the mode switch (enterMode) tears the
+    // stream down before opening Wasm, so there's nothing extra to close here.
     root.setAttribute("data-mode", "wasm");
     canvas.hidden = true;
     // Keep the snapshot visible while the app loads; the iframe mounts over it at opacity 0
@@ -587,6 +595,9 @@ a:hover { text-decoration: underline; }
     status.textContent = "loading Wasm…";
   }
   function closeWasm() {
+    // No Wasm iframe (non-Wasm session) ⇒ nothing to tear down; enterMode() still calls this
+    // unconditionally when switching to Live/PNG, so guard against the null frame.
+    if (!wasmFrame) return;
     root.setAttribute("data-mode", "snapshot");
     wasmReady = false;
     wasmFrame.classList.remove("cp-wasm-live");
@@ -619,24 +630,34 @@ a:hover { text-decoration: underline; }
       // firing a dead refreshSnapshot the user sees as "the control does nothing". (staticSnapshot
       // marks a non-renderable snapshot lane — true even for a live catalog whose Live toggle is
       // enabled; device/orientation stay disabled, so only the wasm-honoured controls reach here.)
-      wasmToggle.checked = true;
-      openWasm();
+      setMode("wasm");
     } else if (!live.checked) {
       refreshSnapshot();
     }
   }
 
-  live.addEventListener("change", function () {
-    if (live.checked) {
-      if (wasmToggle && wasmToggle.checked) { wasmToggle.checked = false; closeWasm(); }
-      openStream();
-    } else { closeStream(); refreshSnapshot(); }
-  });
-  if (wasmToggle) {
-    wasmToggle.addEventListener("change", function () {
-      if (wasmToggle.checked) openWasm();
-      else { closeWasm(); refreshSnapshot(); }
+  // Render-mode radio group (PNG / Live Compose / Wasm). Selecting one tears down the other
+  // transport and enters the chosen one; PNG is the baked snapshot. closeStream / closeWasm are
+  // idempotent, so a mode switch can safely tear down both regardless of the prior state.
+  function enterMode(m) {
+    if (m === "live") { closeWasm(); openStream(); }
+    else if (m === "wasm") { closeStream(); openWasm(); }
+    else { closeStream(); closeWasm(); refreshSnapshot(); }
+  }
+  // Programmatic switch (e.g. a wasm-only control auto-enabling Wasm): tick the radio so the UI
+  // reflects it, then run the transition.
+  function setMode(m) {
+    var r = document.getElementById(
+      m === "live" ? "cp-live" : m === "wasm" ? "cp-wasm-toggle" : "cp-mode-png");
+    if (r) r.checked = true;
+    enterMode(m);
+  }
+  Array.prototype.forEach.call(
+    document.querySelectorAll("input[name=\"cp-mode\"]"),
+    function (r) {
+      r.addEventListener("change", function () { if (r.checked) enterMode(r.value); });
     });
+  if (wasmToggle) {
     // The app posts "cp-wasm-ready" once its first frame is on the canvas — the swap signal.
     // Match on source (the known frame's contentWindow), not e.origin — robust regardless of
     // the frame's origin, and the payload is a fixed string so there's no data surface.
@@ -661,7 +682,7 @@ a:hover { text-decoration: underline; }
     if (wasmBg) {
       wasmBg.addEventListener("change", function () {
         // Background is an in-browser knob: auto-enable the Wasm tier if it isn't on yet.
-        if (!wasmActive()) { wasmToggle.checked = true; openWasm(); return; }
+        if (!wasmActive()) { setMode("wasm"); return; }
         onControlsChanged();
       });
     }

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
@@ -69,6 +69,8 @@ a:hover { text-decoration: underline; }
   transition: opacity 0.15s ease; pointer-events: none; }
 .cp-stage iframe.cp-wasm-live { opacity: 1; pointer-events: auto; }
 .cp-live-row { flex-direction: row !important; align-items: center; gap: 6px !important; }
+.cp-modes { display: flex; flex-direction: row; flex-wrap: wrap; gap: 6px 14px;
+  font-size: 0.8rem; }
 .cp-controls { flex: 0 0 240px; display: flex; flex-direction: column; gap: 14px; }
 .cp-controls label { display: flex; flex-direction: column; gap: 4px; font-size: 0.8rem; }
 .cp-controls input, .cp-controls select { padding: 5px 6px; font-size: 0.85rem; }
@@ -119,9 +121,12 @@ a:hover { text-decoration: underline; }
       <div class="cp-viewer" data-preview-id="com.example.CardPreview" data-mode="snapshot" data-modes="snapshot,live" data-static-snapshot="true" data-can-render-overrides="false" data-snapshot-backend="Snapshot" data-live-backend="Live" data-wasm-src="/wasm/compose-m3/?id=card-filled">
         <div class="cp-stage"><span class="cp-backend" id="cp-backend"></span><img id="cp-img" alt="Card"><canvas id="cp-canvas" hidden></canvas><iframe id="cp-wasm" hidden sandbox="allow-scripts allow-same-origin" title="Card (Wasm)"></iframe></div>
         <div class="cp-controls">
-          <div class="cp-note">Pre-rendered snapshot — tick “Run in browser (Wasm)” to interact: Theme, Font scale, Locale &amp; background apply in the browser. Device/Orientation need the live server. <a href="https://github.com/yschimke/compose-ai-tools/blob/main/docs/public-preview-server.md#running-one">Enable a local preview server.</a></div>
-          <label class="cp-live-row"><input id="cp-live" type="checkbox" disabled> Live (stream)</label>
-          <label class="cp-live-row"><input id="cp-wasm-toggle" type="checkbox"> Run in browser (Wasm)</label>
+          <div class="cp-note">Pre-rendered snapshot — pick “Wasm” to interact: Theme, Font scale, Locale &amp; background apply in the browser. Device/Orientation need the live server. <a href="https://github.com/yschimke/compose-ai-tools/blob/main/docs/public-preview-server.md#running-one">Enable a local preview server.</a></div>
+          <div class="cp-modes" role="radiogroup" aria-label="Render mode">
+            <label class="cp-live-row"><input type="radio" name="cp-mode" value="png" id="cp-mode-png" checked> PNG</label>
+            <label class="cp-live-row"><input type="radio" name="cp-mode" value="live" id="cp-live" disabled> Live Compose</label>
+            <label class="cp-live-row"><input type="radio" name="cp-mode" value="wasm" id="cp-wasm-toggle"> Wasm</label>
+          </div>
           <label class="cp-live-row"><input id="cp-wasm-bg" type="checkbox"> Component only (no background)</label>
           <label>Theme
             <select id="cp-uiMode">
@@ -574,8 +579,11 @@ a:hover { text-decoration: underline; }
     if (patch && wasmFrame.contentWindow) wasmFrame.contentWindow.postMessage(patch, "*");
   }
   function openWasm() {
-    // Wasm and the daemon stream are mutually exclusive — only one transport drives the stage.
-    if (live.checked) { live.checked = false; closeStream(); }
+    // No-op without a Wasm app (wasmFrame absent): enterMode() calls this unconditionally, but a
+    // non-Wasm daemon/static session has no iframe to drive. Guard so touching it can't throw.
+    if (!wasmFrame) return;
+    // Wasm and the daemon stream are mutually exclusive; the mode switch (enterMode) tears the
+    // stream down before opening Wasm, so there's nothing extra to close here.
     root.setAttribute("data-mode", "wasm");
     canvas.hidden = true;
     // Keep the snapshot visible while the app loads; the iframe mounts over it at opacity 0
@@ -587,6 +595,9 @@ a:hover { text-decoration: underline; }
     status.textContent = "loading Wasm…";
   }
   function closeWasm() {
+    // No Wasm iframe (non-Wasm session) ⇒ nothing to tear down; enterMode() still calls this
+    // unconditionally when switching to Live/PNG, so guard against the null frame.
+    if (!wasmFrame) return;
     root.setAttribute("data-mode", "snapshot");
     wasmReady = false;
     wasmFrame.classList.remove("cp-wasm-live");
@@ -619,24 +630,34 @@ a:hover { text-decoration: underline; }
       // firing a dead refreshSnapshot the user sees as "the control does nothing". (staticSnapshot
       // marks a non-renderable snapshot lane — true even for a live catalog whose Live toggle is
       // enabled; device/orientation stay disabled, so only the wasm-honoured controls reach here.)
-      wasmToggle.checked = true;
-      openWasm();
+      setMode("wasm");
     } else if (!live.checked) {
       refreshSnapshot();
     }
   }
 
-  live.addEventListener("change", function () {
-    if (live.checked) {
-      if (wasmToggle && wasmToggle.checked) { wasmToggle.checked = false; closeWasm(); }
-      openStream();
-    } else { closeStream(); refreshSnapshot(); }
-  });
-  if (wasmToggle) {
-    wasmToggle.addEventListener("change", function () {
-      if (wasmToggle.checked) openWasm();
-      else { closeWasm(); refreshSnapshot(); }
+  // Render-mode radio group (PNG / Live Compose / Wasm). Selecting one tears down the other
+  // transport and enters the chosen one; PNG is the baked snapshot. closeStream / closeWasm are
+  // idempotent, so a mode switch can safely tear down both regardless of the prior state.
+  function enterMode(m) {
+    if (m === "live") { closeWasm(); openStream(); }
+    else if (m === "wasm") { closeStream(); openWasm(); }
+    else { closeStream(); closeWasm(); refreshSnapshot(); }
+  }
+  // Programmatic switch (e.g. a wasm-only control auto-enabling Wasm): tick the radio so the UI
+  // reflects it, then run the transition.
+  function setMode(m) {
+    var r = document.getElementById(
+      m === "live" ? "cp-live" : m === "wasm" ? "cp-wasm-toggle" : "cp-mode-png");
+    if (r) r.checked = true;
+    enterMode(m);
+  }
+  Array.prototype.forEach.call(
+    document.querySelectorAll("input[name=\"cp-mode\"]"),
+    function (r) {
+      r.addEventListener("change", function () { if (r.checked) enterMode(r.value); });
     });
+  if (wasmToggle) {
     // The app posts "cp-wasm-ready" once its first frame is on the canvas — the swap signal.
     // Match on source (the known frame's contentWindow), not e.origin — robust regardless of
     // the frame's origin, and the payload is a fixed string so there's no data surface.
@@ -661,7 +682,7 @@ a:hover { text-decoration: underline; }
     if (wasmBg) {
       wasmBg.addEventListener("change", function () {
         // Background is an in-browser knob: auto-enable the Wasm tier if it isn't on yet.
-        if (!wasmActive()) { wasmToggle.checked = true; openWasm(); return; }
+        if (!wasmActive()) { setMode("wasm"); return; }
         onControlsChanged();
       });
     }

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
@@ -69,6 +69,8 @@ a:hover { text-decoration: underline; }
   transition: opacity 0.15s ease; pointer-events: none; }
 .cp-stage iframe.cp-wasm-live { opacity: 1; pointer-events: auto; }
 .cp-live-row { flex-direction: row !important; align-items: center; gap: 6px !important; }
+.cp-modes { display: flex; flex-direction: row; flex-wrap: wrap; gap: 6px 14px;
+  font-size: 0.8rem; }
 .cp-controls { flex: 0 0 240px; display: flex; flex-direction: column; gap: 14px; }
 .cp-controls label { display: flex; flex-direction: column; gap: 4px; font-size: 0.8rem; }
 .cp-controls input, .cp-controls select { padding: 5px 6px; font-size: 0.85rem; }
@@ -120,7 +122,11 @@ a:hover { text-decoration: underline; }
         <div class="cp-stage"><span class="cp-backend" id="cp-backend"></span><img id="cp-img" alt="Profile screen"><canvas id="cp-canvas" hidden></canvas></div>
         <div class="cp-controls">
           <div class="cp-note">Pre-rendered snapshot — overrides (device, locale, font scale, orientation) need the live server, not a published catalog. <a href="https://github.com/yschimke/compose-ai-tools/blob/main/docs/public-preview-server.md#running-one">Enable a local preview server.</a></div>
-          <label class="cp-live-row"><input id="cp-live" type="checkbox" disabled> Live (stream)</label>
+          <div class="cp-modes" role="radiogroup" aria-label="Render mode">
+            <label class="cp-live-row"><input type="radio" name="cp-mode" value="png" id="cp-mode-png" checked> PNG</label>
+            <label class="cp-live-row"><input type="radio" name="cp-mode" value="live" id="cp-live" disabled> Live Compose</label>
+            
+          </div>
           
           <label>Theme
             <select id="cp-uiMode" disabled>
@@ -573,8 +579,11 @@ a:hover { text-decoration: underline; }
     if (patch && wasmFrame.contentWindow) wasmFrame.contentWindow.postMessage(patch, "*");
   }
   function openWasm() {
-    // Wasm and the daemon stream are mutually exclusive — only one transport drives the stage.
-    if (live.checked) { live.checked = false; closeStream(); }
+    // No-op without a Wasm app (wasmFrame absent): enterMode() calls this unconditionally, but a
+    // non-Wasm daemon/static session has no iframe to drive. Guard so touching it can't throw.
+    if (!wasmFrame) return;
+    // Wasm and the daemon stream are mutually exclusive; the mode switch (enterMode) tears the
+    // stream down before opening Wasm, so there's nothing extra to close here.
     root.setAttribute("data-mode", "wasm");
     canvas.hidden = true;
     // Keep the snapshot visible while the app loads; the iframe mounts over it at opacity 0
@@ -586,6 +595,9 @@ a:hover { text-decoration: underline; }
     status.textContent = "loading Wasm…";
   }
   function closeWasm() {
+    // No Wasm iframe (non-Wasm session) ⇒ nothing to tear down; enterMode() still calls this
+    // unconditionally when switching to Live/PNG, so guard against the null frame.
+    if (!wasmFrame) return;
     root.setAttribute("data-mode", "snapshot");
     wasmReady = false;
     wasmFrame.classList.remove("cp-wasm-live");
@@ -618,24 +630,34 @@ a:hover { text-decoration: underline; }
       // firing a dead refreshSnapshot the user sees as "the control does nothing". (staticSnapshot
       // marks a non-renderable snapshot lane — true even for a live catalog whose Live toggle is
       // enabled; device/orientation stay disabled, so only the wasm-honoured controls reach here.)
-      wasmToggle.checked = true;
-      openWasm();
+      setMode("wasm");
     } else if (!live.checked) {
       refreshSnapshot();
     }
   }
 
-  live.addEventListener("change", function () {
-    if (live.checked) {
-      if (wasmToggle && wasmToggle.checked) { wasmToggle.checked = false; closeWasm(); }
-      openStream();
-    } else { closeStream(); refreshSnapshot(); }
-  });
-  if (wasmToggle) {
-    wasmToggle.addEventListener("change", function () {
-      if (wasmToggle.checked) openWasm();
-      else { closeWasm(); refreshSnapshot(); }
+  // Render-mode radio group (PNG / Live Compose / Wasm). Selecting one tears down the other
+  // transport and enters the chosen one; PNG is the baked snapshot. closeStream / closeWasm are
+  // idempotent, so a mode switch can safely tear down both regardless of the prior state.
+  function enterMode(m) {
+    if (m === "live") { closeWasm(); openStream(); }
+    else if (m === "wasm") { closeStream(); openWasm(); }
+    else { closeStream(); closeWasm(); refreshSnapshot(); }
+  }
+  // Programmatic switch (e.g. a wasm-only control auto-enabling Wasm): tick the radio so the UI
+  // reflects it, then run the transition.
+  function setMode(m) {
+    var r = document.getElementById(
+      m === "live" ? "cp-live" : m === "wasm" ? "cp-wasm-toggle" : "cp-mode-png");
+    if (r) r.checked = true;
+    enterMode(m);
+  }
+  Array.prototype.forEach.call(
+    document.querySelectorAll("input[name=\"cp-mode\"]"),
+    function (r) {
+      r.addEventListener("change", function () { if (r.checked) enterMode(r.value); });
     });
+  if (wasmToggle) {
     // The app posts "cp-wasm-ready" once its first frame is on the canvas — the swap signal.
     // Match on source (the known frame's contentWindow), not e.origin — robust regardless of
     // the frame's origin, and the payload is a fixed string so there's no data surface.
@@ -660,7 +682,7 @@ a:hover { text-decoration: underline; }
     if (wasmBg) {
       wasmBg.addEventListener("change", function () {
         // Background is an in-browser knob: auto-enable the Wasm tier if it isn't on yet.
-        if (!wasmActive()) { wasmToggle.checked = true; openWasm(); return; }
+        if (!wasmActive()) { setMode("wasm"); return; }
         onControlsChanged();
       });
     }


### PR DESCRIPTION
## Summary

Replace the viewer's two independent checkboxes — **Live (stream)** and **Run in browser (Wasm)** — with a single **radio group**: `PNG` (baked snapshot, the default) / `Live Compose` (daemon stream) / `Wasm` (in-browser CMP app). The three were already mutually exclusive; a radio group makes that explicit and the modes discoverable, and gives PNG a real "off" option instead of "untick both".

## Implementation

- The transition JS is unified behind `enterMode()` / `setMode()`: selecting a mode tears down the other transport (`closeStream` / `closeWasm` are idempotent) and enters the chosen one; `PNG` returns to the baked snapshot. The auto-enable paths (a wasm-only control change, the background toggle) route through `setMode("wasm")` so the radio reflects the switch.
- Ids `cp-live` / `cp-wasm-toggle` stay on the radio inputs, so the existing state reads (`live.checked`, `wasmActive()`, the live-stream override map) are unchanged.
- `Live Compose` is disabled when no stream is offered; `Wasm` + its `Component only` background checkbox appear only when a wasm app backs the session.

## Test plan

- `./gradlew :cli:test --tests '*ServeWebFixtureTest*'` — green; assertions updated to the radio group; viewer golden fixtures regenerated.

## Visual evidence

Rendered the `serve-viewer-wasm` fixture control panel with headless Chromium (before = `main`, after = this branch):

**Before** — two checkboxes:
- `☐ Live (stream)` (disabled) · `☐ Run in browser (Wasm)` · `☐ Component only`

**After** — a radio group:
- `⦿ PNG` · `◯ Live Compose` (disabled here — snapshot-only fixture) · `◯ Wasm`, with `☐ Component only` below.

(These serve-viewer fixture pages are wired into the `vscode-preview-diff` harness, so the bot renders and diffs this exact panel on the PR; the before/after screenshots are attached in the review thread / shared with the author.)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MkDr2hzvkuW9yrs16eFCyj)_