### PR TITLE
fix(figma-svg): honor Modifier.paint alpha and colorFilter in fill tokens

### DIFF
--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopLayoutInspectorTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopLayoutInspectorTest.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.ImageComposeScene
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.paint
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.painter.BitmapPainter
 import androidx.compose.ui.graphics.painter.ColorPainter
@@ -145,5 +146,42 @@ class DesktopLayoutInspectorTest {
 
     val anyBackground = root.firstWhere { it.tokens?.backgroundColor != null }
     assertTrue("a bitmap painter must not resolve to a background token", anyBackground == null)
+  }
+
+  @Test
+  fun folds_paint_alpha_into_the_resolved_background_token() {
+    // `Modifier.paint(painter, alpha = …)` scales the painter's opacity at draw time, so a
+    // half-alpha fill must export as a half-alpha colour rather than an opaque rectangle.
+    val root = writeAndRead {
+      Box(
+        Modifier.testTag("faded")
+          .size(40.dp, 40.dp)
+          .paint(ColorPainter(Color(0xFFFF0000)), alpha = 0.5f)
+      )
+    }
+
+    // 0xFF * 0.5 = 127.5 → 0x80 alpha over the opaque red.
+    val faded = root.firstWhere { it.tokens?.backgroundColor == "#80FF0000" }
+    assertNotNull("Modifier.paint alpha must fold into the resolved background alpha", faded)
+  }
+
+  @Test
+  fun skips_a_color_filtered_paint_fill() {
+    // A `colorFilter` re-tints the painter at draw time; a flat `#AARRGGBB` token can't reproduce
+    // that, so a filtered paint stays unresolved rather than exporting the wrong, unfiltered
+    // colour.
+    val root = writeAndRead {
+      Box(
+        Modifier.testTag("tinted")
+          .size(40.dp, 40.dp)
+          .paint(ColorPainter(Color(0xFFFF0000)), colorFilter = ColorFilter.tint(Color(0xFF00FF00)))
+      )
+    }
+
+    val anyBackground = root.firstWhere { it.tokens?.backgroundColor != null }
+    assertTrue(
+      "a colour-filtered paint must not resolve to a flat background",
+      anyBackground == null,
+    )
   }
 }

