### PR TITLE
feat(serve): web-mode figma-svg that references Google Fonts instead of embedding

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeFigmaSvg.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeFigmaSvg.kt
@@ -45,6 +45,83 @@ internal fun inlineFigmaRasters(fileSystem: FileSystem, dir: Path, svg: String):
   }
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Web mode (`?mode=web`)
+//
+// The default served figma-svg is self-contained: fonts base64-embedded as `@font-face`, rasters
+// inlined as `data:` URIs — right for pasting into Figma (its importer resolves fonts by family
+// name and can't fetch external hrefs) but heavy, and it duplicates the font bytes into every
+// sticker. A **web/document** viewer that opens the `.svg` URL directly (not as an `<img>`, where
+// browsers block external refs in secure-static mode) can instead pull the faces from Google Fonts.
+//
+// [webModeSvg] rewrites an embedded SVG for that context: it strips the base64 `@font-face` blocks
+// and injects a single `@import url('https://fonts.googleapis.com/css2?family=…')` covering exactly
+// the families/weights/italics the SVG uses (the `<text>` still carry those family names, so the
+// browser resolves them from the imported sheet). Rasters are left as-is (still inlined) for now —
+// referencing the per-node crops needs an HTTP route to serve them, a separate step.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** One `@font-face` the SVG embeds, reduced to what a Google Fonts `css2` request needs. */
+internal data class WebFontFace(val family: String, val weight: Int, val italic: Boolean)
+
+private val FONT_FACE_BLOCK = Regex("@font-face\\{[^}]*\\}")
+
+/**
+ * Rewrite an embedded figma-svg for web/document viewing: replace the base64 `@font-face` blocks
+ * with an external Google Fonts `@import`, so the browser fetches the faces instead of the SVG
+ * carrying their bytes. A vector-only SVG, or one with no parseable `@font-face`, passes through
+ * unchanged. Rasters are untouched (still inlined). Pure — unit-testable without a served host.
+ */
+internal fun webModeSvg(svg: String): String {
+  val faces = FONT_FACE_BLOCK.findAll(svg).mapNotNull { parseWebFontFace(it.value) }.toList()
+  if (faces.isEmpty()) return svg
+  val importUrl = googleFontsImportUrl(faces) ?: return svg
+  // Drop every embedded face, then put the @import at the head of the first <style> (CSS requires
+  // `@import` before other rules; the base64 bytes are what bloated the sticker, so this is the
+  // win).
+  val stripped = FONT_FACE_BLOCK.replace(svg, "")
+  return stripped.replaceFirst("<style>", "<style>@import url('$importUrl');")
+}
+
+/**
+ * Parse `@font-face{font-family:'X';font-style:normal;font-weight:N;src:…}` into a [WebFontFace].
+ */
+private fun parseWebFontFace(block: String): WebFontFace? {
+  val family =
+    Regex("font-family:'([^']*)'").find(block)?.groupValues?.get(1)?.takeIf { it.isNotBlank() }
+      ?: return null
+  val weight = Regex("font-weight:(\\d+)").find(block)?.groupValues?.get(1)?.toIntOrNull() ?: 400
+  val italic = block.contains("font-style:italic")
+  return WebFontFace(family, weight, italic)
+}
+
+/**
+ * Build a single Google Fonts `css2` URL for [faces], grouped by family with sorted, de-duplicated
+ * weights (and the `ital,wght` axis when a family carries any italic). Generic families
+ * (`sans-serif` / `serif` / `monospace` / …) are skipped — they aren't Google Fonts. Null when
+ * nothing references a real family.
+ */
+internal fun googleFontsImportUrl(faces: List<WebFontFace>): String? {
+  val generics = setOf("sans-serif", "serif", "monospace", "cursive", "fantasy", "system-ui")
+  val byFamily =
+    faces.filter { it.family.lowercase() !in generics }.groupBy { it.family }.toSortedMap()
+  if (byFamily.isEmpty()) return null
+  val families = byFamily.map { (family, fs) ->
+    val enc = family.trim().replace(" ", "+")
+    if (fs.any { it.italic }) {
+      val tuples =
+        fs
+          .map { (if (it.italic) 1 else 0) to it.weight }
+          .distinct()
+          .sortedWith(compareBy({ it.first }, { it.second }))
+      "family=$enc:ital,wght@" + tuples.joinToString(";") { "${it.first},${it.second}" }
+    } else {
+      "family=$enc:wght@" + fs.map { it.weight }.distinct().sorted().joinToString(";")
+    }
+  }
+  return "https://fonts.googleapis.com/css2?" + families.joinToString("&") + "&display=swap"
+}
+
 /**
  * True when this path is [root] or a descendant of it (both normalized) — traversal containment.
  */

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeFigmaSvg.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeFigmaSvg.kt
@@ -76,11 +76,15 @@ internal fun webModeSvg(svg: String): String {
   val faces = FONT_FACE_BLOCK.findAll(svg).mapNotNull { parseWebFontFace(it.value) }.toList()
   if (faces.isEmpty()) return svg
   val importUrl = googleFontsImportUrl(faces) ?: return svg
+  // The URL's `&` separators (`&family=`, `&display=swap`) are XML entity starts inside the
+  // `<style>` text of an `image/svg+xml` document, so escape them — the XML parser decodes `&amp;`
+  // back to `&` before the CSS parser sees the `@import`, keeping the served SVG well-formed.
+  val importUrlXml = importUrl.replace("&", "&amp;")
   // Drop every embedded face, then put the @import at the head of the first <style> (CSS requires
   // `@import` before other rules; the base64 bytes are what bloated the sticker, so this is the
   // win).
   val stripped = FONT_FACE_BLOCK.replace(svg, "")
-  return stripped.replaceFirst("<style>", "<style>@import url('$importUrl');")
+  return stripped.replaceFirst("<style>", "<style>@import url('$importUrlXml');")
 }
 
 /**

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -1257,7 +1257,21 @@ class ServeHttpServer(
             // preview (compose/figma-svg-long) instead of the viewport-sized one.
             val scroll =
               call.request.queryParameters["scroll"]?.lowercase() in setOf("long", "full", "page")
-            renderSvgResponse(renderHost, previewId, parsed.overrides, scroll = scroll)
+            // `?mode=web` serves a web/document variant: the base64 `@font-face` blocks are swapped
+            // for an external Google Fonts `@import`, so a browser viewing the `.svg` directly
+            // pulls
+            // the faces from Google instead of the SVG carrying their bytes. The default (no
+            // `mode`,
+            // or `mode=figma`) stays fully self-contained — right for `<img>`/Figma import, where
+            // external references don't load.
+            val webMode = call.request.queryParameters["mode"]?.lowercase() == "web"
+            renderSvgResponse(
+              renderHost,
+              previewId,
+              parsed.overrides,
+              scroll = scroll,
+              webMode = webMode,
+            )
             return@withLeasedSession
           }
           if (wantSlots) {
@@ -1318,6 +1332,7 @@ class ServeHttpServer(
     previewId: String,
     overrides: PreviewOverrides,
     scroll: Boolean = false,
+    webMode: Boolean = false,
   ) {
     val outcome =
       withContext(Dispatchers.IO) {
@@ -1340,8 +1355,14 @@ class ServeHttpServer(
           status = HttpStatusCode.ServiceUnavailable,
         )
       }
-      is SvgOutcome.Ok ->
-        call.respondBytes(outcome.svg, ContentType.parse(ComposeFigmaSvgProduct.MEDIA_TYPE_SVG))
+      is SvgOutcome.Ok -> {
+        // The render host produces the self-contained (embedded) SVG and caches it; the web variant
+        // is a cheap per-response rewrite of those bytes, so both modes share one render + cache.
+        val svg =
+          if (webMode) webModeSvg(outcome.svg.toString(Charsets.UTF_8)).toByteArray(Charsets.UTF_8)
+          else outcome.svg
+        call.respondBytes(svg, ContentType.parse(ComposeFigmaSvgProduct.MEDIA_TYPE_SVG))
+      }
       SvgOutcome.NotFound -> call.respondText("no such preview", status = HttpStatusCode.NotFound)
       is SvgOutcome.Failed ->
         call.respondText(outcome.reason, status = HttpStatusCode.InternalServerError)

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -2841,14 +2841,28 @@ object ServeWeb {
         return location.origin + base + "/render/" + encodeURIComponent(previewId) + ext +
           (qs ? "?" + qs : "");
       }
+      function withMode(url, mode) {
+        return url + (url.indexOf("?") >= 0 ? "&" : "?") + "mode=" + mode;
+      }
       function refreshLinks() {
         [["png", ".png"], ["svg", ".svg"]].forEach(function (pair) {
           var field = document.getElementById("cp-url-" + pair[0]);
           if (!field) return;
-          var url = renderUrl(pair[1]);
-          field.value = url;
+          var embed = renderUrl(pair[1]);
           var dl = document.getElementById("cp-dl-" + pair[0]);
-          if (dl) dl.href = url;
+          if (pair[1] === ".svg") {
+            // Copy URL yields the web/document variant (`?mode=web` → external Google Fonts
+            // @import), so opening the copied link in a browser pulls the faces from Google. Copy
+            // SVG and the download stay on the embedded variant (self-contained — right for pasting
+            // into Figma or an <img>, where external refs don't load); the button reads it from
+            // data-embed-url.
+            field.value = withMode(embed, "web");
+            field.setAttribute("data-embed-url", embed);
+            if (dl) dl.href = embed;
+          } else {
+            field.value = embed;
+            if (dl) dl.href = embed;
+          }
         });
       }
       // Click the read-only URL field to copy the /render URL to the clipboard (no separate button).
@@ -2885,14 +2899,18 @@ object ServeWeb {
           };
           if (!navigator.clipboard || !navigator.clipboard.writeText) { reset("No clipboard"); return; }
           btn.textContent = "Copying…";
+          // Copy SVG targets the EMBEDDED variant (data-embed-url) — the field itself holds the
+          // web-mode URL for Copy URL, but a copied SVG is usually pasted into Figma / an editor,
+          // which needs the fonts baked in, not an external @import. PNG has one variant.
+          var src = (ext === ".svg" && field.getAttribute("data-embed-url")) || field.value;
           // fetch() resolves even on a non-2xx render (503 saturated, 400 bad override, 404 a
           // preview that can't export that lane), so guard on r.ok — otherwise the error body,
           // not the artefact, would land on the clipboard and still report "Copied".
           var okOrThrow = function (r) { if (!r.ok) throw new Error("render " + r.status); return r; };
           var toText =
             ext === ".svg"
-              ? fetch(field.value).then(okOrThrow).then(function (r) { return r.text(); })
-              : fetch(field.value)
+              ? fetch(src).then(okOrThrow).then(function (r) { return r.text(); })
+              : fetch(src)
                   .then(okOrThrow)
                   .then(function (r) { return r.blob(); })
                   .then(function (blob) {

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeFigmaSvgWebModeTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeFigmaSvgWebModeTest.kt
@@ -29,12 +29,15 @@ class ServeFigmaSvgWebModeTest {
     // No base64 font bytes survive.
     assertFalse(out.contains("base64,"))
     assertFalse(out.contains("@font-face"))
-    // A single @import covers both weights of the one family.
+    // A single @import covers both weights of the one family; the URL's `&` is XML-escaped so the
+    // image/svg+xml document stays well-formed (no raw `&` entity starts).
     assertTrue(
       out.contains(
-        "@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;500&display=swap');"
+        "@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;500&amp;display=swap');"
       )
     )
+    // The raw (unescaped) separator must not appear — that would be a malformed entity start.
+    assertFalse(out.contains("&display=swap"))
     // The text node's family is untouched, so the browser resolves it from the imported sheet.
     assertTrue(out.contains("font-family=\"Roboto\""))
   }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeFigmaSvgWebModeTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeFigmaSvgWebModeTest.kt
@@ -1,0 +1,96 @@
+package ee.schimke.composeai.cli.serve
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for the `?mode=web` figma-svg transform ([webModeSvg] / [googleFontsImportUrl]): the
+ * base64 `@font-face` blocks a self-contained export embeds are swapped for an external Google
+ * Fonts `@import`, so a browser viewing the `.svg` directly pulls the faces from Google. Pure
+ * string transform — no served host needed.
+ */
+class ServeFigmaSvgWebModeTest {
+
+  private fun face(family: String, weight: Int, italic: Boolean = false, b64: String = "AAAA") =
+    "@font-face{font-family:'$family';font-style:${if (italic) "italic" else "normal"};" +
+      "font-weight:$weight;src:url(data:font/woff2;base64,$b64)format('woff2');}"
+
+  private fun svg(vararg faces: String, body: String = "<text font-family=\"Roboto\">Hi</text>") =
+    "<svg xmlns=\"http://www.w3.org/2000/svg\"><defs><style>${faces.joinToString("")}" +
+      "</style></defs>$body</svg>"
+
+  @Test
+  fun `webModeSvg strips embedded faces and injects a Google Fonts import`() {
+    val input = svg(face("Roboto", 400), face("Roboto", 500))
+    val out = webModeSvg(input)
+    // No base64 font bytes survive.
+    assertFalse(out.contains("base64,"))
+    assertFalse(out.contains("@font-face"))
+    // A single @import covers both weights of the one family.
+    assertTrue(
+      out.contains(
+        "@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;500&display=swap');"
+      )
+    )
+    // The text node's family is untouched, so the browser resolves it from the imported sheet.
+    assertTrue(out.contains("font-family=\"Roboto\""))
+  }
+
+  @Test
+  fun `webModeSvg leaves a vector-only svg untouched`() {
+    val input = "<svg><text font-family=\"Roboto, sans-serif\">Hi</text></svg>"
+    assertEquals(input, webModeSvg(input))
+  }
+
+  @Test
+  fun `googleFontsImportUrl groups families, sorts and dedups weights`() {
+    val url =
+      googleFontsImportUrl(
+        listOf(
+          WebFontFace("Space Grotesk", 600, false),
+          WebFontFace("Orbitron", 700, false),
+          WebFontFace("Orbitron", 500, false),
+          WebFontFace("Orbitron", 500, false), // dup
+        )
+      )
+    // Families alphabetical; spaces → +; weights sorted & de-duplicated.
+    assertEquals(
+      "https://fonts.googleapis.com/css2?family=Orbitron:wght@500;700&family=Space+Grotesk:wght@600&display=swap",
+      url,
+    )
+  }
+
+  @Test
+  fun `googleFontsImportUrl uses the ital,wght axis when a family has any italic`() {
+    val url =
+      googleFontsImportUrl(
+        listOf(WebFontFace("Inter", 400, italic = false), WebFontFace("Inter", 700, italic = true))
+      )
+    assertEquals(
+      "https://fonts.googleapis.com/css2?family=Inter:ital,wght@0,400;1,700&display=swap",
+      url,
+    )
+  }
+
+  @Test
+  fun `generic families are not sent to Google Fonts`() {
+    assertNull(googleFontsImportUrl(listOf(WebFontFace("sans-serif", 400, false))))
+    // A mix keeps only the real family.
+    val url =
+      googleFontsImportUrl(
+        listOf(WebFontFace("monospace", 400, false), WebFontFace("Roboto Mono", 500, false))
+      )
+    assertEquals("https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@500&display=swap", url)
+  }
+
+  @Test
+  fun `webModeSvg with only generic faces keeps the svg self-describing (no import, faces dropped)`() {
+    // A `sans-serif` @font-face (Roboto stand-in) yields no Google URL, so the transform makes no
+    // claim it can't back — it returns the input unchanged rather than emit a broken @import.
+    val input = svg(face("sans-serif", 400))
+    assertEquals(input, webModeSvg(input))
+  }
+}

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
@@ -1028,14 +1028,28 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     return location.origin + base + "/render/" + encodeURIComponent(previewId) + ext +
       (qs ? "?" + qs : "");
   }
