### PR TITLE
feat(cli): add `bundle render --knob` to re-theme a published bundle offline

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
@@ -1,5 +1,10 @@
 package ee.schimke.composeai.cli
 
+import ee.schimke.composeai.cli.serve.RenderOutcome
+import ee.schimke.composeai.cli.serve.ServeBundleDaemon
+import ee.schimke.composeai.cli.serve.ServeRenderHost
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.data.overrides.PreviewOverrideValue
 import ee.schimke.composeai.io.SystemFileSystem
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
@@ -813,10 +818,16 @@ private class RenderSubcommand(private val args: List<String>) {
   private val verbose: Boolean = "--verbose" in args || "-v" in args
 
   fun run() {
-    val path = args.firstOrNull { !it.startsWith("-") }
+    // Positional bundle path, skipping any valued flag (`--knob k=v`, `--output dir`) value.
+    val path = CliFlags.firstPositional(args)
     val outDir = args.flagValue("--output") ?: args.flagValue("-o")
+    // Repeatable `--knob key=value` theme overrides (e.g. `theme.colors=scheme:…`); see
+    // [parseKnobOverrides] for the split rules.
+    val knobs: Map<String, PreviewOverrideValue> = parseKnobOverrides(args)
     if (path == null) {
-      System.err.println("Usage: compose-preview bundle render <bundle.png | URL> [-o <dir>]")
+      System.err.println(
+        "Usage: compose-preview bundle render <bundle.png | URL> [-o <dir>] [--knob key=value …]"
+      )
       exitProcess(64)
     }
     val file =
@@ -830,6 +841,15 @@ private class RenderSubcommand(private val args: List<String>) {
       File(outDir ?: (file.absoluteFile.parent.toString() + "/${file.nameWithoutExtension}-render"))
         .absoluteFile
     target.mkdirs()
+
+    // Theme overrides can't ride the source subprocess renderer (BundleRenderer →
+    // DesktopRendererMain, positional args). Render via the DAEMON path instead — the same one
+    // `serve` uses for `/render?knob…` — which applies `PreviewOverrides.namedOverrides` to the
+    // PUBLISHED bundle with no source rebuild. See [renderBundleWithOverrides].
+    if (knobs.isNotEmpty()) {
+      if (!renderBundleWithOverrides(file, target, knobs, verbose)) exitProcess(1)
+      return
+    }
 
     val renderer = BundleRenderer(bundleFile = file, outputDir = target, verbose = verbose)
     val result =
@@ -856,6 +876,113 @@ private class RenderSubcommand(private val args: List<String>) {
     if (!result.allOk) exitProcess(1)
   }
 }
+
+/**
+ * Parse repeatable `--knob key=value` flags into theme overrides. Each entry is split on its FIRST
+ * `=` so a serialized value keeps its own `=`/`,`/`;` (e.g. `theme.colors=scheme:l=primary:…`).
+ * Entries with no `=`, or a blank key, are dropped. Theme knobs are all string-valued, so every
+ * value becomes a [PreviewOverrideValue.StringValue]. A repeated key takes its last value.
+ */
+internal fun parseKnobOverrides(args: List<String>): Map<String, PreviewOverrideValue> =
+  args
+    .flagValuesAll("--knob")
+    .mapNotNull { entry ->
+      val i = entry.indexOf('=')
+      if (i <= 0) return@mapNotNull null
+      val key = entry.substring(0, i).trim()
+      if (key.isEmpty()) null else key to PreviewOverrideValue.StringValue(entry.substring(i + 1))
+    }
+    .toMap()
+
+/**
+ * Render every preview of [bundleFile] to a PNG in [outDir] under theme [overrides] — the daemon
+ * path `serve` uses for `/render?knob…`, wired to write files. Reuses
+ * [ServeBundleDaemon.materialize]
+ * + [ServeRenderHost], so a PUBLISHED bundle re-skins with NO source rebuild: the override rides
+ *   `PreviewOverrides.namedOverrides` → the daemon's connector extension →
+ *   `PreviewOverrideController`. A local `--bundle` path is rendered as-is (same trust posture as
+ *   `bundle daemon`); the daemon just runs the bundle the operator handed it. Returns true iff
+ *   every preview rendered.
+ */
+private fun renderBundleWithOverrides(
+  bundleFile: File,
+  outDir: File,
+  overrides: Map<String, PreviewOverrideValue>,
+  verbose: Boolean,
+): Boolean {
+  val log: (String) -> Unit = { if (verbose) System.err.println("[bundle render] $it") }
+  val workspace = File(outDir, ".daemon").also { it.mkdirs() }
+  val state = ServeBundleDaemon.materialize(bundleFile, workspace, system = "bundle", onLog = log)
+  if (state == null) {
+    System.err.println(
+      "bundle render: can't stand up a render daemon for this bundle — --knob theme overrides need " +
+        "a 'desktop'/'android' backend bundle and the matching daemon sidecars (build them with " +
+        ":cli:installDist). Re-run without --knob for the stock render."
+    )
+    return false
+  }
+  val host =
+    try {
+      ServeRenderHost.open(
+        descriptorPath = state.descriptor,
+        workspaceRoot = state.workspaceRoot,
+        workspaceName = state.workspaceName,
+        previews = state.previews,
+        label = state.label,
+        declaredThemes = state.declaredThemes,
+        onLog = log,
+      )
+    } catch (e: Exception) {
+      System.err.println("bundle render: failed to launch the render daemon (${e.message})")
+      if (verbose) e.printStackTrace()
+      return false
+    }
+  val failures =
+    try {
+      renderPreviewsToDir(host, outDir, PreviewOverrides(namedOverrides = overrides))
+    } finally {
+      host.close()
+    }
+  for (f in failures) System.err.println("  FAIL  $f")
+  return failures.isEmpty()
+}
+
+/**
+ * Render every preview [host] exposes to `<outDir>/<sanitized id>.png` under [seed], returning the
+ * list of human-readable failure descriptions (empty iff every preview rendered). The theme [seed]
+ * — `PreviewOverrides.namedOverrides` — is applied identically to every preview. Factored out of
+ * [renderBundleWithOverrides] so the render-and-write loop is unit-testable against a
+ * [ServeRenderHost] built over a fake [ee.schimke.composeai.render.session.RenderSession] — no
+ * daemon subprocess, no native renderer. Does not close [host]; the caller owns its lifecycle.
+ */
+internal fun renderPreviewsToDir(
+  host: ServeRenderHost,
+  outDir: File,
+  seed: PreviewOverrides,
+  log: (String) -> Unit = ::println,
+): List<String> {
+  var rendered = 0
+  val failures = mutableListOf<String>()
+  for (preview in host.previews) {
+    when (val outcome = host.render(preview.id, seed)) {
+      is RenderOutcome.Ok -> {
+        File(outDir, sanitizeBundleRenderName(preview.id) + ".png").writeBytes(outcome.png)
+        rendered++
+        log("  ok    ${preview.id}")
+      }
+      is RenderOutcome.Failed -> failures += "${preview.id} (${outcome.reason})"
+      RenderOutcome.NotFound -> failures += "${preview.id} (not found)"
+    }
+  }
+  log("rendered $rendered / ${host.previews.size} preview(s) themed → ${outDir.path}")
+  return failures
+}
+
+/** Filesystem-safe filename for a preview id — any char outside `[A-Za-z0-9._-]` becomes `_`. */
+internal fun sanitizeBundleRenderName(id: String): String =
+  buildString(id.length) {
+    for (c in id) append(if (c.isLetterOrDigit() || c == '.' || c == '_' || c == '-') c else '_')
+  }
 
 /**
  * Escape a preview id for the `-PbundlePreviewIds=` Gradle property: `,` and `\` are

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
@@ -9,6 +9,7 @@ import ee.schimke.composeai.io.SystemFileSystem
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.File
+import java.nio.file.Files
 import java.util.zip.ZipEntry
 import java.util.zip.ZipInputStream
 import java.util.zip.ZipOutputStream
@@ -911,40 +912,49 @@ private fun renderBundleWithOverrides(
   verbose: Boolean,
 ): Boolean {
   val log: (String) -> Unit = { if (verbose) System.err.println("[bundle render] $it") }
-  val workspace = File(outDir, ".daemon").also { it.mkdirs() }
-  val state = ServeBundleDaemon.materialize(bundleFile, workspace, system = "bundle", onLog = log)
-  if (state == null) {
-    System.err.println(
-      "bundle render: can't stand up a render daemon for this bundle — --knob theme overrides need " +
-        "a 'desktop'/'android' backend bundle and the matching daemon sidecars (build them with " +
-        ":cli:installDist). Re-run without --knob for the stock render."
-    )
-    return false
-  }
-  val host =
-    try {
-      ServeRenderHost.open(
-        descriptorPath = state.descriptor,
-        workspaceRoot = state.workspaceRoot,
-        workspaceName = state.workspaceName,
-        previews = state.previews,
-        label = state.label,
-        declaredThemes = state.declaredThemes,
-        onLog = log,
+  // Materialize the daemon workspace in a private temp dir — NOT under outDir. `materialize`
+  // extracts the bundle's classes/libs/manifests here, which are implementation artifacts; the
+  // command's contract is that outDir holds only the rendered PNGs, so a `.daemon` tree beside them
+  // would leak bytecode/resources into whatever the caller publishes. Torn down once we're done.
+  val workspace = Files.createTempDirectory("bundle-render-daemon").toFile()
+  try {
+    val state = ServeBundleDaemon.materialize(bundleFile, workspace, system = "bundle", onLog = log)
+    if (state == null) {
+      System.err.println(
+        "bundle render: can't stand up a render daemon for this bundle — --knob theme overrides need " +
+          "a 'desktop'/'android' backend bundle and the matching daemon sidecars (build them with " +
+          ":cli:installDist). Re-run without --knob for the stock render."
       )
-    } catch (e: Exception) {
-      System.err.println("bundle render: failed to launch the render daemon (${e.message})")
-      if (verbose) e.printStackTrace()
       return false
     }
-  val failures =
-    try {
-      renderPreviewsToDir(host, outDir, PreviewOverrides(namedOverrides = overrides))
-    } finally {
-      host.close()
-    }
-  for (f in failures) System.err.println("  FAIL  $f")
-  return failures.isEmpty()
+    val host =
+      try {
+        ServeRenderHost.open(
+          descriptorPath = state.descriptor,
+          workspaceRoot = state.workspaceRoot,
+          workspaceName = state.workspaceName,
+          previews = state.previews,
+          label = state.label,
+          declaredThemes = state.declaredThemes,
+          onLog = log,
+        )
+      } catch (e: Exception) {
+        System.err.println("bundle render: failed to launch the render daemon (${e.message})")
+        if (verbose) e.printStackTrace()
+        return false
+      }
+    val failures =
+      try {
+        renderPreviewsToDir(host, outDir, PreviewOverrides(namedOverrides = overrides))
+      } finally {
+        host.close()
+      }
+    for (f in failures) System.err.println("  FAIL  $f")
+    return failures.isEmpty()
+  } finally {
+    // host.close() (inner finally) has already stopped the daemon subprocess before we delete.
+    workspace.deleteRecursively()
+  }
 }
 
 /**

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
@@ -107,6 +107,8 @@ internal object CliFlags {
       // bundle externalize
       "--res-out",
       "--ext",
+      // bundle render — repeatable theme override (theme.colors=scheme:…) applied via the daemon
+      "--knob",
     )
 
   /**

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleRenderKnobTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleRenderKnobTest.kt
@@ -1,0 +1,159 @@
+package ee.schimke.composeai.cli
+
+import ee.schimke.composeai.cli.serve.FakeRenderSession
+import ee.schimke.composeai.cli.serve.ServePreview
+import ee.schimke.composeai.cli.serve.ServeRenderHost
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.data.overrides.PreviewOverrideValue
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Covers the two seams `bundle render --knob` adds to [BundleCommand]:
+ * - [parseKnobOverrides] — turning repeatable `--knob key=value` flags into the
+ *   `PreviewOverrides.namedOverrides` theme seed, and
+ * - [renderPreviewsToDir] — writing one themed PNG per preview to disk, driven here against a fake
+ *   [ee.schimke.composeai.render.session.RenderSession] so no daemon subprocess or native renderer
+ *   is needed (the same skiko-free pattern as `ServeRenderHostTest`).
+ *
+ * The materialize + daemon-launch orchestration around them (`renderBundleWithOverrides`) needs a
+ * real desktop/android bundle plus the `:cli:installDist` sidecars, so it is exercised by the
+ * self-skipping `ServeBundleDaemonTest` integration test rather than here.
+ */
+class BundleRenderKnobTest {
+
+  private fun tempDir(prefix: String): File =
+    Files.createTempDirectory(prefix).toFile().also { it.deleteOnExit() }
+
+  private fun s(value: String) = PreviewOverrideValue.StringValue(value)
+
+  @Test
+  fun `parseKnobOverrides splits on the first equals so a serialized value keeps its own separators`() {
+    // A wire-form theme.colors blob carries its own `=`, `,` and `;` — the split must not shred it.
+    val blob = "scheme:l=primary:FF6750A4,secondary:FF625B71;d=primary:FFD0BCFF"
+    val args = listOf("render", "bundle.png", "--knob", "theme.colors=$blob")
+    assertEquals(mapOf("theme.colors" to s(blob)), parseKnobOverrides(args))
+  }
+
+  @Test
+  fun `parseKnobOverrides is repeatable across flags and a repeated key takes its last value`() {
+    val args =
+      listOf(
+        "--knob",
+        "theme.colors=teal",
+        "--knob",
+        "theme.font=Roboto",
+        // attached `--knob=` form, and a second theme.colors that must win.
+        "--knob=theme.colors=indigo",
+      )
+    assertEquals(
+      mapOf("theme.colors" to s("indigo"), "theme.font" to s("Roboto")),
+      parseKnobOverrides(args),
+    )
+  }
+
+  @Test
+  fun `parseKnobOverrides drops entries with no equals or a blank key`() {
+    val args =
+      listOf(
+        "--knob",
+        "noequals", // no '=' at all
+        "--knob",
+        "=valueonly", // '=' at index 0 → empty key
+        "--knob",
+        "   =blankkey", // key is all whitespace
+        "--knob",
+        "good=v", // the one keeper
+      )
+    assertEquals(mapOf("good" to s("v")), parseKnobOverrides(args))
+  }
+
+  @Test
+  fun `parseKnobOverrides is empty when no --knob flags are present`() {
+    assertEquals(emptyMap(), parseKnobOverrides(listOf("render", "bundle.png", "-o", "out")))
+  }
+
+  @Test
+  fun `sanitizeBundleRenderName keeps safe chars and replaces the rest with underscore`() {
+    // Preview ids can carry a `@Preview(name = "Phone, dark")` suffix and package dots.
+    assertEquals(
+      "com.example.Btn_Phone__dark_",
+      sanitizeBundleRenderName("com.example.Btn/Phone, dark:"),
+    )
+  }
+
+  @Test
+  fun `renderPreviewsToDir writes one themed PNG per preview and reports no failures`() {
+    val session = FakeRenderSession(tempDir("render-root"))
+    val outDir = tempDir("render-out")
+    val host =
+      ServeRenderHost(
+        session = session,
+        previews =
+          listOf(
+            ServePreview("com.example.Filled", "Filled"),
+            ServePreview("com.example.Tonal", "Tonal"),
+          ),
+        renderTimeoutSeconds = 30,
+      )
+    val seed =
+      PreviewOverrides(namedOverrides = mapOf("theme.colors" to s("scheme:l=primary:FF00695C")))
+
+    val failures = host.use { renderPreviewsToDir(it, outDir, seed, log = {}) }
+
+    assertEquals(emptyList(), failures)
+    assertEquals(2, session.renderCount.get(), "each preview renders once")
+    // Both files exist and carry the render output bytes (not an empty stub).
+    val filled = File(outDir, "com.example.Filled.png")
+    val tonal = File(outDir, "com.example.Tonal.png")
+    assertTrue(filled.exists() && tonal.exists(), "one PNG written per preview")
+    assertEquals("png:null:null:null", filled.readText(), "the render output is written verbatim")
+  }
+
+  @Test
+  fun `renderPreviewsToDir renders the raw id but writes under a sanitized filename`() {
+    // The id given to the daemon must be the raw one (else it 404s); only the FILENAME is
+    // sanitized.
+    val session = FakeRenderSession(tempDir("render-root"))
+    val outDir = tempDir("render-out")
+    val host =
+      ServeRenderHost(
+        session = session,
+        previews = listOf(ServePreview("com.example.Btn:Phone, dark", "Btn")),
+        renderTimeoutSeconds = 30,
+      )
+
+    val failures = host.use { renderPreviewsToDir(it, outDir, PreviewOverrides(), log = {}) }
+
+    assertEquals(emptyList(), failures, "the raw id must resolve — a swap to the sanitized id 404s")
+    assertTrue(
+      File(outDir, "com.example.Btn_Phone__dark.png").exists(),
+      "the file is named by the sanitized id",
+    )
+  }
+
+  @Test
+  fun `renderPreviewsToDir reports a rejected render as a failure and writes no file`() {
+    val session = FakeRenderSession(tempDir("render-root"), rejectAll = true)
+    val outDir = tempDir("render-out")
+    val host =
+      ServeRenderHost(
+        session = session,
+        previews = listOf(ServePreview("com.example.Filled", "Filled")),
+        renderTimeoutSeconds = 30,
+      )
+
+    val failures = host.use { renderPreviewsToDir(it, outDir, PreviewOverrides(), log = {}) }
+
+    assertEquals(1, failures.size, "the rejected preview is reported")
+    assertTrue(failures.single().startsWith("com.example.Filled"), "failure names the preview")
+    assertFalse(
+      File(outDir, "com.example.Filled.png").exists(),
+      "a failed render must not leave a PNG behind",
+    )
+  }
+}

--- a/docs/design/m3-catalog-app-palette.md
+++ b/docs/design/m3-catalog-app-palette.md
@@ -97,9 +97,20 @@ The colors axis on its own:
 
 Overrides resolve in-composition, so a value reaches a live render through `compose-preview serve`
 (`/render/<id>.png?knob.theme.colors=scheme:…`, `&knob.theme.shapes=shapes:…`,
-`&knob.theme.typography=typo:…`) or the daemon RPC. Baking the re-themed PNGs into a published bundle
-is a follow-up (a `--knob` seam on `bundle pack`), which lets an app surface the re-skinned catalog as
-its own tab.
+`&knob.theme.typography=typo:…`) or the daemon RPC. The same override seed re-skins an **already
+published** bundle offline, with no source rebuild:
+
+```
+compose-preview bundle render <bundle.png> --knob theme.colors=scheme:… -o <dir>
+```
+
+stands up the bundle's own render daemon (the path `serve` uses for `/render?knob…`) and writes one
+re-themed PNG per preview. Because it runs the published bundle — not the app's source — a consumer
+that only has the `.png` (e.g. meshcore reusing the compose-m3 stickersheet under its own theme) can
+bake the re-skinned catalog and surface it as its own tab. `--knob` is repeatable and each
+`key=value` splits on the first `=`, so a serialized `scheme:…` blob keeps its own `=`/`,`/`;`
+separators; the flag is inert without a `desktop`/`android` backend bundle plus the `:cli:installDist`
+daemon sidecars (re-run without `--knob` for the stock, override-free render).
 
 Encode/decode round-trips are covered by
 [`CatalogColorSchemeTest`](../../samples/design-catalog-m3-shared/src/desktopTest/kotlin/com/example/designcatalogm3/shared/CatalogColorSchemeTest.kt)


### PR DESCRIPTION
## What

`compose-preview bundle render <bundle.png> --knob theme.colors=scheme:… -o <dir>` renders an **already published** preview bundle's previews to PNG under theme overrides, via the same render daemon `serve` uses for `/render?knob…` — **no source rebuild**. A consumer that only has the published `.png` (e.g. meshcore reusing the compose-m3 stickersheet under its own theme) can bake the re-skinned catalog and surface it as its own tab.

This supersedes the abandoned `bundle pack --knob` plan: that rebuilt the catalog from source, which the bundle consumer doesn't have — it only has the published bundle.

## How

- `RenderSubcommand` routes to a daemon render when `--knob` is present: `ServeBundleDaemon.materialize` → `ServeRenderHost.open` → `host.render(id, PreviewOverrides(namedOverrides=…))` → write one PNG per preview. Without `--knob` it keeps the existing stock `BundleRenderer` path untouched.
- `--knob key=value` is repeatable and splits on the **first** `=`, so a serialized `scheme:l=…;d=…` blob keeps its own `=`/`,`/`;`. Registered in `CliFlags.VALUE_FLAGS` so command detection skips its value.
- The override rides `PreviewOverrides.namedOverrides` → the daemon's connector extension → `PreviewOverrideController` → the `MaterialTheme` swap. Inert without a `desktop`/`android` backend bundle plus the `:cli:installDist` daemon sidecars (re-run without `--knob` for the stock, override-free render).

## Visual

`--knob theme.colors=scheme:…` bakes the re-skin below into the output PNGs — the same `PreviewOverrides` re-theme these committed catalog renders show (documented in `docs/design/m3-catalog-app-palette.md`). Colors axis, stock M3 → teal app palette:

| Stock `M3` | App palette (`theme.colors=scheme:…`) |
| --- | --- |
| ![stock M3 palette](https://raw.githubusercontent.com/yschimke/compose-ai-tools/f209f2cce1379b08005773cdabe2575852fb18cb/docs/images/m3-app-palette-stock.png) | ![teal app palette](https://raw.githubusercontent.com/yschimke/compose-ai-tools/f209f2cce1379b08005773cdabe2575852fb18cb/docs/images/m3-app-palette-teal.png) |

Full re-skin (colors + shapes + typography):

| Stock theme | App re-skin |
| --- | --- |
| ![stock theme](https://raw.githubusercontent.com/yschimke/compose-ai-tools/f209f2cce1379b08005773cdabe2575852fb18cb/docs/images/m3-full-theme-stock.png) | ![app re-skin](https://raw.githubusercontent.com/yschimke/compose-ai-tools/f209f2cce1379b08005773cdabe2575852fb18cb/docs/images/m3-full-theme-reskin.png) |

> **Provenance.** These are the committed catalog renders that illustrate the `PreviewOverrides` re-theme the flag drives — not fresh output of the new command. The full bundle→daemon→file path needs the `:cli:installDist` sidecars and a native renderer (skiko) in a subprocess, which the headless sandbox this was built in can't run; it's covered by the self-skipping `ServeBundleDaemonTest`, and a human/CI with skiko verifies e2e by running the command above against a compose-m3 bundle.

## Test plan

- New **`BundleRenderKnobTest`** (skiko-free, via a fake `RenderSession` — the `ServeRenderHostTest` pattern):
  - `parseKnobOverrides` — first-`=` split preserves a serialized value's own separators; repeatable with last-wins; drops no-`=` and blank-key entries; empty when absent.
  - `renderPreviewsToDir` — one PNG per preview named by the sanitized id; renders the **raw** id but writes the sanitized filename (a swap would 404); a rejected render is reported and leaves no file.
  - `sanitizeBundleRenderName` — keeps `[A-Za-z0-9._-]`, replaces the rest with `_`.
- Full `:cli:test` green, including `CliFlagsRegistryTest` for the new `--knob` registration.

_Generated by [Claude Code]_

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBurh9kb3NJ2KsmYRFhU62)_