### PR TITLE
feat(catalog): drive the M3 catalog inventory from annotations

### DIFF
--- a/samples/design-catalog-m3/catalog.spec.json
+++ b/samples/design-catalog-m3/catalog.spec.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/yschimke/compose-ai-tools/main/scripts/design-artifacts/catalog.spec.schema.json",
-  "$comment": "Phase-0 catalog spec for Compose Material 3. Code-led: this declares the component inventory, grouping, captions, primary modes, and breakpoints the sticker sheet covers, plus the published-kit frame each component seeds from. The kit reference is for the one-off import only — our render is authoritative. Consumed by @design-parity/catalog-export to populate ComponentSource group/caption/reference. A component's `variants` fold extra renders onto the same sticker: the default preview is what the grid shows, and each variant's render becomes a secondary image surfaced when you open the single-component view. A variant is tagged either by `state` (pressed/focused/disabled/off/…) or by named `props` content axes (e.g. `content: icon+label` — the same button with a leading icon vs the label-only default). Interaction/state and content stickers therefore live under their parent instead of a flat 'States' group.",
+  "$comment": "Cover-sheet spec for Compose Material 3. The component inventory — ids, grouping, captions, and per-variant tags — now lives next to the `@Preview`s as `@CatalogComponent` / `@CatalogVariant` annotations (see CatalogPreviews.kt); the design-artifacts export builds the catalog from those. This file carries only the fields that aren't per-component code metadata: the system slug, title, the libraries covered, the primary modes, the documented breakpoints, and the published-kit references seeded for the one-off import (our render stays authoritative). To override or add a component from here, reintroduce a `groups` array — a spec component is layered on top of its matching annotation as a field-level override.",
   "system": "compose-m3",
   "title": "Compose Material 3",
   "library": [
@@ -17,99 +17,5 @@
   "referenceKits": [
     "https://www.figma.com/community/file/1035203688168086460/material-3-design-kit",
     "https://www.figma.com/community/file/1228357783685927211/material-design-3-components"
-  ],
-  "groups": [
-    {
-      "name": "Buttons",
-      "components": [
-        { "componentId": "Button/Filled", "preview": "FilledButton", "caption": "Highest emphasis; the primary action.",
-          "variants": [
-            { "state": "pressed", "preview": "FilledButtonPressed", "caption": "Held PressInteraction → pressed state layer." },
-            { "state": "keyboard-focus", "preview": "FilledButtonFocused", "caption": "Keyboard focus (focus-visible) → M3 inset focus ring. This is the directional/keyboard focus indicator, not the pointer/hover state layer." },
-            { "state": "disabled", "preview": "FilledButtonDisabled", "caption": "Disabled state." },
-            { "props": { "content": "icon+label" }, "preview": "FilledButtonIconLabel", "caption": "Content axis (not a state): leading icon + label, vs the label-only default." },
-            { "props": { "locale": "ar-XB" }, "preview": "FilledButtonPseudo", "caption": "i18n axis: the ar-XB bidi pseudolocale — flips the button to RTL layout so mirroring bugs surface (desktop CMP pseudolocalises layout direction, not text)." },
-            { "props": { "direction": "rtl" }, "preview": "FilledButtonRtl", "caption": "i18n axis: forced RTL layout direction (LocalLayoutDirection = Rtl)." },
-            { "props": { "fontScale": "2.0" }, "preview": "FilledButtonLargeFont", "caption": "Accessibility axis: 2× font scale (LocalDensity fontScale = 2.0) — large-text / dynamic-type stress." }
-          ]
-        },
-        { "componentId": "Button/Tonal", "preview": "FilledTonalButtonSticker", "caption": "Secondary, still prominent." },
-        { "componentId": "Button/Outlined", "preview": "OutlinedButtonSticker", "caption": "Medium emphasis on a busy surface.",
-          "variants": [
-            { "state": "disabled", "preview": "OutlinedButtonDisabled", "caption": "Disabled state." }
-          ]
-        },
-        { "componentId": "Button/Elevated", "preview": "ElevatedButtonSticker", "caption": "Outlined alternative needing separation." },
-        { "componentId": "Button/Text", "preview": "TextButtonSticker", "caption": "Lowest emphasis; inline actions." }
-      ]
-    },
-    {
-      "name": "Selection",
-      "components": [
-        { "componentId": "Checkbox/Checked", "preview": "CheckboxChecked", "caption": "Checked; the unchecked state folds in as an @OverrideVariant (checked = false)." },
-        { "componentId": "Switch/On", "preview": "SwitchOn",
-          "caption": "On; the off state folds in as an @OverrideVariant (checked = false).",
-          "variants": [
-            { "props": { "locale": "ar-XB" }, "preview": "SwitchOnPseudo", "caption": "i18n axis: the ar-XB bidi pseudolocale — flips the row to RTL layout (desktop CMP pseudolocalises layout direction, not text)." },
-            { "props": { "direction": "rtl" }, "preview": "SwitchOnRtl", "caption": "i18n axis: forced RTL layout direction (LocalLayoutDirection = Rtl)." },
-            { "props": { "fontScale": "2.0" }, "preview": "SwitchOnLargeFont", "caption": "Accessibility axis: 2× font scale (LocalDensity fontScale = 2.0) — large-text / dynamic-type stress." }
-          ] },
-        { "componentId": "RadioButton/Selected", "preview": "RadioSelected", "caption": "Selected; the unselected state folds in as an @OverrideVariant (selected = false)." },
-        { "componentId": "Slider", "preview": "SliderMid" },
-        { "componentId": "Chip/Filter-Selected", "preview": "FilterChipSelected", "caption": "Selected; the unselected state folds in as an @OverrideVariant (selected = false)." },
-        { "componentId": "Chip/Assist", "preview": "AssistChipSticker" },
-        { "componentId": "SegmentedButton", "preview": "SegmentedToggle", "caption": "Single-choice toggle: selected + unselected segments." }
-      ]
-    },
-    {
-      "name": "Containment",
-      "components": [
-        { "componentId": "Card/Elevated", "preview": "ElevatedCardSticker" },
-        { "componentId": "Card/Outlined", "preview": "OutlinedCardSticker" },
-        { "componentId": "Card/Filled", "preview": "FilledCardSticker" },
-        {
-          "componentId": "Card/Slots",
-          "preview": "SlottedCardSticker",
-          "caption": "A card with named PreviewSlot regions a structured-screen builder fills.",
-          "variants": [
-            {
-              "state": "slot-mode",
-              "preview": "SlottedCardSlotsSticker",
-              "caption": "Slot mode: each PreviewSlot draws its labelled placeholder."
-            }
-          ]
-        },
-        { "componentId": "FAB", "preview": "FabSticker" }
-      ]
-    },
-    {
-      "name": "Communication",
-      "components": [
-        { "componentId": "Progress/Linear", "preview": "LinearProgressSticker" },
-        { "componentId": "Progress/Circular", "preview": "CircularProgressSticker" },
-        { "componentId": "Badge", "preview": "BadgeSticker" }
-      ]
-    },
-    {
-      "name": "Text fields",
-      "components": [
-        { "componentId": "TextField/Filled", "preview": "TextFieldSticker" },
-        { "componentId": "TextField/Outlined", "preview": "OutlinedTextFieldSticker" }
-      ]
-    },
-    {
-      "name": "Text options",
-      "components": [
-        { "componentId": "Text/MaxLines-Truncated", "preview": "TextMaxLinesTruncated", "caption": "maxLines=2 + ellipsis overflow — exercises the textOverflow product." },
-        { "componentId": "Text/Serif", "preview": "TextSerifSpecimen", "caption": "Generic serif family (Noto Serif) — pins the Wasm tier’s font interception." },
-        { "componentId": "Text/Monospace", "preview": "TextMonospaceSpecimen", "caption": "Generic monospace family (Droid Sans Mono) — pins the Wasm tier’s font interception." }
-      ]
-    },
-    {
-      "name": "Scaffold templates",
-      "components": [
-        { "componentId": "Template/AppScaffold", "preview": "AppScaffoldTemplate", "caption": "Full-screen layout with the OS status bar — TopAppBar, a list, and a FAB, captured with showSystemUi on a phone." }
-      ]
-    }
   ]
 }