+  function withMode(url, mode) {
+    return url + (url.indexOf("?") >= 0 ? "&" : "?") + "mode=" + mode;
+  }
   function refreshLinks() {
     [["png", ".png"], ["svg", ".svg"]].forEach(function (pair) {
       var field = document.getElementById("cp-url-" + pair[0]);
       if (!field) return;
-      var url = renderUrl(pair[1]);
-      field.value = url;
+      var embed = renderUrl(pair[1]);
       var dl = document.getElementById("cp-dl-" + pair[0]);
-      if (dl) dl.href = url;
+      if (pair[1] === ".svg") {
+        // Copy URL yields the web/document variant (`?mode=web` → external Google Fonts
+        // @import), so opening the copied link in a browser pulls the faces from Google. Copy
+        // SVG and the download stay on the embedded variant (self-contained — right for pasting
+        // into Figma or an <img>, where external refs don't load); the button reads it from
+        // data-embed-url.
+        field.value = withMode(embed, "web");
+        field.setAttribute("data-embed-url", embed);
+        if (dl) dl.href = embed;
+      } else {
+        field.value = embed;
+        if (dl) dl.href = embed;
+      }
     });
   }
   // Click the read-only URL field to copy the /render URL to the clipboard (no separate button).
@@ -1072,14 +1086,18 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
       };
       if (!navigator.clipboard || !navigator.clipboard.writeText) { reset("No clipboard"); return; }
       btn.textContent = "Copying…";
