### PR TITLE
fix(serve): re-enable Live Compose axis controls on a catalog live session

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -2175,6 +2175,7 @@ object ServeWeb {
           root.setAttribute("data-mode", "svg"); refreshSnapshot();
         } else { snapshotExt = ".png"; closeStream(); closeWasm(); refreshSnapshot(); }
         syncOverlayToggles();
+        syncServerControls();
         syncScrollToggle();
       }
       // "Full page (scroll)" is only meaningful for the SVG lane; enable it iff SVG is the active
@@ -2194,6 +2195,34 @@ object ServeWeb {
       function syncOverlayToggles() {
         var on = !!(live && live.checked);
         Array.prototype.forEach.call(overlayToggles, function (el) { el.disabled = !on; });
+      }
+      // The server-render display controls (Theme / Device / Locale / Font scale / Orientation /
+      // Background / Size) are baked-disabled on a static snapshot — a published catalog's PNG can't
+      // honour them. But a trusted-catalog live session (staticSnapshot yet canRenderOverrides) CAN
+      // re-render every one of them through its carried daemon over the live socket, so enable them
+      // while Live Compose is the active mode and restore the baked-static disabled state otherwise.
+      // Without this the Live lane streamed frames but its overrides (locale, device, …) stayed
+      // greyed out, so "Live Compose" looked interactive yet every axis control did nothing. A
+      // change to a re-enabled control routes through onControlsChanged, which pushes a fresh
+      // setOverrides down the open stream (or, on the snapshot-fallback lane, re-renders via
+      // /render) — both paths honour the override, so this is correct regardless of which lane the
+      // socket resolved to. The Wasm-honoured trio (uiMode / localeTag / fontScale) is left enabled
+      // on a Wasm-backed static snapshot exactly as the baked markup had it, so leaving Live mode
+      // there doesn't wrongly disable the in-browser controls.
+      var serverOnlyControlIds =
+        ["device", "orientation", "background", "sizeMode",
+         "fixedW", "fixedH", "minW", "minH", "maxW", "maxH"];
+      var wasmHonouredControlIds = ["uiMode", "localeTag", "fontScale"];
+      function syncServerControls() {
+        var liveOn = !!(live && live.checked) && canRenderOverrides;
+        serverOnlyControlIds.forEach(function (id) {
+          var el = document.getElementById("cp-" + id);
+          if (el) el.disabled = liveOn ? false : staticSnapshot;
+        });
+        wasmHonouredControlIds.forEach(function (id) {
+          var el = document.getElementById("cp-" + id);
+          if (el) el.disabled = liveOn ? false : (staticSnapshot && !wasmSrc);
+        });
       }
       // Programmatic switch (e.g. a wasm-only control auto-enabling Wasm): tick the radio so the UI
       // reflects it, then run the transition.

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -1117,6 +1117,34 @@ class ServeWebFixtureTest {
       catalogKnobs.contains("setOverrides\", overrides: overrides()"),
       "live-stream setOverrides sends liveOverrides() (knobs included), not the display-only map",
     )
+    // The server-render display controls (Device / Locale / Font scale / Orientation / …) are baked
+    // disabled on the static snapshot, but a live catalog's carried daemon CAN re-render them — so
+    // entering Live Compose must re-enable them (and leaving restores the baked-static disabled
+    // state). Without this, "Live Compose" streamed frames yet the locale/device/etc. controls
+    // stayed greyed out and every axis change did nothing (the reported Wear regression). The
+    // mode-transition JS calls syncServerControls(), which flips the disabled state on when Live is
+    // the active mode and canRenderOverrides.
+    assertTrue(
+      catalogKnobs.contains("function syncServerControls()"),
+      "the viewer has a syncServerControls() that re-enables display controls in Live mode",
+    )
+    assertTrue(
+      catalogKnobs.contains("syncServerControls();"),
+      "syncServerControls() is invoked on every mode transition",
+    )
+    assertTrue(
+      catalogKnobs.contains("!!(live && live.checked) && canRenderOverrides"),
+      "display controls re-enable only when Live is active AND the daemon can render overrides",
+    )
+    // The server-render-only controls (device/orientation/size) render disabled in the baked markup
+    // (restored when not live); Locale is in the wasm-honoured trio and is disabled on this
+    // no-Wasm static snapshot too, so it's inert until Live Compose flips it on.
+    assertTrue(
+      catalogKnobs.contains("id=\"cp-device\" disabled") &&
+        catalogKnobs.contains("id=\"cp-localeTag\"") &&
+        catalogKnobs.contains("autocomplete=\"off\" disabled"),
+      "display controls (incl. locale) render baked-disabled until Live Compose re-enables them",
+    )
     // A plain static bundle (no daemon) still shows the knobs as DISABLED, informational controls.
     val staticKnobs = ServeWeb.viewerPage(knobPreview, token)
     assertTrue(

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
@@ -1158,6 +1158,7 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
       root.setAttribute("data-mode", "svg"); refreshSnapshot();
     } else { snapshotExt = ".png"; closeStream(); closeWasm(); refreshSnapshot(); }
     syncOverlayToggles();
+    syncServerControls();
     syncScrollToggle();
   }
   // "Full page (scroll)" is only meaningful for the SVG lane; enable it iff SVG is the active
