### PR TITLE
feat(remotecompose): bridge knob declarations across the Robolectric sandbox

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/bridge/SandboxRemoteComposeBridge.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/bridge/SandboxRemoteComposeBridge.kt
@@ -1,0 +1,106 @@
+package ee.schimke.composeai.daemon.bridge
+
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Cross-classloader handoff for the Remote Compose knob declarations (`compose/remotecompose`).
+ *
+ * The exact sibling of [SandboxPreviewOverridesBridge], for the Remote Compose named-value surface
+ * instead of the plain-Compose one. A preview's `LocalRemoteComposeHost` named-value reads (and
+ * explicit `declareKnob` calls) push declarations into `RemoteComposeController` from *inside* the
+ * Robolectric sandbox — the controller is loaded fresh per-sandbox (the `ee.schimke.composeai`
+ * namespace is acquired by the sandbox classloader), so the daemon-host
+ * `RemoteComposeDataProductRegistry` (constructed on the host thread, in the host classloader) reads
+ * a different — empty — copy of the controller's static state when it answers
+ * `data/fetch?kind=compose/remotecompose`. The desktop backend has no sandbox and needs no bridge.
+ *
+ * Registered as a do-not-acquire package on [SandboxHoldingRunner] (the whole
+ * `ee.schimke.composeai.daemon.bridge` package already is), so the same single instance is visible
+ * from both sides of the sandbox boundary. The controller's `recordDeclaration` pushes here; the
+ * host registry drains via [snapshot]; [reset] is the per-preview cleanup the controller's
+ * `clearDeclarations` / `resetForNewSession` call.
+ *
+ * **Strict bridge-package rules.** Only `java.util.concurrent.*` types, primitives, and `String`. No
+ * Compose, no Robolectric, no `ee.schimke.composeai.*` imports — those would drag the bridge back
+ * into the instrumented graph and break the single-instance invariant. Declarations therefore cross
+ * as **JSON strings** (the controller serialises each `RemoteComposeKnobDeclaration` before
+ * forwarding, the host registry decodes them): a typed object built in the sandbox classloader could
+ * not be cast to the host classloader's copy of the same class.
+ *
+ * **Per-preview scoping.** State is keyed by previewId (mirroring [SandboxPreviewOverridesBridge]) so
+ * a pooled-sandbox run (`sandboxCount > 1`) where preview A and preview B compose concurrently
+ * doesn't leak A's knobs into B's [snapshot]. Writers stamp their active previewId (the controller
+ * forwards it from the around-composable's `ExtensionComposeContext.previewId`); the host reads back
+ * by the same previewId. A render with no previewId scopes under [NO_PREVIEW_SCOPE].
+ */
+object SandboxRemoteComposeBridge {
+
+  /** Scope key used when a render carries no previewId (legacy stub-render payloads). */
+  const val NO_PREVIEW_SCOPE: String = ""
+
+  private val arrivalCounter: AtomicLong = AtomicLong(0L)
+
+  /**
+   * previewId -> (declaration name -> [Slot]). Both maps are [ConcurrentHashMap] so writes from any
+   * sandbox thread race-free and concurrent previews each own a private inner map. The name keying
+   * mirrors the controller's own de-dup: re-declaring a name (recomposition) replaces its JSON in
+   * place while keeping the first-seen arrival order.
+   */
+  private val byPreview: ConcurrentHashMap<String, ConcurrentHashMap<String, Slot>> =
+    ConcurrentHashMap()
+
+  /** First-seen arrival order + the latest JSON for a declaration. Never crosses the boundary. */
+  private class Slot(@JvmField val order: Long, @JvmField @Volatile var json: String)
+
+  /**
+   * Sandbox-side: record (or replace) [previewId]'s declaration [name] with its serialised [json].
+   * First call for a (previewId, name) stamps an arrival counter so [snapshot] preserves declaration
+   * order; a later call for the same name updates the JSON in place (a recomposition with a fresh
+   * effective value) without reordering.
+   */
+  @JvmStatic
+  fun record(previewId: String, name: String, json: String) {
+    byPreview
+      .computeIfAbsent(previewId) { ConcurrentHashMap() }
+      .compute(name) { _, existing ->
+        if (existing == null) Slot(arrivalCounter.incrementAndGet(), json)
+        else existing.also { it.json = json }
+      }
+  }
+
+  /**
+   * Host-side: snapshot [previewId]'s declarations as serialised JSON strings, in declaration order.
+   * Returns a primitive `String[]` so the cross-loader transport stays in JLS types only — neither
+   * side reinterprets a `kotlin.collections.List` from the other's classloader. A previewId the
+   * bridge never saw (or one whose declarations were [reset]) returns an empty array.
+   */
+  @JvmStatic
+  fun snapshot(previewId: String): Array<String> {
+    val inner = byPreview[previewId] ?: return emptyArray()
+    if (inner.isEmpty()) return emptyArray()
+    val sorted = inner.values.sortedBy { it.order }
+    return Array(sorted.size) { sorted[it].json }
+  }
+
+  /**
+   * Both sides: drop the recorded declarations for [previewId] only. Called by
+   * `RemoteComposeController.clearDeclarations` at the start of each render (so a shrinking list's
+   * stale knobs drop) and by `resetForNewSession`. Scoped to the one preview so a concurrently-held
+   * preview's declarations survive — a JVM-wide `clear()` would reintroduce the cross-preview leak
+   * the per-preview keying fixes.
+   */
+  @JvmStatic
+  fun reset(previewId: String) {
+    byPreview.remove(previewId)
+  }
+
+  /**
+   * Both sides: drop every recorded declaration across all previews. Used by host-restart paths and
+   * test isolation where a full wipe is the intent. Per-render/-session cleanup must use [reset].
+   */
+  @JvmStatic
+  fun resetAll() {
+    byPreview.clear()
+  }
+}

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/bridge/SandboxRemoteComposeBridgeTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/bridge/SandboxRemoteComposeBridgeTest.kt
@@ -1,0 +1,103 @@
+package ee.schimke.composeai.daemon.bridge
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Per-preview scoping + ordering coverage for [SandboxRemoteComposeBridge], the Remote Compose
+ * sibling of [SandboxPermissionsBridge].
+ *
+ * The bridge is a single JVM-wide singleton shared across every Robolectric sandbox (it lives in the
+ * do-not-acquire `ee.schimke.composeai.daemon.bridge` package). Keying its map by previewId keeps two
+ * concurrent previews — each in its own sandbox, each writing into the same singleton — from
+ * cross-polluting each other's host-side declaration snapshot. Declarations cross as JSON strings, so
+ * these tests use opaque strings as stand-ins for the serialised `RemoteComposeKnobDeclaration`.
+ *
+ * Plain JUnit (no `@RunWith(SandboxHoldingRunner::class)`) — the bridge is plain host-side state; its
+ * cross-classloader visibility is exercised end-to-end by the Remote Compose Robolectric render path.
+ */
+class SandboxRemoteComposeBridgeTest {
+
+  @After fun tearDown() = SandboxRemoteComposeBridge.resetAll()
+
+  @Test
+  fun `two concurrent previews see only their own declarations`() {
+    SandboxRemoteComposeBridge.record("preview-a", "label", "{a-label}")
+    SandboxRemoteComposeBridge.record("preview-b", "shaderColor", "{b-color}")
+    SandboxRemoteComposeBridge.record("preview-a", "score", "{a-score}")
+
+    assertEquals(
+      "preview-a must see only its own declarations",
+      listOf("{a-label}", "{a-score}"),
+      SandboxRemoteComposeBridge.snapshot("preview-a").toList(),
+    )
+    assertEquals(
+      "preview-b must see only its own declarations",
+      listOf("{b-color}"),
+      SandboxRemoteComposeBridge.snapshot("preview-b").toList(),
+    )
+  }
+
+  @Test
+  fun `snapshot preserves insertion order and replaces a re-declared name in place`() {
+    SandboxRemoteComposeBridge.record("preview-a", "label", "{v1}")
+    SandboxRemoteComposeBridge.record("preview-a", "score", "{score}")
+    // A recomposition re-declares "label" with a fresh JSON — replaces in place, keeps position.
+    SandboxRemoteComposeBridge.record("preview-a", "label", "{v2}")
+
+    assertEquals(
+      listOf("{v2}", "{score}"),
+      SandboxRemoteComposeBridge.snapshot("preview-a").toList(),
+    )
+  }
+
+  @Test
+  fun `snapshot of an unseen preview is empty`() {
+    SandboxRemoteComposeBridge.record("preview-a", "label", "{a}")
+
+    assertEquals(emptyList<String>(), SandboxRemoteComposeBridge.snapshot("never-rendered").toList())
+  }
+
+  @Test
+  fun `reset clears only the named preview, leaving concurrent previews intact`() {
+    SandboxRemoteComposeBridge.record("preview-a", "label", "{a}")
+    SandboxRemoteComposeBridge.record("preview-b", "color", "{b}")
+
+    SandboxRemoteComposeBridge.reset("preview-a")
+
+    assertEquals(
+      "preview-a's scope is cleared",
+      emptyList<String>(),
+      SandboxRemoteComposeBridge.snapshot("preview-a").toList(),
+    )
+    assertEquals(
+      "closing preview-a's session must not wipe a concurrently-held preview-b",
+      listOf("{b}"),
+      SandboxRemoteComposeBridge.snapshot("preview-b").toList(),
+    )
+  }
+
+  @Test
+  fun `resetAll clears every preview scope`() {
+    SandboxRemoteComposeBridge.record("preview-a", "label", "{a}")
+    SandboxRemoteComposeBridge.record("preview-b", "color", "{b}")
+
+    SandboxRemoteComposeBridge.resetAll()
+
+    assertEquals(emptyList<String>(), SandboxRemoteComposeBridge.snapshot("preview-a").toList())
+    assertEquals(emptyList<String>(), SandboxRemoteComposeBridge.snapshot("preview-b").toList())
+  }
+
+  @Test
+  fun `no-preview renders share the dedicated sentinel scope`() {
+    SandboxRemoteComposeBridge.record(SandboxRemoteComposeBridge.NO_PREVIEW_SCOPE, "label", "{s}")
+
+    assertEquals(
+      listOf("{s}"),
+      SandboxRemoteComposeBridge.snapshot(SandboxRemoteComposeBridge.NO_PREVIEW_SCOPE).toList(),
+    )
+    // A real previewId must not pick up the sentinel scope's declarations.
+    assertEquals(emptyList<String>(), SandboxRemoteComposeBridge.snapshot("preview-a").toList())
+  }
+}

