### PR TITLE
fix(vscode): gate exportPreviewBundle on composePreview.enabled too

### DIFF
--- a/vscode-extension/src/gradleService.ts
+++ b/vscode-extension/src/gradleService.ts
@@ -639,6 +639,19 @@ export class GradleService {
         outputPath: string,
         opts?: TaskOptions,
     ): Promise<void> {
+        // A disabled module has no `composePreviewRender` / `composePreviewBundle`
+        // tasks registered (issue #2016). This path is reachable from the panel's
+        // export action on a stale-but-fresh cached card after `enabled` flips to
+        // false. Unlike the silent background gates, this is a user-explicit
+        // action whose caller surfaces thrown errors — so throw a clear message
+        // rather than letting Gradle fail with a cryptic "task not found".
+        if (!isModulePreviewSchedulable(module)) {
+            this.logDisabledSkip(module, "exportPreviewBundle");
+            throw new Error(
+                `previews are disabled for ${module.modulePath} ` +
+                    `(composePreview.enabled = false), so there is nothing to export`,
+            );
+        }
         const extraArgs = [
             `-PbundlePreviewIds=${encodeBundlePreviewId(previewId)}`,
             `-PbundleOutput=${outputPath}`,

--- a/vscode-extension/src/test/gradleService.test.ts
+++ b/vscode-extension/src/test/gradleService.test.ts
@@ -1282,6 +1282,23 @@ describe("GradleService", () => {
         );
 
         it(
+            "exportPreviewBundle schedules no task and throws a clear error for a disabled module",
+            withTempDir(async (dir, api) => {
+                const service = new GradleService(dir, api);
+                await assert.rejects(
+                    () =>
+                        service.exportPreviewBundle(
+                            disabled,
+                            "com.example.FooKt.BarPreview",
+                            path.join(dir, "out.bundle.png"),
+                        ),
+                    /composePreview\.enabled = false/,
+                );
+                assert.strictEqual(api.runCalls.length, 0);
+            }),
+        );
+
+        it(
             "treats enabled === undefined (legacy marker) as enabled and still schedules",
             withTempDir(async (dir, api) => {
                 fs.mkdirSync(path.join(dir, "mod"));


### PR DESCRIPTION
Follow-up to #2415 (closes the remaining P2 from that PR's Codex review).

## Summary

The disabled-module scheduling gate added in #2415 (issue #2016) covered `composePreviewDiscover`, `composePreviewRender`, `compileOnly`, and `coldStartBundle`, but **not** `exportPreviewBundle` — which schedules `:module:composePreviewRender` and `:module:composePreviewBundle`. Those tasks are unregistered for a `composePreview.enabled = false` module, so the panel's "Export bundle" action on a stale-but-fresh cached card (shown after `enabled` flips to false) would still hit the exact "task not found" failure #2016 set out to eliminate.

- Gate `exportPreviewBundle` via the same `isModulePreviewSchedulable(module)` helper.
- Because this is a **user-explicit** action whose caller (`extension.ts` `exportPreviewBundle`) already catches and surfaces thrown errors via `showErrorMessage`, it **throws a clear message** (`previews are disabled for :module (composePreview.enabled = false)…`) rather than silently no-opping like the background gates — so the user sees why nothing was exported instead of a cryptic Gradle error.

## Test plan

- Added to the `#2016` gating suite in `gradleService.test.ts`: `exportPreviewBundle` on a disabled module schedules **no** task (`api.runCalls.length === 0`) and rejects with the disabled-module message.
- `npx mocha out/test/gradleService.test.js` — 60 passing. `tsc -p ./` clean.

Note: the local `.githooks/pre-commit` runs `format:check` over the whole `src/**` glob and currently trips on ~31 pre-existing unformatted files on `main` unrelated to this change (no CI workflow runs that check); this commit's two touched files are prettier-clean under the pinned prettier 3.9.1.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NE5X73NdmATow7RbkWtEgj)_