+      // Copy SVG targets the EMBEDDED variant (data-embed-url) — the field itself holds the
+      // web-mode URL for Copy URL, but a copied SVG is usually pasted into Figma / an editor,
+      // which needs the fonts baked in, not an external @import. PNG has one variant.
+      var src = (ext === ".svg" && field.getAttribute("data-embed-url")) || field.value;
       // fetch() resolves even on a non-2xx render (503 saturated, 400 bad override, 404 a
       // preview that can't export that lane), so guard on r.ok — otherwise the error body,
       // not the artefact, would land on the clipboard and still report "Copied".
       var okOrThrow = function (r) { if (!r.ok) throw new Error("render " + r.status); return r; };
       var toText =
         ext === ".svg"
-          ? fetch(field.value).then(okOrThrow).then(function (r) { return r.text(); })
-          : fetch(field.value)
+          ? fetch(src).then(okOrThrow).then(function (r) { return r.text(); })
+          : fetch(src)
               .then(okOrThrow)
               .then(function (r) { return r.blob(); })
               .then(function (blob) {

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-focus.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-focus.html
@@ -987,14 +987,28 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     return location.origin + base + "/render/" + encodeURIComponent(previewId) + ext +
       (qs ? "?" + qs : "");
   }
+  function withMode(url, mode) {
+    return url + (url.indexOf("?") >= 0 ? "&" : "?") + "mode=" + mode;
+  }
   function refreshLinks() {
     [["png", ".png"], ["svg", ".svg"]].forEach(function (pair) {
       var field = document.getElementById("cp-url-" + pair[0]);
       if (!field) return;
-      var url = renderUrl(pair[1]);
-      field.value = url;
+      var embed = renderUrl(pair[1]);
       var dl = document.getElementById("cp-dl-" + pair[0]);
-      if (dl) dl.href = url;
+      if (pair[1] === ".svg") {
+        // Copy URL yields the web/document variant (`?mode=web` → external Google Fonts
+        // @import), so opening the copied link in a browser pulls the faces from Google. Copy
+        // SVG and the download stay on the embedded variant (self-contained — right for pasting
+        // into Figma or an <img>, where external refs don't load); the button reads it from
+        // data-embed-url.
+        field.value = withMode(embed, "web");
+        field.setAttribute("data-embed-url", embed);
+        if (dl) dl.href = embed;
+      } else {
+        field.value = embed;
+        if (dl) dl.href = embed;
+      }
     });
   }
   // Click the read-only URL field to copy the /render URL to the clipboard (no separate button).
@@ -1031,14 +1045,18 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
       };
       if (!navigator.clipboard || !navigator.clipboard.writeText) { reset("No clipboard"); return; }
       btn.textContent = "Copying…";
