### PR TITLE
feat(deploy): bake Caddyfile into a Watchtower-watched image

### DIFF
--- a/.github/workflows/preview-caddy-image.yml
+++ b/.github/workflows/preview-caddy-image.yml
@@ -1,0 +1,60 @@
+# Build and publish the baked-Caddyfile reverse-proxy image to GHCR.
+#
+# Pairs with deploy/image/caddy.Dockerfile + docker-compose.yml: the public box
+# runs `ghcr.io/<owner>/compose-preview-caddy:latest` instead of `caddy:2` + a
+# bind-mounted Caddyfile, so a Caddyfile change auto-deploys through the SAME
+# Watchtower path as the preview server (Watchtower watches image digests, not the
+# mounted file). Pushing a new `:latest` digest here is what makes Watchtower
+# recreate the caddy container on the host with the new config.
+#
+# Triggers on a Caddyfile / caddy.Dockerfile change on main (so the published
+# image never lags the repo), plus manual dispatch.
+name: Publish preview-caddy image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - deploy/image/Caddyfile
+      - deploy/image/caddy.Dockerfile
+      - .github/workflows/preview-caddy-image.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Image metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/compose-preview-caddy
+          # `latest` is what the box tracks (Watchtower rolls on its digest); the
+          # `sha-<commit>` tag lets an operator pin a specific config via CADDY_IMAGE_TAG.
+          tags: |
+            type=raw,value=latest
+            type=sha,prefix=sha-
+
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: deploy/image
+          file: deploy/image/caddy.Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/deploy/image/README.md
+++ b/deploy/image/README.md
@@ -65,9 +65,28 @@ published** — so the chain is hands-off:
 > merge → cut a `v*` release → `preview-host-image.yml` publishes `:latest` →
 > Watchtower pulls it → server updates
 
