### PR TITLE
fix(layoutinspector): drop LayoutNode fallback so SVG layers keep their layout identity

### DIFF
--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
@@ -1020,23 +1020,26 @@ internal object ComposeLayoutInspector {
      */
     private fun index(group: CompositionGroup, enclosingName: String?) {
       val sourceInfo = group.sourceInfo
-      // The node's own composable name (its own `C(...)`), or its LayoutNode class when the group
-      // carried source info but no `C(...)` — never inherited. Only a real `C(...)` propagates as
-      // the enclosing name to descendants.
-      val ownName = sourceInfo?.let { it.componentName() ?: group.node?.javaClass?.simpleName }
-      val currentName = sourceInfo?.componentName() ?: enclosingName
+      // The node's own composable name — its own `C(...)`, or null. The raw LayoutNode class
+      // (`LayoutNode`) is deliberately NOT used as a fallback: it names nothing a developer wrote
+      // and is the same string for every node, so leaving `ownComponent` null lets `toWireNode`
+      // fall through to the node's *measure-policy* class instead — a real layout identity
+      // (`Column`, `OutlinedTextFieldMeasurePolicy`, …) that both reads like the code and keeps
+      // opaque-component raster matching working for controls the token export can't vectorise.
+      val ownName = sourceInfo?.componentName()
+      // Display label: own `C(...)`, else the nearest enclosing composable. Only a real `C(...)`
+      // propagates as the enclosing name to descendants — the label tracks the composable the
+      // developer wrote, not Compose's internal layout classes.
+      val currentName = ownName ?: enclosingName
       val node = group.node
-      if (node != null) {
-        val display = currentName ?: ownName
-        if (display != null) {
-          byNode[node] =
-            LayoutSource(
-              component = display,
-              ownComponent = ownName,
-              source = sourceInfo?.sourceLocation(),
-              sourceInfo = sourceInfo,
-            )
-        }
+      if (node != null && currentName != null) {
+        byNode[node] =
+          LayoutSource(
+            component = currentName,
+            ownComponent = ownName,
+            source = sourceInfo?.sourceLocation(),
+            sourceInfo = sourceInfo,
+          )
       }
       group.compositionGroups.forEach { index(it, currentName) }
     }

--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
@@ -988,8 +988,12 @@ internal object ComposeLayoutInspector {
   }
 
   private data class LayoutSource(
-    /** Friendly display label — the node's own `C(...)` name, or the nearest enclosing one. */
-    val component: String,
+    /**
+     * Friendly display label — the node's own `C(...)` name, or the nearest enclosing one. Null
+     * when the group carries source info (a `file:line` link worth keeping) but no name at all; the
+     * caller then falls back to the measure-policy class for the label.
+     */
+    val component: String?,
     /**
      * The node's **own** composable identity (its own `C(...)`, or its LayoutNode class when the
      * group carried source info) — never an inherited name. Null when only an enclosing name was
@@ -1032,7 +1036,11 @@ internal object ComposeLayoutInspector {
       // developer wrote, not Compose's internal layout classes.
       val currentName = ownName ?: enclosingName
       val node = group.node
-      if (node != null && currentName != null) {
+      // Record an entry when there's a name to carry OR source info to preserve. Skipping a
+      // source-info-bearing group would drop its `file:line` source link (the layout-inspector /
+      // source-link UI reads it) even though it has no `C(...)` name — so keep the entry and let
+      // only `component`/`ownComponent` be null.
+      if (node != null && (currentName != null || sourceInfo != null)) {
         byNode[node] =
           LayoutSource(
             component = currentName,

--- a/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvgTest.kt
+++ b/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvgTest.kt
@@ -263,6 +263,39 @@ class FigmaLayeredSvgTest {
   }
 
   @Test
+  fun ownMeasurePolicyIdentityStillRastersUnderAnInheritedLabel() {
+    // Counterpart to the IconButton guard: a control's own identity is its measure-policy class
+    // (OutlinedTextFieldMeasurePolicy) even though its friendly label was inherited from the
+    // enclosing Column. Raster matching keys off `component`, so the control still rasterises — the
+    // token export can't vectorise its imperatively drawn chrome, and an inherited label must not
+    // hide that own identity.
+    val model =
+      FigmaSvgModel.from(
+        layout =
+          LayoutInspectorPayload(
+            LayoutInspectorNode(
+              nodeId = "form",
+              component = "Column",
+              bounds = LayoutInspectorBounds(0, 0, 300, 200),
+              size = LayoutInspectorSize(300, 200),
+              children =
+                listOf(
+                  LayoutInspectorNode(
+                    nodeId = "textField",
+                    component = "OutlinedTextFieldMeasurePolicy",
+                    displayName = "Column",
+                    bounds = LayoutInspectorBounds(0, 0, 300, 56),
+                    size = LayoutInspectorSize(300, 56),
+                  )
+                ),
+            )
+          ),
+        rasterComponents = setOf("TextField"),
+      )
+    assertEquals(listOf("textField"), model.rasterTargets.map { it.nodeId })
+  }
+
+  @Test
   fun rootSvgRequestsGeometricPrecisionSoTextMatchesTheRender() {
     // The default `text-rendering:auto` grid-fits glyphs to pixel boundaries in the browser, which
     // leaves a constant edge diff against the Skiko render on text-heavy previews. Pin the


### PR DESCRIPTION
## Summary

Follow-up to #2470, addressing the Codex P2 there and pushing the layer naming closer to the structure a developer would recognize.

When a layout node's composition group had `sourceInfo` but no `C(Composable)` marker, `LayoutSourceIndex` fell back to the **raw `LayoutNode` class name** as the node's own identity. That's bad twice over:

1. **A developer never wrote `LayoutNode`** — it's a Compose internal, and it's the *same string for every node*, so it reads as noise rather than structure.
2. It became the node's **own identity**, so its real **measure-policy class** (`ColumnMeasurePolicy`, `OutlinedTextFieldMeasurePolicy`, `SliderKt`, …) never surfaced — which in hybrid figma-svg exports **suppressed the intended `DEFAULT_RASTER_COMPONENTS` raster match** for controls the token export can't vectorise (their imperatively-drawn chrome would silently drop).

The fix: leave `ownComponent` **null** when a node has no own `C(...)`, so `toWireNode` falls through to the node's measure-policy class. Now an internal node reads like the code —

- **label** (`displayName`): the composable that encloses it (`Card`, `IconButton`, …), or its layout role (`Column`/`Row`/`Box`) when nothing encloses it;
- **identity** (`component`): its real measure-policy class, which drives raster + curved matching.

`LayoutNode` never appears in an export again.

## Test plan

- New `FigmaLayeredSvgTest` case `ownMeasurePolicyIdentityStillRastersUnderAnInheritedLabel` — a `TextField` whose own `component = "OutlinedTextFieldMeasurePolicy"` but whose `displayName` was inherited as `"Column"` still becomes a raster target under `rasterComponents = {"TextField"}`. This is the direct guard for the Codex scenario: the inherited label must not hide the own measure-policy identity.
- `./gradlew :data-layoutinspector-core:test` → **BUILD SUCCESSFUL** (verified the new case ran, 76 cases in the class; the IconButton raster guard and collapse tests still pass).
- `./gradlew :data-layoutinspector-connector:compileKotlin` → **SUCCESSFUL**.
- `LayoutInspectorFixtureTest` (Robolectric, CI) exercises the real `LayoutSourceIndex` end-to-end and still asserts the root resolves to its measure-policy name.

Producer naming change only — no pixel movement in vector exports; in hybrid exports the sole effect is restoring a control's raster crop that the `LayoutNode` label was suppressing, so the visual-diff bot should be clean or show that restoration.

---
_Generated by [Claude Code](https://claude.ai/code/session_016TRQ2T5st7pySwiHjMqyij)_