### PR TITLE
ci: seed BuildFetch remote cache from CI via a dedicated action

### DIFF
--- a/.github/actions/buildfetch-cache/action.yml
+++ b/.github/actions/buildfetch-cache/action.yml
@@ -9,10 +9,10 @@ description: >
 inputs:
   rw-token:
     description: >
-      BuildFetch cache:readwrite token. Enables cache writes (ON_CI=true). Pass
-      this ONLY under a trusted push condition from the caller (e.g.
-      `${{ github.event_name == 'push' && secrets.… || '' }}`) so the write token
-      is never resolved into a pull_request job's environment.
+      BuildFetch cache:readwrite token. Enables cache writes (ON_CI=true). The
+      caller must gate this on a trusted push condition (resolve the secret only
+      when github.event_name is 'push', otherwise pass an empty string) so the
+      write token is never resolved into a pull_request job's environment.
     default: ''
   ro-token:
     description: >

--- a/.github/actions/buildfetch-cache/action.yml
+++ b/.github/actions/buildfetch-cache/action.yml
@@ -1,0 +1,43 @@
+name: 'BuildFetch remote cache'
+description: >
+  Select the BuildFetch remote-cache credential for the current event and export
+  it (plus ON_CI) to the job environment, where settings.gradle.kts reads it.
+  Opt-in and BuildFetch-specific — kept separate from the generic `setup` action
+  so projects that don't use BuildFetch never pull this in. Call it after `setup`
+  in a job that should participate in the remote cache.
+
+inputs:
+  rw-token:
+    description: >
+      BuildFetch cache:readwrite token. Enables cache writes (ON_CI=true). Pass
+      this ONLY under a trusted push condition from the caller (e.g.
+      `${{ github.event_name == 'push' && secrets.… || '' }}`) so the write token
+      is never resolved into a pull_request job's environment.
+    default: ''
+  ro-token:
+    description: >
+      BuildFetch cache:readonly token for read-only access on PRs / other events.
+      Optional — when unset those builds fall back to the local cache.
+    default: ''
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Configure BuildFetch remote cache
+      shell: bash
+      env:
+        RW_TOKEN: ${{ inputs.rw-token }}
+        RO_TOKEN: ${{ inputs.ro-token }}
+      run: |
+        # ON_CI=true (remote writes + local-cache bypass in settings.gradle.kts) only when a
+        # write token is actually present, so a read-only run never tries to push. GitHub masks
+        # both secrets in logs; nothing here echoes the token value.
+        if [ -n "$RW_TOKEN" ]; then
+          printf 'BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN=%s\nON_CI=true\n' "$RW_TOKEN" >> "$GITHUB_ENV"
+          echo "BuildFetch remote cache: read/write (trusted build)."
+        elif [ -n "$RO_TOKEN" ]; then
+          printf 'BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN=%s\nON_CI=false\n' "$RO_TOKEN" >> "$GITHUB_ENV"
+          echo "BuildFetch remote cache: read-only."
+        else
+          echo "BuildFetch remote cache: disabled (no token provided; using local cache)."
+        fi

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -17,18 +17,6 @@ inputs:
       avoids cache poisoning from untrusted PR runs reading those entries
       on subsequent workflow invocations. (zizmor: cache-poisoning)
     default: 'false'
-  buildfetch-rw-token:
-    description: >
-      BuildFetch cache:readwrite token. Exported (and cache writes enabled via
-      ON_CI=true) only on trusted main-branch push builds. Never exposed to PR
-      runs, so a write-capable token can't leak from a fork/branch PR job.
-    default: ''
-  buildfetch-ro-token:
-    description: >
-      BuildFetch cache:readonly token. Exported for read-only cache access on
-      PRs and other non-push events. Optional — when unset those builds simply
-      fall back to the local build cache.
-    default: ''
 
 runs:
   using: 'composite'
