### PR TITLE
feat: render i18n/a11y axes (locale/direction/fontScale) in the Compose M3 catalog (#220)

### DIFF
--- a/samples/design-catalog-m3/catalog.spec.json
+++ b/samples/design-catalog-m3/catalog.spec.json
@@ -26,7 +26,10 @@
             { "state": "pressed", "preview": "FilledButtonPressed", "caption": "Held PressInteraction → pressed state layer." },
             { "state": "keyboard-focus", "preview": "FilledButtonFocused", "caption": "Keyboard focus (focus-visible) → M3 inset focus ring. This is the directional/keyboard focus indicator, not the pointer/hover state layer." },
             { "state": "disabled", "preview": "FilledButtonDisabled", "caption": "Disabled state." },
-            { "props": { "content": "icon+label" }, "preview": "FilledButtonIconLabel", "caption": "Content axis (not a state): leading icon + label, vs the label-only default." }
+            { "props": { "content": "icon+label" }, "preview": "FilledButtonIconLabel", "caption": "Content axis (not a state): leading icon + label, vs the label-only default." },
+            { "props": { "locale": "ar-XB" }, "preview": "FilledButtonPseudo", "caption": "i18n axis: the ar-XB bidi pseudolocale — flips the button to RTL layout so mirroring bugs surface (desktop CMP pseudolocalises layout direction, not text)." },
+            { "props": { "direction": "rtl" }, "preview": "FilledButtonRtl", "caption": "i18n axis: forced RTL layout direction (LocalLayoutDirection = Rtl)." },
+            { "props": { "fontScale": "2.0" }, "preview": "FilledButtonLargeFont", "caption": "Accessibility axis: 2× font scale (LocalDensity fontScale = 2.0) — large-text / dynamic-type stress." }
           ]
         },
         { "componentId": "Button/Tonal", "preview": "FilledTonalButtonSticker", "caption": "Secondary, still prominent." },
@@ -45,7 +48,12 @@
         { "componentId": "Checkbox/Checked", "preview": "CheckboxChecked",
           "variants": [ { "state": "unchecked", "preview": "CheckboxUnchecked", "caption": "Unchecked state." } ] },
         { "componentId": "Switch/On", "preview": "SwitchOn",
-          "variants": [ { "state": "off", "preview": "SwitchOff", "caption": "Off state." } ] },
+          "variants": [
+            { "state": "off", "preview": "SwitchOff", "caption": "Off state." },
+            { "props": { "locale": "ar-XB" }, "preview": "SwitchOnPseudo", "caption": "i18n axis: the ar-XB bidi pseudolocale — flips the row to RTL layout (desktop CMP pseudolocalises layout direction, not text)." },
+            { "props": { "direction": "rtl" }, "preview": "SwitchOnRtl", "caption": "i18n axis: forced RTL layout direction (LocalLayoutDirection = Rtl)." },
+            { "props": { "fontScale": "2.0" }, "preview": "SwitchOnLargeFont", "caption": "Accessibility axis: 2× font scale (LocalDensity fontScale = 2.0) — large-text / dynamic-type stress." }
+          ] },
         { "componentId": "RadioButton/Selected", "preview": "RadioSelected",
           "variants": [ { "state": "unselected", "preview": "RadioUnselected", "caption": "Unselected state." } ] },
         { "componentId": "Slider", "preview": "SliderMid" },

--- a/samples/design-catalog-m3/src/main/kotlin/com/example/designcatalogm3/CatalogPreviews.kt
+++ b/samples/design-catalog-m3/src/main/kotlin/com/example/designcatalogm3/CatalogPreviews.kt
@@ -16,11 +16,9 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.LayoutDirection
 import com.example.designcatalogm3.shared.CatalogComponent
 import com.example.designcatalogm3.shared.generated.resources.Res
@@ -160,8 +158,14 @@ fun SlottedCardSlotsSticker() = CatalogSticker {
 //     direction, not text (`org.jetbrains.compose.resources` doesn't go through
 //     `LocalContext.resources`), so `en-XA` accent-expansion isn't visible here; the `ar-XB` bidi
 //     pseudolocale is, so it's the one that carries visible evidence.
-//   * **direction** forces `LocalLayoutDirection = Rtl` directly.
-//   * **fontScale** provides a `LocalDensity` with `fontScale = 2f` (large-text / dynamic-type).
+//   * **direction** forces `LocalLayoutDirection = Rtl` directly (layout direction is a composition
+//     property the renderer captures, so an override is faithful in both the PNG and the SVG
+// export).
+//   * **fontScale** is set on the `@Preview` itself (`fontScale = 2f`), not via a `LocalDensity`
+//     override: the design-artifacts SVG export reads `fontScale` from the render spec (the preview
+//     params), so driving it from the annotation keeps the PNG and the exported SVG/text metadata
+// in
+//     lockstep at 2.0 (large-text / dynamic-type).
 
 // Button — filled.
 @Preview(name = "Light", locale = "ar-XB", group = "modes")
@@ -176,14 +180,10 @@ fun FilledButtonRtl() =
     Sticker("button-filled")
   }
 
