### PR TITLE
fix(design-artifacts): stamp spec group sections onto the built catalog manifest

### DIFF
--- a/scripts/design-artifacts/apply-spec-sections.mjs
+++ b/scripts/design-artifacts/apply-spec-sections.mjs
@@ -1,0 +1,53 @@
+/**
+ * Re-stamp each spec group's top-level `section` onto the built catalog manifest.
+ *
+ * The generator sets `source.section = group.section` before handing sources to
+ * `buildCatalog`, but the pinned `@design-parity/catalog-export` (≤ 0.1.25)
+ * doesn't carry a source's `section` through to the emitted component — it never
+ * reads the field. So a spec that buckets its groups into top-level tabs
+ * (meshcore-mobile: Themes / Components / Screens) would otherwise collapse into
+ * a single untabbed "(none)" bucket on the preview server, while an
+ * externally-merged section (e.g. the folded-in "Material 3") survives only
+ * because it's written straight onto the manifest JSON.
+ *
+ * This closes that gap in the same post-process pass that injects `livePreview`
+ * into the written `catalog.json`: read each group's `section` from the spec and
+ * stamp it onto the manifest component with the matching `componentId`. It's the
+ * manifest-level analogue of what {@link file://./merge-catalog-section.mjs}
+ * already does for the borrowed section.
+ *
+ * Additive and idempotent by design:
+ *  - only components whose spec group declares a `section` are touched;
+ *  - a component that already carries a `section` (a future buildCatalog that
+ *    learns to propagate it, or the merge step's borrowed components) is left
+ *    exactly as-is — this never overwrites an existing tab assignment.
+ *
+ * Once `@design-parity/catalog-export` propagates `section` and the pin is
+ * bumped, this becomes a redundant no-op and can be dropped.
+ *
+ * @param {{components?: Array<{componentId: string, section?: string}>}} manifest
+ *   The parsed `catalog.json`, mutated in place.
+ * @param {{groups?: Array<{section?: string, components?: Array<{componentId: string}>}>}} spec
+ *   The catalog spec the manifest was built from.
+ * @returns {number} how many components had a `section` newly stamped.
+ */
+export function applySpecSections(manifest, spec) {
+  const sectionByComponentId = new Map();
+  for (const group of spec?.groups ?? []) {
+    if (group.section === undefined) continue;
+    for (const component of group.components ?? []) {
+      sectionByComponentId.set(component.componentId, group.section);
+    }
+  }
+
+  let stamped = 0;
+  for (const component of manifest?.components ?? []) {
+    if (component.section !== undefined) continue; // never clobber an existing tab
+    const section = sectionByComponentId.get(component.componentId);
+    if (section !== undefined) {
+      component.section = section;
+      stamped += 1;
+    }
+  }
+  return stamped;
+}