+      // Copy SVG targets the EMBEDDED variant (data-embed-url) — the field itself holds the
+      // web-mode URL for Copy URL, but a copied SVG is usually pasted into Figma / an editor,
+      // which needs the fonts baked in, not an external @import. PNG has one variant.
+      var src = (ext === ".svg" && field.getAttribute("data-embed-url")) || field.value;
       // fetch() resolves even on a non-2xx render (503 saturated, 400 bad override, 404 a
       // preview that can't export that lane), so guard on r.ok — otherwise the error body,
       // not the artefact, would land on the clipboard and still report "Copied".
       var okOrThrow = function (r) { if (!r.ok) throw new Error("render " + r.status); return r; };
       var toText =
         ext === ".svg"
-          ? fetch(field.value).then(okOrThrow).then(function (r) { return r.text(); })
-          : fetch(field.value)
+          ? fetch(src).then(okOrThrow).then(function (r) { return r.text(); })
+          : fetch(src)
               .then(okOrThrow)
               .then(function (r) { return r.blob(); })
               .then(function (blob) {

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-gestures.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-gestures.html
@@ -987,14 +987,28 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     return location.origin + base + "/render/" + encodeURIComponent(previewId) + ext +
       (qs ? "?" + qs : "");
   }
+  function withMode(url, mode) {
+    return url + (url.indexOf("?") >= 0 ? "&" : "?") + "mode=" + mode;
+  }
   function refreshLinks() {
     [["png", ".png"], ["svg", ".svg"]].forEach(function (pair) {
       var field = document.getElementById("cp-url-" + pair[0]);
       if (!field) return;
-      var url = renderUrl(pair[1]);
-      field.value = url;
+      var embed = renderUrl(pair[1]);
       var dl = document.getElementById("cp-dl-" + pair[0]);
-      if (dl) dl.href = url;
+      if (pair[1] === ".svg") {
+        // Copy URL yields the web/document variant (`?mode=web` → external Google Fonts
+        // @import), so opening the copied link in a browser pulls the faces from Google. Copy
+        // SVG and the download stay on the embedded variant (self-contained — right for pasting
+        // into Figma or an <img>, where external refs don't load); the button reads it from
+        // data-embed-url.
+        field.value = withMode(embed, "web");
+        field.setAttribute("data-embed-url", embed);
+        if (dl) dl.href = embed;
+      } else {
+        field.value = embed;
+        if (dl) dl.href = embed;
+      }
     });
   }
   // Click the read-only URL field to copy the /render URL to the clipboard (no separate button).
@@ -1031,14 +1045,18 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
       };
       if (!navigator.clipboard || !navigator.clipboard.writeText) { reset("No clipboard"); return; }
       btn.textContent = "Copying…";
+      // Copy SVG targets the EMBEDDED variant (data-embed-url) — the field itself holds the
+      // web-mode URL for Copy URL, but a copied SVG is usually pasted into Figma / an editor,
+      // which needs the fonts baked in, not an external @import. PNG has one variant.
+      var src = (ext === ".svg" && field.getAttribute("data-embed-url")) || field.value;
       // fetch() resolves even on a non-2xx render (503 saturated, 400 bad override, 404 a
       // preview that can't export that lane), so guard on r.ok — otherwise the error body,
       // not the artefact, would land on the clipboard and still report "Copied".
       var okOrThrow = function (r) { if (!r.ok) throw new Error("render " + r.status); return r; };
       var toText =
         ext === ".svg"
