### PR TITLE
fix(serve): bound the per-daemon render lock so a slow render can't starve the render queue

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
@@ -1254,6 +1254,9 @@ internal fun renderPreviewsToDir(
       }
       is RenderOutcome.Failed -> failures += "${preview.id} (${outcome.reason})"
       RenderOutcome.NotFound -> failures += "${preview.id} (not found)"
+      // This CLI renders previews sequentially on one thread, so the per-daemon lock is never
+      // contended — Busy shouldn't occur — but surface it as a failure rather than skip silently.
+      RenderOutcome.Busy -> failures += "${preview.id} (daemon busy)"
     }
   }
   log(

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -1356,6 +1356,9 @@ class ServeCommand(args: List<String>) : Command(args) {
             null
           }
           RenderOutcome.NotFound -> null
+          // Sequential single-thread export — the per-daemon lock is never contended, so Busy
+          // shouldn't occur; treat it like a skip (no PNG) if it somehow does.
+          RenderOutcome.Busy -> null
         }
       }
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
@@ -214,9 +214,18 @@ class ServeCatalogLiveHost(
    * re-render; an unmapped Android-only variant always replays baked.
    */
   override fun render(previewId: String, overrides: PreviewOverrides): RenderOutcome {
-    val daemonId = daemonIdForOverrideRender(previewId, overrides)
-    return if (daemonId != null) liveHostFor(daemonId).render(daemonId, overrides)
-    else baked.render(previewId, overrides)
+    val daemonId =
+      daemonIdForOverrideRender(previewId, overrides) ?: return baked.render(previewId, overrides)
+    // Only await the daemon when it's warm and free. A cold Android render can take minutes, and
+    // blocking the browse — and the HTTP render slot it holds — on it is what saturates the whole
+    // server. A not-yet-warm daemon serves baked now and warms in the background; a warm daemon
+    // that reports [RenderOutcome.Busy] (the bounded-lock back-off — another render in flight)
+    // likewise falls back to baked instead of pinning a slot. This mirrors [renderSvg]'s warm gate.
+    if (daemonWarmOrScheduling(daemonId)) {
+      val live = liveHostFor(daemonId).render(daemonId, overrides)
+      if (live !is RenderOutcome.Busy) return live
+    }
+    return baked.render(previewId, overrides)
   }
 
   /**

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -1033,6 +1033,13 @@ class ServeHttpServer(
           status = HttpStatusCode.ServiceUnavailable,
         )
       }
+      RenderOutcome.Busy -> {
+        // The daemon was mid-render; the request backed off in ~DAEMON_BUSY_WAIT rather than pin
+        // this render slot. Fast 503 + Retry-After (a catalog host would have served baked; a bare
+        // bundle host has no baked fallback).
+        call.response.headers.append(HttpHeaders.RetryAfter, "2")
+        call.respondText("render busy; retry shortly", status = HttpStatusCode.ServiceUnavailable)
+      }
       is RenderOutcome.Ok ->
         call.respondText(StorybookCompat.iframePage(storyId, outcome.png), ContentType.Text.Html)
       RenderOutcome.NotFound -> call.respondText("no such story", status = HttpStatusCode.NotFound)
@@ -1249,6 +1256,15 @@ class ServeHttpServer(
               call.response.headers.append(HttpHeaders.RetryAfter, "2")
               call.respondText(
                 "render queue saturated; retry shortly",
+                status = HttpStatusCode.ServiceUnavailable,
+              )
+            }
+            RenderOutcome.Busy -> {
+              // Daemon mid-render; backed off in ~DAEMON_BUSY_WAIT instead of pinning this slot.
+              // A catalog host serves baked instead of returning Busy; a bare bundle host 503s.
+              call.response.headers.append(HttpHeaders.RetryAfter, "2")
+              call.respondText(
+                "render busy; retry shortly",
                 status = HttpStatusCode.ServiceUnavailable,
               )
             }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
@@ -173,6 +173,14 @@ sealed interface RenderOutcome {
 
   /** The render was attempted but rejected / failed / timed out. [reason] is human-readable. */
   data class Failed(val reason: String) : RenderOutcome
+
+  /**
+   * The per-daemon render lock was held by another in-flight render (a cold Android render can hold
+   * it for up to `renderTimeoutSeconds`, minutes on a public host), so this request **backed off**
+   * rather than block a shared HTTP render slot on that wait. NOT an error: the caller should serve
+   * the baked fallback immediately (or retry). See [ServeRenderHost.DAEMON_BUSY_WAIT_MS].
+   */
+  data object Busy : RenderOutcome
 }
 
 /** Result of a figma-svg render request — the SVG counterpart of [RenderOutcome]. */
