### PR TITLE
fix(renderer): render private @PreviewParameter providers without sinking the shard

### DIFF
--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -138,7 +138,17 @@ object PreviewManifestLoader {
             it.params.kind != PreviewKind.LOTTIE &&
             it.params.kind != PreviewKind.SVG
         }
-        .map { it to expandParameterProvider(it) }
+        .map { entry ->
+          // `expandParameterProvider` already isolates provider-load failures; this outer guard is
+          // belt-and-suspenders so any *other* unexpected throw while expanding one entry drops just
+          // that entry rather than failing the whole shard's `@Parameters` load (issue #2493).
+          entry to
+            runCatching { expandParameterProvider(entry) }
+              .getOrElse { e ->
+                System.err.println("Failed to expand preview '${entry.id}': ${e.message}")
+                emptyList()
+              }
+        }
     val expanded = expandedByEntry.flatMap { it.second }
     // Tier filter (set by the plugin via TierSystemPropProvider). When
     // `fast`, drop heavyweight captures and annotation-sourced data
@@ -242,13 +252,29 @@ object PreviewManifestLoader {
         ?: return listOf(PreviewRow(entry, emptyList()))
     val limit = entry.params.previewParameterLimit.coerceAtLeast(0)
     if (limit == 0) return emptyList()
-    val values = loadProviderValues(providerFqn, limit)
+    val values =
+      try {
+        loadProviderValues(providerFqn, limit)
+      } catch (e: Throwable) {
+        // Isolate the failure: one unloadable provider must not throw out of the JUnit
+        // `@Parameters` method and sink the whole shard (issue #2493). Emit a per-preview
+        // `.error.json` so the failing preview surfaces its cause on the panel instead of silently
+        // vanishing, then drop only this preview from the shard.
+        System.err.println(
+          "@PreviewParameter(provider = $providerFqn) on '${entry.id}' failed to load: ${e.message}"
+        )
+        providerErrorOutputFile(entry)?.let { RenderErrorSidecar.write(it, e) }
+        return emptyList()
+      }
     if (values.isEmpty()) {
       System.err.println(
         "@PreviewParameter(provider = $providerFqn) on '${entry.id}' produced no values — skipping."
       )
       return emptyList()
     }
+    // Provider loaded cleanly this run — drop any stale base error card a prior failed run left at
+    // the unsuffixed output path, so a now-fixed provider doesn't keep haunting the panel.
+    providerErrorOutputFile(entry)?.let { RenderErrorSidecar.deleteStale(it) }
     val suffixes = PreviewParameterLabels.suffixesFor(values)
     val rows = values.mapIndexed { idx, value ->
       val paramSuffix = suffixes[idx]
@@ -340,50 +366,88 @@ object PreviewManifestLoader {
     return if (dot > slash) path.substring(0, dot) + suffix + path.substring(dot) else path + suffix
   }
 
+  /**
+   * Enumerate a `PreviewParameterProvider`'s values reflectively.
+   *
+   * Throws [ProviderLoadException] on any hard failure (class missing, no no-arg constructor,
+   * missing/throwing `getValues()`) so the caller can isolate the failing preview and surface it as
+   * a per-preview error card rather than letting the throw sink the whole shard. Returns an empty
+   * list only when the provider legitimately yields no values.
+   */
   private fun loadProviderValues(providerFqn: String, limit: Int): List<Any?> {
     val clazz =
       try {
         Class.forName(providerFqn)
       } catch (e: ClassNotFoundException) {
-        System.err.println(
-          "@PreviewParameter: provider class $providerFqn not found on test classpath — skipping."
-        )
-        return emptyList()
+        throw ProviderLoadException("provider class $providerFqn not found on the test classpath", e)
       }
     val instance =
-      runCatching {
-          val ctor = clazz.getDeclaredConstructor()
-          ctor.isAccessible = true
-          ctor.newInstance()
-        }
-        .getOrElse { e ->
-          System.err.println(
-            "@PreviewParameter: couldn't instantiate $providerFqn via nullary constructor: ${e.message}"
-          )
-          return emptyList()
-        }
+      try {
+        val ctor = clazz.getDeclaredConstructor()
+        // `private` providers (idiomatic Kotlin, and rendered fine by Android Studio) compile to
+        // package-private JVM classes, so their no-arg constructor isn't reflectively callable from
+        // this package without opening it up first — see issue #2493.
+        ctor.isAccessible = true
+        ctor.newInstance()
+      } catch (e: Throwable) {
+        throw ProviderLoadException(
+          "couldn't instantiate $providerFqn via its no-arg constructor",
+          e,
+        )
+      }
     // `PreviewParameterProvider<T>` exposes `values: Sequence<T>` as a Kotlin
     // property — its JVM signature is `getValues(): Sequence`. Look up the
     // method by name to avoid taking a compile-time dependency on the
     // provider interface (which lives in the consumer's Compose artifact).
     val getValues =
-      runCatching { clazz.getMethod("getValues") }
-        .getOrElse {
-          System.err.println(
-            "@PreviewParameter: $providerFqn has no getValues() — not a PreviewParameterProvider?"
-          )
-          return emptyList()
-        }
-    @Suppress("UNCHECKED_CAST")
-    val sequence = getValues.invoke(instance) as? Sequence<Any?> ?: return emptyList()
-    // `Sequence.take(Int).toList()` is the Kotlin stdlib contract —
-    // drives the sequence lazily up to `limit` without requiring
-    // reflective access into package-private iterator implementations
-    // (`kotlin.jvm.internal.ArrayIterator`, which `Method.invoke`
-    // rejects with IllegalAccessException from outside the stdlib
-    // module).
-    return sequence.take(limit).toList()
+      try {
+        clazz.getMethod("getValues")
+      } catch (e: Throwable) {
+        throw ProviderLoadException(
+          "$providerFqn has no getValues() — not a PreviewParameterProvider?",
+          e,
+        )
+      }
+    // Same package-private-class problem as the constructor above: a public `getValues()` declared
+    // on a package-private class throws `IllegalAccessException` from `Method.invoke` unless the
+    // member is opened up first. This is the crash in issue #2493.
+    getValues.isAccessible = true
+    return try {
+      @Suppress("UNCHECKED_CAST")
+      val sequence = getValues.invoke(instance) as? Sequence<Any?> ?: return emptyList()
+      // `Sequence.take(Int).toList()` is the Kotlin stdlib contract —
+      // drives the sequence lazily up to `limit` without requiring
+      // reflective access into package-private iterator implementations
+      // (`kotlin.jvm.internal.ArrayIterator`, which `Method.invoke`
+      // rejects with IllegalAccessException from outside the stdlib
+      // module).
+      sequence.take(limit).toList()
+    } catch (e: Throwable) {
+      throw ProviderLoadException("$providerFqn.getValues() failed", e)
+    }
   }
+
+  /**
+   * Resolve the base output PNG for [entry] the same way [RobolectricRenderTestBase.outputFileFor]
+   * does, so a provider-load error card lands where the panel already looks for this preview's
+   * render. `null` when no output dir is configured or the entry declares no output at all.
+   */
+  private fun providerErrorOutputFile(entry: RenderPreviewEntry): File? {
+    val outputDir = System.getProperty("composeai.render.outputDir")?.let(::File) ?: return null
+    entry.captures.firstOrNull()?.let { capture ->
+      val leaf = capture.renderOutput.substringAfterLast('/').ifEmpty { "${entry.id}.png" }
+      return File(outputDir, leaf)
+    }
+    entry.dataProducts.firstOrNull()?.let { product ->
+      val rootDir = outputDir.parentFile ?: outputDir
+      return File(rootDir, product.output)
+    }
+    return null
+  }
+
+  /** Thrown by [loadProviderValues] on a hard provider-load failure so the caller can isolate it. */
+  private class ProviderLoadException(message: String, cause: Throwable?) :
+    RuntimeException(message, cause)
 }
 
 /**

--- a/renderers/android/src/test/kotlin/com/example/testproviders/PrivatePreviewProviders.kt
+++ b/renderers/android/src/test/kotlin/com/example/testproviders/PrivatePreviewProviders.kt
@@ -1,0 +1,28 @@
+@file:Suppress("unused")
+
+package com.example.testproviders
+
+/**
+ * Test fixtures for [ee.schimke.composeai.renderer.PreviewManifestLoaderProviderTest].
+ *
+ * These live in a package OTHER than the renderer's so that `private`/package-private access is
+ * exercised cross-package — the exact condition under which `Method.invoke` throws
+ * `IllegalAccessException` without `setAccessible(true)` (issue #2493). They're referenced only by
+ * fully-qualified name via `Class.forName`, never by symbol, so `private` top-level visibility is
+ * fine.
+ */
+
+/**
+ * A `private` top-level provider. Kotlin compiles this to a package-private JVM class, so both its
+ * no-arg constructor and its `getValues()` accessor are unreachable from the renderer's package
+ * unless the loader opens them up with `isAccessible = true`.
+ */
+private class PrivateStringProvider {
+  val values: Sequence<String> = sequenceOf("alpha", "beta", "gamma")
+}
+
+/** A public provider whose `getValues()` throws while the sequence is being driven. */
+class ThrowingProvider {
+  val values: Sequence<String>
+    get() = throw IllegalStateException("provider boom")
+}

--- a/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/PreviewManifestLoaderProviderTest.kt
+++ b/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/PreviewManifestLoaderProviderTest.kt
@@ -1,0 +1,98 @@
+package ee.schimke.composeai.renderer
+
+import java.io.File
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * Pins the `@PreviewParameter` provider-loading behaviour in
+ * [PreviewManifestLoader.expandParameterProvider] / `loadProviderValues` (issue #2493):
+ * - a `private` (package-private in bytecode) provider is opened up with `isAccessible` and
+ *   enumerated instead of crashing with `IllegalAccessException`;
+ * - a provider that can't be loaded is isolated to its own preview — it returns no rows and writes a
+ *   `.error.json` card rather than throwing out of the shard's `@Parameters` method.
+ */
+class PreviewManifestLoaderProviderTest {
+
+  @get:Rule val tmp = TemporaryFolder()
+
+  @After
+  fun clearOutputDir() {
+    System.clearProperty("composeai.render.outputDir")
+  }
+
+  private fun entry(id: String, providerFqn: String?): RenderPreviewEntry =
+    RenderPreviewEntry(
+      id = id,
+      functionName = id,
+      className = "com.example.PreviewsKt",
+      params = RenderPreviewParams(previewParameterProviderClassName = providerFqn),
+      captures = listOf(RenderPreviewCapture(renderOutput = "renders/$id.png")),
+    )
+
+  @Test
+  fun `private provider is enumerated instead of throwing IllegalAccessException`() {
+    val rows =
+      PreviewManifestLoader.expandParameterProvider(
+        entry("FooPreview", "com.example.testproviders.PrivateStringProvider")
+      )
+
+    // One row per provided value ("alpha", "beta", "gamma"), each carrying its own value.
+    assertEquals(3, rows.size)
+    assertEquals(
+      listOf("alpha", "beta", "gamma"),
+      rows.map { it.previewArgs.single() as String },
+    )
+    // Every fan-out row is suffixed off the base id / renderOutput.
+    assertTrue(rows.all { it.entry.id.startsWith("FooPreview") && it.entry.id != "FooPreview" })
+  }
+
+  @Test
+  fun `missing provider is isolated to its preview and writes an error card`() {
+    System.setProperty("composeai.render.outputDir", tmp.root.absolutePath)
+
+    val rows =
+      PreviewManifestLoader.expandParameterProvider(
+        entry("FooPreview", "com.example.testproviders.DoesNotExist")
+      )
+
+    // No rows for the broken preview — but crucially no throw, so sibling previews still load.
+    assertTrue(rows.isEmpty())
+    // The failure surfaces as a per-preview error card at the base output path.
+    assertTrue(File(tmp.root, "FooPreview.png.error.json").exists())
+  }
+
+  @Test
+  fun `provider whose getValues throws is isolated and carded`() {
+    System.setProperty("composeai.render.outputDir", tmp.root.absolutePath)
+
+    val rows =
+      PreviewManifestLoader.expandParameterProvider(
+        entry("FooPreview", "com.example.testproviders.ThrowingProvider")
+      )
+
+    assertTrue(rows.isEmpty())
+    assertTrue(File(tmp.root, "FooPreview.png.error.json").exists())
+  }
+
+  @Test
+  fun `a successful provider clears a stale error card from a prior failed run`() {
+    System.setProperty("composeai.render.outputDir", tmp.root.absolutePath)
+    // Simulate a leftover card from a run when the provider was still broken.
+    val staleCard = File(tmp.root, "FooPreview.png.error.json")
+    staleCard.writeText("{}")
+
+    val rows =
+      PreviewManifestLoader.expandParameterProvider(
+        entry("FooPreview", "com.example.testproviders.PrivateStringProvider")
+      )
+
+    assertEquals(3, rows.size)
+    assertFalse("stale error card should be cleared once the provider loads", staleCard.exists())
+  }
+}

--- a/samples/android/src/main/kotlin/com/example/sampleandroid/PreviewParameterPreviews.kt
+++ b/samples/android/src/main/kotlin/com/example/sampleandroid/PreviewParameterPreviews.kt
@@ -94,3 +94,36 @@ fun BodyTextPreview(@PreviewParameter(TextSampleProvider::class, limit = 3) body
     )
   }
 }
