### PR TITLE
fix(serve): gate the SVG control on per-preview export availability

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
@@ -171,6 +171,22 @@ class ServeBundleHost(
    * an unknown id, or a preview whose component carried no figma-svg. Overrides don't apply
    * (static).
    */
+  // Per-preview SVG availability (issue #2352). `hasSvgExport` is true for the whole session as
+  // soon
+  // as the catalog carries a `figma/` dir, but a specific preview whose component slug has no baked
+  // `figma/<slug>.svg` still 404s the `.svg` lane (see `renderSvg`). Gate the viewer's SVG control
+  // on
+  // the actual file so it isn't offered on a preview that would render "failed". Same slug lookup
+  // as
+  // `renderSvg`, minus the read.
+  override fun hasSvgExportFor(previewId: String): Boolean {
+    val figma = figmaDir ?: return false
+    if (previewId !in previewIds) return false
+    val svgFile =
+      File(figma, "${previewId.substringBefore(SLUG_SEPARATOR)}$SVG_SUFFIX").toOkioPath()
+    return fileSystem.exists(svgFile)
+  }
+
   override fun renderSvg(previewId: String, overrides: PreviewOverrides): SvgOutcome {
     val figma = figmaDir ?: return SvgOutcome.NotFound
     if (previewId !in previewIds) return SvgOutcome.NotFound

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
@@ -183,6 +183,16 @@ class ServeCatalogLiveHost(
    */
   override val hasSvgExport: Boolean = baked.hasSvgExport || live.hasSvgExport
 
+  /**
+   * Per-preview SVG availability (issue #2352): narrows [hasSvgExport] to a specific preview so the
+   * viewer doesn't offer the SVG control where the `.svg` lane would 404. A daemon-twinned id can
+   * export its variant vector when the daemon lane can ([live.hasSvgExport]); an unmapped
+   * (Android-only) id only when the baked catalog carried its slug's `figma/<slug>.svg`. Mirrors
+   * [renderSvg]'s routing and never advertises more broadly than [hasSvgExport].
+   */
+  override fun hasSvgExportFor(previewId: String): Boolean =
+    (previewId in alias && live.hasSvgExport) || baked.hasSvgExportFor(previewId)
+
   /** The "Live (stream)" toggle is offered (unlike a plain static catalog). */
   override val hasLiveStream: Boolean = true
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHost.kt
@@ -84,6 +84,16 @@ interface ServeHost : AutoCloseable {
     get() = false
 
   /**
+   * Whether [renderSvg] can produce a `compose/figma-svg` export for **this specific** [previewId]
+   * — a per-preview refinement of [hasSvgExport]. A static catalog advertises SVG globally as soon
+   * as it carries a `figma/` dir, but an individual preview whose component slug has no baked
+   * `figma/<slug>.svg` still 404s the `.svg` lane; the viewer gates its SVG control on this so it
+   * isn't offered on a preview that would then render "failed" (issue #2352). Defaults to the
+   * session-wide [hasSvgExport] — a daemon-backed host exports any of its previews.
+   */
+  fun hasSvgExportFor(previewId: String): Boolean = hasSvgExport
+
+  /**
    * Whether a **live daemon stream** ("Live (stream)") is available for this session — distinct
    * from [canApplyOverrides], which governs whether the *snapshot* lane re-renders on override
    * edits. The two usually coincide (a plain [ServeRenderHost] has both; a static [ServeBundleHost]

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -712,7 +712,13 @@ class ServeHttpServer(
           // preview, so an unaliased (Android-only) variant reports false and its override controls
           // (knobs, App theme) render disabled/informational rather than enabled-but-dead.
           canRenderOverrides = renderHost.canRenderOverridesFor(preview.id),
-          hasSvgExport = renderHost.hasSvgExport,
+          // Per-preview: a catalog advertises SVG globally as soon as it carries a `figma/` dir,
+          // but
+          // a preview whose slug has no baked `figma/<slug>.svg` still 404s the `.svg` lane, so
+          // gate
+          // the SVG control on this preview's actual availability rather than the session-wide
+          // flag.
+          hasSvgExport = renderHost.hasSvgExportFor(preview.id),
           hasLiveStream = renderHost.hasLiveStream,
           trust = catalogBundleHost(renderHost)?.let { BundleVerifier.summary(it.trust) },
           wasmSrc = wasmSrc,

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServePerPreviewLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServePerPreviewLiveHost.kt
@@ -103,6 +103,16 @@ class ServePerPreviewLiveHost(
   override fun canRenderOverridesFor(previewId: String): Boolean = previewId in alias
 
   /**
+   * Per-preview SVG availability (issue #2352): narrows [hasSvgExport] so the viewer doesn't offer
+   * the SVG control where the `.svg` lane would 404. A daemon-twinned id can export via its
+   * per-preview daemon; an unmapped id only when the baked catalog carried its slug vector. Guarded
+   * by [hasSvgExport] so it never advertises more broadly than the session already does. Mirrors
+   * [renderSvg]'s routing.
+   */
+  override fun hasSvgExportFor(previewId: String): Boolean =
+    hasSvgExport && (previewId in alias || baked.hasSvgExportFor(previewId))
+
+  /**
    * Ordinary browsing serves the baked catalog PNG; an override the baked PNG can't represent
    * routes to that preview's own daemon. An unmapped id, or one whose per-preview daemon can't be
    * resolved, falls back to baked.

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHostTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHostTest.kt
@@ -168,6 +168,29 @@ class ServeBundleHostTest {
   }
 
   @Test
+  fun `hasSvgExportFor gates the SVG control on the preview's own baked vector`() {
+    val dir =
+      bundle("button-filled__ideal__default__dark" to byteArrayOf(1), "badge__x" to byteArrayOf(2))
+
+    // A plain bundle (no figmaDir) advertises no SVG for any preview.
+    val plain = ServeBundleHost(dir, label = "b")
+    assertFalse(plain.hasSvgExportFor("button-filled__ideal__default__dark"))
+
+    // A figma dir carrying only `button-filled.svg`: the session-wide flag is true because a figma
+    // dir exists, but per preview only `button-filled` has a vector — `badge` (no svg) and an
+    // unknown
+    // id must report false so the viewer doesn't offer an SVG control that would render "failed"
+    // (issue #2352).
+    val figma = File(dir, "figma").apply { mkdirs() }
+    File(figma, "button-filled.svg").writeText("<svg/>")
+    val host = ServeBundleHost(dir, label = "b", figmaDir = figma)
+    assertTrue(host.hasSvgExport, "session-wide flag stays true because a figma dir exists")
+    assertTrue(host.hasSvgExportFor("button-filled__ideal__default__dark"))
+    assertFalse(host.hasSvgExportFor("badge__x"), "slug badge carried no baked svg")
+    assertFalse(host.hasSvgExportFor("nope__x"), "unknown id")
+  }
+
+  @Test
   fun `renderSvg does not inline a raster href that escapes the figma dir`() {
     val dir = bundle("button-filled__ideal__default__dark" to byteArrayOf(1))
     val figma = File(dir, "figma").apply { mkdirs() }


### PR DESCRIPTION
## Summary

A static catalog advertises SVG export **session-wide** as soon as it carries a `figma/` dir (`ServeBundleHost.hasSvgExport = figmaDir != null`), but `ServeBundleHost.renderSvg` still 404s for an individual preview whose component slug has no baked `figma/<slug>.svg`. So the viewer offered an SVG download/toggle on previews that then rendered "failed".

Gate the control on a new **per-preview** capability instead of the flat session flag, mirroring the existing `canRenderOverridesFor(previewId)` per-preview pattern.

## Changes
- **`ServeHost.hasSvgExportFor(previewId)`** — new interface method, defaults to the session-wide `hasSvgExport` (so a daemon-backed `ServeRenderHost`, which can export any preview, is unchanged).
- **`ServeBundleHost`** — override: true only when the preview's own `figma/<slug>.svg` exists (same slug lookup as `renderSvg`, minus the read).
- **`ServeCatalogLiveHost` / `ServePerPreviewLiveHost`** — override: a daemon-twinned id can export via its daemon lane; an unmapped (Android-only) id only when the baked slug vector exists. Both are strict narrowings of each host's `hasSvgExport` (never advertise more broadly than before), mirroring their `renderSvg` routing.
- **`ServeHttpServer`** — feed `renderHost.hasSvgExportFor(preview.id)` into `ServeWeb.viewerPage(hasSvgExport = …)` (the value drives both the SVG toggle and the copyable `.svg` download link) instead of the flat `renderHost.hasSvgExport`.

`/api/previews` (`PreviewDto`) doesn't advertise SVG per-preview, so the viewer page is the only surface to gate.

## Test plan
- `./gradlew :cli:ktfmtCheck :cli:test --tests "*ServeBundleHostTest"` — green.
- New `ServeBundleHostTest` case `hasSvgExportFor gates the SVG control on the preview's own baked vector`: with a figma dir carrying only `button-filled.svg`, the session-wide `hasSvgExport` stays true, but `hasSvgExportFor` is true for `button-filled…`, false for a `badge…` preview (no vector) and for an unknown id.

## Visual evidence
Server-side change to the viewer's download panel: the visible effect is the `.svg` download link / SVG toggle now being **absent** on a catalog preview whose slug carries no baked vector (previously present-but-broken). It's conditional HTML driven by per-preview file availability rather than a rendered-pixel/`@Preview` change, so it's covered by the unit test on the underlying capability. To verify visually: serve a catalog whose `figma/` dir covers only some component slugs and open a preview page for an uncovered slug — the SVG download link no longer appears (and the previously-offered link no longer 404s).

Closes #2352

---
_Generated by [Claude Code](https://claude.ai/code/session_01RvgeNjC6QRepDARnQuKPYJ)_