### PR TITLE
perf(daemon): background sandbox boot + warm renders for Android cold start

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt
@@ -504,8 +504,31 @@ internal object ServeBundleDaemon {
       variant = "android",
       daemonClasspath = (daemonJars + listOf(androidJar)).map { it.absolutePath },
       jvmArgs = launch.jvmArgs(),
-      extraSystemProperties = launch.robolectricSystemProperties(),
+      extraSystemProperties =
+        launch.robolectricSystemProperties() + androidColdStartSystemProperties(),
     )
+  }
+
+  /**
+   * Cold-start knobs for a serve-spawned Android/Robolectric daemon. Serve fronts the daemon with
+   * baked PNGs while it warms ([ServeCatalogLiveHost]'s warm-in-background lane), so nothing here
+   * needs the strict all-sandboxes-ready `initialize` contract the Gradle-plugin/VS Code launch
+   * keeps — opt into `RobolectricHost`'s background pool boot by default: `initialize` returns once
+   * ONE sandbox can render (~12 s warm-cache instead of N×), the rest of the pool boots off the
+   * request path, and each background slot gets a boot-time warm render. An explicit
+   * `-Dcomposeai.daemon.backgroundSandboxBoot=…` on the serve JVM (e.g. via `JAVA_TOOL_OPTIONS`)
+   * wins, so operators can opt a deployment out; `composeai.daemon.warmRenderOnBoot` is forwarded
+   * when set for the same reason. Command-line `-D`s land after `JAVA_TOOL_OPTIONS` on the child
+   * JVM, so the value emitted here is authoritative for the daemon.
+   */
+  private fun androidColdStartSystemProperties(): Map<String, String> = buildMap {
+    put(
+      "composeai.daemon.backgroundSandboxBoot",
+      System.getProperty("composeai.daemon.backgroundSandboxBoot") ?: "true",
+    )
+    System.getProperty("composeai.daemon.warmRenderOnBoot")?.let {
+      put("composeai.daemon.warmRenderOnBoot", it)
+    }
   }
 
   /**

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemonTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemonTest.kt
@@ -211,6 +211,10 @@ class ServeBundleDaemonTest {
       parsed.systemProperties["robolectric.graphicsMode"] == "NATIVE",
       "android descriptor should carry the robolectric.* render flags",
     )
+    assertTrue(
+      parsed.systemProperties["composeai.daemon.backgroundSandboxBoot"] == "true",
+      "serve-spawned android daemons should default to background pool boot (fast cold start)",
+    )
 
     val host =
       try {

--- a/daemon/android/build.gradle.kts
+++ b/daemon/android/build.gradle.kts
@@ -212,6 +212,12 @@ dependencies {
   compileOnly(libs.roborazzi)
   compileOnly(libs.roborazzi.compose)
 
+  // atrace-level render-phase sections (see AndroidxTraceSections). `implementation`, not
+  // compileOnly like the Compose stack above: the standalone lib-daemon-android sidecar has no
+  // consumer module to supply it, and the artifact is tiny + binary-stable so the version-skew
+  // rationale behind the compileOnly contract doesn't apply.
+  implementation(libs.androidx.tracing)
+
   // Test classpath: real runtime versions for the RobolectricHost
   // sandbox-reuse assertion. Protocol round-trip and JsonRpcServer
   // framing/integration tests now live in :daemon:core.

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidxTraceSections.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidxTraceSections.kt
@@ -1,0 +1,83 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.data.render.PerfettoTraceDataProducer
+
+/**
+ * `androidx.tracing`-backed [PerfettoTraceDataProducer.TraceSectionBackend] — mirrors every
+ * render-phase span the daemon already times (`classloader:loadPreviewClass`,
+ * `compose:setContent`, `compose:advanceClock`, `render:captureRoboImage`, `dataArtifact:*`, …)
+ * onto `android.os.Trace` sections, so those phases line up with the framework's and Compose's own
+ * sections in an atrace-level capture instead of living only in the daemon's private
+ * chrome-trace JSON.
+ *
+ * **Opt-in** via `-Dcomposeai.daemon.atrace=true` (profiling runs only). Robolectric routes
+ * `android.os.Trace` through `ShadowTrace`, which accumulates section history in static state
+ * with no test-lifecycle resets in a long-lived daemon — an always-on default would be a slow
+ * leak, so the backend installs only when asked for.
+ *
+ * Capture recipes once enabled:
+ * - Robolectric's own reporting (`PerfStatsCollector`, `ShadowTrace`) picks the sections up
+ *   directly inside the sandbox.
+ * - With `androidx.compose.runtime:runtime-tracing` on the consumer classpath (the daemon already
+ *   detects it — see `TraceMetadata.composeRuntimeTracingOnClasspath`), recomposition spans and
+ *   these phase spans share one timeline.
+ * - A wall-clock profiler (async-profiler/JFR per the cold-render handover §4) can be correlated
+ *   against the same section names via the `compose-ai-daemon` stderr markers.
+ *
+ * Must only be installed from **inside the sandbox** (see [installIfEnabled]'s call site in
+ * `RobolectricHost.SandboxRunner`): on the host side of the classloader boundary
+ * `android.os.Trace` is the android.jar stub and every call throws. Both entry points are
+ * additionally try/caught by the callers ([PerfettoTraceDataProducer.Recorder.section] and
+ * [traced]) so a tracer failure can never fail a render.
+ */
+internal object AndroidxTraceSections : PerfettoTraceDataProducer.TraceSectionBackend {
+
+  /** Sysprop turning the atrace mirror on. Default off — see the class KDoc for why. */
+  const val ENABLED_PROP: String = "composeai.daemon.atrace"
+
+  /** `android.os.Trace` truncates section names beyond this; cut cleanly instead. */
+  private const val MAX_SECTION_NAME_LENGTH = 127
+
+  fun enabled(): Boolean = System.getProperty(ENABLED_PROP) == "true"
+
+  /**
+   * Registers this backend on [PerfettoTraceDataProducer.sectionBackend] when [enabled]. Idempotent
+   * — called from the sandbox-side engine init so the registration lands on the sandbox
+   * classloader's copy of the producer (the same copy the render-path [Recorder]s read).
+   */
+  fun installIfEnabled() {
+    if (enabled()) PerfettoTraceDataProducer.sectionBackend = this
+  }
+
+  override fun begin(name: String) {
+    androidx.tracing.Trace.beginSection(name.take(MAX_SECTION_NAME_LENGTH))
+  }
+
+  override fun end() {
+    androidx.tracing.Trace.endSection()
+  }
+
+  /**
+   * Failsafe section wrapper for sandbox-side call sites outside the [Recorder] flow (e.g. the
+   * whole-render span in `SandboxRunner.dispatchRender`). No-op when [enabled] is false.
+   */
+  fun <T> traced(name: String, block: () -> T): T {
+    if (!enabled()) return block()
+    val began =
+      try {
+        begin(name)
+        true
+      } catch (_: Throwable) {
+        false
+      }
+    try {
+      return block()
+    } finally {
+      if (began) {
+        try {
+          end()
+        } catch (_: Throwable) {}
+      }
+    }
+  }
+}

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -437,6 +437,22 @@ open class RobolectricHost(
     if (sandboxCount == 1) "compose-ai-daemon-host" else "compose-ai-daemon-host-$i"
 
   /**
+   * Number of sandbox slots that have finished booting, in slot order (slots boot sequentially, so
+   * ready slots are always the contiguous prefix `0 until readySlotCount`). [chooseSlotIndex]
+   * dispatches across only this prefix so a render never lands on a slot that's still
+   * bootstrapping in the background (see [start]'s background-boot mode). Equals [sandboxCount]
+   * once the pool completes — at which point dispatch is bit-identical with the pre-background
+   * behaviour.
+   */
+  private val readySlotCount = java.util.concurrent.atomic.AtomicInteger(0)
+
+  /** Background pool-boot thread (see [start]); null when background boot isn't active. */
+  @Volatile private var backgroundBootWorker: Thread? = null
+
+  /** Test seam: current ready-slot count (see [readySlotCount]). */
+  internal fun readySlotCountForTest(): Int = readySlotCount.get()
+
+  /**
    * Starts the host thread AND blocks until the Robolectric sandbox is fully bootstrapped.
    *
    * After this returns, [submit] is guaranteed to find a hot sandbox — no per-submit sandbox-ready
@@ -453,6 +469,17 @@ open class RobolectricHost(
    * rather than rendering against a half-built host. Blocking here in [start] delivers that —
    * `JsonRpcServer.run()` only enters its read loop once we return.
    *
+   * **Background pool boot** (`-Dcomposeai.daemon.backgroundSandboxBoot=true`, default off): with a
+   * pool (`sandboxCount > 1`), [start] blocks only until **slot 0** is ready and boots slots
+   * 1..N-1 on a background thread. Sandbox boot is the dominant cold-start cost (~11.6 s measured
+   * per sandbox on a warm `android-all` cache — see the serve cold-render handover), so a
+   * 3-sandbox pool otherwise keeps `initialize` (and therefore serve's first live render) waiting
+   * ~35 s for capacity it doesn't need yet. Dispatch routes only across ready slots
+   * ([readySlotCount]) until the pool completes, so `daemonReady = firstSandboxReady` and the
+   * remaining boots never sit on the request path. Off by default so in-process hosts and the
+   * Gradle-plugin launch keep the strict all-sandboxes-ready contract their tests pin;
+   * `ServeBundleDaemon` and the deploy image opt serve-spawned Android daemons in.
+   *
    * Configurable via `composeai.daemon.sandboxBootTimeoutMs` (default 600_000 = 10 minutes). On
    * timeout the daemon refuses to start; the client surfaces the failure via initialize never
    * returning rather than via per-render timeouts.
@@ -461,29 +488,127 @@ open class RobolectricHost(
     StartupTimings.mark("RobolectricHost.start() entered")
     DaemonHostBridge.reset()
     DaemonHostBridge.configureSlotCount(sandboxCount)
+    readySlotCount.set(0)
     val timeoutMs =
       System.getProperty(SANDBOX_BOOT_TIMEOUT_PROP)?.toLongOrNull()
         ?: DEFAULT_SANDBOX_BOOT_TIMEOUT_MS
+    // Read per-start (not at construction) so tests can flip the sysprop around start().
+    val backgroundBoot =
+      sandboxCount > 1 &&
+        (System.getProperty(BACKGROUND_BOOT_PROP)?.toBooleanStrictOrNull() ?: false)
 
     // SANDBOX-POOL.md — boot sandboxes sequentially, one worker at a time. We could in principle
     // start them concurrently (each sandbox is independent now that the cache-key fix lands and
     // `SandboxManager.getAndroidSandbox` is internally synchronized), but sequenced boots keep
     // diagnosis simple if a future Robolectric upgrade reintroduces a global-state path. Total
-    // cold-start is proportional to N × per-sandbox-boot — on warm cache 5–15s × N — acceptable
-    // for typical pool sizes.
+    // cold-start is proportional to N × per-sandbox-boot — on warm cache 5–15s × N — which is why
+    // background boot moves slots 1..N-1 off the [start] critical path.
+    val eagerCount = if (backgroundBoot) 1 else sandboxCount
     var bootedThrough = -1
     try {
-      for (i in 0 until sandboxCount) {
+      for (i in 0 until eagerCount) {
         bootSlotWithRetries(i, timeoutMs)
         bootedThrough = i
+        readySlotCount.set(i + 1)
       }
     } catch (t: Throwable) {
       runCatching { abortPartialStart(bootedThrough) }
       throw t
     }
     StartupTimings.mark(
-      if (sandboxCount == 1) "sandbox-ready latch fired" else "all sandbox-ready latches fired"
+      when {
+        sandboxCount == 1 -> "sandbox-ready latch fired"
+        backgroundBoot ->
+          "sandbox-ready latch fired (slot 0; ${sandboxCount - 1} more booting in background)"
+        else -> "all sandbox-ready latches fired"
+      }
     )
+    if (backgroundBoot) {
+      backgroundBootWorker =
+        Thread({ bootRemainingSlotsInBackground(timeoutMs) }, "compose-ai-daemon-pool-boot").apply {
+          // Daemon thread: a JVM exiting mid-pool-boot shouldn't be held open by the booter (the
+          // sandbox workers it spawns are non-daemon, but JsonRpcServer exits via System.exit).
+          isDaemon = true
+          start()
+        }
+    }
+  }
+
+  /**
+   * Background-boot path for slots 1..N-1 (see [start]). Sequential like the eager path; stops at
+   * the first slot that fails permanently — [DaemonHostBridge.registerSandbox] claims the first
+   * *free* slot, so booting a later worker past a dead slot would register into the dead slot's
+   * index and strand its own ready latch. A permanent slot failure therefore caps the pool at
+   * [readySlotCount] instead of aborting the whole daemon (the eager path's behaviour): the live
+   * lane degrades to fewer sandboxes rather than collapsing to baked PNGs.
+   *
+   * After each slot comes up it gets a best-effort [warmSlotRender] so its first affinity-routed
+   * real render doesn't pay the per-sandbox first-render init (Compose runtime, HardwareRenderer
+   * native pipeline, font + text stack, PNG encode).
+   */
+  private fun bootRemainingSlotsInBackground(timeoutMs: Long) {
+    for (i in 1 until sandboxCount) {
+      if (DaemonHostBridge.shutdown.get()) return
+      try {
+        bootSlotWithRetries(i, timeoutMs)
+      } catch (t: Throwable) {
+        System.err.println(
+          "RobolectricHost: background boot of sandbox slot $i failed permanently " +
+            "(${t.javaClass.simpleName}: ${t.message}); continuing with ${readySlotCount.get()} " +
+            "ready sandbox(es) — renders stay up on the booted slots."
+        )
+        return
+      }
+      readySlotCount.set(i + 1)
+      StartupTimings.mark("sandbox $i ready (background boot)")
+      if (DaemonHostBridge.shutdown.get()) return
+      warmSlotRender(i)
+    }
+  }
+
+  /**
+   * Best-effort boot-time warm render against [slotIdx] (background-booted slots only; slot 0 is
+   * the live request path and is warmed by serve's own `prewarm()` throwaway render). Renders the
+   * daemon-shipped [DaemonWarmupPreview] — deliberately not a user preview, so it can't inherit a
+   * broken/heavy first catalog entry — which pays the generic per-sandbox first-render costs off
+   * the request path. Failures are logged and swallowed: a cold slot is a latency problem, not a
+   * correctness one. Disable with `-Dcomposeai.daemon.warmRenderOnBoot=false`.
+   */
+  private fun warmSlotRender(slotIdx: Int) {
+    val enabled = System.getProperty(WARM_RENDER_PROP)?.toBooleanStrictOrNull() ?: true
+    if (!enabled) return
+    val id = RenderHost.nextRequestId()
+    val startedAt = System.nanoTime()
+    try {
+      publishChildLoaderForSlot(slotIdx)
+      val payload =
+        "className=$WARMUP_PREVIEW_CLASS;functionName=$WARMUP_PREVIEW_FUNCTION;" +
+          "widthPx=64;heightPx=64;density=1.0;showBackground=true;" +
+          "outputBaseName=__warmup-slot-$slotIdx"
+      DaemonHostBridge.slot(slotIdx).requests.put(RenderRequest.Render(id = id, payload = payload))
+      val resultQueue = DaemonHostBridge.results.computeIfAbsent(id) { LinkedBlockingQueue() }
+      val raw = resultQueue.poll(WARM_RENDER_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+      val tookMs = (System.nanoTime() - startedAt) / 1_000_000
+      when {
+        raw == null ->
+          System.err.println(
+            "compose-ai-daemon: warm render on slot $slotIdx timed out after ${tookMs}ms"
+          )
+        raw is Throwable ->
+          System.err.println(
+            "compose-ai-daemon: warm render on slot $slotIdx failed after ${tookMs}ms " +
+              "(${raw.javaClass.simpleName}: ${raw.message})"
+          )
+        else -> StartupTimings.mark("sandbox $slotIdx warm render done (${tookMs}ms)")
+      }
+    } catch (t: Throwable) {
+      System.err.println(
+        "compose-ai-daemon: warm render on slot $slotIdx threw " +
+          "(${t.javaClass.simpleName}: ${t.message}); continuing"
+      )
+    } finally {
+      DaemonHostBridge.results.remove(id)
+    }
   }
 
   /**
@@ -760,17 +885,30 @@ open class RobolectricHost(
     payload: String,
     id: Long,
     interactiveSlotPinned: Boolean = false,
-  ): Int = chooseSlotIndex(RenderRequest.Render(id = id, payload = payload), interactiveSlotPinned)
+  ): Int =
+    // Tests probe the steady-state dispatch (all slots booted), independent of whether this host
+    // instance ever started — pass the full pool size rather than the live ready count.
+    chooseSlotIndex(
+      RenderRequest.Render(id = id, payload = payload),
+      interactiveSlotPinned,
+      dispatchSlotCount = sandboxCount,
+    )
 
   private fun chooseSlotIndex(
     render: RenderRequest.Render,
     interactiveSlotPinned: Boolean = activeInteractiveStreamId.get() != null,
+    // Background boot (see [start]) brings slots up one at a time; dispatch across only the ready
+    // prefix so a render never queues on a still-bootstrapping sandbox. Affinity shifts as slots
+    // come up (mod 1 → mod 2 → …) which only costs cache warmth, not correctness — the same
+    // preview re-keys at most N-1 times and then stays stable for the daemon's lifetime.
+    dispatchSlotCount: Int = readySlotCount.get().coerceAtLeast(1),
   ): Int {
-    if (sandboxCount == 1) return 0
+    val slots = dispatchSlotCount.coerceIn(1, sandboxCount)
+    if (slots == 1) return 0
     val previewId = parsePreviewIdFromPayload(render.payload)
     val key: Int = previewId?.hashCode() ?: render.id.hashCode()
-    if (!interactiveSlotPinned) return Math.floorMod(key, sandboxCount)
-    val normalSlotCount = sandboxCount - 1
+    if (!interactiveSlotPinned) return Math.floorMod(key, slots)
+    val normalSlotCount = slots - 1
     val normalSlot = Math.floorMod(key, normalSlotCount)
     return if (normalSlot < INTERACTIVE_SLOT_INDEX) normalSlot else normalSlot + 1
   }
@@ -1077,6 +1215,20 @@ open class RobolectricHost(
     inspectionMode: Boolean? = spec.inspectionMode,
     onSessionClosed: (() -> Unit)? = null,
   ): AndroidInteractiveSession {
+    // Background pool boot (see [start]): slot 1 may still be bootstrapping when the first
+    // `interactive/start` arrives. Wait briefly for it rather than failing outright — the slot's
+    // ready latch also counts down on a *failed* boot, so gate on the classloader actually being
+    // registered. A slot that never comes up (permanent background-boot failure) times out here
+    // and surfaces the same clean Unsupported the caller already handles with a v1 fallback.
+    val interactiveSlot = DaemonHostBridge.slot(INTERACTIVE_SLOT_INDEX)
+    interactiveSlot.awaitSandboxReady(INTERACTIVE_START_TIMEOUT_MS)
+    if (interactiveSlot.sandboxClassLoaderRef.get() == null) {
+      throw UnsupportedOperationException(
+        "RobolectricHost: interactive slot $INTERACTIVE_SLOT_INDEX is not booted " +
+          "(ready ${readySlotCount.get()}/$sandboxCount sandboxes) — still warming in the " +
+          "background, or its boot failed permanently. Retry shortly."
+      )
+    }
     val streamId = "android-stream-${nextStreamCounter.getAndIncrement()}"
     if (!activeInteractiveStreamId.compareAndSet(null, streamId)) {
       val held = activeInteractiveStreamId.get() ?: "<concurrent close>"
@@ -1449,6 +1601,37 @@ open class RobolectricHost(
     const val DEFAULT_SANDBOX_BOOT_TIMEOUT_MS: Long = 10L * 60L * 1000L
 
     /**
+     * Sysprop opting a pooled host into background pool boot (see [start]): block only until
+     * sandbox 0 is ready, boot slots 1..N-1 on a background thread, and dispatch across the ready
+     * prefix in the meantime. Cuts a pooled daemon's `initialize`-ready time from N× to 1× the
+     * per-sandbox boot cost (~11.6 s measured warm-cache). Default **false** so in-process hosts
+     * and the Gradle-plugin launch keep the strict all-sandboxes-ready [start] contract;
+     * `ServeBundleDaemon` sets it for serve-spawned Android daemons and the deploy image sets it
+     * via `JAVA_TOOL_OPTIONS`.
+     */
+    const val BACKGROUND_BOOT_PROP: String = "composeai.daemon.backgroundSandboxBoot"
+
+    /**
+     * Sysprop gating the boot-time warm render each background-booted slot gets (see
+     * [warmSlotRender]). Default **true** — only consulted when background boot is active, since
+     * the warm render rides the background boot thread.
+     */
+    const val WARM_RENDER_PROP: String = "composeai.daemon.warmRenderOnBoot"
+
+    /**
+     * Budget for one boot-time warm render. Generous versus a warm frame (~seconds) because the
+     * warm render *is* the sandbox's cold first render — HardwareRenderer native init + font stack
+     * — but bounded so a wedged warm can't pin the background boot thread forever.
+     */
+    const val WARM_RENDER_TIMEOUT_MS: Long = 120_000L
+
+    /** FQN of the file facade carrying [DaemonWarmupPreview] (see WarmupPreviews.kt). */
+    const val WARMUP_PREVIEW_CLASS: String = "ee.schimke.composeai.daemon.WarmupPreviewsKt"
+
+    /** Function name of the boot-time warmup composable. */
+    const val WARMUP_PREVIEW_FUNCTION: String = "DaemonWarmupPreview"
+
+    /**
      * How many times [start] re-launches a single sandbox slot whose first boot attempt failed
      * before it gives up and aborts the host. A transient per-sandbox bootstrap failure (e.g.
      * `Unable to load Robolectric native runtime library` on a memory-pressured pooled boot) then
@@ -1515,8 +1698,16 @@ open class RobolectricHost(
     // Belt-and-braces: also enqueue a Shutdown on every slot's queue so each worker wakes from
     // poll() promptly rather than waiting out the 100ms cycle.
     DaemonHostBridge.slots().forEach { runCatching { it.requests.put(RenderRequest.Shutdown) } }
+    // Background pool boot: give the booter a moment to observe the shutdown flag so it stops
+    // spawning/awaiting further workers before we start joining them.
+    backgroundBootWorker?.let { runCatching { it.join(2_000) } }
     workerThreads.forEach { it.join(timeoutMs) }
-    val stuck = workerThreads.filter { it.isAlive }
+    // A worker whose sandbox never registered (still inside Robolectric bootstrap when shutdown
+    // raced a background pool boot) can't see the poison pill and legitimately outlives the join —
+    // same "orphaned in this JVM" outcome [abortPartialStart] documents, and the daemon exits via
+    // System.exit anyway. Only a *ready* slot's worker refusing to exit is a real bug.
+    val ready = readySlotCount.get()
+    val stuck = workerThreads.filterIndexed { i, t -> t.isAlive && i < ready }
     if (stuck.isNotEmpty()) {
       error(
         "RobolectricHost worker(s) did not exit within ${timeoutMs}ms after shutdown: " +
@@ -1607,6 +1798,11 @@ open class RobolectricHost(
      * contract clean.
      */
     private val engine: RenderEngine by lazy {
+      // Opt-in atrace mirror for the render-phase spans (see [AndroidxTraceSections]). Installed
+      // here — inside the sandbox, before the first render — so the registration lands on the
+      // sandbox classloader's copy of the trace producer and `android.os.Trace` resolves to the
+      // real android-all implementation rather than the host-side android.jar stub.
+      AndroidxTraceSections.installIfEnabled()
       // [AmbientPreviewOverrideExtension] (and its companion [AmbientInputDispatchObserver]
       // registered alongside [acquireRecordingSession]) reach `LocalAmbientModeManager` /
       // `AmbientMode` from `androidx.wear.compose.foundation` and `AmbientLifecycleObserver` from
@@ -1888,7 +2084,14 @@ open class RobolectricHost(
         slot.childLoaderRef.get()
           ?: Thread.currentThread().contextClassLoader
           ?: RenderEngine::class.java.classLoader
-      return engine.render(spec, id, classLoader, sandboxStats = sandboxStats)
+      // Whole-render atrace span bracketing every per-phase section the engine opens — gives a
+      // capture one parent slice per render, named by preview. No-op unless
+      // `-Dcomposeai.daemon.atrace=true` (see [AndroidxTraceSections]).
+      return AndroidxTraceSections.traced(
+        "composeai:render:${spec.previewId ?: spec.outputBaseName}"
+      ) {
+        engine.render(spec, id, classLoader, sandboxStats = sandboxStats)
+      }
     }
 
     /**

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -544,7 +544,10 @@ open class RobolectricHost(
    *
    * After each slot comes up it gets a best-effort [warmSlotRender] so its first affinity-routed
    * real render doesn't pay the per-sandbox first-render init (Compose runtime, HardwareRenderer
-   * native pipeline, font + text stack, PNG encode).
+   * native pipeline, font + text stack, PNG encode). The warm render runs BEFORE the slot is
+   * published into [readySlotCount] — publishing first would let a live render hash onto the
+   * just-advertised slot and queue behind the cold warm-up, putting the very cost the warm-up
+   * absorbs back on the request path.
    */
   private fun bootRemainingSlotsInBackground(timeoutMs: Long) {
     for (i in 1 until sandboxCount) {
@@ -559,10 +562,10 @@ open class RobolectricHost(
         )
         return
       }
-      readySlotCount.set(i + 1)
-      StartupTimings.mark("sandbox $i ready (background boot)")
       if (DaemonHostBridge.shutdown.get()) return
       warmSlotRender(i)
+      readySlotCount.set(i + 1)
+      StartupTimings.mark("sandbox $i ready (background boot)")
     }
   }
 

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/WarmupPreviews.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/WarmupPreviews.kt
@@ -1,0 +1,28 @@
+package ee.schimke.composeai.daemon
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+
+/**
+ * Boot-time warm-render target for background-booted sandbox slots — see
+ * [RobolectricHost.warmSlotRender]. Rendered once per background-booted sandbox so the slot's
+ * first *real* render doesn't pay the per-sandbox cold-render init: first composition + layout
+ * pass, the NATIVE-graphics `HardwareRenderer` pipeline Roborazzi's capture walks, the font/text
+ * stack (the [BasicText] below is what pulls that in), and the PNG encode.
+ *
+ * Ships in the daemon's own main source set (not a user preview, not a testFixture) so it is
+ * always resolvable on the sandbox classpath regardless of what the served bundle carries, and a
+ * broken or heavy first catalog entry can never poison the warm-up. Keep it trivial and
+ * dependency-light: foundation + ui only, no Material, no resources.
+ */
+@Composable
+fun DaemonWarmupPreview() {
+  Box(modifier = Modifier.fillMaxSize().background(Color(0xFF3A3A3A))) {
+    BasicText(text = "compose-preview warm-up")
+  }
+}

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/RobolectricHostPoolTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/RobolectricHostPoolTest.kt
@@ -172,6 +172,60 @@ class RobolectricHostPoolTest {
   }
 
   @Test
+  fun backgroundBootServesRendersBeforePoolCompletesAndWarmsTheLateSlot() {
+    // Cold-start fast path (`composeai.daemon.backgroundSandboxBoot=true`): start() blocks only
+    // until slot 0 is up, slots 1..N-1 boot on a background thread, and dispatch routes across
+    // the ready prefix meanwhile. Asserts the three load-bearing pieces:
+    //   1. a render succeeds immediately after start() (before the pool completes),
+    //   2. the background boot eventually completes the pool and steady-state dispatch spreads
+    //      across both sandboxes again,
+    //   3. the background-booted slot got its boot-time warm render (the __warmup-slot-1 PNG).
+    val outputDir = Files.createTempDirectory("pool-background-boot").toFile()
+    System.setProperty(RenderEngine.OUTPUT_DIR_PROP, outputDir.absolutePath)
+    System.setProperty("roborazzi.test.record", "true")
+    System.setProperty(RobolectricHost.BACKGROUND_BOOT_PROP, "true")
+    val host = RobolectricHost(sandboxCount = 2)
+    try {
+      host.start()
+      // Must not block on slot 1: a stub render right after start() succeeds on the ready prefix.
+      val first = host.submit(RenderRequest.Render(payload = "render-1"))
+      assertNotNull("render immediately after start() should succeed", first)
+
+      // Background boot completes the pool (generous bound — a sandbox boot is ~10s warm-cache).
+      val poolDeadline = System.currentTimeMillis() + 180_000
+      while (host.readySlotCountForTest() < 2 && System.currentTimeMillis() < poolDeadline) {
+        Thread.sleep(200)
+      }
+      assertEquals("background boot should complete the pool", 2, host.readySlotCountForTest())
+
+      // The late slot's boot-time warm render lands (it runs right after the slot turns ready).
+      val warmPng = File(outputDir, "__warmup-slot-1.png")
+      val warmDeadline =
+        System.currentTimeMillis() + RobolectricHost.WARM_RENDER_TIMEOUT_MS + 10_000
+      while (!warmPng.exists() && System.currentTimeMillis() < warmDeadline) {
+        Thread.sleep(200)
+      }
+      assertTrue("expected boot-time warm render PNG at $warmPng", warmPng.exists())
+
+      // Steady state: affinity dispatch spreads across both sandboxes, exactly like the
+      // non-background pool.
+      val results =
+        (0 until 16).map { i ->
+          host.submit(RenderRequest.Render(payload = "previewId=com.example.preview.Bg$i"))
+        }
+      assertEquals(
+        "steady-state dispatch should reach both sandboxes",
+        2,
+        results.map { it.classLoaderHashCode }.toSet().size,
+      )
+    } finally {
+      System.clearProperty(RobolectricHost.BACKGROUND_BOOT_PROP)
+      host.shutdown()
+      outputDir.deleteRecursively()
+    }
+  }
+
+  @Test
   fun rejectsLegacyHolderPlusFactory() {
     // The two constructor paths are mutually exclusive: use either the legacy holder or the
     // per-slot factory, not both.

--- a/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/PerfettoTraceDataProduct.kt
+++ b/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/PerfettoTraceDataProduct.kt
@@ -23,6 +23,28 @@ object PerfettoTraceDataProducer {
 
   fun enabled(): Boolean = System.getProperty(ENABLED_PROP) == "true"
 
+  /**
+   * Optional platform-tracing mirror for [Recorder.section] spans. When set, every named section
+   * additionally opens/closes a span on this backend — the Android engine installs an
+   * `androidx.tracing.Trace` implementation (see `AndroidxTraceSections` in `:daemon:android`) so
+   * the same phases the JSON recorder times (`compose:setContent`, `render:captureRoboImage`, …)
+   * show up in atrace-level captures (Robolectric `ShadowTrace` / Perfetto / Compose
+   * runtime-tracing timelines) alongside the framework's own sections. Null (the default) keeps the
+   * recorder pure-JVM with zero platform coupling — desktop stays null.
+   *
+   * Process-global rather than per-recorder because platform trace sections are process-global too;
+   * the backend is installed once per sandbox classloader. Backend failures must never fail a
+   * render, so both calls are guarded at the call site.
+   */
+  @Volatile var sectionBackend: TraceSectionBackend? = null
+
+  /** Begin/end pair for one [Recorder.section] span on a platform tracer. See [sectionBackend]. */
+  interface TraceSectionBackend {
+    fun begin(name: String)
+
+    fun end()
+  }
+
   fun recorder(previewId: String, backend: String, enabled: Boolean = enabled()): Recorder =
     Recorder(previewId = previewId, backend = backend, enabled = enabled)
 
@@ -47,12 +69,29 @@ object PerfettoTraceDataProducer {
     private val events = mutableListOf<TraceEvent>()
 
     fun <T> section(name: String, category: String = "compose-preview", block: () -> T): T {
-      if (!enabled) return block()
-      val startNs = System.nanoTime()
+      // Mirror the span onto the platform tracer when one is installed (see [sectionBackend]).
+      // Independent of [enabled] — the JSON recorder and an atrace capture are separate opt-ins —
+      // and guarded so a tracer failure can never fail the render it's observing.
+      val platform = sectionBackend
+      if (platform != null) {
+        try {
+          platform.begin(name)
+        } catch (_: Throwable) {}
+      }
       try {
-        return block()
+        if (!enabled) return block()
+        val startNs = System.nanoTime()
+        try {
+          return block()
+        } finally {
+          record(name = name, category = category, startNs = startNs, endNs = System.nanoTime())
+        }
       } finally {
-        record(name = name, category = category, startNs = startNs, endNs = System.nanoTime())
+        if (platform != null) {
+          try {
+            platform.end()
+          } catch (_: Throwable) {}
+        }
       }
     }
 

--- a/deploy/image/Dockerfile
+++ b/deploy/image/Dockerfile
@@ -128,6 +128,11 @@ RUN set -eu; \
 # so it's an ARG: bump it when the bundled robolectric or ANDROID_SDK_PLATFORM changes
 # (it's the `android-all-instrumented-<ver>` dir that appears under ~/.m2 after a first
 # render). Best-effort — the daemon still fetches at runtime if this is stale/missing.
+# Verified against Robolectric 4.17-beta-2 (the version the 0.17.12+ daemon sidecar bundles):
+# `DefaultSdkProvider` still maps SDK 35 → android-all 15 / build 13954326 with
+# PREINSTRUMENTED_VERSION = 7, so this coordinate is a cache HIT and no runtime re-download
+# happens on a cold boot. Re-verify (jar constant `PREINSTRUMENTED_VERSION` + the SDK 35 row in
+# `DefaultSdkProvider`) whenever `robolectric` bumps in gradle/libs.versions.toml.
 ARG ANDROID_ALL_VERSION=15-robolectric-13954326-i7
 # Download to a temp path and move on success. A partial jar left at the real
 # `jarPath()` would be worse than no prefetch: Robolectric 4.16.1's MavenArtifactFetcher
@@ -183,13 +188,21 @@ COPY --from=android-daemon /opt/android-sdk /opt/android-sdk
 # slots) to cut that footprint ~40%. RobolectricHost also now retries a transient per-sandbox boot
 # failure, so the two changes together keep the Wear live lane up instead of collapsing it to the
 # baked-PNG snapshot. Desktop (CMP) daemons ignore this knob.
+#
+# backgroundSandboxBoot — RobolectricHost's fast cold path: `initialize` returns once ONE sandbox
+# is ready (~12 s warm-cache) instead of all `sandboxCount` (~35 s at 3), the remaining sandboxes
+# boot on a background thread with a boot-time warm render each, and dispatch routes across the
+# ready slots meanwhile. Serve fronts the daemon with baked PNGs while it warms, so nothing here
+# needs the strict all-ready contract. `ServeBundleDaemon` already defaults bundle-spawned Android
+# daemons in; carrying it in JAVA_TOOL_OPTIONS extends the same behaviour to the Gradle
+# source-build catalog path (its daemon JVMs inherit this env). Desktop daemons ignore the knob.
 ENV PATH="/opt/compose-preview/bin:${PATH}" \
     SERVE_IDLE_EXIT=0 \
     SERVE_TIMEOUT=1800 \
     COMPOSE_PREVIEW_INIT_USE_MAVEN_LOCAL=1 \
     ANDROID_HOME=/opt/android-sdk \
     ANDROID_SDK_ROOT=/opt/android-sdk \
-    JAVA_TOOL_OPTIONS="-XX:MaxRAMPercentage=70 -Dcomposeai.cli.libDaemonAndroidDir=/opt/lib-daemon-android -Dcomposeai.serve.warmInBackground=true -Dcomposeai.serve.renderTimeoutSeconds=900 -Dcomposeai.serve.frameRenderTimeoutSeconds=120 -Dcomposeai.daemon.sandboxCount=3 -Dcomposeai.daemon.sandboxBootTimeoutMs=1800000"
+    JAVA_TOOL_OPTIONS="-XX:MaxRAMPercentage=70 -Dcomposeai.cli.libDaemonAndroidDir=/opt/lib-daemon-android -Dcomposeai.serve.warmInBackground=true -Dcomposeai.serve.renderTimeoutSeconds=900 -Dcomposeai.serve.frameRenderTimeoutSeconds=120 -Dcomposeai.daemon.sandboxCount=3 -Dcomposeai.daemon.sandboxBootTimeoutMs=1800000 -Dcomposeai.daemon.backgroundSandboxBoot=true"
 
 WORKDIR /project
 # Carry the project + warmed Gradle cache + module build outputs so the first

--- a/docs/daemon/SANDBOX-POOL.md
+++ b/docs/daemon/SANDBOX-POOL.md
@@ -181,6 +181,56 @@ until that lands. Per-slot recycle
 is the other main remaining item — heap-driven recycle could restart
 one sandbox instead of the whole daemon JVM.
 
+## Background pool boot (cold-start fast path)
+
+`-Dcomposeai.daemon.backgroundSandboxBoot=true` (default **off**) changes
+`RobolectricHost.start()`'s contract for a pool: it blocks only until
+**slot 0** is registered, then boots slots 1..N-1 sequentially on a
+background daemon thread. Sandbox boot is the dominant cold-start cost
+(~11.6 s measured per sandbox on a warm `android-all` cache), so a
+3-sandbox pool otherwise holds `initialize` — and therefore serve's first
+live render — for ~35 s of capacity nothing needs yet.
+
+Semantics under background boot:
+
+- **Dispatch routes across the ready prefix.** `chooseSlotIndex` mods by
+  the ready-slot count, not `sandboxCount`, so a render never queues on a
+  still-bootstrapping sandbox. Affinity re-keys as slots come up (mod 1 →
+  mod 2 → …) — a cache-warmth cost only; once the pool completes,
+  dispatch is bit-identical with the eager path.
+- **Interactive waits for slot 1.** `acquireInteractiveSession` awaits
+  the interactive slot's readiness (bounded by the existing 30 s start
+  timeout) and throws the usual clean `Unsupported` if it isn't up yet —
+  callers already handle that with the v1 fallback.
+- **A permanent background slot failure caps the pool** at the slots
+  already booted (loudly logged) instead of aborting the daemon — the
+  eager path's whole-host abort only applies to slot 0. Boot-retry
+  behaviour per slot is unchanged.
+- **Boot-time warm render.** Each background-booted slot renders the
+  daemon-shipped `DaemonWarmupPreview` once (disable with
+  `-Dcomposeai.daemon.warmRenderOnBoot=false`), paying first-composition
+  + `HardwareRenderer` + font-stack + PNG-encode init off the request
+  path. Slot 0 is left to serve's own `prewarm()` throwaway render.
+
+`ServeBundleDaemon` opts serve-spawned Android daemons in by default
+(serve fronts the daemon with baked PNGs while it warms, so nothing
+needs the strict all-ready `initialize`); the Gradle-plugin / VS Code
+launch keeps the eager contract. The deploy image also carries the flag
+in `JAVA_TOOL_OPTIONS` for the source-build catalog path.
+
+## atrace sections (`androidx.tracing`)
+
+`-Dcomposeai.daemon.atrace=true` (default **off**) installs
+`AndroidxTraceSections` inside each sandbox: every render-phase span the
+daemon's chrome-trace recorder already times (`compose:setContent`,
+`render:captureRoboImage`, `dataArtifact:*`, …) plus a whole-render
+`composeai:render:<previewId>` parent span is mirrored onto
+`android.os.Trace` via `androidx.tracing`, lining the daemon's phases up
+with the framework's and Compose's own sections in an atrace-level
+capture. Opt-in because Robolectric's `ShadowTrace` accumulates section
+history in static state with no test-lifecycle resets in a long-lived
+daemon.
+
 ## What this does NOT solve
 
 - **Cross-module sharing.** Different Compose / Kotlin / AGP versions

--- a/docs/daemon/SANDBOX-POOL.md
+++ b/docs/daemon/SANDBOX-POOL.md
@@ -210,7 +210,9 @@ Semantics under background boot:
   daemon-shipped `DaemonWarmupPreview` once (disable with
   `-Dcomposeai.daemon.warmRenderOnBoot=false`), paying first-composition
   + `HardwareRenderer` + font-stack + PNG-encode init off the request
-  path. Slot 0 is left to serve's own `prewarm()` throwaway render.
+  path. The slot is published for dispatch only **after** its warm render
+  completes, so a live render can never queue behind the cold warm-up.
+  Slot 0 is left to serve's own `prewarm()` throwaway render.
 
 `ServeBundleDaemon` opts serve-spawned Android daemons in by default
 (serve fronts the daemon with baked PNGs while it warms, so nothing

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,10 @@ ktfmt = "0.26.0"
 tapmoc = "0.4.2"
 robolectric = "4.17-beta-2"
 roborazzi = "1.68.0"
+# androidx.tracing — atrace-level sections for the Android daemon's render phases (see
+# `AndroidxTraceSections` in :daemon:android). Version-pinned (not BOM-managed) because the daemon
+# ships it in the standalone lib-daemon-android sidecar where no BOM applies.
+androidx-tracing = "1.3.0"
 classgraph = "4.8.184"
 # Stable BOM line — what samples use and what `composePreviewRender` /
 # `Compare previews` is exercised against. Renovate updates this freely;
@@ -247,6 +251,7 @@ compose-material3-catalog = { module = "androidx.compose.material3:material3", v
 compose-foundation = { module = "androidx.compose.foundation:foundation" }
 compose-runtime = { module = "androidx.compose.runtime:runtime" }
 compose-runtime-tracing = { module = "androidx.compose.runtime:runtime-tracing" }
+androidx-tracing = { module = "androidx.tracing:tracing", version.ref = "androidx-tracing" }
 jetbrains-compose-foundation = { module = "org.jetbrains.compose.foundation:foundation", version.ref = "compose-multiplatform" }
 jetbrains-compose-runtime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "compose-multiplatform" }
 jetbrains-compose-ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "compose-multiplatform" }


### PR DESCRIPTION
## Summary

Cuts the Android/Robolectric catalog daemon's cold time-to-first-render on `compose-preview serve` — the amplifier behind the server-wide `503 render queue saturated` now that three heavy Android catalogs render live. Sandbox boot is the dominant cold cost (~11.6 s per sandbox measured on a warm `android-all` cache), and a pooled daemon paid it N× before `initialize` returned.

- **Background pool boot** (`composeai.daemon.backgroundSandboxBoot`, default off): `RobolectricHost.start()` blocks only until sandbox 0 is ready (~12 s instead of ~35 s at prod's `sandboxCount=3`), boots slots 1..N-1 on a background thread, and dispatches across the ready slot prefix meanwhile. Interactive acquire awaits slot 1 (clean `Unsupported` → v1 fallback if it isn't up yet); a *permanent* background slot failure caps the pool loudly instead of aborting the daemon. `initialize` therefore returns as soon as one sandbox can render, so serve's `prewarm()` throwaway render fires N× earlier.
- **Boot-time warm render** per background-booted slot (daemon-shipped `DaemonWarmupPreview`; `composeai.daemon.warmRenderOnBoot=false` to disable) — pays first-composition + `HardwareRenderer` + font-stack + PNG-encode init off the request path, so the slot's first affinity-routed real render is a warm frame.
- **Serve opt-in by default**: `ServeBundleDaemon` sets `backgroundSandboxBoot=true` for serve-spawned Android daemons (an explicit `-D` on the serve JVM wins); the deploy image carries the flag in `JAVA_TOOL_OPTIONS` for the Gradle source-build catalog path. The Gradle-plugin / VS Code launch keeps the strict all-sandboxes-ready contract.
- **androidx.tracing sections** (`composeai.daemon.atrace=true`, default off): a `TraceSectionBackend` hook on the existing per-phase chrome-trace recorder mirrors every render phase (`compose:setContent`, `render:captureRoboImage`, `dataArtifact:*`, …) plus a whole-render `composeai:render:&lt;previewId&gt;` parent span onto `android.os.Trace`, lining daemon phases up with framework/Compose sections in atrace-level captures. Opt-in because Robolectric's `ShadowTrace` accumulates static section history with no test-lifecycle resets in a long-lived daemon.
- **Hypothesis #2 from the handover killed**: `deploy/image/Dockerfile`'s `ANDROID_ALL_VERSION=15-robolectric-13954326-i7` is verified correct for the bundled Robolectric 4.17-beta-2 (checked `DefaultSdkProvider`'s SDK-35 row + `PREINSTRUMENTED_VERSION = 7` in the published jar) — the baked jar is a cache hit, no 150 MB runtime re-download on cold boot. Documented at the ARG with a re-verify note for future Robolectric bumps.

Docs: `docs/daemon/SANDBOX-POOL.md` gains sections on both new knobs.

## Test plan

- `./gradlew :data:render:core:compileKotlin :daemon:android:compileDebugKotlin :cli:compileKotlin` — green.
- `./gradlew ktfmtCheckAll` — green.
- New `RobolectricHostPoolTest.backgroundBootServesRendersBeforePoolCompletesAndWarmsTheLateSlot`: boots a 2-sandbox pool with the flag on, asserts a render succeeds immediately after `start()`, the pool completes in the background, the late slot's `__warmup-slot-1.png` lands, and steady-state dispatch spreads across both sandboxes.
- `ServeBundleDaemonTest` android descriptor test now asserts the `backgroundSandboxBoot=true` sysprop.
- Existing pool tests (`RobolectricHostPoolTest`, interactive/recording session tests) run with the flag off and keep the pre-change eager-boot contract; `chooseSlotIndexForTest` probes steady-state dispatch explicitly so their slot-affinity assertions are unchanged.

Non-visual change (daemon boot plumbing, tracing, deploy knobs) — no rendered-output diff; the CI visual-diff bot should report no changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_012HRLHzhApM2N4hrgNarW3k)_