--- a/samples/design-catalog-m3/src/main/kotlin/com/example/designcatalogm3/CatalogPreviews.kt
+++ b/samples/design-catalog-m3/src/main/kotlin/com/example/designcatalogm3/CatalogPreviews.kt
@@ -29,6 +29,8 @@ import com.example.designcatalogm3.shared.generated.resources.msg_merged
 import com.example.designcatalogm3.shared.generated.resources.msg_specs
 import com.example.designcatalogm3.shared.generated.resources.template_title
 import ee.schimke.composeai.overrides.previewOverrideString
+import ee.schimke.composeai.preview.CatalogComponent
+import ee.schimke.composeai.preview.CatalogVariant
 import ee.schimke.composeai.preview.OverrideVariant
 import ee.schimke.composeai.preview.slots.LocalSlotMode
 import org.jetbrains.compose.resources.stringResource
@@ -49,22 +51,60 @@ import org.jetbrains.compose.resources.stringResource
 //     stateful widgets — matching what the in-browser wasm tier already does. Hard-coding `false`
 //     left every live-lane click a no-op (the segmented toggle wouldn't flip).
 //
-// Function names are the join key the export driver matches against `catalog.spec.json`'s `preview`
-// field (`PreviewDiscovery` keys off the function name), so they must not change.
+// The catalog identity — component id, group, caption, and per-variant tags — lives on each preview
+// via `@CatalogComponent` / `@CatalogVariant` (compose-ai-tools' catalog-annotations), so it sits
+// next to the composable instead of being restated in `catalog.spec.json`. The design-artifacts
+// export builds the inventory from these annotations; `catalog.spec.json` now carries only the
+// cover-sheet fields (system / title / breakpoints / referenceKits). A `@CatalogVariant.of` names
+// its parent by that parent's `@CatalogComponent.id`, so those ids are the join and must stay
+// stable.
 
 // --- Buttons — the five M3 emphasis levels, plus a disabled state. ---
 
-@CatalogModes @Composable fun FilledButton() = Sticker("button-filled")
+@CatalogComponent(
+  id = "Button/Filled",
+  group = "Buttons",
+  caption = "Highest emphasis; the primary action.",
+)
+@CatalogModes
+@Composable
+fun FilledButton() = Sticker("button-filled")
 
