### PR TITLE
feat(deploy): default the preview container to unbounded memory so the live-seat budget scales to the box

### DIFF
--- a/deploy/image/docker-compose.yml
+++ b/deploy/image/docker-compose.yml
@@ -67,8 +67,15 @@ services:
     #   - ./producers.json:/trust/producers.json:ro
     expose:
       - "8080"
-    # The baked warm cache makes renders incremental; this just caps a render storm.
-    mem_limit: 4g
+    # Container memory limit. Default UNBOUNDED (0 = no cgroup cap) so the box's full RAM is
+    # available and the live-seat budget auto-sizes to it: the entrypoint reads the container's
+    # memory limit and, finding none, falls back to physical RAM (~1 GB reserved for the host,
+    # ~1.2 GB per live-seat permit, clamped [2, 8]). So a bigger dedicated box scales on its own —
+    # redeploy and it uses the whole machine, no compose edit. Admission control (the live-seat
+    # budget + the per-render concurrency limiter) is the memory guard here, not a hard cgroup kill.
+    # Set PREVIEW_MEM_LIMIT in .env (e.g. `PREVIEW_MEM_LIMIT=4g`) to cap it on a shared host, which
+    # also lowers the derived seat budget to match.
+    mem_limit: "${PREVIEW_MEM_LIMIT:-0}"
     # Opt this service in to Watchtower auto-updates. Caddy is opted in too (below)
     # via its baked-config image, so both the server and the reverse-proxy config
     # roll automatically.

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -236,10 +236,15 @@ is refused with WebSocket close `1013` (*Try Again Later*) instead of spawning a
 the OOM killer; `0` is unbounded, and snapshot + Wasm sessions never consume a permit.
 
 **Auto-sizing.** When `SERVE_LIVE_SEATS` is unset, the prebuilt image derives the budget from the
-container's memory limit (reserve ~1 GB for the host + OS, ~1.2 GB per permit, clamped to **[2, 8]**),
-so a bigger box scales up on its own with no compose edit: a 4 GB box gets **2** permits (two
-concurrent CMP sessions, or one Android), an 8 GB box gets **5**. Set `SERVE_LIVE_SEATS` explicitly
-in `.env` (then `docker compose up -d`) to override, or `0` for unbounded.
+container's memory (reserve ~1 GB for the host + OS, ~1.2 GB per permit, clamped to **[2, 8]**), so a
+bigger box scales up on its own with no compose edit: an 8 GB box gets **5** permits, a 4 GB box gets
+**2** (two concurrent CMP sessions, or one Android). The `preview` container is **unbounded by
+default** (`mem_limit: ${PREVIEW_MEM_LIMIT:-0}`), so it uses the box's full RAM and the entrypoint
+falls back to physical RAM when there's no cgroup cap — redeploy onto a larger dedicated box and it
+scales automatically. Admission control (the live-seat budget + the per-render concurrency limiter)
+is the memory guard, rather than a hard cgroup kill. On a **shared** host, set `PREVIEW_MEM_LIMIT` in
+`.env` (e.g. `PREVIEW_MEM_LIMIT=4g`) to cap the container — which also lowers the derived seat budget
+to match. Set `SERVE_LIVE_SEATS` explicitly to override the budget directly, or `0` for unbounded.
 
 ## Endpoints
 


### PR DESCRIPTION
## Summary

Follow-up to #2473 (live-seat auto-sizing). The prebuilt image's `preview` service hardcoded `mem_limit: 4g`, which caps the cgroup the entrypoint reads to derive the live-seat budget. So redeploying onto a bigger box did **not** scale — the container still lived in a 4 GiB cgroup and the budget stayed at 2 until someone hand-edited the compose.

Default the container to **unbounded** memory (`mem_limit: ${PREVIEW_MEM_LIMIT:-0}`, where `0` = no cgroup cap) so it uses the box's full RAM. The entrypoint already handles the no-cap case — with no cgroup limit it falls back to physical RAM (`min(cgroup, physical)`, and the "unlimited" cgroup sentinel / `max` resolves to physical). So a larger **dedicated** box now scales on its own: redeploy and the seat budget follows (8 GB → 5), no compose edit.

Admission control — the live-seat budget plus the per-render concurrency limiter — is the memory guard now, rather than a hard cgroup kill. That's the right trade for a dedicated preview box. A **shared** host can still cap the container by setting `PREVIEW_MEM_LIMIT` in `.env` (e.g. `PREVIEW_MEM_LIMIT=4g`), which also lowers the derived seat budget to match.

No entrypoint change was needed — the physical-RAM fallback landed with #2473.

## Test plan
- `deploy/image/docker-compose.yml` parses as YAML; the `${PREVIEW_MEM_LIMIT:-0}` interpolation resolves to `0` (unbounded) when unset and passes a set value through (e.g. `6g`) verified locally.
- `mem_limit: 0` maps to `HostConfig.Memory=0` → Docker applies no limit (same as `--memory=0`); inside the container `/sys/fs/cgroup/memory.max` then reads `max`, which the entrypoint's detection already treats as "no cgroup cap → use physical RAM" (added in #2473 and covered by that PR's dry-run across 2/4/6/8/16/32 GB).
- No Kotlin touched — config + docs only, so no build/format gate.

Docs updated in `docs/public-preview-server.md` (unbounded-by-default, `PREVIEW_MEM_LIMIT` override, scaling behaviour). Non-visual change, so no render evidence.

_Generated by [Claude Code]_

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jxz9i4SuuxPRt3knZKAPbb)_