### PR TITLE
feat(preview): @OverrideVariant — baked override-driven preview variants

### DIFF
--- a/api/preview-annotations/src/commonMain/kotlin/ee/schimke/composeai/preview/OverrideVariant.kt
+++ b/api/preview-annotations/src/commonMain/kotlin/ee/schimke/composeai/preview/OverrideVariant.kt
@@ -1,0 +1,69 @@
+package ee.schimke.composeai.preview
+
+/**
+ * Emits an **extra baked capture** of a `@Preview` composable with named `previewOverride*` values
+ * seeded, so a state/content variant that differs *only* by an override knob — a toggled `checked`,
+ * a disabled `enabled`, a different `label` — rides on the SAME preview function instead of a
+ * duplicated `@Composable` wrapper. Repeatable: stack one per variant.
+ *
+ * The point is to stop authoring a second one-line `@Composable` (`fun SwitchOff() = … checked =
+ * false …`) whose only difference from the primary is one flag. The primary already exposes that
+ * flag as a `previewOverrideBoolean("checked", true)` knob; this annotation renders the primary a
+ * second time with `checked = false` seeded, producing a distinct `<id>_VARIANT_<name>.png`. The
+ * design-catalog fold then surfaces it as a secondary sticker under the primary — the same place a
+ * hand-written `variants` entry used to land, minus the wrapper function and the spec entry.
+ *
+ * The compose-preview Gradle plugin's discovery task picks this up by FQN (mirroring
+ * [AmbientPreview] / [GestureHintPreview] / [ScrollingPreview]); consumers that want to use the
+ * annotation in their own code depend on `ee.schimke.composeai:preview-annotations`. The renderer
+ * seeds the values through the same `PreviewOverrideController` the daemon's
+ * `renderNow.overrides.namedOverrides` lane uses, so the baked variant and a live re-render land at
+ * the same composable seam.
+ *
+ * The seed is **typed** — the value's Kotlin type must match what the composable reads, or the read
+ * falls back to its author default (a `previewOverrideBoolean` only honours a boolean seed). Each
+ * entry is `"key=value"`, or `"key#index=value"` for an indexed knob (`previewOverrideString("row",
+ * …, index = 2)` → `"row#2=…"`). The array a value lives in picks its type: [booleans], [strings],
+ * [ints], [floats], [colors] (ARGB hex, `#AARRGGBB` or `#RRGGBB`).
+ *
+ * Applies to every `@Preview` expansion on the function (each light/dark multipreview member gets
+ * its own variant capture), the same "one annotation, applies to every expansion" policy
+ * [ScrollingPreview] / [AmbientPreview] follow.
+ *
+ * Example — the on switch, its off state folded on without a second function:
+ * ```
+ * @CatalogWearModes
+ * @OverrideVariant(name = "off", booleans = ["checked=false"])
+ * @Composable
+ * fun SwitchButtonOn() =
+ *   WearSticker {
+ *     SwitchButton(checked = previewOverrideBoolean("checked", true), onCheckedChange = {}, …)
+ *   }
+ * ```
+ *
+ * Android/Wear (Robolectric) render path only today — the desktop (Skiko) backend is fed by
+ * positional args and doesn't yet carry the seed, so a CMP-desktop catalog keeps hand-written
+ * variant functions until desktop parity lands.
+ */
+@Repeatable
+@Retention(AnnotationRetention.BINARY)
+@Target(AnnotationTarget.FUNCTION)
+@MustBeDocumented
+annotation class OverrideVariant(
+  /**
+   * Short tag distinguishing this variant, e.g. `"off"`, `"disabled"`, `"unchecked"`. Used as the
+   * `_VARIANT_<name>` suffix on the rendered file and as the variant's `state` in the catalog fold,
+   * so keep it slug-friendly (lowercase, no spaces) and unique across the function's variants.
+   */
+  val name: String,
+  /** Boolean knob seeds, each `"key=true"` / `"key=false"` (or `"key#index=…"`). */
+  val booleans: Array<String> = [],
+  /** String knob seeds, each `"key=value"` (or `"key#index=value"`). */
+  val strings: Array<String> = [],
+  /** Int knob seeds, each `"key=42"` (or `"key#index=42"`). */
+  val ints: Array<String> = [],
+  /** Float knob seeds, each `"key=0.25"` (or `"key#index=0.25"`). */
+  val floats: Array<String> = [],
+  /** Colour knob seeds, each `"key=#AARRGGBB"` (or `#RRGGBB`; or `"key#index=…"`). */
+  val colors: Array<String> = [],
+)

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
@@ -590,6 +590,40 @@ enum class PreviewExtensionUsageMode {
   SUGGESTED_EXTRA_PREVIEW,
 }
 