-@CatalogModes @Composable fun FilledTonalButtonSticker() = Sticker("button-tonal")
+@CatalogComponent(id = "Button/Tonal", group = "Buttons", caption = "Secondary, still prominent.")
+@CatalogModes
+@Composable
+fun FilledTonalButtonSticker() = Sticker("button-tonal")
 
-@CatalogModes @Composable fun OutlinedButtonSticker() = Sticker("button-outlined")
+@CatalogComponent(
+  id = "Button/Outlined",
+  group = "Buttons",
+  caption = "Medium emphasis on a busy surface.",
+)
+@CatalogModes
+@Composable
+fun OutlinedButtonSticker() = Sticker("button-outlined")
 
-@CatalogModes @Composable fun ElevatedButtonSticker() = Sticker("button-elevated")
+@CatalogComponent(
+  id = "Button/Elevated",
+  group = "Buttons",
+  caption = "Outlined alternative needing separation.",
+)
+@CatalogModes
+@Composable
+fun ElevatedButtonSticker() = Sticker("button-elevated")
 
-@CatalogModes @Composable fun TextButtonSticker() = Sticker("button-text")
+@CatalogComponent(
+  id = "Button/Text",
+  group = "Buttons",
+  caption = "Lowest emphasis; inline actions.",
+)
+@CatalogModes
+@Composable
+fun TextButtonSticker() = Sticker("button-text")
 
-@CatalogModes @Composable fun FilledButtonDisabled() = Sticker("button-filled-disabled")
+// `FilledButtonDisabled` (a `Button/Filled` variant) is declared in the States section below,
+// between the pressed/focused and content variants, so the annotation-derived variant order matches
+// the sheet's intended order (pressed → keyboard-focus → disabled → content axes).
 
 // --- Selection controls — checked/selected states (the primary mode to show). ---
 
@@ -72,43 +112,90 @@ import org.jetbrains.compose.resources.stringResource
 // the shared `checked` / `selected` knob) rather than a duplicated `*Unchecked` / `*Off` /
 // `*Unselected`
 // wrapper — the render emits a `_VARIANT_<state>` capture that folds under the primary sticker.
+@CatalogComponent(
+  id = "Checkbox/Checked",
+  group = "Selection",
+  caption = "Checked; the unchecked state folds in as an @OverrideVariant (checked = false).",
+)
 @CatalogModes
 @OverrideVariant(name = "unchecked", booleans = ["checked=false"])
 @Composable
 fun CheckboxChecked() = Sticker("checkbox-checked")
 
+@CatalogComponent(
+  id = "Switch/On",
+  group = "Selection",
+  caption = "On; the off state folds in as an @OverrideVariant (checked = false).",
+)
 @CatalogModes
 @OverrideVariant(name = "off", booleans = ["checked=false"])
 @Composable
 fun SwitchOn() = Sticker("switch-on")
 
+@CatalogComponent(
+  id = "RadioButton/Selected",
+  group = "Selection",
+  caption = "Selected; the unselected state folds in as an @OverrideVariant (selected = false).",
+)
 @CatalogModes
 @OverrideVariant(name = "unselected", booleans = ["selected=false"])
 @Composable
 fun RadioSelected() = Sticker("radiobutton-selected")
 
-@CatalogModes @Composable fun SliderMid() = Sticker("slider")
+@CatalogComponent(id = "Slider", group = "Selection")
+@CatalogModes
+@Composable
+fun SliderMid() = Sticker("slider")
 
+@CatalogComponent(
+  id = "Chip/Filter-Selected",
+  group = "Selection",
+  caption = "Selected; the unselected state folds in as an @OverrideVariant (selected = false).",
+)
 @CatalogModes
 @OverrideVariant(name = "unselected", booleans = ["selected=false"])
 @Composable
 fun FilterChipSelected() = Sticker("chip-filter-selected")
 
-@CatalogModes @Composable fun AssistChipSticker() = Sticker("chip-assist")
+@CatalogComponent(id = "Chip/Assist", group = "Selection")
+@CatalogModes
+@Composable
+fun AssistChipSticker() = Sticker("chip-assist")
 
 // --- Containment — cards and the FAB. ---
 
-@CatalogModes @Composable fun ElevatedCardSticker() = Sticker("card-elevated")
+@CatalogComponent(id = "Card/Elevated", group = "Containment")
+@CatalogModes
+@Composable
+fun ElevatedCardSticker() = Sticker("card-elevated")
 
-@CatalogModes @Composable fun OutlinedCardSticker() = Sticker("card-outlined")
+@CatalogComponent(id = "Card/Outlined", group = "Containment")
+@CatalogModes
+@Composable
+fun OutlinedCardSticker() = Sticker("card-outlined")
 
-@CatalogModes @Composable fun FilledCardSticker() = Sticker("card-filled")
+@CatalogComponent(id = "Card/Filled", group = "Containment")
+@CatalogModes
+@Composable
+fun FilledCardSticker() = Sticker("card-filled")
 
 // A slotted card: its regions are `PreviewSlot` markers. The plain sticker renders normally (the
 // markers are no-ops); `SlottedCardSlots` provides `LocalSlotMode = true` so each marker draws its
 // labelled placeholder — the slot map a structured-screen builder fills. Same body, two modes.
