### PR TITLE
ci(design-artifacts): migrate wear-m3 + remote-m3 to the reusable workflow

### DIFF
--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -88,10 +88,20 @@ on:
         type: boolean
         default: false
       split-per-preview:
-        description: 'After generate, split the carried liveBundle into one addressable bundle per preview under bundle/previews/<id>, for the serve host per-preview live lane. The extra module (if any) is split --view-only (baked, no per-preview re-render classpath). Requires publish-live-bundle.'
+        description: 'After generate, split the render into one addressable bundle per preview under bundle/previews/<id>, for the serve host per-preview live lane. The extra module (if any) is split --view-only (baked, no per-preview re-render classpath). full mode requires publish-live-bundle (see split-mode).'
         required: false
         type: boolean
         default: false
+      split-mode:
+        description: "Per-preview split mode when split-per-preview is set: 'full' (each bundle carries its re-render classpath from the externalised liveBundle — a desktop/live tier; requires publish-live-bundle) or 'view-only' (baked, no classpath, split from the raw render — an Android/baked tier)."
+        required: false
+        type: string
+        default: 'full'
+      cli-source:
+        description: "How to obtain the compose-preview CLI: 'released' installs it via the install action (the default; what external consumers use), or 'build' builds it from the checked-out compose-ai-tools (driver-ref) with ./gradlew :cli:installDist — for compose-ai-tools' own catalogs, which must publish HEAD's renderer output, not a released one."
+        required: false
+        type: string
+        default: 'released'
       publish:
         description: 'Force-push out/ to design-artifacts/<system>. Set false to hand the generated bundle off (via upload-out) to a follow-up job that post-processes it — e.g. folding in an extra re-themed section — before publishing.'
         required: false
@@ -184,6 +194,7 @@ jobs:
       # Install the released compose-preview CLI, pinned to the plugin version when
       # cli-version=catalog so the CLI and the applied plugin stay in lockstep.
       - name: Install compose-preview CLI
+        if: ${{ inputs.cli-source == 'released' }}
         uses: yschimke/compose-ai-tools/.github/actions/install@main
         with:
           version: ${{ inputs.cli-version }}
@@ -200,6 +211,18 @@ jobs:
           ref: ${{ inputs.driver-ref }}
           path: compose-ai-tools
           persist-credentials: false
+
+      # Build the CLI from the compose-ai-tools checkout instead of installing a
+      # release — so compose-ai-tools' own catalogs render against HEAD's renderer.
+      # Its bin/ goes on $GITHUB_PATH, shadowing nothing (the released install step
+      # is skipped for cli-source=build).
+      - name: Build compose-preview CLI from source
+        if: ${{ inputs.cli-source == 'build' }}
+        working-directory: compose-ai-tools
+        run: |
+          set -euo pipefail
+          ./gradlew :cli:installDist --no-daemon
+          echo "$GITHUB_WORKSPACE/compose-ai-tools/cli/build/install/compose-preview/bin" >> "$GITHUB_PATH"
 
       - name: Set up Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -289,18 +312,26 @@ jobs:
             "${live[@]}" \
             "${incomplete[@]}"
 
-      # Split the carried liveBundle into one re-renderable bundle per preview for
-      # the serve host's per-preview live lane. The externalised bundle the generate
-      # step wrote under out/bundle/ (fonts lifted to bundle/res/) is the split
-      # source, so each per-preview bundle inherits the slimmed classpath + shared
-      # font pool. The extra module is split --view-only (baked; no per-preview
-      # re-render classpath on this branch).
+      # Split the render into one addressable bundle per preview for the serve
+      # host's per-preview live lane.
+      #   full      → split the externalised liveBundle the generate step wrote
+      #               under out/bundle/ (fonts lifted to bundle/res/), so each
+      #               per-preview bundle inherits the slimmed classpath + shared
+      #               font pool and serve can re-render it. Needs publish-live-bundle.
+      #   view-only → split the raw render (no live bundle), dropping the classpath
+      #               but keeping the baked image + sidecars — for an Android/baked tier.
+      # The extra module (if any) is always split --view-only.
       - name: Split into per-preview bundles
         if: ${{ inputs.split-per-preview }}
         run: |
           set -euo pipefail
-          compose-preview bundle split "$GITHUB_WORKSPACE/out/bundle/bundle.png" \
-            -o "$GITHUB_WORKSPACE/out/bundle/previews"
+          if [ "${{ inputs.split-mode }}" = "view-only" ]; then
+            compose-preview bundle split "$GITHUB_WORKSPACE/bundle.png" --view-only \
+              -o "$GITHUB_WORKSPACE/out/bundle/previews"
+          else
+            compose-preview bundle split "$GITHUB_WORKSPACE/out/bundle/bundle.png" \
+              -o "$GITHUB_WORKSPACE/out/bundle/previews"
+          fi
           if [ -n "${{ inputs.extra-module }}" ] && [ -f "$GITHUB_WORKSPACE/extra-bundle.png" ]; then
             compose-preview bundle split "$GITHUB_WORKSPACE/extra-bundle.png" --view-only \
               -o "$GITHUB_WORKSPACE/out/bundle/previews"

--- a/.github/workflows/design-artifacts.yml
+++ b/.github/workflows/design-artifacts.yml
@@ -60,22 +60,11 @@ jobs:
             # folds it in (--extra-renders) so the keyboard-focus variant keeps its
             # real ring. Its previews override same-named CMP functions.
             androidExtraModule: 'samples:design-catalog-m3-android'
