### PR TITLE
ci: verify BuildFetch remote cache accepts writes on push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -608,3 +608,53 @@ jobs:
         if: ${{ github.event_name != 'pull_request' || steps.changes.outputs.run == 'true' }}
         working-directory: vscode-extension
         run: xvfb-run -a npm run test:electron
+
+  # Hard signal that the BuildFetch remote cache is actually being SEEDED, not
+  # just "written to" in the Gradle log. The seeding build jobs push task
+  # outputs on every push to main, but a read-only / over-quota token makes
+  # each PUT return 429 — which Gradle only logs as a non-fatal warning, so the
+  # build stays green while the remote stays empty and every consumer (PRs, dev
+  # machines, cloud sessions) gets 0 remote hits. Grepping the build log for
+  # "Stored cache entry" does NOT catch this: that line is emitted when Gradle
+  # hands the entry to the cache, before/regardless of the remote HTTP result.
+  # So verify the write path directly: PUT a sentinel entry with the SAME token
+  # the seeding jobs push with, then GET it back and assert it persisted.
+  # Push-only (that's the sole event where the read/write token is resolved).
+  # Not wired into branch protection: a BuildFetch outage should show a red X
+  # here without blocking merges.
+  buildfetch-write-check:
+    name: BuildFetch remote write check
+    if: ${{ github.event_name == 'push' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Round-trip a sentinel entry through the remote cache
+        env:
+          # Same secret the buildfetch-cache action passes as rw-token on push.
+          TOKEN: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${TOKEN:-}" ]; then
+            echo "::error::BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN is unset — the remote cache is never seeded (dev/PR/cloud builds will get 0 remote hits)."
+            exit 1
+          fi
+          base="https://cache.eu-central-a.buildfetch.com/8ESz2z/gradle/"
+          # Namespaced, run-unique key so this probe never collides with a real
+          # Gradle cache entry (those are 32-hex-char hashes).
+          key="ci-writecheck-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          payload="$(mktemp)"; printf 'buildfetch-write-check %s' "${GITHUB_SHA}" > "$payload"
+          put="$(curl -sS --retry 2 -o /dev/null -w '%{http_code}' -X PUT \
+                   -u "token-auth:${TOKEN}" --data-binary @"$payload" "${base}${key}")"
+          get="$(curl -sS -o /dev/null -w '%{http_code}' \
+                   -u "token-auth:${TOKEN}" "${base}${key}")"
+          echo "PUT -> HTTP ${put} ; GET -> HTTP ${get}"
+          case "${put}" in
+            200|201|202|204) ;;
+            401|403) echo "::error::BuildFetch write rejected (HTTP ${put}): token is not authorized to write. Remote cache will stay empty."; exit 1 ;;
+            429)     echo "::error::BuildFetch write rejected (HTTP 429): token is read-only or the plan/quota is exhausted. Remote cache will stay empty."; exit 1 ;;
+            *)       echo "::error::BuildFetch write failed (HTTP ${put})."; exit 1 ;;
+          esac
+          if [ "${get}" != "200" ]; then
+            echo "::error::BuildFetch stored the entry (PUT ${put}) but it did not read back (GET ${get}) — writes are not persisting."
+            exit 1
+          fi
+          echo "::notice::BuildFetch remote write verified — PUT ${put}, GET ${get}. The seeding token can write; the remote is being populated."


### PR DESCRIPTION
## Summary

While testing whether the BuildFetch remote cache was actually helping `compose-ai-tools`, a fresh build at `main` HEAD (empty local cache) got **0 remote hits / all tasks executed**, and a direct write probe with the seeding token returned **`HTTP 429` on every `PUT`** (reads work fine). That points at the remote being **empty because seeding writes aren't landing** — a read-only or over-quota token makes every `PUT` fail as a *non-fatal* Gradle warning, so CI stays green while the cache stays empty and every consumer (PRs, dev machines, cloud sessions) gets 0 hits.

This adds a small, push-only `buildfetch-write-check` job that verifies the write path directly instead of trusting a green build:

- `PUT`s a namespaced sentinel entry using the **same token the seeding jobs push with** (`secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN`), then `GET`s it back.
- Fails with a specific diagnosis on `401/403` (unauthorized), `429` (read-only / quota exhausted), other non-2xx, or a non-`200` read-back.
- Prints a `::notice::` confirming the write when it works.

### Why not `--info | grep 'Stored cache entry'`

That line is emitted when Gradle *hands the entry to the cache*, before/regardless of the remote's HTTP response — so a fully-`429`'d push still logs "N stored" and reads as success. The round-trip can't be fooled by a `429`.

### Safety / token handling

- Gated to `push` (the only event where the read/write token resolves), so fork PRs never see the secret.
- Token is used only in a `curl -u` header — never echoed, no `set -x` — and GitHub secret masking is a backstop, so it can't appear in logs.
- Not wired into branch protection: a BuildFetch outage shows a red X here without blocking merges.

## Test plan

- [x] `yamllint`/`yaml.safe_load` parses `ci.yml` (12 jobs, new job gated to `push`).
- [x] Round-trip logic validated out-of-band: `PUT` with the current token returns `429` and the job correctly fails with the read-only/quota diagnosis; a working RW token would `PUT` 2xx + `GET` 200 and pass.
- [ ] First push to `main` after merge exercises the job for real.

_Generated by [Claude Code]_

---
_Generated by [Claude Code](https://claude.ai/code/session_01JTetwcYsdGKTzoNBySuUPn)_