-@CatalogModes @Composable fun SlottedCardSticker() = Sticker("card-slots")
+@CatalogComponent(
+  id = "Card/Slots",
+  group = "Containment",
+  caption = "A card with named PreviewSlot regions a structured-screen builder fills.",
+)
+@CatalogModes
+@Composable
+fun SlottedCardSticker() = Sticker("card-slots")
 
+@CatalogVariant(
+  of = "Card/Slots",
+  state = "slot-mode",
+  caption = "Slot mode: each PreviewSlot draws its labelled placeholder.",
+)
 @CatalogModes
 @Composable
 fun SlottedCardSlotsSticker() = CatalogSticker {
@@ -117,47 +204,126 @@ fun SlottedCardSlotsSticker() = CatalogSticker {
   }
 }
 
-@CatalogModes @Composable fun FabSticker() = Sticker("fab")
+@CatalogComponent(id = "FAB", group = "Containment")
+@CatalogModes
+@Composable
+fun FabSticker() = Sticker("fab")
 
 // --- Communication — progress + badge. ---
 
-@CatalogModes @Composable fun LinearProgressSticker() = Sticker("progress-linear")
+@CatalogComponent(id = "Progress/Linear", group = "Communication")
+@CatalogModes
+@Composable
+fun LinearProgressSticker() = Sticker("progress-linear")
 
-@CatalogModes @Composable fun CircularProgressSticker() = Sticker("progress-circular")
+@CatalogComponent(id = "Progress/Circular", group = "Communication")
+@CatalogModes
+@Composable
+fun CircularProgressSticker() = Sticker("progress-circular")
 
-@CatalogModes @Composable fun BadgeSticker() = Sticker("badge")
+@CatalogComponent(id = "Badge", group = "Communication")
+@CatalogModes
+@Composable
+fun BadgeSticker() = Sticker("badge")
 
 // --- Text fields. ---
 
-@CatalogModes @Composable fun TextFieldSticker() = Sticker("textfield-filled")
+@CatalogComponent(id = "TextField/Filled", group = "Text fields")
+@CatalogModes
+@Composable
+fun TextFieldSticker() = Sticker("textfield-filled")
 
-@CatalogModes @Composable fun OutlinedTextFieldSticker() = Sticker("textfield-outlined")
+@CatalogComponent(id = "TextField/Outlined", group = "Text fields")
+@CatalogModes
+@Composable
+fun OutlinedTextFieldSticker() = Sticker("textfield-outlined")
 
 // --- Text options — maxLines + ellipsis overflow, generic-family specimens. ---
 
-@CatalogModes @Composable fun TextMaxLinesTruncated() = Sticker("text-maxlines-truncated")
+@CatalogComponent(
+  id = "Text/MaxLines-Truncated",
+  group = "Text options",
+  caption = "maxLines=2 + ellipsis overflow — exercises the textOverflow product.",
+)
+@CatalogModes
+@Composable
+fun TextMaxLinesTruncated() = Sticker("text-maxlines-truncated")
 
-@CatalogModes @Composable fun TextSerifSpecimen() = Sticker("text-serif")
+@CatalogComponent(
+  id = "Text/Serif",
+  group = "Text options",
+  caption = "Generic serif family (Noto Serif) — pins the Wasm tier’s font interception.",
+)
+@CatalogModes
+@Composable
+fun TextSerifSpecimen() = Sticker("text-serif")
 
-@CatalogModes @Composable fun TextMonospaceSpecimen() = Sticker("text-monospace")
+@CatalogComponent(
+  id = "Text/Monospace",
+  group = "Text options",
+  caption = "Generic monospace family (Droid Sans Mono) — pins the Wasm tier’s font interception.",
+)
+@CatalogModes
+@Composable
+fun TextMonospaceSpecimen() = Sticker("text-monospace")
 
+// `TextBrandedSpecimen` renders but is deliberately NOT in the published catalog inventory (it has
+// no `@CatalogComponent`), matching the pre-annotation spec, which omitted it.
 @CatalogModes @Composable fun TextBrandedSpecimen() = Sticker("text-branded")
 
 // --- States — interaction (pressed / focused), disabled, and toggle off↔on. ---
 
-@CatalogModes @Composable fun FilledButtonPressed() = Sticker("button-filled-pressed")
+@CatalogVariant(
+  of = "Button/Filled",
+  state = "pressed",
+  caption = "Held PressInteraction → pressed state layer.",
+)
+@CatalogModes
+@Composable
+fun FilledButtonPressed() = Sticker("button-filled-pressed")
 
-@CatalogModes @Composable fun FilledButtonFocused() = Sticker("button-filled-focused")
+@CatalogVariant(
+  of = "Button/Filled",
+  state = "keyboard-focus",
+  caption =
+    "Keyboard focus (focus-visible) → M3 inset focus ring. This is the directional/keyboard " +
+      "focus indicator, not the pointer/hover state layer.",
+)
+@CatalogModes
+@Composable
+fun FilledButtonFocused() = Sticker("button-filled-focused")
 
-@CatalogModes @Composable fun FilledButtonIconLabel() = Sticker("button-filled-icon-label")
+@CatalogVariant(of = "Button/Filled", state = "disabled", caption = "Disabled state.")
+@CatalogModes
+@Composable
+fun FilledButtonDisabled() = Sticker("button-filled-disabled")
 
