### PR TITLE
feat(samples): remote-m3 ↔ wear-m3 catalog parity + cross-system compare page

### DIFF
--- a/samples/design-catalog-remote-m3/catalog.spec.json
+++ b/samples/design-catalog-remote-m3/catalog.spec.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "Phase-0 catalog spec for Remote Compose (Wear Compose Remote Material 3 + remote-creation-compose primitives). Code-led: each sticker is a real RemoteDocument built by RemotePreview and rasterised by the Remote Compose player, so the render is authoritative. Remote Compose carries explicit colours in the document rather than a light/dark theme split, so there is a single primary mode. Consumed by @design-parity/catalog-export to populate ComponentSource group/caption/reference. Sibling of samples/design-catalog-{m3,wear-m3}; see docs/design/DESIGN_CATALOGS.md.",
+  "$comment": "Catalog spec for Remote Compose (Wear Compose Remote Material 3 + remote-creation-compose primitives). Code-led: each sticker is a real RemoteDocument built by RemotePreview and rasterised by the Remote Compose player, so the render is authoritative. Remote Compose carries explicit colours in the document rather than a light/dark theme split, so there is a single primary mode. The component set mirrors the androidx.wear.compose.remote.material3 surface (the port of Wear Compose Material 3 to Remote Compose), minus the two non-component helpers RemoteContainerPainter (a painter factory) and RemoteTypographyTokens (the raw token table behind RemoteTypography). Each component carries a `parallel` field naming its Wear Compose Material 3 counterpart (a componentId in samples/design-catalog-wear-m3); the design-artifacts cross-system compare page pairs them side by side. Sibling of samples/design-catalog-{m3,wear-m3}; see docs/design/DESIGN_CATALOGS.md.",
   "system": "remote-m3",
   "title": "Remote Compose Material 3",
   "library": [
@@ -9,31 +9,60 @@
   "module": "samples:design-catalog-remote-m3",
   "modes": ["light"],
   "referenceKits": [],
+  "compareWith": "wear-m3",
   "groups": [
     {
       "name": "Buttons",
       "components": [
-        { "componentId": "Button/Filled", "preview": "FilledRemoteButton", "caption": "Remote Material 3 button — the primary action." },
-        { "componentId": "Button/Bordered", "preview": "BorderedRemoteButton", "caption": "Button with an explicit remote border + border colour." },
-        { "componentId": "Button/CustomShape", "preview": "CustomShapeRemoteButton", "caption": "Button with a RemoteRoundedCornerShape override." }
+        { "componentId": "Button/Filled", "preview": "FilledRemoteButton", "parallel": "Button/Filled", "caption": "Remote Material 3 filled button — the primary action." },
+        { "componentId": "Button/Outlined", "preview": "OutlinedRemoteButton", "parallel": "Button/Outlined", "caption": "Remote Material 3 outlined-emphasis button (RemoteButton with an explicit border + border colour)." },
+        { "componentId": "Button/Text", "preview": "TextRemoteButton", "parallel": "Button/Child", "caption": "Low-emphasis round text button (RemoteTextButton)." },
+        { "componentId": "Button/Icon", "preview": "IconRemoteButton", "parallel": "IconButton", "caption": "Round icon button (RemoteIconButton) carrying a single RemoteIcon." },
+        { "componentId": "Button/Compact", "preview": "CompactRemoteButton", "parallel": "CompactButton", "caption": "Compact single-line button (RemoteCompactButton)." },
+        { "componentId": "Button/Group", "preview": "ButtonGroupRemote", "parallel": "ButtonGroup", "caption": "Two buttons laid out edge-to-edge by RemoteButtonGroup." },
+        { "componentId": "Button/CustomShape", "preview": "CustomShapeRemoteButton", "parallel": "Button/Filled", "caption": "Filled button with a RemoteRoundedCornerShape override." },
+        { "componentId": "Button/NamedLabel", "preview": "NamedLabelRemoteButton", "parallel": "Button/Filled", "caption": "Filled button whose label is bound to a Remote Compose named value — the connector flips it live (default render shows \"Tap me\")." }
+      ]
+    },
+    {
+      "name": "Containment",
+      "components": [
+        { "componentId": "Card", "preview": "CardRemote", "parallel": "Card", "caption": "Remote Material 3 card." },
+        { "componentId": "Card/Outlined", "preview": "OutlinedCardRemote", "parallel": "Card", "caption": "Outlined card variant (RemoteOutlinedCard)." },
+        { "componentId": "TitleCard", "preview": "TitleCardRemote", "parallel": "TitleCard", "caption": "Card with title, subtitle and supporting text slots." },
+        { "componentId": "AppCard", "preview": "AppCardRemote", "parallel": "AppCard", "caption": "App card with app name, icon, time and content slots." }
+      ]
+    },
+    {
+      "name": "Communication",
+      "components": [
+        { "componentId": "Progress/Circular", "preview": "CircularProgressRemote", "parallel": "Progress/Circular", "caption": "Determinate circular progress indicator at a fixed 66%." }
+      ]
+    },
+    {
+      "name": "Iconography",
+      "components": [
+        { "componentId": "Icon", "preview": "IconRemote", "parallel": "Icon", "caption": "The standalone RemoteIcon primitive." }
       ]
     },
     {
       "name": "Text",
       "components": [
-        { "componentId": "Text/Body", "preview": "RemoteTextSticker", "caption": "The Remote Material 3 text primitive on its own." }
+        { "componentId": "Text/Body", "preview": "RemoteTextSticker", "parallel": "Text/MaxLines-Truncated", "caption": "The Remote Material 3 text primitive on its own." },
+        { "componentId": "Text/MaxLines-Truncated", "preview": "TruncatedTextRemote", "parallel": "Text/MaxLines-Truncated", "caption": "maxLines=2 + ellipsis on a narrow column." }
       ]
     },
     {
-      "name": "Interactive",
+      "name": "Theme",
       "components": [
-        { "componentId": "Button/NamedLabel", "preview": "NamedLabelRemoteButton", "caption": "Label bound to a Remote Compose named value — the connector flips it live (default render shows \"Tap me\")." }
+        { "componentId": "Theme/Typography", "preview": "TypographyRemote", "parallel": "Typography", "caption": "A type ramp read from RemoteMaterialTheme.typography." },
+        { "componentId": "Theme/ColorScheme", "preview": "ColorSchemeRemote", "parallel": "ColorScheme", "caption": "Colour-scheme swatches read from RemoteMaterialTheme.colorScheme." }
       ]
     },
     {
       "name": "Shaders",
       "components": [
-        { "componentId": "Shader/LinearGradient", "preview": "ShaderGradientSticker", "caption": "Document-level gradient shader fill; the middle stop is a named value the connector can recolour live." }
+        { "componentId": "Shader/LinearGradient", "preview": "ShaderGradientSticker", "caption": "Document-level gradient shader fill; the middle stop is a named value the connector can recolour live. A remote-creation-compose primitive with no Wear Material 3 component peer." }
       ]
     }
   ]

--- a/samples/design-catalog-remote-m3/src/main/kotlin/com/example/designcatalogremotem3/CatalogPreviews.kt
+++ b/samples/design-catalog-remote-m3/src/main/kotlin/com/example/designcatalogremotem3/CatalogPreviews.kt
@@ -69,11 +69,12 @@ import androidx.wear.compose.remote.material3.buttonSizeModifier
 // payload and a remote-float handler id.
 private val testAction = hostAction("catalogAction".rs, 1.rf)
 
-// A near-black content colour for stickers drawn straight onto the sticker's white
-// `showBackground` (rather than inside a coloured button/card surface, which
-// carries its own contrasting content colour). `RemoteText` / `RemoteIcon` default
-// to a near-white content colour that would be invisible on white.
-private val onLight = RemoteColor(Color(0xFF1D1B20))
+// A neutral outline colour for the bordered (outlined-emphasis) button. The
+// stickers render on a transparent background (like the Wear catalog), so
+// standalone text/icons keep the theme's default (light) content colour rather
+// than an explicit dark one — matching how the Wear stickers read on the same
+// transparent checkerboard.
+private val outline = RemoteColor(Color(0xFF8A8A8E))
 
 // A simple five-point star used by the icon stickers. Remote Compose has no bundled
 // icon set and `RemoteIcon` takes an `ImageVector`, so the catalog carries one
@@ -130,7 +131,7 @@ fun OutlinedRemoteButton() = RemoteSticker {
     onClick = testAction,
     modifier = RemoteModifier.buttonSizeModifier(),
     border = 2.rdp,
-    borderColor = onLight,
+    borderColor = outline,
     content = { RemoteText("Outlined".rs) },
   )
 }
