### PR TITLE
feat(figma-svg): ship a figma-svg per preview variant, not one per component

### DIFF
--- a/scripts/design-artifacts/figma-svg-catalog.test.mjs
+++ b/scripts/design-artifacts/figma-svg-catalog.test.mjs
@@ -4,7 +4,12 @@
  * table reports the figma-svg count. The driver's `figmaSvgByFunction` reader + emit loop are
  * exercised end-to-end by the bundle round-trip; here we pin the two presentation surfaces.
  *
- * Run with `node --test scripts/design-artifacts/`.
+ * Also covers the per-variant emit (`figma/<slug>/<variant>.svg`, one per rendered preview,
+ * mirroring `images/<slug>/<variant>.png`): its bundle readers (`figmaSvgById` / `figmaSvgByIds`,
+ * including the `--extra-renders` fold), its manifest-driven path mapping (`figmaVariantSvgPath`)
+ * and the variant-keyed hybrid raster dir.
+ *
+ * Run with `node --test "scripts/design-artifacts/*.test.mjs"`.
  */
 import assert from "node:assert/strict";
 import { test } from "node:test";
@@ -15,6 +20,9 @@ import {
   figmaRastersForId,
   figmaSvgByFunction,
   figmaSvgByFunctions,
+  figmaSvgById,
+  figmaSvgByIds,
+  figmaVariantSvgPath,
   rewriteRasterHrefs,
 } from "./figma-svg-emit.mjs";
 
@@ -159,4 +167,175 @@ test("rewriteRasterHrefs re-points hrefs to a per-slug dir (no cross-slug collis
   );
   // A vector-only SVG is untouched.
   assert.equal(rewriteRasterHrefs("<svg><rect/></svg>", "fab"), "<svg><rect/></svg>");
