### PR TITLE
fix(figma-svg): raster mixed-paint icon paths and probe the intrinsic tint

### DIFF
--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
@@ -1062,18 +1062,24 @@ internal object ComposeLayoutInspector {
      * path). Anything else — a different blend mode, a colour-matrix filter, an unreadable colour ⇒
      * [UnsupportedTint], so the caller declines vectorisation and the node rasters instead.
      *
-     * The filter can arrive three ways: the external filter the `Icon`/`Image` passed
+     * The filter can arrive several ways: the external filter the `Icon`/`Image` passed
      * (`colorFilter`), the resolved filter used at the last draw (`currentColorFilter`), or — when
-     * a vector carries its own `tintColor` and no external filter is passed — the painter's
-     * `intrinsicColorFilter`. Probe all three so an intrinsically-tinted vector isn't vectorised in
-     * its untinted source colours.
+     * a vector carries its own `tintColor` and no external filter is passed — the intrinsic filter.
+     * `VectorPainter.intrinsicColorFilter` is a forwarding property backed on the
+     * `VectorComponent`, so its `intrinsicColorFilter$delegate` state lives on the vector (older
+     * layouts kept it on the painter); probe both so an intrinsically-tinted vector isn't
+     * vectorised in its source colours.
      */
     private fun resolveTint(painter: Any): TintResult {
+      val vector = runCatching { field(painter, "vector") }.getOrNull()
       val filter =
         runCatching { field(painter, "colorFilter") }.getOrNull()
           ?: runCatching { field(painter, "currentColorFilter") }.getOrNull()
           ?: currentStateValue(
             runCatching { field(painter, "intrinsicColorFilter\$delegate") }.getOrNull()
+          )
+          ?: currentStateValue(
+            runCatching { vector?.let { field(it, "intrinsicColorFilter\$delegate") } }.getOrNull()
           )
           ?: return NoTint
       if (filter.javaClass.simpleName != "BlendModeColorFilter") return UnsupportedTint

--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
@@ -1061,11 +1061,20 @@ internal object ComposeLayoutInspector {
      * colours). A `BlendModeColorFilter` with a `SrcIn` tint ⇒ [SolidTint] (recolour every painted
      * path). Anything else — a different blend mode, a colour-matrix filter, an unreadable colour ⇒
      * [UnsupportedTint], so the caller declines vectorisation and the node rasters instead.
+     *
+     * The filter can arrive three ways: the external filter the `Icon`/`Image` passed
+     * (`colorFilter`), the resolved filter used at the last draw (`currentColorFilter`), or — when
+     * a vector carries its own `tintColor` and no external filter is passed — the painter's
+     * `intrinsicColorFilter`. Probe all three so an intrinsically-tinted vector isn't vectorised in
+     * its untinted source colours.
      */
     private fun resolveTint(painter: Any): TintResult {
       val filter =
         runCatching { field(painter, "colorFilter") }.getOrNull()
           ?: runCatching { field(painter, "currentColorFilter") }.getOrNull()
+          ?: currentStateValue(
+            runCatching { field(painter, "intrinsicColorFilter\$delegate") }.getOrNull()
+          )
           ?: return NoTint
       if (filter.javaClass.simpleName != "BlendModeColorFilter") return UnsupportedTint
       val blend =
@@ -1186,18 +1195,17 @@ internal object ComposeLayoutInspector {
           return true
         }
         "PathComponent" -> {
-          val path = pathOf(vnode)
-          if (path != null) {
-            out.add(path)
-            return true
-          }
-          // `pathOf` gave up on this path. If it draws nothing (blank geometry, or no paint), skip
-          // it. But if it has geometry filled/stroked with a brush we can't represent (a gradient
-          // or
-          // shader), fail so the whole icon rasters — otherwise that path silently vanishes while
-          // the
-          // rest of the icon vectorises. (#2504 review follow-up.)
-          return !hasUnrepresentablePaint(vnode)
+          // A path with geometry filled or stroked by a brush we can't represent (a
+          // gradient/shader,
+          // on the fill OR the stroke) fails the whole icon to raster. Gating before `pathOf` also
+          // covers a *mixed*-paint path (e.g. a solid fill with a gradient stroke): `pathOf` would
+          // otherwise return a partial vector for the solid side and silently drop the gradient
+          // one.
+          // A path that draws nothing (blank geometry / no paint) is skipped. (#2504 / #2505
+          // review.)
+          if (hasUnrepresentablePaint(vnode)) return false
+          pathOf(vnode)?.let(out::add)
+          return true
         }
         else -> return true
       }

--- a/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/FigmaSvgVectorIconRenderTest.kt
+++ b/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/FigmaSvgVectorIconRenderTest.kt
@@ -109,6 +109,29 @@ class FigmaSvgVectorIconRenderTest {
       }
       .build()
 
+  // An ImageVector carrying its own `tintColor`, drawn via `Image` (no external `Icon` tint): its
+  // intrinsic colour filter lives on the VectorComponent, so the export must recolour to that tint
+  // rather than the source white (#2506 review).
+  private val intrinsicallyTintedSquare: ImageVector =
+    ImageVector.Builder(
+        name = "TintedSquare",
+        defaultWidth = 24.dp,
+        defaultHeight = 24.dp,
+        viewportWidth = 24f,
+        viewportHeight = 24f,
+        tintColor = Color(0xFF445566),
+      )
+      .apply {
+        path(fill = SolidColor(Color.White)) {
+          moveTo(2f, 2f)
+          lineTo(22f, 2f)
+          lineTo(22f, 22f)
+          lineTo(2f, 22f)
+          close()
+        }
+      }
+      .build()
+
   // A single path with a solid fill AND a gradient stroke: `pathOf` could vectorise the solid fill
   // and silently drop the gradient stroke, so the whole icon must raster instead (#2505 review).
   private val mixedPaintSquare: ImageVector =
@@ -192,6 +215,19 @@ class FigmaSvgVectorIconRenderTest {
     // raster crop rather than silently vectorising into a partial/empty icon.
     assertTrue("a gradient-filled icon rasters:\n$svg", svg.contains("<image "))
     assertFalse("no vector path for an unrepresentable gradient icon:\n$svg", svg.contains("<path "))
+  }
+
+  @Test
+  fun `an intrinsically tinted vector exports in its tint colour, not the source fill`() {
+    val svg =
+      renderIconSvg("icon-intrinsic") {
+        Image(intrinsicallyTintedSquare, null, Modifier.size(48.dp))
+      }
+    assertTrue("an intrinsically tinted vector still vectorises:\n$svg", svg.contains("<path "))
+    assertFalse("no <image> raster crop for a vectorised icon:\n$svg", svg.contains("<image "))
+    // The vector's own `tintColor` is applied through the intrinsic colour filter on its component.
+    assertTrue("the intrinsic tint is applied:\n$svg", svg.contains("fill=\"#445566\""))
+    assertFalse("the source white fill must not leak through:\n$svg", svg.contains("fill=\"#FFFFFF\""))
   }
 
   @Test

--- a/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/FigmaSvgVectorIconRenderTest.kt
+++ b/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/FigmaSvgVectorIconRenderTest.kt
@@ -109,6 +109,31 @@ class FigmaSvgVectorIconRenderTest {
       }
       .build()
 
+  // A single path with a solid fill AND a gradient stroke: `pathOf` could vectorise the solid fill
+  // and silently drop the gradient stroke, so the whole icon must raster instead (#2505 review).
+  private val mixedPaintSquare: ImageVector =
+    ImageVector.Builder(
+        name = "Mixed",
+        defaultWidth = 24.dp,
+        defaultHeight = 24.dp,
+        viewportWidth = 24f,
+        viewportHeight = 24f,
+      )
+      .apply {
+        path(
+          fill = SolidColor(Color.Red),
+          stroke = Brush.linearGradient(listOf(Color.Green, Color.Blue)),
+          strokeLineWidth = 2f,
+        ) {
+          moveTo(2f, 2f)
+          lineTo(22f, 2f)
+          lineTo(22f, 22f)
+          lineTo(2f, 22f)
+          close()
+        }
+      }
+      .build()
+
   @Before
   fun setUp() {
     rootDir = Files.createTempDirectory("figma-svg-vector-icon").toFile()
@@ -167,6 +192,15 @@ class FigmaSvgVectorIconRenderTest {
     // raster crop rather than silently vectorising into a partial/empty icon.
     assertTrue("a gradient-filled icon rasters:\n$svg", svg.contains("<image "))
     assertFalse("no vector path for an unrepresentable gradient icon:\n$svg", svg.contains("<path "))
+  }
+
+  @Test
+  fun `an icon with a mixed solid-fill gradient-stroke path rasters`() {
+    val svg = renderIconSvg("icon-mixed") { Image(mixedPaintSquare, null, Modifier.size(48.dp)) }
+    // One side (the stroke) is an unrepresentable gradient, so the whole icon rasters rather than
+    // emitting the solid fill alone and silently dropping the gradient stroke.
+    assertTrue("a mixed-paint icon rasters:\n$svg", svg.contains("<image "))
+    assertFalse("no partial vector for a mixed-paint icon:\n$svg", svg.contains("<path "))
   }
 
   /**


### PR DESCRIPTION
## What

Addresses the two additional Codex findings on #2505 (which auto-merged before they could be folded in).

- **Mixed-paint paths now raster the whole icon.** A single `PathComponent` with a solid fill **and** a gradient/shader stroke (or vice versa) previously vectorised the solid side and silently dropped the unrepresentable one — `collect` added the partial `pathOf` result before checking the paint. The unrepresentable-paint check now gates **before** `pathOf`, so any path with geometry painted by a non-`SolidColor` brush on either side falls the whole graphic back to a raster crop.
- **Intrinsic vector tint is now captured.** When an `ImageVector` carries its own `tintColor` and is drawn via `Image` (no external `Icon` tint), the tint is applied through the intrinsic colour filter. `VectorPainter.intrinsicColorFilter` is a *forwarding property backed on the `VectorComponent`*, so `resolveTint` now reads `intrinsicColorFilter$delegate` off the **vector** (in addition to the painter and the external/current filters). The export recolours the paths to that tint instead of the source colours.

_(An earlier revision of this PR wrongly concluded the intrinsic case was unreproducible — that reading came from probing the plain `intrinsicColorFilter` property instead of its `$delegate` backing field, which returned a false null. The review correctly pointed to the `VectorComponent`; it is reproducible and now covered on-device.)_

## Test plan

`FigmaSvgVectorIconRenderTest` (`:renderer-android`, Robolectric) — all five cases pass in-session:
- vectorises an `Icon(ImageVector)` to `<path>` (no raster sidecar, canvas contains it);
- an external `Icon` tint recolours the paths to the tint;
- an **intrinsically** tinted vector (`ImageVector.Builder(tintColor=…)` via `Image`) exports in its tint colour, not the source fill;
- a pure-gradient icon rasters;
- a **mixed** solid-fill / gradient-stroke path rasters.

`./gradlew ktfmtFormat` run clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_Generated by [Claude Code]_