+
+/**
+ * Regression fixture for issue #2493: a `private` `PreviewParameterProvider`. Declaring a provider
+ * private is idiomatic Kotlin and renders fine in Android Studio, but a private top-level class
+ * compiles to a *package-private* JVM class — so the renderer, which lives in a different package,
+ * must open the constructor and `getValues()` accessor with `isAccessible` to enumerate it. Before
+ * the fix this threw `IllegalAccessException` at shard-load time and sank the whole render batch.
+ * Public preview function + file-private provider (legal because both live in this file) so the
+ * fan-out flows through the normal capture pipeline and the visual-diff bot renders it on every PR.
+ */
+private class BadgeProvider : PreviewParameterProvider<String> {
+  override val values: Sequence<String> = sequenceOf("NEW", "BETA", "PRO")
+}
+
+@Preview(
+  name = "Private Provider Badge",
+  showBackground = true,
+  backgroundColor = 0xFFFFFFFF,
+  widthDp = 200,
+)
+@Composable
+fun PrivateProviderBadgePreview(@PreviewParameter(BadgeProvider::class) label: String) {
+  MaterialTheme {
+    Card(modifier = Modifier.padding(12.dp)) {
+      Text(
+        text = label,
+        modifier = Modifier.padding(horizontal = 20.dp, vertical = 12.dp),
+        style = MaterialTheme.typography.labelLarge,
+        fontWeight = FontWeight.Bold,
+      )
+    }
+  }
+}


