### PR TITLE
feat(deploy): default SERVE_EXTRA_MAVEN_REPOS to all required catalog repos

### DIFF
--- a/deploy/image/entrypoint.sh
+++ b/deploy/image/entrypoint.sh
@@ -134,10 +134,11 @@ fi
 # Google Maven. A served catalog whose module pulls deps from a non-default repo (e.g.
 # meshcore-mobile's jitpack.io deps like usb-serial-for-android) otherwise has those coordinates
 # skipped, so its live daemon can't build its classpath and the catalog falls back to baked PNGs.
-# Defaults to jitpack.io (the baked meshcore-mobile catalog needs it); override with your own comma
-# list — add a snapshot repo another catalog needs (e.g. Confetti's Apollo snapshots) — or set `none`
-# to send only Central + Google. Empty inherits this baked default.
-: "${SERVE_EXTRA_MAVEN_REPOS:=https://jitpack.io}"
+# Defaults to the repos every baked live catalog needs: jitpack.io (meshcore-mobile's
+# usb-serial-for-android etc.) and the Apollo snapshots repo (Confetti's mapped Apollo artifacts).
+# Override with your own comma list to add another catalog's repo, or set `none` to send only
+# Central + Google. Empty inherits this baked default.
+: "${SERVE_EXTRA_MAVEN_REPOS:=https://jitpack.io,https://storage.googleapis.com/apollo-snapshots/m2}"
 [[ "${SERVE_EXTRA_MAVEN_REPOS}" != "none" && -n "${SERVE_EXTRA_MAVEN_REPOS}" ]] &&
   args+=(--extra-maven-repos "${SERVE_EXTRA_MAVEN_REPOS}")
 

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -291,7 +291,8 @@ There are two ways to stand that daemon up, both fail-closed on the `Trusted` ve
    what the public server uses for `compose-m3`. A module that pulls deps from a repo **beyond
    Central + Google** (e.g. `meshcore-mobile`'s `jitpack.io` deps like `usb-serial-for-android`)
    needs those repos supplied via `--extra-maven-repos <url>[,<url>…]` (env `SERVE_EXTRA_MAVEN_REPOS`;
-   the prebuilt image defaults it to `https://jitpack.io`, `none` to disable) — otherwise the
+   the prebuilt image defaults it to the repos its baked catalogs need — `https://jitpack.io`
+   (meshcore-mobile) + the Apollo snapshots repo (Confetti); `none` to disable) — otherwise the
    resolver skips those coordinates and the daemon can't build its classpath, so the catalog falls
    back to baked PNGs (`livebundle-unavailable`). Only list repos you trust; the server fetches
    artifacts from them when resolving a trusted catalog's live bundle. Both backends are supported


### PR DESCRIPTION
## Summary

Follow-up to #2665. That added `SERVE_EXTRA_MAVEN_REPOS` and defaulted the prebuilt image to `https://jitpack.io` (for meshcore). This extends the default to **every non-Central repo the baked live catalogs actually need**, so they all resolve their deps out of the box with no per-catalog `.env` edit:

- `https://jitpack.io` — meshcore-mobile (`usb-serial-for-android`, …)
- `https://storage.googleapis.com/apollo-snapshots/m2` — Confetti's mapped Apollo artifacts (its `settings.gradle.kts` routes them there via `forRepository`)

Verified against the served catalogs' `settings.gradle.kts`: the JetBrains Kotlin/Wasm repo is compiler-only (not the Android render classpath), so it's intentionally excluded; compose-m3/wear-m3/remote-m3 are Central+Google only.

Operators still override the comma list or set `none` to send only Central + Google.

## Rollout
Ships in the same release as #2665 → once the image rolls, preview.coo.ee resolves both jitpack.io and the Apollo snapshots repo, so **meshcore-mobile, confetti-mobile, and confetti-wear render live with no further config**.

## Test plan
Deploy-config only (`entrypoint.sh` default + docs). The `--extra-maven-repos` mechanism it feeds is covered by `CoordinateResolverTest` (#2665).


---
_Generated by [Claude Code](https://claude.ai/code/session_018B1heEfDkyWdqj4cgRuy2U)_