### PR TITLE
fix(build): publish data-preview-overrides modules for bundle-render e2e

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -131,6 +131,9 @@ tasks.register("functionalTestWithAndroid") {
 //         api :renderer-xr-client (daemon-core fronts the native XR render server)
 //         api :data-layoutinspector-core (semantics models + differ for `history/diff mode=semantics`, #1785)
 //         api :data-theme-core (theme-token models + differ for `history/diff mode=data`, #1873)
+//         api :data-preview-overrides-core (named-knob override models daemon-core applies)
+//     implementation :data-preview-overrides-runtime (applies preview overrides at render time)
+//       api :data-preview-overrides-core
 //     implementation :data-deviceframe-connector (device-art bezel compositing — post-capture)
 //       api :data-deviceframe-core
 //     implementation :lottie-preview-runtime (Compottie-backed kind=LOTTIE render path)
@@ -151,6 +154,8 @@ val bundleRenderFunctionalTestPublishTargets =
     ":renderer-xr-client",
     ":data-layoutinspector-core",
     ":data-theme-core",
+    ":data-preview-overrides-core",
+    ":data-preview-overrides-runtime",
     ":lottie-preview-runtime",
     ":svg-preview-runtime",
     ":common-io",


### PR DESCRIPTION
## Summary

`main` CI is red: the **Bundle Render E2E** job fails, taking down `BundleRenderEndToEndFunctionalTest` and `BundleDaemonEndToEndFunctionalTest`.

Root cause: `renderer-desktop`'s publishable transitive closure gained two internal modules that were never added to `bundleRenderFunctionalTestPublishTargets`, so the e2e's synthetic Compose Desktop project could not resolve them from mavenLocal:

- `:data-preview-overrides-runtime` — `implementation` dep of `renderer-desktop` (`renderers/desktop/build.gradle.kts:59`)
- `:data-preview-overrides-core` — `api` dep of `daemon-core` (`daemon/core/build.gradle.kts:45`) and `api` dep of the runtime module above

Configuration-cache serialization of `:app:validateComposePreviewDesktopRenderClasspath` failed with:

```
Could not resolve all files for configuration ':app:composePreviewRenderer'.
  > Could not find ee.schimke.composeai:data-preview-overrides-runtime:0.16.37-SNAPSHOT
      Required by: project ':app' > renderer-desktop
  > Could not find ee.schimke.composeai:data-preview-overrides-core:0.16.37-SNAPSHOT
      Required by: project ':app' > renderer-desktop > data-displayfilter-connector > daemon-core
```

This adds both modules to `bundleRenderFunctionalTestPublishTargets` so they are `publishToMavenLocal`'d before the e2e runs, and documents the new edges in the closure comment. Both modules apply the same `composeai.maven-publishing` convention as the already-listed `:daemon:core`, so the `:module:publishToMavenLocal` tasks exist and produce exactly the missing coordinates.

`androidFunctionalTestPublishTargets` needs no change — `renderer-android` does not pull `preview-overrides`.

## Test plan

- Statically verified: the two missing coordinates are precisely these modules; both are in `renderer-desktop`'s publishable closure (edges confirmed in the module build files); both apply `composeai.maven-publishing` like the working siblings already in the list.
- Full local run of `functionalTestWithBundleRender` was not possible in the agent sandbox (the Gradle 9.6.1 distribution download is blocked by the egress policy, and the pre-installed gradle is 8.14.3). CI's **Bundle Render E2E** job re-runs the exact failing path and is the authoritative check for this PR.

_Generated by [Claude Code]_

---
_Generated by [Claude Code](https://claude.ai/code/session_01SoU4RrN1fMwTY2PPZLZQt8)_