@@ -1177,6 +1178,34 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
   function syncOverlayToggles() {
     var on = !!(live && live.checked);
     Array.prototype.forEach.call(overlayToggles, function (el) { el.disabled = !on; });
+  }
+  // The server-render display controls (Theme / Device / Locale / Font scale / Orientation /
+  // Background / Size) are baked-disabled on a static snapshot — a published catalog's PNG can't
+  // honour them. But a trusted-catalog live session (staticSnapshot yet canRenderOverrides) CAN
+  // re-render every one of them through its carried daemon over the live socket, so enable them
+  // while Live Compose is the active mode and restore the baked-static disabled state otherwise.
+  // Without this the Live lane streamed frames but its overrides (locale, device, …) stayed
+  // greyed out, so "Live Compose" looked interactive yet every axis control did nothing. A
+  // change to a re-enabled control routes through onControlsChanged, which pushes a fresh
+  // setOverrides down the open stream (or, on the snapshot-fallback lane, re-renders via
+  // /render) — both paths honour the override, so this is correct regardless of which lane the
+  // socket resolved to. The Wasm-honoured trio (uiMode / localeTag / fontScale) is left enabled
+  // on a Wasm-backed static snapshot exactly as the baked markup had it, so leaving Live mode
+  // there doesn't wrongly disable the in-browser controls.
+  var serverOnlyControlIds =
+    ["device", "orientation", "background", "sizeMode",
+     "fixedW", "fixedH", "minW", "minH", "maxW", "maxH"];
+  var wasmHonouredControlIds = ["uiMode", "localeTag", "fontScale"];
+  function syncServerControls() {
+    var liveOn = !!(live && live.checked) && canRenderOverrides;
+    serverOnlyControlIds.forEach(function (id) {
+      var el = document.getElementById("cp-" + id);
+      if (el) el.disabled = liveOn ? false : staticSnapshot;
+    });
+    wasmHonouredControlIds.forEach(function (id) {
+      var el = document.getElementById("cp-" + id);
+      if (el) el.disabled = liveOn ? false : (staticSnapshot && !wasmSrc);
+    });
   }
   // Programmatic switch (e.g. a wasm-only control auto-enabling Wasm): tick the radio so the UI
   // reflects it, then run the transition.

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-focus.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-focus.html
@@ -1131,6 +1131,7 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
       root.setAttribute("data-mode", "svg"); refreshSnapshot();
     } else { snapshotExt = ".png"; closeStream(); closeWasm(); refreshSnapshot(); }
     syncOverlayToggles();
+    syncServerControls();
     syncScrollToggle();
   }
   // "Full page (scroll)" is only meaningful for the SVG lane; enable it iff SVG is the active