### PR DESCRIPTION
Fixes #2493.

## Problem

A `@Preview` backed by a `private` `PreviewParameterProvider` failed to render with:

```
java.lang.IllegalAccessException: class …PreviewManifestLoader
  cannot access a member of class com.example.FooPreviewProvider with modifiers "public"
```

Two bugs, one symptom:

1. **Access.** A private top-level Kotlin class compiles to a *package-private* JVM class. The constructor was already opened with `isAccessible = true`, but the `getValues()` accessor was not — so `Method.invoke` from the renderer's package threw `IllegalAccessException`. Private providers are idiomatic Kotlin and render fine in Android Studio.
2. **Blast radius.** Provider values are enumerated eagerly in the shard's JUnit `@Parameters` method, so that throw surfaced as `initializationError` and failed the **entire shard** — every sibling preview (including ones that don't use `@PreviewParameter` at all), `--id`/`--filter` targets, and the `--output`/`show --json` retrieval all died with it.

## Fix

- Open the `getValues()` accessor with `isAccessible` before invoking, and wrap the invoke+drain so a provider failure surfaces as a typed `ProviderLoadException` instead of escaping.
- **Isolate provider-load failures per preview.** A bad/unloadable provider now drops only its own preview and writes a per-preview `.error.json` card (using the existing sidecar mechanism) so the failure is visible on the panel instead of the preview silently vanishing — and it's cleared automatically once the provider loads cleanly again. A belt-and-suspenders guard in `loadShard` drops any *other* unexpected per-entry expansion throw the same way, so one bad preview can never sink the batch.

