### PR TITLE
feat(remotecompose): declare catalog knobs so the bundle carries them

### DIFF
--- a/data/remotecompose/connector/src/main/kotlin/ee/schimke/composeai/daemon/RemoteComposeController.kt
+++ b/data/remotecompose/connector/src/main/kotlin/ee/schimke/composeai/daemon/RemoteComposeController.kt
@@ -105,6 +105,9 @@ object RemoteComposeController {
       declarationsState.value = next
       listeners.toList().forEach { it() }
     }
+    // When a document capture is being collected ([collectingDeclarations]), also stash the
+    // declaration so the caller can re-record it on later renders (see `RemoteOverridablePreview`).
+    declarationCollector?.let { sink -> if (declaration !in sink) sink.add(declaration) }
     // Cross-classloader forward for the Android sandbox. Serialise only when the bridge is present
     // (a plain app / desktop daemon skips this entirely). Always forwarded — even when the in-CL
     // value is unchanged — so a host reset the sandbox didn't observe is repopulated.
@@ -113,6 +116,33 @@ object RemoteComposeController {
       declaration.name,
       json.encodeToString(RemoteComposeKnobDeclaration.serializer(), declaration),
     )
+  }
+
+  /** Active collection sink for [collectingDeclarations]; null when no capture is being collected. */
+  @Volatile private var declarationCollector: MutableList<RemoteComposeKnobDeclaration>? = null
+
+  /**
+   * Run [block] with declaration collection active and return its result paired with every
+   * declaration [recordDeclaration] saw during it (deduped, in first-seen order) — *in addition* to
+   * the normal recording.
+   *
+   * `RemoteOverridablePreview` wraps its memoized `captureSingleRemoteDocument` in this so it can
+   * snapshot the knobs the sticker declares while the document is captured, then re-record them on
+   * every subsequent render. That matters on the daemon path: the memoized capture only records once
+   * (during the outer *composition* phase), but `RemoteComposeOverrideExtension`'s render-start
+   * [clearDeclarations] runs from a `DisposableEffect` (the outer *apply* phase, after the capture),
+   * so without re-recording a `renderNow` / `data/fetch` render would report no knobs. Not
+   * re-entrant (one capture at a time per classloader); a nested call restores the outer sink.
+   */
+  fun <T> collectingDeclarations(block: () -> T): Pair<T, List<RemoteComposeKnobDeclaration>> {
+    val sink = mutableListOf<RemoteComposeKnobDeclaration>()
+    val previous = declarationCollector
+    declarationCollector = sink
+    return try {
+      block() to sink.toList()
+    } finally {
+      declarationCollector = previous
+    }
   }
 
   /**

--- a/data/remotecompose/connector/src/main/kotlin/ee/schimke/composeai/daemon/RemoteOverridablePreview.kt
+++ b/data/remotecompose/connector/src/main/kotlin/ee/schimke/composeai/daemon/RemoteOverridablePreview.kt
@@ -86,29 +86,45 @@ fun RemoteOverridablePreview(
     )
   // Same capture pattern as upstream `RemotePreview` — `runBlocking` inside `remember` so the
   // document materialises once per (profile, content) pair without re-capturing across
-  // recompositions.
-  val remoteDocument =
+  // recompositions. Collect the knobs the content declares during the capture (via the
+  // `rememberOverridable*` wrappers) so they can be re-recorded on every render below.
+  val captured =
     remember(profile, content) {
-      runBlocking {
-        val bytes =
-          captureSingleRemoteDocument(
-              context,
-              displayInfo,
-              RemoteDensity.from(displayInfo),
-              LayoutDirection.Ltr,
-              profile = profile,
-              content = content,
-            )
-            .bytes
-        // Offer the captured RC doc so a bundle can carry + replay it without this composable's
-        // bytecode; the render harness drains it into the `renders/<stem>.rcdoc` sidecar that
-        // `BundlePreviewTask.resolvePreviewIr` packs. No-op outside a daemon/test render (no
-        // current
-        // preview id). Best-effort — never fail the render over IR capture. See IrSidecarChannel.
-        runCatching { IrSidecarChannel.offer(IrSidecarChannel.FORMAT_REMOTECOMPOSE, bytes) }
-        RemoteDocument(bytes)
+      RemoteComposeController.collectingDeclarations {
+        runBlocking {
+          val bytes =
+            captureSingleRemoteDocument(
+                context,
+                displayInfo,
+                RemoteDensity.from(displayInfo),
+                LayoutDirection.Ltr,
+                profile = profile,
+                content = content,
+              )
+              .bytes
+          // Offer the captured RC doc so a bundle can carry + replay it without this composable's
+          // bytecode; the render harness drains it into the `renders/<stem>.rcdoc` sidecar that
+          // `BundlePreviewTask.resolvePreviewIr` packs. No-op outside a daemon/test render (no
+          // current preview id). Best-effort — never fail the render over IR capture. See
+          // IrSidecarChannel.
+          runCatching { IrSidecarChannel.offer(IrSidecarChannel.FORMAT_REMOTECOMPOSE, bytes) }
+          RemoteDocument(bytes)
+        }
       }
     }
+  val remoteDocument = captured.first
+  val declaredKnobs = captured.second
+
+  // Re-record the captured knobs on EVERY render. The memoized capture above records them only once
+  // (during the outer composition phase); on the daemon path `RemoteComposeOverrideExtension`'s
+  // render-start `clearDeclarations()` runs afterwards (from a `DisposableEffect`, the apply phase),
+  // so without this a `renderNow` / `data/fetch` render would surface no knobs. A `SideEffect` lands
+  // in the apply phase after that clear (Compose runs every `RememberObserver` before any
+  // `SideEffect`). Idempotent, so the standalone Gradle path (which clears before rendering) is
+  // unaffected.
+  androidx.compose.runtime.SideEffect {
+    declaredKnobs.forEach { RemoteComposeController.recordDeclaration(it) }
+  }
 
   // Snapshot the seeded overrides at composition time. The map is from `RemoteComposeController`
   // (process-static state), seeded by `RemoteComposeOverrideExtension` from

--- a/data/remotecompose/connector/src/main/kotlin/ee/schimke/composeai/daemon/RemoteOverridableState.kt
+++ b/data/remotecompose/connector/src/main/kotlin/ee/schimke/composeai/daemon/RemoteOverridableState.kt
@@ -1,0 +1,59 @@
+@file:Suppress("RestrictedApiAndroidX")
+
+package ee.schimke.composeai.daemon
+
+import androidx.compose.remote.creation.compose.state.RemoteColor
+import androidx.compose.remote.creation.compose.state.RemoteString
+import androidx.compose.remote.creation.compose.state.rememberNamedRemoteColor
+import androidx.compose.remote.creation.compose.state.rememberNamedRemoteString
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import ee.schimke.composeai.daemon.protocol.RemoteNamedValue
+import ee.schimke.composeai.data.remotecompose.RemoteComposeKnobDeclaration
+
+/**
+ * Declaring drop-in replacements for the upstream `rememberNamedRemote*` family: they behave exactly
+ * like the alpha `androidx.compose.remote.creation.compose.state.rememberNamedRemote*` (bind a
+ * `USER:`-domain named value, seedable via `renderNow.overrides.remoteCompose` / the serve
+ * `rc.<name>=` param), and additionally **record the binding as an editable knob declaration** so a
+ * consumer can present a control for it.
+ *
+ * **Why a declaring wrapper rather than auto-enumeration.** The named value a `rememberNamedRemote*`
+ * call binds is resolved into the captured `RemoteDocument` (its top-level ops are just a header +
+ * the root layout — the value is baked into the tree, not exposed as an enumerable named-variable
+ * op), and the runtime table that *would* list it (`RemoteComposePlayer.getNamedStrings()` etc.)
+ * only populates when the player view actually paints — which the Robolectric bundle-render path
+ * doesn't do. So the author naming the binding here is the only point that reliably knows the
+ * `(name, kind, default)` triple; this is the bootstrap that tells the panel which names exist
+ * before it can seed any of them.
+ *
+ * The declaration is recorded from a `SideEffect` (not during composition) so it lands after
+ * `RemoteComposeOverrideExtension`'s render-start `clearDeclarations`, mirroring the plain-Compose
+ * `previewOverride*` discipline. Outside a daemon/render the record is a harmless no-op write to the
+ * process-static controller.
+ */
+@Composable
+fun rememberOverridableRemoteString(name: String, default: String): RemoteString {
+  SideEffect {
+    RemoteComposeController.recordDeclaration(
+      RemoteComposeKnobDeclaration(name, RemoteNamedValue.StringValue(default))
+    )
+  }
+  return rememberNamedRemoteString(name, default)
+}
+
+/** [rememberOverridableRemoteString] for a color knob; the default is recorded as `#AARRGGBB`. */
+@Composable
+fun rememberOverridableRemoteColor(name: String, default: Color): RemoteColor {
+  SideEffect {
+    RemoteComposeController.recordDeclaration(
+      RemoteComposeKnobDeclaration(name, RemoteNamedValue.ColorValue(default.toArgbHex()))
+    )
+  }
+  return rememberNamedRemoteColor(name, default)
+}
+
+/** `#AARRGGBB`, matching the form `RemoteNamedValue.ColorValue` carries and the connector parses. */
+private fun Color.toArgbHex(): String = "#%08X".format(toArgb())