--- a/scripts/design-artifacts/apply-spec-sections.test.mjs
+++ b/scripts/design-artifacts/apply-spec-sections.test.mjs
@@ -1,0 +1,101 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { applySpecSections } from "./apply-spec-sections.mjs";
+
+const comp = (componentId, extra = {}) => ({ componentId, images: [], ...extra });
+const manifest = (components) => ({ schema: "design-parity-catalog/v1", system: "s", components });
+
+test("stamps each spec group's section onto matching manifest components", () => {
+  const spec = {
+    groups: [
+      { name: "Foundation", section: "Themes", components: [{ componentId: "Theme/Light" }] },
+      { name: "Device", section: "Components", components: [{ componentId: "Card/Populated" }] },
+      { name: "Chat", section: "Screens", components: [{ componentId: "Chat/Contact" }] },
+    ],
+  };
+  const m = manifest([comp("Theme/Light"), comp("Card/Populated"), comp("Chat/Contact")]);
+
+  const stamped = applySpecSections(m, spec);
+
+  assert.equal(stamped, 3);
+  assert.equal(m.components[0].section, "Themes");
+  assert.equal(m.components[1].section, "Components");
+  assert.equal(m.components[2].section, "Screens");
+});
+
+test("is a no-op when no spec group declares a section (compose-m3 style)", () => {
+  const spec = {
+    groups: [{ name: "Buttons", components: [{ componentId: "Buttons/Filled" }] }],
+  };
+  const m = manifest([comp("Buttons/Filled")]);
+
+  const stamped = applySpecSections(m, spec);
+
+  assert.equal(stamped, 0);
+  assert.equal("section" in m.components[0], false);
+});
+
+test("never clobbers a section already on the component (e.g. a merged Material 3 tab)", () => {
+  const spec = {
+    groups: [{ name: "Foundation", section: "Themes", components: [{ componentId: "Theme/Light" }] }],
+  };
+  // The borrowed component already carries its own tab from the merge step.
+  const m = manifest([comp("Theme/Light"), comp("Buttons/Filled", { section: "Material 3" })]);
+
+  const stamped = applySpecSections(m, spec);
+
+  assert.equal(stamped, 1); // only Theme/Light gets one
+  assert.equal(m.components[0].section, "Themes");
+  assert.equal(m.components[1].section, "Material 3"); // untouched
+});
+
+test("leaves manifest components absent from the spec untouched", () => {
+  const spec = {
+    groups: [{ name: "Foundation", section: "Themes", components: [{ componentId: "Theme/Light" }] }],
+  };
+  const m = manifest([comp("Theme/Light"), comp("Orphan/NotInSpec")]);
+
+  applySpecSections(m, spec);
+
+  assert.equal(m.components[0].section, "Themes");
+  assert.equal("section" in m.components[1], false);
+});
+
+test("is idempotent — a second pass stamps nothing", () => {
+  const spec = {
+    groups: [{ name: "Foundation", section: "Themes", components: [{ componentId: "Theme/Light" }] }],
+  };
+  const m = manifest([comp("Theme/Light")]);
+
+  assert.equal(applySpecSections(m, spec), 1);
+  assert.equal(applySpecSections(m, spec), 0);
+  assert.equal(m.components[0].section, "Themes");
+});
+
+test("tolerates missing/empty groups and components without throwing", () => {
+  assert.equal(applySpecSections({ components: [] }, {}), 0);
+  assert.equal(applySpecSections({}, { groups: [] }), 0);
+  assert.equal(applySpecSections({ components: [comp("X")] }, { groups: [{ section: "T" }] }), 0);
+});
+
+test("reproduces the meshcore split — Themes/Components/Screens distribution", () => {
+  // A trimmed stand-in for meshcore's spec shape: three tabs across several groups.
+  const spec = {
+    groups: [
+      { name: "Foundation", section: "Themes", components: [{ componentId: "Theme/A" }, { componentId: "Theme/B" }] },
+      { name: "Device", section: "Components", components: [{ componentId: "Card/A" }] },
+      { name: "Contacts", section: "Components", components: [{ componentId: "Row/A" }, { componentId: "Row/B" }] },
+      { name: "Scanner", section: "Screens", components: [{ componentId: "Scan/A" }] },
+      { name: "Chat", section: "Screens", components: [{ componentId: "Chat/A" }, { componentId: "Chat/B" }] },
+    ],
+  };
+  const ids = ["Theme/A", "Theme/B", "Card/A", "Row/A", "Row/B", "Scan/A", "Chat/A", "Chat/B"];
+  const m = manifest(ids.map((id) => comp(id)));
+
+  applySpecSections(m, spec);
+
+  const dist = {};
+  for (const c of m.components) dist[c.section] = (dist[c.section] ?? 0) + 1;
+  assert.deepEqual(dist, { Themes: 2, Components: 3, Screens: 3 });
+});

--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -62,6 +62,7 @@ import { DEFAULT_PREVIEW_BASE, livePreviewUrl } from "./live-preview.mjs";
 import { buildFontsManifest, fontsPayloadsFromBundle } from "./render-fonts-manifest.mjs";
 import { candidatePreviewBundle } from "./bundle-previews.mjs";
 import { bridgeLivePreviewIds } from "./bridge-live-preview-ids.mjs";
