### PR TITLE
fix(ci): boot serve-lanes module-less so the daemon actually comes up

### DIFF
--- a/.github/workflows/serve-lanes-e2e.yml
+++ b/.github/workflows/serve-lanes-e2e.yml
@@ -79,7 +79,12 @@ jobs:
           LIBGL_ALWAYS_SOFTWARE: "1"
           GALLIUM_DRIVER: llvmpipe
         run: |
-          echo "SERVE_URL=$(bash vscode-extension/preview-harness/serve-lanes-boot.sh)" >> "$GITHUB_ENV"
+          # Capture into a var first (not inside echo) so a boot failure trips
+          # `set -e` and fails THIS step with the boot log — instead of exporting an
+          # empty SERVE_URL and surfacing later as a cryptic Playwright "Invalid URL".
+          url="$(bash vscode-extension/preview-harness/serve-lanes-boot.sh)"
+          echo "serve-lanes: SERVE_URL=$url"
+          echo "SERVE_URL=$url" >> "$GITHUB_ENV"
 
       - name: Drive every render lane (Chromium)
         working-directory: vscode-extension

--- a/vscode-extension/preview-harness/serve-lanes-boot.sh
+++ b/vscode-extension/preview-harness/serve-lanes-boot.sh
@@ -5,40 +5,58 @@
 # `--catalogs` system live-rendered from its carried liveBundle, so every render
 # lane (PNG / SVG / Live WS) exercises a real Compose render daemon.
 #
+# IMPORTANT: serve must run MODULE-LESS (hosting only the fetched --catalogs). It
+# decides that by NOT being inside a Gradle project — so this launches it from a
+# scratch dir OUTSIDE the repo. Run from the repo root, serve instead tries to
+# discover + build the ~20 local preview modules and never answers /version. All
+# input paths are resolved to absolute BEFORE we cd out.
+#
 # Env:
 #   SERVE_CLI          path to the compose-preview launcher (default: the
 #                      :cli:installDist output under cli/build/install)
 #   SERVE_PORT         bind port (default 8725)
 #   SERVE_SYSTEM       catalog system to serve (default compose-m3)
 #   SERVE_TRUST_STORE  producer trust store (default deploy/image/trust/producers.json)
-#   SERVE_LOG          serve log file (default serve-lanes.log)
+#   SERVE_LOG          serve log file, relative to the repo root (default serve-lanes.log)
 #
-# Writes the pid to serve-lanes.pid so the caller can tear it down. Needs xvfb +
-# software GL on the PATH (the workflow installs them).
+# Writes the pid to serve-lanes.pid (repo root) so the caller can tear it down, and
+# the log where the caller can upload it. Needs xvfb + software GL on the PATH (the
+# workflow installs them).
 set -euo pipefail
 
-CLI="${SERVE_CLI:-cli/build/install/compose-preview/bin/compose-preview}"
+REPO_ROOT="$(pwd)"
+CLI="$(readlink -f "${SERVE_CLI:-cli/build/install/compose-preview/bin/compose-preview}")"
+TRUST="$(readlink -f "${SERVE_TRUST_STORE:-deploy/image/trust/producers.json}")"
 PORT="${SERVE_PORT:-8725}"
 SYSTEM="${SERVE_SYSTEM:-compose-m3}"
-TRUST="${SERVE_TRUST_STORE:-deploy/image/trust/producers.json}"
-LOG="${SERVE_LOG:-serve-lanes.log}"
+LOG="${REPO_ROOT}/${SERVE_LOG:-serve-lanes.log}"
+PID_FILE="${REPO_ROOT}/serve-lanes.pid"
 BASE="http://127.0.0.1:${PORT}"
 
