### PR TITLE
fix(daemon): invalidate cached launch descriptor on schema bump

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/daemon/DaemonBootstrapTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/daemon/DaemonBootstrapTask.kt
@@ -52,6 +52,23 @@ import org.gradle.api.tasks.TaskAction
 @CacheableTask
 abstract class DaemonBootstrapTask : DefaultTask() {
 
+  /**
+   * The descriptor schema version stamped into [outputFile]. Declared as an `@Input` — even though
+   * it's a compile-time constant with no per-module configuration — so that bumping
+   * [DAEMON_DESCRIPTOR_SCHEMA_VERSION] participates in this task's up-to-date fingerprint.
+   *
+   * Without this, a plugin upgrade that bumps the schema (e.g. 1 → 2 when `btaCompile` landed)
+   * leaves every other declared input unchanged, so Gradle reports the task UP-TO-DATE and skips
+   * re-emitting. The stale lower-schema `daemon-launch.json` survives on disk, the VS Code reader
+   * hard-rejects it (`daemonProcess.ts` → "descriptor schema mismatch: got 1, expected 2"), and the
+   * daemon warm path loops forever — re-running `composePreviewDaemonStart` is a no-op because the
+   * task is still up-to-date. Surfacing the version here makes a schema bump invalidate the cached
+   * descriptor so the next warm rewrites it at the current schema.
+   */
+  @get:Input
+  val schemaVersion: Int
+    get() = DAEMON_DESCRIPTOR_SCHEMA_VERSION
+
   /** `:samples:android` — the Gradle path of the consumer module. */
   @get:Input abstract val modulePath: Property<String>
 
@@ -229,7 +246,7 @@ abstract class DaemonBootstrapTask : DefaultTask() {
   fun emit() {
     val descriptor =
       DaemonClasspathDescriptor(
-        schemaVersion = DAEMON_DESCRIPTOR_SCHEMA_VERSION,
+        schemaVersion = schemaVersion,
         modulePath = modulePath.get(),
         variant = variant.get(),
         enabled = daemonEnabled.get(),

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/daemon/DaemonBootstrapTaskTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/daemon/DaemonBootstrapTaskTest.kt
@@ -33,6 +33,29 @@ class DaemonBootstrapTaskTest {
   }
 
   @Test
+  fun `schema version is a declared Input so a schema bump invalidates the cached descriptor`() {
+    // Regression: DAEMON_DESCRIPTOR_SCHEMA_VERSION must participate in the task fingerprint.
+    // Without it, a plugin upgrade that bumps the schema (all other inputs unchanged) leaves the
+    // task UP-TO-DATE, so the stale lower-schema daemon-launch.json survives and the VS Code reader
+    // hard-rejects it ("descriptor schema mismatch: got 1, expected 2"), bricking the daemon warm
+    // path. Reflect on the accessor so a stray drop-of-@Input regression is caught here.
+    val getter = DaemonBootstrapTask::class.java.getMethod("getSchemaVersion")
+    assertThat(getter.isAnnotationPresent(org.gradle.api.tasks.Input::class.java)).isTrue()
+
+    // And it must stamp the current constant into the emitted descriptor.
+    val project = newProject()
+    val outFile = File(tempDir.root, "build/compose-previews/daemon-launch.json")
+    val task =
+      project.tasks.register("bootstrapSchema", DaemonBootstrapTask::class.java) {
+        baseInputs(outFile)
+      }
+    assertThat(task.get().schemaVersion).isEqualTo(DAEMON_DESCRIPTOR_SCHEMA_VERSION)
+    task.get().emit()
+    val descriptor = json.decodeFromString<DaemonClasspathDescriptor>(outFile.readText())
+    assertThat(descriptor.schemaVersion).isEqualTo(DAEMON_DESCRIPTOR_SCHEMA_VERSION)
+  }
+
+  @Test
   fun `classpath fingerprint tracks launch paths not class contents`() {
     val project = newProject()
     val outFile = File(tempDir.root, "build/compose-previews/daemon-launch.json")


### PR DESCRIPTION
## Problem

Recent sessions reported the VS Code / Antigravity Compose Preview panel stuck at **"Starting · 0%"** forever. The Output log ends with:

```
[daemon] descriptor schema mismatch at .../build/compose-previews/daemon-launch.json: got 1, expected 2
[daemon] warm failed for :composeApp: no launch descriptor ...; run :composeApp:composePreviewDaemonStart first
```

## Root cause

The daemon launch-descriptor **schema version was not part of `DaemonBootstrapTask`'s up-to-date fingerprint**. When the schema bumped `1 → 2` (the `btaCompile` field landing), every *other* declared task input stayed the same, so Gradle reports `composePreviewDaemonStart` **UP-TO-DATE** across the plugin upgrade and skips re-emitting. The stale **v1** `daemon-launch.json` survives on disk.

The extension's reader (`daemonProcess.ts` → `readLaunchDescriptor`) requires `schemaVersion === DAEMON_DESCRIPTOR_SCHEMA_VERSION` (=2) and hard-rejects the v1 file. The daemon warm path (`daemonScheduler.warmModuleInner`) then loops: read descriptor → null → run `composePreviewDaemonStart` → **still up-to-date, no rewrite** → descriptor still v1 → `warm failed`. The daemon never starts, so the progress bar never leaves the zero-weight "starting" phase.

## Fix

Declare the schema version as an `@Input` on `DaemonBootstrapTask` so bumping `DAEMON_DESCRIPTOR_SCHEMA_VERSION` invalidates the cached descriptor — the next warm re-emits `daemon-launch.json` at the current schema. This also self-heals existing stale v1 descriptors, because the new input changes the task fingerprint on the very next plugin version.

- `DaemonBootstrapTask.kt`: add `@get:Input val schemaVersion` (computed from the constant) and stamp it into the descriptor.
- Regression test asserting the accessor is annotated `@Input` and stamps the current constant.

## Test plan

- `./gradlew :gradle-plugin:test --tests '*DaemonBootstrapTaskTest*'` — the new `schema version is a declared Input ...` case plus the existing descriptor-shape tests.
- Manual: on a consumer whose on-disk descriptor is v1, warming the daemon now re-runs the bootstrap (task no longer up-to-date), rewrites the descriptor at v2, and the panel renders instead of hanging at "Starting · 0%".

Text-only evidence is appropriate here — this is build-wiring (a Gradle task input); no rendered surface changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FjDUWeYG9XimiaHB1HdkPz)_