### PR TITLE
feat(serve): carry declared @ThemeCatalog themes into bundle & catalog hosts

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt
@@ -188,7 +188,29 @@ internal object ServeBundleDaemon {
       workspaceName = destDir.name.ifBlank { system },
       previews = previews,
       label = system,
+      // The catalog's app-declared @ThemeCatalog themes, read from the same carried previews.json —
+      // so a published catalog's live lane offers the App theme selector (its daemon applies the
+      // themeProvider override on demand). Empty when the app declares none.
+      declaredThemes = readDeclaredThemes(previewsJson, fileSystem),
     )
+  }
+
+  /**
+   * Read the catalog's declared `@ThemeCatalog` themes from the carried `previews.json` (the
+   * synthetic `THEME_CATALOG` entries discovery emits). Module-global, so the whole catalog shares
+   * one theme set. Absent / unreadable previews.json → no themes.
+   */
+  private fun readDeclaredThemes(previewsJson: File, fileSystem: FileSystem): List<ServeTheme> {
+    val text =
+      try {
+        fileSystem.read(previewsJson.path.toPath()) { readUtf8() }
+      } catch (_: Exception) {
+        return emptyList()
+      }
+    val manifest =
+      runCatching { previewsManifestJson.decodeFromString(PreviewManifest.serializer(), text) }
+        .getOrNull() ?: return emptyList()
+    return declaredThemesFromPreviews(manifest.previews)
   }
 
   /**

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
@@ -67,6 +67,27 @@ class ServeBundleHost(
       .toList()
 
   /**
+   * The app-declared `@ThemeCatalog` themes, read from the bundle's `previews.json` when it carries
+   * one (the synthetic `THEME_CATALOG` entries discovery emits). A plain static bundle can't apply
+   * a `themeProvider` (no daemon to load the provider), so the viewer shows the App theme selector
+   * as a disabled, informational list — mirroring how declared knobs render on a static bundle.
+   * Empty when the bundle carries no `previews.json` (a bare `previews/`-only WebEmbed) or declares
+   * none.
+   */
+  override val declaredThemes: List<ServeTheme> = run {
+    val previewsJson = File(bundleDir, PREVIEWS_JSON).toOkioPath()
+    if (!fileSystem.exists(previewsJson)) return@run emptyList()
+    try {
+      val text = fileSystem.read(previewsJson) { readUtf8() }
+      val manifest =
+        OVERRIDES_JSON.decodeFromString(ee.schimke.composeai.cli.PreviewManifest.serializer(), text)
+      declaredThemesFromPreviews(manifest.previews)
+    } catch (e: Exception) {
+      emptyList()
+    }
+  }
+
+  /**
    * Read the editable knobs carried for [id] in the bundle's `previews/<id>.overrides.json` sidecar
    * (the `compose/overrides` payload the producer packed). Absent / unreadable → no knobs. The host
    * can't re-render (it replays baked PNGs), so [canApplyOverrides] stays false and the viewer
@@ -138,6 +159,7 @@ class ServeBundleHost(
     /** A preview id folds the component slug and variant as `<slug>__<variant>`. */
     private const val SLUG_SEPARATOR = "__"
     private const val OVERRIDES_SUFFIX = ".overrides.json"
