### PR TITLE
fix(design-artifacts): fold only nested assets when merging catalogs

### DIFF
--- a/scripts/design-artifacts/merge-catalog-section.mjs
+++ b/scripts/design-artifacts/merge-catalog-section.mjs
@@ -17,28 +17,28 @@
  *  - strips each borrowed image's `livePreview` deep link (it targets the
  *    borrowed system's own server path, which would mis-link inside the host
  *    catalog — the borrowed section is baked-PNG here),
- *  - copies the borrowed catalog's asset tree (images / wireframes / figma-svg /
- *    …, everything except the top-level `catalog.json` + token projections) into
- *    the primary out dir at the same relative paths, refusing to clobber a
- *    differing primary file,
+ *  - folds the borrowed catalog's per-component assets — the files under its
+ *    subdirectories (`images/`, `wireframes/`, `figma/`) — into the primary out
+ *    dir at the same relative paths, refusing to clobber a differing primary
+ *    file,
  *  - appends the borrowed components to the primary `catalog.json` and rewrites
  *    it in place.
  *
- * The primary catalog's own `meta`, `themeTokens`, and token/Figma projections
- * are kept as-is; the borrowed catalog's token files are NOT merged (its
+ * A catalog's **top-level** files stay the host's: the manifest (`catalog.json`,
+ * merged separately above), the token/Figma projections, the `code-connect.json`
+ * mappings, and the generated `index.html` / `compare.html` / `README.md` pages
+ * — each is derived from that catalog's own component set, and both catalogs
+ * (produced by the same generator) carry them, so copying the borrowed ones would
+ * collide. The host's generated pages therefore don't reflect the folded section;
+ * the preview server renders tabs from the merged `catalog.json`, and a caller
+ * that needs the static pages refreshed re-runs the generator's page renderers
+ * over the merged catalog. The borrowed token files aren't merged either (the
  * re-themed pixels already carry the host palette — a token-set union is a
  * possible fast-follow). componentIds must not collide across the two catalogs.
  */
 import { parseArgs } from "node:util";
 import { readFile, writeFile, mkdir, readdir, stat } from "node:fs/promises";
 import { dirname, join, relative, resolve, sep } from "node:path";
