### PR TITLE
feat(theme): capture the node shape leg of the M3 triad from the render

### DIFF
--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/ThemeConsumerCaptureRenderTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/ThemeConsumerCaptureRenderTest.kt
@@ -1,0 +1,68 @@
+package ee.schimke.composeai.daemon
+
+import androidx.activity.ComponentActivity
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onRoot
+import ee.schimke.composeai.data.theme.ResolvedThemeTokens
+import ee.schimke.composeai.data.theme.ThemeConsumerAttribution
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * End-to-end render check on the Robolectric (Android) backend: a `Surface` clipped to
+ * `MaterialTheme.shapes.medium` must have that shape captured off its rendered modifiers by
+ * [ThemeConsumerCapture] and attributed to the `medium` scale role by [ThemeConsumerAttribution] —
+ * the capture leg that lights up the shape (third M3-triad) attribution. Runs through the same
+ * held-rule sandbox path the daemon uses, so a pass here matches production capture.
+ *
+ * Pinned to `sdk = 35` like the other `:daemon:android` self-tests: Robolectric SDK 36 needs a JDK
+ * 21 test JVM, and the repo toolchain is JDK 17.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35], qualifiers = "w400dp-h800dp")
+class ThemeConsumerCaptureRenderTest {
+
+  @get:Rule val rule = createAndroidComposeRule<ComponentActivity>()
+
+  @Test
+  fun `captures a rendered Surface's Material shape and attributes it to medium`() {
+    // The theme's resolved `medium` value, captured from inside composition so the assertion
+    // doesn't hard-code a version-specific `Shape.toString()`.
+    var mediumShape = ""
+    rule.setContent {
+      MaterialTheme {
+        mediumShape = MaterialTheme.shapes.medium.toString()
+        // Clickable Surface → a real SemanticsNode carrying the clip-shape modifier.
+        Surface(onClick = {}, shape = MaterialTheme.shapes.medium) { Text("Hi") }
+      }
+    }
+
+    val root = rule.onRoot(useUnmergedTree = true).fetchSemanticsNode()
+    val facts = ThemeConsumerCapture.extractFacts(root)
+
+    assertTrue(
+      "expected a node whose captured shape is the theme's medium ($mediumShape); " +
+        "got ${facts.map { it.shape }}",
+      facts.any { it.shape == mediumShape },
+    )
+
+    val resolved =
+      ResolvedThemeTokens(
+        colorScheme = emptyMap(),
+        typography = emptyMap(),
+        shapes = linkedMapOf("medium" to mediumShape),
+      )
+    val consumers = ThemeConsumerAttribution.attribute(facts, resolved)
+    assertTrue(
+      "expected a consumer attributed to the medium shape role; got $consumers",
+      consumers.any { "medium" in it.tokens },
+    )
+  }
+}

