### PR TITLE
feat(theme): attribute the shape leg of the M3 triad to component nodes

### DIFF
--- a/data/theme/core/src/main/kotlin/ee/schimke/composeai/data/theme/ThemeConsumerAttribution.kt
+++ b/data/theme/core/src/main/kotlin/ee/schimke/composeai/data/theme/ThemeConsumerAttribution.kt
@@ -14,6 +14,14 @@ data class NodeThemeFacts(
   val foregroundColor: String? = null,
   val backgroundColor: String? = null,
   val textStyle: TypographyToken? = null,
+  /**
+   * The node's resolved clip/container shape, formatted like [ResolvedThemeTokens.shapes] values (a
+   * `Shape.toString()`, e.g. `RoundedCornerShape(...)`), or `null` when the node draws no
+   * theme-derived shape. Completes the M3 triad — colour, typography, **shape** — so a node that
+   * clips to `MaterialTheme.shapes.medium` attributes the `medium` corner token, the third leg the
+   * design-parity token diff and the importable bundles want (#2179 / shape parity).
+   */
+  val shape: String? = null,
 )
 
 /**
@@ -30,6 +38,9 @@ data class NodeThemeFacts(
  *   `onError`, and `surface` == `background`). When a node's background resolves to a known
  *   container role the foreground is disambiguated to that container's `on*` counterpart; otherwise
  *   every candidate role is emitted so the consumer can decide rather than silently guess.
+ * - **Shape** — matched on the resolved `Shape.toString()` against the theme's shape scale. Two
+ *   roles can share a value (an uncustomised theme leaves `extraSmall`..`large` distinct, but a
+ *   design system may collapse some), so every matching role is emitted, mirroring colour.
  *
  * A node is only emitted as a [ThemeConsumer] when it read at least one token — nodes that hardcode
  * non-theme values produce no entry.
@@ -57,6 +68,7 @@ object ThemeConsumerAttribution {
     tokens += disambiguateForeground(fgRoles, bgRoles)
     tokens += bgRoles
     textStyle?.let { style -> tokens += typographyTokensFor(style, resolved.typography) }
+    shape?.let { value -> tokens += shapeTokensFor(value, resolved.shapes) }
     return if (tokens.isEmpty()) null else ThemeConsumer(nodeId = nodeId, tokens = tokens.toList())
   }
 
@@ -84,6 +96,10 @@ object ThemeConsumerAttribution {
     val target = style.copy(fontFamily = null)
     return typography.filterValues { it.copy(fontFamily = null) == target }.keys.toList()
   }
+
+  /** Shape-scale role names whose resolved value equals the node's resolved [shape]. */
+  private fun shapeTokensFor(shape: String, shapes: Map<String, String>): List<String> =
+    shapes.filterValues { it == shape }.keys.toList()
 
   /** Material 3 container/surface role → the `on*` role whose value is its content colour. */
   private val CONTAINER_TO_ON: Map<String, String> =

--- a/data/theme/core/src/test/kotlin/ee/schimke/composeai/data/theme/ThemeConsumerAttributionTest.kt
+++ b/data/theme/core/src/test/kotlin/ee/schimke/composeai/data/theme/ThemeConsumerAttributionTest.kt
@@ -53,8 +53,19 @@ class ThemeConsumerAttributionTest {
       "labelLarge" to labelLarge,
     )
 
+  // extraSmall..large distinct; `collapsed` shares `small`'s value (a design system that reuses one
+  // corner across two roles) so shape, like colour, must emit every matching role.
+  private val shapes =
+    linkedMapOf(
+      "extraSmall" to "RoundedCornerShape(4.0.dp, 4.0.dp, 4.0.dp, 4.0.dp)",
+      "small" to "RoundedCornerShape(8.0.dp, 8.0.dp, 8.0.dp, 8.0.dp)",
+      "medium" to "RoundedCornerShape(12.0.dp, 12.0.dp, 12.0.dp, 12.0.dp)",
+      "large" to "RoundedCornerShape(16.0.dp, 16.0.dp, 16.0.dp, 16.0.dp)",
+      "collapsed" to "RoundedCornerShape(8.0.dp, 8.0.dp, 8.0.dp, 8.0.dp)",
+    )
+
   private val resolved =
-    ResolvedThemeTokens(colorScheme = colorScheme, typography = typography, shapes = emptyMap())
+    ResolvedThemeTokens(colorScheme = colorScheme, typography = typography, shapes = shapes)
 
   private fun tokensFor(nodeId: String, nodes: List<NodeThemeFacts>): List<String> =
     ThemeConsumerAttribution.attribute(nodes, resolved).single { it.nodeId == nodeId }.tokens
