### PR TITLE
feat(design-artifacts): emit Figma Code Connect mappings from the catalog export

### DIFF
--- a/docs/design/UI_BUILDER.md
+++ b/docs/design/UI_BUILDER.md
@@ -267,7 +267,7 @@ Figma MCP server — real Compose, mapped to the assembled nodes.
 |---|---|---|---|
 | **1** | `PreviewSlot`-ify the scaffold templates (Gap 1). | days | "Pick a scaffold, fill its slots" through the existing plugin flow — no new UI. |
 | **2** | `screen.json` schema + `POST/GET /screens/<name>` on `compose-preview serve`; figma-plugin reads a saved composition (Gap 2). | 1–2 wks | Surface (c): compositions are saved, shared, referenced, rendered as a whole, inserted into Figma. Durable beyond one canvas. |
-| **3** | Stamp stable `ref` onto figma-svg groups (Gap 3); emit **Code Connect** mappings. | ~1 wk | Lossless composition ↔ Figma-node round-trip; screens surface in Dev Mode / MCP. |
+| **3** | Stamp stable `ref` onto figma-svg groups (Gap 3); ~~emit **Code Connect** mappings~~ **done** — the catalog export writes `code-connect.json` per component ([scripts/design-artifacts/docs/code-connect.md](../../scripts/design-artifacts/docs/code-connect.md)); `publish-code-connect.mjs` resolves node ids + emits the `send_code_connect_mappings` payload. | ~1 wk | Lossless composition ↔ Figma-node round-trip; screens surface in Dev Mode / MCP. |
 | **4** | `screen.json` → real `Scaffold(...)` Compose codegen (Gap 4). | 2–3 wks | The dream: assembled screen → idiomatic Compose using real slots. |
 
 **Interop, not reinvention, at the edges:** keep emitting **DTCG tokens**

--- a/scripts/design-artifacts/docs/code-connect.md
+++ b/scripts/design-artifacts/docs/code-connect.md
@@ -1,0 +1,82 @@
+# Figma Code Connect from the design-catalog
+
+The design-catalog export already pushes editable, layered Figma vectors (`figma/<slug>.svg`) onto
+each `design-artifacts/<system>` branch. **Code Connect** is the complementary binding: it makes
+Figma's Dev Mode (and the Figma MCP that grounds design-to-code agents) show *your* Compose component
+for a selected design node, instead of an auto-generated snippet.
+
+This repo emits the mapping; a designer imports the catalog; you publish. Publishing the records
+requires a Figma **Org/Enterprise** plan with a **Dev/Full** seat — but *emitting* and *resolving* the
+mapping are plan-agnostic, so the manifest ships on every branch and you can dry-run resolution on any
+plan.
+
+## What gets emitted
+
+`generate-design-catalog.mjs` writes `code-connect.json` at the bundle root, next to `catalog.json`
+and the `figma/` vectors. One entry per catalog component:
+
+```jsonc
+{
+  "system": "meshcore-mobile",
+  "title": "MeshCore Mobile",
+  "label": "Compose",
+  "source": { "repo": "yschimke/meshcore-mobile", "ref": "main", "module": ":app" },
+  "generatedAt": "…",
+  "mappings": [
+    {
+      "componentId": "DeviceSummaryCard/Populated",     // catalog id
+      "figmaLayerName": "DeviceSummaryCard/Populated",   // the Figma frame name = the join key
+      "componentName": "DeviceSummaryCardPopulatedPreview", // the @Preview that renders the sticker
+      "source": "https://github.com/…/blob/main/app/…/ComponentPreviews.kt",
+      "label": "Compose",
+      "figmaSvg": "figma/devicesummarycard-populated.svg"
+    }
+  ]
+}
+```
+
+The one thing it can't carry is the Figma **node id** — that only exists once the catalog is imported
+into a file. So the manifest keys on `figmaLayerName` (= `componentId`, the name the design-parity
+importer gives each frame) and the node id is resolved at publish time.
+
+Join sources (all already in the pipeline):
+
+- `componentId` → the Figma frame name (from the catalog spec / importer).
+- `componentId` → `@Preview` function (`fnByComponentId`, from `catalog.spec.json`).
+- `--source-repo` / `--source-ref` / `--source-module` → the GitHub `source` URL. When the bundle
+  carried a per-preview `sourceFile`, the URL points at the exact file; otherwise at the module dir.
+
+## Publishing (Org/Enterprise)
+
+1. **Import** the catalog into a Figma design file. The frames must be named by `componentId`
+   (the design-parity catalog import does this; it is the same board the public preview server shows).
+2. **Resolve** layer names → node ids and build the send payload:
+
+   ```
+   FIGMA_TOKEN=<pat> node scripts/design-artifacts/publish-code-connect.mjs \
+     --manifest <branch>/code-connect.json \
+     --file 'https://www.figma.com/design/<fileKey>/…' \
+     --out send-mappings.json
+   ```
+
+   The token only needs **read** access (the walk uses `GET /v1/files/:key`), so this step runs on any
+   plan. Unresolved names (a component not on the board) and ambiguous names (the same component twice)
+   are reported; the rest are bound.
+
+3. **Publish** the resolved mappings. `send-mappings.json` is the exact argument object for Figma's
+   `send_code_connect_mappings` MCP tool — hand it to an agent connected to the Figma MCP, or feed the
+   same mappings to `figma connect`. This is the step gated to an Org/Enterprise Dev/Full seat.
+
+## Reviewing before publish
+
+`componentName`/`source` point at the `@Preview` that renders the sticker. Where a catalog preview is
+a thin wrapper around a production component, retarget it to the underlying component before
+publishing — `get_code_connect_suggestions` is a good cross-check. Node-id resolution is deterministic
+and re-runnable, so re-resolving after the board changes is cheap.
+
+## Why this pairs with the render pipeline
+
+Code Connect's own weak spot is drift: when a design changes, its mapping silently rots and it has no
+way to notice. This repo *does* — it re-renders every component and diffs it. So the same branch that
+carries the Code Connect mapping also carries the rendered PNG + the `compare.html` PNG-vs-SVG score,
+which is the drift signal Code Connect can't produce on its own.