-          ? fetch(field.value).then(okOrThrow).then(function (r) { return r.text(); })
-          : fetch(field.value)
+          ? fetch(src).then(okOrThrow).then(function (r) { return r.text(); })
+          : fetch(src)
               .then(okOrThrow)
               .then(function (r) { return r.blob(); })
               .then(function (blob) {

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-nav-collapsed.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-nav-collapsed.html
@@ -983,14 +983,28 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     return location.origin + base + "/render/" + encodeURIComponent(previewId) + ext +
       (qs ? "?" + qs : "");
   }
+  function withMode(url, mode) {
+    return url + (url.indexOf("?") >= 0 ? "&" : "?") + "mode=" + mode;
+  }
   function refreshLinks() {
     [["png", ".png"], ["svg", ".svg"]].forEach(function (pair) {
       var field = document.getElementById("cp-url-" + pair[0]);
       if (!field) return;
-      var url = renderUrl(pair[1]);
-      field.value = url;
+      var embed = renderUrl(pair[1]);
       var dl = document.getElementById("cp-dl-" + pair[0]);
-      if (dl) dl.href = url;
+      if (pair[1] === ".svg") {
+        // Copy URL yields the web/document variant (`?mode=web` → external Google Fonts
+        // @import), so opening the copied link in a browser pulls the faces from Google. Copy
+        // SVG and the download stay on the embedded variant (self-contained — right for pasting
+        // into Figma or an <img>, where external refs don't load); the button reads it from
+        // data-embed-url.
+        field.value = withMode(embed, "web");
+        field.setAttribute("data-embed-url", embed);
+        if (dl) dl.href = embed;
+      } else {
+        field.value = embed;
+        if (dl) dl.href = embed;
+      }
     });
   }
   // Click the read-only URL field to copy the /render URL to the clipboard (no separate button).
@@ -1027,14 +1041,18 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
       };
       if (!navigator.clipboard || !navigator.clipboard.writeText) { reset("No clipboard"); return; }
       btn.textContent = "Copying…";
+      // Copy SVG targets the EMBEDDED variant (data-embed-url) — the field itself holds the
+      // web-mode URL for Copy URL, but a copied SVG is usually pasted into Figma / an editor,
+      // which needs the fonts baked in, not an external @import. PNG has one variant.
+      var src = (ext === ".svg" && field.getAttribute("data-embed-url")) || field.value;
       // fetch() resolves even on a non-2xx render (503 saturated, 400 bad override, 404 a
       // preview that can't export that lane), so guard on r.ok — otherwise the error body,
       // not the artefact, would land on the clipboard and still report "Copied".
       var okOrThrow = function (r) { if (!r.ok) throw new Error("render " + r.status); return r; };
       var toText =
         ext === ".svg"
-          ? fetch(field.value).then(okOrThrow).then(function (r) { return r.text(); })
-          : fetch(field.value)
+          ? fetch(src).then(okOrThrow).then(function (r) { return r.text(); })
+          : fetch(src)
               .then(okOrThrow)
               .then(function (r) { return r.blob(); })
               .then(function (blob) {

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
@@ -981,14 +981,28 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     return location.origin + base + "/render/" + encodeURIComponent(previewId) + ext +
       (qs ? "?" + qs : "");
   }
+  function withMode(url, mode) {
+    return url + (url.indexOf("?") >= 0 ? "&" : "?") + "mode=" + mode;
+  }
   function refreshLinks() {
     [["png", ".png"], ["svg", ".svg"]].forEach(function (pair) {
       var field = document.getElementById("cp-url-" + pair[0]);
       if (!field) return;
-      var url = renderUrl(pair[1]);
-      field.value = url;
+      var embed = renderUrl(pair[1]);
       var dl = document.getElementById("cp-dl-" + pair[0]);
-      if (dl) dl.href = url;
+      if (pair[1] === ".svg") {
+        // Copy URL yields the web/document variant (`?mode=web` → external Google Fonts
+        // @import), so opening the copied link in a browser pulls the faces from Google. Copy
+        // SVG and the download stay on the embedded variant (self-contained — right for pasting
+        // into Figma or an <img>, where external refs don't load); the button reads it from
+        // data-embed-url.
+        field.value = withMode(embed, "web");
+        field.setAttribute("data-embed-url", embed);
+        if (dl) dl.href = embed;
+      } else {
+        field.value = embed;
+        if (dl) dl.href = embed;
+      }
     });
   }
   // Click the read-only URL field to copy the /render URL to the clipboard (no separate button).
@@ -1025,14 +1039,18 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
       };
       if (!navigator.clipboard || !navigator.clipboard.writeText) { reset("No clipboard"); return; }
       btn.textContent = "Copying…";
+      // Copy SVG targets the EMBEDDED variant (data-embed-url) — the field itself holds the
+      // web-mode URL for Copy URL, but a copied SVG is usually pasted into Figma / an editor,
+      // which needs the fonts baked in, not an external @import. PNG has one variant.
+      var src = (ext === ".svg" && field.getAttribute("data-embed-url")) || field.value;
       // fetch() resolves even on a non-2xx render (503 saturated, 400 bad override, 404 a
       // preview that can't export that lane), so guard on r.ok — otherwise the error body,
       // not the artefact, would land on the clipboard and still report "Copied".
       var okOrThrow = function (r) { if (!r.ok) throw new Error("render " + r.status); return r; };
       var toText =
         ext === ".svg"
-          ? fetch(field.value).then(okOrThrow).then(function (r) { return r.text(); })
-          : fetch(field.value)
+          ? fetch(src).then(okOrThrow).then(function (r) { return r.text(); })
+          : fetch(src)
               .then(okOrThrow)
               .then(function (r) { return r.blob(); })
               .then(function (blob) {

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-states.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-states.html
@@ -980,14 +980,28 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     return location.origin + base + "/render/" + encodeURIComponent(previewId) + ext +
       (qs ? "?" + qs : "");
   }
+  function withMode(url, mode) {
+    return url + (url.indexOf("?") >= 0 ? "&" : "?") + "mode=" + mode;
+  }
   function refreshLinks() {
     [["png", ".png"], ["svg", ".svg"]].forEach(function (pair) {
       var field = document.getElementById("cp-url-" + pair[0]);
       if (!field) return;
-      var url = renderUrl(pair[1]);
-      field.value = url;
+      var embed = renderUrl(pair[1]);
       var dl = document.getElementById("cp-dl-" + pair[0]);
-      if (dl) dl.href = url;
+      if (pair[1] === ".svg") {
+        // Copy URL yields the web/document variant (`?mode=web` → external Google Fonts
+        // @import), so opening the copied link in a browser pulls the faces from Google. Copy
+        // SVG and the download stay on the embedded variant (self-contained — right for pasting
+        // into Figma or an <img>, where external refs don't load); the button reads it from
+        // data-embed-url.
+        field.value = withMode(embed, "web");
+        field.setAttribute("data-embed-url", embed);
+        if (dl) dl.href = embed;
+      } else {
+        field.value = embed;
+        if (dl) dl.href = embed;
+      }
     });
   }
   // Click the read-only URL field to copy the /render URL to the clipboard (no separate button).
@@ -1024,14 +1038,18 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
       };
       if (!navigator.clipboard || !navigator.clipboard.writeText) { reset("No clipboard"); return; }
       btn.textContent = "Copying…";
