### PR TITLE
fix(daemon): preserve prior @Preview params across incremental diffs

### DIFF
--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewIndex.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewIndex.kt
@@ -67,9 +67,15 @@ data class PreviewInfoDto(
   /**
    * Display-property block sourced from the gradle plugin's `PreviewParams`. Optional — fixtures
    * predating issue #420 omit it; the v2 interactive resolver falls back to its built-in defaults
-   * for every absent sub-field (per-field, not per-block). The block is also tracked by [diff], so
-   * a `widthDp =` edit on an existing `@Preview` shows up as a `changed` entry on the next
-   * incremental rescan.
+   * for every absent sub-field (per-field, not per-block).
+   *
+   * The incremental source-change scan ([IncrementalDiscovery.toDto]) rebuilds a preview's DTO from
+   * the class file alone and cannot recover this block, so it emits `params == null` — which reads
+   * as `changed` against a prior that carried params. To avoid dropping a preview's known size on
+   * every edit (which flips the desktop interactive render between wrap-content and the fixed 320²
+   * frame), [applyDiff] carries the prior `params` forward when an incoming `changed` DTO omits
+   * them. A genuine `@Preview(widthDp = …)` edit is therefore reflected only on the next FULL
+   * rediscovery (which re-parses `previews.json`), not on the incremental class-file rescan.
    */
   val params: PreviewParamsDto? = null,
   /**
@@ -359,7 +365,24 @@ internal constructor(
     lock.write {
       for (id in diff.removed) byId.remove(id)
       for (dto in diff.added) byId[dto.id] = dto
-      for (dto in diff.changed) byId[dto.id] = dto
+      // The incremental source-change scan (IncrementalDiscovery.toDto) rebuilds a preview's DTO
+      // from the class file alone, which can't recover the display `params` block (@Preview
+      // widthDp / heightDp / device / showSystemUi / …) — so a `changed` DTO always arrives with
+      // `params == null`. Blindly replacing the entry would strip the preview's known size until
+      // the
+      // next FULL rediscovery, which flips the desktop interactive/stream render between the
+      // wrap-content sandbox and the fixed 320² frame on every save (the PNG↔Live "size shift"
+      // after
+      // an edit, from both #2369/#2370's null-params handling). Carry the prior entry's params
+      // forward when the incoming DTO omits them, so an edited preview keeps its real size and the
+      // wrap decision stays correct in both directions. A genuine `@Preview(widthDp = …)` edit is
+      // (still) only reflected on the next full rediscovery — the class-file rescan can't see it
+      // either way — but keeping the last-known size is strictly better than nulling it.
+      for (dto in diff.changed) {
+        val prior = byId[dto.id]
+        byId[dto.id] =
+          if (dto.params == null && prior?.params != null) dto.copy(params = prior.params) else dto
+      }
     }
   }
 

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewIndex.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewIndex.kt
@@ -70,12 +70,14 @@ data class PreviewInfoDto(
    * for every absent sub-field (per-field, not per-block).
    *
    * The incremental source-change scan ([IncrementalDiscovery.toDto]) rebuilds a preview's DTO from
-   * the class file alone and cannot recover this block, so it emits `params == null` — which reads
-   * as `changed` against a prior that carried params. To avoid dropping a preview's known size on
-   * every edit (which flips the desktop interactive render between wrap-content and the fixed 320²
-   * frame), [applyDiff] carries the prior `params` forward when an incoming `changed` DTO omits
-   * them. A genuine `@Preview(widthDp = …)` edit is therefore reflected only on the next FULL
-   * rediscovery (which re-parses `previews.json`), not on the incremental class-file rescan.
+   * the class file alone and cannot recover this block, so it emits `params == null`. Two places
+   * cooperate so this doesn't drop a preview's known size on every edit (which would flip the
+   * desktop interactive render between wrap-content and the fixed 320² frame): [diff] normalizes a
+   * null-params rescan to the prior's params before deciding `changed`, so a params-only rescan
+   * isn't reported at all; and when a *real* field change happens to also carry null params,
+   * [applyDiff] carries the prior `params` forward. A genuine `@Preview(widthDp = …)` edit is
+   * therefore reflected only on the next FULL rediscovery (which re-parses `previews.json`), not on
+   * the incremental class-file rescan.
    */
   val params: PreviewParamsDto? = null,
   /**
@@ -339,7 +341,19 @@ internal constructor(
     return lock.read {
       val newById = newScanForFile.associateBy { it.id }
       val added = newScanForFile.filter { it.id !in byId }
-      val changed = newScanForFile.filter { fresh -> byId[fresh.id]?.let { it != fresh } == true }
+      val changed = newScanForFile.filter { fresh ->
+        val prior = byId[fresh.id] ?: return@filter false
+        // The incremental source-change scan ([IncrementalDiscovery.toDto]) can't recover the
+        // `params` block, so it always returns `params == null`. On its own that must NOT read as
+        // a change — otherwise every save of any preview in the file re-reports it as `changed`
+        // forever (params never come back on the class-file rescan), so the daemon emits
+        // `discoveryUpdated` + the client re-reconciles on every keystroke-save. Normalize a
+        // null-params rescan to the prior's params before comparing — matching what [applyDiff]
+        // stores — so an otherwise-identical rescan is empty and only a *real* field change
+        // (displayName / group / a genuinely different params block) is reported.
+        val normalized = if (fresh.params == null) fresh.copy(params = prior.params) else fresh
+        normalized != prior
+      }
       // Removed scopes to ids whose previous DTO claimed `sourceFile` matches the saved path.
       // Without this scoping, a scan returning 0 previews for one file would mis-remove every
       // preview in the index (including those owned by sibling files).

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/PreviewIndexDiffTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/PreviewIndexDiffTest.kt
@@ -78,12 +78,13 @@ class PreviewIndexDiffTest {
   }
 
   @Test
-  fun `applyDiff preserves prior params when the incremental DTO omits them`() {
+  fun `a params-less rescan of an otherwise-identical preview is not a change`() {
     // The incremental source-change scan (IncrementalDiscovery.toDto) rebuilds a DTO from the class
-    // file alone, so it always arrives with params == null — which reads as a `changed` entry
-    // against a prior that carried a params block. applyDiff must carry the prior params forward,
-    // or the desktop interactive/stream render would lose the preview's known size after every save
-    // (flipping wrap-content ↔ the fixed 320² frame — the PNG↔Live "size shift").
+    // file alone, so it always arrives with params == null. That must NOT read as a change on its
+    // own — otherwise every save re-reports the preview as `changed` forever (params never come
+    // back
+    // on the class-file rescan), so the daemon emits `discoveryUpdated` + the client re-reconciles
+    // on every keystroke-save. diff() normalizes the null params to the prior's before comparing.
     val prior =
       PreviewInfoDto(
         id = "Sized",
@@ -92,31 +93,24 @@ class PreviewIndexDiffTest {
         sourceFile = "Sized.kt",
         params = PreviewParamsDto(widthDp = 200, device = "id:pixel_5"),
       )
-    val fresh =
-      PreviewInfoDto(
-        id = "Sized",
-        className = "com.example.SizedKt",
-        methodName = "Sized",
-        sourceFile = "Sized.kt",
-        params = null,
-      )
+    val fresh = prior.copy(params = null)
     val index = PreviewIndex.fromMap(path = null, byId = mapOf("Sized" to prior))
     val diff = index.diff(setOf(fresh), Path.of("Sized.kt"))
-    // The params-less rescan reads as a change (params differ from the prior)…
-    assertEquals(listOf("Sized"), diff.changed.map { it.id })
-
+    assertTrue(diff.added.isEmpty())
+    assertTrue(diff.removed.isEmpty())
+    assertTrue("a params-only null rescan must not be reported as changed", diff.changed.isEmpty())
+    assertTrue(discoveryDiffEmpty(diff))
+    // And the entry keeps its previously-discovered params (never nulled).
     index.applyDiff(diff)
-    // …but the committed entry keeps the previously-discovered params, not the null rescan.
-    val merged = index.byId("Sized")
-    assertEquals(200, merged?.params?.widthDp)
-    assertEquals("id:pixel_5", merged?.params?.device)
+    assertEquals(200, index.byId("Sized")?.params?.widthDp)
+    assertEquals("id:pixel_5", index.byId("Sized")?.params?.device)
   }
 
   @Test
-  fun `applyDiff keeps a present empty params block over a null rescan`() {
-    // The other direction: a no-size sticker carries a present-but-empty params block (it wraps).
-    // A params-less rescan must not drop it to null — that would flip the live render from
-    // wrap-content back to the fixed frame.
+  fun `a present empty params block is not dropped by a null rescan`() {
+    // A no-size sticker carries a present-but-empty params block (it wraps). A params-less rescan
+    // is
+    // not a change, and the block survives — so renderSpecFromInfo keeps wrapping it.
     val prior =
       PreviewInfoDto(
         id = "Sticker",
@@ -127,9 +121,32 @@ class PreviewIndexDiffTest {
       )
     val fresh = prior.copy(params = null)
     val index = PreviewIndex.fromMap(path = null, byId = mapOf("Sticker" to prior))
-    index.applyDiff(index.diff(setOf(fresh), Path.of("Sticker.kt")))
-    // The present (empty) block survives — so renderSpecFromInfo still wraps it.
+    val diff = index.diff(setOf(fresh), Path.of("Sticker.kt"))
+    assertTrue(diff.changed.isEmpty())
+    index.applyDiff(diff)
     assertEquals(PreviewParamsDto(), index.byId("Sticker")?.params)
+  }
+
+  @Test
+  fun `a real field change with null params is still reported and preserves params`() {
+    // A genuine change (displayName) alongside the incremental scan's null params IS a change — and
+    // applyDiff still carries the prior params forward, so the real edit lands without losing size.
+    val prior =
+      PreviewInfoDto(
+        id = "Sized",
+        className = "com.example.SizedKt",
+        methodName = "Sized",
+        sourceFile = "Sized.kt",
+        displayName = "X",
+        params = PreviewParamsDto(widthDp = 200),
+      )
+    val fresh = prior.copy(displayName = "Y", params = null)
+    val index = PreviewIndex.fromMap(path = null, byId = mapOf("Sized" to prior))
+    val diff = index.diff(setOf(fresh), Path.of("Sized.kt"))
+    assertEquals(listOf("Sized"), diff.changed.map { it.id })
+    index.applyDiff(diff)
+    assertEquals("Y", index.byId("Sized")?.displayName)
+    assertEquals(200, index.byId("Sized")?.params?.widthDp)
   }
 
   @Test

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/PreviewIndexDiffTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/PreviewIndexDiffTest.kt
@@ -78,6 +78,61 @@ class PreviewIndexDiffTest {
   }
 
   @Test
+  fun `applyDiff preserves prior params when the incremental DTO omits them`() {
+    // The incremental source-change scan (IncrementalDiscovery.toDto) rebuilds a DTO from the class
+    // file alone, so it always arrives with params == null — which reads as a `changed` entry
+    // against a prior that carried a params block. applyDiff must carry the prior params forward,
+    // or the desktop interactive/stream render would lose the preview's known size after every save
+    // (flipping wrap-content ↔ the fixed 320² frame — the PNG↔Live "size shift").
+    val prior =
+      PreviewInfoDto(
+        id = "Sized",
+        className = "com.example.SizedKt",
+        methodName = "Sized",
+        sourceFile = "Sized.kt",
+        params = PreviewParamsDto(widthDp = 200, device = "id:pixel_5"),
+      )
+    val fresh =
+      PreviewInfoDto(
+        id = "Sized",
+        className = "com.example.SizedKt",
+        methodName = "Sized",
+        sourceFile = "Sized.kt",
+        params = null,
+      )
+    val index = PreviewIndex.fromMap(path = null, byId = mapOf("Sized" to prior))
+    val diff = index.diff(setOf(fresh), Path.of("Sized.kt"))
+    // The params-less rescan reads as a change (params differ from the prior)…
+    assertEquals(listOf("Sized"), diff.changed.map { it.id })
+
+    index.applyDiff(diff)
+    // …but the committed entry keeps the previously-discovered params, not the null rescan.
+    val merged = index.byId("Sized")
+    assertEquals(200, merged?.params?.widthDp)
+    assertEquals("id:pixel_5", merged?.params?.device)
+  }
+
+  @Test
+  fun `applyDiff keeps a present empty params block over a null rescan`() {
+    // The other direction: a no-size sticker carries a present-but-empty params block (it wraps).
+    // A params-less rescan must not drop it to null — that would flip the live render from
+    // wrap-content back to the fixed frame.
+    val prior =
+      PreviewInfoDto(
+        id = "Sticker",
+        className = "com.example.StickerKt",
+        methodName = "Sticker",
+        sourceFile = "Sticker.kt",
+        params = PreviewParamsDto(),
+      )
+    val fresh = prior.copy(params = null)
+    val index = PreviewIndex.fromMap(path = null, byId = mapOf("Sticker" to prior))
+    index.applyDiff(index.diff(setOf(fresh), Path.of("Sticker.kt")))
+    // The present (empty) block survives — so renderSpecFromInfo still wraps it.
+    assertEquals(PreviewParamsDto(), index.byId("Sticker")?.params)
+  }
+
+  @Test
   fun `no-op — scan matches index exactly, diff is empty`() {
     val foo = preview("Foo", sourceFile = "Foo.kt", displayName = "Foo!")
     val index = PreviewIndex.fromMap(path = null, byId = mapOf("Foo" to foo))


### PR DESCRIPTION
## Summary

Root-cause follow-up to #2369 / #2370 (the PNG ↔ Live Compose "size shift"), resolving the tension both Codex P2s pointed at.

The incremental source-change scan (`IncrementalDiscovery.toDto`) rebuilds a preview's DTO from the class file alone and **cannot recover the display `params` block** (`@Preview widthDp / heightDp / device / showSystemUi / …`), so it always emits `params == null`. `PreviewIndex.applyDiff` then replaced the entry with that params-less DTO, **dropping the preview's known size** until the next full rediscovery — which made the desktop interactive/stream render flip between the wrap-content sandbox and the fixed 320² frame **on every file save**.

That's why #2369 and #2370 could each only half-fix it, in opposite directions:
- #2369 (`null → wrap`) kept no-size stickers correct but wrongly wrap-cropped **sized/device** previews after a save.
- #2370 (`null → fixed`) kept sized previews correct but reverted **no-size** stickers to the fixed frame after a save.

Neither null-handling choice can be right, because after a save the daemon simply **doesn't know** the preview's real size.

## Fix

Two cooperating changes so a params-less incremental rescan neither drops a preview's size nor churns:

1. **`applyDiff`** carries the **prior entry's `params` forward** when an incoming `changed` DTO omits them, so an edited preview keeps its real size and the wrap decision stays correct for **both** sized and no-size previews during the incremental-edit window.
2. **`diff`** normalizes a null-params rescan to the prior's params before deciding `changed`, so a params-only rescan is **not reported as a change** at all — otherwise every save re-emitted `discoveryUpdated` and the client re-reconciled the manifest on every keystroke-save (Codex P2).

A genuine `@Preview(widthDp = …)` edit is still only reflected on the next full rediscovery (the class-file rescan can't see it either way), but keeping the last-known size is strictly better than nulling it. #2370's `null → fixed` default stays as the safe fallback for a genuinely new preview added mid-edit (no prior params to preserve). Also corrects the `PreviewInfoDto.params` docstring, which claimed a `widthDp` edit "shows up as a changed entry on the next incremental rescan" — it can't, since the rescan drops params.

## Test plan

- `./gradlew :daemon:core:test --tests '*PreviewIndexDiffTest*'` — new coverage: a params-only null rescan of a **sized** preview (`widthDp` + `device`) is **not** reported as changed and keeps its params; a **present empty** params block survives a null rescan (no-size sticker keeps wrapping); a **real** `displayName` change alongside null params **is** reported and still preserves params. Existing diff/apply cases unchanged.
- `./gradlew :daemon:core:test` — full suite green apart from the pre-existing `InteractiveCoalescingTest` timing flake (reproduces on `main`, unrelated).

Non-visual change (daemon-internal preview-index behavior); the rendered before/after for the size-shift itself lives in #2369.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MkDr2hzvkuW9yrs16eFCyj)_