--- a/scripts/design-artifacts/figma-code-connect-emit.mjs
+++ b/scripts/design-artifacts/figma-code-connect-emit.mjs
@@ -1,0 +1,113 @@
+/**
+ * Emit a `code-connect.json` manifest alongside the layered `figma/<slug>.svg` vectors on a
+ * design-catalog delivery branch.
+ *
+ * The catalog already carries everything Figma Code Connect needs *except* the Figma node id:
+ * - `component.componentId` (e.g. `DeviceSummaryCard/Populated`) is the name the design-parity
+ *   importer gives the Figma frame — so it is a stable join key from a mapping to a node.
+ * - the catalog spec maps each componentId to the `@Preview` function that renders the sticker
+ *   (`fnByComponentId`), which is the Compose symbol Code Connect should point at.
+ * - the catalog's `--source-repo` / `--source-ref` / `--source-module` (already plumbed through
+ *   `generate-design-catalog.mjs` as `manifest.source`) give the repo + ref to build a source URL.
+ *
+ * Node ids only exist *after* a designer imports the catalog into a Figma file, so this manifest is
+ * keyed by `figmaLayerName` (= componentId) and the node id is resolved at publish time — see
+ * `publish-code-connect.mjs`, which matches these names against an imported file's layer tree and
+ * produces the `send_code_connect_mappings` payload.
+ *
+ * Pure and deterministic (data in, manifest out — no IO), so the driver can unit-test the join
+ * without running the full export. Publishing itself requires a Figma Org/Enterprise plan with a
+ * Dev/Full seat; emitting the manifest does not, so every catalog carries it.
+ */
+
+/** Code Connect framework/label for a Compose catalog. Matches Figma's `send_code_connect_mappings`
+ *  label enum. */
+export const COMPOSE_LABEL = "Compose";
+
+/**
+ * Resolve a mapping's `source` string — the location Code Connect points at for the component.
+ *
+ * Prefers a GitHub blob URL (matching the `codeConnectSrc` form Figma's `get_code_connect_map`
+ * returns, e.g. `https://github.com/owner/repo/blob/<ref>/<path>`) when the repo + ref + a source
+ * file are known. Falls back to a repo-relative path, then to the bare module. `sourceFile` is
+ * module-root-relative (as discovery records it), so it is prefixed with the module directory
+ * (`:app` → `app`, `:foo:bar` → `foo/bar`) to become repo-relative.
+ */
+export function resolveSource({ repo, ref, module, sourceFile } = {}) {
+  const moduleDir = module ? String(module).replace(/^:/, "").replaceAll(":", "/") : "";
+  const path = sourceFile ? (moduleDir ? `${moduleDir}/${sourceFile}` : sourceFile) : moduleDir;
+  if (repo && ref && path) return `https://github.com/${repo}/blob/${ref}/${path}`;
+  if (path) return path;
+  return module ? String(module) : "";
+}
+
+/**
+ * Build the `code-connect.json` manifest object.
+ *
+ * @param components   catalog components (each with a `componentId`).
+ * @param fnByComponentId Map componentId → `@Preview` function name (from the catalog spec).
+ * @param slug         componentId → slug (the same `slug()` the figma-svg emit uses), so a mapping
+ *                     can link its editable vector at `figma/<slug>.svg`.
+ * @param figmaSvgSlugs Set of slugs that actually carried a `figma/<slug>.svg` (so only real files
+ *                     are linked).
+ * @param sourceByFn   optional Map function → `{ sourceFile }` lifted from the bundle, so a mapping
+ *                     can point at the exact preview source file rather than the bare module.
+ * @param system/title system id + title, copied onto the manifest for provenance.
+ * @param source       `{ repo, ref, module }` — the catalog's buildable-source pointer.
+ * @param label        Code Connect label (default {@link COMPOSE_LABEL}).
+ * @param generatedAt  ISO timestamp (injected by the caller so the pure builder stays deterministic).
+ * @returns `{ system, title?, label, source, generatedAt?, mappings }`. A component whose preview
+ *   function is unknown (not in the spec join) is skipped — there is nothing to point Code Connect at.
+ */
+export function buildCodeConnectManifest({
+  components = [],
+  fnByComponentId,
+  slug,
+  figmaSvgSlugs,
+  sourceByFn,
+  system,
+  title,
+  source = {},
+  label = COMPOSE_LABEL,
+  generatedAt,
+} = {}) {
+  const mappings = [];
+  for (const component of components) {
+    const componentId = component.componentId;
+    const fn = fnByComponentId?.get(componentId);
+    // No preview function ⇒ no code symbol to bind; skip rather than emit a dangling mapping.
+    if (!fn) continue;
+    const sourceFile = sourceByFn?.get(fn)?.sourceFile;
+    const mapping = {
+      componentId,
+      // The Figma layer name a node must carry to receive this mapping. The design-parity importer
+      // names each frame by componentId, so this is that name verbatim — resolved to a node id at
+      // publish time.
+      figmaLayerName: componentId,
+      componentName: fn,
+      source: resolveSource({ repo: source.repo, ref: source.ref, module: source.module, sourceFile }),
+      label,
+    };
+    const s = slug?.(componentId);
+    if (s && figmaSvgSlugs?.has(s)) mapping.figmaSvg = `figma/${s}.svg`;
+    mappings.push(mapping);
+  }
+
+  const manifest = {
+    system,
+    ...(title ? { title } : {}),
+    label,
+    source: {
+      ...(source.repo ? { repo: source.repo } : {}),
+      ...(source.ref ? { ref: source.ref } : {}),
+      ...(source.module ? { module: source.module } : {}),
+    },
+    ...(generatedAt ? { generatedAt } : {}),
+    // Publishing turns these into Figma Code Connect records via `send_code_connect_mappings`
+    // (or `figma connect`); it needs an Org/Enterprise plan + a Dev/Full seat. Review the
+    // componentName/source before publishing — where a catalog `preview` is a thin wrapper, retarget
+    // it to the underlying component.
+    mappings,
+  };
+  return manifest;
+}