+});
+
+test("rewriteRasterHrefs keys the per-variant dir on the variant basename", () => {
+  // Both variants of one component carry a `node-1.png` and both vectors live in the same
+  // `figma/<slug>/` dir, so keying on the slug would have the dark crop overwrite the light one.
+  const svg = '<image href="figma-raster/node-1.png"/>';
+  assert.equal(
+    rewriteRasterHrefs(svg, "ideal__default__light"),
+    '<image href="ideal__default__light.figma-raster/node-1.png"/>',
+  );
+  assert.equal(
+    rewriteRasterHrefs(svg, "ideal__default__dark"),
+    '<image href="ideal__default__dark.figma-raster/node-1.png"/>',
+  );
+});
+
+test("figmaSvgById keeps every carried variant, not just the light one", () => {
+  const bundle = {
+    previews: [
+      { id: "Fab_Dark", functionName: "Fab" },
+      { id: "Fab_Light", functionName: "Fab" },
+      { id: "Fab_NoVector", functionName: "Fab" },
+    ],
+    entries: {
+      "previews/Fab_Dark.figma.svg": enc("<svg><!--dark--></svg>"),
+      "previews/Fab_Light.figma.svg": enc("<svg><!--light--></svg>"),
+    },
+  };
+  const byId = figmaSvgById(bundle);
+  assert.deepEqual([...byId.keys()].sort(), ["Fab_Dark", "Fab_Light"]);
+  assert.match(byId.get("Fab_Dark"), /dark/);
+  assert.match(byId.get("Fab_Light"), /light/);
+  // A preview that produced no drawing layers carries no entry — that's the reportable gap.
+  assert.equal(byId.has("Fab_NoVector"), false);
+});
+
+test("figmaSvgById ignores a carried entry that isn't an SVG", () => {
+  const bundle = {
+    previews: [{ id: "Fab_Light", functionName: "Fab" }],
+    entries: { "previews/Fab_Light.figma.svg": enc("not markup") },
+  };
+  assert.equal(figmaSvgById(bundle).size, 0);
+});
+
+test("figmaSvgByIds folds an --extra-renders bundle in (adds extra-only ids; extra wins)", () => {
+  // The regression this guards: a preview rendered ONLY by the supplementary bundle (a screen from
+  // a second CMP-desktop module) used to get no per-variant vector at all, because the emit read
+  // the primary bundle alone — which is the whole extra-renders-shaped catalog.
+  const primary = {
+    previews: [{ id: "Card_Light", functionName: "Card" }],
+    entries: { "previews/Card_Light.figma.svg": enc("<svg><!--primary card--></svg>") },
+  };
+  const extra = {
+    previews: [
+      { id: "Card_Light", functionName: "Card" }, // same id: extra overrides
+      { id: "ChatScreen_Dark", functionName: "ChatScreen" }, // extra-only: must be added
+    ],
+    entries: {
+      "previews/Card_Light.figma.svg": enc("<svg><!--extra card--></svg>"),
+      "previews/ChatScreen_Dark.figma.svg": enc("<svg><!--extra chat dark--></svg>"),
+    },
+  };
+  const byId = figmaSvgByIds([primary, extra]);
+  assert.ok(byId.has("ChatScreen_Dark"), "extra-renders-only preview id carries its figma-svg");
+  assert.match(byId.get("ChatScreen_Dark"), /extra chat dark/);
+  assert.match(byId.get("Card_Light"), /extra card/);
+  // Falsy bundles are skipped (the primary-only, no-extra-renders case).
+  assert.deepEqual([...figmaSvgByIds([primary, null]).keys()], ["Card_Light"]);
+});
+
+test("figmaVariantSvgPath mirrors the raster path (images/ → figma/, .png → .svg)", () => {
+  assert.equal(
+    figmaVariantSvgPath("images/button-filled/ideal__default__dark__compact.png"),
+    "figma/button-filled/ideal__default__dark__compact.svg",
+  );
+  // The back-compat vector `figma/<slug>.svg` is a *file* while the per-variant set lives in a
+  // `figma/<slug>/` *directory*, so the two never collide.
+  assert.notEqual(
+    figmaVariantSvgPath("images/button-filled/ideal__default__light.png"),
+    "figma/button-filled.svg",
+  );
+});
+
+test("figmaVariantSvgPath rejects anything that isn't a plain images/<slug>/<variant>.png", () => {
+  for (const bad of [
+    undefined,
+    null,
+    42,
+    "",
+    "wireframes/button-filled.svg",
+    "images/button-filled/shot.webp",
+    "images/",
+    // A flat image path would map onto the back-compat `figma/<slug>.svg` and clobber it.
+    "images/button-filled.png",
+    "images/../../etc/passwd.png",
+    "images/a/../../b.png",
+    "images/a\\b.png",
+    "images//b.png",
+  ]) {
+    assert.equal(figmaVariantSvgPath(bad), null, `expected null for ${JSON.stringify(bad)}`);
+  }
+});
+
+test("manifest-driven emit pairs every image with its variant vector and counts the gaps", () => {
+  // Mirrors the driver's per-variant loop: walk the written manifest's images[], look the image's
+  // previewId up in the vectors folded across BOTH bundles, and write the vector at the image's own
+  // path. An image whose previewId carried no vector is a counted gap rather than a silent
+  // omission; an image with no previewId at all (deliberately left unbridged) is skipped silently.
+  const bundle = {
+    previews: [
+      { id: "Fab_Light", functionName: "Fab" },
+      { id: "Fab_Dark", functionName: "Fab" },
+    ],
+    entries: {
+      "previews/Fab_Light.figma.svg": enc("<svg><!--light--></svg>"),
+      "previews/Fab_Dark.figma.svg": enc("<svg><!--dark--></svg>"),
+    },
+  };
+  // Extra-renders-only screen: present in neither the primary bundle nor `figmaSvgByFunction`.
+  const extraBundle = {
+    previews: [{ id: "ChatScreen_Light", functionName: "ChatScreen" }],
+    entries: { "previews/ChatScreen_Light.figma.svg": enc("<svg><!--chat--></svg>") },
+  };
+  const manifest = {
+    components: [
+      {
+        componentId: "fab",
+        images: [
+          { path: "images/fab/ideal__default__light.png", previewId: "Fab_Light" },
+          { path: "images/fab/ideal__default__dark.png", previewId: "Fab_Dark" },
+          { path: "images/fab/ideal__default__dark__compact.png", previewId: "Fab_Dark_Compact" },
+          { path: "images/fab/ideal__default__light__no-preview-id.png" },
+        ],
+      },
+      {
+        componentId: "chat-screen",
+        images: [
+          { path: "images/chat-screen/ideal__default__light.png", previewId: "ChatScreen_Light" },
+        ],
+      },
+    ],
+  };
+  const byId = figmaSvgByIds([bundle, extraBundle]);
+  const written = new Map();
+  let gaps = 0;
+  for (const component of manifest.components) {
+    for (const image of component.images) {
+      if (!image.previewId) continue;
+      const target = figmaVariantSvgPath(image.path);
+      if (!target) continue;
+      const carried = byId.get(image.previewId);
+      if (!carried) {
+        gaps += 1;
+        continue;
+      }
+      written.set(target, carried);
+    }
+  }
+  assert.deepEqual(
+    [...written.keys()].sort(),
+    [
+      "figma/chat-screen/ideal__default__light.svg",
+      "figma/fab/ideal__default__dark.svg",
+      "figma/fab/ideal__default__light.svg",
+    ],
+  );
+  assert.match(written.get("figma/fab/ideal__default__dark.svg"), /dark/);
+  // The extra-renders-only screen gets its vector from the second bundle, not the primary.
+  assert.match(written.get("figma/chat-screen/ideal__default__light.svg"), /chat/);
+  // Fab_Dark_Compact was rendered but carried no vector; the image with no previewId isn't a gap.
+  assert.equal(gaps, 1);
 });

