### PR TITLE
fix(daemon): spawn the render daemon via a classpath @argfile to survive large modules

### DIFF
--- a/common/io/src/main/kotlin/ee/schimke/composeai/io/JvmClasspathArg.kt
+++ b/common/io/src/main/kotlin/ee/schimke/composeai/io/JvmClasspathArg.kt
@@ -1,0 +1,41 @@
+package ee.schimke.composeai.io
+
+import java.io.File
+
+/**
+ * Build the `-classpath` portion of a `java …` command in a form that cannot overflow the OS
+ * argument limit (`execve` `E2BIG` — "Argument list too long").
+ *
+ * A large module's render classpath — a full app's *hundreds* of jars — blows past `ARG_MAX` (and
+ * the per-argument `MAX_ARG_STRLEN`) when passed as a literal `-cp <jar:jar:…>` argument. The spawn
+ * then fails with `error=7`, which silently drops the daemon subprocess: e.g. the
+ * `--with-semantics` layout-inspector capture never starts, so the catalog renders without
+ * wireframe / figma SVGs. Small catalog/sample modules stay under the limit, so the failure stays
+ * invisible until a real app module hits it.
+ *
+ * The fix is a Java **@argfile**: write `-classpath "<cp>"` to a file and pass the single token
+ * `@<file>` on the command line. The launcher reads the classpath from the file, so `argv` stays
+ * short no matter how big the classpath is. Argfiles are honoured by every `java` launcher since
+ * JDK 9.
+ *
+ * @return the `@<file>` token to splice into the command **in place of** `-cp`/`-classpath` + the
+ *   joined classpath. The file is created under the JVM temp dir and registered for deletion on
+ *   exit.
+ */
+fun classpathArgFile(classpath: List<String>): String {
+  require(classpath.isNotEmpty()) { "classpath must not be empty" }
+  val joined = classpath.joinToString(File.pathSeparator)
+  val file = File.createTempFile("composeai-cp", ".args")
+  file.deleteOnExit()
+  file.writeText("-classpath ${quoteForArgFile(joined)}\n")
+  return "@" + file.absolutePath
+}
+
+/**
+ * Quote a single token for a Java argfile. Wrap it in double quotes so embedded whitespace stays one
+ * argument, and double every backslash so Windows paths survive the argfile's `\`-escape rule (the
+ * launcher un-escapes `\\` → `\`, `\"` → `"`). On POSIX classpaths (no backslashes, rarely a space)
+ * this is effectively just the surrounding quotes.
+ */
+internal fun quoteForArgFile(token: String): String =
+  "\"" + token.replace("\\", "\\\\").replace("\"", "\\\"") + "\""

--- a/common/io/src/main/kotlin/ee/schimke/composeai/io/JvmClasspathArg.kt
+++ b/common/io/src/main/kotlin/ee/schimke/composeai/io/JvmClasspathArg.kt
@@ -1,6 +1,18 @@
 package ee.schimke.composeai.io
 
 import java.io.File
+import java.nio.charset.Charset
+
+/**
+ * The charset the `java` launcher uses to decode an `@argfile` — the platform **native** encoding
+ * (`sun.jnu.encoding`, the same charset filenames use), NOT necessarily UTF-8. Writing the argfile
+ * in UTF-8 would corrupt a non-ASCII classpath entry (e.g. a Gradle cache under `C:\Users\José`) on
+ * a non-UTF-8 locale, leaving the spawned daemon unable to resolve its classes. Fall back to the
+ * JVM default only if the property is somehow unset/unknown.
+ */
+private val ARGFILE_CHARSET: Charset =
+  runCatching { Charset.forName(System.getProperty("sun.jnu.encoding")) }
+    .getOrDefault(Charset.defaultCharset())
 
 /**
  * Build the `-classpath` portion of a `java …` command in a form that cannot overflow the OS
@@ -27,15 +39,15 @@ fun classpathArgFile(classpath: List<String>): String {
   val joined = classpath.joinToString(File.pathSeparator)
   val file = File.createTempFile("composeai-cp", ".args")
   file.deleteOnExit()
-  file.writeText("-classpath ${quoteForArgFile(joined)}\n")
+  file.writeText("-classpath ${quoteForArgFile(joined)}\n", ARGFILE_CHARSET)
   return "@" + file.absolutePath
 }
 
 /**
- * Quote a single token for a Java argfile. Wrap it in double quotes so embedded whitespace stays one
- * argument, and double every backslash so Windows paths survive the argfile's `\`-escape rule (the
- * launcher un-escapes `\\` → `\`, `\"` → `"`). On POSIX classpaths (no backslashes, rarely a space)
- * this is effectively just the surrounding quotes.
+ * Quote a single token for a Java argfile. Wrap it in double quotes so embedded whitespace stays
+ * one argument, and double every backslash so Windows paths survive the argfile's `\`-escape rule
+ * (the launcher un-escapes `\\` → `\`, `\"` → `"`). On POSIX classpaths (no backslashes, rarely a
+ * space) this is effectively just the surrounding quotes.
  */
 internal fun quoteForArgFile(token: String): String =
   "\"" + token.replace("\\", "\\\\").replace("\"", "\\\"") + "\""

