### PR TITLE
ci(design-artifacts): generic font-staging, section fold-in & two-module validate hooks

### DIFF
--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -203,7 +203,20 @@ jobs:
       # module's @Preview functions BEFORE the (long) render, so a mistyped or
       # renamed name fails here in seconds instead of as a late "missing" entry.
       - name: Validate catalog spec
-        run: node compose-ai-tools/scripts/design-artifacts/validate-catalog-spec.mjs --spec "${{ inputs.spec }}"
+        env:
+          SPEC: ${{ inputs.spec }}
+          MODULE: ${{ inputs.module }}
+          EXTRA_MODULE: ${{ inputs.extra-module }}
+        run: |
+          set -euo pipefail
+          # Gradle path (":app", "a:b") → directory ("app", "a/b").
+          to_dir() { printf '%s' "${1#:}" | tr ':' '/'; }
+          args=(--spec "$SPEC" --module-dir "$(to_dir "$MODULE")")
+          # A catalog whose previews span the primary + one extra module must
+          # resolve names against BOTH, or the extra module's previews read as
+          # "missing" and fail the pre-flight.
+          if [ -n "$EXTRA_MODULE" ]; then args+=(--src "$(to_dir "$EXTRA_MODULE")"); fi
+          node compose-ai-tools/scripts/design-artifacts/validate-catalog-spec.mjs "${args[@]}"
 
       # Stage bundled fallback fonts into fontconfig before any render, so a
       # desktop (Skiko) render resolves glyphs a preview's FontFamily doesn't

--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -92,6 +92,31 @@ on:
         required: false
         type: boolean
         default: false
+      stage-font-globs:
+        description: 'Whitespace-separated repo-relative globs of font files (.ttf/.otf) to stage into fontconfig BEFORE rendering — for a desktop (Skiko) render that must resolve glyphs (CJK/Arabic/…) from a bundled face rather than a system fallback. Empty ⇒ no staging.'
+        required: false
+        type: string
+        default: ''
+      fold-artifact:
+        description: 'Name of an artifact (uploaded by a prior caller job) holding a pre-built render bundle to fold in as its own top-level section AFTER generate — e.g. a re-themed sibling catalog. Empty ⇒ no fold-in. Requires fold-bundle, fold-spec, fold-section.'
+        required: false
+        type: string
+        default: ''
+      fold-bundle:
+        description: 'Path (within the downloaded fold-artifact) to the render bundle .png to build the folded section from.'
+        required: false
+        type: string
+        default: ''
+      fold-spec:
+        description: 'Path to the catalog.spec.json describing the folded bundle (may live under the checked-out compose-ai-tools/, e.g. compose-ai-tools/samples/design-catalog-m3/catalog.spec.json).'
+        required: false
+        type: string
+        default: ''
+      fold-section:
+        description: 'Top-level section/tab name for the folded-in catalog.'
+        required: false
+        type: string
+        default: ''
       commit-user-name:
         description: 'Author/committer name for the generated delivery-branch commit.'
         required: false
@@ -180,6 +205,21 @@ jobs:
       - name: Validate catalog spec
         run: node compose-ai-tools/scripts/design-artifacts/validate-catalog-spec.mjs --spec "${{ inputs.spec }}"
 
+      # Stage bundled fallback fonts into fontconfig before any render, so a
+      # desktop (Skiko) render resolves glyphs a preview's FontFamily doesn't
+      # cover (CJK/Arabic/…) from the staged face instead of a system fallback.
+      - name: Stage fonts for rendering
+        if: ${{ inputs.stage-font-globs != '' }}
+        env:
+          FONT_GLOBS: ${{ inputs.stage-font-globs }}
+        run: |
+          set -euo pipefail
+          command -v fc-cache >/dev/null 2>&1 || { sudo apt-get update && sudo apt-get install -y --no-install-recommends fontconfig; }
+          mkdir -p "$HOME/.local/share/fonts"
+          shopt -s nullglob
+          for g in $FONT_GLOBS; do cp $g "$HOME/.local/share/fonts/"; done
+          fc-cache -f "$HOME/.local/share/fonts" >/dev/null
+
       # CMP desktop (Skiko) links libGL; install Mesa's software GL + a font stack.
       - name: Install desktop (Skiko) render deps
         if: ${{ inputs.desktop-render }}
@@ -222,6 +262,35 @@ jobs:
             --renderer "$(compose-preview --version | head -1)" \
             "${source_args[@]}" \
             "${incomplete[@]}"
