### PR TITLE
feat(layoutinspector): flatten synthetic SVG layers and inherit composable names

### DIFF
--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
@@ -992,30 +992,38 @@ internal object ComposeLayoutInspector {
     private val byNode = java.util.IdentityHashMap<Any, LayoutSource>()
 
     init {
-      slotTables
-        .snapshot()
-        .asSequence()
-        .flatMap { it.compositionGroups.asSequence() }
-        .flatMap { it.flattenGroups().asSequence() }
-        .forEach { group ->
-          val node = group.node ?: return@forEach
-          val sourceInfo = group.sourceInfo
-          if (sourceInfo != null) {
-            byNode[node] =
-              LayoutSource(
-                component = sourceInfo.componentName() ?: node.javaClass.simpleName,
-                source = sourceInfo.sourceLocation(),
-                sourceInfo = sourceInfo,
-              )
-          }
+      slotTables.snapshot().forEach { data ->
+        data.compositionGroups.forEach { index(it, enclosingName = null) }
+      }
+    }
+
+    /**
+     * Walk the composition-group tree depth-first, carrying the nearest enclosing composable name.
+     * A LayoutNode whose own group has no `C(Composable)` marker — a library-internal
+     * `Box`/`Row`/`Layout` that a `Button`/`Card`/… builds itself from, which otherwise falls back
+     * to its measure-policy class name — inherits the name of the composable that encloses it, so
+     * the export layer reads `Button` rather than an anonymous `Box`. A group's own `C(...)` still
+     * wins for its own subtree; the inherited name only fills the gaps.
+     */
+    private fun index(group: CompositionGroup, enclosingName: String?) {
+      val currentName = group.sourceInfo?.componentName() ?: enclosingName
+      val node = group.node
+      if (node != null) {
+        val name = currentName ?: group.sourceInfo?.let { node.javaClass.simpleName }
+        if (name != null) {
+          byNode[node] =
+            LayoutSource(
+              component = name,
+              source = group.sourceInfo?.sourceLocation(),
+              sourceInfo = group.sourceInfo,
+            )
         }
+      }
+      group.compositionGroups.forEach { index(it, currentName) }
     }
 
     fun sourceFor(node: Any): LayoutSource? = byNode[node]
   }
-
-  private fun CompositionGroup.flattenGroups(): List<CompositionGroup> =
-    listOf(this) + compositionGroups.flatMap { it.flattenGroups() }
 
   private fun String.componentName(): String? =
     Regex("""C\(([^)]+)\)""").find(this)?.groupValues?.getOrNull(1)?.takeIf { it.isNotBlank() }

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgModel.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgModel.kt
@@ -350,7 +350,7 @@ data class FigmaSvgModel(
       val names = colorNames.mapKeys { it.key.uppercase() }
       val ctx =
         BuildContext(textByNodeId, names, density, rasterComponents, rasterHref, captureCanvasDraws)
-      val rootLayer = layout.root.toLayer(ctx)
+      val rootLayer = collapsePassthroughGroups(layout.root.toLayer(ctx))
       // A round Wear device screen is masked to the inscribed circle of the frame (the root node's
       // bounds) — content outside it (the corners, and any list item scrolled below the frame) is
       // clipped away, matching Roborazzi's device crop. Clamp the extent to that frame so the
@@ -630,6 +630,35 @@ data class FigmaSvgModel(
         children = children.map { it.toLayer(ctx, bounds) },
       )
     }
+
+    /**
+     * Collapse pure-grouping pass-through layers — a `<g>` that draws nothing (no
+     * fill/stroke/text/raster/background, no shadow) and only wraps a *single* child — into that
+     * child. Compose's `LayoutNode` tree stacks several such nodes per widget (a `Button` nests a
+     * handful of internal boxes), so a 1:1 layer-per-node export reads as a deep pile of anonymous
+     * `Box` groups. Dropping a wrapper that neither paints nor groups siblings is pixel-identical —
+     * a bare grouping `<g>` carries no transform/clip/opacity, so removing it moves nothing — while
+     * flattening the tree down to the layers that actually stand for something in the design.
+     *
+     * Two deliberate narrowings keep meaningful structure:
+     * - the **root** frame is never dropped (it anchors the canvas); only its descendants collapse.
+     * - a grouping node with **2+ children** is kept — it genuinely groups siblings, so it's real
+     *   structure, not a redundant nesting level.
+     */
+    private fun collapsePassthroughGroups(root: FigmaSvgLayer): FigmaSvgLayer =
+      root.copy(children = root.children.map { it.collapseSubtree() })
+
+    private fun FigmaSvgLayer.collapseSubtree(): FigmaSvgLayer {
+      var layer = copy(children = children.map { it.collapseSubtree() })
+      while (layer.isPassthroughGroup && layer.children.size == 1) {
+        layer = layer.children.single()
+      }
+      return layer
+    }
+
+    /** A layer that neither paints ([FigmaSvgLayer.paints]) nor casts a shadow — pure nesting. */
+    private val FigmaSvgLayer.isPassthroughGroup: Boolean
+      get() = !paints && elevationPx == 0.0
 
     /**
      * The node's captured [LayoutInspectorNode.bounds], or — only for the exact all-zero

--- a/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvgTest.kt
+++ b/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvgTest.kt
@@ -107,6 +107,91 @@ class FigmaLayeredSvgTest {
   }
 
   @Test
+  fun collapsesPurePassthroughWrappersIntoTheirSingleChild() {
+    // Compose stacks anonymous single-child layout nodes per widget (padding / min-size / clip
+    // wrappers). Those draw nothing and only nest one child, so they collapse into the child that
+    // actually paints — the export shouldn't emit a pile of empty <g> groups.
+    val svg =
+      render(
+        layoutNode(
+          "Screen",
+          0,
+          0,
+          200,
+          100,
+          children =
+            listOf(
+              layoutNode(
+                "WrapperA",
+                0,
+                0,
+                100,
+                40,
+                children =
+                  listOf(
+                    layoutNode(
+                      "WrapperB",
+                      0,
+                      0,
+                      100,
+                      40,
+                      children =
+                        listOf(
+                          layoutNode(
+                            "Button",
+                            0,
+                            0,
+                            100,
+                            40,
+                            tokens = ComposeSemanticsTokens(backgroundColor = "#FF000000"),
+                          )
+                        ),
+                    )
+                  ),
+              )
+            ),
+        )
+      )
+    // The two empty wrappers are gone; the painting Button and the root frame survive.
+    assertFalse(svg, svg.contains("WrapperA"))
+    assertFalse(svg, svg.contains("WrapperB"))
+    assertTrue(svg, svg.contains("""<g id="Screen""""))
+    assertTrue(svg, svg.contains("""<g id="Button""""))
+    assertTrue(svg, svg.contains("<rect"))
+  }
+
+  @Test
+  fun keepsGroupingLayersThatHoldMultipleChildren() {
+    // A pass-through node with 2+ children genuinely groups siblings — it's real structure, not a
+    // redundant nesting level, so it must be preserved even though it draws nothing itself.
+    val svg =
+      render(
+        layoutNode(
+          "Screen",
+          0,
+          0,
+          200,
+          100,
+          children =
+            listOf(
+              layoutNode("Header", 0, 0, 200, 40),
+              layoutNode(
+                "Row",
+                0,
+                0,
+                200,
+                40,
+                children =
+                  listOf(layoutNode("Left", 0, 0, 100, 40), layoutNode("Right", 100, 0, 200, 40)),
+              ),
+            ),
+        )
+      )
+    assertTrue(svg, svg.contains("""<g id="Left""""))
+    assertTrue(svg, svg.contains("""<g id="Right""""))
+  }
+
+  @Test
   fun rootSvgRequestsGeometricPrecisionSoTextMatchesTheRender() {
     // The default `text-rendering:auto` grid-fits glyphs to pixel boundaries in the browser, which
     // leaves a constant edge diff against the Skiko render on text-heavy previews. Pin the


### PR DESCRIPTION
## Summary

Follow-up to #2468. The layered Figma SVG mirrored Compose's `LayoutNode` tree 1:1, so every widget exported as a deep stack of anonymous `Box` groups: the internal layout nodes a `Button`/`Card` builds itself from carry no composition `C(Composable)` marker, so they fell back to their measure-policy class name **and** each still emitted its own `<g>`. This brings the layer tree closer to the source structure two ways.

**A — Names (producer, `LayoutSourceIndex`).** Walk the composition-group tree carrying the nearest enclosing composable name, so a node with no `C(...)` of its own inherits the composable that encloses it — a `Button`'s inner box now reads `Button` instead of `Box`. A group's own `C(...)` still wins for its own subtree; inheritance only fills the gaps.

**B — Structure (`FigmaSvgModel`).** Collapse *pure pass-through* layers — a group that draws nothing (no fill/stroke/text/raster/background/shadow) and only wraps a **single** child — into that child. Two nodes are never dropped: the root frame (anchors the canvas) and any group holding **2+ children** (it genuinely groups siblings).

Net effect on a typical `Button { Text }`:

```
before                          after
<g id="Box">                    <g id="Button">      (A: inherited name)
  <g id="Box">                    <rect/>            (B: 3 empty wrappers
    <g id="Box">                    <g id="Text">…      collapsed away)
      <g id="Button"><rect/>      </g>
        <g id="Box">
          <g id="Text">…
```

## Why this is safe to merge without a visual diff

Both changes are **pixel-identical** — they only affect `<g>` layer *names* and *nesting*, never drawn geometry. A bare grouping `<g>` carries no transform/clip/opacity, so removing it moves nothing; renaming a group can't move a pixel. So there is no before/after render to embed — the CI visual-diff bot should show **no pixel change**, which is the intended evidence here. The structural change is verified by unit tests below; the naming change is exercised by the Robolectric `LayoutInspectorFixtureTest` and validated end-to-end by CI.

## Test plan

- Added to `FigmaLayeredSvgTest`:
  - `collapsesPurePassthroughWrappersIntoTheirSingleChild` — a two-wrapper chain over a painting `Button` collapses to `Screen → Button`; the empty wrappers are gone, the root frame and the `<rect>` survive.
  - `keepsGroupingLayersThatHoldMultipleChildren` — a group with 2+ children is preserved.
- `./gradlew :data-layoutinspector-core:test` → **BUILD SUCCESSFUL** (full core suite, incl. the existing `everyLayoutNodeBecomesANamedGroup` / `viewBoxIsUnionOfDrawingLayersPlusPadding` which pin that real structure isn't over-collapsed).
- `./gradlew :data-layoutinspector-connector:compileKotlin` → **SUCCESSFUL** (the producer/naming change).
- Checked the tests that assert `component` strings (`LayoutInspectorFixtureTest`, `ComposeSemanticsDataProductRegistryTest`, `RenderEngineTest`): the root has no enclosing composable so it stays `RootMeasurePolicy`, and the registry tests read hardcoded JSON — none regress.

---
_Generated by [Claude Code](https://claude.ai/code/session_016TRQ2T5st7pySwiHjMqyij)_