### PR TITLE
feat(serve): detected-feature controls in the viewer (keyboard focus)

### DIFF
--- a/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/cli/PreviewData.kt
+++ b/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/cli/PreviewData.kt
@@ -77,6 +77,18 @@ data class Capture(
    * absent when the binary / display / software GL isn't available). Defaults to `false`.
    */
   val optional: Boolean = false,
+  /**
+   * Presence markers for the two per-capture **detected-feature** annotations discovery emits: a
+   * `@FocusedPreview` capture carries a `focus` (or `focusGif`) block, and a `@GestureHintPreview`
+   * one carries `gestureHint`. Modelled here only as opaque [JsonElement]s — the serve layer needs
+   * to know *whether* a preview supports keyboard focus / one-handed gestures (to gate the viewer's
+   * feature controls), not the block's contents, and modelling the full nested shape would drag the
+   * gradle-plugin's discovery types into `:preview-data-api`. Absent (null) when the preview
+   * carries neither annotation.
+   */
+  val focus: JsonElement? = null,
+  val focusGif: JsonElement? = null,
+  val gestureHint: JsonElement? = null,
 )
 
 @Serializable

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -24,6 +24,7 @@ import ee.schimke.composeai.cli.serve.ServeStartupBundles
 import ee.schimke.composeai.cli.serve.ServeUrls
 import ee.schimke.composeai.cli.serve.TrustStore
 import ee.schimke.composeai.cli.serve.declaredThemesFromPreviews
+import ee.schimke.composeai.cli.serve.detectedFeaturesOf
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.render.session.RenderSessionException
 import java.io.File
