### PR TITLE
feat(figma-svg): vectorize ImageVector icons in the layered SVG export

### DIFF
--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopLayoutInspectorTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopLayoutInspectorTest.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.ImageComposeScene
@@ -15,8 +16,11 @@ import androidx.compose.ui.draw.paint
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.painter.BitmapPainter
 import androidx.compose.ui.graphics.painter.ColorPainter
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.unit.Density
@@ -97,6 +101,50 @@ class DesktopLayoutInspectorTest {
     // reflection walk reaches `LayoutNode` children after `scene.render()` Z-sorts the tree.
     assertTrue("root must have a measured width", root.size.width > 0)
     assertTrue("root must have a non-empty subtree", root.children.isNotEmpty())
+  }
+
+  @Test
+  fun captures_an_imagevector_icon_as_editable_vector_paths() {
+    // Tier 1 capture: an `Icon` backed by an `ImageVector` paints through a `VectorPainter`; the
+    // inspector must reflect its path tree into `vectorGraphic` (in the vector's 24×24 viewport) so
+    // the figma-svg export can emit `<path>`s instead of a raster crop. Exercises the reflection
+    // against the real androidx VectorPainter/VectorComponent/PathComponent/PathNode classes.
+    val star =
+      ImageVector.Builder(
+          defaultWidth = 24.dp,
+          defaultHeight = 24.dp,
+          viewportWidth = 24f,
+          viewportHeight = 24f,
+        )
+        .apply {
+          path(fill = SolidColor(Color(0xFF112233))) {
+            moveTo(12f, 0f)
+            lineTo(15f, 9f)
+            lineTo(24f, 9f)
+            lineTo(17f, 14f)
+            lineTo(20f, 24f)
+            lineTo(12f, 18f)
+            lineTo(4f, 24f)
+            lineTo(7f, 14f)
+            lineTo(0f, 9f)
+            lineTo(9f, 9f)
+            close()
+          }
+        }
+        .build()
+
+    val root = writeAndRead { Icon(star, "star", Modifier.size(48.dp)) }
+
+    val node = root.firstWhere { it.vectorGraphic != null }
+    assertNotNull("an ImageVector-backed Icon must carry a captured vectorGraphic", node)
+    val graphic = node!!.vectorGraphic!!
+    assertEquals(24f, graphic.viewportWidth, 0.01f)
+    assertEquals(24f, graphic.viewportHeight, 0.01f)
+    assertEquals("one path captured", 1, graphic.paths.size)
+    val path = graphic.paths.first()
+    assertTrue("path starts at the star tip", path.pathData.startsWith("M12 0"))
+    assertTrue("path is closed", path.pathData.trimEnd().endsWith("Z"))
+    assertEquals("solid fill resolved", "#FF112233", path.fillArgb)
   }
 
   @Test

--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
@@ -33,6 +33,8 @@ import ee.schimke.composeai.daemon.protocol.RecordingProbeNode
 import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsProduct
 import ee.schimke.composeai.data.layoutinspector.LayoutInspectorCurvedText
 import ee.schimke.composeai.data.layoutinspector.LayoutInspectorProduct
+import ee.schimke.composeai.data.layoutinspector.LayoutInspectorVectorGraphic
+import ee.schimke.composeai.data.layoutinspector.LayoutInspectorVectorPath
 import ee.schimke.composeai.data.layoutinspector.SemanticsRefs
 import ee.schimke.composeai.data.render.PreviewContext
 import ee.schimke.composeai.data.render.extensions.compose.ExtensionSlotTables
@@ -796,6 +798,11 @@ internal object ComposeLayoutInspector {
     // reproduce them as an SVG `<textPath>` instead of dropping the clock.
     val curvedTexts =
       if (ownComponent.contains("Curved")) CurvedTextExtractor.extract(this) else emptyList()
+    // An `Icon`/`Image` backed by an `ImageVector` paints through a `VectorPainter`; pull its path
+    // tree (Tier 1) so the figma-svg export emits editable `<path>`s instead of a raster crop.
+    // Reflective + best-effort: any failure (or a bitmap/gradient/transformed painter) yields null
+    // and the node simply rasters as before.
+    val vectorGraphic = VectorGraphicExtractor.extract(this)
     val children = children.map { it.toWireNode(rootCoords, sources, density) }
     val modifiers = modifierInfo
     return LayoutInspectorNode(
@@ -824,6 +831,7 @@ internal object ComposeLayoutInspector {
           density = density,
         ),
       curvedTexts = curvedTexts,
+      vectorGraphic = vectorGraphic,
       children = children,
     )
   }
