### PR TITLE
ci(integration): change-scope the external-repo matrix by file path

### DIFF
--- a/.github/ci/integration-scope.py
+++ b/.github/ci/integration-scope.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Decide whether a PR needs the Integration workflow's external-repo matrix.
+
+Reads the PR's changed files and a committed ignore list
+(`.github/integration-scope.json`) and prints a single token:
+
+    true     run the full external-repo matrix (default / any doubt)
+    false    every changed file is ignore-listed and provably cannot change
+             what the plugin discovers/renders in an external consumer repo —
+             the slow matrix is skipped and a gate re-emits the required legs
+
+The contract is *fail-open*: an empty diff, a git failure, a missing/unreadable
+config, or any unexpected error all resolve to `true`, so scoping can only ever
+skip work that cannot affect the external builds. The one case that skips is
+"every changed file matches an ignore glob".
+
+Why an ignore list (not an allow list): the external consumer builds only pull
+the artifacts `build-plugin` publishes to mavenLocal (gradle-plugin,
+renderer-*, daemon-*, data-*, preview-annotations) plus the CLI-materialised
+init script. They never build THIS repo's own `samples/**`, the VS Code
+extension, docs, the deploy image, or the design-artifacts scripts — so those
+are safe to ignore. Anything not on the list (the plugin, CLI, renderers,
+daemon, data modules, build wiring, or a path we haven't classified) defaults
+to a full run.
+
+Env:
+    BASE_SHA / HEAD_SHA  PR diff endpoints (base must already be fetched)
+    SCOPE_CONFIG         override config path (default .github/integration-scope.json)
+
+Pure stdlib; unit-tested by test_integration_scope.py. The glob semantics match
+.github/actions/apply/compute-scope.py.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+RUN = "true"
+SKIP = "false"
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _log(msg: str) -> None:
+    print(f"integration-scope: {msg}", file=sys.stderr)
+
+
+def glob_to_regex(pattern: str) -> re.Pattern:
+    """Convert a `**`-style glob to a regex over repo-relative POSIX paths.
+
+    `**` crosses directory separators (including matching nothing), `*` and
+    `?` do not. A pattern without a `/` is treated as `**/<pattern>` so bare
+    basename patterns (`*.md`) match at any depth. A trailing `/**` also
+    matches the bare directory itself. (Mirrors compute-scope.py.)
+    """
+    pat = pattern.strip().lstrip("/")
+    if "/" not in pat.replace("/**", ""):
+        if not pat.startswith("**/") and not pat.startswith("**"):
+            pat = "**/" + pat
+    out = []
+    i = 0
+    while i < len(pat):
+        c = pat[i]
+        if c == "*":
+            if pat[i : i + 2] == "**":
+                if pat[i : i + 3] == "**/":
+                    out.append("(?:[^/]+/)*")
+                    i += 3
+                    continue
+                out.append(".*")
+                i += 2
+                continue
+            out.append("[^/]*")
+            i += 1
+            continue
+        if c == "?":
+            out.append("[^/]")
+            i += 1
+            continue
+        out.append(re.escape(c))
+        i += 1
+    regex = "".join(out)
+    if regex.endswith("/.*"):
+        regex = regex[: -len("/.*")] + "(?:/.*)?"
+    return re.compile("^" + regex + "$")
+
+
+def load_ignore_regexes(config_path: Path) -> list[re.Pattern]:
+    raw = json.loads(config_path.read_text())
+    ignores = raw.get("ignorePaths") or []
+    if not isinstance(ignores, list) or not ignores:
+        raise ValueError("ignorePaths missing or empty")
+    return [glob_to_regex(str(p)) for p in ignores]
+
+
+def changed_files(base_sha: str, head_sha: str) -> list[str]:
+    """`git diff --name-only --no-renames` between PR base and head/merge.
+
+    `--no-renames` so a rename surfaces as delete+add and both sides get
+    classified against the ignore list.
+    """
+    proc = subprocess.run(
+        ["git", "diff", "--name-only", "--no-renames", base_sha, head_sha],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(f"git diff exited {proc.returncode}: {proc.stderr.strip()[:400]}")
+    return [line.strip() for line in proc.stdout.splitlines() if line.strip()]
+
+
+def decide(files: list[str], ignore_regexes: list[re.Pattern]) -> str:
+    """`false` (skip) iff there is at least one file and all are ignore-listed."""
+    if not files:
+        _log("empty diff — running the matrix (don't guess)")
+        return RUN
+    unmatched = [f for f in files if not any(rx.match(f) for rx in ignore_regexes)]
+    if unmatched:
+        _log(
+            f"{len(unmatched)} of {len(files)} changed file(s) can affect the "
+            f"external builds (e.g. {unmatched[0]}) — running the matrix"
+        )
+        return RUN
+    _log(f"all {len(files)} changed file(s) ignore-listed — skipping the matrix")
+    return SKIP
+
+
+def main() -> int:
+    # Fail open: any exception below prints `true`.
+    try:
+        config_path = Path(
+            os.environ.get("SCOPE_CONFIG")
+            or (REPO_ROOT / ".github" / "integration-scope.json")
+        )
+        base_sha = os.environ.get("BASE_SHA", "")
+        head_sha = os.environ.get("HEAD_SHA", "")
+        if not base_sha or not head_sha:
+            _log("missing BASE_SHA/HEAD_SHA — running the matrix")
+            print(RUN)
+            return 0
+        ignore_regexes = load_ignore_regexes(config_path)
+        files = changed_files(base_sha, head_sha)
+        print(decide(files, ignore_regexes))
+        return 0
+    except Exception as e:  # noqa: BLE001 — fail-open is the whole contract
+        _log(f"unexpected error ({e}) — running the matrix")
+        print(RUN)
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/ci/test_integration_scope.py
+++ b/.github/ci/test_integration_scope.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Unit tests for integration-scope.py's classifier.
+
+Pure stdlib (unittest). Run: python3 .github/ci/test_integration_scope.py -v
+
+The `decide` cases use real changed-file sets from recent PRs so the config
+and the classifier are pinned to actual project history: docs / samples /
+vscode / scripts-only PRs must skip; anything touching the plugin / CLI /
+renderers / daemon / data / build wiring must run.
+"""
+
+import importlib.util
+import json
+import unittest
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_REPO_ROOT = _HERE.parents[1]
+
+# Load integration-scope.py as a module (hyphenated filename → importlib).
+_spec = importlib.util.spec_from_file_location(
+    "integration_scope", _HERE / "integration-scope.py"
+)
+mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(mod)
+
+# Real ignore list from the committed config.
+_CONFIG = json.loads((_REPO_ROOT / ".github" / "integration-scope.json").read_text())
+IGNORE = [mod.glob_to_regex(p) for p in _CONFIG["ignorePaths"]]
+
+
+def decide(files):
+    return mod.decide(files, IGNORE)
+
+
+class DecideSkip(unittest.TestCase):
+    """PRs whose every file is ignore-listed → skip the external matrix."""
+
+    def test_docs_only(self):
+        self.assertEqual(decide(["docs/AGENTS.md", "docs/SDK_COMPATIBILITY.md"]), "false")
+
+    def test_readme_anywhere(self):
+        # `**/*.md` matches a README nested inside an otherwise-relevant module.
+        self.assertEqual(decide(["gradle-plugin/README.md"]), "false")
+
+    def test_samples_only(self):
+        # Integration checks out EXTERNAL repos, so this repo's samples can't feed it.
+        self.assertEqual(
+            decide(["samples/wear/src/main/kotlin/GestureGalleryPreview.kt"]), "false"
+        )
+
+    def test_docs_and_samples(self):
+        self.assertEqual(
+            decide(["docs/x.md", "samples/cmp-wasm-catalog/src/main/App.kt"]), "false"
+        )
+
+    def test_vscode_only(self):
+        self.assertEqual(
+            decide(["vscode-extension/src/preview.ts", "vscode-extension/package.json"]),
+            "false",
+        )
+
+    def test_scripts_only(self):
+        self.assertEqual(decide(["scripts/design-artifacts/compare_page.py"]), "false")
+
+    def test_deploy_only(self):
+        self.assertEqual(decide(["deploy/preview-host/Dockerfile"]), "false")
+
+    def test_clients_only(self):
+        self.assertEqual(decide(["clients/core/src/main/kotlin/Client.kt"]), "false")
+
+    def test_renders_and_docs(self):
+        self.assertEqual(decide(["renders/samples/android/Foo.png", "docs/x.md"]), "false")
+
+
+class DecideRun(unittest.TestCase):
+    """Any file that can change the external builds → run the full matrix."""
+
+    def test_gradle_plugin(self):
+        self.assertEqual(decide(["gradle-plugin/src/main/kotlin/Plugin.kt"]), "true")
+
+    def test_renderer(self):
+        self.assertEqual(decide(["renderers/android/src/main/kotlin/R.kt"]), "true")
+
+    def test_daemon(self):
+        self.assertEqual(decide(["daemon/core/src/main/kotlin/D.kt"]), "true")
+
+    def test_data_figma_svg(self):
+        # data/** is deliberately NOT ignored (conservative: it's published).
+        self.assertEqual(decide(["data/figma-svg/src/main/kotlin/Svg.kt"]), "true")
+
+    def test_cli(self):
+        # The CLI materialises the init script every integration job uses.
+        self.assertEqual(decide(["cli/src/main/kotlin/InitScript.kt"]), "true")
+
+    def test_build_wiring(self):
+        self.assertEqual(decide(["settings.gradle.kts"]), "true")
+
+    def test_version_catalog(self):
+        self.assertEqual(decide(["gradle/libs.versions.toml"]), "true")
+
+    def test_mixed_relevant_and_ignored(self):
+        # One relevant file among ignored ones is enough to run.
+        self.assertEqual(decide(["docs/x.md", "gradle-plugin/src/main/P.kt"]), "true")
+
+    def test_unclassified_dir_runs(self):
+        # A path not on the ignore list defaults to run (fail-open by design).
+        self.assertEqual(decide(["schema/spatial-scene.schema.json"]), "true")
+
+    def test_empty_diff_runs(self):
+        self.assertEqual(decide([]), "true")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.github/integration-scope.json
+++ b/.github/integration-scope.json
@@ -1,0 +1,20 @@
+{
+  "//": "Change-scope config for the Integration workflow's external-repo matrix (.github/workflows/integration.yml). A PR whose EVERY changed file matches one of these globs cannot affect what the plugin discovers/renders in the external consumer repos (android/androidify, android/wear-os-samples, ...): those builds only consume the artifacts the build-plugin job publishes to mavenLocal (gradle-plugin, renderer-*, daemon-*, data-*, preview-annotations) plus the CLI-materialised init script. Such PRs skip the slow matrix, and integration-scope-gate re-emits the required wear-os-samples legs green so branch protection still clears. ANY changed file NOT matched here -> the full matrix runs (fail-open: the classifier defaults to run on an empty diff, a git failure, or an unreadable config). Note this differs from preview-scope.json: integration checks out EXTERNAL repos, so THIS repo's own samples/** never feed it and are safe to ignore here, whereas preview-scope.json scopes them.",
+  "ignorePaths": [
+    "docs/**",
+    "site/**",
+    "**/*.md",
+    "samples/**",
+    "renders/**",
+    "vscode-extension/**",
+    "deploy/**",
+    "clients/**",
+    "scripts/**",
+    ".githooks/**",
+    ".idea/**",
+    ".vscode/**",
+    "LICENSE",
+    ".gitignore",
+    ".gitattributes"
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -486,6 +486,8 @@ jobs:
         run: python3 .github/actions/apply/test_check_skew.py -v
       - name: Run apply change-scope tests
         run: python3 .github/actions/apply/test_compute_scope.py -v
+      - name: Run integration change-scope tests
+        run: python3 .github/ci/test_integration_scope.py -v
 
   # VS Code extension tests — both the existing in-process Mocha suite and
   # the @vscode/test-electron integration tests. The latter download a

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -22,6 +22,17 @@ name: Integration
 #
 # Each external-repo job runs independently (`fail-fast: false`) so one broken
 # consumer does not mask regressions in the others.
+#
+# Change-scoped on PRs (.github/integration-scope.json): the `changes` job
+# classifies the diff first. A PR that touches only paths which provably cannot
+# alter what the plugin discovers/renders in the external consumers — docs,
+# this repo's own `samples/**` (the matrix builds EXTERNAL repos, never these),
+# the VS Code extension, `deploy/`, `clients/`, the design-artifacts `scripts/`
+# — skips the whole `build-plugin` + external matrix, and `integration-scope-
+# gate` re-emits the required `wear-os-samples` legs green so branch protection
+# still clears. Anything touching the plugin / CLI / renderers / daemon / data
+# modules / build wiring runs the full matrix. Fail-open: pushes to main, the
+# nightly cron, manual dispatch, and any diff error all run everything.
 
 on:
   push:
@@ -53,8 +64,52 @@ env:
   PLUGIN_VERSION: 0.1.0-SNAPSHOT
 
 jobs:
-  build-plugin:
+  # Fast PR-diff classifier that decides whether the slow external-repo matrix
+  # below needs to run at all. Outputs `run` = true|false; every other job keys
+  # off it. On non-PR events (push / cron / dispatch) and on any classification
+  # error it resolves to `true`, so scoping can only ever trim the PR critical
+  # path — never skip work that could hide a regression.
+  changes:
+    name: Determine integration scope
     if: ${{ !(startsWith(github.head_ref, 'release-please--') && github.event.pull_request.user.login == 'github-actions[bot]') }}
+    runs-on: ubuntu-latest
+    outputs:
+      run: ${{ steps.scope.outputs.run }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Classify changed paths
+        id: scope
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          set -uo pipefail
+          # Non-PR events always run the full matrix — scoping only trims PRs.
+          if [ "$EVENT_NAME" != "pull_request" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::event=$EVENT_NAME — running the full integration matrix."
+            exit 0
+          fi
+          # Fetch the PR base so the classifier can diff against it (checkout is
+          # shallow). The script is fail-open, so a failed fetch still runs.
+          git fetch --no-tags --depth=1 origin "$BASE_SHA" 2>/dev/null || true
+          run="$(python3 .github/ci/integration-scope.py)"
+          echo "run=$run" >> "$GITHUB_OUTPUT"
+          if [ "$run" = "true" ]; then
+            echo "::notice::Integration matrix will run — a changed path can affect the external builds."
+          else
+            echo "::notice::Integration matrix scope-skipped — all changes are docs/samples/tooling (.github/integration-scope.json)."
+          fi
+
+  build-plugin:
+    # Skipped on out-of-scope PRs: nothing downstream needs the published
+    # bundle (the matrix is skipped too, and integration-scope-gate reports the
+    # required legs), so the expensive publish/installDist/bundle is pure waste.
+    needs: changes
+    if: ${{ needs.changes.outputs.run == 'true' && !(startsWith(github.head_ref, 'release-please--') && github.event.pull_request.user.login == 'github-actions[bot]') }}
     name: Build plugin + CLI
     runs-on: ubuntu-latest
     steps:
@@ -172,10 +227,44 @@ jobs:
           echo "'${LEG}' is reported green here to satisfy branch"
           echo "protection without an admin bypass."
 
-  integration:
-    if: ${{ !(startsWith(github.head_ref, 'release-please--') && github.event.pull_request.user.login == 'github-actions[bot]') }}
+  # Mirror of release-please-gate, for out-of-scope PRs. When `changes` decides
+  # the diff can't affect the external builds, the `integration` matrix below is
+  # skipped — but a skipped matrix job posts NO per-leg check run, so the two
+  # REQUIRED `wear-os-samples` legs would sit on "Expected — Waiting for status"
+  # forever (the same asymmetry release-please-gate documents). This gate
+  # re-emits those exact contexts green. Its `if:` is the inverse of the matrix
+  # guard (PR + non-release + run == 'false'), so on any given event exactly one
+  # of {matrix, release-please-gate, this gate} posts each required context,
+  # never two. Keep the two names in lockstep with the `pr_blocking: true` wear
+  # matrix cells (same contract as release-please-gate).
+  integration-scope-gate:
+    needs: changes
+    if: >-
+      ${{ github.event_name == 'pull_request'
+      && needs.changes.outputs.run == 'false'
+      && !(startsWith(github.head_ref, 'release-please--') && github.event.pull_request.user.login == 'github-actions[bot]') }}
     name: ${{ matrix.name }}
-    needs: build-plugin
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        name:
+          - "wear-os-samples (ComposeStarter)"
+          - "wear-os-samples (WearTilesKotlin)"
+    steps:
+      - name: Report green (out-of-scope PR — integration not applicable)
+        env:
+          LEG: ${{ matrix.name }}
+        run: |
+          echo "This PR changed only paths that cannot affect what the plugin"
+          echo "discovers or renders in the external consumer repos (see"
+          echo ".github/integration-scope.json), so the integration matrix is"
+          echo "scope-skipped. Required leg '${LEG}' is reported green here to"
+          echo "satisfy branch protection without an admin bypass."
+
+  integration:
+    if: ${{ needs.changes.outputs.run == 'true' && !(startsWith(github.head_ref, 'release-please--') && github.event.pull_request.user.login == 'github-actions[bot]') }}
+    name: ${{ matrix.name }}
+    needs: [changes, build-plugin]
     runs-on: ubuntu-latest
     # `continue-on-error: true` on a matrix entry makes that entry's failures
     # surface as warnings rather than blocking required-status checks on PRs.
@@ -1186,7 +1275,10 @@ jobs:
           retention-days: 7
 
   agp8-min:
-    if: ${{ !(startsWith(github.head_ref, 'release-please--') && github.event.pull_request.user.login == 'github-actions[bot]') }}
+    # Consumes build-plugin's bundle, so it rides the same change-scope gate:
+    # skipped on out-of-scope PRs (not a required check, so a plain skip is
+    # fine — nothing needs to re-emit it).
+    if: ${{ needs.changes.outputs.run == 'true' && !(startsWith(github.head_ref, 'release-please--') && github.event.pull_request.user.login == 'github-actions[bot]') }}
     # Floor-coverage job for AGP 8.x consumers. Uses the in-repo fixture under
     # `.github/ci/fixtures/agp8-min/` (Gradle 8.13 + AGP 8.13.0 + Kotlin 2.0.21
     # + compileSdk 36) so we exercise the bottom of our publicly-supported
@@ -1196,7 +1288,7 @@ jobs:
     # already shaped exactly the way we want it. The plugin still rides in
     # via the same init script, so the auto-apply path is exercised here too.
     name: agp8-min (Gradle 8.13)
-    needs: build-plugin
+    needs: [changes, build-plugin]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout this repo (for the fixture)


### PR DESCRIPTION
## Summary

The `Integration` workflow ran the full external-repo build/discover/render matrix — `wear-os-samples (ComposeStarter)`, `wear-os-samples (WearTilesKotlin)`, `androidify`, `nowinandroid` — on **every** PR, with no path filtering. Those are the slowest checks on the PR critical path, and they can only be affected by the artifacts `build-plugin` publishes to mavenLocal (gradle-plugin, renderer-*, daemon-*, data-*, preview-annotations) plus the CLI-materialised init script. A PR that touches only docs, this repo's own `samples/**` (the matrix builds *external* repos, never these), the VS Code extension, `deploy/`, `clients/`, or the design-artifacts `scripts/` cannot change what those builds discover or render.

Replaying the classifier over the last 80 commits: **8 of 42 non-release PRs (19%) paid for the full matrix while changing nothing that could affect it** — all docs / samples / vscode / scripts-only.

## What changed

- **`.github/integration-scope.json`** — committed ignore list of paths that provably can't affect the external builds.
- **`.github/ci/integration-scope.py`** — fail-open classifier (glob semantics shared with `compute-scope.py`): prints `false` (skip) only when *every* changed file is ignore-listed, else `true`.
- **`integration.yml`** — new fast `changes` job outputs `run`; `build-plugin`, `integration`, and `agp8-min` gate on it. A new `integration-scope-gate` re-emits the two **required** `wear-os-samples` legs green when the matrix is scope-skipped (a skipped matrix job posts no per-leg check run, so they'd otherwise hang on "Expected — Waiting for status"). This mirrors the existing `release-please-gate`, with a mutually-exclusive `if:` so exactly one path reports each required context per event.
- **`ci.yml`** — wired the new unit test into the `actions-tests` job.

**Fail-open throughout:** pushes to `main`, the nightly cron, manual dispatch, an empty diff, a git failure, or an unreadable config all run the full matrix. Scoping can only ever trim the PR critical path — never skip work that could hide a regression. `data/**` is deliberately *not* ignored (it's published), so figma-svg PRs still run.

## Test plan

- `python3 .github/ci/test_integration_scope.py -v` — 19 cases built from real recent-PR file-sets (docs/samples/vscode/scripts/deploy/clients skip; plugin/CLI/renderer/daemon/data/build-wiring run).
- Regression-checked the untouched `test_compute_scope.py` (25 cases, still green).
- Replayed `integration-scope.py` over the last 80 commits on `main`: 8/42 non-release PRs scope-skip, all docs/samples/vscode/scripts-only; every plugin/CLI/renderer/daemon/data/build-wiring PR runs.
- `yaml.safe_load` parses `integration.yml`; job graph and `needs` verified.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H4dBwj7bcTzRaPZ12UYRNQ)_