### PR TITLE
feat(discovery): expand known off-classpath multi-preview annotations, warn on the rest

### DIFF
--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
@@ -2423,20 +2423,22 @@ object PreviewDiscovery {
 
   /**
    * FQNs among [annotations] that look like preview-family annotations — a multi-preview
-   * meta-annotation or user wrapper whose simple name contains `Preview` — yet which
-   * [resolveMultiPreview] can't expand into any `@Preview`, so the preview is dropped with no
-   * diagnostic. Issue #2613: `@WearPreviewLargeRound` in an app's `main` source set, whose wear
-   * tooling artifact was wired only into `screenshotTest`, vanished this way — its annotation class
-   * isn't on the discovery classpath, so the meta-annotation closure has no reachable `@Preview`.
+   * meta-annotation whose simple name contains `Preview` — whose annotation class is NOT on the
+   * discovery classpath, so [resolveMultiPreview] can't reach the `@Preview`(s) inside them and the
+   * preview is dropped with no diagnostic. Issue #2613: `@WearPreviewLargeRound` in an app's `main`
+   * source set, whose wear tooling artifact was wired only into `screenshotTest`, vanished this
+   * way.
    *
-   * Keyed on the *resolution result* (`resolveMultiPreview(...).isEmpty()`) rather than on
-   * `getClassInfo == null`: ClassGraph hands back a non-null placeholder `ClassInfo` for an
-   * annotation class that's merely referenced (never scanned), so a null check misses exactly this
-   * case. Deliberately narrow to avoid false positives: reachable multi-preview annotations resolve
-   * to a non-empty list (skipped), the capture/wrapper/parameter annotations we own are excluded
-   * via [NON_EXPANDING_PREVIEW_FQNS], and the `contains("Preview")` name filter excludes unrelated
-   * annotations (`@Composable`, `@JvmStatic`, …). Direct `@Preview` / `Preview.Container` are
-   * handled elsewhere.
+   * Keyed on the annotation class being **absent from the scan** (`getClassInfo == null`). The scan
+   * doesn't `enableExternalClasses()`, so ClassGraph returns null — never a placeholder — for a
+   * class it only saw referenced, which is precisely the off-classpath case. This is what
+   * distinguishes a genuinely-dropped preview from a *reachable* annotation that merely happens to
+   * contain `Preview` in its name and isn't a multi-preview (a project's own `@PreviewOnly`
+   * marker): the latter is scanned, so `getClassInfo` is non-null and it is not flagged — no
+   * misleading "classpath" WARN on healthy modules (Codex review, PR #2631). `isExternalClass` is
+   * folded in defensively in case external-class scanning is ever enabled. The
+   * capture/wrapper/parameter annotations we own are excluded via [NON_EXPANDING_PREVIEW_FQNS], and
+   * direct `@Preview` / `Preview.Container` are handled elsewhere.
    */
   private fun unexpandablePreviewAnnotationNames(
     annotations: List<AnnotationInfo>,
@@ -2448,7 +2450,7 @@ object PreviewDiscovery {
       .filterNot { it.name in NON_EXPANDING_PREVIEW_FQNS }
       .filter { ann ->
         ann.name.substringAfterLast('.').contains("Preview") &&
-          resolveMultiPreview(ann, scanResult, mutableSetOf()).isEmpty()
+          scanResult.getClassInfo(ann.name).let { it == null || it.isExternalClass }
       }
       .map { it.name }
       .distinct()

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
@@ -1299,6 +1299,25 @@ object PreviewDiscovery {
       } else {
         annotations.flatMap { resolveMultiPreview(it, scanResult, mutableSetOf()) }
       }
+    // Issue #2613: a preview-family annotation whose class isn't on the discovery classpath is
+    // dropped silently by `resolveMultiPreview` (its `getClassInfo` lookup returns null), so the
+    // preview vanishes from the manifest with no diagnostic — a strict catalog render later fails
+    // with `missing renders` and no clue why. Surface it as a WARN. Scoped to the `directPreviews`
+    // empty branch: that's exactly where `resolveMultiPreview` ran and could have silently dropped
+    // an unreachable annotation (and the mixed case where a sibling annotation still resolved).
+    if (directPreviews.isEmpty()) {
+      for (fqn in unexpandablePreviewAnnotationNames(annotations, scanResult)) {
+        val simple = fqn.substringAfterLast('.')
+        warnings.add(
+          "composePreview: '${classInfo.name}.${method.name}' carries @$simple ($fqn) but " +
+            "discovery could not expand it into any @Preview — the annotation class is not on the " +
+            "discovery classpath for source set '${input.variantName}'. This usually means the " +
+            "tooling artifact that defines @$simple is wired into a test-only source set (e.g. " +
+            "screenshotTestImplementation) rather than the main/implementation classpath, so the " +
+            "preview is silently missing until it is resolvable there. See issue #2613."
+        )
+      }
+    }
     if (directPreviews.isEmpty() && resolvedMultiPreviews.isEmpty()) return
 
     // @PreviewWrapper and @ScrollingPreview are both non-repeatable and apply
@@ -2377,6 +2396,63 @@ object PreviewDiscovery {
     }
     return result
   }
+
+  // Preview-adjacent annotations we own that legitimately never expand into a `@Preview` — they
+  // modify, wrap, or parameterise a preview rather than declare one. Their simple names all contain
+  // `Preview`, so the unexpandable-annotation heuristic below (which matches on
+  // `contains("Preview")`
+  // — the wear multi-preview annotations put `Preview` mid-name, e.g. `WearPreviewLargeRound`) must
+  // exclude them explicitly or it would warn on every `@ScrollingPreview` / `@PreviewParameter`.
+  // The
+  // direct-preview FQNs — plain / desktop / tile / notification / glance / XR `@Preview` — are
+  // excluded separately by [isDirectPreview].
+  private val NON_EXPANDING_PREVIEW_FQNS =
+    setOf(
+      SCROLLING_PREVIEW_FQN,
+      ANIMATED_PREVIEW_FQN,
+      FOCUSED_PREVIEW_FQN,
+      AMBIENT_PREVIEW_FQN,
+      GESTURE_HINT_PREVIEW_FQN,
+      LAUNCHER_WIDGET_PREVIEW_FQN,
+      LAUNCHER_WIDGET_RESIZE_FQN,
+      PREVIEW_PARAMETER_FQN,
+      PREVIEW_WRAPPER_FQN,
+      PREVIEW_WRAPPER_CLASS_FQN,
+      ROBO_COMPOSE_PREVIEW_OPTIONS_FQN,
+    )
+
+  /**
+   * FQNs among [annotations] that look like preview-family annotations — a multi-preview
+   * meta-annotation or user wrapper whose simple name contains `Preview` — yet which
+   * [resolveMultiPreview] can't expand into any `@Preview`, so the preview is dropped with no
+   * diagnostic. Issue #2613: `@WearPreviewLargeRound` in an app's `main` source set, whose wear
+   * tooling artifact was wired only into `screenshotTest`, vanished this way — its annotation class
+   * isn't on the discovery classpath, so the meta-annotation closure has no reachable `@Preview`.
+   *
+   * Keyed on the *resolution result* (`resolveMultiPreview(...).isEmpty()`) rather than on
+   * `getClassInfo == null`: ClassGraph hands back a non-null placeholder `ClassInfo` for an
+   * annotation class that's merely referenced (never scanned), so a null check misses exactly this
+   * case. Deliberately narrow to avoid false positives: reachable multi-preview annotations resolve
+   * to a non-empty list (skipped), the capture/wrapper/parameter annotations we own are excluded
+   * via [NON_EXPANDING_PREVIEW_FQNS], and the `contains("Preview")` name filter excludes unrelated
+   * annotations (`@Composable`, `@JvmStatic`, …). Direct `@Preview` / `Preview.Container` are
+   * handled elsewhere.
+   */
+  private fun unexpandablePreviewAnnotationNames(
+    annotations: List<AnnotationInfo>,
+    scanResult: ScanResult,
+  ): List<String> =
+    annotations
+      .asSequence()
+      .filterNot { isDirectPreview(it) || isPreviewContainer(it) }
+      .filterNot { it.name in NON_EXPANDING_PREVIEW_FQNS }
+      .filter { ann ->
+        ann.name.substringAfterLast('.').contains("Preview") &&
+          resolveMultiPreview(ann, scanResult, mutableSetOf()).isEmpty()
+      }
+      .map { it.name }
+      .distinct()
+      .toList()
 
   private fun resolveMultiPreview(
     ann: AnnotationInfo,

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
@@ -1299,14 +1299,22 @@ object PreviewDiscovery {
       } else {
         annotations.flatMap { resolveMultiPreview(it, scanResult, mutableSetOf()) }
       }
-    // Issue #2613: a preview-family annotation whose class isn't on the discovery classpath is
-    // dropped silently by `resolveMultiPreview` (its `getClassInfo` lookup returns null), so the
-    // preview vanishes from the manifest with no diagnostic — a strict catalog render later fails
-    // with `missing renders` and no clue why. Surface it as a WARN. Scoped to the `directPreviews`
-    // empty branch: that's exactly where `resolveMultiPreview` ran and could have silently dropped
-    // an unreachable annotation (and the mixed case where a sibling annotation still resolved).
+    // Issue #2613: a preview annotated only with a multi-preview annotation whose class is off the
+    // discovery classpath (e.g. wear tooling wired into `screenshotTest`, so
+    // `@WearPreviewLargeRound`
+    // resolves there but not in `main`) resolves to nothing and vanishes silently. For the
+    // well-known AndroidX / Wear annotations we expand them from a built-in spec table so they
+    // still
+    // render; for any others we can't recognise, warn so the silent drop is at least visible.
+    // Scoped to the `directPreviews`-empty branch — that's where `resolveMultiPreview` ran and
+    // could
+    // have dropped an unreachable annotation (including the mixed case where a sibling resolved).
+    val builtInSpecs: List<BuiltInPreviewSpec> =
+      if (directPreviews.isEmpty()) annotations.flatMap { builtInExpansionFor(it, scanResult) }
+      else emptyList()
     if (directPreviews.isEmpty()) {
       for (fqn in unexpandablePreviewAnnotationNames(annotations, scanResult)) {
+        if (fqn in BUILT_IN_MULTIPREVIEW_EXPANSIONS) continue // expanded from the table below
         val simple = fqn.substringAfterLast('.')
         warnings.add(
           "composePreview: '${classInfo.name}.${method.name}' carries @$simple ($fqn) but " +
@@ -1318,7 +1326,8 @@ object PreviewDiscovery {
         )
       }
     }
-    if (directPreviews.isEmpty() && resolvedMultiPreviews.isEmpty()) return
+    if (directPreviews.isEmpty() && resolvedMultiPreviews.isEmpty() && builtInSpecs.isEmpty())
+      return
 
     // @PreviewWrapper and @ScrollingPreview are both non-repeatable and apply
     // to every @Preview on the function (including expansions from
@@ -1442,6 +1451,31 @@ object PreviewDiscovery {
           launcherWidgetResizeSpec,
           timings,
           previewParameter,
+          previewSourceFile,
+          inferredTargets,
+        )
+      )
+    }
+
+    // Built-in expansion of known off-classpath multi-preview annotations (issue #2613). Each
+    // synthesised spec runs through the same [buildPreviewInfo] tail as a real `@Preview`, so it
+    // fans out the function's `@ScrollingPreview` / `@AnimatedPreview` / … captures and infers
+    // targets identically.
+    for (spec in builtInSpecs) {
+      previews.add(
+        buildPreviewInfo(
+          classInfo,
+          method,
+          spec.toParams(wrapperFqn, previewParameter),
+          scrollSpecs,
+          animationSpec,
+          focusSpecs,
+          focusGifSpec,
+          ambientSpec,
+          gestureHintSpec,
+          launcherWidgetSpec,
+          launcherWidgetResizeSpec,
+          timings,
           previewSourceFile,
           inferredTargets,
         )
@@ -1590,7 +1624,7 @@ object PreviewDiscovery {
   )
 
   private fun buildOutputPlan(
-    ann: AnnotationInfo,
+    kind: PreviewKind,
     previewId: String,
     scrolls: List<ScrollCapture>,
     animation: AnimationCapture?,
@@ -1602,21 +1636,21 @@ object PreviewDiscovery {
     launcherWidgetResize: LauncherWidgetResizeSpec?,
     timings: List<Long>,
   ): PreviewOutputPlan {
-    val isTile = ann.name == TILE_PREVIEW_FQN
+    val isTile = kind == PreviewKind.TILE
     // Notification previews aren't composable either — no `mainClock`, no scrollables, no focus
     // owner. Treat them the same as tiles for every dimensional fan-out so the single-capture
     // path runs unmodified.
-    val isNotification = ann.name == NOTIFICATION_PREVIEW_FQN
+    val isNotification = kind == PreviewKind.NOTIFICATION
     // Glance preview functions are technically `@Composable`, but they're a closed Glance
     // composition driven by `composeForPreview(...)` rather than the standard Compose machinery.
     // Treat them the same way as tile / notification for fan-out gating — no scroll / animation
     // / focus drive, no `mainClock` tick, the renderer handles the whole materialise + inflate
     // in one shot.
-    val isGlanceAppWidget = ann.name == GLANCE_APPWIDGET_PREVIEW_FQN
+    val isGlanceAppWidget = kind == PreviewKind.GLANCE_APPWIDGET
     // XR subspace previews aren't captured to a single image and have no `mainClock` / scrollable /
     // focus owner here — the `:renderer-xr` task drives the whole recover-and-write in one shot.
     // Gate them out of every dimensional fan-out the same way as tile / notification / glance.
-    val isXrSubspace = ann.name == XR_SUBSPACE_PREVIEW_FQN
+    val isXrSubspace = kind == PreviewKind.XR_SUBSPACE
     // XR subspace previews don't render a PNG through the Robolectric path — the opt-in
     // `composePreviewRenderXr` task writes a `scene.json` (+ one `<panelId>.png` texture per panel)
     // into `renders/<sanitizedId>/`, and the optional `composePreviewCompositeXr` task bakes a
@@ -2456,6 +2490,178 @@ object PreviewDiscovery {
       .distinct()
       .toList()
 
+  /**
+   * A single `@Preview` expansion of a well-known AndroidX / Wear multi-preview annotation, used as
+   * a built-in fallback when the annotation class is off the discovery classpath (issue #2613).
+   * Only the fields these annotations actually vary are modelled.
+   */
+  private data class BuiltInPreviewSpec(
+    val name: String? = null,
+    val group: String? = null,
+    val device: String? = null,
+    val fontScale: Float = 1.0f,
+    val uiMode: Int = 0,
+    val showSystemUi: Boolean = false,
+    val showBackground: Boolean = false,
+    val backgroundColor: Long = 0L,
+  )
+
+  // Every wear `@Preview` sets showBackground / showSystemUi / backgroundColor=0xff000000 and
+  // labels
+  // the variant with `group`, never `name` (verbatim from
+  // androidx.wear.compose:compose-ui-tooling).
+  private fun wearSpec(device: String, group: String, fontScale: Float = 1.0f) =
+    BuiltInPreviewSpec(
+      group = group,
+      device = device,
+      fontScale = fontScale,
+      showSystemUi = true,
+      showBackground = true,
+      backgroundColor = 0xff000000L,
+    )
+
+  /**
+   * Stable, documented `@Preview` expansions of the well-known AndroidX / Wear multi-preview
+   * annotations, transcribed verbatim from the AndroidX sources (wear:
+   * `androidx.wear.compose:compose-ui-tooling`; compose: `androidx.compose.ui:ui-tooling-preview`
+   * `MultiPreviews.kt`). Consulted only when the annotation class is off the discovery classpath —
+   * see [builtInExpansionFor] — so a preview annotated only with e.g. `@WearPreviewLargeRound` in a
+   * `main` source set (its wear tooling wired into `screenshotTest`) still renders instead of
+   * vanishing. `@PreviewDynamicColors` is intentionally absent: its only axis is `wallpaper=`,
+   * which this pipeline doesn't model, so its four variants would render identically — the
+   * off-classpath WARN is more honest than four duplicate PNGs.
+   */
+  private val BUILT_IN_MULTIPREVIEW_EXPANSIONS: Map<String, List<BuiltInPreviewSpec>> =
+    mapOf(
+      "androidx.wear.compose.ui.tooling.preview.WearPreviewLargeRound" to
+        listOf(wearSpec("id:wearos_large_round", "Devices - Large Round")),
+      "androidx.wear.compose.ui.tooling.preview.WearPreviewSmallRound" to
+        listOf(wearSpec("id:wearos_small_round", "Devices - Small Round")),
+      "androidx.wear.compose.ui.tooling.preview.WearPreviewSquare" to
+        listOf(wearSpec("id:wearos_square", "Devices - Small Square")),
+      "androidx.wear.compose.ui.tooling.preview.WearPreviewDevices" to
+        listOf(
+          wearSpec("id:wearos_large_round", "Devices - Large Round"),
+          wearSpec("id:wearos_small_round", "Devices - Small Round"),
+        ),
+      "androidx.wear.compose.ui.tooling.preview.WearPreviewFontScales" to
+        listOf(
+          wearSpec("id:wearos_small_round", "Fonts - Small", 0.94f),
+          wearSpec("id:wearos_small_round", "Fonts - Normal", 1.0f),
+          wearSpec("id:wearos_small_round", "Fonts - Medium", 1.06f),
+          wearSpec("id:wearos_small_round", "Fonts - Large", 1.12f),
+          wearSpec("id:wearos_small_round", "Fonts - Larger", 1.18f),
+          wearSpec("id:wearos_small_round", "Fonts - Largest", 1.24f),
+        ),
+      "androidx.compose.ui.tooling.preview.PreviewLightDark" to
+        listOf(
+          BuiltInPreviewSpec(name = "Light"),
+          // uiMode = UI_MODE_NIGHT_YES (0x20) or UI_MODE_TYPE_NORMAL (0x01) = 0x21
+          BuiltInPreviewSpec(name = "Dark", uiMode = 0x21),
+        ),
+      "androidx.compose.ui.tooling.preview.PreviewFontScale" to
+        listOf(
+          BuiltInPreviewSpec(name = "85%", fontScale = 0.85f),
+          BuiltInPreviewSpec(name = "100%", fontScale = 1.0f),
+          BuiltInPreviewSpec(name = "115%", fontScale = 1.15f),
+          BuiltInPreviewSpec(name = "130%", fontScale = 1.3f),
+          BuiltInPreviewSpec(name = "150%", fontScale = 1.5f),
+          BuiltInPreviewSpec(name = "180%", fontScale = 1.8f),
+          BuiltInPreviewSpec(name = "200%", fontScale = 2.0f),
+        ),
+      "androidx.compose.ui.tooling.preview.PreviewScreenSizes" to
+        listOf(
+          BuiltInPreviewSpec(
+            name = "Phone",
+            device = "spec:width=411dp,height=891dp",
+            showSystemUi = true,
+          ),
+          BuiltInPreviewSpec(
+            name = "Phone - Landscape",
+            device = "spec:width=411dp,height=891dp,orientation=landscape,dpi=420",
+            showSystemUi = true,
+          ),
+          BuiltInPreviewSpec(
+            name = "Unfolded Foldable",
+            device = "spec:width=673dp,height=841dp",
+            showSystemUi = true,
+          ),
+          BuiltInPreviewSpec(
+            name = "Tablet",
+            device = "spec:width=1280dp,height=800dp,dpi=240,orientation=portrait",
+            showSystemUi = true,
+          ),
+          BuiltInPreviewSpec(
+            name = "Tablet - Landscape",
+            device = "spec:width=1280dp,height=800dp,dpi=240",
+            showSystemUi = true,
+          ),
+          BuiltInPreviewSpec(
+            name = "Desktop",
+            device = "spec:width=1920dp,height=1080dp,dpi=160",
+            showSystemUi = true,
+          ),
+        ),
+    )
+
+  /**
+   * The built-in [BuiltInPreviewSpec] expansion for [ann], but ONLY when its annotation class is
+   * off the discovery classpath (`getClassInfo == null`; `isExternalClass` folded in defensively).
+   * An on-classpath copy is resolved from its real `@Preview` definitions by [resolveMultiPreview]
+   * instead, so a project that shadows the annotation keeps its own definition and we never
+   * double-expand.
+   */
+  private fun builtInExpansionFor(
+    ann: AnnotationInfo,
+    scanResult: ScanResult,
+  ): List<BuiltInPreviewSpec> {
+    if (isDirectPreview(ann) || isPreviewContainer(ann)) return emptyList()
+    val specs = BUILT_IN_MULTIPREVIEW_EXPANSIONS[ann.name] ?: return emptyList()
+    val ci = scanResult.getClassInfo(ann.name)
+    return if (ci == null || ci.isExternalClass) specs else emptyList()
+  }
+
+  /**
+   * Builds [PreviewParams] from a built-in spec, resolving the device to concrete dims/density the
+   * same way [extractPreviewParams] does for a real `@Preview`, and threading the function-level
+   * `@PreviewWrapper` / `@PreviewParameter` bindings through.
+   */
+  private fun BuiltInPreviewSpec.toParams(
+    wrapperClassName: String?,
+    previewParameter: Pair<String, Int>?,
+  ): PreviewParams {
+    val effectiveWidth: Int?
+    val effectiveHeight: Int?
+    val effectiveDensity: Float?
+    if (device != null || showSystemUi) {
+      val dims = DeviceDimensions.resolve(device, null, null)
+      effectiveWidth = dims.widthDp
+      effectiveHeight = dims.heightDp
+      effectiveDensity = dims.density
+    } else {
+      effectiveWidth = null
+      effectiveHeight = null
+      effectiveDensity = DeviceDimensions.DEFAULT_DENSITY
+    }
+    return PreviewParams(
+      name = name,
+      device = device,
+      widthDp = effectiveWidth,
+      heightDp = effectiveHeight,
+      density = effectiveDensity,
+      fontScale = fontScale,
+      showSystemUi = showSystemUi,
+      showBackground = showBackground,
+      backgroundColor = backgroundColor,
+      uiMode = uiMode,
+      group = group,
+      wrapperClassName = wrapperClassName,
+      previewParameterProviderClassName = previewParameter?.first,
+      previewParameterLimit = previewParameter?.second ?: Int.MAX_VALUE,
+      kind = PreviewKind.COMPOSE,
+    )
+  }
+
   private fun resolveMultiPreview(
     ann: AnnotationInfo,
     scanResult: ScanResult,
@@ -2495,12 +2701,53 @@ object PreviewDiscovery {
     inferredTargets: Lazy<List<PreviewTarget>>,
   ): PreviewInfo {
     val params = extractPreviewParams(ann, wrapperClassName, previewParameter)
+    return buildPreviewInfo(
+      classInfo,
+      method,
+      params,
+      scrolls,
+      animation,
+      focuses,
+      focusGif,
+      ambient,
+      gestureHint,
+      launcherWidget,
+      launcherWidgetResize,
+      timings,
+      previewSourceFile,
+      inferredTargets,
+    )
+  }
+
+  /**
+   * Assembles a [PreviewInfo] from already-resolved [params] — the shared tail of [makePreview]
+   * (which sources [params] from a real `@Preview` [AnnotationInfo]) and the built-in multi-preview
+   * expansion (which builds [params] from a [BuiltInPreviewSpec] table when the annotation class is
+   * off the discovery classpath — issue #2613). Keeping the id/suffix/output-plan/target assembly
+   * in one place means a synthesised preview fans out captures (scroll/animation/focus/…) and
+   * infers targets identically to a real one.
+   */
+  private fun buildPreviewInfo(
+    classInfo: ClassInfo,
+    method: MethodInfo,
+    params: PreviewParams,
+    scrolls: List<ScrollCapture>,
+    animation: AnimationCapture?,
+    focuses: List<FocusCapture>,
+    focusGif: FocusGifCapture?,
+    ambient: AmbientCapture?,
+    gestureHint: GestureHintCapture?,
+    launcherWidget: LauncherWidgetCapture?,
+    launcherWidgetResize: LauncherWidgetResizeSpec?,
+    timings: List<Long>,
+    previewSourceFile: String?,
+    inferredTargets: Lazy<List<PreviewTarget>>,
+  ): PreviewInfo {
     val fqn = "${classInfo.name}.${method.name}"
-    val suffix = buildVariantSuffix(params)
-    val id = fqn + suffix
+    val id = fqn + buildVariantSuffix(params)
     val outputPlan =
       buildOutputPlan(
-        ann,
+        params.kind,
         id,
         scrolls,
         animation,

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewDiscoveryFailureWarningsTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewDiscoveryFailureWarningsTest.kt
@@ -26,6 +26,20 @@ class PreviewDiscoveryFailureWarningsTest {
 
   @get:Rule val tempDir = TemporaryFolder()
 
+  /** Runs discovery over a single class dir with no dependency jars (`failOnEmpty = false`). */
+  private fun discover(classDir: File): PreviewDiscovery.Outcome =
+    PreviewDiscovery.discover(
+      PreviewDiscovery.Input(
+        classDirs = listOf(classDir),
+        dependencyJars = emptyList(),
+        sourceFiles = emptyList(),
+        moduleName = ":wearApp",
+        variantName = "debug",
+        projectDirectory = classDir,
+        failOnEmpty = false,
+      )
+    )
+
   @Test
   fun `failure path carries per-method skip-reason warnings`() {
     val classDir = tempDir.newFolder("classes")
@@ -153,6 +167,69 @@ class PreviewDiscoveryFailureWarningsTest {
     assertThat(joined).contains("@WearPreviewLargeRound")
     assertThat(joined).contains("com.example.wear.WearPreviewLargeRound")
     assertThat(joined).contains("#2613")
+  }
+
+  @Test
+  fun `a known off-classpath wear device multi-preview is expanded from the built-in table`() {
+    // Issue #2613 follow-up: the reported `@WearPreviewLargeRound` on a `main` method, wear tooling
+    // wired only into screenshotTest so the annotation class is off the discovery classpath. It's a
+    // well-known AndroidX annotation, so discovery expands it from the built-in spec table (one
+    // large-round device variant) instead of dropping it or merely warning.
+    val classDir = tempDir.newFolder("classes")
+    writeMethodWithAnnotationClass(
+      classDir,
+      internalName = "test/SessionDetailsViewKt",
+      methodName = "SessionDetailViewPreview",
+      annotationDescriptor = "Landroidx/wear/compose/ui/tooling/preview/WearPreviewLargeRound;",
+    )
+
+    val outcome = discover(classDir)
+    assertThat(outcome).isInstanceOf(PreviewDiscovery.Outcome.Success::class.java)
+    val success = outcome as PreviewDiscovery.Outcome.Success
+    val previews = success.manifest.previews
+    assertThat(previews).hasSize(1)
+    val preview = previews.single()
+    assertThat(preview.functionName).isEqualTo("SessionDetailViewPreview")
+    assertThat(preview.params.device).isEqualTo("id:wearos_large_round")
+    assertThat(preview.params.group).isEqualTo("Devices - Large Round")
+    // A known, now-expanded annotation must NOT trip the off-classpath warning.
+    assertThat(success.warnings.joinToString("\n")).doesNotContain("WearPreviewLargeRound")
+  }
+
+  @Test
+  fun `a known off-classpath wear font-scale multi-preview fans out to all six variants`() {
+    val classDir = tempDir.newFolder("classes")
+    writeMethodWithAnnotationClass(
+      classDir,
+      internalName = "test/HomeKt",
+      methodName = "HomePreview",
+      annotationDescriptor = "Landroidx/wear/compose/ui/tooling/preview/WearPreviewFontScales;",
+    )
+
+    val success = discover(classDir) as PreviewDiscovery.Outcome.Success
+    val previews = success.manifest.previews
+    assertThat(previews).hasSize(6)
+    assertThat(previews.map { it.params.fontScale })
+      .containsExactly(0.94f, 1.0f, 1.06f, 1.12f, 1.18f, 1.24f)
+    // Every wear font-scale variant renders on the small-round device.
+    assertThat(previews.map { it.params.device }.toSet()).containsExactly("id:wearos_small_round")
+  }
+
+  @Test
+  fun `a known off-classpath compose PreviewFontScale multi-preview fans out to all seven variants`() {
+    val classDir = tempDir.newFolder("classes")
+    writeMethodWithAnnotationClass(
+      classDir,
+      internalName = "test/ScreenKt",
+      methodName = "ScreenPreview",
+      annotationDescriptor = "Landroidx/compose/ui/tooling/preview/PreviewFontScale;",
+    )
+
+    val success = discover(classDir) as PreviewDiscovery.Outcome.Success
+    val previews = success.manifest.previews
+    assertThat(previews).hasSize(7)
+    assertThat(previews.map { it.params.name })
+      .containsExactly("85%", "100%", "115%", "130%", "150%", "180%", "200%")
   }
 
   @Test

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewDiscoveryFailureWarningsTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewDiscoveryFailureWarningsTest.kt
@@ -117,6 +117,45 @@ class PreviewDiscoveryFailureWarningsTest {
   }
 
   @Test
+  fun `an unexpandable preview-family annotation warns instead of vanishing silently`() {
+    // Issue #2613: a method whose only preview annotation is a multi-preview meta-annotation
+    // (`@WearPreviewLargeRound`) whose annotation class is NOT on the discovery classpath — the
+    // classic shape of wear tooling wired only into `screenshotTest`. `resolveMultiPreview` can't
+    // see the `@Preview` inside it (its `getClassInfo` returns null) so the preview used to vanish
+    // with no diagnostic. Discovery must now emit an actionable WARN naming the method +
+    // annotation.
+    val classDir = tempDir.newFolder("classes")
+    writeMethodWithAnnotationClass(
+      classDir,
+      internalName = "test/SessionDetailsViewKt",
+      methodName = "SessionDetailViewPreview",
+      annotationDescriptor = "Lcom/example/wear/WearPreviewLargeRound;",
+    )
+
+    val outcome =
+      PreviewDiscovery.discover(
+        PreviewDiscovery.Input(
+          classDirs = listOf(classDir),
+          dependencyJars = emptyList(),
+          sourceFiles = emptyList(),
+          moduleName = ":wearApp",
+          variantName = "debug",
+          projectDirectory = classDir,
+          failOnEmpty = false,
+        )
+      )
+
+    assertThat(outcome).isInstanceOf(PreviewDiscovery.Outcome.Success::class.java)
+    val success = outcome as PreviewDiscovery.Outcome.Success
+    assertThat(success.manifest.previews).isEmpty()
+    val joined = success.warnings.joinToString("\n")
+    assertThat(joined).contains("test.SessionDetailsViewKt.SessionDetailViewPreview")
+    assertThat(joined).contains("@WearPreviewLargeRound")
+    assertThat(joined).contains("com.example.wear.WearPreviewLargeRound")
+    assertThat(joined).contains("#2613")
+  }
+
+  @Test
   fun `Failure warnings default to empty for source-compatibility`() {
     // Existing callers constructing Failure positionally (reason, diagnostics) must keep
     // working — `warnings` is a new optional field with an empty default.
@@ -151,6 +190,44 @@ class PreviewDiscoveryFailureWarningsTest {
     val av: AnnotationVisitor =
       mv.visitAnnotation("Landroidx/compose/ui/tooling/preview/Preview;", true)
     av.visitEnd()
+    mv.visitCode()
+    mv.visitInsn(Opcodes.RETURN)
+    mv.visitMaxs(0, 0)
+    mv.visitEnd()
+    cw.visitEnd()
+
+    val classFile = File(outDir, "$internalName.class")
+    classFile.parentFile.mkdirs()
+    classFile.writeBytes(cw.toByteArray())
+  }
+
+  /**
+   * Writes a minimal `.class` file with one public static parameterless method carrying
+   * [annotationDescriptor] — an annotation whose own class is deliberately NOT written to [outDir],
+   * so the ClassGraph scan records the annotation on the method (parsed from the method's own
+   * bytecode) but `getClassInfo` for the annotation returns null. Mirrors an app `main` method
+   * tagged with a wear multi-preview annotation whose tooling artifact is absent from the discovery
+   * classpath (issue #2613).
+   */
+  private fun writeMethodWithAnnotationClass(
+    outDir: File,
+    internalName: String,
+    methodName: String,
+    annotationDescriptor: String,
+  ) {
+    val cw = ClassWriter(0)
+    cw.visit(
+      Opcodes.V17,
+      Opcodes.ACC_PUBLIC or Opcodes.ACC_FINAL or Opcodes.ACC_SUPER,
+      internalName,
+      null,
+      "java/lang/Object",
+      null,
+    )
+    val mv = cw.visitMethod(Opcodes.ACC_PUBLIC or Opcodes.ACC_STATIC, methodName, "()V", null, null)
+    // `visible = false` mirrors the wear preview annotations' BINARY retention (they land in
+    // RuntimeInvisibleAnnotations); ClassGraph reads both visible and invisible annotations.
+    mv.visitAnnotation(annotationDescriptor, false).visitEnd()
     mv.visitCode()
     mv.visitInsn(Opcodes.RETURN)
     mv.visitMaxs(0, 0)


### PR DESCRIPTION
## Summary

Fixes #2613 — a preview annotated **only** with a multi-preview annotation whose class isn't on the discovery classpath (reported case: `@WearPreviewLargeRound` in an app's `main` source set, with the wear tooling wired only into `screenshotTest`) was dropped **silently**: no `previews.json` entry, no render, and the only symptom a later strict catalog render failing with `missing renders`.

This PR does two things:

1. **Expands the well-known AndroidX / Wear multi-preview annotations from a built-in spec table** when their annotation class is off the discovery classpath — so those previews actually **render** instead of vanishing.
2. **Warns** for any *other* off-classpath preview-family annotation we don't recognise, so a genuine silent drop is at least visible.

### Root cause
`resolveMultiPreview` walks a meta-annotation's closure for `@Preview`(s) via `scanResult.getClassInfo(ann.name)`. When the defining artifact isn't on the scan classpath, the closure has no reachable `@Preview`, resolution returns empty, and the preview is discarded. Sibling wear annotations (`@WearPreviewFontScales`, `@WearPreviewDevices`) come from an artifact that *is* on `main`, which is why discovery split on the single annotation.

### Built-in expansion
For the annotations below, discovery synthesises the same `@Preview` variants Android Studio / a `screenshotTest` render would produce, transcribed **verbatim from the AndroidX sources**:

| Annotation | Expands to |
|---|---|
| `@WearPreviewLargeRound` / `SmallRound` / `Square` | 1 device variant each (`id:wearos_*`) |
| `@WearPreviewDevices` | large-round + small-round |
| `@WearPreviewFontScales` | 6 font scales (0.94 … 1.24) on small-round |
| `@PreviewLightDark` | Light + Dark (`uiMode` night) |
| `@PreviewFontScale` | 7 font scales (85% … 200%) |
| `@PreviewScreenSizes` | Phone / Phone-Landscape / Foldable / Tablet / Tablet-Landscape / Desktop |

`@PreviewDynamicColors` is intentionally **not** expanded: its only axis is `wallpaper=`, which this pipeline doesn't model, so its four variants would render identically — the off-classpath WARN is more honest than four duplicate PNGs.

Key design points:
- **Fallback only when genuinely off-classpath** (`getClassInfo == null`; the scan doesn't `enableExternalClasses`, so null is returned for a merely-referenced class — never a placeholder). An **on-classpath** copy is still read from its real `@Preview` definitions by `resolveMultiPreview`, so a project that shadows the annotation keeps its own definition and we never double-expand.
- **Synthesised previews run through the same `buildPreviewInfo` / `buildOutputPlan` tail as real ones**, so they fan out the function's `@ScrollingPreview` / `@AnimatedPreview` / … captures and infer targets identically (`buildOutputPlan` now keys on `PreviewKind` rather than the annotation).
- Dimensions/density come from the existing `DeviceDimensions.resolve` — the same path real `@Preview(device=…)` uses.

### Warning (the fallback for unknown annotations)
`discoverFromMethod` emits a per-method WARN — naming the class, method, and annotation, and pointing at the likely cause (annotation in a test-only source set) — for off-classpath preview-family annotations that aren't in the table. Gated on the annotation class being **absent from the scan** (`getClassInfo == null`), so a *reachable* annotation whose name merely contains `Preview` but isn't a multi-preview (a project's own `@PreviewOnly` marker) is **not** flagged — no misleading "classpath" warning on healthy modules (addresses the Codex review).

## Changes
- `PreviewDiscovery`: `BUILT_IN_MULTIPREVIEW_EXPANSIONS` table + `builtInExpansionFor` / `BuiltInPreviewSpec.toParams`; `discoverFromMethod` synthesises + warns; `unexpandablePreviewAnnotationNames` + `NON_EXPANDING_PREVIEW_FQNS`. Refactor: `makePreview` split into `makePreview` (ann → params) + `buildPreviewInfo` (params → info); `buildOutputPlan` takes a `PreviewKind`.
- `PreviewDiscoveryFailureWarningsTest`: warn case for an unknown off-classpath annotation, plus expansion cases for `@WearPreviewLargeRound` (1, device+group), `@WearPreviewFontScales` (6, font scales), `@PreviewFontScale` (7, names). All hand-rolled via ASM with the annotation class deliberately absent.

## Test plan
- `./gradlew -p gradle-plugin :preview-discovery:ktfmtCheck :preview-discovery:test` — green (new + all prior discovery tests).
- Text-only change to discovery plumbing — no new renderable surface of our own (the previews it enables are the consumer's), so no visual evidence applies.

Closes #2613

---
_Generated by [Claude Code](https://claude.ai/code/session_01RvgeNjC6QRepDARnQuKPYJ)_