+
+      - name: Download section bundle to fold in
+        if: ${{ inputs.fold-artifact != '' }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ inputs.fold-artifact }}
+          path: ${{ github.workspace }}/fold-in
+
+      # Build a catalog from the caller-produced bundle and fold it into out/ as
+      # its own top-level section (e.g. a re-themed sibling system as a tab).
+      - name: Fold in extra section
+        if: ${{ inputs.fold-artifact != '' }}
+        env:
+          FOLD_BUNDLE: ${{ inputs.fold-bundle }}
+          FOLD_SPEC: ${{ inputs.fold-spec }}
+          FOLD_SECTION: ${{ inputs.fold-section }}
+        run: |
+          set -euo pipefail
+          incomplete=()
+          if [ "${{ inputs.allow-incomplete }}" = "true" ]; then incomplete=(--allow-incomplete); fi
+          node compose-ai-tools/scripts/design-artifacts/generate-design-catalog.mjs \
+            --spec "$FOLD_SPEC" \
+            --renders "$GITHUB_WORKSPACE/fold-in/$FOLD_BUNDLE" \
+            --out "$GITHUB_WORKSPACE/out-fold" \
+            "${incomplete[@]}"
+          node compose-ai-tools/scripts/design-artifacts/merge-catalog-section.mjs \
+            --into "$GITHUB_WORKSPACE/out" \
+            --from "$GITHUB_WORKSPACE/out-fold" \
+            --section "$FOLD_SECTION"
 
       - name: Upload catalog bundle
         if: ${{ inputs.upload-out }}

--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -82,6 +82,16 @@ on:
         required: false
         type: boolean
         default: true
+      publish:
+        description: 'Force-push out/ to design-artifacts/<system>. Set false to hand the generated bundle off (via upload-out) to a follow-up job that post-processes it — e.g. folding in an extra re-themed section — before publishing.'
+        required: false
+        type: boolean
+        default: true
+      upload-out:
+        description: 'Upload the generated out/ directory as an artifact (<system>-catalog-out) so a downstream job can download, post-process, and publish it. Independent of `publish`.'
+        required: false
+        type: boolean
+        default: false
       commit-user-name:
         description: 'Author/committer name for the generated delivery-branch commit.'
         required: false
@@ -213,7 +223,16 @@ jobs:
             "${source_args[@]}" \
             "${incomplete[@]}"
 
+      - name: Upload catalog bundle
+        if: ${{ inputs.upload-out }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ inputs.system }}-catalog-out
+          path: ${{ github.workspace }}/out
+          if-no-files-found: error
+
       - name: Publish to design-artifacts/${{ inputs.system }}
+        if: ${{ inputs.publish }}
         env:
           GH_TOKEN: ${{ github.token }}
           SYSTEM: ${{ inputs.system }}

--- a/docs/design/DESIGN_CATALOGS.md
+++ b/docs/design/DESIGN_CATALOGS.md
@@ -109,9 +109,17 @@ jobs:
 ```
 
 Author the spec with `init-catalog-spec` and check it with `validate-catalog-spec`
-(see below) before the first run. Catalog-specific lanes some systems add here —
-compose-m3's re-theme fold-in, a Wasm tier — stay in a bespoke workflow; the
-reusable one covers the common single-module (± one extra module) case.
+(see below) before the first run.
+
+For the two bespoke needs a catalog like MeshCore has, the reusable workflow
+exposes generic hooks rather than forcing a copy: `stage-font-globs` stages
+bundled faces into fontconfig before rendering (so a desktop render resolves
+CJK/Arabic glyphs from the app's fonts), and `fold-artifact` + `fold-bundle` +
+`fold-spec` + `fold-section` fold a **caller-produced** bundle in as its own
+top-level section after generate. A caller runs its bespoke lane (e.g. re-theming
+a sibling catalog) in a prior job that uploads the bundle artifact, then passes it
+to the reusable workflow — so the render/generate/publish stays shared while the
+bespoke step lives in the caller. A Wasm tier still needs a bespoke workflow.
 
 ## Rendering a catalog
 


### PR DESCRIPTION
## Why

#2625 was merged when it contained only the **base** reusable pipeline. Three follow-up commits that I'd pushed to the same branch — the generic escape hatches meshcore-mobile needs to adopt the workflow without regressing — never made it onto `main` (the merged branch was auto-deleted, and the pushes re-created an orphan branch with no open PR). This lands them cleanly off current `main`.

## What (delta on top of the merged base)

- **`publish` + `upload-out`** inputs — let a caller hand the generated bundle off to a follow-up job instead of publishing inline.
- **`stage-font-globs`** — stage bundled faces into fontconfig before rendering, so a desktop (Skiko) render resolves CJK/Arabic glyphs from the app's fonts rather than a system fallback.
- **`fold-artifact` / `fold-bundle` / `fold-spec` / `fold-section`** — after generate, build a catalog from a bundle a *prior caller job* produced and fold it in as its own top-level section (e.g. a re-themed sibling system), then publish.
- **Two-module validate** — when `extra-module` is set, the spec pre-flight resolves preview names against the primary **and** extra module, so a catalog spanning two modules (like MeshCore's `:app` + `:meshcore-components`) doesn't fail on the extra module's previews.
- Docs paragraph in `DESIGN_CATALOGS.md` describing the hooks.

All inputs are inert when empty, so the default caller path is unchanged.

## Verified locally

- YAML validates.
- The two-module validate was run against meshcore-mobile's real spec: `--module-dir app --src meshcore-components → 68 previews, 0 errors`, whereas single-module errored on every `:meshcore-components` preview.

## Relationship to other PRs

Supersedes the orphaned follow-up commits. **meshcore-mobile#257 depends on this** (its `fold-*` / `stage-font-globs` inputs, and the two-module validate, only exist once this is on `main`) — merge this before #257.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JAXuf7aPEKxvN5gYWJAmiQ)_