### PR TITLE
feat(serve): render previews under app-declared @ThemeCatalog themes

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -23,6 +23,7 @@ import ee.schimke.composeai.cli.serve.ServeSessionState
 import ee.schimke.composeai.cli.serve.ServeStartupBundles
 import ee.schimke.composeai.cli.serve.ServeUrls
 import ee.schimke.composeai.cli.serve.TrustStore
+import ee.schimke.composeai.cli.serve.declaredThemesFromPreviews
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.render.session.RenderSessionException
 import java.io.File
@@ -305,6 +306,9 @@ class ServeCommand(args: List<String>) : Command(args) {
       manifest.previews
         .filter { matches(it.id) }
         .map { ServePreview(id = it.id, label = it.functionName.ifBlank { it.id }) }
+    // The module's declared @ThemeCatalog themes — the Theme selector renders them so a preview can
+    // be re-rendered under Brand Dark etc. Module-global, so unaffected by the --id/--filter above.
+    val declaredThemes = declaredThemesFromPreviews(manifest.previews)
     if (previews.isEmpty()) {
       System.err.println("serve: no previews matched (--id/--filter excluded them all).")
       exitProcess(3)
@@ -329,6 +333,7 @@ class ServeCommand(args: List<String>) : Command(args) {
           workspaceName = module.projectDir.name,
           previews = previews,
           label = module.gradlePath,
+          declaredThemes = declaredThemes,
           onLog = { System.err.println("[daemon serve] $it") },
         )
       } catch (e: RenderSessionException) {
@@ -506,6 +511,7 @@ class ServeCommand(args: List<String>) : Command(args) {
             workspaceName = state.workspaceName,
             previews = state.previews,
             label = state.label,
+            declaredThemes = state.declaredThemes,
             onLog = { System.err.println("[daemon serve] $it") },
           )
         val fallback = state.bakedFallback

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -391,6 +391,10 @@ class ServeCommand(args: List<String>) : Command(args) {
         workspaceName = module.projectDir.name,
         previews = previews,
         label = module.gradlePath,
+        // Carry the declared themes on the session state too — the registry suspends idle daemons
+        // and reopens from this state, so without it the App theme selector would vanish after the
+        // first idle suspend/resume.
+        declaredThemes = declaredThemes,
       )
     registry.register(module.gradlePath, defaultState, host = renderHost)
     // Shared mode: register any pre-rendered portable bundles under `--bundles <dir>` as read-only
@@ -1010,6 +1014,7 @@ class ServeCommand(args: List<String>) : Command(args) {
         workspaceName = built.moduleDir.name,
         previews = built.previews,
         label = "$system@${source.ref}",
+        declaredThemes = built.declaredThemes,
         // Same catalog-id bridge + baked fallback as the bundle path (a source build's daemon uses
         // the same function-based ids), so a live source-rebuilt catalog also answers the published
         // URLs and falls back to baked PNGs for ids it can't render.

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/GradleRevisionBuilder.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/GradleRevisionBuilder.kt
@@ -55,7 +55,13 @@ class GradleRevisionBuilder(
       onLog("serve: no previews discovered for ${module.gradlePath}")
       return null
     }
-    return BuiltRevision(moduleDir = moduleDir, descriptor = descriptor, previews = previews)
+    val declaredThemes = manifest?.previews?.let { declaredThemesFromPreviews(it) } ?: emptyList()
+    return BuiltRevision(
+      moduleDir = moduleDir,
+      descriptor = descriptor,
+      previews = previews,
+      declaredThemes = declaredThemes,
+    )
   }
 
   private fun runGradle(worktreeDir: File, gradlew: File, args: List<String>): Boolean {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHost.kt
@@ -17,6 +17,16 @@ interface ServeHost : AutoCloseable {
   /** The whole servable preview set for this session. */
   val previews: List<ServePreview>
 
+  /**
+   * The app's declared `@ThemeCatalog` themes — module-global, so the viewer's Theme selector can
+   * offer "render this preview under Brand Dark". Non-empty only for a daemon-backed host
+   * ([ServeRenderHost]) whose module declares them; a static bundle carries no theme-apply lane
+   * (`themeProvider` needs the daemon to load the provider off the app classpath), so it stays
+   * empty and the selector shows only the built-in light/dark axis.
+   */
+  val declaredThemes: List<ServeTheme>
+    get() = emptyList()
+
   /** Human label for the tenant (module Gradle path, `module@rev`, or a bundle name). */
   val label: String
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -511,6 +511,7 @@ class ServeHttpServer(
           wasmSameOrigin = wasmSameOrigin,
           basePath = basePath,
           isPublic = isPublic,
+          declaredThemes = renderHost.declaredThemes,
         ),
         ContentType.Text.Html,
       )

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeOverrides.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeOverrides.kt
@@ -60,6 +60,9 @@ object ServeOverrides {
       // only while a Live Compose session is active. Booleans, like inspectionMode/slotMode.
       "talkBack",
       "touchOverlay",
+      // FQN of an app-declared @ThemeCatalog `PreviewWrapperProvider` to render this preview under
+      // (the discrete-theme axis). Daemon-only — a baked bundle has no provider to load.
+      "themeProvider",
       // "crisp outline" toggle. Friendly `background=clear` (aliases below) or the raw
       // `clearBackground=true`; both map to `PreviewOverrides.clearBackground`.
       "background",
@@ -326,6 +329,7 @@ object ServeOverrides {
         slotMode = slotMode,
         talkBack = talkBack,
         touchOverlay = touchOverlay,
+        themeProvider = params["themeProvider"]?.takeIf { it.isNotBlank() },
         clearBackground = clearBackground,
         namedOverrides = namedOverrides.ifEmpty { null },
       )
@@ -353,6 +357,7 @@ object ServeOverrides {
       append("slot=").append(o.slotMode).append('|')
       append("talk=").append(o.talkBack).append('|')
       append("touch=").append(o.touchOverlay).append('|')
+      append("theme=").append(o.themeProvider).append('|')
       append("clearbg=").append(o.clearBackground).append('|')
       // Named overrides participate so a knob edit isn't coalesced onto the prior render. Sorted by
       // key for order-independence; the value data classes have stable toString.

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
@@ -60,6 +60,37 @@ data class ServePreview(
   val overrides: List<ee.schimke.composeai.data.overrides.PreviewOverrideDeclaration> = emptyList(),
 )
 
+/**
+ * One app-declared `@ThemeCatalog` theme this session can render an arbitrary preview under — the
+ * discrete-theme counterpart of the built-in light/dark axis. Discovered as a module-global set (a
+ * theme applies to every preview, not one), so it hangs off [ServeHost.declaredThemes] rather than
+ * [ServePreview]. [providerFqn] is the `PreviewWrapperProvider` FQN sent verbatim as the
+ * `themeProvider` override; [name] is the human label; [group] buckets related themes (a brand).
+ */
+data class ServeTheme(val name: String, val providerFqn: String, val group: String? = null)
+
+/**
+ * Extract the module's declared `@ThemeCatalog` themes from a discovery manifest's preview list.
+ * Discovery materializes each annotated `PreviewWrapperProvider` as a synthetic `THEME_CATALOG`
+ * preview carrying the provider FQN on `params.wrapperClassName` plus its `name` / `group`; this
+ * lifts those into [ServeTheme]s (the module-global theme options) without disturbing the ordinary
+ * preview cards. Entries missing a provider FQN are skipped (nothing to apply). Deduped by FQN.
+ */
+fun declaredThemesFromPreviews(
+  previews: List<ee.schimke.composeai.cli.PreviewInfo>
+): List<ServeTheme> =
+  previews
+    .filter { it.params.kind == "THEME_CATALOG" }
+    .mapNotNull { p ->
+      val fqn = p.params.wrapperClassName?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
+      ServeTheme(
+        name = p.params.name?.takeIf { it.isNotBlank() } ?: p.functionName.ifBlank { p.id },
+        providerFqn = fqn,
+        group = p.params.group?.takeIf { it.isNotBlank() },
+      )
+    }
+    .distinctBy { it.providerFqn }
+
 /** Result of a snapshot render request. */
 sealed interface RenderOutcome {
   data class Ok(val png: ByteArray) : RenderOutcome
@@ -121,6 +152,8 @@ internal constructor(
   override val previews: List<ServePreview>,
   /** Human label for this tenant (e.g. the module's Gradle path); shown in the served pages. */
   override val label: String = "",
+  /** App-declared `@ThemeCatalog` themes discovered for this module (module-global). */
+  override val declaredThemes: List<ServeTheme> = emptyList(),
   private val fileSystem: FileSystem = SystemFileSystem,
   private val onLog: (String) -> Unit = {},
   private val renderTimeoutSeconds: Long = RENDER_TIMEOUT_SECONDS,
@@ -603,6 +636,7 @@ internal constructor(
       workspaceName: String,
       previews: List<ServePreview>,
       label: String = "",
+      declaredThemes: List<ServeTheme> = emptyList(),
       onLog: (String) -> Unit = {},
       factory: RenderSessionFactory = SubprocessRenderSessions,
     ): ServeRenderHost {
@@ -615,7 +649,13 @@ internal constructor(
             logSink = onLog,
           )
         )
-      return ServeRenderHost(session = session, previews = previews, label = label, onLog = onLog)
+      return ServeRenderHost(
+        session = session,
+        previews = previews,
+        label = label,
+        declaredThemes = declaredThemes,
+        onLog = onLog,
+      )
     }
   }
 }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRevisionFactory.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRevisionFactory.kt
@@ -12,6 +12,8 @@ data class BuiltRevision(
   /** `build/compose-previews/daemon-launch.json` for the built module. */
   val descriptor: File,
   val previews: List<ServePreview>,
+  /** App-declared `@ThemeCatalog` themes discovered for the module (module-global). */
+  val declaredThemes: List<ServeTheme> = emptyList(),
 )
 
 /**
@@ -68,6 +70,7 @@ class ServeRevisionFactory(
       workspaceName = built.moduleDir.name,
       previews = built.previews,
       label = "${module.gradlePath}@$rev",
+      declaredThemes = built.declaredThemes,
     )
   }
 }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionState.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionState.kt
@@ -21,6 +21,10 @@ data class ServeSessionState(
   /** Human label for the tenant (e.g. the module's Gradle path, or `module@rev`). */
   val label: String,
   /**
+   * App-declared `@ThemeCatalog` themes (module-global) surfaced in the viewer's Theme selector.
+   */
+  val declaredThemes: List<ServeTheme> = emptyList(),
+  /**
    * Optional **catalog-id → daemon-preview-id** alias map, set only for a trusted-catalog live
    * session ([ServeCatalogStore] / [ServeBundleDaemon]). The daemon knows previews by their
    * function-based descriptor id (`FilledButton_Dark`), but the published catalog links and image

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -687,6 +687,14 @@ object ServeWeb {
      * generic `Live`.
      */
     liveBackend: String? = null,
+    /**
+     * The app's declared `@ThemeCatalog` themes (module-global). When non-empty, the viewer adds an
+     * "App theme" selector whose options re-render the preview under the chosen provider (the
+     * `themeProvider` override) — daemon-only, so it's enabled exactly when a knob edit would be
+     * (`canApplyOverrides || canRenderOverrides`). Empty ⇒ no selector (a static bundle, or a
+     * module that declares none).
+     */
+    declaredThemes: List<ServeTheme> = emptyList(),
   ): String {
     val idSeg = WebEscaping.urlEncodeSegment(preview.id)
     val q = querySuffix(linkQuery(token, sessionId, basePath, isPublic))
@@ -777,6 +785,46 @@ object ServeWeb {
       }
     val backendLabel = WebEscaping.htmlEscape(snapshotBackend ?: "Snapshot")
     val liveLabel = WebEscaping.htmlEscape(liveBackend ?: "Live")
+    // The app-declared `@ThemeCatalog` theme selector — the discrete-theme axis. Rendered only when
+    // the module declares themes; selecting one re-renders the preview under that provider (the
+    // `themeProvider` override). Daemon-only, so it's disabled unless the host can render an
+    // override (`canApplyOverrides || canRenderOverrides`) — a knob-style control, not a
+    // client-side
+    // one. Options carry the provider FQN as their value; `@ThemeCatalog(group=…)` buckets them
+    // into
+    // <optgroup>s. Marked `.cp-knob-theme` so the JS routes its change through the daemon path.
+    val themeSelectorHtml =
+      if (declaredThemes.isEmpty()) ""
+      else {
+        val themeDis = if (canApplyOverrides || canRenderOverrides) "" else " disabled"
+        val grouped = declaredThemes.groupBy { it.group }
+        val optionsOf: (List<ServeTheme>) -> String = { list ->
+          list.joinToString("\n") { t ->
+            "<option value=\"${WebEscaping.htmlEscape(t.providerFqn)}\">" +
+              "${WebEscaping.htmlEscape(t.name)}</option>"
+          }
+        }
+        val body = buildString {
+          // Ungrouped themes first (flat), then one <optgroup> per declared group.
+          grouped[null]?.let { append(optionsOf(it)).append('\n') }
+          grouped
+            .filterKeys { it != null }
+            .forEach { (group, list) ->
+              append("<optgroup label=\"${WebEscaping.htmlEscape(group!!)}\">")
+                .append(optionsOf(list))
+                .append("</optgroup>\n")
+            }
+        }
+        """
+        <label>App theme
+          <select id="cp-themeProvider" class="cp-knob-theme"$themeDis>
+            <option value="">(default)</option>
+            $body
+          </select>
+        </label>
+        """
+          .trimIndent()
+      }
     // Live-only overlay toggles (accessibility / touch visualization). The daemon composites these
     // onto the held session's frames, so they mean nothing on a baked PNG — offered only when a
     // Live
@@ -816,6 +864,7 @@ object ServeWeb {
               <option value="dark">Dark</option>
             </select>
           </label>
+          $themeSelectorHtml
           <label>Device
             <select id="cp-device"$serverDis>
               <option value="">(default)</option>
@@ -940,6 +989,10 @@ object ServeWeb {
           if (el.disabled) return;
           o[el.id.replace(/^cp-/, "")] = el.checked ? "true" : "false";
         });
+        // App-declared theme (themeProvider = provider FQN). Only when a theme is picked and the
+        // control is live; "(default)" (empty) leaves the daemon on the preview's own wrapper.
+        var tp = document.getElementById("cp-themeProvider");
+        if (tp && !tp.disabled && tp.value) o["themeProvider"] = tp.value;
         return o;
       }
       function query() {
@@ -963,6 +1016,13 @@ object ServeWeb {
           if (val === (el.getAttribute("data-knob-initial") || "")) return;
           parts.push("knob." + encodeURIComponent(key) + "=" + encodeURIComponent(val));
         });
+        // App-declared theme (themeProvider = provider FQN). Routes to the daemon like a knob; a
+        // published catalog re-renders on demand. Omitted at "(default)" so the URL stays on the
+        // instant baked snapshot until a theme is actually chosen.
+        var tp = document.getElementById("cp-themeProvider");
+        if (tp && !tp.disabled && tp.value) {
+          parts.push("themeProvider=" + encodeURIComponent(tp.value));
+        }
         return parts.join("&");
       }
       function refreshSnapshot() {
@@ -1446,6 +1506,11 @@ object ServeWeb {
       document.querySelectorAll(".cp-knob").forEach(function (el) {
         el.addEventListener(el.type === "checkbox" ? "change" : "input", onKnobChanged);
       });
+      // The app-theme selector routes through the daemon like a knob (never the wasm auto-enable
+      // path — an app-declared theme provider is a server-side wrapper the in-browser tier can't
+      // load), so it shares onKnobChanged rather than onControlsChanged.
+      var themeSel = document.getElementById("cp-themeProvider");
+      if (themeSel) themeSel.addEventListener("change", onKnobChanged);
       refreshSnapshot();
     })();
     """

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeOverridesTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeOverridesTest.kt
@@ -35,6 +35,7 @@ class ServeOverridesTest {
     assertNull(o.slotMode)
     assertNull(o.talkBack)
     assertNull(o.touchOverlay)
+    assertNull(o.themeProvider)
     assertNull(o.clearBackground)
   }
 
@@ -55,6 +56,7 @@ class ServeOverridesTest {
           "slotMode" to "true",
           "talkBack" to "true",
           "touchOverlay" to "1",
+          "themeProvider" to "com.example.BrandDarkThemeCatalog",
         )
       )
     assertEquals(UiMode.DARK, o.uiMode)
@@ -69,6 +71,7 @@ class ServeOverridesTest {
     assertEquals(true, o.slotMode)
     assertEquals(true, o.talkBack)
     assertEquals(true, o.touchOverlay)
+    assertEquals("com.example.BrandDarkThemeCatalog", o.themeProvider)
   }
 
   @Test
@@ -164,6 +167,16 @@ class ServeOverridesTest {
     assertNotEquals(
       ServeOverrides.cacheKey("preview.A", ok(mapOf("touchOverlay" to "true"))),
       ServeOverrides.cacheKey("preview.A", ok(emptyMap())),
+    )
+    // A themeProvider selection participates, so rendering a preview under two different declared
+    // themes (or a theme vs the default) doesn't coalesce onto one cache entry.
+    assertNotEquals(
+      ServeOverrides.cacheKey("preview.A", ok(mapOf("themeProvider" to "com.example.BrandDark"))),
+      ServeOverrides.cacheKey("preview.A", ok(emptyMap())),
+    )
+    assertNotEquals(
+      ServeOverrides.cacheKey("preview.A", ok(mapOf("themeProvider" to "com.example.BrandDark"))),
+      ServeOverrides.cacheKey("preview.A", ok(mapOf("themeProvider" to "com.example.BrandLight"))),
     )
   }
 

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -224,6 +224,23 @@ class ServeWebFixtureTest {
         trust = "branch:yschimke/meshcore-mobile@design-artifacts/meshcore-mobile",
         basePath = "/meshcore-mobile",
       )
+    // A daemon-backed viewer whose module declares `@ThemeCatalog` themes: the viewer adds an "App
+    // theme" selector (grouped by `@ThemeCatalog(group=…)`) so a preview can be re-rendered under a
+    // chosen theme via the `themeProvider` override. Captured so the visual-diff bot covers the
+    // selector.
+    val viewerThemes =
+      ServeWeb.viewerPage(
+        previews.first { it.id.endsWith("ProfileScreenPreview") },
+        token,
+        sessionId = "compose-m3",
+        canApplyOverrides = true,
+        declaredThemes =
+          listOf(
+            ServeTheme("Brand Light", "com.example.BrandLightThemeCatalog", group = "Brand"),
+            ServeTheme("Brand Dark", "com.example.BrandDarkThemeCatalog", group = "Brand"),
+            ServeTheme("High Contrast", "com.example.HighContrastThemeCatalog"),
+          ),
+      )
     // A catalog whose previews carry per-theme variants, so the landing shows the sticky light/dark
     // toggle and tags each card with its baked theme for client-side filtering.
     val landingThemed =
@@ -245,6 +262,7 @@ class ServeWebFixtureTest {
       File(pagesDir, "serve-viewer-wasm.html").writeText(wasmViewer)
       File(pagesDir, "serve-viewer-wasm-live.html").writeText(wasmViewerLive)
       File(pagesDir, "serve-viewer-catalog-knobs.html").writeText(viewerCatalogKnobs)
+      File(pagesDir, "serve-viewer-themes.html").writeText(viewerThemes)
       File(pagesDir, "serve-landing-path.html").writeText(landingPath)
       File(pagesDir, "serve-viewer-path.html").writeText(viewerPath)
       File(pagesDir, "serve-landing-themed.html").writeText(landingThemed)
@@ -259,6 +277,7 @@ class ServeWebFixtureTest {
     assertGolden(File(pagesDir, "serve-viewer-wasm.html"), wasmViewer)
     assertGolden(File(pagesDir, "serve-viewer-wasm-live.html"), wasmViewerLive)
     assertGolden(File(pagesDir, "serve-viewer-catalog-knobs.html"), viewerCatalogKnobs)
+    assertGolden(File(pagesDir, "serve-viewer-themes.html"), viewerThemes)
     assertGolden(File(pagesDir, "serve-landing-path.html"), landingPath)
     assertGolden(File(pagesDir, "serve-viewer-path.html"), viewerPath)
     assertGolden(File(pagesDir, "serve-landing-themed.html"), landingThemed)
@@ -620,6 +639,10 @@ class ServeWebFixtureTest {
       staticView.contains("id=\"cp-talkBack\""),
       "no live stream ⇒ the live-only overlay toggles are omitted entirely, not left dead",
     )
+    assertFalse(
+      staticView.contains("id=\"cp-themeProvider\""),
+      "no declared themes ⇒ the App theme selector is omitted entirely",
+    )
 
     // Static + Wasm: theme, font scale, and locale go LIVE (the in-browser app honours them) — only
     // the server-render-only controls (device/orientation/live stream) stay disabled.
@@ -804,6 +827,61 @@ class ServeWebFixtureTest {
     assertTrue(!liveView.contains("value=\"1.0\" disabled"), "font scale enabled on a live session")
     assertTrue(!liveView.contains("id=\"cp-device\" disabled"), "device enabled on a live session")
     assertTrue(liveView.contains("data-static-snapshot=\"false\""), "live session is not static")
+  }
+
+  @Test
+  fun `declared themes render an App theme selector routed through the daemon`() {
+    val themes =
+      listOf(
+        ServeTheme("Brand Light", "com.example.BrandLightThemeCatalog", group = "Brand"),
+        ServeTheme("Brand Dark", "com.example.BrandDarkThemeCatalog", group = "Brand"),
+        ServeTheme("High Contrast", "com.example.HighContrastThemeCatalog"),
+      )
+    val view =
+      ServeWeb.viewerPage(
+        previews.first(),
+        token,
+        canApplyOverrides = true,
+        declaredThemes = themes,
+      )
+    // The selector exists and carries each provider FQN as an option value with the human name.
+    assertTrue(
+      view.contains("id=\"cp-themeProvider\""),
+      "declared themes render an App theme select",
+    )
+    assertTrue(
+      view.contains("<option value=\"com.example.BrandLightThemeCatalog\">Brand Light</option>"),
+      "each declared theme is an option keyed by its provider FQN",
+    )
+    // `@ThemeCatalog(group=…)` buckets themes into <optgroup>s; an ungrouped theme stays flat.
+    assertTrue(view.contains("<optgroup label=\"Brand\">"), "grouped themes get an <optgroup>")
+    assertTrue(
+      view.contains(
+        "<option value=\"com.example.HighContrastThemeCatalog\">High Contrast</option>"
+      ),
+      "an ungrouped theme is a flat option",
+    )
+    // Enabled on a daemon host and routed like a knob (the daemon path, never the wasm
+    // auto-enable).
+    assertFalse(
+      view.contains("id=\"cp-themeProvider\" class=\"cp-knob-theme\" disabled"),
+      "the theme selector is enabled on a daemon-backed host",
+    )
+    assertTrue(
+      view.contains("themeSel.addEventListener(\"change\", onKnobChanged)"),
+      "the theme selector routes its change through the daemon (knob) path",
+    )
+    assertTrue(
+      view.contains("parts.push(\"themeProvider=\""),
+      "a chosen theme is appended to the /render URL as themeProvider",
+    )
+
+    // A static bundle can't load a provider, so the selector renders disabled (informational).
+    val staticThemed = ServeWeb.viewerPage(previews.first(), token, declaredThemes = themes)
+    assertTrue(
+      staticThemed.contains("id=\"cp-themeProvider\" class=\"cp-knob-theme\" disabled"),
+      "the theme selector is disabled on a static bundle (no daemon to apply it)",
+    )
   }
 
   @Test

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -460,13 +460,12 @@ class RenderEngine(
                         } else {
                           InvokeWithOptionalWrapper(
                             composableMethod = composableMethod!!,
+                            wrapperFqnFromSpec = spec.wrapperClassName,
                             // A `themeProvider` override (an app-declared @ThemeCatalog
                             // `PreviewWrapperProvider` FQN) replaces the preview's own
-                            // `@PreviewWrapper` — "render this preview under theme X". Blank /
-                            // unresolvable falls back to the declared wrapper.
-                            wrapperFqnFromSpec =
-                              spec.overrides?.themeProvider?.takeIf { it.isNotBlank() }
-                                ?: spec.wrapperClassName,
+                            // `@PreviewWrapper` — "render this preview under theme X" — but only when
+                            // it resolves; a stale/misspelled FQN falls back to the declared wrapper.
+                            themeProviderFqn = spec.overrides?.themeProvider,
                           )
                         }
                       }
@@ -1218,10 +1217,17 @@ private fun InvokeComposable(composableMethod: ComposableMethod) {
 private fun InvokeWithOptionalWrapper(
   composableMethod: ComposableMethod,
   wrapperFqnFromSpec: String?,
+  themeProviderFqn: String? = null,
 ) {
   val wrapper =
-    remember(composableMethod, wrapperFqnFromSpec) {
-      resolveWrapperOrNull(composableMethod, wrapperFqnFromSpec)
+    remember(composableMethod, wrapperFqnFromSpec, themeProviderFqn) {
+      // A `themeProvider` override wraps the preview in an app-declared theme provider IN PLACE OF
+      // its own `@PreviewWrapper` — but only when it actually loads. On a stale/misspelled FQN,
+      // `loadWrapperByFqnOrNull` logs and returns null; we then fall back to the preview's declared
+      // wrapper rather than stripping it (which would drop a required `@PreviewWrapper` and
+      // misrender). A blank/absent themeProvider skips straight to the declared wrapper.
+      themeProviderFqn?.takeIf { it.isNotBlank() }?.let { loadWrapperByFqnOrNull(it) }
+        ?: resolveWrapperOrNull(composableMethod, wrapperFqnFromSpec)
     }
   if (wrapper == null) {
     InvokeComposable(composableMethod)

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -460,7 +460,13 @@ class RenderEngine(
                         } else {
                           InvokeWithOptionalWrapper(
                             composableMethod = composableMethod!!,
-                            wrapperFqnFromSpec = spec.wrapperClassName,
+                            // A `themeProvider` override (an app-declared @ThemeCatalog
+                            // `PreviewWrapperProvider` FQN) replaces the preview's own
+                            // `@PreviewWrapper` — "render this preview under theme X". Blank /
+                            // unresolvable falls back to the declared wrapper.
+                            wrapperFqnFromSpec =
+                              spec.overrides?.themeProvider?.takeIf { it.isNotBlank() }
+                                ?: spec.wrapperClassName,
                           )
                         }
                       }

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -1321,7 +1321,13 @@ open class RobolectricHost(
       // path keeps the opaque background when the viewer sends `PreviewOverrides(clearBackground =
       // true)`. Null preserves the discovery-time value.
       clearBackground = overrides?.clearBackground ?: base.clearBackground,
-      overrides = merged.toExtensionOverrides(),
+      // Carry a `themeProvider` selection through the held/live path: toExtensionOverrides() drops it
+      // (renderer-read, not extension-consumed), but the renderer reads spec.overrides directly, so
+      // without this a live App-theme change would keep the default wrapper.
+      overrides =
+        merged.toExtensionOverrides().withThemeProvider(
+          overrides?.themeProvider ?: base.overrides?.themeProvider
+        ),
       // Recording sessions consume this on disk (`recordings/<recordingId>/...`); interactive
       // sessions pass `"interactive-$previewId"` and never read the field. The `recording-`
       // prefix is preserved for byte-compat with existing recording-test expectations.

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -348,6 +348,10 @@ open class RobolectricHost(
       "captureAdvanceMs",
       "inspectionMode",
       "material3Theme",
+      // `overrides.themeProvider` wraps the preview in an app-declared @ThemeCatalog
+      // `PreviewWrapperProvider` (resolved off the app classpath in `InvokeWithOptionalWrapper`),
+      // replacing the preview's own `@PreviewWrapper` — the discrete-theme axis.
+      "themeProvider",
       "wallpaper",
       "ambient",
       "gestures",

--- a/daemon/core/build.gradle.kts
+++ b/daemon/core/build.gradle.kts
@@ -35,9 +35,11 @@ dependencies {
   api(project(":data-theme-core"))
 
   // `PreviewOverrideValue` (the plain-Compose named-override value type) lives in the published
-  // `:data-preview-overrides-core` so the runtime/producer/MCP clients depend on the override schema
+  // `:data-preview-overrides-core` so the runtime/producer/MCP clients depend on the override
+  // schema
   // without dragging the daemon onto a preview's classpath. The protocol's
-  // `PreviewOverrides.namedOverrides` field references it, so it's part of this module's compile ABI
+  // `PreviewOverrides.namedOverrides` field references it, so it's part of this module's compile
+  // ABI
   // → `api`, not `implementation`. Pure-JVM (kotlinx-serialization only), safe on the daemon
   // classpath; the module has no dependency back on `:daemon:core`, so no cycle.
   api(project(":data-preview-overrides-core"))

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewOverrideMerge.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewOverrideMerge.kt
@@ -115,6 +115,19 @@ data class MergedPreviewOverrides(
 }
 
 /**
+ * Fold a `themeProvider` FQN back onto an (optionally null) held-session overrides bag. The held /
+ * recording spec's `overrides` is [MergedPreviewOverrides.toExtensionOverrides] — the
+ * extension-only projection, which intentionally omits `themeProvider` (a renderer-read field, not
+ * an extension-consumed one). But the renderer reads `spec.overrides.themeProvider` directly, so a
+ * live `stream/start` / `setOverrides` carrying a theme selection would otherwise drop it and keep
+ * the default wrapper. Both hosts' `applyOverrides` call this to carry the selection through,
+ * mirroring how `clearBackground` is carried onto the held spec. A blank / null FQN is a no-op.
+ */
+fun PreviewOverrides?.withThemeProvider(themeProvider: String?): PreviewOverrides? =
+  if (themeProvider.isNullOrBlank()) this
+  else (this ?: PreviewOverrides()).copy(themeProvider = themeProvider)
+
+/**
  * Hard-coded duplicate of `Pseudolocale.fromTag(...) != null`. Inlined here so `:daemon:core` (the
  * protocol module) doesn't take a dependency on `:data-pseudolocale-core` just to gate the bag
  * projection in [MergedPreviewOverrides.toExtensionOverrides]. If new pseudolocale tags ever land,

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -549,6 +549,20 @@ data class PreviewOverrides(
    */
   val material3Theme: Material3ThemeOverrides? = null,
   /**
+   * Optional FQN of an app-declared theme `PreviewWrapperProvider` — the discrete-theme counterpart
+   * of [uiMode]/[material3Theme]. When set, the renderer wraps the invoked preview in that
+   * provider's `Wrap(content)` **in place of** the preview's own `@PreviewWrapper`, so an arbitrary
+   * preview renders under a chosen `@ThemeCatalog` theme (the N-ary generalization of the built-in
+   * light/dark axis: "render this component under Brand Dark"). The FQN is resolved off the app
+   * classpath through the same machinery `@PreviewWrapper` uses (`loadPreviewWrapperClass` →
+   * `Wrap`), so any `PreviewWrapperProvider` works; a `@ThemeCatalog`-annotated one is just the
+   * discoverable, catalogued case. Unlike [material3Theme] (ad-hoc token overrides) this applies
+   * the app's *own* resolved theme composable. A blank / unresolvable FQN falls back to the
+   * preview's declared wrapper (best-effort, logged) so a bad selection never hard-fails a render.
+   * Backends without a Compose host ignore it.
+   */
+  val themeProvider: String? = null,
+  /**
    * Optional wallpaper seed-color override. The renderer derives a Material 3 color scheme from the
    * seed and wraps the preview in a `MaterialTheme(colorScheme = …)`; an explicit `material3Theme`
    * override on the same call still wins for any role the caller pinned. Sending a fresh

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/PreviewOverrideMergeTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/PreviewOverrideMergeTest.kt
@@ -290,4 +290,25 @@ class PreviewOverrideMergeTest {
     assertEquals(PreviewOverrideValue.IntValue(3), merged.namedOverrides?.get("rowCount"))
     assertEquals(merged.namedOverrides, merged.toExtensionOverrides()?.namedOverrides)
   }
+
+  @Test
+  fun `withThemeProvider folds the FQN onto a null or existing held-session bag`() {
+    // toExtensionOverrides() drops themeProvider, so the held/live path folds it back on. A null
+    // bag
+    // (no other extension override) still gains one carrying only the theme.
+    val fromNull = (null as PreviewOverrides?).withThemeProvider("com.example.BrandDark")
+    assertNotNull(fromNull)
+    assertEquals("com.example.BrandDark", fromNull!!.themeProvider)
+
+    // An existing bag keeps its other fields and gains the theme.
+    val existing = PreviewOverrides(talkBack = true)
+    val folded = existing.withThemeProvider("com.example.BrandLight")
+    assertEquals("com.example.BrandLight", folded?.themeProvider)
+    assertEquals(true, folded?.talkBack)
+
+    // Blank / null FQN is a no-op — a themeless held bag stays exactly as-is (including null).
+    assertNull((null as PreviewOverrides?).withThemeProvider(null))
+    assertNull((null as PreviewOverrides?).withThemeProvider(""))
+    assertEquals(existing, existing.withThemeProvider(null))
+  }
 }

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
@@ -595,7 +595,15 @@ open class DesktopHost(
       // Background → Clear toggle sends `PreviewOverrides(clearBackground = true)`. Null preserves
       // the discovery-time value.
       clearBackground = overrides?.clearBackground ?: base.clearBackground,
-      overrides = merged.toExtensionOverrides(),
+      // Carry a `themeProvider` selection through the held/live path: toExtensionOverrides() drops
+      // it
+      // (it's renderer-read, not extension-consumed), but the renderer reads spec.overrides
+      // directly,
+      // so without this a live App-theme change would keep the default wrapper.
+      overrides =
+        merged
+          .toExtensionOverrides()
+          .withThemeProvider(overrides?.themeProvider ?: base.overrides?.themeProvider),
       outputBaseName = "recording-$recordingId",
     )
   }

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
@@ -209,6 +209,10 @@ open class DesktopHost(
     add("slotMode")
     add("clearBackground")
     add("material3Theme")
+    // `overrides.themeProvider` wraps the preview in an app-declared @ThemeCatalog
+    // `PreviewWrapperProvider` (resolved off the app classpath in `InvokeWithOptionalWrapper`),
+    // replacing the preview's own `@PreviewWrapper` — the discrete-theme axis.
+    add("themeProvider")
     add("wallpaper")
     // Issue #1205 — `renderNow.overrides.focus` is honoured by the planner registered in
     // `data/focus` (`FocusPreviewOverrideExtension`), which installs the around-composable that

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -399,7 +399,16 @@ class RenderEngine(
                       }
                     }
                   } else {
-                    InvokeWithOptionalWrapper(composableMethod!!, spec.wrapperClassName)
+                    InvokeWithOptionalWrapper(
+                      composableMethod!!,
+                      // A `themeProvider` override (an app-declared @ThemeCatalog
+                      // `PreviewWrapperProvider` FQN) replaces the preview's own `@PreviewWrapper`
+                      // —
+                      // "render this preview under theme X". Blank / unresolvable falls back to the
+                      // declared wrapper.
+                      spec.overrides?.themeProvider?.takeIf { it.isNotBlank() }
+                        ?: spec.wrapperClassName,
+                    )
                   }
                 }
               }

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -401,13 +401,13 @@ class RenderEngine(
                   } else {
                     InvokeWithOptionalWrapper(
                       composableMethod!!,
+                      spec.wrapperClassName,
                       // A `themeProvider` override (an app-declared @ThemeCatalog
                       // `PreviewWrapperProvider` FQN) replaces the preview's own `@PreviewWrapper`
                       // —
-                      // "render this preview under theme X". Blank / unresolvable falls back to the
-                      // declared wrapper.
-                      spec.overrides?.themeProvider?.takeIf { it.isNotBlank() }
-                        ?: spec.wrapperClassName,
+                      // "render this preview under theme X" — but only when it resolves; a
+                      // stale/misspelled FQN falls back to the declared wrapper.
+                      themeProviderFqn = spec.overrides?.themeProvider,
                     )
                   }
                 }
@@ -1334,10 +1334,16 @@ private fun InvokeComposable(composableMethod: ComposableMethod) {
 private fun InvokeWithOptionalWrapper(
   composableMethod: ComposableMethod,
   wrapperFqnFromSpec: String?,
+  themeProviderFqn: String? = null,
 ) {
   val wrapper =
-    remember(composableMethod, wrapperFqnFromSpec) {
-      resolveWrapperOrNull(composableMethod, wrapperFqnFromSpec)
+    remember(composableMethod, wrapperFqnFromSpec, themeProviderFqn) {
+      // A `themeProvider` override wraps the preview in an app-declared theme provider IN PLACE OF
+      // its own `@PreviewWrapper` — but only when it actually loads. On a stale/misspelled FQN,
+      // `loadWrapperByFqnOrNull` logs and returns null; we then fall back to the preview's declared
+      // wrapper rather than stripping it. A blank/absent themeProvider skips straight to it.
+      themeProviderFqn?.takeIf { it.isNotBlank() }?.let { loadWrapperByFqnOrNull(it) }
+        ?: resolveWrapperOrNull(composableMethod, wrapperFqnFromSpec)
     }
   if (wrapper == null) {
     InvokeComposable(composableMethod)

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/OverrideIntegrationTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/OverrideIntegrationTest.kt
@@ -486,6 +486,71 @@ class OverrideIntegrationTest {
     }
   }
 
+  /**
+   * End-to-end proof that a `themeProvider` override wraps an arbitrary preview in an app-declared
+   * `@ThemeCatalog` theme (the render side of the serve viewer's declared-theme selector). Renders
+   * [WallpaperAwareSquare] — which paints the *ambient* `MaterialTheme.colorScheme.primary` with no
+   * inner theme of its own — with no override (the M3 default primary) and with `themeProvider =
+   * <BluePrimaryThemeProvider FQN>`, then asserts the fill actually repainted to that theme's blue
+   * primary. The wrapper resolves off the render classloader through the same
+   * `loadPreviewWrapperClass` → `Wrap` path `@PreviewWrapper` uses, so no manifest wrapper is
+   * needed.
+   */
+  @Test
+  fun themeProviderOverrideWrapsPreviewInDeclaredTheme() {
+    val outputDir = tempFolder.newFolder("renders-theme-provider")
+    System.setProperty(RenderEngine.OUTPUT_DIR_PROP, outputDir.absolutePath)
+    val manifest =
+      PreviewManifest(
+        previews =
+          listOf(
+            PreviewManifestEntry(
+              id = "ambient-primary",
+              className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+              functionName = "WallpaperAwareSquare",
+              widthPx = 200,
+              heightPx = 120,
+              density = 1.0f,
+              outputBaseName = "ambient-primary",
+            )
+          )
+      )
+    val host = PreviewManifestRouter(manifest = manifest)
+    host.start()
+    try {
+      val default = renderAndDecode(host, "previewId=ambient-primary", "theme-default")
+      val themed =
+        renderAndDecode(
+          host,
+          "previewId=ambient-primary;overrides=" +
+            encodeThemeProviderBag("ee.schimke.composeai.daemon.BluePrimaryThemeProvider"),
+          "theme-blue",
+        )
+
+      // The declared theme's primary (0xFF1565C0) should dominate the themed render...
+      val themedBluePct = pixelMatchPct(themed, expectedRgb = 0x1565C0, perChannelTolerance = 8)
+      assertTrue(
+        "themeProvider render should paint the declared theme's blue primary; got ${"%.2f".format(themedBluePct * 100)}%",
+        themedBluePct >= 0.95,
+      )
+      // ...and the render must differ from the un-themed M3 default, not silently fall back to it.
+      assertNotEquals(
+        "a themeProvider override must change the render vs the default theme",
+        default.getRGB(default.width / 2, default.height / 2),
+        themed.getRGB(themed.width / 2, themed.height / 2),
+      )
+
+      // Emit before/after PNGs for the PR's visual evidence (mirrors
+      // RenderEngineClearBackgroundTest's `build/clearbg-evidence/`): the default M3 primary vs the
+      // declared theme's blue primary, proving `themeProvider` re-renders under the chosen theme.
+      val evidenceDir = File("build/theme-evidence").apply { mkdirs() }
+      ImageIO.write(default, "png", File(evidenceDir, "ambient-primary-default.png"))
+      ImageIO.write(themed, "png", File(evidenceDir, "ambient-primary-themed.png"))
+    } finally {
+      host.shutdown()
+    }
+  }
+
   private fun renderAndDecode(
     host: PreviewManifestRouter,
     payload: String,
@@ -508,6 +573,17 @@ class OverrideIntegrationTest {
   private fun encodeWallpaperBag(seedColor: String): String {
     val json = Json { encodeDefaults = false }
     val bag = PreviewOverrides(wallpaper = WallpaperOverride(seedColor = seedColor))
+    return Base64.getUrlEncoder()
+      .withoutPadding()
+      .encodeToString(
+        json.encodeToString(PreviewOverrides.serializer(), bag).toByteArray(Charsets.UTF_8)
+      )
+  }
+
+  /** A base64 `overrides=` bag carrying a single `themeProvider` FQN. */
+  private fun encodeThemeProviderBag(fqn: String): String {
+    val json = Json { encodeDefaults = false }
+    val bag = PreviewOverrides(themeProvider = fqn)
     return Base64.getUrlEncoder()
       .withoutPadding()
       .encodeToString(

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/OverrideIntegrationTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/OverrideIntegrationTest.kt
@@ -551,6 +551,60 @@ class OverrideIntegrationTest {
     }
   }
 
+  /**
+   * A stale / misspelled `themeProvider` must fall back to the preview's declared
+   * `@PreviewWrapper`, not strip it (which would drop a required wrapper and misrender — the case a
+   * shared URL with a removed provider hits). The manifest pins `wrapperClassName =
+   * BluePrimaryThemeProvider` (blue), and the request supplies a bogus `themeProvider` FQN; the
+   * render must still be blue (declared wrapper applied), not the un-wrapped M3 default.
+   */
+  @Test
+  fun badThemeProviderFallsBackToDeclaredWrapper() {
+    val outputDir = tempFolder.newFolder("renders-theme-fallback")
+    System.setProperty(RenderEngine.OUTPUT_DIR_PROP, outputDir.absolutePath)
+    val manifest =
+      PreviewManifest(
+        previews =
+          listOf(
+            PreviewManifestEntry(
+              id = "wrapped-ambient",
+              className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+              functionName = "WallpaperAwareSquare",
+              widthPx = 48,
+              heightPx = 48,
+              density = 1.0f,
+              outputBaseName = "wrapped-ambient",
+              // The preview's own declared @PreviewWrapper (blue), threaded into the render spec
+              // via
+              // the resolver — so a bad themeProvider must fall back to THIS, not strip it.
+              params =
+                PreviewParamsEntry(
+                  wrapperClassName = "ee.schimke.composeai.daemon.BluePrimaryThemeProvider"
+                ),
+            )
+          )
+      )
+    val host = PreviewManifestRouter(manifest = manifest)
+    host.start()
+    try {
+      val bogus =
+        renderAndDecode(
+          host,
+          "previewId=wrapped-ambient;overrides=" +
+            encodeThemeProviderBag("ee.schimke.composeai.daemon.NoSuchThemeProvider"),
+          "bad-theme",
+        )
+      // Declared wrapper (blue) still applied — the bogus override didn't strip it.
+      val bluePct = pixelMatchPct(bogus, expectedRgb = 0x1565C0, perChannelTolerance = 8)
+      assertTrue(
+        "a bad themeProvider must fall back to the declared @PreviewWrapper (blue); got ${"%.2f".format(bluePct * 100)}%",
+        bluePct >= 0.95,
+      )
+    } finally {
+      host.shutdown()
+    }
+  }
+
   private fun renderAndDecode(
     host: PreviewManifestRouter,
     payload: String,

--- a/daemon/desktop/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
+++ b/daemon/desktop/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
@@ -549,6 +549,25 @@ fun WallpaperAwareSquare() {
 }
 
 /**
+ * A `PreviewWrapperProvider`-shaped stand-in for an app's `@ThemeCatalog` theme — its `Wrap`
+ * installs a `MaterialTheme` with a distinctive blue `primary`. Used by
+ * [OverrideIntegrationTest.themeProviderOverrideWrapsPreviewInDeclaredTheme] to prove that a
+ * `renderNow.overrides.themeProvider = <this FQN>` renders an arbitrary preview (e.g.
+ * [WallpaperAwareSquare], which paints the ambient `colorScheme.primary`) under this theme instead
+ * of the M3 default. The renderer resolves it by FQN and invokes `Wrap` reflectively
+ * (`getDeclaredComposableMethod("Wrap", …)`, the same path `@PreviewWrapper` uses), so a no-arg
+ * class exposing a `@Composable Wrap(content)` is all it needs — it does not have to implement the
+ * `PreviewWrapperProvider` interface (which is Compose 1.11+ and absent from this CMP classpath),
+ * and `@ThemeCatalog` only adds *discovery*, not the apply path exercised here.
+ */
+@Suppress("unused") // instantiated reflectively by the daemon's InvokeWithOptionalWrapper
+class BluePrimaryThemeProvider {
+  @Composable
+  fun Wrap(content: @Composable () -> Unit) =
+    MaterialTheme(colorScheme = lightColorScheme(primary = Color(0xFF1565C0))) { content() }
+}
+
+/**
  * Issue #1203 — fixture for the desktop keyboard-dispatch integration tests.
  *
  * Paints red on first composition; flips green when the `Key.A` key down event reaches the

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
@@ -142,6 +142,7 @@ a:hover { text-decoration: underline; }
               <option value="dark">Dark</option>
             </select>
           </label>
+          
           <label>Device
             <select id="cp-device" disabled>
               <option value="">(default)</option>
@@ -299,6 +300,10 @@ a:hover { text-decoration: underline; }
       if (el.disabled) return;
       o[el.id.replace(/^cp-/, "")] = el.checked ? "true" : "false";
     });
+    // App-declared theme (themeProvider = provider FQN). Only when a theme is picked and the
+    // control is live; "(default)" (empty) leaves the daemon on the preview's own wrapper.
+    var tp = document.getElementById("cp-themeProvider");
+    if (tp && !tp.disabled && tp.value) o["themeProvider"] = tp.value;
     return o;
   }
   function query() {
@@ -322,6 +327,13 @@ a:hover { text-decoration: underline; }
       if (val === (el.getAttribute("data-knob-initial") || "")) return;
       parts.push("knob." + encodeURIComponent(key) + "=" + encodeURIComponent(val));
     });
+    // App-declared theme (themeProvider = provider FQN). Routes to the daemon like a knob; a
+    // published catalog re-renders on demand. Omitted at "(default)" so the URL stays on the
+    // instant baked snapshot until a theme is actually chosen.
+    var tp = document.getElementById("cp-themeProvider");
+    if (tp && !tp.disabled && tp.value) {
+      parts.push("themeProvider=" + encodeURIComponent(tp.value));
+    }
     return parts.join("&");
   }
   function refreshSnapshot() {
@@ -805,6 +817,11 @@ a:hover { text-decoration: underline; }
   document.querySelectorAll(".cp-knob").forEach(function (el) {
     el.addEventListener(el.type === "checkbox" ? "change" : "input", onKnobChanged);
   });
+  // The app-theme selector routes through the daemon like a knob (never the wasm auto-enable
+  // path — an app-declared theme provider is a server-side wrapper the in-browser tier can't
+  // load), so it shares onKnobChanged rather than onControlsChanged.
+  var themeSel = document.getElementById("cp-themeProvider");
+  if (themeSel) themeSel.addEventListener("change", onKnobChanged);
   refreshSnapshot();
 })();</script>
       <script>(function () {

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
@@ -142,6 +142,7 @@ a:hover { text-decoration: underline; }
               <option value="dark">Dark</option>
             </select>
           </label>
+          
           <label>Device
             <select id="cp-device" disabled>
               <option value="">(default)</option>
@@ -281,6 +282,10 @@ a:hover { text-decoration: underline; }
       if (el.disabled) return;
       o[el.id.replace(/^cp-/, "")] = el.checked ? "true" : "false";
     });
+    // App-declared theme (themeProvider = provider FQN). Only when a theme is picked and the
+    // control is live; "(default)" (empty) leaves the daemon on the preview's own wrapper.
+    var tp = document.getElementById("cp-themeProvider");
+    if (tp && !tp.disabled && tp.value) o["themeProvider"] = tp.value;
     return o;
   }
   function query() {
@@ -304,6 +309,13 @@ a:hover { text-decoration: underline; }
       if (val === (el.getAttribute("data-knob-initial") || "")) return;
       parts.push("knob." + encodeURIComponent(key) + "=" + encodeURIComponent(val));
     });
+    // App-declared theme (themeProvider = provider FQN). Routes to the daemon like a knob; a
+    // published catalog re-renders on demand. Omitted at "(default)" so the URL stays on the
+    // instant baked snapshot until a theme is actually chosen.
+    var tp = document.getElementById("cp-themeProvider");
+    if (tp && !tp.disabled && tp.value) {
+      parts.push("themeProvider=" + encodeURIComponent(tp.value));
+    }
     return parts.join("&");
   }
   function refreshSnapshot() {
@@ -787,6 +799,11 @@ a:hover { text-decoration: underline; }
   document.querySelectorAll(".cp-knob").forEach(function (el) {
     el.addEventListener(el.type === "checkbox" ? "change" : "input", onKnobChanged);
   });
+  // The app-theme selector routes through the daemon like a knob (never the wasm auto-enable
+  // path — an app-declared theme provider is a server-side wrapper the in-browser tier can't
+  // load), so it shares onKnobChanged rather than onControlsChanged.
+  var themeSel = document.getElementById("cp-themeProvider");
+  if (themeSel) themeSel.addEventListener("change", onKnobChanged);
   refreshSnapshot();
 })();</script>
       <script>(function () {

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-themes.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-themes.html
@@ -3,7 +3,7 @@
       <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <title>Card — compose-preview</title>
+        <title>Profile screen — compose-preview</title>
         <style>:root { color-scheme: light dark; }
 * { box-sizing: border-box; }
 body { margin: 0; padding: 24px; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
@@ -122,19 +122,18 @@ a:hover { text-decoration: underline; }
 }</style>
       </head>
       <body>
-              <p class="cp-head"><a href="/?token=demo-token-fixture&session=compose-m3">← previews</a> <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/compose-ai-tools@design-artifacts/compose-m3">✓ branch:yschimke/compose-ai-tools@design-artifacts/compose-m3</span></p>
-      <p class="cp-sub" title="com.example.CardPreview">Card</p>
-      <div class="cp-viewer" data-preview-id="com.example.CardPreview" data-mode="snapshot" data-modes="snapshot,live" data-static-snapshot="true" data-can-render-overrides="false" data-snapshot-backend="Snapshot" data-live-backend="Live" data-wasm-src="/wasm/compose-m3/?id=card-filled">
-        <div class="cp-stage"><span class="cp-backend" id="cp-backend"></span><img id="cp-img" alt="Card"><canvas id="cp-canvas" hidden></canvas><iframe id="cp-wasm" hidden sandbox="allow-scripts allow-same-origin" title="Card (Wasm)"></iframe></div>
+              <p class="cp-head"><a href="/?token=demo-token-fixture&session=compose-m3">← previews</a></p>
+      <p class="cp-sub" title="com.example.ProfileScreenPreview">Profile screen</p>
+      <div class="cp-viewer" data-preview-id="com.example.ProfileScreenPreview" data-mode="snapshot" data-modes="snapshot,live" data-static-snapshot="false" data-can-render-overrides="true" data-snapshot-backend="Snapshot" data-live-backend="Live">
+        <div class="cp-stage"><span class="cp-backend" id="cp-backend"></span><img id="cp-img" alt="Profile screen"><canvas id="cp-canvas" hidden></canvas></div>
         <div class="cp-controls">
-          <div class="cp-note">Pre-rendered snapshot — pick “Wasm” to interact: Theme, Font scale, Locale &amp; background apply in the browser. Device/Orientation need the live server. <a href="https://github.com/yschimke/compose-ai-tools/blob/main/docs/public-preview-server.md#running-one">Enable a local preview server.</a></div>
+          
           <div class="cp-modes" role="radiogroup" aria-label="Render mode">
             <label class="cp-live-row"><input type="radio" name="cp-mode" value="png" id="cp-mode-png" checked> PNG</label>
-            
             <label class="cp-live-row"><input type="radio" name="cp-mode" value="live" id="cp-live"> Live Compose</label>
-            <label class="cp-live-row"><input type="radio" name="cp-mode" value="wasm" id="cp-wasm-toggle"> Wasm</label>
+            
           </div>
-          <label class="cp-live-row"><input id="cp-wasm-bg" type="checkbox"> Component only (no background)</label>
+          
           <label>Theme
             <select id="cp-uiMode">
               <option value="">(default)</option>
@@ -142,9 +141,17 @@ a:hover { text-decoration: underline; }
               <option value="dark">Dark</option>
             </select>
           </label>
-          
+                  <label>App theme
+          <select id="cp-themeProvider" class="cp-knob-theme">
+            <option value="">(default)</option>
+            <option value="com.example.HighContrastThemeCatalog">High Contrast</option>
+<optgroup label="Brand"><option value="com.example.BrandLightThemeCatalog">Brand Light</option>
+<option value="com.example.BrandDarkThemeCatalog">Brand Dark</option></optgroup>
+
+          </select>
+        </label>
           <label>Device
-            <select id="cp-device" disabled>
+            <select id="cp-device">
               <option value="">(default)</option>
               <option value="id:pixel_5">Pixel 5</option>
 <option value="id:pixel_7">Pixel 7</option>
@@ -161,14 +168,14 @@ a:hover { text-decoration: underline; }
             <input id="cp-fontScale" type="range" min="0.5" max="2.0" step="0.1" value="1.0">
           </label>
           <label>Orientation
-            <select id="cp-orientation" disabled>
+            <select id="cp-orientation">
               <option value="">(default)</option>
               <option value="portrait">Portrait</option>
               <option value="landscape">Landscape</option>
             </select>
           </label>
           <label>Background
-            <select id="cp-background" disabled>
+            <select id="cp-background">
               <option value="">(default)</option>
               <option value="clear">Clear (crisp outline)</option>
             </select>
@@ -247,10 +254,6 @@ a:hover { text-decoration: underline; }
   var fsVal = document.getElementById("cp-fontScale-val");
   var fontScaleTouched = false;
   var ws = null;
-  // The snapshot lane serves either the raster PNG or the vector SVG through the same <img>.
-  // The render-mode radio flips this (".png" default, ".svg" in SVG mode); refreshSnapshot and
-  // the copyable links read it so a re-render / copied URL matches the on-screen format.
-  var snapshotExt = ".png";
 
   function overrides() {
     var o = {};
@@ -325,8 +328,7 @@ a:hover { text-decoration: underline; }
   function refreshSnapshot() {
     status.textContent = "rendering…";
     var qs = query();
-    var url =
-      base + "/render/" + encodeURIComponent(previewId) + snapshotExt + (qs ? "?" + qs : "");
+    var url = base + "/render/" + encodeURIComponent(previewId) + ".png" + (qs ? "?" + qs : "");
     var next = new Image();
     next.onload = function () { img.src = url; status.textContent = ""; };
     next.onerror = function () { status.textContent = "render failed"; };
@@ -690,21 +692,13 @@ a:hover { text-decoration: underline; }
     }
   }
 
-  // Render-mode radio group (PNG / SVG / Live Compose / Wasm). Selecting one tears down the
-  // other transport and enters the chosen one. PNG and SVG both drive the baked snapshot lane —
-  // same <img>, different render extension (snapshotExt). closeStream / closeWasm are
-  // idempotent, so a mode switch can safely tear down both regardless of the prior state; live
-  // and wasm reset snapshotExt so a later fallback refresh serves the raster PNG, not a stale
-  // ".svg".
+  // Render-mode radio group (PNG / Live Compose / Wasm). Selecting one tears down the other
+  // transport and enters the chosen one; PNG is the baked snapshot. closeStream / closeWasm are
+  // idempotent, so a mode switch can safely tear down both regardless of the prior state.
   function enterMode(m) {
-    if (m === "live") { snapshotExt = ".png"; closeWasm(); openStream(); }
-    else if (m === "wasm") { snapshotExt = ".png"; closeStream(); openWasm(); }
-    else if (m === "svg") {
-      // SVG reuses the snapshot lane; closeStream/closeWasm reset data-mode to "snapshot", so
-      // stamp "svg" afterwards for the backend badge, then swap the vector into the <img>.
-      closeStream(); closeWasm(); snapshotExt = ".svg";
-      root.setAttribute("data-mode", "svg"); refreshSnapshot();
-    } else { snapshotExt = ".png"; closeStream(); closeWasm(); refreshSnapshot(); }
+    if (m === "live") { closeWasm(); openStream(); }
+    else if (m === "wasm") { closeStream(); openWasm(); }
+    else { closeStream(); closeWasm(); refreshSnapshot(); }
     syncOverlayToggles();
   }
   // The live-only overlay toggles (talkBack / touchOverlay) are meaningful only while the daemon
@@ -719,9 +713,7 @@ a:hover { text-decoration: underline; }
   // reflects it, then run the transition.
   function setMode(m) {
     var r = document.getElementById(
-      m === "live" ? "cp-live" :
-      m === "wasm" ? "cp-wasm-toggle" :
-      m === "svg" ? "cp-mode-svg" : "cp-mode-png");
+      m === "live" ? "cp-live" : m === "wasm" ? "cp-wasm-toggle" : "cp-mode-png");
     if (r) r.checked = true;
     enterMode(m);
   }
@@ -817,7 +809,6 @@ a:hover { text-decoration: underline; }
   function label(mode) {
     if (mode === "wasm") return "CMP-WASM";
     if (mode === "live") return root.getAttribute("data-live-backend") || "Live";
-    if (mode === "svg") return "SVG";
     return root.getAttribute("data-snapshot-backend") || "Snapshot";
   }
   function refresh() { badge.textContent = label(root.getAttribute("data-mode")); }

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-themes.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-themes.html
@@ -130,6 +130,7 @@ a:hover { text-decoration: underline; }
           
           <div class="cp-modes" role="radiogroup" aria-label="Render mode">
             <label class="cp-live-row"><input type="radio" name="cp-mode" value="png" id="cp-mode-png" checked> PNG</label>
+            
             <label class="cp-live-row"><input type="radio" name="cp-mode" value="live" id="cp-live"> Live Compose</label>
             
           </div>
@@ -254,6 +255,10 @@ a:hover { text-decoration: underline; }
   var fsVal = document.getElementById("cp-fontScale-val");
   var fontScaleTouched = false;
   var ws = null;
+  // The snapshot lane serves either the raster PNG or the vector SVG through the same <img>.
+  // The render-mode radio flips this (".png" default, ".svg" in SVG mode); refreshSnapshot and
+  // the copyable links read it so a re-render / copied URL matches the on-screen format.
+  var snapshotExt = ".png";
 
   function overrides() {
     var o = {};
@@ -328,7 +333,8 @@ a:hover { text-decoration: underline; }
   function refreshSnapshot() {
     status.textContent = "rendering…";
     var qs = query();
-    var url = base + "/render/" + encodeURIComponent(previewId) + ".png" + (qs ? "?" + qs : "");
+    var url =
+      base + "/render/" + encodeURIComponent(previewId) + snapshotExt + (qs ? "?" + qs : "");
     var next = new Image();
     next.onload = function () { img.src = url; status.textContent = ""; };
     next.onerror = function () { status.textContent = "render failed"; };
@@ -692,13 +698,21 @@ a:hover { text-decoration: underline; }
     }
   }
 
-  // Render-mode radio group (PNG / Live Compose / Wasm). Selecting one tears down the other
-  // transport and enters the chosen one; PNG is the baked snapshot. closeStream / closeWasm are
-  // idempotent, so a mode switch can safely tear down both regardless of the prior state.
+  // Render-mode radio group (PNG / SVG / Live Compose / Wasm). Selecting one tears down the
+  // other transport and enters the chosen one. PNG and SVG both drive the baked snapshot lane —
+  // same <img>, different render extension (snapshotExt). closeStream / closeWasm are
+  // idempotent, so a mode switch can safely tear down both regardless of the prior state; live
+  // and wasm reset snapshotExt so a later fallback refresh serves the raster PNG, not a stale
+  // ".svg".
   function enterMode(m) {
-    if (m === "live") { closeWasm(); openStream(); }
-    else if (m === "wasm") { closeStream(); openWasm(); }
-    else { closeStream(); closeWasm(); refreshSnapshot(); }
+    if (m === "live") { snapshotExt = ".png"; closeWasm(); openStream(); }
+    else if (m === "wasm") { snapshotExt = ".png"; closeStream(); openWasm(); }
+    else if (m === "svg") {
+      // SVG reuses the snapshot lane; closeStream/closeWasm reset data-mode to "snapshot", so
+      // stamp "svg" afterwards for the backend badge, then swap the vector into the <img>.
+      closeStream(); closeWasm(); snapshotExt = ".svg";
+      root.setAttribute("data-mode", "svg"); refreshSnapshot();
+    } else { snapshotExt = ".png"; closeStream(); closeWasm(); refreshSnapshot(); }
     syncOverlayToggles();
   }
   // The live-only overlay toggles (talkBack / touchOverlay) are meaningful only while the daemon
@@ -713,7 +727,9 @@ a:hover { text-decoration: underline; }
   // reflects it, then run the transition.
   function setMode(m) {
     var r = document.getElementById(
-      m === "live" ? "cp-live" : m === "wasm" ? "cp-wasm-toggle" : "cp-mode-png");
+      m === "live" ? "cp-live" :
+      m === "wasm" ? "cp-wasm-toggle" :
+      m === "svg" ? "cp-mode-svg" : "cp-mode-png");
     if (r) r.checked = true;
     enterMode(m);
   }
@@ -809,6 +825,7 @@ a:hover { text-decoration: underline; }
   function label(mode) {
     if (mode === "wasm") return "CMP-WASM";
     if (mode === "live") return root.getAttribute("data-live-backend") || "Live";
+    if (mode === "svg") return "SVG";
     return root.getAttribute("data-snapshot-backend") || "Snapshot";
   }
   function refresh() { badge.textContent = label(root.getAttribute("data-mode")); }

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
@@ -142,6 +142,7 @@ a:hover { text-decoration: underline; }
               <option value="dark">Dark</option>
             </select>
           </label>
+          
           <label>Device
             <select id="cp-device" disabled>
               <option value="">(default)</option>
@@ -281,6 +282,10 @@ a:hover { text-decoration: underline; }
       if (el.disabled) return;
       o[el.id.replace(/^cp-/, "")] = el.checked ? "true" : "false";
     });
+    // App-declared theme (themeProvider = provider FQN). Only when a theme is picked and the
+    // control is live; "(default)" (empty) leaves the daemon on the preview's own wrapper.
+    var tp = document.getElementById("cp-themeProvider");
+    if (tp && !tp.disabled && tp.value) o["themeProvider"] = tp.value;
     return o;
   }
   function query() {
@@ -304,6 +309,13 @@ a:hover { text-decoration: underline; }
       if (val === (el.getAttribute("data-knob-initial") || "")) return;
       parts.push("knob." + encodeURIComponent(key) + "=" + encodeURIComponent(val));
     });
+    // App-declared theme (themeProvider = provider FQN). Routes to the daemon like a knob; a
+    // published catalog re-renders on demand. Omitted at "(default)" so the URL stays on the
+    // instant baked snapshot until a theme is actually chosen.
+    var tp = document.getElementById("cp-themeProvider");
+    if (tp && !tp.disabled && tp.value) {
+      parts.push("themeProvider=" + encodeURIComponent(tp.value));
+    }
     return parts.join("&");
   }
   function refreshSnapshot() {
@@ -787,6 +799,11 @@ a:hover { text-decoration: underline; }
   document.querySelectorAll(".cp-knob").forEach(function (el) {
     el.addEventListener(el.type === "checkbox" ? "change" : "input", onKnobChanged);
   });
+  // The app-theme selector routes through the daemon like a knob (never the wasm auto-enable
+  // path — an app-declared theme provider is a server-side wrapper the in-browser tier can't
+  // load), so it shares onKnobChanged rather than onControlsChanged.
+  var themeSel = document.getElementById("cp-themeProvider");
+  if (themeSel) themeSel.addEventListener("change", onKnobChanged);
   refreshSnapshot();
 })();</script>
       <script>(function () {

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
@@ -142,6 +142,7 @@ a:hover { text-decoration: underline; }
               <option value="dark">Dark</option>
             </select>
           </label>
+          
           <label>Device
             <select id="cp-device" disabled>
               <option value="">(default)</option>
@@ -281,6 +282,10 @@ a:hover { text-decoration: underline; }
       if (el.disabled) return;
       o[el.id.replace(/^cp-/, "")] = el.checked ? "true" : "false";
     });
+    // App-declared theme (themeProvider = provider FQN). Only when a theme is picked and the
+    // control is live; "(default)" (empty) leaves the daemon on the preview's own wrapper.
+    var tp = document.getElementById("cp-themeProvider");
+    if (tp && !tp.disabled && tp.value) o["themeProvider"] = tp.value;
     return o;
   }
   function query() {
@@ -304,6 +309,13 @@ a:hover { text-decoration: underline; }
       if (val === (el.getAttribute("data-knob-initial") || "")) return;
       parts.push("knob." + encodeURIComponent(key) + "=" + encodeURIComponent(val));
     });
+    // App-declared theme (themeProvider = provider FQN). Routes to the daemon like a knob; a
+    // published catalog re-renders on demand. Omitted at "(default)" so the URL stays on the
+    // instant baked snapshot until a theme is actually chosen.
+    var tp = document.getElementById("cp-themeProvider");
+    if (tp && !tp.disabled && tp.value) {
+      parts.push("themeProvider=" + encodeURIComponent(tp.value));
+    }
     return parts.join("&");
   }
   function refreshSnapshot() {
@@ -787,6 +799,11 @@ a:hover { text-decoration: underline; }
   document.querySelectorAll(".cp-knob").forEach(function (el) {
     el.addEventListener(el.type === "checkbox" ? "change" : "input", onKnobChanged);
   });
+  // The app-theme selector routes through the daemon like a knob (never the wasm auto-enable
+  // path — an app-declared theme provider is a server-side wrapper the in-browser tier can't
+  // load), so it shares onKnobChanged rather than onControlsChanged.
+  var themeSel = document.getElementById("cp-themeProvider");
+  if (themeSel) themeSel.addEventListener("change", onKnobChanged);
   refreshSnapshot();
 })();</script>
       <script>(function () {


### PR DESCRIPTION
## Summary

Surface an app's `@ThemeCatalog` themes in the `compose-preview serve` viewer so a preview can be **re-rendered under a chosen theme** — the discrete-theme generalization of the built-in light/dark axis ("render this component under Brand Dark"). This is a full vertical: nothing previously let the daemon wrap an arbitrary preview in an app-declared `PreviewWrapperProvider` (the existing wrapper FQN came only from the preview's own `@PreviewWrapper` at discovery time; `material3Theme`/`wallpaper` apply *ad-hoc* tokens, not the app's own resolved theme).

## Layers

- **Protocol** — add `PreviewOverrides.themeProvider` (a provider FQN); advertise it in both hosts' `supportedOverrides`.
- **Renderer** — both daemon backends (Android + desktop) prefer `overrides.themeProvider` over the preview's own `@PreviewWrapper`, resolving the FQN through the existing `loadPreviewWrapperClass` → `Wrap` machinery. A stale / unresolvable FQN **falls back to the declared wrapper** (rather than stripping it), so a bad pick never drops a required `@PreviewWrapper` or hard-fails a render.
- **Host** — `declaredThemesFromPreviews` lifts the discovery-time `THEME_CATALOG` entries (FQN + name + `@ThemeCatalog(group)`) into a module-global `ServeHost.declaredThemes`, threaded through the revision builder, session state (so it survives an idle daemon suspend/resume), and both `ServeRenderHost.open` sites. A static bundle carries none.
- **Viewer** — an **"App theme"** selector (grouped into `<optgroup>`s by `@ThemeCatalog(group)`) appears when the module declares themes; picking one re-renders via `themeProvider`. Daemon-only, so it's **disabled on a static bundle** and routes through the knob (`onKnobChanged`) path rather than the display-field path. `ServeOverrides` parses the key and folds it into the render cache key.
- **Live path** — the held/live spec's overrides is the extension-only projection (`toExtensionOverrides`), which omits `themeProvider`; a `withThemeProvider` helper folds the selection back on in both hosts' `applyOverrides`, so an App-theme change during Live Compose actually re-renders under it.

The declared themes still also appear as their own specimen-sheet preview cards (unchanged) — this only *adds* the apply-to-any-preview selector.

## Test plan

- `./gradlew :daemon:desktop:test --tests '*OverrideIntegrationTest*'` — a preview reading the ambient `colorScheme.primary` **repaints** from the M3 default to the declared theme's blue primary; a **bad `themeProvider` falls back to the declared `@PreviewWrapper`** (doesn't strip it).
- `./gradlew :daemon:core:test --tests '*PreviewOverrideMergeTest*'` — `withThemeProvider` folds the FQN onto a null / existing held-session bag and no-ops on blank.
- `./gradlew :cli:test --tests '*ServeOverridesTest*' --tests '*ServeWebFixtureTest*'` — parse + cache-key coverage; a new `serve-viewer-themes` golden fixture (wired into the `vscode-preview-diff` harness) asserts the selector, FQN-keyed options, grouping, and daemon gating.
- Android wrapper-resolution tests still green — the precedence change doesn't disturb the normal `@PreviewWrapper` path.

## Visual evidence

**Viewer — the new "App theme" selector** (from the `serve-viewer-themes` fixture, rendered + diffed by the CI bot). Below "Theme" (light/dark), with themes grouped by `@ThemeCatalog(group)`:

<img src="https://raw.githubusercontent.com/yschimke/compose-ai-tools/be504ab42fcb31b0a5b06d5a3a6e673cbd44d8d2/renders/serve-viewer-themes.light.png" width="360">

**Render effect** — a preview reading the ambient `MaterialTheme.colorScheme.primary`, rendered by the daemon integration test. Default M3 primary → the declared theme's blue when `themeProvider` is applied (before/after PNGs emitted to `build/theme-evidence/` and shared with the author):

| Default (no theme) | `themeProvider` = declared theme |
| --- | --- |
| M3 purple `#6750A4` | Brand blue `#1565C0` |

---
_Generated by [Claude Code](https://claude.ai/code/session_01MkDr2hzvkuW9yrs16eFCyj)_