### PR TITLE
fix(serve): gate rolling update on readiness, not just liveness

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -160,22 +160,31 @@ class ServeHttpServer(
 
   /**
    * Readiness latch for `/readyz` (the rolling-update gate). Unlike `/healthz` — a static "ok" that
-   * only proves the HTTP listener is up — readiness is `true` only once a representative preview has
-   * *actually rendered* on this host, so docker-rollout won't drain traffic onto (and retire the old
-   * replica for) a new container whose render pipeline is broken or whose catalogs failed to load.
-   * Latches on the first success and stays set: the probe render is a baked, override-free snapshot
-   * for a catalog session (cheap, never wakes the daemon — see [ServeCatalogLiveHost.render]), but a
-   * plain daemon module would pay its cold render, so the poll (every ~10s) must not re-run it once
-   * proven.
+   * only proves the HTTP listener is up — readiness is `true` only once a representative preview
+   * has *actually rendered* on this host, so docker-rollout won't drain traffic onto (and retire
+   * the old replica for) a new container whose render pipeline is broken or whose catalogs failed
+   * to load. Latches on the first success and stays set: the probe render is a baked, override-free
+   * snapshot for a catalog session (cheap, never wakes the daemon — see
+   * [ServeCatalogLiveHost.render]), but a plain daemon module would pay its cold render, so it runs
+   * at most once (see [readinessProber]) and the poll only ever reads this flag.
+   *
+   * Set by the **server-owned** [readinessProber] thread, never inside a request coroutine: the
+   * `/readyz` handler must stay instant so a health checker's short command timeout (the Docker
+   * healthcheck allows 5s) can't cancel a slow first render mid-flight and discard the result — the
+   * render happens off the request path, latches here when it lands, and the next poll sees it.
    */
   private val ready = AtomicBoolean(false)
 
+  /** Starts [readinessProber] exactly once, on the first `/readyz` poll (idempotent). */
+  private val readinessProbeStarted = AtomicBoolean(false)
+
   /**
-   * Guards against overlapping readiness probes: only one render runs at a time while the latch is
-   * still cold, so a burst of `/readyz` polls (or a slow first render) can't pile up N concurrent
-   * renders. Losers report "warming" (503) until the in-flight probe latches [ready].
+   * The server-owned background thread that renders the representative preview until it succeeds,
+   * then latches [ready]. Kicked off lazily by the first `/readyz` poll (so a plain `serve` that's
+   * never health-checked pays no eager render) and interrupted on [stop]. Retries on failure so a
+   * daemon still cold-starting eventually flips ready without the request path ever blocking.
    */
-  private val readinessProbeInFlight = AtomicBoolean(false)
+  @Volatile private var readinessProber: Thread? = null
 
   /**
    * Live-seat limiter: a permit **budget** ([maxLiveSeats]) charged per session by its backend
@@ -194,8 +203,10 @@ class ServeHttpServer(
         get("/healthz") { call.respondText("ok") }
 
         // `/readyz` — ungated READINESS: "ready" only once a representative preview has actually
-        // rendered on this host (see [ready]). This is the gate docker-rollout should wait on before
-        // it drains traffic onto a new replica and retires the old one — `/healthz` going green only
+        // rendered on this host (see [ready]). This is the gate docker-rollout should wait on
+        // before
+        // it drains traffic onto a new replica and retires the old one — `/healthz` going green
+        // only
         // means the port bound, so a replica whose render pipeline is broken (dead daemon, missing
         // baked fallback, empty/failed catalog load) would pass it and get promoted into a 500-ing
         // live server. 503 ("warming") until the first render succeeds; then it latches green.
@@ -385,6 +396,7 @@ class ServeHttpServer(
 
   /** Stop with a short grace period. Idempotent enough for a shutdown hook. */
   fun stop() {
+    readinessProber?.interrupt()
     server.stop(gracePeriodMillis = 500, timeoutMillis = 2000)
   }
 
@@ -535,40 +547,61 @@ class ServeHttpServer(
   }
 
   /**
-   * `GET /readyz`: the rolling-update readiness gate. Returns `200 "ready"` once [ready] has
-   * latched — set on the first probe that renders a representative preview — and `503 "warming"`
-   * before that. Once latched it answers instantly (no render), so the ~10s healthcheck poll stays
-   * cheap even against a daemon-backed module. A single probe renders at a time ([readinessProbeInFlight]);
-   * concurrent polls short-circuit to "warming" rather than stacking renders.
+   * `GET /readyz`: the rolling-update readiness gate. Instant and non-blocking — it only reads the
+   * [ready] latch, returning `200 "ready"` once it's set and `503 "warming"` before. The render
+   * that flips the latch runs on the server-owned [readinessProber], NOT in this request coroutine,
+   * so a health checker's short command timeout (the Docker healthcheck allows 5s) can never cancel
+   * a slow first render and discard its result — the first poll just kicks the prober off and
+   * reports "warming"; a later poll sees the latched value. So the ~10s poll stays cheap even
+   * against a daemon-backed module whose cold render runs for much longer than the poll timeout.
    */
   private suspend fun RoutingContext.handleReadyz() {
     if (ready.get()) {
       call.respondText("ready")
       return
     }
-    // Upload-only server (`--accept-bundles`, no landing session): there's no representative preview
+    // Upload-only server (`--accept-bundles`, no landing session): there's no representative
+    // preview
     // to render, so "ready" means the listener is up and waiting for uploads. Latch immediately.
     if (defaultSessionId.isBlank()) {
       ready.set(true)
       call.respondText("ready")
       return
     }
-    if (!readinessProbeInFlight.compareAndSet(false, true)) {
-      call.respondText("warming", status = HttpStatusCode.ServiceUnavailable)
-      return
-    }
-    val ok =
-      try {
-        withContext(Dispatchers.IO) { probeReadiness() }
-      } finally {
-        readinessProbeInFlight.set(false)
-      }
-    if (ok) {
-      ready.set(true)
-      call.respondText("ready")
-    } else {
-      call.respondText("warming", status = HttpStatusCode.ServiceUnavailable)
-    }
+    ensureReadinessProbe()
+    call.respondText("warming", status = HttpStatusCode.ServiceUnavailable)
+  }
+
+  /**
+   * Start the server-owned readiness prober on the first `/readyz` poll (idempotent via
+   * [readinessProbeStarted]). It renders the representative preview off the request path, retrying
+   * on failure, and latches [ready] on the first success — so a client that times out mid-probe
+   * never discards the work. A daemon thread (interrupted on [stop]); it exits as soon as [ready]
+   * is set. Gated behind an actual `/readyz` hit so a plain `serve` that's never health-checked
+   * pays no eager render.
+   */
+  private fun ensureReadinessProbe() {
+    if (!readinessProbeStarted.compareAndSet(false, true)) return
+    val prober =
+      Thread(
+          {
+            while (!ready.get() && !Thread.currentThread().isInterrupted) {
+              if (probeReadiness()) {
+                ready.set(true)
+                return@Thread
+              }
+              try {
+                Thread.sleep(READINESS_PROBE_RETRY_MILLIS)
+              } catch (e: InterruptedException) {
+                return@Thread
+              }
+            }
+          },
+          "serve-readiness-probe",
+        )
+        .apply { isDaemon = true }
+    readinessProber = prober
+    prober.start()
   }
 
   /**
@@ -576,8 +609,9 @@ class ServeHttpServer(
    * successful [RenderOutcome.Ok] means the render path works end-to-end — catalogs loaded, a
    * preview exists, and the host can produce bytes (baked for a catalog session, a real daemon
    * render for a plain module). Any failure — no session, no previews, a render error, or an
-   * exception — reports not-ready so the poll retries. Runs on the IO dispatcher (the lease + render
-   * are blocking). Never throws.
+   * exception — returns false so the prober retries. Runs on the [readinessProber] thread (the
+   * lease
+   * + render are blocking). Never throws.
    */
   private fun probeReadiness(): Boolean {
     val lease = sessions.lease(defaultSessionId) ?: return false
@@ -1430,6 +1464,13 @@ class ServeHttpServer(
   companion object {
     const val TOKEN_HEADER: String = "X-Compose-Preview-Token"
     private const val DEFAULT_PORT_RANGE = 32
+
+    /**
+     * How long the readiness prober waits between failed render attempts before retrying (short, so
+     * a daemon that's still warming latches `ready` promptly once it can render). Only matters
+     * while the latch is cold; the loop exits on first success.
+     */
+    private const val READINESS_PROBE_RETRY_MILLIS = 2000L
 
     /**
      * Authorisation decision for a request: open when [isPublic], otherwise the [provided] token

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -34,6 +34,7 @@ import java.net.InetAddress
 import java.net.ServerSocket
 import java.util.concurrent.Semaphore
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.Serializable
@@ -50,9 +51,12 @@ import kotlinx.serialization.json.Json
  * [defaultSessionId]); the registry forks the tenant behind its factory on first use. Unknown
  * sessions 404 like a bad token.
  *
- * Endpoints (all token-gated except `/healthz`, `/version`, and the `/wasm/` static assets):
+ * Endpoints (all token-gated except `/healthz`, `/readyz`, `/version`, and the `/wasm/` static
+ * assets):
  * - `GET /` landing page, `GET /p/{id}` viewer page,
  * - `GET /render/{id}.png` PNG bytes, `GET /api/previews` JSON, `GET /healthz` liveness,
+ * - `GET /readyz` readiness (green only after a representative preview actually renders — the
+ *   rolling-update gate),
  * - `GET /index.json` Storybook stories index, `GET /iframe.html?id=` isolated story render
  *   (`&format=svg` serves the vector export as an inert SVG image for DOM-capture tools),
  *   ([StorybookCompat]) — the drop-in surface downstream Storybook visual tools consume,
@@ -155,6 +159,25 @@ class ServeHttpServer(
   private val renderSemaphore = Semaphore(renderSlots)
 
   /**
+   * Readiness latch for `/readyz` (the rolling-update gate). Unlike `/healthz` — a static "ok" that
+   * only proves the HTTP listener is up — readiness is `true` only once a representative preview has
+   * *actually rendered* on this host, so docker-rollout won't drain traffic onto (and retire the old
+   * replica for) a new container whose render pipeline is broken or whose catalogs failed to load.
+   * Latches on the first success and stays set: the probe render is a baked, override-free snapshot
+   * for a catalog session (cheap, never wakes the daemon — see [ServeCatalogLiveHost.render]), but a
+   * plain daemon module would pay its cold render, so the poll (every ~10s) must not re-run it once
+   * proven.
+   */
+  private val ready = AtomicBoolean(false)
+
+  /**
+   * Guards against overlapping readiness probes: only one render runs at a time while the latch is
+   * still cold, so a burst of `/readyz` polls (or a slow first render) can't pile up N concurrent
+   * renders. Losers report "warming" (503) until the in-flight probe latches [ready].
+   */
+  private val readinessProbeInFlight = AtomicBoolean(false)
+
+  /**
    * Live-seat limiter: a permit **budget** ([maxLiveSeats]) charged per session by its backend
    * weight, so a heavy Android daemon costs more of the box than a cheap desktop CMP one. `<= 0` ⇒
    * unbounded. See [maxLiveSeats] and [LiveSeatLimiter].
@@ -165,8 +188,18 @@ class ServeHttpServer(
     embeddedServer(CIO, host = host, port = port) {
       install(WebSockets)
       routing {
-        // `/healthz` is the only ungated route — liveness only, leaks nothing.
+        // `/healthz` — ungated liveness: "ok" the moment the listener is up. Leaks nothing, and
+        // proves nothing beyond "the process is answering HTTP". The rolling-update gate is
+        // `/readyz` below, not this.
         get("/healthz") { call.respondText("ok") }
+
+        // `/readyz` — ungated READINESS: "ready" only once a representative preview has actually
+        // rendered on this host (see [ready]). This is the gate docker-rollout should wait on before
+        // it drains traffic onto a new replica and retires the old one — `/healthz` going green only
+        // means the port bound, so a replica whose render pipeline is broken (dead daemon, missing
+        // baked fallback, empty/failed catalog load) would pass it and get promoted into a 500-ing
+        // live server. 503 ("warming") until the first render succeeds; then it latches green.
+        get("/readyz") { handleReadyz() }
 
         // `/version` — ungated machine-readable identity for the host: the CLI version, the serve
         // API schema, and whether this box runs open (public) or token-gated. Lets a deployer,
@@ -498,6 +531,64 @@ class ServeHttpServer(
       )
     } else {
       call.respondText(ServeWeb.statusPage(data.toView(), token), ContentType.Text.Html)
+    }
+  }
+
+  /**
+   * `GET /readyz`: the rolling-update readiness gate. Returns `200 "ready"` once [ready] has
+   * latched — set on the first probe that renders a representative preview — and `503 "warming"`
+   * before that. Once latched it answers instantly (no render), so the ~10s healthcheck poll stays
+   * cheap even against a daemon-backed module. A single probe renders at a time ([readinessProbeInFlight]);
+   * concurrent polls short-circuit to "warming" rather than stacking renders.
+   */
+  private suspend fun RoutingContext.handleReadyz() {
+    if (ready.get()) {
+      call.respondText("ready")
+      return
+    }
+    // Upload-only server (`--accept-bundles`, no landing session): there's no representative preview
+    // to render, so "ready" means the listener is up and waiting for uploads. Latch immediately.
+    if (defaultSessionId.isBlank()) {
+      ready.set(true)
+      call.respondText("ready")
+      return
+    }
+    if (!readinessProbeInFlight.compareAndSet(false, true)) {
+      call.respondText("warming", status = HttpStatusCode.ServiceUnavailable)
+      return
+    }
+    val ok =
+      try {
+        withContext(Dispatchers.IO) { probeReadiness() }
+      } finally {
+        readinessProbeInFlight.set(false)
+      }
+    if (ok) {
+      ready.set(true)
+      call.respondText("ready")
+    } else {
+      call.respondText("warming", status = HttpStatusCode.ServiceUnavailable)
+    }
+  }
+
+  /**
+   * One readiness attempt: lease the default session and render its first preview override-free. A
+   * successful [RenderOutcome.Ok] means the render path works end-to-end — catalogs loaded, a
+   * preview exists, and the host can produce bytes (baked for a catalog session, a real daemon
+   * render for a plain module). Any failure — no session, no previews, a render error, or an
+   * exception — reports not-ready so the poll retries. Runs on the IO dispatcher (the lease + render
+   * are blocking). Never throws.
+   */
+  private fun probeReadiness(): Boolean {
+    val lease = sessions.lease(defaultSessionId) ?: return false
+    return try {
+      val preview = lease.host.previews.firstOrNull() ?: return false
+      lease.host.render(preview.id, PreviewOverrides()) is RenderOutcome.Ok
+    } catch (e: Exception) {
+      System.err.println("[serve] readiness probe failed: ${e.message}")
+      false
+    } finally {
+      lease.close()
     }
   }
 

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
@@ -22,8 +22,8 @@ import okhttp3.Request
  * [ServeBundleHost] sessions, exercised over HTTP. Guards the two access forms — the legacy
  * `?session=` query lane and the canonical path lane (`/<system>/…`) — and, crucially, that the
  * constant top-level routes (`/healthz`, `/readyz`, `/version`) still win over the `/{system}`
- * catch-all in Ktor's route scoring (a regression here would 404 liveness/readiness checks or shadow
- * `/version`).
+ * catch-all in Ktor's route scoring (a regression here would 404 liveness/readiness checks or
+ * shadow `/version`).
  *
  * Runs public (no token) so the assertions stay about routing, not the auth gate ([ServeAuthTest]).
  */
@@ -97,6 +97,15 @@ class ServeHttpRoutingTest {
     }
   }
 
+  /** Poll `/readyz` until it latches ready (the prober renders off the request path), up to ~5s. */
+  private fun awaitReady(): Boolean {
+    repeat(50) {
+      if (get("/readyz") == 200 to "ready") return true
+      Thread.sleep(100)
+    }
+    return false
+  }
+
   @AfterTest
   fun tearDown() {
     server.stop()
@@ -112,12 +121,13 @@ class ServeHttpRoutingTest {
   }
 
   @Test
-  fun `readyz is green once the default session renders a preview`() {
-    // The default session (default-mod) carries a baked preview, so the first /readyz probe renders
-    // it successfully and latches ready — the signal docker-rollout gates the swap on. Unlike
-    // /healthz (a static "ok"), this only passes because a real render succeeded.
-    assertEquals(200 to "ready", get("/readyz"))
-    // Latched: a second poll stays green (and, on a daemon-backed host, doesn't re-render).
+  fun `readyz goes green once the default session renders a preview`() {
+    // The first poll kicks off the server-owned readiness prober; the default session (default-mod)
+    // carries a baked preview, so that render succeeds OFF the request path and latches ready — the
+    // signal docker-rollout gates the swap on. Unlike /healthz (a static "ok"), this only flips
+    // because a real render succeeded. Poll until green, exactly like a real healthcheck does.
+    assertTrue(awaitReady(), "readyz should latch ready after the default session renders")
+    // Latched: it stays green.
     assertEquals(200 to "ready", get("/readyz"))
   }
 
@@ -139,8 +149,7 @@ class ServeHttpRoutingTest {
         )
         .also { it.start() }
     try {
-      val req =
-        Request.Builder().url("http://127.0.0.1:${brokenServer.port}/readyz").build()
+      val req = Request.Builder().url("http://127.0.0.1:${brokenServer.port}/readyz").build()
       client.newCall(req).execute().use { r ->
         assertEquals(503, r.code)
         assertEquals("warming", r.body?.string())

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
@@ -21,8 +21,9 @@ import okhttp3.Request
  * End-to-end routing check for [ServeHttpServer]: a real embedded server fronting two static
  * [ServeBundleHost] sessions, exercised over HTTP. Guards the two access forms — the legacy
  * `?session=` query lane and the canonical path lane (`/<system>/…`) — and, crucially, that the
- * constant top-level routes (`/healthz`, `/version`) still win over the `/{system}` catch-all in
- * Ktor's route scoring (a regression here would 404 liveness checks or shadow `/version`).
+ * constant top-level routes (`/healthz`, `/readyz`, `/version`) still win over the `/{system}`
+ * catch-all in Ktor's route scoring (a regression here would 404 liveness/readiness checks or shadow
+ * `/version`).
  *
  * Runs public (no token) so the assertions stay about routing, not the auth gate ([ServeAuthTest]).
  */
@@ -108,6 +109,46 @@ class ServeHttpRoutingTest {
     val (code, body) = get("/version")
     assertEquals(200, code)
     assertTrue(body.contains("compose-preview-serve/version/v1"), "version json: $body")
+  }
+
+  @Test
+  fun `readyz is green once the default session renders a preview`() {
+    // The default session (default-mod) carries a baked preview, so the first /readyz probe renders
+    // it successfully and latches ready — the signal docker-rollout gates the swap on. Unlike
+    // /healthz (a static "ok"), this only passes because a real render succeeded.
+    assertEquals(200 to "ready", get("/readyz"))
+    // Latched: a second poll stays green (and, on a daemon-backed host, doesn't re-render).
+    assertEquals(200 to "ready", get("/readyz"))
+  }
+
+  @Test
+  fun `readyz withholds ready when the default session cannot render`() {
+    // A server whose default session resolves to nothing (an empty registry) can't render a
+    // representative preview, so /readyz must report 503 "warming" — NOT a false green. This is the
+    // failure docker-rollout must catch: a replica up on the port but unable to serve. Its own
+    // server + registry so the class-level `server` fields are untouched.
+    val emptyRegistry = ServeSessionRegistry(open = { null })
+    val brokenServer =
+      ServeHttpServer(
+          host = "127.0.0.1",
+          requestedPort = 0,
+          token = "unused-in-public",
+          sessions = emptyRegistry,
+          defaultSessionId = "no-such-session",
+          isPublic = true,
+        )
+        .also { it.start() }
+    try {
+      val req =
+        Request.Builder().url("http://127.0.0.1:${brokenServer.port}/readyz").build()
+      client.newCall(req).execute().use { r ->
+        assertEquals(503, r.code)
+        assertEquals("warming", r.body?.string())
+      }
+    } finally {
+      brokenServer.stop()
+      emptyRegistry.close()
+    }
   }
 
   @Test

--- a/deploy/cloudrun/README.md
+++ b/deploy/cloudrun/README.md
@@ -45,6 +45,8 @@ Endpoints (all token-gated except `/healthz`), token via `?token=` or the
 - `GET /render/{id}.png?token=…` — PNG bytes (supports overrides, e.g. `&fontScale=1.3`)
 - `GET /api/previews?token=…` — preview list as JSON
 - `GET /healthz` — liveness (unauthenticated; used by the startup probe)
+- `GET /readyz` — readiness: green only once a preview actually renders (unauthenticated; the
+  `deploy/image` docker-rollout gate uses this instead of `/healthz`)
 
 ## Manual deploy (without deploy.sh)
 

--- a/deploy/image/Caddyfile
+++ b/deploy/image/Caddyfile
@@ -37,7 +37,7 @@
 		# lands on a just-started replica before it's accepting connections gets a dial
 		# refusal, which Caddy retries against the healthy replica within
 		# lb_try_duration (nothing was written upstream yet, so this is safe to retry).
-		# docker-rollout keeps the OLD replica up until the new one passes its /healthz
+		# docker-rollout keeps the OLD replica up until the new one passes its /readyz
 		# healthcheck, so there's always a warm backend to retry onto. Deliberately no
 		# passive `fail_duration` / `unhealthy_status`: in steady state there's a single
 		# backend, and benching it on a transient error or an app-level 5xx would

--- a/deploy/image/README.md
+++ b/deploy/image/README.md
@@ -71,7 +71,7 @@ services split the work:
 - **`rollout`** updates the `preview` server with
   [docker-rollout](https://github.com/wowu/docker-rollout). It polls GHCR and,
   when a new `:latest` lands, boots a **second** `preview` replica alongside the
-  live one, waits for that replica's `/healthz` healthcheck to pass, lets Caddy
+  live one, waits for that replica's `/readyz` healthcheck to pass, lets Caddy
   drain traffic onto it, then retires the old replica. The chain stays hands-off:
 
   > merge → cut a `v*` release → `preview-host-image.yml` publishes `:latest` →
@@ -83,8 +83,10 @@ services split the work:
   recreate is a ~1s proxy blip, and only when the baked-Caddyfile image changes.
 
 **How the swap stays seamless.** `preview` has a Docker `healthcheck` on the
-app's ungated `/healthz` liveness route; docker-rollout won't retire the old
-replica until the new one reports `healthy`. Meanwhile the Caddyfile proxies to
+app's ungated `/readyz` **readiness** route — green only once the new replica has
+actually rendered a preview, not merely bound its port (that's `/healthz`), so a
+replica with a broken render pipeline never gets promoted. docker-rollout won't
+retire the old replica until the new one reports `healthy`. Meanwhile the Caddyfile proxies to
 `preview` via **dynamic upstreams** (re-resolving the service's Docker DNS every
 few seconds) with cross-replica **retry**, so during the brief two-replica
 overlap a request that hits the still-booting replica is retried onto the warm

--- a/deploy/image/docker-compose.yml
+++ b/deploy/image/docker-compose.yml
@@ -7,7 +7,8 @@
 #
 # Auto-updates are ZERO-DOWNTIME: the `rollout` service (below) polls GHCR and,
 # when a new :latest is published, hands `preview` to docker-rollout — a fresh
-# replica boots alongside the live one, Docker waits for its /healthz healthcheck,
+# replica boots alongside the live one, Docker waits for its /readyz healthcheck
+# (green only once a preview actually renders — see the `preview` healthcheck),
 # Caddy drains traffic onto it (dynamic upstreams + passive health), then the old
 # replica retires. `watchtower` still rolls `caddy` (fixed 80/443 ports can't be
 # scaled). Leave IMAGE_TAG unset (defaults to `latest`) for updates. See README.md.
@@ -105,14 +106,19 @@ services:
     # Set PREVIEW_MEM_LIMIT in .env (e.g. `PREVIEW_MEM_LIMIT=4g`) to cap it on a shared host, which
     # also lowers the derived seat budget to match.
     mem_limit: "${PREVIEW_MEM_LIMIT:-0}"
-    # Liveness for the rolling update. docker-rollout (driven by the `rollout`
+    # Readiness gate for the rolling update. docker-rollout (driven by the `rollout`
     # service) waits for a freshly-started replica to report `healthy` BEFORE it
     # retires the old one, so this is the gate that makes updates zero-downtime.
-    # `/healthz` is the app's ungated liveness route (returns "ok" once the HTTP
-    # server is listening); `start_period` covers the cold-start catalog fetch +
-    # warm render so a slow boot isn't counted as a failure.
+    # It MUST hit `/readyz`, not `/healthz`: `/healthz` returns "ok" the instant the
+    # HTTP listener binds (a static string — it proves nothing rendered), so a replica
+    # whose catalogs failed to load or whose render pipeline is dead would pass it and
+    # get promoted into a 500-ing server. `/readyz` goes green only after a
+    # representative preview has actually rendered, so the gate reflects "can serve
+    # traffic". `start_period` covers the cold-start catalog fetch + first render so a
+    # slow boot isn't counted as a failure (503 "warming" during the start period is
+    # expected and not a failure).
     healthcheck:
-      test: ["CMD", "curl", "-fsS", "http://localhost:8080/healthz"]
+      test: ["CMD", "curl", "-fsS", "http://localhost:8080/readyz"]
       interval: 10s
       timeout: 5s
       retries: 3
@@ -124,7 +130,7 @@ services:
 
   # Zero-downtime updater for `preview`: poll GHCR for a new :latest digest and,
   # when one lands, roll the service with docker-rollout (boot a new replica →
-  # wait for its /healthz healthcheck → drain onto it → retire the old one) so
+  # wait for its /readyz healthcheck → drain onto it → retire the old one) so
   # live traffic never sees a stop→recreate gap. Needs the Docker socket (like
   # Watchtower) and the compose project mounted read-only so it can pull + scale.
   # The docker-rollout plugin is the vendored ./docker-rollout, mounted into the

--- a/deploy/image/rollout.sh
+++ b/deploy/image/rollout.sh
@@ -4,7 +4,8 @@
 # This replaces Watchtower's in-place stop→recreate of `preview` (which 502s for
 # the whole ~1 min the new container spends booting + warm-rendering) with a
 # rolling swap: pull the new image, start a SECOND preview replica alongside the
-# live one, wait for its /healthz healthcheck to pass, let Caddy drain traffic
+# live one, wait for its /readyz healthcheck to pass (green only once a preview
+# actually renders — not merely once the port binds), let Caddy drain traffic
 # onto it (see Caddyfile — dynamic upstreams + passive health), then retire the
 # old replica. Existing traffic is served the entire time.
 #

--- a/deploy/oracle/README.md
+++ b/deploy/oracle/README.md
@@ -60,7 +60,7 @@ https://preview.example.com/?token=<TOKEN>
 
 Endpoints (token via `?token=` or `X-Compose-Preview-Token`):
 `GET /` index · `GET /p/{id}` viewer · `GET /render/{id}.png` PNG · `GET /healthz`
-(unauthenticated).
+liveness · `GET /readyz` readiness (both unauthenticated).
 
 ## Operating it
 

--- a/deploy/vps/README.md
+++ b/deploy/vps/README.md
@@ -67,7 +67,7 @@ https://preview.example.com/?token=<TOKEN>
 
 Endpoints (token via `?token=` or `X-Compose-Preview-Token`):
 `GET /` index · `GET /p/{id}` viewer · `GET /render/{id}.png` PNG · `GET /healthz`
-(unauthenticated).
+liveness · `GET /readyz` readiness (both unauthenticated).
 
 ## Operating it
 

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -373,9 +373,11 @@ indexed here); otherwise the served module's preview grid · `GET /p/{id}?sessio
 `GET /render/{id}.png` PNG ·
 `GET /api/previews` JSON (now includes `trust`) · `POST /bundles/{name}` upload (returns `trust`) ·
 `GET /wasm/{system}/…` in-browser CMP app (ungated static assets) · `GET /status` server status
-(HTML, or JSON with `?format=json`) · `GET /status.json` server status JSON · `GET /healthz` ·
-`GET /version`. In `--public` mode all are open **and links carry no `?token`** (the token gates
-nothing); otherwise the token gates everything but `/healthz`, `/version`, and `/wasm/` (static, no
+(HTML, or JSON with `?format=json`) · `GET /status.json` server status JSON · `GET /healthz`
+liveness · `GET /readyz` readiness (green only once a preview actually renders — the docker-rollout
+gate) · `GET /version`. In `--public` mode all are open **and links carry no `?token`** (the token
+gates nothing); otherwise the token gates everything but `/healthz`, `/readyz`, `/version`, and
+`/wasm/` (static, no
 session data) and is threaded through every generated link. `/status` is gated like the API routes
 (open in `--public`, else token-required) — its running-daemon + config detail is more sensitive
 than the bare `/version`/`/healthz`, so a private box keeps it behind the token.
@@ -424,7 +426,7 @@ the session instead of `?session=`: `GET /{system}/` index · `GET /{system}/p/{
 `GET /{system}/render/{id}.png` PNG · `GET /{system}/api/previews` JSON · `GET /{system}/bundle.zip`
 · `WS /{system}/ws/{id}` stream. This is the canonical public URL for a published catalog
 (`/compose-m3/`, `/meshcore-mobile/`, …); the `?session=` form stays for back-compat. The constant
-routes (`/healthz`, `/version`, `/status`, `/status.json`, `/bundle.zip`, `/wasm/…`) outrank the
+routes (`/healthz`, `/readyz`, `/version`, `/status`, `/status.json`, `/bundle.zip`, `/wasm/…`) outrank the
 `/{system}` catch-all, so an unknown single segment just 404s like a bad session.
 
 `GET /version` is the host's machine-readable identity — ungated so a deployer, Watchtower check, or


### PR DESCRIPTION
## Summary

The staged docker-rollout swap waited on `/healthz` — but that route is a static `call.respondText("ok")` (`ServeHttpServer.kt`). It goes green the instant the HTTP listener binds and **proves nothing rendered**. So the "wait for the new replica to be able to serve traffic" premise wasn't actually met: a replica whose catalogs failed to load or whose render pipeline is dead still reports `healthy`, and docker-rollout would drain traffic onto it **and retire the old replica** — turning a zero-downtime swap into an outage with no fallback.

What `/healthz` *does* gate (catalog fetch is synchronous before the port binds) is fine; what it never checked is whether a render actually works. This PR closes that gap.

### Changes

- **New `/readyz` readiness route** (ungated, like `/healthz`). It latches green only after a *representative preview actually renders* on the host:
  - Leases the default session, renders its first preview override-free. For a catalog session that's the baked snapshot — cheap, and never wakes the daemon (`ServeCatalogLiveHost.render`); for a plain module it's a real daemon render.
  - Latches on first success and answers instantly thereafter, so the ~10s healthcheck poll stays cheap even against a daemon-backed module. A single probe renders at a time (`readinessProbeInFlight`) so a burst of polls can't stack N concurrent renders.
  - `503 "warming"` until proven; `200 "ready"` after. Upload-only servers (no landing session) latch ready immediately — nothing to prove, listener is up.
- **Compose healthcheck now hits `/readyz`** (`deploy/image/docker-compose.yml`) — the actual rollout gate. `/healthz` stays as pure liveness.
- **Docs/config updated** to describe the gate accurately: `deploy/image/{README.md,rollout.sh,Caddyfile}`, `deploy/{vps,oracle,cloudrun}/README.md`, `docs/public-preview-server.md`. Cloud Run's own startup probe is left on `/healthz` (its comment already justifies that for the build-then-bind mode); its README notes the new route.

## Test plan

- `:cli:test --tests ServeHttpRoutingTest` — green. Added:
  - `readyz is green once the default session renders a preview` (+ latches on a second poll).
  - `readyz withholds ready when the default session cannot render` — an empty-registry server returns `503 "warming"`, proving the gate actually withholds a false green.
- Existing `constant top-level routes still win over the system catch-all` extended to cover `/readyz` route scoring vs the `/{system}` catch-all.
- Non-visual change (health-check plumbing + docs), so no rendered before/after applies.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpJsKNrF6z67fZ8uaLD8uo)_