### PR TITLE
test(serve): expand Overrides group before editing a knob in serve-lanes e2e

### DIFF
--- a/vscode-extension/preview-harness/serve-lanes.spec.mjs
+++ b/vscode-extension/preview-harness/serve-lanes.spec.mjs
@@ -41,6 +41,19 @@ test.beforeAll(async ({ request }) => {
   previewId = hit?.id ?? null;
 });
 
+// The declared knobs now live in a collapsed-by-default "Overrides"
+// `<details class="cp-group">` section (the viewer remembers each section's
+// open/closed state in localStorage, defaulting everything except Export to
+// closed). Expand it before touching a `.cp-knob`, since Playwright refuses to
+// fill a control inside a closed <details> ("element is not visible").
+async function openOverridesGroup(page) {
+  await page
+    .locator('details.cp-group[data-cp-group="overrides"]')
+    .evaluate((d) => {
+      d.open = true;
+    });
+}
+
 function requirePreview() {
   // In CI the boot step starts a known compose-m3 daemon serve, so a missing
   // label-knob preview is a real regression — FAIL, don't green-skip the required
@@ -152,6 +165,7 @@ test("viewer wires the knob into every render lane", async ({ page }) => {
     waitUntil: "domcontentloaded",
   });
 
+  await openOverridesGroup(page);
   const knob = page.locator('.cp-knob[data-knob-key="label"]');
   await expect(knob, "label knob control exists").toBeVisible();
   await knob.fill(OVERRIDE);
@@ -243,6 +257,7 @@ test("Wasm iframe re-renders on knob override", async ({ page }) => {
   const wasmToggle = page.locator("#cp-wasm-toggle");
   test.skip((await wasmToggle.count()) === 0, "no Wasm tier for this session");
 
+  await openOverridesGroup(page);
   const knob = page.locator('.cp-knob[data-knob-key="label"]');
   await knob.fill("WasmBefore");
   await knob.dispatchEvent("input");


### PR DESCRIPTION
## Summary

Follow-up fix for a regression #2550 introduced on `main`. That PR moved the declared knobs into a **collapsed-by-default `Overrides` `<details>`** section, so the `serve-lanes` Playwright e2e could no longer fill the `label` knob — Playwright refuses to `fill()` a control inside a closed `<details>` (`element is not visible`), timing out both knob-driven lane tests:

- `viewer wires the knob into every render lane`
- `Wasm iframe re-renders on knob override`

This adds a small `openOverridesGroup(page)` helper that forces the `details[data-cp-group="overrides"]` open, and calls it before touching a `.cp-knob` in both tests. This mirrors the real UX (a user expands the section to reach the knobs) rather than reverting the collapse-by-default behaviour.

## Why forward-fix

#2550 auto-merged before this required check reported, leaving `main` red on the `Serve render lanes honor overrides` job. This is a test-only change (`serve-lanes.spec.mjs`); no product behaviour changes.

## Test plan

- The `serve-lanes` suite requires a running daemon-backed `serve` under xvfb, which only the CI job provides — CI will exercise both previously-failing tests against the collapsed section.
- No fixture or `ServeWeb` changes, so the `ServeWebFixtureTest` drift-guard and ktfmt gates are unaffected.

_Generated by [Claude Code]_

---
_Generated by [Claude Code](https://claude.ai/code/session_011GTopYN71MKKgwMJoSxRJC)_