-It polls hourly (`--interval 3600`), is scoped to the labelled `preview` service
-(`--label-enable`, so it leaves Caddy alone), and `--cleanup` prunes the old image.
-It needs the Docker socket (root-equivalent on the host — fine for your own box).
+It polls hourly (`--interval 3600`), is scoped to the labelled services
+(`--label-enable` — the `preview` server **and** `caddy`, see below), and
+`--cleanup` prunes the old image. It needs the Docker socket (root-equivalent on
+the host — fine for your own box).
+
+**The reverse-proxy config auto-deploys too.** The `caddy` service runs
+`ghcr.io/…/compose-preview-caddy:latest` — a `caddy:2` image with
+`deploy/image/Caddyfile` **baked in** — rather than `caddy:2` + a bind-mounted
+Caddyfile. Watchtower watches image digests, not files, so this is what lets a
+Caddyfile change roll out on its own:
+
+> edit `deploy/image/Caddyfile` → merge → `preview-caddy-image.yml` publishes
+> `compose-preview-caddy:latest` → Watchtower pulls it → caddy recreated with the
+> new config
+
+Certs survive a recreate (they live in the `caddy_data` volume, so no
+re-provision / rate-limit). `{$DOMAIN}` is still read from `.env` at runtime.
+Pin a specific config with `CADDY_IMAGE_TAG=sha-<commit>` in `.env`.
+
+> **Migrating an existing box** from the old `caddy:2` + `./Caddyfile` mount: pull
+> this compose and `docker compose up -d` once — it swaps in the baked image. After
+> that, Caddyfile edits ride Watchtower with no manual `caddy reload`.
 
 > **Image:** this uses the maintained
 > [`nicholas-fedor/watchtower`](https://github.com/nicholas-fedor/watchtower) fork,

--- a/deploy/image/README.md
+++ b/deploy/image/README.md
@@ -88,6 +88,14 @@ Pin a specific config with `CADDY_IMAGE_TAG=sha-<commit>` in `.env`.
 > this compose and `docker compose up -d` once — it swaps in the baked image. After
 > that, Caddyfile edits ride Watchtower with no manual `caddy reload`.
 
+> **First publish is private — make it public once.** GHCR packages default to
+> private, so after `preview-caddy-image.yml`'s first run, set the new
+> `compose-preview-caddy` package **public** (Packages → settings), exactly like
+> `compose-preview-host` above. Otherwise a fresh or migrating box's unauthenticated
+> `docker compose pull` fails on the caddy image *before Caddy can start* — no TLS,
+> no proxy. (Alternatively, give the box registry creds — see *Private GHCR
+> package* below; it now covers the caddy image too, not just the server.)
+
 > **Image:** this uses the maintained
 > [`nicholas-fedor/watchtower`](https://github.com/nicholas-fedor/watchtower) fork,
 > pinned by tag+digest. The original `containrrr/watchtower` is effectively

--- a/deploy/image/caddy.Dockerfile
+++ b/deploy/image/caddy.Dockerfile
@@ -1,0 +1,17 @@
+# syntax=docker/dockerfile:1.25
+
+# Bakes deploy/image/Caddyfile into a caddy:2 image so a Caddyfile change ships to
+# the running host over the SAME Watchtower auto-update path as the preview server.
+#
+# Why bake it: Watchtower watches image *digests*, not the bind-mounted config file,
+# so a plain `caddy:2` + `./Caddyfile` volume never auto-updates when the Caddyfile
+# changes — an edit has to be copied onto the box and Caddy reloaded by hand. With
+# the config in a watched image, a Caddyfile change → preview-caddy-image.yml pushes
+# a new `:latest` → Watchtower pulls + recreates caddy → new config live. Certs
+# survive (they live in the caddy_data volume), so a recreate doesn't re-provision.
+#
+# `{$DOMAIN}` stays an env placeholder — Caddy substitutes it from the container's
+# DOMAIN at runtime, so the same image serves any host. Published to
+# ghcr.io/<owner>/compose-preview-caddy by .github/workflows/preview-caddy-image.yml.
+FROM caddy:2
+COPY Caddyfile /etc/caddy/Caddyfile

--- a/deploy/image/docker-compose.yml
+++ b/deploy/image/docker-compose.yml
@@ -69,15 +69,18 @@ services:
       - "8080"
     # The baked warm cache makes renders incremental; this just caps a render storm.
     mem_limit: 4g
-    # Opt this service in to Watchtower auto-updates (caddy is intentionally left out).
+    # Opt this service in to Watchtower auto-updates. Caddy is opted in too (below)
+    # via its baked-config image, so both the server and the reverse-proxy config
+    # roll automatically.
     labels:
       com.centurylinklabs.watchtower.enable: "true"
 
-  # Auto-update: poll GHCR for a new :latest digest and recreate `preview` when the
-  # release workflow publishes one. --label-enable scopes it to the labelled service
-  # above; --cleanup prunes the superseded image. Comment this service out to manage
-  # updates manually (docker compose pull && up -d). For a private GHCR package, mount
-  # a registry config: `- ~/.docker/config.json:/config.json:ro`. See README.md.
+  # Auto-update: poll GHCR for a new :latest digest and recreate `preview` (and
+  # `caddy`) when the release / preview-caddy-image workflow publishes one.
+  # --label-enable scopes it to the labelled services; --cleanup prunes the
+  # superseded image. Comment this service out to manage updates manually
+  # (docker compose pull && up -d). For a private GHCR package, mount a registry
+  # config: `- ~/.docker/config.json:/config.json:ro`. See README.md.
   watchtower:
     # Maintained fork of the (now-stale) containrrr/watchtower: the upstream image's
     # baked Docker SDK negotiates API 1.25, which modern engines reject ("client
@@ -91,7 +94,15 @@ services:
     command: --label-enable --cleanup --interval 1200
 
   caddy:
-    image: caddy:2
+    # The Caddyfile is BAKED into this image (preview-caddy-image.yml) instead of
+    # bind-mounted, so a config change auto-deploys via Watchtower like the server
+    # (Watchtower watches image digests, not files). DOMAIN is still substituted
+    # from .env at runtime. Pin a config with CADDY_IMAGE_TAG=<sha> in .env; leave
+    # it unset for the auto-updating :latest. (Migrating an existing box: the first
+    # `docker compose up -d` after adopting this compose swaps caddy:2 + the mount
+    # for this image — a one-time step; edits then ride Watchtower.)
+    image: "ghcr.io/yschimke/compose-preview-caddy:${CADDY_IMAGE_TAG:-latest}"
+    pull_policy: always
     restart: always
     depends_on:
       - preview
@@ -101,9 +112,11 @@ services:
     environment:
       DOMAIN: "${DOMAIN:?set DOMAIN in .env}"
     volumes:
-      - ./Caddyfile:/etc/caddy/Caddyfile:ro
       - caddy_data:/data
       - caddy_config:/config
+    # Opt in to Watchtower so a new baked-Caddyfile image rolls onto this box.
+    labels:
+      com.centurylinklabs.watchtower.enable: "true"
 
 volumes:
   caddy_data:

--- a/deploy/image/setup.sh
+++ b/deploy/image/setup.sh
@@ -37,7 +37,11 @@ else
   echo "==> Reusing existing .env (token preserved)"
 fi
 
-echo "==> Pulling the prebuilt image and starting the stack"
+echo "==> Pulling the prebuilt images and starting the stack"
+# Unauthenticated pull: both GHCR packages (compose-preview-host AND
+# compose-preview-caddy, which carries the baked Caddyfile) must be PUBLIC, or this
+# box needs registry creds. A private package fails here before Caddy starts — see
+# README "First publish is private".
 sudo docker compose pull
 sudo docker compose up -d
 


### PR DESCRIPTION
## Summary

Automates the Caddy reverse-proxy config deploy through the **same Watchtower path** as the preview server, so a Caddyfile change (like the recent WebSocket `read_timeout` fix) no longer needs a manual copy + `caddy reload` on the box.

**Why it wasn't automatic:** the `caddy` service ran stock `caddy:2` with the Caddyfile **bind-mounted** (`./Caddyfile:/etc/caddy/Caddyfile`). Watchtower watches image *digests*, not mounted files, and the compose deliberately excluded caddy from `--label-enable` — so a repo Caddyfile edit never reached the running host on its own.

**The change** — put the config on the watched-image path:
- `deploy/image/caddy.Dockerfile` — `FROM caddy:2` + `COPY Caddyfile`, baking `deploy/image/Caddyfile` in.
- `.github/workflows/preview-caddy-image.yml` — builds + pushes `ghcr.io/<owner>/compose-preview-caddy:latest` (+ a `sha-<commit>` tag) on any Caddyfile / Dockerfile change, mirroring `preview-host-image.yml`'s GHCR recipe.
- `deploy/image/docker-compose.yml` — the `caddy` service now uses that image (`pull_policy: always`, Watchtower label) instead of `caddy:2` + the mount.

Flow becomes: **edit `Caddyfile` → merge → image published → Watchtower recreates caddy with the new config** — identical to the server. Certs survive (they live in the `caddy_data` volume, so no re-provision / Let's Encrypt rate-limit), and `{$DOMAIN}` stays a runtime env placeholder so the same image serves any host. Pin a config with `CADDY_IMAGE_TAG=sha-<commit>`.

Scoped to the `deploy/image` deployment (the Watchtower-based public box, e.g. preview.coo.ee). The `deploy/oracle` and `deploy/vps` recipes keep their bind-mounted Caddyfiles.

## Test plan

- `docker compose config` validates and resolves the `caddy` service to `ghcr.io/yschimke/compose-preview-caddy:latest` with the Watchtower label and the bind mount removed (`caddy_data` / `caddy_config` volumes retained).
- `caddy.Dockerfile` is a two-line `FROM caddy:2` + `COPY`; the publish workflow uses the same pinned actions as `preview-host-image.yml`.
- Deploy-config only — no application code or visual surface.
- **One-time migration note** (in the README): an existing box adopts this with a single `docker compose up -d`; after that, Caddyfile edits ride Watchtower.

_Generated by [Claude Code]_

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jxz9i4SuuxPRt3knZKAPbb)_