-          - system: wear-m3
-            module: 'samples:design-catalog-wear-m3'
-            spec: 'samples/design-catalog-wear-m3/catalog.spec.json'
-            # Publish the Android bundle as a `liveBundle` so a serve box that carries
-            # the Android (Robolectric) daemon renders Wear live + per-variant (the SVG
-            # lane in particular — the baked per-slug vector collapses state variants).
-            # No wasm tier (androidx.wear.compose has no wasmJs target), so it's flagged
-            # explicitly rather than piggy-backing on `wasmModule`. Inert until a box with
-            # the Android daemon fronts it (else serve falls back to the baked PNGs).
-            androidLiveBundle: '1'
-          - system: remote-m3
-            module: 'samples:design-catalog-remote-m3'
-            spec: 'samples/design-catalog-remote-m3/catalog.spec.json'
-            # No wasm tier: Remote Compose is an Android-only alpha
-            # (androidx.wear.compose.remote / androidx.compose.remote, compileSdk 37),
-            # with no wasmJs target — same as Wear.
+          # wear-m3 and remote-m3 moved to the `wear-m3` / `remote-m3` jobs below,
+          # which delegate to the reusable workflow. compose-m3 stays here: its Wasm
+          # tier + released-runtime Maven-Central gate are repo-internal machinery
+          # that (per DESIGN_CATALOGS.md's convention) doesn't belong in the shared
+          # consumer workflow.
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -371,3 +360,48 @@ jobs:
           git push --force \
             "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
             "HEAD:refs/heads/design-artifacts/$SYSTEM"
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # wear-m3 / remote-m3 delegate to the shared reusable workflow (same one
+  # external consumers use), building the CLI from source (cli-source: build) so
+  # they still publish HEAD's renderer output. They're Android (Robolectric)
+  # renders with no Wasm tier, so they fit the common pipeline; only their split
+  # lane differs — wear carries a live bundle (full split), remote-m3 is baked
+  # (view-only). See DESIGN_CATALOGS.md's reference-caller convention.
+  # ───────────────────────────────────────────────────────────────────────────
+  wear-m3:
+    name: wear-m3
+    if: ${{ github.repository == 'yschimke/compose-ai-tools' }}
+    permissions:
+      contents: write
+    uses: ./.github/workflows/design-artifacts-reusable.yml
+    with:
+      system: wear-m3
+      spec: samples/design-catalog-wear-m3/catalog.spec.json
+      module: 'samples:design-catalog-wear-m3'
+      cli-source: build
+      # Android Robolectric daemon can re-render Wear, so carry a live bundle and
+      # split it full (each per-preview bundle keeps its re-render classpath).
+      publish-live-bundle: true
+      split-per-preview: true
+      split-mode: full
+    secrets:
+      buildfetch_ro_token: ${{ secrets.BUILDFETCH_COMPOSEAI_GRADLE_REMOTE_CACHE_TOKEN_RO || secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN_RO }}
+
+  remote-m3:
+    name: remote-m3
+    if: ${{ github.repository == 'yschimke/compose-ai-tools' }}
+    permissions:
+      contents: write
+    uses: ./.github/workflows/design-artifacts-reusable.yml
+    with:
+      system: remote-m3
+      spec: samples/design-catalog-remote-m3/catalog.spec.json
+      module: 'samples:design-catalog-remote-m3'
+      cli-source: build
+      # Remote Compose has no runnable desktop daemon on the serve host, so it
+      # stays baked: split view-only (addressable stickers, no re-render classpath).
+      split-per-preview: true
+      split-mode: view-only
+    secrets:
+      buildfetch_ro_token: ${{ secrets.BUILDFETCH_COMPOSEAI_GRADLE_REMOTE_CACHE_TOKEN_RO || secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN_RO }}


### PR DESCRIPTION
## Why

Dogfood the reusable workflow for compose-ai-tools' **own** catalogs, per the reference-caller convention (#2639). If the shared pipeline is good enough for consumers, the repo's own simple catalogs should use it too — and any drift then shows up immediately.

## What

Two new **generic** hooks make an in-repo catalog fit the reusable workflow:
- **`cli-source: build`** — build the CLI from the checked-out compose-ai-tools (`:cli:installDist`) instead of the released install action, so the published catalog reflects **HEAD's renderer** (what the repo's own publish requires). Default stays `released` (consumers unaffected).
- **`split-mode: view-only`** — split the raw render (no live bundle) for a baked Android tier; `full` (default) keeps the re-render classpath from the externalised liveBundle.

**Migrated:** `wear-m3` (Android live bundle → full split) and `remote-m3` (baked → view-only split) now delegate to the reusable workflow.

**Deliberately NOT migrated:** `compose-m3` stays a bespoke job. Its **Wasm tier** + **released-runtime Maven-Central gate** are repo-internal machinery that (per the convention) doesn't belong in the consumer workflow — and its `design-artifacts/compose-m3` branch is what **meshcore's re-theme fetches**, so it's the highest-blast-radius system and I left its job byte-identical (just reduced the matrix to one row).

## Verification limits

- Both workflow YAMLs validate; job graph is `generate` (compose-m3) + `wear-m3` + `remote-m3`.
- **Not runnable in CI here** — `design-artifacts.yml` only fires on schedule/dispatch/release. After merge, dispatch it and confirm `design-artifacts/wear-m3` and `design-artifacts/remote-m3` regenerate correctly (diff against the current branches for parity). compose-m3 is unchanged so its branch should be identical.
- Note: the caller jobs pass the buildfetch RO token as an env-based cache (the reusable workflow doesn't use the `buildfetch-cache` composite action) — worst case wear/remote build colder, not wrong.

## Stack / order

Stacked on **#2636** (`publish-live-bundle` / `split-per-preview` hooks — wear-m3 needs them). Merge order: **#2636 → this**. Rebase onto `main` after #2636 lands. Complements convention doc **#2639**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JAXuf7aPEKxvN5gYWJAmiQ)_