--- a/scripts/design-artifacts/figma-svg-emit.mjs
+++ b/scripts/design-artifacts/figma-svg-emit.mjs
@@ -46,6 +46,69 @@ export function figmaSvgByFunctions(bundles) {
 }
 
 /**
+ * Map previewId → svg for **every** preview that carried a `compose/figma-svg` — no per-function
+ * collapse, no light preference. The bundle carries one vector per rendered preview (dark, locale
+ * and size included: the Kotlin-side `figmaSvgById` is keyed by preview id with no theme gating),
+ * so this is the raw carry that {@link figmaSvgByFunction} above narrows down to one sticker per
+ * component. Used for the per-variant emit, which mirrors the raster set 1:1.
+ */
+export function figmaSvgById(bundle) {
+  const out = new Map();
+  for (const preview of bundle.previews ?? []) {
+    const bytes = bundle.entries?.[`previews/${preview.id}.figma.svg`];
+    if (!bytes) continue;
+    const svg = new TextDecoder().decode(bytes);
+    if (svg.includes("<svg")) out.set(preview.id, svg);
+  }
+  return out;
+}
+
+/**
+ * Fold {@link figmaSvgById} across several bundles, later bundles winning — the by-id counterpart of
+ * {@link figmaSvgByFunctions}, and there for the same reason: an `--extra-renders`-only preview (a
+ * screen rendered from a second CMP-desktop module) exists in ONLY the supplementary bundle, so a
+ * primary-only read emits no per-variant vector for it at all — which would gut this feature for
+ * exactly the catalogs that lean on `--extra-renders`. Preview ids are unique per bundle, so the
+ * "later wins" tie-break only fires when the extra bundle re-renders the same preview — precisely
+ * where the extra render is meant to win, matching the candidate fold. Falsy bundles are skipped.
+ */
+export function figmaSvgByIds(bundles) {
+  const out = new Map();
+  for (const bundle of bundles) {
+    if (!bundle) continue;
+    for (const [id, svg] of figmaSvgById(bundle)) out.set(id, svg);
+  }
+  return out;
+}
+
+/**
+ * The per-variant vector path for a manifest image path: `images/<slug>/<variant>.png` →
+ * `figma/<slug>/<variant>.svg`. Deriving the vector's name from the image's own path (rather than
+ * re-deriving one from theme/size/props) is what keeps the two sets 1:1 and reuses the export
+ * engine's already-collision-safe `imagePath` naming — a vector always sits at its PNG's path with
+ * `images/` → `figma/` and `.png` → `.svg`.
+ *
+ * Returns null for anything that isn't a plain `images/<slug>/<variant>.png`:
+ *   - a non-`images/` or non-`.png` path has no raster to mirror;
+ *   - empty / `.` / `..` / absolute / backslash segments are rejected so a hostile manifest can't
+ *     write outside `figma/`;
+ *   - a *flat* `images/<slug>.png` is rejected too: it would map onto `figma/<slug>.svg`, the
+ *     back-compat per-component vector this emit must leave untouched. Every path the export engine
+ *     writes carries the component subdir (see `catalogPreviewId`, which flattens exactly one `/`),
+ *     so this only ever rejects a malformed manifest.
+ */
+export function figmaVariantSvgPath(imagePath) {
+  if (typeof imagePath !== "string") return null;
+  if (!imagePath.startsWith("images/") || !imagePath.endsWith(".png")) return null;
+  const rest = imagePath.slice("images/".length, -".png".length);
+  if (!rest || rest.startsWith("/") || rest.includes("\\")) return null;
+  const segments = rest.split("/");
+  if (segments.length < 2) return null;
+  if (segments.some((s) => s === "" || s === "." || s === "..")) return null;
+  return `figma/${rest}.svg`;
+}
+
+/**
  * The hybrid raster crops carried for preview [id] as `previews/<id>.figma-raster/<node>.png`.
  * Returns a Map name→bytes; empty for the common vector-only sticker.
  */
