### PR TITLE
fix(serve): disable Remote Compose knobs while the Wasm lane is active

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -3344,11 +3344,16 @@ object ServeWeb {
           // Static snapshot lane: raster PNG, or the vector SVG when the format toggle is on.
           snapshotExt = svgOn() ? ".svg" : ".png";
           if (svgOn()) root.setAttribute("data-mode", "svg");
-          refreshSnapshot();
         }
         syncOverlayToggles();
         syncServerControls();
         updateLiveToggle();
+        // Render the static lane AFTER syncServerControls() has reconciled the daemon-only controls
+        // for the new lane. Returning from Wasm this re-enables the `.cp-rc-knob` inputs first, so
+        // query() includes an rc.* value edited before the Wasm detour in the first snapshot render
+        // (and its direct links) instead of skipping the still-disabled control. The live/wasm lanes
+        // drive their own render (openStream / openWasm), so only the static lane renders here.
+        if (m !== "live" && m !== "wasm") refreshSnapshot();
       }
       // SVG format toggle: swap the static snapshot between raster and vector. Pressing it while a
       // live lane is active drops back to the static vector render; pressing it in the static lane

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -3422,6 +3422,13 @@ object ServeWeb {
         if (themeProviderEl) {
           themeProviderEl.disabled = onWasm || !(!staticSnapshot || canRenderOverrides);
         }
+        // Remote Compose knobs are daemon-only (Remote Compose has no in-browser runtime), so like
+        // the app-theme selector they're dead in the Wasm lane — an edit would route only through
+        // the daemon path and never touch the visible iframe. Disable them there; otherwise mirror
+        // the server-side gate (enabled iff the host can render an override).
+        document.querySelectorAll(".cp-rc-knob").forEach(function (el) {
+          el.disabled = onWasm || !(!staticSnapshot || canRenderOverrides);
+        });
       }
       // Programmatic switch (the live toggle, or a wasm-only control auto-enabling Wasm): tick the
       // hidden mode radio so its state is consistent, then run the transition.

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
@@ -1531,11 +1531,16 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
       // Static snapshot lane: raster PNG, or the vector SVG when the format toggle is on.
       snapshotExt = svgOn() ? ".svg" : ".png";
       if (svgOn()) root.setAttribute("data-mode", "svg");
-      refreshSnapshot();
     }
     syncOverlayToggles();
     syncServerControls();
     updateLiveToggle();
+    // Render the static lane AFTER syncServerControls() has reconciled the daemon-only controls
+    // for the new lane. Returning from Wasm this re-enables the `.cp-rc-knob` inputs first, so
+    // query() includes an rc.* value edited before the Wasm detour in the first snapshot render
+    // (and its direct links) instead of skipping the still-disabled control. The live/wasm lanes
+    // drive their own render (openStream / openWasm), so only the static lane renders here.
+    if (m !== "live" && m !== "wasm") refreshSnapshot();
   }
   // SVG format toggle: swap the static snapshot between raster and vector. Pressing it while a
   // live lane is active drops back to the static vector render; pressing it in the static lane

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
@@ -1609,6 +1609,13 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     if (themeProviderEl) {
       themeProviderEl.disabled = onWasm || !(!staticSnapshot || canRenderOverrides);
     }
+    // Remote Compose knobs are daemon-only (Remote Compose has no in-browser runtime), so like
+    // the app-theme selector they're dead in the Wasm lane — an edit would route only through
+    // the daemon path and never touch the visible iframe. Disable them there; otherwise mirror
+    // the server-side gate (enabled iff the host can render an override).
+    document.querySelectorAll(".cp-rc-knob").forEach(function (el) {
+      el.disabled = onWasm || !(!staticSnapshot || canRenderOverrides);
+    });
   }
   // Programmatic switch (the live toggle, or a wasm-only control auto-enabling Wasm): tick the
   // hidden mode radio so its state is consistent, then run the transition.

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-focus.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-focus.html
@@ -1490,11 +1490,16 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
       // Static snapshot lane: raster PNG, or the vector SVG when the format toggle is on.
       snapshotExt = svgOn() ? ".svg" : ".png";
       if (svgOn()) root.setAttribute("data-mode", "svg");
