### PR TITLE
feat(deploy/image): zero-downtime preview updates via docker-rollout

### DIFF
--- a/deploy/image/Caddyfile
+++ b/deploy/image/Caddyfile
@@ -19,7 +19,33 @@
 	# the upstream request on client disconnect — an abandoned /render/*.png|svg tab
 	# would then hold a render slot for the whole cold-render budget. WS doesn't need
 	# it (hijacked); render endpoints must keep cancel-on-disconnect.
-	reverse_proxy preview:8080 {
+	reverse_proxy {
+		# Zero-downtime rollout support. During a docker-rollout swap the `preview`
+		# service briefly has TWO replicas (old still serving + new booting), then one
+		# again. Resolve the service name via Docker's embedded DNS (127.0.0.11 inside
+		# the compose network) on a short refresh so the upstream set tracks that
+		# without a Caddy reload — a plain `reverse_proxy preview:8080` resolves once
+		# and would keep pointing at the retired container.
+		dynamic a {
+			name preview
+			port 8080
+			refresh 3s
+			resolvers 127.0.0.11
+		}
+
+		# Retry across replicas so the swap is invisible to clients: a request that
+		# lands on a just-started replica before it's accepting connections gets a dial
+		# refusal, which Caddy retries against the healthy replica within
+		# lb_try_duration (nothing was written upstream yet, so this is safe to retry).
+		# docker-rollout keeps the OLD replica up until the new one passes its /healthz
+		# healthcheck, so there's always a warm backend to retry onto. Deliberately no
+		# passive `fail_duration` / `unhealthy_status`: in steady state there's a single
+		# backend, and benching it on a transient error or an app-level 5xx would
+		# self-inflict an outage with no alternative to fail over to.
+		lb_policy least_conn
+		lb_try_duration 10s
+		lb_try_interval 250ms
+
 		transport http {
 			dial_timeout 30s
 		}

--- a/deploy/image/README.md
+++ b/deploy/image/README.md
@@ -62,20 +62,51 @@ DOMAIN=preview.example.com ./setup.sh
 Pin a version with `IMAGE_TAG=0.16.33` in `.env` (a bare tag; defaults to the
 `latest` tag when unset).
 
-## Auto-updates (Watchtower)
+## Auto-updates (zero-downtime)
 
-`docker-compose.yml` includes a
-[Watchtower](https://github.com/nicholas-fedor/watchtower) service that **watches the
-`:latest` tag and updates the `preview` container when a new release image is
-published** — so the chain is hands-off:
+Updates are **rolling** — existing traffic keeps being served on the old
+container until the new one is up and healthy, so a deploy never 502s. Two
+services split the work:
 
-> merge → cut a `v*` release → `preview-host-image.yml` publishes `:latest` →
-> Watchtower pulls it → server updates
+- **`rollout`** updates the `preview` server with
+  [docker-rollout](https://github.com/wowu/docker-rollout). It polls GHCR and,
+  when a new `:latest` lands, boots a **second** `preview` replica alongside the
+  live one, waits for that replica's `/healthz` healthcheck to pass, lets Caddy
+  drain traffic onto it, then retires the old replica. The chain stays hands-off:
 
-It polls hourly (`--interval 3600`), is scoped to the labelled services
-(`--label-enable` — the `preview` server **and** `caddy`, see below), and
-`--cleanup` prunes the old image. It needs the Docker socket (root-equivalent on
-the host — fine for your own box).
+  > merge → cut a `v*` release → `preview-host-image.yml` publishes `:latest` →
+  > `rollout` pulls it → new replica boots + goes healthy → traffic drains over →
+  > old replica retired
+
+- **`watchtower`** updates only the `caddy` reverse-proxy (below). Caddy publishes
+  fixed `80`/`443` ports, so it can't be scaled/rolled; Watchtower's in-place
+  recreate is a ~1s proxy blip, and only when the baked-Caddyfile image changes.
+
+**How the swap stays seamless.** `preview` has a Docker `healthcheck` on the
+app's ungated `/healthz` liveness route; docker-rollout won't retire the old
+replica until the new one reports `healthy`. Meanwhile the Caddyfile proxies to
+`preview` via **dynamic upstreams** (re-resolving the service's Docker DNS every
+few seconds) with cross-replica **retry**, so during the brief two-replica
+overlap a request that hits the still-booting replica is retried onto the warm
+one. Net effect: no dropped requests across an update.
+
+Both `rollout` and `watchtower` poll every `1200`s (set `ROLLOUT_INTERVAL` in
+`.env` to change the rollout cadence) and need the Docker socket (root-equivalent
+on the host — fine for your own box). `rollout` also mounts this directory
+read-only so it can `docker compose pull` + scale `preview`; the vendored
+[`docker-rollout`](./docker-rollout) plugin is mounted into the container's CLI
+plugins dir (no runtime download).
+
+> **Manual rollout.** `setup.sh` also installs the plugin on the host, so you can
+> force a zero-downtime update by hand with `sudo docker rollout preview` (or
+> `./rollout.sh`, which pulls first and only rolls if the image changed).
+
+> **Adopting this on a box first started before the project name was pinned.**
+> `docker-compose.yml` now sets `name: compose-preview` so the `rollout`
+> container's Compose commands target the same project as the host. A box brought
+> up before that change ran under the directory-derived project name, so adopt it
+> once with `docker compose down && docker compose up -d` from this directory
+> (one brief restart; rolling from then on).
 
 **The reverse-proxy config auto-deploys too.** The `caddy` service runs
 `ghcr.io/…/compose-preview-caddy:latest` — a `caddy:2` image with
@@ -112,21 +143,25 @@ Pin a specific config with `CADDY_IMAGE_TAG=sha-<commit>` in `.env`.
 > release.
 
 Requirements / options:
-- **Leave `IMAGE_TAG` unset (it defaults to the `latest` tag)** — Watchtower only
-  tracks a moving tag. A pinned `IMAGE_TAG=0.16.32` won't auto-update (by design).
+- **Leave `IMAGE_TAG` unset (it defaults to the `latest` tag)** — both pollers only
+  track a moving tag. A pinned `IMAGE_TAG=0.16.32` won't auto-update (by design).
   The value is a bare tag like `latest`, not `:latest` — the compose image string
   already supplies the colon (`…host:${IMAGE_TAG:-latest}`).
-- **Brief downtime on update:** recreating `preview` restarts it (a ~1 min window
-  where it does its startup render and Caddy 502s), then it's back. Fine for a
-  single-instance host; not zero-downtime.
-- **Private GHCR package:** mount registry creds — add
-  `- ~/.docker/config.json:/config.json:ro` to the `watchtower` service (after
-  `docker login ghcr.io`). Public packages need nothing.
-- **Notify instead of auto-update:** add `--monitor-only` to the `command` (plus a
-  [shoutrrr](https://containrrr.dev/shoutrrr/) `WATCHTOWER_NOTIFICATION_URL`) to get
-  pinged on a new version and pull manually.
-- **Don't want it at all:** comment out the `watchtower` service and update by hand
-  with `docker compose pull && docker compose up -d`.
+- **Zero-downtime updates:** the old `preview` keeps serving until the new replica
+  is healthy, so there's no 502 window (contrast the old Watchtower recreate, which
+  restarted `preview` in place for ~1 min). The swap briefly runs **two** `preview`
+  replicas; on a memory-tight shared host cap the transient overlap with
+  `PREVIEW_MEM_LIMIT` (which also lowers the derived live-seat budget per replica).
+- **Private GHCR package:** mount registry creds so the in-container pull can
+  authenticate — add `- ~/.docker/config.json:/root/.docker/config.json:ro` to the
+  `rollout` service (for `preview`) and `- ~/.docker/config.json:/config.json:ro`
+  to `watchtower` (for `caddy`), after `docker login ghcr.io`. Public packages need
+  nothing.
+- **Pause auto-rollout:** comment out the `rollout` service and update `preview` by
+  hand with `sudo docker rollout preview` (still zero-downtime) or the blunt
+  `docker compose pull preview && docker compose up -d preview` (recreates in place).
+- **Don't want any of it:** comment out both `rollout` and `watchtower` and update
+  by hand with `docker compose pull && docker compose up -d`.
 
 ### Even simpler (no Caddy/TLS — quick test)
 
@@ -145,8 +180,10 @@ docker run -d --restart always -p 8080:8080 \
 | `Dockerfile` | Downloads the released CLI, warm-renders `sample-project/`. |
 | `sample-project/` | Self-contained Compose Desktop module (foundation-only previews) + Gradle wrapper. Applies the published plugin via auto-inject. |
 | `entrypoint.sh` | Maps `$PORT`/`$SERVE_TOKEN` onto serve flags; generous `--timeout`. |
-| `docker-compose.yml` + `Caddyfile` | Pull the image + Caddy auto-HTTPS + Watchtower auto-updates. |
-| `setup.sh` | Install Docker, write `.env`, pull + start. |
+| `docker-compose.yml` + `Caddyfile` | Pull the image + Caddy auto-HTTPS + zero-downtime (`rollout`) / Watchtower auto-updates. |
+| `rollout.sh` | Poll loop / one-shot that pulls `preview` and rolls it via docker-rollout. |
+| `docker-rollout` | Vendored [docker-rollout](https://github.com/wowu/docker-rollout) CLI plugin (adds `docker rollout`). |
+| `setup.sh` | Install Docker + the docker-rollout plugin, write `.env`, pull + start. |
 
 ## Serving a different project
 

--- a/deploy/image/README.md
+++ b/deploy/image/README.md
@@ -104,9 +104,20 @@ plugins dir (no runtime download).
 > **Adopting this on a box first started before the project name was pinned.**
 > `docker-compose.yml` now sets `name: compose-preview` so the `rollout`
 > container's Compose commands target the same project as the host. A box brought
-> up before that change ran under the directory-derived project name, so adopt it
-> once with `docker compose down && docker compose up -d` from this directory
-> (one brief restart; rolling from then on).
+> up before that change ran under the **directory-derived** project name (`image`
+> when deployed the documented way, from `deploy/image/`). Because the new `name:`
+> takes precedence, a plain `docker compose down` here would target the *new,
+> empty* `compose-preview` project and leave the old stack running — colliding on
+> ports 80/443. So stop the **old** project by name first, then start the pinned
+> one:
+>
+> ```bash
+> docker compose ls                # find the old project name (e.g. `image`)
+> docker compose -p image down     # stop the OLD stack explicitly
+> docker compose up -d             # start the pinned `compose-preview` project
+> ```
+>
+> One brief restart; rolling from then on.
 
 **The reverse-proxy config auto-deploys too.** The `caddy` service runs
 `ghcr.io/…/compose-preview-caddy:latest` — a `caddy:2` image with

--- a/deploy/image/docker-compose.yml
+++ b/deploy/image/docker-compose.yml
@@ -5,9 +5,18 @@
 #
 # Pin a version with IMAGE_TAG=0.16.33 in .env (a bare tag); defaults to the latest tag.
 #
-# Auto-updates: the optional `watchtower` service (below) watches the :latest tag
-# and pulls + recreates `preview` when a new release image is published. Leave
-# IMAGE_TAG unset (it defaults to `latest`) for that to work. See README.md.
+# Auto-updates are ZERO-DOWNTIME: the `rollout` service (below) polls GHCR and,
+# when a new :latest is published, hands `preview` to docker-rollout — a fresh
+# replica boots alongside the live one, Docker waits for its /healthz healthcheck,
+# Caddy drains traffic onto it (dynamic upstreams + passive health), then the old
+# replica retires. `watchtower` still rolls `caddy` (fixed 80/443 ports can't be
+# scaled). Leave IMAGE_TAG unset (defaults to `latest`) for updates. See README.md.
+#
+# `name:` pins the Compose project name so the `rollout` container's `docker
+# compose`/`docker rollout` targets the SAME project as the host regardless of the
+# clone directory. Migrating a box first started without it is a one-time
+# `docker compose down && up -d` (see README → Auto-updates).
+name: compose-preview
 services:
   preview:
     image: "ghcr.io/yschimke/compose-preview-host:${IMAGE_TAG:-latest}"
@@ -81,18 +90,57 @@ services:
     # Set PREVIEW_MEM_LIMIT in .env (e.g. `PREVIEW_MEM_LIMIT=4g`) to cap it on a shared host, which
     # also lowers the derived seat budget to match.
     mem_limit: "${PREVIEW_MEM_LIMIT:-0}"
-    # Opt this service in to Watchtower auto-updates. Caddy is opted in too (below)
-    # via its baked-config image, so both the server and the reverse-proxy config
-    # roll automatically.
-    labels:
-      com.centurylinklabs.watchtower.enable: "true"
+    # Liveness for the rolling update. docker-rollout (driven by the `rollout`
+    # service) waits for a freshly-started replica to report `healthy` BEFORE it
+    # retires the old one, so this is the gate that makes updates zero-downtime.
+    # `/healthz` is the app's ungated liveness route (returns "ok" once the HTTP
+    # server is listening); `start_period` covers the cold-start catalog fetch +
+    # warm render so a slow boot isn't counted as a failure.
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:8080/healthz"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 90s
+    # NOT Watchtower-managed: Watchtower does an in-place stop→recreate (downtime).
+    # `preview` is updated by docker-rollout instead (see the `rollout` service),
+    # which needs the service to stay scalable — so no `container_name`, no
+    # published host ports (only `expose` above), which is already the case.
 
-  # Auto-update: poll GHCR for a new :latest digest and recreate `preview` (and
-  # `caddy`) when the release / preview-caddy-image workflow publishes one.
-  # --label-enable scopes it to the labelled services; --cleanup prunes the
-  # superseded image. Comment this service out to manage updates manually
-  # (docker compose pull && up -d). For a private GHCR package, mount a registry
-  # config: `- ~/.docker/config.json:/config.json:ro`. See README.md.
+  # Zero-downtime updater for `preview`: poll GHCR for a new :latest digest and,
+  # when one lands, roll the service with docker-rollout (boot a new replica →
+  # wait for its /healthz healthcheck → drain onto it → retire the old one) so
+  # live traffic never sees a stop→recreate gap. Needs the Docker socket (like
+  # Watchtower) and the compose project mounted read-only so it can pull + scale.
+  # The docker-rollout plugin is the vendored ./docker-rollout, mounted into the
+  # CLI plugins dir. For a private GHCR package the host daemon's creds are used
+  # for the pull (docker login ghcr.io on the host) — no in-container config.
+  # Set ROLLOUT_INTERVAL in .env to change the poll cadence (default 1200s).
+  rollout:
+    image: docker:27-cli
+    restart: always
+    depends_on:
+      - preview
+    environment:
+      ROLLOUT_INTERVAL: "${ROLLOUT_INTERVAL:-1200}"
+      ROLLOUT_HEALTH_TIMEOUT: "${ROLLOUT_HEALTH_TIMEOUT:-300}"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      # The compose project (compose file + .env) so `docker compose`/`docker
+      # rollout` can pull and scale `preview`. Read-only: compose never writes here.
+      - ./:/workspace:ro
+      # The vendored docker-rollout plugin → the CLI plugins dir (adds `docker rollout`).
+      - ./docker-rollout:/usr/local/lib/docker/cli-plugins/docker-rollout:ro
+    working_dir: /workspace
+    entrypoint: ["/bin/sh", "/workspace/rollout.sh", "--loop"]
+
+  # Auto-update for `caddy` only: poll GHCR and recreate `caddy` when the
+  # preview-caddy-image workflow publishes a new baked-Caddyfile image. `preview`
+  # is intentionally NOT labelled here — it's rolled by the `rollout` service
+  # above (zero-downtime) instead of Watchtower's in-place recreate. --label-enable
+  # scopes Watchtower to the labelled services (just `caddy`); --cleanup prunes the
+  # superseded image. Comment this out to manage caddy manually. For a private GHCR
+  # package, mount a registry config: `- ~/.docker/config.json:/config.json:ro`.
   watchtower:
     # Maintained fork of the (now-stale) containrrr/watchtower: the upstream image's
     # baked Docker SDK negotiates API 1.25, which modern engines reject ("client

--- a/deploy/image/docker-compose.yml
+++ b/deploy/image/docker-compose.yml
@@ -14,8 +14,10 @@
 #
 # `name:` pins the Compose project name so the `rollout` container's `docker
 # compose`/`docker rollout` targets the SAME project as the host regardless of the
-# clone directory. Migrating a box first started without it is a one-time
-# `docker compose down && up -d` (see README → Auto-updates).
+# clone directory. Migrating a box first started without it needs a one-time stop
+# of the OLD directory-derived project first (`docker compose -p <old> down`, e.g.
+# `-p image`) THEN `up -d` — a plain `down` would target this new name and leave
+# the old stack colliding on 80/443. See README → Auto-updates.
 name: compose-preview
 services:
   preview:

--- a/deploy/image/docker-rollout
+++ b/deploy/image/docker-rollout
@@ -1,0 +1,285 @@
+#!/bin/sh
+# Vendored copy of docker-rollout (https://github.com/wowu/docker-rollout), MIT
+# licensed, © Karol Musur. Pinned verbatim at v0.14 so the `rollout` service
+# needs no runtime `curl | sh` of an external script (no network fetch, no
+# supply-chain surprise between deploys). Bump this whole file to adopt a newer
+# release. It's a Docker CLI plugin: dropped into cli-plugins/ it adds
+# `docker rollout <service>` — a zero-downtime Compose swap (scale up, wait for
+# the new container's healthcheck, then retire the old one).
+set -e
+
+VERSION=v0.14
+
+# Defaults
+HEALTHCHECK_TIMEOUT=60
+NO_HEALTHCHECK_TIMEOUT=10
+WAIT_AFTER_HEALTHY_DELAY=0
+
+# Print metadata for Docker CLI plugin
+if [ "$1" = "docker-cli-plugin-metadata" ]; then
+  cat <<EOF
+{
+  "SchemaVersion": "0.1.0",
+  "Vendor": "Karol Musur",
+  "Version": "$VERSION",
+  "ShortDescription": "Rollout new Compose service version"
+}
+EOF
+  exit
+fi
+
+# Save docker arguments, i.e. arguments before "rollout"
+while [ $# -gt 0 ]; do
+  if [ "$1" = "rollout" ]; then
+    shift
+    break
+  fi
+
+  DOCKER_ARGS="$DOCKER_ARGS $1"
+  shift
+done
+
+# Check if compose v2 is available
+if docker compose >/dev/null 2>&1; then
+  # shellcheck disable=SC2086 # DOCKER_ARGS must be unquoted to allow multiple arguments
+  COMPOSE_COMMAND="docker $DOCKER_ARGS compose"
+elif docker-compose >/dev/null 2>&1; then
+  COMPOSE_COMMAND="docker-compose"
+else
+  echo "docker compose or docker-compose is required"
+  exit 1
+fi
+
+usage() {
+  cat <<EOF
+
+Usage: docker rollout [OPTIONS] SERVICE
+
+Rollout new Compose service version.
+
+Options:
+  -h, --help                  Print usage
+  -f, --file FILE             Compose configuration files
+  -t, --timeout N             Healthcheck timeout (default: $HEALTHCHECK_TIMEOUT seconds)
+  -w, --wait N                When no healthcheck is defined, wait for N seconds
+                              before stopping old container (default: $NO_HEALTHCHECK_TIMEOUT seconds)
+      --wait-after-healthy N  When healthcheck is defined and succeeds, wait for additional N seconds
+                              before stopping the old container (default: 0 seconds)
+      --env-file FILE         Specify an alternate environment file
+  -p, --project-name NAME     Specify an alternate project name
+      --profile NAME          Specify an alternate profile to use
+      --pre-stop-hook CMD     Run a command in the old container before stopping it.
+  -v, --version               Print plugin version
+
+EOF
+}
+
+exit_with_usage() {
+  usage
+  exit 1
+}
+
+healthcheck() {
+  # shellcheck disable=SC2086 # DOCKER_ARGS must be unquoted to allow multiple arguments
+  docker $DOCKER_ARGS inspect --format='{{json .State.Health.Status}}' "$1" | grep -v "unhealthy" | grep -q "healthy"
+}
+
+scale() {
+  # shellcheck disable=SC2086 # COMPOSE_FILES and ENV_FILES must be unquoted to allow multiple files
+  $COMPOSE_COMMAND $COMPOSE_FILES $ENV_FILES up --detach --scale "$1=$2" --no-recreate "$1"
+}
+
+main() {
+  # shellcheck disable=SC2086 # COMPOSE_FILES and ENV_FILES must be unquoted to allow multiple files
+  ALL_CONTAINER_IDS=$($COMPOSE_COMMAND $COMPOSE_FILES $ENV_FILES ps -a --quiet "$SERVICE")
+  # shellcheck disable=SC2086 # COMPOSE_FILES and ENV_FILES must be unquoted to allow multiple files
+  RUNNING_CONTAINER_IDS=$($COMPOSE_COMMAND $COMPOSE_FILES $ENV_FILES ps --quiet "$SERVICE")
+
+  # Start the service with "compose up" when no containers exist yet
+  if [ -z "$ALL_CONTAINER_IDS" ]; then
+    echo "==> Service '$SERVICE' is not running. Starting the service."
+    # shellcheck disable=SC2086 # COMPOSE_FILES and ENV_FILES must be unquoted to allow multiple files
+    $COMPOSE_COMMAND $COMPOSE_FILES $ENV_FILES up --detach --no-recreate "$SERVICE"
+    exit 0
+  fi
+
+  # Identify stopped containers (present in ps -a but not in ps --quiet)
+  STOPPED_CONTAINER_IDS=""
+  for id in $ALL_CONTAINER_IDS; do
+    if ! echo "$RUNNING_CONTAINER_IDS" | grep -qx "$id"; then
+      STOPPED_CONTAINER_IDS="$STOPPED_CONTAINER_IDS $id"
+    fi
+  done
+
+  # Remove only the stopped containers and let compose create fresh ones
+  if [ -n "$STOPPED_CONTAINER_IDS" ]; then
+    echo "==> Service '$SERVICE' has stopped containers:$STOPPED_CONTAINER_IDS. Replacing only those."
+    # shellcheck disable=SC2086 # DOCKER_ARGS and STOPPED_CONTAINER_IDS must be unquoted to allow multiple arguments
+    docker $DOCKER_ARGS rm $STOPPED_CONTAINER_IDS
+    # shellcheck disable=SC2086 # COMPOSE_FILES and ENV_FILES must be unquoted to allow multiple files
+    $COMPOSE_COMMAND $COMPOSE_FILES $ENV_FILES up --detach --no-recreate "$SERVICE"
+    exit 0
+  fi
+
+  # shellcheck disable=SC2086 # COMPOSE_FILES and ENV_FILES must be unquoted to allow multiple files
+  OLD_CONTAINER_IDS_STRING=$($COMPOSE_COMMAND $COMPOSE_FILES $ENV_FILES ps --quiet "$SERVICE" | tr '\n' '|' | sed 's/|$//')
+  OLD_CONTAINER_IDS=$(echo "$OLD_CONTAINER_IDS_STRING" | tr '|' ' ')
+  SCALE=$(echo "$OLD_CONTAINER_IDS" | wc -w | tr -d ' ')
+  SCALE_TIMES_TWO=$((SCALE * 2))
+  echo "==> Scaling '$SERVICE' to '$SCALE_TIMES_TWO' instances"
+  scale "$SERVICE" $SCALE_TIMES_TWO
+
+  # Create a variable that contains the IDs of the new containers, but not the old ones
+  # shellcheck disable=SC2086 # COMPOSE_FILES and ENV_FILES must be unquoted to allow multiple files
+  NEW_CONTAINER_IDS=$($COMPOSE_COMMAND $COMPOSE_FILES $ENV_FILES ps --quiet "$SERVICE" | grep -Ev "$OLD_CONTAINER_IDS_STRING" | tr '\n' ' ')
+
+  # Check if first container has healthcheck
+  # shellcheck disable=SC2086 # DOCKER_ARGS must be unquoted to allow multiple arguments
+  if docker $DOCKER_ARGS inspect --format='{{json .State.Health}}' "$(echo $NEW_CONTAINER_IDS | cut -d\  -f 1)" | grep -q "Status"; then
+    echo "==> Waiting for new containers to be healthy (timeout: $HEALTHCHECK_TIMEOUT seconds)"
+    for _ in $(seq 1 "$HEALTHCHECK_TIMEOUT"); do
+      SUCCESS=0
+
+      for NEW_CONTAINER_ID in $NEW_CONTAINER_IDS; do
+        if healthcheck "$NEW_CONTAINER_ID"; then
+          SUCCESS=$((SUCCESS + 1))
+        fi
+      done
+
+      if [ "$SUCCESS" = "$SCALE" ]; then
+        break
+      fi
+
+      sleep 1
+    done
+
+    SUCCESS=0
+
+    for NEW_CONTAINER_ID in $NEW_CONTAINER_IDS; do
+      if healthcheck "$NEW_CONTAINER_ID"; then
+        SUCCESS=$((SUCCESS + 1))
+      fi
+    done
+
+    if [ "$SUCCESS" != "$SCALE" ]; then
+      for NEW_CONTAINER_ID in $NEW_CONTAINER_IDS; do
+        echo "==> Health check status for container $NEW_CONTAINER_ID"
+
+        # shellcheck disable=SC2086 # DOCKER_ARGS must be unquoted to allow multiple arguments
+        docker $DOCKER_ARGS inspect --format='{{json .State.Health}}' "$NEW_CONTAINER_ID"
+
+        echo "==> Logs for container $NEW_CONTAINER_ID"
+        # shellcheck disable=SC2086 # DOCKER_ARGS must be unquoted to allow multiple arguments
+        docker $DOCKER_ARGS logs "$NEW_CONTAINER_ID"
+      done
+
+      echo "==> New containers are not healthy. Rolling back." >&2
+
+      docker $DOCKER_ARGS stop $NEW_CONTAINER_IDS
+      docker $DOCKER_ARGS rm $NEW_CONTAINER_IDS
+
+      exit 1
+    fi
+
+    if [ "$WAIT_AFTER_HEALTHY_DELAY" != "0" ]; then
+      echo "==> Waiting for healthy containers to settle down ($WAIT_AFTER_HEALTHY_DELAY seconds)"
+      sleep $WAIT_AFTER_HEALTHY_DELAY
+    fi
+  else
+    echo "==> Waiting for new containers to be ready ($NO_HEALTHCHECK_TIMEOUT seconds)"
+    sleep "$NO_HEALTHCHECK_TIMEOUT"
+  fi
+
+  # Check if pre-stop hook is defined in first old container label
+  FIRST_OLD_CONTAINER_ID=$(echo "$OLD_CONTAINER_IDS" | cut -d\  -f 1)
+  # shellcheck disable=SC2086 # DOCKER_ARGS must be unquoted to allow multiple arguments
+  PRE_STOP_HOOK=${PRE_STOP_HOOK:-$(docker $DOCKER_ARGS inspect --format='{{index .Config.Labels "docker-rollout.pre-stop-hook"}}' "$FIRST_OLD_CONTAINER_ID")}
+
+  if [ -n "$PRE_STOP_HOOK" ]; then
+    echo "==> Running pre-stop hook: $PRE_STOP_HOOK"
+
+    for OLD_CONTAINER_ID in $OLD_CONTAINER_IDS; do
+      # shellcheck disable=SC2086 # DOCKER_ARGS must be unquoted to allow multiple arguments
+      docker $DOCKER_ARGS exec "$OLD_CONTAINER_ID" sh -c "$PRE_STOP_HOOK" &
+    done
+
+    # Wait for all pre-stop hooks to finish
+    wait
+  fi
+
+  echo "==> Stopping and removing old containers"
+
+  # shellcheck disable=SC2086 # DOCKER_ARGS and OLD_CONTAINER_IDS must be unquoted to allow multiple arguments
+  docker $DOCKER_ARGS stop $OLD_CONTAINER_IDS
+  # shellcheck disable=SC2086 # DOCKER_ARGS and OLD_CONTAINER_IDS must be unquoted to allow multiple arguments
+  docker $DOCKER_ARGS rm $OLD_CONTAINER_IDS
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+  -h | --help)
+    usage
+    exit 0
+    ;;
+  -f | --file)
+    COMPOSE_FILES="$COMPOSE_FILES -f $2"
+    shift 2
+    ;;
+  --env-file)
+    ENV_FILES="$ENV_FILES --env-file $2"
+    shift 2
+    ;;
+  -p | --project-name)
+    COMPOSE_COMMAND="$COMPOSE_COMMAND --project-name $2"
+    shift 2
+    ;;
+  --profile)
+    COMPOSE_COMMAND="$COMPOSE_COMMAND --profile $2"
+    shift 2
+    ;;
+  -t | --timeout)
+    HEALTHCHECK_TIMEOUT="$2"
+    shift 2
+    ;;
+  -w | --wait)
+    NO_HEALTHCHECK_TIMEOUT="$2"
+    shift 2
+    ;;
+  --wait-after-healthy)
+    WAIT_AFTER_HEALTHY_DELAY="$2"
+    shift 2
+    ;;
+  --pre-stop-hook)
+    PRE_STOP_HOOK="$2"
+    shift 2
+    ;;
+  -v | --version)
+    echo "docker-rollout version $VERSION"
+    exit 0
+    ;;
+  -*)
+    echo "Unknown option: $1"
+    exit_with_usage
+    ;;
+  *)
+    if [ -n "$SERVICE" ]; then
+      echo "SERVICE is already set to '$SERVICE'"
+
+      if [ "$SERVICE" != "$1" ]; then
+        exit_with_usage
+      fi
+    fi
+
+    SERVICE="$1"
+    shift
+    ;;
+  esac
+done
+
+# Require SERVICE argument
+if [ -z "$SERVICE" ]; then
+  echo "SERVICE is missing"
+  exit_with_usage
+fi
+
+main