@@ -1150,6 +1151,34 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
   function syncOverlayToggles() {
     var on = !!(live && live.checked);
     Array.prototype.forEach.call(overlayToggles, function (el) { el.disabled = !on; });
+  }
+  // The server-render display controls (Theme / Device / Locale / Font scale / Orientation /
+  // Background / Size) are baked-disabled on a static snapshot — a published catalog's PNG can't
+  // honour them. But a trusted-catalog live session (staticSnapshot yet canRenderOverrides) CAN
+  // re-render every one of them through its carried daemon over the live socket, so enable them
+  // while Live Compose is the active mode and restore the baked-static disabled state otherwise.
+  // Without this the Live lane streamed frames but its overrides (locale, device, …) stayed
+  // greyed out, so "Live Compose" looked interactive yet every axis control did nothing. A
+  // change to a re-enabled control routes through onControlsChanged, which pushes a fresh
+  // setOverrides down the open stream (or, on the snapshot-fallback lane, re-renders via
+  // /render) — both paths honour the override, so this is correct regardless of which lane the
+  // socket resolved to. The Wasm-honoured trio (uiMode / localeTag / fontScale) is left enabled
+  // on a Wasm-backed static snapshot exactly as the baked markup had it, so leaving Live mode
+  // there doesn't wrongly disable the in-browser controls.
+  var serverOnlyControlIds =
+    ["device", "orientation", "background", "sizeMode",
+     "fixedW", "fixedH", "minW", "minH", "maxW", "maxH"];
+  var wasmHonouredControlIds = ["uiMode", "localeTag", "fontScale"];
+  function syncServerControls() {
+    var liveOn = !!(live && live.checked) && canRenderOverrides;
+    serverOnlyControlIds.forEach(function (id) {
+      var el = document.getElementById("cp-" + id);
+      if (el) el.disabled = liveOn ? false : staticSnapshot;
+    });
+    wasmHonouredControlIds.forEach(function (id) {
+      var el = document.getElementById("cp-" + id);
+      if (el) el.disabled = liveOn ? false : (staticSnapshot && !wasmSrc);
+    });
   }
   // Programmatic switch (e.g. a wasm-only control auto-enabling Wasm): tick the radio so the UI
   // reflects it, then run the transition.

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-gestures.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-gestures.html
@@ -1131,6 +1131,7 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
       root.setAttribute("data-mode", "svg"); refreshSnapshot();
     } else { snapshotExt = ".png"; closeStream(); closeWasm(); refreshSnapshot(); }
     syncOverlayToggles();
+    syncServerControls();
     syncScrollToggle();
   }
   // "Full page (scroll)" is only meaningful for the SVG lane; enable it iff SVG is the active
@@ -1150,6 +1151,34 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
   function syncOverlayToggles() {
     var on = !!(live && live.checked);
     Array.prototype.forEach.call(overlayToggles, function (el) { el.disabled = !on; });
+  }
+  // The server-render display controls (Theme / Device / Locale / Font scale / Orientation /
+  // Background / Size) are baked-disabled on a static snapshot — a published catalog's PNG can't
+  // honour them. But a trusted-catalog live session (staticSnapshot yet canRenderOverrides) CAN
+  // re-render every one of them through its carried daemon over the live socket, so enable them
+  // while Live Compose is the active mode and restore the baked-static disabled state otherwise.
+  // Without this the Live lane streamed frames but its overrides (locale, device, …) stayed
+  // greyed out, so "Live Compose" looked interactive yet every axis control did nothing. A
+  // change to a re-enabled control routes through onControlsChanged, which pushes a fresh
+  // setOverrides down the open stream (or, on the snapshot-fallback lane, re-renders via
+  // /render) — both paths honour the override, so this is correct regardless of which lane the
+  // socket resolved to. The Wasm-honoured trio (uiMode / localeTag / fontScale) is left enabled
+  // on a Wasm-backed static snapshot exactly as the baked markup had it, so leaving Live mode
+  // there doesn't wrongly disable the in-browser controls.
+  var serverOnlyControlIds =
+    ["device", "orientation", "background", "sizeMode",
+     "fixedW", "fixedH", "minW", "minH", "maxW", "maxH"];
+  var wasmHonouredControlIds = ["uiMode", "localeTag", "fontScale"];
+  function syncServerControls() {
+    var liveOn = !!(live && live.checked) && canRenderOverrides;
+    serverOnlyControlIds.forEach(function (id) {
+      var el = document.getElementById("cp-" + id);
+      if (el) el.disabled = liveOn ? false : staticSnapshot;
+    });
+    wasmHonouredControlIds.forEach(function (id) {
+      var el = document.getElementById("cp-" + id);
+      if (el) el.disabled = liveOn ? false : (staticSnapshot && !wasmSrc);
+    });
   }
   // Programmatic switch (e.g. a wasm-only control auto-enabling Wasm): tick the radio so the UI
   // reflects it, then run the transition.

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
@@ -1135,6 +1135,7 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
       root.setAttribute("data-mode", "svg"); refreshSnapshot();
     } else { snapshotExt = ".png"; closeStream(); closeWasm(); refreshSnapshot(); }
     syncOverlayToggles();
