### PR TITLE
feat: compose/figma-svg output from render, bundles, and a VS Code copy button

### DIFF
--- a/cli/completions/compose-preview.fish
+++ b/cli/completions/compose-preview.fish
@@ -203,7 +203,11 @@ end
 
 # render: --output <path>.
 complete -c compose-preview -r -n '__compose_preview_using_command render' \
-    -l output -d 'Copy the single matched PNG to this path'
+    -l output -d 'Copy the single matched preview (PNG, or .svg under --format svg) to this path'
+
+# render: --format png|svg (svg emits the editable compose/figma-svg vector per preview).
+complete -c compose-preview -x -n '__compose_preview_using_command render' \
+    -l format -a 'png svg' -d 'Output format (default png; svg = editable compose/figma-svg vector)'
 
 # a11y / report commands: --fail-on.
 complete -c compose-preview -x -n '__compose_preview_using_command a11y' \

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -1099,7 +1099,30 @@ class RenderCommand(args: List<String>) : Command(args) {
    */
   private val embedDeps: Boolean = "--embed-deps" in args
 
+  /**
+   * `--format png|svg` (default `png`). `svg` emits the layered, editable `compose/figma-svg`
+   * vector export per matched preview instead of stopping at the raster PNG. Because the standalone
+   * `composePreviewRender` task never produces figma-svg (it's a daemon-only structured data
+   * product — see `docs/DATA_PRODUCTS.md`), `--format svg` drives a short-lived render daemon after
+   * the render, exactly like `bundle pack --with-semantics`. The PNGs are still produced; the SVGs
+   * are the additional deliverable.
+   */
+  private val formatFlag: String? =
+    args.flagValue("--format")?.trim()?.lowercase()?.ifEmpty { null }
+
   override fun run() {
+    val svg =
+      when (formatFlag) {
+        null,
+        "png" -> false
+        "svg" -> true
+        else -> {
+          System.err.println(
+            "unsupported --format '$formatFlag' for render; expected 'png' or 'svg'"
+          )
+          exitProcess(1)
+        }
+      }
     withGradle { gradle ->
       val modules = resolveModules(gradle)
       val xrArgs = provisionXrCompositeArgs(gradle, modules, silenceStdout = false)
@@ -1123,6 +1146,11 @@ class RenderCommand(args: List<String>) : Command(args) {
       if (filtered.isEmpty()) {
         System.err.println("No previews matched.")
         exitProcess(3)
+      }
+
+      if (svg) {
+        emitSvgOutputs(gradle, modules, filtered)
+        return@withGradle
       }
 
       val missing = previewsMissingPng(filtered)
@@ -1159,6 +1187,175 @@ class RenderCommand(args: List<String>) : Command(args) {
         }
       }
     }
+  }
+
+  /**
+   * `--format svg` output pass. The standalone render never produces figma-svg (a daemon-only
+   * structured data product), so — exactly like `bundle pack --with-semantics` — we regenerate each
+   * module's `daemon-launch.json` and drive a short-lived [DaemonSemanticsFetcher] render so the
+   * always-on `compose/figma-svg` extension writes each preview's sidecar, then land those bytes.
+   *
+   * Where they land depends on `--bundle`:
+   * - **without `--bundle`**: loose `.svg` files. With `--output` a single matched preview's SVG is
+   *   written to that path; otherwise each lands at
+   *   `<module>/build/compose-previews/renders/<id>.svg` beside the PNGs.
+   * - **with `--bundle`**: the SVGs (and any hybrid `figma-raster/<node>.png` crops) are injected
+   *   into each module's freshly-packed `bundle.png` as `previews/<id>.figma.svg`, the same carrier
+   *   `bundle pack --with-semantics` uses — so the packaged live bundle ships the editable vector
+   *   per preview alongside the raster cover.
+   *
+   * Best-effort per preview (a backend with no figma-svg producer, or a preview that drew no vector
+   * layers, is simply skipped with a stderr note), but if *nothing* was produced the command exits
+   * non-zero — `--format svg` asked for SVG and got none.
+   */
+  private fun emitSvgOutputs(
+    gradle: GradleConnection,
+    modules: List<PreviewModule>,
+    filtered: List<PreviewResult>,
+  ) {
+    // A single-file `--output` target only makes sense for loose output; `--bundle` injects into
+    // each module's bundle, so the two are mutually exclusive.
+    if (output != null && bundle) {
+      System.err.println("--output cannot be combined with --bundle for --format svg.")
+      exitProcess(1)
+    }
+    if (output != null && filtered.size != 1) {
+      System.err.println(
+        "--output requires a single match (got ${filtered.size}). " +
+          "Narrow with --id <exact> or --filter <substring>."
+      )
+      exitProcess(1)
+    }
+
+    val moduleByPath = modules.associateBy { it.gradlePath }
+    var totalWritten = 0
+    for ((modulePath, rows) in filtered.groupBy { it.module }) {
+      val module = moduleByPath[modulePath] ?: continue
+      // Regenerate the launch descriptor against the current classpath in a separate invocation —
+      // its failure only forfeits this module's SVGs, it must not abort the whole command.
+      val daemonStarted =
+        runGradle(
+          gradle,
+          ":$modulePath:composePreviewDaemonStart",
+          arguments = gradleArgsWithForce(),
+        )
+      if (!daemonStarted) {
+        System.err.println(
+          "render --format svg: could not start the preview daemon for $modulePath " +
+            "(composePreviewDaemonStart failed) — no SVG produced for its previews."
+        )
+        continue
+      }
+
+      val fetcher =
+        DaemonSemanticsFetcher(onLog = { if (verbose) System.err.println("[daemon svg] $it") })
+      val outcome =
+        fetcher.fetch(
+          projectDir = module.projectDir,
+          moduleName = modulePath,
+          previewIds = rows.map { it.id },
+        )
+      val svgById: Map<String, ByteArray>
+      val rasterById: Map<String, Map<String, ByteArray>>
+      when (outcome) {
+        is DaemonSemanticsFetcher.Outcome.Ok -> {
+          svgById = outcome.figmaSvgById
+          rasterById = outcome.figmaRasterById
+        }
+        is DaemonSemanticsFetcher.Outcome.DescriptorMissing -> {
+          System.err.println(
+            "render --format svg: daemon-launch.json missing at ${outcome.expected.path} for " +
+              "$modulePath — no SVG produced."
+          )
+          continue
+        }
+        is DaemonSemanticsFetcher.Outcome.OpenFailed -> {
+          System.err.println(
+            "render --format svg: could not open a render session for $modulePath " +
+              "(${outcome.reason}) — no SVG produced."
+          )
+          continue
+        }
+      }
+
+      totalWritten +=
+        if (bundle) injectSvgIntoModuleBundle(module, modulePath, svgById, rasterById)
+        else writeLooseSvgFiles(module, rows, svgById, rasterById)
+
+      val noSvg = rows.filter { it.id !in svgById }
+      if (noSvg.isNotEmpty()) {
+        System.err.println(
+          "render --format svg: no figma-svg for ${noSvg.size} preview(s) in $modulePath " +
+            "(backend has no figma-svg producer, or the preview drew no vector layers):"
+        )
+        for (r in noSvg) System.err.println("  ${r.id}")
+      }
+    }
+
+    if (totalWritten == 0) {
+      System.err.println("render --format svg produced no SVG output.")
+      exitProcess(2)
+    }
+    if (output == null && !bundle) println("Wrote $totalWritten SVG file(s)")
+  }
+
+  /**
+   * Write one module's figma-svg exports as loose `.svg` files (the non-`--bundle` path) and return
+   * the number written. A hybrid preview's `figma-raster/<node>.png` crops ride along in a sibling
+   * `<id>.figma-raster/` dir via [RenderSvgOutput.write].
+   */
+  private fun writeLooseSvgFiles(
+    module: PreviewModule,
+    rows: List<PreviewResult>,
+    svgById: Map<String, ByteArray>,
+    rasterById: Map<String, Map<String, ByteArray>>,
+  ): Int {
+    val rendersDir = module.projectDir.resolve("build/compose-previews/renders")
+    var written = 0
+    for (row in rows) {
+      val svgBytes = svgById[row.id] ?: continue
+      val target =
+        if (output != null) File(output)
+        else File(rendersDir, RenderSvgOutput.safeFilename(row.id) + ".svg")
+      RenderSvgOutput.write(target, svgBytes, rasterById[row.id].orEmpty(), fileSystem)
+      written++
+      println(
+        if (output != null) "Rendered ${row.id} to ${target.path}" else "Wrote ${target.path}"
+      )
+    }
+    return written
+  }
+
+  /**
+   * Inject one module's figma-svg exports (and hybrid raster crops) into its freshly-packed
+   * `bundle.png` as `previews/<id>.figma.svg` — the same carrier + reusable injectors `bundle pack
+   * --with-semantics` uses. Returns the number of SVG entries written (0 if the bundle is missing).
+   * Best-effort: a missing bundle warns rather than aborting the whole command.
+   */
+  private fun injectSvgIntoModuleBundle(
+    module: PreviewModule,
+    modulePath: String,
+    svgById: Map<String, ByteArray>,
+    rasterById: Map<String, Map<String, ByteArray>>,
+  ): Int {
+    val bundleFile = module.projectDir.resolve("build/compose-previews/bundle.png")
+    if (!bundleFile.isFile) {
+      System.err.println(
+        "render --format svg --bundle: expected bundle missing at ${bundleFile.path} for " +
+          "$modulePath — cannot inject SVG."
+      )
+      return 0
+    }
+    val svgWritten = injectFigmaSvgIntoBundle(bundleFile, svgById, fileSystem)
+    val rasterWritten = injectFigmaRasterIntoBundle(bundleFile, rasterById, fileSystem)
+    if (svgWritten > 0) {
+      println(
+        "Injected $svgWritten figma-svg" +
+          (if (rasterWritten > 0) " + $rasterWritten raster crop(s)" else "") +
+          " into ${bundleFile.path} as previews/<id>$BUNDLE_FIGMA_SVG_SUFFIX"
+      )
+    }
+    return svgWritten
   }
 
   /**

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
@@ -146,7 +146,12 @@ private fun printFullUsage() {
       list             List discovered previews
       render           Render previews; with --output copies a single match to disk.
                        --bundle additionally packs each module's previews into a
-                       portable PNG+ZIP bundle (off by default).
+                       portable PNG+ZIP bundle (off by default). --format svg emits
+                       the editable compose/figma-svg vector per preview (into
+                       renders/<id>.svg, or --output for a single match) alongside
+                       the PNGs — driven through a short-lived render daemon. Combine
+                       --format svg --bundle to inject the vectors into each module's
+                       bundle.png as previews/<id>.figma.svg.
       render-matrix    Render one preview across a cross-product of display axes
                        (--device/--locale/--ui-mode/--font-scale); per-cell hashes +
                        optional --contact-sheet grid PNG.
@@ -207,14 +212,16 @@ private fun printFullUsage() {
       --json               Emit JSON (show, list, a11y, devices)
       --brief              JSON only: drop functionName/className/sourceFile/params
       --changed-only       JSON only (show, a11y): drop previews with no changed capture
-      --output <path>      Copy matched preview PNG to this path (render)
+      --output <path>      Copy a single matched preview to this path (render; the PNG, or the
+                           .svg under --format svg)
       --preview <ref>      record: preview to record — an id, a `Class.function` reference, or a
                            unique substring of an id
       --script <path>      record: JSON array of RecordingScriptEvent driving the session
       --out <path>         record: write the encoded recording here (extension auto-selects the
                            format unless --format is set)
-      --format <fmt>       record: gif | apng | mp4 | webm. gif/apng always available (pure-JVM);
-                           mp4/webm need ffmpeg on PATH
+      --format <fmt>       render: png (default) | svg — svg emits the editable compose/figma-svg
+                           vector per preview (daemon-driven). record: gif | apng | mp4 | webm.
+                           gif/apng always available (pure-JVM); mp4/webm need ffmpeg on PATH
       --fps <n>            record: frames per second of the virtual playback clock (default 30)
       --scale <f>          record: capture scale multiplier (default 1.0)
       --overrides <k=v,…>  record: per-render overrides, e.g. touchOverlay=true (also device,

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/RenderSvgOutput.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/RenderSvgOutput.kt
@@ -1,0 +1,65 @@
+package ee.schimke.composeai.cli
+
+import ee.schimke.composeai.data.layoutinspector.ComposeFigmaSvgProduct
+import ee.schimke.composeai.io.SystemFileSystem
+import java.io.File
+import okio.FileSystem
+import okio.Path.Companion.toPath
+
+/**
+ * Writes the daemon-produced `compose/figma-svg` export for one preview to a standalone `.svg` on
+ * disk — the `compose-preview render --format svg` output. Mirrors how `bundle pack
+ * --with-semantics` carries the same bytes inside a bundle, but lands them as loose files a user
+ * can open directly.
+ *
+ * # Hybrid crops
+ *
+ * A pure-vector export (the common case for a component catalog) is a single self-contained `.svg`.
+ * A **hybrid** export — one whose opaque `Image`/`Icon`/`Canvas` nodes are emitted as `<image>`
+ * placeholders — references sibling `figma-raster/<node>.png` crops via **relative** hrefs. The
+ * daemon writes those crops beside the sidecar in its own `data/<id>/figma-raster/` dir. When we
+ * flatten the SVG to `renders/<id>.svg`, the crops move to a sibling `renders/<id>.figma-raster/`
+ * dir, so the `figma-raster/` href prefix is rewritten to `<id>.figma-raster/` to keep the
+ * `<image>` layers resolving. Naming the crop dir after the SVG stem also avoids collisions when
+ * several previews' SVGs share one `renders/` dir.
+ */
+internal object RenderSvgOutput {
+  /**
+   * Strip filesystem-hostile characters from a preview id (mirrors `BundleRenderer.safeFilename`).
+   */
+  fun safeFilename(id: String): String =
+    id.map { c -> if (c.isLetterOrDigit() || c in "._-") c else '_' }.joinToString("")
+
+  /**
+   * Write [svgBytes] to [target] (an `.svg` path), creating parent dirs as needed. When [crops] is
+   * non-empty (a hybrid export), also write each `<node>.png` into a sibling
+   * `<target-stem>.figma-raster/` dir and rewrite the SVG's `figma-raster/` href prefix to point at
+   * it. Returns the number of files written (the SVG plus any crops).
+   */
+  fun write(
+    target: File,
+    svgBytes: ByteArray,
+    crops: Map<String, ByteArray> = emptyMap(),
+    fileSystem: FileSystem = SystemFileSystem,
+  ): Int {
+    target.parentFile?.mkdirs()
+    if (crops.isEmpty()) {
+      fileSystem.write(target.path.toPath()) { write(svgBytes) }
+      return 1
+    }
+
+    val stem = target.name.removeSuffix(".svg")
+    val rasterDirName = "$stem.${ComposeFigmaSvgProduct.RASTER_DIR}"
+    val rewritten =
+      svgBytes.decodeToString().replace("${ComposeFigmaSvgProduct.RASTER_DIR}/", "$rasterDirName/")
+    fileSystem.write(target.path.toPath()) { write(rewritten.encodeToByteArray()) }
+
+    var written = 1
+    val rasterDir = File(target.parentFile, rasterDirName).also { it.mkdirs() }
+    for ((name, bytes) in crops) {
+      fileSystem.write(File(rasterDir, name).path.toPath()) { write(bytes) }
+      written++
+    }
+    return written
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/RenderSvgOutputTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/RenderSvgOutputTest.kt
@@ -1,0 +1,80 @@
+package ee.schimke.composeai.cli
+
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Coverage for [RenderSvgOutput.write] — the on-disk landing of `render --format svg`. The two
+ * cases that matter are the pure-vector export (a single self-contained `.svg`) and the hybrid
+ * export, whose relative `figma-raster/<node>.png` hrefs must be re-pointed at the flattened crop
+ * dir so the `<image>` layers still resolve once the SVG sits beside its peers in `renders/`.
+ */
+class RenderSvgOutputTest {
+  private val tempDirs = mutableListOf<File>()
+
+  @AfterTest
+  fun cleanup() {
+    tempDirs.forEach { it.deleteRecursively() }
+  }
+
+  private fun tempDir(): File =
+    Files.createTempDirectory("compose-preview-svgout-").toFile().also { tempDirs += it }
+
+  private fun vectorSvg(): ByteArray =
+    """<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><rect width="10" height="10"/></svg>"""
+      .encodeToByteArray()
+
+  private fun hybridSvg(): ByteArray =
+    """<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><image href="figma-raster/node-1.png" width="10" height="10"/></svg>"""
+      .encodeToByteArray()
+
+  @Test
+  fun `pure vector writes a single self-contained svg`() {
+    val dir = tempDir()
+    val target = File(dir, "MyPreview.svg")
+
+    val written = RenderSvgOutput.write(target, vectorSvg())
+
+    assertEquals(1, written)
+    assertTrue(target.isFile)
+    assertEquals(vectorSvg().decodeToString(), target.readText())
+    // No crop dir materialised for a vector-only export.
+    assertFalse(File(dir, "MyPreview.figma-raster").exists())
+  }
+
+  @Test
+  fun `hybrid rewrites href prefix and lands crops in a stem-named sibling dir`() {
+    val dir = tempDir()
+    val target = File(dir, "MyPreview.svg")
+    val cropBytes =
+      byteArrayOf(0x89.toByte(), 'P'.code.toByte(), 'N'.code.toByte(), 'G'.code.toByte())
+
+    val written = RenderSvgOutput.write(target, hybridSvg(), mapOf("node-1.png" to cropBytes))
+
+    // svg + one crop.
+    assertEquals(2, written)
+    val svgText = target.readText()
+    // Href now points at the flattened, stem-named crop dir — not the bare daemon-relative one.
+    assertTrue(
+      svgText.contains("href=\"MyPreview.figma-raster/node-1.png\""),
+      "expected rewritten href, got: $svgText",
+    )
+    assertFalse(
+      svgText.contains("href=\"figma-raster/node-1.png\""),
+      "bare figma-raster/ href should have been rewritten",
+    )
+    val crop = File(dir, "MyPreview.figma-raster/node-1.png")
+    assertTrue(crop.isFile)
+    assertTrue(cropBytes.contentEquals(crop.readBytes()))
+  }
+
+  @Test
+  fun `safeFilename strips filesystem-hostile characters`() {
+    assertEquals("com.example.Foo_bar_", RenderSvgOutput.safeFilename("com.example.Foo bar/"))
+  }
+}

--- a/docs/DATA_PRODUCTS.md
+++ b/docs/DATA_PRODUCTS.md
@@ -10,6 +10,10 @@ Consumers reach them three ways, all backed by the same daemon:
 - the VS Code chip toggle (`data/subscribe`),
 - `compose-preview a11y` and the MCP server (`get_preview_data`), which spin up or
   talk to a daemon,
+- `compose-preview bundle pack --with-semantics` and `compose-preview render --format
+  svg`, which drive a short-lived daemon (`DaemonSemanticsFetcher`) to bake the
+  `compose/figma-svg` (and semantics) sidecars, then carry them into the bundle or land
+  them as loose `.svg` files,
 - on-disk history (`compose-preview history`), which reads what the daemon archived.
 
 The standalone `composePreviewRenderAll` Gradle Test task is the **lean PNG path**:

--- a/vscode-extension/src/daemon/daemonScheduler.ts
+++ b/vscode-extension/src/daemon/daemonScheduler.ts
@@ -225,6 +225,17 @@ export interface DaemonScheduler {
             absolutePath: string;
         },
     ): Promise<string | null>;
+    /**
+     * Pull a preview's `compose/figma-svg` export (the layered, editable vector) through the
+     * daemon's `data/fetch` re-render path and return the absolute on-disk path the daemon wrote
+     * (`<module>/build/compose-previews/data/<id>/compose-figma.svg`), or `null` when the daemon
+     * isn't ready, doesn't advertise the kind, or the preview drew no vector layers. The webview's
+     * "Copy SVG" affordance reads the file at this path and writes it to the clipboard.
+     */
+    fetchFigmaSvg(
+        module: ModuleInfo,
+        previewId: string,
+    ): Promise<string | null>;
     daemonEvents(moduleId: string): DaemonClientEvents;
 }
 
@@ -805,6 +816,31 @@ export class LiveDaemonScheduler implements DaemonScheduler {
         }
     }
 