--- a/scripts/design-artifacts/figma-code-connect-emit.test.mjs
+++ b/scripts/design-artifacts/figma-code-connect-emit.test.mjs
@@ -1,0 +1,113 @@
+/**
+ * Unit tests for the Figma Code Connect emit join: componentId → `@Preview` function + repo source,
+ * keyed by the Figma layer name so `publish-code-connect.mjs` can resolve node ids later.
+ *
+ * Run with `node --test scripts/design-artifacts/`.
+ */
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  COMPOSE_LABEL,
+  buildCodeConnectManifest,
+  resolveSource,
+} from "./figma-code-connect-emit.mjs";
+
+test("resolveSource builds a GitHub blob URL from repo + ref + module-relative source file", () => {
+  const url = resolveSource({
+    repo: "yschimke/meshcore-mobile",
+    ref: "main",
+    module: ":app",
+    sourceFile: "src/main/kotlin/ee/schimke/meshcore/app/ui/ComponentPreviews.kt",
+  });
+  assert.equal(
+    url,
+    "https://github.com/yschimke/meshcore-mobile/blob/main/app/src/main/kotlin/ee/schimke/meshcore/app/ui/ComponentPreviews.kt",
+  );
+});
+
+test("resolveSource maps a nested module id to a path segment", () => {
+  const url = resolveSource({
+    repo: "o/r",
+    ref: "v1",
+    module: ":features:home",
+    sourceFile: "Foo.kt",
+  });
+  assert.equal(url, "https://github.com/o/r/blob/v1/features/home/Foo.kt");
+});
+
+test("resolveSource falls back to the module directory when no source file is known", () => {
+  assert.equal(resolveSource({ repo: "o/r", ref: "main", module: ":app" }), "https://github.com/o/r/blob/main/app");
+  // No repo/ref ⇒ a bare repo-relative path, still useful for review.
+  assert.equal(resolveSource({ module: ":app", sourceFile: "Foo.kt" }), "app/Foo.kt");
+  // Nothing at all ⇒ empty string, never a broken URL.
+  assert.equal(resolveSource({}), "");
+});
+
+const slug = (id) => id.toLowerCase().replaceAll("/", "-");
+
+test("buildCodeConnectManifest maps each component to its preview function and layer name", () => {
+  const manifest = buildCodeConnectManifest({
+    components: [{ componentId: "DeviceSummaryCard/Populated" }, { componentId: "ContactRow/Variants" }],
+    fnByComponentId: new Map([
+      ["DeviceSummaryCard/Populated", "DeviceSummaryCardPopulatedPreview"],
+      ["ContactRow/Variants", "ContactRowVariantsPreview"],
+    ]),
+    slug,
+    figmaSvgSlugs: new Set(["devicesummarycard-populated"]),
+    sourceByFn: new Map([
+      ["DeviceSummaryCardPopulatedPreview", { sourceFile: "src/DeviceBodyPreviews.kt" }],
+    ]),
+    system: "meshcore-mobile",
+    title: "MeshCore Mobile",
+    source: { repo: "yschimke/meshcore-mobile", ref: "main", module: ":app" },
+    generatedAt: "2026-07-17T00:00:00.000Z",
+  });
+
+  assert.equal(manifest.system, "meshcore-mobile");
+  assert.equal(manifest.label, COMPOSE_LABEL);
+  assert.equal(manifest.source.repo, "yschimke/meshcore-mobile");
+  assert.equal(manifest.mappings.length, 2);
+
+  const device = manifest.mappings[0];
+  assert.equal(device.componentId, "DeviceSummaryCard/Populated");
+  // The layer name a Figma node must carry to receive this mapping = componentId verbatim.
+  assert.equal(device.figmaLayerName, "DeviceSummaryCard/Populated");
+  assert.equal(device.componentName, "DeviceSummaryCardPopulatedPreview");
+  assert.equal(
+    device.source,
+    "https://github.com/yschimke/meshcore-mobile/blob/main/app/src/DeviceBodyPreviews.kt",
+  );
+  assert.equal(device.label, "Compose");
+  // Only components that carried a figma-svg get a vector link.
+  assert.equal(device.figmaSvg, "figma/devicesummarycard-populated.svg");
+  assert.equal(manifest.mappings[1].figmaSvg, undefined);
+});
+
+test("buildCodeConnectManifest skips components with no preview function (nothing to bind)", () => {
+  const manifest = buildCodeConnectManifest({
+    components: [{ componentId: "Known/One" }, { componentId: "Orphan/Two" }],
+    fnByComponentId: new Map([["Known/One", "KnownOnePreview"]]),
+    slug,
+    figmaSvgSlugs: new Set(),
+    system: "s",
+    source: {},
+  });
+  assert.equal(manifest.mappings.length, 1);
+  assert.equal(manifest.mappings[0].componentId, "Known/One");
+});
+
+test("buildCodeConnectManifest omits generatedAt and empty source fields when absent", () => {
+  const manifest = buildCodeConnectManifest({
+    components: [{ componentId: "A/B" }],
+    fnByComponentId: new Map([["A/B", "AbPreview"]]),
+    slug,
+    figmaSvgSlugs: new Set(),
+    system: "s",
+    source: {},
+  });
+  assert.equal(manifest.generatedAt, undefined);
+  assert.deepEqual(manifest.source, {});
+  // Falls back to an empty source string rather than a broken URL when nothing is known.
+  assert.equal(manifest.mappings[0].source, "");
+});

