### PR TITLE
feat(serve): per-preview live-bundle host + FULL split publish (foundation)

### DIFF
--- a/.github/workflows/design-artifacts.yml
+++ b/.github/workflows/design-artifacts.yml
@@ -185,19 +185,30 @@ jobs:
             --source-module ":$SOURCE_MODULE"
 
       # Split the rendered sheet into one addressable, self-contained bundle per preview under
-      # `bundle/previews/<id>.png`. `--view-only` drops the re-render classpath (classes/app.jar +
-      # libs/) and keeps the baked image + every captured sidecar, so each sticker stays ~tens of KB
-      # — a consumer (a designer, design-parity) can fetch a single preview without pulling the whole
-      # catalog sheet. The sheet was packed `--with-semantics` above, so each per-preview bundle
-      # carries its own semantics / layout / figma-svg with no re-render and no daemon. Runs for
-      # every system (the live sheet itself is only published for the CMP tier).
+      # `bundle/previews/<id>.png`.
+      #
+      # The CMP tier (a `wasmModule` ⇒ a carried desktop `liveBundle`) splits **FULL**: each
+      # per-preview bundle carries its re-render classpath so `serve` can re-render that preview from
+      # its OWN bundle (ServePerPreviewLiveHost) — a `?knob.<key>=…` edit re-renders per preview
+      # instead of routing through one monolithic catalog daemon. Because the classpath is
+      # maven-coordinate (re-resolved at serve time) and fonts resolve from the shared `bundle/res`
+      # pool, a FULL split bundle stays small — only `classes/app.jar` repeats per preview.
+      #
+      # The Android tiers (wear-m3 / remote-m3) have no runnable desktop daemon, so they stay
+      # `--view-only`: the re-render classpath is dropped, keeping the baked image + every captured
+      # sidecar (semantics / layout / figma-svg, from the `--with-semantics` pack) at ~tens of KB —
+      # the right unit for an addressable, baked-only sticker.
       - name: Split into per-preview bundles
         env:
           SYSTEM: ${{ matrix.system }}
           EXTRA_RENDERS: ${{ matrix.androidExtraModule }}
+          # FULL for the CMP (live-bundle) tier, --view-only for the baked-only Android tiers.
+          SPLIT_MODE: ${{ matrix.wasmModule != '' && 'full' || 'view-only' }}
         run: |
           set -euo pipefail
-          compose-preview bundle split "$GITHUB_WORKSPACE/$SYSTEM-bundle.png" --view-only \
+          view_only_flag=""
+          [ "$SPLIT_MODE" = "view-only" ] && view_only_flag="--view-only"
+          compose-preview bundle split "$GITHUB_WORKSPACE/$SYSTEM-bundle.png" $view_only_flag \
             -o "$GITHUB_WORKSPACE/out/bundle/previews"
           # For compose-m3 the catalog also folds an Android-only supplement (the material3 inset
           # focus ring CMP can't draw), whose renders/semantics override same-named CMP functions in
@@ -207,6 +218,10 @@ jobs:
           # for an overridden function both the CMP and the (catalog-matching) Android sticker are
           # published. Collapsing to a single per-function bundle (dropping the superseded CMP one)
           # would need the export's function-name mapping and is a follow-up.
