### PR TITLE
fix(bundle): carry + load app resources for classic Android previews

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/AndroidBundleResources.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/AndroidBundleResources.kt
@@ -10,18 +10,19 @@ import java.util.zip.ZipInputStream
  *
  * A classic `@Composable @Preview` that calls `stringResource(R.string.…)` needs the app's compiled
  * resource table (the `0x7f` package, `resources.arsc` / `apk-for-local-test.ap_`) at render time.
- * The in-Gradle render path gets it for free — AGP puts a `com/android/tools/test_config.properties`
- * on the unit-test classpath and Robolectric's `RobolectricTestRunner` auto-reads it. A **detached**
- * render (a packed bundle spawned by `bundle daemon` / `bundle render`, or a `serve --catalogs`
- * live bundle) has neither the AGP build nor that config file, so without re-supplying them the
- * sandbox has only the framework `android-all` table and `R.string.…` throws
- * `Resources$NotFoundException: String resource ID #0x7f…`.
+ * The in-Gradle render path gets it for free — AGP puts a
+ * `com/android/tools/test_config.properties` on the unit-test classpath and Robolectric's
+ * `RobolectricTestRunner` auto-reads it. A **detached** render (a packed bundle spawned by `bundle
+ * daemon` / `bundle render`, or a `serve --catalogs` live bundle) has neither the AGP build nor
+ * that config file, so without re-supplying them the sandbox has only the framework `android-all`
+ * table and `R.string.…` throws `Resources$NotFoundException: String resource ID #0x7f…`.
  *
  * `BundlePreviewTask.resolveAndroidResources` packs `android/resources.ap_` +
  * `android/AndroidManifest.xml` (+ optional `android/r-classes.jar`) for any `backend == "android"`
  * bundle; this object extracts that payload and synthesizes the `test_config.properties` both the