--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -52,6 +52,7 @@ import {
   figmaSvgByFunction,
   rewriteRasterHrefs,
 } from "./figma-svg-emit.mjs";
+import { buildCodeConnectManifest } from "./figma-code-connect-emit.mjs";
 import { renderWireframeSvg, slug } from "./render-wireframe-svg.mjs";
 import { renderLayoutWireframeSvg } from "./render-layout-wireframe-svg.mjs";
 import { DEFAULT_PREVIEW_BASE, livePreviewUrl } from "./live-preview.mjs";
@@ -124,6 +125,25 @@ function layoutByFunction(bundle) {
   return out;
 }
 
+
+/**
+ * Build a `functionName → { sourceFile }` lookup from the bundle's previews, so a Code Connect
+ * mapping can point at the exact `@Preview` source file rather than the bare module. `sourceFile`
+ * (module-root-relative) is carried per preview when discovery recorded it; prefer the light variant
+ * for a deterministic pick, and fall through to `undefined` when no variant carried a path (the
+ * mapping then falls back to the module directory).
+ */
+function sourceByFunction(bundle) {
+  const out = new Map();
+  const prefer = (id) => /(_|\b)light$/i.test(id);
+  for (const preview of bundle.previews ?? []) {
+    const fn = preview.functionName ?? preview.id;
+    if (out.has(fn) && !prefer(preview.id)) continue;
+    if (preview.sourceFile) out.set(fn, { sourceFile: preview.sourceFile });
+    else if (!out.has(fn)) out.set(fn, { sourceFile: undefined });
+  }
+  return out;
+}
 
 /** Drop `widthDp`/`heightDp` when serialized as JSON null so the published
  *  normalizeSize doesn't `.trim()` a null. */
