### PR TITLE
feat(overrides): make resource strings overridable without an explicit knob

### DIFF
--- a/daemon/desktop/build.gradle.kts
+++ b/daemon/desktop/build.gradle.kts
@@ -79,6 +79,10 @@ dependencies {
   // `renderNow.overrides.namedOverrides` into the `previewOverride*` lookups and produces the
   // `compose/overrides` data product (the preview's declared editable knobs).
   implementation(project(":data-preview-overrides-connector"))
+  // Desktop-only half of the named-override surface: wraps CMP's `LocalResourceReader` so every
+  // `stringResource(...)` lookup becomes an editable `compose/overrides` knob automatically (no
+  // `previewOverrideString(...)` needed) and applies the daemon-seeded replacement.
+  implementation(project(":data-preview-overrides-connector-desktop"))
   // Launcher-widget container-size connector — same module Android consumes. The around-composable
   // wraps the preview body in a sized `Box` matching the clamped whole-cell footprint, driven
   // from `renderNow.overrides.launcherWidget`.

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -723,6 +723,12 @@ internal fun buildDesktopExtensions(
       previewOverrideExtensions =
         listOf(
           PreviewOverridesPreviewOverrideExtension(),
+          // Desktop-only, always-on: wraps CMP's `LocalResourceReader` so every `stringResource(...)`
+          // a preview loads becomes an editable knob on the same `compose/overrides` product — no
+          // `previewOverrideString(...)` needed — and applies the daemon-seeded replacement. Ordered
+          // after the named-override planner so `LocalPreviewOverrideHost` + the seed are already in
+          // place when the resource reader resolves.
+          ResourceOverridePreviewOverrideExtensionDesktop(),
           // Fake wall clock (#1968): plans an extension only when
           // `renderNow.overrides.clockEpochMillis` is set, pinning `LocalClock` to that instant so
           // time-dependent UI renders deterministically. Portable — the same planner is wired into

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -723,10 +723,13 @@ internal fun buildDesktopExtensions(
       previewOverrideExtensions =
         listOf(
           PreviewOverridesPreviewOverrideExtension(),
-          // Desktop-only, always-on: wraps CMP's `LocalResourceReader` so every `stringResource(...)`
+          // Desktop-only, always-on: wraps CMP's `LocalResourceReader` so every
+          // `stringResource(...)`
           // a preview loads becomes an editable knob on the same `compose/overrides` product — no
-          // `previewOverrideString(...)` needed — and applies the daemon-seeded replacement. Ordered
-          // after the named-override planner so `LocalPreviewOverrideHost` + the seed are already in
+          // `previewOverrideString(...)` needed — and applies the daemon-seeded replacement.
+          // Ordered
+          // after the named-override planner so `LocalPreviewOverrideHost` + the seed are already
+          // in
           // place when the resource reader resolves.
           ResourceOverridePreviewOverrideExtensionDesktop(),
           // Fake wall clock (#1968): plans an extension only when

--- a/data/preview-overrides/connector-desktop/build.gradle.kts
+++ b/data/preview-overrides/connector-desktop/build.gradle.kts
@@ -1,0 +1,50 @@
+@file:Suppress("DEPRECATION")
+
+// `:data-preview-overrides-connector-desktop` is the JVM-side counterpart to
+// `:data-preview-overrides-connector`. The portable connector installs `LocalPreviewOverrideHost`
+// and drains the `compose/overrides` product; this desktop connector adds the piece that only the
+// CMP-desktop backend can provide: it wraps `org.jetbrains.compose.resources.LocalResourceReader`
+// so every `stringResource(...)` a preview loads becomes an editable override knob automatically —
+// no `previewOverrideString(...)` needed. A resource lookup already tells us the text that rendered
+// and gives us a stable key to seed a replacement against, so the reader records the knob and
+// substitutes the daemon-seeded value in one pass.
+//
+// CMP Desktop's `stringResource` doesn't walk `LocalContext.resources`, so — exactly like the
+// pseudolocale desktop connector — we intercept at the byte-level reader rather than swapping a
+// `Resources` subclass the way the Android connector does. The recorded knobs ride the same
+// `PreviewOverrideController` (and thus the same `compose/overrides` product) as the explicit
+// `previewOverride*` knobs, so no new data product is introduced here.
+
+plugins {
+  id("composeai.base-conventions")
+  id("composeai.maven-publishing")
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.compose.multiplatform)
+  alias(libs.plugins.compose.compiler)
+}
+
+dependencies {
+  api(project(":daemon:core"))
+  api(project(":data-render-compose"))
+  api(project(":data-preview-overrides-core"))
+  api(project(":data-preview-overrides-runtime"))
+  implementation(libs.jetbrains.compose.runtime)
+  implementation(libs.jetbrains.compose.ui)
+  // `org.jetbrains.compose.resources.LocalResourceReader` — the byte-level interceptor we wrap so a
+  // `stringResource(...)` lookup records an editable knob and returns the seeded replacement. The
+  // `internal` env-swap path isn't reachable from outside the resources module at CMP 1.10.x, so
+  // this published handle is the one that works (same reasoning as the pseudolocale connector).
+  implementation(libs.jetbrains.compose.components.resources)
+
+  testImplementation(libs.junit)
+}
+
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "data-preview-overrides-connector-desktop",
+    displayName = "Compose Preview - Named Override Data Product Connector (Desktop)",
+    description =
+      "Daemon-side connector for Compose Multiplatform Desktop that makes every stringResource(...) lookup an editable preview-override knob: wraps LocalResourceReader to record the resource string as a compose/overrides declaration and substitute the daemon-seeded replacement, without requiring an explicit previewOverride* call.",
+  )
+  inceptionYear.set("2026")
+}

--- a/data/preview-overrides/connector-desktop/src/main/kotlin/ee/schimke/composeai/daemon/RecordingResourceReader.kt
+++ b/data/preview-overrides/connector-desktop/src/main/kotlin/ee/schimke/composeai/daemon/RecordingResourceReader.kt
@@ -7,9 +7,10 @@ import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.ResourceReader
 
 /**
- * Resolves a resource-loaded string to its effective (possibly daemon-seeded) text and records it as
- * an editable knob. The production sink is backed by `PreviewOverrideController.resolveResourceString`;
- * tests supply a fake so [RecordingResourceReader] can be exercised without the controller.
+ * Resolves a resource-loaded string to its effective (possibly daemon-seeded) text and records it
+ * as an editable knob. The production sink is backed by
+ * `PreviewOverrideController.resolveResourceString`; tests supply a fake so
+ * [RecordingResourceReader] can be exercised without the controller.
  */
 @FunctionalInterface
 fun interface ResourceOverrideSink {
@@ -27,20 +28,20 @@ fun interface ResourceOverrideSink {
  * [ResourceOverrideSink] — which records it as a `compose/overrides` knob and returns the
  * daemon-seeded replacement (or the original when unseeded) — and re-encodes the effective value.
  *
- * **Why the reader, not an explicit call.** CMP resolves `stringResource(...)` through this byte-level
- * reader; intercepting here means the author doesn't have to wrap the lookup in
+ * **Why the reader, not an explicit call.** CMP resolves `stringResource(...)` through this
+ * byte-level reader; intercepting here means the author doesn't have to wrap the lookup in
  * `previewOverrideString(...)`. A resource read already tells us the exact text that rendered, and
  * `(path, offset)` gives a stable key to seed a replacement against.
  *
  * **Record format** (same as `PseudolocalizingResourceReader`): UTF-8 bytes split on `|`; the last
  * segment is the data. `string` — one Base64 payload; `string-array` — comma-separated Base64;
- * `plurals` — comma-separated `<category>:<Base64>`. Any record without a `|` (fonts, drawables, raw
- * bytes) or of an unrecognised type passes through byte-for-byte.
+ * `plurals` — comma-separated `<category>:<Base64>`. Any record without a `|` (fonts, drawables,
+ * raw bytes) or of an unrecognised type passes through byte-for-byte.
  *
- * **Key.** `res:<path>#<offset>` for a scalar string; the array index or plural category is appended
- * (`…#<offset>[<i>]`, `…#<offset>:<category>`) so each editable slot round-trips independently. The
- * key is minted identically here at record time and at substitution time (both inside this
- * `readPart`), keeping the `namedOverrides` seed round-trip intact.
+ * **Key.** `res:<path>#<offset>` for a scalar string; the array index or plural category is
+ * appended (`…#<offset>[<i>]`, `…#<offset>:<category>`) so each editable slot round-trips
+ * independently. The key is minted identically here at record time and at substitution time (both
+ * inside this `readPart`), keeping the `namedOverrides` seed round-trip intact.
  */
 @OptIn(ExperimentalResourceApi::class, ExperimentalEncodingApi::class)
 class RecordingResourceReader(
@@ -82,27 +83,25 @@ class RecordingResourceReader(
 
   private fun transformArray(baseKey: String, data: String): String? {
     val parts = data.split(",")
-    val encoded =
-      parts.mapIndexed { index, item ->
-        val decoded = decodeOrNull(item) ?: return null
-        val effective = sink.resolve("$baseKey[$index]", decoded)
-        Base64.encode(effective.encodeToByteArray())
-      }
+    val encoded = parts.mapIndexed { index, item ->
+      val decoded = decodeOrNull(item) ?: return null
+      val effective = sink.resolve("$baseKey[$index]", decoded)
+      Base64.encode(effective.encodeToByteArray())
+    }
     return encoded.joinToString(",")
   }
 
   private fun transformPlurals(baseKey: String, data: String): String? {
     val parts = data.split(",")
-    val encoded =
-      parts.map { item ->
-        val colon = item.indexOf(':')
-        if (colon < 0) return null
-        val category = item.substring(0, colon)
-        val payload = item.substring(colon + 1)
-        val decoded = decodeOrNull(payload) ?: return null
-        val effective = sink.resolve("$baseKey:$category", decoded)
-        "$category:${Base64.encode(effective.encodeToByteArray())}"
-      }
+    val encoded = parts.map { item ->
+      val colon = item.indexOf(':')
+      if (colon < 0) return null
+      val category = item.substring(0, colon)
+      val payload = item.substring(colon + 1)
+      val decoded = decodeOrNull(payload) ?: return null
+      val effective = sink.resolve("$baseKey:$category", decoded)
+      "$category:${Base64.encode(effective.encodeToByteArray())}"
+    }
     return encoded.joinToString(",")
   }
 

--- a/data/preview-overrides/connector-desktop/src/main/kotlin/ee/schimke/composeai/daemon/RecordingResourceReader.kt
+++ b/data/preview-overrides/connector-desktop/src/main/kotlin/ee/schimke/composeai/daemon/RecordingResourceReader.kt
@@ -1,0 +1,115 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.data.overrides.RESOURCE_OVERRIDE_KEY_PREFIX
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.ResourceReader
+
+/**
+ * Resolves a resource-loaded string to its effective (possibly daemon-seeded) text and records it as
+ * an editable knob. The production sink is backed by `PreviewOverrideController.resolveResourceString`;
+ * tests supply a fake so [RecordingResourceReader] can be exercised without the controller.
+ */
+@FunctionalInterface
+fun interface ResourceOverrideSink {
+  /**
+   * Record the resource string [default] as an editable knob under [key] and return the effective
+   * value — the seeded replacement bound to [key], or [default] when none is bound.
+   */
+  fun resolve(key: String, default: String): String
+}
+
+/**
+ * [ResourceReader] decorator that makes every string a preview loads from resources editable, the
+ * counterpart to the pseudolocale connector's `PseudolocalizingResourceReader`. Where that one
+ * rewrites the text to its pseudolocalised form, this one hands each decoded string to a
+ * [ResourceOverrideSink] — which records it as a `compose/overrides` knob and returns the
+ * daemon-seeded replacement (or the original when unseeded) — and re-encodes the effective value.
+ *
+ * **Why the reader, not an explicit call.** CMP resolves `stringResource(...)` through this byte-level
+ * reader; intercepting here means the author doesn't have to wrap the lookup in
+ * `previewOverrideString(...)`. A resource read already tells us the exact text that rendered, and
+ * `(path, offset)` gives a stable key to seed a replacement against.
+ *
+ * **Record format** (same as `PseudolocalizingResourceReader`): UTF-8 bytes split on `|`; the last
+ * segment is the data. `string` — one Base64 payload; `string-array` — comma-separated Base64;
+ * `plurals` — comma-separated `<category>:<Base64>`. Any record without a `|` (fonts, drawables, raw
+ * bytes) or of an unrecognised type passes through byte-for-byte.
+ *
+ * **Key.** `res:<path>#<offset>` for a scalar string; the array index or plural category is appended
+ * (`…#<offset>[<i>]`, `…#<offset>:<category>`) so each editable slot round-trips independently. The
+ * key is minted identically here at record time and at substitution time (both inside this
+ * `readPart`), keeping the `namedOverrides` seed round-trip intact.
+ */
+@OptIn(ExperimentalResourceApi::class, ExperimentalEncodingApi::class)
+class RecordingResourceReader(
+  private val delegate: ResourceReader,
+  private val sink: ResourceOverrideSink,
+) : ResourceReader {
+
+  override suspend fun read(path: String): ByteArray = delegate.read(path)
+
+  override suspend fun readPart(path: String, offset: Long, size: Long): ByteArray {
+    val raw = delegate.readPart(path, offset, size)
+    val record = raw.decodeToString()
+    val pipe = record.indexOf('|')
+    // No `|` means this isn't a string record (e.g. raw image bytes). Pass through unchanged.
+    if (pipe < 0) return raw
+    val type = record.substring(0, pipe)
+    val lastPipe = record.lastIndexOf('|')
+    val prefix = record.substring(0, lastPipe + 1)
+    val data = record.substring(lastPipe + 1)
+    val baseKey = "$RESOURCE_OVERRIDE_KEY_PREFIX$path#$offset"
+    val transformedData =
+      when (type) {
+        "string" -> transformSingle(baseKey, data)
+        "string-array" -> transformArray(baseKey, data)
+        "plurals" -> transformPlurals(baseKey, data)
+        // Unrecognised type — leave it untouched rather than risk mangling a non-string payload.
+        else -> null
+      } ?: return raw
+    return (prefix + transformedData).encodeToByteArray()
+  }
+
+  override fun getUri(path: String): String = delegate.getUri(path)
+
+  private fun transformSingle(key: String, data: String): String? {
+    val decoded = decodeOrNull(data) ?: return null
+    val effective = sink.resolve(key, decoded)
+    return Base64.encode(effective.encodeToByteArray())
+  }
+
+  private fun transformArray(baseKey: String, data: String): String? {
+    val parts = data.split(",")
+    val encoded =
+      parts.mapIndexed { index, item ->
+        val decoded = decodeOrNull(item) ?: return null
+        val effective = sink.resolve("$baseKey[$index]", decoded)
+        Base64.encode(effective.encodeToByteArray())
+      }
+    return encoded.joinToString(",")
+  }
+
+  private fun transformPlurals(baseKey: String, data: String): String? {
+    val parts = data.split(",")
+    val encoded =
+      parts.map { item ->
+        val colon = item.indexOf(':')
+        if (colon < 0) return null
+        val category = item.substring(0, colon)
+        val payload = item.substring(colon + 1)
+        val decoded = decodeOrNull(payload) ?: return null
+        val effective = sink.resolve("$baseKey:$category", decoded)
+        "$category:${Base64.encode(effective.encodeToByteArray())}"
+      }
+    return encoded.joinToString(",")
+  }
+
+  private fun decodeOrNull(base64: String): String? =
+    try {
+      Base64.decode(base64).decodeToString()
+    } catch (_: IllegalArgumentException) {
+      null
+    }
+}

--- a/data/preview-overrides/connector-desktop/src/main/kotlin/ee/schimke/composeai/daemon/ResourceOverrideExtensionDesktop.kt
+++ b/data/preview-overrides/connector-desktop/src/main/kotlin/ee/schimke/composeai/daemon/ResourceOverrideExtensionDesktop.kt
@@ -1,0 +1,81 @@
+package ee.schimke.composeai.daemon
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.data.render.extensions.DataExtension
+import ee.schimke.composeai.data.render.extensions.DataExtensionConstraints
+import ee.schimke.composeai.data.render.extensions.DataExtensionId
+import ee.schimke.composeai.data.render.extensions.DataExtensionPhase
+import ee.schimke.composeai.data.render.extensions.PlannedDataExtension
+import ee.schimke.composeai.data.render.extensions.compose.AroundComposableExtension
+import ee.schimke.composeai.overrides.PreviewOverrideController
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.LocalResourceReader
+
+/**
+ * Always-on desktop extension that makes every `org.jetbrains.compose.resources.stringResource(...)`
+ * a preview loads an editable override knob, without the author writing `previewOverrideString(...)`.
+ *
+ * It wraps [LocalResourceReader] with a [RecordingResourceReader] whose sink records each resolved
+ * string as a `compose/overrides` declaration on the process-static [PreviewOverrideController] and
+ * substitutes the daemon-seeded replacement (the seed rides the same `namedOverrides` map the
+ * portable [PreviewOverridesOverrideExtension] already installs, keyed by the reader's `res:` key).
+ * Because the recorded knobs live on the same controller and product, this connector introduces no
+ * new data product — it just widens what shows up under `compose/overrides`.
+ *
+ * **Per-render reset + cache clear.** `remember(this)` runs its block once per render (the planner
+ * mints a fresh instance per render, mirroring the pseudolocale desktop extension), so on entry it:
+ * - clears CMP's process-wide string-item cache ([ResourceOverrideStringCache]) so the wrapped
+ *   reader is actually re-invoked instead of served a value a prior render cached — otherwise the
+ *   substitution silently no-ops on a warm JVM; and
+ * - drops the previous render's resource knobs ([PreviewOverrideController.resetResourceDeclarations])
+ *   so this render re-discovers its own set. This is deliberately separate from the explicit-knob
+ *   `clearDeclarations` the named-override extension runs post-composition: the resource reader
+ *   records eagerly while resources load (an async coroutine dispatcher on desktop), so folding the
+ *   two lifecycles together would let the explicit-knob clear erase a resource knob mid-render.
+ *
+ * Runs in [DataExtensionPhase.OuterEnvironment] so [LocalResourceReader] is swapped before user
+ * preview content reaches a `stringResource(...)` call, alongside the named-override host.
+ */
+@OptIn(ExperimentalResourceApi::class)
+class ResourceOverrideExtensionDesktop :
+  AroundComposableExtension(
+    id = ID,
+    constraints = DataExtensionConstraints(phase = DataExtensionPhase.OuterEnvironment),
+  ) {
+
+  private val sink =
+    ResourceOverrideSink { key, default ->
+      PreviewOverrideController.resolveResourceString(key, default, label = default)
+    }
+
+  @Composable
+  override fun AroundComposable(content: @Composable () -> Unit) {
+    remember(this) {
+      ResourceOverrideStringCache.clearBestEffort()
+      PreviewOverrideController.resetResourceDeclarations()
+    }
+    val baseReader = LocalResourceReader.current
+    val wrappedReader = remember(baseReader) { RecordingResourceReader(baseReader, sink) }
+    CompositionLocalProvider(LocalResourceReader provides wrappedReader) { content() }
+  }
+
+  companion object {
+    val ID: DataExtensionId = DataExtensionId("data-resource-overrides")
+  }
+}
+
+/**
+ * Always-on planner for [ResourceOverrideExtensionDesktop]. Returns a fresh extension on every render
+ * (including no-override renders — see [AlwaysOnPreviewOverrideExtension]) so the resource reader is
+ * installed unconditionally; the actual replacement values ride the named-override seed the portable
+ * connector already threads through, so this planner ignores the request bag.
+ */
+class ResourceOverridePreviewOverrideExtensionDesktop :
+  DataExtension<PreviewOverrides>, AlwaysOnPreviewOverrideExtension {
+  override val id: DataExtensionId = ResourceOverrideExtensionDesktop.ID
+
+  override fun plan(request: PreviewOverrides): PlannedDataExtension = ResourceOverrideExtensionDesktop()
+}

--- a/data/preview-overrides/connector-desktop/src/main/kotlin/ee/schimke/composeai/daemon/ResourceOverrideExtensionDesktop.kt
+++ b/data/preview-overrides/connector-desktop/src/main/kotlin/ee/schimke/composeai/daemon/ResourceOverrideExtensionDesktop.kt
@@ -15,8 +15,9 @@ import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.LocalResourceReader
 
 /**
- * Always-on desktop extension that makes every `org.jetbrains.compose.resources.stringResource(...)`
- * a preview loads an editable override knob, without the author writing `previewOverrideString(...)`.
+ * Always-on desktop extension that makes every
+ * `org.jetbrains.compose.resources.stringResource(...)` a preview loads an editable override knob,
+ * without the author writing `previewOverrideString(...)`.
  *
  * It wraps [LocalResourceReader] with a [RecordingResourceReader] whose sink records each resolved
  * string as a `compose/overrides` declaration on the process-static [PreviewOverrideController] and
@@ -25,16 +26,28 @@ import org.jetbrains.compose.resources.LocalResourceReader
  * Because the recorded knobs live on the same controller and product, this connector introduces no
  * new data product — it just widens what shows up under `compose/overrides`.
  *
- * **Per-render reset + cache clear.** `remember(this)` runs its block once per render (the planner
- * mints a fresh instance per render, mirroring the pseudolocale desktop extension), so on entry it:
- * - clears CMP's process-wide string-item cache ([ResourceOverrideStringCache]) so the wrapped
- *   reader is actually re-invoked instead of served a value a prior render cached — otherwise the
- *   substitution silently no-ops on a warm JVM; and
- * - drops the previous render's resource knobs ([PreviewOverrideController.resetResourceDeclarations])
- *   so this render re-discovers its own set. This is deliberately separate from the explicit-knob
- *   `clearDeclarations` the named-override extension runs post-composition: the resource reader
- *   records eagerly while resources load (an async coroutine dispatcher on desktop), so folding the
- *   two lifecycles together would let the explicit-knob clear erase a resource knob mid-render.
+ * **Per-render reset.** `remember(this)` runs once per render (the planner mints a fresh instance
+ * per render, mirroring the pseudolocale desktop extension) and drops the previous render's
+ * resource knobs ([PreviewOverrideController.resetResourceDeclarations]) so this render
+ * re-discovers its own set. This is deliberately separate from the explicit-knob
+ * `clearDeclarations` the named-override extension runs post-composition: the resource reader
+ * records eagerly while resources load (an async coroutine dispatcher on desktop), so folding the
+ * two lifecycles together would let the explicit-knob clear erase a resource knob mid-render.
+ *
+ * **Cache clear keyed on the seed.** CMP keeps a process-wide string-item cache
+ * ([ResourceOverrideStringCache]) that short-circuits the wrapped reader once a key is warm, so the
+ * clear can't run just once at render start: the seed for a `res:` key is installed by the sibling
+ * `PreviewOverridesOverrideExtension` from a `DisposableEffect`, which runs *after* the first
+ * composition. If we only cleared on entry, the first `stringResource` read would happen before the
+ * seed lands — recording/returning the default and warming the cache with it — and the
+ * recomposition that `set(seed)` triggers would hit that cached default instead of re-invoking this
+ * reader, so editing an auto-discovered string would never affect the render until a later clear /
+ * JVM restart (Codex review on #2477). Instead we read [PreviewOverrideController.seededValues] as
+ * snapshot state and clear the cache in a `remember(seed)`: when the seed changes, this composable
+ * recomposes and clears the cache *before* `content()` re-reads, so the next `stringResource`
+ * misses the cache and the reader resolves against the now-present seed. Unlike the resource
+ * reader, the explicit `previewOverride*` host reads the controller's seeded state directly during
+ * composition, so it has no CMP cache to invalidate.
  *
  * Runs in [DataExtensionPhase.OuterEnvironment] so [LocalResourceReader] is swapped before user
  * preview content reaches a `stringResource(...)` call, alongside the named-override host.
@@ -46,17 +59,18 @@ class ResourceOverrideExtensionDesktop :
     constraints = DataExtensionConstraints(phase = DataExtensionPhase.OuterEnvironment),
   ) {
 
-  private val sink =
-    ResourceOverrideSink { key, default ->
-      PreviewOverrideController.resolveResourceString(key, default, label = default)
-    }
+  private val sink = ResourceOverrideSink { key, default ->
+    PreviewOverrideController.resolveResourceString(key, default, label = default)
+  }
 
   @Composable
   override fun AroundComposable(content: @Composable () -> Unit) {
-    remember(this) {
-      ResourceOverrideStringCache.clearBestEffort()
-      PreviewOverrideController.resetResourceDeclarations()
-    }
+    remember(this) { PreviewOverrideController.resetResourceDeclarations() }
+    // Snapshot read: recomposes this scope when the sibling override extension seeds
+    // `namedOverrides`
+    // (or a later edit changes it), so the cache clear below re-runs before `content()` re-reads.
+    val seed = PreviewOverrideController.seededValues.value
+    remember(seed) { ResourceOverrideStringCache.clearBestEffort() }
     val baseReader = LocalResourceReader.current
     val wrappedReader = remember(baseReader) { RecordingResourceReader(baseReader, sink) }
     CompositionLocalProvider(LocalResourceReader provides wrappedReader) { content() }
@@ -68,14 +82,15 @@ class ResourceOverrideExtensionDesktop :
 }
 
 /**
- * Always-on planner for [ResourceOverrideExtensionDesktop]. Returns a fresh extension on every render
- * (including no-override renders — see [AlwaysOnPreviewOverrideExtension]) so the resource reader is
- * installed unconditionally; the actual replacement values ride the named-override seed the portable
- * connector already threads through, so this planner ignores the request bag.
+ * Always-on planner for [ResourceOverrideExtensionDesktop]. Returns a fresh extension on every
+ * render (including no-override renders — see [AlwaysOnPreviewOverrideExtension]) so the resource
+ * reader is installed unconditionally; the actual replacement values ride the named-override seed
+ * the portable connector already threads through, so this planner ignores the request bag.
  */
 class ResourceOverridePreviewOverrideExtensionDesktop :
   DataExtension<PreviewOverrides>, AlwaysOnPreviewOverrideExtension {
   override val id: DataExtensionId = ResourceOverrideExtensionDesktop.ID
 
-  override fun plan(request: PreviewOverrides): PlannedDataExtension = ResourceOverrideExtensionDesktop()
+  override fun plan(request: PreviewOverrides): PlannedDataExtension =
+    ResourceOverrideExtensionDesktop()
 }

--- a/data/preview-overrides/connector-desktop/src/main/kotlin/ee/schimke/composeai/daemon/ResourceOverrideStringCache.kt
+++ b/data/preview-overrides/connector-desktop/src/main/kotlin/ee/schimke/composeai/daemon/ResourceOverrideStringCache.kt
@@ -1,0 +1,50 @@
+package ee.schimke.composeai.daemon
+
+/**
+ * Reflective shim that clears Compose Multiplatform Resources' process-wide string-item cache so the
+ * wrapped [org.jetbrains.compose.resources.LocalResourceReader] is actually re-invoked for a
+ * `stringResource(...)` lookup, rather than served the value a prior render already cached.
+ *
+ * **Why a second copy.** The pseudolocale desktop connector has the same need and its own
+ * `PseudolocaleResourceCache`; that one is `internal` to `:data-pseudolocale-connector-desktop`, and
+ * the resource-override feature is intentionally decoupled from pseudolocale, so this connector
+ * carries its own equivalent rather than depending on that module. Both reach the same CMP internal
+ * (`StringResourcesUtilsKt.stringItemsCache`, an `AsyncCache<String, StringItem>` keyed by
+ * `path/offset-size`) via reflection; if a future CMP version reshapes it, both degrade the same way
+ * (the reader stops being re-invoked, and an already-cached string is returned unmodified).
+ *
+ * Clearing on every render is required because [DesktopHost] reuses the JVM / classloader across
+ * requests: without it, the first render of a given string in the JVM warms the cache and every
+ * later render — including one carrying a fresh `namedOverrides` seed — reads the cached original,
+ * so the substitution silently no-ops.
+ */
+internal object ResourceOverrideStringCache {
+
+  private const val UTILS_CLASS = "org.jetbrains.compose.resources.StringResourcesUtilsKt"
+  private const val CACHE_FIELD = "stringItemsCache"
+  private const val ASYNC_CACHE_MAP_FIELD = "cache"
+
+  /**
+   * Clear the cache. Returns `true` on success, `false` if reflection couldn't find it (CMP version
+   * drift). Never throws; safe to call from any thread (the underlying `Map.clear()` is a single
+   * instruction and the renderer issues renders sequentially).
+   */
+  fun clearBestEffort(): Boolean {
+    return try {
+      val utilsClass = Class.forName(UTILS_CLASS)
+      val cacheField = utilsClass.getDeclaredField(CACHE_FIELD).apply { isAccessible = true }
+      val asyncCache = cacheField.get(null) ?: return false
+      val mapField =
+        asyncCache.javaClass.getDeclaredField(ASYNC_CACHE_MAP_FIELD).apply { isAccessible = true }
+      val map = mapField.get(asyncCache) as? MutableMap<*, *> ?: return false
+      map.clear()
+      true
+    } catch (_: ReflectiveOperationException) {
+      false
+    } catch (_: ClassCastException) {
+      false
+    } catch (_: SecurityException) {
+      false
+    }
+  }
+}

--- a/data/preview-overrides/connector-desktop/src/main/kotlin/ee/schimke/composeai/daemon/ResourceOverrideStringCache.kt
+++ b/data/preview-overrides/connector-desktop/src/main/kotlin/ee/schimke/composeai/daemon/ResourceOverrideStringCache.kt
@@ -1,17 +1,17 @@
 package ee.schimke.composeai.daemon
 
 /**
- * Reflective shim that clears Compose Multiplatform Resources' process-wide string-item cache so the
- * wrapped [org.jetbrains.compose.resources.LocalResourceReader] is actually re-invoked for a
+ * Reflective shim that clears Compose Multiplatform Resources' process-wide string-item cache so
+ * the wrapped [org.jetbrains.compose.resources.LocalResourceReader] is actually re-invoked for a
  * `stringResource(...)` lookup, rather than served the value a prior render already cached.
  *
  * **Why a second copy.** The pseudolocale desktop connector has the same need and its own
- * `PseudolocaleResourceCache`; that one is `internal` to `:data-pseudolocale-connector-desktop`, and
- * the resource-override feature is intentionally decoupled from pseudolocale, so this connector
+ * `PseudolocaleResourceCache`; that one is `internal` to `:data-pseudolocale-connector-desktop`,
+ * and the resource-override feature is intentionally decoupled from pseudolocale, so this connector
  * carries its own equivalent rather than depending on that module. Both reach the same CMP internal
  * (`StringResourcesUtilsKt.stringItemsCache`, an `AsyncCache<String, StringItem>` keyed by
- * `path/offset-size`) via reflection; if a future CMP version reshapes it, both degrade the same way
- * (the reader stops being re-invoked, and an already-cached string is returned unmodified).
+ * `path/offset-size`) via reflection; if a future CMP version reshapes it, both degrade the same
+ * way (the reader stops being re-invoked, and an already-cached string is returned unmodified).
  *
  * Clearing on every render is required because [DesktopHost] reuses the JVM / classloader across
  * requests: without it, the first render of a given string in the JVM warms the cache and every

--- a/data/preview-overrides/connector-desktop/src/test/kotlin/ee/schimke/composeai/daemon/RecordingResourceReaderTest.kt
+++ b/data/preview-overrides/connector-desktop/src/test/kotlin/ee/schimke/composeai/daemon/RecordingResourceReaderTest.kt
@@ -1,0 +1,180 @@
+package ee.schimke.composeai.daemon
+
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+import kotlinx.coroutines.runBlocking
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.ResourceReader
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Verifies the desktop connector turns `stringResource(...)` lookups into editable override knobs at
+ * the `org.jetbrains.compose.resources.ResourceReader` byte level — the auto-resource counterpart to
+ * `PseudolocalizingResourceReaderTest`. Uses a fake [ResourceOverrideSink] to observe the (key,
+ * default) the reader records and to inject a seeded replacement, without standing up the controller.
+ */
+@OptIn(ExperimentalResourceApi::class, ExperimentalEncodingApi::class)
+class RecordingResourceReaderTest {
+
+  @Test
+  fun `string record records a res-keyed knob and re-encodes the effective value`() {
+    val (path, offset, size, raw) = stringRecord("Hello")
+    val seen = mutableListOf<Pair<String, String>>()
+    val reader =
+      RecordingResourceReader(stubReader(path, raw)) { key, default ->
+        seen += key to default
+        default // no seed → original text
+      }
+
+    val out = runBlocking { reader.readPart(path, offset, size) }
+
+    assertEquals(listOf("res:$path#$offset" to "Hello"), seen)
+    assertEquals("Hello", decodeStringRecord(out))
+  }
+
+  @Test
+  fun `a seeded replacement is written back into the record`() {
+    val (path, offset, size, raw) = stringRecord("Hello")
+    val reader =
+      RecordingResourceReader(stubReader(path, raw)) { _, _ -> "Bonjour" }
+
+    val out = runBlocking { reader.readPart(path, offset, size) }
+
+    assertEquals("Bonjour", decodeStringRecord(out))
+  }
+
+  @Test
+  fun `string-array records key and substitute each entry independently`() {
+    val items = listOf("Save", "Cancel", "Retry")
+    val (path, offset, size, raw) = arrayRecord(items)
+    val seen = mutableListOf<Pair<String, String>>()
+    val reader =
+      RecordingResourceReader(stubReader(path, raw)) { key, default ->
+        seen += key to default
+        if (default == "Cancel") "Dismiss" else default
+      }
+
+    val out = runBlocking { reader.readPart(path, offset, size) }
+    val parts = out.decodeToString().removePrefix("string-array|").split(",")
+    val decoded = parts.map { Base64.decode(it).decodeToString() }
+
+    assertEquals(
+      listOf("res:$path#$offset[0]" to "Save", "res:$path#$offset[1]" to "Cancel", "res:$path#$offset[2]" to "Retry"),
+      seen,
+    )
+    assertEquals(listOf("Save", "Dismiss", "Retry"), decoded)
+  }
+
+  @Test
+  fun `plural records key by category and substitute`() {
+    val plurals = mapOf("one" to "%1\$d item", "other" to "%1\$d items")
+    val (path, offset, size, raw) = pluralRecord(plurals)
+    val seen = mutableListOf<String>()
+    val reader =
+      RecordingResourceReader(stubReader(path, raw)) { key, default ->
+        seen += key
+        if (key.endsWith(":other")) "%1\$d things" else default
+      }
+
+    val out = runBlocking { reader.readPart(path, offset, size) }
+    val data = out.decodeToString().removePrefix("plurals|")
+    val decoded =
+      data.split(",").associate { entry ->
+        entry.substringBefore(':') to Base64.decode(entry.substringAfter(':')).decodeToString()
+      }
+
+    assertTrue(seen.contains("res:$path#$offset:one"))
+    assertTrue(seen.contains("res:$path#$offset:other"))
+    assertEquals("%1\$d item", decoded["one"])
+    assertEquals("%1\$d things", decoded["other"])
+  }
+
+  @Test
+  fun `non-string records pass through untouched and never hit the sink`() {
+    val raw = byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A)
+    var called = false
+    val reader =
+      RecordingResourceReader(stubReader("img.png", raw)) { _, _ ->
+        called = true
+        ""
+      }
+
+    val out = runBlocking { reader.readPart("img.png", 0, raw.size.toLong()) }
+
+    assertArrayEqualsBytes(raw, out)
+    assertTrue("sink must not be consulted for non-string records", !called)
+  }
+
+  @Test
+  fun `read and getUri delegate unchanged`() {
+    val raw = "delegated-bytes".encodeToByteArray()
+    val delegate = stubReader("any", raw, uri = "file:///fake/any")
+    val reader = RecordingResourceReader(delegate) { _, d -> d }
+
+    val read = runBlocking { reader.read("any") }
+    assertArrayEqualsBytes(raw, read)
+    assertSame("file:///fake/any", reader.getUri("any"))
+  }
+
+  // -- helpers --------------------------------------------------------------
+
+  private data class Record(val path: String, val offset: Long, val size: Long, val bytes: ByteArray)
+
+  private fun stringRecord(text: String): Record {
+    val bytes = "string|${Base64.encode(text.encodeToByteArray())}".encodeToByteArray()
+    return Record("strings.cvr", 0, bytes.size.toLong(), bytes)
+  }
+
+  private fun arrayRecord(items: List<String>): Record {
+    val joined = items.joinToString(",") { Base64.encode(it.encodeToByteArray()) }
+    val bytes = "string-array|$joined".encodeToByteArray()
+    return Record("strings.cvr", 0, bytes.size.toLong(), bytes)
+  }
+
+  private fun pluralRecord(items: Map<String, String>): Record {
+    val joined =
+      items.entries.joinToString(",") { (k, v) -> "$k:${Base64.encode(v.encodeToByteArray())}" }
+    val bytes = "plurals|$joined".encodeToByteArray()
+    return Record("strings.cvr", 0, bytes.size.toLong(), bytes)
+  }
+
+  private fun decodeStringRecord(bytes: ByteArray): String {
+    val record = bytes.decodeToString()
+    return Base64.decode(record.substringAfterLast('|')).decodeToString()
+  }
+
+  private fun stubReader(
+    path: String,
+    bytes: ByteArray,
+    uri: String = "file:///fake/$path",
+  ): ResourceReader {
+    val expectedPath = path
+    val resolvedUri = uri
+    return object : ResourceReader {
+      override suspend fun read(path: String): ByteArray {
+        check(path == expectedPath) { "unexpected path $path" }
+        return bytes
+      }
+
+      override suspend fun readPart(path: String, offset: Long, size: Long): ByteArray {
+        check(path == expectedPath) { "unexpected path $path" }
+        return bytes.copyOfRange(offset.toInt(), (offset + size).toInt())
+      }
+
+      override fun getUri(path: String): String {
+        check(path == expectedPath) { "unexpected path $path" }
+        return resolvedUri
+      }
+    }
+  }
+
+  private fun assertArrayEqualsBytes(expected: ByteArray, actual: ByteArray) {
+    assertEquals("byte length", expected.size, actual.size)
+    for (i in expected.indices) {
+      assertEquals("byte at $i", expected[i], actual[i])
+    }
+  }
+}

--- a/data/preview-overrides/connector-desktop/src/test/kotlin/ee/schimke/composeai/daemon/RecordingResourceReaderTest.kt
+++ b/data/preview-overrides/connector-desktop/src/test/kotlin/ee/schimke/composeai/daemon/RecordingResourceReaderTest.kt
@@ -11,10 +11,11 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
- * Verifies the desktop connector turns `stringResource(...)` lookups into editable override knobs at
- * the `org.jetbrains.compose.resources.ResourceReader` byte level — the auto-resource counterpart to
- * `PseudolocalizingResourceReaderTest`. Uses a fake [ResourceOverrideSink] to observe the (key,
- * default) the reader records and to inject a seeded replacement, without standing up the controller.
+ * Verifies the desktop connector turns `stringResource(...)` lookups into editable override knobs
+ * at the `org.jetbrains.compose.resources.ResourceReader` byte level — the auto-resource
+ * counterpart to `PseudolocalizingResourceReaderTest`. Uses a fake [ResourceOverrideSink] to
+ * observe the (key, default) the reader records and to inject a seeded replacement, without
+ * standing up the controller.
  */
 @OptIn(ExperimentalResourceApi::class, ExperimentalEncodingApi::class)
 class RecordingResourceReaderTest {
@@ -38,8 +39,7 @@ class RecordingResourceReaderTest {
   @Test
   fun `a seeded replacement is written back into the record`() {
     val (path, offset, size, raw) = stringRecord("Hello")
-    val reader =
-      RecordingResourceReader(stubReader(path, raw)) { _, _ -> "Bonjour" }
+    val reader = RecordingResourceReader(stubReader(path, raw)) { _, _ -> "Bonjour" }
 
     val out = runBlocking { reader.readPart(path, offset, size) }
 
@@ -62,7 +62,11 @@ class RecordingResourceReaderTest {
     val decoded = parts.map { Base64.decode(it).decodeToString() }
 
     assertEquals(
-      listOf("res:$path#$offset[0]" to "Save", "res:$path#$offset[1]" to "Cancel", "res:$path#$offset[2]" to "Retry"),
+      listOf(
+        "res:$path#$offset[0]" to "Save",
+        "res:$path#$offset[1]" to "Cancel",
+        "res:$path#$offset[2]" to "Retry",
+      ),
       seen,
     )
     assertEquals(listOf("Save", "Dismiss", "Retry"), decoded)
@@ -121,7 +125,12 @@ class RecordingResourceReaderTest {
 
   // -- helpers --------------------------------------------------------------
 
-  private data class Record(val path: String, val offset: Long, val size: Long, val bytes: ByteArray)
+  private data class Record(
+    val path: String,
+    val offset: Long,
+    val size: Long,
+    val bytes: ByteArray,
+  )
 
   private fun stringRecord(text: String): Record {
     val bytes = "string|${Base64.encode(text.encodeToByteArray())}".encodeToByteArray()

--- a/data/preview-overrides/connector/src/main/kotlin/ee/schimke/composeai/daemon/PreviewOverridesDataProduct.kt
+++ b/data/preview-overrides/connector/src/main/kotlin/ee/schimke/composeai/daemon/PreviewOverridesDataProduct.kt
@@ -11,8 +11,8 @@ import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.data.overrides.PreviewOverrideDeclaration
 import ee.schimke.composeai.data.overrides.PreviewOverrideValue
 import ee.schimke.composeai.data.overrides.PreviewOverridesPayload
-import ee.schimke.composeai.data.overrides.dedupeResourceOverrideDeclarations
 import ee.schimke.composeai.data.overrides.PreviewOverridesProduct
+import ee.schimke.composeai.data.overrides.dedupeResourceOverrideDeclarations
 import ee.schimke.composeai.data.render.PreviewContext
 import ee.schimke.composeai.data.render.extensions.DataExtension
 import ee.schimke.composeai.data.render.extensions.DataExtensionCapability
@@ -198,21 +198,21 @@ class PreviewOverridesDataProductRegistry : DataProductRegistry {
    */
   private fun readDeclarationsAcrossClassloaders(scope: String): List<PreviewOverrideDeclaration> {
     val bridge = SandboxPreviewOverridesBridgeReader.tryLoad()
-    // `declarations()` already merges + dedupes the explicit and resource-string buckets. The bridge
+    // `declarations()` already merges + dedupes the explicit and resource-string buckets. The
+    // bridge
     // path decodes raw per-key JSON snapshots that never went through it, so dedupe that list too
     // (a no-op until the Android sandbox bridge also forwards resource knobs).
     val controllerDeclarations = PreviewOverrideController.declarations()
     if (bridge == null) return controllerDeclarations
     val bridgeJson = bridge.snapshot(scope)
     if (bridgeJson.isEmpty()) return controllerDeclarations
-    val decoded =
-      bridgeJson.mapNotNull { entry ->
-        try {
-          json.decodeFromString(PreviewOverrideDeclaration.serializer(), entry)
-        } catch (_: Exception) {
-          null
-        }
+    val decoded = bridgeJson.mapNotNull { entry ->
+      try {
+        json.decodeFromString(PreviewOverrideDeclaration.serializer(), entry)
+      } catch (_: Exception) {
+        null
       }
+    }
     return dedupeResourceOverrideDeclarations(decoded)
   }
 

--- a/data/preview-overrides/connector/src/main/kotlin/ee/schimke/composeai/daemon/PreviewOverridesDataProduct.kt
+++ b/data/preview-overrides/connector/src/main/kotlin/ee/schimke/composeai/daemon/PreviewOverridesDataProduct.kt
@@ -11,6 +11,7 @@ import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.data.overrides.PreviewOverrideDeclaration
 import ee.schimke.composeai.data.overrides.PreviewOverrideValue
 import ee.schimke.composeai.data.overrides.PreviewOverridesPayload
+import ee.schimke.composeai.data.overrides.dedupeResourceOverrideDeclarations
 import ee.schimke.composeai.data.overrides.PreviewOverridesProduct
 import ee.schimke.composeai.data.render.PreviewContext
 import ee.schimke.composeai.data.render.extensions.DataExtension
@@ -197,17 +198,22 @@ class PreviewOverridesDataProductRegistry : DataProductRegistry {
    */
   private fun readDeclarationsAcrossClassloaders(scope: String): List<PreviewOverrideDeclaration> {
     val bridge = SandboxPreviewOverridesBridgeReader.tryLoad()
+    // `declarations()` already merges + dedupes the explicit and resource-string buckets. The bridge
+    // path decodes raw per-key JSON snapshots that never went through it, so dedupe that list too
+    // (a no-op until the Android sandbox bridge also forwards resource knobs).
     val controllerDeclarations = PreviewOverrideController.declarations()
     if (bridge == null) return controllerDeclarations
     val bridgeJson = bridge.snapshot(scope)
     if (bridgeJson.isEmpty()) return controllerDeclarations
-    return bridgeJson.mapNotNull { entry ->
-      try {
-        json.decodeFromString(PreviewOverrideDeclaration.serializer(), entry)
-      } catch (_: Exception) {
-        null
+    val decoded =
+      bridgeJson.mapNotNull { entry ->
+        try {
+          json.decodeFromString(PreviewOverrideDeclaration.serializer(), entry)
+        } catch (_: Exception) {
+          null
+        }
       }
-    }
+    return dedupeResourceOverrideDeclarations(decoded)
   }
 
   /**

--- a/data/preview-overrides/core/src/main/kotlin/ee/schimke/composeai/data/overrides/PreviewOverrideModels.kt
+++ b/data/preview-overrides/core/src/main/kotlin/ee/schimke/composeai/data/overrides/PreviewOverrideModels.kt
@@ -79,3 +79,52 @@ data class PreviewOverrideDeclaration(
  */
 @Serializable
 data class PreviewOverridesPayload(val declarations: List<PreviewOverrideDeclaration> = emptyList())
+
+/**
+ * Marks a [PreviewOverrideDeclaration] that the render backend synthesised for a **string loaded
+ * from resources** (Android `stringResource` / CMP `org.jetbrains.compose.resources.stringResource`)
+ * rather than an author's explicit `previewOverride*` call. Any string a preview pulls from
+ * resources is editable without the author having to wrap it — a resource lookup already tells the
+ * backend what text was rendered and gives us a stable key to seed a replacement against.
+ *
+ * The marker is a **key prefix** rather than a new schema field so older readers of the
+ * `compose/overrides` payload tolerate it unchanged: to them a resource knob is just another string
+ * knob whose `key` happens to start with `res:`. The backend mints the key deterministically (the
+ * Android resource entry name, or the CMP resource `path#offset`) so the same key is recomputed at
+ * declaration time and at substitution time, keeping the `namedOverrides` seed round-trip intact.
+ */
+const val RESOURCE_OVERRIDE_KEY_PREFIX: String = "res:"
+
+/** True when [key] was minted for a resource-loaded string (see [RESOURCE_OVERRIDE_KEY_PREFIX]). */
+fun isResourceOverrideKey(key: String): Boolean = key.startsWith(RESOURCE_OVERRIDE_KEY_PREFIX)
+
+/** True when this declaration was synthesised for a resource-loaded string. */
+fun PreviewOverrideDeclaration.isResourceOverride(): Boolean = isResourceOverrideKey(key)
+
+/**
+ * Collapse the "same string offered twice" case the auto-resource surface can create: when a preview
+ * both loads a string from resources **and** passes it through an explicit `previewOverride*` call,
+ * the render records two knobs whose author default is the same text — one resource-synthesised, one
+ * explicit. Drop the resource-synthesised duplicate so the viewer shows a single control; the
+ * explicit knob wins because the author named it deliberately.
+ *
+ * A resource knob is dropped only when its author [PreviewOverrideDeclaration.default] equals the
+ * default of some **explicit** (non-resource) string knob. Resource knobs that no explicit knob
+ * shadows are kept, and explicit knobs are never removed. Declaration order is otherwise preserved.
+ */
+fun dedupeResourceOverrideDeclarations(
+  declarations: List<PreviewOverrideDeclaration>
+): List<PreviewOverrideDeclaration> {
+  if (declarations.isEmpty()) return declarations
+  val explicitStringDefaults: Set<String> =
+    declarations
+      .asSequence()
+      .filterNot { it.isResourceOverride() }
+      .mapNotNull { (it.default as? PreviewOverrideValue.StringValue)?.value }
+      .toSet()
+  if (explicitStringDefaults.isEmpty()) return declarations
+  return declarations.filterNot { declaration ->
+    declaration.isResourceOverride() &&
+      (declaration.default as? PreviewOverrideValue.StringValue)?.value in explicitStringDefaults
+  }
+}

--- a/data/preview-overrides/core/src/main/kotlin/ee/schimke/composeai/data/overrides/PreviewOverrideModels.kt
+++ b/data/preview-overrides/core/src/main/kotlin/ee/schimke/composeai/data/overrides/PreviewOverrideModels.kt
@@ -82,10 +82,11 @@ data class PreviewOverridesPayload(val declarations: List<PreviewOverrideDeclara
 
 /**
  * Marks a [PreviewOverrideDeclaration] that the render backend synthesised for a **string loaded
- * from resources** (Android `stringResource` / CMP `org.jetbrains.compose.resources.stringResource`)
- * rather than an author's explicit `previewOverride*` call. Any string a preview pulls from
- * resources is editable without the author having to wrap it — a resource lookup already tells the
- * backend what text was rendered and gives us a stable key to seed a replacement against.
+ * from resources** (Android `stringResource` / CMP
+ * `org.jetbrains.compose.resources.stringResource`) rather than an author's explicit
+ * `previewOverride*` call. Any string a preview pulls from resources is editable without the author
+ * having to wrap it — a resource lookup already tells the backend what text was rendered and gives
+ * us a stable key to seed a replacement against.
  *
  * The marker is a **key prefix** rather than a new schema field so older readers of the
  * `compose/overrides` payload tolerate it unchanged: to them a resource knob is just another string
@@ -102,11 +103,11 @@ fun isResourceOverrideKey(key: String): Boolean = key.startsWith(RESOURCE_OVERRI
 fun PreviewOverrideDeclaration.isResourceOverride(): Boolean = isResourceOverrideKey(key)
 
 /**
- * Collapse the "same string offered twice" case the auto-resource surface can create: when a preview
- * both loads a string from resources **and** passes it through an explicit `previewOverride*` call,
- * the render records two knobs whose author default is the same text — one resource-synthesised, one
- * explicit. Drop the resource-synthesised duplicate so the viewer shows a single control; the
- * explicit knob wins because the author named it deliberately.
+ * Collapse the "same string offered twice" case the auto-resource surface can create: when a
+ * preview both loads a string from resources **and** passes it through an explicit
+ * `previewOverride*` call, the render records two knobs whose author default is the same text — one
+ * resource-synthesised, one explicit. Drop the resource-synthesised duplicate so the viewer shows a
+ * single control; the explicit knob wins because the author named it deliberately.
  *
  * A resource knob is dropped only when its author [PreviewOverrideDeclaration.default] equals the
  * default of some **explicit** (non-resource) string knob. Resource knobs that no explicit knob

--- a/data/preview-overrides/core/src/test/kotlin/ee/schimke/composeai/data/overrides/ResourceOverrideDeclarationsTest.kt
+++ b/data/preview-overrides/core/src/test/kotlin/ee/schimke/composeai/data/overrides/ResourceOverrideDeclarationsTest.kt
@@ -1,0 +1,74 @@
+package ee.schimke.composeai.data.overrides
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ResourceOverrideDeclarationsTest {
+
+  private fun explicit(key: String, default: String) =
+    PreviewOverrideDeclaration(
+      key = key,
+      type = PreviewOverrideType.STRING,
+      default = PreviewOverrideValue.StringValue(default),
+      current = PreviewOverrideValue.StringValue(default),
+    )
+
+  private fun resource(name: String, default: String) =
+    PreviewOverrideDeclaration(
+      key = "${RESOURCE_OVERRIDE_KEY_PREFIX}strings.cvr#$name",
+      type = PreviewOverrideType.STRING,
+      default = PreviewOverrideValue.StringValue(default),
+      current = PreviewOverrideValue.StringValue(default),
+    )
+
+  @Test
+  fun `resource key detection`() {
+    assertTrue(resource("0", "Hi").isResourceOverride())
+    assertFalse(explicit("title", "Hi").isResourceOverride())
+    assertTrue(isResourceOverrideKey("res:foo#3"))
+    assertFalse(isResourceOverrideKey("title"))
+  }
+
+  @Test
+  fun `a resource knob duplicating an explicit knob's default is dropped`() {
+    val explicit = explicit("title", "Shopping list")
+    val duplicate = resource("0", "Shopping list")
+    val distinct = resource("1", "Other text")
+
+    val result = dedupeResourceOverrideDeclarations(listOf(explicit, duplicate, distinct))
+
+    // Explicit knob kept, the resource knob shadowing it dropped, the distinct resource knob kept.
+    assertEquals(listOf(explicit, distinct), result)
+  }
+
+  @Test
+  fun `explicit knobs are never dropped even if two share a default`() {
+    val a = explicit("a", "Same")
+    val b = explicit("b", "Same")
+    assertEquals(listOf(a, b), dedupeResourceOverrideDeclarations(listOf(a, b)))
+  }
+
+  @Test
+  fun `nothing is dropped when there are no explicit string knobs`() {
+    val r1 = resource("0", "One")
+    val r2 = resource("1", "Two")
+    assertEquals(listOf(r1, r2), dedupeResourceOverrideDeclarations(listOf(r1, r2)))
+  }
+
+  @Test
+  fun `dedup matches on default not on current value`() {
+    // The author default is what the two knobs share; a seeded `current` on either must not affect
+    // the match (the explicit knob's authored text is still what the resource lookup returned).
+    val explicit =
+      PreviewOverrideDeclaration(
+        key = "title",
+        type = PreviewOverrideType.STRING,
+        default = PreviewOverrideValue.StringValue("Hello"),
+        current = PreviewOverrideValue.StringValue("Edited"),
+      )
+    val duplicate = resource("0", "Hello")
+    assertEquals(listOf(explicit), dedupeResourceOverrideDeclarations(listOf(explicit, duplicate)))
+  }
+}

--- a/data/preview-overrides/runtime/src/main/kotlin/ee/schimke/composeai/overrides/PreviewOverrideController.kt
+++ b/data/preview-overrides/runtime/src/main/kotlin/ee/schimke/composeai/overrides/PreviewOverrideController.kt
@@ -4,7 +4,9 @@ import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
 import ee.schimke.composeai.data.overrides.PreviewOverrideDeclaration
+import ee.schimke.composeai.data.overrides.PreviewOverrideType
 import ee.schimke.composeai.data.overrides.PreviewOverrideValue
+import ee.schimke.composeai.data.overrides.dedupeResourceOverrideDeclarations
 import java.util.concurrent.CopyOnWriteArrayList
 import kotlinx.serialization.json.Json
 
@@ -54,6 +56,18 @@ object PreviewOverrideController {
   // for the viewer while letting a re-declared key (recomposition) replace its prior entry in
   // place.
   private val declarationsState: MutableState<Map<String, PreviewOverrideDeclaration>> =
+    mutableStateOf(emptyMap())
+
+  // Auto-synthesised knobs for strings loaded from resources (see [recordResource]). Held in a
+  // SEPARATE bucket from the explicit `previewOverride*` declarations above because the two have
+  // different lifecycles: the resource interceptor records eagerly while resources load (on desktop
+  // that is an async coroutine dispatcher, out of step with composition), whereas the explicit knobs
+  // record from a post-composition `SideEffect` after [clearDeclarations] has wiped the prior
+  // render. Folding resource knobs into `declarationsState` would let `clearDeclarations` erase a
+  // resource record that already landed this render, and the warm CMP string cache would keep the
+  // interceptor from re-recording it — the knob would vanish. Keeping them apart, reset once per
+  // render via [resetResourceDeclarations] (not on the explicit-knob clear), makes the two independent.
+  private val resourceDeclarationsState: MutableState<Map<String, PreviewOverrideDeclaration>> =
     mutableStateOf(emptyMap())
 
   private val listeners: MutableList<() -> Unit> = CopyOnWriteArrayList()
@@ -121,8 +135,69 @@ object PreviewOverrideController {
     )
   }
 
-  /** The knobs declared so far this render, in declaration order. */
-  fun declarations(): List<PreviewOverrideDeclaration> = declarationsState.value.values.toList()
+  /**
+   * Record an auto-synthesised knob for a string just loaded from resources, keyed by
+   * [PreviewOverrideDeclaration.seedKey] (a `res:`-prefixed key the backend mints deterministically).
+   * Kept in the resource bucket so the explicit-knob [clearDeclarations] can't erase it mid-render;
+   * [resetResourceDeclarations] clears this bucket once per render instead. A repeat record of the
+   * same key (a later render pass, or the same string read twice) replaces the prior entry in place,
+   * preserving first-seen order.
+   */
+  fun recordResource(declaration: PreviewOverrideDeclaration) {
+    val current = resourceDeclarationsState.value
+    if (current[declaration.seedKey] == declaration) return
+    val next = LinkedHashMap(current)
+    next[declaration.seedKey] = declaration
+    resourceDeclarationsState.value = next
+    listeners.toList().forEach { it() }
+  }
+
+  /**
+   * Resolve the effective text for a resource-loaded string and record it as an editable knob in one
+   * call — the entry point the platform resource interceptors use. Returns the daemon-seeded
+   * replacement bound to [key] (via the same `namedOverrides` map that seeds explicit knobs) when one
+   * is present and string-typed, otherwise [default]. Either way the knob is recorded (with its
+   * resolved `current`) so a viewer can offer an editable control. [key] must carry the
+   * `res:` prefix; [label] is what the viewer shows (typically the author default text).
+   */
+  fun resolveResourceString(key: String, default: String, label: String = default): String {
+    val effective = (valueOf(key) as? PreviewOverrideValue.StringValue)?.value ?: default
+    recordResource(
+      PreviewOverrideDeclaration(
+        key = key,
+        type = PreviewOverrideType.STRING,
+        label = label,
+        default = PreviewOverrideValue.StringValue(default),
+        current = PreviewOverrideValue.StringValue(effective),
+      )
+    )
+    return effective
+  }
+
+  /**
+   * Drop the resource-synthesised knobs so the next render re-discovers its own set. Called once per
+   * render by the resource interceptor's around-composable (keyed on the extension instance so it
+   * runs at render start, not on every recomposition) — deliberately NOT wired into
+   * [clearDeclarations], which only owns the explicit `previewOverride*` bucket.
+   */
+  fun resetResourceDeclarations() {
+    if (resourceDeclarationsState.value.isEmpty()) return
+    resourceDeclarationsState.value = emptyMap()
+  }
+
+  /**
+   * The knobs declared so far this render, in declaration order: the explicit `previewOverride*`
+   * knobs first, then the auto-synthesised resource-string knobs. A resource knob that merely
+   * duplicates an explicit knob's author default is dropped (see [dedupeResourceOverrideDeclarations])
+   * so a preview that wraps a `stringResource(...)` in `previewOverrideString(...)` shows one control,
+   * not two.
+   */
+  fun declarations(): List<PreviewOverrideDeclaration> {
+    val explicit = declarationsState.value.values
+    val resource = resourceDeclarationsState.value.values
+    if (resource.isEmpty()) return explicit.toList()
+    return dedupeResourceOverrideDeclarations(explicit + resource)
+  }
 
   /** Register a callback fired on every state change. Returns an unregister handle. */
   fun addChangeListener(listener: () -> Unit): () -> Unit {
@@ -138,6 +213,7 @@ object PreviewOverrideController {
     val scope = bridgeScope()
     seededValuesState.value = emptyMap()
     declarationsState.value = emptyMap()
+    resourceDeclarationsState.value = emptyMap()
     activePreviewId = null
     bridgeForwarder?.reset(scope)
   }

--- a/data/preview-overrides/runtime/src/main/kotlin/ee/schimke/composeai/overrides/PreviewOverrideController.kt
+++ b/data/preview-overrides/runtime/src/main/kotlin/ee/schimke/composeai/overrides/PreviewOverrideController.kt
@@ -61,12 +61,14 @@ object PreviewOverrideController {
   // Auto-synthesised knobs for strings loaded from resources (see [recordResource]). Held in a
   // SEPARATE bucket from the explicit `previewOverride*` declarations above because the two have
   // different lifecycles: the resource interceptor records eagerly while resources load (on desktop
-  // that is an async coroutine dispatcher, out of step with composition), whereas the explicit knobs
+  // that is an async coroutine dispatcher, out of step with composition), whereas the explicit
+  // knobs
   // record from a post-composition `SideEffect` after [clearDeclarations] has wiped the prior
   // render. Folding resource knobs into `declarationsState` would let `clearDeclarations` erase a
   // resource record that already landed this render, and the warm CMP string cache would keep the
   // interceptor from re-recording it — the knob would vanish. Keeping them apart, reset once per
-  // render via [resetResourceDeclarations] (not on the explicit-knob clear), makes the two independent.
+  // render via [resetResourceDeclarations] (not on the explicit-knob clear), makes the two
+  // independent.
   private val resourceDeclarationsState: MutableState<Map<String, PreviewOverrideDeclaration>> =
     mutableStateOf(emptyMap())
 
@@ -137,11 +139,11 @@ object PreviewOverrideController {
 
   /**
    * Record an auto-synthesised knob for a string just loaded from resources, keyed by
-   * [PreviewOverrideDeclaration.seedKey] (a `res:`-prefixed key the backend mints deterministically).
-   * Kept in the resource bucket so the explicit-knob [clearDeclarations] can't erase it mid-render;
-   * [resetResourceDeclarations] clears this bucket once per render instead. A repeat record of the
-   * same key (a later render pass, or the same string read twice) replaces the prior entry in place,
-   * preserving first-seen order.
+   * [PreviewOverrideDeclaration.seedKey] (a `res:`-prefixed key the backend mints
+   * deterministically). Kept in the resource bucket so the explicit-knob [clearDeclarations] can't
+   * erase it mid-render; [resetResourceDeclarations] clears this bucket once per render instead. A
+   * repeat record of the same key (a later render pass, or the same string read twice) replaces the
+   * prior entry in place, preserving first-seen order.
    */
   fun recordResource(declaration: PreviewOverrideDeclaration) {
     val current = resourceDeclarationsState.value
@@ -153,12 +155,12 @@ object PreviewOverrideController {
   }
 
   /**
-   * Resolve the effective text for a resource-loaded string and record it as an editable knob in one
-   * call — the entry point the platform resource interceptors use. Returns the daemon-seeded
-   * replacement bound to [key] (via the same `namedOverrides` map that seeds explicit knobs) when one
-   * is present and string-typed, otherwise [default]. Either way the knob is recorded (with its
-   * resolved `current`) so a viewer can offer an editable control. [key] must carry the
-   * `res:` prefix; [label] is what the viewer shows (typically the author default text).
+   * Resolve the effective text for a resource-loaded string and record it as an editable knob in
+   * one call — the entry point the platform resource interceptors use. Returns the daemon-seeded
+   * replacement bound to [key] (via the same `namedOverrides` map that seeds explicit knobs) when
+   * one is present and string-typed, otherwise [default]. Either way the knob is recorded (with its
+   * resolved `current`) so a viewer can offer an editable control. [key] must carry the `res:`
+   * prefix; [label] is what the viewer shows (typically the author default text).
    */
   fun resolveResourceString(key: String, default: String, label: String = default): String {
     val effective = (valueOf(key) as? PreviewOverrideValue.StringValue)?.value ?: default
@@ -175,9 +177,9 @@ object PreviewOverrideController {
   }
 
   /**
-   * Drop the resource-synthesised knobs so the next render re-discovers its own set. Called once per
-   * render by the resource interceptor's around-composable (keyed on the extension instance so it
-   * runs at render start, not on every recomposition) — deliberately NOT wired into
+   * Drop the resource-synthesised knobs so the next render re-discovers its own set. Called once
+   * per render by the resource interceptor's around-composable (keyed on the extension instance so
+   * it runs at render start, not on every recomposition) — deliberately NOT wired into
    * [clearDeclarations], which only owns the explicit `previewOverride*` bucket.
    */
   fun resetResourceDeclarations() {
@@ -188,9 +190,9 @@ object PreviewOverrideController {
   /**
    * The knobs declared so far this render, in declaration order: the explicit `previewOverride*`
    * knobs first, then the auto-synthesised resource-string knobs. A resource knob that merely
-   * duplicates an explicit knob's author default is dropped (see [dedupeResourceOverrideDeclarations])
-   * so a preview that wraps a `stringResource(...)` in `previewOverrideString(...)` shows one control,
-   * not two.
+   * duplicates an explicit knob's author default is dropped (see
+   * [dedupeResourceOverrideDeclarations]) so a preview that wraps a `stringResource(...)` in
+   * `previewOverrideString(...)` shows one control, not two.
    */
   fun declarations(): List<PreviewOverrideDeclaration> {
     val explicit = declarationsState.value.values

--- a/data/preview-overrides/runtime/src/test/kotlin/ee/schimke/composeai/overrides/ResourceOverrideControllerTest.kt
+++ b/data/preview-overrides/runtime/src/test/kotlin/ee/schimke/composeai/overrides/ResourceOverrideControllerTest.kt
@@ -1,0 +1,86 @@
+package ee.schimke.composeai.overrides
+
+import ee.schimke.composeai.data.overrides.PreviewOverrideType
+import ee.schimke.composeai.data.overrides.PreviewOverrideValue
+import ee.schimke.composeai.data.overrides.isResourceOverride
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Covers the resource-string half of the controller: [PreviewOverrideController.resolveResourceString]
+ * (record + seed), the separate resource-declaration bucket surviving the explicit-knob
+ * [PreviewOverrideController.clearDeclarations], and the merge + dedupe in
+ * [PreviewOverrideController.declarations].
+ */
+class ResourceOverrideControllerTest {
+
+  @Before fun reset() = PreviewOverrideController.resetForNewSession()
+
+  @After fun tearDown() = PreviewOverrideController.resetForNewSession()
+
+  @Test
+  fun `resolveResourceString returns the default and records a resource knob when unseeded`() {
+    val effective = PreviewOverrideController.resolveResourceString("res:strings.cvr#0", "Hello")
+    assertEquals("Hello", effective)
+
+    val declarations = PreviewOverrideController.declarations()
+    assertEquals(1, declarations.size)
+    val declaration = declarations.single()
+    assertTrue(declaration.isResourceOverride())
+    assertEquals("res:strings.cvr#0", declaration.key)
+    assertEquals(PreviewOverrideValue.StringValue("Hello"), declaration.default)
+    assertEquals(PreviewOverrideValue.StringValue("Hello"), declaration.current)
+  }
+
+  @Test
+  fun `a seeded value replaces the default and rides current`() {
+    PreviewOverrideController.set(
+      mapOf("res:strings.cvr#0" to PreviewOverrideValue.StringValue("Bonjour"))
+    )
+    val effective = PreviewOverrideController.resolveResourceString("res:strings.cvr#0", "Hello")
+    assertEquals("Bonjour", effective)
+    assertEquals(
+      PreviewOverrideValue.StringValue("Bonjour"),
+      PreviewOverrideController.declarations().single().current,
+    )
+  }
+
+  @Test
+  fun `resource declarations survive the explicit-knob clearDeclarations`() {
+    PreviewOverrideController.resolveResourceString("res:strings.cvr#0", "Hello")
+    // The named-override extension calls this post-composition; it must not wipe resource knobs.
+    PreviewOverrideController.clearDeclarations()
+    assertEquals(1, PreviewOverrideController.declarations().size)
+
+    // …but the per-render resource reset does drop them.
+    PreviewOverrideController.resetResourceDeclarations()
+    assertTrue(PreviewOverrideController.declarations().isEmpty())
+  }
+
+  @Test
+  fun `declarations lists explicit knobs first then resource knobs, deduped`() {
+    // Explicit knob whose default equals a resource string → the resource duplicate is dropped.
+    PreviewOverrideController.record(
+      declaration("title", "Shopping list")
+    )
+    PreviewOverrideController.resolveResourceString("res:strings.cvr#0", "Shopping list")
+    PreviewOverrideController.resolveResourceString("res:strings.cvr#1", "Standalone label")
+
+    val declarations = PreviewOverrideController.declarations()
+    assertEquals(
+      listOf("title", "res:strings.cvr#1"),
+      declarations.map { it.key },
+    )
+  }
+
+  private fun declaration(key: String, default: String) =
+    ee.schimke.composeai.data.overrides.PreviewOverrideDeclaration(
+      key = key,
+      type = PreviewOverrideType.STRING,
+      default = PreviewOverrideValue.StringValue(default),
+      current = PreviewOverrideValue.StringValue(default),
+    )
+}

--- a/data/preview-overrides/runtime/src/test/kotlin/ee/schimke/composeai/overrides/ResourceOverrideControllerTest.kt
+++ b/data/preview-overrides/runtime/src/test/kotlin/ee/schimke/composeai/overrides/ResourceOverrideControllerTest.kt
@@ -10,8 +10,9 @@ import org.junit.Before
 import org.junit.Test
 
 /**
- * Covers the resource-string half of the controller: [PreviewOverrideController.resolveResourceString]
- * (record + seed), the separate resource-declaration bucket surviving the explicit-knob
+ * Covers the resource-string half of the controller:
+ * [PreviewOverrideController.resolveResourceString] (record + seed), the separate
+ * resource-declaration bucket surviving the explicit-knob
  * [PreviewOverrideController.clearDeclarations], and the merge + dedupe in
  * [PreviewOverrideController.declarations].
  */
@@ -63,17 +64,12 @@ class ResourceOverrideControllerTest {
   @Test
   fun `declarations lists explicit knobs first then resource knobs, deduped`() {
     // Explicit knob whose default equals a resource string → the resource duplicate is dropped.
-    PreviewOverrideController.record(
-      declaration("title", "Shopping list")
-    )
+    PreviewOverrideController.record(declaration("title", "Shopping list"))
     PreviewOverrideController.resolveResourceString("res:strings.cvr#0", "Shopping list")
     PreviewOverrideController.resolveResourceString("res:strings.cvr#1", "Standalone label")
 
     val declarations = PreviewOverrideController.declarations()
-    assertEquals(
-      listOf("title", "res:strings.cvr#1"),
-      declarations.map { it.key },
-    )
+    assertEquals(listOf("title", "res:strings.cvr#1"), declarations.map { it.key })
   }
 
   private fun declaration(key: String, default: String) =

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -504,6 +504,11 @@ include(":data-preview-overrides-connector")
 
 project(":data-preview-overrides-connector").projectDir = file("data/preview-overrides/connector")
 
+include(":data-preview-overrides-connector-desktop")
+
+project(":data-preview-overrides-connector-desktop").projectDir =
+  file("data/preview-overrides/connector-desktop")
+
 // UIAutomator-shaped query/action API for the Compose preview renderer. Carries the matcher,
 // the Selector DSL, and the JSON wire format — consumed by `:daemon:android` for
 // `record_preview`'s `uia.*` script events.


### PR DESCRIPTION
## Summary

Any string a preview loads from resources is now an editable preview-override knob **automatically** — no `previewOverrideString(...)` wrapper required. A `stringResource(...)` lookup already tells the backend the exact text that rendered and gives a stable key to seed a replacement against, so the desktop backend records the knob and applies the daemon-seeded value in one pass.

Recorded resource knobs ride the **same** `compose/overrides` product and `namedOverrides` seed as the explicit `previewOverride*` knobs, so no new data product is introduced — they just widen what shows up under `compose/overrides`.

### What changed
- **`:data-preview-overrides-core`** — a `res:`-prefixed key convention marks resource-synthesised declarations, plus `dedupeResourceOverrideDeclarations`. This is the "don't double up" rule: when a preview both loads a string from resources **and** wraps it in an explicit `previewOverride*`, only one control shows — the explicit knob wins (matched by equal author default).
- **`:data-preview-overrides-runtime`** — `PreviewOverrideController` gains a **separate resource-declaration bucket** that survives the explicit-knob `clearDeclarations` (reset once per render instead), and `resolveResourceString` (resolve seed + record in one call). `declarations()` merges and dedupes the two buckets — the single drain choke point, so the daemon product, and both bundle sidecars, get the deduped set for free.
- **`:data-preview-overrides-connector-desktop`** (new module) — `RecordingResourceReader` wraps CMP's `LocalResourceReader` to record + substitute each string (scalars, `string-array`, `plurals`; non-string records pass through byte-for-byte), and an always-on `ResourceOverrideExtensionDesktop` installs it on every render, clearing CMP's process-wide string cache so the wrapped reader is actually re-invoked.
- **`:data-preview-overrides-connector`** — apply the same dedupe after the cross-classloader bridge decode (a no-op until Android also forwards resource knobs).
- **`:daemon:desktop`** — register the always-on planner in the `data/overrides` extension.

### Why a separate resource bucket
The explicit `previewOverride*` knobs record from a post-composition `SideEffect`, after the named-override extension's `clearDeclarations` wipes the prior render. The resource reader records **eagerly** while resources load (an async coroutine dispatcher on desktop, out of step with composition), and a warm CMP cache stops it from re-recording. Folding the two lifecycles together would let the explicit-knob clear erase a resource knob mid-render, so they are kept independent.

### Scope / follow-ups
Desktop-scoped for now. Tracked as fast-follows:
- Android `Resources`-subclass interception (mirror `RecordingResources`) + sandbox-bridge forwarding of resource knobs.
- Standalone (gradle bundle) renderer wrap, so resource knobs also land in `previews/<id>.overrides.json` sidecars.

## Test plan
- `RecordingResourceReaderTest` — records a `res:<path>#<offset>` knob and re-encodes the effective value; seeded substitution; per-entry array keys; per-category plural keys; non-string passthrough; `read`/`getUri` delegation.
- `ResourceOverrideDeclarationsTest` (core) — resource-key detection; a resource knob duplicating an explicit knob's default is dropped; explicit knobs never dropped; match is on `default` not `current`.
- `ResourceOverrideControllerTest` (runtime) — resolve returns default + records when unseeded; a seed replaces the default; resource knobs survive `clearDeclarations` but drop on `resetResourceDeclarations`; `declarations()` lists explicit-then-resource, deduped.
- `:daemon:desktop:compileKotlin` passes with the new wiring; the existing `:data-preview-overrides-connector` suite is unaffected.

This is override-plumbing (no rendered-pixel change unless a seed is applied), so no visual evidence is attached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gr3jnTqTWyk4eoTqfxiCsp)_