### PR TITLE
fix(cloud): seed Gradle distribution from repo.gradle.org proxy before warm

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -31,6 +31,20 @@ if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
   exit 0
 fi
 
+# Seed the Gradle wrapper distribution(s) from the allowlisted repo.gradle.org
+# github-downloads-proxy BEFORE any `./gradlew` runs. The wrapper's
+# distributionUrl (services.gradle.org) 307-redirects to a github.com release
+# asset, which the "custom" cloud egress policy blocks (403) — so the warm below
+# would otherwise die with `Server returned HTTP response code: 403` before the
+# build starts. The proxy serves the identical, checksum-verified bytes and is an
+# allowlisted Gradle host. Covers single- and multi-repo checkouts (every wrapper
+# across the side-by-side clones). Best-effort: a failure leaves the download to
+# Gradle and never aborts the session.
+if [ -x scripts/seed-gradle-dist.sh ]; then
+  scripts/seed-gradle-dist.sh >&2 || \
+    echo "[session-start] seed-gradle-dist.sh failed; Gradle will fetch the distribution itself" >&2
+fi
+
 # Ensure a JDK 17 toolchain exists before warming Gradle. The build pins
 # `toolchainVersion=17` (gradle/gradle-daemon-jvm.properties), but cloud
 # containers commonly ship only JDK 21, and on the allowlist network policy

