### PR TITLE
feat(resources): record render failures/fallbacks into the bundle and surface them

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ResourceCommands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ResourceCommands.kt
@@ -315,8 +315,12 @@ class ShowResourcesCommand(args: List<String>) : Command(args) {
    * no PNG. Empty when the sidecar is absent (an older renderer) or reports nothing.
    */
   private fun readRenderErrors(module: PreviewModule): Map<String, ResourceRenderError> {
+    // Inside the render task's declared output subtree (`renders/resources`) so up-to-date /
+    // build-cache flows carry it with the PNGs — see the renderer's `writeRenderErrorsSidecar`.
     val sidecar =
-      module.projectDir.resolve("build/compose-previews/$RESOURCE_RENDER_ERRORS_SIDECAR")
+      module.projectDir.resolve(
+        "build/compose-previews/renders/resources/$RESOURCE_RENDER_ERRORS_SIDECAR"
+      )
     if (!sidecar.exists()) return emptyMap()
     return try {
       resourceJson

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ResourceCommands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ResourceCommands.kt
@@ -69,7 +69,31 @@ data class ResourceCaptureResult(
   val sha256: String? = null,
   /** True when sha256 differs from the prior `compose-preview show-resources` run. */
   val changed: Boolean? = null,
+  /**
+   * Why this capture produced no PNG, from the renderer's `resource-render-errors.json` sidecar
+   * (`failed` = the drawable couldn't be rasterised; `skipped` = a known degradation; `not-found` =
+   * the resource id didn't resolve). `null` when the capture rendered. Lets a consumer (the CI
+   * comment, the preview server, VS Code) show *why* a render is missing instead of just that it
+   * is.
+   */
+  val error: String? = null,
+  /** `failed` | `skipped` | `not-found` — the [error]'s category; `null` when [error] is null. */
+  val errorStatus: String? = null,
 )
+
+/** Sidecar the resource renderer writes its per-capture failures/fallbacks into (see renderer). */
+private const val RESOURCE_RENDER_ERRORS_SIDECAR = "resource-render-errors.json"
+
+@Serializable
+private data class ResourceRenderError(
+  val id: String = "",
+  val renderOutput: String = "",
+  val status: String = "",
+  val message: String = "",
+)
+
+@Serializable
+private data class ResourceRenderErrorReport(val entries: List<ResourceRenderError> = emptyList())
 
 @Serializable
 data class ResourcePreviewResult(
@@ -238,10 +262,14 @@ class ShowResourcesCommand(args: List<String>) : Command(args) {
           "${filtered.size} resource preview(s):"
       )
       for (r in missing) {
+        val nullCaptures = r.captures.filter { it.pngPath == null }
         val nullVariants =
-          r.captures
-            .filter { it.pngPath == null }
-            .joinToString(", ") { it.renderOutput.ifBlank { "default" } }
+          nullCaptures
+            .joinToString(", ") { c ->
+              val label = c.renderOutput.ifBlank { "default" }
+              // Append the renderer's reason (from the sidecar) so the log says *why* it's missing.
+              if (c.error != null) "$label (${c.errorStatus ?: "error"}: ${c.error})" else label
+            }
             .ifEmpty { "default" }
         val moduleTag = if (r.module.isNotBlank()) " (${r.module})" else ""
         System.err.println("  - ${r.id}$moduleTag — no PNG for: $nullVariants")
@@ -281,6 +309,27 @@ class ShowResourcesCommand(args: List<String>) : Command(args) {
     return resourceJson.decodeFromString(fileSystem.read(manifestFile.path.toPath()) { readUtf8() })
   }
 
+  /**
+   * Reads the renderer's `resource-render-errors.json` sidecar for [module], returning a
+   * `renderOutput -> error` map so [buildResourceResults] can attach the reason a capture produced
+   * no PNG. Empty when the sidecar is absent (an older renderer) or reports nothing.
+   */
+  private fun readRenderErrors(module: PreviewModule): Map<String, ResourceRenderError> {
+    val sidecar =
+      module.projectDir.resolve("build/compose-previews/$RESOURCE_RENDER_ERRORS_SIDECAR")
+    if (!sidecar.exists()) return emptyMap()
+    return try {
+      resourceJson
+        .decodeFromString<ResourceRenderErrorReport>(
+          fileSystem.read(sidecar.path.toPath()) { readUtf8() }
+        )
+        .entries
+        .associateBy { it.renderOutput }
+    } catch (_: Exception) {
+      emptyMap()
+    }
+  }
+
   private fun readAllResourceManifests(
     modules: List<PreviewModule>
   ): List<Pair<PreviewModule, ResourceManifest>> = modules.mapNotNull { module ->
@@ -294,6 +343,7 @@ class ShowResourcesCommand(args: List<String>) : Command(args) {
     for ((module, manifest) in manifests) {
       val prior = readResourceState(module).shas
       val updated = mutableMapOf<String, String>()
+      val renderErrors = readRenderErrors(module)
 
       for (resource in manifest.resources) {
         val captureResults =
@@ -315,12 +365,17 @@ class ShowResourcesCommand(args: List<String>) : Command(args) {
                 else -> prior[key] != sha
               }
             if (sha != null) updated[key] = sha
+            // Attach the renderer's reason only when the PNG is actually missing — a stale sidecar
+            // entry for a capture that later rendered shouldn't mask a good render.
+            val renderError = if (pngFile == null) renderErrors[capture.renderOutput] else null
             ResourceCaptureResult(
               variant = capture.variant,
               renderOutput = capture.renderOutput,
               pngPath = pngFile?.absolutePath,
               sha256 = sha,
               changed = changed,
+              error = renderError?.message,
+              errorStatus = renderError?.status,
             )
           }
         val first = captureResults.firstOrNull()

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RenderResourceManifest.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RenderResourceManifest.kt
@@ -103,6 +103,14 @@ data class RenderResourceManifest(
 const val RENDER_ERRORS_SIDECAR = "resource-render-errors.json"
 
 /**
+ * Subtree (under the renders output dir) the sidecar is written into — the `resources/` dir the
+ * captures land under, which is the Gradle render task's *declared* output (`renders/resources`).
+ * Keeping the sidecar inside the declared tree is what makes up-to-date / build-cache flows carry it
+ * alongside the PNGs instead of leaving it stale (Codex review, PR #2649).
+ */
+const val RENDER_ERRORS_SIDECAR_SUBTREE = "resources"
+
+/**
  * One capture that did NOT produce a PNG, and why. Written to [RENDER_ERRORS_SIDECAR] in the bundle
  * so the reason survives past the CI log and can be surfaced later (CLI / preview server / VS Code).
  * Keyed by `(id, renderOutput)` so a consumer can line an entry up with the exact missing render.

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RenderResourceManifest.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RenderResourceManifest.kt
@@ -98,3 +98,28 @@ data class RenderResourceManifest(
   val resources: List<RenderResourcePreview> = emptyList(),
   val manifestReferences: List<RenderManifestReference> = emptyList(),
 )
+
+/** Sidecar filename the resource renderer writes its per-capture failures/fallbacks into. */
+const val RENDER_ERRORS_SIDECAR = "resource-render-errors.json"
+
+/**
+ * One capture that did NOT produce a PNG, and why. Written to [RENDER_ERRORS_SIDECAR] in the bundle
+ * so the reason survives past the CI log and can be surfaced later (CLI / preview server / VS Code).
+ * Keyed by `(id, renderOutput)` so a consumer can line an entry up with the exact missing render.
+ *
+ * [status]:
+ * - `failed` — the drawable threw while rasterising (a resource the platform can't draw).
+ * - `skipped` — a known, expected degradation (wrong drawable type, no mask shape, no `<monochrome>`
+ *   layer, …).
+ * - `not-found` — the resource id didn't resolve on the consumer's `R` class.
+ */
+@Serializable
+data class RenderErrorEntry(
+  val id: String,
+  val renderOutput: String,
+  val status: String,
+  val message: String,
+)
+
+/** Envelope for [RENDER_ERRORS_SIDECAR]. An empty [entries] means "ran clean, nothing to report". */
+@Serializable data class RenderErrorReport(val entries: List<RenderErrorEntry> = emptyList())

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/ResourcePreviewRenderTest.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/ResourcePreviewRenderTest.kt
@@ -124,18 +124,21 @@ class ResourcePreviewRenderTest {
   }
 
   /**
-   * Writes the [errors] to `resource-render-errors.json`, next to the `renders/` tree (i.e. in the
-   * `build/compose-previews/` root — [outputRoot] is the `renders/` dir the PNGs are written under).
-   * Always written — an empty `entries` list is a positive "the renderer ran and everything
-   * rendered" signal that consumers can distinguish from "the sidecar is absent because an old
-   * renderer produced it". Keyed by `(id, renderOutput)` so a consumer can correlate an error with
-   * the exact missing PNG. This is the on-disk contract the CLI / preview server / VS Code read to
-   * surface *why* a resource render is missing.
+   * Writes the [errors] to `resource-render-errors.json` **inside** the `renders/resources/` subtree
+   * ([outputRoot] is the `renders/` dir the PNGs are written under; the captures land under
+   * `resources/`). It must live inside the Gradle task's declared output tree
+   * (`resourcesRendersSubtree` = `renders/resources`) — a sidecar in the parent dir would be left
+   * stale or dropped by up-to-date / build-cache flows while the PNG subtree is still considered
+   * valid (Codex review, PR #2649). Always written — an empty `entries` list is a positive "the
+   * renderer ran and everything rendered" signal, distinct from "the sidecar is absent (old
+   * renderer)". Keyed by `(id, renderOutput)` so a consumer can line an error up with the exact
+   * missing PNG. This is the on-disk contract the CLI / preview server / VS Code read to surface
+   * *why* a resource render is missing.
    */
   private fun writeRenderErrorsSidecar(outputRoot: File, errors: List<RenderErrorEntry>) {
-    val root = outputRoot.parentFile ?: outputRoot
-    root.mkdirs()
-    val sidecar = File(root, RENDER_ERRORS_SIDECAR)
+    val dir = File(outputRoot, RENDER_ERRORS_SIDECAR_SUBTREE)
+    dir.mkdirs()
+    val sidecar = File(dir, RENDER_ERRORS_SIDECAR)
     sidecar.writeText(json.encodeToString(RenderErrorReport(entries = errors)))
   }
 

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/ResourcePreviewRenderTest.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/ResourcePreviewRenderTest.kt
@@ -18,6 +18,7 @@ import java.awt.Graphics2D
 import java.awt.image.BufferedImage
 import java.io.File
 import javax.imageio.ImageIO
+import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -63,14 +64,19 @@ class ResourcePreviewRenderTest {
 
     var rendered = 0
     var missing = 0
+    // Every failure / fallback that leaves a capture without a PNG is recorded here and written to a
+    // `resource-render-errors.json` sidecar in the bundle, so the reason survives past the CI log and
+    // can be surfaced later (CLI / preview server / VS Code) rather than being invisible.
+    val errors = mutableListOf<RenderErrorEntry>()
     for (preview in manifest.resources) {
       val (resType, resName) = preview.id.split('/', limit = 2).let { it[0] to it[1] }
       val resId = context.resources.getIdentifier(resName, resType, packageName)
       if (resId == 0) {
-        System.err.println(
-          "compose-preview: resource ${preview.id} not found on the consumer's R class " +
-            "(package=$packageName); skipping ${preview.captures.size} capture(s)"
-        )
+        val reason = "resource not found on the consumer's R class (package=$packageName)"
+        System.err.println("compose-preview: ${preview.id} $reason; skipping")
+        for (capture in preview.captures) {
+          errors += RenderErrorEntry(preview.id, capture.renderOutput, "not-found", reason)
+        }
         missing += preview.captures.size
         continue
       }
@@ -89,29 +95,59 @@ class ResourcePreviewRenderTest {
           // in-memory rasterisation failures are downgraded to missing renders (issue #2589).
           fatal = ::isOutputFailure,
           onError = { capture, t ->
+            val message = "${t.javaClass.simpleName}: ${t.message}"
             System.err.println(
               "compose-preview: failed to rasterise ${preview.id} (${capture.renderOutput}): " +
-                "${t.javaClass.simpleName}: ${t.message}; skipping capture — a renderer limitation " +
-                "(e.g. an adaptive launcher icon or a vector NATIVE graphics can't draw), not a " +
-                "preview error. Surfaced as a missing render (issue #2589)."
+                "$message; skipping capture — a renderer limitation (e.g. an adaptive launcher icon " +
+                "or a vector NATIVE graphics can't draw), not a preview error. Surfaced as a " +
+                "missing render (issue #2589)."
             )
+            errors += RenderErrorEntry(preview.id, capture.renderOutput, "failed", message)
           },
         ) { capture ->
-          renderCapture(context, resId, preview, capture, outputRoot)
+          val skipReason = renderCapture(context, resId, preview, capture, outputRoot)
+          if (skipReason == null) {
+            true
+          } else {
+            System.err.println(
+              "compose-preview: ${preview.id} (${capture.renderOutput}) — skipped: $skipReason"
+            )
+            errors += RenderErrorEntry(preview.id, capture.renderOutput, "skipped", skipReason)
+            false
+          }
         }
       rendered += renderedHere
       missing += missingHere
     }
+    writeRenderErrorsSidecar(outputRoot, errors)
     println("compose-preview resource render: $rendered file(s), $missing capture(s) missing")
   }
 
   /**
-   * Renders one [capture] of [preview] to disk. Returns `true` when a file was written, `false` when
-   * the capture was deliberately skipped for a known reason (a null drawable, a missing mask shape,
-   * a wrong drawable type, an absent `<monochrome>` layer, …). Unexpected failures — a resource the
-   * platform simply can't rasterise under Robolectric — are left to propagate; [renderResources]
-   * catches them per capture and records them as missing renders (issue #2589) rather than aborting
-   * the whole batch.
+   * Writes the [errors] to `resource-render-errors.json`, next to the `renders/` tree (i.e. in the
+   * `build/compose-previews/` root — [outputRoot] is the `renders/` dir the PNGs are written under).
+   * Always written — an empty `entries` list is a positive "the renderer ran and everything
+   * rendered" signal that consumers can distinguish from "the sidecar is absent because an old
+   * renderer produced it". Keyed by `(id, renderOutput)` so a consumer can correlate an error with
+   * the exact missing PNG. This is the on-disk contract the CLI / preview server / VS Code read to
+   * surface *why* a resource render is missing.
+   */
+  private fun writeRenderErrorsSidecar(outputRoot: File, errors: List<RenderErrorEntry>) {
+    val root = outputRoot.parentFile ?: outputRoot
+    root.mkdirs()
+    val sidecar = File(root, RENDER_ERRORS_SIDECAR)
+    sidecar.writeText(json.encodeToString(RenderErrorReport(entries = errors)))
+  }
+
+  /**
+   * Renders one [capture] of [preview] to disk. Returns `null` when a file was written, or a short
+   * human-readable **skip reason** when the capture was deliberately skipped for a known reason (a
+   * null drawable, a missing mask shape, a wrong drawable type, an absent `<monochrome>` layer, …).
+   * The reason is recorded into the bundle's `resource-render-errors.json` sidecar (and logged) so it
+   * can be surfaced later in the CLI / preview server / VS Code, instead of only living in the CI
+   * log. Unexpected failures — a resource the platform simply can't rasterise under Robolectric —
+   * are left to propagate; [renderResources] catches them per capture and records them the same way
+   * (issue #2589) rather than aborting the whole batch.
    */
   private fun renderCapture(
     context: android.content.Context,
@@ -119,19 +155,14 @@ class ResourcePreviewRenderTest {
     preview: RenderResourcePreview,
     capture: RenderResourceCapture,
     outputRoot: File,
-  ): Boolean {
+  ): String? {
     val qualifiers = capture.variant?.qualifiers
     if (!qualifiers.isNullOrEmpty()) {
       RuntimeEnvironment.setQualifiers(qualifiers)
     }
-    val drawable: Drawable = ContextCompat.getDrawable(context, resId)
-        ?: run {
-          System.err.println(
-            "compose-preview: ContextCompat.getDrawable returned null for ${preview.id} " +
-              "at qualifiers=${qualifiers ?: "<default>"}; skipping capture"
-          )
-          return false
-        }
+    val drawable: Drawable =
+      ContextCompat.getDrawable(context, resId)
+        ?: return "getDrawable returned null at qualifiers=${qualifiers ?: "<default>"}"
     val outFile = resolveOutputPath(outputRoot, capture.renderOutput)
     outFile.parentFile?.mkdirs()
 
@@ -148,21 +179,16 @@ class ResourcePreviewRenderTest {
         val shape = capture.variant?.shape
         val style = capture.variant?.style ?: RenderAdaptiveStyle.FULL_COLOR
         if (style != RenderAdaptiveStyle.LEGACY && shape == null) {
-          System.err.println(
-            "compose-preview: adaptive icon ${preview.id} ${style.name} capture has no shape; " +
-              "skipping"
-          )
-          return false
+          return "adaptive-icon ${style.name} capture has no mask shape"
         }
         val adaptive = drawable as? AdaptiveIconDrawable
         if (adaptive == null) {
-          System.err.println(
-            "compose-preview: ${preview.id} resolved as ${drawable.javaClass.simpleName}, " +
-              "not AdaptiveIconDrawable; skipping ${shape?.name ?: style.name} capture"
-          )
-          return false
+          return "resolved as ${drawable.javaClass.simpleName}, not AdaptiveIconDrawable " +
+            "(${shape?.name ?: style.name})"
         }
-        val bitmap = renderAdaptiveIcon(adaptive, shape, style, preview.id) ?: return false
+        val bitmap =
+          renderAdaptiveIcon(adaptive, shape, style, preview.id)
+            ?: return "no <monochrome> layer for ${style.name}"
         try {
           outFile.outputStream().use { bitmap.compress(Bitmap.CompressFormat.PNG, 100, it) }
         } finally {
@@ -172,19 +198,12 @@ class ResourcePreviewRenderTest {
       RenderResourceType.ANIMATED_VECTOR -> {
         val animatable = drawable as? Animatable
         if (animatable == null) {
-          System.err.println(
-            "compose-preview: ${preview.id} resolved as ${drawable.javaClass.simpleName}, " +
-              "not Animatable; skipping animated capture"
-          )
-          return false
+          return "resolved as ${drawable.javaClass.simpleName}, not Animatable"
         }
         if (capture.variant?.filmstrip == true) {
           val fractions = capture.filmstripFractions
           if (fractions.isEmpty()) {
-            System.err.println(
-              "compose-preview: ${preview.id} filmstrip capture has no fractions; skipping"
-            )
-            return false
+            return "filmstrip capture has no fractions"
           }
           renderAnimatedVectorFilmstrip(drawable, animatable, fractions, outFile)
         } else {
@@ -194,11 +213,7 @@ class ResourcePreviewRenderTest {
       RenderResourceType.NINE_PATCH -> {
         val ninePatch = drawable as? NinePatchDrawable
         if (ninePatch == null) {
-          System.err.println(
-            "compose-preview: ${preview.id} resolved as ${drawable.javaClass.simpleName}, " +
-              "not NinePatchDrawable; skipping nine-patch capture"
-          )
-          return false
+          return "resolved as ${drawable.javaClass.simpleName}, not NinePatchDrawable"
         }
         val stretch = capture.variant?.stretch ?: RenderNinePatchStretch.INTRINSIC
         val bitmap = renderNinePatch(ninePatch, stretch)
@@ -209,7 +224,7 @@ class ResourcePreviewRenderTest {
         }
       }
     }
-    return true
+    return null
   }
 
   /**

--- a/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/ResourcePreviewRenderTallyTest.kt
+++ b/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/ResourcePreviewRenderTallyTest.kt
@@ -1,6 +1,8 @@
 package ee.schimke.composeai.renderer
 
 import java.io.IOException
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
@@ -84,6 +86,42 @@ class ResourcePreviewRenderTallyTest {
     )
     // A pure rasterisation failure (no IOException anywhere in the chain) is NOT fatal.
     assertTrue(!ResourcePreviewRenderTest.isOutputFailure(UnsupportedOperationException("no draw")))
+  }
+
+  @Test
+  fun `render-errors sidecar report round-trips through JSON`() {
+    // The sidecar is the on-disk contract the CLI / preview server / VS Code read to surface why a
+    // resource render is missing — pin its shape so a rename/field change is a deliberate break.
+    val report =
+      RenderErrorReport(
+        entries =
+          listOf(
+            RenderErrorEntry(
+              id = "mipmap/ic_launcher",
+              renderOutput = "renders/resources/mipmap/ic_launcher_xhdpi_SHAPE_circle.png",
+              status = "failed",
+              message = "RuntimeException: can't rasterise",
+            ),
+            RenderErrorEntry(
+              id = "drawable/foo",
+              renderOutput = "renders/resources/drawable/foo.png",
+              status = "skipped",
+              message = "no <monochrome> layer for THEMED_LIGHT",
+            ),
+          )
+      )
+    val json = Json { ignoreUnknownKeys = true }
+    val decoded = json.decodeFromString<RenderErrorReport>(json.encodeToString(report))
+    assertEquals(report, decoded)
+    assertEquals("failed", decoded.entries[0].status)
+    assertEquals("mipmap/ic_launcher", decoded.entries[0].id)
+  }
+
+  @Test
+  fun `an empty render-errors report is the clean-run signal`() {
+    val json = Json { ignoreUnknownKeys = true }
+    val decoded = json.decodeFromString<RenderErrorReport>(json.encodeToString(RenderErrorReport()))
+    assertTrue(decoded.entries.isEmpty())
   }
 
   @Test


### PR DESCRIPTION
## Summary

Render failures and fallbacks previously only went to **stderr** in the CI job log — gone the moment you look at the bundle in the preview server or VS Code. That's exactly why "why is this render missing?" was unanswerable without digging through GitHub Actions logs (as happened chasing #2589). This captures the reason **into the bundle** and surfaces it.

## What it does

- The resource renderer (`ResourcePreviewRenderTest`) now records **every capture that produced no PNG** — with a `status` (`failed` / `skipped` / `not-found`) and a `message` — into a **`resource-render-errors.json` sidecar** written next to the renders in the bundle (`build/compose-previews/`). An empty report is the positive "ran clean" signal.
  - `renderCapture` returns the **skip reason** (`String?`) instead of a bare `Boolean`, so "not an `AdaptiveIconDrawable`", "no `<monochrome>` layer", etc. become structured records.
  - The `tallyRenders` catch records the **exception** (the un-rasterisable-resource case from #2589).
  - The `resId == 0` not-found case is recorded per capture too.
- The CLI's `show-resources` **reads the sidecar** and attaches `error` + `errorStatus` to each capture in the `resources.json` envelope — the same envelope the **preview server and VS Code** already consume — and the `--missing-renders` diagnostic now prints the reason next to each missing PNG (`- mipmap/ic_launcher — no PNG for: …_circle.png (failed: RuntimeException: …)`), instead of just "no PNG for".

The error is attached only when the PNG is genuinely absent, so a stale sidecar entry for a capture that later rendered can't mask a good render.

## Scope

This is the **foundation + resource-path surfacing**. The error data now flows end-to-end into the `resources.json` envelope, so the **VS Code badge/hover** and **preview-server display** are fast-follows that render the `error` / `errorStatus` fields (no new capture plumbing needed). Compose-preview (`@Preview`) render failures can get the same treatment as a follow-up.

## Changes
- `RenderResourceManifest.kt`: `RenderErrorEntry` / `RenderErrorReport` models + `RENDER_ERRORS_SIDECAR` constant.
- `ResourcePreviewRenderTest.kt`: `renderCapture` returns a skip reason; `renderResources` collects failures/skips/not-found and writes the sidecar.
- `ResourceCommands.kt` (CLI): read the sidecar; `error` / `errorStatus` on `ResourceCaptureResult`; reason in the missing-renders diagnostic.
- `ResourcePreviewRenderTallyTest.kt`: sidecar report JSON round-trip + empty-is-clean-run tests (contract pinning).

## Test plan
- `./gradlew -p . :renderer-android:ktfmtCheck :renderer-android:testDebugUnitTest --tests "*ResourcePreviewRenderTallyTest*"` — green.
- `./gradlew -p . :cli:ktfmtCheck :cli:test` — green (full CLI suite).
- Text-only change to renderer error-handling + CLI plumbing; no rendered output changes.

Refs #2589

---
_Generated by [Claude Code](https://claude.ai/code/session_01RvgeNjC6QRepDARnQuKPYJ)_