### PR TITLE
feat(serve): add an "Apps" front-page section and fix the near-dead theme toggle

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -231,6 +231,13 @@ class ServeCommand(args: List<String>) : Command(args) {
   private val registeredCatalogs = mutableListOf<String>()
 
   /**
+   * The unlisted app catalogs (`--catalogs-unlisted`) that registered successfully. Served at
+   * `/<system>/` like [registeredCatalogs] but surfaced under the front page's separate "Apps"
+   * section instead of the "Design systems" nav.
+   */
+  private val registeredUnlistedCatalogs = mutableListOf<String>()
+
+  /**
    * Per-catalog per-preview daemon pools built by [buildTrustedCatalogBundle], keyed by system.
    * Each backs a live catalog's default (per-preview) render lane and outlives suspend/resume, so
    * it's owned here — torn down at server shutdown ([catalogPerPreviewPoolsCloseable] in the
@@ -688,6 +695,7 @@ class ServeCommand(args: List<String>) : Command(args) {
         isPublic = public,
         wasmCatalogs = wasmCatalogs,
         catalogSessions = registeredCatalogs.toList(),
+        appCatalogSessions = registeredUnlistedCatalogs.toList(),
         maxLiveSeats = liveSeats,
       )
 
@@ -1001,9 +1009,9 @@ class ServeCommand(args: List<String>) : Command(args) {
     for (ref in catalogRefs) {
       when (val r = store.load(ref.system, sourceRepo = ref.repo)) {
         is ServeCatalogStore.Result.Ok -> {
-          // Only listed catalogs feed the front-page nav; unlisted ones stay reachable by
-          // /<system>/ and ?session=<system> but off the landing "Design systems" row.
-          if (ref.listed) registeredCatalogs += r.system
+          // Listed catalogs feed the front-page "Design systems" nav; unlisted app catalogs feed
+          // the separate "Apps" section (both reachable at /<system>/ and ?session=<system>).
+          if (ref.listed) registeredCatalogs += r.system else registeredUnlistedCatalogs += r.system
           System.err.println(
             "serve: catalog ${r.system} → ${r.previewCount} preview(s), trust=${r.trust} " +
               "(/${r.system}/${if (ref.listed) "" else ", unlisted"})"

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -93,6 +93,14 @@ class ServeHttpServer(
    * default).
    */
   private val catalogSessions: List<String> = emptyList(),
+  /**
+   * App catalogs registered UNLISTED (`--catalogs-unlisted`), e.g. `["meshcore-mobile","cadence"]`.
+   * Served at `/<system>/` exactly like [catalogSessions], but grouped under a separate "Apps"
+   * section on the front-page index and kept OFF the in-catalog "Design systems" nav row. Empty ⇒
+   * no Apps section (the historical behaviour, where unlisted catalogs were reachable only by their
+   * path / `?session=`).
+   */
+  private val appCatalogSessions: List<String> = emptyList(),
   portRange: Int = DEFAULT_PORT_RANGE,
   /**
    * Max renders in flight across the HTTP `/render` lane. Defaults to the host's CPU count so a
@@ -366,7 +374,7 @@ class ServeHttpServer(
     // below.
     if (
       !sessionInPath &&
-        catalogSessions.isNotEmpty() &&
+        (catalogSessions.isNotEmpty() || appCatalogSessions.isNotEmpty()) &&
         call.request.queryParameters["session"] == null
     ) {
       handleHomeIndex()
@@ -405,38 +413,46 @@ class ServeHttpServer(
     }
 
   /**
-   * The public server's front-page index of published design-system catalogs ([catalogSessions]).
-   * Leases each catalog in turn (they're cheap, pinned bundle hosts) to read its title, preview
-   * count, trust verdict, and pick a meaningful hero preview — then renders a card per system. A
-   * catalog that can't be leased (e.g. transiently unavailable) is skipped rather than sinking the
-   * whole page.
+   * The public server's front-page index: the published design systems ([catalogSessions]) under a
+   * "Design systems" section and the app catalogs ([appCatalogSessions]) under a separate "Apps"
+   * section, each a card linking to its `/<system>/` catalog. See [homeSystemsFor].
    */
   private suspend fun RoutingContext.handleHomeIndex() {
-    val systems =
+    val (systems, apps) =
       withContext(Dispatchers.IO) {
-        catalogSessions.mapNotNull { system ->
-          val lease = sessions.lease(system) ?: return@mapNotNull null
-          try {
-            val host = lease.host
-            val bundle = catalogBundleHost(host)
-            ServeWeb.HomeSystem(
-              system = system,
-              title = bundle?.title?.takeIf { it.isNotBlank() } ?: host.label,
-              subtitle = bundle?.subtitle,
-              previewCount = host.previews.size,
-              trust = bundle?.let { BundleVerifier.summary(it.trust) },
-              heroPreviewId = ServeWeb.representativePreviewId(host.previews),
-            )
-          } finally {
-            lease.close()
-          }
-        }
+        homeSystemsFor(catalogSessions) to homeSystemsFor(appCatalogSessions)
       }
     call.respondText(
-      ServeWeb.homeIndexPage(systems, token, isPublic = isPublic),
+      ServeWeb.homeIndexPage(systems, token, isPublic = isPublic, apps = apps),
       ContentType.Text.Html,
     )
   }
+
+  /**
+   * Resolve a list of catalog [ids] into [ServeWeb.HomeSystem] cards for the front-page index.
+   * Leases each in turn (they're cheap, pinned bundle hosts) to read its title, preview count,
+   * trust verdict, and pick a meaningful hero preview. A catalog that can't be leased (e.g.
+   * transiently unavailable) is skipped rather than sinking the whole page. Blocking — call inside
+   * a `Dispatchers.IO` context.
+   */
+  private fun homeSystemsFor(ids: List<String>): List<ServeWeb.HomeSystem> =
+    ids.mapNotNull { system ->
+      val lease = sessions.lease(system) ?: return@mapNotNull null
+      try {
+        val host = lease.host
+        val bundle = catalogBundleHost(host)
+        ServeWeb.HomeSystem(
+          system = system,
+          title = bundle?.title?.takeIf { it.isNotBlank() } ?: host.label,
+          subtitle = bundle?.subtitle,
+          previewCount = host.previews.size,
+          trust = bundle?.let { BundleVerifier.summary(it.trust) },
+          heroPreviewId = ServeWeb.representativePreviewId(host.previews),
+        )
+      } finally {
+        lease.close()
+      }
+    }
 
   /**
    * `GET /api/previews` (query) and `GET /{system}/api/previews` (path): the session's preview

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -372,6 +372,22 @@ object ServeWeb {
     cardTheme(id) ?: if (darkFirst) "dark" else null
 
   /**
+   * Whether the sticky Light/Dark toggle should show for this catalog. The toggle is a *filter*
+   * over baked per-theme variants, so it's only meaningful when the catalog is genuinely two-sided
+   * AND theme-paired: it carries BOTH `__light` and `__dark` variants, and themed previews are the
+   * majority. A catalog that's mostly theme-neutral — an app catalog whose screens each render in a
+   * single theme, with only a couple of explicit theme-showcase previews — would otherwise sprout a
+   * toggle that hides a handful of cards and otherwise does nothing, reading as broken. This is the
+   * same "no dead toggle" rule [bgTheme] keeps for a dark-first catalog with no light variants,
+   * generalised. Kept generic across every catalog (app or design-system) — keyed purely off the
+   * preview theme distribution, never the system name.
+   */
+  private fun hasThemeVariants(previews: List<ServePreview>): Boolean {
+    val themes = previews.mapNotNull { cardTheme(it.id) }
+    return themes.toSet().containsAll(listOf("light", "dark")) && themes.size * 2 > previews.size
+  }
+
+  /**
    * The sticky light/dark control for the catalog header. Persists to `localStorage['cp-theme']`
    * (shared with the viewer's Theme select) and filters the card grid to the chosen theme's
    * variants. Purely client-side — the server emits every card tagged with `data-card-theme`, and
@@ -594,66 +610,81 @@ object ServeWeb {
   )
 
   /**
-   * The public preview server's **front door**: an index of the design systems it publishes, each a
-   * card carrying a meaningful preview, the system's title + library, its trust badge, and a link
-   * to its `/<system>/` catalog. This replaces showing an arbitrary default module's previews at
-   * `/` (the point of `preview.coo.ee` is the catalogs, so the landing lists them rather than
-   * hiding them behind a nav pill). Non-catalog `serve` (no `--catalogs`) keeps the plain
-   * [landingPage].
+   * The public preview server's **front door**: an index of the systems it publishes, each a card
+   * carrying a meaningful preview, the system's title + library, its trust badge, and a link to its
+   * `/<system>/` catalog. This replaces showing an arbitrary default module's previews at `/` (the
+   * point of `preview.coo.ee` is the catalogs, so the landing lists them rather than hiding them
+   * behind a nav pill). Non-catalog `serve` (no `--catalogs`) keeps the plain [landingPage].
+   *
+   * [systems] are the published design systems (the `--catalogs` set) shown under "Design systems";
+   * [apps] are the app catalogs (the `--catalogs-unlisted` set, e.g. meshcore-mobile / cadence)
+   * shown under a separate "Apps" section so they surface on the front door too — while staying off
+   * the in-catalog "Design systems" nav row. Either group may be empty.
    */
-  fun homeIndexPage(systems: List<HomeSystem>, token: String, isPublic: Boolean = false): String {
+  fun homeIndexPage(
+    systems: List<HomeSystem>,
+    token: String,
+    isPublic: Boolean = false,
+    apps: List<HomeSystem> = emptyList(),
+  ): String {
     val about = if (isPublic) aboutSection() + "\n" else ""
     // Public routes are open — no token param on the cards; a token-gated box keeps it.
     val suffix = querySuffix(if (isPublic) "" else "token=" + WebEscaping.urlEncodeSegment(token))
-    val body =
-      if (systems.isEmpty()) {
-        "<p class=\"cp-sub\">No design systems are configured on this server.</p>"
-      } else {
-        val cards =
-          systems.joinToString("\n") { s ->
-            val sysSeg = WebEscaping.urlEncodeSegment(s.system)
-            val title = WebEscaping.htmlEscape(s.title)
-            val sysId = WebEscaping.htmlEscape(s.system)
-            val img =
-              if (s.heroPreviewId != null) {
-                val idSeg = WebEscaping.urlEncodeSegment(s.heroPreviewId)
-                "<img loading=\"lazy\" alt=\"$title preview\" src=\"/$sysSeg/render/$idSeg.png$suffix\">"
-              } else {
-                "<span class=\"cp-sys-noimg\">no preview</span>"
-              }
-            val desc =
-              s.subtitle
-                ?.takeIf { it.isNotBlank() }
-                ?.let {
-                  "\n            <div class=\"cp-sys-desc\">${WebEscaping.htmlEscape(it)}</div>"
-                } ?: ""
-            """
-            <a class="cp-card cp-sys" href="/$sysSeg/$suffix">
-              <div class="cp-imgwrap">$img</div>
-              <div class="cp-meta">
-                <div class="cp-sys-title">$title${compactTrustBadge(s.trust)}</div>
-                <div class="cp-id">$sysId</div>$desc
-                <div class="cp-sys-foot">${s.previewCount} preview(s)</div>
-              </div>
-            </a>
-            """
-              .trimIndent()
-          }
-        """
-        <p class="cp-sub">${systems.size} design system(s) · pick one to browse its components and
-          open a live, customisable preview.</p>
-        <div class="cp-grid cp-syslist" id="cp-grid">
-        $cards
+    fun card(s: HomeSystem): String {
+      val sysSeg = WebEscaping.urlEncodeSegment(s.system)
+      val title = WebEscaping.htmlEscape(s.title)
+      val sysId = WebEscaping.htmlEscape(s.system)
+      val img =
+        if (s.heroPreviewId != null) {
+          val idSeg = WebEscaping.urlEncodeSegment(s.heroPreviewId)
+          "<img loading=\"lazy\" alt=\"$title preview\" src=\"/$sysSeg/render/$idSeg.png$suffix\">"
+        } else {
+          "<span class=\"cp-sys-noimg\">no preview</span>"
+        }
+      val desc =
+        s.subtitle
+          ?.takeIf { it.isNotBlank() }
+          ?.let { "\n            <div class=\"cp-sys-desc\">${WebEscaping.htmlEscape(it)}</div>" }
+          ?: ""
+      return """
+      <a class="cp-card cp-sys" href="/$sysSeg/$suffix">
+        <div class="cp-imgwrap">$img</div>
+        <div class="cp-meta">
+          <div class="cp-sys-title">$title${compactTrustBadge(s.trust)}</div>
+          <div class="cp-id">$sysId</div>$desc
+          <div class="cp-sys-foot">${s.previewCount} preview(s)</div>
         </div>
-        """
-          .trimIndent()
+      </a>
+      """
+        .trimIndent()
+    }
+    fun section(heading: String, list: List<HomeSystem>, noun: String, gridId: String): String =
+      """
+      <p class="cp-head">$heading</p>
+      <p class="cp-sub">${list.size} $noun · pick one to browse its components and
+        open a live, customisable preview.</p>
+      <div class="cp-grid cp-syslist" id="$gridId">
+      ${list.joinToString("\n") { card(it) }}
+      </div>
+      """
+        .trimIndent()
+    val body =
+      if (systems.isEmpty() && apps.isEmpty()) {
+        "<p class=\"cp-head\">Design systems</p>\n" +
+          "<p class=\"cp-sub\">No design systems are configured on this server.</p>"
+      } else {
+        buildList {
+            if (systems.isNotEmpty())
+              add(section("Design systems", systems, "design system(s)", "cp-grid"))
+            if (apps.isNotEmpty()) add(section("Apps", apps, "app(s)", "cp-grid-apps"))
+          }
+          .joinToString("\n")
       }
     return document(
       title = "Design systems — compose-preview",
       body =
         """
-        $about<p class="cp-head">Design systems</p>
-        $body
+        $about$body
         """
           .trimIndent(),
     )
@@ -746,8 +777,10 @@ object ServeWeb {
     val about = if (isPublic) aboutSection() + "\n" else ""
     val nav =
       if (catalogs.isNotEmpty()) catalogNav(catalogs, token, sessionId, isPublic) + "\n" else ""
-    // The theme toggle only makes sense when the catalog carries per-theme variants to filter.
-    val hasThemes = previews.any { cardTheme(it.id) != null }
+    // The theme toggle only makes sense when the catalog is genuinely theme-paired (both light and
+    // dark variants, themed previews in the majority) — otherwise it's a near-dead filter. See
+    // [hasThemeVariants].
+    val hasThemes = hasThemeVariants(previews)
     val themeToggle = if (hasThemes) themeToggleHtml() + "\n" else ""
     // Search + empty-state + the combined filter script are shown whenever there are previews to
     // filter, independent of the theme axis.

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -149,6 +149,28 @@ class ServeWebFixtureTest {
         ),
         token,
         isPublic = true,
+        // The app catalogs (`--catalogs-unlisted`): served like the design systems but grouped
+        // under
+        // a separate "Apps" section on the front door instead of the "Design systems" nav.
+        apps =
+          listOf(
+            ServeWeb.HomeSystem(
+              system = "meshcore-mobile",
+              title = "MeshCore",
+              subtitle = "ee.schimke.meshcore",
+              previewCount = 33,
+              trust = "branch:yschimke/meshcore-mobile@design-artifacts/meshcore-mobile",
+              heroPreviewId = "device-manycontacts__ideal__default__compact",
+            ),
+            ServeWeb.HomeSystem(
+              system = "cadence",
+              title = "Cadence",
+              subtitle = "ee.schimke.cadence",
+              previewCount = 12,
+              trust = "branch:yschimke/cadence@design-artifacts/cadence",
+              heroPreviewId = null,
+            ),
+          ),
       )
     val viewer =
       ServeWeb.viewerPage(
@@ -416,6 +438,22 @@ class ServeWebFixtureTest {
     assertTrue(
       homeIndex.contains("cp-badge--trusted"),
       "the index badges each system's producer trust",
+    )
+    // The app catalogs (`--catalogs-unlisted`) show under a separate "Apps" section, each linking
+    // to
+    // its canonical /<system>/ path — so meshcore-mobile / cadence surface on the front door too,
+    // while staying off the "Design systems" nav.
+    assertTrue(
+      homeIndex.contains("<p class=\"cp-head\">Apps</p>"),
+      "home index has an Apps section",
+    )
+    assertTrue(
+      homeIndex.contains("href=\"/meshcore-mobile/\"") && homeIndex.contains("href=\"/cadence/\""),
+      "app cards link to each app catalog's canonical /<system>/ path",
+    )
+    assertTrue(
+      homeIndex.contains("MeshCore") && homeIndex.contains("Cadence"),
+      "each app appears in the Apps section with its human title",
     )
     // Public mode opens every route, so server-rendered links carry NO ?token param.
     assertFalse(homeIndex.contains("token="), "public home index links are token-free")
@@ -1142,6 +1180,55 @@ class ServeWebFixtureTest {
     // A live daemon-backed module carries no trust verdict → no badge element (the CSS still
     // defines `.cp-badge`, so check for the rendered `class="cp-badge…` span, not the bare string).
     assertTrue(!ServeWeb.landingPage(moduleLabel, previews, token).contains("class=\"cp-badge"))
+  }
+
+  @Test
+  fun `theme toggle shows only for a genuinely theme-paired catalog`() {
+    // A theme-PAIRED catalog (every component has both a __light and a __dark variant): the toggle
+    // is meaningful — flipping it swaps the whole grid between the light and dark set — so it
+    // shows.
+    val paired =
+      listOf(
+        ServePreview("button__ideal__default__light", "Button (light)"),
+        ServePreview("button__ideal__default__dark", "Button (dark)"),
+        ServePreview("switch__ideal__default__light", "Switch (light)"),
+        ServePreview("switch__ideal__default__dark", "Switch (dark)"),
+      )
+    assertTrue(
+      ServeWeb.landingPage("compose-m3", paired, token).contains("class=\"cp-theme\""),
+      "a theme-paired catalog shows the Light/Dark toggle",
+    )
+
+    // An APP catalog (meshcore-mobile shape): mostly theme-neutral app screens, with only a couple
+    // of explicit theme-showcase previews. The toggle would filter a handful of cards and otherwise
+    // do nothing — reading as broken — so it is suppressed. This is the fix applied uniformly to
+    // every app catalog: it keys off the preview theme distribution, never the system name.
+    val appCatalog =
+      listOf(
+        ServePreview("theme-meshcore__ideal__default__light__compact", "Theme (light)"),
+        ServePreview("theme-meshcore__ideal__default__dark__compact", "Theme (dark)"),
+        ServePreview("contactlist-many__ideal__default__compact", "Contacts"),
+        ServePreview("scanner-blefew__ideal__default__compact", "Scanner"),
+        ServePreview("device-lowbattery__ideal__default__compact", "Device"),
+        ServePreview("tcpconnectpanel-idle__ideal__default__compact", "TCP connect"),
+      )
+    assertFalse(
+      ServeWeb.landingPage("meshcore-mobile", appCatalog, token, basePath = "/meshcore-mobile")
+        .contains("class=\"cp-theme\""),
+      "a mostly theme-neutral app catalog shows no near-dead Light/Dark toggle",
+    )
+
+    // A one-sided themed catalog (dark variants only, no light pair) also shows no toggle — the
+    // filter would have nothing to switch to.
+    val darkOnly =
+      listOf(
+        ServePreview("a__ideal__default__dark", "A"),
+        ServePreview("b__ideal__default__dark", "B"),
+      )
+    assertFalse(
+      ServeWeb.landingPage("x", darkOnly, token).contains("class=\"cp-theme\""),
+      "a catalog with only one theme side shows no toggle",
+    )
   }
 
   private fun assertGolden(file: File, rendered: String) {

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -22,10 +22,13 @@
    A catalog entry may name a **per-system source repo** as `<system>@<owner>/<repo>`, so one server
    can serve systems published to *different* repos — e.g. `compose-m3,wear-m3` from this repo
    alongside `--catalogs-unlisted meshcore-mobile@yschimke/meshcore-mobile` from the app's own repo.
-   `--catalogs-unlisted` serves a system exactly like `--catalogs` but keeps it **off the front-page
-   "Design systems" nav** — reachable at `/<system>/` (and `?session=`) but not advertised on the
-   landing page. Every catalog's branch (whatever repo) must be in the `--trust-store` to badge
-   `Trusted(Branch)`; otherwise it serves `Unverified` (the data tiers serve either way).
+   `--catalogs-unlisted` serves a system exactly like `--catalogs` but groups it under a separate
+   **"Apps"** section on the front page instead of the **"Design systems"** section — the app
+   catalogs (meshcore-mobile, cadence, …) still surface on the landing page, just under their own
+   heading and kept off the in-catalog "Design systems" nav row. Reachable at `/<system>/` (and
+   `?session=`) like any catalog. Every catalog's branch (whatever repo) must be in the
+   `--trust-store` to badge `Trusted(Branch)`; otherwise it serves `Unverified` (the data tiers serve
+   either way).
 
 In `--public` mode the landing page opens with a short **"about" intro** explaining what the host is
 and its safety model, with a link to the machine-readable [`/version`](#endpoints):
@@ -243,8 +246,10 @@ in `.env` (then `docker compose up -d`) to override, or `0` for unbounded.
 
 ## Endpoints
 
-`GET /` — with `--catalogs`, the **design-systems index** (one card per listed system); otherwise
-the served module's preview grid · `GET /p/{id}?session=<s>` viewer · `GET /render/{id}.png` PNG ·
+`GET /` — with `--catalogs` / `--catalogs-unlisted`, the **systems index** (a "Design systems"
+section for the listed catalogs and an "Apps" section for the unlisted app catalogs, one card each);
+otherwise the served module's preview grid · `GET /p/{id}?session=<s>` viewer ·
+`GET /render/{id}.png` PNG ·
 `GET /api/previews` JSON (now includes `trust`) · `POST /bundles/{name}` upload (returns `trust`) ·
 `GET /wasm/{system}/…` in-browser CMP app (ungated static assets) · `GET /healthz` ·
 `GET /version`. In `--public` mode all are open **and links carry no `?token`** (the token gates

--- a/vscode-extension/preview-harness/fixtures/pages/serve-home-index.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-home-index.html
@@ -222,16 +222,16 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     <a href="/version">/version</a>
   </p>
 </section>
-<p class="cp-head">Design systems</p>
-                <p class="cp-sub">3 design system(s) · pick one to browse its components and
-          open a live, customisable preview.</p>
-        <div class="cp-grid cp-syslist" id="cp-grid">
-        <a class="cp-card cp-sys" href="/compose-m3/">
+      <p class="cp-head">Design systems</p>
+      <p class="cp-sub">3 design system(s) · pick one to browse its components and
+        open a live, customisable preview.</p>
+      <div class="cp-grid cp-syslist" id="cp-grid">
+      <a class="cp-card cp-sys" href="/compose-m3/">
   <div class="cp-imgwrap"><img loading="lazy" alt="Compose Material 3 preview" src="/compose-m3/render/button-filled__ideal__default__light.png"></div>
   <div class="cp-meta">
     <div class="cp-sys-title">Compose Material 3 <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/compose-ai-tools@design-artifacts/compose-m3">✓ trusted</span></div>
     <div class="cp-id">compose-m3</div>
-<div class="cp-sys-desc">androidx.compose.material3:material3</div>
+      <div class="cp-sys-desc">androidx.compose.material3:material3</div>
     <div class="cp-sys-foot">42 preview(s)</div>
   </div>
 </a>
@@ -240,7 +240,7 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
   <div class="cp-meta">
     <div class="cp-sys-title">Wear Compose Material 3 <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/compose-ai-tools@design-artifacts/wear-m3">✓ trusted</span></div>
     <div class="cp-id">wear-m3</div>
-<div class="cp-sys-desc">androidx.wear.compose:compose-material3</div>
+      <div class="cp-sys-desc">androidx.wear.compose:compose-material3</div>
     <div class="cp-sys-foot">18 preview(s)</div>
   </div>
 </a>
@@ -249,10 +249,33 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
   <div class="cp-meta">
     <div class="cp-sys-title">Remote Compose Material 3 <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/compose-ai-tools@design-artifacts/remote-m3">✓ trusted</span></div>
     <div class="cp-id">remote-m3</div>
-<div class="cp-sys-desc">androidx.wear.compose.remote:remote-material3</div>
+      <div class="cp-sys-desc">androidx.wear.compose.remote:remote-material3</div>
     <div class="cp-sys-foot">6 preview(s)</div>
   </div>
 </a>
-        </div>
+      </div>
+      <p class="cp-head">Apps</p>
+      <p class="cp-sub">2 app(s) · pick one to browse its components and
+        open a live, customisable preview.</p>
+      <div class="cp-grid cp-syslist" id="cp-grid-apps">
+      <a class="cp-card cp-sys" href="/meshcore-mobile/">
+  <div class="cp-imgwrap"><img loading="lazy" alt="MeshCore preview" src="/meshcore-mobile/render/device-manycontacts__ideal__default__compact.png"></div>
+  <div class="cp-meta">
+    <div class="cp-sys-title">MeshCore <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/meshcore-mobile@design-artifacts/meshcore-mobile">✓ trusted</span></div>
+    <div class="cp-id">meshcore-mobile</div>
+      <div class="cp-sys-desc">ee.schimke.meshcore</div>
+    <div class="cp-sys-foot">33 preview(s)</div>
+  </div>
+</a>
+<a class="cp-card cp-sys" href="/cadence/">
+  <div class="cp-imgwrap"><span class="cp-sys-noimg">no preview</span></div>
+  <div class="cp-meta">
+    <div class="cp-sys-title">Cadence <span class="cp-badge cp-badge--trusted" title="producer trust: branch:yschimke/cadence@design-artifacts/cadence">✓ trusted</span></div>
+    <div class="cp-id">cadence</div>
+      <div class="cp-sys-desc">ee.schimke.cadence</div>
+    <div class="cp-sys-foot">12 preview(s)</div>
+  </div>
+</a>
+      </div>
       </body>
     </html>


### PR DESCRIPTION
## Summary

Two fixes for the public preview server (`preview.coo.ee`), both reported against `/meshcore-mobile`:

1. **App catalogs now show on the front page.** The `--catalogs-unlisted` app catalogs (meshcore-mobile, cadence, homeassistant-remotecompose) were served only at their `/<system>/` path and hidden from the landing index. They now appear under a dedicated **"Apps"** section on `/`, separate from the **"Design systems"** section (`--catalogs`). Wired through `ServeCommand` → `ServeHttpServer` (new `appCatalogSessions`) → `ServeWeb.homeIndexPage` (new `apps` group); the front-door routing gate opens the index when *either* group is non-empty.

2. **The Light/Dark toggle no longer looks broken on app catalogs.** It's a client-side *variant filter*, shown whenever *any* preview carried a `__light`/`__dark` token. meshcore-mobile has only 5 themed previews of 33, so the toggle filtered a handful of cards and otherwise did nothing — reading as "doesn't work". It now shows only for genuinely **theme-paired** catalogs: both light and dark variants present, with themed previews in the majority. The rule is keyed purely off the preview theme distribution (no per-system logic), so it applies uniformly to every app catalog — the same "no dead toggle" principle the code already keeps for dark-first catalogs, generalised.

## Visual evidence

The front-page index is a captured fixture (`serve-home-index.html`) rendered + diffed by the CI visual-diff harness. **Before** the index had only a "Design systems" section; **after** it adds an "Apps" section carrying the app catalogs (MeshCore, Cadence, …).

| Theme | Before | After |
| --- | --- | --- |
| light | ![before light](https://raw.githubusercontent.com/yschimke/compose-ai-tools/88ec5b0dfc104c257fe5feb61ef66e6cd3ecc49f/renders/serve-home-index.light.png) | ![after light](https://raw.githubusercontent.com/yschimke/compose-ai-tools/e28603d40c53ce16535d101348e313308c4e04ac/renders/serve-home-index.light.png) |
| dark | ![before dark](https://raw.githubusercontent.com/yschimke/compose-ai-tools/88ec5b0dfc104c257fe5feb61ef66e6cd3ecc49f/renders/serve-home-index.dark.png) | ![after dark](https://raw.githubusercontent.com/yschimke/compose-ai-tools/e28603d40c53ce16535d101348e313308c4e04ac/renders/serve-home-index.dark.png) |

The theme-toggle change is not tied to an existing fixture (the app-catalog landing never rendered a toggle in the goldens); it is covered by unit assertions instead.

## Test plan

- [x] `UPDATE_SERVE_WEB_FIXTURES=true ./gradlew :cli:test --tests '*ServeWebFixtureTest*'` to regenerate `serve-home-index.html`
- [x] `./gradlew :cli:ktfmtFormatMain :cli:ktfmtFormatTest :cli:test --tests '*ServeWebFixtureTest*'` — green (goldens match, all assertions pass)
- [x] New assertions: Apps section + app cards linking to `/<system>/`; theme toggle shown for a theme-paired catalog and hidden for a mostly-neutral app catalog and a one-sided (dark-only) catalog
- [x] Docs updated (`docs/public-preview-server.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)