### PR TITLE
fix(deploy): make Caddy WebSocket-safe so Live Compose /ws/ streams

### DIFF
--- a/deploy/image/Caddyfile
+++ b/deploy/image/Caddyfile
@@ -7,9 +7,17 @@
 {$DOMAIN} {
 	encode zstd gzip
 
+	# The backend serves two long-lived request shapes: multi-second cold renders
+	# and the persistent /ws/ WebSocket frame lane (Live Compose). Stream responses
+	# straight through (flush_interval -1) and DON'T put a read deadline on the
+	# upstream connection — a `read_timeout` on the http transport fails the
+	# WebSocket upgrade with a 502 (the /ws/ frame lane never opens). Bound only the
+	# initial dial; the app enforces its own render timeout, so an un-capped read
+	# here won't hold a render open forever.
 	reverse_proxy preview:8080 {
+		flush_interval -1
 		transport http {
-			read_timeout 120s
+			dial_timeout 30s
 		}
 	}
 }

--- a/deploy/oracle/Caddyfile
+++ b/deploy/oracle/Caddyfile
@@ -9,10 +9,17 @@
 {$DOMAIN} {
 	encode zstd gzip
 
+	# The backend serves two long-lived request shapes: multi-second cold renders
+	# and the persistent /ws/ WebSocket frame lane (Live Compose). Stream responses
+	# straight through (flush_interval -1) and DON'T put a read deadline on the
+	# upstream connection — a `read_timeout` on the http transport fails the
+	# WebSocket upgrade with a 502 (the /ws/ frame lane never opens), and would also
+	# cut a slow cold render short. Bound only the initial dial; the app enforces its
+	# own render timeout.
 	reverse_proxy preview:8080 {
-		# Renders can take a few seconds on a cold daemon; don't cut them short.
+		flush_interval -1
 		transport http {
-			read_timeout 120s
+			dial_timeout 30s
 		}
 	}
 

--- a/deploy/vps/Caddyfile
+++ b/deploy/vps/Caddyfile
@@ -9,10 +9,17 @@
 {$DOMAIN} {
 	encode zstd gzip
 
+	# The backend serves two long-lived request shapes: multi-second cold renders
+	# and the persistent /ws/ WebSocket frame lane (Live Compose). Stream responses
+	# straight through (flush_interval -1) and DON'T put a read deadline on the
+	# upstream connection — a `read_timeout` on the http transport fails the
+	# WebSocket upgrade with a 502 (the /ws/ frame lane never opens), and would also
+	# cut a slow cold render short. Bound only the initial dial; the app enforces its
+	# own render timeout.
 	reverse_proxy preview:8080 {
-		# Renders can take a few seconds on a cold daemon; don't cut them short.
+		flush_interval -1
 		transport http {
-			read_timeout 120s
+			dial_timeout 30s
 		}
 	}
 


### PR DESCRIPTION
## Summary

On the public server (preview.coo.ee) the **Live Compose** mode fails: its WebSocket (`wss://…/{system}/ws/{id}`) never opens. A faithful browser probe returns:

```
WebSocket handshake failed: Unexpected response code: 502   (close 1006, not clean)
```

The other three lanes (PNG, SVG, Wasm) work and honor `?knob.…` overrides — only the WS lane is dead.

**Root cause is the reverse proxy, not the server.** The committed Caddyfiles carried:

```
reverse_proxy preview:8080 {
    transport http { read_timeout 120s }
}
```

A `read_timeout` on the http transport puts a read deadline on the upstream connection, which fails the WebSocket **upgrade** (Caddy returns 502 before a 101 is ever produced). `serveStreamLane` only closes *after* a 101, so the server-side logic isn't even reached.

### Verified diagnosis (server is fine; it's the proxy)

Booted a local `compose-preview serve --catalogs compose-m3 --public` and probed the frame lane **directly** (no Caddy):

```
ws://127.0.0.1:8723/compose-m3/ws/<id>  →  {"outcome":"frame","bytes":2027,"events":["open"]}
```

The upgrade succeeds and a frame is delivered. So the 502 is introduced solely by the Caddy hop.

### The fix

Across `deploy/{image,oracle,vps}/Caddyfile`, make the proxy WebSocket/streaming-safe:

- `flush_interval -1` — stream responses through immediately (WS frames + long renders), no buffering.
- drop `read_timeout` on the transport; bound only `dial_timeout 30s`. The app enforces its own render timeout (`--timeout`), so an un-capped read won't hold a render open forever, and the WS upgrade is no longer deadline-failed.

`deploy/cloudrun` has no Caddyfile (Cloud Run's front end proxies WebSockets natively), so no change there.

## Test plan

- **Server side proven locally**: direct `ws://…/compose-m3/ws/<id>` on a local serve upgrades + returns a 2027-byte frame (above). The 502 is Caddy-only.
- **Best-effort on the proxy directive**: I could not run a `caddy` binary in this environment (no docker daemon; the egress proxy blocks the release download) to bisect the exact directive behind Caddy, so this applies Caddy's canonical streaming/WS-safe recipe rather than a locally-reproduced fix. **Needs confirmation on coo.ee after `caddy reload`** — Live Compose should upgrade (101) and the `?knob.…` override should re-render live. If a residual issue remains, next suspects are the `encode` directive on the `/ws/` path or a stale on-box Caddyfile.
- Config-only (reverse-proxy tuning); no code or visual-surface change.

_Generated by [Claude Code]_

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jxz9i4SuuxPRt3knZKAPbb)_