### PR TITLE
fix: keep placeholder Text editable in figma-svg instead of rasterising it

### DIFF
--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgModel.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgModel.kt
@@ -892,6 +892,14 @@ data class FigmaSvgModel(
      * export. Each layout node keeps only its closest text and each text lands on its closest
      * layout node (favouring the tight `Text` leaf over a looser wrapper), so text is neither
      * dropped nor duplicated across nested layers that share bounds.
+     *
+     * The "favour the tight leaf" rule is what the tie-break enforces: a `Text` and a wrapper that
+     * shares its bounds (a slot `Box`, a `fillMaxWidth` parent) match a run equally well, and the
+     * text MUST land on the leaf. If the wrapper wins, the leaf is left text-less — and a leaf that
+     * also carries a `drawWithContent` draw (Wear M3 `Modifier.placeholder` is one) is then treated
+     * as un-vectorisable canvas chrome and rasterised out of the frame, baking its glyphs into an
+     * `<image>` that doubles the `<text>` the wrapper emits (the "text rendered twice" bug). Nodes
+     * are collected with their tree depth so a bounds tie resolves to the deepest (innermost) node.
      */
     private fun assignTextToLayers(
       layoutRoot: LayoutInspectorNode,
@@ -899,14 +907,18 @@ data class FigmaSvgModel(
       density: Float,
       fontScale: Float,
     ): Map<String, FigmaSvgText> {
-      val candidates = mutableListOf<Pair<String, IntArray>>()
-      fun collect(n: LayoutInspectorNode) {
+      val candidates = mutableListOf<Triple<String, IntArray, Int>>()
+      fun collect(n: LayoutInspectorNode, depth: Int) {
         candidates.add(
-          n.nodeId to intArrayOf(n.bounds.left, n.bounds.top, n.bounds.right, n.bounds.bottom)
+          Triple(
+            n.nodeId,
+            intArrayOf(n.bounds.left, n.bounds.top, n.bounds.right, n.bounds.bottom),
+            depth,
+          )
         )
-        n.children.forEach(::collect)
+        n.children.forEach { collect(it, depth + 1) }
       }
-      collect(layoutRoot)
+      collect(layoutRoot, 0)
 
       val textByNodeId = HashMap<String, FigmaSvgText>()
       val bestDistForNode = HashMap<String, Int>()
@@ -917,15 +929,20 @@ data class FigmaSvgModel(
         if (content != null && b != null) {
           var bestId: String? = null
           var bestDist = Int.MAX_VALUE
-          for ((id, lb) in candidates) {
+          var bestDepth = -1
+          for ((id, lb, depth) in candidates) {
             val d0 = abs(lb[0] - b[0])
             val d1 = abs(lb[1] - b[1])
             val d2 = abs(lb[2] - b[2])
             val d3 = abs(lb[3] - b[3])
             if (maxOf(d0, d1, d2, d3) <= BOUNDS_TOLERANCE_PX) {
               val d = d0 + d1 + d2 + d3
-              if (d < bestDist) {
+              // Closest match wins; on an exact tie prefer the DEEPER (innermost) node — the real
+              // `Text` leaf over a wrapper that shares its bounds — so the leaf keeps its editable
+              // text and a `drawWithContent`/placeholder leaf isn't rasterised as canvas chrome.
+              if (d < bestDist || (d == bestDist && depth > bestDepth)) {
                 bestDist = d
+                bestDepth = depth
                 bestId = id
               }
             }

--- a/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgPlaceholderTextTest.kt
+++ b/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgPlaceholderTextTest.kt
@@ -1,0 +1,99 @@
+package ee.schimke.composeai.data.layoutinspector
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Regression for the "text rendered twice" figma-svg bug (Confetti wear `SessionCard`): a `Text`
+ * carrying a `drawWithContent` draw (Wear M3 `Modifier.placeholder`) nested under a wrapper that
+ * shares its bounds (the `TitleCard` title slot, a `fillMaxWidth` parent).
+ *
+ * The semantics run matches the wrapper and the `Text` leaf equally well; it must land on the leaf.
+ * When it landed on the wrapper instead, the (now text-less) `drawWithContent` leaf was treated as
+ * un-vectorisable canvas chrome and cropped out of the frame as an opaque `<image>` — doubling the
+ * `<text>` the wrapper already emitted. The fix: a bounds tie in `assignTextToLayers` resolves to
+ * the deepest (innermost) node, so the leaf keeps its editable text and never rasterises.
+ */
+class FigmaSvgPlaceholderTextTest {
+
+  private fun bounds(l: Int, t: Int, r: Int, b: Int) = LayoutInspectorBounds(l, t, r, b)
+
+  /** A `Text` leaf drawing via `Modifier.placeholder` (⇒ a `drawWithContent` modifier). */
+  private fun placeholderTextLeaf(nodeId: String, l: Int, t: Int, r: Int, b: Int) =
+    LayoutInspectorNode(
+      nodeId = nodeId,
+      component = "Text",
+      bounds = bounds(l, t, r, b),
+      size = LayoutInspectorSize(r - l, b - t),
+      modifiers = listOf(LayoutInspectorModifier(name = "drawWithContent")),
+    )
+
+  /** A pass-through wrapper (a slot `Box` / `fillMaxWidth` parent) sharing the leaf's bounds. */
+  private fun wrapper(nodeId: String, l: Int, t: Int, r: Int, b: Int, child: LayoutInspectorNode) =
+    LayoutInspectorNode(
+      nodeId = nodeId,
+      component = "Box",
+      bounds = bounds(l, t, r, b),
+      size = LayoutInspectorSize(r - l, b - t),
+      children = listOf(child),
+    )
+
+  private fun semanticsText(l: Int, t: Int, r: Int, b: Int, text: String) =
+    ComposeSemanticsNode(nodeId = "sem", boundsInRoot = "$l,$t,$r,$b", text = text)
+
+  private fun model(layout: LayoutInspectorNode, semanticsRoot: ComposeSemanticsNode) =
+    FigmaSvgModel.from(
+      layout = LayoutInspectorPayload(layout),
+      semantics = ComposeSemanticsPayload(semanticsRoot),
+      // Hybrid mode (a frame PNG exists to crop from) — the mode the SessionCard renders in, and
+      // the only mode in which the canvas-draw raster path is even reachable.
+      captureCanvasDraws = true,
+    )
+
+  private fun leafLayer(m: FigmaSvgModel): FigmaSvgLayer {
+    fun find(l: FigmaSvgLayer): FigmaSvgLayer? =
+      if (l.name == "Text" || l.text != null || l.raster != null || l.background != null) l
+      else l.children.firstNotNullOfOrNull(::find)
+    return find(m.root) ?: error("no leaf layer")
+  }
+
+  @Test
+  fun placeholderTextUnderASharedBoundsWrapperStaysEditableTextNotAnImage() {
+    val leaf = placeholderTextLeaf("text-1", 0, 0, 200, 50)
+    val root = wrapper("slot", 0, 0, 200, 50, leaf)
+    val m = model(root, semanticsText(0, 0, 200, 50, "Confetti"))
+
+    assertTrue("the placeholder Text leaf must not rasterise", m.rasterTargets.isEmpty())
+    val layer = leafLayer(m)
+    assertNull("no opaque <image> for a text node", layer.raster)
+    assertNull("no background <image> for a text node", layer.background)
+    assertNotNull("the run lands on the tight Text leaf as editable text", layer.text)
+    assertEquals("Confetti", layer.text!!.content)
+  }
+
+  @Test
+  fun renderedSvgHasTheTextOnceAndNoImage() {
+    val leaf = placeholderTextLeaf("text-1", 0, 0, 200, 50)
+    val root = wrapper("slot", 0, 0, 200, 50, leaf)
+    val svg = FigmaLayeredSvg.render(model(root, semanticsText(0, 0, 200, 50, "Confetti")))
+
+    assertTrue("emitted as vector <text>", svg.contains("<text"))
+    assertTrue("the run is not baked into a raster <image>", !svg.contains("<image"))
+    assertEquals("the string appears exactly once", 1, svg.split(">Confetti<").size - 1)
+  }
+
+  @Test
+  fun aTieResolvesToTheDeeperNodeRegardlessOfSiblingOrder() {
+    // Two wrapper levels share the leaf's bounds; the deepest (the Text leaf) must win the tie.
+    val leaf = placeholderTextLeaf("text-1", 0, 0, 200, 50)
+    val inner = wrapper("inner", 0, 0, 200, 50, leaf)
+    val outer = wrapper("outer", 0, 0, 200, 50, inner)
+    val m = model(outer, semanticsText(0, 0, 200, 50, "Confetti"))
+
+    assertTrue(m.rasterTargets.isEmpty())
+    assertEquals("Confetti", leafLayer(m).text?.content)
+  }
+}


### PR DESCRIPTION
## Summary

In the layered figma-svg export, a `Text` carrying a `drawWithContent` draw — **Wear-M3 `Modifier.placeholder`** is one — nested under a wrapper that shares its bounds (a `TitleCard` title slot, a `fillMaxWidth` parent) was **rendered twice**: once as vector `<text>` on the wrapper, and once as an opaque `<image>` crop of the frame on the (text-less) leaf. The overlapping raster (with the card background baked in) produced the ghosted/seamed text.

Repro: `https://preview.coo.ee/confetti-wear/render/sessioncard__ideal__default__compact.svg?uiMode=dark` (Confetti wear `SessionCard`, whose title/speakers `Text`s use `Modifier.placeholder`).

## Root cause

`FigmaSvgModel.assignTextToLayers` matches each semantics run to the closest-bounds layout node. When a `Text` leaf and a bounds-sharing wrapper matched a run **equally well**, the tie resolved to the *first-collected* node (pre-order ⇒ the outer wrapper) — contradicting the method's own doc ("favouring the tight `Text` leaf over a looser wrapper"). The text landed on the wrapper, so the `drawWithContent` leaf was left text-less; the hybrid canvas-draw path then treated it as un-vectorisable chrome and cropped it out of the frame as an `<image>`. (Room/time `Text`s escape because their bounds don't coincide with any wrapper, so their run already lands on the leaf.)

## Fix

Collect candidates with their tree depth and resolve a bounds tie to the **deepest (innermost)** node, so the run lands on the real `Text` leaf. The leaf keeps its editable `<text>`, and — because it now has assigned text — the canvas-draw raster path no longer fires on it. Genuine imperative chrome (progress track / slider groove: draw-only `Spacer`/`Box` leaves with no text) is unaffected.

## Visual evidence

Chromium render of the actual served card SVG (before) vs. the same SVG with the fix's effect applied (the two rasterised-text `<image>` layers removed, `<text>` retained):

**Before** — each line drawn twice (vector `<text>` under an opaque `<image>`):

![before](https://raw.githubusercontent.com/yschimke/compose-ai-tools/f721330e930798b8954d0c8d22f8b02c9ef0d3af/docs/evidence/svg-placeholder-text/before.png)

**After** — single editable `<text>` per line, no raster:

![after](https://raw.githubusercontent.com/yschimke/compose-ai-tools/f721330e930798b8954d0c8d22f8b02c9ef0d3af/docs/evidence/svg-placeholder-text/after.png)

> The end-to-end Confetti-wear render can't be produced in this sandbox (no Confetti Android build), so the pixels above are Chromium renders of the real served SVG and its fixed form; regenerating the `confetti-wear` bundle / the CI visual-diff bot will show the same delta on the live preview. The images are hosted on the throwaway `agent/svg-placeholder-text-evidence` branch (commit-pinned) so they don't land in `main` on squash-merge.
>
> The heavy pill corners visible in both shots are a **separate** shape/corner-token bug (`rx = height/2`), tracked/fixed independently — not part of this change.

## Test plan

- New `FigmaSvgPlaceholderTextTest` reproduces the scenario (placeholder `Text` leaf under a shared-bounds wrapper, hybrid mode): now **0 raster targets** and the run on the leaf as editable text; also covers a two-level-wrapper tie.
- `./gradlew :data-layoutinspector-core:test :data-layoutinspector-connector:test` — green, including the existing `FigmaSvgModelCanvasDrawTest` (genuine progress-track/slider rasters untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01K71Sb7CDXnUAWB6t5rZ7JV)_