### PR TITLE
feat(serve): serve inline SVG from iframe.html for DOM-capture visual tools

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -54,6 +54,7 @@ import kotlinx.serialization.json.Json
  * - `GET /` landing page, `GET /p/{id}` viewer page,
  * - `GET /render/{id}.png` PNG bytes, `GET /api/previews` JSON, `GET /healthz` liveness,
  * - `GET /index.json` Storybook stories index, `GET /iframe.html?id=` isolated story render
+ *   (`&format=svg` inlines the vector export as real DOM for DOM-capture tools),
  *   ([StorybookCompat]) — the drop-in surface downstream Storybook visual tools consume,
  * - `GET /version` host identity (CLI version, serve schema, public flag),
  * - `GET /bundle.zip` portable bundle, `WS /ws/{id}` streamed-frame lane.
@@ -512,9 +513,12 @@ class ServeHttpServer(
   /**
    * `GET /iframe.html?id=<storyId>` (query) and `GET /{system}/iframe.html?id=<storyId>` (path):
    * render one story in isolation. Answers with a chrome-free HTML page embedding the freshly-
-   * rendered PNG as a `data:` URI ([StorybookCompat.iframePage]) — what a screenshot tool captures.
-   * Honours the same override query params as `/render` (e.g. `&uiMode=dark`), and load-sheds
-   * through the shared render semaphore exactly like [handleRender].
+   * rendered preview — a raster PNG `data:` URI by default ([StorybookCompat.iframePage]), or with
+   * `&format=svg` the figma-svg export inlined **as `<svg>` markup**
+   * ([StorybookCompat.iframeSvgPage]) so DOM-serializing visual tools (Percy/Chromatic/Applitools)
+   * have real DOM to re-render. SVG is daemon-only, so a static bundle 404s that lane. Honours the
+   * same override query params as `/render` (e.g. `&uiMode=dark`), and load-sheds through the
+   * shared render semaphore.
    */
   private suspend fun RoutingContext.handleStorybookIframe(sessionInPath: Boolean) {
     if (rejectBadToken()) return
@@ -545,42 +549,97 @@ class ServeHttpServer(
           .toMap()
       val knobKinds =
         ServeOverrides.declaredKnobKinds(renderHost.previews.firstOrNull { it.id == previewId })
+      // `?format=svg` inlines the figma-svg export as real DOM (for DOM-capture visual tools);
+      // default (png) inlines the raster. SVG is daemon-only, so a static bundle 404s it.
+      val wantSvg = call.request.queryParameters["format"]?.lowercase() == "svg"
       when (val parsed = ServeOverrides.parse(overrideParams, knobKinds)) {
         is OverrideParse.Invalid ->
           call.respondText(parsed.message, status = HttpStatusCode.BadRequest)
-        is OverrideParse.Ok -> {
-          val outcome =
-            withContext(Dispatchers.IO) {
-              if (!renderSemaphore.tryAcquire(RENDER_QUEUE_WAIT_SECONDS, TimeUnit.SECONDS)) {
-                null
-              } else {
-                try {
-                  renderHost.render(previewId, parsed.overrides)
-                } finally {
-                  renderSemaphore.release()
-                }
-              }
-            }
-          when (outcome) {
-            null -> {
-              call.response.headers.append(HttpHeaders.RetryAfter, "2")
-              call.respondText(
-                "render queue saturated; retry shortly",
-                status = HttpStatusCode.ServiceUnavailable,
-              )
-            }
-            is RenderOutcome.Ok ->
-              call.respondText(
-                StorybookCompat.iframePage(storyId, outcome.png),
-                ContentType.Text.Html,
-              )
-            RenderOutcome.NotFound ->
-              call.respondText("no such story", status = HttpStatusCode.NotFound)
-            is RenderOutcome.Failed ->
-              call.respondText(outcome.reason, status = HttpStatusCode.InternalServerError)
+        is OverrideParse.Ok ->
+          if (wantSvg) {
+            storybookIframeSvg(renderHost, storyId, previewId, parsed.overrides)
+          } else {
+            storybookIframePng(renderHost, storyId, previewId, parsed.overrides)
+          }
+      }
+    }
+  }
+
+  /** PNG lane of [handleStorybookIframe]: render, then inline the raster in the isolation page. */
+  private suspend fun RoutingContext.storybookIframePng(
+    renderHost: ServeHost,
+    storyId: String,
+    previewId: String,
+    overrides: PreviewOverrides,
+  ) {
+    val outcome =
+      withContext(Dispatchers.IO) {
+        if (!renderSemaphore.tryAcquire(RENDER_QUEUE_WAIT_SECONDS, TimeUnit.SECONDS)) {
+          null
+        } else {
+          try {
+            renderHost.render(previewId, overrides)
+          } finally {
+            renderSemaphore.release()
           }
         }
       }
+    when (outcome) {
+      null -> {
+        call.response.headers.append(HttpHeaders.RetryAfter, "2")
+        call.respondText(
+          "render queue saturated; retry shortly",
+          status = HttpStatusCode.ServiceUnavailable,
+        )
+      }
+      is RenderOutcome.Ok ->
+        call.respondText(StorybookCompat.iframePage(storyId, outcome.png), ContentType.Text.Html)
+      RenderOutcome.NotFound -> call.respondText("no such story", status = HttpStatusCode.NotFound)
+      is RenderOutcome.Failed ->
+        call.respondText(outcome.reason, status = HttpStatusCode.InternalServerError)
+    }
+  }
+
+  /**
+   * SVG lane of [handleStorybookIframe]: render the figma-svg export and inline it as markup — real
+   * DOM for DOM-capture visual tools. Daemon-only, so a static bundle host 404s (like
+   * `/render.svg`).
+   */
+  private suspend fun RoutingContext.storybookIframeSvg(
+    renderHost: ServeHost,
+    storyId: String,
+    previewId: String,
+    overrides: PreviewOverrides,
+  ) {
+    val outcome =
+      withContext(Dispatchers.IO) {
+        if (!renderSemaphore.tryAcquire(RENDER_QUEUE_WAIT_SECONDS, TimeUnit.SECONDS)) {
+          null
+        } else {
+          try {
+            renderHost.renderSvg(previewId, overrides)
+          } finally {
+            renderSemaphore.release()
+          }
+        }
+      }
+    when (outcome) {
+      null -> {
+        call.response.headers.append(HttpHeaders.RetryAfter, "2")
+        call.respondText(
+          "render queue saturated; retry shortly",
+          status = HttpStatusCode.ServiceUnavailable,
+        )
+      }
+      is SvgOutcome.Ok ->
+        call.respondText(StorybookCompat.iframeSvgPage(storyId, outcome.svg), ContentType.Text.Html)
+      SvgOutcome.NotFound ->
+        call.respondText(
+          "svg unavailable for this story (no daemon-backed SVG export)",
+          status = HttpStatusCode.NotFound,
+        )
+      is SvgOutcome.Failed ->
+        call.respondText(outcome.reason, status = HttpStatusCode.InternalServerError)
     }
   }
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -54,7 +54,7 @@ import kotlinx.serialization.json.Json
  * - `GET /` landing page, `GET /p/{id}` viewer page,
  * - `GET /render/{id}.png` PNG bytes, `GET /api/previews` JSON, `GET /healthz` liveness,
  * - `GET /index.json` Storybook stories index, `GET /iframe.html?id=` isolated story render
- *   (`&format=svg` inlines the vector export as real DOM for DOM-capture tools),
+ *   (`&format=svg` serves the vector export as an inert SVG image for DOM-capture tools),
  *   ([StorybookCompat]) — the drop-in surface downstream Storybook visual tools consume,
  * - `GET /version` host identity (CLI version, serve schema, public flag),
  * - `GET /bundle.zip` portable bundle, `WS /ws/{id}` streamed-frame lane.
@@ -514,11 +514,12 @@ class ServeHttpServer(
    * `GET /iframe.html?id=<storyId>` (query) and `GET /{system}/iframe.html?id=<storyId>` (path):
    * render one story in isolation. Answers with a chrome-free HTML page embedding the freshly-
    * rendered preview — a raster PNG `data:` URI by default ([StorybookCompat.iframePage]), or with
-   * `&format=svg` the figma-svg export inlined **as `<svg>` markup**
-   * ([StorybookCompat.iframeSvgPage]) so DOM-serializing visual tools (Percy/Chromatic/Applitools)
-   * have real DOM to re-render. SVG is daemon-only, so a static bundle 404s that lane. Honours the
-   * same override query params as `/render` (e.g. `&uiMode=dark`), and load-sheds through the
-   * shared render semaphore.
+   * `&format=svg` the figma-svg export as an **inert `<img src="data:image/svg+xml">`**
+   * ([StorybookCompat.iframeSvgPage]): a still-vector, resolution-independent render for
+   * DOM-capture visual tools (Percy/Chromatic/Applitools), kept in the browser's non-scripting
+   * `<img>` mode so an unverified catalog's untrusted SVG can't execute. SVG is daemon-only, so a
+   * static bundle 404s that lane. Honours the same override query params as `/render` (e.g.
+   * `&uiMode=dark`), and load-sheds through the shared render semaphore.
    */
   private suspend fun RoutingContext.handleStorybookIframe(sessionInPath: Boolean) {
     if (rejectBadToken()) return
@@ -549,8 +550,9 @@ class ServeHttpServer(
           .toMap()
       val knobKinds =
         ServeOverrides.declaredKnobKinds(renderHost.previews.firstOrNull { it.id == previewId })
-      // `?format=svg` inlines the figma-svg export as real DOM (for DOM-capture visual tools);
-      // default (png) inlines the raster. SVG is daemon-only, so a static bundle 404s it.
+      // `?format=svg` serves the figma-svg export as an inert svg <img> (vector, for DOM-capture
+      // visual tools); default (png) inlines the raster. SVG is daemon-only, so a static bundle
+      // 404s.
       val wantSvg = call.request.queryParameters["format"]?.lowercase() == "svg"
       when (val parsed = ServeOverrides.parse(overrideParams, knobKinds)) {
         is OverrideParse.Invalid ->
@@ -601,8 +603,9 @@ class ServeHttpServer(
   }
 
   /**
-   * SVG lane of [handleStorybookIframe]: render the figma-svg export and inline it as markup — real
-   * DOM for DOM-capture visual tools. Daemon-only, so a static bundle host 404s (like
+   * SVG lane of [handleStorybookIframe]: render the figma-svg export and serve it as an inert svg
+   * `<img>` — a vector render for DOM-capture visual tools, safe even for an untrusted catalog's
+   * SVG (see [StorybookCompat.iframeSvgPage]). Daemon-only, so a static bundle host 404s (like
    * `/render.svg`).
    */
   private suspend fun RoutingContext.storybookIframeSvg(

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/StorybookCompat.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/StorybookCompat.kt
@@ -160,6 +160,42 @@ object StorybookCompat {
   }
 
   /**
+   * The SVG isolation page for `iframe.html?id=<storyId>&format=svg`: the figma-svg export
+   * ([svgBytes] from `/render/<id>.svg`) inlined **as markup** into the document body. Unlike the
+   * PNG page (an opaque `<img>`), an inline `<svg>` is real, browser-native DOM — the
+   * resolution-independent, self-contained (embedded-font) content that DOM-serializing visual
+   * tools (Percy, Chromatic, Applitools) re-render in their own cloud browsers. Any XML prolog /
+   * doctype is stripped so the `<svg>` element drops straight into HTML5. [storyId] is HTML-escaped
+   * into the title.
+   */
+  fun iframeSvgPage(storyId: String, svgBytes: ByteArray): String {
+    val svg = stripXmlProlog(svgBytes.toString(Charsets.UTF_8))
+    val esc = WebEscaping.htmlEscape(storyId)
+    return buildString {
+      append("<!doctype html>\n")
+      append("<html><head><meta charset=\"utf-8\">\n")
+      append("<title>").append(esc).append(" · compose-preview</title>\n")
+      append("<style>html,body{margin:0;padding:0;background:#fff}svg{display:block}</style>\n")
+      append("</head><body>\n")
+      append(svg)
+      append("\n</body></html>\n")
+    }
+  }
+
+  /**
+   * Drop a leading `<?xml …?>` declaration and `<!DOCTYPE …>` from an SVG document so its `<svg>`
+   * root can be inlined directly into an HTML5 body (HTML5 has no place for an XML prolog).
+   */
+  private fun stripXmlProlog(svg: String): String {
+    var s = svg.trimStart()
+    if (s.startsWith("<?xml")) s = s.substringAfter("?>").trimStart()
+    if (s.startsWith("<!DOCTYPE", ignoreCase = true) || s.startsWith("<!doctype")) {
+      s = s.substringAfter(">").trimStart()
+    }
+    return s
+  }
+
+  /**
    * Sidebar grouping ([Entry.title]) for a native preview id: the enclosing class/file simple name
    * for an FQN (`com.example.PreviewsKt.RedBoxPreview…` → `Previews`, trailing `Kt` dropped), the
    * component slug for a catalog id (`button__dark` → `button`), else the id itself.

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/StorybookCompat.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/StorybookCompat.kt
@@ -161,38 +161,33 @@ object StorybookCompat {
 
   /**
    * The SVG isolation page for `iframe.html?id=<storyId>&format=svg`: the figma-svg export
-   * ([svgBytes] from `/render/<id>.svg`) inlined **as markup** into the document body. Unlike the
-   * PNG page (an opaque `<img>`), an inline `<svg>` is real, browser-native DOM — the
-   * resolution-independent, self-contained (embedded-font) content that DOM-serializing visual
-   * tools (Percy, Chromatic, Applitools) re-render in their own cloud browsers. Any XML prolog /
-   * doctype is stripped so the `<svg>` element drops straight into HTML5. [storyId] is HTML-escaped
-   * into the title.
+   * ([svgBytes] from `/render/<id>.svg`) embedded as an **`<img>` with a `data:image/svg+xml` URI**
+   * — a still-**vector**, resolution-independent render that the DOM-serializing visual tools
+   * (Percy, Chromatic, Applitools) re-render in their own cloud browsers, unlike the
+   * fixed-resolution raster PNG page.
+   *
+   * **Deliberately an `<img>`, not inline `<svg>` markup** (security): a serve host can hand back
+   * the `figma/<slug>.svg` bytes of an *unverified* catalog (repo-controlled, unsanitised —
+   * `ServeCatalogStore.fetchFigmaSvgs`). Inlining that as markup into a same-origin document would
+   * let a hostile SVG run `<script>` / `on*` handlers. SVG referenced through `<img>` is processed
+   * in the browser's restricted mode — no script execution, no external fetches, everywhere
+   * including the downstream tool's browser — so untrusted bytes are inert while still rendering as
+   * vector. The bytes are base64'd verbatim (no need to strip the XML prolog for a data URI).
+   * [storyId] is HTML-escaped into the title/alt.
    */
   fun iframeSvgPage(storyId: String, svgBytes: ByteArray): String {
-    val svg = stripXmlProlog(svgBytes.toString(Charsets.UTF_8))
+    val b64 = Base64.getEncoder().encodeToString(svgBytes)
     val esc = WebEscaping.htmlEscape(storyId)
     return buildString {
       append("<!doctype html>\n")
       append("<html><head><meta charset=\"utf-8\">\n")
       append("<title>").append(esc).append(" · compose-preview</title>\n")
-      append("<style>html,body{margin:0;padding:0;background:#fff}svg{display:block}</style>\n")
+      append("<style>html,body{margin:0;padding:0;background:#fff}img{display:block}</style>\n")
       append("</head><body>\n")
-      append(svg)
-      append("\n</body></html>\n")
+      append("<img alt=\"").append(esc).append("\" src=\"data:image/svg+xml;base64,")
+      append(b64).append("\">\n")
+      append("</body></html>\n")
     }
-  }
-
-  /**
-   * Drop a leading `<?xml …?>` declaration and `<!DOCTYPE …>` from an SVG document so its `<svg>`
-   * root can be inlined directly into an HTML5 body (HTML5 has no place for an XML prolog).
-   */
-  private fun stripXmlProlog(svg: String): String {
-    var s = svg.trimStart()
-    if (s.startsWith("<?xml")) s = s.substringAfter("?>").trimStart()
-    if (s.startsWith("<!DOCTYPE", ignoreCase = true) || s.startsWith("<!doctype")) {
-      s = s.substringAfter(">").trimStart()
-    }
-    return s
   }
 
   /**

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
@@ -238,4 +238,11 @@ class ServeHttpRoutingTest {
     assertEquals(400, get("/compose-m3/iframe.html").first)
     assertEquals(404, get("/compose-m3/iframe.html?id=no.such.Story").first)
   }
+
+  @Test
+  fun `iframe_html format svg 404s on a static bundle`() {
+    // The SVG lane inlines the figma-svg export, which only a daemon-backed host produces; a static
+    // ServeBundleHost 404s it just like the /render/<id>.svg lane does.
+    assertEquals(404, get("/compose-m3/iframe.html?id=$previewId&format=svg").first)
+  }
 }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/StorybookCompatTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/StorybookCompatTest.kt
@@ -127,20 +127,20 @@ class StorybookCompatTest {
   }
 
   @Test
-  fun `iframe svg page inlines the svg markup as real dom and strips the xml prolog`() {
+  fun `iframe svg page embeds the vector as an inert svg image not inline markup`() {
+    // A hostile SVG (e.g. from an unverified catalog) must not run when the page is opened. Serving
+    // it via <img src=data:image/svg+xml> keeps it in the browser's restricted (non-scripting)
+    // mode.
     val svg =
-      "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+      "<?xml version=\"1.0\"?>\n" +
         "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"10\" height=\"4\">" +
-        "<rect width=\"10\" height=\"4\"/></svg>"
+        "<script>alert(1)</script><rect width=\"10\" height=\"4\"/></svg>"
     val page = StorybookCompat.iframeSvgPage("main--greeting", svg.toByteArray())
     assertTrue(page.startsWith("<!doctype html>"), "is an html document")
-    assertTrue(
-      page.contains("<svg xmlns=\"http://www.w3.org/2000/svg\""),
-      "inlines the svg root as markup: $page",
-    )
-    assertTrue(!page.contains("<?xml"), "strips the xml prolog: $page")
-    // Inline DOM, not an opaque image element — that's the whole point for DOM-capture tools.
-    assertTrue(!page.contains("data:image"), "not embedded as an image: $page")
+    assertTrue(page.contains("src=\"data:image/svg+xml;base64,"), "embeds as an svg image: $page")
+    // The raw SVG (and any embedded <script>) is base64'd inside the data URI — never live markup.
+    assertTrue(!page.contains("<svg"), "no inline svg markup in the document: $page")
+    assertTrue(!page.contains("<script>alert"), "no live script from the svg: $page")
     assertTrue(page.contains("main--greeting"), "labels with the story id")
   }
 }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/StorybookCompatTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/StorybookCompatTest.kt
@@ -125,4 +125,22 @@ class StorybookCompatTest {
     assertTrue(page.contains("width=\"24\" height=\"8\""), "sizes to the png dimensions: $page")
     assertTrue(page.contains("main--greeting"), "labels with the story id")
   }
+
+  @Test
+  fun `iframe svg page inlines the svg markup as real dom and strips the xml prolog`() {
+    val svg =
+      "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+        "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"10\" height=\"4\">" +
+        "<rect width=\"10\" height=\"4\"/></svg>"
+    val page = StorybookCompat.iframeSvgPage("main--greeting", svg.toByteArray())
+    assertTrue(page.startsWith("<!doctype html>"), "is an html document")
+    assertTrue(
+      page.contains("<svg xmlns=\"http://www.w3.org/2000/svg\""),
+      "inlines the svg root as markup: $page",
+    )
+    assertTrue(!page.contains("<?xml"), "strips the xml prolog: $page")
+    // Inline DOM, not an opaque image element — that's the whole point for DOM-capture tools.
+    assertTrue(!page.contains("data:image"), "not embedded as an image: $page")
+    assertTrue(page.contains("main--greeting"), "labels with the story id")
+  }
 }

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -343,9 +343,15 @@ in remote-URL mode) can crawl a compose-preview `serve` with **no compose-specif
   embedding the freshly-rendered PNG (a `data:` URI on a white ground), which is exactly what a
   screenshot tool captures. Accepts the same override query params as `/render` (e.g. `&uiMode=dark`),
   and also accepts a raw native preview id as `id=` for hand-authored deep links.
+  - `&format=svg` inlines the figma-svg export **as `<svg>` markup** instead of a raster `<img>`.
+    That's real, resolution-independent, self-contained (embedded-font) DOM, so the **DOM-capture**
+    visual tools (Percy, Chromatic, Applitools) — which serialize the page's DOM and re-render it in
+    their own cloud browsers — have something faithful to work with, not an opaque bitmap. SVG is
+    produced by a daemon-backed session only, so a static bundle 404s this lane (like `/render.svg`).
 
 Both come in the `?session=` and path (`/{system}/index.json`, `/{system}/iframe.html`) forms like the
 rest, and follow the same token gate: open in `--public` mode, otherwise `?token=` is required (pass it
-through your visual tool's URL, or run the server `--public` on a trusted network). DOM-capture tools
-(Percy, Chromatic, Applitools) that re-render captured DOM in cloud browsers are **not** a fit — a
-compose preview is a raster image, not a DOM tree; target the pixel-diff tools instead.
+through your visual tool's URL, or run the server `--public` on a trusted network). Which tools fit:
+**pixel-diff** tools (BackstopJS, storycap/reg-suit, jest-image-snapshot) consume the default PNG page;
+**DOM-capture** tools (Percy, Chromatic, Applitools) consume `&format=svg` — a Compose render has no
+HTML DOM of its own, but the vector export gives those tools a browser-native DOM to re-render.

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -343,11 +343,15 @@ in remote-URL mode) can crawl a compose-preview `serve` with **no compose-specif
   embedding the freshly-rendered PNG (a `data:` URI on a white ground), which is exactly what a
   screenshot tool captures. Accepts the same override query params as `/render` (e.g. `&uiMode=dark`),
   and also accepts a raw native preview id as `id=` for hand-authored deep links.
-  - `&format=svg` inlines the figma-svg export **as `<svg>` markup** instead of a raster `<img>`.
-    That's real, resolution-independent, self-contained (embedded-font) DOM, so the **DOM-capture**
-    visual tools (Percy, Chromatic, Applitools) — which serialize the page's DOM and re-render it in
-    their own cloud browsers — have something faithful to work with, not an opaque bitmap. SVG is
-    produced by a daemon-backed session only, so a static bundle 404s this lane (like `/render.svg`).
+  - `&format=svg` serves the figma-svg export as an **inert `<img src="data:image/svg+xml">`**
+    instead of the raster PNG. That's a still-**vector**, resolution-independent render, so the
+    **DOM-capture** visual tools (Percy, Chromatic, Applitools) — which serialize the page and
+    re-render it in their own cloud browsers — get faithful vector output, not a fixed-resolution
+    bitmap. It's an `<img>` (not inline `<svg>`) on purpose: a serve host can return an *unverified*
+    catalog's repo-controlled SVG, and SVG referenced through `<img>` is processed in the browser's
+    restricted, non-scripting mode — so untrusted bytes can't execute, here or in the downstream
+    tool's browser. SVG is produced by a daemon-backed session only, so a static bundle 404s this
+    lane (like `/render.svg`).
 
 Both come in the `?session=` and path (`/{system}/index.json`, `/{system}/iframe.html`) forms like the
 rest, and follow the same token gate: open in `--public` mode, otherwise `?token=` is required (pass it


### PR DESCRIPTION
## Summary

Adds a vector lane to the Storybook-compatible `iframe.html` surface: **`GET /iframe.html?id=<storyId>&format=svg`** serves the figma-svg export as an **inert ``'&lt;img src="data:image/svg+xml;base64,…"&gt;'``** instead of the default raster PNG.

That's the piece that unblocks the **DOM-capture** half of the Storybook visual-tool ecosystem — Percy, Chromatic, Applitools — which I'd explicitly written off in the `/index.json` + `iframe.html` PR (#2, merged). Those tools serialize the page and re-render it in their own cloud browsers; a fixed-resolution PNG gives them nothing to work with, but an SVG is a **browser-rendered, resolution-independent vector**. This became worth doing now that SVG-export fidelity has improved (the `FigmaFidelity` harness + font embedding).

**pixel-diff** tools (BackstopJS, storycap/reg-suit, jest-image-snapshot) keep consuming the default PNG page; **DOM-capture** tools use `&format=svg`.

## Design

- Reuses the existing `renderHost.renderSvg(...)` (the `/render/<id>.svg` figma-svg lane) + the shared render semaphore for load-shedding. No new render path.
- **Served as an `<img>`, not inline `<svg>` markup — for security.** A serve host can return the `figma/<slug>.svg` bytes of an *unverified* catalog (repo-controlled, unsanitised via `ServeCatalogStore.fetchFigmaSvgs`); inlining that as markup into a same-origin document would let a hostile SVG run `<script>`/`on*` handlers (P1 flagged in review). SVG referenced through `<img>` is processed in the browser's restricted, non-scripting mode — no scripts, no external fetches — everywhere including the downstream tool's browser, so untrusted bytes are inert while still rendering as vector. New pure `StorybookCompat.iframeSvgPage` base64s the bytes into the `data:` URI.
- **SVG is daemon-only** (a static bundle has no figma-svg export), so that lane 404s on a bundle host exactly like `/render/<id>.svg` — the default PNG lane still works everywhere.
- Same token gate, override query params (`&uiMode=dark`, …), and `?session=` / `/{system}/` forms as the rest of the surface.

## Test plan

- [x] `:cli:test StorybookCompatTest` — `iframeSvgPage` embeds the vector via `data:image/svg+xml` and inlines **no** live `<svg>`/`<script>` in the document (a `<script>` in the input SVG stays base64'd, inert).
- [x] `:cli:test ServeHttpRoutingTest` — `iframe.html?id=…&format=svg` 404s on a static bundle (the daemon-only SVG lane); the existing PNG-lane / index.json cases stay green.
- [x] `:cli:compileKotlin` + `:cli:ktfmtFormat` clean.

## Review

- P1 XSS (inline SVG markup) → fixed by the inert-`<img>` approach above (edc38914).
- CI: the `homeassistant-remotecompose` failure on the first commit was an infra flake (`Unable to download artifact(s): (403) Forbidden`), unrelated to this serve-layer change; the security-fix push re-runs CI.

## Visual evidence

Non-visual change — an HTTP container swap around content the figma-svg pipeline already produces (fidelity-covered by `FigmaFidelity` and the `/render/<id>.svg` lane); this PR renders no new preview pixels.