--- a/deploy/image/rollout.sh
+++ b/deploy/image/rollout.sh
@@ -63,18 +63,28 @@ roll_once() {
     log "could not resolve pulled image for '$SERVICE' — skipping"
     return 0
   fi
-  if [ -z "$before" ]; then
-    log "'$SERVICE' not running — starting via rollout"
-    docker rollout --timeout "$HEALTH_TIMEOUT" "$SERVICE"
-    return 0
-  fi
-  if [ "$before" = "$after" ]; then
+  if [ -n "$before" ] && [ "$before" = "$after" ]; then
     log "'$SERVICE' already up to date"
     return 0
   fi
-  log "new image for '$SERVICE' — rolling (health timeout ${HEALTH_TIMEOUT}s)"
-  docker rollout --timeout "$HEALTH_TIMEOUT" "$SERVICE"
-  log "'$SERVICE' rolled"
+  if [ -z "$before" ]; then
+    log "'$SERVICE' not running — starting via rollout"
+  else
+    log "new image for '$SERVICE' — rolling (health timeout ${HEALTH_TIMEOUT}s)"
+  fi
+  # Capture and return the rollout's own exit status. Don't rely on `set -e` here:
+  # errexit is suppressed whenever roll_once runs on the left of `||` (the poll
+  # loop below) or in an `if` condition, so a failed `docker rollout` would
+  # otherwise fall through to the success log and a 0 return — reporting a failed
+  # rollout as rolled. Inside the `else`, `$?` still holds the rollout exit code.
+  if docker rollout --timeout "$HEALTH_TIMEOUT" "$SERVICE"; then
+    log "'$SERVICE' rolled"
+    return 0
+  else
+    rc=$?
+    log "docker rollout failed (exit $rc)"
+    return "$rc"
+  fi
 }
 
 if [ "${1:-}" = "--loop" ]; then