+      // Copy SVG targets the EMBEDDED variant (data-embed-url) — the field itself holds the
+      // web-mode URL for Copy URL, but a copied SVG is usually pasted into Figma / an editor,
+      // which needs the fonts baked in, not an external @import. PNG has one variant.
+      var src = (ext === ".svg" && field.getAttribute("data-embed-url")) || field.value;
       // fetch() resolves even on a non-2xx render (503 saturated, 400 bad override, 404 a
       // preview that can't export that lane), so guard on r.ok — otherwise the error body,
       // not the artefact, would land on the clipboard and still report "Copied".
       var okOrThrow = function (r) { if (!r.ok) throw new Error("render " + r.status); return r; };
       var toText =
         ext === ".svg"
-          ? fetch(field.value).then(okOrThrow).then(function (r) { return r.text(); })
-          : fetch(field.value)
+          ? fetch(src).then(okOrThrow).then(function (r) { return r.text(); })
+          : fetch(src)
               .then(okOrThrow)
               .then(function (r) { return r.blob(); })
               .then(function (blob) {

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-themes.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-themes.html
@@ -986,14 +986,28 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     return location.origin + base + "/render/" + encodeURIComponent(previewId) + ext +
       (qs ? "?" + qs : "");
   }
+  function withMode(url, mode) {
+    return url + (url.indexOf("?") >= 0 ? "&" : "?") + "mode=" + mode;
+  }
   function refreshLinks() {
     [["png", ".png"], ["svg", ".svg"]].forEach(function (pair) {
       var field = document.getElementById("cp-url-" + pair[0]);
       if (!field) return;
-      var url = renderUrl(pair[1]);
-      field.value = url;
+      var embed = renderUrl(pair[1]);
       var dl = document.getElementById("cp-dl-" + pair[0]);
-      if (dl) dl.href = url;
+      if (pair[1] === ".svg") {
+        // Copy URL yields the web/document variant (`?mode=web` → external Google Fonts
+        // @import), so opening the copied link in a browser pulls the faces from Google. Copy
+        // SVG and the download stay on the embedded variant (self-contained — right for pasting
+        // into Figma or an <img>, where external refs don't load); the button reads it from
+        // data-embed-url.
+        field.value = withMode(embed, "web");
+        field.setAttribute("data-embed-url", embed);
+        if (dl) dl.href = embed;
+      } else {
+        field.value = embed;
+        if (dl) dl.href = embed;
+      }
     });
   }
   // Click the read-only URL field to copy the /render URL to the clipboard (no separate button).
@@ -1030,14 +1044,18 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
       };
       if (!navigator.clipboard || !navigator.clipboard.writeText) { reset("No clipboard"); return; }
       btn.textContent = "Copying…";
+      // Copy SVG targets the EMBEDDED variant (data-embed-url) — the field itself holds the
+      // web-mode URL for Copy URL, but a copied SVG is usually pasted into Figma / an editor,
+      // which needs the fonts baked in, not an external @import. PNG has one variant.
+      var src = (ext === ".svg" && field.getAttribute("data-embed-url")) || field.value;
       // fetch() resolves even on a non-2xx render (503 saturated, 400 bad override, 404 a
       // preview that can't export that lane), so guard on r.ok — otherwise the error body,
       // not the artefact, would land on the clipboard and still report "Copied".
       var okOrThrow = function (r) { if (!r.ok) throw new Error("render " + r.status); return r; };
       var toText =
         ext === ".svg"
-          ? fetch(field.value).then(okOrThrow).then(function (r) { return r.text(); })
-          : fetch(field.value)
+          ? fetch(src).then(okOrThrow).then(function (r) { return r.text(); })
+          : fetch(src)
               .then(okOrThrow)
               .then(function (r) { return r.blob(); })
               .then(function (blob) {

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-variants.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-variants.html
@@ -974,14 +974,28 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     return location.origin + base + "/render/" + encodeURIComponent(previewId) + ext +
       (qs ? "?" + qs : "");
   }
+  function withMode(url, mode) {
+    return url + (url.indexOf("?") >= 0 ? "&" : "?") + "mode=" + mode;
+  }
   function refreshLinks() {
     [["png", ".png"], ["svg", ".svg"]].forEach(function (pair) {
       var field = document.getElementById("cp-url-" + pair[0]);
       if (!field) return;
-      var url = renderUrl(pair[1]);
-      field.value = url;
+      var embed = renderUrl(pair[1]);
       var dl = document.getElementById("cp-dl-" + pair[0]);
-      if (dl) dl.href = url;
+      if (pair[1] === ".svg") {
+        // Copy URL yields the web/document variant (`?mode=web` → external Google Fonts
+        // @import), so opening the copied link in a browser pulls the faces from Google. Copy
+        // SVG and the download stay on the embedded variant (self-contained — right for pasting
+        // into Figma or an <img>, where external refs don't load); the button reads it from
+        // data-embed-url.
+        field.value = withMode(embed, "web");
+        field.setAttribute("data-embed-url", embed);
+        if (dl) dl.href = embed;
+      } else {
+        field.value = embed;
+        if (dl) dl.href = embed;
+      }
     });
   }
   // Click the read-only URL field to copy the /render URL to the clipboard (no separate button).
@@ -1018,14 +1032,18 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
       };
       if (!navigator.clipboard || !navigator.clipboard.writeText) { reset("No clipboard"); return; }
       btn.textContent = "Copying…";
