### PR TITLE
fix(remotecompose): track compose-remote alpha14 RemoteDensity.from signature

### DIFF
--- a/data/remotecompose/connector/src/main/kotlin/ee/schimke/composeai/daemon/RemoteOverridablePreview.kt
+++ b/data/remotecompose/connector/src/main/kotlin/ee/schimke/composeai/daemon/RemoteOverridablePreview.kt
@@ -94,7 +94,7 @@ fun RemoteOverridablePreview(
           captureSingleRemoteDocument(
               context,
               displayInfo,
-              RemoteDensity.from(displayInfo, context),
+              RemoteDensity.from(displayInfo),
               LayoutDirection.Ltr,
               profile = profile,
               content = content,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -143,9 +143,11 @@ horologist = "0.7.15"
 #    `captureSingleRemoteDocument` now takes `RemoteCreationDisplayInfo` +
 #    `RemoteDensity` + `LayoutDirection`; the `RemotePreview` composable became
 #    `RemoteContentPreview`), so the pair now tracks the latest
-#    verified-together alpha.
-compose-remote = "1.0.0-alpha13"
-wear-compose-remote = "1.0.0-alpha06"
+#    verified-together alpha. alpha14 / alpha07 is the next such pair:
+#    `RemoteDensity.from` dropped its trailing `Context` arg and now derives
+#    density solely from the `RemoteCreationDisplayInfo` it's handed.
+compose-remote = "1.0.0-alpha14"
+wear-compose-remote = "1.0.0-alpha07"
 # Pre-release compose-ui artifacts used by `:samples:remotecompose`, which
 # deliberately diverges from `compose-bom-stable` (1.10.x) to track what
 # wear-compose-remote-material3 alpha pulls in transitively — compose 1.11.0+


### PR DESCRIPTION
## Summary

The `androidx.compose.remote:*` alpha14 bump changed `RemoteDensity.from`: it dropped its trailing `Context` argument and now derives density solely from the `RemoteCreationDisplayInfo` it's handed. That broke `:data-remotecompose:connector` compilation:

```
e: RemoteOverridablePreview.kt:97:47 Too many arguments for
   'fun from(creationDisplayInfo: RemoteCreationDisplayInfo): RemoteDensity'.
```

(surfaced under the renovate `gradle-minorpatch` bump, PR #2457).

This lands the source migration together with the dependency bump, so `main` compiles against the new API:

- Bump the **verified-together pair** `compose-remote` alpha13 → **alpha14** and `wear-compose-remote` alpha06 → **alpha07** in `gradle/libs.versions.toml`. The catalog comment already documents that these two must move together — bumping only `compose-remote` reintroduces the `NoClassDefFoundError` in `RemoteButtonImpl` at render time.
- Drop the now-invalid `context` argument from the `RemoteDensity.from(displayInfo, context)` call in `RemoteOverridablePreview`. Density comes from `RemoteCreationDisplayInfo.densityDpi`, which is already populated from `displayMetrics`, so there is no behavioural change to the captured document.

`RemoteOverridablePreview.kt` is the only source usage of `RemoteDensity` / `captureSingleRemoteDocument` in the tree, so this is the complete migration surface for the `from` change.

## Test plan

- [ ] CI Kotlin compile (`:data-remotecompose:connector` + dependents) — the failing task that motivated this change.
- [ ] CI visual-diff bot on the remotecompose previews. This is a build-compatibility change with **no intended visual delta** (same display info → same density → same captured RC document); the diff bot's render is the verification, since the Android render pipeline (SDK + alpha14 artifacts) isn't reachable in the authoring container here.

_Generated by [Claude Code](https://claude.ai/code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_018Swf7Xn1EUcrnNzVwYdMcm)_