-      refreshSnapshot();
     }
     syncOverlayToggles();
     syncServerControls();
     updateLiveToggle();
+    // Render the static lane AFTER syncServerControls() has reconciled the daemon-only controls
+    // for the new lane. Returning from Wasm this re-enables the `.cp-rc-knob` inputs first, so
+    // query() includes an rc.* value edited before the Wasm detour in the first snapshot render
+    // (and its direct links) instead of skipping the still-disabled control. The live/wasm lanes
+    // drive their own render (openStream / openWasm), so only the static lane renders here.
+    if (m !== "live" && m !== "wasm") refreshSnapshot();
   }
   // SVG format toggle: swap the static snapshot between raster and vector. Pressing it while a
   // live lane is active drops back to the static vector render; pressing it in the static lane

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-focus.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-focus.html
@@ -1568,6 +1568,13 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     if (themeProviderEl) {
       themeProviderEl.disabled = onWasm || !(!staticSnapshot || canRenderOverrides);
     }
+    // Remote Compose knobs are daemon-only (Remote Compose has no in-browser runtime), so like
+    // the app-theme selector they're dead in the Wasm lane — an edit would route only through
+    // the daemon path and never touch the visible iframe. Disable them there; otherwise mirror
+    // the server-side gate (enabled iff the host can render an override).
+    document.querySelectorAll(".cp-rc-knob").forEach(function (el) {
+      el.disabled = onWasm || !(!staticSnapshot || canRenderOverrides);
+    });
   }
   // Programmatic switch (the live toggle, or a wasm-only control auto-enabling Wasm): tick the
   // hidden mode radio so its state is consistent, then run the transition.

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-gestures.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-gestures.html
@@ -1490,11 +1490,16 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
       // Static snapshot lane: raster PNG, or the vector SVG when the format toggle is on.
       snapshotExt = svgOn() ? ".svg" : ".png";
       if (svgOn()) root.setAttribute("data-mode", "svg");
-      refreshSnapshot();
     }
     syncOverlayToggles();
     syncServerControls();
     updateLiveToggle();
+    // Render the static lane AFTER syncServerControls() has reconciled the daemon-only controls
+    // for the new lane. Returning from Wasm this re-enables the `.cp-rc-knob` inputs first, so
+    // query() includes an rc.* value edited before the Wasm detour in the first snapshot render
+    // (and its direct links) instead of skipping the still-disabled control. The live/wasm lanes
+    // drive their own render (openStream / openWasm), so only the static lane renders here.
+    if (m !== "live" && m !== "wasm") refreshSnapshot();
   }
   // SVG format toggle: swap the static snapshot between raster and vector. Pressing it while a
   // live lane is active drops back to the static vector render; pressing it in the static lane

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-gestures.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-gestures.html
@@ -1568,6 +1568,13 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     if (themeProviderEl) {
       themeProviderEl.disabled = onWasm || !(!staticSnapshot || canRenderOverrides);
     }
+    // Remote Compose knobs are daemon-only (Remote Compose has no in-browser runtime), so like
+    // the app-theme selector they're dead in the Wasm lane — an edit would route only through
+    // the daemon path and never touch the visible iframe. Disable them there; otherwise mirror
+    // the server-side gate (enabled iff the host can render an override).
+    document.querySelectorAll(".cp-rc-knob").forEach(function (el) {
+      el.disabled = onWasm || !(!staticSnapshot || canRenderOverrides);
+    });
   }
   // Programmatic switch (the live toggle, or a wasm-only control auto-enabling Wasm): tick the
   // hidden mode radio so its state is consistent, then run the transition.

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-nav-collapsed.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-nav-collapsed.html
@@ -1564,6 +1564,13 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     if (themeProviderEl) {
       themeProviderEl.disabled = onWasm || !(!staticSnapshot || canRenderOverrides);
     }
