### PR TITLE
feat(serve): register cadence catalog for preview.coo.ee

### DIFF
--- a/deploy/image/docker-compose.yml
+++ b/deploy/image/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       SERVE_PUBLIC: "${SERVE_PUBLIC:-1}"
       # The catalog set is BAKED INTO THE IMAGE (entrypoint): the front-page systems
       # (compose-m3,wear-m3,remote-m3) and the app systems served unlisted from their own repos
-      # (meshcore-mobile, homeassistant-remotecompose). Leave these empty to inherit the
+      # (meshcore-mobile, homeassistant-remotecompose, cadence). Leave these empty to inherit the
       # baked defaults — so a bare image pull self-heals without editing this compose.
       # Set your own comma list to override, or the literal `none` to serve none of that
       # kind. (Empty is NOT `none` — it falls back to the baked default.)

--- a/deploy/image/entrypoint.sh
+++ b/deploy/image/entrypoint.sh
@@ -36,7 +36,7 @@ fi
 # /<system>/ (and ?session=<system>) but off the front-page nav. <system>@<owner>/<repo>
 # points at a per-repo design-artifacts branch, which must be trusted (see the store
 # below) to badge Trusted. Override with your own list, or `none` to serve none.
-: "${SERVE_CATALOGS_UNLISTED:=meshcore-mobile@yschimke/meshcore-mobile,homeassistant-remotecompose@yschimke/homeassistant-remotecompose}"
+: "${SERVE_CATALOGS_UNLISTED:=meshcore-mobile@yschimke/meshcore-mobile,homeassistant-remotecompose@yschimke/homeassistant-remotecompose,cadence@yschimke/cadence}"
 [[ "${SERVE_CATALOGS_UNLISTED}" != "none" ]] && args+=(--catalogs-unlisted "${SERVE_CATALOGS_UNLISTED}")
 # Default to the baked branch-trust store so the published design-artifacts catalogs
 # badge as Trusted(Branch) out of the box. `:=` fills it when SERVE_TRUST_STORE is

--- a/deploy/image/trust/producers.json
+++ b/deploy/image/trust/producers.json
@@ -12,6 +12,10 @@
     {
       "repo": "yschimke/homeassistant-remotecompose",
       "branch": "design-artifacts/*"
+    },
+    {
+      "repo": "yschimke/cadence",
+      "branch": "design-artifacts/*"
     }
   ]
 }

--- a/deploy/vps/docker-compose.yml
+++ b/deploy/vps/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       # front-page nav — reachable at /<system>/ (and ?session=<system>). <system>@<owner>/<repo>
       # points serve at each app's design-artifacts/<system> branch; those branches are in
       # trust/producers.json so they badge Trusted(Branch).
-      SERVE_CATALOGS_UNLISTED: "${SERVE_CATALOGS_UNLISTED:-meshcore-mobile@yschimke/meshcore-mobile,homeassistant-remotecompose@yschimke/homeassistant-remotecompose}"
+      SERVE_CATALOGS_UNLISTED: "${SERVE_CATALOGS_UNLISTED:-meshcore-mobile@yschimke/meshcore-mobile,homeassistant-remotecompose@yschimke/homeassistant-remotecompose,cadence@yschimke/cadence}"
       SERVE_TRUST_STORE: "${SERVE_TRUST_STORE:-trust/producers.json}"
       SERVE_WASM_DIR: "${SERVE_WASM_DIR:-compose-m3=samples/cmp-wasm-catalog/build/wasmDist}"
       # Live (daemon-backed) server-side re-render. Now that compose-m3 is a

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -99,7 +99,7 @@ compose-preview serve \
   --public \                              # open every route (no token)
   --catalogs compose-m3,wear-m3,remote-m3 \  # published design systems, listed on the front-page index
   --catalogs-unlisted \                   # served at /<system>/ but hidden from the nav; each from its own repo
-      meshcore-mobile@yschimke/meshcore-mobile,homeassistant-remotecompose@yschimke/homeassistant-remotecompose \
+      meshcore-mobile@yschimke/meshcore-mobile,homeassistant-remotecompose@yschimke/homeassistant-remotecompose,cadence@yschimke/cadence \
   --trust-store trust/producers.json \    # who we trust (must list every catalog's branch/repo)
   --host 0.0.0.0 --port 8080
 
@@ -168,7 +168,7 @@ out — which also means a bare image pull self-heals a box without editing its 
 
 The **catalog set is baked into the image the same way**: the entrypoint defaults `SERVE_CATALOGS`
 to `compose-m3,wear-m3,remote-m3` (front-page index) and `SERVE_CATALOGS_UNLISTED` to
-`meshcore-mobile@yschimke/meshcore-mobile,homeassistant-remotecompose@yschimke/homeassistant-remotecompose`
+`meshcore-mobile@yschimke/meshcore-mobile,homeassistant-remotecompose@yschimke/homeassistant-remotecompose,cadence@yschimke/cadence`
 (served at `/<system>/`, off the nav). So a bare `docker pull` / Watchtower update serves them
 without editing the box's compose. Override either with your own comma list, or `none` to serve none
 of that kind (empty inherits the baked default). The `deploy/vps` from-source path still sets these

--- a/trust/producers.json
+++ b/trust/producers.json
@@ -22,6 +22,10 @@
     {
       "repo": "yschimke/homeassistant-remotecompose",
       "branch": "design-artifacts/*"
+    },
+    {
+      "repo": "yschimke/cadence",
+      "branch": "design-artifacts/*"
     }
   ],
 


### PR DESCRIPTION
## Summary

Registers the **cadence** design catalog on the public preview server (`preview.coo.ee`) so its `design-artifacts/cadence` branch is both trusted and served, alongside the existing `meshcore-mobile` and `homeassistant-remotecompose` app catalogs.

- `trust/producers.json` + `deploy/image/trust/producers.json`: add `yschimke/cadence` `design-artifacts/*` as a trusted branch (badges `Trusted(Branch)` instead of `Unverified`).
- `deploy/image/entrypoint.sh` + `deploy/vps/docker-compose.yml`: add `cadence@yschimke/cadence` to the baked `SERVE_CATALOGS_UNLISTED` default (served at `/cadence/`, off the front-page nav).
- `deploy/image/docker-compose.yml` + `docs/public-preview-server.md`: update the accompanying comments/example to list cadence.

## Test plan

- Data/config-only change (trust store + deploy env defaults + docs). Trust JSON validated as parseable.
- Once cadence's `design-artifacts/cadence` branch is published, `https://preview.coo.ee/cadence/` serves it as `Trusted(Branch)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LKLNdPaUGZnLnSERV2bSH1)_