### PR TITLE
feat(design-artifacts): pin published previews to released preview-runtimes

### DIFF
--- a/.github/workflows/design-artifacts.yml
+++ b/.github/workflows/design-artifacts.yml
@@ -29,6 +29,13 @@ jobs:
     # Don't run on forks — the publish step pushes branches into this repo.
     if: ${{ github.repository == 'yschimke/compose-ai-tools' }}
     runs-on: ubuntu-latest
+    env:
+      # Published previews are always built against RELEASED preview-runtimes: substitute the
+      # catalog's `:data-preview-overrides-runtime` / `:slot-preview-runtime` project deps for their
+      # released Maven coordinates (at `composeaiReleasedRuntimeVersion` in gradle.properties) so
+      # `bundle pack` records small coordinates instead of inlining the jars. Only
+      # :samples:design-catalog-m3 acts on it; the CLI build + other rows/modules ignore it.
+      ORG_GRADLE_PROJECT_composeaiUseReleasedRuntimes: 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -90,6 +97,39 @@ jobs:
         working-directory: scripts/design-artifacts
         run: npm ci
 
+      # Published previews pin their preview-runtimes to a RELEASED version
+      # (`composeaiReleasedRuntimeVersion`, bumped by release-please on each release). Sonatype →
+      # Maven Central propagation lags a release, so a regen kicked right after a release (or by the
+      # release chain) could reference a version that isn't resolvable yet. Wait for it to appear on
+      # Central before rendering — that's what lets "release, then regenerate the artifacts once the
+      # release makes Central" work reliably. Only the CMP tier substitutes released runtimes, so
+      # only it needs the gate; a bounded poll fails loudly rather than rendering an unpinned
+      # (inlined) bundle.
+      - name: Wait for released preview-runtimes on Maven Central
+        if: ${{ matrix.wasmModule != '' }}
+        run: |
+          set -euo pipefail
+          version="$(grep -oP '(?<=^composeaiReleasedRuntimeVersion=).*' gradle.properties || true)"
+          if [ -z "$version" ]; then
+            echo "no composeaiReleasedRuntimeVersion in gradle.properties" >&2
+            exit 1
+          fi
+          base="https://repo1.maven.org/maven2/ee/schimke/composeai"
+          echo "waiting for preview-runtimes $version on Maven Central…"
+          for i in $(seq 1 60); do
+            ok=1
+            for a in data-preview-overrides-runtime slot-preview-runtime; do
+              code="$(curl -s -o /dev/null -w '%{http_code}' \
+                "$base/$a/$version/$a-$version.pom" || true)"
+              [ "$code" = "200" ] || { ok=0; echo "  $a:$version -> HTTP ${code:-000}"; }
+            done
+            if [ "$ok" = 1 ]; then echo "all preview-runtimes $version on Central (attempt $i)"; exit 0; fi
+            echo "attempt $i/60 — not fully propagated; retrying in 60s"
+            sleep 60
+          done
+          echo "preview-runtimes $version never fully appeared on Maven Central after ~60m" >&2
+          exit 1
+
       - name: Render catalog bundle
         env:
           MODULE: ${{ matrix.module }}
@@ -113,6 +153,11 @@ jobs:
           # Run under a virtual framebuffer so the Skiko desktop daemon has a
           # display (matches ci.yml's desktop-render jobs); harmless for the
           # Robolectric rows, which don't touch it.
+          #
+          # The job pins the catalog's preview-runtime deps to their RELEASED coordinates via the
+          # `composeaiUseReleasedRuntimes` gate (job env) + `composeaiReleasedRuntimeVersion`
+          # (gradle.properties, release-please-managed); the "Wait for released preview-runtimes"
+          # step above guarantees that version is resolvable on Central before we render.
           xvfb-run -a -s "-screen 0 2000x1400x24" \
             compose-preview bundle pack --module "$MODULE" --with-semantics \
               -o "$GITHUB_WORKSPACE/$SYSTEM-bundle.png"

--- a/gradle.properties
+++ b/gradle.properties
@@ -32,3 +32,16 @@ org.gradle.configuration-cache.unsafe.ignore.unsupported-build-events-listeners=
 # trips `configuration-cache.problems=fail`). We don't use hot reload, so
 # disable it.
 org.jetbrains.compose.hot.reload.disable=true
