### PR TITLE
feat(serve): carry the last failure reason in /status renderStats

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/RenderPerfStats.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/RenderPerfStats.kt
@@ -32,6 +32,8 @@ class RenderPerfStats {
   private var maxMs = 0L
   private var totalMs = 0L
   private var lastMs: Long? = null
+  private var lastFailureReason: String? = null
+  private var lastFailureAtEpochMillis: Long? = null
   private val window = LongArray(WINDOW_SIZE)
   private var windowCount = 0
   private var windowIdx = 0
@@ -42,13 +44,23 @@ class RenderPerfStats {
   /** The bounded render-lock acquire backed off ([RenderOutcome.Busy] → caller serves baked). */
   fun recordBusy(): Unit = synchronized(lock) { busy++ }
 
-  /** A render that ended in [RenderOutcome.Failed]; [timeout] when it blew its render budget. */
-  fun recordFailed(durationMs: Long, timeout: Boolean): Unit =
+  /**
+   * A render that ended in [RenderOutcome.Failed]; [timeout] when it blew its render budget.
+   * [reason] is the outcome's failure text — kept (truncated) so `/status.json` can say WHY a
+   * catalog's live lane is failing without anyone tailing container logs: a daemon whose every
+   * render fails otherwise shows only a climbing `failed` counter while the composite silently
+   * serves baked fallback.
+   */
+  fun recordFailed(durationMs: Long, timeout: Boolean, reason: String? = null): Unit =
     synchronized(lock) {
       renders++
       failed++
       if (timeout) timedOut++
       lastMs = durationMs
+      if (reason != null) {
+        lastFailureReason = reason.take(MAX_FAILURE_REASON_LENGTH)
+        lastFailureAtEpochMillis = System.currentTimeMillis()
+      }
     }
 
   /**
@@ -96,12 +108,17 @@ class RenderPerfStats {
         p50Ms = pct(0.5),
         p95Ms = pct(0.95),
         windowSize = windowCount,
+        lastFailureReason = lastFailureReason,
+        lastFailureAtEpochMillis = lastFailureAtEpochMillis,
       )
     }
 
   companion object {
     /** Ring size for the recent-durations percentile window. */
     const val WINDOW_SIZE: Int = 128
+
+    /** Cap on the carried failure-reason text — enough for a message, not a stack trace. */
+    const val MAX_FAILURE_REASON_LENGTH: Int = 300
   }
 }
 
