### PR TITLE
test(daemon): fix stale DesktopHost recording-descriptor expectations

### DIFF
--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
@@ -160,6 +160,9 @@ open class DesktopHost(
    * Script-event descriptors this host's [DesktopRecordingSession] dispatches:
    *
    * - `recording.probe` — timeline marker.
+   * - `assertion` — golden-image / visibility asserts evaluated by [DesktopRecordingSession] (issue
+   *
+   * #1967); omitting it makes the MCP layer reject `assert.*` up front.
    * - `input.touch` — click + pointer up/down/move via `ImageComposeScene.sendPointerEvent`.
    * - `input.keyboard` — keyDown / keyUp via Skiko `sendKeyEvent` + the Android-keycode → Compose
    *   `Key` translation table in `DesktopKeyDispatch.kt`. Wired by issue #1203.

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopHostTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopHostTest.kt
@@ -111,16 +111,20 @@ class DesktopHostTest {
   }
 
   /**
-   * With a resolver wired, `recordingScriptEventDescriptors()` advertises three extensions:
-   * `recording` (probe, supported), `input.touch` (4 pointer events, supported), and
-   * `input.keyboard` (2 key events, roadmap). The Wear-only `input.rsb` lives on the Android host;
-   * desktop daemons skip it.
+   * With a resolver wired, `recordingScriptEventDescriptors()` advertises four extensions:
+   * `recording` (probe, supported), `assertion` (golden-image / visibility asserts the desktop
+   * `DesktopRecordingSession` dispatches, issue #1967), `input.touch` (4 pointer events,
+   * supported), and `input.keyboard` (2 key events, roadmap). The Wear-only `input.rsb` lives on
+   * the Android host; desktop daemons skip it.
    */
   @Test
   fun recordingScriptEventDescriptorsAdvertiseSupportedExtensions() {
     val descriptors = DesktopHost(previewSpecResolver = { null }).recordingScriptEventDescriptors()
     val advertisedExtensionIds = descriptors.map { it.id.value }.toSet()
-    assertEquals(setOf("recording", "input.touch", "input.keyboard"), advertisedExtensionIds)
+    assertEquals(
+      setOf("recording", "assertion", "input.touch", "input.keyboard"),
+      advertisedExtensionIds,
+    )
     assertTrue(
       "input.rsb is Wear-only and must NOT appear on the desktop host",
       "input.rsb" !in advertisedExtensionIds,


### PR DESCRIPTION
## Summary

`DesktopHostTest.recordingScriptEventDescriptorsAdvertiseSupportedExtensions` was failing on `main` (surfaced while verifying an earlier PR). The cause is a stale test, not a code bug: `DesktopHost.recordingScriptEventDescriptors()` advertises the `assertion` extension (golden-image / visibility asserts that `DesktopRecordingSession` actually dispatches, #1967), but the test's expected set — and the KDocs on both the test and the method — were never updated when `assertionDescriptor` was added to the list. The test asserted a three-extension set and the code returns four.

Fix (the code is correct, so the test moves):
- Add `assertion` to the expected set in the test.
- Refresh the test KDoc ("three extensions" → four, with the `assertion` entry).
- Add the missing `assertion` bullet to the `recordingScriptEventDescriptors()` KDoc.

## Test plan

- [x] `./gradlew :daemon:desktop:test --tests "*DesktopHostTest"` — BUILD SUCCESSFUL (previously failed on this case on `main`)
- [x] `ktfmtFormat` on the touched main + test files

_Generated by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01GUmFnbWgEjZUnupdPwMHVf)_