### PR TITLE
feat(deploy): serve confetti-mobile on the public preview server

### DIFF
--- a/deploy/image/entrypoint.sh
+++ b/deploy/image/entrypoint.sh
@@ -30,7 +30,7 @@ fi
 # The published catalog set is BAKED INTO THE IMAGE (same `:=` + `none` convention
 # as SERVE_TRUST_STORE below), so a bare `docker pull` / Watchtower auto-update
 # self-heals without editing the box's compose. Front-page systems:
-: "${SERVE_CATALOGS:=compose-m3,wear-m3,remote-m3,meshcore-mobile@yschimke/meshcore-mobile,homeassistant-remotecompose@yschimke/homeassistant-remotecompose,confetti-wear@joreilly/Confetti}"
+: "${SERVE_CATALOGS:=compose-m3,wear-m3,remote-m3,meshcore-mobile@yschimke/meshcore-mobile,homeassistant-remotecompose@yschimke/homeassistant-remotecompose,confetti-wear@joreilly/Confetti,confetti-mobile@joreilly/Confetti}"
 [[ "${SERVE_CATALOGS}" != "none" ]] && args+=(--catalogs "${SERVE_CATALOGS}")
 # …and cadence, served UNLISTED from its own repo — reachable at /cadence/ (and ?session=cadence)
 # but kept OFF the front-page index. (meshcore-mobile / homeassistant-remotecompose are LISTED above


### PR DESCRIPTION
## Summary

`preview.coo.ee/confetti-mobile/` returns **404** even though the catalog is generated and published — the Confetti `Design Artifacts` workflow renders `:androidApp` and force-pushes to `design-artifacts/confetti-mobile` (joreilly/Confetti), and that branch is already covered by the baked trust store (`joreilly/Confetti` → `design-artifacts/*`). The only gap is that `confetti-mobile` isn't in the served set.

This adds `confetti-mobile@joreilly/Confetti` to the baked `SERVE_CATALOGS` default in `deploy/image/entrypoint.sh`, next to `confetti-wear`, so a plain image pull front-pages the phone catalog alongside the wear one — no per-box compose edit needed (same `:=` self-heal convention as the rest of the list).

## Verification

- `design-artifacts/confetti-mobile` branch exists (regenerated 2026-07-22, head `0e2c273`) and is trusted by the baked `producers.json` wildcard — no trust-store change required.
- `confetti-wear` is served today from this same default; mobile follows the identical `<system>@<owner>/<repo>` form.
- Deploy note: this is the baked image default, so the running preview host still needs to pull the new image (Watchtower / redeploy) before `/confetti-mobile/` goes live.

## Test plan

- [ ] After image redeploy: `curl -sI https://preview.coo.ee/confetti-mobile/` returns 200 and the system appears on the front-page index.

_Non-visual change (deploy config); no render diff applies._

---
_Generated by [Claude Code](https://claude.ai/code/session_0139VLZEXpg4KASSpjm6mxg9)_