### PR TITLE
fix(design-artifacts): carry figma-svg + wireframes from the --extra-renders bundle

### DIFF
--- a/scripts/design-artifacts/figma-svg-catalog.test.mjs
+++ b/scripts/design-artifacts/figma-svg-catalog.test.mjs
@@ -14,6 +14,7 @@ import { renderReadmeMd } from "./render-readme-md.mjs";
 import {
   figmaRastersForId,
   figmaSvgByFunction,
+  figmaSvgByFunctions,
   rewriteRasterHrefs,
 } from "./figma-svg-emit.mjs";
 
@@ -95,6 +96,31 @@ test("figmaSvgByFunction prefers the light variant and keeps the preview id", ()
   const byFn = figmaSvgByFunction(bundle);
   assert.equal(byFn.get("Fab").id, "Fab_Light");
   assert.match(byFn.get("Fab").svg, /light/);
+});
+
+test("figmaSvgByFunctions folds an --extra-renders bundle in (adds extra-only fns; extra wins)", () => {
+  const primary = {
+    previews: [{ id: "Card_Light", functionName: "Card" }],
+    entries: { "previews/Card_Light.figma.svg": enc("<svg><!--primary card--></svg>") },
+  };
+  const extra = {
+    previews: [
+      { id: "Card_Light", functionName: "Card" }, // same-named: extra overrides
+      { id: "Chat_Light", functionName: "Chat" }, // extra-only: must be added, not dropped
+    ],
+    entries: {
+      "previews/Card_Light.figma.svg": enc("<svg><!--extra card--></svg>"),
+      "previews/Chat_Light.figma.svg": enc("<svg><!--extra chat--></svg>"),
+    },
+  };
+  const byFn = figmaSvgByFunctions([primary, extra]);
+  // The regression this guards: an extra-renders-only function used to be dropped (primary-only read).
+  assert.ok(byFn.has("Chat"), "extra-only function carries its figma-svg");
+  assert.match(byFn.get("Chat").svg, /extra chat/);
+  // On a name clash the extra bundle wins, matching the candidate fold.
+  assert.match(byFn.get("Card").svg, /extra card/);
+  // Falsy bundles are skipped (the primary-only, no-extra-renders case).
+  assert.deepEqual([...figmaSvgByFunctions([primary, null]).keys()], ["Card"]);
 });
 
 test("figmaRastersForId returns only that preview's crops", () => {

--- a/scripts/design-artifacts/figma-svg-emit.mjs
+++ b/scripts/design-artifacts/figma-svg-emit.mjs
@@ -29,6 +29,23 @@ export function figmaSvgByFunction(bundle) {
 }
 
 /**
+ * Fold {@link figmaSvgByFunction} across several bundles, later bundles overriding earlier ones for
+ * the same function name — matching generate-design-catalog's `--extra-renders` candidate fold, where
+ * the supplementary bundle wins. Crucially a function present in ONLY a later bundle (an
+ * `--extra-renders`-only sticker, e.g. a screen rendered from a second CMP-desktop module) is *added*,
+ * so an extra render carries its editable vector into the catalog too — not just its raster PNG.
+ * Reading only the primary bundle silently dropped those vectors. Falsy bundles are skipped.
+ */
+export function figmaSvgByFunctions(bundles) {
+  const out = new Map();
+  for (const bundle of bundles) {
+    if (!bundle) continue;
+    for (const [fn, entry] of figmaSvgByFunction(bundle)) out.set(fn, entry);
+  }
+  return out;
+}
+
+/**
  * The hybrid raster crops carried for preview [id] as `previews/<id>.figma-raster/<node>.png`.
  * Returns a Map name→bytes; empty for the common vector-only sticker.
  */

--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -51,7 +51,7 @@ import { renderCrossSystemHtml } from "./render-cross-system-html.mjs";
 import { renderReadmeMd } from "./render-readme-md.mjs";
 import {
   figmaRastersForId,
-  figmaSvgByFunction,
+  figmaSvgByFunctions,
   rewriteRasterHrefs,
 } from "./figma-svg-emit.mjs";
 import { buildCodeConnectManifest } from "./figma-code-connect-emit.mjs";
@@ -399,8 +399,12 @@ const { candidates, bundle } = await loadCandidates(rendersPath);
 // from what the desktop daemon (`bundle.previews`) would draw (e.g. the focus ring CMP can't paint),
 // so the live-preview bridge below MUST NOT map them to a desktop preview — they stay baked-only.
 const overriddenFunctions = new Set();
+let extraBundle = null;
 if (values["extra-renders"]) {
-  const { candidates: extra } = await loadCandidates(resolve(values["extra-renders"]));
+  const { candidates: extra, bundle: extraRenderBundle } = await loadCandidates(
+    resolve(values["extra-renders"]),
+  );
+  extraBundle = extraRenderBundle;
   const overridden = new Set(extra.map(functionOf));
   for (const fn of overridden) overriddenFunctions.add(fn);
   for (let i = candidates.length - 1; i >= 0; i--) {
@@ -614,7 +618,12 @@ if (values["publish-live-bundle"]) {
 // captures the slot containers + resolved design tokens (background / border /
 // corner / padding) a redline needs. Where no tree was carried, fall back to the
 // a11y-greenline wireframe (touch-target rects only).
+// Wireframes + figma-svg read from BOTH the primary and the `--extra-renders` bundle: an extra render
+// that ADDS a function (not just overrides a same-named one) carries its own layout tree + editable
+// figma-svg, which must land in the catalog too — otherwise a screen rendered from a second module is
+// PNG-only. Extra wins on a name clash, matching the candidate fold above.
 const layoutByFn = layoutByFunction(bundle);
+if (extraBundle) for (const [fn, v] of layoutByFunction(extraBundle)) layoutByFn.set(fn, v);
 const fnByComponentId = new Map(
   spec.groups.flatMap((g) => g.components.map((c) => [c.componentId, c.preview])),
 );
@@ -647,7 +656,7 @@ for (const component of catalog.components) {
 // this is the *design* SVG — a designer imports it into Figma for an editable
 // component rather than a flat screenshot. Written under figma/<slug>.svg; the
 // index links it. Components whose render produced no drawing layers are skipped.
-const figmaSvgByFn = figmaSvgByFunction(bundle);
+const figmaSvgByFn = figmaSvgByFunctions([bundle, extraBundle]);
 const figmaDir = join(outPath, "figma");
 await mkdir(figmaDir, { recursive: true });
 const figmaSvgSlugs = new Set();
@@ -666,7 +675,14 @@ for (const component of catalog.components) {
   // A hybrid sticker's `<image href="figma-raster/<node>.png">` layers reference crops carried in
   // the bundle. Copy them under a per-slug dir and rewrite the href prefix so they resolve next to
   // figma/<slug>.svg (per-slug avoids <node>.png name collisions across components).
-  const rasters = figmaRastersForId(bundle, carried.id);
+  // A hybrid sticker's raster crops live in whichever bundle carried its figma-svg; an id is unique
+  // to one bundle, so merging both is safe (the other returns empty).
+  const rasters = extraBundle
+    ? new Map([
+        ...figmaRastersForId(bundle, carried.id),
+        ...figmaRastersForId(extraBundle, carried.id),
+      ])
+    : figmaRastersForId(bundle, carried.id);
   if (rasters.size) {
     figmaSvgHybridSlugs.add(componentSlug);
     const rasterDir = `${componentSlug}.figma-raster`;


### PR DESCRIPTION
## Summary

`generate-design-catalog` read the editable `compose/figma-svg` export (and the layout-tree wireframe) **only from the primary `--renders` bundle**. `--extra-renders` was built to *override* same-named functions (compose-m3's Android-only focus-ring case), so a function present **only** in the extra bundle — e.g. a screen rendered from a second CMP-desktop module and folded in via `--extra-renders` — had its figma-svg produced by the render but **silently dropped**, leaving it PNG-only in the catalog.

This folds figma-svg + the layout wireframe across **both** bundles (extra wins on a name clash, matching the existing candidate fold) and looks up hybrid raster crops in whichever bundle carried the sticker. Adds a small pure `figmaSvgByFunctions()` helper + unit test.

## How it surfaced

meshcore-mobile now folds a second `:meshcore-components` (CMP desktop) render into its `:app` catalog via `--extra-renders` (yschimke/meshcore-mobile#227). In the regenerated `design-artifacts/meshcore-mobile`:
- **37 / 42** components had `figma/<slug>.svg` — all the `:app` ones.
- **5 / 42** had none — exactly the 5 desktop-rendered screens (`Chat/*`, `Settings/Ready`, `Device/Cached`).

`design-artifacts/compose-m3` (also a desktop render) has **26 / 26** with figma-svg, which pinned the bug to the **driver**, not the renderer — my original guess in #2573 was wrong; the desktop backend emits figma-svg fine.

## Changes

- `figma-svg-emit.mjs`: add `figmaSvgByFunctions(bundles)` — fold `figmaSvgByFunction` across bundles (later wins, falsy skipped).
- `generate-design-catalog.mjs`: capture the `--extra-renders` bundle; read figma-svg via the fold; merge the extra bundle's layout trees into the wireframe lookup; search both bundles for hybrid raster crops.
- `figma-svg-catalog.test.mjs`: pin the fold (extra-only fn added, extra wins on clash, falsy skipped).

## Test plan

- [x] `node --test scripts/design-artifacts/figma-svg-catalog.test.mjs` — 10/10 pass (new fold test + existing figma-svg/index/readme tests)
- [x] `node --check` on both edited scripts
- [ ] Post-merge: re-dispatch meshcore-mobile `design-artifacts.yml` → the `Chat/*`, `Settings/Ready`, `Device/Cached` screens gain `figma/<slug>.svg` (currently PNG-only)

Fixes #2573.

_Generated by [Claude Code]_

---
_Generated by [Claude Code](https://claude.ai/code/session_01GWWMcA4XFhj7qbDNVNrM8e)_