### PR TITLE
style(catalog): satisfy ktfmt Google style in CatalogPreviews

### DIFF
--- a/samples/design-catalog-m3/src/main/kotlin/com/example/designcatalogm3/CatalogPreviews.kt
+++ b/samples/design-catalog-m3/src/main/kotlin/com/example/designcatalogm3/CatalogPreviews.kt
@@ -34,7 +34,8 @@ import org.jetbrains.compose.resources.stringResource
 // the shared component set in `:samples:design-catalog-m3-shared`, so the bodies live in one place
 // (also mounted live by the in-browser wasm tier).
 //
-// `interactive` is derived from `LocalInspectionMode` rather than hard-coded, so the SAME `@Preview`
+// `interactive` is derived from `LocalInspectionMode` rather than hard-coded, so the SAME
+// `@Preview`
 // serves both lanes correctly (the two share this sticker sheet — see [Sticker]):
 //   * baked snapshot / one-shot `/render` (`LocalInspectionMode = true`) → `interactive = false`,
 //     the deterministic frame (static toggles / determinate progress) the published catalog shows —
@@ -161,8 +162,9 @@ fun SlottedCardSlotsSticker() = CatalogSticker {
 //     actually mutates state (the segmented toggle flips, the switch/chip toggle).
 // This is the one lever on which the baked and live lanes diverge, exactly as `CatalogComponent`
 // documents.
-private fun Sticker(id: String) =
-  CatalogSticker { CatalogComponent(id, interactive = !LocalInspectionMode.current) }
+private fun Sticker(id: String) = CatalogSticker {
+  CatalogComponent(id, interactive = !LocalInspectionMode.current)
+}
 
 // ---------------------------------------------------------------------------
 // Scaffold templates — full-screen, pre-built screen skeletons an app copies


### PR DESCRIPTION
## Summary

Follow-up to #2529, which broke `main`'s **Format Check** (`ktfmt (Google style)` → `:samples:design-catalog-m3:ktfmtCheckMain`). That PR's scoped CI didn't run the formatter, so the layout slipped through and only failed on the push-to-`main` build.

This reformats `CatalogPreviews.kt` to what `ktfmtFormatMain` produces — **no logic change**:
- Canonical ktfmt lambda layout for the `Sticker` expression body (`= CatalogSticker {` … `}` instead of a wrapped `=`).
- One doc-comment line wrapped at the 100-column limit.

The `interactive = !LocalInspectionMode.current` behavior from #2529 is unchanged.

## Test plan

- [x] `./gradlew :samples:design-catalog-m3:ktfmtFormatMain` — produced exactly this diff (formatter output == `ktfmtCheckMain` input, so the check will pass).
- No source-behavior change; the `Build Samples` / preview lanes that were green on #2529 stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011P7nQurmu63kAL5MwC8yXt)_