### PR TITLE
fix(serve): expose per-preview bakedHost + split the externalised bundle FULL

### DIFF
--- a/.github/workflows/design-artifacts.yml
+++ b/.github/workflows/design-artifacts.yml
@@ -207,8 +207,19 @@ jobs:
         run: |
           set -euo pipefail
           view_only_flag=""
-          [ "$SPLIT_MODE" = "view-only" ] && view_only_flag="--view-only"
-          compose-preview bundle split "$GITHUB_WORKSPACE/$SYSTEM-bundle.png" $view_only_flag \
+          split_source="$GITHUB_WORKSPACE/$SYSTEM-bundle.png"
+          if [ "$SPLIT_MODE" = "view-only" ]; then
+            view_only_flag="--view-only"
+          else
+            # FULL: split the EXTERNALISED live bundle the generate step already produced under
+            # out/bundle/ (fonts lifted to bundle/res/<sha>), not the raw sheet. Splitting the raw
+            # sheet would copy its un-externalised classes/app.jar — fonts inlined — into every
+            # per-preview bundle, so the delivery branch would balloon by the preview count. Reading
+            # the externalised copy means each FULL per-preview bundle inherits the slimmed app.jar +
+            # the shared-pool font references, so `serve` rehydrates fonts from bundle/res once.
+            split_source="$GITHUB_WORKSPACE/out/bundle/$SYSTEM-bundle.png"
+          fi
+          compose-preview bundle split "$split_source" $view_only_flag \
             -o "$GITHUB_WORKSPACE/out/bundle/previews"
           # For compose-m3 the catalog also folds an Android-only supplement (the material3 inset
           # focus ring CMP can't draw), whose renders/semantics override same-named CMP functions in

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -380,6 +380,7 @@ class ServeHttpServer(
     when (host) {
       is ServeBundleHost -> host
       is ServeCatalogLiveHost -> host.bakedHost as? ServeBundleHost
+      is ServePerPreviewLiveHost -> host.bakedHost as? ServeBundleHost
       else -> null
     }
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServePerPreviewLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServePerPreviewLiveHost.kt
@@ -76,6 +76,14 @@ class ServePerPreviewLiveHost(
   private val streamCount: () -> Int = { 0 },
 ) : ServeHost {
 
+  /**
+   * The underlying baked catalog host, so the HTTP layer's `catalogBundleHost()` can recover its
+   * title / subtitle / trust verdict (which only a [ServeBundleHost] carries) even though the
+   * session is fronted by this composite — otherwise `/api/previews`, the viewer badge, and the
+   * home card would lose the trust badge + card title. Mirrors [ServeCatalogLiveHost.bakedHost].
+   */
+  internal val bakedHost: ServeHost = baked
+
   override val label: String = baked.label
 
   /**


### PR DESCRIPTION
## Summary

Follow-up to #2376 addressing two P2 review findings that arrived just as it auto-merged (so they missed the squash). Both were verified against the code before fixing.

- **Catalog metadata would be lost when a `ServePerPreviewLiveHost` fronts a catalog.** `ServeHttpServer.catalogBundleHost()` only unwrapped `ServeBundleHost` and `ServeCatalogLiveHost.bakedHost`, so a per-preview live catalog would fall through to `null` and drop its trust verdict + subtitle in `/api/previews`, the viewer badge, and the home card. Expose `bakedHost` on `ServePerPreviewLiveHost` (mirroring `ServeCatalogLiveHost.bakedHost`) and teach `catalogBundleHost()` to unwrap it.

- **The FULL split would balloon the delivery branch.** For the CMP tier the split read the **raw** `$SYSTEM-bundle.png`, whose `classes/app.jar` still has fonts inlined — so every per-preview FULL bundle would repeat them and the branch would grow by the preview count, defeating the size goal of #2376. The generate step already externalises the carried live bundle under `out/bundle/` (fonts → `bundle/res/<sha>`), so split **that** copy for FULL mode: each per-preview bundle then inherits the slimmed `app.jar` + shared-pool font references, and `serve` rehydrates fonts from `bundle/res` once. View-only tiers (no live bundle produced) keep splitting the raw sheet.

## Test plan
- `./gradlew :cli:test --tests '*ServePerPreviewLiveHostTest*' --tests '*ServeCatalogLiveHostTest*'` — green (unwrap + host routing unchanged; the `bakedHost` field + `catalogBundleHost` branch compile against merged `main`).
- The workflow split-source change validates in the `design-artifacts.yml` run against a real `compose-m3` build (FULL bundles now reference `bundle/res` instead of carrying inlined fonts) — called out rather than claimed locally proven.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jxz9i4SuuxPRt3knZKAPbb)_