### PR TITLE
fix(cli): fail Android bundle render batch on subprocess timeout

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleRenderer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleRenderer.kt
@@ -285,22 +285,8 @@ class BundleRenderer(
     outputDir.mkdirs()
     val (exitCode, tail) = spawnAndroidRenderer(launch, classpath, previewsJsonFile, outputDir)
 
-    // AndroidRendererMain renders the whole manifest into outputDir. Reconcile per-preview by the
-    // manifest capture's renderOutput leaf — the exact name `RobolectricRenderTest.outputFileFor`
-    // writes — NOT `safeFilename(id).png` (the renderer normalizes ids, e.g.
-    // `com.example.FooKt.CardPreview` → `CardPreview.png`, so an id-derived name would miss the
-    // file and falsely fail the preview).
-    val succeeded = mutableListOf<RenderedPreview>()
-    val failed = mutableListOf<FailedPreview>()
-    for (preview in renderable) {
-      val outFile = outputDir.resolve(androidOutputLeaf(preview))
-      if (outFile.isFile && outFile.length() > 0) {
-        succeeded += RenderedPreview(preview.id, outFile)
-        if (verbose) logSink("rendered ${preview.id} → ${outFile.path}")
-      } else {
-        failed += FailedPreview(preview.id, exitCode, tail)
-      }
-    }
+    val (succeeded, failed) = reconcileAndroidRenders(renderable, outputDir, exitCode, tail)
+    if (verbose) succeeded.forEach { logSink("rendered ${it.id} → ${it.outputFile.path}") }
     if (failed.isNotEmpty()) {
       logSink("bundle render (android): ${failed.size} preview(s) produced no PNG (exit=$exitCode)")
       if (verbose) logSink(tail)
@@ -353,7 +339,8 @@ class BundleRenderer(
     return if (finished) {
       proc.exitValue() to tail
     } else {
-      124 to (tail + "\n[render subprocess timed out after ${RENDER_PROCESS_TIMEOUT_SECONDS}s]")
+      RENDER_TIMEOUT_EXIT to
+        (tail + "\n[render subprocess timed out after ${RENDER_PROCESS_TIMEOUT_SECONDS}s]")
     }
   }
 
@@ -645,6 +632,38 @@ class BundleRenderer(
       return if (leaf.isNullOrEmpty()) "${preview.id}.png" else leaf
     }
 
+    /**
+     * Reconcile the Android batch renderer's exit code + produced PNGs into per-preview
+     * succeeded/failed lists. [AndroidRendererMain] renders the whole manifest into [outputDir];
+     * each preview is matched by its capture's `renderOutput` leaf (the exact name
+     * `RobolectricRenderTest.outputFileFor` writes — NOT an id-derived name, which the renderer
+     * normalizes, e.g. `com.example.FooKt.CardPreview` → `CardPreview.png`).
+     *
+     * A force-killed run (timeout → [RENDER_TIMEOUT_EXIT]) fails *every* preview regardless of
+     * on-disk PNGs: it may have written some before the kill, and [outputDir] can hold stale PNGs
+     * from a prior run — either would falsely pass the file check. A normal non-zero exit keeps
+     * partial-success semantics (some previews render, others don't), matching the desktop path.
+     */
+    internal fun reconcileAndroidRenders(
+      renderable: List<PreviewInfo>,
+      outputDir: File,
+      exitCode: Int,
+      tail: String,
+    ): Pair<List<RenderedPreview>, List<FailedPreview>> {
+      val timedOut = exitCode == RENDER_TIMEOUT_EXIT
+      val succeeded = mutableListOf<RenderedPreview>()
+      val failed = mutableListOf<FailedPreview>()
+      for (preview in renderable) {
+        val outFile = outputDir.resolve(androidOutputLeaf(preview))
+        if (!timedOut && outFile.isFile && outFile.length() > 0) {
+          succeeded += RenderedPreview(preview.id, outFile)
+        } else {
+          failed += FailedPreview(preview.id, exitCode, tail)
+        }
+      }
+      return succeeded to failed
+    }
+
     /** Compose Desktop's default density = 2.625× (~xxhdpi). Same constant as the renderer. */
     private const val DEFAULT_DENSITY: Float = 2.625f
 
@@ -655,6 +674,9 @@ class BundleRenderer(
      */
     private const val RENDER_PROCESS_TIMEOUT_SECONDS = 600L
     private const val DRAIN_FLUSH_MILLIS = 2000L
+
+    /** Exit code [runRenderProcess] returns when it force-kills a subprocess past the timeout. */
+    private const val RENDER_TIMEOUT_EXIT = 124
 
     private val BUNDLE_JSON = Json {
       ignoreUnknownKeys = true

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleRendererAndroidOutputTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleRendererAndroidOutputTest.kt
@@ -1,5 +1,7 @@
 package ee.schimke.composeai.cli
 
+import java.io.File
+import kotlin.io.path.createTempDirectory
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -72,5 +74,57 @@ class BundleRendererAndroidOutputTest {
     val filtered = BundleRenderer.filterPreviewsJson(raw, drop = emptySet())
     assertTrue(filtered.contains("a.Foo"))
     assertTrue(filtered.contains("a.Bar"))
+  }
+
+  private fun writePng(dir: File, leaf: String) {
+    dir.resolve(leaf).writeBytes(byteArrayOf(1, 2, 3))
+  }
+
+  @Test
+  fun `exit 0 with all PNGs present marks every preview succeeded`() {
+    val dir = createTempDirectory("android-reconcile").toFile()
+    val previews =
+      listOf(preview("a.FooKt.One", "renders/One.png"), preview("a.FooKt.Two", "renders/Two.png"))
+    writePng(dir, "One.png")
+    writePng(dir, "Two.png")
+
+    val (succeeded, failed) =
+      BundleRenderer.reconcileAndroidRenders(previews, dir, exitCode = 0, tail = "")
+
+    assertEquals(setOf("a.FooKt.One", "a.FooKt.Two"), succeeded.map { it.id }.toSet())
+    assertTrue(failed.isEmpty())
+  }
+
+  @Test
+  fun `non-zero exit keeps partial success for previews that produced a PNG`() {
+    val dir = createTempDirectory("android-reconcile").toFile()
+    val previews =
+      listOf(preview("a.FooKt.One", "renders/One.png"), preview("a.FooKt.Two", "renders/Two.png"))
+    // Only One rendered; Two never produced a PNG (e.g. it threw). Partial success is preserved.
+    writePng(dir, "One.png")
+
+    val (succeeded, failed) =
+      BundleRenderer.reconcileAndroidRenders(previews, dir, exitCode = 1, tail = "boom")
+
+    assertEquals(listOf("a.FooKt.One"), succeeded.map { it.id })
+    assertEquals(listOf("a.FooKt.Two"), failed.map { it.id })
+  }
+
+  @Test
+  fun `timeout fails every preview even when PNGs are present on disk`() {
+    val dir = createTempDirectory("android-reconcile").toFile()
+    val previews =
+      listOf(preview("a.FooKt.One", "renders/One.png"), preview("a.FooKt.Two", "renders/Two.png"))
+    // Both PNGs exist (written before the force-kill, or stale from a prior run), but exit 124
+    // means the run never completed — so neither may be trusted.
+    writePng(dir, "One.png")
+    writePng(dir, "Two.png")
+
+    val (succeeded, failed) =
+      BundleRenderer.reconcileAndroidRenders(previews, dir, exitCode = 124, tail = "timed out")
+
+    assertTrue(succeeded.isEmpty())
+    assertEquals(setOf("a.FooKt.One", "a.FooKt.Two"), failed.map { it.id }.toSet())
+    assertTrue(failed.all { it.exitCode == 124 })
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to #2611. That PR made the bundle render subprocess return exit `124` on timeout instead of hanging — which exposed a latent gap the Codex bot flagged: `renderAndroid` marks each preview succeeded from `outFile.isFile && outFile.length() > 0` alone, ignoring the exit code. So a run force-killed **after** writing its PNGs, or one reusing an `outputDir` that still holds stale PNGs from a prior run, reported every preview `ok` and exited 0 despite never completing.

Fix: a force-killed run (exit `124`) now fails the **whole batch**, regardless of on-disk PNGs. A normal non-zero exit keeps partial-success semantics (some previews render, others fail) — matching the desktop path, which deliberately relies on file presence because `DesktopRendererMain` exits 0 per-preview by design.

I went narrower than the review's literal suggestion (gate all successes on `exitCode == 0`): that would flip a whole batch to failed when one preview fails but the rest render fine. Gating on **timeout specifically** closes the real hole without over-failing healthy partial batches.

The reconciliation logic is extracted into a pure `reconcileAndroidRenders` companion helper so it's unit-testable — the same pattern as the existing `androidOutputLeaf` / `filterPreviewsJson` tests (which themselves exist from a prior Codex catch on #1651).

## Test plan

- [x] `./gradlew :cli:compileKotlin` — BUILD SUCCESSFUL
- [x] `./gradlew :cli:test --tests "*BundleRendererAndroidOutputTest"` — passes, incl. 3 new cases:
  - exit 0 with all PNGs present → all succeeded
  - non-zero exit with a partial PNG set → partial success preserved
  - exit 124 (timeout) with PNGs present on disk → every preview failed
- [x] `ktfmtFormat` on main + test

_Generated by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01GUmFnbWgEjZUnupdPwMHVf)_