### PR TITLE
fix(cli): strip manifest &lt;application android:name&gt; for the daemon render

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/AndroidBundleResources.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/AndroidBundleResources.kt
@@ -210,10 +210,10 @@ internal object AndroidBundleResources {
 
     return runCatching {
         val writer = StringWriter()
-        TransformerFactory.newInstance().newTransformer().apply {
-          setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "no")
-        }
-        .transform(DOMSource(doc), StreamResult(writer))
+        TransformerFactory.newInstance()
+          .newTransformer()
+          .apply { setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "no") }
+          .transform(DOMSource(doc), StreamResult(writer))
         writer.toString()
       }
       .getOrNull()

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/AndroidBundleResources.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/AndroidBundleResources.kt
@@ -2,7 +2,14 @@ package ee.schimke.composeai.cli
 
 import java.io.ByteArrayInputStream
 import java.io.File
+import java.io.StringWriter
 import java.util.zip.ZipInputStream
+import javax.xml.parsers.DocumentBuilderFactory
+import javax.xml.transform.OutputKeys
+import javax.xml.transform.TransformerFactory
+import javax.xml.transform.dom.DOMSource
+import javax.xml.transform.stream.StreamResult
+import org.w3c.dom.Element
 
 /**
  * The Android app-resource carriage a **packed bundle** carries under `android/`, and the wiring
@@ -108,16 +115,107 @@ internal object AndroidBundleResources {
    */
   fun daemonClasspath(zipBytes: ByteArray, workDir: File, applicationPackage: String?): List<File> {
     val res = extract(zipBytes, File(workDir, "android")) ?: return emptyList()
+    // Neutralize the merged manifest's `<application android:name>` before handing it to
+    // Robolectric — see [sanitizeManifestForDaemon]. The daemon pins `android.app.Application`
+    // (SandboxHoldingRunner.buildGlobalConfig), so the consumer Application never runs; but
+    // Robolectric still *resolves* the manifest-declared class name at sandbox bootstrap, and a
+    // custom `Application` that the bundle doesn't pack (the common case — an app's own
+    // `Application` subclass) then throws `ClassNotFoundException` and aborts the whole sandbox
+    // pool, collapsing the live lane to baked PNGs. Stripping the attribute keeps bootstrap on the
+    // framework `android.app.Application`, matching the config pin.
+    val manifestForConfig = sanitizeManifestForDaemon(res.mergedManifest)
     val testConfigDir =
       writeTestConfig(
         File(workDir, "test-config"),
         res.resourceApk,
-        res.mergedManifest,
+        manifestForConfig,
         applicationPackage,
       )
     return buildList {
       add(testConfigDir)
       res.rClassesJar?.let { add(it) }
     }
+  }
+
+  /** The Android resource namespace `android:*` attributes are qualified by. */
+  private const val ANDROID_NS = "http://schemas.android.com/apk/res/android"
+
+  /**
+   * Return a manifest file for the daemon's `android_merged_manifest` whose `<application>` no
+   * longer declares an `android:name`. When [mergedManifest] has no application-name attribute
+   * (default `Application`, or already stripped), or when it can't be parsed, [mergedManifest] is
+   * returned unchanged — so a bundle whose manifest was already daemon-safe pays no cost and a
+   * malformed manifest degrades to the pre-sanitize behaviour rather than the render failing here.
+   *
+   * The stripped copy is written next to the original as `AndroidManifest-daemon.xml` so the raw
+   * merged manifest stays on disk for diagnostics. Only `android:name` is removed; `android:theme`,
+   * `android:label`, and every child element (`<activity>`, `<service>`, …) are preserved — those
+   * are resolved lazily (only when launched), so they never fire at bootstrap the way the
+   * `Application` does.
+   */
+  private fun sanitizeManifestForDaemon(mergedManifest: File): File {
+    val original = runCatching { mergedManifest.readText() }.getOrNull() ?: return mergedManifest
+    val stripped = stripApplicationName(original) ?: return mergedManifest
+    val dest = File(mergedManifest.parentFile, "AndroidManifest-daemon.xml")
+    return runCatching {
+        dest.writeText(stripped)
+        System.err.println(
+          "[android-bundle] stripped <application android:name> from the daemon manifest " +
+            "(previews run on android.app.Application; the consumer Application is not bootstrapped)"
+        )
+        dest
+      }
+      .getOrDefault(mergedManifest)
+  }
+
+  /**
+   * Remove the `android:name` attribute from every `<application>` element in [manifestXml].
+   * Returns the rewritten XML when at least one attribute was removed, or `null` when there was
+   * nothing to strip (no `<application android:name>`) or the document couldn't be parsed — the
+   * caller treats `null` as "use the manifest as-is". Namespace-aware and XXE-safe (DOCTYPE and
+   * external entities disabled), so a hostile or unusual manifest can't reach the network or blow
+   * up parsing.
+   */
+  internal fun stripApplicationName(manifestXml: String): String? {
+    val doc =
+      runCatching {
+          val factory =
+            DocumentBuilderFactory.newInstance().apply {
+              isNamespaceAware = true
+              // XXE hardening: no DTDs, no external entities.
+              runCatching {
+                setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)
+              }
+              runCatching {
+                setFeature("http://xml.org/sax/features/external-general-entities", false)
+              }
+              runCatching {
+                setFeature("http://xml.org/sax/features/external-parameter-entities", false)
+              }
+            }
+          factory.newDocumentBuilder().parse(ByteArrayInputStream(manifestXml.toByteArray()))
+        }
+        .getOrNull() ?: return null
+
+    val applications = doc.getElementsByTagName("application")
+    var removedAny = false
+    for (i in 0 until applications.length) {
+      val app = applications.item(i) as? Element ?: continue
+      if (app.hasAttributeNS(ANDROID_NS, "name")) {
+        app.removeAttributeNS(ANDROID_NS, "name")
+        removedAny = true
+      }
+    }
+    if (!removedAny) return null
+
+    return runCatching {
+        val writer = StringWriter()
+        TransformerFactory.newInstance().newTransformer().apply {
+          setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "no")
+        }
+        .transform(DOMSource(doc), StreamResult(writer))
+        writer.toString()
+      }
+      .getOrNull()
   }
 }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/AndroidBundleResources.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/AndroidBundleResources.kt