@@ -305,7 +306,15 @@ class ServeCommand(args: List<String>) : Command(args) {
     val previews =
       manifest.previews
         .filter { matches(it.id) }
-        .map { ServePreview(id = it.id, label = it.functionName.ifBlank { it.id }) }
+        .map {
+          val (focus, gestures) = detectedFeaturesOf(it)
+          ServePreview(
+            id = it.id,
+            label = it.functionName.ifBlank { it.id },
+            supportsFocus = focus,
+            supportsGestures = gestures,
+          )
+        }
     // The module's declared @ThemeCatalog themes — the Theme selector renders them so a preview can
     // be re-rendered under Brand Dark etc. Module-global, so unaffected by the --id/--filter above.
     val declaredThemes = declaredThemesFromPreviews(manifest.previews)

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/GradleRevisionBuilder.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/GradleRevisionBuilder.kt
@@ -49,7 +49,13 @@ class GradleRevisionBuilder(
     val manifest = PreviewResultBuilder.readManifest(PreviewModule(module.gradlePath, moduleDir))
     val previews =
       manifest?.previews?.map {
-        ServePreview(id = it.id, label = it.functionName.ifBlank { it.id })
+        val (focus, gestures) = detectedFeaturesOf(it)
+        ServePreview(
+          id = it.id,
+          label = it.functionName.ifBlank { it.id },
+          supportsFocus = focus,
+          supportsGestures = gestures,
+        )
       } ?: emptyList()
     if (previews.isEmpty()) {
       onLog("serve: no previews discovered for ${module.gradlePath}")

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt
@@ -212,10 +212,13 @@ internal object ServeBundleDaemon {
       runCatching { previewsManifestJson.decodeFromString(PreviewManifest.serializer(), text) }
         .getOrNull() ?: return emptyList()
     return manifest.previews.map {
+      val (focus, gestures) = detectedFeaturesOf(it)
       ServePreview(
         id = it.id,
         label = it.functionName.ifBlank { it.id },
         overrides = readOverrideSidecar(previewsDir, it.id, fileSystem),
+        supportsFocus = focus,
+        supportsGestures = gestures,
       )
     }
   }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
@@ -174,21 +174,29 @@ class ServeCatalogLiveHost(
   override fun activeStreamCount(): Int = live.activeStreamCount()
 
   /**
-   * Graft the daemon previews' author-declared knobs onto the baked browse surface. The daemon
-   * knows its previews by descriptor id (`FilledButton_Dark`) and carries their
-   * [ServePreview.overrides] (from the bundle sidecars); the baked catalog keys by catalog id
-   * (`button-filled__ideal__default__dark`) and carries none. For each mapped baked preview, copy
-   * its daemon twin's declarations across so `/api/previews` + the viewer advertise the editable
-   * knobs. Unmapped previews (Android-only variants with no daemon lane) are returned unchanged.
+   * Graft the daemon previews' per-preview metadata onto the baked browse surface. The daemon knows
+   * its previews by descriptor id (`FilledButton_Dark`) and carries their author-declared knobs
+   * ([ServePreview.overrides], from the bundle sidecars) plus the detected-feature flags
+   * ([ServePreview.supportsFocus] / [supportsGestures], from `@FocusedPreview` /
+   * `@GestureHintPreview` discovery); the baked catalog keys by catalog id
+   * (`button-filled__ideal__default__dark`) and carries neither. For each mapped baked preview,
+   * copy its daemon twin's knobs + feature flags across so `/api/previews` + the viewer advertise
+   * the editable knobs AND the detected-feature controls (a mapped `@FocusedPreview` component's
+   * Keyboard focus toggle re-renders on the daemon). Unmapped previews (Android-only variants with
+   * no daemon lane) are returned unchanged.
    */
   private fun mergeDeclaredKnobs(
     bakedPreviews: List<ServePreview>,
     livePreviews: List<ServePreview>,
   ): List<ServePreview> {
-    val knobsByDaemonId = livePreviews.associate { it.id to it.overrides }
+    val twinByDaemonId = livePreviews.associateBy { it.id }
     return bakedPreviews.map { p ->
-      val knobs = alias[p.id]?.let { knobsByDaemonId[it] }
-      if (knobs.isNullOrEmpty()) p else p.copy(overrides = knobs)
+      val twin = alias[p.id]?.let { twinByDaemonId[it] } ?: return@map p
+      p.copy(
+        overrides = twin.overrides,
+        supportsFocus = twin.supportsFocus,
+        supportsGestures = twin.supportsGestures,
+      )
     }
   }
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeOverrides.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeOverrides.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.cli.serve
 
+import ee.schimke.composeai.daemon.protocol.FocusOverride
 import ee.schimke.composeai.daemon.protocol.Orientation
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.daemon.protocol.UiMode
@@ -63,6 +64,10 @@ object ServeOverrides {
       // FQN of an app-declared @ThemeCatalog `PreviewWrapperProvider` to render this preview under
       // (the discrete-theme axis). Daemon-only — a baked bundle has no provider to load.
       "themeProvider",
+      // Detected-feature: keyboard focus. `focus=<tabIndex>` lands focus on the n-th focusable and
+      // draws the focus overlay (`FocusOverride(tabIndex, overlay=true)`). Offered only for a
+      // `@FocusedPreview`-detected preview; daemon-only (the desktop daemon honours it).
+      "focus",
       // "crisp outline" toggle. Friendly `background=clear` (aliases below) or the raw
       // `clearBackground=true`; both map to `PreviewOverrides.clearBackground`.
       "background",
@@ -240,6 +245,21 @@ object ServeOverrides {
           }
         }
 
+    // Detected-feature: keyboard focus. `focus=<tabIndex>` lands focus on the n-th focusable in tab
+    // order and draws the post-capture focus overlay (stroke + label). A non-negative integer; a
+    // malformed value is a hard Invalid. Absent → no focus override (discovery-time behaviour).
+    val focus: FocusOverride? =
+      params["focus"]
+        ?.takeIf { it.isNotBlank() }
+        ?.let {
+          val tabIndex =
+            it.toIntOrNull()?.takeIf { n -> n >= 0 }
+              ?: return OverrideParse.Invalid(
+                "focus must be a non-negative integer tab index, got '$it'"
+              )
+          FocusOverride(tabIndex = tabIndex, overlay = true)
+        }
+
     // Cleared background ("crisp outline"). Two spellings: the friendly `background=clear`
     // (aliases `transparent` / `none` / `off`; `default` / `show` mean "keep the preview's
     // background") and the raw boolean `clearBackground=true`. A present `background` key wins over
@@ -330,6 +350,7 @@ object ServeOverrides {
         talkBack = talkBack,
         touchOverlay = touchOverlay,
         themeProvider = params["themeProvider"]?.takeIf { it.isNotBlank() },
+        focus = focus,
         clearBackground = clearBackground,
         namedOverrides = namedOverrides.ifEmpty { null },
       )
@@ -358,6 +379,7 @@ object ServeOverrides {
       append("talk=").append(o.talkBack).append('|')
       append("touch=").append(o.touchOverlay).append('|')
       append("theme=").append(o.themeProvider).append('|')
+      append("focus=").append(o.focus).append('|')
       append("clearbg=").append(o.clearBackground).append('|')
       // Named overrides participate so a knob edit isn't coalesced onto the prior render. Sorted by
       // key for order-independence; the value data classes have stable toString.

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
@@ -58,7 +58,34 @@ data class ServePreview(
    * Empty when the preview declared none (or the host doesn't carry them).
    */
   val overrides: List<ee.schimke.composeai.data.overrides.PreviewOverrideDeclaration> = emptyList(),
+  /**
+   * Whether this preview supports **keyboard focus** — it carries `@FocusedPreview` (discovery
+   * emits a `focus` capture). Lets the viewer offer a "Keyboard focus" control *only* for previews
+   * that actually have something focusable, rather than as a dead control everywhere. Applied live
+   * via the `focus` override (daemon-only); the desktop daemon honours it.
+   */
+  val supportsFocus: Boolean = false,
+  /**
+   * Whether this preview supports **one-handed (wear) gestures** — it carries `@GestureHintPreview`
+   * (discovery emits a `gestureHint` capture). Surfaced for detection, but the gesture *override*
+   * is Android-only (the desktop daemon behind `serve` ignores `overrides.gestures`), so the viewer
+   * gates the control to Android-backed sessions.
+   */
+  val supportsGestures: Boolean = false,
 )
+
+/**
+ * Detected per-preview feature support, folded across a discovery
+ * [ee.schimke.composeai.cli.PreviewInfo]'s captures: keyboard focus (`@FocusedPreview` → a
+ * `focus`/`focusGif` capture) and one-handed gestures (`@GestureHintPreview` → a `gestureHint`
+ * capture). Returns the two booleans the viewer gates its feature controls on. A preview with
+ * neither annotation yields `(false, false)`.
+ */
+fun detectedFeaturesOf(preview: ee.schimke.composeai.cli.PreviewInfo): Pair<Boolean, Boolean> {
+  val focus = preview.captures.any { it.focus != null || it.focusGif != null }
+  val gestures = preview.captures.any { it.gestureHint != null }
+  return focus to gestures
+}
 
 /**
  * One app-declared `@ThemeCatalog` theme this session can render an arbitrary preview under — the

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -842,6 +842,26 @@ object ServeWeb {
         """
           .trimIndent()
       else ""
+    // Detected-feature controls — shown ONLY for previews that actually support the feature (so
+    // it's
+    // never a dead control everywhere). Today: "Keyboard focus" for a `@FocusedPreview` preview,
+    // which re-renders with focus landed on the first focusable + the focus overlay drawn
+    // (`focus=0`). Daemon-only (routed like a knob via onKnobChanged), so disabled unless the host
+    // can render an override. `cp-feature` marks it for the JS collector. Gestures are detected too
+    // ([ServePreview.supportsGestures]) but their override is Android-only, so no control is
+    // offered
+    // on the desktop `serve` path yet.
+    val featureDaemonDis = if (canApplyOverrides || canRenderOverrides) "" else " disabled"
+    val featureControlsHtml =
+      if (preview.supportsFocus)
+        """
+        <div class="cp-overlays">
+          <div class="cp-overlays-head">Detected features</div>
+          <label class="cp-live-row"><input class="cp-feature" id="cp-focus" type="checkbox"$featureDaemonDis> Keyboard focus</label>
+        </div>
+        """
+          .trimIndent()
+      else ""
     val body =
       """
       <p class="cp-head"><a href="$basePath/$q">← previews</a>${trustBadge(trust)}</p>
@@ -891,6 +911,7 @@ object ServeWeb {
             </select>
           </label>
           $overlaysHtml
+          $featureControlsHtml
           ${overrideKnobsHtml(preview, canApplyOverrides || canRenderOverrides)}
           ${downloadLinksHtml(hasSvgExport)}
           <div class="cp-status" id="cp-status"></div>
@@ -993,6 +1014,10 @@ object ServeWeb {
         // control is live; "(default)" (empty) leaves the daemon on the preview's own wrapper.
         var tp = document.getElementById("cp-themeProvider");
         if (tp && !tp.disabled && tp.value) o["themeProvider"] = tp.value;
+        // Detected-feature: keyboard focus. Checked ⇒ focus the first focusable + draw the overlay
+        // (focus=0). Daemon-only, so skipped when disabled.
+        var fc = document.getElementById("cp-focus");
+        if (fc && !fc.disabled && fc.checked) o["focus"] = "0";
         return o;
       }
       function query() {
@@ -1023,6 +1048,10 @@ object ServeWeb {
         if (tp && !tp.disabled && tp.value) {
           parts.push("themeProvider=" + encodeURIComponent(tp.value));
         }
+        // Detected-feature: keyboard focus (focus=0). Routes to the daemon like a knob; omitted when
+        // unchecked so the URL stays on the baked snapshot.
+        var fc = document.getElementById("cp-focus");
+        if (fc && !fc.disabled && fc.checked) parts.push("focus=0");
         return parts.join("&");
       }
       function refreshSnapshot() {
@@ -1511,6 +1540,11 @@ object ServeWeb {
       // load), so it shares onKnobChanged rather than onControlsChanged.
       var themeSel = document.getElementById("cp-themeProvider");
       if (themeSel) themeSel.addEventListener("change", onKnobChanged);
+      // Detected-feature toggles (Keyboard focus) re-render on the daemon like a knob — same routing,
+      // never the wasm auto-enable path.
+      document.querySelectorAll(".cp-feature").forEach(function (el) {
+        el.addEventListener("change", onKnobChanged);
+      });
       refreshSnapshot();
     })();
     """

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
@@ -146,6 +146,30 @@ class ServeCatalogLiveHostTest {
   }
 
   @Test
+  fun `grafts the daemon's detected-feature flags onto the mapped baked preview`() {
+    // The baked catalog images carry no detected-feature flags; the daemon twin (from
+    // previews.json)
+    // does. Without grafting, a mapped @FocusedPreview catalog component would never show the
+    // Keyboard focus control even though the daemon could render focus=0.
+    val baked =
+      RecordingHost(
+        previews =
+          listOf(ServePreview(catalogId, catalogId), ServePreview(androidOnlyId, androidOnlyId)),
+        tag = "baked",
+      )
+    val live =
+      RecordingHost(
+        previews = listOf(ServePreview(daemonId, daemonId, supportsFocus = true)),
+        tag = "live",
+        streaming = true,
+      )
+    val composite = ServeCatalogLiveHost(mapOf(catalogId to daemonId), live, baked)
+    assertTrue(composite.previews.first { it.id == catalogId }.supportsFocus)
+    // An unmapped variant has no daemon twin, so it stays feature-flagless.
+    assertEquals(false, composite.previews.first { it.id == androidOnlyId }.supportsFocus)
+  }
+
+  @Test
   fun `a knob-bearing render on a mapped id routes to the daemon`() {
     val (composite, live, baked) = host()
     val out = composite.render(catalogId, knobOverride()) as RenderOutcome.Ok

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeFeatureDetectionTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeFeatureDetectionTest.kt
@@ -1,0 +1,54 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.cli.Capture
+import ee.schimke.composeai.cli.PreviewInfo
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+
+/**
+ * [detectedFeaturesOf] folds per-capture `@FocusedPreview` / `@GestureHintPreview` presence markers
+ * into the two booleans the viewer gates its detected-feature controls on.
+ */
+class ServeFeatureDetectionTest {
+
+  private fun preview(vararg captures: Capture) =
+    PreviewInfo(
+      id = "com.example.P",
+      functionName = "P",
+      className = "com.example.PKt",
+      captures = captures.toList(),
+    )
+
+  @Test
+  fun `a focus capture flags focus support only`() {
+    val (focus, gestures) = detectedFeaturesOf(preview(Capture(focus = buildJsonObject {})))
+    assertEquals(true to false, focus to gestures)
+  }
+
+  @Test
+  fun `a focusGif capture also flags focus support`() {
+    val (focus, _) = detectedFeaturesOf(preview(Capture(focusGif = JsonPrimitive("x"))))
+    assertEquals(true, focus)
+  }
+
+  @Test
+  fun `a gestureHint capture flags gesture support only`() {
+    val (focus, gestures) = detectedFeaturesOf(preview(Capture(gestureHint = buildJsonObject {})))
+    assertEquals(false to true, focus to gestures)
+  }
+
+  @Test
+  fun `an ordinary preview supports neither`() {
+    val (focus, gestures) = detectedFeaturesOf(preview(Capture()))
+    assertEquals(false to false, focus to gestures)
+  }
+
+  @Test
+  fun `support is folded across all captures`() {
+    // A preview whose first capture is plain but a later one carries the annotation still counts.
+    val (focus, _) = detectedFeaturesOf(preview(Capture(), Capture(focus = buildJsonObject {})))
+    assertEquals(true, focus)
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeOverridesTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeOverridesTest.kt
@@ -36,7 +36,35 @@ class ServeOverridesTest {
     assertNull(o.talkBack)
     assertNull(o.touchOverlay)
     assertNull(o.themeProvider)
+    assertNull(o.focus)
     assertNull(o.clearBackground)
+  }
+
+  @Test
+  fun `focus tab index maps to a focus override with the overlay drawn`() {
+    val o = ok(mapOf("focus" to "2"))
+    assertEquals(2, o.focus?.tabIndex)
+    assertEquals(true, o.focus?.overlay)
+  }
+
+  @Test
+  fun `a malformed focus index is rejected`() {
+    for (bad in listOf("focus" to "yes", "focus" to "-1", "focus" to "1.5")) {
+      val parsed = ServeOverrides.parse(mapOf(bad))
+      assertTrue(parsed is OverrideParse.Invalid, "expected Invalid for $bad, got $parsed")
+    }
+  }
+
+  @Test
+  fun `cache key differs when a focus override is applied`() {
+    assertNotEquals(
+      ServeOverrides.cacheKey("preview.A", ok(mapOf("focus" to "0"))),
+      ServeOverrides.cacheKey("preview.A", ok(emptyMap())),
+    )
+    assertNotEquals(
+      ServeOverrides.cacheKey("preview.A", ok(mapOf("focus" to "0"))),
+      ServeOverrides.cacheKey("preview.A", ok(mapOf("focus" to "1"))),
+    )
   }
 
   @Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -241,6 +241,16 @@ class ServeWebFixtureTest {
             ServeTheme("High Contrast", "com.example.HighContrastThemeCatalog"),
           ),
       )
+    // A daemon-backed viewer for a preview detected to support keyboard focus (`@FocusedPreview`):
+    // the "Detected features" group with the "Keyboard focus" control appears, gated to daemon
+    // sessions. Captured so the visual-diff bot covers the detected-feature control.
+    val viewerFocus =
+      ServeWeb.viewerPage(
+        ServePreview("com.example.FocusRingPreview", "Focus ring", supportsFocus = true),
+        token,
+        sessionId = "compose-m3",
+        canApplyOverrides = true,
+      )
     // A catalog whose previews carry per-theme variants, so the landing shows the sticky light/dark
     // toggle and tags each card with its baked theme for client-side filtering.
     val landingThemed =
@@ -263,6 +273,7 @@ class ServeWebFixtureTest {
       File(pagesDir, "serve-viewer-wasm-live.html").writeText(wasmViewerLive)
       File(pagesDir, "serve-viewer-catalog-knobs.html").writeText(viewerCatalogKnobs)
       File(pagesDir, "serve-viewer-themes.html").writeText(viewerThemes)
+      File(pagesDir, "serve-viewer-focus.html").writeText(viewerFocus)
       File(pagesDir, "serve-landing-path.html").writeText(landingPath)
       File(pagesDir, "serve-viewer-path.html").writeText(viewerPath)
       File(pagesDir, "serve-landing-themed.html").writeText(landingThemed)
@@ -278,6 +289,17 @@ class ServeWebFixtureTest {
     assertGolden(File(pagesDir, "serve-viewer-wasm-live.html"), wasmViewerLive)
     assertGolden(File(pagesDir, "serve-viewer-catalog-knobs.html"), viewerCatalogKnobs)
     assertGolden(File(pagesDir, "serve-viewer-themes.html"), viewerThemes)
+    assertGolden(File(pagesDir, "serve-viewer-focus.html"), viewerFocus)
+    // The detected-feature control shows for a focus-supporting preview…
+    assertTrue(
+      viewerFocus.contains("id=\"cp-focus\"") && viewerFocus.contains("Keyboard focus"),
+      "a @FocusedPreview preview shows the Keyboard focus control",
+    )
+    // …and NOT for an ordinary preview (no dead control).
+    assertFalse(
+      viewerThemes.contains("id=\"cp-focus\""),
+      "a preview without @FocusedPreview shows no Keyboard focus control",
+    )
     assertGolden(File(pagesDir, "serve-landing-path.html"), landingPath)
     assertGolden(File(pagesDir, "serve-viewer-path.html"), viewerPath)
     assertGolden(File(pagesDir, "serve-landing-themed.html"), landingThemed)

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
@@ -178,6 +178,7 @@ a:hover { text-decoration: underline; }
   <label class="cp-live-row"><input class="cp-overlay" id="cp-talkBack" type="checkbox" disabled> Accessibility (TalkBack)</label>
   <label class="cp-live-row"><input class="cp-overlay" id="cp-touchOverlay" type="checkbox" disabled> Show touches</label>
 </div>
+          
                 <div class="cp-knobs">
         <div class="cp-knobs-head">Declared overrides — edit a value to re-render.</div>
         <label>label
@@ -304,6 +305,10 @@ a:hover { text-decoration: underline; }
     // control is live; "(default)" (empty) leaves the daemon on the preview's own wrapper.
     var tp = document.getElementById("cp-themeProvider");
     if (tp && !tp.disabled && tp.value) o["themeProvider"] = tp.value;
+    // Detected-feature: keyboard focus. Checked ⇒ focus the first focusable + draw the overlay
+    // (focus=0). Daemon-only, so skipped when disabled.
+    var fc = document.getElementById("cp-focus");
+    if (fc && !fc.disabled && fc.checked) o["focus"] = "0";
     return o;
   }
   function query() {
@@ -334,6 +339,10 @@ a:hover { text-decoration: underline; }
     if (tp && !tp.disabled && tp.value) {
       parts.push("themeProvider=" + encodeURIComponent(tp.value));
     }
+    // Detected-feature: keyboard focus (focus=0). Routes to the daemon like a knob; omitted when
+    // unchecked so the URL stays on the baked snapshot.
+    var fc = document.getElementById("cp-focus");
+    if (fc && !fc.disabled && fc.checked) parts.push("focus=0");
     return parts.join("&");
   }
   function refreshSnapshot() {
@@ -822,6 +831,11 @@ a:hover { text-decoration: underline; }
   // load), so it shares onKnobChanged rather than onControlsChanged.
   var themeSel = document.getElementById("cp-themeProvider");
   if (themeSel) themeSel.addEventListener("change", onKnobChanged);
+  // Detected-feature toggles (Keyboard focus) re-render on the daemon like a knob — same routing,
+  // never the wasm auto-enable path.
+  document.querySelectorAll(".cp-feature").forEach(function (el) {
+    el.addEventListener("change", onKnobChanged);
+  });
   refreshSnapshot();
 })();</script>
       <script>(function () {

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-focus.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-focus.html
@@ -3,7 +3,7 @@
       <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <title>Profile screen — compose-preview</title>
+        <title>Focus ring — compose-preview</title>
         <style>:root { color-scheme: light dark; }
 * { box-sizing: border-box; }
 body { margin: 0; padding: 24px; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
@@ -122,21 +122,21 @@ a:hover { text-decoration: underline; }
 }</style>
       </head>
       <body>
-              <p class="cp-head"><a href="/?token=demo-token-fixture">← previews</a> <span class="cp-badge cp-badge--unverified" title="producer trust: unverified">⚠ unverified</span></p>
-      <p class="cp-sub" title="com.example.ProfileScreenPreview">Profile screen</p>
-      <div class="cp-viewer" data-preview-id="com.example.ProfileScreenPreview" data-mode="snapshot" data-modes="snapshot,live" data-static-snapshot="true" data-can-render-overrides="false" data-snapshot-backend="Snapshot" data-live-backend="Live">
-        <div class="cp-stage"><span class="cp-backend" id="cp-backend"></span><img id="cp-img" alt="Profile screen"><canvas id="cp-canvas" hidden></canvas></div>
+              <p class="cp-head"><a href="/?token=demo-token-fixture&session=compose-m3">← previews</a></p>
+      <p class="cp-sub" title="com.example.FocusRingPreview">Focus ring</p>
+      <div class="cp-viewer" data-preview-id="com.example.FocusRingPreview" data-mode="snapshot" data-modes="snapshot" data-static-snapshot="false" data-can-render-overrides="true" data-snapshot-backend="Snapshot" data-live-backend="Live">
+        <div class="cp-stage"><span class="cp-backend" id="cp-backend"></span><img id="cp-img" alt="Focus ring"><canvas id="cp-canvas" hidden></canvas></div>
         <div class="cp-controls">
-          <div class="cp-note">Pre-rendered snapshot — overrides (device, locale, font scale, orientation) need the live server, not a published catalog. <a href="https://github.com/yschimke/compose-ai-tools/blob/main/docs/public-preview-server.md#running-one">Enable a local preview server.</a></div>
+          
           <div class="cp-modes" role="radiogroup" aria-label="Render mode">
             <label class="cp-live-row"><input type="radio" name="cp-mode" value="png" id="cp-mode-png" checked> PNG</label>
             
-            <label class="cp-live-row"><input type="radio" name="cp-mode" value="live" id="cp-live" disabled> Live Compose</label>
+            <label class="cp-live-row"><input type="radio" name="cp-mode" value="live" id="cp-live"> Live Compose</label>
             
           </div>
           
           <label>Theme
-            <select id="cp-uiMode" disabled>
+            <select id="cp-uiMode">
               <option value="">(default)</option>
               <option value="light">Light</option>
               <option value="dark">Dark</option>
@@ -144,7 +144,7 @@ a:hover { text-decoration: underline; }
           </label>
           
           <label>Device
-            <select id="cp-device" disabled>
+            <select id="cp-device">
               <option value="">(default)</option>
               <option value="id:pixel_5">Pixel 5</option>
 <option value="id:pixel_7">Pixel 7</option>
@@ -155,26 +155,33 @@ a:hover { text-decoration: underline; }
             </select>
           </label>
           <label>Locale (BCP-47)
-            <input id="cp-localeTag" type="text" placeholder="e.g. ar, ja-JP" autocomplete="off" disabled>
+            <input id="cp-localeTag" type="text" placeholder="e.g. ar, ja-JP" autocomplete="off">
           </label>
           <label>Font scale: <span id="cp-fontScale-val">default</span>
-            <input id="cp-fontScale" type="range" min="0.5" max="2.0" step="0.1" value="1.0" disabled>
+            <input id="cp-fontScale" type="range" min="0.5" max="2.0" step="0.1" value="1.0">
           </label>
           <label>Orientation
-            <select id="cp-orientation" disabled>
+            <select id="cp-orientation">
               <option value="">(default)</option>
               <option value="portrait">Portrait</option>
               <option value="landscape">Landscape</option>
             </select>
           </label>
           <label>Background
-            <select id="cp-background" disabled>
+            <select id="cp-background">
               <option value="">(default)</option>
               <option value="clear">Clear (crisp outline)</option>
             </select>
           </label>
-          
-          
+          <div class="cp-overlays">
+  <div class="cp-overlays-head">Overlays (Live Compose)</div>
+  <label class="cp-live-row"><input class="cp-overlay" id="cp-talkBack" type="checkbox" disabled> Accessibility (TalkBack)</label>
+  <label class="cp-live-row"><input class="cp-overlay" id="cp-touchOverlay" type="checkbox" disabled> Show touches</label>
+</div>
+          <div class="cp-overlays">
+  <div class="cp-overlays-head">Detected features</div>
+  <label class="cp-live-row"><input class="cp-feature" id="cp-focus" type="checkbox"> Keyboard focus</label>
+</div>
           
                 <div class="cp-links">
         <div class="cp-knobs-head">Direct links — the current view as a URL (overrides applied)</div>

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
@@ -175,6 +175,7 @@ a:hover { text-decoration: underline; }
           </label>
           
           
+          
                 <div class="cp-links">
         <div class="cp-knobs-head">Direct links — the current view as a URL (overrides applied)</div>
         <div class="cp-link-row">
@@ -286,6 +287,10 @@ a:hover { text-decoration: underline; }
     // control is live; "(default)" (empty) leaves the daemon on the preview's own wrapper.
     var tp = document.getElementById("cp-themeProvider");
     if (tp && !tp.disabled && tp.value) o["themeProvider"] = tp.value;
+    // Detected-feature: keyboard focus. Checked ⇒ focus the first focusable + draw the overlay
+    // (focus=0). Daemon-only, so skipped when disabled.
+    var fc = document.getElementById("cp-focus");
+    if (fc && !fc.disabled && fc.checked) o["focus"] = "0";
     return o;
   }
   function query() {
@@ -316,6 +321,10 @@ a:hover { text-decoration: underline; }
     if (tp && !tp.disabled && tp.value) {
       parts.push("themeProvider=" + encodeURIComponent(tp.value));
     }
+    // Detected-feature: keyboard focus (focus=0). Routes to the daemon like a knob; omitted when
+    // unchecked so the URL stays on the baked snapshot.
+    var fc = document.getElementById("cp-focus");
+    if (fc && !fc.disabled && fc.checked) parts.push("focus=0");
     return parts.join("&");
   }
   function refreshSnapshot() {
@@ -804,6 +813,11 @@ a:hover { text-decoration: underline; }
   // load), so it shares onKnobChanged rather than onControlsChanged.
   var themeSel = document.getElementById("cp-themeProvider");
   if (themeSel) themeSel.addEventListener("change", onKnobChanged);
+  // Detected-feature toggles (Keyboard focus) re-render on the daemon like a knob — same routing,
+  // never the wasm auto-enable path.
+  document.querySelectorAll(".cp-feature").forEach(function (el) {
+    el.addEventListener("change", onKnobChanged);
+  });
   refreshSnapshot();
 })();</script>
       <script>(function () {

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-themes.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-themes.html
@@ -187,6 +187,7 @@ a:hover { text-decoration: underline; }
   <label class="cp-live-row"><input class="cp-overlay" id="cp-touchOverlay" type="checkbox" disabled> Show touches</label>
 </div>
           
+          
                 <div class="cp-links">
         <div class="cp-knobs-head">Direct links — the current view as a URL (overrides applied)</div>
         <div class="cp-link-row">
@@ -298,6 +299,10 @@ a:hover { text-decoration: underline; }
     // control is live; "(default)" (empty) leaves the daemon on the preview's own wrapper.
     var tp = document.getElementById("cp-themeProvider");
     if (tp && !tp.disabled && tp.value) o["themeProvider"] = tp.value;
+    // Detected-feature: keyboard focus. Checked ⇒ focus the first focusable + draw the overlay
+    // (focus=0). Daemon-only, so skipped when disabled.
+    var fc = document.getElementById("cp-focus");
+    if (fc && !fc.disabled && fc.checked) o["focus"] = "0";
     return o;
   }
   function query() {
@@ -328,6 +333,10 @@ a:hover { text-decoration: underline; }
     if (tp && !tp.disabled && tp.value) {
       parts.push("themeProvider=" + encodeURIComponent(tp.value));
     }
+    // Detected-feature: keyboard focus (focus=0). Routes to the daemon like a knob; omitted when
+    // unchecked so the URL stays on the baked snapshot.
+    var fc = document.getElementById("cp-focus");
+    if (fc && !fc.disabled && fc.checked) parts.push("focus=0");
     return parts.join("&");
   }
   function refreshSnapshot() {
@@ -816,6 +825,11 @@ a:hover { text-decoration: underline; }
   // load), so it shares onKnobChanged rather than onControlsChanged.
   var themeSel = document.getElementById("cp-themeProvider");
   if (themeSel) themeSel.addEventListener("change", onKnobChanged);
+  // Detected-feature toggles (Keyboard focus) re-render on the daemon like a knob — same routing,
+  // never the wasm auto-enable path.
+  document.querySelectorAll(".cp-feature").forEach(function (el) {
+    el.addEventListener("change", onKnobChanged);
+  });
   refreshSnapshot();
 })();</script>
       <script>(function () {

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
@@ -179,6 +179,7 @@ a:hover { text-decoration: underline; }
   <label class="cp-live-row"><input class="cp-overlay" id="cp-touchOverlay" type="checkbox" disabled> Show touches</label>
 </div>
           
+          
                 <div class="cp-links">
         <div class="cp-knobs-head">Direct links — the current view as a URL (overrides applied)</div>
         <div class="cp-link-row">
@@ -290,6 +291,10 @@ a:hover { text-decoration: underline; }
     // control is live; "(default)" (empty) leaves the daemon on the preview's own wrapper.
     var tp = document.getElementById("cp-themeProvider");
     if (tp && !tp.disabled && tp.value) o["themeProvider"] = tp.value;
+    // Detected-feature: keyboard focus. Checked ⇒ focus the first focusable + draw the overlay
+    // (focus=0). Daemon-only, so skipped when disabled.
+    var fc = document.getElementById("cp-focus");
+    if (fc && !fc.disabled && fc.checked) o["focus"] = "0";
     return o;
   }
   function query() {
@@ -320,6 +325,10 @@ a:hover { text-decoration: underline; }
     if (tp && !tp.disabled && tp.value) {
       parts.push("themeProvider=" + encodeURIComponent(tp.value));
     }
+    // Detected-feature: keyboard focus (focus=0). Routes to the daemon like a knob; omitted when
+    // unchecked so the URL stays on the baked snapshot.
+    var fc = document.getElementById("cp-focus");
+    if (fc && !fc.disabled && fc.checked) parts.push("focus=0");
     return parts.join("&");
   }
   function refreshSnapshot() {
@@ -808,6 +817,11 @@ a:hover { text-decoration: underline; }
   // load), so it shares onKnobChanged rather than onControlsChanged.
   var themeSel = document.getElementById("cp-themeProvider");
   if (themeSel) themeSel.addEventListener("change", onKnobChanged);
+  // Detected-feature toggles (Keyboard focus) re-render on the daemon like a knob — same routing,
+  // never the wasm auto-enable path.
+  document.querySelectorAll(".cp-feature").forEach(function (el) {
+    el.addEventListener("change", onKnobChanged);
+  });
   refreshSnapshot();
 })();</script>
       <script>(function () {

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
@@ -175,6 +175,7 @@ a:hover { text-decoration: underline; }
           </label>
           
           
+          
                 <div class="cp-links">
         <div class="cp-knobs-head">Direct links — the current view as a URL (overrides applied)</div>
         <div class="cp-link-row">
@@ -286,6 +287,10 @@ a:hover { text-decoration: underline; }
     // control is live; "(default)" (empty) leaves the daemon on the preview's own wrapper.
     var tp = document.getElementById("cp-themeProvider");
     if (tp && !tp.disabled && tp.value) o["themeProvider"] = tp.value;
+    // Detected-feature: keyboard focus. Checked ⇒ focus the first focusable + draw the overlay
+    // (focus=0). Daemon-only, so skipped when disabled.
+    var fc = document.getElementById("cp-focus");
+    if (fc && !fc.disabled && fc.checked) o["focus"] = "0";
     return o;
   }
   function query() {
@@ -316,6 +321,10 @@ a:hover { text-decoration: underline; }
     if (tp && !tp.disabled && tp.value) {
       parts.push("themeProvider=" + encodeURIComponent(tp.value));
     }
+    // Detected-feature: keyboard focus (focus=0). Routes to the daemon like a knob; omitted when
+    // unchecked so the URL stays on the baked snapshot.
+    var fc = document.getElementById("cp-focus");
+    if (fc && !fc.disabled && fc.checked) parts.push("focus=0");
     return parts.join("&");
   }
   function refreshSnapshot() {
@@ -804,6 +813,11 @@ a:hover { text-decoration: underline; }
   // load), so it shares onKnobChanged rather than onControlsChanged.
   var themeSel = document.getElementById("cp-themeProvider");
   if (themeSel) themeSel.addEventListener("change", onKnobChanged);
+  // Detected-feature toggles (Keyboard focus) re-render on the daemon like a knob — same routing,
+  // never the wasm auto-enable path.
+  document.querySelectorAll(".cp-feature").forEach(function (el) {
+    el.addEventListener("change", onKnobChanged);
+  });
   refreshSnapshot();
 })();</script>
       <script>(function () {


### PR DESCRIPTION
## Summary

The last Part-3 piece: **per-preview detected-feature controls** — surface a feature control *only* for previews that actually support it, never as a dead control everywhere. The first concrete one is **Keyboard focus** for a `@FocusedPreview` preview.

The two candidate features split on backend support: **focus renders on the desktop daemon** (so it's demonstrable on `serve`), while **gestures are Android-only** (the desktop daemon behind `serve` silently ignores `overrides.gestures`). So this ships the focus control and *detects* gestures for a future Android-gated control, rather than offering a gesture toggle that would do nothing on the desktop catalog.

## Layers

- **Detection** — the cli `:preview-data-api` `Capture` now models the presence of the `@FocusedPreview` (`focus` / `focusGif`) and `@GestureHintPreview` (`gestureHint`) capture blocks as opaque `JsonElement`s (enough to know *whether* a preview supports the feature, without dragging the discovery types into the API). `detectedFeaturesOf` folds them across a preview's captures into two `ServePreview` flags — `supportsFocus` / `supportsGestures` — populated at all three build sites (direct `serve`, revision builder, catalog bundle).
- **Viewer** — a "Detected features" group with a "Keyboard focus" checkbox appears **only** when the preview `supportsFocus`, gated to daemon-capable sessions (routed like a knob via `onKnobChanged`, never the wasm auto-enable path). Checking it re-renders with `focus=0` — focus landed on the first focusable plus the focus overlay drawn.
- **ServeOverrides** — parses `focus=<tabIndex>` into `FocusOverride(tabIndex, overlay = true)` (a non-negative int; malformed is a hard `Invalid`) and folds it into the render cache key.

## Test plan

- `./gradlew :cli:test --tests '*ServeOverridesTest*'` — `focus=2` → `FocusOverride(tabIndex=2, overlay=true)`; bad values rejected; cache-key participates.
- `./gradlew :cli:test --tests '*ServeFeatureDetectionTest*'` — `detectedFeaturesOf` flags focus/gestures from the right capture blocks and folds across captures.
- `./gradlew :cli:test --tests '*ServeWebFixtureTest*'` — a new `serve-viewer-focus` golden fixture (wired into the visual-diff bot) shows the "Keyboard focus" control for a focus preview and asserts it's **absent** for an ordinary one.

The daemon's application of `FocusOverride` (the focus overlay render) is existing, separately-tested behaviour in the `data/focus` modules; this PR's job is detect → parse → route → gate, which the above cover.

## Visual evidence

The **Detected features** group with **Keyboard focus** — shown only for a `@FocusedPreview`-detected preview, enabled on a daemon session (`serve-viewer-focus` fixture, rendered + diffed by the CI bot):

<img src="https://raw.githubusercontent.com/yschimke/compose-ai-tools/42e1688c61dcdbaae3528841099f89372aa5503d/renders/serve-viewer-focus.light.png" width="360">

---
_Generated by [Claude Code](https://claude.ai/code/session_01MkDr2hzvkuW9yrs16eFCyj)_