### PR TITLE
docs: explain why icon and imperative-chrome vectorisation use separate extractors

### DIFF
--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
@@ -1037,6 +1037,16 @@ internal object ComposeLayoutInspector {
    *   follows),
    * - a group carrying a non-identity transform (translate/scale/rotate/clip) → null, so a
    *   transformed icon rasters rather than emitting misplaced geometry (kept minimal on purpose).
+   *
+   * Why reflection here rather than the [DrawCaptureExtractor] recorder that vectorises imperative
+   * chrome (`Slider`/`Checkbox`/progress): those controls issue `drawPath`/`drawCircle`/… straight
+   * to the `DrawScope`, so re-invoking their draw lambda against a recording scope captures the
+   * primitives directly. A `VectorPainter` does NOT — its `onDraw` records the vector into a cached
+   * `GraphicsLayer` and then `drawLayer`s it, so a recording scope would only see the opaque layer
+   * blit (which the recorder rejects) and never the underlying paths, aborting every icon to
+   * raster. Reflecting the live `VectorComponent` tree is the mechanism that actually reaches an
+   * `ImageVector`'s geometry; the two extractors are deliberately separate, not a duplication to
+   * fold together.
    */
   private object VectorGraphicExtractor {
     fun extract(node: LayoutNodeFacade): LayoutInspectorVectorGraphic? =

--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/DrawCaptureExtractor.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/DrawCaptureExtractor.kt
@@ -36,7 +36,10 @@ import kotlin.math.sin
  * bar/arc, a `Checkbox` box+tick, a `RadioButton` ring+dot) by re-invoking its draw lambda against
  * a recording [DrawScope] and translating the primitive calls into editable SVG `<path>`s — the
  * same [LayoutInspectorVectorGraphic] an `Icon`'s `ImageVector` produces, so it rides the existing
- * vector-export pipeline instead of the opaque raster crop.
+ * vector-export pipeline instead of the opaque raster crop. (An `ImageVector` icon can't use this
+ * recorder — a `VectorPainter` draws through a cached `GraphicsLayer` a recording scope can't see
+ * into — so `VectorGraphicExtractor` reflects that geometry instead; the two are separate on
+ * purpose.)
  *
  * The draw lambda is read from the draw modifier the same way the token resolver reads container
  * tokens: preferring the modifier's [InspectableValue] projection (`properties["onDraw"]`, the


### PR DESCRIPTION
## Summary

Documents why `VectorGraphicExtractor` (icon `ImageVector` reflection) and `DrawCaptureExtractor` (imperative slider/checkbox/progress chrome) are **deliberately separate mechanisms** and shouldn't be folded together — closing off a tempting-but-regressing "consolidation".

The two look like they duplicate work (both produce a `LayoutInspectorVectorGraphic`), so the natural instinct is to retire the icon reflection and re-draw the `VectorPainter` through the same recording `DrawScope` the chrome capture uses. That doesn't work:

- Imperative chrome issues `drawPath`/`drawCircle`/… straight to the `DrawScope`, so re-invoking its draw lambda against a recording scope captures the primitives directly.
- A `VectorPainter` does **not** — its `onDraw` records the vector into a cached `GraphicsLayer` and then `drawLayer`s it. A recording scope would only see the opaque layer blit (which the recorder rejects) and never the underlying paths, so re-drawing would abort **every icon** to raster.

Reflecting the live `VectorComponent` tree is the mechanism that actually reaches an `ImageVector`'s geometry. The note is added to both KDocs so the split is documented from each side.

## Test plan

- Doc-only change (no behavioural code touched).
- `./gradlew :data-layoutinspector-connector:ktfmtFormatMain :data-layoutinspector-connector:compileKotlin` — clean.

_Generated by [Claude Code](https://claude.ai/code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01MKLWAgKunMpmXezWGWiWxE)_