### PR TITLE
docs(serve): clarify the automatic image→Watchtower deploy chain and Wear live lane

### DIFF
--- a/deploy/image/README.md
+++ b/deploy/image/README.md
@@ -10,9 +10,12 @@ and pushed to GHCR, so hosts just pull it.
 - **Image:** `ghcr.io/yschimke/compose-preview-host:<version>` (and `:latest`)
 - **Render target:** Compose **Desktop** (Skiko software GL) for the warm-render sample, **plus** a
   baked **Android/Robolectric** daemon + minimal Android SDK so a served Android **Wear** catalog
-  (`wear-m3`) *can* render live server-side — provided its stickers carry the `previewId` daemon
-  mapping (the currently-published `wear-m3` catalog doesn't yet, so it serves baked in the viewer;
-  see `docs/public-preview-server.md`). This is what `preview.coo.ee` runs.
+  (`wear-m3`) renders live server-side. Lighting the Android live lane needs the catalog's stickers to
+  carry the `previewId` daemon mapping **and** the bundle to carry the app's resource table under
+  `android/`; both shipped in **0.16.50** (previewId #2492, app-resource carriage #2498 + missing-
+  resource placeholder fallback #2499), so `wear-m3` renders live once the box rolls that image and
+  re-fetches the regenerated bundle. See `docs/public-preview-server.md`. This is what
+  `preview.coo.ee` runs.
 - **Bundle uploads:** disabled. **Auth:** shared token. **TLS:** via Caddy.
 
 ## How it's fast

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -186,11 +186,27 @@ release that carries `--catalogs-unlisted`).
 | Picks up a regenerated `design-artifacts/<system>` branch | via the same auto-refresh (rebuild + re-run) | **auto**: the server re-checks each catalog branch head every `SERVE_CATALOG_REFRESH`s (default 600) and re-fetches on change — **no restart**. Watchtower only rolls the *image*; this keeps the *catalog content* current. Set `SERVE_CATALOG_REFRESH=0` to disable. |
 
 `preview.coo.ee` **runs the prebuilt [`deploy/image`](../deploy/image)** — a `docker pull` of the
