### PR TITLE
feat(serve): consume per-preview bundles as the default live lane

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -14,6 +14,7 @@ import ee.schimke.composeai.cli.serve.ServeHost
 import ee.schimke.composeai.cli.serve.ServeHttpServer
 import ee.schimke.composeai.cli.serve.ServeMdnsAdvertiser
 import ee.schimke.composeai.cli.serve.ServeModuleRef
+import ee.schimke.composeai.cli.serve.ServePerPreviewDaemonPool
 import ee.schimke.composeai.cli.serve.ServePreview
 import ee.schimke.composeai.cli.serve.ServeRenderHost
 import ee.schimke.composeai.cli.serve.ServeRevisionFactory
@@ -208,6 +209,14 @@ class ServeCommand(args: List<String>) : Command(args) {
    * as sessions but never land here, so they stay off the nav.
    */
   private val registeredCatalogs = mutableListOf<String>()
+
+  /**
+   * Per-catalog per-preview daemon pools built by [buildTrustedCatalogBundle]. Each backs a live
+   * catalog's default (per-preview) render lane and outlives suspend/resume, so it's owned here and
+   * torn down at server shutdown (added to the [bringUpServer] closeables) rather than by the
+   * session host's [close][ServeHost.close].
+   */
+  private val catalogPerPreviewPools = mutableListOf<AutoCloseable>()
   /**
    * In-browser CMP tier (`--wasm-dir <system>=<dir>[,<system>=<dir>…]`): map a design system to the
    * assembled Wasm catalog app (`./gradlew :samples:cmp-wasm-catalog:wasmCatalogDist` →
@@ -441,7 +450,8 @@ class ServeCommand(args: List<String>) : Command(args) {
       bannerPreviewCount = previews.size,
       mdnsModuleLabel = module.gradlePath,
       mdnsPreviewIds = previews.map { it.id },
-      closeables = listOf(worktrees, catalogWorktrees.takeIf { it !== worktrees }),
+      closeables =
+        listOf(worktrees, catalogWorktrees.takeIf { it !== worktrees }) + catalogPerPreviewPools,
     )
   }
 
@@ -503,7 +513,7 @@ class ServeCommand(args: List<String>) : Command(args) {
       // No module previews to advertise; discovery is a module-session nicety, so skip it here.
       mdnsModuleLabel = null,
       mdnsPreviewIds = null,
-      closeables = emptyList(),
+      closeables = catalogPerPreviewPools.toList(),
     )
   }
 
@@ -528,7 +538,14 @@ class ServeCommand(args: List<String>) : Command(args) {
             onLog = { System.err.println("[daemon serve] $it") },
           )
         val fallback = state.bakedFallback
-        if (fallback != null) ServeCatalogLiveHost(state.previewAliases, daemon, fallback())
+        if (fallback != null)
+          ServeCatalogLiveHost(
+            alias = state.previewAliases,
+            live = daemon,
+            baked = fallback(),
+            perPreviewResolve = state.perPreviewResolve,
+            perPreviewStreamCount = state.perPreviewStreamCount,
+          )
         else daemon
       }
       .getOrNull()
@@ -871,13 +888,20 @@ class ServeCommand(args: List<String>) : Command(args) {
             "serve: catalog $system carries an in-browser Wasm app (/wasm/$system/)"
           )
         },
-        buildTrustedBundle = { system, bundleFile, externalResourcesDir, alias, bakedFallback ->
+        buildTrustedBundle = {
+          system,
+          bundleFile,
+          externalResourcesDir,
+          alias,
+          bakedFallback,
+          fetchPerPreviewBundle ->
           buildTrustedCatalogBundle(
             system,
             bundleFile,
             externalResourcesDir,
             alias,
             bakedFallback,
+            fetchPerPreviewBundle,
             registry,
             openHost,
           )
@@ -929,6 +953,7 @@ class ServeCommand(args: List<String>) : Command(args) {
     externalResourcesDir: File?,
     alias: Map<String, String>,
     bakedFallback: () -> ServeHost,
+    fetchPerPreviewBundle: (daemonId: String) -> File?,
     registry: ServeSessionRegistry,
     openHost: (ServeSessionState) -> ServeHost?,
   ): Boolean {
@@ -937,13 +962,38 @@ class ServeCommand(args: List<String>) : Command(args) {
       java.nio.file.Files.createTempDirectory("serve-catalog-bundle-$system").toFile().also {
         it.deleteOnExit()
       }
-    // Carry the catalog-id→daemon-id alias + the baked-PNG fallback on the state so openHost fronts
-    // the daemon with the baked catalog: the published /p/<id> deep links + /render/<id>.png
-    // thumbnails keep resolving (Android-only variants fall back to baked), while the mapped ids
-    // get
-    // a live lane. See ServeCatalogLiveHost. The rehydrated external-resource pool (fonts lifted
-    // out
-    // of classes/app.jar) joins the daemon classpath so text rasterises with the same faces.
+    // The per-preview live lane (default render path, monolithic fallback): a bounded, idle-LRU
+    // pool
+    // of daemons, one per edited preview, each materialised from that preview's OWN FULL split
+    // bundle fetched from the trusted branch. Shares the monolithic bundle's rehydrated font pool
+    // ([externalResourcesDir]) — both were split from the same externalised bundle — so a
+    // per-preview daemon rasterises text with the same faces without re-fetching. A per-preview
+    // state carries no alias/bakedFallback, so openHost returns the bare single-preview daemon (not
+    // another composite). When the fetch/materialise fails the pool yields null and
+    // ServeCatalogLiveHost falls back to the monolithic daemon, so the lane never regresses.
+    val perPreviewPool = ServePerPreviewDaemonPool { daemonId ->
+      val ppFile = fetchPerPreviewBundle(daemonId) ?: return@ServePerPreviewDaemonPool null
+      val ppDest =
+        java.nio.file.Files.createTempDirectory("serve-catalog-preview-$system").toFile().also {
+          it.deleteOnExit()
+        }
+      val ppState =
+        ServeBundleDaemon.materialize(
+          ppFile,
+          ppDest,
+          system,
+          extraClasspathDirs = listOfNotNull(externalResourcesDir),
+        ) ?: return@ServePerPreviewDaemonPool null
+      openHost(ppState)
+    }
+    catalogPerPreviewPools += perPreviewPool
+    // Carry the catalog-id→daemon-id alias + the baked-PNG fallback + the per-preview lane on the
+    // state so openHost fronts the daemon with the baked catalog: the published /p/<id> deep links
+    // +
+    // /render/<id>.png thumbnails keep resolving (Android-only variants fall back to baked), while
+    // the mapped ids get a live lane. See ServeCatalogLiveHost. The rehydrated external-resource
+    // pool (fonts lifted out of classes/app.jar) joins the daemon classpath so text rasterises with
+    // the same faces.
     val state =
       ServeBundleDaemon.materialize(
           bundleFile,
@@ -951,7 +1001,12 @@ class ServeCommand(args: List<String>) : Command(args) {
           system,
           extraClasspathDirs = listOfNotNull(externalResourcesDir),
         )
-        ?.copy(previewAliases = alias, bakedFallback = bakedFallback) ?: return false
+        ?.copy(
+          previewAliases = alias,
+          bakedFallback = bakedFallback,
+          perPreviewResolve = perPreviewPool::get,
+          perPreviewStreamCount = perPreviewPool::activeStreamCount,
+        ) ?: return false
     val host = openHost(state) ?: return false
     registry.register(system, state, host = host)
     System.err.println("serve: catalog $system → LIVE from bundle (no build) (?session=$system)")

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
@@ -32,6 +32,19 @@ import ee.schimke.composeai.daemon.protocol.StreamFrameParams
  *
  * The net effect: the published catalog behaves exactly as before (static, trusted, instant), plus
  * the CMP components the desktop daemon can run gain an interactive live stream on demand.
+ *
+ * ## Per-preview live lane (default, with monolithic fallback)
+ *
+ * When [perPreviewResolve] is supplied, an override-bearing render/stream first tries to resolve a
+ * daemon that re-renders **only that one preview** from its own per-preview bundle
+ * (`bundle/previews/<daemon-id>.png`, materialised + pooled by the caller). This is the default
+ * render path — small, addressable, per-preview daemons the pool reaps when idle — so the
+ * per-preview bundles the delivery branch ships are exercised routinely. It falls back to the
+ * monolithic [live] `liveBundle` daemon when a per-preview daemon can't be resolved (fetch /
+ * materialise failed, or the preview ships no per-preview bundle), and both fall back to [baked]
+ * when the id has no daemon twin at all. So the worst case is exactly the pre-per-preview
+ * behaviour; the composite never regresses. With [perPreviewResolve] absent it is the plain
+ * monolithic-only host described above.
  */
 class ServeCatalogLiveHost(
   /**
@@ -42,6 +55,17 @@ class ServeCatalogLiveHost(
   private val live: ServeHost,
   /** The static baked-PNG host, keyed by catalog ids (the browse + snapshot surface). */
   private val baked: ServeHost,
+  /**
+   * Resolve a daemon-backed host that re-renders the given **daemon-preview id** from its own
+   * per-preview bundle, or null when none is available. Tried FIRST for an alias-mapped id carrying
+   * a pixel-changing override; a null result falls back to the monolithic [live] daemon. The
+   * returned host is owned + pooled by the caller (this host never closes it), so repeated calls
+   * for the same id should return the pooled instance. `null` (the default) disables the
+   * per-preview lane, leaving the plain monolithic-only host.
+   */
+  private val perPreviewResolve: ((daemonId: String) -> ServeHost?)? = null,
+  /** Live upstream stream count across the pooled per-preview daemons (supplied by the pool). */
+  private val perPreviewStreamCount: () -> Int = { 0 },
 ) : ServeHost {
 
   /**
@@ -118,9 +142,17 @@ class ServeCatalogLiveHost(
    */
   override fun render(previewId: String, overrides: PreviewOverrides): RenderOutcome {
     val daemonId = daemonIdForOverrideRender(previewId, overrides)
-    return if (daemonId != null) live.render(daemonId, overrides)
+    return if (daemonId != null) liveHostFor(daemonId).render(daemonId, overrides)
     else baked.render(previewId, overrides)
   }
+
+  /**
+   * The daemon-backed host to route a mapped [daemonId] to: the per-preview daemon if
+   * [perPreviewResolve] resolves one (the default lane, exercised routinely), else the monolithic
+   * [live] daemon. Both re-render the same daemon id — the per-preview bundle simply carries only
+   * that one preview's closure — so callers pass the daemon id either way.
+   */
+  private fun liveHostFor(daemonId: String): ServeHost = perPreviewResolve?.invoke(daemonId) ?: live
 
   /**
    * SVG export mirrors [render]'s knob routing, plus a fallback: the SVG row is advertised whenever
@@ -132,12 +164,12 @@ class ServeCatalogLiveHost(
    */
   override fun renderSvg(previewId: String, overrides: PreviewOverrides): SvgOutcome {
     daemonIdForOverrideRender(previewId, overrides)?.let {
-      return live.renderSvg(it, overrides)
+      return liveHostFor(it).renderSvg(it, overrides)
     }
     val bakedOutcome = baked.renderSvg(previewId, overrides)
     if (bakedOutcome !is SvgOutcome.NotFound) return bakedOutcome
     val daemonId = alias[previewId] ?: return bakedOutcome
-    return live.renderSvg(daemonId, overrides)
+    return liveHostFor(daemonId).renderSvg(daemonId, overrides)
   }
 
   /**
@@ -157,10 +189,10 @@ class ServeCatalogLiveHost(
     onFrame: (StreamFrameParams) -> Unit,
   ): StreamHandle? {
     val daemonId = alias[previewId] ?: return null
-    return live.subscribeStream(daemonId, overrides, codec, maxFps, onFrame)
+    return liveHostFor(daemonId).subscribeStream(daemonId, overrides, codec, maxFps, onFrame)
   }
 
-  override fun activeStreamCount(): Int = live.activeStreamCount()
+  override fun activeStreamCount(): Int = live.activeStreamCount() + perPreviewStreamCount()
 
   /**
    * Graft the daemon previews' per-preview metadata onto the baked browse surface. The daemon knows

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
@@ -258,8 +258,18 @@ class ServeCatalogStore(
             // own FULL split bundle beside the monolithic one on the trusted branch. Fetched on
             // demand + pooled by the builder; shares the monolithic bundle's rehydrated font pool
             // ([res.dir]) since both were split from the same externalised bundle.
+            //
+            // Collision safety: `bundle split` writes colliding sanitised ids as `<base>.png`,
+            // `<base>-2.png`, … so a daemon id whose sanitised stem is NOT unique among the alias
+            // values would fetch a sibling's bundle under the bare `<stem>.png`. We can't recover
+            // which suffix maps to which id without the publisher's ordering, so we only serve the
+            // per-preview lane for ids with an unambiguous stem; a colliding id resolves null and
+            // falls back to the monolithic daemon (which serves every preview correctly).
+            val safeStems = uniquePerPreviewStems(alias.values)
             val fetchPerPreview: (String) -> File? = { daemonId ->
-              fetchPerPreviewBundle(daemonId, liveBundle, base, dir, safe)
+              safeStems[daemonId]?.let { stem ->
+                fetchPerPreviewBundle(stem, liveBundle, base, dir, safe)
+              }
             }
             if (
               buildTrustedBundle(safe, bundleFile, res.dir, alias, bakedFallback, fetchPerPreview)
@@ -367,32 +377,46 @@ class ServeCatalogStore(
   }
 
   /**
-   * Fetch one preview's own **per-preview FULL bundle**
-   * (`<liveBundle.path>/previews/<daemon-id>.png` on the trusted branch) into
-   * `<dir>/$LIVE_BUNDLE_DIR/$PER_PREVIEW_DIR/<daemon-id>.png` — the unit the per-preview live lane
-   * materialises + pools. `design-artifacts.yml` splits the externalised monolithic bundle into
-   * these (one re-renderable sticker per preview) beside it. Fail-closed like [fetchLiveBundle]: an
-   * invalid/escaping [daemonId] or a fetch miss returns null and the caller simply falls back to
-   * the monolithic daemon for that id (so a branch that ships no per-preview bundles still serves
-   * live from the monolith). Cached on disk: a second request for the same id re-uses the
-   * already-fetched file rather than re-downloading.
+   * The subset of [daemonIds] whose sanitised per-preview stem is **unambiguous** — mapped to that
+   * stem. `bundle split` disambiguates colliding stems with `-2`/`-3`/… suffixes it derives from
+   * the sheet's preview order, which the server can't reconstruct; so an id sharing a stem with
+   * another is dropped here and the caller serves it from the monolithic daemon instead of fetching
+   * a sibling's bundle under the bare `<stem>.png`. A blank stem (an id with no usable characters)
+   * is dropped too.
+   */
+  private fun uniquePerPreviewStems(daemonIds: Collection<String>): Map<String, String> {
+    val counts = HashMap<String, Int>()
+    val stems = LinkedHashMap<String, String>()
+    for (id in daemonIds) {
+      val stem = sanitizePerPreviewName(id)
+      if (stem.isEmpty()) continue
+      stems[id] = stem
+      counts[stem] = (counts[stem] ?: 0) + 1
+    }
+    return stems.filterValues { counts[it] == 1 }
+  }
+
+  /**
+   * Fetch one preview's own **per-preview FULL bundle** (`<liveBundle.path>/previews/<stem>.png` on
+   * the trusted branch) into `<dir>/$LIVE_BUNDLE_DIR/$PER_PREVIEW_DIR/<stem>.png` — the unit the
+   * per-preview live lane materialises + pools. `design-artifacts.yml` splits the externalised
+   * monolithic bundle into these (one re-renderable sticker per preview) beside it. Fail-closed
+   * like [fetchLiveBundle]: an escaping [stem] or a fetch miss returns null and the caller simply
+   * falls back to the monolithic daemon for that id (so a branch that ships no per-preview bundles
+   * still serves live from the monolith). Cached on disk: a second request for the same stem
+   * re-uses the already-fetched file rather than re-downloading.
    *
-   * [daemonId] is a bundle preview descriptor id (the [alias][previewAliasFor] values), sanitised
-   * to the same route-safe stem `bundle split` wrote the file under (keep `A-Za-z0-9._-`, else
-   * `_`), so the URL stem matches the published filename.
+   * [stem] is the route-safe filename `bundle split` wrote the bundle under (a sanitised bundle
+   * preview descriptor id), pre-resolved by [uniquePerPreviewStems] so it's unambiguous — the URL
+   * stem matches the published filename exactly.
    */
   private fun fetchPerPreviewBundle(
-    daemonId: String,
+    stem: String,
     liveBundle: LiveBundle,
     base: String,
     dir: File,
     system: String,
   ): File? {
-    val stem = sanitizePerPreviewName(daemonId)
-    if (stem.isEmpty()) {
-      System.err.println("serve: $system per-preview id '$daemonId' is unusable — skipping")
-      return null
-    }
     val previewsDir = File(File(dir, LIVE_BUNDLE_DIR), PER_PREVIEW_DIR)
     val previewsRoot = previewsDir.canonicalFile.toPath()
     val target = File(previewsDir, "$stem.png")

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
@@ -60,6 +60,16 @@ class ServeCatalogStore(
    * rehydrated font/resource pool the daemon adds to its classpath (see
    * [rehydrateExternalResources]) — null when the bundle carried its resources inline (a
    * self-contained pack).
+   *
+   * `fetchPerPreviewBundle` lifts the **per-preview live lane** (the default render path, with the
+   * monolithic bundle as fallback): given a daemon-preview id it fetches that preview's own FULL
+   * split bundle (`<liveBundle.path>/previews/<daemon-id>.png` on the same trusted branch,
+   * fail-closed) into a local file, or null when the branch ships none / the fetch fails. The
+   * per-preview FULL bundles were split from the *externalised* monolithic bundle, so they share
+   * its font pool — the caller re-uses the monolithic bundle's already-rehydrated
+   * `externalResourcesDir` rather than re-fetching. The builder pools + materialises these on
+   * demand and prefers them over the monolithic daemon; a null resolve falls back to it, so the
+   * lane is exercised routinely without ever regressing.
    */
   private val buildTrustedBundle:
     (
@@ -68,8 +78,9 @@ class ServeCatalogStore(
       externalResourcesDir: File?,
       alias: Map<String, String>,
       bakedFallback: () -> ServeHost,
+      fetchPerPreviewBundle: (daemonId: String) -> File?,
     ) -> Boolean =
-    { _, _, _, _, _ ->
+    { _, _, _, _, _, _ ->
       false
     },
   /**
@@ -242,10 +253,20 @@ class ServeCatalogStore(
         // broken
         // live tier.
         when (val res = rehydrateExternalResources(bundleFile, base, liveBundle.path, dir, safe)) {
-          is ResRehydrate.Ready ->
-            if (buildTrustedBundle(safe, bundleFile, res.dir, alias, bakedFallback)) {
+          is ResRehydrate.Ready -> {
+            // The per-preview live lane (default render path): each daemon-preview id maps to its
+            // own FULL split bundle beside the monolithic one on the trusted branch. Fetched on
+            // demand + pooled by the builder; shares the monolithic bundle's rehydrated font pool
+            // ([res.dir]) since both were split from the same externalised bundle.
+            val fetchPerPreview: (String) -> File? = { daemonId ->
+              fetchPerPreviewBundle(daemonId, liveBundle, base, dir, safe)
+            }
+            if (
+              buildTrustedBundle(safe, bundleFile, res.dir, alias, bakedFallback, fetchPerPreview)
+            ) {
               return Result.Ok(safe, count, "${BundleVerifier.summary(verdict)} (live bundle)")
             }
+          }
           ResRehydrate.Unavailable -> {} // fall through to source/static
         }
       }
@@ -343,6 +364,61 @@ class ServeCatalogStore(
     target.parentFile?.mkdirs()
     target.writeBytes(bytes)
     return target
+  }
+
+  /**
+   * Fetch one preview's own **per-preview FULL bundle**
+   * (`<liveBundle.path>/previews/<daemon-id>.png` on the trusted branch) into
+   * `<dir>/$LIVE_BUNDLE_DIR/$PER_PREVIEW_DIR/<daemon-id>.png` — the unit the per-preview live lane
+   * materialises + pools. `design-artifacts.yml` splits the externalised monolithic bundle into
+   * these (one re-renderable sticker per preview) beside it. Fail-closed like [fetchLiveBundle]: an
+   * invalid/escaping [daemonId] or a fetch miss returns null and the caller simply falls back to
+   * the monolithic daemon for that id (so a branch that ships no per-preview bundles still serves
+   * live from the monolith). Cached on disk: a second request for the same id re-uses the
+   * already-fetched file rather than re-downloading.
+   *
+   * [daemonId] is a bundle preview descriptor id (the [alias][previewAliasFor] values), sanitised
+   * to the same route-safe stem `bundle split` wrote the file under (keep `A-Za-z0-9._-`, else
+   * `_`), so the URL stem matches the published filename.
+   */
+  private fun fetchPerPreviewBundle(
+    daemonId: String,
+    liveBundle: LiveBundle,
+    base: String,
+    dir: File,
+    system: String,
+  ): File? {
+    val stem = sanitizePerPreviewName(daemonId)
+    if (stem.isEmpty()) {
+      System.err.println("serve: $system per-preview id '$daemonId' is unusable — skipping")
+      return null
+    }
+    val previewsDir = File(File(dir, LIVE_BUNDLE_DIR), PER_PREVIEW_DIR)
+    val previewsRoot = previewsDir.canonicalFile.toPath()
+    val target = File(previewsDir, "$stem.png")
+    if (!target.canonicalFile.toPath().startsWith(previewsRoot)) {
+      System.err.println("serve: $system per-preview '$stem' escapes — skipping")
+      return null
+    }
+    // Cached on disk from a prior request for the same id (the pool reopens lazily on eviction).
+    if (target.isFile && target.length() > 0) return target
+    val prefix = liveBundle.path.trim('/')
+    val rel = "$PER_PREVIEW_DIR/$stem.png"
+    val url = if (prefix.isEmpty()) "$base$rel" else "$base$prefix/$rel"
+    val bytes = runCatching { fetch(url) }.getOrNull()
+    if (bytes == null) {
+      // Expected when the branch ships no per-preview bundle for this id (older catalog, view-only
+      // tier); the caller falls back to the monolithic daemon. Quiet — not an error.
+      return null
+    }
+    target.parentFile?.mkdirs()
+    target.writeBytes(bytes)
+    return target
+  }
+
+  /** Filesystem/route-safe stem for a per-preview id (mirrors `bundle split`'s sanitiser). */
+  private fun sanitizePerPreviewName(id: String): String = buildString {
+    for (c in id) append(if (c.isLetterOrDigit() || c == '.' || c == '_' || c == '-') c else '_')
   }
 
   /**
@@ -554,6 +630,14 @@ class ServeCatalogStore(
     private const val MAX_WASM_FILES = 64
     /** Local subdir a catalog's `liveBundle` file is fetched into (`<dir>/bundle/<file>`). */
     const val LIVE_BUNDLE_DIR = "bundle"
+
+    /**
+     * Branch- and local-relative subdir (under `liveBundle.path` / [LIVE_BUNDLE_DIR]) holding the
+     * per-preview FULL split bundles `design-artifacts.yml` writes (`previews/<daemon-id>.png`),
+     * one re-renderable sticker per preview. Fetched by [fetchPerPreviewBundle] for the per-preview
+     * live lane.
+     */
+    const val PER_PREVIEW_DIR = "previews"
 
     /**
      * Branch-relative subdir (under the `liveBundle.path`) holding the bundle's externalized

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServePerPreviewDaemonPool.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServePerPreviewDaemonPool.kt
@@ -1,0 +1,76 @@
+package ee.schimke.composeai.cli.serve
+
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+
+/**
+ * A bounded, LRU pool of per-preview daemon hosts backing [ServePerPreviewLiveHost]. Each entry is
+ * a daemon-backed [ServeHost] materialised from ONE preview's own bundle
+ * (`bundle/previews/<id>.png`), opened lazily on the first override render for that daemon id and
+ * kept for reuse. When the pool exceeds [maxOpen] the least-recently-used daemon is closed (its
+ * subprocess torn down), so the server holds live daemons only for the handful of previews being
+ * actively edited — the per-preview counterpart of the one monolithic catalog daemon.
+ *
+ * Thread-safe: a miss opens **under the lock**, so concurrent requests for the same id share one
+ * daemon rather than racing two subprocess launches (opens are serialised, which is fine — a daemon
+ * launch is the expensive step and duplicate launches for one preview would only waste a slot).
+ *
+ * [open] returns null when a preview has no usable per-preview bundle (fetch / materialise failed);
+ * [get] then returns null and the caller ([ServePerPreviewLiveHost.resolveLive]) falls back to the
+ * baked PNG. A null open is **not** cached, so a transient fetch failure recovers on a later
+ * request.
+ */
+class ServePerPreviewDaemonPool(
+  private val maxOpen: Int = DEFAULT_MAX_OPEN,
+  private val open: (daemonId: String) -> ServeHost?,
+) : AutoCloseable {
+
+  private val lock = ReentrantLock()
+
+  // Access-order LRU: reading a key moves it to most-recently-used; the eldest entry is the LRU one
+  // evicted first when the pool is over [maxOpen].
+  private val hosts = LinkedHashMap<String, ServeHost>(16, 0.75f, true)
+
+  private var closed = false
+
+  /**
+   * The pooled per-preview daemon for [daemonId], opening + caching it on a miss. Returns null when
+   * no per-preview daemon could be opened (so the caller replays the baked PNG); a null is never
+   * cached. Opening a new daemon beyond [maxOpen] evicts + closes the least-recently-used one.
+   */
+  fun get(daemonId: String): ServeHost? = lock.withLock {
+    if (closed) return null
+    hosts[daemonId]?.let {
+      return it
+    }
+    val host = open(daemonId) ?: return null
+    hosts[daemonId] = host
+    while (hosts.size > maxOpen) {
+      val eldest = hosts.entries.iterator().next()
+      hosts.remove(eldest.key)
+      runCatching { eldest.value.close() }
+    }
+    host
+  }
+
+  /** Live per-preview daemons currently held (diagnostics). */
+  fun openCount(): Int = lock.withLock { hosts.size }
+
+  /** Total live upstream streams across the pooled per-preview daemons. */
+  fun activeStreamCount(): Int = lock.withLock { hosts.values.sumOf { it.activeStreamCount() } }
+
+  override fun close() = lock.withLock {
+    closed = true
+    hosts.values.forEach { runCatching { it.close() } }
+    hosts.clear()
+  }
+
+  companion object {
+    /**
+     * Default cap on concurrently-held per-preview daemons. A preview server sees a few previews
+     * edited at a time, and each held daemon is a JVM Compose render subprocess, so keep this
+     * small; the LRU reaps the rest.
+     */
+    const val DEFAULT_MAX_OPEN = 8
+  }
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServePerPreviewDaemonPool.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServePerPreviewDaemonPool.kt
@@ -7,9 +7,13 @@ import kotlin.concurrent.withLock
  * A bounded, LRU pool of per-preview daemon hosts backing [ServePerPreviewLiveHost]. Each entry is
  * a daemon-backed [ServeHost] materialised from ONE preview's own bundle
  * (`bundle/previews/<id>.png`), opened lazily on the first override render for that daemon id and
- * kept for reuse. When the pool exceeds [maxOpen] the least-recently-used daemon is closed (its
- * subprocess torn down), so the server holds live daemons only for the handful of previews being
- * actively edited — the per-preview counterpart of the one monolithic catalog daemon.
+ * kept for reuse. When the pool exceeds [maxOpen] the least-recently-used daemon **that has no
+ * active stream** is closed (its subprocess torn down), so the server holds live daemons only for
+ * the handful of previews being actively edited — the per-preview counterpart of the one monolithic
+ * catalog daemon. A daemon backing a live WebSocket stream is retained even past the cap (the cap
+ * is a soft target): the pool is touched only once, when the stream is opened
+ * ([ServeCatalogLiveHost.subscribeStream]), so a long-lived stream ages into the LRU slot and must
+ * never be closed out from under its connected client.
  *
  * Thread-safe: a miss opens **under the lock**, so concurrent requests for the same id share one
  * daemon rather than racing two subprocess launches (opens are serialised, which is fine — a daemon
@@ -36,7 +40,8 @@ class ServePerPreviewDaemonPool(
   /**
    * The pooled per-preview daemon for [daemonId], opening + caching it on a miss. Returns null when
    * no per-preview daemon could be opened (so the caller replays the baked PNG); a null is never
-   * cached. Opening a new daemon beyond [maxOpen] evicts + closes the least-recently-used one.
+   * cached. Opening a new daemon beyond [maxOpen] evicts + closes the least-recently-used one that
+   * isn't backing a live stream (see [evictExcess]).
    */
   fun get(daemonId: String): ServeHost? = lock.withLock {
     if (closed) return null
@@ -45,12 +50,25 @@ class ServePerPreviewDaemonPool(
     }
     val host = open(daemonId) ?: return null
     hosts[daemonId] = host
-    while (hosts.size > maxOpen) {
-      val eldest = hosts.entries.iterator().next()
-      hosts.remove(eldest.key)
-      runCatching { eldest.value.close() }
-    }
+    evictExcess()
     host
+  }
+
+  /**
+   * Trim the pool back to [maxOpen] by closing least-recently-used daemons — but never one with an
+   * active stream. Access-order iteration is LRU-first, so [firstOrNull] finds the least-recently
+   * used **evictable** (stream-free) host; a streaming daemon is retained even past the cap rather
+   * than closed out from under its connected client. When every held daemon is streaming there's
+   * nothing to evict and the pool holds over the cap until a stream ends (bounded by the live-seat
+   * cap). Caller holds [lock]. Iterating `entries` doesn't count as an access, so it can't reorder
+   * the LRU mid-scan.
+   */
+  private fun evictExcess() {
+    while (hosts.size > maxOpen) {
+      val evictable = hosts.entries.firstOrNull { it.value.activeStreamCount() == 0 } ?: break
+      hosts.remove(evictable.key)
+      runCatching { evictable.value.close() }
+    }
   }
 
   /** Live per-preview daemons currently held (diagnostics). */

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionState.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionState.kt
@@ -42,4 +42,18 @@ data class ServeSessionState(
    * resume (the baked dir persists), so suspend/resume is preserved. Null for plain sessions.
    */
   val bakedFallback: (() -> ServeHost)? = null,
+  /**
+   * Optional **per-preview live lane** resolver, set only for a trusted-catalog live-bundle session
+   * whose branch ships per-preview FULL bundles ([ServeCatalogStore]). Given a daemon-preview id it
+   * returns a daemon-backed host that re-renders **only that one preview** from its own bundle,
+   * pooled with idle LRU eviction, or null when none is available. [openHost][ServeCommand] hands
+   * it to the [ServeCatalogLiveHost] as the default render lane (tried before the monolithic
+   * daemon), so the small per-preview bundles are exercised routinely; a null result falls back to
+   * the monolithic daemon, so the session never regresses. The pool is owned by the command (closed
+   * at server shutdown) and outlives suspend/resume, so this stays valid across re-opens. Null for
+   * plain sessions and for a branch that ships only the monolithic bundle.
+   */
+  val perPreviewResolve: ((daemonId: String) -> ServeHost?)? = null,
+  /** Live upstream stream count across the pooled per-preview daemons (see [perPreviewResolve]). */
+  val perPreviewStreamCount: () -> Int = { 0 },
 )

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
@@ -405,4 +405,122 @@ class ServeCatalogLiveHostTest {
     assertTrue(live.closed)
     assertTrue(baked.closed)
   }
+
+  // --- Per-preview lane (default, with monolithic fallback) -----------------------------------
+
+  @Test
+  fun `an override render prefers the per-preview daemon over the monolithic one`() {
+    val baked = RecordingHost(previews = listOf(ServePreview(catalogId, catalogId)), tag = "baked")
+    val monolithic =
+      RecordingHost(
+        previews = listOf(ServePreview(daemonId, daemonId, overrides = listOf(labelKnob))),
+        tag = "mono",
+        streaming = true,
+      )
+    val perPreview = RecordingHost(previews = emptyList(), tag = "per")
+    val composite =
+      ServeCatalogLiveHost(
+        alias = mapOf(catalogId to daemonId),
+        live = monolithic,
+        baked = baked,
+        perPreviewResolve = { id -> if (id == daemonId) perPreview else null },
+      )
+
+    // A knob edit resolves the per-preview daemon FIRST — the monolithic one is never touched, so
+    // the small per-preview bundle is the routinely-exercised default lane.
+    val out = composite.render(catalogId, knobOverride()) as RenderOutcome.Ok
+    assertEquals("per:$daemonId", out.png.decodeToString())
+    assertEquals(daemonId, perPreview.lastRenderId)
+    assertNull(monolithic.lastRenderId)
+    assertNull(baked.lastRenderId)
+  }
+
+  @Test
+  fun `an override render falls back to the monolithic daemon when no per-preview daemon resolves`() {
+    val (_, monolithic, baked) = host()
+    // The per-preview resolver always fails (no per-preview bundle / materialise failed). The
+    // composite must fall back to the monolithic liveBundle daemon, never baked, so a knob edit
+    // still re-renders — worst case is exactly the pre-per-preview behaviour.
+    val composite =
+      ServeCatalogLiveHost(
+        alias = mapOf(catalogId to daemonId),
+        live = monolithic,
+        baked = baked,
+        perPreviewResolve = { null },
+      )
+
+    val out = composite.render(catalogId, knobOverride()) as RenderOutcome.Ok
+    assertEquals("live:$daemonId", out.png.decodeToString())
+    assertEquals(daemonId, monolithic.lastRenderId)
+    assertNull(baked.lastRenderId)
+  }
+
+  @Test
+  fun `a plain snapshot never resolves a per-preview daemon`() {
+    var resolved = false
+    val baked = RecordingHost(previews = listOf(ServePreview(catalogId, catalogId)), tag = "baked")
+    val monolithic =
+      RecordingHost(
+        previews = listOf(ServePreview(daemonId, daemonId)),
+        tag = "mono",
+        streaming = true,
+      )
+    val composite =
+      ServeCatalogLiveHost(
+        alias = mapOf(catalogId to daemonId),
+        live = monolithic,
+        baked = baked,
+        perPreviewResolve = {
+          resolved = true
+          null
+        },
+      )
+    // Ordinary browsing stays baked and must not even ask the pool to spin up a per-preview daemon.
+    val out = composite.render(catalogId, PreviewOverrides()) as RenderOutcome.Ok
+    assertEquals("baked:$catalogId", out.png.decodeToString())
+    assertEquals(false, resolved)
+    assertNull(monolithic.lastRenderId)
+  }
+
+  @Test
+  fun `a live stream prefers the per-preview daemon over the monolithic one`() {
+    val baked = RecordingHost(previews = listOf(ServePreview(catalogId, catalogId)), tag = "baked")
+    val monolithic =
+      RecordingHost(
+        previews = listOf(ServePreview(daemonId, daemonId)),
+        tag = "mono",
+        streaming = true,
+      )
+    val perPreview = RecordingHost(previews = emptyList(), tag = "per", streaming = true)
+    val composite =
+      ServeCatalogLiveHost(
+        alias = mapOf(catalogId to daemonId),
+        live = monolithic,
+        baked = baked,
+        perPreviewResolve = { perPreview },
+      )
+    val handle = composite.subscribeStream(catalogId, PreviewOverrides(), null, null) {}
+    assertTrue(handle != null)
+    assertEquals(daemonId, perPreview.lastStreamId)
+    assertNull(monolithic.lastStreamId)
+  }
+
+  @Test
+  fun `activeStreamCount sums the monolithic and per-preview lanes`() {
+    val baked = RecordingHost(previews = listOf(ServePreview(catalogId, catalogId)), tag = "baked")
+    val monolithic =
+      RecordingHost(
+        previews = listOf(ServePreview(daemonId, daemonId)),
+        tag = "mono",
+        streaming = true,
+      )
+    val composite =
+      ServeCatalogLiveHost(
+        alias = mapOf(catalogId to daemonId),
+        live = monolithic, // reports 1 active stream
+        baked = baked,
+        perPreviewStreamCount = { 3 },
+      )
+    assertEquals(4, composite.activeStreamCount())
+  }
 }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
@@ -236,6 +236,54 @@ class ServeCatalogStoreTest {
   }
 
   @Test
+  fun `daemon ids that sanitize to the same stem skip the per-preview lane`() {
+    // `bundle split` disambiguates colliding sanitised ids with -2/-3 suffixes the server can't
+    // reconstruct, so two daemon ids that sanitise to one stem ("Foo Bar" and "Foo_Bar" → Foo_Bar)
+    // must NOT fetch the bare <stem>.png (that's only one of them) — both resolve null and fall
+    // back to the monolithic daemon, which renders every preview correctly.
+    val json =
+      """
+      {"schema":"design-parity-catalog/v1","system":"compose-m3",
+       "liveBundle":{"path":"bundle/","file":"compose-m3-bundle.png"},
+       "components":[{"componentId":"Foo","images":[
+         {"path":"images/foo/a.png","theme":"dark","previewId":"Foo Bar"},
+         {"path":"images/foo/b.png","theme":"dark","previewId":"Foo_Bar"}]}]}
+      """
+        .trimIndent()
+    val fetch: (String) -> ByteArray? = { url ->
+      when {
+        url.endsWith("/${ServeCatalogStore.CATALOG_FILE}") -> json.toByteArray()
+        url.endsWith("bundle/compose-m3-bundle.png") -> byteArrayOf(1, 2, 3)
+        url.contains("bundle/previews/") -> byteArrayOf(4, 5, 6) // present, but must NOT be used
+        url.endsWith(".png") -> png()
+        else -> null
+      }
+    }
+    val trust =
+      TrustStore(
+        branches = listOf(TrustedBranch("yschimke/compose-ai-tools", "design-artifacts/*"))
+      )
+    var fetchPerPreview: ((String) -> File?)? = null
+    val store =
+      ServeCatalogStore(
+        root = tempRoot(),
+        register = { n, h -> registered[n] = h },
+        trust = trust,
+        fetch = fetch,
+        buildTrustedBundle = { _, _, _, _, _, fetcher ->
+          fetchPerPreview = fetcher
+          true
+        },
+      )
+    store.load("compose-m3")
+
+    val fetcher = fetchPerPreview!!
+    // Both colliding ids skip the per-preview lane (null) despite the branch serving a Foo_Bar.png.
+    assertNull(fetcher("Foo Bar"))
+    assertNull(fetcher("Foo_Bar"))
+  }
+
+  @Test
   fun `a trusted liveBundle's externalized fonts are fetched into a cache and materialized`() {
     // The bundle's manifest declares an externalized font (lifted out of classes/app.jar by
     // `bundle externalize`); the store must fetch it from bundle/res/<sha>, verify the hash, cache

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
@@ -7,8 +7,10 @@ import java.io.File
 import java.nio.file.Files
 import javax.imageio.ImageIO
 import kotlin.test.Test
+import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 /**
@@ -154,7 +156,7 @@ class ServeCatalogStoreTest {
         register = { n, h -> registered[n] = h },
         trust = trust,
         fetch = fetch,
-        buildTrustedBundle = { _, _, _, alias, _ ->
+        buildTrustedBundle = { _, _, _, alias, _, _ ->
           captured = alias
           true // pretend the live host took over, so no static host is registered
         },
@@ -166,6 +168,71 @@ class ServeCatalogStoreTest {
     assertEquals(mapOf("button-filled__ideal__default__dark" to "FilledButton_Dark"), captured)
     // The live builder claimed the session, so nothing was registered as a plain static host.
     assertTrue(registered["compose-m3"] == null)
+  }
+
+  @Test
+  fun `the per-preview fetcher fetches a daemon-id's own split bundle beside the liveBundle`() {
+    // The builder is handed a per-preview fetcher: given a daemon-preview id it fetches that
+    // preview's OWN FULL split bundle from <liveBundle.path>/previews/<daemon-id>.png on the same
+    // branch (the default render lane). A hit returns a local file; a miss (no per-preview bundle)
+    // returns null so the caller falls back to the monolithic daemon.
+    val json =
+      """
+      {"schema":"design-parity-catalog/v1","system":"compose-m3",
+       "liveBundle":{"path":"bundle/","file":"compose-m3-bundle.png"},
+       "components":[{"componentId":"Button/Filled","images":[
+         {"path":"images/button-filled/ideal__default__dark.png","theme":"dark","previewId":"FilledButton_Dark"}]}]}
+      """
+        .trimIndent()
+    val perPreviewBytes = byteArrayOf(9, 8, 7)
+    val requested = mutableListOf<String>()
+    val fetch: (String) -> ByteArray? = { url ->
+      requested += url
+      when {
+        url.endsWith("/${ServeCatalogStore.CATALOG_FILE}") -> json.toByteArray()
+        url.endsWith("bundle/compose-m3-bundle.png") -> byteArrayOf(1, 2, 3)
+        url.endsWith("bundle/previews/FilledButton_Dark.png") -> perPreviewBytes
+        // Any OTHER per-preview bundle 404s (the branch ships none for it).
+        url.contains("bundle/previews/") -> null
+        url.endsWith(".png") -> png()
+        else -> null
+      }
+    }
+    val trust =
+      TrustStore(
+        branches = listOf(TrustedBranch("yschimke/compose-ai-tools", "design-artifacts/*"))
+      )
+    var fetchPerPreview: ((String) -> File?)? = null
+    val store =
+      ServeCatalogStore(
+        root = tempRoot(),
+        register = { n, h -> registered[n] = h },
+        trust = trust,
+        fetch = fetch,
+        buildTrustedBundle = { _, _, _, _, _, fetcher ->
+          fetchPerPreview = fetcher
+          true
+        },
+      )
+    store.load("compose-m3")
+
+    val fetcher = fetchPerPreview
+    assertTrue(fetcher != null, "the builder was handed a per-preview fetcher")
+    // A mapped daemon id resolves its own split bundle from previews/<daemon-id>.png…
+    val hit = fetcher!!("FilledButton_Dark")
+    assertTrue(hit != null && hit.isFile)
+    assertContentEquals(perPreviewBytes, hit.readBytes())
+    assertTrue(requested.any { it.endsWith("bundle/previews/FilledButton_Dark.png") })
+    // …a second request for the same id re-uses the cached file rather than re-downloading…
+    val fetchCountBefore = requested.count { it.endsWith("bundle/previews/FilledButton_Dark.png") }
+    fetcher("FilledButton_Dark")
+    assertEquals(
+      fetchCountBefore,
+      requested.count { it.endsWith("bundle/previews/FilledButton_Dark.png") },
+      "the cached per-preview bundle is re-used",
+    )
+    // …and an id the branch ships no per-preview bundle for yields null (falls back to monolith).
+    assertNull(fetcher("MissingButton_Light"))
   }
 
   @Test
@@ -219,7 +286,7 @@ class ServeCatalogStoreTest {
         register = { n, h -> registered[n] = h },
         trust = trust,
         fetch = fetch,
-        buildTrustedBundle = { _, _, externalResourcesDir, _, _ ->
+        buildTrustedBundle = { _, _, externalResourcesDir, _, _, _ ->
           capturedDir = externalResourcesDir
           true
         },
@@ -281,7 +348,7 @@ class ServeCatalogStoreTest {
         register = { n, h -> registered[n] = h },
         trust = trust,
         fetch = fetch,
-        buildTrustedBundle = { _, _, _, _, _ ->
+        buildTrustedBundle = { _, _, _, _, _, _ ->
           builderCalled = true
           true
         },
@@ -350,7 +417,7 @@ class ServeCatalogStoreTest {
         register = { n, h -> registered[n] = h },
         trust = trust,
         fetch = fetch,
-        buildTrustedBundle = { _, _, externalResourcesDir, _, _ ->
+        buildTrustedBundle = { _, _, externalResourcesDir, _, _, _ ->
           capturedDir = externalResourcesDir
           true
         },

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServePerPreviewDaemonPoolTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServePerPreviewDaemonPoolTest.kt
@@ -1,0 +1,107 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.daemon.protocol.StreamCodec
+import ee.schimke.composeai.daemon.protocol.StreamFrameParams
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+/**
+ * [ServePerPreviewDaemonPool] opens a per-preview daemon lazily on the first request for its id,
+ * reuses it, evicts + closes the least-recently-used one over the cap, and never caches a failed
+ * (null) open. It's the idle-bounded fleet behind [ServePerPreviewLiveHost].
+ */
+class ServePerPreviewDaemonPoolTest {
+
+  private class FakeHost(private val streams: Int = 0) : ServeHost {
+    override val previews: List<ServePreview> = emptyList()
+    override val label: String = "fake"
+    var closed = false
+
+    override fun render(previewId: String, overrides: PreviewOverrides): RenderOutcome =
+      RenderOutcome.Ok(ByteArray(0))
+
+    override fun subscribeStream(
+      previewId: String,
+      overrides: PreviewOverrides,
+      codec: StreamCodec?,
+      maxFps: Int?,
+      onFrame: (StreamFrameParams) -> Unit,
+    ): StreamHandle? = null
+
+    override fun activeStreamCount(): Int = streams
+
+    override fun close() {
+      closed = true
+    }
+  }
+
+  @Test
+  fun `opens on a miss, then reuses the same daemon`() {
+    val opens = mutableListOf<String>()
+    val pool = ServePerPreviewDaemonPool { id -> FakeHost().also { opens.add(id) } }
+    val first = pool.get("A")
+    val second = pool.get("A")
+    assertSame(first, second, "the same id reuses the pooled daemon")
+    assertEquals(listOf("A"), opens, "opened exactly once")
+    assertEquals(1, pool.openCount())
+  }
+
+  @Test
+  fun `a failed (null) open is not cached and retries`() {
+    var fail = true
+    val opens = mutableListOf<String>()
+    val pool = ServePerPreviewDaemonPool { id ->
+      opens.add(id)
+      if (fail) null else FakeHost()
+    }
+    assertNull(pool.get("A"), "no daemon when the open fails")
+    assertEquals(0, pool.openCount(), "a null open is not cached")
+    fail = false
+    assertTrue(pool.get("A") != null, "a later request recovers")
+    assertEquals(
+      listOf("A", "A"),
+      opens,
+      "it re-attempted the open rather than caching the failure",
+    )
+  }
+
+  @Test
+  fun `evicts and closes the least-recently-used daemon over the cap`() {
+    val hosts = mutableMapOf<String, FakeHost>()
+    val pool = ServePerPreviewDaemonPool(maxOpen = 2) { id -> FakeHost().also { hosts[id] = it } }
+    pool.get("A")
+    pool.get("B")
+    // Touch A so B is now the least-recently-used.
+    pool.get("A")
+    // Opening C evicts B (LRU), closing its daemon.
+    pool.get("C")
+    assertEquals(2, pool.openCount(), "capped at maxOpen")
+    assertTrue(hosts.getValue("B").closed, "the LRU daemon was torn down")
+    assertEquals(false, hosts.getValue("A").closed, "the recently-used daemon stays open")
+    assertEquals(false, hosts.getValue("C").closed)
+    // A is still pooled (reused, not reopened); C is pooled.
+    val opensAfter = mutableListOf<String>()
+    val probe =
+      ServePerPreviewDaemonPool(maxOpen = 2) { id -> FakeHost().also { opensAfter.add(id) } }
+    probe.get("A")
+    assertEquals(listOf("A"), opensAfter)
+  }
+
+  @Test
+  fun `activeStreamCount sums the pooled daemons and close tears them all down`() {
+    val hosts = mutableListOf<FakeHost>()
+    val pool =
+      ServePerPreviewDaemonPool(maxOpen = 8) { _ -> FakeHost(streams = 1).also { hosts.add(it) } }
+    pool.get("A")
+    pool.get("B")
+    assertEquals(2, pool.activeStreamCount(), "one stream per pooled daemon")
+    pool.close()
+    assertEquals(0, pool.openCount())
+    assertTrue(hosts.all { it.closed }, "close tears down every held daemon")
+    assertNull(pool.get("A"), "a closed pool opens nothing")
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServePerPreviewDaemonPoolTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServePerPreviewDaemonPoolTest.kt
@@ -92,6 +92,42 @@ class ServePerPreviewDaemonPoolTest {
   }
 
   @Test
+  fun `eviction retains a streaming daemon and closes an idle one instead`() {
+    // A is the eldest but is backing a live stream; B is idle. Opening C over the cap must NOT
+    // close A out from under its client — it evicts the idle B (older-but-streaming A is retained
+    // even though it's the LRU entry, since the pool is only touched once at subscribe).
+    val hosts = mutableMapOf<String, FakeHost>()
+    var nextStreams = 1 // A streams; B and C don't
+    val pool =
+      ServePerPreviewDaemonPool(maxOpen = 2) { id ->
+        FakeHost(streams = nextStreams).also {
+          hosts[id] = it
+          nextStreams = 0
+        }
+      }
+    pool.get("A") // streaming
+    pool.get("B") // idle
+    pool.get("C") // over cap → evict an idle LRU host, not the streaming A
+    assertEquals(false, hosts.getValue("A").closed, "the streaming daemon is retained past the cap")
+    assertTrue(hosts.getValue("B").closed, "the idle LRU daemon was evicted instead")
+    assertEquals(false, hosts.getValue("C").closed)
+  }
+
+  @Test
+  fun `eviction holds over the cap when every daemon is streaming`() {
+    // All held daemons back a live stream, so none is evictable; the pool holds over the cap rather
+    // than close a connected client's daemon. The soft cap is bounded by the live-seat cap
+    // upstream.
+    val hosts = mutableListOf<FakeHost>()
+    val pool =
+      ServePerPreviewDaemonPool(maxOpen = 1) { _ -> FakeHost(streams = 1).also { hosts.add(it) } }
+    pool.get("A")
+    pool.get("B")
+    assertEquals(2, pool.openCount(), "no streaming daemon is evicted even over the cap")
+    assertTrue(hosts.none { it.closed })
+  }
+
+  @Test
   fun `activeStreamCount sums the pooled daemons and close tears them all down`() {
     val hosts = mutableListOf<FakeHost>()
     val pool =


### PR DESCRIPTION
## Summary

Wires the `serve` trusted-catalog live path to render each preview from its **own per-preview FULL bundle** (`bundle/previews/<daemon-id>.png` on the `design-artifacts/<system>` branch) as the **default** render lane, falling back to the monolithic `liveBundle` daemon and then the baked PNG. This makes the small, addressable per-preview bundles the delivery branch already ships (`design-artifacts.yml`'s FULL split) get exercised routinely — while guaranteeing the worst case is exactly the pre-per-preview behaviour, so the composite never regresses.

Render routing per request, for a mapped id carrying a pixel-changing override:

```
per-preview daemon (own bundle)  →  monolithic liveBundle daemon  →  baked PNG
      (default, pooled)                    (fallback)                 (unmapped / no daemon)
```

Ordinary browsing (no override, or a sticky-theme replay) still serves the baked PNG instantly and never wakes any daemon.

### Changes
- **`ServeCatalogLiveHost`** gains an optional `perPreviewResolve` (+ `perPreviewStreamCount`). It's tried first in `render` / `renderSvg` / `subscribeStream` via a `liveHostFor(daemonId)` helper; a `null` resolve falls back to the monolithic `live` daemon. `activeStreamCount()` sums both lanes so an active per-preview stream keeps the session from being idle-suspended. With the resolver absent it's the unchanged monolithic-only host.
- **`ServeCatalogStore`** fetches a daemon id's own split bundle from the same trusted branch (`<liveBundle.path>/previews/<daemon-id>.png`), fail-closed + path-contained + disk-cached, and re-uses the monolithic bundle's already-rehydrated font pool (both were split from the same *externalised* bundle, so they share `bundle/res/<sha>`). The `buildTrustedBundle` seam gains a `fetchPerPreviewBundle` param.
- **`ServeCommand`** builds a bounded, idle-LRU `ServePerPreviewDaemonPool` per live catalog whose opener does fetch → `materialize` → bare single-preview daemon, threads its `get` / `activeStreamCount` onto `ServeSessionState`, and tears the pool down at server shutdown (it outlives suspend/resume, so it can't be owned by the session host).

### Notes
- Per-preview daemons are bounded by the pool's `maxOpen` LRU (default 8 per catalog); eviction closes the evicted daemon. The pool open runs under the pool lock (serialised), matching the registry's "correctness beats build concurrency" stance.
- A branch that ships no per-preview bundles (older catalog, view-only tier) simply resolves `null` every time and serves live from the monolith — no behaviour change there.

## Test plan
- `ServeCatalogLiveHostTest` — new cases: an override render/stream prefers the per-preview daemon; falls back to the monolithic daemon when none resolves; a plain snapshot never spins one up; `activeStreamCount` sums both lanes.
- `ServeCatalogStoreTest` — new case: the fetcher pulls `bundle/previews/<daemon-id>.png`, disk-caches it (no re-download), and yields `null` for an id the branch ships no per-preview bundle for.
- `ServePerPreviewDaemonPoolTest` — open-on-miss/reuse, null-not-cached, LRU eviction closes the daemon, stream-count sum + teardown.
- Full `ee.schimke.composeai.cli.serve.*` suite green locally.

Non-visual change (server-side render routing + session lifecycle) — the per-preview daemon runs the same composable against the same resolved classpath as the monolith, so rendered output is unchanged; text-only per the repo's visual-evidence rule.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jxz9i4SuuxPRt3knZKAPbb)_