@@ -672,6 +692,37 @@ for (const component of catalog.components) {
   figmaSvgSlugs.add(componentSlug);
   figmaSvgCount += 1;
 }
+
+// Figma Code Connect manifest next to the figma-svg vectors: one mapping per component binding its
+// Figma layer (by componentId) to the `@Preview` function that renders it, plus the repo source. It
+// carries everything `send_code_connect_mappings` needs except the node id, which only exists once a
+// designer imports the catalog — `publish-code-connect.mjs` resolves layer-name → node id against
+// the imported file and produces the send payload. Emitting the manifest is plan-agnostic; only
+// publishing needs an Org/Enterprise Dev/Full seat. Written for every catalog so the surface is
+// covered automatically.
+const codeConnect = buildCodeConnectManifest({
+  components: catalog.components,
+  fnByComponentId,
+  slug,
+  figmaSvgSlugs,
+  sourceByFn: sourceByFunction(bundle),
+  system: spec.system,
+  title: spec.title,
+  source: {
+    repo: values["source-repo"],
+    ref: values["source-ref"],
+    module: values["source-module"],
+  },
+  generatedAt: new Date().toISOString(),
+});
+await writeFile(
+  join(outPath, "code-connect.json"),
+  `${JSON.stringify(codeConnect, null, 2)}\n`,
+  "utf8",
+);
+console.log(
+  `[${spec.system}] code-connect → ${codeConnect.mappings.length} mapping(s) (code-connect.json)`,
+);
 
 // Browsable index next to catalog.json + images/ — a designer can open this
 // straight from the branch to skim every component (its a11y greenlines and the

--- a/scripts/design-artifacts/publish-code-connect.mjs
+++ b/scripts/design-artifacts/publish-code-connect.mjs
@@ -148,6 +148,19 @@ async function main() {
     console.warn(`[code-connect] "${a.name}" matched ${a.ids.length} nodes; using ${a.ids[0]}`);
   }
 
