### PR TITLE
fix: resource-leak and subprocess-hang fixes from an architecture review

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleRenderer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleRenderer.kt
@@ -5,6 +5,7 @@ import ee.schimke.composeai.io.TemporaryDirectory
 import java.io.ByteArrayInputStream
 import java.io.File
 import java.util.UUID
+import java.util.concurrent.TimeUnit
 import java.util.zip.ZipEntry
 import java.util.zip.ZipInputStream
 import kotlinx.serialization.json.Json
@@ -325,11 +326,35 @@ class BundleRenderer(
       add(classpath)
       add("ee.schimke.composeai.renderer.AndroidRendererMainKt")
     }
-    val pb = ProcessBuilder(command).redirectErrorStream(true)
+    return runRenderProcess(ProcessBuilder(command), tailLines = 40)
+  }
+
+  /**
+   * Start a render subprocess, drain its merged stdout/stderr on a daemon thread, and wait up to
+   * [RENDER_PROCESS_TIMEOUT_SECONDS]. Reading the pipe on a separate thread (rather than
+   * `readText()` on the caller) means a subprocess that hangs without closing stdout can't block us
+   * past the timeout — `destroyForcibly()` closes the stream and ends the drain thread. Returns
+   * exit code (124 on timeout) and the last [tailLines] lines of output.
+   */
+  private fun runRenderProcess(pb: ProcessBuilder, tailLines: Int): Pair<Int, String> {
+    pb.redirectErrorStream(true)
     val proc = pb.start()
-    val output = proc.inputStream.bufferedReader().readText()
-    val exitCode = proc.waitFor()
-    return exitCode to output.lines().takeLast(40).joinToString("\n")
+    val sb = StringBuilder()
+    val drain =
+      Thread { proc.inputStream.bufferedReader().forEachLine { sb.appendLine(it) } }
+        .apply {
+          isDaemon = true
+          start()
+        }
+    val finished = proc.waitFor(RENDER_PROCESS_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+    if (!finished) proc.destroyForcibly()
+    drain.join(DRAIN_FLUSH_MILLIS)
+    val tail = sb.toString().lines().takeLast(tailLines).joinToString("\n")
+    return if (finished) {
+      proc.exitValue() to tail
+    } else {
+      124 to (tail + "\n[render subprocess timed out after ${RENDER_PROCESS_TIMEOUT_SECONDS}s]")
+    }
   }
 
   /** Locate the Android renderer sidecar jars — Android twin of [locateRendererClasspath]. */
@@ -463,12 +488,7 @@ class BundleRenderer(
         .toMutableList()
         .apply { addAll(args) }
         .let { ProcessBuilder(it) }
-    pb.redirectErrorStream(true)
-    val proc = pb.start()
-    val output = proc.inputStream.bufferedReader().readText()
-    val exitCode = proc.waitFor()
-    val tail = output.lines().takeLast(20).joinToString("\n")
-    return exitCode to tail
+    return runRenderProcess(pb, tailLines = 20)
   }
 
   internal fun buildRendererArgs(preview: PreviewInfo, outFile: File): List<String> {
@@ -627,6 +647,14 @@ class BundleRenderer(
 
     /** Compose Desktop's default density = 2.625× (~xxhdpi). Same constant as the renderer. */
     private const val DEFAULT_DENSITY: Float = 2.625f
+
+    /**
+     * Upper bound on a single render subprocess (cold JVM start + one preview). Matches the
+     * generous Gradle-render ceiling in [serve.GradleRevisionBuilder]; a wedged render (composition
+     * that never settles, native Skiko stall) is force-killed rather than hanging `bundle render`.
+     */
+    private const val RENDER_PROCESS_TIMEOUT_SECONDS = 600L
+    private const val DRAIN_FLUSH_MILLIS = 2000L
 
     private val BUNDLE_JSON = Json {
       ignoreUnknownKeys = true

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
@@ -1238,13 +1238,23 @@ class DoctorCommand(
   private fun runCommand(cmd: List<String>): CommandResult? {
     return try {
       val process = ProcessBuilder(cmd).redirectErrorStream(false).start()
+      // Drain stderr concurrently: reading stdout to EOF before touching stderr deadlocks if the
+      // child fills the stderr pipe buffer first, and the 5s `waitFor` guard below can never fire
+      // while we're blocked on that read. (`java -version` prints to stderr, so this path matters.)
+      val stderrHolder = arrayOfNulls<String>(1)
+      val stderrThread =
+        Thread { stderrHolder[0] = process.errorStream.bufferedReader().use { it.readText() } }
+          .apply {
+            isDaemon = true
+            start()
+          }
       val stdout = process.inputStream.bufferedReader().use { it.readText() }
-      val stderr = process.errorStream.bufferedReader().use { it.readText() }
       if (!process.waitFor(5, java.util.concurrent.TimeUnit.SECONDS)) {
         process.destroyForcibly()
         return null
       }
-      CommandResult(process.exitValue(), stdout, stderr)
+      stderrThread.join(java.util.concurrent.TimeUnit.SECONDS.toMillis(5))
+      CommandResult(process.exitValue(), stdout, stderrHolder[0] ?: "")
     } catch (_: Exception) {
       null
     }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/SharePreviewCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/SharePreviewCommand.kt
@@ -444,10 +444,23 @@ class SharePreviewCommand(
   private fun exec(cmd: List<String>): ExecResult {
     return try {
       val p = ProcessBuilder(cmd).redirectErrorStream(false).start()
+      // Drain stderr on a separate thread. With separate stdout/stderr pipes, reading stdout to EOF
+      // first (as this did) deadlocks when the child fills the ~64 KB stderr buffer before closing
+      // stdout — e.g. a `git push` whose server hook is chatty on stderr. Consuming both pipes
+      // concurrently is the only safe ordering, and it lets the `waitFor` timeout actually fire.
+      val stderrHolder = arrayOfNulls<String>(1)
+      val stderrThread =
+        Thread { stderrHolder[0] = p.errorStream.bufferedReader().use { it.readText() } }
+          .apply {
+            isDaemon = true
+            start()
+          }
       val stdout = p.inputStream.bufferedReader().use { it.readText() }
-      val stderr = p.errorStream.bufferedReader().use { it.readText() }
-      if (!p.waitFor(120, TimeUnit.SECONDS)) {
-        p.destroyForcibly()
+      val finished = p.waitFor(120, TimeUnit.SECONDS)
+      if (!finished) p.destroyForcibly()
+      stderrThread.join(TimeUnit.SECONDS.toMillis(5))
+      val stderr = stderrHolder[0] ?: ""
+      if (!finished) {
         ExecResult(124, stdout, stderr + "\n[command timed out]")
       } else {
         ExecResult(p.exitValue(), stdout, stderr)

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
@@ -292,12 +292,21 @@ open class DesktopHost(
       "Use shutdown() to stop the host, not submit(Shutdown)."
     }
     val typed = request as RenderRequest.Render
-    requests.put(typed)
+    // Register the result slot *before* enqueuing the request so the render worker always finds an
+    // existing queue (it delivers via a plain `results[id]?.put`, never `computeIfAbsent`).
+    // Otherwise a worker that finishes *after* we give up on timeout below would resurrect a fresh
+    // entry that nobody ever drains — a per-timeout leak of the queue plus its RenderResult.
     val resultQueue = results.computeIfAbsent(typed.id) { LinkedBlockingQueue() }
+    requests.put(typed)
     val raw =
-      resultQueue.poll(timeoutMs, TimeUnit.MILLISECONDS)
-        ?: error("DesktopHost.submit($typed) timed out after ${timeoutMs}ms")
-    results.remove(typed.id)
+      try {
+        resultQueue.poll(timeoutMs, TimeUnit.MILLISECONDS)
+          ?: error("DesktopHost.submit($typed) timed out after ${timeoutMs}ms")
+      } finally {
+        // Remove on every exit path — success, timeout, or a re-thrown engine Throwable — so the
+        // map never retains a completed request's slot.
+        results.remove(typed.id)
+      }
     // The render loop posts either a [RenderResult] (success / stub) or a [Throwable] (engine
     // body threw). Re-throw the Throwable so `JsonRpcServer.submitRenderAsync`'s catch surfaces
     // it as a `renderFailed` notification — the path the v1 `S5RenderFailedRealModeTest` covers.
@@ -680,7 +689,10 @@ open class DesktopHost(
               // leaking reflection details into S5RenderFailedRealModeTest's assertions.
               unwrapInvocationTarget(t)
             }
-          results.computeIfAbsent(request.id) { LinkedBlockingQueue() }.put(result)
+          // Deliver into the slot `submit` registered before enqueuing this request. Use a plain
+          // lookup, never `computeIfAbsent`: if `submit` already gave up (timeout) and removed the
+          // slot, drop the result here instead of resurrecting an entry no one will ever drain.
+          results[request.id]?.put(result)
         }
       }
     }

--- a/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRendererMain.kt
+++ b/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRendererMain.kt
@@ -697,6 +697,10 @@ private fun loadProviderValues(providerFqn: String, limit: Int): List<Any?> {
         )
         return emptyList()
       }
+  // A `private` provider (idiomatic Kotlin, renders fine in Android Studio) compiles to a
+  // package-private JVM class; `getValues.invoke` from outside the package then throws
+  // IllegalAccessException without this. Mirrors the Android renderer fix for issue #2493.
+  getValues.isAccessible = true
   @Suppress("UNCHECKED_CAST")
   val sequence = getValues.invoke(instance) as? Sequence<Any?> ?: return emptyList()
   // `Sequence.take(Int)` is lazy and `.toList()` drives it — bounds the

--- a/vscode-extension/src/daemon/daemonProcess.ts
+++ b/vscode-extension/src/daemon/daemonProcess.ts
@@ -318,6 +318,18 @@ export async function spawnDaemon(opts: SpawnOptions): Promise<SpawnedDaemon> {
             logger?.appendLine(`[daemon] process exited with code=${code}`);
             resolve(code);
         });
+        // A spawn failure (a bad/non-executable javaLauncher that still passed the statSync
+        // pre-check, EACCES, a fork failure) emits 'error' on the ChildProcess, and because the
+        // process never started no 'exit' follows. Without a listener Node re-throws it as an
+        // uncaught exception in the extension host; instead log it and resolve `exited` so the
+        // argfile temp-dir cleanup fires. The `initialize` handshake below then fails gracefully
+        // via the stdin/stdout stream-error path DaemonClient already handles.
+        child.on("error", (err) => {
+            logger?.appendLine(
+                `[daemon] process failed to start: ${err.message}`,
+            );
+            resolve(exitCode);
+        });
     });
     // `java` reads the @argfile during launch, so it's safe to remove once the
     // process exits — whether that's a clean shutdown, a crash, or the SIGTERM


### PR DESCRIPTION
## Summary

A critical architecture/code review surfaced a cluster of resource-leak and hang bugs. This PR fixes the clearly-scoped, low-risk ones (one commit each); the larger architectural findings — the `encodeRenderPayload`/history-dispatcher hardcoding and the desktop-vs-Android `RenderEngine` divergence — are intentionally left for separate, focused PRs.

- **daemon — `DesktopHost` result-queue leak on render timeout.** On timeout, `submit()` threw before removing the per-id result slot, and the render worker later resurrected it via `computeIfAbsent` — orphaning one queue + its `RenderResult` per timeout for the daemon's lifetime. The slot is now registered before the request is enqueued, the poll is wrapped in `try/finally`, and the worker delivers via a plain lookup that drops the result instead of resurrecting an abandoned slot.
- **renderer — desktop `@PreviewParameter` reflection.** A `private` `PreviewParameterProvider` compiles to a package-private JVM class; invoking its `getValues()` from outside the package threw `IllegalAccessException`, so a preview that rendered on Android produced an `.error.json` on Desktop. Set `isAccessible = true`, mirroring the Android fix for #2493.
- **cli — subprocess stderr pipe deadlock.** `SharePreviewCommand.exec()` and `DoctorCommand.runCommand()` read stdout to EOF before touching stderr with separate pipes, so a child that filled its ~64 KB stderr buffer first (e.g. a `git push` with a chatty server hook) deadlocked — and the `waitFor` timeout sat *after* the blocking reads, so it could never fire. Both now drain stderr on a daemon thread.
- **cli — unbounded bundle render subprocess.** `spawnRenderer`/`spawnAndroidRenderer` waited on the render subprocess with an unbounded `waitFor()`, so a wedged render hung `bundle render` forever. Both now route through a shared helper that drains output on a daemon thread and force-kills after a 600s ceiling (matching the Gradle-render ceiling).
- **vscode — daemon spawn `'error'` handling.** The spawned daemon `ChildProcess` had no `'error'` listener, so a spawn failure (bad `javaLauncher` path passing `statSync`, `EACCES`, fork failure) re-threw as an uncaught exception in the extension host and leaked the argfile temp dir (`exited` never resolved). Added an `'error'` handler that logs and resolves `exited`.

## Test plan

- [x] `./gradlew :cli:compileKotlin :daemon:desktop:compileKotlin :renderer-desktop:compileKotlin` — BUILD SUCCESSFUL
- [x] `ktfmtFormat` on the three Kotlin modules; `daemonProcess.ts` verified prettier-clean under the repo's `--tab-width 4`
- [x] `vscode-extension` `npm run compile` — clean
- [x] Confirmed the one failing `:daemon:desktop` test (`DesktopHostTest.recordingScriptEventDescriptorsAdvertiseSupportedExtensions`, an assertion about advertised extension kinds) fails **identically on the untouched baseline** — pre-existing and unrelated to these changes.

_Generated by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01GUmFnbWgEjZUnupdPwMHVf)_