+
+# The RELEASED preview-runtime version published previews pin to. When design-artifacts builds the
+# published catalog bundle (it sets the gate `composeaiUseReleasedRuntimes=true`),
+# `:samples:design-catalog-m3` swaps its `:data-preview-overrides-runtime` / `:slot-preview-runtime`
+# project deps for `ee.schimke.composeai:*:<this version>` so `bundle pack` records small Maven
+# coordinates instead of inlining ~80 KB of runtime jars. Release-please bumps this on every release
+# (see release-please-config.json extra-files), so the published previews always target the current
+# release's runtimes — a new runtime API must ship in a release before a published preview can use
+# it (the released preview server couldn't act on an unreleased one anyway). Normal builds leave the
+# gate unset and keep the `project(...)` deps, so local dev + CI still compile against HEAD.
+# x-release-please-start-version
+composeaiReleasedRuntimeVersion=0.16.33
+# x-release-please-end

--- a/gradle.properties
+++ b/gradle.properties
@@ -43,5 +43,5 @@ org.jetbrains.compose.hot.reload.disable=true
 # it (the released preview server couldn't act on an unreleased one anyway). Normal builds leave the
 # gate unset and keep the `project(...)` deps, so local dev + CI still compile against HEAD.
 # x-release-please-start-version
-composeaiReleasedRuntimeVersion=0.16.33
+composeaiReleasedRuntimeVersion=0.16.34
 # x-release-please-end

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -34,6 +34,10 @@
         {
           "type": "generic",
           "path": ".github/workflows/preview-host-image.yml"
+        },
+        {
+          "type": "generic",
+          "path": "gradle.properties"
         }
       ]
     }

--- a/samples/design-catalog-m3-shared/build.gradle.kts
+++ b/samples/design-catalog-m3-shared/build.gradle.kts
@@ -93,3 +93,31 @@ compose.resources {
   publicResClass = true
   packageOfResClass = "com.example.designcatalogm3.shared.generated.resources"
 }
+
+// Published-preview runtime pinning — the SHARED half of the note in
+// `:samples:design-catalog-m3`'s build. Most `catalogOverride*` / `PreviewSlot` usage lives in THIS
+// module's commonMain/desktopMain, so the released-runtime guard + coordinate substitution must
+// apply here too. Without it, this module compiles its runtime usage against the HEAD
+// `project(...)`
+// deps while the consumer links the released jars — an unreleased runtime API would then slip
+// through the guard and only surface later as a linkage / render error, not a compile failure. Same
+// gate + release-please-managed version as the consumer (kept in lockstep by hand — a shared
+// convention over both modules is the DRY follow-up).
+if (providers.gradleProperty("composeaiUseReleasedRuntimes").orNull.toBoolean()) {
+  val version =
+    providers.gradleProperty("composeaiReleasedRuntimeVersion").orNull
+      ?: error(
+        "composeaiUseReleasedRuntimes is set but composeaiReleasedRuntimeVersion is missing from " +
+          "gradle.properties"
+      )
+  configurations.all {
+    resolutionStrategy.dependencySubstitution {
+      substitute(project(":data-preview-overrides-runtime"))
+        .using(module("ee.schimke.composeai:data-preview-overrides-runtime:$version"))
+        .because("published previews reference released preview-runtimes (see :design-catalog-m3)")
+      substitute(project(":slot-preview-runtime"))
+        .using(module("ee.schimke.composeai:slot-preview-runtime:$version"))
+        .because("published previews reference released preview-runtimes (see :design-catalog-m3)")
+    }
+  }
+}

--- a/samples/design-catalog-m3/build.gradle.kts
+++ b/samples/design-catalog-m3/build.gradle.kts
@@ -51,3 +51,51 @@ dependencies {
   // `api(compose.components.resources)`, but declared directly since this module uses it head-on.
   implementation(libs.jetbrains.compose.components.resources)
 }
