### PR TITLE
fix(android): resolve wireframe corner-radius tokens density-aware, matching desktop

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -1716,13 +1716,18 @@ open class RobolectricHost(
               // factory, so wrap it inline here.
               RenderDataArtifactExtensionFactory { ComposeSemanticsExtension() },
               // ComposeSemanticsWireframeExtension is shared too; Android supplies the Robolectric
-              // PNG baker and densityAware=false to preserve its current (density=1f) payload.
+              // PNG baker and — like Desktop — renders density-aware, so a percent/CircleShape corner
+              // radius (and density-dependent font-variation axes) resolves against the real render
+              // density (`spec.density`, provided on the `RenderArtifactContextKeys.Density` key
+              // above) instead of px-as-dp at density=1 (#1908). Only the resolved *token* values in
+              // the `compose/semantics-wireframe` + `compose/spatial-semantics` payloads change; the
+              // wireframe raster is drawn from px bounds + labels, so it's byte-identical.
               RenderDataArtifactExtensionFactory {
                 ComposeSemanticsWireframeExtension(
                   pngGenerator = { payload, destPng ->
                     AndroidSemanticsWireframe.generate(payload, destPng)
                   },
-                  densityAware = false,
+                  densityAware = true,
                 )
               },
               // LayoutInspectorExtension is shared now; it reads the captured semantics root + slot

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopSemanticsTokensTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopSemanticsTokensTest.kt
@@ -119,6 +119,29 @@ class DesktopSemanticsTokensTest {
   }
 
   @Test
+  fun circle_shape_corner_radius_resolves_to_density_independent_dp() {
+    // A `CircleShape` is a *percent* (50%) corner: its radius is a fraction of the measured **px**
+    // size, so expressing it as dp needs the render density (dp = px / density). A 48dp box is 96px
+    // at density 2 and 48px at density 1 — the circle radius differs in px but must resolve to the
+    // *same* dp. Without density (Android's former `densityAware = false`, i.e. density = 1f) the
+    // density-2 capture would mislabel the raw px radius as dp. This is the shared
+    // `buildPayload(root, density)` path the Android wireframe / spatial payload now uses via
+    // `RobolectricHost`'s `densityAware = true` (#1908).
+    fun radiusAt(density: Float): String? =
+      buildTree(density = density) {
+          Box(Modifier.testTag("pill").size(48.dp).background(Color(0xFF006A60), CircleShape))
+        }
+        .find("pill")
+        ?.tokens
+        ?.cornerRadius
+
+    val atOne = radiusAt(1f)
+    val atTwo = radiusAt(2f)
+    assertNotNull("a CircleShape must resolve a dp corner radius", atOne)
+    assertEquals("the resolved dp radius must be density-independent", atOne, atTwo)
+  }
+
+  @Test
   fun node_without_container_tokens_emits_null() {
     // Plain text carries text-layout fields (layoutForegroundColor etc.) but no container tokens.
     val root = buildTree { Text("just text", modifier = Modifier.testTag("label")) }

--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsWireframeExtension.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsWireframeExtension.kt
@@ -22,10 +22,12 @@ import java.io.File
  * - **[pngGenerator]** — the wireframe raster is baked with a platform toolkit (Robolectric canvas
  *   on Android, Skia on Desktop). Each daemon passes its own `SemanticsWireframe.generate`.
  * - **[densityAware]** — whether the payload resolves density-dependent tokens (percent corner
- *   radii → dp, #1908). Desktop passes `true` (real `spec.density`); Android passes `false`
- *   (`density = 1f`), preserving each backend's current output exactly. Unifying the two — making
- *   Android density-aware here too — is a deliberate follow-up gated on visual review, not folded
- *   into this refactor.
+ *   radii → dp, density-dependent font-variation axes; #1908). Both backends now pass `true` and
+ *   read the real `spec.density` off [RenderArtifactContextKeys.Density], so a `CircleShape` corner
+ *   radius resolves to the same dp on Android and Desktop instead of Android's former px-as-dp at
+ *   `density = 1f`. Only the resolved *token* values change; the wireframe raster is drawn from px
+ *   bounds + labels, so it is unaffected. The flag remains a constructor parameter (rather than a
+ *   hard-coded `true`) so a backend can still opt a payload out where density isn't meaningful.
  */
 class ComposeSemanticsWireframeExtension(
   private val pngGenerator: (ComposeSemanticsPayload, File) -> Unit,

--- a/data/layoutinspector/connector/src/test/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsWireframeExtensionTest.kt
+++ b/data/layoutinspector/connector/src/test/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsWireframeExtensionTest.kt
@@ -14,15 +14,16 @@ import org.junit.Test
 
 /**
  * Pins the shared [ComposeSemanticsWireframeExtension]: an after-capture, capture-phase processor
- * targeting both backends, over the shared [RenderArtifactContextKeys]. The Android daemon supplies
- * the Robolectric PNG baker + `densityAware = false`; the Desktop daemon supplies the Skia baker +
- * `densityAware = true`. Lives here next to the moved class; replaces the former `:daemon:android`
- * copy.
+ * targeting both backends, over the shared [RenderArtifactContextKeys]. Both daemons now supply
+ * their own PNG baker + `densityAware = true` (Robolectric on Android, Skia on Desktop); the
+ * density-dependent token resolution itself is pinned by
+ * `DesktopSemanticsTokensTest.circle_shape_corner_radius_resolves_to_density_independent_dp`. Lives
+ * here next to the moved class; replaces the former `:daemon:android` copy.
  */
 class ComposeSemanticsWireframeExtensionTest {
 
   private fun extension() =
-    ComposeSemanticsWireframeExtension(pngGenerator = { _, _ -> }, densityAware = false)
+    ComposeSemanticsWireframeExtension(pngGenerator = { _, _ -> }, densityAware = true)
 
   @Test
   fun `is an after-capture capture-phase processor targeting both backends`() {


### PR DESCRIPTION
## Summary

The Android render path passed `densityAware = false` to the shared `ComposeSemanticsWireframeExtension`, so a **percent / `CircleShape` corner radius** (and density-dependent font-variation axes) in the `compose/semantics-wireframe` and `compose/spatial-semantics` payloads was resolved at `density = 1f`. A percent corner is a fraction of the measured **px** size, so at any real device density that mislabelled the raw px radius as dp (a 48dp pill's 48px radius at density 2 came out as "48dp" instead of "24dp") — issue #1908. Desktop already passed `true`.

This was the deliberate follow-up the extension's doc comment flagged after the shared-extension refactor. It flips Android to `densityAware = true`:

- Android's `RenderEngine` **already** provides the render density on the `RenderArtifactContextKeys.Density` key, so no new plumbing is needed — the flip just routes Android through the same shared `ComposeSemanticsDataProducer.buildPayload(root, density)` path desktop uses.
- Both backends now resolve the **same dp** for the same component, so a batch bundle re-render and a `compose-preview serve` render agree, and the `compose/spatial-semantics` tree the 3D view reads carries correct dp.

**Scope of the change is token metadata, not pixels.** The `semantics-wireframe` raster is drawn purely from each node's `boundsInRoot` (px) + `label` — it does not consult the corner-radius token (confirmed in `SemanticsWireframe` / both bakers). Only the resolved token *values* in the payloads change. So per the visual-evidence convention this is a data-product change and text-only is correct; there is no wireframe-PNG delta to embed.

## Test plan

- **New** `DesktopSemanticsTokensTest.circle_shape_corner_radius_resolves_to_density_independent_dp` — renders a `CircleShape` box through the shared `buildPayload(root, density)` at density 1 and 2 and asserts the resolved dp corner radius is **density-independent** (equal across densities, non-null). Without density applied the density-2 capture would report double, so this pins exactly the resolution Android's flip now uses. **Passes** (desktop `ImageComposeScene`, run locally).
- `:daemon:desktop:test --tests *DesktopSemanticsTokensTest*` green (the existing token-resolution suite, incl. the `#1901` pixel-corner-stays-null case).
- `:data-layoutinspector-connector:test` green, including the updated `ComposeSemanticsWireframeExtensionTest` (now pins both backends at `densityAware = true`).
- `:daemon:android:compileDebugKotlin` green (the `RobolectricHost` flip compiles).
- I couldn't run the Android Robolectric render in this environment, but the change is a one-line flag flip onto an already-tested shared path, and no `:daemon:android` test asserts px token values that this would move; CI's `Daemon Harness (android, real renderer)` exercises the Android render. I'll follow the PR and fix any Android-side fallout.

_Generated by [Claude Code](https://claude.ai/code/session_01GUmFnbWgEjZUnupdPwMHVf)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01GUmFnbWgEjZUnupdPwMHVf)_