@@ -66,10 +129,20 @@ export function figmaRastersForId(bundle, id) {
 }
 
 /**
- * Rewrite a hybrid SVG's relative `figma-raster/<node>.png` `<image>` hrefs to a per-slug directory
- * (`<slug>.figma-raster/<node>.png`) so they resolve next to `figma/<slug>.svg` and never collide
- * across components (two stickers can each have a `node-3.png`). A no-op for a vector-only SVG.
+ * Rewrite a hybrid SVG's relative `figma-raster/<node>.png` `<image>` hrefs into a sibling directory
+ * named after [key], so the crops resolve next to the SVG that references them and never collide
+ * with another vector's crops (any two stickers can each carry a `node-3.png`).
+ *
+ * [key] is whatever makes the emitted vector unique **within its own directory**:
+ *   - the component slug for the back-compat `figma/<slug>.svg`
+ *     → `figma/<slug>.figma-raster/<node>.png`
+ *   - the variant basename for a per-variant `figma/<slug>/<variant>.svg`
+ *     → `figma/<slug>/<variant>.figma-raster/<node>.png`
+ *
+ * Keying the per-variant crops on the slug would have a component's light and dark vectors overwrite
+ * each other's `<node>.png`, since both live in the same `figma/<slug>/` dir — hence the basename.
+ * A no-op for a vector-only SVG.
  */