@@ -117,6 +128,62 @@ class ThemeConsumerAttributionTest {
     val tokens = tokensFor("5", listOf(NodeThemeFacts(nodeId = "5", textStyle = titleSmall.copy())))
 
     assertEquals(setOf("titleSmall", "labelLarge"), tokens.toSet())
+  }
+
+  @Test
+  fun `attributes a node's resolved shape to its scale role`() {
+    val tokens =
+      tokensFor(
+        "6",
+        listOf(
+          NodeThemeFacts(
+            nodeId = "6",
+            shape = "RoundedCornerShape(12.0.dp, 12.0.dp, 12.0.dp, 12.0.dp)",
+          )
+        ),
+      )
+
+    assertEquals(listOf("medium"), tokens)
+  }
+
+  @Test
+  fun `shape shared across roles reports every matching role`() {
+    val tokens =
+      tokensFor(
+        "7",
+        listOf(
+          NodeThemeFacts(nodeId = "7", shape = "RoundedCornerShape(8.0.dp, 8.0.dp, 8.0.dp, 8.0.dp)")
+        ),
+      )
+
+    assertEquals(setOf("small", "collapsed"), tokens.toSet())
+  }
+
+  @Test
+  fun `a node attributes colour, typography and shape together`() {
+    val node =
+      NodeThemeFacts(
+        nodeId = "8",
+        foregroundColor = "#FFB3261E",
+        textStyle = titleMedium.copy(fontFamily = null),
+        shape = "RoundedCornerShape(16.0.dp, 16.0.dp, 16.0.dp, 16.0.dp)",
+      )
+
+    assertEquals(
+      ThemeConsumer(nodeId = "8", tokens = listOf("error", "titleMedium", "large")),
+      ThemeConsumerAttribution.attribute(listOf(node), resolved).single(),
+    )
+  }
+
+  @Test
+  fun `a shape that matches no scale role is dropped`() {
+    assertEquals(
+      emptyList<ThemeConsumer>(),
+      ThemeConsumerAttribution.attribute(
+        listOf(NodeThemeFacts(nodeId = "9", shape = "CutCornerShape(3.0.dp)")),
+        resolved,
+      ),
+    )
   }
 
   @Test


### PR DESCRIPTION
## Summary

Theme consumer attribution (#1847) maps each rendered node to the Material theme
tokens it read — but only **colour** and **typography**. `NodeThemeFacts` carried
no shape and `ThemeConsumerAttribution` never matched `ResolvedThemeTokens.shapes`,
so a component preview attributed colour + typography per node yet never its
corner **shape** — the third M3 leg the design-parity token-compliance diff and
the importable bundles want. (It's why a `DeviceBodyPreview`-style parity report
shows every `radius.shape/corner-*` token as "missing from candidate": the
resolved theme shapes are captured, but nothing attributes them to nodes.)

This adds the shape leg to the **attribution**:

- `NodeThemeFacts.shape` — a node's resolved clip/container `Shape.toString()`,
  formatted like `ResolvedThemeTokens.shapes` values.
- `ThemeConsumerAttribution` matches it against the theme's shape scale and emits
  every role that shares the value (mirroring colour's ambiguity handling, e.g. a
  design system that reuses one corner across two roles).

## Scope

This is the pure attribution/data-model half — the codebase deliberately splits
capture from attribution (`ThemeConsumerCapture` ↔ `ThemeConsumerAttribution`).
The **capture** that populates `NodeThemeFacts.shape` from the render is a
separate follow-up: unlike colour/typography (read off each text node's
`TextLayoutResult`), a node's shape isn't in the semantics tree, so it needs
`LayoutNode`/graphics-layer modifier introspection and a Robolectric render to
validate. Colour + typography attribution already works for component previews
today via #1847; this closes the triad on the attribution side and unblocks the
capture work.

## Test plan

- `data-theme-core:test` green (`./gradlew :data-theme-core:test`), including new
  `ThemeConsumerAttributionTest` cases: shape → scale role; a shape shared across
  roles reports every match; colour + typography + shape attribute together on
  one node; a non-theme shape is dropped.
- Pure JVM module, no render required for these.

_Generated by [Claude Code]_
https://claude.ai/code/session_01PFaMPQ3D2PmcxAqsCZHD1e

---
_Generated by [Claude Code](https://claude.ai/code/session_01PFaMPQ3D2PmcxAqsCZHD1e)_