### PR TITLE
fix(figma-svg): apply the render's font scale to exported text

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/ComposeFigmaSvgExtension.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/ComposeFigmaSvgExtension.kt
@@ -34,6 +34,7 @@ class ComposeFigmaSvgExtension : PostCaptureProcessor {
     val previewContext =
       context.require(RenderDataArtifactContextKeys.LayoutInspectorPreviewContext)
     val density = context.get(RenderDataArtifactContextKeys.Density) ?: 1f
+    val fontScale = context.get(RenderDataArtifactContextKeys.FontScale) ?: 1f
     val layout = LayoutInspectorDataProducer.buildPayload(previewContext, density) ?: return
     val semantics: ComposeSemanticsPayload? =
       context.get(RenderDataArtifactContextKeys.SemanticsRoot)?.let {
@@ -48,6 +49,8 @@ class ComposeFigmaSvgExtension : PostCaptureProcessor {
       layout = layout,
       semantics = semantics,
       density = density,
+      // Size sp text at the render's font scale (setFontScale) so the vector matches the render.
+      fontScale = fontScale,
       frameImage = frameImage,
       // Embed the real (Google-downloadable) face so `<text>` renders faithfully — parity with the
       // desktop export. On Android the render itself is Roboto, so the embedded face is the exact

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderDataArtifactExtensions.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderDataArtifactExtensions.kt
@@ -89,6 +89,14 @@ object RenderDataArtifactContextKeys {
     ExtensionContextKey(name = "render-data-artifact.density", type = Float::class.javaObjectType)
 
   /**
+   * Render font scale (`spec.fontScale`, the multiplier `RuntimeEnvironment.setFontScale` applied).
+   * Threaded so the `compose/figma-svg` export can size `sp` text as `sp × density × fontScale` —
+   * matching the render, whose layer geometry was measured with the scaled text. Absent ⇒ 1.0.
+   */
+  val FontScale: ExtensionContextKey<Float> =
+    ExtensionContextKey(name = "render-data-artifact.fontScale", type = Float::class.javaObjectType)
+
+  /**
    * The held [`androidx.activity.ComponentActivity`] the rule launched for this render. Threaded to
    * extensions that read activity-scoped state — `getIntent()` (deep-link routing audits),
    * `onBackPressedDispatcher.hasEnabledCallbacks()` (registered back callbacks). Robolectric's

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -676,6 +676,7 @@ class RenderEngine(
                     add(RenderDataArtifactContextKeys.SemanticsRoot provides it)
                   }
                   add(RenderDataArtifactContextKeys.Density provides spec.density)
+                  add(RenderDataArtifactContextKeys.FontScale provides (spec.fontScale ?: 1.0f))
                   add(RenderDataArtifactContextKeys.OutputPng provides outputFile)
                   add(RenderDataArtifactContextKeys.HeldActivity provides rule.activity)
                   layoutInspectorPreviewContext?.let {
@@ -1290,6 +1291,9 @@ class RenderEngine(
       layout = out.layout,
       semantics = out.semantics,
       density = spec.density,
+      // Match the render's font scale (setFontScale) so the long-scroll vector's text isn't
+      // undersized against the boxes it was measured into.
+      fontScale = spec.fontScale ?: 1.0f,
       frameImage = out.framePng,
       roundClip = true,
       deviceBackground = WEAR_DEVICE_FACE,

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -673,6 +673,10 @@ class RenderEngine(
                 layout = layout,
                 semantics = payload,
                 density = density,
+                // Emit sp text at the render's font scale so the vector matches the render (which
+                // sized its text — and the boxes measured around it — via Density(density,
+                // fontScale)).
+                fontScale = state.spec.fontScale ?: 1.0f,
                 // Hand the just-written frame PNG so opaque components (Image/Icon/Canvas/charts)
                 // export as `<image>` layers backed by a real background-free crop of the frame.
                 frameImage = state.outputFile,

--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeFigmaSvgDataProduct.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeFigmaSvgDataProduct.kt
@@ -57,6 +57,9 @@ object ComposeFigmaSvgDataProducer {
    * @param colorNames optional `#AARRGGBB` → theme-role-name map so named fills carry their
    *   variable.
    * @param density px-per-dp of the captured frame (dp/sp tokens are converted to px against it).
+   * @param fontScale the render's font-scale multiplier; sp text is emitted at `sp × density ×
+   *   fontScale` so the `<text>` matches the render whose (already fontScale-scaled) layer geometry
+   *   this export places it into. Defaults to 1.0 (an un-scaled capture).
    * @param frameImage the captured frame PNG in root-pixel space; when present, enables hybrid
    *   raster export by cropping opaque-node rasters out of it.
    */
@@ -67,6 +70,7 @@ object ComposeFigmaSvgDataProducer {
     semantics: ComposeSemanticsPayload? = null,
     colorNames: Map<String, String> = emptyMap(),
     density: Float = 1f,
+    fontScale: Float = 1f,
     frameImage: File? = null,
     fontResolver: FigmaFontResolver? = null,
     roundClip: Boolean = false,
@@ -81,6 +85,7 @@ object ComposeFigmaSvgDataProducer {
         semantics = semantics,
         colorNames = colorNames,
         density = density,
+        fontScale = fontScale,
         rasterComponents =
           if (frame != null) FigmaSvgModel.DEFAULT_RASTER_COMPONENTS else emptySet(),
         // Hybrid mode also crops Canvas-drawn chrome (progress track, slider groove) the token

--- a/data/layoutinspector/connector/src/test/kotlin/ee/schimke/composeai/daemon/FigmaSvgFontScaleTest.kt
+++ b/data/layoutinspector/connector/src/test/kotlin/ee/schimke/composeai/daemon/FigmaSvgFontScaleTest.kt
@@ -1,0 +1,127 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsNode
+import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsPayload
+import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsTypography
+import ee.schimke.composeai.data.layoutinspector.LayoutInspectorBounds
+import ee.schimke.composeai.data.layoutinspector.LayoutInspectorNode
+import ee.schimke.composeai.data.layoutinspector.LayoutInspectorPayload
+import ee.schimke.composeai.data.layoutinspector.LayoutInspectorSize
+import java.io.File
+import java.nio.file.Files
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * The `compose/figma-svg` export must size `sp` text at the render's **font scale**. Compose sizes
+ * `sp` text as `sp × density × fontScale`, and the layer geometry the export places text into is
+ * captured *after* that fontScale is applied (the boxes were measured for scaled text). So a
+ * `fontScale` render whose export still emits text at 1.0 draws undersized glyphs floating in
+ * oversized boxes — the drift the compare page surfaces. These tests pin that the emitted `<text
+ * font-size>` carries the fontScale.
+ */
+class FigmaSvgFontScaleTest {
+  private lateinit var dir: File
+
+  @Before
+  fun setUp() {
+    dir = Files.createTempDirectory("figma-font-scale").toFile()
+  }
+
+  @After
+  fun tearDown() {
+    dir.deleteRecursively()
+  }
+
+  private fun layout() =
+    LayoutInspectorPayload(
+      LayoutInspectorNode(
+        nodeId = "Screen",
+        component = "Screen",
+        bounds = LayoutInspectorBounds(0, 0, 200, 100),
+        size = LayoutInspectorSize(200, 100),
+        children =
+          listOf(
+            LayoutInspectorNode(
+              nodeId = "Text",
+              component = "Text",
+              bounds = LayoutInspectorBounds(8, 8, 192, 40),
+              size = LayoutInspectorSize(184, 32),
+            )
+          ),
+      )
+    )
+
+  private fun semantics() =
+    ComposeSemanticsPayload(
+      ComposeSemanticsNode(
+        nodeId = "root",
+        boundsInRoot = "0,0,200,100",
+        children =
+          listOf(
+            ComposeSemanticsNode(
+              nodeId = "Text",
+              boundsInRoot = "8,8,192,40",
+              text = "Hi",
+              typography =
+                ComposeSemanticsTypography(
+                  fontSize = "16.0sp",
+                  fontWeight = 400,
+                  lineHeight = "24.0sp",
+                  letterSpacing = "1.0sp",
+                ),
+            )
+          ),
+      )
+    )
+
+  /** The first `<text …>`'s `font-size` value, or null when the export emitted no sized text. */
+  private fun fontSizeOf(svg: String): Double? =
+    Regex("<text\\b[^>]*\\bfont-size=\"([0-9.]+)\"").find(svg)?.groupValues?.get(1)?.toDouble()
+
+  private fun render(density: Float, fontScale: Float): String {
+    ComposeFigmaSvgDataProducer.writeSvg(
+      rootDir = dir,
+      previewId = "p",
+      layout = layout(),
+      semantics = semantics(),
+      density = density,
+      fontScale = fontScale,
+    )
+    return dir.resolve("p").resolve(ComposeFigmaSvgDataProducer.FILE_SVG).readText()
+  }
+
+  @Test
+  fun defaultFontScaleEmitsSpTimesDensity() {
+    // 16.0sp × density 2.0 × fontScale 1.0 = 32px.
+    val fs = fontSizeOf(render(density = 2f, fontScale = 1f))
+    assertNotNull("export emits a sized <text>", fs)
+    assertEquals(32.0, fs!!, 0.01)
+  }
+
+  @Test
+  fun fontScaleMultipliesTheEmittedTextSize() {
+    val base = fontSizeOf(render(density = 2f, fontScale = 1f))
+    dir.resolve("p").deleteRecursively()
+    val scaled = fontSizeOf(render(density = 2f, fontScale = 2f))
+    assertNotNull(base)
+    assertNotNull(scaled)
+    // 16.0sp × density 2.0 × fontScale 2.0 = 64px — twice the un-scaled size.
+    assertEquals(64.0, scaled!!, 0.01)
+    assertEquals(2.0, scaled / base!!, 0.01)
+  }
+
+  @Test
+  fun fontScaleAlsoScalesLineHeightAndLetterSpacing() {
+    // line-height and letter-spacing are sp metrics too, so they carry the same fontScale — a
+    // faithful vector grows the leading/tracking with the glyphs, not just the glyph size.
+    val svg = render(density = 2f, fontScale = 2f)
+    // 24.0sp × 2 × 2 = 96 line-height feeds the wrapped-line baseline math; 1.0sp × 2 × 2 = 4
+    // letter-spacing is emitted directly. The scaled tracking is the observable one.
+    assertTrue("letter-spacing scaled by fontScale", svg.contains("letter-spacing=\"4\""))
+  }
+}

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgModel.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgModel.kt
@@ -367,6 +367,7 @@ data class FigmaSvgModel(
       semantics: ComposeSemanticsPayload? = null,
       colorNames: Map<String, String> = emptyMap(),
       density: Float = 1f,
+      fontScale: Float = 1f,
       padding: Int = DEFAULT_PADDING,
       rasterComponents: Set<String> = emptySet(),
       rasterHref: (nodeId: String) -> String = ::defaultRasterHref,
@@ -376,7 +377,7 @@ data class FigmaSvgModel(
       deviceBackground: String? = null,
     ): FigmaSvgModel {
       val textByNodeId =
-        semantics?.let { assignTextToLayers(layout.root, it, density) } ?: emptyMap()
+        semantics?.let { assignTextToLayers(layout.root, it, density, fontScale) } ?: emptyMap()
       val names = colorNames.mapKeys { it.key.uppercase() }
       val ctx =
         BuildContext(textByNodeId, names, density, rasterComponents, rasterHref, captureCanvasDraws)
@@ -882,6 +883,7 @@ data class FigmaSvgModel(
       layoutRoot: LayoutInspectorNode,
       semantics: ComposeSemanticsPayload,
       density: Float,
+      fontScale: Float,
     ): Map<String, FigmaSvgText> {
       val candidates = mutableListOf<Pair<String, IntArray>>()
       fun collect(n: LayoutInspectorNode) {
@@ -916,7 +918,7 @@ data class FigmaSvgModel(
           }
           val chosen = bestId
           if (chosen != null && bestDist < (bestDistForNode[chosen] ?: Int.MAX_VALUE)) {
-            textByNodeId[chosen] = textFrom(node, content, density)
+            textByNodeId[chosen] = textFrom(node, content, density, fontScale)
             bestDistForNode[chosen] = bestDist
           }
         }
@@ -930,22 +932,24 @@ data class FigmaSvgModel(
       node: ComposeSemanticsNode,
       content: String,
       density: Float,
+      fontScale: Float,
     ): FigmaSvgText =
       FigmaSvgText(
         content = content,
-        fontSizePx = node.typography?.fontSize?.let { spToPx(it, density) },
+        fontSizePx = node.typography?.fontSize?.let { spToPx(it, density, fontScale) },
         fontFamily = node.typography?.fontFamily,
         fontWeight = node.typography?.fontWeight,
         italic = node.typography?.fontStyle == "italic",
         color = node.textColor?.foreground?.let { argbToColor(it, emptyMap()) },
         lineHeightPx =
           node.typography?.lineHeight?.let {
-            lineHeightToPx(it, node.typography.fontSize, density)
+            lineHeightToPx(it, node.typography.fontSize, density, fontScale)
           },
-        // Letter spacing uses the same sp×density / em×fontSize resolution as line height.
+        // Letter spacing uses the same sp×density×fontScale / em×fontSize resolution as line
+        // height.
         letterSpacingPx =
           node.typography?.letterSpacing?.let {
-            lineHeightToPx(it, node.typography.fontSize, density)
+            lineHeightToPx(it, node.typography.fontSize, density, fontScale)
           },
         // Carry per-line runs only for genuinely wrapped text (2+ lines). The captured offsets are
         // already in render px (same space as the node bounds), so they map straight to layer space
@@ -962,13 +966,19 @@ data class FigmaSvgModel(
      * resolved font size (in px). Returns null when neither the value nor (for `em`) the font size
      * parses.
      */
-    fun lineHeightToPx(value: String, fontSize: String?, density: Float): Double? {
+    fun lineHeightToPx(
+      value: String,
+      fontSize: String?,
+      density: Float,
+      fontScale: Float = 1f,
+    ): Double? {
       val trimmed = value.trim()
       return when {
-        trimmed.endsWith("sp") -> spToPx(trimmed, density)
+        trimmed.endsWith("sp") -> spToPx(trimmed, density, fontScale)
         trimmed.endsWith("em") -> {
           val em = trimmed.removeSuffix("em").trim().toDoubleOrNull() ?: return null
-          val fontPx = fontSize?.let { spToPx(it, density) } ?: return null
+          // em is a multiple of the (already fontScale-scaled) font size.
+          val fontPx = fontSize?.let { spToPx(it, density, fontScale) } ?: return null
           em * fontPx
         }
         else -> null
@@ -1054,10 +1064,16 @@ data class FigmaSvgModel(
       return n * density
     }
 
-    /** `"22.0sp"` → px at [density]. Font scale is intentionally not applied (capture is 1.0). */
-    fun spToPx(value: String, density: Float): Double? {
+    /**
+     * `"22.0sp"` → px at [density], scaled by [fontScale]. Compose sizes `sp` text as `sp × density
+     * × fontScale`, and the layer geometry this SVG places text into is captured *after* that
+     * fontScale is applied (the boxes are measured for scaled text), so the emitted `<text
+     * font-size>` must carry the same fontScale or the glyphs float undersized in boxes sized for
+     * larger text. [fontScale] defaults to 1.0 (an un-scaled capture).
+     */
+    fun spToPx(value: String, density: Float, fontScale: Float = 1f): Double? {
       val n = value.removeSuffix("sp").trim().toDoubleOrNull() ?: return null
-      return n * density
+      return n * density * fontScale
     }
 
     /**

--- a/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvgTest.kt
+++ b/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvgTest.kt
@@ -305,6 +305,17 @@ class FigmaLayeredSvgTest {
   }
 
   @Test
+  fun spToPxAppliesDensityAndFontScale() {
+    // sp text sizes as sp × density × fontScale; fontScale defaults to 1.0 (an un-scaled capture).
+    assertEquals(32.0, FigmaSvgModel.spToPx("16.0sp", 2f)!!, 0.001)
+    assertEquals(64.0, FigmaSvgModel.spToPx("16.0sp", 2f, 2f)!!, 0.001)
+    // An `em` line-height resolves against the (scaled) font px, so it grows with fontScale too.
+    assertEquals(1.5 * 64.0, FigmaSvgModel.lineHeightToPx("1.5em", "16.0sp", 2f, 2f)!!, 0.001)
+    // An `sp` line-height scales directly.
+    assertEquals(48.0, FigmaSvgModel.lineHeightToPx("12.0sp", "16.0sp", 2f, 2f)!!, 0.001)
+  }
+
+  @Test
   fun nestingIsPreservedAsNestedGroups() {
     val svg =
       render(


### PR DESCRIPTION
## Summary

The `compose/figma-svg` export sized `sp` text as `sp × density` with **font scale pinned to 1.0** (`FigmaSvgModel.spToPx`: *"Font scale is intentionally not applied (capture is 1.0)"*), even when the render applied a `fontScale`. But the layer **geometry** the export places text into is captured *after* fontScale is applied — the boxes are measured for scaled text. So at fontScale 2.0 the vector drew **1× glyphs inside 2×-sized boxes**: small text floating in oversized containers. This is exactly the drift the compare page's font-scale probe surfaces (PR #2518).

This threads the render's `fontScale` end-to-end so `sp` text is emitted at `sp × density × fontScale`:

- `FigmaSvgModel.spToPx` / `lineHeightToPx` / `textFrom` / `assignTextToLayers` / `from` take a `fontScale` (default **1.0**, so un-scaled captures are byte-for-byte unchanged). Font size, `sp`/`em` line-height, and letter-spacing all scale.
- `ComposeFigmaSvgDataProducer.writeSvg` forwards it into the model.
- **Desktop** + **Android** `RenderEngine` pass `spec.fontScale`; the always-on **Android post-capture extension** reads a new `FontScale` render-context key, populated beside `Density` from `spec.fontScale`.

Layer **geometry** (px bounds, dp corner radii) is deliberately untouched — only `sp` text metrics scale, which is what Compose's fontScale actually affects.

## Test plan
- **New `FigmaSvgFontScaleTest`** (connector, end-to-end through `writeSvg`): a `16.0sp` label at density 2.0 emits `<text font-size="32">` at fontScale 1.0 and `font-size="64"` at fontScale 2.0 (a clean 2×), and `letter-spacing` scales likewise.
- **`FigmaLayeredSvgTest`** case pins `spToPx` / `lineHeightToPx` (incl. the `em` branch resolving against the scaled font px).
- Ran locally, green: `:data-layoutinspector-core:test`, `:data-layoutinspector-connector:test`, `:daemon:desktop:compileKotlin`.

## Visual verification
This is renderer-*logic*: the observable output is the figma-svg's `<text>` metrics, pinned numerically by the tests above. A pixel before/after needs a catalog **re-rendered at fontScale ≠ 1**, which requires the Android SDK + the `design-artifacts` pipeline that isn't provisioned in this session — CI's design-artifacts / preview-diff workflows cover that render. The compare page from #2518 is the tool that makes the drift (and its fix) visible once the catalog is regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MKLWAgKunMpmXezWGWiWxE)_