+    // Remote Compose knobs are daemon-only (Remote Compose has no in-browser runtime), so like
+    // the app-theme selector they're dead in the Wasm lane — an edit would route only through
+    // the daemon path and never touch the visible iframe. Disable them there; otherwise mirror
+    // the server-side gate (enabled iff the host can render an override).
+    document.querySelectorAll(".cp-rc-knob").forEach(function (el) {
+      el.disabled = onWasm || !(!staticSnapshot || canRenderOverrides);
+    });
   }
   // Programmatic switch (the live toggle, or a wasm-only control auto-enabling Wasm): tick the
   // hidden mode radio so its state is consistent, then run the transition.

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-nav-collapsed.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-nav-collapsed.html
@@ -1486,11 +1486,16 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
       // Static snapshot lane: raster PNG, or the vector SVG when the format toggle is on.
       snapshotExt = svgOn() ? ".svg" : ".png";
       if (svgOn()) root.setAttribute("data-mode", "svg");
-      refreshSnapshot();
     }
     syncOverlayToggles();
     syncServerControls();
     updateLiveToggle();
+    // Render the static lane AFTER syncServerControls() has reconciled the daemon-only controls
+    // for the new lane. Returning from Wasm this re-enables the `.cp-rc-knob` inputs first, so
+    // query() includes an rc.* value edited before the Wasm detour in the first snapshot render
+    // (and its direct links) instead of skipping the still-disabled control. The live/wasm lanes
+    // drive their own render (openStream / openWasm), so only the static lane renders here.
+    if (m !== "live" && m !== "wasm") refreshSnapshot();
   }
   // SVG format toggle: swap the static snapshot between raster and vector. Pressing it while a
   // live lane is active drops back to the static vector render; pressing it in the static lane

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
@@ -1562,6 +1562,13 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     if (themeProviderEl) {
       themeProviderEl.disabled = onWasm || !(!staticSnapshot || canRenderOverrides);
     }
+    // Remote Compose knobs are daemon-only (Remote Compose has no in-browser runtime), so like
+    // the app-theme selector they're dead in the Wasm lane — an edit would route only through
+    // the daemon path and never touch the visible iframe. Disable them there; otherwise mirror
+    // the server-side gate (enabled iff the host can render an override).
+    document.querySelectorAll(".cp-rc-knob").forEach(function (el) {
+      el.disabled = onWasm || !(!staticSnapshot || canRenderOverrides);
+    });
   }
   // Programmatic switch (the live toggle, or a wasm-only control auto-enabling Wasm): tick the
   // hidden mode radio so its state is consistent, then run the transition.

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
@@ -1484,11 +1484,16 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
       // Static snapshot lane: raster PNG, or the vector SVG when the format toggle is on.
       snapshotExt = svgOn() ? ".svg" : ".png";
       if (svgOn()) root.setAttribute("data-mode", "svg");
-      refreshSnapshot();
     }
     syncOverlayToggles();
     syncServerControls();
     updateLiveToggle();
+    // Render the static lane AFTER syncServerControls() has reconciled the daemon-only controls
+    // for the new lane. Returning from Wasm this re-enables the `.cp-rc-knob` inputs first, so
+    // query() includes an rc.* value edited before the Wasm detour in the first snapshot render
+    // (and its direct links) instead of skipping the still-disabled control. The live/wasm lanes
+    // drive their own render (openStream / openWasm), so only the static lane renders here.
+    if (m !== "live" && m !== "wasm") refreshSnapshot();
   }
   // SVG format toggle: swap the static snapshot between raster and vector. Pressing it while a
   // live lane is active drops back to the static vector render; pressing it in the static lane

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-states.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-states.html
@@ -1561,6 +1561,13 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     if (themeProviderEl) {
       themeProviderEl.disabled = onWasm || !(!staticSnapshot || canRenderOverrides);
     }
+    // Remote Compose knobs are daemon-only (Remote Compose has no in-browser runtime), so like
+    // the app-theme selector they're dead in the Wasm lane — an edit would route only through
+    // the daemon path and never touch the visible iframe. Disable them there; otherwise mirror
+    // the server-side gate (enabled iff the host can render an override).
+    document.querySelectorAll(".cp-rc-knob").forEach(function (el) {
+      el.disabled = onWasm || !(!staticSnapshot || canRenderOverrides);
+    });
   }
   // Programmatic switch (the live toggle, or a wasm-only control auto-enabling Wasm): tick the
   // hidden mode radio so its state is consistent, then run the transition.

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-states.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-states.html
@@ -1483,11 +1483,16 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
       // Static snapshot lane: raster PNG, or the vector SVG when the format toggle is on.
       snapshotExt = svgOn() ? ".svg" : ".png";
       if (svgOn()) root.setAttribute("data-mode", "svg");
