### PR TITLE
fix(figma-svg): retry Google-Fonts fetch so a cold-start blip doesn't strand a preview

### DIFF
--- a/.github/workflows/design-artifacts.yml
+++ b/.github/workflows/design-artifacts.yml
@@ -149,15 +149,17 @@ jobs:
           MODULE: ${{ matrix.module }}
           SYSTEM: ${{ matrix.system }}
           # Embed the real (measured) face into each `compose/figma-svg` export.
-          # Without this the layered SVGs emit `font-family="sans-serif"` and a
-          # browser substitutes a wider fallback, so text drifts off the boxes we
-          # measured against Roboto (the button-label centering skew seen on the
-          # published stickers). The daemon's figma-svg export gates font embedding
-          # on `composeai.figma.embedFonts`; the daemon is spawned as a subprocess
-          # of `bundle pack`, so it inherits this via JAVA_TOOL_OPTIONS. It fetches
-          # the Roboto WOFF2 from the same Google-Fonts source (and cache) the
-          # renderer already uses for the PNGs, and degrades to `sans-serif` if the
-          # face is unreachable — so this never fails a render, only improves it.
+          # Without this the layered SVGs emit `font-family="<face>, sans-serif"`
+          # and a browser substitutes a wider fallback, so text drifts off the
+          # boxes we measured against the catalog face (the button-label centering
+          # skew seen on the published stickers). The daemon's figma-svg export
+          # gates font embedding on `composeai.figma.embedFonts`; the daemon is
+          # spawned as a subprocess of `bundle pack`, so it inherits this via
+          # JAVA_TOOL_OPTIONS. It fetches the catalog face (Roboto Flex) as WOFF2
+          # from the same Google-Fonts source (and cache) the renderer already uses
+          # for the PNGs — with bounded retries so a cold-start network blip doesn't
+          # strand a preview — and degrades to `sans-serif` if the face stays
+          # unreachable, so this never fails a render, only improves it.
           JAVA_TOOL_OPTIONS: -Dcomposeai.figma.embedFonts=true
           # Force Mesa's software GL path (no GPU on the runner) for the desktop
           # Skiko render; inert for the Robolectric (Android) catalog rows.

