### PR TITLE
feat(serve): re-fetch catalog branches on change so a live server stays fresh

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
@@ -64,6 +64,7 @@ internal object CliFlags {
       "--catalogs-unlisted",
       "--catalog-repo",
       "--catalog-branch-prefix",
+      "--catalog-refresh-interval",
       "--catalog-source-root",
       "--wasm-dir",
       "--revisions-allow",

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -9,6 +9,7 @@ import ee.schimke.composeai.cli.serve.ServeBundleDaemon
 import ee.schimke.composeai.cli.serve.ServeBundleHost
 import ee.schimke.composeai.cli.serve.ServeBundleStore
 import ee.schimke.composeai.cli.serve.ServeCatalogLiveHost
+import ee.schimke.composeai.cli.serve.ServeCatalogRefresher
 import ee.schimke.composeai.cli.serve.ServeCatalogStore
 import ee.schimke.composeai.cli.serve.ServeHost
 import ee.schimke.composeai.cli.serve.ServeHttpServer
@@ -123,6 +124,15 @@ class ServeCommand(args: List<String>) : Command(args) {
   private val idleExitSeconds: Long =
     args.flagValue("--exit-when-idle")?.toLongOrNull()?.takeIf { it > 0 }
       ?: DEFAULT_IDLE_EXIT_SECONDS
+
+  /**
+   * Seconds between re-checks of each `--catalogs` branch's head commit; when it has moved, the
+   * catalog is re-fetched in place (no restart) — see [ServeCatalogRefresher]. Default
+   * [DEFAULT_CATALOG_REFRESH_SECONDS]; `0` (or negative) disables polling (boot-snapshot only, the
+   * pre-refresh behaviour). Wired from `SERVE_CATALOG_REFRESH` by the image entrypoint.
+   */
+  private val catalogRefreshSeconds: Long =
+    args.flagValue("--catalog-refresh-interval")?.toLongOrNull() ?: DEFAULT_CATALOG_REFRESH_SECONDS
 
   /**
    * Shared mode: a directory of pre-rendered portable bundles (or a single bundle) to host
@@ -428,9 +438,17 @@ class ServeCommand(args: List<String>) : Command(args) {
     // Serve our published design systems from their trusted `design-artifacts/<system>` branches.
     // A catalog that carries a `web/wasm/` app yields a system→dir entry so the in-browser tier
     // rides the same trusted branch (no local --wasm-dir build needed).
-    val catalogWasm =
-      if (catalogRefs.isNotEmpty()) registerCatalogs(registry, catalogWorktrees, openHost)
-      else emptyMap()
+    val catalogReg =
+      if (catalogRefs.isNotEmpty()) registerCatalogs(registry, catalogWorktrees, openHost) else null
+    val catalogWasm = catalogReg?.wasm ?: emptyMap()
+    // Keep the catalogs fresh against their (routinely-changing) branches without a restart.
+    val catalogRefresher =
+      catalogReg
+        ?.let { buildCatalogRefresher(it.store) }
+        ?.also {
+          it.seedInitialHeads()
+          it.start()
+        }
     // Runtime ingestion (--accept-bundles): clients POST a bundle (or a ?url= to one) and it's
     // registered as a pinned session. Unpacked under a temp dir for this server's lifetime.
     val bundleStore = if (acceptBundles) openUploadStore(registry) else null
@@ -451,7 +469,8 @@ class ServeCommand(args: List<String>) : Command(args) {
       mdnsModuleLabel = module.gradlePath,
       mdnsPreviewIds = previews.map { it.id },
       closeables =
-        listOf(worktrees, catalogWorktrees.takeIf { it !== worktrees }) + catalogPerPreviewPools,
+        listOf(worktrees, catalogWorktrees.takeIf { it !== worktrees }, catalogRefresher) +
+          catalogPerPreviewPools,
     )
   }
 
@@ -476,9 +495,19 @@ class ServeCommand(args: List<String>) : Command(args) {
     }
     val registeredStartup = registerStartupBundles(registry)
     // No worktrees in module-less mode — catalogs live-render only from their carried `liveBundle`.
-    val catalogWasm =
+    val catalogReg =
       if (catalogRefs.isNotEmpty()) registerCatalogs(registry, worktrees = null, ::openHost)
-      else emptyMap()
+      else null
+    val catalogWasm = catalogReg?.wasm ?: emptyMap()
+    // Keep the catalogs fresh against their (routinely-changing) branches without a restart — the
+    // public preview server (preview.coo.ee) runs this module-less path.
+    val catalogRefresher =
+      catalogReg
+        ?.let { buildCatalogRefresher(it.store) }
+        ?.also {
+          it.seedInitialHeads()
+          it.start()
+        }
     val bundleStore = if (acceptBundles) openUploadStore(registry) else null
 
     val localWasm = filterLocalWasm()
@@ -513,7 +542,7 @@ class ServeCommand(args: List<String>) : Command(args) {
       // No module previews to advertise; discovery is a module-session nicety, so skip it here.
       mdnsModuleLabel = null,
       mdnsPreviewIds = null,
-      closeables = catalogPerPreviewPools.toList(),
+      closeables = catalogPerPreviewPools.toList() + listOfNotNull(catalogRefresher),
     )
   }
 
@@ -867,11 +896,14 @@ class ServeCommand(args: List<String>) : Command(args) {
    * branch is in the trust store; otherwise served as `unverified` (the images execute no code).
    * Best-effort per system — one catalog failing to fetch doesn't sink the others or the server.
    */
+  /** [registerCatalogs] result: the wasm-app dirs plus the [store] a refresher re-loads from. */
+  private class CatalogRegistration(val wasm: Map<String, File>, val store: ServeCatalogStore)
+
   private fun registerCatalogs(
     registry: ServeSessionRegistry,
     worktrees: GitWorktrees?,
     openHost: (ServeSessionState) -> ServeHost?,
-  ): Map<String, File> {
+  ): CatalogRegistration {
     val dir =
       java.nio.file.Files.createTempDirectory("serve-catalogs").toFile().also { it.deleteOnExit() }
     val wasm = linkedMapOf<String, File>()
@@ -933,7 +965,33 @@ class ServeCommand(args: List<String>) : Command(args) {
           System.err.println("serve: catalog ${r.system} not served: ${r.reason}")
       }
     }
-    return wasm
+    return CatalogRegistration(wasm = wasm, store = store)
+  }
+
+  /**
+   * Build the background poller that keeps a running server fresh against its catalog branches (see
+   * [ServeCatalogRefresher]). Null when polling is disabled ([catalogRefreshSeconds] ≤ 0) or there
+   * are no catalogs. The caller seeds heads + starts it, and adds it to the server's closeables so
+   * the daemon thread stops on shutdown. A successful re-load re-registers the catalog host in
+   * place (the registry closes the replaced daemon) and rewrites the on-disk `web/wasm/` dir the
+   * `/wasm/<system>/` route serves.
+   */
+  private fun buildCatalogRefresher(store: ServeCatalogStore): ServeCatalogRefresher? {
+    if (catalogRefreshSeconds <= 0 || catalogRefs.isEmpty()) return null
+    val entries = catalogRefs.map {
+      ServeCatalogRefresher.Entry(
+        system = it.system,
+        repo = it.repo,
+        branch = "$catalogBranchPrefix${it.system}",
+      )
+    }
+    return ServeCatalogRefresher(
+      entries = entries,
+      reload = { system, repo ->
+        store.load(system, sourceRepo = repo) is ServeCatalogStore.Result.Ok
+      },
+      intervalMillis = catalogRefreshSeconds * 1000,
+    )
   }
 
   /**
@@ -1315,6 +1373,12 @@ class ServeCommand(args: List<String>) : Command(args) {
                           yschimke/compose-ai-tools); per-entry @<owner>/<repo> overrides it.
         --catalog-branch-prefix <prefix>
                           Branch prefix for --catalogs (default design-artifacts/).
+        --catalog-refresh-interval <seconds>
+                          Keep a running server fresh: re-check each --catalogs branch's head every
+                          <seconds> and re-fetch (catalog.json + renders + web/wasm/ + liveBundle) in
+                          place when it moved — so a regenerated branch is picked up with no restart
+                          (default ${DEFAULT_CATALOG_REFRESH_SECONDS}s; 0 disables, serving the boot snapshot only). Uses
+                          `git ls-remote` (no API rate limit), and skips a branch it can't resolve.
         --wasm-dir <system>=<dir>[,<system>=<dir>…]
                           In-browser CMP tier: map a design system to its assembled Kotlin/Wasm
                           catalog app (./gradlew :samples:cmp-wasm-catalog:wasmCatalogDist →
@@ -1331,5 +1395,12 @@ class ServeCommand(args: List<String>) : Command(args) {
   private companion object {
     const val DEFAULT_PORT = 8723
     const val DEFAULT_IDLE_EXIT_SECONDS = 60L
+
+    /**
+     * Default catalog re-check cadence (10 min). Fresh enough that a regenerated design-artifacts
+     * branch reaches a running server within minutes, and — via `git ls-remote` (no API rate limit)
+     * — cheap enough to poll every watched catalog at this cadence indefinitely.
+     */
+    const val DEFAULT_CATALOG_REFRESH_SECONDS = 600L
   }
 }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -221,12 +221,21 @@ class ServeCommand(args: List<String>) : Command(args) {
   private val registeredCatalogs = mutableListOf<String>()
 
   /**
-   * Per-catalog per-preview daemon pools built by [buildTrustedCatalogBundle]. Each backs a live
-   * catalog's default (per-preview) render lane and outlives suspend/resume, so it's owned here and
-   * torn down at server shutdown (added to the [bringUpServer] closeables) rather than by the
-   * session host's [close][ServeHost.close].
+   * Per-catalog per-preview daemon pools built by [buildTrustedCatalogBundle], keyed by system.
+   * Each backs a live catalog's default (per-preview) render lane and outlives suspend/resume, so
+   * it's owned here — torn down at server shutdown ([catalogPerPreviewPoolsCloseable] in the
+   * [bringUpServer] closeables) rather than by the session host's [close][ServeHost.close] (the
+   * pool is referenced by the state's closure, not the host). Keyed so a [ServeCatalogRefresher]
+   * re-load closes the **previous** pool for that system instead of leaking its per-preview
+   * daemons.
    */
-  private val catalogPerPreviewPools = mutableListOf<AutoCloseable>()
+  private val catalogPerPreviewPools =
+    java.util.concurrent.ConcurrentHashMap<String, AutoCloseable>()
+
+  /** Closes every live per-preview pool at shutdown; a live view of [catalogPerPreviewPools]. */
+  private val catalogPerPreviewPoolsCloseable = AutoCloseable {
+    catalogPerPreviewPools.values.forEach { runCatching { it.close() } }
+  }
   /**
    * In-browser CMP tier (`--wasm-dir <system>=<dir>[,<system>=<dir>…]`): map a design system to the
    * assembled Wasm catalog app (`./gradlew :samples:cmp-wasm-catalog:wasmCatalogDist` →
@@ -469,8 +478,12 @@ class ServeCommand(args: List<String>) : Command(args) {
       mdnsModuleLabel = module.gradlePath,
       mdnsPreviewIds = previews.map { it.id },
       closeables =
-        listOf(worktrees, catalogWorktrees.takeIf { it !== worktrees }, catalogRefresher) +
-          catalogPerPreviewPools,
+        listOf(
+          worktrees,
+          catalogWorktrees.takeIf { it !== worktrees },
+          catalogRefresher,
+          catalogPerPreviewPoolsCloseable,
+        ),
     )
   }
 
@@ -542,7 +555,7 @@ class ServeCommand(args: List<String>) : Command(args) {
       // No module previews to advertise; discovery is a module-session nicety, so skip it here.
       mdnsModuleLabel = null,
       mdnsPreviewIds = null,
-      closeables = catalogPerPreviewPools.toList() + listOfNotNull(catalogRefresher),
+      closeables = listOfNotNull(catalogPerPreviewPoolsCloseable, catalogRefresher),
     )
   }
 
@@ -1044,7 +1057,6 @@ class ServeCommand(args: List<String>) : Command(args) {
         ) ?: return@ServePerPreviewDaemonPool null
       openHost(ppState)
     }
-    catalogPerPreviewPools += perPreviewPool
     // Carry the catalog-id→daemon-id alias + the baked-PNG fallback + the per-preview lane on the
     // state so openHost fronts the daemon with the baked catalog: the published /p/<id> deep links
     // +
@@ -1067,6 +1079,10 @@ class ServeCommand(args: List<String>) : Command(args) {
         ) ?: return false
     val host = openHost(state) ?: return false
     registry.register(system, state, host = host)
+    // Track the new pool and close the one it replaces — but only AFTER the fresh host is
+    // registered (register already closed the old host), so a re-load never closes a pool the
+    // still-live old host is mid-render on. First load for a system has no predecessor.
+    catalogPerPreviewPools.put(system, perPreviewPool)?.let { runCatching { it.close() } }
     System.err.println("serve: catalog $system → LIVE from bundle (no build) (?session=$system)")
     return true
   }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogRefresher.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogRefresher.kt
@@ -111,11 +111,28 @@ internal fun gitLsRemoteHead(repo: String, branch: String): String? =
         ProcessBuilder("git", "ls-remote", "https://github.com/$repo.git", "refs/heads/$branch")
           .redirectErrorStream(true)
           .start()
-      val out = proc.inputStream.bufferedReader().use { it.readText() }
+      proc.outputStream.close()
+      // Drain stdout on a daemon thread: if git hangs *without* closing stdout (a DNS/TLS/network
+      // stall), a direct `readText()` would block on EOF forever and never reach the `waitFor`
+      // timeout below — wedging the single catalog-refresh thread so no branch ever updates again.
+      // The reader thread lets `waitFor(20s)` bound the wait; `join` after the process exits reads
+      // the (now-complete) output safely.
+      val captured = StringBuilder()
+      val reader =
+        Thread {
+            runCatching {
+              proc.inputStream.bufferedReader().use { r -> captured.append(r.readText()) }
+            }
+          }
+          .apply {
+            isDaemon = true
+            start()
+          }
       if (!proc.waitFor(20, TimeUnit.SECONDS)) {
         proc.destroyForcibly()
         return null
       }
-      Regex("\\b([0-9a-f]{40})\\b").find(out)?.groupValues?.get(1)
+      reader.join(2_000)
+      Regex("\\b([0-9a-f]{40})\\b").find(captured.toString())?.groupValues?.get(1)
     }
     .getOrNull()

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogRefresher.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogRefresher.kt
@@ -1,0 +1,121 @@
+package ee.schimke.composeai.cli.serve
+
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
+
+/**
+ * Keeps a running `serve` fresh against routinely-changing catalog branches.
+ *
+ * `serve --catalogs <system>` fetches each system's `design-artifacts/<system>` branch — its
+ * `catalog.json`, baked renders, `web/wasm/` app, and `liveBundle` — **once at startup**. Nothing
+ * re-checks it, so a regenerated branch (the `design-artifacts.yml` force-push) never reaches a
+ * live server until the container restarts. But serving content that changes routinely is exactly
+ * what this multi-catalog server is for — `compose-m3` is no different from the external apps it
+ * also serves (`cadence`, `meshcore-mobile`, …), all of which go stale the same way.
+ *
+ * This closes that gap without a restart, a per-project server release, or baking content into the
+ * image: a daemon thread periodically resolves each catalog branch's head commit and, when it has
+ * moved, re-runs the same [reload] path (`ServeCatalogStore.load`) that the initial fetch used —
+ * which re-fetches into the same on-disk dir and re-registers the host in place (the registry
+ * closes the replaced host's daemon; the `/wasm/<system>/` route serves the rewritten dir on the
+ * next request). A branch whose head can't be resolved (offline, `git` absent) is simply skipped —
+ * the server keeps serving what it already has, exactly as today.
+ *
+ * @param entries the catalog branches to watch: `system` id + owning `repo` + full `branch` ref.
+ * @param reload re-fetch + re-register one system; the `store.load(system, sourceRepo = repo)`
+ *   seam. Its boolean result is whether the reload succeeded (a failure keeps the old head so the
+ *   next tick retries).
+ * @param headResolver resolve a branch's head commit sha (or null when it can't be determined).
+ *   Defaults to [gitLsRemoteHead]; injected so tests drive change detection without a network.
+ * @param intervalMillis poll cadence; the first tick fires one interval after [start].
+ */
+internal class ServeCatalogRefresher(
+  private val entries: List<Entry>,
+  private val reload: (system: String, repo: String) -> Boolean,
+  private val intervalMillis: Long,
+  private val headResolver: (repo: String, branch: String) -> String? = ::gitLsRemoteHead,
+  private val onLog: (String) -> Unit = { System.err.println(it) },
+) : AutoCloseable {
+
+  /** One watched catalog branch. */
+  data class Entry(val system: String, val repo: String, val branch: String)
+
+  private val lastHead = ConcurrentHashMap<String, String>()
+  private val exec: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor { r ->
+    Thread(r, "serve-catalog-refresh").apply { isDaemon = true }
+  }
+
+  /**
+   * Record each branch's current head so the first tick only reloads a branch that has *moved since
+   * boot*, not every branch once. Best-effort — an unresolvable branch stays absent, so its first
+   * successful resolve later counts as "changed" and triggers one reload (harmless, idempotent).
+   */
+  fun seedInitialHeads() {
+    for (e in entries) headResolver(e.repo, e.branch)?.let { lastHead[e.system] = it }
+  }
+
+  /** Start the daemon poller. Idempotent-safe to call once after [seedInitialHeads]. */
+  fun start() {
+    exec.scheduleWithFixedDelay(
+      {
+        runCatching { tick() }
+          .onFailure { onLog("serve: catalog refresh tick failed: ${it.message}") }
+      },
+      intervalMillis,
+      intervalMillis,
+      TimeUnit.MILLISECONDS,
+    )
+  }
+
+  /**
+   * One poll pass over every watched branch. Package-visible so a test can drive it
+   * deterministically.
+   */
+  fun tick() {
+    for (e in entries) checkOne(e)
+  }
+
+  private fun checkOne(e: Entry) {
+    // Can't resolve the head (offline / git missing / private) → leave what we serve untouched.
+    val head = headResolver(e.repo, e.branch) ?: return
+    if (head == lastHead[e.system]) return
+    val prev = lastHead[e.system]
+    onLog(
+      "serve: catalog ${e.system} (${e.branch}) moved ${prev?.take(7) ?: "?"}→${head.take(7)} — re-fetching"
+    )
+    if (runCatching { reload(e.system, e.repo) }.getOrDefault(false)) {
+      // Only advance the recorded head on success, so a failed reload retries next tick.
+      lastHead[e.system] = head
+      onLog("serve: catalog ${e.system} refreshed to ${head.take(7)}")
+    } else {
+      onLog("serve: catalog ${e.system} refresh failed — keeping the current copy, will retry")
+    }
+  }
+
+  override fun close() {
+    exec.shutdownNow()
+  }
+}
+
+/**
+ * Resolve a branch's head commit via `git ls-remote` — unauthenticated and unrated (unlike the
+ * GitHub commits API's 60/hr), so it scales to any number of watched catalogs. Returns null on any
+ * failure (git absent, network error, unknown branch), which the refresher treats as "can't check,
+ * skip". Best-effort with a bounded wait so a hung remote can't wedge the poll thread.
+ */
+internal fun gitLsRemoteHead(repo: String, branch: String): String? =
+  runCatching {
+      val proc =
+        ProcessBuilder("git", "ls-remote", "https://github.com/$repo.git", "refs/heads/$branch")
+          .redirectErrorStream(true)
+          .start()
+      val out = proc.inputStream.bufferedReader().use { it.readText() }
+      if (!proc.waitFor(20, TimeUnit.SECONDS)) {
+        proc.destroyForcibly()
+        return null
+      }
+      Regex("\\b([0-9a-f]{40})\\b").find(out)?.groupValues?.get(1)
+    }
+    .getOrNull()

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
@@ -161,9 +161,17 @@ class ServeCatalogStore(
         }
         .getOrNull() ?: return Result.Failed(system, "could not parse catalog.json")
 
+    // Stage the fetch so a re-load (ServeCatalogRefresher) can't turn a healthy catalog into 404s:
+    // fetch the images into a sibling `.staging` dir and only swap it over the live `dir` once we
+    // know we have a usable catalog (count > 0). A partial/failed fetch (e.g. images temporarily
+    // unavailable) leaves the currently-served `dir` untouched. The wasm / figma / liveBundle steps
+    // below run *after* the swap and are all fail-soft (they disable their tier or fall back to the
+    // baked host), so they never leave the catalog broken — only the image fetch is a hard failure,
+    // and that's what staging protects.
     val dir = File(root, safe)
-    dir.deleteRecursively()
-    val previewsDir = File(dir, "previews")
+    val staging = File(root, "$safe.staging")
+    staging.deleteRecursively()
+    val previewsDir = File(staging, "previews")
     val previewsRoot = previewsDir.canonicalFile.toPath()
     var count = 0
     // The component slugs whose baked figma-svg to fetch (a slug is the preview id up to `__`).
@@ -187,8 +195,18 @@ class ServeCatalogStore(
       }
     }
     if (count == 0) {
-      dir.deleteRecursively()
+      staging.deleteRecursively()
       return Result.Failed(system, "catalog had no usable images")
+    }
+
+    // The staged catalog is usable — atomically replace the live dir with it. The delete + rename
+    // is near-instant (same filesystem), so the window where `dir` is absent is microseconds, not
+    // the multi-second fetch above. From here everything operates on the fresh `dir` as before.
+    dir.deleteRecursively()
+    if (!staging.renameTo(dir)) {
+      // Cross-device or a racing reader held a handle — copy then drop the staging dir.
+      staging.copyRecursively(dir, overwrite = true)
+      staging.deleteRecursively()
     }
 
     // Optional in-browser Wasm tier: when the catalog declares a `compose-wasm` webRender, fetch

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistry.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistry.kt
@@ -115,6 +115,13 @@ class ServeSessionRegistry(
    * Seed a session from already-known [state] (e.g. the CLI's current checkout), optionally with an
    * already-open [host]. Replaces any prior entry. The session participates in suspend/resume like
    * a forked one — its daemon is released when idle and reopened from [state] on demand.
+   *
+   * **Re-registration closes the replaced host.** A catalog refresh ([ServeCatalogRefresher])
+   * re-runs the catalog load and re-registers the same pinned id with a fresh host; the prior
+   * entry's host (and its live daemon subprocess) is dropped from [sessions] and would otherwise
+   * never be closed (`close()` only walks the live map), leaking the daemon. So close it here —
+   * outside the lock, since a host `close()` can block on daemon shutdown. A no-op on first
+   * registration (no prior entry) and when the same host instance is re-registered.
    */
   fun register(
     sessionId: String,
@@ -122,12 +129,15 @@ class ServeSessionRegistry(
     host: ServeHost? = null,
     pinned: Boolean = false,
   ) {
-    lock.withLock {
+    val replaced = lock.withLock {
       check(!closed) { "ServeSessionRegistry is closed" }
+      val prior = sessions[sessionId]
       // Registered sessions (the current-checkout default, bundle/catalog hosts) are never GC'd:
       // forked = false keeps them permanently resumable regardless of pinning.
       sessions[sessionId] = Entry(state, host, pinned, forked = false, lastAccess = clock())
+      prior?.host?.takeIf { it !== host }
     }
+    replaced?.let { runCatching { it.close() } }
   }
 
   /**

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogRefresherTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogRefresherTest.kt
@@ -1,0 +1,142 @@
+package ee.schimke.composeai.cli.serve
+
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ServeCatalogRefresherTest {
+
+  private fun entry(system: String = "compose-m3") =
+    ServeCatalogRefresher.Entry(
+      system = system,
+      repo = "yschimke/compose-ai-tools",
+      branch = "design-artifacts/$system",
+    )
+
+  @Test
+  fun `reloads only when the branch head changes`() {
+    val head = ConcurrentHashMap(mapOf("compose-m3" to "aaaaaaa"))
+    val reloads = mutableListOf<String>()
+    val r =
+      ServeCatalogRefresher(
+        entries = listOf(entry()),
+        reload = { sys, _ ->
+          reloads += sys
+          true
+        },
+        intervalMillis = 1_000,
+        headResolver = { _, _ -> head["compose-m3"] },
+        onLog = {},
+      )
+    r.seedInitialHeads()
+    r.tick()
+    assertEquals(emptyList(), reloads, "unchanged head → no reload")
+    head["compose-m3"] = "bbbbbbb"
+    r.tick()
+    assertEquals(listOf("compose-m3"), reloads, "a moved head triggers exactly one reload")
+    r.tick()
+    assertEquals(listOf("compose-m3"), reloads, "the same new head does not reload again")
+    r.close()
+  }
+
+  @Test
+  fun `a failed reload keeps the old head and retries next tick`() {
+    var head = "aaaaaaa"
+    var succeed = false
+    val reloads = AtomicInteger(0)
+    val r =
+      ServeCatalogRefresher(
+        entries = listOf(entry()),
+        reload = { _, _ ->
+          reloads.incrementAndGet()
+          succeed
+        },
+        intervalMillis = 1_000,
+        headResolver = { _, _ -> head },
+        onLog = {},
+      )
+    r.seedInitialHeads()
+    head = "bbbbbbb"
+    r.tick()
+    assertEquals(1, reloads.get(), "the moved head is reloaded")
+    r.tick()
+    assertEquals(2, reloads.get(), "a failed reload didn't advance the head, so it retries")
+    succeed = true
+    r.tick()
+    assertEquals(3, reloads.get(), "still retrying until success")
+    r.tick()
+    assertEquals(3, reloads.get(), "a successful reload records the head, so it stops reloading")
+    r.close()
+  }
+
+  @Test
+  fun `an unresolvable head is skipped, never reloading`() {
+    val reloads = AtomicInteger(0)
+    val r =
+      ServeCatalogRefresher(
+        entries = listOf(entry()),
+        reload = { _, _ ->
+          reloads.incrementAndGet()
+          true
+        },
+        intervalMillis = 1_000,
+        headResolver = { _, _ -> null },
+        onLog = {},
+      )
+    r.seedInitialHeads()
+    r.tick()
+    r.tick()
+    assertEquals(0, reloads.get(), "a branch whose head can't be resolved is left exactly as-is")
+    r.close()
+  }
+
+  @Test
+  fun `seedInitialHeads prevents reloading an unchanged branch on the first tick`() {
+    val reloads = AtomicInteger(0)
+    val r =
+      ServeCatalogRefresher(
+        entries = listOf(entry()),
+        reload = { _, _ ->
+          reloads.incrementAndGet()
+          true
+        },
+        intervalMillis = 1_000,
+        headResolver = { _, _ -> "stable-sha" },
+        onLog = {},
+      )
+    r.seedInitialHeads()
+    r.tick()
+    assertEquals(
+      0,
+      reloads.get(),
+      "the boot head is recorded, so an unchanged branch isn't reloaded",
+    )
+    r.close()
+  }
+
+  @Test
+  fun `each catalog is tracked independently`() {
+    val heads = ConcurrentHashMap(mapOf("compose-m3" to "a1", "cadence" to "c1"))
+    val reloads = mutableListOf<String>()
+    val r =
+      ServeCatalogRefresher(
+        entries = listOf(entry("compose-m3"), entry("cadence")),
+        reload = { sys, _ ->
+          reloads += sys
+          true
+        },
+        intervalMillis = 1_000,
+        headResolver = { _, branch -> heads[branch.substringAfterLast('/')] },
+        onLog = {},
+      )
+    r.seedInitialHeads()
+    r.tick()
+    assertEquals(emptyList(), reloads)
+    // Only cadence moves — compose-m3 must not be re-fetched.
+    heads["cadence"] = "c2"
+    r.tick()
+    assertEquals(listOf("cadence"), reloads, "only the changed catalog reloads")
+    r.close()
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
@@ -90,6 +90,41 @@ class ServeCatalogStoreTest {
   }
 
   @Test
+  fun `a failed re-load leaves the previously-served catalog intact`() {
+    // The ServeCatalogRefresher re-runs load() on a live server; a transient total image outage
+    // must NOT delete the currently-served catalog (which would 404 it until the next success).
+    val root = tempRoot()
+    var imagesAvailable = true
+    val fetch: (String) -> ByteArray? = { url ->
+      when {
+        url.endsWith("/${ServeCatalogStore.CATALOG_FILE}") -> catalogJson.toByteArray()
+        url.endsWith(".png") -> if (imagesAvailable) png() else null
+        else -> null
+      }
+    }
+    val store =
+      ServeCatalogStore(
+        root = root,
+        register = { n, h -> registered[n] = h },
+        trust = TrustStore.EMPTY,
+        fetch = fetch,
+        registerWasm = { s, d -> registeredWasm[s] = d },
+      )
+    assertTrue(store.load("compose-m3") is ServeCatalogStore.Result.Ok, "first load succeeds")
+    val png = File(root, "compose-m3/previews/button-filled__ideal__default__dark.png")
+    assertTrue(png.isFile, "the first load writes the preview PNG on disk")
+
+    // Re-load with every image (transiently) unavailable — parseable catalog.json, zero images.
+    imagesAvailable = false
+    assertTrue(
+      store.load("compose-m3") is ServeCatalogStore.Result.Failed,
+      "a catalog with no usable images fails the re-load",
+    )
+    assertTrue(png.isFile, "the previously-served catalog is left intact on a failed re-load")
+    assertFalse(File(root, "compose-m3.staging").exists(), "the staging dir is cleaned up")
+  }
+
+  @Test
   fun `a catalog's baked figma svgs are fetched and served self-contained`() {
     val svg = "<svg><image href=\"button-filled.figma-raster/n0.png\"/></svg>"
     val crop = byteArrayOf(7, 7, 7)

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistryTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistryTest.kt
@@ -127,6 +127,49 @@ class ServeSessionRegistryTest {
       }
   }
 
+  /** Minimal [ServeHost] that only records whether it was closed. */
+  private class RecordingHost : ServeHost {
+    var closed = false
+      private set
+
+    override val previews: List<ServePreview> = emptyList()
+    override val label: String = "recording"
+
+    override fun render(previewId: String, overrides: PreviewOverrides): RenderOutcome =
+      RenderOutcome.NotFound
+
+    override fun subscribeStream(
+      previewId: String,
+      overrides: PreviewOverrides,
+      codec: ee.schimke.composeai.daemon.protocol.StreamCodec?,
+      maxFps: Int?,
+      onFrame: (ee.schimke.composeai.daemon.protocol.StreamFrameParams) -> Unit,
+    ): StreamHandle? = null
+
+    override fun activeStreamCount(): Int = 0
+
+    override fun close() {
+      closed = true
+    }
+  }
+
+  @Test
+  fun `re-registering a session id closes the replaced host`() {
+    ServeSessionRegistry(open = Opener()).use { reg ->
+      val first = RecordingHost()
+      val second = RecordingHost()
+      reg.register("compose-m3", host = first, pinned = true)
+      // A catalog refresh re-registers the same pinned id with a fresh host.
+      reg.register("compose-m3", host = second, pinned = true)
+      assertTrue(first.closed, "the replaced host (and its daemon) is closed on re-registration")
+      assertTrue(!second.closed, "the newly registered host stays open")
+      assertSame(second, reg.acquire("compose-m3"), "the new host is served")
+      // Re-registering the SAME instance must NOT close it (idempotent seed).
+      reg.register("compose-m3", host = second, pinned = true)
+      assertTrue(!second.closed, "re-registering the same host instance does not close it")
+    }
+  }
+
   @Test
   fun `a leased session is not suspended until the lease closes`() {
     val clock = AtomicLong(0)

--- a/deploy/image/docker-compose.yml
+++ b/deploy/image/docker-compose.yml
@@ -56,6 +56,10 @@ services:
       SERVE_CATALOG_SOURCE_REPO: "${SERVE_CATALOG_SOURCE_REPO:-}"
       SERVE_CATALOG_SOURCE_REF: "${SERVE_CATALOG_SOURCE_REF:-}"
       SERVE_LIVE_SEATS: "${SERVE_LIVE_SEATS:-}"
+      # Re-check each catalog's design-artifacts branch every N seconds and re-fetch on change, so a
+      # regenerated branch reaches this running server without a restart (Watchtower only rolls the
+      # image). Empty ⇒ the CLI default (600s); set 0 to disable and serve the boot snapshot only.
+      SERVE_CATALOG_REFRESH: "${SERVE_CATALOG_REFRESH:-}"
       PORT: "8080"
     # To pin your OWN producers, mount a trust store over the baked one and keep
     # SERVE_TRUST_STORE pointing at it:

--- a/deploy/image/entrypoint.sh
+++ b/deploy/image/entrypoint.sh
@@ -100,5 +100,12 @@ if [[ -n "${SERVE_IDLE_EXIT:-}" && "${SERVE_IDLE_EXIT}" != "0" ]]; then
   args+=("--exit-when-idle=${SERVE_IDLE_EXIT}")
 fi
 
+# Keep the published catalogs fresh against their `design-artifacts/<system>` branches WITHOUT a
+# restart: re-check each branch's head every SERVE_CATALOG_REFRESH seconds and re-fetch on change
+# (via `git ls-remote`, no API rate limit). Defaults to the CLI's 600s; set 0 to disable (serve the
+# boot snapshot until the container recycles). This is what lets a `design-artifacts.yml` regen
+# reach preview.coo.ee on its own — Watchtower only rolls the *image*, never the branch content.
+[[ -n "${SERVE_CATALOG_REFRESH:-}" ]] && args+=(--catalog-refresh-interval "${SERVE_CATALOG_REFRESH}")
+
 echo "entrypoint: compose-preview serve on 0.0.0.0:${PORT}" >&2
 exec compose-preview "${args[@]}"

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -180,6 +180,7 @@ release that carries `--catalogs-unlisted`).
 | CLI | compiled from this checkout (~8 min build) | the **released** tarball (`docker pull`, no build) + Watchtower auto-update |
 | Has the latest serve features? | **immediately** (built from `main`) | only once they're in a **published CLI release** (bump `CP_VERSION`) |
 | In-browser Wasm tier | local build, `SERVE_WASM_DIR=compose-m3=samples/cmp-wasm-catalog/build/wasmDist` | branch-fetch: `--catalogs` pulls each system's `web/wasm/` from the trusted branch (needs the branch to carry it) |
+| Picks up a regenerated `design-artifacts/<system>` branch | via the same auto-refresh (rebuild + re-run) | **auto**: the server re-checks each catalog branch head every `SERVE_CATALOG_REFRESH`s (default 600) and re-fetches on change — **no restart**. Watchtower only rolls the *image*; this keeps the *catalog content* current. Set `SERVE_CATALOG_REFRESH=0` to disable. |
 
 So **today** (before a release), deploy from source: `cd deploy/vps && DOMAIN=preview.coo.ee ./setup.sh`
 — it builds the current `main`, including the Wasm app, and comes up public. **After** the serve


### PR DESCRIPTION
## Problem

`serve --catalogs <system>` fetches each system's `design-artifacts/<system>` branch — `catalog.json`, baked PNG/SVG, the `web/wasm/` app, and the `liveBundle` — **once at startup**, then never re-checks it. So a regenerated branch (the `design-artifacts.yml` force-push) **never reaches a running server** until the container restarts.

This is exactly the staleness we hit on preview.coo.ee: `#2414` (Wasm knobs) merged and the branch was regenerated, but the live server kept serving the **old** wasm app (verified: the deployed 22 MB binary had zero knob code) because Watchtower only rolls the *image*, never the branch content.

And it's **not compose-m3-specific** — every routinely-changing catalog this multi-tenant server hosts (`wear-m3`, plus the external apps `cadence` / `meshcore-mobile` / `homeassistant-remotecompose`, served via `--catalogs-unlisted <sys>@<owner>/<repo>`) goes stale the same way. Serving content that changes routinely is what the server is *for*, so this makes it first-class.

## Fix — pull re-fetch

A background poller (`ServeCatalogRefresher`) resolves each catalog branch's head commit via **`git ls-remote`** (unauthenticated, no API rate limit, scales to any number of catalogs) and, when it has moved, re-runs the **same** `ServeCatalogStore.load(system)` the initial fetch used. That re-fetches into the same on-disk dir — so the `/wasm/<system>/` route serves the rewritten app on the next request — and re-registers the host in place. No restart, no per-project server release, nothing baked into the image.

- **`ServeSessionRegistry.register` now closes the host it replaces.** A re-load re-registers the same pinned id; the prior entry's live daemon subprocess would otherwise leak (`close()` only walks the live `sessions` map). Closed outside the lock (a daemon `close()` can block); a no-op on first registration and when the same instance is re-registered.
- **`--catalog-refresh-interval <seconds>`** (default `600`; `0` disables → boot-snapshot only), wired from **`SERVE_CATALOG_REFRESH`** in the image `entrypoint.sh` + `docker-compose.yml`.
- A branch whose head can't be resolved (offline, `git` absent, private) is **skipped** — the server keeps serving what it already has, exactly as today. A failed re-load keeps the old head so the next tick retries.

## Test plan

`ServeCatalogRefresherTest` (drives `tick()` deterministically with an injected head resolver):
- reloads **only** when the branch head changes; the same new head doesn't reload again;
- a **failed** reload keeps the old head and retries until it succeeds;
- an **unresolvable** head is skipped (never reloads);
- `seedInitialHeads` records the boot head so an unchanged branch isn't reloaded on the first tick;
- catalogs are tracked **independently** (only the changed one reloads).

`ServeSessionRegistryTest` gains `re-registering a session id closes the replaced host` (and leaves a re-registered *same* instance open). Full `:cli:test '*serve*'` green; ktfmt clean. Docs (`docs/public-preview-server.md`) updated — the "only a restart refreshes" row is now "auto: re-checks each branch head every `SERVE_CATALOG_REFRESH`s".

Text-only PR: this is server plumbing (branch-fetch lifecycle) with no rendered-surface change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jxz9i4SuuxPRt3knZKAPbb)_