@@ -41,33 +29,3 @@ runs:
       with:
         cache-provider: ${{ inputs.cache-provider }}
         cache-read-only: ${{ inputs.cache-read-only }}
-    # Select the BuildFetch remote-cache credential for the current event and
-    # export it (plus ON_CI) to the job env, where settings.gradle.kts reads it.
-    # Writes are confined to trusted main-branch push builds (readwrite token +
-    # ON_CI=true); PRs and other events get read-only access with the readonly
-    # token, if one is provided. The readwrite token is never placed in a PR
-    # job's environment. GitHub masks both secrets in logs.
-    - name: Configure BuildFetch remote cache
-      shell: bash
-      env:
-        EVENT_NAME: ${{ github.event_name }}
-        RW_TOKEN: ${{ inputs.buildfetch-rw-token }}
-        RO_TOKEN: ${{ inputs.buildfetch-ro-token }}
-      run: |
-        if [ "$EVENT_NAME" = "push" ]; then
-          if [ -n "$RW_TOKEN" ]; then
-            printf 'BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN=%s\n' "$RW_TOKEN" >> "$GITHUB_ENV"
-            echo "ON_CI=true" >> "$GITHUB_ENV"
-            echo "BuildFetch remote cache: read/write (trusted push build)."
-          else
-            echo "BuildFetch remote cache: disabled (no readwrite token provided)."
-          fi
-        else
-          if [ -n "$RO_TOKEN" ]; then
-            printf 'BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN=%s\n' "$RO_TOKEN" >> "$GITHUB_ENV"
-            echo "ON_CI=false" >> "$GITHUB_ENV"
-            echo "BuildFetch remote cache: read-only."
-          else
-            echo "BuildFetch remote cache: disabled (no readonly token provided)."
-          fi
-        fi

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -17,6 +17,18 @@ inputs:
       avoids cache poisoning from untrusted PR runs reading those entries
       on subsequent workflow invocations. (zizmor: cache-poisoning)
     default: 'false'
+  buildfetch-rw-token:
+    description: >
+      BuildFetch cache:readwrite token. Exported (and cache writes enabled via
+      ON_CI=true) only on trusted main-branch push builds. Never exposed to PR
+      runs, so a write-capable token can't leak from a fork/branch PR job.
+    default: ''
+  buildfetch-ro-token:
+    description: >
+      BuildFetch cache:readonly token. Exported for read-only cache access on
+      PRs and other non-push events. Optional — when unset those builds simply
+      fall back to the local build cache.
+    default: ''
 
 runs:
   using: 'composite'
@@ -29,3 +41,33 @@ runs:
       with:
         cache-provider: ${{ inputs.cache-provider }}
         cache-read-only: ${{ inputs.cache-read-only }}
+    # Select the BuildFetch remote-cache credential for the current event and
+    # export it (plus ON_CI) to the job env, where settings.gradle.kts reads it.
+    # Writes are confined to trusted main-branch push builds (readwrite token +
+    # ON_CI=true); PRs and other events get read-only access with the readonly
+    # token, if one is provided. The readwrite token is never placed in a PR
+    # job's environment. GitHub masks both secrets in logs.
+    - name: Configure BuildFetch remote cache
+      shell: bash
+      env:
+        EVENT_NAME: ${{ github.event_name }}
+        RW_TOKEN: ${{ inputs.buildfetch-rw-token }}
+        RO_TOKEN: ${{ inputs.buildfetch-ro-token }}
+      run: |
+        if [ "$EVENT_NAME" = "push" ]; then
+          if [ -n "$RW_TOKEN" ]; then
+            printf 'BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN=%s\n' "$RW_TOKEN" >> "$GITHUB_ENV"
+            echo "ON_CI=true" >> "$GITHUB_ENV"
+            echo "BuildFetch remote cache: read/write (trusted push build)."
+          else
+            echo "BuildFetch remote cache: disabled (no readwrite token provided)."
+          fi
+        else
+          if [ -n "$RO_TOKEN" ]; then
+            printf 'BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN=%s\n' "$RO_TOKEN" >> "$GITHUB_ENV"
+            echo "ON_CI=false" >> "$GITHUB_ENV"
+            echo "BuildFetch remote cache: read-only."
+          else
+            echo "BuildFetch remote cache: disabled (no readonly token provided)."
+          fi
+        fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,11 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/setup
         with:
-          buildfetch-rw-token: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN }}
+          # Only resolve the write-capable token on trusted main-branch push builds. On a
+          # pull_request event this expression (evaluated from the base ci.yml, not the PR head)
+          # yields '' so the secret is never placed in a PR job's environment — a PR cannot
+          # exfiltrate it even by editing the composite action.
+          buildfetch-rw-token: ${{ github.event_name == 'push' && secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN || '' }}
           buildfetch-ro-token: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_READONLY_TOKEN }}
       - name: Run unit tests
         run: ./gradlew :gradle-plugin:test
@@ -77,7 +81,11 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/setup
         with:
-          buildfetch-rw-token: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN }}
+          # Only resolve the write-capable token on trusted main-branch push builds. On a
+          # pull_request event this expression (evaluated from the base ci.yml, not the PR head)
+          # yields '' so the secret is never placed in a PR job's environment — a PR cannot
+          # exfiltrate it even by editing the composite action.
+          buildfetch-rw-token: ${{ github.event_name == 'push' && secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN || '' }}
           buildfetch-ro-token: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_READONLY_TOKEN }}
       - name: Run functional tests
         run: ./gradlew :gradle-plugin:functionalTest
@@ -98,7 +106,11 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/setup
         with:
-          buildfetch-rw-token: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN }}
+          # Only resolve the write-capable token on trusted main-branch push builds. On a
+          # pull_request event this expression (evaluated from the base ci.yml, not the PR head)
+          # yields '' so the secret is never placed in a PR job's environment — a PR cannot
+          # exfiltrate it even by editing the composite action.
+          buildfetch-rw-token: ${{ github.event_name == 'push' && secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN || '' }}
           buildfetch-ro-token: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_READONLY_TOKEN }}
       - name: Build CMP sample and discover previews
         run: ./gradlew :samples:cmp:composePreviewDiscover
@@ -182,7 +194,11 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/setup
         with:
-          buildfetch-rw-token: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN }}
+          # Only resolve the write-capable token on trusted main-branch push builds. On a
+          # pull_request event this expression (evaluated from the base ci.yml, not the PR head)
+          # yields '' so the secret is never placed in a PR job's environment — a PR cannot
+          # exfiltrate it even by editing the composite action.
+          buildfetch-rw-token: ${{ github.event_name == 'push' && secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN || '' }}
           buildfetch-ro-token: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_READONLY_TOKEN }}
       - name: Build CLI
         run: ./gradlew :cli:build
@@ -206,7 +222,11 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/setup
         with:
-          buildfetch-rw-token: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN }}
+          # Only resolve the write-capable token on trusted main-branch push builds. On a
+          # pull_request event this expression (evaluated from the base ci.yml, not the PR head)
+          # yields '' so the secret is never placed in a PR job's environment — a PR cannot
+          # exfiltrate it even by editing the composite action.
+          buildfetch-rw-token: ${{ github.event_name == 'push' && secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN || '' }}
           buildfetch-ro-token: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_READONLY_TOKEN }}
       # Build the compositor (clang + libc++ against the pinned Filament SDK) and its compiled
       # materials into dist/ — the same composite action the build/release workflows use.
@@ -360,7 +380,11 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/setup
         with:
-          buildfetch-rw-token: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN }}
+          # Only resolve the write-capable token on trusted main-branch push builds. On a
+          # pull_request event this expression (evaluated from the base ci.yml, not the PR head)
+          # yields '' so the secret is never placed in a PR job's environment — a PR cannot
+          # exfiltrate it even by editing the composite action.
+          buildfetch-rw-token: ${{ github.event_name == 'push' && secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN || '' }}
           buildfetch-ro-token: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_READONLY_TOKEN }}
       # End-to-end: pack a bundle from a synthetic Compose Desktop project, then re-render it
       # outside of any Gradle project by spawning the actual CLI binary against the packed PNG.
@@ -398,7 +422,11 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/setup
         with:
-          buildfetch-rw-token: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN }}
+          # Only resolve the write-capable token on trusted main-branch push builds. On a
+          # pull_request event this expression (evaluated from the base ci.yml, not the PR head)
+          # yields '' so the secret is never placed in a PR job's environment — a PR cannot
+          # exfiltrate it even by editing the composite action.
+          buildfetch-rw-token: ${{ github.event_name == 'push' && secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN || '' }}
           buildfetch-ro-token: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_READONLY_TOKEN }}
       # End-to-end for the Android path of `bundle daemon`: pack real-sample bundles (Wear tile +
       # Remote Compose IR, plus classic Compose previews), then spawn the actual CLI binary against
@@ -463,7 +491,11 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/setup
         with:
-          buildfetch-rw-token: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN }}
+          # Only resolve the write-capable token on trusted main-branch push builds. On a
+          # pull_request event this expression (evaluated from the base ci.yml, not the PR head)
+          # yields '' so the secret is never placed in a PR job's environment — a PR cannot
+          # exfiltrate it even by editing the composite action.
+          buildfetch-rw-token: ${{ github.event_name == 'push' && secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN || '' }}
           buildfetch-ro-token: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_READONLY_TOKEN }}
       - name: Fetch agent audit script from yschimke/skills
         # The script lives in the sibling skills repo since it's part of the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,13 +55,13 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup
+      - uses: ./.github/actions/buildfetch-cache
         with:
-          # Only resolve the write-capable token on trusted main-branch push builds. On a
-          # pull_request event this expression (evaluated from the base ci.yml, not the PR head)
-          # yields '' so the secret is never placed in a PR job's environment — a PR cannot
-          # exfiltrate it even by editing the composite action.
-          buildfetch-rw-token: ${{ github.event_name == 'push' && secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN || '' }}
-          buildfetch-ro-token: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_READONLY_TOKEN }}
+          # Only resolve the write token on trusted main-branch push builds — on a pull_request
+          # this expression (evaluated from the base ci.yml, not the PR head) yields '' so the
+          # write token is never placed in a PR job's environment.
+          rw-token: ${{ github.event_name == 'push' && secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN || '' }}
+          ro-token: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_READONLY_TOKEN }}
       - name: Run unit tests
         run: ./gradlew :gradle-plugin:test
       - name: Upload test results
@@ -80,13 +80,13 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup
+      - uses: ./.github/actions/buildfetch-cache
         with:
-          # Only resolve the write-capable token on trusted main-branch push builds. On a
-          # pull_request event this expression (evaluated from the base ci.yml, not the PR head)
-          # yields '' so the secret is never placed in a PR job's environment — a PR cannot
-          # exfiltrate it even by editing the composite action.
-          buildfetch-rw-token: ${{ github.event_name == 'push' && secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN || '' }}
-          buildfetch-ro-token: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_READONLY_TOKEN }}
+          # Only resolve the write token on trusted main-branch push builds — on a pull_request
+          # this expression (evaluated from the base ci.yml, not the PR head) yields '' so the
+          # write token is never placed in a PR job's environment.
+          rw-token: ${{ github.event_name == 'push' && secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN || '' }}
+          ro-token: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_READONLY_TOKEN }}
       - name: Run functional tests
         run: ./gradlew :gradle-plugin:functionalTest
       - name: Upload test results
@@ -105,13 +105,13 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup
+      - uses: ./.github/actions/buildfetch-cache
         with:
