### PR TITLE
fix(desktop): run the desktop preview JVM as a macOS background agent

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleDaemonCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleDaemonCommand.kt
@@ -266,7 +266,9 @@ class BundleDaemonCommand(args: List<String>) : Command(args) {
     }
     return DaemonLaunch(
       classpath = (daemonJars + rendererJars).joinToString(File.pathSeparator) { it.absolutePath },
-      jvmArgs = listOf("--enable-native-access=ALL-UNNAMED"),
+      // -Dapple.awt.UIElement=true runs the desktop daemon JVM as a macOS background agent
+      // (no Dock icon / focus steal). Launch -D so it lands before AWT inits; macOS-only.
+      jvmArgs = listOf("--enable-native-access=ALL-UNNAMED", "-Dapple.awt.UIElement=true"),
       sysProps = emptyList(),
     )
   }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleRenderer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleRenderer.kt
@@ -435,6 +435,10 @@ class BundleRenderer(
       ProcessBuilder(
           javaBin,
           "--enable-native-access=ALL-UNNAMED",
+          // Run the desktop renderer JVM as a macOS background agent (LSUIElement) so it
+          // doesn't claim a Dock icon or steal focus. Must be a launch -D (before AWT inits);
+          // macOS-only, ignored on Linux/Windows.
+          "-Dapple.awt.UIElement=true",
           "-cp",
           classpath,
           "ee.schimke.composeai.renderer.DesktopRendererMainKt",

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt
@@ -433,7 +433,9 @@ internal object ServeBundleDaemon {
     return BackendDaemonLaunch(
       variant = "desktop",
       daemonClasspath = (daemonJars + rendererJars).map { it.absolutePath },
-      jvmArgs = listOf("--enable-native-access=ALL-UNNAMED"),
+      // -Dapple.awt.UIElement=true runs the desktop daemon JVM as a macOS background agent
+      // (no Dock icon / focus steal). Launch -D so it lands before AWT inits; macOS-only.
+      jvmArgs = listOf("--enable-native-access=ALL-UNNAMED", "-Dapple.awt.UIElement=true"),
       extraSystemProperties = emptyMap(),
     )
   }

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -717,6 +717,14 @@ internal object ComposePreviewTasks {
       // apply here. `-Xmx` is the only essential JVM arg; B-desktop follow-ups can add Skia /
       // ImageComposeScene-specific opens if profiling shows a need.
       jvmArgs.add(extension.daemon.maxHeapMb.map { "-Xmx${it}m" })
+      // Run the long-lived desktop daemon JVM as a macOS "background agent" (LSUIElement) so it
+      // never claims a Dock icon or steals keyboard focus. The daemon renders offscreen (Skiko /
+      // ImageComposeScene, no window), but any non-headless AWT init still registers a Dock tile +
+      // focus grab on macOS — far more noticeable than a one-shot render because the daemon stays
+      // resident for the whole editing session. Passed as a launch `-D` (before AWT initializes);
+      // ignored off macOS, so it's safe unconditionally. See the twin flag on the one-shot render
+      // JavaExec in RenderPreviewsTask.
+      jvmArgs.add("-Dapple.awt.UIElement=true")
 
       // Desktop sysprops are a strict subset of the Android side — no Robolectric / Roborazzi
       // keys. Per-key `put(...)` so each Provider chain captures only serialisable references

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderPreviewsTask.kt
@@ -329,6 +329,15 @@ abstract class RenderPreviewsTask : DefaultTask() {
     execOperations.javaexec {
       classpath = renderClasspath
       this.mainClass.set(mainClass)
+      // Run the render JVM as a macOS "background agent" (LSUIElement) so it never claims a Dock
+      // icon or steals keyboard focus while capturing. DesktopRendererMain draws offscreen via
+      // ImageComposeScene and never opens a window, but any non-headless AWT/Skiko init still
+      // registers a Dock tile + focus grab on macOS. Setting it here on the JavaExec spec forwards
+      // it as a `-D` on the forked JVM command line, i.e. *before* AWT initializes (a
+      // `System.setProperty` inside main() is too late once Skiko touches the toolkit). Ignored on
+      // Linux/Windows, so it's safe to set unconditionally. Headless=true would be stronger but can
+      // break Skiko font/graphics init, so scope this to the focus/Dock symptom only.
+      systemProperty("apple.awt.UIElement", "true")
       // Forward the display-filter selection so DesktopRendererMain can call
       // DisplayFilterDataProducer.writeArtifacts after each render. Empty string is fine —
       // DisplayFilterConfig.parseFilters treats blank input as "feature disabled".


### PR DESCRIPTION
## Problem

On macOS the desktop preview renderer (`DesktopRendererMainKt`) shows up as a **visible Java app** — a Dock icon that steals keyboard focus. It renders **offscreen** via `ImageComposeScene` and never opens a window, but a non-headless AWT/Skiko JVM still claims a Dock tile + focus grab. Nothing in the repo ever set `apple.awt.UIElement` / `java.awt.headless` (confirmed by a repo-wide grep and `git log -S`), so this is a long-standing gap — newly obvious because the **long-lived desktop daemon** now stays resident for the whole editing session instead of flashing per one-shot render.

## Fix

Launch the desktop preview JVM as a macOS "background agent" (LSUIElement) by setting `-Dapple.awt.UIElement=true` at both desktop launch sites:

- `RenderPreviewsTask.invokeRenderer` — the one-shot `composePreviewRender` `JavaExec` (`systemProperty(...)`, which becomes a child `-D`).
- `ComposePreviewTasks` desktop `composePreviewDaemonStart` — added to the daemon `jvmArgs` alongside `-Xmx`.

It has to be a **launch `-D`** so it lands before AWT initializes — a `System.setProperty` inside `main()` is too late once Skiko touches the toolkit. The flag is macOS-only (ignored on Linux/Windows), so it's safe to set unconditionally. `java.awt.headless=true` would be stronger but can break Skiko font/graphics init, so this scopes to the Dock-icon/focus symptom only. The Android/Robolectric render path is headless already and is unaffected.

## Test plan

- No unit/functional test currently decodes the desktop daemon `jvmArgs` or the render `JavaExec` sysprops, and the plugin functional tests spin real Gradle (not runnable in this environment), so this is verified by inspection — it's launch/JVM wiring, no rendered pixels change (text-only per the repo's build-wiring guidance).
- Manual (macOS): open a `:samples:cmp` (or any desktop) module in VS Code; on refresh the render/daemon JVM no longer bounces into the Dock or steals focus, and previews render identically.

## Notes / out of scope

Two other symptoms from the same session log are **not** addressed here and look independent — happy to investigate as follow-ups: the `ScrollingListPreview … slice_0/slice_2.png (No such file)` scroll-slice render failures, and the socket `Timed out waiting for finished message` on the daemon connection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FjDUWeYG9XimiaHB1HdkPz)_