### PR TITLE
feat(serve): advertise Remote Compose knobs from the bundle sidecar

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -166,6 +166,12 @@ dependencies {
   // knobs `compose-preview serve` reads from a bundle's `previews/<id>.overrides.json` sidecar to
   // present controls. Pure JVM (depends only on `:daemon:core`), not a renderer artifact.
   implementation(project(":data-preview-overrides-core"))
+  // Wire-shape of the `compose/remotecompose` data product (`RemoteComposeKnobDeclaration` /
+  // `RemoteComposeDeclarationsPayload`) — the Remote Compose named-value knobs `serve` reads from a
+  // bundle's `previews/<id>.remotecompose.json` sidecar to advertise editable controls. Pure JVM
+  // (payload schema only; the alpha `androidx.compose.remote.*` deps live in the connector, not
+  // here), so it stays off the renderer/daemon boundary the CLI guards.
+  implementation(project(":data-remotecompose-core"))
   // Public render-session library — the CLI consumes its own published API for daemon-driven
   // commands (`compose-preview a11y` etc.) instead of touching DaemonClient directly. We eat
   // our own dog food: anything the CLI can do, a third-party tooling consumer can do via the

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt
@@ -259,14 +259,14 @@ internal object ServeBundleDaemon {
       return null
     }
 
-    // The author-declared knob sidecars (`previews/<id>.overrides.json`) ride alongside the PNGs in
-    // the bundle. Extract them so [readPreviews] can advertise each preview's editable knobs — the
-    // `compose/overrides` payload the viewer renders as live knob controls (and that
-    // ServeCatalogLiveHost grafts onto the baked browse surface). Best-effort: a bundle that
-    // carried
-    // none simply yields previews with no knobs.
+    // The author-declared knob sidecars ride alongside the PNGs in the bundle — the plain-Compose
+    // `previews/<id>.overrides.json` (`compose/overrides`) and the Remote Compose
+    // `previews/<id>.remotecompose.json` (`compose/remotecompose`) channels. Extract both so
+    // [readPreviews] can advertise each preview's editable knobs, which the viewer renders as live
+    // knob controls (and that ServeCatalogLiveHost grafts onto the baked browse surface).
+    // Best-effort: a bundle that carried none simply yields previews with no knobs.
     val previewsDir = File(destDir, "previews").apply { mkdirs() }
-    extractOverrideSidecars(zipBytes, previewsDir, fileSystem)
+    extractKnobSidecars(zipBytes, previewsDir, fileSystem)
 
     val previews = readPreviews(previewsJson, previewsDir, fileSystem)
     if (previews.isEmpty()) {
@@ -315,7 +315,7 @@ internal object ServeBundleDaemon {
    * `previews/<id>.overrides.json` sidecar (in [previewsDir]) so the daemon-backed session
    * advertises what's editable.
    */
-  private fun readPreviews(
+  internal fun readPreviews(
     previewsJson: File,
     previewsDir: File,
     fileSystem: FileSystem,
@@ -335,6 +335,7 @@ internal object ServeBundleDaemon {
         id = it.id,
         label = it.functionName.ifBlank { it.id },
         overrides = readOverrideSidecar(previewsDir, it.id, fileSystem),
+        remoteComposeKnobs = readRemoteComposeSidecar(previewsDir, it.id, fileSystem),
         supportsFocus = focus,
         supportsGestures = gestures,
       )
@@ -342,15 +343,12 @@ internal object ServeBundleDaemon {
   }
 
   /**
-   * Extract only the `previews/<id>.overrides.json` sidecars from [zipBytes] into [previewsDir]
-   * (zip-slip safe). Mirrors the PNG-side extraction in [ServeBundleStore]; other bundle entries
-   * are handled elsewhere ([extractBundleClassesAndManifest]).
+   * Extract the per-preview knob sidecars (`previews/<id>.overrides.json` and
+   * `previews/<id>.remotecompose.json`) from [zipBytes] into [previewsDir] (zip-slip safe). Mirrors
+   * the PNG-side extraction in [ServeBundleStore]; other bundle entries are handled elsewhere
+   * ([extractBundleClassesAndManifest]).
    */
-  private fun extractOverrideSidecars(
-    zipBytes: ByteArray,
-    previewsDir: File,
-    fileSystem: FileSystem,
-  ) {
+  internal fun extractKnobSidecars(zipBytes: ByteArray, previewsDir: File, fileSystem: FileSystem) {
     val root = previewsDir.canonicalFile.toPath()
     java.util.zip.ZipInputStream(java.io.ByteArrayInputStream(zipBytes)).use { zin ->
       while (true) {
@@ -359,7 +357,7 @@ internal object ServeBundleDaemon {
         if (
           !entry.isDirectory &&
             name.startsWith("previews/") &&
-            name.endsWith(OVERRIDES_SUFFIX) &&
+            (name.endsWith(OVERRIDES_SUFFIX) || name.endsWith(REMOTECOMPOSE_SUFFIX)) &&
             ".." !in name.split("/")
         ) {
           // Strip the leading `previews/` so the file lands directly under previewsDir (keyed by
@@ -397,8 +395,40 @@ internal object ServeBundleDaemon {
     }
   }
 
-  /** Suffix of the per-preview knob sidecar; lockstep with `PreviewBundleFormat`'s. */
+  /**
+   * Read [id]'s extracted `<id>.remotecompose.json` sidecar (the `compose/remotecompose`
+   * declarations payload) into its declared knobs. Absent / unreadable ⇒ no knobs, so a bundle that
+   * carried none (or a non-RC catalog) just advertises an empty list.
+   */
+  private fun readRemoteComposeSidecar(
+    previewsDir: File,
+    id: String,
+    fileSystem: FileSystem,
+  ): List<ee.schimke.composeai.data.remotecompose.RemoteComposeKnobDeclaration> {
+    val sidecar = File(previewsDir, "$id$REMOTECOMPOSE_SUFFIX").path.toPath()
+    if (!fileSystem.exists(sidecar)) return emptyList()
+    return try {
+      val text = fileSystem.read(sidecar) { readUtf8() }
+      overridesJson
+        .decodeFromString(
+          ee.schimke.composeai.data.remotecompose.RemoteComposeDeclarationsPayload.serializer(),
+          text,
+        )
+        .declarations
+    } catch (_: Exception) {
+      emptyList()
+    }
+  }
+
+  /**
+   * Suffix of the per-preview plain-Compose knob sidecar; lockstep with `PreviewBundleFormat`'s.
+   */
   private const val OVERRIDES_SUFFIX = ".overrides.json"
+
+  /**
+   * Suffix of the per-preview Remote Compose knob sidecar; lockstep with `PreviewBundleFormat`'s.
+   */
+  private const val REMOTECOMPOSE_SUFFIX = ".remotecompose.json"
 
   private val json = Json { encodeDefaults = true }
   private val overridesJson = Json { ignoreUnknownKeys = true }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
@@ -105,6 +105,7 @@ class ServeBundleHost(
           id = id,
           label = id,
           overrides = readOverrides(id),
+          remoteComposeKnobs = readRemoteComposeKnobs(id),
           // `state` comes only from a `catalog.json`-backed bundle's `variants.json`
           // (`meta.state`).
           // A plain module bundle has no manifest, so an `@OverrideVariant` synthetic preview
@@ -197,6 +198,29 @@ class ServeBundleHost(
     return try {
       val json = fileSystem.read(sidecar) { readUtf8() }
       OVERRIDES_JSON.decodeFromString(PreviewOverridesPayload.serializer(), json).declarations
+    } catch (e: Exception) {
+      emptyList()
+    }
+  }
+
+  /**
+   * Read the Remote Compose named-value knobs carried for [id] in the bundle's
+   * `previews/<id>.remotecompose.json` sidecar (the `compose/remotecompose` declarations payload).
+   * The RC counterpart of [readOverrides]: absent / unreadable → no knobs. A baked bundle can't
+   * re-render, so the viewer shows these as informational controls until a live daemon backs them.
+   */
+  private fun readRemoteComposeKnobs(
+    id: String
+  ): List<ee.schimke.composeai.data.remotecompose.RemoteComposeKnobDeclaration> {
+    val sidecar = File(previewsDir, "$id$REMOTECOMPOSE_SUFFIX").toOkioPath()
+    if (!fileSystem.exists(sidecar)) return emptyList()
+    return try {
+      val json = fileSystem.read(sidecar) { readUtf8() }
+      OVERRIDES_JSON.decodeFromString(
+          ee.schimke.composeai.data.remotecompose.RemoteComposeDeclarationsPayload.serializer(),
+          json,
+        )
+        .declarations
     } catch (e: Exception) {
       emptyList()
     }
@@ -324,6 +348,7 @@ class ServeBundleHost(
       value.replace(Regex("[^a-zA-Z0-9._-]+"), "-").trim('-').lowercase().ifBlank { "x" }
 
     private const val OVERRIDES_SUFFIX = ".overrides.json"
+    private const val REMOTECOMPOSE_SUFFIX = ".remotecompose.json"
     private const val PREVIEWS_JSON = "previews.json"
     private val OVERRIDES_JSON = Json { ignoreUnknownKeys = true }
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleStore.kt
@@ -18,13 +18,15 @@ import okhttp3.Request
  * a deployed public server useful without it building anything: clients contribute pre-rendered
  * results and get a shareable `?session=<name>` link back.
  *
- * Safety: only `previews/<id>.png` entries are extracted (everything else in the zip is ignored),
- * each written under a per-bundle directory with a zip-slip containment check, and the total
- * extracted size is capped. The URL case ([addFromUrl]) is an **SSRF** surface — a public server
- * fetching arbitrary URLs could be steered at internal metadata/services — so it is gated by
- * [allowedHosts]: only a URL whose host is on that operator-supplied allowlist is fetched, and an
- * empty allowlist refuses every URL (fail closed). [fetch] is injected so it can be stubbed in
- * tests; the host gate runs in [addFromUrl] regardless of which fetcher is wired.
+ * Safety: only the servable `previews/` entries are extracted — the baked `<id>.png` images, the
+ * per-preview knob sidecars (`<id>.overrides.json` / `<id>.remotecompose.json`), and the root
+ * `previews.json` manifest; everything else in the zip is ignored — each written under a per-bundle
+ * directory with a zip-slip containment check, and the total extracted size is capped. The URL case
+ * ([addFromUrl]) is an **SSRF** surface — a public server fetching arbitrary URLs could be steered
+ * at internal metadata/services — so it is gated by [allowedHosts]: only a URL whose host is on
+ * that operator-supplied allowlist is fetched, and an empty allowlist refuses every URL (fail
+ * closed). [fetch] is injected so it can be stubbed in tests; the host gate runs in [addFromUrl]
+ * regardless of which fetcher is wired.
  */
 class ServeBundleStore(
   private val root: File,
@@ -141,7 +143,11 @@ class ServeBundleStore(
     return allowedHosts.any { it.equals(host, ignoreCase = true) }
   }
 
-  /** Extract only `previews/<id>.png` entries into [dir] (zip-slip safe, size-capped). */
+  /**
+   * Extract the servable `previews/` entries (baked `<id>.png`, the `<id>.overrides.json` /
+   * `<id>.remotecompose.json` knob sidecars) plus the root `previews.json` into [dir] (zip-slip
+   * safe, size-capped). Returns the PNG count — only a baked image makes a servable preview.
+   */
   private fun extractPreviews(zipBytes: ByteArray, dir: File): Int {
     val rootPath = dir.canonicalFile.toPath()
     var count = 0
@@ -151,19 +157,21 @@ class ServeBundleStore(
       while (entry != null) {
         val name = entry.name.replace('\\', '/')
         val segments = name.split("/")
-        // Keep the baked PNGs (the servable images) and, since v8, the per-preview override
-        // sidecars
-        // (`previews/<id>.overrides.json`) so a served bundle can present its declared editable
-        // knobs.
+        // Keep the baked PNGs (the servable images) and the per-preview knob sidecars — both the
+        // plain-Compose `previews/<id>.overrides.json` and the Remote Compose
+        // `previews/<id>.remotecompose.json` — so a served upload can present its declared editable
+        // knobs. Dropping the RC sidecar here would silently strip `remoteComposeKnobs` from the
+        // upload path (POST / URL) while the live-bundle / directory paths kept them.
         val underPreviews = name.startsWith("$PREVIEWS_SUBDIR/") && ".." !in segments
         val isPng = underPreviews && name.endsWith(PNG_SUFFIX)
         val isOverrides = underPreviews && name.endsWith(OVERRIDES_SUFFIX)
+        val isRemoteCompose = underPreviews && name.endsWith(REMOTECOMPOSE_SUFFIX)
         // Also keep the root `previews.json` manifest so a served bundle can surface the app's
         // declared @ThemeCatalog themes (the synthetic THEME_CATALOG entries live only here, not in
         // the per-preview sidecars). A top-level file (no path segments), so it's exempt from the
         // `previews/` prefix check but still zip-slip guarded below.
         val isPreviewsJson = name == PREVIEWS_JSON
-        if (!entry.isDirectory && (isPng || isOverrides || isPreviewsJson)) {
+        if (!entry.isDirectory && (isPng || isOverrides || isRemoteCompose || isPreviewsJson)) {
           val target = File(dir, name)
           // Zip-slip guard: the resolved path must stay under the bundle dir.
           if (target.canonicalFile.toPath().startsWith(rootPath)) {
@@ -203,6 +211,7 @@ class ServeBundleStore(
     private const val PREVIEWS_SUBDIR = "previews"
     private const val PNG_SUFFIX = ".png"
     private const val OVERRIDES_SUFFIX = ".overrides.json"
+    private const val REMOTECOMPOSE_SUFFIX = ".remotecompose.json"
     private const val PREVIEWS_JSON = "previews.json"
     private const val DEFAULT_MAX_BYTES = 100L * 1024 * 1024 // 100 MB
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
@@ -332,14 +332,15 @@ class ServeCatalogLiveHost(
   /**
    * Graft the daemon previews' per-preview metadata onto the baked browse surface. The daemon knows
    * its previews by descriptor id (`FilledButton_Dark`) and carries their author-declared knobs
-   * ([ServePreview.overrides], from the bundle sidecars) plus the detected-feature flags
-   * ([ServePreview.supportsFocus] / [supportsGestures], from `@FocusedPreview` /
-   * `@GestureHintPreview` discovery); the baked catalog keys by catalog id
+   * ([ServePreview.overrides] + [ServePreview.remoteComposeKnobs], from the bundle sidecars) plus
+   * the detected-feature flags ([ServePreview.supportsFocus] / [supportsGestures], from
+   * `@FocusedPreview` / `@GestureHintPreview` discovery); the baked catalog keys by catalog id
    * (`button-filled__ideal__default__dark`) and carries neither. For each mapped baked preview,
    * copy its daemon twin's knobs + feature flags across so `/api/previews` + the viewer advertise
-   * the editable knobs AND the detected-feature controls (a mapped `@FocusedPreview` component's
-   * Keyboard focus toggle re-renders on the daemon). Unmapped previews (Android-only variants with
-   * no daemon lane) are returned unchanged.
+   * the editable knobs (both the plain-Compose and Remote Compose channels) AND the
+   * detected-feature controls (a mapped `@FocusedPreview` component's Keyboard focus toggle
+   * re-renders on the daemon). Unmapped previews (Android-only variants with no daemon lane) are
+   * returned unchanged.
    */
   private fun mergeDeclaredKnobs(
     bakedPreviews: List<ServePreview>,
@@ -350,6 +351,7 @@ class ServeCatalogLiveHost(
       val twin = alias[p.id]?.let { twinByDaemonId[it] } ?: return@map p
       p.copy(
         overrides = twin.overrides,
+        remoteComposeKnobs = twin.remoteComposeKnobs,
         supportsFocus = twin.supportsFocus,
         supportsGestures = twin.supportsGestures,
       )

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -5,6 +5,7 @@ import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.daemon.protocol.StreamCodec
 import ee.schimke.composeai.data.layoutinspector.ComposeFigmaSvgProduct
 import ee.schimke.composeai.data.overrides.PreviewOverrideDeclaration
+import ee.schimke.composeai.data.remotecompose.RemoteComposeKnobDeclaration
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
@@ -954,6 +955,7 @@ class ServeHttpServer(
                 label = p.label,
                 modes = p.modes.map { it.wire },
                 overrides = p.overrides,
+                remoteComposeKnobs = p.remoteComposeKnobs,
               )
             },
         )
@@ -1781,6 +1783,15 @@ private data class PreviewDto(
    * declares none (or the host doesn't carry them). Additive since `compose-preview-serve/v2`.
    */
   val overrides: List<PreviewOverrideDeclaration> = emptyList(),
+  /**
+   * The Remote Compose named-value knobs this preview declared (`compose/remotecompose`) — name +
+   * typed author default (float / dp / int / string / bool / color). The auto-capture counterpart
+   * of [overrides]: a programmatic client renders a control per entry and writes an edit back
+   * through the `rc.<name>=<kind>:<value>` render param. Empty when the preview binds no named
+   * values through the declaring `rememberOverridableRemote*` wrappers (or the host doesn't carry
+   * them). Additive since `compose-preview-serve/v2`.
+   */
+  val remoteComposeKnobs: List<RemoteComposeKnobDeclaration> = emptyList(),
 )
 
 @Serializable

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
@@ -63,6 +63,18 @@ data class ServePreview(
    */
   val overrides: List<ee.schimke.composeai.data.overrides.PreviewOverrideDeclaration> = emptyList(),
   /**
+   * The Remote Compose named-value knobs this preview declared during its render (the
+   * `compose/remotecompose` editable surface). Populated from a bundle's
+   * `previews/<id>.remotecompose.json` sidecar so the viewer can present a control per knob (text
+   * field / colour swatch / slider) whose edits round-trip through the `rc.<name>=…` serve
+   * override. Empty when the preview binds no named values through the declaring
+   * `rememberOverridableRemote*` wrappers (or the host doesn't carry them). Distinct from
+   * [overrides], which is the plain-Compose `previewOverride*` surface.
+   */
+  val remoteComposeKnobs:
+    List<ee.schimke.composeai.data.remotecompose.RemoteComposeKnobDeclaration> =
+    emptyList(),
+  /**
    * Whether this preview supports **keyboard focus** — it carries `@FocusedPreview` (discovery
    * emits a `focus` capture). Lets the viewer offer a "Keyboard focus" control *only* for previews
    * that actually have something focusable, rather than as a dead control everywhere. Applied live

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemonKnobSidecarTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemonKnobSidecarTest.kt
@@ -1,0 +1,134 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.cli.PreviewInfo
+import ee.schimke.composeai.cli.PreviewManifest
+import ee.schimke.composeai.daemon.protocol.RemoteNamedValue
+import ee.schimke.composeai.data.overrides.PreviewOverrideDeclaration
+import ee.schimke.composeai.data.overrides.PreviewOverrideValue
+import ee.schimke.composeai.data.overrides.PreviewOverridesPayload
+import ee.schimke.composeai.data.remotecompose.RemoteComposeDeclarationsPayload
+import ee.schimke.composeai.data.remotecompose.RemoteComposeKnobDeclaration
+import ee.schimke.composeai.io.SystemFileSystem
+import java.io.ByteArrayOutputStream
+import java.nio.file.Files
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.Json
+
+/**
+ * Hermetic coverage for [ServeBundleDaemon]'s knob-sidecar plumbing — the serve-advertise half of
+ * the "auto-render Remote Compose knobs" chain. Builds a fake bundle (a `previews.json` + a zip of
+ * `previews/<id>.*.json` sidecars) entirely in a temp dir, then drives [ServeBundleDaemon
+ * .extractKnobSidecars] + [ServeBundleDaemon.readPreviews] directly — no daemon, no Gradle, no
+ * packed bundle — and asserts each [ServePreview] carries both channels: the Remote Compose
+ * `remoteComposeKnobs` (from `previews/<id>.remotecompose.json`) and the plain-Compose `overrides`
+ * (from `previews/<id>.overrides.json`), while a preview with no sidecar carries neither.
+ */
+class ServeBundleDaemonKnobSidecarTest {
+
+  private val json = Json { encodeDefaults = true }
+
+  @Test
+  fun `readPreviews folds both the remotecompose and overrides sidecars onto each preview`() {
+    val dir = Files.createTempDirectory("serve-knob-sidecar").toFile()
+    val previewsDir = java.io.File(dir, "previews").apply { mkdirs() }
+
+    // Three previews: one with an RC knob, one with a plain-Compose override, one bare.
+    val rcId = "pkg.CatalogPreviewsKt.ShaderGradientSticker"
+    val overrideId = "pkg.CatalogPreviewsKt.FilledButton_Light"
+    val bareId = "pkg.CatalogPreviewsKt.PlainSticker"
+    val manifest =
+      PreviewManifest(
+        module = ":catalog",
+        variant = "debug",
+        previews =
+          listOf(
+            PreviewInfo(id = rcId, functionName = "ShaderGradientSticker", className = "pkg.X"),
+            PreviewInfo(id = overrideId, functionName = "FilledButton", className = "pkg.X"),
+            PreviewInfo(id = bareId, functionName = "PlainSticker", className = "pkg.X"),
+          ),
+      )
+    val previewsJson = java.io.File(dir, "previews.json")
+    previewsJson.writeText(json.encodeToString(PreviewManifest.serializer(), manifest))
+
+    // A bundle zip carrying the two knob sidecars (and an unrelated PNG entry the extractor must
+    // ignore, plus a zip-slip attempt the extractor must refuse to write outside previewsDir).
+    val rcPayload =
+      RemoteComposeDeclarationsPayload(
+        listOf(
+          RemoteComposeKnobDeclaration("shaderColor", RemoteNamedValue.ColorValue("#FF7DE2FF"))
+        )
+      )
+    val overridesPayload =
+      PreviewOverridesPayload(
+        listOf(
+          PreviewOverrideDeclaration(
+            key = "label",
+            type = "string",
+            default = PreviewOverrideValue.StringValue("Filled"),
+          )
+        )
+      )
+    val zipBytes =
+      zipOf(
+        "previews/$rcId.remotecompose.json" to
+          json.encodeToString(RemoteComposeDeclarationsPayload.serializer(), rcPayload),
+        "previews/$overrideId.overrides.json" to
+          json.encodeToString(PreviewOverridesPayload.serializer(), overridesPayload),
+        "previews/$rcId.png" to "not-json",
+        "previews/../escape.remotecompose.json" to "{}",
+      )
+
+    ServeBundleDaemon.extractKnobSidecars(zipBytes, previewsDir, SystemFileSystem)
+    val previews = ServeBundleDaemon.readPreviews(previewsJson, previewsDir, SystemFileSystem)
+
+    assertEquals(3, previews.size, "all three manifest previews should surface")
+
+    val rc = previews.first { it.id == rcId }
+    assertEquals(
+      listOf("shaderColor"),
+      rc.remoteComposeKnobs.map { it.name },
+      "the RC sticker should advertise its declared color knob",
+    )
+    assertTrue(
+      rc.remoteComposeKnobs.single().default is RemoteNamedValue.ColorValue,
+      "the knob default should decode as a ColorValue, got ${rc.remoteComposeKnobs.single().default}",
+    )
+    assertTrue(rc.overrides.isEmpty(), "the RC sticker declared no plain-Compose override")
+
+    val ov = previews.first { it.id == overrideId }
+    assertEquals(
+      listOf("label"),
+      ov.overrides.map { it.key },
+      "the button should advertise its declared plain-Compose label knob",
+    )
+    assertTrue(ov.remoteComposeKnobs.isEmpty(), "the button declared no RC knob")
+
+    val bare = previews.first { it.id == bareId }
+    assertTrue(
+      bare.remoteComposeKnobs.isEmpty() && bare.overrides.isEmpty(),
+      "bare preview: no knobs",
+    )
+
+    // The zip-slip entry must not have escaped previewsDir.
+    assertTrue(
+      !java.io.File(dir, "escape.remotecompose.json").exists(),
+      "extractKnobSidecars must refuse a `..` path traversal",
+    )
+  }
+
+  private fun zipOf(vararg entries: Pair<String, String>): ByteArray {
+    val bos = ByteArrayOutputStream()
+    ZipOutputStream(bos).use { zos ->
+      for ((name, body) in entries) {
+        zos.putNextEntry(ZipEntry(name))
+        zos.write(body.toByteArray())
+        zos.closeEntry()
+      }
+    }
+    return bos.toByteArray()
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleStoreTest.kt
@@ -78,6 +78,27 @@ class ServeBundleStoreTest {
   }
 
   @Test
+  fun `remotecompose sidecars are extracted and surfaced as a preview's RC knobs`() {
+    // The upload path (POST / URL) must keep `.remotecompose.json` sidecars just like the
+    // `.overrides.json` ones — otherwise an uploaded bundle would silently drop
+    // `remoteComposeKnobs`
+    // that the live-bundle / directory paths carry.
+    val rc =
+      """{"declarations":[{"name":"shaderColor",""" +
+        """"default":{"kind":"color","argb":"#FF7DE2FF"}}]}"""
+    val zip =
+      zipOf(
+        "previews/com.example.Red.png" to byteArrayOf(1, 2, 3),
+        "previews/com.example.Red.remotecompose.json" to rc.toByteArray(),
+      )
+    val result = store().add("demo", zip, isSecurityChecked = true)
+    assertEquals(ServeBundleStore.Result.Ok("demo", 1), result)
+
+    val preview = registered.getValue("demo").previews.single { it.id == "com.example.Red" }
+    assertEquals(listOf("shaderColor"), preview.remoteComposeKnobs.map { it.name })
+  }
+
+  @Test
   fun `the root previews_json is extracted so an uploaded bundle surfaces its declared themes`() {
     val previewsJson =
       """

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
@@ -1,9 +1,12 @@
 package ee.schimke.composeai.cli.serve
 
+import ee.schimke.composeai.daemon.protocol.RemoteNamedValue
 import ee.schimke.composeai.data.overrides.PreviewOverrideDeclaration
 import ee.schimke.composeai.data.overrides.PreviewOverrideType
 import ee.schimke.composeai.data.overrides.PreviewOverrideValue
 import ee.schimke.composeai.data.overrides.PreviewOverridesPayload
+import ee.schimke.composeai.data.remotecompose.RemoteComposeDeclarationsPayload
+import ee.schimke.composeai.data.remotecompose.RemoteComposeKnobDeclaration
 import java.awt.image.BufferedImage
 import java.io.ByteArrayOutputStream
 import java.io.File
@@ -45,9 +48,14 @@ class ServeHttpRoutingTest {
       default = PreviewOverrideValue.StringValue("Tap me"),
     )
 
+  /** A declared Remote Compose knob, carried into the bundle as a `remotecompose.json` sidecar. */
+  private val rcColorKnob =
+    RemoteComposeKnobDeclaration("shaderColor", RemoteNamedValue.ColorValue("#FF7DE2FF"))
+
   private fun bundle(
     label: String,
     overrides: List<PreviewOverrideDeclaration> = emptyList(),
+    remoteComposeKnobs: List<RemoteComposeKnobDeclaration> = emptyList(),
     degradations: List<ServeDegradation> = emptyList(),
   ): ServeBundleHost {
     val dir = Files.createTempDirectory("routing-$label").toFile().also { it.deleteOnExit() }
@@ -62,13 +70,25 @@ class ServeHttpRoutingTest {
         )
       File(dir, "previews/$previewId.overrides.json").writeText(sidecar)
     }
+    if (remoteComposeKnobs.isNotEmpty()) {
+      val sidecar =
+        Json.encodeToString(
+          RemoteComposeDeclarationsPayload.serializer(),
+          RemoteComposeDeclarationsPayload(remoteComposeKnobs),
+        )
+      File(dir, "previews/$previewId.remotecompose.json").writeText(sidecar)
+    }
     return ServeBundleHost(dir, label = label, degradations = degradations)
   }
 
   private val registry = ServeSessionRegistry(open = { null })
   private val server: ServeHttpServer by lazy {
     registry.register("default-mod", host = bundle("default-mod"), pinned = true)
-    registry.register("compose-m3", host = bundle("compose-m3", listOf(labelKnob)), pinned = true)
+    registry.register(
+      "compose-m3",
+      host = bundle("compose-m3", listOf(labelKnob), listOf(rcColorKnob)),
+      pinned = true,
+    )
     // A baked-only session carrying a degradation reason — reachable at /baked-only/… but kept off
     // catalogSessions so the home-index test is unaffected. Exercises the /api/previews surfacing.
     registry.register(
@@ -223,6 +243,12 @@ class ServeHttpRoutingTest {
     assertTrue(api.contains("\"overrides\":["), "overrides array present: $api")
     assertTrue(api.contains("\"key\":\"label\""), "declared knob key: $api")
     assertTrue(api.contains("\"value\":\"Tap me\""), "declared knob default value: $api")
+    // The declared Remote Compose knob (from the `.remotecompose.json` sidecar) surfaces too, with
+    // its typed default (the `kind` discriminator + argb the connector round-trips).
+    assertTrue(api.contains("\"remoteComposeKnobs\":["), "rc knobs array present: $api")
+    assertTrue(api.contains("\"name\":\"shaderColor\""), "declared rc knob name: $api")
+    assertTrue(api.contains("\"kind\":\"color\""), "rc knob typed default kind: $api")
+    assertTrue(api.contains("\"argb\":\"#FF7DE2FF\""), "rc knob default argb: $api")
     // A fully-served (non-degraded) session carries an empty degradations array.
     assertTrue(
       api.contains("\"degradations\":[]"),


### PR DESCRIPTION
## Summary

**PR 4b of the "auto-render Remote Compose knobs" series** (builds on #2677 / #2681 / #2686 / #2690, all merged). This is the **serve-advertise half**: the serve host now reads the per-preview `previews/<id>.remotecompose.json` sidecar (the `compose/remotecompose` declarations payload PR #2686 packs) and surfaces each preview's declared named-value knobs — alongside the existing plain-Compose `overrides` channel — so a client knows the editable Remote Compose surface without scraping the viewer HTML.

## What changed

- **`:cli`** now depends on `:data-remotecompose-core` for the payload types (`RemoteComposeKnobDeclaration` / `RemoteComposeDeclarationsPayload`) — pure JVM, no alpha `androidx.compose.remote.*` or renderer artifacts, so the CLI's daemon-library boundary check still holds.
- **`ServePreview`** gains a `remoteComposeKnobs` field (the RC counterpart of `overrides`).
- **`ServeBundleDaemon`** — `extractKnobSidecars` (renamed from `extractOverrideSidecars`) now extracts both the `.overrides.json` and `.remotecompose.json` sidecars; `readRemoteComposeSidecar` decodes the RC payload and `readPreviews` folds it onto each `ServePreview`.
- **`ServeBundleHost`** (the baked static host) reads the same sidecar via `readRemoteComposeKnobs`.
- **`ServeCatalogLiveHost`** grafts the daemon twin's `remoteComposeKnobs` onto the baked browse surface, exactly like it already does for `overrides`.
- **`/api/previews`** carries `remoteComposeKnobs` per preview (additive on `compose-preview-serve/v2`), with the typed default (`{"kind":"color","argb":"#FF7DE2FF"}` — the connector's `@JsonClassDiscriminator("kind")` round-trips).

## Why the JSON discriminator is safe

`RemoteNamedValue` carries `@JsonClassDiscriminator("kind")` on the sealed class, so any `Json` instance (producer or reader) encodes/decodes the `"kind"` tag regardless of its default `classDiscriminator` — the sidecar the render step wrote decodes cleanly through the serve reader.

## Verification (hermetic, in-session)

- `ServeBundleDaemonKnobSidecarTest` (new) builds a fake bundle (a `previews.json` + a zip of `previews/<id>.*.json` sidecars) entirely in a temp dir and drives `extractKnobSidecars` + `readPreviews` directly — asserts each `ServePreview` carries the RC `remoteComposeKnobs` and the plain-Compose `overrides`, a bare preview carries neither, and a `..` zip-slip entry never escapes `previews/`.
- `ServeHttpRoutingTest` (extended) packs an RC color-knob sidecar and asserts `GET /api/previews` returns `remoteComposeKnobs` with `name":"shaderColor"` and its typed `kind":"color"` / `argb":"#FF7DE2FF"` default.

Both pass in-session (`./gradlew :cli:test`), ktfmt clean.

This is non-visual plumbing (a JSON field + sidecar reads, no rendered surface changes) — text-only evidence is correct. The **viewer HTML controls** for these knobs (the live `rc.<name>=` round-trip, which *is* visual) follow in a separate change.

## Next in the series

- **PR 4c** — render a control per RC knob in the serve / VS Code viewer (edits round-trip via the `rc.<name>=` param from #2674). *(visual — preview-harness evidence.)*
- **PR 5** — flip `remote-m3` to a live Android bundle in `design-artifacts.yml`.

---
_Generated by [Claude Code](https://claude.ai/code/session_011K7sgCfdsbhN7fwMb3WhSS)_