+    syncServerControls();
     syncScrollToggle();
   }
   // "Full page (scroll)" is only meaningful for the SVG lane; enable it iff SVG is the active
@@ -1154,6 +1155,34 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
   function syncOverlayToggles() {
     var on = !!(live && live.checked);
     Array.prototype.forEach.call(overlayToggles, function (el) { el.disabled = !on; });
+  }
+  // The server-render display controls (Theme / Device / Locale / Font scale / Orientation /
+  // Background / Size) are baked-disabled on a static snapshot — a published catalog's PNG can't
+  // honour them. But a trusted-catalog live session (staticSnapshot yet canRenderOverrides) CAN
+  // re-render every one of them through its carried daemon over the live socket, so enable them
+  // while Live Compose is the active mode and restore the baked-static disabled state otherwise.
+  // Without this the Live lane streamed frames but its overrides (locale, device, …) stayed
+  // greyed out, so "Live Compose" looked interactive yet every axis control did nothing. A
+  // change to a re-enabled control routes through onControlsChanged, which pushes a fresh
+  // setOverrides down the open stream (or, on the snapshot-fallback lane, re-renders via
+  // /render) — both paths honour the override, so this is correct regardless of which lane the
+  // socket resolved to. The Wasm-honoured trio (uiMode / localeTag / fontScale) is left enabled
+  // on a Wasm-backed static snapshot exactly as the baked markup had it, so leaving Live mode
+  // there doesn't wrongly disable the in-browser controls.
+  var serverOnlyControlIds =
+    ["device", "orientation", "background", "sizeMode",
+     "fixedW", "fixedH", "minW", "minH", "maxW", "maxH"];
+  var wasmHonouredControlIds = ["uiMode", "localeTag", "fontScale"];
+  function syncServerControls() {
+    var liveOn = !!(live && live.checked) && canRenderOverrides;
+    serverOnlyControlIds.forEach(function (id) {
+      var el = document.getElementById("cp-" + id);
+      if (el) el.disabled = liveOn ? false : staticSnapshot;
+    });
+    wasmHonouredControlIds.forEach(function (id) {
+      var el = document.getElementById("cp-" + id);
+      if (el) el.disabled = liveOn ? false : (staticSnapshot && !wasmSrc);
+    });
   }
   // Programmatic switch (e.g. a wasm-only control auto-enabling Wasm): tick the radio so the UI
   // reflects it, then run the transition.

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-states.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-states.html
@@ -1140,6 +1140,7 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
       root.setAttribute("data-mode", "svg"); refreshSnapshot();
     } else { snapshotExt = ".png"; closeStream(); closeWasm(); refreshSnapshot(); }
     syncOverlayToggles();
+    syncServerControls();
     syncScrollToggle();
   }
   // "Full page (scroll)" is only meaningful for the SVG lane; enable it iff SVG is the active
