### PR TITLE
feat(mcp): Storybook-compatible MCP profile (--storybook)

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -317,12 +317,17 @@ mcp/
         └── RealMcpEndToEndTest.kt     # opt-in real-daemon JUnit (use -Pmcp.real=true)
 ```
 
-## Storybook-compatible tools
+## Storybook-compatible profile
 
-The server also exposes a handful of aliases named after Storybook's official MCP server (GA in
-Storybook 10.3), so an agent harness that has learned the Storybook-MCP vocabulary drives this server
-unmodified. They address a preview by a **story id** (minted CSF-style, `title--name`) instead of a
-`compose-preview://` URI, and route to the native handlers via the `StorybookMcp` adapter (a raw
+Run with **`--storybook`** (or `-Dcomposeai.mcp.profile=storybook`) to present a surface named after
+Storybook's official MCP server (GA in Storybook 10.3), so an agent harness that has learned the
+Storybook-MCP vocabulary drives compose-preview unmodified. In this profile the server identifies as
+`compose-preview-storybook` and exposes **only** the Storybook tools below — the native tools are
+hidden, so there's no overlapping/duplicate surface (e.g. `render_preview` *and* `preview-stories`)
+to confuse tool routing. The default profile is the full native tool set.
+
+The tools address a preview by a **story id** (minted CSF-style, `title--name`) instead of a
+`compose-preview://` URI, and route to the same native handlers via the `StorybookMcp` adapter (a raw
 native URI is still accepted):
 
 | Storybook tool | Maps to | Returns |
@@ -330,7 +335,15 @@ native URI is still accepted):
 | `list-all-documentation` | the resource catalog | every preview as a Storybook story (`id`, `title`, `name`, `importPath`, native `uri`) |
 | `get-documentation-for-story` | catalog lookup | one story's metadata + native `uri`/coords |
 | `preview-stories` | `render_preview` | the rendered image(s); `observe` + `overrides` pass through |
