### PR TITLE
feat(catalog): infer each theme's supported light/dark mode(s)

### DIFF
--- a/docs/design/m3-catalog-app-palette.md
+++ b/docs/design/m3-catalog-app-palette.md
@@ -30,6 +30,24 @@ scheme:l=<role>:<AARRGGBB>,<role>:<AARRGGBB>,…;d=<role>:<AARRGGBB>,…
 
 Encoder: `serializeCatalogColorScheme(light, dark)`.
 
+### Light/dark support per theme
+
+A theme baked or shown in a mode it doesn't define renders an auto-derived variant its author never
+intended (a light-only palette force-darkened to muddy greys), so a consumer that enumerates
+variants — an exporter baking per-mode PNGs, the landing's Light/Dark selector — asks
+`catalogThemeModes(value)` which modes a theme actually supports and offers only those. Generating
+both modes for a single-mode theme just makes 50% of the output unusable.
+
+| Theme (`theme.colors`) | Light | Dark | How it's determined |
+| --- | :---: | :---: | --- |
+| `M3` (and any unknown name) | ✅ | ✅ | Declared — the stock M3 light/dark scheme. |
+| `Coral` | ✅ | — | Declared — a fixed **light** brand scheme. |
+| `Teal` | — | ✅ | Declared — a fixed **dark** brand scheme. |
+| `scheme:…` app palette | if `l=` | if `d=` | **Inferred** from which mode segments carry usable roles — reusing the same decoder the renderer uses, so it can't disagree with what actually renders; a blob with neither mode falls back to both. |
+
+So a meshcore palette serialized with both `l=` and `d=` segments is offered in both modes, while an
+app that ships only a light palette (`scheme:l=…`) is never baked or shown dark.
+
 ## `theme.shapes` — a serialized `Shapes`
 
 ```

--- a/samples/design-catalog-m3-shared/src/commonMain/kotlin/com/example/designcatalogm3/shared/CatalogThemeChoices.kt
+++ b/samples/design-catalog-m3-shared/src/commonMain/kotlin/com/example/designcatalogm3/shared/CatalogThemeChoices.kt
@@ -83,6 +83,47 @@ fun catalogColorScheme(name: String, dark: Boolean): ColorScheme {
   }
 }
 
+/** A display mode a catalog theme can be rendered in. */
+enum class CatalogThemeMode {
+  LIGHT,
+  DARK,
+}
+
+/** Light + dark — the both-modes result, shared so the common case allocates once. */
+private val CATALOG_THEME_MODES_BOTH = setOf(CatalogThemeMode.LIGHT, CatalogThemeMode.DARK)
+
+/**
+ * The display mode(s) the `theme.colors` value [name] is actually designed for. A theme baked or
+ * shown in a mode it doesn't define renders an auto-derived variant its author never intended (a
+ * light-only brand palette force-darkened to muddy greys), so a consumer that enumerates variants —
+ * an exporter baking per-mode PNGs, the landing's Light/Dark selector — should offer only these
+ * modes rather than a fixed both, or half the output is unusable.
+ * - A **serialized app palette** ([CATALOG_COLORS_SCHEME_PREFIX] blob) is inferred from which mode
+ *   segments actually carry usable roles: only `l=…` ⇒ light-only, only `d=…` ⇒ dark-only, both ⇒
+ *   both. Inference reuses [parseCatalogColorScheme], so it can never disagree with what
+ *   [catalogColorScheme] would render; a blob with no usable mode (malformed/empty) falls back to
+ *   both, mirroring [catalogColorScheme]'s stock-M3 fallback for an unparseable value.
+ * - A **named palette** is declared: [CATALOG_PALETTE_CORAL] is light-only and
+ *   [CATALOG_PALETTE_TEAL] is dark-only (each a fixed-tone scheme [catalogColorScheme] returns
+ *   regardless of the requested mode), while [CATALOG_PALETTE_M3] and any unknown name are the
+ *   stock M3 scheme — both modes.
+ *
+ * Always non-empty. Documented per theme in `docs/design/m3-catalog-app-palette.md`.
+ */
+fun catalogThemeModes(name: String): Set<CatalogThemeMode> {
+  if (name.startsWith(CATALOG_COLORS_SCHEME_PREFIX)) {
+    val modes = mutableSetOf<CatalogThemeMode>()
+    if (parseCatalogColorScheme(name, dark = false) != null) modes += CatalogThemeMode.LIGHT
+    if (parseCatalogColorScheme(name, dark = true) != null) modes += CatalogThemeMode.DARK
+    return if (modes.isEmpty()) CATALOG_THEME_MODES_BOTH else modes
+  }
+  return when (name) {
+    CATALOG_PALETTE_CORAL -> setOf(CatalogThemeMode.LIGHT)
+    CATALOG_PALETTE_TEAL -> setOf(CatalogThemeMode.DARK)
+    else -> CATALOG_THEME_MODES_BOTH
+  }
+}
+
 /**
  * The M3 [ColorScheme] roles carried in a serialized app palette, paired name→value. One list
  * drives both [serializeCatalogColorScheme] (emit) and the round-trip test; [applyColorRoles]
@@ -144,6 +185,15 @@ private fun schemeRoles(s: ColorScheme): List<Pair<String, Color>> =
   )
 
 /**
+ * The recognized M3 role names a serialized palette may carry — the keys [applyColorRoles] reads
+ * and [schemeRoles] emits. A blob key outside this set is a typo or a future role: it's skipped, so
+ * it never counts as a "usable role" for [parseCatalogColorScheme] (nor a supported mode for
+ * [catalogThemeModes]). Role names don't depend on the scheme's tones, so any instance seeds it.
+ */
+private val CATALOG_SCHEME_ROLE_NAMES: Set<String> =
+  schemeRoles(lightColorScheme()).mapTo(HashSet()) { it.first }
+
+/**
  * Serialize a [light] + [dark] [ColorScheme] pair into the `theme.colors` wire form
  * [catalogColorScheme] decodes: `scheme:l=<role>:<AARRGGBB>,…;d=<role>:<AARRGGBB>,…`. A consumer
  * (e.g. an app publishing the M3 catalog under its own theme) calls this on its brand schemes and
@@ -178,7 +228,10 @@ fun parseCatalogColorScheme(value: String, dark: Boolean): ColorScheme? {
     val sep = entry.indexOf(':')
     if (sep <= 0) continue
     val color = parseHexColor(entry.substring(sep + 1)) ?: continue
-    roles[entry.substring(0, sep).trim()] = color
+    val role = entry.substring(0, sep).trim()
+    // Only a RECOGNIZED role counts — an unknown/typo'd name (e.g. `primry`) is skipped, so a
+    // segment of only unknown roles leaves the map empty → null (not a falsely "usable" mode).
+    if (role in CATALOG_SCHEME_ROLE_NAMES) roles[role] = color
   }
   if (roles.isEmpty()) return null
   return applyColorRoles(if (dark) darkColorScheme() else lightColorScheme(), roles)

--- a/samples/design-catalog-m3-shared/src/desktopTest/kotlin/com/example/designcatalogm3/shared/CatalogColorSchemeTest.kt
+++ b/samples/design-catalog-m3-shared/src/desktopTest/kotlin/com/example/designcatalogm3/shared/CatalogColorSchemeTest.kt
@@ -72,4 +72,58 @@ class CatalogColorSchemeTest {
     // A blob carrying no segment for the requested mode → null (caller uses stock for that mode).
     assertNull(parseCatalogColorScheme("scheme:l=primary:FF00695C", dark = true))
   }
+
+  @Test
+  fun `named palettes declare their supported light and dark modes`() {
+    val both = setOf(CatalogThemeMode.LIGHT, CatalogThemeMode.DARK)
+    // Stock M3 (and any unknown name) supports both modes.
+    assertEquals(both, catalogThemeModes(CATALOG_PALETTE_M3))
+    assertEquals(both, catalogThemeModes("nope"))
+    // The brand palettes are single-mode: Coral is a light scheme, Teal a dark one.
+    assertEquals(setOf(CatalogThemeMode.LIGHT), catalogThemeModes(CATALOG_PALETTE_CORAL))
+    assertEquals(setOf(CatalogThemeMode.DARK), catalogThemeModes(CATALOG_PALETTE_TEAL))
+  }
+
+  @Test
+  fun `a serialized palette's modes are inferred from the segments it carries`() {
+    val light = lightColorScheme(primary = Color(0xFFFF6F61))
+    val dark = darkColorScheme(primary = Color(0xFF4DD0E1))
+    // A full serialize carries both l= and d= → both modes.
+    assertEquals(
+      setOf(CatalogThemeMode.LIGHT, CatalogThemeMode.DARK),
+      catalogThemeModes(serializeCatalogColorScheme(light, dark)),
+    )
+    // Only an l= segment → light-only; only a d= segment → dark-only.
+    assertEquals(setOf(CatalogThemeMode.LIGHT), catalogThemeModes("scheme:l=primary:FFFF6F61"))
+    assertEquals(setOf(CatalogThemeMode.DARK), catalogThemeModes("scheme:d=primary:FF4DD0E1"))
+  }
+
+  @Test
+  fun `a malformed serialized palette falls back to both modes`() {
+    // No usable role in either mode → neither parses → both (mirrors catalogColorScheme's
+    // fallback).
+    assertEquals(
+      setOf(CatalogThemeMode.LIGHT, CatalogThemeMode.DARK),
+      catalogThemeModes("scheme:garbage"),
+    )
+  }
+
+  @Test
+  fun `a segment of only unknown roles is not a usable mode`() {
+    // A valid `l=` segment whose only key is a typo'd / unknown role (`primry`) carries no
+    // recognized role, so it isn't a usable mode: the parser skips the unknown key and returns
+    // null,
+    // and catalogThemeModes falls back to both rather than reporting a spurious light-only.
+    assertNull(parseCatalogColorScheme("scheme:l=primry:FF000000", dark = false))
+    assertEquals(
+      setOf(CatalogThemeMode.LIGHT, CatalogThemeMode.DARK),
+      catalogThemeModes("scheme:l=primry:FF000000"),
+    )
+    // A recognized role alongside the unknown one still applies (the unknown is just ignored).
+    assertNull(parseCatalogColorScheme("scheme:d=primry:FF000000", dark = false))
+    assertEquals(
+      Color(0xFF00695C),
+      parseCatalogColorScheme("scheme:l=primry:FF000000,primary:FF00695C", dark = false)?.primary,
+    )
+  }
 }


