### PR TITLE
fix(vscode): honor composePreview.enabled=false in task scheduling

### DIFF
--- a/docs/HOW_IT_WORKS.md
+++ b/docs/HOW_IT_WORKS.md
@@ -88,6 +88,17 @@ composePreview {
 }
 ```
 
+When `enabled = false`, the plugin skips registering the preview tasks
+(`composePreviewDiscover` / render / daemon-start) but still writes the
+`build/compose-previews/applied.json` marker (carrying `enabled: false`). The
+VS Code extension reads that marker: the module stays **visible** in discovery
+and the doctor report, but the extension never **schedules** a preview task for
+it — so opening or saving a file in a disabled module no longer produces a
+"task not found" failure. (This is the "keep but flag" choice from #2016:
+`ModuleInfo.enabled` gates scheduling in `GradleService`, leaving visibility
+intact. A missing `enabled` — legacy markers, scan-detected modules — is
+treated as enabled.)
+
 ## Project structure
 
 | Module | Purpose |

--- a/vscode-extension/src/gradleService.ts
+++ b/vscode-extension/src/gradleService.ts
@@ -176,6 +176,28 @@ export interface ModuleInfo {
     readonly enabled?: boolean;
 }
 
+/**
+ * Whether the extension should schedule Gradle *preview* tasks for a module
+ * (issue #2016). `composePreview.enabled = false` disables preview-task
+ * *registration* on the Gradle side (`docs/HOW_IT_WORKS.md`; the Android path
+ * exits before registering variant tasks when `extension.enabled` is false),
+ * so the `composePreviewDiscover` / render / daemon-start tasks never exist —
+ * scheduling one yields a "task not found" failure on refresh / cold-start.
+ *
+ * The `enabled` intent is surfaced on `ModuleInfo.enabled` from the module's
+ * `applied.json` marker (which is written unconditionally). A missing value
+ * (`undefined`) — legacy markers written before the field existed, or
+ * scan-detected modules with no marker — is treated as **enabled**, so the
+ * historical behaviour is unchanged for everything that predates this field.
+ *
+ * Visibility is intentionally NOT gated on this: `findPreviewModules` still
+ * returns disabled modules, and doctor still reports on them (its task is
+ * registered unconditionally). Only task *scheduling* is skipped.
+ */
+export function isModulePreviewSchedulable(module: ModuleInfo): boolean {
+    return module.enabled !== false;
+}
+
 /** Synthesises a Gradle project path from a workspace-relative directory.
  *  Used as a fallback when no `applied.json` has been written yet — the
  *  marker, once present, supplies the authoritative `modulePath`. */
@@ -401,10 +423,27 @@ export class GradleService {
         this.logFilter = logFilter ?? new LogFilter();
     }
 
+    /**
+     * Logs why a preview task was not scheduled for a `composePreview.enabled =
+     * false` module (issue #2016). Kept quiet — an INFO line, not a warning:
+     * a disabled module is an intentional configuration, not a fault, and this
+     * fires on every refresh/save for files in such a module.
+     */
+    private logDisabledSkip(module: ModuleInfo, task: string): void {
+        this.logger.appendLine(
+            `[compose-preview] ${module.modulePath}: composePreview.enabled = false — ` +
+                `skipping ${task} (no preview tasks are registered for this module).`,
+        );
+    }
+
     async composePreviewDiscover(
         module: ModuleInfo,
         opts?: TaskOptions,
     ): Promise<PreviewManifest | null> {
+        if (!isModulePreviewSchedulable(module)) {
+            this.logDisabledSkip(module, "composePreviewDiscover");
+            return null;
+        }
         const key = module.modulePath;
         const inFlight = this.inFlightDiscover.get(key);
         if (inFlight) {
@@ -466,6 +505,10 @@ export class GradleService {
      * will repopulate the cache through `composePreviewDiscover`.
      */
     async compileOnly(module: ModuleInfo, opts?: TaskOptions): Promise<void> {
+        if (!isModulePreviewSchedulable(module)) {
+            this.logDisabledSkip(module, "compileOnly");
+            return;
+        }
         this.manifestCache.delete(module.modulePath);
         const worker = this.continuousWorkers.get(module.modulePath);
         if (worker && worker.running) {
@@ -548,6 +591,10 @@ export class GradleService {
         opts?: TaskOptions,
         extraArgs: readonly string[] = [],
     ): Promise<PreviewManifest | null> {
+        if (!isModulePreviewSchedulable(module)) {
+            this.logDisabledSkip(module, "composePreviewRenderAll");
+            return null;
+        }
         this.manifestCache.delete(module.modulePath);
         await this.runTask(
             `${module.modulePath}:composePreviewRenderAll`,
@@ -1286,6 +1333,14 @@ export class GradleService {
         opts?: TaskOptions,
         bundleOpts?: { includeDiscover?: boolean },
     ): Promise<PreviewManifest | null> {
+        if (!isModulePreviewSchedulable(module)) {
+            // Covers the daemon-start bootstrap path too — `runDaemonBootstrap`
+            // delegates here — so a disabled module never triggers
+            // `composePreviewDaemonStart` / `composePreviewDiscover` from a
+            // cold start or daemon warm.
+            this.logDisabledSkip(module, "coldStartBundle");
+            return null;
+        }
         const includeDiscover = bundleOpts?.includeDiscover ?? true;
         const key = module.modulePath;
         const inFlight = this.inFlightColdStart.get(key);

--- a/vscode-extension/src/test/gradleService.test.ts
+++ b/vscode-extension/src/test/gradleService.test.ts
@@ -7,6 +7,7 @@ import {
     GradleApi,
     TaskCancelledError,
     encodeBundlePreviewId,
+    isModulePreviewSchedulable,
 } from "../gradleService";
 import { JdkImageError } from "../jdkImageErrorDetector";
 
@@ -1225,6 +1226,98 @@ describe("GradleService", () => {
         );
     });
 
+    describe("composePreview.enabled = false gating (#2016)", () => {
+        const disabled = {
+            projectDir: "mod",
+            modulePath: ":mod",
+            enabled: false,
+        } as const;
+
+        it(
+            "composePreviewDiscover schedules no task and returns null for a disabled module",
+            withTempDir(async (dir, api) => {
+                const service = new GradleService(dir, api);
+                const manifest = await service.composePreviewDiscover(disabled);
+                assert.strictEqual(manifest, null);
+                assert.strictEqual(api.runCalls.length, 0);
+            }),
+        );
+
+        it(
+            "composePreviewRender schedules no task and returns null for a disabled module",
+            withTempDir(async (dir, api) => {
+                const service = new GradleService(dir, api);
+                const manifest = await service.composePreviewRender(disabled);
+                assert.strictEqual(manifest, null);
+                assert.strictEqual(api.runCalls.length, 0);
+            }),
+        );
+
+        it(
+            "compileOnly schedules no task for a disabled module",
+            withTempDir(async (dir, api) => {
+                const service = new GradleService(dir, api);
+                await service.compileOnly(disabled);
+                assert.strictEqual(api.runCalls.length, 0);
+            }),
+        );
+
+        it(
+            "coldStartBundle schedules no task and returns null for a disabled module",
+            withTempDir(async (dir, api) => {
+                const service = new GradleService(dir, api);
+                const manifest = await service.coldStartBundle(disabled);
+                assert.strictEqual(manifest, null);
+                assert.strictEqual(api.runCalls.length, 0);
+            }),
+        );
+
+        it(
+            "runDaemonBootstrap schedules no task for a disabled module",
+            withTempDir(async (dir, api) => {
+                const service = new GradleService(dir, api);
+                await service.runDaemonBootstrap(disabled);
+                assert.strictEqual(api.runCalls.length, 0);
+            }),
+        );
+
+        it(
+            "treats enabled === undefined (legacy marker) as enabled and still schedules",
+            withTempDir(async (dir, api) => {
+                fs.mkdirSync(path.join(dir, "mod"));
+                const service = new GradleService(dir, api);
+                // No `enabled` field — the shape of a legacy/scan-detected module.
+                await service.composePreviewDiscover({
+                    projectDir: "mod",
+                    modulePath: ":mod",
+                });
+                assert.strictEqual(api.runCalls.length, 1);
+                assert.strictEqual(
+                    api.runCalls[0].taskName,
+                    ":mod:composePreviewDiscover",
+                );
+            }),
+        );
+
+        it(
+            "treats enabled === true as enabled and still schedules",
+            withTempDir(async (dir, api) => {
+                fs.mkdirSync(path.join(dir, "mod"));
+                const service = new GradleService(dir, api);
+                await service.composePreviewDiscover({
+                    projectDir: "mod",
+                    modulePath: ":mod",
+                    enabled: true,
+                });
+                assert.strictEqual(api.runCalls.length, 1);
+                assert.strictEqual(
+                    api.runCalls[0].taskName,
+                    ":mod:composePreviewDiscover",
+                );
+            }),
+        );
+    });
+
     describe("coldStartBundle", () => {
         function writeManifest(dir: string, moduleDir: string): void {
             const manifestDir = path.join(
@@ -1695,5 +1788,27 @@ describe("encodeBundlePreviewId", () => {
         // came next (e.g. `\,` would lose the literal `\`).
         assert.strictEqual(encodeBundlePreviewId("a\\b"), "a\\\\b");
         assert.strictEqual(encodeBundlePreviewId("a\\,b"), "a\\\\\\,b");
+    });
+});
+
+describe("isModulePreviewSchedulable", () => {
+    const base = { projectDir: "mod", modulePath: ":mod" };
+
+    it("blocks scheduling only when enabled is explicitly false", () => {
+        assert.strictEqual(
+            isModulePreviewSchedulable({ ...base, enabled: false }),
+            false,
+        );
+    });
+
+    it("schedules when enabled is true", () => {
+        assert.strictEqual(
+            isModulePreviewSchedulable({ ...base, enabled: true }),
+            true,
+        );
+    });
+
+    it("treats a missing enabled (legacy / scan-detected) as enabled", () => {
+        assert.strictEqual(isModulePreviewSchedulable(base), true);
     });
 });


### PR DESCRIPTION
Closes #2016.

## Summary

A module with `composePreview.enabled = false` skips preview-task registration on the Gradle side but still writes its `applied.json` marker and is returned by `GradleService.findPreviewModules()`. Opening or saving a file in such a module let refresh / cold-start / daemon-warm schedule `:module:composePreviewDiscover` / render / daemon-start tasks that were never registered → "task not found" (or a silently skipped task).

This implements **Option 2 (keep but flag)** from the issue: gate task *scheduling* on `ModuleInfo.enabled` while leaving discovery/visibility intact.

- **`isModulePreviewSchedulable(module)`** — returns false only when `enabled === false`. A missing `enabled` (legacy markers written before the field existed, or scan-detected modules with no marker) is treated as **enabled**, so historical behaviour is unchanged.
- **Gated the four `GradleService` scheduling chokepoints** every refresh / cold-start / daemon-warm path funnels through (confirmed by a full call-site audit — no `findPreviewModules()` loop schedules preview tasks; all schedulers hold a `ModuleInfo`): `composePreviewDiscover`, `composePreviewRender`, `compileOnly`, and `coldStartBundle` (which also covers `runDaemonBootstrap`, which delegates to it). Each logs an INFO skip line and no-ops (returns `null` / void) instead of scheduling a task.
- **Left ungated:** `findPreviewModules`, `runDoctor`, the module-list dropdown, and `bootstrapAppliedMarkers` (the root `composePreviewApplied` fan-out that writes the markers) — so a disabled module stays **visible** in discovery and the doctor report, exactly as the issue's acceptance requires.
- **Documented the exclude-vs-flag decision** in `docs/HOW_IT_WORKS.md`.

## Acceptance criteria

- ✅ A module with `composePreview.enabled = false` never has Gradle preview tasks scheduled by the extension (no "task not found" from refresh/cold-start).
- ✅ `enabled === undefined` (legacy markers, scan-detected modules) is treated as enabled.
- ✅ Decision on exclude-vs-flag documented, with tests for the chosen path.

## Test plan

Added to `gradleService.test.ts`, asserting against `StubGradleApi.runCalls` (records every scheduled task):

- `composePreviewDiscover` / `composePreviewRender` / `coldStartBundle` on a disabled module schedule **no** task and return `null`; `compileOnly` / `runDaemonBootstrap` schedule no task.
- `enabled === undefined` and `enabled === true` still schedule the task (1 run call each).
- `isModulePreviewSchedulable` unit tests pin the `false` / `true` / `undefined` contract.

`npx mocha out/test/runMocha.js` — **1599 passing**, no regressions. `npx tsc -p ./` clean.

Note: the local `.githooks/pre-commit` runs `format:check` over the whole `src/**` glob (not just staged files), which currently trips on ~31 pre-existing unformatted files on `main` unrelated to this change; no CI workflow runs that check. This commit's two touched TS files are prettier-clean (verified with the pinned prettier 3.9.1).


---
_Generated by [Claude Code](https://claude.ai/code/session_01NE5X73NdmATow7RbkWtEgj)_