--- a/deploy/image/rollout.sh
+++ b/deploy/image/rollout.sh
@@ -1,0 +1,88 @@
+#!/bin/sh
+# Zero-downtime image updates for the `preview` service via docker-rollout.
+#
+# This replaces Watchtower's in-place stop→recreate of `preview` (which 502s for
+# the whole ~1 min the new container spends booting + warm-rendering) with a
+# rolling swap: pull the new image, start a SECOND preview replica alongside the
+# live one, wait for its /healthz healthcheck to pass, let Caddy drain traffic
+# onto it (see Caddyfile — dynamic upstreams + passive health), then retire the
+# old replica. Existing traffic is served the entire time.
+#
+# Two ways to run it:
+#   ./rollout.sh          one-shot: pull + roll if the image changed (manual op)
+#   ./rollout.sh --loop   poll forever (used by the `rollout` compose service)
+#
+# Only `preview` is rolled this way — `caddy` publishes fixed 80/443 ports so it
+# can't be scaled, and stays on Watchtower's recreate (a ~1s proxy blip, and only
+# when the Caddyfile image itself changes).
+set -eu
+
+SERVICE="${ROLLOUT_SERVICE:-preview}"
+INTERVAL="${ROLLOUT_INTERVAL:-1200}"
+# docker-rollout's default healthcheck timeout is 60s; preview's cold start
+# (catalog fetch from the design-artifacts branches + warm render) can exceed
+# that, so give it room before rollout would wrongly declare the new replica
+# unhealthy and roll back.
+HEALTH_TIMEOUT="${ROLLOUT_HEALTH_TIMEOUT:-300}"
+
+log() { echo "rollout: $*"; }
+
+# The `rollout` service runs on docker:*-cli, which bundles the compose plugin on
+# current images; fall back to installing it (Alpine) if a slimmer base is used.
+# On a Debian/Ubuntu host (manual `./rollout.sh`) compose is already present, so
+# this is a no-op there.
+ensure_compose() {
+  if docker compose version >/dev/null 2>&1; then
+    return 0
+  fi
+  if command -v apk >/dev/null 2>&1; then
+    log "installing docker compose plugin"
+    apk add --no-cache docker-cli-compose >/dev/null
+  fi
+}
+
+# The image id the running container is on, vs. the id the pulled tag now points
+# at — roll only when they differ, so an unchanged poll is a cheap no-op instead
+# of churning a replica every interval.
+running_image_id() {
+  cid="$(docker compose ps -q "$SERVICE" 2>/dev/null | head -n1 || true)"
+  [ -n "$cid" ] && docker inspect --format '{{.Image}}' "$cid" 2>/dev/null || true
+}
+
+pulled_image_id() {
+  ref="$(docker compose config --images "$SERVICE" 2>/dev/null | head -n1 || true)"
+  [ -n "$ref" ] && docker image inspect --format '{{.Id}}' "$ref" 2>/dev/null || true
+}
+
+roll_once() {
+  ensure_compose
+  docker compose pull "$SERVICE" >/dev/null 2>&1 || log "pull failed (using cached image)"
+  before="$(running_image_id)"
+  after="$(pulled_image_id)"
+  if [ -z "$after" ]; then
+    log "could not resolve pulled image for '$SERVICE' — skipping"
+    return 0
+  fi
+  if [ -z "$before" ]; then
+    log "'$SERVICE' not running — starting via rollout"
+    docker rollout --timeout "$HEALTH_TIMEOUT" "$SERVICE"
+    return 0
+  fi
+  if [ "$before" = "$after" ]; then
+    log "'$SERVICE' already up to date"
+    return 0
+  fi
+  log "new image for '$SERVICE' — rolling (health timeout ${HEALTH_TIMEOUT}s)"
+  docker rollout --timeout "$HEALTH_TIMEOUT" "$SERVICE"
+  log "'$SERVICE' rolled"
+}
+
+if [ "${1:-}" = "--loop" ]; then
+  log "polling '$SERVICE' every ${INTERVAL}s for zero-downtime updates"
+  while true; do
+    roll_once || log "roll attempt failed — will retry next cycle"
+    sleep "$INTERVAL"
+  done
+else
+  roll_once
+fi

