### PR TITLE
fix(cli): carry the android resource payload into split per-preview bundles

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleSplit.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleSplit.kt
@@ -104,9 +104,22 @@ internal fun splitBundleZip(
       ?: emptyList()
   val previewsArray = previews["previews"]?.jsonArray ?: JsonArray(emptyList())
 
-  // Shared re-render classpath — copied into every FULL bundle, omitted for VIEW_ONLY.
+  // Shared re-render carriage — copied into every FULL bundle, omitted for VIEW_ONLY. Besides
+  // the classpath (`classes/app.jar` + `libs/`), this carries the Android app-resource payload
+  // under `android/` (the merged `resources.ap_` table, `AndroidManifest.xml`, and the generated
+  // `r-classes.jar`): a detached daemon re-rendering an Android per-preview bundle needs the
+  // app's own `0x7f` table for `stringResource(R.string.…)` / `colorResource(…)` to resolve —
+  // the same table the monolithic `pack` bundle carries (via
+  // `BundlePreviewTask.resolveAndroidResources`, re-registered by
+  // `AndroidBundleResources.daemonClasspath`). Without it every app-resource lookup misses and
+  // renders the `⟦res 0x7f…⟧` placeholder — which only surfaces once an override forces a live
+  // per-preview re-render (a plain browse serves the baked PNG/SVG), so a per-variant knob edit
+  // on a Wear/Android sticker showed the placeholder instead of the real label.
   val shared = entries.filterKeys {
-    it == "classes/app.jar" || it.startsWith("libs/") || it == "report.json"
+    it == "classes/app.jar" ||
+      it.startsWith("libs/") ||
+      it == "report.json" ||
+      it.startsWith("android/")
   }
   val fullMode = mode == SplitMode.FULL
 
@@ -181,6 +194,12 @@ private fun perPreviewManifest(manifest: JsonObject, id: String, fullMode: Boole
         // View-only carries no re-render classpath, so record that honestly.
         "classpath" -> put(key, if (fullMode) value else JsonArray(emptyList()))
         "resolution" -> put(key, if (fullMode) value else JsonPrimitive("view-only"))
+        // The Android app-resource carriage rides the FULL re-render set (the `android/` entries
+        // copied above); a VIEW_ONLY bundle ships none of it, so drop the manifest pointer too
+        // rather than advertise a `resources.ap_` table the zip doesn't carry (mirrors emptying
+        // `classpath`). A FULL bundle keeps the pointer, now backed by the carried `android/`
+        // files.
+        "androidResources" -> if (fullMode) put(key, value)
         // Keep only this preview's intermediate representation (empty for classpath-backed
         // previews).
         "intermediateRepresentations" ->

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleSplitTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleSplitTest.kt
@@ -141,4 +141,78 @@ class BundleSplitTest {
     val a2 = splitBundleZip(sheetZip(), SplitMode.VIEW_ONLY).first { it.id == "A" }
     assertContentEquals(a1.zipBytes, a2.zipBytes)
   }
+
+  /**
+   * An Android sheet also carries the app-resource payload under `android/` (the merged
+   * `resources.ap_` table, manifest, and generated R classes) plus an `androidResources` manifest
+   * pointer — the carriage a detached daemon needs to resolve `stringResource(R.string.…)`.
+   */
+  private fun androidSheetZip(): ByteArray {
+    val entries =
+      linkedMapOf(
+        "bundle.json" to
+          """
+          {"schemaVersion":8,"backend":"android","previewIds":["A"],
+           "coverPreviewId":"A","resolution":"coordinates",
+           "classpath":[{"kind":"module","path":"classes/app.jar"}],
+           "androidResources":{"resourceApkPath":"android/resources.ap_",
+             "mergedManifestPath":"android/AndroidManifest.xml",
+             "rClassesJarPath":"android/r-classes.jar",
+             "applicationPackage":"com.example.app"},
+           "intermediateRepresentations":[],"dataExtensions":[]}
+          """
+            .trimIndent()
+            .encodeToByteArray(),
+        "previews.json" to """{"schemaVersion":8,"previews":[{"id":"A"}]}""".encodeToByteArray(),
+        "previews/A.png" to "PNG-A".encodeToByteArray(),
+        "classes/app.jar" to ByteArray(2048) { 1 },
+        "android/resources.ap_" to ByteArray(1024) { 7 },
+        "android/AndroidManifest.xml" to "<manifest/>".encodeToByteArray(),
+        "android/r-classes.jar" to ByteArray(512) { 9 },
+      )
+    val baos = ByteArrayOutputStream()
+    ZipOutputStream(baos).use { zout ->
+      for ((name, bytes) in entries) {
+        zout.putNextEntry(ZipEntry(name))
+        zout.write(bytes)
+        zout.closeEntry()
+      }
+    }
+    return baos.toByteArray()
+  }
+
+  @Test
+  fun `full split carries the android app-resource payload so a detached daemon resolves stringResource`() {
+    val a = splitBundleZip(androidSheetZip(), SplitMode.FULL).first { it.id == "A" }
+    val entries = readEntries(a.zipBytes)
+
+    // The whole `android/` carriage travels into the per-preview bundle — the merged resource APK,
+    // the manifest, and the generated R classes — matching what the monolithic pack carries.
+    assertTrue("android/resources.ap_" in entries, "merged resource APK must travel")
+    assertTrue("android/AndroidManifest.xml" in entries, "merged manifest must travel")
+    assertTrue("android/r-classes.jar" in entries, "generated R classes must travel")
+    assertContentEquals(ByteArray(1024) { 7 }, entries.getValue("android/resources.ap_"))
+
+    // The manifest keeps its `androidResources` pointer, now backed by the carried files.
+    val manifest =
+      json.parseToJsonElement(entries.getValue("bundle.json").decodeToString()).jsonObject
+    val res = manifest["androidResources"]!!.jsonObject
+    assertEquals("android/resources.ap_", res["resourceApkPath"]!!.jsonPrimitive.content)
+    assertEquals("com.example.app", res["applicationPackage"]!!.jsonPrimitive.content)
+  }
+
+  @Test
+  fun `view-only split drops the android payload and its manifest pointer`() {
+    val a = splitBundleZip(androidSheetZip(), SplitMode.VIEW_ONLY).first { it.id == "A" }
+    val entries = readEntries(a.zipBytes)
+
+    // A baked, non-re-rendering sticker carries no `android/` payload…
+    assertFalse(entries.keys.any { it.startsWith("android/") })
+    // …and doesn't advertise a `resources.ap_` table it isn't shipping.
+    val manifest =
+      json.parseToJsonElement(entries.getValue("bundle.json").decodeToString()).jsonObject
+    assertFalse("androidResources" in manifest)
+    // The baked image still travels.
+    assertTrue("previews/A.png" in entries)
+  }
 }

--- a/samples/design-catalog-wear-m3/catalog.spec.json
+++ b/samples/design-catalog-wear-m3/catalog.spec.json
@@ -71,7 +71,8 @@
     {
       "name": "Communication",
       "components": [
-        { "componentId": "Progress/Circular", "preview": "CircularProgressSticker" }
+        { "componentId": "Progress/Circular", "preview": "CircularProgressSticker" },
+        { "componentId": "Progress/Circular/Indeterminate", "preview": "IndeterminateCircularProgressSticker", "caption": "Indeterminate (animated) progress ring — the no-progress overload sweeps continuously; animates in the live preview." }
       ]
     },
     {

--- a/samples/design-catalog-wear-m3/src/main/kotlin/com/example/designcatalogwearm3/CatalogPreviews.kt
+++ b/samples/design-catalog-wear-m3/src/main/kotlin/com/example/designcatalogwearm3/CatalogPreviews.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.wear.compose.foundation.lazy.TransformingLazyColumn
 import androidx.wear.compose.foundation.lazy.items
@@ -59,6 +60,7 @@ import androidx.wear.compose.material3.lazy.transformedHeight
 import androidx.wear.compose.material3.timeTextCurvedText
 import ee.schimke.composeai.overrides.previewOverrideBoolean
 import ee.schimke.composeai.overrides.previewOverrideString
+import ee.schimke.composeai.preview.AnimatedPreview
 import ee.schimke.composeai.preview.ScrollMode
 import ee.schimke.composeai.preview.ScrollingPreview
 import ee.schimke.composeai.preview.slots.PreviewSlot
@@ -488,6 +490,33 @@ fun CircularProgressSticker() =
   // Determinate at a fixed 66% (matching the remote `Progress/Circular` parallel) rather than the
   // animated indeterminate overload, so the static capture is deterministic and the pair lines up.
   WearSticker { CircularProgressIndicator(progress = { 0.66f }, modifier = Modifier.size(72.dp)) }
+
+// The **indeterminate** counterpart to [CircularProgressSticker]: the animated Wear M3 progress
+// ring — the no-`progress` overload — sweeping continuously rather than sitting at a fixed value.
+// In the live interactive stream the held composition's clock advances by the wall-clock delta, so
+// the sweep actually animates (`CircularProgressIndicator`'s indeterminate mode is a
+// `rememberInfiniteTransition`); a static capture freezes it at the paused-clock frame, which is
+// deterministic because the renderer parks infinite animations at a fixed advance (see AGENTS.md —
+// "indeterminate CircularProgressIndicator" is a called-out case). Sized to match the determinate
+// sticker so the pair frames alike.
+@CatalogWearModes
+@Composable
+fun IndeterminateCircularProgressSticker() =
+  WearSticker { CircularProgressIndicator(modifier = Modifier.size(72.dp)) }
+
+// The same indeterminate ring captured as an **animated GIF** — the shareable, self-playing form of
+// the spinner (the static sticker above only moves in the live interactive lane). `@AnimatedPreview`
+// drives the paused clock across the animation window and encodes `renders/<id>.gif`;
+// `showCurves = false` keeps it a screenshot-only GIF (no debug curve-plot panel), and the duration
+// auto-detects from the indeterminate `InfiniteTransition`'s iteration so the loop is seamless.
+// Standalone, not a `catalog.spec` component: the sticker-sheet join represents each component as a
+// static PNG, so a GIF-primary preview travels in the bundle as `previews/<id>.gif` (same treatment
+// as `CardScalingScrollGif`) rather than becoming a grid sticker.
+@Preview(showBackground = false)
+@AnimatedPreview(showCurves = false)
+@Composable
+fun IndeterminateCircularProgressGif() =
+  WearSticker { CircularProgressIndicator(modifier = Modifier.size(72.dp)) }
 
 // ---------------------------------------------------------------------------
 // Text options — exercises the maxLines / overflow product on a round screen.


### PR DESCRIPTION
## Summary

Fixes the wear-m3 live-preview bug where the button label (and any `stringResource`) renders as `⟦res 0x7f0a0022⟧` the moment an interactive override is applied, plus adds an animated indeterminate `CircularProgressIndicator` to the wear-m3 catalog.

### Root cause of the text failure

`compose-preview bundle split` turns a packed sheet into one self-contained bundle per preview, but its **shared re-render carriage only copied `classes/app.jar` + `libs/` + `report.json`** — it dropped the `android/` app-resource payload (the merged `resources.ap_` table, `AndroidManifest.xml`, generated `r-classes.jar`) that `bundle pack` carries for every Android bundle.

So a FULL-mode Android **per-preview** bundle shipped no `0x7f` resource table. Because the serve viewer routes an **override-bearing** render to the per-preview daemon (`ServeCatalogLiveHost` → `perPreviewResolve`), every `stringResource(R.string.…)` lookup missed and hit the missing-resource placeholder:

| Request | Route | Result |
|---|---|---|
| no override | baked PNG/SVG | ✅ real text |
| `?knob.label=Hello` | per-preview daemon, label overridden | ✅ "Hello" (no resource lookup) |
| `?knob.theme.colors=…` (label falls to `stringResource`) | per-preview daemon | ❌ `⟦res 0x7f0a0022⟧` |

That third row is exactly the reported "text fails once interactive previews start" — reproduced live against `preview.coo.ee` before the fix.

### The fix (`BundleSplit.kt`)

- Include the `android/` entries in the FULL shared set, alongside the classpath — mirroring what the monolithic `pack` bundle carries (`BundlePreviewTask.resolveAndroidResources`, re-registered by `AndroidBundleResources.daemonClasspath`).
- Drop the `androidResources` manifest pointer in `VIEW_ONLY` (a baked sticker that ships no `android/` payload must not advertise a table it lacks) — mirrors how `classpath` is emptied there.

### Also: indeterminate `CircularProgressIndicator` for wear-m3

- `IndeterminateCircularProgressSticker` — the static catalog sticker (the no-`progress` overload), registered as `Progress/Circular/Indeterminate`. It **animates in the live interactive lane** (the held clock advances by the wall-clock delta); a static capture freezes it deterministically at the paused-clock frame.
- `IndeterminateCircularProgressGif` — the same ring as an **animated GIF** via `@AnimatedPreview(showCurves = false)` (standalone, like the existing `CardScalingScrollGif`).

## Test plan

- `./gradlew :cli:test` — green, including two new `BundleSplitTest` cases proving a FULL Android split carries the whole `android/` payload + keeps the manifest pointer, and a VIEW_ONLY split drops both.
- `./gradlew :cli:ktfmtCheckMain :cli:ktfmtCheckTest :samples:design-catalog-wear-m3:ktfmtCheck` — green.
- `./gradlew :samples:design-catalog-wear-m3:composePreviewRenderAll` — BUILD SUCCESSFUL; renders both `IndeterminateCircularProgressSticker.png` and the animated `IndeterminateCircularProgressGif.gif`.

## Visual evidence

The two new renders (static PNG + animated GIF) were produced locally and shared with the requester. I could not inline-host the ephemeral `build/` renders from this container, so the wear-m3 catalog's PR preview-diff bot is the inline record on this PR; after merge the `design-artifacts/wear-m3` regen publishes them at their committed URLs. The `BundleSplit` change itself is non-visual plumbing.

## Follow-up after merge

Regenerate the delivery branches so the deployed server picks up resource-carrying per-preview bundles: dispatch `design-artifacts.yml` on `main` (it builds the CLI from source, so no CLI release is needed). The catalog auto-refresh then re-fetches `design-artifacts/wear-m3`, and interactive overrides render real text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_Session: https://claude.ai/code/session_013bRuLkmxdngn3j5oX61avn_

---
_Generated by [Claude Code](https://claude.ai/code/session_013bRuLkmxdngn3j5oX61avn)_