-@CatalogModes @Composable fun OutlinedButtonDisabled() = Sticker("button-outlined-disabled")
+@CatalogVariant(
+  of = "Button/Filled",
+  props = ["content=icon+label"],
+  caption = "Content axis (not a state): leading icon + label, vs the label-only default.",
+)
+@CatalogModes
+@Composable
+fun FilledButtonIconLabel() = Sticker("button-filled-icon-label")
+
+@CatalogVariant(of = "Button/Outlined", state = "disabled", caption = "Disabled state.")
+@CatalogModes
+@Composable
+fun OutlinedButtonDisabled() = Sticker("button-outlined-disabled")
 
 // (`SwitchOff`, `CheckboxUnchecked`, `FilterChipUnselected`, `RadioUnselected` removed — those
 // states now ride their primary selection control via `@OverrideVariant`, seeding the shared
 // `checked` / `selected` knob.)
 
-@CatalogModes @Composable fun SegmentedToggle() = Sticker("segmentedbutton")
+@CatalogComponent(
+  id = "SegmentedButton",
+  group = "Selection",
+  caption = "Single-choice toggle: selected + unselected segments.",
+)
+@CatalogModes
+@Composable
+fun SegmentedToggle() = Sticker("segmentedbutton")
 
 // --- Internationalisation / accessibility axes ---
 //
@@ -181,11 +347,23 @@ fun SlottedCardSlotsSticker() = CatalogSticker {
 //     lockstep at 2.0 (large-text / dynamic-type).
 
 // Button — filled.
+@CatalogVariant(
+  of = "Button/Filled",
+  props = ["locale=ar-XB"],
+  caption =
+    "i18n axis: the ar-XB bidi pseudolocale — flips the button to RTL layout so mirroring bugs " +
+      "surface (desktop CMP pseudolocalises layout direction, not text).",
+)
 @Preview(name = "Light", locale = "ar-XB", group = "modes")
 @Preview(name = "Dark", locale = "ar-XB", uiMode = 32, group = "modes")
 @Composable
 fun FilledButtonPseudo() = Sticker("button-filled")
 
+@CatalogVariant(
+  of = "Button/Filled",
+  props = ["direction=rtl"],
+  caption = "i18n axis: forced RTL layout direction (LocalLayoutDirection = Rtl).",
+)
 @CatalogModes
 @Composable
 fun FilledButtonRtl() =
@@ -193,17 +371,36 @@ fun FilledButtonRtl() =
     Sticker("button-filled")
   }
 
+@CatalogVariant(
+  of = "Button/Filled",
+  props = ["fontScale=2.0"],
+  caption =
+    "Accessibility axis: 2× font scale (LocalDensity fontScale = 2.0) — large-text / dynamic-type " +
+      "stress.",
+)
 @Preview(name = "Light", fontScale = 2f, group = "modes")
 @Preview(name = "Dark", fontScale = 2f, uiMode = 32, group = "modes")
 @Composable
 fun FilledButtonLargeFont() = Sticker("button-filled")
 
 // List row — the on switch (a settings-style selection row).
+@CatalogVariant(
+  of = "Switch/On",
+  props = ["locale=ar-XB"],
+  caption =
+    "i18n axis: the ar-XB bidi pseudolocale — flips the row to RTL layout (desktop CMP " +
+      "pseudolocalises layout direction, not text).",
+)
 @Preview(name = "Light", locale = "ar-XB", group = "modes")
 @Preview(name = "Dark", locale = "ar-XB", uiMode = 32, group = "modes")
 @Composable
 fun SwitchOnPseudo() = Sticker("switch-on")
 
+@CatalogVariant(
+  of = "Switch/On",
+  props = ["direction=rtl"],
+  caption = "i18n axis: forced RTL layout direction (LocalLayoutDirection = Rtl).",
+)
 @CatalogModes
 @Composable
 fun SwitchOnRtl() =
@@ -211,6 +408,13 @@ fun SwitchOnRtl() =
     Sticker("switch-on")
   }
 
+@CatalogVariant(
+  of = "Switch/On",
+  props = ["fontScale=2.0"],
+  caption =
+    "Accessibility axis: 2× font scale (LocalDensity fontScale = 2.0) — large-text / dynamic-type " +
+      "stress.",
+)
 @Preview(name = "Light", fontScale = 2f, group = "modes")
 @Preview(name = "Dark", fontScale = 2f, uiMode = 32, group = "modes")
 @Composable
@@ -265,6 +469,13 @@ private val templateMessages =
  * supplies them itself ([SYSTEM_BAR_INSET]): the app bar paints under the status bar with its title
  * below the OS clock, and the content/FAB clear the gesture pill.
  */
