### PR TITLE
ci: make release tagging resilient to a post-cut release-please crash

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -70,8 +70,19 @@ jobs:
       # (release.yml, preview-host-image.yml) check out `ref: <tag>`, so create
       # the tag now, at the release PR's merge commit. Idempotent: skips if the
       # ref already exists (e.g. a re-run, or a future non-draft release-please).
+      #
+      # `!cancelled()` (not the default success-only gate) is deliberate and hard-won:
+      # the release-please-action step cuts the draft (sets `release_created=true`)
+      # and THEN builds the next candidate PR in the same step — and that second
+      # half can crash (`Error adding to tree`) *after* the release is already cut.
+      # With a plain `if: …release_created == 'true'`, that crash skips this step,
+      # so the tag is never written; the manifest then names a version with no tag,
+      # which wedges every later release-please run into re-listing all history and
+      # failing again. Running whenever a release was actually cut — even if the rp
+      # step later failed — guarantees the tag exists and breaks that trap. This is
+      # exactly what stranded 0.16.34 (draft, untagged) until it was fixed by hand.
       - name: Ensure the release tag exists for the draft
-        if: steps.rp.outputs.release_created == 'true'
+        if: ${{ !cancelled() && steps.rp.outputs.release_created == 'true' }}
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.rp.outputs.tag_name }}
@@ -88,9 +99,15 @@ jobs:
 
   # Build and publish the artifacts whenever release-please actually cuts a
   # release. Skipped on "just updating the release PR" runs.
+  #
+  # `!cancelled() && …release_created == 'true'` rather than a plain output check:
+  # the release-please job can report `release_created=true` (draft cut) and STILL
+  # end in failure if the rp step crashes while building the next candidate PR (see
+  # the tag-ensure step). We want the artifact build to proceed whenever a release
+  # was genuinely cut, so a post-cut crash doesn't strand the release unpublished.
   release:
     needs: release-please
-    if: needs.release-please.outputs.release_created == 'true'
+    if: ${{ !cancelled() && needs.release-please.outputs.release_created == 'true' }}
     uses: ./.github/workflows/release.yml
     with:
       tag: ${{ needs.release-please.outputs.tag_name }}
@@ -114,7 +131,7 @@ jobs:
   # `latest/download/…` flip atomically to a fully-populated release.
   finalize-release:
     needs: [release-please, release]