### PR DESCRIPTION
## Summary

Adds `catalogThemeModes(value)` to the shared theme resolver (`CatalogThemeChoices`) so a consumer can ask which display mode(s) a `theme.colors` value actually supports, instead of assuming both:

- **Serialized app palettes** (`scheme:…`) — inferred from which mode segments carry usable roles: only `l=…` → light-only, only `d=…` → dark-only, both → both. Inference reuses `parseCatalogColorScheme`, so it can never disagree with what `catalogColorScheme` actually renders; a malformed/empty blob falls back to both (mirroring the stock-M3 fallback).
- **Named palettes** — declared: `M3` (and any unknown name) = both, `Coral` = light-only, `Teal` = dark-only.

This is the gate for variant-enumerating consumers — a per-mode PNG bake, or the landing's Light/Dark selector — so a single-mode theme isn't baked/shown in a mode its author never defined (half the output would be an unusable auto-derived variant, e.g. a light-only brand palette force-darkened to muddy greys). Foundational for the theme bake-variants work; **no behaviour change** to existing rendering.

## Test plan

- `./gradlew :samples:design-catalog-m3-shared:desktopTest :samples:design-catalog-m3-shared:ktfmtCheck` — green. New tests cover: named `M3`/unknown = both, `Coral` = light-only, `Teal` = dark-only; serialized both / light-only / dark-only inferred from the segments; malformed → both.
- Documented per-theme in `docs/design/m3-catalog-app-palette.md` (a light/dark support table).

This is non-visual (a pure resolver function + tests + docs — no rendered output changes), so no visual evidence.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBurh9kb3NJ2KsmYRFhU62)_