### PR TITLE
feat(overrides): honour wrapped-axis size bounds in the Android backend and standalone renderer

### DIFF
--- a/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/cli/PreviewData.kt
+++ b/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/cli/PreviewData.kt
@@ -26,6 +26,19 @@ data class PreviewParams(
   val widthDp: Int? = null,
   val heightDp: Int? = null,
   /**
+   * Wrapped-axis content-size bounds (the Max / Min / Within size modes), in **pixels**. Null means
+   * "no bound" — the AS-parity wrap (min = 0, max = sandbox). They only bite on a wrapped axis (one
+   * with no fixed [widthDp]/[heightDp]), letting a bundle carry a "render this component as it
+   * would appear constrained to a list column" request that the desktop renderer honours — the same
+   * `PreviewOverrides.{min,max}{Width,Height}Px` the daemon applies for `compose-preview serve`.
+   * Absent from discovery today (no `@Preview` equivalent), so they round-trip only when a bundle /
+   * catalog author sets them; the render pipeline defaults them to the unbounded wrap.
+   */
+  val minWidthPx: Int? = null,
+  val minHeightPx: Int? = null,
+  val maxWidthPx: Int? = null,
+  val maxHeightPx: Int? = null,
+  /**
    * Compose density factor (= densityDpi / 160) resolved at discovery from the @Preview device;
    * null means "use the renderer default". Carried through so agents can spot per-device fan-outs
    * without re-reading the Gradle manifest.

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleRenderer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleRenderer.kt
@@ -455,7 +455,7 @@ class BundleRenderer(
     return exitCode to tail
   }
 
-  private fun buildRendererArgs(preview: PreviewInfo, outFile: File): List<String> {
+  internal fun buildRendererArgs(preview: PreviewInfo, outFile: File): List<String> {
     // DesktopRendererMain arg positions (see renderer-desktop/DesktopRendererMain.kt):
     //  0 className  1 functionName  2 widthPx  3 heightPx  4 density  5 showBackground
     //  6 backgroundColor  7 outputFile  8 wrapperClassName  9 wrapWidth  10 wrapHeight
@@ -472,22 +472,37 @@ class BundleRenderer(
     val heightPx = (heightDp * density).toInt().coerceAtLeast(1)
     val wrapWidth = preview.params.widthDp == null
     val wrapHeight = preview.params.heightDp == null
-    return listOf(
-      preview.className,
-      preview.functionName,
-      widthPx.toString(),
-      heightPx.toString(),
-      density.toString(),
-      preview.params.showBackground.toString(),
-      preview.params.backgroundColor.toString(),
-      outFile.absolutePath,
-      preview.params.wrapperClassName.orEmpty(),
-      wrapWidth.toString(),
-      wrapHeight.toString(),
-      preview.params.previewParameterProviderClassName.orEmpty(),
-      preview.params.previewParameterLimit.toString(),
-      preview.params.locale.orEmpty(),
-    )
+    val base =
+      listOf(
+        preview.className,
+        preview.functionName,
+        widthPx.toString(),
+        heightPx.toString(),
+        density.toString(),
+        preview.params.showBackground.toString(),
+        preview.params.backgroundColor.toString(),
+        outFile.absolutePath,
+        preview.params.wrapperClassName.orEmpty(),
+        wrapWidth.toString(),
+        wrapHeight.toString(),
+        preview.params.previewParameterProviderClassName.orEmpty(),
+        preview.params.previewParameterLimit.toString(),
+        preview.params.locale.orEmpty(),
+      )
+    // Wrapped-axis size bounds (Max / Min / Within), when the bundle carries them, land at
+    // DesktopRendererMain arg indices 28–31. The intervening optional slots (14–27: scroll / kind /
+    // fontScale / systemUi / anim / siblings) aren't driven by the bundle path, so pad them with
+    // empty strings that DesktopRendererMain's `getOrNull(...)` reads as "unset". Emit nothing when
+    // no bound is set so the common case keeps the short, positional-stable arg list.
+    val bounds =
+      listOf(
+        preview.params.minWidthPx,
+        preview.params.minHeightPx,
+        preview.params.maxWidthPx,
+        preview.params.maxHeightPx,
+      )
+    if (bounds.all { it == null }) return base
+    return base + List(14) { "" } + bounds.map { it?.toString() ?: "" }
   }
 
   /**

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleRendererSizeBoundsArgsTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleRendererSizeBoundsArgsTest.kt
@@ -1,0 +1,64 @@
+package ee.schimke.composeai.cli
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Locks the desktop bundle-render arg wiring for the wrapped-axis size bounds (Max / Min / Within),
+ * so a bundle whose `previews.json` carries `PreviewParams.{min,max}{Width,Height}Px` re-renders
+ * the same way `compose-preview serve` does. The bounds land at [DesktopRendererMain]
+ * positional-arg indices 28–31; the intervening optional slots (14–27) are padded with empty
+ * strings. An off-by-one would silently drop the bound, so pin the exact positions and the "no
+ * bound ⇒ short arg list" fast path.
+ */
+class BundleRendererSizeBoundsArgsTest {
+
+  private val renderer =
+    BundleRenderer(bundleFile = File("unused.png"), outputDir = File("unused-out"))
+
+  private fun preview(params: PreviewParams): PreviewInfo =
+    PreviewInfo(id = "a.Foo", functionName = "Foo", className = "a.Kt", params = params)
+
+  @Test
+  fun `no bounds keeps the short positional arg list`() {
+    val args = renderer.buildRendererArgs(preview(PreviewParams()), File("/tmp/out.png"))
+    // className, functionName, widthPx, heightPx, density, showBackground, backgroundColor,
+    // outputFile, wrapperClassName, wrapWidth, wrapHeight, provider, limit, locale = 14.
+    assertEquals(14, args.size)
+  }
+
+  @Test
+  fun `size bounds land at indices 28-31 with 14-27 padded`() {
+    val args =
+      renderer.buildRendererArgs(
+        preview(
+          PreviewParams(minWidthPx = 120, minHeightPx = 48, maxWidthPx = 400, maxHeightPx = 800)
+        ),
+        File("/tmp/out.png"),
+      )
+    assertEquals(32, args.size)
+    // Intervening optional slots (scroll / kind / fontScale / systemUi / anim / siblings) are
+    // unset.
+    for (i in 14..27) assertTrue(
+      args[i].isEmpty(),
+      "arg $i should be padded empty, was '${args[i]}'",
+    )
+    assertEquals("120", args[28]) // minWidthPx
+    assertEquals("48", args[29]) // minHeightPx
+    assertEquals("400", args[30]) // maxWidthPx
+    assertEquals("800", args[31]) // maxHeightPx
+  }
+
+  @Test
+  fun `a single bound still emits the full padded list with the others blank`() {
+    val args =
+      renderer.buildRendererArgs(preview(PreviewParams(maxWidthPx = 240)), File("/tmp/out.png"))
+    assertEquals(32, args.size)
+    assertEquals("", args[28])
+    assertEquals("", args[29])
+    assertEquals("240", args[30])
+    assertEquals("", args[31])
+  }
+}

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -327,13 +327,29 @@ class RenderEngine(
         ee.schimke.composeai.renderer.WearReduceMotionLocal.get(classLoader)
       else null
 
+    // Content-size bounds (the Max / Min / Within size modes) apply on a wrapped axis, where
+    // widthPx/heightPx are a sandbox bound rather than a fixed frame. A min bound larger than the
+    // default sandbox needs the Robolectric display enlarged to fit, otherwise the wrap measure is
+    // clamped to the sandbox window before it can reach the requested floor. Only widen (never
+    // shrink) the sandbox — the intrinsic-size crop still trims the PNG back to the measured size.
+    // Mirrors the desktop daemon's scene-enlarge in `:daemon:desktop`'s RenderEngine.
+    val sizeOverrides = spec.overrides
+    val sandboxWidthPx =
+      if (spec.wrapWidth)
+        maxOf(spec.widthPx, sizeOverrides?.minWidthPx ?: 0, sizeOverrides?.maxWidthPx ?: 0)
+      else spec.widthPx
+    val sandboxHeightPx =
+      if (spec.wrapHeight)
+        maxOf(spec.heightPx, sizeOverrides?.minHeightPx ?: 0, sizeOverrides?.maxHeightPx ?: 0)
+      else spec.heightPx
+
     // Per-preview Robolectric configuration — qualifiers re-applied so a previous render's size /
     // density doesn't bleed into this one. Same entrypoints `RobolectricRenderTest` uses; both
     // mutate `RuntimeEnvironment` global state, which is OK here because the sandbox is single-
     // threaded under our render loop (DESIGN § 9 invariant: no concurrent renders).
     applyPreviewQualifiers(
-      widthDp = pxToDp(spec.widthPx, spec.density),
-      heightDp = pxToDp(spec.heightPx, spec.density),
+      widthDp = pxToDp(sandboxWidthPx, spec.density),
+      heightDp = pxToDp(sandboxHeightPx, spec.density),
       density = spec.density,
       isRound = isRound,
       localeTag = spec.localeTag,
@@ -463,12 +479,29 @@ class RenderEngine(
                       val contentBoxModifier =
                         if (spec.wrapWidth || spec.wrapHeight) {
                           Modifier.layout { measurable, constraints ->
+                            // Size-mode bounds (Max / Min / Within) clamp the wrapped-axis measure:
+                            // a max bound lowers the sandbox ceiling so the composable can't grow
+                            // past it; a min bound raises the floor so it can't collapse below it.
+                            // Both are clamped to the (already-enlarged) sandbox so a bound larger
+                            // than the window can't produce an impossible constraint. Absent bounds
+                            // keep the AS-parity wrap (min = 0, max = sandbox). Mirrors the desktop
+                            // daemon RenderEngine.
+                            val maxWBound =
+                              sizeOverrides?.maxWidthPx?.coerceAtMost(constraints.maxWidth)
+                                ?: constraints.maxWidth
+                            val maxHBound =
+                              sizeOverrides?.maxHeightPx?.coerceAtMost(constraints.maxHeight)
+                                ?: constraints.maxHeight
+                            val minWBound = (sizeOverrides?.minWidthPx ?: 0).coerceIn(0, maxWBound)
+                            val minHBound = (sizeOverrides?.minHeightPx ?: 0).coerceIn(0, maxHBound)
                             val wrapped =
                               androidx.compose.ui.unit.Constraints(
-                                minWidth = if (spec.wrapWidth) 0 else constraints.minWidth,
-                                maxWidth = constraints.maxWidth,
-                                minHeight = if (spec.wrapHeight) 0 else constraints.minHeight,
-                                maxHeight = constraints.maxHeight,
+                                minWidth = if (spec.wrapWidth) minWBound else constraints.minWidth,
+                                maxWidth = if (spec.wrapWidth) maxWBound else constraints.maxWidth,
+                                minHeight =
+                                  if (spec.wrapHeight) minHBound else constraints.minHeight,
+                                maxHeight =
+                                  if (spec.wrapHeight) maxHBound else constraints.maxHeight,
                               )
                             val placeable = measurable.measure(wrapped)
                             measuredContent[0] = placeable.width

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/RenderEngineSizeBoundsTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/RenderEngineSizeBoundsTest.kt
@@ -1,0 +1,148 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import java.io.ByteArrayInputStream
+import java.io.File
+import java.util.Base64
+import javax.imageio.ImageIO
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * Android (Robolectric) counterpart of `:daemon:desktop`'s `RenderEngineWrapContentTest`
+ * size-bound cases — proves the Android backend honours the wrapped-axis content-size bounds
+ * (`PreviewOverrides.{min,max}{Width,Height}Px`, the Max / Min / Within size modes) instead of
+ * silently ignoring them.
+ *
+ * Before the fix the Android [RenderEngine]'s wrap measure used `minWidth = 0` / `maxWidth =
+ * sandbox` with no reference to the bounds, so a `compose-preview serve` (or MCP / matrix) size
+ * override against an Android module dropped the constraint — the sticker rendered at its full
+ * intrinsic size no matter what "Within 120–400" / "Max 100" the viewer requested. With the fix the
+ * wrap measure is clamped to `[min, max]` (and the Robolectric sandbox enlarged for a min bound
+ * larger than the frame), then the AS-parity crop trims the PNG to the resulting size — matching the
+ * desktop daemon exactly.
+ *
+ * Drives the production path: the base64 `overrides=` payload token is decoded into
+ * `RenderSpec.overrides` by `parseFromPayloadOrNull`, the same shape the host builds from a
+ * `renderNow.overrides` request. [WrapContentStickerPreview]'s intrinsic size is 176 px (56 dp badge
+ * + 16 dp padding each side, × density 2), so each bound visibly reshapes the crop.
+ */
+class RenderEngineSizeBoundsTest {
+
+  @get:Rule val tempFolder: TemporaryFolder = TemporaryFolder()
+
+  private val json = Json { encodeDefaults = false }
+
+  /** Render the sticker fixture wrap-content with [overrides]; returns the PNG dimensions. */
+  private fun renderBounded(
+    host: RobolectricHost,
+    overrides: PreviewOverrides,
+    base: String,
+  ): Pair<Int, Int> {
+    val overridesB64 =
+      Base64.getEncoder()
+        .encodeToString(
+          json.encodeToString(PreviewOverrides.serializer(), overrides).toByteArray()
+        )
+    val result =
+      host.submit(
+        RenderRequest.Render(
+          payload =
+            "className=ee.schimke.composeai.daemon.RedFixturePreviewsKt;" +
+              "functionName=WrapContentStickerPreview;" +
+              // Generous 800×1600 px wrap sandbox (like the desktop test) so the *bound*, not the
+              // frame, decides the measured intrinsic size the crop keeps.
+              "widthPx=800;heightPx=1600;density=2.0;" +
+              "wrapWidth=true;wrapHeight=true;" +
+              "showBackground=true;outputBaseName=$base;" +
+              "overrides=$overridesB64",
+        ),
+        timeoutMs = 120_000,
+      )
+    assertNotNull("$base: pngPath must be populated", result.pngPath)
+    val png = File(result.pngPath!!)
+    assertTrue("$base: rendered PNG must exist", png.exists())
+    // Keep the size-mode renders for the PR's visual evidence (build dir, not committed).
+    File("build/size-evidence").apply { mkdirs() }.let { png.copyTo(File(it, "$base.png"), true) }
+    val img =
+      ByteArrayInputStream(png.readBytes()).use { ImageIO.read(it) } ?: error("$base: no decode")
+    return img.width to img.height
+  }
+
+  @Test
+  fun maxBoundCapsTheWrapCropBelowTheComponentsIntrinsicSize() {
+    System.setProperty(RenderEngine.OUTPUT_DIR_PROP, tempFolder.newFolder("renders").absolutePath)
+    System.setProperty("roborazzi.test.record", "true")
+    val host = RobolectricHost()
+    host.start()
+    try {
+      // A max bound of 100 px lowers the wrap ceiling below the 176 px intrinsic, so the crop lands
+      // at the bound on both axes.
+      val (w, h) =
+        renderBounded(
+          host,
+          PreviewOverrides(maxWidthPx = 100, maxHeightPx = 100),
+          "android-size-max-100",
+        )
+      assertEquals("max width bound caps the crop", 100, w)
+      assertEquals("max height bound caps the crop", 100, h)
+    } finally {
+      host.shutdown()
+    }
+  }
+
+  @Test
+  fun minBoundForcesTheWrapCropAboveTheComponentsIntrinsicSize() {
+    System.setProperty(RenderEngine.OUTPUT_DIR_PROP, tempFolder.newFolder("renders").absolutePath)
+    System.setProperty("roborazzi.test.record", "true")
+    val host = RobolectricHost()
+    host.start()
+    try {
+      // A min bound of 400 px (> the 176 px intrinsic) raises the wrap floor to that size on both
+      // axes; the sandbox is generous enough that nothing is clipped before the crop.
+      val (w, h) =
+        renderBounded(
+          host,
+          PreviewOverrides(minWidthPx = 400, minHeightPx = 400),
+          "android-size-min-400",
+        )
+      assertEquals("min width bound raises the crop floor", 400, w)
+      assertEquals("min height bound raises the crop floor", 400, h)
+    } finally {
+      host.shutdown()
+    }
+  }
+
+  @Test
+  fun withinBoundKeepsTheCropInsideTheMinMaxRange() {
+    System.setProperty(RenderEngine.OUTPUT_DIR_PROP, tempFolder.newFolder("renders").absolutePath)
+    System.setProperty("roborazzi.test.record", "true")
+    val host = RobolectricHost()
+    host.start()
+    try {
+      // The 176 px intrinsic already sits inside [120, 400], so a "within" range leaves it
+      // unchanged — the bounds only bite when the component would fall outside them.
+      val (w, h) =
+        renderBounded(
+          host,
+          PreviewOverrides(
+            minWidthPx = 120,
+            minHeightPx = 120,
+            maxWidthPx = 400,
+            maxHeightPx = 400,
+          ),
+          "android-size-within-120-400",
+        )
+      assertTrue("width stays within the range (got $w)", w in 120..400)
+      assertTrue("height stays within the range (got $h)", h in 120..400)
+      assertEquals("unconstrained intrinsic is preserved inside the range", 176, w)
+    } finally {
+      host.shutdown()
+    }
+  }
+}

--- a/daemon/android/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
+++ b/daemon/android/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
@@ -93,6 +93,27 @@ fun TallWrapColumn() {
 }
 
 /**
+ * Wrap-content sticker fixture mirroring the desktop `WrapContentStickerPreview` (and the
+ * design-catalog `CatalogSticker`): a 56.dp badge in 16.dp padding with **no `fillMaxSize`**, so its
+ * intrinsic size is 88.dp on both axes — 176 px at density 2, far smaller than the wrap sandbox.
+ * Used by [RenderEngineSizeBoundsTest] to prove the Android backend honours the wrapped-axis size
+ * bounds (`PreviewOverrides.{min,max}{Width,Height}Px` — the Max / Min / Within size modes) the same
+ * way the desktop daemon does, so a `compose-preview serve` size override against an Android module
+ * reshapes the crop instead of being silently ignored.
+ */
+@Composable
+fun WrapContentStickerPreview() {
+  Box(modifier = Modifier.padding(16.dp)) {
+    Box(
+      modifier = Modifier.size(56.dp).background(Color(0xFFB71C1C), RoundedCornerShape(28.dp)),
+      contentAlignment = Alignment.Center,
+    ) {
+      Text(text = "8", color = Color.White)
+    }
+  }
+}
+
+/**
  * Fixture for `PreviewOverridesDataFetchE2ETest`: declares two opt-in `previewOverride*` knobs (a
  * colour `fill` and a string `label`) so a render through the sandbox records them into the
  * sandbox-classloader `PreviewOverrideController`. The test then asserts the host-side

--- a/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRendererMain.kt
+++ b/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRendererMain.kt
@@ -77,6 +77,16 @@ import org.jetbrains.skia.EncodedImageFormat
  * cleanup must leave those siblings' files alone — see [deleteStaleFanoutFiles] (issue #2193). `|`
  * is safe as a separator because discovery's `sanitizeForPath` strips it from every stem.
  *
+ * Args 29–32 (indices 28–31) are the wrapped-axis content-size bounds — `minWidthPx`,
+ * `minHeightPx`, `maxWidthPx`, `maxHeightPx` (the Max / Min / Within size modes). Positive
+ * integers; missing / blank / non-positive means "no bound" (the AS-parity wrap). They only bite on
+ * a wrapped axis: a max bound lowers the wrap ceiling so the component can't grow past it, a min
+ * bound raises the floor (the scene is enlarged to fit) so it can't collapse below it, then the
+ * capture crops to the resulting intrinsic size. Mirror the daemon's
+ * `PreviewOverrides.{min,max}{Width,Height}Px` so a `compose-preview bundle render` matches what
+ * `compose-preview serve` produces for the same size override — letting a component be captured as
+ * it would appear constrained to e.g. a list column.
+ *
  * Args 15–18 carry `@ScrollingPreview` intent. When [scrollMode] is `"LONG"` or `"GIF"` the
  * renderer leaves the [ImageComposeScene] path and dispatches to [renderScrollPreview] (which uses
  * `runComposeUiTest` for paused-clock + semantic scroll). `"TOP"` / `"END"` / empty are handled by
@@ -192,6 +202,17 @@ fun main(args: Array<String>) {
   // 28th — sibling stems for the stale fan-out cleanup (issue #2193). Missing / blank keeps the
   // pre-#2193 behaviour (no sibling protection), so older callers stay arg-compatible.
   val fanoutSiblingStems = args.getOrNull(27)?.split('|')?.filter { it.isNotBlank() } ?: emptyList()
+  // Args 29–32 (indices 28–31) — wrapped-axis content-size bounds (the Max / Min / Within size
+  // modes). Positive integers; missing / blank / non-positive means "no bound" (the AS-parity
+  // wrap).
+  // Only consulted on a wrapped axis. Mirror the daemon's
+  // `PreviewOverrides.{min,max}{Width,Height}Px`, so a `compose-preview bundle render` matches what
+  // `compose-preview serve` produces for the same size-mode override. Older callers omit them and
+  // keep the unbounded wrap.
+  val minWidthPx = args.getOrNull(28)?.toIntOrNull()?.takeIf { it > 0 }
+  val minHeightPx = args.getOrNull(29)?.toIntOrNull()?.takeIf { it > 0 }
+  val maxWidthPx = args.getOrNull(30)?.toIntOrNull()?.takeIf { it > 0 }
+  val maxHeightPx = args.getOrNull(31)?.toIntOrNull()?.takeIf { it > 0 }
   if (previewKind == "LOTTIE") {
     val assetPath = args.getOrNull(19)?.takeIf { it.isNotBlank() }
     val sidecar = errorSidecarFor(outputFile)
@@ -390,6 +411,10 @@ fun main(args: Array<String>) {
             showSystemUi,
             uiMode,
             device,
+            minWidthPx = minWidthPx,
+            minHeightPx = minHeightPx,
+            maxWidthPx = maxWidthPx,
+            maxHeightPx = maxHeightPx,
           )
         }
       } else {
@@ -411,6 +436,10 @@ fun main(args: Array<String>) {
           showSystemUi,
           uiMode,
           device,
+          minWidthPx = minWidthPx,
+          minHeightPx = minHeightPx,
+          maxWidthPx = maxWidthPx,
+          maxHeightPx = maxHeightPx,
         )
       }
       // Display filters — post-capture colour-matrix variants (grayscale / invert / daltonizer
@@ -694,7 +723,7 @@ internal fun systemThemeFromUiMode(uiMode: Int): androidx.compose.ui.SystemTheme
   }
 
 @OptIn(androidx.compose.ui.InternalComposeUiApi::class)
-private fun renderPreview(
+internal fun renderPreview(
   className: String,
   functionName: String,
   widthPx: Int,
@@ -712,6 +741,15 @@ private fun renderPreview(
   showSystemUi: Boolean = false,
   uiMode: Int = 0,
   device: String? = null,
+  // Wrapped-axis content-size bounds (the Max / Min / Within size modes). Null keeps the AS-parity
+  // wrap (min = 0, max = sandbox); a max bound lowers the wrap ceiling, a min bound raises the
+  // floor.
+  // Only consulted on a wrapped axis. Mirrors the desktop daemon RenderEngine so a bundle re-render
+  // matches what `compose-preview serve` produces for the same size-mode override.
+  minWidthPx: Int? = null,
+  minHeightPx: Int? = null,
+  maxWidthPx: Int? = null,
+  maxHeightPx: Int? = null,
   fileSystem: FileSystem = SystemFileSystem,
 ) {
   val clazz = Class.forName(className)
@@ -732,7 +770,14 @@ private fun renderPreview(
   // paths read it directly during composition rather than via the scene density. Mirrors the
   // daemon's desktop RenderEngine (issue: @Preview(fontScale) was ignored on the CMP pipeline).
   val sceneDensity = Density(density, fontScale)
-  val scene = ImageComposeScene(width = widthPx, height = heightPx, density = sceneDensity)
+  // A min bound larger than the default sandbox needs the scene enlarged to fit, otherwise the
+  // composable is clipped to the scene before the intrinsic-size crop runs. Only widen (never
+  // shrink) on a wrapped axis; the crop still trims the PNG back to the measured intrinsic size.
+  val sceneWidthPx = if (wrapWidth) maxOf(widthPx, minWidthPx ?: 0, maxWidthPx ?: 0) else widthPx
+  val sceneHeightPx =
+    if (wrapHeight) maxOf(heightPx, minHeightPx ?: 0, maxHeightPx ?: 0) else heightPx
+  val scene =
+    ImageComposeScene(width = sceneWidthPx, height = sceneHeightPx, density = sceneDensity)
 
   // Measured content size in pixels, captured from the wrapping Box via
   // onGloballyPositioned. Only read when at least one axis wraps.
@@ -805,13 +850,24 @@ private fun renderPreview(
                   // small composables can shrink below the
                   // sandbox; keep the max bounded (the parent's
                   // maxWidth/maxHeight) so `fillMax*` / LazyColumn
-                  // still have a finite viewport.
+                  // still have a finite viewport. Size-mode bounds
+                  // (Max / Min / Within) clamp that further: a max
+                  // bound lowers the ceiling, a min bound raises the
+                  // floor, both clamped into the (already-enlarged)
+                  // sandbox so a bound larger than the scene can't
+                  // make an impossible constraint.
+                  val maxWBound =
+                    maxWidthPx?.coerceAtMost(constraints.maxWidth) ?: constraints.maxWidth
+                  val maxHBound =
+                    maxHeightPx?.coerceAtMost(constraints.maxHeight) ?: constraints.maxHeight
+                  val minWBound = (minWidthPx ?: 0).coerceIn(0, maxWBound)
+                  val minHBound = (minHeightPx ?: 0).coerceIn(0, maxHBound)
                   val wrappedConstraints =
                     Constraints(
-                      minWidth = if (wrapWidth) 0 else constraints.minWidth,
-                      maxWidth = constraints.maxWidth,
-                      minHeight = if (wrapHeight) 0 else constraints.minHeight,
-                      maxHeight = constraints.maxHeight,
+                      minWidth = if (wrapWidth) minWBound else constraints.minWidth,
+                      maxWidth = if (wrapWidth) maxWBound else constraints.maxWidth,
+                      minHeight = if (wrapHeight) minHBound else constraints.minHeight,
+                      maxHeight = if (wrapHeight) maxHBound else constraints.maxHeight,
                     )
                   val placeable = measurable.measure(wrappedConstraints)
                   measured = IntSize(placeable.width, placeable.height)
@@ -869,8 +925,10 @@ private fun renderPreview(
   // fall back to the sandbox dimensions and write the uncropped PNG.
   if ((wrapWidth || wrapHeight) && measured != null) {
     val m = measured!!
-    val cropW = (if (wrapWidth) m.width else widthPx).coerceIn(1, widthPx)
-    val cropH = (if (wrapHeight) m.height else heightPx).coerceIn(1, heightPx)
+    // Ceiling is the (possibly enlarged) scene dimension, not the raw widthPx/heightPx — a min
+    // bound larger than the original frame grew the scene, and the crop must keep that extent.
+    val cropW = (if (wrapWidth) m.width else widthPx).coerceIn(1, sceneWidthPx)
+    val cropH = (if (wrapHeight) m.height else heightPx).coerceIn(1, sceneHeightPx)
     val decoded = ByteArrayInputStream(pngData.bytes).use { ImageIO.read(it) }
     if (decoded != null && (cropW < decoded.width || cropH < decoded.height)) {
       val sub =

--- a/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/DesktopSizeBoundsRendererTest.kt
+++ b/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/DesktopSizeBoundsRendererTest.kt
@@ -1,0 +1,128 @@
+package ee.schimke.composeai.renderer
+
+import java.io.ByteArrayInputStream
+import java.io.File
+import javax.imageio.ImageIO
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * Standalone-renderer counterpart of the daemon's `RenderEngineWrapContentTest` size-bound cases —
+ * proves the `compose-preview bundle render` / `composePreviewRenderAll` renderer honours the
+ * wrapped-axis content-size bounds (`minWidthPx` / `minHeightPx` / `maxWidthPx` / `maxHeightPx`,
+ * the Max / Min / Within size modes) the same way `compose-preview serve`'s desktop daemon does.
+ *
+ * Before the fix the standalone [renderPreview] wrap measure used `minWidth = 0` / `maxWidth =
+ * sandbox` with no bound plumbing at all, so a bundle could carry a size-mode request but the
+ * export dropped it. [WrapContentSticker]'s intrinsic size is 176 px (56 dp badge + 16 dp padding
+ * each side, × density 2), so each bound visibly reshapes the crop.
+ */
+class DesktopSizeBoundsRendererTest {
+
+  @get:Rule val tempFolder: TemporaryFolder = TemporaryFolder()
+
+  private val stickerClass = "ee.schimke.composeai.renderer.SizeBoundsRenderTestFixturesKt"
+
+  private fun dims(file: File): Pair<Int, Int> {
+    assertTrue("rendered PNG must exist: ${file.absolutePath}", file.exists() && file.length() > 0)
+    val img = ByteArrayInputStream(file.readBytes()).use { ImageIO.read(it) } ?: error("no decode")
+    // Keep the size-mode render for the PR's visual evidence (build dir, not committed).
+    File("build/size-evidence").apply { mkdirs() }.let { file.copyTo(File(it, file.name), true) }
+    return img.width to img.height
+  }
+
+  private fun renderSticker(
+    base: String,
+    minWidthPx: Int? = null,
+    minHeightPx: Int? = null,
+    maxWidthPx: Int? = null,
+    maxHeightPx: Int? = null,
+  ): File {
+    val out = File(tempFolder.newFolder(base), "$base.png")
+    renderPreview(
+      className = stickerClass,
+      functionName = "WrapContentSticker",
+      // Generous 800×1600 px wrap sandbox (like the daemon test) so the *bound*, not the frame,
+      // decides the measured intrinsic size the crop keeps.
+      widthPx = 800,
+      heightPx = 1600,
+      density = 2.0f,
+      showBackground = true,
+      backgroundColor = 0L,
+      outputFile = out,
+      wrapperClassName = null,
+      wrapWidth = true,
+      wrapHeight = true,
+      previewArgs = emptyList(),
+      localeTag = null,
+      minWidthPx = minWidthPx,
+      minHeightPx = minHeightPx,
+      maxWidthPx = maxWidthPx,
+      maxHeightPx = maxHeightPx,
+    )
+    return out
+  }
+
+  @Test
+  fun maxBoundCapsTheWrapCropBelowTheComponentsIntrinsicSize() {
+    val (w, h) = dims(renderSticker("desktop-size-max-100", maxWidthPx = 100, maxHeightPx = 100))
+    assertEquals("max width bound caps the crop", 100, w)
+    assertEquals("max height bound caps the crop", 100, h)
+  }
+
+  @Test
+  fun minBoundForcesTheWrapCropAboveTheComponentsIntrinsicSize() {
+    val (w, h) = dims(renderSticker("desktop-size-min-400", minWidthPx = 400, minHeightPx = 400))
+    assertEquals("min width bound raises the crop floor", 400, w)
+    assertEquals("min height bound raises the crop floor", 400, h)
+  }
+
+  @Test
+  fun withinBoundKeepsTheCropInsideTheMinMaxRange() {
+    val (w, h) =
+      dims(
+        renderSticker(
+          "desktop-size-within-120-400",
+          minWidthPx = 120,
+          minHeightPx = 120,
+          maxWidthPx = 400,
+          maxHeightPx = 400,
+        )
+      )
+    assertTrue("width stays within the range (got $w)", w in 120..400)
+    assertTrue("height stays within the range (got $h)", h in 120..400)
+    assertEquals("unconstrained intrinsic is preserved inside the range", 176, w)
+  }
+
+  /**
+   * Locks the `main()` positional-arg wiring: the wrapped-axis bounds live at indices 28–31 with
+   * the intervening optional slots (14–27) padded. An off-by-one in that padding would silently
+   * drop the bound, so drive the real entry point and assert the max bound still caps the crop.
+   */
+  @Test
+  fun mainAppliesBoundsAtTheirPositionalArgIndices() {
+    val out = File(tempFolder.newFolder("main-args"), "sticker.png")
+    val args = MutableList(32) { "" }
+    args[0] = stickerClass
+    args[1] = "WrapContentSticker"
+    args[2] = "800" // widthPx
+    args[3] = "1600" // heightPx
+    args[4] = "2.0" // density
+    args[5] = "true" // showBackground
+    args[6] = "0" // backgroundColor
+    args[7] = out.absolutePath
+    args[9] = "true" // wrapWidth
+    args[10] = "true" // wrapHeight
+    args[12] = "0" // previewParameterLimit
+    args[28] = "100" // minWidthPx — not exceeded, so no floor effect
+    args[30] = "100" // maxWidthPx — caps the width crop at 100
+    args[31] = "100" // maxHeightPx — caps the height crop at 100
+    main(args.toTypedArray())
+    val (w, h) = dims(out)
+    assertEquals("main() must thread maxWidthPx (arg 30) into the crop", 100, w)
+    assertEquals("main() must thread maxHeightPx (arg 31) into the crop", 100, h)
+  }
+}

--- a/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/SizeBoundsRenderTestFixtures.kt
+++ b/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/SizeBoundsRenderTestFixtures.kt
@@ -1,0 +1,25 @@
+package ee.schimke.composeai.renderer
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+
+/**
+ * Wrap-content sticker fixture for [DesktopSizeBoundsRendererTest], mirroring the daemon's
+ * `WrapContentStickerPreview`: a 56.dp badge in 16.dp padding with **no `fillMaxSize`**, so its
+ * intrinsic size is 88.dp on both axes — 176 px at density 2, far smaller than the wrap sandbox.
+ * Top-level so the renderer can reflect it the way it reflects a consumer's `@Preview`
+ * (`Class.forName("…SizeBoundsRenderTestFixturesKt")` + `getDeclaredComposableMethod`).
+ */
+@Composable
+fun WrapContentSticker() {
+  Box(modifier = Modifier.padding(16.dp)) {
+    Box(modifier = Modifier.size(56.dp).background(Color(0xFFB71C1C), RoundedCornerShape(28.dp)))
+  }
+}


### PR DESCRIPTION
## Summary

Confirms and completes support for **size overrides** — requesting a component at a constrained size (fixed `widthPx`/`heightPx`, or the `widthIn`-style `minWidthPx`/`maxWidthPx`/within bounds) so it can be reviewed the way it would render inside a container such as a list column growing to the width.

Audit of the existing pipeline found this already worked in `compose-preview serve` on the **desktop daemon** (parse → validate → cache → `RenderEngine` scene-enlarge + wrap-measure clamp + intrinsic crop; covered by `ServeOverridesTest` + `RenderEngineWrapContentTest`). Two surfaces silently dropped the wrapped-axis min/max bounds — this PR closes both so `widthIn`/within is honoured everywhere fixed size already is:

- **Android (Robolectric) daemon `RenderEngine`** — its wrap measure used `minWidth = 0` / `maxWidth = sandbox` with no reference to the bounds, so a `serve`/MCP/matrix size override against an Android module dropped the constraint. Now it enlarges the Robolectric sandbox for a min bound larger than the frame and clamps the wrap measure to `[min, max]`, mirroring the desktop daemon. The host already carries the bounds onto `spec.overrides` via `withSizeBounds`, and `parseFromPayloadOrNull` decodes them — so the production path is intact end-to-end.
- **Standalone `DesktopRendererMain`** (`composePreviewRenderAll` + `compose-preview bundle render`) — had no min/max plumbing at all, so a bundle could carry a size-mode request the export dropped. Adds min/max width/height args (positional indices 28–31), enlarges the scene, clamps the wrap measure, and fixes the crop ceiling. `BundleRenderer.buildRendererArgs` threads them from new optional `PreviewParams.{min,max}{Width,Height}Px` fields (null default → unchanged for every existing bundle), so a bundle re-render now matches what `serve` produces for the same override.

Both new paths are line-for-line mirrors of the desktop daemon's proven implementation.

## Visual evidence

This change is behavior-gated behind an explicit size override that **no committed `@Preview` / catalog sticker sets**, so no existing render diffs — there is no before/after for a committed preview to embed. The behaviour is instead pinned by new render tests that assert the cropped PNG **dimensions** for each size mode (max caps below intrinsic, min raises the floor, within preserves the 176 px intrinsic) on a wrap-content sticker fixture.

Note: the two Skiko/Robolectric **render** tests could not be executed in the authoring container — Skiko's native lib can't resolve its X11/GL closure in this Nix sandbox, which fails the *pre-existing* `RenderEngineWrapContentTest` identically. They run in CI, which has the graphics stack (and Android SDK). The pure-JVM arg-wiring test **passes here** (3/3).

## Test plan

- [x] `:cli:test --tests *BundleRendererSizeBoundsArgsTest` — export arg wiring (bounds at indices 28–31, 14–27 padded, short list when unset). **Passing locally.**
- [ ] `:renderer-desktop:test --tests *DesktopSizeBoundsRendererTest` — standalone render: max caps / min floors / within-preserves + a `main()` arg-index smoke. *(CI — needs Skiko graphics stack.)*
- [ ] `:daemon:android:test --tests *RenderEngineSizeBoundsTest` — Android render, same three cases via the base64 `overrides=` payload path. *(CI — needs Android SDK + Robolectric graphics.)*
- [x] `ktfmtFormat` on all touched modules.

_Generated by [Claude Code](https://claude.ai/code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01SNiovHYyL8Euha2BQUqn9N)_