### PR TITLE
feat(overrides): fake-clock injector for deterministic time-dependent previews

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
@@ -218,7 +218,8 @@ private fun printFullUsage() {
       --fps <n>            record: frames per second of the virtual playback clock (default 30)
       --scale <f>          record: capture scale multiplier (default 1.0)
       --overrides <k=v,…>  record: per-render overrides, e.g. touchOverlay=true (also device,
-                           localeTag, fontScale, density, widthPx, heightPx, inspectionMode)
+                           localeTag, fontScale, density, widthPx, heightPx, inspectionMode,
+                           clockEpochMillis=<epoch-ms> to pin a fake wall clock)
       --bundle             render: after rendering, pack each module's previews into a portable
                            PNG+ZIP bundle at <module>/build/compose-previews/bundle.png. Opt-in —
                            adds a classpath closure walk + jar minimization on top of the render.

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/RecordPreviewCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/RecordPreviewCommand.kt
@@ -343,10 +343,14 @@ class RecordPreviewCommand(args: List<String>) : Command(args) {
           "density" -> overrides.copy(density = value.toFloatOrFail(key))
           "widthPx" -> overrides.copy(widthPx = value.toIntOrFail(key))
           "heightPx" -> overrides.copy(heightPx = value.toIntOrFail(key))
+          // Fake wall clock (#1968): pin the preview's time-of-day to a fixed epoch-millis instant
+          // so relative timestamps / countdowns are deterministic. Needs the preview to read
+          // `LocalClock` (:data-preview-overrides-runtime).
+          "clockEpochMillis" -> overrides.copy(clockEpochMillis = value.toLongOrFail(key))
           else ->
             fail(
               "unsupported --overrides key '$key'. Supported: touchOverlay, inspectionMode, " +
-                "device, localeTag, fontScale, density, widthPx, heightPx"
+                "device, localeTag, fontScale, density, widthPx, heightPx, clockEpochMillis"
             )
         }
     }
