### PR TITLE
fix(daemon): don't wrap a preview whose params are unknown (null block)

### DIFF
--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -474,13 +474,18 @@ private fun previewIndexBackedSpecResolver(previewIndex: PreviewIndex): ((String
 internal fun renderSpecFromInfo(info: PreviewInfoDto): RenderSpec {
   val defaults =
     RenderSpec(previewId = info.id, className = info.className, functionName = info.methodName)
-  // A null params block is treated exactly like an empty one — every field falls back per-default,
-  // so (like the bake's [PreviewManifestEntry.resolved]) a no-size preview wraps whether it carried
-  // an empty params block or none at all.
-  val params = info.params
-  val density = params?.density ?: defaults.density
-  val explicitWidthPx = params?.widthDp?.let { (it * density).toInt() }
-  val explicitHeightPx = params?.heightDp?.let { (it * density).toInt() }
+  // A *missing* params block means "params unknown", NOT "params empty" — the incremental
+  // source-change path (IncrementalDiscovery.toDto → PreviewIndex.applyDiff) replaces an edited
+  // preview's index entry with a DTO that carries no params until the next full rediscovery. So a
+  // null block must fall back to the fixed-frame defaults (no wrap): treating it as an explicit
+  // empty block would make an edited preview that actually declares widthDp / device / showSystemUi
+  // briefly render wrap-cropped at the 400×800 sandbox after every save, then snap back once params
+  // return. Only a *present* params block drives the wrap decision below — a catalog sticker always
+  // carries one (it declares showBackground), so the PNG↔Live parity fix is unaffected.
+  val params = info.params ?: return defaults
+  val density = params.density ?: defaults.density
+  val explicitWidthPx = params.widthDp?.let { (it * density).toInt() }
+  val explicitHeightPx = params.heightDp?.let { (it * density).toInt() }
   // AS-parity wrap-content, mirroring the offline-bake / harness resolver
   // ([PreviewManifestEntry.resolved]). A preview that declares no explicit size on an axis and is
   // not pinned to a device frame renders wrap-content on that axis: the held-session/stream render
@@ -491,7 +496,7 @@ internal fun renderSpecFromInfo(info: PreviewInfoDto): RenderSpec {
   // device-pinned preview keeps its fixed frame (device sizing is applied downstream). Note the
   // interactive `PreviewParamsDto` carries no `showSystemUi`, so `pinned` is device-only here — a
   // catalog sticker declares neither, so it wraps.
-  val pinned = (params?.device ?: defaults.device) != null
+  val pinned = (params.device ?: defaults.device) != null
   val wrapWidth = explicitWidthPx == null && !pinned
   val wrapHeight = explicitHeightPx == null && !pinned
   val widthPx =
@@ -502,7 +507,7 @@ internal fun renderSpecFromInfo(info: PreviewInfoDto): RenderSpec {
     explicitHeightPx
       ?: if (wrapHeight) (PreviewManifestEntry.WRAP_SANDBOX_HEIGHT_DP * density).toInt()
       else defaults.heightPx
-  val uiMode = if (uiModeIsNight(params?.uiMode)) RenderSpec.SpecUiMode.DARK else defaults.uiMode
+  val uiMode = if (uiModeIsNight(params.uiMode)) RenderSpec.SpecUiMode.DARK else defaults.uiMode
   return RenderSpec(
     previewId = info.id,
     className = info.className,
@@ -512,17 +517,17 @@ internal fun renderSpecFromInfo(info: PreviewInfoDto): RenderSpec {
     wrapWidth = wrapWidth,
     wrapHeight = wrapHeight,
     density = density,
-    showBackground = params?.showBackground ?: defaults.showBackground,
-    backgroundColor = params?.backgroundColor ?: defaults.backgroundColor,
-    device = params?.device ?: defaults.device,
+    showBackground = params.showBackground ?: defaults.showBackground,
+    backgroundColor = params.backgroundColor ?: defaults.backgroundColor,
+    device = params.device ?: defaults.device,
     outputBaseName = defaults.outputBaseName,
-    localeTag = params?.locale ?: defaults.localeTag,
-    fontScale = params?.fontScale ?: defaults.fontScale,
+    localeTag = params.locale ?: defaults.localeTag,
+    fontScale = params.fontScale ?: defaults.fontScale,
     uiMode = uiMode,
     orientation = defaults.orientation,
-    wrapperClassName = params?.wrapperClassName ?: defaults.wrapperClassName,
-    kind = params?.kind ?: defaults.kind,
-    assetPath = params?.assetPath ?: defaults.assetPath,
+    wrapperClassName = params.wrapperClassName ?: defaults.wrapperClassName,
+    kind = params.kind ?: defaults.kind,
+    assetPath = params.assetPath ?: defaults.assetPath,
   )
 }
 

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/RenderSpecFromInfoTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/RenderSpecFromInfoTest.kt
@@ -12,10 +12,12 @@ import org.junit.Test
  * standing up a [PreviewIndex] or threading an inputs lambda through.
  *
  * Coverage matrix (one assertion clump per row):
- * - No size + no device (or an empty / absent params block) ⇒ wrap-content on both axes at the
- *   400×800 dp sandbox bound, mirroring the bake ([PreviewManifestEntry.resolved]) so a catalog
- *   sticker's live stream matches its wrap-cropped baked snapshot instead of shifting.
- * - Empty params block ⇒ identical to passing no block at all (both wrap).
+ * - A present, no-size, no-device params block ⇒ wrap-content on both axes at the 400×800 dp
+ *   sandbox bound, mirroring the bake ([PreviewManifestEntry.resolved]) so a catalog sticker's live
+ *   stream matches its wrap-cropped baked snapshot instead of shifting.
+ * - A *null* (absent) params block ⇒ "params unknown" ⇒ the fixed 320² frame, wrap OFF — so an
+ *   incrementally-rediscovered preview (whose DTO carries no params) doesn't briefly wrap-crop.
+ * - Null ≠ empty: only the present-but-empty block wraps.
  * - An explicit `device` ⇒ pinned: neither axis wraps, px dims fall back to defaults.
  * - `widthDp` / `heightDp` / `density` set ⇒ pixel dimensions multiply through and wrap is off.
  * - `density` defaulted ⇒ default 2.0x is used for the dp→px conversion of `widthDp`.
@@ -30,12 +32,13 @@ class RenderSpecFromInfoTest {
 
   @Test
   fun `no-size no-device preview wraps to content in the sandbox bound`() {
-    // A preview that declares neither an explicit size nor a device (a catalog sticker) renders
+    // A preview whose (present) params block declares neither an explicit size nor a device (a
+    // catalog sticker — it always carries params because it declares showBackground) renders
     // wrap-content, mirroring the offline bake (PreviewManifestEntry.resolved): both axes wrap and
     // the px dims are the 400x800 dp sandbox bound (× default 2x density), so the held-session /
     // stream render crops to the composable's intrinsic size instead of leaving it small in the
     // top-left of the old fixed 320² frame.
-    val spec = renderSpecFromInfo(info(params = null))
+    val spec = renderSpecFromInfo(info(params = PreviewParamsDto()))
     assertEquals(true, spec.wrapWidth)
     assertEquals(true, spec.wrapHeight)
     assertEquals(PreviewManifestEntry.WRAP_SANDBOX_WIDTH_DP * 2, spec.widthPx)
@@ -51,19 +54,30 @@ class RenderSpecFromInfoTest {
   }
 
   @Test
-  fun `empty params block is identical to null params`() {
+  fun `a null params block falls back to the fixed frame and never wraps`() {
+    // A *missing* params block means "params unknown", not "params empty": the incremental
+    // source-change path (IncrementalDiscovery.toDto → PreviewIndex.applyDiff) swaps an edited
+    // preview's index entry for a DTO carrying no params until the next full rediscovery. Treating
+    // that as an empty block would make an edited preview that actually declares a size / device
+    // briefly wrap-crop at the sandbox bound after every save. So a null block must stay on the
+    // fixed 320² frame with wrap OFF — the regression guard for that window.
+    val spec = renderSpecFromInfo(info(params = null))
+    assertEquals(false, spec.wrapWidth)
+    assertEquals(false, spec.wrapHeight)
+    assertEquals(320, spec.widthPx)
+    assertEquals(320, spec.heightPx)
+    assertNull(spec.device)
+  }
+
+  @Test
+  fun `a null params block differs from an empty one — only the empty block wraps`() {
     val nullSpec = renderSpecFromInfo(info(params = null))
     val emptySpec = renderSpecFromInfo(info(params = PreviewParamsDto()))
-    // Same shape; we don't compare data classes directly because outputBaseName is computed on
-    // both sides identically. A null block is treated exactly like an empty one — both wrap.
-    assertEquals(nullSpec.widthPx, emptySpec.widthPx)
-    assertEquals(nullSpec.heightPx, emptySpec.heightPx)
-    assertEquals(nullSpec.wrapWidth, emptySpec.wrapWidth)
-    assertEquals(nullSpec.wrapHeight, emptySpec.wrapHeight)
-    assertEquals(nullSpec.density, emptySpec.density, 0.0f)
-    assertEquals(nullSpec.uiMode, emptySpec.uiMode)
-    assertEquals(nullSpec.localeTag, emptySpec.localeTag)
-    assertEquals(nullSpec.fontScale, emptySpec.fontScale)
+    // Present-but-empty ⇒ wrap-content (a no-size sticker); absent ⇒ unknown params ⇒ fixed frame.
+    assertEquals(false, nullSpec.wrapWidth)
+    assertEquals(true, emptySpec.wrapWidth)
+    assertEquals(320, nullSpec.widthPx)
+    assertEquals(PreviewManifestEntry.WRAP_SANDBOX_WIDTH_DP * 2, emptySpec.widthPx)
   }
 
   @Test


### PR DESCRIPTION
## Summary

Follow-up to #2369 (PNG ↔ Live Compose size-shift fix), addressing a valid Codex P2 on that PR.

That change made `renderSpecFromInfo` treat a **null** params block like an **empty** one, so a *missing* params block wrapped-to-content. But a null block doesn't mean "no params declared" — it means **"params unknown"**: the incremental source-change path (`IncrementalDiscovery.toDto` builds a `PreviewInfoDto` with **no** `params`, and `PreviewIndex.applyDiff` replaces the edited preview's index entry with it) strips params until the next full rediscovery. So an edited preview that actually declares `widthDp` / `device` / `showSystemUi` would briefly render **wrap-cropped at the 400×800 dp sandbox** after every file save, then snap back to its real frame once params return — a jarring size/crop flicker in the VS Code live-edit loop.

## Fix

Treat a null (absent) params block as "params unknown" → the fixed 320² frame with **wrap OFF**; only a *present* params block drives the wrap decision. A catalog sticker always carries a params block (it declares `showBackground`), so the PNG ↔ Live parity fix from #2369 is **unaffected** — the size-shift stays fixed.

## Test plan

- `./gradlew :daemon:desktop:test --tests '*RenderSpecFromInfoTest*'` — new coverage: a **null** params block ⇒ fixed 320² frame, wrap off (the regression guard for the incremental-edit window); a present-but-**empty** block ⇒ wraps; `null ≠ empty`. Existing wrap / pinned / explicit-size cases updated to use a present params block.
- `./gradlew :daemon:desktop:test --tests '*RenderEngineWrapContentTest*'` — the #2369 crop-parity render test still passes (it constructs the `RenderSpec` directly, unaffected).

This is a non-visual edge-case fix — it only restores the prior fixed-frame behavior for the transient unknown-params window; catalog rendering (params always present) is unchanged, and the rendered-pixel before/after lives in #2369.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MkDr2hzvkuW9yrs16eFCyj)_