-          # Only resolve the write-capable token on trusted main-branch push builds. On a
-          # pull_request event this expression (evaluated from the base ci.yml, not the PR head)
-          # yields '' so the secret is never placed in a PR job's environment — a PR cannot
-          # exfiltrate it even by editing the composite action.
-          buildfetch-rw-token: ${{ github.event_name == 'push' && secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN || '' }}
-          buildfetch-ro-token: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_READONLY_TOKEN }}
+          # Only resolve the write token on trusted main-branch push builds — on a pull_request
+          # this expression (evaluated from the base ci.yml, not the PR head) yields '' so the
+          # write token is never placed in a PR job's environment.
+          rw-token: ${{ github.event_name == 'push' && secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN || '' }}
+          ro-token: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_READONLY_TOKEN }}
       - name: Build CMP sample and discover previews
         run: ./gradlew :samples:cmp:composePreviewDiscover
       - name: Build Android sample and discover previews
@@ -193,13 +193,13 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup
+      - uses: ./.github/actions/buildfetch-cache
         with:
-          # Only resolve the write-capable token on trusted main-branch push builds. On a
-          # pull_request event this expression (evaluated from the base ci.yml, not the PR head)
-          # yields '' so the secret is never placed in a PR job's environment — a PR cannot
-          # exfiltrate it even by editing the composite action.
-          buildfetch-rw-token: ${{ github.event_name == 'push' && secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN || '' }}
-          buildfetch-ro-token: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_READONLY_TOKEN }}
+          # Only resolve the write token on trusted main-branch push builds — on a pull_request
+          # this expression (evaluated from the base ci.yml, not the PR head) yields '' so the
+          # write token is never placed in a PR job's environment.
+          rw-token: ${{ github.event_name == 'push' && secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN || '' }}
+          ro-token: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_READONLY_TOKEN }}
       - name: Build CLI
         run: ./gradlew :cli:build
 
@@ -221,13 +221,13 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup
+      - uses: ./.github/actions/buildfetch-cache
         with:
-          # Only resolve the write-capable token on trusted main-branch push builds. On a
-          # pull_request event this expression (evaluated from the base ci.yml, not the PR head)
-          # yields '' so the secret is never placed in a PR job's environment — a PR cannot
-          # exfiltrate it even by editing the composite action.
-          buildfetch-rw-token: ${{ github.event_name == 'push' && secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN || '' }}
-          buildfetch-ro-token: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_READONLY_TOKEN }}
+          # Only resolve the write token on trusted main-branch push builds — on a pull_request
+          # this expression (evaluated from the base ci.yml, not the PR head) yields '' so the
+          # write token is never placed in a PR job's environment.
+          rw-token: ${{ github.event_name == 'push' && secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN || '' }}
+          ro-token: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_READONLY_TOKEN }}
       # Build the compositor (clang + libc++ against the pinned Filament SDK) and its compiled
       # materials into dist/ — the same composite action the build/release workflows use.
       - uses: ./.github/actions/build-xr-composite
@@ -379,13 +379,13 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup
+      - uses: ./.github/actions/buildfetch-cache
         with:
-          # Only resolve the write-capable token on trusted main-branch push builds. On a
-          # pull_request event this expression (evaluated from the base ci.yml, not the PR head)
-          # yields '' so the secret is never placed in a PR job's environment — a PR cannot
-          # exfiltrate it even by editing the composite action.
-          buildfetch-rw-token: ${{ github.event_name == 'push' && secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN || '' }}
-          buildfetch-ro-token: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_READONLY_TOKEN }}
+          # Only resolve the write token on trusted main-branch push builds — on a pull_request
+          # this expression (evaluated from the base ci.yml, not the PR head) yields '' so the
+          # write token is never placed in a PR job's environment.
+          rw-token: ${{ github.event_name == 'push' && secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN || '' }}
+          ro-token: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_READONLY_TOKEN }}
       # End-to-end: pack a bundle from a synthetic Compose Desktop project, then re-render it
       # outside of any Gradle project by spawning the actual CLI binary against the packed PNG.
       # The aggregate task pre-publishes the plugin to mavenLocal (so the synthetic project's
