### PR TITLE
build(deploy): bake Robolectric android-all into the preview-host image

### DIFF
--- a/deploy/image/Dockerfile
+++ b/deploy/image/Dockerfile
@@ -129,13 +129,22 @@ RUN set -eu; \
 # (it's the `android-all-instrumented-<ver>` dir that appears under ~/.m2 after a first
 # render). Best-effort — the daemon still fetches at runtime if this is stale/missing.
 ARG ANDROID_ALL_VERSION=15-robolectric-13954326-i7
+# Download to a temp path and move on success. A partial jar left at the real
+# `jarPath()` would be worse than no prefetch: Robolectric 4.16.1's MavenArtifactFetcher
+# skips its runtime download when the target exists, so a truncated file would boot the
+# daemon with a corrupt android-all instead of falling back. On any failure, delete the
+# temp file and let the daemon fetch at runtime.
 RUN set -eu; \
     d="/root/.m2/repository/org/robolectric/android-all-instrumented/${ANDROID_ALL_VERSION}"; \
+    f="$d/android-all-instrumented-${ANDROID_ALL_VERSION}.jar"; \
     mkdir -p "$d"; \
-    curl -fsSL --retry 10 --retry-delay 15 --retry-all-errors \
-      -o "$d/android-all-instrumented-${ANDROID_ALL_VERSION}.jar" \
-      "https://repo1.maven.org/maven2/org/robolectric/android-all-instrumented/${ANDROID_ALL_VERSION}/android-all-instrumented-${ANDROID_ALL_VERSION}.jar" \
-      || echo "warn: android-all prefetch failed (coordinate stale?); daemon will fetch at runtime"
+    if curl -fsSL --retry 10 --retry-delay 15 --retry-all-errors -o "$f.tmp" \
+        "https://repo1.maven.org/maven2/org/robolectric/android-all-instrumented/${ANDROID_ALL_VERSION}/android-all-instrumented-${ANDROID_ALL_VERSION}.jar"; then \
+      mv "$f.tmp" "$f"; \
+    else \
+      rm -f "$f.tmp"; \
+      echo "warn: android-all prefetch failed (coordinate stale?); daemon will fetch at runtime"; \
+    fi
 
 # ---------------------------------------------------------------------------
 # Stage 2: runtime.

--- a/deploy/image/Dockerfile
+++ b/deploy/image/Dockerfile
@@ -119,6 +119,23 @@ RUN set -eu; \
     unzip -q /tmp/android-daemon.zip -d /opt; \
     rm /tmp/android-daemon.zip; \
     test -d /opt/lib-daemon-android
+# Pre-fetch Robolectric's instrumented `android-all` runtime (~200 MB) into the local
+# Maven cache so the daemon's FIRST render doesn't download it (the runtime stage
+# carries this m2 subtree). This removes the download from the cold start — though the
+# dominant cold cost is the per-process Robolectric/Compose warm-up + first render,
+# which only serve's prewarm can move off the request path (a cached android-all still
+# leaves that). The coordinate is Robolectric-version + SDK specific (4.16.1 → SDK 35),
+# so it's an ARG: bump it when the bundled robolectric or ANDROID_SDK_PLATFORM changes
+# (it's the `android-all-instrumented-<ver>` dir that appears under ~/.m2 after a first
+# render). Best-effort — the daemon still fetches at runtime if this is stale/missing.
+ARG ANDROID_ALL_VERSION=15-robolectric-13954326-i7
+RUN set -eu; \
+    d="/root/.m2/repository/org/robolectric/android-all-instrumented/${ANDROID_ALL_VERSION}"; \
+    mkdir -p "$d"; \
+    curl -fsSL --retry 10 --retry-delay 15 --retry-all-errors \
+      -o "$d/android-all-instrumented-${ANDROID_ALL_VERSION}.jar" \
+      "https://repo1.maven.org/maven2/org/robolectric/android-all-instrumented/${ANDROID_ALL_VERSION}/android-all-instrumented-${ANDROID_ALL_VERSION}.jar" \
+      || echo "warn: android-all prefetch failed (coordinate stale?); daemon will fetch at runtime"
 
 # ---------------------------------------------------------------------------
 # Stage 2: runtime.
@@ -157,6 +174,10 @@ WORKDIR /project
 COPY --from=build /project /project
 COPY --from=build /root/.gradle /root/.gradle
 COPY --from=build /root/.m2 /root/.m2
+# Merge the pre-fetched Robolectric `android-all` runtime into the Maven cache (after
+# the build-stage m2 so it lands alongside it), so the Android daemon's first render
+# skips the ~200 MB download.
+COPY --from=android-daemon /root/.m2/repository/org/robolectric /root/.m2/repository/org/robolectric
 
 # Bake the branch-trust store so a public deploy badges the published
 # design-artifacts catalogs as Trusted(Branch) out of the box (SERVE_TRUST_STORE


### PR DESCRIPTION
Follow-up to #2460. Answers "how much of the Android cold start can be baked into the image?"

## What's now baked (zero runtime downloads)

| Artifact | Size | Where |
|---|---|---|
| `lib-daemon-android` sidecar | ~234 MB | #2460 |
| Android SDK platform (`android.jar`) | ~310 MB | #2460 |
| **`android-all-instrumented` runtime** | ~200 MB | **this PR** |

The `android-daemon` stage now pre-fetches Robolectric's instrumented `android-all` into the local Maven cache and the runtime stage merges that m2 subtree, so the daemon's **first render pays zero download**. The coordinate is Robolectric-version + SDK specific (4.16.1 → SDK 35), so it's a bumpable `ARG ANDROID_ALL_VERSION`; the fetch is best-effort (`|| echo warn`) so a stale coordinate just falls back to the runtime download rather than failing the build.

## What can't be baked (measured)

Baking `android-all` removes the **download** and the network dependency at first boot — but **not** the dominant cold cost. With the jar already on disk, a cold Wear render still took **~30 min** on a CPU-starved box: the per-process Robolectric sandbox classloading + JVM JIT + Compose/Wear runtime init + first composition is *execution*, not a file. Only serve's `prewarm()` (shipped in #2460) hides that, by moving it off the request path. Truly baking the warm-up itself would need a JVM checkpoint/restore (CRaC) of a pre-warmed daemon — a much bigger lift, noted for later.

## Test plan

Can't be built from here (image build needs this in CI + real network). Change is a self-contained artifact prefetch + a runtime `COPY`; the fetch is fail-soft and the daemon's existing runtime fetch remains the fallback.

_Generated by [Claude Code](https://claude.ai/code/session_01Jxz9i4SuuxPRt3knZKAPbb)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jxz9i4SuuxPRt3knZKAPbb)_