-    if: needs.release-please.outputs.release_created == 'true'
+    if: ${{ !cancelled() && needs.release-please.outputs.release_created == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write   # un-draft + mark latest
@@ -173,7 +190,7 @@ jobs:
   # tarball-resolvable poll resolve immediately instead of riding out the upload).
   preview-host-image:
     needs: [release-please, release, finalize-release]
-    if: needs.release-please.outputs.release_created == 'true'
+    if: ${{ !cancelled() && needs.release-please.outputs.release_created == 'true' }}
     uses: ./.github/workflows/preview-host-image.yml
     with:
       cli_version: ${{ needs.release-please.outputs.tag_name }}
@@ -187,7 +204,7 @@ jobs:
   # than relying on the `clients-v*` tag push.
   release-clients:
     needs: release-please
-    if: needs.release-please.outputs.clients_release_created == 'true'
+    if: ${{ !cancelled() && needs.release-please.outputs.clients_release_created == 'true' }}
     uses: ./.github/workflows/clients-release.yml
     with:
       tag: ${{ needs.release-please.outputs.clients_tag_name }}
@@ -215,7 +232,7 @@ jobs:
   # release was publishing, it opens the correct next PR instead of the phantom.
   reconcile-release-pr:
     needs: [release-please, finalize-release]
-    if: needs.release-please.outputs.release_created == 'true'
+    if: ${{ !cancelled() && needs.release-please.outputs.release_created == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write        # update the release branch

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -129,9 +129,16 @@ jobs:
   #      anyway with a warning rather than wedge the release on CDN lag).
   # Only then `gh release edit --draft=false --latest`, so `/releases/latest` and
   # `latest/download/…` flip atomically to a fully-populated release.
+  # The `!cancelled()` override tolerates a post-cut crash in the `release-please`
+  # JOB — but it must NOT tolerate a failed `release`. `release.yml` decouples the
+  # GitHub asset upload from the Maven Central publish, so `release` can fail with
+  # the required assets already attached (Maven publish failed). Finalizing then
+  # would un-draft a release whose Gradle plugin/runtime never actually published.
+  # So require `needs.release.result == 'success'` explicitly: skip release-please's
+  # failure, but never release's.
   finalize-release:
     needs: [release-please, release]
-    if: ${{ !cancelled() && needs.release-please.outputs.release_created == 'true' }}
+    if: ${{ !cancelled() && needs.release-please.outputs.release_created == 'true' && needs.release.result == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write   # un-draft + mark latest
@@ -188,9 +195,12 @@ jobs:
   # `releases/download/<tag>/…` URL, which 404s while the release is still a
   # draft — so it must run only after finalize un-drafts it (which also makes its
   # tarball-resolvable poll resolve immediately instead of riding out the upload).
+  # Same scoping as finalize: tolerate release-please's post-cut crash, but require
+  # `release` AND `finalize-release` to have actually succeeded — this job pulls the
+  # CLI tarball from the now-PUBLISHED release, which only exists if finalize ran.
   preview-host-image:
     needs: [release-please, release, finalize-release]
-    if: ${{ !cancelled() && needs.release-please.outputs.release_created == 'true' }}
+    if: ${{ !cancelled() && needs.release-please.outputs.release_created == 'true' && needs.release.result == 'success' && needs.finalize-release.result == 'success' }}
     uses: ./.github/workflows/preview-host-image.yml
     with:
       cli_version: ${{ needs.release-please.outputs.tag_name }}
@@ -232,7 +242,10 @@ jobs:
   # release was publishing, it opens the correct next PR instead of the phantom.
   reconcile-release-pr:
     needs: [release-please, finalize-release]
-    if: ${{ !cancelled() && needs.release-please.outputs.release_created == 'true' }}
+    # Tolerate release-please's post-cut crash, but only reconcile once the release
+    # actually finalized (tag + published) — otherwise the re-run hits the same
+    # unanchored-manifest wedge it's meant to clear.
+    if: ${{ !cancelled() && needs.release-please.outputs.release_created == 'true' && needs.finalize-release.result == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write        # update the release branch


### PR DESCRIPTION
## Summary

Fixes the failure mode that stranded **0.16.34** as an untagged draft and wedged release-please on every push to `main`.

**What happened.** The `release-please-action` step cuts the draft Release (`release_created=true`) and then, in the *same step*, builds the next candidate PR. That second half crashed with `Error adding to tree` **after** the release was already cut. Because the tag-ensure step and the downstream jobs used plain success-only gates, the crash skipped **tag creation** and the entire publish chain. The version (`0.16.34`) then sat in `main`'s manifest with **no matching `v0.16.34` tag** — so every later release-please run couldn't anchor, re-listed ~613 commits, and hit `Error adding to tree` again. A self-perpetuating wedge.

**The fix.** Gate the tag-ensure step and the `release` / `finalize-release` / `preview-host-image` / `release-clients` / `reconcile-release-pr` jobs on `!cancelled() && …release_created == 'true'` instead of the bare output check. They now run whenever a release was *genuinely cut* — even if the `rp` step later failed — so a post-cut crash can't strand the release untagged and unpublished. The `release_created == 'true'` guard is unchanged, so PR-update runs (where nothing was cut) still skip the whole chain exactly as before; the release-please job itself still surfaces as failed so the underlying action bug stays visible.

## Why `!cancelled()`

A job's declared `outputs` are still readable by dependents even when the job's conclusion is *failure* — but a dependent with `needs:` is skipped on upstream failure unless its `if` tolerates it. `!cancelled()` lets the dependent run on success **or** failure (but not on an actual cancellation), and the `release_created == 'true'` check keeps it correct.

## Scope / limits

- This prevents recurrence. It does **not** retroactively finalize 0.16.34 (that needs the tag created + draft published, done out-of-band).
- It does not fix the underlying `Error adding to tree` inside `release-please-action` (the 613-commit candidate-PR build); it makes the pipeline *survive* it. Bounding/upgrading the action can be a follow-up.

## Test plan

- `yaml.safe_load` parses the workflow; all six gates confirmed updated to the `!cancelled() && …` form (tag-ensure step + five jobs).
- Reasoned through the truth table: PR-update run (`release_created=''`) → all skipped (unchanged); clean release (`true`, job success) → all run (unchanged); post-cut crash (`true`, job failure) → tag-ensure + publish chain now run (previously skipped — the bug).

Non-visual change (release/CI config only).

---
_Generated by [Claude Code](https://claude.ai/code/session_01AGXoRXk6dDjygWw5kmisYA)_