### PR TITLE
chore(preview-server): serve the Confetti Wear design catalog

### DIFF
--- a/deploy/image/entrypoint.sh
+++ b/deploy/image/entrypoint.sh
@@ -30,7 +30,7 @@ fi
 # The published catalog set is BAKED INTO THE IMAGE (same `:=` + `none` convention
 # as SERVE_TRUST_STORE below), so a bare `docker pull` / Watchtower auto-update
 # self-heals without editing the box's compose. Front-page systems:
-: "${SERVE_CATALOGS:=compose-m3,wear-m3,remote-m3,meshcore-mobile@yschimke/meshcore-mobile,homeassistant-remotecompose@yschimke/homeassistant-remotecompose}"
+: "${SERVE_CATALOGS:=compose-m3,wear-m3,remote-m3,meshcore-mobile@yschimke/meshcore-mobile,homeassistant-remotecompose@yschimke/homeassistant-remotecompose,confetti-wear@yschimke/Confetti}"
 [[ "${SERVE_CATALOGS}" != "none" ]] && args+=(--catalogs "${SERVE_CATALOGS}")
 # …and cadence, served UNLISTED from its own repo — reachable at /cadence/ (and ?session=cadence)
 # but kept OFF the front-page index. (meshcore-mobile / homeassistant-remotecompose are LISTED above

--- a/deploy/image/trust/producers.json
+++ b/deploy/image/trust/producers.json
@@ -16,6 +16,14 @@
     {
       "repo": "yschimke/cadence",
       "branch": "design-artifacts/*"
+    },
+    {
+      "repo": "joreilly/Confetti",
+      "branch": "design-artifacts/*"
+    },
+    {
+      "repo": "yschimke/Confetti",
+      "branch": "design-artifacts/*"
     }
   ]
 }


### PR DESCRIPTION
## What

Registers the **Confetti Wear** design catalog with the public preview server (`preview.coo.ee`), so it fetches and serves the sticker sheet at `/confetti-wear/` alongside meshcore-mobile et al.

- `deploy/image/trust/producers.json` — trust `joreilly/Confetti` and `yschimke/Confetti` `design-artifacts/*` branches (so the fetched catalog badges Trusted(Branch), not Unverified).
- `deploy/image/entrypoint.sh` — add `confetti-wear@yschimke/Confetti` to the baked front-page `SERVE_CATALOGS` set.

The catalog is produced by a new `design-artifacts.yml` job in the Confetti repo (separate PR) that renders the `:wearApp` `@Preview` sticker sheet and force-pushes the importable bundle to `design-artifacts/confetti-wear`.

## Notes
- Serve entry points at `yschimke/Confetti` since that fork is where the `design-artifacts/confetti-wear` branch is produced during prototyping (mirrors `meshcore-mobile@yschimke/meshcore-mobile`). Retarget to `joreilly/Confetti` once the catalog job lands upstream — `joreilly/Confetti` is already trusted here, so that's a one-token change.
- The server 404s `/confetti-wear/` until the Confetti catalog job has run once and the branch exists; this PR is the standing config.

Text-only deploy/config change — no rendered surface, so no visual evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LsfqPFRpxuN9qULr9h6SVJ)_