+          #
+          # Always --view-only: the supplement is Android-rendered, so there's no desktop daemon to
+          # re-render it (ServeBundleDaemon.materialize is desktop-only) — a FULL split would just
+          # carry an unusable Android classpath.
           if [ -n "${EXTRA_RENDERS:-}" ] && [ -f "$GITHUB_WORKSPACE/$SYSTEM-extra-bundle.png" ]; then
             compose-preview bundle split "$GITHUB_WORKSPACE/$SYSTEM-extra-bundle.png" --view-only \
               -o "$GITHUB_WORKSPACE/out/bundle/previews"

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogLiveRouting.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogLiveRouting.kt
@@ -1,0 +1,59 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.daemon.protocol.UiMode
+
+/**
+ * Shared override-routing logic for the two trusted-catalog live hosts:
+ * - [ServeCatalogLiveHost] — one monolithic `liveBundle` daemon serving every preview by id;
+ * - [ServePerPreviewLiveHost] — a daemon per per-preview bundle
+ *   (`bundle/previews/<daemon-id>.png`).
+ *
+ * Both front a baked catalog and re-render only the requests the baked PNG can't satisfy, mapping
+ * the catalog id to its daemon-preview id via the same alias. Extracted so the "does this override
+ * need a fresh render vs. the baked sticker?" predicate is defined once and can't drift between the
+ * two hosts.
+ */
+internal object CatalogLiveRouting {
+
+  /**
+   * The daemon-preview id to route an override [render][ServeHost.render] to, or null to stay
+   * baked. Non-null only when [previewId] is a mapped (daemon-renderable) id in [alias] AND the
+   * request carries an override the baked PNG can't satisfy ([overridesAffectRender]).
+   */
+  fun daemonIdForOverrideRender(
+    previewId: String,
+    overrides: PreviewOverrides,
+    alias: Map<String, String>,
+  ): String? {
+    // No daemon twin (an Android-only variant) ⇒ always baked; it has no live lane.
+    val daemonId = alias[previewId] ?: return null
+    return if (overridesAffectRender(previewId, overrides)) daemonId else null
+  }
+
+  /**
+   * Whether [o] would change pixels vs the preview's baked sticker, so the render must go to the
+   * daemon rather than replay the baked PNG. The baked variant already encodes its **theme** (the
+   * `…__light` / `…__dark` id segment) and every other axis at its discovery-time default, so a
+   * bare `uiMode` that matches the variant is a no-op and stays baked (keeping browsing instant);
+   * anything else — a font scale, device, locale, orientation, a named knob, a feature override
+   * (gestures / focus / keyboard / …) — needs a re-render. Uses data-class equality against a
+   * defaults instance so a newly added override field is covered without touching this predicate.
+   */
+  fun overridesAffectRender(previewId: String, o: PreviewOverrides): Boolean {
+    // The theme is the LAST `light`/`dark` id segment (past the component slug) — matching
+    // `ServeUrls.wasmAppSrc` / `ServeWeb.cardTheme`. Scanning for `dark` first would misread a
+    // non-theme segment named `dark` in an otherwise-light variant, wrongly treating `uiMode=dark`
+    // as a no-op and dropping the override.
+    val bakedTheme =
+      when (previewId.split("__").drop(1).lastOrNull { it == "light" || it == "dark" }) {
+        "dark" -> UiMode.DARK
+        "light" -> UiMode.LIGHT
+        else -> null
+      }
+    // A uiMode matching the baked variant is a no-op; drop it, then any remaining set field
+    // (including a *differing* uiMode) means a re-render is required.
+    val uiModeIsNoOp = o.uiMode == null || o.uiMode == bakedTheme
+    return if (uiModeIsNoOp) o.copy(uiMode = null) != PreviewOverrides() else true
+  }
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
@@ -3,7 +3,6 @@ package ee.schimke.composeai.cli.serve
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.daemon.protocol.StreamCodec
 import ee.schimke.composeai.daemon.protocol.StreamFrameParams
-import ee.schimke.composeai.daemon.protocol.UiMode
 
 /**
  * A [ServeHost] that fronts a trusted design-system catalog with its baked-PNG render **and** an
@@ -142,41 +141,12 @@ class ServeCatalogLiveHost(
   }
 
   /**
-   * The daemon preview id to route a [render] / [renderSvg] to, or null to stay baked. Non-null
-   * only when [previewId] is a mapped (daemon-renderable) id AND the request carries an override
-   * the baked PNG can't satisfy ([overridesAffectRender]).
+   * The daemon preview id to route a [render] / [renderSvg] to, or null to stay baked. Delegates to
+   * [CatalogLiveRouting] — the same predicate [ServePerPreviewLiveHost] uses — so the "baked vs
+   * re-render" decision is identical across the two trusted-catalog live hosts.
    */
-  private fun daemonIdForOverrideRender(previewId: String, overrides: PreviewOverrides): String? {
-    // No daemon twin (an Android-only variant) ⇒ always baked; it has no live lane.
-    val daemonId = alias[previewId] ?: return null
-    return if (overridesAffectRender(previewId, overrides)) daemonId else null
-  }
-
-  /**
-   * Whether [overrides] would change pixels vs the preview's baked sticker, so the render must go
-   * to the daemon rather than replay the baked PNG. The baked variant already encodes its **theme**
-   * (the `…__light` / `…__dark` id segment) and every other axis at its discovery-time default, so
-   * a bare `uiMode` that matches the variant is a no-op and stays baked (keeping browsing instant);
-   * anything else — a font scale, device, locale, orientation, a named knob, a feature override
-   * (gestures / focus / keyboard / …) — needs a re-render. Uses data-class equality against a
-   * defaults instance so a newly added override field is covered without touching this predicate.
-   */
-  private fun overridesAffectRender(previewId: String, o: PreviewOverrides): Boolean {
-    // The theme is the LAST `light`/`dark` id segment (past the component slug) — matching
-    // `ServeUrls.wasmAppSrc` / `ServeWeb.cardTheme`. Scanning for `dark` first would misread a
-    // non-theme segment named `dark` in an otherwise-light variant, wrongly treating `uiMode=dark`
-    // as a no-op and dropping the override.
-    val bakedTheme =
-      when (previewId.split("__").drop(1).lastOrNull { it == "light" || it == "dark" }) {
-        "dark" -> UiMode.DARK
-        "light" -> UiMode.LIGHT
-        else -> null
-      }
-    // A uiMode matching the baked variant is a no-op; drop it, then any remaining set field
-    // (including a *differing* uiMode) means a re-render is required.
-    val uiModeIsNoOp = o.uiMode == null || o.uiMode == bakedTheme
-    return if (uiModeIsNoOp) o.copy(uiMode = null) != PreviewOverrides() else true
-  }
+  private fun daemonIdForOverrideRender(previewId: String, overrides: PreviewOverrides): String? =
+    CatalogLiveRouting.daemonIdForOverrideRender(previewId, overrides, alias)
 
   /** Live streaming is available only for aliased ids; others have no stream (snapshot only). */
   override fun subscribeStream(

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServePerPreviewLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServePerPreviewLiveHost.kt
@@ -1,0 +1,148 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.daemon.protocol.StreamCodec
+import ee.schimke.composeai.daemon.protocol.StreamFrameParams
+
+/**
+ * A [ServeHost] that fronts a trusted design-system catalog's baked PNGs with an opt-in live daemon
+ * that re-renders each preview from its **own per-preview bundle**
+ * (`bundle/previews/<daemon-id>.png` on the `design-artifacts/<system>` branch), rather than from
+ * one monolithic catalog `liveBundle` ([ServeCatalogLiveHost]).
+ *
+ * ## Browsing is baked
+ *
+ * Exactly like [ServeCatalogLiveHost]: [previews], the grid, deep links, thumbnails, title, and
+ * trust badge all resolve to [baked], and an override-free `/render` (or one replaying only the
+ * variant's own sticky theme) replays the baked PNG — so browsing is instant and never wakes a
+ * daemon. Only an override the baked PNG can't satisfy — a `?knob.<key>=…` edit, a font scale, a
+ * differing theme, … ([CatalogLiveRouting.overridesAffectRender]) — routes to [resolveLive].
+ *
+ * ## Per-preview live lane
+ *
+ * [resolveLive] maps a daemon-preview id to a daemon-backed host that serves **exactly that one
+ * preview**, materialised from that preview's own bundle and pooled (with idle eviction) by the
+ * caller — this host never owns or closes those daemons. `null` ⇒ no per-preview daemon is
+ * available (fetch/materialise failed, or the preview ships no live bundle), so the request falls
+ * back to the baked PNG. Because the resolved daemon serves a single id, [render] / [renderSvg] /
+ * [subscribeStream] all call it with the mapped **daemon** id, not the catalog id.
+ *
+ * ## Why per-preview
+ *
+ * Each per-preview bundle carries only its preview's closure over a **maven-coordinate** classpath
+ * (re-resolved at materialise time), so the delivery branch ships small addressable re-renderable
+ * stickers and the server holds daemons only for the previews actually being edited — the pool
+ * reaps idle ones. Contrast [ServeCatalogLiveHost], which launches one daemon carrying the whole
+ * catalog.
+ */
+class ServePerPreviewLiveHost(
+  /**
+   * Catalog id (`button-elevated__ideal__default__light`) → daemon preview id
+   * (`…ElevatedButtonSticker_Light`). An unmapped id (an Android-only variant) has no per-preview
+   * live lane and always replays baked.
+   */
+  private val alias: Map<String, String>,
+  /** The static baked-PNG host — the browse + snapshot surface, keyed by catalog ids. */
+  private val baked: ServeHost,
+  /**
+   * Resolve a daemon-backed host that re-renders the given **daemon-preview id** from its own
+   * per-preview bundle, or null when none is available. Called only for an alias-mapped id carrying
+   * a pixel-changing override; the returned host is owned + pooled by the caller (this host never
+   * closes it), so repeated calls for the same id should return the pooled instance.
+   */
+  private val resolveLive: (daemonId: String) -> ServeHost?,
+  /**
+   * The whole servable preview set — the baked catalog's previews with the author-declared knobs +
+   * detected-feature flags already grafted on (read from the per-preview bundles' `overrides.json`
+   * sidecars), so the viewer offers the editable controls. The caller assembles this; the host does
+   * not read bundles itself.
+   */
+  override val previews: List<ServePreview>,
+  /**
+   * App-declared `@ThemeCatalog` themes (module-global); forwarded to the viewer's Theme selector.
+   */
+  override val declaredThemes: List<ServeTheme> = emptyList(),
+  /**
+   * Whether the per-preview daemons honour the one-handed gesture override (Android-backed only).
+   */
+  override val gesturesRenderable: Boolean = false,
+  /**
+   * SVG is exportable when either lane can: the baked catalog carries `figma/<slug>.svg` vectors
+   * and a per-preview daemon exports a `compose/figma-svg`. Defaults to the baked host's
+   * capability.
+   */
+  override val hasSvgExport: Boolean = baked.hasSvgExport,
+  /** Live upstream stream count across the pooled per-preview daemons (supplied by the pool). */
+  private val streamCount: () -> Int = { 0 },
+) : ServeHost {
+
+  override val label: String = baked.label
+
+  /**
+   * Snapshots stay static (baked PNGs) so browsing is instant — the live lane is opt-in per edit.
+   */
+  override val canApplyOverrides: Boolean = false
+
+  /**
+   * A per-preview daemon CAN re-render an override on demand, so the viewer's knobs render live.
+   */
+  override val canRenderOverrides: Boolean = true
+
+  /** The "Live (stream)" toggle is offered (unlike a plain static catalog). */
+  override val hasLiveStream: Boolean = true
+
+  /** Only a preview with a per-preview live bundle ([alias]) can re-render; others replay baked. */
+  override fun canRenderOverridesFor(previewId: String): Boolean = previewId in alias
+
+  /**
+   * Ordinary browsing serves the baked catalog PNG; an override the baked PNG can't represent
+   * routes to that preview's own daemon. An unmapped id, or one whose per-preview daemon can't be
+   * resolved, falls back to baked.
+   */
+  override fun render(previewId: String, overrides: PreviewOverrides): RenderOutcome {
+    val daemonId =
+      CatalogLiveRouting.daemonIdForOverrideRender(previewId, overrides, alias)
+        ?: return baked.render(previewId, overrides)
+    val live = resolveLive(daemonId) ?: return baked.render(previewId, overrides)
+    return live.render(daemonId, overrides)
+  }
+
+  /**
+   * SVG mirrors [render]'s per-preview routing, with the same baked fallback as
+   * [ServeCatalogLiveHost]: an override-bearing mapped id renders on its daemon; otherwise the
+   * baked catalog's `figma/<slug>.svg` vector serves it, and only when the baked lane has none does
+   * a mapped id fall back to its daemon.
+   */
+  override fun renderSvg(previewId: String, overrides: PreviewOverrides): SvgOutcome {
+    CatalogLiveRouting.daemonIdForOverrideRender(previewId, overrides, alias)?.let { daemonId ->
+      resolveLive(daemonId)?.let {
+        return it.renderSvg(daemonId, overrides)
+      }
+    }
+    val bakedOutcome = baked.renderSvg(previewId, overrides)
+    if (bakedOutcome !is SvgOutcome.NotFound) return bakedOutcome
+    val daemonId = alias[previewId] ?: return bakedOutcome
+    return resolveLive(daemonId)?.renderSvg(daemonId, overrides) ?: bakedOutcome
+  }
+
+  /** Live streaming is available only for aliased ids that resolve a per-preview daemon. */
+  override fun subscribeStream(
+    previewId: String,
+    overrides: PreviewOverrides,
+    codec: StreamCodec?,
+    maxFps: Int?,
+    onFrame: (StreamFrameParams) -> Unit,
+  ): StreamHandle? {
+    val daemonId = alias[previewId] ?: return null
+    return resolveLive(daemonId)?.subscribeStream(daemonId, overrides, codec, maxFps, onFrame)
+  }
+
+  override fun activeStreamCount(): Int = streamCount()
+
+  /**
+   * The per-preview daemons are owned by the pool; this host only closes the baked browse surface.
+   */
+  override fun close() {
+    baked.close()
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServePerPreviewLiveHostTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServePerPreviewLiveHostTest.kt
@@ -1,0 +1,224 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.daemon.protocol.InteractiveInputKind
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.daemon.protocol.StreamCodec
+import ee.schimke.composeai.daemon.protocol.StreamFrameParams
+import ee.schimke.composeai.daemon.protocol.UiMode
+import ee.schimke.composeai.data.overrides.PreviewOverrideValue
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * [ServePerPreviewLiveHost] fronts the baked catalog and re-renders each preview from its OWN
+ * per-preview bundle's daemon (resolved lazily + pooled by the caller). Browsing / no-op overrides
+ * stay baked; only a pixel-changing override on a mapped id resolves a per-preview daemon — and it
+ * must be called with the mapped **daemon** id, not the catalog id. An unmapped id, or one whose
+ * daemon can't be resolved, falls back to baked. The baked-vs-render decision is shared with
+ * [ServeCatalogLiveHost] via [CatalogLiveRouting], so this test focuses on the per-preview routing.
+ */
+class ServePerPreviewLiveHostTest {
+
+  private class RecordingHost(
+    override val previews: List<ServePreview>,
+    private val tag: String,
+    private val streaming: Boolean = false,
+    private val svgNotFound: Boolean = false,
+    override val hasSvgExport: Boolean = true,
+  ) : ServeHost {
+    override val label: String = tag
+    override val canApplyOverrides: Boolean = streaming
+    var lastRenderId: String? = null
+    var lastRenderOverrides: PreviewOverrides? = null
+    var lastSvgId: String? = null
+    var lastStreamId: String? = null
+    var closed = false
+
+    override fun render(previewId: String, overrides: PreviewOverrides): RenderOutcome {
+      lastRenderId = previewId
+      lastRenderOverrides = overrides
+      return RenderOutcome.Ok("$tag:$previewId".encodeToByteArray())
+    }
+
+    override fun renderSvg(previewId: String, overrides: PreviewOverrides): SvgOutcome {
+      lastSvgId = previewId
+      lastRenderOverrides = overrides
+      if (svgNotFound) return SvgOutcome.NotFound
+      return SvgOutcome.Ok("$tag-svg:$previewId".encodeToByteArray())
+    }
+
+    override fun subscribeStream(
+      previewId: String,
+      overrides: PreviewOverrides,
+      codec: StreamCodec?,
+      maxFps: Int?,
+      onFrame: (StreamFrameParams) -> Unit,
+    ): StreamHandle? {
+      lastStreamId = previewId
+      if (!streaming) return null
+      return object : StreamHandle {
+        override fun input(
+          kind: InteractiveInputKind,
+          pixelX: Int?,
+          pixelY: Int?,
+          pointerId: Int?,
+          scrollDeltaY: Float?,
+          keyCode: String?,
+        ) {}
+
+        override fun close() {}
+      }
+    }
+
+    override fun activeStreamCount(): Int = if (streaming) 1 else 0
+
+    override fun close() {
+      closed = true
+    }
+  }
+
+  private val catalogId = "button-elevated__ideal__default__light"
+  private val daemonId = "ElevatedButtonSticker_Light"
+  private val androidOnlyId = "button-filled__ideal__keyboard-focus__dark"
+
+  /** The daemon ids [resolveLive] was asked for — proves per-preview routing uses the daemon id. */
+  private val resolved = mutableListOf<String>()
+
+  private fun host(
+    liveHost: RecordingHost = RecordingHost(listOf(ServePreview(daemonId, daemonId)), "live", true),
+    resolve: (String) -> ServeHost? = { liveHost },
+  ): Pair<ServePerPreviewLiveHost, RecordingHost> {
+    val baked =
+      RecordingHost(
+        previews =
+          listOf(ServePreview(catalogId, catalogId), ServePreview(androidOnlyId, androidOnlyId)),
+        tag = "baked",
+      )
+    val composite =
+      ServePerPreviewLiveHost(
+        alias = mapOf(catalogId to daemonId),
+        baked = baked,
+        resolveLive = { id ->
+          resolved.add(id)
+          resolve(id)
+        },
+        previews = baked.previews,
+        streamCount = { liveHost.activeStreamCount() },
+      )
+    return composite to baked
+  }
+
+  private fun knobOverride() =
+    PreviewOverrides(
+      namedOverrides = mapOf("label" to PreviewOverrideValue.StringValue("Televise"))
+    )
+
+  @Test
+  fun `a knob override renders on the preview's own daemon, called with the daemon id`() {
+    val live = RecordingHost(listOf(ServePreview(daemonId, daemonId)), "live", streaming = true)
+    val (composite, baked) = host(live)
+    val outcome = composite.render(catalogId, knobOverride())
+    // Routed to the per-preview daemon — resolved by DAEMON id, rendered by DAEMON id.
+    assertEquals(listOf(daemonId), resolved)
+    assertEquals(daemonId, live.lastRenderId)
+    assertEquals("live:$daemonId", (outcome as RenderOutcome.Ok).png.decodeToString())
+    // The baked host was NOT asked to render.
+    assertNull(baked.lastRenderId)
+  }
+
+  @Test
+  fun `an override-free browse stays baked and never resolves a daemon`() {
+    val (composite, baked) = host()
+    composite.render(catalogId, PreviewOverrides())
+    assertEquals(catalogId, baked.lastRenderId)
+    assertTrue(resolved.isEmpty(), "browsing must not wake a per-preview daemon")
+  }
+
+  @Test
+  fun `a uiMode matching the baked variant theme is a no-op and stays baked`() {
+    val (composite, baked) = host()
+    // The variant id ends in `__light`, so uiMode=LIGHT changes nothing — replay baked.
+    composite.render(catalogId, PreviewOverrides(uiMode = UiMode.LIGHT))
+    assertEquals(catalogId, baked.lastRenderId)
+    assertTrue(resolved.isEmpty())
+    // A DIFFERING theme (dark on a light variant) does need a re-render.
+    composite.render(catalogId, PreviewOverrides(uiMode = UiMode.DARK))
+    assertEquals(listOf(daemonId), resolved)
+  }
+
+  @Test
+  fun `an unmapped preview always replays baked and reports no live lane`() {
+    val (composite, baked) = host()
+    assertEquals(false, composite.canRenderOverridesFor(androidOnlyId))
+    composite.render(androidOnlyId, knobOverride())
+    assertEquals(androidOnlyId, baked.lastRenderId)
+    assertTrue(resolved.isEmpty())
+    assertNull(composite.subscribeStream(androidOnlyId, PreviewOverrides(), null, null) {})
+  }
+
+  @Test
+  fun `when no per-preview daemon can be resolved the override falls back to baked`() {
+    val (composite, baked) = host(resolve = { null })
+    val outcome = composite.render(catalogId, knobOverride())
+    assertEquals(listOf(daemonId), resolved, "it tried to resolve the daemon…")
+    assertEquals(catalogId, baked.lastRenderId, "…then fell back to the baked catalog PNG")
+    assertEquals("baked:$catalogId", (outcome as RenderOutcome.Ok).png.decodeToString())
+  }
+
+  @Test
+  fun `host advertises static snapshots, on-demand render, live stream, and mapped-only render`() {
+    val (composite, _) = host()
+    assertEquals(false, composite.canApplyOverrides)
+    assertTrue(composite.canRenderOverrides)
+    assertTrue(composite.hasLiveStream)
+    assertTrue(composite.canRenderOverridesFor(catalogId))
+    assertTrue(composite.hasSvgExport, "hasSvgExport defaults to the baked host's capability")
+  }
+
+  @Test
+  fun `svg prefers the per-preview daemon for an override, else the baked vector`() {
+    val live = RecordingHost(listOf(ServePreview(daemonId, daemonId)), "live", streaming = true)
+    val (composite, baked) = host(live)
+    // Override → the daemon's figma-svg, by daemon id.
+    val overSvg = composite.renderSvg(catalogId, knobOverride())
+    assertEquals(daemonId, live.lastSvgId)
+    assertEquals("live-svg:$daemonId", (overSvg as SvgOutcome.Ok).svg.decodeToString())
+    // No override → the baked catalog's committed vector (no daemon).
+    resolved.clear()
+    val bakedSvg = composite.renderSvg(catalogId, PreviewOverrides())
+    assertEquals(catalogId, baked.lastSvgId)
+    assertEquals("baked-svg:$catalogId", (bakedSvg as SvgOutcome.Ok).svg.decodeToString())
+  }
+
+  @Test
+  fun `svg falls back to the per-preview daemon when the baked catalog has no vector`() {
+    val live = RecordingHost(listOf(ServePreview(daemonId, daemonId)), "live", streaming = true)
+    val baked =
+      RecordingHost(listOf(ServePreview(catalogId, catalogId)), "baked", svgNotFound = true)
+    val composite =
+      ServePerPreviewLiveHost(
+        alias = mapOf(catalogId to daemonId),
+        baked = baked,
+        resolveLive = {
+          resolved.add(it)
+          live
+        },
+        previews = baked.previews,
+      )
+    // No override, but the baked lane 404s the vector → fall back to the mapped daemon.
+    val svg = composite.renderSvg(catalogId, PreviewOverrides())
+    assertEquals("live-svg:$daemonId", (svg as SvgOutcome.Ok).svg.decodeToString())
+  }
+
+  @Test
+  fun `a live stream subscribes on the preview's own daemon by daemon id`() {
+    val live = RecordingHost(listOf(ServePreview(daemonId, daemonId)), "live", streaming = true)
+    val (composite, _) = host(live)
+    val handle = composite.subscribeStream(catalogId, knobOverride(), null, null) {}
+    assertTrue(handle != null, "a mapped preview offers a live stream")
+    assertEquals(daemonId, live.lastStreamId)
+    assertEquals(1, composite.activeStreamCount())
+  }
+}


### PR DESCRIPTION
## Summary

Foundation for approach **B** — re-render each catalog preview from its **own** per-preview bundle (`bundle/previews/<daemon-id>.png`) instead of one monolithic catalog `liveBundle`. This is the direction we chose: a `?knob.<key>=…` edit re-renders per preview, the delivery branch ships small addressable re-renderable stickers, and the server only holds a daemon for the previews actually being edited.

This PR lands the **tested core routing + the publish side**. The `ServeCatalogStore` wiring (on-demand fetch + materialize + pool) is the sequenced follow-up — see *Staging* below.

### What's here

- **`ServePerPreviewLiveHost`** — fronts the baked catalog (browsing stays baked + instant, never wakes a daemon) and routes only pixel-changing overrides to a per-preview daemon via an injected `resolveLive(daemonId) -> ServeHost?`, falling back to baked when none resolves. The pool + fetch live behind that seam, so the host itself is **pure routing → fully unit-tested** (`ServePerPreviewLiveHostTest`, 9 cases: knob → daemon by daemon-id, no-op/uiMode-match stays baked, unmapped → baked, resolver-null fallback, SVG prefer-daemon-else-baked-vector, per-preview stream).
- **`CatalogLiveRouting`** — extracted the shared "does this override need a fresh render vs. the baked sticker?" predicate so `ServeCatalogLiveHost` (monolithic) and the new per-preview host can't drift; `ServeCatalogLiveHost` now delegates to it (its own test still green).
- **`design-artifacts.yml`** — the CMP tier's per-preview split is now **FULL** (re-renderable) instead of `--view-only`, so `bundle/previews/<id>.png` carry their classpath. Kept small by the **maven-coordinate** classpath (only `classes/app.jar` repeats; fonts resolve from the shared `bundle/res` pool). The Android tiers (wear/remote) and the Android supplement stay `--view-only` — no desktop daemon can re-render them.

### Staging (so knobs never regress)

1. **This PR** + regenerate `design-artifacts/*` so the CMP per-preview bundles are published FULL.
2. **Follow-up PR**: wire `resolveLive` in `ServeCatalogStore` — on an override render, fetch `bundle/previews/<daemon-id>.png`, `ServeBundleDaemon.materialize` + open it, and pool via `ServeSessionRegistry` (idle-evicting, reusing its `suspendIdle` reaper). Gated to prefer per-preview only when FULL bundles are present, falling back to today's monolithic `liveBundle` path otherwise — so the working knob-render path is never regressed during rollout.

## Test plan
- `./gradlew :cli:test --tests '*ServePerPreviewLiveHostTest*' --tests '*ServeCatalogLiveHostTest*'` — green (new host + the refactored monolithic host).
- The publish-side workflow change only validates against a real catalog build in the `design-artifacts.yml` run (FULL split of `compose-m3`); called out here rather than claimed locally proven. Bundle-size impact is bounded by the maven-coordinate classpath as noted.

**Scope note:** `ServePerPreviewLiveHost` is intentionally introduced here as a tested, self-contained unit ahead of its `ServeCatalogStore` wiring (which is integration-validated and rolls out in step 2), so the routing lands reviewed and covered before the network/daemon-pool plumbing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jxz9i4SuuxPRt3knZKAPbb)_