### PR TITLE
fix(serve): merge previewId override bags instead of replacing base

### DIFF
--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewOverrideMerge.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewOverrideMerge.kt
@@ -140,6 +140,64 @@ private fun isPseudolocaleTag(tag: String?): Boolean {
 }
 
 /**
+ * Layer a sparse per-call [PreviewOverrides] bag ([this], the winner) over a discovery-time base
+ * bag ([base]), field by field: the per-call value wins where set, [base] fills every unset field,
+ * and `namedOverrides` merges **per-key** (not whole-map replace) — the same rule
+ * [mergePreviewOverrides] applies, so editing one knob never drops the other seeds the base already
+ * declared. A null receiver or [base] degenerates to the other side.
+ *
+ * Used by the previewId render path
+ * ([ee.schimke.composeai.daemon.DesktopHost.specFromPreviewIdPayload]): the resolved base spec can
+ * carry a theme / wallpaper / named seeds in `RenderSpec.overrides` (interactive / recording
+ * resolvers construct such specs, and a future manifest could seed them), while a `?knob.<key>=…`
+ * edit arrives as a sparse bag carrying only the changed knob. Replacing wholesale would drop the
+ * base's other overrides; this layers them. Today's production serve resolver
+ * (`renderSpecFromInfo`) leaves `.overrides` null, so this is a no-op there — but the merge keeps
+ * the seam correct if that changes.
+ *
+ * The field list must stay exhaustive over [PreviewOverrides]; a forgotten field silently drops its
+ * base value. `PreviewOverrideMergeTest.layeredOver…` guards this by asserting an empty overlay
+ * over a fully-populated base round-trips to the base unchanged.
+ */
+fun PreviewOverrides?.layeredOver(base: PreviewOverrides?): PreviewOverrides? {
+  val over = this ?: return base
+  if (base == null) return over
+  return PreviewOverrides(
+    widthPx = over.widthPx ?: base.widthPx,
+    heightPx = over.heightPx ?: base.heightPx,
+    density = over.density ?: base.density,
+    localeTag = over.localeTag ?: base.localeTag,
+    fontScale = over.fontScale ?: base.fontScale,
+    uiMode = over.uiMode ?: base.uiMode,
+    orientation = over.orientation ?: base.orientation,
+    device = over.device ?: base.device,
+    captureAdvanceMs = over.captureAdvanceMs ?: base.captureAdvanceMs,
+    inspectionMode = over.inspectionMode ?: base.inspectionMode,
+    slotMode = over.slotMode ?: base.slotMode,
+    clearBackground = over.clearBackground ?: base.clearBackground,
+    material3Theme = over.material3Theme ?: base.material3Theme,
+    themeProvider = over.themeProvider ?: base.themeProvider,
+    wallpaper = over.wallpaper ?: base.wallpaper,
+    ambient = over.ambient ?: base.ambient,
+    gestures = over.gestures ?: base.gestures,
+    focus = over.focus ?: base.focus,
+    touchOverlay = over.touchOverlay ?: base.touchOverlay,
+    talkBack = over.talkBack ?: base.talkBack,
+    keyboard = over.keyboard ?: base.keyboard,
+    permissions = over.permissions ?: base.permissions,
+    remoteCompose = over.remoteCompose ?: base.remoteCompose,
+    launcherWidget = over.launcherWidget ?: base.launcherWidget,
+    lottie = over.lottie ?: base.lottie,
+    // Per-key merge (not whole-map replace): a follow-up edit of one knob keeps the base's other
+    // seeds. Overlay entries win over base entries with the same key. Mirrors
+    // mergePreviewOverrides.
+    namedOverrides =
+      if (base.namedOverrides == null && over.namedOverrides == null) null
+      else (base.namedOverrides ?: emptyMap()) + (over.namedOverrides ?: emptyMap()),
+  )
+}
+
+/**
  * Merge per-call [PreviewOverrides] over a discovery-time spec.
  *
  * Explicit `widthPx` / `heightPx` / `density` overrides win over `device`-resolved values. Device

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/PreviewOverrideMergeTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/PreviewOverrideMergeTest.kt
@@ -1,9 +1,16 @@
 package ee.schimke.composeai.daemon
 
+import ee.schimke.composeai.daemon.protocol.AmbientOverride
+import ee.schimke.composeai.daemon.protocol.AmbientStateOverride
 import ee.schimke.composeai.daemon.protocol.FocusDirection
 import ee.schimke.composeai.daemon.protocol.FocusOverride
 import ee.schimke.composeai.daemon.protocol.GestureKindOverride
 import ee.schimke.composeai.daemon.protocol.GestureOverride
+import ee.schimke.composeai.daemon.protocol.KeyboardOverride
+import ee.schimke.composeai.daemon.protocol.LauncherWidgetOverride
+import ee.schimke.composeai.daemon.protocol.LauncherWidgetSize
+import ee.schimke.composeai.daemon.protocol.LottieOverride
+import ee.schimke.composeai.daemon.protocol.Material3ThemeOverrides
 import ee.schimke.composeai.daemon.protocol.Orientation
 import ee.schimke.composeai.daemon.protocol.PermissionGrantStateOverride
 import ee.schimke.composeai.daemon.protocol.PermissionsOverride
@@ -12,6 +19,7 @@ import ee.schimke.composeai.daemon.protocol.RemoteComposeOverride
 import ee.schimke.composeai.daemon.protocol.RemoteComposeProfile
 import ee.schimke.composeai.daemon.protocol.RemoteNamedValue
 import ee.schimke.composeai.daemon.protocol.UiMode
+import ee.schimke.composeai.daemon.protocol.WallpaperOverride
 import ee.schimke.composeai.data.overrides.PreviewOverrideValue
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -311,4 +319,86 @@ class PreviewOverrideMergeTest {
     assertNull((null as PreviewOverrides?).withThemeProvider(""))
     assertEquals(existing, existing.withThemeProvider(null))
   }
+
+  /**
+   * Exhaustiveness guard for [layeredOver]: an empty overlay over a fully-populated base must
+   * round-trip to the base unchanged. Every [PreviewOverrides] field is non-null here, so a field
+   * the merge forgot to carry would come back null and fail the whole-object [assertEquals] — the
+   * canary that keeps the hand-written field list in sync as the protocol grows.
+   */
+  @Test
+  fun `layeredOver with an empty overlay preserves every base field`() {
+    val base = fullyPopulatedOverrides()
+    assertEquals(base, PreviewOverrides().layeredOver(base))
+  }
+
+  @Test
+  fun `layeredOver lets the overlay win per-field and merges namedOverrides per-key`() {
+    val base =
+      PreviewOverrides(
+        fontScale = 1.0f,
+        themeProvider = "com.example.Base",
+        namedOverrides =
+          mapOf(
+            "rowCount" to PreviewOverrideValue.IntValue(3),
+            "label" to PreviewOverrideValue.StringValue("base"),
+          ),
+      )
+    // A `?knob.label=…` edit arrives as a sparse overlay: only `label` (and, say, fontScale) set.
+    // The base's themeProvider and the untouched `rowCount` seed must survive.
+    val overlay =
+      PreviewOverrides(
+        fontScale = 2.0f,
+        namedOverrides = mapOf("label" to PreviewOverrideValue.StringValue("edited")),
+      )
+    val merged = overlay.layeredOver(base)!!
+    assertEquals(2.0f, merged.fontScale!!, 0.0f) // overlay wins where set
+    assertEquals("com.example.Base", merged.themeProvider) // base fills the gap
+    assertEquals(PreviewOverrideValue.StringValue("edited"), merged.namedOverrides?.get("label"))
+    assertEquals(PreviewOverrideValue.IntValue(3), merged.namedOverrides?.get("rowCount"))
+  }
+
+  @Test
+  fun `layeredOver degenerates to the other side when one bag is null`() {
+    val bag = PreviewOverrides(fontScale = 1.5f)
+    assertEquals(bag, bag.layeredOver(null))
+    assertEquals(bag, (null as PreviewOverrides?).layeredOver(bag))
+    assertNull((null as PreviewOverrides?).layeredOver(null))
+  }
+
+  /**
+   * Every [PreviewOverrides] field set to a distinct non-null value — the exhaustiveness fixture.
+   */
+  private fun fullyPopulatedOverrides() =
+    PreviewOverrides(
+      widthPx = 111,
+      heightPx = 222,
+      density = 3.0f,
+      localeTag = "fr-FR",
+      fontScale = 1.4f,
+      uiMode = UiMode.DARK,
+      orientation = Orientation.LANDSCAPE,
+      device = "id:pixel_7",
+      captureAdvanceMs = 64L,
+      inspectionMode = true,
+      slotMode = true,
+      clearBackground = true,
+      material3Theme = Material3ThemeOverrides(colorScheme = mapOf("primary" to "#FFFF0000")),
+      themeProvider = "com.example.BrandDark",
+      wallpaper = WallpaperOverride(seedColor = "#3366FF"),
+      ambient = AmbientOverride(state = AmbientStateOverride.AMBIENT),
+      gestures = GestureOverride(enabled = true),
+      focus = FocusOverride(tabIndex = 2),
+      touchOverlay = true,
+      talkBack = true,
+      keyboard = KeyboardOverride(visible = true),
+      permissions =
+        PermissionsOverride(
+          grants = mapOf("android.permission.CAMERA" to PermissionGrantStateOverride.GRANTED)
+        ),
+      remoteCompose = RemoteComposeOverride(profile = RemoteComposeProfile.ANDROIDX),
+      launcherWidget = LauncherWidgetOverride(cells = LauncherWidgetSize(width = 4, height = 2)),
+      lottie = LottieOverride(progress = 0.5f),
+      namedOverrides = mapOf("label" to PreviewOverrideValue.StringValue("base")),
+    )
 }

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
@@ -759,8 +759,15 @@ open class DesktopHost(
       // this previewId-based path — the one the bundle-backed live daemon (`serve` /
       // preview.coo.ee)
       // takes for a renderNow — must too, or a `?knob.<key>=…` edit is silently dropped while the
-      // display axes above (fontScale / uiMode / density / …) still apply.
-      overrides = map["overrides"]?.let { RenderSpec.decodeOverridesToken(it) } ?: base.overrides,
+      // display axes above (fontScale / uiMode / density / …) still apply. The decoded per-call bag
+      // is a sparse overlay — it carries only the knob the caller edited — so layer it *over*
+      // `base.overrides` (per-key for `namedOverrides`) rather than replacing wholesale, or a
+      // one-knob edit would drop any theme / wallpaper / other seeds the resolved base spec already
+      // declares. Today's serve resolver leaves `base.overrides` null, but interactive / recording
+      // resolvers don't, and this keeps the seam correct for them.
+      overrides =
+        map["overrides"]?.let { RenderSpec.decodeOverridesToken(it) }?.layeredOver(base.overrides)
+          ?: base.overrides,
     )
   }
 