+/** Kind of a seeded `previewOverride*` value — mirrors `PreviewOverrideValue`'s subtypes. */
+@Serializable
+enum class OverrideSeedKind {
+  STRING,
+  BOOLEAN,
+  INT,
+  FLOAT,
+  COLOR,
+}
+
+/**
+ * One seeded `previewOverride*` value for an [OverrideVariantSpec], sourced from an
+ * `@OverrideVariant` annotation entry (`"key=value"` / `"key#index=value"`). [raw] is the verbatim
+ * string; the renderer parses it into a typed `PreviewOverrideValue` of [kind] and seeds it under
+ * `seedKey(key, index)`. Discovery keeps it stringly-typed so the plugin classpath needn't carry
+ * the overrides runtime.
+ */
+@Serializable
+data class OverrideSeed(
+  val key: String,
+  val index: Int? = null,
+  val kind: OverrideSeedKind,
+  val raw: String,
+)
+
+/**
+ * A named override variant sourced from an `@OverrideVariant` annotation. Discovery emits one extra
+ * synthetic [PreviewInfo] per variant (per multipreview member), carrying these [seeds] on
+ * [PreviewInfo.overrides]; the renderer seeds them via `PreviewOverrideController.set(...)` before
+ * composing, so the same preview function renders once more with the knob(s) flipped. [name] is the
+ * `_VARIANT_<name>` render-output tag and the variant's catalog `state`.
+ */
+@Serializable data class OverrideVariantSpec(val name: String, val seeds: List<OverrideSeed>)
+
 @Serializable
 data class PreviewInfo(
   val id: String,
@@ -597,6 +631,13 @@ data class PreviewInfo(
   val className: String,
   val sourceFile: String? = null,
   val params: PreviewParams = PreviewParams(),
+  /**
+   * Non-null on a synthetic override-variant preview (from `@OverrideVariant`): the
+   * `previewOverride*` values the renderer seeds before composing this variant. `null` on an
+   * ordinary preview, whose `previewOverride*` reads resolve to their author defaults. See
+   * [OverrideVariantSpec].
+   */
+  val overrides: OverrideVariantSpec? = null,
   /**
    * All snapshots this preview produces. Always at least one element: a static preview has a single
    * capture with null dimensions; an animated / scrolled preview can have many.

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
@@ -193,6 +193,14 @@ object PreviewDiscovery {
   private const val GESTURE_HINT_PREVIEW_FQN = "ee.schimke.composeai.preview.GestureHintPreview"
   private const val LAUNCHER_WIDGET_PREVIEW_FQN =
     "ee.schimke.composeai.preview.LauncherWidgetPreview"
+  // `@OverrideVariant` — repeatable; emits one extra synthetic preview per variant with
+  // `previewOverride*` values seeded, so a state/content variant rides on the same function instead
+  // of a duplicated wrapper. Same FQN-match policy as the other annotations we own; the
+  // `.Container`
+  // FQN is the synthetic holder Kotlin generates for the repeated case. See `OverrideVariant.kt`.
+  private const val OVERRIDE_VARIANT_FQN = "ee.schimke.composeai.preview.OverrideVariant"
+  private const val OVERRIDE_VARIANT_CONTAINER_FQN =
+    "ee.schimke.composeai.preview.OverrideVariant.Container"
   // The stable FQN is shared by both Android's ui-tooling-preview and CMP's
   // `org.jetbrains.compose.components:components-ui-tooling-preview` — Kotlin
   // `expect`/`actual` collapses onto the same `androidx...` class name on
@@ -1345,6 +1353,10 @@ object PreviewDiscovery {
     val gestureHintSpec = extractGestureHintSpec(annotations)
     val launcherWidgetSpec = extractLauncherWidgetSpec(annotations)
     val launcherWidgetResizeSpec = extractLauncherWidgetResizeSpec(annotations)
+    // `@OverrideVariant` (repeatable) — each spec yields one extra synthetic preview per @Preview
+    // expansion below, rendered with its `previewOverride*` seeds applied. Applies to every
+    // expansion, the same "one annotation, applies to every preview" policy as the capture specs.
+    val overrideVariantSpecs = extractOverrideVariantSpecs(annotations)
     // @RoboComposePreviewOptions, similarly, applies to the function as a
     // whole — each timing fans out into its own manifest entry, orthogonal
     // to any multi-preview expansion.
@@ -1410,7 +1422,7 @@ object PreviewDiscovery {
 
     if (directPreviews.isNotEmpty()) {
       for (ann in directPreviews) {
-        previews.add(
+        val base =
           makePreview(
             classInfo,
             method,
@@ -1429,13 +1441,14 @@ object PreviewDiscovery {
             previewSourceFile,
             inferredTargets,
           )
-        )
+        previews.add(base)
+        for (spec in overrideVariantSpecs) previews.add(overrideVariantPreview(base, spec))
       }
       return
     }
 
     for (resolvedAnn in resolvedMultiPreviews) {
-      previews.add(
+      val base =
         makePreview(
           classInfo,
           method,
@@ -1454,7 +1467,8 @@ object PreviewDiscovery {
           previewSourceFile,
           inferredTargets,
         )
-      )
+      previews.add(base)
+      for (spec in overrideVariantSpecs) previews.add(overrideVariantPreview(base, spec))
     }
 
     // Built-in expansion of known off-classpath multi-preview annotations (issue #2613). Each
@@ -1462,7 +1476,7 @@ object PreviewDiscovery {
     // fans out the function's `@ScrollingPreview` / `@AnimatedPreview` / … captures and infers
     // targets identically.
     for (spec in builtInSpecs) {
-      previews.add(
+      val base =
         buildPreviewInfo(
           classInfo,
           method,
@@ -1479,9 +1493,104 @@ object PreviewDiscovery {
           previewSourceFile,
           inferredTargets,
         )
-      )
+      previews.add(base)
+      for (variant in overrideVariantSpecs) previews.add(overrideVariantPreview(base, variant))
     }
   }
+
+  /**
+   * Derives a synthetic override-variant preview from a rendered [base]: same function, a
+   * `_VARIANT_<name>`-suffixed id + render outputs, the [spec]'s seeds carried on
+   * [PreviewInfo.overrides] for the renderer to apply, and no data products (a state variant
+   * doesn't re-emit the heavy scroll/animation products). The unchanged `functionName` is what lets
+   * the design-catalog fold merge the variant image back under its primary sticker.
+   */
+  private fun overrideVariantPreview(base: PreviewInfo, spec: OverrideVariantSpec): PreviewInfo {
+    val tag = "_VARIANT_${spec.name}"
+    return base.copy(
+      id = base.id + tag,
+      overrides = spec,
+      captures =
+        base.captures.map { it.copy(renderOutput = insertRenderTag(it.renderOutput, tag)) },
+      dataProducts = emptyList(),
+    )
+  }
+
+  /** Inserts [tag] just before the file extension of a `renders/<stem>.<ext>` output path. */
+  private fun insertRenderTag(renderOutput: String, tag: String): String {
+    if (renderOutput.isEmpty()) return renderOutput
+    val dot = renderOutput.lastIndexOf('.')
+    val slash = renderOutput.lastIndexOf('/')
+    return if (dot > slash) renderOutput.substring(0, dot) + tag + renderOutput.substring(dot)
+    else renderOutput + tag
+  }
+
+  /**
+   * Reads `@OverrideVariant` annotations (repeatable — direct instances or the synthetic
+   * `.Container` holder Kotlin generates for the repeated case) into one [OverrideVariantSpec]
+   * each. Each per-type array entry is `"key=value"` / `"key#index=value"`; the array it lives in
+   * fixes its [OverrideSeedKind]. A variant that names no parseable seed is dropped (it would
+   * render identically to the base).
+   */
+  private fun extractOverrideVariantSpecs(
+    annotations: List<AnnotationInfo>
+  ): List<OverrideVariantSpec> {
+    val infos = mutableListOf<AnnotationInfo>()
+    for (ann in annotations) {
+      when (ann.name) {
+        OVERRIDE_VARIANT_FQN -> infos.add(ann)
+        OVERRIDE_VARIANT_CONTAINER_FQN -> {
+          when (val value = ann.parameterValues.getValue("value")) {
+            is Array<*> -> value.filterIsInstance<AnnotationInfo>().forEach { infos.add(it) }
+            is AnnotationInfo -> infos.add(value)
+            else -> {
+              val len = runCatching { java.lang.reflect.Array.getLength(value) }.getOrNull() ?: 0
+              for (i in 0 until len) {
+                (java.lang.reflect.Array.get(value, i) as? AnnotationInfo)?.let { infos.add(it) }
+              }
+            }
+          }
+        }
+      }
+    }
+    return infos.mapNotNull { info ->
+      val pv = info.parameterValues
+      val name =
+        (pv.getValue("name") as? String)?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
+      val seeds =
+        readOverrideSeeds(pv.getValue("booleans"), OverrideSeedKind.BOOLEAN) +
+          readOverrideSeeds(pv.getValue("strings"), OverrideSeedKind.STRING) +
+          readOverrideSeeds(pv.getValue("ints"), OverrideSeedKind.INT) +
+          readOverrideSeeds(pv.getValue("floats"), OverrideSeedKind.FLOAT) +
+          readOverrideSeeds(pv.getValue("colors"), OverrideSeedKind.COLOR)
+      if (seeds.isEmpty()) null else OverrideVariantSpec(name = name, seeds = seeds)
+    }
+  }
+
+  /** Parses `"key=value"` / `"key#index=value"` string-array entries into typed [OverrideSeed]s. */
+  private fun readOverrideSeeds(raw: Any?, kind: OverrideSeedKind): List<OverrideSeed> =
+    readStringArray(raw).mapNotNull { entry ->
+      val eq = entry.indexOf('=')
+      if (eq <= 0) return@mapNotNull null
+      val lhs = entry.substring(0, eq).trim()
+      val value = entry.substring(eq + 1)
+      val hash = lhs.indexOf('#')
+      val key = (if (hash < 0) lhs else lhs.substring(0, hash)).trim()
+      val index = if (hash < 0) null else lhs.substring(hash + 1).trim().toIntOrNull()
+      if (key.isEmpty()) null else OverrideSeed(key = key, index = index, kind = kind, raw = value)
+    }
+
+  /** ClassGraph surfaces an `Array<String>` param as a String[]; normalise to a `List<String>`. */
+  private fun readStringArray(raw: Any?): List<String> =
+    when (raw) {
+      null -> emptyList()
+      is Array<*> -> raw.filterIsInstance<String>()
+      is String -> listOf(raw)
+      else -> {
+        val len = runCatching { java.lang.reflect.Array.getLength(raw) }.getOrNull() ?: 0
+        (0 until len).mapNotNull { java.lang.reflect.Array.get(raw, it) as? String }
+      }
+    }
 
   /**
    * Tile previews ([TILE_PREVIEW_FQN]) take a single `(context: Context)` argument supplied by the
@@ -2449,6 +2558,8 @@ object PreviewDiscovery {
       GESTURE_HINT_PREVIEW_FQN,
       LAUNCHER_WIDGET_PREVIEW_FQN,
       LAUNCHER_WIDGET_RESIZE_FQN,
+      OVERRIDE_VARIANT_FQN,
+      OVERRIDE_VARIANT_CONTAINER_FQN,
       PREVIEW_PARAMETER_FQN,
       PREVIEW_WRAPPER_FQN,
       PREVIEW_WRAPPER_CLASS_FQN,

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
@@ -150,6 +150,96 @@ class DiscoveryFunctionalTest {
   }
 
   @Test
+  fun `composePreviewDiscover expands @OverrideVariant into synthetic seeded previews`() {
+    val projectDir = createCmpTestProject()
+
+    // Declare the annotation locally with the discovered FQN so the test needs no external
+    // preview-annotations artifact — discovery matches by FQN. `@Repeatable` exercises the
+    // synthetic `.Container` holder path for the two-variant case.
+    val annDir = File(projectDir, "src/main/kotlin/ee/schimke/composeai/preview")
+    annDir.mkdirs()
+    File(annDir, "OverrideVariant.kt")
+      .writeText(
+        """
+        package ee.schimke.composeai.preview
+
+        @Repeatable
+        @Retention(AnnotationRetention.BINARY)
+        @Target(AnnotationTarget.FUNCTION)
+        annotation class OverrideVariant(
+            val name: String,
+            val booleans: Array<String> = [],
+            val strings: Array<String> = [],
+            val ints: Array<String> = [],
+            val floats: Array<String> = [],
+            val colors: Array<String> = [],
+        )
+        """
+          .trimIndent()
+      )
+
+    File(projectDir, "src/main/kotlin/test/Toggle.kt")
+      .writeText(
+        """
+        package test
+
+        import androidx.compose.foundation.layout.Box
+        import androidx.compose.foundation.layout.size
+        import androidx.compose.material3.Text
+        import androidx.compose.runtime.Composable
+        import androidx.compose.ui.Modifier
+        import androidx.compose.ui.tooling.preview.Preview
+        import androidx.compose.ui.unit.dp
+        import ee.schimke.composeai.preview.OverrideVariant
+
+        @Preview
+        @OverrideVariant(name = "off", booleans = ["checked=false"])
+        @OverrideVariant(name = "labelled", strings = ["label=Hi", "sub#1=Two"])
+        @Composable
+        fun TogglePreview() {
+            Box(modifier = Modifier.size(50.dp)) { Text("Toggle") }
+        }
+        """
+          .trimIndent()
+      )
+
+    val result =
+      GradleRunner.create()
+        .withProjectDir(projectDir)
+        .withArguments("composePreviewDiscover", "--stacktrace")
+        .withPluginClasspath()
+        .build()
+    assertThat(result.task(":composePreviewDiscover")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+
+    val manifest =
+      json.decodeFromString<PreviewManifest>(
+        File(projectDir, "build/compose-previews/previews.json").readText()
+      )
+    val toggles = manifest.previews.filter { it.functionName == "TogglePreview" }
+    // Base preview + one synthetic seeded preview per `@OverrideVariant`.
+    assertThat(toggles).hasSize(3)
+
+    val base = toggles.single { it.overrides == null }
+    assertThat(base.captures.single().renderOutput).doesNotContain("_VARIANT_")
+
+    val off = toggles.single { it.overrides?.name == "off" }
+    assertThat(off.id).endsWith("_VARIANT_off")
+    assertThat(off.captures.single().renderOutput).contains("_VARIANT_off")
+    assertThat(off.overrides!!.seeds)
+      .containsExactly(
+        OverrideSeed(key = "checked", index = null, kind = OverrideSeedKind.BOOLEAN, raw = "false")
+      )
+
+    // Multiple typed seeds, including an indexed knob (`sub#1` → seedKey `sub[1]`).
+    val labelled = toggles.single { it.overrides?.name == "labelled" }
+    assertThat(labelled.overrides!!.seeds)
+      .containsExactly(
+        OverrideSeed(key = "label", index = null, kind = OverrideSeedKind.STRING, raw = "Hi"),
+        OverrideSeed(key = "sub", index = 1, kind = OverrideSeedKind.STRING, raw = "Two"),
+      )
+  }
+
+  @Test
   fun `composePreviewDiscover aggregates @ColorCatalog tokens into catalog sheets`() {
     val projectDir = createCmpTestProject()
 

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RenderManifest.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RenderManifest.kt
@@ -141,6 +141,28 @@ data class AmbientCapture(
 /** Renderer-side mirror of the plugin's `GestureHintCapture`. */
 @Serializable data class GestureHintCapture(val showHints: Boolean = true)
 
+/** Renderer-side mirror of the plugin's `OverrideSeedKind`. */
+@Serializable
+enum class OverrideSeedKind {
+  STRING,
+  BOOLEAN,
+  INT,
+  FLOAT,
+  COLOR,
+}
+
+/** Renderer-side mirror of the plugin's `OverrideSeed`. */
+@Serializable
+data class OverrideSeed(
+  val key: String,
+  val index: Int? = null,
+  val kind: OverrideSeedKind,
+  val raw: String,
+)
+
+/** Renderer-side mirror of the plugin's `OverrideVariantSpec` (an `@OverrideVariant` seed set). */
+@Serializable data class OverrideVariantSpec(val name: String, val seeds: List<OverrideSeed>)
+
 /** Renderer-side mirror of the plugin's `LauncherWidgetCaptureResizeOrder`. */
 @Serializable
 enum class LauncherWidgetCaptureResizeOrder {
@@ -209,6 +231,12 @@ data class RenderPreviewEntry(
    * siblings and the PNG path it lands at. Always at least one element.
    */
   val captures: List<RenderPreviewCapture> = listOf(RenderPreviewCapture()),
+  /**
+   * Non-null on a synthetic `@OverrideVariant` preview: the `previewOverride*` values the renderer
+   * seeds via `PreviewOverrideController.set(...)` before composing this entry, so the same function
+   * renders once more with the knob(s) flipped. `null` on an ordinary preview (defaults resolve).
+   */
+  val overrides: OverrideVariantSpec? = null,
   /**
    * Annotation-sourced *rendered artefacts* for this preview — secondary images (each with a
    * `kind`, an output PNG, and a render cost), as opposed to the primary screenshots in [captures].

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -595,6 +595,12 @@ abstract class RobolectricRenderTestBase(
     // Drop any named-override knobs a prior preview declared so this preview's `previewOverride*`
     // lookups accumulate a clean set (drained into the overrides sidecar below).
     ee.schimke.composeai.overrides.PreviewOverrideController.clearDeclarations()
+    // Seed any `@OverrideVariant` values onto the controller so this synthetic variant preview's
+    // `previewOverride*` reads resolve to the flipped knob(s). Replaces the whole seed map, so an
+    // ordinary preview (null overrides → empty map) clears the prior variant's seeds — no leakage
+    // between previews. Same `ControllerPreviewOverrideHost` seam the daemon's `renderNow.overrides`
+    // lane feeds; here the batch render owns the controller lifecycle directly.
+    ee.schimke.composeai.overrides.PreviewOverrideController.set(overrideSeedMap(preview))
     try {
       renderDefault(
         params = params,
@@ -2428,6 +2434,63 @@ private fun AmbientCapture.toAmbientOverride(): AmbientOverride =
     burnInProtectionRequired = burnInProtectionRequired,
     deviceHasLowBitAmbient = deviceHasLowBitAmbient,
   )
+
+/**
+ * Builds the seed map for a synthetic `@OverrideVariant` preview from its
+ * [RenderPreviewEntry.overrides], keyed by `seedKey` (`key` or `key[index]`) so
+ * `ControllerPreviewOverrideHost` resolves each `previewOverride*` read to the flipped value.
+ * Returns `null` for an ordinary preview (no overrides) or when nothing parsed — `set(null)` clears
+ * all seeds. A seed whose raw value doesn't parse to its declared kind is dropped rather than
+ * coerced, matching the host's type-strict `as?` read (a bad value would silently fall back to the
+ * author default anyway).
+ */
+private fun overrideSeedMap(
+  preview: RenderPreviewEntry
+): Map<String, ee.schimke.composeai.data.overrides.PreviewOverrideValue>? {
+  val spec = preview.overrides ?: return null
+  val out = LinkedHashMap<String, ee.schimke.composeai.data.overrides.PreviewOverrideValue>()
+  for (seed in spec.seeds) {
+    val value = seed.toOverrideValue() ?: continue
+    out[if (seed.index == null) seed.key else "${seed.key}[${seed.index}]"] = value
+  }
+  return out.ifEmpty { null }
+}
+
+private fun OverrideSeed.toOverrideValue():
+  ee.schimke.composeai.data.overrides.PreviewOverrideValue? =
+  when (kind) {
+    OverrideSeedKind.STRING ->
+      ee.schimke.composeai.data.overrides.PreviewOverrideValue.StringValue(raw)
+    OverrideSeedKind.BOOLEAN ->
+      raw.trim().toBooleanStrictOrNull()?.let {
+        ee.schimke.composeai.data.overrides.PreviewOverrideValue.BooleanValue(it)
+      }
+    OverrideSeedKind.INT ->
+      raw.trim().toIntOrNull()?.let {
+        ee.schimke.composeai.data.overrides.PreviewOverrideValue.IntValue(it)
+      }
+    OverrideSeedKind.FLOAT ->
+      raw.trim().toFloatOrNull()?.let {
+        ee.schimke.composeai.data.overrides.PreviewOverrideValue.FloatValue(it)
+      }
+    OverrideSeedKind.COLOR ->
+      normalizeArgbHex(raw)?.let {
+        ee.schimke.composeai.data.overrides.PreviewOverrideValue.ColorValue(it)
+      }
+  }
+
+/** Normalises `#RRGGBB` / `#AARRGGBB` (with or without a leading `#`) to `#AARRGGBB`; null when not hex. */
+private fun normalizeArgbHex(raw: String): String? {
+  val s = raw.trim().removePrefix("#")
+  val hex =
+    when (s.length) {
+      6 -> "FF$s"
+      8 -> s
+      else -> return null
+    }
+  return if (hex.all { it.isDigit() || it.lowercaseChar() in 'a'..'f' }) "#${hex.uppercase()}"
+  else null
+}
 
 /**
  * Maps the renderer-side [GestureHintCapture] (read from `previews.json`) onto the connector's

--- a/samples/design-catalog-wear-m3/build.gradle.kts
+++ b/samples/design-catalog-wear-m3/build.gradle.kts
@@ -4,11 +4,14 @@
 // (see `@design-parity/catalog-export` in yschimke/design-parity, and the M3
 // sibling `:samples:design-catalog-m3`).
 //
-// Code-led source of truth for the Wear M3 sheet. Wear is dark-first, so the
-// primary "modes" are the round size breakpoints (small + large round) supplied
-// by the `@WearPreviewSmallRound` / `@WearPreviewLargeRound` multipreviews rather
-// than a light/dark pair. Kept thin — `wear.compose.material3` + the Wear preview
-// tooling — so it builds against the stable Compose BOM.
+// Code-led source of truth for the Wear M3 sheet. Wear is dark-first, so component
+// stickers are a single transparent dark capture (`@CatalogWearModes`,
+// `showBackground = false`) rather than a light/dark pair; the round size
+// breakpoints (192/227/240 round) are fanned out only for the FULL-SCREEN
+// components (scaffold templates, scaling lists, EdgeButton) via
+// `@CatalogWearBreakpoints`, which uses the Wear tooling device ids directly. Kept
+// thin — `wear.compose.material3` + the Wear preview tooling — so it builds against
+// the stable Compose BOM.
 plugins {
   id("composeai.base-conventions")
   id("composeai.android-conventions")

--- a/samples/design-catalog-wear-m3/catalog.spec.json
+++ b/samples/design-catalog-wear-m3/catalog.spec.json
@@ -1,11 +1,16 @@
 {
   "$schema": "https://raw.githubusercontent.com/yschimke/compose-ai-tools/main/scripts/design-artifacts/catalog.spec.schema.json",
-  "$comment": "Phase-0 catalog spec for Wear Compose Material 3. Code-led: the render is authoritative; the kit references are for the one-off seed import only. Wear is dark-first, so the primary modes are the round size breakpoints (small/large round) rather than light/dark. A component's `variants` fold extra state renders (pressed/focused/disabled/off/…) onto the same sticker: the default preview is what the grid shows, and each variant's render becomes a secondary image (tagged with its `state`) surfaced in the single-component view, so state stickers live under their parent instead of a flat 'States' group.",
+  "$comment": "Phase-0 catalog spec for Wear Compose Material 3. Code-led: the render is authoritative; the kit references are for the one-off seed import only. Wear is dark-first, so `modes` is the single dark component capture (`@CatalogWearModes`, `showBackground = false`) rather than a light/dark pair — a Wear component sticker is one transparent capture, not one-per-breakpoint. The round size breakpoints in `breakpoints` are what the FULL-SCREEN components (scaffold templates, scaling lists, the EdgeButton) fan out across via `@CatalogWearBreakpoints` (small/large/xl round); the centred component stickers are size-agnostic and don't. A component's `variants` fold extra state renders (pressed/focused/disabled/off/…) onto the same sticker: the default preview is what the grid shows, and each variant's render becomes a secondary image (tagged with its `state`) surfaced in the single-component view, so state stickers live under their parent instead of a flat 'States' group. State variants that differ only by a `previewOverride*` knob (off↔on, unchecked↔checked, disabled) ride the primary function via `@OverrideVariant` instead of a duplicated wrapper — the render still emits a distinct `_VARIANT_<state>` capture, so they fold in the same way.",
   "system": "wear-m3",
   "title": "Wear Compose Material 3",
   "library": ["androidx.wear.compose:compose-material3"],
   "module": "samples:design-catalog-wear-m3",
-  "modes": ["smallRound", "largeRound"],
+  "modes": ["dark"],
+  "breakpoints": [
+    { "size": "smallRound", "widthDp": 192 },
+    { "size": "largeRound", "widthDp": 227 },
+    { "size": "xlRound", "widthDp": 240 }
+  ],
   "display": {
     "surface": "dark",
     "hero": "Template/TimeText"


### PR DESCRIPTION
## Why

Reviewing the `design-catalog-{m3,wear-m3,remote-m3}` catalogs surfaced that the three have drifted, and that a lot of the drift is **duplicated variant functions**: a Wear `SwitchButtonOff` differs from `SwitchButtonOn` only by `previewOverrideBoolean("checked", false)`, yet must be a whole second `@Composable`. The reason is a genuine gap in the pipeline — **a baked/batch render can't seed `previewOverride*` values** (the seeding path only runs in the live daemon), so every state/content variant has to be its own `@Preview`.

This PR adds the missing capability so a variant that differs only by an override knob rides on the *same* function.

## What

- **`@OverrideVariant`** (`api/preview-annotations`) — repeatable annotation carrying `name` + typed seed arrays (`booleans` / `strings` / `ints` / `floats` / `colors`), each entry `"key=value"` or `"key#index=value"`.
- **Discovery** (`preview-discovery`) — reads the annotation (direct + the repeatable `.Container`) and emits one **synthetic seeded preview** per variant: same `functionName` (so the catalog fold merges it back under the primary sticker), a `_VARIANT_<name>` id + render output, and the typed seeds on `PreviewInfo.overrides`. Same "one annotation, applies to every `@Preview` expansion" policy as the capture-mode annotations.
- **Android/Wear renderer** (`renderer-android`) — seeds `PreviewOverrideController.set(...)` at the existing per-preview hook, so the batch render reaches the *same* `ControllerPreviewOverrideHost` seam the daemon's `renderNow.overrides` lane uses. An ordinary preview clears the seed, so nothing leaks between previews. No new module dependency, no risky reflective plumbing.
- **Decorative catalog-metadata fixes** (`design-catalog-wear-m3`) — the spec advertised `modes: ["smallRound","largeRound"]`, but Wear component stickers render a *single dark capture* (`@CatalogWearModes`); the round sizes are what the **full-screen** components fan out across (`@CatalogWearBreakpoints`). Corrected `modes` to `["dark"]`, moved the round sizes to `breakpoints`, and fixed the stale `build.gradle.kts` comment referencing unused `@WearPreview*` aliases. (These fields are informational — nothing in the render/export reads them — so this is a documentation correction, no pixel change.)

## Scope

- **Android/Wear render path only.** The desktop (Skiko) backend is arg-fed and doesn't yet carry the seed, so CMP-desktop catalogs (m3) keep hand-written variant functions until a follow-up adds the seed there. Documented in the annotation KDoc.
- **No catalog `@Preview` was converted in this PR.** Converting `SwitchButtonOff`/`CheckboxButtonUnchecked`/`ButtonDisabled` etc. to `@OverrideVariant` needs a companion change so the export fold tags the folded variant image with its `state` (otherwise preview.coo.ee would show two "default" stickers). That conversion + export tagging + a render-diff is the immediate fast-follow; this PR is the purely-additive mechanism so it can't regress a published catalog.

## Test plan

- [x] `:preview-discovery` + `:renderer-android` compile.
- [x] New `DiscoveryFunctionalTest` case: a `@Preview` with two `@OverrideVariant`s (exercising the repeatable `.Container` path and an indexed knob) discovers as base + 2 synthetic previews, each with the correct `_VARIANT_<name>` id/output and typed seeds. **BUILD SUCCESSFUL.**
- [x] `ktfmtFormat` applied to all touched modules.
- [ ] Follow-up: end-to-end Robolectric render asserting the seeded variant PNG differs from the base (lands with the catalog conversion).

---
_Generated by [Claude Code](https://claude.ai/code/session_011hSHR1CuZuumjyAdLe3Mxx)_