-echo "serve-lanes: booting daemon-backed serve ($SYSTEM) on $BASE" >&2
+if [ ! -x "$CLI" ]; then
+  echo "::error::serve CLI not found or not executable at $CLI — run :cli:installDist first" >&2
+  exit 1
+fi
+
+# Launch from a scratch dir OUTSIDE the Gradle project so serve runs module-less.
+WORK="$(mktemp -d "${RUNNER_TEMP:-/tmp}/serve-lanes.XXXXXX")"
+echo "serve-lanes: booting daemon-backed serve ($SYSTEM) on $BASE (module-less, cwd=$WORK)" >&2
+cd "$WORK"
 LIBGL_ALWAYS_SOFTWARE=1 nohup xvfb-run -a "$CLI" serve \
   --catalogs "$SYSTEM" --public --host 127.0.0.1 --port "$PORT" \
   --trust-store "$TRUST" --allow-render-trusted --live-seats 1 \
   > "$LOG" 2>&1 &
-echo $! > serve-lanes.pid
+echo $! > "$PID_FILE"
 
 # 1) Wait for the HTTP server to answer.
+up=""
 for _ in $(seq 1 120); do
-  if curl -sf -o /dev/null --max-time 4 "$BASE/version"; then break; fi
+  if curl -sf -o /dev/null --max-time 4 "$BASE/version"; then up=1; break; fi
   sleep 2
 done
-if ! curl -sf -o /dev/null --max-time 4 "$BASE/version"; then
+if [ -z "$up" ]; then
   echo "::error::serve did not answer /version in time" >&2
-  tail -40 "$LOG" >&2 || true
+  tail -60 "$LOG" >&2 || true
   exit 1
 fi
 

--- a/vscode-extension/preview-harness/serve-lanes.config.mjs
+++ b/vscode-extension/preview-harness/serve-lanes.config.mjs
@@ -14,7 +14,9 @@ import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
 
 const here = dirname(fileURLToPath(import.meta.url));
-const serveUrl = process.env.SERVE_URL ?? "http://127.0.0.1:8725";
+// `||` (not `??`) so an empty SERVE_URL — e.g. an env var set to "" — falls back
+// to the default instead of becoming a broken empty baseURL.
+const serveUrl = process.env.SERVE_URL || "http://127.0.0.1:8725";
 
 export default defineConfig({
   testDir: ".",


### PR DESCRIPTION
## Summary

The new **Serve Lanes E2E** job (from #2443) failed on its first real runs. Root cause from the job log:

```
serve-lanes: booting daemon-backed serve (compose-m3) on http://127.0.0.1:8725
[4 minutes pass]
##[error]serve did not answer /version in time
Found preview modules: clients:mobile, … samples:design-catalog-m3, …
```

The boot script launched `serve` **from the repo root** — a Gradle project — so `serve` fell into module-discovery/build of the ~20 local preview modules instead of running **module-less**, never answered `/version`, and exported an **empty `SERVE_URL`**. That surfaced downstream as a cryptic `apiRequestContext.get: Invalid URL` and "5 did not run".

## Fix

- **`serve-lanes-boot.sh`**: resolve the CLI + trust store to absolute paths, then launch `serve` from a scratch dir **outside** the project (`mktemp` under `RUNNER_TEMP`) so it runs module-less and hosts only the fetched `compose-m3` catalog — the same shape verified locally (`… → LIVE from bundle`, `/version` 200, 22/22 lane checks).
- **workflow**: capture the boot URL into a var first (`url="$(bash …boot.sh)"`) so a boot failure trips `set -e` and fails the **boot** step (with the serve log) instead of quietly exporting an empty `SERVE_URL`.
- **config**: fall back to the default baseURL on an empty `SERVE_URL` (`||`, not `??`).

## Test plan

- Boot-script mechanics verified locally: CLI + trust store resolve to absolute paths, the scratch dir is outside the repo (so serve runs module-less), `bash -n` clean. Module-less daemon-backed serve from a dir outside the project was already verified end-to-end (all four lanes + failure overlay, 22/22).
- CI-plumbing only (boot script + workflow step + Playwright config); no application code change. The **Serve Lanes E2E** job on this PR is the real end-to-end check.

## Follow-up

A companion PR makes `serve`'s Gradle discover/build **opt-in** (`--discover`), so `serve --catalogs …` never auto-builds a local project — fixing this footgun at the source. This PR is the immediate CI-green fix.

_Generated by [Claude Code]_

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jxz9i4SuuxPRt3knZKAPbb)_