### PR TITLE
fix(serve): surface the live lane's original failure instead of a bare input error

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBroadcastHub.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBroadcastHub.kt
@@ -16,6 +16,7 @@ fun interface StreamOpener {
     overrides: PreviewOverrides,
     codec: StreamCodec?,
     maxFps: Int?,
+    onUnavailable: ((String) -> Unit)?,
     onFrame: (StreamFrameParams) -> Unit,
   ): StreamHandle?
 }
@@ -53,6 +54,7 @@ class ServeBroadcastHub(private val opener: StreamOpener) {
     overrides: PreviewOverrides,
     codec: StreamCodec? = null,
     maxFps: Int? = null,
+    onUnavailable: ((String) -> Unit)? = null,
     onFrame: (StreamFrameParams) -> Unit,
   ): StreamHandle? = lock.withLock {
     val key = keyOf(previewId, overrides, codec, maxFps)
@@ -61,9 +63,10 @@ class ServeBroadcastHub(private val opener: StreamOpener) {
         ?: run {
           val fresh = Broadcast(key)
           // Hold the lock across the open so two racing first-subscribers can't open two upstreams
-          // for one key; opens are cheap relative to a dev server's client count.
+          // for one key; opens are cheap relative to a dev server's client count. A failed open
+          // reports its reason through [onUnavailable] (forwarded to the opener) before the null.
           val handle =
-            opener.open(previewId, overrides, codec, maxFps, fresh::onUpstreamFrame)
+            opener.open(previewId, overrides, codec, maxFps, onUnavailable, fresh::onUpstreamFrame)
               ?: return@withLock null
           fresh.handle = handle
           broadcasts[key] = fresh

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
@@ -218,8 +218,12 @@ class ServeBundleHost(
     overrides: PreviewOverrides,
     codec: StreamCodec?,
     maxFps: Int?,
+    onUnavailable: ((String) -> Unit)?,
     onFrame: (StreamFrameParams) -> Unit,
-  ): StreamHandle? = null
+  ): StreamHandle? {
+    onUnavailable?.invoke("this session serves baked snapshots only (no live daemon)")
+    return null
+  }
 
   override fun activeStreamCount(): Int = 0
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
@@ -264,10 +264,26 @@ class ServeCatalogLiveHost(
     overrides: PreviewOverrides,
     codec: StreamCodec?,
     maxFps: Int?,
+    onUnavailable: ((String) -> Unit)?,
     onFrame: (StreamFrameParams) -> Unit,
   ): StreamHandle? {
-    val daemonId = alias[previewId] ?: return null
-    return liveHostFor(daemonId).subscribeStream(daemonId, overrides, codec, maxFps, onFrame)
+    val daemonId =
+      alias[previewId]
+        ?: run {
+          // An unmapped (Android-only) variant has no daemon twin, so no live lane — report it so
+          // the viewer explains the snapshot fallback rather than a bare "input requires a stream".
+          onUnavailable?.invoke("no live daemon twin for '$previewId' (baked snapshot only)")
+          return null
+        }
+    return liveHostFor(daemonId)
+      .subscribeStream(
+        daemonId,
+        overrides,
+        codec,
+        maxFps,
+        onUnavailable = onUnavailable,
+        onFrame = onFrame,
+      )
   }
 
   override fun activeStreamCount(): Int = live.activeStreamCount() + perPreviewStreamCount()

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHost.kt
@@ -128,12 +128,20 @@ interface ServeHost : AutoCloseable {
   /**
    * Join the shared live stream for [previewId], or `null` when this host has no live lane (the
    * snapshot fallback is used instead — always the case for [ServeBundleHost]).
+   *
+   * [onUnavailable] is invoked (once, before the `null` return) with a short human-readable reason
+   * when the live lane can't be opened — the daemon's original failure (e.g. `interactive session
+   * already held`, `previewSpecResolver returned null`, a `stream/start` timeout) or "no live
+   * daemon twin for this variant". The caller surfaces it so the viewer shows *why* it fell back to
+   * re-rendered snapshots instead of the opaque "input requires a live stream". Not called on
+   * success (a non-null return).
    */
   fun subscribeStream(
     previewId: String,
     overrides: PreviewOverrides,
     codec: StreamCodec?,
     maxFps: Int?,
+    onUnavailable: ((String) -> Unit)? = null,
     onFrame: (StreamFrameParams) -> Unit,
   ): StreamHandle?
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -898,10 +898,22 @@ class ServeHttpServer(
           }
         val maxFps = call.request.queryParameters["maxFps"]?.toIntOrNull()?.takeIf { it > 0 }
         // Prefer the daemon's live stream lane (frames pushed, input dispatched); fall back to the
-        // snapshot re-render lane when the backend doesn't support streaming.
+        // snapshot re-render lane when the backend doesn't support streaming. Capture the live
+        // lane's original failure so the snapshot session can explain why input isn't live. The
+        // callback fires synchronously inside tryStart (before it returns), so a plain var is safe.
+        var liveUnavailableReason: String? = null
         val live =
           withContext(Dispatchers.IO) {
-            ServeLiveSession.tryStart(renderHost, previewId, initialOverrides, codec, maxFps, send)
+            ServeLiveSession.tryStart(
+              renderHost,
+              previewId,
+              initialOverrides,
+              codec,
+              maxFps,
+              send,
+            ) { reason ->
+              if (liveUnavailableReason == null) liveUnavailableReason = reason
+            }
           }
         if (live != null) {
           try {
@@ -915,7 +927,14 @@ class ServeHttpServer(
             withContext(Dispatchers.IO) { live.close() }
           }
         } else {
-          val session = ServeStreamSession(renderHost, previewId, initialOverrides, send)
+          val session =
+            ServeStreamSession(
+              renderHost,
+              previewId,
+              initialOverrides,
+              send,
+              liveUnavailableReason = liveUnavailableReason,
+            )
           // Renders block (renderNow + await); keep them off the socket's event-loop thread.
           withContext(Dispatchers.IO) { session.onOpen() }
           for (frame in incoming) {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeLiveSession.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeLiveSession.kt
@@ -72,7 +72,7 @@ private constructor(
   private fun restart(parsed: PreviewOverrides) {
     handle?.close()
     handle =
-      renderHost.subscribeStream(previewId, parsed, codec, maxFps, ::onFrame)
+      renderHost.subscribeStream(previewId, parsed, codec, maxFps, onFrame = ::onFrame)
         ?: run {
           send(ServeStreamProtocol.errorMessage("live stream ended"))
           null
@@ -95,7 +95,8 @@ private constructor(
         }
         is OverrideParse.Ok -> p.overrides
       }
-    val next = renderHost.subscribeStream(message.previewId, parsed, codec, maxFps, ::onFrame)
+    val next =
+      renderHost.subscribeStream(message.previewId, parsed, codec, maxFps, onFrame = ::onFrame)
     if (next == null) {
       send(ServeStreamProtocol.errorMessage("cannot switch to preview: ${message.previewId}"))
       return
@@ -145,6 +146,7 @@ private constructor(
       codec: StreamCodec? = null,
       maxFps: Int? = null,
       send: (String) -> Unit,
+      onUnavailable: ((String) -> Unit)? = null,
     ): ServeLiveSession? {
       val knobKinds =
         ServeOverrides.declaredKnobKinds(renderHost.previews.firstOrNull { it.id == previewId })
@@ -153,8 +155,14 @@ private constructor(
           ?: PreviewOverrides()
       val session = ServeLiveSession(renderHost, previewId, overrides, codec, maxFps, send)
       session.handle =
-        renderHost.subscribeStream(previewId, initial, codec, maxFps, session::onFrame)
-          ?: return null
+        renderHost.subscribeStream(
+          previewId,
+          initial,
+          codec,
+          maxFps,
+          onUnavailable = onUnavailable,
+          onFrame = session::onFrame,
+        ) ?: return null
       return session
     }
   }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServePerPreviewLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServePerPreviewLiveHost.kt
@@ -146,10 +146,29 @@ class ServePerPreviewLiveHost(
     overrides: PreviewOverrides,
     codec: StreamCodec?,
     maxFps: Int?,
+    onUnavailable: ((String) -> Unit)?,
     onFrame: (StreamFrameParams) -> Unit,
   ): StreamHandle? {
-    val daemonId = alias[previewId] ?: return null
-    return resolveLive(daemonId)?.subscribeStream(daemonId, overrides, codec, maxFps, onFrame)
+    val daemonId =
+      alias[previewId]
+        ?: run {
+          onUnavailable?.invoke("no live daemon twin for '$previewId' (baked snapshot only)")
+          return null
+        }
+    val live =
+      resolveLive(daemonId)
+        ?: run {
+          onUnavailable?.invoke("live daemon for '$previewId' could not be resolved")
+          return null
+        }
+    return live.subscribeStream(
+      daemonId,
+      overrides,
+      codec,
+      maxFps,
+      onUnavailable = onUnavailable,
+      onFrame = onFrame,
+    )
   }
 
   override fun activeStreamCount(): Int = streamCount()

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
@@ -634,10 +634,14 @@ internal constructor(
     overrides: PreviewOverrides,
     codec: StreamCodec? = null,
     maxFps: Int? = null,
+    onUnavailable: ((String) -> Unit)? = null,
     onFrame: (StreamFrameParams) -> Unit,
   ): StreamHandle? {
     check(!closed.get()) { "ServeRenderHost is closed" }
-    if (previewId !in previewIds) return null
+    if (previewId !in previewIds) {
+      onUnavailable?.invoke("daemon has no preview '$previewId'")
+      return null
+    }
 
     // Register the listener BEFORE stream/start: the daemon's frame loop can emit the initial
     // keyframe before the RPC response returns, and missing it leaves static previews blank (later
@@ -678,7 +682,14 @@ internal constructor(
         )
       } catch (e: Exception) {
         // UnsupportedOperationException (no streaming on this backend) or a daemon error — degrade.
-        onLog("stream/start unavailable for $previewId (${e.message}); falling back to snapshots")
+        // The exception message IS the daemon's original failure (e.g. "interactive session already
+        // held", "previewSpecResolver returned null for previewId=…", a 30s interactive-start
+        // timeout) — carry it to the viewer via [onUnavailable] rather than only logging it, so the
+        // client can show why input isn't live instead of the opaque "input requires a live
+        // stream".
+        val reason = e.message?.takeIf { it.isNotBlank() } ?: e.javaClass.simpleName
+        onLog("stream/start unavailable for $previewId ($reason); falling back to snapshots")
+        onUnavailable?.invoke(reason)
         runCatching { listener.close() }
         return null
       }
@@ -687,6 +698,7 @@ internal constructor(
       // The daemon accepted stream/start but couldn't hold an interactive session, so it won't run
       // the live frame loop — fall back to the snapshot lane rather than open a frameless stream.
       onLog("stream/start for $previewId has no held session; falling back to snapshots")
+      onUnavailable?.invoke("the daemon could not hold an interactive session for this preview")
       runCatching { listener.close() }
       runCatching { session.streamStop(result.frameStreamId) }
       return null
@@ -747,10 +759,18 @@ internal constructor(
     overrides: PreviewOverrides,
     codec: StreamCodec?,
     maxFps: Int?,
+    onUnavailable: ((String) -> Unit)?,
     onFrame: (StreamFrameParams) -> Unit,
   ): StreamHandle? {
     check(!closed.get()) { "ServeRenderHost is closed" }
-    return broadcast.subscribe(previewId, overrides, codec, maxFps, onFrame)
+    return broadcast.subscribe(
+      previewId,
+      overrides,
+      codec,
+      maxFps,
+      onUnavailable = onUnavailable,
+      onFrame = onFrame,
+    )
   }
 
   /** Live shared upstream streams (one per distinct preview/overrides/codec/fps). Diagnostics. */

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
@@ -697,8 +697,14 @@ internal constructor(
     if (!result.heldSession) {
       // The daemon accepted stream/start but couldn't hold an interactive session, so it won't run
       // the live frame loop — fall back to the snapshot lane rather than open a frameless stream.
-      onLog("stream/start for $previewId has no held session; falling back to snapshots")
-      onUnavailable?.invoke("the daemon could not hold an interactive session for this preview")
+      // The daemon records the actual acquisition failure in `fallbackReason` (e.g.
+      // `UnsupportedOperationException: interactive session already held`); prefer it so the viewer
+      // shows the real cause, and use the generic text only when the daemon sent none.
+      val reason =
+        result.fallbackReason?.takeIf { it.isNotBlank() }
+          ?: "the daemon could not hold an interactive session for this preview"
+      onLog("stream/start for $previewId has no held session ($reason); falling back to snapshots")
+      onUnavailable?.invoke(reason)
       runCatching { listener.close() }
       runCatching { session.streamStop(result.frameStreamId) }
       return null

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeStreamSession.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeStreamSession.kt
@@ -22,6 +22,15 @@ class ServeStreamSession(
   previewId: String,
   initialOverrides: Map<String, String> = emptyMap(),
   private val send: (String) -> Unit,
+  /**
+   * Why this connection is on the snapshot-fallback lane rather than the live daemon stream — the
+   * daemon's original failure captured by [ServeLiveSession.tryStart]'s `onUnavailable` (e.g.
+   * `interactive session already held`, a `stream/start` timeout, or "no live daemon twin"). Folded
+   * into the input-rejection message so a click reports *why* input isn't live instead of the
+   * opaque "input requires a live stream". Null when the reason is unknown (e.g. a backend that
+   * returned null without one).
+   */
+  private val liveUnavailableReason: String? = null,
 ) {
   private var previewId: String = previewId
   private var overrides: Map<String, String> = initialOverrides
@@ -47,8 +56,9 @@ class ServeStreamSession(
       is ServeStreamProtocol.ClientMessage.Switch -> switchTo(message)
       is ServeStreamProtocol.ClientMessage.Input ->
         // The snapshot fallback can't dispatch input into a live composition — only the daemon
-        // stream lane ([ServeLiveSession]) can. Report it rather than silently dropping.
-        send(ServeStreamProtocol.errorMessage("input requires a live stream"))
+        // stream lane ([ServeLiveSession]) can. Report it — with the original reason the live lane
+        // was unavailable when known — rather than silently dropping or showing a bare message.
+        send(ServeStreamProtocol.errorMessage(inputUnavailableMessage()))
       is ServeStreamProtocol.ClientMessage.Unsupported ->
         send(ServeStreamProtocol.errorMessage(message.reason))
     }
@@ -85,6 +95,16 @@ class ServeStreamSession(
    */
   private fun knobKindsFor(id: String): Map<String, String> =
     ServeOverrides.declaredKnobKinds(renderHost.previews.firstOrNull { it.id == id })
+
+  /**
+   * The message for an [input][ServeStreamProtocol.ClientMessage.Input] the snapshot lane can't
+   * dispatch. When the live lane's original failure was captured, surface it so the user sees *why*
+   * (e.g. "…: the daemon could not hold an interactive session for this preview") instead of a bare
+   * "input requires a live stream".
+   */
+  private fun inputUnavailableMessage(): String =
+    if (liveUnavailableReason.isNullOrBlank()) "input requires a live stream"
+    else "input requires a live stream — unavailable: $liveUnavailableReason"
 
   private fun renderCurrent() {
     when (val parsed = ServeOverrides.parse(overrides, knobKindsFor(previewId))) {

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/FakeRenderSession.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/FakeRenderSession.kt
@@ -66,6 +66,11 @@ internal class FakeRenderSession(
    * `StreamStartResult.heldSession` value when [streaming]; false models a non-interactive host.
    */
   private val heldSession: Boolean = true,
+  /**
+   * `StreamStartResult.fallbackReason` — the daemon's real acquisition failure when [heldSession]
+   * is false (e.g. `interactive session already held`). Null models a daemon that sent none.
+   */
+  private val heldFallbackReason: String? = null,
   /** When set, [streamStart] emits a keyframe with this base64 payload *before* it returns. */
   private val emitKeyframeOnStart: String? = null,
   /**
@@ -400,6 +405,7 @@ internal class FakeRenderSession(
       frameStreamId = fsid,
       codec = codec ?: StreamCodec.PNG,
       heldSession = heldSession,
+      fallbackReason = heldFallbackReason,
     )
   }
 

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBroadcastHubTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBroadcastHubTest.kt
@@ -62,9 +62,13 @@ class ServeBroadcastHubTest {
       overrides: PreviewOverrides,
       codec: StreamCodec?,
       maxFps: Int?,
+      onUnavailable: ((String) -> Unit)?,
       onFrame: (StreamFrameParams) -> Unit,
     ): StreamHandle? {
-      if (!streamable) return null
+      if (!streamable) {
+        onUnavailable?.invoke("fake opener: not streamable")
+        return null
+      }
       val up = FakeUpstream()
       up.emit = onFrame
       opens.add(up)
@@ -157,6 +161,14 @@ class ServeBroadcastHubTest {
     val hub = ServeBroadcastHub(FakeOpener(streamable = false))
     assertNull(hub.subscribe("p", PreviewOverrides()) {})
     assertEquals(0, hub.activeStreamCount())
+  }
+
+  @Test
+  fun `subscribe forwards the opener's unavailable reason`() {
+    val hub = ServeBroadcastHub(FakeOpener(streamable = false))
+    var reason: String? = null
+    assertNull(hub.subscribe("p", PreviewOverrides(), onUnavailable = { reason = it }) {})
+    assertEquals("fake opener: not streamable", reason)
   }
 
   @Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
@@ -61,6 +61,7 @@ class ServeCatalogLiveHostTest {
       overrides: PreviewOverrides,
       codec: StreamCodec?,
       maxFps: Int?,
+      onUnavailable: ((String) -> Unit)?,
       onFrame: (StreamFrameParams) -> Unit,
     ): StreamHandle? {
       lastStreamId = previewId

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeLiveSessionTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeLiveSessionTest.kt
@@ -30,7 +30,49 @@ class ServeLiveSessionTest {
   @Test
   fun `tryStart returns null when streaming is unsupported`() {
     val session = FakeRenderSession(newRenderRoot()) // streaming = false
-    host(session).use { h -> assertNull(ServeLiveSession.tryStart(h, previewId, emptyMap()) {}) }
+    host(session).use { h ->
+      assertNull(ServeLiveSession.tryStart(h, previewId, emptyMap(), send = {}))
+    }
+  }
+
+  @Test
+  fun `tryStart forwards the daemon's original failure to onUnavailable`() {
+    val session = FakeRenderSession(newRenderRoot()) // streaming = false → streamStart throws
+    host(session).use { h ->
+      var reason: String? = null
+      assertNull(
+        ServeLiveSession.tryStart(
+          h,
+          previewId,
+          emptyMap(),
+          send = {},
+          onUnavailable = { reason = it },
+        )
+      )
+      // The daemon's own exception message is carried through, not swallowed into a log.
+      assertEquals("streaming not supported", reason)
+    }
+  }
+
+  @Test
+  fun `tryStart forwards a no-held-session reason to onUnavailable`() {
+    val session = FakeRenderSession(newRenderRoot(), streaming = true, heldSession = false)
+    host(session).use { h ->
+      var reason: String? = null
+      assertNull(
+        ServeLiveSession.tryStart(
+          h,
+          previewId,
+          emptyMap(),
+          send = {},
+          onUnavailable = { reason = it },
+        )
+      )
+      assertTrue(
+        reason?.contains("could not hold an interactive session") == true,
+        "expected a held-session reason, got: $reason",
+      )
+    }
   }
 
   @Test
@@ -91,7 +133,7 @@ class ServeLiveSessionTest {
   fun `input messages dispatch interactive input`() {
     val session = FakeRenderSession(newRenderRoot(), streaming = true)
     host(session).use { h ->
-      val live = assertNotNull(ServeLiveSession.tryStart(h, previewId, emptyMap()) {})
+      val live = assertNotNull(ServeLiveSession.tryStart(h, previewId, emptyMap(), send = {}))
       live.onClientMessage("""{"type":"input","kind":"click","pixelX":10,"pixelY":20}""")
       assertEquals(1, session.interactiveInputs.size)
       val input = session.interactiveInputs[0]
@@ -105,7 +147,7 @@ class ServeLiveSessionTest {
   fun `pointer drag, scroll and key inputs are forwarded with their fields`() {
     val session = FakeRenderSession(newRenderRoot(), streaming = true)
     host(session).use { h ->
-      val live = assertNotNull(ServeLiveSession.tryStart(h, previewId, emptyMap()) {})
+      val live = assertNotNull(ServeLiveSession.tryStart(h, previewId, emptyMap(), send = {}))
       live.onClientMessage(
         """{"type":"input","kind":"pointerDown","pixelX":3,"pixelY":4,"pointerId":1}"""
       )
@@ -152,7 +194,7 @@ class ServeLiveSessionTest {
   fun `setOverrides restarts the held stream`() {
     val session = FakeRenderSession(newRenderRoot(), streaming = true)
     host(session).use { h ->
-      val live = assertNotNull(ServeLiveSession.tryStart(h, previewId, emptyMap()) {})
+      val live = assertNotNull(ServeLiveSession.tryStart(h, previewId, emptyMap(), send = {}))
       val first = assertNotNull(session.lastFrameStreamId)
       assertEquals(1, session.streamStarts.get())
 
@@ -196,7 +238,7 @@ class ServeLiveSessionTest {
         renderTimeoutSeconds = 30,
       )
       .use { h ->
-        val live = assertNotNull(ServeLiveSession.tryStart(h, previewId, emptyMap()) {})
+        val live = assertNotNull(ServeLiveSession.tryStart(h, previewId, emptyMap(), send = {}))
         val firstFsid = assertNotNull(session.lastFrameStreamId)
         assertEquals(1, session.streamStarts.get())
 
@@ -234,7 +276,7 @@ class ServeLiveSessionTest {
   fun `closing the live session stops the stream`() {
     val session = FakeRenderSession(newRenderRoot(), streaming = true)
     host(session).use { h ->
-      val live = assertNotNull(ServeLiveSession.tryStart(h, previewId, emptyMap()) {})
+      val live = assertNotNull(ServeLiveSession.tryStart(h, previewId, emptyMap(), send = {}))
       val fsid = assertNotNull(session.lastFrameStreamId)
       live.close()
       assertEquals(listOf(fsid), session.streamStops)

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeLiveSessionTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeLiveSessionTest.kt
@@ -55,7 +55,7 @@ class ServeLiveSessionTest {
   }
 
   @Test
-  fun `tryStart forwards a no-held-session reason to onUnavailable`() {
+  fun `tryStart forwards the generic no-held-session reason when the daemon sent none`() {
     val session = FakeRenderSession(newRenderRoot(), streaming = true, heldSession = false)
     host(session).use { h ->
       var reason: String? = null
@@ -70,8 +70,34 @@ class ServeLiveSessionTest {
       )
       assertTrue(
         reason?.contains("could not hold an interactive session") == true,
-        "expected a held-session reason, got: $reason",
+        "expected the generic held-session reason, got: $reason",
       )
+    }
+  }
+
+  @Test
+  fun `tryStart prefers the daemon's fallbackReason for a non-held session`() {
+    // The daemon accepted stream/start but couldn't hold the session AND told us why — surface it
+    // rather than the generic text (Codex #2515 review).
+    val session =
+      FakeRenderSession(
+        newRenderRoot(),
+        streaming = true,
+        heldSession = false,
+        heldFallbackReason = "UnsupportedOperationException: interactive session already held",
+      )
+    host(session).use { h ->
+      var reason: String? = null
+      assertNull(
+        ServeLiveSession.tryStart(
+          h,
+          previewId,
+          emptyMap(),
+          send = {},
+          onUnavailable = { reason = it },
+        )
+      )
+      assertEquals("UnsupportedOperationException: interactive session already held", reason)
     }
   }
 

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServePerPreviewDaemonPoolTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServePerPreviewDaemonPoolTest.kt
@@ -29,6 +29,7 @@ class ServePerPreviewDaemonPoolTest {
       overrides: PreviewOverrides,
       codec: StreamCodec?,
       maxFps: Int?,
+      onUnavailable: ((String) -> Unit)?,
       onFrame: (StreamFrameParams) -> Unit,
     ): StreamHandle? = null
 

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServePerPreviewLiveHostTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServePerPreviewLiveHostTest.kt
@@ -54,6 +54,7 @@ class ServePerPreviewLiveHostTest {
       overrides: PreviewOverrides,
       codec: StreamCodec?,
       maxFps: Int?,
+      onUnavailable: ((String) -> Unit)?,
       onFrame: (StreamFrameParams) -> Unit,
     ): StreamHandle? {
       lastStreamId = previewId

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistryTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistryTest.kt
@@ -155,6 +155,7 @@ class ServeSessionRegistryTest {
       overrides: PreviewOverrides,
       codec: ee.schimke.composeai.daemon.protocol.StreamCodec?,
       maxFps: Int?,
+      onUnavailable: ((String) -> Unit)?,
       onFrame: (ee.schimke.composeai.daemon.protocol.StreamFrameParams) -> Unit,
     ): StreamHandle? = null
 

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeStreamSessionTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeStreamSessionTest.kt
@@ -27,6 +27,9 @@ class ServeStreamSessionTest {
   private fun typeOf(text: String): String =
     Json.parseToJsonElement(text).jsonObject.getValue("type").jsonPrimitive.content
 
+  private fun messageOf(text: String): String =
+    Json.parseToJsonElement(text).jsonObject.getValue("message").jsonPrimitive.content
+
   private fun frameBytes(text: String): ByteArray =
     Base64.getDecoder()
       .decode(Json.parseToJsonElement(text).jsonObject.getValue("dataBase64").jsonPrimitive.content)
@@ -131,6 +134,41 @@ class ServeStreamSessionTest {
       // The bad override must not poison the session — the previous view still renders.
       session.onClientMessage("""{"type":"requestFrame"}""")
       assertEquals("frame", typeOf(sent.last()))
+    }
+  }
+
+  @Test
+  fun `input on the snapshot lane reports the original live-lane failure when known`() {
+    host().use { h ->
+      val sent = CopyOnWriteArrayList<String>()
+      val session =
+        ServeStreamSession(
+          h,
+          previewId,
+          emptyMap(),
+          sent::add,
+          liveUnavailableReason =
+            "the daemon could not hold an interactive session for this preview",
+        )
+      session.onClientMessage("""{"type":"input","kind":"click","pixelX":1,"pixelY":1}""")
+      assertEquals("error", typeOf(sent.single()))
+      val message = messageOf(sent.single())
+      assertTrue(message.contains("input requires a live stream"), "keeps the base explanation")
+      assertTrue(
+        message.contains("the daemon could not hold an interactive session"),
+        "surfaces the original live-lane failure instead of the opaque message: $message",
+      )
+    }
+  }
+
+  @Test
+  fun `input on the snapshot lane falls back to the bare message when no reason is known`() {
+    host().use { h ->
+      val sent = CopyOnWriteArrayList<String>()
+      // No liveUnavailableReason (e.g. a backend that returned null without one).
+      val session = ServeStreamSession(h, previewId, emptyMap(), sent::add)
+      session.onClientMessage("""{"type":"input","kind":"click","pixelX":1,"pixelY":1}""")
+      assertEquals("input requires a live stream", messageOf(sent.single()))
     }
   }
 


### PR DESCRIPTION
## Summary

When a **Live Compose** WebSocket can't open the daemon's interactive held session it silently falls back to the snapshot lane, and a click was answered with the opaque **`input requires a live stream`** — the real cause (the daemon's own exception) was only written to the server log, so the viewer couldn't show *why* it wasn't interactive. This is the follow-up the Wear M3 "input requires a live stream" symptom needed.

Now the live lane's **original failure** is threaded to the client:

- Add an optional `onUnavailable: ((String) -> Unit)?` reason callback down the stream path — `ServeHost.subscribeStream` → `ServeBroadcastHub` → `ServeRenderHost.startStream`, plus the two trusted-catalog composite hosts (`ServeCatalogLiveHost` / `ServePerPreviewLiveHost`).
- `startStream` reports the daemon's own `stream/start` exception message (e.g. `interactive session already held`, `previewSpecResolver returned null for previewId=…`, a 30s interactive-start timeout), or a no-held-session / no-daemon-twin reason.
- `ServeLiveSession.tryStart` forwards it; the WebSocket handler captures it and hands it to the snapshot `ServeStreamSession`, which folds it into the input rejection: **`input requires a live stream — unavailable: <reason>`**. Falls back to the bare message when no reason was captured.

`onUnavailable` is placed **before** the trailing `onFrame` lambda in every signature, so all existing trailing-lambda callers compile unchanged.

## Test plan

- [x] `./gradlew :cli:test --tests '*Serve*'` — green.
- [x] New tests: `ServeStreamSessionTest` (reason surfaced in the input error; bare fallback when unknown), `ServeLiveSessionTest` (`tryStart` forwards the daemon's exception message and the no-held-session reason), `ServeBroadcastHubTest` (`subscribe` forwards the opener's reason).
- [x] `ktfmtFormat` on the touched module.

Text-only change (WebSocket protocol message wording + plumbing) — no rendered/visual surface, so no preview evidence applies.

## Context

Follow-up to #2511 (which fixed the Live-mode axis controls). That change made Locale/Device/etc. usable over both lanes; this one makes the *fallback itself* self-explanatory, so when the interactive lane can't come up on a box the viewer says why (the exact `preview-test.coo.ee` diagnosis path). Opened on a new branch because the previous `agent/wear-m3-live-preview-x49oo2` branch already carries the merged #2511 history.

---
_Generated by [Claude Code](https://claude.ai/code/session_01W2hVUK8JYkwaEGpU4sXBod)_