### PR TITLE
feat(design-artifacts): map Code Connect to the real composable, not the @Preview

### DIFF
--- a/scripts/design-artifacts/docs/code-connect.md
+++ b/scripts/design-artifacts/docs/code-connect.md
@@ -26,9 +26,11 @@ and the `figma/` vectors. One entry per catalog component:
     {
       "componentId": "DeviceSummaryCard/Populated",     // catalog id
       "figmaLayerName": "DeviceSummaryCard/Populated",   // the Figma frame name = the join key
-      "componentName": "DeviceSummaryCardPopulatedPreview", // the @Preview that renders the sticker
-      "source": "https://github.com/…/blob/main/app/…/ComponentPreviews.kt",
+      "componentName": "DeviceSummaryCard",              // the real component (not the @Preview)
+      "source": "https://github.com/…/blob/main/…/DeviceSummaryCard.kt",
       "label": "Compose",
+      "confidence": "HIGH",                              // how componentName/source were resolved
+      "previewName": "DeviceSummaryCardPopulatedPreview", // the @Preview that rendered the sticker
       "figmaSvg": "figma/devicesummarycard-populated.svg"
     }
   ]
@@ -39,12 +41,35 @@ The one thing it can't carry is the Figma **node id** — that only exists once 
 into a file. So the manifest keys on `figmaLayerName` (= `componentId`, the name the design-parity
 importer gives each frame) and the node id is resolved at publish time.
 
+### Which composable does it point at?
+
+Code Connect's value is showing how to *use the real component* (`DeviceSummaryCard(state = …)`), not
+the zero-arg `@Preview` wrapper that nobody calls. `componentName`/`source` resolve to the real
+component by priority, and each mapping's `confidence` records which source won:
+
+1. **`explicit`** — a `component` (plus optional `import` / `source`) authored on the catalog-spec
+   entry. Deterministic; use it wherever inference is uncertain:
+   ```jsonc
+   { "componentId": "Btn/Primary", "preview": "BtnPrimaryPreview",
+     "component": "PrimaryButton", "import": "import com.x.ui.PrimaryButton",
+     "source": "src/commonMain/kotlin/com/x/ui/Button.kt" }
+   ```
+2. **`HIGH` / `MEDIUM` / `LOW`** — discovery's inferred `PreviewTarget` (`PreviewInfo.targets`, carried
+   in the bundle's `previews.json`), i.e. the composable the preview's bytecode actually calls, with
+   its inference confidence.
+3. **`preview-fallback`** — the `@Preview` function itself, when neither above is available. Still a
+   valid mapping; review it before publishing.
+
+`previewName` always records the `@Preview` that rendered the sticker, so the trace back to the render
+survives even when the mapping points at the underlying component.
+
 Join sources (all already in the pipeline):
 
 - `componentId` → the Figma frame name (from the catalog spec / importer).
 - `componentId` → `@Preview` function (`fnByComponentId`, from `catalog.spec.json`).
-- `--source-repo` / `--source-ref` / `--source-module` → the GitHub `source` URL. When the bundle
-  carried a per-preview `sourceFile`, the URL points at the exact file; otherwise at the module dir.
+- `previewName` → inferred target composable + its source file (`targetsByFunction`, from the bundle).
+- `--source-repo` / `--source-ref` / `--source-module` → the GitHub `source` URL, pointing at the
+  resolved component's file when known, otherwise the module dir.
 
 ## Publishing (Org/Enterprise)
 
@@ -69,10 +94,10 @@ Join sources (all already in the pipeline):
 
 ## Reviewing before publish
 
-`componentName`/`source` point at the `@Preview` that renders the sticker. Where a catalog preview is
-a thin wrapper around a production component, retarget it to the underlying component before
-publishing — `get_code_connect_suggestions` is a good cross-check. Node-id resolution is deterministic
-and re-runnable, so re-resolving after the board changes is cheap.
+Sort review by `confidence`: `explicit` mappings are author-pinned and need no scrutiny; `HIGH` is
+usually safe; `MEDIUM`/`LOW`/`preview-fallback` are where to look — either pin an explicit `component`
+on the spec entry or retarget before publishing. `get_code_connect_suggestions` is a good cross-check.
+Node-id resolution is deterministic and re-runnable, so re-resolving after the board changes is cheap.
 
 ## Why this pairs with the render pipeline
 