-| `run-story-tests` | `enable_extensions(a11y)` + `get_preview_data(a11y/atf)` | the accessibility (ATF) findings |
+| `run-story-tests` | `record_preview` scripted assertions | test results — the compose analogue of Storybook's play + expect |
+
+**`run-story-tests`** is a façade over our scripted-recording assertions (`record_preview`): pass a
+`script` — a timeline of `input.*` events to drive the UI and `assert.visible` / `assert.notVisible`
+/ `assert.textEquals` / `assert.a11y` / `assert.pixels` events to check it — and each assertion is
+recorded APPLIED/FAILED. With no script it runs an accessibility smoke (`preview.reload` +
+`assert.a11y`). `emitTest` also returns a generated Compose UI test. Assertion coverage is
+backend-dependent (desktop vs Android — tracked in
+[issue #2519](https://github.com/yschimke/compose-ai-tools/issues/2519)).
 
 Deferred for now: `get-changed-stories` (composable from `history_list`/`history_diff`) and
 `get-storybook-story-instructions`.

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -317,6 +317,24 @@ mcp/
         └── RealMcpEndToEndTest.kt     # opt-in real-daemon JUnit (use -Pmcp.real=true)
 ```
 
+## Storybook-compatible tools
+
+The server also exposes a handful of aliases named after Storybook's official MCP server (GA in
+Storybook 10.3), so an agent harness that has learned the Storybook-MCP vocabulary drives this server
+unmodified. They address a preview by a **story id** (minted CSF-style, `title--name`) instead of a
+`compose-preview://` URI, and route to the native handlers via the `StorybookMcp` adapter (a raw
+native URI is still accepted):
+
+| Storybook tool | Maps to | Returns |
+|---|---|---|
+| `list-all-documentation` | the resource catalog | every preview as a Storybook story (`id`, `title`, `name`, `importPath`, native `uri`) |
+| `get-documentation-for-story` | catalog lookup | one story's metadata + native `uri`/coords |
+| `preview-stories` | `render_preview` | the rendered image(s); `observe` + `overrides` pass through |
+| `run-story-tests` | `enable_extensions(a11y)` + `get_preview_data(a11y/atf)` | the accessibility (ATF) findings |
+
+Deferred for now: `get-changed-stories` (composable from `history_list`/`history_diff`) and
+`get-storybook-story-instructions`.
+
 ## See also
 
 - [`docs/daemon/MCP.md`](../docs/daemon/MCP.md) — protocol-level design

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpMain.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpMain.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.mcp
 
+import io.modelcontextprotocol.kotlin.sdk.types.Implementation
 import java.io.File
 import java.util.concurrent.TimeUnit
 import kotlinx.serialization.json.JsonObject
@@ -13,7 +14,14 @@ import kotlinx.serialization.json.JsonObject
  * ```
  * compose-preview-mcp [--project <path>[:<rootProjectName>]]...
  *                     [--replicas-per-daemon <N>]
+ *                     [--storybook]
  * ```
+ *
+ * `--storybook` (or `-Dcomposeai.mcp.profile=storybook`) runs the **Storybook-compatibility
+ * profile**: the server exposes only the Storybook-MCP tools (`list-all-documentation`,
+ * `get-documentation-for-story`, `preview-stories`, `run-story-tests`) with the native tools
+ * hidden, and identifies as `compose-preview-storybook`. Point a Storybook-MCP-trained agent at
+ * this to drive compose-preview unmodified. Omit it for the full native tool set (the default).
  *
  * Each `--project` flag pre-registers a workspace with the supervisor at startup so connecting
  * clients see the project in `list_projects` immediately. Projects can also be added at runtime via
@@ -41,7 +49,19 @@ object DaemonMcpMain {
         clientFactory = SubprocessDaemonClientFactory(),
         replicasPerDaemon = replicasPerDaemon,
       )
-    val server = DaemonMcpServer(supervisor)
+    val server =
+      if (parseStorybookProfile(args)) {
+        // Storybook-compat face: present ONLY the Storybook-MCP tools (native tools hidden) and
+        // identify as `compose-preview-storybook`, so a Storybook-MCP-trained agent sees a clean
+        // Storybook surface. Same daemon core + handlers underneath.
+        DaemonMcpServer(
+          supervisor,
+          serverInfo = Implementation(name = "compose-preview-storybook", version = "v0"),
+          profile = McpToolProfile.STORYBOOK,
+        )
+      } else {
+        DaemonMcpServer(supervisor)
+      }
 
     parseProjects(args).forEach { (path, name) ->
       runCatching { supervisor.registerProject(File(path), name) }
@@ -93,6 +113,17 @@ object DaemonMcpMain {
       }
     }
     return out
+  }
+
+  /**
+   * True when the server should run the Storybook-compatibility profile — either the `--storybook`
+   * flag or the `composeai.mcp.profile=storybook` system property. In that profile only the
+   * Storybook-MCP tools are exposed (native tools hidden). See [McpToolProfile].
+   */
+  private fun parseStorybookProfile(args: Array<String>): Boolean {
+    if (args.any { it == "--storybook" }) return true
+    return System.getProperty("composeai.mcp.profile")?.equals("storybook", ignoreCase = true) ==
+      true
   }
 
   private fun splitProjectArg(raw: String): Pair<String, String?> {

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
@@ -54,6 +54,7 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonObjectBuilder
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.decodeFromJsonElement
@@ -64,6 +65,33 @@ import kotlinx.serialization.json.putJsonArray
 import kotlinx.serialization.json.putJsonObject
 import okio.FileSystem
 import okio.Path.Companion.toPath
+
+/**
+ * Which tool surface a [DaemonMcpServer] presents. [NATIVE] is the full compose-preview tool set;
+ * [STORYBOOK] is the Storybook-MCP-compatible subset only (native tools hidden), so a
+ * Storybook-MCP-trained agent sees a clean Storybook surface with no overlapping/duplicate tools.
+ */
+enum class McpToolProfile {
+  NATIVE,
+  STORYBOOK,
+}
+
+/**
+ * The Storybook alias tool names (excludes `status`, which both profiles expose). Used to filter
+ * the two profiles apart from the single `buildFullToolDefs` source so no `ToolDef` literal is
+ * duplicated: NATIVE serves everything except these; STORYBOOK serves only these + `status`.
+ *
+ * Top-level (not an instance `val`) on purpose: the async full-tool-catalog loader reads it off the
+ * `toolCatalogExecutor` thread during construction, before instance properties declared later would
+ * have initialized — a top-level val is class-load-time, so there's no init-order race.
+ */
+private val STORYBOOK_ALIAS_NAMES =
+  setOf(
+    "list-all-documentation",
+    "get-documentation-for-story",
+    "preview-stories",
+    "run-story-tests",
+  )
 
 /**
  * The load-bearing wiring layer. Owns:
@@ -110,10 +138,18 @@ class DaemonMcpServer(
   private val samplingIntervalMs: Long = DEFAULT_SAMPLING_INTERVAL_MS,
   private val fileSystem: FileSystem = SystemFileSystem,
   fullToolDefsLoader: (() -> List<ToolDef>)? = null,
+  /**
+   * Which tool surface this server presents. [McpToolProfile.NATIVE] (default) exposes the full
+   * compose-preview tool set. [McpToolProfile.STORYBOOK] exposes ONLY the Storybook-compatible
+   * tools ([storybookToolDefs]) with the native tools hidden, so a Storybook-MCP-trained agent sees
+   * a clean Storybook surface without the overlapping/duplicate native tools (e.g. `render_preview`
+   * alongside `preview-stories`). Both profiles route through the same handlers.
+   */
+  private val profile: McpToolProfile = McpToolProfile.NATIVE,
 ) {
 
   private val fullToolDefsLoader: () -> List<ToolDef> =
-    fullToolDefsLoader ?: { buildFullToolDefs() }
+    fullToolDefsLoader ?: { effectiveFullToolDefs() }
 
   private val json = Json {
     ignoreUnknownKeys = true
@@ -942,7 +978,26 @@ class DaemonMcpServer(
     }
   }
 
+  /** Tools served in the [McpToolProfile.STORYBOOK] profile: the aliases plus `status`. */
+  private fun storybookToolDefs(): List<ToolDef> =
+    buildFullToolDefs().filter { it.name == "status" || it.name in STORYBOOK_ALIAS_NAMES }
+
+  /** The full tool list for the active [profile] — native-only, or Storybook-only. */
+  private fun effectiveFullToolDefs(): List<ToolDef> =
+    when (profile) {
+      McpToolProfile.NATIVE -> buildFullToolDefs().filterNot { it.name in STORYBOOK_ALIAS_NAMES }
+      McpToolProfile.STORYBOOK -> storybookToolDefs()
+    }
+
+  /** Bootstrap tools served before the full catalog loads, for the active [profile]. */
   private val bootstrapToolDefs: List<ToolDef> by lazy {
+    when (profile) {
+      McpToolProfile.NATIVE -> nativeBootstrapToolDefs
+      McpToolProfile.STORYBOOK -> storybookToolDefs()
+    }
+  }
+
+  private val nativeBootstrapToolDefs: List<ToolDef> by lazy {
     listOf(
       ToolDef(
         name = "status",
@@ -1843,15 +1898,19 @@ class DaemonMcpServer(
       ToolDef(
         name = "run-story-tests",
         description =
-          "Storybook-compatible: run the accessibility checks for a story and return structured " +
-            "results. Enables the `a11y` extension on the owning daemon, renders, and returns the " +
-            "Accessibility Test Framework (ATF) findings (`a11y/atf`) — the compose analogue of " +
-            "Storybook's `run-story-tests` accessibility pass. Accepts a story id from " +
-            "`list-all-documentation` (or a raw compose-preview URI) as `storyId`/`id`.",
+          "Storybook-compatible: run a story's tests and return structured results. Maps to our " +
+            "scripted-recording assertions (record_preview) — the compose analogue of Storybook's " +
+            "play-function + expect. Pass a `script`: a record_preview event timeline where " +
+            "`input.*` events drive the UI and `assert.visible`/`assert.notVisible`/" +
+            "`assert.textEquals`/`assert.a11y`/`assert.pixels` events check it (each records " +
+            "APPLIED/FAILED). With NO script it runs an accessibility smoke (`preview.reload` + " +
+            "`assert.a11y`). Set `emitTest` to also get a generated Compose UI test. Assertion " +
+            "support is backend-dependent (desktop vs Android — see issue #2519). Accepts a story " +
+            "id from `list-all-documentation` (or a raw compose-preview URI) as `storyId`/`id`.",
         inputSchema =
           parseSchema(
             """
-            {"type":"object","properties":{"storyId":{"type":"string","description":"Story id from list-all-documentation, or a raw compose-preview:// URI."},"id":{"type":"string","description":"Alias for storyId."}}}
+            {"type":"object","properties":{"storyId":{"type":"string","description":"Story id from list-all-documentation, or a raw compose-preview:// URI."},"id":{"type":"string","description":"Alias for storyId."},"script":{"type":"array","description":"Optional record_preview event timeline (input.* to drive, assert.* to check). Omit to run an accessibility smoke test.","items":{"type":"object"}},"emitTest":{"type":"boolean","description":"Also return a runnable Compose UI test generated from the interaction."},"observe":{"type":"string","enum":["frames","media"],"description":"record_preview observation level; default 'frames' (structured per-frame + per-assertion evidence, no inline media)."},"format":{"type":"string","enum":["apng","gif","mp4","webm"],"description":"Recording format for the artifact; default 'apng'."}}}
             """
               .trimIndent()
           ),
@@ -2002,30 +2061,38 @@ class DaemonMcpServer(
     val uri =
       StorybookMcp.resolveUri(id, catalogResources())
         ?: return errorCallToolResult("run-story-tests: no such story: $id")
-    val parsed =
-      PreviewUri.parseOrNull(uri)
-        ?: return errorCallToolResult("run-story-tests: could not parse resolved uri: $uri")
-    // Prime the daemon with one render (enable_extensions only reaches already-spawned daemons),
-    // enable the a11y extension on it, then fetch the ATF findings (get_preview_data re-renders
-    // with
-    // a11y attached). Priming errors are surfaced by the final fetch rather than masked here.
-    toolRenderPreview(
+    // Our recording-assertion surface IS the play-function + expect equivalent: an `input.*` +
+    // `assert.*` timeline evaluated against the held scene. Delegate to record_preview, which
+    // drives
+    // the script and records each assertion APPLIED/FAILED. With no script, run an a11y smoke so a
+    // bare `run-story-tests <id>` still returns a meaningful check.
+    val events = (args["script"] as? JsonArray) ?: defaultA11ySmokeScript
+    return toolRecordPreview(
       buildJsonObject {
         put("uri", uri)
-        put("observe", "hash")
+        put("events", events)
+        put("observe", args["observe"]?.jsonPrimitive?.contentOrNull ?: "frames")
+        args["emitTest"]?.let { put("emitTest", it) }
+        args["format"]?.let { put("format", it) }
       }
     )
-    toolEnableExtensions(
+  }
+
+  /**
+   * Default `run-story-tests` script when the caller gives none: reload the scene, then assert no
+   * accessibility findings — the a11y-smoke degenerate case of the interaction+assertion timeline.
+   */
+  private val defaultA11ySmokeScript: JsonArray = buildJsonArray {
+    add(
       buildJsonObject {
-        putJsonArray("ids") { add(JsonPrimitive("a11y")) }
-        put("workspaceId", parsed.workspaceId.value)
-        put("module", parsed.modulePath)
+        put("tMs", 0)
+        put("kind", "preview.reload")
       }
     )
-    return toolGetPreviewData(
+    add(
       buildJsonObject {
-        put("uri", uri)
-        put("kind", "a11y/atf")
+        put("tMs", 100)
+        put("kind", "assert.a11y")
       }
     )
   }

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
@@ -1788,6 +1788,74 @@ class DaemonMcpServer(
               .trimIndent()
           ),
       ),
+      // ---------------------------------------------------------------------
+      // Storybook-MCP-compatible aliases (issue: storybook downstream adoption)
+      //
+      // Storybook shipped an official MCP server (GA in Storybook 10.3) whose tool NAMES an agent's
+      // harness learns. These kebab-named aliases map that vocabulary onto our catalog/render/a11y
+      // capabilities and accept a Storybook **story id** (minted by [StorybookMcp]) wherever we'd
+      // take a `compose-preview://` URI — so a Storybook-MCP-trained agent drives this server
+      // unmodified. Each routes to an existing `tool…()` handler; a raw native URI is still
+      // accepted.
+      // ---------------------------------------------------------------------
+      ToolDef(
+        name = "list-all-documentation",
+        description =
+          "Storybook-compatible: list every catalogued preview as a Storybook story — its stable " +
+            "`id` (title--name), `title`, `name`, synthetic `importPath`, and the native " +
+            "compose-preview `uri`. The story-catalog equivalent of Storybook's " +
+            "`list-all-documentation`; use the returned ids with `preview-stories`, " +
+            "`get-documentation-for-story`, and `run-story-tests`.",
+        inputSchema = parseSchema("""{"type":"object","properties":{}}"""),
+      ),
+      ToolDef(
+        name = "get-documentation-for-story",
+        description =
+          "Storybook-compatible: return one story's metadata — id, title, name, the native " +
+            "compose-preview `uri`, and its workspace/module/fqn. Accepts a story id from " +
+            "`list-all-documentation` (or a raw compose-preview URI) as `storyId`/`id`. Render it " +
+            "with `preview-stories`; check accessibility with `run-story-tests`.",
+        inputSchema =
+          parseSchema(
+            """
+            {"type":"object","properties":{"storyId":{"type":"string","description":"Story id from list-all-documentation, or a raw compose-preview:// URI."},"id":{"type":"string","description":"Alias for storyId."}}}
+            """
+              .trimIndent()
+          ),
+      ),
+      ToolDef(
+        name = "preview-stories",
+        description =
+          "Storybook-compatible: render one or more stories in isolation and return the images. " +
+            "Maps to `render_preview` per story. Pass `storyIds` (array) or a single `storyId` " +
+            "(ids from `list-all-documentation`, or raw compose-preview URIs). `observe` defaults " +
+            "to 'png' (the rendered image); 'semantics'/'hash' return the token-frugal structured " +
+            "observation instead. Optional `overrides` are the same per-call display overrides as " +
+            "`render_preview.overrides`.",
+        inputSchema =
+          parseSchema(
+            """
+            {"type":"object","properties":{"storyIds":{"type":"array","items":{"type":"string"},"description":"Story ids from list-all-documentation, or raw compose-preview:// URIs."},"storyId":{"type":"string","description":"A single story id, if not using storyIds."},"observe":{"type":"string","enum":["png","semantics","hash"],"description":"Default 'png'."},"overrides":{"type":"object","description":"Optional per-call display overrides, same shape as render_preview.overrides."}}}
+            """
+              .trimIndent()
+          ),
+      ),
+      ToolDef(
+        name = "run-story-tests",
+        description =
+          "Storybook-compatible: run the accessibility checks for a story and return structured " +
+            "results. Enables the `a11y` extension on the owning daemon, renders, and returns the " +
+            "Accessibility Test Framework (ATF) findings (`a11y/atf`) — the compose analogue of " +
+            "Storybook's `run-story-tests` accessibility pass. Accepts a story id from " +
+            "`list-all-documentation` (or a raw compose-preview URI) as `storyId`/`id`.",
+        inputSchema =
+          parseSchema(
+            """
+            {"type":"object","properties":{"storyId":{"type":"string","description":"Story id from list-all-documentation, or a raw compose-preview:// URI."},"id":{"type":"string","description":"Alias for storyId."}}}
+            """
+              .trimIndent()
+          ),
+      ),
     )
 
   private fun handleCallTool(
@@ -1823,8 +1891,156 @@ class DaemonMcpServer(
       "subscribe_preview_data" -> toolDataSubOrUnsub(session, args, subscribe = true)
       "unsubscribe_preview_data" -> toolDataSubOrUnsub(session, args, subscribe = false)
       "record_preview" -> toolRecordPreview(args)
+      // Storybook-MCP-compatible aliases → existing handlers via the story-id adapter.
+      "list-all-documentation" -> toolStorybookListDocs()
+      "get-documentation-for-story" -> toolStorybookGetDoc(args)
+      "preview-stories" -> toolStorybookPreviewStories(args)
+      "run-story-tests" -> toolStorybookRunTests(args)
       else -> errorCallToolResult("unknown tool: $name")
     }
+  }
+
+  // -------------------------------------------------------------------------
+  // Storybook-MCP-compatible alias handlers (see [StorybookMcp]). Each takes a Storybook story id
+  // (or a raw compose-preview URI) and routes to an existing handler via the id→URI adapter.
+  // -------------------------------------------------------------------------
+
+  /** `list-all-documentation`: the whole catalog presented as Storybook stories. */
+  private fun toolStorybookListDocs(): CallToolResult {
+    val stories = StorybookMcp.stories(catalogResources())
+    val payload = buildJsonObject {
+      put("schema", "compose-preview-mcp-storybook/v1")
+      put("count", stories.size)
+      putJsonArray("stories") {
+        stories.forEach { s ->
+          add(
+            buildJsonObject {
+              put("id", s.storyId)
+              put("title", s.title)
+              put("name", s.name)
+              put("type", "story")
+              put("importPath", "virtual:compose-preview/${s.fqn}")
+              put("uri", s.uri)
+            }
+          )
+        }
+      }
+    }
+    return textCallToolResult(payload.toString())
+  }
+
+  /** `get-documentation-for-story`: one story's metadata (id, title, name, native URI, coords). */
+  private fun toolStorybookGetDoc(args: JsonObject): CallToolResult {
+    val id =
+      (args["storyId"] ?: args["id"])?.jsonPrimitive?.contentOrNull
+        ?: return errorCallToolResult("get-documentation-for-story: missing 'storyId'")
+    val story =
+      StorybookMcp.stories(catalogResources()).firstOrNull { it.storyId == id || it.uri == id }
+        ?: return errorCallToolResult("get-documentation-for-story: no such story: $id")
+    val parsed = PreviewUri.parseOrNull(story.uri)
+    val payload = buildJsonObject {
+      put("schema", "compose-preview-mcp-storybook/v1")
+      put("id", story.storyId)
+      put("title", story.title)
+      put("name", story.name)
+      put("uri", story.uri)
+      put("importPath", "virtual:compose-preview/${story.fqn}")
+      if (parsed != null) {
+        put("workspaceId", parsed.workspaceId.value)
+        put("module", parsed.modulePath)
+        put("fqn", parsed.previewFqn)
+        parsed.config?.let { put("config", it) }
+      }
+      put(
+        "note",
+        "Render with preview-stories; check accessibility with run-story-tests. Native tools " +
+          "(render_preview, get_preview_data, …) accept `uri` directly.",
+      )
+    }
+    return textCallToolResult(payload.toString())
+  }
+
+  /** `preview-stories`: render one or more stories in isolation and return the images. */
+  private fun toolStorybookPreviewStories(args: JsonObject): CallToolResult {
+    val ids =
+      storybookStoryIds(args)
+        ?: return errorCallToolResult("preview-stories: provide 'storyIds' (array) or 'storyId'")
+    val observe = args["observe"]?.jsonPrimitive?.contentOrNull?.lowercase() ?: "png"
+    val overrides = args["overrides"]
+    val resources = catalogResources()
+    val blocks = mutableListOf<ContentBlock>()
+    var anyOk = false
+    var anyError = false
+    for (id in ids) {
+      val uri = StorybookMcp.resolveUri(id, resources)
+      if (uri == null) {
+        blocks.add(ContentBlock.Text("preview-stories: no such story: $id"))
+        anyError = true
+        continue
+      }
+      blocks.add(ContentBlock.Text("story: $id → $uri"))
+      val sub = buildJsonObject {
+        put("uri", uri)
+        put("observe", observe)
+        if (overrides != null) put("overrides", overrides)
+      }
+      val res = toolRenderPreview(sub)
+      blocks.addAll(res.content)
+      if (res.isError == true) anyError = true else anyOk = true
+    }
+    // Error only when nothing rendered — a partial success still returns the frames that worked.
+    return CallToolResult(content = blocks, isError = !anyOk && anyError)
+  }
+
+  /**
+   * `run-story-tests`: enable a11y, render, and return the ATF accessibility findings for a story.
+   */
+  private fun toolStorybookRunTests(args: JsonObject): CallToolResult {
+    val id =
+      (args["storyId"] ?: args["id"])?.jsonPrimitive?.contentOrNull
+        ?: return errorCallToolResult("run-story-tests: missing 'storyId'")
+    val uri =
+      StorybookMcp.resolveUri(id, catalogResources())
+        ?: return errorCallToolResult("run-story-tests: no such story: $id")
+    val parsed =
+      PreviewUri.parseOrNull(uri)
+        ?: return errorCallToolResult("run-story-tests: could not parse resolved uri: $uri")
+    // Prime the daemon with one render (enable_extensions only reaches already-spawned daemons),
+    // enable the a11y extension on it, then fetch the ATF findings (get_preview_data re-renders
+    // with
+    // a11y attached). Priming errors are surfaced by the final fetch rather than masked here.
+    toolRenderPreview(
+      buildJsonObject {
+        put("uri", uri)
+        put("observe", "hash")
+      }
+    )
+    toolEnableExtensions(
+      buildJsonObject {
+        putJsonArray("ids") { add(JsonPrimitive("a11y")) }
+        put("workspaceId", parsed.workspaceId.value)
+        put("module", parsed.modulePath)
+      }
+    )
+    return toolGetPreviewData(
+      buildJsonObject {
+        put("uri", uri)
+        put("kind", "a11y/atf")
+      }
+    )
+  }
+
+  /**
+   * One or many story ids from `storyIds` (array) or `storyId`/`id`. Null when neither is present.
+   */
+  private fun storybookStoryIds(args: JsonObject): List<String>? {
+    (args["storyIds"] as? JsonArray)?.let { arr ->
+      val ids = arr.mapNotNull { (it as? JsonPrimitive)?.contentOrNull }.filter { it.isNotBlank() }
+      return ids.ifEmpty { null }
+    }
+    val single =
+      (args["storyId"] ?: args["id"])?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() }
+    return single?.let { listOf(it) }
   }
 
   private fun toolStatus(): CallToolResult {

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/StorybookMcp.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/StorybookMcp.kt
@@ -1,0 +1,119 @@
+package ee.schimke.composeai.mcp
+
+import ee.schimke.composeai.mcp.protocol.ResourceDescriptor
+
+/**
+ * Storybook-MCP-compatibility adapter. Storybook shipped an official MCP server (GA in Storybook
+ * 10.3) whose tool names an agent's harness learns — `list-all-documentation`, `preview-stories`,
+ * `get-documentation-for-story`, `run-story-tests`. This maps that vocabulary onto our existing
+ * catalog + render + a11y capabilities so a Storybook-MCP-trained agent drives our server
+ * unmodified.
+ *
+ * Storybook addresses a unit of UI by a **story id** (`title--name`, kebab-cased via CSF's `toId`);
+ * we address one by a `compose-preview://<ws>/<module>/<fqn>?config=` URI. This adapter is the
+ * bridge: it mints a stable story id per catalogued preview and resolves a story id back to its URI
+ * ([resolveUri]) so the alias tools can hand our native handlers a URI.
+ *
+ * Pure (no daemon/IO) so id minting and resolution unit-test in isolation. It reuses the same CSF
+ * `sanitize`/`toId` convention as the serve-side twin `cli.serve.StorybookCompat` (that module
+ * isn't on `:mcp`'s classpath, so the tiny primitives are duplicated here — CSF is a fixed
+ * standard, so drift risk is low; keep the two in step if the convention ever changes).
+ */
+object StorybookMcp {
+
+  /** A catalogued preview presented as a Storybook story. */
+  data class Story(
+    val storyId: String,
+    /** The native `compose-preview://…` URI this story resolves to. */
+    val uri: String,
+    val title: String,
+    val name: String,
+    /** The preview's fully-qualified function name (for `importPath` / display). */
+    val fqn: String,
+  )
+
+  /**
+   * CSF `sanitize`: lowercase, collapse runs of non-`[a-z0-9]` to a single `-`, trim
+   * leading/trailing `-`. Compose FQNs are ASCII, so this reproduces Storybook's id shape.
+   */
+  fun sanitize(raw: String): String = raw.lowercase().replace(Regex("[^a-z0-9]+"), "-").trim('-')
+
+  /** CSF `toId(kind, name)` → `sanitize(kind)--sanitize(name)`, dropping a blank side. */
+  fun toId(title: String, name: String): String =
+    listOf(sanitize(title), sanitize(name)).filter { it.isNotBlank() }.joinToString("--")
+
+  /**
+   * Mint the stories for a catalog ([DaemonMcpServer.catalogResources] output). Resources are
+   * already sorted by URI, so iteration — and the deterministic collision suffixes (`-2`, `-3`, …)
+   * that keep the story id → URI map 1:1 — are stable across calls as long as the preview set is
+   * unchanged. Resources whose URI doesn't parse as a preview URI are skipped.
+   */
+  fun stories(resources: List<ResourceDescriptor>): List<Story> {
+    val used = HashSet<String>()
+    val out = ArrayList<Story>(resources.size)
+    for (resource in resources) {
+      val uri = PreviewUri.parseOrNull(resource.uri) ?: continue
+      val title = deriveTitle(uri)
+      val name = deriveName(uri, resource.description)
+      val base = toId(title, name).ifBlank { sanitize(uri.previewFqn).ifBlank { "preview" } }
+      var candidate = base
+      var n = 2
+      while (!used.add(candidate)) candidate = "$base-${n++}"
+      out.add(
+        Story(
+          storyId = candidate,
+          uri = resource.uri,
+          title = title,
+          name = name,
+          fqn = uri.previewFqn,
+        )
+      )
+    }
+    return out
+  }
+
+  /**
+   * Resolve a Storybook story id (or a raw native `compose-preview://…` URI, the deep-link escape
+   * hatch) to a native URI. The minted story ids are matched first — they're what
+   * `list-all-documentation` advertises — so an advertised id always round-trips; a native URI
+   * can't collide with a kebab story id, so the hatch never shadows an advertised story. Null when
+   * nothing matches.
+   */
+  fun resolveUri(storyIdOrUri: String, resources: List<ResourceDescriptor>): String? {
+    stories(resources)
+      .firstOrNull { it.storyId == storyIdOrUri }
+      ?.let {
+        return it.uri
+      }
+    // Native-URI escape hatch: accept it only if it's actually in the catalog.
+    if (PreviewUri.parseOrNull(storyIdOrUri) != null) {
+      return resources.firstOrNull { it.uri == storyIdOrUri }?.uri
+    }
+    return null
+  }
+
+  /**
+   * Sidebar grouping ([Story.title]): `<module>/<Class>` — the Gradle module path
+   * (`:samples:android` → `samples/android`) plus the enclosing class/file simple name
+   * (`com.example.PreviewsKt.Foo` → `Previews`, trailing `Kt` dropped). The module prefix keeps
+   * titles distinct across a multi-module catalog.
+   */
+  private fun deriveTitle(uri: PreviewUri): String {
+    val modulePretty = uri.modulePath.removePrefix(":").replace(':', '/')
+    val container = uri.previewFqn.substringBeforeLast('.', missingDelimiterValue = "")
+    val classSimple = container.substringAfterLast('.').removeSuffix("Kt")
+    val group = classSimple.ifBlank { uri.previewFqn.substringAfterLast('.') }
+    return listOf(modulePretty, group).filter { it.isNotBlank() }.joinToString("/")
+  }
+
+  /**
+   * Story [Story.name]: the preview's display name when the catalog carries one (the resource
+   * description, unless it's just the FQN), else the function simple name; a config qualifier is
+   * appended so named/parameterised variants stay distinct.
+   */
+  private fun deriveName(uri: PreviewUri, description: String?): String {
+    val fnSimple = uri.previewFqn.substringAfterLast('.')
+    val base = description?.trim()?.takeIf { it.isNotBlank() && it != uri.previewFqn } ?: fnSimple
+    return if (uri.config != null) "$base (${uri.config})" else base
+  }
+}

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
@@ -5,6 +5,7 @@ import com.google.common.truth.Truth.assertWithMessage
 import ee.schimke.composeai.mcp.protocol.ListToolsResult
 import ee.schimke.composeai.mcp.protocol.ReadResourceResult
 import ee.schimke.composeai.mcp.protocol.ResourceContents
+import io.modelcontextprotocol.kotlin.sdk.types.Implementation
 import java.awt.image.BufferedImage
 import java.io.IOException
 import java.io.InputStream
@@ -118,6 +119,45 @@ class DaemonMcpServerTest {
         "get_preview_extras",
         "record_preview",
       )
+  }
+
+  @Test
+  fun `storybook profile exposes only the storybook tools`() {
+    val sbSupervisor =
+      DaemonSupervisor(
+        descriptorProvider = FakeDescriptorProvider(),
+        clientFactory = FakeDaemonClientFactory(),
+      )
+    val sbServer =
+      DaemonMcpServer(
+        sbSupervisor,
+        serverInfo = Implementation(name = "compose-preview-storybook", version = "v0"),
+        profile = McpToolProfile.STORYBOOK,
+      )
+    val (c2s, sfc) = pipedPair()
+    val (s2c, cfs) = pipedPair()
+    val sbSession = sbServer.newSession(input = sfc, output = s2c)
+    sbSession.start()
+    val sbClient = McpTestClient(input = cfs, output = c2s)
+    try {
+      sbClient.initialize()
+      val tools = sbClient.awaitToolsContaining("preview-stories")
+      // Only the Storybook surface (+ status); native tools are hidden so the two surfaces never
+      // overlap.
+      assertThat(tools.tools.map { it.name }.toSet())
+        .containsExactly(
+          "status",
+          "list-all-documentation",
+          "get-documentation-for-story",
+          "preview-stories",
+          "run-story-tests",
+        )
+      assertThat(tools.tools.map { it.name }).doesNotContain("render_preview")
+    } finally {
+      runCatching { sbClient.close() }
+      runCatching { sbSession.close() }
+      runCatching { sbSupervisor.shutdown() }
+    }
   }
 
   @Test

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/StorybookMcpTest.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/StorybookMcpTest.kt
@@ -1,0 +1,85 @@
+package ee.schimke.composeai.mcp
+
+import com.google.common.truth.Truth.assertThat
+import ee.schimke.composeai.mcp.protocol.ResourceDescriptor
+import org.junit.Test
+
+/** Unit coverage for the pure Storybook-MCP id / resolution adapter ([StorybookMcp]). */
+class StorybookMcpTest {
+
+  private val ws = WorkspaceId("demo-1a2b3c4d")
+
+  private fun previewUri(module: String, fqn: String, config: String? = null): String =
+    PreviewUri(workspaceId = ws, modulePath = module, previewFqn = fqn, config = config).toUri()
+
+  private fun resource(uri: String, name: String, description: String?): ResourceDescriptor =
+    ResourceDescriptor(uri = uri, name = name, description = description, mimeType = "image/png")
+
+  @Test
+  fun sanitize_and_toId_follow_the_CSF_convention() {
+    assertThat(StorybookMcp.sanitize("Red Box")).isEqualTo("red-box")
+    assertThat(StorybookMcp.sanitize("com.example/PreviewsKt")).isEqualTo("com-example-previewskt")
+    assertThat(StorybookMcp.toId("samples/android/Previews", "Red Box"))
+      .isEqualTo("samples-android-previews--red-box")
+    // A blank side is dropped rather than leaving a dangling separator.
+    assertThat(StorybookMcp.toId("", "Greeting")).isEqualTo("greeting")
+  }
+
+  @Test
+  fun stories_mint_module_grouped_titles_from_the_uri() {
+    val uri = previewUri(":samples:android", "com.example.PreviewsKt.RedBoxPreview")
+    val stories = StorybookMcp.stories(listOf(resource(uri, "RedBoxPreview", "Red Box")))
+    assertThat(stories).hasSize(1)
+    val s = stories.single()
+    assertThat(s.title).isEqualTo("samples/android/Previews")
+    assertThat(s.name).isEqualTo("Red Box")
+    assertThat(s.storyId).isEqualTo("samples-android-previews--red-box")
+    assertThat(s.uri).isEqualTo(uri)
+    assertThat(s.fqn).isEqualTo("com.example.PreviewsKt.RedBoxPreview")
+  }
+
+  @Test
+  fun name_falls_back_to_the_function_and_folds_in_the_config_variant() {
+    // No display name (description == fqn) → the function simple name; config qualifier appended.
+    val fqn = "com.example.MainKt.GreetingPreview"
+    val uri = previewUri(":app", fqn, config = "Dark")
+    val stories = StorybookMcp.stories(listOf(resource(uri, "GreetingPreview", fqn)))
+    val s = stories.single()
+    assertThat(s.title).isEqualTo("app/Main")
+    assertThat(s.name).isEqualTo("GreetingPreview (Dark)")
+    assertThat(s.storyId).isEqualTo("app-main--greetingpreview-dark")
+  }
+
+  @Test
+  fun colliding_slugs_get_deterministic_suffixes_and_stay_one_to_one() {
+    // Two previews in the same file with the same display name derive the same slug; the second
+    // gets a deterministic suffix, and each id still round-trips to its own distinct uri.
+    val primary = previewUri(":ui", "com.example.ButtonsKt.PrimaryPreview")
+    val secondary = previewUri(":ui", "com.example.ButtonsKt.SecondaryPreview")
+    val resources =
+      listOf(
+        resource(primary, "PrimaryPreview", "Button"),
+        resource(secondary, "SecondaryPreview", "Button"),
+      )
+    val stories = StorybookMcp.stories(resources)
+    assertThat(stories.map { it.storyId })
+      .containsExactly("ui-buttons--button", "ui-buttons--button-2")
+      .inOrder()
+    assertThat(StorybookMcp.resolveUri("ui-buttons--button", resources)).isEqualTo(primary)
+    assertThat(StorybookMcp.resolveUri("ui-buttons--button-2", resources)).isEqualTo(secondary)
+  }
+
+  @Test
+  fun resolveUri_matches_minted_ids_and_the_native_uri_escape_hatch() {
+    val uri = previewUri(":samples:android", "com.example.PreviewsKt.RedBoxPreview")
+    val resources = listOf(resource(uri, "RedBoxPreview", "Red Box"))
+    // Minted story id → native uri.
+    assertThat(StorybookMcp.resolveUri("samples-android-previews--red-box", resources))
+      .isEqualTo(uri)
+    // Raw native uri accepted verbatim when it's in the catalog.
+    assertThat(StorybookMcp.resolveUri(uri, resources)).isEqualTo(uri)
+    // Unknown id / uri not in the catalog → null.
+    assertThat(StorybookMcp.resolveUri("no--such", resources)).isNull()
+    assertThat(StorybookMcp.resolveUri(previewUri(":other", "com.other.Foo"), resources)).isNull()
+  }
+}


### PR DESCRIPTION
## Summary

Storybook shipped an **official MCP server** (GA in Storybook 10.3) whose tool *names* an agent harness learns. This adds a **`--storybook` tool profile** to `compose-preview-mcp` that presents a clean Storybook surface mapping onto our existing catalog / render / testing capabilities, so a Storybook-MCP-trained agent (Cursor, Claude Code, Copilot, …) drives compose-preview **unmodified**. Item **#1** of the "pretend to be Storybook where it pays off" plan (#2, serve-side `index.json` + `iframe.html`, already merged).

| Storybook tool | Maps to | Returns |
|---|---|---|
| `list-all-documentation` | the resource catalog | every preview as a Storybook story (`id`, `title`, `name`, `importPath`, native `uri`) |
| `get-documentation-for-story` | catalog lookup | one story's metadata + native `uri`/coords |
| `preview-stories` | `render_preview` | the rendered image(s); `observe` + `overrides` pass through |
| `run-story-tests` | `record_preview` scripted assertions | structured test results — the compose analogue of Storybook's play + expect |

## Design

**Separate profile, not a merged tool list.** Run with `--storybook` (or `-Dcomposeai.mcp.profile=storybook`) and the server exposes **only** the Storybook tools (native tools hidden) and identifies as `compose-preview-storybook`. This avoids the two surfaces overlapping — an agent seeing both `render_preview` *and* `preview-stories` muddies tool routing. The default profile is the full native tool set. Both profiles filter one `buildFullToolDefs()` source by tool name, so no `ToolDef` literal is duplicated; the alias-name set is a top-level constant to avoid a construction-time init-order race with the async tool-catalog loader.

**Story-id addressing** (approach B). Storybook addresses a preview by a CSF-style **story id** (`title--name`); we address one by a `compose-preview://…` URI. The pure `StorybookMcp` adapter mints a stable story id per catalogued preview (module-grouped title + CSF `toId`, deterministic collision suffixes) and resolves it back to its URI — advertised ids first, raw-URI escape hatch second, so `list-all-documentation` and the render/test tools can never disagree.

**`run-story-tests` = our interactive testing.** Our scripted-recording assertions (`record_preview`: `input.*` to drive, `assert.visible`/`assert.notVisible`/`assert.textEquals`/`assert.a11y`/`assert.pixels` to check) already *are* the play-function + `expect` model applied to held `@Preview` scenes (see `docs/daemon/RECORDING-ASSERTIONS.md`). So `run-story-tests` is a façade over `record_preview`: pass a `script` for interaction + assertions, or omit it for an a11y smoke (`preview.reload` + `assert.a11y`); `emitTest` also returns a generated Compose UI test. This covers **both** Storybook test dimensions (interaction *and* a11y) with capability that already ships.

- **Backend coverage** of the assertion surface is uneven (Desktop lacks `assert.a11y`; Android lacks `assert.textEquals`/`assert.pixels` and resolves `testTag` only). Tracked in **#2519**.
- Deferred (noted in the README): `get-changed-stories` (composable from `history_list`/`history_diff`) and `get-storybook-story-instructions`.

## Test plan

- [x] `:mcp:test StorybookMcpTest` — CSF `sanitize`/`toId`, module-grouped titles, config-variant names, deterministic collision suffixes, `resolveUri` (minted id + native-URI hatch, advertised-id-wins).
- [x] `:mcp:test DaemonMcpServerTest` — **79 pass**, incl. a new `storybook profile exposes only the storybook tools` case, and the native tool-surface assertion (now correctly excludes the aliases).
- [x] `:mcp:compileKotlin` + `:mcp:ktfmtFormat` clean.

Note: `:mcp:test` isn't currently a CI gate here, so these were run locally.

## Visual evidence

Non-visual change — MCP tool plumbing + a pure id adapter, no rendered surface. (`preview-stories` / `run-story-tests` return renders/recordings from the existing pipeline, already harness-covered.)