--- a/common/io/src/test/kotlin/ee/schimke/composeai/io/JvmClasspathArgTest.kt
+++ b/common/io/src/test/kotlin/ee/schimke/composeai/io/JvmClasspathArgTest.kt
@@ -16,10 +16,7 @@ class JvmClasspathArgTest {
     assertTrue(token.startsWith("@"), "expected an @argfile token, got: $token")
     val file = File(token.removePrefix("@"))
     assertTrue(file.isFile, "argfile should exist on disk")
-    assertEquals(
-      "-classpath \"${cp.joinToString(File.pathSeparator)}\"\n",
-      file.readText(),
-    )
+    assertEquals("-classpath \"${cp.joinToString(File.pathSeparator)}\"\n", file.readText())
   }
 
   @Test

--- a/common/io/src/test/kotlin/ee/schimke/composeai/io/JvmClasspathArgTest.kt
+++ b/common/io/src/test/kotlin/ee/schimke/composeai/io/JvmClasspathArgTest.kt
@@ -1,0 +1,57 @@
+package ee.schimke.composeai.io
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class JvmClasspathArgTest {
+
+  @Test
+  fun `emits an @argfile token backed by a -classpath file`() {
+    val cp = listOf("/a/b.jar", "/c/d.jar")
+    val token = classpathArgFile(cp)
+
+    assertTrue(token.startsWith("@"), "expected an @argfile token, got: $token")
+    val file = File(token.removePrefix("@"))
+    assertTrue(file.isFile, "argfile should exist on disk")
+    assertEquals(
+      "-classpath \"${cp.joinToString(File.pathSeparator)}\"\n",
+      file.readText(),
+    )
+  }
+
+  @Test
+  fun `command length stays bounded no matter how large the classpath is`() {
+    // The whole point: a full app's render classpath (hundreds of long jar paths) must NOT land on
+    // the command line, where it overflows ARG_MAX (execve E2BIG). The @argfile token is a short,
+    // fixed-shape reference regardless of classpath size.
+    val huge = (1..5_000).map { "/nix/store/${"x".repeat(40)}/lib/artifact-$it.jar" }
+    val joinedBytes = huge.joinToString(File.pathSeparator).length
+    val token = classpathArgFile(huge)
+
+    assertTrue(joinedBytes > 200_000, "sanity: the raw classpath really is huge ($joinedBytes B)")
+    assertTrue(
+      token.length < 512,
+      "the @argfile token must stay short (was ${token.length} B) so argv can't overflow",
+    )
+    // …and the file still round-trips the full classpath.
+    val body = File(token.removePrefix("@")).readText()
+    assertTrue(body.contains("artifact-5000.jar"), "argfile should carry every entry")
+  }
+
+  @Test
+  fun `quotes and escapes spaces, backslashes and quotes for the argfile grammar`() {
+    // Wrapped in quotes; backslashes doubled (argfile un-escapes \\ -> \); embedded quote escaped.
+    assertEquals("\"/plain/path.jar\"", quoteForArgFile("/plain/path.jar"))
+    assertEquals("\"/has a space/x.jar\"", quoteForArgFile("/has a space/x.jar"))
+    assertEquals("\"C:\\\\Program Files\\\\a.jar\"", quoteForArgFile("C:\\Program Files\\a.jar"))
+    assertEquals("\"weird\\\"name.jar\"", quoteForArgFile("weird\"name.jar"))
+  }
+
+  @Test
+  fun `rejects an empty classpath`() {
+    assertFailsWith<IllegalArgumentException> { classpathArgFile(emptyList()) }
+  }
+}

--- a/daemon/harness/src/main/kotlin/ee/schimke/composeai/daemon/harness/HarnessLauncher.kt
+++ b/daemon/harness/src/main/kotlin/ee/schimke/composeai/daemon/harness/HarnessLauncher.kt
@@ -117,7 +117,8 @@ class FakeHarnessLauncher(
           add("-Dcomposeai.daemon.history.autoPruneIntervalMs=$pruneAutoIntervalMs")
         addHistorySyspropsIfSet()
         addAll(extraJvmArgs)
-        // @argfile so a large harness classpath can't overflow the OS arg limit — see classpathArgFile.
+        // @argfile so a large harness classpath can't overflow the OS arg limit — see
+        // classpathArgFile.
         add(classpathArgFile(classpath.map { it.absolutePath }))
         add(mainClass)
       }
