### PR TITLE
feat(design-artifacts): render downloadable GoogleFonts in the wasm/desktop catalog tiers

### DIFF
--- a/scripts/design-artifacts/render-fonts-manifest.mjs
+++ b/scripts/design-artifacts/render-fonts-manifest.mjs
@@ -34,6 +34,44 @@ function familyKey(requestedFamily) {
 }
 
 /**
+ * Pull the display name out of a downloadable-GoogleFont `requestedFamily` record, e.g.
+ * `Font(GoogleFont("Space Grotesk", bestEffort=true), weight=…, …)` → `"Space Grotesk"`. Returns
+ * null for any record that isn't a GoogleFont request. The name is the same string the consumer's
+ * `Font(GoogleFont("Space Grotesk"), …)` passes, so the wasm/desktop tiers can key a vendored
+ * family off it.
+ */
+export function googleFontName(requestedFamily) {
+  const m = /GoogleFont\(\s*"([^"]+)"/.exec(requestedFamily ?? "");
+  return m ? m[1] : null;
+}
+
+/**
+ * Slugify a GoogleFont display name into the vendored-file stem, matching the renderer's
+ * `GoogleFontKey.slugify` (lowercase, every non-alphanumeric run collapsed to a single `-`, no
+ * leading/trailing `-`). `"Space Grotesk"` → `"space-grotesk"`, so its 400-weight face vendors as
+ * `space-grotesk-400.ttf` — the exact file the download step writes.
+ */
+export function fontSlug(name) {
+  let out = "";
+  let prevDash = true;
+  for (const ch of name.toLowerCase()) {
+    if ((ch >= "a" && ch <= "z") || (ch >= "0" && ch <= "9")) {
+      out += ch;
+      prevDash = false;
+    } else if (!prevDash) {
+      out += "-";
+      prevDash = true;
+    }
+  }
+  return out.replace(/^-+|-+$/g, "") || "font";
+}
+
+/** Vendored file stem for a named GoogleFont at [weight] (italic faces get an `-italic` suffix). */
+function namedFontFile(name, weight, italic) {
+  return `${fontSlug(name)}-${weight}${italic ? "-italic" : ""}.ttf`;
+}
+
+/**
  * Parse every `previews/<id>.fonts.json` entry out of a read preview bundle into an array of
  * `fonts/used` payloads (`{fonts: [{requestedFamily, weight, style, …}]}`). Unparseable entries
  * are skipped — the record is best-effort by design.
@@ -63,9 +101,29 @@ export function fontsPayloadsFromBundle(bundle) {
 export function buildFontsManifest(payloads, availableFiles) {
   const warnings = [];
   const wanted = new Map(); // familyKey -> Map(weight -> file)
+  const namedWanted = new Map(); // GoogleFont display name -> Map("<weight>[i]" -> {file,weight,italic})
   const unknown = new Set();
   const missing = new Set();
   let recorded = 0;
+
+  // A downloadable GoogleFont resolves to one vendored file per (weight, italic). Unlike the
+  // generic families there's no nearest-weight snap: each recorded face has its own vendored TTF
+  // (`<slug>-<weight>[-italic].ttf`), so a face whose file the dist doesn't carry warns and drops
+  // just that face (the tier falls back to its bundled default for it) without taking the family's
+  // other weights down.
+  const wantNamed = (name, weight, italic) => {
+    const w = Number(weight) || 400;
+    const file = namedFontFile(name, w, italic);
+    if (!availableFiles.has(file)) {
+      if (!missing.has(file)) {
+        missing.add(file);
+        warnings.push(`'${name}' needs ${file}, which the dist fonts/ does not carry — dropped`);
+      }
+      return;
+    }
+    if (!namedWanted.has(name)) namedWanted.set(name, new Map());
+    namedWanted.get(name).set(`${w}${italic ? "i" : ""}`, { file, weight: w, italic });
+  };
 
   const want = (key, weight) => {
     const table = FAMILY_FILES[key].files;
@@ -89,6 +147,11 @@ export function buildFontsManifest(payloads, availableFiles) {
       recorded++;
       const key = familyKey(entry.requestedFamily);
       if (key === null) {
+        const gf = googleFontName(entry.requestedFamily);
+        if (gf) {
+          wantNamed(gf, entry.weight, entry.style === "italic");
+          continue;
+        }
         if (!unknown.has(entry.requestedFamily)) {
           unknown.add(entry.requestedFamily);
           warnings.push(
@@ -120,5 +183,17 @@ export function buildFontsManifest(payloads, availableFiles) {
         .sort(([a], [b]) => a - b)
         .map(([weight, file]) => ({ file, weight })),
     }));
-  return { manifest: { version: 1, families }, warnings };
+  // Named GoogleFont families follow the default/generic block, alphabetically. Each carries the
+  // GoogleFont display name so the wasm/desktop tiers can resolve a `Font(GoogleFont("<name>"), …)`
+  // request onto the vendored faces instead of falling back to Roboto.
+  const named = [...namedWanted.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([name, byFace]) => ({
+      name,
+      role: "named",
+      fonts: [...byFace.values()]
+        .sort((a, b) => a.weight - b.weight || Number(a.italic) - Number(b.italic))
+        .map(({ file, weight, italic }) => (italic ? { file, weight, italic } : { file, weight })),
+    }));
+  return { manifest: { version: 1, families: [...families, ...named] }, warnings };
 }

--- a/scripts/design-artifacts/render-fonts-manifest.mjs
+++ b/scripts/design-artifacts/render-fonts-manifest.mjs
@@ -193,7 +193,13 @@ export function buildFontsManifest(payloads, availableFiles) {
       role: "named",
       fonts: [...byFace.values()]
         .sort((a, b) => a.weight - b.weight || Number(a.italic) - Number(b.italic))
-        .map(({ file, weight, italic }) => (italic ? { file, weight, italic } : { file, weight })),
+        // `style: "italic"` (not `italic: true`): the Wasm manifest bridge (`flattenFontsManifest`
+        // in the cmp-wasm-catalog app) keys a face's style off `f.style`, so an italic face must
+        // carry that field or it registers as normal and an Italic request can't match it. Normal
+        // faces omit style entirely — the reader defaults a missing style to normal.
+        .map(({ file, weight, italic }) =>
+          italic ? { file, weight, style: "italic" } : { file, weight },
+        ),
     }));
   return { manifest: { version: 1, families: [...families, ...named] }, warnings };
 }

--- a/scripts/design-artifacts/render-fonts-manifest.test.mjs
+++ b/scripts/design-artifacts/render-fonts-manifest.test.mjs
@@ -147,12 +147,14 @@ test("a named GoogleFont face with no vendored file warns and drops just that fa
   ]);
 });
 
-test("italic GoogleFont faces vendor with the -italic stem and carry the flag", () => {
+test("italic GoogleFont faces vendor with the -italic stem and carry style:italic", () => {
+  // The Wasm manifest bridge keys style off `f.style`, so an italic face must emit
+  // `style: "italic"` (not an `italic` boolean) or it registers as a normal face.
   const files = new Set([...ALL_FILES, "space-grotesk-400-italic.ttf"]);
   const payloads = [{ fonts: [gf("Space Grotesk", 400, "italic")] }];
   const { manifest } = buildFontsManifest(payloads, files);
   assert.deepEqual(manifest.families.find((f) => f.name === "Space Grotesk").fonts, [
-    { file: "space-grotesk-400-italic.ttf", weight: 400, italic: true },
+    { file: "space-grotesk-400-italic.ttf", weight: 400, style: "italic" },
   ]);
 });
 

--- a/scripts/design-artifacts/render-fonts-manifest.test.mjs
+++ b/scripts/design-artifacts/render-fonts-manifest.test.mjs
@@ -101,6 +101,61 @@ test("the default family is always included when anything was recorded", () => {
   );
 });
 
+const gf = (name, weight = 400, style = "normal") =>
+  entry(
+    `Font(GoogleFont("${name}", bestEffort=true), weight=FontWeight(weight=${weight}), ` +
+      `style=${style === "italic" ? "Italic" : "Normal"}, fontVariationSettings=Settings(settings=[]))`,
+    weight,
+    style,
+  );
+
+test("downloadable GoogleFonts become named families keyed by display name", () => {
+  const files = new Set([
+    ...ALL_FILES,
+    "space-grotesk-400.ttf",
+    "space-grotesk-700.ttf",
+    "orbitron-500.ttf",
+  ]);
+  const payloads = [
+    { fonts: [gf("Space Grotesk", 400), gf("Space Grotesk", 700), gf("Orbitron", 500)] },
+  ];
+  const { manifest, warnings } = buildFontsManifest(payloads, files);
+  assert.equal(warnings.length, 0);
+  // Roboto (default) is always present; named families follow, alphabetically.
+  assert.deepEqual(
+    manifest.families.map((f) => [f.name, f.role]),
+    [
+      ["Roboto", "default"],
+      ["Orbitron", "named"],
+      ["Space Grotesk", "named"],
+    ],
+  );
+  assert.deepEqual(manifest.families[2].fonts, [
+    { file: "space-grotesk-400.ttf", weight: 400 },
+    { file: "space-grotesk-700.ttf", weight: 700 },
+  ]);
+});
+
+test("a named GoogleFont face with no vendored file warns and drops just that face", () => {
+  const files = new Set([...ALL_FILES, "space-grotesk-400.ttf"]);
+  const payloads = [{ fonts: [gf("Space Grotesk", 400), gf("Space Grotesk", 700)] }];
+  const { manifest, warnings } = buildFontsManifest(payloads, files);
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /space-grotesk-700\.ttf/);
+  assert.deepEqual(manifest.families.find((f) => f.name === "Space Grotesk").fonts, [
+    { file: "space-grotesk-400.ttf", weight: 400 },
+  ]);
+});
+
+test("italic GoogleFont faces vendor with the -italic stem and carry the flag", () => {
+  const files = new Set([...ALL_FILES, "space-grotesk-400-italic.ttf"]);
+  const payloads = [{ fonts: [gf("Space Grotesk", 400, "italic")] }];
+  const { manifest } = buildFontsManifest(payloads, files);
+  assert.deepEqual(manifest.families.find((f) => f.name === "Space Grotesk").fonts, [
+    { file: "space-grotesk-400-italic.ttf", weight: 400, italic: true },
+  ]);
+});
+
 test("no recorded usage keeps the committed manifest (null)", () => {
   assert.equal(buildFontsManifest([], ALL_FILES).manifest, null);
   assert.equal(buildFontsManifest([{ fonts: [] }], ALL_FILES).manifest, null);


### PR DESCRIPTION
## Summary

The in-browser Wasm tier (and its desktop sibling) regenerate `fonts.json` from what a catalog's previews actually resolved, then load those families from the TTFs vendored into the dist. Downloadable **GoogleFonts** (`Font(GoogleFont("Space Grotesk"), …)`) were dropped from that manifest, so any catalog using a branded face silently fell back to Roboto in the Wasm/CMP render instead of the font the component asked for.

This is the first of three parts that make the catalog tiers vendor and render downloadable GoogleFonts:

- **Part 1 (this commit): manifest generator.** `render-fonts-manifest.mjs` now recognises a downloadable-GoogleFont `requestedFamily` record, pulls out the display name, slugifies it to match the renderer's `GoogleFontKey.slugify`, and emits a `role:"named"` family per font keyed by that display name — one vendored file per (weight, italic) face (`<slug>-<weight>[-italic].ttf`). Unlike the generic families there's no nearest-weight snap: a face whose file the dist doesn't carry warns and drops just that face, leaving the family's other weights intact.
- **Part 3 (follow-on): load `role:"named"` families** in the Wasm `Main.kt` and desktop `CatalogTheme.kt` as a lookup map so a `Font(GoogleFont("<name>"))` request resolves onto the vendored faces.
- **Part 2 (follow-on): vendor the GoogleFont TTFs** into the dist `fonts/` dir in the export driver, plus a catalog demo consumer using a branded face so the manifest has real named usage to render.

Parts 2 & 3 land as further commits on this branch.

## Test plan

- `node --test scripts/design-artifacts/render-fonts-manifest.test.mjs` — 10/10 pass, including the three new named-family cases: downloadable GoogleFonts become `role:"named"` families keyed by display name and ordered after the default/generic block; a named face with no vendored file warns and drops just that face; italic faces vendor with the `-italic` stem and carry the `italic` flag.

This part is pure manifest-generation plumbing (no rendered surface changes yet), so no visual evidence applies until Parts 2/3 wire a branded face through the render.

_Generated by [Claude Code]_

---
_Generated by [Claude Code](https://claude.ai/code/session_01H8tYLhrNQShexawFUaqeGM)_