@@ -985,6 +993,189 @@ internal object ComposeLayoutInspector {
 
     private fun floatField(o: Any, name: String): Double? =
       runCatching { (field(o, name) as? Float)?.toDouble() }.getOrNull()
+  }
+
+  /**
+   * Extracts an editable [LayoutInspectorVectorGraphic] from a node whose `Icon`/`Image` paints an
+   * `ImageVector` through a `Modifier.paint(VectorPainter)`. Reflects the painter's live vector tree
+   * (`VectorComponent` → `GroupComponent`/`PathComponent`) into SVG path data + solid paints, in the
+   * vector's own viewport coordinates. All reflective and best-effort — any failure yields null and
+   * the node keeps its raster fallback:
+   * - a `BitmapPainter`/`ColorPainter`/other painter (not a `VectorPainter`) → null,
+   * - a path with a gradient/brush paint (no resolvable solid colour) is dropped, and a graphic left
+   *   with no paintable path → null (matching the vector-vs-raster rule the export already follows),
+   * - a group carrying a non-identity transform (translate/scale/rotate/clip) → null, so a
+   *   transformed icon rasters rather than emitting misplaced geometry (kept minimal on purpose).
+   */
+  private object VectorGraphicExtractor {
+    fun extract(node: LayoutNodeFacade): LayoutInspectorVectorGraphic? =
+      runCatching { extractOrNull(node) }.getOrNull()
+
+    private fun extractOrNull(node: LayoutNodeFacade): LayoutInspectorVectorGraphic? {
+      val painter =
+        node.modifierInfo
+          .asSequence()
+          .mapNotNull { info -> runCatching { field(info.modifier, "painter") }.getOrNull() }
+          .firstOrNull { it.javaClass.simpleName == "VectorPainter" } ?: return null
+      val vector = field(painter, "vector") ?: return null // VectorComponent
+      val (vw, vh) = viewport(vector) ?: return null
+      if (vw <= 0f || vh <= 0f) return null
+      val root = field(vector, "root") ?: return null // GroupComponent
+      val paths = ArrayList<LayoutInspectorVectorPath>()
+      if (!collect(root, paths) || paths.isEmpty()) return null
+      return LayoutInspectorVectorGraphic(vw, vh, paths)
+    }
+
+    /** The vector's viewport, trying `viewportWidth`/`viewportHeight` then a `viewportSize` Size. */
+    private fun viewport(vector: Any): Pair<Float, Float>? {
+      floatField(vector, "viewportWidth")?.let { w ->
+        floatField(vector, "viewportHeight")?.let { h -> return w.toFloat() to h.toFloat() }
+      }
+      // A `Size` value class packs two floats into a Long (width high bits, height low bits).
+      longField(vector, "viewportSize")?.let { packed ->
+        val w = Float.fromBits((packed shr 32).toInt())
+        val h = Float.fromBits((packed and 0xFFFFFFFFL).toInt())
+        if (w > 0f && h > 0f) return w to h
+      }
+      return null
+    }
+
+    /**
+     * Walks a `VNode` tree collecting `PathComponent`s. Returns false when a group carries a
+     * non-identity transform — the caller then drops to raster rather than emit misplaced paths.
+     */
+    private fun collect(vnode: Any, out: MutableList<LayoutInspectorVectorPath>): Boolean {
+      when (vnode.javaClass.simpleName) {
+        "GroupComponent" -> {
+          if (!isIdentityGroup(vnode)) return false
+          val children = field(vnode, "children") as? List<*> ?: return true
+          for (child in children) if (child != null && !collect(child, out)) return false
+          return true
+        }
+        "PathComponent" -> {
+          pathOf(vnode)?.let(out::add)
+          return true
+        }
+        else -> return true
+      }
+    }
+
+    private fun isIdentityGroup(g: Any): Boolean {
+      fun v(name: String, id: Float) = (floatField(g, name)?.toFloat() ?: id) == id
+      val clip = runCatching { field(g, "clipPathData") as? List<*> }.getOrNull()
+      return v("translationX", 0f) &&
+        v("translationY", 0f) &&
+        v("scaleX", 1f) &&
+        v("scaleY", 1f) &&
+        v("rotation", 0f) &&
+        v("pivotX", 0f) &&
+        v("pivotY", 0f) &&
+        (clip == null || clip.isEmpty())
+    }
+
+    private fun pathOf(p: Any): LayoutInspectorVectorPath? {
+      val nodes = field(p, "pathData") as? List<*> ?: return null
+      val d = pathData(nodes)
+      if (d.isBlank()) return null
+      val fill = brushArgb(runCatching { field(p, "fill") }.getOrNull())
+      val stroke = brushArgb(runCatching { field(p, "stroke") }.getOrNull())
+      if (fill == null && stroke == null) return null
+      val strokeWidth = if (stroke != null) (floatField(p, "strokeLineWidth")?.toFloat() ?: 0f) else 0f
+      // `PathFillType` is a value class over Int (NonZero = 0, EvenOdd = 1), so the backing field
+      // reads back as an Int; fall back to a name match for any boxed representation.
+      val fillType = runCatching { field(p, "pathFillType") }.getOrNull()
+      val evenOdd =
+        when (fillType) {
+          is Int -> fillType == 1
+          else -> fillType?.toString()?.contains("EvenOdd", ignoreCase = true) == true
+        }
+      return LayoutInspectorVectorPath(
+        pathData = d,
+        fillArgb = fill,
+        fillAlpha = floatField(p, "fillAlpha")?.toFloat() ?: 1f,
+        strokeArgb = stroke,
+        strokeWidth = strokeWidth,
+        strokeAlpha = floatField(p, "strokeAlpha")?.toFloat() ?: 1f,
+        evenOdd = evenOdd,
+      )
+    }
+
+    /** A `SolidColor` brush's colour as `#AARRGGBB`; null for gradient/none or a non-sRGB packing. */
+    private fun brushArgb(brush: Any?): String? {
+      if (brush == null || brush.javaClass.simpleName != "SolidColor") return null
+      val packed = (longField(brush, "value") ?: return null).toULong()
+      if (packed and 0xFFFFFFFFuL != 0uL) return null // non-sRGB packing we can't read as flat ARGB
+      val argb = (packed shr 32).toInt()
+      return if (argb == 0) null else "#%08X".format(argb)
+    }
+
+    /** Serialises a `List<PathNode>` (SVG-shaped commands) into an SVG path `d` string. */
+    private fun pathData(nodes: List<*>): String {
+      val sb = StringBuilder()
+      for (n in nodes) {
+        if (n == null) continue
+        fun g(name: String) = num(floatField(n, name)?.toFloat() ?: 0f)
+        fun b(name: String) = if (runCatching { field(n, name) as? Boolean }.getOrNull() == true) "1" else "0"
+        when (n.javaClass.simpleName) {
+          "MoveTo" -> sb.append("M").append(g("x")).append(" ").append(g("y"))
+          "RelativeMoveTo" -> sb.append("m").append(g("dx")).append(" ").append(g("dy"))
+          "LineTo" -> sb.append("L").append(g("x")).append(" ").append(g("y"))
+          "RelativeLineTo" -> sb.append("l").append(g("dx")).append(" ").append(g("dy"))
+          "HorizontalTo" -> sb.append("H").append(g("x"))
+          "RelativeHorizontalTo" -> sb.append("h").append(g("dx"))
+          "VerticalTo" -> sb.append("V").append(g("y"))
+          "RelativeVerticalTo" -> sb.append("v").append(g("dy"))
+          "CurveTo" ->
+            sb.append("C ${g("x1")} ${g("y1")} ${g("x2")} ${g("y2")} ${g("x3")} ${g("y3")}")
+          "RelativeCurveTo" ->
+            sb.append("c ${g("dx1")} ${g("dy1")} ${g("dx2")} ${g("dy2")} ${g("dx3")} ${g("dy3")}")
+          "ReflectiveCurveTo" -> sb.append("S ${g("x1")} ${g("y1")} ${g("x2")} ${g("y2")}")
+          "RelativeReflectiveCurveTo" ->
+            sb.append("s ${g("dx1")} ${g("dy1")} ${g("dx2")} ${g("dy2")}")
+          "QuadTo" -> sb.append("Q ${g("x1")} ${g("y1")} ${g("x2")} ${g("y2")}")
+          "RelativeQuadTo" -> sb.append("q ${g("dx1")} ${g("dy1")} ${g("dx2")} ${g("dy2")}")
+          "ReflectiveQuadTo" -> sb.append("T ${g("x1")} ${g("y1")}")
+          "RelativeReflectiveQuadTo" -> sb.append("t ${g("dx1")} ${g("dy1")}")
+          "ArcTo" ->
+            sb.append(
+              "A ${g("horizontalEllipseRadius")} ${g("verticalEllipseRadius")} ${g("theta")} " +
+                "${b("isMoreThanHalf")} ${b("isPositiveArc")} ${g("arcStartX")} ${g("arcStartY")}"
+            )
+          "RelativeArcTo" ->
+            sb.append(
+              "a ${g("horizontalEllipseRadius")} ${g("verticalEllipseRadius")} ${g("theta")} " +
+                "${b("isMoreThanHalf")} ${b("isPositiveArc")} ${g("arcStartDx")} ${g("arcStartDy")}"
+            )
+          "Close" -> sb.append("Z")
+          else -> return "" // an unknown node type means we can't faithfully serialise — bail
+        }
+        sb.append(" ")
+      }
+      return sb.toString().trim()
+    }
+
+    /** Compact number: drop a trailing `.0` so `12.0` → `12`, keeping the path string small. */
+    private fun num(v: Float): String =
+      if (v == v.toLong().toFloat()) v.toLong().toString() else v.toString()
+
+    private fun field(o: Any, name: String): Any? = findField(o.javaClass, name)?.get(o)
+
+    private fun floatField(o: Any, name: String): Double? =
+      runCatching { (field(o, name) as? Float)?.toDouble() }.getOrNull()
+
+    private fun longField(o: Any, name: String): Long? =
+      runCatching { findField(o.javaClass, name)?.getLong(o) }.getOrNull()
+
+    private fun findField(cls: Class<*>, name: String): java.lang.reflect.Field? {
+      var c: Class<*>? = cls
+      while (c != null) {
+        runCatching {
+            return c!!.getDeclaredField(name).apply { isAccessible = true }
+          }
+        c = c.superclass
+      }
+      return null
+    }
   }
 
   private data class LayoutSource(

--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
@@ -1012,11 +1012,16 @@ internal object ComposeLayoutInspector {
       runCatching { extractOrNull(node) }.getOrNull()
 
     private fun extractOrNull(node: LayoutNodeFacade): LayoutInspectorVectorGraphic? {
+      // The `VectorPainter` an `Icon`/`Image` paints with rides in the node's draw modifier — as a
+      // `Modifier.paint(painter)` `PainterElement` field, or (depending on the Compose version /
+      // wrapping) nested a level inside it. Scan each modifier element's fields shallowly for the
+      // painter rather than assume a single exact field name, so the capture survives those shapes.
+      val seen = java.util.Collections.newSetFromMap(java.util.IdentityHashMap<Any, Boolean>())
       val painter =
-        node.modifierInfo
-          .asSequence()
-          .mapNotNull { info -> runCatching { field(info.modifier, "painter") }.getOrNull() }
-          .firstOrNull { it.javaClass.simpleName == "VectorPainter" } ?: return null
+        (node.modifierInfo.asSequence().map { it.modifier } + sequenceOf(node.measurePolicy))
+          .mapNotNull { candidate -> findVectorPainter(candidate, 0, seen) }
+          .firstOrNull()
+      if (painter == null) return null
       val vector = field(painter, "vector") ?: return null // VectorComponent
       val (vw, vh) = viewport(vector) ?: return null
       if (vw <= 0f || vh <= 0f) return null
@@ -1026,19 +1031,68 @@ internal object ComposeLayoutInspector {
       return LayoutInspectorVectorGraphic(vw, vh, paths)
     }
 
-    /** The vector's viewport, trying `viewportWidth`/`viewportHeight` then a `viewportSize` Size. */
+    /**
+     * Depth-limited search of a modifier element for the `VectorPainter` it draws with. The painter
+     * is usually a direct `painter` field on a `Modifier.paint(...)` `PainterElement`, but a version
+     * bump or a wrapping node can bury it one level down, so scan declared fields (across the class
+     * hierarchy) up to a shallow depth rather than hard-code the path. Identity-tracked to avoid
+     * cycles; confined to `androidx` objects so it never wanders into unrelated graphs.
+     */
+    private fun findVectorPainter(o: Any?, depth: Int, seen: MutableSet<Any>): Any? {
+      if (o == null || depth > 2 || o is String || o is Number || o is Boolean) return null
+      if (!seen.add(o)) return null
+      if (o.javaClass.simpleName == "VectorPainter") return o
+      if (!o.javaClass.name.startsWith("androidx")) return null
+      var c: Class<*>? = o.javaClass
+      while (c != null) {
+        for (f in c.declaredFields) {
+          val v = runCatching { f.isAccessible = true; f.get(o) }.getOrNull()
+          findVectorPainter(v, depth + 1, seen)?.let { return it }
+        }
+        c = c.superclass
+      }
+      return null
+    }
+
+    /**
+     * The vector's viewport in its own units. Older Compose exposed plain `viewportWidth` /
+     * `viewportHeight` floats (or a raw `viewportSize` Long); current Compose keeps it as a
+     * `MutableState<Size>` behind `viewportSize$delegate`, so read the delegate's current value and
+     * unpack the `Size`. A `Size` value class packs two floats into a Long (width high, height low).
+     */
     private fun viewport(vector: Any): Pair<Float, Float>? {
       floatField(vector, "viewportWidth")?.let { w ->
         floatField(vector, "viewportHeight")?.let { h -> return w.toFloat() to h.toFloat() }
       }
-      // A `Size` value class packs two floats into a Long (width high bits, height low bits).
-      longField(vector, "viewportSize")?.let { packed ->
-        val w = Float.fromBits((packed shr 32).toInt())
-        val h = Float.fromBits((packed and 0xFFFFFFFFL).toInt())
-        if (w > 0f && h > 0f) return w to h
-      }
-      return null
+      val packed =
+        sizePackedValue(runCatching { field(vector, "viewportSize") }.getOrNull())
+          ?: sizePackedValue(
+            currentStateValue(runCatching { field(vector, "viewportSize\$delegate") }.getOrNull())
+          )
+          ?: return null
+      val w = Float.fromBits((packed shr 32).toInt())
+      val h = Float.fromBits((packed and 0xFFFFFFFFL).toInt())
+      return if (w > 0f && h > 0f) w to h else null
     }
+
+    /** The current value held by a Compose `MutableState`, via its value getter or newest record. */
+    private fun currentStateValue(state: Any?): Any? {
+      if (state == null) return null
+      runCatching { state.javaClass.getMethod("getValue").invoke(state) }
+        .getOrNull()
+        ?.let { return it }
+      // Fall back to the newest state record's `value` when reading outside a live snapshot.
+      val record = runCatching { field(state, "next") }.getOrNull() ?: return null
+      return runCatching { field(record, "value") }.getOrNull()
+    }
+
+    /** A packed `Size` Long from a boxed `Size` value class (its `packedValue`) or a raw Long. */
+    private fun sizePackedValue(v: Any?): Long? =
+      when (v) {
+        null -> null
+        is Long -> v
+        else -> longField(v, "packedValue")
+      }
 
     /**
      * Walks a `VNode` tree collecting `PathComponent`s. Returns false when a group carries a

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/ComposeSemanticsModels.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/ComposeSemanticsModels.kt
@@ -402,7 +402,49 @@ data class LayoutInspectorNode(
    * baseline arc. Empty for the common case.
    */
   val curvedTexts: List<LayoutInspectorCurvedText> = emptyList(),
+  /**
+   * An editable vector graphic captured from this node's `VectorPainter` (an `Icon`/`Image` backed
+   * by an `ImageVector`), so the `compose/figma-svg` export can emit it as real `<path>` layers
+   * instead of an opaque raster crop. Null for the common node — including a *bitmap*-backed
+   * `Icon`/`Image` (a `BitmapPainter`), which has no vector form and still rasterises. Additive (v6):
+   * older `layout-inspector.json` decodes with `vectorGraphic = null`.
+   */
+  val vectorGraphic: LayoutInspectorVectorGraphic? = null,
   val children: List<LayoutInspectorNode> = emptyList(),
+)
+
+/**
+ * An editable vector graphic (an `ImageVector` an `Icon`/`Image` painted) captured off a node's
+ * `VectorPainter`. Path coordinates are in the vector's own viewport ([viewportWidth] ×
+ * [viewportHeight]); the figma-svg export scales+translates them onto the node's placed bounds, so
+ * the same icon renders crisp at any component size. Only solid (`SolidColor`) fills/strokes are
+ * captured — a gradient/brush leaves its colour null and the export drops that fill rather than
+ * guessing — matching the vector-vs-raster rule the rest of the export follows.
+ */
+@Serializable
+data class LayoutInspectorVectorGraphic(
+  val viewportWidth: Float,
+  val viewportHeight: Float,
+  val paths: List<LayoutInspectorVectorPath>,
+)
+
+/** One `<path>` of a [LayoutInspectorVectorGraphic]: SVG path data plus its resolved solid paint. */
+@Serializable
+data class LayoutInspectorVectorPath(
+  /** SVG path `d` string, in viewport coordinates. */
+  val pathData: String,
+  /** Solid fill as `#AARRGGBB`, or null when there is no fill (or a non-solid brush fill). */
+  val fillArgb: String? = null,
+  /** Extra fill alpha (`fillAlpha`, 0..1) multiplied onto [fillArgb]'s own alpha. */
+  val fillAlpha: Float = 1f,
+  /** Solid stroke as `#AARRGGBB`, or null when there is no stroke (or a non-solid brush stroke). */
+  val strokeArgb: String? = null,
+  /** Stroke width in viewport units; 0 when unstroked. */
+  val strokeWidth: Float = 0f,
+  /** Extra stroke alpha (`strokeAlpha`, 0..1) multiplied onto [strokeArgb]'s own alpha. */
+  val strokeAlpha: Float = 1f,
+  /** True when the fill uses the even-odd winding rule (SVG `fill-rule="evenodd"`). */
+  val evenOdd: Boolean = false,
 )
 
 /**

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvg.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvg.kt
@@ -143,6 +143,13 @@ object FigmaLayeredSvg {
       sb.append("$indent</g>\n")
       return
     }
+    // A captured `ImageVector` (an `Icon`/`Image`) emits as editable `<path>` layers under a
+    // transform that maps the vector's own viewport onto the layer's placed box — the vector
+    // alternative to the `<image>` leaf above. Also a leaf: an icon's art has no editable subtree.
+    if (layer.vector != null) {
+      sb.append(vectorGroup(layer, layer.vector, indent)).append('\n')
+      return
+    }
     val tokenName = layer.fill?.tokenName ?: layer.stroke?.tokenName
     val dataToken =
       if (options.annotateTokens && tokenName != null) """ data-token="${escapeAttr(tokenName)}""""
@@ -264,6 +271,55 @@ object FigmaLayeredSvg {
   private fun backgroundImage(bg: FigmaSvgBackgroundRaster): String =
     """<image href="${escapeAttr(bg.href)}" x="${bg.left}" y="${bg.top}" """ +
       """width="${bg.width}" height="${bg.height}"/>"""
+
+  /**
+   * A captured icon [FigmaSvgVector] as a named `<g>` holding a `translate(left,top)
+   * scale(w/viewportW, h/viewportH)` group of `<path>`s — the vector's viewport coordinates mapped
+   * onto the layer's placed box, so the icon draws crisp at the component's actual size.
+   */
+  private fun vectorGroup(layer: FigmaSvgLayer, vec: FigmaSvgVector, indent: String): String {
+    val sx = if (vec.viewportWidth > 0f) layer.width / vec.viewportWidth.toDouble() else 1.0
+    val sy = if (vec.viewportHeight > 0f) layer.height / vec.viewportHeight.toDouble() else 1.0
+    val sb = StringBuilder()
+    sb.append("""$indent<g id="${escapeAttr(layer.name)}">""").append('\n')
+    sb.append(
+        """$indent  <g transform="translate(${layer.left} ${layer.top}) scale(${fmt(sx)} ${fmt(sy)})">"""
+      )
+      .append('\n')
+    for (p in vec.paths) sb.append(indent).append("    ").append(vectorPath(p)).append('\n')
+    sb.append("$indent  </g>\n")
+    sb.append("$indent</g>")
+    return sb.toString()
+  }
+
+  private fun vectorPath(p: FigmaSvgVectorPath): String {
+    val fill = paintAttr("fill", p.fillArgb, p.fillAlpha) ?: """fill="none""""
+    val fillRule = if (p.evenOdd && p.fillArgb != null) """ fill-rule="evenodd"""" else ""
+    val stroke =
+      if (p.strokeArgb != null && p.strokeWidth > 0f) {
+        paintAttr("stroke", p.strokeArgb, p.strokeAlpha)?.let {
+          """ $it stroke-width="${fmt(p.strokeWidth.toDouble())}""""
+        } ?: ""
+      } else ""
+    return """<path d="${escapeAttr(p.pathData)}" $fill$fillRule$stroke/>"""
+  }
+
+  /**
+   * A captured `#AARRGGBB` paint as an SVG colour + opacity pair (`fill="#RRGGBB"
+   * fill-opacity="0.5"`), folding the channel alpha and the painter's extra [extraAlpha] together.
+   * Null when fully transparent or absent, so the caller can fall back to `fill="none"`.
+   */
+  private fun paintAttr(kind: String, argb: String?, extraAlpha: Float): String? {
+    if (argb == null) return null
+    val hex = argb.removePrefix("#")
+    val (a, rgb) =
+      if (hex.length == 8) hex.substring(0, 2).toInt(16) to hex.substring(2)
+      else 255 to hex.takeLast(6)
+    val op = (a / 255.0) * extraAlpha.coerceIn(0f, 1f).toDouble()
+    if (op <= 0.0) return null
+    val opAttr = if (op < 0.999) """ $kind-opacity="${fmt(op)}"""" else ""
+    return """$kind="#$rgb"$opAttr"""
+  }
 
   private fun shape(layer0: FigmaSvgLayer): String {
     // Compose's `Modifier.border` draws the stroke *inside* the layout bounds; SVG centers a stroke

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgModel.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgModel.kt
@@ -93,6 +93,29 @@ data class FigmaSvgFontFace(
 data class FigmaSvgRaster(val href: String)
 
 /**
+ * An editable vector graphic (an `Icon`/`Image`'s `ImageVector`) emitted as real `<path>` layers —
+ * the vector alternative to a [FigmaSvgRaster] leaf. Path coordinates are in the vector's own
+ * [viewportWidth] × [viewportHeight]; the emitter wraps them in a `translate(left,top)
+ * scale(w/viewportWidth, h/viewportHeight)` group so they land on the layer's placed box.
+ */
+data class FigmaSvgVector(
+  val viewportWidth: Float,
+  val viewportHeight: Float,
+  val paths: List<FigmaSvgVectorPath>,
+)
+
+/** One `<path>` of a [FigmaSvgVector] in viewport coordinates, with its resolved solid paint. */
+data class FigmaSvgVectorPath(
+  val pathData: String,
+  val fillArgb: String? = null,
+  val fillAlpha: Float = 1f,
+  val strokeArgb: String? = null,
+  val strokeWidth: Float = 0f,
+  val strokeAlpha: Float = 1f,
+  val evenOdd: Boolean = false,
+)
+
+/**
  * A raster drawn beneath a layer's content ([FigmaSvgLayer.background]) — the pixels of a
  * `Modifier.drawBehind {…}` cropped to the drawn region, which may be tighter than the layer's own
  * box (a padded `Spacer` paints only the bar). Carries its own bounds so the `<image>` lands on the
@@ -161,6 +184,12 @@ data class FigmaSvgLayer(
   val text: FigmaSvgText? = null,
   /** Set when this layer is an opaque component rendered as an `<image>`. */
   val raster: FigmaSvgRaster? = null,
+  /**
+   * Set when this layer is an `Icon`/`Image` whose `ImageVector` was captured — emitted as editable
+   * `<path>` layers instead of a [raster] crop. Mutually exclusive with [raster]: a vector-backed
+   * icon takes this path, a bitmap-backed one still rasters.
+   */
+  val vector: FigmaSvgVector? = null,
   /**
    * A raster `<image>` drawn *beneath* this layer's own shape/text/children — the pixels of an
    * imperative `Modifier.drawBehind {…}` (a progress track, a slider groove, a custom-drawn
@@ -416,6 +445,32 @@ data class FigmaSvgModel(
       val rasterTargets: MutableList<FigmaSvgRasterTarget> = mutableListOf(),
     )
 
+    /**
+     * The emitter-native [FigmaSvgVector] for a captured [LayoutInspectorVectorGraphic], or null
+     * when it carries nothing paintable — no paths, a degenerate viewport, or only
+     * gradient/brush-filled paths (whose colour the capture left null, matching the
+     * vector-vs-raster rule: what we can't resolve to a flat paint, we don't emit as vector).
+     */
+    private fun LayoutInspectorVectorGraphic.toFigmaSvgVector(): FigmaSvgVector? {
+      if (viewportWidth <= 0f || viewportHeight <= 0f) return null
+      val emittable =
+        paths
+          .filter { it.pathData.isNotBlank() && (it.fillArgb != null || it.strokeArgb != null) }
+          .map {
+            FigmaSvgVectorPath(
+              pathData = it.pathData,
+              fillArgb = it.fillArgb,
+              fillAlpha = it.fillAlpha,
+              strokeArgb = it.strokeArgb,
+              strokeWidth = it.strokeWidth,
+              strokeAlpha = it.strokeAlpha,
+              evenOdd = it.evenOdd,
+            )
+          }
+      return if (emittable.isEmpty()) null
+      else FigmaSvgVector(viewportWidth, viewportHeight, emittable)
+    }
+
     private fun LayoutInspectorNode.toLayer(
       ctx: BuildContext,
       parentBounds: LayoutInspectorBounds? = null,
@@ -433,6 +488,21 @@ data class FigmaSvgModel(
       // origin, clamped to the parent, and use it everywhere below. Best-effort geometry for a
       // pathological capture; a normally-placed node keeps its real `bounds` untouched.
       val bounds = recoverBounds(parentBounds)
+      // An `Icon`/`Image` whose `ImageVector` the inspector captured emits as editable `<path>`
+      // layers rather than a raster crop — the vector alternative to the opaque-by-name fallback
+      // below. Placed before the raster branch so a vector-backed icon never rasterises; a
+      // bitmap-backed one (no `vectorGraphic`) falls through and rasters as before. An empty/
+      // gradient-only capture yields null and also falls through.
+      vectorGraphic?.toFigmaSvgVector()?.let { vec ->
+        return FigmaSvgLayer(
+          name = layerName(),
+          left = bounds.left,
+          top = bounds.top,
+          right = bounds.right,
+          bottom = bounds.bottom,
+          vector = vec,
+        )
+      }
       // An opaque component matched by name (Image/Icon/TextField/…) can't be vectorised at all —
       // emit an <image> for the whole node and drop the subtree.
       val opaqueByName = isOpaque(ctx.rasterComponents)

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgModel.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgModel.kt
@@ -225,6 +225,7 @@ data class FigmaSvgLayer(
         stroke != null ||
         text != null ||
         raster != null ||
+        vector != null ||
         background != null ||
         curvedTexts.isNotEmpty()
 }

--- a/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgVectorIconTest.kt
+++ b/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgVectorIconTest.kt
@@ -1,0 +1,90 @@
+package ee.schimke.composeai.data.layoutinspector
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Tier 1 — an `Icon`/`Image` backed by a captured [LayoutInspectorVectorGraphic] emits as editable
+ * `<path>` layers instead of an opaque `<image>` raster crop, while a bitmap-backed one (no captured
+ * graphic) still rasters. The capture side (reflecting the `VectorPainter`) is exercised on-device;
+ * this covers the pure model/emitter half from a synthetic payload.
+ */
+class FigmaSvgVectorIconTest {
+
+  private fun bounds(l: Int, t: Int, r: Int, b: Int) = LayoutInspectorBounds(l, t, r, b)
+
+  private fun iconNode(graphic: LayoutInspectorVectorGraphic?) =
+    LayoutInspectorNode(
+      nodeId = "icon-1",
+      component = "Icon", // opaque-by-name: without a graphic this rasters
+      bounds = bounds(0, 0, 96, 96),
+      size = LayoutInspectorSize(96, 96),
+      vectorGraphic = graphic,
+    )
+
+  private val star =
+    LayoutInspectorVectorGraphic(
+      viewportWidth = 24f,
+      viewportHeight = 24f,
+      paths =
+        listOf(
+          LayoutInspectorVectorPath(
+            pathData = "M12 0L15 9L24 9L17 14L20 24L12 18L4 24L7 14L0 9L9 9Z",
+            fillArgb = "#FF112233",
+          )
+        ),
+    )
+
+  private fun model(node: LayoutInspectorNode) =
+    FigmaSvgModel.from(
+      layout = LayoutInspectorPayload(node),
+      rasterComponents = FigmaSvgModel.DEFAULT_RASTER_COMPONENTS,
+    )
+
+  @Test
+  fun vectorBackedIconEmitsPathsNotRaster() {
+    val m = model(iconNode(star))
+    assertNull("a captured vector icon is not an opaque <image> leaf", m.root.raster)
+    assertTrue("no raster crops are scheduled for it", m.rasterTargets.isEmpty())
+    val vec = m.root.vector
+    assertNotNull("the layer carries the editable vector", vec)
+    assertTrue(vec!!.paths.single().pathData.startsWith("M12 0"))
+
+    val svg = FigmaLayeredSvg.render(m)
+    assertFalse("no <image> for a vectorised icon", svg.contains("<image"))
+    assertTrue("emits a <path>", svg.contains("<path d=\"M12 0"))
+    assertTrue("solid fill is carried through", svg.contains("fill=\"#112233\""))
+    // 96px box over a 24-unit viewport ⇒ 4× scale, translated to the placed origin.
+    assertTrue(
+      "viewport is scaled onto the placed box",
+      svg.contains("transform=\"translate(0 0) scale(4 4)\""),
+    )
+  }
+
+  @Test
+  fun bitmapBackedIconStillRasters() {
+    // No captured graphic (a BitmapPainter-backed Icon/Image) ⇒ the opaque-by-name raster fallback.
+    val m = model(iconNode(graphic = null))
+    assertNotNull("a bitmap icon still rasters", m.root.raster)
+    assertNull(m.root.vector)
+    assertTrue(m.rasterTargets.isNotEmpty())
+  }
+
+  @Test
+  fun gradientOnlyGraphicFallsBackToRaster() {
+    // A path whose fill/stroke never resolved to a solid colour (a gradient/brush) carries no
+    // paintable path, so the icon falls through to the raster fallback rather than emitting nothing.
+    val gradientOnly =
+      LayoutInspectorVectorGraphic(
+        viewportWidth = 24f,
+        viewportHeight = 24f,
+        paths = listOf(LayoutInspectorVectorPath(pathData = "M0 0L24 24Z", fillArgb = null)),
+      )
+    val m = model(iconNode(gradientOnly))
+    assertNull("no emittable paths ⇒ not a vector layer", m.root.vector)
+    assertNotNull("falls back to the raster crop", m.root.raster)
+  }
+}

--- a/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/FigmaSvgVectorIconRenderTest.kt
+++ b/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/FigmaSvgVectorIconRenderTest.kt
@@ -1,0 +1,183 @@
+package ee.schimke.composeai.renderer
+
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.InternalComposeApi
+import androidx.compose.runtime.currentComposer
+import androidx.compose.runtime.tooling.CompositionData
+import androidx.compose.runtime.tooling.LocalInspectionTables
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.node.RootForTest
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.unit.dp
+import com.github.takahirom.roborazzi.captureRoboImage
+import ee.schimke.composeai.daemon.ComposeFigmaSvgDataProducer
+import ee.schimke.composeai.daemon.ComposeSemanticsDataProducer
+import ee.schimke.composeai.daemon.LayoutInspectorDataProducer
+import ee.schimke.composeai.data.render.PreviewContext
+import java.io.File
+import java.nio.file.Files
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.Description
+import org.junit.runner.RunWith
+import org.junit.runners.model.Statement
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * Tier-1 end-to-end validation + measurement: renders a real `Icon(ImageVector)` through the
+ * Robolectric render (measure + draw + z-sort), then runs the production figma-svg export in
+ * **hybrid raster mode** (a frame PNG is passed, so `DEFAULT_RASTER_COMPONENTS` is active and an
+ * `Icon` is opaque-by-name — the pre-change behaviour cropped it as an `<image>`). It asserts the
+ * export now emits the icon as an editable `<path>` and schedules **no** raster crop for it. This is
+ * the on-device counterpart of the synthetic `FigmaSvgVectorIconTest` in `:data-layoutinspector-core`
+ * — it exercises `VectorGraphicExtractor`'s reflection against the *live* `VectorPainter` tree that a
+ * material `Icon` builds, which the synthetic test cannot cover.
+ *
+ * A draw is forced (`captureRoboImage`) before reading the tree because the layout inspector reflects
+ * over `LayoutNode.getZSortedChildren`, empty until measure/draw z-sort the children — the same seam
+ * `WearScrollSvgGrowthTest` relies on.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+class FigmaSvgVectorIconRenderTest {
+
+  private lateinit var rootDir: File
+
+  // The wear-m3 catalog's `catalogIcon` verbatim: a hand-built five-point star with a single solid
+  // fill over a 24-unit viewport — precisely the Tier-1 vectorization case.
+  private val catalogStar: ImageVector =
+    ImageVector.Builder(
+        name = "Star",
+        defaultWidth = 24.dp,
+        defaultHeight = 24.dp,
+        viewportWidth = 24f,
+        viewportHeight = 24f,
+      )
+      .apply {
+        path(fill = SolidColor(Color.White)) {
+          moveTo(12f, 2f)
+          lineTo(15.1f, 8.3f)
+          lineTo(22f, 9.3f)
+          lineTo(17f, 14.1f)
+          lineTo(18.2f, 21f)
+          lineTo(12f, 17.8f)
+          lineTo(5.8f, 21f)
+          lineTo(7f, 14.1f)
+          lineTo(2f, 9.3f)
+          lineTo(8.9f, 8.3f)
+          close()
+        }
+      }
+      .build()
+
+  @Before
+  fun setUp() {
+    rootDir = Files.createTempDirectory("figma-svg-vector-icon").toFile()
+    System.setProperty("roborazzi.test.record", "true")
+  }
+
+  @After
+  fun tearDown() {
+    rootDir.deleteRecursively()
+    System.clearProperty("roborazzi.test.record")
+  }
+
+  @Test
+  fun `a rendered ImageVector Icon exports as an editable path, not an opaque image crop`() {
+    val svg = renderIconSvg("icon-star") { Icon(catalogStar, "Star", Modifier.size(48.dp)) }
+
+    // The whole point: with a frame PNG present (hybrid mode) an `Icon` is opaque-by-name and used to
+    // crop out as an `<image>`. Tier-1 captures the VectorPainter, so it is now a real `<path>`.
+    // Persist the exported SVG as before/after evidence for the PR (the pre-Tier-1 form of this same
+    // preview was `<image href="figma-raster/…png">`).
+    File("build/figma-svg-vector-icon").mkdirs()
+    File("build/figma-svg-vector-icon/icon-star.svg").writeText(svg)
+
+    assertTrue("the icon must export as a <path>:\n$svg", svg.contains("<path "))
+    assertFalse("no <image> raster crop for a vectorised icon:\n$svg", svg.contains("<image "))
+    // The vector layer must count toward the canvas extent, so the 48px icon isn't clipped by a
+    // degenerate padding-only viewBox (the `paints` regression).
+    val width = Regex("""<svg[^>]*\bwidth="(\d+)"""").find(svg)?.groupValues?.get(1)?.toInt() ?: 0
+    assertTrue("the canvas must contain the 48px icon, got width=$width:\n$svg", width >= 48)
+    // No `figma-raster/` sidecar PNGs were written for it.
+    val rasterDir = File(rootDir, "icon-star/figma-raster")
+    assertFalse(
+      "no raster sidecars for a fully-vectorised icon: ${rasterDir.listFiles()?.joinToString()}",
+      rasterDir.isDirectory && (rasterDir.listFiles()?.isNotEmpty() ?: false),
+    )
+  }
+
+  /**
+   * Renders [content] in a fresh rule at a small component size, forces a draw so children z-sort,
+   * then runs the production capture + **hybrid** figma-svg export (a frame PNG is passed) and
+   * returns the SVG string.
+   */
+  private fun renderIconSvg(previewId: String, content: @Composable () -> Unit): String {
+    RuntimeEnvironment.setQualifiers("w96dp-h96dp-mdpi")
+    @Suppress("DEPRECATION") val rule = createAndroidComposeRule<ComponentActivity>()
+    var svg = ""
+    val statement =
+      object : Statement() {
+        override fun evaluate() {
+          val slotTables = mutableSetOf<CompositionData>()
+          rule.setContent { InspectableContent(slotTables, content) }
+          rule.waitForIdle()
+          val frameFile = File(rootDir, "$previewId-frame.png")
+          frameFile.parentFile?.mkdirs()
+          rule.onRoot().captureRoboImage(file = frameFile)
+          val semanticsRoot = rule.onRoot(useUnmergedTree = true).fetchSemanticsNode()
+          val previewContext =
+            PreviewContext.Builder(
+                previewId = previewId,
+                backend = null,
+                renderMode = null,
+                outputBaseName = previewId,
+              )
+              .rootForTest(semanticsRoot.root as RootForTest)
+              .addSlotTables(slotTables.toList())
+              .parameterInformationCollected()
+              .build()
+          val layout = LayoutInspectorDataProducer.buildPayload(previewContext, density = 1f)!!
+          val semantics = ComposeSemanticsDataProducer.buildPayload(semanticsRoot, density = 1f)
+          ComposeFigmaSvgDataProducer.writeSvg(
+            rootDir = rootDir,
+            previewId = previewId,
+            layout = layout,
+            semantics = semantics,
+            density = 1f,
+            frameImage = frameFile,
+          )
+          svg = File(rootDir, "$previewId/compose-figma.svg").readText()
+        }
+      }
+    rule.apply(statement, Description.createTestDescription(javaClass, previewId)).evaluate()
+    return svg
+  }
+}
+
+@OptIn(InternalComposeApi::class)
+@Composable
+private fun InspectableContent(
+  capture: MutableSet<CompositionData>,
+  content: @Composable () -> Unit,
+) {
+  currentComposer.collectParameterInformation()
+  capture.add(currentComposer.compositionData)
+  CompositionLocalProvider(LocalInspectionTables provides capture, content = content)
+}


### PR DESCRIPTION
## What

Tier 1 of the raster→vector export work: an `Icon`/`Image` backed by an `ImageVector` now exports as **editable `<path>` layers** instead of an opaque `<image>` raster crop. On the wear-m3 and compose-m3 catalogs this converts every material-style icon sticker (`IconSticker`, `IconButtonSticker`, `AppCardSticker`, the compose-m3 `addGlyph` button) from a flattened bitmap into real vector geometry a designer can edit in Figma.

The capture reflects the live `VectorPainter` tree during the layout-inspector walk and lowers it to SVG path data + solid paints. It is **best-effort with a guaranteed raster fallback**: a bitmap-backed painter, a gradient/brush fill that never resolves to a flat colour, a transformed group, or any reflection failure yields `null` and the node rasters exactly as before.

## How

- **`VectorGraphicExtractor`** (`ComposeSemanticsDataProduct.kt`) walks the node's `paint` modifier for the `VectorPainter` (it rides one level inside the `PainterElement`, not as a bare `painter` field), reads the viewport from `VectorComponent.viewportSize$delegate` (a `MutableState<Size>`), and serialises `root → GroupComponent → PathComponent` into `d`/fill/stroke. Older Compose builds' plain `viewportWidth`/`viewportHeight` are kept as a fallback.
- **`FigmaSvgModel` / `FigmaLayeredSvg`** gain a `vector` layer alongside `raster`, emitted *before* the opaque-by-name raster branch so a captured icon never rasterises. `FigmaSvgLayer.paints` now counts `vector`, so a vector-only icon constrains the canvas extent instead of collapsing the viewBox to padding.

## Visual evidence

This is a **source-format** change: the rendered pixels are intentionally identical (loss-less vectorization) — the diff is in the SVG the export produces. The wear-m3 `IconSticker` (`Icon(catalogStar, Modifier.size(48.dp))`), captured through the real Android/Robolectric render pipeline in hybrid raster mode:

**Before** — opaque raster crop:
```xml
<g id="ReusableComposeNode">
  ``&lt;image href="figma-raster/2.png" x="0" y="0" width="48" height="48"/&gt;``
</g>
```

**After** — editable vector path (this PR):
```xml
<g id="ReusableComposeNode">
  <g transform="translate(0 0) scale(2 2)">
    <path d="M12 2 L15.1 8.3 L22 9.3 L17 14.1 L18.2 21 L12 17.8 L5.8 21 L7 14.1 L2 9.3 L8.9 8.3 Z" fill="#FFFFFF"/>
  </g>
</g>
```

The star geometry matches the source `ImageVector` exactly, scaled onto the placed 48px box (48/24 viewport = 2×), and the canvas stays `80×80` (48px icon + 16px padding) rather than clipping to a degenerate `32×32`.

## Test plan

- **`FigmaSvgVectorIconRenderTest`** (new, `:renderer-android`) — renders a real `Icon(ImageVector)` through the Robolectric pipeline (measure + draw + z-sort) and asserts it exports as `<path>` with **no `<image>`**, **no `figma-raster/` sidecar**, and a canvas that contains the icon. This exercises the reflection against the live Compose classes. ✅ passing in-session.
- **`FigmaSvgVectorIconTest`** (`:data-layoutinspector-core`) — synthetic model/emitter coverage: vector-backed icon → paths; bitmap-backed → raster; gradient-only → raster fallback.
- **`DesktopLayoutInspectorTest`** — adds a Skiko-backed capture case (runs in CI; the desktop Skiko native lib isn't present in this container).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_Generated by [Claude Code]_

---
_Generated by [Claude Code](https://claude.ai/code/session_013Q9cjwna73rpvVdrw1ApLP)_