### PR TITLE
ci: add manual "Create Release Tag" escape-hatch workflow

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -58,13 +58,13 @@ jobs:
         run: |
           set -euo pipefail
 
-          case "${TAG}" in
-            v[0-9]* | clients-v[0-9]*) ;;
-            *)
-              echo "::error::refusing to create '${TAG}' — expected a v<semver> or clients-v<semver> release tag."
-              exit 1
-              ;;
-          esac
+          # Validate the WHOLE string, not just a prefix: a glob like `v[0-9]*`
+          # would let `v0foo` or `v0.16.34/foo` through and create a bogus
+          # release-looking ref while reporting success.
+          if [[ ! "${TAG}" =~ ^(v|clients-v)[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::refusing to create '${TAG}' — expected v<major>.<minor>.<patch> or clients-v<major>.<minor>.<patch> (digits and dots only)."
+            exit 1
+          fi
 
           # Resolve to a full commit SHA (also validates the commit exists).
           full_sha="$(gh api "repos/${GH_REPO}/commits/${SHA}" --jq '.sha')"

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,80 @@
+name: Create Release Tag
+
+# Manual escape hatch for creating a release tag at a specific commit.
+#
+# WHY THIS EXISTS
+# ---------------
+# release-please cuts a draft Release and then, in the SAME action step, writes
+# its git tag (the "Ensure the release tag exists" step in release-please.yml).
+# If that step is skipped — e.g. the rp step crashes with `Error adding to tree`
+# right after cutting the draft — the version lands in the manifest with NO tag,
+# and every later release-please run can't anchor to it, re-lists all history,
+# and fails again. That is exactly what stranded 0.16.34 (draft, untagged).
+#
+# Dispatching this workflow writes the missing tag ref, which re-anchors
+# release-please so the next version can be cut normally.
+#
+# IMPORTANT: the ref is created via the API with GITHUB_TOKEN, which does NOT
+# trigger tag-push workflows (the "GITHUB_TOKEN doesn't trigger workflows"
+# limitation). So this ONLY writes the tag — it does not build or publish
+# artifacts and does not publish to Maven Central. Use it to re-anchor
+# release-please (and to "burn" a stranded version as a bare tag). To actually
+# ship a version, run release.yml (workflow_dispatch, tag input) or publish the
+# draft — deliberately, as a separate step.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to create, e.g. v0.16.35 (or clients-v0.3.0)'
+        required: true
+        type: string
+      sha:
+        description: 'Commit SHA or ref to tag (e.g. the release PR merge commit)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: create-release-tag-${{ inputs.tag }}
+  cancel-in-progress: false
+
+jobs:
+  create-tag:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # create the tag ref
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
+      # Referenced only via these env vars in the script below — never
+      # interpolated into the run block — so a crafted input can't inject shell.
+      TAG: ${{ inputs.tag }}
+      SHA: ${{ inputs.sha }}
+    steps:
+      - name: Create the tag ref if it doesn't already exist
+        run: |
+          set -euo pipefail
+
+          case "${TAG}" in
+            v[0-9]* | clients-v[0-9]*) ;;
+            *)
+              echo "::error::refusing to create '${TAG}' — expected a v<semver> or clients-v<semver> release tag."
+              exit 1
+              ;;
+          esac
+
+          # Resolve to a full commit SHA (also validates the commit exists).
+          full_sha="$(gh api "repos/${GH_REPO}/commits/${SHA}" --jq '.sha')"
+
+          if gh api "repos/${GH_REPO}/git/ref/tags/${TAG}" >/dev/null 2>&1; then
+            echo "tag ${TAG} already exists — leaving it untouched."
+            exit 0
+          fi
+
+          gh api --method POST "repos/${GH_REPO}/git/refs" \
+            -f ref="refs/tags/${TAG}" -f sha="${full_sha}"
+          echo "created tag ${TAG} at ${full_sha}."
+          echo "note: this did NOT trigger release.yml (token-created ref) — build/publish separately if you want artifacts."


### PR DESCRIPTION
## Summary

A `workflow_dispatch` workflow that writes a release tag ref at a given commit — the tool to **re-anchor release-please** (and burn a stranded version) when a run cut a draft but failed to write its tag, which is exactly what stranded **0.16.34** (draft, untagged) and wedged `main`.

The tag is created via the API with `GITHUB_TOKEN`, which **does not trigger tag-push workflows** (the "GITHUB_TOKEN doesn't trigger workflows" rule). So dispatching it **only writes the ref** — no build, **no Maven Central publish**. That's precisely the "burn a version" operation: it re-anchors release-please so the next version cuts cleanly, without shipping the stranded one.

### Immediate use — burn 0.16.34, advance to 0.16.35

Once this merges, dispatch it with:
- `tag: v0.16.34`
- `sha: 0fee07059b0bf61a0f293838bd7c439cd6d2c763` (the `release 0.16.34 (#2346)` commit)

That writes the `v0.16.34` tag → release-please anchors on it → stops the `Error adding to tree` death-spiral → the next `main` merge opens the **0.16.35** release PR. The existing `0.16.34` draft can then be deleted (it stays a bare, artifact-less tag = burned). **Merge #2381 (the pipeline hardening) first** so a future post-cut crash can't re-wedge.

## Safety

- Input `tag` is guarded to a `v<semver>` / `clients-v<semver>` shape and passed via `env` (never interpolated into the run block), so a crafted input can't inject shell.
- `sha` is resolved through `gh api …/commits/<sha>`, which also validates the commit exists.
- Idempotent: if the tag already exists it's left untouched. Job holds only `contents: write`.

## Test plan

- `yaml.safe_load` parses; embedded script passes `bash -n`.
- Verified the guard accepts `v0.16.35` / `clients-v0.3.0` and rejects `main` and a `;rm -rf /` injection attempt.
- Behavioural verification is the dispatch itself (creates the ref, or no-ops if present); I'll run it against `v0.16.34` once this merges and confirm release-please recovers.

Non-visual change (CI tooling only).

---
_Generated by [Claude Code](https://claude.ai/code/session_01AGXoRXk6dDjygWw5kmisYA)_