### PR TITLE
ci(design-artifacts): cache downloadable fonts across catalog renders

### DIFF
--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -279,25 +279,28 @@ jobs:
           sudo apt-get install -y --no-install-recommends \
             xvfb libgl1 libglx-mesa0 libgl1-mesa-dri libfreetype6 libfontconfig1 fontconfig
 
-      # Persist the downloadable-font cache across runs. The Android renderer's
-      # GoogleFont shadow and the figma-svg export fetch faces (Orbitron, Space
-      # Grotesk, JetBrains Mono, Noto, Roboto, …) from Google Fonts into
-      # `~/.cache/composeai/fonts` on a cache miss; caching that dir means a face is
-      # downloaded once and reused on every later run instead of re-fetched. That
-      # keeps a branded catalog's bake deterministic (e.g. meshcore's Orbitron /
-      # Space Grotesk / JetBrains Mono resolve instead of silently rendering Roboto)
-      # and stops a transient Google Fonts hiccup from degrading the render — which,
-      # now that an unresolved downloadable font is a fatal render error rather than a
-      # silent Roboto fallback, would otherwise fail the bake outright. The rolling
-      # run_id key + prefix restore accumulates newly-seen faces across runs; a
-      # partially-populated cache from a run that failed mid-render is still saved and
-      # reused, so the next run only fetches what's missing.
-      - name: Cache downloadable fonts
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      # Restore the downloadable-font cache (the matching save runs after the render,
+      # below). The Android renderer's GoogleFont shadow and the figma-svg export fetch
+      # faces (Orbitron, Space Grotesk, JetBrains Mono, Noto, Roboto, …) from Google Fonts
+      # into `~/.cache/composeai/fonts` on a miss; restoring it means a face is downloaded
+      # once and reused, so a branded catalog resolves deterministically (meshcore's
+      # Orbitron / Space Grotesk / JetBrains Mono instead of a silent Roboto fallback) and a
+      # transient Google Fonts hiccup can't degrade the bake — which, now that an unresolved
+      # downloadable font is a fatal render error, would otherwise fail the whole render.
+      #
+      # `inputs.system` is in the key so sibling catalog jobs of ONE caller run (e.g.
+      # compose-m3 / wear-m3 / remote-m3 in design-artifacts.yml) don't collide on the
+      # shared `github.run_id` — Actions caches are immutable, so a shared key would let the
+      # first job's post-save win and discard the others' fonts. The restore-keys fall back
+      # to this catalog's prior runs, then to any catalog's (fonts are global, keyed by
+      # family, so a warm start from a sibling is a bonus).
+      - name: Restore downloadable-font cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/composeai/fonts
-          key: composeai-fonts-${{ runner.os }}-${{ github.run_id }}
+          key: composeai-fonts-${{ runner.os }}-${{ inputs.system }}-${{ github.run_id }}
           restore-keys: |
+            composeai-fonts-${{ runner.os }}-${{ inputs.system }}-
             composeai-fonts-${{ runner.os }}-
 
       - name: Render catalog bundle
@@ -316,6 +319,21 @@ jobs:
           embed=(); if [ "${{ inputs.embed-deps }}" = "true" ]; then embed=(--embed-deps); fi
           run compose-preview bundle pack --module "${{ inputs.extra-module }}" --with-semantics \
             "${embed[@]}" -o "$GITHUB_WORKSPACE/extra-bundle.png" --timeout 600
+
+      # Save the font cache even when a render step FAILED. A cold-cache run that downloaded
+      # some faces before a later one failed to resolve must persist what it got, so the
+      # rerun self-heals instead of starting cold again — `actions/cache` only saves on job
+      # success, so restore/save are split and this runs under `if: always()`. It sits right
+      # after the render steps (the only steps that fetch fonts) so a failure there still
+      # captures the partial warm-up; the fresh run_id key never hits the immutable-key
+      # conflict. Font downloads happen during the two render steps above only; the generate
+      # / split / publish steps below process the already-rendered bundle.
+      - name: Save downloadable-font cache
+        if: always()
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/composeai/fonts
+          key: composeai-fonts-${{ runner.os }}-${{ inputs.system }}-${{ github.run_id }}
 
       - name: Generate importable catalog
         run: |