+
+// --- Published-preview runtime pinning
+// -------------------------------------------------------------
+// ⚠️ RELEASES ARE EFFECTIVELY REQUIRED FOR PUBLISHED PREVIEWS ⚠️
+//
+// The preview runtimes this catalog uses (`:data-preview-overrides-runtime` for `previewOverride*`,
+// and `:slot-preview-runtime` transitively via the shared module) are `project(...)` deps, which
+// `bundle pack` can only INLINE (a project jar has no re-resolvable coordinate) — ~80 KB of runtime
+// jars carried in the published bundle, and, with per-preview bundles, in EVERY one.
+//
+// When design-artifacts builds the PUBLISHED bundle it sets the gate
+// `ORG_GRADLE_PROJECT_composeaiUseReleasedRuntimes=true`. That swaps those project deps for their
+// RELEASED Maven coordinates at [composeaiReleasedRuntimeVersion] (a release-please-managed
+// property
+// in `gradle.properties`), so `bundle pack` records small `ClasspathEntry.Maven` references
+// (re-resolved from Maven Central at serve time) instead of inlining the jars.
+//
+// The consequence is deliberate: a NEW preview-runtime API/annotation added on `main` can't be used
+// by a published preview until it's RELEASED — the released coordinate won't carry it (so the
+// compile fails HERE, which is the guard), AND the live preview server that re-renders the bundle
+// runs the RELEASED CLI/daemon, so it couldn't act on an unreleased annotation anyway. Ship the
+// runtime change in a release first, then use it in the catalog.
+//
+// The pinned version is owned by release-please (it bumps `composeaiReleasedRuntimeVersion` on each
+// release), so published previews target the current release's runtimes. Local / normal-CI builds
+// leave the GATE unset, so they keep the `project(...)` deps and compile + test against HEAD.
+if (providers.gradleProperty("composeaiUseReleasedRuntimes").orNull.toBoolean()) {
+  val version =
+    providers.gradleProperty("composeaiReleasedRuntimeVersion").orNull
+      ?: error(
+        "composeaiUseReleasedRuntimes is set but composeaiReleasedRuntimeVersion is missing from " +
+          "gradle.properties"
+      )
+  logger.lifecycle(
+    ":samples:design-catalog-m3: pinning preview-runtime deps to released $version for the " +
+      "published bundle (new runtime APIs must be released before a published preview can use them)."
+  )
+  configurations.all {
+    resolutionStrategy.dependencySubstitution {
+      substitute(project(":data-preview-overrides-runtime"))
+        .using(module("ee.schimke.composeai:data-preview-overrides-runtime:$version"))
+        .because("published previews reference released preview-runtimes (see build note)")
+      substitute(project(":slot-preview-runtime"))
+        .using(module("ee.schimke.composeai:slot-preview-runtime:$version"))
+        .because("published previews reference released preview-runtimes (see build note)")
+    }
+  }
+}


### PR DESCRIPTION
## Summary

The catalog's preview-runtimes — `:data-preview-overrides-runtime` (`previewOverride*`) and `:slot-preview-runtime` — are `project(":…")` deps, which `bundle pack` can only **inline** (a project jar has no re-resolvable coordinate). That's ~80 KB of runtime jars carried in every published bundle — and, once per-preview FULL bundles land, in *every* one. This pins published previews to the **released** coordinates instead, so pack records small `ClasspathEntry.Maven` references re-resolved from Maven Central at serve time.

### How

- **`gradle.properties` → `composeaiReleasedRuntimeVersion`** — the pinned released runtime version, **owned by release-please** (block-marked + registered in `release-please-config.json` extra-files), so it bumps on every release and published previews always target the current release's runtimes.
- **`:samples:design-catalog-m3`** — behind the `composeaiUseReleasedRuntimes` gate, substitutes the runtime `project(…)` deps for `ee.schimke.composeai:*:<version>`. Local / normal-CI builds leave the gate unset and keep the project deps, so they compile + test against **HEAD** as usual. (config-cache-safe; verified with the gate on and off.)
- **`design-artifacts.yml`** — sets the gate job-wide, and adds a **"Wait for released preview-runtimes on Maven Central"** step before rendering. Sonatype→Central propagation lags a release, so this is what lets *"release, then regenerate the artifacts once the release makes Central"* work reliably: the regen polls Central for the pinned version (bounded, fails loudly) before it renders. The FULL per-preview split then inherits small coordinate references, not inlined jars.

### Why releases are effectively required (deliberate)

A new preview-runtime API/annotation added on `main` can't be used by a published preview until it's **released**: the released coordinate won't carry it (so the compile fails here — the guard), **and** the live preview server that re-renders the bundle runs the *released* CLI/daemon, so it couldn't act on an unreleased annotation anyway. Ship the runtime change in a release first, then use it in the catalog.

## Test plan
- `:samples:design-catalog-m3:help` with the gate **off** → keeps `project(…)` deps (no pinning); with the gate **on** → pins to `composeaiReleasedRuntimeVersion` (0.16.33), config-cache entry stored cleanly.
- `:samples:design-catalog-m3:compileKotlin` against the pinned `0.16.33` → **BUILD SUCCESSFUL** (catalog is API-compatible with the released runtime; verified `0.16.30–0.16.33` are on Central, only today's `0.16.34` is still propagating — exactly what the wait step handles).
- The end-to-end bundle-size win (coordinates vs inlined jars) validates in the `design-artifacts.yml` run against a real `compose-m3` build; called out rather than claimed locally proven.

## Follow-on (not in this PR)
Auto-**triggering** the design-artifacts regen from the release chain (so a release *builds* the artifacts, not just makes the version available). The wait step already makes any post-release regen — cron, manual dispatch, or a future release-triggered `workflow_call` — safe; wiring `release-please.yml` to invoke it is the small remaining connect.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jxz9i4SuuxPRt3knZKAPbb)_