+    async fetchFigmaSvg(
+        module: ModuleInfo,
+        previewId: string,
+    ): Promise<string | null> {
+        const client = await this.gate.getOrSpawn(
+            module,
+            this.daemonEvents(module.modulePath),
+        );
+        if (!client) return null;
+        try {
+            const result = await client.dataFetch({
+                previewId,
+                kind: "compose/figma-svg",
+                inline: false,
+            });
+            return result.path ?? null;
+        } catch (err) {
+            // DataProductUnknown (-32020) on a daemon without the figma-svg producer, or
+            // FetchFailed when the preview drew no vector layers — both surface as throws.
+            // Return null so the caller reports "SVG unavailable" rather than crashing.
+            void err;
+            return null;
+        }
+    }
+
     daemonEvents(moduleId: string) {
         return {
             onRenderFinished: (params: RenderFinishedParams) => {
@@ -1028,6 +1064,14 @@ export class GradleOnlyDaemonScheduler implements DaemonScheduler {
         },
     ): Promise<string | null> {
         /* no-op: minimal mode has no daemon; caller falls back to Gradle */
+        return null;
+    }
+
+    async fetchFigmaSvg(
+        _module: ModuleInfo,
+        _previewId: string,
+    ): Promise<string | null> {
+        /* no-op: minimal mode has no daemon, so no figma-svg export */
         return null;
     }
 

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -769,15 +769,13 @@ export function applyDataProductsToRegistry(
         try {
             if (dp.kind === "a11y/atf") {
                 const payload = (dp.payload ?? readJsonPath(dp.path, log)) as
-                    | { findings?: AccessibilityFinding[] }
-                    | undefined;
+                    { findings?: AccessibilityFinding[] } | undefined;
                 if (payload?.findings) {
                     findings = payload.findings;
                 }
             } else if (dp.kind === "a11y/hierarchy") {
                 const payload = (dp.payload ?? readJsonPath(dp.path, log)) as
-                    | { nodes?: AccessibilityNode[] }
-                    | undefined;
+                    { nodes?: AccessibilityNode[] } | undefined;
                 if (payload?.nodes) {
                     nodes = payload.nodes;
                 }
@@ -1789,14 +1787,12 @@ export async function activate(
                         picked: !scope.gitRef,
                         ref: undefined,
                     },
-                    ...branches.map(
-                        (b): RefItem => ({
-                            label: "$(git-branch) " + b.label,
-                            description: b.ref,
-                            picked: scope.gitRef === b.ref,
-                            ref: b.ref,
-                        }),
-                    ),
+                    ...branches.map((b): RefItem => ({
+                        label: "$(git-branch) " + b.label,
+                        description: b.ref,
+                        picked: scope.gitRef === b.ref,
+                        ref: b.ref,
+                    })),
                 ];
                 const pick = await vscode.window.showQuickPick(items, {
                     title: "Preview History — source",
@@ -4693,11 +4689,7 @@ function sourceLooksLikePreviewDeclaration(
  *   will run a real refresh.
  */
 type RefreshOutcome =
-    | "completed"
-    | "cancelled"
-    | "no-module"
-    | "failed"
-    | "gated";
+    "completed" | "cancelled" | "no-module" | "failed" | "gated";
 
 /**
  * Rank for the coalesce-or-supersede decision when a new refresh arrives
@@ -5903,6 +5895,9 @@ function handleWebviewMessage(msg: WebviewToExtension) {
                 void exportPreviewBundle(msg.previewId);
             }
             break;
+        case "copyFigmaSvg":
+            void handleCopyFigmaSvg(msg.previewId);
+            break;
         case "bundleDropped":
             if (earlyFeaturesEnabled()) {
                 void handleBundleDropped(msg.fsPath, msg.fileName);
@@ -6294,8 +6289,8 @@ async function handleSetRemoteComposeNamedValue(
     // would shadow user edits with stale values from the last-attached payload.
     const priorOverride = remoteComposeOverridesByPreview.get(previewId);
     let seed:
-        | import("./daemon/daemonProtocol").RemoteComposeOverride
-        | undefined = priorOverride;
+        import("./daemon/daemonProtocol").RemoteComposeOverride | undefined =
+        priorOverride;
     if (!seed) {
         const snapshot = latestRemoteComposeByPreview.get(previewId);
         if (snapshot) {
@@ -6419,7 +6414,10 @@ async function handleSetLottieProgress(
         // Compose over the host-authoritative bag so scrubbing keeps a co-active
         // permissions / remoteCompose / clear-background override. `lottie` itself is
         // daemon-sticky, so it's added here inline rather than stored host-side.
-        { ...(buildPreviewOverrides(previewId) ?? {}), lottie: { progress: clamped } },
+        {
+            ...(buildPreviewOverrides(previewId) ?? {}),
+            lottie: { progress: clamped },
+        },
     );
 }
 
@@ -7279,6 +7277,66 @@ function formatRelativeShort(iso: string | undefined): string {
  * success / failure via toasts; the resulting `.png` is a valid image that
  * also unzips to the bundle contents.
  */
+/**
+ * Copy a preview's `compose/figma-svg` export (the layered, editable vector) to the clipboard.
+ * Pulls the SVG through the daemon's `data/fetch` (may trigger a re-render), reads the file the
+ * daemon wrote, and writes its text to the clipboard. Best-effort: an unavailable export (backend
+ * without the figma-svg producer, or a preview that drew no vector layers) surfaces as a warning
+ * rather than an error.
+ */
+async function handleCopyFigmaSvg(previewId: string): Promise<void> {
+    const module = previewModuleIndex.get(previewId);
+    if (!module) {
+        vscode.window.showWarningMessage(
+            "Compose Preview: could not resolve the module for this preview.",
+        );
+        return;
+    }
+    if (!daemonScheduler) {
+        vscode.window.showInformationMessage(
+            "Compose Preview is not ready yet.",
+        );
+        return;
+    }
+    const label = lookupPreviewLabel(previewId) ?? previewId;
+    let svgPath: string | null = null;
+    try {
+        svgPath = await vscode.window.withProgress(
+            {
+                location: vscode.ProgressLocation.Window,
+                title: `Copying ${label} SVG…`,
+            },
+            () => daemonScheduler!.fetchFigmaSvg(module, previewId),
+        );
+    } catch (err) {
+        logLine(
+            `copy figma-svg: fetch failed for ${previewId}: ${(err as Error).message ?? String(err)}`,
+        );
+    }
+    if (!svgPath) {
+        vscode.window.showWarningMessage(
+            `Compose Preview: no SVG available for ${label}. The backend may not produce ` +
+                `compose/figma-svg, or the preview drew no vector layers.`,
+        );
+        return;
+    }
+    let svg: string;
+    try {
+        svg = fs.readFileSync(svgPath, "utf8");
+    } catch (err) {
+        const message = (err as Error).message ?? String(err);
+        logLine(`copy figma-svg: read failed at ${svgPath}: ${message}`);
+        vscode.window.showErrorMessage(
+            `Compose Preview: could not read the SVG for ${label} — ${message}`,
+        );
+        return;
+    }
+    await vscode.env.clipboard.writeText(svg);
+    vscode.window.showInformationMessage(
+        `Compose Preview: copied ${label} as SVG to the clipboard.`,
+    );
+}
+
 async function exportPreviewBundle(previewId: string): Promise<void> {
     if (!gradleService) {
         vscode.window.showInformationMessage(

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -7331,9 +7331,37 @@ async function handleCopyFigmaSvg(previewId: string): Promise<void> {
         );
         return;
     }
+    // Inline any hybrid `figma-raster/<node>.png` crops as data URIs so the clipboard SVG is
+    // self-contained — a bare relative href can't resolve once the text is pasted into Figma or
+    // another consumer away from the sidecar dir. No-op for a pure-vector export.
+    svg = inlineFigmaSvgRasterLayers(svg, path.dirname(svgPath));
     await vscode.env.clipboard.writeText(svg);
     vscode.window.showInformationMessage(
         `Compose Preview: copied ${label} as SVG to the clipboard.`,
+    );
+}
+
+/**
+ * Rewrite a figma-svg's relative `figma-raster/<node>.png` `<image>` hrefs to inline
+ * `data:image/png;base64,…` URIs by reading the sibling crop files under [svgDir], so a copied SVG
+ * is self-contained (the CLI export path carries the crops as files instead; the clipboard can't,
+ * so it embeds them). A crop that can't be read is left as-is — best-effort. Pure-vector exports
+ * reference no crops, so this is a no-op for the common case. The `[^"'/]` node class keeps the
+ * read pinned to the crop dir (no `/` → no traversal).
+ */
+function inlineFigmaSvgRasterLayers(svgText: string, svgDir: string): string {
+    return svgText.replace(
+        /figma-raster\/([^"'/]+?\.png)/g,
+        (whole, node: string) => {
+            try {
+                const bytes = fs.readFileSync(
+                    path.join(svgDir, "figma-raster", node),
+                );
+                return `data:image/png;base64,${bytes.toString("base64")}`;
+            } catch {
+                return whole;
+            }
+        },
     );
 }
 

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -125,16 +125,10 @@ export type PreviewDataProductFacet =
     | "INTERACTIVE";
 
 export type PreviewDataProductSampling =
-    | "START"
-    | "END"
-    | "EACH_FRAME"
-    | "ON_DEMAND"
-    | "AGGREGATE"
-    | "FAILURE";
+    "START" | "END" | "EACH_FRAME" | "ON_DEMAND" | "AGGREGATE" | "FAILURE";
 
 export type PreviewExtensionUsageMode =
-    | "EXPLICIT_EFFECT"
-    | "SUGGESTED_EXTRA_PREVIEW";
+    "EXPLICIT_EFFECT" | "SUGGESTED_EXTRA_PREVIEW";
 
 export interface PreviewInfo {
     id: string;
@@ -301,24 +295,13 @@ export interface PreviewRenderErrorTopFrame {
 // -------------------------------------------------------------------------
 
 export type ResourceType =
-    | "VECTOR"
-    | "ANIMATED_VECTOR"
-    | "ADAPTIVE_ICON"
-    | string;
+    "VECTOR" | "ANIMATED_VECTOR" | "ADAPTIVE_ICON" | string;
 
 export type AdaptiveShape =
-    | "CIRCLE"
-    | "SQUIRCLE"
-    | "ROUNDED_SQUARE"
-    | "SQUARE"
-    | string;
+    "CIRCLE" | "SQUIRCLE" | "ROUNDED_SQUARE" | "SQUARE" | string;
 
 export type AdaptiveStyle =
-    | "FULL_COLOR"
-    | "THEMED_LIGHT"
-    | "THEMED_DARK"
-    | "LEGACY"
-    | string;
+    "FULL_COLOR" | "THEMED_LIGHT" | "THEMED_DARK" | "LEGACY" | string;
 
 export interface ResourceVariant {
     /**
@@ -1005,6 +988,12 @@ export type WebviewToExtension =
      * focused preview).
      */
     | { command: "requestExportPreviewBundle"; previewId: string }
+    /**
+     * Copy the preview's `compose/figma-svg` export (the layered, editable
+     * vector) to the clipboard. The host pulls the SVG through the daemon's
+     * `data/fetch` and writes the file's text to the clipboard.
+     */
+    | { command: "copyFigmaSvg"; previewId: string }
     /**
      * User dragged a file onto the sidebar preview panel. The host
      * checks that [fsPath] is a `composePreviewBundle` polyglot

--- a/vscode-extension/src/webview/preview/cardBuilder.ts
+++ b/vscode-extension/src/webview/preview/cardBuilder.ts
@@ -207,15 +207,13 @@ export function populatePreviewCard(
     }
     setCardCaptures(
         p.id,
-        captures.map(
-            (c): CapturePresentation => ({
-                label: c.label || "",
-                renderOutput: c.renderOutput || "",
-                imageData: null,
-                errorMessage: null,
-                renderError: null,
-            }),
-        ),
+        captures.map((c): CapturePresentation => ({
+            label: c.label || "",
+            renderOutput: c.renderOutput || "",
+            imageData: null,
+            errorMessage: null,
+            renderError: null,
+        })),
     );
 
     const header = document.createElement("div");
@@ -273,6 +271,26 @@ export function populatePreviewCard(
         }
     });
     titleRow.appendChild(focusBtn);
+
+    // Per-card "Copy SVG" affordance. Copies the preview's layered, editable
+    // compose/figma-svg export to the clipboard — the host pulls it through the
+    // daemon's data/fetch on click (the vector isn't shipped to the webview),
+    // so this is best-effort: previews the backend can't vectorise surface a
+    // warning from the host rather than failing here.
+    const copySvgBtn = document.createElement("button");
+    copySvgBtn.type = "button";
+    copySvgBtn.className = "card-copy-svg-btn";
+    copySvgBtn.innerHTML =
+        '<i class="codicon codicon-copy" aria-hidden="true"></i>';
+    copySvgBtn.title = "Copy this preview as SVG";
+    copySvgBtn.setAttribute("aria-label", "Copy this preview as SVG");
+    copySvgBtn.addEventListener("click", (evt) => {
+        evt.stopPropagation();
+        const previewId = card.dataset.previewId;
+        if (!previewId) return;
+        config.vscode.postMessage({ command: "copyFigmaSvg", previewId });
+    });
+    titleRow.appendChild(copySvgBtn);
 
     // Stale-tier refresh button — only attached up front for cards
     // already known to be stale at setPreviews time. updateStaleBadges


### PR DESCRIPTION
## Summary

Surfaces the daemon's layered, editable `compose/figma-svg` export in three new places. All of them reuse the sanctioned daemon path (`DaemonSemanticsFetcher` → the always-on `ComposeFigmaSvgExtension`), so the lean standalone render task stays untouched — see `docs/DATA_PRODUCTS.md`.

### 1. `compose-preview render --format svg`
Emits the editable vector per matched preview alongside the PNGs.
- `--format png` (default) is unchanged.
- Without `--bundle`: loose `.svg` files — `--output` for a single match, else `build/compose-previews/renders/<id>.svg` beside the PNGs.
- Hybrid exports carry their `figma-raster/<node>.png` crops in a sibling `<id>.figma-raster/` dir, with the SVG's relative hrefs rewritten to match.
- Best-effort per preview; exits non-zero only when nothing was produced.

### 2. SVG in the live PNG bundle
`render --format svg --bundle` injects `previews/<id>.figma.svg` (+ hybrid `figma-raster/` crops) into each module's `bundle.png`, using the same reusable injectors (`injectFigmaSvgIntoBundle` / `injectFigmaRasterIntoBundle`) that `bundle pack --with-semantics` already uses — so the packaged bundle ships the editable vector per preview.

### 3. VS Code "Copy SVG" button
A per-card button next to the focus icon. On click the host pulls `compose/figma-svg` through the daemon's `data/fetch` (the vector isn't shipped to the webview) via the new `daemonScheduler.fetchFigmaSvg`, and writes the SVG text to the clipboard (`handleCopyFigmaSvg`). Previews the backend can't vectorise surface a warning, not an error.

## Test plan
- `:cli:compileKotlin` / `:cli:compileTestKotlin` — BUILD SUCCESSFUL.
- New `RenderSvgOutputTest` (pure-vector single file; hybrid href rewrite + crops land in the stem-named sibling dir) — passes.
- VS Code extension `npm run compile` (tsc + esbuild) — clean; changed files prettier-clean.

## Visual evidence
No embedded before/after here, and this is called out deliberately:
- The **VS Code webview button** can't be screenshotted in a headless container. It's verified via the extension's compile + the existing mocha/harness suites in CI; the button reuses the established `postMessage → clipboard` pipeline.
- The **CLI SVG output** is daemon-backed plumbing (no new rendered surface of its own) — the `RenderSvgOutput` unit test pins the on-disk shape.

Happy to fast-follow with a committed fixture + preview-harness wiring so the figma-svg output gets automatic visual-diff coverage on future PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NYFyAw1BWKW5rrup44CSnz)_