### PR TITLE
feat(serve): expose a Storybook-compatible index.json + iframe.html surface

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -53,6 +53,8 @@ import kotlinx.serialization.json.Json
  * Endpoints (all token-gated except `/healthz`, `/version`, and the `/wasm/` static assets):
  * - `GET /` landing page, `GET /p/{id}` viewer page,
  * - `GET /render/{id}.png` PNG bytes, `GET /api/previews` JSON, `GET /healthz` liveness,
+ * - `GET /index.json` Storybook stories index, `GET /iframe.html?id=` isolated story render
+ *   ([StorybookCompat]) — the drop-in surface downstream Storybook visual tools consume,
  * - `GET /version` host identity (CLI version, serve schema, public flag),
  * - `GET /bundle.zip` portable bundle, `WS /ws/{id}` streamed-frame lane.
  *
@@ -269,6 +271,18 @@ class ServeHttpServer(
         get("/api/previews") { handleApiPreviews(sessionInPath = false) }
         get("/{system}/api/previews") { handleApiPreviews(sessionInPath = true) }
 
+        // Storybook-compatibility surface (see [StorybookCompat]). `/index.json` is the stories
+        // index every downstream visual tool (Chromatic, Percy, storycap/reg-suit, BackstopJS, the
+        // test-runner) crawls to enumerate stories; `iframe.html?id=<storyId>` renders one story in
+        // isolation for a screenshot tool. Both come in the query-`?session=` and
+        // path-`/{system}/…`
+        // forms like the rest; the constant first segment outscores `/{system}`.
+        get("/index.json") { handleStorybookIndex(sessionInPath = false) }
+        get("/{system}/index.json") { handleStorybookIndex(sessionInPath = true) }
+
+        get("/iframe.html") { handleStorybookIframe(sessionInPath = false) }
+        get("/{system}/iframe.html") { handleStorybookIframe(sessionInPath = true) }
+
         get("/bundle.zip") { handleBundleZip(sessionInPath = false) }
         get("/{system}/bundle.zip") { handleBundleZip(sessionInPath = true) }
 
@@ -445,6 +459,99 @@ class ServeHttpServer(
         JSON.encodeToString(PreviewsResponse.serializer(), dto),
         ContentType.Application.Json,
       )
+    }
+  }
+
+  /**
+   * `GET /index.json` (query) and `GET /{system}/index.json` (path): the session's previews as a
+   * Storybook stories index ([StorybookCompat.Index]). This is the manifest a downstream visual
+   * tool crawls to enumerate stories and their stable ids.
+   */
+  private suspend fun RoutingContext.handleStorybookIndex(sessionInPath: Boolean) {
+    if (rejectBadToken()) return
+    withLeasedSession(selectedSessionId(sessionInPath)) { renderHost ->
+      call.respondText(
+        JSON.encodeToString(
+          StorybookCompat.Index.serializer(),
+          StorybookCompat.index(renderHost.previews),
+        ),
+        ContentType.Application.Json,
+      )
+    }
+  }
+
+  /**
+   * `GET /iframe.html?id=<storyId>` (query) and `GET /{system}/iframe.html?id=<storyId>` (path):
+   * render one story in isolation. Answers with a chrome-free HTML page embedding the freshly-
+   * rendered PNG as a `data:` URI ([StorybookCompat.iframePage]) — what a screenshot tool captures.
+   * Honours the same override query params as `/render` (e.g. `&uiMode=dark`), and load-sheds
+   * through the shared render semaphore exactly like [handleRender].
+   */
+  private suspend fun RoutingContext.handleStorybookIframe(sessionInPath: Boolean) {
+    if (rejectBadToken()) return
+    withLeasedSession(selectedSessionId(sessionInPath)) { renderHost ->
+      val storyId = call.request.queryParameters["id"]
+      if (storyId.isNullOrBlank()) {
+        call.respondText("missing story id", status = HttpStatusCode.BadRequest)
+        return@withLeasedSession
+      }
+      val previewId = StorybookCompat.resolvePreviewId(storyId, renderHost.previews)
+      if (previewId == null) {
+        call.respondText("no such story", status = HttpStatusCode.NotFound)
+        return@withLeasedSession
+      }
+      val overrideParams =
+        call.request.queryParameters
+          .entries()
+          .mapNotNull { (key, values) ->
+            val value = values.firstOrNull() ?: return@mapNotNull null
+            if (
+              key in ServeOverrides.SUPPORTED_KEYS || key.startsWith(ServeOverrides.KNOB_PREFIX)
+            ) {
+              key to value
+            } else {
+              null
+            }
+          }
+          .toMap()
+      val knobKinds =
+        ServeOverrides.declaredKnobKinds(renderHost.previews.firstOrNull { it.id == previewId })
+      when (val parsed = ServeOverrides.parse(overrideParams, knobKinds)) {
+        is OverrideParse.Invalid ->
+          call.respondText(parsed.message, status = HttpStatusCode.BadRequest)
+        is OverrideParse.Ok -> {
+          val outcome =
+            withContext(Dispatchers.IO) {
+              if (!renderSemaphore.tryAcquire(RENDER_QUEUE_WAIT_SECONDS, TimeUnit.SECONDS)) {
+                null
+              } else {
+                try {
+                  renderHost.render(previewId, parsed.overrides)
+                } finally {
+                  renderSemaphore.release()
+                }
+              }
+            }
+          when (outcome) {
+            null -> {
+              call.response.headers.append(HttpHeaders.RetryAfter, "2")
+              call.respondText(
+                "render queue saturated; retry shortly",
+                status = HttpStatusCode.ServiceUnavailable,
+              )
+            }
+            is RenderOutcome.Ok ->
+              call.respondText(
+                StorybookCompat.iframePage(storyId, outcome.png),
+                ContentType.Text.Html,
+              )
+            RenderOutcome.NotFound ->
+              call.respondText("no such story", status = HttpStatusCode.NotFound)
+            is RenderOutcome.Failed ->
+              call.respondText(outcome.reason, status = HttpStatusCode.InternalServerError)
+          }
+        }
+      }
     }
   }
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/StorybookCompat.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/StorybookCompat.kt
@@ -120,17 +120,20 @@ object StorybookCompat {
     )
 
   /**
-   * Resolve a story id from `iframe.html?id=` to a native preview id. A raw native preview id is
-   * accepted verbatim first (deep-link escape hatch); otherwise the id is matched against the
-   * minted [stories]. Returns null when nothing matches.
+   * Resolve a story id from `iframe.html?id=` to a native preview id. The minted [stories] ids are
+   * the `/index.json` contract, so they're matched **first** — an advertised entry always
+   * round-trips even if some other preview's native id happens to equal this minted id. Only when
+   * the id matches no advertised story does the raw-native-id escape hatch apply (deep-linking a
+   * preview by its `<fqn>`), so the hatch can never shadow an indexed story. Returns null when
+   * nothing matches.
    */
   fun resolvePreviewId(storyId: String, previews: List<ServePreview>): String? {
-    previews
-      .firstOrNull { it.id == storyId }
+    stories(previews)
+      .firstOrNull { it.storyId == storyId }
       ?.let {
-        return it.id
+        return it.previewId
       }
-    return stories(previews).firstOrNull { it.storyId == storyId }?.previewId
+    return previews.firstOrNull { it.id == storyId }?.id
   }
 
   /**

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/StorybookCompat.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/StorybookCompat.kt
@@ -1,0 +1,184 @@
+package ee.schimke.composeai.cli.serve
+
+import java.util.Base64
+import kotlinx.serialization.Serializable
+
+/**
+ * Storybook-compatibility shim for the `compose-preview serve` surface. Emits the two tiny
+ * contracts the whole downstream Storybook ecosystem (Chromatic, Percy, storycap/reg-suit,
+ * BackstopJS, the `@storybook/test-runner`, the various Storybook MCP servers) is built on:
+ *
+ * 1. **`/index.json`** — the stories index: a `{ "v": 5, "entries": { <storyId>: … } }` manifest a
+ *    tool crawls to enumerate every renderable unit and its stable id. This is Storybook's
+ *    build-time-generated, documented, versioned contract (renamed from `stories.json` in SB7,
+ *    parameter-free since SB8). See [Index] / [Entry].
+ * 2. **`iframe.html?id=<storyId>`** — render one story in isolation, no chrome. A screenshot tool
+ *    navigates a browser here and captures the viewport. We answer with a minimal HTML page that
+ *    embeds the freshly-rendered preview PNG as a `data:` URI ([iframePage]) — self-contained, so
+ *    no token has to be threaded onto a sub-resource `<img src>`.
+ *
+ * The **story id** is the join key between the two, exactly as in Storybook. We mint it from the
+ * preview the way CSF's `toId(title, name)` does — `sanitize(title)--sanitize(name)`, kebab-cased —
+ * so ids look native to a Storybook consumer. Resolution back to our native preview id ([Story.id])
+ * goes through [resolvePreviewId], which also accepts a raw native id verbatim so our own tools /
+ * humans can deep-link `iframe.html?id=<fqn>` without knowing the minted form.
+ *
+ * Pure and IO-free (no ktor types) so the id/index/page logic is unit-testable in isolation,
+ * mirror- ing [ServeUrls]; the HTTP glue lives in [ServeHttpServer].
+ */
+object StorybookCompat {
+
+  /**
+   * Storybook `index.json` schema version. Storybook has emitted `"v": 5` since SB8 (SB7 used 4,
+   * the legacy `stories.json` used 3 with a different, parameter-carrying shape). Consumers key off
+   * the `entries` map regardless; the version is advisory.
+   */
+  const val INDEX_VERSION: Int = 5
+
+  /**
+   * Synthetic `importPath` prefix. We have no CSF source file, so we encode the native preview id
+   * here — informative for a human, and ignored by the visual/remote-URL tools that only navigate
+   * `iframe.html?id=`.
+   */
+  private const val IMPORT_PATH_PREFIX = "virtual:compose-preview/"
+
+  /** Tag stamped on every entry so a consumer can tell these stories are Compose previews. */
+  private val TAGS = listOf("compose-preview")
+
+  /** The Storybook stories index served at `/index.json`. */
+  @Serializable data class Index(val v: Int = INDEX_VERSION, val entries: Map<String, Entry>)
+
+  /**
+   * One entry in the [Index]. Fields mirror a Storybook `'story'` index entry: [id] is the stable
+   * story id (also the map key), [title] the sidebar grouping path, [name] the story name, and
+   * [importPath] the (here synthetic) source module. [type] is always `"story"` — we emit no docs
+   * entries.
+   */
+  @Serializable
+  data class Entry(
+    val id: String,
+    val title: String,
+    val name: String,
+    val importPath: String,
+    val type: String = "story",
+    val tags: List<String> = TAGS,
+  )
+
+  /**
+   * A resolved story: its minted Storybook [storyId] and the native compose-preview [previewId].
+   */
+  data class Story(val storyId: String, val previewId: String, val title: String, val name: String)
+
+  /**
+   * CSF `sanitize`: lowercase, collapse every run of non-`[a-z0-9]` characters to a single `-`, and
+   * trim leading/trailing `-`. Our preview ids are ASCII Kotlin FQNs, so this reproduces
+   * Storybook's id shape faithfully (Storybook's own regex replaces punctuation/space with `-` and
+   * collapses).
+   */
+  fun sanitize(raw: String): String = raw.lowercase().replace(Regex("[^a-z0-9]+"), "-").trim('-')
+
+  /**
+   * CSF `toId(kind, name)` → `sanitize(kind)--sanitize(name)`. When either side sanitizes to blank
+   * (e.g. a symbol-only title) it's dropped rather than emitting a dangling `--`, so the result is
+   * always a usable slug.
+   */
+  fun toId(title: String, name: String): String =
+    listOf(sanitize(title), sanitize(name)).filter { it.isNotBlank() }.joinToString("--")
+
+  /**
+   * Minted stories for [previews], in list order, with deterministic collision suffixes (`-2`,
+   * `-3`, …) so the story id → preview id mapping stays 1:1 even when two previews derive the same
+   * slug. Both [index] and [resolvePreviewId] go through this, so `/index.json` and
+   * `iframe.html?id=` can never disagree.
+   */
+  fun stories(previews: List<ServePreview>): List<Story> {
+    val used = HashSet<String>()
+    return previews.map { preview ->
+      val title = deriveTitle(preview.id)
+      val name = deriveName(preview)
+      val base = toId(title, name).ifBlank { sanitize(preview.id).ifBlank { "preview" } }
+      var candidate = base
+      var n = 2
+      while (!used.add(candidate)) candidate = "$base-${n++}"
+      Story(storyId = candidate, previewId = preview.id, title = title, name = name)
+    }
+  }
+
+  /** Build the `/index.json` payload from a session's preview list. */
+  fun index(previews: List<ServePreview>): Index =
+    Index(
+      entries =
+        stories(previews).associate { s ->
+          s.storyId to
+            Entry(
+              id = s.storyId,
+              title = s.title,
+              name = s.name,
+              importPath = IMPORT_PATH_PREFIX + s.previewId,
+            )
+        }
+    )
+
+  /**
+   * Resolve a story id from `iframe.html?id=` to a native preview id. A raw native preview id is
+   * accepted verbatim first (deep-link escape hatch); otherwise the id is matched against the
+   * minted [stories]. Returns null when nothing matches.
+   */
+  fun resolvePreviewId(storyId: String, previews: List<ServePreview>): String? {
+    previews
+      .firstOrNull { it.id == storyId }
+      ?.let {
+        return it.id
+      }
+    return stories(previews).firstOrNull { it.storyId == storyId }?.previewId
+  }
+
+  /**
+   * The isolation page for `iframe.html?id=<storyId>`: a chrome-free HTML document that shows the
+   * rendered [pngBytes] at their intrinsic pixel size on a white ground, so a screenshot tool
+   * captures exactly the preview. The PNG is inlined as a `data:` URI — one request, no token on a
+   * sub-resource. [storyId] is HTML-escaped into the title/alt for context.
+   */
+  fun iframePage(storyId: String, pngBytes: ByteArray): String {
+    val (w, h) = WebEscaping.pngDimensions(pngBytes)
+    val b64 = Base64.getEncoder().encodeToString(pngBytes)
+    val esc = WebEscaping.htmlEscape(storyId)
+    val sizeAttrs = if (w > 0 && h > 0) " width=\"$w\" height=\"$h\"" else ""
+    return buildString {
+      append("<!doctype html>\n")
+      append("<html><head><meta charset=\"utf-8\">\n")
+      append("<title>").append(esc).append(" · compose-preview</title>\n")
+      append("<style>html,body{margin:0;padding:0;background:#fff}img{display:block}</style>\n")
+      append("</head><body>\n")
+      append("<img alt=\"").append(esc).append("\"").append(sizeAttrs)
+      append(" src=\"data:image/png;base64,").append(b64).append("\">\n")
+      append("</body></html>\n")
+    }
+  }
+
+  /**
+   * Sidebar grouping ([Entry.title]) for a native preview id: the enclosing class/file simple name
+   * for an FQN (`com.example.PreviewsKt.RedBoxPreview…` → `Previews`, trailing `Kt` dropped), the
+   * component slug for a catalog id (`button__dark` → `button`), else the id itself.
+   */
+  private fun deriveTitle(id: String): String {
+    val beforeAxis = id.substringBefore("__")
+    if (beforeAxis.contains('.')) {
+      val container = beforeAxis.substringBeforeLast('.')
+      val simple = container.substringAfterLast('.')
+      return simple.removeSuffix("Kt").ifBlank { simple }.ifBlank { beforeAxis }
+    }
+    return beforeAxis
+  }
+
+  /**
+   * Story [Entry.name] for a preview: its human label when it has one (the viewer already shows
+   * it), else the trailing segment of the native id.
+   */
+  private fun deriveName(preview: ServePreview): String {
+    val label = preview.label.trim()
+    if (label.isNotBlank()) return label
+    val beforeAxis = preview.id.substringBefore("__")
+    return if (beforeAxis.contains('.')) beforeAxis.substringAfterLast('.') else beforeAxis
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
@@ -197,4 +197,45 @@ class ServeHttpRoutingTest {
     assertEquals(404, get("/no-such-system/").first)
     assertEquals(404, get("/no-such-system/p/$previewId").first)
   }
+
+  @Test
+  fun `index_json serves a storybook stories index`() {
+    val (code, body) = get("/compose-m3/index.json")
+    assertEquals(200, code)
+    assertTrue(body.contains("\"v\":${StorybookCompat.INDEX_VERSION}"), "index version: $body")
+    assertTrue(body.contains("\"entries\":"), "entries map: $body")
+    assertTrue(body.contains("\"type\":\"story\""), "story-typed entry: $body")
+    // The synthetic importPath encodes the native preview id, so a reader can recover it.
+    assertTrue(
+      body.contains("virtual:compose-preview/$previewId"),
+      "entry importPath carries the native id: $body",
+    )
+    // The legacy query-session lane serves the same index.
+    val (queryCode, queryBody) = get("/index.json?session=compose-m3")
+    assertEquals(200, queryCode)
+    assertTrue(queryBody.contains("\"entries\":"), "query-lane index: $queryBody")
+  }
+
+  @Test
+  fun `iframe_html renders one story in isolation as an html page embedding the png`() {
+    // The native preview id is accepted verbatim by iframe.html (the deep-link escape hatch), so
+    // this doesn't depend on how the story id is minted from the label.
+    val req =
+      Request.Builder()
+        .url("http://127.0.0.1:${server.port}/compose-m3/iframe.html?id=$previewId")
+        .build()
+    client.newCall(req).execute().use { r ->
+      assertEquals(200, r.code)
+      assertEquals("text/html", r.body?.contentType()?.let { "${it.type}/${it.subtype}" })
+      val body = r.body?.string() ?: ""
+      assertTrue(body.startsWith("<!doctype html>"), "is an html document: $body")
+      assertTrue(body.contains("src=\"data:image/png;base64,"), "embeds the render png: $body")
+    }
+  }
+
+  @Test
+  fun `iframe_html 400s a missing id and 404s an unknown one`() {
+    assertEquals(400, get("/compose-m3/iframe.html").first)
+    assertEquals(404, get("/compose-m3/iframe.html?id=no.such.Story").first)
+  }
 }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/StorybookCompatTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/StorybookCompatTest.kt
@@ -1,0 +1,102 @@
+package ee.schimke.composeai.cli.serve
+
+import java.awt.image.BufferedImage
+import java.io.ByteArrayOutputStream
+import javax.imageio.ImageIO
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/** Unit coverage for the pure Storybook-compat id / index / iframe logic ([StorybookCompat]). */
+class StorybookCompatTest {
+
+  private fun preview(id: String, label: String) = ServePreview(id = id, label = label)
+
+  private fun pngBytes(w: Int, h: Int): ByteArray =
+    ByteArrayOutputStream()
+      .also { ImageIO.write(BufferedImage(w, h, BufferedImage.TYPE_INT_RGB), "png", it) }
+      .toByteArray()
+
+  @Test
+  fun `sanitize follows the CSF kebab convention`() {
+    assertEquals("red-box", StorybookCompat.sanitize("Red Box"))
+    assertEquals("previews", StorybookCompat.sanitize("  Previews  "))
+    assertEquals("a-b-c", StorybookCompat.sanitize("a.b/c"))
+    assertEquals("", StorybookCompat.sanitize("---"))
+  }
+
+  @Test
+  fun `toId joins title and name with a double dash`() {
+    assertEquals("previews--red-box", StorybookCompat.toId("Previews", "Red Box"))
+    // A blank side is dropped rather than leaving a dangling separator.
+    assertEquals("greeting", StorybookCompat.toId("", "Greeting"))
+    assertEquals("previews", StorybookCompat.toId("Previews", "!!!"))
+  }
+
+  @Test
+  fun `story ids derive class-grouped titles from an FQN`() {
+    val stories =
+      StorybookCompat.stories(
+        listOf(
+          preview("com.example.PreviewsKt.RedBoxPreview_Red Box", "Red Box"),
+          preview("com.example.MainKt.GreetingPreview", "Greeting"),
+        )
+      )
+    assertEquals(listOf("previews--red-box", "main--greeting"), stories.map { it.storyId })
+    assertEquals("Previews", stories[0].title)
+    assertEquals("Red Box", stories[0].name)
+    // Round-trips back to the native preview id.
+    assertEquals("com.example.PreviewsKt.RedBoxPreview_Red Box", stories[0].previewId)
+  }
+
+  @Test
+  fun `catalog axis ids group by the component slug`() {
+    val stories =
+      StorybookCompat.stories(
+        listOf(preview("button__dark", "Button"), preview("button__light", "Button"))
+      )
+    assertEquals("button", stories[0].title)
+    // Two previews minting the same slug get a deterministic collision suffix, staying 1:1.
+    assertNotEquals(stories[0].storyId, stories[1].storyId)
+    assertEquals("button--button", stories[0].storyId)
+    assertEquals("button--button-2", stories[1].storyId)
+  }
+
+  @Test
+  fun `index carries the version and one entry per preview`() {
+    val index =
+      StorybookCompat.index(listOf(preview("com.example.MainKt.GreetingPreview", "Greeting")))
+    assertEquals(StorybookCompat.INDEX_VERSION, index.v)
+    val entry = index.entries.getValue("main--greeting")
+    assertEquals("main--greeting", entry.id)
+    assertEquals("story", entry.type)
+    assertEquals("virtual:compose-preview/com.example.MainKt.GreetingPreview", entry.importPath)
+    assertTrue(entry.tags.contains("compose-preview"))
+  }
+
+  @Test
+  fun `resolvePreviewId accepts both the minted story id and a raw native id`() {
+    val previews = listOf(preview("com.example.MainKt.GreetingPreview", "Greeting"))
+    assertEquals(
+      "com.example.MainKt.GreetingPreview",
+      StorybookCompat.resolvePreviewId("main--greeting", previews),
+    )
+    // Native id escape hatch.
+    assertEquals(
+      "com.example.MainKt.GreetingPreview",
+      StorybookCompat.resolvePreviewId("com.example.MainKt.GreetingPreview", previews),
+    )
+    assertNull(StorybookCompat.resolvePreviewId("no--such", previews))
+  }
+
+  @Test
+  fun `iframe page embeds the png as a data uri sized to its pixels`() {
+    val page = StorybookCompat.iframePage("main--greeting", pngBytes(24, 8))
+    assertTrue(page.startsWith("<!doctype html>"), "is an html document")
+    assertTrue(page.contains("src=\"data:image/png;base64,"), "inlines the png: $page")
+    assertTrue(page.contains("width=\"24\" height=\"8\""), "sizes to the png dimensions: $page")
+    assertTrue(page.contains("main--greeting"), "labels with the story id")
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/StorybookCompatTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/StorybookCompatTest.kt
@@ -92,6 +92,32 @@ class StorybookCompatTest {
   }
 
   @Test
+  fun `an advertised story id wins over a colliding native preview id`() {
+    // Preview B's native id is literally "greeting"; preview A (labelled "Greeting" in file
+    // Main.kt)
+    // mints the story id "main--greeting". Now craft the collision: give B a native id equal to A's
+    // minted id. `/index.json` advertises "main--greeting" for A, so it must round-trip to A even
+    // though a preview whose raw id is "main--greeting" also exists.
+    val a = preview("com.example.MainKt.GreetingPreview", "Greeting")
+    val b = preview("main--greeting", "Other")
+    val previews = listOf(a, b)
+    // Sanity: A really does mint that id.
+    assertEquals(
+      "main--greeting",
+      StorybookCompat.index(previews).entries.getValue("main--greeting").id,
+    )
+    // Advertised id resolves to A (round-trips), not to the raw-id preview B.
+    assertEquals(
+      "com.example.MainKt.GreetingPreview",
+      StorybookCompat.resolvePreviewId("main--greeting", previews),
+    )
+    // B is still reachable by its own advertised story id.
+    val bStoryId =
+      StorybookCompat.stories(previews).first { it.previewId == "main--greeting" }.storyId
+    assertEquals("main--greeting", StorybookCompat.resolvePreviewId(bStoryId, previews))
+  }
+
+  @Test
   fun `iframe page embeds the png as a data uri sized to its pixels`() {
     val page = StorybookCompat.iframePage("main--greeting", pngBytes(24, 8))
     assertTrue(page.startsWith("<!doctype html>"), "is an html document")

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -257,3 +257,24 @@ the design-artifacts gallery can confirm which build is live without a token:
 { "schema": "compose-preview-serve/version/v1", "version": "0.16.5",
   "serveSchema": "compose-preview-serve/v1", "public": true }
 ```
+
+### Storybook-compatible surface
+
+The serve host also speaks the two tiny contracts the downstream Storybook ecosystem is built on, so
+PNG-diff visual tools (BackstopJS, storycap/reg-suit, jest-image-snapshot, the `@storybook/test-runner`
+in remote-URL mode) can crawl a compose-preview `serve` with **no compose-specific code**:
+
+- `GET /index.json` — the [Storybook stories index](https://storybook.js.org/docs/api/main-config/main-config-indexers):
+  `{ "v": 5, "entries": { "<storyId>": { "id", "title", "name", "importPath", "type": "story", "tags" } } }`.
+  Each `@Preview` is one `'story'` entry; the `storyId` is minted CSF-style (`sanitize(title)--sanitize(name)`)
+  and `importPath` carries the native preview id (`virtual:compose-preview/<fqn>`).
+- `GET /iframe.html?id=<storyId>` — renders that one story in isolation as a chrome-free HTML page
+  embedding the freshly-rendered PNG (a `data:` URI on a white ground), which is exactly what a
+  screenshot tool captures. Accepts the same override query params as `/render` (e.g. `&uiMode=dark`),
+  and also accepts a raw native preview id as `id=` for hand-authored deep links.
+
+Both come in the `?session=` and path (`/{system}/index.json`, `/{system}/iframe.html`) forms like the
+rest, and follow the same token gate: open in `--public` mode, otherwise `?token=` is required (pass it
+through your visual tool's URL, or run the server `--public` on a trusted network). DOM-capture tools
+(Percy, Chromatic, Applitools) that re-render captured DOM in cloud browsers are **not** a fit — a
+compose preview is a raster image, not a DOM tree; target the pixel-diff tools instead.


### PR DESCRIPTION
## Summary

Teaches `compose-preview serve` to speak the two tiny contracts the entire downstream **Storybook** visual-tooling ecosystem is built on, so pixel-diff tools can crawl a served module with **no compose-specific code**:

- **`GET /index.json`** — the [Storybook stories index](https://storybook.js.org/docs/api/main-config/main-config-indexers): `{ "v": 5, "entries": { "<storyId>": { id, title, name, importPath, type: "story", tags } } }`. One `'story'` entry per `@Preview`; the `storyId` is minted CSF-style (`sanitize(title)--sanitize(name)`, matching CSF's `toId`), and `importPath` carries the native preview id (`virtual:compose-preview/<fqn>`).
- **`GET /iframe.html?id=<storyId>`** — renders that one story in isolation as a chrome-free HTML page embedding the freshly-rendered PNG as a `data:` URI (what a screenshot tool captures). Honours the same override query params as `/render` (e.g. `&uiMode=dark`) and also accepts a raw native preview id for hand-authored deep links.

Both come in the `?session=` and `/{system}/…` path forms like the rest of the serve surface, and follow the existing token gate (open in `--public`, else `?token=` required).

### Why

This is item **#2** of a "pretend to be Storybook where it pays off" plan. `index.json` + `iframe.html?id=` are the exact join points BackstopJS, storycap/reg-suit, jest-image-snapshot, and the `@storybook/test-runner` (remote-URL mode) already know how to consume. Serving them means those tools do visual regression against Compose `@Preview`s for free. DOM-capture tools (Percy/Chromatic/Applitools) that re-render captured DOM in cloud browsers are deliberately **out of scope** — a Compose preview is a raster image, not a DOM tree.

## Design notes

- Id/index/page logic lives in a pure, IO-free `StorybookCompat` helper (mirrors `ServeUrls`), so the id-minting and index shape are unit-testable without standing up a server. The HTTP glue in `ServeHttpServer` reuses the existing render semaphore + session-lease path — no new per-request state.
- The story id ↔ native preview id mapping is 1:1 and deterministic (collision-suffixed), and `/index.json` and `iframe.html?id=` are computed from the same generator so they can never disagree.

## Test plan

- [x] `:cli:test --tests StorybookCompatTest` — `sanitize`/`toId` follow the CSF kebab convention, class-grouped titles from FQNs, catalog-axis grouping + collision suffixes, index shape/version, `resolvePreviewId` (minted id **and** native-id escape hatch), iframe page embeds the PNG sized to its pixels.
- [x] `:cli:test --tests ServeHttpRoutingTest` — new cases: `/index.json` serves the stories index over a real embedded server (path + `?session=` forms); `iframe.html?id=` returns `text/html` embedding the render PNG; missing id → 400, unknown id → 404.
- [x] `:cli:ktfmtFormat{Main,Test}` clean.

## Visual evidence

Non-visual change (HTTP/JSON contract plumbing). The `iframe.html` body is a raster **passthrough** of the existing render pipeline — it embeds the very PNG `GET /render/{id}.png` already produces, on a plain white ground with no chrome — so it introduces no new rendered surface of its own; the underlying `@Preview` output is already covered by the preview harness. The machine-readable `/index.json` is text.

## Follow-up

Item **#1** (aligning the MCP server's tool names/semantics to Storybook's official MCP shape) is the planned next PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_0158um2p1cx3oK1FagChzAmD)_