--- a/deploy/image/setup.sh
+++ b/deploy/image/setup.sh
@@ -37,6 +37,13 @@ else
   echo "==> Reusing existing .env (token preserved)"
 fi
 
+# Install the vendored docker-rollout CLI plugin so `sudo docker rollout preview`
+# works from the host shell for a manual zero-downtime update. The `rollout`
+# service does this automatically on a poll; this is just for hands-on ops.
+echo "==> Installing the docker-rollout CLI plugin"
+sudo mkdir -p /usr/local/lib/docker/cli-plugins
+sudo install -m 0755 ./docker-rollout /usr/local/lib/docker/cli-plugins/docker-rollout
+
 echo "==> Pulling the prebuilt images and starting the stack"
 # Unauthenticated pull: both GHCR packages (compose-preview-host AND
 # compose-preview-caddy, which carries the baked Caddyfile) must be PUBLIC, or this


### PR DESCRIPTION
## Summary

Watchtower updated the `preview` server with an in-place **stop → recreate**, so every release opened a ~1 min window where the new container was booting (catalog fetch + warm render) and Caddy `502`'d all live traffic. This swaps that for a **rolling** update: the old container keeps serving until the new one is healthy.

The mechanism is [docker-rollout](https://github.com/wowu/docker-rollout), gated on the app's existing ungated `/healthz` liveness route.

### What changes

- **New `rollout` service** — polls GHCR and, when a new `:latest` lands, runs `docker rollout preview`: boots a **second** `preview` replica alongside the live one, waits for its `/healthz` healthcheck, lets Caddy drain onto it, then retires the old replica. The plugin is **vendored** (`deploy/image/docker-rollout`, pinned v0.14) and mounted into the container — no runtime `curl | sh`.
- **`preview` healthcheck + off Watchtower** — a Docker `healthcheck` on `/healthz` (the gate docker-rollout waits on), and the Watchtower label removed. Watchtower now rolls **only `caddy`** (fixed `80`/`443` ports can't be scaled — its in-place recreate is a ~1s proxy blip).
- **Caddyfile dynamic upstreams + retry** — proxies to `preview` via Docker-DNS `dynamic a` (re-resolved every few seconds so the upstream set tracks the two-replica overlap) with cross-replica retry, so a request that hits the still-booting replica is retried onto the warm one. Deliberately **no** passive `fail_duration`/`unhealthy_status`: in steady state there's a single backend, and benching it on a transient error or app-level 5xx would self-inflict an outage with nothing to fail over to.
- **Pinned Compose project name** (`name: compose-preview`) so the `rollout` container's `docker compose`/`docker rollout` target the same project as the host regardless of clone dir.
- **`setup.sh`** installs the plugin host-side for manual `sudo docker rollout preview`; **`rollout.sh`** provides the poll loop / one-shot; **README** documents the flow and the one-time adoption step for boxes started before the project name was pinned.

### Why this shape (repo-specific)

The entrypoint auto-sizes `SERVE_LIVE_SEATS` from **physical RAM** when `mem_limit: 0`, so a *permanent* second replica would have each instance claim the whole box and risk OOM. docker-rollout's **transient** overlap (~1–2 min per update) keeps that bounded; the README notes capping it with `PREVIEW_MEM_LIMIT` on a memory-tight shared host.

## Test plan

- ✅ `docker-compose.yml` parses; top-level `name: compose-preview`, services `preview, rollout, watchtower, caddy`.
- ✅ `sh -n` clean on `rollout.sh` and the vendored `docker-rollout`; `bash -n` clean on `setup.sh`.
- ✅ Vendored `docker-rollout` is byte-for-byte upstream v0.14.
- ⏳ **Needs a Docker host to verify at runtime** (no Docker engine in this environment): on a preview box, `docker compose up -d`, publish a new `:latest`, and confirm `curl https://$DOMAIN/` stays 200 throughout the swap while `docker compose ps` briefly shows two `preview` replicas, then one. `sudo docker rollout preview` should do the same on demand.

This is deploy plumbing with no visual surface, so evidence is text-only.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ep4BtSL3v3S6Ff9BBgV7Nh)_