@@ -1159,6 +1160,34 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
   function syncOverlayToggles() {
     var on = !!(live && live.checked);
     Array.prototype.forEach.call(overlayToggles, function (el) { el.disabled = !on; });
+  }
+  // The server-render display controls (Theme / Device / Locale / Font scale / Orientation /
+  // Background / Size) are baked-disabled on a static snapshot — a published catalog's PNG can't
+  // honour them. But a trusted-catalog live session (staticSnapshot yet canRenderOverrides) CAN
+  // re-render every one of them through its carried daemon over the live socket, so enable them
+  // while Live Compose is the active mode and restore the baked-static disabled state otherwise.
+  // Without this the Live lane streamed frames but its overrides (locale, device, …) stayed
+  // greyed out, so "Live Compose" looked interactive yet every axis control did nothing. A
+  // change to a re-enabled control routes through onControlsChanged, which pushes a fresh
+  // setOverrides down the open stream (or, on the snapshot-fallback lane, re-renders via
+  // /render) — both paths honour the override, so this is correct regardless of which lane the
+  // socket resolved to. The Wasm-honoured trio (uiMode / localeTag / fontScale) is left enabled
+  // on a Wasm-backed static snapshot exactly as the baked markup had it, so leaving Live mode
+  // there doesn't wrongly disable the in-browser controls.
+  var serverOnlyControlIds =
+    ["device", "orientation", "background", "sizeMode",
+     "fixedW", "fixedH", "minW", "minH", "maxW", "maxH"];
+  var wasmHonouredControlIds = ["uiMode", "localeTag", "fontScale"];
+  function syncServerControls() {
+    var liveOn = !!(live && live.checked) && canRenderOverrides;
+    serverOnlyControlIds.forEach(function (id) {
+      var el = document.getElementById("cp-" + id);
+      if (el) el.disabled = liveOn ? false : staticSnapshot;
+    });
+    wasmHonouredControlIds.forEach(function (id) {
+      var el = document.getElementById("cp-" + id);
+      if (el) el.disabled = liveOn ? false : (staticSnapshot && !wasmSrc);
+    });
   }
   // Programmatic switch (e.g. a wasm-only control auto-enabling Wasm): tick the radio so the UI
   // reflects it, then run the transition.

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-themes.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-themes.html
@@ -1135,6 +1135,7 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
       root.setAttribute("data-mode", "svg"); refreshSnapshot();
     } else { snapshotExt = ".png"; closeStream(); closeWasm(); refreshSnapshot(); }
     syncOverlayToggles();
+    syncServerControls();
     syncScrollToggle();
   }
   // "Full page (scroll)" is only meaningful for the SVG lane; enable it iff SVG is the active
@@ -1154,6 +1155,34 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
   function syncOverlayToggles() {
     var on = !!(live && live.checked);
     Array.prototype.forEach.call(overlayToggles, function (el) { el.disabled = !on; });
+  }
+  // The server-render display controls (Theme / Device / Locale / Font scale / Orientation /
+  // Background / Size) are baked-disabled on a static snapshot — a published catalog's PNG can't
+  // honour them. But a trusted-catalog live session (staticSnapshot yet canRenderOverrides) CAN
+  // re-render every one of them through its carried daemon over the live socket, so enable them
+  // while Live Compose is the active mode and restore the baked-static disabled state otherwise.
+  // Without this the Live lane streamed frames but its overrides (locale, device, …) stayed
+  // greyed out, so "Live Compose" looked interactive yet every axis control did nothing. A
+  // change to a re-enabled control routes through onControlsChanged, which pushes a fresh
+  // setOverrides down the open stream (or, on the snapshot-fallback lane, re-renders via
+  // /render) — both paths honour the override, so this is correct regardless of which lane the
+  // socket resolved to. The Wasm-honoured trio (uiMode / localeTag / fontScale) is left enabled
+  // on a Wasm-backed static snapshot exactly as the baked markup had it, so leaving Live mode
+  // there doesn't wrongly disable the in-browser controls.
+  var serverOnlyControlIds =
+    ["device", "orientation", "background", "sizeMode",
+     "fixedW", "fixedH", "minW", "minH", "maxW", "maxH"];
+  var wasmHonouredControlIds = ["uiMode", "localeTag", "fontScale"];
+  function syncServerControls() {
+    var liveOn = !!(live && live.checked) && canRenderOverrides;
+    serverOnlyControlIds.forEach(function (id) {
+      var el = document.getElementById("cp-" + id);
+      if (el) el.disabled = liveOn ? false : staticSnapshot;
+    });
+    wasmHonouredControlIds.forEach(function (id) {
+      var el = document.getElementById("cp-" + id);
+      if (el) el.disabled = liveOn ? false : (staticSnapshot && !wasmSrc);
+    });
   }
   // Programmatic switch (e.g. a wasm-only control auto-enabling Wasm): tick the radio so the UI
   // reflects it, then run the transition.

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
@@ -1127,6 +1127,7 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
       root.setAttribute("data-mode", "svg"); refreshSnapshot();
     } else { snapshotExt = ".png"; closeStream(); closeWasm(); refreshSnapshot(); }
     syncOverlayToggles();