@@ -169,7 +170,7 @@ fun NamedLabelRemoteButton() = RemoteSticker {
 @CatalogRemoteModes
 @Composable
 fun TextRemoteButton() = RemoteSticker {
-  RemoteTextButton(onClick = testAction, content = { RemoteText("OK".rs) })
+  RemoteTextButton(onClick = testAction, content = { RemoteText("Child".rs) })
 }
 
 // A round icon button (`RemoteIconButton`) carrying a single `RemoteIcon`. Inside the
@@ -225,9 +226,8 @@ fun OutlinedCardRemote() = RemoteSticker {
 fun TitleCardRemote() = RemoteSticker {
   RemoteTitleCard(
     onClick = testAction,
-    title = { RemoteText("Title".rs) },
-    subtitle = { RemoteText("Subtitle".rs) },
-    content = { RemoteText("Supporting text".rs) },
+    title = { RemoteText("Morning run".rs) },
+    subtitle = { RemoteText("5.2 km · 28 min".rs) },
   )
 }
 
@@ -237,10 +237,9 @@ fun AppCardRemote() = RemoteSticker {
   RemoteAppCard(
     onClick = testAction,
     appName = { RemoteText("App".rs) },
-    title = { RemoteText("Title".rs) },
+    title = { RemoteText("Morning run".rs) },
     appImage = { RemoteIcon(starIcon, null, modifier = RemoteModifier.size(16.rdp)) },
-    time = { RemoteText("now".rs) },
-    content = { RemoteText("Content".rs) },
+    content = { RemoteText("5.2 km · 28 min".rs) },
   )
 }
 
@@ -264,7 +263,7 @@ fun CircularProgressRemote() = RemoteSticker {
 @CatalogRemoteModes
 @Composable
 fun IconRemote() = RemoteSticker {
-  RemoteIcon(starIcon, "Star".rs, modifier = RemoteModifier.size(48.rdp), tint = onLight)
+  RemoteIcon(starIcon, "Star".rs, modifier = RemoteModifier.size(48.rdp))
 }
 
 // ---------------------------------------------------------------------------
@@ -275,7 +274,7 @@ fun IconRemote() = RemoteSticker {
 
 @CatalogRemoteModes
 @Composable
-fun RemoteTextSticker() = RemoteSticker { RemoteText("Remote".rs, color = onLight) }
+fun RemoteTextSticker() = RemoteSticker { RemoteText("Remote".rs) }
 
 // The text primitive exercising the maxLines / overflow product on a narrow column —
 // the Remote parallel of Wear M3's `Text/MaxLines-Truncated`. `RemoteText` carries the
@@ -288,7 +287,6 @@ fun TruncatedTextRemote() = RemoteSticker {
     modifier = RemoteModifier.width(150.rdp),
     maxLines = 2,
     overflow = TextOverflow.Ellipsis,
-    color = onLight,
   )
 }
 
@@ -308,13 +306,9 @@ fun TruncatedTextRemote() = RemoteSticker {
 @Composable
 fun TypographyRemote() = RemoteSticker {
   RemoteColumn {
-    RemoteText("Body Large".rs, style = RemoteMaterialTheme.typography.bodyLarge, color = onLight)
-    RemoteText(
-      "Label Medium".rs,
-      style = RemoteMaterialTheme.typography.labelMedium,
-      color = onLight,
-    )
-    RemoteText("Label Small".rs, style = RemoteMaterialTheme.typography.labelSmall, color = onLight)
+    RemoteText("Body Large".rs, style = RemoteMaterialTheme.typography.bodyLarge)
+    RemoteText("Label Medium".rs, style = RemoteMaterialTheme.typography.labelMedium)
+    RemoteText("Label Small".rs, style = RemoteMaterialTheme.typography.labelSmall)
   }
 }
 

--- a/samples/design-catalog-remote-m3/src/main/kotlin/com/example/designcatalogremotem3/CatalogPreviews.kt
+++ b/samples/design-catalog-remote-m3/src/main/kotlin/com/example/designcatalogremotem3/CatalogPreviews.kt
@@ -5,11 +5,16 @@ package com.example.designcatalogremotem3
 import androidx.compose.remote.creation.compose.action.hostAction
 import androidx.compose.remote.creation.compose.layout.RemoteAlignment
 import androidx.compose.remote.creation.compose.layout.RemoteBox
+import androidx.compose.remote.creation.compose.layout.RemoteColumn
+import androidx.compose.remote.creation.compose.layout.RemoteRow
 import androidx.compose.remote.creation.compose.modifier.RemoteModifier
 import androidx.compose.remote.creation.compose.modifier.background
 import androidx.compose.remote.creation.compose.modifier.fillMaxSize
+import androidx.compose.remote.creation.compose.modifier.size
+import androidx.compose.remote.creation.compose.modifier.width
 import androidx.compose.remote.creation.compose.shaders.RemoteBrush
 import androidx.compose.remote.creation.compose.shaders.linearGradient
+import androidx.compose.remote.creation.compose.shaders.solidColor
 import androidx.compose.remote.creation.compose.shapes.RemoteRoundedCornerShape
 import androidx.compose.remote.creation.compose.state.RemoteColor
 import androidx.compose.remote.creation.compose.state.rb
@@ -20,28 +25,88 @@ import androidx.compose.remote.creation.compose.state.rf
 import androidx.compose.remote.creation.compose.state.rs
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.wear.compose.remote.material3.RemoteAppCard
 import androidx.wear.compose.remote.material3.RemoteButton
+import androidx.wear.compose.remote.material3.RemoteButtonGroup
+import androidx.wear.compose.remote.material3.RemoteCard
+import androidx.wear.compose.remote.material3.RemoteCircularProgressIndicator
+import androidx.wear.compose.remote.material3.RemoteCompactButton
+import androidx.wear.compose.remote.material3.RemoteIcon
+import androidx.wear.compose.remote.material3.RemoteIconButton
+import androidx.wear.compose.remote.material3.RemoteMaterialTheme
+import androidx.wear.compose.remote.material3.RemoteOutlinedCard
 import androidx.wear.compose.remote.material3.RemoteText
+import androidx.wear.compose.remote.material3.RemoteTextButton
+import androidx.wear.compose.remote.material3.RemoteTitleCard
 import androidx.wear.compose.remote.material3.buttonSizeModifier
 
 // ---------------------------------------------------------------------------
 // Remote Compose design-catalog sticker sheet.
 //
-// Each `@CatalogRemoteModes`-annotated function is one component sticker: the
-// remote content wrapped in the module's `RemoteSticker` frame (RemotePreview →
-// RemoteDocument → player raster). The function names below are the stable keys
-// `catalog.spec.json` joins on. Components mirror the Wear Compose Remote
-// Material 3 (`androidx.wear.compose.remote.material3`) + `remote-creation-compose`
-// surface exercised by `:samples:remotecompose`, arranged as a sticker sheet.
+// Each `@CatalogRemoteModes` / `@CatalogRemoteLarge`-annotated function is one
+// component sticker: the remote content wrapped in the module's `RemoteSticker`
+// frame (RemotePreview → RemoteDocument → player raster). The function names below
+// are the stable keys `catalog.spec.json` joins on.
+//
+// The set mirrors the **Wear Compose Remote Material 3**
+// (`androidx.wear.compose.remote.material3`) component surface — the port of Wear
+// Compose Material 3 to Remote Compose — so every sticker here has a Wear M3
+// parallel (declared per-component in `catalog.spec.json`'s `parallel` field, and
+// surfaced side-by-side by the branch's cross-system compare page). Only the two
+// non-component helpers are omitted, matching the spec: `RemoteContainerPainter`
+// (a painter factory, not a drawable component) and `RemoteTypographyTokens` (raw
+// token table behind `RemoteTypography`). The `remote-creation-compose` shader
+// sticker is the one Remote-only extra with no Wear M3 peer.
 // ---------------------------------------------------------------------------
 
 // A shared action used by every sample button — `hostAction(...)` is the Remote
-// Compose equivalent of `onClick = { ... }`. The two arguments are a remote
-// string payload and a remote-float handler id.
+// Compose equivalent of `onClick = { ... }`. The two arguments are a remote string
+// payload and a remote-float handler id.
 private val testAction = hostAction("catalogAction".rs, 1.rf)
 
+// A near-black content colour for stickers drawn straight onto the sticker's white
+// `showBackground` (rather than inside a coloured button/card surface, which
+// carries its own contrasting content colour). `RemoteText` / `RemoteIcon` default
+// to a near-white content colour that would be invisible on white.
+private val onLight = RemoteColor(Color(0xFF1D1B20))
+
+// A simple five-point star used by the icon stickers. Remote Compose has no bundled
+// icon set and `RemoteIcon` takes an `ImageVector`, so the catalog carries one
+// hand-built vector rather than depending on `material-icons`. `RemoteIcon` re-tints
+// it, so the path fill here is a placeholder.
+private val starIcon: ImageVector =
+  ImageVector.Builder(
+      name = "Star",
+      defaultWidth = 24.dp,
+      defaultHeight = 24.dp,
+      viewportWidth = 24f,
+      viewportHeight = 24f,
+    )
+    .apply {
+      path(fill = SolidColor(Color.White)) {
+        moveTo(12f, 2f)
+        lineTo(15.1f, 8.3f)
+        lineTo(22f, 9.3f)
+        lineTo(17f, 14.1f)
+        lineTo(18.2f, 21f)
+        lineTo(12f, 17.8f)
+        lineTo(5.8f, 21f)
+        lineTo(7f, 14.1f)
+        lineTo(2f, 9.3f)
+        lineTo(8.9f, 8.3f)
+        close()
+      }
+    }
+    .build()
+
 // ---------------------------------------------------------------------------
-// Buttons — the Remote Material 3 button plus its border / shape variants.
+// Buttons — the Remote Material 3 button emphasis family plus the border / shape /
+// named-value variants. Parallels of the Wear M3 button family.
 // ---------------------------------------------------------------------------
 
 @CatalogRemoteModes
@@ -51,19 +116,22 @@ fun FilledRemoteButton() = RemoteSticker {
     onClick = testAction,
     modifier = RemoteModifier.buttonSizeModifier(),
     enabled = true.rb,
-    content = { RemoteText("Enabled".rs) },
+    content = { RemoteText("Filled".rs) },
   )
 }
 
+// Remote Material 3's outlined-emphasis button: a `RemoteButton` with an explicit
+// border + border colour (Remote Compose has no separate `OutlinedButton`). Wear
+// M3 parallel: `OutlinedButton` (`Button/Outlined`).
 @CatalogRemoteModes
 @Composable
-fun BorderedRemoteButton() = RemoteSticker {
+fun OutlinedRemoteButton() = RemoteSticker {
   RemoteButton(
     onClick = testAction,
     modifier = RemoteModifier.buttonSizeModifier(),
-    border = 8.rdp,
-    borderColor = RemoteColor(Color.Green),
-    content = { RemoteText("Bordered".rs) },
+    border = 2.rdp,
+    borderColor = onLight,
+    content = { RemoteText("Outlined".rs) },
   )
 }
 
@@ -96,24 +164,191 @@ fun NamedLabelRemoteButton() = RemoteSticker {
   )
 }
 
+// A low-emphasis round text button (`RemoteTextButton`), the Remote parallel of Wear
+// M3's `TextButton`.
+@CatalogRemoteModes
+@Composable
+fun TextRemoteButton() = RemoteSticker {
+  RemoteTextButton(onClick = testAction, content = { RemoteText("OK".rs) })
+}
+
+// A round icon button (`RemoteIconButton`) carrying a single `RemoteIcon`. Inside the
+// button the icon inherits the button's (contrasting) content colour, so no explicit
+// tint is needed. Wear M3 parallel: `IconButton`.
+@CatalogRemoteModes
+@Composable
+fun IconRemoteButton() = RemoteSticker {
+  RemoteIconButton(onClick = testAction, content = { RemoteIcon(starIcon, "Favourite".rs) })
+}
+
+// The compact, single-line button (`RemoteCompactButton`) — Wear M3 parallel:
+// `CompactButton`.
+@CatalogRemoteModes
+@Composable
+fun CompactRemoteButton() = RemoteSticker {
+  RemoteCompactButton(onClick = testAction, label = { RemoteText("Compact".rs) })
+}
+
+// A pair of buttons laid out edge-to-edge by `RemoteButtonGroup`, each taking an equal
+// share of the row via `weight`. Wear M3 parallel: `ButtonGroup`.
+@CatalogRemoteLarge
+@Composable
+fun ButtonGroupRemote() = RemoteSticker {
+  RemoteButtonGroup {
+    RemoteButton(onClick = testAction, modifier = RemoteModifier.weight(1f.rf)) {
+      RemoteText("Yes".rs)
+    }
+    RemoteButton(onClick = testAction, modifier = RemoteModifier.weight(1f.rf)) {
+      RemoteText("No".rs)
+    }
+  }
+}
+
 // ---------------------------------------------------------------------------
-// Text — the Remote Material 3 text primitive on its own. An explicit dark
-// `color` is required: `RemoteText` defaults to a near-white content colour
-// (fine inside a button surface or on the shader, invisible on the sticker's
-// white `showBackground`).
+// Containment — the Remote Material 3 card family. Parallels of the Wear M3 cards.
+// ---------------------------------------------------------------------------
+
+@CatalogRemoteLarge
+@Composable
+fun CardRemote() = RemoteSticker {
+  RemoteCard(onClick = testAction, content = { RemoteText("Card".rs) })
+}
+
+@CatalogRemoteLarge
+@Composable
+fun OutlinedCardRemote() = RemoteSticker {
+  RemoteOutlinedCard(onClick = testAction, content = { RemoteText("Outlined card".rs) })
+}
+
+@CatalogRemoteLarge
+@Composable
+fun TitleCardRemote() = RemoteSticker {
+  RemoteTitleCard(
+    onClick = testAction,
+    title = { RemoteText("Title".rs) },
+    subtitle = { RemoteText("Subtitle".rs) },
+    content = { RemoteText("Supporting text".rs) },
+  )
+}
+
+@CatalogRemoteLarge
+@Composable
+fun AppCardRemote() = RemoteSticker {
+  RemoteAppCard(
+    onClick = testAction,
+    appName = { RemoteText("App".rs) },
+    title = { RemoteText("Title".rs) },
+    appImage = { RemoteIcon(starIcon, null, modifier = RemoteModifier.size(16.rdp)) },
+    time = { RemoteText("now".rs) },
+    content = { RemoteText("Content".rs) },
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Communication — the determinate circular progress indicator at a fixed 66%, so the
+// static capture is deterministic (the indeterminate overload animates off the
+// document clock). Wear M3 parallel: `CircularProgressIndicator` (`Progress/Circular`).
 // ---------------------------------------------------------------------------
 
 @CatalogRemoteModes
 @Composable
-fun RemoteTextSticker() = RemoteSticker {
-  RemoteText("Remote".rs, color = RemoteColor(Color(0xFF1D1B20)))
+fun CircularProgressRemote() = RemoteSticker {
+  RemoteCircularProgressIndicator(progress = 0.66f.rf, modifier = RemoteModifier.size(72.rdp))
+}
+
+// ---------------------------------------------------------------------------
+// Iconography — the standalone `RemoteIcon` primitive. Tinted dark so it reads on the
+// sticker's white background. Wear M3 parallel: `Icon`.
+// ---------------------------------------------------------------------------
+
+@CatalogRemoteModes
+@Composable
+fun IconRemote() = RemoteSticker {
+  RemoteIcon(starIcon, "Star".rs, modifier = RemoteModifier.size(48.rdp), tint = onLight)
+}
+
+// ---------------------------------------------------------------------------
+// Text — the Remote Material 3 text primitive. An explicit dark `color` is required:
+// `RemoteText` defaults to a near-white content colour (fine inside a button surface
+// or on the shader, invisible on the sticker's white `showBackground`).
+// ---------------------------------------------------------------------------
+
+@CatalogRemoteModes
+@Composable
+fun RemoteTextSticker() = RemoteSticker { RemoteText("Remote".rs, color = onLight) }
+
+// The text primitive exercising the maxLines / overflow product on a narrow column —
+// the Remote parallel of Wear M3's `Text/MaxLines-Truncated`. `RemoteText` carries the
+// same `maxLines` + `overflow` knobs as Wear's `Text`.
+@CatalogRemoteLarge
+@Composable
+fun TruncatedTextRemote() = RemoteSticker {
+  RemoteText(
+    "A longer passage of body text that runs past two lines and clips with an ellipsis".rs,
+    modifier = RemoteModifier.width(150.rdp),
+    maxLines = 2,
+    overflow = TextOverflow.Ellipsis,
+    color = onLight,
+  )
+}
+
+// NOTE: `RemoteTimeText` is intentionally NOT catalogued. It draws the time as
+// *curved* text (a `DrawTextOnCircle` document op) that the Remote Compose player
+// bundled in the renderer can't replay ("Operation 57 is not supported for this
+// version" — an alpha writer/player version skew), so it fails the render outright.
+// Re-add a `TimeText` sticker once the player supports the curved-text op.
+
+// ---------------------------------------------------------------------------
+// Theme — the Remote Material 3 theme surfaced as design specimens (the "even themes"
+// parallels): a typography ramp and a colour-scheme swatch row, read straight from
+// `RemoteMaterialTheme`. Parallels of the M3 typography / colour token sheets.
+// ---------------------------------------------------------------------------
+
+@CatalogRemoteLarge
+@Composable
+fun TypographyRemote() = RemoteSticker {
+  RemoteColumn {
+    RemoteText("Body Large".rs, style = RemoteMaterialTheme.typography.bodyLarge, color = onLight)
+    RemoteText(
+      "Label Medium".rs,
+      style = RemoteMaterialTheme.typography.labelMedium,
+      color = onLight,
+    )
+    RemoteText("Label Small".rs, style = RemoteMaterialTheme.typography.labelSmall, color = onLight)
+  }
+}
+
+@CatalogRemoteLarge
+@Composable
+fun ColorSchemeRemote() = RemoteSticker {
+  RemoteRow {
+    RemoteBox(
+      modifier =
+        RemoteModifier.size(44.rdp)
+          .background(RemoteBrush.solidColor(RemoteMaterialTheme.colorScheme.primary)),
+      content = {},
+    )
+    RemoteBox(
+      modifier =
+        RemoteModifier.size(44.rdp)
+          .background(RemoteBrush.solidColor(RemoteMaterialTheme.colorScheme.surfaceContainer)),
+      content = {},
+    )
+    RemoteBox(
+      modifier =
+        RemoteModifier.size(44.rdp)
+          .background(RemoteBrush.solidColor(RemoteMaterialTheme.colorScheme.onBackground)),
+      content = {},
+    )
+  }
 }
 
 // ---------------------------------------------------------------------------
 // Shaders — a document-level gradient fill (`remote-creation-compose` shaders),
 // serialised into the RemoteDocument and rasterised by the player rather than an
-// app-side `ShaderBrush`. The middle stop is a named-value binding so the
-// connector can recolour it live.
+// app-side `ShaderBrush`. The one Remote-only sticker with no Wear M3 component peer
+// (it's a creation-compose primitive, not a `remote-material3` component). The middle
+// stop is a named-value binding so the connector can recolour it live.
 // ---------------------------------------------------------------------------
 
 @CatalogRemoteModes

--- a/samples/design-catalog-remote-m3/src/main/kotlin/com/example/designcatalogremotem3/CatalogTheme.kt
+++ b/samples/design-catalog-remote-m3/src/main/kotlin/com/example/designcatalogremotem3/CatalogTheme.kt
@@ -49,3 +49,11 @@ fun RemoteSticker(content: @Composable @RemoteComposable () -> Unit) {
  * room than a single button.
  */
 @Preview(showBackground = true, widthDp = 200, heightDp = 200) annotation class CatalogRemoteModes
+
+/**
+ * A larger single-capture multipreview for the components that need more room than a single button —
+ * cards, the app card, a button group, the TimeText strip, and the theme (typography / colour)
+ * specimens. Same solid-background, single-mode contract as [CatalogRemoteModes]; only the canvas is
+ * bigger so the content isn't clipped by the 200×200 frame.
+ */
+@Preview(showBackground = true, widthDp = 320, heightDp = 240) annotation class CatalogRemoteLarge

--- a/samples/design-catalog-remote-m3/src/main/kotlin/com/example/designcatalogremotem3/CatalogTheme.kt
+++ b/samples/design-catalog-remote-m3/src/main/kotlin/com/example/designcatalogremotem3/CatalogTheme.kt
@@ -48,7 +48,7 @@ fun RemoteSticker(content: @Composable @RemoteComposable () -> Unit) {
  * `remote-m3` spec's single `light` mode. Bump `widthDp` / `heightDp` if a component needs more
  * room than a single button.
  */
-@Preview(showBackground = true, widthDp = 200, heightDp = 200) annotation class CatalogRemoteModes
+@Preview(showBackground = false, widthDp = 200, heightDp = 200) annotation class CatalogRemoteModes
 
 /**
  * A larger single-capture multipreview for the components that need more room than a single button —
@@ -56,4 +56,4 @@ fun RemoteSticker(content: @Composable @RemoteComposable () -> Unit) {
  * specimens. Same solid-background, single-mode contract as [CatalogRemoteModes]; only the canvas is
  * bigger so the content isn't clipped by the 200×200 frame.
  */
-@Preview(showBackground = true, widthDp = 320, heightDp = 240) annotation class CatalogRemoteLarge
+@Preview(showBackground = false, widthDp = 320, heightDp = 240) annotation class CatalogRemoteLarge

--- a/samples/design-catalog-wear-m3/catalog.spec.json
+++ b/samples/design-catalog-wear-m3/catalog.spec.json
@@ -23,7 +23,10 @@
         { "componentId": "Button/Tonal", "preview": "FilledTonalButtonSticker" },
         { "componentId": "Button/Outlined", "preview": "OutlinedButtonSticker" },
         { "componentId": "Button/Child", "preview": "ChildButtonSticker" },
-        { "componentId": "EdgeButton", "preview": "EdgeButtonSticker", "caption": "Screen-hugging bottom action unique to Wear." }
+        { "componentId": "EdgeButton", "preview": "EdgeButtonSticker", "caption": "Screen-hugging bottom action unique to Wear." },
+        { "componentId": "IconButton", "preview": "IconButtonSticker", "caption": "Round icon button." },
+        { "componentId": "CompactButton", "preview": "CompactButtonSticker", "caption": "Compact single-line button." },
+        { "componentId": "ButtonGroup", "preview": "ButtonGroupSticker", "caption": "Two buttons laid out edge-to-edge." }
       ]
     },
     {
@@ -40,7 +43,8 @@
       "components": [
         { "componentId": "Card", "preview": "CardSticker" },
         { "componentId": "TitleCard", "preview": "TitleCardSticker" },
-        { "componentId": "ListHeader", "preview": "ListHeaderSticker" }
+        { "componentId": "ListHeader", "preview": "ListHeaderSticker" },
+        { "componentId": "AppCard", "preview": "AppCardSticker", "caption": "Card with app name, icon, title and content slots." }
       ]
     },
     {
@@ -73,6 +77,19 @@
       "name": "Text options",
       "components": [
         { "componentId": "Text/MaxLines-Truncated", "preview": "TextMaxLinesTruncated", "caption": "maxLines=2 + ellipsis on a round screen." }
+      ]
+    },
+    {
+      "name": "Iconography",
+      "components": [
+        { "componentId": "Icon", "preview": "IconSticker", "caption": "The standalone Icon primitive." }
+      ]
+    },
+    {
+      "name": "Theme",
+      "components": [
+        { "componentId": "Typography", "preview": "TypographySpecimen", "caption": "A type ramp read from MaterialTheme.typography." },
+        { "componentId": "ColorScheme", "preview": "ColorSchemeSpecimen", "caption": "Colour-scheme swatches read from MaterialTheme.colorScheme." }
       ]
     }
   ]

--- a/samples/design-catalog-wear-m3/src/main/kotlin/com/example/designcatalogwearm3/CatalogPreviews.kt
+++ b/samples/design-catalog-wear-m3/src/main/kotlin/com/example/designcatalogwearm3/CatalogPreviews.kt
@@ -600,10 +600,7 @@ fun IconButtonSticker() =
 @Composable
 fun CompactButtonSticker() =
   WearSticker {
-    CompactButton(
-      onClick = {},
-      label = { Text(previewOverrideString("label", stringResource(R.string.label_start))) },
-    )
+    CompactButton(onClick = {}, label = { Text(previewOverrideString("label", "Compact")) })
   }
 
 @CatalogWearModes
@@ -642,7 +639,7 @@ fun TypographySpecimen() =
   WearSticker {
     Column {
       Text("Body Large", style = MaterialTheme.typography.bodyLarge)
-      Text("Title Medium", style = MaterialTheme.typography.titleMedium)
+      Text("Label Medium", style = MaterialTheme.typography.labelMedium)
       Text("Label Small", style = MaterialTheme.typography.labelSmall)
     }
   }

--- a/samples/design-catalog-wear-m3/src/main/kotlin/com/example/designcatalogwearm3/CatalogPreviews.kt
+++ b/samples/design-catalog-wear-m3/src/main/kotlin/com/example/designcatalogwearm3/CatalogPreviews.kt
@@ -6,8 +6,21 @@ import androidx.compose.foundation.interaction.PressInteraction
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.wear.compose.material3.AppCard
+import androidx.wear.compose.material3.ButtonGroup
+import androidx.wear.compose.material3.CompactButton
+import androidx.wear.compose.material3.Icon
+import androidx.wear.compose.material3.IconButton
+import androidx.wear.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
@@ -541,4 +554,106 @@ fun CheckboxButtonUnchecked() =
       onCheckedChange = {},
       label = { Text(previewOverrideString("label", stringResource(R.string.label_sync))) },
     )
+  }
+
+// ---------------------------------------------------------------------------
+// Parallels of the Remote Compose Material 3 catalog. These mirror the extra
+// components the remote-m3 sheet carries (IconButton, CompactButton, ButtonGroup,
+// AppCard, Icon, and the theme specimens), so the cross-system compare page pairs
+// every remote sticker with a real Wear M3 counterpart rather than a placeholder.
+// ---------------------------------------------------------------------------
+
+// A simple five-point star shared by the icon stickers — the catalog doesn't pull
+// in material-icons, so it carries one hand-built vector. `Icon` re-tints it, so
+// the path fill here is a placeholder.
+private val catalogIcon: ImageVector =
+  ImageVector.Builder(
+      name = "Star",
+      defaultWidth = 24.dp,
+      defaultHeight = 24.dp,
+      viewportWidth = 24f,
+      viewportHeight = 24f,
+    )
+    .apply {
+      path(fill = SolidColor(Color.White)) {
+        moveTo(12f, 2f)
+        lineTo(15.1f, 8.3f)
+        lineTo(22f, 9.3f)
+        lineTo(17f, 14.1f)
+        lineTo(18.2f, 21f)
+        lineTo(12f, 17.8f)
+        lineTo(5.8f, 21f)
+        lineTo(7f, 14.1f)
+        lineTo(2f, 9.3f)
+        lineTo(8.9f, 8.3f)
+        close()
+      }
+    }
+    .build()
+
+@CatalogWearModes
+@Composable
+fun IconButtonSticker() =
+  WearSticker { IconButton(onClick = {}) { Icon(catalogIcon, "Favourite") } }
+
+@CatalogWearModes
+@Composable
+fun CompactButtonSticker() =
+  WearSticker {
+    CompactButton(
+      onClick = {},
+      label = { Text(previewOverrideString("label", stringResource(R.string.label_start))) },
+    )
+  }
+
+@CatalogWearModes
+@Composable
+fun ButtonGroupSticker() =
+  WearSticker {
+    ButtonGroup {
+      Button(onClick = {}, modifier = Modifier.weight(1f)) { Text("Yes") }
+      Button(onClick = {}, modifier = Modifier.weight(1f)) { Text("No") }
+    }
+  }
+
+@CatalogWearModes
+@Composable
+fun AppCardSticker() =
+  WearSticker {
+    AppCard(
+      onClick = {},
+      appName = { Text("App") },
+      title = { Text(previewOverrideString("title", stringResource(R.string.title_morning_run))) },
+      appImage = { Icon(catalogIcon, null, Modifier.size(16.dp)) },
+    ) {
+      Text("5.2 km · 28 min")
+    }
+  }
+
+@CatalogWearModes
+@Composable
+fun IconSticker() = WearSticker { Icon(catalogIcon, "Star", Modifier.size(48.dp)) }
+
+// Theme specimens — the Wear M3 type ramp and colour-scheme swatches read straight
+// from MaterialTheme, parallels of the remote-m3 theme stickers.
+@CatalogWearModes
+@Composable
+fun TypographySpecimen() =
+  WearSticker {
+    Column {
+      Text("Body Large", style = MaterialTheme.typography.bodyLarge)
+      Text("Title Medium", style = MaterialTheme.typography.titleMedium)
+      Text("Label Small", style = MaterialTheme.typography.labelSmall)
+    }
+  }
+
+@CatalogWearModes
+@Composable
+fun ColorSchemeSpecimen() =
+  WearSticker {
+    Row {
+      Box(Modifier.size(44.dp).background(MaterialTheme.colorScheme.primary))
+      Box(Modifier.size(44.dp).background(MaterialTheme.colorScheme.surfaceContainer))
+      Box(Modifier.size(44.dp).background(MaterialTheme.colorScheme.onBackground))
+    }
   }

--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -46,6 +46,7 @@ import { buildCatalog, writeCatalog } from "@design-parity/catalog-export";
 import { foldVariants } from "./catalog-variants.mjs";
 import { renderIndexHtml } from "./render-index-html.mjs";
 import { renderCompareHtml } from "./render-compare-html.mjs";
+import { renderCrossSystemHtml } from "./render-cross-system-html.mjs";
 import { renderReadmeMd } from "./render-readme-md.mjs";
 import {
   figmaRastersForId,
@@ -697,8 +698,64 @@ for (const component of catalog.components) {
 // `component.images`, so passing the manifest is what makes the stickers actually
 // show (and lets the zoom view group them by `state`).
 const indexManifest = JSON.parse(await readFile(join(outPath, "catalog.json"), "utf8"));
+
+// Cross-system component-parallel page (matches.html): pair every component with
+// its declared counterpart in the sibling system named by `spec.compareWith`,
+// side by side, so a reader sees how the two design systems line up. The pairing
+// is authored per component via the `parallel` field; the other system's spec
+// (its componentId list + captions) comes from the same repo checkout, and its
+// renders are fetched from its own design-artifacts branch at view time (see
+// render-cross-system-html.mjs). Best-effort: a missing/broken sibling spec just
+// skips the page rather than failing the publish.
+let crossSystem = null;
+if (spec.compareWith) {
+  try {
+    const otherSpecPath = join(
+      dirname(dirname(specPath)),
+      `design-catalog-${spec.compareWith}`,
+      "catalog.spec.json",
+    );
+    const otherSpec = JSON.parse(await readFile(otherSpecPath, "utf8"));
+    const parallelById = {};
+    for (const group of spec.groups ?? []) {
+      for (const component of group.components ?? []) {
+        if (component.parallel) parallelById[component.componentId] = component.parallel;
+      }
+    }
+    const otherComponents = (otherSpec.groups ?? []).flatMap((group) =>
+      (group.components ?? []).map((c) => ({
+        componentId: c.componentId,
+        group: group.name,
+        caption: c.caption,
+      })),
+    );
+    const matchesPath = join(outPath, "matches.html");
+    await writeFile(
+      matchesPath,
+      renderCrossSystemHtml(indexManifest, {
+        parallelById,
+        otherComponents,
+        otherSystem: spec.compareWith,
+        otherTitle: otherSpec.title,
+        repo: values["source-repo"] || process.env.GITHUB_REPOSITORY || undefined,
+      }),
+      "utf8",
+    );
+    crossSystem = { system: spec.compareWith, title: otherSpec.title ?? spec.compareWith };
+    console.log(`[${spec.system}] matches → ${matchesPath}`);
+  } catch (err) {
+    console.warn(
+      `[${spec.system}] cross-system page skipped (${err.message?.split("\n")[0] ?? err})`,
+    );
+  }
+}
+
 const indexPath = join(outPath, "index.html");
-await writeFile(indexPath, renderIndexHtml(indexManifest, { wireframeSlugs, figmaSvgSlugs }), "utf8");
+await writeFile(
+  indexPath,
+  renderIndexHtml(indexManifest, { wireframeSlugs, figmaSvgSlugs, crossSystem }),
+  "utf8",
+);
 
 // PNG-vs-SVG comparison page next to index.html: every component on one row, its
 // rendered PNG beside its browser-rasterized figma-svg, and a live structural
@@ -722,6 +779,7 @@ await writeFile(
     wireframeCount,
     figmaSvgCount,
     previewBase,
+    crossSystem,
   }),
   "utf8",
 );

--- a/scripts/design-artifacts/render-cross-system-html.mjs
+++ b/scripts/design-artifacts/render-cross-system-html.mjs
@@ -179,7 +179,15 @@ const RESOLVER = (catalogUrl, branchBase) => String.raw`
     });
     document.querySelectorAll(".shot--other[data-parallel]").forEach(function (slot) {
       var path = bySlug[slot.getAttribute("data-parallel")];
-      if (!path) return;
+      if (!path) {
+        // The sibling catalog loaded but carries no render for this parallel —
+        // e.g. the other branch is stale (published before its matching sticker
+        // landed) or that render was skipped. Don't leave "loading …" forever.
+        var pending = slot.querySelector(".pending");
+        if (pending) pending.textContent = "not published yet";
+        slot.classList.add("shot--stale");
+        return;
+      }
       var img = new Image();
       img.loading = "lazy";
       img.decoding = "async";
@@ -279,6 +287,7 @@ export function renderCrossSystemHtml(catalog, opts = {}) {
   .shot img { max-width:260px; max-height:200px; height:auto; display:block; }
   .shot--missing { color:var(--muted); font-style:italic; background:var(--panel); }
   .shot--other .pending { color:var(--muted); font-size:12px; }
+  .shot--stale .pending { color:var(--warn); font-style:italic; }
   .shot--other .wf { position:absolute; bottom:4px; right:6px; font-size:11px; }
   .rel code { font-size:12px; }
   a.wf { color:#8ab4f8; text-decoration:none; }

--- a/scripts/design-artifacts/render-cross-system-html.mjs
+++ b/scripts/design-artifacts/render-cross-system-html.mjs
@@ -1,0 +1,329 @@
+/**
+ * Render a self-contained `matches.html` for a design-artifact catalog: every
+ * component of THIS system (e.g. remote-m3) paired with its declared parallel in
+ * a SIBLING system (e.g. wear-m3), side by side, so you can eyeball how a ported
+ * component compares to its origin across the whole system at once.
+ *
+ * The pairing is authored, not guessed: each component in the system's
+ * `catalog.spec.json` carries a `parallel` field naming its counterpart's
+ * `componentId` in the other system (see samples/design-catalog-remote-m3). This
+ * module takes the local catalog (the flattened manifest, same shape
+ * `renderIndexHtml`/`renderCompareHtml` read), the `parallel` map lifted from the
+ * spec, and the other system's component list (also from its committed spec), and
+ * computes three buckets: paired, only-here, and only-there.
+ *
+ * The local (this-system) render is referenced by the catalog's own relative
+ * `images/...` path, so it works straight from the branch checkout. The OTHER
+ * system's render lives on its own `design-artifacts/<other>` branch, so the page
+ * fetches that branch's `catalog.json` at view time (from the same
+ * `raw.githubusercontent.com` origin the images already load from) and fills in
+ * the parallel thumbnails by slug. That keeps the page self-contained at build
+ * time and always fresh; if the fetch fails (offline, or opened over file://) the
+ * pair still lists the parallel's name with a link to the other catalog.
+ *
+ * Pure + dependency-free: returns an HTML string. Slug derivation matches
+ * render-wireframe-svg's `slug` so the client can map componentId → image path
+ * the same way the export wrote them.
+ */
+
+import { slug } from "./render-wireframe-svg.mjs";
+
+/** Minimal HTML-escape for text interpolated into the page. */
+function esc(s) {
+  return String(s ?? "").replace(
+    /[&<>"']/g,
+    (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c],
+  );
+}
+
+/** A component's `ideal` capture images (excludes the `layout` wireframe variant). */
+function idealImages(component) {
+  return (component.images ?? []).filter((i) => i.variant === "ideal");
+}
+
+/** True for the label-only, resting render (no folded state, no content-axis props). */
+function isDefault(image) {
+  const hasProps = Object.keys(image.props ?? {}).length > 0;
+  return !hasProps && (image.state ?? "default") === "default";
+}
+
+/**
+ * The hero PNG for a component: the default, light-themed, largest render — the
+ * same pick the index/compare pages make, so the paired thumbnail matches what a
+ * browser sees elsewhere. Returns the image record (with `.path`) or undefined.
+ */
+function heroImage(component) {
+  const ideal = idealImages(component);
+  const pool = ideal.length ? ideal : (component.images ?? []);
+  const defaults = pool.filter(isDefault);
+  const byDefault = defaults.length ? defaults : pool;
+  const light = byDefault.filter((i) => i.theme === "light");
+  const chooseFrom = light.length ? light : byDefault;
+  return [...chooseFrom].sort((a, b) => (b.width ?? 0) - (a.width ?? 0))[0];
+}
+
+/**
+ * Split the local catalog against the other system's components using the authored
+ * `parallel` map (this-system componentId → other-system componentId).
+ *
+ * @param {object[]} localComponents the local manifest's `components`
+ * @param {Record<string,string>} parallelById componentId → parallel componentId
+ * @param {object[]} otherComponents the other system's spec components ({componentId, group, caption})
+ * @returns {{paired: object[], onlyLocal: object[], onlyOther: object[]}}
+ *   paired: { local, parallelId, other|null } — `other` is null when the parallel
+ *     id isn't (yet) catalogued in the other system.
+ *   onlyLocal: local components with no `parallel` declared.
+ *   onlyOther: other components no local `parallel` points at.
+ */
+export function crossSystemMatches(localComponents, parallelById, otherComponents) {
+  const otherById = new Map((otherComponents ?? []).map((c) => [c.componentId, c]));
+  const referenced = new Set();
+  const paired = [];
+  const onlyLocal = [];
+  for (const local of localComponents ?? []) {
+    const parallelId = parallelById?.[local.componentId];
+    if (!parallelId) {
+      onlyLocal.push(local);
+      continue;
+    }
+    const other = otherById.get(parallelId) ?? null;
+    if (other) referenced.add(parallelId);
+    paired.push({ local, parallelId, other });
+  }
+  const onlyOther = (otherComponents ?? []).filter((c) => !referenced.has(c.componentId));
+  return { paired, onlyLocal, onlyOther };
+}
+
+/** The `<img>` (or placeholder) for the local render column. */
+function localShot(component) {
+  const hero = heroImage(component);
+  const id = component.componentId ?? "(unnamed)";
+  return hero
+    ? `<div class="shot"><img loading="lazy" src="${esc(hero.path)}" alt="${esc(id)}" /></div>`
+    : `<div class="shot shot--missing">no render</div>`;
+}
+
+/**
+ * The other-system column: a slot the client fills from the other branch's
+ * catalog.json (keyed by the parallel's slug via `data-parallel`), plus a link to
+ * the other catalog. When the parallel isn't catalogued there yet, an inert note.
+ */
+function otherShot(parallelId, other, otherBranchBase, otherIndexUrl) {
+  if (!other) {
+    return `<div class="shot shot--missing">no <code>${esc(parallelId)}</code> sticker yet</div>`;
+  }
+  const s = slug(parallelId);
+  return `<div class="shot shot--other" data-parallel="${esc(s)}">
+    <span class="pending">loading ${esc(parallelId)}…</span>
+    <a class="wf" href="${esc(otherIndexUrl)}" target="_blank" rel="noopener">open ↗</a>
+  </div>`;
+}
+
+/**
+ * One `<tr>` per pairing. The local render is baked in; the other render is
+ * resolved client-side from the other branch's catalog.
+ */
+function pairRow(pair, opts) {
+  const { local, parallelId, other } = pair;
+  const id = local.componentId ?? "(unnamed)";
+  const group = local.group ?? "Components";
+  return `<tr class="crow">
+  <th scope="row" class="rowhead"><span class="cid">${esc(id)}</span><span class="grp">${esc(group)}</span></th>
+  <td class="col-a">${localShot(local)}</td>
+  <td class="col-b">${otherShot(parallelId, other, opts.otherBranchBase, opts.otherIndexUrl)}</td>
+  <td class="rel"><code>${esc(parallelId)}</code>${other ? "" : `<span class="badge" title="the parallel isn't in the ${esc(opts.otherSystem)} catalog yet">unpaired</span>`}</td>
+</tr>`;
+}
+
+/** A short inventory row for the only-here / only-there sections. */
+function soloRow(component) {
+  const id = component.componentId ?? "(unnamed)";
+  const group = component.group ?? "Components";
+  const cap = component.caption ? `<span class="cap">${esc(component.caption)}</span>` : "";
+  return `<li><span class="cid">${esc(id)}</span><span class="grp">${esc(group)}</span>${cap}</li>`;
+}
+
+const DEFAULT_REPO = "yschimke/compose-ai-tools";
+
+/**
+ * The client-side resolver, inlined so the page is self-contained. It fetches the
+ * other branch's catalog.json once, maps componentId-slug → hero image path, and
+ * fills each `[data-parallel]` slot with an <img> pointing at the other branch's
+ * raw asset. Best-effort: on any failure the slots keep their name + link.
+ */
+const RESOLVER = (catalogUrl, branchBase) => String.raw`
+(() => {
+  "use strict";
+  var CATALOG = ${JSON.stringify(catalogUrl)};
+  var BASE = ${JSON.stringify(branchBase)};
+  function slugOf(s) {
+    return String(s == null ? "" : s).toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)/g, "");
+  }
+  function heroPath(component) {
+    var imgs = (component.images || []).filter(function (i) { return i.variant === "ideal"; });
+    if (!imgs.length) imgs = component.images || [];
+    var defaults = imgs.filter(function (i) {
+      return Object.keys(i.props || {}).length === 0 && (i.state || "default") === "default";
+    });
+    var pool = defaults.length ? defaults : imgs;
+    var light = pool.filter(function (i) { return i.theme === "light"; });
+    var from = light.length ? light : pool;
+    from = from.slice().sort(function (a, b) { return (b.width || 0) - (a.width || 0); });
+    return from[0] && from[0].path;
+  }
+  fetch(CATALOG).then(function (r) { return r.json(); }).then(function (manifest) {
+    var bySlug = {};
+    (manifest.components || []).forEach(function (c) {
+      var p = heroPath(c);
+      if (p) bySlug[slugOf(c.componentId)] = p;
+    });
+    document.querySelectorAll(".shot--other[data-parallel]").forEach(function (slot) {
+      var path = bySlug[slot.getAttribute("data-parallel")];
+      if (!path) return;
+      var img = new Image();
+      img.loading = "lazy";
+      img.decoding = "async";
+      img.crossOrigin = "anonymous";
+      img.alt = slot.getAttribute("data-parallel");
+      img.src = BASE + path;
+      img.onload = function () {
+        var pending = slot.querySelector(".pending");
+        if (pending) pending.remove();
+        slot.insertBefore(img, slot.firstChild);
+        slot.classList.add("shot--loaded");
+      };
+    });
+  }).catch(function () { /* offline / file:// — keep the name + link fallback */ });
+})();
+`;
+
+/**
+ * Render the catalog to a complete cross-system comparison page.
+ * @param {object} catalog the local flattened manifest (system, title, components, …)
+ * @param {object} opts
+ *   { parallelById, otherComponents, otherSystem, otherTitle?, repo? }
+ * @returns {string} a self-contained matches.html
+ */
+export function renderCrossSystemHtml(catalog, opts = {}) {
+  const components = catalog.components ?? [];
+  const meta = catalog.meta ?? catalog;
+  const system = meta.system ?? "catalog";
+  const title = meta.title ?? system;
+  const repo = opts.repo ?? DEFAULT_REPO;
+  const otherSystem = opts.otherSystem ?? "other";
+  const otherTitle = opts.otherTitle ?? otherSystem;
+  const otherBranch = `design-artifacts/${otherSystem}`;
+  const otherBranchBase = `https://raw.githubusercontent.com/${repo}/${otherBranch}/`;
+  const otherCatalogUrl = `${otherBranchBase}catalog.json`;
+  const otherIndexUrl = `https://htmlpreview.github.io/?https://github.com/${repo}/blob/${otherBranch}/index.html`;
+
+  const { paired, onlyLocal, onlyOther } = crossSystemMatches(
+    components,
+    opts.parallelById ?? {},
+    opts.otherComponents ?? [],
+  );
+
+  const rowOpts = { otherSystem, otherBranchBase, otherIndexUrl };
+  const body = paired.map((p) => pairRow(p, rowOpts)).join("\n");
+  const pairedReal = paired.filter((p) => p.other).length;
+
+  const onlyLocalList = onlyLocal.length
+    ? `<section class="solo"><h2>Only in ${esc(system)} <span>${onlyLocal.length}</span></h2>
+       <ul>${onlyLocal.map(soloRow).join("\n")}</ul></section>`
+    : "";
+  const onlyOtherList = onlyOther.length
+    ? `<section class="solo"><h2>Only in ${esc(otherSystem)} <span>${onlyOther.length}</span></h2>
+       <ul>${onlyOther.map(soloRow).join("\n")}</ul></section>`
+    : "";
+
+  const subtitleParts = [
+    `${title} <span class="arrow">↔</span> ${otherTitle}`,
+    `${paired.length} paired`,
+    `${pairedReal} rendered both sides`,
+  ];
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>${esc(title)} ↔ ${esc(otherTitle)} — component matches</title>
+<style>
+  :root { color-scheme: light dark; --bg:#0f0f10; --panel:#1b1b1d; --fg:#e8e8ea; --muted:#9b9ba1; --line:#2a2a2d;
+    --accent:#7dd87d; --warn:#e0c060; }
+  * { box-sizing: border-box; }
+  body { margin:0; font:14px/1.5 system-ui, -apple-system, Segoe UI, Roboto, sans-serif; background:var(--bg); color:var(--fg); }
+  header.top { padding:24px clamp(16px,4vw,40px); border-bottom:1px solid var(--line); }
+  header.top h1 { margin:0 0 6px; font-size:22px; }
+  header.top .subtitle { color:var(--muted); font-size:13px; display:flex; gap:16px; flex-wrap:wrap; }
+  header.top .arrow { color:var(--accent); }
+  header.top .note { margin-top:10px; color:var(--muted); font-size:12px; max-width:78ch; }
+  header.top code { background:var(--panel); padding:1px 6px; border-radius:5px; }
+  main { padding:8px clamp(16px,4vw,40px) 64px; }
+  table { border-collapse:collapse; width:100%; }
+  thead th { position:sticky; top:0; background:var(--bg); text-align:left; font-size:12px; color:var(--muted);
+    padding:10px 12px; border-bottom:1px solid var(--line); z-index:1; }
+  tbody tr.crow { border-bottom:1px solid var(--line); }
+  th.rowhead { text-align:left; font-weight:600; padding:12px; vertical-align:middle; width:22%; }
+  th.rowhead .cid { display:block; word-break:break-word; }
+  th.rowhead .grp { display:block; margin-top:3px; font-weight:400; font-size:11px; color:var(--muted); }
+  td { padding:10px 12px; vertical-align:middle; }
+  .shot { position:relative; display:inline-grid; place-items:center; min-width:120px; min-height:80px; padding:10px; border-radius:10px;
+    background-color:#161617;
+    background-image:
+      linear-gradient(45deg,#202022 25%,transparent 25%),
+      linear-gradient(-45deg,#202022 25%,transparent 25%),
+      linear-gradient(45deg,transparent 75%,#202022 75%),
+      linear-gradient(-45deg,transparent 75%,#202022 75%);
+    background-size:16px 16px; background-position:0 0,0 8px,8px -8px,-8px 0; }
+  .shot img { max-width:260px; max-height:200px; height:auto; display:block; }
+  .shot--missing { color:var(--muted); font-style:italic; background:var(--panel); }
+  .shot--other .pending { color:var(--muted); font-size:12px; }
+  .shot--other .wf { position:absolute; bottom:4px; right:6px; font-size:11px; }
+  .rel code { font-size:12px; }
+  a.wf { color:#8ab4f8; text-decoration:none; }
+  a.wf:hover { text-decoration:underline; }
+  .badge { display:inline-block; margin-left:6px; font-size:10px; padding:0 6px; border-radius:999px;
+    background:rgba(224,192,96,0.12); color:var(--warn); border:1px solid var(--warn); }
+  section.solo { margin-top:36px; }
+  section.solo h2 { font-size:15px; border-bottom:1px solid var(--line); padding-bottom:6px; }
+  section.solo h2 span { color:var(--muted); font-weight:400; }
+  section.solo ul { list-style:none; padding:0; display:grid; grid-template-columns:repeat(auto-fill,minmax(240px,1fr)); gap:6px 20px; }
+  section.solo li { padding:6px 0; border-bottom:1px solid var(--line); }
+  section.solo .cid { font-weight:600; }
+  section.solo .grp { color:var(--muted); font-size:11px; margin-left:8px; }
+  section.solo .cap { display:block; color:var(--muted); font-size:12px; }
+  @media (max-width:640px){ .shot img { max-width:150px; } th.rowhead { width:auto; } }
+</style>
+</head>
+<body>
+<header class="top">
+  <h1>${esc(title)} ↔ ${esc(otherTitle)}</h1>
+  <div class="subtitle">${subtitleParts.map((s) => `<span>${s}</span>`).join("")}</div>
+  <p class="note">Each row pairs a <strong>${esc(system)}</strong> component with its declared
+  <strong>${esc(otherSystem)}</strong> parallel (the <code>parallel</code> field in the catalog spec). The
+  left render is this branch's baked PNG; the right one is fetched live from the
+  <code>${esc(otherBranch)}</code> branch, so browsing this page shows both systems side by side. A parallel
+  that isn't catalogued in ${esc(otherSystem)} yet is flagged <span class="badge">unpaired</span>. Components with
+  no parallel on either side are listed below the table.</p>
+</header>
+<main>
+  <table>
+    <thead>
+      <tr>
+        <th scope="col">Component</th>
+        <th scope="col">${esc(title)}</th>
+        <th scope="col">${esc(otherTitle)}</th>
+        <th scope="col">Parallel</th>
+      </tr>
+    </thead>
+    <tbody id="rows">${body}</tbody>
+  </table>
+  ${onlyLocalList}
+  ${onlyOtherList}
+</main>
+<script>${RESOLVER(otherCatalogUrl, otherBranchBase)}</script>
+</body>
+</html>
+`;
+}

--- a/scripts/design-artifacts/render-cross-system-html.test.mjs
+++ b/scripts/design-artifacts/render-cross-system-html.test.mjs
@@ -1,0 +1,114 @@
+/**
+ * Unit tests for the cross-system component-parallel page (`matches.html`): each
+ * row pairs a component with its authored parallel in a sibling system, and the
+ * page carries a client resolver that fetches the other branch's catalog.json to
+ * fill in the parallel thumbnails. The fetch/canvas work runs in a browser
+ * (untestable under `node --test`); here we pin the pure pairing logic and the
+ * page structure — the buckets, the row wiring, the unpaired flag, and that the
+ * resolver + other-branch URLs are present.
+ *
+ * Run with `node --test scripts/design-artifacts/`.
+ */
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { crossSystemMatches, renderCrossSystemHtml } from "./render-cross-system-html.mjs";
+
+const png = (path) => ({ path, variant: "ideal", state: "default", theme: "light", width: 200, height: 100 });
+
+const catalog = {
+  system: "remote-m3",
+  title: "Remote Compose Material 3",
+  components: [
+    { componentId: "Button/Filled", group: "Buttons", images: [png("images/button-filled/ideal__default__light.png")] },
+    { componentId: "Button/Icon", group: "Buttons", images: [png("images/button-icon/ideal__default__light.png")] },
+    { componentId: "Shader/LinearGradient", group: "Shaders", images: [png("images/shader/ideal__default__light.png")] },
+  ],
+};
+
+const parallelById = {
+  "Button/Filled": "Button/Filled",
+  "Button/Icon": "IconButton",
+  // Shader/LinearGradient has no parallel declared.
+};
+
+const otherComponents = [
+  { componentId: "Button/Filled", group: "Buttons", caption: "Filled button." },
+  { componentId: "IconButton", group: "Buttons", caption: "Round icon button." },
+  { componentId: "Card", group: "Containment", caption: "A card." },
+];
+
+test("crossSystemMatches buckets paired / only-local / only-other", () => {
+  const { paired, onlyLocal, onlyOther } = crossSystemMatches(
+    catalog.components,
+    parallelById,
+    otherComponents,
+  );
+  assert.equal(paired.length, 2);
+  assert.deepEqual(
+    paired.map((p) => [p.local.componentId, p.parallelId, p.other?.componentId]),
+    [
+      ["Button/Filled", "Button/Filled", "Button/Filled"],
+      ["Button/Icon", "IconButton", "IconButton"],
+    ],
+  );
+  // Shader has no parallel → only-local.
+  assert.deepEqual(onlyLocal.map((c) => c.componentId), ["Shader/LinearGradient"]);
+  // Card is never referenced by a parallel → only-other.
+  assert.deepEqual(onlyOther.map((c) => c.componentId), ["Card"]);
+});
+
+test("a parallel not catalogued in the other system pairs with other=null", () => {
+  const { paired } = crossSystemMatches(
+    [{ componentId: "Button/Compact", group: "Buttons", images: [] }],
+    { "Button/Compact": "CompactButton" },
+    [], // other system has no CompactButton yet
+  );
+  assert.equal(paired.length, 1);
+  assert.equal(paired[0].other, null);
+  assert.equal(paired[0].parallelId, "CompactButton");
+});
+
+test("each paired row shows the local render and a slot for the parallel", () => {
+  const html = renderCrossSystemHtml(catalog, { parallelById, otherComponents, otherSystem: "wear-m3", otherTitle: "Wear Compose Material 3" });
+  // Local render baked in.
+  assert.match(html, /<img[^>]*src="images\/button-filled\/ideal__default__light\.png"/);
+  // Parallel slot keyed by the parallel's slug for the client resolver.
+  assert.match(html, /class="shot shot--other" data-parallel="iconbutton"/);
+});
+
+test("an uncatalogued parallel is flagged unpaired", () => {
+  const html = renderCrossSystemHtml(
+    { system: "remote-m3", title: "Remote", components: [{ componentId: "Button/Compact", group: "Buttons", images: [] }] },
+    { parallelById: { "Button/Compact": "CompactButton" }, otherComponents: [], otherSystem: "wear-m3" },
+  );
+  assert.match(html, /class="badge"[^>]*>unpaired</);
+  assert.match(html, /no <code>CompactButton<\/code> sticker yet/);
+});
+
+test("only-local and only-other inventories are listed", () => {
+  const html = renderCrossSystemHtml(catalog, { parallelById, otherComponents, otherSystem: "wear-m3" });
+  assert.match(html, /Only in remote-m3 <span>1<\/span>/);
+  assert.match(html, /Only in wear-m3 <span>1<\/span>/);
+  assert.match(html, /Shader\/LinearGradient/);
+  assert.match(html, />Card</);
+});
+
+test("the client resolver fetches the other branch catalog for thumbnails", () => {
+  const html = renderCrossSystemHtml(catalog, {
+    parallelById,
+    otherComponents,
+    otherSystem: "wear-m3",
+    repo: "yschimke/compose-ai-tools",
+  });
+  assert.match(html, /raw\.githubusercontent\.com\/yschimke\/compose-ai-tools\/design-artifacts\/wear-m3\/catalog\.json/);
+  assert.match(html, /querySelectorAll\("\.shot--other\[data-parallel\]"\)/);
+  // Cross-origin so the other-branch images load on htmlpreview.
+  assert.match(html, /img\.crossOrigin = "anonymous"/);
+});
+
+test("the summary counts pairs and how many render both sides", () => {
+  const html = renderCrossSystemHtml(catalog, { parallelById, otherComponents, otherSystem: "wear-m3" });
+  assert.match(html, /2 paired/);
+  assert.match(html, /2 rendered both sides/);
+});

--- a/scripts/design-artifacts/render-cross-system-html.test.mjs
+++ b/scripts/design-artifacts/render-cross-system-html.test.mjs
@@ -107,6 +107,15 @@ test("the client resolver fetches the other branch catalog for thumbnails", () =
   assert.match(html, /img\.crossOrigin = "anonymous"/);
 });
 
+test("the resolver marks a paired slot 'not published yet' when the sibling render is missing", () => {
+  const html = renderCrossSystemHtml(catalog, { parallelById, otherComponents, otherSystem: "wear-m3" });
+  // When the fetched sibling catalog carries no render for a declared parallel,
+  // the slot must not stay stuck on the "loading …" placeholder forever.
+  assert.match(html, /if \(!path\) \{/);
+  assert.match(html, /textContent = "not published yet"/);
+  assert.match(html, /shot--stale/);
+});
+
 test("the summary counts pairs and how many render both sides", () => {
   const html = renderCrossSystemHtml(catalog, { parallelById, otherComponents, otherSystem: "wear-m3" });
   assert.match(html, /2 paired/);

--- a/scripts/design-artifacts/render-index-html.mjs
+++ b/scripts/design-artifacts/render-index-html.mjs
@@ -196,6 +196,7 @@ export function renderIndexHtml(catalog, opts = {}) {
   const components = catalog.components ?? [];
   const wireframeSlugs = opts.wireframeSlugs;
   const figmaSvgSlugs = opts.figmaSvgSlugs;
+  const crossSystem = opts.crossSystem;
 
   // Group preserving first-seen group order.
   const groupOrder = [];
@@ -348,7 +349,11 @@ export function renderIndexHtml(catalog, opts = {}) {
 <header class="top">
   <h1>${esc(title)}</h1>
   <div class="subtitle">${subtitleParts.join(" · ")}</div>
-  <div class="subtitle"><a class="pagelink" href="compare.html">PNG vs SVG compare ↗</a></div>
+  <div class="subtitle"><a class="pagelink" href="compare.html">PNG vs SVG compare ↗</a>${
+    crossSystem
+      ? ` <a class="pagelink" href="matches.html">↔ ${esc(crossSystem.title)} matches ↗</a>`
+      : ""
+  }</div>
 </header>
 <div class="layout">
   <nav class="index">${nav}</nav>

--- a/scripts/design-artifacts/render-readme-md.mjs
+++ b/scripts/design-artifacts/render-readme-md.mjs
@@ -51,6 +51,8 @@ export function renderReadmeMd(catalog, opts = {}) {
   const branch = `design-artifacts/${system}`;
   const indexUrl = `https://htmlpreview.github.io/?https://github.com/${repo}/blob/${branch}/index.html`;
   const compareUrl = `https://htmlpreview.github.io/?https://github.com/${repo}/blob/${branch}/compare.html`;
+  const crossSystem = opts.crossSystem;
+  const matchesUrl = `https://htmlpreview.github.io/?https://github.com/${repo}/blob/${branch}/matches.html`;
   const previewBase = opts.previewBase ?? DEFAULT_PREVIEW_BASE;
   const liveUrl = liveSessionUrl(previewBase, system);
 
@@ -104,12 +106,33 @@ dark scheme.
     .map(([g, n]) => `| ${cell(g)} | ${n} |`)
     .join("\n");
 
+  const crossSection = crossSystem
+    ? `
+## ↔ Compare across systems
+
+**[▶ Open the ${cell(title)} ↔ ${cell(crossSystem.title)} matches (htmlpreview)](${matchesUrl})**
+
+Every component paired with its counterpart in **${cell(crossSystem.title)}**, side by side — the
+authored \`parallel\` mapping in the catalog spec, rendered as a cross-system contact sheet. This
+branch's baked render on the left; the ${cell(crossSystem.system)} render fetched live from its own
+\`design-artifacts/${cell(crossSystem.system)}\` branch on the right.
+`
+    : "";
+
   const files = [
     [`\`index.html\``, `Self-contained gallery — [open via htmlpreview](${indexUrl})`],
     [
       `\`compare.html\``,
       `PNG↔SVG comparison with a live structural-similarity score — [open via htmlpreview](${compareUrl})`,
     ],
+    ...(crossSystem
+      ? [
+          [
+            `\`matches.html\``,
+            `Cross-system component pairing vs \`${crossSystem.system}\` — [open via htmlpreview](${matchesUrl})`,
+          ],
+        ]
+      : []),
     [
       `\`catalog.json\``,
       `Machine-readable catalog (\`${schema}\`): components, variants, design tokens, greenlines, and per-variant \`livePreview\` deep links`,
@@ -143,7 +166,7 @@ re-rasterized by the browser, plus a live **structural-similarity (SSIM)** match
 score — so you can eyeball vector fidelity across the whole system at once and
 spot which stickers drift. The score is pre-blurred and downscaled, so a
 half-pixel rasterizer offset doesn't read as a mismatch.
-
+${crossSection}
 ## 🎛 Customise live
 
 **[▶ Open this catalog in the live preview server](${liveUrl})**


### PR DESCRIPTION
## Summary

Brings the **remote-m3** design catalog up to parity with its **wear-m3** sibling and adds a new **cross-system compare page** so every Remote Compose Material 3 component can be seen next to its Wear Material 3 counterpart.

Three parts:

1. **Complete the Remote Compose Material 3 catalog** (`:samples:design-catalog-remote-m3`) — from 6 stickers to the full `androidx.wear.compose.remote.material3` (alpha06) surface: buttons (Filled, Outlined, Text, Icon, Compact, ButtonGroup, CustomShape, NamedLabel), cards (Card, OutlinedCard, TitleCard, AppCard), Icon, CircularProgressIndicator, Text (body + truncated), theme (typography ramp + colour swatches), and the existing shader. Each component declares its Wear parallel via a new `parallel` field, and the spec gains `compareWith: "wear-m3"`.
   - `RemoteContainerPainter` and `RemoteTypographyTokens` are omitted (helpers, not components); the shader is the one Remote-only extra.
   - `RemoteTimeText` is intentionally left out — it draws curved text (`DrawTextOnCircle`) the Remote Compose player bundled in the renderer can't replay (`Operation 57 is not supported for this version`), so it fails the render and would trip the design-artifacts completeness gate.
   - Remote stickers now render on a **transparent, tight-cropped** canvas (`showBackground = false`) like the Wear catalog (verified: the player emits RGBA with transparent corners).

2. **Wear M3 parallels** (`:samples:design-catalog-wear-m3`) — add the counterparts the remote sheet references but the wear catalog didn't carry: IconButton, CompactButton, ButtonGroup, AppCard, Icon, and theme specimens (Typography, ColorScheme). Paired content is matched across systems (labels, icons) so the comparison is apples-to-apples.

3. **`matches.html` cross-system page** (`scripts/design-artifacts/`) — a new generated page on each delivery branch that pairs every component with its declared parallel, side by side. The local render is baked in; the other system's render is fetched from its own `design-artifacts/<other>` branch at view time (same `raw.githubusercontent` origin the images already use), so the page is self-contained at build time and degrades to name + link offline. Wired into the generator (via `compareWith`), linked from `index.html` + README.

## Test plan

- [x] `:samples:design-catalog-remote-m3:compileDebugKotlin` — green (built against the real alpha06 API via its `-sources.jar`).
- [x] `:samples:design-catalog-remote-m3:composePreviewRenderAll` — **19/19 render**, transparent RGBA.
- [x] `:samples:design-catalog-wear-m3:composePreviewRenderAll` — green, 7 new stickers render.
- [x] `node --test scripts/design-artifacts/` — 23 pass (8 new for the cross-system page: pairing buckets, unpaired flag, row wiring, resolver + other-branch URL, inventories, counts).
- [x] `ktfmtFormat` clean on both modules.

## Visual evidence

Everything above was rendered locally through the real pipeline (Robolectric + the Remote Compose player) and the `matches.html` page was screenshotted with both columns populated from the local PNGs — shared with the author in the authoring session. Because the sample renders live under gitignored `build/` (not committed) and images can't be uploaded to a PR body from this environment, GitHub-renderable embeds aren't available here; the CI visual-diff bot will render the new `@Preview` stickers on this PR, and the `design-artifacts.yml` workflow publishes the live `matches.html` on the `design-artifacts/remote-m3` branch.

_Generated by [Claude Code]_

---
_Generated by [Claude Code](https://claude.ai/code/session_017Sc7gvWJ6CvwTARwpBJrUa)_