@@ -137,6 +154,13 @@ data class RenderPerfSnapshot(
   val p50Ms: Long? = null,
   val p95Ms: Long? = null,
   val windowSize: Int = 0,
+  /**
+   * The most recent failure's reason text (truncated) + when it happened — the "why" behind a
+   * non-zero [failed] counter, so a catalog whose live lane silently falls back to baked is
+   * diagnosable from `/status.json` alone.
+   */
+  val lastFailureReason: String? = null,
+  val lastFailureAtEpochMillis: Long? = null,
 ) {
   companion object {
     /**
@@ -164,6 +188,13 @@ data class RenderPerfSnapshot(
         p50Ms = null,
         p95Ms = null,
         windowSize = snapshots.sumOf { it.windowSize },
+        // Most recent failure across daemons (by timestamp) so the roll-up carries a "why" too.
+        lastFailureReason =
+          snapshots
+            .filter { it.lastFailureAtEpochMillis != null }
+            .maxByOrNull { it.lastFailureAtEpochMillis!! }
+            ?.lastFailureReason,
+        lastFailureAtEpochMillis = snapshots.mapNotNull { it.lastFailureAtEpochMillis }.maxOrNull(),
       )
     }
   }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
@@ -452,7 +452,7 @@ internal constructor(
           } catch (e: RenderSessionException) {
             val reason = "renderNow failed: ${e.message}"
             onLog(reason)
-            perfStats.recordFailed(perfElapsedMs(), timeout = false)
+            perfStats.recordFailed(perfElapsedMs(), timeout = false, reason = reason)
             return RenderOutcome.Failed(reason)
           }
 
@@ -464,7 +464,7 @@ internal constructor(
           }
           val reason = "render rejected: ${rejected.reason}"
           onLog(reason)
-          perfStats.recordFailed(perfElapsedMs(), timeout = false)
+          perfStats.recordFailed(perfElapsedMs(), timeout = false, reason = reason)
           return RenderOutcome.Failed(reason)
         }
 
@@ -482,7 +482,7 @@ internal constructor(
           staleRenders.merge(previewId, 1, Int::plus)
           val reason = "timed out after ${budget}s waiting for render"
           onLog(reason)
-          perfStats.recordFailed(perfElapsedMs(), timeout = true)
+          perfStats.recordFailed(perfElapsedMs(), timeout = true, reason = reason)
           return RenderOutcome.Failed(reason)
         }
         // The latch also trips on `renderFailed` — the daemon reported the render body threw.
@@ -494,7 +494,7 @@ internal constructor(
         pendingFailure.get()?.let { failure ->
           val reason = "render failed: $failure"
           onLog(reason)
-          perfStats.recordFailed(perfElapsedMs(), timeout = false)
+          perfStats.recordFailed(perfElapsedMs(), timeout = false, reason = reason)
           return RenderOutcome.Failed(reason)
         }
         warmedUp.set(true)
@@ -511,7 +511,7 @@ internal constructor(
       if (bytes == null) {
         val reason = "render produced no PNG"
         onLog(reason)
-        perfStats.recordFailed(perfElapsedMs(), timeout = false)
+        perfStats.recordFailed(perfElapsedMs(), timeout = false, reason = reason)
         return RenderOutcome.Failed(reason)
       }
 

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/RenderPerfStatsTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/RenderPerfStatsTest.kt
@@ -2,6 +2,7 @@ package ee.schimke.composeai.cli.serve
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
 class RenderPerfStatsTest {
@@ -24,7 +25,7 @@ class RenderPerfStatsTest {
     stats.recordOk(1_000, cold = false)
     stats.recordCacheHit()
     stats.recordBusy()
-    stats.recordFailed(120_000, timeout = true)
+    stats.recordFailed(120_000, timeout = true, reason = "timed out after 120s waiting for render")
 
     val snap = stats.snapshot()
     assertEquals(4, snap.renders)
@@ -43,6 +44,9 @@ class RenderPerfStatsTest {
     assertEquals(120_000, snap.lastMs)
     assertEquals(3, snap.windowSize)
     assertEquals(2_000, snap.p50Ms)
+    // The failure's "why" is carried so /status can explain a climbing failed counter.
+    assertEquals("timed out after 120s waiting for render", snap.lastFailureReason)
+    assertNotNull(snap.lastFailureAtEpochMillis)
   }
 
   @Test


### PR DESCRIPTION
## Summary

Post-deploy verification of 0.17.14 on preview.coo.ee proved the need immediately: the new `renderStats` shows **meshcore-mobile's live lane at `failed: 16, ok: 0, timedOut: 0`**, and a probe (`?fontScale=2.0`) returns bytes identical to the baked PNG — every override render fails fast and silently falls back to baked. `/status.json` can count the failures but not say *why*; the reason only exists in container logs.

- `RenderPerfStats.recordFailed` now takes the outcome's failure text; `RenderPerfSnapshot` carries `lastFailureReason` (truncated to 300 chars — a message, not a stack trace) plus `lastFailureAtEpochMillis`.
- All five `ServeRenderHost` failure sites pass their reason (`renderNow failed:`, `render rejected:`, `timed out after…`, `render failed: <daemon message>`, `render produced no PNG`).
- The server-wide roll-up picks the newest failure across daemons by timestamp.
- Additive on `compose-preview-serve/status/v1`.

With this deployed, the meshcore-mobile diagnosis is one `curl /status.json | jq '.runningServers[].renderStats.lastFailureReason'` away.

## Test plan

- `RenderPerfStatsTest` asserts the carried reason + timestamp; `ServeRenderHostTest` (including the renderFailed fail-fast regression) green.
- ktfmt green.

Non-visual change — text-only per the repo's visual-evidence rule.

---
_Generated by [Claude Code](https://claude.ai/code/session_012HRLHzhApM2N4hrgNarW3k)_