+    syncServerControls();
     syncScrollToggle();
   }
   // "Full page (scroll)" is only meaningful for the SVG lane; enable it iff SVG is the active
@@ -1146,6 +1147,34 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
   function syncOverlayToggles() {
     var on = !!(live && live.checked);
     Array.prototype.forEach.call(overlayToggles, function (el) { el.disabled = !on; });
+  }
+  // The server-render display controls (Theme / Device / Locale / Font scale / Orientation /
+  // Background / Size) are baked-disabled on a static snapshot — a published catalog's PNG can't
+  // honour them. But a trusted-catalog live session (staticSnapshot yet canRenderOverrides) CAN
+  // re-render every one of them through its carried daemon over the live socket, so enable them
+  // while Live Compose is the active mode and restore the baked-static disabled state otherwise.
+  // Without this the Live lane streamed frames but its overrides (locale, device, …) stayed
+  // greyed out, so "Live Compose" looked interactive yet every axis control did nothing. A
+  // change to a re-enabled control routes through onControlsChanged, which pushes a fresh
+  // setOverrides down the open stream (or, on the snapshot-fallback lane, re-renders via
+  // /render) — both paths honour the override, so this is correct regardless of which lane the
+  // socket resolved to. The Wasm-honoured trio (uiMode / localeTag / fontScale) is left enabled
+  // on a Wasm-backed static snapshot exactly as the baked markup had it, so leaving Live mode
+  // there doesn't wrongly disable the in-browser controls.
+  var serverOnlyControlIds =
+    ["device", "orientation", "background", "sizeMode",
+     "fixedW", "fixedH", "minW", "minH", "maxW", "maxH"];
+  var wasmHonouredControlIds = ["uiMode", "localeTag", "fontScale"];
+  function syncServerControls() {
+    var liveOn = !!(live && live.checked) && canRenderOverrides;
+    serverOnlyControlIds.forEach(function (id) {
+      var el = document.getElementById("cp-" + id);
+      if (el) el.disabled = liveOn ? false : staticSnapshot;
+    });
+    wasmHonouredControlIds.forEach(function (id) {
+      var el = document.getElementById("cp-" + id);
+      if (el) el.disabled = liveOn ? false : (staticSnapshot && !wasmSrc);
+    });
   }
   // Programmatic switch (e.g. a wasm-only control auto-enabling Wasm): tick the radio so the UI
   // reflects it, then run the transition.

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
@@ -1123,6 +1123,7 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
       root.setAttribute("data-mode", "svg"); refreshSnapshot();
     } else { snapshotExt = ".png"; closeStream(); closeWasm(); refreshSnapshot(); }
     syncOverlayToggles();
+    syncServerControls();
     syncScrollToggle();
   }
   // "Full page (scroll)" is only meaningful for the SVG lane; enable it iff SVG is the active
