### PR TITLE
chore(serve): serve confetti-wear catalog from joreilly/Confetti

### DIFF
--- a/deploy/image/entrypoint.sh
+++ b/deploy/image/entrypoint.sh
@@ -30,7 +30,7 @@ fi
 # The published catalog set is BAKED INTO THE IMAGE (same `:=` + `none` convention
 # as SERVE_TRUST_STORE below), so a bare `docker pull` / Watchtower auto-update
 # self-heals without editing the box's compose. Front-page systems:
-: "${SERVE_CATALOGS:=compose-m3,wear-m3,remote-m3,meshcore-mobile@yschimke/meshcore-mobile,homeassistant-remotecompose@yschimke/homeassistant-remotecompose,confetti-wear@yschimke/Confetti}"
+: "${SERVE_CATALOGS:=compose-m3,wear-m3,remote-m3,meshcore-mobile@yschimke/meshcore-mobile,homeassistant-remotecompose@yschimke/homeassistant-remotecompose,confetti-wear@joreilly/Confetti}"
 [[ "${SERVE_CATALOGS}" != "none" ]] && args+=(--catalogs "${SERVE_CATALOGS}")
 # …and cadence, served UNLISTED from its own repo — reachable at /cadence/ (and ?session=cadence)
 # but kept OFF the front-page index. (meshcore-mobile / homeassistant-remotecompose are LISTED above


### PR DESCRIPTION
## Summary

Point the baked front-page `confetti-wear` catalog at **`joreilly/Confetti`** instead of the `yschimke/Confetti` fork.

The wear previews and the design-catalog job have merged upstream into `joreilly/Confetti` (PRs #1702 / #1703), and `joreilly/Confetti` now publishes the importable bundle to its own `design-artifacts/confetti-wear` branch (confirmed present, last updated 2026-07-20). Serving from the canonical upstream repo means preview.coo.ee tracks the source of truth rather than the fork.

`joreilly/Confetti` is already trusted in `deploy/image/trust/producers.json` (`design-artifacts/*`), so the catalog still badges Trusted(Branch) with no trust-store change.

## Change

`deploy/image/entrypoint.sh` — one token in the baked `SERVE_CATALOGS` default:

```diff
-…,confetti-wear@yschimke/Confetti}"
+…,confetti-wear@joreilly/Confetti}"
```

Single system id `confetti-wear` maps to one repo in the front-page list, so this is a switch (not an add). The `vps`/`cloudrun` deploys leave `SERVE_CATALOGS` unset and inherit this baked default.

## Test plan

- Text/config-only change to the image entrypoint default — no code or renderable surface affected.
- After merge + image publish (or `docker pull` / Watchtower), the front-page `confetti-wear` sticker resolves from `joreilly/Confetti@design-artifacts/confetti-wear`; the branch's `SERVE_CATALOG_REFRESH` loop keeps it fresh without a restart.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LsfqPFRpxuN9qULr9h6SVJ)_