### PR TITLE
fix(wear-m3): keep the catalog's own authored locales

### DIFF
--- a/samples/design-catalog-wear-m3/build.gradle.kts
+++ b/samples/design-catalog-wear-m3/build.gradle.kts
@@ -23,6 +23,25 @@ composePreview {
   sdkVersion.set(35)
 }
 
+// The locales this catalog localises — its own `values-<locale>` string-resource dirs plus the `en`
+// default — consumed by `androidResources.localeFilters` below to keep exactly these and drop the
+// further ~68 locales the AAR dependencies ship (wear-compose / compose-ui). That keeps this
+// catalog's real translations available to the renderer's locale-override picker while dropping
+// ~470 KB of otherwise-dead `resources.arsc` string data. Derived from the resource dirs so a new
+// `values-<locale>` translation is covered automatically.
+val wearCatalogAuthoredLocales: List<String> =
+  (listOf("en") +
+      projectDir
+        .resolve("src/main/res")
+        .listFiles()
+        .orEmpty()
+        .map { it.name }
+        .filter { it.startsWith("values-") }
+        .map { it.removePrefix("values-") }
+        .filter { it.matches(Regex("[a-z]{2}(-r[A-Z]{2})?")) })
+    .distinct()
+    .sorted()
+
 android {
   namespace = "com.example.designcatalogwearm3"
   // wear-compose 1.7.0-alpha requires `compileSdk = 37`; override the conventions `compileSdk =
@@ -39,16 +58,13 @@ android {
 
   buildFeatures { compose = true }
 
-  // English-only resource table. wear-compose / compose-ui ship their strings translated into ~86
-  // locales, so the merged unit-test resource APK (`apk-for-local-test.ap_`, which every packed
-  // bundle carries) devotes ~500 KB of its `resources.arsc` to ~13 000 translated string values —
-  // for strings this English-only Compose catalog never displays. The renderer runs single-locale
-  // (Robolectric's default en_US resolves to the unqualified `()` config), so the other 85 locales
-  // are pure dead weight. `localeFilters` drops them at resource-merge time — the APK is born
-  // small,
-  // no post-hoc `resources.arsc` surgery, bundles stay self-contained. The default (English) config
-  // is always retained, so every specimen still renders its real text.
-  androidResources { localeFilters += listOf("en") }
+  // Keep only the locales this catalog localises (wearCatalogAuthoredLocales) — the `en` default
+  // plus its own `values-<locale>` translations — and drop the further ~68 locales the AAR
+  // dependencies ship but this catalog never provides. Those AAR-only locales are dead weight
+  // (~470 KB of `resources.arsc` string data nothing here renders); dropping them at resource-merge
+  // time keeps bundles self-contained with no post-hoc `resources.arsc` surgery, while the
+  // renderer's locale-override picker still resolves this catalog's real translations.
+  androidResources { localeFilters += wearCatalogAuthoredLocales }
 
   testOptions { unitTests.all { it.jvmArgs("-Xmx2048m") } }
 }


### PR DESCRIPTION
## Summary

Follow-up to #2563. That PR's `localeFilters += listOf("en")` shrank the merged resource table by dropping all non-default locales — but it also dropped this catalog's **own** 17 authored translations (`values-ar` … `values-zh-rTW`), which the renderer's **locale-override picker** relies on to render localised text. Only the ~68 *additional* locales the AAR dependencies ship (and this catalog never provides) are true dead weight.

This filters to exactly the locales the catalog localises — `en` plus its own `values-<locale>` dirs, **derived** from the resource tree so a new translation dir is covered automatically — instead of `en` only.

| | #2563 (en-only) | this PR (authored locales) | original |
|---|--:|--:|--:|
| `resources.arsc` | 54 KB | 179 KB | 650 KB |
| module `apk-for-local-test.ap_` | 156 KB | 281 KB | 1.86 MB |
| packed bundle (after drawable prune) | 57 KB | ~181 KB | — |

The kept locales carry the AARs' translations for those locales too (`localeFilters` can't distinguish catalog-authored from dependency strings) — that's the 54 → 179 KB cost — but it's still far below the 650 KB / 1.86 MB we started from, and the catalog's i18n is intact.

## Rendered output is unchanged
The preview render is single-locale (`en_US` → the unqualified default), so the baked catalog PNGs are byte-identical to #2563 — this only restores the **bundled** translations that the live locale-override picker resolves. Text-only change; no visual diff.

## Test plan
- `:samples:design-catalog-wear-m3:packageDebugUnitTestForUnitTest` — BUILD SUCCESSFUL (the derived `localeFilters` evaluates cleanly under the configuration cache).
- `aapt2 dump resources`: **19 locale configs** retained (the 17 authored + `id`/`pt` normalisation aliases); `activity_heart_rate` resolves `(de) "Herzfrequenz"`, `(ja) "心拍数"`, `(ru) "Пульс"`, … ; **Zulu** and the other AAR-only locales are dropped (0 occurrences).

## Note
The delivery branches (`design-artifacts/wear-m3`) will need a regen after this merges (already the standing post-merge step); the earlier `design-artifacts.yml` dispatch reflects #2563's en-only table, so it'll be re-run once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013bRuLkmxdngn3j5oX61avn

---
_Generated by [Claude Code](https://claude.ai/code/session_013bRuLkmxdngn3j5oX61avn)_