--- a/data/remotecompose/connector/src/main/kotlin/ee/schimke/composeai/daemon/RemoteComposeController.kt
+++ b/data/remotecompose/connector/src/main/kotlin/ee/schimke/composeai/daemon/RemoteComposeController.kt
@@ -10,6 +10,7 @@ import ee.schimke.composeai.daemon.protocol.RemoteNamedValue
 import ee.schimke.composeai.data.remotecompose.RemoteComposeKnobDeclaration
 import ee.schimke.composeai.data.remotecompose.RemoteComposePayload
 import java.util.concurrent.CopyOnWriteArrayList
+import kotlinx.serialization.json.Json
 
 /**
  * Process-static state holder for the Remote Compose connector.
@@ -66,6 +67,18 @@ object RemoteComposeController {
   /** Hooks notified whenever the named-value map or host-action buffer changes. */
   private val listeners: MutableList<() -> Unit> = CopyOnWriteArrayList()
 
+  /** Bridge scope key for a render that carries no previewId; mirrors the bridge's own sentinel. */
+  private const val NO_PREVIEW_SCOPE: String = ""
+
+  /**
+   * previewId of the render currently composing, stamped by the around-composable via [beginRender].
+   * Scopes the [bridgeForwarder] forwards so a pooled-sandbox run (`sandboxCount > 1`) doesn't leak
+   * one preview's declarations into another's host-side snapshot.
+   */
+  @Volatile private var activePreviewId: String? = null
+
+  private val json = Json { encodeDefaults = true }
+
   val namedValues: State<Map<String, RemoteNamedValue>>
     get() = namedValuesState
 