+import { applySpecSections } from "./apply-spec-sections.mjs";
 
 /**
  * Best-effort fetch + parse of a JSON URL, with a short timeout. Returns null on
@@ -593,6 +594,14 @@ if (values["publish-live-bundle"]) {
 {
   const catalogJsonPath = join(outPath, "catalog.json");
   const manifest = JSON.parse(await readFile(catalogJsonPath, "utf8"));
+  // Re-stamp each spec group's top-level `section` (the preview-server tab) onto
+  // the manifest: the pinned buildCatalog drops `source.section`, so without this
+  // a sectioned spec (meshcore's Themes / Components / Screens) collapses to one
+  // untabbed bucket. No-op for specs with no group `section` (compose-m3 et al.).
+  const stampedSections = applySpecSections(manifest, spec);
+  if (stampedSections > 0) {
+    console.log(`[${spec.system}] stamped section on ${stampedSections} component(s) from spec groups`);
+  }
   for (const component of manifest.components ?? []) {
     for (const image of component.images ?? []) {
       if (image.path) image.livePreview = livePreviewUrl(previewBase, manifest.system, image.path);


### PR DESCRIPTION
## Summary

A catalog spec can bucket its groups into top-level tabs via each group's `section` (e.g. meshcore-mobile's **Themes / Components / Screens**). `generate-design-catalog.mjs` already sets `source.section = group.section` before building — but the pinned `@design-parity/catalog-export@0.1.25` **never reads that field**, so `buildCatalog` drops it. The emitted `catalog.json` components carry no `section`, and the preview server collapses the whole system into a single untabbed **"(none)"** bucket.

Only an *externally-merged* section survived — the folded-in "Material 3" tab — because `merge-catalog-section.mjs` writes `section` straight onto the manifest JSON, after `buildCatalog`. Native components had no such second chance.

## Fix

Re-stamp each spec group's `section` onto the manifest in the same post-process pass that already injects `livePreview` into the written `catalog.json` — the manifest-level analogue of what the merge step does for the borrowed tab. Extracted as a pure, unit-tested helper (`apply-spec-sections.mjs`).

**Additive & idempotent:** only components whose spec group declares a `section` are touched, and an existing `section` (a future `buildCatalog` that propagates it, or the merge step's borrowed components) is never overwritten. Once `catalog-export` propagates `section` upstream and the pin is bumped, this reverts to a redundant no-op.

## Effect (meshcore-mobile)

The served catalog gains its intended tab structure — the spec already declared it; it just wasn't reaching the manifest:

| | Before | After |
|---|---|---|
| Themes | — | 4 |
| Components | — | 17 |
| Screens | — | 21 |
| Material&nbsp;3 | 26 | 26 |
| **(none)** | **42** | **0** |

## Blast radius

The `m3`, `wear-m3`, and `remote-m3` specs declare **zero** group sections, so `applySpecSections` stamps nothing and those bundles are byte-for-byte unchanged. Only meshcore-mobile (the one sectioned spec) is affected. `meshcore-mobile`'s `design-artifacts.yml` checks out `compose-ai-tools@main`, so it picks this up on its next run.

The static `index.html` groups by `group` (unaffected); the change is confined to `catalog.json`'s per-component `section`, which is a data field — no rendered pixel changes, so no visual diff applies.

## Test plan

- `apply-spec-sections.test.mjs` — 7 cases: stamps by group; no-op for sectionless specs; never clobbers an existing `section`; leaves spec-absent components alone; idempotent; null-safety; and a meshcore-shaped distribution assertion.
- Full suite green: `node --test scripts/design-artifacts/*.test.mjs` → **143/143** (was 136; +7).
- `node --check` on the modified generator.

_Generated by [Claude Code](https://claude.ai/code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBurh9kb3NJ2KsmYRFhU62)_