### PR TITLE
refactor(desktop): share AS-parity wrap-measure box + scene sizing across render bodies

### DIFF
--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -1,7 +1,5 @@
 package ee.schimke.composeai.daemon
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.MaterialTheme
@@ -25,7 +23,6 @@ import androidx.compose.ui.ImageComposeScene
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.SystemTheme
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.layout.layout
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.semantics.SemanticsNode
@@ -323,14 +320,28 @@ class RenderEngine(
     // scene before the intrinsic-size crop runs. Only widen (never shrink) the scene here — the
     // crop still trims the PNG back to the measured intrinsic size.
     val sizeOverrides = spec.overrides
-    val sceneWidthPx =
-      if (spec.wrapWidth)
-        maxOf(spec.widthPx, sizeOverrides?.minWidthPx ?: 0, sizeOverrides?.maxWidthPx ?: 0)
-      else spec.widthPx
-    val sceneHeightPx =
-      if (spec.wrapHeight)
-        maxOf(spec.heightPx, sizeOverrides?.minHeightPx ?: 0, sizeOverrides?.maxHeightPx ?: 0)
-      else spec.heightPx
+    // Scene sizing + the AS-parity wrap-measure box are shared with the one-shot
+    // `:renderer-desktop`
+    // fork via [ee.schimke.composeai.renderer.composePreviewSceneSize] /
+    // [ee.schimke.composeai.renderer.ComposePreviewContentBox], so a `compose-preview serve` render
+    // and a batch bundle re-render size the same preview identically.
+    val sizeBounds =
+      ee.schimke.composeai.renderer.PreviewSizeBounds(
+        minWidthPx = sizeOverrides?.minWidthPx,
+        minHeightPx = sizeOverrides?.minHeightPx,
+        maxWidthPx = sizeOverrides?.maxWidthPx,
+        maxHeightPx = sizeOverrides?.maxHeightPx,
+      )
+    val sceneSize =
+      ee.schimke.composeai.renderer.composePreviewSceneSize(
+        widthPx = spec.widthPx,
+        heightPx = spec.heightPx,
+        wrapWidth = spec.wrapWidth,
+        wrapHeight = spec.wrapHeight,
+        sizeBounds = sizeBounds,
+      )
+    val sceneWidthPx = sceneSize.width
+    val sceneHeightPx = sceneSize.height
     val scene =
       try {
         ImageComposeScene(width = sceneWidthPx, height = sceneHeightPx, density = density)
@@ -399,67 +410,22 @@ class RenderEngine(
                   spec.showBackground -> Color.White
                   else -> Color.Transparent
                 }
-              // AS-parity wrap: on a wrapped axis, measure the composable with a relaxed (min = 0)
-              // constraint against the sandbox max and size the box to the child's intrinsic size,
-              // so the captured tree (and the figma-svg / wireframe / semantics derived from it)
-              // reflects the preview's natural size instead of a fixed frame that clips or reflows
-              // wide content. `.background` paints on that intrinsic box so the sticker's backdrop
-              // is
-              // content-sized, not sandbox-sized. Fixed axes keep the sandbox constraint so
-              // `fillMax*` / LazyColumn still have a finite viewport (mirrors DesktopRendererMain).
-              val boxModifier =
-                if (spec.wrapWidth || spec.wrapHeight) {
-                  Modifier.layout { measurable, constraints ->
-                      // Size-mode bounds (Max / Min / Within) clamp the wrapped-axis measure: a max
-                      // bound lowers the sandbox ceiling so the composable can't grow past it; a
-                      // min
-                      // bound raises the floor so it can't collapse below it. Both are clamped to
-                      // the
-                      // scene's available space so a bound larger than the (already-enlarged) scene
-                      // can't produce an impossible constraint. Absent bounds keep the AS-parity
-                      // wrap
-                      // behaviour (min = 0, max = sandbox).
-                      val maxWBound =
-                        sizeOverrides?.maxWidthPx?.coerceAtMost(constraints.maxWidth)
-                          ?: constraints.maxWidth
-                      val maxHBound =
-                        sizeOverrides?.maxHeightPx?.coerceAtMost(constraints.maxHeight)
-                          ?: constraints.maxHeight
-                      val minWBound = (sizeOverrides?.minWidthPx ?: 0).coerceIn(0, maxWBound)
-                      val minHBound = (sizeOverrides?.minHeightPx ?: 0).coerceIn(0, maxHBound)
-                      val wrapped =
-                        androidx.compose.ui.unit.Constraints(
-                          minWidth = if (spec.wrapWidth) minWBound else constraints.minWidth,
-                          maxWidth = if (spec.wrapWidth) maxWBound else constraints.maxWidth,
-                          minHeight = if (spec.wrapHeight) minHBound else constraints.minHeight,
-                          maxHeight = if (spec.wrapHeight) maxHBound else constraints.maxHeight,
-                        )
-                      val placeable = measurable.measure(wrapped)
-                      // Record the intrinsic size so renderOnce can crop the PNG to it on wrapped
-                      // axes — otherwise a no-size preview's frame is the whole sandbox with
-                      // content
-                      // in the corner, not the natural-size capture (matches DesktopRendererMain).
-                      measuredContent[0] = placeable.width
-                      measuredContent[1] = placeable.height
-                      layout(placeable.width, placeable.height) { placeable.place(0, 0) }
-                    }
-                    .background(bgColor)
-                } else {
-                  Modifier.fillMaxSize().background(bgColor)
-                }
-              // On a wrapped axis, `propagateMinConstraints = true` pushes the wrapped-axis *min*
-              // bound (the Min / Within size modes) down onto the composable itself, not just the
-              // wrapping box — with the default (false) the outer box grows to the min bound but
-              // relaxes the child's min to 0, so a wrap-content component (a Button, a badge) stays
-              // at its intrinsic size in the corner of an enlarged frame instead of filling the
-              // requested size. Scoped to wrapped renders only: the fixed-frame branch above is
-              // `fillMaxSize`, whose tight min would otherwise be forwarded into the root
-              // composable
-              // and stretch wrap-content content that must stay small in an explicitly-sized frame
-              // (RenderEngineWrapContentTest's wrap-off case). Mirrors DesktopRendererMain.
-              Box(
-                modifier = boxModifier,
-                propagateMinConstraints = spec.wrapWidth || spec.wrapHeight,
+              // The AS-parity wrap-measure box (and its fixed-axis `fillMaxSize` counterpart) is
+              // shared with the one-shot `:renderer-desktop` fork via [ComposePreviewContentBox],
+              // so
+              // both size the preview and capture its intrinsic bounds identically.
+              // `measuredContent`
+              // is written only on a wrapped axis, then read by [renderOnce] to crop the PNG to the
+              // composable's natural size instead of the whole sandbox.
+              ee.schimke.composeai.renderer.ComposePreviewContentBox(
+                wrapWidth = spec.wrapWidth,
+                wrapHeight = spec.wrapHeight,
+                backgroundColor = bgColor,
+                sizeBounds = sizeBounds,
+                onMeasured = { w, h ->
+                  measuredContent[0] = w
+                  measuredContent[1] = h
+                },
               ) {
                 ComposeDataExtensionPipeline.Apply(
                   extensions = previewOverrideExtensions.plan(spec.overrides),

--- a/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/ComposePreviewScene.kt
+++ b/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/ComposePreviewScene.kt
@@ -1,0 +1,117 @@
+package ee.schimke.composeai.renderer
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.layout
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.IntSize
+
+/**
+ * Content-size bounds for the wrapped axes — the Max / Min / Within size modes. Only consulted on
+ * an axis that wraps; a `null` on either end keeps the Android-Studio-parity wrap (min = 0, max =
+ * sandbox). A max bound lowers the wrap ceiling, a min bound raises the floor.
+ *
+ * The two desktop render bodies (the daemon [ee.schimke.composeai.daemon] `RenderEngine` and the
+ * one-shot [DesktopRendererMain] fork) both feed these into [composePreviewSceneSize] and
+ * [ComposePreviewContentBox], so a batch bundle re-render and a `compose-preview serve` render size
+ * the same preview identically.
+ */
+data class PreviewSizeBounds(
+  val minWidthPx: Int? = null,
+  val minHeightPx: Int? = null,
+  val maxWidthPx: Int? = null,
+  val maxHeightPx: Int? = null,
+)
+
+/**
+ * The [ImageComposeScene][androidx.compose.ui.ImageComposeScene] pixel dimensions for a preview
+ * render. Fixed axes use the requested frame size verbatim; a wrapped axis widens to fit a min/max
+ * size bound so the composable isn't clipped to the sandbox before the intrinsic-size crop runs
+ * (the crop still trims the PNG back to the measured size). Only ever widens, never shrinks.
+ *
+ * Shared verbatim by both desktop render bodies so the scene they measure in is the same size.
+ */
+fun composePreviewSceneSize(
+  widthPx: Int,
+  heightPx: Int,
+  wrapWidth: Boolean,
+  wrapHeight: Boolean,
+  sizeBounds: PreviewSizeBounds = PreviewSizeBounds(),
+): IntSize {
+  val w =
+    if (wrapWidth) maxOf(widthPx, sizeBounds.minWidthPx ?: 0, sizeBounds.maxWidthPx ?: 0)
+    else widthPx
+  val h =
+    if (wrapHeight) maxOf(heightPx, sizeBounds.minHeightPx ?: 0, sizeBounds.maxHeightPx ?: 0)
+    else heightPx
+  return IntSize(w, h)
+}
+
+/**
+ * The Android-Studio-parity wrap-measure box that both desktop render bodies place the preview
+ * content in.
+ *
+ * On a wrapped axis it measures [content] with a relaxed (min = 0, clamped by [sizeBounds]) bound
+ * against the sandbox max and sizes the box to the child's intrinsic size — so the captured tree
+ * (and the figma-svg / wireframe / semantics derived from it) reflects the preview's natural size
+ * instead of a fixed frame that clips or reflows wide content. The measured pixel size is reported
+ * through [onMeasured] so the caller can crop the PNG to it. `.background` paints on that intrinsic
+ * box so a sticker's backdrop is content-sized, not sandbox-sized. Fixed axes keep the sandbox
+ * constraint so `fillMax*` / `LazyColumn` still have a finite viewport.
+ *
+ * On a wrapped axis `propagateMinConstraints = true` pushes the wrapped-axis *min* bound (the Min /
+ * Within size modes) down onto the composable itself, not just this box — with the default the box
+ * grows to the min bound but relaxes the child's min to 0, so a wrap-content component (a Button, a
+ * badge) stays at its intrinsic size in the corner of an enlarged frame instead of filling the
+ * requested size. It is scoped to wrapped renders only: the fixed-frame branch is `fillMaxSize`,
+ * whose tight min would otherwise be forwarded into the root composable and stretch wrap-content
+ * content that must stay small in an explicitly-sized frame.
+ *
+ * [onMeasured] is invoked exactly once per measure pass, and only when at least one axis wraps.
+ */
+@Composable
+fun ComposePreviewContentBox(
+  wrapWidth: Boolean,
+  wrapHeight: Boolean,
+  backgroundColor: Color,
+  sizeBounds: PreviewSizeBounds = PreviewSizeBounds(),
+  onMeasured: (width: Int, height: Int) -> Unit,
+  content: @Composable () -> Unit,
+) {
+  val boxModifier =
+    if (wrapWidth || wrapHeight) {
+      Modifier.layout { measurable, constraints ->
+          // Size-mode bounds (Max / Min / Within) clamp the wrapped-axis measure: a max bound
+          // lowers
+          // the sandbox ceiling so the composable can't grow past it; a min bound raises the floor
+          // so
+          // it can't collapse below it. Both are clamped to the scene's available space so a bound
+          // larger than the (already-enlarged) scene can't produce an impossible constraint. Absent
+          // bounds keep the AS-parity wrap behaviour (min = 0, max = sandbox).
+          val maxWBound =
+            sizeBounds.maxWidthPx?.coerceAtMost(constraints.maxWidth) ?: constraints.maxWidth
+          val maxHBound =
+            sizeBounds.maxHeightPx?.coerceAtMost(constraints.maxHeight) ?: constraints.maxHeight
+          val minWBound = (sizeBounds.minWidthPx ?: 0).coerceIn(0, maxWBound)
+          val minHBound = (sizeBounds.minHeightPx ?: 0).coerceIn(0, maxHBound)
+          val wrapped =
+            Constraints(
+              minWidth = if (wrapWidth) minWBound else constraints.minWidth,
+              maxWidth = if (wrapWidth) maxWBound else constraints.maxWidth,
+              minHeight = if (wrapHeight) minHBound else constraints.minHeight,
+              maxHeight = if (wrapHeight) maxHBound else constraints.maxHeight,
+            )
+          val placeable = measurable.measure(wrapped)
+          onMeasured(placeable.width, placeable.height)
+          layout(placeable.width, placeable.height) { placeable.place(0, 0) }
+        }
+        .background(backgroundColor)
+    } else {
+      Modifier.fillMaxSize().background(backgroundColor)
+    }
+  Box(modifier = boxModifier, propagateMinConstraints = wrapWidth || wrapHeight) { content() }
+}

--- a/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRendererMain.kt
+++ b/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRendererMain.kt
@@ -13,10 +13,8 @@ import androidx.compose.ui.ImageComposeScene
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.layout.layout
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalInspectionMode
-import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntSize
 import ee.schimke.composeai.daemon.CachedDeviceArtSource
@@ -822,9 +820,18 @@ internal fun renderPreview(
     // A min bound larger than the default sandbox needs the scene enlarged to fit, otherwise the
     // composable is clipped to the scene before the intrinsic-size crop runs. Only widen (never
     // shrink) on a wrapped axis; the crop still trims the PNG back to the measured intrinsic size.
-    val sceneWidthPx = if (wrapWidth) maxOf(widthPx, minWidthPx ?: 0, maxWidthPx ?: 0) else widthPx
-    val sceneHeightPx =
-      if (wrapHeight) maxOf(heightPx, minHeightPx ?: 0, maxHeightPx ?: 0) else heightPx
+    // Shared with the daemon's desktop RenderEngine via [composePreviewSceneSize] so a bundle
+    // re-render and a `compose-preview serve` render size the same preview identically.
+    val sizeBounds =
+      PreviewSizeBounds(
+        minWidthPx = minWidthPx,
+        minHeightPx = minHeightPx,
+        maxWidthPx = maxWidthPx,
+        maxHeightPx = maxHeightPx,
+      )
+    val sceneSize = composePreviewSceneSize(widthPx, heightPx, wrapWidth, wrapHeight, sizeBounds)
+    val sceneWidthPx = sceneSize.width
+    val sceneHeightPx = sceneSize.height
     val scene =
       ImageComposeScene(width = sceneWidthPx, height = sceneHeightPx, density = sceneDensity)
 
@@ -876,71 +883,18 @@ internal fun renderPreview(
             else -> Color.Transparent
           }
         val body: @Composable () -> Unit = {
-          if (wrapWidth || wrapHeight) {
-            // AS-parity wrap: measure the composable with unbounded
-            // constraints on wrapped axes (keep the sandbox constraint
-            // on fixed axes), capture the child's pixel size, then
-            // size the outer Box to exactly that. The .layout modifier
-            // lets us both observe and bound the child's size in a
-            // single measurement pass — more reliable under
-            // ImageComposeScene than onGloballyPositioned, which is
-            // tied to a post-layout effect pass the scene doesn't
-            // always flush.
-            // Bounded sandbox constraints (not Infinity) — matches
-            // Android Studio's preview pane. `fillMaxWidth` / LazyColumn
-            // / etc. require bounded constraints; they'd throw from
-            // `InlineClassHelper` under an Infinity max. Small
-            // composables (`Modifier.size(100.dp)`) still measure at
-            // their intrinsic size and get cropped to that below;
-            // `fillMax*` composables measure at the sandbox size and
-            // no crop happens on that axis.
-            Box(
-              // `propagateMinConstraints = true` pushes the wrapped-axis *min* bound (the Min /
-              // Within size modes) down onto the composable itself, not just this wrapping box.
-              // With
-              // the default (false) the box grows to the min bound but relaxes the child's min to
-              // 0,
-              // so a wrap-content component (a Button, a badge) stays at its intrinsic size in the
-              // corner of an enlarged frame instead of filling the requested size. A min of 0 (the
-              // AS-parity / Max case) is a no-op, so this is safe for every mode.
-              propagateMinConstraints = true,
-              modifier =
-                Modifier.layout { measurable, constraints ->
-                    // Relax the min constraint on wrapped axes so
-                    // small composables can shrink below the
-                    // sandbox; keep the max bounded (the parent's
-                    // maxWidth/maxHeight) so `fillMax*` / LazyColumn
-                    // still have a finite viewport. Size-mode bounds
-                    // (Max / Min / Within) clamp that further: a max
-                    // bound lowers the ceiling, a min bound raises the
-                    // floor, both clamped into the (already-enlarged)
-                    // sandbox so a bound larger than the scene can't
-                    // make an impossible constraint.
-                    val maxWBound =
-                      maxWidthPx?.coerceAtMost(constraints.maxWidth) ?: constraints.maxWidth
-                    val maxHBound =
-                      maxHeightPx?.coerceAtMost(constraints.maxHeight) ?: constraints.maxHeight
-                    val minWBound = (minWidthPx ?: 0).coerceIn(0, maxWBound)
-                    val minHBound = (minHeightPx ?: 0).coerceIn(0, maxHBound)
-                    val wrappedConstraints =
-                      Constraints(
-                        minWidth = if (wrapWidth) minWBound else constraints.minWidth,
-                        maxWidth = if (wrapWidth) maxWBound else constraints.maxWidth,
-                        minHeight = if (wrapHeight) minHBound else constraints.minHeight,
-                        maxHeight = if (wrapHeight) maxHBound else constraints.maxHeight,
-                      )
-                    val placeable = measurable.measure(wrappedConstraints)
-                    measured = IntSize(placeable.width, placeable.height)
-                    layout(placeable.width, placeable.height) { placeable.place(0, 0) }
-                  }
-                  .background(bgColor),
-            ) {
-              InvokeComposable(composableMethod, null, previewArgs)
-            }
-          } else {
-            Box(modifier = Modifier.fillMaxSize().background(bgColor)) {
-              InvokeComposable(composableMethod, null, previewArgs)
-            }
+          // The AS-parity wrap-measure box (and its fixed-axis `fillMaxSize` counterpart) is shared
+          // with the daemon's desktop RenderEngine via [ComposePreviewContentBox], so both size the
+          // preview and capture its intrinsic bounds identically. `measured` is only written on a
+          // wrapped axis; it stays null for a fixed frame and the PNG is left uncropped below.
+          ComposePreviewContentBox(
+            wrapWidth = wrapWidth,
+            wrapHeight = wrapHeight,
+            backgroundColor = bgColor,
+            sizeBounds = sizeBounds,
+            onMeasured = { w, h -> measured = IntSize(w, h) },
+          ) {
+            InvokeComposable(composableMethod, null, previewArgs)
           }
         }
         // `@PreviewWrapper(Provider::class)` — instantiate the provider reflectively
@@ -984,8 +938,8 @@ internal fun renderPreview(
     // populated during the Modifier.layout measure pass in the wrap branch
     // above — if it somehow wasn't set (shouldn't happen, but defensive),
     // fall back to the sandbox dimensions and write the uncropped PNG.
-    if ((wrapWidth || wrapHeight) && measured != null) {
-      val m = measured!!
+    val m = measured
+    if ((wrapWidth || wrapHeight) && m != null) {
       // Ceiling is the (possibly enlarged) scene dimension, not the raw widthPx/heightPx — a min
       // bound larger than the original frame grew the scene, and the crop must keep that extent.
       val cropW = (if (wrapWidth) m.width else widthPx).coerceIn(1, sceneWidthPx)

--- a/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/ComposePreviewSceneTest.kt
+++ b/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/ComposePreviewSceneTest.kt
@@ -1,0 +1,70 @@
+package ee.schimke.composeai.renderer
+
+import androidx.compose.ui.unit.IntSize
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Pins [composePreviewSceneSize] — the scene-dimension math shared by the daemon desktop
+ * `RenderEngine` and the one-shot [DesktopRendererMain] fork. The wrap-measure box
+ * ([ComposePreviewContentBox]) is exercised end-to-end by the renderer's size-bounds render tests
+ * and the daemon's wrap-content tests; this covers the pure sizing rule directly.
+ */
+class ComposePreviewSceneTest {
+
+  @Test
+  fun `fixed axes use the requested frame size and ignore bounds`() {
+    val bounds = PreviewSizeBounds(minWidthPx = 5000, minHeightPx = 5000, maxWidthPx = 9000)
+    assertEquals(
+      IntSize(400, 800),
+      composePreviewSceneSize(400, 800, wrapWidth = false, wrapHeight = false, sizeBounds = bounds),
+    )
+  }
+
+  @Test
+  fun `a wrapped axis widens to a min bound larger than the frame`() {
+    val size =
+      composePreviewSceneSize(
+        widthPx = 300,
+        heightPx = 600,
+        wrapWidth = true,
+        wrapHeight = false,
+        sizeBounds = PreviewSizeBounds(minWidthPx = 900),
+      )
+    assertEquals(IntSize(900, 600), size)
+  }
+
+  @Test
+  fun `a wrapped axis widens to a max bound larger than the frame`() {
+    // The scene must fit the largest extent any mode can ask for, so it widens to a max bound too;
+    // the intrinsic-size crop trims the PNG back down afterwards.
+    val size =
+      composePreviewSceneSize(
+        widthPx = 300,
+        heightPx = 600,
+        wrapWidth = false,
+        wrapHeight = true,
+        sizeBounds = PreviewSizeBounds(maxHeightPx = 1500),
+      )
+    assertEquals(IntSize(300, 1500), size)
+  }
+
+  @Test
+  fun `bounds smaller than the frame never shrink the scene`() {
+    val size =
+      composePreviewSceneSize(
+        widthPx = 800,
+        heightPx = 800,
+        wrapWidth = true,
+        wrapHeight = true,
+        sizeBounds = PreviewSizeBounds(minWidthPx = 100, maxWidthPx = 200, minHeightPx = 50),
+      )
+    assertEquals(IntSize(800, 800), size)
+  }
+
+  @Test
+  fun `absent bounds keep the frame size on a wrapped axis`() {
+    val size = composePreviewSceneSize(500, 700, wrapWidth = true, wrapHeight = true)
+    assertEquals(IntSize(500, 700), size)
+  }
+}


### PR DESCRIPTION
## Summary

The two desktop render bodies had drifted into byte-identical copies of the same intricate layout logic:

- the daemon's long-lived `RenderEngine.setUp` (`:daemon:desktop`), and
- the one-shot `DesktopRendererMain.renderPreview` fork (`:renderer-desktop`) the Gradle preview task invokes.

Both carried their own copy of (1) the scene-dimension enlargement math (widen a wrapped axis to fit a min/max size bound) and (2) the Android-Studio-parity wrap-measure `Box` — the `Modifier.layout` constraints computation, `propagateMinConstraints`, the intrinsic-size capture, and the `.background`. Two copies of the trickiest pixel-affecting code in the desktop path is exactly where the daemon and the batch renderer silently diverge (issue history: fontScale, size-mode bounds, round-clip all had to be fixed in *both* places).

This extracts that shared core into `:renderer-desktop` (which `:daemon:desktop` already depends on):

- `composePreviewSceneSize(...)` — the scene pixel dimensions.
- `ComposePreviewContentBox(...)` — the wrap-measure box (and its fixed-axis `fillMaxSize` counterpart), reporting the measured intrinsic size via an `onMeasured` callback.
- `PreviewSizeBounds` — the min/max size-mode bounds both feed in.

Both callers now route through these. The genuinely backend-specific parts stay put: the daemon keeps its classloader install, Perfetto trace sections, slot-table / theme-fallback capture hooks, `LocalSlotMode` / `LocalLottieProgress` providers and the `ComposeDataExtensionPipeline` trampoline; the fork keeps its pseudolocale RTL providers and `InvokeComposable`. Net −80 lines across the two bodies.

## Test plan

- **Behaviour-preserving, verified at the pixel level.** Re-rendered the full `:samples:cmp` preview set with the change and byte-compared every PNG against a pre-change baseline: **32/32 identical, 0 differing** (`cmp -s`). Since the fork is what `composePreviewRenderAll` invokes, this exercises the changed `renderPreview` path end-to-end.
- New `ComposePreviewSceneTest` pins the `composePreviewSceneSize` rule (fixed axes ignore bounds; a wrapped axis widens to a min *or* max bound; bounds never shrink the scene; absent bounds keep the frame). `ComposePreviewContentBox` stays covered end-to-end by the existing `DesktopSizeBoundsRendererTest` and the daemon's `RenderEngineWrapContentTest`.
- `:renderer-desktop:test` + `:daemon:desktop:test` green — with one **pre-existing, unrelated** failure: `DesktopLottieRendererTest > renders a multi-frame looping gif spanning the intrinsic duration`, an order-dependent Lottie animation-clock flake that fails identically on a clean `main` checkout (confirmed by stashing this change and re-running: same test, same 49/1 tally). It touches the `DesktopLottieRenderer` path, which this PR does not.

No visual change by construction (the byte-identical render set is the evidence), so this is text-only per the visual-evidence convention.

_Generated by [Claude Code](https://claude.ai/code/session_01GUmFnbWgEjZUnupdPwMHVf)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01GUmFnbWgEjZUnupdPwMHVf)_