+      // Copy SVG targets the EMBEDDED variant (data-embed-url) — the field itself holds the
+      // web-mode URL for Copy URL, but a copied SVG is usually pasted into Figma / an editor,
+      // which needs the fonts baked in, not an external @import. PNG has one variant.
+      var src = (ext === ".svg" && field.getAttribute("data-embed-url")) || field.value;
       // fetch() resolves even on a non-2xx render (503 saturated, 400 bad override, 404 a
       // preview that can't export that lane), so guard on r.ok — otherwise the error body,
       // not the artefact, would land on the clipboard and still report "Copied".
       var okOrThrow = function (r) { if (!r.ok) throw new Error("render " + r.status); return r; };
       var toText =
         ext === ".svg"
-          ? fetch(field.value).then(okOrThrow).then(function (r) { return r.text(); })
-          : fetch(field.value)
+          ? fetch(src).then(okOrThrow).then(function (r) { return r.text(); })
+          : fetch(src)
               .then(okOrThrow)
               .then(function (r) { return r.blob(); })
               .then(function (blob) {

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
@@ -978,14 +978,28 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     return location.origin + base + "/render/" + encodeURIComponent(previewId) + ext +
       (qs ? "?" + qs : "");
   }
+  function withMode(url, mode) {
+    return url + (url.indexOf("?") >= 0 ? "&" : "?") + "mode=" + mode;
+  }
   function refreshLinks() {
     [["png", ".png"], ["svg", ".svg"]].forEach(function (pair) {
       var field = document.getElementById("cp-url-" + pair[0]);
       if (!field) return;
-      var url = renderUrl(pair[1]);
-      field.value = url;
+      var embed = renderUrl(pair[1]);
       var dl = document.getElementById("cp-dl-" + pair[0]);
-      if (dl) dl.href = url;
+      if (pair[1] === ".svg") {
+        // Copy URL yields the web/document variant (`?mode=web` → external Google Fonts
+        // @import), so opening the copied link in a browser pulls the faces from Google. Copy
+        // SVG and the download stay on the embedded variant (self-contained — right for pasting
+        // into Figma or an <img>, where external refs don't load); the button reads it from
+        // data-embed-url.
+        field.value = withMode(embed, "web");
+        field.setAttribute("data-embed-url", embed);
+        if (dl) dl.href = embed;
+      } else {
+        field.value = embed;
+        if (dl) dl.href = embed;
+      }
     });
   }
   // Click the read-only URL field to copy the /render URL to the clipboard (no separate button).
@@ -1022,14 +1036,18 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
       };
       if (!navigator.clipboard || !navigator.clipboard.writeText) { reset("No clipboard"); return; }
       btn.textContent = "Copying…";
+      // Copy SVG targets the EMBEDDED variant (data-embed-url) — the field itself holds the
+      // web-mode URL for Copy URL, but a copied SVG is usually pasted into Figma / an editor,
+      // which needs the fonts baked in, not an external @import. PNG has one variant.
+      var src = (ext === ".svg" && field.getAttribute("data-embed-url")) || field.value;
       // fetch() resolves even on a non-2xx render (503 saturated, 400 bad override, 404 a
       // preview that can't export that lane), so guard on r.ok — otherwise the error body,
       // not the artefact, would land on the clipboard and still report "Copied".
       var okOrThrow = function (r) { if (!r.ok) throw new Error("render " + r.status); return r; };
       var toText =
         ext === ".svg"
-          ? fetch(field.value).then(okOrThrow).then(function (r) { return r.text(); })
-          : fetch(field.value)
+          ? fetch(src).then(okOrThrow).then(function (r) { return r.text(); })
+          : fetch(src)
               .then(okOrThrow)
               .then(function (r) { return r.blob(); })
               .then(function (blob) {

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
@@ -969,14 +969,28 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     return location.origin + base + "/render/" + encodeURIComponent(previewId) + ext +
       (qs ? "?" + qs : "");
   }
+  function withMode(url, mode) {
+    return url + (url.indexOf("?") >= 0 ? "&" : "?") + "mode=" + mode;
+  }
   function refreshLinks() {
     [["png", ".png"], ["svg", ".svg"]].forEach(function (pair) {
       var field = document.getElementById("cp-url-" + pair[0]);
       if (!field) return;
-      var url = renderUrl(pair[1]);
-      field.value = url;
+      var embed = renderUrl(pair[1]);
       var dl = document.getElementById("cp-dl-" + pair[0]);
-      if (dl) dl.href = url;
+      if (pair[1] === ".svg") {
+        // Copy URL yields the web/document variant (`?mode=web` → external Google Fonts
+        // @import), so opening the copied link in a browser pulls the faces from Google. Copy
+        // SVG and the download stay on the embedded variant (self-contained — right for pasting
+        // into Figma or an <img>, where external refs don't load); the button reads it from
+        // data-embed-url.
+        field.value = withMode(embed, "web");
+        field.setAttribute("data-embed-url", embed);
+        if (dl) dl.href = embed;
+      } else {
+        field.value = embed;
+        if (dl) dl.href = embed;
+      }
     });
   }
   // Click the read-only URL field to copy the /render URL to the clipboard (no separate button).
@@ -1013,14 +1027,18 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
       };
       if (!navigator.clipboard || !navigator.clipboard.writeText) { reset("No clipboard"); return; }
       btn.textContent = "Copying…";
+      // Copy SVG targets the EMBEDDED variant (data-embed-url) — the field itself holds the
+      // web-mode URL for Copy URL, but a copied SVG is usually pasted into Figma / an editor,
+      // which needs the fonts baked in, not an external @import. PNG has one variant.
+      var src = (ext === ".svg" && field.getAttribute("data-embed-url")) || field.value;
       // fetch() resolves even on a non-2xx render (503 saturated, 400 bad override, 404 a
       // preview that can't export that lane), so guard on r.ok — otherwise the error body,
       // not the artefact, would land on the clipboard and still report "Copied".
       var okOrThrow = function (r) { if (!r.ok) throw new Error("render " + r.status); return r; };
       var toText =
         ext === ".svg"