+  // Nothing resolved ⇒ every layer name was absent (wrong file, or the board's frames were renamed).
+  // A `send_code_connect_mappings` payload needs at least one real node id — the top-level `nodeId` is
+  // required — so writing one with an empty anchor + no mappings would be a success-looking invalid
+  // artifact. Fail loudly instead of emitting it.
+  if (resolved.length === 0) {
+    console.error(
+      `[code-connect] resolved 0/${manifest.mappings?.length ?? 0} mapping(s) in file ${fileKey} — ` +
+        "no layer names matched. Check the file is the imported catalog and its frames are named by " +
+        "componentId. Nothing written.",
+    );
+    process.exit(1);
+  }
+
   const payload = toSendMappingsPayload(fileKey, resolved);
   const json = `${JSON.stringify(payload, null, 2)}\n`;
   if (values.out) {

--- a/scripts/design-artifacts/publish-code-connect.mjs
+++ b/scripts/design-artifacts/publish-code-connect.mjs
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+/**
+ * Resolve a `code-connect.json` manifest (emitted by `figma-code-connect-emit.mjs`) against a Figma
+ * file's layer tree and produce the `send_code_connect_mappings` payload — the last mile that binds
+ * each Compose component to a real Figma node id.
+ *
+ * Two-step flow:
+ *   1. export     generate-design-catalog.mjs writes code-connect.json onto design-artifacts/<system>
+ *   2. import     a designer imports that catalog into a Figma file (frames named by componentId)
+ *   3. publish    THIS script resolves componentId → nodeId and emits the mappings payload
+ *
+ *   node scripts/design-artifacts/publish-code-connect.mjs \
+ *     --manifest <path to code-connect.json> \
+ *     --file <figma file key or /design/ URL> \
+ *     --out   <path to write send-mappings.json>   # else printed to stdout
+ *
+ * Node-name resolution uses the Figma REST API (`GET /v1/files/:key`, `X-Figma-Token: $FIGMA_TOKEN`)
+ * — which any readable file allows. The resulting `send-mappings.json` is the exact argument object
+ * for Figma's MCP `send_code_connect_mappings` tool (or feed the same mappings to `figma connect`).
+ * **Actually creating the Code Connect records requires a Figma Org/Enterprise plan with a Dev/Full
+ * seat** — this script only prepares the payload, so it is safe to run (and test the resolution) on
+ * any plan.
+ *
+ * The tree-walk, name index, and payload shaping are pure functions (unit-tested); only the REST
+ * fetch + file IO live in the CLI shell at the bottom.
+ */
+import { readFile, writeFile } from "node:fs/promises";
+import { parseArgs } from "node:util";
+
+/** Extract a Figma file key from a bare key or a `figma.com/design/:key/...` URL. */
+export function fileKeyFromArg(arg) {
+  if (!arg) return null;
+  const m = String(arg).match(/\/design\/([A-Za-z0-9]+)/);
+  return m ? m[1] : String(arg);
+}
+
+/**
+ * Index every node in a Figma file document by its layer `name` → list of node ids, walking the
+ * `document.children` tree (pages → frames → …). A name can repeat (the catalog wraps each sticker
+ * in a `Card: <id>` frame that contains the bare `<id>` frame), so ids are collected into an array
+ * and the caller decides how to disambiguate.
+ */
+export function indexNodesByName(document) {
+  const byName = new Map();
+  const visit = (node) => {
+    if (!node || typeof node !== "object") return;
+    if (typeof node.name === "string" && node.id) {
+      const ids = byName.get(node.name);
+      if (ids) ids.push(node.id);
+      else byName.set(node.name, [node.id]);
+    }
+    for (const child of node.children ?? []) visit(child);
+  };
+  visit(document);
+  return byName;
+}
+
+/**
+ * Resolve each manifest mapping's `figmaLayerName` to a node id via [nameIndex].
+ *
+ * Returns `{ resolved, unresolved, ambiguous }`:
+ * - `resolved` — mappings that matched exactly one node, each with `nodeId` filled in.
+ * - `unresolved` — mappings whose layer name is absent from the file (nothing to bind).
+ * - `ambiguous` — mappings whose name matched multiple nodes; the FIRST id is used (and the mapping
+ *   still lands in `resolved`), but it is also reported here so the caller can warn. The importer
+ *   names the inner sticker frame and its `Card:` wrapper differently, so an exact componentId match
+ *   is normally unique; a genuine duplicate (the same component twice on the board) is the ambiguous
+ *   case worth surfacing.
+ */
+export function resolveMappings(manifest, nameIndex) {
+  const resolved = [];
+  const unresolved = [];
+  const ambiguous = [];
+  for (const mapping of manifest.mappings ?? []) {
+    const ids = nameIndex.get(mapping.figmaLayerName);
+    if (!ids || ids.length === 0) {
+      unresolved.push(mapping.figmaLayerName);
+      continue;
+    }
+    if (ids.length > 1) ambiguous.push({ name: mapping.figmaLayerName, ids: [...ids] });
+    resolved.push({ ...mapping, nodeId: ids[0] });
+  }
+  return { resolved, unresolved, ambiguous };
+}
+
+/**
+ * Shape resolved mappings into the argument object for Figma's `send_code_connect_mappings` MCP
+ * tool: `{ fileKey, nodeId, mappings: [{ nodeId, componentName, source, label, template? }] }`.
+ * `nodeId` at the top level is required by the tool and set to the first mapping's node (an anchor);
+ * the per-mapping `nodeId`s carry the real bindings.
+ */
+export function toSendMappingsPayload(fileKey, resolved) {
+  const mappings = resolved.map((m) => ({
+    nodeId: m.nodeId,
+    componentName: m.componentName,
+    source: m.source,
+    label: m.label,
+    ...(m.template ? { template: m.template } : {}),
+  }));
+  return {
+    fileKey,
+    nodeId: mappings[0]?.nodeId ?? "",
+    mappings,
+  };
+}
+
+// --- CLI shell ----------------------------------------------------------------
+
+async function fetchFigmaFile(fileKey, token) {
+  const res = await fetch(`https://api.figma.com/v1/files/${fileKey}`, {
+    headers: { "X-Figma-Token": token },
+  });
+  if (!res.ok) {
+    throw new Error(`Figma API ${res.status} ${res.statusText} for file ${fileKey}`);
+  }
+  return res.json();
+}
+
+async function main() {
+  const { values } = parseArgs({
+    options: {
+      manifest: { type: "string" },
+      file: { type: "string" },
+      out: { type: "string" },
+    },
+  });
+  if (!values.manifest || !values.file) {
+    console.error(
+      "usage: publish-code-connect --manifest <code-connect.json> --file <key|/design/ URL> [--out <send-mappings.json>]",
+    );
+    process.exit(2);
+  }
+  const token = process.env.FIGMA_TOKEN;
+  if (!token) {
+    console.error("FIGMA_TOKEN env var is required (a Figma personal access token that can read the file).");
+    process.exit(2);
+  }
+  const manifest = JSON.parse(await readFile(values.manifest, "utf8"));
+  const fileKey = fileKeyFromArg(values.file);
+  const doc = await fetchFigmaFile(fileKey, token);
+  const nameIndex = indexNodesByName(doc.document);
+  const { resolved, unresolved, ambiguous } = resolveMappings(manifest, nameIndex);
+
+  for (const name of unresolved) {
+    console.warn(`[code-connect] no node named "${name}" in file ${fileKey} — skipped`);
+  }
+  for (const a of ambiguous) {
+    console.warn(`[code-connect] "${a.name}" matched ${a.ids.length} nodes; using ${a.ids[0]}`);
+  }
+
+  const payload = toSendMappingsPayload(fileKey, resolved);
+  const json = `${JSON.stringify(payload, null, 2)}\n`;
+  if (values.out) {
+    await writeFile(values.out, json, "utf8");
+    console.log(
+      `[code-connect] resolved ${resolved.length}/${manifest.mappings?.length ?? 0} mapping(s) → ${values.out}`,
+    );
+  } else {
+    process.stdout.write(json);
+  }
+  console.log(
+    "[code-connect] hand this to Figma's send_code_connect_mappings MCP tool (or `figma connect`) " +
+      "on an Org/Enterprise plan to publish.",
+  );
+}
+
+// Only run the CLI when executed directly (not when imported by tests).
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((err) => {
+    console.error(err.message ?? err);
+    process.exit(1);
+  });
+}

