### PR TITLE
feat(deploy): persist runtime download caches across image rolls

### DIFF
--- a/deploy/image/docker-compose.yml
+++ b/deploy/image/docker-compose.yml
@@ -77,9 +77,22 @@ services:
       # image). Empty ⇒ the CLI default (600s); set 0 to disable and serve the boot snapshot only.
       SERVE_CATALOG_REFRESH: "${SERVE_CATALOG_REFRESH:-}"
       PORT: "8080"
-    # To pin your OWN producers, mount a trust store over the baked one and keep
+    # Persist the RUNTIME download caches across image rolls. A rollout (or Watchtower
+    # recreate) replaces the container, discarding its writable layer — so without this the
+    # fresh replica cold-starts: it re-resolves every live catalog's bundle classpath
+    # (jitpack / apollo-snapshots / extra-Central jars land in `bundle-deps`) and re-fetches
+    # Google Fonts for the figma-svg export (`fonts`) on its first render. Both live under
+    # `composeAiCacheDir` = `~/.cache/composeai` (container home is /root), so a single named
+    # volume there carries them over. NB the heavy baked caches — the Robolectric
+    # `android-all` runtime and the build `~/.m2` — live in the IMAGE layer, so they already
+    # survive a roll and are deliberately NOT volume-mounted (mounting over /root/.m2 would
+    # shadow the baked content and go stale across image bumps). During a zero-downtime roll
+    # two replicas mount this volume at once; writes are content-addressed Maven-layout files,
+    # so a concurrent re-resolve is idempotent (same bytes, last-writer-wins).
+    volumes:
+      - preview_cache:/root/.cache/composeai
+    # To also pin your OWN producers, mount a trust store over the baked one and keep
     # SERVE_TRUST_STORE pointing at it:
-    # volumes:
     #   - ./producers.json:/trust/producers.json:ro
     expose:
       - "8080"
@@ -181,5 +194,9 @@ services:
       com.centurylinklabs.watchtower.enable: "true"
 
 volumes:
+  # Runtime download caches for `preview` (resolved live-bundle dep jars + fonts), kept across
+  # image rolls so a freshly-rolled replica reuses them instead of re-downloading. See the
+  # `preview` service's volumes block for why the baked android-all / ~/.m2 are excluded.
+  preview_cache:
   caddy_data:
   caddy_config:


### PR DESCRIPTION
## Summary

The `preview` service mounted **no volumes**, so every zero-downtime rollout (docker-rollout) — and every Watchtower recreate — discarded the container's writable layer and cold-started the fresh replica. On its first render it had to:

- **re-resolve each live catalog's bundle classpath** — the jars `CoordinateResolver` pulls from jitpack.io, the Apollo snapshots repo, and any extra-Central coordinates (`~/.cache/composeai/bundle-deps`), and
- **re-fetch Google Fonts** for the `compose/figma-svg` export (`~/.cache/composeai/fonts`).

Both caches live under `composeAiCacheDir` (`~/.cache/composeai`; container home is `/root`), so this mounts a single named volume `preview_cache` there and the resolved jars + fonts now survive a roll.

**Deliberately *not* mounted:** the heavy baked caches — the Robolectric `android-all` runtime and the build `~/.m2` — already live in the **image layer**, so they survive a roll for free. A volume over `/root/.m2` would *shadow* the baked content and go stale across image bumps, so it's left baked.

Concurrency: during a zero-downtime roll two `preview` replicas mount `preview_cache` at once; writes are content-addressed Maven-layout files (and font blobs), so a concurrent re-resolve is idempotent — same bytes, last-writer-wins.

## Deploying

This is a compose-file change, so unlike the image it is **not** auto-rolled by Watchtower. The box picks it up on the next `git pull` + `docker compose up -d`. The volume starts empty and fills on the first render after that redeploy, then persists across all subsequent rolls.

## Test plan

- `docker compose config` parses (validated: `preview.volumes = [preview_cache:/root/.cache/composeai]`, top-level `volumes` declares `preview_cache`).
- Non-visual change (deploy plumbing only) — no rendered surfaces affected.

---
_Generated by [Claude Code](https://claude.ai/code/session_018B1heEfDkyWdqj4cgRuy2U)_