### PR TITLE
feat(serve): GC long-idle suspended forked sessions and prune their worktrees

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/GitWorktrees.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/GitWorktrees.kt
@@ -106,6 +106,20 @@ class GitWorktrees(
     return if (res.ok && sha.isNotEmpty()) sha else null
   }
 
+  /**
+   * Remove a single worktree this instance created — the second-level GC of a long-idle revision
+   * session (issue #2022) — and drop it from [prepared] so [close] won't try again. A no-op for a
+   * [dir] this instance didn't prepare, so a stray reclaim can't `git worktree remove` an unrelated
+   * path. Best-effort; a later `git worktree prune` (on [close]) mops up any residue. A subsequent
+   * [prepare] of the same revision re-adds the worktree from the shared object store.
+   */
+  fun remove(dir: File) = lock.withLock {
+    if (prepared.remove(dir)) {
+      onLog("serve: reclaiming worktree ${dir.name}")
+      runCatching { git.run(repoRoot, listOf("worktree", "remove", "--force", dir.absolutePath)) }
+    }
+  }
+
   /** Remove the worktrees this instance created and prune stale registrations. Best-effort. */
   override fun close() {
     val dirs = lock.withLock { prepared.toList().also { prepared.clear() } }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/GitWorktrees.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/GitWorktrees.kt
@@ -48,11 +48,18 @@ class GitWorktrees(
 ) : AutoCloseable {
 
   private val lock = ReentrantLock()
-  private val prepared = HashSet<File>()
+
+  // Reference count per worktree directory, NOT a plain set: two different revisions (e.g. a branch
+  // name and its SHA, or a revision session and a same-ref catalog session) resolve to the SAME
+  // `<cacheRoot>/<sha>` directory, so a shared worktree must survive until *every* holder has
+  // reclaimed it (issue #2022 review). Each [prepare] increments; each [remove] decrements and only
+  // `git worktree remove`s at zero.
+  private val prepared = HashMap<File, Int>()
 
   /**
    * Resolve [rev] to a commit and ensure a worktree for it exists; returns the worktree directory,
    * or `null` when the revision can't be resolved, isn't allowed by policy, or can't be created.
+   * Registers a reference on the worktree — balance it with a [remove] (or a terminal [close]).
    */
   fun prepare(rev: String): File? = lock.withLock {
     val sha = resolve(rev) ?: return null
@@ -61,9 +68,10 @@ class GitWorktrees(
       return null
     }
     val dir = File(cacheRoot, sha)
-    // A `.git` file/dir in the worktree means it's already a valid checkout — reuse it.
+    // A `.git` file/dir in the worktree means it's already a valid checkout — reuse it (another
+    // revision that resolved to the same commit, or a survivor from an earlier run).
     if (File(dir, ".git").exists()) {
-      prepared.add(dir)
+      prepared.merge(dir, 1, Int::plus)
       return dir
     }
     cacheRoot.mkdirs()
@@ -73,7 +81,7 @@ class GitWorktrees(
       onLog("serve: 'git worktree add' failed for $sha")
       return null
     }
-    prepared.add(dir)
+    prepared.merge(dir, 1, Int::plus)
     dir
   }
 
@@ -107,22 +115,29 @@ class GitWorktrees(
   }
 
   /**
-   * Remove a single worktree this instance created — the second-level GC of a long-idle revision
-   * session (issue #2022) — and drop it from [prepared] so [close] won't try again. A no-op for a
-   * [dir] this instance didn't prepare, so a stray reclaim can't `git worktree remove` an unrelated
-   * path. Best-effort; a later `git worktree prune` (on [close]) mops up any residue. A subsequent
-   * [prepare] of the same revision re-adds the worktree from the shared object store.
+   * Release one reference on a worktree this instance prepared — the second-level GC of a long-idle
+   * revision session (issue #2022). The worktree is only `git worktree remove`d once its **last**
+   * reference is released, so GC of one revision alias can't delete a `<cacheRoot>/<sha>` directory
+   * another still-live session (a same-commit alias, or a same-ref catalog session) is resuming or
+   * rendering from. A no-op for a [dir] this instance didn't prepare, so a stray reclaim can't `git
+   * worktree remove` an unrelated path. Best-effort; a later `git worktree prune` (on [close]) mops
+   * up any residue. A subsequent [prepare] of the same revision re-adds the worktree from the
+   * shared object store.
    */
   fun remove(dir: File) = lock.withLock {
-    if (prepared.remove(dir)) {
-      onLog("serve: reclaiming worktree ${dir.name}")
-      runCatching { git.run(repoRoot, listOf("worktree", "remove", "--force", dir.absolutePath)) }
+    val refs = prepared[dir] ?: return@withLock
+    if (refs > 1) {
+      prepared[dir] = refs - 1
+      return@withLock
     }
+    prepared.remove(dir)
+    onLog("serve: reclaiming worktree ${dir.name}")
+    runCatching { git.run(repoRoot, listOf("worktree", "remove", "--force", dir.absolutePath)) }
   }
 
   /** Remove the worktrees this instance created and prune stale registrations. Best-effort. */
   override fun close() {
-    val dirs = lock.withLock { prepared.toList().also { prepared.clear() } }
+    val dirs = lock.withLock { prepared.keys.toList().also { prepared.clear() } }
     dirs.forEach { dir ->
       runCatching { git.run(repoRoot, listOf("worktree", "remove", "--force", dir.absolutePath)) }
     }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRevisionFactory.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRevisionFactory.kt
@@ -71,6 +71,10 @@ class ServeRevisionFactory(
       previews = built.previews,
       label = "${module.gradlePath}@$rev",
       declaredThemes = built.declaredThemes,
+      // Prune this revision's worktree when the registry reclaims a long-idle suspended forked
+      // session (issue #2022). A later `?session=<rev>` for the same revision re-prepares the
+      // worktree from the shared object store, so reclaiming is safe.
+      reclaim = { worktrees.remove(worktree) },
     )
   }
 }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistry.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistry.kt
@@ -36,6 +36,15 @@ class ServeSessionRegistry(
   private val factory: ServeSessionFactory = ServeSessionFactory { null },
   private val idleTimeoutMillis: Long = DEFAULT_IDLE_TIMEOUT_MILLIS,
   reaperIntervalMillis: Long = idleTimeoutMillis,
+  /**
+   * Second-level idle window (issue #2022): a *forked* session that has stayed suspended this long
+   * is removed entirely and its git worktree pruned (via [ServeSessionState.reclaim]), so a
+   * long-lived project-mode server doesn't accumulate suspended-session state + worktrees for every
+   * revision it has ever served. Must exceed [idleTimeoutMillis] (a session suspends first, then
+   * GCs). Non-positive disables the GC (tests drive [reclaimIdleForked] directly with a fake
+   * clock).
+   */
+  private val suspendedGcTimeoutMillis: Long = DEFAULT_SUSPENDED_GC_TIMEOUT_MILLIS,
   private val clock: () -> Long = System::currentTimeMillis,
 ) : AutoCloseable {
 
@@ -46,6 +55,14 @@ class ServeSessionRegistry(
     @Volatile var host: ServeHost?,
     /** Pinned sessions (e.g. static bundle hosts — no daemon to reclaim) are never suspended. */
     val pinned: Boolean,
+    /**
+     * True only for sessions built on demand by [factory] (project mode `?session=<rev>`), each
+     * with a git worktree on disk. These are the only entries the second-level GC
+     * ([reclaimIdleForked]) *removes* — [register]ed sessions (the pinned checkout, bundle/catalog
+     * hosts) are kept permanently resumable, matching the register-vs-fork distinction in the issue
+     * (#2022).
+     */
+    val forked: Boolean,
     @Volatile var lastAccess: Long,
     /** Open long-lived holders (e.g. WebSocket connections) keeping this session resident. */
     @Volatile var leases: Int = 0,
@@ -79,7 +96,12 @@ class ServeSessionRegistry(
         }
         .also {
           it.scheduleWithFixedDelay(
-            { runCatching { suspendIdle() } },
+            {
+              // Suspend first, then GC: a session must be suspended (host released) before it's
+              // eligible for the longer-window forked-session reclaim below.
+              runCatching { suspendIdle() }
+              runCatching { reclaimIdleForked() }
+            },
             reaperIntervalMillis,
             reaperIntervalMillis,
             TimeUnit.MILLISECONDS,
@@ -102,7 +124,9 @@ class ServeSessionRegistry(
   ) {
     lock.withLock {
       check(!closed) { "ServeSessionRegistry is closed" }
-      sessions[sessionId] = Entry(state, host, pinned, lastAccess = clock())
+      // Registered sessions (the current-checkout default, bundle/catalog hosts) are never GC'd:
+      // forked = false keeps them permanently resumable regardless of pinning.
+      sessions[sessionId] = Entry(state, host, pinned, forked = false, lastAccess = clock())
     }
   }
 
@@ -181,6 +205,34 @@ class ServeSessionRegistry(
     suspended
   }
 
+  /**
+   * Second-level reclaim (issue #2022): fully **remove** *forked* sessions — ones built on demand
+   * by [factory] (project mode `?session=<rev>`), each with a git worktree on disk — that have
+   * stayed suspended (no live host, no lease) past [suspendedGcTimeoutMillis], running each one's
+   * [ServeSessionState.reclaim] to prune its worktree. Pinned/registered sessions are never
+   * removed, so the current checkout and bundle/catalog hosts stay permanently resumable. A later
+   * `?session=<rev>` for a reclaimed revision simply rebuilds it. Returns the number reclaimed.
+   *
+   * Idle is measured from [Entry.lastAccess] (the last acquire/lease), the same basis as
+   * [suspendIdle], so the window means "untouched for this long" — which is what a long-lived
+   * project server wants: a revision nobody has opened in the GC window is gone, worktree and all.
+   */
+  fun reclaimIdleForked(): Int = lock.withLock {
+    if (closed || suspendedGcTimeoutMillis <= 0) return 0
+    val now = clock()
+    val stale = sessions.filterValues { entry ->
+      entry.forked &&
+        entry.host == null &&
+        entry.leases == 0 &&
+        now - entry.lastAccess >= suspendedGcTimeoutMillis
+    }
+    for ((id, entry) in stale) {
+      sessions.remove(id)
+      runCatching { entry.state?.reclaim?.invoke() }
+    }
+    stale.size
+  }
+
   /** Total known sessions (resident + suspended). */
   fun activeCount(): Int = lock.withLock { sessions.size }
 
@@ -213,7 +265,8 @@ class ServeSessionRegistry(
     // is
     // slow, but a shared dev/CI server has few tenants and correctness beats build concurrency.
     val state = factory.create(sessionId) ?: return null
-    return Entry(state, host = null, pinned = false, lastAccess = clock()).also {
+    // forked = true: built on demand (a git worktree on disk), so it's GC-eligible once long idle.
+    return Entry(state, host = null, pinned = false, forked = true, lastAccess = clock()).also {
       sessions[sessionId] = it
     }
   }
@@ -232,5 +285,12 @@ class ServeSessionRegistry(
   private companion object {
     /** Default idle window before a resident session's daemon is suspended. */
     const val DEFAULT_IDLE_TIMEOUT_MILLIS = 10 * 60 * 1000L
+
+    /**
+     * Default second-level window before a *forked* suspended session is removed and its worktree
+     * pruned (issue #2022) — an hour, comfortably past the 10-minute suspend window so a session
+     * always suspends first. Pinned/registered sessions are exempt regardless.
+     */
+    const val DEFAULT_SUSPENDED_GC_TIMEOUT_MILLIS = 60 * 60 * 1000L
   }
 }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionState.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionState.kt
@@ -56,4 +56,13 @@ data class ServeSessionState(
   val perPreviewResolve: ((daemonId: String) -> ServeHost?)? = null,
   /** Live upstream stream count across the pooled per-preview daemons (see [perPreviewResolve]). */
   val perPreviewStreamCount: () -> Int = { 0 },
+  /**
+   * Optional reclaim hook invoked when the registry **removes** this session entirely — the
+   * second-level GC of a long-idle *suspended* forked session (issue #2022), NOT ordinary
+   * suspend/resume. Set by the project-mode factory ([ServeRevisionFactory]) to prune the
+   * revision's git worktree from disk once the session is reclaimed; null for sessions with nothing
+   * on-disk to reclaim (the pinned checkout, bundle/catalog hosts). Best-effort and expected to be
+   * idempotent — the registry runs it under `runCatching`.
+   */
+  val reclaim: (() -> Unit)? = null,
 )

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/GitWorktreesTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/GitWorktreesTest.kt
@@ -210,6 +210,41 @@ class GitWorktreesTest {
   }
 
   @Test
+  fun `a worktree shared by two revisions is pruned only after both reclaim`() {
+    // Both revisions resolve to the same commit (FakeGit's single resolveSha), so prepare() hands
+    // back the same <cacheRoot>/<sha> dir. GC of the first alias must NOT delete the worktree the
+    // second alias is still using (issue #2022 review) — only the last reclaim prunes it.
+    val git = FakeGit(ancestorRefs = setOf("refs/heads/main"))
+    GitWorktrees(
+        repoRoot = tempDir("repo"),
+        cacheRoot = tempDir("wt-cache"),
+        allowedRefs = listOf("main"),
+        git = git,
+      )
+      .use { wt ->
+        val a = assertNotNull(wt.prepare("HEAD"))
+        val b = assertNotNull(wt.prepare("main"))
+        assertEquals(a, b, "both revisions share one worktree")
+        assertEquals(1, git.count(listOf("worktree", "add")), "shared worktree added once")
+
+        wt.remove(a)
+        assertEquals(
+          0,
+          git.count(listOf("worktree", "remove")),
+          "the first reclaim only drops a reference — the worktree is still in use",
+        )
+        wt.remove(b)
+        assertEquals(
+          1,
+          git.count(listOf("worktree", "remove")),
+          "the last reclaim prunes the now-unused worktree",
+        )
+      }
+    // close() must not remove the already-pruned worktree again.
+    assertEquals(1, git.count(listOf("worktree", "remove")))
+  }
+
+  @Test
   fun `remove is a no-op for a worktree this instance did not prepare`() {
     val git = FakeGit(ancestorRefs = setOf("refs/heads/main"))
     GitWorktrees(

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/GitWorktreesTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/GitWorktreesTest.kt
@@ -188,4 +188,43 @@ class GitWorktreesTest {
     assertEquals(1, git.count(listOf("worktree", "remove")))
     assertEquals(1, git.count(listOf("worktree", "prune")))
   }
+
+  @Test
+  fun `remove prunes a single prepared worktree and close does not remove it again`() {
+    val git = FakeGit(ancestorRefs = setOf("refs/heads/main"))
+    GitWorktrees(
+        repoRoot = tempDir("repo"),
+        cacheRoot = tempDir("wt-cache"),
+        allowedRefs = listOf("main"),
+        git = git,
+      )
+      .use { wt ->
+        val dir = assertNotNull(wt.prepare("HEAD"))
+        wt.remove(dir)
+        assertEquals(1, git.count(listOf("worktree", "remove")), "remove pruned the worktree")
+      }
+    // close() must not remove the already-reclaimed worktree a second time (it was dropped from
+    // `prepared`); only the terminal `git worktree prune` runs.
+    assertEquals(1, git.count(listOf("worktree", "remove")), "no double remove on close")
+    assertEquals(1, git.count(listOf("worktree", "prune")))
+  }
+
+  @Test
+  fun `remove is a no-op for a worktree this instance did not prepare`() {
+    val git = FakeGit(ancestorRefs = setOf("refs/heads/main"))
+    GitWorktrees(
+        repoRoot = tempDir("repo"),
+        cacheRoot = tempDir("wt-cache"),
+        allowedRefs = listOf("main"),
+        git = git,
+      )
+      .use { wt ->
+        wt.remove(File("/some/unrelated/worktree"))
+        assertEquals(
+          0,
+          git.count(listOf("worktree", "remove")),
+          "an unprepared path is never git-removed",
+        )
+      }
+  }
 }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistryTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistryTest.kt
@@ -198,6 +198,103 @@ class ServeSessionRegistryTest {
   }
 
   @Test
+  fun `a long-idle suspended forked session is reclaimed and its worktree pruned`() {
+    val clock = AtomicLong(0)
+    val reclaimed = mutableListOf<String>()
+    val factory = ServeSessionFactory { id -> stateFor(id).copy(reclaim = { reclaimed += id }) }
+    ServeSessionRegistry(
+        open = Opener(),
+        factory = factory,
+        idleTimeoutMillis = 100,
+        reaperIntervalMillis = 0,
+        suspendedGcTimeoutMillis = 1_000,
+        clock = clock::get,
+      )
+      .use { reg ->
+        assertNotNull(reg.acquire("rev1")) // fork + open at t=0
+        clock.set(200)
+        assertEquals(1, reg.suspendIdle(), "idle past the suspend window → daemon released")
+        assertEquals(0, reg.reclaimIdleForked(), "still inside the GC window → not reclaimed")
+        assertEquals(1, reg.activeCount(), "state retained while inside the GC window")
+
+        clock.set(1_500)
+        assertEquals(1, reg.reclaimIdleForked(), "past the GC window → reclaimed")
+        assertEquals(0, reg.activeCount(), "the forked session is removed entirely")
+        assertEquals(listOf("rev1"), reclaimed, "its worktree reclaim hook ran exactly once")
+      }
+  }
+
+  @Test
+  fun `a resident forked session is never reclaimed`() {
+    val clock = AtomicLong(0)
+    val reclaimed = mutableListOf<String>()
+    val factory = ServeSessionFactory { id -> stateFor(id).copy(reclaim = { reclaimed += id }) }
+    ServeSessionRegistry(
+        open = Opener(),
+        factory = factory,
+        idleTimeoutMillis = 100,
+        reaperIntervalMillis = 0,
+        suspendedGcTimeoutMillis = 1_000,
+        clock = clock::get,
+      )
+      .use { reg ->
+        assertNotNull(reg.acquire("rev1"))
+        clock.set(10_000) // long idle, but never suspended (host still resident)
+        assertEquals(0, reg.reclaimIdleForked(), "a live host is suspended before it can be GC'd")
+        assertEquals(1, reg.activeCount())
+        assertTrue(reclaimed.isEmpty())
+      }
+  }
+
+  @Test
+  fun `a registered session is never reclaimed even when long-idle and suspended`() {
+    val clock = AtomicLong(0)
+    ServeSessionRegistry(
+        open = Opener(),
+        factory = CountingFactory(),
+        idleTimeoutMillis = 100,
+        reaperIntervalMillis = 0,
+        suspendedGcTimeoutMillis = 1_000,
+        clock = clock::get,
+      )
+      .use { reg ->
+        val eager =
+          ServeRenderHost(
+            FakeRenderSession(newRenderRoot()),
+            listOf(ServePreview(previewId, "Red")),
+          )
+        reg.register("primary", stateFor("primary"), host = eager)
+        clock.set(200)
+        assertEquals(1, reg.suspendIdle(), "a registered session still suspends its daemon")
+        clock.set(10_000)
+        assertEquals(0, reg.reclaimIdleForked(), "but a registered session is never removed")
+        assertEquals(1, reg.activeCount(), "so it stays permanently resumable")
+      }
+  }
+
+  @Test
+  fun `the GC is disabled when the timeout is non-positive`() {
+    val clock = AtomicLong(0)
+    val factory = ServeSessionFactory { id -> stateFor(id).copy(reclaim = {}) }
+    ServeSessionRegistry(
+        open = Opener(),
+        factory = factory,
+        idleTimeoutMillis = 100,
+        reaperIntervalMillis = 0,
+        suspendedGcTimeoutMillis = 0,
+        clock = clock::get,
+      )
+      .use { reg ->
+        assertNotNull(reg.acquire("rev1"))
+        clock.set(200)
+        reg.suspendIdle()
+        clock.set(1_000_000)
+        assertEquals(0, reg.reclaimIdleForked(), "GC off → nothing reclaimed however idle")
+        assertEquals(1, reg.activeCount())
+      }
+  }
+
+  @Test
   fun `close releases every resident host and rejects further acquire`() {
     val reg =
       ServeSessionRegistry(open = Opener(), factory = CountingFactory(), reaperIntervalMillis = 0)


### PR DESCRIPTION
Part of #2022 (the suspended-session GC — part 2 of the issue).

## Problem

A project-mode `serve` server (`--revisions`) forks a session per git revision behind `ServeSessionRegistry`'s factory, each built in its own git worktree. `suspendIdle()` releases an idle session's daemon but **keeps its state forever** — entries are never removed — so a long-lived server that has served many revisions accumulates suspended-session entries and their **on-disk worktrees** indefinitely.

## Change — a second-level reclaim

- **Distinguish forked from registered sessions.** `Entry` gains a `forked` flag: `true` only for sessions built on demand by the factory (a git worktree on disk → GC-eligible), `false` for `register()`ed ones (the current checkout, bundle/catalog hosts → permanently resumable). This is the register-vs-fork distinction the issue calls for; it's orthogonal to the existing `pinned` flag (which only governs suspend).
- **`reclaimIdleForked()`** removes forked entries that have stayed suspended (no live host, no lease) past a longer `suspendedGcTimeoutMillis` window (default **1h**, comfortably past the 10-min suspend window so a session always suspends first), invoking each session's reclaim hook. The reaper runs it right after `suspendIdle()` on the same tick. Non-positive timeout disables it.
- **Worktree pruning.** `ServeSessionState` gains an optional `reclaim` hook; `ServeRevisionFactory` sets it to `worktrees.remove(worktree)`. `GitWorktrees.remove(dir)` is a new single-worktree `git worktree remove --force` that drops the dir from `prepared` (so `close()` won't double-remove) and is a no-op for a dir this instance didn't prepare (a stray reclaim can't remove an unrelated path).

Registered/pinned sessions are never GC'd, so the current checkout and bundle/catalog hosts stay permanently resumable. A reclaimed revision simply rebuilds on a later `?session=<rev>` (the worktree re-prepares from the shared object store). No `ServeCommand` wiring change is needed — the registry default enables the GC and the factory supplies the reclaim hook.

## Test plan

`./gradlew :cli:test` — full suite green (`:cli:ktfmtCheck` clean). New coverage:

- `ServeSessionRegistryTest`: a long-idle **suspended forked** session is reclaimed (removed + worktree hook run once) past the window; a **resident** forked session is not (it suspends first); a **registered** session is never reclaimed even when long-idle and suspended; the GC is off when the timeout is non-positive.
- `GitWorktreesTest`: `remove` prunes a single prepared worktree and `close` doesn't remove it again; `remove` is a no-op for an unprepared dir.

## Scope

This is part 2 of #2022. Part 1 (the explicit `ServeMode` taxonomy — `Pinned` / `Project` / `Shared` as a first-class concept over `ServeCommand`'s current flag booleans) is a larger, design-heavier refactor and is left as a follow-up, so the issue stays open.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NE5X73NdmATow7RbkWtEgj)_