### PR TITLE
fix(serve): keep the live render lane up for knob overrides and Wear

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
@@ -280,6 +280,16 @@ internal constructor(
   // [frameRenderTimeoutSeconds] so a single wedged render can't hold the only render slot.
   private val warmedUp = AtomicBoolean(false)
 
+  // An override-bearing render (a `?knob.…=` edit, device/locale/theme override, …) forces a real
+  // recomposition and is much slower than a plain re-emit — its first occurrence is effectively
+  // cold even when [warmedUp] is already set by a background prewarm (a throwaway default render
+  // that flips [warmedUp] without ever exercising the override path). Without a separate gate the
+  // very first override render on `preview.coo.ee` — where `warmInBackground` prewarms — is charged
+  // the tight [frameRenderTimeoutSeconds] cap and times out (the public `?knob.…` 500). Give the
+  // first override render the generous [renderTimeoutSeconds] budget too; subsequent override frames
+  // are capped like any other so a wedged one can't pin the slot.
+  private val overridesWarmedUp = AtomicBoolean(false)
+
   // Fans one upstream daemon stream out to all watchers of the same preview/overrides/codec/fps, so
   // many browsers cost one held session instead of one each. Built on [startStream]; shared because
   // there's one host per server.
@@ -357,8 +367,12 @@ internal constructor(
         }
 
         // Cold start gets the generous budget; every frame after the first is capped so a wedged
-        // render can't pin the slot.
-        val budget = if (warmedUp.get()) frameRenderTimeoutSeconds else renderTimeoutSeconds
+        // render can't pin the slot. An override-bearing render's *first* occurrence is cold too
+        // (real recompose, and prewarm may have flipped [warmedUp] without ever paying it), so it
+        // keeps the generous budget until one override render has succeeded.
+        val hasOverrides = overrides != PreviewOverrides()
+        val warmForThisRender = warmedUp.get() && (!hasOverrides || overridesWarmedUp.get())
+        val budget = if (warmForThisRender) frameRenderTimeoutSeconds else renderTimeoutSeconds
         if (!latch.await(budget, TimeUnit.SECONDS)) {
           // The daemon still owes this queued render a `renderFinished`; record it so the late
           // event
@@ -369,6 +383,7 @@ internal constructor(
           return@withLock RenderOutcome.Failed(reason)
         }
         warmedUp.set(true)
+        if (hasOverrides) overridesWarmedUp.set(true)
         break
       }
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
@@ -286,7 +286,8 @@ internal constructor(
   // that flips [warmedUp] without ever exercising the override path). Without a separate gate the
   // very first override render on `preview.coo.ee` — where `warmInBackground` prewarms — is charged
   // the tight [frameRenderTimeoutSeconds] cap and times out (the public `?knob.…` 500). Give the
-  // first override render the generous [renderTimeoutSeconds] budget too; subsequent override frames
+  // first override render the generous [renderTimeoutSeconds] budget too; subsequent override
+  // frames
   // are capped like any other so a wedged one can't pin the slot.
   private val overridesWarmedUp = AtomicBoolean(false)
 

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -522,30 +522,37 @@ open class RobolectricHost(
       val bootErr = workerBootErrors.get(i)
       if (bootErr == null && ready) return
 
-      if (attempt++ >= MAX_SANDBOX_BOOT_RETRIES) {
+      // Only a *recorded* boot error is safe to retry. [runJUnit] sets [workerBootErrors] just
+      // after `JUnitCore.runClasses` returns, so a non-null entry proves the worker has exited and
+      // its slot (never claimed — the failure happens before `registerSandbox`) is free to re-boot.
+      // A bare `awaitSandboxReady` timeout with no recorded error is different: the worker may still
+      // be inside Robolectric bootstrap, so swapping in a replacement would leave two workers racing
+      // to `registerSandbox` / count down the slot latch. Treat that as a clean startup failure —
+      // the pre-retry behaviour — and only ever replace a worker that demonstrably exited.
+      val canRetry = bootErr != null && attempt < MAX_SANDBOX_BOOT_RETRIES
+      if (!canRetry) {
         if (sandboxCount > 1) dumpAllThreadsToStderr(slot = i, timeoutMs = timeoutMs)
         if (bootErr != null) {
           throw IllegalStateException(
-            "Robolectric sandbox slot $i aborted during bootstrap after " +
-              "${MAX_SANDBOX_BOOT_RETRIES + 1} attempt(s) — see the SandboxRunner[$i] failure(s) " +
-              "logged above for the underlying cause.",
+            "Robolectric sandbox slot $i aborted during bootstrap after ${attempt + 1} " +
+              "attempt(s) — see the SandboxRunner[$i] failure(s) logged above for the underlying " +
+              "cause.",
             bootErr,
           )
         }
         error(
-          "Robolectric sandbox slot $i failed to bootstrap within ${timeoutMs}ms after " +
-            "${MAX_SANDBOX_BOOT_RETRIES + 1} attempt(s) — holdSandboxOpen never registered. On a " +
-            "cold cache the instrumented android-all jar download can dominate; raise the timeout " +
-            "via -D$SANDBOX_BOOT_TIMEOUT_PROP=<ms>. Otherwise check the SandboxHoldingRunner / " +
-            "Robolectric sandbox bootstrap logs."
+          "Robolectric sandbox slot $i failed to bootstrap within ${timeoutMs}ms — holdSandboxOpen " +
+            "never registered. On a cold cache the instrumented android-all jar download can " +
+            "dominate; raise the timeout via -D$SANDBOX_BOOT_TIMEOUT_PROP=<ms>. Otherwise check the " +
+            "SandboxHoldingRunner / Robolectric sandbox bootstrap logs."
         )
       }
+      attempt++
 
       System.err.println(
-        "RobolectricHost: sandbox slot $i failed to boot " +
-          "(attempt ${attempt}/${MAX_SANDBOX_BOOT_RETRIES + 1}" +
-          (bootErr?.message?.let { ": $it" } ?: " — sandbox-ready timeout") +
-          "); retrying with a fresh worker."
+        "RobolectricHost: sandbox slot $i failed to boot with a recorded error " +
+          "(attempt ${attempt}/${MAX_SANDBOX_BOOT_RETRIES + 1}: ${bootErr!!.message}); " +
+          "retrying with a fresh worker."
       )
       // The failed worker has exited (its `SandboxRunner` JUnit run returned with the failure);
       // join briefly to be sure, then reset the slot's boot state and install a fresh worker. A

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -410,8 +410,11 @@ open class RobolectricHost(
       if (userClassloaderHolder != null) it.set(0, userClassloaderHolder)
     }
 
-  private val workerThreads: List<Thread> =
-    (0 until sandboxCount).map { i ->
+  // Mutable so [start] can replace a slot's worker with a fresh one when its first boot attempt
+  // fails transiently (see the retry loop in [start] / [bootSlotWithRetries]). A dead worker's
+  // Thread can't be re-`start()`ed, so a retry allocates a new one at the same index.
+  private val workerThreads: Array<Thread> =
+    Array(sandboxCount) { i ->
       Thread({ runJUnit(workerIndex = i) }, threadName(i)).apply { isDaemon = false }
     }
 
@@ -471,36 +474,7 @@ open class RobolectricHost(
     var bootedThrough = -1
     try {
       for (i in 0 until sandboxCount) {
-        workerThreads[i].start()
-        StartupTimings.mark(
-          if (sandboxCount == 1) "worker thread launched (Robolectric init begins)"
-          else "worker $i launched (Robolectric init begins)"
-        )
-        val slot = DaemonHostBridge.slot(i)
-        val ready = slot.awaitSandboxReady(timeoutMs)
-        // [runJUnit] trips the latch + records the JUnit failure in [workerBootErrors] when the
-        // worker thread exits before `holdSandboxOpen` registered the slot. Check that path first
-        // so a bootstrap crash surfaces with its real cause rather than the timeout message
-        // below — `ready` will read `true` in that case because the latch was counted down by
-        // the same recording step.
-        val bootErr = workerBootErrors.get(i)
-        if (bootErr != null) {
-          if (sandboxCount > 1) dumpAllThreadsToStderr(slot = i, timeoutMs = timeoutMs)
-          throw IllegalStateException(
-            "Robolectric sandbox slot $i aborted during bootstrap — see the " +
-              "SandboxRunner[$i] failure(s) logged above for the underlying cause.",
-            bootErr,
-          )
-        }
-        if (!ready) {
-          if (sandboxCount > 1) dumpAllThreadsToStderr(slot = i, timeoutMs = timeoutMs)
-          error(
-            "Robolectric sandbox slot $i failed to bootstrap within ${timeoutMs}ms — " +
-              "holdSandboxOpen never registered. On a cold cache the instrumented android-all " +
-              "jar download can dominate; raise the timeout via -D$SANDBOX_BOOT_TIMEOUT_PROP=<ms>." +
-              " Otherwise check the SandboxHoldingRunner / Robolectric sandbox bootstrap logs."
-          )
-        }
+        bootSlotWithRetries(i, timeoutMs)
         bootedThrough = i
       }
     } catch (t: Throwable) {
@@ -510,6 +484,80 @@ open class RobolectricHost(
     StartupTimings.mark(
       if (sandboxCount == 1) "sandbox-ready latch fired" else "all sandbox-ready latches fired"
     )
+  }
+
+  /**
+   * Boot the worker for sandbox slot [i] and block until its sandbox registers, **retrying a
+   * transient bootstrap failure** before giving up.
+   *
+   * A single sandbox occasionally dies during Robolectric bootstrap on a memory-pressured host —
+   * observed in production as `Unable to load Robolectric native runtime library` on one slot of a
+   * five-sandbox `wear-m3` pool while its siblings (and a prior daemon's full pool) booted fine, so
+   * the failure is transient, not a hard incompatibility. Previously any single slot's failure threw
+   * straight out of [start] and aborted the **whole** host, which on the public preview server
+   * collapsed the entire live (daemon-backed) lane to the baked-PNG snapshot fallback — the `input
+   * requires a live stream` symptom. Retrying the one flaky slot lets the full pool come up instead
+   * of one hiccup taking down every live render.
+   *
+   * A dead [Thread] can't be restarted, so each retry resets the slot's ready latch + recorded boot
+   * error and installs a fresh worker at index [i] (the sandbox never claimed the slot — the native
+   * load fails before `registerSandbox` — so the slot's `sandboxClassLoaderRef` is still null and a
+   * fresh sandbox re-claims it cleanly). If every attempt fails the last failure is rethrown exactly
+   * as before, so an unrecoverable slot degrades no worse than the pre-retry behaviour.
+   */
+  private fun bootSlotWithRetries(i: Int, timeoutMs: Long) {
+    var attempt = 0
+    while (true) {
+      workerThreads[i].start()
+      StartupTimings.mark(
+        if (sandboxCount == 1) "worker thread launched (Robolectric init begins)"
+        else "worker $i launched (Robolectric init begins)"
+      )
+      val slot = DaemonHostBridge.slot(i)
+      val ready = slot.awaitSandboxReady(timeoutMs)
+      // [runJUnit] trips the latch + records the JUnit failure in [workerBootErrors] when the
+      // worker thread exits before `holdSandboxOpen` registered the slot. Check that path first so
+      // a bootstrap crash surfaces with its real cause rather than the timeout message below —
+      // `ready` reads `true` in that case because the latch was counted down by the same step.
+      val bootErr = workerBootErrors.get(i)
+      if (bootErr == null && ready) return
+
+      if (attempt++ >= MAX_SANDBOX_BOOT_RETRIES) {
+        if (sandboxCount > 1) dumpAllThreadsToStderr(slot = i, timeoutMs = timeoutMs)
+        if (bootErr != null) {
+          throw IllegalStateException(
+            "Robolectric sandbox slot $i aborted during bootstrap after " +
+              "${MAX_SANDBOX_BOOT_RETRIES + 1} attempt(s) — see the SandboxRunner[$i] failure(s) " +
+              "logged above for the underlying cause.",
+            bootErr,
+          )
+        }
+        error(
+          "Robolectric sandbox slot $i failed to bootstrap within ${timeoutMs}ms after " +
+            "${MAX_SANDBOX_BOOT_RETRIES + 1} attempt(s) — holdSandboxOpen never registered. On a " +
+            "cold cache the instrumented android-all jar download can dominate; raise the timeout " +
+            "via -D$SANDBOX_BOOT_TIMEOUT_PROP=<ms>. Otherwise check the SandboxHoldingRunner / " +
+            "Robolectric sandbox bootstrap logs."
+        )
+      }
+
+      System.err.println(
+        "RobolectricHost: sandbox slot $i failed to boot " +
+          "(attempt ${attempt}/${MAX_SANDBOX_BOOT_RETRIES + 1}" +
+          (bootErr?.message?.let { ": $it" } ?: " — sandbox-ready timeout") +
+          "); retrying with a fresh worker."
+      )
+      // The failed worker has exited (its `SandboxRunner` JUnit run returned with the failure);
+      // join briefly to be sure, then reset the slot's boot state and install a fresh worker. A
+      // fresh ready latch is required because `runJUnit`'s failure path already counted the old one
+      // down; `registerSandbox` / the sandbox prologue counts down whatever latch the slot ref holds
+      // at retry time.
+      runCatching { workerThreads[i].join(2_000) }
+      workerBootErrors.set(i, null)
+      DaemonHostBridge.slot(i).sandboxReadyLatchRef.set(java.util.concurrent.CountDownLatch(1))
+      workerThreads[i] =
+        Thread({ runJUnit(workerIndex = i) }, threadName(i)).apply { isDaemon = false }
+    }
   }
 
   /**
@@ -1392,6 +1440,16 @@ open class RobolectricHost(
 
     /** 10 minutes — covers a cold-cache instrumented-android-all download + first-time scan. */
     const val DEFAULT_SANDBOX_BOOT_TIMEOUT_MS: Long = 10L * 60L * 1000L
+
+    /**
+     * How many times [start] re-launches a single sandbox slot whose first boot attempt failed
+     * before it gives up and aborts the host. A transient per-sandbox bootstrap failure (e.g.
+     * `Unable to load Robolectric native runtime library` on a memory-pressured pooled boot) then
+     * no longer takes down the whole live daemon — only a slot that fails every attempt does. Two
+     * retries (three attempts total) clears the observed intermittent case cheaply; a genuinely
+     * broken slot still fails fast rather than looping.
+     */
+    const val MAX_SANDBOX_BOOT_RETRIES: Int = 2
 
     /**
      * Forensic-dump payload prefix — see docs/daemon/CLASSLOADER-FORENSICS.md § Implementation

--- a/deploy/image/Dockerfile
+++ b/deploy/image/Dockerfile
@@ -165,16 +165,31 @@ COPY --from=android-daemon /opt/android-sdk /opt/android-sdk
 #   * sandboxBootTimeoutMs — the Robolectric sandbox boot (the one-time
 #     `android-all-instrumented` ~150 MB fetch + instrumentation, in RobolectricHost.start,
 #     default 600s) — the dominant cold cost; raised so a first boot completes.
-#   * renderTimeoutSeconds — serve's per-render budget once booted.
+#   * renderTimeoutSeconds — serve's per-render *cold* budget once booted.
+#   * frameRenderTimeoutSeconds — serve's per-render budget for a *warm* frame. The 10s default
+#     suits a warm Skiko desktop frame but starves a warm Robolectric (Wear) frame and any
+#     override-bearing re-render (a `?knob.…=` edit forces a real recompose) on this shared box,
+#     which surfaced as `/render?knob.…` returning `500 timed out after 10s`. Lift it in lockstep
+#     with the cold budget so warm overrides/Wear frames have room (ServeRenderHost also gives the
+#     first override render the cold budget, so this only bounds steady-state frames).
 # Both are absorbed by prewarm off the request path, so a browse never blocks. See
 # RobolectricHost / ServeCatalogLiveHost / ServeRenderHost.
+#
+# sandboxCount — the Android/Robolectric daemon defaults to a **5**-sandbox pool (DaemonMain,
+# warmSpare). Five instrumented sandboxes (each ~150 MB+ of instrumented android-all in its own
+# classloader) is heavy for this 8 GB box; the memory pressure is what makes one sandbox
+# intermittently die with `Unable to load Robolectric native runtime library` mid-boot. Pin the
+# pooled Android daemons to **3** (interactive needs ≥2; 3 keeps an interactive slot + two render
+# slots) to cut that footprint ~40%. RobolectricHost also now retries a transient per-sandbox boot
+# failure, so the two changes together keep the Wear live lane up instead of collapsing it to the
+# baked-PNG snapshot. Desktop (CMP) daemons ignore this knob.
 ENV PATH="/opt/compose-preview/bin:${PATH}" \
     SERVE_IDLE_EXIT=0 \
     SERVE_TIMEOUT=1800 \
     COMPOSE_PREVIEW_INIT_USE_MAVEN_LOCAL=1 \
     ANDROID_HOME=/opt/android-sdk \
     ANDROID_SDK_ROOT=/opt/android-sdk \
-    JAVA_TOOL_OPTIONS="-XX:MaxRAMPercentage=70 -Dcomposeai.cli.libDaemonAndroidDir=/opt/lib-daemon-android -Dcomposeai.serve.warmInBackground=true -Dcomposeai.serve.renderTimeoutSeconds=900 -Dcomposeai.daemon.sandboxBootTimeoutMs=1800000"
+    JAVA_TOOL_OPTIONS="-XX:MaxRAMPercentage=70 -Dcomposeai.cli.libDaemonAndroidDir=/opt/lib-daemon-android -Dcomposeai.serve.warmInBackground=true -Dcomposeai.serve.renderTimeoutSeconds=900 -Dcomposeai.serve.frameRenderTimeoutSeconds=120 -Dcomposeai.daemon.sandboxCount=3 -Dcomposeai.daemon.sandboxBootTimeoutMs=1800000"
 
 WORKDIR /project
 # Carry the project + warmed Gradle cache + module build outputs so the first


### PR DESCRIPTION
## Summary

Two failure modes on the public preview server (`preview.coo.ee`) collapsed the live, daemon-backed render lane to the baked-PNG snapshot:

### 1. `?knob.…=` on `/render/{id}.png` → `500 timed out after 10s` (compose-m3)

Reproduced against production (`/version` = `0.16.50`):
- `…/render/button-filled__ideal__default__dark.png` → **200**, PNG ✓
- `…?knob.label=Hello` → **500**, body `timed out after 10s waiting for render`

A knob override is a valid string override that flips `/render` off the instant baked-PNG lane onto a **live desktop re-render**. That render is governed by two budgets in `ServeRenderHost`: a cold budget (`renderTimeoutSeconds`, lifted to 900s by the deploy image) and a warm-frame budget (`frameRenderTimeoutSeconds`, **10s**, not lifted). Because the deploy image runs `warmInBackground`, the background prewarm flips the host-wide `warmedUp` flag, so the user's *first real override render* is charged the tight 10s frame cap and times out.

**Fix:** `ServeRenderHost` now gives the **first override-bearing render** the cold budget too (a prewarm/no-override render no longer starves it); steady-state override frames stay capped so a wedged render can't pin the slot. The deploy image also sets `composeai.serve.frameRenderTimeoutSeconds` alongside the cold budget it already lifts (this also unstarves warm Wear/Robolectric frames, which the 10s default is too tight for).

### 2. wear-m3 live streams → `input requires a live stream`

The `/wear-m3/…` live daemon logs showed `RobolectricHost SandboxRunner[3] failed: Unable to load Robolectric native runtime library`. The Android daemon boots a **5-sandbox pool** (`warmSpare`), and under memory pressure on the 8 GB box one sandbox intermittently fails to load the native runtime. `RobolectricHost.start()` was **all-or-nothing** — any single slot's boot failure aborted the whole host, so the live lane fell back to the snapshot session, whose `Input` handler emits exactly `input requires a live stream`. (Logs prove the native runtime loads fine normally on that box — an earlier full pool booted and rendered — so the failure is transient, not a hard incompatibility.)

**Fix:** `RobolectricHost.start()` now **retries a transient per-slot boot failure** (2 retries; a fresh worker + reset latch each time) before giving up, so one flaky sandbox no longer takes down the whole live lane; an unrecoverable slot still fails exactly as before. The deploy image pins the pooled Android daemons to `sandboxCount=3` (interactive needs ≥2) to relieve the memory pressure that triggers the failure.

## Changes
- `cli/…/serve/ServeRenderHost.kt` — first override render gets the cold budget.
- `daemon/…/RobolectricHost.kt` — bounded per-slot boot retry in `start()`.
- `deploy/image/Dockerfile` — `frameRenderTimeoutSeconds=120` + `sandboxCount=3` in the runtime env.

## Test plan
- `:cli:test` — `ServeRenderHostTest` (22) + `ServeRenderHostStreamTest` (7): **green**.
- `:daemon:android:compileDebugKotlin` + `:cli:compileKotlin`: **clean**.
- Reproduced the production 500 and root-caused it to the warm-frame budget above.
- The `:daemon:android` Robolectric pool tests can't run in the agent container (a nix-vs-glibc `libstdc++` mismatch blocks Robolectric's native libs — it blocks unmodified code too); the new retry path was confirmed to execute and surface the real underlying cause. CI exercises those tests where `libstdc++` is present.

## Rollout note
This is non-visual (it restores rendering; pixels are unchanged), so text-only evidence. The deploy-image env changes reach `preview.coo.ee` on the next image roll; the `ServeRenderHost`/`RobolectricHost` changes ship with the next CLI release (Watchtower).

_Generated by [Claude Code](https://claude.com/claude-code)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SLoRFBUZCqf4rMWJbSvDFZ)_