### PR TITLE
ci(design-artifacts): publish remote-m3 as a live Android bundle

### DIFF
--- a/.github/workflows/design-artifacts.yml
+++ b/.github/workflows/design-artifacts.yml
@@ -263,7 +263,9 @@ jobs:
           # a render daemon from it (no build). The DESKTOP CMP catalog (compose-m3,
           # the wasm-tier row) runs on the Skiko daemon; an Android catalog flagged
           # `androidLiveBundle` (wear-m3) runs on the Robolectric daemon a box carrying
-          # the Android sidecar provides — see deploy/image. remote-m3 stays baked-PNG.
+          # the Android sidecar provides — see deploy/image. The Android-only tiers
+          # (wear-m3 / remote-m3) publish their live bundle through the reusable job
+          # below, not this matrix.
           PUBLISH_LIVE_BUNDLE: ${{ (matrix.wasmModule != '' || matrix.androidLiveBundle == '1') && '1' || '' }}
           # Buildable source for trusted server-side re-render: catalog.json gets a
           # `source: {repo, ref, module}` so a `serve --allow-render-trusted` box can
@@ -365,9 +367,10 @@ jobs:
   # wear-m3 / remote-m3 delegate to the shared reusable workflow (same one
   # external consumers use), building the CLI from source (cli-source: build) so
   # they still publish HEAD's renderer output. They're Android (Robolectric)
-  # renders with no Wasm tier, so they fit the common pipeline; only their split
-  # lane differs — wear carries a live bundle (full split), remote-m3 is baked
-  # (view-only). See DESIGN_CATALOGS.md's reference-caller convention.
+  # renders with no Wasm tier, so they fit the common pipeline; both now carry a
+  # live bundle (full split) — the Robolectric daemon a serve host with the Android
+  # sidecar runs re-renders either. See DESIGN_CATALOGS.md's reference-caller
+  # convention.
   # ───────────────────────────────────────────────────────────────────────────
   wear-m3:
     name: wear-m3
@@ -399,9 +402,13 @@ jobs:
       spec: samples/design-catalog-remote-m3/catalog.spec.json
       module: 'samples:design-catalog-remote-m3'
       cli-source: build
-      # Remote Compose has no runnable desktop daemon on the serve host, so it
-      # stays baked: split view-only (addressable stickers, no re-render classpath).
+      # Remote Compose is an Android/Robolectric catalog, so the same Android
+      # daemon that re-renders wear-m3 (on a serve host carrying the Android
+      # sidecar) drives it — carry a live bundle and split it full so each
+      # per-preview bundle keeps its re-render classpath, and the viewer's declared
+      # Remote Compose knobs re-render live via the `rc.<name>=` override.
+      publish-live-bundle: true
       split-per-preview: true
-      split-mode: view-only
+      split-mode: full
     secrets:
       buildfetch_ro_token: ${{ secrets.BUILDFETCH_COMPOSEAI_GRADLE_REMOTE_CACHE_TOKEN_RO || secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN_RO }}


### PR DESCRIPTION
## Summary

**PR 5 — the final step of the "auto-render Remote Compose knobs" series** (#2677 / #2681 / #2686 / #2690 / #2693 merged; #2696 the viewer controls is open). Flips the `remote-m3` catalog from a **baked** delivery to a **live Android bundle**, so its declared Remote Compose knobs drive a real re-render on the serve host instead of serving baked PNGs.

`remote-m3` is an Android/Robolectric catalog, exactly like `wear-m3` — the same Robolectric daemon a serve host with the Android sidecar runs re-renders either. Previously `remote-m3` was published `split-mode: view-only` with no live bundle (a stale "Remote Compose has no runnable desktop daemon" rationale — the relevant daemon is the *Android* one, which the host already carries for `wear-m3`).

## What changed

In `.github/workflows/design-artifacts.yml`, the `remote-m3` reusable-workflow job now mirrors `wear-m3`:
- `publish-live-bundle: true`
- `split-mode: full` (was `view-only`) — each per-preview bundle keeps its re-render classpath.

Plus two stale comments corrected (the matrix-job note that claimed `remote-m3` stays baked-PNG, and the section header).

## Why this completes the series

With this flip, the full chain is live end-to-end:

**declare** (`rememberOverridableRemote*`, #2690) → **capture** the knobs into the bundle sidecar (#2686) → **serve advertises** them (#2693) → **viewer renders a control per knob** (#2696) → **live re-render**: an edit posts `rc.<name>=<kind>:<value>`, the Robolectric daemon re-renders `remote-m3` with the seeded named value, and the viewer swaps in the fresh frame.

## Test plan / validation boundary

- YAML parses; the inputs (`publish-live-bundle`, `split-mode: full`) are the same ones `wear-m3` already passes to the reusable workflow, so they're validated by that caller.
- This is a **deploy-host** change — the live bundle only re-renders on a `serve --allow-render-trusted` box carrying the Android (Robolectric) sidecar (`deploy/image`), the same requirement `wear-m3` already has. The publish itself runs in `design-artifacts.yml`; the delivery branch `design-artifacts/remote-m3` will carry the live bundle after this merges and the workflow is dispatched.

After merge I'll dispatch `design-artifacts.yml` (ref `main`) so `design-artifacts/remote-m3` is regenerated as the live bundle, per the repo's delivery-branch-refresh convention.

---
_Generated by [Claude Code](https://claude.ai/code/session_011K7sgCfdsbhN7fwMb3WhSS)_