### PR TITLE
feat(serve): weight live seats by backend and auto-size the budget from box memory

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -1388,11 +1388,13 @@ class ServeCommand(args: List<String>) : Command(args) {
                           separate checkout (e.g. a prebuilt image serving sample-project that clones
                           the CMP catalog repo for live render). The trust + same-repo + ref-allowlist
                           gates are unchanged.
-        --live-seats <n>  Cap concurrent live (daemon-backed) stream sessions. Each seat holds a JVM
-                          Compose daemon, so on a small box bound this (e.g. 1–2) when the live tier
-                          is on (--allow-render-trusted) — an over-cap stream is refused (WS 1013)
-                          rather than risking the OOM killer. Default 0 = unbounded. Snapshot + Wasm
-                          sessions never take a seat.
+        --live-seats <n>  Live (daemon-backed) stream PERMIT BUDGET. Each live session charges permits
+                          by backend weight — a desktop CMP daemon costs 1, a heavier Robolectric
+                          Android one costs 2 — so one heavy catalog can't hog a flat seat count and
+                          starve the cheap CMP lanes. On a small box bound this (e.g. 2) when the live
+                          tier is on (--allow-render-trusted); an over-budget stream is refused (WS
+                          1013) rather than risking the OOM killer. Default 0 = unbounded. Snapshot +
+                          Wasm sessions never take a permit.
         --exit-when-idle[=<seconds>]
                           Ephemeral mode: shut the server down once it's been idle (no open
                           connections and no requests) for <seconds> (default ${DEFAULT_IDLE_EXIT_SECONDS}s). Use a small

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -1193,6 +1193,13 @@ class ServeCommand(args: List<String>) : Command(args) {
         // URLs and falls back to baked PNGs for ids it can't render.
         previewAliases = alias,
         bakedFallback = bakedFallback,
+        // A source-built Android/Robolectric catalog costs the same heavier live-seat weight as the
+        // bundle path — read from the built daemon descriptor, since there's no bundle
+        // manifest.backend here — so a from-source deployment keeps the OOM protection the
+        // weighting
+        // adds (a --live-seats budget can't admit two Android daemons thinking they're
+        // desktop-cost).
+        liveSeatWeight = ServeBundleDaemon.liveSeatWeightForDescriptor(built.descriptor),
       )
     val host = openHost(state) ?: return false
     registry.register(system, state, host = host)

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/LiveSeatLimiter.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/LiveSeatLimiter.kt
@@ -1,0 +1,64 @@
+package ee.schimke.composeai.cli.serve
+
+import java.util.concurrent.Semaphore
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Bounds concurrent **live** (daemon-backed) stream sessions by a *permit budget* rather than a
+ * flat session count, so a cheap desktop CMP daemon and a heavy Robolectric Android daemon don't
+ * cost the same seat. [totalPermits] is the whole-box budget (memory-derived on the deployed image,
+ * see `deploy/image/entrypoint.sh`); each session acquires permits equal to its backend's
+ * **weight** — `1` for a desktop CMP daemon, more for a heavier Android one ([ServeBundleDaemon]'s
+ * `ANDROID_LIVE_SEAT_WEIGHT]`). A session that can't get its permits is refused (the caller closes
+ * the WebSocket with 1013 "Try Again Later") instead of spawning a daemon that would risk the OOM
+ * killer.
+ *
+ * Why weighting fixes the reported starvation: with a flat cap of 1, a single heavy `wear-m3`
+ * Android daemon holds the only seat and turns away the cheap `compose-m3` CMP daemon even though
+ * the box has memory for it. Under a budget of 2 with Android weight 2, two CMP sessions coexist,
+ * while a lone Android session still runs (its weight is [coerced][acquire] down to the budget so
+ * it never deadlocks against a ceiling smaller than its weight).
+ *
+ * [totalPermits] `<= 0` means **unbounded** — the historical local-`serve` behaviour — and every
+ * [acquire] returns a free ticket. A weight `<= 0` (a static snapshot/Wasm session that spawns no
+ * daemon) is likewise always free.
+ *
+ * Thread-safe: the backing [Semaphore] is fair-agnostic like the old flat gate, and each [Ticket]
+ * releases its permits at most once.
+ */
+class LiveSeatLimiter(val totalPermits: Int) {
+  private val semaphore: Semaphore? = if (totalPermits > 0) Semaphore(totalPermits) else null
+
+  /** True when this limiter imposes no bound (`totalPermits <= 0`). */
+  val unbounded: Boolean
+    get() = semaphore == null
+
+  /**
+   * Try to reserve [weight] permits for a live session. Returns a [Ticket] the caller **must**
+   * [close][Ticket.close] when the session ends (release the permits), or `null` when the budget is
+   * exhausted and the session should be refused.
+   *
+   * A [weight] `<= 0` (static/no-daemon session) and an [unbounded] limiter both return a
+   * zero-permit ticket that always succeeds. A positive [weight] larger than [totalPermits] is
+   * coerced down to [totalPermits], so a backend heavier than the whole budget can still run alone
+   * rather than being permanently refused.
+   */
+  fun acquire(weight: Int): Ticket? {
+    val sem = semaphore ?: return Ticket(0)
+    if (weight <= 0) return Ticket(0)
+    val permits = weight.coerceIn(1, totalPermits)
+    return if (sem.tryAcquire(permits)) Ticket(permits) else null
+  }
+
+  /** Permits currently available — for tests/diagnostics. */
+  fun availablePermits(): Int = semaphore?.availablePermits() ?: Int.MAX_VALUE
+
+  /** A held reservation of [permits] live-seat permits; [close] returns them (idempotent). */
+  inner class Ticket internal constructor(val permits: Int) : AutoCloseable {
+    private val released = AtomicBoolean(false)
+
+    override fun close() {
+      if (permits > 0 && released.compareAndSet(false, true)) semaphore?.release(permits)
+    }
+  }
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt
@@ -48,6 +48,15 @@ import okio.Path.Companion.toPath
 internal object ServeBundleDaemon {
 
   /**
+   * Live-seat cost ([LiveSeatLimiter] permits) of an **Android/Robolectric** catalog daemon. It
+   * boots a sandbox fleet (each `wear-m3` daemon spins ~5 Robolectric sandboxes) and holds ~1.5–2
+   * GB RSS, versus ~0.5–1 GB for a desktop CMP daemon — so it consumes two permits where desktop
+   * takes one. Tuned for the reference 4 GB box's default budget; a bigger box's budget scales up
+   * (see `deploy/image/entrypoint.sh`), letting more of these run at once.
+   */
+  const val ANDROID_LIVE_SEAT_WEIGHT: Int = 2
+
+  /**
    * Extract [bundleFile] into [destDir] and synthesise a working [ServeSessionState] for it, or
    * `null` (logging a clear reason via [onLog]) on any failure — a bad/foreign bundle, an
    * unsupported backend, missing sidecar jars (desktop or android), or an empty preview manifest.
@@ -208,6 +217,10 @@ internal object ServeBundleDaemon {
       // so a published catalog's live lane offers the App theme selector (its daemon applies the
       // themeProvider override on demand). Empty when the app declares none.
       declaredThemes = readDeclaredThemes(previewsJson, fileSystem),
+      // An Android/Robolectric daemon boots a sandbox fleet and is far heavier than a desktop CMP
+      // one, so it costs more of the live-seat budget (see [LiveSeatLimiter]); a desktop bundle
+      // keeps the default weight of 1.
+      liveSeatWeight = if (backend == "android") ANDROID_LIVE_SEAT_WEIGHT else 1,
     )
   }
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt
@@ -57,6 +57,29 @@ internal object ServeBundleDaemon {
   const val ANDROID_LIVE_SEAT_WEIGHT: Int = 2
 
   /**
+   * Live-seat weight ([LiveSeatLimiter] permits) of an already-built daemon [descriptor] file — for
+   * the Gradle **source-build** catalog path ([ServeCommand.buildTrustedCatalogSource]), which has
+   * no bundle `manifest.backend` to read. Detects the Android/Robolectric backend by the
+   * `robolectric.*` JVM sysprops every Android daemon launch carries (see
+   * [AndroidPreviewClasspath]) and a desktop CMP daemon never does, so a source-served Android
+   * catalog is charged [ANDROID_LIVE_SEAT_WEIGHT] exactly like the bundle path — keeping the OOM
+   * protection intact in from-source deployments. Defaults to `1` (desktop) when the descriptor is
+   * missing or unreadable.
+   */
+  fun liveSeatWeightForDescriptor(descriptor: File): Int {
+    val text = descriptor.takeIf { it.isFile }?.let { runCatching { it.readText() }.getOrNull() }
+    val launch =
+      text?.let {
+        runCatching { overridesJson.decodeFromString(DaemonLaunchDescriptor.serializer(), it) }
+          .getOrNull()
+      } ?: return 1
+    val android =
+      launch.systemProperties.keys.any { it.startsWith("robolectric.") } ||
+        launch.jvmArgs.any { it.contains("robolectric.", ignoreCase = true) }
+    return if (android) ANDROID_LIVE_SEAT_WEIGHT else 1
+  }
+
+  /**
    * Extract [bundleFile] into [destDir] and synthesise a working [ServeSessionState] for it, or
    * `null` (logging a clear reason via [onLog]) on any failure — a bad/foreign bundle, an
    * unsupported backend, missing sidecar jars (desktop or android), or an empty preview manifest.

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -102,13 +102,15 @@ class ServeHttpServer(
    */
   maxConcurrentRenders: Int = Runtime.getRuntime().availableProcessors().coerceAtLeast(1),
   /**
-   * Max concurrent **live** (daemon-backed) stream sessions — the "live seats". Each holds a JVM
-   * Compose render session on the box, so a constrained host (e.g. a 4 GB / 2-vCPU VM) can bound
-   * them: a stream that would exceed the cap is refused with WebSocket close 1013 (Try Again Later)
-   * rather than spawning an unbounded daemon and risking the OOM killer. `0` (the default) is
-   * unbounded — the historical behaviour for a local `serve` on a developer box. Static
-   * (snapshot/Wasm) sessions never consume a seat, so the public server's default tiers are
-   * unaffected; this only bites when `--allow-render-trusted` puts a live daemon behind a catalog.
+   * Live-seat **permit budget** for concurrent **live** (daemon-backed) stream sessions. Each live
+   * session charges permits equal to its backend weight ([ServeSessionState.liveSeatWeight]): a
+   * desktop CMP daemon costs 1, a heavier Android/Robolectric one costs more, so one heavy catalog
+   * can't hog a flat seat count and starve several cheap ones. A session that can't get its permits
+   * is refused with WebSocket close 1013 (Try Again Later) rather than spawning a daemon that would
+   * risk the OOM killer. `0` (the default) is unbounded — the historical behaviour for a local
+   * `serve` on a developer box. Static (snapshot/Wasm) sessions never consume a permit, so the
+   * public server's default tiers are unaffected; this only bites when `--allow-render-trusted`
+   * puts a live daemon behind a catalog. See [LiveSeatLimiter].
    */
   maxLiveSeats: Int = 0,
 ) {
@@ -117,8 +119,12 @@ class ServeHttpServer(
 
   private val renderSemaphore = Semaphore(maxConcurrentRenders.coerceAtLeast(1))
 
-  /** Live-seat limiter; null ⇒ unbounded (`maxLiveSeats <= 0`). See [maxLiveSeats]. */
-  private val liveSeats: Semaphore? = if (maxLiveSeats > 0) Semaphore(maxLiveSeats) else null
+  /**
+   * Live-seat limiter: a permit **budget** ([maxLiveSeats]) charged per session by its backend
+   * weight, so a heavy Android daemon costs more of the box than a cheap desktop CMP one. `<= 0` ⇒
+   * unbounded. See [maxLiveSeats] and [LiveSeatLimiter].
+   */
+  private val liveSeats: LiveSeatLimiter = LiveSeatLimiter(maxLiveSeats)
 
   private val server: EmbeddedServer<*, *> =
     embeddedServer(CIO, host = host, port = port) {
@@ -810,15 +816,19 @@ class ServeHttpServer(
     }
     val sessionId =
       call.parameters["system"] ?: call.request.queryParameters["session"] ?: defaultSessionId
-    // Reserve a live seat BEFORE opening the session: leasing resumes a suspended/forked host,
-    // which
-    // spawns the JVM render daemon, so a post-lease check would let an over-cap burst spawn the
-    // very
-    // daemons this cap bounds. A known-static (pinned bundle/catalog) session never takes a seat;
-    // an
-    // as-yet-unregistered one (lazily forked, e.g. --revisions) counts as daemon-backed.
-    val seats = if (liveSeats != null && !sessions.isKnownStatic(sessionId)) liveSeats else null
-    if (seats != null && !seats.tryAcquire()) {
+    // Reserve live-seat permits BEFORE opening the session: leasing resumes a suspended/forked
+    // host,
+    // which spawns the JVM render daemon, so a post-lease check would let an over-budget burst
+    // spawn
+    // the very daemons this budget bounds. A known-static (pinned bundle/catalog) session takes no
+    // permit (weight 0); a daemon-backed one charges its backend weight (desktop 1, Android
+    // heavier),
+    // read from the session state without opening the daemon. A lazily-forked session (e.g.
+    // --revisions), unregistered until its build runs, defaults to weight 1 — a desktop-cost
+    // daemon.
+    val weight = if (sessions.isKnownStatic(sessionId)) 0 else sessions.liveSeatWeight(sessionId)
+    val seatTicket = liveSeats.acquire(weight)
+    if (seatTicket == null) {
       close(CloseReason(1013.toShort(), "live preview at capacity — try again shortly"))
       return
     }
@@ -896,7 +906,7 @@ class ServeHttpServer(
         lease.close()
       }
     } finally {
-      seats?.release()
+      seatTicket.close()
     }
   }
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistry.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistry.kt
@@ -186,6 +186,17 @@ class ServeSessionRegistry(
   }
 
   /**
+   * Live-seat cost of [sessionId]'s daemon in [LiveSeatLimiter] permits — its session state's
+   * [ServeSessionState.liveSeatWeight], or `1` for an unknown / lazily-forked session (whose
+   * on-demand build hasn't run yet, so it's treated as a default desktop-weight daemon). Read
+   * before leasing so the seat gate can charge a heavy Android catalog more than a cheap desktop
+   * one without opening the daemon.
+   */
+  fun liveSeatWeight(sessionId: String): Int = lock.withLock {
+    sessions[sessionId]?.state?.liveSeatWeight ?: 1
+  }
+
+  /**
    * Milliseconds the *whole server* has been idle, or `null` when it's busy (any session has an
    * open lease — e.g. a live WebSocket). Idle counts from the last acquire/lease/release; with no
    * leases and no requests it grows unbounded. Drives the ephemeral "exit when idle" watchdog.

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionState.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionState.kt
@@ -65,4 +65,13 @@ data class ServeSessionState(
    * idempotent — the registry runs it under `runCatching`.
    */
   val reclaim: (() -> Unit)? = null,
+  /**
+   * Cost of this session's live daemon in **live-seat permits** ([LiveSeatLimiter]). Defaults to
+   * `1` (a desktop CMP daemon, and every plain project / revision session). A trusted-catalog live
+   * session sets it higher for a heavier backend — an Android/Robolectric daemon costs
+   * [ServeBundleDaemon.ANDROID_LIVE_SEAT_WEIGHT] — so one heavy catalog can't starve several cheap
+   * ones out of a flat seat count. Only consulted when [ServeHttpServer] enforces a live-seat
+   * budget (`--live-seats`); ignored for static (snapshot/Wasm) sessions, which take no seat.
+   */
+  val liveSeatWeight: Int = 1,
 )

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/LiveSeatLimiterTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/LiveSeatLimiterTest.kt
@@ -1,0 +1,108 @@
+package ee.schimke.composeai.cli.serve
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for the live-seat permit budget ([LiveSeatLimiter]) — the gate that lets a heavy
+ * Android daemon cost more of the box than a cheap desktop CMP one, replacing the flat seat count
+ * that let one heavy catalog starve the rest.
+ */
+class LiveSeatLimiterTest {
+
+  @Test
+  fun `zero budget is unbounded — every acquire is a free ticket`() {
+    val limiter = LiveSeatLimiter(0)
+    assertTrue(limiter.unbounded)
+    // Even an absurd weight succeeds and holds no permits.
+    val ticket = limiter.acquire(999)
+    assertNotNull(ticket)
+    assertEquals(0, ticket.permits)
+    assertEquals(Int.MAX_VALUE, limiter.availablePermits())
+    ticket.close()
+  }
+
+  @Test
+  fun `a static (zero-weight) session takes no permit`() {
+    val limiter = LiveSeatLimiter(2)
+    val ticket = limiter.acquire(0)
+    assertNotNull(ticket)
+    assertEquals(0, ticket.permits)
+    // Budget untouched — two daemon-backed sessions can still run alongside it.
+    assertEquals(2, limiter.availablePermits())
+  }
+
+  @Test
+  fun `desktop-weight sessions fill the budget then the next is refused`() {
+    val limiter = LiveSeatLimiter(2)
+    val a = limiter.acquire(1)
+    val b = limiter.acquire(1)
+    assertNotNull(a)
+    assertNotNull(b)
+    assertEquals(0, limiter.availablePermits())
+    // Third desktop session over budget → refused (caller closes WS 1013).
+    assertNull(limiter.acquire(1))
+    // Freeing one reopens a seat.
+    a!!.close()
+    assertEquals(1, limiter.availablePermits())
+    val c = limiter.acquire(1)
+    assertNotNull(c)
+  }
+
+  @Test
+  fun `an Android session costs its heavier weight and blocks a concurrent desktop one`() {
+    val limiter = LiveSeatLimiter(2)
+    // Weight 2 (Android) consumes the whole budget of 2.
+    val android = limiter.acquire(ServeBundleDaemon.ANDROID_LIVE_SEAT_WEIGHT)
+    assertNotNull(android)
+    assertEquals(2, android!!.permits)
+    assertEquals(0, limiter.availablePermits())
+    // A cheap desktop session can't squeeze in while the heavy one holds both permits.
+    assertNull(limiter.acquire(1))
+    // Once the Android daemon releases, the desktop session gets a seat.
+    android.close()
+    assertEquals(2, limiter.availablePermits())
+    assertNotNull(limiter.acquire(1))
+  }
+
+  @Test
+  fun `a weight heavier than the whole budget is coerced so it can still run alone`() {
+    // Budget 1, Android weight 2: without coercion the Android catalog would be permanently refused
+    // (its weight exceeds the ceiling). Coerce to the budget so it runs solo instead of
+    // deadlocking.
+    val limiter = LiveSeatLimiter(1)
+    val android = limiter.acquire(ServeBundleDaemon.ANDROID_LIVE_SEAT_WEIGHT)
+    assertNotNull(android)
+    assertEquals(1, android!!.permits)
+    assertEquals(0, limiter.availablePermits())
+    // …but it does hold the whole box: nothing else runs concurrently.
+    assertNull(limiter.acquire(1))
+    android.close()
+    assertEquals(1, limiter.availablePermits())
+  }
+
+  @Test
+  fun `releasing a ticket is idempotent — a double close returns permits only once`() {
+    val limiter = LiveSeatLimiter(2)
+    val a = limiter.acquire(1)
+    assertNotNull(a)
+    a!!.close()
+    a.close() // second close is a no-op
+    assertEquals(2, limiter.availablePermits())
+    // Sanity: the budget didn't inflate past its total.
+    assertNotNull(limiter.acquire(1))
+    assertNotNull(limiter.acquire(1))
+    assertNull(limiter.acquire(1))
+  }
+
+  @Test
+  fun `a bounded limiter reports itself bounded`() {
+    assertFalse(LiveSeatLimiter(2).unbounded)
+    assertTrue(LiveSeatLimiter(0).unbounded)
+    assertTrue(LiveSeatLimiter(-3).unbounded)
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemonWeightTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemonWeightTest.kt
@@ -1,0 +1,87 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.mcp.DaemonLaunchDescriptor
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.serialization.json.Json
+
+/**
+ * Guards [ServeBundleDaemon.liveSeatWeightForDescriptor] — the backend-weight detector for the
+ * Gradle **source-build** catalog path, which has no bundle `manifest.backend` to read and instead
+ * sniffs the built daemon descriptor's `robolectric.*` sysprops. Without this, a source-served
+ * Android catalog would be charged as a cheap desktop daemon and undercut the live-seat budget's
+ * OOM protection.
+ */
+class ServeBundleDaemonWeightTest {
+
+  private val json = Json { encodeDefaults = true }
+
+  private fun descriptorFile(
+    systemProperties: Map<String, String>,
+    jvmArgs: List<String> = emptyList(),
+  ): File {
+    val descriptor =
+      DaemonLaunchDescriptor(
+        schemaVersion = 2,
+        modulePath = ":catalog",
+        variant = "debug",
+        enabled = true,
+        mainClass = "ee.schimke.composeai.daemon.DaemonMain",
+        classpath = listOf("app.jar"),
+        jvmArgs = jvmArgs,
+        systemProperties = systemProperties,
+        workingDirectory = ".",
+        manifestPath = "previews.json",
+      )
+    return File.createTempFile("daemon-launch", ".json").apply {
+      deleteOnExit()
+      writeText(json.encodeToString(DaemonLaunchDescriptor.serializer(), descriptor))
+    }
+  }
+
+  @Test
+  fun `an Android descriptor (robolectric sysprops) is charged the Android weight`() {
+    val file =
+      descriptorFile(
+        systemProperties =
+          mapOf("robolectric.graphicsMode" to "NATIVE", "robolectric.looperMode" to "PAUSED")
+      )
+    assertEquals(
+      ServeBundleDaemon.ANDROID_LIVE_SEAT_WEIGHT,
+      ServeBundleDaemon.liveSeatWeightForDescriptor(file),
+    )
+  }
+
+  @Test
+  fun `robolectric flags carried as jvm args are also detected`() {
+    val file =
+      descriptorFile(
+        systemProperties = emptyMap(),
+        jvmArgs =
+          listOf("-Drobolectric.graphicsMode=NATIVE", "--add-opens=java.base/java.lang=ALL-UNNAMED"),
+      )
+    assertEquals(
+      ServeBundleDaemon.ANDROID_LIVE_SEAT_WEIGHT,
+      ServeBundleDaemon.liveSeatWeightForDescriptor(file),
+    )
+  }
+
+  @Test
+  fun `a desktop descriptor (no robolectric) keeps weight 1`() {
+    val file =
+      descriptorFile(
+        systemProperties = mapOf("composeai.daemon.userClassDirs" to "classes"),
+        jvmArgs = listOf("--enable-native-access=ALL-UNNAMED"),
+      )
+    assertEquals(1, ServeBundleDaemon.liveSeatWeightForDescriptor(file))
+  }
+
+  @Test
+  fun `a missing or unreadable descriptor defaults to weight 1`() {
+    assertEquals(
+      1,
+      ServeBundleDaemon.liveSeatWeightForDescriptor(File("/no/such/daemon-launch.json")),
+    )
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistryTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistryTest.kt
@@ -127,6 +127,18 @@ class ServeSessionRegistryTest {
       }
   }
 
+  @Test
+  fun `liveSeatWeight surfaces the session state's weight, defaulting to 1`() {
+    ServeSessionRegistry(open = Opener()).use { reg ->
+      val heavy = stateFor("wear-m3").copy(liveSeatWeight = 2)
+      reg.register("wear-m3", heavy)
+      reg.register("compose-m3", stateFor("compose-m3")) // default weight
+      assertEquals(2, reg.liveSeatWeight("wear-m3"), "the Android session's heavier weight is read")
+      assertEquals(1, reg.liveSeatWeight("compose-m3"), "a default-weight session reads 1")
+      assertEquals(1, reg.liveSeatWeight("unknown"), "an unknown/forked session defaults to 1")
+    }
+  }
+
   /** Minimal [ServeHost] that only records whether it was closed. */
   private class RecordingHost : ServeHost {
     var closed = false

--- a/deploy/image/entrypoint.sh
+++ b/deploy/image/entrypoint.sh
@@ -78,11 +78,51 @@ if [[ "${SERVE_ALLOW_RENDER_TRUSTED}" == "1" || "${SERVE_ALLOW_RENDER_TRUSTED}" 
     args+=(--catalog-source-root "${src_root}")
   fi
 fi
-# Bound concurrent live (daemon-backed) stream seats — each seat holds a JVM Compose daemon, so with
-# the live tier on by default we default the cap to 1 for the reference 4 GB / 2 vCPU box
-# (preview.coo.ee): an over-cap viewer is refused (WS 1013) rather than OOM-ing the box. Raise it on
-# a beefier box (SERVE_LIVE_SEATS=4), or set 0 for unbounded.
-: "${SERVE_LIVE_SEATS:=1}"
+# Bound concurrent live (daemon-backed) stream sessions by a PERMIT BUDGET — each live session
+# charges permits by backend weight (a desktop CMP daemon = 1, a heavier Robolectric Android one = 2,
+# see LiveSeatLimiter), so one heavy catalog can't hog a flat seat count and starve the cheap CMP
+# lanes. An over-budget viewer is refused (WS 1013) rather than OOM-ing the box.
+#
+# When SERVE_LIVE_SEATS is unset we AUTO-DERIVE the budget from the container's memory limit so a
+# bigger box scales up on its own (no compose edit, no rebuild): reserve ~1 GB for the serve host +
+# OS, budget ~1.2 GB of headroom per permit, and clamp to [2, 8]. The floor of 2 means even the
+# reference 4 GB box always runs at least two cheap CMP sessions concurrently (4 GB → 2; 8 GB → 5).
+# Set SERVE_LIVE_SEATS explicitly to override, or 0 for unbounded.
+if [[ -z "${SERVE_LIVE_SEATS:-}" ]]; then
+  # Detect the cgroup memory limit (v2 then v1), capped by physical RAM so an "unlimited" sentinel
+  # (a huge number or the literal "max") falls back to the real total instead of overshooting.
+  mem_total_mb=0
+  if [[ -r /proc/meminfo ]]; then
+    mem_total_mb=$(awk '/^MemTotal:/ {printf "%d", $2/1024}' /proc/meminfo 2>/dev/null || echo 0)
+  fi
+  limit_bytes=""
+  if [[ -r /sys/fs/cgroup/memory.max ]]; then
+    limit_bytes=$(cat /sys/fs/cgroup/memory.max 2>/dev/null)          # cgroup v2
+  elif [[ -r /sys/fs/cgroup/memory/memory.limit_in_bytes ]]; then
+    limit_bytes=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes 2>/dev/null)  # cgroup v1
+  fi
+  mem_limit_mb=0
+  if [[ "${limit_bytes}" =~ ^[0-9]+$ ]]; then
+    mem_limit_mb=$(( limit_bytes / 1024 / 1024 ))
+  fi
+  # Effective memory = the tighter of the cgroup limit and physical RAM (0 = unknown → ignore).
+  eff_mb=0
+  if (( mem_limit_mb > 0 && mem_total_mb > 0 )); then
+    eff_mb=$(( mem_limit_mb < mem_total_mb ? mem_limit_mb : mem_total_mb ))
+  elif (( mem_limit_mb > 0 )); then
+    eff_mb=${mem_limit_mb}
+  else
+    eff_mb=${mem_total_mb}
+  fi
+  seats=2
+  if (( eff_mb > 0 )); then
+    seats=$(( (eff_mb - 1024) / 1200 ))
+    (( seats < 2 )) && seats=2
+    (( seats > 8 )) && seats=8
+  fi
+  SERVE_LIVE_SEATS="${seats}"
+  echo "entrypoint: auto live-seat budget ${SERVE_LIVE_SEATS} (effective mem ${eff_mb} MB)" >&2
+fi
 [[ -n "${SERVE_LIVE_SEATS}" ]] && args+=(--live-seats "${SERVE_LIVE_SEATS}")
 if [[ "${SERVE_ACCEPT_BUNDLES:-}" == "1" || "${SERVE_ACCEPT_BUNDLES:-}" == "true" ]]; then
   args+=(--accept-bundles)

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -218,20 +218,28 @@ There are two ways to stand that daemon up, both fail-closed on the `Trusted` ve
 
 Because path (1) is cheap and safe, both public profiles turn it **on by default**: `deploy/vps`
 (from source) and the prebuilt `deploy/image` (`preview.coo.ee`) both default
-`SERVE_ALLOW_RENDER_TRUSTED=1` + `SERVE_LIVE_SEATS=1` — a bare image pull "just works" with live CMP,
-no clone and no build. Set `SERVE_ALLOW_RENDER_TRUSTED=0` to opt out (the Wasm tier still carries
-CMP). The other published catalogs (`wear-m3`, `remote-m3`) are **Android** — no desktop-runnable
-bundle — so they fall back to baked PNG (fail-closed): no error, just no daemon tier for them.
+`SERVE_ALLOW_RENDER_TRUSTED=1` and auto-size the live-seat budget from the box's memory — a bare
+image pull "just works" with live CMP, no clone and no build. Set `SERVE_ALLOW_RENDER_TRUSTED=0` to
+opt out (the Wasm tier still carries CMP). The other published catalogs (`wear-m3`, `remote-m3`) are
+**Android** — no desktop-runnable bundle — so their live lane runs a heavier Robolectric daemon (and
+those that carry no runnable bundle fall back to baked PNG, fail-closed: no error, just no daemon
+tier).
 
 ### Bounding the live tier — `--live-seats` / `SERVE_LIVE_SEATS`
 
 Each live (daemon-backed) stream holds a JVM Compose render session, so on a constrained box a burst
-of viewers could exhaust memory. `--live-seats <n>` (env `SERVE_LIVE_SEATS`) caps concurrent live
-streams: a stream that would exceed the cap is refused with WebSocket close `1013` (*Try Again
-Later*) instead of spawning an unbounded daemon and risking the OOM killer. `0` (the default) is
-unbounded; snapshot + Wasm sessions never consume a seat. On a small box (e.g. a 4 GB / 2 vCPU VM),
-keep it to **1–2** when you turn the live tier on — it's just another env var, so flip it with a
-compose redeploy (`SERVE_LIVE_SEATS=1` in `.env`, then `docker compose up -d`).
+of viewers could exhaust memory. `--live-seats <n>` (env `SERVE_LIVE_SEATS`) is a **permit budget**,
+not a flat count: each live session charges permits by backend weight — a desktop CMP daemon costs
+**1**, a heavier Robolectric **Android** daemon costs **2** — so one heavy `wear-m3` catalog can't
+hog a single seat and starve the cheap `compose-m3` CMP lanes. A session that can't get its permits
+is refused with WebSocket close `1013` (*Try Again Later*) instead of spawning a daemon that risks
+the OOM killer; `0` is unbounded, and snapshot + Wasm sessions never consume a permit.
+
+**Auto-sizing.** When `SERVE_LIVE_SEATS` is unset, the prebuilt image derives the budget from the
+container's memory limit (reserve ~1 GB for the host + OS, ~1.2 GB per permit, clamped to **[2, 8]**),
+so a bigger box scales up on its own with no compose edit: a 4 GB box gets **2** permits (two
+concurrent CMP sessions, or one Android), an 8 GB box gets **5**. Set `SERVE_LIVE_SEATS` explicitly
+in `.env` (then `docker compose up -d`) to override, or `0` for unbounded.
 
 ## Endpoints
 


### PR DESCRIPTION
## Summary

The live-preview lane on `preview.coo.ee` kept refusing **compose-m3** (a cheap desktop CMP daemon) with `WS 1013 — at capacity`, even though the box had memory to spare. Root cause: `--live-seats` was a single flat `Semaphore` shared **server-wide across every catalog**, so one heavy Robolectric **Android** daemon (a `wear-m3` daemon boots ~5 sandboxes, ~1.5–2 GB) held the only seat and starved the ~0.5–1 GB desktop lanes. It IS using CMP — it just couldn't get the one global seat.

This makes the seat cap a **permit budget charged by backend weight**, and auto-sizes that budget from the box's memory.

### Backend-weighted seats (`LiveSeatLimiter`)
- Each live session charges permits equal to its backend weight, read from `ServeSessionState.liveSeatWeight` **before leasing** (no daemon opened to price it):
  - desktop CMP daemon → **1**
  - Android/Robolectric daemon → **2** (`ServeBundleDaemon.ANDROID_LIVE_SEAT_WEIGHT`)
- A weight larger than the whole budget is **coerced down** so a heavy catalog can still run alone instead of deadlocking against a ceiling below its weight.
- Static snapshot/Wasm sessions stay free (weight 0). Over-budget sessions are refused with `WS 1013`, same as before.
- `--live-seats 0` is still unbounded.

### Memory-aware auto-default (auto-deployed image)
- When `SERVE_LIVE_SEATS` is unset, `deploy/image/entrypoint.sh` derives the budget from the container's cgroup memory limit (capped by physical RAM to ignore the "unlimited" sentinel): reserve ~1 GB for the host + OS, ~1.2 GB per permit, clamp to **[2, 8]**.
  - 4 GB box → **2** (two concurrent CMP sessions, or one Android)
  - 8 GB box → **5**
- Floor of **2** guarantees the reference box never regresses to a single seat. Set `SERVE_LIVE_SEATS` explicitly (or `0`) to override.

### Behaviour compatibility
Desktop-only setups are unchanged — weight 1 == the old flat count. Only Android sessions now cost more, matching their real footprint.

## Test plan
- `./gradlew :cli:compileKotlin :cli:test --tests "…LiveSeatLimiterTest" --tests "…ServeSessionRegistryTest"` → **BUILD SUCCESSFUL**.
- New `LiveSeatLimiterTest`: unbounded/free tickets, static-zero-weight, budget-fill-then-refuse, Android weight blocks a concurrent desktop, heavier-than-budget coercion runs solo, idempotent double-close, bounded/unbounded reporting.
- New `ServeSessionRegistryTest` case: `liveSeatWeight` surfaces the state's weight and defaults unknown/forked sessions to 1.
- `deploy/image/entrypoint.sh`: `bash -n` clean; the budget formula + cgroup detection dry-run verified across 2/4/6/8/12/16/32 GB (2, 2, 4, 5, 8, 8, 8), and the "unlimited" cgroup sentinel correctly falls back to physical RAM.
- `./gradlew :cli:ktfmtFormatMain :cli:ktfmtFormatTest` applied.

Non-visual change (concurrency/deploy plumbing), so no render evidence.

_Generated by [Claude Code]_

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jxz9i4SuuxPRt3knZKAPbb)_