--- a/data/theme/connector/src/main/kotlin/ee/schimke/composeai/daemon/ThemeConsumerCapture.kt
+++ b/data/theme/connector/src/main/kotlin/ee/schimke/composeai/daemon/ThemeConsumerCapture.kt
@@ -97,29 +97,49 @@ object ThemeConsumerCapture {
 
   /**
    * The `Shape.toString()` declared by the first shape-bearing modifier — `background(color,
-   * shape)`, `clip(shape)` (routed through `graphicsLayer`), or `border(..., shape)` — or `null`
-   * when none carries one. Reads the inspector `shape` element first, then a reflected `shape`
-   * field, foundation-free, mirroring `ModifierTokenResolver.shapeOf`. `internal` so the extraction
-   * is unit-testable against a real modifier chain without a render.
+   * shape)`, `clip(shape)` (routed through `graphicsLayer`), `border(..., shape)`, or a Wear
+   * scaling card's `paint(BackgroundPainter)` — or `null` when none carries one. Reads the
+   * inspector `shape` element first, then a reflected `shape` field, then a
+   * `BackgroundPainter.shape`, foundation-free, mirroring `ModifierTokenResolver.shapeOf`.
+   * `internal` so the extraction is unit-testable against a real modifier chain without a render.
    */
   internal fun shapeStringOf(modifiers: List<Any>): String? {
     for (mod in modifiers) {
-      val fromElement =
-        (mod as? InspectableValue)?.inspectableElements?.firstOrNull { it.name == "shape" }?.value
-          as? Shape
-      val shape =
-        fromElement
-          ?: runCatching {
-              mod.javaClass.getDeclaredField("shape").apply { isAccessible = true }.get(mod)
-                as? Shape
-            }
-            .getOrNull()
+      val shape = mod.shapeFromModifier() ?: mod.shapeFromBackgroundPainter()
       // `Modifier.background(color)` defaults its shape to `RectangleShape`; a plain rectangle is
       // never a theme shape role, so skip it and keep scanning for a real (rounded/cut) shape.
       if (shape != null && shape != RectangleShape) return shape.toString()
     }
     return null
   }
+
+  /** The inspector `shape` element, or a reflected `shape` field on the modifier element. */
+  private fun Any.shapeFromModifier(): Shape? {
+    val fromElement =
+      (this as? InspectableValue)?.inspectableElements?.firstOrNull { it.name == "shape" }?.value
+        as? Shape
+    return fromElement
+      ?: runCatching {
+          javaClass.getDeclaredField("shape").apply { isAccessible = true }.get(this) as? Shape
+        }
+        .getOrNull()
+  }
+
+  /**
+   * A Wear scaling card (`TransformingLazyColumn` + `SurfaceTransformation`) fills through a
+   * `Modifier.paint(BackgroundPainter)` whose rounded/morphing shape rides on the *painter*
+   * (`BackgroundPainter.shape`), not the modifier — so without this such a card gets no
+   * `NodeThemeFacts.shape` even though `ModifierTokenResolver` resolves the same node's shape (it
+   * carries the identical fallback). Best-effort reflection, foundation-free.
+   */
+  private fun Any.shapeFromBackgroundPainter(): Shape? =
+    runCatching {
+        val painter = javaClass.getDeclaredField("painter").apply { isAccessible = true }.get(this)
+        if (painter?.javaClass?.simpleName != "BackgroundPainter") return null
+        painter.javaClass.getDeclaredField("shape").apply { isAccessible = true }.get(painter)
+          as? Shape
+      }
+      .getOrNull()
 
   private fun SemanticsConfiguration.layoutThemeFacts(): LayoutThemeFacts? {
     val action = getOrNull(SemanticsActions.GetTextLayoutResult)?.action ?: return null

--- a/data/theme/connector/src/main/kotlin/ee/schimke/composeai/daemon/ThemeConsumerCapture.kt
+++ b/data/theme/connector/src/main/kotlin/ee/schimke/composeai/daemon/ThemeConsumerCapture.kt
@@ -1,7 +1,10 @@
 package ee.schimke.composeai.daemon
 
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.node.RootForTest
+import androidx.compose.ui.platform.InspectableValue
 import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.semantics.SemanticsConfiguration
 import androidx.compose.ui.semantics.SemanticsNode
@@ -60,16 +63,62 @@ object ThemeConsumerCapture {
   ) {
     val facts = node.config.layoutThemeFacts()
     val effectiveBackground = facts?.background ?: inheritedBackground
-    if (facts != null && (facts.foreground != null || facts.textStyle != null)) {
+    // Text signal (colour/typography) rides the `TextLayoutResult`; the node's clip/container shape
+    // rides its modifiers instead — a `Surface`/`Card` is a *non-text* node, so shape is the reason
+    // to emit it. `#1847` covered the text legs; this adds the shape leg (the third of the M3
+    // triad).
+    val hasText = facts != null && (facts.foreground != null || facts.textStyle != null)
+    val shape = node.layoutShape()
+    if (hasText || shape != null) {
       out +=
         NodeThemeFacts(
           nodeId = node.id.toString(),
-          foregroundColor = facts.foreground,
-          backgroundColor = effectiveBackground,
-          textStyle = facts.textStyle,
+          foregroundColor = facts?.foreground,
+          // Background is only a text-disambiguation signal; a shape-only container carries none.
+          backgroundColor = if (hasText) effectiveBackground else null,
+          textStyle = facts?.textStyle,
+          shape = shape,
         )
     }
     node.children.forEach { collect(it, effectiveBackground, out) }
+  }
+
+  /**
+   * The node's resolved clip/container [Shape] as a `Shape.toString()` — matched by
+   * [ThemeConsumerAttribution] against the theme's shape scale — read off its modifiers the way
+   * `ModifierTokenResolver` reads the layout inspector's shape token. A node with no shape-bearing
+   * modifier (the common case for plain layout/text nodes) yields `null`.
+   */
+  private fun SemanticsNode.layoutShape(): String? {
+    val modifiers =
+      runCatching { layoutInfo.getModifierInfo().map { it.modifier } }.getOrNull() ?: return null
+    return shapeStringOf(modifiers)
+  }
+
+  /**
+   * The `Shape.toString()` declared by the first shape-bearing modifier — `background(color,
+   * shape)`, `clip(shape)` (routed through `graphicsLayer`), or `border(..., shape)` — or `null`
+   * when none carries one. Reads the inspector `shape` element first, then a reflected `shape`
+   * field, foundation-free, mirroring `ModifierTokenResolver.shapeOf`. `internal` so the extraction
+   * is unit-testable against a real modifier chain without a render.
+   */
+  internal fun shapeStringOf(modifiers: List<Any>): String? {
+    for (mod in modifiers) {
+      val fromElement =
+        (mod as? InspectableValue)?.inspectableElements?.firstOrNull { it.name == "shape" }?.value
+          as? Shape
+      val shape =
+        fromElement
+          ?: runCatching {
+              mod.javaClass.getDeclaredField("shape").apply { isAccessible = true }.get(mod)
+                as? Shape
+            }
+            .getOrNull()
+      // `Modifier.background(color)` defaults its shape to `RectangleShape`; a plain rectangle is
+      // never a theme shape role, so skip it and keep scanning for a real (rounded/cut) shape.
+      if (shape != null && shape != RectangleShape) return shape.toString()
+    }
+    return null
   }
 
   private fun SemanticsConfiguration.layoutThemeFacts(): LayoutThemeFacts? {

--- a/data/theme/connector/src/test/kotlin/ee/schimke/composeai/daemon/ThemeConsumerCaptureShapeTest.kt
+++ b/data/theme/connector/src/test/kotlin/ee/schimke/composeai/daemon/ThemeConsumerCaptureShapeTest.kt
@@ -1,0 +1,49 @@
+package ee.schimke.composeai.daemon
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ThemeConsumerCaptureShapeTest {
+  private fun elements(modifier: Modifier): List<Any> =
+    modifier.foldIn(mutableListOf<Modifier.Element>()) { acc, element ->
+      acc.add(element)
+      acc
+    }
+
+  @Test
+  fun `reads the shape from a background(color, shape) modifier`() {
+    val shape = RoundedCornerShape(12.dp)
+    assertEquals(
+      shape.toString(),
+      ThemeConsumerCapture.shapeStringOf(elements(Modifier.background(Color.Red, shape))),
+    )
+  }
+
+  @Test
+  fun `reads the shape from a clip(shape) modifier`() {
+    val shape = RoundedCornerShape(8.dp)
+    assertEquals(
+      shape.toString(),
+      ThemeConsumerCapture.shapeStringOf(elements(Modifier.clip(shape))),
+    )
+  }
+
+  @Test
+  fun `a plain rectangular background carries no theme shape`() {
+    // `background(color)` defaults to RectangleShape — not a theme shape role.
+    assertNull(ThemeConsumerCapture.shapeStringOf(elements(Modifier.background(Color.Red))))
+  }
+
+  @Test
+  fun `no shape-bearing modifier yields null`() {
+    assertNull(ThemeConsumerCapture.shapeStringOf(elements(Modifier.padding(4.dp))))
+  }
+}

--- a/data/theme/connector/src/test/kotlin/ee/schimke/composeai/daemon/ThemeConsumerCaptureShapeTest.kt
+++ b/data/theme/connector/src/test/kotlin/ee/schimke/composeai/daemon/ThemeConsumerCaptureShapeTest.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.unit.dp
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -45,5 +46,31 @@ class ThemeConsumerCaptureShapeTest {
   @Test
   fun `no shape-bearing modifier yields null`() {
     assertNull(ThemeConsumerCapture.shapeStringOf(elements(Modifier.padding(4.dp))))
+  }
+
+  // A Wear scaling card fills through `Modifier.paint(BackgroundPainter)`, whose shape rides on the
+  // painter, not the modifier — matched reflectively by simple-name + a `painter`/`shape` field.
+  // These fakes reproduce that field shape without a Wear-compose dependency on the test classpath.
+  private class BackgroundPainter(@JvmField val shape: Shape)
+
+  private class PaintModifier(@JvmField val painter: Any)
+
+  @Test
+  fun `reads the shape from a BackgroundPainter behind a paint modifier`() {
+    val shape = RoundedCornerShape(20.dp)
+    assertEquals(
+      shape.toString(),
+      ThemeConsumerCapture.shapeStringOf(listOf(PaintModifier(BackgroundPainter(shape)))),
+    )
+  }
+
+  @Test
+  fun `a non-BackgroundPainter behind a paint modifier yields null`() {
+    class OtherPainter(@JvmField val shape: Shape)
+    assertNull(
+      ThemeConsumerCapture.shapeStringOf(
+        listOf(PaintModifier(OtherPainter(RoundedCornerShape(20.dp))))
+      )
+    )
   }
 }


### PR DESCRIPTION
## Summary

Shape attribution landed in #2574 — `ThemeConsumerAttribution` maps a node's
resolved `Shape` to the theme's shape scale — but nothing populated
`NodeThemeFacts.shape` from the render, so the leg was dark end to end. This adds
the **capture**:

- `ThemeConsumerCapture` reads each node's resolved clip/container `Shape` off
  its `LayoutNode` modifiers (`getModifierInfo()`): the inspector `shape`
  element first, then a reflected `shape` field, skipping the default
  `RectangleShape` — the same foundation-free path `ModifierTokenResolver` walks.
- A shape-bearing node is now emitted even when it carries no text (a
  `Surface`/`Card` is a non-text node, so its shape is the reason to appear);
  colour/typography still ride the text node's `TextLayoutResult` as before.

This closes the M3 triad on the capture side: a component preview now attributes
colour, typography, **and** corner shape per node, so a `DeviceBodyPreview`-style
design-parity token diff stops flagging `radius`/`shape` corner tokens as
"missing from candidate".

## Test plan

- `./gradlew :data-theme-connector:test` — `ThemeConsumerCaptureShapeTest`
  extracts the shape from `background(color, shape)` and `clip(shape)` off a real
  modifier chain, and returns `null` for a plain `RectangleShape` background and
  a shapeless `padding` modifier.
- `./gradlew :daemon:android:testDebugUnitTest --tests '*ThemeConsumerCaptureRenderTest*'`
  — renders a `Surface` clipped to `MaterialTheme.shapes.medium` under
  Robolectric, then asserts `extractFacts` captures that shape and
  `ThemeConsumerAttribution` maps it to the `medium` role. Green (1 test, 0
  failures).

Non-visual change (data-product plumbing + tests), so no rendered before/after
is applicable — the Robolectric render test is the behavioural evidence.

_Generated by [Claude Code](https://claude.ai/code/session_01PFaMPQ3D2PmcxAqsCZHD1e)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01PFaMPQ3D2PmcxAqsCZHD1e)_