### PR TITLE
fix(serve): set render outputDir so the bundle daemon registers figma-svg

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt
@@ -153,6 +153,17 @@ internal object ServeBundleDaemon {
           mapOf(
             "composeai.daemon.userClassDirs" to userClassPath,
             "composeai.daemon.previewsJsonPath" to previewsJson.absolutePath,
+            // Point the daemon's render output at `<destDir>/renders`. This is what makes
+            // `DaemonMain.dataRoot` non-null (`<destDir>/data`), which is the gate that *registers*
+            // the file-based data products — including `compose/figma-svg` (+ `-long`). Without it
+            // `dataRoot` is null, the figma-svg producer still writes its SVG (it has an
+            // independent
+            // fallback dir) but the product is never advertised, so an override-bearing `.svg`
+            // render fails `-32020 kind not advertised` and the SVG lane 404s (ServeRenderHost's
+            // `enableExtensions` gets it back in `unknown`). `RenderEngine.dataDir` resolves to the
+            // SAME `<destDir>/data` (`outputDir.parent/data`), so the registry reads exactly where
+            // the render wrote. Keep the key literal to avoid a `:daemon:desktop` compile dep.
+            "composeai.render.outputDir" to File(destDir, "renders").absolutePath,
           ),
         workingDirectory = destDir.absolutePath,
         manifestPath = previewsJson.absolutePath,

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemonTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemonTest.kt
@@ -69,6 +69,22 @@ class ServeBundleDaemonTest {
     assertEquals(previewsJsonPath, parsed.manifestPath)
     assertEquals(state.workspaceRoot.absolutePath, parsed.workingDirectory)
 
+    // The render-output dir must be set so DaemonMain.dataRoot is non-null and the file-based data
+    // products register — notably compose/figma-svg, without which an override-bearing .svg render
+    // fails "-32020 kind not advertised". It must sit under the working dir so its sibling `data/`
+    // (where both DaemonMain's registry and RenderEngine's producer resolve) is inside this
+    // session's temp tree.
+    val outputDir = parsed.systemProperties["composeai.render.outputDir"]
+    assertTrue(
+      !outputDir.isNullOrBlank(),
+      "composeai.render.outputDir must be set so figma-svg registers",
+    )
+    assertEquals(
+      File(state.workspaceRoot, "renders").absolutePath,
+      outputDir,
+      "output dir lives under the session dir, so its sibling data/ dir does too",
+    )
+
     assertTrue(state.previews.isNotEmpty(), "materialize should discover at least one preview")
     assertEquals("compose-m3", state.label)
 

--- a/render-session/subprocess/src/main/kotlin/ee/schimke/composeai/render/session/subprocess/SubprocessRenderSession.kt
+++ b/render-session/subprocess/src/main/kotlin/ee/schimke/composeai/render/session/subprocess/SubprocessRenderSession.kt
@@ -119,6 +119,12 @@ object SubprocessRenderSessions : RenderSessionFactory {
           mapOf(
             "composeai.daemon.userClassDirs" to classesDir.absolutePath,
             "composeai.daemon.previewsJsonPath" to previewsJson.absolutePath,
+            // Set the render-output dir so DaemonMain.dataRoot is non-null and the file-based data
+            // products (compose/figma-svg + -long, semantics, wireframe, …) register — otherwise a
+            // data/fetch(compose/figma-svg) on a bundle daemon fails "-32020 kind not advertised".
+            // `<root>/data` (where the registry + the RenderEngine producer both resolve) then sits
+            // inside this session's tree. Mirrors ServeBundleDaemon.materialize.
+            "composeai.render.outputDir" to File(canonicalRoot, "renders").absolutePath,
           ),
         workingDirectory = canonicalRoot.absolutePath,
         manifestPath = previewsJson.absolutePath,


### PR DESCRIPTION
## Summary

An override-bearing SVG render on a **published-catalog** server (the catalog-live daemon on preview.coo.ee) fails with `-32020 kind not advertised` for `compose/figma-svg`. Root cause: the bundle-daemon launch descriptor never sets `composeai.render.outputDir`, so `DaemonMain.dataRoot` is `null` and the `if (dataRoot != null)` block that registers the file-based data products — including `compose/figma-svg` (+ `-long`) — is skipped entirely.

This wires `composeai.render.outputDir` into the descriptor's `systemProperties` in both bundle-daemon launch paths:

- `ServeBundleDaemon.materialize` (the `serve --catalogs` path that fetches a catalog's `liveBundle`)
- `SubprocessRenderSessions.openBundleDaemon` (the in-process bundle-daemon path)

pointing at `<sessionDir>/renders`, so its sibling `<sessionDir>/data` — where both `DaemonMain`'s registry and `RenderEngine`'s producer resolve — lands inside the session's own tree. With `dataRoot` non-null, `compose/figma-svg` registers and the override `.svg` lane resolves instead of 404/`-32020`.

Server plumbing only — no visual surface changes. This is what lets the override-SVG lane (`…button-filled….svg?knob.label=…`) work on the deployed published-catalog daemon, which the earlier `hasSvgExport` enable work (#2418/#2419) assumed was already advertised.

## Test plan

- `ServeBundleDaemonTest` asserts the descriptor's `composeai.render.outputDir` equals `<workspaceRoot>/renders` (its sibling `data/` therefore sits inside the session temp tree). `:cli:test --tests '*ServeBundleDaemonTest*'` green.
- Override-SVG on a published catalog can't be pixel-captured headlessly without a real catalog-live daemon + catalog branch, so live confirmation (`https://preview.coo.ee/compose-m3/render/button-filled__ideal__default__dark.svg?knob.label=Hello` returns 200 SVG, not 404) will follow once this releases and the deployed image rolls.

_Generated by [Claude Code]_

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jxz9i4SuuxPRt3knZKAPbb)_