### PR TITLE
fix(serve): seed the daemon with current overrides when the live socket opens

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -1132,6 +1132,14 @@ object ServeWeb {
         var qs = query();
         ws = new WebSocket(proto + "//" + location.host + base + "/ws/" +
           encodeURIComponent(previewId) + "?" + (qs ? qs + "&codec=webp" : "codec=webp"));
+        ws.onopen = function () {
+          // The connect URL seeds only query()'s fields — the display axes plus changed knobs — so
+          // the live-only overlays (talkBack / touchOverlay) and anything toggled during the
+          // connecting window aren't in it. Replay the full live override map once the socket is
+          // ready so the daemon reflects the exact current control state, including an overlay
+          // checked before onopen whose change event the readyState guard dropped.
+          ws.send(JSON.stringify({ type: "setOverrides", overrides: liveOverrides() }));
+        };
         ws.onmessage = function (ev) {
           var m;
           try { m = JSON.parse(ev.data); } catch (e) { return; }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -663,6 +663,13 @@ class ServeWebFixtureTest {
         liveCatalogWasm.contains("id=\"cp-touchOverlay\" type=\"checkbox\" disabled"),
       "live stream offers the overlay toggles, disabled until Live Compose is active",
     )
+    // The stream replays the full liveOverrides() on open so an overlay checked while the socket
+    // was
+    // still connecting (its change event dropped by the readyState guard) still reaches the daemon.
+    assertTrue(
+      liveCatalogWasm.contains("ws.onopen = function () {"),
+      "the live stream seeds the daemon with the current overrides once the socket opens",
+    )
 
     // Trusted catalog served LIVE whose preview declares author knobs (ServeCatalogLiveHost with
     // canRenderOverrides): snapshots stay baked, but the carried daemon re-renders a knob edit on

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
@@ -501,6 +501,14 @@ a:hover { text-decoration: underline; }
     var qs = query();
     ws = new WebSocket(proto + "//" + location.host + base + "/ws/" +
       encodeURIComponent(previewId) + "?" + (qs ? qs + "&codec=webp" : "codec=webp"));
+    ws.onopen = function () {
+      // The connect URL seeds only query()'s fields — the display axes plus changed knobs — so
+      // the live-only overlays (talkBack / touchOverlay) and anything toggled during the
+      // connecting window aren't in it. Replay the full live override map once the socket is
+      // ready so the daemon reflects the exact current control state, including an overlay
+      // checked before onopen whose change event the readyState guard dropped.
+      ws.send(JSON.stringify({ type: "setOverrides", overrides: liveOverrides() }));
+    };
     ws.onmessage = function (ev) {
       var m;
       try { m = JSON.parse(ev.data); } catch (e) { return; }

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
@@ -483,6 +483,14 @@ a:hover { text-decoration: underline; }
     var qs = query();
     ws = new WebSocket(proto + "//" + location.host + base + "/ws/" +
       encodeURIComponent(previewId) + "?" + (qs ? qs + "&codec=webp" : "codec=webp"));
+    ws.onopen = function () {
+      // The connect URL seeds only query()'s fields — the display axes plus changed knobs — so
+      // the live-only overlays (talkBack / touchOverlay) and anything toggled during the
+      // connecting window aren't in it. Replay the full live override map once the socket is
+      // ready so the daemon reflects the exact current control state, including an overlay
+      // checked before onopen whose change event the readyState guard dropped.
+      ws.send(JSON.stringify({ type: "setOverrides", overrides: liveOverrides() }));
+    };
     ws.onmessage = function (ev) {
       var m;
       try { m = JSON.parse(ev.data); } catch (e) { return; }

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
@@ -487,6 +487,14 @@ a:hover { text-decoration: underline; }
     var qs = query();
     ws = new WebSocket(proto + "//" + location.host + base + "/ws/" +
       encodeURIComponent(previewId) + "?" + (qs ? qs + "&codec=webp" : "codec=webp"));
+    ws.onopen = function () {
+      // The connect URL seeds only query()'s fields — the display axes plus changed knobs — so
+      // the live-only overlays (talkBack / touchOverlay) and anything toggled during the
+      // connecting window aren't in it. Replay the full live override map once the socket is
+      // ready so the daemon reflects the exact current control state, including an overlay
+      // checked before onopen whose change event the readyState guard dropped.
+      ws.send(JSON.stringify({ type: "setOverrides", overrides: liveOverrides() }));
+    };
     ws.onmessage = function (ev) {
       var m;
       try { m = JSON.parse(ev.data); } catch (e) { return; }

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
@@ -483,6 +483,14 @@ a:hover { text-decoration: underline; }
     var qs = query();
     ws = new WebSocket(proto + "//" + location.host + base + "/ws/" +
       encodeURIComponent(previewId) + "?" + (qs ? qs + "&codec=webp" : "codec=webp"));
+    ws.onopen = function () {
+      // The connect URL seeds only query()'s fields — the display axes plus changed knobs — so
+      // the live-only overlays (talkBack / touchOverlay) and anything toggled during the
+      // connecting window aren't in it. Replay the full live override map once the socket is
+      // ready so the daemon reflects the exact current control state, including an overlay
+      // checked before onopen whose change event the readyState guard dropped.
+      ws.send(JSON.stringify({ type: "setOverrides", overrides: liveOverrides() }));
+    };
     ws.onmessage = function (ev) {
       var m;
       try { m = JSON.parse(ev.data); } catch (e) { return; }

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
@@ -483,6 +483,14 @@ a:hover { text-decoration: underline; }
     var qs = query();
     ws = new WebSocket(proto + "//" + location.host + base + "/ws/" +
       encodeURIComponent(previewId) + "?" + (qs ? qs + "&codec=webp" : "codec=webp"));
+    ws.onopen = function () {
+      // The connect URL seeds only query()'s fields — the display axes plus changed knobs — so
+      // the live-only overlays (talkBack / touchOverlay) and anything toggled during the
+      // connecting window aren't in it. Replay the full live override map once the socket is
+      // ready so the daemon reflects the exact current control state, including an overlay
+      // checked before onopen whose change event the readyState guard dropped.
+      ws.send(JSON.stringify({ type: "setOverrides", overrides: liveOverrides() }));
+    };
     ws.onmessage = function (ev) {
       var m;
       try { m = JSON.parse(ev.data); } catch (e) { return; }


### PR DESCRIPTION
## Summary

Follow-up to #2332, addressing a Codex P2 review comment that landed after that PR auto-merged.

When **Live Compose** is selected, the new overlay toggles (`talkBack` / `touchOverlay`) are enabled immediately while `openStream()` is still connecting. The WebSocket connect URL is built from `query()`, which by design excludes the live-only overlay fields — and there was no `ws.onopen` handler. So an overlay checked during the connecting window fired a `change` event that the `readyState === 1` guard in `onOverlayChanged` dropped: the checkbox stayed checked, but the daemon never received the overlay until some *other* control happened to resend `liveOverrides()`.

## Fix

Add a `ws.onopen` handler in `openStream()` that replays the full `liveOverrides()` once the socket is ready. This guarantees the daemon reflects the exact current control state the moment the stream is live — including an overlay toggled before `onopen`. As a bonus it also covers any display-axis or knob change made during the connecting window, which had the same latent drop.

`setOverrides` replaces the whole override map on the daemon side, so the replay is idempotent with the fields already seeded via the connect URL.

## Test plan

- `./gradlew :cli:test --tests '*ServeWebFixtureTest*' --tests '*ServeOverridesTest*'` — green. Added a fixture-test assertion that the live viewer emits the `ws.onopen` replay. Viewer golden fixtures regenerated.

## Visual evidence

None applicable — this is a **script-only** behavior fix inside the viewer's embedded JS. The rendered control panel is pixel-identical to #2332 (the `vscode-preview-diff` bot will show no change to `serve-viewer-*`); the fixture `.html` files differ only in the inlined `<script>`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MkDr2hzvkuW9yrs16eFCyj)_