### PR TITLE
feat: add BuildFetch remote Gradle build cache

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -68,6 +68,44 @@ dependencyResolutionManagement {
   }
 }
 
+// BuildFetch remote Gradle build cache. Complements the local build cache (org.gradle.caching=true
+// in gradle.properties) by sharing task outputs across CI runs and developer machines.
+//
+// Token: resolved from the first non-blank of, in order —
+//          1. env  BUILDFETCH_COMPOSEAI_GRADLE_REMOTE_CACHE_TOKEN  (project-specific)
+//          2. prop BUILDFETCH_COMPOSEAI_GRADLE_REMOTE_CACHE_TOKEN
+//          3. env  BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN            (shared / general fallback)
+//          4. prop BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN
+//        The project-specific name lets a developer keep a separate token per BuildFetch project
+//        (this repo and meshcore-mobile point at different caches) in one shared
+//        ~/.gradle/gradle.properties; the general name lets a single token serve everything and is
+//        what CI exports. Env wins over a gradle property of the same name so CI overrides a stray
+//        local property. Each source is trimmed and empty-checked independently so a present-but-
+//        empty value (e.g. an unset secret that CI still exports) never shadows a later source and
+//        never enables the cache with an empty credential. When nothing resolves the cache disables
+//        itself (isEnabled below) and the build falls back to the local cache with no error.
+// Push:  writes are restricted to trusted CI builds (ON_CI=true on main); PRs and developer machines
+//        are read-only. The gate is value-based so an explicit ON_CI=false is honoured as read-only.
+buildCache {
+  remote<HttpBuildCache> {
+    url = uri("https://cache.eu-central-a.buildfetch.com/8ESz2z/gradle/")
+
+    credentials {
+      username = "token-auth"
+      val nonBlank = { source: Provider<String> -> source.map { it.trim() }.filter { it.isNotEmpty() } }
+      password =
+        nonBlank(providers.environmentVariable("BUILDFETCH_COMPOSEAI_GRADLE_REMOTE_CACHE_TOKEN"))
+          .orElse(nonBlank(providers.gradleProperty("BUILDFETCH_COMPOSEAI_GRADLE_REMOTE_CACHE_TOKEN")))
+          .orElse(nonBlank(providers.environmentVariable("BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN")))
+          .orElse(nonBlank(providers.gradleProperty("BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN")))
+          .orNull
+    }
+
+    isPush = providers.environmentVariable("ON_CI").orElse("false").get().toBoolean()
+    isEnabled = credentials.password != null
+  }
+}
+
 rootProject.name = "compose-ai-tools"
 
 includeBuild("gradle-plugin")


### PR DESCRIPTION
## Summary

Wires the [BuildFetch](https://buildfetch.com) HTTP remote Gradle build cache into `settings.gradle.kts`, alongside the existing local build cache (`org.gradle.caching=true`), pointing at the compose-ai-tools project cache (`8ESz2z`). Mirrors the meshcore-mobile setup.

**Token resolution** — first non-blank of, in order:

1. env `BUILDFETCH_COMPOSEAI_GRADLE_REMOTE_CACHE_TOKEN` — project-specific
2. gradle property `BUILDFETCH_COMPOSEAI_GRADLE_REMOTE_CACHE_TOKEN`
3. env `BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN` — shared / general fallback
4. gradle property `BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN`

Both names are supported, so **a single token under the general name serves every project** (this repo + meshcore-mobile), while a developer who wants per-project tokens can keep them side by side in one `~/.gradle/gradle.properties`. Env wins over a gradle property of the same name so CI overrides a stray local property.

**Safety:**
- Each source is trimmed and blank-filtered independently, so a present-but-empty value (e.g. an unset secret that CI still exports, or a fork PR) never enables the cache with an empty credential.
- `isEnabled = credentials.password != null` — no token ⇒ cache disabled ⇒ falls back to the local cache with no error.
- `isPush` is gated on `ON_CI` (value-based), so writes are restricted to trusted `main` CI; PRs and developer machines are read-only.

## Follow-up (not in this PR)

- **CI push wiring.** CI reads/writes activate once CI jobs carry the token env var + `ON_CI` on `main`. This repo fans CI out through the shared `.github/actions/setup` across many workflows, and a `cache:readwrite` token wants careful scoping (readwrite on `main` only, readonly/none on PRs). I'll do that as a focused follow-up PR so it can be reviewed and verified on its own.
- **Provision the token secret** (`BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN` or the project-specific name) before the follow-up.

## Test plan

- [x] `settings.gradle.kts` change is byte-identical in construct to the meshcore-mobile version, which was verified to evaluate cleanly (build proceeds past settings evaluation). This repo can't run a full build in the sandbox (the Gradle 9.6.1 wrapper distribution is egress-blocked, and the build needs the Android SDK + included builds), so evaluation relies on that analogy and the file's existing use of the same `providers` API.
- [ ] CI green on this PR (no behaviour change until a token is provisioned — the cache stays disabled).

_Generated by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_017ZNP9KNVXpZbwDVimAdw86)_