--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeFigmaSvgDataProduct.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeFigmaSvgDataProduct.kt
@@ -206,11 +206,22 @@ object ComposeFigmaSvgDataProducer {
       // A meaningful generic (serif/monospace) maps to a concrete embeddable family; a bare
       // cursive/fantasy has none, so skip embedding and let the text fall back to the generic.
       val name = FigmaLayeredSvg.embedFamily(captured, DEFAULT_EMBED_FAMILY) ?: return
-      resolver.woff2(name, weight, italic)?.let {
-        faces["$name|$weight|$italic|woff2"] =
-          FigmaSvgFontFace(name, weight, italic, Base64.getEncoder().encodeToString(it))
-        if (captured != null) overrides[captured] = name
+      val bytes = resolver.woff2(name, weight, italic)
+      if (bytes == null) {
+        // Fail loud: embedding was asked for (a resolver is present) but this concrete face didn't
+        // resolve — the `<text>` degrades to a named generic and the SVG renders with a substitute
+        // typeface (and, as an `<img>`, can't recover it). Surface it so a degraded bundle doesn't
+        // publish silently; a deliberately-offline render prints the same line, which is fine.
+        System.err.println(
+          "ComposeFigmaSvg: could not embed font \"$name\" " +
+            "(weight=$weight${if (italic) ", italic" else ""}) — the figma-svg text falls back to a " +
+            "generic family and will render with a substitute typeface"
+        )
+        return
       }
+      faces["$name|$weight|$italic|woff2"] =
+        FigmaSvgFontFace(name, weight, italic, Base64.getEncoder().encodeToString(bytes))
+      if (captured != null) overrides[captured] = name
     }
     // First gather the code points each face draws (across every `<text>` and wrapped `<tspan>`
     // that

--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/FigmaFontResolver.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/FigmaFontResolver.kt
@@ -32,6 +32,10 @@ class GoogleFontsWoff2Resolver(
   private val offline: Boolean = false,
   private val fileSystem: FileSystem = SystemFileSystem,
   private val httpGet: (String, String) -> ByteArray? = ::defaultFontHttpGet,
+  // Bounded retries around the fetch (see [downloadWithRetry]); injectable so tests can drop the
+  // sleep and drive the failure sequence deterministically.
+  private val maxAttempts: Int = DEFAULT_MAX_ATTEMPTS,
+  private val sleep: (Long) -> Unit = { Thread.sleep(it) },
 ) : FigmaFontResolver {
 
   override fun woff2(family: String, weight: Int, italic: Boolean): ByteArray? {
@@ -42,7 +46,7 @@ class GoogleFontsWoff2Resolver(
         return runCatching { fileSystem.read(it.path.toPath()) { readByteArray() } }.getOrNull()
       }
     if (offline) return null
-    val bytes = download(family, weight, italic) ?: return null
+    val bytes = downloadWithRetry(family, weight, italic) ?: return null
     cacheFile?.let { f ->
       runCatching {
         f.parentFile?.mkdirs()
@@ -50,6 +54,29 @@ class GoogleFontsWoff2Resolver(
       }
     }
     return bytes
+  }
+
+  /**
+   * [download] wrapped in bounded retries with exponential backoff. A whole-catalog render fires
+   * its first font fetches the instant the daemon subprocess starts — a cold DNS/TLS path that
+   * intermittently times out. A single such failure used to *permanently* degrade whichever
+   * previews raced the cold start: their SVGs fell back to a named `sans-serif` (rendering with a
+   * substitute typeface), while later previews — served from the now-warm disk cache — embedded the
+   * real face. Retrying the transient failure keeps one slow first connection from stranding a
+   * sticker. A genuinely unresolvable family (Google has no such face, so every attempt returns
+   * null) just exhausts the attempts and returns null — the same degradation as before, after a
+   * bounded wait.
+   */
+  private fun downloadWithRetry(family: String, weight: Int, italic: Boolean): ByteArray? {
+    var attempt = 1
+    while (true) {
+      download(family, weight, italic)?.let {
+        return it
+      }
+      if (attempt >= maxAttempts) return null
+      sleep(RETRY_BASE_DELAY_MS shl (attempt - 1))
+      attempt++
+    }
   }
 
   private fun download(family: String, weight: Int, italic: Boolean): ByteArray? {
@@ -63,6 +90,12 @@ class GoogleFontsWoff2Resolver(
     "${slugify(family)}-$weight${if (italic) "-italic" else ""}.woff2"
 
   companion object {
+    /** Total fetch attempts (initial + retries) before giving up on a transient network failure. */
+    const val DEFAULT_MAX_ATTEMPTS: Int = 3
+
+    /** First retry backoff (ms); doubles per attempt — 300, 600 for the default 3 attempts. */
+    private const val RETRY_BASE_DELAY_MS: Long = 300L
+
     private const val MODERN_UA =
       "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) " +
         "Chrome/120.0.0.0 Safari/537.36"

--- a/data/layoutinspector/connector/src/test/kotlin/ee/schimke/composeai/daemon/FigmaFontEmbedTest.kt
+++ b/data/layoutinspector/connector/src/test/kotlin/ee/schimke/composeai/daemon/FigmaFontEmbedTest.kt
@@ -87,6 +87,57 @@ class FigmaFontEmbedTest {
   }
 
   @Test
+  fun resolverRetriesTransientFailureThenSucceeds() {
+    // The first CSS fetch fails (a cold DNS/TLS path on a fresh daemon subprocess); the retry
+    // succeeds. The face must embed rather than be permanently stranded on one transient miss.
+    val css = "/* latin */ src: url(https://fonts.gstatic.com/lat.woff2) format('woff2');"
+    var cssAttempts = 0
+    val http: (String, String) -> ByteArray? = { url, _ ->
+      when {
+        url.contains("css2") -> if (++cssAttempts >= 2) css.toByteArray() else null
+        url.endsWith("lat.woff2") -> byteArrayOf(1, 2, 3, 4)
+        else -> null
+      }
+    }
+    val slept = mutableListOf<Long>()
+    val resolver =
+      GoogleFontsWoff2Resolver(
+        cacheDir = dir,
+        offline = false,
+        httpGet = http,
+        sleep = { slept.add(it) },
+      )
+
+    assertArrayEquals(byteArrayOf(1, 2, 3, 4), resolver.woff2("Roboto Flex", 500, false))
+    assertEquals("retried the failed CSS fetch once", 2, cssAttempts)
+    assertEquals("backed off once between the two attempts", listOf(300L), slept)
+  }
+
+  @Test
+  fun resolverGivesUpAfterMaxAttempts() {
+    // A genuinely unresolvable family exhausts the bounded attempts and returns null (the same
+    // degradation as before, just after a bounded wait) — it never loops forever.
+    var attempts = 0
+    val http: (String, String) -> ByteArray? = { _, _ ->
+      attempts++
+      null
+    }
+    val slept = mutableListOf<Long>()
+    val resolver =
+      GoogleFontsWoff2Resolver(
+        cacheDir = dir,
+        offline = false,
+        httpGet = http,
+        maxAttempts = 3,
+        sleep = { slept.add(it) },
+      )
+
+    assertEquals(null, resolver.woff2("No Such Family", 400, false))
+    assertEquals("one CSS fetch per attempt", 3, attempts)
+    assertEquals("exponential backoff between attempts", listOf(300L, 600L), slept)
+  }
+
+  @Test
   fun offlineResolverReturnsNullOnCacheMiss() {
     val http: (String, String) -> ByteArray? = { _, _ ->
       error("must not hit network when offline")


### PR DESCRIPTION
## Problem

`https://preview.coo.ee/compose-m3/render/button-elevated__ideal__default__light.svg` renders as **sans-serif** instead of Roboto Flex. The served SVG has **no `@font-face`** and its text carries `font-family="RobotoFlex, sans-serif"`, so a browser uses the `sans-serif` fallback (and bare `RobotoFlex` alone falls to the viewer's default *serif* — which is what "editing to just RobotoFlex" showed).

This is **preview-specific**, not stale output and not a global outage. In the *same* published bundle:

| preview | emitted `font-family` | `@font-face`? |
|---|---|---|
| button-elevated / button-filled / button-outlined label | `RobotoFlex, sans-serif` | ❌ |
| button-text / button-tonal / card-elevated / textfield-outlined | `Roboto Flex` | ✅ |

## Root cause

The `compose/figma-svg` export embeds each text node's face by fetching its WOFF2 from Google Fonts at render time (`GoogleFontsWoff2Resolver`). A whole-catalog render fires its first fetches the instant the daemon subprocess starts — a cold DNS/TLS path that intermittently times out. A single failure **permanently** degraded whichever previews raced the cold start (they fall back to a named `sans-serif`), while later previews served from the now-warm disk cache embedded the real face. The failures cluster at the start of render order (elevated/filled/outlined), which is exactly the observed split.

I confirmed the CSS2 API itself serves `Roboto Flex:wght@500` correctly, so it's render-time reliability, not the URL or the name derivation.

### Why not reference Google Fonts remotely instead of embedding?
Investigated and rejected: the compare/gallery displays SVGs via ``'&lt;img src=…&gt;'`` ("SVG-as-image" mode), where browsers **block** all external font loads (`@import` / remote `@font-face src`) — a remote reference would silently fall back to sans-serif there, relocating the bug. Figma ignores `@font-face` and resolves by family name; the fidelity harness inlines into a local `file://` page (a remote ref would re-add a network dependency at raster time). Self-contained embedding is required, so this hardens that path instead.

## Changes

- **`GoogleFontsWoff2Resolver`** — the fetch now retries with bounded exponential backoff (3 attempts, 300 ms / 600 ms; injectable sleeper for tests). A cold-start blip no longer strands a preview.
- **`ComposeFigmaSvgDataProducer`** — fail-loud: logs a warning to stderr when a concrete named face can't be embedded, instead of silently degrading, so a half-degraded bundle doesn't publish unnoticed.
- **`design-artifacts.yml`** — corrected the stale "Roboto" comment (the catalog face is Roboto Flex) and documented the retry behaviour.

## Test plan

- `./gradlew :data-layoutinspector-connector:test --tests "…FigmaFontEmbedTest"` — **passes**, including two new tests: retry-then-succeed (one backoff of 300 ms), and give-up-after-max (3 attempts, backoff `300, 600`).

## Visual evidence

The visible pixels come from the catalog render pipeline (full daemon + GL + network + Chromium), which can't run in this container, so I can't attach a rendered before/after here. Current **before** state is live and reproducible via the served SVGs above (elevated → `RobotoFlex, sans-serif`; tonal → `Roboto Flex`). The **after** lands when the `design-artifacts/compose-m3` delivery branch is regenerated — I'll dispatch `design-artifacts.yml` on `main` after this merges (per the delivery-branch house rule), and the CI visual-diff bot will render/diff `button-elevated` on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BUnpKN5KGZNFGKPjRVWdk9)_