--- a/scripts/design-artifacts/figma-code-connect-emit.mjs
+++ b/scripts/design-artifacts/figma-code-connect-emit.mjs
@@ -44,14 +44,28 @@ export function resolveSource({ repo, ref, module, sourceFile } = {}) {
 /**
  * Build the `code-connect.json` manifest object.
  *
+ * `componentName`/`source` should point at the **production composable** the sticker renders — the
+ * thing a designer/agent actually calls — not the zero-arg `@Preview` wrapper. Three sources, in
+ * priority order (each mapping records which one won in `confidence`):
+ *   1. **explicit** — a `component` (+ optional `import`/`source`) authored on the catalog-spec entry,
+ *      surfaced here via `componentByComponentId`. Deterministic; use it where inference is uncertain.
+ *   2. **inferred** — discovery's `PreviewTarget` for the preview function (`targetByFn`), carrying
+ *      its own `HIGH`/`MEDIUM`/`LOW` confidence and the target's source file.
+ *   3. **preview-fallback** — the `@Preview` function itself, when neither of the above is available.
+ *      Still a valid mapping, but review it before publishing.
+ *
  * @param components   catalog components (each with a `componentId`).
  * @param fnByComponentId Map componentId → `@Preview` function name (from the catalog spec).
+ * @param componentByComponentId optional Map componentId → `{ component, import?, source? }` — the
+ *                     explicit spec override (source 1 above).
+ * @param targetByFn   optional Map function → `{ functionName, sourceFile?, confidence? }` — the
+ *                     inferred production composable (source 2 above), from `targetsByFunction`.
  * @param slug         componentId → slug (the same `slug()` the figma-svg emit uses), so a mapping
  *                     can link its editable vector at `figma/<slug>.svg`.
  * @param figmaSvgSlugs Set of slugs that actually carried a `figma/<slug>.svg` (so only real files
  *                     are linked).
- * @param sourceByFn   optional Map function → `{ sourceFile }` lifted from the bundle, so a mapping
- *                     can point at the exact preview source file rather than the bare module.
+ * @param sourceByFn   optional Map function → `{ sourceFile }` lifted from the bundle — the preview
+ *                     function's own source file, used only for the preview-fallback source.
  * @param system/title system id + title, copied onto the manifest for provenance.
  * @param source       `{ repo, ref, module }` — the catalog's buildable-source pointer.
  * @param label        Code Connect label (default {@link COMPOSE_LABEL}).
@@ -62,6 +76,8 @@ export function resolveSource({ repo, ref, module, sourceFile } = {}) {
 export function buildCodeConnectManifest({
   components = [],
   fnByComponentId,
+  componentByComponentId,
+  targetByFn,
   slug,
   figmaSvgSlugs,
   sourceByFn,
@@ -77,17 +93,42 @@ export function buildCodeConnectManifest({
     const fn = fnByComponentId?.get(componentId);
     // No preview function ⇒ no code symbol to bind; skip rather than emit a dangling mapping.
     if (!fn) continue;
-    const sourceFile = sourceByFn?.get(fn)?.sourceFile;
+    const explicit = componentByComponentId?.get(componentId);
+    const target = targetByFn?.get(fn);
+    // Resolve the code symbol + its source file by priority (explicit > inferred > preview).
+    let componentName;
+    let sourceFile;
+    let confidence;
+    if (explicit?.component) {
+      componentName = explicit.component;
+      sourceFile = explicit.source ?? target?.sourceFile ?? sourceByFn?.get(fn)?.sourceFile;
+      confidence = "explicit";
+    } else if (target?.functionName) {
+      componentName = target.functionName;
+      sourceFile = target.sourceFile ?? sourceByFn?.get(fn)?.sourceFile;
+      confidence = target.confidence ?? "inferred";
+    } else {
+      componentName = fn;
+      sourceFile = sourceByFn?.get(fn)?.sourceFile;
+      confidence = "preview-fallback";
+    }
     const mapping = {
       componentId,
       // The Figma layer name a node must carry to receive this mapping. The design-parity importer
       // names each frame by componentId, so this is that name verbatim — resolved to a node id at
       // publish time.
       figmaLayerName: componentId,
-      componentName: fn,
+      componentName,
       source: resolveSource({ repo: source.repo, ref: source.ref, module: source.module, sourceFile }),
       label,
+      // How componentName/source were resolved, so the publish/review step knows what to trust:
+      // "explicit" | "HIGH" | "MEDIUM" | "LOW" | "preview-fallback".
+      confidence,
+      // The @Preview that rendered the sticker, always recorded for traceability even when the
+      // mapping points at the underlying component.
+      previewName: fn,
     };
+    if (explicit?.import) mapping.import = explicit.import;
     const s = slug?.(componentId);
     if (s && figmaSvgSlugs?.has(s)) mapping.figmaSvg = `figma/${s}.svg`;
     mappings.push(mapping);

--- a/scripts/design-artifacts/figma-code-connect-emit.mjs
+++ b/scripts/design-artifacts/figma-code-connect-emit.mjs
@@ -101,7 +101,15 @@ export function buildCodeConnectManifest({
     let confidence;
     if (explicit?.component) {
       componentName = explicit.component;
-      sourceFile = explicit.source ?? target?.sourceFile ?? sourceByFn?.get(fn)?.sourceFile;
+      // Don't inherit the inferred target's file for an explicit component — the explicit override is
+      // often there precisely to reject a wrong inference, so its sourceFile would point at the wrong
+      // composable. Reuse it only when the inferred function IS the explicit component; otherwise use
+      // the authored `source`, then the preview's own file, then (via resolveSource) the module.
+      const inferredMatches = target?.functionName === explicit.component;
+      sourceFile =
+        explicit.source ??
+        (inferredMatches ? target?.sourceFile : undefined) ??
+        sourceByFn?.get(fn)?.sourceFile;
       confidence = "explicit";
     } else if (target?.functionName) {
       componentName = target.functionName;

--- a/scripts/design-artifacts/figma-code-connect-emit.test.mjs
+++ b/scripts/design-artifacts/figma-code-connect-emit.test.mjs
@@ -129,6 +129,42 @@ test("buildCodeConnectManifest: explicit spec component wins over an inferred ta
   assert.equal(m.source, "https://github.com/o/r/blob/main/ui/src/Button.kt");
 });
 
+test("explicit component without a source does NOT inherit a rejected inference's file", () => {
+  const manifest = buildCodeConnectManifest({
+    components: [{ componentId: "Btn/Primary" }],
+    fnByComponentId: new Map([["Btn/Primary", "BtnPrimaryPreview"]]),
+    // Author pins the component to override the inference, but supplies no explicit source.
+    componentByComponentId: new Map([["Btn/Primary", { component: "PrimaryButton" }]]),
+    // The inference guessed a DIFFERENT composable — its file must not be linked.
+    targetByFn: new Map([
+      ["BtnPrimaryPreview", { functionName: "WrongGuess", sourceFile: "src/WrongGuess.kt", confidence: "LOW" }],
+    ]),
+    // The preview's own file is the honest fallback.
+    sourceByFn: new Map([["BtnPrimaryPreview", { sourceFile: "src/BtnPreviews.kt" }]]),
+    slug,
+    figmaSvgSlugs: new Set(),
+    source: { repo: "o/r", ref: "main", module: ":ui" },
+  });
+  const m = manifest.mappings[0];
+  assert.equal(m.componentName, "PrimaryButton");
+  // Falls back to the preview's file, NOT src/WrongGuess.kt.
+  assert.equal(m.source, "https://github.com/o/r/blob/main/ui/src/BtnPreviews.kt");
+});
+
+test("explicit component reuses the inferred file only when the inference matches it", () => {
+  const manifest = buildCodeConnectManifest({
+    components: [{ componentId: "Fab/Default" }],
+    fnByComponentId: new Map([["Fab/Default", "FabPreview"]]),
+    componentByComponentId: new Map([["Fab/Default", { component: "Fab" }]]),
+    // Inference agrees with the explicit component ⇒ its source file is trustworthy.
+    targetByFn: new Map([["FabPreview", { functionName: "Fab", sourceFile: "src/Fab.kt", confidence: "HIGH" }]]),
+    slug,
+    figmaSvgSlugs: new Set(),
+    source: { repo: "o/r", ref: "main", module: ":ui" },
+  });
+  assert.equal(manifest.mappings[0].source, "https://github.com/o/r/blob/main/ui/src/Fab.kt");
+});
+
 test("buildCodeConnectManifest skips components with no preview function (nothing to bind)", () => {
   const manifest = buildCodeConnectManifest({
     components: [{ componentId: "Known/One" }, { componentId: "Orphan/Two" }],

--- a/scripts/design-artifacts/figma-code-connect-emit.test.mjs
+++ b/scripts/design-artifacts/figma-code-connect-emit.test.mjs
@@ -73,7 +73,10 @@ test("buildCodeConnectManifest maps each component to its preview function and l
   assert.equal(device.componentId, "DeviceSummaryCard/Populated");
   // The layer name a Figma node must carry to receive this mapping = componentId verbatim.
   assert.equal(device.figmaLayerName, "DeviceSummaryCard/Populated");
+  // No explicit spec component and no inferred target here ⇒ the preview function is the fallback.
   assert.equal(device.componentName, "DeviceSummaryCardPopulatedPreview");
+  assert.equal(device.confidence, "preview-fallback");
+  assert.equal(device.previewName, "DeviceSummaryCardPopulatedPreview");
   assert.equal(
     device.source,
     "https://github.com/yschimke/meshcore-mobile/blob/main/app/src/DeviceBodyPreviews.kt",
@@ -82,6 +85,48 @@ test("buildCodeConnectManifest maps each component to its preview function and l
   // Only components that carried a figma-svg get a vector link.
   assert.equal(device.figmaSvg, "figma/devicesummarycard-populated.svg");
   assert.equal(manifest.mappings[1].figmaSvg, undefined);
+});
+
+test("buildCodeConnectManifest prefers an inferred target over the preview function", () => {
+  const manifest = buildCodeConnectManifest({
+    components: [{ componentId: "DeviceSummaryCard/Populated" }],
+    fnByComponentId: new Map([["DeviceSummaryCard/Populated", "DeviceSummaryCardPopulatedPreview"]]),
+    targetByFn: new Map([
+      [
+        "DeviceSummaryCardPopulatedPreview",
+        { functionName: "DeviceSummaryCard", sourceFile: "src/DeviceSummaryCard.kt", confidence: "HIGH" },
+      ],
+    ]),
+    slug,
+    figmaSvgSlugs: new Set(),
+    source: { repo: "o/r", ref: "main", module: ":app" },
+  });
+  const m = manifest.mappings[0];
+  // Points at the real component, not the wrapper.
+  assert.equal(m.componentName, "DeviceSummaryCard");
+  assert.equal(m.source, "https://github.com/o/r/blob/main/app/src/DeviceSummaryCard.kt");
+  assert.equal(m.confidence, "HIGH");
+  // The preview that rendered the sticker is still recorded for traceability.
+  assert.equal(m.previewName, "DeviceSummaryCardPopulatedPreview");
+});
+
+test("buildCodeConnectManifest: explicit spec component wins over an inferred target", () => {
+  const manifest = buildCodeConnectManifest({
+    components: [{ componentId: "Btn/Primary" }],
+    fnByComponentId: new Map([["Btn/Primary", "BtnPrimaryPreview"]]),
+    componentByComponentId: new Map([
+      ["Btn/Primary", { component: "PrimaryButton", import: "import com.x.PrimaryButton", source: "src/Button.kt" }],
+    ]),
+    targetByFn: new Map([["BtnPrimaryPreview", { functionName: "WrongGuess", confidence: "LOW" }]]),
+    slug,
+    figmaSvgSlugs: new Set(),
+    source: { repo: "o/r", ref: "main", module: ":ui" },
+  });
+  const m = manifest.mappings[0];
+  assert.equal(m.componentName, "PrimaryButton");
+  assert.equal(m.confidence, "explicit");
+  assert.equal(m.import, "import com.x.PrimaryButton");
+  assert.equal(m.source, "https://github.com/o/r/blob/main/ui/src/Button.kt");
 });
 
 test("buildCodeConnectManifest skips components with no preview function (nothing to bind)", () => {

--- a/scripts/design-artifacts/figma-code-connect-target.mjs
+++ b/scripts/design-artifacts/figma-code-connect-target.mjs
@@ -1,0 +1,68 @@
+/**
+ * Resolve the **production composable** a catalog sticker renders, so Code Connect points at the real
+ * component (`DeviceSummaryCard`) instead of the zero-arg `@Preview` wrapper
+ * (`DeviceSummaryCardPopulatedPreview`) that nobody calls in real code.
+ *
+ * Discovery already infers this: each preview in the bundle's `previews.json` carries a
+ * `targets: [{ className, functionName, sourceFile, confidence, signals }]` list (see
+ * `PreviewInfo.targets` / `PreviewTargetInference`), most-confident first, inferred by walking the
+ * preview's bytecode for the project-local `@Composable` call it renders. This module lifts that per
+ * function so the emit join can prefer it over the preview name.
+ *
+ * Read robustly, independent of whether the private bundle reader preserves the `targets` field:
+ * first from the parsed `bundle.previews[].targets`, then — if none survived parsing — from the raw
+ * `previews.json` entry in the bundle. Pure (no IO); unit-tested against both shapes.
+ */
+
+/**
+ * The best target for a preview: the first (most-confident) entry, since discovery orders them
+ * most-confident first and v1 emits at most one. Returns `{ functionName, sourceFile, confidence }`
+ * or null when the preview carried no inferred target (nothing cleared the confidence threshold).
+ */
+export function bestTarget(targets) {
+  const t = Array.isArray(targets) ? targets[0] : undefined;
+  if (!t || !t.functionName) return null;
+  return {
+    functionName: t.functionName,
+    sourceFile: t.sourceFile ?? undefined,
+    confidence: t.confidence ?? undefined,
+  };
+}
+
+/** Parse the raw `previews.json` entry (a `{ previews: [...] }` manifest or a bare array). */
+function parsePreviewsEntry(bundle) {
+  const bytes = bundle?.entries?.["previews.json"];
+  if (!bytes) return [];
+  try {
+    const parsed = JSON.parse(new TextDecoder().decode(bytes));
+    return Array.isArray(parsed) ? parsed : (parsed.previews ?? []);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Map `functionName → { functionName, sourceFile, confidence }` for the composable each preview
+ * renders. Prefers the light variant (matching the catalog's light-themed sticker) for a
+ * deterministic pick when a function has several theme/size variants. A function whose previews
+ * carried no target is simply absent — the emit join then falls back to the preview name.
+ */
+export function targetsByFunction(bundle) {
+  const out = new Map();
+  const prefer = (id) => /(_|\b)light$/i.test(String(id ?? ""));
+  const ingest = (previews) => {
+    for (const p of previews ?? []) {
+      const fn = p.functionName ?? p.id;
+      if (!fn) continue;
+      const target = bestTarget(p.targets);
+      if (!target) continue;
+      if (out.has(fn) && !prefer(p.id)) continue;
+      out.set(fn, target);
+    }
+  };
+  // Parsed previews first (the common path when the reader preserves `targets`)…
+  ingest(bundle?.previews);
+  // …then the raw manifest, so a reader that dropped the field still yields targets.
+  if (out.size === 0) ingest(parsePreviewsEntry(bundle));
+  return out;
+}

--- a/scripts/design-artifacts/figma-code-connect-target.test.mjs
+++ b/scripts/design-artifacts/figma-code-connect-target.test.mjs
@@ -1,0 +1,95 @@
+/**
+ * Unit tests for resolving the production composable a preview renders (Code Connect should point at
+ * the real component, not the @Preview wrapper). Covers both read paths: parsed `preview.targets`
+ * and the raw `previews.json` fallback.
+ *
+ * Run with `node --test scripts/design-artifacts/`.
+ */
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { bestTarget, targetsByFunction } from "./figma-code-connect-target.mjs";
+
+test("bestTarget takes the first (most-confident) entry, or null when none", () => {
+  assert.deepEqual(
+    bestTarget([
+      { functionName: "DeviceSummaryCard", sourceFile: "a.kt", confidence: "HIGH" },
+      { functionName: "Other", confidence: "LOW" },
+    ]),
+    { functionName: "DeviceSummaryCard", sourceFile: "a.kt", confidence: "HIGH" },
+  );
+  assert.equal(bestTarget([]), null);
+  assert.equal(bestTarget(undefined), null);
+  // A malformed entry with no functionName is treated as "no target".
+  assert.equal(bestTarget([{ sourceFile: "a.kt" }]), null);
+});
+
+test("targetsByFunction reads parsed preview.targets, preferring the light variant", () => {
+  const bundle = {
+    previews: [
+      {
+        id: "Fab_Dark",
+        functionName: "FabPreview",
+        targets: [{ functionName: "Fab", sourceFile: "dark.kt", confidence: "MEDIUM" }],
+      },
+      {
+        id: "Fab_Light",
+        functionName: "FabPreview",
+        targets: [{ functionName: "Fab", sourceFile: "light.kt", confidence: "HIGH" }],
+      },
+    ],
+  };
+  const byFn = targetsByFunction(bundle);
+  assert.deepEqual(byFn.get("FabPreview"), {
+    functionName: "Fab",
+    sourceFile: "light.kt",
+    confidence: "HIGH",
+  });
+});
+
+test("targetsByFunction omits previews that carried no target", () => {
+  const bundle = { previews: [{ id: "X_Light", functionName: "XPreview", targets: [] }] };
+  assert.equal(targetsByFunction(bundle).has("XPreview"), false);
+});
+
+test("targetsByFunction falls back to the raw previews.json entry when parsing dropped targets", () => {
+  const raw = JSON.stringify({
+    previews: [
+      {
+        id: "Card_Light",
+        functionName: "CardPreview",
+        targets: [{ functionName: "Card", sourceFile: "Card.kt", confidence: "HIGH" }],
+      },
+    ],
+  });
+  const bundle = {
+    // Reader surfaced previews WITHOUT the targets field…
+    previews: [{ id: "Card_Light", functionName: "CardPreview" }],
+    // …but the raw manifest entry still carries them.
+    entries: { "previews.json": new TextEncoder().encode(raw) },
+  };
+  const byFn = targetsByFunction(bundle);
+  assert.deepEqual(byFn.get("CardPreview"), {
+    functionName: "Card",
+    sourceFile: "Card.kt",
+    confidence: "HIGH",
+  });
+});
+
+test("targetsByFunction handles a bare-array previews.json and bad JSON gracefully", () => {
+  const arr = JSON.stringify([
+    { id: "A_Light", functionName: "APreview", targets: [{ functionName: "A", confidence: "LOW" }] },
+  ]);
+  assert.equal(
+    targetsByFunction({ entries: { "previews.json": new TextEncoder().encode(arr) } }).get("APreview")
+      .functionName,
+    "A",
+  );
+  // Malformed JSON ⇒ empty map, never a throw.
+  assert.equal(
+    targetsByFunction({ entries: { "previews.json": new TextEncoder().encode("{not json") } }).size,
+    0,
+  );
+  // No previews and no entry ⇒ empty map.
+  assert.equal(targetsByFunction({}).size, 0);
+});

--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -54,6 +54,7 @@ import {
   rewriteRasterHrefs,
 } from "./figma-svg-emit.mjs";
 import { buildCodeConnectManifest } from "./figma-code-connect-emit.mjs";
+import { targetsByFunction } from "./figma-code-connect-target.mjs";
 import { renderWireframeSvg, slug } from "./render-wireframe-svg.mjs";
 import { renderLayoutWireframeSvg } from "./render-layout-wireframe-svg.mjs";
 import { DEFAULT_PREVIEW_BASE, livePreviewUrl } from "./live-preview.mjs";
@@ -662,15 +663,28 @@ for (const component of catalog.components) {
 }
 
 // Figma Code Connect manifest next to the figma-svg vectors: one mapping per component binding its
-// Figma layer (by componentId) to the `@Preview` function that renders it, plus the repo source. It
+// Figma layer (by componentId) to the **production composable** it renders, plus the repo source. It
 // carries everything `send_code_connect_mappings` needs except the node id, which only exists once a
 // designer imports the catalog — `publish-code-connect.mjs` resolves layer-name → node id against
 // the imported file and produces the send payload. Emitting the manifest is plan-agnostic; only
 // publishing needs an Org/Enterprise Dev/Full seat. Written for every catalog so the surface is
 // covered automatically.
+//
+// componentName/source resolve to the real component, not the zero-arg @Preview wrapper: an explicit
+// `component` authored on the spec entry wins; else discovery's inferred `PreviewTarget`
+// (`targetsByFunction`); else the preview function as a marked fallback.
+const componentByComponentId = new Map(
+  spec.groups.flatMap((g) =>
+    g.components
+      .filter((c) => c.component)
+      .map((c) => [c.componentId, { component: c.component, import: c.import, source: c.source }]),
+  ),
+);
 const codeConnect = buildCodeConnectManifest({
   components: catalog.components,
   fnByComponentId,
+  componentByComponentId,
+  targetByFn: targetsByFunction(bundle),
   slug,
   figmaSvgSlugs,
   sourceByFn: sourceByFunction(bundle),


### PR DESCRIPTION
## Summary

Follow-up to #2524. Fixes the concern that the emitted Code Connect mappings pointed at the zero-arg `@Preview` wrapper (`DeviceSummaryCardPopulatedPreview`) instead of the production composable a designer/agent actually calls (`DeviceSummaryCard(state = …)`).

The real-composable info was never missing — discovery already infers it (`PreviewInfo.targets` / `PreviewTargetInference`) and it's serialized into the bundle's `previews.json` (which is `PreviewInfo`, filtered). It was just never read on the export side. So this is a JS-layer change; no renderer/manifest plumbing needed.

`componentName`/`source` now resolve by priority, recorded per mapping in a new `confidence` field:

1. **`explicit`** — a `component` (+ optional `import` / `source`) authored on the catalog-spec entry. Deterministic override for where inference is uncertain.
2. **`HIGH` / `MEDIUM` / `LOW`** — discovery's inferred `PreviewTarget`, with its confidence tier.
3. **`preview-fallback`** — the `@Preview` function, when neither is available (still valid; flagged for review).

`previewName` is always retained so the trace back to the render survives even when the mapping points at the underlying component.

Robustness: `targetsByFunction` reads the parsed `preview.targets`, then falls back to parsing the raw `previews.json` bundle entry — so it works regardless of whether the private bundle reader preserves the `targets` field.

Files:
- `figma-code-connect-target.mjs` — pure `bestTarget` + `targetsByFunction`
- `figma-code-connect-emit.mjs` — three-tier `componentName`/`source` resolution + `confidence`/`previewName`/`import`
- `generate-design-catalog.mjs` — build `componentByComponentId` (from spec) + `targetByFn` (from bundle), wire in
- `docs/code-connect.md` — document the resolution tiers and the optional spec fields

This is Stage 1 of the "realise the full promise" plan; Stage 2 (emit a `figma.code` template with the real parameter list) and Stage 3 (prop→param mapping) build on it. Non-visual change (data plumbing, docs, tests).

## Test plan

- [x] `node --test` from `scripts/design-artifacts/` — **110 pass, 0 fail** (11 new across the two modules).
- [x] `node --check` on all three touched/added `.mjs`.
- [x] Real-data check against meshcore-mobile `catalog.spec.json`: an inferred `PreviewTarget` for `DeviceSummaryCardPopulatedPreview` resolves to `componentName: "DeviceSummaryCard"` at `HIGH` confidence with the source URL pointing at the component's file and `previewName` retained; components without a target fall back to `preview-fallback`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FnX9TKA4TRpCj3PJhK5M7q)_