@@ -192,7 +193,8 @@ class RealDesktopHarnessLauncher(
         add("-Dcomposeai.daemon.discoveryWatchdogMs=500")
         addHistorySyspropsIfSet()
         addAll(extraJvmArgs)
-        // @argfile so a large harness classpath can't overflow the OS arg limit — see classpathArgFile.
+        // @argfile so a large harness classpath can't overflow the OS arg limit — see
+        // classpathArgFile.
         add(classpathArgFile(fullClasspath.map { it.absolutePath }))
         add("ee.schimke.composeai.daemon.DaemonMain")
       }
@@ -336,7 +338,8 @@ class RealAndroidHarnessLauncher(
         add("-Dcomposeai.daemon.idleTimeoutMs=2000")
         addHistorySyspropsIfSet()
         addAll(extraJvmArgs)
-        // @argfile so a large harness classpath can't overflow the OS arg limit — see classpathArgFile.
+        // @argfile so a large harness classpath can't overflow the OS arg limit — see
+        // classpathArgFile.
         add(classpathArgFile(fullClasspath.map { it.absolutePath }))
         add("ee.schimke.composeai.daemon.DaemonMain")
       }

--- a/daemon/harness/src/main/kotlin/ee/schimke/composeai/daemon/harness/HarnessLauncher.kt
+++ b/daemon/harness/src/main/kotlin/ee/schimke/composeai/daemon/harness/HarnessLauncher.kt
@@ -1,6 +1,7 @@
 package ee.schimke.composeai.daemon.harness
 
 import ee.schimke.composeai.io.SystemFileSystem
+import ee.schimke.composeai.io.classpathArgFile
 import java.io.File
 import okio.FileSystem
 import okio.Path.Companion.toPath
@@ -90,7 +91,6 @@ class FakeHarnessLauncher(
       "FakeHarnessLauncher.spawn: fixtureDir '${fixtureDir.absolutePath}' is not a directory"
     }
     val javaBin = File(System.getProperty("java.home"), "bin/java")
