### PR TITLE
fix(mcp): rescan descriptor index on a miss instead of caching the negative

### DIFF
--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonSupervisor.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonSupervisor.kt
@@ -593,30 +593,42 @@ fun interface DescriptorProvider {
      * and let the user (or VS Code) drive the bootstrap.
      */
     fun readingFromDisk(fileSystem: FileSystem = SystemFileSystem): DescriptorProvider {
-      // Per-project-root index of modulePath -> descriptor file, built lazily on the first miss of
-      // the layout fast-path below and cached so the scan runs at most once per project root.
+      // Per-project-root index of modulePath -> descriptor file, populated on the first miss of the
+      // layout fast-path below. Only *positive* results are cached: a lookup for a module absent
+      // from the cached index rescans (a descriptor may have been written since — exactly what the
+      // "run composePreviewDaemonStart first" error tells the user to do), so a long-lived server
+      // picks up a newly-generated descriptor without a restart. The fast path spares normal
+      // layouts the scan entirely, so the rescan-on-miss cost only lands on the error path.
       val scannedIndexByRoot = ConcurrentHashMap<String, Map<String, File>>()
       return DescriptorProvider { project, modulePath ->
         // Fast path: the Gradle path mirrors the directory layout (`:a:b` → <root>/a/b).
         val guessed =
-          File(gradlePathToFile(project.path, modulePath), "build/compose-previews/daemon-launch.json")
+          File(
+            gradlePathToFile(project.path, modulePath),
+            "build/compose-previews/daemon-launch.json",
+          )
         val descriptorFile =
           if (guessed.isFile) {
             guessed
           } else {
             // Fallback: a project can remap projectDir in settings.gradle.kts (e.g. `:featureTasks`
             // → shared/features/tasks), so the Gradle path is not the on-disk layout. Locate the
-            // descriptor by the modulePath recorded inside each daemon-launch.json.
-            val index =
-              scannedIndexByRoot.getOrPut(project.path.absolutePath) {
-                indexDescriptorsByModulePath(project.path, fileSystem)
+            // descriptor by the modulePath recorded inside each daemon-launch.json. Reuse the
+            // cached
+            // index only if it already resolves this module; otherwise rebuild it (a descriptor may
+            // have appeared) and cache the fresh scan before giving up.
+            val root = project.path.absolutePath
+            scannedIndexByRoot[root]?.get(modulePath)
+              ?: run {
+                val rescanned = indexDescriptorsByModulePath(project.path, fileSystem)
+                scannedIndexByRoot[root] = rescanned
+                rescanned[modulePath]
+                  ?: error(
+                    "Missing daemon launch descriptor for $modulePath under " +
+                      "${project.path.absolutePath}. " +
+                      "Run `./gradlew $modulePath:composePreviewDaemonStart` first."
+                  )
               }
-            index[modulePath]
-              ?: error(
-                "Missing daemon launch descriptor for $modulePath under " +
-                  "${project.path.absolutePath}. " +
-                  "Run `./gradlew $modulePath:composePreviewDaemonStart` first.",
-              )
           }
         DaemonLaunchDescriptor.parse(fileSystem.read(descriptorFile.path.toPath()) { readUtf8() })
       }
@@ -657,8 +669,10 @@ fun interface DescriptorProvider {
         .forEach { file ->
           val recorded =
             runCatching {
-              DaemonLaunchDescriptor.parse(fileSystem.read(file.path.toPath()) { readUtf8() }).modulePath
-            }.getOrNull()
+                DaemonLaunchDescriptor.parse(fileSystem.read(file.path.toPath()) { readUtf8() })
+                  .modulePath
+              }
+              .getOrNull()
           if (recorded != null) index.putIfAbsent(recorded, file)
         }
       return index

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonSupervisorTest.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonSupervisorTest.kt
@@ -23,9 +23,57 @@ class DaemonSupervisorTest {
   @Test
   fun `readingFromDisk resolves descriptor for a projectDir-remapped module`() {
     val root = createTempDirectory("cp-supervisor-test").toFile()
-    // `:featureTasks` can be remapped to shared/features/tasks in settings.gradle.kts, so the Gradle
-    // path does NOT mirror the on-disk layout. The layout fast path (<root>/featureTasks) must miss,
+    // `:featureTasks` can be remapped to shared/features/tasks in settings.gradle.kts, so the
+    // Gradle
+    // path does NOT mirror the on-disk layout. The layout fast path (<root>/featureTasks) must
+    // miss,
     // and the fallback scan must locate the descriptor by the modulePath recorded inside it.
+    writeRemappedDescriptor(root)
+
+    val project =
+      RegisteredProject(
+        workspaceId = WorkspaceId("ws-test"),
+        rootProjectName = "client",
+        path = root,
+        knownModules = mutableListOf(":featureTasks"),
+      )
+
+    val descriptor = DescriptorProvider.readingFromDisk().descriptorFor(project, ":featureTasks")
+
+    assertThat(descriptor.modulePath).isEqualTo(":featureTasks")
+    assertThat(descriptor.variant).isEqualTo("desktop")
+  }
+
+  @Test
+  fun `readingFromDisk rescans when a remapped descriptor appears after a miss`() {
+    val root = createTempDirectory("cp-supervisor-test").toFile()
+    val project =
+      RegisteredProject(
+        workspaceId = WorkspaceId("ws-test"),
+        rootProjectName = "client",
+        path = root,
+        knownModules = mutableListOf(":featureTasks"),
+      )
+    // A single long-lived provider: the first lookup misses (no descriptor yet, so the scanned
+    // index is empty), the descriptor is then generated (as the error tells the user to do), and a
+    // second lookup on the SAME provider must resolve it — i.e. the empty scan is not cached as a
+    // permanent negative for the remapped module.
+    val provider = DescriptorProvider.readingFromDisk()
+
+    val firstAttempt = runCatching { provider.descriptorFor(project, ":featureTasks") }
+    assertThat(firstAttempt.exceptionOrNull()).isInstanceOf(IllegalStateException::class.java)
+
+    writeRemappedDescriptor(root)
+
+    val descriptor = provider.descriptorFor(project, ":featureTasks")
+    assertThat(descriptor.modulePath).isEqualTo(":featureTasks")
+    assertThat(descriptor.variant).isEqualTo("desktop")
+  }
+
+  /**
+   * Writes a `:featureTasks` descriptor at the remapped `shared/features/tasks` path under [root].
+   */
+  private fun writeRemappedDescriptor(root: File) {
     val previewsDir = File(root, "shared/features/tasks/build/compose-previews")
     previewsDir.mkdirs()
     File(previewsDir, "daemon-launch.json")
@@ -44,20 +92,7 @@ class DaemonSupervisorTest {
           "manifestPath": "manifest.json"
         }
         """
-          .trimIndent(),
+          .trimIndent()
       )
-
-    val project =
-      RegisteredProject(
-        workspaceId = WorkspaceId("ws-test"),
-        rootProjectName = "client",
-        path = root,
-        knownModules = mutableListOf(":featureTasks"),
-      )
-
-    val descriptor = DescriptorProvider.readingFromDisk().descriptorFor(project, ":featureTasks")
-
-    assertThat(descriptor.modulePath).isEqualTo(":featureTasks")
-    assertThat(descriptor.variant).isEqualTo("desktop")
   }
 }


### PR DESCRIPTION
Follow-up to #2397 (merged), addressing the P2 raised in review.

## Problem

The `projectDir`-remapped descriptor fallback added in #2397 built a `modulePath -> descriptor` index by scanning the project root, then cached it **per project root, forever, on the first miss** (`scannedIndexByRoot.getOrPut`). For a remapped module whose descriptor is generated *after* the MCP server is already running — exactly what the `Missing daemon launch descriptor … Run \`./gradlew …:composePreviewDaemonStart\` first` error tells the user to do — the layout fast path still misses (remapped path), and the stale cached index keeps reporting the descriptor missing until the server restarts. So the error message invites a recovery step the cache defeats.

(Layout-mirroring modules were never affected — their fast path re-stats disk on every call. Only remapped modules that rely on the scan hit this.)

## Fix

Cache only **positive** results. A lookup for a module absent from the cached index rebuilds the index (a descriptor may have appeared since) and caches the fresh scan before erroring:

```kotlin
scannedIndexByRoot[root]?.get(modulePath)
  ?: run {
    val rescanned = indexDescriptorsByModulePath(project.path, fileSystem)
    scannedIndexByRoot[root] = rescanned
    rescanned[modulePath] ?: error("Missing daemon launch descriptor …")
  }
```

The layout fast path still spares normal projects any scan, so the rescan-on-miss cost only lands on the error path (a genuinely missing module), and a resolved module stays cached for its hot path.

## Testing

- New regression test `readingFromDisk rescans when a remapped descriptor appears after a miss`: one long-lived provider, a first lookup misses (throws), the descriptor is then written, and a second lookup on the **same provider** resolves it.
- `:mcp:test --tests '*DaemonSupervisorTest*'` green (both the #2397 remapped test and the new rescan test). Refactored the shared descriptor-writing into a `writeRemappedDescriptor` helper.

_Generated by [Claude Code](https://claude.ai/code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_014nC2f2D5MWRPnJeqnrrq5Y)_