### PR TITLE
fix(layoutinspector): key SVG raster matching off own component, not inherited name

### DIFF
--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
@@ -785,18 +785,23 @@ internal object ComposeLayoutInspector {
   ): LayoutInspectorNode {
     val rootCoords = rootCoordinates ?: coordinates
     val source = sources.sourceFor(raw)
+    // The node's own identity (own `C(...)` or measure-policy class) drives raster/curved matching;
+    // the friendly, possibly-inherited label rides separately in `displayName`. Keying matching off
+    // the own identity keeps an inherited label like `IconButton` (⊃ `Icon`) from wrongly
+    // rasterising a non-opaque wrapper's subtree (#2469 follow-up).
+    val ownComponent = source?.ownComponent ?: componentFallback
+    val displayComponent = source?.component ?: componentFallback
     // A Wear `CurvedLayout`/`TimeText` draws text along an arc via a `CurvedTextChild` that no
     // LayoutNode represents; pull those runs (string + baseline arc + font) so the export can
     // reproduce them as an SVG `<textPath>` instead of dropping the clock.
     val curvedTexts =
-      if ((source?.component ?: componentFallback).contains("Curved"))
-        CurvedTextExtractor.extract(this)
-      else emptyList()
+      if (ownComponent.contains("Curved")) CurvedTextExtractor.extract(this) else emptyList()
     val children = children.map { it.toWireNode(rootCoords, sources, density) }
     val modifiers = modifierInfo
     return LayoutInspectorNode(
       nodeId = semanticsId?.toString() ?: identityId,
-      component = source?.component ?: componentFallback,
+      component = ownComponent,
+      displayName = displayComponent.takeIf { it != ownComponent },
       source = source?.source,
       sourceInfo = source?.sourceInfo,
       bounds = coordinates.boundsIn(rootCoords),
@@ -983,7 +988,15 @@ internal object ComposeLayoutInspector {
   }
 
   private data class LayoutSource(
+    /** Friendly display label — the node's own `C(...)` name, or the nearest enclosing one. */
     val component: String,
+    /**
+     * The node's **own** composable identity (its own `C(...)`, or its LayoutNode class when the
+     * group carried source info) — never an inherited name. Null when only an enclosing name was
+     * available, so the caller falls back to the measure-policy class for identity matching exactly
+     * as it did before name inheritance existed.
+     */
+    val ownComponent: String?,
     val source: String?,
     val sourceInfo: String?,
   )
@@ -1006,16 +1019,22 @@ internal object ComposeLayoutInspector {
      * wins for its own subtree; the inherited name only fills the gaps.
      */
     private fun index(group: CompositionGroup, enclosingName: String?) {
-      val currentName = group.sourceInfo?.componentName() ?: enclosingName
+      val sourceInfo = group.sourceInfo
+      // The node's own composable name (its own `C(...)`), or its LayoutNode class when the group
+      // carried source info but no `C(...)` — never inherited. Only a real `C(...)` propagates as
+      // the enclosing name to descendants.
+      val ownName = sourceInfo?.let { it.componentName() ?: group.node?.javaClass?.simpleName }
+      val currentName = sourceInfo?.componentName() ?: enclosingName
       val node = group.node
       if (node != null) {
-        val name = currentName ?: group.sourceInfo?.let { node.javaClass.simpleName }
-        if (name != null) {
+        val display = currentName ?: ownName
+        if (display != null) {
           byNode[node] =
             LayoutSource(
-              component = name,
-              source = group.sourceInfo?.sourceLocation(),
-              sourceInfo = group.sourceInfo,
+              component = display,
+              ownComponent = ownName,
+              source = sourceInfo?.sourceLocation(),
+              sourceInfo = sourceInfo,
             )
         }
       }

--- a/data/layoutinspector/connector/src/test/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProductRegistryTest.kt
+++ b/data/layoutinspector/connector/src/test/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProductRegistryTest.kt
@@ -95,9 +95,9 @@ class ComposeSemanticsDataProductRegistryTest {
     val registry = LayoutInspectorDataProductRegistry(rootDir)
     val cap = registry.capabilities.single()
     assertEquals("layout/inspector", cap.kind)
-    // v2 (#1903): per-node `tokens` added to LayoutInspectorNode.
-    // v3 (#1908 follow-up): `tokens.cornerRadiusPx` added for raw-pixel RoundedCornerShape corners.
-    assertEquals(3, cap.schemaVersion)
+    // Assert against the producer's constant rather than a literal so an additive schema bump
+    // (tokens, cornerRadiusPx, curvedTexts, displayName, …) updates the contract in one place.
+    assertEquals(LayoutInspectorDataProducer.SCHEMA_VERSION, cap.schemaVersion)
     assertTrue(cap.attachable)
     assertTrue(cap.fetchable)
     assertTrue(!cap.requiresRerender)

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/ComposeSemanticsModels.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/ComposeSemanticsModels.kt
@@ -56,7 +56,11 @@ object LayoutInspectorProduct {
   // arc (string + baseline circle + font), captured from the `CurvedTextChild` runtime state a
   // LayoutNode walk can't see, so the figma-svg export reproduces the clock as an SVG `<textPath>`
   // instead of dropping it. Additive — older entries parse with an empty list.
-  const val SCHEMA_VERSION: Int = 4
+  // v5: each node may carry a `displayName` — the nearest enclosing composable name, used as the
+  // figma-svg layer label so an internal `Box`/`Row` reads as the `Button`/`IconButton` that owns
+  // it, while `component` stays the node's own identity for raster/curved matching. Additive —
+  // older entries parse with `displayName = null` and fall back to `component`.
+  const val SCHEMA_VERSION: Int = 5
   const val FILE: String = "layout-inspector.json"
 }
 
@@ -357,7 +361,23 @@ data class ComposeSemanticsInsets(
 @Serializable
 data class LayoutInspectorNode(
   val nodeId: String,
+  /**
+   * The node's **own** identity — its own `C(Composable)` name, or (when it has none) its
+   * measure-policy class. Kept as the node's own identity on purpose: opaque-component raster
+   * matching (`Icon`/`Image`/`TextField`/…) and curved-text detection key off *what the node
+   * actually is*, so an inherited display label (`IconButton` ⊃ `Icon`) can never wrongly rasterise
+   * a non-opaque wrapper's subtree. The friendly, possibly-inherited label lives in [displayName].
+   */
   val component: String,
+  /**
+   * Friendly layer label — the nearest *enclosing* composable name, filled in when this node's own
+   * group carries no `C(Composable)` marker (a library-internal `Box`/`Row` a `Button`/`IconButton`
+   * builds itself from). Used only as the figma-svg `<g>` layer id, so the export reads
+   * `IconButton` instead of an anonymous `Box`. Null when it would just equal [component]. Additive
+   * (v5) — older `layout-inspector.json` decodes with `displayName = null` and falls back to
+   * [component].
+   */
+  val displayName: String? = null,
   val source: String? = null,
   val sourceInfo: String? = null,
   val bounds: LayoutInspectorBounds,

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgModel.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgModel.kt
@@ -773,7 +773,7 @@ data class FigmaSvgModel(
     }
 
     private fun LayoutInspectorNode.layerName(): String =
-      composableName(component).ifBlank { "Layer" }
+      composableName(displayName ?: component).ifBlank { "Layer" }
 
     /**
      * The composable name to show as the SVG layer id. When source-info resolution succeeds

--- a/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvgTest.kt
+++ b/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvgTest.kt
@@ -192,6 +192,77 @@ class FigmaLayeredSvgTest {
   }
 
   @Test
+  fun layerLabelPrefersInheritedDisplayNameOverOwnComponent() {
+    // A node keeps its own identity in `component` (here a measure-policy fallback), but the layer
+    // label reads the friendly inherited `displayName`.
+    val svg =
+      render(
+        LayoutInspectorNode(
+          nodeId = "root",
+          component = "BoxMeasurePolicy",
+          displayName = "Card",
+          bounds = LayoutInspectorBounds(0, 0, 100, 60),
+          size = LayoutInspectorSize(100, 60),
+          tokens = ComposeSemanticsTokens(backgroundColor = "#FF000000"),
+        )
+      )
+    assertTrue(svg, svg.contains("""<g id="Card""""))
+    assertFalse(svg, svg.contains("""id="Box"""))
+  }
+
+  @Test
+  fun inheritedDisplayNameIsNotUsedForOpaqueRasterMatching() {
+    // Regression guard (#2469 follow-up): an IconButton's internal wrapper inherits the label
+    // "IconButton" for display, but its own identity is a plain Box — it must NOT match the "Icon"
+    // raster fragment and rasterise, which would drop the whole editable button subtree into a PNG.
+    // Only the real Icon leaf, whose own `component` is "Icon", rasterises.
+    val model =
+      FigmaSvgModel.from(
+        layout =
+          LayoutInspectorPayload(
+            LayoutInspectorNode(
+              nodeId = "screen",
+              component = "Screen",
+              bounds = LayoutInspectorBounds(0, 0, 200, 100),
+              size = LayoutInspectorSize(200, 100),
+              children =
+                listOf(
+                  LayoutInspectorNode(
+                    nodeId = "iconButton",
+                    component = "BoxMeasurePolicy",
+                    displayName = "IconButton",
+                    bounds = LayoutInspectorBounds(0, 0, 48, 48),
+                    size = LayoutInspectorSize(48, 48),
+                    children =
+                      listOf(
+                        LayoutInspectorNode(
+                          nodeId = "icon",
+                          component = "Icon",
+                          bounds = LayoutInspectorBounds(12, 12, 36, 36),
+                          size = LayoutInspectorSize(24, 24),
+                        ),
+                        LayoutInspectorNode(
+                          nodeId = "ripple",
+                          component = "BoxMeasurePolicy",
+                          displayName = "IconButton",
+                          bounds = LayoutInspectorBounds(0, 0, 48, 48),
+                          size = LayoutInspectorSize(48, 48),
+                          tokens = ComposeSemanticsTokens(backgroundColor = "#22000000"),
+                        ),
+                      ),
+                  )
+                ),
+            )
+          ),
+        rasterComponents = setOf("Icon"),
+      )
+    // Only the real Icon leaf became a raster; the IconButton wrapper stayed editable vector.
+    assertEquals(listOf("icon"), model.rasterTargets.map { it.nodeId })
+    val svg = FigmaLayeredSvg.render(model)
+    assertTrue(svg, svg.contains("""<g id="IconButton""""))
+  }
+
+  @Test
   fun rootSvgRequestsGeometricPrecisionSoTextMatchesTheRender() {
     // The default `text-rendering:auto` grid-fits glyphs to pixel boundaries in the browser, which
     // leaves a constant edge diff against the Skiko render on text-heavy previews. Pin the


### PR DESCRIPTION
## Summary

Follow-up to #2469, fixing a P2 the Codex review caught there.

#2469 taught the producer to inherit the nearest enclosing composable name so an internal `Box`/`Row` reads as the `Button`/`IconButton` that owns it. But that name also flows into `FigmaSvgModel.isOpaque`, which **substring**-matches `component` against raster fragments (`Icon`, `Image`, `TextField`, `Slider`, …). So an `IconButton`'s internal container node inherited `"IconButton"`, matched the `"Icon"` fragment, and — in **hybrid raster exports** (Android/Wear device previews) — got rasterized, **dropping the whole editable button subtree into a PNG**.

The fix **decouples identity from label**:

- `LayoutInspectorNode.component` goes back to the node's **own** identity — its own `C(...)` name, or its measure-policy class — and is what raster + curved-text matching key off. An inherited label can no longer trip the matcher.
- The inherited friendly name moves to a new additive **`displayName`** field, used *only* as the figma-svg `<g>` layer label.

So the layer still reads `IconButton`, but only a real `Icon` leaf (own `component == "Icon"`) rasterizes. Substring matching is preserved for its intended targets (e.g. `OutlinedTextFieldMeasurePolicy` → `TextField`) because those live on the node's own identity.

`layout/inspector` schema bumped **v4 → v5** (additive; older files decode with `displayName = null` and fall back to `component`).

## Test plan

- New `FigmaLayeredSvgTest` cases:
  - `inheritedDisplayNameIsNotUsedForOpaqueRasterMatching` — an `IconButton` wrapper (own `component = "BoxMeasurePolicy"`, `displayName = "IconButton"`) over a real `Icon` leaf, with `rasterComponents = {"Icon"}`: only `icon` becomes a raster target, the wrapper stays an editable `<g id="IconButton">`. This is the regression guard.
  - `layerLabelPrefersInheritedDisplayNameOverOwnComponent` — the `<g>` id uses `displayName` when present.
- `./gradlew :data-layoutinspector-core:test` → **BUILD SUCCESSFUL** (full core suite, incl. the existing raster/zero-bounds and collapse tests).
- `./gradlew :data-layoutinspector-connector:compileKotlin` → **SUCCESSFUL** (producer split of own vs. display name).
- Updated the connector registry test to assert `schemaVersion` against `LayoutInspectorDataProducer.SCHEMA_VERSION` (was a stale literal `3`) so future additive bumps update in one place.

Names-only + structure change — no pixel movement except the intended fix (a wrongly-rasterized subtree in hybrid IconButton exports now renders as editable vector), so the visual-diff bot should be clean elsewhere.

---
_Generated by [Claude Code](https://claude.ai/code/session_016TRQ2T5st7pySwiHjMqyij)_