--- a/scripts/design-artifacts/publish-code-connect.test.mjs
+++ b/scripts/design-artifacts/publish-code-connect.test.mjs
@@ -1,0 +1,130 @@
+/**
+ * Unit tests for the Code Connect publish resolution: Figma file tree → name index → node-id-bound
+ * mappings → `send_code_connect_mappings` payload. The REST fetch + file IO are a thin shell over
+ * these pure functions and are not exercised here.
+ *
+ * Run with `node --test scripts/design-artifacts/`.
+ */
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  fileKeyFromArg,
+  indexNodesByName,
+  resolveMappings,
+  toSendMappingsPayload,
+} from "./publish-code-connect.mjs";
+
+test("fileKeyFromArg accepts a bare key or a /design/ URL", () => {
+  assert.equal(fileKeyFromArg("gYzowY4cQ7rNr2gYoco1M6"), "gYzowY4cQ7rNr2gYoco1M6");
+  assert.equal(
+    fileKeyFromArg("https://www.figma.com/design/gYzowY4cQ7rNr2gYoco1M6/Name?node-id=0-1"),
+    "gYzowY4cQ7rNr2gYoco1M6",
+  );
+  assert.equal(fileKeyFromArg(null), null);
+});
+
+// A minimal Figma file document: pages → card wrapper → inner sticker frame.
+const doc = {
+  id: "0:0",
+  name: "Document",
+  children: [
+    {
+      id: "0:1",
+      name: "Page 1",
+      children: [
+        {
+          id: "14:22",
+          name: "Card: DeviceSummaryCard/Populated",
+          children: [{ id: "11:6", name: "DeviceSummaryCard/Populated", children: [] }],
+        },
+        {
+          id: "14:32",
+          name: "Card: ContactRow/Variants",
+          children: [{ id: "11:8", name: "ContactRow/Variants", children: [] }],
+        },
+      ],
+    },
+  ],
+};
+
+test("indexNodesByName walks the whole tree and collects ids per name", () => {
+  const index = indexNodesByName(doc);
+  assert.deepEqual(index.get("DeviceSummaryCard/Populated"), ["11:6"]);
+  assert.deepEqual(index.get("Card: ContactRow/Variants"), ["14:32"]);
+  assert.equal(index.get("Nope"), undefined);
+});
+
+test("indexNodesByName collects multiple ids for a repeated name", () => {
+  const dup = {
+    children: [
+      { id: "1", name: "Dup", children: [] },
+      { id: "2", name: "Dup", children: [] },
+    ],
+  };
+  assert.deepEqual(indexNodesByName(dup).get("Dup"), ["1", "2"]);
+});
+
+const manifest = {
+  mappings: [
+    {
+      componentId: "DeviceSummaryCard/Populated",
+      figmaLayerName: "DeviceSummaryCard/Populated",
+      componentName: "DeviceSummaryCardPopulatedPreview",
+      source: "https://github.com/o/r/blob/main/app/Foo.kt",
+      label: "Compose",
+    },
+    {
+      componentId: "Missing/One",
+      figmaLayerName: "Missing/One",
+      componentName: "MissingOnePreview",
+      source: "app",
+      label: "Compose",
+    },
+  ],
+};
+
+test("resolveMappings binds present names to node ids and reports absent ones", () => {
+  const { resolved, unresolved, ambiguous } = resolveMappings(manifest, indexNodesByName(doc));
+  assert.equal(resolved.length, 1);
+  assert.equal(resolved[0].nodeId, "11:6");
+  assert.equal(resolved[0].componentName, "DeviceSummaryCardPopulatedPreview");
+  assert.deepEqual(unresolved, ["Missing/One"]);
+  assert.deepEqual(ambiguous, []);
+});
+
+test("resolveMappings flags an ambiguous name but still binds the first id", () => {
+  const dupDoc = {
+    children: [
+      { id: "a", name: "DeviceSummaryCard/Populated", children: [] },
+      { id: "b", name: "DeviceSummaryCard/Populated", children: [] },
+    ],
+  };
+  const { resolved, ambiguous } = resolveMappings(manifest, indexNodesByName(dupDoc));
+  assert.equal(resolved[0].nodeId, "a");
+  assert.equal(ambiguous.length, 1);
+  assert.deepEqual(ambiguous[0], { name: "DeviceSummaryCard/Populated", ids: ["a", "b"] });
+});
+
+test("toSendMappingsPayload shapes the send_code_connect_mappings argument object", () => {
+  const { resolved } = resolveMappings(manifest, indexNodesByName(doc));
+  const payload = toSendMappingsPayload("FILEKEY", resolved);
+  assert.equal(payload.fileKey, "FILEKEY");
+  // Top-level nodeId is the first mapping's node (an anchor the tool requires).
+  assert.equal(payload.nodeId, "11:6");
+  assert.deepEqual(payload.mappings, [
+    {
+      nodeId: "11:6",
+      componentName: "DeviceSummaryCardPopulatedPreview",
+      source: "https://github.com/o/r/blob/main/app/Foo.kt",
+      label: "Compose",
+    },
+  ]);
+});
+
+test("toSendMappingsPayload passes through a template when present", () => {
+  const payload = toSendMappingsPayload("K", [
+    { nodeId: "1:1", componentName: "X", source: "s", label: "Compose", template: "figma.code`X()`" },
+  ]);
+  assert.equal(payload.mappings[0].template, "figma.code`X()`");
+});


