### PR TITLE
feat(serve): swap catalog previews between light/dark in place instead of filtering

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -372,14 +372,25 @@ object ServeWeb {
     cardTheme(id) ?: if (darkFirst) "dark" else null
 
   /**
-   * The flattened id with its `light`/`dark` theme token stripped — the key that pairs a
-   * component's light and dark variants into ONE grid card. `button-filled__ideal__default__light`
-   * and `…__dark` both key to `button-filled__ideal__default`, so the Light/Dark control can swap
-   * the card between the two baked renders in place. Only a standalone theme *segment* is removed
-   * (a component slug like `theme-meshcore-light` is one segment and stays intact).
+   * The flattened id with its theme token stripped — the key that pairs a component's light and
+   * dark variants into ONE grid card. `button-filled__ideal__default__light` and `…__dark` both key
+   * to `button-filled__ideal__default`, so the Light/Dark control can swap the card between the two
+   * baked renders in place.
+   *
+   * Strips ONLY the segment [cardTheme] treats as the theme — the *last* standalone `light`/`dark`
+   * segment after the component-id head — never every one. A flattened id can carry a non-theme
+   * `light`/`dark` *state* segment earlier (e.g. `toggle__dark__default__light` is the dark-state
+   * toggle rendered in the light theme); stripping all of them would collapse `toggle__dark__…` and
+   * `toggle__light__…` onto one key and drop a state. A component slug like `theme-meshcore-light`
+   * is a single segment and is never a theme token.
    */
-  private fun baseKey(id: String): String =
-    id.split("__").filterNot { it == "light" || it == "dark" }.joinToString("__")
+  private fun baseKey(id: String): String {
+    val parts = id.split("__")
+    val themeIdx =
+      parts.indices.lastOrNull { it >= 1 && (parts[it] == "light" || parts[it] == "dark") }
+    return if (themeIdx == null) id
+    else parts.filterIndexed { i, _ -> i != themeIdx }.joinToString("__")
+  }
 
   /**
    * One grid card: a component that may carry a baked `light` and/or `dark` variant (a pair the

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -372,26 +372,60 @@ object ServeWeb {
     cardTheme(id) ?: if (darkFirst) "dark" else null
 
   /**
-   * Whether the sticky Light/Dark toggle should show for this catalog. The toggle is a *filter*
-   * over baked per-theme variants, so it's only meaningful when the catalog is genuinely two-sided
-   * AND theme-paired: it carries BOTH `__light` and `__dark` variants, and themed previews are the
-   * majority. A catalog that's mostly theme-neutral — an app catalog whose screens each render in a
-   * single theme, with only a couple of explicit theme-showcase previews — would otherwise sprout a
-   * toggle that hides a handful of cards and otherwise does nothing, reading as broken. This is the
-   * same "no dead toggle" rule [bgTheme] keeps for a dark-first catalog with no light variants,
-   * generalised. Kept generic across every catalog (app or design-system) — keyed purely off the
-   * preview theme distribution, never the system name.
+   * The flattened id with its `light`/`dark` theme token stripped — the key that pairs a
+   * component's light and dark variants into ONE grid card. `button-filled__ideal__default__light`
+   * and `…__dark` both key to `button-filled__ideal__default`, so the Light/Dark control can swap
+   * the card between the two baked renders in place. Only a standalone theme *segment* is removed
+   * (a component slug like `theme-meshcore-light` is one segment and stays intact).
    */
-  private fun hasThemeVariants(previews: List<ServePreview>): Boolean {
-    val themes = previews.mapNotNull { cardTheme(it.id) }
-    return themes.toSet().containsAll(listOf("light", "dark")) && themes.size * 2 > previews.size
+  private fun baseKey(id: String): String =
+    id.split("__").filterNot { it == "light" || it == "dark" }.joinToString("__")
+
+  /**
+   * One grid card: a component that may carry a baked `light` and/or `dark` variant (a pair the
+   * Light/Dark control [swaps][GridCard.swappable] in place) and/or a theme-neutral render. [order]
+   * preserves first-seen position so the grid keeps catalog order.
+   */
+  private class GridCard(val order: Int) {
+    var light: ServePreview? = null
+    var dark: ServePreview? = null
+    var neutral: ServePreview? = null
+
+    /** True when both themes are baked, so the card can swap between them (rather than filter). */
+    val swappable: Boolean
+      get() = light != null && dark != null
+
+    /** The variant shown by default (server-side): light, else dark, else the neutral render. */
+    val default: ServePreview
+      get() = light ?: dark ?: neutral!!
+  }
+
+  /**
+   * Collapse a catalog's per-theme previews into grid cards keyed by [baseKey], so a component's
+   * `__light`/`__dark` variants become a SINGLE card the Light/Dark control swaps between — instead
+   * of two separate cards a filter hides between. A component captured in only one theme (or a
+   * theme-neutral app screen) stays a lone card the toggle leaves untouched. Order follows first
+   * appearance.
+   */
+  private fun groupPreviews(previews: List<ServePreview>): List<GridCard> {
+    val byKey = LinkedHashMap<String, GridCard>()
+    previews.forEachIndexed { i, p ->
+      val card = byKey.getOrPut(baseKey(p.id)) { GridCard(i) }
+      when (cardTheme(p.id)) {
+        "light" -> if (card.light == null) card.light = p
+        "dark" -> if (card.dark == null) card.dark = p
+        else -> if (card.neutral == null) card.neutral = p
+      }
+    }
+    return byKey.values.sortedBy { it.order }
   }
 
   /**
    * The sticky light/dark control for the catalog header. Persists to `localStorage['cp-theme']`
-   * (shared with the viewer's Theme select) and filters the card grid to the chosen theme's
-   * variants. Purely client-side — the server emits every card tagged with `data-card-theme`, and
-   * [catalogThemeScript] does the hiding, so a no-JS client still sees the full catalog.
+   * (shared with the viewer's Theme select). [catalogFilterScript] wires it to *swap* each
+   * swappable card between its baked light/dark render in place — a no-JS client still sees the
+   * full catalog on its default renders. Shown only when the grid has at least one light/dark pair
+   * to swap.
    */
   private fun themeToggleHtml(): String =
     """
@@ -426,13 +460,13 @@ object ServeWeb {
       .trimIndent()
 
   /**
-   * Combined landing-grid filter: owns every `.cp-card`'s visibility from two independent inputs —
-   * the search box (matches the card's label + id, case-insensitive) and, when the catalog carries
-   * per-theme variants, the sticky light/dark toggle. A card is shown only when it satisfies BOTH,
-   * so the two filters compose instead of fighting over `hidden`. Theme state persists to the
-   * shared `localStorage['cp-theme']` key (round-tripped with the viewer's Theme select); the
-   * search text is ephemeral. Fully client-side progressive enhancement — a no-JS client sees the
-   * whole grid.
+   * Landing-grid controls: the search box (matches a card's label + id, case-insensitive) and, when
+   * the catalog carries light/dark pairs, the sticky Light/Dark **toggle** — which *swaps* each
+   * swappable card between its baked light and dark render in place (image, viewer link, id, label,
+   * and stage backing), rather than hiding cards. Single-theme / theme-neutral cards carry no swap
+   * data and are left untouched. Theme state persists to the shared `localStorage['cp-theme']` key
+   * (round-tripped with the viewer's Theme select); the search text is ephemeral. Fully client-side
+   * progressive enhancement — a no-JS client sees the full grid on its baked (default) renders.
    */
   private fun catalogFilterScript(hasThemes: Boolean): String {
     val themeInit =
@@ -446,13 +480,33 @@ object ServeWeb {
         """
           .trimIndent()
       else ""
-    val reflectTheme =
+    // Swap every swappable card to the chosen theme's baked render (src / viewer href / id / label
+    // /
+    // stage backing), and light up the pressed button. A card missing the chosen theme is skipped.
+    val applyTheme =
       if (hasThemes)
-        """themeBtns.forEach(function (b) {
+        """
+        themeBtns.forEach(function (b) {
           b.setAttribute("aria-pressed", b.getAttribute("data-theme-choice") === theme ? "true" : "false");
-        });"""
+        });
+        var k = theme === "dark" ? "d" : "l";
+        cards.forEach(function (c) {
+          if (c.getAttribute("data-swap") !== "1") return;
+          var src = c.getAttribute("data-" + k + "-src");
+          if (!src) return;
+          var img = c.querySelector("img");
+          var lab = c.querySelector(".cp-label");
+          var idn = c.querySelector(".cp-id");
+          var lbl = c.getAttribute("data-" + k + "-label");
+          if (img) { img.src = src; img.setAttribute("alt", lbl); }
+          c.setAttribute("href", c.getAttribute("data-" + k + "-href"));
+          if (lab) { lab.textContent = lbl; lab.setAttribute("title", lbl); }
+          if (idn) idn.textContent = c.getAttribute("data-" + k + "-id");
+          c.setAttribute("data-bg-theme", theme);
+        });
+        """
+          .trimIndent()
       else ""
-    val themeOk = if (hasThemes) "(!ct || ct === theme)" else "true"
     val themeWiring =
       if (hasThemes)
         """themeBtns.forEach(function (b) {
@@ -472,18 +526,16 @@ object ServeWeb {
       var total = cards.length;
       $themeInit
       function apply() {
-        $reflectTheme
+        $applyTheme
         var q = input ? input.value.trim().toLowerCase() : "";
         var shown = 0;
         cards.forEach(function (c) {
-          var ct = c.getAttribute("data-card-theme");
           var lab = c.querySelector(".cp-label");
           var idn = c.querySelector(".cp-id");
           var hay = ((lab ? lab.textContent : "") + " " + (idn ? idn.textContent : "")).toLowerCase();
           var searchOk = q === "" || hay.indexOf(q) !== -1;
-          var visible = $themeOk && searchOk;
-          c.hidden = !visible;
-          if (visible) shown++;
+          c.hidden = !searchOk;
+          if (searchOk) shown++;
         });
         if (count) count.textContent = q === "" ? "" : (shown + " of " + total);
         if (empty) empty.hidden = shown !== 0;
@@ -745,23 +797,47 @@ object ServeWeb {
     // variants keep their own token. Only affects the background — the Light/Dark filter axis below
     // still keys off the explicit-only [cardTheme].
     val darkFirst = isDarkFirstSystem(basePath, sessionId)
-    val cards =
-      if (previews.isEmpty()) {
-        "<p class=\"cp-sub\">No previews discovered in this module.</p>"
-      } else {
-        previews.joinToString("\n") { p ->
-          val idSeg = WebEscaping.urlEncodeSegment(p.id)
-          val label = WebEscaping.htmlEscape(p.label)
-          val idText = WebEscaping.htmlEscape(p.id)
-          // Two distinct axes: data-card-theme is the EXPLICIT light/dark token (drives the
-          // Light/Dark
-          // filter — must stay null for an unthemed card so it shows under both), while
-          // data-bg-theme
-          // is the thumbnail's background (explicit token, else the dark-first default).
-          val filterAttr = cardTheme(p.id)?.let { " data-card-theme=\"$it\"" } ?: ""
-          val bgAttr = bgTheme(p.id, darkFirst)?.let { " data-bg-theme=\"$it\"" } ?: ""
-          """
-          <a class="cp-card"$filterAttr$bgAttr href="$basePath/p/$idSeg$q">
+    // Collapse per-theme variants into one card each so the Light/Dark control swaps a card between
+    // its baked light/dark render *in place*, rather than filtering two cards. A single-theme /
+    // theme-neutral card carries no swap data and the toggle leaves it alone.
+    val groups = groupPreviews(previews)
+    fun renderSrc(p: ServePreview) = "$basePath/render/${WebEscaping.urlEncodeSegment(p.id)}.png$q"
+    fun viewerHref(p: ServePreview) = "$basePath/p/${WebEscaping.urlEncodeSegment(p.id)}$q"
+    fun swapCard(card: GridCard): String {
+      val l = card.light!!
+      val d = card.dark!!
+      // Default to the light render (dark-first systems open dark); the JS re-swaps to the sticky
+      // choice on load. Each theme's src / viewer href / id / label ride as data-* so the swap
+      // needs
+      // no URL-building in the browser.
+      val def = if (darkFirst) d else l
+      val defTheme = if (darkFirst) "dark" else "light"
+      return """
+        <a class="cp-card" data-swap="1" data-bg-theme="$defTheme"
+          data-l-src="${renderSrc(l)}" data-l-href="${viewerHref(l)}"
+          data-l-id="${WebEscaping.htmlEscape(l.id)}" data-l-label="${WebEscaping.htmlEscape(l.label)}"
+          data-d-src="${renderSrc(d)}" data-d-href="${viewerHref(d)}"
+          data-d-id="${WebEscaping.htmlEscape(d.id)}" data-d-label="${WebEscaping.htmlEscape(d.label)}"
+          href="${viewerHref(def)}">
+          <div class="cp-imgwrap">
+            <img loading="lazy" alt="${WebEscaping.htmlEscape(def.label)}" src="${renderSrc(def)}">
+          </div>
+          <div class="cp-meta">
+            <div class="cp-label" title="${WebEscaping.htmlEscape(def.label)}">${WebEscaping.htmlEscape(def.label)}</div>
+            <div class="cp-id">${WebEscaping.htmlEscape(def.id)}</div>
+          </div>
+        </a>
+        """
+        .trimIndent()
+    }
+    fun singleCard(p: ServePreview): String {
+      val idSeg = WebEscaping.urlEncodeSegment(p.id)
+      val label = WebEscaping.htmlEscape(p.label)
+      val idText = WebEscaping.htmlEscape(p.id)
+      // data-bg-theme is the thumbnail's background (explicit token, else the dark-first default).
+      val bgAttr = bgTheme(p.id, darkFirst)?.let { " data-bg-theme=\"$it\"" } ?: ""
+      return """
+          <a class="cp-card"$bgAttr href="$basePath/p/$idSeg$q">
             <div class="cp-imgwrap">
               <img loading="lazy" alt="$label" src="$basePath/render/$idSeg.png$q">
             </div>
@@ -771,16 +847,22 @@ object ServeWeb {
             </div>
           </a>
           """
-            .trimIndent()
-        }
+        .trimIndent()
+    }
+    val cards =
+      if (groups.isEmpty()) {
+        "<p class=\"cp-sub\">No previews discovered in this module.</p>"
+      } else {
+        groups.joinToString("\n") { if (it.swappable) swapCard(it) else singleCard(it.default) }
       }
     val about = if (isPublic) aboutSection() + "\n" else ""
     val nav =
       if (catalogs.isNotEmpty()) catalogNav(catalogs, token, sessionId, isPublic) + "\n" else ""
-    // The theme toggle only makes sense when the catalog is genuinely theme-paired (both light and
-    // dark variants, themed previews in the majority) — otherwise it's a near-dead filter. See
-    // [hasThemeVariants].
-    val hasThemes = hasThemeVariants(previews)
+    // The Light/Dark toggle shows only when at least one component is baked in BOTH themes, i.e.
+    // the
+    // grid has something to swap. A catalog with no light/dark pairs (mostly theme-neutral app
+    // screens) never sprouts a control that would do nothing.
+    val hasThemes = groups.any { it.swappable }
     val themeToggle = if (hasThemes) themeToggleHtml() + "\n" else ""
     // Search + empty-state + the combined filter script are shown whenever there are previews to
     // filter, independent of the theme axis.

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -492,20 +492,36 @@ class ServeWebFixtureTest {
       "the hero pick prefers a default-state, light, filled-button render",
     )
 
-    // The sticky theme toggle appears only for a catalog with per-theme variants, and each themed
-    // card is tagged for client-side filtering; a plain component module shows no toggle.
+    // The sticky theme toggle appears only for a catalog with light/dark pairs, and each paired
+    // component collapses into ONE swap card carrying both themes' baked render; a plain component
+    // module shows no toggle.
     assertTrue(
       landingThemed.contains("class=\"cp-theme\""),
       "themed catalog shows the theme toggle",
     )
     assertTrue(
-      landingThemed.contains("cp-card\" data-card-theme=\"dark\"") &&
-        landingThemed.contains("cp-card\" data-card-theme=\"light\""),
-      "themed cards are tagged with their baked theme",
+      landingThemed.contains("class=\"cp-card\" data-swap=\"1\"") &&
+        landingThemed.contains("data-l-src=") &&
+        landingThemed.contains("data-d-src="),
+      "a paired component renders one swap card carrying both themes' baked render",
+    )
+    // The swap collapses the two variants into one card: the button-filled light+dark pair is a
+    // single card, not two, so the dark variant's id no longer appears as its own card id line.
+    assertFalse(
+      landingThemed.contains(">button-filled__ideal__default__dark</div>"),
+      "the dark variant is folded into the swap card, not a separate card",
     )
     assertTrue(
       landingThemed.contains("localStorage.setItem(\"cp-theme\""),
       "toggle persists the choice to the shared cp-theme key",
+    )
+    // The swap re-points the image + viewer link + id + label to the chosen theme's baked render.
+    assertTrue(
+      landingThemed.contains("img.src = src;") &&
+        landingThemed.contains(
+          "c.setAttribute(\"href\", c.getAttribute(\"data-\" + k + \"-href\"))"
+        ),
+      "the toggle swaps the card's render and viewer link in place (not a filter)",
     )
     // Dark-first system (Wear): a preview with no explicit __light/__dark token still tags the
     // viewer stage dark (data-bg-theme, the background axis — separate from the data-card-theme
@@ -1183,10 +1199,10 @@ class ServeWebFixtureTest {
   }
 
   @Test
-  fun `theme toggle shows only for a genuinely theme-paired catalog`() {
-    // A theme-PAIRED catalog (every component has both a __light and a __dark variant): the toggle
-    // is meaningful — flipping it swaps the whole grid between the light and dark set — so it
-    // shows.
+  fun `theme toggle shows only when the grid has light-dark pairs to swap`() {
+    // A theme-PAIRED catalog: each component is baked in both __light and __dark, so those two
+    // previews collapse into ONE swap card and the toggle re-points it between them — the toggle
+    // shows, and the grid has one card per component (not two).
     val paired =
       listOf(
         ServePreview("button__ideal__default__light", "Button (light)"),
@@ -1194,19 +1210,31 @@ class ServeWebFixtureTest {
         ServePreview("switch__ideal__default__light", "Switch (light)"),
         ServePreview("switch__ideal__default__dark", "Switch (dark)"),
       )
+    val pairedHtml = ServeWeb.landingPage("compose-m3", paired, token)
     assertTrue(
-      ServeWeb.landingPage("compose-m3", paired, token).contains("class=\"cp-theme\""),
+      pairedHtml.contains("class=\"cp-theme\""),
       "a theme-paired catalog shows the Light/Dark toggle",
     )
+    // Two components × two themes → two swap cards, each carrying both themes' render.
+    assertEquals(
+      2,
+      Regex("class=\"cp-card\" data-swap=\"1\"").findAll(pairedHtml).count(),
+      "each paired component is one swap card (two components → two cards, not four)",
+    )
+    assertTrue(
+      pairedHtml.contains("data-l-src=") && pairedHtml.contains("data-d-src="),
+      "a swap card carries both the light and dark baked render",
+    )
 
-    // An APP catalog (meshcore-mobile shape): mostly theme-neutral app screens, with only a couple
-    // of explicit theme-showcase previews. The toggle would filter a handful of cards and otherwise
-    // do nothing — reading as broken — so it is suppressed. This is the fix applied uniformly to
-    // every app catalog: it keys off the preview theme distribution, never the system name.
+    // An APP catalog (meshcore-mobile shape): theme-neutral app screens plus two theme-showcase
+    // previews that are DISTINCT components (theme-meshcore-light vs theme-meshcore-dark), so
+    // nothing
+    // pairs into a swap card. No pair → no toggle. This is the behaviour uniformly across every app
+    // catalog: it keys off whether any component is baked in both themes, never the system name.
     val appCatalog =
       listOf(
-        ServePreview("theme-meshcore__ideal__default__light__compact", "Theme (light)"),
-        ServePreview("theme-meshcore__ideal__default__dark__compact", "Theme (dark)"),
+        ServePreview("theme-meshcore-light__ideal__default__light__compact", "MeshCore light"),
+        ServePreview("theme-meshcore-dark__ideal__default__dark__compact", "MeshCore dark"),
         ServePreview("contactlist-many__ideal__default__compact", "Contacts"),
         ServePreview("scanner-blefew__ideal__default__compact", "Scanner"),
         ServePreview("device-lowbattery__ideal__default__compact", "Device"),
@@ -1215,11 +1243,12 @@ class ServeWebFixtureTest {
     assertFalse(
       ServeWeb.landingPage("meshcore-mobile", appCatalog, token, basePath = "/meshcore-mobile")
         .contains("class=\"cp-theme\""),
-      "a mostly theme-neutral app catalog shows no near-dead Light/Dark toggle",
+      "an app catalog with no light/dark pairs shows no Light/Dark toggle",
     )
 
-    // A one-sided themed catalog (dark variants only, no light pair) also shows no toggle — the
-    // filter would have nothing to switch to.
+    // A one-sided themed catalog (dark variants only, no light pair) also shows no toggle — there
+    // is
+    // nothing to swap to.
     val darkOnly =
       listOf(
         ServePreview("a__ideal__default__dark", "A"),

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -1260,6 +1260,40 @@ class ServeWebFixtureTest {
     )
   }
 
+  @Test
+  fun `grouping strips only the theme segment, keeping a non-theme light-dark state segment`() {
+    // A flattened id can carry a non-theme `light`/`dark` STATE segment before the theme segment
+    // (the `toggle__<state>__default__<theme>` shape the catalog routing already documents). Only
+    // the LAST light/dark (the theme, per cardTheme) may be stripped for the grouping key — else
+    // the
+    // dark-state and light-state toggles collapse onto one card and a state disappears.
+    val stateful =
+      listOf(
+        ServePreview("toggle__dark__default__light", "Toggle · dark state (light)"),
+        ServePreview("toggle__dark__default__dark", "Toggle · dark state (dark)"),
+        ServePreview("toggle__light__default__light", "Toggle · light state (light)"),
+        ServePreview("toggle__light__default__dark", "Toggle · light state (dark)"),
+      )
+    val html = ServeWeb.landingPage("compose-m3", stateful, token)
+    // Two distinct components (dark-state, light-state), each a swap pair → two swap cards, not
+    // one.
+    assertEquals(
+      2,
+      Regex("class=\"cp-card\" data-swap=\"1\"").findAll(html).count(),
+      "the dark-state and light-state toggles stay separate swap cards",
+    )
+    // Both states survive: each state's light+dark ids appear as swap-card data (none dropped).
+    for (id in
+      listOf(
+        "toggle__dark__default__light",
+        "toggle__dark__default__dark",
+        "toggle__light__default__light",
+        "toggle__light__default__dark",
+      )) {
+      assertTrue(html.contains(id), "the $id variant must survive grouping, not be dropped")
+    }
+  }
+
   private fun assertGolden(file: File, rendered: String) {
     assertTrue(
       file.isFile,

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-path.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-path.html
@@ -308,14 +308,12 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     var q = input ? input.value.trim().toLowerCase() : "";
     var shown = 0;
     cards.forEach(function (c) {
-      var ct = c.getAttribute("data-card-theme");
       var lab = c.querySelector(".cp-label");
       var idn = c.querySelector(".cp-id");
       var hay = ((lab ? lab.textContent : "") + " " + (idn ? idn.textContent : "")).toLowerCase();
       var searchOk = q === "" || hay.indexOf(q) !== -1;
-      var visible = true && searchOk;
-      c.hidden = !visible;
-      if (visible) shown++;
+      c.hidden = !searchOk;
+      if (searchOk) shown++;
     });
     if (count) count.textContent = q === "" ? "" : (shown + " of " + total);
     if (empty) empty.hidden = shown !== 0;

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-public.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-public.html
@@ -308,14 +308,12 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     var q = input ? input.value.trim().toLowerCase() : "";
     var shown = 0;
     cards.forEach(function (c) {
-      var ct = c.getAttribute("data-card-theme");
       var lab = c.querySelector(".cp-label");
       var idn = c.querySelector(".cp-id");
       var hay = ((lab ? lab.textContent : "") + " " + (idn ? idn.textContent : "")).toLowerCase();
       var searchOk = q === "" || hay.indexOf(q) !== -1;
-      var visible = true && searchOk;
-      c.hidden = !visible;
-      if (visible) shown++;
+      c.hidden = !searchOk;
+      if (searchOk) shown++;
     });
     if (count) count.textContent = q === "" ? "" : (shown + " of " + total);
     if (empty) empty.hidden = shown !== 0;

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-themed.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-themed.html
@@ -246,40 +246,32 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
   </span>
 </div>
 <div class="cp-grid" id="cp-grid">
-        <a class="cp-card" data-card-theme="light" data-bg-theme="light" href="/p/button-filled__ideal__default__light">
+        <a class="cp-card" data-swap="1" data-bg-theme="light"
+  data-l-src="/render/button-filled__ideal__default__light.png" data-l-href="/p/button-filled__ideal__default__light"
+  data-l-id="button-filled__ideal__default__light" data-l-label="Button · Filled (light)"
+  data-d-src="/render/button-filled__ideal__default__dark.png" data-d-href="/p/button-filled__ideal__default__dark"
+  data-d-id="button-filled__ideal__default__dark" data-d-label="Button · Filled (dark)"
+  href="/p/button-filled__ideal__default__light">
   <div class="cp-imgwrap">
     <img loading="lazy" alt="Button · Filled (light)" src="/render/button-filled__ideal__default__light.png">
   </div>
   <div class="cp-meta">
-    <div class="cp-label" title="button-filled__ideal__default__light">Button · Filled (light)</div>
+    <div class="cp-label" title="Button · Filled (light)">Button · Filled (light)</div>
     <div class="cp-id">button-filled__ideal__default__light</div>
   </div>
 </a>
-<a class="cp-card" data-card-theme="dark" data-bg-theme="dark" href="/p/button-filled__ideal__default__dark">
-  <div class="cp-imgwrap">
-    <img loading="lazy" alt="Button · Filled (dark)" src="/render/button-filled__ideal__default__dark.png">
-  </div>
-  <div class="cp-meta">
-    <div class="cp-label" title="button-filled__ideal__default__dark">Button · Filled (dark)</div>
-    <div class="cp-id">button-filled__ideal__default__dark</div>
-  </div>
-</a>
-<a class="cp-card" data-card-theme="light" data-bg-theme="light" href="/p/switch-on__ideal__default__light">
+<a class="cp-card" data-swap="1" data-bg-theme="light"
+  data-l-src="/render/switch-on__ideal__default__light.png" data-l-href="/p/switch-on__ideal__default__light"
+  data-l-id="switch-on__ideal__default__light" data-l-label="Switch · On (light)"
+  data-d-src="/render/switch-on__ideal__default__dark.png" data-d-href="/p/switch-on__ideal__default__dark"
+  data-d-id="switch-on__ideal__default__dark" data-d-label="Switch · On (dark)"
+  href="/p/switch-on__ideal__default__light">
   <div class="cp-imgwrap">
     <img loading="lazy" alt="Switch · On (light)" src="/render/switch-on__ideal__default__light.png">
   </div>
   <div class="cp-meta">
-    <div class="cp-label" title="switch-on__ideal__default__light">Switch · On (light)</div>
+    <div class="cp-label" title="Switch · On (light)">Switch · On (light)</div>
     <div class="cp-id">switch-on__ideal__default__light</div>
-  </div>
-</a>
-<a class="cp-card" data-card-theme="dark" data-bg-theme="dark" href="/p/switch-on__ideal__default__dark">
-  <div class="cp-imgwrap">
-    <img loading="lazy" alt="Switch · On (dark)" src="/render/switch-on__ideal__default__dark.png">
-  </div>
-  <div class="cp-meta">
-    <div class="cp-label" title="switch-on__ideal__default__dark">Switch · On (dark)</div>
-    <div class="cp-id">switch-on__ideal__default__dark</div>
   </div>
 </a>
 <a class="cp-card" href="/p/badge">
@@ -306,19 +298,32 @@ var theme = (stored === "light" || stored === "dark") ? stored
 var themeBtns = document.querySelectorAll(".cp-theme-btn");
       function apply() {
         themeBtns.forEach(function (b) {
-          b.setAttribute("aria-pressed", b.getAttribute("data-theme-choice") === theme ? "true" : "false");
-        });
+  b.setAttribute("aria-pressed", b.getAttribute("data-theme-choice") === theme ? "true" : "false");
+});
+var k = theme === "dark" ? "d" : "l";
+cards.forEach(function (c) {
+  if (c.getAttribute("data-swap") !== "1") return;
+  var src = c.getAttribute("data-" + k + "-src");
+  if (!src) return;
+  var img = c.querySelector("img");
+  var lab = c.querySelector(".cp-label");
+  var idn = c.querySelector(".cp-id");
+  var lbl = c.getAttribute("data-" + k + "-label");
+  if (img) { img.src = src; img.setAttribute("alt", lbl); }
+  c.setAttribute("href", c.getAttribute("data-" + k + "-href"));
+  if (lab) { lab.textContent = lbl; lab.setAttribute("title", lbl); }
+  if (idn) idn.textContent = c.getAttribute("data-" + k + "-id");
+  c.setAttribute("data-bg-theme", theme);
+});
         var q = input ? input.value.trim().toLowerCase() : "";
         var shown = 0;
         cards.forEach(function (c) {
-          var ct = c.getAttribute("data-card-theme");
           var lab = c.querySelector(".cp-label");
           var idn = c.querySelector(".cp-id");
           var hay = ((lab ? lab.textContent : "") + " " + (idn ? idn.textContent : "")).toLowerCase();
           var searchOk = q === "" || hay.indexOf(q) !== -1;
-          var visible = (!ct || ct === theme) && searchOk;
-          c.hidden = !visible;
-          if (visible) shown++;
+          c.hidden = !searchOk;
+          if (searchOk) shown++;
         });
         if (count) count.textContent = q === "" ? "" : (shown + " of " + total);
         if (empty) empty.hidden = shown !== 0;

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing.html
@@ -291,14 +291,12 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     var q = input ? input.value.trim().toLowerCase() : "";
     var shown = 0;
     cards.forEach(function (c) {
-      var ct = c.getAttribute("data-card-theme");
       var lab = c.querySelector(".cp-label");
       var idn = c.querySelector(".cp-id");
       var hay = ((lab ? lab.textContent : "") + " " + (idn ? idn.textContent : "")).toLowerCase();
       var searchOk = q === "" || hay.indexOf(q) !== -1;
-      var visible = true && searchOk;
-      c.hidden = !visible;
-      if (visible) shown++;
+      c.hidden = !searchOk;
+      if (searchOk) shown++;
     });
     if (count) count.textContent = q === "" ? "" : (shown + " of " + total);
     if (empty) empty.hidden = shown !== 0;


### PR DESCRIPTION
## Summary

Follow-up to the theme-toggle work: make the catalog Light/Dark control an actual **toggle of the previews**, not a filter.

Before, a component's `__light` and `__dark` variants were two separate cards and the control filtered the grid down to one theme's set. Now they collapse into **one card per component**, and Light/Dark **swaps that card in place** between its baked light and dark render — image, viewer link, id, label, and stage backing all re-point to the chosen theme. Toggling actually re-themes the previews you're looking at.

- `groupPreviews` keys previews by `baseKey` (the flattened id with its light/dark token stripped), so paired variants share one `GridCard`; a single-theme or theme-neutral preview stays a lone card the toggle leaves alone.
- The toggle shows only when at least one component is baked in **both** themes (there's something to swap). A catalog with no light/dark pairs shows no toggle.
- `catalogFilterScript` swaps `.cp-card[data-swap]` to the chosen theme's `data-l-*`/`data-d-*` render instead of hiding cards; search + the background toggle are unchanged. Fully client-side over baked renders — a no-JS client still sees the grid on its default renders.

**MeshCore / app catalogs:** this delivers the toggle for any catalog carrying light/dark pairs (compose-m3, wear-m3). MeshCore's app screens are each captured in a single theme, so there's nothing to swap for them yet — making MeshCore fully toggle-able needs its screens captured in both themes, a follow-up in the `meshcore-mobile` repo.

## Visual evidence

Runtime proof of the swap (driven with Chromium — click **Dark**): the Button and Switch cards flip to their dark render *in place* (same cards, `…__dark` ids/labels, dark stage), while the single-theme Badge card is untouched. The grid is one card per component, not filtered. (Placeholder images are colored by theme purely to make the swap visible in this local render.) Shared with the requester in-session; I'll embed the CI harness's before/after `serve-landing-themed` renders here once the visual-diff bot posts them.

A static screenshot of the fixture can't show the *interaction*; the CI `serve-landing-themed` capture shows the grouping (5 filtered cards → 3 swap/neutral cards), and the runtime swap is additionally covered by a unit assertion + a headless click-through in this session.

## Test plan

- [x] `UPDATE_SERVE_WEB_FIXTURES=true ./gradlew :cli:test --tests '*ServeWebFixtureTest*'` to regenerate the landing goldens
- [x] `./gradlew :cli:ktfmtFormatMain :cli:ktfmtFormatTest :cli:test --tests '*ServeWebFixtureTest*'` — green (goldens match, all assertions pass)
- [x] New/updated assertions: one swap card per paired component (two components → two cards, not four); swap card carries both themes' render; the script re-points src + viewer href on toggle; no toggle when there are no pairs (app-catalog shape) or only one theme side
- [x] Headless click-through: toggling Dark re-points every swap card's id/href/img from `__light` to `__dark` (`SWAP OK: true`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KMjHJDf9MhAAd4k1t6SUD6)_