-@CatalogModes
+@Preview(name = "Light", fontScale = 2f, group = "modes")
+@Preview(name = "Dark", fontScale = 2f, uiMode = 32, group = "modes")
 @Composable
-fun FilledButtonLargeFont() =
-  CompositionLocalProvider(
-    LocalDensity provides Density(density = LocalDensity.current.density, fontScale = 2f)
-  ) {
-    Sticker("button-filled")
-  }
+fun FilledButtonLargeFont() = Sticker("button-filled")
 
 // List row — the on switch (a settings-style selection row).
 @Preview(name = "Light", locale = "ar-XB", group = "modes")
@@ -198,14 +198,10 @@ fun SwitchOnRtl() =
     Sticker("switch-on")
   }
 
-@CatalogModes
+@Preview(name = "Light", fontScale = 2f, group = "modes")
+@Preview(name = "Dark", fontScale = 2f, uiMode = 32, group = "modes")
 @Composable
-fun SwitchOnLargeFont() =
-  CompositionLocalProvider(
-    LocalDensity provides Density(density = LocalDensity.current.density, fontScale = 2f)
-  ) {
-    Sticker("switch-on")
-  }
+fun SwitchOnLargeFont() = Sticker("switch-on")
 
 /**
  * Every sticker is the shared component (deterministic frame) inside the catalog theme wrapper. All

--- a/samples/design-catalog-m3/src/main/kotlin/com/example/designcatalogm3/CatalogPreviews.kt
+++ b/samples/design-catalog-m3/src/main/kotlin/com/example/designcatalogm3/CatalogPreviews.kt
@@ -16,7 +16,12 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
 import com.example.designcatalogm3.shared.CatalogComponent
 import com.example.designcatalogm3.shared.generated.resources.Res
 import com.example.designcatalogm3.shared.generated.resources.msg_deploy
@@ -142,6 +147,65 @@ fun SlottedCardSlotsSticker() = CatalogSticker {
 @CatalogModes @Composable fun RadioUnselected() = Sticker("radiobutton-unselected")
 
 @CatalogModes @Composable fun SegmentedToggle() = Sticker("segmentedbutton")
+
+// --- Internationalisation / accessibility axes ---
+//
+// The same two representative components — the filled button and the on switch — rendered under the
+// i18n/a11y dimensions, declared as named `props` variants (`locale` / `direction` / `fontScale`)
+// on their parent sticker in `catalog.spec.json`, mirroring the `content: icon+label` content-axis
+// variant. Pure Compose, no renderer change:
+//   * **pseudolocale** reuses the repo's existing pseudolocale-in-previews mechanism —
+//     `@Preview(locale = "ar-XB")`, the `Pseudolocale.BIDI` tag the desktop renderer recognises and
+//     flips to RTL (see `:samples:cmp`'s `CmpPseudoBidi`). Desktop CMP pseudolocalises layout
+//     direction, not text (`org.jetbrains.compose.resources` doesn't go through
+//     `LocalContext.resources`), so `en-XA` accent-expansion isn't visible here; the `ar-XB` bidi
+//     pseudolocale is, so it's the one that carries visible evidence.
+//   * **direction** forces `LocalLayoutDirection = Rtl` directly.
+//   * **fontScale** provides a `LocalDensity` with `fontScale = 2f` (large-text / dynamic-type).
+
+// Button — filled.
+@Preview(name = "Light", locale = "ar-XB", group = "modes")
+@Preview(name = "Dark", locale = "ar-XB", uiMode = 32, group = "modes")
+@Composable
+fun FilledButtonPseudo() = Sticker("button-filled")
+
+@CatalogModes
+@Composable
+fun FilledButtonRtl() =
+  CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Rtl) {
+    Sticker("button-filled")
+  }
+
+@CatalogModes
+@Composable
+fun FilledButtonLargeFont() =
+  CompositionLocalProvider(
+    LocalDensity provides Density(density = LocalDensity.current.density, fontScale = 2f)
+  ) {
+    Sticker("button-filled")
+  }
+
+// List row — the on switch (a settings-style selection row).
+@Preview(name = "Light", locale = "ar-XB", group = "modes")
+@Preview(name = "Dark", locale = "ar-XB", uiMode = 32, group = "modes")
+@Composable
+fun SwitchOnPseudo() = Sticker("switch-on")
+
+@CatalogModes
+@Composable
+fun SwitchOnRtl() =
+  CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Rtl) {
+    Sticker("switch-on")
+  }
+
+@CatalogModes
+@Composable
+fun SwitchOnLargeFont() =
+  CompositionLocalProvider(
+    LocalDensity provides Density(density = LocalDensity.current.density, fontScale = 2f)
+  ) {
+    Sticker("switch-on")
+  }
 
 /**
  * Every sticker is the shared component (deterministic frame) inside the catalog theme wrapper. All


### PR DESCRIPTION
## Summary

The **render side of design-parity [#220](https://github.com/yschimke/design-parity/issues/220)**. Renders the Compose M3 sample catalog across the i18n / a11y dimensions so they flow through `catalog.json` as `props` axes and surface as **data-driven picker dimensions** in the design-parity figma-plugin (the plugin half is [design-parity#245](https://github.com/yschimke/design-parity/pull/245)).

Applied to two representative components — the **filled button** and the **on switch** (a settings-style row) — declared as `props` variants in `catalog.spec.json`, mirroring the existing `content: icon+label` content-axis variant. **No renderer / daemon change**; each axis is applied purely in Compose:

| Axis (`props`) | How | Checks |
| --- | --- | --- |
| `locale = ar-XB` | `@Preview(locale = "ar-XB")` — the `Pseudolocale.BIDI` tag the desktop renderer honours (flips layout direction) | pseudolocale / mirroring |
| `direction = rtl` | `CompositionLocalProvider(LocalLayoutDirection provides Rtl)` | RTL mirroring |
| `fontScale = 2.0` | `@Preview(fontScale = 2f)` (render spec, so PNG + exported SVG stay in lockstep) | large-text / dynamic type |

### Pseudolocale note
Desktop CMP pseudolocalises **layout direction, not text** (`org.jetbrains.compose.resources` doesn't route through `LocalContext.resources`), so an `en-XA` accent/expansion render would be invisible. The `ar-XB` **bidi** pseudolocale *is* honoured by the renderer, so it carries visible evidence while genuinely reusing the repo's existing `@Preview(locale=…)` pseudolocale-in-previews mechanism (as `:samples:cmp`'s `CmpPseudoBidi` does). The `locale` and `direction` axes both yield RTL via different mechanisms (renderer locale path vs. explicit local); captions distinguish them.

## Changes
- `samples/design-catalog-m3/src/main/kotlin/com/example/designcatalogm3/CatalogPreviews.kt` — 6 new preview functions (button + switch × pseudolocale / RTL / fontScale)
- `samples/design-catalog-m3/catalog.spec.json` — 3 `props` variants on `Button/Filled` and 3 on `Switch/On`

## Verification
- **`./gradlew :samples:design-catalog-m3:compileKotlin` — BUILD SUCCESSFUL**; `ktfmtFormat` clean.
- `catalog.spec.json` validated as JSON.

## Visual evidence

All six new variants, rendered by the CI preview pipeline (commit `aaa4587`, dark theme shown):

### Button — filled
| Pseudolocale (`ar-XB`) | RTL (`direction`) | Font scale 2× |
| --- | --- | --- |
| ![Filled button, ar-XB bidi pseudolocale](``https://raw.githubusercontent.com/yschimke/compose-ai-tools/aaa4587bda164da175fad6ebeb5b5496d0662069/renders/samples:design-catalog-m3/FilledButtonPseudo_Dark.png)`` | ![Filled button, RTL](``https://raw.githubusercontent.com/yschimke/compose-ai-tools/aaa4587bda164da175fad6ebeb5b5496d0662069/renders/samples:design-catalog-m3/FilledButtonRtl_Dark.png)`` | ![Filled button, 2x font scale](``https://raw.githubusercontent.com/yschimke/compose-ai-tools/aaa4587bda164da175fad6ebeb5b5496d0662069/renders/samples:design-catalog-m3/FilledButtonLargeFont_Dark.png)`` |

### Switch — on
| Pseudolocale (`ar-XB`) | RTL (`direction`) | Font scale 2× |
| --- | --- | --- |
| ![Switch on, ar-XB bidi pseudolocale](``https://raw.githubusercontent.com/yschimke/compose-ai-tools/aaa4587bda164da175fad6ebeb5b5496d0662069/renders/samples:design-catalog-m3/SwitchOnPseudo_Dark.png)`` | ![Switch on, RTL](``https://raw.githubusercontent.com/yschimke/compose-ai-tools/aaa4587bda164da175fad6ebeb5b5496d0662069/renders/samples:design-catalog-m3/SwitchOnRtl_Dark.png``) | ![Switch on, 2x font scale](``https://raw.githubusercontent.com/yschimke/compose-ai-tools/aaa4587bda164da175fad6ebeb5b5496d0662069/renders/samples:design-catalog-m3/SwitchOnLargeFont_Dark.png)`` |

Light-theme renders are linked from the CI `preview-diff` comment below. These are new stickers (no before), and they're standard discovered `@Preview`s, so the visual-diff bot renders and diffs them automatically on every future change.

Part of design-parity #220 (render side); the figma-plugin already surfaces these as picker dimensions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_Generated by [Claude Code]_