- * `bundle daemon` ([BundleDaemonCommand]) and `serve` ([ee.schimke.composeai.cli.serve.ServeBundleDaemon])
- * paths prepend to the Robolectric daemon's `-cp`. Shared so both wire resources identically.
+ * `bundle daemon` ([BundleDaemonCommand]) and `serve`
+ * ([ee.schimke.composeai.cli.serve.ServeBundleDaemon]) paths prepend to the Robolectric daemon's
+ * `-cp`. Shared so both wire resources identically.
  */
 internal object AndroidBundleResources {
 
@@ -102,13 +103,18 @@ internal object AndroidBundleResources {
    * Convenience for a daemon launch: extract [zipBytes]'s `android/` resources into
    * `<workDir>/android`, synthesize the `test_config.properties` under `<workDir>/test-config`, and
    * return the classpath entries (the `test-config` dir + optional `r-classes.jar`) to prepend to
-   * the Robolectric daemon's `-cp`. Empty when the bundle carries no `android/` payload — the render
-   * then falls back to framework resources only (unchanged pre-carriage behaviour).
+   * the Robolectric daemon's `-cp`. Empty when the bundle carries no `android/` payload — the
+   * render then falls back to framework resources only (unchanged pre-carriage behaviour).
    */
   fun daemonClasspath(zipBytes: ByteArray, workDir: File, applicationPackage: String?): List<File> {
     val res = extract(zipBytes, File(workDir, "android")) ?: return emptyList()
     val testConfigDir =
-      writeTestConfig(File(workDir, "test-config"), res.resourceApk, res.mergedManifest, applicationPackage)
+      writeTestConfig(
+        File(workDir, "test-config"),
+        res.resourceApk,
+        res.mergedManifest,
+        applicationPackage,
+      )
     return buildList {
       add(testConfigDir)
       res.rClassesJar?.let { add(it) }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/AndroidBundleResources.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/AndroidBundleResources.kt
@@ -1,0 +1,117 @@
+package ee.schimke.composeai.cli
+
+import java.io.ByteArrayInputStream
+import java.io.File
+import java.util.zip.ZipInputStream
+
+/**
+ * The Android app-resource carriage a **packed bundle** carries under `android/`, and the wiring
+ * that re-registers it with a detached Robolectric render.
+ *
+ * A classic `@Composable @Preview` that calls `stringResource(R.string.…)` needs the app's compiled
+ * resource table (the `0x7f` package, `resources.arsc` / `apk-for-local-test.ap_`) at render time.
+ * The in-Gradle render path gets it for free — AGP puts a `com/android/tools/test_config.properties`
+ * on the unit-test classpath and Robolectric's `RobolectricTestRunner` auto-reads it. A **detached**
+ * render (a packed bundle spawned by `bundle daemon` / `bundle render`, or a `serve --catalogs`
+ * live bundle) has neither the AGP build nor that config file, so without re-supplying them the
+ * sandbox has only the framework `android-all` table and `R.string.…` throws
+ * `Resources$NotFoundException: String resource ID #0x7f…`.
+ *
+ * `BundlePreviewTask.resolveAndroidResources` packs `android/resources.ap_` +
+ * `android/AndroidManifest.xml` (+ optional `android/r-classes.jar`) for any `backend == "android"`
+ * bundle; this object extracts that payload and synthesizes the `test_config.properties` both the
+ * `bundle daemon` ([BundleDaemonCommand]) and `serve` ([ee.schimke.composeai.cli.serve.ServeBundleDaemon])
+ * paths prepend to the Robolectric daemon's `-cp`. Shared so both wire resources identically.
+ */
+internal object AndroidBundleResources {
+
+  /**
+   * The `android/…` payload extracted from a bundle zip: the merged resource APK, the merged
+   * manifest, and (optional) the generated non-final library R classes the tile renderer links.
+   */
+  data class Extracted(val resourceApk: File, val mergedManifest: File, val rClassesJar: File?)
+
+  /**
+   * Extract `android/resources.ap_` + `android/AndroidManifest.xml` (+ optional
+   * `android/r-classes.jar`) from [zipBytes] into [androidDir] (Zip-Slip guarded — every
+   * destination is verified to live inside [androidDir]). Returns null when the bundle carries no
+   * `android/` resource payload (a desktop bundle, or an Android bundle packed before this carriage
+   * existed): the caller then renders without an app resource table, exactly as before.
+   */
+  fun extract(zipBytes: ByteArray, androidDir: File): Extracted? {
+    androidDir.mkdirs()
+    val canonical = androidDir.canonicalFile
+    var apk: File? = null
+    var mergedManifest: File? = null
+    var rJar: File? = null
+    ZipInputStream(ByteArrayInputStream(zipBytes)).use { zin ->
+      while (true) {
+        val entry = zin.nextEntry ?: break
+        val name = entry.name
+        if (!entry.isDirectory && name.startsWith("android/")) {
+          val dest = File(androidDir, File(name).name).canonicalFile
+          if (dest.path.startsWith(canonical.path + File.separator)) {
+            dest.outputStream().use { sink -> zin.copyTo(sink) }
+            when (name) {
+              "android/resources.ap_" -> apk = dest
+              "android/AndroidManifest.xml" -> mergedManifest = dest
+              "android/r-classes.jar" -> rJar = dest
+            }
+          }
+        }
+        zin.closeEntry()
+      }
+    }
+    val resolvedApk = apk
+    val resolvedManifest = mergedManifest
+    return if (resolvedApk != null && resolvedManifest != null)
+      Extracted(resolvedApk, resolvedManifest, rJar)
+    else null
+  }
+
+  /**
+   * Write the Robolectric `com/android/tools/test_config.properties` under [root], pointing at the
+   * extracted [resourceApk] + [mergedManifest] (binary-resources mode: `android_resource_apk`
+   * carries the table; package + theme come from `android_merged_manifest`). [applicationPackage]
+   * (when the pack step recorded it) is written as `android_custom_package` — the package
+   * Robolectric/AGP use for the final R class. Returns [root] for the caller to put on the daemon
+   * `-cp`; it's the only mechanism a detached bundle has to re-register a resource table with
+   * Robolectric.
+   */
+  fun writeTestConfig(
+    root: File,
+    resourceApk: File,
+    mergedManifest: File,
+    applicationPackage: String?,
+  ): File {
+    val dir = File(root, "com/android/tools").apply { mkdirs() }
+    File(dir, "test_config.properties")
+      .writeText(
+        buildString {
+          appendLine("android_resource_apk=${resourceApk.absolutePath}")
+          appendLine("android_merged_manifest=${mergedManifest.absolutePath}")
+          if (!applicationPackage.isNullOrBlank()) {
+            appendLine("android_custom_package=$applicationPackage")
+          }
+        }
+      )
+    return root
+  }
+
+  /**
+   * Convenience for a daemon launch: extract [zipBytes]'s `android/` resources into
+   * `<workDir>/android`, synthesize the `test_config.properties` under `<workDir>/test-config`, and
+   * return the classpath entries (the `test-config` dir + optional `r-classes.jar`) to prepend to
+   * the Robolectric daemon's `-cp`. Empty when the bundle carries no `android/` payload — the render
+   * then falls back to framework resources only (unchanged pre-carriage behaviour).
+   */
+  fun daemonClasspath(zipBytes: ByteArray, workDir: File, applicationPackage: String?): List<File> {
+    val res = extract(zipBytes, File(workDir, "android")) ?: return emptyList()
+    val testConfigDir =
+      writeTestConfig(File(workDir, "test-config"), res.resourceApk, res.mergedManifest, applicationPackage)
+    return buildList {
+      add(testConfigDir)
+      res.rClassesJar?.let { add(it) }
+    }
+  }
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleDaemonCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleDaemonCommand.kt
@@ -110,38 +110,25 @@ class BundleDaemonCommand(args: List<String>) : Command(args) {
       extractIrArtifacts(zipBytes, irDir!!, bundleManifestFile!!, file)
     }
 
-    // v6 Android resource carriage: a protolayout (Wear tile) IR replays through `TileRenderer`,
-    // which resolves a library theme resource via `getResources()` and links the non-final library
-    // `R$style` class. A detached daemon has neither the merged resource table (no AGP build) nor
-    // those generated R classes (an AAR's published classes.jar omits them), so an android bundle
-    // carrying protolayout IR also carries the merged resource APK + manifest + R classes under
-    // `android/`. Extract them, synthesize the Robolectric
-    // `com/android/tools/test_config.properties`
-    // the daemon's RobolectricTestRunner auto-reads from the classpath (exactly how the in-Gradle
-    // render path gets resources), and expose the R classes to the parent (renderer) classloader.
-    // The synthesized-config dir and the R jar both ride the IR-carriage `-cp` seam below. Absent
-    // for desktop / classic / Remote-Compose-only bundles.
+    // Android resource carriage (ungated by IR): any `backend == "android"` bundle carries the app's
+    // merged resource APK + manifest (+ generated R classes) under `android/`, because a classic
+    // `@Preview` that calls `stringResource(R.string.…)` needs the `0x7f` app table just as much as a
+    // Wear tile does. A detached daemon has neither the merged table (no AGP build) nor those R
+    // classes, so [AndroidBundleResources] extracts them and synthesizes the Robolectric
+    // `com/android/tools/test_config.properties` the daemon's RobolectricTestRunner auto-reads from
+    // the classpath — exactly how the in-Gradle render path gets resources — and the config dir + R
+    // jar ride the `-cp` seam below. Empty for a bundle with no `android/` payload (packed before this
+    // carriage / no binary resources): renders framework-resources-only, as before.
     val androidReplayClasspath = mutableListOf<File>()
-    if (manifest.backend == "android" && hasIr) {
-      val androidDir = workDir.resolve("android").apply { mkdirs() }
-      val res = extractAndroidResources(zipBytes, androidDir)
-      if (res != null) {
-        val testConfigDir = workDir.resolve("test-config")
-        writeAndroidTestConfig(
-          testConfigDir,
-          res.resourceApk,
-          res.mergedManifest,
+    if (manifest.backend == "android") {
+      androidReplayClasspath +=
+        AndroidBundleResources.daemonClasspath(
+          zipBytes,
+          workDir,
           manifest.androidResources?.applicationPackage,
         )
-        androidReplayClasspath += testConfigDir
-        res.rClassesJar?.let { androidReplayClasspath += it }
-      }
-      // Always surface what the bundle carried (even when nothing) — this is the one signal that
-      // distinguishes a pack-side miss (bundle has no `android/` payload) from a launch-side miss,
-      // and it prints near the top of the daemon's own stderr.
       System.err.println(
-        "[bundle-daemon] android carriage: resourcesAp_=${res != null} " +
-          "rClasses=${res?.rClassesJar != null} cpEntries=${androidReplayClasspath.size}"
+        "[bundle-daemon] android carriage: cpEntries=${androidReplayClasspath.size}"
       )
     }
 
@@ -403,85 +390,6 @@ class BundleDaemonCommand(args: List<String>) : Command(args) {
     require(sawManifest) {
       "bundle daemon: bundle.json missing in ${bundleFile.path} — cannot resolve IR descriptors"
     }
-  }
-
-  /** The extracted v6 `android/` resource carriage (see [extractAndroidResources]). */
-  private data class AndroidReplayResources(
-    val resourceApk: File,
-    val mergedManifest: File,
-    val rClassesJar: File?,
-  )
-
-  /**
-   * Extract the v6 `android/` resource carriage from [zipBytes] into [androidDir]: the merged
-   * resource APK and manifest (both required) plus the generated R-class jar (optional). Returns
-   * null when the bundle carries no resource APK — a protolayout bundle from a pre-v6 producer, or
-   * one whose pack couldn't locate AGP's merged resources — in which case the daemon falls back to
-   * its pre-v6 (failing) tile-replay path. Each destination is verified to live inside [androidDir]
-   * (Zip Slip guard), same shape as [extractIrArtifacts].
-   */
-  private fun extractAndroidResources(
-    zipBytes: ByteArray,
-    androidDir: File,
-  ): AndroidReplayResources? {
-    val canonical = androidDir.canonicalFile
-    var apk: File? = null
-    var mergedManifest: File? = null
-    var rJar: File? = null
-    ZipInputStream(ByteArrayInputStream(zipBytes)).use { zin ->
-      while (true) {
-        val entry = zin.nextEntry ?: break
-        val name = entry.name
-        if (!entry.isDirectory && name.startsWith("android/")) {
-          val dest = File(androidDir, File(name).name).canonicalFile
-          if (dest.path.startsWith(canonical.path + File.separator)) {
-            dest.outputStream().use { sink -> zin.copyTo(sink) }
-            when (name) {
-              "android/resources.ap_" -> apk = dest
-              "android/AndroidManifest.xml" -> mergedManifest = dest
-              "android/r-classes.jar" -> rJar = dest
-            }
-          }
-        }
-        zin.closeEntry()
-      }
-    }
-    val resolvedApk = apk
-    val resolvedManifest = mergedManifest
-    return if (resolvedApk != null && resolvedManifest != null)
-      AndroidReplayResources(resolvedApk, resolvedManifest, rJar)
-    else null
-  }
-
-  /**
-   * Write the Robolectric `com/android/tools/test_config.properties` the daemon's
-   * RobolectricTestRunner reads from the classpath — the same file AGP generates for the in-Gradle
-   * render path — pointing at the extracted merged resource APK + manifest. Returns [root], which
-   * the caller puts on the daemon `-cp` so the resource resolves. Binary-resources mode:
-   * `android_resource_apk` carries the resource table; package + theme come from
-   * `android_merged_manifest`. [applicationPackage] (when the pack step recorded it) is written as
-   * `android_custom_package` — the package Robolectric/AGP use for the final R class; without it,
-   * for projects whose namespace isn't recoverable from the merged manifest alone, the final R
-   * would resolve against the wrong/default package and tile replay could miss its resources.
-   */
-  private fun writeAndroidTestConfig(
-    root: File,
-    resourceApk: File,
-    mergedManifest: File,
-    applicationPackage: String?,
-  ): File {
-    val dir = File(root, "com/android/tools").apply { mkdirs() }
-    File(dir, "test_config.properties")
-      .writeText(
-        buildString {
-          appendLine("android_resource_apk=${resourceApk.absolutePath}")
-          appendLine("android_merged_manifest=${mergedManifest.absolutePath}")
-          if (!applicationPackage.isNullOrBlank()) {
-            appendLine("android_custom_package=$applicationPackage")
-          }
-        }
-      )
-    return root
   }
 
   private fun createTempWorkDir(): File {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleDaemonCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleDaemonCommand.kt
@@ -110,14 +110,17 @@ class BundleDaemonCommand(args: List<String>) : Command(args) {
       extractIrArtifacts(zipBytes, irDir!!, bundleManifestFile!!, file)
     }
 
-    // Android resource carriage (ungated by IR): any `backend == "android"` bundle carries the app's
+    // Android resource carriage (ungated by IR): any `backend == "android"` bundle carries the
+    // app's
     // merged resource APK + manifest (+ generated R classes) under `android/`, because a classic
-    // `@Preview` that calls `stringResource(R.string.…)` needs the `0x7f` app table just as much as a
+    // `@Preview` that calls `stringResource(R.string.…)` needs the `0x7f` app table just as much as
+    // a
     // Wear tile does. A detached daemon has neither the merged table (no AGP build) nor those R
     // classes, so [AndroidBundleResources] extracts them and synthesizes the Robolectric
     // `com/android/tools/test_config.properties` the daemon's RobolectricTestRunner auto-reads from
     // the classpath — exactly how the in-Gradle render path gets resources — and the config dir + R
-    // jar ride the `-cp` seam below. Empty for a bundle with no `android/` payload (packed before this
+    // jar ride the `-cp` seam below. Empty for a bundle with no `android/` payload (packed before
+    // this
     // carriage / no binary resources): renders framework-resources-only, as before.
     val androidReplayClasspath = mutableListOf<File>()
     if (manifest.backend == "android") {
@@ -167,9 +170,16 @@ class BundleDaemonCommand(args: List<String>) : Command(args) {
       add("-cp")
       add(
         composeDaemonClasspath(
-          launch.classpath,
-          libJars + resolvedJars + androidReplayClasspath,
-          hasIr,
+          // The Android resource carriage (test-config dir + r-classes jar) must reach the
+          // daemon `-cp` for *every* android bundle, not just IR-carrying ones — a classic
+          // `stringResource` preview needs the resource table regardless of IR. Fold it into
+          // the base classpath so it survives the `hasIr` gate that only guards the carried
+          // lib/coordinate jars.
+          base =
+            (listOf(launch.classpath) + androidReplayClasspath.map { it.absolutePath })
+              .joinToString(File.pathSeparator),
+          carriedDeps = libJars + resolvedJars,
+          hasIr = hasIr,
         )
       )
       add("ee.schimke.composeai.daemon.DaemonMain")

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt
@@ -1,6 +1,7 @@
 package ee.schimke.composeai.cli.serve
 
 import ee.schimke.composeai.cli.AndroidBundleLaunch
+import ee.schimke.composeai.cli.AndroidBundleResources
 import ee.schimke.composeai.cli.BundleReader
 import ee.schimke.composeai.cli.CoordinateResolver
 import ee.schimke.composeai.cli.PreviewManifest
@@ -165,6 +166,26 @@ internal object ServeBundleDaemon {
       (listOf(classesDir) + extraClasspathDirs.filter { it.isDirectory } + libJars + resolvedJars)
         .joinToString(File.pathSeparator) { it.absolutePath }
 
+    // Android app-resource carriage: a classic `@Preview` that calls `stringResource(R.string.…)`
+    // needs the app's own `0x7f` resource table at render time. Extract the bundle's carried
+    // `android/` payload and synthesize the Robolectric `test_config.properties` onto the daemon
+    // `-cp` — the same wiring `bundle daemon` uses — or Robolectric throws
+    // `Resources$NotFoundException`. Empty for a desktop bundle, or an Android bundle packed before
+    // this carriage existed (renders framework-resources-only, exactly as before).
+    val androidResourceClasspath =
+      if (backend == "android")
+        AndroidBundleResources.daemonClasspath(
+            zipBytes,
+            destDir,
+            manifest.androidResources?.applicationPackage,
+          )
+          .map { it.absolutePath }
+          .also {
+            if (it.isNotEmpty())
+              onLog("catalog $system: android resource carriage → ${it.size} classpath entry(s)")
+          }
+      else emptyList()
+
     val backendLaunch =
       when (backend) {
         "android" -> androidBundleDaemonLaunch(system, onLog)
@@ -181,7 +202,7 @@ internal object ServeBundleDaemon {
         // classpath / JVM args / sysprops differ (see [BackendDaemonLaunch]).
         mainClass = DAEMON_MAIN_CLASS,
         javaLauncher = null,
-        classpath = backendLaunch.daemonClasspath,
+        classpath = backendLaunch.daemonClasspath + androidResourceClasspath,
         jvmArgs = backendLaunch.jvmArgs,
         systemProperties =
           buildMap {

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/AndroidBundleResourcesTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/AndroidBundleResourcesTest.kt
@@ -54,7 +54,8 @@ class AndroidBundleResourcesTest {
   @Test
   fun `extract returns null when the bundle carries no android payload`() {
     val dir = Files.createTempDirectory("abr-none").toFile()
-    val zip = zipOf(mapOf("classes/app.jar" to byteArrayOf(1), "previews.json" to "{}".toByteArray()))
+    val zip =
+      zipOf(mapOf("classes/app.jar" to byteArrayOf(1), "previews.json" to "{}".toByteArray()))
 
     assertNull(AndroidBundleResources.extract(zip, File(dir, "android")))
   }
@@ -73,7 +74,8 @@ class AndroidBundleResourcesTest {
     val apk = File(dir, "resources.ap_").apply { writeText("x") }
     val manifest = File(dir, "AndroidManifest.xml").apply { writeText("y") }
 
-    val root = AndroidBundleResources.writeTestConfig(File(dir, "cfg"), apk, manifest, "com.example.app")
+    val root =
+      AndroidBundleResources.writeTestConfig(File(dir, "cfg"), apk, manifest, "com.example.app")
 
     val props = File(root, "com/android/tools/test_config.properties").readText()
     assertTrue(props.contains("android_resource_apk=${apk.absolutePath}"), props)

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/AndroidBundleResourcesTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/AndroidBundleResourcesTest.kt
@@ -1,0 +1,126 @@
+package ee.schimke.composeai.cli
+
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.nio.file.Files
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for the packed-bundle Android app-resource carriage — the fix that lets a detached
+ * Robolectric render resolve `stringResource(R.string.…)` (`0x7f…`) instead of throwing
+ * `Resources$NotFoundException`. Pure file/zip logic, so it runs on any `:cli:test` (no Android
+ * render toolchain needed).
+ */
+class AndroidBundleResourcesTest {
+
+  private fun zipOf(entries: Map<String, ByteArray>): ByteArray {
+    val out = ByteArrayOutputStream()
+    ZipOutputStream(out).use { zos ->
+      for ((name, bytes) in entries) {
+        zos.putNextEntry(ZipEntry(name))
+        zos.write(bytes)
+        zos.closeEntry()
+      }
+    }
+    return out.toByteArray()
+  }
+
+  @Test
+  fun `extract pulls the resource apk, manifest and r-classes from an android bundle`() {
+    val dir = Files.createTempDirectory("abr-extract").toFile()
+    val zip =
+      zipOf(
+        mapOf(
+          "classes/app.jar" to byteArrayOf(1, 2, 3),
+          "android/resources.ap_" to "APK".toByteArray(),
+          "android/AndroidManifest.xml" to "<manifest/>".toByteArray(),
+          "android/r-classes.jar" to "RJAR".toByteArray(),
+        )
+      )
+
+    val res = AndroidBundleResources.extract(zip, File(dir, "android"))
+
+    assertTrue(res != null)
+    assertEquals("APK", res.resourceApk.readText())
+    assertEquals("<manifest/>", res.mergedManifest.readText())
+    assertEquals("RJAR", res.rClassesJar?.readText())
+  }
+
+  @Test
+  fun `extract returns null when the bundle carries no android payload`() {
+    val dir = Files.createTempDirectory("abr-none").toFile()
+    val zip = zipOf(mapOf("classes/app.jar" to byteArrayOf(1), "previews.json" to "{}".toByteArray()))
+
+    assertNull(AndroidBundleResources.extract(zip, File(dir, "android")))
+  }
+
+  @Test
+  fun `extract needs both apk and manifest — apk alone is not enough`() {
+    val dir = Files.createTempDirectory("abr-partial").toFile()
+    val zip = zipOf(mapOf("android/resources.ap_" to "APK".toByteArray()))
+
+    assertNull(AndroidBundleResources.extract(zip, File(dir, "android")))
+  }
+
+  @Test
+  fun `writeTestConfig emits the Robolectric properties AGP would, incl the custom package`() {
+    val dir = Files.createTempDirectory("abr-cfg").toFile()
+    val apk = File(dir, "resources.ap_").apply { writeText("x") }
+    val manifest = File(dir, "AndroidManifest.xml").apply { writeText("y") }
+
+    val root = AndroidBundleResources.writeTestConfig(File(dir, "cfg"), apk, manifest, "com.example.app")
+
+    val props = File(root, "com/android/tools/test_config.properties").readText()
+    assertTrue(props.contains("android_resource_apk=${apk.absolutePath}"), props)
+    assertTrue(props.contains("android_merged_manifest=${manifest.absolutePath}"), props)
+    assertTrue(props.contains("android_custom_package=com.example.app"), props)
+  }
+
+  @Test
+  fun `writeTestConfig omits the custom package when none was recorded`() {
+    val dir = Files.createTempDirectory("abr-cfg-nopkg").toFile()
+    val apk = File(dir, "resources.ap_").apply { writeText("x") }
+    val manifest = File(dir, "AndroidManifest.xml").apply { writeText("y") }
+
+    val root = AndroidBundleResources.writeTestConfig(File(dir, "cfg"), apk, manifest, null)
+
+    val props = File(root, "com/android/tools/test_config.properties").readText()
+    assertTrue(!props.contains("android_custom_package"), props)
+  }
+
+  @Test
+  fun `daemonClasspath returns the test-config dir plus r-classes jar for an android bundle`() {
+    val dir = Files.createTempDirectory("abr-cp").toFile()
+    val zip =
+      zipOf(
+        mapOf(
+          "android/resources.ap_" to "APK".toByteArray(),
+          "android/AndroidManifest.xml" to "<manifest/>".toByteArray(),
+          "android/r-classes.jar" to "RJAR".toByteArray(),
+        )
+      )
+
+    val cp = AndroidBundleResources.daemonClasspath(zip, dir, "com.example.app")
+
+    assertEquals(2, cp.size)
+    // First entry is the synthesized test-config root; the Robolectric properties live under it.
+    val props = File(cp[0], "com/android/tools/test_config.properties")
+    assertTrue(props.isFile, "expected test_config.properties under ${cp[0]}")
+    assertTrue(props.readText().contains("android_resource_apk="))
+    // Second entry is the extracted R-classes jar.
+    assertEquals("RJAR", cp[1].readText())
+  }
+
+  @Test
+  fun `daemonClasspath is empty for a bundle with no android payload`() {
+    val dir = Files.createTempDirectory("abr-cp-none").toFile()
+    val zip = zipOf(mapOf("classes/app.jar" to byteArrayOf(1)))
+
+    assertTrue(AndroidBundleResources.daemonClasspath(zip, dir, null).isEmpty())
+  }
+}

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
@@ -429,15 +429,15 @@ abstract class BundlePreviewTask : DefaultTask() {
         )
     }
 
-    // v6 Android resource carriage: a protolayout (Wear tile) IR replays through `TileRenderer`,
-    // which resolves a library theme resource and links the non-final library `R$style` class —
-    // neither of which a detached daemon has. When the bundle carries protolayout IR, pack the
-    // AGP-built merged resource APK + manifest and the generated library R classes under `android/`
-    // (added to `irZipFiles`, written verbatim by `buildZip`). No-op for desktop / non-protolayout.
+    // Android resource carriage: pack the AGP-built merged resource APK + manifest (+ generated
+    // library R classes) under `android/` for ANY Android bundle. Both a Wear-tile IR replay (via
+    // `TileRenderer`, which links the library `R$style`) AND a classic `@Preview` that calls
+    // `stringResource(R.string.…)` need the app's `0x7f` resource table at detached-render time — a
+    // detached daemon has neither the merged table nor those R classes. Added to `irZipFiles`,
+    // written verbatim by `buildZip`. `resolveAndroidResources` no-ops (returns null) when there's no
+    // prior render / no binary resources, so desktop and render-less packs stay unchanged.
     val androidResources =
-      if (irByPreview.values.any { it.format == IR_FORMAT_PROTOLAYOUT })
-        resolveAndroidResources(irZipFiles)
-      else null
+      if (backend.get() == "android") resolveAndroidResources(irZipFiles) else null
 
     // v7 optional data-extension carriage: when asked, pack the per-extension report sidecars (a11y
     // findings, theme tokens, …) so a detached reader can surface that data without re-rendering.
@@ -838,9 +838,9 @@ abstract class BundlePreviewTask : DefaultTask() {
         .firstOrNull { it.isFile && it.name == "test_config.properties" }
     if (configFile == null) {
       logger.warn(
-        "composePreviewBundle: protolayout IR present but no test_config.properties on the " +
-          "unit-test config / runtime-classpath inputs — tile replay on a detached daemon can't " +
-          "resolve resources. Run composePreviewRender first so AGP generates it."
+        "composePreviewBundle: no test_config.properties on the unit-test config / runtime-classpath " +
+          "inputs — a detached daemon can't resolve app resources (stringResource / tile themes). " +
+          "Run composePreviewRender first so AGP generates it."
       )
       return null
     }
@@ -871,9 +871,9 @@ abstract class BundlePreviewTask : DefaultTask() {
     val manifestFile = resolveModulePath(manifestPath)
     if (apkFile == null || !apkFile.isFile || manifestFile == null || !manifestFile.isFile) {
       logger.warn(
-        "composePreviewBundle: protolayout IR present but the merged resource APK / manifest from " +
-          "test_config.properties is missing (apk='$apkPath', manifest='$manifestPath') — tile " +
-          "replay on a detached daemon can't resolve resources."
+        "composePreviewBundle: the merged resource APK / manifest from test_config.properties is " +
+          "missing (apk='$apkPath', manifest='$manifestPath') — a detached daemon can't resolve app " +
+          "resources (stringResource / tile themes)."
       )
       return null
     }
@@ -882,7 +882,7 @@ abstract class BundlePreviewTask : DefaultTask() {
     val rClassesJar = packAndroidRClasses()
     if (rClassesJar != null) zipFiles[ANDROID_R_CLASSES_JAR_PATH] = rClassesJar
     logger.lifecycle(
-      "composePreviewBundle — carried Android resources for protolayout replay " +
+      "composePreviewBundle — carried Android resources for detached render " +
         "(apk=${apkFile.length()}B, manifest=${manifestFile.length()}B, " +
         "rClasses=${if (rClassesJar != null) "${rClassesJar.size}B" else "none"})"
     )

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
@@ -434,7 +434,8 @@ abstract class BundlePreviewTask : DefaultTask() {
     // `TileRenderer`, which links the library `R$style`) AND a classic `@Preview` that calls
     // `stringResource(R.string.…)` need the app's `0x7f` resource table at detached-render time — a
     // detached daemon has neither the merged table nor those R classes. Added to `irZipFiles`,
-    // written verbatim by `buildZip`. `resolveAndroidResources` no-ops (returns null) when there's no
+    // written verbatim by `buildZip`. `resolveAndroidResources` no-ops (returns null) when there's
+    // no
     // prior render / no binary resources, so desktop and render-less packs stay unchanged.
     val androidResources =
       if (backend.get() == "android") resolveAndroidResources(irZipFiles) else null


### PR DESCRIPTION
## Summary

An Android `@Preview` that calls `stringResource(R.string.…)` fails to render from a **packed bundle** (`bundle daemon` / `serve --catalogs` live bundle) with:

```
android.content.res.Resources$NotFoundException: String resource ID #0x7f0a0022
```

This is the real blocker behind "Wear overrides don't work on preview.coo.ee": `wear-m3`'s stickers use `stringResource(R.string.label_filled)` etc., so the baked PNGs render fine (from a Gradle source build, where AGP puts `test_config.properties` on the classpath), but the **live daemon** — rendering from the packed bundle — has no app resource table and throws on every `stringResource`.

**Root cause:** the app's merged resource table (`resources.arsc` / `apk-for-local-test.ap_`) is neither **packed** into the bundle nor **registered** with Robolectric on the packed-bundle path, because the entire Android resource carriage was **gated on protolayout (Wear-tile) IR** (`IR_FORMAT_PROTOLAYOUT`). A classic Compose `@Preview` produces no IR → gate false → nothing carried, nothing loaded → `0x7f` lookups throw.

## Changes (un-gate the carriage for any `backend == "android"` bundle)

- **Pack** — `BundlePreviewTask`: run `resolveAndroidResources` for any Android bundle, not just protolayout-IR ones. The AGP inputs (`androidUnitTestConfig` / `…RuntimeClasspath`) are already wired unconditionally, so no Gradle re-wiring needed.
- **Load** — new shared, unit-tested `AndroidBundleResources` helper (extract `android/` + synthesize the Robolectric `test_config.properties`):
  - `ServeBundleDaemon` (the serve live-bundle path, which had **no** resource wiring) now prepends it to the daemon `-cp`.
  - `BundleDaemonCommand` un-gates its `&& hasIr` condition and routes through the same helper (its old private copies removed — net −71 lines).

`resolveAndroidResources` / `daemonClasspath` no-op when a bundle carries no `android/` payload, so **desktop and render-less packs are unchanged**.

## Test plan

- **New unit tests** — `AndroidBundleResourcesTest` (7 cases): extract from a synthetic bundle zip, the `test_config.properties` contents (incl. `android_custom_package`), the daemon classpath entries, and the no-payload/partial-payload null paths. Pure file/zip logic, runs on any `:cli:test`.
- **CI is the integration gate** — the `Daemon Harness (android, real renderer)` job exercises the Robolectric render path; a cold `:cli` build didn't complete locally in this environment, so I couldn't produce a local green (the new helper's logic is covered by the unit tests above).
- **Visual proof is post-deploy**: this fixes the live re-render, so the evidence is `wear-m3` overrides working in the `serve` viewer once released + repacked. It's daemon/bundle plumbing (no `@Preview` output changes in this diff), so no rendered before/after applies to the change itself.

## Deploy chain (for it to reach preview.coo.ee)

Needs a CLI release (so `bundle pack` carries resources **and** `serve` loads them) → a `design-artifacts` regen (repacks the `wear-m3` bundle **with** `android/` resources) → the box picks up the new bundle. Until both the pack and load sides ship together, the bundle carries no `android/` payload and the daemon falls back to framework resources (i.e. today's behaviour), so this is safe to land incrementally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LYKGF6PKwGVfqR7FLDyuQ9)_