### PR TITLE
fix: don't let a placeholder overlay dictate the figma-svg container corner

### DIFF
--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ModifierTokenResolver.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ModifierTokenResolver.kt
@@ -118,9 +118,11 @@ internal object ModifierTokenResolver {
       // expose `PlaceholderDefaults.shape` (= `ShapeTokens.CornerFull`, a 50% pill) as an
       // inspectable `shape`, and ride on the *caller's* chain outside the component's own Surface
       // shape — so as the first shape-bearing modifier they hijack the container corner and a
-      // placeholdered `TitleCard`/`Button` (modest corner) exports as a full pill (`rx = height/2`).
+      // placeholdered `TitleCard`/`Button` (modest corner) exports as a full pill (`rx =
+      // height/2`).
       // Skip their shape so the real `clip`/`paint`/`background` shape later in the chain wins.
-      val nodeShape = if (isPlaceholderShapeModifier(name, simpleName)) null else shapeOf(mod, elements)
+      val nodeShape =
+        if (isPlaceholderShapeModifier(name, simpleName)) null else shapeOf(mod, elements)
       if (nodeShape != null) {
         if (cornerRadius == null) cornerRadius = nodeShape.cornerRadiusWire(minSidePx, density)
         // A `RoundedCornerShape(<px>f)` has no dp `cornerRadius`; capture its raw-pixel radii so

--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ModifierTokenResolver.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ModifierTokenResolver.kt
@@ -113,7 +113,14 @@ internal object ModifierTokenResolver {
       // Shape comes from any shape-bearing modifier: `background(color, shape)`, `clip(shape)`
       // (which Compose routes through `graphicsLayer`), or `border(..., shape)`. A plain rectangle
       // yields null for both fields and is skipped.
-      val nodeShape = shapeOf(mod, elements)
+      //
+      // NOT a placeholder overlay, though: Wear M3 `Modifier.placeholder`/`placeholderShimmer`
+      // expose `PlaceholderDefaults.shape` (= `ShapeTokens.CornerFull`, a 50% pill) as an
+      // inspectable `shape`, and ride on the *caller's* chain outside the component's own Surface
+      // shape — so as the first shape-bearing modifier they hijack the container corner and a
+      // placeholdered `TitleCard`/`Button` (modest corner) exports as a full pill (`rx = height/2`).
+      // Skip their shape so the real `clip`/`paint`/`background` shape later in the chain wins.
+      val nodeShape = if (isPlaceholderShapeModifier(name, simpleName)) null else shapeOf(mod, elements)
       if (nodeShape != null) {
         if (cornerRadius == null) cornerRadius = nodeShape.cornerRadiusWire(minSidePx, density)
         // A `RoundedCornerShape(<px>f)` has no dp `cornerRadius`; capture its raw-pixel radii so
@@ -458,6 +465,18 @@ internal object ModifierTokenResolver {
     if (start == null && top == null && end == null && bottom == null) return null
     return ComposeSemanticsInsets(start = start, top = top, end = end, bottom = bottom)
   }
+
+  /**
+   * True for the Wear M3 `Modifier.placeholder` / `Modifier.placeholderShimmer` elements. Their
+   * inspectable `shape` is the *placeholder overlay's* shape (`PlaceholderDefaults.shape` =
+   * `ShapeTokens.CornerFull`, a 50% pill), never the container's shape — and because the modifier
+   * rides on the caller's chain ahead of the component's own Surface shape, sourcing the container
+   * corner from it exports a placeholdered `TitleCard`/`Button` as a full pill. Matched by the
+   * inspector `nameFallback` (`placeholder`/`placeholderShimmer`) or the element class name
+   * (`PlaceholderElement`, `PlaceholderShimmerElement`, …).
+   */
+  internal fun isPlaceholderShapeModifier(name: String?, simpleName: String): Boolean =
+    name == "placeholder" || name == "placeholderShimmer" || simpleName.startsWith("Placeholder")
 
   /** The inspector `shape` element, or a reflected `shape` field on the modifier element. */
   private fun shapeOf(mod: Any, elements: Map<String, Any?>): Shape? {

--- a/data/layoutinspector/connector/src/test/kotlin/ee/schimke/composeai/daemon/ModifierTokenResolverPlaceholderShapeTest.kt
+++ b/data/layoutinspector/connector/src/test/kotlin/ee/schimke/composeai/daemon/ModifierTokenResolverPlaceholderShapeTest.kt
@@ -1,0 +1,40 @@
+package ee.schimke.composeai.daemon
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins [ModifierTokenResolver.isPlaceholderShapeModifier], the guard that stops a Wear M3
+ * `Modifier.placeholder`/`placeholderShimmer` from dictating the exported container corner.
+ *
+ * Those modifiers expose `PlaceholderDefaults.shape` (= `ShapeTokens.CornerFull`, a full 50% pill)
+ * as an inspectable `shape` and sit on the caller's chain ahead of the component's own Surface
+ * shape, so without the guard they win as the first shape-bearing modifier and a placeholdered
+ * `TitleCard` (modest corner) exports as a full pill (`rx = height/2`). The container shapes
+ * (`background`/`clip`/`border`) must stay eligible so the real corner is still captured.
+ */
+class ModifierTokenResolverPlaceholderShapeTest {
+
+  @Test
+  fun `placeholder and placeholderShimmer by inspector name are skipped`() {
+    assertTrue(ModifierTokenResolver.isPlaceholderShapeModifier("placeholder", "PlaceholderElement"))
+    assertTrue(
+      ModifierTokenResolver.isPlaceholderShapeModifier("placeholderShimmer", "PlaceholderShimmerElement")
+    )
+  }
+
+  @Test
+  fun `placeholder elements by class name are skipped when inspector name is absent`() {
+    assertTrue(ModifierTokenResolver.isPlaceholderShapeModifier(null, "PlaceholderElement"))
+    assertTrue(ModifierTokenResolver.isPlaceholderShapeModifier(null, "PlaceholderShimmerModifierNodeElement"))
+  }
+
+  @Test
+  fun `real container-shape modifiers stay eligible`() {
+    assertFalse(ModifierTokenResolver.isPlaceholderShapeModifier("background", "BackgroundElement"))
+    assertFalse(ModifierTokenResolver.isPlaceholderShapeModifier("clip", "GraphicsLayerElement"))
+    assertFalse(ModifierTokenResolver.isPlaceholderShapeModifier("border", "BorderModifierElement"))
+    assertFalse(ModifierTokenResolver.isPlaceholderShapeModifier("paint", "PainterElement"))
+  }
+}

--- a/data/layoutinspector/connector/src/test/kotlin/ee/schimke/composeai/daemon/ModifierTokenResolverPlaceholderShapeTest.kt
+++ b/data/layoutinspector/connector/src/test/kotlin/ee/schimke/composeai/daemon/ModifierTokenResolverPlaceholderShapeTest.kt
@@ -18,16 +18,26 @@ class ModifierTokenResolverPlaceholderShapeTest {
 
   @Test
   fun `placeholder and placeholderShimmer by inspector name are skipped`() {
-    assertTrue(ModifierTokenResolver.isPlaceholderShapeModifier("placeholder", "PlaceholderElement"))
     assertTrue(
-      ModifierTokenResolver.isPlaceholderShapeModifier("placeholderShimmer", "PlaceholderShimmerElement")
+      ModifierTokenResolver.isPlaceholderShapeModifier("placeholder", "PlaceholderElement")
+    )
+    assertTrue(
+      ModifierTokenResolver.isPlaceholderShapeModifier(
+        "placeholderShimmer",
+        "PlaceholderShimmerElement",
+      )
     )
   }
 
   @Test
   fun `placeholder elements by class name are skipped when inspector name is absent`() {
     assertTrue(ModifierTokenResolver.isPlaceholderShapeModifier(null, "PlaceholderElement"))
-    assertTrue(ModifierTokenResolver.isPlaceholderShapeModifier(null, "PlaceholderShimmerModifierNodeElement"))
+    assertTrue(
+      ModifierTokenResolver.isPlaceholderShapeModifier(
+        null,
+        "PlaceholderShimmerModifierNodeElement",
+      )
+    )
   }
 
   @Test


### PR DESCRIPTION
## Summary

Second defect from the same Confetti-wear `SessionCard` SVG (`sessioncard__ideal__default__compact`): the card outline exports as a full **pill** — `<rect … rx="131" ry="131">`, where `131 = height/2` — instead of its modest rounded corner. Same placeholder-leakage family as #2644 (the text-rasterisation fix), but a different code path.

## Root cause

Wear-M3 `Modifier.placeholder` / `placeholderShimmer` expose `PlaceholderDefaults.shape` — `ShapeTokens.CornerFull`, a full **50% pill** — as an inspectable `shape`, and they ride on the *caller's* modifier chain (`…fillMaxWidth().placeholderShimmer(…)`) **outside** the component's own Surface shape. In `ModifierTokenResolver`, the container corner is taken from the *first* shape-bearing modifier (`if (cornerRadius == null)`), so the placeholder's `CornerFull` wins over the real `CardDefaults.shape` and a placeholdered `TitleCard`/`Button` exports as a pill (`minSide·0.5 = 131`).

## Fix

Skip `placeholder`/`placeholderShimmer` elements when sourcing the node shape (new `isPlaceholderShapeModifier`), so the real `clip`/`paint`/`background` shape later in the chain wins. Matched by inspector `nameFallback` or element class name. Container shapes (`background`/`clip`/`border`/`paint`) stay eligible.

## Visual evidence

Isolated to the corner (text already clean via #2644); only `rx` differs — pill (131) vs. the reference render's real ~24dp corner (~60px at this density, measured from the live `.png`):

**Before** — `rx = height/2`, full pill:

![before](https://raw.githubusercontent.com/yschimke/compose-ai-tools/bb90288540eb32307fb0e206aa81a5592ae5237d/docs/evidence/svg-card-corner/before.png)

**After** — modest corner matching the render:

![after](https://raw.githubusercontent.com/yschimke/compose-ai-tools/bb90288540eb32307fb0e206aa81a5592ae5237d/docs/evidence/svg-card-corner/after.png)

> The end-to-end Confetti-wear render can't run in this sandbox (no Confetti Android build); the pixels above are Chromium renders of the real served SVG with only `rx` varied, and the ~60px target is measured from the live reference `.png`. Regenerating the `confetti-wear` bundle / the CI visual-diff bot will show the real corner on the live preview. Images hosted on the throwaway `agent/svg-placeholder-text-evidence` branch (commit-pinned) so they don't land in `main`.

## Test plan

- New `ModifierTokenResolverPlaceholderShapeTest` pins `isPlaceholderShapeModifier`: `placeholder`/`placeholderShimmer` (by inspector name and by element class name) are skipped, while `background`/`clip`/`border`/`paint` stay eligible.
- `./gradlew :data-layoutinspector-connector:test` — green (incl. the existing `ModifierTokenResolverShadowTest`).

## Follow-up

Both this and #2644 are point-fixes for placeholder modifiers leaking into the ideal-state export. A proper model for placeholders in the SVG export (and preview overrides to exercise the active placeholder state) is worth a dedicated issue — filing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01K71Sb7CDXnUAWB6t5rZ7JV)_