--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ModifierTokenResolver.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ModifierTokenResolver.kt
@@ -89,7 +89,7 @@ internal object ModifierTokenResolver {
       // the `ColorPainter`'s colour as the fill; bitmap/vector painters (an `Image`/`Icon`'s art)
       // stay unresolved so they keep to the raster path (issue #1985).
       if (backgroundColor == null && (name == "paint" || simpleName == "PainterElement")) {
-        backgroundColor = painterColorHex(elements["painter"], mod)
+        backgroundColor = painterColorHex(elements, mod)
       }
       // `Modifier.defaultMinSize(minWidth, minHeight)` — an M3 `Badge` measures its background at
       // this min box even when its narrow content is placed smaller, so the figma-svg export grows
@@ -248,31 +248,65 @@ internal object ModifierTokenResolver {
   }
 
   /**
-   * Resolves a painter-based container fill (`Modifier.paint(painter)`) as ARGB hex. Only a solid
-   * [androidx.compose.ui.graphics.painter.ColorPainter] yields a colour — the fill Wear M3 surfaces
-   * apply for their container — while bitmap / vector / gradient painters (an `Image`/`Icon`'s art)
-   * return null so they stay on the raster path rather than collapsing to a bogus flat rectangle.
-   * Reads the inspector `painter` element (the live painter object) when present, else reflects the
-   * element's backing `painter` field; the `ColorPainter`'s `color` is a [Color] value class stored
-   * as its packed `ULong`, decoded exactly like [backgroundColorHex].
+   * Resolves a painter-based container fill (`Modifier.paint(painter, alpha, colorFilter)`) as ARGB
+   * hex. Only a solid [androidx.compose.ui.graphics.painter.ColorPainter] yields a colour — the
+   * fill Wear M3 surfaces apply for their container — while bitmap / vector / gradient painters (an
+   * `Image`/`Icon`'s art) return null so they stay on the raster path rather than collapsing to a
+   * bogus flat rectangle.
+   *
+   * `Modifier.paint` also carries an `alpha` multiplier and an optional `colorFilter` that Compose
+   * applies at draw time ([androidx.compose.ui.draw.PainterElement]; the wear `surface()` element
+   * carries neither). A `colorFilter` re-tints the fill in ways a flat `#AARRGGBB` can't represent,
+   * so a filtered paint is skipped entirely; the `alpha` is folded into the emitted colour's alpha
+   * channel so a semi-transparent paint doesn't export as an opaque rectangle. Both are read from
+   * the inspector [elements] when present, else reflected off the element's backing fields, and
+   * both default to their no-op values (alpha 1, no filter) when the element doesn't expose them.
    */
-  private fun painterColorHex(painterElement: Any?, mod: Any): String? {
+  private fun painterColorHex(elements: Map<String, Any?>, mod: Any): String? {
+    // A colorFilter re-tints the painter at draw time — a flat fill token can't reproduce it.
+    val colorFilter =
+      elements["colorFilter"]
+        ?: runCatching {
+            mod.javaClass.getDeclaredField("colorFilter").apply { isAccessible = true }.get(mod)
+          }
+          .getOrNull()
+    if (colorFilter != null) return null
     val painter =
-      painterElement
+      elements["painter"]
         ?: runCatching {
             mod.javaClass.getDeclaredField("painter").apply { isAccessible = true }.get(mod)
           }
           .getOrNull()
         ?: return null
     if (painter.javaClass.simpleName != "ColorPainter") return null
-    return runCatching {
-        val field = painter.javaClass.getDeclaredField("color").apply { isAccessible = true }
-        val packed = field.getLong(painter).toULong()
-        if (packed and 0xFFFFFFFFuL != 0uL) return null
-        val argb = (packed shr 32).toInt()
-        if (argb == 0) null else "#${String.format(Locale.US, "%08X", argb)}"
+    val baseArgb =
+      runCatching {
+          val field = painter.javaClass.getDeclaredField("color").apply { isAccessible = true }
+          val packed = field.getLong(painter).toULong()
+          if (packed and 0xFFFFFFFFuL != 0uL) return null
+          (packed shr 32).toInt()
+        }
+        .getOrNull() ?: return null
+    if (baseArgb == 0) return null
+    // Fold `Modifier.paint`'s alpha multiplier into the colour's alpha channel (default 1 =
+    // opaque).
+    val alpha =
+      (floatValue(elements["alpha"])
+          ?: runCatching {
+              mod.javaClass.getDeclaredField("alpha").apply { isAccessible = true }.getFloat(mod)
+            }
+            .getOrNull()
+          ?: 1f)
+        .coerceIn(0f, 1f)
+    val argb =
+      if (alpha >= 1f) baseArgb
+      else {
+        val a = ((baseArgb ushr 24) and 0xFF) * alpha
+        val newA = a.roundToInt().coerceIn(0, 255)
+        if (newA == 0) return null
+        (baseArgb and 0x00FFFFFF) or (newA shl 24)
       }
-      .getOrNull()
+    return "#${String.format(Locale.US, "%08X", argb)}"
   }
 
   /**


### PR DESCRIPTION
## What & why

Follow-up to #2345 (wear painter-based container fills), addressing a Codex review comment on that PR.

The painter-fill resolver read a `ColorPainter`'s raw `color` unconditionally, ignoring the two draw-time modifiers `Modifier.paint` also carries:

- **`alpha`** — an opacity multiplier. A `paint(ColorPainter(c), alpha = 0.5f)` fill was exported as an opaque rectangle.
- **`colorFilter`** — a re-tint. A filtered paint was exported as the wrong, unfiltered colour.

## Fix

- Fold the paint `alpha` into the emitted colour's alpha channel (`A' = round(A × alpha)`; a result of 0 drops to null).
- Skip a `colorFilter`ed paint entirely — a flat `#AARRGGBB` token can't reproduce a filter, so it stays unresolved (raster path) rather than exporting a wrong colour.

Both are read from the inspector `elements` when present, else reflected off the element's backing fields, and default to their no-op values (`alpha 1`, no filter). The wear `surface()` `PainterElement` carries **neither** field (its constructor is `(Painter, ContentScale, Alignment)`), so the actual wear fills from #2345 are unaffected — this only tightens the general `Modifier.paint` case.

## Test plan
- New desktop unit tests: `paint(ColorPainter(0xFFFF0000), alpha = 0.5f)` → `#80FF0000`; a `ColorFilter.tint(...)`ed paint resolves to no background token.
- Existing painter tests (solid fill resolves, bitmap fill stays raster) still green.
- `:daemon:desktop:test` green; ktfmt clean.

No visual evidence: no wear/catalog surface currently uses an alpha'd or filtered `Modifier.paint`, so there's no rendered before/after — this is a correctness guard for the general case, verified by unit tests.

_Generated by [Claude Code](https://claude.ai/code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_014nC2f2D5MWRPnJeqnrrq5Y)_