-      refreshSnapshot();
     }
     syncOverlayToggles();
     syncServerControls();
     updateLiveToggle();
+    // Render the static lane AFTER syncServerControls() has reconciled the daemon-only controls
+    // for the new lane. Returning from Wasm this re-enables the `.cp-rc-knob` inputs first, so
+    // query() includes an rc.* value edited before the Wasm detour in the first snapshot render
+    // (and its direct links) instead of skipping the still-disabled control. The live/wasm lanes
+    // drive their own render (openStream / openWasm), so only the static lane renders here.
+    if (m !== "live" && m !== "wasm") refreshSnapshot();
   }
   // SVG format toggle: swap the static snapshot between raster and vector. Pressing it while a
   // live lane is active drops back to the static vector render; pressing it in the static lane

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-themes.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-themes.html
@@ -1567,6 +1567,13 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     if (themeProviderEl) {
       themeProviderEl.disabled = onWasm || !(!staticSnapshot || canRenderOverrides);
     }
+    // Remote Compose knobs are daemon-only (Remote Compose has no in-browser runtime), so like
+    // the app-theme selector they're dead in the Wasm lane — an edit would route only through
+    // the daemon path and never touch the visible iframe. Disable them there; otherwise mirror
+    // the server-side gate (enabled iff the host can render an override).
+    document.querySelectorAll(".cp-rc-knob").forEach(function (el) {
+      el.disabled = onWasm || !(!staticSnapshot || canRenderOverrides);
+    });
   }
   // Programmatic switch (the live toggle, or a wasm-only control auto-enabling Wasm): tick the
   // hidden mode radio so its state is consistent, then run the transition.

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-themes.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-themes.html
@@ -1489,11 +1489,16 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
       // Static snapshot lane: raster PNG, or the vector SVG when the format toggle is on.
       snapshotExt = svgOn() ? ".svg" : ".png";
       if (svgOn()) root.setAttribute("data-mode", "svg");
-      refreshSnapshot();
     }
     syncOverlayToggles();
     syncServerControls();
     updateLiveToggle();
+    // Render the static lane AFTER syncServerControls() has reconciled the daemon-only controls
+    // for the new lane. Returning from Wasm this re-enables the `.cp-rc-knob` inputs first, so
+    // query() includes an rc.* value edited before the Wasm detour in the first snapshot render
+    // (and its direct links) instead of skipping the still-disabled control. The live/wasm lanes
+    // drive their own render (openStream / openWasm), so only the static lane renders here.
+    if (m !== "live" && m !== "wasm") refreshSnapshot();
   }
   // SVG format toggle: swap the static snapshot between raster and vector. Pressing it while a
   // live lane is active drops back to the static vector render; pressing it in the static lane

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-variants.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-variants.html
@@ -1477,11 +1477,16 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
       // Static snapshot lane: raster PNG, or the vector SVG when the format toggle is on.
       snapshotExt = svgOn() ? ".svg" : ".png";
       if (svgOn()) root.setAttribute("data-mode", "svg");
-      refreshSnapshot();
     }
     syncOverlayToggles();
     syncServerControls();
     updateLiveToggle();
+    // Render the static lane AFTER syncServerControls() has reconciled the daemon-only controls
+    // for the new lane. Returning from Wasm this re-enables the `.cp-rc-knob` inputs first, so
+    // query() includes an rc.* value edited before the Wasm detour in the first snapshot render
+    // (and its direct links) instead of skipping the still-disabled control. The live/wasm lanes
+    // drive their own render (openStream / openWasm), so only the static lane renders here.
+    if (m !== "live" && m !== "wasm") refreshSnapshot();
   }
   // SVG format toggle: swap the static snapshot between raster and vector. Pressing it while a
   // live lane is active drops back to the static vector render; pressing it in the static lane

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-variants.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-variants.html
@@ -1555,6 +1555,13 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     if (themeProviderEl) {
       themeProviderEl.disabled = onWasm || !(!staticSnapshot || canRenderOverrides);
     }