-    val cpString = classpath.joinToString(File.pathSeparator) { it.absolutePath }
     val command =
       buildList<String> {
         add(javaBin.absolutePath)
@@ -117,8 +117,8 @@ class FakeHarnessLauncher(
           add("-Dcomposeai.daemon.history.autoPruneIntervalMs=$pruneAutoIntervalMs")
         addHistorySyspropsIfSet()
         addAll(extraJvmArgs)
-        add("-cp")
-        add(cpString)
+        // @argfile so a large harness classpath can't overflow the OS arg limit — see classpathArgFile.
+        add(classpathArgFile(classpath.map { it.absolutePath }))
         add(mainClass)
       }
     return ProcessBuilder(command)
@@ -182,7 +182,6 @@ class RealDesktopHarnessLauncher(
     }
     val javaBin = File(System.getProperty("java.home"), "bin/java")
     val fullClasspath = classpath + extraClasspath
-    val cpString = fullClasspath.joinToString(File.pathSeparator) { it.absolutePath }
     val command =
       buildList<String> {
         add(javaBin.absolutePath)
@@ -193,8 +192,8 @@ class RealDesktopHarnessLauncher(
         add("-Dcomposeai.daemon.discoveryWatchdogMs=500")
         addHistorySyspropsIfSet()
         addAll(extraJvmArgs)
-        add("-cp")
-        add(cpString)
+        // @argfile so a large harness classpath can't overflow the OS arg limit — see classpathArgFile.
+        add(classpathArgFile(fullClasspath.map { it.absolutePath }))
         add("ee.schimke.composeai.daemon.DaemonMain")
       }
     return ProcessBuilder(command)
@@ -299,7 +298,6 @@ class RealAndroidHarnessLauncher(
     }
     val javaBin = File(System.getProperty("java.home"), "bin/java")
     val fullClasspath = classpath + extraClasspath
-    val cpString = fullClasspath.joinToString(File.pathSeparator) { it.absolutePath }
     val command =
       buildList<String> {
         add(javaBin.absolutePath)
@@ -338,8 +336,8 @@ class RealAndroidHarnessLauncher(
         add("-Dcomposeai.daemon.idleTimeoutMs=2000")
         addHistorySyspropsIfSet()
         addAll(extraJvmArgs)
-        add("-cp")
-        add(cpString)
+        // @argfile so a large harness classpath can't overflow the OS arg limit — see classpathArgFile.
+        add(classpathArgFile(fullClasspath.map { it.absolutePath }))
         add("ee.schimke.composeai.daemon.DaemonMain")
       }
     return ProcessBuilder(command)

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpMain.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpMain.kt
@@ -183,7 +183,8 @@ class SubprocessDaemonClientFactory : DaemonClientFactory {
         descriptor.systemProperties.forEach { (k, v) -> add("-D$k=$v") }
         // A full-app render classpath (hundreds of jars) overflows the OS arg limit if passed as a
         // literal `-cp`, which silently drops the daemon (e.g. --with-semantics capture). Pass it
-        // via a Java @argfile so argv stays short regardless of classpath size (see classpathArgFile).
+        // via a Java @argfile so argv stays short regardless of classpath size (see
+        // classpathArgFile).
         add(classpathArgFile(descriptor.classpath))
         add(descriptor.mainClass)
       }

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpMain.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpMain.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.mcp
 
+import ee.schimke.composeai.io.classpathArgFile
 import io.modelcontextprotocol.kotlin.sdk.types.Implementation
 import java.io.File
 import java.util.concurrent.TimeUnit
@@ -175,14 +176,15 @@ class SubprocessDaemonClientFactory : DaemonClientFactory {
     }
     val javaBin =
       descriptor.javaLauncher ?: File(System.getProperty("java.home"), "bin/java").absolutePath
-    val cpString = descriptor.classpath.joinToString(File.pathSeparator)
     val command =
       buildList<String> {
         add(javaBin)
         addAll(descriptor.jvmArgs)
         descriptor.systemProperties.forEach { (k, v) -> add("-D$k=$v") }
-        add("-cp")
-        add(cpString)
+        // A full-app render classpath (hundreds of jars) overflows the OS arg limit if passed as a
+        // literal `-cp`, which silently drops the daemon (e.g. --with-semantics capture). Pass it
+        // via a Java @argfile so argv stays short regardless of classpath size (see classpathArgFile).
+        add(classpathArgFile(descriptor.classpath))
         add(descriptor.mainClass)
       }
     val process =


### PR DESCRIPTION
## Problem

`bundle pack --with-semantics` on a large app module silently produces a catalog with **no wireframe / figma SVGs**. Root cause: the daemon subprocess is spawned as `java … -cp <full-classpath> DaemonMain`, and a full app's render classpath (hundreds of jars) overflows the OS argument limit:

```
Failed to spawn daemon subprocess for :wearApp:
  Cannot run program ".../java" … error=7, Argument list too long
→ bundle written without semantics.
```

The CLI degrades gracefully (writes the bundle **without** the layout-inspector trees), so there's no hard failure — the semantics/wireframe/figma-svg data products just never get produced. Small catalog/sample modules stay under the limit, so the bug is invisible until a real app module hits it.

**Reproduced** with the released CLI (both 0.16.57 and 0.17.0):

| module | `bundle pack --with-semantics` result |
|---|---|
| confetti `:wearApp` (full app) | `PACK_EXIT=0`, **0** `.layout.json` trees → `error=7` in the log → PNG-only catalog |
| `wear-m3` sample (small) | classpath fits → **52** `figma/*.svg` + wireframes |

## Fix

Pass the classpath through a Java **@argfile** (`java @cp.args MainClass`) instead of a literal `-cp` argument, so `argv` stays short regardless of classpath size. Argfiles are honoured by every `java` launcher since JDK 9.

Factored into a shared `classpathArgFile()` helper in `:common-io` (coroutines-free, safe on the render subprocess classpath) and applied at **every** JVM daemon spawn — I audited the repo for the same pattern:

- `SubprocessDaemonClientFactory.spawn` (`:mcp`) — the primary path: `bundle pack` **and** the serve live-render both ride this (`ServeBundleDaemon` writes a descriptor `SubprocessRenderSessions.open` reads → same factory).
- `HarnessLauncher` — all three launchers (`Fake` / `RealDesktop` / `RealAndroid`).

Not touched (not exposed): the `…Cli --classpath` entrypoints (`DaemonLaunchBuilderCli` / `PreviewDiscoveryCli` / `RenderCli`) **receive** the classpath as a parsed arg from an external build system (Bazel/Amper) — the overflow risk there is on that spawner, and those systems (e.g. Bazel params files) handle it themselves. Worth a follow-up to let them accept `@file` too, but out of scope here.

## Test plan

- New `JvmClasspathArgTest` in `:common-io`: asserts the `@argfile` round-trips the classpath, that the returned token stays short for a 5 000-entry / >200 KB classpath (the overflow invariant), and that argfile quoting escapes spaces / backslashes / quotes.
- `./gradlew :common-io:test :common-io:ktfmtCheck :mcp:compileKotlin` passes locally.
- Text-only PR (daemon/build plumbing — no visual surface). After this ships, re-running the confetti-wear catalog job produces the layout trees → wireframes + figma SVGs populate.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LsfqPFRpxuN9qULr9h6SVJ)_