### PR DESCRIPTION
## Summary

Follow-up to #2401 addressing a Codex P2 on that PR. #2401 made `DesktopHost.specFromPreviewIdPayload` carry the decoded `overrides=` bag through the previewId render path (the `serve` / preview.coo.ee lane), but it set `overrides = decoded ?: base.overrides` — **replacing** `base.overrides` wholesale whenever a token is present.

The decoded per-call bag is a **sparse overlay**: a `?knob.<key>=…` edit carries only the changed knob. So on a resolver whose base spec already declares overrides (a theme / wallpaper / other named seeds), a one-knob edit would drop every *other* base override. `mergePreviewOverrides` already documents the correct rule ("editing one knob in a follow-up render must not drop the others"); this path wasn't following it.

## Scope of the live impact

Today's **production** serve resolver (`renderSpecFromInfo`, `DaemonMain.kt`) leaves `RenderSpec.overrides` null, and the Android sibling (`RobolectricHost.reshapeRenderPayload`) forwards only the inbound token — so **there is no live drop on preview.coo.ee** (`base.overrides` is null there, and replace ≡ merge over null). The fix hardens the seam for the resolvers that *do* build override-carrying base specs (interactive / recording) and for any future manifest that seeds overrides.

## Fix

- Adds `PreviewOverrides.layeredOver(base)` in `:daemon:core`, next to `mergePreviewOverrides`: per-field the overlay wins and the base fills gaps; `namedOverrides` merges **per-key** (not whole-map replace), mirroring `mergePreviewOverrides`.
- `specFromPreviewIdPayload` now does `decoded?.layeredOver(base.overrides) ?: base.overrides` instead of `decoded ?: base.overrides`.

## Test plan

`:daemon:core:test` — `PreviewOverrideMergeTest` gains three cases:
- **Exhaustiveness guard** — an empty overlay over a *fully-populated* base (every `PreviewOverrides` field non-null) must round-trip to the base unchanged; a field the merge forgot to carry comes back null and fails the whole-object `assertEquals`, keeping the hand-written field list honest as the protocol grows.
- **Per-field win + per-key named merge** — a sparse overlay editing only `label` + `fontScale` keeps the base's `themeProvider` and untouched `rowCount` seed.
- **Null degeneration** — either side null returns the other; both null returns null.

`:daemon:desktop:test` — `OverrideIntegrationTest` (the #2401 regression guard driving the bare `previewId=…;overrides=` path through `DesktopHost` directly) still passes. `./gradlew ktfmtFormat` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jxz9i4SuuxPRt3knZKAPbb)_