### PR TITLE
feat(serve): resolve live-bundle deps from extra Maven repos (SERVE_EXTRA_MAVEN_REPOS)

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
@@ -59,6 +59,7 @@ internal object CliFlags {
       "--bundles",
       "--bundle",
       "--accept-bundles-from",
+      "--extra-maven-repos",
       "--trust-store",
       "--catalogs",
       "--catalogs-unlisted",

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -194,6 +194,20 @@ class ServeCommand(args: List<String>) : Command(args) {
       ?.filter { it.isNotEmpty() } ?: emptyList()
 
   /**
+   * Extra remote Maven repository base URLs the live-daemon classpath resolver may fetch from, on
+   * top of Maven Central + Google Maven (`--extra-maven-repos <url>[,<url>…]`; env
+   * `SERVE_EXTRA_MAVEN_REPOS`). A served catalog whose module pulls deps from a non-default repo —
+   * e.g. `https://jitpack.io`, an Apollo/JetBrains snapshot repo — otherwise has those coordinates
+   * skipped by the resolver, leaving the daemon's classpath incomplete so a class that references
+   * them fails at bootstrap and the catalog falls back to baked PNGs (`livebundle-unavailable`).
+   * Empty by default. Operator-curated: only repos the deployer trusts should be listed, since the
+   * server will fetch artifacts from them when resolving a trusted catalog's live bundle.
+   */
+  private val extraMavenRepos: List<String> =
+    args.flagValue("--extra-maven-repos")?.split(",")?.map { it.trim() }?.filter { it.isNotEmpty() }
+      ?: emptyList()
+
+  /**
    * Path to the producer-trust store (`--trust-store <file>`): the JSON allowlist of trusted
    * signing keys / branches / CI identities ([TrustStore]). Uploaded bundles are verified against
    * it and the verdict is surfaced in the API + viewer. Absent ⇒ the empty, fail-closed store
@@ -910,7 +924,13 @@ class ServeCommand(args: List<String>) : Command(args) {
       // the bundle (no build); a non-desktop/foreign/empty bundle returns null → falls to baked.
       if (allowRenderTrusted && verdict is BundleVerifier.Verdict.Trusted) {
         val destDir = File(root, "${spec.name}-live").apply { mkdirs() }
-        val state = ServeBundleDaemon.materialize(bundleFile, destDir, spec.name)
+        val state =
+          ServeBundleDaemon.materialize(
+            bundleFile,
+            destDir,
+            spec.name,
+            extraMavenRepos = extraMavenRepos,
+          )
         val host = state?.let { openHost(it) }
         if (state != null && host != null) {
           registry.register(spec.name, state, host = host)
@@ -1115,6 +1135,7 @@ class ServeCommand(args: List<String>) : Command(args) {
           ppFile,
           ppDest,
           system,
+          extraMavenRepos = extraMavenRepos,
           extraClasspathDirs = listOfNotNull(externalResourcesDir),
         ) ?: return@ServePerPreviewDaemonPool null
       openHost(ppState)
@@ -1131,6 +1152,7 @@ class ServeCommand(args: List<String>) : Command(args) {
           bundleFile,
           destDir,
           system,
+          extraMavenRepos = extraMavenRepos,
           extraClasspathDirs = listOfNotNull(externalResourcesDir),
         )
         ?.copy(

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt
@@ -95,6 +95,16 @@ internal object ServeBundleDaemon {
     system: String,
     offline: Boolean = false,
     /**
+     * Extra remote Maven repository base URLs the classpath resolver may fetch from, in addition to
+     * Maven Central + Google Maven ([CoordinateResolver.DEFAULT_REMOTE_REPOSITORIES]). A catalog
+     * whose module pulls deps from a non-default repo (e.g. `https://jitpack.io`, an
+     * Apollo/JetBrains snapshot repo) would otherwise have those coordinates skipped — leaving the
+     * live daemon's classpath incomplete, so a class that references them fails at bootstrap and
+     * the catalog silently falls back to baked PNGs. Empty by default (Central + Google only); the
+     * serve host passes its `--extra-maven-repos` / `SERVE_EXTRA_MAVEN_REPOS` list here.
+     */
+    extraMavenRepos: List<String> = emptyList(),
+    /**
      * Extra classpath directories prepended after the bundle's own `classes/` — the rehydrated
      * [BundleReader.Manifest.externalResources] pool (fonts lifted out of `classes/app.jar` by
      * `bundle externalize`, materialized at their original resource paths so
@@ -158,6 +168,9 @@ internal object ServeBundleDaemon {
       CoordinateResolver(
           warn = { onLog("catalog $system: $it") },
           networkEnabled = if (offline) false else CoordinateResolver.defaultNetworkEnabled(),
+          remoteRepositories =
+            CoordinateResolver.DEFAULT_REMOTE_REPOSITORIES +
+              extraMavenRepos.filter { it.isNotBlank() },
         )
         .resolveAll(mavenCoords)
         .mapNotNull { it.file }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/CoordinateResolverTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/CoordinateResolverTest.kt
@@ -12,6 +12,7 @@ import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -72,6 +73,45 @@ class CoordinateResolverTest {
       remoteRepositories = listOf(base),
       downloadCacheDir = cacheDir,
     )
+
+  @Test
+  fun `an extra repo beyond the primary ones resolves a coord the primary repos miss`() {
+    // Two loopback Maven repos ordered [primary, extra] — the exact shape ServeBundleDaemon passes
+    // as DEFAULT_REMOTE_REPOSITORIES + extraMavenRepos. The primary 404s the coordinate (Central /
+    // Google don't serve a JitPack-only dep); the extra serves it, so resolution falls through.
+    val jar = byteArrayOf(4, 2)
+    val primary = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+    primary.createContext("/") { ex ->
+      ex.sendResponseHeaders(404, -1)
+      ex.close()
+    }
+    primary.start()
+    val extra = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+    extra.createContext("/") { ex ->
+      ex.sendResponseHeaders(200, jar.size.toLong())
+      ex.responseBody.use { it.write(jar) }
+    }
+    extra.start()
+    try {
+      val resolver =
+        CoordinateResolver(
+          repositoryRoots = listOf(root),
+          warn = { warnings += it },
+          networkEnabled = true,
+          remoteRepositories =
+            listOf(
+              "http://127.0.0.1:${primary.address.port}",
+              "http://127.0.0.1:${extra.address.port}",
+            ),
+          downloadCacheDir = cacheDir,
+        )
+      val file = assertNotNull(resolver.resolve(maven()).file, "should resolve from the extra repo")
+      assertEquals(jar.toList(), file.readBytes().toList())
+    } finally {
+      primary.stop(0)
+      extra.stop(0)
+    }
+  }
 
   private fun maven(sha: String? = null) =
     BundleReader.ClasspathEntry.Maven(

--- a/deploy/image/entrypoint.sh
+++ b/deploy/image/entrypoint.sh
@@ -130,6 +130,17 @@ if [[ "${SERVE_ACCEPT_BUNDLES:-}" == "1" || "${SERVE_ACCEPT_BUNDLES:-}" == "true
     args+=(--accept-bundles-from "${SERVE_ACCEPT_BUNDLES_FROM}")
 fi
 
+# Extra Maven repositories the live-daemon classpath resolver may fetch from, beyond Maven Central +
+# Google Maven. A served catalog whose module pulls deps from a non-default repo (e.g.
+# meshcore-mobile's jitpack.io deps like usb-serial-for-android) otherwise has those coordinates
+# skipped, so its live daemon can't build its classpath and the catalog falls back to baked PNGs.
+# Defaults to jitpack.io (the baked meshcore-mobile catalog needs it); override with your own comma
+# list — add a snapshot repo another catalog needs (e.g. Confetti's Apollo snapshots) — or set `none`
+# to send only Central + Google. Empty inherits this baked default.
+: "${SERVE_EXTRA_MAVEN_REPOS:=https://jitpack.io}"
+[[ "${SERVE_EXTRA_MAVEN_REPOS}" != "none" && -n "${SERVE_EXTRA_MAVEN_REPOS}" ]] &&
+  args+=(--extra-maven-repos "${SERVE_EXTRA_MAVEN_REPOS}")
+
 # Generous render/build timeout so a slow host's first render doesn't trip the
 # CLI's 300s default (the warm cache is baked in, so it's normally fast anyway).
 args+=(--timeout "${SERVE_TIMEOUT:-1800}")

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -286,9 +286,15 @@ There are two ways to stand that daemon up, both fail-closed on the `Trusted` ve
    The design-artifacts pipeline publishes the executable preview bundle (minimized module classes +
    `previews.json` + classpath manifest) onto the branch under `bundle/` and records a `liveBundle`
    in `catalog.json`. `serve` fetches that bundle like it fetches the Wasm app, resolves its
-   classpath from the local Maven/Gradle caches (or Central), and launches the render daemon
-   **straight from it** — no repo checkout, no Gradle build, no per-request compile. This is what the
-   public server uses for `compose-m3`. Both backends are supported
+   classpath from the local Maven/Gradle caches (or Central + Google Maven), and launches the render
+   daemon **straight from it** — no repo checkout, no Gradle build, no per-request compile. This is
+   what the public server uses for `compose-m3`. A module that pulls deps from a repo **beyond
+   Central + Google** (e.g. `meshcore-mobile`'s `jitpack.io` deps like `usb-serial-for-android`)
+   needs those repos supplied via `--extra-maven-repos <url>[,<url>…]` (env `SERVE_EXTRA_MAVEN_REPOS`;
+   the prebuilt image defaults it to `https://jitpack.io`, `none` to disable) — otherwise the
+   resolver skips those coordinates and the daemon can't build its classpath, so the catalog falls
+   back to baked PNGs (`livebundle-unavailable`). Only list repos you trust; the server fetches
+   artifacts from them when resolving a trusted catalog's live bundle. Both backends are supported
    ([`ServeBundleDaemon.materialize`](../cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt)):
    a **desktop** bundle spawns the Skiko desktop daemon, and an **android** bundle spawns the
    Robolectric daemon **on a box that carries the Android sidecar + SDK** — the prebuilt `deploy/image`


### PR DESCRIPTION
## Summary

The "without embed-deps" fix for a live daemon that can't resolve a catalog's non-Central deps.

The serve host's `CoordinateResolver` only searches **Maven Central + Google Maven** (plus local caches, which the prebuilt image doesn't pre-populate). A served catalog whose module pulls deps from another repo — e.g. `meshcore-mobile`'s `jitpack.io` deps (`usb-serial-for-android`), Confetti's Apollo snapshots — has those coordinates **skipped**, so the live daemon can't build its classpath and the catalog silently falls back to baked PNGs (`livebundle-unavailable`) even with a published `liveBundle`.

Add **`--extra-maven-repos <url>[,<url>…]`** (env `SERVE_EXTRA_MAVEN_REPOS`), threaded into `ServeBundleDaemon.materialize` → `CoordinateResolver.remoteRepositories` as `DEFAULT_REMOTE_REPOSITORIES + extras`. This resolves the deps from their real repos with **no bundle changes** — no embedding, no bloat, no per-preview split blowup. Fixes the whole class of "consumer uses a non-default repo."

- `ServeBundleDaemon.materialize`: new `extraMavenRepos` param → resolver.
- `ServeCommand`: `--extra-maven-repos` flag (list), threaded to all three materialize call sites.
- `CliFlags`: register the flag (value flag) — required by `CliFlagsRegistryTest`.
- `deploy/image/entrypoint.sh`: map `SERVE_EXTRA_MAVEN_REPOS` → `--extra-maven-repos`, **defaulting to `https://jitpack.io`** (the baked `meshcore-mobile` catalog needs it); `none` disables.
- Docs updated.

**Security:** operator-curated — the server only fetches from repos the deployer lists, and only when resolving a **trusted** catalog's live bundle (the existing trust gate is unchanged).

## Rollout
After this ships in a release + image roll, preview.coo.ee resolves `jitpack.io` out of the box → `meshcore-mobile` renders live with **no bundle/export changes**. Confetti's snapshot repo can be added to the box's `SERVE_EXTRA_MAVEN_REPOS`.

## Test plan
- `CoordinateResolverTest`: new — two loopback repos ordered `[primary-404, extra-200]`; a coordinate the primary misses resolves from the extra (the exact `DEFAULT + extras` shape).
- `CliFlagsRegistryTest`: passes with the new flag registered.
- `./gradlew :cli:test --tests CoordinateResolverTest --tests CliFlagsRegistryTest` green; `:cli:ktfmtCheck` clean.

Non-visual (classpath-resolution plumbing).


---
_Generated by [Claude Code](https://claude.ai/code/session_018B1heEfDkyWdqj4cgRuy2U)_