### PR TITLE
feat(discovery): capture target composable parameters for Code Connect call sites

### DIFF
--- a/gradle-plugin/preview-discovery/build.gradle.kts
+++ b/gradle-plugin/preview-discovery/build.gradle.kts
@@ -40,6 +40,10 @@ dependencies {
   // only surfaces annotations + signatures, not method-body invocations. Used by
   // `PreviewTargetInference`.
   api(libs.asm)
+  // Parses a target composable's `@kotlin.Metadata` to recover its real Kotlin parameter list
+  // (names / types / defaults) for the Code Connect template — `implementation`, not `api`: the
+  // metadata types stay an internal detail of `ComposableSignature`, off the published API.
+  implementation(libs.kotlin.metadata.jvm)
 
   testImplementation(libs.junit)
   testImplementation(libs.truth)

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComposableSignature.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComposableSignature.kt
@@ -1,0 +1,215 @@
+package ee.schimke.composeai.discovery
+
+import io.github.classgraph.ClassInfo
+import io.github.classgraph.MethodInfo
+import kotlin.metadata.KmClassifier
+import kotlin.metadata.KmFunction
+import kotlin.metadata.KmType
+import kotlin.metadata.KmTypeProjection
+import kotlin.metadata.KmValueParameter
+import kotlin.metadata.declaresDefaultValue
+import kotlin.metadata.isNullable
+import kotlin.metadata.jvm.KotlinClassMetadata
+import kotlin.metadata.jvm.signature
+import org.objectweb.asm.AnnotationVisitor
+import org.objectweb.asm.ClassReader
+import org.objectweb.asm.ClassVisitor
+import org.objectweb.asm.Opcodes
+
+/**
+ * Recovers a target composable's real Kotlin value parameters (names / types / defaults) from its
+ * `@kotlin.Metadata`, so a consumer can render a true call site for Figma Code Connect rather than
+ * a bare `Foo()`.
+ *
+ * Why metadata and not the JVM signature: a `@Composable` function's bytecode signature is mangled
+ * — parameter names are dropped and Compose's compiler inserts synthetic `Composer` and `changed:
+ * Int` parameters plus a default-mask arg. `@kotlin.Metadata` carries the *source* Kotlin
+ * signature, so reading it yields the parameters as the author wrote them, with none of the
+ * synthetic noise.
+ *
+ * Best-effort and non-fatal: any failure (no metadata, a newer metadata version than this reader
+ * understands, a signature that doesn't line up) returns an empty list, and the caller falls back
+ * to a parameterless call. Read leniently so a class compiled by a newer Kotlin than the bundled
+ * `kotlin-metadata-jvm` still parses instead of throwing.
+ */
+internal object ComposableSignature {
+
+  /**
+   * The value parameters of [method] on [classInfo], or empty when they can't be recovered.
+   * [method] is matched inside the class metadata by its JVM name + descriptor, so overloads don't
+   * collide.
+   */
+  fun parametersOf(classInfo: ClassInfo, method: MethodInfo): List<TargetParameter> {
+    return try {
+      val metadata = readClassMetadata(classInfo) ?: return emptyList()
+      val functions =
+        when (val parsed = KotlinClassMetadata.readLenient(metadata)) {
+          is KotlinClassMetadata.Class -> parsed.kmClass.functions
+          is KotlinClassMetadata.FileFacade -> parsed.kmPackage.functions
+          is KotlinClassMetadata.MultiFileClassPart -> parsed.kmPackage.functions
+          else -> return emptyList()
+        }
+      val fn = matchFunction(functions, method) ?: return emptyList()
+      fn.valueParameters.map { it.toTargetParameter() }
+    } catch (_: Throwable) {
+      // Metadata unreadable / newer format / API mismatch — degrade to no parameters.
+      emptyList()
+    }
+  }
+
+  /** Match the metadata function to [method] by JVM signature (name + descriptor). */
+  private fun matchFunction(functions: List<KmFunction>, method: MethodInfo): KmFunction? {
+    val name = method.name
+    val descriptor = method.typeDescriptorStr
+    val byName = functions.filter { it.signature?.name == name }
+    if (byName.isEmpty()) return null
+    if (byName.size == 1) return byName.single()
+    // Overloads: disambiguate by the exact JVM descriptor.
+    return byName.firstOrNull { it.signature?.descriptor == descriptor } ?: byName.first()
+  }
+
+  private fun KmValueParameter.toTargetParameter(): TargetParameter =
+    TargetParameter(
+      name = name,
+      type = renderType(type),
+      hasDefault = declaresDefaultValue,
+      composableSlot = isComposableFunctionType(type),
+    )
+
+  /**
+   * A short, readable type: the classifier's simple name, a trailing `?` when nullable, and a
+   * best-effort `<…>` of its type arguments (so `List<String>` reads as such). A function type
+   * renders as `(…) -> …`. This is a scaffolding hint, not a resolvable reference — the developer
+   * or agent completing the Code Connect mapping supplies the real value.
+   */
+  private fun renderType(type: KmType): String {
+    val base =
+      when (val c = type.classifier) {
+        is KmClassifier.Class -> {
+          val simple = c.name.substringAfterLast('/').substringAfterLast('.').replace('$', '.')
+          if (isFunctionClassName(c.name)) renderFunctionType(type, simple) else simple
+        }
+        is KmClassifier.TypeAlias -> c.name.substringAfterLast('/').substringAfterLast('.')
+        is KmClassifier.TypeParameter -> "T"
+      }
+    val args =
+      if (
+        type.arguments.isNotEmpty() &&
+          (type.classifier as? KmClassifier.Class)?.name?.let { !isFunctionClassName(it) } != false
+      ) {
+        type.arguments
+          .joinToString(", ") { renderProjection(it) }
+          .let { if (it.isBlank()) "" else "<$it>" }
+      } else {
+        ""
+      }
+    return base + args + if (type.isNullable) "?" else ""
+  }
+
+  private fun renderProjection(projection: KmTypeProjection): String {
+    val t = projection.type ?: return "*"
+    return renderType(t)
+  }
+
+  /** `(A, B) -> R` for a `kotlin/FunctionN` type, using its type arguments (last = return). */
+  private fun renderFunctionType(
+    type: KmType,
+    @Suppress("UNUSED_PARAMETER") simple: String,
+  ): String {
+    val args = type.arguments
+    if (args.isEmpty()) return "() -> Unit"
+    val params = args.dropLast(1).joinToString(", ") { renderProjection(it) }
+    val ret = args.last().type?.let { renderType(it) } ?: "Unit"
+    return "($params) -> $ret"
+  }
+
+  private fun isFunctionClassName(name: String): Boolean = name.startsWith("kotlin/Function")
+
+  /**
+   * A function-typed parameter — treated as a composable content slot. Metadata doesn't cheaply
+   * expose the `@Composable` *type* annotation here, so this approximates: a `kotlin/FunctionN`
+   * parameter on a composable is, in practice, a `content = { … }` slot. Good enough to let a
+   * consumer render the slot as a trailing-lambda rather than an inline value.
+   */
+  private fun isComposableFunctionType(type: KmType): Boolean =
+    (type.classifier as? KmClassifier.Class)?.name?.let { isFunctionClassName(it) } == true
+
+  // --- @kotlin.Metadata extraction (ASM, from the class bytes)
+  // -------------------------------------
+
+  /**
+   * Read the raw `@kotlin.Metadata` values off [classInfo]'s class file and rebuild a `Metadata`.
+   */
+  private fun readClassMetadata(classInfo: ClassInfo): Metadata? {
+    val resource = classInfo.resource ?: return null
+    val collector = MetadataCollector()
+    resource.open().use { stream ->
+      ClassReader(stream)
+        .accept(
+          object : ClassVisitor(Opcodes.ASM9) {
+            override fun visitAnnotation(descriptor: String, visible: Boolean): AnnotationVisitor? {
+              if (descriptor != "Lkotlin/Metadata;") return null
+              return collector
+            }
+          },
+          ClassReader.SKIP_CODE or ClassReader.SKIP_FRAMES or ClassReader.SKIP_DEBUG,
+        )
+    }
+    return collector.build()
+  }
+
+  /** Accumulates the `@kotlin.Metadata` annotation members as ASM visits them. */
+  private class MetadataCollector : AnnotationVisitor(Opcodes.ASM9) {
+    private var kind = 1
+    private var metadataVersion = IntArray(0)
+    private val data1 = mutableListOf<String>()
+    private val data2 = mutableListOf<String>()
+    private val mv = mutableListOf<Int>()
+    private var extraInt = 0
+    private var extraString = ""
+    private var packageName = ""
+    private var seen = false
+
+    override fun visit(name: String?, value: Any?) {
+      seen = true
+      when (name) {
+        "k" -> kind = value as? Int ?: kind
+        // ASM hands a primitive-typed annotation array (here `mv: IntArray`) to `visit` as the
+        // whole
+        // array in one call — NOT element-by-element through `visitArray` (which only object
+        // arrays,
+        // e.g. the `String[]` d1/d2, use). So capture `mv` here.
+        "mv" -> (value as? IntArray)?.let { metadataVersion = it }
+        "xi" -> extraInt = value as? Int ?: extraInt
+        "xs" -> extraString = value as? String ?: extraString
+        "pn" -> packageName = value as? String ?: packageName
+      }
+    }
+
+    override fun visitArray(name: String?): AnnotationVisitor {
+      return object : AnnotationVisitor(Opcodes.ASM9) {
+        override fun visit(n: String?, value: Any?) {
+          when (name) {
+            // Fallback: some ASM paths do stream an int array element-by-element.
+            "mv" -> (value as? Int)?.let { mv += it }
+            "d1" -> (value as? String)?.let { data1 += it }
+            "d2" -> (value as? String)?.let { data2 += it }
+          }
+        }
+      }
+    }
+
+    fun build(): Metadata? {
+      if (!seen) return null
+      return Metadata(
+        kind = kind,
+        metadataVersion = if (mv.isNotEmpty()) mv.toIntArray() else metadataVersion,
+        data1 = data1.toTypedArray(),
+        data2 = data2.toTypedArray(),
+        extraInt = extraInt,
+        extraString = extraString,
+        packageName = packageName,
+      )
+    }
+  }
+}

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
@@ -639,6 +639,31 @@ data class PreviewTarget(
   val sourceFile: String? = null,
   val confidence: TargetConfidence,
   val signals: List<TargetSignal> = emptyList(),
+  /**
+   * The target composable's real Kotlin value parameters, in declared order — recovered from its
+   * `@kotlin.Metadata` (see `ComposableSignature`), so a consumer can render a true call site
+   * (`Foo(bar = …, baz = …)`) for Figma Code Connect instead of a bare `Foo()`. Empty when the
+   * signature couldn't be read (metadata absent, produced by a newer compiler than the reader, or
+   * the function had no value parameters) — consumers degrade to a parameterless call.
+   */
+  val parameters: List<TargetParameter> = emptyList(),
+)
+
+/**
+ * One value parameter of a target composable, from its Kotlin metadata. [type] is a short,
+ * human-readable rendering (simple class name + `?` when nullable), enough to scaffold a call site
+ * and let a developer/agent fill the value — not a fully-qualified, resolvable type reference.
+ */
+@Serializable
+data class TargetParameter(
+  val name: String,
+  val type: String,
+  /** True when the parameter declares a default value (so a call site may legally omit it). */
+  val hasDefault: Boolean = false,
+  /**
+   * True when the parameter is a `@Composable` function-typed slot (a `content = { … }` lambda).
+   */
+  val composableSlot: Boolean = false,
 )
 
 @Serializable

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewTargetInference.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewTargetInference.kt
@@ -139,30 +139,33 @@ object PreviewTargetInference {
     if (candidates.isEmpty()) return emptyList()
 
     val survivors = candidates.size
-    val scored = candidates.map { (callerOwner, callerMethod, callerClassInfo) ->
-      score(
-        callerOwner = callerOwner,
-        callerMethod = callerMethod,
-        callerClassInfo = callerClassInfo,
-        previewClassFqn = previewFqn,
-        previewMethodName = previewMethodName,
-        previewSourceFile = previewSourceFile,
-        variantName = variantName,
-        hasPreviewParameter = hasPreviewParameter,
-        callerMethodHasComposableParam =
-          callerMethod.parameterInfo?.any { p ->
-            // Heuristic for "this candidate consumes a value of the same shape as the preview's
-            // @PreviewParameter" — a non-`@Composable () -> Unit` parameter on the candidate.
-            // Cheap stand-in for proper data-flow analysis; good enough to flag the common
-            // `@PreviewParameter color: Long → Foo(color)` pattern.
-            p.annotationInfo?.none { it.name == COMPOSABLE_FQN } ?: true
-          } == true,
-        totalSurvivors = survivors,
-        resolveSourceFile = resolveSourceFile,
-      )
+    // Keep each candidate paired with its score so the winner's resolved ClassInfo/MethodInfo is in
+    // hand for signature extraction (params come from the target's Kotlin metadata, below).
+    val scored = candidates.map { candidate ->
+      candidate to
+        score(
+          callerOwner = candidate.ownerFqn,
+          callerMethod = candidate.method,
+          callerClassInfo = candidate.classInfo,
+          previewClassFqn = previewFqn,
+          previewMethodName = previewMethodName,
+          previewSourceFile = previewSourceFile,
+          variantName = variantName,
+          hasPreviewParameter = hasPreviewParameter,
+          callerMethodHasComposableParam =
+            candidate.method.parameterInfo?.any { p ->
+              // Heuristic for "this candidate consumes a value of the same shape as the preview's
+              // @PreviewParameter" — a non-`@Composable () -> Unit` parameter on the candidate.
+              // Cheap stand-in for proper data-flow analysis; good enough to flag the common
+              // `@PreviewParameter color: Long → Foo(color)` pattern.
+              p.annotationInfo?.none { it.name == COMPOSABLE_FQN } ?: true
+            } == true,
+          totalSurvivors = survivors,
+          resolveSourceFile = resolveSourceFile,
+        )
     }
 
-    val best = scored.maxByOrNull { it.score } ?: return emptyList()
+    val (bestCandidate, best) = scored.maxByOrNull { it.second.score } ?: return emptyList()
     if (best.score < MIN_EMIT_SCORE) return emptyList()
 
     val confidence =
@@ -178,6 +181,9 @@ object PreviewTargetInference {
         sourceFile = best.sourceFile,
         confidence = confidence,
         signals = best.signals,
+        // The target's real Kotlin value parameters (names / types / defaults) for the call site a
+        // consumer renders into Code Connect. Best-effort — empty when metadata can't be read.
+        parameters = ComposableSignature.parametersOf(bestCandidate.classInfo, bestCandidate.method),
       )
     )
   }

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ComposableSignatureTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ComposableSignatureTest.kt
@@ -1,0 +1,60 @@
+package ee.schimke.composeai.discovery
+
+import com.google.common.truth.Truth.assertThat
+import io.github.classgraph.ClassGraph
+import io.github.classgraph.MethodInfo
+import org.junit.Test
+
+/**
+ * Reads the real Kotlin signature of the [sampleComponent] fixture out of its `@kotlin.Metadata`
+ * and checks parameter names, rendered types, and default flags — the data a Code Connect call site
+ * is built from. Scans this test module's own classes so the fixture's compiled metadata is
+ * exercised end to end (no mocking of the metadata blob).
+ */
+class ComposableSignatureTest {
+
+  /**
+   * Resolve the fixture facade's [simpleName] method and read its parameters — all inside the open
+   * ClassGraph scan, because `ClassInfo.resource` (which `ComposableSignature` reads the class
+   * bytes from) is only valid while the scan is open.
+   */
+  private fun parametersOf(simpleName: String): List<TargetParameter> {
+    ClassGraph()
+      .enableClassInfo()
+      .enableMethodInfo()
+      .acceptPackages("ee.schimke.composeai.discovery")
+      .scan()
+      .use { scan ->
+        val classInfo =
+          scan.getClassInfo("ee.schimke.composeai.discovery.SignatureFixturesKt")
+            ?: error("fixture facade class not found")
+        // A defaulted function also emits a synthetic `<name>$default`; match the real one by name.
+        val m: MethodInfo = classInfo.methodInfo.first { it.name == simpleName }
+        return ComposableSignature.parametersOf(classInfo, m)
+      }
+  }
+
+  @Test
+  fun `reads parameter names, types and defaults from metadata`() {
+    val params = parametersOf("sampleComponent")
+
+    assertThat(params.map { it.name })
+      .containsExactly("state", "count", "labels", "onClick", "note")
+      .inOrder()
+    assertThat(params.map { it.type })
+      .containsExactly("String", "Int", "List<String>", "() -> Unit", "String?")
+      .inOrder()
+    assertThat(params.first { it.name == "count" }.hasDefault).isTrue()
+    assertThat(params.first { it.name == "note" }.hasDefault).isTrue()
+    assertThat(params.first { it.name == "state" }.hasDefault).isFalse()
+    assertThat(params.first { it.name == "labels" }.hasDefault).isFalse()
+    // The function-typed parameter is flagged as a slot.
+    assertThat(params.first { it.name == "onClick" }.composableSlot).isTrue()
+    assertThat(params.first { it.name == "state" }.composableSlot).isFalse()
+  }
+
+  @Test
+  fun `a no-parameter function yields an empty list`() {
+    assertThat(parametersOf("noParams")).isEmpty()
+  }
+}

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/SignatureFixtures.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/SignatureFixtures.kt
@@ -1,0 +1,16 @@
+package ee.schimke.composeai.discovery
+
+// Fixtures for ComposableSignatureTest. Deliberately NOT @Composable — that would drag the Compose
+// runtime onto the discovery test classpath, and ComposableSignature reads only Kotlin @Metadata,
+// which every Kotlin declaration carries regardless. A top-level function compiles into the file
+// facade class `SignatureFixturesKt`, exercising the FileFacade metadata path.
+@Suppress("unused", "UNUSED_PARAMETER")
+fun sampleComponent(
+  state: String,
+  count: Int = 3,
+  labels: List<String>,
+  onClick: () -> Unit,
+  note: String? = null,
+) {}
+
+@Suppress("unused") fun noParams() {}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -345,6 +345,10 @@ wear-protolayout-proto = { module = "androidx.wear.protolayout:protolayout-proto
 wear-protolayout-external-protobuf = { module = "androidx.wear.protolayout:protolayout-external-protobuf", version.ref = "wear-protolayout" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
+# Reads a class file's `@kotlin.Metadata` to recover the real Kotlin signature (parameter names,
+# types, defaults) of a discovered target composable — the JVM bytecode alone drops names and
+# carries Compose's synthetic Composer/changed params. Version tracks the Kotlin toolchain.
+kotlin-metadata-jvm = { module = "org.jetbrains.kotlin:kotlin-metadata-jvm", version.ref = "kotlin" }
 mcp-kotlin-sdk-server = { module = "io.modelcontextprotocol:kotlin-sdk-server", version.ref = "mcp-kotlin-sdk" }
 okio = { module = "com.squareup.okio:okio", version.ref = "okio" }
 okio-fakefilesystem = { module = "com.squareup.okio:okio-fakefilesystem", version.ref = "okio" }

--- a/scripts/design-artifacts/docs/code-connect.md
+++ b/scripts/design-artifacts/docs/code-connect.md
@@ -63,6 +63,29 @@ component by priority, and each mapping's `confidence` records which source won:
 `previewName` always records the `@Preview` that rendered the sticker, so the trace back to the render
 survives even when the mapping points at the underlying component.
 
+### Real call site (a template, not a bare mapping)
+
+When the emitted component IS the inferred target, the mapping also carries a real call site built
+from the component's **actual Kotlin parameters** — recovered from its `@kotlin.Metadata` (see
+`ComposableSignature`), which yields the source signature with names/types/defaults and none of the
+synthetic `Composer`/`changed` params the bytecode carries:
+
+```jsonc
+{
+  "componentName": "DeviceSummaryCard",
+  "codeSnippet": "DeviceSummaryCard(\n    state = /* DeviceState */,\n    content = { },\n)",
+  "imports": ["import ee.schimke.meshcore.components.ui.DeviceSummaryCard"],
+  "parameters": [ { "name": "state", "type": "DeviceState", "hasDefault": false }, … ]
+}
+```
+
+Only **required** parameters (no default) form the minimal call; a function-typed slot renders as
+`name = { }`, everything else as a `name = <type-placeholder>` for the developer/agent to fill.
+At publish time `publish-code-connect.mjs` wraps `codeSnippet` into a `figma.code` parserless
+`template` (with `imports` in `templateDataJson`), so Dev Mode shows the real call rather than just the
+component name. A component with no required params, or one whose signature couldn't be read, degrades
+to a bare `Foo()` — still valid.
+
 Join sources (all already in the pipeline):
 
 - `componentId` → the Figma frame name (from the catalog spec / importer).

--- a/scripts/design-artifacts/docs/code-connect.md
+++ b/scripts/design-artifacts/docs/code-connect.md
@@ -73,14 +73,15 @@ synthetic `Composer`/`changed` params the bytecode carries:
 ```jsonc
 {
   "componentName": "DeviceSummaryCard",
-  "codeSnippet": "DeviceSummaryCard(\n    state = /* DeviceState */,\n    content = { },\n)",
+  "codeSnippet": "DeviceSummaryCard(\n    state = TODO(\"DeviceState\"),\n    content = { },\n)",
   "imports": ["import ee.schimke.meshcore.components.ui.DeviceSummaryCard"],
   "parameters": [ { "name": "state", "type": "DeviceState", "hasDefault": false }, … ]
 }
 ```
 
 Only **required** parameters (no default) form the minimal call; a function-typed slot renders as
-`name = { }`, everything else as a `name = <type-placeholder>` for the developer/agent to fill.
+`name = { }`, everything else as `name = TODO("Type")` — valid, copyable Kotlin (`TODO()` returns
+`Nothing`, assignable anywhere) with the type as the hint for the developer/agent to replace.
 At publish time `publish-code-connect.mjs` wraps `codeSnippet` into a `figma.code` parserless
 `template` (with `imports` in `templateDataJson`), so Dev Mode shows the real call rather than just the
 component name. A component with no required params, or one whose signature couldn't be read, degrades

--- a/scripts/design-artifacts/figma-code-connect-emit.mjs
+++ b/scripts/design-artifacts/figma-code-connect-emit.mjs
@@ -57,8 +57,10 @@ export function importFor(className, componentName) {
  * Connect mapping from a bare `Foo()` into `Foo(bar = …, …)`.
  *
  * Only the **required** parameters (no default) form the minimal call; a defaulted parameter is
- * omitted, since a real call site normally would. A function-typed slot renders as a trailing-style
- * `name = { }`; everything else as a `name = <type-placeholder>` for the developer/agent to fill.
+ * omitted, since a real call site normally would. Values are valid, copyable Kotlin: a function-typed
+ * slot renders as `name = { }`; everything else as `name = TODO("Type")` — `TODO()` returns `Nothing`
+ * (assignable to any parameter) so the snippet compiles as-is, with the type as the hint, for the
+ * developer/agent to replace.
  *
  * @returns `{ codeSnippet, imports }` — `imports` is `[importLine]` or `[]`.
  */
@@ -69,7 +71,11 @@ export function renderCallSite(componentName, importLine, parameters = []) {
       ? `${componentName}()`
       : `${componentName}(\n` +
         required
-          .map((p) => (p.composableSlot ? `    ${p.name} = { },` : `    ${p.name} = /* ${p.type} */,`))
+          .map((p) =>
+            p.composableSlot
+              ? `    ${p.name} = { },`
+              : `    ${p.name} = TODO(${JSON.stringify(p.type)}),`,
+          )
           .join("\n") +
         `\n)`;
   return { codeSnippet, imports: importLine ? [importLine] : [] };

--- a/scripts/design-artifacts/figma-code-connect-emit.mjs
+++ b/scripts/design-artifacts/figma-code-connect-emit.mjs
@@ -42,6 +42,40 @@ export function resolveSource({ repo, ref, module, sourceFile } = {}) {
 }
 
 /**
+ * The `import <package>.<Component>` line for a target, from its owner-class FQN. A top-level
+ * composable's owner is the file facade (`com.x.ui.ButtonsKt`), so the package is the class FQN minus
+ * its last segment. Returns null when the class FQN has no package.
+ */
+export function importFor(className, componentName) {
+  if (!className || !componentName) return null;
+  const pkg = className.split(".").slice(0, -1).join(".");
+  return pkg ? `import ${pkg}.${componentName}` : null;
+}
+
+/**
+ * Render a real Kotlin call site for a component from its parameters — the payload that turns a Code
+ * Connect mapping from a bare `Foo()` into `Foo(bar = …, …)`.
+ *
+ * Only the **required** parameters (no default) form the minimal call; a defaulted parameter is
+ * omitted, since a real call site normally would. A function-typed slot renders as a trailing-style
+ * `name = { }`; everything else as a `name = <type-placeholder>` for the developer/agent to fill.
+ *
+ * @returns `{ codeSnippet, imports }` — `imports` is `[importLine]` or `[]`.
+ */
+export function renderCallSite(componentName, importLine, parameters = []) {
+  const required = parameters.filter((p) => !p.hasDefault);
+  const codeSnippet =
+    required.length === 0
+      ? `${componentName}()`
+      : `${componentName}(\n` +
+        required
+          .map((p) => (p.composableSlot ? `    ${p.name} = { },` : `    ${p.name} = /* ${p.type} */,`))
+          .join("\n") +
+        `\n)`;
+  return { codeSnippet, imports: importLine ? [importLine] : [] };
+}
+
+/**
  * Build the `code-connect.json` manifest object.
  *
  * `componentName`/`source` should point at the **production composable** the sticker renders — the
@@ -137,6 +171,16 @@ export function buildCodeConnectManifest({
       previewName: fn,
     };
     if (explicit?.import) mapping.import = explicit.import;
+    // A real call site, but only when the emitted component IS the inferred target — then its captured
+    // parameters genuinely belong to `componentName`. (An explicit override that names a different
+    // component has no matching signature, so it stays a bare mapping for review.)
+    if (target?.functionName && target.functionName === componentName) {
+      const importLine = explicit?.import ?? importFor(target.className, componentName);
+      const call = renderCallSite(componentName, importLine, target.parameters ?? []);
+      mapping.codeSnippet = call.codeSnippet;
+      if (call.imports.length > 0) mapping.imports = call.imports;
+      if ((target.parameters?.length ?? 0) > 0) mapping.parameters = target.parameters;
+    }
     const s = slug?.(componentId);
     if (s && figmaSvgSlugs?.has(s)) mapping.figmaSvg = `figma/${s}.svg`;
     mappings.push(mapping);

--- a/scripts/design-artifacts/figma-code-connect-emit.test.mjs
+++ b/scripts/design-artifacts/figma-code-connect-emit.test.mjs
@@ -29,7 +29,7 @@ test("renderCallSite renders only required params, slots as lambdas", () => {
   ]);
   assert.equal(
     codeSnippet,
-    "DeviceSummaryCard(\n    state = /* State */,\n    content = { },\n)",
+    'DeviceSummaryCard(\n    state = TODO("State"),\n    content = { },\n)',
   );
   assert.deepEqual(imports, ["import com.x.DeviceSummaryCard"]);
 });
