### PR TITLE
fix(wear): freeze GestureGalleryPreview clock with FixedPreviewTimeSource

### DIFF
--- a/samples/wear/src/main/kotlin/com/example/samplewear/Gestures.kt
+++ b/samples/wear/src/main/kotlin/com/example/samplewear/Gestures.kt
@@ -95,10 +95,13 @@ object GestureRoutes {
 
 @Composable
 fun GestureGalleryApp(
-  navController: NavHostController = rememberSwipeDismissableNavController()
+  navController: NavHostController = rememberSwipeDismissableNavController(),
+  // Real production app — let TimeText use the system clock. Previews that want a
+  // deterministic time supply a `FixedPreviewTimeSource` (see [GestureGalleryPreview]).
+  timeText: @Composable () -> Unit = { TimeText() },
 ) {
   MaterialTheme {
-    AppScaffold(timeText = { TimeText() }) {
+    AppScaffold(timeText = timeText) {
       SwipeDismissableNavHost(
         navController = navController,
         startDestination = GestureRoutes.HOME,
@@ -560,7 +563,7 @@ fun PageIndicatorStickerPreview() {
 @WearPreviewLargeRound
 @Composable
 fun GestureGalleryPreview() {
-  GestureGalleryApp()
+  GestureGalleryApp(timeText = { TimeText(timeSource = FixedPreviewTimeSource) })
 }
 
 @WearPreviewLargeRound


### PR DESCRIPTION
## Summary

`GestureGalleryPreview` rendered `GestureGalleryApp()`, whose `AppScaffold` used `timeText = { TimeText() }` — the **real system clock**. The preview's status strip therefore drew a different time on every render, making its visual diff non-deterministic (flaky).

This applies the pattern already used by the sibling previews in `Previews.kt` (`ActivityListPreview`, etc.):

- Add a `timeText: @Composable () -> Unit = { TimeText() }` parameter to `GestureGalleryApp` so production still uses the system clock by default.
- Have `GestureGalleryPreview` inject the existing `FixedPreviewTimeSource`, freezing the clock to `10:10` — the same fixed time every other Wear preview in this module already uses.

## Visual evidence

This change is a **determinism-only fix**: the sole visual delta is the status clock now reading a stable `10:10` instead of the wall-clock time — i.e. it removes the flakiness rather than altering the UI. No render PNG is embedded here because the change was authored in a headless container with no Android SDK, so the `@Preview` couldn't be rendered locally; the CI visual-diff bot (which has the SDK) will render and diff `GestureGalleryPreview` on this PR.

## Test plan

- [ ] CI visual-diff bot renders `GestureGalleryPreview` and shows the frozen `10:10` clock, with no other visual change vs. base.
- [ ] `:samples:wear` compiles (verified pattern; local compile blocked by absent Android SDK).

---
_Generated by [Claude Code](https://claude.ai/code/session_019nhp3ujAhTni7a28N8ShhS)_