### PR TITLE
fix(figma-svg): mirror the final render setup in the Android scroll-SVG probe

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -1174,16 +1174,32 @@ class RenderEngine(
         override fun evaluate() {
           rule.mainClock.autoAdvance = false
           val clazz = Class.forName(spec.className, true, classLoader)
-          val composableMethod = clazz.getDeclaredComposableMethod(spec.functionName)
+          val composableMethod =
+            clazz.getDeclaredComposableMethod(spec.functionName).also {
+              // Kotlin `private fun` scrolling previews compile to JVM-private methods; open them
+              // so the reflective invoke doesn't throw IllegalAccessException — same as `render`.
+              runCatching { it.asMethod().isAccessible = true }
+            }
           val bgArgb = resolveBackgroundColor(spec).toArgb()
           rule.setContent {
             CompositionLocalProvider(
-              LocalInspectionMode provides false,
+              // Match the final render's inspection mode so a preview that branches on
+              // `LocalInspectionMode.current` composes the same content the export will (measuring a
+              // different branch would size the frame to the wrong extent). The final SVG render
+              // re-enters `render` in the non-a11y path, i.e. `spec.inspectionMode ?: true`.
+              LocalInspectionMode provides (spec.inspectionMode ?: true),
               ee.schimke.composeai.preview.slots.LocalPreviewBackgroundCleared provides
                 spec.clearBackground,
             ) {
               Box(modifier = Modifier.fillMaxSize().background(Color(bgArgb))) {
-                InvokeComposable(composableMethod)
+                // Mirror the normal render's invocation so a `@PreviewWrapper` / theme-provider that
+                // supplies the scrollable content is applied during measurement too, not just at the
+                // final render.
+                InvokeWithOptionalWrapper(
+                  composableMethod,
+                  wrapperFqnFromSpec = spec.wrapperClassName,
+                  themeProviderFqn = spec.overrides?.themeProvider,
+                )
               }
             }
           }

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -1209,7 +1209,18 @@ class RenderEngine(
           if (root != null) measure = measureVerticalScroll(root)
         }
       }
-    rule.apply(statement, description).evaluate()
+    // Install the request classloader as the context loader for the probe, exactly as the normal
+    // render dispatch does: `InvokeWithOptionalWrapper` resolves `@PreviewWrapper` / theme-provider
+    // classes via the thread context loader, and those live only on the app child classloader — so
+    // without this install the probe would measure unwrapped content (or fail) while the final
+    // render uses the wrapper.
+    val previousContext = Thread.currentThread().contextClassLoader
+    Thread.currentThread().contextClassLoader = classLoader
+    try {
+      rule.apply(statement, description).evaluate()
+    } finally {
+      Thread.currentThread().contextClassLoader = previousContext
+    }
     return measure
   }
 


### PR DESCRIPTION
## Summary

Follow-up to the Android `figma-svg-long` backend (#2405), addressing three Codex review findings on the growth-loop probe (`measureScrollAtHeight`). The probe composed the preview with a bespoke setup that diverged from the final SVG render in ways a private / wrapper / inspection-mode-branching preview would notice:

- **Inspection mode.** The probe forced `LocalInspectionMode = false`, but the final render uses `spec.inspectionMode ?: true`. A preview that shows different content in inspection mode would be measured on the wrong branch, sizing the frame to the wrong extent (and exporting a clipped page). Now matches the final render's inspection mode.
- **Invocation.** The probe invoked the composable raw — no `setAccessible`, no `@PreviewWrapper` / theme-provider. A private scrolling preview would throw `IllegalAccessException`, and a preview whose scrollable content is supplied by a wrapper would be measured unwrapped. Now opens the method and routes through `InvokeWithOptionalWrapper`, mirroring `render()`.
- **Classloader.** Resolving those wrappers goes through the thread context classloader, but the probe ran before the request `classLoader` was installed as the context loader (the normal render dispatch installs it around `evaluate()`). Wrappers live only on the app child classloader, so without the install the probe would still measure unwrapped content. Now installs/restores the context classloader around the probe, mirroring `render()`.

Desktop is unaffected — its probe reuses the shared `setUp` path, so it already matched the final render.

Text-only (no rendered-output change; the default fixture doesn't hit these edge cases — this hardens the measurement path for previews that do).

## Test plan

- [x] `:daemon:android:testDebugUnitTest RenderEngineTest.figmaSvgLongRenderModeProducesFullPageSvg` — green after each fix; the full page is still content-sized (all 30 rows, ~1564px), so mirroring the render setup didn't regress the normal path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)