### PR TITLE
feat(gradle): add --preview name filter to composePreviewRender

### DIFF
--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewNameFilter.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewNameFilter.kt
@@ -1,0 +1,92 @@
+package ee.schimke.composeai.discovery
+
+/**
+ * Name-based `@Preview` selector used by `composePreviewRender --preview` /
+ * `-PcomposePreview.filter` (issue #2066). Narrows a discovered manifest to the preview functions a
+ * caller names, so a tight iteration loop can re-render a single screen instead of the whole module
+ * — and so an unrelated broken preview never poisons a filtered run (it's simply not scheduled).
+ *
+ * A preview matches a pattern against two candidate names:
+ * - its **simple** function name (e.g. `ExportHelpDialogPreview`), and
+ * - its **package-qualified** name (`<package>.<functionName>`, e.g.
+ *   `com.example.preview.ExportHelpDialogPreview`) — the FQN a user reads off the source, derived
+ *   from the owning class's package rather than the synthetic `…Kt` holder class.
+ *
+ * Two matching styles, chosen per pattern:
+ * - **Glob** — a pattern containing `*` (any run) or `?` (one char) is anchored and full-matched
+ *   against either candidate: `*ExportHelpDialogPreview`, `Export*Preview`, `com.example.*.Foo`.
+ * - **Plain** — a pattern with no glob chars matches on equality *or substring* against either
+ *   candidate, so `ExportHelpDialog` finds `ExportHelpDialogPreview` and a full FQN matches
+ *   exactly.
+ *
+ * Matching is case-sensitive (Kotlin function names are), and any pattern matching keeps the
+ * preview (OR across the pattern list). An empty pattern list matches everything — the historical
+ * "render every preview" behaviour.
+ */
+object PreviewNameFilter {
+
+  /**
+   * True when [functionName] (owned by [className]) matches at least one of [patterns], or when
+   * [patterns] is empty (no filter → keep everything). Blank patterns are ignored so a stray comma
+   * in `-PcomposePreview.filter=Foo,` can't silently match nothing-or-everything.
+   */
+  fun matches(patterns: Collection<String>, functionName: String, className: String): Boolean {
+    val cleaned = patterns.map(String::trim).filter(String::isNotEmpty)
+    if (cleaned.isEmpty()) return true
+    val fqName = fqName(className, functionName)
+    return cleaned.any { matchOne(it, functionName, fqName) }
+  }
+
+  /**
+   * The package-qualified name a user reads off the source: `<package>.<functionName>`. [className]
+   * is the owning class FQN (a synthetic `…Kt` holder for top-level functions), so only its package
+   * segment is meaningful for naming a preview. Falls back to the bare function name when the class
+   * has no package (default package).
+   */
+  fun fqName(className: String, functionName: String): String {
+    val pkg = className.substringBeforeLast('.', "")
+    return if (pkg.isEmpty()) functionName else "$pkg.$functionName"
+  }
+
+  private fun matchOne(pattern: String, simpleName: String, fqName: String): Boolean =
+    if (pattern.any { it == '*' || it == '?' }) {
+      val regex = globToRegex(pattern)
+      regex.matches(simpleName) || regex.matches(fqName)
+    } else {
+      simpleName == pattern ||
+        fqName == pattern ||
+        simpleName.contains(pattern) ||
+        fqName.contains(pattern)
+    }
+
+  /**
+   * Translates a `*`/`?` glob into an anchored regex, escaping every other character so a `.` in an
+   * FQN is a literal dot rather than "any char". Literal runs are batched through [Regex.escape] so
+   * regex metacharacters in a package name can never leak into the pattern.
+   */
+  private fun globToRegex(glob: String): Regex {
+    val out = StringBuilder()
+    val literal = StringBuilder()
+    fun flushLiteral() {
+      if (literal.isNotEmpty()) {
+        out.append(Regex.escape(literal.toString()))
+        literal.clear()
+      }
+    }
+    for (c in glob) {
+      when (c) {
+        '*' -> {
+          flushLiteral()
+          out.append(".*")
+        }
+        '?' -> {
+          flushLiteral()
+          out.append(".")
+        }
+        else -> literal.append(c)
+      }
+    }
+    flushLiteral()
+    return Regex(out.toString())
+  }
+}

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewNameFilterTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewNameFilterTest.kt
@@ -1,0 +1,102 @@
+package ee.schimke.composeai.discovery
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class PreviewNameFilterTest {
+
+  private val cls = "com.example.preview.ExportHelpDialogKt"
+  private val fn = "ExportHelpDialogPreview"
+
+  @Test
+  fun `empty filter matches everything`() {
+    assertThat(PreviewNameFilter.matches(emptyList(), fn, cls)).isTrue()
+  }
+
+  @Test
+  fun `blank-only filter matches everything`() {
+    assertThat(PreviewNameFilter.matches(listOf("  ", ""), fn, cls)).isTrue()
+  }
+
+  @Test
+  fun `exact simple name matches`() {
+    assertThat(PreviewNameFilter.matches(listOf("ExportHelpDialogPreview"), fn, cls)).isTrue()
+  }
+
+  @Test
+  fun `substring of simple name matches`() {
+    assertThat(PreviewNameFilter.matches(listOf("ExportHelpDialog"), fn, cls)).isTrue()
+  }
+
+  @Test
+  fun `exact package-qualified name matches`() {
+    assertThat(
+        PreviewNameFilter.matches(listOf("com.example.preview.ExportHelpDialogPreview"), fn, cls)
+      )
+      .isTrue()
+  }
+
+  @Test
+  fun `leading-star glob matches simple name`() {
+    assertThat(PreviewNameFilter.matches(listOf("*ExportHelpDialogPreview"), fn, cls)).isTrue()
+  }
+
+  @Test
+  fun `star glob matches package-qualified name`() {
+    assertThat(PreviewNameFilter.matches(listOf("com.example.*.ExportHelpDialogPreview"), fn, cls))
+      .isTrue()
+  }
+
+  @Test
+  fun `interior star glob matches simple name`() {
+    assertThat(PreviewNameFilter.matches(listOf("Export*Preview"), fn, cls)).isTrue()
+  }
+
+  @Test
+  fun `question-mark glob matches a single char`() {
+    assertThat(PreviewNameFilter.matches(listOf("ExportHelpDialogPrevie?"), fn, cls)).isTrue()
+  }
+
+  @Test
+  fun `glob is anchored - partial glob does not match`() {
+    // A glob is full-matched, so a bare stem without a trailing wildcard must not match a longer
+    // name (unlike the plain-substring path).
+    assertThat(PreviewNameFilter.matches(listOf("Export*Dialog"), fn, cls)).isFalse()
+  }
+
+  @Test
+  fun `dot in glob is a literal, not any-char`() {
+    // `com.example` must not match `comXexample` — the escaped dot proves the glob isn't leaking
+    // regex metacharacters.
+    assertThat(
+        PreviewNameFilter.matches(listOf("com.example.preview.*"), fn, "comXexampleXpreviewXKt")
+      )
+      .isFalse()
+  }
+
+  @Test
+  fun `non-matching name is rejected`() {
+    assertThat(PreviewNameFilter.matches(listOf("SomethingElse"), fn, cls)).isFalse()
+  }
+
+  @Test
+  fun `matching is case-sensitive`() {
+    assertThat(PreviewNameFilter.matches(listOf("exporthelpdialogpreview"), fn, cls)).isFalse()
+  }
+
+  @Test
+  fun `any pattern in the list matching keeps the preview`() {
+    assertThat(PreviewNameFilter.matches(listOf("Nope", "*DialogPreview"), fn, cls)).isTrue()
+  }
+
+  @Test
+  fun `fqName uses the class package, not the synthetic Kt holder`() {
+    assertThat(PreviewNameFilter.fqName(cls, fn))
+      .isEqualTo("com.example.preview.ExportHelpDialogPreview")
+  }
+
+  @Test
+  fun `fqName falls back to the bare function name in the default package`() {
+    assertThat(PreviewNameFilter.fqName("FooKt", "BarPreview")).isEqualTo("BarPreview")
+  }
+}

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -245,6 +245,10 @@ internal object ComposePreviewTasks {
         dataProductsDir.set(previewOutputDir.map { it.dir("data") })
         renderBackend.set("desktop")
         tier.set(tierProperty(project))
+        // `composePreview.filter` convention for the `--preview` name filter (issue #2066); the
+        // repeatable `--preview` CLI option overrides it. Comma-separated so a single `-P` can name
+        // several previews.
+        previewFilters.convention(previewFilterProperty(project))
         displayFilterFilters.set(AndroidPreviewSupport.resolveDisplayFilterFilters(project))
         deviceFrameDevice.set(AndroidPreviewSupport.resolveDeviceFrameDevice(project))
         renderClasspath.from(sourceClassDirs)
@@ -1162,6 +1166,20 @@ internal object ComposePreviewTasks {
       .gradleProperty("composePreview.tier")
       .map { v -> if (v.equals("fast", ignoreCase = true)) "fast" else "full" }
       .orElse("full")
+
+  /**
+   * `Provider<List<String>>` for the `composePreview.filter` Gradle property — the `--preview` name
+   * filter's project-property form (issue #2066). Comma-separated so a single
+   * `-PcomposePreview.filter=*FooPreview,BarPreview` can name several previews; blank segments are
+   * dropped. Empty/absent → an empty list, i.e. "render every preview". Lazy through
+   * `project.providers` so reading it doesn't invalidate the configuration cache when the property
+   * flips between runs. The repeatable `--preview` task option overrides this convention.
+   */
+  internal fun previewFilterProperty(project: Project): Provider<List<String>> =
+    project.providers
+      .gradleProperty("composePreview.filter")
+      .map { v -> v.split(",").map(String::trim).filter(String::isNotEmpty) }
+      .orElse(emptyList())
 
   /**
    * `Provider<String>` for the `composePreview.missingRenders` Gradle property. Controls how

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderPreviewsTask.kt
@@ -119,15 +119,22 @@ abstract class RenderPreviewsTask : DefaultTask() {
     // Empty default = "render every preview". The plugin registration overrides this convention
     // with the `composePreview.filter` Gradle property; a `--preview` option overrides both.
     previewFilters.convention(emptyList())
-    // Caching is intentionally gated on `tier=full`: a `tier=fast` run
-    // only writes a subset of captures (fast ones), so a build-cache
-    // restore from a fast snapshot would *wipe* the previous full run's
-    // heavy outputs from `outputDir` — exactly the stale images the
-    // interactive UI relies on. Up-to-date checks still apply, so a
-    // re-run with no input changes is a no-op and the renders directory
-    // stays as-is regardless of tier.
-    outputs.cacheIf("composePreviewRender caches tier=full runs only") {
-      tier.get().equals("full", ignoreCase = true)
+    // Caching is intentionally gated on `tier=full` AND an empty `--preview` filter — a run is only
+    // cacheable when its `outputDir` is the module's *complete* render set. A `tier=fast` run
+    // writes
+    // only the fast captures, so a build-cache restore from a fast snapshot would *wipe* the
+    // previous full run's heavy outputs — exactly the stale images the interactive UI relies on. A
+    // filtered `tier=full` run is likewise partial: it renders only the named previews and
+    // deliberately leaves every other (possibly stale) PNG in place, so caching that mixed
+    // directory
+    // could store an unrelated stale `Bar.png` and later restore it on a clean checkout for the
+    // same
+    // filtered inputs (issue #2066 review). Up-to-date checks still apply, so a re-run with no
+    // input
+    // changes is a no-op and the renders directory stays as-is regardless of tier or filter.
+    outputs.cacheIf("composePreviewRender caches full, unfiltered runs only") {
+      tier.get().equals("full", ignoreCase = true) &&
+        previewFilters.getOrElse(emptyList()).none { it.isNotBlank() }
     }
   }
 

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderPreviewsTask.kt
@@ -4,9 +4,11 @@ import ee.schimke.composeai.discovery.*
 import javax.inject.Inject
 import kotlinx.serialization.json.Json
 import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Classpath
@@ -16,6 +18,7 @@ import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.options.Option
 import org.gradle.process.ExecOperations
 
 @CacheableTask
@@ -36,6 +39,36 @@ abstract class RenderPreviewsTask : DefaultTask() {
    * can reuse it.
    */
   @get:Input abstract val includeKinds: org.gradle.api.provider.SetProperty<String>
+
+  /**
+   * Preview-name filter (issue #2066). When non-empty, only previews whose simple or
+   * package-qualified name matches an entry are rendered; everything else — including any unrelated
+   * broken preview — is left untouched on disk and never scheduled. Empty (the default) renders
+   * every discovered preview, the historical behaviour.
+   *
+   * Populated from the repeatable `--preview` task option (see [setPreviewFilterOption]) or, as a
+   * convention, from the `composePreview.filter` Gradle property wired at registration. Matching
+   * (glob `*`/`?` or substring, against simple + FQN) lives in [PreviewNameFilter]. `@Input` so a
+   * filter change re-runs the render.
+   */
+  @get:Input abstract val previewFilters: ListProperty<String>
+
+  /**
+   * Backs the repeatable `--preview` CLI option. `List<String>` makes it repeatable (`--preview A
+   * --preview B`); each value is a name or glob. Setting the option overrides the
+   * `composePreview.filter` convention rather than merging with it, so the command line always
+   * wins.
+   */
+  @Option(
+    option = "preview",
+    description =
+      "Render only previews whose simple or fully-qualified name matches this pattern " +
+        "(repeatable; supports '*'/'?' globs or a plain substring). No match fails the task. " +
+        "Overrides -PcomposePreview.filter.",
+  )
+  fun setPreviewFilterOption(values: List<String>) {
+    previewFilters.set(values)
+  }
 
   /**
    * Render-tier filter. When `"fast"` the desktop path skips any preview whose representative
@@ -83,6 +116,9 @@ abstract class RenderPreviewsTask : DefaultTask() {
     // the managed-`SetProperty` implicit empty convention — keeps "render every kind" the default
     // and self-documents it.
     includeKinds.convention(emptySet())
+    // Empty default = "render every preview". The plugin registration overrides this convention
+    // with the `composePreview.filter` Gradle property; a `--preview` option overrides both.
+    previewFilters.convention(emptyList())
     // Caching is intentionally gated on `tier=full`: a `tier=fast` run
     // only writes a subset of captures (fast ones), so a build-cache
     // restore from a fast snapshot would *wipe* the previous full run's
@@ -100,6 +136,15 @@ abstract class RenderPreviewsTask : DefaultTask() {
     val json = Json { ignoreUnknownKeys = true }
     val rawManifest = json.decodeFromString<PreviewManifest>(previewsJson.get().asFile.readText())
 
+    // Name filter (issue #2066) — when `--preview` / `-PcomposePreview.filter` is set, narrow to
+    // the
+    // named previews FIRST, before tier/kind/catalog filtering. A non-empty filter that matches
+    // nothing fails fast (listing available names) rather than silently rendering zero previews.
+    // Filtered-out previews keep their PNGs on disk (protected by the raw-manifest fan-out guard
+    // below), so an unrelated broken preview is never scheduled and can't poison a filtered run.
+    val nameFiltered =
+      selectNamedPreviews(rawManifest.previews, previewFilters.getOrElse(emptyList()))
+
     // Tier filter — drop previews whose representative capture is heavy
     // when running in `fast` mode. The desktop path renders just the
     // first capture per preview, so the decision is per-preview rather
@@ -110,9 +155,9 @@ abstract class RenderPreviewsTask : DefaultTask() {
     // with its badge.
     val isFastTier = tier.get().equals("fast", ignoreCase = true)
     val tierFiltered =
-      if (!isFastTier) rawManifest.previews
+      if (!isFastTier) nameFiltered
       else
-        rawManifest.previews.filter {
+        nameFiltered.filter {
           val firstCost = it.captures.firstOrNull()?.cost ?: STATIC_COST
           !isHeavyCost(firstCost)
         }
@@ -148,8 +193,7 @@ abstract class RenderPreviewsTask : DefaultTask() {
     renderWithCompose(manifest, rawManifest, outDir)
 
     val tierTag =
-      if (isFastTier)
-        " (fast tier; ${rawManifest.previews.size - manifest.previews.size} heavy skipped)"
+      if (isFastTier) " (fast tier; ${nameFiltered.size - manifest.previews.size} heavy skipped)"
       else ""
     logger.lifecycle("Rendered ${manifest.previews.size} preview(s)$tierTag")
   }
@@ -378,6 +422,52 @@ abstract class RenderPreviewsTask : DefaultTask() {
         )
     }
   }
+}
+
+/** How many available preview names to list in a no-match `--preview` error before truncating. */
+private const val MAX_SUGGESTED_PREVIEW_NAMES = 20
+
+/**
+ * Narrows [previews] to those matching [filters] (issue #2066). An empty/blank filter returns the
+ * list unchanged ("render every preview"). A non-empty filter that matches nothing throws a
+ * [GradleException] listing the available preview names — a filtered run that would render zero
+ * previews is a user error (typo / wrong module), not a silent no-op. Matching semantics live in
+ * [PreviewNameFilter]; this function owns only the select-or-fail policy so it's unit-testable
+ * without a Gradle task instance.
+ */
+internal fun selectNamedPreviews(
+  previews: List<PreviewInfo>,
+  filters: List<String>,
+): List<PreviewInfo> {
+  val cleaned = filters.map(String::trim).filter(String::isNotEmpty)
+  if (cleaned.isEmpty()) return previews
+
+  val matched = previews.filter {
+    PreviewNameFilter.matches(cleaned, it.functionName, it.className)
+  }
+  if (matched.isNotEmpty()) return matched
+
+  val available =
+    previews.map { PreviewNameFilter.fqName(it.className, it.functionName) }.distinct().sorted()
+  throw GradleException(
+    buildString {
+      append("composePreviewRender --preview matched no previews for ")
+      append(cleaned.joinToString(", ") { "'$it'" })
+      append(".")
+      if (available.isEmpty()) {
+        append(" This module has no discovered previews — run composePreviewDiscover to confirm.")
+      } else {
+        append(" Available previews:")
+        available.take(MAX_SUGGESTED_PREVIEW_NAMES).forEach { append("\n  ").append(it) }
+        val more = available.size - MAX_SUGGESTED_PREVIEW_NAMES
+        if (more > 0) {
+          append("\n  … and ")
+          append(more)
+          append(" more (run composePreviewDiscover for the full list).")
+        }
+      }
+    }
+  )
 }
 
 /**

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/SelectNamedPreviewsTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/SelectNamedPreviewsTest.kt
@@ -1,0 +1,76 @@
+package ee.schimke.composeai.plugin
+
+import com.google.common.truth.Truth.assertThat
+import ee.schimke.composeai.discovery.PreviewInfo
+import org.gradle.api.GradleException
+import org.junit.Test
+
+class SelectNamedPreviewsTest {
+
+  private fun preview(functionName: String, pkg: String = "com.example.preview") =
+    PreviewInfo(
+      id = "$pkg.$functionName",
+      functionName = functionName,
+      className = "$pkg.PreviewsKt",
+    )
+
+  private val all =
+    listOf(
+      preview("ExportHelpDialogPreview"),
+      preview("HomeScreenPreview"),
+      preview("BrokenPreview"),
+    )
+
+  @Test
+  fun `empty filter returns every preview`() {
+    assertThat(selectNamedPreviews(all, emptyList())).isEqualTo(all)
+  }
+
+  @Test
+  fun `blank-only filter returns every preview`() {
+    assertThat(selectNamedPreviews(all, listOf("  ", ""))).isEqualTo(all)
+  }
+
+  @Test
+  fun `glob narrows to the single matching preview`() {
+    val selected = selectNamedPreviews(all, listOf("*ExportHelpDialogPreview"))
+    assertThat(selected.map { it.functionName }).containsExactly("ExportHelpDialogPreview")
+  }
+
+  @Test
+  fun `an unrelated broken preview is not selected by a non-matching filter`() {
+    val selected = selectNamedPreviews(all, listOf("HomeScreenPreview"))
+    assertThat(selected.map { it.functionName }).containsExactly("HomeScreenPreview")
+    assertThat(selected.map { it.functionName }).doesNotContain("BrokenPreview")
+  }
+
+  @Test
+  fun `no match fails fast and lists available preview names`() {
+    val thrown =
+      try {
+        selectNamedPreviews(all, listOf("DoesNotExist"))
+        null
+      } catch (e: GradleException) {
+        e
+      }
+    assertThat(thrown).isNotNull()
+    val message = thrown!!.message!!
+    assertThat(message).contains("matched no previews")
+    assertThat(message).contains("'DoesNotExist'")
+    // Names are surfaced as the readable package-qualified form, sorted.
+    assertThat(message).contains("com.example.preview.ExportHelpDialogPreview")
+    assertThat(message).contains("com.example.preview.HomeScreenPreview")
+  }
+
+  @Test
+  fun `no match with no discovered previews explains the empty module`() {
+    val thrown =
+      try {
+        selectNamedPreviews(emptyList(), listOf("Anything"))
+        null
+      } catch (e: GradleException) {
+        e
+      }
+    assertThat(thrown!!.message).contains("no discovered previews")
+  }
+}

--- a/site/index.md
+++ b/site/index.md
@@ -90,13 +90,17 @@ plugins {
 ./gradlew :app:composePreviewRenderAll   # render every @Preview to PNG
 ```
 
-Iterating on one screen? Narrow the render to a single preview (or a glob) so an
-unrelated broken preview can't poison the run:
+Iterating on one screen? On Compose Desktop / Multiplatform-JVM modules you can
+narrow the render to a single preview (or a glob) so an unrelated broken preview
+can't poison the run:
 
 ```sh
-./gradlew :app:composePreviewRender --preview '*ExportHelpDialogPreview'
+./gradlew :desktopApp:composePreviewRender --preview '*ExportHelpDialogPreview'
 # or, as a Gradle property: -PcomposePreview.filter='*ExportHelpDialogPreview'
 ```
+
+(Android modules render previews through a Robolectric test task; the `--preview`
+filter there is tracked as a follow-up.)
 
 Requirements and CI recipes live on the [Install page](./install/).
 

--- a/site/index.md
+++ b/site/index.md
@@ -90,6 +90,14 @@ plugins {
 ./gradlew :app:composePreviewRenderAll   # render every @Preview to PNG
 ```
 
+Iterating on one screen? Narrow the render to a single preview (or a glob) so an
+unrelated broken preview can't poison the run:
+
+```sh
+./gradlew :app:composePreviewRender --preview '*ExportHelpDialogPreview'
+# or, as a Gradle property: -PcomposePreview.filter='*ExportHelpDialogPreview'
+```
+
 Requirements and CI recipes live on the [Install page](./install/).
 
 ---


### PR DESCRIPTION
Closes #2066.

## Summary

Adds a name filter to the desktop `composePreviewRender` task so a tight iteration loop can render a single preview (or a subset) instead of the whole module — and so an unrelated broken preview can't poison a filtered run (it's simply never scheduled).

- **New `--preview` CLI option** (repeatable) on `RenderPreviewsTask`, e.g. `./gradlew :app:composePreviewRender --preview '*ExportHelpDialogPreview'`.
- **New `-PcomposePreview.filter` Gradle property** (comma-separated), matching the repo's existing `composePreview.tier` / `composePreview.missingRenders` property convention. The `--preview` option overrides the property.
- **Matching** (`PreviewNameFilter`, in `preview-discovery`) supports glob (`*` / `?`, anchored) and plain substring, against both the simple function name and the package-qualified name (`<package>.<functionName>`). Case-sensitive; any pattern matching keeps the preview; an empty filter renders everything (unchanged historical behaviour).
- **No match fails fast** with a clear message listing the available preview names and pointing at `composePreviewDiscover`.
- Filtering runs **before** tier/kind/catalog filtering. Filtered-out previews keep their PNGs on disk (protected by the existing raw-manifest fan-out guard) and are never handed to the renderer, so a broken sibling can't fail a filtered run.

Scope note: this covers the desktop `RenderPreviewsTask` the issue names explicitly. The Android/Robolectric `composePreviewRender` (a `Test`-type task driven by `PreviewManifestLoader`) does not yet honor the filter — a natural fast-follow that would wire the same matcher through a `composeai.render.previewFilter` system property.

## Test plan

- `PreviewNameFilterTest` (preview-discovery) — matcher: exact / substring / FQN / glob anchoring / literal-dot escaping / case-sensitivity / multi-pattern OR / `fqName` derivation.
- `SelectNamedPreviewsTest` (gradle-plugin) — select-or-fail policy: empty/blank filter passthrough, glob narrowing, unrelated-broken-preview exclusion, fail-fast message listing available names, empty-module message.
- `./gradlew :gradle-plugin:test :gradle-plugin:preview-discovery:test :gradle-plugin:ktfmtCheck :gradle-plugin:preview-discovery:ktfmtCheck` — green.
- End-to-end against `:samples:cmp`, verifying each acceptance criterion:
  - `composePreviewRender --preview '*KeyboardDemoPreview'` → renders exactly `KeyboardDemoPreview_Keyboard_Demo.png` (`Rendered 1 preview(s)`).
  - `-PcomposePreview.filter=FontScale150` (substring) → renders exactly `FontScale150Preview_Font_scale_1_5x.png`.
  - `--preview 'NoSuchPreviewXYZ'` → build fails non-zero with `composePreviewRender --preview matched no previews for 'NoSuchPreviewXYZ'. Available previews: …`.
  - `gradle help --task composePreviewRender` lists the `--preview` option.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NE5X73NdmATow7RbkWtEgj)_