### PR TITLE
fix(design-artifacts): bridge preview ids from every render bundle, not just the primary

### DIFF
--- a/scripts/design-artifacts/bridge-live-preview-ids.mjs
+++ b/scripts/design-artifacts/bridge-live-preview-ids.mjs
@@ -67,7 +67,19 @@ function variantKey(componentId, state, props, theme) {
   return theme ? `${base}${NUL}theme=${theme}` : base;
 }
 
-export function bridgeLivePreviewIds(manifest, spec, bundle, overriddenFunctions) {
+/**
+ * [bundles] is every bundle whose previews can back this catalog — the primary render plus any
+ * `--extra-renders` supplement — mirroring how `figmaSvgByFunctions` folds them. A single bundle
+ * is accepted too, so existing callers keep working.
+ *
+ * Reading only the primary bundle silently dropped every `--extra-renders`-only component: its
+ * previews never entered the id maps below, so its images got no `previewId` at all. That is not
+ * cosmetic — `previewId` is what `ServeCatalogStore` aliases on (so those components had no live
+ * lane) and what the per-variant figma-svg emit keys on (so they got no editable vectors). It hid
+ * well because "no previewId" is also the legitimate outcome for a deliberately-unbridged image,
+ * so a wholly-unbridged component looked no different from an intentional skip.
+ */
+export function bridgeLivePreviewIds(manifest, spec, bundles, overriddenFunctions) {
   const previewForState = new Map();
   for (const group of spec.groups ?? []) {
     for (const component of group.components ?? []) {
@@ -94,11 +106,18 @@ export function bridgeLivePreviewIds(manifest, spec, bundle, overriddenFunctions
   // function (first wins — state variants never share a function).
   const daemonIdFor = new Map();
   const unthemedIdFor = new Map();
-  for (const preview of bundle.previews ?? []) {
-    const fn = preview.functionName ?? preview.id;
-    const theme = themeOfPreviewId(preview.id);
-    if (theme) daemonIdFor.set(`${fn}\0${theme}`, preview.id);
-    else if (!unthemedIdFor.has(fn)) unthemedIdFor.set(fn, preview.id);
+  // Earlier bundles win, matching `figmaSvgByFunctions`' fold: the primary render is the
+  // authority, and a supplement only contributes previews the primary doesn't have. Falsy
+  // entries are skipped so callers can pass `[bundle, extraBundle]` with no extra render.
+  for (const bundle of Array.isArray(bundles) ? bundles : [bundles]) {
+    if (!bundle) continue;
+    for (const preview of bundle.previews ?? []) {
+      const fn = preview.functionName ?? preview.id;
+      const theme = themeOfPreviewId(preview.id);
+      if (theme) {
+        if (!daemonIdFor.has(`${fn}\0${theme}`)) daemonIdFor.set(`${fn}\0${theme}`, preview.id);
+      } else if (!unthemedIdFor.has(fn)) unthemedIdFor.set(fn, preview.id);
+    }
   }
   let mapped = 0;
   for (const component of manifest.components ?? []) {

--- a/scripts/design-artifacts/bridge-live-preview-ids.test.mjs
+++ b/scripts/design-artifacts/bridge-live-preview-ids.test.mjs
@@ -241,6 +241,91 @@ test("theme and state coexist: a themed variant of a non-default state keys on b
   );
 });
 
+test("an --extra-renders-only component bridges from the supplementary bundle", () => {
+  // Regression: the bridge took a single bundle, so a component whose previews live ONLY in the
+  // `--extra-renders` supplement (a screen rendered from a second CMP-desktop module) got no
+  // `previewId` on any image — costing it both the live lane and, once the per-variant figma-svg
+  // emit keyed off previewId, every editable vector. It hid because "no previewId" is also the
+  // legitimate outcome for a deliberately-skipped image.
+  const spec = {
+    system: "meshcore-mobile",
+    groups: [
+      {
+        components: [
+          { componentId: "Button/Filled", preview: "FilledButton" },
+          { componentId: "Chat/Contact", preview: "ContactChatPreview" },
+        ],
+      },
+    ],
+  };
+  const primary = { previews: [{ id: "app.CatalogKt.FilledButton", functionName: "FilledButton" }] };
+  const extra = {
+    previews: [{ id: "cmp.ChatKt.ContactChatPreview", functionName: "ContactChatPreview" }],
+  };
+  const manifest = {
+    system: "meshcore-mobile",
+    components: [
+      { componentId: "Button/Filled", images: [{ state: "default" }] },
+      { componentId: "Chat/Contact", images: [{ state: "default" }] },
+    ],
+  };
+
+  bridgeLivePreviewIds(manifest, spec, [primary, extra], new Set());
+
+  assert.equal(manifest.components[0].images[0].previewId, "app.CatalogKt.FilledButton");
+  // The one that used to come back undefined.
+  assert.equal(manifest.components[1].images[0].previewId, "cmp.ChatKt.ContactChatPreview");
+});
+
+test("a falsy bundle in the list is skipped (no --extra-renders)", () => {
+  const spec = {
+    system: "wear-m3",
+    groups: [{ components: [{ componentId: "Button/Filled", preview: "FilledButton" }] }],
+  };
+  const bundle = { previews: [{ id: "pkg.CatalogKt.FilledButton", functionName: "FilledButton" }] };
+  const manifest = {
+    system: "wear-m3",
+    components: [{ componentId: "Button/Filled", images: [{ state: "default" }] }],
+  };
+
+  bridgeLivePreviewIds(manifest, spec, [bundle, null], new Set());
+
+  assert.equal(manifest.components[0].images[0].previewId, "pkg.CatalogKt.FilledButton");
+});
+
+test("the primary bundle wins when both carry the same function", () => {
+  const spec = {
+    system: "meshcore-mobile",
+    groups: [{ components: [{ componentId: "Button/Filled", preview: "FilledButton" }] }],
+  };
+  const primary = { previews: [{ id: "app.CatalogKt.FilledButton", functionName: "FilledButton" }] };
+  const extra = { previews: [{ id: "cmp.CatalogKt.FilledButton", functionName: "FilledButton" }] };
+  const manifest = {
+    system: "meshcore-mobile",
+    components: [{ componentId: "Button/Filled", images: [{ state: "default" }] }],
+  };
+
+  bridgeLivePreviewIds(manifest, spec, [primary, extra], new Set());
+
+  assert.equal(manifest.components[0].images[0].previewId, "app.CatalogKt.FilledButton");
+});
+
+test("a bare bundle (not an array) is still accepted", () => {
+  const spec = {
+    system: "wear-m3",
+    groups: [{ components: [{ componentId: "Button/Filled", preview: "FilledButton" }] }],
+  };
+  const bundle = { previews: [{ id: "pkg.CatalogKt.FilledButton", functionName: "FilledButton" }] };
+  const manifest = {
+    system: "wear-m3",
+    components: [{ componentId: "Button/Filled", images: [{ state: "default" }] }],
+  };
+
+  bridgeLivePreviewIds(manifest, spec, bundle, new Set());
+
+  assert.equal(manifest.components[0].images[0].previewId, "pkg.CatalogKt.FilledButton");
+});
+
 test("overridden functions (Android-only supplement) get no daemon id", () => {
   const spec = {
     system: "wear-m3",

--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -634,7 +634,10 @@ if (values["publish-live-bundle"]) {
   // too: `ServeCatalogStore` builds the alias solely from `image.previewId`, so without this a
   // `--allow-render-trusted` box would pay the Gradle build yet reach the daemon for no catalog id.
   if (liveBundle || values["source-module"]) {
-    bridgeLivePreviewIds(manifest, spec, bundle, overriddenFunctions);
+    // Both bundles: an `--extra-renders`-only component's previews live solely in the
+    // supplement, so passing just the primary left every one of its images with no
+    // `previewId` — no live lane for it, and no per-variant figma-svg.
+    bridgeLivePreviewIds(manifest, spec, [bundle, extraBundle], overriddenFunctions);
   }
   await writeFile(catalogJsonPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
 }
@@ -780,8 +783,19 @@ for (const component of catalog.components) {
 const figmaSvgsById = figmaSvgByIds([bundle, extraBundle]);
 let figmaVariantSvgCount = 0;
 let figmaVariantGapCount = 0;
+// Components with at least one image carrying no `previewId`. Some of those are legitimate
+// (`bridgeLivePreviewIds` deliberately skips a state with no desktop source, and any function
+// the Android-only supplement overrode) — but a component where NONE of the images bridged is
+// the signature of a whole bundle never reaching the bridge, which is how the
+// `--extra-renders` module silently lost every per-variant vector once already. Silence is
+// what made that expensive, so name them.
+const unbridgedComponents = new Map();
 for (const component of indexManifest.components ?? []) {
   for (const image of component.images ?? []) {
+    const seen = unbridgedComponents.get(component.componentId) ?? { unbridged: 0, total: 0 };
+    seen.total += 1;
+    if (!image.previewId) seen.unbridged += 1;
+    unbridgedComponents.set(component.componentId, seen);
     if (!image.previewId) continue;
     const target = figmaVariantSvgPath(image.path);
     if (!target) continue;
@@ -997,6 +1011,32 @@ if (figmaVariantGapCount) {
   console.warn(
     `[${spec.system}] ${figmaVariantGapCount} render(s) had no figma-svg carried for their ` +
       `previewId — no per-variant vector emitted for those`,
+  );
+}
+// An image with NO previewId never even reaches the vector lookup. Some of that is deliberate
+// (a state with no desktop source, a function the Android-only supplement overrode), so this is
+// informational — but a component where EVERY image is unbridged means its previews never
+// reached `bridgeLivePreviewIds` at all, which costs it both the live lane and its per-variant
+// vectors. That failure shipped once precisely because it was silent, so name the components.
+const fullyUnbridged = [...unbridgedComponents]
+  .filter(([, c]) => c.unbridged === c.total)
+  .map(([id]) => id);
+const partiallyUnbridged = [...unbridgedComponents].filter(
+  ([, c]) => c.unbridged > 0 && c.unbridged < c.total,
+).length;
+if (fullyUnbridged.length) {
+  const shown = fullyUnbridged.slice(0, 8).join(", ");
+  const more = fullyUnbridged.length > 8 ? `, +${fullyUnbridged.length - 8} more` : "";
+  console.warn(
+    `[${spec.system}] ${fullyUnbridged.length} component(s) had NO image bridged to a preview ` +
+      `id — no live lane and no per-variant vectors for them: ${shown}${more}. If that is a whole ` +
+      `module, check every render bundle is passed to bridgeLivePreviewIds.`,
+  );
+}
+if (partiallyUnbridged) {
+  console.log(
+    `[${spec.system}] ${partiallyUnbridged} component(s) had some images unbridged ` +
+      `(expected for states with no desktop source or overridden by the supplement)`,
   );
 }
 console.log(`[${spec.system}] index → ${indexPath}`);


### PR DESCRIPTION
## The bug

`bridgeLivePreviewIds` took a **single** bundle:

```js
bridgeLivePreviewIds(manifest, spec, bundle, overriddenFunctions);
```

So a component whose previews live only in the `--extra-renders` supplement never entered
the daemon-id maps, and got **no `previewId` on any image**.

That is not cosmetic:

- `previewId` is what `ServeCatalogStore` aliases on → those components had **no live lane**;
- since #2653 it is also what the per-variant figma-svg emit keys on → they produced
  **zero editable vectors**.

## Caught in production, one run after #2653

meshcore-mobile's first regenerate after #2653 published 70 per-variant vectors — all for
`:app` components, **none for any screen**. The unbridged set was exactly its
`:meshcore-components` supplement:

    Chat/Contact (3)  Chat/Channel (3)  Chat/Commands (3)
    Device/Cached (5)  Settings/Ready (5)          = 19 images

…which are precisely that repo's five design-parity subjects, across their theme and locale
variants. The run log read `bridged 70 live preview id(s) → daemon` against `89 image(s)`
and reported success.

It hid because **"no previewId" is also the legitimate outcome** for a deliberately-unbridged
image — a state with no desktop source, or a function the Android-only supplement overrode —
so a wholly-unbridged component was indistinguishable from an intentional skip. (The symptom
was visible even before #2653: those components have carried `"previewId": null` in the
published `catalog.json` all along, which reads as "hand-authored, no live preview".)

## Fix

Take `bundles` and fold them the way `figmaSvgByFunctions` already does — primary wins on a
clash, falsy entries skipped so `[bundle, extraBundle]` works with no extra render. A bare
bundle is still accepted, so any other caller is unaffected.

**Plus: make the silence visible.** The emit now warns naming components where *no* image
bridged — the signature of a whole bundle never reaching the bridge — and reports partial
unbridging separately, at `log` level, as the expected case:

    [meshcore-mobile] 5 component(s) had NO image bridged to a preview id — no live lane
      and no per-variant vectors for them: Chat/Contact, Chat/Channel, … If that is a whole
      module, check every render bundle is passed to bridgeLivePreviewIds.

Silence is what made this expensive; a warning would have surfaced it on the first run.

## Test plan

- [x] `node --test "scripts/design-artifacts/*.test.mjs"` — **181 pass, 0 fail**
- [x] Four new tests; **the three multi-bundle ones fail against the unfixed bridge**
      (verified by reverting the source and re-running):
  - an `--extra-renders`-only component bridges from the supplementary bundle ← the regression
  - a falsy bundle in the list is skipped (no `--extra-renders`)
  - the primary bundle wins when both carry the same function
  - a bare bundle (not an array) is still accepted ← back-compat, passes either way
- [x] all seven pre-existing bridge tests unchanged and passing

Text-only evidence: catalog-manifest plumbing, no renderable surface changes.

## After merge

meshcore-mobile needs a `design-artifacts.yml` re-dispatch to actually publish the missing
screen vectors — its last run is the one that surfaced this.