### PR TITLE
fix(design-artifacts): preserve catalog-token sheets when filtering non-raster previews

### DIFF
--- a/scripts/design-artifacts/bundle-previews.mjs
+++ b/scripts/design-artifacts/bundle-previews.mjs
@@ -7,22 +7,31 @@
  */
 
 /**
- * Drop previews that carry no static `previews/<id>.png` raster from [bundle] (mutating
- * `bundle.previews` in place), returning the ids removed.
+ * Build the bundle view handed to `@design-parity/candidate`'s `bundleToCandidates`, keeping only
+ * previews that carry a static `previews/<id>.png` raster. Returns `{ bundle, dropped }` where
+ * `bundle` is a shallow clone with a filtered `previews` array (the original is left untouched) and
+ * `dropped` is the ids removed.
  *
- * These are animated / non-raster captures — a `@ScrollingPreview` `ScrollMode.GIF` scroll preview
- * emits only `previews/<id>.gif`, no PNG. The `@design-parity/candidate` loader
- * (`bundleToCandidates`) represents every preview as a PNG sticker and throws `InvalidBundleError`
- * on a missing `previews/<id>.png`, so a single animated preview would otherwise fail the entire
- * catalog export. Filtering `bundle.previews` here also keeps every downstream consumer (layout
- * wireframes, fonts manifest) consistent — they all iterate the same list.
+ * `bundleToCandidates` represents every preview as a PNG sticker and throws `InvalidBundleError` on a
+ * missing `previews/<id>.png`, so a preview whose only artifact is non-raster would fail the whole
+ * catalog export. Two kinds of preview have no PNG:
+ *   - animated captures — a `@ScrollingPreview` `ScrollMode.GIF` preview emits only
+ *     `previews/<id>.gif` (e.g. the wear catalog's `CardScalingScrollGif`); it isn't an importable
+ *     static sticker, so it's simply excluded from the candidate join.
+ *   - catalog-token sheets — `@ColorCatalog` / `@TypographyCatalog` / `@ThemeCatalog` metadata
+ *     previews are rendered PNG-less by design, but their `previews/<id>.catalog.json` sidecars are
+ *     read separately via `catalogTokensFromBundle(bundle)` to export `themeTokens`.
+ *
+ * Because this returns a **clone** and never mutates `bundle.previews`, those catalog-token sheets
+ * stay in the original bundle for the token pass (and layout wireframes / fonts manifest, which
+ * iterate the full list) — only the candidate join sees the filtered view.
  */
