### PR TITLE
fix(serve): complete the render wait on renderFailed instead of sleeping out the budget

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
@@ -29,6 +29,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import okio.FileSystem
 import okio.Path.Companion.toPath
@@ -309,6 +310,12 @@ internal constructor(
   private val pendingPreviewId = AtomicReference<String?>(null)
   private val pendingPngPath = AtomicReference<String?>(null)
 
+  // Set (instead of [pendingPngPath]) when the in-flight render's terminal event is
+  // `renderFailed` — the render body threw, e.g. a preview whose composition NPEs. Carrying the
+  // failure through the same latch turns "broken preview" into an immediate
+  // [RenderOutcome.Failed] instead of a full render-budget sleep under [renderLock].
+  private val pendingFailure = AtomicReference<String?>(null)
+
   // Count of timed-out renders per preview id whose `renderFinished` is still outstanding. A render
   // that timed out releases the lock, but the daemon still emits that render's `renderFinished`
   // later; since the notification carries only the preview id (no per-render correlation id), a
@@ -343,17 +350,34 @@ internal constructor(
 
   private val closed = AtomicBoolean(false)
   private val notificationHandle: AutoCloseable = session.onNotification { method, params ->
-    if (method != "renderFinished" || params == null) return@onNotification
+    if (params == null) return@onNotification
+    val isFinished = method == "renderFinished"
+    val isFailed = method == "renderFailed"
+    if (!isFinished && !isFailed) return@onNotification
     val id = params["id"]?.jsonPrimitive?.contentOrNull ?: return@onNotification
     // Drain the late event of a previously timed-out render (FIFO: it arrives before the current
     // render's own event) so it can't complete a fresh same-id render's latch with a stale PNG.
+    // Either terminal event drains — the daemon owes exactly one (finished OR failed) per render.
     if ((staleRenders[id] ?: 0) > 0) {
       staleRenders.compute(id) { _, v -> ((v ?: 0) - 1).takeIf { it > 0 } }
       return@onNotification
     }
     if (id != pendingPreviewId.get()) return@onNotification
-    // `unchanged` renders still carry a (re-used) pngPath, so this captures bytes either way.
-    params["pngPath"]?.jsonPrimitive?.contentOrNull?.let { pendingPngPath.set(it) }
+    if (isFinished) {
+      // `unchanged` renders still carry a (re-used) pngPath, so this captures bytes either way.
+      params["pngPath"]?.jsonPrimitive?.contentOrNull?.let { pendingPngPath.set(it) }
+    } else {
+      // `renderFailed` must complete the wait too. Without this the render body's failure (a
+      // preview whose composition throws) left the latch untouched and [render] slept out its
+      // ENTIRE cold budget — 900s on the public server — holding [renderLock] for a render the
+      // daemon had already reported dead seconds in. Profiled on the confetti-mobile bundle: a
+      // broken preview failed in ~4s and the host still burned the full 180s CLI budget per
+      // render of it, which read as "cold Android renders take minutes".
+      pendingFailure.set(
+        params["error"]?.jsonObject?.get("message")?.jsonPrimitive?.contentOrNull
+          ?: "daemon reported renderFailed"
+      )
+    }
     pendingLatch.get()?.countDown()
   }
 
@@ -403,6 +427,7 @@ internal constructor(
         pendingLatch.set(latch)
         pendingPreviewId.set(previewId)
         pendingPngPath.set(null)
+        pendingFailure.set(null)
 
         val ack =
           try {
@@ -446,6 +471,18 @@ internal constructor(
           val reason = "timed out after ${budget}s waiting for render"
           onLog(reason)
           perfStats.recordFailed(perfElapsedMs(), timeout = true)
+          return RenderOutcome.Failed(reason)
+        }
+        // The latch also trips on `renderFailed` — the daemon reported the render body threw.
+        // Fail immediately: sleeping out the budget here (the pre-fix behaviour, since only
+        // `renderFinished` completed the latch) held [renderLock] for minutes per broken preview
+        // and is what read as "cold Android renders take minutes" in the serve 503 investigation.
+        // No [staleRenders] entry — the daemon already delivered this render's terminal event —
+        // and [warmedUp] stays as-is: a failed render proves nothing about engine warmth.
+        pendingFailure.get()?.let { failure ->
+          val reason = "render failed: $failure"
+          onLog(reason)
+          perfStats.recordFailed(perfElapsedMs(), timeout = false)
           return RenderOutcome.Failed(reason)
         }
         warmedUp.set(true)

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/FakeRenderSession.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/FakeRenderSession.kt
@@ -164,6 +164,26 @@ internal class FakeRenderSession(
     listeners.forEach { it.onNotification("renderFinished", params) }
   }
 
+  /**
+   * Fire a `renderFailed` notification — the daemon's terminal event when the render body threw
+   * (e.g. a preview whose composition NPEs). Wire shape mirrors the daemon's `RenderFailedParams`
+   * (`{id, error: {kind, message}}`). Public so a [renderHook] can model a broken preview; the host
+   * must fail that render immediately instead of sleeping out its render budget.
+   */
+  fun emitFailed(id: String, message: String) {
+    val params = buildJsonObject {
+      put("id", id)
+      put(
+        "error",
+        buildJsonObject {
+          put("kind", "renderBody")
+          put("message", message)
+        },
+      )
+    }
+    listeners.forEach { it.onNotification("renderFailed", params) }
+  }
+
   override val workspaceRoot: String = renderRoot.absolutePath
   override val modulePath: String = ":sample"
   override val initializeResult: InitializeResult =

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHostTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHostTest.kt
@@ -50,6 +50,41 @@ class ServeRenderHostTest {
   }
 
   @Test
+  fun `renderFailed completes the wait immediately instead of sleeping out the budget`() {
+    // Regression for the serve cold-render investigation: only `renderFinished` completed the
+    // pending latch, so a preview whose render body threw (daemon sends `renderFailed` within
+    // seconds) left the host sleeping out its ENTIRE render budget under renderLock — 180s per
+    // broken-preview render on the CLI, 900s on the public server. Profiled on confetti-mobile:
+    // this single behaviour was the whole "cold Android renders take minutes" symptom.
+    lateinit var session: FakeRenderSession
+    session =
+      FakeRenderSession(
+        newRenderRoot(),
+        renderHook = { _, _ -> session.emitFailed(previewId, "java.lang.NullPointerException") },
+      )
+    host(session).use { h ->
+      val startedMs = System.currentTimeMillis()
+      val outcome = h.render(previewId, PreviewOverrides())
+      val tookMs = System.currentTimeMillis() - startedMs
+      assertTrue(outcome is RenderOutcome.Failed, "expected Failed, got $outcome")
+      assertTrue(
+        outcome.reason.contains("NullPointerException"),
+        "failure reason should carry the daemon's error message, got '${outcome.reason}'",
+      )
+      // The host is built with renderTimeoutSeconds = 30; anything near that means we slept out
+      // the budget rather than completing on the failure event.
+      assertTrue(tookMs < 10_000, "render should fail fast on renderFailed, took ${tookMs}ms")
+      // A failed render proves nothing about warmth: the next render must still get the cold
+      // budget, and a subsequent success must work unaffected.
+      val ok =
+        FakeRenderSession(newRenderRoot()).let { fresh ->
+          host(fresh).use { it2 -> it2.render(previewId, PreviewOverrides()) }
+        }
+      assertTrue(ok is RenderOutcome.Ok)
+    }
+  }
+
+  @Test
   fun `different overrides each render`() {
     val session = FakeRenderSession(newRenderRoot())
     host(session).use { h ->


### PR DESCRIPTION
## Summary

Answers "where is the first-render time going — is it Robolectric processing?" with a profile, and fixes what it found. **It is not Robolectric.**

**The profile** (JFR attached via `jcmd` to the daemon JVM, confetti-mobile bundle, released 0.17.12 sidecar): only 520 execution samples across the ~185 s "first render" — nothing was computing. The periodic thread dumps show every daemon thread parked: the sandbox main thread idle-polling an empty request queue with just **7.9 s of total CPU** (boot + the actual renders), the render-watcher idle on its own queue. The daemon had rendered — and **failed** — the first requested preview (`ScreenshotTest.SessionDetailsPreview`, an app-side NPE in its composition) within seconds and sent `renderFailed`. But `ServeRenderHost`'s notification listener only completed the pending render latch on **`renderFinished`**, so the host slept out its ENTIRE cold render budget under `renderLock` — 180 s on the CLI path, **900 s on the public server** — for a render the daemon had already reported dead. The engine's genuine first-render cost is ~3–8 s (`tookMs`); the "minutes" were this bug, and on serve it also pins the per-daemon render lock (and interacts with the HTTP-slot saturation in the 503 investigation) for 15 minutes per broken-preview render.

**The fix**: treat `renderFailed` as the terminal event it is —
- the listener now completes the latch on either `renderFinished` or `renderFailed` (stale-event draining covers both, since the daemon owes exactly one terminal event per render);
- `render()` returns `RenderOutcome.Failed("render failed: &lt;daemon message&gt;")` immediately; no `staleRenders` entry (the event already arrived), `warmedUp` untouched (a failure proves nothing about warmth), recorded as a non-timeout failure in the `/status` render stats.

**Measured end-to-end** (same bundle, fixed CLI + unchanged released daemon):

| | before | after |
|---|---|---|
| total wall, 37 previews (1 broken) | 225 s | **47.6 s** |
| first `renderFinished` | +189.6 s | **+12.9 s** |
| broken preview | `timed out after 180s` | `render failed: java.lang.NullPointerException` in seconds |

## Test plan

- New `ServeRenderHostTest.renderFailed completes the wait immediately…` — `FakeRenderSession` gains `emitFailed` (daemon `RenderFailedParams` wire shape); asserts fail-fast (`&lt;&lt;` budget), the daemon's message in the failure reason, and that success paths are unaffected. Full `ServeRenderHostTest` suite green.
- `:cli:compileKotlin` + ktfmt green.
- End-to-end repro numbers above (fixed `:cli:installDist` against the released android daemon sidecar).

Non-visual change — text-only per the repo's visual-evidence rule.

---
_Generated by [Claude Code](https://claude.ai/code/session_012HRLHzhApM2N4hrgNarW3k)_