@@ -421,13 +421,13 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup
+      - uses: ./.github/actions/buildfetch-cache
         with:
-          # Only resolve the write-capable token on trusted main-branch push builds. On a
-          # pull_request event this expression (evaluated from the base ci.yml, not the PR head)
-          # yields '' so the secret is never placed in a PR job's environment — a PR cannot
-          # exfiltrate it even by editing the composite action.
-          buildfetch-rw-token: ${{ github.event_name == 'push' && secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN || '' }}
-          buildfetch-ro-token: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_READONLY_TOKEN }}
+          # Only resolve the write token on trusted main-branch push builds — on a pull_request
+          # this expression (evaluated from the base ci.yml, not the PR head) yields '' so the
+          # write token is never placed in a PR job's environment.
+          rw-token: ${{ github.event_name == 'push' && secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN || '' }}
+          ro-token: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_READONLY_TOKEN }}
       # End-to-end for the Android path of `bundle daemon`: pack real-sample bundles (Wear tile +
       # Remote Compose IR, plus classic Compose previews), then spawn the actual CLI binary against
       # each and render protolayout / remotecompose / classic previews to PNG via the Robolectric
@@ -490,13 +490,13 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup
+      - uses: ./.github/actions/buildfetch-cache
         with:
-          # Only resolve the write-capable token on trusted main-branch push builds. On a
-          # pull_request event this expression (evaluated from the base ci.yml, not the PR head)
-          # yields '' so the secret is never placed in a PR job's environment — a PR cannot
-          # exfiltrate it even by editing the composite action.
-          buildfetch-rw-token: ${{ github.event_name == 'push' && secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN || '' }}
-          buildfetch-ro-token: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_READONLY_TOKEN }}
+          # Only resolve the write token on trusted main-branch push builds — on a pull_request
+          # this expression (evaluated from the base ci.yml, not the PR head) yields '' so the
+          # write token is never placed in a PR job's environment.
+          rw-token: ${{ github.event_name == 'push' && secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN || '' }}
+          ro-token: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_READONLY_TOKEN }}
       - name: Fetch agent audit script from yschimke/skills
         # The script lives in the sibling skills repo since it's part of the
         # compose-preview-review skill bundle; fetch the pinned ref so CI

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,9 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup
+        with:
+          buildfetch-rw-token: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN }}
+          buildfetch-ro-token: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_READONLY_TOKEN }}
       - name: Run unit tests
         run: ./gradlew :gradle-plugin:test
       - name: Upload test results
@@ -73,6 +76,9 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup
+        with:
+          buildfetch-rw-token: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN }}
+          buildfetch-ro-token: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_READONLY_TOKEN }}
       - name: Run functional tests
         run: ./gradlew :gradle-plugin:functionalTest
       - name: Upload test results
@@ -91,6 +97,9 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup
+        with:
+          buildfetch-rw-token: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN }}
+          buildfetch-ro-token: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_READONLY_TOKEN }}
       - name: Build CMP sample and discover previews
         run: ./gradlew :samples:cmp:composePreviewDiscover
       - name: Build Android sample and discover previews
@@ -172,6 +181,9 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup
+        with:
+          buildfetch-rw-token: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN }}
+          buildfetch-ro-token: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_READONLY_TOKEN }}
       - name: Build CLI
         run: ./gradlew :cli:build
 
@@ -193,6 +205,9 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup
+        with:
+          buildfetch-rw-token: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN }}
+          buildfetch-ro-token: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_READONLY_TOKEN }}
       # Build the compositor (clang + libc++ against the pinned Filament SDK) and its compiled
       # materials into dist/ — the same composite action the build/release workflows use.
       - uses: ./.github/actions/build-xr-composite
