### PR TITLE
feat: vectorize Slider chrome via draw-capture instead of rastering by name

### DIFF
--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgModel.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgModel.kt
@@ -309,13 +309,22 @@ data class FigmaSvgModel(
      * vector assets (`Icon`), custom `Canvas`/chart drawing. Second, **Material components whose
      * chrome is drawn imperatively** (a `drawWithContent`/`Canvas` inside the component, not a
      * `Modifier.background`/`border` the layout inspector can read as a container token): the
-     * filled & outlined `TextField` container + indicator, and the `Slider` track + thumb. Their
-     * fills never surface as tokens, so a token-driven vector export drops them entirely — the
-     * filled `TextField` was the worst sticker in the fidelity audit (dark: 66%, container box
-     * missing). Rasterising the component's measure-policy node (`TextFieldMeasurePolicy`,
-     * `OutlinedTextFieldMeasurePolicy`, `SliderKt`) crops its faithful pixels out of the frame
-     * while the rest of the screen stays editable vector — the sanctioned hybrid split, tuned by
-     * the fidelity diff (render vs. SVG) rather than guessed per-component.
+     * filled & outlined `TextField` container + indicator. Its fills never surface as tokens, so a
+     * token-driven vector export drops them entirely — the filled `TextField` was the worst sticker
+     * in the fidelity audit (dark: 66%, container box missing). Rasterising the component's
+     * measure-policy node (`TextFieldMeasurePolicy`, `OutlinedTextFieldMeasurePolicy`) crops its
+     * faithful pixels out of the frame while the rest of the screen stays editable vector — the
+     * sanctioned hybrid split, tuned by the fidelity diff (render vs. SVG) rather than guessed
+     * per-component. `TextField` stays here because its live cursor / selection / IME state is
+     * genuinely raster-only.
+     *
+     * The `Slider` used to sit in this family too, for the same reason (its track + thumb are drawn
+     * imperatively by `SliderKt`, never as tokens). It no longer needs a name entry: the
+     * draw-capture extractor re-invokes those draw lambdas against a recording `DrawScope` and
+     * emits the track and thumb as editable `<path>`s, so the drawn descendants vectorise
+     * faithfully instead of being cropped out as an opaque `<image>`. Rasterising the `SliderKt`
+     * node by name would pre-empt that capture (the opaque-by-name branch drops the subtree before
+     * recursion reaches the drawn leaves), so keep `Slider` out of this set.
      */
     val DEFAULT_RASTER_COMPONENTS: Set<String> =
       setOf(
@@ -330,7 +339,6 @@ data class FigmaSvgModel(
         "AndroidView",
         "Painter",
         "TextField",
-        "Slider",
       )
 
     /** Default `<image>` href for an opaque node: a per-node PNG under `figma-raster/`. */

--- a/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgSliderVectorizeTest.kt
+++ b/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgSliderVectorizeTest.kt
@@ -1,0 +1,102 @@
+package ee.schimke.composeai.data.layoutinspector
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * `Slider` is no longer in [FigmaSvgModel.DEFAULT_RASTER_COMPONENTS]: its track + thumb are drawn
+ * imperatively by `SliderKt`, and the draw-capture extractor re-invokes those draw lambdas against
+ * a recording `DrawScope` on-device, populating a [LayoutInspectorVectorGraphic] on the drawn
+ * leaves. This covers the pure model/emitter half from a synthetic payload — that a `SliderKt` node
+ * keeps recursing into those captured leaves (instead of being cropped out as an opaque-by-name
+ * `<image>`, which would drop the whole subtree before recursion ever reached them).
+ */
+class FigmaSvgSliderVectorizeTest {
+
+  private fun bounds(l: Int, t: Int, r: Int, b: Int) = LayoutInspectorBounds(l, t, r, b)
+
+  /** The active-track segment the draw-capture extractor recorded as a rounded `<path>`. */
+  private val track =
+    LayoutInspectorVectorGraphic(
+      viewportWidth = 200f,
+      viewportHeight = 4f,
+      paths =
+        listOf(
+          LayoutInspectorVectorPath(
+            pathData =
+              "M2 0L198 0A2 2 0 0 1 200 2A2 2 0 0 1 198 4L2 4A2 2 0 0 1 0 2A2 2 0 0 1 2 0Z",
+            fillArgb = "#FF6750A4",
+          )
+        ),
+    )
+
+  /**
+   * A `SliderKt` container whose drawn track leaf carries a captured
+   * [LayoutInspectorVectorGraphic], exactly as the connector's draw-capture populates it on-device.
+   */
+  private fun sliderNode() =
+    LayoutInspectorNode(
+      nodeId = "slider-1",
+      component = "SliderKt", // fragment "Slider" used to force an opaque raster of the whole node
+      bounds = bounds(0, 0, 200, 48),
+      size = LayoutInspectorSize(200, 48),
+      children =
+        listOf(
+          LayoutInspectorNode(
+            nodeId = "track-1",
+            component = "Spacer",
+            bounds = bounds(0, 22, 200, 26),
+            size = LayoutInspectorSize(200, 4),
+            vectorGraphic = track,
+          )
+        ),
+    )
+
+  private fun model(node: LayoutInspectorNode, rasterComponents: Set<String>) =
+    FigmaSvgModel.from(layout = LayoutInspectorPayload(node), rasterComponents = rasterComponents)
+
+  @Test
+  fun sliderIsNotInTheDefaultRasterSet() {
+    assertFalse(
+      "Slider is draw-captured now, not rastered by name",
+      FigmaSvgModel.DEFAULT_RASTER_COMPONENTS.contains("Slider"),
+    )
+    assertTrue(
+      "TextField stays rastered — its cursor/selection/IME state is genuinely raster-only",
+      FigmaSvgModel.DEFAULT_RASTER_COMPONENTS.contains("TextField"),
+    )
+  }
+
+  @Test
+  fun sliderRecursesIntoItsCapturedTrackAsAVector() {
+    val m = model(sliderNode(), FigmaSvgModel.DEFAULT_RASTER_COMPONENTS)
+    // The SliderKt node itself is a plain container now — no opaque-by-name raster of the subtree.
+    assertNull("SliderKt is not an opaque-leaf <image>", m.root.raster)
+    assertEquals("its drawn track survives as a child layer", 1, m.root.children.size)
+    val trackLayer = m.root.children.single()
+    assertNotNull("the track carries the editable captured vector", trackLayer.vector)
+    assertNull("the track is a vector, not a raster crop", trackLayer.raster)
+    assertTrue(m.rasterTargets.isEmpty())
+
+    val svg = FigmaLayeredSvg.render(m)
+    assertFalse("no <image> for a vectorised slider track", svg.contains("<image"))
+    assertTrue("emits the captured track <path>", svg.contains("<path d=\"M2 0"))
+    assertTrue("solid track fill is carried through", svg.contains("fill=\"#6750A4\""))
+  }
+
+  @Test
+  fun withSliderBackInTheRasterSetTheSubtreeIsCroppedOut() {
+    // Guard the mechanism: had `Slider` stayed a raster-component fragment, the opaque-by-name
+    // branch
+    // would fire on `SliderKt` *before* recursion, cropping the node to an <image> and dropping the
+    // captured track entirely — the very regression removing it from the set avoids.
+    val m = model(sliderNode(), FigmaSvgModel.DEFAULT_RASTER_COMPONENTS + "Slider")
+    assertNotNull("with Slider rastered, the node is an opaque <image>", m.root.raster)
+    assertTrue("the drawn track child is dropped", m.root.children.isEmpty())
+    assertTrue(m.rasterTargets.isNotEmpty())
+  }
+}


### PR DESCRIPTION
## Summary

Removes `"Slider"` from `FigmaSvgModel.DEFAULT_RASTER_COMPONENTS` so a `SliderKt` node no longer short-circuits to an opaque `<image>` that crops its whole subtree out of the editable-vector export.

The draw-capture extractor (#2526) already re-invokes a control's imperative draw lambda against a recording `DrawScope` and translates the primitives into editable `<path>`s — the slider's track + thumb are drawn exactly this way (into bare `Spacer`/`Canvas` leaves), so they now vectorise faithfully instead of being rastered. Keeping `"Slider"` in the name set actively *prevented* that: the opaque-by-name branch fires on the `SliderKt` node **before** recursion, dropping the drawn descendants before the capture ever reaches them.

`"TextField"` stays in the raster set — its live cursor / selection / IME state is genuinely raster-only, and it was the worst sticker in the fidelity audit.

## Why this is the right shape

- No per-component geometry is ported — the slider's real theme/state/version draw calls are captured, so it can't drift from the component.
- The mechanism is guarded both ways in tests: default set ⇒ the track surfaces as a vector; `+ "Slider"` ⇒ the node reverts to an opaque `<image>` and the subtree is dropped (the exact regression this removes).

## Visual evidence

This surface can't be rendered in the current headless sandbox (the draw-capture path is Skiko-backed — `Path`/`PathMeasure` need libGL + Xvfb, which aren't available here), so I can't embed a before/after of the real catalog slider from this environment. The end-to-end visual verification path is:

1. the CI visual-diff bot (`preview-comment` / catalog render vs. SVG) on this PR, and
2. the `design-artifacts.yml` regen + compare-page fidelity scoring after merge.

If the slider's fidelity score regresses below its current raster baseline once rendered, this is a clean single-commit revert (remove-from-set only) — the draw-capture plumbing it relies on is unchanged.

## Test plan

- `./gradlew :data-layoutinspector-core:test` — green, including the new `FigmaSvgSliderVectorizeTest`:
  - `sliderIsNotInTheDefaultRasterSet` — `Slider` gone, `TextField` retained.
  - `sliderRecursesIntoItsCapturedTrackAsAVector` — a `SliderKt` node with a captured-track leaf emits a `<path>` (no `<image>`), fill carried through.
  - `withSliderBackInTheRasterSetTheSubtreeIsCroppedOut` — mechanism guard: re-adding `Slider` restores the opaque-image + dropped-subtree behaviour.
- `./gradlew :data-layoutinspector-core:ktfmtFormatMain :data-layoutinspector-core:ktfmtFormatTest` — clean.

_Generated by [Claude Code](https://claude.ai/code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01MKLWAgKunMpmXezWGWiWxE)_