-export function dropNonRasterPreviews(bundle) {
+export function candidatePreviewBundle(bundle) {
   const dropped = [];
-  bundle.previews = (bundle.previews ?? []).filter((preview) => {
+  const previews = (bundle.previews ?? []).filter((preview) => {
     if (bundle.entries?.[`previews/${preview.id}.png`]) return true;
     dropped.push(preview.id);
     return false;
   });
-  return dropped;
+  return { bundle: { ...bundle, previews }, dropped };
 }

--- a/scripts/design-artifacts/bundle-previews.test.mjs
+++ b/scripts/design-artifacts/bundle-previews.test.mjs
@@ -1,7 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { dropNonRasterPreviews } from "./bundle-previews.mjs";
+import { candidatePreviewBundle } from "./bundle-previews.mjs";
 
 const enc = (s) => new TextEncoder().encode(s);
 
@@ -18,24 +18,50 @@ test("keeps PNG-backed previews and drops PNG-less (animated GIF) ones", () => {
       "previews/CardScalingScrollGif_Large Round.gif": enc("gif"),
     },
   };
-  const dropped = dropNonRasterPreviews(bundle);
+  const { bundle: view, dropped } = candidatePreviewBundle(bundle);
   assert.deepEqual(dropped, ["CardScalingScrollGif_Large Round"]);
   assert.deepEqual(
-    bundle.previews.map((p) => p.id),
+    view.previews.map((p) => p.id),
     ["Card_Light", "Card_Dark"],
   );
 });
 
-test("no-op when every preview has a PNG", () => {
+test("does not mutate the original bundle — catalog-token sheets survive for the token pass", () => {
+  // A @ThemeCatalog/@ColorCatalog sheet is rendered PNG-less by design; its tokens are read later
+  // via catalogTokensFromBundle(bundle). Filtering must not strip it from the original bundle.
+  const bundle = {
+    previews: [{ id: "Button_Light" }, { id: "MeshCoreLight_theme" }],
+    entries: {
+      "previews/Button_Light.png": enc("png"),
+      "previews/MeshCoreLight_theme.catalog.json": enc("{}"),
+    },
+  };
+  const { bundle: view, dropped } = candidatePreviewBundle(bundle);
+  // The candidate view excludes the PNG-less sheet…
+  assert.deepEqual(dropped, ["MeshCoreLight_theme"]);
+  assert.deepEqual(
+    view.previews.map((p) => p.id),
+    ["Button_Light"],
+  );
+  // …but the original bundle still carries it (and its entries) for token extraction.
+  assert.deepEqual(
+    bundle.previews.map((p) => p.id),
+    ["Button_Light", "MeshCoreLight_theme"],
+  );
+  assert.ok(bundle.entries["previews/MeshCoreLight_theme.catalog.json"]);
+});
+
+test("no-op view when every preview has a PNG", () => {
   const bundle = {
     previews: [{ id: "A" }, { id: "B" }],
     entries: { "previews/A.png": enc("x"), "previews/B.png": enc("x") },
   };
-  assert.deepEqual(dropNonRasterPreviews(bundle), []);
-  assert.equal(bundle.previews.length, 2);
+  const { bundle: view, dropped } = candidatePreviewBundle(bundle);
+  assert.deepEqual(dropped, []);
+  assert.equal(view.previews.length, 2);
 });
 
 test("tolerates a bundle with no previews / no entries", () => {
-  assert.deepEqual(dropNonRasterPreviews({}), []);
-  assert.deepEqual(dropNonRasterPreviews({ previews: [{ id: "X" }] }), ["X"]);
+  assert.deepEqual(candidatePreviewBundle({}).dropped, []);
+  assert.deepEqual(candidatePreviewBundle({ previews: [{ id: "X" }] }).dropped, ["X"]);
 });

--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -56,7 +56,7 @@ import { renderWireframeSvg, slug } from "./render-wireframe-svg.mjs";
 import { renderLayoutWireframeSvg } from "./render-layout-wireframe-svg.mjs";
 import { DEFAULT_PREVIEW_BASE, livePreviewUrl } from "./live-preview.mjs";
 import { buildFontsManifest, fontsPayloadsFromBundle } from "./render-fonts-manifest.mjs";
-import { dropNonRasterPreviews } from "./bundle-previews.mjs";
+import { candidatePreviewBundle } from "./bundle-previews.mjs";
 
 /** Relative paths of every file under `dir` (forward-slashed), for the webRender manifest. */
 async function listFilesRecursive(dir) {
@@ -85,26 +85,26 @@ async function listFilesRecursive(dir) {
  */
 async function loadCandidates(path) {
   const bundle = await readPreviewBundle(path);
-  // `bundleToCandidates` represents every preview as a static PNG sticker — it looks up
-  // `previews/<id>.png` and throws `InvalidBundleError` if it's missing. A `@ScrollingPreview`
-  // `ScrollMode.GIF` preview (e.g. the wear catalog's `CardScalingScrollGif`) only emits an animated
-  // `previews/<id>.gif`, so it has no PNG and can't be a static catalog candidate. Drop those up
-  // front (logging what's dropped) so one animated preview can't fail the whole catalog export.
-  const dropped = dropNonRasterPreviews(bundle);
-  if (dropped.length > 0) {
-    console.warn(
-      `[${basename(path)}] skipped ${dropped.length} preview(s) with no static PNG ` +
-        `(animated GIF / non-raster capture): ${dropped.join(", ")}`,
-    );
-  }
   for (const preview of bundle.previews) {
     sanitizeNullSizes(preview.params);
     for (const capture of preview.captures ?? []) sanitizeNullSizes(capture.params);
   }
-  const candidates = bundleToCandidates(bundle, (entry) => entry.functionName ?? entry.id);
-  // Keep the bundle around: its raw `entries` carry the per-preview
-  // `previews/<id>.layout.json` (the layout-inspector tree) the layout wireframe
-  // is built from — a sidecar `bundleToCandidates` doesn't surface.
+  // `bundleToCandidates` represents every preview as a static PNG sticker — it looks up
+  // `previews/<id>.png` and throws `InvalidBundleError` if it's missing. Feed it a filtered *view*
+  // (animated `ScrollMode.GIF` previews and PNG-less catalog-token sheets removed) rather than
+  // mutating `bundle`, so the original keeps those records: the catalog-token sheets are read
+  // separately by `catalogTokensFromBundle(bundle)` below, and layout/fonts iterate the full list.
+  const { bundle: candidateBundle, dropped } = candidatePreviewBundle(bundle);
+  if (dropped.length > 0) {
+    console.warn(
+      `[${basename(path)}] excluded ${dropped.length} preview(s) with no static PNG from the ` +
+        `candidate join (animated GIF / metadata sheet): ${dropped.join(", ")}`,
+    );
+  }
+  const candidates = bundleToCandidates(candidateBundle, (entry) => entry.functionName ?? entry.id);
+  // Return the ORIGINAL (unfiltered) bundle: its raw `entries` carry the per-preview
+  // `previews/<id>.layout.json` (layout-inspector tree) the wireframe is built from, and its full
+  // `previews` list carries the catalog-token sheets `catalogTokensFromBundle` needs.
   return { candidates, bundle };
 }
 


### PR DESCRIPTION
## Summary

Follow-up hardening to #2458 (skip animated-GIF previews in the catalog export), addressing a valid review point: `dropNonRasterPreviews` **mutated** `bundle.previews`, dropping every PNG-less preview in place. But `@ColorCatalog` / `@TypographyCatalog` / `@ThemeCatalog` metadata sheets are rendered **PNG-less by design**, and their `previews/<id>.catalog.json` sidecars are read later via `catalogTokensFromBundle(bundle)` to export `themeTokens`. Mutating the shared bundle would strip those records before the token pass, silently dropping exported theme tokens for any catalog that carries them.

**Fix:** replace `dropNonRasterPreviews(bundle)` with `candidatePreviewBundle(bundle)`, which returns a **shallow-cloned view** (`{ bundle, dropped }`) with a filtered `previews` array and leaves the original untouched. `bundleToCandidates` gets the filtered view (GIF + PNG-less sheets excluded, so no `InvalidBundleError`); the original bundle flows on to `catalogTokensFromBundle` and the layout/fonts passes with all records intact.

No regression today — the current compose-ai catalogs carry no `@*Catalog` sheets — but the machinery supports them (meshcore uses `@ThemeCatalog`), so this prevents a future silent token loss. The GIF-skip behavior from #2458 is unchanged.

## Test plan

- `node --test scripts/design-artifacts/bundle-previews.test.mjs` — 4 pass, including a new case asserting the original bundle (and its `.catalog.json` entry) survives while the candidate view excludes the PNG-less sheet.
- `node --check scripts/design-artifacts/generate-design-catalog.mjs` — clean.

Build/data-plumbing only; no rendered-surface change, so no visual evidence applies.

_Generated by [Claude Code]_

---
_Generated by [Claude Code](https://claude.ai/code/session_01H8tYLhrNQShexawFUaqeGM)_