@@ -371,6 +375,9 @@ class RecordPreviewCommand(args: List<String>) : Command(args) {
 
   private fun String.toIntOrFail(key: String): Int =
     toIntOrNull() ?: fail("--overrides $key expects an integer; got '$this'")
+
+  private fun String.toLongOrFail(key: String): Long =
+    toLongOrNull() ?: fail("--overrides $key expects an integer; got '$this'")
 
   // ---------------------------------------------------------------------------
   // Output.

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -1622,6 +1622,11 @@ open class RobolectricHost(
                 // when present. The `compose/overrides` data product (registered in `DaemonMain`)
                 // surfaces the declared knobs.
                 PreviewOverridesPreviewOverrideExtension(),
+                // Fake wall clock (#1968): when `renderNow.overrides.clockEpochMillis` is set, pin
+                // `LocalClock` to that instant so time-dependent UI (relative timestamps,
+                // countdowns) renders deterministically. Plans null when unset, so a plain render
+                // stays byte-identical. Same portable planner registered on `DesktopHost`.
+                FakeClockPreviewOverrideExtension(),
                 // Runtime pseudolocale: when `localeTag` is `en-XA` / `ar-XB`, wrap LocalContext
                 // with a Resources subclass that pseudolocalises `getString*` returns. The
                 // planner returns null for any other tag, so non-pseudo locales keep going through

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -535,6 +535,20 @@ data class PreviewOverrides(
    */
   val captureAdvanceMs: Long? = null,
   /**
+   * Fake **wall clock** — pins the preview's time-of-day to this instant (milliseconds since the
+   * Unix epoch) so time-dependent UI (relative timestamps like "2m ago", countdowns like "expires
+   * in…") renders deterministically instead of drifting every run (issue #1968). Both backends
+   * honour it through a composition-local provider (`:data-preview-overrides-connector`), so no
+   * renderer branch is involved.
+   *
+   * **Opt-in**, like `previewOverride*` / `PreviewSlot`: Compose has no built-in wall-clock local,
+   * so consumer UI must read time via `LocalClock` (`:data-preview-overrides-runtime`) rather than
+   * `System.currentTimeMillis()` to be affected. Null leaves `LocalClock` at real system time, so
+   * an untoggled render is byte-identical. Distinct from [captureAdvanceMs], which advances the
+   * paused *frame* clock (animations), not the wall clock. Negative values are ignored.
+   */
+  val clockEpochMillis: Long? = null,
+  /**
    * Per-render `LocalInspectionMode` value for one-shot renders. Null preserves the backend's
    * default preview behaviour (`true` for renderNow). Set `false` to render as runtime-like content
    * without allocating a held interactive session.

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -720,7 +720,15 @@ internal fun buildDesktopExtensions(
       id = "data/overrides",
       displayName = "Named preview overrides",
       dataProductRegistry = PreviewOverridesDataProductRegistry(),
-      previewOverrideExtensions = listOf(PreviewOverridesPreviewOverrideExtension()),
+      previewOverrideExtensions =
+        listOf(
+          PreviewOverridesPreviewOverrideExtension(),
+          // Fake wall clock (#1968): plans an extension only when
+          // `renderNow.overrides.clockEpochMillis` is set, pinning `LocalClock` to that instant so
+          // time-dependent UI renders deterministically. Portable — the same planner is wired into
+          // `RobolectricHost.previewOverrideExtensions` on Android.
+          FakeClockPreviewOverrideExtension(),
+        ),
     )
   }
   tryAdd("data/touch-overlay") {

--- a/data/preview-overrides/connector/src/main/kotlin/ee/schimke/composeai/daemon/FakeClockOverrideExtension.kt
+++ b/data/preview-overrides/connector/src/main/kotlin/ee/schimke/composeai/daemon/FakeClockOverrideExtension.kt
@@ -1,0 +1,55 @@
+package ee.schimke.composeai.daemon
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.data.render.extensions.DataExtension
+import ee.schimke.composeai.data.render.extensions.DataExtensionConstraints
+import ee.schimke.composeai.data.render.extensions.DataExtensionId
+import ee.schimke.composeai.data.render.extensions.DataExtensionPhase
+import ee.schimke.composeai.data.render.extensions.PlannedDataExtension
+import ee.schimke.composeai.data.render.extensions.compose.AroundComposableExtension
+import ee.schimke.composeai.overrides.LocalClock
+import ee.schimke.composeai.overrides.PreviewClock
+import ee.schimke.composeai.overrides.fixedPreviewClock
+
+/**
+ * `AroundComposable` extension that pins [LocalClock] to a fixed instant so time-dependent preview
+ * UI (relative timestamps, countdowns) renders deterministically (issue #1968). The portable,
+ * both-backend counterpart of the frame-clock advance: it acts purely through a composition local,
+ * so there is no renderer branch — a preview reads `LocalClock.current.nowEpochMillis()` and sees
+ * [epochMillis] instead of the drifting real time.
+ *
+ * Runs in [DataExtensionPhase.OuterEnvironment] so the clock local is in scope before user preview
+ * content reads it — matching `PseudolocaleOverrideExtension` /
+ * `PreviewOverridesOverrideExtension`.
+ */
+class FakeClockOverrideExtension(private val epochMillis: Long) :
+  AroundComposableExtension(
+    id = ID,
+    constraints = DataExtensionConstraints(phase = DataExtensionPhase.OuterEnvironment),
+  ) {
+  private val clock: PreviewClock = fixedPreviewClock(epochMillis)
+
+  @Composable
+  override fun AroundComposable(content: @Composable () -> Unit) {
+    CompositionLocalProvider(LocalClock provides clock) { content() }
+  }
+
+  companion object {
+    val ID: DataExtensionId = DataExtensionId("data-fake-clock")
+  }
+}
+
+/**
+ * Planner mapping `renderNow.overrides.clockEpochMillis` to a [FakeClockOverrideExtension]. Returns
+ * null when the field is unset or negative, so a plain render keeps [LocalClock] at real system
+ * time and stays byte-identical — the fake clock only engages when a caller explicitly pins an
+ * instant.
+ */
+class FakeClockPreviewOverrideExtension : DataExtension<PreviewOverrides> {
+  override val id: DataExtensionId = FakeClockOverrideExtension.ID
+
+  override fun plan(request: PreviewOverrides): PlannedDataExtension? =
+    request.clockEpochMillis?.takeIf { it >= 0 }?.let(::FakeClockOverrideExtension)
+}

--- a/data/preview-overrides/connector/src/test/kotlin/ee/schimke/composeai/daemon/FakeClockOverrideExtensionTest.kt
+++ b/data/preview-overrides/connector/src/test/kotlin/ee/schimke/composeai/daemon/FakeClockOverrideExtensionTest.kt
@@ -1,0 +1,40 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class FakeClockOverrideExtensionTest {
+
+  private val extension = FakeClockPreviewOverrideExtension()
+
+  @Test
+  fun `plan returns null when no fake clock is set`() {
+    assertNull(extension.plan(PreviewOverrides()))
+    assertNull(extension.plan(PreviewOverrides(clockEpochMillis = null)))
+  }
+
+  @Test
+  fun `plan returns null for a negative instant`() {
+    // A negative epoch is nonsensical for a pinned wall clock; abstain so the render stays
+    // byte-identical rather than pinning to a pre-1970 instant.
+    assertNull(extension.plan(PreviewOverrides(clockEpochMillis = -1)))
+  }
+
+  @Test
+  fun `plan returns the fake-clock extension when an instant is set`() {
+    val planned = extension.plan(PreviewOverrides(clockEpochMillis = 1_700_000_000_000))
+    assertNotNull(planned)
+    assertEquals(FakeClockOverrideExtension.ID, planned!!.id)
+    assertTrue(planned is FakeClockOverrideExtension)
+  }
+
+  @Test
+  fun `plan accepts the epoch zero instant`() {
+    // Zero (1970-01-01T00:00:00Z) is a valid pin — only negatives are rejected.
+    assertNotNull(extension.plan(PreviewOverrides(clockEpochMillis = 0)))
+  }
+}

--- a/data/preview-overrides/runtime/src/main/kotlin/ee/schimke/composeai/overrides/PreviewClock.kt
+++ b/data/preview-overrides/runtime/src/main/kotlin/ee/schimke/composeai/overrides/PreviewClock.kt
@@ -1,0 +1,34 @@
+package ee.schimke.composeai.overrides
+
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.compositionLocalOf
+
+/**
+ * A wall clock a `@Preview` reads so a fake-clock override can pin it (issue #1968).
+ *
+ * Compose has no built-in composition-local for time-of-day, so consumer UI that shows
+ * time-dependent content — relative timestamps ("2m ago"), countdowns ("expires in…") — reads
+ * [LocalClock]`.current.nowEpochMillis()` instead of `System.currentTimeMillis()`. Adopting it is
+ * behaviour-preserving: in a normal render (and in production) [LocalClock] defaults to
+ * [SystemPreviewClock] (real system time). Under the daemon's `clockEpochMillis` override the
+ * connector provides a fixed clock around the rendered preview, so the frame is deterministic — the
+ * same opt-in model as `previewOverride*` and `PreviewSlot`.
+ */
+fun interface PreviewClock {
+  /** Milliseconds since the Unix epoch — what the preview should treat as "now". */
+  fun nowEpochMillis(): Long
+}
+
+/** The real wall clock: the default [LocalClock] value when no fake-clock override is active. */
+val SystemPreviewClock: PreviewClock = PreviewClock { System.currentTimeMillis() }
+
+/** A [PreviewClock] frozen at [epochMillis] — what the fake-clock override installs. */
+fun fixedPreviewClock(epochMillis: Long): PreviewClock = PreviewClock { epochMillis }
+
+/**
+ * The clock preview content reads for wall-clock time. Defaults to [SystemPreviewClock]; the
+ * daemon's `clockEpochMillis` render override provides a [fixedPreviewClock] around the rendered
+ * preview (issue #1968), mirroring how the `slotMode` override provides `LocalSlotMode`. Backends
+ * that don't provide it (or a plain render) leave it at real system time.
+ */
+val LocalClock: ProvidableCompositionLocal<PreviewClock> = compositionLocalOf { SystemPreviewClock }

--- a/data/preview-overrides/runtime/src/test/kotlin/ee/schimke/composeai/overrides/PreviewClockTest.kt
+++ b/data/preview-overrides/runtime/src/test/kotlin/ee/schimke/composeai/overrides/PreviewClockTest.kt
@@ -1,0 +1,30 @@
+package ee.schimke.composeai.overrides
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PreviewClockTest {
+
+  @Test
+  fun `fixedPreviewClock reports its pinned instant`() {
+    val clock = fixedPreviewClock(1_700_000_000_000)
+    assertEquals(1_700_000_000_000, clock.nowEpochMillis())
+    // Stable across reads — a pinned clock never advances.
+    assertEquals(1_700_000_000_000, clock.nowEpochMillis())
+  }
+
+  @Test
+  fun `SystemPreviewClock tracks real wall-clock time`() {
+    val before = System.currentTimeMillis()
+    val now = SystemPreviewClock.nowEpochMillis()
+    val after = System.currentTimeMillis()
+    assertTrue("system clock reads within the sampling window", now in before..after)
+  }
+
+  @Test
+  fun `PreviewClock is a functional interface`() {
+    val clock = PreviewClock { 42 }
+    assertEquals(42, clock.nowEpochMillis())
+  }
+}

--- a/docs/daemon/RECORDING-ASSERTIONS.md
+++ b/docs/daemon/RECORDING-ASSERTIONS.md
@@ -173,11 +173,18 @@ Comparison with the emulator-driven UI-test tools this is modelled on:
 Things these tools apply on emulators that *could* map onto held preview scenes, with how they'd
 land (each is a separate follow-up, not in this PR):
 
-- **State / network / clock injection** — Maestro's `setLocation`, Espresso's `IdlingResource` and
-  test doubles. Previews already expose `PreviewOverrides` (locale, font scale, theme, ambient,
-  permissions, …); the same `DataExtension` seam could inject a fake clock or a canned network
-  response so an assertion checks a *loaded* state rather than a spinner. Fits the existing override
-  model cleanly.
+- **Fake clock** — **Shipped** as the `clockEpochMillis` override (issue #1968). Pins the preview's
+  wall clock to a fixed instant so time-dependent UI — relative timestamps ("2m ago"), countdowns
+  ("expires in…") — renders deterministically instead of drifting every run, so an assertion checks a
+  stable frame. It rides the existing `DataExtension` seam (no renderer branch): the
+  `:data-preview-overrides-connector` planner provides a fixed clock through the `LocalClock`
+  composition local (`:data-preview-overrides-runtime`), and it's **opt-in** — since Compose has no
+  built-in wall-clock local, consumer UI reads `LocalClock.current.nowEpochMillis()` instead of
+  `System.currentTimeMillis()`, the same model as `previewOverride*` / `PreviewSlot`. Drive it with
+  `compose-preview record --overrides clockEpochMillis=<epoch-ms>`. Both backends honour it.
+- **Canned state / network injection** — Maestro's `setLocation`, Espresso's `IdlingResource` and
+  test doubles. A canned "loaded vs. loading vs. error" seam so an assertion checks *content* rather
+  than a spinner would fit the same override model as the fake clock above — a natural follow-up.
 - **Retry / flake quarantine** — emulator suites re-run flaky tests. Here it's mostly moot: the
   virtual clock makes a scripted recording deterministic frame-for-frame, so a flaky assertion is a
   real bug, not a timing race. Worth a note in docs rather than a retry knob.


### PR DESCRIPTION
Closes #1968 (the fake-clock injector; canned-data/network is left as a documented follow-up).

## Summary

Adds a **fake wall clock** so time-dependent preview UI — relative timestamps ("2m ago"), countdowns ("expires in…") — renders deterministically instead of drifting every run, so a recording can assert on a stable, *loaded* frame rather than a moving target.

It rides the existing `PreviewOverrides` / `DataExtension` seam — **no `RenderEngine` or `JsonRpcServer` branch**, per the issue and AGENTS.md ("no hardcoded special-case logic for extensions"):

- **`PreviewOverrides.clockEpochMillis`** (`daemon:core`) — pin the preview's wall clock to this epoch-millis instant. Nullable/absent = unchanged; negative = ignored.
- **`:data-preview-overrides-runtime`** gains **`LocalClock` + `PreviewClock`** — the opt-in composition local consumer UI reads for wall-clock time. Compose has no built-in wall-clock local, so this is opt-in exactly like `previewOverride*` / `PreviewSlot`: a preview reads `LocalClock.current.nowEpochMillis()` instead of `System.currentTimeMillis()`. It **defaults to real system time**, so adopting it is behaviour-preserving in production and in a plain render.
- **`:data-preview-overrides-connector`** gains **`FakeClockOverrideExtension`** (an `AroundComposable` that provides a fixed `LocalClock`) + its `DataExtension<PreviewOverrides>` planner, which engages **only** when `clockEpochMillis >= 0` — so a plain render stays byte-identical. Registered on **both** backends (desktop `DaemonMain`, Android `RobolectricHost`).
- **CLI**: `compose-preview record --overrides clockEpochMillis=<epoch-ms>` (plus the `--overrides` help + a new `toLongOrFail`).

Per the maintainer's call, this is **folded into the existing preview-overrides runtime/connector pair** rather than new published modules — the connector was already a daemon dependency and already `api`-exports the runtime, so there's no `settings.gradle.kts` / daemon-build wiring.

## Design note / scope

The connector seam can only inject a **composition local**, so this pins the **wall clock** for opt-in time-of-day UI. Pinning the deterministic **frame clock** (so `withFrameNanos`-driven animation lands at a fixed virtual instant with no source changes) would require a `RenderEngine` branch (`mainClock.advanceTimeBy` / desktop `frameNanoTime`) — explicitly out of scope for this issue. `captureAdvanceMs` already covers *relative* frame advance. The `RECORDING-ASSERTIONS.md` follow-up bullet is updated to mark the fake clock shipped and reframe canned-state as the remaining follow-up.

## Test plan

`./gradlew :data-preview-overrides-runtime:test :data-preview-overrides-connector:test :cli:test` — green; `:daemon:desktop:compileKotlin` green (Android compile needs the SDK, unavailable in this env; the registration is a one-line same-package addition that CI compiles).

- `FakeClockOverrideExtensionTest` — planner engages (returns the extension with `id = data-fake-clock`) only for a non-negative instant; returns null for unset / null / negative; accepts epoch 0.
- `PreviewClockTest` — `fixedPreviewClock` reports its pinned instant and never advances; `SystemPreviewClock` tracks real time; `PreviewClock` is a functional interface.

Note: the pre-existing `InteractiveCoalescingTest` (a 2.5s wall-clock render-coalescing timing test in `:daemon:core`) flakes under load in this container — it fails identically with my `Messages.kt` change stashed, so it's environmental and unrelated to adding a nullable field.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NE5X73NdmATow7RbkWtEgj)_