### PR TITLE
fix(resources): keep output/filesystem failures fatal in the resource render

### DIFF
--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/ResourcePreviewRenderTest.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/ResourcePreviewRenderTest.kt
@@ -85,6 +85,9 @@ class ResourcePreviewRenderTest {
       val (renderedHere, missingHere) =
         tallyRenders(
           preview.captures,
+          // Output/filesystem failures (ENOSPC, permissions, uncreatable dir) stay fatal — only
+          // in-memory rasterisation failures are downgraded to missing renders (issue #2589).
+          fatal = ::isOutputFailure,
           onError = { capture, t ->
             System.err.println(
               "compose-preview: failed to rasterise ${preview.id} (${capture.renderOutput}): " +
@@ -714,11 +717,18 @@ class ResourcePreviewRenderTest {
      * Renders each of [items] with [render], returning `(rendered, missing)`. A `false` return is a
      * deliberately-skipped capture (counted missing); a thrown exception is caught, reported via
      * [onError], and also counted missing — so one un-rasterisable resource can't abort the batch
-     * (issue #2589). Pure and side-effect-free apart from [render] / [onError], so the isolation
-     * contract is unit-testable without a Robolectric drawable that actually throws.
+     * (issue #2589).
+     *
+     * [fatal] guards the downgrade: when it returns `true` for a caught throwable, that throwable is
+     * re-thrown so the whole task fails. This keeps genuine output/filesystem failures (a dir that
+     * can't be created, ENOSPC, a write error) hard — only in-memory rasterisation failures should
+     * be swallowed as missing renders. See [isOutputFailure]. Pure and side-effect-free apart from
+     * [render] / [onError] / [fatal], so the isolation contract is unit-testable without a
+     * Robolectric drawable that actually throws.
      */
     fun <T> tallyRenders(
       items: List<T>,
+      fatal: (Throwable) -> Boolean = { false },
       onError: (T, Throwable) -> Unit,
       render: (T) -> Boolean,
     ): Pair<Int, Int> {
@@ -728,11 +738,29 @@ class ResourcePreviewRenderTest {
         try {
           if (render(item)) rendered++ else missing++
         } catch (t: Throwable) {
+          if (fatal(t)) throw t
           onError(item, t)
           missing++
         }
       }
       return rendered to missing
+    }
+
+    /**
+     * `true` when [t] (or anything in its cause chain) is an [java.io.IOException] — i.e. the
+     * renderer got as far as trying to write output and the filesystem failed (missing/uncreatable
+     * dir, ENOSPC, permissions, a path collision). Those must fail the task, not be downgraded to a
+     * missing render (Codex review, PR #2638): rasterising a drawable is in-memory and surfaces as a
+     * `RuntimeException` / `Error`, so this cleanly separates "can't draw this resource" (tolerated)
+     * from "couldn't write the output" (fatal).
+     */
+    fun isOutputFailure(t: Throwable): Boolean {
+      var cur: Throwable? = t
+      while (cur != null) {
+        if (cur is java.io.IOException) return true
+        cur = cur.cause
+      }
+      return false
     }
 
     /**

--- a/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/ResourcePreviewRenderTallyTest.kt
+++ b/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/ResourcePreviewRenderTallyTest.kt
@@ -1,6 +1,8 @@
 package ee.schimke.composeai.renderer
 
+import java.io.IOException
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -50,6 +52,38 @@ class ResourcePreviewRenderTallyTest {
       ResourcePreviewRenderTest.tallyRenders(listOf("x", "y", "z"), onError = { _, _ -> }) { true }
     assertEquals(3, rendered)
     assertEquals(0, missing)
+  }
+
+  @Test
+  fun `a fatal (output) failure is re-thrown, not downgraded to missing`() {
+    // Codex review, PR #2638: an I/O / output failure (ENOSPC, unwritable dir, a failed PNG write)
+    // must still fail the task rather than be swallowed as a missing render — otherwise CI can pass
+    // green under `--missing-renders warn` while the renderer couldn't write its output.
+    val errors = mutableListOf<String>()
+    val boom = IOException("No space left on device")
+    val thrown =
+      assertThrows(IOException::class.java) {
+        ResourcePreviewRenderTest.tallyRenders(
+          listOf("ok", "write-fails"),
+          fatal = ResourcePreviewRenderTest::isOutputFailure,
+          onError = { item, t -> errors.add("$item:${t.message}") },
+        ) { item ->
+          if (item == "write-fails") throw boom else true
+        }
+      }
+    assertEquals(boom, thrown)
+    // A fatal failure propagates immediately — it is NOT routed through onError as a missing render.
+    assertTrue("fatal failures must not be reported as missing", errors.isEmpty())
+  }
+
+  @Test
+  fun `isOutputFailure sees an IOException wrapped in a runtime exception`() {
+    assertTrue(ResourcePreviewRenderTest.isOutputFailure(IOException("boom")))
+    assertTrue(
+      ResourcePreviewRenderTest.isOutputFailure(RuntimeException("wrap", IOException("disk full")))
+    )
+    // A pure rasterisation failure (no IOException anywhere in the chain) is NOT fatal.
+    assertTrue(!ResourcePreviewRenderTest.isOutputFailure(UnsupportedOperationException("no draw")))
   }
 
   @Test


### PR DESCRIPTION
## Summary

Follow-up to #2589 / #2638, addressing a Codex review on that PR that landed after it merged.

The per-capture isolation added in #2638 caught **every** `Throwable` and downgraded it to a missing render. That's correct for an un-rasterisable drawable, but it also swallowed genuine **output/filesystem** failures — an uncreatable output dir, `ENOSPC`, a permissions error, a failed PNG/GIF write. Under `--missing-renders warn|ignore` those became a green exit 0, so CI could pass even though the renderer couldn't write its outputs.

## Fix

Only in-memory rasterisation failures should be tolerated. Rasterising a drawable never touches the filesystem and surfaces as a `RuntimeException` / `Error`; output failures surface as `IOException`. So:

- `tallyRenders` now takes a `fatal: (Throwable) -> Boolean` predicate; when it matches a caught throwable, that throwable is **re-thrown** (the task fails) instead of being counted missing.
- `renderResources` passes `fatal = ::isOutputFailure`, where `isOutputFailure(t)` is `true` when `t` **or anything in its cause chain** is an `IOException`.

Net effect: an un-rasterisable resource is still a warning (issue #2589 stays fixed), but a real "couldn't write the output" failure once again fails the task.

## Changes
- `ResourcePreviewRenderTest`: `tallyRenders` gains the `fatal` predicate + re-throw; new `isOutputFailure` helper; `renderResources` wires `fatal = ::isOutputFailure`.
- `ResourcePreviewRenderTallyTest`: a fatal (`IOException`) render is re-thrown and **not** reported as missing; `isOutputFailure` sees an `IOException` through a wrapping `RuntimeException` and returns `false` for a pure rasterisation failure.

## Test plan
- `./gradlew -p . :renderer-android:ktfmtCheck :renderer-android:testDebugUnitTest --tests "*ResourcePreviewRenderTallyTest*"` — green.
- Text-only change to renderer error-handling; no rendered output changes.

Refs #2589

---
_Generated by [Claude Code](https://claude.ai/code/session_01RvgeNjC6QRepDARnQuKPYJ)_