### PR TITLE
feat(serve): add size overrides (Fixed/Max/Min/Within) to the preview page

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeOverrides.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeOverrides.kt
@@ -54,6 +54,12 @@ object ServeOverrides {
       "density",
       "widthPx",
       "heightPx",
+      // Wrapped-axis content-size bounds (the Max / Min / Within size modes). Fixed size uses
+      // widthPx/heightPx above; these constrain a wrapping preview's intrinsic measure instead.
+      "minWidthPx",
+      "minHeightPx",
+      "maxWidthPx",
+      "maxHeightPx",
       "orientation",
       "inspectionMode",
       "slotMode",
@@ -196,6 +202,52 @@ object ServeOverrides {
           ?: return OverrideParse.Invalid(
             "heightPx must be a positive integer, got '${params["heightPx"]}'"
           )
+
+    // Wrapped-axis content-size bounds (Max / Min / Within). Same positive-integer grammar as the
+    // fixed widthPx/heightPx; a malformed value is a hard Invalid rather than a silently-dropped
+    // bound. A `min > max` on the same axis is rejected below — it can't be satisfied.
+    val minWidthPx =
+      if (blank("minWidthPx")) null
+      else
+        params.getValue("minWidthPx").toIntOrNull()?.takeIf { it > 0 }
+          ?: return OverrideParse.Invalid(
+            "minWidthPx must be a positive integer, got '${params["minWidthPx"]}'"
+          )
+
+    val minHeightPx =
+      if (blank("minHeightPx")) null
+      else
+        params.getValue("minHeightPx").toIntOrNull()?.takeIf { it > 0 }
+          ?: return OverrideParse.Invalid(
+            "minHeightPx must be a positive integer, got '${params["minHeightPx"]}'"
+          )
+
+    val maxWidthPx =
+      if (blank("maxWidthPx")) null
+      else
+        params.getValue("maxWidthPx").toIntOrNull()?.takeIf { it > 0 }
+          ?: return OverrideParse.Invalid(
+            "maxWidthPx must be a positive integer, got '${params["maxWidthPx"]}'"
+          )
+
+    val maxHeightPx =
+      if (blank("maxHeightPx")) null
+      else
+        params.getValue("maxHeightPx").toIntOrNull()?.takeIf { it > 0 }
+          ?: return OverrideParse.Invalid(
+            "maxHeightPx must be a positive integer, got '${params["maxHeightPx"]}'"
+          )
+
+    if (minWidthPx != null && maxWidthPx != null && minWidthPx > maxWidthPx) {
+      return OverrideParse.Invalid(
+        "minWidthPx ($minWidthPx) must not exceed maxWidthPx ($maxWidthPx)"
+      )
+    }
+    if (minHeightPx != null && maxHeightPx != null && minHeightPx > maxHeightPx) {
+      return OverrideParse.Invalid(
+        "minHeightPx ($minHeightPx) must not exceed maxHeightPx ($maxHeightPx)"
+      )
+    }
 
     val inspectionMode =
       params["inspectionMode"]
@@ -360,6 +412,10 @@ object ServeOverrides {
       PreviewOverrides(
         widthPx = widthPx,
         heightPx = heightPx,
+        minWidthPx = minWidthPx,
+        minHeightPx = minHeightPx,
+        maxWidthPx = maxWidthPx,
+        maxHeightPx = maxHeightPx,
         density = density,
         localeTag = params["localeTag"]?.takeIf { it.isNotBlank() },
         fontScale = fontScale,
@@ -390,6 +446,10 @@ object ServeOverrides {
       append(previewId).append(' ')
       append("w=").append(o.widthPx).append('|')
       append("h=").append(o.heightPx).append('|')
+      append("minw=").append(o.minWidthPx).append('|')
+      append("minh=").append(o.minHeightPx).append('|')
+      append("maxw=").append(o.maxWidthPx).append('|')
+      append("maxh=").append(o.maxHeightPx).append('|')
       append("d=").append(o.density).append('|')
       append("loc=").append(o.localeTag).append('|')
       append("fs=").append(o.fontScale).append('|')

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -91,6 +91,11 @@ object ServeWeb {
     .cp-note { font-size: 0.75rem; color: #6b6b70; line-height: 1.4; padding: 8px 10px;
       border-radius: 8px; background: #f4f4f6; }
     .cp-controls label:has(:disabled) { opacity: 0.55; }
+    .cp-size { display: flex; flex-direction: column; gap: 8px; }
+    /* :not([hidden]) so the mode toggle's `hidden` attribute still wins over this display rule. */
+    .cp-size-row:not([hidden]) { display: flex; gap: 8px; }
+    .cp-size-row label { flex: 1; }
+    .cp-size-row input { width: 100%; box-sizing: border-box; }
     .cp-knobs { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
     .cp-knobs-head { font-size: 0.72rem; color: #6b6b70; }
     .cp-overlays { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
@@ -995,6 +1000,29 @@ object ServeWeb {
               <option value="clear">Clear (crisp outline)</option>
             </select>
           </label>
+          <div class="cp-size">
+            <label>Size
+              <select id="cp-sizeMode"$serverDis>
+                <option value="">(default)</option>
+                <option value="fixed">Fixed size</option>
+                <option value="max">Max</option>
+                <option value="min">Min</option>
+                <option value="within">Within (min–max)</option>
+              </select>
+            </label>
+            <div class="cp-size-row" id="cp-size-fixed" hidden>
+              <label>Width (px)<input id="cp-fixedW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"$serverDis></label>
+              <label>Height (px)<input id="cp-fixedH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"$serverDis></label>
+            </div>
+            <div class="cp-size-row" id="cp-size-min" hidden>
+              <label>Min width (px)<input id="cp-minW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"$serverDis></label>
+              <label>Min height (px)<input id="cp-minH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"$serverDis></label>
+            </div>
+            <div class="cp-size-row" id="cp-size-max" hidden>
+              <label>Max width (px)<input id="cp-maxW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"$serverDis></label>
+              <label>Max height (px)<input id="cp-maxH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"$serverDis></label>
+            </div>
+          </div>
           $overlaysHtml
           $featureControlsHtml
           ${overrideKnobsHtml(preview, canApplyOverrides || canRenderOverrides)}
@@ -1062,6 +1090,33 @@ object ServeWeb {
       // the copyable links read it so a re-render / copied URL matches the on-screen format.
       var snapshotExt = ".png";
 
+      // Size overrides (the Fixed / Max / Min / Within modes). Which query params carry the numbers
+      // is chosen by the mode: Fixed pins the frame via widthPx/heightPx; Max / Min / Within are
+      // wrapped-axis bounds (maxWidthPx / minWidthPx …). Blank inputs are omitted, so one axis can be
+      // bounded without the other. Server-side only (a daemon re-measures) — the inputs are
+      // disabled on a static snapshot like Device/Orientation, so it never emits them.
+      function sizeVal(id) {
+        var el = document.getElementById(id);
+        return el && el.value ? el.value : null;
+      }
+      function sizeOverrides() {
+        var mode = document.getElementById("cp-sizeMode");
+        var o = {};
+        if (!mode || !mode.value) return o;
+        if (mode.value === "fixed") {
+          if (sizeVal("cp-fixedW")) o.widthPx = sizeVal("cp-fixedW");
+          if (sizeVal("cp-fixedH")) o.heightPx = sizeVal("cp-fixedH");
+        }
+        if (mode.value === "min" || mode.value === "within") {
+          if (sizeVal("cp-minW")) o.minWidthPx = sizeVal("cp-minW");
+          if (sizeVal("cp-minH")) o.minHeightPx = sizeVal("cp-minH");
+        }
+        if (mode.value === "max" || mode.value === "within") {
+          if (sizeVal("cp-maxW")) o.maxWidthPx = sizeVal("cp-maxW");
+          if (sizeVal("cp-maxH")) o.maxHeightPx = sizeVal("cp-maxH");
+        }
+        return o;
+      }
       function overrides() {
         var o = {};
         fields.forEach(function (f) {
@@ -1069,6 +1124,8 @@ object ServeWeb {
           if (el && el.value) o[f] = el.value;
         });
         if (fontScaleTouched && fs) o.fontScale = fs.value;
+        var size = sizeOverrides();
+        Object.keys(size).forEach(function (k) { o[k] = size[k]; });
         return o;
       }
       // The live-stream override map: the display fields PLUS the author-declared knob values as
@@ -1649,6 +1706,26 @@ object ServeWeb {
         var el = document.getElementById("cp-" + f);
         if (el) el.addEventListener("change", onControlsChanged);
       });
+      // Size mode: show only the input rows the chosen mode uses (Within shows both min + max), then
+      // re-render. The number inputs re-render on "input" (live typing) like the locale field.
+      var sizeMode = document.getElementById("cp-sizeMode");
+      if (sizeMode) {
+        var syncSizeRows = function () {
+          var m = sizeMode.value;
+          var show = { fixed: m === "fixed", min: m === "min" || m === "within",
+            max: m === "max" || m === "within" };
+          ["fixed", "min", "max"].forEach(function (g) {
+            var row = document.getElementById("cp-size-" + g);
+            if (row) row.hidden = !show[g];
+          });
+        };
+        syncSizeRows();
+        sizeMode.addEventListener("change", function () { syncSizeRows(); onControlsChanged(); });
+        ["cp-fixedW", "cp-fixedH", "cp-minW", "cp-minH", "cp-maxW", "cp-maxH"].forEach(function (id) {
+          var el = document.getElementById(id);
+          if (el) el.addEventListener("input", onControlsChanged);
+        });
+      }
       // Overlay toggles are live-only: they push a fresh setOverrides through the open stream and do
       // nothing otherwise. They get their own handler rather than onControlsChanged so a toggle mid
       // connect (ws not yet readyState 1) can't fall through to the snapshot / wasm-auto-enable

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -955,7 +955,7 @@ object ServeWeb {
         $navToggle
         <button type="button" class="cp-drawer-toggle" id="cp-controls-toggle" aria-expanded="true" aria-controls="cp-controls">⚙ Overrides</button>
       </div>
-      <div class="cp-viewer cp-controls-open" data-preview-id="$idText" data-mode="snapshot" data-modes="$modes" data-static-snapshot="$staticSnapshot" data-can-render-overrides="$canRenderOverrides" data-snapshot-backend="$backendLabel" data-live-backend="$liveLabel"$wasmAttr>
+      <div class="cp-viewer cp-controls-open" data-preview-id="$idText" data-mode="snapshot" data-modes="$modes" data-static-snapshot="$staticSnapshot" data-can-render-overrides="$canRenderOverrides" data-snapshot-backend="$backendLabel" data-live-backend="$liveLabel" data-render-density="$RENDER_DENSITY"$wasmAttr>
         $navDrawer
         <div class="cp-stage"><span class="cp-backend" id="cp-backend"></span><img id="cp-img" alt="$label"><canvas id="cp-canvas" hidden></canvas>$wasmFrame</div>
         <div class="cp-controls" id="cp-controls">
@@ -1011,16 +1011,16 @@ object ServeWeb {
               </select>
             </label>
             <div class="cp-size-row" id="cp-size-fixed" hidden>
-              <label>Width (px)<input id="cp-fixedW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"$serverDis></label>
-              <label>Height (px)<input id="cp-fixedH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"$serverDis></label>
+              <label>Width (dp)<input id="cp-fixedW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"$serverDis></label>
+              <label>Height (dp)<input id="cp-fixedH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"$serverDis></label>
             </div>
             <div class="cp-size-row" id="cp-size-min" hidden>
-              <label>Min width (px)<input id="cp-minW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"$serverDis></label>
-              <label>Min height (px)<input id="cp-minH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"$serverDis></label>
+              <label>Min width (dp)<input id="cp-minW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"$serverDis></label>
+              <label>Min height (dp)<input id="cp-minH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"$serverDis></label>
             </div>
             <div class="cp-size-row" id="cp-size-max" hidden>
-              <label>Max width (px)<input id="cp-maxW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"$serverDis></label>
-              <label>Max height (px)<input id="cp-maxH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"$serverDis></label>
+              <label>Max width (dp)<input id="cp-maxW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"$serverDis></label>
+              <label>Max height (dp)<input id="cp-maxH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"$serverDis></label>
             </div>
           </div>
           $overlaysHtml
@@ -1095,25 +1095,34 @@ object ServeWeb {
       // wrapped-axis bounds (maxWidthPx / minWidthPx …). Blank inputs are omitted, so one axis can be
       // bounded without the other. Server-side only (a daemon re-measures) — the inputs are
       // disabled on a static snapshot like Device/Orientation, so it never emits them.
-      function sizeVal(id) {
+      //
+      // The inputs are authored in dp (the Compose unit); the wire stays in px like every other
+      // override, so a dp value is multiplied by the backend's render density before it's sent (and
+      // the copyable /render URL stays px-consistent). data-render-density carries the factor.
+      var renderDensity = parseFloat(root.getAttribute("data-render-density")) || 2;
+      // dp (string from the input) → a positive integer px value, or null when blank/non-positive.
+      function sizePx(id) {
         var el = document.getElementById(id);
-        return el && el.value ? el.value : null;
+        if (!el || !el.value) return null;
+        var dp = parseFloat(el.value);
+        if (!(dp > 0)) return null;
+        return String(Math.max(1, Math.round(dp * renderDensity)));
       }
       function sizeOverrides() {
         var mode = document.getElementById("cp-sizeMode");
         var o = {};
         if (!mode || !mode.value) return o;
         if (mode.value === "fixed") {
-          if (sizeVal("cp-fixedW")) o.widthPx = sizeVal("cp-fixedW");
-          if (sizeVal("cp-fixedH")) o.heightPx = sizeVal("cp-fixedH");
+          if (sizePx("cp-fixedW")) o.widthPx = sizePx("cp-fixedW");
+          if (sizePx("cp-fixedH")) o.heightPx = sizePx("cp-fixedH");
         }
         if (mode.value === "min" || mode.value === "within") {
-          if (sizeVal("cp-minW")) o.minWidthPx = sizeVal("cp-minW");
-          if (sizeVal("cp-minH")) o.minHeightPx = sizeVal("cp-minH");
+          if (sizePx("cp-minW")) o.minWidthPx = sizePx("cp-minW");
+          if (sizePx("cp-minH")) o.minHeightPx = sizePx("cp-minH");
         }
         if (mode.value === "max" || mode.value === "within") {
-          if (sizeVal("cp-maxW")) o.maxWidthPx = sizeVal("cp-maxW");
-          if (sizeVal("cp-maxH")) o.maxHeightPx = sizeVal("cp-maxH");
+          if (sizePx("cp-maxW")) o.maxWidthPx = sizePx("cp-maxW");
+          if (sizePx("cp-maxH")) o.maxHeightPx = sizePx("cp-maxH");
         }
         return o;
       }
@@ -2003,6 +2012,16 @@ object ServeWeb {
    */
   private const val LOCAL_SERVER_DOCS =
     "https://github.com/yschimke/compose-ai-tools/blob/main/docs/public-preview-server.md#running-one"
+
+  /**
+   * Render density the `serve` backend captures at (the manifest default — `PreviewManifestEntry`
+   * resolves `density ?: 2.0f`). The size-override inputs are authored in **dp** (the Compose
+   * unit); the viewer converts dp→px against this factor before sending the px-valued `widthPx` /
+   * `min…Px` / `max…Px` query params, so the wire and copyable `/render` URLs stay in pixels like
+   * every other override. Carried to the page as `data-render-density` so the conversion isn't a
+   * hidden magic number.
+   */
+  private const val RENDER_DENSITY = 2
 
   private val COMMON_DEVICES: List<Pair<String, String>> =
     listOf(

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeOverridesTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeOverridesTest.kt
@@ -395,6 +395,79 @@ class ServeOverridesTest {
   }
 
   @Test
+  fun `size-bound params parse to the min-max fields`() {
+    val o =
+      ok(
+        mapOf(
+          "minWidthPx" to "120",
+          "minHeightPx" to "48",
+          "maxWidthPx" to "400",
+          "maxHeightPx" to "800",
+        )
+      )
+    assertEquals(120, o.minWidthPx)
+    assertEquals(48, o.minHeightPx)
+    assertEquals(400, o.maxWidthPx)
+    assertEquals(800, o.maxHeightPx)
+  }
+
+  @Test
+  fun `empty params leave the size bounds null`() {
+    val o = ok(emptyMap())
+    assertNull(o.minWidthPx)
+    assertNull(o.minHeightPx)
+    assertNull(o.maxWidthPx)
+    assertNull(o.maxHeightPx)
+  }
+
+  @Test
+  fun `a non-positive or malformed size bound is rejected`() {
+    for (bad in
+      listOf(
+        mapOf("minWidthPx" to "0"),
+        mapOf("minHeightPx" to "-3"),
+        mapOf("maxWidthPx" to "wide"),
+        mapOf("maxHeightPx" to "1.5"),
+      )) {
+      val parsed = ServeOverrides.parse(bad)
+      assertTrue(parsed is OverrideParse.Invalid, "expected Invalid for $bad, got $parsed")
+      assertTrue(parsed.message.isNotBlank())
+    }
+  }
+
+  @Test
+  fun `a min bound above the max on the same axis is rejected`() {
+    assertTrue(
+      ServeOverrides.parse(mapOf("minWidthPx" to "500", "maxWidthPx" to "200"))
+        is OverrideParse.Invalid
+    )
+    assertTrue(
+      ServeOverrides.parse(mapOf("minHeightPx" to "900", "maxHeightPx" to "300"))
+        is OverrideParse.Invalid
+    )
+    // Equal bounds are a degenerate-but-valid fixed range.
+    assertTrue(
+      ServeOverrides.parse(mapOf("minWidthPx" to "200", "maxWidthPx" to "200")) is OverrideParse.Ok
+    )
+  }
+
+  @Test
+  fun `cache key differs when a size bound changes`() {
+    assertNotEquals(
+      ServeOverrides.cacheKey("preview.A", ok(mapOf("maxWidthPx" to "300"))),
+      ServeOverrides.cacheKey("preview.A", ok(emptyMap())),
+    )
+    assertNotEquals(
+      ServeOverrides.cacheKey("preview.A", ok(mapOf("minWidthPx" to "100"))),
+      ServeOverrides.cacheKey("preview.A", ok(mapOf("minWidthPx" to "200"))),
+    )
+    assertNotEquals(
+      ServeOverrides.cacheKey("preview.A", ok(mapOf("minHeightPx" to "100"))),
+      ServeOverrides.cacheKey("preview.A", ok(mapOf("maxHeightPx" to "100"))),
+    )
+  }
+
+  @Test
   fun `preview mode parses known wire values`() {
     assertEquals(PreviewMode.SNAPSHOT, PreviewMode.parse("snapshot"))
     assertEquals(PreviewMode.LIVE, PreviewMode.parse("live"))

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -1325,9 +1325,12 @@ open class RobolectricHost(
       // (renderer-read, not extension-consumed), but the renderer reads spec.overrides directly, so
       // without this a live App-theme change would keep the default wrapper.
       overrides =
-        merged.toExtensionOverrides().withThemeProvider(
-          overrides?.themeProvider ?: base.overrides?.themeProvider
-        ),
+        merged
+          .toExtensionOverrides()
+          .withThemeProvider(overrides?.themeProvider ?: base.overrides?.themeProvider)
+          // Carry size bounds (Max / Min / Within) through the held/live projection for wire parity
+          // with desktop; the Android renderer ignores fields it doesn't model, like other overrides.
+          .withSizeBounds(overrides ?: base.overrides),
       // Recording sessions consume this on disk (`recordings/<recordingId>/...`); interactive
       // sessions pass `"interactive-$previewId"` and never read the field. The `recording-`
       // prefix is preserved for byte-compat with existing recording-test expectations.

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -1091,6 +1091,15 @@ class JsonRpcServer(
           // so a preview's `previewOverride*("title", …)` returns the requested value, not its
           // default.
           namedOverrides = overrides.namedOverrides,
+          // Min/max content-size bounds ride the bag so
+          // `renderNow.overrides.{min,max}{Width,Height}Px`
+          // reach the desktop `RenderEngine`, which clamps the wrap-layout measure to them (the
+          // Fixed / Max / Min / Within size modes). Fixed size stays on the `widthPx`/`heightPx`
+          // tokens above; these are the wrapped-axis bounds only, so no new fixed-frame token.
+          minWidthPx = overrides.minWidthPx,
+          minHeightPx = overrides.minHeightPx,
+          maxWidthPx = overrides.maxWidthPx,
+          maxHeightPx = overrides.maxHeightPx,
         )
       if (
         extensionBag.material3Theme != null ||
@@ -1098,7 +1107,11 @@ class JsonRpcServer(
           extensionBag.permissions != null ||
           extensionBag.gestures != null ||
           extensionBag.lottie != null ||
-          !extensionBag.namedOverrides.isNullOrEmpty()
+          !extensionBag.namedOverrides.isNullOrEmpty() ||
+          extensionBag.minWidthPx != null ||
+          extensionBag.minHeightPx != null ||
+          extensionBag.maxWidthPx != null ||
+          extensionBag.maxHeightPx != null
       ) {
         if (isNotEmpty()) append(';')
         append("overrides=")

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewOverrideMerge.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewOverrideMerge.kt
@@ -128,6 +128,32 @@ fun PreviewOverrides?.withThemeProvider(themeProvider: String?): PreviewOverride
   else (this ?: PreviewOverrides()).copy(themeProvider = themeProvider)
 
 /**
+ * Carry the wrapped-axis size bounds (the Max / Min / Within controls) onto a held-session
+ * overrides bag. Like `themeProvider`, these are **renderer-read** fields — the desktop
+ * `RenderEngine` reads `spec.overrides.{min,max}{Width,Height}Px` directly — so
+ * `toExtensionOverrides()` (the extension-only projection) drops them. Without this a live
+ * `stream/start` / `setOverrides` carrying a size-mode change would fall back to the unbounded
+ * wrap. Mirrors [withThemeProvider] and the `clearBackground` carry in each host's
+ * `applyOverrides`. A [source] with no bounds set is a no-op.
+ */
+fun PreviewOverrides?.withSizeBounds(source: PreviewOverrides?): PreviewOverrides? {
+  if (
+    source?.minWidthPx == null &&
+      source?.minHeightPx == null &&
+      source?.maxWidthPx == null &&
+      source?.maxHeightPx == null
+  ) {
+    return this
+  }
+  return (this ?: PreviewOverrides()).copy(
+    minWidthPx = source.minWidthPx,
+    minHeightPx = source.minHeightPx,
+    maxWidthPx = source.maxWidthPx,
+    maxHeightPx = source.maxHeightPx,
+  )
+}
+
+/**
  * Hard-coded duplicate of `Pseudolocale.fromTag(...) != null`. Inlined here so `:daemon:core` (the
  * protocol module) doesn't take a dependency on `:data-pseudolocale-core` just to gate the bag
  * projection in [MergedPreviewOverrides.toExtensionOverrides]. If new pseudolocale tags ever land,
@@ -165,6 +191,10 @@ fun PreviewOverrides?.layeredOver(base: PreviewOverrides?): PreviewOverrides? {
   return PreviewOverrides(
     widthPx = over.widthPx ?: base.widthPx,
     heightPx = over.heightPx ?: base.heightPx,
+    minWidthPx = over.minWidthPx ?: base.minWidthPx,
+    minHeightPx = over.minHeightPx ?: base.minHeightPx,
+    maxWidthPx = over.maxWidthPx ?: base.maxWidthPx,
+    maxHeightPx = over.maxHeightPx ?: base.maxHeightPx,
     density = over.density ?: base.density,
     localeTag = over.localeTag ?: base.localeTag,
     fontScale = over.fontScale ?: base.fontScale,

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -474,10 +474,28 @@ data class RenderNowParams(
  */
 @Serializable
 data class PreviewOverrides(
-  /** Sandbox width in pixels. Mirrors `@Preview(widthDp=…)` × density. */
+  /** Sandbox width in pixels. Mirrors `@Preview(widthDp=…)` × density. A *fixed* frame. */
   val widthPx: Int? = null,
-  /** Sandbox height in pixels. */
+  /** Sandbox height in pixels. A *fixed* frame. */
   val heightPx: Int? = null,
+  /**
+   * Minimum content width in pixels applied on a wrapped (no fixed [widthPx]) axis — the composable
+   * is measured with `minWidth = minWidthPx` so it is at least this wide, then the capture crops to
+   * the resulting intrinsic size. Combine with [maxWidthPx] for a bounded "within" range. Desktop
+   * honours it in the wrap-layout; backends that don't model a min bound ignore it.
+   */
+  val minWidthPx: Int? = null,
+  /** Minimum content height in pixels on a wrapped axis. See [minWidthPx]. */
+  val minHeightPx: Int? = null,
+  /**
+   * Maximum content width in pixels applied on a wrapped (no fixed [widthPx]) axis — the composable
+   * is measured against `maxWidth = maxWidthPx` (a smaller sandbox bound than the default), then
+   * the capture crops to the intrinsic size. Combine with [minWidthPx] for a bounded "within"
+   * range.
+   */
+  val maxWidthPx: Int? = null,
+  /** Maximum content height in pixels on a wrapped axis. See [maxWidthPx]. */
+  val maxHeightPx: Int? = null,
   /** Display density (1.0 = mdpi/160dpi, 2.0 = xhdpi/320dpi, etc.). */
   val density: Float? = null,
   /** BCP-47 locale tag (e.g. `"en-US"`, `"fr"`, `"ja-JP"`). */

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/PreviewOverrideMergeTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/PreviewOverrideMergeTest.kt
@@ -320,6 +320,30 @@ class PreviewOverrideMergeTest {
     assertEquals(existing, existing.withThemeProvider(null))
   }
 
+  @Test
+  fun `withSizeBounds carries the wrapped-axis bounds onto a null or existing held-session bag`() {
+    // toExtensionOverrides() drops the renderer-read size bounds, so the held/live path folds them
+    // back on. A null bag gains one carrying only the bounds.
+    val source = PreviewOverrides(minWidthPx = 120, maxWidthPx = 400, maxHeightPx = 800)
+    val fromNull = (null as PreviewOverrides?).withSizeBounds(source)
+    assertNotNull(fromNull)
+    assertEquals(120, fromNull!!.minWidthPx)
+    assertEquals(400, fromNull.maxWidthPx)
+    assertEquals(800, fromNull.maxHeightPx)
+    assertNull(fromNull.minHeightPx)
+
+    // An existing bag keeps its other fields and gains the bounds.
+    val existing = PreviewOverrides(themeProvider = "com.example.Brand")
+    val folded = existing.withSizeBounds(source)
+    assertEquals("com.example.Brand", folded?.themeProvider)
+    assertEquals(400, folded?.maxWidthPx)
+
+    // A source with no bounds set is a no-op — the held bag stays exactly as-is (including null).
+    assertNull((null as PreviewOverrides?).withSizeBounds(PreviewOverrides()))
+    assertNull((null as PreviewOverrides?).withSizeBounds(null))
+    assertEquals(existing, existing.withSizeBounds(PreviewOverrides(fontScale = 2f)))
+  }
+
   /**
    * Exhaustiveness guard for [layeredOver]: an empty overlay over a fully-populated base must
    * round-trip to the base unchanged. Every [PreviewOverrides] field is non-null here, so a field
@@ -373,6 +397,10 @@ class PreviewOverrideMergeTest {
     PreviewOverrides(
       widthPx = 111,
       heightPx = 222,
+      minWidthPx = 33,
+      minHeightPx = 44,
+      maxWidthPx = 555,
+      maxHeightPx = 666,
       density = 3.0f,
       localeTag = "fr-FR",
       fontScale = 1.4f,

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
@@ -199,6 +199,14 @@ open class DesktopHost(
   override val supportedOverrides: Set<String> = buildSet {
     add("widthPx")
     add("heightPx")
+    // Wrapped-axis content-size bounds (the viewer's Max / Min / Within size modes). The desktop
+    // `RenderEngine` clamps its wrap-content layout to these before the intrinsic-size crop, so a
+    // `renderNow.overrides.{min,max}{Width,Height}Px` IS applied, not silently ignored — advertise
+    // them so MCP / external clients don't hide or warn on the controls.
+    add("minWidthPx")
+    add("minHeightPx")
+    add("maxWidthPx")
+    add("maxHeightPx")
     add("density")
     if (RenderEngine.supportsLocaleTagOverride()) add("localeTag")
     add("fontScale")
@@ -603,7 +611,11 @@ open class DesktopHost(
       overrides =
         merged
           .toExtensionOverrides()
-          .withThemeProvider(overrides?.themeProvider ?: base.overrides?.themeProvider),
+          .withThemeProvider(overrides?.themeProvider ?: base.overrides?.themeProvider)
+          // Size bounds (Max / Min / Within) are renderer-read like themeProvider, so carry them
+          // through the held/live projection or a live size-mode change would drop to unbounded
+          // wrap.
+          .withSizeBounds(overrides ?: base.overrides),
       outputBaseName = "recording-$recordingId",
     )
   }

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -293,9 +293,23 @@ class RenderEngine(
           spec.previewId?.let { LottieProgressController.remember(it, p) }
         } ?: spec.previewId?.let { LottieProgressController.progressFor(it) }
       )
+    // Content-size bounds (the Max / Min / Within size modes) apply on a wrapped axis, where
+    // widthPx/heightPx are a sandbox bound rather than a fixed frame. A min bound larger than the
+    // default sandbox needs the scene enlarged to fit, otherwise the composable is clipped to the
+    // scene before the intrinsic-size crop runs. Only widen (never shrink) the scene here — the
+    // crop still trims the PNG back to the measured intrinsic size.
+    val sizeOverrides = spec.overrides
+    val sceneWidthPx =
+      if (spec.wrapWidth)
+        maxOf(spec.widthPx, sizeOverrides?.minWidthPx ?: 0, sizeOverrides?.maxWidthPx ?: 0)
+      else spec.widthPx
+    val sceneHeightPx =
+      if (spec.wrapHeight)
+        maxOf(spec.heightPx, sizeOverrides?.minHeightPx ?: 0, sizeOverrides?.maxHeightPx ?: 0)
+      else spec.heightPx
     val scene =
       try {
-        ImageComposeScene(width = spec.widthPx, height = spec.heightPx, density = density)
+        ImageComposeScene(width = sceneWidthPx, height = sceneHeightPx, density = density)
       } catch (t: Throwable) {
         // Ensure we don't leave the context classloader installed if scene allocation fails before
         // the SceneState is even handed back to the caller (caller never gets a chance to call
@@ -362,12 +376,29 @@ class RenderEngine(
               val boxModifier =
                 if (spec.wrapWidth || spec.wrapHeight) {
                   Modifier.layout { measurable, constraints ->
+                      // Size-mode bounds (Max / Min / Within) clamp the wrapped-axis measure: a max
+                      // bound lowers the sandbox ceiling so the composable can't grow past it; a
+                      // min
+                      // bound raises the floor so it can't collapse below it. Both are clamped to
+                      // the
+                      // scene's available space so a bound larger than the (already-enlarged) scene
+                      // can't produce an impossible constraint. Absent bounds keep the AS-parity
+                      // wrap
+                      // behaviour (min = 0, max = sandbox).
+                      val maxWBound =
+                        sizeOverrides?.maxWidthPx?.coerceAtMost(constraints.maxWidth)
+                          ?: constraints.maxWidth
+                      val maxHBound =
+                        sizeOverrides?.maxHeightPx?.coerceAtMost(constraints.maxHeight)
+                          ?: constraints.maxHeight
+                      val minWBound = (sizeOverrides?.minWidthPx ?: 0).coerceIn(0, maxWBound)
+                      val minHBound = (sizeOverrides?.minHeightPx ?: 0).coerceIn(0, maxHBound)
                       val wrapped =
                         androidx.compose.ui.unit.Constraints(
-                          minWidth = if (spec.wrapWidth) 0 else constraints.minWidth,
-                          maxWidth = constraints.maxWidth,
-                          minHeight = if (spec.wrapHeight) 0 else constraints.minHeight,
-                          maxHeight = constraints.maxHeight,
+                          minWidth = if (spec.wrapWidth) minWBound else constraints.minWidth,
+                          maxWidth = if (spec.wrapWidth) maxWBound else constraints.maxWidth,
+                          minHeight = if (spec.wrapHeight) minHBound else constraints.minHeight,
+                          maxHeight = if (spec.wrapHeight) maxHBound else constraints.maxHeight,
                         )
                       val placeable = measurable.measure(wrapped)
                       // Record the intrinsic size so renderOnce can crop the PNG to it on wrapped

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/RenderEngineWrapContentTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/RenderEngineWrapContentTest.kt
@@ -85,6 +85,101 @@ class RenderEngineWrapContentTest {
     return img.width to img.height
   }
 
+  /**
+   * Render the sticker fixture on a wrapped axis with the given size-bound overrides (the Fixed /
+   * Max / Min / Within controls). The sandbox bound stays generous (800×1600 like wrap-on) so the
+   * bound — not the frame — decides the measured intrinsic size the crop keeps.
+   */
+  private fun renderBounded(
+    engine: RenderEngine,
+    overrides: ee.schimke.composeai.daemon.protocol.PreviewOverrides,
+    baseName: String,
+  ): File {
+    val spec =
+      RenderSpec(
+        previewId = "sticker",
+        className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+        functionName = "WrapContentStickerPreview",
+        widthPx = 800,
+        heightPx = 1600,
+        wrapWidth = true,
+        wrapHeight = true,
+        density = 2.0f,
+        showBackground = true,
+        outputBaseName = baseName,
+        overrides = overrides,
+      )
+    val result = engine.render(spec, requestId = 1L, classLoader = javaClass.classLoader)
+    assertNotNull("pngPath must be populated", result.pngPath)
+    val png = File(result.pngPath!!)
+    assertTrue("rendered PNG must exist: ${png.absolutePath}", png.exists())
+    return png
+  }
+
+  /** Persist a size-mode render to `build/size-evidence/` for the PR's visual evidence. */
+  private fun keepEvidence(png: File, name: String) {
+    val evidenceDir = File("build/size-evidence").apply { mkdirs() }
+    png.copyTo(File(evidenceDir, "$name.png"), overwrite = true)
+  }
+
+  @Test
+  fun maxBoundCapsTheWrapCropBelowTheComponentsIntrinsicSize() {
+    val engine = RenderEngine(outputDir = tempFolder.newFolder("renders"))
+    // The sticker's intrinsic size is 176 px (56 dp badge + 16 dp padding each side, × density 2).
+    // A max bound of 100 px lowers the wrap ceiling below that, so the crop lands at the bound.
+    val png =
+      renderBounded(
+        engine,
+        ee.schimke.composeai.daemon.protocol.PreviewOverrides(maxWidthPx = 100, maxHeightPx = 100),
+        "sticker-max-100",
+      )
+    keepEvidence(png, "size-max-100")
+    val (w, h) = dims(png)
+    assertEquals("max width bound caps the crop", 100, w)
+    assertEquals("max height bound caps the crop", 100, h)
+  }
+
+  @Test
+  fun minBoundForcesTheWrapCropAboveTheComponentsIntrinsicSize() {
+    val engine = RenderEngine(outputDir = tempFolder.newFolder("renders"))
+    // A min bound of 400 px (> the 176 px intrinsic) forces the wrapped box to that floor, and the
+    // scene is enlarged to fit so the component isn't clipped before the crop.
+    val png =
+      renderBounded(
+        engine,
+        ee.schimke.composeai.daemon.protocol.PreviewOverrides(minWidthPx = 400, minHeightPx = 400),
+        "sticker-min-400",
+      )
+    keepEvidence(png, "size-min-400")
+    val (w, h) = dims(png)
+    assertEquals("min width bound raises the crop floor", 400, w)
+    assertEquals("min height bound raises the crop floor", 400, h)
+  }
+
+  @Test
+  fun withinBoundKeepsTheCropInsideTheMinMaxRange() {
+    val engine = RenderEngine(outputDir = tempFolder.newFolder("renders"))
+    // The 176 px intrinsic already sits inside [120, 400], so a "within" range leaves it unchanged
+    // —
+    // the bounds only bite when the component would fall outside them.
+    val png =
+      renderBounded(
+        engine,
+        ee.schimke.composeai.daemon.protocol.PreviewOverrides(
+          minWidthPx = 120,
+          minHeightPx = 120,
+          maxWidthPx = 400,
+          maxHeightPx = 400,
+        ),
+        "sticker-within-120-400",
+      )
+    keepEvidence(png, "size-within-120-400")
+    val (w, h) = dims(png)
+    assertTrue("width stays within the range (got $w)", w in 120..400)
+    assertTrue("height stays within the range (got $h)", h in 120..400)
+    assertEquals("unconstrained intrinsic is preserved inside the range", 176, w)
+  }
+
   @Test
   fun wrapContentCropsTheStreamFrameToMatchTheBakedSnapshot() {
     val engine = RenderEngine(outputDir = tempFolder.newFolder("renders"))

--- a/vscode-extension/preview-harness/fixtures/pages/serve-home-index.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-home-index.html
@@ -82,6 +82,11 @@ a:hover { text-decoration: underline; }
 .cp-note { font-size: 0.75rem; color: #6b6b70; line-height: 1.4; padding: 8px 10px;
   border-radius: 8px; background: #f4f4f6; }
 .cp-controls label:has(:disabled) { opacity: 0.55; }
+.cp-size { display: flex; flex-direction: column; gap: 8px; }
+/* :not([hidden]) so the mode toggle's `hidden` attribute still wins over this display rule. */
+.cp-size-row:not([hidden]) { display: flex; gap: 8px; }
+.cp-size-row label { flex: 1; }
+.cp-size-row input { width: 100%; box-sizing: border-box; }
 .cp-knobs { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
 .cp-knobs-head { font-size: 0.72rem; color: #6b6b70; }
 .cp-overlays { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-path.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-path.html
@@ -82,6 +82,11 @@ a:hover { text-decoration: underline; }
 .cp-note { font-size: 0.75rem; color: #6b6b70; line-height: 1.4; padding: 8px 10px;
   border-radius: 8px; background: #f4f4f6; }
 .cp-controls label:has(:disabled) { opacity: 0.55; }
+.cp-size { display: flex; flex-direction: column; gap: 8px; }
+/* :not([hidden]) so the mode toggle's `hidden` attribute still wins over this display rule. */
+.cp-size-row:not([hidden]) { display: flex; gap: 8px; }
+.cp-size-row label { flex: 1; }
+.cp-size-row input { width: 100%; box-sizing: border-box; }
 .cp-knobs { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
 .cp-knobs-head { font-size: 0.72rem; color: #6b6b70; }
 .cp-overlays { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-public.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-public.html
@@ -82,6 +82,11 @@ a:hover { text-decoration: underline; }
 .cp-note { font-size: 0.75rem; color: #6b6b70; line-height: 1.4; padding: 8px 10px;
   border-radius: 8px; background: #f4f4f6; }
 .cp-controls label:has(:disabled) { opacity: 0.55; }
+.cp-size { display: flex; flex-direction: column; gap: 8px; }
+/* :not([hidden]) so the mode toggle's `hidden` attribute still wins over this display rule. */
+.cp-size-row:not([hidden]) { display: flex; gap: 8px; }
+.cp-size-row label { flex: 1; }
+.cp-size-row input { width: 100%; box-sizing: border-box; }
 .cp-knobs { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
 .cp-knobs-head { font-size: 0.72rem; color: #6b6b70; }
 .cp-overlays { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-themed.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-themed.html
@@ -82,6 +82,11 @@ a:hover { text-decoration: underline; }
 .cp-note { font-size: 0.75rem; color: #6b6b70; line-height: 1.4; padding: 8px 10px;
   border-radius: 8px; background: #f4f4f6; }
 .cp-controls label:has(:disabled) { opacity: 0.55; }
+.cp-size { display: flex; flex-direction: column; gap: 8px; }
+/* :not([hidden]) so the mode toggle's `hidden` attribute still wins over this display rule. */
+.cp-size-row:not([hidden]) { display: flex; gap: 8px; }
+.cp-size-row label { flex: 1; }
+.cp-size-row input { width: 100%; box-sizing: border-box; }
 .cp-knobs { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
 .cp-knobs-head { font-size: 0.72rem; color: #6b6b70; }
 .cp-overlays { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing.html
@@ -82,6 +82,11 @@ a:hover { text-decoration: underline; }
 .cp-note { font-size: 0.75rem; color: #6b6b70; line-height: 1.4; padding: 8px 10px;
   border-radius: 8px; background: #f4f4f6; }
 .cp-controls label:has(:disabled) { opacity: 0.55; }
+.cp-size { display: flex; flex-direction: column; gap: 8px; }
+/* :not([hidden]) so the mode toggle's `hidden` attribute still wins over this display rule. */
+.cp-size-row:not([hidden]) { display: flex; gap: 8px; }
+.cp-size-row label { flex: 1; }
+.cp-size-row input { width: 100%; box-sizing: border-box; }
 .cp-knobs { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
 .cp-knobs-head { font-size: 0.72rem; color: #6b6b70; }
 .cp-overlays { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
@@ -82,6 +82,11 @@ a:hover { text-decoration: underline; }
 .cp-note { font-size: 0.75rem; color: #6b6b70; line-height: 1.4; padding: 8px 10px;
   border-radius: 8px; background: #f4f4f6; }
 .cp-controls label:has(:disabled) { opacity: 0.55; }
+.cp-size { display: flex; flex-direction: column; gap: 8px; }
+/* :not([hidden]) so the mode toggle's `hidden` attribute still wins over this display rule. */
+.cp-size-row:not([hidden]) { display: flex; gap: 8px; }
+.cp-size-row label { flex: 1; }
+.cp-size-row input { width: 100%; box-sizing: border-box; }
 .cp-knobs { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
 .cp-knobs-head { font-size: 0.72rem; color: #6b6b70; }
 .cp-overlays { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
@@ -226,6 +231,29 @@ a:hover { text-decoration: underline; }
               <option value="clear">Clear (crisp outline)</option>
             </select>
           </label>
+          <div class="cp-size">
+            <label>Size
+              <select id="cp-sizeMode" disabled>
+                <option value="">(default)</option>
+                <option value="fixed">Fixed size</option>
+                <option value="max">Max</option>
+                <option value="min">Min</option>
+                <option value="within">Within (min–max)</option>
+              </select>
+            </label>
+            <div class="cp-size-row" id="cp-size-fixed" hidden>
+              <label>Width (px)<input id="cp-fixedW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
+              <label>Height (px)<input id="cp-fixedH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
+            </div>
+            <div class="cp-size-row" id="cp-size-min" hidden>
+              <label>Min width (px)<input id="cp-minW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
+              <label>Min height (px)<input id="cp-minH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
+            </div>
+            <div class="cp-size-row" id="cp-size-max" hidden>
+              <label>Max width (px)<input id="cp-maxW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
+              <label>Max height (px)<input id="cp-maxH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
+            </div>
+          </div>
           <div class="cp-overlays">
   <div class="cp-overlays-head">Overlays (Live Compose)</div>
   <label class="cp-live-row"><input class="cp-overlay" id="cp-talkBack" type="checkbox" disabled> Accessibility (TalkBack)</label>
@@ -358,6 +386,33 @@ a:hover { text-decoration: underline; }
   // the copyable links read it so a re-render / copied URL matches the on-screen format.
   var snapshotExt = ".png";
 
+  // Size overrides (the Fixed / Max / Min / Within modes). Which query params carry the numbers
+  // is chosen by the mode: Fixed pins the frame via widthPx/heightPx; Max / Min / Within are
+  // wrapped-axis bounds (maxWidthPx / minWidthPx …). Blank inputs are omitted, so one axis can be
+  // bounded without the other. Server-side only (a daemon re-measures) — the inputs are
+  // disabled on a static snapshot like Device/Orientation, so it never emits them.
+  function sizeVal(id) {
+    var el = document.getElementById(id);
+    return el && el.value ? el.value : null;
+  }
+  function sizeOverrides() {
+    var mode = document.getElementById("cp-sizeMode");
+    var o = {};
+    if (!mode || !mode.value) return o;
+    if (mode.value === "fixed") {
+      if (sizeVal("cp-fixedW")) o.widthPx = sizeVal("cp-fixedW");
+      if (sizeVal("cp-fixedH")) o.heightPx = sizeVal("cp-fixedH");
+    }
+    if (mode.value === "min" || mode.value === "within") {
+      if (sizeVal("cp-minW")) o.minWidthPx = sizeVal("cp-minW");
+      if (sizeVal("cp-minH")) o.minHeightPx = sizeVal("cp-minH");
+    }
+    if (mode.value === "max" || mode.value === "within") {
+      if (sizeVal("cp-maxW")) o.maxWidthPx = sizeVal("cp-maxW");
+      if (sizeVal("cp-maxH")) o.maxHeightPx = sizeVal("cp-maxH");
+    }
+    return o;
+  }
   function overrides() {
     var o = {};
     fields.forEach(function (f) {
@@ -365,6 +420,8 @@ a:hover { text-decoration: underline; }
       if (el && el.value) o[f] = el.value;
     });
     if (fontScaleTouched && fs) o.fontScale = fs.value;
+    var size = sizeOverrides();
+    Object.keys(size).forEach(function (k) { o[k] = size[k]; });
     return o;
   }
   // The live-stream override map: the display fields PLUS the author-declared knob values as
@@ -945,6 +1002,26 @@ a:hover { text-decoration: underline; }
     var el = document.getElementById("cp-" + f);
     if (el) el.addEventListener("change", onControlsChanged);
   });
+  // Size mode: show only the input rows the chosen mode uses (Within shows both min + max), then
+  // re-render. The number inputs re-render on "input" (live typing) like the locale field.
+  var sizeMode = document.getElementById("cp-sizeMode");
+  if (sizeMode) {
+    var syncSizeRows = function () {
+      var m = sizeMode.value;
+      var show = { fixed: m === "fixed", min: m === "min" || m === "within",
+        max: m === "max" || m === "within" };
+      ["fixed", "min", "max"].forEach(function (g) {
+        var row = document.getElementById("cp-size-" + g);
+        if (row) row.hidden = !show[g];
+      });
+    };
+    syncSizeRows();
+    sizeMode.addEventListener("change", function () { syncSizeRows(); onControlsChanged(); });
+    ["cp-fixedW", "cp-fixedH", "cp-minW", "cp-minH", "cp-maxW", "cp-maxH"].forEach(function (id) {
+      var el = document.getElementById(id);
+      if (el) el.addEventListener("input", onControlsChanged);
+    });
+  }
   // Overlay toggles are live-only: they push a fresh setOverrides through the open stream and do
   // nothing otherwise. They get their own handler rather than onControlsChanged so a toggle mid
   // connect (ws not yet readyState 1) can't fall through to the snapshot / wasm-auto-enable

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
@@ -174,7 +174,7 @@ a:hover { text-decoration: underline; }
         
         <button type="button" class="cp-drawer-toggle" id="cp-controls-toggle" aria-expanded="true" aria-controls="cp-controls">⚙ Overrides</button>
       </div>
-      <div class="cp-viewer cp-controls-open" data-preview-id="button-filled__ideal__default__light" data-mode="snapshot" data-modes="snapshot" data-static-snapshot="true" data-can-render-overrides="true" data-snapshot-backend="Snapshot" data-live-backend="Live" data-wasm-src="/wasm/compose-m3/?id=button-filled">
+      <div class="cp-viewer cp-controls-open" data-preview-id="button-filled__ideal__default__light" data-mode="snapshot" data-modes="snapshot" data-static-snapshot="true" data-can-render-overrides="true" data-snapshot-backend="Snapshot" data-live-backend="Live" data-render-density="2" data-wasm-src="/wasm/compose-m3/?id=button-filled">
         
         <div class="cp-stage"><span class="cp-backend" id="cp-backend"></span><img id="cp-img" alt="Button · Filled (light)"><canvas id="cp-canvas" hidden></canvas><iframe id="cp-wasm" hidden sandbox="allow-scripts allow-same-origin" title="Button · Filled (light) (Wasm)"></iframe></div>
         <div class="cp-controls" id="cp-controls">
@@ -242,16 +242,16 @@ a:hover { text-decoration: underline; }
               </select>
             </label>
             <div class="cp-size-row" id="cp-size-fixed" hidden>
-              <label>Width (px)<input id="cp-fixedW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
-              <label>Height (px)<input id="cp-fixedH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
+              <label>Width (dp)<input id="cp-fixedW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
+              <label>Height (dp)<input id="cp-fixedH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
             </div>
             <div class="cp-size-row" id="cp-size-min" hidden>
-              <label>Min width (px)<input id="cp-minW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
-              <label>Min height (px)<input id="cp-minH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
+              <label>Min width (dp)<input id="cp-minW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
+              <label>Min height (dp)<input id="cp-minH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
             </div>
             <div class="cp-size-row" id="cp-size-max" hidden>
-              <label>Max width (px)<input id="cp-maxW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
-              <label>Max height (px)<input id="cp-maxH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
+              <label>Max width (dp)<input id="cp-maxW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
+              <label>Max height (dp)<input id="cp-maxH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
             </div>
           </div>
           <div class="cp-overlays">
@@ -391,25 +391,34 @@ a:hover { text-decoration: underline; }
   // wrapped-axis bounds (maxWidthPx / minWidthPx …). Blank inputs are omitted, so one axis can be
   // bounded without the other. Server-side only (a daemon re-measures) — the inputs are
   // disabled on a static snapshot like Device/Orientation, so it never emits them.
-  function sizeVal(id) {
+  //
+  // The inputs are authored in dp (the Compose unit); the wire stays in px like every other
+  // override, so a dp value is multiplied by the backend's render density before it's sent (and
+  // the copyable /render URL stays px-consistent). data-render-density carries the factor.
+  var renderDensity = parseFloat(root.getAttribute("data-render-density")) || 2;
+  // dp (string from the input) → a positive integer px value, or null when blank/non-positive.
+  function sizePx(id) {
     var el = document.getElementById(id);
-    return el && el.value ? el.value : null;
+    if (!el || !el.value) return null;
+    var dp = parseFloat(el.value);
+    if (!(dp > 0)) return null;
+    return String(Math.max(1, Math.round(dp * renderDensity)));
   }
   function sizeOverrides() {
     var mode = document.getElementById("cp-sizeMode");
     var o = {};
     if (!mode || !mode.value) return o;
     if (mode.value === "fixed") {
-      if (sizeVal("cp-fixedW")) o.widthPx = sizeVal("cp-fixedW");
-      if (sizeVal("cp-fixedH")) o.heightPx = sizeVal("cp-fixedH");
+      if (sizePx("cp-fixedW")) o.widthPx = sizePx("cp-fixedW");
+      if (sizePx("cp-fixedH")) o.heightPx = sizePx("cp-fixedH");
     }
     if (mode.value === "min" || mode.value === "within") {
-      if (sizeVal("cp-minW")) o.minWidthPx = sizeVal("cp-minW");
-      if (sizeVal("cp-minH")) o.minHeightPx = sizeVal("cp-minH");
+      if (sizePx("cp-minW")) o.minWidthPx = sizePx("cp-minW");
+      if (sizePx("cp-minH")) o.minHeightPx = sizePx("cp-minH");
     }
     if (mode.value === "max" || mode.value === "within") {
-      if (sizeVal("cp-maxW")) o.maxWidthPx = sizeVal("cp-maxW");
-      if (sizeVal("cp-maxH")) o.maxHeightPx = sizeVal("cp-maxH");
+      if (sizePx("cp-maxW")) o.maxWidthPx = sizePx("cp-maxW");
+      if (sizePx("cp-maxH")) o.maxHeightPx = sizePx("cp-maxH");
     }
     return o;
   }

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-focus.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-focus.html
@@ -174,7 +174,7 @@ a:hover { text-decoration: underline; }
         
         <button type="button" class="cp-drawer-toggle" id="cp-controls-toggle" aria-expanded="true" aria-controls="cp-controls">⚙ Overrides</button>
       </div>
-      <div class="cp-viewer cp-controls-open" data-preview-id="com.example.FocusRingPreview" data-mode="snapshot" data-modes="snapshot" data-static-snapshot="false" data-can-render-overrides="true" data-snapshot-backend="Snapshot" data-live-backend="Live">
+      <div class="cp-viewer cp-controls-open" data-preview-id="com.example.FocusRingPreview" data-mode="snapshot" data-modes="snapshot" data-static-snapshot="false" data-can-render-overrides="true" data-snapshot-backend="Snapshot" data-live-backend="Live" data-render-density="2">
         
         <div class="cp-stage"><span class="cp-backend" id="cp-backend"></span><img id="cp-img" alt="Focus ring"><canvas id="cp-canvas" hidden></canvas></div>
         <div class="cp-controls" id="cp-controls">
@@ -235,16 +235,16 @@ a:hover { text-decoration: underline; }
               </select>
             </label>
             <div class="cp-size-row" id="cp-size-fixed" hidden>
-              <label>Width (px)<input id="cp-fixedW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"></label>
-              <label>Height (px)<input id="cp-fixedH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"></label>
+              <label>Width (dp)<input id="cp-fixedW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"></label>
+              <label>Height (dp)<input id="cp-fixedH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"></label>
             </div>
             <div class="cp-size-row" id="cp-size-min" hidden>
-              <label>Min width (px)<input id="cp-minW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"></label>
-              <label>Min height (px)<input id="cp-minH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"></label>
+              <label>Min width (dp)<input id="cp-minW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"></label>
+              <label>Min height (dp)<input id="cp-minH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"></label>
             </div>
             <div class="cp-size-row" id="cp-size-max" hidden>
-              <label>Max width (px)<input id="cp-maxW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"></label>
-              <label>Max height (px)<input id="cp-maxH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"></label>
+              <label>Max width (dp)<input id="cp-maxW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"></label>
+              <label>Max height (dp)<input id="cp-maxH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"></label>
             </div>
           </div>
           <div class="cp-overlays">
@@ -374,25 +374,34 @@ a:hover { text-decoration: underline; }
   // wrapped-axis bounds (maxWidthPx / minWidthPx …). Blank inputs are omitted, so one axis can be
   // bounded without the other. Server-side only (a daemon re-measures) — the inputs are
   // disabled on a static snapshot like Device/Orientation, so it never emits them.
-  function sizeVal(id) {
+  //
+  // The inputs are authored in dp (the Compose unit); the wire stays in px like every other
+  // override, so a dp value is multiplied by the backend's render density before it's sent (and
+  // the copyable /render URL stays px-consistent). data-render-density carries the factor.
+  var renderDensity = parseFloat(root.getAttribute("data-render-density")) || 2;
+  // dp (string from the input) → a positive integer px value, or null when blank/non-positive.
+  function sizePx(id) {
     var el = document.getElementById(id);
-    return el && el.value ? el.value : null;
+    if (!el || !el.value) return null;
+    var dp = parseFloat(el.value);
+    if (!(dp > 0)) return null;
+    return String(Math.max(1, Math.round(dp * renderDensity)));
   }
   function sizeOverrides() {
     var mode = document.getElementById("cp-sizeMode");
     var o = {};
     if (!mode || !mode.value) return o;
     if (mode.value === "fixed") {
-      if (sizeVal("cp-fixedW")) o.widthPx = sizeVal("cp-fixedW");
-      if (sizeVal("cp-fixedH")) o.heightPx = sizeVal("cp-fixedH");
+      if (sizePx("cp-fixedW")) o.widthPx = sizePx("cp-fixedW");
+      if (sizePx("cp-fixedH")) o.heightPx = sizePx("cp-fixedH");
     }
     if (mode.value === "min" || mode.value === "within") {
-      if (sizeVal("cp-minW")) o.minWidthPx = sizeVal("cp-minW");
-      if (sizeVal("cp-minH")) o.minHeightPx = sizeVal("cp-minH");
+      if (sizePx("cp-minW")) o.minWidthPx = sizePx("cp-minW");
+      if (sizePx("cp-minH")) o.minHeightPx = sizePx("cp-minH");
     }
     if (mode.value === "max" || mode.value === "within") {
-      if (sizeVal("cp-maxW")) o.maxWidthPx = sizeVal("cp-maxW");
-      if (sizeVal("cp-maxH")) o.maxHeightPx = sizeVal("cp-maxH");
+      if (sizePx("cp-maxW")) o.maxWidthPx = sizePx("cp-maxW");
+      if (sizePx("cp-maxH")) o.maxHeightPx = sizePx("cp-maxH");
     }
     return o;
   }

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-focus.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-focus.html
@@ -82,6 +82,11 @@ a:hover { text-decoration: underline; }
 .cp-note { font-size: 0.75rem; color: #6b6b70; line-height: 1.4; padding: 8px 10px;
   border-radius: 8px; background: #f4f4f6; }
 .cp-controls label:has(:disabled) { opacity: 0.55; }
+.cp-size { display: flex; flex-direction: column; gap: 8px; }
+/* :not([hidden]) so the mode toggle's `hidden` attribute still wins over this display rule. */
+.cp-size-row:not([hidden]) { display: flex; gap: 8px; }
+.cp-size-row label { flex: 1; }
+.cp-size-row input { width: 100%; box-sizing: border-box; }
 .cp-knobs { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
 .cp-knobs-head { font-size: 0.72rem; color: #6b6b70; }
 .cp-overlays { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
@@ -219,6 +224,29 @@ a:hover { text-decoration: underline; }
               <option value="clear">Clear (crisp outline)</option>
             </select>
           </label>
+          <div class="cp-size">
+            <label>Size
+              <select id="cp-sizeMode">
+                <option value="">(default)</option>
+                <option value="fixed">Fixed size</option>
+                <option value="max">Max</option>
+                <option value="min">Min</option>
+                <option value="within">Within (min–max)</option>
+              </select>
+            </label>
+            <div class="cp-size-row" id="cp-size-fixed" hidden>
+              <label>Width (px)<input id="cp-fixedW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"></label>
+              <label>Height (px)<input id="cp-fixedH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"></label>
+            </div>
+            <div class="cp-size-row" id="cp-size-min" hidden>
+              <label>Min width (px)<input id="cp-minW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"></label>
+              <label>Min height (px)<input id="cp-minH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"></label>
+            </div>
+            <div class="cp-size-row" id="cp-size-max" hidden>
+              <label>Max width (px)<input id="cp-maxW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"></label>
+              <label>Max height (px)<input id="cp-maxH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"></label>
+            </div>
+          </div>
           <div class="cp-overlays">
   <div class="cp-overlays-head">Overlays (Live Compose)</div>
   <label class="cp-live-row"><input class="cp-overlay" id="cp-talkBack" type="checkbox" disabled> Accessibility (TalkBack)</label>
@@ -341,6 +369,33 @@ a:hover { text-decoration: underline; }
   // the copyable links read it so a re-render / copied URL matches the on-screen format.
   var snapshotExt = ".png";
 
+  // Size overrides (the Fixed / Max / Min / Within modes). Which query params carry the numbers
+  // is chosen by the mode: Fixed pins the frame via widthPx/heightPx; Max / Min / Within are
+  // wrapped-axis bounds (maxWidthPx / minWidthPx …). Blank inputs are omitted, so one axis can be
+  // bounded without the other. Server-side only (a daemon re-measures) — the inputs are
+  // disabled on a static snapshot like Device/Orientation, so it never emits them.
+  function sizeVal(id) {
+    var el = document.getElementById(id);
+    return el && el.value ? el.value : null;
+  }
+  function sizeOverrides() {
+    var mode = document.getElementById("cp-sizeMode");
+    var o = {};
+    if (!mode || !mode.value) return o;
+    if (mode.value === "fixed") {
+      if (sizeVal("cp-fixedW")) o.widthPx = sizeVal("cp-fixedW");
+      if (sizeVal("cp-fixedH")) o.heightPx = sizeVal("cp-fixedH");
+    }
+    if (mode.value === "min" || mode.value === "within") {
+      if (sizeVal("cp-minW")) o.minWidthPx = sizeVal("cp-minW");
+      if (sizeVal("cp-minH")) o.minHeightPx = sizeVal("cp-minH");
+    }
+    if (mode.value === "max" || mode.value === "within") {
+      if (sizeVal("cp-maxW")) o.maxWidthPx = sizeVal("cp-maxW");
+      if (sizeVal("cp-maxH")) o.maxHeightPx = sizeVal("cp-maxH");
+    }
+    return o;
+  }
   function overrides() {
     var o = {};
     fields.forEach(function (f) {
@@ -348,6 +403,8 @@ a:hover { text-decoration: underline; }
       if (el && el.value) o[f] = el.value;
     });
     if (fontScaleTouched && fs) o.fontScale = fs.value;
+    var size = sizeOverrides();
+    Object.keys(size).forEach(function (k) { o[k] = size[k]; });
     return o;
   }
   // The live-stream override map: the display fields PLUS the author-declared knob values as
@@ -928,6 +985,26 @@ a:hover { text-decoration: underline; }
     var el = document.getElementById("cp-" + f);
     if (el) el.addEventListener("change", onControlsChanged);
   });
+  // Size mode: show only the input rows the chosen mode uses (Within shows both min + max), then
+  // re-render. The number inputs re-render on "input" (live typing) like the locale field.
+  var sizeMode = document.getElementById("cp-sizeMode");
+  if (sizeMode) {
+    var syncSizeRows = function () {
+      var m = sizeMode.value;
+      var show = { fixed: m === "fixed", min: m === "min" || m === "within",
+        max: m === "max" || m === "within" };
+      ["fixed", "min", "max"].forEach(function (g) {
+        var row = document.getElementById("cp-size-" + g);
+        if (row) row.hidden = !show[g];
+      });
+    };
+    syncSizeRows();
+    sizeMode.addEventListener("change", function () { syncSizeRows(); onControlsChanged(); });
+    ["cp-fixedW", "cp-fixedH", "cp-minW", "cp-minH", "cp-maxW", "cp-maxH"].forEach(function (id) {
+      var el = document.getElementById(id);
+      if (el) el.addEventListener("input", onControlsChanged);
+    });
+  }
   // Overlay toggles are live-only: they push a fresh setOverrides through the open stream and do
   // nothing otherwise. They get their own handler rather than onControlsChanged so a toggle mid
   // connect (ws not yet readyState 1) can't fall through to the snapshot / wasm-auto-enable

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-gestures.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-gestures.html
@@ -82,6 +82,11 @@ a:hover { text-decoration: underline; }
 .cp-note { font-size: 0.75rem; color: #6b6b70; line-height: 1.4; padding: 8px 10px;
   border-radius: 8px; background: #f4f4f6; }
 .cp-controls label:has(:disabled) { opacity: 0.55; }
+.cp-size { display: flex; flex-direction: column; gap: 8px; }
+/* :not([hidden]) so the mode toggle's `hidden` attribute still wins over this display rule. */
+.cp-size-row:not([hidden]) { display: flex; gap: 8px; }
+.cp-size-row label { flex: 1; }
+.cp-size-row input { width: 100%; box-sizing: border-box; }
 .cp-knobs { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
 .cp-knobs-head { font-size: 0.72rem; color: #6b6b70; }
 .cp-overlays { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
@@ -219,6 +224,29 @@ a:hover { text-decoration: underline; }
               <option value="clear">Clear (crisp outline)</option>
             </select>
           </label>
+          <div class="cp-size">
+            <label>Size
+              <select id="cp-sizeMode">
+                <option value="">(default)</option>
+                <option value="fixed">Fixed size</option>
+                <option value="max">Max</option>
+                <option value="min">Min</option>
+                <option value="within">Within (min–max)</option>
+              </select>
+            </label>
+            <div class="cp-size-row" id="cp-size-fixed" hidden>
+              <label>Width (px)<input id="cp-fixedW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"></label>
+              <label>Height (px)<input id="cp-fixedH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"></label>
+            </div>
+            <div class="cp-size-row" id="cp-size-min" hidden>
+              <label>Min width (px)<input id="cp-minW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"></label>
+              <label>Min height (px)<input id="cp-minH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"></label>
+            </div>
+            <div class="cp-size-row" id="cp-size-max" hidden>
+              <label>Max width (px)<input id="cp-maxW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"></label>
+              <label>Max height (px)<input id="cp-maxH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"></label>
+            </div>
+          </div>
           <div class="cp-overlays">
   <div class="cp-overlays-head">Overlays (Live Compose)</div>
   <label class="cp-live-row"><input class="cp-overlay" id="cp-talkBack" type="checkbox" disabled> Accessibility (TalkBack)</label>
@@ -341,6 +369,33 @@ a:hover { text-decoration: underline; }
   // the copyable links read it so a re-render / copied URL matches the on-screen format.
   var snapshotExt = ".png";
 
+  // Size overrides (the Fixed / Max / Min / Within modes). Which query params carry the numbers
+  // is chosen by the mode: Fixed pins the frame via widthPx/heightPx; Max / Min / Within are
+  // wrapped-axis bounds (maxWidthPx / minWidthPx …). Blank inputs are omitted, so one axis can be
+  // bounded without the other. Server-side only (a daemon re-measures) — the inputs are
+  // disabled on a static snapshot like Device/Orientation, so it never emits them.
+  function sizeVal(id) {
+    var el = document.getElementById(id);
+    return el && el.value ? el.value : null;
+  }
+  function sizeOverrides() {
+    var mode = document.getElementById("cp-sizeMode");
+    var o = {};
+    if (!mode || !mode.value) return o;
+    if (mode.value === "fixed") {
+      if (sizeVal("cp-fixedW")) o.widthPx = sizeVal("cp-fixedW");
+      if (sizeVal("cp-fixedH")) o.heightPx = sizeVal("cp-fixedH");
+    }
+    if (mode.value === "min" || mode.value === "within") {
+      if (sizeVal("cp-minW")) o.minWidthPx = sizeVal("cp-minW");
+      if (sizeVal("cp-minH")) o.minHeightPx = sizeVal("cp-minH");
+    }
+    if (mode.value === "max" || mode.value === "within") {
+      if (sizeVal("cp-maxW")) o.maxWidthPx = sizeVal("cp-maxW");
+      if (sizeVal("cp-maxH")) o.maxHeightPx = sizeVal("cp-maxH");
+    }
+    return o;
+  }
   function overrides() {
     var o = {};
     fields.forEach(function (f) {
@@ -348,6 +403,8 @@ a:hover { text-decoration: underline; }
       if (el && el.value) o[f] = el.value;
     });
     if (fontScaleTouched && fs) o.fontScale = fs.value;
+    var size = sizeOverrides();
+    Object.keys(size).forEach(function (k) { o[k] = size[k]; });
     return o;
   }
   // The live-stream override map: the display fields PLUS the author-declared knob values as
@@ -928,6 +985,26 @@ a:hover { text-decoration: underline; }
     var el = document.getElementById("cp-" + f);
     if (el) el.addEventListener("change", onControlsChanged);
   });
+  // Size mode: show only the input rows the chosen mode uses (Within shows both min + max), then
+  // re-render. The number inputs re-render on "input" (live typing) like the locale field.
+  var sizeMode = document.getElementById("cp-sizeMode");
+  if (sizeMode) {
+    var syncSizeRows = function () {
+      var m = sizeMode.value;
+      var show = { fixed: m === "fixed", min: m === "min" || m === "within",
+        max: m === "max" || m === "within" };
+      ["fixed", "min", "max"].forEach(function (g) {
+        var row = document.getElementById("cp-size-" + g);
+        if (row) row.hidden = !show[g];
+      });
+    };
+    syncSizeRows();
+    sizeMode.addEventListener("change", function () { syncSizeRows(); onControlsChanged(); });
+    ["cp-fixedW", "cp-fixedH", "cp-minW", "cp-minH", "cp-maxW", "cp-maxH"].forEach(function (id) {
+      var el = document.getElementById(id);
+      if (el) el.addEventListener("input", onControlsChanged);
+    });
+  }
   // Overlay toggles are live-only: they push a fresh setOverrides through the open stream and do
   // nothing otherwise. They get their own handler rather than onControlsChanged so a toggle mid
   // connect (ws not yet readyState 1) can't fall through to the snapshot / wasm-auto-enable

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-gestures.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-gestures.html
@@ -174,7 +174,7 @@ a:hover { text-decoration: underline; }
         
         <button type="button" class="cp-drawer-toggle" id="cp-controls-toggle" aria-expanded="true" aria-controls="cp-controls">⚙ Overrides</button>
       </div>
-      <div class="cp-viewer cp-controls-open" data-preview-id="com.example.OneHandedPreview" data-mode="snapshot" data-modes="snapshot" data-static-snapshot="false" data-can-render-overrides="true" data-snapshot-backend="Snapshot" data-live-backend="Live">
+      <div class="cp-viewer cp-controls-open" data-preview-id="com.example.OneHandedPreview" data-mode="snapshot" data-modes="snapshot" data-static-snapshot="false" data-can-render-overrides="true" data-snapshot-backend="Snapshot" data-live-backend="Live" data-render-density="2">
         
         <div class="cp-stage"><span class="cp-backend" id="cp-backend"></span><img id="cp-img" alt="One-handed"><canvas id="cp-canvas" hidden></canvas></div>
         <div class="cp-controls" id="cp-controls">
@@ -235,16 +235,16 @@ a:hover { text-decoration: underline; }
               </select>
             </label>
             <div class="cp-size-row" id="cp-size-fixed" hidden>
-              <label>Width (px)<input id="cp-fixedW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"></label>
-              <label>Height (px)<input id="cp-fixedH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"></label>
+              <label>Width (dp)<input id="cp-fixedW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"></label>
+              <label>Height (dp)<input id="cp-fixedH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"></label>
             </div>
             <div class="cp-size-row" id="cp-size-min" hidden>
-              <label>Min width (px)<input id="cp-minW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"></label>
-              <label>Min height (px)<input id="cp-minH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"></label>
+              <label>Min width (dp)<input id="cp-minW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"></label>
+              <label>Min height (dp)<input id="cp-minH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"></label>
             </div>
             <div class="cp-size-row" id="cp-size-max" hidden>
-              <label>Max width (px)<input id="cp-maxW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"></label>
-              <label>Max height (px)<input id="cp-maxH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"></label>
+              <label>Max width (dp)<input id="cp-maxW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"></label>
+              <label>Max height (dp)<input id="cp-maxH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"></label>
             </div>
           </div>
           <div class="cp-overlays">
@@ -374,25 +374,34 @@ a:hover { text-decoration: underline; }
   // wrapped-axis bounds (maxWidthPx / minWidthPx …). Blank inputs are omitted, so one axis can be
   // bounded without the other. Server-side only (a daemon re-measures) — the inputs are
   // disabled on a static snapshot like Device/Orientation, so it never emits them.
-  function sizeVal(id) {
+  //
+  // The inputs are authored in dp (the Compose unit); the wire stays in px like every other
+  // override, so a dp value is multiplied by the backend's render density before it's sent (and
+  // the copyable /render URL stays px-consistent). data-render-density carries the factor.
+  var renderDensity = parseFloat(root.getAttribute("data-render-density")) || 2;
+  // dp (string from the input) → a positive integer px value, or null when blank/non-positive.
+  function sizePx(id) {
     var el = document.getElementById(id);
-    return el && el.value ? el.value : null;
+    if (!el || !el.value) return null;
+    var dp = parseFloat(el.value);
+    if (!(dp > 0)) return null;
+    return String(Math.max(1, Math.round(dp * renderDensity)));
   }
   function sizeOverrides() {
     var mode = document.getElementById("cp-sizeMode");
     var o = {};
     if (!mode || !mode.value) return o;
     if (mode.value === "fixed") {
-      if (sizeVal("cp-fixedW")) o.widthPx = sizeVal("cp-fixedW");
-      if (sizeVal("cp-fixedH")) o.heightPx = sizeVal("cp-fixedH");
+      if (sizePx("cp-fixedW")) o.widthPx = sizePx("cp-fixedW");
+      if (sizePx("cp-fixedH")) o.heightPx = sizePx("cp-fixedH");
     }
     if (mode.value === "min" || mode.value === "within") {
-      if (sizeVal("cp-minW")) o.minWidthPx = sizeVal("cp-minW");
-      if (sizeVal("cp-minH")) o.minHeightPx = sizeVal("cp-minH");
+      if (sizePx("cp-minW")) o.minWidthPx = sizePx("cp-minW");
+      if (sizePx("cp-minH")) o.minHeightPx = sizePx("cp-minH");
     }
     if (mode.value === "max" || mode.value === "within") {
-      if (sizeVal("cp-maxW")) o.maxWidthPx = sizeVal("cp-maxW");
-      if (sizeVal("cp-maxH")) o.maxHeightPx = sizeVal("cp-maxH");
+      if (sizePx("cp-maxW")) o.maxWidthPx = sizePx("cp-maxW");
+      if (sizePx("cp-maxH")) o.maxHeightPx = sizePx("cp-maxH");
     }
     return o;
   }

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
@@ -82,6 +82,11 @@ a:hover { text-decoration: underline; }
 .cp-note { font-size: 0.75rem; color: #6b6b70; line-height: 1.4; padding: 8px 10px;
   border-radius: 8px; background: #f4f4f6; }
 .cp-controls label:has(:disabled) { opacity: 0.55; }
+.cp-size { display: flex; flex-direction: column; gap: 8px; }
+/* :not([hidden]) so the mode toggle's `hidden` attribute still wins over this display rule. */
+.cp-size-row:not([hidden]) { display: flex; gap: 8px; }
+.cp-size-row label { flex: 1; }
+.cp-size-row input { width: 100%; box-sizing: border-box; }
 .cp-knobs { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
 .cp-knobs-head { font-size: 0.72rem; color: #6b6b70; }
 .cp-overlays { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
@@ -231,6 +236,29 @@ a:hover { text-decoration: underline; }
               <option value="clear">Clear (crisp outline)</option>
             </select>
           </label>
+          <div class="cp-size">
+            <label>Size
+              <select id="cp-sizeMode" disabled>
+                <option value="">(default)</option>
+                <option value="fixed">Fixed size</option>
+                <option value="max">Max</option>
+                <option value="min">Min</option>
+                <option value="within">Within (min–max)</option>
+              </select>
+            </label>
+            <div class="cp-size-row" id="cp-size-fixed" hidden>
+              <label>Width (px)<input id="cp-fixedW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
+              <label>Height (px)<input id="cp-fixedH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
+            </div>
+            <div class="cp-size-row" id="cp-size-min" hidden>
+              <label>Min width (px)<input id="cp-minW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
+              <label>Min height (px)<input id="cp-minH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
+            </div>
+            <div class="cp-size-row" id="cp-size-max" hidden>
+              <label>Max width (px)<input id="cp-maxW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
+              <label>Max height (px)<input id="cp-maxH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
+            </div>
+          </div>
           
           
           
@@ -345,6 +373,33 @@ a:hover { text-decoration: underline; }
   // the copyable links read it so a re-render / copied URL matches the on-screen format.
   var snapshotExt = ".png";
 
+  // Size overrides (the Fixed / Max / Min / Within modes). Which query params carry the numbers
+  // is chosen by the mode: Fixed pins the frame via widthPx/heightPx; Max / Min / Within are
+  // wrapped-axis bounds (maxWidthPx / minWidthPx …). Blank inputs are omitted, so one axis can be
+  // bounded without the other. Server-side only (a daemon re-measures) — the inputs are
+  // disabled on a static snapshot like Device/Orientation, so it never emits them.
+  function sizeVal(id) {
+    var el = document.getElementById(id);
+    return el && el.value ? el.value : null;
+  }
+  function sizeOverrides() {
+    var mode = document.getElementById("cp-sizeMode");
+    var o = {};
+    if (!mode || !mode.value) return o;
+    if (mode.value === "fixed") {
+      if (sizeVal("cp-fixedW")) o.widthPx = sizeVal("cp-fixedW");
+      if (sizeVal("cp-fixedH")) o.heightPx = sizeVal("cp-fixedH");
+    }
+    if (mode.value === "min" || mode.value === "within") {
+      if (sizeVal("cp-minW")) o.minWidthPx = sizeVal("cp-minW");
+      if (sizeVal("cp-minH")) o.minHeightPx = sizeVal("cp-minH");
+    }
+    if (mode.value === "max" || mode.value === "within") {
+      if (sizeVal("cp-maxW")) o.maxWidthPx = sizeVal("cp-maxW");
+      if (sizeVal("cp-maxH")) o.maxHeightPx = sizeVal("cp-maxH");
+    }
+    return o;
+  }
   function overrides() {
     var o = {};
     fields.forEach(function (f) {
@@ -352,6 +407,8 @@ a:hover { text-decoration: underline; }
       if (el && el.value) o[f] = el.value;
     });
     if (fontScaleTouched && fs) o.fontScale = fs.value;
+    var size = sizeOverrides();
+    Object.keys(size).forEach(function (k) { o[k] = size[k]; });
     return o;
   }
   // The live-stream override map: the display fields PLUS the author-declared knob values as
@@ -932,6 +989,26 @@ a:hover { text-decoration: underline; }
     var el = document.getElementById("cp-" + f);
     if (el) el.addEventListener("change", onControlsChanged);
   });
+  // Size mode: show only the input rows the chosen mode uses (Within shows both min + max), then
+  // re-render. The number inputs re-render on "input" (live typing) like the locale field.
+  var sizeMode = document.getElementById("cp-sizeMode");
+  if (sizeMode) {
+    var syncSizeRows = function () {
+      var m = sizeMode.value;
+      var show = { fixed: m === "fixed", min: m === "min" || m === "within",
+        max: m === "max" || m === "within" };
+      ["fixed", "min", "max"].forEach(function (g) {
+        var row = document.getElementById("cp-size-" + g);
+        if (row) row.hidden = !show[g];
+      });
+    };
+    syncSizeRows();
+    sizeMode.addEventListener("change", function () { syncSizeRows(); onControlsChanged(); });
+    ["cp-fixedW", "cp-fixedH", "cp-minW", "cp-minH", "cp-maxW", "cp-maxH"].forEach(function (id) {
+      var el = document.getElementById(id);
+      if (el) el.addEventListener("input", onControlsChanged);
+    });
+  }
   // Overlay toggles are live-only: they push a fresh setOverrides through the open stream and do
   // nothing otherwise. They get their own handler rather than onControlsChanged so a toggle mid
   // connect (ws not yet readyState 1) can't fall through to the snapshot / wasm-auto-enable

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
@@ -174,7 +174,7 @@ a:hover { text-decoration: underline; }
         <button type="button" class="cp-drawer-toggle" id="cp-nav-toggle" aria-expanded="false" aria-controls="cp-nav">☰ Components</button>
         <button type="button" class="cp-drawer-toggle" id="cp-controls-toggle" aria-expanded="true" aria-controls="cp-controls">⚙ Overrides</button>
       </div>
-      <div class="cp-viewer cp-controls-open" data-preview-id="com.example.ProfileScreenPreview" data-mode="snapshot" data-modes="snapshot,live" data-static-snapshot="true" data-can-render-overrides="false" data-snapshot-backend="Snapshot" data-live-backend="Live">
+      <div class="cp-viewer cp-controls-open" data-preview-id="com.example.ProfileScreenPreview" data-mode="snapshot" data-modes="snapshot,live" data-static-snapshot="true" data-can-render-overrides="false" data-snapshot-backend="Snapshot" data-live-backend="Live" data-render-density="2">
               <aside class="cp-nav" id="cp-nav" aria-label="Components">
         <div class="cp-nav-head"><span>Components</span><button type="button" class="cp-nav-close" id="cp-nav-close" aria-label="Close component navigation">×</button></div>
         <input type="search" class="cp-nav-search" id="cp-nav-search" placeholder="Filter components" autocomplete="off" aria-label="Filter components">
@@ -247,16 +247,16 @@ a:hover { text-decoration: underline; }
               </select>
             </label>
             <div class="cp-size-row" id="cp-size-fixed" hidden>
-              <label>Width (px)<input id="cp-fixedW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
-              <label>Height (px)<input id="cp-fixedH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
+              <label>Width (dp)<input id="cp-fixedW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
+              <label>Height (dp)<input id="cp-fixedH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
             </div>
             <div class="cp-size-row" id="cp-size-min" hidden>
-              <label>Min width (px)<input id="cp-minW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
-              <label>Min height (px)<input id="cp-minH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
+              <label>Min width (dp)<input id="cp-minW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
+              <label>Min height (dp)<input id="cp-minH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
             </div>
             <div class="cp-size-row" id="cp-size-max" hidden>
-              <label>Max width (px)<input id="cp-maxW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
-              <label>Max height (px)<input id="cp-maxH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
+              <label>Max width (dp)<input id="cp-maxW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
+              <label>Max height (dp)<input id="cp-maxH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
             </div>
           </div>
           
@@ -378,25 +378,34 @@ a:hover { text-decoration: underline; }
   // wrapped-axis bounds (maxWidthPx / minWidthPx …). Blank inputs are omitted, so one axis can be
   // bounded without the other. Server-side only (a daemon re-measures) — the inputs are
   // disabled on a static snapshot like Device/Orientation, so it never emits them.
-  function sizeVal(id) {
+  //
+  // The inputs are authored in dp (the Compose unit); the wire stays in px like every other
+  // override, so a dp value is multiplied by the backend's render density before it's sent (and
+  // the copyable /render URL stays px-consistent). data-render-density carries the factor.
+  var renderDensity = parseFloat(root.getAttribute("data-render-density")) || 2;
+  // dp (string from the input) → a positive integer px value, or null when blank/non-positive.
+  function sizePx(id) {
     var el = document.getElementById(id);
-    return el && el.value ? el.value : null;
+    if (!el || !el.value) return null;
+    var dp = parseFloat(el.value);
+    if (!(dp > 0)) return null;
+    return String(Math.max(1, Math.round(dp * renderDensity)));
   }
   function sizeOverrides() {
     var mode = document.getElementById("cp-sizeMode");
     var o = {};
     if (!mode || !mode.value) return o;
     if (mode.value === "fixed") {
-      if (sizeVal("cp-fixedW")) o.widthPx = sizeVal("cp-fixedW");
-      if (sizeVal("cp-fixedH")) o.heightPx = sizeVal("cp-fixedH");
+      if (sizePx("cp-fixedW")) o.widthPx = sizePx("cp-fixedW");
+      if (sizePx("cp-fixedH")) o.heightPx = sizePx("cp-fixedH");
     }
     if (mode.value === "min" || mode.value === "within") {
-      if (sizeVal("cp-minW")) o.minWidthPx = sizeVal("cp-minW");
-      if (sizeVal("cp-minH")) o.minHeightPx = sizeVal("cp-minH");
+      if (sizePx("cp-minW")) o.minWidthPx = sizePx("cp-minW");
+      if (sizePx("cp-minH")) o.minHeightPx = sizePx("cp-minH");
     }
     if (mode.value === "max" || mode.value === "within") {
-      if (sizeVal("cp-maxW")) o.maxWidthPx = sizeVal("cp-maxW");
-      if (sizeVal("cp-maxH")) o.maxHeightPx = sizeVal("cp-maxH");
+      if (sizePx("cp-maxW")) o.maxWidthPx = sizePx("cp-maxW");
+      if (sizePx("cp-maxH")) o.maxHeightPx = sizePx("cp-maxH");
     }
     return o;
   }

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-themes.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-themes.html
@@ -82,6 +82,11 @@ a:hover { text-decoration: underline; }
 .cp-note { font-size: 0.75rem; color: #6b6b70; line-height: 1.4; padding: 8px 10px;
   border-radius: 8px; background: #f4f4f6; }
 .cp-controls label:has(:disabled) { opacity: 0.55; }
+.cp-size { display: flex; flex-direction: column; gap: 8px; }
+/* :not([hidden]) so the mode toggle's `hidden` attribute still wins over this display rule. */
+.cp-size-row:not([hidden]) { display: flex; gap: 8px; }
+.cp-size-row label { flex: 1; }
+.cp-size-row input { width: 100%; box-sizing: border-box; }
 .cp-knobs { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
 .cp-knobs-head { font-size: 0.72rem; color: #6b6b70; }
 .cp-overlays { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
@@ -227,6 +232,29 @@ a:hover { text-decoration: underline; }
               <option value="clear">Clear (crisp outline)</option>
             </select>
           </label>
+          <div class="cp-size">
+            <label>Size
+              <select id="cp-sizeMode">
+                <option value="">(default)</option>
+                <option value="fixed">Fixed size</option>
+                <option value="max">Max</option>
+                <option value="min">Min</option>
+                <option value="within">Within (min–max)</option>
+              </select>
+            </label>
+            <div class="cp-size-row" id="cp-size-fixed" hidden>
+              <label>Width (px)<input id="cp-fixedW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"></label>
+              <label>Height (px)<input id="cp-fixedH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"></label>
+            </div>
+            <div class="cp-size-row" id="cp-size-min" hidden>
+              <label>Min width (px)<input id="cp-minW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"></label>
+              <label>Min height (px)<input id="cp-minH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"></label>
+            </div>
+            <div class="cp-size-row" id="cp-size-max" hidden>
+              <label>Max width (px)<input id="cp-maxW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"></label>
+              <label>Max height (px)<input id="cp-maxH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"></label>
+            </div>
+          </div>
           <div class="cp-overlays">
   <div class="cp-overlays-head">Overlays (Live Compose)</div>
   <label class="cp-live-row"><input class="cp-overlay" id="cp-talkBack" type="checkbox" disabled> Accessibility (TalkBack)</label>
@@ -345,6 +373,33 @@ a:hover { text-decoration: underline; }
   // the copyable links read it so a re-render / copied URL matches the on-screen format.
   var snapshotExt = ".png";
 
+  // Size overrides (the Fixed / Max / Min / Within modes). Which query params carry the numbers
+  // is chosen by the mode: Fixed pins the frame via widthPx/heightPx; Max / Min / Within are
+  // wrapped-axis bounds (maxWidthPx / minWidthPx …). Blank inputs are omitted, so one axis can be
+  // bounded without the other. Server-side only (a daemon re-measures) — the inputs are
+  // disabled on a static snapshot like Device/Orientation, so it never emits them.
+  function sizeVal(id) {
+    var el = document.getElementById(id);
+    return el && el.value ? el.value : null;
+  }
+  function sizeOverrides() {
+    var mode = document.getElementById("cp-sizeMode");
+    var o = {};
+    if (!mode || !mode.value) return o;
+    if (mode.value === "fixed") {
+      if (sizeVal("cp-fixedW")) o.widthPx = sizeVal("cp-fixedW");
+      if (sizeVal("cp-fixedH")) o.heightPx = sizeVal("cp-fixedH");
+    }
+    if (mode.value === "min" || mode.value === "within") {
+      if (sizeVal("cp-minW")) o.minWidthPx = sizeVal("cp-minW");
+      if (sizeVal("cp-minH")) o.minHeightPx = sizeVal("cp-minH");
+    }
+    if (mode.value === "max" || mode.value === "within") {
+      if (sizeVal("cp-maxW")) o.maxWidthPx = sizeVal("cp-maxW");
+      if (sizeVal("cp-maxH")) o.maxHeightPx = sizeVal("cp-maxH");
+    }
+    return o;
+  }
   function overrides() {
     var o = {};
     fields.forEach(function (f) {
@@ -352,6 +407,8 @@ a:hover { text-decoration: underline; }
       if (el && el.value) o[f] = el.value;
     });
     if (fontScaleTouched && fs) o.fontScale = fs.value;
+    var size = sizeOverrides();
+    Object.keys(size).forEach(function (k) { o[k] = size[k]; });
     return o;
   }
   // The live-stream override map: the display fields PLUS the author-declared knob values as
@@ -932,6 +989,26 @@ a:hover { text-decoration: underline; }
     var el = document.getElementById("cp-" + f);
     if (el) el.addEventListener("change", onControlsChanged);
   });
+  // Size mode: show only the input rows the chosen mode uses (Within shows both min + max), then
+  // re-render. The number inputs re-render on "input" (live typing) like the locale field.
+  var sizeMode = document.getElementById("cp-sizeMode");
+  if (sizeMode) {
+    var syncSizeRows = function () {
+      var m = sizeMode.value;
+      var show = { fixed: m === "fixed", min: m === "min" || m === "within",
+        max: m === "max" || m === "within" };
+      ["fixed", "min", "max"].forEach(function (g) {
+        var row = document.getElementById("cp-size-" + g);
+        if (row) row.hidden = !show[g];
+      });
+    };
+    syncSizeRows();
+    sizeMode.addEventListener("change", function () { syncSizeRows(); onControlsChanged(); });
+    ["cp-fixedW", "cp-fixedH", "cp-minW", "cp-minH", "cp-maxW", "cp-maxH"].forEach(function (id) {
+      var el = document.getElementById(id);
+      if (el) el.addEventListener("input", onControlsChanged);
+    });
+  }
   // Overlay toggles are live-only: they push a fresh setOverrides through the open stream and do
   // nothing otherwise. They get their own handler rather than onControlsChanged so a toggle mid
   // connect (ws not yet readyState 1) can't fall through to the snapshot / wasm-auto-enable

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-themes.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-themes.html
@@ -174,7 +174,7 @@ a:hover { text-decoration: underline; }
         
         <button type="button" class="cp-drawer-toggle" id="cp-controls-toggle" aria-expanded="true" aria-controls="cp-controls">⚙ Overrides</button>
       </div>
-      <div class="cp-viewer cp-controls-open" data-preview-id="com.example.ProfileScreenPreview" data-mode="snapshot" data-modes="snapshot,live" data-static-snapshot="false" data-can-render-overrides="true" data-snapshot-backend="Snapshot" data-live-backend="Live">
+      <div class="cp-viewer cp-controls-open" data-preview-id="com.example.ProfileScreenPreview" data-mode="snapshot" data-modes="snapshot,live" data-static-snapshot="false" data-can-render-overrides="true" data-snapshot-backend="Snapshot" data-live-backend="Live" data-render-density="2">
         
         <div class="cp-stage"><span class="cp-backend" id="cp-backend"></span><img id="cp-img" alt="Profile screen"><canvas id="cp-canvas" hidden></canvas></div>
         <div class="cp-controls" id="cp-controls">
@@ -243,16 +243,16 @@ a:hover { text-decoration: underline; }
               </select>
             </label>
             <div class="cp-size-row" id="cp-size-fixed" hidden>
-              <label>Width (px)<input id="cp-fixedW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"></label>
-              <label>Height (px)<input id="cp-fixedH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"></label>
+              <label>Width (dp)<input id="cp-fixedW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"></label>
+              <label>Height (dp)<input id="cp-fixedH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"></label>
             </div>
             <div class="cp-size-row" id="cp-size-min" hidden>
-              <label>Min width (px)<input id="cp-minW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"></label>
-              <label>Min height (px)<input id="cp-minH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"></label>
+              <label>Min width (dp)<input id="cp-minW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"></label>
+              <label>Min height (dp)<input id="cp-minH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"></label>
             </div>
             <div class="cp-size-row" id="cp-size-max" hidden>
-              <label>Max width (px)<input id="cp-maxW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"></label>
-              <label>Max height (px)<input id="cp-maxH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"></label>
+              <label>Max width (dp)<input id="cp-maxW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"></label>
+              <label>Max height (dp)<input id="cp-maxH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off"></label>
             </div>
           </div>
           <div class="cp-overlays">
@@ -378,25 +378,34 @@ a:hover { text-decoration: underline; }
   // wrapped-axis bounds (maxWidthPx / minWidthPx …). Blank inputs are omitted, so one axis can be
   // bounded without the other. Server-side only (a daemon re-measures) — the inputs are
   // disabled on a static snapshot like Device/Orientation, so it never emits them.
-  function sizeVal(id) {
+  //
+  // The inputs are authored in dp (the Compose unit); the wire stays in px like every other
+  // override, so a dp value is multiplied by the backend's render density before it's sent (and
+  // the copyable /render URL stays px-consistent). data-render-density carries the factor.
+  var renderDensity = parseFloat(root.getAttribute("data-render-density")) || 2;
+  // dp (string from the input) → a positive integer px value, or null when blank/non-positive.
+  function sizePx(id) {
     var el = document.getElementById(id);
-    return el && el.value ? el.value : null;
+    if (!el || !el.value) return null;
+    var dp = parseFloat(el.value);
+    if (!(dp > 0)) return null;
+    return String(Math.max(1, Math.round(dp * renderDensity)));
   }
   function sizeOverrides() {
     var mode = document.getElementById("cp-sizeMode");
     var o = {};
     if (!mode || !mode.value) return o;
     if (mode.value === "fixed") {
-      if (sizeVal("cp-fixedW")) o.widthPx = sizeVal("cp-fixedW");
-      if (sizeVal("cp-fixedH")) o.heightPx = sizeVal("cp-fixedH");
+      if (sizePx("cp-fixedW")) o.widthPx = sizePx("cp-fixedW");
+      if (sizePx("cp-fixedH")) o.heightPx = sizePx("cp-fixedH");
     }
     if (mode.value === "min" || mode.value === "within") {
-      if (sizeVal("cp-minW")) o.minWidthPx = sizeVal("cp-minW");
-      if (sizeVal("cp-minH")) o.minHeightPx = sizeVal("cp-minH");
+      if (sizePx("cp-minW")) o.minWidthPx = sizePx("cp-minW");
+      if (sizePx("cp-minH")) o.minHeightPx = sizePx("cp-minH");
     }
     if (mode.value === "max" || mode.value === "within") {
-      if (sizeVal("cp-maxW")) o.maxWidthPx = sizeVal("cp-maxW");
-      if (sizeVal("cp-maxH")) o.maxHeightPx = sizeVal("cp-maxH");
+      if (sizePx("cp-maxW")) o.maxWidthPx = sizePx("cp-maxW");
+      if (sizePx("cp-maxH")) o.maxHeightPx = sizePx("cp-maxH");
     }
     return o;
   }

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
@@ -174,7 +174,7 @@ a:hover { text-decoration: underline; }
         
         <button type="button" class="cp-drawer-toggle" id="cp-controls-toggle" aria-expanded="true" aria-controls="cp-controls">⚙ Overrides</button>
       </div>
-      <div class="cp-viewer cp-controls-open" data-preview-id="com.example.CardPreview" data-mode="snapshot" data-modes="snapshot,live" data-static-snapshot="true" data-can-render-overrides="false" data-snapshot-backend="Snapshot" data-live-backend="Live" data-wasm-src="/wasm/compose-m3/?id=card-filled">
+      <div class="cp-viewer cp-controls-open" data-preview-id="com.example.CardPreview" data-mode="snapshot" data-modes="snapshot,live" data-static-snapshot="true" data-can-render-overrides="false" data-snapshot-backend="Snapshot" data-live-backend="Live" data-render-density="2" data-wasm-src="/wasm/compose-m3/?id=card-filled">
         
         <div class="cp-stage"><span class="cp-backend" id="cp-backend"></span><img id="cp-img" alt="Card"><canvas id="cp-canvas" hidden></canvas><iframe id="cp-wasm" hidden sandbox="allow-scripts allow-same-origin" title="Card (Wasm)"></iframe></div>
         <div class="cp-controls" id="cp-controls">
@@ -235,16 +235,16 @@ a:hover { text-decoration: underline; }
               </select>
             </label>
             <div class="cp-size-row" id="cp-size-fixed" hidden>
-              <label>Width (px)<input id="cp-fixedW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
-              <label>Height (px)<input id="cp-fixedH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
+              <label>Width (dp)<input id="cp-fixedW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
+              <label>Height (dp)<input id="cp-fixedH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
             </div>
             <div class="cp-size-row" id="cp-size-min" hidden>
-              <label>Min width (px)<input id="cp-minW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
-              <label>Min height (px)<input id="cp-minH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
+              <label>Min width (dp)<input id="cp-minW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
+              <label>Min height (dp)<input id="cp-minH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
             </div>
             <div class="cp-size-row" id="cp-size-max" hidden>
-              <label>Max width (px)<input id="cp-maxW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
-              <label>Max height (px)<input id="cp-maxH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
+              <label>Max width (dp)<input id="cp-maxW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
+              <label>Max height (dp)<input id="cp-maxH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
             </div>
           </div>
           <div class="cp-overlays">
@@ -370,25 +370,34 @@ a:hover { text-decoration: underline; }
   // wrapped-axis bounds (maxWidthPx / minWidthPx …). Blank inputs are omitted, so one axis can be
   // bounded without the other. Server-side only (a daemon re-measures) — the inputs are
   // disabled on a static snapshot like Device/Orientation, so it never emits them.
-  function sizeVal(id) {
+  //
+  // The inputs are authored in dp (the Compose unit); the wire stays in px like every other
+  // override, so a dp value is multiplied by the backend's render density before it's sent (and
+  // the copyable /render URL stays px-consistent). data-render-density carries the factor.
+  var renderDensity = parseFloat(root.getAttribute("data-render-density")) || 2;
+  // dp (string from the input) → a positive integer px value, or null when blank/non-positive.
+  function sizePx(id) {
     var el = document.getElementById(id);
-    return el && el.value ? el.value : null;
+    if (!el || !el.value) return null;
+    var dp = parseFloat(el.value);
+    if (!(dp > 0)) return null;
+    return String(Math.max(1, Math.round(dp * renderDensity)));
   }
   function sizeOverrides() {
     var mode = document.getElementById("cp-sizeMode");
     var o = {};
     if (!mode || !mode.value) return o;
     if (mode.value === "fixed") {
-      if (sizeVal("cp-fixedW")) o.widthPx = sizeVal("cp-fixedW");
-      if (sizeVal("cp-fixedH")) o.heightPx = sizeVal("cp-fixedH");
+      if (sizePx("cp-fixedW")) o.widthPx = sizePx("cp-fixedW");
+      if (sizePx("cp-fixedH")) o.heightPx = sizePx("cp-fixedH");
     }
     if (mode.value === "min" || mode.value === "within") {
-      if (sizeVal("cp-minW")) o.minWidthPx = sizeVal("cp-minW");
-      if (sizeVal("cp-minH")) o.minHeightPx = sizeVal("cp-minH");
+      if (sizePx("cp-minW")) o.minWidthPx = sizePx("cp-minW");
+      if (sizePx("cp-minH")) o.minHeightPx = sizePx("cp-minH");
     }
     if (mode.value === "max" || mode.value === "within") {
-      if (sizeVal("cp-maxW")) o.maxWidthPx = sizeVal("cp-maxW");
-      if (sizeVal("cp-maxH")) o.maxHeightPx = sizeVal("cp-maxH");
+      if (sizePx("cp-maxW")) o.maxWidthPx = sizePx("cp-maxW");
+      if (sizePx("cp-maxH")) o.maxHeightPx = sizePx("cp-maxH");
     }
     return o;
   }

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
@@ -82,6 +82,11 @@ a:hover { text-decoration: underline; }
 .cp-note { font-size: 0.75rem; color: #6b6b70; line-height: 1.4; padding: 8px 10px;
   border-radius: 8px; background: #f4f4f6; }
 .cp-controls label:has(:disabled) { opacity: 0.55; }
+.cp-size { display: flex; flex-direction: column; gap: 8px; }
+/* :not([hidden]) so the mode toggle's `hidden` attribute still wins over this display rule. */
+.cp-size-row:not([hidden]) { display: flex; gap: 8px; }
+.cp-size-row label { flex: 1; }
+.cp-size-row input { width: 100%; box-sizing: border-box; }
 .cp-knobs { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
 .cp-knobs-head { font-size: 0.72rem; color: #6b6b70; }
 .cp-overlays { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
@@ -219,6 +224,29 @@ a:hover { text-decoration: underline; }
               <option value="clear">Clear (crisp outline)</option>
             </select>
           </label>
+          <div class="cp-size">
+            <label>Size
+              <select id="cp-sizeMode" disabled>
+                <option value="">(default)</option>
+                <option value="fixed">Fixed size</option>
+                <option value="max">Max</option>
+                <option value="min">Min</option>
+                <option value="within">Within (min–max)</option>
+              </select>
+            </label>
+            <div class="cp-size-row" id="cp-size-fixed" hidden>
+              <label>Width (px)<input id="cp-fixedW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
+              <label>Height (px)<input id="cp-fixedH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
+            </div>
+            <div class="cp-size-row" id="cp-size-min" hidden>
+              <label>Min width (px)<input id="cp-minW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
+              <label>Min height (px)<input id="cp-minH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
+            </div>
+            <div class="cp-size-row" id="cp-size-max" hidden>
+              <label>Max width (px)<input id="cp-maxW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
+              <label>Max height (px)<input id="cp-maxH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
+            </div>
+          </div>
           <div class="cp-overlays">
   <div class="cp-overlays-head">Overlays (Live Compose)</div>
   <label class="cp-live-row"><input class="cp-overlay" id="cp-talkBack" type="checkbox" disabled> Accessibility (TalkBack)</label>
@@ -337,6 +365,33 @@ a:hover { text-decoration: underline; }
   // the copyable links read it so a re-render / copied URL matches the on-screen format.
   var snapshotExt = ".png";
 
+  // Size overrides (the Fixed / Max / Min / Within modes). Which query params carry the numbers
+  // is chosen by the mode: Fixed pins the frame via widthPx/heightPx; Max / Min / Within are
+  // wrapped-axis bounds (maxWidthPx / minWidthPx …). Blank inputs are omitted, so one axis can be
+  // bounded without the other. Server-side only (a daemon re-measures) — the inputs are
+  // disabled on a static snapshot like Device/Orientation, so it never emits them.
+  function sizeVal(id) {
+    var el = document.getElementById(id);
+    return el && el.value ? el.value : null;
+  }
+  function sizeOverrides() {
+    var mode = document.getElementById("cp-sizeMode");
+    var o = {};
+    if (!mode || !mode.value) return o;
+    if (mode.value === "fixed") {
+      if (sizeVal("cp-fixedW")) o.widthPx = sizeVal("cp-fixedW");
+      if (sizeVal("cp-fixedH")) o.heightPx = sizeVal("cp-fixedH");
+    }
+    if (mode.value === "min" || mode.value === "within") {
+      if (sizeVal("cp-minW")) o.minWidthPx = sizeVal("cp-minW");
+      if (sizeVal("cp-minH")) o.minHeightPx = sizeVal("cp-minH");
+    }
+    if (mode.value === "max" || mode.value === "within") {
+      if (sizeVal("cp-maxW")) o.maxWidthPx = sizeVal("cp-maxW");
+      if (sizeVal("cp-maxH")) o.maxHeightPx = sizeVal("cp-maxH");
+    }
+    return o;
+  }
   function overrides() {
     var o = {};
     fields.forEach(function (f) {
@@ -344,6 +399,8 @@ a:hover { text-decoration: underline; }
       if (el && el.value) o[f] = el.value;
     });
     if (fontScaleTouched && fs) o.fontScale = fs.value;
+    var size = sizeOverrides();
+    Object.keys(size).forEach(function (k) { o[k] = size[k]; });
     return o;
   }
   // The live-stream override map: the display fields PLUS the author-declared knob values as
@@ -924,6 +981,26 @@ a:hover { text-decoration: underline; }
     var el = document.getElementById("cp-" + f);
     if (el) el.addEventListener("change", onControlsChanged);
   });
+  // Size mode: show only the input rows the chosen mode uses (Within shows both min + max), then
+  // re-render. The number inputs re-render on "input" (live typing) like the locale field.
+  var sizeMode = document.getElementById("cp-sizeMode");
+  if (sizeMode) {
+    var syncSizeRows = function () {
+      var m = sizeMode.value;
+      var show = { fixed: m === "fixed", min: m === "min" || m === "within",
+        max: m === "max" || m === "within" };
+      ["fixed", "min", "max"].forEach(function (g) {
+        var row = document.getElementById("cp-size-" + g);
+        if (row) row.hidden = !show[g];
+      });
+    };
+    syncSizeRows();
+    sizeMode.addEventListener("change", function () { syncSizeRows(); onControlsChanged(); });
+    ["cp-fixedW", "cp-fixedH", "cp-minW", "cp-minH", "cp-maxW", "cp-maxH"].forEach(function (id) {
+      var el = document.getElementById(id);
+      if (el) el.addEventListener("input", onControlsChanged);
+    });
+  }
   // Overlay toggles are live-only: they push a fresh setOverrides through the open stream and do
   // nothing otherwise. They get their own handler rather than onControlsChanged so a toggle mid
   // connect (ws not yet readyState 1) can't fall through to the snapshot / wasm-auto-enable

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
@@ -82,6 +82,11 @@ a:hover { text-decoration: underline; }
 .cp-note { font-size: 0.75rem; color: #6b6b70; line-height: 1.4; padding: 8px 10px;
   border-radius: 8px; background: #f4f4f6; }
 .cp-controls label:has(:disabled) { opacity: 0.55; }
+.cp-size { display: flex; flex-direction: column; gap: 8px; }
+/* :not([hidden]) so the mode toggle's `hidden` attribute still wins over this display rule. */
+.cp-size-row:not([hidden]) { display: flex; gap: 8px; }
+.cp-size-row label { flex: 1; }
+.cp-size-row input { width: 100%; box-sizing: border-box; }
 .cp-knobs { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
 .cp-knobs-head { font-size: 0.72rem; color: #6b6b70; }
 .cp-overlays { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
@@ -219,6 +224,29 @@ a:hover { text-decoration: underline; }
               <option value="clear">Clear (crisp outline)</option>
             </select>
           </label>
+          <div class="cp-size">
+            <label>Size
+              <select id="cp-sizeMode" disabled>
+                <option value="">(default)</option>
+                <option value="fixed">Fixed size</option>
+                <option value="max">Max</option>
+                <option value="min">Min</option>
+                <option value="within">Within (min–max)</option>
+              </select>
+            </label>
+            <div class="cp-size-row" id="cp-size-fixed" hidden>
+              <label>Width (px)<input id="cp-fixedW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
+              <label>Height (px)<input id="cp-fixedH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
+            </div>
+            <div class="cp-size-row" id="cp-size-min" hidden>
+              <label>Min width (px)<input id="cp-minW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
+              <label>Min height (px)<input id="cp-minH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
+            </div>
+            <div class="cp-size-row" id="cp-size-max" hidden>
+              <label>Max width (px)<input id="cp-maxW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
+              <label>Max height (px)<input id="cp-maxH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
+            </div>
+          </div>
           
           
           
@@ -333,6 +361,33 @@ a:hover { text-decoration: underline; }
   // the copyable links read it so a re-render / copied URL matches the on-screen format.
   var snapshotExt = ".png";
 
+  // Size overrides (the Fixed / Max / Min / Within modes). Which query params carry the numbers
+  // is chosen by the mode: Fixed pins the frame via widthPx/heightPx; Max / Min / Within are
+  // wrapped-axis bounds (maxWidthPx / minWidthPx …). Blank inputs are omitted, so one axis can be
+  // bounded without the other. Server-side only (a daemon re-measures) — the inputs are
+  // disabled on a static snapshot like Device/Orientation, so it never emits them.
+  function sizeVal(id) {
+    var el = document.getElementById(id);
+    return el && el.value ? el.value : null;
+  }
+  function sizeOverrides() {
+    var mode = document.getElementById("cp-sizeMode");
+    var o = {};
+    if (!mode || !mode.value) return o;
+    if (mode.value === "fixed") {
+      if (sizeVal("cp-fixedW")) o.widthPx = sizeVal("cp-fixedW");
+      if (sizeVal("cp-fixedH")) o.heightPx = sizeVal("cp-fixedH");
+    }
+    if (mode.value === "min" || mode.value === "within") {
+      if (sizeVal("cp-minW")) o.minWidthPx = sizeVal("cp-minW");
+      if (sizeVal("cp-minH")) o.minHeightPx = sizeVal("cp-minH");
+    }
+    if (mode.value === "max" || mode.value === "within") {
+      if (sizeVal("cp-maxW")) o.maxWidthPx = sizeVal("cp-maxW");
+      if (sizeVal("cp-maxH")) o.maxHeightPx = sizeVal("cp-maxH");
+    }
+    return o;
+  }
   function overrides() {
     var o = {};
     fields.forEach(function (f) {
@@ -340,6 +395,8 @@ a:hover { text-decoration: underline; }
       if (el && el.value) o[f] = el.value;
     });
     if (fontScaleTouched && fs) o.fontScale = fs.value;
+    var size = sizeOverrides();
+    Object.keys(size).forEach(function (k) { o[k] = size[k]; });
     return o;
   }
   // The live-stream override map: the display fields PLUS the author-declared knob values as
@@ -920,6 +977,26 @@ a:hover { text-decoration: underline; }
     var el = document.getElementById("cp-" + f);
     if (el) el.addEventListener("change", onControlsChanged);
   });
+  // Size mode: show only the input rows the chosen mode uses (Within shows both min + max), then
+  // re-render. The number inputs re-render on "input" (live typing) like the locale field.
+  var sizeMode = document.getElementById("cp-sizeMode");
+  if (sizeMode) {
+    var syncSizeRows = function () {
+      var m = sizeMode.value;
+      var show = { fixed: m === "fixed", min: m === "min" || m === "within",
+        max: m === "max" || m === "within" };
+      ["fixed", "min", "max"].forEach(function (g) {
+        var row = document.getElementById("cp-size-" + g);
+        if (row) row.hidden = !show[g];
+      });
+    };
+    syncSizeRows();
+    sizeMode.addEventListener("change", function () { syncSizeRows(); onControlsChanged(); });
+    ["cp-fixedW", "cp-fixedH", "cp-minW", "cp-minH", "cp-maxW", "cp-maxH"].forEach(function (id) {
+      var el = document.getElementById(id);
+      if (el) el.addEventListener("input", onControlsChanged);
+    });
+  }
   // Overlay toggles are live-only: they push a fresh setOverrides through the open stream and do
   // nothing otherwise. They get their own handler rather than onControlsChanged so a toggle mid
   // connect (ws not yet readyState 1) can't fall through to the snapshot / wasm-auto-enable

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
@@ -174,7 +174,7 @@ a:hover { text-decoration: underline; }
         
         <button type="button" class="cp-drawer-toggle" id="cp-controls-toggle" aria-expanded="true" aria-controls="cp-controls">⚙ Overrides</button>
       </div>
-      <div class="cp-viewer cp-controls-open" data-preview-id="com.example.CardPreview" data-mode="snapshot" data-modes="snapshot,live" data-static-snapshot="true" data-can-render-overrides="false" data-snapshot-backend="Snapshot" data-live-backend="Live" data-wasm-src="/wasm/compose-m3/?id=card-filled">
+      <div class="cp-viewer cp-controls-open" data-preview-id="com.example.CardPreview" data-mode="snapshot" data-modes="snapshot,live" data-static-snapshot="true" data-can-render-overrides="false" data-snapshot-backend="Snapshot" data-live-backend="Live" data-render-density="2" data-wasm-src="/wasm/compose-m3/?id=card-filled">
         
         <div class="cp-stage"><span class="cp-backend" id="cp-backend"></span><img id="cp-img" alt="Card"><canvas id="cp-canvas" hidden></canvas><iframe id="cp-wasm" hidden sandbox="allow-scripts allow-same-origin" title="Card (Wasm)"></iframe></div>
         <div class="cp-controls" id="cp-controls">
@@ -235,16 +235,16 @@ a:hover { text-decoration: underline; }
               </select>
             </label>
             <div class="cp-size-row" id="cp-size-fixed" hidden>
-              <label>Width (px)<input id="cp-fixedW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
-              <label>Height (px)<input id="cp-fixedH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
+              <label>Width (dp)<input id="cp-fixedW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
+              <label>Height (dp)<input id="cp-fixedH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
             </div>
             <div class="cp-size-row" id="cp-size-min" hidden>
-              <label>Min width (px)<input id="cp-minW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
-              <label>Min height (px)<input id="cp-minH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
+              <label>Min width (dp)<input id="cp-minW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
+              <label>Min height (dp)<input id="cp-minH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
             </div>
             <div class="cp-size-row" id="cp-size-max" hidden>
-              <label>Max width (px)<input id="cp-maxW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
-              <label>Max height (px)<input id="cp-maxH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
+              <label>Max width (dp)<input id="cp-maxW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
+              <label>Max height (dp)<input id="cp-maxH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
             </div>
           </div>
           
@@ -366,25 +366,34 @@ a:hover { text-decoration: underline; }
   // wrapped-axis bounds (maxWidthPx / minWidthPx …). Blank inputs are omitted, so one axis can be
   // bounded without the other. Server-side only (a daemon re-measures) — the inputs are
   // disabled on a static snapshot like Device/Orientation, so it never emits them.
-  function sizeVal(id) {
+  //
+  // The inputs are authored in dp (the Compose unit); the wire stays in px like every other
+  // override, so a dp value is multiplied by the backend's render density before it's sent (and
+  // the copyable /render URL stays px-consistent). data-render-density carries the factor.
+  var renderDensity = parseFloat(root.getAttribute("data-render-density")) || 2;
+  // dp (string from the input) → a positive integer px value, or null when blank/non-positive.
+  function sizePx(id) {
     var el = document.getElementById(id);
-    return el && el.value ? el.value : null;
+    if (!el || !el.value) return null;
+    var dp = parseFloat(el.value);
+    if (!(dp > 0)) return null;
+    return String(Math.max(1, Math.round(dp * renderDensity)));
   }
   function sizeOverrides() {
     var mode = document.getElementById("cp-sizeMode");
     var o = {};
     if (!mode || !mode.value) return o;
     if (mode.value === "fixed") {
-      if (sizeVal("cp-fixedW")) o.widthPx = sizeVal("cp-fixedW");
-      if (sizeVal("cp-fixedH")) o.heightPx = sizeVal("cp-fixedH");
+      if (sizePx("cp-fixedW")) o.widthPx = sizePx("cp-fixedW");
+      if (sizePx("cp-fixedH")) o.heightPx = sizePx("cp-fixedH");
     }
     if (mode.value === "min" || mode.value === "within") {
-      if (sizeVal("cp-minW")) o.minWidthPx = sizeVal("cp-minW");
-      if (sizeVal("cp-minH")) o.minHeightPx = sizeVal("cp-minH");
+      if (sizePx("cp-minW")) o.minWidthPx = sizePx("cp-minW");
+      if (sizePx("cp-minH")) o.minHeightPx = sizePx("cp-minH");
     }
     if (mode.value === "max" || mode.value === "within") {
-      if (sizeVal("cp-maxW")) o.maxWidthPx = sizeVal("cp-maxW");
-      if (sizeVal("cp-maxH")) o.maxHeightPx = sizeVal("cp-maxH");
+      if (sizePx("cp-maxW")) o.maxWidthPx = sizePx("cp-maxW");
+      if (sizePx("cp-maxH")) o.maxHeightPx = sizePx("cp-maxH");
     }
     return o;
   }

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
@@ -82,6 +82,11 @@ a:hover { text-decoration: underline; }
 .cp-note { font-size: 0.75rem; color: #6b6b70; line-height: 1.4; padding: 8px 10px;
   border-radius: 8px; background: #f4f4f6; }
 .cp-controls label:has(:disabled) { opacity: 0.55; }
+.cp-size { display: flex; flex-direction: column; gap: 8px; }
+/* :not([hidden]) so the mode toggle's `hidden` attribute still wins over this display rule. */
+.cp-size-row:not([hidden]) { display: flex; gap: 8px; }
+.cp-size-row label { flex: 1; }
+.cp-size-row input { width: 100%; box-sizing: border-box; }
 .cp-knobs { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
 .cp-knobs-head { font-size: 0.72rem; color: #6b6b70; }
 .cp-overlays { border-top: 1px solid #e3e3e8; padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
@@ -231,6 +236,29 @@ a:hover { text-decoration: underline; }
               <option value="clear">Clear (crisp outline)</option>
             </select>
           </label>
+          <div class="cp-size">
+            <label>Size
+              <select id="cp-sizeMode" disabled>
+                <option value="">(default)</option>
+                <option value="fixed">Fixed size</option>
+                <option value="max">Max</option>
+                <option value="min">Min</option>
+                <option value="within">Within (min–max)</option>
+              </select>
+            </label>
+            <div class="cp-size-row" id="cp-size-fixed" hidden>
+              <label>Width (px)<input id="cp-fixedW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
+              <label>Height (px)<input id="cp-fixedH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
+            </div>
+            <div class="cp-size-row" id="cp-size-min" hidden>
+              <label>Min width (px)<input id="cp-minW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
+              <label>Min height (px)<input id="cp-minH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
+            </div>
+            <div class="cp-size-row" id="cp-size-max" hidden>
+              <label>Max width (px)<input id="cp-maxW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
+              <label>Max height (px)<input id="cp-maxH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
+            </div>
+          </div>
           
           
           
@@ -345,6 +373,33 @@ a:hover { text-decoration: underline; }
   // the copyable links read it so a re-render / copied URL matches the on-screen format.
   var snapshotExt = ".png";
 
+  // Size overrides (the Fixed / Max / Min / Within modes). Which query params carry the numbers
+  // is chosen by the mode: Fixed pins the frame via widthPx/heightPx; Max / Min / Within are
+  // wrapped-axis bounds (maxWidthPx / minWidthPx …). Blank inputs are omitted, so one axis can be
+  // bounded without the other. Server-side only (a daemon re-measures) — the inputs are
+  // disabled on a static snapshot like Device/Orientation, so it never emits them.
+  function sizeVal(id) {
+    var el = document.getElementById(id);
+    return el && el.value ? el.value : null;
+  }
+  function sizeOverrides() {
+    var mode = document.getElementById("cp-sizeMode");
+    var o = {};
+    if (!mode || !mode.value) return o;
+    if (mode.value === "fixed") {
+      if (sizeVal("cp-fixedW")) o.widthPx = sizeVal("cp-fixedW");
+      if (sizeVal("cp-fixedH")) o.heightPx = sizeVal("cp-fixedH");
+    }
+    if (mode.value === "min" || mode.value === "within") {
+      if (sizeVal("cp-minW")) o.minWidthPx = sizeVal("cp-minW");
+      if (sizeVal("cp-minH")) o.minHeightPx = sizeVal("cp-minH");
+    }
+    if (mode.value === "max" || mode.value === "within") {
+      if (sizeVal("cp-maxW")) o.maxWidthPx = sizeVal("cp-maxW");
+      if (sizeVal("cp-maxH")) o.maxHeightPx = sizeVal("cp-maxH");
+    }
+    return o;
+  }
   function overrides() {
     var o = {};
     fields.forEach(function (f) {
@@ -352,6 +407,8 @@ a:hover { text-decoration: underline; }
       if (el && el.value) o[f] = el.value;
     });
     if (fontScaleTouched && fs) o.fontScale = fs.value;
+    var size = sizeOverrides();
+    Object.keys(size).forEach(function (k) { o[k] = size[k]; });
     return o;
   }
   // The live-stream override map: the display fields PLUS the author-declared knob values as
@@ -932,6 +989,26 @@ a:hover { text-decoration: underline; }
     var el = document.getElementById("cp-" + f);
     if (el) el.addEventListener("change", onControlsChanged);
   });
+  // Size mode: show only the input rows the chosen mode uses (Within shows both min + max), then
+  // re-render. The number inputs re-render on "input" (live typing) like the locale field.
+  var sizeMode = document.getElementById("cp-sizeMode");
+  if (sizeMode) {
+    var syncSizeRows = function () {
+      var m = sizeMode.value;
+      var show = { fixed: m === "fixed", min: m === "min" || m === "within",
+        max: m === "max" || m === "within" };
+      ["fixed", "min", "max"].forEach(function (g) {
+        var row = document.getElementById("cp-size-" + g);
+        if (row) row.hidden = !show[g];
+      });
+    };
+    syncSizeRows();
+    sizeMode.addEventListener("change", function () { syncSizeRows(); onControlsChanged(); });
+    ["cp-fixedW", "cp-fixedH", "cp-minW", "cp-minH", "cp-maxW", "cp-maxH"].forEach(function (id) {
+      var el = document.getElementById(id);
+      if (el) el.addEventListener("input", onControlsChanged);
+    });
+  }
   // Overlay toggles are live-only: they push a fresh setOverrides through the open stream and do
   // nothing otherwise. They get their own handler rather than onControlsChanged so a toggle mid
   // connect (ws not yet readyState 1) can't fall through to the snapshot / wasm-auto-enable

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
@@ -174,7 +174,7 @@ a:hover { text-decoration: underline; }
         <button type="button" class="cp-drawer-toggle" id="cp-nav-toggle" aria-expanded="false" aria-controls="cp-nav">☰ Components</button>
         <button type="button" class="cp-drawer-toggle" id="cp-controls-toggle" aria-expanded="true" aria-controls="cp-controls">⚙ Overrides</button>
       </div>
-      <div class="cp-viewer cp-controls-open" data-preview-id="com.example.ProfileScreenPreview" data-mode="snapshot" data-modes="snapshot,live" data-static-snapshot="true" data-can-render-overrides="false" data-snapshot-backend="Snapshot" data-live-backend="Live">
+      <div class="cp-viewer cp-controls-open" data-preview-id="com.example.ProfileScreenPreview" data-mode="snapshot" data-modes="snapshot,live" data-static-snapshot="true" data-can-render-overrides="false" data-snapshot-backend="Snapshot" data-live-backend="Live" data-render-density="2">
               <aside class="cp-nav" id="cp-nav" aria-label="Components">
         <div class="cp-nav-head"><span>Components</span><button type="button" class="cp-nav-close" id="cp-nav-close" aria-label="Close component navigation">×</button></div>
         <input type="search" class="cp-nav-search" id="cp-nav-search" placeholder="Filter components" autocomplete="off" aria-label="Filter components">
@@ -247,16 +247,16 @@ a:hover { text-decoration: underline; }
               </select>
             </label>
             <div class="cp-size-row" id="cp-size-fixed" hidden>
-              <label>Width (px)<input id="cp-fixedW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
-              <label>Height (px)<input id="cp-fixedH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
+              <label>Width (dp)<input id="cp-fixedW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
+              <label>Height (dp)<input id="cp-fixedH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
             </div>
             <div class="cp-size-row" id="cp-size-min" hidden>
-              <label>Min width (px)<input id="cp-minW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
-              <label>Min height (px)<input id="cp-minH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
+              <label>Min width (dp)<input id="cp-minW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
+              <label>Min height (dp)<input id="cp-minH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
             </div>
             <div class="cp-size-row" id="cp-size-max" hidden>
-              <label>Max width (px)<input id="cp-maxW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
-              <label>Max height (px)<input id="cp-maxH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
+              <label>Max width (dp)<input id="cp-maxW" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
+              <label>Max height (dp)<input id="cp-maxH" type="number" min="1" step="1" inputmode="numeric" placeholder="auto" autocomplete="off" disabled></label>
             </div>
           </div>
           
@@ -378,25 +378,34 @@ a:hover { text-decoration: underline; }
   // wrapped-axis bounds (maxWidthPx / minWidthPx …). Blank inputs are omitted, so one axis can be
   // bounded without the other. Server-side only (a daemon re-measures) — the inputs are
   // disabled on a static snapshot like Device/Orientation, so it never emits them.
-  function sizeVal(id) {
+  //
+  // The inputs are authored in dp (the Compose unit); the wire stays in px like every other
+  // override, so a dp value is multiplied by the backend's render density before it's sent (and
+  // the copyable /render URL stays px-consistent). data-render-density carries the factor.
+  var renderDensity = parseFloat(root.getAttribute("data-render-density")) || 2;
+  // dp (string from the input) → a positive integer px value, or null when blank/non-positive.
+  function sizePx(id) {
     var el = document.getElementById(id);
-    return el && el.value ? el.value : null;
+    if (!el || !el.value) return null;
+    var dp = parseFloat(el.value);
+    if (!(dp > 0)) return null;
+    return String(Math.max(1, Math.round(dp * renderDensity)));
   }
   function sizeOverrides() {
     var mode = document.getElementById("cp-sizeMode");
     var o = {};
     if (!mode || !mode.value) return o;
     if (mode.value === "fixed") {
-      if (sizeVal("cp-fixedW")) o.widthPx = sizeVal("cp-fixedW");
-      if (sizeVal("cp-fixedH")) o.heightPx = sizeVal("cp-fixedH");
+      if (sizePx("cp-fixedW")) o.widthPx = sizePx("cp-fixedW");
+      if (sizePx("cp-fixedH")) o.heightPx = sizePx("cp-fixedH");
     }
     if (mode.value === "min" || mode.value === "within") {
-      if (sizeVal("cp-minW")) o.minWidthPx = sizeVal("cp-minW");
-      if (sizeVal("cp-minH")) o.minHeightPx = sizeVal("cp-minH");
+      if (sizePx("cp-minW")) o.minWidthPx = sizePx("cp-minW");
+      if (sizePx("cp-minH")) o.minHeightPx = sizePx("cp-minH");
     }
     if (mode.value === "max" || mode.value === "within") {
-      if (sizeVal("cp-maxW")) o.maxWidthPx = sizeVal("cp-maxW");
-      if (sizeVal("cp-maxH")) o.maxHeightPx = sizeVal("cp-maxH");
+      if (sizePx("cp-maxW")) o.maxWidthPx = sizePx("cp-maxW");
+      if (sizePx("cp-maxH")) o.maxHeightPx = sizePx("cp-maxH");
     }
     return o;
   }


### PR DESCRIPTION
## Summary

The preview viewer's **Overrides** drawer (`compose-preview serve`, e.g. `preview.coo.ee/…/p/…`) could change theme, device, locale, font scale, orientation and background — but not size. This adds a **Size** control with four modes:

| Mode | Behaviour | Wire |
|---|---|---|
| **Fixed** | Pin an exact W×H frame | `widthPx` / `heightPx` (existing) |
| **Max** | Cap a wrapping preview's intrinsic measure at a W×H ceiling | `maxWidthPx` / `maxHeightPx` |
| **Min** | Raise a wrapping preview's floor to a W×H minimum | `minWidthPx` / `minHeightPx` |
| **Within** | A bounded `min..max` range (min + max together) | all four |

The mode picker shows only the input rows it uses; blank inputs are omitted so a single axis can be bounded on its own.

## How it threads through

- **`PreviewOverrides`** gains four nullable fields (`min/maxWidthPx`, `min/maxHeightPx`). They ride the existing base64 `overrides=` bag in `JsonRpcServer.encodeRenderPayload`, so there are **no new wire tokens and no new branches in `PreviewManifestRouter` / `DesktopHost`**.
- The **desktop `RenderEngine`** clamps its AS-parity wrap-content layout constraints to the bounds and enlarges the `ImageComposeScene` to fit a large `min` before the intrinsic-size crop runs. Fixed size stays on the existing `widthPx`/`heightPx` path.
- Backends that don't model size bounds ignore the fields, consistent with the `PreviewOverrides` contract (same as `captureAdvanceMs` being Android-only).
- **`ServeOverrides`** parses/validates the new query keys (positive ints; `min ≤ max` per axis) and folds them into the render cache key. The controls are `serverDis`-gated like Device/Orientation (a static published catalog can't re-measure).

## Visual evidence

**Rendered output** — same 176×176px sticker preview through the real desktop `RenderEngine` at three modes (produced by `RenderEngineWrapContentTest`, saved to `build/size-evidence/`). Max caps the crop below the intrinsic, Min forces it above (badge sits in the enlarged frame), Within leaves an in-range intrinsic untouched:

- `size-max-100.png` → 100×100 · `size-within-120-400.png` → 176×176 (preserved) · `size-min-400.png` → 400×400

**Viewer UI** — the new Size control in the Overrides drawer (Fixed shows Width/Height; Within shows Min + Max). The changed `serve-viewer*` fixtures under `vscode-extension/preview-harness/fixtures/pages/` are what the CI pages-snapshot / visual-diff bot renders, so the drawer diff is captured automatically. Rendered screenshots of both states were shared with the reviewer in the session (headless-Chromium renders of the fixture HTML).

> Note: a CSS bug caught by these screenshots — an author `.cp-size-row { display:flex }` rule was overriding the `[hidden]` attribute so the mode toggle couldn't hide rows — was fixed by scoping it to `.cp-size-row:not([hidden])`.

## Test plan

- [x] `:cli:test` — `ServeOverridesTest` (new: field mapping, non-positive/malformed rejection, `min > max` rejection, cache-key participation) + regenerated `ServeWebFixtureTest` goldens
- [x] `:daemon:desktop:test` — `RenderEngineWrapContentTest` (new: max caps, min forces, within preserves) render end-to-end and assert PNG dimensions
- [x] `:daemon:core:compileKotlin`, `:cli:compileKotlin`, `:daemon:desktop:compileKotlin`, `ktfmtFormat`
- [ ] Android renderer honours the bounds — out of scope here (desktop is the `serve` backend); the fields are wired so a follow-up can add Robolectric measure support

_Pre-existing, unrelated: `:daemon:core` `InteractiveCoalescingTest` (a load-sensitive coalescing timing assertion) fails identically on the clean tree with these changes stashed._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LT4NAv4z2bmtiFo8gpgoCM)_