### PR TITLE
fix(design-artifacts): link README htmlpreview URLs at the publishing repo

### DIFF
--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -486,6 +486,17 @@ const result = await writeCatalog(catalog, outPath, { sourceRoot });
 const previewBase =
   values["preview-base"] || process.env.PREVIEW_SERVER_BASE || DEFAULT_PREVIEW_BASE;
 
+// The repo whose `design-artifacts/<system>` branch this bundle publishes to — it
+// owns the htmlpreview links (index/compare/matches) the README emits and the raw
+// asset URLs the cross-system page bakes. Comes from `--source-repo` (each
+// design-artifacts workflow passes its own `${GITHUB_REPOSITORY}`), then
+// $GITHUB_REPOSITORY, and finally this repo. Getting this right is why a bundle
+// published from a *sibling* repo (e.g. meshcore-mobile, which runs this generator
+// against a compose-ai-tools checkout) links its README at its OWN branch instead
+// of 404-ing against compose-ai-tools.
+const repo =
+  values["source-repo"] || process.env.GITHUB_REPOSITORY || "yschimke/compose-ai-tools";
+
 // Bundle the in-browser CMP Wasm app into the branch (out/web/wasm/) and record
 // a `webRender` descriptor in catalog.json. `compose-preview serve --catalogs`
 // reads that descriptor and fetches these exact files from the same trusted
@@ -778,7 +789,6 @@ if (spec.compareWith) {
     // fetched manifest may be one generation stale (both branches regenerate in the
     // same workflow run), but the baked image URLs point at the branch tip, so the
     // pixels stay current — only a brand-new sibling component waits a run.
-    const repo = values["source-repo"] || process.env.GITHUB_REPOSITORY || "yschimke/compose-ai-tools";
     const otherCatalogUrl = `https://raw.githubusercontent.com/${repo}/design-artifacts/${spec.compareWith}/catalog.json`;
     const otherManifest = await fetchJsonBestEffort(otherCatalogUrl);
     if (otherManifest) {
@@ -843,6 +853,7 @@ await writeFile(
     imageCount: result.imageCount,
     wireframeCount,
     figmaSvgCount,
+    repo,
     previewBase,
     crossSystem,
   }),

--- a/scripts/design-artifacts/render-readme-md.test.mjs
+++ b/scripts/design-artifacts/render-readme-md.test.mjs
@@ -1,0 +1,53 @@
+/**
+ * Unit tests for the `README.md` committed into each `design-artifacts/<system>`
+ * branch. The README is the landing page a designer hits first on GitHub, and its
+ * prominent links (index / compare / matches) are htmlpreview URLs pinned to a
+ * specific repo + branch. The repo MUST be the one the branch actually publishes
+ * to — a bundle generated from a sibling repo (meshcore-mobile runs this same
+ * generator against a compose-ai-tools checkout, then force-pushes to its OWN
+ * `design-artifacts/meshcore-mobile` branch) has to link at that sibling, not at
+ * the default compose-ai-tools, or every htmlpreview link 404s.
+ *
+ * Run with `node --test scripts/design-artifacts/`.
+ */
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { renderReadmeMd } from "./render-readme-md.mjs";
+
+const catalog = {
+  meta: {
+    system: "meshcore-mobile",
+    title: "MeshCore Mobile",
+    library: ["androidx.compose.material3"],
+    renderer: "compose-preview 0.16.54",
+  },
+  components: [
+    { componentId: "Button/Filled", group: "Buttons", images: [{ path: "images/a.png" }] },
+    { componentId: "Card/Outlined", group: "Cards", images: [{ path: "images/b.png" }] },
+  ],
+};
+
+test("htmlpreview links point at the given repo's branch, not the default", () => {
+  const md = renderReadmeMd(catalog, { repo: "yschimke/meshcore-mobile" });
+  const branch = "design-artifacts/meshcore-mobile";
+  for (const page of ["index.html", "compare.html"]) {
+    const url = `https://htmlpreview.github.io/?https://github.com/yschimke/meshcore-mobile/blob/${branch}/${page}`;
+    assert.ok(md.includes(url), `expected README to link ${page} at ${url}`);
+  }
+  // The default repo must NOT leak into a sibling repo's README — that's the 404.
+  assert.ok(
+    !md.includes("github.com/yschimke/compose-ai-tools/blob/design-artifacts/meshcore-mobile"),
+    "sibling README must not link its branch under compose-ai-tools",
+  );
+});
+
+test("repo defaults to compose-ai-tools when none is given", () => {
+  const md = renderReadmeMd(catalog);
+  assert.ok(
+    md.includes(
+      "https://htmlpreview.github.io/?https://github.com/yschimke/compose-ai-tools/blob/design-artifacts/meshcore-mobile/index.html",
+    ),
+    "default repo should remain yschimke/compose-ai-tools",
+  );
+});


### PR DESCRIPTION
## Summary

The design parity report (`compare.html`) for **meshcore-mobile** failed to open via htmlpreview with a 404 followed by a CORS-proxy failure:

```
github.com/yschimke/compose-ai-tools/blob/design-artifacts/meshcore-mobile/compare.html → 404
api.codetabs.com/v1/proxy/?quest=…/compose-ai-tools/design-artifacts/meshcore-mobile/compare.html → blocked by CORS
```

Root cause: `renderReadmeMd` hard-defaults its `repo` to `yschimke/compose-ai-tools`, and `generate-design-catalog.mjs` never passed one through. The **meshcore-mobile** repo runs this same generator against a compose-ai-tools checkout and force-pushes to its **own** `design-artifacts/meshcore-mobile` branch (`${GITHUB_REPOSITORY}` = `yschimke/meshcore-mobile`). But the generated README linked its `index.html` / `compare.html` / `matches.html` under `yschimke/compose-ai-tools`, where that branch doesn't exist — so htmlpreview 404s and drops through to its (currently failing) codetabs CORS proxy.

## Fix

- Resolve `repo` once (from `--source-repo`, then `$GITHUB_REPOSITORY`, then the compose-ai-tools default) and thread it into `renderReadmeMd`, so the htmlpreview links point at the branch that actually holds the report.
- Reuse that same resolved `repo` for the cross-system `matches.html` page instead of recomputing it locally.
- Each `design-artifacts.yml` workflow already passes its own `--source-repo`, so compose-ai-tools' own catalogs are unchanged (they resolve to `yschimke/compose-ai-tools`) and meshcore-mobile now resolves to `yschimke/meshcore-mobile`.

## Test plan

- New `render-readme-md.test.mjs`: asserts the htmlpreview links point at the given repo's branch (and that the default repo does not leak into a sibling's README — the exact 404), plus the default-repo fallback.
- `node --test scripts/design-artifacts/` — all 127 tests pass.

## Follow-up (post-merge)

The already-published `design-artifacts/meshcore-mobile` branch still carries the old README (its links are generated from `compose-ai-tools@main`). After this merges, re-dispatch **meshcore-mobile**'s `Design Artifacts` workflow to regenerate that branch with the corrected links. compose-ai-tools' own `design-artifacts/{compose-m3,wear-m3,remote-m3}` branches are unaffected but will pick up the (identical) links on their next regen.

_Generated by [Claude Code]_

---
_Generated by [Claude Code](https://claude.ai/code/session_01PPcAhcjBHfqTMHWUsRNCkE)_