### PR TITLE
feat(remotecompose): auto-capture editable named-value knob declarations

### DIFF
--- a/data/remotecompose/connector/src/main/kotlin/ee/schimke/composeai/daemon/RemoteComposeController.kt
+++ b/data/remotecompose/connector/src/main/kotlin/ee/schimke/composeai/daemon/RemoteComposeController.kt
@@ -7,6 +7,7 @@ import ee.schimke.composeai.daemon.protocol.RemoteComposeOverride
 import ee.schimke.composeai.daemon.protocol.RemoteComposeProfile
 import ee.schimke.composeai.daemon.protocol.RemoteHostAction
 import ee.schimke.composeai.daemon.protocol.RemoteNamedValue
+import ee.schimke.composeai.data.remotecompose.RemoteComposeKnobDeclaration
 import ee.schimke.composeai.data.remotecompose.RemoteComposePayload
 import java.util.concurrent.CopyOnWriteArrayList
 
@@ -49,6 +50,13 @@ object RemoteComposeController {
 
   private val profileState: MutableState<RemoteComposeProfile?> = mutableStateOf(null)
 
+  // Editable named-value knobs the current render declared, keyed by name for dedup with first-seen
+  // order preserved (a re-declaration during recomposition replaces the entry in place). Mirrors
+  // `PreviewOverrideController.declarationsState` — the auto-capture surface the viewer renders
+  // controls from.
+  private val declarationsState: MutableState<Map<String, RemoteComposeKnobDeclaration>> =
+    mutableStateOf(emptyMap())
+
   /**
    * Optional allow-list for [recordHostAction]. `null` accepts every action; non-null filters by
    * `payload` membership. Snapshot of the override's `acceptedHostActions`.
@@ -66,6 +74,26 @@ object RemoteComposeController {
 
   val profile: State<RemoteComposeProfile?>
     get() = profileState
+
+  /**
+   * Record an editable knob the preview just declared (via a `LocalRemoteComposeHost` named-value
+   * read, or an explicit `declareKnob`). Keyed by [RemoteComposeKnobDeclaration.name]; a repeat
+   * declaration of the same name (recomposition) replaces the prior entry while keeping its position
+   * so the viewer's control list stays stable. Idempotent — re-recording an identical declaration
+   * doesn't notify listeners. Mirrors `PreviewOverrideController.record`.
+   */
+  fun recordDeclaration(declaration: RemoteComposeKnobDeclaration) {
+    val current = declarationsState.value
+    if (current[declaration.name] == declaration) return
+    // LinkedHashMap preserves first-seen order even when replacing an existing name's value.
+    val next = LinkedHashMap(current)
+    next[declaration.name] = declaration
+    declarationsState.value = next
+    listeners.toList().forEach { it() }
+  }
+
+  /** The knobs declared so far this render, in declaration order. */
+  fun declarations(): List<RemoteComposeKnobDeclaration> = declarationsState.value.values.toList()
 
   /**
    * Read [name]'s current value, or `null` if no override / write has bound it. Caller decides the
@@ -157,6 +185,7 @@ object RemoteComposeController {
     namedValuesState.value = emptyMap()
     hostActionsState.value = emptyList()
     profileState.value = null
+    declarationsState.value = emptyMap()
     acceptedActionPayloads = null
   }
 }

--- a/data/remotecompose/connector/src/main/kotlin/ee/schimke/composeai/daemon/RemoteComposeController.kt
+++ b/data/remotecompose/connector/src/main/kotlin/ee/schimke/composeai/daemon/RemoteComposeController.kt
@@ -96,6 +96,18 @@ object RemoteComposeController {
   fun declarations(): List<RemoteComposeKnobDeclaration> = declarationsState.value.values.toList()
 
   /**
+   * Drop the recorded declarations at the start of a render pass, keeping named values / profile /
+   * host actions, so a held session re-rendering with a shrunk knob set doesn't carry stale
+   * declarations from an earlier pass. Called from [RemoteComposeOverrideExtension] before the pass
+   * re-records via the `named*` reads' `SideEffect`s. Mirrors
+   * `PreviewOverrideController.clearDeclarations`.
+   */
+  fun clearDeclarations() {
+    if (declarationsState.value.isEmpty()) return
+    declarationsState.value = emptyMap()
+  }
+
+  /**
    * Read [name]'s current value, or `null` if no override / write has bound it. Caller decides the
    * default (the `LocalRemoteComposeHost.namedFloat(name, default)` helpers default to the user-
    * supplied fallback when this returns null).

--- a/data/remotecompose/connector/src/main/kotlin/ee/schimke/composeai/daemon/RemoteComposeDataProduct.kt
+++ b/data/remotecompose/connector/src/main/kotlin/ee/schimke/composeai/daemon/RemoteComposeDataProduct.kt
@@ -11,6 +11,7 @@ import androidx.compose.remote.creation.profile.RcPlatformProfiles
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.getValue
 import ee.schimke.composeai.daemon.protocol.DataFetchResult
@@ -117,9 +118,7 @@ private object ControllerRemoteComposeHost : RemoteComposeHost {
 
   @Composable
   override fun namedFloat(name: String, default: Float): Float {
-    RemoteComposeController.recordDeclaration(
-      RemoteComposeKnobDeclaration(name, RemoteNamedValue.FloatValue(default))
-    )
+    declareInComposition(name, RemoteNamedValue.FloatValue(default))
     val current by RemoteComposeController.namedValues
     return when (val v = current[name]) {
       is RemoteNamedValue.FloatValue -> v.value
@@ -131,18 +130,14 @@ private object ControllerRemoteComposeHost : RemoteComposeHost {
 
   @Composable
   override fun namedBoolean(name: String, default: Boolean): Boolean {
-    RemoteComposeController.recordDeclaration(
-      RemoteComposeKnobDeclaration(name, RemoteNamedValue.BooleanValue(default))
-    )
+    declareInComposition(name, RemoteNamedValue.BooleanValue(default))
     val current by RemoteComposeController.namedValues
     return (current[name] as? RemoteNamedValue.BooleanValue)?.value ?: default
   }
 
   @Composable
   override fun namedInt(name: String, default: Int): Int {
-    RemoteComposeController.recordDeclaration(
-      RemoteComposeKnobDeclaration(name, RemoteNamedValue.IntValue(default))
-    )
+    declareInComposition(name, RemoteNamedValue.IntValue(default))
     val current by RemoteComposeController.namedValues
     return when (val v = current[name]) {
       is RemoteNamedValue.IntValue -> v.value
@@ -153,20 +148,31 @@ private object ControllerRemoteComposeHost : RemoteComposeHost {
 
   @Composable
   override fun namedString(name: String, default: String): String {
-    RemoteComposeController.recordDeclaration(
-      RemoteComposeKnobDeclaration(name, RemoteNamedValue.StringValue(default))
-    )
+    declareInComposition(name, RemoteNamedValue.StringValue(default))
     val current by RemoteComposeController.namedValues
     return (current[name] as? RemoteNamedValue.StringValue)?.value ?: default
   }
 
   @Composable
   override fun namedColor(name: String, default: String): String {
-    RemoteComposeController.recordDeclaration(
-      RemoteComposeKnobDeclaration(name, RemoteNamedValue.ColorValue(default))
-    )
+    declareInComposition(name, RemoteNamedValue.ColorValue(default))
     val current by RemoteComposeController.namedValues
     return (current[name] as? RemoteNamedValue.ColorValue)?.argb ?: default
+  }
+
+  /**
+   * Record the read name as an editable knob from a `SideEffect`, not directly during composition:
+   * mirrors `ControllerPreviewOverrideHost`'s `previewOverride*`. A `SideEffect` runs after the
+   * `DisposableEffect` clear that [RemoteComposeOverrideExtension] performs at render start (Compose
+   * runs every `RememberObserver` before any `SideEffect`), so each pass's declaration set is rebuilt
+   * from scratch, and it never writes controller snapshot state mid-composition (which would risk a
+   * recompose loop).
+   */
+  @Composable
+  private fun declareInComposition(name: String, default: RemoteNamedValue) {
+    SideEffect {
+      RemoteComposeController.recordDeclaration(RemoteComposeKnobDeclaration(name, default))
+    }
   }
 
   override fun setNamedValue(name: String, value: RemoteNamedValue) {
@@ -246,6 +252,11 @@ class RemoteComposeOverrideExtension(private val seed: RemoteComposeOverride? = 
   override fun AroundComposable(content: @Composable () -> Unit) {
     DisposableEffect(seed) {
       RemoteComposeController.set(seed)
+      // Clear declarations at render start (mirrors PreviewOverridesOverrideExtension): a held
+      // session re-rendering with a shrunk knob set must not carry stale controls. A DisposableEffect
+      // runs as a RememberObserver, which Compose invokes before any SideEffect, so this clear always
+      // precedes the `named*` reads' SideEffect-recorded declarations for this pass.
+      RemoteComposeController.clearDeclarations()
       onDispose { RemoteComposeController.resetForNewSession() }
     }
     CompositionLocalProvider(LocalRemoteComposeHost provides ControllerRemoteComposeHost) {

--- a/data/remotecompose/connector/src/main/kotlin/ee/schimke/composeai/daemon/RemoteComposeDataProduct.kt
+++ b/data/remotecompose/connector/src/main/kotlin/ee/schimke/composeai/daemon/RemoteComposeDataProduct.kt
@@ -22,6 +22,7 @@ import ee.schimke.composeai.daemon.protocol.RemoteComposeOverride
 import ee.schimke.composeai.daemon.protocol.RemoteComposeProfile
 import ee.schimke.composeai.daemon.protocol.RemoteHostAction
 import ee.schimke.composeai.daemon.protocol.RemoteNamedValue
+import ee.schimke.composeai.data.remotecompose.RemoteComposeKnobDeclaration
 import ee.schimke.composeai.data.remotecompose.RemoteComposePayload
 import ee.schimke.composeai.data.remotecompose.RemoteComposeProduct
 import ee.schimke.composeai.data.render.PreviewContext
@@ -84,6 +85,16 @@ interface RemoteComposeHost {
   @Composable fun namedColor(name: String, default: String): String
 
   /**
+   * Declare [name] as an editable named-value knob with [default] as its author fallback, so a
+   * consumer (the VS Code panel, the serve viewer) can render a control for it and write an edit
+   * back through `renderNow.overrides.remoteCompose.namedValues`. The typed `namedFloat` /
+   * `namedString` / … reads above already self-declare, so call this only for a value user code
+   * binds *without* reading it through the host — e.g. a name seeded straight into the player's
+   * `StateUpdater`. Recording is deduped by name and preserves declaration order.
+   */
+  fun declareKnob(name: String, default: RemoteNamedValue)
+
+  /**
    * Push a value computed by the remote runtime back into the controller so the next
    * `data/fetch?kind=compose/remotecompose` returns it. Use from inside a `RemotePreview` block
    * after the remote computation lands a new value the host should observe.
@@ -106,6 +117,9 @@ private object ControllerRemoteComposeHost : RemoteComposeHost {
 
   @Composable
   override fun namedFloat(name: String, default: Float): Float {
+    RemoteComposeController.recordDeclaration(
+      RemoteComposeKnobDeclaration(name, RemoteNamedValue.FloatValue(default))
+    )
     val current by RemoteComposeController.namedValues
     return when (val v = current[name]) {
       is RemoteNamedValue.FloatValue -> v.value
@@ -117,12 +131,18 @@ private object ControllerRemoteComposeHost : RemoteComposeHost {
 
   @Composable
   override fun namedBoolean(name: String, default: Boolean): Boolean {
+    RemoteComposeController.recordDeclaration(
+      RemoteComposeKnobDeclaration(name, RemoteNamedValue.BooleanValue(default))
+    )
     val current by RemoteComposeController.namedValues
     return (current[name] as? RemoteNamedValue.BooleanValue)?.value ?: default
   }
 
   @Composable
   override fun namedInt(name: String, default: Int): Int {
+    RemoteComposeController.recordDeclaration(
+      RemoteComposeKnobDeclaration(name, RemoteNamedValue.IntValue(default))
+    )
     val current by RemoteComposeController.namedValues
     return when (val v = current[name]) {
       is RemoteNamedValue.IntValue -> v.value
@@ -133,18 +153,28 @@ private object ControllerRemoteComposeHost : RemoteComposeHost {
 
   @Composable
   override fun namedString(name: String, default: String): String {
+    RemoteComposeController.recordDeclaration(
+      RemoteComposeKnobDeclaration(name, RemoteNamedValue.StringValue(default))
+    )
     val current by RemoteComposeController.namedValues
     return (current[name] as? RemoteNamedValue.StringValue)?.value ?: default
   }
 
   @Composable
   override fun namedColor(name: String, default: String): String {
+    RemoteComposeController.recordDeclaration(
+      RemoteComposeKnobDeclaration(name, RemoteNamedValue.ColorValue(default))
+    )
     val current by RemoteComposeController.namedValues
     return (current[name] as? RemoteNamedValue.ColorValue)?.argb ?: default
   }
 
   override fun setNamedValue(name: String, value: RemoteNamedValue) {
     RemoteComposeController.setNamedValue(name, value)
+  }
+
+  override fun declareKnob(name: String, default: RemoteNamedValue) {
+    RemoteComposeController.recordDeclaration(RemoteComposeKnobDeclaration(name, default))
   }
 
   override fun reportHostAction(action: RemoteHostAction) {
@@ -331,13 +361,21 @@ class RemoteComposeDataProductRegistry : DataProductRegistry {
     val namedValues = RemoteComposeController.namedValues.value
     val hostActions = RemoteComposeController.hostActions.value
     val profile = RemoteComposeController.profile.value
-    if (namedValues.isEmpty() && hostActions.isEmpty() && profile == null) {
+    val declarations = RemoteComposeController.declarations()
+    if (
+      namedValues.isEmpty() && hostActions.isEmpty() && profile == null && declarations.isEmpty()
+    ) {
       clear(previewId)
       return
     }
     capture(
       previewId,
-      RemoteComposePayload(namedValues = namedValues, hostActions = hostActions, profile = profile),
+      RemoteComposePayload(
+        namedValues = namedValues,
+        hostActions = hostActions,
+        profile = profile,
+        declarations = declarations,
+      ),
     )
   }
 

--- a/data/remotecompose/connector/src/test/kotlin/ee/schimke/composeai/daemon/RemoteComposeDataProductTest.kt
+++ b/data/remotecompose/connector/src/test/kotlin/ee/schimke/composeai/daemon/RemoteComposeDataProductTest.kt
@@ -6,6 +6,7 @@ import ee.schimke.composeai.daemon.protocol.RemoteComposeOverride
 import ee.schimke.composeai.daemon.protocol.RemoteComposeProfile
 import ee.schimke.composeai.daemon.protocol.RemoteHostAction
 import ee.schimke.composeai.daemon.protocol.RemoteNamedValue
+import ee.schimke.composeai.data.remotecompose.RemoteComposeKnobDeclaration
 import ee.schimke.composeai.data.remotecompose.RemoteComposePayload
 import ee.schimke.composeai.data.render.PreviewContext
 import ee.schimke.composeai.data.render.extensions.DataExtensionHookKind
@@ -13,6 +14,7 @@ import ee.schimke.composeai.data.render.extensions.DataExtensionId
 import ee.schimke.composeai.data.render.extensions.DataExtensionPhase
 import ee.schimke.composeai.data.render.extensions.compose.AroundComposableHook
 import ee.schimke.composeai.data.render.extensions.compose.hasAroundComposableHook
+import kotlinx.serialization.json.Json
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -62,7 +64,7 @@ class RemoteComposeDataProductTest {
   fun capabilities_advertise_compose_remotecompose_as_inline_no_rerender_product() {
     val cap = RemoteComposeDataProductRegistry().capabilities.single()
     assertEquals("compose/remotecompose", cap.kind)
-    assertEquals(1, cap.schemaVersion)
+    assertEquals(2, cap.schemaVersion)
     assertEquals(DataProductTransport.INLINE, cap.transport)
     assertTrue(cap.attachable)
     assertTrue(cap.fetchable)
@@ -188,6 +190,66 @@ class RemoteComposeDataProductTest {
       DataProductRegistry.Outcome.NotAvailable,
       registry.fetch("preview-1", "compose/remotecompose", params = null, inline = true),
     )
+  }
+
+  @Test
+  fun controller_recordDeclaration_dedupes_by_name_and_preserves_order() {
+    val controller = RemoteComposeController
+    controller.recordDeclaration(
+      RemoteComposeKnobDeclaration("label", RemoteNamedValue.StringValue("Tap me"))
+    )
+    controller.recordDeclaration(
+      RemoteComposeKnobDeclaration("score", RemoteNamedValue.FloatValue(0f))
+    )
+    // Re-declaring "label" (recomposition) replaces its value but keeps first-seen position.
+    controller.recordDeclaration(
+      RemoteComposeKnobDeclaration("label", RemoteNamedValue.StringValue("Filled"))
+    )
+    val decls = controller.declarations()
+    assertEquals(2, decls.size)
+    assertEquals("label", decls[0].name)
+    assertEquals(RemoteNamedValue.StringValue("Filled"), decls[0].default)
+    assertEquals("score", decls[1].name)
+  }
+
+  @Test
+  fun controller_declarations_clear_on_reset() {
+    val controller = RemoteComposeController
+    controller.recordDeclaration(
+      RemoteComposeKnobDeclaration("label", RemoteNamedValue.StringValue("Tap me"))
+    )
+    controller.resetForNewSession()
+    assertTrue(controller.declarations().isEmpty())
+  }
+
+  @Test
+  fun on_render_captures_declared_knobs_in_payload() {
+    val registry = RemoteComposeDataProductRegistry()
+    RemoteComposeController.recordDeclaration(
+      RemoteComposeKnobDeclaration("label", RemoteNamedValue.StringValue("Filled"))
+    )
+    RemoteComposeController.recordDeclaration(
+      RemoteComposeKnobDeclaration("shaderColor", RemoteNamedValue.ColorValue("#FF7DE2FF"))
+    )
+
+    registry.onRender(
+      previewId = "preview-1",
+      result = stubRenderResult(),
+      overrides = null,
+      previewContext = stubContext(),
+    )
+
+    val outcome = registry.fetch("preview-1", "compose/remotecompose", params = null, inline = true)
+    assertTrue(outcome is DataProductRegistry.Outcome.Ok)
+    val payload =
+      Json.decodeFromJsonElement(
+        RemoteComposePayload.serializer(),
+        (outcome as DataProductRegistry.Outcome.Ok).result.payload!!,
+      )
+    assertEquals(2, payload.declarations.size)
+    assertEquals("label", payload.declarations[0].name)
+    assertEquals(RemoteNamedValue.StringValue("Filled"), payload.declarations[0].default)
+    assertEquals("shaderColor", payload.declarations[1].name)
   }
 
   private fun stubRenderResult(): RenderResult =

--- a/data/remotecompose/connector/src/test/kotlin/ee/schimke/composeai/daemon/RemoteComposeDataProductTest.kt
+++ b/data/remotecompose/connector/src/test/kotlin/ee/schimke/composeai/daemon/RemoteComposeDataProductTest.kt
@@ -223,6 +223,28 @@ class RemoteComposeDataProductTest {
   }
 
   @Test
+  fun controller_clearDeclarations_keeps_named_values_and_profile() {
+    val controller = RemoteComposeController
+    controller.set(
+      RemoteComposeOverride(
+        profile = RemoteComposeProfile.ANDROIDX,
+        namedValues = mapOf("a" to RemoteNamedValue.IntValue(1)),
+      )
+    )
+    controller.recordDeclaration(
+      RemoteComposeKnobDeclaration("label", RemoteNamedValue.StringValue("x"))
+    )
+    controller.clearDeclarations()
+    assertTrue("declarations must clear", controller.declarations().isEmpty())
+    assertEquals(
+      "profile must survive a declarations-only clear",
+      RemoteComposeProfile.ANDROIDX,
+      controller.profile.value,
+    )
+    assertEquals(RemoteNamedValue.IntValue(1), controller.valueOf("a"))
+  }
+
+  @Test
   fun on_render_captures_declared_knobs_in_payload() {
     val registry = RemoteComposeDataProductRegistry()
     RemoteComposeController.recordDeclaration(

--- a/data/remotecompose/core/src/main/kotlin/ee/schimke/composeai/data/remotecompose/RemoteComposeModels.kt
+++ b/data/remotecompose/core/src/main/kotlin/ee/schimke/composeai/data/remotecompose/RemoteComposeModels.kt
@@ -14,8 +14,29 @@ import kotlinx.serialization.Serializable
  */
 object RemoteComposeProduct {
   const val KIND: String = "compose/remotecompose"
-  const val SCHEMA_VERSION: Int = 1
+  // v2 adds [RemoteComposePayload.declarations] — the auto-captured set of editable named-value
+  // knobs a preview declared this render, so the viewer can render a control per knob instead of
+  // relying on a hand-authored sidecar. Additive + defaulted, so a v1 reader that ignores the field
+  // still decodes a v2 payload.
+  const val SCHEMA_VERSION: Int = 2
 }
+
+/**
+ * One editable Remote Compose named-value knob a preview declared during its render — the auto-
+ * capture counterpart of a plain-Compose `compose/overrides`
+ * [ee.schimke.composeai.data.overrides.PreviewOverrideDeclaration]. A knob is declared whenever
+ * user code reads a named value through `LocalRemoteComposeHost` (the typed `namedFloat` /
+ * `namedString` / … helpers self-declare) or calls
+ * `LocalRemoteComposeHost.current.declareKnob(...)` explicitly.
+ *
+ * [name] is the bare binding name (the same key `renderNow.overrides.remoteCompose.namedValues` and
+ * the serve `rc.<name>=…` param address); [default] is the author-supplied fallback, typed via the
+ * shared [RemoteNamedValue] sum so its variant carries the knob's kind (float / dp / int / string /
+ * bool / color). A consumer renders the matching control (slider, text field, colour swatch) and
+ * writes an edit back through the `remoteCompose` override facet.
+ */
+@Serializable
+data class RemoteComposeKnobDeclaration(val name: String, val default: RemoteNamedValue)
 
 /**
  * Wire-shape returned by `data/fetch?kind=compose/remotecompose`.
@@ -32,12 +53,19 @@ object RemoteComposeProduct {
  *   unboundedly.
  * * [profile] — the active platform profile (mirrors `RcPlatformProfiles`). Null when user code
  *   didn't bind one through `LocalRemoteComposeHost`.
+ * * [declarations] — the editable named-value knobs the preview declared this render, in
+ *   declaration order, deduped by name. Drives the viewer's per-knob controls (a slider / field /
+ *   swatch per entry). Empty when the preview reads no named values through
+ *   `LocalRemoteComposeHost` and never calls `declareKnob`. Distinct from [namedValues], which is
+ *   the *effective* value map (seeds + write-backs) — [declarations] is the *editable surface*
+ *   (name + author default + kind).
  */
 @Serializable
 data class RemoteComposePayload(
   val namedValues: Map<String, RemoteNamedValue> = emptyMap(),
   val hostActions: List<RemoteHostAction> = emptyList(),
   val profile: RemoteComposeProfile? = null,
+  val declarations: List<RemoteComposeKnobDeclaration> = emptyList(),
 ) {
   companion object {
     /**


### PR DESCRIPTION
## Summary

**PR 1 of the "auto-render Remote Compose knobs" series.** This lands the *producer foundation*: a preview's editable Remote Compose named values are now captured as **declarations** during render and surfaced in the `compose/remotecompose` data product, so a consumer can eventually render a control per knob instead of relying on a hand-authored sidecar.

Remote Compose named values are a separate channel from the plain-Compose `compose/overrides` knobs (a `rememberNamedRemote*` binding is reachable only through the `remoteCompose` override facet — `applyConnectorOverrides` reads only that). Unlike `previewOverride*`, whose API is connector-owned and self-records, `rememberNamedRemote*` is upstream alpha API the connector can't hook — so declaration capture is done at the connector-owned read/façade points instead.

## What changed (producer only)

- **`:data-remotecompose-core`** — new `RemoteComposeKnobDeclaration(name, default: RemoteNamedValue)` and a `declarations: List<…>` field on `RemoteComposePayload`. `RemoteComposeProduct.SCHEMA_VERSION` `1 → 2` (additive + defaulted, so a v1 reader still decodes a v2 payload).
- **`:data-remotecompose-connector`**
  - `RemoteComposeController` gains a declarations facet — `recordDeclaration` / `declarations()`, deduped by name with first-seen order preserved, cleared on `resetForNewSession` — mirroring `PreviewOverrideController`.
  - The `LocalRemoteComposeHost` typed reads (`namedFloat` / `namedString` / `namedBoolean` / `namedInt` / `namedColor`) now **self-declare** a knob (name + kind + author default), and a new `RemoteComposeHost.declareKnob(name, default)` covers a value bound without a host read (e.g. seeded straight into the player's `StateUpdater`).
  - `RemoteComposeDataProductRegistry.onRender` folds the captured declarations into the payload; the "nothing to capture" clear path now also accounts for declarations.

## Not in this PR (follow-ups)

1. **Android sandbox→host bridge** — a `SandboxRemoteComposeBridge` so declarations recorded in the Robolectric sandbox classloader reach the host registry (mirrors `SandboxPreviewOverridesBridge`). Required before the data product returns knobs on the Android path (the only backend `remote-m3` uses).
2. **Bundle-sidecar packing** — persist declarations so `serve` can advertise knobs for a baked/live catalog.
3. **Serve + VS Code viewer controls** — render a control per declared knob; edits already have a home via the serve `rc.<name>=` / `rcProfile=` params (landed in #2674) and `interactive/setRemoteCompose`.
4. **remote-m3 live lane** — flipping `publish-live-bundle`/`split-mode: full` in `design-artifacts.yml` (currently baked-only) so the knobs actually re-render live on `preview.coo.ee`.

## Test plan

- [x] `./gradlew :data-remotecompose-connector:testDebugUnitTest` — green. New coverage: declaration dedup-by-name + first-seen order, reset clearing, and `onRender` folding declarations into the fetched payload (decoded and asserted).
- [x] `./gradlew :data-remotecompose-core:ktfmtFormat :data-remotecompose-connector:ktfmtFormat` — clean.
- Non-visual (data-product plumbing + tests), so no rendered evidence; the viewer controls that need visual evidence come in the follow-up viewer PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_011K7sgCfdsbhN7fwMb3WhSS)_