### PR TITLE
fix(serve): short-circuit SVG render when figma-svg is unavailable

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
@@ -386,6 +386,10 @@ internal constructor(
   override fun renderSvg(previewId: String, overrides: PreviewOverrides): SvgOutcome {
     check(!closed.get()) { "ServeRenderHost is closed" }
     if (previewId !in previewIds) return SvgOutcome.NotFound
+    // A daemon without the figma-svg producer ([hasSvgExport] false) can't export it — fetchData
+    // would fail `-32020 kind not advertised`. Short-circuit to NotFound (a clean 404) instead, so
+    // a direct/stale `/render/<id>.svg` matches the "no SVG lane" this host already advertises.
+    if (!hasSvgExport) return SvgOutcome.NotFound
 
     val key = ServeOverrides.cacheKey(previewId, overrides)
     svgCache.get(key)?.let {
@@ -454,6 +458,9 @@ internal constructor(
   override fun renderScrollSvg(previewId: String, overrides: PreviewOverrides): SvgOutcome {
     check(!closed.get()) { "ServeRenderHost is closed" }
     if (previewId !in previewIds) return SvgOutcome.NotFound
+    // No figma-svg producer ⇒ no export; NotFound (404) rather than a `-32020` fetch 500. See
+    // [renderSvg].
+    if (!hasSvgExport) return SvgOutcome.NotFound
 
     val key = previewId
     scrollSvgCache.get(key)?.let {

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHostTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHostTest.kt
@@ -94,6 +94,26 @@ class ServeRenderHostTest {
   }
 
   @Test
+  fun `renderSvg short-circuits to NotFound when figma-svg is unavailable`() {
+    // Without the producer the SVG render methods must NOT hit fetchData (which would 500 with
+    // `-32020 kind not advertised`); they return NotFound (a 404) to match the advertised no-SVG
+    // lane. Guards the Codex P2 on the availability gate.
+    val session = FakeRenderSession(newRenderRoot(), figmaSvgAvailable = false)
+    host(session).use { h ->
+      assertEquals(
+        SvgOutcome.NotFound,
+        h.renderSvg(previewId, PreviewOverrides(uiMode = UiMode.DARK)),
+      )
+      assertEquals(SvgOutcome.NotFound, h.renderScrollSvg(previewId, PreviewOverrides()))
+      assertEquals(
+        0,
+        session.renderCount.get(),
+        "no render/fetch is attempted for an SVG-less host",
+      )
+    }
+  }
+
+  @Test
   fun `renderSvg returns the figma-svg for the given overrides`() {
     val session = FakeRenderSession(newRenderRoot())
     host(session).use { h ->


### PR DESCRIPTION
## Summary

Follow-up to #2418 (enable figma-svg data products) addressing a Codex P2 on that PR.

#2418 gated `hasSvgExport` on whether the daemon actually has the figma-svg producer, but `renderSvg` / `renderScrollSvg` still called `session.fetchData(compose/figma-svg)` **unconditionally**. So on a backend *without* figma-svg (`hasSvgExport == false`), a direct or stale `/render/<id>.svg` request still hit the fetch and returned `SvgOutcome.Failed` → **HTTP 500 `-32020 kind not advertised`**, instead of the `NotFound` (404) the availability gate advertises.

## Fix

Short-circuit both SVG render methods to `SvgOutcome.NotFound` when `hasSvgExport` is false — no render or fetch is attempted, so an SVG-less backend cleanly 404s the SVG lane rather than 500ing.

(No effect on the deployed desktop daemon, where figma-svg *is* available and `hasSvgExport` is true — this only tightens the degraded-backend path #2418 introduced.)

## Test plan

`ServeRenderHostTest` gains **`renderSvg short-circuits to NotFound when figma-svg is unavailable`** — asserts both `renderSvg` and `renderScrollSvg` return `NotFound` and that **zero** renders/fetches are attempted for an SVG-less host. `:cli:test` green; ktfmt clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jxz9i4SuuxPRt3knZKAPbb)_