-released `compose-preview-host` image on an **8 GB host**, no build, with Watchtower rolling each new
-release image (and the server auto-refreshing the catalog branches in between). This is the canonical
-public deployment. Because the image bakes the Android/Robolectric daemon + a minimal Android SDK, it
-*can* serve an Android catalog like **Wear** live server-side — but only once that catalog's stickers
-carry the `previewId` daemon-mapping (see the live-lane note below).
+released `compose-preview-host` image on an **8 GB host**, no build. The **whole deploy chain is
+automatic**: cutting a CLI release publishes the host image to GHCR (release-please invokes
+[`preview-host-image.yml`](../.github/workflows/preview-host-image.yml) via `workflow_call`, tagging
+that version **and** `:latest`), and **Watchtower** on the box polls the `:latest` tag hourly and
+rolls the `preview` container onto the new image — no manual step.
+
+> **Why the *Publish preview-host image* Actions list can look stale.** Because that publish runs as
+> a **reusable-workflow call** from the release job, its runs appear *inside the release-please run*,
+> **not** as standalone *Publish preview-host image* runs — so that workflow's run list shows only the
+> occasional manual `workflow_dispatch`, and can read as "hasn't built since <months ago>" even though
+> **every release rebuilds the image**. To confirm which build is deployed, check the release-please
+> run, the GHCR `:latest` digest, or [`GET /version`](#endpoints) — not the preview-host-image run list.
+
+The two delivery paths move on **different clocks**: a **daemon/CLI change** reaches the box on the
+next Watchtower pull of a new release image, while a **`design-artifacts` regen** reaches it much
+sooner — the server **auto-refreshes the catalog branches** in between image rolls (re-checks each
+`design-artifacts/<system>` head every `SERVE_CATALOG_REFRESH`s, default 600, and re-fetches on
+change, no restart). So a catalog repack needs no image roll, but a change to how the daemon *renders*
+(or *loads resources*) does. This is the canonical public deployment. The image bakes the
+Android/Robolectric daemon + a minimal Android SDK, so it serves the Android **Wear** catalog
+(`wear-m3`) live server-side (see the live-lane note below).
 
 The from-source [`deploy/vps`](../deploy/vps) path (`cd deploy/vps && DOMAIN=preview.coo.ee
 ./setup.sh`) is the **alternative** for when you need a serve feature *before* it ships in a CLI
@@ -245,15 +261,22 @@ runtime — the desktop-only from-source `deploy/vps` — instead falls back to 
 catalogs, fail-closed: no error, just no daemon tier. (`remote-m3` carries no runnable bundle, so it
 stays baked-PNG on either box.)
 
-> **The live lane also needs a `previewId` sticker→daemon mapping.** The viewer only exposes the
-> live/override controls for a preview whose baked sticker is mapped to its daemon twin — the
-> `previewId` field the exporter records on each `catalog.json` image, from which `ServeCatalogStore`
-> builds the daemon `alias` (`canRenderOverridesFor`). `compose-m3` carries these; the currently
-> published **`wear-m3`/`remote-m3` stickers do not**, so even with the Robolectric daemon running and
-> prewarmed, the viewer serves them baked and the override controls are disabled ("input requires a
-> live stream" if Live Compose is selected). Lighting up the Android live lane end-to-end therefore
-> needs the exporter to emit `previewId` for these catalogs, followed by a `design-artifacts/<system>`
-> regen — the daemon plumbing on the box is already in place.
+> **The live lane also needs a `previewId` sticker→daemon mapping — and, for Android, the app's
+> resource table.** The viewer only exposes live/override controls for a preview whose baked sticker
+> is mapped to its daemon twin — the `previewId` field the exporter records on each `catalog.json`
+> image, from which `ServeCatalogStore` builds the daemon `alias` (`canRenderOverridesFor`). For an
+> **Android** catalog there is a second requirement: the packed bundle must **carry the app's compiled
+> resource table** (`resources.arsc` / `apk-for-local-test.ap_` under `android/`) *and* the daemon
+> must load it onto the render classpath, or a classic `stringResource(R.string.…)` render throws
+> `Resources$NotFoundException` and the whole preview fails.
+>
+> Both requirements have **landed for `wear-m3`**: `previewId` for un-themed state-variant catalogs
+> (#2492), and the Android app-resource carriage + daemon-load (#2498) — with a missing-resource
+> **placeholder fallback** (#2499, renders an obvious `⟦res 0x7f…⟧` / magenta marker rather than
+> crashing) as a safety net — shipped in **0.16.50**. So `wear-m3` renders live and per-variant once
+> the box has **rolled the 0.16.50 image** (Watchtower) **and** re-fetched the `design-artifacts/wear-m3`
+> bundle regenerated to carry the `android/` resources (catalog auto-refresh). `compose-m3` carried
+> `previewId` already; `remote-m3` stays baked-PNG — it publishes no runnable bundle.
 
 ### Bounding the live tier — `--live-seats` / `SERVE_LIVE_SEATS`
 


### PR DESCRIPTION
## Summary

Two doc corrections to `docs/public-preview-server.md` + `deploy/image/README.md`, both prompted by real confusion hit while shipping the Wear live-render fix:

1. **Spell out that the deploy chain is fully automatic.** Each CLI release auto-publishes the preview-host image to GHCR via a `release-please` → `preview-host-image.yml` **`workflow_call`**, and Watchtower on the box rolls `:latest`. The subtlety worth documenting: because that publish is a *reusable-workflow call*, its runs appear **inside the release-please run**, not as standalone *Publish preview-host image* runs — so that workflow's Actions list shows only occasional manual dispatches and can look months-stale even though every release rebuilds the image. Added the reliable ways to confirm the deployed build (release-please run / GHCR `:latest` digest / `GET /version`), and clarified that catalog-branch auto-refresh and Watchtower image rolls move on **different clocks** (a `design-artifacts` regen lands on the next refresh; a daemon/CLI change needs the next image pull).

2. **Update the stale Wear live-lane caveat.** It said `wear-m3` stickers carry no `previewId` mapping so the live lane is dark. That's now resolved: `previewId` for un-themed state-variant catalogs (#2492) and the Android **app-resource carriage + daemon-load** (#2498) — plus a missing-resource **placeholder fallback** (#2499) — shipped in **0.16.50**. Documented both requirements (previewId mapping *and*, for Android, the `android/` resource table on the bundle `-cp`) and that `wear-m3` renders live once the box rolls the 0.16.50 image and re-fetches the regenerated bundle.

## Test plan

Docs-only; no code paths touched. Prose verified against the actual `preview-host-image.yml` triggers (`workflow_dispatch` / `workflow_call` from release-please / `release: published`) and the shipped behaviour of #2492 / #2498 / #2499.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LYKGF6PKwGVfqR7FLDyuQ9)_