--- a/scripts/seed-gradle-dist.sh
+++ b/scripts/seed-gradle-dist.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+# Seed the Gradle wrapper distribution(s) into the wrapper cache from an
+# allowlisted mirror, so the first `./gradlew` never has to fetch one over a
+# path the sandbox blocks.
+#
+# The problem: a wrapper's distributionUrl points at services.gradle.org, which
+# 307-redirects to a GitHub release
+# (github.com/gradle/gradle-distributions/releases/…). Locked-down cloud
+# sandboxes (Claude Code on the web's "custom" network mode is the motivating
+# case) routinely block github.com's release assets, so the very first
+# `./gradlew` — including the SessionStart warm-up — dies fetching the
+# distribution with `Server returned HTTP response code: 403`, before the build
+# even starts.
+#
+# The fix: repo.gradle.org's github-downloads-proxy serves the identical bytes
+# (it proxies the same GitHub release server-side) and is a normal Gradle host
+# that allowlists already permit. So we fetch the distribution from there,
+# checksum-verify it, and drop the zip into $GRADLE_USER_HOME/wrapper/dists
+# exactly where the wrapper looks for it — Gradle then unpacks + re-verifies +
+# marks it ready itself on the first invocation, with no network. No repo
+# changes: the wrapper properties are read, never written.
+#
+# Single- and multi-repo checkouts: a web session often has several repos
+# checked out side by side (the workspace root, i.e. the parent of this repo),
+# and they can pin *different* Gradle versions. Seeding only this repo's wrapper
+# covers one version; the others' first `./gradlew` still dies on the blocked
+# redirect. So we discover every wrapper across the local checkouts, dedup by
+# distributionUrl, and seed each distinct version. Override the search root with
+# COOEE_CHECKOUTS_DIR.
+#
+# No-op when there is no wrapper anywhere, when a distribution is already cached
+# (warm box / prior run), or when a distributionUrl isn't the services.gradle.org
+# default (a custom/self-hosted URL is the project's own call). Best-effort:
+# any failure warns and leaves that download to Gradle — it never fails the
+# session.
+
+set -uo pipefail
+
+log()  { echo "[seed-gradle-dist] $*" >&2; }
+warn() { echo "[seed-gradle-dist] WARNING: $*" >&2; }
+
+project_dir="${CLAUDE_PROJECT_DIR:-$(git -C "$(dirname "$0")" rev-parse --show-toplevel 2>/dev/null || pwd)}"
+
+# The workspace root that holds the side-by-side checkouts — the parent of this
+# repo. Never root the scan at a broad system directory: fall back to the
+# project dir itself so a single-repo layout still gets its own wrapper seeded.
+workspace_root() {
+  local root="${COOEE_CHECKOUTS_DIR:-}"
+  if [[ -z "$root" ]]; then
+    root="$(dirname "$project_dir")"
+    case "$root" in ""|.|/|/home|/Users|/root|/usr|/var|/opt|/tmp) root="$project_dir" ;; esac
+  fi
+  printf '%s' "$root"
+}
+
+# Every gradle-wrapper.properties across the local checkouts. Bounded depth keeps
+# the scan cheap and still catches both a repo-root wrapper and a nested build's
+# wrapper (e.g. <repo>/android/gradle/…).
+wrapper_props() {
+  local root; root="$(workspace_root)"
+  [[ -d "$root" ]] || return 0
+  find "$root" -maxdepth 5 -type f \
+    -path '*/gradle/wrapper/gradle-wrapper.properties' 2>/dev/null | sort
+}
+
+# distributionUrl from a gradle-wrapper.properties, unescaping the properties-file
+# '\:' -> ':' and stripping any trailing CR. Empty output when absent.
+distribution_url() {
+  local props="$1" url
+  [[ -f "$props" ]] || return 0
+  url=$(sed -n 's/^[[:space:]]*distributionUrl[[:space:]]*=[[:space:]]*//p' "$props" | head -1)
+  url="${url%$'\r'}"; url="${url//\\:/:}"
+  printf '%s' "$url"
+}
+
+# base36(md5(s)) — reproduces org.gradle.wrapper.PathAssembler#getHash, the
+# scheme Gradle uses to name a distribution's wrapper cache directory from its
+# distributionUrl (MD5 of the URL, rendered as an unsigned BigInteger in base
+# 36). Pure bash so it needs no python/bc: md5 -> hex, then repeated
+# long-division of that base-16 bignum by 36, collecting remainders.
+wrapper_hash() {
+  local url="$1" hex
+  if command -v md5sum >/dev/null 2>&1; then hex=$(printf '%s' "$url" | md5sum | cut -d' ' -f1)
+  elif command -v md5 >/dev/null 2>&1; then hex=$(printf '%s' "$url" | md5 -q)
+  else return 1; fi
+  [[ ${#hex} -eq 32 ]] || return 1
+
+  local -a nib=() out=(); local i
+  for (( i=0; i<32; i++ )); do nib+=($((16#${hex:i:1}))); done
+
+  local digits="0123456789abcdefghijklmnopqrstuvwxyz"
+  while ((${#nib[@]})); do
+    local -a q=(); local carry=0 started=0 d val qi
+    for d in "${nib[@]}"; do
+      val=$(( carry*16 + d )); qi=$(( val/36 )); carry=$(( val%36 ))
+      if (( started || qi )); then q+=("$qi"); started=1; fi
+    done
+    out=("$carry" "${out[@]}")      # prepend this base36 digit (the remainder)
+    nib=("${q[@]}")
+  done
+
+  local s=""; ((${#out[@]})) || s=0
+  for d in "${out[@]}"; do s+="${digits:d:1}"; done
+  printf '%s' "$s"
+}
+
+# Seed one wrapper's distribution (props file + its extracted distributionUrl)
+# into the wrapper cache.
+seed_one() {
+  local props="$1" url="$2"
+  local repo="${props%/gradle/wrapper/gradle-wrapper.properties}"
+
+  # Only handle the stock services.gradle.org distribution — the one whose GitHub
+  # redirect is what gets blocked. A custom distributionUrl is left untouched.
+  case "$url" in
+    https://services.gradle.org/distributions/*.zip) : ;;
+    *) log "$repo wrapper distributionUrl isn't the services.gradle.org default ($url); leaving the download to Gradle."; return 0 ;;
+  esac
+
+  local zipname="${url##*/}"                 # gradle-9.6.1-bin.zip
+  local distname="${zipname%.zip}"           # gradle-9.6.1-bin
+  local ver="${distname#gradle-}"            # 9.6.1-bin
+  ver="${ver%-bin}"; ver="${ver%-all}"       # 9.6.1
+
+  # Where the wrapper looks: <dists>/<distname>/<hash>/, hash = base36(md5(url)).
+  # GRADLE_USER_HOME defaults to ~/.gradle; distributionPath to wrapper/dists.
+  local hash; hash=$(wrapper_hash "$url") \
+    || { warn "couldn't compute the wrapper cache hash for $repo; leaving the download to Gradle."; return 0; }
+  local dest="${GRADLE_USER_HOME:-$HOME/.gradle}/wrapper/dists/$distname/$hash"
+
+  # Already there? Either Gradle installed it (.ok marker) or a prior seed placed
+  # the zip pending unpack. Nothing to do.
+  if [[ -f "$dest/$zipname.ok" || -f "$dest/$zipname" ]]; then
+    log "Gradle $ver already present in the wrapper cache; nothing to seed."
+    return 0
+  fi
+
+  # Rewrite services.gradle.org -> the github-downloads-proxy, which mirrors the
+  # exact GitHub release asset (v<ver>/<zipname>) the redirect points at.
+  local mirror="https://repo.gradle.org/gradle/github-downloads-proxy/gradle/gradle-distributions/releases/download/v$ver/$zipname"
+
+  log "seeding Gradle $ver into the wrapper cache from repo.gradle.org (services.gradle.org's GitHub redirect is blocked here)..."
+
+  local tmp; tmp=$(mktemp -d "${TMPDIR:-/tmp}/seed-gradle-dist.XXXXXX") \
+    || { warn "couldn't create a temp dir for the wrapper seed; skipping."; return 0; }
+  local zip="$tmp/$zipname"
+  if ! curl -fsSL --retry 3 -o "$zip" "$mirror"; then
+    warn "couldn't download Gradle $ver from $mirror; leaving the download to Gradle."
+    rm -rf "$tmp"; return 0
+  fi
+
+  # Verify: prefer the wrapper's pinned distributionSha256Sum, else the mirror's
+  # published .sha256. A mismatch means don't trust the bytes — bail, don't seed.
+  local want
+  want=$(sed -n 's/^[[:space:]]*distributionSha256Sum[[:space:]]*=[[:space:]]*//p' "$props" | head -1)
+  want="${want%$'\r'}"
+  [[ -n "$want" ]] || want=$(curl -fsSL "$mirror.sha256" 2>/dev/null | tr -d '[:space:]')
+  if [[ -n "$want" ]]; then
+    local got; got=$(sha256sum "$zip" | cut -d' ' -f1)
+    if [[ "$got" != "$want" ]]; then
+      warn "Gradle $ver checksum mismatch (got $got, want $want); refusing to seed. Leaving the download to Gradle."
+      rm -rf "$tmp"; return 0
+    fi
+    log "Gradle $ver checksum verified ($want)."
+  else
+    warn "no checksum available for Gradle $ver; seeding the download unverified."
+  fi
+
+  # Place the verified zip where the wrapper expects it. Gradle finds it there,
+  # (re-)checksums it against any pinned sum, unpacks it, and writes the .ok
+  # marker on the first `./gradlew` — all offline.
+  mkdir -p "$dest" && mv -f "$zip" "$dest/$zipname" || {
+    warn "couldn't place the Gradle $ver zip in the wrapper cache ($dest); skipping."
+    rm -rf "$tmp"; return 0; }
+  rm -rf "$tmp"
+  log "Gradle $ver seeded into the wrapper cache; ./gradlew will unpack it without fetching the distribution."
+}
+
+main() {
+  local -A seen=()
+  local props url seeded=0
+  while IFS= read -r props; do
+    [[ -n "$props" ]] || continue
+    url=$(distribution_url "$props")
+    [[ -n "$url" ]] || continue
+    # Same distribution pinned by more than one checkout — seed it once.
+    [[ -n "${seen[$url]:-}" ]] && continue
+    seen[$url]=1
+    seed_one "$props" "$url"
+    seeded=$((seeded + 1))
+  done < <(wrapper_props)
+  (( seeded )) || log "no Gradle wrapper found in the local checkouts; nothing to seed."
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

The SessionStart Gradle warm (`./gradlew help`) and the first real `./gradlew` died in locked-down cloud sandboxes (Claude Code on the web's "custom" network mode) with:

```
Downloading https://services.gradle.org/distributions/gradle-9.6.1-bin.zip
Attempt 1/1 failed. Reason: Server returned HTTP response code: 403
java.io.IOException: Server returned HTTP response code: 403
```

**Root cause:** the wrapper's `distributionUrl` (`services.gradle.org`) 307-redirects to a `github.com` release asset (`gradle/gradle-distributions/releases/...`), and the egress policy blocks `github.com` (403). So the distribution could never be fetched, and no Gradle task worked.

**Fix:** new `scripts/seed-gradle-dist.sh` seeds the wrapper distribution into `$GRADLE_USER_HOME/wrapper/dists` from `repo.gradle.org`'s github-downloads-proxy — which serves the identical, checksum-verified bytes and is an allowlisted Gradle host. Gradle then unpacks it offline on the first invocation (no repo files are written; the wrapper properties are read-only). The SessionStart hook runs it before the JDK setup and warm.

## Details

- **Single- and multi-repo checkouts:** discovers every `gradle-wrapper.properties` across the side-by-side clones (workspace root = parent of this repo), dedups by `distributionUrl`, and seeds each distinct Gradle version. A single-repo layout falls back to seeding just this repo.
- **Idempotent + best-effort:** no-ops when the `.zip` or `.zip.ok` marker is already cached — a warm box, a prior run, or an environment where `coo.ee/env`'s java module already seeded it. Any failure (blocked mirror, checksum mismatch, no wrapper) warns and leaves the download to Gradle without aborting the session.
- **Checksum-verified:** prefers the wrapper's pinned `distributionSha256Sum`, else the mirror's published `.sha256`; a mismatch refuses to seed.
- Only rewrites the stock `services.gradle.org` distribution URL; a custom/self-hosted `distributionUrl` is left untouched.

## Test plan

Exercised in a live cloud sandbox (github.com blocked, 403):

- `services.gradle.org/distributions/gradle-9.6.1-bin.zip` → 403 (reproduced the failure); `repo.gradle.org/gradle/github-downloads-proxy/.../v9.6.1/gradle-9.6.1-bin.zip` → 200.
- Clean cache → `seed-gradle-dist.sh` seeds from the proxy, checksum verified against the published `.sha256`, zip lands in the exact wrapper cache dir (`gradle-9.6.1-bin/4ticwg1pgcbps2hj28r8so764/`).
- `./gradlew --version` then runs fully offline from the seeded distribution.
- Second run is a clean no-op (`already present; nothing to seed`) — confirms idempotency after coo.ee/env or a prior run.
- The `base36(md5(distributionUrl))` cache-dir hash matches Gradle's own `PathAssembler#getHash` output.

## Notes

A related, separate blocker remains out of scope here: `scripts/setup-cloud-jdk.sh` provisions JDK 17 from `github.com/adoptium/...` release assets, which the same policy blocks (403). With no JDK 17 on the box, tasks that start the daemon still fail toolchain resolution even once the distribution is seeded. Happy to follow up with a non-GitHub JDK source if wanted.

_Generated by [Claude Code]_

---
_Generated by [Claude Code](https://claude.ai/code/session_012iPYAXfPHfVuLj5vEeyRYm)_