### PR TITLE
feat(vscode): show resource render errors in the manifest icon hover

### DIFF
--- a/vscode-extension/src/manifestResourceHoverImages.ts
+++ b/vscode-extension/src/manifestResourceHoverImages.ts
@@ -7,7 +7,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 
-import { VariantImage } from "./resourceVariantHover";
+import { ResourceRenderError, VariantImage } from "./resourceVariantHover";
 import { ResourcePreview } from "./types";
 
 /**
@@ -55,4 +55,42 @@ export function readVariantImages(
         }
     }
     return out;
+}
+
+/**
+ * Reads the renderer's `resource-render-errors.json` sidecar (written inside the render task's
+ * declared output tree, `renders/resources/`) and returns its entries. Tolerates an absent or
+ * malformed sidecar (returns `[]`) — an older renderer, or a run that produced nothing.
+ * [moduleBuildRoot] is the module's `build/compose-previews` dir, same anchor as [readVariantImages].
+ */
+export function readResourceRenderErrors(
+    moduleBuildRoot: string,
+): ResourceRenderError[] {
+    const sidecar = path.resolve(
+        moduleBuildRoot,
+        "renders",
+        "resources",
+        "resource-render-errors.json",
+    );
+    try {
+        const parsed = JSON.parse(fs.readFileSync(sidecar, "utf8"));
+        const entries: unknown[] = Array.isArray(parsed?.entries)
+            ? (parsed.entries as unknown[])
+            : [];
+        return entries
+            .filter(
+                (e: unknown): e is Record<string, unknown> =>
+                    typeof e === "object" &&
+                    e !== null &&
+                    typeof (e as Record<string, unknown>).renderOutput ===
+                        "string",
+            )
+            .map((e) => ({
+                renderOutput: String(e.renderOutput),
+                status: String(e.status ?? ""),
+                message: String(e.message ?? ""),
+            }));
+    } catch {
+        return [];
+    }
 }

--- a/vscode-extension/src/manifestResourceHoverProvider.ts
+++ b/vscode-extension/src/manifestResourceHoverProvider.ts
@@ -1,7 +1,10 @@
 import * as path from "node:path";
 import * as vscode from "vscode";
 import { GradleService } from "./gradleService";
-import { readVariantImages } from "./manifestResourceHoverImages";
+import {
+    readResourceRenderErrors,
+    readVariantImages,
+} from "./manifestResourceHoverImages";
 import { findManifestIconReferences } from "./manifestIconReferences";
 import { buildResourceVariantHoverMarkdown } from "./resourceVariantHover";
 
@@ -57,12 +60,20 @@ export class ManifestResourceHoverProvider implements vscode.HoverProvider {
             "compose-previews",
         );
         const images = readVariantImages(resource, moduleRoot);