@@ -84,13 +97,36 @@ object RemoteComposeController {
    */
   fun recordDeclaration(declaration: RemoteComposeKnobDeclaration) {
     val current = declarationsState.value
-    if (current[declaration.name] == declaration) return
-    // LinkedHashMap preserves first-seen order even when replacing an existing name's value.
-    val next = LinkedHashMap(current)
-    next[declaration.name] = declaration
-    declarationsState.value = next
-    listeners.toList().forEach { it() }
+    if (current[declaration.name] != declaration) {
+      // LinkedHashMap preserves first-seen order even when replacing an existing name's value.
+      val next = LinkedHashMap(current)
+      next[declaration.name] = declaration
+      declarationsState.value = next
+      listeners.toList().forEach { it() }
+    }
+    // Cross-classloader forward for the Android sandbox. Serialise only when the bridge is present
+    // (a plain app / desktop daemon skips this entirely). Always forwarded — even when the in-CL
+    // value is unchanged — so a host reset the sandbox didn't observe is repopulated.
+    bridgeForwarder?.record(
+      bridgeScope(),
+      declaration.name,
+      json.encodeToString(RemoteComposeKnobDeclaration.serializer(), declaration),
+    )
   }
+
+  /**
+   * Stamp the previewId whose composition is about to run, so subsequent [recordDeclaration] /
+   * [clearDeclarations] forwards land in this preview's bridge scope (not a concurrently-rendering
+   * preview's, under a pooled sandbox). Called by the around-composable before preview content
+   * composes; `null` (a render with no previewId) maps to the bridge's no-preview scope. Mirrors
+   * `PreviewOverrideController.beginRender`.
+   */
+  fun beginRender(previewId: String?) {
+    activePreviewId = previewId
+  }
+
+  /** Bridge scope key for the active render — the no-preview sentinel when unset. */
+  private fun bridgeScope(): String = activePreviewId ?: NO_PREVIEW_SCOPE
 
   /** The knobs declared so far this render, in declaration order. */
   fun declarations(): List<RemoteComposeKnobDeclaration> = declarationsState.value.values.toList()
@@ -103,6 +139,10 @@ object RemoteComposeController {
    * `PreviewOverrideController.clearDeclarations`.
    */
   fun clearDeclarations() {
+    // Always reset the bridge scope (even when the in-classloader set is already empty) so a
+    // shrinking list's stale knobs drop from a reused sandbox's bridge entries — mirrors
+    // `PreviewOverrideController.clearDeclarations`.
+    bridgeForwarder?.reset(bridgeScope())
     if (declarationsState.value.isEmpty()) return
     declarationsState.value = emptyMap()
   }
@@ -194,10 +234,67 @@ object RemoteComposeController {
    * `PermissionsController.resetForNewSession`.
    */
   fun resetForNewSession() {
+    val scope = bridgeScope()
     namedValuesState.value = emptyMap()
     hostActionsState.value = emptyList()
     profileState.value = null
     declarationsState.value = emptyMap()
+    activePreviewId = null
     acceptedActionPayloads = null
+    bridgeForwarder?.reset(scope)
+  }
+
+  /**
+   * Resolved once per JVM, cached even on failure. `null` means the bridge class isn't on the
+   * classpath (plain apps, the desktop daemon, connector unit tests) — every forward no-ops. Mirrors
+   * `PreviewOverrideController`'s `BridgeForwarder`.
+   */
+  private val bridgeForwarder: BridgeForwarder? by lazy { BridgeForwarder.tryLoad() }
+
+  /**
+   * Reflective handle to `ee.schimke.composeai.daemon.bridge.SandboxRemoteComposeBridge`, which lives
+   * in `:daemon:android` (a downstream module this connector does NOT depend on). Reached via
+   * `Class.forName` — same shape as `PreviewOverrideController`'s `BridgeForwarder`. In the
+   * production Android daemon the controller is sandbox-loaded and the bridge package is
+   * do-not-acquire on the sandbox classloader, so both sides observe the same single bridge instance.
+   */
+  private class BridgeForwarder(
+    private val recordMethod: java.lang.reflect.Method,
+    private val resetMethod: java.lang.reflect.Method,
+  ) {
+    fun record(previewId: String, name: String, json: String) {
+      try {
+        recordMethod.invoke(null, previewId, name, json)
+      } catch (_: ReflectiveOperationException) {
+        // Drop — the in-classloader controller state still serves the same-CL fast path.
+      }
+    }
+
+    fun reset(previewId: String) {
+      try {
+        resetMethod.invoke(null, previewId)
+      } catch (_: ReflectiveOperationException) {
+        // Same defensive drop.
+      }
+    }
+
+    companion object {
+      private const val BRIDGE_FQN: String =
+        "ee.schimke.composeai.daemon.bridge.SandboxRemoteComposeBridge"
+
+      fun tryLoad(): BridgeForwarder? =
+        try {
+          val cls = Class.forName(BRIDGE_FQN, true, RemoteComposeController::class.java.classLoader)
+          BridgeForwarder(
+            recordMethod =
+              cls.getMethod("record", String::class.java, String::class.java, String::class.java),
+            resetMethod = cls.getMethod("reset", String::class.java),
+          )
+        } catch (_: ClassNotFoundException) {
+          null
+        } catch (_: NoSuchMethodException) {
+          null
+        }
+    }
   }
 }

--- a/data/remotecompose/connector/src/main/kotlin/ee/schimke/composeai/daemon/RemoteComposeDataProduct.kt
+++ b/data/remotecompose/connector/src/main/kotlin/ee/schimke/composeai/daemon/RemoteComposeDataProduct.kt
@@ -234,8 +234,13 @@ fun RemoteHostAction.toHostAction(): Action = hostAction(payload.rs, handlerId.r
  * * On enter — [RemoteComposeController.set] is called with the seed (clears the map / profile when
  *   null). `DisposableEffect(seed)` re-runs only when the override identity changes, so a
  *   subsequent `renderNow.overrides.remoteCompose` with the same shape doesn't churn.
- * * On dispose — clears the override and any captured host-action buffer (`resetForNewSession`).
- *   Matches `KeyboardOverrideExtension` / `PermissionsOverrideExtension` semantics.
+ * * On dispose — clears only the seed (named values / profile / accepted-action filter) via
+ *   [RemoteComposeController.set]`(null)`, **not** the recorded declarations or the sandbox bridge.
+ *   On Android the Compose test rule disposes the activity *before* `JsonRpcServer` calls
+ *   [RemoteComposeDataProductRegistry.onRender] → `declarationsFor`, so resetting the bridge here
+ *   would wipe the knobs before the host snapshots them. Declarations drop at the *next* render's
+ *   start via [RemoteComposeController.clearDeclarations] (after the host captured this render).
+ *   Mirrors `PreviewOverridesOverrideExtension`'s `onDispose { set(null) }`.
  *
  * Runs in [DataExtensionPhase.OuterEnvironment] so the composition local is in place before the
  * user-environment phase reaches preview content — `RemotePreview` blocks composed by user code see
@@ -268,7 +273,10 @@ class RemoteComposeOverrideExtension(private val seed: RemoteComposeOverride? = 
       // runs as a RememberObserver, which Compose invokes before any SideEffect, so this clear always
       // precedes the `named*` reads' SideEffect-recorded declarations for this pass.
       RemoteComposeController.clearDeclarations()
-      onDispose { RemoteComposeController.resetForNewSession() }
+      // Dispose clears only the seed — NOT declarations or the bridge — so the host's post-dispose
+      // onRender snapshot still sees this render's knobs (see the lifecycle KDoc above). Mirrors
+      // PreviewOverridesOverrideExtension's `onDispose { set(null) }`.
+      onDispose { RemoteComposeController.set(null) }
     }
     CompositionLocalProvider(LocalRemoteComposeHost provides ControllerRemoteComposeHost) {
       content()

--- a/data/remotecompose/connector/src/main/kotlin/ee/schimke/composeai/daemon/RemoteComposeDataProduct.kt
+++ b/data/remotecompose/connector/src/main/kotlin/ee/schimke/composeai/daemon/RemoteComposeDataProduct.kt
@@ -30,10 +30,12 @@ import ee.schimke.composeai.data.render.PreviewContext
 import ee.schimke.composeai.data.render.extensions.DataExtension
 import ee.schimke.composeai.data.render.extensions.DataExtensionCapability
 import ee.schimke.composeai.data.render.extensions.DataExtensionConstraints
+import ee.schimke.composeai.data.render.extensions.DataExtensionHookKind
 import ee.schimke.composeai.data.render.extensions.DataExtensionId
 import ee.schimke.composeai.data.render.extensions.DataExtensionPhase
 import ee.schimke.composeai.data.render.extensions.PlannedDataExtension
-import ee.schimke.composeai.data.render.extensions.compose.AroundComposableExtension
+import ee.schimke.composeai.data.render.extensions.compose.AroundComposableHook
+import ee.schimke.composeai.data.render.extensions.compose.ExtensionComposeContext
 import java.util.concurrent.ConcurrentHashMap
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
@@ -240,16 +242,25 @@ fun RemoteHostAction.toHostAction(): Action = hostAction(payload.rs, handlerId.r
  * the host.
  */
 class RemoteComposeOverrideExtension(private val seed: RemoteComposeOverride? = null) :
-  AroundComposableExtension(
-    id = ID,
-    constraints =
-      DataExtensionConstraints(
-        phase = DataExtensionPhase.OuterEnvironment,
-        provides = setOf(DataExtensionCapability(RemoteComposeDataProductRegistry.KIND)),
-      ),
-  ) {
+  AroundComposableHook {
+
+  override val id: DataExtensionId = ID
+
+  override val hooks: Set<DataExtensionHookKind> = setOf(DataExtensionHookKind.AroundComposable)
+
+  override val constraints: DataExtensionConstraints =
+    DataExtensionConstraints(
+      phase = DataExtensionPhase.OuterEnvironment,
+      provides = setOf(DataExtensionCapability(RemoteComposeDataProductRegistry.KIND)),
+    )
+
   @Composable
-  override fun AroundComposable(content: @Composable () -> Unit) {
+  override fun Around(context: ExtensionComposeContext, content: @Composable () -> Unit) {
+    // Stamp the active previewId before content composes so the sandbox-side declaration forwards
+    // land in this preview's bridge scope, not a concurrently-rendering preview's (pooled sandboxes).
+    // Plain call (not a SideEffect) so it runs during composition, ahead of any `named*` read in
+    // `content()`. Mirrors PreviewOverridesOverrideExtension.
+    RemoteComposeController.beginRender(context.previewId)
     DisposableEffect(seed) {
       RemoteComposeController.set(seed)
       // Clear declarations at render start (mirrors PreviewOverridesOverrideExtension): a held
@@ -372,7 +383,7 @@ class RemoteComposeDataProductRegistry : DataProductRegistry {
     val namedValues = RemoteComposeController.namedValues.value
     val hostActions = RemoteComposeController.hostActions.value
     val profile = RemoteComposeController.profile.value
-    val declarations = RemoteComposeController.declarations()
+    val declarations = declarationsFor(previewId)
     if (
       namedValues.isEmpty() && hostActions.isEmpty() && profile == null && declarations.isEmpty()
     ) {
@@ -390,6 +401,74 @@ class RemoteComposeDataProductRegistry : DataProductRegistry {
     )
   }
 
+  /**
+   * The knobs declared by the render for [previewId]. The do-not-acquire [SandboxRemoteComposeBridge]
+   * is shared across the sandbox boundary, so prefer it when reachable (its JSON snapshot is decoded
+   * back into typed declarations) — on Android the in-classloader controller the host reads is a
+   * different, empty instance. Falls back to the in-CL `RemoteComposeController` when the bridge
+   * isn't on the classpath (the desktop daemon / connector unit tests, where the controller IS the
+   * source of truth) or the bridge has nothing for this preview. Mirrors
+   * `PreviewOverridesDataProductRegistry.declarationsFor`.
+   */
+  private fun declarationsFor(previewId: String): List<RemoteComposeKnobDeclaration> {
+    val controllerDeclarations = RemoteComposeController.declarations()
+    val bridge = SandboxRemoteComposeBridgeReader.tryLoad() ?: return controllerDeclarations
+    val bridgeJson = bridge.snapshot(previewId)
+    if (bridgeJson.isEmpty()) return controllerDeclarations
+    return bridgeJson.mapNotNull { entry ->
+      runCatching { json.decodeFromString(RemoteComposeKnobDeclaration.serializer(), entry) }
+        .getOrNull()
+    }
+  }
+
+  /**
+   * Reflective lookup of `ee.schimke.composeai.daemon.bridge.SandboxRemoteComposeBridge`. Cached per
+   * JVM. `null` means the bridge isn't on the classpath (connector-only unit tests; the desktop
+   * daemon has no sandbox). Mirrors `PreviewOverridesDataProductRegistry`'s
+   * `SandboxPreviewOverridesBridgeReader`.
+   */
+  private class SandboxRemoteComposeBridgeReader(
+    private val snapshotMethod: java.lang.reflect.Method
+  ) {
+    fun snapshot(scope: String): List<String> =
+      runCatching {
+          @Suppress("UNCHECKED_CAST")
+          (snapshotMethod.invoke(null, scope) as Array<String>).toList()
+        }
+        .getOrDefault(emptyList())
+
+    companion object {
+      private const val BRIDGE_FQN: String =
+        "ee.schimke.composeai.daemon.bridge.SandboxRemoteComposeBridge"
+
+      @Volatile private var resolved: SandboxRemoteComposeBridgeReader? = null
+      @Volatile private var attempted: Boolean = false
+
+      fun tryLoad(): SandboxRemoteComposeBridgeReader? {
+        if (attempted) return resolved
+        val reader =
+          try {
+            val cls =
+              Class.forName(
+                BRIDGE_FQN,
+                true,
+                SandboxRemoteComposeBridgeReader::class.java.classLoader,
+              )
+            SandboxRemoteComposeBridgeReader(
+              snapshotMethod = cls.getMethod("snapshot", String::class.java)
+            )
+          } catch (_: ClassNotFoundException) {
+            null
+          } catch (_: NoSuchMethodException) {
+            null
+          }
+        resolved = reader
+        attempted = true
+        return reader
+      }
+    }
+  }
+
   companion object {
     const val KIND: String = RemoteComposeProduct.KIND
     const val SCHEMA_VERSION: Int = RemoteComposeProduct.SCHEMA_VERSION
@@ -397,6 +476,7 @@ class RemoteComposeDataProductRegistry : DataProductRegistry {
     private val json = Json {
       encodeDefaults = true
       prettyPrint = false
+      ignoreUnknownKeys = true
     }
   }
 }

--- a/data/remotecompose/connector/src/test/kotlin/ee/schimke/composeai/daemon/RemoteComposeDataProductTest.kt
+++ b/data/remotecompose/connector/src/test/kotlin/ee/schimke/composeai/daemon/RemoteComposeDataProductTest.kt
@@ -245,6 +245,26 @@ class RemoteComposeDataProductTest {
   }
 
   @Test
+  fun dispose_via_set_null_keeps_declarations_for_post_render_snapshot() {
+    // On Android the around-composable's onDispose runs before the host's onRender snapshot, so
+    // dispose (modelled by `set(null)`) must NOT drop declarations — otherwise the knobs vanish
+    // before `declarationsFor` reads them. Regression guard for the P1 on the bridge PR.
+    val controller = RemoteComposeController
+    controller.recordDeclaration(
+      RemoteComposeKnobDeclaration("label", RemoteNamedValue.StringValue("Filled"))
+    )
+    controller.set(
+      RemoteComposeOverride(namedValues = mapOf("label" to RemoteNamedValue.StringValue("seed")))
+    )
+    controller.set(null) // simulates the around-composable's onDispose
+    assertEquals(
+      "declarations must survive dispose for the host's post-render snapshot",
+      listOf("label"),
+      controller.declarations().map { it.name },
+    )
+  }
+
+  @Test
   fun on_render_captures_declared_knobs_in_payload() {
     val registry = RemoteComposeDataProductRegistry()
     RemoteComposeController.recordDeclaration(


### PR DESCRIPTION
## Summary

**PR 2 of the "auto-render Remote Compose knobs" series** (builds on #2677, now merged). This makes the captured knob declarations reach the host on the **Android** backend — the only one `remote-m3` uses.

On Android a preview composes inside a Robolectric **sandbox classloader**, so the declarations `RemoteComposeController` records there live in a *sandbox-local* copy of the controller's static state. The host-side `RemoteComposeDataProductRegistry` runs in the host classloader and reads a *different, empty* controller instance — so before this PR, `data/fetch?kind=compose/remotecompose` returned no `declarations` on Android even though PR 1 captured them. (Desktop has no sandbox and already worked.)

This is the exact sibling of the plain-Compose `compose/overrides` bridge (`SandboxPreviewOverridesBridge`).

## What changed

- **New `SandboxRemoteComposeBridge`** (`daemon/android/…/bridge/`) — a JVM-wide singleton in the `ee.schimke.composeai.daemon.bridge` package, which `SandboxHoldingRunner` **already** registers as `doNotAcquirePackage`, so one instance is visible from both sides of the sandbox boundary (no registration change needed). Declarations cross as **JSON strings** (a typed object from the sandbox classloader couldn't be cast on the host side), **per-preview scoped** so a pooled-sandbox run doesn't leak preview A's knobs into preview B's snapshot.
- **`RemoteComposeController`** — a reflective `BridgeForwarder` (the connector doesn't depend on `:daemon:android`) plus `beginRender(previewId)` scoping. `recordDeclaration` / `clearDeclarations` / `resetForNewSession` now forward to the bridge. Mirrors `PreviewOverrideController`.
- **`RemoteComposeOverrideExtension`** now implements `AroundComposableHook` directly (was the context-free `AroundComposableExtension` base) so it can stamp `beginRender(context.previewId)` before content composes.
- **`RemoteComposeDataProductRegistry.declarationsFor`** prefers the bridge's decoded JSON snapshot for the preview, falling back to the in-classloader controller (desktop daemon / connector unit tests). Mirrors `PreviewOverridesDataProductRegistry`.

## Test plan

- [x] `./gradlew :daemon:android:testDebugUnitTest --tests "*SandboxRemoteComposeBridgeTest"` — green. Covers per-preview isolation, insertion order, in-place replace of a re-declared name, per-preview `reset` (a concurrent preview survives), `resetAll`, and the no-preview sentinel scope.
- [x] `./gradlew :data-remotecompose-connector:testDebugUnitTest` — green (bridge absent on the connector classpath → the in-CL controller fallback path, which the PR-1 tests already assert).
- [x] `:daemon:android` compiles against the refactored extension; ktfmt clean on both modules.
- The cross-classloader forward (sandbox `record` → host `snapshot`) is only exercisable end-to-end by an actual Robolectric render, same as its `SandboxPreviewOverridesBridge` sibling — CI's Android render path covers it.

## Remaining in the series

3. Bundle-sidecar packing (persist declarations for serve).
4. Serve advertise + VS Code viewer controls *(needs preview-harness visual evidence)*.
5. Flip `remote-m3` to a live bundle in `design-artifacts.yml` *(deploy-host validation)*.

---
_Generated by [Claude Code](https://claude.ai/code/session_011K7sgCfdsbhN7fwMb3WhSS)_