### PR TITLE
fix(deploy): drop Caddy flush_interval -1 so aborted renders cancel

### DIFF
--- a/deploy/image/Caddyfile
+++ b/deploy/image/Caddyfile
@@ -7,15 +7,19 @@
 {$DOMAIN} {
 	encode zstd gzip
 
-	# The backend serves two long-lived request shapes: multi-second cold renders
-	# and the persistent /ws/ WebSocket frame lane (Live Compose). Stream responses
-	# straight through (flush_interval -1) and DON'T put a read deadline on the
-	# upstream connection — a `read_timeout` on the http transport fails the
-	# WebSocket upgrade with a 502 (the /ws/ frame lane never opens). Bound only the
-	# initial dial; the app enforces its own render timeout, so an un-capped read
-	# here won't hold a render open forever.
+	# The /ws/ WebSocket frame lane (Live Compose) was 502ing: a `read_timeout` on
+	# the http transport puts a read deadline on the upstream connection and fails
+	# the WebSocket upgrade before a 101 is produced. Dropping it fixes the upgrade —
+	# WebSockets are proxied by connection hijack (no read deadline, no response
+	# buffering involved), and long cold renders are already bounded by the app's own
+	# --timeout, so the proxy needn't cap the read. Bound only the initial dial.
+	#
+	# Deliberately NOT `flush_interval -1`: a negative flush interval disables
+	# response buffering globally AND, per Caddy's reverse_proxy docs, does not cancel
+	# the upstream request on client disconnect — an abandoned /render/*.png|svg tab
+	# would then hold a render slot for the whole cold-render budget. WS doesn't need
+	# it (hijacked); render endpoints must keep cancel-on-disconnect.
 	reverse_proxy preview:8080 {
-		flush_interval -1
 		transport http {
 			dial_timeout 30s
 		}

--- a/deploy/oracle/Caddyfile
+++ b/deploy/oracle/Caddyfile
@@ -9,15 +9,19 @@
 {$DOMAIN} {
 	encode zstd gzip
 
-	# The backend serves two long-lived request shapes: multi-second cold renders
-	# and the persistent /ws/ WebSocket frame lane (Live Compose). Stream responses
-	# straight through (flush_interval -1) and DON'T put a read deadline on the
-	# upstream connection — a `read_timeout` on the http transport fails the
-	# WebSocket upgrade with a 502 (the /ws/ frame lane never opens), and would also
-	# cut a slow cold render short. Bound only the initial dial; the app enforces its
-	# own render timeout.
+	# The /ws/ WebSocket frame lane (Live Compose) was 502ing: a `read_timeout` on
+	# the http transport puts a read deadline on the upstream connection and fails
+	# the WebSocket upgrade before a 101 is produced. Dropping it fixes the upgrade —
+	# WebSockets are proxied by connection hijack (no read deadline, no response
+	# buffering involved), and long cold renders are already bounded by the app's own
+	# --timeout, so the proxy needn't cap the read. Bound only the initial dial.
+	#
+	# Deliberately NOT `flush_interval -1`: a negative flush interval disables
+	# response buffering globally AND, per Caddy's reverse_proxy docs, does not cancel
+	# the upstream request on client disconnect — an abandoned /render/*.png|svg tab
+	# would then hold a render slot for the whole cold-render budget. WS doesn't need
+	# it (hijacked); render endpoints must keep cancel-on-disconnect.
 	reverse_proxy preview:8080 {
-		flush_interval -1
 		transport http {
 			dial_timeout 30s
 		}

--- a/deploy/vps/Caddyfile
+++ b/deploy/vps/Caddyfile
@@ -9,15 +9,19 @@
 {$DOMAIN} {
 	encode zstd gzip
 
-	# The backend serves two long-lived request shapes: multi-second cold renders
-	# and the persistent /ws/ WebSocket frame lane (Live Compose). Stream responses
-	# straight through (flush_interval -1) and DON'T put a read deadline on the
-	# upstream connection — a `read_timeout` on the http transport fails the
-	# WebSocket upgrade with a 502 (the /ws/ frame lane never opens), and would also
-	# cut a slow cold render short. Bound only the initial dial; the app enforces its
-	# own render timeout.
+	# The /ws/ WebSocket frame lane (Live Compose) was 502ing: a `read_timeout` on
+	# the http transport puts a read deadline on the upstream connection and fails
+	# the WebSocket upgrade before a 101 is produced. Dropping it fixes the upgrade —
+	# WebSockets are proxied by connection hijack (no read deadline, no response
+	# buffering involved), and long cold renders are already bounded by the app's own
+	# --timeout, so the proxy needn't cap the read. Bound only the initial dial.
+	#
+	# Deliberately NOT `flush_interval -1`: a negative flush interval disables
+	# response buffering globally AND, per Caddy's reverse_proxy docs, does not cancel
+	# the upstream request on client disconnect — an abandoned /render/*.png|svg tab
+	# would then hold a render slot for the whole cold-render budget. WS doesn't need
+	# it (hijacked); render endpoints must keep cancel-on-disconnect.
 	reverse_proxy preview:8080 {
-		flush_interval -1
 		transport http {
 			dial_timeout 30s
 		}


### PR DESCRIPTION
## Summary

Follow-up to #2440 (the Caddy WebSocket fix), addressing a Codex P2 that landed after #2440 auto-merged.

#2440 added a global `flush_interval -1` alongside dropping the transport `read_timeout`. The `read_timeout` removal is what actually fixes the WebSocket 502 — **WebSockets are proxied by connection hijack, not response buffering, so `flush_interval` plays no part in the `/ws/` upgrade.** Meanwhile, per Caddy's [reverse_proxy docs](https://caddyserver.com/docs/caddyfile/directives/reverse_proxy#streaming) a negative `flush_interval` disables buffering globally **and does not cancel the upstream request on client disconnect**. That regresses the render lanes: an abandoned `/render/*.png|svg` tab would keep the daemon rendering and hold a render slot for the whole cold-render budget (those routes block in `handleRender` under the render semaphore).

So this removes `flush_interval -1` from all three Caddyfiles (`deploy/{image,oracle,vps}`), keeping only `transport http { dial_timeout 30s }`. The WebSocket upgrade still works (it never depended on `flush_interval`), and `/render` requests regain cancel-on-disconnect. Renders remain bounded by the app's own `--timeout`.

## Test plan

- WebSocket lane: unaffected by this change — the upgrade is a hijacked connection, independent of `flush_interval`. The `read_timeout` removal from #2440 (still in place) is the WS fix; verified locally that a direct `ws://…/{system}/ws/{id}` upgrades and delivers a frame.
- Render lanes: with the default flush behavior restored, Caddy propagates client disconnects to the upstream, so an aborted `/render/*.png|svg` no longer pins a render slot.
- Config-only (reverse-proxy tuning); no code or visual-surface change.

_Generated by [Claude Code]_

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jxz9i4SuuxPRt3knZKAPbb)_