### PR TITLE
fix(serve): stop the thumbnail crop window overflowing narrow grid cards

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -114,10 +114,12 @@ object ServeWeb {
     .cp-imgwrap { display: flex; align-items: center; justify-content: center; min-height: 88px;
       background: #fff; padding: 12px; }
     .cp-imgwrap img { max-width: 100%; max-height: 240px; height: auto; display: block; }
-    /* A framed thumbnail: a fixed-size clip window (inline width/height = the component box) that
-       crops away a sticker's empty watch canvas. The render <img> inside is absolutely positioned,
-       sized + offset inline so only the component shows. Overrides the fit-to-box rule above. */
-    .cp-crop { position: relative; overflow: hidden; display: block; }
+    /* A framed thumbnail: a clip window whose aspect-ratio is the component box, that crops away a
+       sticker's empty watch canvas. The window's natural width is the box (so it never upscales past
+       1x), but `max-width: 100%` lets it shrink to a narrow grid card instead of overflowing it —
+       the render <img> inside is absolutely positioned and sized + offset in PERCENTAGES of the box,
+       so the whole frame scales as one when the card is narrower than the box. Overrides fit-to-box. */
+    .cp-crop { position: relative; overflow: hidden; display: block; max-width: 100%; }
     .cp-imgwrap .cp-crop img { position: absolute; max-width: none; max-height: none; margin: 0; }
     /* Sticker backing: the preview server shows components on a solid surface by DEFAULT, so a
        transparent sticker reads like a real component instead of washing out. The header's
@@ -1193,10 +1195,31 @@ object ServeWeb {
   ): String {
     val img = "<img$extraImgAttrs alt=\"$alt\" src=\"$src\">"
     if (crop == null) return img
+    // Geometry in PERCENTAGES of the box, not fixed px: the box sizes itself by aspect-ratio and
+    // may
+    // shrink under `max-width: 100%` on a narrow grid card, and the absolutely-positioned render
+    // scales with it (a fixed-px window overflowed the card and clipped wide components). `height`
+    // stays auto (the img keeps the render's aspect); `left` %s resolve against the box width,
+    // `top`
+    // against its aspect-ratio height.
+    val w = cropPct(crop.imgW, crop.boxW)
+    val l = cropPct(crop.left, crop.boxW)
+    val t = cropPct(crop.top, crop.boxH)
     val cropped =
-      "<img$extraImgAttrs alt=\"$alt\" src=\"$src\" " +
-        "style=\"width:${crop.imgW}px;height:${crop.imgH}px;left:${crop.left}px;top:${crop.top}px\">"
-    return "<span class=\"cp-crop\" style=\"width:${crop.boxW}px;height:${crop.boxH}px\">$cropped</span>"
+      "<img$extraImgAttrs alt=\"$alt\" src=\"$src\" style=\"width:${w}%;left:${l}%;top:${t}%\">"
+    return "<span class=\"cp-crop\" style=\"width:${crop.boxW}px;aspect-ratio:${crop.boxW}/${crop.boxH}\">$cropped</span>"
+  }
+
+  /**
+   * A crop dimension as a percentage of its box axis (e.g. `imgW/boxW`), formatted for a CSS
+   * length: up to 4 decimals, locale-independent, trailing zeros trimmed (`0`, `119.5833`,
+   * `-422.9167`). Kept exact enough that the framed component lands on the same pixels the old
+   * fixed-px window did.
+   */
+  private fun cropPct(numerator: Int, denominator: Int): String {
+    val v = numerator * 100.0 / denominator
+    val s = String.format(java.util.Locale.ROOT, "%.4f", v)
+    return if (s.contains('.')) s.trimEnd('0').trimEnd('.') else s
   }
 
   /**

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebThumbCropTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebThumbCropTest.kt
@@ -6,9 +6,10 @@ import kotlin.test.assertTrue
 
 /**
  * Pins the HTML wiring of the server-side thumbnail crop: when a card's [ContentCrop] is present
- * the render `<img>` is wrapped in a fixed-size `.cp-crop` clip window (so a Wear sticker shows the
- * component, not its watch canvas); when absent the card keeps the plain fit-to-box `<img>` — so a
- * phone/desktop catalog and the plain-module landing are untouched.
+ * the render `<img>` is wrapped in a `.cp-crop` clip window sized by aspect-ratio (so a Wear
+ * sticker shows the component, not its watch canvas) and framed in PERCENTAGES so it shrinks with a
+ * narrow grid card instead of overflowing it; when absent the card keeps the plain fit-to-box
+ * `<img>` — so a phone/desktop catalog and the plain-module landing are untouched.
  */
 class ServeWebThumbCropTest {
 
@@ -18,7 +19,7 @@ class ServeWebThumbCropTest {
     ContentCrop(boxW = 120, boxH = 48, imgW = 454, imgH = 454, left = -167, top = -203)
 
   @Test
-  fun `a catalog card with a crop wraps the image in a sized clip window`() {
+  fun `a catalog card with a crop wraps the image in an aspect-sized clip window`() {
     val html =
       ServeWeb.landingPage(
         "wear-m3",
@@ -27,13 +28,17 @@ class ServeWebThumbCropTest {
         basePath = "/wear-m3",
         thumbCrop = { crop },
       )
+    // The window's natural width is the box, but it sizes by aspect-ratio (so `max-width: 100%` can
+    // shrink it on a narrow card) rather than a fixed height.
     assertTrue(
-      html.contains("class=\"cp-crop\" style=\"width:120px;height:48px\""),
-      "clip window sized to the box",
+      html.contains("class=\"cp-crop\" style=\"width:120px;aspect-ratio:120/48\""),
+      "clip window sized to the box by aspect-ratio",
     )
+    // Render img framed in percentages of the box (454/120, -167/120, -203/48), so the whole frame
+    // scales as one when the window shrinks.
     assertTrue(
-      html.contains("style=\"width:454px;height:454px;left:-167px;top:-203px\""),
-      "render img sized + offset to show only the component",
+      html.contains("style=\"width:378.3333%;left:-139.1667%;top:-422.9167%\""),
+      "render img sized + offset in box-percentages to show only the component",
     )
   }
 
@@ -59,7 +64,7 @@ class ServeWebThumbCropTest {
       )
     val html = ServeWeb.homeIndexPage(listOf(system), token = "t", isPublic = true)
     assertTrue(
-      html.contains("class=\"cp-crop\" style=\"width:120px;height:48px\""),
+      html.contains("class=\"cp-crop\" style=\"width:120px;aspect-ratio:120/48\""),
       "hero framed to its box",
     )
   }

--- a/scripts/design-artifacts/render-index-html.mjs
+++ b/scripts/design-artifacts/render-index-html.mjs
@@ -308,7 +308,7 @@ export function renderIndexHtml(catalog, opts = {}) {
      the component instead of floating in an empty frame; a no-op for close-cropped (phone) renders
      where the bbox already fills the frame. */
   .shot--framed { overflow:hidden; padding:0; min-height:0; position:relative; place-items:stretch;
-    margin:16px auto; border-radius:8px; }
+    margin:16px auto; border-radius:8px; max-width:100%; }
   .shot--framed img { position:absolute; max-width:none; max-height:none; }
   .shot--missing { color:var(--muted); font-style:italic; }
   .meta { padding:10px 12px 12px; border-top:1px solid var(--line); }
@@ -380,16 +380,20 @@ ${details}
       if (!(rw > 0 && rh > 0)) return;
       if (box.vw >= rw * 0.9 && box.vh >= rh * 0.9) return; // already close-cropped
       var cap = 240, scale = Math.min(1, cap / Math.max(box.vw, box.vh));
-      var dw = Math.max(1, Math.round(box.vw * scale)), dh = Math.max(1, Math.round(box.vh * scale));
+      var dw = Math.max(1, Math.round(box.vw * scale));
       shot.classList.add("shot--framed");
+      // Size the window by aspect-ratio at its natural (capped) width, with max-width:100% so it
+      // shrinks to a narrow grid card instead of overflowing it; frame the render in PERCENTAGES of
+      // the box so the whole thing scales as one. (A fixed-px window overflowed the card and clipped
+      // wide components.) Height stays auto — the img keeps the render's aspect.
+      var pct = function (n, d) { return +(n / d * 100).toFixed(4); };
       shot.style.width = dw + "px";
-      shot.style.height = dh + "px";
-      img.style.width = Math.round(rw * scale) + "px";
-      img.style.height = Math.round(rh * scale) + "px";
-      // (tx,ty) is negative for a centred component, so tx*scale shifts the render to bring the
-      // component's top-left to the clip origin.
-      img.style.left = Math.round(box.tx * scale) + "px";
-      img.style.top = Math.round(box.ty * scale) + "px";
+      shot.style.aspectRatio = box.vw + " / " + box.vh;
+      img.style.width = pct(rw, box.vw) + "%";
+      // (tx,ty) is negative for a centred component, so it shifts the render to bring the component's
+      // top-left to the clip origin; as a % of the box axis it scales with the shrunk window.
+      img.style.left = pct(box.tx, box.vw) + "%";
+      img.style.top = pct(box.ty, box.vh) + "%";
     }
     if (img.complete) apply();
     else img.addEventListener("load", apply);

--- a/vscode-extension/preview-harness/fixtures/pages/serve-home-index.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-home-index.html
@@ -105,10 +105,12 @@ html.cp-js .cp-section-head { display: none; }
 .cp-imgwrap { display: flex; align-items: center; justify-content: center; min-height: 88px;
   background: #fff; padding: 12px; }
 .cp-imgwrap img { max-width: 100%; max-height: 240px; height: auto; display: block; }
-/* A framed thumbnail: a fixed-size clip window (inline width/height = the component box) that
-   crops away a sticker's empty watch canvas. The render <img> inside is absolutely positioned,
-   sized + offset inline so only the component shows. Overrides the fit-to-box rule above. */
-.cp-crop { position: relative; overflow: hidden; display: block; }
+/* A framed thumbnail: a clip window whose aspect-ratio is the component box, that crops away a
+   sticker's empty watch canvas. The window's natural width is the box (so it never upscales past
+   1x), but `max-width: 100%` lets it shrink to a narrow grid card instead of overflowing it —
+   the render <img> inside is absolutely positioned and sized + offset in PERCENTAGES of the box,
+   so the whole frame scales as one when the card is narrower than the box. Overrides fit-to-box. */
+.cp-crop { position: relative; overflow: hidden; display: block; max-width: 100%; }
 .cp-imgwrap .cp-crop img { position: absolute; max-width: none; max-height: none; margin: 0; }
 /* Sticker backing: the preview server shows components on a solid surface by DEFAULT, so a
    transparent sticker reads like a real component instead of washing out. The header's

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-path.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-path.html
@@ -105,10 +105,12 @@ html.cp-js .cp-section-head { display: none; }
 .cp-imgwrap { display: flex; align-items: center; justify-content: center; min-height: 88px;
   background: #fff; padding: 12px; }
 .cp-imgwrap img { max-width: 100%; max-height: 240px; height: auto; display: block; }
-/* A framed thumbnail: a fixed-size clip window (inline width/height = the component box) that
-   crops away a sticker's empty watch canvas. The render <img> inside is absolutely positioned,
-   sized + offset inline so only the component shows. Overrides the fit-to-box rule above. */
-.cp-crop { position: relative; overflow: hidden; display: block; }
+/* A framed thumbnail: a clip window whose aspect-ratio is the component box, that crops away a
+   sticker's empty watch canvas. The window's natural width is the box (so it never upscales past
+   1x), but `max-width: 100%` lets it shrink to a narrow grid card instead of overflowing it —
+   the render <img> inside is absolutely positioned and sized + offset in PERCENTAGES of the box,
+   so the whole frame scales as one when the card is narrower than the box. Overrides fit-to-box. */
+.cp-crop { position: relative; overflow: hidden; display: block; max-width: 100%; }
 .cp-imgwrap .cp-crop img { position: absolute; max-width: none; max-height: none; margin: 0; }
 /* Sticker backing: the preview server shows components on a solid surface by DEFAULT, so a
    transparent sticker reads like a real component instead of washing out. The header's

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-public.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-public.html
@@ -105,10 +105,12 @@ html.cp-js .cp-section-head { display: none; }
 .cp-imgwrap { display: flex; align-items: center; justify-content: center; min-height: 88px;
   background: #fff; padding: 12px; }
 .cp-imgwrap img { max-width: 100%; max-height: 240px; height: auto; display: block; }
-/* A framed thumbnail: a fixed-size clip window (inline width/height = the component box) that
-   crops away a sticker's empty watch canvas. The render <img> inside is absolutely positioned,
-   sized + offset inline so only the component shows. Overrides the fit-to-box rule above. */
-.cp-crop { position: relative; overflow: hidden; display: block; }
+/* A framed thumbnail: a clip window whose aspect-ratio is the component box, that crops away a
+   sticker's empty watch canvas. The window's natural width is the box (so it never upscales past
+   1x), but `max-width: 100%` lets it shrink to a narrow grid card instead of overflowing it —
+   the render <img> inside is absolutely positioned and sized + offset in PERCENTAGES of the box,
+   so the whole frame scales as one when the card is narrower than the box. Overrides fit-to-box. */
+.cp-crop { position: relative; overflow: hidden; display: block; max-width: 100%; }
 .cp-imgwrap .cp-crop img { position: absolute; max-width: none; max-height: none; margin: 0; }
 /* Sticker backing: the preview server shows components on a solid surface by DEFAULT, so a
    transparent sticker reads like a real component instead of washing out. The header's

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-sections.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-sections.html
@@ -105,10 +105,12 @@ html.cp-js .cp-section-head { display: none; }
 .cp-imgwrap { display: flex; align-items: center; justify-content: center; min-height: 88px;
   background: #fff; padding: 12px; }
 .cp-imgwrap img { max-width: 100%; max-height: 240px; height: auto; display: block; }
-/* A framed thumbnail: a fixed-size clip window (inline width/height = the component box) that
-   crops away a sticker's empty watch canvas. The render <img> inside is absolutely positioned,
-   sized + offset inline so only the component shows. Overrides the fit-to-box rule above. */
-.cp-crop { position: relative; overflow: hidden; display: block; }
+/* A framed thumbnail: a clip window whose aspect-ratio is the component box, that crops away a
+   sticker's empty watch canvas. The window's natural width is the box (so it never upscales past
+   1x), but `max-width: 100%` lets it shrink to a narrow grid card instead of overflowing it —
+   the render <img> inside is absolutely positioned and sized + offset in PERCENTAGES of the box,
+   so the whole frame scales as one when the card is narrower than the box. Overrides fit-to-box. */
+.cp-crop { position: relative; overflow: hidden; display: block; max-width: 100%; }
 .cp-imgwrap .cp-crop img { position: absolute; max-width: none; max-height: none; margin: 0; }
 /* Sticker backing: the preview server shows components on a solid surface by DEFAULT, so a
    transparent sticker reads like a real component instead of washing out. The header's

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-states.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-states.html
@@ -105,10 +105,12 @@ html.cp-js .cp-section-head { display: none; }
 .cp-imgwrap { display: flex; align-items: center; justify-content: center; min-height: 88px;
   background: #fff; padding: 12px; }
 .cp-imgwrap img { max-width: 100%; max-height: 240px; height: auto; display: block; }
-/* A framed thumbnail: a fixed-size clip window (inline width/height = the component box) that
-   crops away a sticker's empty watch canvas. The render <img> inside is absolutely positioned,
-   sized + offset inline so only the component shows. Overrides the fit-to-box rule above. */
-.cp-crop { position: relative; overflow: hidden; display: block; }
+/* A framed thumbnail: a clip window whose aspect-ratio is the component box, that crops away a
+   sticker's empty watch canvas. The window's natural width is the box (so it never upscales past
+   1x), but `max-width: 100%` lets it shrink to a narrow grid card instead of overflowing it —
+   the render <img> inside is absolutely positioned and sized + offset in PERCENTAGES of the box,
+   so the whole frame scales as one when the card is narrower than the box. Overrides fit-to-box. */
+.cp-crop { position: relative; overflow: hidden; display: block; max-width: 100%; }
 .cp-imgwrap .cp-crop img { position: absolute; max-width: none; max-height: none; margin: 0; }
 /* Sticker backing: the preview server shows components on a solid surface by DEFAULT, so a
    transparent sticker reads like a real component instead of washing out. The header's

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-themed.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-themed.html
@@ -105,10 +105,12 @@ html.cp-js .cp-section-head { display: none; }
 .cp-imgwrap { display: flex; align-items: center; justify-content: center; min-height: 88px;
   background: #fff; padding: 12px; }
 .cp-imgwrap img { max-width: 100%; max-height: 240px; height: auto; display: block; }
-/* A framed thumbnail: a fixed-size clip window (inline width/height = the component box) that
-   crops away a sticker's empty watch canvas. The render <img> inside is absolutely positioned,
-   sized + offset inline so only the component shows. Overrides the fit-to-box rule above. */
-.cp-crop { position: relative; overflow: hidden; display: block; }
+/* A framed thumbnail: a clip window whose aspect-ratio is the component box, that crops away a
+   sticker's empty watch canvas. The window's natural width is the box (so it never upscales past
+   1x), but `max-width: 100%` lets it shrink to a narrow grid card instead of overflowing it —
+   the render <img> inside is absolutely positioned and sized + offset in PERCENTAGES of the box,
+   so the whole frame scales as one when the card is narrower than the box. Overrides fit-to-box. */
+.cp-crop { position: relative; overflow: hidden; display: block; max-width: 100%; }
 .cp-imgwrap .cp-crop img { position: absolute; max-width: none; max-height: none; margin: 0; }
 /* Sticker backing: the preview server shows components on a solid surface by DEFAULT, so a
    transparent sticker reads like a real component instead of washing out. The header's

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing.html
@@ -105,10 +105,12 @@ html.cp-js .cp-section-head { display: none; }
 .cp-imgwrap { display: flex; align-items: center; justify-content: center; min-height: 88px;
   background: #fff; padding: 12px; }
 .cp-imgwrap img { max-width: 100%; max-height: 240px; height: auto; display: block; }
-/* A framed thumbnail: a fixed-size clip window (inline width/height = the component box) that
-   crops away a sticker's empty watch canvas. The render <img> inside is absolutely positioned,
-   sized + offset inline so only the component shows. Overrides the fit-to-box rule above. */
-.cp-crop { position: relative; overflow: hidden; display: block; }
+/* A framed thumbnail: a clip window whose aspect-ratio is the component box, that crops away a
+   sticker's empty watch canvas. The window's natural width is the box (so it never upscales past
+   1x), but `max-width: 100%` lets it shrink to a narrow grid card instead of overflowing it —
+   the render <img> inside is absolutely positioned and sized + offset in PERCENTAGES of the box,
+   so the whole frame scales as one when the card is narrower than the box. Overrides fit-to-box. */
+.cp-crop { position: relative; overflow: hidden; display: block; max-width: 100%; }
 .cp-imgwrap .cp-crop img { position: absolute; max-width: none; max-height: none; margin: 0; }
 /* Sticker backing: the preview server shows components on a solid surface by DEFAULT, so a
    transparent sticker reads like a real component instead of washing out. The header's

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
@@ -105,10 +105,12 @@ html.cp-js .cp-section-head { display: none; }
 .cp-imgwrap { display: flex; align-items: center; justify-content: center; min-height: 88px;
   background: #fff; padding: 12px; }
 .cp-imgwrap img { max-width: 100%; max-height: 240px; height: auto; display: block; }
-/* A framed thumbnail: a fixed-size clip window (inline width/height = the component box) that
-   crops away a sticker's empty watch canvas. The render <img> inside is absolutely positioned,
-   sized + offset inline so only the component shows. Overrides the fit-to-box rule above. */
-.cp-crop { position: relative; overflow: hidden; display: block; }
+/* A framed thumbnail: a clip window whose aspect-ratio is the component box, that crops away a
+   sticker's empty watch canvas. The window's natural width is the box (so it never upscales past
+   1x), but `max-width: 100%` lets it shrink to a narrow grid card instead of overflowing it —
+   the render <img> inside is absolutely positioned and sized + offset in PERCENTAGES of the box,
+   so the whole frame scales as one when the card is narrower than the box. Overrides fit-to-box. */
+.cp-crop { position: relative; overflow: hidden; display: block; max-width: 100%; }
 .cp-imgwrap .cp-crop img { position: absolute; max-width: none; max-height: none; margin: 0; }
 /* Sticker backing: the preview server shows components on a solid surface by DEFAULT, so a
    transparent sticker reads like a real component instead of washing out. The header's

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-focus.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-focus.html
@@ -105,10 +105,12 @@ html.cp-js .cp-section-head { display: none; }
 .cp-imgwrap { display: flex; align-items: center; justify-content: center; min-height: 88px;
   background: #fff; padding: 12px; }
 .cp-imgwrap img { max-width: 100%; max-height: 240px; height: auto; display: block; }
-/* A framed thumbnail: a fixed-size clip window (inline width/height = the component box) that
-   crops away a sticker's empty watch canvas. The render <img> inside is absolutely positioned,
-   sized + offset inline so only the component shows. Overrides the fit-to-box rule above. */
-.cp-crop { position: relative; overflow: hidden; display: block; }
+/* A framed thumbnail: a clip window whose aspect-ratio is the component box, that crops away a
+   sticker's empty watch canvas. The window's natural width is the box (so it never upscales past
+   1x), but `max-width: 100%` lets it shrink to a narrow grid card instead of overflowing it —
+   the render <img> inside is absolutely positioned and sized + offset in PERCENTAGES of the box,
+   so the whole frame scales as one when the card is narrower than the box. Overrides fit-to-box. */
+.cp-crop { position: relative; overflow: hidden; display: block; max-width: 100%; }
 .cp-imgwrap .cp-crop img { position: absolute; max-width: none; max-height: none; margin: 0; }
 /* Sticker backing: the preview server shows components on a solid surface by DEFAULT, so a
    transparent sticker reads like a real component instead of washing out. The header's

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-gestures.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-gestures.html
@@ -105,10 +105,12 @@ html.cp-js .cp-section-head { display: none; }
 .cp-imgwrap { display: flex; align-items: center; justify-content: center; min-height: 88px;
   background: #fff; padding: 12px; }
 .cp-imgwrap img { max-width: 100%; max-height: 240px; height: auto; display: block; }
-/* A framed thumbnail: a fixed-size clip window (inline width/height = the component box) that
-   crops away a sticker's empty watch canvas. The render <img> inside is absolutely positioned,
-   sized + offset inline so only the component shows. Overrides the fit-to-box rule above. */
-.cp-crop { position: relative; overflow: hidden; display: block; }
+/* A framed thumbnail: a clip window whose aspect-ratio is the component box, that crops away a
+   sticker's empty watch canvas. The window's natural width is the box (so it never upscales past
+   1x), but `max-width: 100%` lets it shrink to a narrow grid card instead of overflowing it —
+   the render <img> inside is absolutely positioned and sized + offset in PERCENTAGES of the box,
+   so the whole frame scales as one when the card is narrower than the box. Overrides fit-to-box. */
+.cp-crop { position: relative; overflow: hidden; display: block; max-width: 100%; }
 .cp-imgwrap .cp-crop img { position: absolute; max-width: none; max-height: none; margin: 0; }
 /* Sticker backing: the preview server shows components on a solid surface by DEFAULT, so a
    transparent sticker reads like a real component instead of washing out. The header's

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
@@ -105,10 +105,12 @@ html.cp-js .cp-section-head { display: none; }
 .cp-imgwrap { display: flex; align-items: center; justify-content: center; min-height: 88px;
   background: #fff; padding: 12px; }
 .cp-imgwrap img { max-width: 100%; max-height: 240px; height: auto; display: block; }
-/* A framed thumbnail: a fixed-size clip window (inline width/height = the component box) that
-   crops away a sticker's empty watch canvas. The render <img> inside is absolutely positioned,
-   sized + offset inline so only the component shows. Overrides the fit-to-box rule above. */
-.cp-crop { position: relative; overflow: hidden; display: block; }
+/* A framed thumbnail: a clip window whose aspect-ratio is the component box, that crops away a
+   sticker's empty watch canvas. The window's natural width is the box (so it never upscales past
+   1x), but `max-width: 100%` lets it shrink to a narrow grid card instead of overflowing it —
+   the render <img> inside is absolutely positioned and sized + offset in PERCENTAGES of the box,
+   so the whole frame scales as one when the card is narrower than the box. Overrides fit-to-box. */
+.cp-crop { position: relative; overflow: hidden; display: block; max-width: 100%; }
 .cp-imgwrap .cp-crop img { position: absolute; max-width: none; max-height: none; margin: 0; }
 /* Sticker backing: the preview server shows components on a solid surface by DEFAULT, so a
    transparent sticker reads like a real component instead of washing out. The header's

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-states.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-states.html
@@ -105,10 +105,12 @@ html.cp-js .cp-section-head { display: none; }
 .cp-imgwrap { display: flex; align-items: center; justify-content: center; min-height: 88px;
   background: #fff; padding: 12px; }
 .cp-imgwrap img { max-width: 100%; max-height: 240px; height: auto; display: block; }
-/* A framed thumbnail: a fixed-size clip window (inline width/height = the component box) that
-   crops away a sticker's empty watch canvas. The render <img> inside is absolutely positioned,
-   sized + offset inline so only the component shows. Overrides the fit-to-box rule above. */
-.cp-crop { position: relative; overflow: hidden; display: block; }
+/* A framed thumbnail: a clip window whose aspect-ratio is the component box, that crops away a
+   sticker's empty watch canvas. The window's natural width is the box (so it never upscales past
+   1x), but `max-width: 100%` lets it shrink to a narrow grid card instead of overflowing it —
+   the render <img> inside is absolutely positioned and sized + offset in PERCENTAGES of the box,
+   so the whole frame scales as one when the card is narrower than the box. Overrides fit-to-box. */
+.cp-crop { position: relative; overflow: hidden; display: block; max-width: 100%; }
 .cp-imgwrap .cp-crop img { position: absolute; max-width: none; max-height: none; margin: 0; }
 /* Sticker backing: the preview server shows components on a solid surface by DEFAULT, so a
    transparent sticker reads like a real component instead of washing out. The header's

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-themes.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-themes.html
@@ -105,10 +105,12 @@ html.cp-js .cp-section-head { display: none; }
 .cp-imgwrap { display: flex; align-items: center; justify-content: center; min-height: 88px;
   background: #fff; padding: 12px; }
 .cp-imgwrap img { max-width: 100%; max-height: 240px; height: auto; display: block; }
-/* A framed thumbnail: a fixed-size clip window (inline width/height = the component box) that
-   crops away a sticker's empty watch canvas. The render <img> inside is absolutely positioned,
-   sized + offset inline so only the component shows. Overrides the fit-to-box rule above. */
-.cp-crop { position: relative; overflow: hidden; display: block; }
+/* A framed thumbnail: a clip window whose aspect-ratio is the component box, that crops away a
+   sticker's empty watch canvas. The window's natural width is the box (so it never upscales past
+   1x), but `max-width: 100%` lets it shrink to a narrow grid card instead of overflowing it —
+   the render <img> inside is absolutely positioned and sized + offset in PERCENTAGES of the box,
+   so the whole frame scales as one when the card is narrower than the box. Overrides fit-to-box. */
+.cp-crop { position: relative; overflow: hidden; display: block; max-width: 100%; }
 .cp-imgwrap .cp-crop img { position: absolute; max-width: none; max-height: none; margin: 0; }
 /* Sticker backing: the preview server shows components on a solid surface by DEFAULT, so a
    transparent sticker reads like a real component instead of washing out. The header's

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
@@ -105,10 +105,12 @@ html.cp-js .cp-section-head { display: none; }
 .cp-imgwrap { display: flex; align-items: center; justify-content: center; min-height: 88px;
   background: #fff; padding: 12px; }
 .cp-imgwrap img { max-width: 100%; max-height: 240px; height: auto; display: block; }
-/* A framed thumbnail: a fixed-size clip window (inline width/height = the component box) that
-   crops away a sticker's empty watch canvas. The render <img> inside is absolutely positioned,
-   sized + offset inline so only the component shows. Overrides the fit-to-box rule above. */
-.cp-crop { position: relative; overflow: hidden; display: block; }
+/* A framed thumbnail: a clip window whose aspect-ratio is the component box, that crops away a
+   sticker's empty watch canvas. The window's natural width is the box (so it never upscales past
+   1x), but `max-width: 100%` lets it shrink to a narrow grid card instead of overflowing it —
+   the render <img> inside is absolutely positioned and sized + offset in PERCENTAGES of the box,
+   so the whole frame scales as one when the card is narrower than the box. Overrides fit-to-box. */
+.cp-crop { position: relative; overflow: hidden; display: block; max-width: 100%; }
 .cp-imgwrap .cp-crop img { position: absolute; max-width: none; max-height: none; margin: 0; }
 /* Sticker backing: the preview server shows components on a solid surface by DEFAULT, so a
    transparent sticker reads like a real component instead of washing out. The header's

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
@@ -105,10 +105,12 @@ html.cp-js .cp-section-head { display: none; }
 .cp-imgwrap { display: flex; align-items: center; justify-content: center; min-height: 88px;
   background: #fff; padding: 12px; }
 .cp-imgwrap img { max-width: 100%; max-height: 240px; height: auto; display: block; }
-/* A framed thumbnail: a fixed-size clip window (inline width/height = the component box) that
-   crops away a sticker's empty watch canvas. The render <img> inside is absolutely positioned,
-   sized + offset inline so only the component shows. Overrides the fit-to-box rule above. */
-.cp-crop { position: relative; overflow: hidden; display: block; }
+/* A framed thumbnail: a clip window whose aspect-ratio is the component box, that crops away a
+   sticker's empty watch canvas. The window's natural width is the box (so it never upscales past
+   1x), but `max-width: 100%` lets it shrink to a narrow grid card instead of overflowing it —
+   the render <img> inside is absolutely positioned and sized + offset in PERCENTAGES of the box,
+   so the whole frame scales as one when the card is narrower than the box. Overrides fit-to-box. */
+.cp-crop { position: relative; overflow: hidden; display: block; max-width: 100%; }
 .cp-imgwrap .cp-crop img { position: absolute; max-width: none; max-height: none; margin: 0; }
 /* Sticker backing: the preview server shows components on a solid surface by DEFAULT, so a
    transparent sticker reads like a real component instead of washing out. The header's

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
@@ -105,10 +105,12 @@ html.cp-js .cp-section-head { display: none; }
 .cp-imgwrap { display: flex; align-items: center; justify-content: center; min-height: 88px;
   background: #fff; padding: 12px; }
 .cp-imgwrap img { max-width: 100%; max-height: 240px; height: auto; display: block; }
-/* A framed thumbnail: a fixed-size clip window (inline width/height = the component box) that
-   crops away a sticker's empty watch canvas. The render <img> inside is absolutely positioned,
-   sized + offset inline so only the component shows. Overrides the fit-to-box rule above. */
-.cp-crop { position: relative; overflow: hidden; display: block; }
+/* A framed thumbnail: a clip window whose aspect-ratio is the component box, that crops away a
+   sticker's empty watch canvas. The window's natural width is the box (so it never upscales past
+   1x), but `max-width: 100%` lets it shrink to a narrow grid card instead of overflowing it —
+   the render <img> inside is absolutely positioned and sized + offset in PERCENTAGES of the box,
+   so the whole frame scales as one when the card is narrower than the box. Overrides fit-to-box. */
+.cp-crop { position: relative; overflow: hidden; display: block; max-width: 100%; }
 .cp-imgwrap .cp-crop img { position: absolute; max-width: none; max-height: none; margin: 0; }
 /* Sticker backing: the preview server shows components on a solid surface by DEFAULT, so a
    transparent sticker reads like a real component instead of washing out. The header's


### PR DESCRIPTION
## Summary

On the catalog grid, a content-cropped thumbnail (a Wear sticker framed to its component) sized its `.cp-crop` clip window in **fixed pixels** — up to `CAP = 240px` — while the grid cards are `minmax(200px, 1fr)` (140px on the narrow breakpoint). On a narrow card the 240px window overflowed, and since `.cp-card` is `overflow: hidden` its right edge was clipped — cutting off the right of any wide component. This is why the Confetti Wear **speaker chip showed "AI Unicorn Foun…"** on preview.coo.ee: the underlying render was complete, the *tile* was clipping it.

The fix makes the frame **responsive**:
- `.cp-crop` sizes by `aspect-ratio` at its natural (capped) width with `max-width: 100%`, so it shrinks to fit a narrow card instead of overflowing.
- the absolutely-positioned render is sized + offset in **percentages of the box**, so the whole frame scales as one.
- `height` stays `auto` (the img keeps the render's aspect).

At full width it lands on the same pixels as before; uncropped phone/desktop cards are untouched (they carry no `.cp-crop`).

The static gallery (`render-index-html.mjs`, `.shot--framed`) shipped the same fixed-px frame in its `minmax(180px,1fr)` grid, so it gets the identical treatment. The compare view (`render-compare-html.mjs`) is a **table** layout with no narrow-overflow constraint, so it's intentionally left as-is.

## Visual evidence

Verified in headless Chromium (the narrow-card overflow isn't isolated by any committed full-page fixture, so this is the direct repro):

| card | old (fixed px) | new (responsive) |
|---|---|---|
| 200px | pill clipped — "AI Unicorn **Fou…**" | full pill, both rounded ends |
| 150px | — | full pill, scaled down |
| offset crop (box 120×48 @ -167,-203) | — | component framed correctly (proves `left%`/`top%` resolve against the aspect-ratio box) |

## Test plan

- [x] `:cli:test --tests '*ServeWebThumbCropTest*'` — updated to pin the new aspect-ratio + percentage markup.
- [x] `:cli:test --tests '*ServeWebFixtureTest*'` — serve fixture goldens regenerated for the CSS delta (comment + `max-width: 100%`); the crop-less fixtures are visually unchanged.
- [x] `:cli:test --tests '*ServeThumbCropTest*'` — crop math unchanged, still green.
- [x] `node --test render-index-html.test.mjs render-compare-html.test.mjs` — 24/24 pass.
- [x] Headless-Chromium repro above.

_Visual change confined to the framed-thumbnail geometry; no committed fixture exercises a narrow-card crop, so the fixture visual-diff shows only the CSS-text delta. The `ServeWebThumbCropTest` markup assertions are the regression guard._

---
_Generated by [Claude Code](https://claude.ai/code/session_0139VLZEXpg4KASSpjm6mxg9)_