### PR TITLE
feat(serve): apply author-declared knob overrides in the Wasm tier

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -831,9 +831,9 @@ object ServeWeb {
         !staticSnapshot -> ""
         wasmSrc != null ->
           "<div class=\"cp-note\">Pre-rendered snapshot — pick “Wasm” to interact: " +
-            "Theme, Font scale, Locale &amp; background apply in the browser. Device/Orientation " +
-            "need the live server. <a href=\"$LOCAL_SERVER_DOCS\">Enable a local preview server.</a>" +
-            "</div>"
+            "Theme, Font scale, Locale, background &amp; declared knob values apply in the browser. " +
+            "Device/Orientation need the live server. " +
+            "<a href=\"$LOCAL_SERVER_DOCS\">Enable a local preview server.</a></div>"
         else ->
           "<div class=\"cp-note\">Pre-rendered snapshot — overrides (device, locale, font scale, " +
             "orientation) need the live server, not a published catalog. " +
@@ -997,7 +997,7 @@ object ServeWeb {
           </label>
           $overlaysHtml
           $featureControlsHtml
-          ${overrideKnobsHtml(preview, canApplyOverrides || canRenderOverrides)}
+          ${overrideKnobsHtml(preview, canApplyOverrides || canRenderOverrides, wasmSrc != null)}
           ${downloadLinksHtml(hasSvgExport)}
           <div class="cp-status" id="cp-status"></div>
         </div>
@@ -1424,6 +1424,18 @@ object ServeWeb {
         if (fontScaleTouched && fs) parts.push("fontScale=" + encodeURIComponent(fs.value));
         if (wasmBg && wasmBg.checked) parts.push("background=off");
         parts.push("bgPhase=" + encodeURIComponent(wasmBgPhase()));
+        // Author-declared knobs also apply in the browser: the wasm catalog seeds its
+        // `catalogOverride*` from these `knob.<key>` params. Mirror query() — omit a knob still at
+        // its `data-knob-initial` so an unedited knob reverts to the author default in the app.
+        document.querySelectorAll(".cp-knob").forEach(function (el) {
+          if (el.disabled) return;
+          var key = el.getAttribute("data-knob-key");
+          if (!key) return;
+          var val = (el.type === "checkbox") ? (el.checked ? "true" : "false") : el.value;
+          if (val === "") return;
+          if (val === (el.getAttribute("data-knob-initial") || "")) return;
+          parts.push("knob." + encodeURIComponent(key) + "=" + encodeURIComponent(val));
+        });
         return parts.join("&");
       }
       // Initial iframe URL: the baked base plus the current overrides in the `#…` fragment, so the
@@ -1661,10 +1673,40 @@ object ServeWeb {
       Array.prototype.forEach.call(overlayToggles, function (el) {
         el.addEventListener("change", onOverlayChanged);
       });
-      // Author-declared knobs re-render on edit (text/number debounce via "input", toggles "change").
-      // They route differently from the display axes: a named knob (label, a color, …) is honoured
-      // ONLY by the server daemon — the in-browser Wasm tier's `catalogOverride*` returns the author
-      // default — so a knob edit must hit /render (onKnobChanged), never the wasm auto-enable path.
+      // Author-declared **named knobs** (label, count, colour, …) re-render on edit (text/number
+      // debounce via "input", toggles "change"). Unlike the app-theme selector and detected-feature
+      // toggles below, these ARE honoured by the in-browser Wasm tier (its `catalogOverride*` seeds
+      // from the `knob.<key>` patch), so a knob edit drives whichever transport is live: the Wasm
+      // iframe when it's active (or auto-enable it on a static published catalog), the daemon stream
+      // when Live is up, or a `/render` snapshot when the session can re-render.
+      function onKnobEdited() {
+        refreshLinks();
+        if (wasmActive()) {
+          if (wasmReady && wasmFrame.contentWindow) {
+            wasmFrame.contentWindow.postMessage(wasmOverridePatch(), "*");
+          } else {
+            wasmFrame.src = wasmInitialSrc();
+          }
+          return;
+        }
+        if (live.checked && ws && ws.readyState === 1) {
+          ws.send(JSON.stringify({ type: "setOverrides", overrides: liveOverrides() }));
+        } else if (canRenderOverrides) {
+          refreshSnapshot();
+        } else if (staticSnapshot && wasmToggle) {
+          // A published catalog can't re-render on the server, but its in-browser app can apply the
+          // knob — auto-enable the Wasm tier and let its load carry the edit (wasmInitialSrc bakes
+          // the patch into the fragment), mirroring the display-axis auto-enable in onControlsChanged.
+          setMode("wasm");
+        }
+      }
+      document.querySelectorAll(".cp-knob").forEach(function (el) {
+        el.addEventListener(el.type === "checkbox" ? "change" : "input", onKnobEdited);
+      });
+      // The app-theme selector and detected-feature toggles route ONLY through the server daemon —
+      // an app-declared theme provider is a server-side wrapper, and focus/gesture overlays are
+      // daemon-rendered, neither of which the in-browser tier can produce — so they use a
+      // daemon-only handler and never the wasm path.
       function onKnobChanged() {
         refreshLinks();
         if (live.checked && ws && ws.readyState === 1) {
@@ -1673,12 +1715,6 @@ object ServeWeb {
           refreshSnapshot();
         }
       }
-      document.querySelectorAll(".cp-knob").forEach(function (el) {
-        el.addEventListener(el.type === "checkbox" ? "change" : "input", onKnobChanged);
-      });
-      // The app-theme selector routes through the daemon like a knob (never the wasm auto-enable
-      // path — an app-declared theme provider is a server-side wrapper the in-browser tier can't
-      // load), so it shares onKnobChanged rather than onControlsChanged.
       var themeSel = document.getElementById("cp-themeProvider");
       if (themeSel) themeSel.addEventListener("change", onKnobChanged);
       // Detected-feature toggles (Keyboard focus) re-render on the daemon like a knob — same routing,
@@ -1840,18 +1876,25 @@ object ServeWeb {
    * Renders the preview's author-declared editable knobs (the `compose/overrides` payload carried
    * in a bundle's `previews/<id>.overrides.json`) as a labelled control list. Indexed knobs
    * (per-item values on a repeated component) are grouped under their base key with a `#<index>`
-   * suffix. The controls are disabled when [canApplyOverrides] is false — a static bundle replays
-   * baked PNGs and can't re-render — with a one-line note explaining why; the live daemon-backed
-   * re-render loop for these knobs is a follow-up. Empty string when the preview declared no knobs
-   * (the common case).
+   * suffix. The controls are live when [canApplyOverrides] (a daemon re-renders the edit) **or**
+   * [wasmAvailable] (the in-browser catalog app seeds its `catalogOverride*` from the edit); a
+   * plain static bundle with neither leaves them disabled with a one-line note. Empty string when
+   * the preview declared no knobs (the common case).
    */
-  private fun overrideKnobsHtml(preview: ServePreview, canApplyOverrides: Boolean): String {
+  private fun overrideKnobsHtml(
+    preview: ServePreview,
+    canApplyOverrides: Boolean,
+    wasmAvailable: Boolean = false,
+  ): String {
     if (preview.overrides.isEmpty()) return ""
-    // Editable only on a daemon-backed session (canApplyOverrides) — a static bundle / the Wasm
-    // tier
-    // can't re-render with new knob values, so there the controls show *what* is editable but stay
-    // disabled. The viewer JS collects `.cp-knob` values into `knob.<key>=<kind>:<value>` params.
-    val dis = if (canApplyOverrides) "" else " disabled"
+    // Editable when the server can re-render (canApplyOverrides) OR an in-browser app can honour
+    // the
+    // edit (wasmAvailable — its `catalogOverride*` seed from the `knob.<key>` patch). A plain
+    // static
+    // bundle with neither shows *what* is editable but stays disabled. The viewer JS collects
+    // `.cp-knob` values into `knob.<key>=<value>` params.
+    val editable = canApplyOverrides || wasmAvailable
+    val dis = if (editable) "" else " disabled"
     val rows =
       preview.overrides.joinToString("\n") { d ->
         val name = if (d.index == null) d.key else "${d.key} #${d.index}"
@@ -1884,8 +1927,11 @@ object ServeWeb {
         }
       }
     val note =
-      if (canApplyOverrides) "Declared overrides — edit a value to re-render."
-      else "Declared overrides — static bundle, values are baked in."
+      when {
+        canApplyOverrides -> "Declared overrides — edit a value to re-render."
+        wasmAvailable -> "Declared overrides — edit a value to apply it in the browser (Wasm)."
+        else -> "Declared overrides — static bundle, values are baked in."
+      }
     return """
       <div class="cp-knobs">
         <div class="cp-knobs-head">$note</div>

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -1048,6 +1048,23 @@ object ServeWeb {
       var token = new URLSearchParams(location.search).get("token") || "";
       // Carry the tenant through follow-up requests so a non-default ?session= stays on its module.
       var session = new URLSearchParams(location.search).get("session") || "";
+      // Hydrate the declared knob controls from the page URL's `knob.<key>` params, so a deep link
+      // (or a copied "Direct links — overrides applied" URL) opens with those values already set.
+      // The initial render then carries them through whichever transport is live — including the
+      // Wasm iframe, whose fragment/patch is built purely from control state — instead of showing
+      // the author default until the control is manually edited. Only the author-declared knobs this
+      // feature drives are hydrated (display axes are unchanged, pre-existing behaviour).
+      (function () {
+        var q = new URLSearchParams(location.search);
+        document.querySelectorAll(".cp-knob").forEach(function (el) {
+          var key = el.getAttribute("data-knob-key");
+          if (!key) return;
+          var v = q.get("knob." + key);
+          if (v === null) return;
+          if (el.type === "checkbox") el.checked = (v === "true" || v === "1");
+          else el.value = v;
+        });
+      })();
       // The selects + text input are opt-in (empty value = "use the preview's default"). The font
       // scale slider has no empty state, so it's gated separately: we only send fontScale once the
       // user moves it (fontScaleTouched), otherwise the slider's standing 1.0 would override a

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -989,6 +989,15 @@ class ServeWebFixtureTest {
         wasmKnobs.contains("parts.push(\"knob.\" + encodeURIComponent(key)"),
       "the wasm override patch includes the author-declared knob values",
     )
+    // Deep-link parity: the knob controls hydrate from the page URL's `knob.<key>` params on load,
+    // so opening `/p/…?knob.label=Hello` (or a copied direct link) renders the override immediately
+    // in every transport — including the Wasm iframe, whose patch is built purely from control
+    // state
+    // — rather than the author default until the user edits the control.
+    assertTrue(
+      wasmKnobs.contains("q.get(\"knob.\" + key)"),
+      "the viewer hydrates declared knob controls from the URL's knob.<key> params",
+    )
 
     // Copyable direct links: every viewer offers a PNG URL row (copy + download); a session that
     // can

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -910,11 +910,13 @@ class ServeWebFixtureTest {
       catalogKnobs.contains("edit a value to re-render"),
       "the knob note invites editing rather than saying values are baked in",
     )
-    // A knob edit routes to the server /render (the only tier that honours a named override — the
-    // Wasm tier's catalogOverride* returns the author default), never the wasm auto-enable path.
+    // A knob edit has a dedicated handler (onKnobEdited) that drives whichever transport is live —
+    // here the carried daemon via /render (canRenderOverrides). The Wasm tier also honours named
+    // knobs now, so the handler picks the iframe when Wasm is active (see the wasm-only case
+    // below).
     assertTrue(
-      catalogKnobs.contains("function onKnobChanged()"),
-      "knob edits have a dedicated handler that hits /render",
+      catalogKnobs.contains("function onKnobEdited()"),
+      "knob edits have a dedicated, transport-aware handler",
     )
     // During an active Live (stream), the override map sent over the WebSocket must carry the knob
     // values too (as knob.<key> entries), not just the display fields — otherwise the daemon resets
@@ -941,6 +943,51 @@ class ServeWebFixtureTest {
     assertTrue(
       staticKnobs.contains("static bundle, values are baked in"),
       "a plain static bundle keeps the baked-in note",
+    )
+
+    // A published static catalog whose ONLY interactive lane is the in-browser Wasm app (no daemon
+    // re-render: canApplyOverrides/canRenderOverrides both false, wasmSrc present). The wasm tier
+    // now
+    // seeds its `catalogOverride*` from the `knob.<key>` patch, so the declared knob controls
+    // render
+    // ENABLED and a knob edit drives the Wasm iframe — this is the preview.coo.ee case where
+    // `?knob.label=…` did nothing in Wasm mode before.
+    val wasmKnobs =
+      ServeWeb.viewerPage(
+        knobPreview,
+        token,
+        sessionId = "compose-m3",
+        canApplyOverrides = false,
+        canRenderOverrides = false,
+        wasmSrc = "/wasm/compose-m3/?id=button-filled",
+        wasmSameOrigin = true,
+      )
+    assertTrue(
+      wasmKnobs.contains(
+        "data-knob-key=\"label\" data-knob-kind=\"string\" data-knob-initial=\"Filled\" " +
+          "value=\"Filled\">"
+      ),
+      "a wasm-backed published catalog enables the declared knob controls (no trailing disabled)",
+    )
+    assertTrue(
+      wasmKnobs.contains("apply it in the browser (Wasm)"),
+      "the knob note invites in-browser editing when only the Wasm lane is available",
+    )
+    // The `.cp-knob` edit handler drives whichever transport is live — for a wasm-only session it
+    // posts the override patch (with the knob) to the iframe, or auto-enables Wasm from the
+    // snapshot.
+    assertTrue(
+      wasmKnobs.contains("function onKnobEdited()") &&
+        wasmKnobs.contains("wasmFrame.contentWindow.postMessage(wasmOverridePatch()"),
+      "a knob edit routes to the Wasm iframe when that tier is active",
+    )
+    // wasmOverridePatch() carries the changed knob into the iframe fragment / postMessage,
+    // alongside
+    // the display axes — without this the app never sees the edit.
+    assertTrue(
+      wasmKnobs.contains("function wasmOverridePatch()") &&
+        wasmKnobs.contains("parts.push(\"knob.\" + encodeURIComponent(key)"),
+      "the wasm override patch includes the author-declared knob values",
     )
 
     // Copyable direct links: every viewer offers a PNG URL row (copy + download); a session that

--- a/samples/cmp-wasm-catalog/src/wasmJsMain/kotlin/com/example/cmpwasmcatalog/Main.kt
+++ b/samples/cmp-wasm-catalog/src/wasmJsMain/kotlin/com/example/cmpwasmcatalog/Main.kt
@@ -7,6 +7,7 @@
 
 package com.example.cmpwasmcatalog
 
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -19,6 +20,7 @@ import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.platform.Font
 import androidx.compose.ui.window.ComposeViewport
+import com.example.designcatalogm3.shared.LocalWasmCatalogKnobs
 import com.example.designcatalogm3.shared.catalogComponentIds
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
@@ -31,12 +33,13 @@ import kotlinx.coroutines.withTimeoutOrNull
 /**
  * Browser entrypoint for the in-browser CMP catalog (Workstream C / model 1).
  *
- * Reads `?id=<component>&uiMode=<light|dark>&fontScale=<f>&localeTag=<bcp47>` from the page URL and
- * mounts the matching catalog component into the `#composeApp` container. This is what the `serve`
- * viewer embeds in a sandboxed `<iframe>` at the `data-mode="live"` seam — the Wasm runs in the
- * browser sandbox, so it's safe to execute even for an unverified session (no code runs on our
- * server). The viewer's theme / font-scale / locale controls re-point these params, so they drive
- * the in-browser render live (device/orientation are server-render-only and stay disabled there).
+ * Reads `?id=<component>&uiMode=<light|dark>&fontScale=<f>&localeTag=<bcp47>` (plus any
+ * author-declared `knob.<key>=<value>` edits) from the page URL and mounts the matching catalog
+ * component into the `#composeApp` container. This is what the `serve` viewer embeds in a sandboxed
+ * `<iframe>` at the `data-mode="live"` seam — the Wasm runs in the browser sandbox, so it's safe to
+ * execute even for an unverified session (no code runs on our server). The viewer's theme /
+ * font-scale / locale controls re-point these params, so they drive the in-browser render live
+ * (device/orientation are server-render-only and stay disabled there).
  *
  * Those controls update the render **in place** rather than reloading the iframe: the page's
  * initial query is the [baseParams] floor and [applyOverrides] (called by the embedding viewer via
@@ -81,19 +84,42 @@ fun main() {
     // this frame's CSS-px coordinates, so that checkerboard continues the page's cells exactly.
     val showBackground = params["background"] !in setOf("off", "false", "none", "transparent")
     val checkerPhase = parsePhase(params["bgPhase"])
-    CatalogApp(
-      id,
-      dark,
-      fontScale,
-      rtl,
-      showBackground,
-      checkerPhase,
-      loaded.family,
-      loaded.generics,
-      ::postFirstFrame,
-    )
+    // Author-declared editable knobs ride as `knob.<key>=<value>` params (the viewer pushes the
+    // changed ones); strip the prefix and provide them to the shared catalog's `catalogOverride*`
+    // lookups. Absent ⇒ empty map ⇒ every knob renders its author default (baked-parity).
+    val knobs = knobOverrides(params)
+    CompositionLocalProvider(LocalWasmCatalogKnobs provides knobs) {
+      CatalogApp(
+        id,
+        dark,
+        fontScale,
+        rtl,
+        showBackground,
+        checkerPhase,
+        loaded.family,
+        loaded.generics,
+        ::postFirstFrame,
+      )
+    }
   }
 }
+
+/**
+ * Project the `knob.<key>=<value>` params out of the merged render params, stripped to the bare
+ * `<key>` (matching the shared runtime's `seedKey` — the base key or `key[index]`). The value stays
+ * a raw string; each typed `catalogOverride*` parses it to its own type.
+ */
+internal fun knobOverrides(params: Map<String, String>): Map<String, String> {
+  val out = mutableMapOf<String, String>()
+  for ((k, v) in params) {
+    if (k.startsWith(KNOB_PREFIX) && k.length > KNOB_PREFIX.length) {
+      out[k.substring(KNOB_PREFIX.length)] = v
+    }
+  }
+  return out
+}
+
+private const val KNOB_PREFIX = "knob."
 
 private const val FONT_LOAD_TIMEOUT_MS = 8_000L
 

--- a/samples/design-catalog-m3-shared/src/wasmJsMain/kotlin/com/example/designcatalogm3/shared/CatalogOverrides.wasm.kt
+++ b/samples/design-catalog-m3-shared/src/wasmJsMain/kotlin/com/example/designcatalogm3/shared/CatalogOverrides.wasm.kt
@@ -1,24 +1,75 @@
 package com.example.designcatalogm3.shared
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.ui.graphics.Color
 
-// The in-browser tier never runs a daemon, so there is nothing to seed a knob: every lookup is the
-// author default. Keeping the wrappers here (rather than dropping the `previewOverride*` calls)
-// lets
-// the shared body declare its knobs once in `commonMain` and still compile to a wasm klib — the
-// `:data-preview-overrides-runtime` JVM artifact has none.
+// The in-browser tier never runs a daemon, so it can't seed a knob the way the desktop `@Preview`
+// path does (`previewOverride*` ← `renderNow.overrides.namedOverrides`). Instead the embedding
+// `serve` viewer pushes the current `knob.<key>` values into the sandboxed iframe (URL fragment +
+// `postMessage`), the wasm entrypoint parses them, and provides them through
+// [LocalWasmCatalogKnobs] around the catalog composition. These `actual`s read that map so an
+// edited knob (a label, a count, a colour) is honoured live in the browser, matching what the
+// daemon lanes (PNG / SVG / Live Compose) already do. An un-seeded knob still returns its author
+// [default], so the baked sticker sheet stays pixel-unchanged.
+
+/**
+ * Current in-browser knob seeds, keyed by the runtime's `seedKey` scheme — the bare `key`, or
+ * `key[index]` for an indexed (per-item) knob. Empty by default; the wasm entrypoint
+ * ([com.example.cmpwasmcatalog] `main` / `applyOverrides`) re-provides it whenever the viewer
+ * pushes a fresh `knob.*` set.
+ */
+val LocalWasmCatalogKnobs: ProvidableCompositionLocal<Map<String, String>> = compositionLocalOf {
+  emptyMap()
+}
+
+/** Mirrors `PreviewOverrideHost.seedKey`: bare [key], or `key[index]` for an indexed knob. */
+private fun wasmSeedKey(key: String, index: Int?): String =
+  if (index == null) key else "$key[$index]"
 
 @Composable
-actual fun catalogOverrideString(key: String, default: String, index: Int?): String = default
-
-@Composable actual fun catalogOverrideInt(key: String, default: Int, index: Int?): Int = default
-
-@Composable
-actual fun catalogOverrideFloat(key: String, default: Float, index: Int?): Float = default
+private fun seededKnob(key: String, index: Int?): String? =
+  LocalWasmCatalogKnobs.current[wasmSeedKey(key, index)]
 
 @Composable
-actual fun catalogOverrideBoolean(key: String, default: Boolean, index: Int?): Boolean = default
+actual fun catalogOverrideString(key: String, default: String, index: Int?): String =
+  seededKnob(key, index) ?: default
 
 @Composable
-actual fun catalogOverrideColor(key: String, default: Color, index: Int?): Color = default
+actual fun catalogOverrideInt(key: String, default: Int, index: Int?): Int =
+  seededKnob(key, index)?.trim()?.toIntOrNull() ?: default
+
+@Composable
+actual fun catalogOverrideFloat(key: String, default: Float, index: Int?): Float =
+  seededKnob(key, index)?.trim()?.toFloatOrNull() ?: default
+
+@Composable
+actual fun catalogOverrideBoolean(key: String, default: Boolean, index: Int?): Boolean =
+  when (seededKnob(key, index)?.trim()?.lowercase()) {
+    "true",
+    "1" -> true
+    "false",
+    "0" -> false
+    else -> default
+  }
+
+@Composable
+actual fun catalogOverrideColor(key: String, default: Color, index: Int?): Color =
+  seededKnob(key, index)?.let { parseKnobColorOrNull(it) } ?: default
+
+/**
+ * Parse `#AARRGGBB` / `#RRGGBB` (with or without the `#`) to a [Color]; null on malformed input so
+ * the caller keeps its author default. Mirrors the JVM runtime's `parseColorOrNull` — reimplemented
+ * here because that lives in the JVM-only `:data-preview-overrides-runtime` artifact, which has no
+ * wasm klib.
+ */
+internal fun parseKnobColorOrNull(hex: String): Color? {
+  val raw = hex.trim().removePrefix("#")
+  val v = raw.toLongOrNull(16) ?: return null
+  return when (raw.length) {
+    8 -> Color((v and 0xFFFFFFFF).toInt())
+    6 -> Color((0xFF000000 or v).toInt())
+    else -> null
+  }
+}

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
@@ -173,7 +173,7 @@ a:hover { text-decoration: underline; }
         
         <div class="cp-stage"><span class="cp-backend" id="cp-backend"></span><img id="cp-img" alt="Button · Filled (light)"><canvas id="cp-canvas" hidden></canvas><iframe id="cp-wasm" hidden sandbox="allow-scripts allow-same-origin" title="Button · Filled (light) (Wasm)"></iframe></div>
         <div class="cp-controls" id="cp-controls">
-          <div class="cp-note">Pre-rendered snapshot — pick “Wasm” to interact: Theme, Font scale, Locale &amp; background apply in the browser. Device/Orientation need the live server. <a href="https://github.com/yschimke/compose-ai-tools/blob/main/docs/public-preview-server.md#running-one">Enable a local preview server.</a></div>
+          <div class="cp-note">Pre-rendered snapshot — pick “Wasm” to interact: Theme, Font scale, Locale, background &amp; declared knob values apply in the browser. Device/Orientation need the live server. <a href="https://github.com/yschimke/compose-ai-tools/blob/main/docs/public-preview-server.md#running-one">Enable a local preview server.</a></div>
           <div class="cp-modes" role="radiogroup" aria-label="Render mode">
             <label class="cp-live-row"><input type="radio" name="cp-mode" value="png" id="cp-mode-png" checked> PNG</label>
             <label class="cp-live-row"><input type="radio" name="cp-mode" value="svg" id="cp-mode-svg"> SVG</label>
@@ -720,6 +720,18 @@ a:hover { text-decoration: underline; }
     if (fontScaleTouched && fs) parts.push("fontScale=" + encodeURIComponent(fs.value));
     if (wasmBg && wasmBg.checked) parts.push("background=off");
     parts.push("bgPhase=" + encodeURIComponent(wasmBgPhase()));
+    // Author-declared knobs also apply in the browser: the wasm catalog seeds its
+    // `catalogOverride*` from these `knob.<key>` params. Mirror query() — omit a knob still at
+    // its `data-knob-initial` so an unedited knob reverts to the author default in the app.
+    document.querySelectorAll(".cp-knob").forEach(function (el) {
+      if (el.disabled) return;
+      var key = el.getAttribute("data-knob-key");
+      if (!key) return;
+      var val = (el.type === "checkbox") ? (el.checked ? "true" : "false") : el.value;
+      if (val === "") return;
+      if (val === (el.getAttribute("data-knob-initial") || "")) return;
+      parts.push("knob." + encodeURIComponent(key) + "=" + encodeURIComponent(val));
+    });
     return parts.join("&");
   }
   // Initial iframe URL: the baked base plus the current overrides in the `#…` fragment, so the
@@ -957,10 +969,40 @@ a:hover { text-decoration: underline; }
   Array.prototype.forEach.call(overlayToggles, function (el) {
     el.addEventListener("change", onOverlayChanged);
   });
-  // Author-declared knobs re-render on edit (text/number debounce via "input", toggles "change").
-  // They route differently from the display axes: a named knob (label, a color, …) is honoured
-  // ONLY by the server daemon — the in-browser Wasm tier's `catalogOverride*` returns the author
-  // default — so a knob edit must hit /render (onKnobChanged), never the wasm auto-enable path.
+  // Author-declared **named knobs** (label, count, colour, …) re-render on edit (text/number
+  // debounce via "input", toggles "change"). Unlike the app-theme selector and detected-feature
+  // toggles below, these ARE honoured by the in-browser Wasm tier (its `catalogOverride*` seeds
+  // from the `knob.<key>` patch), so a knob edit drives whichever transport is live: the Wasm
+  // iframe when it's active (or auto-enable it on a static published catalog), the daemon stream
+  // when Live is up, or a `/render` snapshot when the session can re-render.
+  function onKnobEdited() {
+    refreshLinks();
+    if (wasmActive()) {
+      if (wasmReady && wasmFrame.contentWindow) {
+        wasmFrame.contentWindow.postMessage(wasmOverridePatch(), "*");
+      } else {
+        wasmFrame.src = wasmInitialSrc();
+      }
+      return;
+    }
+    if (live.checked && ws && ws.readyState === 1) {
+      ws.send(JSON.stringify({ type: "setOverrides", overrides: liveOverrides() }));
+    } else if (canRenderOverrides) {
+      refreshSnapshot();
+    } else if (staticSnapshot && wasmToggle) {
+      // A published catalog can't re-render on the server, but its in-browser app can apply the
+      // knob — auto-enable the Wasm tier and let its load carry the edit (wasmInitialSrc bakes
+      // the patch into the fragment), mirroring the display-axis auto-enable in onControlsChanged.
+      setMode("wasm");
+    }
+  }
+  document.querySelectorAll(".cp-knob").forEach(function (el) {
+    el.addEventListener(el.type === "checkbox" ? "change" : "input", onKnobEdited);
+  });
+  // The app-theme selector and detected-feature toggles route ONLY through the server daemon —
+  // an app-declared theme provider is a server-side wrapper, and focus/gesture overlays are
+  // daemon-rendered, neither of which the in-browser tier can produce — so they use a
+  // daemon-only handler and never the wasm path.
   function onKnobChanged() {
     refreshLinks();
     if (live.checked && ws && ws.readyState === 1) {
@@ -969,12 +1011,6 @@ a:hover { text-decoration: underline; }
       refreshSnapshot();
     }
   }
-  document.querySelectorAll(".cp-knob").forEach(function (el) {
-    el.addEventListener(el.type === "checkbox" ? "change" : "input", onKnobChanged);
-  });
-  // The app-theme selector routes through the daemon like a knob (never the wasm auto-enable
-  // path — an app-declared theme provider is a server-side wrapper the in-browser tier can't
-  // load), so it shares onKnobChanged rather than onControlsChanged.
   var themeSel = document.getElementById("cp-themeProvider");
   if (themeSel) themeSel.addEventListener("change", onKnobChanged);
   // Detected-feature toggles (Keyboard focus) re-render on the daemon like a knob — same routing,

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
@@ -344,6 +344,23 @@ a:hover { text-decoration: underline; }
   var token = new URLSearchParams(location.search).get("token") || "";
   // Carry the tenant through follow-up requests so a non-default ?session= stays on its module.
   var session = new URLSearchParams(location.search).get("session") || "";
+  // Hydrate the declared knob controls from the page URL's `knob.<key>` params, so a deep link
+  // (or a copied "Direct links — overrides applied" URL) opens with those values already set.
+  // The initial render then carries them through whichever transport is live — including the
+  // Wasm iframe, whose fragment/patch is built purely from control state — instead of showing
+  // the author default until the control is manually edited. Only the author-declared knobs this
+  // feature drives are hydrated (display axes are unchanged, pre-existing behaviour).
+  (function () {
+    var q = new URLSearchParams(location.search);
+    document.querySelectorAll(".cp-knob").forEach(function (el) {
+      var key = el.getAttribute("data-knob-key");
+      if (!key) return;
+      var v = q.get("knob." + key);
+      if (v === null) return;
+      if (el.type === "checkbox") el.checked = (v === "true" || v === "1");
+      else el.value = v;
+    });
+  })();
   // The selects + text input are opt-in (empty value = "use the preview's default"). The font
   // scale slider has no empty state, so it's gated separately: we only send fontScale once the
   // user moves it (fontScaleTouched), otherwise the slider's standing 1.0 would override a

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-focus.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-focus.html
@@ -327,6 +327,23 @@ a:hover { text-decoration: underline; }
   var token = new URLSearchParams(location.search).get("token") || "";
   // Carry the tenant through follow-up requests so a non-default ?session= stays on its module.
   var session = new URLSearchParams(location.search).get("session") || "";
+  // Hydrate the declared knob controls from the page URL's `knob.<key>` params, so a deep link
+  // (or a copied "Direct links — overrides applied" URL) opens with those values already set.
+  // The initial render then carries them through whichever transport is live — including the
+  // Wasm iframe, whose fragment/patch is built purely from control state — instead of showing
+  // the author default until the control is manually edited. Only the author-declared knobs this
+  // feature drives are hydrated (display axes are unchanged, pre-existing behaviour).
+  (function () {
+    var q = new URLSearchParams(location.search);
+    document.querySelectorAll(".cp-knob").forEach(function (el) {
+      var key = el.getAttribute("data-knob-key");
+      if (!key) return;
+      var v = q.get("knob." + key);
+      if (v === null) return;
+      if (el.type === "checkbox") el.checked = (v === "true" || v === "1");
+      else el.value = v;
+    });
+  })();
   // The selects + text input are opt-in (empty value = "use the preview's default"). The font
   // scale slider has no empty state, so it's gated separately: we only send fontScale once the
   // user moves it (fontScaleTouched), otherwise the slider's standing 1.0 would override a

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-focus.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-focus.html
@@ -703,6 +703,18 @@ a:hover { text-decoration: underline; }
     if (fontScaleTouched && fs) parts.push("fontScale=" + encodeURIComponent(fs.value));
     if (wasmBg && wasmBg.checked) parts.push("background=off");
     parts.push("bgPhase=" + encodeURIComponent(wasmBgPhase()));
+    // Author-declared knobs also apply in the browser: the wasm catalog seeds its
+    // `catalogOverride*` from these `knob.<key>` params. Mirror query() — omit a knob still at
+    // its `data-knob-initial` so an unedited knob reverts to the author default in the app.
+    document.querySelectorAll(".cp-knob").forEach(function (el) {
+      if (el.disabled) return;
+      var key = el.getAttribute("data-knob-key");
+      if (!key) return;
+      var val = (el.type === "checkbox") ? (el.checked ? "true" : "false") : el.value;
+      if (val === "") return;
+      if (val === (el.getAttribute("data-knob-initial") || "")) return;
+      parts.push("knob." + encodeURIComponent(key) + "=" + encodeURIComponent(val));
+    });
     return parts.join("&");
   }
   // Initial iframe URL: the baked base plus the current overrides in the `#…` fragment, so the
@@ -940,10 +952,40 @@ a:hover { text-decoration: underline; }
   Array.prototype.forEach.call(overlayToggles, function (el) {
     el.addEventListener("change", onOverlayChanged);
   });
-  // Author-declared knobs re-render on edit (text/number debounce via "input", toggles "change").
-  // They route differently from the display axes: a named knob (label, a color, …) is honoured
-  // ONLY by the server daemon — the in-browser Wasm tier's `catalogOverride*` returns the author
-  // default — so a knob edit must hit /render (onKnobChanged), never the wasm auto-enable path.
+  // Author-declared **named knobs** (label, count, colour, …) re-render on edit (text/number
+  // debounce via "input", toggles "change"). Unlike the app-theme selector and detected-feature
+  // toggles below, these ARE honoured by the in-browser Wasm tier (its `catalogOverride*` seeds
+  // from the `knob.<key>` patch), so a knob edit drives whichever transport is live: the Wasm
+  // iframe when it's active (or auto-enable it on a static published catalog), the daemon stream
+  // when Live is up, or a `/render` snapshot when the session can re-render.
+  function onKnobEdited() {
+    refreshLinks();
+    if (wasmActive()) {
+      if (wasmReady && wasmFrame.contentWindow) {
+        wasmFrame.contentWindow.postMessage(wasmOverridePatch(), "*");
+      } else {
+        wasmFrame.src = wasmInitialSrc();
+      }
+      return;
+    }
+    if (live.checked && ws && ws.readyState === 1) {
+      ws.send(JSON.stringify({ type: "setOverrides", overrides: liveOverrides() }));
+    } else if (canRenderOverrides) {
+      refreshSnapshot();
+    } else if (staticSnapshot && wasmToggle) {
+      // A published catalog can't re-render on the server, but its in-browser app can apply the
+      // knob — auto-enable the Wasm tier and let its load carry the edit (wasmInitialSrc bakes
+      // the patch into the fragment), mirroring the display-axis auto-enable in onControlsChanged.
+      setMode("wasm");
+    }
+  }
+  document.querySelectorAll(".cp-knob").forEach(function (el) {
+    el.addEventListener(el.type === "checkbox" ? "change" : "input", onKnobEdited);
+  });
+  // The app-theme selector and detected-feature toggles route ONLY through the server daemon —
+  // an app-declared theme provider is a server-side wrapper, and focus/gesture overlays are
+  // daemon-rendered, neither of which the in-browser tier can produce — so they use a
+  // daemon-only handler and never the wasm path.
   function onKnobChanged() {
     refreshLinks();
     if (live.checked && ws && ws.readyState === 1) {
@@ -952,12 +994,6 @@ a:hover { text-decoration: underline; }
       refreshSnapshot();
     }
   }
-  document.querySelectorAll(".cp-knob").forEach(function (el) {
-    el.addEventListener(el.type === "checkbox" ? "change" : "input", onKnobChanged);
-  });
-  // The app-theme selector routes through the daemon like a knob (never the wasm auto-enable
-  // path — an app-declared theme provider is a server-side wrapper the in-browser tier can't
-  // load), so it shares onKnobChanged rather than onControlsChanged.
   var themeSel = document.getElementById("cp-themeProvider");
   if (themeSel) themeSel.addEventListener("change", onKnobChanged);
   // Detected-feature toggles (Keyboard focus) re-render on the daemon like a knob — same routing,

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-gestures.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-gestures.html
@@ -327,6 +327,23 @@ a:hover { text-decoration: underline; }
   var token = new URLSearchParams(location.search).get("token") || "";
   // Carry the tenant through follow-up requests so a non-default ?session= stays on its module.
   var session = new URLSearchParams(location.search).get("session") || "";
+  // Hydrate the declared knob controls from the page URL's `knob.<key>` params, so a deep link
+  // (or a copied "Direct links — overrides applied" URL) opens with those values already set.
+  // The initial render then carries them through whichever transport is live — including the
+  // Wasm iframe, whose fragment/patch is built purely from control state — instead of showing
+  // the author default until the control is manually edited. Only the author-declared knobs this
+  // feature drives are hydrated (display axes are unchanged, pre-existing behaviour).
+  (function () {
+    var q = new URLSearchParams(location.search);
+    document.querySelectorAll(".cp-knob").forEach(function (el) {
+      var key = el.getAttribute("data-knob-key");
+      if (!key) return;
+      var v = q.get("knob." + key);
+      if (v === null) return;
+      if (el.type === "checkbox") el.checked = (v === "true" || v === "1");
+      else el.value = v;
+    });
+  })();
   // The selects + text input are opt-in (empty value = "use the preview's default"). The font
   // scale slider has no empty state, so it's gated separately: we only send fontScale once the
   // user moves it (fontScaleTouched), otherwise the slider's standing 1.0 would override a

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-gestures.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-gestures.html
@@ -703,6 +703,18 @@ a:hover { text-decoration: underline; }
     if (fontScaleTouched && fs) parts.push("fontScale=" + encodeURIComponent(fs.value));
     if (wasmBg && wasmBg.checked) parts.push("background=off");
     parts.push("bgPhase=" + encodeURIComponent(wasmBgPhase()));
+    // Author-declared knobs also apply in the browser: the wasm catalog seeds its
+    // `catalogOverride*` from these `knob.<key>` params. Mirror query() — omit a knob still at
+    // its `data-knob-initial` so an unedited knob reverts to the author default in the app.
+    document.querySelectorAll(".cp-knob").forEach(function (el) {
+      if (el.disabled) return;
+      var key = el.getAttribute("data-knob-key");
+      if (!key) return;
+      var val = (el.type === "checkbox") ? (el.checked ? "true" : "false") : el.value;
+      if (val === "") return;
+      if (val === (el.getAttribute("data-knob-initial") || "")) return;
+      parts.push("knob." + encodeURIComponent(key) + "=" + encodeURIComponent(val));
+    });
     return parts.join("&");
   }
   // Initial iframe URL: the baked base plus the current overrides in the `#…` fragment, so the
@@ -940,10 +952,40 @@ a:hover { text-decoration: underline; }
   Array.prototype.forEach.call(overlayToggles, function (el) {
     el.addEventListener("change", onOverlayChanged);
   });
-  // Author-declared knobs re-render on edit (text/number debounce via "input", toggles "change").
-  // They route differently from the display axes: a named knob (label, a color, …) is honoured
-  // ONLY by the server daemon — the in-browser Wasm tier's `catalogOverride*` returns the author
-  // default — so a knob edit must hit /render (onKnobChanged), never the wasm auto-enable path.
+  // Author-declared **named knobs** (label, count, colour, …) re-render on edit (text/number
+  // debounce via "input", toggles "change"). Unlike the app-theme selector and detected-feature
+  // toggles below, these ARE honoured by the in-browser Wasm tier (its `catalogOverride*` seeds
+  // from the `knob.<key>` patch), so a knob edit drives whichever transport is live: the Wasm
+  // iframe when it's active (or auto-enable it on a static published catalog), the daemon stream
+  // when Live is up, or a `/render` snapshot when the session can re-render.
+  function onKnobEdited() {
+    refreshLinks();
+    if (wasmActive()) {
+      if (wasmReady && wasmFrame.contentWindow) {
+        wasmFrame.contentWindow.postMessage(wasmOverridePatch(), "*");
+      } else {
+        wasmFrame.src = wasmInitialSrc();
+      }
+      return;
+    }
+    if (live.checked && ws && ws.readyState === 1) {
+      ws.send(JSON.stringify({ type: "setOverrides", overrides: liveOverrides() }));
+    } else if (canRenderOverrides) {
+      refreshSnapshot();
+    } else if (staticSnapshot && wasmToggle) {
+      // A published catalog can't re-render on the server, but its in-browser app can apply the
+      // knob — auto-enable the Wasm tier and let its load carry the edit (wasmInitialSrc bakes
+      // the patch into the fragment), mirroring the display-axis auto-enable in onControlsChanged.
+      setMode("wasm");
+    }
+  }
+  document.querySelectorAll(".cp-knob").forEach(function (el) {
+    el.addEventListener(el.type === "checkbox" ? "change" : "input", onKnobEdited);
+  });
+  // The app-theme selector and detected-feature toggles route ONLY through the server daemon —
+  // an app-declared theme provider is a server-side wrapper, and focus/gesture overlays are
+  // daemon-rendered, neither of which the in-browser tier can produce — so they use a
+  // daemon-only handler and never the wasm path.
   function onKnobChanged() {
     refreshLinks();
     if (live.checked && ws && ws.readyState === 1) {
@@ -952,12 +994,6 @@ a:hover { text-decoration: underline; }
       refreshSnapshot();
     }
   }
-  document.querySelectorAll(".cp-knob").forEach(function (el) {
-    el.addEventListener(el.type === "checkbox" ? "change" : "input", onKnobChanged);
-  });
-  // The app-theme selector routes through the daemon like a knob (never the wasm auto-enable
-  // path — an app-declared theme provider is a server-side wrapper the in-browser tier can't
-  // load), so it shares onKnobChanged rather than onControlsChanged.
   var themeSel = document.getElementById("cp-themeProvider");
   if (themeSel) themeSel.addEventListener("change", onKnobChanged);
   // Detected-feature toggles (Keyboard focus) re-render on the daemon like a knob — same routing,

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
@@ -331,6 +331,23 @@ a:hover { text-decoration: underline; }
   var token = new URLSearchParams(location.search).get("token") || "";
   // Carry the tenant through follow-up requests so a non-default ?session= stays on its module.
   var session = new URLSearchParams(location.search).get("session") || "";
+  // Hydrate the declared knob controls from the page URL's `knob.<key>` params, so a deep link
+  // (or a copied "Direct links — overrides applied" URL) opens with those values already set.
+  // The initial render then carries them through whichever transport is live — including the
+  // Wasm iframe, whose fragment/patch is built purely from control state — instead of showing
+  // the author default until the control is manually edited. Only the author-declared knobs this
+  // feature drives are hydrated (display axes are unchanged, pre-existing behaviour).
+  (function () {
+    var q = new URLSearchParams(location.search);
+    document.querySelectorAll(".cp-knob").forEach(function (el) {
+      var key = el.getAttribute("data-knob-key");
+      if (!key) return;
+      var v = q.get("knob." + key);
+      if (v === null) return;
+      if (el.type === "checkbox") el.checked = (v === "true" || v === "1");
+      else el.value = v;
+    });
+  })();
   // The selects + text input are opt-in (empty value = "use the preview's default"). The font
   // scale slider has no empty state, so it's gated separately: we only send fontScale once the
   // user moves it (fontScaleTouched), otherwise the slider's standing 1.0 would override a

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
@@ -707,6 +707,18 @@ a:hover { text-decoration: underline; }
     if (fontScaleTouched && fs) parts.push("fontScale=" + encodeURIComponent(fs.value));
     if (wasmBg && wasmBg.checked) parts.push("background=off");
     parts.push("bgPhase=" + encodeURIComponent(wasmBgPhase()));
+    // Author-declared knobs also apply in the browser: the wasm catalog seeds its
+    // `catalogOverride*` from these `knob.<key>` params. Mirror query() — omit a knob still at
+    // its `data-knob-initial` so an unedited knob reverts to the author default in the app.
+    document.querySelectorAll(".cp-knob").forEach(function (el) {
+      if (el.disabled) return;
+      var key = el.getAttribute("data-knob-key");
+      if (!key) return;
+      var val = (el.type === "checkbox") ? (el.checked ? "true" : "false") : el.value;
+      if (val === "") return;
+      if (val === (el.getAttribute("data-knob-initial") || "")) return;
+      parts.push("knob." + encodeURIComponent(key) + "=" + encodeURIComponent(val));
+    });
     return parts.join("&");
   }
   // Initial iframe URL: the baked base plus the current overrides in the `#…` fragment, so the
@@ -944,10 +956,40 @@ a:hover { text-decoration: underline; }
   Array.prototype.forEach.call(overlayToggles, function (el) {
     el.addEventListener("change", onOverlayChanged);
   });
-  // Author-declared knobs re-render on edit (text/number debounce via "input", toggles "change").
-  // They route differently from the display axes: a named knob (label, a color, …) is honoured
-  // ONLY by the server daemon — the in-browser Wasm tier's `catalogOverride*` returns the author
-  // default — so a knob edit must hit /render (onKnobChanged), never the wasm auto-enable path.
+  // Author-declared **named knobs** (label, count, colour, …) re-render on edit (text/number
+  // debounce via "input", toggles "change"). Unlike the app-theme selector and detected-feature
+  // toggles below, these ARE honoured by the in-browser Wasm tier (its `catalogOverride*` seeds
+  // from the `knob.<key>` patch), so a knob edit drives whichever transport is live: the Wasm
+  // iframe when it's active (or auto-enable it on a static published catalog), the daemon stream
+  // when Live is up, or a `/render` snapshot when the session can re-render.
+  function onKnobEdited() {
+    refreshLinks();
+    if (wasmActive()) {
+      if (wasmReady && wasmFrame.contentWindow) {
+        wasmFrame.contentWindow.postMessage(wasmOverridePatch(), "*");
+      } else {
+        wasmFrame.src = wasmInitialSrc();
+      }
+      return;
+    }
+    if (live.checked && ws && ws.readyState === 1) {
+      ws.send(JSON.stringify({ type: "setOverrides", overrides: liveOverrides() }));
+    } else if (canRenderOverrides) {
+      refreshSnapshot();
+    } else if (staticSnapshot && wasmToggle) {
+      // A published catalog can't re-render on the server, but its in-browser app can apply the
+      // knob — auto-enable the Wasm tier and let its load carry the edit (wasmInitialSrc bakes
+      // the patch into the fragment), mirroring the display-axis auto-enable in onControlsChanged.
+      setMode("wasm");
+    }
+  }
+  document.querySelectorAll(".cp-knob").forEach(function (el) {
+    el.addEventListener(el.type === "checkbox" ? "change" : "input", onKnobEdited);
+  });
+  // The app-theme selector and detected-feature toggles route ONLY through the server daemon —
+  // an app-declared theme provider is a server-side wrapper, and focus/gesture overlays are
+  // daemon-rendered, neither of which the in-browser tier can produce — so they use a
+  // daemon-only handler and never the wasm path.
   function onKnobChanged() {
     refreshLinks();
     if (live.checked && ws && ws.readyState === 1) {
@@ -956,12 +998,6 @@ a:hover { text-decoration: underline; }
       refreshSnapshot();
     }
   }
-  document.querySelectorAll(".cp-knob").forEach(function (el) {
-    el.addEventListener(el.type === "checkbox" ? "change" : "input", onKnobChanged);
-  });
-  // The app-theme selector routes through the daemon like a knob (never the wasm auto-enable
-  // path — an app-declared theme provider is a server-side wrapper the in-browser tier can't
-  // load), so it shares onKnobChanged rather than onControlsChanged.
   var themeSel = document.getElementById("cp-themeProvider");
   if (themeSel) themeSel.addEventListener("change", onKnobChanged);
   // Detected-feature toggles (Keyboard focus) re-render on the daemon like a knob — same routing,

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-themes.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-themes.html
@@ -331,6 +331,23 @@ a:hover { text-decoration: underline; }
   var token = new URLSearchParams(location.search).get("token") || "";
   // Carry the tenant through follow-up requests so a non-default ?session= stays on its module.
   var session = new URLSearchParams(location.search).get("session") || "";
+  // Hydrate the declared knob controls from the page URL's `knob.<key>` params, so a deep link
+  // (or a copied "Direct links — overrides applied" URL) opens with those values already set.
+  // The initial render then carries them through whichever transport is live — including the
+  // Wasm iframe, whose fragment/patch is built purely from control state — instead of showing
+  // the author default until the control is manually edited. Only the author-declared knobs this
+  // feature drives are hydrated (display axes are unchanged, pre-existing behaviour).
+  (function () {
+    var q = new URLSearchParams(location.search);
+    document.querySelectorAll(".cp-knob").forEach(function (el) {
+      var key = el.getAttribute("data-knob-key");
+      if (!key) return;
+      var v = q.get("knob." + key);
+      if (v === null) return;
+      if (el.type === "checkbox") el.checked = (v === "true" || v === "1");
+      else el.value = v;
+    });
+  })();
   // The selects + text input are opt-in (empty value = "use the preview's default"). The font
   // scale slider has no empty state, so it's gated separately: we only send fontScale once the
   // user moves it (fontScaleTouched), otherwise the slider's standing 1.0 would override a

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-themes.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-themes.html
@@ -707,6 +707,18 @@ a:hover { text-decoration: underline; }
     if (fontScaleTouched && fs) parts.push("fontScale=" + encodeURIComponent(fs.value));
     if (wasmBg && wasmBg.checked) parts.push("background=off");
     parts.push("bgPhase=" + encodeURIComponent(wasmBgPhase()));
+    // Author-declared knobs also apply in the browser: the wasm catalog seeds its
+    // `catalogOverride*` from these `knob.<key>` params. Mirror query() — omit a knob still at
+    // its `data-knob-initial` so an unedited knob reverts to the author default in the app.
+    document.querySelectorAll(".cp-knob").forEach(function (el) {
+      if (el.disabled) return;
+      var key = el.getAttribute("data-knob-key");
+      if (!key) return;
+      var val = (el.type === "checkbox") ? (el.checked ? "true" : "false") : el.value;
+      if (val === "") return;
+      if (val === (el.getAttribute("data-knob-initial") || "")) return;
+      parts.push("knob." + encodeURIComponent(key) + "=" + encodeURIComponent(val));
+    });
     return parts.join("&");
   }
   // Initial iframe URL: the baked base plus the current overrides in the `#…` fragment, so the
@@ -944,10 +956,40 @@ a:hover { text-decoration: underline; }
   Array.prototype.forEach.call(overlayToggles, function (el) {
     el.addEventListener("change", onOverlayChanged);
   });
-  // Author-declared knobs re-render on edit (text/number debounce via "input", toggles "change").
-  // They route differently from the display axes: a named knob (label, a color, …) is honoured
-  // ONLY by the server daemon — the in-browser Wasm tier's `catalogOverride*` returns the author
-  // default — so a knob edit must hit /render (onKnobChanged), never the wasm auto-enable path.
+  // Author-declared **named knobs** (label, count, colour, …) re-render on edit (text/number
+  // debounce via "input", toggles "change"). Unlike the app-theme selector and detected-feature
+  // toggles below, these ARE honoured by the in-browser Wasm tier (its `catalogOverride*` seeds
+  // from the `knob.<key>` patch), so a knob edit drives whichever transport is live: the Wasm
+  // iframe when it's active (or auto-enable it on a static published catalog), the daemon stream
+  // when Live is up, or a `/render` snapshot when the session can re-render.
+  function onKnobEdited() {
+    refreshLinks();
+    if (wasmActive()) {
+      if (wasmReady && wasmFrame.contentWindow) {
+        wasmFrame.contentWindow.postMessage(wasmOverridePatch(), "*");
+      } else {
+        wasmFrame.src = wasmInitialSrc();
+      }
+      return;
+    }
+    if (live.checked && ws && ws.readyState === 1) {
+      ws.send(JSON.stringify({ type: "setOverrides", overrides: liveOverrides() }));
+    } else if (canRenderOverrides) {
+      refreshSnapshot();
+    } else if (staticSnapshot && wasmToggle) {
+      // A published catalog can't re-render on the server, but its in-browser app can apply the
+      // knob — auto-enable the Wasm tier and let its load carry the edit (wasmInitialSrc bakes
+      // the patch into the fragment), mirroring the display-axis auto-enable in onControlsChanged.
+      setMode("wasm");
+    }
+  }
+  document.querySelectorAll(".cp-knob").forEach(function (el) {
+    el.addEventListener(el.type === "checkbox" ? "change" : "input", onKnobEdited);
+  });
+  // The app-theme selector and detected-feature toggles route ONLY through the server daemon —
+  // an app-declared theme provider is a server-side wrapper, and focus/gesture overlays are
+  // daemon-rendered, neither of which the in-browser tier can produce — so they use a
+  // daemon-only handler and never the wasm path.
   function onKnobChanged() {
     refreshLinks();
     if (live.checked && ws && ws.readyState === 1) {
@@ -956,12 +998,6 @@ a:hover { text-decoration: underline; }
       refreshSnapshot();
     }
   }
-  document.querySelectorAll(".cp-knob").forEach(function (el) {
-    el.addEventListener(el.type === "checkbox" ? "change" : "input", onKnobChanged);
-  });
-  // The app-theme selector routes through the daemon like a knob (never the wasm auto-enable
-  // path — an app-declared theme provider is a server-side wrapper the in-browser tier can't
-  // load), so it shares onKnobChanged rather than onControlsChanged.
   var themeSel = document.getElementById("cp-themeProvider");
   if (themeSel) themeSel.addEventListener("change", onKnobChanged);
   // Detected-feature toggles (Keyboard focus) re-render on the daemon like a knob — same routing,

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
@@ -173,7 +173,7 @@ a:hover { text-decoration: underline; }
         
         <div class="cp-stage"><span class="cp-backend" id="cp-backend"></span><img id="cp-img" alt="Card"><canvas id="cp-canvas" hidden></canvas><iframe id="cp-wasm" hidden sandbox="allow-scripts allow-same-origin" title="Card (Wasm)"></iframe></div>
         <div class="cp-controls" id="cp-controls">
-          <div class="cp-note">Pre-rendered snapshot — pick “Wasm” to interact: Theme, Font scale, Locale &amp; background apply in the browser. Device/Orientation need the live server. <a href="https://github.com/yschimke/compose-ai-tools/blob/main/docs/public-preview-server.md#running-one">Enable a local preview server.</a></div>
+          <div class="cp-note">Pre-rendered snapshot — pick “Wasm” to interact: Theme, Font scale, Locale, background &amp; declared knob values apply in the browser. Device/Orientation need the live server. <a href="https://github.com/yschimke/compose-ai-tools/blob/main/docs/public-preview-server.md#running-one">Enable a local preview server.</a></div>
           <div class="cp-modes" role="radiogroup" aria-label="Render mode">
             <label class="cp-live-row"><input type="radio" name="cp-mode" value="png" id="cp-mode-png" checked> PNG</label>
             
@@ -699,6 +699,18 @@ a:hover { text-decoration: underline; }
     if (fontScaleTouched && fs) parts.push("fontScale=" + encodeURIComponent(fs.value));
     if (wasmBg && wasmBg.checked) parts.push("background=off");
     parts.push("bgPhase=" + encodeURIComponent(wasmBgPhase()));
+    // Author-declared knobs also apply in the browser: the wasm catalog seeds its
+    // `catalogOverride*` from these `knob.<key>` params. Mirror query() — omit a knob still at
+    // its `data-knob-initial` so an unedited knob reverts to the author default in the app.
+    document.querySelectorAll(".cp-knob").forEach(function (el) {
+      if (el.disabled) return;
+      var key = el.getAttribute("data-knob-key");
+      if (!key) return;
+      var val = (el.type === "checkbox") ? (el.checked ? "true" : "false") : el.value;
+      if (val === "") return;
+      if (val === (el.getAttribute("data-knob-initial") || "")) return;
+      parts.push("knob." + encodeURIComponent(key) + "=" + encodeURIComponent(val));
+    });
     return parts.join("&");
   }
   // Initial iframe URL: the baked base plus the current overrides in the `#…` fragment, so the
@@ -936,10 +948,40 @@ a:hover { text-decoration: underline; }
   Array.prototype.forEach.call(overlayToggles, function (el) {
     el.addEventListener("change", onOverlayChanged);
   });
-  // Author-declared knobs re-render on edit (text/number debounce via "input", toggles "change").
-  // They route differently from the display axes: a named knob (label, a color, …) is honoured
-  // ONLY by the server daemon — the in-browser Wasm tier's `catalogOverride*` returns the author
-  // default — so a knob edit must hit /render (onKnobChanged), never the wasm auto-enable path.
+  // Author-declared **named knobs** (label, count, colour, …) re-render on edit (text/number
+  // debounce via "input", toggles "change"). Unlike the app-theme selector and detected-feature
+  // toggles below, these ARE honoured by the in-browser Wasm tier (its `catalogOverride*` seeds
+  // from the `knob.<key>` patch), so a knob edit drives whichever transport is live: the Wasm
+  // iframe when it's active (or auto-enable it on a static published catalog), the daemon stream
+  // when Live is up, or a `/render` snapshot when the session can re-render.
+  function onKnobEdited() {
+    refreshLinks();
+    if (wasmActive()) {
+      if (wasmReady && wasmFrame.contentWindow) {
+        wasmFrame.contentWindow.postMessage(wasmOverridePatch(), "*");
+      } else {
+        wasmFrame.src = wasmInitialSrc();
+      }
+      return;
+    }
+    if (live.checked && ws && ws.readyState === 1) {
+      ws.send(JSON.stringify({ type: "setOverrides", overrides: liveOverrides() }));
+    } else if (canRenderOverrides) {
+      refreshSnapshot();
+    } else if (staticSnapshot && wasmToggle) {
+      // A published catalog can't re-render on the server, but its in-browser app can apply the
+      // knob — auto-enable the Wasm tier and let its load carry the edit (wasmInitialSrc bakes
+      // the patch into the fragment), mirroring the display-axis auto-enable in onControlsChanged.
+      setMode("wasm");
+    }
+  }
+  document.querySelectorAll(".cp-knob").forEach(function (el) {
+    el.addEventListener(el.type === "checkbox" ? "change" : "input", onKnobEdited);
+  });
+  // The app-theme selector and detected-feature toggles route ONLY through the server daemon —
+  // an app-declared theme provider is a server-side wrapper, and focus/gesture overlays are
+  // daemon-rendered, neither of which the in-browser tier can produce — so they use a
+  // daemon-only handler and never the wasm path.
   function onKnobChanged() {
     refreshLinks();
     if (live.checked && ws && ws.readyState === 1) {
@@ -948,12 +990,6 @@ a:hover { text-decoration: underline; }
       refreshSnapshot();
     }
   }
-  document.querySelectorAll(".cp-knob").forEach(function (el) {
-    el.addEventListener(el.type === "checkbox" ? "change" : "input", onKnobChanged);
-  });
-  // The app-theme selector routes through the daemon like a knob (never the wasm auto-enable
-  // path — an app-declared theme provider is a server-side wrapper the in-browser tier can't
-  // load), so it shares onKnobChanged rather than onControlsChanged.
   var themeSel = document.getElementById("cp-themeProvider");
   if (themeSel) themeSel.addEventListener("change", onKnobChanged);
   // Detected-feature toggles (Keyboard focus) re-render on the daemon like a knob — same routing,

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
@@ -323,6 +323,23 @@ a:hover { text-decoration: underline; }
   var token = new URLSearchParams(location.search).get("token") || "";
   // Carry the tenant through follow-up requests so a non-default ?session= stays on its module.
   var session = new URLSearchParams(location.search).get("session") || "";
+  // Hydrate the declared knob controls from the page URL's `knob.<key>` params, so a deep link
+  // (or a copied "Direct links — overrides applied" URL) opens with those values already set.
+  // The initial render then carries them through whichever transport is live — including the
+  // Wasm iframe, whose fragment/patch is built purely from control state — instead of showing
+  // the author default until the control is manually edited. Only the author-declared knobs this
+  // feature drives are hydrated (display axes are unchanged, pre-existing behaviour).
+  (function () {
+    var q = new URLSearchParams(location.search);
+    document.querySelectorAll(".cp-knob").forEach(function (el) {
+      var key = el.getAttribute("data-knob-key");
+      if (!key) return;
+      var v = q.get("knob." + key);
+      if (v === null) return;
+      if (el.type === "checkbox") el.checked = (v === "true" || v === "1");
+      else el.value = v;
+    });
+  })();
   // The selects + text input are opt-in (empty value = "use the preview's default"). The font
   // scale slider has no empty state, so it's gated separately: we only send fontScale once the
   // user moves it (fontScaleTouched), otherwise the slider's standing 1.0 would override a

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
@@ -319,6 +319,23 @@ a:hover { text-decoration: underline; }
   var token = new URLSearchParams(location.search).get("token") || "";
   // Carry the tenant through follow-up requests so a non-default ?session= stays on its module.
   var session = new URLSearchParams(location.search).get("session") || "";
+  // Hydrate the declared knob controls from the page URL's `knob.<key>` params, so a deep link
+  // (or a copied "Direct links — overrides applied" URL) opens with those values already set.
+  // The initial render then carries them through whichever transport is live — including the
+  // Wasm iframe, whose fragment/patch is built purely from control state — instead of showing
+  // the author default until the control is manually edited. Only the author-declared knobs this
+  // feature drives are hydrated (display axes are unchanged, pre-existing behaviour).
+  (function () {
+    var q = new URLSearchParams(location.search);
+    document.querySelectorAll(".cp-knob").forEach(function (el) {
+      var key = el.getAttribute("data-knob-key");
+      if (!key) return;
+      var v = q.get("knob." + key);
+      if (v === null) return;
+      if (el.type === "checkbox") el.checked = (v === "true" || v === "1");
+      else el.value = v;
+    });
+  })();
   // The selects + text input are opt-in (empty value = "use the preview's default"). The font
   // scale slider has no empty state, so it's gated separately: we only send fontScale once the
   // user moves it (fontScaleTouched), otherwise the slider's standing 1.0 would override a

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
@@ -173,7 +173,7 @@ a:hover { text-decoration: underline; }
         
         <div class="cp-stage"><span class="cp-backend" id="cp-backend"></span><img id="cp-img" alt="Card"><canvas id="cp-canvas" hidden></canvas><iframe id="cp-wasm" hidden sandbox="allow-scripts allow-same-origin" title="Card (Wasm)"></iframe></div>
         <div class="cp-controls" id="cp-controls">
-          <div class="cp-note">Pre-rendered snapshot — pick “Wasm” to interact: Theme, Font scale, Locale &amp; background apply in the browser. Device/Orientation need the live server. <a href="https://github.com/yschimke/compose-ai-tools/blob/main/docs/public-preview-server.md#running-one">Enable a local preview server.</a></div>
+          <div class="cp-note">Pre-rendered snapshot — pick “Wasm” to interact: Theme, Font scale, Locale, background &amp; declared knob values apply in the browser. Device/Orientation need the live server. <a href="https://github.com/yschimke/compose-ai-tools/blob/main/docs/public-preview-server.md#running-one">Enable a local preview server.</a></div>
           <div class="cp-modes" role="radiogroup" aria-label="Render mode">
             <label class="cp-live-row"><input type="radio" name="cp-mode" value="png" id="cp-mode-png" checked> PNG</label>
             
@@ -695,6 +695,18 @@ a:hover { text-decoration: underline; }
     if (fontScaleTouched && fs) parts.push("fontScale=" + encodeURIComponent(fs.value));
     if (wasmBg && wasmBg.checked) parts.push("background=off");
     parts.push("bgPhase=" + encodeURIComponent(wasmBgPhase()));
+    // Author-declared knobs also apply in the browser: the wasm catalog seeds its
+    // `catalogOverride*` from these `knob.<key>` params. Mirror query() — omit a knob still at
+    // its `data-knob-initial` so an unedited knob reverts to the author default in the app.
+    document.querySelectorAll(".cp-knob").forEach(function (el) {
+      if (el.disabled) return;
+      var key = el.getAttribute("data-knob-key");
+      if (!key) return;
+      var val = (el.type === "checkbox") ? (el.checked ? "true" : "false") : el.value;
+      if (val === "") return;
+      if (val === (el.getAttribute("data-knob-initial") || "")) return;
+      parts.push("knob." + encodeURIComponent(key) + "=" + encodeURIComponent(val));
+    });
     return parts.join("&");
   }
   // Initial iframe URL: the baked base plus the current overrides in the `#…` fragment, so the
@@ -932,10 +944,40 @@ a:hover { text-decoration: underline; }
   Array.prototype.forEach.call(overlayToggles, function (el) {
     el.addEventListener("change", onOverlayChanged);
   });
-  // Author-declared knobs re-render on edit (text/number debounce via "input", toggles "change").
-  // They route differently from the display axes: a named knob (label, a color, …) is honoured
-  // ONLY by the server daemon — the in-browser Wasm tier's `catalogOverride*` returns the author
-  // default — so a knob edit must hit /render (onKnobChanged), never the wasm auto-enable path.
+  // Author-declared **named knobs** (label, count, colour, …) re-render on edit (text/number
+  // debounce via "input", toggles "change"). Unlike the app-theme selector and detected-feature
+  // toggles below, these ARE honoured by the in-browser Wasm tier (its `catalogOverride*` seeds
+  // from the `knob.<key>` patch), so a knob edit drives whichever transport is live: the Wasm
+  // iframe when it's active (or auto-enable it on a static published catalog), the daemon stream
+  // when Live is up, or a `/render` snapshot when the session can re-render.
+  function onKnobEdited() {
+    refreshLinks();
+    if (wasmActive()) {
+      if (wasmReady && wasmFrame.contentWindow) {
+        wasmFrame.contentWindow.postMessage(wasmOverridePatch(), "*");
+      } else {
+        wasmFrame.src = wasmInitialSrc();
+      }
+      return;
+    }
+    if (live.checked && ws && ws.readyState === 1) {
+      ws.send(JSON.stringify({ type: "setOverrides", overrides: liveOverrides() }));
+    } else if (canRenderOverrides) {
+      refreshSnapshot();
+    } else if (staticSnapshot && wasmToggle) {
+      // A published catalog can't re-render on the server, but its in-browser app can apply the
+      // knob — auto-enable the Wasm tier and let its load carry the edit (wasmInitialSrc bakes
+      // the patch into the fragment), mirroring the display-axis auto-enable in onControlsChanged.
+      setMode("wasm");
+    }
+  }
+  document.querySelectorAll(".cp-knob").forEach(function (el) {
+    el.addEventListener(el.type === "checkbox" ? "change" : "input", onKnobEdited);
+  });
+  // The app-theme selector and detected-feature toggles route ONLY through the server daemon —
+  // an app-declared theme provider is a server-side wrapper, and focus/gesture overlays are
+  // daemon-rendered, neither of which the in-browser tier can produce — so they use a
+  // daemon-only handler and never the wasm path.
   function onKnobChanged() {
     refreshLinks();
     if (live.checked && ws && ws.readyState === 1) {
@@ -944,12 +986,6 @@ a:hover { text-decoration: underline; }
       refreshSnapshot();
     }
   }
-  document.querySelectorAll(".cp-knob").forEach(function (el) {
-    el.addEventListener(el.type === "checkbox" ? "change" : "input", onKnobChanged);
-  });
-  // The app-theme selector routes through the daemon like a knob (never the wasm auto-enable
-  // path — an app-declared theme provider is a server-side wrapper the in-browser tier can't
-  // load), so it shares onKnobChanged rather than onControlsChanged.
   var themeSel = document.getElementById("cp-themeProvider");
   if (themeSel) themeSel.addEventListener("change", onKnobChanged);
   // Detected-feature toggles (Keyboard focus) re-render on the daemon like a knob — same routing,

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
@@ -331,6 +331,23 @@ a:hover { text-decoration: underline; }
   var token = new URLSearchParams(location.search).get("token") || "";
   // Carry the tenant through follow-up requests so a non-default ?session= stays on its module.
   var session = new URLSearchParams(location.search).get("session") || "";
+  // Hydrate the declared knob controls from the page URL's `knob.<key>` params, so a deep link
+  // (or a copied "Direct links — overrides applied" URL) opens with those values already set.
+  // The initial render then carries them through whichever transport is live — including the
+  // Wasm iframe, whose fragment/patch is built purely from control state — instead of showing
+  // the author default until the control is manually edited. Only the author-declared knobs this
+  // feature drives are hydrated (display axes are unchanged, pre-existing behaviour).
+  (function () {
+    var q = new URLSearchParams(location.search);
+    document.querySelectorAll(".cp-knob").forEach(function (el) {
+      var key = el.getAttribute("data-knob-key");
+      if (!key) return;
+      var v = q.get("knob." + key);
+      if (v === null) return;
+      if (el.type === "checkbox") el.checked = (v === "true" || v === "1");
+      else el.value = v;
+    });
+  })();
   // The selects + text input are opt-in (empty value = "use the preview's default"). The font
   // scale slider has no empty state, so it's gated separately: we only send fontScale once the
   // user moves it (fontScaleTouched), otherwise the slider's standing 1.0 would override a

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
@@ -707,6 +707,18 @@ a:hover { text-decoration: underline; }
     if (fontScaleTouched && fs) parts.push("fontScale=" + encodeURIComponent(fs.value));
     if (wasmBg && wasmBg.checked) parts.push("background=off");
     parts.push("bgPhase=" + encodeURIComponent(wasmBgPhase()));
+    // Author-declared knobs also apply in the browser: the wasm catalog seeds its
+    // `catalogOverride*` from these `knob.<key>` params. Mirror query() — omit a knob still at
+    // its `data-knob-initial` so an unedited knob reverts to the author default in the app.
+    document.querySelectorAll(".cp-knob").forEach(function (el) {
+      if (el.disabled) return;
+      var key = el.getAttribute("data-knob-key");
+      if (!key) return;
+      var val = (el.type === "checkbox") ? (el.checked ? "true" : "false") : el.value;
+      if (val === "") return;
+      if (val === (el.getAttribute("data-knob-initial") || "")) return;
+      parts.push("knob." + encodeURIComponent(key) + "=" + encodeURIComponent(val));
+    });
     return parts.join("&");
   }
   // Initial iframe URL: the baked base plus the current overrides in the `#…` fragment, so the
@@ -944,10 +956,40 @@ a:hover { text-decoration: underline; }
   Array.prototype.forEach.call(overlayToggles, function (el) {
     el.addEventListener("change", onOverlayChanged);
   });
-  // Author-declared knobs re-render on edit (text/number debounce via "input", toggles "change").
-  // They route differently from the display axes: a named knob (label, a color, …) is honoured
-  // ONLY by the server daemon — the in-browser Wasm tier's `catalogOverride*` returns the author
-  // default — so a knob edit must hit /render (onKnobChanged), never the wasm auto-enable path.
+  // Author-declared **named knobs** (label, count, colour, …) re-render on edit (text/number
+  // debounce via "input", toggles "change"). Unlike the app-theme selector and detected-feature
+  // toggles below, these ARE honoured by the in-browser Wasm tier (its `catalogOverride*` seeds
+  // from the `knob.<key>` patch), so a knob edit drives whichever transport is live: the Wasm
+  // iframe when it's active (or auto-enable it on a static published catalog), the daemon stream
+  // when Live is up, or a `/render` snapshot when the session can re-render.
+  function onKnobEdited() {
+    refreshLinks();
+    if (wasmActive()) {
+      if (wasmReady && wasmFrame.contentWindow) {
+        wasmFrame.contentWindow.postMessage(wasmOverridePatch(), "*");
+      } else {
+        wasmFrame.src = wasmInitialSrc();
+      }
+      return;
+    }
+    if (live.checked && ws && ws.readyState === 1) {
+      ws.send(JSON.stringify({ type: "setOverrides", overrides: liveOverrides() }));
+    } else if (canRenderOverrides) {
+      refreshSnapshot();
+    } else if (staticSnapshot && wasmToggle) {
+      // A published catalog can't re-render on the server, but its in-browser app can apply the
+      // knob — auto-enable the Wasm tier and let its load carry the edit (wasmInitialSrc bakes
+      // the patch into the fragment), mirroring the display-axis auto-enable in onControlsChanged.
+      setMode("wasm");
+    }
+  }
+  document.querySelectorAll(".cp-knob").forEach(function (el) {
+    el.addEventListener(el.type === "checkbox" ? "change" : "input", onKnobEdited);
+  });
+  // The app-theme selector and detected-feature toggles route ONLY through the server daemon —
+  // an app-declared theme provider is a server-side wrapper, and focus/gesture overlays are
+  // daemon-rendered, neither of which the in-browser tier can produce — so they use a
+  // daemon-only handler and never the wasm path.
   function onKnobChanged() {
     refreshLinks();
     if (live.checked && ws && ws.readyState === 1) {
@@ -956,12 +998,6 @@ a:hover { text-decoration: underline; }
       refreshSnapshot();
     }
   }
-  document.querySelectorAll(".cp-knob").forEach(function (el) {
-    el.addEventListener(el.type === "checkbox" ? "change" : "input", onKnobChanged);
-  });
-  // The app-theme selector routes through the daemon like a knob (never the wasm auto-enable
-  // path — an app-declared theme provider is a server-side wrapper the in-browser tier can't
-  // load), so it shares onKnobChanged rather than onControlsChanged.
   var themeSel = document.getElementById("cp-themeProvider");
   if (themeSel) themeSel.addEventListener("change", onKnobChanged);
   // Detected-feature toggles (Keyboard focus) re-render on the daemon like a knob — same routing,


### PR DESCRIPTION
## Summary

Named knobs (`?knob.<key>=…` — a label, a count, a colour) were honoured by the PNG / SVG / Live Compose lanes but **silently ignored in the in-browser Wasm mode**: on `preview.coo.ee`, `…/p/button-filled__ideal__default__dark?knob.label=Hello` retitled the button in every mode *except* Wasm.

This was a deliberate boundary — the wasm `catalogOverride*` hard-returned the author default with the comment *"the in-browser tier never runs a daemon, so there is nothing to seed a knob."* But seeding needs no daemon: it's all in-process in the browser. The knob value was dropped at three layers, all fixed here.

## The three layers

1. **Wasm sink** — `design-catalog-m3-shared/wasmJsMain/CatalogOverrides.wasm.kt`
   The `catalogOverride{String,Int,Float,Boolean,Color}` actuals no longer hard-return `default`. They read a new `LocalWasmCatalogKnobs` composition local (keyed by the runtime's `seedKey` scheme — bare `key`, or `key[index]` for an indexed knob), parsing the raw string per type; a wasm-safe `#AARRGGBB`/`#RRGGBB` colour parser mirrors the JVM runtime's. An **un-seeded knob still returns its author default**, so the baked sticker sheet stays pixel-identical.

2. **Wasm app** — `cmp-wasm-catalog/wasmJsMain/Main.kt`
   Projects the `knob.<key>` params out of the merged render params (stripping the prefix) and provides them via `CompositionLocalProvider(LocalWasmCatalogKnobs)` around `CatalogApp`. Because it flows through the existing `renderParams` state, a `postMessage` / fragment patch recomposes the live tree in place — no reload.

3. **Viewer client** — `cli/…/serve/ServeWeb.kt`
   - `wasmOverridePatch()` now carries the changed `.cp-knob` values into the iframe (fragment + `postMessage`), mirroring `query()` (omit a knob still at its `data-knob-initial` so it reverts to the author default).
   - A new `onKnobEdited` handler drives whichever transport is live for a named-knob edit: the Wasm iframe when active, the daemon stream when Live is up, `/render` when the session re-renders, or **auto-enable Wasm** from a static published catalog.
   - The declared knob controls render **enabled** when a Wasm app backs the session (previously disabled unless a daemon could re-render).
   - The app-theme selector and focus/gesture feature toggles stay **daemon-only** (an app-declared theme provider is a server-side wrapper and the overlays are daemon-rendered — the in-browser tier can't produce either), so those keep the unchanged `onKnobChanged`.

## Test plan

- `:samples:design-catalog-m3-shared:compileKotlinWasmJs`, `:samples:cmp-wasm-catalog:compileKotlinWasmJs`, `:cli:compileKotlin` — all clean.
- `ServeWebFixtureTest` gains a **wasm-only-knobs** case (a published catalog with `canApplyOverrides=false`, `canRenderOverrides=false`, `wasmSrc` set — exactly the preview.coo.ee scenario): asserts the knob controls render **enabled**, the note invites in-browser editing, `onKnobEdited` posts `wasmOverridePatch()` to the iframe, and the patch includes `knob.<key>` entries. Existing knob/theme/feature routing assertions updated to the split handler. `./gradlew ktfmtFormat` clean.

## Visual evidence

**Viewer chrome** (knob controls now enabled + the "apply it in the browser (Wasm)" note) is a golden-fixture surface — the regenerated `vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html` (and the other viewer pages) are screenshotted per theme by the harness's `pages-snapshot.spec.mjs`, so the CI visual-diff bot renders + diffs this change automatically on this PR.

**The in-browser Wasm render itself** (the button text actually changing to `Hello`) runs inside a sandboxed Kotlin/Wasm iframe that this headless container can't pixel-capture — analogous to the three.js webview case in the repo's visual-evidence rule. It's verified by (a) the wasm modules compiling, (b) the client fixture test asserting the full override→iframe wiring, and (c) the deployed server once this ships in a release. I'll confirm the live `?knob.label=…` render on preview.coo.ee after the next release rolls.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jxz9i4SuuxPRt3knZKAPbb)_