### PR TITLE
feat(design-artifacts): add embed-deps input to the reusable export workflow

### DIFF
--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -87,6 +87,11 @@ on:
         required: false
         type: boolean
         default: false
+      embed-deps:
+        description: 'Pass --embed-deps to bundle pack so reachable third-party jars are carried inside the bundle under libs/ instead of referenced as Maven coordinates. Needed with publish-live-bundle when the module depends on artifacts the serve box cannot resolve from Maven Central (e.g. JitPack-only deps): without it the live daemon fails to build its classpath and the catalog silently falls back to baked PNGs (livebundle-unavailable). Larger bundle; leave off when every dep is on Central.'
+        required: false
+        type: boolean
+        default: false
       split-per-preview:
         description: 'After generate, split the render into one addressable bundle per preview under bundle/previews/<id>, for the serve host per-preview live lane. The extra module (if any) is split --view-only (baked, no per-preview re-render classpath). full mode requires publish-live-bundle (see split-mode).'
         required: false
@@ -278,16 +283,18 @@ jobs:
         run: |
           set -euo pipefail
           run() { if [ "${{ inputs.desktop-render }}" = "true" ]; then xvfb-run -a -s "-screen 0 2000x1400x24" "$@"; else "$@"; fi; }
+          embed=(); if [ "${{ inputs.embed-deps }}" = "true" ]; then embed=(--embed-deps); fi
           run compose-preview bundle pack --module "${{ inputs.module }}" --with-semantics \
-            -o "$GITHUB_WORKSPACE/bundle.png" --timeout 600
+            "${embed[@]}" -o "$GITHUB_WORKSPACE/bundle.png" --timeout 600
 
       - name: Render extra module
         if: ${{ inputs.extra-module != '' }}
         run: |
           set -euo pipefail
           run() { if [ "${{ inputs.desktop-render }}" = "true" ]; then xvfb-run -a -s "-screen 0 2000x1400x24" "$@"; else "$@"; fi; }
+          embed=(); if [ "${{ inputs.embed-deps }}" = "true" ]; then embed=(--embed-deps); fi
           run compose-preview bundle pack --module "${{ inputs.extra-module }}" --with-semantics \
-            -o "$GITHUB_WORKSPACE/extra-bundle.png" --timeout 600
+            "${embed[@]}" -o "$GITHUB_WORKSPACE/extra-bundle.png" --timeout 600
 
       - name: Generate importable catalog
         run: |


### PR DESCRIPTION
## Summary

A consumer catalog whose module pulls artifacts the preview server **can't resolve from Maven Central** — e.g. JitPack-only deps like `usb-serial-for-android` — publishes a `liveBundle` that references those as bare Maven coordinates. On `preview.coo.ee` the live daemon then can't build its classpath, so the catalog **silently falls back to baked PNGs** (`livebundle-unavailable`) even with `publish-live-bundle: true`.

The CLI's `bundle pack` already solves this with `--embed-deps` (carry reachable third-party jars inside the bundle under `libs/`), but the reusable export workflow never exposed it. This adds an **`embed-deps`** boolean input and threads `--embed-deps` into both `bundle pack` invocations (primary + extra module).

Opt-in, default `false` — no change for catalogs whose deps are all on Central (`compose-m3`, `wear-m3`, …). The consumer this unblocks is **meshcore-mobile**, which declares `maven("https://jitpack.io")` and whose live daemon currently fails to stand up on the public server for exactly this reason (its manifest-`Application` blocker was already fixed in v0.17.9 #2659; the classpath one is what remains).

## Test plan
Workflow-only change. `embed-deps: false` (default) produces byte-identical `bundle pack` commands to today; `embed-deps: true` appends `--embed-deps`, which `BundleCommand` maps to `-PbundleEmbedDeps=true`. Verified against the `bundle pack` flag contract. The end-to-end proof is meshcore-mobile's next regen (its consumer PR sets `embed-deps: true`) clearing `livebundle-unavailable` on preview.coo.ee.


---
_Generated by [Claude Code](https://claude.ai/code/session_018B1heEfDkyWdqj4cgRuy2U)_