### PR TITLE
test: use ASCII hyphens in test method names, not em-dashes

### DIFF
--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/AutoInjectTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/AutoInjectTest.kt
@@ -105,7 +105,7 @@ class AutoInjectTest {
   }
 
   @Test
-  fun `materializeInitScript is idempotent — same version leaves the file untouched`() {
+  fun `materializeInitScript is idempotent - same version leaves the file untouched`() {
     val dir = tempDir()
     val first = materializeInitScript(dir, "1.0.0")
     // Bump mtime forward so a rewrite would be observable.

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleEmbedDataTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleEmbedDataTest.kt
@@ -188,7 +188,7 @@ class BundleEmbedDataTest {
   }
 
   @Test
-  fun `embedWebIntoZip is idempotent — re-embedding replaces stale web entries`() {
+  fun `embedWebIntoZip is idempotent - re-embedding replaces stale web entries`() {
     val withOldWeb =
       ByteArrayOutputStream()
         .also { baos ->

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/XrCompositeProvisionTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/XrCompositeProvisionTest.kt
@@ -119,7 +119,7 @@ class XrCompositeProvisionTest {
   }
 
   @Test
-  fun `ensureCached is idempotent — second call does not re-download`() {
+  fun `ensureCached is idempotent - second call does not re-download`() {
     if (XrCompositeProvision.currentPlatformToken() == null) return
     var fetches = 0
     val fetcher = XrCompositeProvision.Fetcher { _, dst ->

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/PreviewIndexDiffTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/PreviewIndexDiffTest.kt
@@ -29,7 +29,7 @@ class PreviewIndexDiffTest {
     )
 
   @Test
-  fun `pure addition — empty index plus two-preview scan emits two added`() {
+  fun `pure addition - empty index plus two-preview scan emits two added`() {
     val index = PreviewIndex.empty()
     val scan =
       setOf(preview("Foo", sourceFile = "Foo.kt"), preview("Foo_dark", sourceFile = "Foo.kt"))
@@ -46,7 +46,7 @@ class PreviewIndexDiffTest {
   }
 
   @Test
-  fun `pure removal — index has two from Foo, scan returns empty, both removed`() {
+  fun `pure removal - index has two from Foo, scan returns empty, both removed`() {
     val foo1 = preview("Foo", sourceFile = "Foo.kt")
     val foo2 = preview("Foo_dark", sourceFile = "Foo.kt")
     val index = PreviewIndex.fromMap(path = null, byId = mapOf("Foo" to foo1, "Foo_dark" to foo2))
@@ -62,7 +62,7 @@ class PreviewIndexDiffTest {
   }
 
   @Test
-  fun `field change — same id with different displayName is changed not added`() {
+  fun `field change - same id with different displayName is changed not added`() {
     val before = preview("Foo_bar", sourceFile = "Foo.kt", displayName = "X")
     val after = preview("Foo_bar", sourceFile = "Foo.kt", displayName = "Y")
     val index = PreviewIndex.fromMap(path = null, byId = mapOf("Foo_bar" to before))
@@ -150,7 +150,7 @@ class PreviewIndexDiffTest {
   }
 
   @Test
-  fun `no-op — scan matches index exactly, diff is empty`() {
+  fun `no-op - scan matches index exactly, diff is empty`() {
     val foo = preview("Foo", sourceFile = "Foo.kt", displayName = "Foo!")
     val index = PreviewIndex.fromMap(path = null, byId = mapOf("Foo" to foo))
     val diff = index.diff(setOf(foo), Path.of("Foo.kt"))
@@ -162,7 +162,7 @@ class PreviewIndexDiffTest {
   }
 
   @Test
-  fun `file-scoped — Bar slice survives a Foo-targeted scan that returns nothing`() {
+  fun `file-scoped - Bar slice survives a Foo-targeted scan that returns nothing`() {
     val fooPreview = preview("Foo", sourceFile = "Foo.kt")
     val barPreview = preview("Bar", sourceFile = "Bar.kt")
     val index =

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/PreviewManifestEntryResolveTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/PreviewManifestEntryResolveTest.kt
@@ -22,7 +22,7 @@ class PreviewManifestEntryResolveTest {
   private val json = Json { ignoreUnknownKeys = true }
 
   @Test
-  fun `flat schema — harness shape — reads top-level fields`() {
+  fun `flat schema - harness shape - reads top-level fields`() {
     val raw =
       """{"id":"red-square","className":"X","functionName":"R","widthPx":64,""" +
         """"heightPx":64,"density":1.0,"showBackground":true,"device":"id:wearos_small_round"}"""
@@ -37,7 +37,7 @@ class PreviewManifestEntryResolveTest {
   }
 
   @Test
-  fun `no explicit size — wraps content at the sandbox bound (AS-parity natural size)`() {
+  fun `no explicit size - wraps content at the sandbox bound (AS-parity natural size)`() {
     // A preview that declares no widthDp/heightDp/device renders wrap-content: the resolved size is
     // the 400x800dp sandbox bound and the wrap flags are set, so the capture (figma-svg / wireframe
     // /
@@ -56,7 +56,7 @@ class PreviewManifestEntryResolveTest {
   }
 
   @Test
-  fun `explicit size or device pins the frame — no wrap`() {
+  fun `explicit size or device pins the frame - no wrap`() {
     val sized =
       json.decodeFromString(
         PreviewManifestEntry.serializer(),
@@ -77,7 +77,7 @@ class PreviewManifestEntryResolveTest {
   }
 
   @Test
-  fun `nested schema — plugin shape — reads params block`() {
+  fun `nested schema - plugin shape - reads params block`() {
     // Mirrors what `DiscoverPreviewsTask` writes for a Wear preview annotated with
     // `@Preview(device = "id:wearos_small_round")` — production manifest the daemon was silently
     // dropping pre-fix. `widthDp` × `density` is the per-render sandbox size; the resolver does
@@ -112,7 +112,7 @@ class PreviewManifestEntryResolveTest {
   }
 
   @Test
-  fun `bare entry falls back to defaults — never crashes the routing path`() {
+  fun `bare entry falls back to defaults - never crashes the routing path`() {
     val raw = """{"id":"bare","className":"X","functionName":"R"}"""
     val entry = json.decodeFromString(PreviewManifestEntry.serializer(), raw)
     val resolved = entry.resolved()

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/RenderSpecFromInfoTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/RenderSpecFromInfoTest.kt
@@ -70,7 +70,7 @@ class RenderSpecFromInfoTest {
   }
 
   @Test
-  fun `a null params block differs from an empty one — only the empty block wraps`() {
+  fun `a null params block differs from an empty one - only the empty block wraps`() {
     val nullSpec = renderSpecFromInfo(info(params = null))
     val emptySpec = renderSpecFromInfo(info(params = PreviewParamsDto()))
     // Present-but-empty ⇒ wrap-content (a no-size sticker); absent ⇒ unknown params ⇒ fixed frame.

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewDiscoveryRenderStemTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewDiscoveryRenderStemTest.kt
@@ -12,7 +12,7 @@ class PreviewDiscoveryRenderStemTest {
    * sanitisation step.
    */
   @Test
-  fun `every resolved stem is shell-safe — only letters, digits, underscores, and dots`() {
+  fun `every resolved stem is shell-safe - only letters, digits, underscores, and dots`() {
     val previews =
       listOf(
         preview("com.example.PreviewsKt.ActivityListPreview_Devices - Large Round"),
@@ -142,7 +142,7 @@ class PreviewDiscoveryRenderStemTest {
   }
 
   @Test
-  fun `single-preview module — bare function-and-variant segment, no prefixes`() {
+  fun `single-preview module - bare function-and-variant segment, no prefixes`() {
     val previews = listOf(preview("com.example.PreviewsKt.OnlyOne_Variant - With Space"))
 
     val stems = PreviewDiscovery.resolveRenderStems(previews)

--- a/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/PixelSystemFontAliasesTest.kt
+++ b/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/PixelSystemFontAliasesTest.kt
@@ -129,7 +129,7 @@ class PixelSystemFontAliasesTest {
   }
 
   @Test
-  fun `seedSystemFontMap is idempotent — preseeded slugs aren't overwritten`() {
+  fun `seedSystemFontMap is idempotent - preseeded slugs aren't overwritten`() {
     val sentinelOld = SentinelTypeface.NORMAL
     val sentinelNew = SentinelTypeface.BOLD
     val map = mutableMapOf<String, Typeface>("roboto-flex" to sentinelOld)


### PR DESCRIPTION
## Summary

An em-dash (U+2014, `—`) inside a backtick test method name ends up as a non-ASCII character in the generated `.class` filename — e.g. `PreviewIndexDiffTest$pure addition — empty index plus two-preview scan emits two added$$inlined$sortedBy$1.class`. On a runner whose filesystem encoding isn't UTF-8 (an empty/POSIX locale), the Kotlin compiler can't write or hash that path and fails the **entire** test sourceset with an `InvalidPathException: Malformed input` internal compiler error — taking unrelated tests down with it. I hit this compiling `:daemon:core:test` while working on the override fix.

Replaced the em-dashes with plain ASCII hyphens across all 8 affected test files (16 method names). Pure rename — no behaviour change.

- `daemon/core/.../PreviewIndexDiffTest.kt`
- `daemon/desktop/.../PreviewManifestEntryResolveTest.kt`, `RenderSpecFromInfoTest.kt`
- `gradle-plugin/preview-discovery/.../PreviewDiscoveryRenderStemTest.kt`
- `cli/.../AutoInjectTest.kt`, `BundleEmbedDataTest.kt`, `XrCompositeProvisionTest.kt`
- `renderers/android/.../PixelSystemFontAliasesTest.kt`

## Test plan

- `grep` confirms no non-ASCII characters remain in any backtick test method name repo-wide.
- `:daemon:core:compileTestKotlin` now compiles clean under an empty locale (it failed before with the `InvalidPathException`), and `:daemon:core:test --tests "*PreviewIndexDiffTest"` passes with the renamed methods.

Test-only rename — no runtime or visual surface.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jxz9i4SuuxPRt3knZKAPbb)_