### PR TITLE
docs(design-catalogs): codify the reference-caller convention for the reusable workflow

### DIFF
--- a/docs/design/DESIGN_CATALOGS.md
+++ b/docs/design/DESIGN_CATALOGS.md
@@ -121,6 +121,22 @@ a sibling catalog) in a prior job that uploads the bundle artifact, then passes 
 to the reusable workflow — so the render/generate/publish stays shared while the
 bespoke step lives in the caller. A Wasm tier still needs a bespoke workflow.
 
+### Convention: the reference caller drives common features
+
+**meshcore-mobile is the reference consumer of the reusable workflow, and it
+drives what "common" means.** When a caller needs a new catalog-pipeline
+capability, the rule is: **add it as a generic input to the reusable workflow and
+consume it from the caller — never fork a bespoke copy of the pipeline.** That is
+how font-staging, section fold-in, two-module validation, and the live-bundle /
+per-preview-split lanes each became reusable inputs after MeshCore first needed
+them. The test for "generic" is whether it's a capability any catalog could want
+(it belongs upstream) versus machinery specific to one repo's internals — a
+**Wasm tier**, a **build-from-source CLI to publish HEAD's renderer**, a
+**release-runtime Maven-Central gate** — which stays in that repo's own workflow.
+The payoff is that every consumer's pipeline can't silently drift from the shared
+one; the cost is one small upstream input per new feature, paid by the caller
+that introduces it.
+
 ## Rendering a catalog
 
 ```sh


### PR DESCRIPTION
## Why

The reusable design-artifacts workflow already follows a clear pattern — meshcore-mobile pioneers a catalog-pipeline feature, it gets generalized into a reusable input, and meshcore consumes it (font-staging, section fold-in, two-module validate, live-bundle/split all landed this way). This writes that rule down so future contributors (human or agent) follow it instead of re-forking a bespoke copy.

## What

A `### Convention: the reference caller drives common features` subsection in `DESIGN_CATALOGS.md`, under the reusable-workflow section:

- **meshcore-mobile is the reference caller** and drives what "common" means.
- New capability → **generic input upstream + consume from the caller; never fork the pipeline.**
- The generic/bespoke test: any-catalog-could-want-it → upstream; one-repo-internals (Wasm tier, build-from-source CLI, release-runtime Maven-Central gate) → stays in that repo's workflow.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JAXuf7aPEKxvN5gYWJAmiQ)_