-          ? fetch(field.value).then(okOrThrow).then(function (r) { return r.text(); })
-          : fetch(field.value)
+          ? fetch(src).then(okOrThrow).then(function (r) { return r.text(); })
+          : fetch(src)
               .then(okOrThrow)
               .then(function (r) { return r.blob(); })
               .then(function (blob) {

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
@@ -981,14 +981,28 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     return location.origin + base + "/render/" + encodeURIComponent(previewId) + ext +
       (qs ? "?" + qs : "");
   }
+  function withMode(url, mode) {
+    return url + (url.indexOf("?") >= 0 ? "&" : "?") + "mode=" + mode;
+  }
   function refreshLinks() {
     [["png", ".png"], ["svg", ".svg"]].forEach(function (pair) {
       var field = document.getElementById("cp-url-" + pair[0]);
       if (!field) return;
-      var url = renderUrl(pair[1]);
-      field.value = url;
+      var embed = renderUrl(pair[1]);
       var dl = document.getElementById("cp-dl-" + pair[0]);
-      if (dl) dl.href = url;
+      if (pair[1] === ".svg") {
+        // Copy URL yields the web/document variant (`?mode=web` → external Google Fonts
+        // @import), so opening the copied link in a browser pulls the faces from Google. Copy
+        // SVG and the download stay on the embedded variant (self-contained — right for pasting
+        // into Figma or an <img>, where external refs don't load); the button reads it from
+        // data-embed-url.
+        field.value = withMode(embed, "web");
+        field.setAttribute("data-embed-url", embed);
+        if (dl) dl.href = embed;
+      } else {
+        field.value = embed;
+        if (dl) dl.href = embed;
+      }
     });
   }
   // Click the read-only URL field to copy the /render URL to the clipboard (no separate button).
@@ -1025,14 +1039,18 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
       };
       if (!navigator.clipboard || !navigator.clipboard.writeText) { reset("No clipboard"); return; }
       btn.textContent = "Copying…";
+      // Copy SVG targets the EMBEDDED variant (data-embed-url) — the field itself holds the
+      // web-mode URL for Copy URL, but a copied SVG is usually pasted into Figma / an editor,
+      // which needs the fonts baked in, not an external @import. PNG has one variant.
+      var src = (ext === ".svg" && field.getAttribute("data-embed-url")) || field.value;
       // fetch() resolves even on a non-2xx render (503 saturated, 400 bad override, 404 a
       // preview that can't export that lane), so guard on r.ok — otherwise the error body,
       // not the artefact, would land on the clipboard and still report "Copied".
       var okOrThrow = function (r) { if (!r.ok) throw new Error("render " + r.status); return r; };
       var toText =
         ext === ".svg"
-          ? fetch(field.value).then(okOrThrow).then(function (r) { return r.text(); })
-          : fetch(field.value)
+          ? fetch(src).then(okOrThrow).then(function (r) { return r.text(); })
+          : fetch(src)
               .then(okOrThrow)
               .then(function (r) { return r.blob(); })
               .then(function (blob) {


### PR DESCRIPTION
## Why

The served `figma-svg` is fully self-contained — base64 `@font-face` + inlined rasters. That's correct for **Figma** (its importer resolves fonts by family name and can't fetch external hrefs) but heavy for the **web/document** consumer, and it duplicates every font's bytes into every sticker. A browser that opens the `.svg` URL directly can instead pull the faces from Google Fonts.

This is the first half of the two-mode export idea: let the two consumers stop fighting over one artifact.

## What

- **`?mode=web` on the SVG endpoint.** New pure transform `webModeSvg` strips the embedded `@font-face` blocks and injects one `@import url('https://fonts.googleapis.com/css2?family=…')` covering exactly the families/weights/italics the SVG uses (grouped per family, weights sorted + de-duplicated, `ital,wght` axis when needed; generic families like `sans-serif` are never sent to Google). The `<text>` keep their family names, so the browser resolves them from the imported sheet.
- Applied as a **cheap per-response rewrite** of the render host's bytes, so both modes share one render + cache. **The default (no `mode`, or `mode=figma`) is unchanged** — fully self-contained, correct for `<img>` / the fidelity harness / Figma import, where external refs don't load (browser secure-static mode).
- **Viewer copy panel wired to the two consumers:** the SVG **Copy URL** field now yields `?mode=web` (open in a browser → fonts from Google); **Copy SVG** and the **download** stay on the embedded variant (paste into Figma). Decoupled via a `data-embed-url` on the field so the shared field can serve both.
- **Rasters stay embedded** in web mode for now — referencing the per-node crops needs a new HTTP route to serve them; that's the natural next increment.

## Test plan

- New `ServeFigmaSvgWebModeTest` (pure, no served host): strip-and-import, family grouping / weight dedup / `ital,wght` axis, generic-family skip, and vector-only pass-through. `./gradlew :cli:test --tests '*ServeFigmaSvgWebModeTest'` → green.
- `:cli:compileKotlin` clean (endpoint + viewer wiring).
- **Manual/CI visual check** (this change alters *which URL the copy buttons hit*, not any rendered pixels, and the served viewer can't be screenshotted in a headless container): open a `/render/<id>.svg?mode=web` for a branded preview in a browser and confirm the branded faces load from Google Fonts and the base64 `@font-face` is gone; confirm bare `/render/<id>.svg` is byte-identical to before (embedded). In the viewer, Copy URL yields `…?mode=web`, Copy SVG copies the embedded markup.

## Follow-up

Web-mode **raster referencing** (skip inlining + serve the crops over HTTP), and the `figma`-mode raster/font parity, per the two-mode design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KL6aMkWHRwot53LnwDoAc2

---
_Generated by [Claude Code](https://claude.ai/code/session_01KL6aMkWHRwot53LnwDoAc2)_