@@ -112,8 +112,21 @@ internal object AndroidBundleResources {
    * return the classpath entries (the `test-config` dir + optional `r-classes.jar`) to prepend to
    * the Robolectric daemon's `-cp`. Empty when the bundle carries no `android/` payload — the
    * render then falls back to framework resources only (unchanged pre-carriage behaviour).
+   *
+   * [useConsumerApplication] mirrors the daemon's own `composeai.daemon.useConsumerApplication`
+   * opt-in (read by `SandboxHoldingRunner.buildGlobalConfig`). It must carry the SAME value the
+   * caller forwards to the daemon subprocess: when the daemon is told to run the consumer's
+   * manifest `Application` (`true`), the manifest name is left intact so that opt-in works; when
+   * the daemon pins the framework `android.app.Application` (`false`, the default and the only
+   * value any current CLI path uses), the name is stripped so bootstrap can't crash on it. Pass it
+   * and the daemon `-D` from one source so the two never disagree.
    */
-  fun daemonClasspath(zipBytes: ByteArray, workDir: File, applicationPackage: String?): List<File> {
+  fun daemonClasspath(
+    zipBytes: ByteArray,
+    workDir: File,
+    applicationPackage: String?,
+    useConsumerApplication: Boolean = false,
+  ): List<File> {
     val res = extract(zipBytes, File(workDir, "android")) ?: return emptyList()
     // Neutralize the merged manifest's `<application android:name>` before handing it to
     // Robolectric — see [sanitizeManifestForDaemon]. The daemon pins `android.app.Application`
@@ -122,8 +135,12 @@ internal object AndroidBundleResources {
     // custom `Application` that the bundle doesn't pack (the common case — an app's own
     // `Application` subclass) then throws `ClassNotFoundException` and aborts the whole sandbox
     // pool, collapsing the live lane to baked PNGs. Stripping the attribute keeps bootstrap on the
-    // framework `android.app.Application`, matching the config pin.
-    val manifestForConfig = sanitizeManifestForDaemon(res.mergedManifest)
+    // framework `android.app.Application`, matching the config pin. When the daemon opts into the
+    // consumer Application ([useConsumerApplication]), the manifest is handed over untouched so the
+    // opt-in — which requires a Robolectric-safe, packed Application — still resolves and runs.
+    val manifestForConfig =
+      if (useConsumerApplication) res.mergedManifest
+      else sanitizeManifestForDaemon(res.mergedManifest)
     val testConfigDir =
       writeTestConfig(
         File(workDir, "test-config"),

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/AndroidBundleResourcesTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/AndroidBundleResourcesTest.kt
@@ -125,4 +125,62 @@ class AndroidBundleResourcesTest {
 
     assertTrue(AndroidBundleResources.daemonClasspath(zip, dir, null).isEmpty())
   }
+
+  // --- <application android:name> sanitization (fix for the custom-Application boot crash) ---
+
+  private val androidNs = "xmlns:android=\"http://schemas.android.com/apk/res/android\""
+
+  @Test
+  fun `stripApplicationName removes a custom application name`() {
+    val xml =
+      """<manifest $androidNs package="ee.schimke.meshcore.app">
+           <application android:name=".MeshcoreApp" android:theme="@style/T"/>
+         </manifest>"""
+    val out = AndroidBundleResources.stripApplicationName(xml)
+    assertTrue(out != null, "expected a rewrite")
+    assertTrue(!out!!.contains("MeshcoreApp"), out)
+    // The theme (and every other attribute) survives — only android:name is removed.
+    assertTrue(out.contains("@style/T"), out)
+  }
+
+  @Test
+  fun `stripApplicationName returns null when there is no application name to strip`() {
+    val xml =
+      """<manifest $androidNs package="com.example">
+           <application android:theme="@style/T"/>
+         </manifest>"""
+    assertNull(AndroidBundleResources.stripApplicationName(xml))
+  }
+
+  @Test
+  fun `stripApplicationName returns null for an unparseable manifest`() {
+    assertNull(AndroidBundleResources.stripApplicationName("<manifest><application"))
+  }
+
+  @Test
+  fun `daemonClasspath points test-config at a manifest with no custom application name`() {
+    val dir = Files.createTempDirectory("abr-sanitize").toFile()
+    val manifest =
+      """<manifest $androidNs package="ee.schimke.meshcore.app">
+           <application android:name="ee.schimke.meshcore.app.MeshcoreApp"/>
+         </manifest>"""
+    val zip =
+      zipOf(
+        mapOf(
+          "android/resources.ap_" to "APK".toByteArray(),
+          "android/AndroidManifest.xml" to manifest.toByteArray(),
+        )
+      )
+
+    val cp = AndroidBundleResources.daemonClasspath(zip, dir, "ee.schimke.meshcore.app")
+
+    val props = File(cp[0], "com/android/tools/test_config.properties").readText()
+    val manifestPath =
+      props.lineSequence().first { it.startsWith("android_merged_manifest=") }.substringAfter('=')
+    val handedToRobolectric = File(manifestPath).readText()
+    assertTrue(
+      !handedToRobolectric.contains("MeshcoreApp"),
+      "the daemon manifest must not name a consumer Application: $handedToRobolectric",
+    )
+  }
 }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/AndroidBundleResourcesTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/AndroidBundleResourcesTest.kt
@@ -157,30 +157,60 @@ class AndroidBundleResourcesTest {
     assertNull(AndroidBundleResources.stripApplicationName("<manifest><application"))
   }
 
-  @Test
-  fun `daemonClasspath points test-config at a manifest with no custom application name`() {
-    val dir = Files.createTempDirectory("abr-sanitize").toFile()
+  private fun bundleWithApplicationManifest(): ByteArray {
     val manifest =
       """<manifest $androidNs package="ee.schimke.meshcore.app">
            <application android:name="ee.schimke.meshcore.app.MeshcoreApp"/>
          </manifest>"""
-    val zip =
-      zipOf(
-        mapOf(
-          "android/resources.ap_" to "APK".toByteArray(),
-          "android/AndroidManifest.xml" to manifest.toByteArray(),
-        )
+    return zipOf(
+      mapOf(
+        "android/resources.ap_" to "APK".toByteArray(),
+        "android/AndroidManifest.xml" to manifest.toByteArray(),
       )
+    )
+  }
 
-    val cp = AndroidBundleResources.daemonClasspath(zip, dir, "ee.schimke.meshcore.app")
-
-    val props = File(cp[0], "com/android/tools/test_config.properties").readText()
+  private fun manifestHandedToRobolectric(configRoot: File): String {
+    val props = File(configRoot, "com/android/tools/test_config.properties").readText()
     val manifestPath =
       props.lineSequence().first { it.startsWith("android_merged_manifest=") }.substringAfter('=')
-    val handedToRobolectric = File(manifestPath).readText()
+    return File(manifestPath).readText()
+  }
+
+  @Test
+  fun `daemonClasspath points test-config at a manifest with no custom application name`() {
+    val dir = Files.createTempDirectory("abr-sanitize").toFile()
+
+    val cp =
+      AndroidBundleResources.daemonClasspath(
+        bundleWithApplicationManifest(),
+        dir,
+        "ee.schimke.meshcore.app",
+      )
+
     assertTrue(
-      !handedToRobolectric.contains("MeshcoreApp"),
-      "the daemon manifest must not name a consumer Application: $handedToRobolectric",
+      !manifestHandedToRobolectric(cp[0]).contains("MeshcoreApp"),
+      "the daemon manifest must not name a consumer Application",
+    )
+  }
+
+  @Test
+  fun `daemonClasspath keeps the consumer application name when the daemon opts in`() {
+    val dir = Files.createTempDirectory("abr-optin").toFile()
+
+    // useConsumerApplication=true mirrors composeai.daemon.useConsumerApplication — the daemon will
+    // run the manifest Application, so the name must survive the manifest we hand it.
+    val cp =
+      AndroidBundleResources.daemonClasspath(
+        bundleWithApplicationManifest(),
+        dir,
+        "ee.schimke.meshcore.app",
+        useConsumerApplication = true,
+      )
+
+    assertTrue(
+      manifestHandedToRobolectric(cp[0]).contains("MeshcoreApp"),
+      "the opt-in must preserve the consumer Application declaration",
     )
   }
 }


### PR DESCRIPTION
## Summary

The Android live daemon points Robolectric at the bundle's merged manifest via `android_merged_manifest` (`AndroidBundleResources.daemonClasspath`, used by both `ServeBundleDaemon` and `BundleDaemonCommand`). Robolectric **resolves** the manifest-declared `<application android:name>` class at sandbox bootstrap — before any render — even though the daemon already pins `android.app.Application` (`SandboxHoldingRunner.buildGlobalConfig`) so the consumer `Application` never actually runs.

When the consumer's custom `Application` (an app's own subclass) is **not packed** into the bundle — the common case — that eager resolution throws `ClassNotFoundException` and aborts the **whole sandbox pool**, so the live lane collapses to baked PNGs. On the public preview server this is the meshcore-mobile "can't render / `livebundle-unavailable`" banner:

```
java.lang.ClassNotFoundException: Could not find a class for package: ee.schimke.meshcore.app
  and class name: ee.schimke.meshcore.app.MeshcoreApp
```

`wear-m3` (also Android/Robolectric) boots fine because its sample manifest declares no custom `Application` — confirming this is specific to consumers with an unpacked `android:name`.

## Fix

Sanitize the manifest handed to the daemon by removing `<application android:name>` before writing `test_config.properties`. Bootstrap then stays on the framework `android.app.Application`, matching the config pin that's already in place. This is a manifest-layer mirror of `buildGlobalConfig`'s stub-`Application` pin — previews never run consumer `onCreate` anyway, so the app name only ever risked the crash.

- Namespace-aware, XXE-safe parse (DOCTYPE + external entities disabled).
- Only `android:name` is removed; `android:theme`, `android:label`, and every child element (`<activity>`, `<service>`, `<receiver>`, …) are preserved. Those are resolved lazily (only when launched), so they never fire at bootstrap.
- A manifest with no custom `Application` name, or an unparseable one, is passed through unchanged — no behaviour change for already-safe bundles, graceful degradation on a malformed one.

## Test plan

`./gradlew :cli:test --tests "ee.schimke.composeai.cli.AndroidBundleResourcesTest"` — 11 passing (7 existing + 4 new):

- `stripApplicationName removes a custom application name` (theme/other attrs survive)
- `stripApplicationName returns null when there is no application name to strip`
- `stripApplicationName returns null for an unparseable manifest`
- `daemonClasspath points test-config at a manifest with no custom application name`

Non-visual change (daemon/manifest plumbing) — no rendered-preview surface, so no before/after images.


---
_Generated by [Claude Code](https://claude.ai/code/session_018B1heEfDkyWdqj4cgRuy2U)_