-
-/** Top-level manifest / token files that describe a catalog, not its assets. */
-const CATALOG_META_FILES = new Set([
-  "catalog.json",
-  "tokens.dtcg.json",
-  "figma-variables.json",
-]);
 
 /**
  * Pure manifest merge: return a new primary manifest with [borrowed]'s components
@@ -86,18 +86,30 @@ async function sameBytes(a, b) {
 }
 
 /**
- * Copy the borrowed catalog's asset tree (everything but the top-level
- * {@link CATALOG_META_FILES}) from [fromDir] into [intoDir] at the same relative
- * paths. Returns the number of files copied. Throws if a destination already
- * exists with different bytes (a real collision — same relative asset path, two
- * different images).
+ * Fold the borrowed catalog's per-component assets — the files under its
+ * subdirectories (`images/`, `wireframes/`, `figma/`, …) — from [fromDir] into
+ * [intoDir] at the same relative paths. Returns the number of files copied.
+ * Throws if a NESTED asset already exists in the host with different bytes (a
+ * real collision — same asset path, two different images).
+ *
+ * Only nested files are folded: every **top-level** file a catalog emits is
+ * catalog-level, not a per-component asset — the manifest (`catalog.json`), the
+ * token projections (`tokens.dtcg.json` / `figma-variables.json`), the
+ * `code-connect.json` mappings, and the generated gallery pages (`index.html` /
+ * `compare.html` / `README.md`). Each is derived from that catalog's own
+ * component set, so the host keeps its own; copying the borrowed ones would both
+ * collide with the host's same-named page (different bytes → abort) and be wrong
+ * in the host. Skipping *every* top-level file (rather than a fixed denylist)
+ * stays correct if the generator grows a new top-level artifact.
  */
 async function copyAssets(fromDir, intoDir) {
   let copied = 0;
   for (const src of await listFiles(fromDir)) {
     const rel = relative(fromDir, src);
-    // Skip the borrowed catalog's own top-level manifest + token projections.
-    if (!rel.includes(sep) && CATALOG_META_FILES.has(rel)) continue;
+    // Top-level files are catalog-level (manifest / tokens / code-connect /
+    // generated pages), not per-component assets — the host keeps its own. Every
+    // foldable asset lives in a subdirectory (images/ / wireframes/ / figma/).
+    if (!rel.includes(sep)) continue;
     const dest = join(intoDir, rel);
     const existing = await stat(dest).catch(() => null);
     if (existing) {

--- a/scripts/design-artifacts/merge-catalog-section.test.mjs
+++ b/scripts/design-artifacts/merge-catalog-section.test.mjs
@@ -94,27 +94,71 @@ test("mergeCatalogSection folds assets in and rewrites catalog.json", async () =
   );
   await writeFile(join(into, "images/Device_Card/x.png"), "HOST-IMG");
 
-  // Borrowed catalog: one component, its image, and a token file that must NOT copy.
+  // Borrowed catalog: one component + its image, plus the top-level files every
+  // generated catalog carries (manifest / tokens / code-connect / pages) — none
+  // of which must be copied into the host.
   await mkdir(join(from, "images/Buttons_Filled"), { recursive: true });
   await writeFile(join(from, "catalog.json"), JSON.stringify(manifest([comp("Buttons/Filled")])));
   await writeFile(join(from, "images/Buttons_Filled/x.png"), "M3-IMG");
   await writeFile(join(from, "tokens.dtcg.json"), "{}");
+  await writeFile(join(from, "code-connect.json"), "{}");
+  await writeFile(join(from, "index.html"), "<html>m3</html>");
+  await writeFile(join(from, "README.md"), "# m3");
 
   const res = await mergeCatalogSection({ into, from, section: "Material 3" });
 
   assert.equal(res.componentsAdded, 1);
-  assert.equal(res.filesCopied, 1); // the borrowed image, not tokens.dtcg.json
+  assert.equal(res.filesCopied, 1); // only the nested image, none of the top-level files
 
   const merged = JSON.parse(await readFile(join(into, "catalog.json"), "utf8"));
   assert.deepEqual(
     merged.components.map((c) => [c.componentId, c.section]),
     [["Device/Card", "Components"], ["Buttons/Filled", "Material 3"]],
   );
-  // Borrowed image copied in; borrowed token file NOT copied.
+  // Borrowed image copied in; none of the borrowed top-level files leaked over.
   assert.equal(await readFile(join(into, "images/Buttons_Filled/x.png"), "utf8"), "M3-IMG");
-  assert.equal(await stat(join(into, "tokens.dtcg.json")).then(() => true, () => false), false);
+  for (const f of ["tokens.dtcg.json", "code-connect.json", "index.html", "README.md"]) {
+    assert.equal(
+      await stat(join(into, f)).then(() => true, () => false),
+      false,
+      `borrowed top-level ${f} must not be copied`,
+    );
+  }
   // Host image untouched.
   assert.equal(await readFile(join(into, "images/Device_Card/x.png"), "utf8"), "HOST-IMG");
+});
+
+test("mergeCatalogSection does not abort when both catalogs have differing top-level pages", async () => {
+  // The real case: host + borrowed are BOTH generated catalogs, so each carries
+  // its own index.html / code-connect.json / README.md with different bytes.
+  // Those are catalog-level, not assets — the merge must skip them, not collide.
+  const root = await mkdtemp(join(tmpdir(), "merge-catalog-pages-"));
+  const into = join(root, "into");
+  const from = join(root, "from");
+
+  await mkdir(join(into, "images/Host"), { recursive: true });
+  await writeFile(join(into, "catalog.json"), JSON.stringify(manifest([comp("Host/One")])));
+  await writeFile(join(into, "images/Host/x.png"), "HOST-IMG");
+  await writeFile(join(into, "index.html"), "<html>HOST</html>");
+  await writeFile(join(into, "code-connect.json"), '{"Host/One":{}}');
+
+  await mkdir(join(from, "images/M3"), { recursive: true });
+  await writeFile(join(from, "catalog.json"), JSON.stringify(manifest([comp("M3/Two")])));
+  await writeFile(join(from, "images/M3/x.png"), "M3-IMG");
+  await writeFile(join(from, "index.html"), "<html>M3-DIFFERENT</html>");
+  await writeFile(join(from, "code-connect.json"), '{"M3/Two":{}}');
+
+  const res = await mergeCatalogSection({ into, from, section: "Material 3" });
+
+  assert.equal(res.componentsAdded, 1);
+  assert.equal(res.filesCopied, 1); // only images/M3/x.png
+  // Host's own top-level pages are preserved verbatim (not clobbered, not aborted).
+  assert.equal(await readFile(join(into, "index.html"), "utf8"), "<html>HOST</html>");
+  assert.equal(await readFile(join(into, "code-connect.json"), "utf8"), '{"Host/One":{}}');
+  // The borrowed component + its asset still landed.
+  assert.equal(await readFile(join(into, "images/M3/x.png"), "utf8"), "M3-IMG");
+  const merged = JSON.parse(await readFile(join(into, "catalog.json"), "utf8"));
+  assert.equal(merged.components.some((c) => c.componentId === "M3/Two"), true);
 });
 
 test("mergeCatalogSection refuses to overwrite a differing asset", async () => {


### PR DESCRIPTION
## What

Fixes the Codex **P1** on #2586 (`merge-catalog-section`, merged): merging two *real* built catalogs aborts.

`copyAssets` copied every borrowed file except an explicit manifest/token denylist (`catalog.json`, `tokens.dtcg.json`, `figma-variables.json`). But a `generate-design-catalog.mjs` output also carries other top-level files — `index.html`, `compare.html`, `README.md`, `code-connect.json`. Those fell through as "assets", so when the host (also a generated catalog) already had its own same-named page with different bytes, the differing-asset guard threw and aborted the merge before `catalog.json` was rewritten. The original test used a *synthetic* host with no pages, which masked it — but the actual meshcore-reuses-compose-m3 case folds two real catalogs, which **always** collide.

## How

Fold only **nested** files. Every per-component asset lives in a subdirectory (`images/` / `wireframes/` / `figma/`); every **top-level** file is catalog-level — the manifest, the token/Figma projections, the `code-connect.json` mappings, and the generated `index.html` / `compare.html` / `README.md` pages — each derived from that catalog's own component set, so the host keeps its own. Skipping *every* top-level file (rather than a fixed denylist) also stays correct if the generator grows a new top-level artifact — which is exactly how the denylist missed these four.

The host's generated pages therefore don't reflect the folded section; the preview server renders tabs from the merged `catalog.json`, and a caller that needs the static pages refreshed re-runs the page renderers over the merged catalog (noted in the module doc). Nested-asset collision detection is unchanged (a genuinely-differing same-path asset still throws).

## Test plan

- `merge-catalog-section.test.mjs`: new test reproduces the two-differing-top-level-pages case (host + borrowed each carry their own `index.html` / `code-connect.json` with different bytes) — the merge now **folds cleanly** instead of aborting; the strengthened fold test asserts none of the borrowed top-level files (`tokens.dtcg.json` / `code-connect.json` / `index.html` / `README.md`) leak into the host. **136/136** `node --test scripts/design-artifacts/` green.
- End-to-end: folded compose-m3's **real** re-themed catalog — with its own `index.html` / `compare.html` / `README.md` / `code-connect.json` — into a page-bearing host: succeeds, 26 components into a "Material 3" tab, 126 nested assets copied, host pages preserved. Before this fix that path aborted.

Text-only: this is a merge-logic bugfix, no change to any rendered surface.

_Generated by [Claude Code](https://claude.ai/code/session_01KBurh9kb3NJ2KsmYRFhU62)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBurh9kb3NJ2KsmYRFhU62)_