+    // Remote Compose knobs are daemon-only (Remote Compose has no in-browser runtime), so like
+    // the app-theme selector they're dead in the Wasm lane — an edit would route only through
+    // the daemon path and never touch the visible iframe. Disable them there; otherwise mirror
+    // the server-side gate (enabled iff the host can render an override).
+    document.querySelectorAll(".cp-rc-knob").forEach(function (el) {
+      el.disabled = onWasm || !(!staticSnapshot || canRenderOverrides);
+    });
   }
   // Programmatic switch (the live toggle, or a wasm-only control auto-enabling Wasm): tick the
   // hidden mode radio so its state is consistent, then run the transition.

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
@@ -1559,6 +1559,13 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     if (themeProviderEl) {
       themeProviderEl.disabled = onWasm || !(!staticSnapshot || canRenderOverrides);
     }
+    // Remote Compose knobs are daemon-only (Remote Compose has no in-browser runtime), so like
+    // the app-theme selector they're dead in the Wasm lane — an edit would route only through
+    // the daemon path and never touch the visible iframe. Disable them there; otherwise mirror
+    // the server-side gate (enabled iff the host can render an override).
+    document.querySelectorAll(".cp-rc-knob").forEach(function (el) {
+      el.disabled = onWasm || !(!staticSnapshot || canRenderOverrides);
+    });
   }
   // Programmatic switch (the live toggle, or a wasm-only control auto-enabling Wasm): tick the
   // hidden mode radio so its state is consistent, then run the transition.

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
@@ -1481,11 +1481,16 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
       // Static snapshot lane: raster PNG, or the vector SVG when the format toggle is on.
       snapshotExt = svgOn() ? ".svg" : ".png";
       if (svgOn()) root.setAttribute("data-mode", "svg");
-      refreshSnapshot();
     }
     syncOverlayToggles();
     syncServerControls();
     updateLiveToggle();
+    // Render the static lane AFTER syncServerControls() has reconciled the daemon-only controls
+    // for the new lane. Returning from Wasm this re-enables the `.cp-rc-knob` inputs first, so
+    // query() includes an rc.* value edited before the Wasm detour in the first snapshot render
+    // (and its direct links) instead of skipping the still-disabled control. The live/wasm lanes
+    // drive their own render (openStream / openWasm), so only the static lane renders here.
+    if (m !== "live" && m !== "wasm") refreshSnapshot();
   }
   // SVG format toggle: swap the static snapshot between raster and vector. Pressing it while a
   // live lane is active drops back to the static vector render; pressing it in the static lane

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
@@ -1550,6 +1550,13 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     if (themeProviderEl) {
       themeProviderEl.disabled = onWasm || !(!staticSnapshot || canRenderOverrides);
     }
+    // Remote Compose knobs are daemon-only (Remote Compose has no in-browser runtime), so like
+    // the app-theme selector they're dead in the Wasm lane — an edit would route only through
+    // the daemon path and never touch the visible iframe. Disable them there; otherwise mirror
+    // the server-side gate (enabled iff the host can render an override).
+    document.querySelectorAll(".cp-rc-knob").forEach(function (el) {
+      el.disabled = onWasm || !(!staticSnapshot || canRenderOverrides);
+    });
   }
   // Programmatic switch (the live toggle, or a wasm-only control auto-enabling Wasm): tick the
   // hidden mode radio so its state is consistent, then run the transition.

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
@@ -1472,11 +1472,16 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
       // Static snapshot lane: raster PNG, or the vector SVG when the format toggle is on.
       snapshotExt = svgOn() ? ".svg" : ".png";
       if (svgOn()) root.setAttribute("data-mode", "svg");
-      refreshSnapshot();
     }
     syncOverlayToggles();
     syncServerControls();
     updateLiveToggle();
