### PR TITLE
fix(layoutinspector): strip MeasurePolicy suffix from SVG layer names

### DIFF
--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgModel.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgModel.kt
@@ -743,7 +743,20 @@ data class FigmaSvgModel(
       )
     }
 
-    private fun LayoutInspectorNode.layerName(): String = component.ifBlank { "Layer" }
+    private fun LayoutInspectorNode.layerName(): String =
+      composableName(component).ifBlank { "Layer" }
+
+    /**
+     * The composable name to show as the SVG layer id. When source-info resolution succeeds
+     * [LayoutInspectorNode.component] already carries the composable name (`Box`, `Card`, …); when
+     * it falls back to the measure-policy class it reads `BoxMeasurePolicy` / `RootMeasurePolicy` /
+     * `OutlinedTextFieldMeasurePolicy`. Strip that implementation-detail suffix so the layer reads
+     * as the composable — `BoxMeasurePolicy` → `Box` — rather than exposing an internal class name.
+     */
+    private fun composableName(component: String): String =
+      component.removeSuffix(MEASURE_POLICY_SUFFIX).ifBlank { component }
+
+    private const val MEASURE_POLICY_SUFFIX = "MeasurePolicy"
 
     /**
      * Assigns each semantics text node to the single best-matching layout node, keyed by layout

--- a/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvgTest.kt
+++ b/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvgTest.kt
@@ -67,6 +67,32 @@ class FigmaLayeredSvgTest {
   }
 
   @Test
+  fun layerNameStripsMeasurePolicySuffixSoGroupsReadAsComposables() {
+    // When source-info resolution fails the component falls back to the measure-policy class name
+    // (`BoxMeasurePolicy`, `RootMeasurePolicy`); the layer id should read as the composable
+    // instead.
+    val svg =
+      render(
+        layoutNode(
+          "RootMeasurePolicy",
+          0,
+          0,
+          200,
+          100,
+          children =
+            listOf(
+              layoutNode("BoxMeasurePolicy", 0, 0, 100, 50),
+              layoutNode("OutlinedTextFieldMeasurePolicy", 0, 50, 200, 100),
+            ),
+        )
+      )
+    assertTrue(svg, svg.contains("""<g id="Root""""))
+    assertTrue(svg, svg.contains("""<g id="Box""""))
+    assertTrue(svg, svg.contains("""<g id="OutlinedTextField""""))
+    assertFalse(svg, svg.contains("MeasurePolicy"))
+  }
+
+  @Test
   fun rootSvgRequestsGeometricPrecisionSoTextMatchesTheRender() {
     // The default `text-rendering:auto` grid-fits glyphs to pixel boundaries in the browser, which
     // leaves a constant edge diff against the Skiko render on text-heavy previews. Pin the


### PR DESCRIPTION
## Summary

The layered Figma SVG names every `<g>` layer after the composable it stands
for (`Box`, `Card`, `Column`, …). That name comes from
`LayoutInspectorNode.component`, which — when composition source-info
resolution succeeds — is the real composable name. When it falls back to the
node's **measure policy** class, though, the layer id leaked an internal
implementation name: `BoxMeasurePolicy`, `RootMeasurePolicy`,
`OutlinedTextFieldMeasurePolicy`.

This strips the `MeasurePolicy` suffix in the SVG generation (`layerName()` in
`FigmaSvgModel`) so each group reads as the composable it represents:

| before | after |
| --- | --- |
| `<g id="BoxMeasurePolicy">` | `<g id="Box">` |
| `<g id="RootMeasurePolicy">` | `<g id="Root">` |
| `<g id="OutlinedTextFieldMeasurePolicy">` | `<g id="OutlinedTextField">` |

When source-info already gave a clean composable name, output is unchanged.
This only affects the `<g>` layer id (group/frame naming in a Figma import) —
it is metadata, not drawn pixels, so the rendered SVG is pixel-identical and
there is no visual diff to show. Raster/opaque-component detection is
untouched: it still matches on the raw `component` value.

## Test plan

- Added `layerNameStripsMeasurePolicySuffixSoGroupsReadAsComposables` to
  `FigmaLayeredSvgTest`, asserting a tree of `RootMeasurePolicy` /
  `BoxMeasurePolicy` / `OutlinedTextFieldMeasurePolicy` nodes emits
  `<g id="Root">`, `<g id="Box">`, `<g id="OutlinedTextField">` and no
  `MeasurePolicy` anywhere in the SVG.
- `./gradlew :data-layoutinspector-core:test --tests "*FigmaLayeredSvgTest*"
  --tests "*FigmaSvgZeroBoundsTest*"` → `BUILD SUCCESSFUL` (existing SVG tests
  still pass alongside the new one).

---
_Generated by [Claude Code](https://claude.ai/code/session_016TRQ2T5st7pySwiHjMqyij)_