### PR TITLE
fix(serve): carry named-knob overrides through the previewId render path

### DIFF
--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
@@ -752,6 +752,15 @@ open class DesktopHost(
       inspectionMode = map["inspectionMode"]?.toBooleanStrictOrNull() ?: base.inspectionMode,
       slotMode = map["slotMode"]?.toBooleanStrictOrNull() ?: base.slotMode,
       clearBackground = map["clearBackground"]?.toBoolean() ?: base.clearBackground,
+      // The extension-driven override bag (`namedOverrides` / `themeProvider` / `wallpaper` /
+      // `permissions` / `gestures` / `lottie`) rides the `overrides=<base64>` token that
+      // `JsonRpcServer.encodeRenderPayload` emits. The className-based `parseFromPayload` decodes
+      // it;
+      // this previewId-based path — the one the bundle-backed live daemon (`serve` /
+      // preview.coo.ee)
+      // takes for a renderNow — must too, or a `?knob.<key>=…` edit is silently dropped while the
+      // display axes above (fontScale / uiMode / density / …) still apply.
+      overrides = map["overrides"]?.let { RenderSpec.decodeOverridesToken(it) } ?: base.overrides,
     )
   }
 

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -1296,6 +1296,17 @@ data class RenderSpec(
           json.decodeFromString(PreviewOverrides.serializer(), bytes.toString(Charsets.UTF_8))
         }
         .getOrNull()