-export function rewriteRasterHrefs(svg, componentSlug) {
-  return svg.replaceAll("figma-raster/", `${componentSlug}.figma-raster/`);
+export function rewriteRasterHrefs(svg, key) {
+  return svg.replaceAll("figma-raster/", `${key}.figma-raster/`);
 }

--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -52,6 +52,8 @@ import { renderReadmeMd } from "./render-readme-md.mjs";
 import {
   figmaRastersForId,
   figmaSvgByFunctions,
+  figmaSvgByIds,
+  figmaVariantSvgPath,
   rewriteRasterHrefs,
 } from "./figma-svg-emit.mjs";
 import { buildCodeConnectManifest } from "./figma-code-connect-emit.mjs";
@@ -679,6 +681,20 @@ for (const component of catalog.components) {
   wireframeCount += 1;
 }
 
+// The written manifest (catalog.json), re-read from disk — NOT the in-memory
+// `catalog`: `buildCatalog` keeps a component's captures under `variants.ideal`
+// (each with a source `uri`), while the manifest carries the flattened `images[]`
+// with the bundle-relative `path` every artifact must reference, plus the
+// `previewId` the stamp pass above bridged onto each image.
+//
+// Read here rather than just before the index render because two consumers need
+// it: the per-variant figma-svg emit below mirrors `images[]` path for path, and
+// `renderIndexHtml` / `renderCompareHtml` / `renderCrossSystemHtml` read
+// `component.images` to show the stickers (and to group them by `state` in the
+// zoom view). Nothing between the write above and the renders below touches
+// catalog.json, so moving the read earlier is behaviour-preserving.
+const indexManifest = JSON.parse(await readFile(join(outPath, "catalog.json"), "utf8"));
+
 // Editable, design-fidelity vectors next to the raster PNGs: the layered
 // `compose/figma-svg` export (real fills / strokes / corner radii + editable
 // text) carried per sticker in the bundle. Unlike the schematic wireframe above
@@ -727,6 +743,85 @@ for (const component of catalog.components) {
   figmaSvgCount += 1;
 }
 
+// Per-variant vectors, mirroring the raster set 1:1:
+//
+//   images/<slug>/ideal__default__dark__compact.png   (written by the export engine)
+//   figma/<slug>/ideal__default__dark__compact.svg    (written here)
+//
+// The loop above ships exactly ONE vector per component (`figmaSvgByFunction` prefers
+// the light preview), yet the bundle carries a `previews/<id>.figma.svg` for *every*
+// rendered preview — the dark, locale and size vectors are rendered, carried, then
+// dropped on the floor by that per-function collapse. This loop ships them.
+//
+// It's driven from the manifest's `images[]` rather than from a naming scheme of its
+// own: each image already carries the `previewId` that keys the bundle's vectors plus
+// the bundle-relative `path` the export engine chose for it, so mapping `images/` →
+// `figma/` and `.png` → `.svg` inherits that collision-safe naming and guarantees a
+// vector can't drift away from the PNG it depicts.
+//
+// The `previewId` it keys on is stamped onto each image by `bridgeLivePreviewIds`
+// above, which runs for a carried liveBundle OR a `--source-module` (the workflow
+// always passes the latter, so every published catalog is covered). An image it
+// deliberately left unbridged — a state with no desktop source, or a function the
+// Android-only supplement overrode — carries no previewId and is skipped silently:
+// there is no daemon-rendered vector for it to be missing. An image that HAS a
+// previewId but no carried vector is a *gap*, counted and reported below, because a
+// silently missing vector is precisely the failure this emit exists to prevent.
+//
+// Vectors are folded across BOTH bundles (`figmaSvgByIds`), exactly like the
+// per-function fold and the raster merge above: an `--extra-renders`-only preview
+// exists in the supplementary bundle alone, so a primary-only read would emit no
+// per-variant vector at all for every screen rendered from a second module.
+//
+// Purely additive: `figma/<slug>.svg` and its per-slug crop dir stay exactly where
+// they are, since index.html, compare.html, design-parity's FIGMA_IMPORT.md and the
+// meshcore-mobile seeding runbook all reference that path today. The per-variant set
+// lives in a `figma/<slug>/` *directory*, so the two never collide.
+const figmaSvgsById = figmaSvgByIds([bundle, extraBundle]);
+let figmaVariantSvgCount = 0;
+let figmaVariantGapCount = 0;
+for (const component of indexManifest.components ?? []) {
+  for (const image of component.images ?? []) {
+    if (!image.previewId) continue;
+    const target = figmaVariantSvgPath(image.path);
+    if (!target) continue;
+    const carried = figmaSvgsById.get(image.previewId);
+    if (!carried) {
+      figmaVariantGapCount += 1;
+      continue;
+    }
+    let svg = carried;
+    const variantPath = join(outPath, target);
+    const variantDir = dirname(variantPath);
+    const variantBase = basename(target, ".svg");
+    // Same two-bundle merge as the back-compat loop: a hybrid sticker's crops live in
+    // whichever bundle carried its figma-svg, and a preview id belongs to one bundle,
+    // so merging is safe (the other side returns empty).
+    const rasters = extraBundle
+      ? new Map([
+          ...figmaRastersForId(bundle, image.previewId),
+          ...figmaRastersForId(extraBundle, image.previewId),
+        ])
+      : figmaRastersForId(bundle, image.previewId);
+    if (rasters.size) {
+      // Hybrid crops get a sibling dir keyed by the *variant* basename, not the slug:
+      // a component's light and dark vectors share one `figma/<slug>/` dir and each
+      // carries its own `<node>.png`, so a per-slug dir would have them overwrite each
+      // other. Sitting next to the SVG, the rewritten relative href resolves as-is.
+      svg = rewriteRasterHrefs(svg, variantBase);
+      const rasterDir = join(variantDir, `${variantBase}.figma-raster`);
+      await mkdir(rasterDir, { recursive: true });
+      for (const [name, bytes] of rasters) {
+        await writeFile(join(rasterDir, name), Buffer.from(bytes));
+        figmaRasterCount += 1;
+      }
+    }
+    await mkdir(variantDir, { recursive: true });
+    await writeFile(variantPath, svg, "utf8");
+    figmaVariantSvgCount += 1;
+  }
+}
+
 // Figma Code Connect manifest next to the figma-svg vectors: one mapping per component binding its
 // Figma layer (by componentId) to the **production composable** it renders, plus the repo source. It
 // carries everything `send_code_connect_mappings` needs except the node id, which only exists once a
@@ -770,18 +865,6 @@ await writeFile(
 console.log(
   `[${spec.system}] code-connect → ${codeConnect.mappings.length} mapping(s) (code-connect.json)`,
 );
-
-// Browsable index next to catalog.json + images/ — a designer can open this
-// straight from the branch to skim every component (its a11y greenlines and the
-// editable wireframe) before importing the tokens/images into a design tool.
-//
-// Render from the written manifest (catalog.json), NOT the in-memory `catalog`:
-// `buildCatalog` keeps a component's captures under `variants.ideal` (each with a
-// source `uri`), while the manifest carries the flattened `images[]` with the
-// bundle-relative `path` the page must reference. `renderIndexHtml` reads
-// `component.images`, so passing the manifest is what makes the stickers actually
-// show (and lets the zoom view group them by `state`).
-const indexManifest = JSON.parse(await readFile(join(outPath, "catalog.json"), "utf8"));
 
 // Cross-system component-parallel page (matches.html): pair every component with
 // its declared counterpart in the sibling system named by `spec.compareWith`,
@@ -859,6 +942,13 @@ if (spec.compareWith) {
   }
 }
 
+// Browsable index next to catalog.json + images/ — a designer can open this
+// straight from the branch to skim every component (its a11y greenlines and the
+// editable wireframe) before importing the tokens/images into a design tool.
+// Rendered from `indexManifest` (the written manifest, read above), NOT the
+// in-memory `catalog`: `renderIndexHtml` reads `component.images`, which only the
+// manifest carries — passing the in-memory catalog makes every card fall back to
+// the "no render" placeholder.
 const indexPath = join(outPath, "index.html");
 await writeFile(
   indexPath,
@@ -898,8 +988,17 @@ console.log(
   `[${spec.system}] ${catalog.components.length} component(s), ${result.imageCount} image(s), ` +
     `${wireframeCount} wireframe(s) (${layoutWireframeCount} from layout-inspector, ` +
     `${wireframeCount - layoutWireframeCount} greenline), ${figmaSvgCount} figma-svg ` +
-    `(${figmaRasterCount} raster crop(s)) → ${result.manifestPath}`,
+    `(${figmaRasterCount} raster crop(s)), ${figmaVariantSvgCount} per-variant figma-svg ` +
+    `→ ${result.manifestPath}`,
 );
+// An image with a previewId but no carried vector means the per-variant set is no longer 1:1 with
+// the raster set — surface it rather than letting the vector vanish quietly.
+if (figmaVariantGapCount) {
+  console.warn(
+    `[${spec.system}] ${figmaVariantGapCount} render(s) had no figma-svg carried for their ` +
+      `previewId — no per-variant vector emitted for those`,
+  );
+}
 console.log(`[${spec.system}] index → ${indexPath}`);
 console.log(`[${spec.system}] compare → ${comparePath}`);
 console.log(`[${spec.system}] readme → ${readmePath}`);


### PR DESCRIPTION
## Problem

The bundle already carries `previews/<id>.figma.svg` for **every** rendered preview —
`DaemonSemanticsFetcher.Outcome.Ok.figmaSvgById` is keyed by preview id with no theme
gating, and `injectFigmaSvgIntoBundle` writes one entry per id.

But `figmaSvgByFunction` collapses that map to one vector per component *function*,
preferring the light variant:

> Prefer the light variant so a single deterministic sticker is emitted per component.

So every dark / locale / size vector is rendered, carried across the wire, and then
dropped at the last step. A consumer wanting an editable dark vector has to fall back
to the raster PNG.

## Change

Ship them, mirroring the raster set 1:1:

    images/<slug>/ideal__default__dark__compact.png     (today)
    figma/<slug>/ideal__default__dark__compact.svg      (new)

- **`figmaSvgById(bundle)`** — the uncollapsed carry (`previewId → svg`).
  `figmaSvgByFunction` is untouched and now documented as the narrowing of it.
- **`figmaVariantSvgPath(imagePath)`** — `images/<slug>/<variant>.png` →
  `figma/<slug>/<variant>.svg`, rejecting anything that isn't a plain `images/…png`
  and any `..` / absolute / backslash / empty segment, so a hostile manifest can't
  write outside `figma/`.
- **The emit is driven from the written manifest's `images[]`**, not from a naming
  scheme of its own. Each image already carries the `previewId` that keys the bundle's
  vectors *and* the `path` the export engine chose, so the mapping inherits
  `imagePath`'s collision-safe naming and a vector cannot drift away from the PNG it
  depicts.
- **Gaps are reported.** An image with a `previewId` but no carried vector increments
  `figmaVariantGapCount` and warns. A silently missing vector is exactly the failure
  this emit exists to prevent.
- **Hybrid crops key on the variant basename**, not the component slug — two variants
  of one component each carry their own `<node>.png`, which a per-slug dir would
  overwrite. `rewriteRasterHrefs`' second arg is now a generic `key`; behaviour is
  unchanged for existing callers.

**Purely additive.** `figma/<slug>.svg` and its per-slug crop dir are written exactly
as before — `index.html`, `compare.html`, design-parity's `FIGMA_IMPORT.md` and
meshcore-mobile's seeding runbook all reference that path today. The back-compat file
lives *beside* the new `figma/<slug>/` directory, so they can't collide.

## Worth knowing

`previewId` is **not** universal on manifest images: `buildCatalog` doesn't emit it —
`bridgeLivePreviewIds` stamps it on, and that only runs for a carried live bundle or a
`--source-module`. The workflow always passes `--source-module`, so every published
catalog is covered, but a manual run without it emits zero per-variant vectors *and*
zero gaps. Documented in the block comment rather than papered over with a fallback
derivation.

Images `bridgeLivePreviewIds` deliberately leaves unbridged (a state with no desktop
source, or a function the Android-only supplement overrode) are skipped rather than
counted as gaps — there's no daemon-rendered vector for them to be missing.

Consumers aren't updated: `index.html` / `compare.html` / `README.md` still only link
`figma/<slug>.svg`, so the per-variant set ships on the branch but is unlinked. That
matches the additive scope; surfacing it to a browsing designer is the natural
follow-up.

## Test plan

- [x] `node --test "scripts/design-artifacts/*.test.mjs"` — **88 pass, 0 fail**
      (15 in `figma-svg-catalog.test.mjs`, 6 of them new: `figmaSvgById` keeps every
      variant / drops non-SVG payloads, `figmaVariantSvgPath` mapping + rejection
      table, variant-basename raster keying, and a manifest-driven emit test that
      asserts both the written set and the gap count)
- [x] every pre-existing assertion kept unchanged
- [x] `node --check scripts/design-artifacts/generate-design-catalog.mjs`
- [ ] a real `design-artifacts.yml` run — the generator needs the private
      `@design-parity/catalog-export` and a real render bundle, so it can't be
      smoke-run locally

Text-only evidence: this is export-driver plumbing, not a renderable surface — no
`@Preview` output, webview or overlay changes.

Unblocks the theme axis of yschimke/meshcore-mobile#261.