### PR TITLE
feat(remotecompose): pack declared knobs into the preview bundle sidecar

### DIFF
--- a/data/remotecompose/connector/src/main/kotlin/ee/schimke/composeai/daemon/RemoteComposeController.kt
+++ b/data/remotecompose/connector/src/main/kotlin/ee/schimke/composeai/daemon/RemoteComposeController.kt
@@ -7,6 +7,7 @@ import ee.schimke.composeai.daemon.protocol.RemoteComposeOverride
 import ee.schimke.composeai.daemon.protocol.RemoteComposeProfile
 import ee.schimke.composeai.daemon.protocol.RemoteHostAction
 import ee.schimke.composeai.daemon.protocol.RemoteNamedValue
+import ee.schimke.composeai.data.remotecompose.RemoteComposeDeclarationsPayload
 import ee.schimke.composeai.data.remotecompose.RemoteComposeKnobDeclaration
 import ee.schimke.composeai.data.remotecompose.RemoteComposePayload
 import java.util.concurrent.CopyOnWriteArrayList
@@ -130,6 +131,24 @@ object RemoteComposeController {
 
   /** The knobs declared so far this render, in declaration order. */
   fun declarations(): List<RemoteComposeKnobDeclaration> = declarationsState.value.values.toList()
+
+  /**
+   * The declared knobs serialised as a [RemoteComposeDeclarationsPayload] JSON string, or `null`
+   * when nothing was declared. Called **reflectively** by the standalone render step
+   * (`RobolectricRenderTest.writeRemoteComposeSidecar`) to emit the
+   * `renders/<stem>.remotecompose.json` bundle sidecar — reflection keeps the renderer free of a
+   * hard dependency on this alpha-gated connector, exactly like the bridge readers. Returning a
+   * ready JSON string (not the typed list) means the renderer never needs the
+   * `RemoteComposeKnobDeclaration` type on its classpath.
+   */
+  fun declarationsJson(): String? {
+    val decls = declarations()
+    if (decls.isEmpty()) return null
+    return json.encodeToString(
+      RemoteComposeDeclarationsPayload.serializer(),
+      RemoteComposeDeclarationsPayload(decls),
+    )
+  }
 
   /**
    * Drop the recorded declarations at the start of a render pass, keeping named values / profile /

--- a/data/remotecompose/connector/src/test/kotlin/ee/schimke/composeai/daemon/RemoteComposeDataProductTest.kt
+++ b/data/remotecompose/connector/src/test/kotlin/ee/schimke/composeai/daemon/RemoteComposeDataProductTest.kt
@@ -6,6 +6,7 @@ import ee.schimke.composeai.daemon.protocol.RemoteComposeOverride
 import ee.schimke.composeai.daemon.protocol.RemoteComposeProfile
 import ee.schimke.composeai.daemon.protocol.RemoteHostAction
 import ee.schimke.composeai.daemon.protocol.RemoteNamedValue
+import ee.schimke.composeai.data.remotecompose.RemoteComposeDeclarationsPayload
 import ee.schimke.composeai.data.remotecompose.RemoteComposeKnobDeclaration
 import ee.schimke.composeai.data.remotecompose.RemoteComposePayload
 import ee.schimke.composeai.data.render.PreviewContext
@@ -17,6 +18,7 @@ import ee.schimke.composeai.data.render.extensions.compose.hasAroundComposableHo
 import kotlinx.serialization.json.Json
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -292,6 +294,27 @@ class RemoteComposeDataProductTest {
     assertEquals("label", payload.declarations[0].name)
     assertEquals(RemoteNamedValue.StringValue("Filled"), payload.declarations[0].default)
     assertEquals("shaderColor", payload.declarations[1].name)
+  }
+
+  @Test
+  fun declarationsJson_is_null_when_empty_and_a_payload_when_declared() {
+    val controller = RemoteComposeController
+    assertNull("no declarations → no sidecar", controller.declarationsJson())
+
+    controller.recordDeclaration(
+      RemoteComposeKnobDeclaration("label", RemoteNamedValue.StringValue("Filled"))
+    )
+    controller.recordDeclaration(
+      RemoteComposeKnobDeclaration("stopColor", RemoteNamedValue.ColorValue("#FF7DE2FF"))
+    )
+    val jsonStr = controller.declarationsJson()
+    assertNotNull(jsonStr)
+    val payload =
+      Json.decodeFromString(RemoteComposeDeclarationsPayload.serializer(), jsonStr!!)
+    assertEquals(2, payload.declarations.size)
+    assertEquals("label", payload.declarations[0].name)
+    assertEquals(RemoteNamedValue.StringValue("Filled"), payload.declarations[0].default)
+    assertEquals("stopColor", payload.declarations[1].name)
   }
 
   private fun stubRenderResult(): RenderResult =

--- a/data/remotecompose/core/src/main/kotlin/ee/schimke/composeai/data/remotecompose/RemoteComposeModels.kt
+++ b/data/remotecompose/core/src/main/kotlin/ee/schimke/composeai/data/remotecompose/RemoteComposeModels.kt
@@ -39,6 +39,20 @@ object RemoteComposeProduct {
 data class RemoteComposeKnobDeclaration(val name: String, val default: RemoteNamedValue)
 
 /**
+ * Bundle-sidecar shape for a preview's declared Remote Compose knobs — the payload of the
+ * `renders/<stem>.remotecompose.json` file the render step writes and the bundle packs under
+ * `previews/<id>.remotecompose.json`. The counterpart of the plain-Compose
+ * `ee.schimke.composeai.data.overrides.PreviewOverridesPayload`. A detached reader (the serve host,
+ * a viewer) decodes this to render a control per knob; the render manifest never parses it (it's
+ * copied verbatim). Distinct from [RemoteComposePayload], the live `data/fetch` shape — the sidecar
+ * carries only the editable surface, not the effective values / host actions / profile.
+ */
+@Serializable
+data class RemoteComposeDeclarationsPayload(
+  val declarations: List<RemoteComposeKnobDeclaration> = emptyList()
+)
+
+/**
  * Wire-shape returned by `data/fetch?kind=compose/remotecompose`.
  *
  * Three facets feed the panel's per-card chip:

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
@@ -519,6 +519,14 @@ abstract class BundlePreviewTask : DefaultTask() {
       resolvePreviewOverrides(preview)?.let {
         overrideFiles["$BUNDLE_PREVIEWS_DIR/${preview.id}.$BUNDLE_OVERRIDES_SIDECAR_EXT"] = it
       }
+      // Per-preview Remote Compose knob sidecars (`renders/<stem>.remotecompose.json`), packed
+      // under `previews/<id>.remotecompose.json` — a separate channel from the plain-Compose
+      // `overrides.json` (its edits round-trip through `renderNow.overrides.remoteCompose`). Rides
+      // the same verbatim-copied `overrideFiles` map, so no `buildZip` signature change. Absent for
+      // previews that declared no Remote Compose knobs.
+      resolvePreviewRemoteCompose(preview)?.let {
+        overrideFiles["$BUNDLE_PREVIEWS_DIR/${preview.id}.$BUNDLE_REMOTECOMPOSE_SIDECAR_EXT"] = it
+      }
     }
 
     // Per-sheet catalog-token sidecars (issue #2167): the resolved `@ColorCatalog` /
@@ -714,6 +722,23 @@ abstract class BundlePreviewTask : DefaultTask() {
       preview.captures.firstOrNull()?.renderOutput?.takeIf { it.isNotEmpty() } ?: return null
     val stem = rel.substringAfterLast('/').removeSuffix(".png")
     val f = File(rendersRoot, "$stem.$BUNDLE_OVERRIDES_SIDECAR_EXT")
+    return if (f.isFile && f.length() > 0) f.readBytes() else null
+  }
+
+  /**
+   * Look for the per-preview Remote Compose knob sidecar the render step wrote next to [preview]'s
+   * PNG (`renders/<stem>.remotecompose.json`) — the serialized `RemoteComposeDeclarationsPayload`
+   * of the named-value knobs the preview declared through `LocalRemoteComposeHost`. Resolution
+   * mirrors [resolvePreviewOverrides]; the bytes are copied verbatim (the producer never parses
+   * them). `null` when the preview declared no Remote Compose knobs (every non-Remote-Compose
+   * preview).
+   */
+  private fun resolvePreviewRemoteCompose(preview: PreviewInfo): ByteArray? {
+    val rendersRoot = rendersDir.orNull?.asFile ?: return null
+    val rel =
+      preview.captures.firstOrNull()?.renderOutput?.takeIf { it.isNotEmpty() } ?: return null
+    val stem = rel.substringAfterLast('/').removeSuffix(".png")
+    val f = File(rendersRoot, "$stem.$BUNDLE_REMOTECOMPOSE_SIDECAR_EXT")
     return if (f.isFile && f.length() > 0) f.readBytes() else null
   }
 

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
@@ -737,7 +737,11 @@ abstract class BundlePreviewTask : DefaultTask() {
     val rendersRoot = rendersDir.orNull?.asFile ?: return null
     val rel =
       preview.captures.firstOrNull()?.renderOutput?.takeIf { it.isNotEmpty() } ?: return null
-    val stem = rel.substringAfterLast('/').removeSuffix(".png")
+    // Anchor to the primary capture's leaf, stripping its actual extension the way the writer's
+    // `pngFile.nameWithoutExtension` does — so a non-PNG primary capture (e.g. an animated `.gif`
+    // still) resolves the sidecar the renderer actually wrote, not a `<leaf>.png`-shaped guess.
+    val leaf = rel.substringAfterLast('/')
+    val stem = if ('.' in leaf) leaf.substringBeforeLast('.') else leaf
     val f = File(rendersRoot, "$stem.$BUNDLE_REMOTECOMPOSE_SIDECAR_EXT")
     return if (f.isFile && f.length() > 0) f.readBytes() else null
   }

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewBundleFormat.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewBundleFormat.kt
@@ -632,6 +632,18 @@ const val BUNDLE_SCHEMA_VERSION: Int = 8
 const val BUNDLE_OVERRIDES_SIDECAR_EXT: String = "overrides.json"
 
 /**
+ * File extension of the per-preview Remote Compose knob sidecar the render step writes next to the
+ * PNG (`renders/<stem>.remotecompose.json`) and the bundle packs under
+ * `previews/<id>.remotecompose.json`. Holds the serialized `compose/remotecompose`
+ * `RemoteComposeDeclarationsPayload` — the editable named-value knobs the preview declared through
+ * `LocalRemoteComposeHost` (a separate channel from the plain-Compose `overrides.json`, since a
+ * Remote Compose sticker's edits round-trip via `renderNow.overrides.remoteCompose` / the serve
+ * `rc.<name>=` param, not the generic knob lane). Kept in lockstep with the consumer runtime's
+ * writer (`RobolectricRenderTest.writeRemoteComposeSidecar`).
+ */
+const val BUNDLE_REMOTECOMPOSE_SIDECAR_EXT: String = "remotecompose.json"
+
+/**
  * File extension of the per-sheet catalog-token sidecar the render step writes under
  * `data/catalog-tokens/<id>.catalog.json` (issue #2167) and the bundle packs under
  * `previews/<id>.catalog.json`. Holds the resolved `@ColorCatalog` / `@TypographyCatalog` token

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -619,6 +619,9 @@ abstract class RobolectricRenderTestBase(
       // Write the editable knobs the preview declared via `previewOverride*` as the
       // `renders/<stem>.overrides.json` sidecar `BundlePreviewTask.resolvePreviewOverrides` packs.
       writeOverridesSidecar(pngFile)
+      // Same, for Remote Compose named-value knobs declared through `LocalRemoteComposeHost`:
+      // `renders/<stem>.remotecompose.json`, packed by `BundlePreviewTask.resolvePreviewRemoteCompose`.
+      writeRemoteComposeSidecar(pngFile)
     } catch (e: Throwable) {
       System.err.println(
         "Render failed for ${preview.className}.${preview.functionName}: ${e.message}"
@@ -704,6 +707,44 @@ abstract class RobolectricRenderTestBase(
       )
     } catch (e: Throwable) {
       System.err.println("Failed to write overrides sidecar: ${e.message}")
+    }
+  }
+
+  /**
+   * Write the Remote Compose named-value knobs the preview declared through `LocalRemoteComposeHost`
+   * as the `renders/<stem>.remotecompose.json` sidecar
+   * `BundlePreviewTask.resolvePreviewRemoteCompose` packs. An empty / absent set deletes any stale
+   * sidecar. Read **reflectively** so this renderer never hard-depends on the alpha-gated
+   * `:data-remotecompose-connector` (`RemoteComposeController` is only on the classpath when the
+   * consumer ships the `compose-remote` runtime — a non-Remote-Compose module renders exactly as
+   * before). Best-effort — a write failure must not derail the PNG render path. The
+   * `remotecompose.json` suffix is kept in lockstep with
+   * `PreviewBundleFormat.BUNDLE_REMOTECOMPOSE_SIDECAR_EXT`.
+   */
+  private fun writeRemoteComposeSidecar(pngFile: File) {
+    val dir = pngFile.parentFile ?: return
+    val sidecar = File(dir, "${pngFile.nameWithoutExtension}.remotecompose.json")
+    val json =
+      try {
+        val cls = Class.forName("ee.schimke.composeai.daemon.RemoteComposeController")
+        val instance = cls.getField("INSTANCE").get(null)
+        cls.getMethod("declarationsJson").invoke(instance) as String?
+      } catch (_: ClassNotFoundException) {
+        // The consumer doesn't ship the Remote Compose runtime — nothing to write.
+        null
+      } catch (_: ReflectiveOperationException) {
+        null
+      }
+    try {
+      if (json == null) {
+        if (sidecar.isFile && !sidecar.delete()) {
+          System.err.println("Failed to delete stale remotecompose sidecar: ${sidecar.absolutePath}")
+        }
+        return
+      }
+      sidecar.writeText(json)
+    } catch (e: Throwable) {
+      System.err.println("Failed to write remotecompose sidecar: ${e.message}")
     }
   }
 

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -595,6 +595,10 @@ abstract class RobolectricRenderTestBase(
     // Drop any named-override knobs a prior preview declared so this preview's `previewOverride*`
     // lookups accumulate a clean set (drained into the overrides sidecar below).
     ee.schimke.composeai.overrides.PreviewOverrideController.clearDeclarations()
+    // Same for the Remote Compose knob declarations (reflectively — the alpha-gated connector may be
+    // absent), so preview B doesn't serialize the Remote Compose knobs preview A declared in the same
+    // JVM into its `renders/<stem>.remotecompose.json` sidecar.
+    clearRemoteComposeDeclarations()
     // Seed any `@OverrideVariant` values onto the controller so this synthetic variant preview's
     // `previewOverride*` reads resolve to the flipped knob(s). Replaces the whole seed map, so an
     // ordinary preview (null overrides → empty map) clears the prior variant's seeds — no leakage
@@ -721,6 +725,24 @@ abstract class RobolectricRenderTestBase(
    * `remotecompose.json` suffix is kept in lockstep with
    * `PreviewBundleFormat.BUNDLE_REMOTECOMPOSE_SIDECAR_EXT`.
    */
+  /**
+   * Reflectively drop the process-static Remote Compose declarations before a render, mirroring the
+   * `PreviewOverrideController.clearDeclarations()` call in the render loop. Reflective so this
+   * renderer keeps no hard dependency on the alpha-gated `:data-remotecompose-connector` — a no-op
+   * when the connector isn't on the classpath.
+   */
+  private fun clearRemoteComposeDeclarations() {
+    try {
+      val cls = Class.forName("ee.schimke.composeai.daemon.RemoteComposeController")
+      val instance = cls.getField("INSTANCE").get(null)
+      cls.getMethod("clearDeclarations").invoke(instance)
+    } catch (_: ClassNotFoundException) {
+      // No Remote Compose runtime on the classpath — nothing to clear.
+    } catch (_: ReflectiveOperationException) {
+      // Best-effort: a reflective miss must not derail the render path.
+    }
+  }
+
   private fun writeRemoteComposeSidecar(pngFile: File) {
     val dir = pngFile.parentFile ?: return
     val sidecar = File(dir, "${pngFile.nameWithoutExtension}.remotecompose.json")


### PR DESCRIPTION
## Summary

**PR 3 of the "auto-render Remote Compose knobs" series** (builds on #2677 + #2681, both merged). Persists a preview's declared Remote Compose named-value knobs into the packed bundle so a detached reader — the serve host, a viewer — can present a control per knob without re-deriving them.

Mirrors the plain-Compose `previews/<id>.overrides.json` mechanism, on a **separate channel**: a Remote Compose knob's edits round-trip through `renderNow.overrides.remoteCompose` / the serve `rc.<name>=` param (landed in #2674), not the generic `knob.` lane.

## What changed

- **`:data-remotecompose-core`** — `RemoteComposeDeclarationsPayload(declarations)`, the sidecar shape (counterpart of `PreviewOverridesPayload`).
- **`:data-remotecompose-connector`** — `RemoteComposeController.declarationsJson()` returns that payload as JSON (or `null` when nothing was declared), read reflectively by the renderer so the ready string crosses without the renderer needing the `RemoteComposeKnobDeclaration` type.
- **`:renderer-android`** — `RobolectricRenderTest.writeRemoteComposeSidecar` drains it to `renders/<stem>.remotecompose.json`, **reflectively** (`Class.forName("…RemoteComposeController")`), so the renderer keeps **no** hard dependency on the alpha-gated `:data-remotecompose-connector` — a non-Remote-Compose module renders exactly as before, and an empty/absent set deletes any stale sidecar.
- **`:gradle-plugin`** — `BUNDLE_REMOTECOMPOSE_SIDECAR_EXT = "remotecompose.json"` + `resolvePreviewRemoteCompose`; the sidecar is packed under `previews/<id>.remotecompose.json` via the existing verbatim `overrideFiles` map, so **no `buildZip` signature change**.

## Not in this PR (follow-ups)

- **Serve reads the sidecar** to advertise knobs (`ServeBundleDaemon`), and the **VS Code / serve viewer controls** — next PR.
- **Migrating the catalog stickers** (`NamedLabelRemoteButton`, `ShaderGradientSticker`) to declare their knobs through `LocalRemoteComposeHost` so the sidecar is non-empty for `remote-m3` — also next PR (they currently use upstream `rememberNamedRemote*`, which the connector can't observe).

## Test plan

- [x] `./gradlew :data-remotecompose-connector:testDebugUnitTest` — green. New: `declarationsJson()` returns `null` when empty and decodes to the payload (name + typed default, order preserved) when declared.
- [x] `./gradlew :gradle-plugin:compileKotlin :renderer-android:compileDebugKotlin` — green; ktfmt clean across all four modules.
- The render→sidecar path is alpha-gated (needs the `compose-remote` runtime), verified by analogy to the `writeOverridesSidecar` sibling; the packing logic (`resolvePreviewRemoteCompose` → `previews/<id>.remotecompose.json`) is exercised once the catalog declares knobs (next PR) and by CI's Android bundle path.

---
_Generated by [Claude Code](https://claude.ai/code/session_011K7sgCfdsbhN7fwMb3WhSS)_