### PR TITLE
feat(slots): record slot scope (Row/Column/Box/Lazy) and scrolling

### DIFF
--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/PreviewSlots.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/PreviewSlots.kt
@@ -78,7 +78,9 @@ enum class SlotScope {
   COLUMN,
   /** `BoxScope` — a single child fills / aligns within the box. */
   BOX,
-  /** A lazy list/grid item scope (`LazyItemScope`) — children scroll; orientation is unspecified. */
+  /**
+   * A lazy list/grid item scope (`LazyItemScope`) — children scroll; orientation is unspecified.
+   */
   LAZY;
 
   companion object {

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/PreviewSlots.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/PreviewSlots.kt
@@ -12,29 +12,85 @@ import kotlinx.serialization.Serializable
  * slots are therefore **explicit and named**, not guessed from a layout heuristic. [extractSlots]
  * distils a captured [ComposeSemanticsPayload] down to just those markers; the box each returns
  * (absolute-to-root px) is the size a child rendered to fill the slot should be given.
+ *
+ * **Scope + scrolling.** The marker also records *what kind of container the slot sits in* — its
+ * [SlotScope] (`Row`/`Column`/`Box`/`Lazy`) and whether that container [PreviewSlot.scrolling] — so
+ * a builder knows how a filled child will be laid out (a `Row` child is placed horizontally, a
+ * `Column` child stacks vertically) and whether the region can hold overflowing content. The marker
+ * encodes these onto the same `testTag` as `;`-separated attributes after the name
+ * (`dp-slot:content;scope=column;scroll=1`); a bare `dp-slot:<name>` (no attributes) reads back as
+ * [SlotScope.UNKNOWN], not scrolling, so older tags still parse.
  */
 object PreviewSlots {
   /** The `testTag` prefix a slot marker applies; the slot name is the suffix (`dp-slot:<name>`). */
   const val SLOT_TAG_PREFIX: String = "dp-slot:"
 
+  /** Separates the slot name from its optional `key=value` attributes in the tag. */
+  private const val ATTR_SEP: Char = ';'
+
   /**
    * The slot markers in [payload], in depth-first order: each node whose `testTag` starts with
-   * [SLOT_TAG_PREFIX], as its name (the suffix) + box (its `boundsInRoot`). Nodes with a blank name
-   * or malformed bounds are skipped, so a partial/garbled tree never throws.
+   * [SLOT_TAG_PREFIX], as its name + optional [SlotScope]/`scroll` attributes + box (its
+   * `boundsInRoot`). Nodes with a blank name or malformed bounds are skipped, so a partial/garbled
+   * tree never throws; an unrecognised attribute is ignored (forward-compatible).
    */
   fun extractSlots(payload: ComposeSemanticsPayload): List<PreviewSlot> {
     val out = mutableListOf<PreviewSlot>()
     fun walk(node: ComposeSemanticsNode) {
       val tag = node.testTag
       if (tag != null && tag.startsWith(SLOT_TAG_PREFIX)) {
-        val name = tag.removePrefix(SLOT_TAG_PREFIX)
+        val parts = tag.removePrefix(SLOT_TAG_PREFIX).split(ATTR_SEP)
+        val name = parts.first()
+        var scope = SlotScope.UNKNOWN
+        var scrolling = false
+        for (attr in parts.drop(1)) {
+          val eq = attr.indexOf('=')
+          if (eq < 0) continue
+          when (attr.substring(0, eq)) {
+            "scope" -> scope = SlotScope.fromWire(attr.substring(eq + 1))
+            "scroll" -> scrolling = attr.substring(eq + 1).let { it == "1" || it == "true" }
+          }
+        }
         val bounds = SlotBounds.parse(node.boundsInRoot)
-        if (name.isNotBlank() && bounds != null) out.add(PreviewSlot(name, bounds))
+        if (name.isNotBlank() && bounds != null) {
+          out.add(PreviewSlot(name, bounds, scope, scrolling))
+        }
       }
       node.children.forEach(::walk)
     }
     walk(payload.root)
     return out
+  }
+}
+
+/**
+ * The layout container a [PreviewSlot] sits in — how a child that fills the slot will be arranged.
+ * Derived from the Compose scope receiver at the marker's call site (`RowScope` → [ROW], etc.), or
+ * declared explicitly for a slot in a receiver-less lambda (a `Scaffold` `topBar`/`fab`). [UNKNOWN]
+ * when the marker didn't record one (a bare `dp-slot:<name>` tag).
+ */
+@Serializable
+enum class SlotScope {
+  UNKNOWN,
+  /** `RowScope` — children are placed horizontally. */
+  ROW,
+  /** `ColumnScope` — children stack vertically. */
+  COLUMN,
+  /** `BoxScope` — a single child fills / aligns within the box. */
+  BOX,
+  /** A lazy list/grid item scope (`LazyItemScope`) — children scroll; orientation is unspecified. */
+  LAZY;
+
+  companion object {
+    /** The [SlotScope] for a tag's `scope=<wire>` value; [UNKNOWN] for null / anything unknown. */
+    fun fromWire(wire: String?): SlotScope =
+      when (wire) {
+        "row" -> ROW
+        "column" -> COLUMN
+        "box" -> BOX
+        "lazy" -> LAZY
+        else -> UNKNOWN
+      }
   }
 }
 
@@ -45,9 +101,19 @@ object PreviewSlots {
  */
 @Serializable data class PreviewSlotsPayload(val previewId: String, val slots: List<PreviewSlot>)
 
-/** One named slot region — its author-declared name and its box (absolute-to-root px). */
+/**
+ * One named slot region — its author-declared [name], its [bounds] (absolute-to-root px), the
+ * [scope] container it sits in, and whether that container is [scrolling]. [scope]/[scrolling]
+ * default to "unspecified" so a bare `dp-slot:<name>` tag (or a client that predates these fields)
+ * round-trips unchanged.
+ */
 @Serializable
-data class PreviewSlot(val name: String, val bounds: SlotBounds) {
+data class PreviewSlot(
+  val name: String,
+  val bounds: SlotBounds,
+  val scope: SlotScope = SlotScope.UNKNOWN,
+  val scrolling: Boolean = false,
+) {
   val width: Int
     get() = bounds.right - bounds.left
 

--- a/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/PreviewSlotsTest.kt
+++ b/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/PreviewSlotsTest.kt
@@ -39,6 +39,59 @@ class PreviewSlotsTest {
   }
 
   @Test
+  fun `parses scope and scroll attributes from the tag; bare tags read as unknown`() {
+    val tree =
+      ComposeSemanticsPayload(
+        node(
+          children =
+            listOf(
+              node(tag = "dp-slot:topBar;scope=box", bounds = "0,0,200,40"),
+              node(tag = "dp-slot:content;scope=column;scroll=1", bounds = "0,40,200,400"),
+              node(tag = "dp-slot:list;scope=lazy;scroll=true", bounds = "0,40,200,400"),
+              node(tag = "dp-slot:plain", bounds = "0,0,10,10"), // no attributes
+            )
+        )
+      )
+
+    val slots = PreviewSlots.extractSlots(tree).associateBy { it.name }
+    assertEquals(SlotScope.BOX, slots.getValue("topBar").scope)
+    assertEquals(false, slots.getValue("topBar").scrolling)
+    assertEquals(SlotScope.COLUMN, slots.getValue("content").scope)
+    assertEquals(true, slots.getValue("content").scrolling)
+    assertEquals(SlotScope.LAZY, slots.getValue("list").scope)
+    assertEquals(true, slots.getValue("list").scrolling)
+    assertEquals(SlotScope.UNKNOWN, slots.getValue("plain").scope)
+    assertEquals(false, slots.getValue("plain").scrolling)
+  }
+
+  @Test
+  fun `unknown attributes and scope values are ignored, name still parses`() {
+    val tree =
+      ComposeSemanticsPayload(
+        node(
+          children =
+            listOf(
+              node(tag = "dp-slot:x;scope=carousel;future=1;scroll=1", bounds = "0,0,10,10")
+            )
+        )
+      )
+    val slot = PreviewSlots.extractSlots(tree).single()
+    assertEquals("x", slot.name)
+    assertEquals(SlotScope.UNKNOWN, slot.scope) // "carousel" is not a known scope
+    assertEquals(true, slot.scrolling)
+  }
+
+  @Test
+  fun `maps every scope wire token`() {
+    assertEquals(SlotScope.ROW, SlotScope.fromWire("row"))
+    assertEquals(SlotScope.COLUMN, SlotScope.fromWire("column"))
+    assertEquals(SlotScope.BOX, SlotScope.fromWire("box"))
+    assertEquals(SlotScope.LAZY, SlotScope.fromWire("lazy"))
+    assertEquals(SlotScope.UNKNOWN, SlotScope.fromWire(null))
+    assertEquals(SlotScope.UNKNOWN, SlotScope.fromWire("nope"))
+  }
+
+  @Test
   fun `skips blank names and malformed bounds, never throws`() {
     val tree =
       ComposeSemanticsPayload(

--- a/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/PreviewSlotsTest.kt
+++ b/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/PreviewSlotsTest.kt
@@ -70,9 +70,7 @@ class PreviewSlotsTest {
       ComposeSemanticsPayload(
         node(
           children =
-            listOf(
-              node(tag = "dp-slot:x;scope=carousel;future=1;scroll=1", bounds = "0,0,10,10")
-            )
+            listOf(node(tag = "dp-slot:x;scope=carousel;future=1;scroll=1", bounds = "0,0,10,10"))
         )
       )
     val slot = PreviewSlots.extractSlots(tree).single()

--- a/runtimes/slots/src/commonMain/kotlin/ee/schimke/composeai/preview/slots/PreviewSlot.kt
+++ b/runtimes/slots/src/commonMain/kotlin/ee/schimke/composeai/preview/slots/PreviewSlot.kt
@@ -80,32 +80,42 @@ val LocalSlotMode: ProvidableCompositionLocal<Boolean> = compositionLocalOf { fa
  * Marks [content] as a named slot region a structured-screen builder can fill with a child.
  *
  * **A no-op in a normal render**: it draws [content] inside a [Box] carrying `testTag =
- * "[SLOT_TAG_PREFIX]<name>"` (plus [scope]/[scrolling] attributes). `testTag` is a semantics
- * property (no visual/layout effect of its own), so the region is captured into the
- * `compose/semantics` tree with its `boundsInRoot` — which the `/render/<id>.slots` route distils
- * into `{ name, bounds, scope, scrolling }`. Under [LocalSlotMode] it renders a translucent
- * [SlotPlaceholder] labelled [name] instead of [content], so a designer sees exactly where the slot
- * is and drops a composable into that precise box.
+ * "[SLOT_TAG_PREFIX]<name>"`. `testTag` is a semantics property (no visual/layout effect of its
+ * own), so the region is captured into the `compose/semantics` tree with its `boundsInRoot` — which
+ * the `/render/<id>.slots` route distils into `{ name, bounds, scope, scrolling }`. Under
+ * [LocalSlotMode] it renders a translucent [SlotPlaceholder] labelled [name] instead of [content],
+ * so a designer sees exactly where the slot is and drops a composable into that precise box.
  *
- * This receiver-less overload is for a slot placed in a lambda with **no layout scope** (a
- * `Scaffold` `topBar` / `floatingActionButton`); pass [scope] explicitly there. A slot placed
- * directly inside a `Row` / `Column` / `Box` / lazy-item body resolves to the matching
- * scope-receiver overload, which records the [PreviewSlotScope] automatically — prefer that.
+ * A slot placed directly inside a `Row` / `Column` / `Box` / lazy-item body resolves to the
+ * matching scope-receiver overload, which records its [PreviewSlotScope] automatically — prefer
+ * that. This bare overload records [PreviewSlotScope.Unknown]; use the [scope]-taking overload for
+ * a slot in a lambda with **no layout scope** (a `Scaffold` `topBar` / `floatingActionButton`).
  *
  * Give the slot a size (via [modifier], or by placing it in a sized parent — a fixed icon box, a
  * `Row` weight): that box is both what the placeholder fills and the constraint a child rendered to
  * fill the slot is given.
  *
  * @param name the slot's author-declared name (the `dp-slot:` suffix); should be non-blank.
- * @param scope the container the slot sits in; declare it for a receiver-less slot.
- * @param scrolling whether the slot's container scrolls (so the region can hold overflowing
- *   content). A [PreviewSlotScope.Lazy] slot is always scrolling.
+ */
+@Composable
+fun PreviewSlot(name: String, modifier: Modifier = Modifier, content: @Composable () -> Unit) =
+  SlotBox(name, PreviewSlotScope.Unknown, scrolling = false, modifier = modifier, content = content)
+
+/**
+ * [PreviewSlot] for a slot in a lambda with **no layout scope** — a `Scaffold` `topBar` /
+ * `floatingActionButton` — where the container can't be inferred from a scope receiver. Declares
+ * the [scope] (and [scrolling]) explicitly. A slot inside a `Row` / `Column` / `Box` / lazy body
+ * should use the scope-receiver overload instead, which infers [scope].
+ *
+ * @param scope the container the slot sits in.
+ * @param scrolling whether that container scrolls; a [PreviewSlotScope.Lazy] slot is always
+ *   scrolling.
  */
 @Composable
 fun PreviewSlot(
   name: String,
+  scope: PreviewSlotScope,
   modifier: Modifier = Modifier,
-  scope: PreviewSlotScope = PreviewSlotScope.Unknown,
   scrolling: Boolean = false,
   content: @Composable () -> Unit,
 ) = SlotBox(name, scope, scrolling, modifier, content)

--- a/runtimes/slots/src/commonMain/kotlin/ee/schimke/composeai/preview/slots/PreviewSlot.kt
+++ b/runtimes/slots/src/commonMain/kotlin/ee/schimke/composeai/preview/slots/PreviewSlot.kt
@@ -2,7 +2,11 @@ package ee.schimke.composeai.preview.slots
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.lazy.LazyItemScope
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.foundation.text.TextAutoSize
 import androidx.compose.runtime.Composable
@@ -25,8 +29,40 @@ import androidx.compose.ui.unit.sp
  */
 const val SLOT_TAG_PREFIX: String = "dp-slot:"
 
-/** The `testTag` a `PreviewSlot(name)` applies: `dp-slot:<name>`. */
-fun slotTag(name: String): String = "$SLOT_TAG_PREFIX$name"
+/**
+ * The layout container a slot sits in, recorded onto the tag so a builder knows how a filled child
+ * is arranged. The scope-receiver [PreviewSlot] overloads set this automatically from the Compose
+ * scope at the call site (`RowScope` → [Row], …); the receiver-less overload takes it explicitly.
+ *
+ * [wire] is the on-tag token, mirrored by the reader's `SlotScope.fromWire`; a drift test asserts
+ * the two agree. Kept as a runtime-local enum (not the reader's `SlotScope`) so this module's
+ * classpath stays free of the serialization dependency.
+ */
+enum class PreviewSlotScope(internal val wire: String?) {
+  Unknown(null),
+  Row("row"),
+  Column("column"),
+  Box("box"),
+  Lazy("lazy"),
+}
+
+/** The `testTag` a bare `PreviewSlot(name)` applies: `dp-slot:<name>`. */
+fun slotTag(name: String): String = slotTag(name, PreviewSlotScope.Unknown, scrolling = false)
+
+/**
+ * The `testTag` a slot applies: `dp-slot:<name>` plus optional `;scope=<wire>` / `;scroll=1`
+ * attributes for a non-[PreviewSlotScope.Unknown] scope or a scrolling container. The reader
+ * (`PreviewSlots.extractSlots`) parses this exact shape.
+ */
+fun slotTag(name: String, scope: PreviewSlotScope, scrolling: Boolean): String = buildString {
+  append(SLOT_TAG_PREFIX)
+  append(name)
+  scope.wire?.let {
+    append(";scope=")
+    append(it)
+  }
+  if (scrolling) append(";scroll=1")
+}
 
 /**
  * Whether the composition is rendering in **slot mode** — the "author a screen" pass. When `true`,
@@ -44,21 +80,84 @@ val LocalSlotMode: ProvidableCompositionLocal<Boolean> = compositionLocalOf { fa
  * Marks [content] as a named slot region a structured-screen builder can fill with a child.
  *
  * **A no-op in a normal render**: it draws [content] inside a [Box] carrying `testTag =
- * "[SLOT_TAG_PREFIX]<name>"`. `testTag` is a semantics property (no visual/layout effect of its
- * own), so the region is captured into the `compose/semantics` tree with its `boundsInRoot` — which
- * the `/render/<id>.slots` route distils into `{ name, bounds }`. Under [LocalSlotMode] it renders
- * a translucent [SlotPlaceholder] labelled [name] instead of [content], so a designer sees exactly
- * where the slot is and drops a composable into that precise box.
+ * "[SLOT_TAG_PREFIX]<name>"` (plus [scope]/[scrolling] attributes). `testTag` is a semantics
+ * property (no visual/layout effect of its own), so the region is captured into the
+ * `compose/semantics` tree with its `boundsInRoot` — which the `/render/<id>.slots` route distils
+ * into `{ name, bounds, scope, scrolling }`. Under [LocalSlotMode] it renders a translucent
+ * [SlotPlaceholder] labelled [name] instead of [content], so a designer sees exactly where the slot
+ * is and drops a composable into that precise box.
+ *
+ * This receiver-less overload is for a slot placed in a lambda with **no layout scope** (a
+ * `Scaffold` `topBar` / `floatingActionButton`); pass [scope] explicitly there. A slot placed
+ * directly inside a `Row` / `Column` / `Box` / lazy-item body resolves to the matching
+ * scope-receiver overload, which records the [PreviewSlotScope] automatically — prefer that.
  *
  * Give the slot a size (via [modifier], or by placing it in a sized parent — a fixed icon box, a
  * `Row` weight): that box is both what the placeholder fills and the constraint a child rendered to
  * fill the slot is given.
  *
  * @param name the slot's author-declared name (the `dp-slot:` suffix); should be non-blank.
+ * @param scope the container the slot sits in; declare it for a receiver-less slot.
+ * @param scrolling whether the slot's container scrolls (so the region can hold overflowing
+ *   content). A [PreviewSlotScope.Lazy] slot is always scrolling.
  */
 @Composable
-fun PreviewSlot(name: String, modifier: Modifier = Modifier, content: @Composable () -> Unit) {
-  Box(modifier.testTag(slotTag(name))) {
+fun PreviewSlot(
+  name: String,
+  modifier: Modifier = Modifier,
+  scope: PreviewSlotScope = PreviewSlotScope.Unknown,
+  scrolling: Boolean = false,
+  content: @Composable () -> Unit,
+) = SlotBox(name, scope, scrolling, modifier, content)
+
+/** `RowScope` slot — records [PreviewSlotScope.Row]; children are placed horizontally. */
+@Composable
+fun RowScope.PreviewSlot(
+  name: String,
+  modifier: Modifier = Modifier,
+  scrolling: Boolean = false,
+  content: @Composable () -> Unit,
+) = SlotBox(name, PreviewSlotScope.Row, scrolling, modifier, content)
+
+/** `ColumnScope` slot — records [PreviewSlotScope.Column]; children stack vertically. */
+@Composable
+fun ColumnScope.PreviewSlot(
+  name: String,
+  modifier: Modifier = Modifier,
+  scrolling: Boolean = false,
+  content: @Composable () -> Unit,
+) = SlotBox(name, PreviewSlotScope.Column, scrolling, modifier, content)
+
+/** `BoxScope` slot — records [PreviewSlotScope.Box]; a single child fills / aligns in the box. */
+@Composable
+fun BoxScope.PreviewSlot(
+  name: String,
+  modifier: Modifier = Modifier,
+  scrolling: Boolean = false,
+  content: @Composable () -> Unit,
+) = SlotBox(name, PreviewSlotScope.Box, scrolling, modifier, content)
+
+/**
+ * `LazyItemScope` slot — records [PreviewSlotScope.Lazy], always scrolling: the slot is one item of
+ * a lazy list/grid, so a filled child sits in a scrolling container.
+ */
+@Composable
+fun LazyItemScope.PreviewSlot(
+  name: String,
+  modifier: Modifier = Modifier,
+  content: @Composable () -> Unit,
+) = SlotBox(name, PreviewSlotScope.Lazy, scrolling = true, modifier = modifier, content = content)
+
+/** Shared body of every [PreviewSlot] overload: the tagged [Box] + slot-mode placeholder swap. */
+@Composable
+private fun SlotBox(
+  name: String,
+  scope: PreviewSlotScope,
+  scrolling: Boolean,
+  modifier: Modifier,
+  content: @Composable () -> Unit,
+) {
+  Box(modifier.testTag(slotTag(name, scope, scrolling || scope == PreviewSlotScope.Lazy))) {
     if (LocalSlotMode.current) SlotPlaceholder(name) else content()
   }
 }

--- a/runtimes/slots/src/jvmTest/kotlin/ee/schimke/composeai/preview/slots/PreviewSlotTest.kt
+++ b/runtimes/slots/src/jvmTest/kotlin/ee/schimke/composeai/preview/slots/PreviewSlotTest.kt
@@ -1,6 +1,9 @@
 package ee.schimke.composeai.preview.slots
 
+import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsNode
+import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsPayload
 import ee.schimke.composeai.data.layoutinspector.PreviewSlots
+import ee.schimke.composeai.data.layoutinspector.SlotScope
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -13,8 +16,38 @@ class PreviewSlotTest {
   }
 
   @Test
+  fun `slotTag appends scope and scroll attributes`() {
+    assertEquals("dp-slot:content;scope=column", slotTag("content", PreviewSlotScope.Column, false))
+    assertEquals("dp-slot:list;scope=lazy;scroll=1", slotTag("list", PreviewSlotScope.Lazy, true))
+    assertEquals("dp-slot:fab;scope=box", slotTag("fab", PreviewSlotScope.Box, false))
+    // Unknown scope emits no scope attribute — a bare tag when not scrolling.
+    assertEquals("dp-slot:x", slotTag("x", PreviewSlotScope.Unknown, false))
+    assertEquals("dp-slot:x;scroll=1", slotTag("x", PreviewSlotScope.Unknown, true))
+  }
+
+  @Test
   fun `the marker prefix agrees with the reader's source of truth`() {
     // The extractor keys off this exact prefix; if the two drift, slots stop being discovered.
     assertEquals(PreviewSlots.SLOT_TAG_PREFIX, SLOT_TAG_PREFIX)
+  }
+
+  @Test
+  fun `every scope's tag round-trips through the reader`() {
+    // The writer (this module) and parser (the reader) must agree on the wire tokens, or a slot's
+    // scope silently reads back UNKNOWN. Assert each scope survives tag → extractSlots.
+    val expected =
+      mapOf(
+        PreviewSlotScope.Unknown to SlotScope.UNKNOWN,
+        PreviewSlotScope.Row to SlotScope.ROW,
+        PreviewSlotScope.Column to SlotScope.COLUMN,
+        PreviewSlotScope.Box to SlotScope.BOX,
+        PreviewSlotScope.Lazy to SlotScope.LAZY,
+      )
+    for ((runtimeScope, readerScope) in expected) {
+      val tag = slotTag("s", runtimeScope, scrolling = false)
+      val node = ComposeSemanticsNode(nodeId = "0", boundsInRoot = "0,0,1,1", testTag = tag)
+      val slot = PreviewSlots.extractSlots(ComposeSemanticsPayload(node)).single()
+      assertEquals("scope $runtimeScope", readerScope, slot.scope)
+    }
   }
 }


### PR DESCRIPTION
## Summary

First step of the catalog-driven UI builder (see `docs/design/UI_BUILDER.md`): teach `PreviewSlot` to record **what container a slot sits in** and **whether it scrolls**, so a structured-screen builder knows how a filled child will be laid out.

- **Scope is auto-detected from the Compose scope receiver** at the call site — new `RowScope` / `ColumnScope` / `BoxScope` / `LazyItemScope` overloads of `PreviewSlot` each record their `PreviewSlotScope`. A slot inside a `Row`/`Column`/`Box`/lazy-item body resolves to the matching overload with no extra syntax (implicit-receiver extensions win over the plain top-level in the same package).
- **Receiver-less slots declare scope explicitly** — a `Scaffold` `topBar`/`floatingActionButton` lambda has no layout receiver, so those pass `scope = PreviewSlotScope.Box` (etc.) to the plain overload, which now takes optional `scope` + `scrolling` params.
- **`scrolling`** marks a slot whose container scrolls (a `Column(verticalScroll)`); a `LazyItemScope` slot is always scrolling.
- **Wire format:** encoded as `;`-separated attributes on the existing `dp-slot:` testTag — `dp-slot:content;scope=column;scroll=1`. A bare `dp-slot:<name>` still parses as `UNKNOWN`/not-scrolling, so older tags and clients that predate these fields round-trip unchanged.
- `PreviewSlots.extractSlots` parses the attributes into new `scope: SlotScope` + `scrolling: Boolean` fields on `PreviewSlot`; `/render/<id>.slots` carries them additively.

**Backward compatible:** the published `PreviewSlot(name, modifier, content)` signature is preserved; existing catalog card slots keep rendering identically and simply start auto-recording their scope (Column/Row). Not a UI change — `testTag` has no rendered effect — so this is a data-plumbing PR.

Scope-*filling* the scaffold templates (the visual Phase-1 work) is a fast-follow that will carry rendered before/after evidence.

## Test plan

- [x] `PreviewSlotsTest` (reader): parses `scope`/`scroll` attributes; bare tags → `UNKNOWN`/false; unknown attribute keys and unknown scope tokens ignored; every wire token maps (`SlotScope.fromWire`).
- [x] `PreviewSlotTest` (runtime): `slotTag` emits the attribute forms; **every scope round-trips writer → `extractSlots`** (guards writer/reader drift, extending the existing prefix-agreement test).
- [ ] CI compiles the `RowScope`/`ColumnScope`/`BoxScope`/`LazyItemScope` overloads + the existing card call sites (confirms overload resolution) and runs the unit tests above.

> Note: I could not build/test locally in this environment — the required Gradle 9.x distribution download is proxy-blocked (HTTP 403), the system Gradle is 8.14.3 (below the repo's 9.4.1 floor), and there's no dependency cache. The logic is covered by the unit tests above for CI to run.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MwY6vhTFyKRhvVbyBsjtmW)_