### PR TITLE
fix(catalog): make Live Compose stickers interactive via LocalInspectionMode

### DIFF
--- a/samples/design-catalog-m3/src/main/kotlin/com/example/designcatalogm3/CatalogPreviews.kt
+++ b/samples/design-catalog-m3/src/main/kotlin/com/example/designcatalogm3/CatalogPreviews.kt
@@ -16,6 +16,7 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalInspectionMode
 import com.example.designcatalogm3.shared.CatalogComponent
 import com.example.designcatalogm3.shared.generated.resources.Res
 import com.example.designcatalogm3.shared.generated.resources.msg_deploy
@@ -29,10 +30,19 @@ import ee.schimke.composeai.preview.slots.LocalSlotMode
 import org.jetbrains.compose.resources.stringResource
 
 // The M3 catalog sticker sheet: one `@Preview` per component, in light + dark (`@CatalogModes`).
-// Each is a thin wrapper — `CatalogSticker { CatalogComponent("<slug>", interactive = false) }` —
-// over the shared component set in `:samples:design-catalog-m3-shared`, so the bodies live in one
-// place (also mounted live by the in-browser wasm tier). `interactive = false` renders the
-// deterministic baked frame (static toggles / determinate progress) the published catalog shows.
+// Each is a thin wrapper — `CatalogSticker { CatalogComponent("<slug>", interactive = …) }` — over
+// the shared component set in `:samples:design-catalog-m3-shared`, so the bodies live in one place
+// (also mounted live by the in-browser wasm tier).
+//
+// `interactive` is derived from `LocalInspectionMode` rather than hard-coded, so the SAME `@Preview`
+// serves both lanes correctly (the two share this sticker sheet — see [Sticker]):
+//   * baked snapshot / one-shot `/render` (`LocalInspectionMode = true`) → `interactive = false`,
+//     the deterministic frame (static toggles / determinate progress) the published catalog shows —
+//     pixel-unchanged.
+//   * held **Live Compose** daemon session (`LocalInspectionMode = false`) → `interactive = true`,
+//     so its click dispatch actually toggles the segmented button / switch / chip and drives the
+//     stateful widgets — matching what the in-browser wasm tier already does. Hard-coding `false`
+//     left every live-lane click a no-op (the segmented toggle wouldn't flip).
 //
 // Function names are the join key the export driver matches against `catalog.spec.json`'s `preview`
 // field (`PreviewDiscovery` keys off the function name), so they must not change.
@@ -140,9 +150,19 @@ fun SlottedCardSlotsSticker() = CatalogSticker {
  */
 @Composable
 // A clean one-liner: the theme (and the font / palette override) lives entirely in
-// [CatalogSticker],
-// so a preview never spells the typeface or knows an override exists.
-private fun Sticker(id: String) = CatalogSticker { CatalogComponent(id, interactive = false) }
+// [CatalogSticker], so a preview never spells the typeface or knows an override exists.
+//
+// `interactive = !LocalInspectionMode.current`, so a single sticker serves both render lanes:
+//   * one-shot / baked render — `LocalInspectionMode = true` (Compose's preview signal, and what
+//     the daemon's one-shot `/render` lane sets) → `interactive = false` → a deterministic static
+//     frame, pixel-unchanged from before.
+//   * held Live Compose daemon session — `DesktopHost.acquireInteractiveSession` seeds
+//     `inspectionMode = false` → `interactive = true` → live, stateful widgets whose click dispatch
+//     actually mutates state (the segmented toggle flips, the switch/chip toggle).
+// This is the one lever on which the baked and live lanes diverge, exactly as `CatalogComponent`
+// documents.
+private fun Sticker(id: String) =
+  CatalogSticker { CatalogComponent(id, interactive = !LocalInspectionMode.current) }
 
 // ---------------------------------------------------------------------------
 // Scaffold templates — full-screen, pre-built screen skeletons an app copies


### PR DESCRIPTION
## Summary

In **Live Compose** (daemon-stream) mode — e.g. `…/compose-m3/p/segmentedbutton__ideal__default__light` — the segmented toggle didn't respond to clicks: clicking **Off** never toggled, and the ripple stayed on the selected **On** segment.

Root cause is not the `SegmentedToggle` composable (it's correct, and the in-browser Wasm tier already works). The desktop `@Preview` sticker sheet rendered every component with a hard-coded `CatalogComponent(id, interactive = false)`. With `interactive = false`, `SegmentedToggle` pins "On" as selected (`selected = if (interactive) … else true`) and guards its handlers to no-ops (`onClick = { if (interactive) selected = 1 }`). The Live Compose lane routes real clicks into a held composition via `DesktopInteractiveSession`, but those clicks hit no-op handlers — so nothing toggled and "On" stayed lit. Switch / slider / chip were dead in the same lane.

The codebase already carries the right signal: `LocalInspectionMode`, which the daemon sets `true` for baked / one-shot renders and `false` for the held interactive session (`DesktopHost.acquireInteractiveSession`; documented in `RenderEngine.setUp`). The stickers just ignored it.

## Change

One line in the desktop `Sticker` wrapper (`samples/design-catalog-m3/.../CatalogPreviews.kt`):

```kotlin
CatalogSticker { CatalogComponent(id, interactive = !LocalInspectionMode.current) }
```

- **Baked snapshot / one-shot `/render`** (`LocalInspectionMode = true`) → `interactive = false` → deterministic frame, **pixel-identical** to before.
- **Held Live Compose daemon session** (`LocalInspectionMode = false`) → `interactive = true` → click dispatch mutates state, matching the Wasm tier.

This fixes the whole live lane (segmented button, switch, slider, chip), not just one component.

## Test plan

- [x] `./gradlew :samples:design-catalog-m3:compileKotlin` → `BUILD SUCCESSFUL`.
- Baked catalog PNGs are unchanged by construction: the snapshot / one-shot `/render` lanes keep `LocalInspectionMode = true` → `interactive = false`, the exact prior code path. The visual-diff bot should report no sticker changes.
- Behavioral fix is confined to the daemon interactive session (`LocalInspectionMode = false`): opening the preview in **Live Compose** mode and clicking **Off** now flips the selection to "Off".

## Visual evidence

This is a **behavioral** change to the live interactive lane, not a change to any rendered sticker — the baked pixels are intentionally identical. There's no static before/after image to embed for the clickable behavior; a human/CI verifies it by clicking the segmented toggle in Live Compose mode, and the visual-diff bot confirms the baked stickers are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011P7nQurmu63kAL5MwC8yXt)_