### PR TITLE
fix(figma-svg): resolve Modifier.shadow elevation for drop-shadow export

### DIFF
--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ModifierTokenResolver.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ModifierTokenResolver.kt
@@ -156,14 +156,24 @@ internal object ModifierTokenResolver {
   }
 
   /**
-   * The shadow elevation of a `graphicsLayer` modifier in dp, or null when it casts no shadow.
-   * `GraphicsLayerScope.shadowElevation` is a raw **pixel** value (a `Modifier.shadow(elevation:
-   * Dp)` converts dp→px before setting it), and the inspector reports it in px too — so both the
-   * inspector `shadowElevation` element and the reflected field are divided by [density] to recover
-   * dp. Zero (a clip-only graphicsLayer) returns null.
+   * The shadow elevation of a `graphicsLayer`/`shadow` modifier in dp, or null when it casts no
+   * shadow. Two shapes carry it, so both are probed:
+   * - A `graphicsLayer { shadowElevation = … }` (what `Surface`/`Card`/`FAB` cast their Material
+   *   shadow through) exposes `GraphicsLayerScope.shadowElevation`, a raw **pixel** value — the
+   *   inspector reports it in px too, so both the inspector `shadowElevation` element and the
+   *   reflected field are divided by [density] to recover dp.
+   * - A bare `Modifier.shadow(elevation: Dp)` lowers to a `ShadowGraphicsLayerElement` (also
+   *   matched by the `GraphicsLayer` name gate) that keeps its **`Dp` `elevation`** instead —
+   *   already dp, so it is read as-is with no `/ density`. Without this fallback such a node
+   *   resolved null and the figma-svg export dropped its `feDropShadow` (issue #2357).
+   *
+   * Zero / non-positive (a clip-only graphicsLayer) returns null.
+   *
+   * Non-private for the direct unit test in this module.
    */
