### PR TITLE
feat(serve): make figma-svg-long re-render override-aware

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.cli.serve
 
+import ee.schimke.composeai.daemon.protocol.DataFetchParams
 import ee.schimke.composeai.daemon.protocol.InteractiveInputKind
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.daemon.protocol.StreamCodec
@@ -25,6 +26,8 @@ import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonPrimitive
 import okio.FileSystem
@@ -441,19 +444,19 @@ internal constructor(
    * a cached result when one exists. Thread-safe.
    *
    * Unlike [renderSvg] this fetches the `requiresRerender = true` long kind directly:
-   * `session.fetchData` drives the daemon's `figma-svg-long` re-render (an expanded-viewport render
-   * that composes the whole list) and returns the written SVG path — so there's no separate PNG
-   * render to force first. Still serialised through [renderLock] with the fetch reading the file
-   * the re-render just wrote.
+   * `session.fetchData` drives the daemon's `figma-svg-long` re-render (an expanded-viewport /
+   * slice- stitched render that composes the whole list) and returns the written SVG path — so
+   * there's no separate PNG render to force first. Still serialised through [renderLock] with the
+   * fetch reading the file the re-render just wrote.
    *
-   * The full-page export currently renders at the preview's **default** overrides — the
-   * `data/fetch` re-render path is keyed by `(previewId, kind)` and doesn't carry the live `uiMode`
-   * / `device` / locale / theme / knob overrides (the same limitation the scroll PNG data products
-   * have). So [overrides] are deliberately **not** part of the cache key: keying by them would
-   * cache the one override-independent file under many keys (a stale-looking hit under a different
-   * override). Threading overrides through the long re-render is a follow-up (see
-   * docs/design/SCROLLING_SVG.md); until then the cache stays correct by keying on the preview id
-   * alone.
+   * **Override-aware.** The full-page SVG file is shared per preview, so serving it at non-default
+   * overrides needs a fresh render: the [overrides] ride the fetch's kind-agnostic `params` bag
+   * ([DataFetchParams.PARAM_OVERRIDES]) — the daemon threads them into the `figma-svg-long`
+   * re-render — and [DataFetchParams.PARAM_FORCE_RERENDER] makes the file-backed registry re-render
+   * even though a prior (differently-themed) file exists. The cache is keyed by
+   * [ServeOverrides.cacheKey] so themed and default capsules don't collide; the held [renderLock]
+   * keeps the shared file from being overwritten between the re-render and the read, mirroring the
+   * viewport [renderSvg] lane.
    */
   override fun renderScrollSvg(previewId: String, overrides: PreviewOverrides): SvgOutcome {
     check(!closed.get()) { "ServeRenderHost is closed" }
@@ -462,7 +465,7 @@ internal constructor(
     // [renderSvg].
     if (!hasSvgExport) return SvgOutcome.NotFound
 
-    val key = previewId
+    val key = ServeOverrides.cacheKey(previewId, overrides)
     scrollSvgCache.get(key)?.let {
       return SvgOutcome.Ok(it)
     }
@@ -472,9 +475,21 @@ internal constructor(
         return@withLock SvgOutcome.Ok(it)
       }
 
+      // Force a fresh full-page render at these overrides (the shared per-preview file may hold a
+      // different theme's export) and read it under the held lock.
+      val fetchParams = buildJsonObject {
+        put(DataFetchParams.PARAM_FORCE_RERENDER, JsonPrimitive(true))
+        put(
+          DataFetchParams.PARAM_OVERRIDES,
+          Json.encodeToJsonElement(PreviewOverrides.serializer(), overrides),
+        )
+      }
       val svgPath =
         try {
-          session.fetchData(previewId, ComposeFigmaSvgProduct.KIND_LONG).path?.toPath()
+          session
+            .fetchData(previewId, ComposeFigmaSvgProduct.KIND_LONG, params = fetchParams)
+            .path
+            ?.toPath()
         } catch (e: Exception) {
           val reason = "figma-svg-long fetch failed: ${e.message}"
           onLog(reason)

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/FakeRenderSession.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/FakeRenderSession.kt
@@ -1,6 +1,7 @@
 package ee.schimke.composeai.cli.serve
 
 import ee.schimke.composeai.daemon.protocol.ChangeType
+import ee.schimke.composeai.daemon.protocol.DataFetchParams
 import ee.schimke.composeai.daemon.protocol.DataFetchResult
 import ee.schimke.composeai.daemon.protocol.DataSubscribeResult
 import ee.schimke.composeai.daemon.protocol.ExtensionsDisableResult
@@ -92,6 +93,12 @@ internal class FakeRenderSession(
   private val figmaSvgAvailable: Boolean = true,
 ) : RenderSession {
   val renderCount = AtomicInteger(0)
+
+  /**
+   * Count of `figma-svg-long` fetches + the `params` bag of the last one — for scroll-lane asserts.
+   */
+  val scrollFetchCount = AtomicInteger(0)
+  @Volatile var lastScrollFetchParams: JsonElement? = null
 
   /** Extension ids passed to [enableExtensions], in call order — for assertions. */
   val enabledExtensionIds = CopyOnWriteArrayList<String>()
@@ -273,10 +280,18 @@ internal class FakeRenderSession(
       )
     }
     if (kind == ComposeFigmaSvgProduct.KIND_LONG) {
-      // Model the daemon's `requiresRerender` full-page export: the fetch itself produces the file.
+      // Model the daemon's `requiresRerender` full-page export: the fetch itself produces the file,
+      // reflecting the overrides threaded through the `params` bag (as the real re-render does) so
+      // the serve host's override-awareness is observable.
+      scrollFetchCount.incrementAndGet()
+      lastScrollFetchParams = params
+      val o =
+        params?.jsonObject?.get(DataFetchParams.PARAM_OVERRIDES)?.let {
+          Json.decodeFromJsonElement(PreviewOverrides.serializer(), it)
+        }
       val previewDir = File(renderRoot, previewId).apply { mkdirs() }
       val file = File(previewDir, ComposeFigmaSvgProduct.FILE_SVG_LONG)
-      file.writeText("svg-long:$previewId")
+      file.writeText("svg-long:$previewId:${o?.uiMode}:${o?.localeTag}:${o?.device}")
       return DataFetchResult(
         kind = kind,
         schemaVersion = ComposeFigmaSvgProduct.SCHEMA_VERSION,

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHostTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHostTest.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.cli.serve
 
+import ee.schimke.composeai.daemon.protocol.DataFetchParams
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.daemon.protocol.UiMode
 import ee.schimke.composeai.data.layoutinspector.ComposeFigmaSvgProduct
@@ -15,8 +16,11 @@ import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 
 class ServeRenderHostTest {
 
@@ -129,7 +133,14 @@ class ServeRenderHostTest {
     host(session).use { h ->
       val out = h.renderScrollSvg(previewId, PreviewOverrides())
       assertTrue(out is SvgOutcome.Ok)
-      assertEquals("svg-long:$previewId", (out as SvgOutcome.Ok).svg.decodeToString())
+      assertEquals(
+        "svg-long:$previewId:null:null:null",
+        (out as SvgOutcome.Ok).svg.decodeToString(),
+      )
+      // The fetch carries the force flag + a serialized overrides bag (default here).
+      val params = session.lastScrollFetchParams as JsonObject
+      assertEquals(JsonPrimitive(true), params[DataFetchParams.PARAM_FORCE_RERENDER])
+      assertNotNull(params[DataFetchParams.PARAM_OVERRIDES])
     }
   }
 
@@ -141,6 +152,38 @@ class ServeRenderHostTest {
       val b = h.renderScrollSvg(previewId, PreviewOverrides())
       assertTrue(a is SvgOutcome.Ok && b is SvgOutcome.Ok)
       assertContentEquals(a.svg, b.svg)
+      assertEquals(
+        1,
+        session.scrollFetchCount.get(),
+        "identical overrides ⇒ one fetch, then cached",
+      )
+    }
+  }
+
+  @Test
+  fun `renderScrollSvg is override-aware — distinct overrides re-render and don't collide in cache`() {
+    val session = FakeRenderSession(newRenderRoot())
+    host(session).use { h ->
+      val dark = h.renderScrollSvg(previewId, PreviewOverrides(uiMode = UiMode.DARK))
+      val light = h.renderScrollSvg(previewId, PreviewOverrides(uiMode = UiMode.LIGHT))
+      assertTrue(dark is SvgOutcome.Ok && light is SvgOutcome.Ok)
+      assertEquals(
+        "svg-long:$previewId:DARK:null:null",
+        (dark as SvgOutcome.Ok).svg.decodeToString(),
+      )
+      assertEquals(
+        "svg-long:$previewId:LIGHT:null:null",
+        (light as SvgOutcome.Ok).svg.decodeToString(),
+      )
+      assertEquals(2, session.scrollFetchCount.get(), "each distinct override re-renders")
+      // Re-requesting the dark capsule is a cache hit — no third fetch, and its bytes are intact.
+      val darkAgain = h.renderScrollSvg(previewId, PreviewOverrides(uiMode = UiMode.DARK))
+      assertContentEquals(dark.svg, (darkAgain as SvgOutcome.Ok).svg)
+      assertEquals(
+        2,
+        session.scrollFetchCount.get(),
+        "the repeat dark request is served from cache",
+      )
     }
   }
 

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/FileBackedDataProductRegistry.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/FileBackedDataProductRegistry.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.daemon
 
+import ee.schimke.composeai.daemon.protocol.DataFetchParams
 import ee.schimke.composeai.daemon.protocol.DataFetchResult
 import ee.schimke.composeai.daemon.protocol.DataProductAttachment
 import ee.schimke.composeai.daemon.protocol.DataProductCapability
@@ -9,6 +10,9 @@ import ee.schimke.composeai.io.SystemFileSystem
 import java.io.File
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import okio.FileSystem
 import okio.Path.Companion.toPath
 
@@ -111,7 +115,16 @@ abstract class FileBackedDataProductRegistry(
   ): DataProductRegistry.Outcome {
     val cap = byKind[kind] ?: return DataProductRegistry.Outcome.Unknown
     val file = fileFor(previewId, kind) ?: return DataProductRegistry.Outcome.Unknown
-    if (!file.exists()) return missingOutcome(previewId, kind)
+    // `force` (from the caller's `params`) re-renders even when a file already exists — but only
+    // for
+    // a `requiresRerender` kind, whose `missingOutcome` is a `RequiresRerender` the dispatcher acts
+    // on. The full-page SVG file is shared per preview, so a differently-overridden fetch must
+    // re-render rather than serve the stale file. For non-rerender kinds `force` is a no-op (their
+    // `missingOutcome` is just `NotAvailable`, so honouring it would wrongly hide an existing
+    // file).
+    if (!file.exists() || (cap.requiresRerender && forceRerender(params))) {
+      return missingOutcome(previewId, kind)
+    }
     val shouldInline =
       cap.transport == DataProductTransport.INLINE || (inline && allowInlineUpgrade(kind))
     return if (shouldInline) {
@@ -182,6 +195,15 @@ abstract class FileBackedDataProductRegistry(
     }
     return out
   }
+
+  /**
+   * Reads the [DataFetchParams.PARAM_FORCE_RERENDER] flag from a fetch's kind-agnostic `params`.
+   */
+  private fun forceRerender(params: JsonElement?): Boolean =
+    runCatching {
+        params?.jsonObject?.get(DataFetchParams.PARAM_FORCE_RERENDER)?.jsonPrimitive?.booleanOrNull
+      }
+      .getOrNull() == true
 
   companion object {
     private val DEFAULT_JSON = Json { ignoreUnknownKeys = true }

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -2041,7 +2041,12 @@ class JsonRpcServer(
     hostIdToPreviewId[hostId] = previewId
     acceptedAtMs[hostId] = System.currentTimeMillis()
     inFlightRenders.add(hostId)
-    val payload = encodeRenderPayloadWithMode(previewId, mode)
+    // Thread any caller-supplied overrides (theme / device / locale / font-scale / knobs, carried
+    // in
+    // the fetch's `params` bag) into the re-render, so a `?scroll=long` fetch at non-default
+    // overrides produces the matching artefact rather than the preview's defaults.
+    val overrides = decodeFetchOverrides(params.params)
+    val payload = encodeRenderPayloadWithMode(previewId, mode, overrides)
     Thread(
         {
           // Submit goes through the same render thread as renderNow but on a worker so the
@@ -2084,9 +2089,13 @@ class JsonRpcServer(
               // producer bug — we don't recurse, we surface a fetch-failed so callers see it.
               val secondOutcome =
                 try {
+                  // Strip `force` for the re-ask: the re-render just wrote the artefact, so this
+                  // fetch must read it (a still-forced fetch would re-trigger RequiresRerender,
+                  // which
+                  // the code below treats as a producer bug).
                   extensions
                     .publicDataProducts()
-                    .fetch(params.previewId, params.kind, params.params, params.inline)
+                    .fetch(params.previewId, params.kind, stripForce(params.params), params.inline)
                 } catch (t: Throwable) {
                   DataProductRegistry.Outcome.FetchFailed(
                     "registry threw on post-rerender fetch: ${t.message ?: t.javaClass.simpleName}"
@@ -2148,13 +2157,45 @@ class JsonRpcServer(
    * producer-supplied tag. Fake-mode hosts (the test harness's `FakeHost`, `FakeRenderHost` in unit
    * tests) ignore unknown payload keys, so this is forward-compatible.
    */
-  private fun encodeRenderPayloadWithMode(previewId: String, mode: String): String = buildString {
-    if (previewId.isNotEmpty()) append("previewId=").append(previewId)
+  private fun encodeRenderPayloadWithMode(
+    previewId: String,
+    mode: String,
+    overrides: PreviewOverrides? = null,
+  ): String = buildString {
+    // Reuse the full override serialization (typed size/locale/fontScale/uiMode/device tokens + the
+    // base64 `overrides=` bag) so the mode re-render honours the same overrides the normal render
+    // path does; then tag the render mode. `overrides == null` reduces to `previewId` alone, i.e.
+    // the
+    // prior behaviour for override-free re-renders.
+    append(encodeRenderPayload(previewId, overrides))
     if (mode.isNotEmpty()) {
       if (isNotEmpty()) append(';')
       append("mode=").append(mode)
     }
   }
+
+  /**
+   * Decodes a [PreviewOverrides] from a fetch's `params` bag ([DataFetchParams.PARAM_OVERRIDES]).
+   */
+  private fun decodeFetchOverrides(params: JsonElement?): PreviewOverrides? =
+    runCatching {
+        (params as? JsonObject)?.get(DataFetchParams.PARAM_OVERRIDES)?.let {
+          json.decodeFromJsonElement(PreviewOverrides.serializer(), it)
+        }
+      }
+      .getOrNull()
+
+  /**
+   * Returns [params] without the [DataFetchParams.PARAM_FORCE_RERENDER] key (other keys intact).
+   */
+  private fun stripForce(params: JsonElement?): JsonElement? =
+    when (params) {
+      is JsonObject ->
+        if (DataFetchParams.PARAM_FORCE_RERENDER in params)
+          JsonObject(params - DataFetchParams.PARAM_FORCE_RERENDER)
+        else params
+      else -> params
+    }
 
   private fun sendDataFetchOutcome(
     req: JsonRpcRequest,

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -2046,6 +2046,14 @@ class JsonRpcServer(
     // the fetch's `params` bag) into the re-render, so a `?scroll=long` fetch at non-default
     // overrides produces the matching artefact rather than the preview's defaults.
     val overrides = decodeFetchOverrides(params.params)
+    // Register the overrides against this hostId (as `renderNow` does) so `emitRenderFinished`
+    // hands
+    // them to `onRender` — registries that stamp per-render metadata (e.g. locale / font-scale in
+    // the
+    // strings product) must see this fetch's overrides, not null, or an override-bearing scroll
+    // fetch
+    // records its data products as if the default preview rendered.
+    overrides?.let { hostIdToOverrides[hostId] = it }
     val payload = encodeRenderPayloadWithMode(previewId, mode, overrides)
     Thread(
         {

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -1323,7 +1323,25 @@ data class DataFetchParams(
   val kind: String,
   val params: JsonElement? = null,
   val inline: Boolean = false,
-)
+) {
+  companion object {
+    /**
+     * `params` key: when `true`, a `requiresRerender` kind re-renders even if its on-disk artefact
+     * already exists — used by the serve host's `?scroll=long` lane to force a fresh render at the
+     * requested [PreviewOverrides] (the full-page SVG file is shared per preview, so a stale
+     * differently-themed file must be re-rendered rather than served). Ignored by kinds that don't
+     * re-render.
+     */
+    const val PARAM_FORCE_RERENDER: String = "force"
+
+    /**
+     * `params` key: a serialized [PreviewOverrides] the daemon threads into a `requiresRerender`
+     * re-render, so the produced artefact reflects the caller's theme / device / locale /
+     * font-scale / knob overrides rather than the preview's defaults.
+     */
+    const val PARAM_OVERRIDES: String = "overrides"
+  }
+}
 
 @Serializable
 data class DataFetchResult(

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/DataFetchRerenderTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/DataFetchRerenderTest.kt
@@ -159,6 +159,13 @@ class DataFetchRerenderTest {
         "force must be stripped before the post-rerender re-ask",
         reaskParams?.get("force"),
       )
+      // The overrides must also reach `onRender` (registered against the hostId) so per-render
+      // metadata (locale / font-scale) isn't recorded as the default preview's.
+      assertEquals(
+        "onRender should observe the fetch overrides",
+        UiMode.DARK,
+        producer.lastOnRenderOverrides?.uiMode,
+      )
     }
   }
 
@@ -397,10 +404,17 @@ class DataFetchRerenderTest {
     override fun attachmentsFor(previewId: String, kinds: Set<String>) =
       emptyList<ee.schimke.composeai.daemon.protocol.DataProductAttachment>()
 
+    @Volatile var lastOnRenderOverrides: PreviewOverrides? = null
+
     override fun onRender(previewId: String, result: RenderResult) {
       onRenderCalls.incrementAndGet()
       lastOnRenderPreviewId = previewId
       lastOnRenderMetrics = result.metrics
+    }
+
+    override fun onRender(previewId: String, result: RenderResult, overrides: PreviewOverrides?) {
+      lastOnRenderOverrides = overrides
+      onRender(previewId, result)
     }
 
     /** Called by [TestRenderHost] when the dispatcher submits a render. */

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/DataFetchRerenderTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/DataFetchRerenderTest.kt
@@ -3,6 +3,8 @@ package ee.schimke.composeai.daemon
 import ee.schimke.composeai.daemon.protocol.DataFetchResult
 import ee.schimke.composeai.daemon.protocol.DataProductCapability
 import ee.schimke.composeai.daemon.protocol.DataProductTransport
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.daemon.protocol.UiMode
 import java.io.PipedInputStream
 import java.io.PipedOutputStream
 import java.util.concurrent.CountDownLatch
@@ -100,6 +102,63 @@ class DataFetchRerenderTest {
       assertEquals("producer should observe the completed render", 1, producer.onRenderCalls.get())
       assertEquals("com.example.Foo_bar", producer.lastOnRenderPreviewId)
       assertEquals(3L, producer.lastOnRenderMetrics?.get("tookMs"))
+    }
+  }
+
+  /**
+   * Overrides carried in the fetch's `params` bag are threaded into the re-render payload (so a
+   * `?scroll=long`-style themed fetch re-renders at those overrides), and the `force` flag is
+   * stripped before the post-rerender re-ask (so it doesn't re-trigger `RequiresRerender`).
+   */
+  @Test(timeout = 30_000)
+  fun rerender_threads_overrides_into_payload_and_strips_force_on_reask() {
+    val producer = FakeProducer(modeForKind = mapOf("a11y/hierarchy" to "a11y"))
+    runWithServer(producer = producer) { rpc ->
+      rpc.initialize()
+      // uiMode rides a typed token; maxWidthPx rides the base64 `overrides=` extension bag — assert
+      // both channels thread through, matching what the normal render lane's encoder carries.
+      val overridesJson =
+        Json.encodeToString(
+          PreviewOverrides.serializer(),
+          PreviewOverrides(uiMode = UiMode.DARK, maxWidthPx = 480),
+        )
+      rpc.send(
+        """
+        {"jsonrpc":"2.0","id":51,"method":"data/fetch","params":{
+          "previewId":"com.example.Foo_bar","kind":"a11y/hierarchy",
+          "params":{"force":true,"overrides":$overridesJson}
+        }}
+        """
+          .trimIndent()
+      )
+
+      val response = rpc.pollUntil { it["id"]?.jsonPrimitive?.intOrNull == 51 }
+      assertNotNull("data/fetch should resolve once the re-render produces the payload", response)
+      assertNotNull(
+        "payload must be present on Ok",
+        response!!["result"]?.jsonObject?.get("payload"),
+      )
+
+      val payload = producer.lastRenderPayload
+      assertNotNull("producer should observe the host payload", payload)
+      assertTrue(
+        "render payload should carry the mode, was: $payload",
+        payload!!.contains("mode=a11y"),
+      )
+      assertTrue(
+        "override token should thread into the re-render payload, was: $payload",
+        payload.contains("uiMode=dark"),
+      )
+      assertTrue(
+        "the base64 overrides bag should ride along, was: $payload",
+        payload.contains("overrides="),
+      )
+      // The post-rerender re-ask must not carry `force` (else it would loop on RequiresRerender).
+      val reaskParams = producer.lastFetchParams as? JsonObject
+      assertNull(
+        "force must be stripped before the post-rerender re-ask",
+        reaskParams?.get("force"),
+      )
     }
   }
 
@@ -278,6 +337,7 @@ class DataFetchRerenderTest {
 
     val renderSubmits = AtomicInteger(0)
     @Volatile var lastRenderPayload: String? = null
+    @Volatile var lastFetchParams: JsonElement? = null
     @Volatile var renderObserved: Boolean = false
     val onRenderCalls = AtomicInteger(0)
     @Volatile var lastOnRenderPreviewId: String? = null
@@ -316,6 +376,7 @@ class DataFetchRerenderTest {
       params: JsonElement?,
       inline: Boolean,
     ): DataProductRegistry.Outcome {
+      lastFetchParams = params
       if (immediateOk != null && kind == immediateOk.kind) {
         return DataProductRegistry.Outcome.Ok(immediateOk)
       }

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/FileBackedDataProductRegistryTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/FileBackedDataProductRegistryTest.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.daemon
 
+import ee.schimke.composeai.daemon.protocol.DataFetchParams
 import ee.schimke.composeai.daemon.protocol.DataProductCapability
 import ee.schimke.composeai.daemon.protocol.DataProductExtra
 import ee.schimke.composeai.daemon.protocol.DataProductTransport
@@ -165,6 +166,37 @@ class FileBackedDataProductRegistryTest {
     writeFile(tempFolder.root, "p", "payload.json", "not json")
     val outcome = reg.fetch("p", "demo/inline", params = null, inline = true)
     assertTrue(outcome is DataProductRegistry.Outcome.FetchFailed)
+  }
+
+  private val forceParams: JsonObject =
+    JsonObject(mapOf(DataFetchParams.PARAM_FORCE_RERENDER to JsonPrimitive(true)))
+
+  @Test
+  fun fetch_force_rerenders_existing_file_for_rerender_kind() {
+    val reg = RerenderRegistry(tempFolder.root)
+    writeFile(tempFolder.root, "p", "rerender.json", "{\"stale\":true}")
+    // File exists, but `force` on a requiresRerender kind must re-render (serve the fresh
+    // artefact).
+    val outcome = reg.fetch("p", "demo/rerender", params = forceParams, inline = false)
+    assertEquals(DataProductRegistry.Outcome.RequiresRerender(mode = "demo"), outcome)
+  }
+
+  @Test
+  fun fetch_without_force_serves_existing_rerender_file() {
+    val reg = RerenderRegistry(tempFolder.root)
+    val written = writeFile(tempFolder.root, "p", "rerender.json", "{\"k\":1}")
+    val outcome = reg.fetch("p", "demo/rerender", params = null, inline = false)
+    assertEquals(written.absolutePath, (outcome as DataProductRegistry.Outcome.Ok).result.path)
+  }
+
+  @Test
+  fun fetch_force_is_noop_for_non_rerender_kind() {
+    val reg = PathRegistry(tempFolder.root)
+    val written = writeFile(tempFolder.root, "p", "payload.json", "{\"k\":1}")
+    // A non-rerender kind has no RequiresRerender outcome; honouring `force` would wrongly hide the
+    // existing file, so it must still serve it.
+    val outcome = reg.fetch("p", "demo/path", params = forceParams, inline = false)
+    assertEquals(written.absolutePath, (outcome as DataProductRegistry.Outcome.Ok).result.path)
   }
 
   @Test

--- a/docs/design/SCROLLING_SVG.md
+++ b/docs/design/SCROLLING_SVG.md
@@ -239,8 +239,13 @@ inside the stadium mask.)*
     fixture from the production assembler output (inlining the EdgeButton crescent raster as a `data:`
     URI so the harness — which stubs `/render/**` — can render it offline); regenerate after a
     renderer/stitcher change with `UPDATE_WEAR_SCROLL_FIXTURE=true`.
-- **Remaining:** the same **override-aware** re-render gap the mobile path has (the `data/fetch`
-  re-render is keyed by preview id, not by the applied overrides).
+  - **Override-aware.** A `?scroll=long` fetch now re-renders at the caller's theme / device / locale
+    / font-scale / knob overrides: the serve host rides them through the `data/fetch` `params` bag
+    ([`DataFetchParams.PARAM_OVERRIDES`]) and forces a fresh render
+    ([`DataFetchParams.PARAM_FORCE_RERENDER`]) since the full-page SVG file is shared per preview; the
+    daemon folds the overrides into the `figma-svg-long` re-render payload and the serve cache keys by
+    [`ServeOverrides.cacheKey`] so themed and default capsules don't collide. The render bodies
+    already honoured `spec.overrides`, so the fix is serve→fetch→re-render plumbing only.
 
 ## Non-goals
 


### PR DESCRIPTION
## Summary

Closes the last remaining item in `docs/design/SCROLLING_SVG.md`: the full-page scroll SVG served at
`GET /render/<id>.svg?scroll=long` ignored the caller's live overrides. The `data/fetch` re-render was
keyed by preview id alone, so a themed / resized / localized / font-scaled / knob-adjusted request got
the preview's **default** capsule. The render bodies already honour `spec.overrides` — the gap was
purely the **serve → `data/fetch` → re-render** plumbing.

## What changed

- **Serve host** (`ServeRenderHost.renderScrollSvg`) keys the scroll-SVG cache by
  `ServeOverrides.cacheKey(previewId, overrides)` and threads the overrides through the fetch's
  kind-agnostic `params` bag (`DataFetchParams.PARAM_OVERRIDES`) plus a force flag
  (`PARAM_FORCE_RERENDER`). The full-page SVG file is shared per preview, so a differently-themed
  request must re-render rather than serve the stale file; the fresh file is read back under the held
  `renderLock`, exactly like the viewport `renderSvg` lane.
- **File-backed registry** honours `force` for `requiresRerender` kinds (a no-op for the rest, whose
  `missingOutcome` is `NotAvailable` — honouring it would wrongly hide an existing file).
- **Daemon dispatch** folds the overrides into the `figma-svg-long` re-render payload (reusing
  `encodeRenderPayload`, so the mode render carries the same overrides the normal render path does)
  and **strips `force`** on the post-rerender re-ask so it doesn't loop on `RequiresRerender`.

Reuses the existing `params: JsonElement?` field and the `@Serializable PreviewOverrides`, so there's
**no wire-message or `fetchData`-signature change**. The scroll lane now carries exactly what the base
static render lane carries (size, locale, font-scale, `uiMode`, device, orientation, and the base64
extension bag — knobs, `material3Theme`, wallpaper, gestures, size bounds). The `@ThemeCatalog`
`themeProvider` stays held/live-session-only, unchanged — the base static PNG/SVG re-render never
carried it either, so this is parity, not a regression.

## Test plan

- `:daemon:core:test --tests '*FileBackedDataProductRegistryTest*'` — `force` re-renders an existing
  file for a `requiresRerender` kind, serves it without `force`, and is a no-op for a non-rerender
  kind. ✅
- `:daemon:core:test --tests '*DataFetchRerenderTest*'` — overrides in the `params` bag thread into
  the re-render payload (a typed `uiMode=dark` token **and** the base64 `overrides=` extension bag),
  and `force` is stripped before the post-rerender re-ask. ✅
- `:cli:test --tests '*ServeRenderHostTest*'` — the scroll fetch carries `force` + the serialized
  overrides; identical overrides are one fetch then cache-served; distinct overrides re-render and
  don't collide in cache (dark vs light produce distinct capsules, repeat dark is a cache hit). ✅
- `:daemon:core` + `:cli` compile, `ktfmtFormat`. ✅

**Verification note:** the full serve → subprocess-daemon → themed render loop isn't exercised in a
unit test (it needs a live daemon + a real scrolling preview). It's covered by (1) the render bodies
already consuming `spec.overrides` on both backends, (2) the daemon test proving the overrides reach
the render payload, (3) the registry test proving `force` re-renders, and (4) the serve test proving
the cache is override-keyed and the fetch carries the bag — i.e. each seam of the plumbing is unit-
tested, and the render body is unchanged.

Text-only PR: this is data-product plumbing + tests, no rendered-surface change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NxeSZ1XQ8NoVbHXpQy7Lyw)_