+    private const val PREVIEWS_JSON = "previews.json"
     private val OVERRIDES_JSON = Json { ignoreUnknownKeys = true }
 
     /** True when [dir] looks like a servable bundle (a `previews/` tree with at least one PNG). */

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleStore.kt
@@ -158,7 +158,12 @@ class ServeBundleStore(
         val underPreviews = name.startsWith("$PREVIEWS_SUBDIR/") && ".." !in segments
         val isPng = underPreviews && name.endsWith(PNG_SUFFIX)
         val isOverrides = underPreviews && name.endsWith(OVERRIDES_SUFFIX)
-        if (!entry.isDirectory && (isPng || isOverrides)) {
+        // Also keep the root `previews.json` manifest so a served bundle can surface the app's
+        // declared @ThemeCatalog themes (the synthetic THEME_CATALOG entries live only here, not in
+        // the per-preview sidecars). A top-level file (no path segments), so it's exempt from the
+        // `previews/` prefix check but still zip-slip guarded below.
+        val isPreviewsJson = name == PREVIEWS_JSON
+        if (!entry.isDirectory && (isPng || isOverrides || isPreviewsJson)) {
           val target = File(dir, name)
           // Zip-slip guard: the resolved path must stay under the bundle dir.
           if (target.canonicalFile.toPath().startsWith(rootPath)) {
@@ -198,6 +203,7 @@ class ServeBundleStore(
     private const val PREVIEWS_SUBDIR = "previews"
     private const val PNG_SUFFIX = ".png"
     private const val OVERRIDES_SUFFIX = ".overrides.json"
+    private const val PREVIEWS_JSON = "previews.json"
     private const val DEFAULT_MAX_BYTES = 100L * 1024 * 1024 // 100 MB
 
     /** A session name safe to use as a path segment + URL value; null if it can't be made safe. */

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
@@ -80,6 +80,14 @@ class ServeCatalogLiveHost(
   override val canRenderOverrides: Boolean = true
 
   /**
+   * Only a preview with a daemon twin ([alias]) can actually re-render an override; an unaliased
+   * (Android-only) variant always replays the baked PNG, which ignores overrides. So the viewer
+   * must treat those as non-renderable — otherwise the App theme selector (advertised host-wide via
+   * [declaredThemes]) would render enabled on a variant where picking a theme changes nothing.
+   */
+  override fun canRenderOverridesFor(previewId: String): Boolean = previewId in alias
+
+  /**
    * SVG is exportable when either lane can produce it — the baked catalog carries
    * `figma/<slug>.svg` vectors, and the daemon exports a `compose/figma-svg` for a knob-bearing
    * render.

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
@@ -58,6 +58,14 @@ class ServeCatalogLiveHost(
   override val label: String = baked.label
 
   /**
+   * The app-declared `@ThemeCatalog` themes come from the daemon lane (read from the live bundle's
+   * `previews.json`) — the baked browse surface carries none. Forwarded so the viewer's App theme
+   * selector renders and, since [canRenderOverrides] is true, actually re-renders under a chosen
+   * theme via the carried daemon.
+   */
+  override val declaredThemes: List<ServeTheme> = live.declaredThemes
+
+  /**
    * Snapshots stay static (baked PNGs) so browsing is instant and the viewer shows the published
    * pixels + trust badge — the live daemon is opt-in via [hasLiveStream], not the snapshot lane.
    */

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHost.kt
@@ -53,6 +53,17 @@ interface ServeHost : AutoCloseable {
     get() = canApplyOverrides
 
   /**
+   * Per-preview refinement of [canRenderOverrides]: whether *this* preview can be re-rendered with
+   * an override. Defaults to the host-wide [canRenderOverrides] (true for every preview on a plain
+   * daemon host, false on a static bundle). A trusted-catalog live session ([ServeCatalogLiveHost])
+   * overrides it: only previews with a daemon twin can re-render, so an unaliased (e.g.
+   * Android-only) variant returns false — the viewer then shows its override controls (knobs, App
+   * theme) as disabled/informational rather than enabled-but-dead (an override on such a preview
+   * falls back to the baked PNG, which ignores it).
+   */
+  fun canRenderOverridesFor(previewId: String): Boolean = canRenderOverrides
+
+  /**
    * Whether [renderSvg] can actually produce a `compose/figma-svg` export for this session's
    * previews — a daemon-backed host always can, a static bundle only when it carried baked
    * `figma/<slug>.svg` vectors (a design catalog). Drives whether the viewer offers a copyable SVG

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -503,7 +503,10 @@ class ServeHttpServer(
           token,
           webSessionId,
           canApplyOverrides = renderHost.canApplyOverrides,
-          canRenderOverrides = renderHost.canRenderOverrides,
+          // Per-preview: a catalog-live host can only re-render an override on a daemon-twinned
+          // preview, so an unaliased (Android-only) variant reports false and its override controls
+          // (knobs, App theme) render disabled/informational rather than enabled-but-dead.
+          canRenderOverrides = renderHost.canRenderOverridesFor(preview.id),
           hasSvgExport = renderHost.hasSvgExport,
           hasLiveStream = renderHost.hasLiveStream,
           trust = catalogBundleHost(renderHost)?.let { BundleVerifier.summary(it.trust) },

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHostTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHostTest.kt
@@ -29,6 +29,49 @@ class ServeBundleHostTest {
   }
 
   @Test
+  fun `declared themes are read from the bundle's previews_json when present`() {
+    val dir = bundle("com.example.Card" to byteArrayOf(1))
+    // A previews.json carrying two synthetic THEME_CATALOG entries (the shape discovery emits) plus
+    // an ordinary preview that must NOT be mistaken for a theme.
+    File(dir, "previews.json")
+      .writeText(
+        """
+        {
+          "module": ":samples:cmp",
+          "variant": "debug",
+          "previews": [
+            { "id": "com.example.Card", "functionName": "Card", "className": "com.example.CardKt" },
+            { "id": "themecatalog__Brand_Light", "functionName": "Brand Light theme",
+              "className": "com.example.BrandLightTheme",
+              "params": { "name": "Brand Light", "group": "Brand", "kind": "THEME_CATALOG",
+                          "wrapperClassName": "com.example.BrandLightTheme" } },
+            { "id": "themecatalog__Brand_Dark", "functionName": "Brand Dark theme",
+              "className": "com.example.BrandDarkTheme",
+              "params": { "name": "Brand Dark", "group": "Brand", "kind": "THEME_CATALOG",
+                          "wrapperClassName": "com.example.BrandDarkTheme" } }
+          ]
+        }
+        """
+          .trimIndent()
+      )
+    val host = ServeBundleHost(dir, label = "compose-m3")
+    assertEquals(
+      listOf(
+        "Brand Light" to "com.example.BrandLightTheme",
+        "Brand Dark" to "com.example.BrandDarkTheme",
+      ),
+      host.declaredThemes.map { it.name to it.providerFqn },
+    )
+    assertEquals(listOf("Brand", "Brand"), host.declaredThemes.map { it.group })
+  }
+
+  @Test
+  fun `no declared themes without a previews_json (a bare WebEmbed)`() {
+    val host = ServeBundleHost(bundle("com.example.Red" to byteArrayOf(1)), label = "b")
+    assertTrue(host.declaredThemes.isEmpty())
+  }
+
+  @Test
   fun `previews are discovered from the bundle's png files, sorted`() {
     val host =
       ServeBundleHost(

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleStoreTest.kt
@@ -78,6 +78,35 @@ class ServeBundleStoreTest {
   }
 
   @Test
+  fun `the root previews_json is extracted so an uploaded bundle surfaces its declared themes`() {
+    val previewsJson =
+      """
+      {"module":":samples:cmp","variant":"debug","previews":[
+        {"id":"com.example.Card","functionName":"Card","className":"com.example.CardKt"},
+        {"id":"themecatalog__Brand_Dark","functionName":"Brand Dark theme",
+         "className":"com.example.BrandDarkTheme",
+         "params":{"name":"Brand Dark","group":"Brand","kind":"THEME_CATALOG",
+                   "wrapperClassName":"com.example.BrandDarkTheme"}}]}
+      """
+        .trimIndent()
+    val zip =
+      zipOf(
+        "previews/com.example.Card.png" to byteArrayOf(1, 2, 3),
+        "previews.json" to previewsJson.toByteArray(),
+      )
+    assertEquals(
+      ServeBundleStore.Result.Ok("demo", 1),
+      store().add("demo", zip, isSecurityChecked = true),
+    )
+    // The uploaded bundle's App theme selector is fed from the root previews.json — which must be
+    // extracted alongside the PNGs (it isn't a `previews/…` entry).
+    assertEquals(
+      listOf("Brand Dark" to "com.example.BrandDarkTheme"),
+      registered.getValue("demo").declaredThemes.map { it.name to it.providerFqn },
+    )
+  }
+
+  @Test
   fun `a bundle without previews is rejected`() {
     val result = store().add("demo", zipOf("notes.txt" to byteArrayOf(1)), isSecurityChecked = true)
     assertTrue(result is ServeBundleStore.Result.Failed)

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
@@ -119,6 +119,18 @@ class ServeCatalogLiveHostTest {
     PreviewOverrides(namedOverrides = mapOf("label" to PreviewOverrideValue.StringValue("Tap me")))
 
   @Test
+  fun `canRenderOverridesFor is true only for aliased previews`() {
+    val (composite, _, _) = host()
+    // A daemon-twinned catalog preview can re-render an override…
+    assertTrue(composite.canRenderOverridesFor(catalogId))
+    // …but an unaliased (Android-only) variant can't — it always replays baked, so its override
+    // controls (App theme, knobs) must render disabled rather than enabled-but-dead.
+    assertEquals(false, composite.canRenderOverridesFor(androidOnlyId))
+    // The host-wide flag stays true (the session offers on-demand re-render for the mapped ids).
+    assertTrue(composite.canRenderOverrides)
+  }
+
+  @Test
   fun `declared themes come from the daemon lane, not the baked browse surface`() {
     val baked = RecordingHost(previews = listOf(ServePreview(catalogId, catalogId)), tag = "baked")
     val live =

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
@@ -32,6 +32,7 @@ class ServeCatalogLiveHostTest {
     private val streaming: Boolean = false,
     /** When true, `renderSvg` reports `NotFound` (a baked catalog missing this slug's vector). */
     private val svgNotFound: Boolean = false,
+    override val declaredThemes: List<ServeTheme> = emptyList(),
   ) : ServeHost {
     override val label: String = tag
     override val canApplyOverrides: Boolean = streaming
@@ -116,6 +117,24 @@ class ServeCatalogLiveHostTest {
   /** A knob-bearing override — the sole case the baked PNG can't satisfy. */
   private fun knobOverride() =
     PreviewOverrides(namedOverrides = mapOf("label" to PreviewOverrideValue.StringValue("Tap me")))
+
+  @Test
+  fun `declared themes come from the daemon lane, not the baked browse surface`() {
+    val baked = RecordingHost(previews = listOf(ServePreview(catalogId, catalogId)), tag = "baked")
+    val live =
+      RecordingHost(
+        previews = listOf(ServePreview(daemonId, daemonId)),
+        tag = "live",
+        streaming = true,
+        declaredThemes = listOf(ServeTheme("Brand Dark", "com.example.BrandDarkTheme", "Brand")),
+      )
+    val composite = ServeCatalogLiveHost(mapOf(catalogId to daemonId), live, baked)
+    // Forwarded from the daemon lane (which read them from the live bundle's previews.json); the
+    // baked browse surface carries none. canRenderOverrides is true, so the selector is live.
+    assertEquals(listOf("Brand Dark"), composite.declaredThemes.map { it.name })
+    assertEquals("com.example.BrandDarkTheme", composite.declaredThemes.single().providerFqn)
+    assertTrue(composite.canRenderOverrides)
+  }
 
   @Test
   fun `presents as a static-snapshot host that still offers Live`() {

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -201,6 +201,15 @@ class ServeWebFixtureTest {
         trust = "branch:yschimke/compose-ai-tools@design-artifacts/compose-m3",
         wasmSrc = "/wasm/compose-m3/?id=button-filled",
         wasmSameOrigin = true,
+        // A trusted-catalog live session now also carries the app's declared @ThemeCatalog themes
+        // (read from the live bundle's previews.json), so the App theme selector renders enabled
+        // and
+        // re-renders via the carried daemon — the surface this PR wires up end-to-end.
+        declaredThemes =
+          listOf(
+            ServeTheme("Brand Light", "com.example.BrandLightThemeCatalog", group = "Brand"),
+            ServeTheme("Brand Dark", "com.example.BrandDarkThemeCatalog", group = "Brand"),
+          ),
       )
     // A catalog served under its canonical path (/meshcore-mobile/) rather than ?session=: same
     // pages, but links stay on the path (basePath) and drop the &session= param. Captures the

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
@@ -142,7 +142,14 @@ a:hover { text-decoration: underline; }
               <option value="dark">Dark</option>
             </select>
           </label>
-          
+                  <label>App theme
+          <select id="cp-themeProvider" class="cp-knob-theme">
+            <option value="">(default)</option>
+            <optgroup label="Brand"><option value="com.example.BrandLightThemeCatalog">Brand Light</option>
+<option value="com.example.BrandDarkThemeCatalog">Brand Dark</option></optgroup>
+
+          </select>
+        </label>
           <label>Device
             <select id="cp-device" disabled>
               <option value="">(default)</option>


### PR DESCRIPTION
## Summary

Follow-up to #2341. That PR added the **App theme** selector, but only a daemon-backed `compose-preview serve` session carried the declared themes — a published catalog or portable bundle showed nothing. This wires the themes through the bundle/catalog hosts too, **reusing the `previews.json` already packed in the bundle** (no new write-side sidecar).

## Changes

- **`ServeBundleDaemon`** (the live-bundle → daemon path a trusted-catalog session runs on) reads the catalog's declared `@ThemeCatalog` themes from the carried `previews.json` and puts them on the `ServeSessionState`, so the carried daemon can apply `themeProvider` on demand.
- **`ServeCatalogLiveHost`** forwards `declaredThemes` from its daemon lane (the baked browse surface carries none). Since it already has `canRenderOverrides = true`, the selector renders **enabled** and re-renders under a chosen theme via the daemon.
- **`ServeBundleHost`** reads `previews.json` when present. A pure static bundle has no daemon to load a provider, so the selector renders **disabled/informational** — mirroring how declared knobs behave on a static bundle. A bare `previews/`-only WebEmbed (no `previews.json`) simply shows no selector.

Reuses the `declaredThemesFromPreviews` extractor from #2341, so the `THEME_CATALOG`-entry → `ServeTheme` mapping stays in one place.

## Test plan

- `./gradlew :cli:test --tests '*ServeBundleHostTest*'` — themes are read from a bundle's `previews.json` (name / FQN / group), and absent without one.
- `./gradlew :cli:test --tests '*ServeCatalogLiveHostTest*'` — the composite host forwards the **daemon lane's** themes (not the baked browse surface's) and stays `canRenderOverrides`.
- `./gradlew :cli:test --tests '*ServeWebFixtureTest*'` — the `serve-viewer-catalog-knobs` golden fixture now carries declared themes, so the CI visual-diff bot captures the App theme selector on a catalog session.

## Visual evidence

A trusted-catalog **live** viewer now shows the **App theme** selector (enabled, grouped by `@ThemeCatalog(group)`) beside the declared knobs — from the `serve-viewer-catalog-knobs` fixture, before (`main`) vs after (this branch), rendered + diffed by the CI bot:

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/yschimke/compose-ai-tools/bc5d71bbaf5648e4e9e4491c933da0d0a211c159/renders/serve-viewer-catalog-knobs.light.png" width="360"> | <img src="https://raw.githubusercontent.com/yschimke/compose-ai-tools/7c083a22943abb6391c6c8c0fbb16d0e29c36555/renders/serve-viewer-catalog-knobs.light.png" width="360"> |

---
_Generated by [Claude Code](https://claude.ai/code/session_01MkDr2hzvkuW9yrs16eFCyj)_