### PR TITLE
feat(serve): live-only overlay toggles (TalkBack / touch) in the viewer

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeOverrides.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeOverrides.kt
@@ -55,6 +55,11 @@ object ServeOverrides {
       "orientation",
       "inspectionMode",
       "slotMode",
+      // Live-only overlay toggles (held-session / recording features). The daemon composites these
+      // onto the streamed frames; a baked snapshot never carries them, so the viewer offers them
+      // only while a Live Compose session is active. Booleans, like inspectionMode/slotMode.
+      "talkBack",
+      "touchOverlay",
       // "crisp outline" toggle. Friendly `background=clear` (aliases below) or the raw
       // `clearBackground=true`; both map to `PreviewOverrides.clearBackground`.
       "background",
@@ -204,6 +209,34 @@ object ServeOverrides {
           }
         }
 
+    // Live-only overlay flags (daemon composites onto the held session's frames). Parsed like the
+    // other booleans; a malformed value is a hard Invalid rather than a silently-dropped toggle.
+    val talkBack =
+      params["talkBack"]
+        ?.takeIf { it.isNotBlank() }
+        ?.let {
+          when (it.lowercase()) {
+            "true",
+            "1" -> true
+            "false",
+            "0" -> false
+            else -> return OverrideParse.Invalid("talkBack must be a boolean, got '$it'")
+          }
+        }
+
+    val touchOverlay =
+      params["touchOverlay"]
+        ?.takeIf { it.isNotBlank() }
+        ?.let {
+          when (it.lowercase()) {
+            "true",
+            "1" -> true
+            "false",
+            "0" -> false
+            else -> return OverrideParse.Invalid("touchOverlay must be a boolean, got '$it'")
+          }
+        }
+
     // Cleared background ("crisp outline"). Two spellings: the friendly `background=clear`
     // (aliases `transparent` / `none` / `off`; `default` / `show` mean "keep the preview's
     // background") and the raw boolean `clearBackground=true`. A present `background` key wins over
@@ -291,6 +324,8 @@ object ServeOverrides {
         device = params["device"]?.takeIf { it.isNotBlank() },
         inspectionMode = inspectionMode,
         slotMode = slotMode,
+        talkBack = talkBack,
+        touchOverlay = touchOverlay,
         clearBackground = clearBackground,
         namedOverrides = namedOverrides.ifEmpty { null },
       )
