### PR TITLE
feat(daemon): Android recording assertions — textEquals, role/text targets, pixels (#2519)

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSession.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSession.kt
@@ -165,6 +165,10 @@ class AndroidRecordingSession(
     var frameWidthPx = 0
     var frameHeightPx = 0
     val evidence = mutableListOf<RecordingScriptEvidence>()
+    // `assert.pixels` events (issue #2519) diff against the frame written for their timeline
+    // position, which isn't on disk until that frame's iteration finishes — so each reserves its
+    // evidence slot here and the diff runs in a post-loop pass, keeping evidence in timeline order.
+    val pendingPixels = mutableListOf<PendingPixelAssert>()
     for (frameIndex in 0 until totalFrames) {
       val tMs: Long = frameIndex.toLong() * 1000L / fps.toLong()
 
@@ -174,8 +178,17 @@ class AndroidRecordingSession(
       // doesn't matter on the host side (the underlying session has its own streamId).
       while (nextEventIdx < sortedEvents.size && sortedEvents[nextEventIdx].tMs <= tMs) {
         val e = sortedEvents[nextEventIdx]
-        val ctx = SimpleRecordingDispatchContext(tNanos = tMs * 1_000_000L, tMs = tMs)
-        evidence.add(scriptHandlers.dispatch(e, ctx))
+        if (e.kind == RecordingScriptDataExtensions.ASSERT_PIXELS_EVENT) {
+          // Defer to the frame written for this bucket (below): on Android every same-bucket event
+          // is dispatched before the single render, so "the frame at this tMs" is the only
+          // well-defined snapshot — the on-disk `frame-NNNNN.png` for this frameIndex. Reserve a
+          // FAILED placeholder so a (bug) skipped finalization fails closed.
+          pendingPixels.add(PendingPixelAssert(evidence.size, frameIndex, e))
+          evidence.add(failedEvidence(e, "assert.pixels: not evaluated"))
+        } else {
+          val ctx = SimpleRecordingDispatchContext(tNanos = tMs * 1_000_000L, tMs = tMs)
+          evidence.add(scriptHandlers.dispatch(e, ctx))
+        }
         nextEventIdx++
       }
 
@@ -195,6 +208,11 @@ class AndroidRecordingSession(
         frameHeightPx = dims.second
       }
     }
+    // Post-loop: every frame is on disk now, so diff each deferred assert.pixels against the frame
+    // written for its timeline position.
+    for (p in pendingPixels) {
+      evidence[p.evidenceIndex] = evaluatePixelAssert(p.event, p.frameIndex)
+    }
     val tookMs = (System.nanoTime() - startNs) / 1_000_000L
     System.err.println(
       "compose-ai-daemon: AndroidRecordingSession.stop($recordingId): rendered $totalFrames " +
@@ -209,6 +227,60 @@ class AndroidRecordingSession(
       frameHeightPx = frameHeightPx,
       scriptEvents = evidence,
     )
+  }
+
+  /**
+   * A deferred `assert.pixels` event (issue #2519): the diff of the frame written for [frameIndex]
+   * against the baseline runs after the playback loop (once every frame is on disk) and its result
+   * replaces the placeholder evidence at [evidenceIndex] so the event keeps its timeline position.
+   */
+  private class PendingPixelAssert(
+    val evidenceIndex: Int,
+    val frameIndex: Int,
+    val event: RecordingScriptEvent,
+  )
+
+  /**
+   * Golden-image assertion on the Android backend (issue #2519): diff the frame written for
+   * [frameIndex] (`frame-NNNNN.png`, the same file the encoder reads) against the committed baseline
+   * PNG named by the event's `inputText` (resolved CLI-side against `--baseline-dir`). The pure
+   * verdict lives in [pixelAssertVerdict] in `:daemon:core` — the same one the desktop backend uses,
+   * reusing the `PixelDiff` comparator. On failure it writes actual/expected/diff PNGs under
+   * [encodedDir] so the drift is inspectable without re-running. Fail-closed: a missing baseline, a
+   * missing frame, or a dimension mismatch is FAILED, never a silent pass.
+   */
+  private fun evaluatePixelAssert(
+    event: RecordingScriptEvent,
+    frameIndex: Int,
+  ): RecordingScriptEvidence {
+    val baselinePath =
+      event.inputText
+        ?: return failedEvidence(
+          event,
+          "assert.pixels requires the baseline PNG path in the 'inputText' field",
+        )
+    val frameFile = File(framesDir, "frame-${"%05d".format(frameIndex)}.png")
+    val actualPng = frameFile.takeIf { it.isFile }?.readBytes()
+    val baselineBytes = File(baselinePath).takeIf { it.isFile }?.readBytes()
+    return when (val verdict = pixelAssertVerdict(actualPng, baselineBytes)) {
+      AssertionVerdict.Passed ->
+        appliedEvidence(event, "assert.pixels matched baseline '${File(baselinePath).name}'")
+      is AssertionVerdict.Failed -> {
+        if (actualPng != null && baselineBytes != null) {
+          // Best-effort diagnostics — never let an artefact-write failure mask the real verdict.
+          try {
+            val diffDir = File(encodedDir, "pixel-diff-t${event.tMs}ms").apply { mkdirs() }
+            PixelDiff.writeDiffArtefacts(actualPng, baselineBytes, diffDir)
+          } catch (t: Throwable) {
+            System.err.println(
+              "compose-ai-daemon: assert.pixels diff-artefact write failed at t=${event.tMs}ms: " +
+                "${t.javaClass.simpleName}: ${t.message}"
+            )
+          }
+        }
+        failedEvidence(event, verdict.reason)
+      }
+    }
   }
 
   private fun stopLive(): RecordingResult {
@@ -308,6 +380,11 @@ class AndroidRecordingSession(
             RecordingScriptDataExtensions.ASSERT_NOT_VISIBLE_EVENT,
             assertVisibilityHandler(expectVisible = false),
           )
+          // `assert.textEquals` (issue #2519) — resolves the target against the probe snapshot and
+          // compares the resolved node's (merged) text to the expected string in `inputText`. The
+          // snapshot now carries each node's merged descendant text, so a tag-on-container /
+          // role+text shape resolves the text the user sees.
+          put(RecordingScriptDataExtensions.ASSERT_TEXT_EQUALS_EVENT, assertTextEqualsHandler())
           // Accessibility assertion (issue #1966) — `assert.a11y` runs Android ATF against the held
           // composition's View hierarchy and fails the recording when findings breach the
           // threshold.
@@ -383,16 +460,14 @@ class AndroidRecordingSession(
   /**
    * Maestro-style visibility assertion on the Android backend. Resolves the event's target against
    * the **probe semantics snapshot** ([InteractiveSession.captureProbeSemantics], already bridged
-   * across the sandbox/host classloader boundary) and records APPLIED / FAILED via the shared
-   * [evaluateVisibilityAssertion].
+   * across the sandbox/host classloader boundary) via the shared [resolveProbeTarget] and records
+   * APPLIED / FAILED through the shared [evaluateVisibilityAssertion].
    *
-   * **`testTag` only (today).** The probe snapshot is a *flat* node list, so it can't reliably
-   * match a `role`+`text` target: common controls like `Button { Text("Add") }` emit the `role` on
-   * the button node and the `text` on a separate child, so checking both on one node would match
-   * nothing — making `assert.notVisible` *wrongly pass* while the control is on screen. `testTag`
-   * lands on a single node, so it resolves cleanly. `ref` (no refs in the snapshot) and
-   * `role`+`text` both fail with a clear message rather than risk a false pass; enriching the
-   * snapshot for `role`+`text` is a follow-up. A missing/empty target is itself a failed assertion.
+   * **Targets (issue #2519).** The snapshot is a *flat* node list, but each retained node now
+   * carries its merged descendant text ([RecordingProbeNode.mergedText]), so `testTag`, `role`+`text`
+   * (a `Button { Text("Add") }` matches via the button's merged text), and `text` alone all resolve.
+   * `ref` still has no counterpart in the snapshot and fails with a clear message rather than risk a
+   * false `assert.notVisible` pass. A missing/empty target is itself a failed assertion.
    */
   private fun assertVisibilityHandler(expectVisible: Boolean): RecordingScriptEventHandler =
     RecordingScriptEventHandler { event, _ ->
@@ -400,24 +475,72 @@ class AndroidRecordingSession(
         event.target
           ?: return@RecordingScriptEventHandler failedEvidence(
             event,
-            "${event.kind} requires a 'target' (testTag) to assert on",
+            "${event.kind} requires a 'target' (testTag / role+text / text) to assert on",
           )
-      val tag = target.testTag
-      if (tag.isNullOrBlank()) {
-        return@RecordingScriptEventHandler failedEvidence(
-          event,
-          "${event.kind}: the Android recording backend resolves assertions by testTag only " +
-            "(its probe snapshot is a flat node list); ref and role+text targets aren't supported " +
-            "yet — set a testTag",
-        )
-      }
       val probeNodes = interactive.captureProbeSemantics().orEmpty()
-      val matchCount = probeNodes.count { it.testTag == tag }
-      when (
-        val verdict = evaluateVisibilityAssertion(expectVisible, matchCount, target.toString())
-      ) {
-        AssertionVerdict.Passed -> appliedEvidence(event, "${event.kind} satisfied")
-        is AssertionVerdict.Failed -> failedEvidence(event, verdict.reason)
+      when (val resolution = resolveProbeTarget(probeNodes, target)) {
+        is ProbeTargetResolution.Unsupported ->
+          failedEvidence(event, "${event.kind}: ${resolution.reason}")
+        is ProbeTargetResolution.Matched ->
+          when (
+            val verdict =
+              evaluateVisibilityAssertion(expectVisible, resolution.nodes.size, target.toString())
+          ) {
+            AssertionVerdict.Passed -> appliedEvidence(event, "${event.kind} satisfied")
+            is AssertionVerdict.Failed -> failedEvidence(event, verdict.reason)
+          }
+      }
+    }
+
+  /**
+   * `assert.textEquals` on the Android backend (issue #2519). Resolves the event's target against
+   * the flat probe snapshot via [resolveProbeTarget], requires it to land on exactly one node, and
+   * fails unless that node's [effectiveText] (own text, else merged descendant text) equals the
+   * expected string carried in the event's existing `inputText` field. Mirrors the desktop
+   * `assertTextEqualsHandler`, reusing the shared pure [evaluateTextEqualsAssertion]. A missing
+   * target/expected, an unsupported (`ref`) target, or a target that matches no node — or more than
+   * one, so "the text" is ambiguous — is a failed assertion.
+   */
+  private fun assertTextEqualsHandler(): RecordingScriptEventHandler =
+    RecordingScriptEventHandler { event, _ ->
+      val expected =
+        event.inputText
+          ?: return@RecordingScriptEventHandler failedEvidence(
+            event,
+            "${event.kind} requires the expected text in the 'inputText' field",
+          )
+      val target =
+        event.target
+          ?: return@RecordingScriptEventHandler failedEvidence(
+            event,
+            "${event.kind} requires a 'target' (testTag / role+text / text) to assert on",
+          )
+      val probeNodes = interactive.captureProbeSemantics().orEmpty()
+      when (val resolution = resolveProbeTarget(probeNodes, target)) {
+        is ProbeTargetResolution.Unsupported ->
+          failedEvidence(event, "${event.kind}: ${resolution.reason}")
+        is ProbeTargetResolution.Matched ->
+          when (resolution.nodes.size) {
+            0 -> failedEvidence(event, "${event.kind}: $target matched no node")
+            1 ->
+              when (
+                val verdict =
+                  evaluateTextEqualsAssertion(
+                    expected,
+                    resolution.nodes.single().effectiveText(),
+                    target.toString(),
+                  )
+              ) {
+                AssertionVerdict.Passed -> appliedEvidence(event, "${event.kind} satisfied")
+                is AssertionVerdict.Failed -> failedEvidence(event, verdict.reason)
+              }
+            else ->
+              failedEvidence(
+                event,
+                "${event.kind}: $target matched ${resolution.nodes.size} nodes; " +
+                  "narrow it to assert text",
+              )
+          }
       }
     }
 

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSession.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSession.kt
@@ -165,12 +165,25 @@ class AndroidRecordingSession(
     var frameWidthPx = 0
     var frameHeightPx = 0
     val evidence = mutableListOf<RecordingScriptEvidence>()
-    // `assert.pixels` events (issue #2519) diff against the frame written for their timeline
-    // position, which isn't on disk until that frame's iteration finishes — so each reserves its
-    // evidence slot here and the diff runs in a post-loop pass, keeping evidence in timeline order.
+    // `assert.pixels` events (issue #2519) freeze the frame bytes at the assertion's own timeline
+    // position — before any later same-bucket event — mirroring the desktop session, so the golden
+    // check observes the UI as of the assertion rather than after a same-bucket input. Each reserves
+    // its evidence slot here and the diff runs in a post-loop pass, keeping evidence in timeline
+    // order.
     val pendingPixels = mutableListOf<PendingPixelAssert>()
     for (frameIndex in 0 until totalFrames) {
       val tMs: Long = frameIndex.toLong() * 1000L / fps.toLong()
+
+      // A bucket's virtual clock must advance to `tMs` exactly once, whether the advancing render is
+      // an `assert.pixels` snapshot mid-drain or the final written-frame render. `advanceFor` hands
+      // the full delta to the first render of the bucket and 0 to the rest.
+      var bucketAdvanceApplied = false
+      fun advanceForThisBucket(): Long =
+        if (bucketAdvanceApplied) 0L
+        else {
+          bucketAdvanceApplied = true
+          if (frameIndex == 0) 0L else tMs - lastFrameTimeMs
+        }
 
       // Drain script events whose virtual tMs has elapsed by this frame's tMs and dispatch each
       // through the held-rule loop. Translation back through the InteractiveInputParams shape
@@ -179,11 +192,25 @@ class AndroidRecordingSession(
       while (nextEventIdx < sortedEvents.size && sortedEvents[nextEventIdx].tMs <= tMs) {
         val e = sortedEvents[nextEventIdx]
         if (e.kind == RecordingScriptDataExtensions.ASSERT_PIXELS_EVENT) {
-          // Defer to the frame written for this bucket (below): on Android every same-bucket event
-          // is dispatched before the single render, so "the frame at this tMs" is the only
-          // well-defined snapshot — the on-disk `frame-NNNNN.png` for this frameIndex. Reserve a
-          // FAILED placeholder so a (bug) skipped finalization fails closed.
-          pendingPixels.add(PendingPixelAssert(evidence.size, frameIndex, e))
+          // Render + freeze the frame *now*, at this assertion's position in the drain (after the
+          // events before it, before the ones after it) — the same "before later same-bucket
+          // events" snapshot the desktop session takes. The advance is charged to the bucket once
+          // (above); a later same-bucket event then dispatches against the already-advanced clock
+          // and shows up in the final written frame, not in this frozen snapshot.
+          val snapshotSrc =
+            interactive
+              .render(
+                requestId = RenderHost.nextRequestId(),
+                advanceTimeMs = advanceForThisBucket(),
+              )
+              .pngPath
+              ?: error(
+                "AndroidRecordingSession: interactive.render returned no pngPath for assert.pixels " +
+                  "at frame $frameIndex"
+              )
+          pendingPixels.add(
+            PendingPixelAssert(evidence.size, captureScaledFrameBytes(snapshotSrc), e)
+          )
           evidence.add(failedEvidence(e, "assert.pixels: not evaluated"))
         } else {
           val ctx = SimpleRecordingDispatchContext(tNanos = tMs * 1_000_000L, tMs = tMs)
@@ -192,10 +219,15 @@ class AndroidRecordingSession(
         nextEventIdx++
       }
 
-      val advanceTimeMs = if (frameIndex == 0) 0L else tMs - lastFrameTimeMs
-      lastFrameTimeMs = tMs
+      // The written-frame render; `advanceForThisBucket()` must be called before `lastFrameTimeMs`
+      // is bumped so it can compute `tMs - lastFrameTimeMs` (it returns 0 here when an earlier
+      // assert.pixels render already advanced this bucket).
       val rendered =
-        interactive.render(requestId = RenderHost.nextRequestId(), advanceTimeMs = advanceTimeMs)
+        interactive.render(
+          requestId = RenderHost.nextRequestId(),
+          advanceTimeMs = advanceForThisBucket(),
+        )
+      lastFrameTimeMs = tMs
       val srcPath =
         rendered.pngPath
           ?: error(
@@ -208,10 +240,10 @@ class AndroidRecordingSession(
         frameHeightPx = dims.second
       }
     }
-    // Post-loop: every frame is on disk now, so diff each deferred assert.pixels against the frame
-    // written for its timeline position.
+    // Post-loop: diff each frozen assert.pixels snapshot against its baseline (deferred to keep
+    // evidence in timeline order; the pixels were frozen at the assertion above).
     for (p in pendingPixels) {
-      evidence[p.evidenceIndex] = evaluatePixelAssert(p.event, p.frameIndex)
+      evidence[p.evidenceIndex] = evaluatePixelAssert(p.event, p.snapshotPng)
     }
     val tookMs = (System.nanoTime() - startNs) / 1_000_000L
     System.err.println(
@@ -230,28 +262,47 @@ class AndroidRecordingSession(
   }
 
   /**
-   * A deferred `assert.pixels` event (issue #2519): the diff of the frame written for [frameIndex]
-   * against the baseline runs after the playback loop (once every frame is on disk) and its result
-   * replaces the placeholder evidence at [evidenceIndex] so the event keeps its timeline position.
+   * A deferred `assert.pixels` event (issue #2519): [snapshotPng] is the frame frozen at the event's
+   * timeline position during playback (scaled the same way the written frames are); the diff against
+   * the baseline runs after the loop and its result replaces the placeholder evidence at
+   * [evidenceIndex] so the event keeps its position. Not a `data class` — it holds a `ByteArray` and
+   * is only ever appended to a list (no equality needed).
    */
   private class PendingPixelAssert(
     val evidenceIndex: Int,
-    val frameIndex: Int,
+    val snapshotPng: ByteArray,
     val event: RecordingScriptEvent,
   )
 
   /**
-   * Golden-image assertion on the Android backend (issue #2519): diff the frame written for
-   * [frameIndex] (`frame-NNNNN.png`, the same file the encoder reads) against the committed baseline
-   * PNG named by the event's `inputText` (resolved CLI-side against `--baseline-dir`). The pure
-   * verdict lives in [pixelAssertVerdict] in `:daemon:core` — the same one the desktop backend uses,
-   * reusing the `PixelDiff` comparator. On failure it writes actual/expected/diff PNGs under
-   * [encodedDir] so the drift is inspectable without re-running. Fail-closed: a missing baseline, a
-   * missing frame, or a dimension mismatch is FAILED, never a silent pass.
+   * Render [srcPngPath] (an `interactive.render` output, the raw natural-size frame) through the
+   * same [copyAndMaybeScale] the written frames use, and return the scaled PNG bytes. A baseline is
+   * captured from a written (scaled) `frame-NNNNN.png`, so the frozen `assert.pixels` snapshot has
+   * to be scaled identically for the diff to be apples-to-apples. Uses a short-lived temp file under
+   * [framesDir] because `copyAndMaybeScale` writes to disk.
+   */
+  private fun captureScaledFrameBytes(srcPngPath: String): ByteArray {
+    val tmp = File.createTempFile("assert-pixels-snapshot-", ".png", framesDir)
+    return try {
+      copyAndMaybeScale(File(srcPngPath), tmp, scale)
+      tmp.readBytes()
+    } finally {
+      tmp.delete()
+    }
+  }
+
+  /**
+   * Golden-image assertion on the Android backend (issue #2519): diff the [actualPng] snapshot
+   * (frozen at the event's position in [stopScripted]) against the committed baseline PNG named by
+   * the event's `inputText` (resolved CLI-side against `--baseline-dir`). The pure verdict lives in
+   * [pixelAssertVerdict] in `:daemon:core` — the same one the desktop backend uses, reusing the
+   * `PixelDiff` comparator. On failure it writes actual/expected/diff PNGs under [encodedDir] so the
+   * drift is inspectable without re-running. Fail-closed: a missing baseline, a missing frame, or a
+   * dimension mismatch is FAILED, never a silent pass.
    */
   private fun evaluatePixelAssert(
     event: RecordingScriptEvent,
-    frameIndex: Int,
+    actualPng: ByteArray,
   ): RecordingScriptEvidence {
     val baselinePath =
       event.inputText
@@ -259,14 +310,12 @@ class AndroidRecordingSession(
           event,
           "assert.pixels requires the baseline PNG path in the 'inputText' field",
         )
-    val frameFile = File(framesDir, "frame-${"%05d".format(frameIndex)}.png")
-    val actualPng = frameFile.takeIf { it.isFile }?.readBytes()
     val baselineBytes = File(baselinePath).takeIf { it.isFile }?.readBytes()
     return when (val verdict = pixelAssertVerdict(actualPng, baselineBytes)) {
       AssertionVerdict.Passed ->
         appliedEvidence(event, "assert.pixels matched baseline '${File(baselinePath).name}'")
       is AssertionVerdict.Failed -> {
-        if (actualPng != null && baselineBytes != null) {
+        if (baselineBytes != null) {
           // Best-effort diagnostics — never let an artefact-write failure mask the real verdict.
           try {
             val diffDir = File(encodedDir, "pixel-diff-t${event.tMs}ms").apply { mkdirs() }

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -282,7 +282,7 @@ open class RobolectricHost(
     if (supportsRecording)
       listOf(
         RecordingScriptDataExtensions.recordingDescriptor,
-        RecordingScriptDataExtensions.assertionVisibilityDescriptor,
+        RecordingScriptDataExtensions.assertionAndroidDescriptor,
         RecordingScriptDataExtensions.assertionA11yDescriptor,
         InputTouchRecordingScriptEvents.descriptor,
         InputKeyboardRecordingScriptEvents.supportedDescriptor,

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSessionTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSessionTest.kt
@@ -274,6 +274,54 @@ class AndroidRecordingSessionTest {
   }
 
   /**
+   * Issue #2519 — `assert.pixels` freezes the frame at the assertion's timeline position, *before* a
+   * later same-bucket input, mirroring the desktop session (rather than diffing the post-input frame
+   * that lands on disk). The fake renders `sourcePng` until an input lands and `postDispatchPng`
+   * after; an `assert.pixels` ordered before a same-tMs `input.click` must match the pre-input
+   * baseline. Without the freeze it would compare the post-click frame and fail.
+   */
+  @Test
+  fun scriptedPixelAssertionFreezesBeforeLaterSameBucketInput() {
+    val framesDir = tempFolder.newFolder("pixels-freeze-frames")
+    val encodedDir = tempFolder.newFolder("pixels-freeze-encoded")
+    val sourceDir = tempFolder.newFolder("pixels-freeze-source")
+    val preInput = File(sourceDir, "pre.png")
+    ImageIO.write(solidArgb(8, 8, 0xFF3366CC.toInt()), "png", preInput) // blue, pre-click
+    val postInput = File(sourceDir, "post.png")
+    ImageIO.write(solidArgb(8, 8, 0xFFCC3366.toInt()), "png", postInput) // red, post-click
+    val baseline = File(sourceDir, "baseline.png")
+    ImageIO.write(solidArgb(8, 8, 0xFF3366CC.toInt()), "png", baseline) // matches the pre-click frame
+
+    val interactive = RecordingDeltaSession(preInput).apply { postDispatchPng = postInput }
+    val session =
+      AndroidRecordingSession(
+        previewId = INTERACTIVE_PREVIEW_ID,
+        recordingId = "test-rec-pixels-freeze",
+        fps = FPS,
+        scale = 1.0f,
+        interactive = interactive,
+        framesDir = framesDir,
+        encodedDir = encodedDir,
+      )
+
+    // Same bucket (tMs = 0): the assertion is ordered before the click, so it must observe the
+    // pre-click (blue) frame even though the click (which flips the frame to red) shares the bucket.
+    session.postScript(
+      listOf(
+        RecordingScriptEvent(tMs = 0L, kind = "assert.pixels", inputText = baseline.absolutePath),
+        RecordingScriptEvent(tMs = 0L, kind = "input.click", pixelX = 4, pixelY = 4),
+      )
+    )
+    val asserts = session.stop().scriptEvents.filter { it.kind == "assert.pixels" }
+    assertEquals(1, asserts.size)
+    assertEquals(
+      "assert.pixels must freeze the pre-input frame; got ${asserts[0].message}",
+      RecordingScriptEventStatus.APPLIED,
+      asserts[0].status,
+    )
+  }
+
+  /**
    * Issue #1966 — `assert.a11y` runs Android ATF against the held composition and fails the
    * recording when findings breach the threshold (`inputText`: `errors` default | `warnings`).
    * Verdict comes from the shared `evaluateA11yAssertion`; capture rides the `captureA11yFindings`
@@ -2140,13 +2188,21 @@ class AndroidRecordingSessionTest {
       return override ?: super.dispatchNavigation(actionKind, deepLinkUri, backProgress, backEdge)
     }
 
+    /**
+     * When non-null, [render] returns this frame instead of [sourcePng] once at least one dispatch
+     * has landed — a minimal "the UI changed after an input" model, so a test can prove
+     * `assert.pixels` freezes the *pre-input* frame at the assertion's timeline position.
+     */
+    var postDispatchPng: File? = null
+
     override fun render(requestId: Long, advanceTimeMs: Long?): RenderResult {
       renderAdvances.add(advanceTimeMs)
+      val png = postDispatchPng?.takeIf { dispatchCount > 0 } ?: sourcePng
       return RenderResult(
         id = requestId,
         classLoaderHashCode = 0,
         classLoaderName = "recording-delta-session",
-        pngPath = sourcePng.absolutePath,
+        pngPath = png.absolutePath,
         metrics = mapOf("tookMs" to 0L),
       )
     }

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSessionTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSessionTest.kt
@@ -82,11 +82,12 @@ class AndroidRecordingSessionTest {
   }
 
   /**
-   * Issue #1964 — `assert.visible` / `assert.notVisible` resolve against the probe semantics
-   * snapshot ([InteractiveSession.captureProbeSemantics]) by testTag, producing APPLIED / FAILED
-   * evidence via the shared `evaluateVisibilityAssertion`. `ref` targets fail with a clear message
-   * (the probe snapshot carries no refs). Uses the fake [RecordingDeltaSession] with canned probe
-   * nodes, so no Robolectric sandbox is needed.
+   * Issues #1964, #2519 — `assert.visible` / `assert.notVisible` resolve against the probe semantics
+   * snapshot ([InteractiveSession.captureProbeSemantics]) by `testTag`, `role`+`text`, or `text`,
+   * producing APPLIED / FAILED evidence via the shared `evaluateVisibilityAssertion`. `role`+`text`
+   * matches a container via its merged descendant text (a bare `Button { Text("Add") }`); `ref`
+   * targets fail with a clear message (the probe snapshot carries no refs). Uses the fake
+   * [RecordingDeltaSession] with canned probe nodes, so no Robolectric sandbox is needed.
    */
   @Test
   fun scriptedVisibilityAssertionsResolveAgainstProbeSnapshot() {
@@ -103,6 +104,8 @@ class AndroidRecordingSessionTest {
         probeNodesResult =
           listOf(
             RecordingProbeNode(testTag = "target-box", clickable = true),
+            // A bare `Button { Text("Add") }`: role on the container, text merged up from the child.
+            RecordingProbeNode(role = "Button", clickable = true, mergedText = "Add"),
             RecordingProbeNode(text = "Hello"),
           )
       }
@@ -127,12 +130,86 @@ class AndroidRecordingSessionTest {
         assertEvent("assert.notVisible", SemanticsInputTarget(testTag = "nope")), // APPLIED
         assertEvent("assert.notVisible", SemanticsInputTarget(testTag = "target-box")), // FAILED
         assertEvent("assert.visible", SemanticsInputTarget(ref = "r1")), // FAILED (no refs)
-        // role+text isn't resolvable against a flat probe snapshot; must FAIL, never silently pass.
-        assertEvent("assert.notVisible", SemanticsInputTarget(role = "Button", text = "Hello")),
+        // role+text now resolves via the container's merged text — the button is on screen.
+        assertEvent(
+          "assert.visible",
+          SemanticsInputTarget(role = "Button", text = "Add"),
+        ), // APPLIED
+        assertEvent("assert.visible", SemanticsInputTarget(text = "Hello")), // APPLIED (text only)
+        // role+text with the wrong text matches nothing → notVisible passes.
+        assertEvent(
+          "assert.notVisible",
+          SemanticsInputTarget(role = "Button", text = "Missing"),
+        ), // APPLIED
       )
     )
     val result = session.stop()
     val asserts = result.scriptEvents.filter { it.kind.startsWith("assert.") }
+    assertEquals(8, asserts.size)
+    assertEquals(RecordingScriptEventStatus.APPLIED, asserts[0].status)
+    assertEquals(RecordingScriptEventStatus.FAILED, asserts[1].status)
+    assertEquals(RecordingScriptEventStatus.APPLIED, asserts[2].status)
+    assertEquals(RecordingScriptEventStatus.FAILED, asserts[3].status)
+    assertEquals(RecordingScriptEventStatus.FAILED, asserts[4].status)
+    assertTrue(
+      "a ref target should explain refs aren't in the snapshot; got ${asserts[4].message}",
+      asserts[4].message?.contains("ref") == true,
+    )
+    assertEquals(RecordingScriptEventStatus.APPLIED, asserts[5].status)
+    assertEquals(RecordingScriptEventStatus.APPLIED, asserts[6].status)
+    assertEquals(RecordingScriptEventStatus.APPLIED, asserts[7].status)
+  }
+
+  /**
+   * Issue #2519 — `assert.textEquals` on Android resolves the target against the probe snapshot and
+   * compares the resolved node's (merged) text to the expected `inputText`. A tag-on-container /
+   * role+text shape resolves the merged descendant text the user sees; a wrong expected string, a
+   * `ref` target, or a target that matches no node fails. Fake session, no sandbox.
+   */
+  @Test
+  fun scriptedTextEqualsAssertionsResolveAgainstProbeSnapshot() {
+    val framesDir = tempFolder.newFolder("texteq-frames")
+    val encodedDir = tempFolder.newFolder("texteq-encoded")
+    val sourcePng = File(tempFolder.newFolder("texteq-source"), "source.png")
+    ImageIO.write(
+      java.awt.image.BufferedImage(8, 8, java.awt.image.BufferedImage.TYPE_INT_ARGB),
+      "png",
+      sourcePng,
+    )
+    val interactive =
+      RecordingDeltaSession(sourcePng).apply {
+        probeNodesResult =
+          listOf(
+            // Tag-on-container: own text null, merged text "Submit" from the child.
+            RecordingProbeNode(testTag = "submit", role = "Button", mergedText = "Submit"),
+            RecordingProbeNode(text = "Hello"),
+          )
+      }
+    val session =
+      AndroidRecordingSession(
+        previewId = INTERACTIVE_PREVIEW_ID,
+        recordingId = "test-rec-texteq",
+        fps = FPS,
+        scale = 1.0f,
+        interactive = interactive,
+        framesDir = framesDir,
+        encodedDir = encodedDir,
+      )
+
+    fun textEq(target: SemanticsInputTarget, expected: String?) =
+      RecordingScriptEvent(tMs = 0L, kind = "assert.textEquals", target = target, inputText = expected)
+
+    session.postScript(
+      listOf(
+        textEq(SemanticsInputTarget(testTag = "submit"), "Submit"), // APPLIED (merged text)
+        textEq(SemanticsInputTarget(testTag = "submit"), "Nope"), // FAILED (text differs)
+        textEq(SemanticsInputTarget(text = "Hello"), "Hello"), // APPLIED (own text)
+        textEq(SemanticsInputTarget(testTag = "absent"), "Submit"), // FAILED (no match)
+        textEq(SemanticsInputTarget(ref = "r1"), "Submit"), // FAILED (ref unsupported)
+        textEq(SemanticsInputTarget(testTag = "submit"), null), // FAILED (no expected)
+      )
+    )
+    val asserts = session.stop().scriptEvents.filter { it.kind == "assert.textEquals" }
     assertEquals(6, asserts.size)
     assertEquals(RecordingScriptEventStatus.APPLIED, asserts[0].status)
     assertEquals(RecordingScriptEventStatus.FAILED, asserts[1].status)
@@ -140,13 +217,60 @@ class AndroidRecordingSessionTest {
     assertEquals(RecordingScriptEventStatus.FAILED, asserts[3].status)
     assertEquals(RecordingScriptEventStatus.FAILED, asserts[4].status)
     assertTrue(
-      "non-testTag target should explain it resolves by testTag; got ${asserts[4].message}",
-      asserts[4].message?.contains("testTag") == true,
+      "a ref target should explain refs aren't in the snapshot; got ${asserts[4].message}",
+      asserts[4].message?.contains("ref") == true,
     )
-    // The dangerous case: a role+text assert.notVisible must NOT pass just because the flat
-    // snapshot
-    // can't see a role+text node — it fails as unsupported instead of silently passing.
     assertEquals(RecordingScriptEventStatus.FAILED, asserts[5].status)
+  }
+
+  /**
+   * Issue #2519 — `assert.pixels` on Android diffs the frame written for the event's tMs against a
+   * committed baseline PNG (path in `inputText`), reusing the shared `pixelAssertVerdict` /
+   * `PixelDiff`. The fake session renders every frame from `sourcePng`, so a baseline byte-identical
+   * to it passes, a different-content baseline fails, and a missing baseline fails closed.
+   */
+  @Test
+  fun scriptedPixelAssertionsDiffTheWrittenFrameAgainstTheBaseline() {
+    val framesDir = tempFolder.newFolder("pixels-frames")
+    val encodedDir = tempFolder.newFolder("pixels-encoded")
+    val sourceDir = tempFolder.newFolder("pixels-source")
+    val sourcePng = File(sourceDir, "source.png")
+    // A solid-blue frame is what every render returns; the matching baseline is byte-identical.
+    ImageIO.write(solidArgb(8, 8, 0xFF3366CC.toInt()), "png", sourcePng)
+    val matchingBaseline = File(sourceDir, "match.png")
+    ImageIO.write(solidArgb(8, 8, 0xFF3366CC.toInt()), "png", matchingBaseline)
+    val driftingBaseline = File(sourceDir, "drift.png")
+    ImageIO.write(solidArgb(8, 8, 0xFFCC3366.toInt()), "png", driftingBaseline)
+
+    val interactive = RecordingDeltaSession(sourcePng)
+    val session =
+      AndroidRecordingSession(
+        previewId = INTERACTIVE_PREVIEW_ID,
+        recordingId = "test-rec-pixels",
+        fps = FPS,
+        scale = 1.0f,
+        interactive = interactive,
+        framesDir = framesDir,
+        encodedDir = encodedDir,
+      )
+
+    fun pixels(baseline: String?) =
+      RecordingScriptEvent(tMs = 0L, kind = "assert.pixels", inputText = baseline)
+
+    session.postScript(
+      listOf(
+        pixels(matchingBaseline.absolutePath), // APPLIED
+        pixels(driftingBaseline.absolutePath), // FAILED (drift)
+        pixels(File(sourceDir, "missing.png").absolutePath), // FAILED (no baseline)
+        pixels(null), // FAILED (no path)
+      )
+    )
+    val asserts = session.stop().scriptEvents.filter { it.kind == "assert.pixels" }
+    assertEquals(4, asserts.size)
+    assertEquals(RecordingScriptEventStatus.APPLIED, asserts[0].status)
+    assertEquals(RecordingScriptEventStatus.FAILED, asserts[1].status)
+    assertEquals(RecordingScriptEventStatus.FAILED, asserts[2].status)
+    assertEquals(RecordingScriptEventStatus.FAILED, asserts[3].status)
   }
 
   /**
@@ -2031,6 +2155,12 @@ class AndroidRecordingSessionTest {
       closed = true
     }
   }
+
+  /** A solid `argb`-filled image, used to build byte-stable golden frames / baselines. */
+  private fun solidArgb(width: Int, height: Int, argb: Int): java.awt.image.BufferedImage =
+    java.awt.image.BufferedImage(width, height, java.awt.image.BufferedImage.TYPE_INT_ARGB).apply {
+      for (y in 0 until height) for (x in 0 until width) setRGB(x, y, argb)
+    }
 
   companion object {
     private const val INTERACTIVE_PREVIEW_ID = "recording-clicktoggle"

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PixelAssertions.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PixelAssertions.kt
@@ -1,11 +1,16 @@
 package ee.schimke.composeai.daemon
 
 /**
- * Pure verdict logic for the `assert.pixels` recording event (issue #1967): diff a recorded frame
- * against a committed baseline PNG and decide pass/fail, reusing the [PixelDiff] comparator that
- * the preview-review pipeline already uses. Kept free of file IO and the recording session so it's
- * unit-testable from raw PNG bytes — the session ([DesktopRecordingSession]) handles reading the
- * frame + baseline off disk and turning this verdict into `RecordingScriptEvidence`.
+ * Pure verdict logic for the `assert.pixels` recording event (issues #1967, #2519): diff a recorded
+ * frame against a committed baseline PNG and decide pass/fail, reusing the [PixelDiff] comparator
+ * that the preview-review pipeline already uses. Kept free of file IO and the recording session so
+ * it is unit-testable from raw PNG bytes — the backend session (`DesktopRecordingSession` /
+ * `AndroidRecordingSession`) handles reading the frame + baseline off disk and turning this verdict
+ * into `RecordingScriptEvidence`.
+ *
+ * Lives in `:daemon:core` (alongside [PixelDiff]) so **both** the desktop and Android recording
+ * sessions share one implementation: each writes its frames the same way (a `frame-NNNNN.png` per
+ * frame) and feeds the frame + baseline bytes here.
  *
  * Fail-closed: a missing baseline or a missing recorded frame is a [AssertionVerdict.Failed], never
  * a silent pass — the script asked to pin pixels, so an un-runnable check is a failure. `PixelDiff`

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RecordingProbeTargets.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RecordingProbeTargets.kt
@@ -21,8 +21,11 @@ import ee.schimke.composeai.daemon.protocol.SemanticsInputTarget
  * - `testTag` → nodes whose `testTag` equals it (the pre-#2519 behaviour).
  * - `role` + `text` → nodes whose `role` equals it **and** whose [effectiveText] equals the text,
  *   so a `Button { Text("Add") }` (role on the button, text merged up from the child) matches.
- * - `text` alone → nodes whose [effectiveText] (or [contentDescription], for an icon-only control)
- *   equals it.
+ * - `text` alone → nodes whose **own** `text` (or [contentDescription], for an icon-only control)
+ *   equals it — deliberately *not* [effectiveText]. A merged-text container and the child text node
+ *   it merged always coexist in the flat snapshot, so matching merged text here would return both
+ *   for `text: "Add"` and make `assert.textEquals` ambiguous; the child text node carries the
+ *   visible text for a text-only find, mirroring the desktop `hasText` finder.
  * - `role` alone → nodes whose `role` equals it.
  */
 
@@ -77,8 +80,10 @@ fun resolveProbeTarget(
     )
   }
   if (text != null) {
+    // Own text (not merged) so the merged-text container and its child text node don't both match
+    // and make assert.textEquals ambiguous; contentDescription covers icon-only controls.
     return ProbeTargetResolution.Matched(
-      nodes.filter { it.effectiveText() == text || it.contentDescription == text }
+      nodes.filter { it.text == text || it.contentDescription == text }
     )
   }
   if (role != null) {

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RecordingProbeTargets.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RecordingProbeTargets.kt
@@ -1,0 +1,96 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.protocol.RecordingProbeNode
+import ee.schimke.composeai.daemon.protocol.SemanticsInputTarget
+
+/**
+ * Pure target resolution against the Android backend's **flat probe-semantics snapshot**
+ * ([RecordingProbeNode] list, issue #2519). The desktop backend resolves a [SemanticsInputTarget]
+ * against a live unmerged semantics tree via `SemanticsTargets.resolve`; Android only ever sees the
+ * flat snapshot bridged out of the Robolectric sandbox, so this is its equivalent resolver — kept
+ * in `:daemon:core` and free of any Compose / Robolectric dependency so it is unit-testable without
+ * standing up a held scene.
+ *
+ * **What it matches (and why not `ref`).** The snapshot carries `testTag`, `role`, the node's own
+ * `text`, its merged descendant text ([RecordingProbeNode.mergedText]), and `contentDescription` —
+ * but no stable [ref][SemanticsInputTarget.ref] (refs are assigned on the tree the snapshot was
+ * flattened from and don't survive into it). So a `ref` target resolves to
+ * [ProbeTargetResolution.Unsupported] rather than silently matching nothing — a false
+ * `assert.notVisible` pass is worse than a clear "unsupported" failure. The other target shapes
+ * resolve by the most specific field present:
+ * - `testTag` → nodes whose `testTag` equals it (the pre-#2519 behaviour).
+ * - `role` + `text` → nodes whose `role` equals it **and** whose [effectiveText] equals the text,
+ *   so a `Button { Text("Add") }` (role on the button, text merged up from the child) matches.
+ * - `text` alone → nodes whose [effectiveText] (or [contentDescription], for an icon-only control)
+ *   equals it.
+ * - `role` alone → nodes whose `role` equals it.
+ */
+
+/**
+ * The text to match / compare a probe node against: its own [RecordingProbeNode.text] when present,
+ * else its [RecordingProbeNode.mergedText] (the merged text of its descendants). Mirrors the
+ * desktop [resolvedNodeText] preference (own text wins over descendant text) so the two backends
+ * answer `role`+`text` and `assert.textEquals` the same way.
+ */
+fun RecordingProbeNode.effectiveText(): String? =
+  text?.takeIf { it.isNotEmpty() } ?: mergedText?.takeIf { it.isNotEmpty() }
+
+/** Outcome of resolving a [SemanticsInputTarget] against a flat probe snapshot. */
+sealed interface ProbeTargetResolution {
+  /**
+   * The target shape is resolvable against the snapshot; [nodes] is every node that matched (0, 1,
+   * or more). A visibility check reads its size; a text check requires exactly one.
+   */
+  data class Matched(val nodes: List<RecordingProbeNode>) : ProbeTargetResolution
+
+  /**
+   * The target can't be resolved against the flat snapshot at all (a `ref` target, or a target with
+   * no resolvable field). [reason] is a caller-facing explanation for the failed-assertion
+   * evidence.
+   */
+  data class Unsupported(val reason: String) : ProbeTargetResolution
+}
+
+/**
+ * Resolve [target] against the flat probe [nodes]. See the file header for the matching rules. A
+ * `ref` target — or a target that carries no resolvable field — is
+ * [ProbeTargetResolution.Unsupported] so the caller fails the assertion with a clear message
+ * instead of risking a false pass.
+ */
+fun resolveProbeTarget(
+  nodes: List<RecordingProbeNode>,
+  target: SemanticsInputTarget,
+): ProbeTargetResolution {
+  val testTag = target.testTag?.takeIf { it.isNotBlank() }
+  val role = target.role?.takeIf { it.isNotBlank() }
+  val text = target.text?.takeIf { it.isNotBlank() }
+  val ref = target.ref?.takeIf { it.isNotBlank() }
+
+  // `testTag` is the most specific finder and lands on a single node — resolve it first even when a
+  // role/text also rode along, mirroring the desktop resolver's precedence.
+  if (testTag != null) {
+    return ProbeTargetResolution.Matched(nodes.filter { it.testTag == testTag })
+  }
+  if (role != null && text != null) {
+    return ProbeTargetResolution.Matched(
+      nodes.filter { it.role == role && it.effectiveText() == text }
+    )
+  }
+  if (text != null) {
+    return ProbeTargetResolution.Matched(
+      nodes.filter { it.effectiveText() == text || it.contentDescription == text }
+    )
+  }
+  if (role != null) {
+    return ProbeTargetResolution.Matched(nodes.filter { it.role == role })
+  }
+  if (ref != null) {
+    return ProbeTargetResolution.Unsupported(
+      "the Android recording backend has no refs in its probe snapshot; " +
+        "target by testTag, role+text, or text instead of ref"
+    )
+  }
+  return ProbeTargetResolution.Unsupported(
+    "target has no resolvable field; set testTag, role, or text"
+  )
+}

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -2256,6 +2256,15 @@ data class RecordingScriptParams(val recordingId: String, val events: List<Recor
  * testTag/text/ contentDescription at capture time — without one of those there is no stable finder
  * to assert on.
  *
+ * [mergedText] carries the **merged text of this node's descendants** (issue #2519), so a
+ * tag-on-the-container or role-bearing shape like `Button(Modifier.testTag("submit")) {
+ * Text("Submit") }` — whose own [text] is null while the visible text sits on a child — still
+ * exposes what the user sees. It mirrors Compose's merged semantics (depth-first, newline-joined,
+ * the same separator [resolvedNodeText][ee.schimke.composeai.daemon.resolvedNodeText] uses) so the
+ * flat snapshot can answer `role`+`text` targets and `assert.textEquals` on the Android backend
+ * without a live tree. The *effective* text of a node is its own [text] when present, else
+ * [mergedText] (see [effectiveText][ee.schimke.composeai.daemon.effectiveText]).
+ *
  * [RecordingTestGenerator] diffs a probe's node list against the previous probe's to turn each
  * `recording.probe` into the strongest stable assertion (a node appeared, a node disappeared, text
  * became present) instead of a hand-filled TODO stub.
@@ -2267,6 +2276,7 @@ data class RecordingProbeNode(
   val contentDescription: String? = null,
   val role: String? = null,
   val clickable: Boolean = false,
+  val mergedText: String? = null,
 )
 
 /**

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/PixelAssertionsTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/PixelAssertionsTest.kt
@@ -8,10 +8,12 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
- * Unit tests for the pure [pixelAssertVerdict] golden-image verdict logic (issue #1967) — the part
- * of the `assert.pixels` recording handler that doesn't need a held scene or file IO. The wired
- * handler (deferred post-loop diff against the frame the session wrote) is covered by the
- * integration test in `DesktopRecordingSessionTest`.
+ * Unit tests for the pure [pixelAssertVerdict] golden-image verdict logic (issues #1967, #2519) —
+ * the part of the `assert.pixels` recording handler that doesn't need a held scene or file IO.
+ * Lives in `:daemon:core` alongside the verdict it covers (relocated from `:daemon:desktop` when
+ * Android gained `assert.pixels` too). The wired handlers (deferred post-loop diff against the
+ * frame each session wrote) are covered by the integration tests in `DesktopRecordingSessionTest` /
+ * `AndroidRecordingSessionTest`.
  */
 class PixelAssertionsTest {
 

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/RecordingProbeTargetsTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/RecordingProbeTargetsTest.kt
@@ -1,0 +1,85 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.protocol.RecordingProbeNode
+import ee.schimke.composeai.daemon.protocol.SemanticsInputTarget
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Unit coverage for the pure Android probe-target resolver (issue #2519). */
+class RecordingProbeTargetsTest {
+
+  // A bare `Button { Text("Add") }` (role on the container, text merged up from a child), a
+  // test-tagged submit button carrying its child's text, a standalone label, and an icon-only
+  // control with just a content description.
+  private val snapshot =
+    listOf(
+      RecordingProbeNode(role = "Button", clickable = true, mergedText = "Add"),
+      RecordingProbeNode(testTag = "submit", role = "Button", mergedText = "Submit"),
+      RecordingProbeNode(text = "Thanks!"),
+      RecordingProbeNode(contentDescription = "Settings", role = "Button"),
+    )
+
+  private fun matched(target: SemanticsInputTarget): List<RecordingProbeNode> {
+    val res = resolveProbeTarget(snapshot, target)
+    assertTrue("expected Matched but got $res", res is ProbeTargetResolution.Matched)
+    return (res as ProbeTargetResolution.Matched).nodes
+  }
+
+  @Test
+  fun effectiveTextPrefersOwnTextThenMerged() {
+    assertEquals("Thanks!", RecordingProbeNode(text = "Thanks!").effectiveText())
+    assertEquals("Add", RecordingProbeNode(mergedText = "Add").effectiveText())
+    assertEquals("own", RecordingProbeNode(text = "own", mergedText = "child").effectiveText())
+    assertEquals(null, RecordingProbeNode(role = "Button").effectiveText())
+  }
+
+  @Test
+  fun testTagMatchesTheTaggedNode() {
+    assertEquals(listOf(snapshot[1]), matched(SemanticsInputTarget(testTag = "submit")))
+  }
+
+  @Test
+  fun testTagWinsWhenRoleAndTextAlsoRideAlong() {
+    // The most specific finder resolves even when role/text are also set (desktop precedence).
+    assertEquals(
+      listOf(snapshot[1]),
+      matched(SemanticsInputTarget(testTag = "submit", role = "Button", text = "wrong")),
+    )
+  }
+
+  @Test
+  fun roleAndTextMatchTheContainerViaMergedText() {
+    // `Button { Text("Add") }`: role on the button, text on the child — resolved via merged text.
+    assertEquals(listOf(snapshot[0]), matched(SemanticsInputTarget(role = "Button", text = "Add")))
+  }
+
+  @Test
+  fun textAloneMatchesOwnTextMergedTextAndContentDescription() {
+    assertEquals(listOf(snapshot[2]), matched(SemanticsInputTarget(text = "Thanks!")))
+    assertEquals(listOf(snapshot[0]), matched(SemanticsInputTarget(text = "Add")))
+    assertEquals(listOf(snapshot[3]), matched(SemanticsInputTarget(text = "Settings")))
+  }
+
+  @Test
+  fun noMatchIsAnEmptyMatchedList() {
+    assertEquals(emptyList<RecordingProbeNode>(), matched(SemanticsInputTarget(testTag = "absent")))
+    assertEquals(
+      emptyList<RecordingProbeNode>(),
+      matched(SemanticsInputTarget(role = "Button", text = "Nope")),
+    )
+  }
+
+  @Test
+  fun refTargetIsUnsupportedRatherThanAFalseMiss() {
+    val res = resolveProbeTarget(snapshot, SemanticsInputTarget(ref = "n42"))
+    assertTrue(res is ProbeTargetResolution.Unsupported)
+    assertTrue((res as ProbeTargetResolution.Unsupported).reason.contains("ref"))
+  }
+
+  @Test
+  fun emptyTargetIsUnsupported() {
+    val res = resolveProbeTarget(snapshot, SemanticsInputTarget())
+    assertTrue(res is ProbeTargetResolution.Unsupported)
+  }
+}

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/RecordingProbeTargetsTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/RecordingProbeTargetsTest.kt
@@ -9,12 +9,14 @@ import org.junit.Test
 /** Unit coverage for the pure Android probe-target resolver (issue #2519). */
 class RecordingProbeTargetsTest {
 
-  // A bare `Button { Text("Add") }` (role on the container, text merged up from a child), a
-  // test-tagged submit button carrying its child's text, a standalone label, and an icon-only
-  // control with just a content description.
+  // A realistic flat snapshot of `Button { Text("Add") }` (the role-bearing container with merged
+  // text [0] *and* the child text node it merged [1] — both are retained), a test-tagged submit
+  // button carrying its child's merged text [2], a standalone label [3], and an icon-only control
+  // with just a content description [4].
   private val snapshot =
     listOf(
       RecordingProbeNode(role = "Button", clickable = true, mergedText = "Add"),
+      RecordingProbeNode(text = "Add"),
       RecordingProbeNode(testTag = "submit", role = "Button", mergedText = "Submit"),
       RecordingProbeNode(text = "Thanks!"),
       RecordingProbeNode(contentDescription = "Settings", role = "Button"),
@@ -36,14 +38,14 @@ class RecordingProbeTargetsTest {
 
   @Test
   fun testTagMatchesTheTaggedNode() {
-    assertEquals(listOf(snapshot[1]), matched(SemanticsInputTarget(testTag = "submit")))
+    assertEquals(listOf(snapshot[2]), matched(SemanticsInputTarget(testTag = "submit")))
   }
 
   @Test
   fun testTagWinsWhenRoleAndTextAlsoRideAlong() {
     // The most specific finder resolves even when role/text are also set (desktop precedence).
     assertEquals(
-      listOf(snapshot[1]),
+      listOf(snapshot[2]),
       matched(SemanticsInputTarget(testTag = "submit", role = "Button", text = "wrong")),
     )
   }
@@ -51,14 +53,17 @@ class RecordingProbeTargetsTest {
   @Test
   fun roleAndTextMatchTheContainerViaMergedText() {
     // `Button { Text("Add") }`: role on the button, text on the child — resolved via merged text.
+    // Only the container matches; the child text node has no role.
     assertEquals(listOf(snapshot[0]), matched(SemanticsInputTarget(role = "Button", text = "Add")))
   }
 
   @Test
-  fun textAloneMatchesOwnTextMergedTextAndContentDescription() {
-    assertEquals(listOf(snapshot[2]), matched(SemanticsInputTarget(text = "Thanks!")))
-    assertEquals(listOf(snapshot[0]), matched(SemanticsInputTarget(text = "Add")))
-    assertEquals(listOf(snapshot[3]), matched(SemanticsInputTarget(text = "Settings")))
+  fun textAloneMatchesOwnTextAndContentDescriptionNotMergedText() {
+    assertEquals(listOf(snapshot[3]), matched(SemanticsInputTarget(text = "Thanks!")))
+    // `text: "Add"` resolves to the child text node (own text) only — NOT the role-bearing
+    // container that merged it — so assert.textEquals stays unambiguous.
+    assertEquals(listOf(snapshot[1]), matched(SemanticsInputTarget(text = "Add")))
+    assertEquals(listOf(snapshot[4]), matched(SemanticsInputTarget(text = "Settings")))
   }
 
   @Test

--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
@@ -574,20 +574,52 @@ fun ComposeSemanticsNode.toProbeNodes(): List<RecordingProbeNode> = buildList {
     val testTag = node.testTag?.takeIf { it.isNotBlank() }
     val text = node.text?.takeIf { it.isNotBlank() }
     val contentDescription = node.label?.takeIf { it.isNotBlank() && it != text }
-    if (testTag != null || text != null || contentDescription != null) {
+    val role = node.role?.takeIf { it.isNotBlank() }
+    // Merged text of the descendants (issue #2519): the container's visible text lives on a child
+    // in the unmerged tree (`Button { Text("Add") }`), so carry it here — mirroring Compose's
+    // merged semantics — so the flat snapshot can resolve `role`+`text` targets and answer
+    // `assert.textEquals` without a live tree. Own text wins over this at resolution time.
+    val mergedText = node.mergedDescendantText()
+    // Keep a node when it has a stable finder (testTag / rendered text / content description) or is
+    // a role-bearing container whose merged descendant text makes it a `role`+`text` finder — a
+    // bare `Button { Text("Add") }` carries neither testTag nor own text, and dropping it would
+    // make a `role`+`text` assertion fail closed on a control that is plainly on screen.
+    if (
+      testTag != null ||
+        text != null ||
+        contentDescription != null ||
+        (role != null && mergedText != null)
+    ) {
       add(
         RecordingProbeNode(
           testTag = testTag,
           text = text,
           contentDescription = contentDescription,
-          role = node.role?.takeIf { it.isNotBlank() },
+          role = role,
           clickable = node.clickable,
+          mergedText = mergedText,
         )
       )
     }
     node.children.forEach(::visit)
   }
   visit(this@toProbeNodes)
+}
+
+/**
+ * Merged text of this node's **descendants** (issue #2519), depth-first and newline-joined — the
+ * same separator Compose's merged semantics (and the desktop `resolvedNodeText`) use. Excludes the
+ * node's own [ComposeSemanticsNode.text] so a resolver can prefer own text and fall back to this;
+ * null when no descendant draws text.
+ */
+private fun ComposeSemanticsNode.mergedDescendantText(): String? {
+  val parts = mutableListOf<String>()
+  fun collect(n: ComposeSemanticsNode) {
+    n.text?.takeIf { it.isNotBlank() }?.let { parts.add(it) }
+    n.children.forEach(::collect)
+  }
+  children.forEach(::collect)
+  return parts.joinToString("\n").ifEmpty { null }
 }
 
 /**

--- a/data/layoutinspector/connector/src/test/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsProbeNodesTest.kt
+++ b/data/layoutinspector/connector/src/test/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsProbeNodesTest.kt
@@ -30,8 +30,9 @@ class ComposeSemanticsProbeNodesTest {
   @Test
   fun flattensOnlyNodesWithAStableFinder() {
     // A clickable test-tagged button wrapping a text label, plus a structural container with no
-    // finder. The container is dropped; the button keeps testTag + role + clickable, the label
-    // keeps its text.
+    // finder. The container is dropped; the button keeps testTag + role + clickable and carries the
+    // child's merged text (issue #2519) so a `role`+`text` / `assert.textEquals` resolver sees it,
+    // the label keeps its own text.
     val root =
       node(
         "root",
@@ -49,7 +50,42 @@ class ComposeSemanticsProbeNodesTest {
 
     assertEquals(
       listOf(
-        RecordingProbeNode(testTag = "addItem", role = "Button", clickable = true),
+        RecordingProbeNode(
+          testTag = "addItem",
+          role = "Button",
+          clickable = true,
+          mergedText = "Add",
+        ),
+        RecordingProbeNode(text = "Add"),
+      ),
+      root.toProbeNodes(),
+    )
+  }
+
+  @Test
+  fun keepsARoleBearingContainerWhoseTextLivesOnAChild() {
+    // A bare `Button { Text("Add") }` — no testTag, no own text, no content description. Before
+    // issue #2519 this button node was dropped (no stable finder), so a `role`+`text` assertion
+    // failed closed on a control that is plainly on screen. It is now kept via its merged
+    // descendant
+    // text, alongside the standalone text node.
+    val root =
+      node(
+        "root",
+        children =
+          listOf(
+            node(
+              "button",
+              role = "Button",
+              clickable = true,
+              children = listOf(node("label", text = "Add")),
+            )
+          ),
+      )
+
+    assertEquals(
+      listOf(
+        RecordingProbeNode(role = "Button", clickable = true, mergedText = "Add"),
         RecordingProbeNode(text = "Add"),
       ),
       root.toProbeNodes(),

--- a/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/extensions/DataExtensionPlan.kt
+++ b/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/extensions/DataExtensionPlan.kt
@@ -361,16 +361,18 @@ object RecordingScriptDataExtensions {
     )
 
   /**
-   * Visibility-only assertion descriptor for backends that wire `assert.visible` /
-   * `assert.notVisible` but not yet `assert.textEquals` — the Android backend today, which resolves
-   * visibility against its flat probe-semantics snapshot (issue #1964). That snapshot only supports
-   * `testTag` targets: it can't reliably match `role`+`text` (a `Button { Text(...) }` emits the
-   * role and text on separate flat nodes, so checking both on one node matches nothing) and carries
-   * no refs. So `record_preview` advertises only these two events here, and the handler rejects
-   * non-`testTag` targets rather than risk a false pass; `assert.textEquals` isn't advertised at
-   * all.
+   * Assertion descriptor for the Android backend (issue #2519). It resolves against the flat
+   * probe-semantics snapshot, which now carries each node's **merged descendant text**, so it
+   * advertises `assert.visible` / `assert.notVisible` / `assert.textEquals` — resolvable by
+   * `testTag`, `role`+`text` (a `Button { Text(...) }` matches via the button's merged text), or
+   * `text` alone — plus `assert.pixels`, which diffs the recorded frame the same way desktop does.
+   * The one shape it can't resolve is a `ref` target (no refs survive into the flat snapshot),
+   * which the handler fails with a clear message rather than risk a false pass. `assert.a11y` rides
+   * its own [assertionA11yDescriptor]. (This is the descriptor formerly known as
+   * `assertionVisibilityDescriptor`, back when Android was `testTag`-only and text/pixels weren't
+   * wired.)
    */
-  val assertionVisibilityDescriptor: DataExtensionDescriptor =
+  val assertionAndroidDescriptor: DataExtensionDescriptor =
     DataExtensionDescriptor(
       id = DataExtensionId("assertion"),
       displayName = "Recording assertions",
@@ -379,13 +381,31 @@ object RecordingScriptDataExtensions {
           RecordingScriptEventDescriptor(
             id = ASSERT_VISIBLE_EVENT,
             displayName = "Assert visible",
-            summary = "Fails the recording unless the target (testTag) matches a node.",
+            summary =
+              "Fails the recording unless the target (testTag / role+text / text) matches a node.",
             supported = true,
           ),
           RecordingScriptEventDescriptor(
             id = ASSERT_NOT_VISIBLE_EVENT,
             displayName = "Assert not visible",
-            summary = "Fails the recording if the target (testTag) matches any node.",
+            summary =
+              "Fails the recording if the target (testTag / role+text / text) matches any node.",
+            supported = true,
+          ),
+          RecordingScriptEventDescriptor(
+            id = ASSERT_TEXT_EQUALS_EVENT,
+            displayName = "Assert text equals",
+            summary =
+              "Fails the recording unless the target node's (merged) text equals the expected " +
+                "string (carried in the event's inputText field).",
+            supported = true,
+          ),
+          RecordingScriptEventDescriptor(
+            id = ASSERT_PIXELS_EVENT,
+            displayName = "Assert pixels",
+            summary =
+              "Fails the recording unless the recorded frame at this tMs matches the baseline " +
+                "PNG (path in the event's inputText field) within PixelDiff tolerance.",
             supported = true,
           ),
         ),

--- a/docs/daemon/RECORDING-ASSERTIONS.md
+++ b/docs/daemon/RECORDING-ASSERTIONS.md
@@ -67,22 +67,25 @@ recording as a gating check.
 | Backend | `assert.visible` / `assert.notVisible` | `assert.textEquals` | `assert.a11y` | `assert.pixels` |
 |---------|----------------------------------------|---------------------|---------------|-----------------|
 | Desktop | ✅ (resolved against the live unmerged semantics tree) | ✅ | ❌ — desktop a11y is overlay-only (no ATF findings); not advertised | ✅ (diffs the frame it wrote against the baseline) |
-| Android | ✅ (resolved against the probe-semantics snapshot, by `testTag` only) | ❌ — `record_preview` rejects it | ✅ (ATF against the held View hierarchy) | ❌ — not advertised yet (follow-up) |
+| Android | ✅ (resolved against the probe-semantics snapshot: `testTag` / `role`+`text` / `text`) | ✅ | ✅ (ATF against the held View hierarchy) | ✅ (diffs the frame it wrote against the baseline) |
 
-Desktop advertises `RecordingScriptDataExtensions.assertionDescriptor` (all three) and resolves via
-`state.scene.composeSemanticsRoot()`. Android (issue #1964) advertises the narrower
-`assertionVisibilityDescriptor` and resolves visibility against the already-bridged
-`captureProbeSemantics()` snapshot — the same path the `recording.probe` event uses, so no new
-sandbox command is needed. The pure verdict logic (`evaluateVisibilityAssertion`) lives in
+Desktop advertises `RecordingScriptDataExtensions.assertionDescriptor` (all four) and resolves via
+`state.scene.composeSemanticsRoot()`. Android (issues #1964, #2519) advertises
+`assertionAndroidDescriptor` (visible / notVisible / textEquals / pixels) and resolves targets
+against the already-bridged `captureProbeSemantics()` snapshot — the same path the `recording.probe`
+event uses, so no new sandbox command is needed. The pure verdict logic
+(`evaluateVisibilityAssertion` / `evaluateTextEqualsAssertion` / `pixelAssertVerdict`) lives in
 `:daemon:core` so both backends share one implementation.
 
-**Android limitations (today):** assertions resolve by **`testTag` only**. The probe snapshot is a
-flat node list, so a `role`+`text` target can't be matched reliably — a `Button { Text("Add") }`
-emits the `role` on the button and the `text` on a separate child, so checking both on one node
-matches nothing and would make `assert.notVisible` *wrongly pass* while the control is on screen.
-`ref` (no refs in the snapshot) and `role`+`text` both fail with a clear message rather than risk a
-false pass; `assert.textEquals` isn't advertised at all. Enriching the snapshot to support
-`role`+`text` is a follow-up.
+**Android targets (issue #2519):** the probe snapshot is a flat node list, but each retained node
+now carries its **merged descendant text** (`RecordingProbeNode.mergedText`), so `testTag`,
+`role`+`text`, and `text` alone all resolve. A `Button { Text("Add") }` emits the `role` on the
+button and the `text` on a child; the button node carries the child's merged text, so a
+`role`+`text` (or `assert.textEquals`) target matches the control the user sees rather than failing
+closed. The pure resolver `resolveProbeTarget` (in `:daemon:core`) mirrors the desktop resolver's
+precedence (testTag → role+text → text) and reads a node's *effective* text (own text, else merged
+descendant text). The one shape it can't resolve is a `ref` target — no refs survive into the flat
+snapshot — which fails with a clear message rather than risk a false `assert.notVisible` pass.
 
 ### Accessibility assertions (`assert.a11y`)
 
@@ -147,12 +150,14 @@ compose-preview record --preview MyForm --script form.json --out form.gif --base
   `diff.png` next to the encoded output so the drift is inspectable without re-running.
 - **Fail-closed.** A missing baseline or a dimension mismatch is `FAILED`, never a silent pass — the
   script asked to pin pixels.
-- **Desktop-only today.** The Android backend renders frames the same way, so extending
-  `assert.pixels` there is a mechanical follow-up, but it's not advertised yet so `record_preview`
-  rejects it on Android. The pure verdict (`pixelAssertVerdict`) lives in `:daemon:desktop` and is
-  unit-tested from raw PNG bytes; it reuses the `PixelDiff` comparator, which this change relocated
-  from the (unpublished) `:daemon:harness` into the published `:daemon:core` so the released
-  `daemon-desktop` runtime can depend on it.
+- **Both backends (issue #2519).** Desktop and Android both write a `frame-NNNNN.png` per frame and
+  diff the frame at the event's `tMs` against the baseline. The pure verdict (`pixelAssertVerdict`)
+  lives in `:daemon:core` (relocated there from `:daemon:desktop` when Android gained the feature),
+  reusing the `PixelDiff` comparator (also in `:daemon:core`). Desktop snapshots the frame *before*
+  any later same-bucket event; Android renders one frame per bucket *after* dispatching every
+  same-bucket event, so on Android the golden check observes the on-disk frame written for that
+  `tMs` (a same-bucket input dispatched before the assert is therefore reflected in it). Both write
+  `actual/expected/diff.png` next to the encoded output on failure.
 
 ## What we borrowed (and what we deliberately didn't)
 
@@ -192,10 +197,9 @@ land (each is a separate follow-up, not in this PR):
   [above](#accessibility-assertions-asserta11y). Runs ATF against the held View hierarchy and fails
   the recording on findings at the chosen threshold. Desktop has no ATF backend, so it stays
   Android-only for now.
-- **Pixel / golden assertions** — **Shipped (desktop)** as `assert.pixels`, see
+- **Pixel / golden assertions** — **Shipped (both backends)** as `assert.pixels`, see
   [above](#pixel-assertions-assertpixels). Diffs the recorded frame against a committed baseline PNG
-  via `PixelDiff`. Android is a mechanical follow-up (it writes frames the same way; just not
-  advertised yet).
+  via `PixelDiff`; Android landed alongside the text/target enrichment in issue #2519.
 
 ## Code map
 
@@ -203,20 +207,26 @@ land (each is a separate follow-up, not in this PR):
   (`daemon/core/.../RecordingScriptHandlerRegistry.kt`).
 - Event kinds + descriptors: `RecordingScriptDataExtensions.ASSERT_VISIBLE_EVENT` /
   `ASSERT_NOT_VISIBLE_EVENT` / `ASSERT_TEXT_EQUALS_EVENT` / `ASSERT_A11Y_EVENT` / `ASSERT_PIXELS_EVENT`;
-  `assertionDescriptor` (desktop — visibility, text, **and pixels**), `assertionVisibilityDescriptor`
-  (Android, visibility only), and `assertionA11yDescriptor` (Android, a11y)
-  (`data/render/core/.../DataExtensionPlan.kt`).
-- Verdict logic (pure, unit-tested): `evaluateVisibilityAssertion` / `evaluateTextEqualsAssertion` /
-  `resolvedNodeText` / `evaluateA11yAssertion` + `A11yAssertThreshold`
-  (`daemon/core/.../RecordingAssertions.kt`); `pixelAssertVerdict` (golden-image, reuses `PixelDiff`)
-  (`daemon/desktop/.../PixelAssertions.kt`).
+  `assertionDescriptor` (desktop — visibility, text, **and pixels**), `assertionAndroidDescriptor`
+  (Android — visibility, text, **and pixels**, resolved against the flat probe snapshot), and
+  `assertionA11yDescriptor` (Android, a11y) (`data/render/core/.../DataExtensionPlan.kt`).
+- Verdict logic (pure, unit-tested, all in `:daemon:core`): `evaluateVisibilityAssertion` /
+  `evaluateTextEqualsAssertion` / `resolvedNodeText` / `evaluateA11yAssertion` + `A11yAssertThreshold`
+  (`daemon/core/.../RecordingAssertions.kt`); `resolveProbeTarget` / `effectiveText` (the Android
+  flat-snapshot resolver, `daemon/core/.../RecordingProbeTargets.kt`); `pixelAssertVerdict`
+  (golden-image, reuses `PixelDiff`, `daemon/core/.../PixelAssertions.kt`).
+- Probe-snapshot enrichment: `RecordingProbeNode.mergedText` (`daemon/core/.../protocol/Messages.kt`)
+  populated by `ComposeSemanticsNode.toProbeNodes()`
+  (`data/layoutinspector/connector/.../ComposeSemanticsDataProduct.kt`).
 - Handler wiring: `DesktopRecordingSession.assertVisibilityHandler` /
   `assertTextEqualsHandler` (advertised by `DesktopHost`); `AndroidRecordingSession`'s
-  `assertVisibilityHandler` resolving against `captureProbeSemantics()` and `assertA11yHandler`
-  resolving against `captureA11yFindings()` — the latter bridged by the `CaptureA11yFindings`
-  interactive command running `AccessibilityChecker.check` sandbox-side in `RobolectricHost`
-  (advertised by `RobolectricHost`).
-- Pixel-assert wiring: `DesktopRecordingSession.evaluatePixelAssert` (post-playback diff of the
-  written `frame-NNNNN.png` against the baseline, writes `actual/expected/diff.png` on failure).
+  `assertVisibilityHandler` / `assertTextEqualsHandler` resolving against `captureProbeSemantics()`
+  via `resolveProbeTarget`, and `assertA11yHandler` resolving against `captureA11yFindings()` — the
+  latter bridged by the `CaptureA11yFindings` interactive command running `AccessibilityChecker.check`
+  sandbox-side in `RobolectricHost` (advertised by `RobolectricHost`).
+- Pixel-assert wiring: `DesktopRecordingSession.evaluatePixelAssert` (snapshots the frame at the
+  event's position) and `AndroidRecordingSession.evaluatePixelAssert` (diffs the on-disk
+  `frame-NNNNN.png` written for the event's `tMs`); both a post-playback diff against the baseline,
+  writing `actual/expected/diff.png` on failure.
 - CLI gate: `RecordPreviewCommand` — `--baseline-dir` resolves `assert.pixels` baseline paths; fails
   any non-`APPLIED` `assert.*` evidence, prints each, exits 2.

--- a/docs/daemon/RECORDING-ASSERTIONS.md
+++ b/docs/daemon/RECORDING-ASSERTIONS.md
@@ -153,11 +153,13 @@ compose-preview record --preview MyForm --script form.json --out form.gif --base
 - **Both backends (issue #2519).** Desktop and Android both write a `frame-NNNNN.png` per frame and
   diff the frame at the event's `tMs` against the baseline. The pure verdict (`pixelAssertVerdict`)
   lives in `:daemon:core` (relocated there from `:daemon:desktop` when Android gained the feature),
-  reusing the `PixelDiff` comparator (also in `:daemon:core`). Desktop snapshots the frame *before*
-  any later same-bucket event; Android renders one frame per bucket *after* dispatching every
-  same-bucket event, so on Android the golden check observes the on-disk frame written for that
-  `tMs` (a same-bucket input dispatched before the assert is therefore reflected in it). Both write
-  `actual/expected/diff.png` next to the encoded output on failure.
+  reusing the `PixelDiff` comparator (also in `:daemon:core`). Both **freeze the frame at the
+  assertion's own timeline position — before any later same-bucket event** — so the golden check
+  observes the UI as of the assertion, not after a same-bucket input. Android does this by rendering
+  and capturing the frame bytes when the `assert.pixels` is drained (charging the bucket's
+  virtual-clock advance to that render so the bucket still advances exactly once), rather than
+  reusing the post-dispatch frame it writes to disk. Both write `actual/expected/diff.png` next to
+  the encoded output on failure.
 
 ## What we borrowed (and what we deliberately didn't)
 


### PR DESCRIPTION
## Context

Closes the Android half of the per-backend gaps tracked in #2519. The scripted-recording assertion surface (`record_preview` / `assert.*`, the equivalent of Storybook's play-function + `expect` interaction tests that the `run-story-tests` façade in #2517 is built on) behaved differently on the Android/Robolectric backend than on Desktop/CMP. This makes `assert.textEquals`, richer targets, and `assert.pixels` work on Android too, so the surface is uniform.

## What changed

**Android backend**
- **Enriched probe snapshot.** `RecordingProbeNode` now carries each node's **merged descendant text** (`mergedText`), populated in `toProbeNodes`, and role-bearing containers whose text lives on a child are retained. A `Button { Text("Add") }` (role on the button, text on the child) is now resolvable, instead of the projection dropping it and a `role`+`text` assertion failing closed.
- **`assert.textEquals`** — resolves the target and compares the resolved node's effective text (own text, else merged descendant text) to the expected `inputText`.
- **Richer targets** — `assert.visible` / `assert.notVisible` now resolve `testTag`, `role`+`text`, and `text` (not just `testTag`). `ref` still fails with a clear message (no refs survive into the flat snapshot) rather than risking a false pass.
- **`assert.pixels`** — diffs the on-disk `frame-NNNNN.png` written for the event's `tMs` against the baseline (deferred post-playback pass, mirroring desktop), reusing `pixelAssertVerdict` / `PixelDiff`.

**Shared / plumbing**
- New pure resolver `resolveProbeTarget` / `effectiveText` in `:daemon:core` — the Android flat-snapshot analogue of the desktop `SemanticsTargets.resolve`, free of Compose/Robolectric so it's unit-tested directly. Same precedence as desktop (testTag → role+text → text).
- Moved `pixelAssertVerdict` from `:daemon:desktop` to `:daemon:core` (next to `PixelDiff`) so both backends share one implementation.
- Advertise the enriched surface via `assertionAndroidDescriptor` (visible/notVisible/textEquals/pixels) from `RobolectricHost`.
- Updated `docs/daemon/RECORDING-ASSERTIONS.md` (backend matrix + code map).

The assertion **verdict** logic was already pure and shared in `:daemon:core`, so this is backend-side capture/advertisement work plus one new pure resolver — no new comparators.

## Test plan

- `:daemon:core`, `:data-layoutinspector-connector`, `:data-render-core` unit tests pass — new `RecordingProbeTargetsTest`, relocated `PixelAssertionsTest`, updated probe-projection tests (`ComposeSemanticsProbeNodesTest`).
- `:daemon:android` targeted `AndroidRecordingSessionTest` fake-session tests pass: role+text / text visibility, `assert.textEquals`, `assert.pixels`, `assert.a11y`, playback.
- The desktop Skiko-rendering tests only fail in this headless sandbox with a Skiko native-init error (`Could not initialize class org.jetbrains.skia.Surface`), unrelated to this change; CI runs them on a real display.

Non-visual change (data-product/daemon plumbing + tests + docs), so no rendered before/after evidence applies.

## Follow-ups still open on #2519
- Desktop `assert.a11y` (an ATF-equivalent for the Skiko scene, or a documented "no a11y on desktop" stance).

_Generated by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01PpcbiRc4P1cX2pSUZ8NzMf)_