### PR TITLE
fix(design-artifacts): skip animated-GIF previews in the catalog export

### DIFF
--- a/scripts/design-artifacts/bundle-previews.mjs
+++ b/scripts/design-artifacts/bundle-previews.mjs
@@ -1,0 +1,28 @@
+/**
+ * Bundle preview-list helpers for the catalog export.
+ *
+ * Kept in its own module (not inline in `generate-design-catalog.mjs`) so it can be unit-tested: the
+ * generate script runs its whole pipeline at import (top-level `await`), so importing it from a test
+ * would execute the CLI.
+ */
+
+/**
+ * Drop previews that carry no static `previews/<id>.png` raster from [bundle] (mutating
+ * `bundle.previews` in place), returning the ids removed.
+ *
+ * These are animated / non-raster captures — a `@ScrollingPreview` `ScrollMode.GIF` scroll preview
+ * emits only `previews/<id>.gif`, no PNG. The `@design-parity/candidate` loader
+ * (`bundleToCandidates`) represents every preview as a PNG sticker and throws `InvalidBundleError`
+ * on a missing `previews/<id>.png`, so a single animated preview would otherwise fail the entire
+ * catalog export. Filtering `bundle.previews` here also keeps every downstream consumer (layout
+ * wireframes, fonts manifest) consistent — they all iterate the same list.
+ */
+export function dropNonRasterPreviews(bundle) {
+  const dropped = [];
+  bundle.previews = (bundle.previews ?? []).filter((preview) => {
+    if (bundle.entries?.[`previews/${preview.id}.png`]) return true;
+    dropped.push(preview.id);
+    return false;
+  });
+  return dropped;
+}

--- a/scripts/design-artifacts/bundle-previews.test.mjs
+++ b/scripts/design-artifacts/bundle-previews.test.mjs
@@ -1,0 +1,41 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { dropNonRasterPreviews } from "./bundle-previews.mjs";
+
+const enc = (s) => new TextEncoder().encode(s);
+
+test("keeps PNG-backed previews and drops PNG-less (animated GIF) ones", () => {
+  const bundle = {
+    previews: [
+      { id: "Card_Light" },
+      { id: "Card_Dark" },
+      { id: "CardScalingScrollGif_Large Round" }, // GIF preview: only a .gif in the zip
+    ],
+    entries: {
+      "previews/Card_Light.png": enc("png"),
+      "previews/Card_Dark.png": enc("png"),
+      "previews/CardScalingScrollGif_Large Round.gif": enc("gif"),
+    },
+  };
+  const dropped = dropNonRasterPreviews(bundle);
+  assert.deepEqual(dropped, ["CardScalingScrollGif_Large Round"]);
+  assert.deepEqual(
+    bundle.previews.map((p) => p.id),
+    ["Card_Light", "Card_Dark"],
+  );
+});
+
+test("no-op when every preview has a PNG", () => {
+  const bundle = {
+    previews: [{ id: "A" }, { id: "B" }],
+    entries: { "previews/A.png": enc("x"), "previews/B.png": enc("x") },
+  };
+  assert.deepEqual(dropNonRasterPreviews(bundle), []);
+  assert.equal(bundle.previews.length, 2);
+});
+
+test("tolerates a bundle with no previews / no entries", () => {
+  assert.deepEqual(dropNonRasterPreviews({}), []);
+  assert.deepEqual(dropNonRasterPreviews({ previews: [{ id: "X" }] }), ["X"]);
+});

--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -56,6 +56,7 @@ import { renderWireframeSvg, slug } from "./render-wireframe-svg.mjs";
 import { renderLayoutWireframeSvg } from "./render-layout-wireframe-svg.mjs";
 import { DEFAULT_PREVIEW_BASE, livePreviewUrl } from "./live-preview.mjs";
 import { buildFontsManifest, fontsPayloadsFromBundle } from "./render-fonts-manifest.mjs";
+import { dropNonRasterPreviews } from "./bundle-previews.mjs";
 
 /** Relative paths of every file under `dir` (forward-slashed), for the webRender manifest. */
 async function listFilesRecursive(dir) {
@@ -84,6 +85,18 @@ async function listFilesRecursive(dir) {
  */
 async function loadCandidates(path) {
   const bundle = await readPreviewBundle(path);
+  // `bundleToCandidates` represents every preview as a static PNG sticker — it looks up
+  // `previews/<id>.png` and throws `InvalidBundleError` if it's missing. A `@ScrollingPreview`
+  // `ScrollMode.GIF` preview (e.g. the wear catalog's `CardScalingScrollGif`) only emits an animated
+  // `previews/<id>.gif`, so it has no PNG and can't be a static catalog candidate. Drop those up
+  // front (logging what's dropped) so one animated preview can't fail the whole catalog export.
+  const dropped = dropNonRasterPreviews(bundle);
+  if (dropped.length > 0) {
+    console.warn(
+      `[${basename(path)}] skipped ${dropped.length} preview(s) with no static PNG ` +
+        `(animated GIF / non-raster capture): ${dropped.join(", ")}`,
+    );
+  }
   for (const preview of bundle.previews) {
     sanitizeNullSizes(preview.params);
     for (const capture of preview.captures ?? []) sanitizeNullSizes(capture.params);


### PR DESCRIPTION
## Summary

The `wear-m3` catalog export has been failing (the "Generate importable catalog" step) since the wear scroll-GIF preview was added in #2433 — the two most recent `design-artifacts` runs both failed here, unrelated to any font work:

```
InvalidBundleError: not a valid compose-ai-tools preview bundle: preview
'…CardScalingScrollGif_Large Round' references image
'previews/…CardScalingScrollGif_Large Round.png' which is not in the zip
```

`CardScalingScrollGif` is a `@ScrollingPreview(ScrollMode.GIF)`, so its only artifact is an animated `previews/<id>.gif` — there's no PNG. But `@design-parity/candidate`'s `bundleToCandidates` represents **every** preview as a static PNG sticker and throws `InvalidBundleError` on the missing `previews/<id>.png`, taking down the whole catalog export for one animated preview.

**Fix:** drop previews that carry no static `previews/<id>.png` before the candidate join. An animated scroll GIF isn't an importable static sticker (and `CardScalingScrollGif` isn't in `catalog.spec.json`, so dropping it removes nothing from the catalog); the skip is logged rather than silent. The filter is extracted to `bundle-previews.mjs` so it's unit-testable — the generate script runs its whole pipeline at import, so it can't be imported from a test directly. Filtering `bundle.previews` in place also keeps the downstream consumers (layout wireframes, fonts manifest) consistent, since they iterate the same list.

No behavior change for `compose-m3` / `remote-m3` — they have no GIF previews, so the filter is a no-op there.

## Test plan

- `node --test scripts/design-artifacts/bundle-previews.test.mjs` — new coverage: PNG-backed previews kept, PNG-less (GIF) dropped and reported; no-op when all previews have PNGs; tolerates empty/absent `previews`/`entries`.
- `node --test scripts/design-artifacts/*.test.mjs` — full suite green (50 tests).
- `node --check scripts/design-artifacts/generate-design-catalog.mjs` — clean.

This is build/data-plumbing (no rendered surface changes), so no visual evidence applies. End-to-end confirmation is the next `design-artifacts` run's `wear-m3` job going green — I'll dispatch it once this merges.

_Generated by [Claude Code]_

---
_Generated by [Claude Code](https://claude.ai/code/session_01H8tYLhrNQShexawFUaqeGM)_