+
+    /**
+     * Decode the base64-encoded `PreviewOverrides` bag carried in the `overrides=<b64>` payload
+     * token — the extension bag `JsonRpcServer.encodeRenderPayload` emits (`namedOverrides`,
+     * `themeProvider`, `wallpaper`, `permissions`, `gestures`, `lottie`). Exposed so the
+     * previewId-based render path ([DesktopHost.specFromPreviewIdPayload]) can carry the bag
+     * through too, not just the className-based [parseFromPayload]; without it a `?knob.<key>=…`
+     * edit on the bundle-backed live daemon (`serve` / preview.coo.ee) is silently dropped.
+     */
+    internal fun decodeOverridesToken(token: String): PreviewOverrides? =
+      token.decodePreviewOverrides()
   }
 }
 

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/OverrideIntegrationTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/OverrideIntegrationTest.kt
@@ -563,6 +563,62 @@ class OverrideIntegrationTest {
   }
 
   /**
+   * **Regression guard for the `serve` / preview.coo.ee named-override drop.** The bundle-backed
+   * live daemon renders via a `previewId=<id>` payload (`JsonRpcServer.encodeRenderPayload`), which
+   * [DesktopHost.dispatchRender] routes through [DesktopHost.specFromPreviewIdPayload] — NOT the
+   * `className=`-based [RenderSpec.parseFromPayload] that every other test here exercises via
+   * [PreviewManifestRouter] (the router rewrites `previewId` → `className=…`). That previewId path
+   * rebuilt the spec with `base.copy(...)` and **dropped the `overrides=<b64>` extension bag**, so
+   * a `?knob.<key>=…` edit silently no-op'd on the deployed server while display axes (fontScale /
+   * uiMode / …) still applied — the exact deployed bug. Drive [DesktopHost] directly with a bare
+   * previewId payload carrying a seeded `fill` knob and assert the fill actually repaints; before
+   * the fix the bag never reached the render and it stayed author-default red.
+   */
+  @Test
+  fun namedOverrideAppliesOnPreviewIdPayloadPath() {
+    val outputDir = tempFolder.newFolder("renders-previewid-override")
+    System.setProperty(RenderEngine.OUTPUT_DIR_PROP, outputDir.absolutePath)
+    val baseSpec =
+      RenderSpec(
+        previewId = "overridable",
+        className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+        functionName = "OverridableSquare",
+        widthPx = 32,
+        heightPx = 32,
+        density = 1.0f,
+      )
+    // A real DesktopHost (not the PreviewManifestRouter subclass), so a `previewId=…` payload with
+    // NO `className=` takes the specFromPreviewIdPayload branch — the serve/bundle-daemon path.
+    val host =
+      DesktopHost(
+        engine =
+          RenderEngine(
+            previewOverrideExtensions =
+              PreviewOverrideExtensions(listOf(PreviewOverridesPreviewOverrideExtension()))
+          ),
+        previewSpecResolver = { id -> baseSpec.takeIf { id == "overridable" } },
+      )
+    host.start()
+    try {
+      val request =
+        RenderRequest.Render(
+          payload = "previewId=overridable;overrides=${encodeNamedBag("fill", "#FF42A5F5")}"
+        )
+      val result = host.submit(request, timeoutMs = 30_000)
+      assertNotNull("pngPath must be populated", result.pngPath)
+      val png = ByteArrayInputStream(File(result.pngPath!!).readBytes()).use { ImageIO.read(it) }
+      val bluePct = pixelMatchPct(png, expectedRgb = 0x42A5F5, perChannelTolerance = 8)
+      assertTrue(
+        "a named override on the previewId payload path must repaint blue; got " +
+          "${"%.2f".format(bluePct * 100)}% — the serve knob-drop is back",
+        bluePct >= 0.95,
+      )
+    } finally {
+      host.shutdown()
+    }
+  }
+
+  /**
    * End-to-end proof that a `themeProvider` override wraps an arbitrary preview in an app-declared
    * `@ThemeCatalog` theme (the render side of the serve viewer's declared-theme selector). Renders
    * [WallpaperAwareSquare] — which paints the *ambient* `MaterialTheme.colorScheme.primary` with no


### PR DESCRIPTION
## Summary

`?knob.label=…` (and every other named/text knob) silently did nothing on `serve` / preview.coo.ee, while display-axis overrides (`fontScale`, `uiMode`, `density`) worked. This is the **real** root cause — found by building the deployed `v0.16.36` binary and tracing the override end-to-end against a live local server.

The daemon has two render-spec parsers:
- `RenderSpec.parseFromPayload` — the **`className=`** payload path (Gradle / `PreviewManifestRouter`). **Decodes** the `overrides=<base64>` bag.
- `DesktopHost.specFromPreviewIdPayload` — the **`previewId=`** path, which is exactly what the bundle-backed live daemon (`serve`) takes for a `renderNow` (`JsonRpcServer.encodeRenderPayload` emits `previewId=…` with no `className=`). It rebuilt the spec via `base.copy(...)` copying every display-axis field **but never `overrides`** — so the bag carrying `namedOverrides` (and `themeProvider`/`wallpaper`/`permissions`/`gestures`/`lottie`) was dropped. Display axes survived because they're copied as individual fields.

Trace that pinned it (instrumentation since removed):
```
[OVR-SEND]   named=[label]   serve sends it ✓
[OVR-ENCODE] named=[label]   daemon base64-encodes it into overrides=<b64> ✓
(no decode)                  parseFromPayload never runs — no className= → specFromPreviewIdPayload
[OVR-SET]    keys=null        the extension is seeded with nothing → renders the default
```

This is the missing half of the serve override chain: #2392 made the override extension *active* on the un-enabled daemon, but the override never *reached* it because the spec dropped it here.

## Fix

`specFromPreviewIdPayload` now decodes and carries the `overrides` bag, identical to `parseFromPayload`. The decoder is exposed as `RenderSpec.decodeOverridesToken`. Two-line behavioural change; no wire-format change.

## Verified end-to-end

Built the CLI, ran `serve --catalogs compose-m3 --allow-render-trusted` locally against the real trusted catalog (same `producers.json` the image ships), and rendered the button:
- **Before:** `?knob.label=…` → "Filled" (any label, byte-identical).
- **After:** `?knob.label=ItWorks` → the button reads **"ItWorks"**; two distinct labels produce distinct renders.

## Test plan / regression guard

Adds `namedOverrideAppliesOnPreviewIdPayloadPath` to `OverrideIntegrationTest`. It drives **`DesktopHost` directly** with a bare `previewId=…;overrides=<b64>` payload (no `className=`) carrying a seeded `fill` color knob, and asserts the fill repaints blue. The existing override tests all went through `PreviewManifestRouter` (which rewrites `previewId` → `className=` and hits the *working* parser), so they never exercised this path — that's why the bug shipped green. Verified locally: the new test **fails without the fix** (stays author-default red) and **passes with it**; the existing `namedOverrideChangesRenderedFill` still passes.

**Visual verification:** the regression test asserts on actual rendered pixels (author-default red vs seeded blue) through the exact serve seam — that's the in-repo visual check. The user-visible before/after (`Filled` → `ItWorks`) was captured from the local server; the deployed surface updates once this ships via a release + preview-host image rebuild.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jxz9i4SuuxPRt3knZKAPbb)_