### PR TITLE
fix(serve): re-pin overlays when the snapshot image loads

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -2862,6 +2862,15 @@ object ServeWeb {
       window.addEventListener("resize", function () {
         if (live && live.checked && !canvas.hidden) fitLiveCanvas();
       });
+      // Re-pin the active overlay whenever the snapshot image itself loads — its first render, or a
+      // re-render at a new size. positionOverlay/fitLiveCanvas measure `img.getBoundingClientRect()`,
+      // which only becomes final once the new bytes are decoded, so without this an overlay picked
+      // (e.g. Live selected before the first /render lands) or a re-rendered snapshot kept the stale
+      // box until the next window resize (issue #2359).
+      img.addEventListener("load", function () {
+        if (live && live.checked && !canvas.hidden) fitLiveCanvas();
+        if (wasmActive()) positionWasmFrame();
+      });
       if (wasmToggle) {
         // The app posts "cp-wasm-ready" once its first frame is on the canvas — the swap signal.
         // Match on source (the known frame's contentWindow), not e.origin — robust regardless of

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -2869,7 +2869,14 @@ object ServeWeb {
       // box until the next window resize (issue #2359).
       img.addEventListener("load", function () {
         if (live && live.checked && !canvas.hidden) fitLiveCanvas();
-        if (wasmActive()) positionWasmFrame();
+        // Mirror the Wasm resize handler: the checkerboard phase moves with the overlay box, so
+        // re-hand the patch (which carries bgPhase) to a ready app — not just reposition the frame.
+        if (wasmActive()) {
+          positionWasmFrame();
+          if (wasmReady && wasmFrame.contentWindow) {
+            wasmFrame.contentWindow.postMessage(wasmOverridePatch(), "*");
+          }
+        }
       });
       if (wasmToggle) {
         // The app posts "cp-wasm-ready" once its first frame is on the canvas — the swap signal.

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
@@ -1601,6 +1601,15 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
   window.addEventListener("resize", function () {
     if (live && live.checked && !canvas.hidden) fitLiveCanvas();
   });
+  // Re-pin the active overlay whenever the snapshot image itself loads — its first render, or a
+  // re-render at a new size. positionOverlay/fitLiveCanvas measure `img.getBoundingClientRect()`,
+  // which only becomes final once the new bytes are decoded, so without this an overlay picked
+  // (e.g. Live selected before the first /render lands) or a re-rendered snapshot kept the stale
+  // box until the next window resize (issue #2359).
+  img.addEventListener("load", function () {
+    if (live && live.checked && !canvas.hidden) fitLiveCanvas();
+    if (wasmActive()) positionWasmFrame();
+  });
   if (wasmToggle) {
     // The app posts "cp-wasm-ready" once its first frame is on the canvas — the swap signal.
     // Match on source (the known frame's contentWindow), not e.origin — robust regardless of

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
@@ -1608,7 +1608,14 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
   // box until the next window resize (issue #2359).
   img.addEventListener("load", function () {
     if (live && live.checked && !canvas.hidden) fitLiveCanvas();
-    if (wasmActive()) positionWasmFrame();
+    // Mirror the Wasm resize handler: the checkerboard phase moves with the overlay box, so
+    // re-hand the patch (which carries bgPhase) to a ready app — not just reposition the frame.
+    if (wasmActive()) {
+      positionWasmFrame();
+      if (wasmReady && wasmFrame.contentWindow) {
+        wasmFrame.contentWindow.postMessage(wasmOverridePatch(), "*");
+      }
+    }
   });
   if (wasmToggle) {
     // The app posts "cp-wasm-ready" once its first frame is on the canvas — the swap signal.

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-focus.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-focus.html
@@ -1573,6 +1573,15 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
   window.addEventListener("resize", function () {
     if (live && live.checked && !canvas.hidden) fitLiveCanvas();
   });
+  // Re-pin the active overlay whenever the snapshot image itself loads — its first render, or a
+  // re-render at a new size. positionOverlay/fitLiveCanvas measure `img.getBoundingClientRect()`,
+  // which only becomes final once the new bytes are decoded, so without this an overlay picked
+  // (e.g. Live selected before the first /render lands) or a re-rendered snapshot kept the stale
+  // box until the next window resize (issue #2359).
+  img.addEventListener("load", function () {
+    if (live && live.checked && !canvas.hidden) fitLiveCanvas();
+    if (wasmActive()) positionWasmFrame();
+  });
   if (wasmToggle) {
     // The app posts "cp-wasm-ready" once its first frame is on the canvas — the swap signal.
     // Match on source (the known frame's contentWindow), not e.origin — robust regardless of

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-focus.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-focus.html
@@ -1580,7 +1580,14 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
   // box until the next window resize (issue #2359).
   img.addEventListener("load", function () {
     if (live && live.checked && !canvas.hidden) fitLiveCanvas();
-    if (wasmActive()) positionWasmFrame();
+    // Mirror the Wasm resize handler: the checkerboard phase moves with the overlay box, so
+    // re-hand the patch (which carries bgPhase) to a ready app — not just reposition the frame.
+    if (wasmActive()) {
+      positionWasmFrame();
+      if (wasmReady && wasmFrame.contentWindow) {
+        wasmFrame.contentWindow.postMessage(wasmOverridePatch(), "*");
+      }
+    }
   });
   if (wasmToggle) {
     // The app posts "cp-wasm-ready" once its first frame is on the canvas — the swap signal.

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-gestures.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-gestures.html
@@ -1573,6 +1573,15 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
   window.addEventListener("resize", function () {
     if (live && live.checked && !canvas.hidden) fitLiveCanvas();
   });
+  // Re-pin the active overlay whenever the snapshot image itself loads — its first render, or a
+  // re-render at a new size. positionOverlay/fitLiveCanvas measure `img.getBoundingClientRect()`,
+  // which only becomes final once the new bytes are decoded, so without this an overlay picked
+  // (e.g. Live selected before the first /render lands) or a re-rendered snapshot kept the stale
+  // box until the next window resize (issue #2359).
+  img.addEventListener("load", function () {
+    if (live && live.checked && !canvas.hidden) fitLiveCanvas();
+    if (wasmActive()) positionWasmFrame();
+  });
   if (wasmToggle) {
     // The app posts "cp-wasm-ready" once its first frame is on the canvas — the swap signal.
     // Match on source (the known frame's contentWindow), not e.origin — robust regardless of

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-gestures.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-gestures.html
@@ -1580,7 +1580,14 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
   // box until the next window resize (issue #2359).
   img.addEventListener("load", function () {
     if (live && live.checked && !canvas.hidden) fitLiveCanvas();
-    if (wasmActive()) positionWasmFrame();
+    // Mirror the Wasm resize handler: the checkerboard phase moves with the overlay box, so
+    // re-hand the patch (which carries bgPhase) to a ready app — not just reposition the frame.
+    if (wasmActive()) {
+      positionWasmFrame();
+      if (wasmReady && wasmFrame.contentWindow) {
+        wasmFrame.contentWindow.postMessage(wasmOverridePatch(), "*");
+      }
+    }
   });
   if (wasmToggle) {
     // The app posts "cp-wasm-ready" once its first frame is on the canvas — the swap signal.

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
@@ -1567,6 +1567,15 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
   window.addEventListener("resize", function () {
     if (live && live.checked && !canvas.hidden) fitLiveCanvas();
   });
+  // Re-pin the active overlay whenever the snapshot image itself loads — its first render, or a
+  // re-render at a new size. positionOverlay/fitLiveCanvas measure `img.getBoundingClientRect()`,
+  // which only becomes final once the new bytes are decoded, so without this an overlay picked
+  // (e.g. Live selected before the first /render lands) or a re-rendered snapshot kept the stale
+  // box until the next window resize (issue #2359).
+  img.addEventListener("load", function () {
+    if (live && live.checked && !canvas.hidden) fitLiveCanvas();
+    if (wasmActive()) positionWasmFrame();
+  });
   if (wasmToggle) {
     // The app posts "cp-wasm-ready" once its first frame is on the canvas — the swap signal.
     // Match on source (the known frame's contentWindow), not e.origin — robust regardless of

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
@@ -1574,7 +1574,14 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
   // box until the next window resize (issue #2359).
   img.addEventListener("load", function () {
     if (live && live.checked && !canvas.hidden) fitLiveCanvas();
-    if (wasmActive()) positionWasmFrame();
+    // Mirror the Wasm resize handler: the checkerboard phase moves with the overlay box, so
+    // re-hand the patch (which carries bgPhase) to a ready app — not just reposition the frame.
+    if (wasmActive()) {
+      positionWasmFrame();
+      if (wasmReady && wasmFrame.contentWindow) {
+        wasmFrame.contentWindow.postMessage(wasmOverridePatch(), "*");
+      }
+    }
   });
   if (wasmToggle) {
     // The app posts "cp-wasm-ready" once its first frame is on the canvas — the swap signal.

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-states.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-states.html
@@ -1572,6 +1572,15 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
   window.addEventListener("resize", function () {
     if (live && live.checked && !canvas.hidden) fitLiveCanvas();
   });
+  // Re-pin the active overlay whenever the snapshot image itself loads — its first render, or a
+  // re-render at a new size. positionOverlay/fitLiveCanvas measure `img.getBoundingClientRect()`,
+  // which only becomes final once the new bytes are decoded, so without this an overlay picked
+  // (e.g. Live selected before the first /render lands) or a re-rendered snapshot kept the stale
+  // box until the next window resize (issue #2359).
+  img.addEventListener("load", function () {
+    if (live && live.checked && !canvas.hidden) fitLiveCanvas();
+    if (wasmActive()) positionWasmFrame();
+  });
   if (wasmToggle) {
     // The app posts "cp-wasm-ready" once its first frame is on the canvas — the swap signal.
     // Match on source (the known frame's contentWindow), not e.origin — robust regardless of

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-states.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-states.html
@@ -1579,7 +1579,14 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
   // box until the next window resize (issue #2359).
   img.addEventListener("load", function () {
     if (live && live.checked && !canvas.hidden) fitLiveCanvas();
-    if (wasmActive()) positionWasmFrame();
+    // Mirror the Wasm resize handler: the checkerboard phase moves with the overlay box, so
+    // re-hand the patch (which carries bgPhase) to a ready app — not just reposition the frame.
+    if (wasmActive()) {
+      positionWasmFrame();
+      if (wasmReady && wasmFrame.contentWindow) {
+        wasmFrame.contentWindow.postMessage(wasmOverridePatch(), "*");
+      }
+    }
   });
   if (wasmToggle) {
     // The app posts "cp-wasm-ready" once its first frame is on the canvas — the swap signal.

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-themes.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-themes.html
@@ -1572,6 +1572,15 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
   window.addEventListener("resize", function () {
     if (live && live.checked && !canvas.hidden) fitLiveCanvas();
   });
+  // Re-pin the active overlay whenever the snapshot image itself loads — its first render, or a
+  // re-render at a new size. positionOverlay/fitLiveCanvas measure `img.getBoundingClientRect()`,
+  // which only becomes final once the new bytes are decoded, so without this an overlay picked
+  // (e.g. Live selected before the first /render lands) or a re-rendered snapshot kept the stale
+  // box until the next window resize (issue #2359).
+  img.addEventListener("load", function () {
+    if (live && live.checked && !canvas.hidden) fitLiveCanvas();
+    if (wasmActive()) positionWasmFrame();
+  });
   if (wasmToggle) {
     // The app posts "cp-wasm-ready" once its first frame is on the canvas — the swap signal.
     // Match on source (the known frame's contentWindow), not e.origin — robust regardless of

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-themes.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-themes.html
@@ -1579,7 +1579,14 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
   // box until the next window resize (issue #2359).
   img.addEventListener("load", function () {
     if (live && live.checked && !canvas.hidden) fitLiveCanvas();
-    if (wasmActive()) positionWasmFrame();
+    // Mirror the Wasm resize handler: the checkerboard phase moves with the overlay box, so
+    // re-hand the patch (which carries bgPhase) to a ready app — not just reposition the frame.
+    if (wasmActive()) {
+      positionWasmFrame();
+      if (wasmReady && wasmFrame.contentWindow) {
+        wasmFrame.contentWindow.postMessage(wasmOverridePatch(), "*");
+      }
+    }
   });
   if (wasmToggle) {
     // The app posts "cp-wasm-ready" once its first frame is on the canvas — the swap signal.

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
@@ -1564,6 +1564,15 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
   window.addEventListener("resize", function () {
     if (live && live.checked && !canvas.hidden) fitLiveCanvas();
   });
+  // Re-pin the active overlay whenever the snapshot image itself loads — its first render, or a
+  // re-render at a new size. positionOverlay/fitLiveCanvas measure `img.getBoundingClientRect()`,
+  // which only becomes final once the new bytes are decoded, so without this an overlay picked
+  // (e.g. Live selected before the first /render lands) or a re-rendered snapshot kept the stale
+  // box until the next window resize (issue #2359).
+  img.addEventListener("load", function () {
+    if (live && live.checked && !canvas.hidden) fitLiveCanvas();
+    if (wasmActive()) positionWasmFrame();
+  });
   if (wasmToggle) {
     // The app posts "cp-wasm-ready" once its first frame is on the canvas — the swap signal.
     // Match on source (the known frame's contentWindow), not e.origin — robust regardless of

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
@@ -1571,7 +1571,14 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
   // box until the next window resize (issue #2359).
   img.addEventListener("load", function () {
     if (live && live.checked && !canvas.hidden) fitLiveCanvas();
-    if (wasmActive()) positionWasmFrame();
+    // Mirror the Wasm resize handler: the checkerboard phase moves with the overlay box, so
+    // re-hand the patch (which carries bgPhase) to a ready app — not just reposition the frame.
+    if (wasmActive()) {
+      positionWasmFrame();
+      if (wasmReady && wasmFrame.contentWindow) {
+        wasmFrame.contentWindow.postMessage(wasmOverridePatch(), "*");
+      }
+    }
   });
   if (wasmToggle) {
     // The app posts "cp-wasm-ready" once its first frame is on the canvas — the swap signal.

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
@@ -1555,6 +1555,15 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
   window.addEventListener("resize", function () {
     if (live && live.checked && !canvas.hidden) fitLiveCanvas();
   });
+  // Re-pin the active overlay whenever the snapshot image itself loads — its first render, or a
+  // re-render at a new size. positionOverlay/fitLiveCanvas measure `img.getBoundingClientRect()`,
+  // which only becomes final once the new bytes are decoded, so without this an overlay picked
+  // (e.g. Live selected before the first /render lands) or a re-rendered snapshot kept the stale
+  // box until the next window resize (issue #2359).
+  img.addEventListener("load", function () {
+    if (live && live.checked && !canvas.hidden) fitLiveCanvas();
+    if (wasmActive()) positionWasmFrame();
+  });
   if (wasmToggle) {
     // The app posts "cp-wasm-ready" once its first frame is on the canvas — the swap signal.
     // Match on source (the known frame's contentWindow), not e.origin — robust regardless of

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
@@ -1562,7 +1562,14 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
   // box until the next window resize (issue #2359).
   img.addEventListener("load", function () {
     if (live && live.checked && !canvas.hidden) fitLiveCanvas();
-    if (wasmActive()) positionWasmFrame();
+    // Mirror the Wasm resize handler: the checkerboard phase moves with the overlay box, so
+    // re-hand the patch (which carries bgPhase) to a ready app — not just reposition the frame.
+    if (wasmActive()) {
+      positionWasmFrame();
+      if (wasmReady && wasmFrame.contentWindow) {
+        wasmFrame.contentWindow.postMessage(wasmOverridePatch(), "*");
+      }
+    }
   });
   if (wasmToggle) {
     // The app posts "cp-wasm-ready" once its first frame is on the canvas — the swap signal.

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
@@ -1567,6 +1567,15 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
   window.addEventListener("resize", function () {
     if (live && live.checked && !canvas.hidden) fitLiveCanvas();
   });
+  // Re-pin the active overlay whenever the snapshot image itself loads — its first render, or a
+  // re-render at a new size. positionOverlay/fitLiveCanvas measure `img.getBoundingClientRect()`,
+  // which only becomes final once the new bytes are decoded, so without this an overlay picked
+  // (e.g. Live selected before the first /render lands) or a re-rendered snapshot kept the stale
+  // box until the next window resize (issue #2359).
+  img.addEventListener("load", function () {
+    if (live && live.checked && !canvas.hidden) fitLiveCanvas();
+    if (wasmActive()) positionWasmFrame();
+  });
   if (wasmToggle) {
     // The app posts "cp-wasm-ready" once its first frame is on the canvas — the swap signal.
     // Match on source (the known frame's contentWindow), not e.origin — robust regardless of

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
@@ -1574,7 +1574,14 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
   // box until the next window resize (issue #2359).
   img.addEventListener("load", function () {
     if (live && live.checked && !canvas.hidden) fitLiveCanvas();
-    if (wasmActive()) positionWasmFrame();
+    // Mirror the Wasm resize handler: the checkerboard phase moves with the overlay box, so
+    // re-hand the patch (which carries bgPhase) to a ready app — not just reposition the frame.
+    if (wasmActive()) {
+      positionWasmFrame();
+      if (wasmReady && wasmFrame.contentWindow) {
+        wasmFrame.contentWindow.postMessage(wasmOverridePatch(), "*");
+      }
+    }
   });
   if (wasmToggle) {
     // The app posts "cp-wasm-ready" once its first frame is on the canvas — the swap signal.


### PR DESCRIPTION
## Summary

`positionOverlay` / `fitLiveCanvas` measure `img.getBoundingClientRect()`, which only becomes final once the render's bytes are decoded. `refreshSnapshot` swapped `img.src` without re-running them, and overlay positioning otherwise fired only on **window resize** and **per streamed frame**. So an overlay picked before the first `/render` landed (e.g. **Live selected while the snapshot was still loading**), or a snapshot re-rendered at a new size, kept the stale box until the next window resize.

Add an `img` `"load"` listener that re-pins whichever overlay is active — the live canvas via `fitLiveCanvas()`, the Wasm frame via `positionWasmFrame()` — exactly mirroring the two existing `resize` handlers (same guards: `live && live.checked && !canvas.hidden`; `wasmActive()`).

## Changes
- `ServeWeb.kt`: add the `img` load handler next to the existing resize handlers.
- Regenerated the committed serve viewer HTML fixtures (`vscode-extension/preview-harness/fixtures/pages/serve-viewer*.html`) via `UPDATE_SERVE_WEB_FIXTURES=true`. The diff in each is exactly the added listener.

## Test plan
- `./gradlew :cli:ktfmtCheck :cli:test --tests '*ServeWebFixtureTest*'` — green (fixtures in sync with `ServeWeb`).

## Visual evidence
This is a **behavioral** timing fix — the overlay ends up in the same final position; the fix is that it gets there on image load instead of only on the next resize. The regenerated fixture pages therefore render **identically** (the `pages-snapshot` visual-diff bot will show no pixel change, as expected). It can't be captured as a static before/after image; to verify interactively: open a live-capable viewer, select **Live** before the first render lands (or trigger a re-render at a different size) — the live canvas / Wasm overlay now aligns immediately instead of being offset until you resize the window.

Closes #2359

---
_Generated by [Claude Code](https://claude.ai/code/session_01RvgeNjC6QRepDARnQuKPYJ)_