### PR TITLE
feat(design-artifacts): bind Code Connect params to Figma variant properties

### DIFF
--- a/samples/design-catalog-m3/src/main/kotlin/com/example/designcatalogm3/CatalogPreviews.kt
+++ b/samples/design-catalog-m3/src/main/kotlin/com/example/designcatalogm3/CatalogPreviews.kt
@@ -34,7 +34,8 @@ import org.jetbrains.compose.resources.stringResource
 // the shared component set in `:samples:design-catalog-m3-shared`, so the bodies live in one place
 // (also mounted live by the in-browser wasm tier).
 //
-// `interactive` is derived from `LocalInspectionMode` rather than hard-coded, so the SAME `@Preview`
+// `interactive` is derived from `LocalInspectionMode` rather than hard-coded, so the SAME
+// `@Preview`
 // serves both lanes correctly (the two share this sticker sheet — see [Sticker]):
 //   * baked snapshot / one-shot `/render` (`LocalInspectionMode = true`) → `interactive = false`,
 //     the deterministic frame (static toggles / determinate progress) the published catalog shows —
@@ -161,8 +162,9 @@ fun SlottedCardSlotsSticker() = CatalogSticker {
 //     actually mutates state (the segmented toggle flips, the switch/chip toggle).
 // This is the one lever on which the baked and live lanes diverge, exactly as `CatalogComponent`
 // documents.
-private fun Sticker(id: String) =
-  CatalogSticker { CatalogComponent(id, interactive = !LocalInspectionMode.current) }
+private fun Sticker(id: String) = CatalogSticker {
+  CatalogComponent(id, interactive = !LocalInspectionMode.current)
+}
 
 // ---------------------------------------------------------------------------
 // Scaffold templates — full-screen, pre-built screen skeletons an app copies

--- a/scripts/design-artifacts/docs/code-connect.md
+++ b/scripts/design-artifacts/docs/code-connect.md
@@ -87,6 +87,30 @@ At publish time `publish-code-connect.mjs` wraps `codeSnippet` into a `figma.cod
 component name. A component with no required params, or one whose signature couldn't be read, degrades
 to a bare `Foo()` — still valid.
 
+### Binding parameters to Figma variant properties
+
+When the target Figma component is a real **component set** with variant properties, the publisher
+binds them to the matching parameters — a param whose name matches a Figma property gets a live
+`figma.properties.*` interpolation instead of a `TODO`:
+
+```kotlin
+DeviceSummaryCard(
+    state = ${figma.properties.enum('State', { 'Loading': 'DeviceState.Loading', 'Populated': 'DeviceState.Populated' })},
+    title = ${figma.properties.string('Title')},
+)
+```
+
+`VARIANT` → `figma.properties.enum` (options mapped best-effort to `Type.Option`, for you to confirm),
+`BOOLEAN` → `figma.properties.boolean`, `TEXT` → `figma.properties.string`. Matching is by normalized
+name; a param with no matching property keeps its `TODO`. Bound property names are recorded in
+`templateDataJson.props`.
+
+**Important:** variant properties live on Figma **component sets**. The code-led rendered catalog is
+plain frames with none, so binding is a no-op there — it activates when you publish against an actual
+Figma design system whose components carry variants (e.g. a hand-built or generated `Button` set). This
+is the same boundary Figma's own Code Connect draws: prop mapping is a component-set concept, and the
+final design-prop → code-value mapping is expected to be reviewed/completed by hand.
+
 Join sources (all already in the pipeline):
 
 - `componentId` → the Figma frame name (from the catalog spec / importer).

--- a/scripts/design-artifacts/publish-code-connect.mjs
+++ b/scripts/design-artifacts/publish-code-connect.mjs
@@ -146,10 +146,12 @@ export function bindingExpression(name, def, param) {
       const optIdent = String(opt).replace(/[^A-Za-z0-9_]/g, "");
       map[opt] = enumType && optIdent ? `${enumType}.${optIdent}` : optIdent || String(opt);
     }
-    return `figma.properties.enum('${name}', ${JSON.stringify(map)})`;
+    // JSON.stringify the display name (not `'${name}'`) so an apostrophe/backslash in a Figma-authored
+    // property name can't break out of the JS string and produce an invalid template.
+    return `figma.properties.enum(${JSON.stringify(name)}, ${JSON.stringify(map)})`;
   }
-  if (type === "BOOLEAN") return `figma.properties.boolean('${name}')`;
-  if (type === "TEXT") return `figma.properties.string('${name}')`;
+  if (type === "BOOLEAN") return `figma.properties.boolean(${JSON.stringify(name)})`;
+  if (type === "TEXT") return `figma.properties.string(${JSON.stringify(name)})`;
   return null; // INSTANCE_SWAP and anything else: no scalar binding.
 }
 

--- a/scripts/design-artifacts/publish-code-connect.mjs
+++ b/scripts/design-artifacts/publish-code-connect.mjs
@@ -98,16 +98,106 @@ export function codeConnectTemplate(codeSnippet) {
 }
 
 /**
+ * Index a Figma document's **component sets / components** by name → their
+ * `componentPropertyDefinitions` (variant / boolean / text properties). This is where the props a
+ * call site can bind to live — a real design-system `Button` component set carries `State`, `Size`,
+ * etc. NOTE: the code-led rendered catalog is plain frames with *no* component sets, so this is empty
+ * for it; variant binding activates when publishing against an actual Figma design system.
+ */
+export function variantPropsByName(document) {
+  const byName = new Map();
+  const visit = (node) => {
+    if (!node || typeof node !== "object") return;
+    if (
+      (node.type === "COMPONENT_SET" || node.type === "COMPONENT") &&
+      node.componentPropertyDefinitions &&
+      typeof node.name === "string"
+    ) {
+      byName.set(node.name, node.componentPropertyDefinitions);
+    }
+    for (const child of node.children ?? []) visit(child);
+  };
+  visit(document);
+  return byName;
+}
+
+/** Normalized key for matching a Figma property name to a Kotlin parameter name. */
+const normalizeName = (s) => String(s ?? "").toLowerCase().replace(/[^a-z0-9]/g, "");
+
+/** Strip Figma's `#nodeId` suffix from a boolean/text property key to get its display name. */
+const propDisplayName = (key) => key.split("#")[0];
+
+/** A safe Kotlin/Figma identifier — guards the string-built template against injection. */
+const isSafeIdent = (s) => /^[A-Za-z_][A-Za-z0-9_]*$/.test(s);
+
+/**
+ * The `figma.properties.*` expression that binds a Kotlin parameter to a Figma property, or null for
+ * an unsupported/instance-swap property. A VARIANT (enum) maps each option to a best-effort code
+ * value `Type.Option` for the developer to confirm; BOOLEAN → `figma.properties.boolean`; TEXT →
+ * `figma.properties.string`.
+ */
+export function bindingExpression(name, def, param) {
+  const type = def?.type;
+  if (type === "VARIANT") {
+    const options = Array.isArray(def.variantOptions) ? def.variantOptions : [];
+    const enumType = param?.type && isSafeIdent(param.type) ? param.type : null;
+    const map = {};
+    for (const opt of options) {
+      const optIdent = String(opt).replace(/[^A-Za-z0-9_]/g, "");
+      map[opt] = enumType && optIdent ? `${enumType}.${optIdent}` : optIdent || String(opt);
+    }
+    return `figma.properties.enum('${name}', ${JSON.stringify(map)})`;
+  }
+  if (type === "BOOLEAN") return `figma.properties.boolean('${name}')`;
+  if (type === "TEXT") return `figma.properties.string('${name}')`;
+  return null; // INSTANCE_SWAP and anything else: no scalar binding.
+}
+
+/**
+ * Build a `figma.code` template whose required parameters are **bound to Figma properties** where a
+ * property name matches the parameter name. Bound params interpolate a live `figma.properties.*`
+ * expression; unmatched params keep their `TODO("Type")` / `{ }` placeholder. Returns
+ * `{ template, boundProps }`, or null when nothing bound (caller falls back to the static template).
+ */
+export function buildBoundTemplate(componentName, parameters = [], propDefs = {}) {
+  if (!isSafeIdent(componentName)) return null;
+  // Figma property display-name (normalized) → { name, def }.
+  const propByNorm = new Map();
+  for (const [key, def] of Object.entries(propDefs)) {
+    const dn = propDisplayName(key);
+    propByNorm.set(normalizeName(dn), { name: dn, def });
+  }
+  const required = parameters.filter((p) => !p.hasDefault);
+  const boundProps = [];
+  const lines = required.map((p) => {
+    const match = isSafeIdent(p.name) ? propByNorm.get(normalizeName(p.name)) : undefined;
+    const expr = match ? bindingExpression(match.name, match.def, p) : null;
+    if (expr) {
+      boundProps.push(match.name);
+      return `    ${p.name} = \${${expr}},`;
+    }
+    if (p.composableSlot) return `    ${p.name} = { },`;
+    return `    ${p.name} = TODO(${JSON.stringify(p.type ?? "")}),`;
+  });
+  if (boundProps.length === 0) return null;
+  const body =
+    lines.length === 0 ? `${componentName}()` : `${componentName}(\n${lines.join("\n")}\n)`;
+  const template = "const figma = require('figma')\nexport default figma.code`" + body + "`";
+  return { template, boundProps };
+}
+
+/**
  * Shape resolved mappings into the argument object for Figma's `send_code_connect_mappings` MCP
  * tool: `{ fileKey, nodeId, mappings: [{ nodeId, componentName, source, label, template?,
  * templateDataJson? }] }`. `nodeId` at the top level is required by the tool and set to the first
  * mapping's node (an anchor); the per-mapping `nodeId`s carry the real bindings.
  *
- * When a mapping carries a `codeSnippet` (a real call site, from the emit step), it is turned into a
- * `figma.code` template + `templateDataJson` (`isParserless` + `imports`) so Dev Mode shows the real
- * call, not just the component name. An explicit `m.template` overrides the generated one.
+ * Template precedence per mapping: an explicit `m.template` wins; else, when the file has variant
+ * properties for the component AND the mapping carries `parameters`, a **prop-bound** `figma.code`
+ * template (`figma.properties.*` interpolated per matching param); else the static call site from
+ * `m.codeSnippet`. `templateDataJson` carries `isParserless`, `imports`, and any bound `props`.
  */
-export function toSendMappingsPayload(fileKey, resolved) {
+export function toSendMappingsPayload(fileKey, resolved, propsByName = new Map()) {
   const mappings = resolved.map((m) => {
     const out = {
       nodeId: m.nodeId,
@@ -115,10 +205,18 @@ export function toSendMappingsPayload(fileKey, resolved) {
       source: m.source,
       label: m.label,
     };
-    const template = m.template ?? (m.codeSnippet ? codeConnectTemplate(m.codeSnippet) : null);
+    const propDefs = propsByName.get(m.figmaLayerName) ?? propsByName.get(m.componentName);
+    const bound =
+      !m.template && propDefs && m.parameters?.length
+        ? buildBoundTemplate(m.componentName, m.parameters, propDefs)
+        : null;
+    const template =
+      m.template ?? bound?.template ?? (m.codeSnippet ? codeConnectTemplate(m.codeSnippet) : null);
     if (template) {
       out.template = template;
-      out.templateDataJson = JSON.stringify({ isParserless: true, imports: m.imports ?? [] });
+      const data = { isParserless: true, imports: m.imports ?? [] };
+      if (bound?.boundProps.length) data.props = bound.boundProps;
+      out.templateDataJson = JSON.stringify(data);
     }
     return out;
   });
@@ -186,12 +284,23 @@ async function main() {
     process.exit(1);
   }
 
-  const payload = toSendMappingsPayload(fileKey, resolved);
+  // Variant properties from the file's component sets, so a matching parameter binds to a Figma prop
+  // (figma.properties.*) instead of a TODO. Empty for the code-led rendered catalog (plain frames).
+  const propsByName = variantPropsByName(doc.document);
+  const payload = toSendMappingsPayload(fileKey, resolved, propsByName);
+  const boundCount = payload.mappings.filter((m) => {
+    try {
+      return (m.templateDataJson && JSON.parse(m.templateDataJson).props?.length) > 0;
+    } catch {
+      return false;
+    }
+  }).length;
   const json = `${JSON.stringify(payload, null, 2)}\n`;
   if (values.out) {
     await writeFile(values.out, json, "utf8");
     console.log(
-      `[code-connect] resolved ${resolved.length}/${manifest.mappings?.length ?? 0} mapping(s) → ${values.out}`,
+      `[code-connect] resolved ${resolved.length}/${manifest.mappings?.length ?? 0} mapping(s), ` +
+        `${boundCount} with bound variant props → ${values.out}`,
     );
   } else {
     process.stdout.write(json);

--- a/scripts/design-artifacts/publish-code-connect.test.mjs
+++ b/scripts/design-artifacts/publish-code-connect.test.mjs
@@ -9,17 +9,90 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import {
+  bindingExpression,
+  buildBoundTemplate,
   codeConnectTemplate,
   fileKeyFromArg,
   indexNodesByName,
   resolveMappings,
   toSendMappingsPayload,
+  variantPropsByName,
 } from "./publish-code-connect.mjs";
 
 test("codeConnectTemplate wraps a snippet in a figma.code parserless template", () => {
   const t = codeConnectTemplate("Foo(\n    bar = /* Baz */,\n)");
   assert.match(t, /export default figma\.code`Foo\(/);
   assert.match(t, /const figma = require\('figma'\)/);
+});
+
+test("variantPropsByName indexes component sets, ignores plain frames", () => {
+  const doc = {
+    children: [
+      {
+        type: "COMPONENT_SET",
+        name: "DeviceSummaryCard",
+        componentPropertyDefinitions: { State: { type: "VARIANT", variantOptions: ["Loading", "Populated"] } },
+      },
+      { type: "FRAME", name: "Just A Sticker", children: [] },
+    ],
+  };
+  const idx = variantPropsByName(doc);
+  assert.equal(idx.size, 1);
+  assert.ok(idx.get("DeviceSummaryCard").State);
+  assert.equal(idx.get("Just A Sticker"), undefined);
+});
+
+test("bindingExpression maps variant/boolean/text to figma.properties.*", () => {
+  assert.equal(
+    bindingExpression("State", { type: "VARIANT", variantOptions: ["Loading", "Populated"] }, { type: "DeviceState" }),
+    "figma.properties.enum('State', {\"Loading\":\"DeviceState.Loading\",\"Populated\":\"DeviceState.Populated\"})",
+  );
+  assert.equal(bindingExpression("Disabled", { type: "BOOLEAN" }, {}), "figma.properties.boolean('Disabled')");
+  assert.equal(bindingExpression("Label", { type: "TEXT" }, {}), "figma.properties.string('Label')");
+  assert.equal(bindingExpression("Icon", { type: "INSTANCE_SWAP" }, {}), null);
+});
+
+test("buildBoundTemplate interpolates matched params, keeps TODO for the rest", () => {
+  const built = buildBoundTemplate(
+    "DeviceSummaryCard",
+    [
+      { name: "state", type: "DeviceState", hasDefault: false },
+      { name: "title", type: "String", hasDefault: false }, // no matching Figma prop → TODO
+    ],
+    { State: { type: "VARIANT", variantOptions: ["Loading", "Populated"] } },
+  );
+  assert.deepEqual(built.boundProps, ["State"]);
+  assert.match(built.template, /state = \$\{figma\.properties\.enum\('State'/);
+  assert.match(built.template, /title = TODO\("String"\)/);
+});
+
+test("buildBoundTemplate returns null when nothing binds (plain catalog case)", () => {
+  assert.equal(
+    buildBoundTemplate("Foo", [{ name: "bar", type: "Baz", hasDefault: false }], {}),
+    null,
+  );
+});
+
+test("toSendMappingsPayload prefers a prop-bound template and records props", () => {
+  const payload = toSendMappingsPayload(
+    "K",
+    [
+      {
+        nodeId: "1:1",
+        figmaLayerName: "DeviceSummaryCard",
+        componentName: "DeviceSummaryCard",
+        source: "s",
+        label: "Compose",
+        codeSnippet: 'DeviceSummaryCard(\n    state = TODO("DeviceState"),\n)',
+        imports: ["import x.DeviceSummaryCard"],
+        parameters: [{ name: "state", type: "DeviceState", hasDefault: false }],
+      },
+    ],
+    new Map([["DeviceSummaryCard", { State: { type: "VARIANT", variantOptions: ["Loading", "Populated"] } }]]),
+  );
+  const m = payload.mappings[0];
+  assert.match(m.template, /figma\.properties\.enum\('State'/);
+  assert.deepEqual(JSON.parse(m.templateDataJson).props, ["State"]);
 });
 
 test("toSendMappingsPayload turns a codeSnippet into template + templateDataJson", () => {

--- a/scripts/design-artifacts/publish-code-connect.test.mjs
+++ b/scripts/design-artifacts/publish-code-connect.test.mjs
@@ -45,11 +45,16 @@ test("variantPropsByName indexes component sets, ignores plain frames", () => {
 test("bindingExpression maps variant/boolean/text to figma.properties.*", () => {
   assert.equal(
     bindingExpression("State", { type: "VARIANT", variantOptions: ["Loading", "Populated"] }, { type: "DeviceState" }),
-    "figma.properties.enum('State', {\"Loading\":\"DeviceState.Loading\",\"Populated\":\"DeviceState.Populated\"})",
+    'figma.properties.enum("State", {"Loading":"DeviceState.Loading","Populated":"DeviceState.Populated"})',
   );
-  assert.equal(bindingExpression("Disabled", { type: "BOOLEAN" }, {}), "figma.properties.boolean('Disabled')");
-  assert.equal(bindingExpression("Label", { type: "TEXT" }, {}), "figma.properties.string('Label')");
+  assert.equal(bindingExpression("Disabled", { type: "BOOLEAN" }, {}), 'figma.properties.boolean("Disabled")');
+  assert.equal(bindingExpression("Label", { type: "TEXT" }, {}), 'figma.properties.string("Label")');
   assert.equal(bindingExpression("Icon", { type: "INSTANCE_SWAP" }, {}), null);
+  // A property name with an apostrophe stays valid JS (JSON-escaped, not `'...'`).
+  assert.equal(
+    bindingExpression("Owner's state", { type: "BOOLEAN" }, {}),
+    'figma.properties.boolean("Owner\'s state")',
+  );
 });
 
 test("buildBoundTemplate interpolates matched params, keeps TODO for the rest", () => {
@@ -62,7 +67,7 @@ test("buildBoundTemplate interpolates matched params, keeps TODO for the rest", 
     { State: { type: "VARIANT", variantOptions: ["Loading", "Populated"] } },
   );
   assert.deepEqual(built.boundProps, ["State"]);
-  assert.match(built.template, /state = \$\{figma\.properties\.enum\('State'/);
+  assert.match(built.template, /state = \$\{figma\.properties\.enum\("State"/);
   assert.match(built.template, /title = TODO\("String"\)/);
 });
 
@@ -91,7 +96,7 @@ test("toSendMappingsPayload prefers a prop-bound template and records props", ()
     new Map([["DeviceSummaryCard", { State: { type: "VARIANT", variantOptions: ["Loading", "Populated"] } }]]),
   );
   const m = payload.mappings[0];
-  assert.match(m.template, /figma\.properties\.enum\('State'/);
+  assert.match(m.template, /figma\.properties\.enum\("State"/);
   assert.deepEqual(JSON.parse(m.templateDataJson).props, ["State"]);
 });
 


### PR DESCRIPTION
## Summary

Stage 3 (final) of the Code Connect work (follows #2524, #2525, #2528). At publish time, binds a Figma component set's **variant properties** to the captured Kotlin **parameters**, so the `figma.code` template interpolates live prop values instead of `TODO` placeholders:

```kotlin
DeviceSummaryCard(
    state = ${figma.properties.enum('State', { 'Loading': 'DeviceState.Loading', … })},
    title = ${figma.properties.string('Title')},
)
```

- `variantPropsByName` — index component sets/components by name → `componentPropertyDefinitions`.
- `bindingExpression` — `VARIANT` → `figma.properties.enum` (options mapped best-effort to `Type.Option`), `BOOLEAN` → `figma.properties.boolean`, `TEXT` → `figma.properties.string`; `INSTANCE_SWAP` skipped.
- `buildBoundTemplate` — interpolate matched params (by normalized name), keep `TODO`/slot placeholders for the rest; returns null when nothing binds so the caller falls back to the static template.
- `toSendMappingsPayload` takes `propsByName` and prefers the bound template; bound prop names ride in `templateDataJson.props`.
- Template identifiers are guarded (`isSafeIdent`) since the template is string-built.

### Honest limitation (documented)
Variant properties live on Figma **component sets**. The code-led rendered catalog is plain frames with none, so binding is a **no-op there** — it activates when publishing against an actual Figma design system whose components carry variants (a hand-built or generated `Button` set). This is the same boundary Figma's own Code Connect draws: prop mapping is a component-set concept, and the final design-prop → code-value mapping is expected to be reviewed/completed by hand. So this completes the *capability*; exercising it needs a real component-set file (your Enterprise test).

This closes the "full promise" arc: real component (Stage 1) → real call with parameters (Stage 2) → variant-prop binding (Stage 3).

## Test plan

- [x] `node --test` from `scripts/design-artifacts/` — **125 pass, 0 fail** (5 new: index component sets, `figma.properties.*` expressions incl. INSTANCE_SWAP skip, interpolate-matched-keep-TODO, null-when-nothing-binds, payload prefers bound template + records props).
- [x] `node --check` on the publisher.
- [ ] End-to-end publish against a real Figma component-set file — requires Org/Enterprise; the join is verified against synthetic component-set JSON here.

Non-visual change (publish-time data plumbing, docs, tests).

---
_Generated by [Claude Code](https://claude.ai/code/session_01FnX9TKA4TRpCj3PJhK5M7q)_