-        if (images.length === 0) {
+        // Render errors for THIS resource's captures (from the sidecar), so a missing variant shows
+        // *why* it's missing instead of vanishing from the hover.
+        const captureOutputs = new Set(
+            resource.captures.map((c) => c.renderOutput),
+        );
+        const errors = readResourceRenderErrors(moduleRoot).filter((e) =>
+            captureOutputs.has(e.renderOutput),
+        );
+        if (images.length === 0 && errors.length === 0) {
             return undefined;
         }
 
         const md = new vscode.MarkdownString(
-            buildResourceVariantHoverMarkdown({ resource, images }),
+            buildResourceVariantHoverMarkdown({ resource, images, errors }),
         );
         // `resources.json` is workspace-controlled (could be authored by an
         // attacker if a victim opens a hostile project). The hover only needs

--- a/vscode-extension/src/resourceVariantHover.ts
+++ b/vscode-extension/src/resourceVariantHover.ts
@@ -40,9 +40,28 @@ export interface VariantImage {
     base64: string;
 }
 
+/**
+ * One capture that produced no PNG, and why — read from the renderer's
+ * `resource-render-errors.json` sidecar. Lets the hover explain a missing
+ * variant ("⚠ render failed: …") instead of silently dropping it.
+ */
+export interface ResourceRenderError {
+    /** Module-relative path matched against `ResourceCapture.renderOutput`. */
+    renderOutput: string;
+    /** `failed` | `skipped` | `not-found`. */
+    status: string;
+    message: string;
+}
+
 export interface VariantHoverInput {
     resource: ResourcePreview;
     images: VariantImage[];
+    /**
+     * Per-capture render errors (from the `resource-render-errors.json` sidecar). A capture with no
+     * image but a matching error is rendered as a warning line; a capture with neither is skipped
+     * silently (the host chose not to render that variant). Optional for back-compat.
+     */
+    errors?: ResourceRenderError[];
 }
 
 /**
@@ -70,32 +89,70 @@ export function buildResourceVariantHoverMarkdown(
     const byOutput = new Map(
         input.images.map((i) => [i.renderOutput, i.base64]),
     );
+    const errorsByOutput = new Map(
+        (input.errors ?? []).map((e) => [e.renderOutput, e]),
+    );
     const imgs: string[] = [];
+    const errorLines: string[] = [];
     for (const capture of input.resource.captures) {
         const base64 = byOutput.get(capture.renderOutput);
-        if (!base64) {
+        if (base64) {
+            const mime = capture.renderOutput.toLowerCase().endsWith(".gif")
+                ? "image/gif"
+                : "image/png";
+            const label = captureLabel(capture);
+            imgs.push(
+                `<img src="data:${mime};base64,${base64}" ` +
+                    `width="${VARIANT_HOVER_IMG_PX}" ` +
+                    `height="${VARIANT_HOVER_IMG_PX}" ` +
+                    `alt="${escapeAttr(label)}" ` +
+                    `title="${escapeAttr(label)}" />`,
+            );
             continue;
         }
-        const mime = capture.renderOutput.toLowerCase().endsWith(".gif")
-            ? "image/gif"
-            : "image/png";
-        const label = captureLabel(capture);
-        imgs.push(
-            `<img src="data:${mime};base64,${base64}" ` +
-                `width="${VARIANT_HOVER_IMG_PX}" ` +
-                `height="${VARIANT_HOVER_IMG_PX}" ` +
-                `alt="${escapeAttr(label)}" ` +
-                `title="${escapeAttr(label)}" />`,
-        );
+        // No image for this capture. If the renderer recorded why (a failed / skipped / not-found
+        // capture), surface it so the user sees the reason instead of a silently-missing variant.
+        // `status` and `message` come from the sidecar — escaped before interpolation.
+        const err = errorsByOutput.get(capture.renderOutput);
+        if (err) {
+            errorLines.push(
+                `⚠ ${escapeMarkdown(captureLabel(capture))} — ` +
+                    `${escapeMarkdown(friendlyErrorStatus(err.status))}: ` +
+                    `${escapeMarkdown(err.message)}`,
+            );
+        }
+        // else: skip silently — the host chose not to render this variant (e.g. a fast-tier run).
     }
-    if (imgs.length === 0) {
+    if (imgs.length === 0 && errorLines.length === 0) {
         lines.push("");
         lines.push("_No rendered captures available._");
         return lines.join("\n");
     }
-    lines.push("");
-    lines.push(imgs.join(" "));
+    if (imgs.length > 0) {
+        lines.push("");
+        lines.push(imgs.join(" "));
+    }
+    if (errorLines.length > 0) {
+        lines.push("");
+        for (const line of errorLines) {
+            lines.push(line);
+        }
+    }
     return lines.join("\n");
+}
+
+/** Human-readable label for a sidecar render-error [status]. */
+function friendlyErrorStatus(status: string): string {
+    switch (status) {
+        case "failed":
+            return "render failed";
+        case "skipped":
+            return "skipped";
+        case "not-found":
+            return "resource not found";
+        default:
+            return status;
+    }
 }
 
 /**

--- a/vscode-extension/src/test/resourceVariantHover.test.ts
+++ b/vscode-extension/src/test/resourceVariantHover.test.ts
@@ -235,3 +235,91 @@ describe("buildResourceVariantHoverMarkdown", () => {
         assert.match(md, /\*\*command​:workbench/);
     });
 });
+
+describe("buildResourceVariantHoverMarkdown — render errors", () => {
+    it("shows a ⚠ line with the reason for a capture that has no image but a sidecar error", () => {
+        const md = buildResourceVariantHoverMarkdown({
+            resource: VECTOR,
+            images: [],
+            errors: [
+                {
+                    renderOutput:
+                        "renders/resources/drawable/ic_compose_logo_xhdpi.png",
+                    status: "failed",
+                    message: "RuntimeException: can't rasterise",
+                },
+            ],
+        });
+        assert.match(md, /⚠/);
+        assert.match(md, /render failed/);
+        assert.match(md, /can't rasterise/);
+        // Not the "nothing available" fallback — we DID have something to say.
+        assert.doesNotMatch(md, /No rendered captures available/);
+    });
+
+    it("maps each status to a friendly label", () => {
+        const skip = buildResourceVariantHoverMarkdown({
+            resource: VECTOR,
+            images: [],
+            errors: [
+                {
+                    renderOutput:
+                        "renders/resources/drawable/ic_compose_logo_xhdpi.png",
+                    status: "skipped",
+                    message: "no monochrome layer",
+                },
+            ],
+        });
+        assert.match(skip, /skipped: no monochrome layer/);
+    });
+
+    it("renders images and error lines together for a partially-failed adaptive icon", () => {
+        const md = buildResourceVariantHoverMarkdown({
+            resource: ADAPTIVE,
+            images: [
+                {
+                    renderOutput: "renders/resources/mipmap/full.png",
+                    base64: "QUJD",
+                },
+            ],
+            errors: [
+                {
+                    renderOutput: "renders/resources/mipmap/themed-light.png",
+                    status: "failed",
+                    message: "boom",
+                },
+            ],
+        });
+        assert.match(md, /<img /); // the one that rendered
+        assert.match(md, /⚠/);
+        assert.match(md, /Themed light/);
+        assert.match(md, /render failed: boom/);
+    });
+
+    it("still returns the empty fallback when there is neither an image nor an error", () => {
+        const md = buildResourceVariantHoverMarkdown({
+            resource: VECTOR,
+            images: [],
+            errors: [],
+        });
+        assert.match(md, /No rendered captures available/);
+    });
+
+    it("escapes the error message so a crafted sidecar can't inject markup", () => {
+        const md = buildResourceVariantHoverMarkdown({
+            resource: VECTOR,
+            images: [],
+            errors: [
+                {
+                    renderOutput:
+                        "renders/resources/drawable/ic_compose_logo_xhdpi.png",
+                    status: "failed",
+                    message: "<img src=x onerror=alert(1)>",
+                },
+            ],
+        });
+        // The `<` is backslash-escaped (same policy as the resource id), so markdown renders it as
+        // literal text rather than an HTML tag — no `<img …>` reaches the DOM unescaped.
+        assert.match(md, /\\<img src=x/);
+    });
+});


### PR DESCRIPTION
## Summary

Surfaces the resource render errors captured in #2649 in VS Code. The `AndroidManifest.xml` icon hover (`android:icon` / `roundIcon` / `logo` / `banner`) renders each resource capture's PNG. When a capture produced **no PNG** — an un-rasterisable adaptive icon / vector, a wrong drawable type, an absent `<monochrome>` layer, a resource that didn't resolve — it was **dropped silently**, so the user saw a variant just… missing, with no reason.

Now the hover reads the renderer's `resource-render-errors.json` sidecar and, for a capture with no image but a recorded error, renders a `⚠ <label> — <status>: <message>` line in place of the missing variant. Images and error lines show **together** for a partially-failed adaptive icon, so you still see the variants that rendered.

- Status is mapped to a friendly label: `failed` → "render failed", `skipped` → "skipped", `not-found` → "resource not found".
- The message is escaped with the **same policy as the resource id** (the hover stays `isTrusted = false`), so a crafted sidecar can't inject markup.
- The sidecar reader tolerates an absent / malformed file (older renderer → `[]`), and the hover only appears if there's at least one image **or** one error for the resource.

## Visual evidence

This is a VS Code **hover popover** rendered in the extension host — it isn't part of the `@Preview` PNG diff-bot pipeline and can't be screenshotted in this headless environment. The hover body is markdown built by the pure `buildResourceVariantHoverMarkdown`, so here is the **exact markdown it now emits** for a partially-failed adaptive icon (one variant rendered, one failed) — a faithful proxy for what appears in the popover:

```markdown
**mipmap/ic_launcher** — Adaptive icon

``&lt;img src="data:image/png;base64,…" width="80" height="80" alt="Circle · Full colour" title="Circle · Full colour" /&gt;``

⚠ Squircle · Themed light — render failed: java.lang.RuntimeException: can't rasterise
```

(Before this change, the `⚠` line was absent — the themed-light variant simply didn't appear.) A human verifies visually by hovering an `android:icon` attribute in a Wear/Android module whose launcher icon has a failing capture; the electron hover test path exercises the provider wiring.

## Changes
- `resourceVariantHover.ts`: `ResourceRenderError` type; `VariantHoverInput.errors?`; the builder renders a `⚠` line for a missing capture with a matching error (and keeps skipping ones with neither image nor error); `friendlyErrorStatus`.
- `manifestResourceHoverImages.ts`: `readResourceRenderErrors(moduleBuildRoot)` — reads/validates the `renders/resources/resource-render-errors.json` sidecar.
- `manifestResourceHoverProvider.ts`: reads the sidecar, filters to this resource's captures, passes `errors`, and shows the hover when there are images **or** errors.
- `resourceVariantHover.test.ts`: `⚠` line, status labels, images+errors together, empty fallback, and message-escaping tests.

## Test plan
- `npm test` (compile + Mocha unit) — green, **1606 passing** including the new "render errors" cases.
- `npm run lint` fails in this environment on a pre-existing config mismatch (installed ESLint 10 expects flat config; the repo uses `eslint src --ext ts`) — it errors identically for every file and is unrelated to this change.

Refs #2589, #2649

---
_Generated by [Claude Code](https://claude.ai/code/session_01RvgeNjC6QRepDARnQuKPYJ)_