@@ -1142,6 +1143,34 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
   function syncOverlayToggles() {
     var on = !!(live && live.checked);
     Array.prototype.forEach.call(overlayToggles, function (el) { el.disabled = !on; });
+  }
+  // The server-render display controls (Theme / Device / Locale / Font scale / Orientation /
+  // Background / Size) are baked-disabled on a static snapshot — a published catalog's PNG can't
+  // honour them. But a trusted-catalog live session (staticSnapshot yet canRenderOverrides) CAN
+  // re-render every one of them through its carried daemon over the live socket, so enable them
+  // while Live Compose is the active mode and restore the baked-static disabled state otherwise.
+  // Without this the Live lane streamed frames but its overrides (locale, device, …) stayed
+  // greyed out, so "Live Compose" looked interactive yet every axis control did nothing. A
+  // change to a re-enabled control routes through onControlsChanged, which pushes a fresh
+  // setOverrides down the open stream (or, on the snapshot-fallback lane, re-renders via
+  // /render) — both paths honour the override, so this is correct regardless of which lane the
+  // socket resolved to. The Wasm-honoured trio (uiMode / localeTag / fontScale) is left enabled
+  // on a Wasm-backed static snapshot exactly as the baked markup had it, so leaving Live mode
+  // there doesn't wrongly disable the in-browser controls.
+  var serverOnlyControlIds =
+    ["device", "orientation", "background", "sizeMode",
+     "fixedW", "fixedH", "minW", "minH", "maxW", "maxH"];
+  var wasmHonouredControlIds = ["uiMode", "localeTag", "fontScale"];
+  function syncServerControls() {
+    var liveOn = !!(live && live.checked) && canRenderOverrides;
+    serverOnlyControlIds.forEach(function (id) {
+      var el = document.getElementById("cp-" + id);
+      if (el) el.disabled = liveOn ? false : staticSnapshot;
+    });
+    wasmHonouredControlIds.forEach(function (id) {
+      var el = document.getElementById("cp-" + id);
+      if (el) el.disabled = liveOn ? false : (staticSnapshot && !wasmSrc);
+    });
   }
   // Programmatic switch (e.g. a wasm-only control auto-enabling Wasm): tick the radio so the UI
   // reflects it, then run the transition.

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
@@ -1135,6 +1135,7 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
       root.setAttribute("data-mode", "svg"); refreshSnapshot();
     } else { snapshotExt = ".png"; closeStream(); closeWasm(); refreshSnapshot(); }
     syncOverlayToggles();
+    syncServerControls();
     syncScrollToggle();
   }
   // "Full page (scroll)" is only meaningful for the SVG lane; enable it iff SVG is the active
@@ -1154,6 +1155,34 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
   function syncOverlayToggles() {
     var on = !!(live && live.checked);
     Array.prototype.forEach.call(overlayToggles, function (el) { el.disabled = !on; });
+  }
+  // The server-render display controls (Theme / Device / Locale / Font scale / Orientation /
+  // Background / Size) are baked-disabled on a static snapshot — a published catalog's PNG can't
+  // honour them. But a trusted-catalog live session (staticSnapshot yet canRenderOverrides) CAN
+  // re-render every one of them through its carried daemon over the live socket, so enable them
+  // while Live Compose is the active mode and restore the baked-static disabled state otherwise.
+  // Without this the Live lane streamed frames but its overrides (locale, device, …) stayed
+  // greyed out, so "Live Compose" looked interactive yet every axis control did nothing. A
+  // change to a re-enabled control routes through onControlsChanged, which pushes a fresh
+  // setOverrides down the open stream (or, on the snapshot-fallback lane, re-renders via
+  // /render) — both paths honour the override, so this is correct regardless of which lane the
+  // socket resolved to. The Wasm-honoured trio (uiMode / localeTag / fontScale) is left enabled
+  // on a Wasm-backed static snapshot exactly as the baked markup had it, so leaving Live mode
+  // there doesn't wrongly disable the in-browser controls.
+  var serverOnlyControlIds =
+    ["device", "orientation", "background", "sizeMode",
+     "fixedW", "fixedH", "minW", "minH", "maxW", "maxH"];
+  var wasmHonouredControlIds = ["uiMode", "localeTag", "fontScale"];
+  function syncServerControls() {
+    var liveOn = !!(live && live.checked) && canRenderOverrides;
+    serverOnlyControlIds.forEach(function (id) {
+      var el = document.getElementById("cp-" + id);
+      if (el) el.disabled = liveOn ? false : staticSnapshot;
+    });
+    wasmHonouredControlIds.forEach(function (id) {
+      var el = document.getElementById("cp-" + id);
+      if (el) el.disabled = liveOn ? false : (staticSnapshot && !wasmSrc);
+    });
   }
   // Programmatic switch (e.g. a wasm-only control auto-enabling Wasm): tick the radio so the UI
   // reflects it, then run the transition.