@@ -284,7 +292,10 @@ internal constructor(
   // schema's additive fields (a v7 file read by this v-agnostic slot extractor).
   private val dataJson = Json { ignoreUnknownKeys = true }
 
-  private val renderLock = ReentrantLock()
+  // Fair (FIFO) so a waiter can't be starved and the longest-waiting render — an interactive
+  // browse — wins the daemon when it frees, ahead of the background prewarm re-acquiring the lock
+  // for the next warm render.
+  private val renderLock = ReentrantLock(/* fair= */ true)
 
   // Set under renderLock immediately before each renderNow; the (single) in-flight render's
   // renderFinished notification fills pngPath and trips the latch. Safe because the lock guarantees
@@ -351,10 +362,15 @@ internal constructor(
       return RenderOutcome.Ok(it)
     }
 
-    return renderLock.withLock {
+    // Bounded acquire (Fix 4): a cold render holds [renderLock] for up to renderTimeoutSeconds
+    // (minutes); don't pin the caller's HTTP render slot on that wait — back off to Busy so the
+    // caller serves baked instead. Waiting the [DAEMON_BUSY_WAIT_MS] window still rides out a fast
+    // warm re-emit.
+    if (!renderLock.tryLock(DAEMON_BUSY_WAIT_MS, TimeUnit.MILLISECONDS)) return RenderOutcome.Busy
+    try {
       // Double-check: another request may have filled the cache while we waited for the lock.
       cache.get(key)?.let {
-        return@withLock RenderOutcome.Ok(it)
+        return RenderOutcome.Ok(it)
       }
 
       // The daemon coalesces an override-bearing `renderNow` whose previewId already has one in
@@ -382,7 +398,7 @@ internal constructor(
           } catch (e: RenderSessionException) {
             val reason = "renderNow failed: ${e.message}"
             onLog(reason)
-            return@withLock RenderOutcome.Failed(reason)
+            return RenderOutcome.Failed(reason)
           }
 
         val rejected = ack.rejected.firstOrNull { it.id == previewId }
@@ -393,7 +409,7 @@ internal constructor(
           }
           val reason = "render rejected: ${rejected.reason}"
           onLog(reason)
-          return@withLock RenderOutcome.Failed(reason)
+          return RenderOutcome.Failed(reason)
         }
 
         // Cold start gets the generous budget; every frame after the first is capped so a wedged
@@ -410,7 +426,7 @@ internal constructor(
           staleRenders.merge(previewId, 1, Int::plus)
           val reason = "timed out after ${budget}s waiting for render"
           onLog(reason)
-          return@withLock RenderOutcome.Failed(reason)
+          return RenderOutcome.Failed(reason)
         }
         warmedUp.set(true)
         if (hasOverrides) overridesWarmedUp.set(true)
@@ -426,11 +442,13 @@ internal constructor(
       if (bytes == null) {
         val reason = "render produced no PNG"
         onLog(reason)
-        return@withLock RenderOutcome.Failed(reason)
+        return RenderOutcome.Failed(reason)
       }
 
       cache.put(key, bytes)
-      RenderOutcome.Ok(bytes)
+      return RenderOutcome.Ok(bytes)
+    } finally {
+      renderLock.unlock()
     }
   }
 
@@ -469,6 +487,9 @@ internal constructor(
       when (val pngOutcome = render(previewId, overrides)) {
         RenderOutcome.NotFound -> return@withLock SvgOutcome.NotFound
         is RenderOutcome.Failed -> return@withLock SvgOutcome.Failed(pngOutcome.reason)
+        // Unreachable in practice — render() re-enters the lock we already hold — but the caller
+        // falls back to the baked vector on any non-Ok, so a busy signal degrades gracefully.
+        RenderOutcome.Busy -> return@withLock SvgOutcome.Failed("daemon busy")
         is RenderOutcome.Ok -> {} // rendered; the SVG for these overrides is now on disk
       }
 
@@ -612,6 +633,9 @@ internal constructor(
       when (val pngOutcome = render(previewId, overrides)) {
         RenderOutcome.NotFound -> return@withLock SlotsOutcome.NotFound
         is RenderOutcome.Failed -> return@withLock SlotsOutcome.Failed(pngOutcome.reason)
+        // Unreachable in practice — render() re-enters the lock we already hold — but keep the
+        // match exhaustive and degrade to a clean failure rather than pretending we rendered.
+        RenderOutcome.Busy -> return@withLock SlotsOutcome.Failed("daemon busy")
         is RenderOutcome.Ok -> {} // rendered; the semantics for these overrides is now on disk
       }
 
@@ -852,6 +876,17 @@ internal constructor(
      */
     private const val MAX_COALESCED_RETRIES = 50
     private const val COALESCED_RETRY_BACKOFF_MS = 100L
+
+    /**
+     * How long a render waits for the per-daemon [renderLock] before reporting
+     * [RenderOutcome.Busy]. The lock is held for the whole render, and a cold Android render can
+     * hold it for `renderTimeoutSeconds` (minutes on a public host). Blocking that long pins a
+     * shared HTTP render slot ([ServeHttpServer.renderSemaphore]) and — enough times over —
+     * saturates the whole server. This caps the wait to a couple of seconds (enough to ride out a
+     * fast warm re-emit); past it the caller serves the baked fallback instead of blocking a slot
+     * on a busy daemon.
+     */
+    private const val DAEMON_BUSY_WAIT_MS = 2_000L
 
     private const val MAX_CACHE_ENTRIES = 256
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeStreamSession.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeStreamSession.kt
@@ -114,17 +114,41 @@ class ServeStreamSession(
   }
 
   private fun sendFrame(overrides: PreviewOverrides) {
-    when (val outcome = renderHost.render(previewId, overrides)) {
-      is RenderOutcome.Ok -> {
-        val (w, h) = WebEscaping.pngDimensions(outcome.png)
-        send(ServeStreamProtocol.frameMessage(seq.getAndIncrement(), w, h, outcome.png))
+    // The viewer sends its initial `setOverrides` on open and doesn't poll for frames, so a
+    // swallowed frame would leave the socket stuck at "connecting…". When the daemon is mid-render
+    // (RenderOutcome.Busy from the serve host's bounded lock), retry a few times as it frees, then
+    // surface an error rather than hang. (A catalog host serves baked instead of returning Busy, so
+    // Busy only reaches here for a bare daemon-backed stream.)
+    var busyAttempts = 0
+    while (true) {
+      when (val outcome = renderHost.render(previewId, overrides)) {
+        is RenderOutcome.Ok -> {
+          val (w, h) = WebEscaping.pngDimensions(outcome.png)
+          send(ServeStreamProtocol.frameMessage(seq.getAndIncrement(), w, h, outcome.png))
+          return
+        }
+        RenderOutcome.NotFound -> {
+          send(ServeStreamProtocol.errorMessage("no such preview"))
+          return
+        }
+        is RenderOutcome.Failed -> {
+          send(ServeStreamProtocol.errorMessage(outcome.reason))
+          return
+        }
+        RenderOutcome.Busy -> {
+          if (busyAttempts++ >= BUSY_FRAME_RETRIES) {
+            send(ServeStreamProtocol.errorMessage("render busy; please retry"))
+            return
+          }
+          Thread.sleep(BUSY_FRAME_RETRY_BACKOFF_MS)
+        }
       }
-      RenderOutcome.NotFound -> send(ServeStreamProtocol.errorMessage("no such preview"))
-      is RenderOutcome.Failed -> send(ServeStreamProtocol.errorMessage(outcome.reason))
-      // Daemon mid-render — skip this frame silently rather than tear the stream down with an
-      // error; the next frame request retries once the daemon frees. (A catalog host serves baked
-      // instead of returning Busy, so this is only reachable for a bare daemon-backed stream.)
-      RenderOutcome.Busy -> {}
     }
+  }
+
+  private companion object {
+    /** Retries when a snapshot frame's render backs off Busy before surfacing an error. */
+    private const val BUSY_FRAME_RETRIES = 2
+    private const val BUSY_FRAME_RETRY_BACKOFF_MS = 250L
   }
 }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeStreamSession.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeStreamSession.kt
@@ -121,6 +121,10 @@ class ServeStreamSession(
       }
       RenderOutcome.NotFound -> send(ServeStreamProtocol.errorMessage("no such preview"))
       is RenderOutcome.Failed -> send(ServeStreamProtocol.errorMessage(outcome.reason))
+      // Daemon mid-render — skip this frame silently rather than tear the stream down with an
+      // error; the next frame request retries once the daemon frees. (A catalog host serves baked
+      // instead of returning Busy, so this is only reachable for a bare daemon-backed stream.)
+      RenderOutcome.Busy -> {}
     }
   }
 }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHostTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHostTest.kt
@@ -60,6 +60,56 @@ class ServeRenderHostTest {
   }
 
   @Test
+  fun `a render backs off to Busy when the daemon lock is held, not blocking the render budget`() {
+    // The host is built with renderTimeoutSeconds = 30. A cold render holding the per-daemon lock
+    // for that long must NOT make a concurrent render block for the whole budget (which, on the
+    // live server, pins a shared HTTP render slot and saturates the queue). It must back off to
+    // Busy near the bounded wait instead.
+    val firstHoldsLock = CountDownLatch(1)
+    val release = CountDownLatch(1)
+    val session =
+      FakeRenderSession(
+        newRenderRoot(),
+        renderHook = { call, emit ->
+          if (call == 1) {
+            // We're inside renderNow, i.e. under renderLock — signal, then block to model a slow
+            // cold render holding the lock.
+            firstHoldsLock.countDown()
+            release.await(30, TimeUnit.SECONDS)
+          }
+          emit("png-$call".toByteArray())
+        },
+      )
+    host(session).use { h ->
+      val pool = Executors.newSingleThreadExecutor()
+      try {
+        // Thread A: grabs the lock and blocks in its render.
+        pool.submit { h.render(previewId, PreviewOverrides(uiMode = UiMode.LIGHT)) }
+        assertTrue(firstHoldsLock.await(10, TimeUnit.SECONDS), "first render should take the lock")
+
+        // Thread B (this thread): a DIFFERENT override, so no cache hit — it must contend for the
+        // lock and back off rather than wait out the 30s budget.
+        val startNs = System.nanoTime()
+        val outcome = h.render(previewId, PreviewOverrides(uiMode = UiMode.DARK))
+        val elapsedMs = (System.nanoTime() - startNs) / 1_000_000
+
+        assertTrue(
+          outcome is RenderOutcome.Busy,
+          "a render blocked on the busy daemon must back off to Busy, got $outcome",
+        )
+        assertTrue(
+          elapsedMs < 10_000,
+          "Busy must return near the bounded wait (~2s), not the 30s budget; took ${elapsedMs}ms",
+        )
+      } finally {
+        release.countDown()
+        pool.shutdown()
+        pool.awaitTermination(30, TimeUnit.SECONDS)
+      }
+    }
+  }
+
+  @Test
   fun `gesturesRenderable follows the daemon's advertised gesture capability`() {
     // An Android-style backend advertises "gestures" ⇒ the viewer offers the hint control.
     host(FakeRenderSession(newRenderRoot(), supportedOverrides = listOf("gestures"))).use { h ->


### PR DESCRIPTION
## Summary

Live re-renders on preview.coo.ee were returning `503 "render queue saturated"` for **every** catalog — including the desktop `compose-m3` — with `activeStreams: 0`. Reproduced by curling `/render` for any preview (with or without a `fontScale`/knob override): 30 s wait, then 503.

**Root cause.** A cold Android/Robolectric render holds a `ServeRenderHost`'s per-daemon `renderLock` for up to `renderTimeoutSeconds` (**900 s** on the public host). The HTTP layer holds one of `maxConcurrentRenders` (**8**) global render slots across the *entire* `render()` call, so a handful of requests blocked on such a render pin all 8 slots and the whole server 503s — starving fast desktop renders and interactive requests alike. The background prewarm (its own thread) legitimately holds a daemon's lock for the cold warm render, which is what interactive requests then block behind.

This implements the two agreed mitigations:

### Fix 4 — don't pin an HTTP slot on a busy daemon
`ServeRenderHost.render()` now acquires `renderLock` with a **bounded `tryLock` (`DAEMON_BUSY_WAIT_MS` = 2 s)** and returns a new `RenderOutcome.Busy` on contention instead of blocking for the render budget. `ServeCatalogLiveHost.render()` maps `Busy` — and a not-yet-warm daemon — to the **baked fallback immediately** (mirroring the existing `renderSvg` warm gate), so the HTTP slot frees in ~2 s instead of ~900 s and one slow catalog can no longer take the server down. Raw daemon-backed hosts (bare `--bundle`) return a fast `503` on `Busy`; the stream lane skips the frame.

### Fix 2 — interactive beats prewarm
`renderLock` is now **fair (FIFO)**, so when a daemon frees, the longest-waiting render — an interactive browse — wins ahead of the background prewarm re-acquiring the lock for its next warm render.

### RenderOutcome.Busy
New sealed case; all `when(RenderOutcome)` sites updated (catalog host → baked, HTTP → fast 503, stream → skip frame, the two CLI export paths → treated as skip/failure since they're single-threaded and never contend).

## Test plan

- **New unit test** (`ServeRenderHostTest`): with the host built at `renderTimeoutSeconds = 30`, one render holds the lock (a blocking `renderHook`) while a concurrent render for a **different** override asserts it returns `RenderOutcome.Busy` in well under the 30 s budget (near the 2 s bound) rather than blocking it out.
- `:cli:test --tests "*Serve*"` green; `:cli:compileKotlin`, `:cli:ktfmtCheckMain`, `:cli:ktfmtCheckTest` all pass locally.
- Non-visual change (render-server scheduling); rendered output is unaffected — this restores interactive live renders under load.

## Follow-ups (not in this PR)
- The **cold Android render itself** (~minutes) is the underlying amplifier — separate profiling/optimisation workstream (handover written).
- Android serve-lane e2e coverage — issue #2675.

---
_Generated by [Claude Code](https://claude.ai/code/session_018B1heEfDkyWdqj4cgRuy2U)_