+@CatalogComponent(
+  id = "Template/AppScaffold",
+  group = "Scaffold templates",
+  caption =
+    "Full-screen layout with the OS status bar — TopAppBar, a list, and a FAB, captured with " +
+      "showSystemUi on a phone.",
+)
 @CatalogTemplate
 @Composable
 fun AppScaffoldTemplate() = FullScreenM3 {

--- a/scripts/design-artifacts/catalog-spec.mjs
+++ b/scripts/design-artifacts/catalog-spec.mjs
@@ -281,8 +281,18 @@ export function validateSpec(spec, opts = {}) {
   if (typeof spec.title !== "string" || spec.title.length === 0) {
     errors.push("`title` is required (the human-readable catalog name)");
   }
+  // `groups` is optional: a catalog can supply its whole component inventory from
+  // `@CatalogComponent` / `@CatalogVariant` annotations (compose-ai-tools' catalog-annotations)
+  // and carry only cover-sheet fields here. An ABSENT `groups` therefore validates — the
+  // annotation-derived inventory is checked at render time (generate-design-catalog.mjs reports
+  // any `@CatalogVariant` whose parent has no `@CatalogComponent`). When `groups` IS present it
+  // must be a non-empty array (an explicit `[]` is a mistake, not "annotation-supplied") and is
+  // validated in full below.
+  if (spec.groups === undefined) {
+    return { errors, warnings };
+  }
   if (!Array.isArray(spec.groups) || spec.groups.length === 0) {
-    errors.push("`groups` must be a non-empty array");
+    errors.push("`groups`, when present, must be a non-empty array");
     return { errors, warnings };
   }
 

--- a/scripts/design-artifacts/catalog-spec.mjs
+++ b/scripts/design-artifacts/catalog-spec.mjs
@@ -197,6 +197,17 @@ export function discoverPreviews(sources, opts = {}) {
   };
 }
 
+/**
+ * True when any source declares a `@CatalogComponent` — i.e. the module supplies (at least part of)
+ * its catalog inventory from annotations rather than the spec. Lets a caller with source access tell
+ * [validateSpec] (via `annotatedInventory`) to reject a `groups`-less spec that ALSO has no
+ * annotated inventory (which would otherwise pass validation, render, then crash at the join).
+ * Comments are stripped first so a commented-out or prose mention doesn't count.
+ */
+export function hasCatalogAnnotations(sources) {
+  return sources.some((s) => /@CatalogComponent\b/.test(stripComments(s)));
+}
+
 /** Every `preview` a spec references, top-level and inside `variants`, each with
  *  a human-readable JSON-ish path for diagnostics. */
 export function specPreviewRefs(spec) {
@@ -283,12 +294,20 @@ export function validateSpec(spec, opts = {}) {
   }
   // `groups` is optional: a catalog can supply its whole component inventory from
   // `@CatalogComponent` / `@CatalogVariant` annotations (compose-ai-tools' catalog-annotations)
-  // and carry only cover-sheet fields here. An ABSENT `groups` therefore validates — the
-  // annotation-derived inventory is checked at render time (generate-design-catalog.mjs reports
-  // any `@CatalogVariant` whose parent has no `@CatalogComponent`). When `groups` IS present it
-  // must be a non-empty array (an explicit `[]` is a mistake, not "annotation-supplied") and is
-  // validated in full below.
+  // and carry only cover-sheet fields here. An ABSENT `groups` therefore validates — UNLESS the
+  // caller passed `annotatedInventory: false` (it scanned the module and found no
+  // `@CatalogComponent`), in which case the catalog has no inventory at all and would render then
+  // crash, so fail here with a clear message. When the caller can't tell (`annotatedInventory`
+  // undefined, e.g. the structural-only CLI path), stay lenient. When `groups` IS present it must
+  // be a non-empty array (an explicit `[]` is a mistake, not "annotation-supplied").
   if (spec.groups === undefined) {
+    if (opts.annotatedInventory === false) {
+      errors.push(
+        "`groups` is omitted but the module declares no @CatalogComponent — the catalog has no " +
+          "inventory. Declare `groups`, or add @CatalogComponent / @CatalogVariant to the module's " +
+          "@Preview functions.",
+      );
+    }
     return { errors, warnings };
   }
   if (!Array.isArray(spec.groups) || spec.groups.length === 0) {

--- a/scripts/design-artifacts/catalog-spec.test.mjs
+++ b/scripts/design-artifacts/catalog-spec.test.mjs
@@ -134,13 +134,30 @@ test("validateSpec flags structural problems", () => {
 
 test("validateSpec accepts a cover-sheet spec with no groups (annotation-supplied inventory)", () => {
   // A catalog whose inventory lives in `@CatalogComponent` / `@CatalogVariant` annotations carries
-  // only cover-sheet fields; an absent `groups` must validate cleanly.
+  // only cover-sheet fields; an absent `groups` must validate cleanly when the module is annotated.
   const { errors, warnings } = validateSpec(
     { system: "compose-m3", title: "Compose Material 3" },
-    { knownPreviews: ["FilledButton", "SwitchOn"] },
+    { knownPreviews: ["FilledButton", "SwitchOn"], annotatedInventory: true },
   );
   assert.deepEqual(errors, []);
   assert.deepEqual(warnings, []);
+});
+
+test("validateSpec rejects a no-groups spec when the module has no @CatalogComponent", () => {
+  // Caller scanned the module and found no annotated inventory, so a `groups`-less spec has no
+  // components at all — reject early instead of rendering then crashing at the join.
+  const { errors } = validateSpec(
+    { system: "compose-m3", title: "Compose Material 3" },
+    { knownPreviews: ["FilledButton"], annotatedInventory: false },
+  );
+  assert.ok(errors.some((e) => e.includes("the catalog has no")));
+});
+
+test("validateSpec stays lenient on a no-groups spec when annotation state is unknown", () => {
+  // Structural-only path (no source access): don't reject — the render-time generator guard is the
+  // backstop for a genuinely empty inventory.
+  const { errors } = validateSpec({ system: "s", title: "t" });
+  assert.deepEqual(errors, []);
 });
 
 test("validateSpec flags duplicate componentId and warns on folded preview", () => {

--- a/scripts/design-artifacts/catalog-spec.test.mjs
+++ b/scripts/design-artifacts/catalog-spec.test.mjs
@@ -128,7 +128,19 @@ test("validateSpec flags structural problems", () => {
   const { errors } = validateSpec({ groups: [] });
   assert.ok(errors.some((e) => e.includes("`system` is required")));
   assert.ok(errors.some((e) => e.includes("`title` is required")));
-  assert.ok(errors.some((e) => e.includes("`groups` must be a non-empty array")));
+  // An explicit empty `groups` is a mistake, not "annotation-supplied".
+  assert.ok(errors.some((e) => e.includes("`groups`, when present, must be a non-empty array")));
+});
+
+test("validateSpec accepts a cover-sheet spec with no groups (annotation-supplied inventory)", () => {
+  // A catalog whose inventory lives in `@CatalogComponent` / `@CatalogVariant` annotations carries
+  // only cover-sheet fields; an absent `groups` must validate cleanly.
+  const { errors, warnings } = validateSpec(
+    { system: "compose-m3", title: "Compose Material 3" },
+    { knownPreviews: ["FilledButton", "SwitchOn"] },
+  );
+  assert.deepEqual(errors, []);
+  assert.deepEqual(warnings, []);
 });
 
 test("validateSpec flags duplicate componentId and warns on folded preview", () => {

--- a/scripts/design-artifacts/catalog.spec.schema.json
+++ b/scripts/design-artifacts/catalog.spec.schema.json
@@ -4,7 +4,7 @@
   "title": "Design catalog spec",
   "description": "Code-led design-catalog spec: declares which @Preview composables (by function name) make up a published sticker sheet, their grouping, sections, captions, and per-component variants. Consumed by scripts/design-artifacts/generate-design-catalog.mjs over a `compose-preview bundle pack` render. Each `preview` MUST equal an exact @Preview function name in the rendered module; validate before rendering with `node scripts/design-artifacts/validate-catalog-spec.mjs`.",
   "type": "object",
-  "required": ["system", "title", "groups"],
+  "required": ["system", "title"],
   "additionalProperties": false,
   "properties": {
     "$schema": { "type": "string" },
@@ -71,8 +71,7 @@
     },
     "groups": {
       "type": "array",
-      "minItems": 1,
-      "description": "The component inventory, grouped. Group order is the display order.",
+      "description": "The component inventory, grouped. Group order is the display order. OPTIONAL: a catalog can instead declare its inventory with `@CatalogComponent` / `@CatalogVariant` annotations next to the `@Preview`s (the design-artifacts export builds the inventory from them, layering any groups declared here on top as an override). Absent ⇒ the inventory is wholly annotation-supplied.",
       "items": { "$ref": "#/definitions/group" }
     }
   },

--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -508,6 +508,21 @@ if (annotationGroups.length > 0) {
   );
 }
 
+// Zero effective inventory: the spec declares no `groups` AND the render carried no
+// `@CatalogComponent` annotations (an author forgot them, or the render ran with a CLI/plugin that
+// predates catalog metadata). Fail here with a clear, actionable message rather than letting the
+// join iterate an undefined `spec.groups` and die with a late TypeError after the expensive render.
+if (!Array.isArray(spec.groups) || spec.groups.length === 0) {
+  console.error(
+    `[${spec.system}] no catalog inventory: catalog.spec.json declares no \`groups\` and the ` +
+      `render carried no @CatalogComponent annotations. Add @CatalogComponent / @CatalogVariant to ` +
+      `the module's @Preview functions, or declare \`groups\` in the spec. (If the render is right ` +
+      `but the metadata is missing, the CLI/plugin that produced this bundle may predate ` +
+      `catalog-annotations discovery.)`,
+  );
+  process.exit(1);
+}
+
 // System tokens declared via `@ColorCatalog` / `@TypographyCatalog` — carried in the
 // bundle as `previews/<id>.catalog.json` sidecars (compose-ai-tools#2167), which the
 // screen-render `compose/theme` never sees (an ad-hoc palette / type scale has no

--- a/scripts/design-artifacts/validate-catalog-spec.mjs
+++ b/scripts/design-artifacts/validate-catalog-spec.mjs
@@ -14,7 +14,7 @@
 import { readFile } from "node:fs/promises";
 import { parseArgs } from "node:util";
 
-import { discoverPreviews, validateSpec } from "./catalog-spec.mjs";
+import { discoverPreviews, hasCatalogAnnotations, validateSpec } from "./catalog-spec.mjs";
 import { resolveSourceDirs, collectKotlinSources } from "./catalog-spec-io.mjs";
 
 const { values } = parseArgs({
@@ -51,6 +51,7 @@ try {
 const srcDirs = values["module-dir"] ? [values["module-dir"], ...(values.src ?? [])] : values.src;
 
 let knownPreviews = null;
+let annotatedInventory = undefined;
 let scannedDirs = [];
 if (!values["no-scan"]) {
   scannedDirs = resolveSourceDirs({ srcDirs, spec, specPath: values.spec });
@@ -60,10 +61,16 @@ if (!values["no-scan"]) {
       extraAnnotations: values["preview-annotation"] ?? [],
     });
     knownPreviews = previews;
+    // Only meaningful when a module was scanned; leaves `annotatedInventory` undefined (lenient) on
+    // the structural-only path so a no-groups spec isn't wrongly rejected without source access.
+    annotatedInventory = hasCatalogAnnotations(sources);
   }
 }
 
-const { errors, warnings } = validateSpec(spec, knownPreviews ? { knownPreviews } : {});
+const { errors, warnings } = validateSpec(spec, {
+  ...(knownPreviews ? { knownPreviews } : {}),
+  ...(annotatedInventory !== undefined ? { annotatedInventory } : {}),
+});
 
 if (values.json) {
   console.log(

--- a/scripts/design-artifacts/validate-samples.test.mjs
+++ b/scripts/design-artifacts/validate-samples.test.mjs
@@ -10,7 +10,7 @@ import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
 import { readFile } from "node:fs/promises";
 
-import { discoverPreviews, validateSpec } from "./catalog-spec.mjs";
+import { discoverPreviews, hasCatalogAnnotations, validateSpec } from "./catalog-spec.mjs";
 import { moduleToDir, collectKotlinSources } from "./catalog-spec-io.mjs";
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
@@ -31,7 +31,12 @@ for (const rel of SAMPLE_SPECS) {
     const sources = await collectKotlinSources([moduleDir]);
     const { previews } = discoverPreviews(sources);
     assert.ok(previews.length > 0, `discovered no @Preview functions for ${rel}`);
-    const { errors } = validateSpec(spec, { knownPreviews: previews });
+    // Pass whether the module carries @CatalogComponent annotations, so a cover-sheet-only spec
+    // (no `groups`) is accepted iff its inventory really is annotation-supplied.
+    const { errors } = validateSpec(spec, {
+      knownPreviews: previews,
+      annotatedInventory: hasCatalogAnnotations(sources),
+    });
     assert.deepEqual(errors, [], `${rel} has spec errors:\n${errors.join("\n")}`);
   });
 }


### PR DESCRIPTION
## Summary

Phase 3 — migrate `design-catalog-m3` to the catalog-annotations flow (Phase 1 [#2680], Phase 2 [#2688], both merged; the annotations shipped in release `0.17.14`).

Every component and variant now declares its identity **next to the `@Preview`** via `@CatalogComponent` / `@CatalogVariant` (id, group, caption, state/props), and `catalog.spec.json` is trimmed from 115 lines to just the cover-sheet fields (system, title, library, module, modes, breakpoints, referenceKits). The design-artifacts export builds the inventory from the annotations.

```kotlin
@CatalogComponent(id = "Button/Filled", group = "Buttons", caption = "Highest emphasis; the primary action.")
@CatalogModes @Composable fun FilledButton() = Sticker("button-filled")

@CatalogVariant(of = "Button/Filled", state = "pressed", caption = "Held PressInteraction → pressed state layer.")
@CatalogModes @Composable fun FilledButtonPressed() = Sticker("button-filled-pressed")
```

### Schema / validate
`groups` is now **optional** in the schema and `validateSpec`: a catalog whose inventory is wholly annotation-supplied validates with cover-sheet fields alone. An explicit empty `groups` is still flagged (a mistake, not "annotation-supplied").

## Verified output-equivalent (in-session)

This changes where the inventory lives, **not** the published catalog. I proved the chain end-to-end without a full render diff:

1. **Discovery writes it** — ran `:samples:design-catalog-m3:composePreviewDiscover`; every preview's resolved `catalog` lands in `previews.json`.
2. **Inventory matches the old spec exactly** — `inventoryFromPreviews(previews.json)` deep-equals the pre-trim `catalog.spec.json` groups: same group order, component order, captions, variant `state`/`props`, and **zero orphan variants**. (Fixed one ordering nit — moved `FilledButtonDisabled`'s declaration so its variant sorts pressed → keyboard-focus → disabled, matching the sheet.)
3. **The export sees the same data** — `@design-parity/candidate`'s `readPreviewBundle` sets `bundle.previews = previews.json.previews` verbatim (`bundle.js:115`), so the new `catalog` field is preserved and `catalogFromCandidates` receives an identical inventory.
4. **Pixels unchanged** — no `@Preview` body changed, so the rendered stickers are pixel-identical; only the inventory's *source* moved from JSON to code. (`TextBrandedSpecimen` stays un-annotated — it renders but was never in the published spec, so it stays out of the inventory as before.)

That's why this is text-only evidence: the sticker sheet doesn't change, and the delivery-branch re-render after merge will reproduce the same `catalog.json`.

## Test plan
- [x] `:samples:design-catalog-m3:composePreviewDiscover` + inventory equivalence check (annotation inventory == old spec, byte-for-byte on the normalized groups)
- [x] `:samples:design-catalog-m3:ktfmtCheckMain`
- [x] `node --test` in `scripts/design-artifacts` — **204 pass** (incl. the trimmed m3 spec resolving through `validate-samples`, and a new `validateSpec` case for a cover-sheet-only spec)
- [x] `readPreviewBundle` field-preservation confirmed by source

## Post-merge
Dispatch `design-artifacts.yml` (ref `main`) to regenerate the `design-artifacts/compose-m3` delivery branch — it should reproduce the same catalog. Wear / remote / shared catalogs migrate the same way as fast-follows.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KgsC1iTXvfJpJ6LBUe21R6)_