### PR DESCRIPTION
## Summary

On a trusted-catalog **live** session (`ServeCatalogLiveHost` — the `wear-m3` / `compose-m3` shape), the viewer serves static baked snapshots (`canApplyOverrides=false`) yet offers the daemon live stream (`hasLiveStream=true`) and can re-render every display axis on demand (`canRenderOverrides=true`).

But the server-render controls — **Theme, Device, Locale, Font scale, Orientation, Background, Size** — are emitted `disabled` for a static snapshot, and the mode-transition JS only ever re-enabled the *live-only overlay toggles* (`syncOverlayToggles`), never these axes. So switching to **Live Compose** streamed frames while Locale/Device/etc. stayed greyed out and every axis change did nothing — the reported Wear M3 **"locale selection isn't working."**

### Fix

Add `syncServerControls()`, called on every mode transition alongside `syncOverlayToggles()`:

- enables the axis controls while **Live Compose is the active mode and `canRenderOverrides`**;
- restores the baked-static disabled state otherwise;
- leaves the Wasm-honoured trio (`uiMode`/`localeTag`/`fontScale`) untouched on a Wasm-backed snapshot, so leaving Live mode there doesn't wrongly disable the in-browser controls.

A change to a re-enabled control already routes through `onControlsChanged`, which pushes a fresh `setOverrides` down the open stream — or, on the snapshot-fallback lane, re-renders via the daemon (`ServeStreamSession.setOverrides → render → ServeCatalogLiveHost.render → daemon`). So the override is honoured on **either** lane.

## Test plan

- [x] `./gradlew :cli:test --tests '*ServeWebFixtureTest*'` — green. Added a regression on the catalog-live (no-Wasm, `canRenderOverrides=true`) viewer shape asserting the JS carries `syncServerControls()`, invokes it on mode transitions, gates on `live && canRenderOverrides`, and still renders the controls baked-disabled (incl. locale) in the static markup.
- [x] Regenerated the `serve-viewer-*` preview-harness fixtures (`UPDATE_SERVE_WEB_FIXTURES=true`) so the drift guard passes.
- [x] `ktfmtFormat` on the touched module.

## Visual evidence

This is a **runtime JS state transition** (axis controls flip from disabled→enabled when Live Compose is entered), not a static-markup change — the committed `serve-viewer-*.html` fixture PNGs render the controls in their baked (disabled) state on both sides, so a static screenshot can't show the before/after. It's verified instead by the `ServeWebFixtureTest` assertions above and reproducible in a browser: open a `wear-m3` preview, pick **Live Compose**, and the Locale / Device / Font scale / Orientation controls become editable and re-render the stream.

## Not covered here (separate, server-side)

The **"input requires a live stream"** symptom (clicks not dispatching) is the WebSocket falling back to the snapshot lane (`ServeStreamSession`) because the Android interactive session (`RobolectricHost` v3 held session) didn't come up on that box. The wiring looks correct on paper — the bundle daemon sets `previewsJsonPath` (so `previewSpecResolver` is wired), the deploy image sets `sandboxCount=3`, and plain override renders succeed (proving preview-id resolution works) — so this needs the box's daemon logs to pin down (interactive-start failure vs. second-sandbox boot) rather than a blind code change. Tracking separately.

---
_Generated by [Claude Code](https://claude.ai/code/session_01W2hVUK8JYkwaEGpU4sXBod)_