@@ -316,6 +351,8 @@ object ServeOverrides {
       append("dev=").append(o.device).append('|')
       append("insp=").append(o.inspectionMode).append('|')
       append("slot=").append(o.slotMode).append('|')
+      append("talk=").append(o.talkBack).append('|')
+      append("touch=").append(o.touchOverlay).append('|')
       append("clearbg=").append(o.clearBackground).append('|')
       // Named overrides participate so a knob edit isn't coalesced onto the prior render. Sorted by
       // key for order-independence; the value data classes have stable toString.

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -93,6 +93,8 @@ object ServeWeb {
     .cp-controls label:has(:disabled) { opacity: 0.55; }
     .cp-knobs { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
     .cp-knobs-head { font-size: 0.72rem; color: #6b6b70; }
+    .cp-overlays { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
+    .cp-overlays-head { font-size: 0.72rem; color: #6b6b70; }
     .cp-knobs input:disabled { opacity: 0.7; }
     .cp-links { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
     .cp-link-row { display: flex; align-items: center; gap: 6px; }
@@ -765,6 +767,23 @@ object ServeWeb {
       }
     val backendLabel = WebEscaping.htmlEscape(snapshotBackend ?: "Snapshot")
     val liveLabel = WebEscaping.htmlEscape(liveBackend ?: "Live")
+    // Live-only overlay toggles (accessibility / touch visualization). The daemon composites these
+    // onto the held session's frames, so they mean nothing on a baked PNG — offered only when a
+    // Live
+    // Compose stream is available, and disabled until that mode is active (the mode-transition JS
+    // flips them). Omitted entirely when no stream backs the session, rather than left permanently
+    // dead. `cp-overlay` marks them for the JS collector + enable/disable sync.
+    val overlaysHtml =
+      if (hasLiveStream)
+        """
+        <div class="cp-overlays">
+          <div class="cp-overlays-head">Overlays (Live Compose)</div>
+          <label class="cp-live-row"><input class="cp-overlay" id="cp-talkBack" type="checkbox" disabled> Accessibility (TalkBack)</label>
+          <label class="cp-live-row"><input class="cp-overlay" id="cp-touchOverlay" type="checkbox" disabled> Show touches</label>
+        </div>
+        """
+          .trimIndent()
+      else ""
     val body =
       """
       <p class="cp-head"><a href="$basePath/$q">← previews</a>${trustBadge(trust)}</p>
@@ -811,6 +830,7 @@ object ServeWeb {
               <option value="clear">Clear (crisp outline)</option>
             </select>
           </label>
+          $overlaysHtml
           ${overrideKnobsHtml(preview, canApplyOverrides || canRenderOverrides)}
           ${downloadLinksHtml(hasSvgExport)}
           <div class="cp-status" id="cp-status"></div>
@@ -896,6 +916,14 @@ object ServeWeb {
           var val = (el.type === "checkbox") ? (el.checked ? "true" : "false") : el.value;
           if (val === "") return;
           o["knob." + key] = val;
+        });
+        // Live-only overlay toggles (talkBack / touchOverlay). Their id is "cp-<key>", so the daemon
+        // key is the id minus the prefix. Sent as an explicit true/false so unchecking clears the
+        // overlay on the next setOverrides (which replaces the whole map). Disabled ⇒ not live ⇒
+        // skipped, so they never leak onto a snapshot.
+        document.querySelectorAll(".cp-overlay").forEach(function (el) {
+          if (el.disabled) return;
+          o[el.id.replace(/^cp-/, "")] = el.checked ? "true" : "false";
         });
         return o;
       }
@@ -1288,6 +1316,15 @@ object ServeWeb {
         if (m === "live") { closeWasm(); openStream(); }
         else if (m === "wasm") { closeStream(); openWasm(); }
         else { closeStream(); closeWasm(); refreshSnapshot(); }
+        syncOverlayToggles();
+      }
+      // The live-only overlay toggles (talkBack / touchOverlay) are meaningful only while the daemon
+      // holds the composition, so they're enabled iff Live Compose is the active mode and greyed out
+      // (like the static-snapshot controls) otherwise. Called on every mode transition.
+      var overlayToggles = document.querySelectorAll(".cp-overlay");
+      function syncOverlayToggles() {
+        var on = !!(live && live.checked);
+        Array.prototype.forEach.call(overlayToggles, function (el) { el.disabled = !on; });
       }
       // Programmatic switch (e.g. a wasm-only control auto-enabling Wasm): tick the radio so the UI
       // reflects it, then run the transition.
@@ -1347,6 +1384,18 @@ object ServeWeb {
       fields.forEach(function (f) {
         var el = document.getElementById("cp-" + f);
         if (el) el.addEventListener("change", onControlsChanged);
+      });
+      // Overlay toggles are live-only: they push a fresh setOverrides through the open stream and do
+      // nothing otherwise. They get their own handler rather than onControlsChanged so a toggle mid
+      // connect (ws not yet readyState 1) can't fall through to the snapshot / wasm-auto-enable
+      // branches — an overlay never applies to a baked PNG or the in-browser tier.
+      function onOverlayChanged() {
+        if (live.checked && ws && ws.readyState === 1) {
+          ws.send(JSON.stringify({ type: "setOverrides", overrides: liveOverrides() }));
+        }
+      }
+      Array.prototype.forEach.call(overlayToggles, function (el) {
+        el.addEventListener("change", onOverlayChanged);
       });
       // Author-declared knobs re-render on edit (text/number debounce via "input", toggles "change").
       // They route differently from the display axes: a named knob (label, a color, …) is honoured

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeOverridesTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeOverridesTest.kt
@@ -33,6 +33,8 @@ class ServeOverridesTest {
     assertNull(o.density)
     assertNull(o.inspectionMode)
     assertNull(o.slotMode)
+    assertNull(o.talkBack)
+    assertNull(o.touchOverlay)
     assertNull(o.clearBackground)
   }
 
@@ -51,6 +53,8 @@ class ServeOverridesTest {
           "orientation" to "landscape",
           "inspectionMode" to "true",
           "slotMode" to "true",
+          "talkBack" to "true",
+          "touchOverlay" to "1",
         )
       )
     assertEquals(UiMode.DARK, o.uiMode)
@@ -63,6 +67,8 @@ class ServeOverridesTest {
     assertEquals(Orientation.LANDSCAPE, o.orientation)
     assertEquals(true, o.inspectionMode)
     assertEquals(true, o.slotMode)
+    assertEquals(true, o.talkBack)
+    assertEquals(true, o.touchOverlay)
   }
 
   @Test
@@ -86,6 +92,8 @@ class ServeOverridesTest {
         mapOf("widthPx" to "-5"),
         mapOf("inspectionMode" to "maybe"),
         mapOf("slotMode" to "maybe"),
+        mapOf("talkBack" to "maybe"),
+        mapOf("touchOverlay" to "maybe"),
         mapOf("background" to "polkadot"),
         mapOf("clearBackground" to "maybe"),
       )) {
@@ -145,6 +153,16 @@ class ServeOverridesTest {
     // slotMode participates, so a slot-map render isn't coalesced onto the normal render's cache.
     assertNotEquals(
       ServeOverrides.cacheKey("preview.A", ok(mapOf("slotMode" to "true"))),
+      ServeOverrides.cacheKey("preview.A", ok(emptyMap())),
+    )
+    // The live overlay flags participate too, so a crafted /render?talkBack / ?touchOverlay can't
+    // collide with the baked render's cache entry.
+    assertNotEquals(
+      ServeOverrides.cacheKey("preview.A", ok(mapOf("talkBack" to "true"))),
+      ServeOverrides.cacheKey("preview.A", ok(emptyMap())),
+    )
+    assertNotEquals(
+      ServeOverrides.cacheKey("preview.A", ok(mapOf("touchOverlay" to "true"))),
       ServeOverrides.cacheKey("preview.A", ok(emptyMap())),
     )
   }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -584,6 +584,10 @@ class ServeWebFixtureTest {
       staticView.contains("id=\"cp-uiMode\" disabled"),
       "theme disabled without a Wasm app",
     )
+    assertFalse(
+      staticView.contains("id=\"cp-talkBack\""),
+      "no live stream ⇒ the live-only overlay toggles are omitted entirely, not left dead",
+    )
 
     // Static + Wasm: theme, font scale, and locale go LIVE (the in-browser app honours them) — only
     // the server-render-only controls (device/orientation/live stream) stay disabled.
@@ -650,6 +654,14 @@ class ServeWebFixtureTest {
     assertTrue(
       liveCatalogWasm.contains("id=\"cp-device\" disabled"),
       "server-render-only controls stay disabled on a live catalog's static snapshot",
+    )
+    // A live-stream session offers the overlay toggles (talkBack / touch), rendered disabled until
+    // the Live Compose mode is actually entered (the mode-transition JS flips them on).
+    assertTrue(
+      liveCatalogWasm.contains("cp-overlays") &&
+        liveCatalogWasm.contains("id=\"cp-talkBack\" type=\"checkbox\" disabled") &&
+        liveCatalogWasm.contains("id=\"cp-touchOverlay\" type=\"checkbox\" disabled"),
+      "live stream offers the overlay toggles, disabled until Live Compose is active",
     )
 
     // Trusted catalog served LIVE whose preview declares author knobs (ServeCatalogLiveHost with

--- a/vscode-extension/preview-harness/fixtures/pages/serve-home-index.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-home-index.html
@@ -84,6 +84,8 @@ a:hover { text-decoration: underline; }
 .cp-controls label:has(:disabled) { opacity: 0.55; }
 .cp-knobs { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
 .cp-knobs-head { font-size: 0.72rem; color: #6b6b70; }
+.cp-overlays { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
+.cp-overlays-head { font-size: 0.72rem; color: #6b6b70; }
 .cp-knobs input:disabled { opacity: 0.7; }
 .cp-links { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
 .cp-link-row { display: flex; align-items: center; gap: 6px; }

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-path.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-path.html
@@ -84,6 +84,8 @@ a:hover { text-decoration: underline; }
 .cp-controls label:has(:disabled) { opacity: 0.55; }
 .cp-knobs { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
 .cp-knobs-head { font-size: 0.72rem; color: #6b6b70; }
+.cp-overlays { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
+.cp-overlays-head { font-size: 0.72rem; color: #6b6b70; }
 .cp-knobs input:disabled { opacity: 0.7; }
 .cp-links { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
 .cp-link-row { display: flex; align-items: center; gap: 6px; }

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-public.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-public.html
@@ -84,6 +84,8 @@ a:hover { text-decoration: underline; }
 .cp-controls label:has(:disabled) { opacity: 0.55; }
 .cp-knobs { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
 .cp-knobs-head { font-size: 0.72rem; color: #6b6b70; }
+.cp-overlays { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
+.cp-overlays-head { font-size: 0.72rem; color: #6b6b70; }
 .cp-knobs input:disabled { opacity: 0.7; }
 .cp-links { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
 .cp-link-row { display: flex; align-items: center; gap: 6px; }

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-themed.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-themed.html
@@ -84,6 +84,8 @@ a:hover { text-decoration: underline; }
 .cp-controls label:has(:disabled) { opacity: 0.55; }
 .cp-knobs { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
 .cp-knobs-head { font-size: 0.72rem; color: #6b6b70; }
+.cp-overlays { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
+.cp-overlays-head { font-size: 0.72rem; color: #6b6b70; }
 .cp-knobs input:disabled { opacity: 0.7; }
 .cp-links { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
 .cp-link-row { display: flex; align-items: center; gap: 6px; }

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing.html
@@ -84,6 +84,8 @@ a:hover { text-decoration: underline; }
 .cp-controls label:has(:disabled) { opacity: 0.55; }
 .cp-knobs { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
 .cp-knobs-head { font-size: 0.72rem; color: #6b6b70; }
+.cp-overlays { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
+.cp-overlays-head { font-size: 0.72rem; color: #6b6b70; }
 .cp-knobs input:disabled { opacity: 0.7; }
 .cp-links { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
 .cp-link-row { display: flex; align-items: center; gap: 6px; }

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
@@ -84,6 +84,8 @@ a:hover { text-decoration: underline; }
 .cp-controls label:has(:disabled) { opacity: 0.55; }
 .cp-knobs { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
 .cp-knobs-head { font-size: 0.72rem; color: #6b6b70; }
+.cp-overlays { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
+.cp-overlays-head { font-size: 0.72rem; color: #6b6b70; }
 .cp-knobs input:disabled { opacity: 0.7; }
 .cp-links { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
 .cp-link-row { display: flex; align-items: center; gap: 6px; }
@@ -169,6 +171,11 @@ a:hover { text-decoration: underline; }
               <option value="clear">Clear (crisp outline)</option>
             </select>
           </label>
+          <div class="cp-overlays">
+  <div class="cp-overlays-head">Overlays (Live Compose)</div>
+  <label class="cp-live-row"><input class="cp-overlay" id="cp-talkBack" type="checkbox" disabled> Accessibility (TalkBack)</label>
+  <label class="cp-live-row"><input class="cp-overlay" id="cp-touchOverlay" type="checkbox" disabled> Show touches</label>
+</div>
                 <div class="cp-knobs">
         <div class="cp-knobs-head">Declared overrides — edit a value to re-render.</div>
         <label>label
@@ -278,6 +285,14 @@ a:hover { text-decoration: underline; }
       var val = (el.type === "checkbox") ? (el.checked ? "true" : "false") : el.value;
       if (val === "") return;
       o["knob." + key] = val;
+    });
+    // Live-only overlay toggles (talkBack / touchOverlay). Their id is "cp-<key>", so the daemon
+    // key is the id minus the prefix. Sent as an explicit true/false so unchecking clears the
+    // overlay on the next setOverrides (which replaces the whole map). Disabled ⇒ not live ⇒
+    // skipped, so they never leak onto a snapshot.
+    document.querySelectorAll(".cp-overlay").forEach(function (el) {
+      if (el.disabled) return;
+      o[el.id.replace(/^cp-/, "")] = el.checked ? "true" : "false";
     });
     return o;
   }
@@ -670,6 +685,15 @@ a:hover { text-decoration: underline; }
     if (m === "live") { closeWasm(); openStream(); }
     else if (m === "wasm") { closeStream(); openWasm(); }
     else { closeStream(); closeWasm(); refreshSnapshot(); }
+    syncOverlayToggles();
+  }
+  // The live-only overlay toggles (talkBack / touchOverlay) are meaningful only while the daemon
+  // holds the composition, so they're enabled iff Live Compose is the active mode and greyed out
+  // (like the static-snapshot controls) otherwise. Called on every mode transition.
+  var overlayToggles = document.querySelectorAll(".cp-overlay");
+  function syncOverlayToggles() {
+    var on = !!(live && live.checked);
+    Array.prototype.forEach.call(overlayToggles, function (el) { el.disabled = !on; });
   }
   // Programmatic switch (e.g. a wasm-only control auto-enabling Wasm): tick the radio so the UI
   // reflects it, then run the transition.
@@ -729,6 +753,18 @@ a:hover { text-decoration: underline; }
   fields.forEach(function (f) {
     var el = document.getElementById("cp-" + f);
     if (el) el.addEventListener("change", onControlsChanged);
+  });
+  // Overlay toggles are live-only: they push a fresh setOverrides through the open stream and do
+  // nothing otherwise. They get their own handler rather than onControlsChanged so a toggle mid
+  // connect (ws not yet readyState 1) can't fall through to the snapshot / wasm-auto-enable
+  // branches — an overlay never applies to a baked PNG or the in-browser tier.
+  function onOverlayChanged() {
+    if (live.checked && ws && ws.readyState === 1) {
+      ws.send(JSON.stringify({ type: "setOverrides", overrides: liveOverrides() }));
+    }
+  }
+  Array.prototype.forEach.call(overlayToggles, function (el) {
+    el.addEventListener("change", onOverlayChanged);
   });
   // Author-declared knobs re-render on edit (text/number debounce via "input", toggles "change").
   // They route differently from the display axes: a named knob (label, a color, …) is honoured

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
@@ -84,6 +84,8 @@ a:hover { text-decoration: underline; }
 .cp-controls label:has(:disabled) { opacity: 0.55; }
 .cp-knobs { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
 .cp-knobs-head { font-size: 0.72rem; color: #6b6b70; }
+.cp-overlays { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
+.cp-overlays-head { font-size: 0.72rem; color: #6b6b70; }
 .cp-knobs input:disabled { opacity: 0.7; }
 .cp-links { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
 .cp-link-row { display: flex; align-items: center; gap: 6px; }
@@ -169,6 +171,7 @@ a:hover { text-decoration: underline; }
               <option value="clear">Clear (crisp outline)</option>
             </select>
           </label>
+          
           
                 <div class="cp-links">
         <div class="cp-knobs-head">Direct links — the current view as a URL (overrides applied)</div>
@@ -264,6 +267,14 @@ a:hover { text-decoration: underline; }
       var val = (el.type === "checkbox") ? (el.checked ? "true" : "false") : el.value;
       if (val === "") return;
       o["knob." + key] = val;
+    });
+    // Live-only overlay toggles (talkBack / touchOverlay). Their id is "cp-<key>", so the daemon
+    // key is the id minus the prefix. Sent as an explicit true/false so unchecking clears the
+    // overlay on the next setOverrides (which replaces the whole map). Disabled ⇒ not live ⇒
+    // skipped, so they never leak onto a snapshot.
+    document.querySelectorAll(".cp-overlay").forEach(function (el) {
+      if (el.disabled) return;
+      o[el.id.replace(/^cp-/, "")] = el.checked ? "true" : "false";
     });
     return o;
   }
@@ -656,6 +667,15 @@ a:hover { text-decoration: underline; }
     if (m === "live") { closeWasm(); openStream(); }
     else if (m === "wasm") { closeStream(); openWasm(); }
     else { closeStream(); closeWasm(); refreshSnapshot(); }
+    syncOverlayToggles();
+  }
+  // The live-only overlay toggles (talkBack / touchOverlay) are meaningful only while the daemon
+  // holds the composition, so they're enabled iff Live Compose is the active mode and greyed out
+  // (like the static-snapshot controls) otherwise. Called on every mode transition.
+  var overlayToggles = document.querySelectorAll(".cp-overlay");
+  function syncOverlayToggles() {
+    var on = !!(live && live.checked);
+    Array.prototype.forEach.call(overlayToggles, function (el) { el.disabled = !on; });
   }
   // Programmatic switch (e.g. a wasm-only control auto-enabling Wasm): tick the radio so the UI
   // reflects it, then run the transition.
@@ -715,6 +735,18 @@ a:hover { text-decoration: underline; }
   fields.forEach(function (f) {
     var el = document.getElementById("cp-" + f);
     if (el) el.addEventListener("change", onControlsChanged);
+  });
+  // Overlay toggles are live-only: they push a fresh setOverrides through the open stream and do
+  // nothing otherwise. They get their own handler rather than onControlsChanged so a toggle mid
+  // connect (ws not yet readyState 1) can't fall through to the snapshot / wasm-auto-enable
+  // branches — an overlay never applies to a baked PNG or the in-browser tier.
+  function onOverlayChanged() {
+    if (live.checked && ws && ws.readyState === 1) {
+      ws.send(JSON.stringify({ type: "setOverrides", overrides: liveOverrides() }));
+    }
+  }
+  Array.prototype.forEach.call(overlayToggles, function (el) {
+    el.addEventListener("change", onOverlayChanged);
   });
   // Author-declared knobs re-render on edit (text/number debounce via "input", toggles "change").
   // They route differently from the display axes: a named knob (label, a color, …) is honoured

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
@@ -84,6 +84,8 @@ a:hover { text-decoration: underline; }
 .cp-controls label:has(:disabled) { opacity: 0.55; }
 .cp-knobs { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
 .cp-knobs-head { font-size: 0.72rem; color: #6b6b70; }
+.cp-overlays { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
+.cp-overlays-head { font-size: 0.72rem; color: #6b6b70; }
 .cp-knobs input:disabled { opacity: 0.7; }
 .cp-links { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
 .cp-link-row { display: flex; align-items: center; gap: 6px; }
@@ -169,6 +171,11 @@ a:hover { text-decoration: underline; }
               <option value="clear">Clear (crisp outline)</option>
             </select>
           </label>
+          <div class="cp-overlays">
+  <div class="cp-overlays-head">Overlays (Live Compose)</div>
+  <label class="cp-live-row"><input class="cp-overlay" id="cp-talkBack" type="checkbox" disabled> Accessibility (TalkBack)</label>
+  <label class="cp-live-row"><input class="cp-overlay" id="cp-touchOverlay" type="checkbox" disabled> Show touches</label>
+</div>
           
                 <div class="cp-links">
         <div class="cp-knobs-head">Direct links — the current view as a URL (overrides applied)</div>
@@ -264,6 +271,14 @@ a:hover { text-decoration: underline; }
       var val = (el.type === "checkbox") ? (el.checked ? "true" : "false") : el.value;
       if (val === "") return;
       o["knob." + key] = val;
+    });
+    // Live-only overlay toggles (talkBack / touchOverlay). Their id is "cp-<key>", so the daemon
+    // key is the id minus the prefix. Sent as an explicit true/false so unchecking clears the
+    // overlay on the next setOverrides (which replaces the whole map). Disabled ⇒ not live ⇒
+    // skipped, so they never leak onto a snapshot.
+    document.querySelectorAll(".cp-overlay").forEach(function (el) {
+      if (el.disabled) return;
+      o[el.id.replace(/^cp-/, "")] = el.checked ? "true" : "false";
     });
     return o;
   }
@@ -656,6 +671,15 @@ a:hover { text-decoration: underline; }
     if (m === "live") { closeWasm(); openStream(); }
     else if (m === "wasm") { closeStream(); openWasm(); }
     else { closeStream(); closeWasm(); refreshSnapshot(); }
+    syncOverlayToggles();
+  }
+  // The live-only overlay toggles (talkBack / touchOverlay) are meaningful only while the daemon
+  // holds the composition, so they're enabled iff Live Compose is the active mode and greyed out
+  // (like the static-snapshot controls) otherwise. Called on every mode transition.
+  var overlayToggles = document.querySelectorAll(".cp-overlay");
+  function syncOverlayToggles() {
+    var on = !!(live && live.checked);
+    Array.prototype.forEach.call(overlayToggles, function (el) { el.disabled = !on; });
   }
   // Programmatic switch (e.g. a wasm-only control auto-enabling Wasm): tick the radio so the UI
   // reflects it, then run the transition.
@@ -715,6 +739,18 @@ a:hover { text-decoration: underline; }
   fields.forEach(function (f) {
     var el = document.getElementById("cp-" + f);
     if (el) el.addEventListener("change", onControlsChanged);
+  });
+  // Overlay toggles are live-only: they push a fresh setOverrides through the open stream and do
+  // nothing otherwise. They get their own handler rather than onControlsChanged so a toggle mid
+  // connect (ws not yet readyState 1) can't fall through to the snapshot / wasm-auto-enable
+  // branches — an overlay never applies to a baked PNG or the in-browser tier.
+  function onOverlayChanged() {
+    if (live.checked && ws && ws.readyState === 1) {
+      ws.send(JSON.stringify({ type: "setOverrides", overrides: liveOverrides() }));
+    }
+  }
+  Array.prototype.forEach.call(overlayToggles, function (el) {
+    el.addEventListener("change", onOverlayChanged);
   });
   // Author-declared knobs re-render on edit (text/number debounce via "input", toggles "change").
   // They route differently from the display axes: a named knob (label, a color, …) is honoured

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
@@ -84,6 +84,8 @@ a:hover { text-decoration: underline; }
 .cp-controls label:has(:disabled) { opacity: 0.55; }
 .cp-knobs { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
 .cp-knobs-head { font-size: 0.72rem; color: #6b6b70; }
+.cp-overlays { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
+.cp-overlays-head { font-size: 0.72rem; color: #6b6b70; }
 .cp-knobs input:disabled { opacity: 0.7; }
 .cp-links { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
 .cp-link-row { display: flex; align-items: center; gap: 6px; }
@@ -169,6 +171,7 @@ a:hover { text-decoration: underline; }
               <option value="clear">Clear (crisp outline)</option>
             </select>
           </label>
+          
           
                 <div class="cp-links">
         <div class="cp-knobs-head">Direct links — the current view as a URL (overrides applied)</div>
@@ -264,6 +267,14 @@ a:hover { text-decoration: underline; }
       var val = (el.type === "checkbox") ? (el.checked ? "true" : "false") : el.value;
       if (val === "") return;
       o["knob." + key] = val;
+    });
+    // Live-only overlay toggles (talkBack / touchOverlay). Their id is "cp-<key>", so the daemon
+    // key is the id minus the prefix. Sent as an explicit true/false so unchecking clears the
+    // overlay on the next setOverrides (which replaces the whole map). Disabled ⇒ not live ⇒
+    // skipped, so they never leak onto a snapshot.
+    document.querySelectorAll(".cp-overlay").forEach(function (el) {
+      if (el.disabled) return;
+      o[el.id.replace(/^cp-/, "")] = el.checked ? "true" : "false";
     });
     return o;
   }
@@ -656,6 +667,15 @@ a:hover { text-decoration: underline; }
     if (m === "live") { closeWasm(); openStream(); }
     else if (m === "wasm") { closeStream(); openWasm(); }
     else { closeStream(); closeWasm(); refreshSnapshot(); }
+    syncOverlayToggles();
+  }
+  // The live-only overlay toggles (talkBack / touchOverlay) are meaningful only while the daemon
+  // holds the composition, so they're enabled iff Live Compose is the active mode and greyed out
+  // (like the static-snapshot controls) otherwise. Called on every mode transition.
+  var overlayToggles = document.querySelectorAll(".cp-overlay");
+  function syncOverlayToggles() {
+    var on = !!(live && live.checked);
+    Array.prototype.forEach.call(overlayToggles, function (el) { el.disabled = !on; });
   }
   // Programmatic switch (e.g. a wasm-only control auto-enabling Wasm): tick the radio so the UI
   // reflects it, then run the transition.
@@ -715,6 +735,18 @@ a:hover { text-decoration: underline; }
   fields.forEach(function (f) {
     var el = document.getElementById("cp-" + f);
     if (el) el.addEventListener("change", onControlsChanged);
+  });
+  // Overlay toggles are live-only: they push a fresh setOverrides through the open stream and do
+  // nothing otherwise. They get their own handler rather than onControlsChanged so a toggle mid
+  // connect (ws not yet readyState 1) can't fall through to the snapshot / wasm-auto-enable
+  // branches — an overlay never applies to a baked PNG or the in-browser tier.
+  function onOverlayChanged() {
+    if (live.checked && ws && ws.readyState === 1) {
+      ws.send(JSON.stringify({ type: "setOverrides", overrides: liveOverrides() }));
+    }
+  }
+  Array.prototype.forEach.call(overlayToggles, function (el) {
+    el.addEventListener("change", onOverlayChanged);
   });
   // Author-declared knobs re-render on edit (text/number debounce via "input", toggles "change").
   // They route differently from the display axes: a named knob (label, a color, …) is honoured

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
@@ -84,6 +84,8 @@ a:hover { text-decoration: underline; }
 .cp-controls label:has(:disabled) { opacity: 0.55; }
 .cp-knobs { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
 .cp-knobs-head { font-size: 0.72rem; color: #6b6b70; }
+.cp-overlays { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
+.cp-overlays-head { font-size: 0.72rem; color: #6b6b70; }
 .cp-knobs input:disabled { opacity: 0.7; }
 .cp-links { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
 .cp-link-row { display: flex; align-items: center; gap: 6px; }
@@ -169,6 +171,7 @@ a:hover { text-decoration: underline; }
               <option value="clear">Clear (crisp outline)</option>
             </select>
           </label>
+          
           
                 <div class="cp-links">
         <div class="cp-knobs-head">Direct links — the current view as a URL (overrides applied)</div>
@@ -264,6 +267,14 @@ a:hover { text-decoration: underline; }
       var val = (el.type === "checkbox") ? (el.checked ? "true" : "false") : el.value;
       if (val === "") return;
       o["knob." + key] = val;
+    });
+    // Live-only overlay toggles (talkBack / touchOverlay). Their id is "cp-<key>", so the daemon
+    // key is the id minus the prefix. Sent as an explicit true/false so unchecking clears the
+    // overlay on the next setOverrides (which replaces the whole map). Disabled ⇒ not live ⇒
+    // skipped, so they never leak onto a snapshot.
+    document.querySelectorAll(".cp-overlay").forEach(function (el) {
+      if (el.disabled) return;
+      o[el.id.replace(/^cp-/, "")] = el.checked ? "true" : "false";
     });
     return o;
   }
@@ -656,6 +667,15 @@ a:hover { text-decoration: underline; }
     if (m === "live") { closeWasm(); openStream(); }
     else if (m === "wasm") { closeStream(); openWasm(); }
     else { closeStream(); closeWasm(); refreshSnapshot(); }
+    syncOverlayToggles();
+  }
+  // The live-only overlay toggles (talkBack / touchOverlay) are meaningful only while the daemon
+  // holds the composition, so they're enabled iff Live Compose is the active mode and greyed out
+  // (like the static-snapshot controls) otherwise. Called on every mode transition.
+  var overlayToggles = document.querySelectorAll(".cp-overlay");
+  function syncOverlayToggles() {
+    var on = !!(live && live.checked);
+    Array.prototype.forEach.call(overlayToggles, function (el) { el.disabled = !on; });
   }
   // Programmatic switch (e.g. a wasm-only control auto-enabling Wasm): tick the radio so the UI
   // reflects it, then run the transition.
@@ -715,6 +735,18 @@ a:hover { text-decoration: underline; }
   fields.forEach(function (f) {
     var el = document.getElementById("cp-" + f);
     if (el) el.addEventListener("change", onControlsChanged);
+  });
+  // Overlay toggles are live-only: they push a fresh setOverrides through the open stream and do
+  // nothing otherwise. They get their own handler rather than onControlsChanged so a toggle mid
+  // connect (ws not yet readyState 1) can't fall through to the snapshot / wasm-auto-enable
+  // branches — an overlay never applies to a baked PNG or the in-browser tier.
+  function onOverlayChanged() {
+    if (live.checked && ws && ws.readyState === 1) {
+      ws.send(JSON.stringify({ type: "setOverrides", overrides: liveOverrides() }));
+    }
+  }
+  Array.prototype.forEach.call(overlayToggles, function (el) {
+    el.addEventListener("change", onOverlayChanged);
   });
   // Author-declared knobs re-render on edit (text/number debounce via "input", toggles "change").
   // They route differently from the display axes: a named knob (label, a color, …) is honoured


### PR DESCRIPTION
## Summary

Add an **Overlays (Live Compose)** control group to the serve viewer with two toggles — **Accessibility (TalkBack)** and **Show touches**. These map to the daemon's `talkBack` / `touchOverlay` fields, which composite an overlay onto the held session's streamed frames, so they mean nothing on a baked PNG. The group is therefore:

- **offered only when a Live Compose stream backs the session** (omitted entirely otherwise, not left as a dead control), and
- **disabled until Live Compose is the active mode** — greyed out (like the server-render-only device/orientation controls) in PNG / Wasm mode, and enabled by the mode-transition JS the moment Live Compose is selected.

This follows the guidance to disable such toggles in PNG mode and only enable them once live mode is on. It reuses the Part 2 render-mode radio group (#2328) as the gate and establishes the pattern that per-preview detected features (wear gestures, keyboard focus, …) will follow.

## Implementation

- **`ServeOverrides`** — parses `talkBack` / `touchOverlay` as booleans (mirroring `inspectionMode` / `slotMode`), and folds them into the render cache key so a crafted `/render?talkBack=true` can't coalesce onto the baked entry.
- **`ServeWeb`** — renders the overlay group (gated on `hasLiveStream`), collects checked overlays into `liveOverrides()` as explicit `true`/`false` (so unchecking clears the overlay on the next `setOverrides`), and syncs their `disabled` state on every mode transition via `syncOverlayToggles()`. Overlays get a dedicated `onOverlayChanged` handler rather than the shared `onControlsChanged`, so a toggle flipped while the stream is still connecting can't fall through to the snapshot / wasm-auto-enable branches — an overlay never applies to a PNG or the in-browser tier.
- Overlays are **never** added to `overrides()` / `query()`, so the PNG `/render` URL and the copyable links stay clean.

## Test plan

- `./gradlew :cli:test --tests '*ServeOverridesTest*' --tests '*ServeWebFixtureTest*'` — green. Override tests cover parse (true/`1`), rejection of bad values, and cache-key participation; the fixture test asserts the group is **absent** with no live stream and **present-but-disabled** with one. Viewer golden fixtures regenerated.

## Visual evidence

The `serve-viewer-catalog-knobs` / `serve-viewer-wasm-live` fixture pages are wired into the `vscode-preview-diff` harness, so the bot renders and diffs this exact control panel. Before = `main`, after = this branch (commit-pinned renders):

**`serve-viewer-catalog-knobs` (light)** — controls end at Background before; after, the new **Overlays (Live Compose)** group with `☐ Accessibility (TalkBack)` and `☐ Show touches`, greyed out in the default PNG mode:

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/yschimke/compose-ai-tools/f0adcd4eec6a8a7d7d42694a00fc89910534a6b5/renders/serve-viewer-catalog-knobs.light.png" width="360"> | <img src="https://raw.githubusercontent.com/yschimke/compose-ai-tools/b7584406356cbc7ad1ff5ca4955917155133e6e6/renders/serve-viewer-catalog-knobs.light.png" width="360"> |

**`serve-viewer-wasm-live` (light):**

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/yschimke/compose-ai-tools/f0adcd4eec6a8a7d7d42694a00fc89910534a6b5/renders/serve-viewer-wasm-live.light.png" width="360"> | <img src="https://raw.githubusercontent.com/yschimke/compose-ai-tools/b7584406356cbc7ad1ff5ca4955917155133e6e6/renders/serve-viewer-wasm-live.light.png" width="360"> |

The renders above show the **default PNG mode** (overlays present, disabled). Selecting **Live Compose** enables both toggles; ticking **Accessibility (TalkBack)** keeps the mode on Live Compose and pushes a `setOverrides` through the stream (verified with headless Chromium against the fixture; screenshots shared with the author).

---
_Generated by [Claude Code](https://claude.ai/code/session_01MkDr2hzvkuW9yrs16eFCyj)_