### PR TITLE
fix(serve): apply named-knob overrides on the un-enabled preview-server daemon

### DIFF
--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/ExtensionRegistry.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/ExtensionRegistry.kt
@@ -303,6 +303,19 @@ class ExtensionRegistry(extensions: List<Extension>) {
     return PreviewOverrideExtensions(
       extensions = all,
       isActive = { extension ->
+        // Always-on override extensions (the plain-Compose named-override host + scope stamper)
+        // must
+        // plan on EVERY render regardless of enablement — that is the whole point of the
+        // AlwaysOnPreviewOverrideExtension marker ("must be planned on every render"). The
+        // enable gate governs the *client-visible* `data/fetch` product (the editable-knob
+        // payload),
+        // NOT the host installation + seed application that make `previewOverride*` resolve a
+        // per-render override. Gating the always-on host here silently dropped every named-knob
+        // override (a `?knob.label=…` edit) for any consumer that never calls `extensions/enable`:
+        // the `serve` preview server (preview.coo.ee) is exactly that consumer — unlike the MCP
+        // supervisor, which enables an allowlist on connect. Non-always-on override extensions
+        // (wallpaper, focus, keyboard, …) stay gated on their owning extension as before.
+        if (extension is AlwaysOnPreviewOverrideExtension) return@PreviewOverrideExtensions true
         val owningId = byOverrideId[extension.id.value] ?: return@PreviewOverrideExtensions false
         isActive(owningId)
       },

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/OverrideIntegrationTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/OverrideIntegrationTest.kt
@@ -10,6 +10,7 @@ import javax.imageio.ImageIO
 import kotlin.math.abs
 import kotlinx.serialization.json.Json
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
@@ -480,6 +481,81 @@ class OverrideIntegrationTest {
         "a named override must change the render vs the author default",
         default.getRGB(default.width / 2, default.height / 2),
         seeded.getRGB(seeded.width / 2, seeded.height / 2),
+      )
+    } finally {
+      host.shutdown()
+    }
+  }
+
+  /**
+   * **Regression guard for the `serve` / preview.coo.ee named-override drop.**
+   * [namedOverrideChangesRenderedFill] above wires the planner with the *ungated*
+   * `PreviewOverrideExtensions(listOf(...))` (its `isActive` defaults to `{ true }`), so it never
+   * exercised the `extensions/enable` gate the real bundle-backed live daemon runs under — and a
+   * `?knob.label=…` edit silently no-op'd on the deployed preview server while every unit test
+   * stayed green.
+   *
+   * This renders the same seeded `fill` knob through the **production seam**: a real
+   * [ExtensionRegistry] whose `compose/overrides` extension is registered but **never enabled**
+   * (exactly what `serve` does — only the MCP supervisor enables an allowlist), threading its
+   * [ExtensionRegistry.activeOverrideExtensions] into the engine. The named-override host is marked
+   * [AlwaysOnPreviewOverrideExtension], so the seed must still apply despite the extension being
+   * inactive. Before the fix the gate skipped the planner and the fill fell back to author-default
+   * red; the assertion below would fail — which is the deployed bug, now caught in CI.
+   */
+  @Test
+  fun namedOverrideAppliesThroughGatedRegistryWithoutEnable() {
+    val outputDir = tempFolder.newFolder("renders-named-override-gated")
+    System.setProperty(RenderEngine.OUTPUT_DIR_PROP, outputDir.absolutePath)
+    val manifest =
+      PreviewManifest(
+        previews =
+          listOf(
+            PreviewManifestEntry(
+              id = "overridable",
+              className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+              functionName = "OverridableSquare",
+              widthPx = 32,
+              heightPx = 32,
+              density = 1.0f,
+              outputBaseName = "overridable",
+            )
+          )
+      )
+    // A real registry with the named-override extension registered but NOT enabled — the exact
+    // shape `serve` builds (it never calls extensions/enable). activeOverrideExtensions() returns
+    // the gated `isActive` predicate the deployed daemon uses.
+    val registry =
+      ExtensionRegistry(
+        listOf(
+          Extension(
+            id = "compose/overrides",
+            previewOverrideExtensions = listOf(PreviewOverridesPreviewOverrideExtension()),
+          )
+        )
+      )
+    assertFalse(
+      "the override extension must be inactive — the whole point of this regression",
+      registry.isActive("compose/overrides"),
+    )
+    val host =
+      PreviewManifestRouter(
+        manifest = manifest,
+        engine = RenderEngine(previewOverrideExtensions = registry.activeOverrideExtensions()),
+      )
+    host.start()
+    try {
+      val seeded =
+        renderAndDecode(
+          host,
+          "previewId=overridable;overrides=${encodeNamedBag("fill", "#FF42A5F5")}",
+          "named-seeded-gated",
+        )
+      val seededBluePct = pixelMatchPct(seeded, expectedRgb = 0x42A5F5, perChannelTolerance = 8)
+      assertTrue(
+        "a named override must apply on the un-enabled (serve) path too; got " +
+          "${"%.2f".format(seededBluePct * 100)}% blue — the label/knob drop is back",
+        seededBluePct >= 0.95,
       )
     } finally {
       host.shutdown()


### PR DESCRIPTION
## Summary

`?knob.label=Hello` (and every other named/text knob) silently did nothing on `serve` / preview.coo.ee — the button kept its author default while display-axis overrides (`fontScale`, `uiMode`, `density`) worked fine.

**Root cause:** the plain-Compose named-override host (`PreviewOverridesOverrideExtension`) installs `LocalPreviewOverrideHost` and seeds `previewOverride*` values. It's registered on the daemon but **inactive until `extensions/enable`** — and the bundle-backed live daemon behind `serve` never calls `extensions/enable` (only the MCP supervisor does, enabling an allowlist on connect). So `ExtensionRegistry.activeOverrideExtensions()` reported it inactive and `PreviewOverrideExtensions.plan(...)` skipped its planner, even for a render that carried `namedOverrides`. The knob's *declaration* still showed in the viewer because that comes from the bundle's baked `overrides.json` sidecar — so the control looked wired but the value never landed. Display axes were unaffected because they're applied directly on the render spec, not via a gated extension.

This was **not** the released-runtime change (#2384) — the classloader delegation from #2297 is correct and the runtime is a shared singleton; the override extension was simply never activated on this path.

## Fix

The named-override host is marked `AlwaysOnPreviewOverrideExtension`, whose documented contract is "must be planned on **every** render." Honour it in `ExtensionRegistry.activeOverrideExtensions()`: an `AlwaysOnPreviewOverrideExtension` is always active regardless of enablement. The enable gate governs the *client-visible* `compose/overrides` `data/fetch` product (the editable-knob payload) — not the host installation + seed application that make `previewOverride*` resolve a per-render override. Non-always-on override extensions (wallpaper, focus, keyboard, …) stay gated exactly as before, and the MCP path is unchanged (it already enabled the extension).

## Test plan / "known overrides in CI"

The prior end-to-end test (`namedOverrideChangesRenderedFill`) wired the planner with the **ungated** `PreviewOverrideExtensions(listOf(...))` (its `isActive` defaults to `{ true }`), so it never exercised the `extensions/enable` gate the real daemon runs under — which is why the bug shipped green.

Added `namedOverrideAppliesThroughGatedRegistryWithoutEnable`: it renders a seeded `fill` knob through a **real `ExtensionRegistry` whose `compose/overrides` extension is registered but never enabled** — the exact shape `serve` builds — and asserts the seed repaints the pixels. Verified locally:
- **without the fix** → the planner is skipped, the fill stays author-default red, the test **fails** (reproduces the deployed bug);
- **with the fix** → the seed reaches `previewOverrideColor`, the fill repaints blue, the test **passes**.

`:daemon:desktop` override tests green locally. (The `:daemon:core` test sourceset couldn't compile in my sandbox due to a pre-existing empty-locale charset issue on an unrelated test's em-dash method name — `PreviewIndexDiffTest` — nothing I touched; CI's UTF-8 locale compiles it fine.)

### Visual verification

The regression test is the in-repo visual check: it asserts on actual rendered pixels (author-default red vs seeded blue) through the production gating seam. The user-visible before on the deployed server is a `button-filled` render that reads **"Filled"** for both the plain URL and `?knob.label=Hello`; after this ships and the preview-host image is rebuilt, the same URL renders the overridden label. (The deployed surface itself can't be recaptured from this PR — it needs a release + image redeploy to reach preview.coo.ee.)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jxz9i4SuuxPRt3knZKAPbb)_