### PR TITLE
chore(deploy): drop cadence from the default unlisted catalogs

### DIFF
--- a/deploy/image/entrypoint.sh
+++ b/deploy/image/entrypoint.sh
@@ -36,7 +36,7 @@ fi
 # /<system>/ (and ?session=<system>) but off the front-page nav. <system>@<owner>/<repo>
 # points at a per-repo design-artifacts branch, which must be trusted (see the store
 # below) to badge Trusted. Override with your own list, or `none` to serve none.
-: "${SERVE_CATALOGS_UNLISTED:=meshcore-mobile@yschimke/meshcore-mobile,homeassistant-remotecompose@yschimke/homeassistant-remotecompose,cadence@yschimke/cadence}"
+: "${SERVE_CATALOGS_UNLISTED:=meshcore-mobile@yschimke/meshcore-mobile,homeassistant-remotecompose@yschimke/homeassistant-remotecompose}"
 [[ "${SERVE_CATALOGS_UNLISTED}" != "none" ]] && args+=(--catalogs-unlisted "${SERVE_CATALOGS_UNLISTED}")
 # Default to the baked branch-trust store so the published design-artifacts catalogs
 # badge as Trusted(Branch) out of the box. `:=` fills it when SERVE_TRUST_STORE is

--- a/deploy/vps/docker-compose.yml
+++ b/deploy/vps/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       # front-page nav — reachable at /<system>/ (and ?session=<system>). <system>@<owner>/<repo>
       # points serve at each app's design-artifacts/<system> branch; those branches are in
       # trust/producers.json so they badge Trusted(Branch).
-      SERVE_CATALOGS_UNLISTED: "${SERVE_CATALOGS_UNLISTED:-meshcore-mobile@yschimke/meshcore-mobile,homeassistant-remotecompose@yschimke/homeassistant-remotecompose,cadence@yschimke/cadence}"
+      SERVE_CATALOGS_UNLISTED: "${SERVE_CATALOGS_UNLISTED:-meshcore-mobile@yschimke/meshcore-mobile,homeassistant-remotecompose@yschimke/homeassistant-remotecompose}"
       SERVE_TRUST_STORE: "${SERVE_TRUST_STORE:-trust/producers.json}"
       SERVE_WASM_DIR: "${SERVE_WASM_DIR:-compose-m3=samples/cmp-wasm-catalog/build/wasmDist}"
       # Live (daemon-backed) server-side re-render. Now that compose-m3 is a

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -24,7 +24,7 @@
    alongside `--catalogs-unlisted meshcore-mobile@yschimke/meshcore-mobile` from the app's own repo.
    `--catalogs-unlisted` serves a system exactly like `--catalogs` but groups it under a separate
    **"Apps"** section on the front page instead of the **"Design systems"** section — the app
-   catalogs (meshcore-mobile, cadence, …) still surface on the landing page, just under their own
+   catalogs (meshcore-mobile, …) still surface on the landing page, just under their own
    heading and kept off the in-catalog "Design systems" nav row. Reachable at `/<system>/` (and
    `?session=`) like any catalog. Every catalog's branch (whatever repo) must be in the
    `--trust-store` to badge `Trusted(Branch)`; otherwise it serves `Unverified` (the data tiers serve
@@ -122,7 +122,7 @@ compose-preview serve \
   --public \                              # open every route (no token)
   --catalogs compose-m3,wear-m3,remote-m3 \  # published design systems, listed on the front-page index
   --catalogs-unlisted \                   # served at /<system>/ but hidden from the nav; each from its own repo
-      meshcore-mobile@yschimke/meshcore-mobile,homeassistant-remotecompose@yschimke/homeassistant-remotecompose,cadence@yschimke/cadence \
+      meshcore-mobile@yschimke/meshcore-mobile,homeassistant-remotecompose@yschimke/homeassistant-remotecompose \
   --trust-store trust/producers.json \    # who we trust (must list every catalog's branch/repo)
   --host 0.0.0.0 --port 8080
 
@@ -191,7 +191,7 @@ out — which also means a bare image pull self-heals a box without editing its 
 
 The **catalog set is baked into the image the same way**: the entrypoint defaults `SERVE_CATALOGS`
 to `compose-m3,wear-m3,remote-m3` (front-page index) and `SERVE_CATALOGS_UNLISTED` to
-`meshcore-mobile@yschimke/meshcore-mobile,homeassistant-remotecompose@yschimke/homeassistant-remotecompose,cadence@yschimke/cadence`
+`meshcore-mobile@yschimke/meshcore-mobile,homeassistant-remotecompose@yschimke/homeassistant-remotecompose`
 (served at `/<system>/`, off the nav). So a bare `docker pull` / Watchtower update serves them
 without editing the box's compose. Override either with your own comma list, or `none` to serve none
 of that kind (empty inherits the baked default). The `deploy/vps` from-source path still sets these


### PR DESCRIPTION
Removes `cadence@yschimke/cadence` from the baked `SERVE_CATALOGS_UNLISTED` defaults so it no longer surfaces as a card on the preview front page (`preview.coo.ee`).

## What changed
- `deploy/vps/docker-compose.yml` and `deploy/image/entrypoint.sh` — drop `cadence@yschimke/cadence` from the default `SERVE_CATALOGS_UNLISTED` value. `meshcore-mobile` and `homeassistant-remotecompose` stay.
- `docs/public-preview-server.md` — the example commands + prose updated to match.

Those two defaults are the only places cadence is hard-coded into the served catalog set (`deploy/cloudrun/entrypoint.sh` reads the env var without a default; the `integration.yml` build-matrix entry and the `serve-home-index` test fixture are unrelated to the deployed front page). A deployment that still wants cadence can set `SERVE_CATALOGS_UNLISTED` explicitly.

Deploy-config + docs only — no code or rendered output changes.

_Generated by [Claude Code]_

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBurh9kb3NJ2KsmYRFhU62)_