@@ -160,7 +160,7 @@ test("buildCodeConnectManifest attaches a call site when the emitted component i
   });
   const m = manifest.mappings[0];
   assert.equal(m.componentName, "DeviceSummaryCard");
-  assert.equal(m.codeSnippet, "DeviceSummaryCard(\n    state = /* State */,\n)");
+  assert.equal(m.codeSnippet, 'DeviceSummaryCard(\n    state = TODO("State"),\n)');
   assert.deepEqual(m.imports, ["import com.x.ui.DeviceSummaryCard"]);
   assert.equal(m.parameters.length, 2);
 });

--- a/scripts/design-artifacts/figma-code-connect-emit.test.mjs
+++ b/scripts/design-artifacts/figma-code-connect-emit.test.mjs
@@ -10,8 +10,34 @@ import { test } from "node:test";
 import {
   COMPOSE_LABEL,
   buildCodeConnectManifest,
+  importFor,
+  renderCallSite,
   resolveSource,
 } from "./figma-code-connect-emit.mjs";
+
+test("importFor derives the import from the owner-facade FQN", () => {
+  assert.equal(importFor("com.x.ui.ButtonsKt", "Button"), "import com.x.ui.Button");
+  assert.equal(importFor("Button", "Button"), null); // no package
+  assert.equal(importFor(undefined, "Button"), null);
+});
+
+test("renderCallSite renders only required params, slots as lambdas", () => {
+  const { codeSnippet, imports } = renderCallSite("DeviceSummaryCard", "import com.x.DeviceSummaryCard", [
+    { name: "state", type: "State", hasDefault: false },
+    { name: "modifier", type: "Modifier", hasDefault: true }, // defaulted → omitted
+    { name: "content", type: "() -> Unit", hasDefault: false, composableSlot: true },
+  ]);
+  assert.equal(
+    codeSnippet,
+    "DeviceSummaryCard(\n    state = /* State */,\n    content = { },\n)",
+  );
+  assert.deepEqual(imports, ["import com.x.DeviceSummaryCard"]);
+});
+
+test("renderCallSite with no required params is a bare call", () => {
+  assert.equal(renderCallSite("Foo", null, [{ name: "a", type: "Int", hasDefault: true }]).codeSnippet, "Foo()");
+  assert.equal(renderCallSite("Foo", null, []).codeSnippet, "Foo()");
+});
 
 test("resolveSource builds a GitHub blob URL from repo + ref + module-relative source file", () => {
   const url = resolveSource({
@@ -108,6 +134,46 @@ test("buildCodeConnectManifest prefers an inferred target over the preview funct
   assert.equal(m.confidence, "HIGH");
   // The preview that rendered the sticker is still recorded for traceability.
   assert.equal(m.previewName, "DeviceSummaryCardPopulatedPreview");
+});
+
+test("buildCodeConnectManifest attaches a call site when the emitted component is the inferred target", () => {
+  const manifest = buildCodeConnectManifest({
+    components: [{ componentId: "Device/Summary" }],
+    fnByComponentId: new Map([["Device/Summary", "DeviceSummaryPreview"]]),
+    targetByFn: new Map([
+      [
+        "DeviceSummaryPreview",
+        {
+          functionName: "DeviceSummaryCard",
+          className: "com.x.ui.DeviceKt",
+          confidence: "HIGH",
+          parameters: [
+            { name: "state", type: "State", hasDefault: false },
+            { name: "modifier", type: "Modifier", hasDefault: true },
+          ],
+        },
+      ],
+    ]),
+    slug,
+    figmaSvgSlugs: new Set(),
+    source: { repo: "o/r", ref: "main", module: ":app" },
+  });
+  const m = manifest.mappings[0];
+  assert.equal(m.componentName, "DeviceSummaryCard");
+  assert.equal(m.codeSnippet, "DeviceSummaryCard(\n    state = /* State */,\n)");
+  assert.deepEqual(m.imports, ["import com.x.ui.DeviceSummaryCard"]);
+  assert.equal(m.parameters.length, 2);
+});
+
+test("buildCodeConnectManifest: no call site for a preview-fallback (no matching target)", () => {
+  const manifest = buildCodeConnectManifest({
+    components: [{ componentId: "Theme/Light" }],
+    fnByComponentId: new Map([["Theme/Light", "ThemeLightPreview"]]),
+    slug,
+    figmaSvgSlugs: new Set(),
+    source: {},
+  });
+  assert.equal(manifest.mappings[0].codeSnippet, undefined);
 });
 
 test("buildCodeConnectManifest: explicit spec component wins over an inferred target", () => {

--- a/scripts/design-artifacts/figma-code-connect-target.mjs
+++ b/scripts/design-artifacts/figma-code-connect-target.mjs
@@ -24,8 +24,13 @@ export function bestTarget(targets) {
   if (!t || !t.functionName) return null;
   return {
     functionName: t.functionName,
+    className: t.className ?? undefined,
     sourceFile: t.sourceFile ?? undefined,
     confidence: t.confidence ?? undefined,
+    // The target composable's real value parameters (name / type / hasDefault / composableSlot),
+    // recovered from its Kotlin metadata — the raw material for a real call site. Empty when the
+    // signature couldn't be read.
+    parameters: Array.isArray(t.parameters) ? t.parameters : [],
   };
 }
 

--- a/scripts/design-artifacts/figma-code-connect-target.test.mjs
+++ b/scripts/design-artifacts/figma-code-connect-target.test.mjs
@@ -13,15 +13,29 @@ import { bestTarget, targetsByFunction } from "./figma-code-connect-target.mjs";
 test("bestTarget takes the first (most-confident) entry, or null when none", () => {
   assert.deepEqual(
     bestTarget([
-      { functionName: "DeviceSummaryCard", sourceFile: "a.kt", confidence: "HIGH" },
+      {
+        functionName: "DeviceSummaryCard",
+        className: "com.x.DeviceKt",
+        sourceFile: "a.kt",
+        confidence: "HIGH",
+        parameters: [{ name: "state", type: "State", hasDefault: false }],
+      },
       { functionName: "Other", confidence: "LOW" },
     ]),
-    { functionName: "DeviceSummaryCard", sourceFile: "a.kt", confidence: "HIGH" },
+    {
+      functionName: "DeviceSummaryCard",
+      className: "com.x.DeviceKt",
+      sourceFile: "a.kt",
+      confidence: "HIGH",
+      parameters: [{ name: "state", type: "State", hasDefault: false }],
+    },
   );
   assert.equal(bestTarget([]), null);
   assert.equal(bestTarget(undefined), null);
   // A malformed entry with no functionName is treated as "no target".
   assert.equal(bestTarget([{ sourceFile: "a.kt" }]), null);
+  // A target with no parameters carried yields an empty array (never undefined).
+  assert.deepEqual(bestTarget([{ functionName: "X" }]).parameters, []);
 });
 
 test("targetsByFunction reads parsed preview.targets, preferring the light variant", () => {
@@ -40,11 +54,9 @@ test("targetsByFunction reads parsed preview.targets, preferring the light varia
     ],
   };
   const byFn = targetsByFunction(bundle);
-  assert.deepEqual(byFn.get("FabPreview"), {
-    functionName: "Fab",
-    sourceFile: "light.kt",
-    confidence: "HIGH",
-  });
+  assert.equal(byFn.get("FabPreview").functionName, "Fab");
+  assert.equal(byFn.get("FabPreview").sourceFile, "light.kt");
+  assert.equal(byFn.get("FabPreview").confidence, "HIGH");
 });
 
 test("targetsByFunction omits previews that carried no target", () => {
@@ -69,11 +81,35 @@ test("targetsByFunction falls back to the raw previews.json entry when parsing d
     entries: { "previews.json": new TextEncoder().encode(raw) },
   };
   const byFn = targetsByFunction(bundle);
-  assert.deepEqual(byFn.get("CardPreview"), {
-    functionName: "Card",
-    sourceFile: "Card.kt",
-    confidence: "HIGH",
-  });
+  assert.equal(byFn.get("CardPreview").functionName, "Card");
+  assert.equal(byFn.get("CardPreview").sourceFile, "Card.kt");
+  assert.equal(byFn.get("CardPreview").confidence, "HIGH");
+});
+
+test("targetsByFunction carries the target's parameters and className", () => {
+  const bundle = {
+    previews: [
+      {
+        id: "Btn_Light",
+        functionName: "BtnPreview",
+        targets: [
+          {
+            functionName: "Button",
+            className: "com.x.ButtonsKt",
+            confidence: "HIGH",
+            parameters: [
+              { name: "label", type: "String", hasDefault: false },
+              { name: "onClick", type: "() -> Unit", hasDefault: false, composableSlot: true },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+  const t = targetsByFunction(bundle).get("BtnPreview");
+  assert.equal(t.className, "com.x.ButtonsKt");
+  assert.equal(t.parameters.length, 2);
+  assert.equal(t.parameters[1].composableSlot, true);
 });
 
 test("targetsByFunction handles a bare-array previews.json and bad JSON gracefully", () => {

--- a/scripts/design-artifacts/publish-code-connect.mjs
+++ b/scripts/design-artifacts/publish-code-connect.mjs
@@ -83,20 +83,45 @@ export function resolveMappings(manifest, nameIndex) {
   return { resolved, unresolved, ambiguous };
 }
 
+/** Escape a code string for safe embedding inside a JS template literal (`figma.code` ...``). */
+function escapeForTemplateLiteral(code) {
+  return code.replace(/\\/g, "\\\\").replace(/`/g, "\\`").replace(/\$\{/g, "\\${");
+}
+
+/**
+ * Wrap a rendered Kotlin call site in a Code Connect **parserless template** — executable JS that
+ * emits the snippet via `figma.code`, the form Figma's Dev Mode / MCP renders. Imports are carried
+ * separately in `templateDataJson`, per the `send_code_connect_mappings` contract.
+ */
+export function codeConnectTemplate(codeSnippet) {
+  return "const figma = require('figma')\nexport default figma.code`" + escapeForTemplateLiteral(codeSnippet) + "`";
+}
+
 /**
  * Shape resolved mappings into the argument object for Figma's `send_code_connect_mappings` MCP
- * tool: `{ fileKey, nodeId, mappings: [{ nodeId, componentName, source, label, template? }] }`.
- * `nodeId` at the top level is required by the tool and set to the first mapping's node (an anchor);
- * the per-mapping `nodeId`s carry the real bindings.
+ * tool: `{ fileKey, nodeId, mappings: [{ nodeId, componentName, source, label, template?,
+ * templateDataJson? }] }`. `nodeId` at the top level is required by the tool and set to the first
+ * mapping's node (an anchor); the per-mapping `nodeId`s carry the real bindings.
+ *
+ * When a mapping carries a `codeSnippet` (a real call site, from the emit step), it is turned into a
+ * `figma.code` template + `templateDataJson` (`isParserless` + `imports`) so Dev Mode shows the real
+ * call, not just the component name. An explicit `m.template` overrides the generated one.
  */
 export function toSendMappingsPayload(fileKey, resolved) {
-  const mappings = resolved.map((m) => ({
-    nodeId: m.nodeId,
-    componentName: m.componentName,
-    source: m.source,
-    label: m.label,
-    ...(m.template ? { template: m.template } : {}),
-  }));
+  const mappings = resolved.map((m) => {
+    const out = {
+      nodeId: m.nodeId,
+      componentName: m.componentName,
+      source: m.source,
+      label: m.label,
+    };
+    const template = m.template ?? (m.codeSnippet ? codeConnectTemplate(m.codeSnippet) : null);
+    if (template) {
+      out.template = template;
+      out.templateDataJson = JSON.stringify({ isParserless: true, imports: m.imports ?? [] });
+    }
+    return out;
+  });
   return {
     fileKey,
     nodeId: mappings[0]?.nodeId ?? "",

--- a/scripts/design-artifacts/publish-code-connect.test.mjs
+++ b/scripts/design-artifacts/publish-code-connect.test.mjs
@@ -9,11 +9,34 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import {
+  codeConnectTemplate,
   fileKeyFromArg,
   indexNodesByName,
   resolveMappings,
   toSendMappingsPayload,
 } from "./publish-code-connect.mjs";
+
+test("codeConnectTemplate wraps a snippet in a figma.code parserless template", () => {
+  const t = codeConnectTemplate("Foo(\n    bar = /* Baz */,\n)");
+  assert.match(t, /export default figma\.code`Foo\(/);
+  assert.match(t, /const figma = require\('figma'\)/);
+});
+
+test("toSendMappingsPayload turns a codeSnippet into template + templateDataJson", () => {
+  const payload = toSendMappingsPayload("K", [
+    {
+      nodeId: "1:1",
+      componentName: "Foo",
+      source: "s",
+      label: "Compose",
+      codeSnippet: "Foo(\n    bar = /* Baz */,\n)",
+      imports: ["import com.x.Foo"],
+    },
+  ]);
+  const m = payload.mappings[0];
+  assert.match(m.template, /figma\.code`Foo\(/);
+  assert.deepEqual(JSON.parse(m.templateDataJson), { isParserless: true, imports: ["import com.x.Foo"] });
+});
 
 test("fileKeyFromArg accepts a bare key or a /design/ URL", () => {
   assert.equal(fileKeyFromArg("gYzowY4cQ7rNr2gYoco1M6"), "gYzowY4cQ7rNr2gYoco1M6");


### PR DESCRIPTION
## Summary

Stage 2 of the Code Connect work (follows #2524, #2525). Emits a **real call site** — a `figma.code` template — instead of a bare mapping, so Dev Mode / the Figma MCP show `DeviceSummaryCard(state = …)` rather than `DeviceSummaryCard()`.

The key enabler is reading the target composable's **real Kotlin signature** from its `@kotlin.Metadata`. The JVM bytecode signature is no good here — Compose's compiler drops parameter names and inserts synthetic `Composer` / `changed: Int` / default-mask params. Metadata carries the source signature, so we get the parameters as authored, clean.

### Kotlin (`preview-discovery`)
- **`ComposableSignature`** (new): reads a target's value parameters (name / type / `hasDefault` / `composableSlot`) from `@kotlin.Metadata` via `kotlin-metadata-jvm`, parsing the `@Metadata` annotation off the class bytes with ASM. Best-effort and non-fatal — any failure (absent metadata, a newer compiler than the reader, no match) degrades to an empty list. Read leniently so a consumer on a newer Kotlin still parses.
- `PreviewTarget` gains a `parameters: List<TargetParameter>` field; `PreviewTargetInference` attaches them for the winning target. Since the bundle's `previews.json` **is** `PreviewInfo`, this flows to the export side for free.

### JS (`design-artifacts`)
- `targetsByFunction` carries `parameters` + `className`.
- `renderCallSite` builds the minimal call (required params only; a function slot as `name = { }`, others as `name = <type-placeholder>`); `buildCodeConnectManifest` attaches `codeSnippet` / `imports` / `parameters` when the emitted component is the inferred target.
- `publish-code-connect` wraps `codeSnippet` into a `figma.code` parserless `template` with `imports` in `templateDataJson`.

A component with no required params, or whose signature couldn't be read, degrades to a bare `Foo()` — still valid. `docs/code-connect.md` documents the call-site emission.

This gets Code Connect close to its full promise. Remaining Stage 3 (Figma variant-prop → parameter binding) is inherently part-authored even in Figma's own tooling.

## Test plan

- [x] `:gradle-plugin:preview-discovery:test` — full suite green, incl. new `ComposableSignatureTest` (reads names/types/defaults/slot from a compiled fixture's real metadata; a no-param fn yields `[]`).
- [x] `node --test` from `scripts/design-artifacts/` — **120 pass, 0 fail** (call-site render, emit attachment, `figma.code` template + `templateDataJson`).
- [x] `ktfmtFormat` applied to the touched Kotlin.
- [x] Verified end-to-end during development: the metadata reader resolves `sampleComponent(state: String, count: Int = 3, labels: List<String>, onClick: () -> Unit, note: String? = null)` to the exact param list with correct default flags and `() -> Unit` slot detection.

Non-visual change (discovery/data plumbing, docs, tests).

---
_Generated by [Claude Code](https://claude.ai/code/session_01FnX9TKA4TRpCj3PJhK5M7q)_