@@ -344,6 +359,9 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup
+        with:
+          buildfetch-rw-token: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN }}
+          buildfetch-ro-token: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_READONLY_TOKEN }}
       # End-to-end: pack a bundle from a synthetic Compose Desktop project, then re-render it
       # outside of any Gradle project by spawning the actual CLI binary against the packed PNG.
       # The aggregate task pre-publishes the plugin to mavenLocal (so the synthetic project's
@@ -379,6 +397,9 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup
+        with:
+          buildfetch-rw-token: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN }}
+          buildfetch-ro-token: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_READONLY_TOKEN }}
       # End-to-end for the Android path of `bundle daemon`: pack real-sample bundles (Wear tile +
       # Remote Compose IR, plus classic Compose previews), then spawn the actual CLI binary against
       # each and render protolayout / remotecompose / classic previews to PNG via the Robolectric
@@ -441,6 +462,9 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup
+        with:
+          buildfetch-rw-token: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN }}
+          buildfetch-ro-token: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_READONLY_TOKEN }}
       - name: Fetch agent audit script from yschimke/skills
         # The script lives in the sibling skills repo since it's part of the
         # compose-preview-review skill bundle; fetch the pinned ref so CI

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -86,23 +86,48 @@ dependencyResolutionManagement {
 //        itself (isEnabled below) and the build falls back to the local cache with no error.
 // Push:  writes are restricted to trusted CI builds (ON_CI=true on main); PRs and developer machines
 //        are read-only. The gate is value-based so an explicit ON_CI=false is honoured as read-only.
+val onCi = providers.environmentVariable("ON_CI").orElse("false").get().toBoolean()
+
+// Non-blank view of a single env var / gradle property: trims and drops empties so a present-but-empty
+// source doesn't shadow a later fallback (see the header comment).
+val nonBlank = { source: Provider<String> -> source.map { it.trim() }.filter { it.isNotEmpty() } }
+val cacheToken =
+  nonBlank(providers.environmentVariable("BUILDFETCH_COMPOSEAI_GRADLE_REMOTE_CACHE_TOKEN"))
+    .orElse(nonBlank(providers.gradleProperty("BUILDFETCH_COMPOSEAI_GRADLE_REMOTE_CACHE_TOKEN")))
+    .orElse(nonBlank(providers.environmentVariable("BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN")))
+    .orElse(nonBlank(providers.gradleProperty("BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN")))
+    .orNull
+
+// True only when this run will actually push to the remote: a trusted main-branch run (ON_CI) with a
+// usable token. Anything else (PRs, dev machines, or a main run whose token is unprovisioned/blank)
+// does not push, so it must keep the local cache.
+val remotePushEnabled = onCi && cacheToken != null
+
 buildCache {
+  // On the trusted main-branch runs, CI is the sole writer of the BuildFetch remote cache — and the
+  // only thing that populates it for every other consumer (PRs, developer machines). Gradle never
+  // re-uploads a *local* build-cache hit to the remote; it pushes to the remote only when a task
+  // actually executes. setup-gradle restores a warm local build cache (caches/build-cache-1) from the
+  // GitHub Actions cache, so with it in place every task resolves as FROM-CACHE (local), nothing is
+  // pushed, and the remote stays empty (dev machines then see 0 remote hits). Disabling the local
+  // cache on the pushing runs forces tasks to execute-and-push, or to hit the remote directly, so
+  // BuildFetch actually gets seeded.
+  //
+  // Gate this on remotePushEnabled, not just ON_CI: if the token is unprovisioned/blank the remote
+  // below disables itself, and disabling the local cache too would make that main run execute every
+  // cacheable task with *no* cache at all. Off-CI, on PRs, and on token-less main runs the local
+  // cache stays on.
+  local { isEnabled = !remotePushEnabled }
   remote<HttpBuildCache> {
     url = uri("https://cache.eu-central-a.buildfetch.com/8ESz2z/gradle/")
 
     credentials {
       username = "token-auth"
-      val nonBlank = { source: Provider<String> -> source.map { it.trim() }.filter { it.isNotEmpty() } }
-      password =
-        nonBlank(providers.environmentVariable("BUILDFETCH_COMPOSEAI_GRADLE_REMOTE_CACHE_TOKEN"))
-          .orElse(nonBlank(providers.gradleProperty("BUILDFETCH_COMPOSEAI_GRADLE_REMOTE_CACHE_TOKEN")))
-          .orElse(nonBlank(providers.environmentVariable("BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN")))
-          .orElse(nonBlank(providers.gradleProperty("BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN")))
-          .orNull
+      password = cacheToken
     }
 
-    isPush = providers.environmentVariable("ON_CI").orElse("false").get().toBoolean()
-    isEnabled = credentials.password != null
+    isPush = onCi
+    isEnabled = cacheToken != null
   }
 }
 


### PR DESCRIPTION
## Summary

Follow-up to the BuildFetch settings wiring (#2532) — makes CI actually use **and populate** the remote cache, without touching the shared generic `setup` action.

### 1. Credential wiring in a dedicated, opt-in action

The generic `.github/actions/setup` is reused by jobs/projects that don't use BuildFetch, so BuildFetch stays out of it. Instead a new **`.github/actions/buildfetch-cache`** composite action selects the credential for the current event and exports `BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN` + `ON_CI` to the job env (read by `settings.gradle.kts`). Each Gradle job in `ci.yml` calls it right after `setup`.

**Token scoping (P1-safe):**
- The **`cache:readwrite`** token is only resolved under a push condition in `ci.yml` (`${{ github.event_name == 'push' && secrets.… || '' }}`). On `pull_request` this is evaluated from the **base** `ci.yml`, so it yields `''` — the write token is **never** placed in a PR job's environment and can't be exfiltrated by a branch/fork PR.
- PRs / other events use the optional **`cache:readonly`** token → read-only.
- `ON_CI=true` (writes enabled) only when a write token is actually present, so a read-only run never attempts a push. No token ⇒ local cache only.

### 2. Seed the remote from CI (disable the local cache on pushing runs)

`gradle/actions/setup-gradle` restores a warm **local** `build-cache-1`, so on `main` every task resolves `FROM-CACHE (local)` and Gradle never pushes it to the remote — BuildFetch stays empty and every consumer (PRs, dev machines) misses. `settings.gradle.kts` now disables the local cache when `remotePushEnabled` (`ON_CI` + a usable token), forcing tasks to execute-and-push and seed the remote. Off-CI, on PRs, and on token-less `main` runs the local cache stays on. (Mirrors meshcore-mobile #208.)

## Secrets to provision

| Secret | Type | Effect |
| --- | --- | --- |
| `BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN` | `cache:readwrite` | Required. `main` builds seed the cache. |
| `BUILDFETCH_GRADLE_REMOTE_CACHE_READONLY_TOKEN` | `cache:readonly` | Optional. Gives PR builds cache reads; omit and PRs use the local cache. |

## Test plan

- [x] `ci.yml` and `buildfetch-cache/action.yml` parse as YAML; the shared `setup` action is unchanged in the final diff.
- [x] `settings.gradle.kts` reuses the constructs from #2532 that already pass `ktfmtCheckScripts`; the added `val`s / `local { … }` are ktfmt-neutral (verified none of the added code lines are reformatted).
- [ ] CI green (no behaviour change until the secrets are set — `buildfetch-cache` reports "disabled" with no token).
- [ ] After merge + secret provisioning: first `main` build seeds the remote; a subsequent PR gets remote hits.

_Generated by [Claude Code](https://claude.com/claude-code)_