## Test plan

- **New unit tests** (`PreviewManifestLoaderProviderTest`, cross-package `private`/throwing provider fixtures): a private provider is enumerated instead of throwing; a missing provider and a throwing `getValues()` are each isolated to their own preview and write an `.error.json` card; a now-working provider clears the stale card. `:renderer-android:testDebugUnitTest` → **4/4 pass** (plus the existing shard/fan-out suites green).
- **End-to-end render.** Added a `private`-provider regression fixture (`PrivateProviderBadgePreview`) to `:samples:android` and rendered it through the real Robolectric pipeline — it now produces its three fan-out PNGs (`NEW`/`BETA`/`PRO`) instead of crashing. The fixture is wired into the sample so the CI visual-diff bot renders and diffs it on every future PR (see the **Preview Comment** bot's inline before/after on this PR).

### Visual evidence

The three fan-out renders of the new private-provider fixture (rendered locally with this fix; the CI preview bot posts the same inline on this PR):

| NEW | BETA | PRO |
|-----|------|-----|
| `PrivateProviderBadgePreview … _NEW.png` | `… _BETA.png` | `… _PRO.png` |

Each is a Material 3 `Card` badge — a rounded chip with the provider's value in bold. Before the fix these could not render at all (the whole shard failed at init); they were verified in-session as actual pixels. Inline pixels couldn't be hosted from the headless render environment, so the authoritative inline before/after is the CI **Preview Comment** on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Libi7mCUErR1v6DgfAFkTN)_