### PR TITLE
chore(deps): update npm minor/patch and fix serialize-javascript override

### DIFF
--- a/scripts/design-artifacts/package-lock.json
+++ b/scripts/design-artifacts/package-lock.json
@@ -16,28 +16,28 @@
       }
     },
     "node_modules/@design-parity/candidate": {
-      "version": "0.1.25",
-      "resolved": "https://registry.npmjs.org/@design-parity/candidate/-/candidate-0.1.25.tgz",
-      "integrity": "sha512-vf/YtvG0H3PFjdbL4zPkmxlm7Vf7ZybcJgM/govVX++SWluQ67pk5tnmTcfxcIEep+MfhYKJq4ToX3MpWIjOkA==",
+      "version": "0.1.29",
+      "resolved": "https://registry.npmjs.org/@design-parity/candidate/-/candidate-0.1.29.tgz",
+      "integrity": "sha512-Cvgc0S337d54z96EKFD3QWPa/zUKYtkDyk9/HuRuuMBFHKd/gBo9sSewnMmTDy/2n6Y21zQy0QsMgXf9Y1dwmA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@design-parity/core": "^0.1.25",
+        "@design-parity/core": "^0.1.29",
         "fflate": "^0.8.2"
       }
     },
     "node_modules/@design-parity/catalog-export": {
-      "version": "0.1.25",
-      "resolved": "https://registry.npmjs.org/@design-parity/catalog-export/-/catalog-export-0.1.25.tgz",
-      "integrity": "sha512-U9HJ6cwUxNEeJGCmSzA2huVStce4F/zB33x1TeFAbMe0YYANAx196UiS4Km80Fq5g5LD8OuesVcHYCVD10bTxQ==",
+      "version": "0.1.29",
+      "resolved": "https://registry.npmjs.org/@design-parity/catalog-export/-/catalog-export-0.1.29.tgz",
+      "integrity": "sha512-d+jqFHaqKovDMdfRY6i6AjxGXeeZvuaQcAALUPekJDHxexyl/n+d6kESs7Xf7xTqf4C8Fc4fS93MpAs3VPMUsA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@design-parity/core": "^0.1.25"
+        "@design-parity/core": "^0.1.29"
       }
     },
     "node_modules/@design-parity/core": {
-      "version": "0.1.25",
-      "resolved": "https://registry.npmjs.org/@design-parity/core/-/core-0.1.25.tgz",
-      "integrity": "sha512-lyeng/0SnX1zL59xBk7yuPhEmytPJJ5D0IzNZ+VDBmm2s+b46YuQKgy9n7tTJIUIYwWZ5rW2wxLWX7Jffzv/Iw==",
+      "version": "0.1.29",
+      "resolved": "https://registry.npmjs.org/@design-parity/core/-/core-0.1.29.tgz",
+      "integrity": "sha512-HAVi/hbVYoE0zucT36YC83awfiq3GxJYW8X+BvvzVjb5Nhsomm/X95720KvhXZFCUUp0fBfGXY0dehaVgX99lw==",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.17.1"
@@ -70,9 +70,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1085,9 +1085,9 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "24.13.2",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
-            "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
+            "version": "24.13.3",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+            "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1116,9 +1116,9 @@
             "license": "MIT"
         },
         "node_modules/@types/three": {
-            "version": "0.185.0",
-            "resolved": "https://registry.npmjs.org/@types/three/-/three-0.185.0.tgz",
-            "integrity": "sha512-O2Uy8Cj4Nonr8dWUUbifMdPe8B0Mq7EdOHb89S4+kjUw/KhbjTZrUuYlrQ1bpUKG+EP9QJnN7qNxbHGlGoLHMA==",
+            "version": "0.185.1",
+            "resolved": "https://registry.npmjs.org/@types/three/-/three-0.185.1.tgz",
+            "integrity": "sha512-db1xTb+EgYF2didW+eudSvVPtn75zo+fGsY8ShQrJY/B5ZBmC2Fiaykv3aImHAlCNEGuMPkPGXBJGLwzu5mC7A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4846,9 +4846,9 @@
             }
         },
         "node_modules/prettier": {
-            "version": "3.9.1",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.1.tgz",
-            "integrity": "sha512-ppiDo2CSwexck1eyZUwJHg/N3nf1+6IRCv7W/VJ5vaLnVCmB7+3CdRfMwoCHBBX6xTrREDTksZ4OZl5SSf4zXA==",
+            "version": "3.9.6",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+            "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -5203,9 +5203,9 @@
             }
         },
         "node_modules/serialize-javascript": {
-            "version": "7.0.6",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.6.tgz",
-            "integrity": "sha512-ATTK5Q4gFVg0YDp1my2vqygyvhcklD/UV5GIlYHooGTn/NogJqIzpetkD6E5kmuVULqz/S9inUL25XcAgDRJQg==",
+            "version": "7.0.7",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.7.tgz",
+            "integrity": "sha512-YAy8Od6KV+uuwUuU50np8fGB/Aues6Y0nAhA9y/hId74PlKUcme4pXcBD46NWKr1Q4osN/iseZ17YqO1XfmI8g==",
             "dev": true,
             "license": "BSD-3-Clause",
             "engines": {
@@ -5754,9 +5754,9 @@
             }
         },
         "node_modules/three": {
-            "version": "0.185.0",
-            "resolved": "https://registry.npmjs.org/three/-/three-0.185.0.tgz",
-            "integrity": "sha512-+yRrcRO2iZa8uzvNNl0d7cL4huhgKgBvVJ0njcTe8xFqZ6DMAFZdCKDP91SEAuj25bNAj7k1QQdf+srZywVK6w==",
+            "version": "0.185.1",
+            "resolved": "https://registry.npmjs.org/three/-/three-0.185.1.tgz",
+            "integrity": "sha512-5aojFCXKwnjBRZvUnt3WFfEcvUJgkN5LlijRFN95hMy8WVkG4I0QNcJE+OuWvuJ0bOdStrbfXn0pkd6/QyiAlg==",
             "license": "MIT"
         },
         "node_modules/tmp": {

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -306,7 +306,7 @@
         "typescript": "^7.0.0"
     },
     "overrides": {
-        "serialize-javascript": "^7.0.5"
+        "serialize-javascript": "^7.0.7"
     },
     "dependencies": {
         "three": "^0.185.0"


### PR DESCRIPTION
## Summary

Supersedes #2583, which was stuck on a failing `renovate/artifacts` check. Renovate could not refresh `vscode-extension/package-lock.json` because it runs `npm install serialize-javascript@7.0.7`, and `serialize-javascript` exists only as a pinned `overrides` entry there — adding it as a direct dependency conflicts with that override (`npm error code EOVERRIDE`).

This PR regenerates the lockfiles directly (which does not hit the EOVERRIDE path) and bumps the override range so the pin tracks the patched release.

### Changes
- **`vscode-extension/`**: bump the `serialize-javascript` override `^7.0.5` → `^7.0.7` and refresh the lockfile:
  - `three` 0.185.0 → 0.185.1
  - `@types/three` 0.185.0 → 0.185.1
  - `@types/node` 24.13.2 → 24.13.3
  - `prettier` 3.9.1 → 3.9.6 (latest in the `^3.8.3` range; newer than the 3.9.5 Renovate targeted)
  - `serialize-javascript` 7.0.6 → 7.0.7
- **`scripts/design-artifacts/`**: refresh the lockfile for `@design-parity/candidate`, `@design-parity/catalog-export` and `@design-parity/core` to the latest in the `^0.1.25` range (0.1.29; newer than the 0.1.26 Renovate targeted).

All package.json semver ranges are unchanged except the `serialize-javascript` override.

## Test plan
- `npm install --package-lock-only` in `vscode-extension/` — resolves without EOVERRIDE and is idempotent (`up to date`).
- `npm update --package-lock-only` in `scripts/design-artifacts/` — resolves cleanly.
- CI (`Build Samples`, `VS Code Extension Tests`, `ktfmt`, etc.) covers the rest.

Non-visual change (dependency/lockfile plumbing), so no rendered evidence applies.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GHeyfkotErKBztcYaJSWET)_