### PR TITLE
fix(figma-svg): match opaque raster components case-sensitively

### DIFF
--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgModel.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgModel.kt
@@ -770,9 +770,19 @@ data class FigmaSvgModel(
     }
 
     /** True when the composable name matches a [rasterComponents] fragment. */
+    /**
+     * True when the node's composable name carries an opaque, un-vectorisable component as a
+     * CamelCase token — `AsyncImage`/`Image`, `IconButton`/`Icon`, `OutlinedTextField`/`TextField`.
+     * The match is **case-sensitive** on purpose: the fragments and Compose component names are all
+     * PascalCase, so a token boundary is an uppercase letter. A case-insensitive `contains` instead
+     * false-matches a keyword buried across a lowercase→uppercase seam — e.g.
+     * `MultiContentMeasurePolicyImpl` (the `SegmentedButton`/multi-content layout policy) contains
+     * "icon" in "Mult**iCon**tent", which would raster the whole labelled subtree as if it were an
+     * `Icon`.
+     */
     private fun LayoutInspectorNode.isOpaque(rasterComponents: Set<String>): Boolean =
       rasterComponents.any {
-        component.contains(it, ignoreCase = true)
+        component.contains(it)
       }
 
     /**

--- a/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/FigmaSvgSegmentedButtonTest.kt
+++ b/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/FigmaSvgSegmentedButtonTest.kt
@@ -1,0 +1,143 @@
+package ee.schimke.composeai.renderer
+
+import androidx.activity.ComponentActivity
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.InternalComposeApi
+import androidx.compose.runtime.currentComposer
+import androidx.compose.runtime.tooling.CompositionData
+import androidx.compose.runtime.tooling.LocalInspectionTables
+import androidx.compose.ui.node.RootForTest
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onRoot
+import com.github.takahirom.roborazzi.captureRoboImage
+import ee.schimke.composeai.daemon.ComposeFigmaSvgDataProducer
+import ee.schimke.composeai.daemon.ComposeSemanticsDataProducer
+import ee.schimke.composeai.daemon.LayoutInspectorDataProducer
+import ee.schimke.composeai.data.render.PreviewContext
+import java.io.File
+import java.nio.file.Files
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.Description
+import org.junit.runner.RunWith
+import org.junit.runners.model.Statement
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * A `SegmentedButton`'s label must export as editable `<text>`, not a raster `<image>`. Its content
+ * sits under a `MultiContentMeasurePolicyImpl` layout node whose name contains "icon" across the
+ * "Mult**iCon**tent" seam; a case-insensitive opaque-by-name match rasterised the whole labelled
+ * subtree as if it were an `Icon`. The match is case-sensitive (PascalCase-token) so that seam no
+ * longer false-matches — the labels stay text and the selection checkmark vectorises.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+class FigmaSvgSegmentedButtonTest {
+
+  private lateinit var rootDir: File
+
+  @Before
+  fun setUp() {
+    rootDir = Files.createTempDirectory("figma-svg-segmented").toFile()
+    System.setProperty("roborazzi.test.record", "true")
+  }
+
+  @After
+  fun tearDown() {
+    rootDir.deleteRecursively()
+    System.clearProperty("roborazzi.test.record")
+  }
+
+  @Test
+  fun `segmented button labels export as editable text, not raster crops`() {
+    val svg =
+      renderSvg("segmented") {
+        SingleChoiceSegmentedButtonRow {
+          SegmentedButton(
+            selected = true,
+            onClick = {},
+            shape = SegmentedButtonDefaults.itemShape(index = 0, count = 2),
+          ) {
+            Text("Enabled")
+          }
+          SegmentedButton(
+            selected = false,
+            onClick = {},
+            shape = SegmentedButtonDefaults.itemShape(index = 1, count = 2),
+          ) {
+            Text("Disabled")
+          }
+        }
+      }
+
+    File("build/figma-svg-segmented").mkdirs()
+    File("build/figma-svg-segmented/segmented.svg").writeText(svg)
+
+    assertTrue("the first label must be editable text:\n$svg", svg.contains(">Enabled</text>"))
+    assertTrue("the second label must be editable text:\n$svg", svg.contains(">Disabled</text>"))
+    assertFalse(
+      "the labelled content must not raster as an <image> (the MultiContent 'iCon' seam):\n$svg",
+      svg.contains("<image "),
+    )
+  }
+
+  private fun renderSvg(previewId: String, content: @Composable () -> Unit): String {
+    RuntimeEnvironment.setQualifiers("w400dp-h200dp-mdpi")
+    @Suppress("DEPRECATION") val rule = createAndroidComposeRule<ComponentActivity>()
+    var svg = ""
+    val statement =
+      object : Statement() {
+        override fun evaluate() {
+          val slots = mutableSetOf<CompositionData>()
+          rule.setContent { InspectableSegContent(slots, content) }
+          rule.waitForIdle()
+          val frame = File(rootDir, "$previewId-frame.png")
+          frame.parentFile?.mkdirs()
+          rule.onRoot().captureRoboImage(file = frame)
+          val semRoot = rule.onRoot(useUnmergedTree = true).fetchSemanticsNode()
+          val ctx =
+            PreviewContext.Builder(previewId, null, null, previewId)
+              .rootForTest(semRoot.root as RootForTest)
+              .addSlotTables(slots.toList())
+              .parameterInformationCollected()
+              .build()
+          val layout = LayoutInspectorDataProducer.buildPayload(ctx, density = 1f)!!
+          val sem = ComposeSemanticsDataProducer.buildPayload(semRoot, density = 1f)
+          ComposeFigmaSvgDataProducer.writeSvg(
+            rootDir = rootDir,
+            previewId = previewId,
+            layout = layout,
+            semantics = sem,
+            density = 1f,
+            frameImage = frame,
+          )
+          svg = File(rootDir, "$previewId/compose-figma.svg").readText()
+        }
+      }
+    rule.apply(statement, Description.createTestDescription(javaClass, previewId)).evaluate()
+    return svg
+  }
+}
+
+@OptIn(InternalComposeApi::class)
+@Composable
+private fun InspectableSegContent(
+  capture: MutableSet<CompositionData>,
+  content: @Composable () -> Unit,
+) {
+  currentComposer.collectParameterInformation()
+  capture.add(currentComposer.compositionData)
+  CompositionLocalProvider(LocalInspectionTables provides capture, content = content)
+}


### PR DESCRIPTION
## What

A `SegmentedButton`'s labels were exporting as opaque `<image>` raster crops instead of editable `<text>` (reported on `compose-m3/render/segmentedbutton__ideal__default__light.svg`).

**Root cause:** the opaque-by-name raster rule matched a node's component name against the raster keywords (`Icon`, `Image`, `TextField`, …) with a **case-insensitive** `contains`. Those keywords and Compose component names are all PascalCase, so a CamelCase token boundary is an uppercase letter — and the case-insensitive match false-fired across a lowercase→uppercase seam. `SegmentedButton`'s content sits under `MultiContentMeasurePolicyImpl`, whose name contains "icon" in "Mult**iCon**tent", so the whole labelled subtree rasterised as if it were an `Icon`.

Matching **case-sensitively** still catches every real case (`AsyncImage`→`Image`, `IconButton`→`Icon`, `OutlinedTextField`→`TextField`) while rejecting the seam. A bonus: with the false raster gone, the selection checkmark now flows through the Tier-1 `ImageVector` path and vectorises to `<path>`.

## Evidence

Rendered through the real Android/Robolectric export in hybrid raster mode. Element counts for the segmented button preview:

| | `<image>` | `<text>` | `<path>` |
|---|---|---|---|
| **before** | 2 (label crops) | 0 | 2 (pill outlines) |
| **after** | 0 | 2 (`Enabled`, `Disabled`) | 3 (+ checkmark) |

Before (the served SVG) — each label was an opaque crop:
```xml
<g id="MultiContentMeasurePolicyImpl">
  ``&lt;image href="figma-raster/…png" x="253" y="79" width="118" height="53"/&gt;``
</g>
```
After — editable text (and the checkmark as vector):
```xml
<text …>Enabled</text>
<text …>Disabled</text>
<path d="…" …/>   <!-- selection checkmark -->
```

## Test plan

`FigmaSvgSegmentedButtonTest` (`:renderer-android`, Robolectric) — renders a `SegmentedButton` and asserts the labels export as `>Enabled</text>` / `>Disabled</text>` with no `<image>`. `FigmaSvgVectorIconRenderTest` (the icon suite that exercises the same opaque-by-name path) still passes, confirming the case-sensitive match doesn't regress `Icon`/`Image` rasterisation. `./gradlew ktfmtFormat` run clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_Generated by [Claude Code]_

---
_Generated by [Claude Code](https://claude.ai/code/session_013Q9cjwna73rpvVdrw1ApLP)_