--- a/samples/design-catalog-remote-m3/src/main/kotlin/com/example/designcatalogremotem3/CatalogPreviews.kt
+++ b/samples/design-catalog-remote-m3/src/main/kotlin/com/example/designcatalogremotem3/CatalogPreviews.kt
@@ -19,8 +19,8 @@ import androidx.compose.remote.creation.compose.shapes.RemoteRoundedCornerShape
 import androidx.compose.remote.creation.compose.state.RemoteColor
 import androidx.compose.remote.creation.compose.state.rb
 import androidx.compose.remote.creation.compose.state.rdp
-import androidx.compose.remote.creation.compose.state.rememberNamedRemoteColor
-import androidx.compose.remote.creation.compose.state.rememberNamedRemoteString
+import ee.schimke.composeai.daemon.rememberOverridableRemoteColor
+import ee.schimke.composeai.daemon.rememberOverridableRemoteString
 import androidx.compose.remote.creation.compose.state.rf
 import androidx.compose.remote.creation.compose.state.rs
 import androidx.compose.runtime.Composable
@@ -167,7 +167,7 @@ fun CustomShapeRemoteButton() = RemoteSticker {
 @CatalogRemoteModes
 @Composable
 fun NamedLabelRemoteButton() = RemoteSticker {
-  val label = rememberNamedRemoteString("label", "Filled")
+  val label = rememberOverridableRemoteString("label", "Filled")
   RemoteButton(
     onClick = testAction,
     modifier = RemoteModifier.buttonSizeModifier(),
@@ -370,7 +370,7 @@ fun ColorSchemeRemote() = RemoteSticker {
 @CatalogRemoteModes
 @Composable
 fun ShaderGradientSticker() = RemoteSticker {
-  val shaderColor = rememberNamedRemoteColor("shaderColor", Color(0xFF7DE2FF))
+  val shaderColor = rememberOverridableRemoteColor("shaderColor", Color(0xFF7DE2FF))
   val brush =
     RemoteBrush.linearGradient(
       listOf(RemoteColor(Color(0xFF101820)), shaderColor, RemoteColor(Color(0xFFFFB86C)))


### PR DESCRIPTION
## Summary

**PR 4a of the "auto-render Remote Compose knobs" series** (builds on #2677 / #2681 / #2686, all merged). Makes the `remote-m3` catalog's named-value stickers actually *declare* their knobs, so the packed bundle carries them for a viewer to present.

### Why a declaring wrapper, not auto-enumeration

I tested auto-enumeration empirically in-session (rendering the catalog through Robolectric and probing the alpha API), and it doesn't work in the bundle-render path:
- the value a `rememberNamedRemote*` call binds is **resolved into** the captured `RemoteDocument` — its top-level ops are just a `Header` + `RootLayoutComponent`, not an enumerable named-variable op;
- `CoreDocument.getNamedVariables(…)` / `getNamedColors()` come back **empty**, and `RemoteComposeState` has no named-value accessors;
- the runtime table that *would* list them (`RemoteComposePlayer.getNamedStrings()` …) throws **NPE** — the player view never paints in the Robolectric capture.

So the author naming the binding is the one point that reliably knows the `(name, kind, default)` triple — and it's the bootstrap the panel needs before it can seed any override.

## What changed

- **`:data-remotecompose-connector`** — `rememberOverridableRemoteString` / `rememberOverridableRemoteColor`: declaring drop-in replacements for the upstream `rememberNamedRemote*`. They record a `RemoteComposeKnobDeclaration` from a `SideEffect` (after the render-start `clearDeclarations`, matching the plain-Compose discipline) and delegate to the upstream call — **byte-for-byte the same binding**, plus the declaration.
- **`:samples:design-catalog-remote-m3`** — switch the two named-value stickers (`NamedLabelRemoteButton`, `ShaderGradientSticker`) to the wrappers.

## Verification (in-session render)

`./gradlew :samples:design-catalog-remote-m3:composePreviewRenderAll` now writes the knob sidecars — and **only** for those two stickers (no leakage across the other ~20):

```json
NamedLabelRemoteButton.remotecompose.json
  {"declarations":[{"name":"label","default":{"kind":"string","value":"Filled"}}]}
ShaderGradientSticker.remotecompose.json
  {"declarations":[{"name":"shaderColor","default":{"kind":"color","argb":"#FF7DE2FF"}}]}
```

PR 3's packing puts these under `previews/<id>.remotecompose.json`. The render **PNGs are unchanged** — the wrapper is a no-op on the binding — so this is non-visual plumbing (no before/after images needed).

## Next in the series

- **PR 4b** — `ServeBundleDaemon` reads `previews/<id>.remotecompose.json` and advertises the knobs on `ServePreview`; the serve / VS Code viewer renders a control per knob (edits round-trip via the `rc.<name>=` param from #2674). *(viewer = visual evidence via preview-harness)*
- **PR 5** — flip `remote-m3` to a live Android bundle in `design-artifacts.yml`.

---
_Generated by [Claude Code](https://claude.ai/code/session_011K7sgCfdsbhN7fwMb3WhSS)_