### PR DESCRIPTION
## Summary

Adds a **Figma Code Connect** integration to the design-catalog pipeline, in two plan-agnostic steps (publishing the records is the only Org/Enterprise-gated part).

- **Emit** — `generate-design-catalog.mjs` now writes `code-connect.json` onto every `design-artifacts/<system>` branch, beside the existing `figma/<slug>.svg` vectors. One mapping per component, binding the Figma layer name (`componentId`, the join key) → the `@Preview` that renders it (`componentName`) → a GitHub `source` URL built from the already-plumbed `--source-repo/-ref/-module`. The Figma node id is deliberately absent (it only exists after import), so mappings key on the layer name.
- **Publish** — `publish-code-connect.mjs` resolves those layer names → node ids against an imported Figma file (`GET /v1/files/:key`, read-only) and emits the exact `send_code_connect_mappings` payload. Hand it to the Figma MCP `send_code_connect_mappings` tool or `figma connect` on an Org/Enterprise Dev/Full seat to publish.

New modules keep the pure join/resolve logic testable (following the `figma-svg-emit.mjs` split); only REST fetch + file IO live in the CLI shell.

Files:
- `figma-code-connect-emit.mjs` — pure `buildCodeConnectManifest` + `resolveSource`
- `publish-code-connect.mjs` — pure `indexNodesByName` / `resolveMappings` / `toSendMappingsPayload` + REST CLI
- `generate-design-catalog.mjs` — wire `code-connect.json` emission after the figma-svg loop
- `scripts/design-artifacts/docs/code-connect.md` — the emit→import→publish flow and why it pairs with the render pipeline (drift detection)
- `docs/design/UI_BUILDER.md` — mark the roadmap's "emit Code Connect mappings" step done

Why it pairs with this repo: Code Connect's own weak spot is drift — when a design changes, its mapping silently rots and it can't notice. The same branch that carries the mapping also carries the re-rendered PNG + the `compare.html` PNG-vs-SVG score, which is the drift signal Code Connect can't produce on its own.

Non-visual change (build/data plumbing, docs, tests) — no rendered-surface diff applies.

## Test plan

- [x] `node --test` from `scripts/design-artifacts/` — full suite green (**57 pass, 0 fail**, 13 new).
- [x] `node --check scripts/design-artifacts/generate-design-catalog.mjs` + import smoke of both new modules.
- [x] Real-data join: meshcore-mobile `catalog.spec.json` → 33 mappings, whose `figmaLayerName`s match the live Figma catalog file's actual layer names (e.g. node `11:6` = `DeviceSummaryCard/Populated`), so emit→resolve is proven end-to-end.
- [ ] Publish against an Org/Enterprise file (requires that plan) — resolve step alone is verifiable on any plan.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FnX9TKA4TRpCj3PJhK5M7q)_