+    // Render the static lane AFTER syncServerControls() has reconciled the daemon-only controls
+    // for the new lane. Returning from Wasm this re-enables the `.cp-rc-knob` inputs first, so
+    // query() includes an rc.* value edited before the Wasm detour in the first snapshot render
+    // (and its direct links) instead of skipping the still-disabled control. The live/wasm lanes
+    // drive their own render (openStream / openWasm), so only the static lane renders here.
+    if (m !== "live" && m !== "wasm") refreshSnapshot();
   }
   // SVG format toggle: swap the static snapshot between raster and vector. Pressing it while a
   // live lane is active drops back to the static vector render; pressing it in the static lane

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
@@ -1562,6 +1562,13 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     if (themeProviderEl) {
       themeProviderEl.disabled = onWasm || !(!staticSnapshot || canRenderOverrides);
     }
+    // Remote Compose knobs are daemon-only (Remote Compose has no in-browser runtime), so like
+    // the app-theme selector they're dead in the Wasm lane — an edit would route only through
+    // the daemon path and never touch the visible iframe. Disable them there; otherwise mirror
+    // the server-side gate (enabled iff the host can render an override).
+    document.querySelectorAll(".cp-rc-knob").forEach(function (el) {
+      el.disabled = onWasm || !(!staticSnapshot || canRenderOverrides);
+    });
   }
   // Programmatic switch (the live toggle, or a wasm-only control auto-enabling Wasm): tick the
   // hidden mode radio so its state is consistent, then run the transition.

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
@@ -1484,11 +1484,16 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
       // Static snapshot lane: raster PNG, or the vector SVG when the format toggle is on.
       snapshotExt = svgOn() ? ".svg" : ".png";
       if (svgOn()) root.setAttribute("data-mode", "svg");
-      refreshSnapshot();
     }
     syncOverlayToggles();
     syncServerControls();
     updateLiveToggle();
+    // Render the static lane AFTER syncServerControls() has reconciled the daemon-only controls
+    // for the new lane. Returning from Wasm this re-enables the `.cp-rc-knob` inputs first, so
+    // query() includes an rc.* value edited before the Wasm detour in the first snapshot render
+    // (and its direct links) instead of skipping the still-disabled control. The live/wasm lanes
+    // drive their own render (openStream / openWasm), so only the static lane renders here.
+    if (m !== "live" && m !== "wasm") refreshSnapshot();
   }
   // SVG format toggle: swap the static snapshot between raster and vector. Pressing it while a
   // live lane is active drops back to the static vector render; pressing it in the static lane


### PR DESCRIPTION
## Summary

Follow-up to #2696 (which merged before this fix landed) addressing a Codex **P2** on that PR.

Remote Compose has no in-browser runtime, so an RC knob edit routes only through the daemon path (`setOverrides` for a live stream, or a `/render` refresh) and never updates the visible Wasm iframe. When a preview declares both RC knobs **and** has a Wasm app available (the `serve-viewer-catalog-knobs` case), switching to **In-browser (Wasm)** left the `.cp-rc-knob` controls enabled but inert — editing one changed only the hidden snapshot / direct links, so the visible preview didn't move: a dead-looking control.

## Fix

In `syncServerControls` — the function that already reconciles control enabled-state on every mode transition — disable `.cp-rc-knob` while the Wasm lane is active, exactly like the daemon-only app-theme selector right above it:

```js
document.querySelectorAll(".cp-rc-knob").forEach(function (el) {
  el.disabled = onWasm || !(!staticSnapshot || canRenderOverrides);
});
```

They re-enable when the lane leaves Wasm (back to a daemon/snapshot lane that can honour them).

## Test plan

- `./gradlew :cli:test --tests '*ServeWebFixtureTest*'` — golden drift-guard passes; the serve-web page fixtures are regenerated to carry the updated `syncServerControls` JS.
- ktfmt clean.

Non-visual at rest (the control panel looks the same until you switch to the Wasm lane, where the RC controls now correctly grey out — the same treatment the app-theme selector already gets), so no new before/after images.

---
_Generated by [Claude Code](https://claude.ai/code/session_011K7sgCfdsbhN7fwMb3WhSS)_