-  private fun shadowElevationDp(mod: Any, elements: Map<String, Any?>, density: Float): Double? {
+  internal fun shadowElevationDp(mod: Any, elements: Map<String, Any?>, density: Float): Double? {
     if (density <= 0f) return null
+    // `graphicsLayer` shadowElevation — a raw pixel value → recover dp by dividing by density.
     val px =
       floatValue(elements["shadowElevation"])
         ?: runCatching {
@@ -173,9 +183,26 @@ internal object ModifierTokenResolver {
               .getFloat(mod)
           }
           .getOrNull()
+    if (px != null) {
+      if (px <= 0f) return null
+      return roundedDp(px / density).toDouble()
+    }
+    // `Modifier.shadow(elevation: Dp)` → `ShadowGraphicsLayerElement.elevation` is a `Dp` (already
+    // dp, unlike the px `shadowElevation`), so take it verbatim. `floatValue` reads either the
+    // inspector element or the reflected `elevation` field (a `Dp` value class, inlined to a
+    // float).
+    val elevationDp =
+      floatValue(elements["elevation"])
+        ?: runCatching {
+            mod.javaClass
+              .getDeclaredField("elevation")
+              .apply { isAccessible = true }
+              .let { floatValue(it.get(mod)) }
+          }
+          .getOrNull()
         ?: return null
-    if (px <= 0f) return null
-    return roundedDp(px / density).toDouble()
+    if (elevationDp <= 0f) return null
+    return roundedDp(elevationDp).toDouble()
   }
 
   /** Reads a bare Float/Double, or a value class's `value` float (e.g. a `Dp`), as a Float. */

--- a/data/layoutinspector/connector/src/test/kotlin/ee/schimke/composeai/daemon/ModifierTokenResolverShadowTest.kt
+++ b/data/layoutinspector/connector/src/test/kotlin/ee/schimke/composeai/daemon/ModifierTokenResolverShadowTest.kt
@@ -1,0 +1,71 @@
+package ee.schimke.composeai.daemon
+
+import androidx.compose.ui.unit.dp
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Pins [ModifierTokenResolver.shadowElevationDp]'s two shadow sources (issue #2357):
+ * - a `graphicsLayer { shadowElevation = … }` (Surface/Card/FAB Material shadow) exposes a raw
+ *   **pixel** `shadowElevation`, recovered to dp by dividing by density, and
+ * - a bare `Modifier.shadow(elevation: Dp)` lowers to a `ShadowGraphicsLayerElement` that keeps a
+ *   **`Dp` `elevation`** instead — already dp, so it must be taken verbatim (no `/ density`).
+ *
+ * Before the fix only the px `shadowElevation` was probed, so a `Modifier.shadow(...)` node
+ * resolved null and the figma-svg export dropped its `feDropShadow`. Each shape is fed both as an
+ * inspector element and as the reflected backing field, matching the resolver's two lookup paths.
+ */
+class ModifierTokenResolverShadowTest {
+
+  /** A `graphicsLayer` node: a raw px `shadowElevation` float field. */
+  private class FakeGraphicsLayer(@JvmField val shadowElevation: Float)
+
+  /** A `Modifier.shadow` node: a `Dp` `elevation` (inlined to a float field), NOT px. */
+  private class FakeShadowElement(@JvmField val elevation: Float)
+
+  @Test
+  fun `graphicsLayer shadowElevation element is px and divided by density`() {
+    // 16px at density 2 → 8dp.
+    assertEquals(
+      8.0,
+      ModifierTokenResolver.shadowElevationDp(Any(), mapOf("shadowElevation" to 16f), density = 2f),
+    )
+  }
+
+  @Test
+  fun `graphicsLayer shadowElevation reflected field is px and divided by density`() {
+    assertEquals(
+      8.0,
+      ModifierTokenResolver.shadowElevationDp(FakeGraphicsLayer(16f), emptyMap(), density = 2f),
+    )
+  }
+
+  @Test
+  fun `Modifier shadow elevation element is dp and taken verbatim`() {
+    // 6dp stays 6dp regardless of density — it is NOT a pixel value.
+    assertEquals(
+      6.0,
+      ModifierTokenResolver.shadowElevationDp(Any(), mapOf("elevation" to 6.dp), density = 2f),
+    )
+  }
+
+  @Test
+  fun `Modifier shadow elevation reflected field is dp and taken verbatim`() {
+    assertEquals(
+      4.0,
+      ModifierTokenResolver.shadowElevationDp(FakeShadowElement(4f), emptyMap(), density = 3f),
+    )
+  }
+
+  @Test
+  fun `a clip-only node with zero elevation casts no shadow`() {
+    assertNull(ModifierTokenResolver.shadowElevationDp(FakeShadowElement(0f), emptyMap(), 2f))
+    assertNull(ModifierTokenResolver.shadowElevationDp(FakeGraphicsLayer(0f), emptyMap(), 2f))
+  }
+
+  @Test
+  fun `a node with no shadow field resolves null`() {
+    assertNull(ModifierTokenResolver.shadowElevationDp(Any(), emptyMap(), density = 2f))
+  }
+}


### PR DESCRIPTION
## Summary

`ModifierTokenResolver.shadowElevationDp` only probed a `graphicsLayer`'s **px** `shadowElevation` (the element + the reflected field). A bare `Modifier.shadow(elevation: Dp)` lowers to a `ShadowGraphicsLayerElement` that keeps a **`Dp` `elevation`** field instead of `shadowElevation`, so those nodes resolved `null` and the figma-svg export dropped their `feDropShadow` — shadows rendered flat.

The node still matches the existing `GraphicsLayer` name gate (`ShadowGraphicsLayerElement` contains `GraphicsLayer`), so the fix is contained to the resolver: after the px path finds nothing, fall back to reading the `Dp` `elevation` **verbatim** (already dp — no `/ density`, unlike the px `shadowElevation`), via either the inspector element or the reflected backing field. The existing px `graphicsLayer` path is unchanged, and a plain (non-shadow) `graphicsLayer` has no `elevation` field so it stays unaffected.

Fixes the deferred review point from #2325 tracked in #2357.

## Changes
- `ModifierTokenResolver.shadowElevationDp`: add the `Dp` `elevation` fallback; split the px branch so a found-but-zero px value still short-circuits (clip-only graphicsLayer) while a *missing* px value falls through to the Dp path. Widened to `internal` for a direct unit test.
- New `ModifierTokenResolverShadowTest` pinning both sources (inspector element + reflected field) for each shape (px `shadowElevation` ÷ density; `Dp` `elevation` verbatim) plus the zero / no-shadow cases.

## Test plan
- `./gradlew :data-layoutinspector-connector:ktfmtCheck :data-layoutinspector-connector:test` — green (new test included).

## Visual evidence
This is a data-layer fix in the modifier → design-token resolver. Its visible effect (a restored `<feDropShadow>` in the exported figma-svg vector) is produced downstream by the Android/daemon render harness, which needs a live composition casting a `Modifier.shadow(...)` — not reproducible in this headless CMP-JVM module, whose test classpath has `compose.ui` but no render/layout harness. It's therefore covered mechanically by the unit test above (the resolved elevation dp), rather than by an embedded image.

Fast-follow worth doing: wire a shadow-casting component into the figma-svg golden/preview harness so future changes to this path get an automatic before/after SVG diff.

Closes #2357

---
_Generated by [Claude Code](https://claude.ai/code/session_01RvgeNjC6QRepDARnQuKPYJ)_