--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -279,6 +279,27 @@ jobs:
           sudo apt-get install -y --no-install-recommends \
             xvfb libgl1 libglx-mesa0 libgl1-mesa-dri libfreetype6 libfontconfig1 fontconfig
 
+      # Persist the downloadable-font cache across runs. The Android renderer's
+      # GoogleFont shadow and the figma-svg export fetch faces (Orbitron, Space
+      # Grotesk, JetBrains Mono, Noto, Roboto, …) from Google Fonts into
+      # `~/.cache/composeai/fonts` on a cache miss; caching that dir means a face is
+      # downloaded once and reused on every later run instead of re-fetched. That
+      # keeps a branded catalog's bake deterministic (e.g. meshcore's Orbitron /
+      # Space Grotesk / JetBrains Mono resolve instead of silently rendering Roboto)
+      # and stops a transient Google Fonts hiccup from degrading the render — which,
+      # now that an unresolved downloadable font is a fatal render error rather than a
+      # silent Roboto fallback, would otherwise fail the bake outright. The rolling
+      # run_id key + prefix restore accumulates newly-seen faces across runs; a
+      # partially-populated cache from a run that failed mid-render is still saved and
+      # reused, so the next run only fetches what's missing.
+      - name: Cache downloadable fonts
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/composeai/fonts
+          key: composeai-fonts-${{ runner.os }}-${{ github.run_id }}
+          restore-keys: |
+            composeai-fonts-${{ runner.os }}-
+
       - name: Render catalog bundle
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Why

Follow-up to #2689. The shared catalog-render workflow (`design-artifacts-reusable.yml`, used by every published catalog incl. `meshcore-mobile`, which renders `:app` on the Android/Robolectric path) fetches downloadable faces — Orbitron, Space Grotesk, JetBrains Mono, Noto, Roboto — from Google Fonts into `~/.cache/composeai/fonts` on each run. **Nothing persisted that dir**, so every bake re-downloaded, and a transient Google Fonts failure silently degraded a branded catalog to a Roboto fallback. That's exactly why [`theme-meshcore-light…svg`](https://preview.coo.ee/meshcore-mobile/render/theme-meshcore-light__ideal__default__light__compact.svg) bakes as Roboto. And now that #2689 makes an unresolved downloadable font a **fatal** render error, the same hiccup would fail the whole bake.

## What

Add an `actions/cache` step for `~/.cache/composeai/fonts` before the render, with a rolling `run_id` key + prefix restore-key:

- A face is downloaded once and reused on later runs → branded catalogs resolve deterministically instead of racing a live fetch.
- A partially-populated cache from a run that failed mid-render is still saved and restored, so the next run only fetches what's missing (self-healing toward a warm cache).
- Covers both the Android GoogleFont-shadow render and the `compose/figma-svg` woff2 export, for every catalog that goes through the reusable workflow.

This is the render-side half of "once a font is downloaded, reuse it" — the deploy box already persists the same dir via the `preview_cache` volume; this brings the CI bake (which actually produces the published SVGs) to parity.

## Test plan

- YAML validated (`yaml.safe_load`); `actions/cache` pinned by SHA (v6.1.0) per repo convention.
- Behaviour is verified by dispatching `design-artifacts.yml` after merge: first run populates the cache (dispatch with `allow_incomplete: true` so a cold-cache transient miss doesn't fail the publish while the cache warms), subsequent runs restore it and re-bake the branded catalogs in the correct faces.

## Follow-up (separate)

Two-mode SVG export so the two consumers stop fighting over one artifact: **Figma** (embed rasters, fonts by family name — Figma ignores `@font-face`) vs **web/document** (reference rasters + reference fonts). Noted for a later change; both modes still depend on correct render-time font resolution for text metrics, which this PR + #2689 provide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KL6aMkWHRwot53LnwDoAc2

---
_Generated by [Claude Code](https://claude.ai/code/session_01KL6aMkWHRwot53LnwDoAc2)_