### PR TITLE
feat(serve): drive Remote Compose named values + profile from the live serve host

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -837,13 +837,7 @@ class ServeHttpServer(
           .entries()
           .mapNotNull { (key, values) ->
             val value = values.firstOrNull() ?: return@mapNotNull null
-            if (
-              key in ServeOverrides.SUPPORTED_KEYS || key.startsWith(ServeOverrides.KNOB_PREFIX)
-            ) {
-              key to value
-            } else {
-              null
-            }
+            if (ServeOverrides.isOverrideParam(key)) key to value else null
           }
           .toMap()
       val knobKinds =
@@ -1053,22 +1047,15 @@ class ServeHttpServer(
       val wantSvg = rawName.endsWith(".svg")
       val wantSlots = rawName.endsWith(".slots")
       val previewId = rawName.removeSuffix(".png").removeSuffix(".svg").removeSuffix(".slots")
-      // Forward the fixed render axes plus any author-declared knob params (`knob.<key>=…`, dynamic
-      // keys not in SUPPORTED_KEYS) so a live knob edit reaches ServeOverrides.parse instead of
-      // being
-      // silently dropped.
+      // Forward the fixed render axes plus any dynamic override params (`knob.<key>=…` knobs and
+      // `rc.<name>=…` Remote Compose seeds, neither in SUPPORTED_KEYS) so a live knob / Remote
+      // Compose edit reaches ServeOverrides.parse instead of being silently dropped.
       val overrideParams =
         call.request.queryParameters
           .entries()
           .mapNotNull { (key, values) ->
             val value = values.firstOrNull() ?: return@mapNotNull null
-            if (
-              key in ServeOverrides.SUPPORTED_KEYS || key.startsWith(ServeOverrides.KNOB_PREFIX)
-            ) {
-              key to value
-            } else {
-              null
-            }
+            if (ServeOverrides.isOverrideParam(key)) key to value else null
           }
           .toMap()
       // Type a bare `knob.<key>=<value>` from the preview's declared knobs (an explicit

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -1236,13 +1236,7 @@ class ServeHttpServer(
             .entries()
             .mapNotNull { (key, values) ->
               val value = values.firstOrNull() ?: return@mapNotNull null
-              if (
-                key in ServeOverrides.SUPPORTED_KEYS || key.startsWith(ServeOverrides.KNOB_PREFIX)
-              ) {
-                key to value
-              } else {
-                null
-              }
+              if (ServeOverrides.isOverrideParam(key)) key to value else null
             }
             .toMap()
         // Non-suspending hand-off to the socket; drop frames a slow client can't keep up with.

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeOverrides.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeOverrides.kt
@@ -4,6 +4,9 @@ import ee.schimke.composeai.daemon.protocol.FocusOverride
 import ee.schimke.composeai.daemon.protocol.GestureOverride
 import ee.schimke.composeai.daemon.protocol.Orientation
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.daemon.protocol.RemoteComposeOverride
+import ee.schimke.composeai.daemon.protocol.RemoteComposeProfile
+import ee.schimke.composeai.daemon.protocol.RemoteNamedValue
 import ee.schimke.composeai.daemon.protocol.UiMode
 import ee.schimke.composeai.data.overrides.PreviewOverrideValue
 import java.security.MessageDigest
@@ -84,6 +87,12 @@ object ServeOverrides {
       // `clearBackground=true`; both map to `PreviewOverrides.clearBackground`.
       "background",
       "clearBackground",
+      // Remote Compose platform profile (`RcPlatformProfiles` variant) the daemon compiles the
+      // remote document against. Wire names match `RemoteComposeProfile` (androidx, androidx7…,
+      // widgetsV6/V7, wearWidgets). Daemon-only + Android-only — a desktop/static session ignores
+      // it. The per-name seeds ride the dynamic `rc.<name>=…` prefix ([RC_NAMED_PREFIX]), like the
+      // `knob.` knobs.
+      "rcProfile",
     )
 
   /**
@@ -101,10 +110,42 @@ object ServeOverrides {
   const val KNOB_PREFIX = "knob."
 
   /**
+   * Prefix for Remote Compose named-value seeds: `rc.<name>=<value>`, e.g. `rc.label=Tap me` or
+   * `rc.stopColor=color:%23FF8800`. These feed `PreviewOverrides.remoteCompose.namedValues` (the
+   * `RemoteComposeOverride` facet the `:data-remotecompose-connector` bridges into the running
+   * `RemoteDocumentPlayer`'s `StateUpdater`), which is a **separate channel** from the generic
+   * `knob.` overrides — a Remote Compose sticker's `rememberNamedRemote*` binding is reachable only
+   * through this facet, never the `compose/overrides` knob map. Unlike `knob.`, there is no
+   * per-preview declaration to infer the type from, so the value carries its own `<kind>:<value>`
+   * tag ([RC_KNOWN_KINDS], default `string`). Daemon-only + Android-only — a desktop/static session
+   * has no Remote Compose runtime and ignores it. Dynamic keys, so not listed in [SUPPORTED_KEYS].
+   */
+  const val RC_NAMED_PREFIX = "rc."
+
+  /**
+   * True when [key] is a param [parse] consumes — a fixed [SUPPORTED_KEYS] axis, an author-declared
+   * `knob.` knob, or an `rc.` Remote Compose seed. The HTTP `GET /render` handlers filter the query
+   * string through this so a dynamic knob/rc edit reaches [parse] instead of being dropped, while
+   * an unrelated param (a cache-buster, an analytics tag) never does. The `message.overrides` map
+   * the WebSocket live/stream sessions send is already scoped, so it is passed to [parse]
+   * wholesale.
+   */
+  fun isOverrideParam(key: String): Boolean =
+    key in SUPPORTED_KEYS || key.startsWith(KNOB_PREFIX) || key.startsWith(RC_NAMED_PREFIX)
+
+  /**
    * The `<kind>` tags an explicit `knob.<key>=<kind>:<value>` may carry (legacy /
    * declaration-less).
    */
   private val KNOWN_KINDS: Set<String> = setOf("string", "int", "float", "bool", "color")
+
+  /**
+   * The `<kind>` tags an `rc.<name>=<kind>:<value>` seed may carry. Superset of [KNOWN_KINDS] with
+   * `dp` — Remote Compose distinguishes a density-independent measure ([RemoteNamedValue.DpValue])
+   * from a raw float, matching the connector's `setUserLocalFloat` (dp) vs `setUserLocalFloat`
+   * (float) bind. A bare value with no recognised prefix is a `string`.
+   */
+  private val RC_KNOWN_KINDS: Set<String> = setOf("string", "int", "float", "dp", "bool", "color")
 
   /**
    * Map a `compose/overrides` declaration `type` to the [PreviewOverrideValue] wire kind. Shared
@@ -408,6 +449,66 @@ object ServeOverrides {
         }
     }
 
+    // Remote Compose profile (`rcProfile=<wire name>`). Absent → null (the connector's default
+    // ANDROIDX). An unknown value is a hard Invalid rather than a silently-ignored profile.
+    val rcProfile: RemoteComposeProfile? =
+      params["rcProfile"]
+        ?.takeIf { it.isNotBlank() }
+        ?.let {
+          when (it.lowercase()) {
+            "androidx" -> RemoteComposeProfile.ANDROIDX
+            "androidx7" -> RemoteComposeProfile.ANDROIDX7
+            "androidx8" -> RemoteComposeProfile.ANDROIDX8
+            "androidx9" -> RemoteComposeProfile.ANDROIDX9
+            "widgetsv6" -> RemoteComposeProfile.WIDGETS_V6
+            "widgetsv7" -> RemoteComposeProfile.WIDGETS_V7
+            "wearwidgets" -> RemoteComposeProfile.WEAR_WIDGETS
+            else ->
+              return OverrideParse.Invalid(
+                "rcProfile must be one of androidx/androidx7/androidx8/androidx9/widgetsV6/" +
+                  "widgetsV7/wearWidgets, got '$it'"
+              )
+          }
+        }
+
+    // Remote Compose named-value seeds (`rc.<name>=<value>`, own `<kind>:<value>` tag, default
+    // string). A malformed typed value is a hard Invalid, mirroring the `knob.` block.
+    val rcNamedValues = mutableMapOf<String, RemoteNamedValue>()
+    for ((rawKey, raw) in params) {
+      if (!rawKey.startsWith(RC_NAMED_PREFIX)) continue
+      val name = rawKey.removePrefix(RC_NAMED_PREFIX)
+      if (name.isBlank() || raw.isBlank()) continue
+      val sep = raw.indexOf(':')
+      val kind = if (sep > 0) raw.substring(0, sep).takeIf { it in RC_KNOWN_KINDS } else null
+      val value = if (kind != null) raw.substring(sep + 1) else raw
+      rcNamedValues[name] =
+        when (kind ?: "string") {
+          "string" -> RemoteNamedValue.StringValue(value)
+          "int" ->
+            value.toIntOrNull()?.let { RemoteNamedValue.IntValue(it) }
+              ?: return OverrideParse.Invalid("rc '$name' int must be an integer, got '$value'")
+          "float" ->
+            value.toFloatOrNull()?.let { RemoteNamedValue.FloatValue(it) }
+              ?: return OverrideParse.Invalid("rc '$name' float must be a number, got '$value'")
+          "dp" ->
+            value.toFloatOrNull()?.let { RemoteNamedValue.DpValue(it) }
+              ?: return OverrideParse.Invalid("rc '$name' dp must be a number, got '$value'")
+          "bool" ->
+            RemoteNamedValue.BooleanValue(value.equals("true", ignoreCase = true) || value == "1")
+          // Color carries the raw `#AARRGGBB` string; the connector strips `#` and skips a value it
+          // can't parse (a panel typo must not crash the render), so accept any string here.
+          "color" -> RemoteNamedValue.ColorValue(value)
+          else -> return OverrideParse.Invalid("rc '$name' has unknown kind '$kind'")
+        }
+    }
+
+    // Fold the two Remote Compose facets into one override, or leave null when neither is present
+    // so
+    // an rc-free render carries no `remoteCompose` payload (identical wire shape to before).
+    val remoteCompose: RemoteComposeOverride? =
+      if (rcProfile == null && rcNamedValues.isEmpty()) null
+      else RemoteComposeOverride(profile = rcProfile, namedValues = rcNamedValues)
+
     return OverrideParse.Ok(
       PreviewOverrides(
         widthPx = widthPx,
@@ -431,6 +532,7 @@ object ServeOverrides {
         gestures = gestures,
         clearBackground = clearBackground,
         namedOverrides = namedOverrides.ifEmpty { null },
+        remoteCompose = remoteCompose,
       )
     )
   }
@@ -468,6 +570,14 @@ object ServeOverrides {
       // key for order-independence; the value data classes have stable toString.
       append("named=")
       o.namedOverrides?.toSortedMap()?.forEach { (k, v) ->
+        append(k).append('=').append(v).append(';')
+      }
+      // Remote Compose facet participates for the same reason — an `rc.` seed / profile edit must
+      // re-render. Named values sorted for order-independence; the value/profile toStrings are
+      // stable. acceptedHostActions is never set from the serve query path, so it is omitted.
+      append("|rcProfile=").append(o.remoteCompose?.profile)
+      append("|rc=")
+      o.remoteCompose?.namedValues?.toSortedMap()?.forEach { (k, v) ->
         append(k).append('=').append(v).append(';')
       }
     }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeOverridesTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeOverridesTest.kt
@@ -1,6 +1,8 @@
 package ee.schimke.composeai.cli.serve
 
 import ee.schimke.composeai.daemon.protocol.Orientation
+import ee.schimke.composeai.daemon.protocol.RemoteComposeProfile
+import ee.schimke.composeai.daemon.protocol.RemoteNamedValue
 import ee.schimke.composeai.daemon.protocol.UiMode
 import ee.schimke.composeai.data.overrides.PreviewOverrideValue
 import kotlin.test.Test
@@ -473,5 +475,119 @@ class ServeOverridesTest {
     assertEquals(PreviewMode.LIVE, PreviewMode.parse("live"))
     assertNull(PreviewMode.parse("bogus"))
     assertNull(PreviewMode.parse(null))
+  }
+
+  @Test
+  fun `no remote compose params leaves the facet null`() {
+    assertNull(ok(emptyMap()).remoteCompose)
+    // A generic knob alone must NOT synthesise a remoteCompose facet.
+    assertNull(ok(mapOf("knob.label" to "Hi")).remoteCompose)
+  }
+
+  @Test
+  fun `rc named seeds map to typed remote named values`() {
+    val rc =
+      ok(
+          mapOf(
+            "rc.label" to "Tap me",
+            "rc.count" to "int:3",
+            "rc.ratio" to "float:0.5",
+            "rc.gap" to "dp:8",
+            "rc.on" to "bool:true",
+            "rc.stopColor" to "color:#FF8800",
+          )
+        )
+        .remoteCompose
+    assertNotNull(rc)
+    assertEquals(RemoteNamedValue.StringValue("Tap me"), rc.namedValues["label"])
+    assertEquals(RemoteNamedValue.IntValue(3), rc.namedValues["count"])
+    assertEquals(RemoteNamedValue.FloatValue(0.5f), rc.namedValues["ratio"])
+    assertEquals(RemoteNamedValue.DpValue(8f), rc.namedValues["gap"])
+    assertEquals(RemoteNamedValue.BooleanValue(true), rc.namedValues["on"])
+    assertEquals(RemoteNamedValue.ColorValue("#FF8800"), rc.namedValues["stopColor"])
+    assertNull(rc.profile)
+  }
+
+  @Test
+  fun `a bare rc value is a string`() {
+    val rc = ok(mapOf("rc.label" to "Ship it")).remoteCompose
+    assertEquals(RemoteNamedValue.StringValue("Ship it"), rc?.namedValues?.get("label"))
+  }
+
+  @Test
+  fun `an unknown rc kind prefix is treated as part of the string`() {
+    // `weird` isn't a known kind, so the whole value is the string — never a hard error.
+    val rc = ok(mapOf("rc.label" to "weird:value")).remoteCompose
+    assertEquals(RemoteNamedValue.StringValue("weird:value"), rc?.namedValues?.get("label"))
+  }
+
+  @Test
+  fun `a malformed typed rc value is rejected`() {
+    for (bad in listOf("rc.count" to "int:x", "rc.ratio" to "float:nan!", "rc.gap" to "dp:big")) {
+      val parsed = ServeOverrides.parse(mapOf(bad))
+      assertTrue(parsed is OverrideParse.Invalid, "expected Invalid for $bad, got $parsed")
+    }
+  }
+
+  @Test
+  fun `blank rc name or value is skipped`() {
+    // `rc.` with no name, and a present-but-blank value, both drop out rather than seeding.
+    assertNull(ok(mapOf("rc." to "x", "rc.label" to "")).remoteCompose)
+  }
+
+  @Test
+  fun `rc profile parses known wire names and rejects unknown`() {
+    assertEquals(
+      RemoteComposeProfile.ANDROIDX,
+      ok(mapOf("rcProfile" to "androidx")).remoteCompose?.profile,
+    )
+    assertEquals(
+      RemoteComposeProfile.WEAR_WIDGETS,
+      ok(mapOf("rcProfile" to "wearWidgets")).remoteCompose?.profile,
+    )
+    // Case-insensitive on the wire name.
+    assertEquals(
+      RemoteComposeProfile.WIDGETS_V6,
+      ok(mapOf("rcProfile" to "WIDGETSV6")).remoteCompose?.profile,
+    )
+    assertTrue(ServeOverrides.parse(mapOf("rcProfile" to "bogus")) is OverrideParse.Invalid)
+  }
+
+  @Test
+  fun `rc profile alone populates the facet`() {
+    val rc = ok(mapOf("rcProfile" to "androidx9")).remoteCompose
+    assertNotNull(rc)
+    assertEquals(RemoteComposeProfile.ANDROIDX9, rc.profile)
+    assertTrue(rc.namedValues.isEmpty())
+  }
+
+  @Test
+  fun `isOverrideParam accepts fixed rc and knob keys and rejects others`() {
+    assertTrue(ServeOverrides.isOverrideParam("uiMode"))
+    assertTrue(ServeOverrides.isOverrideParam("rcProfile"))
+    assertTrue(ServeOverrides.isOverrideParam("rc.label"))
+    assertTrue(ServeOverrides.isOverrideParam("knob.count"))
+    assertTrue(!ServeOverrides.isOverrideParam("cacheBuster"))
+  }
+
+  @Test
+  fun `cache key differs when a remote compose facet changes`() {
+    assertNotEquals(
+      ServeOverrides.cacheKey("preview.A", ok(mapOf("rc.label" to "A"))),
+      ServeOverrides.cacheKey("preview.A", ok(emptyMap())),
+    )
+    assertNotEquals(
+      ServeOverrides.cacheKey("preview.A", ok(mapOf("rc.label" to "A"))),
+      ServeOverrides.cacheKey("preview.A", ok(mapOf("rc.label" to "B"))),
+    )
+    assertNotEquals(
+      ServeOverrides.cacheKey("preview.A", ok(mapOf("rcProfile" to "androidx"))),
+      ServeOverrides.cacheKey("preview.A", ok(mapOf("rcProfile" to "androidx9"))),
+    )
+    // Order-independent + stable for equal seeds.
+    assertEquals(
+      ServeOverrides.cacheKey("preview.A", ok(mapOf("rc.a" to "1", "rc.b" to "2"))),
+      ServeOverrides.cacheKey("preview.A", ok(mapOf("rc.b" to "2", "rc.a" to "1"))),
+    )
   }
 }


### PR DESCRIPTION
## Summary

The public/live preview server (`compose-preview serve`) already renders the Remote Compose design catalog (`samples/design-catalog-remote-m3`) live — it packs as an **android** backend, so `ServeBundleDaemon.materialize` spins up a Robolectric daemon and the Android `DaemonMain` registers the `RemoteComposeDataProductRegistry` + override extension whenever the alpha `compose-remote` runtime is on the classpath.

What was missing was the **override channel**: `ServeOverrides.parse` (the `/render` query → `PreviewOverrides` mapper) had no path to the `PreviewOverrides.remoteCompose` facet. So a viewer on the live server could never flip a Remote Compose named-value sticker — the `NamedLabelRemoteButton` label, the `ShaderGradientSticker` middle stop — even though the daemon connector fully supports it via `renderNow.overrides.remoteCompose` (the same facet the VS Code `interactive/setRemoteCompose` path drives). Remote Compose named values are a **separate channel** from the generic `knob.` overrides: a `rememberNamedRemote*` binding is reachable only through `RemoteComposeController.namedValues`, never the `compose/overrides` knob map (`applyConnectorOverrides` reads only the former).

This wires that channel into the serve host.

## What changed

- **`ServeOverrides.parse`** gains two query-param channels, mirroring the existing `knob.` mechanism:
  - `rc.<name>=<value>` — a typed Remote Compose named-value seed. Because there's no per-preview declaration to infer the type from (unlike `knob.`), the value carries its own `<kind>:<value>` tag — kinds `string` / `int` / `float` / `dp` / `bool` / `color`, default `string`. Malformed typed values are a hard `Invalid`, matching the numeric fields. Maps to `RemoteComposeOverride.namedValues`.
  - `rcProfile=<wire name>` — the `RemoteComposeProfile` platform profile (`androidx`, `androidx7…9`, `widgetsV6/V7`, `wearWidgets`; case-insensitive). Unknown → `Invalid`.
- Both fold into `PreviewOverrides.remoteCompose`, left `null` when neither is present so an rc-free render keeps its prior wire shape, and both participate in the render `cacheKey` so an rc edit isn't coalesced onto the prior frame.
- **`ServeOverrides.isOverrideParam(key)`** — a shared predicate (fixed key ∪ `knob.` ∪ `rc.`) that both HTTP `GET /render` param filters in `ServeHttpServer` now route through, replacing the duplicated inline `key in SUPPORTED_KEYS || startsWith(KNOB_PREFIX)` checks. The WebSocket live/stream sessions already forward their scoped `message.overrides` map wholesale, so they need no filter change and pick up the new facet for free.

## Test plan

- [x] `./gradlew :cli:test --tests "ee.schimke.composeai.cli.serve.ServeOverridesTest"` — green. Added coverage: typed `rc.` seeds (each kind), bare-value-is-string, unknown-kind-prefix-is-literal, malformed-typed-value rejection, blank name/value skipped, profile parsing (known + case-insensitive + unknown-rejected), profile-alone populates the facet, `isOverrideParam` accepts fixed/`rc.`/`knob.` and rejects others, and `cacheKey` participation (differs on value/profile, order-independent).
- [x] `./gradlew :cli:ktfmtCheckMain :cli:ktfmtCheckTest` — clean.

## Notes / follow-ups

- Non-visual change (query-param plumbing + tests), so no rendered before/after — text evidence per the repo's visual-evidence rule.
- This enables **shared-link / API-driven** live Remote Compose edits (`?rc.label=…`, `?rcProfile=…`). Auto-generating a slider/control in the browse UI for these is a separate, larger change: Remote Compose named values aren't emitted as `compose/overrides` declarations at discovery time, so the viewer has no declaration to render a widget from. Worth a fast-follow if we want the knob chips to appear automatically for the remote-m3 stickers.

---
_Generated by [Claude Code](https://claude.ai/code/session_011K7sgCfdsbhN7fwMb3WhSS)_