### PR TITLE
fix(serve): enable figma-svg data products so override SVG renders

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
@@ -190,9 +190,25 @@ internal constructor(
   // A daemon backs this host, so an override edit actually re-renders (unlike a static bundle).
   override val canApplyOverrides: Boolean = true
 
-  // The daemon can export a `compose/figma-svg` for any preview, so the viewer can offer an SVG
-  // download link alongside the PNG.
-  override val hasSvgExport: Boolean = true
+  // The daemon registers its `compose/figma-svg` (+ `-long`) data products **inactive**, so
+  // `renderSvg`'s `session.fetchData(compose/figma-svg…)` would fail `-32020 kind not advertised`
+  // — an override-bearing `.svg` request (any `?knob…`/`fontScale`/… on the SVG lane) 500s while
+  // the baked vector still serves. Enable them once on open so the export is advertised; gate
+  // `hasSvgExport` on whether the daemon actually has them (a backend without figma-svg reports
+  // them in `unknown`), so a non-figma backend cleanly offers no SVG rather than dead-ending in a
+  // 500. Best-effort: an enable RPC failure disables the export, it doesn't break the host.
+  override val hasSvgExport: Boolean =
+    runCatching {
+        val result =
+          session.enableExtensions(
+            listOf(ComposeFigmaSvgProduct.KIND, ComposeFigmaSvgProduct.KIND_LONG)
+          )
+        ComposeFigmaSvgProduct.KIND !in result.unknown
+      }
+      .getOrElse { e ->
+        onLog("figma-svg export unavailable: enable failed: ${e.message}")
+        false
+      }
 
   // The one-handed gesture override is honoured only by the Android (Robolectric) backend — the
   // desktop backend ignores `overrides.gestures`. Read the daemon's advertised capabilities so the

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/FakeRenderSession.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/FakeRenderSession.kt
@@ -83,8 +83,18 @@ internal class FakeRenderSession(
    * desktop-style backend that honours no feature overrides).
    */
   private val supportedOverrides: List<String> = emptyList(),
+  /**
+   * Whether the modelled daemon has the `compose/figma-svg` (+ `-long`) data products —
+   * [ServeRenderHost] enables them on open and gates [ServeRenderHost.hasSvgExport] on the result.
+   * True by default (a desktop-style backend that exports figma-svg); false models a backend
+   * without it (the ids come back in [ExtensionsEnableResult.unknown]).
+   */
+  private val figmaSvgAvailable: Boolean = true,
 ) : RenderSession {
   val renderCount = AtomicInteger(0)
+
+  /** Extension ids passed to [enableExtensions], in call order — for assertions. */
+  val enabledExtensionIds = CopyOnWriteArrayList<String>()
   private val coalesceRemaining = AtomicInteger(coalescedOverrideRejections)
   private val listeners = CopyOnWriteArrayList<NotificationListener>()
   private val counter = AtomicInteger(0)
@@ -302,7 +312,15 @@ internal class FakeRenderSession(
   override fun enableExtensions(
     ids: List<String>,
     timeout: kotlin.time.Duration,
-  ): ExtensionsEnableResult = error("unused")
+  ): ExtensionsEnableResult {
+    enabledExtensionIds.addAll(ids)
+    val figmaKinds = setOf(ComposeFigmaSvgProduct.KIND, ComposeFigmaSvgProduct.KIND_LONG)
+    val (figma, other) = ids.partition { it in figmaKinds }
+    // A backend without figma-svg reports those ids as unknown; everything else enables.
+    val unknown = if (figmaSvgAvailable) emptyList() else figma
+    val enabled = if (figmaSvgAvailable) ids else other
+    return ExtensionsEnableResult(newlyEnabled = enabled, unknown = unknown)
+  }
 
   override fun disableExtensions(
     ids: List<String>,

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHostTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHostTest.kt
@@ -2,6 +2,7 @@ package ee.schimke.composeai.cli.serve
 
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.daemon.protocol.UiMode
+import ee.schimke.composeai.data.layoutinspector.ComposeFigmaSvgProduct
 import ee.schimke.composeai.data.layoutinspector.PreviewSlotsPayload
 import ee.schimke.composeai.data.layoutinspector.SlotBounds
 import ee.schimke.composeai.render.session.RenderSession
@@ -63,6 +64,32 @@ class ServeRenderHostTest {
     // A desktop-style backend advertises none ⇒ the control is gated off (would be a dead toggle).
     host(FakeRenderSession(newRenderRoot())).use { h ->
       assertFalse(h.gesturesRenderable, "no gesture capability ⇒ not renderable")
+    }
+  }
+
+  @Test
+  fun `hasSvgExport enables the daemon's figma-svg data products on open`() {
+    // The daemon registers compose/figma-svg (+ -long) inactive; without this enable an
+    // override-bearing .svg render fails "-32020 kind not advertised". Assert the host activates
+    // them on open and advertises the SVG export.
+    val session = FakeRenderSession(newRenderRoot())
+    host(session).use { h ->
+      assertTrue(h.hasSvgExport, "a figma-svg-capable daemon advertises SVG export")
+      assertTrue(
+        session.enabledExtensionIds.containsAll(
+          listOf(ComposeFigmaSvgProduct.KIND, ComposeFigmaSvgProduct.KIND_LONG)
+        ),
+        "the host enables both figma-svg data products on open",
+      )
+    }
+  }
+
+  @Test
+  fun `hasSvgExport is false when the daemon lacks figma-svg`() {
+    // A backend without the figma-svg producer reports the ids as unknown; the host must then offer
+    // no SVG export rather than dead-ending an override .svg in a 500.
+    host(FakeRenderSession(newRenderRoot(), figmaSvgAvailable = false)).use { h ->
+      assertFalse(h.hasSvgExport, "no figma-svg producer ⇒ no advertised SVG export")
     }
   }
 


### PR DESCRIPTION
## Summary

An override-bearing `.svg` request on a daemon-backed serve session — e.g. `…/render/button-filled__ideal__default__dark.svg?knob.label=Hello` (or any `?fontScale=…` / `?uiMode=…` on the SVG lane) — returned **HTTP 500** on preview.coo.ee:

```
figma-svg fetch failed: data/fetch wire error -32020: data/fetch: kind not advertised: compose/figma-svg
```

while the **plain baked SVG** (no overrides) served fine.

## Root cause

The daemon registers its `compose/figma-svg` (+ `compose/figma-svg-long`) data products **inactive** (activated via `extensions/enable`). `ServeRenderHost` — whose `renderSvg` drives the export via `session.fetchData(compose/figma-svg)` — opened its session but **never enabled** those products, so `data/fetch` returned `Unknown` → `-32020 kind not advertised` → 500.

- **Baked SVG** dodged it: it's served from the catalog's committed vectors, no daemon.
- **Any override** forces a daemon re-render + figma-svg fetch → 500.

`hasSvgExport` was also hardcoded `true`, so the viewer offered the SVG lane even though the carried daemon couldn't actually produce it.

(Unrelated to the recent `?knob.*` work — this is a pre-existing gap in the daemon-backed SVG lane, exposed by any override on `.svg`.)

## Fix

`ServeRenderHost` now enables `compose/figma-svg` + `compose/figma-svg-long` once when it opens, and derives `hasSvgExport` from the result:

- a backend that has them (desktop) advertises the SVG export and `renderSvg` works;
- a backend that doesn't reports the ids in `ExtensionsEnableResult.unknown`, so `hasSvgExport` is `false` and the viewer offers **no** SVG rather than dead-ending in a 500.

Best-effort: an enable-RPC failure disables the export (logged) without breaking host construction.

## Test plan

`ServeRenderHostTest` gains:
- **`hasSvgExport enables the daemon's figma-svg data products on open`** — asserts the host enables both kinds and advertises the export.
- **`hasSvgExport is false when the daemon lacks figma-svg`** — the no-figma-svg backend degrades to no SVG lane.

`FakeRenderSession` gains a `figmaSvgAvailable` knob and records the enabled ids. `:cli:test` (ServeRenderHost / ServeCatalogLiveHost / ServePerPreviewLiveHost) green; ktfmt clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jxz9i4SuuxPRt3knZKAPbb)_