### PR TITLE
feat(remotecompose): add float/dp overridable knobs + expose useful catalog knobs

### DIFF
--- a/data/remotecompose/connector/src/main/kotlin/ee/schimke/composeai/daemon/RemoteOverridableState.kt
+++ b/data/remotecompose/connector/src/main/kotlin/ee/schimke/composeai/daemon/RemoteOverridableState.kt
@@ -3,13 +3,20 @@
 package ee.schimke.composeai.daemon
 
 import androidx.compose.remote.creation.compose.state.RemoteColor
+import androidx.compose.remote.creation.compose.state.RemoteDp
+import androidx.compose.remote.creation.compose.state.RemoteFloat
 import androidx.compose.remote.creation.compose.state.RemoteString
+import androidx.compose.remote.creation.compose.state.rdp
 import androidx.compose.remote.creation.compose.state.rememberNamedRemoteColor
+import androidx.compose.remote.creation.compose.state.rememberNamedRemoteDp
+import androidx.compose.remote.creation.compose.state.rememberNamedRemoteFloat
 import androidx.compose.remote.creation.compose.state.rememberNamedRemoteString
+import androidx.compose.remote.creation.compose.state.rf
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.unit.Dp
 import ee.schimke.composeai.daemon.protocol.RemoteNamedValue
 import ee.schimke.composeai.data.remotecompose.RemoteComposeKnobDeclaration
 
@@ -53,6 +60,37 @@ fun rememberOverridableRemoteColor(name: String, default: Color): RemoteColor {
     )
   }
   return rememberNamedRemoteColor(name, default)
+}
+
+/**
+ * [rememberOverridableRemoteString] for a **float** knob (e.g. a 0..1 progress value). The viewer
+ * renders a number field; a seed arrives as `rc.<name>=float:<value>`.
+ */
+@Composable
+fun rememberOverridableRemoteFloat(name: String, default: Float): RemoteFloat {
+  SideEffect {
+    RemoteComposeController.recordDeclaration(
+      RemoteComposeKnobDeclaration(name, RemoteNamedValue.FloatValue(default))
+    )
+  }
+  // The alpha `rememberNamedRemoteFloat` has no plain-default overload — it takes a lambda that
+  // produces the default RemoteFloat — so wrap the bare default with `.rf`.
+  return rememberNamedRemoteFloat(name) { default.rf }
+}
+
+/**
+ * [rememberOverridableRemoteString] for a **dp** knob (a density-independent measurement, e.g. an
+ * icon size). Recorded as its raw dp value; a seed arrives as `rc.<name>=dp:<value>`.
+ */
+@Composable
+fun rememberOverridableRemoteDp(name: String, default: Dp): RemoteDp {
+  SideEffect {
+    RemoteComposeController.recordDeclaration(
+      RemoteComposeKnobDeclaration(name, RemoteNamedValue.DpValue(default.value))
+    )
+  }
+  // Like the float wrapper, the alpha `rememberNamedRemoteDp` takes a lambda producing the default.
+  return rememberNamedRemoteDp(name) { default.value.rdp }
 }
 
 /** `#AARRGGBB`, matching the form `RemoteNamedValue.ColorValue` carries and the connector parses. */

--- a/samples/design-catalog-remote-m3/src/main/kotlin/com/example/designcatalogremotem3/CatalogPreviews.kt
+++ b/samples/design-catalog-remote-m3/src/main/kotlin/com/example/designcatalogremotem3/CatalogPreviews.kt
@@ -20,6 +20,8 @@ import androidx.compose.remote.creation.compose.state.RemoteColor
 import androidx.compose.remote.creation.compose.state.rb
 import androidx.compose.remote.creation.compose.state.rdp
 import ee.schimke.composeai.daemon.rememberOverridableRemoteColor
+import ee.schimke.composeai.daemon.rememberOverridableRemoteDp
+import ee.schimke.composeai.daemon.rememberOverridableRemoteFloat
 import ee.schimke.composeai.daemon.rememberOverridableRemoteString
 import androidx.compose.remote.creation.compose.state.rf
 import androidx.compose.remote.creation.compose.state.rs
@@ -269,7 +271,11 @@ fun AppCardRemote() = RemoteSticker {
 @CatalogRemoteModes
 @Composable
 fun CircularProgressRemote() = RemoteSticker {
-  RemoteCircularProgressIndicator(progress = 0.66f.rf, modifier = RemoteModifier.size(72.rdp))
+  // The 0..1 fill is an editable `progress` float knob: the viewer's number field reseeds the arc
+  // live (`rc.progress=float:<0..1>`) without re-capturing the document. Default 0.66 keeps the
+  // static sticker deterministic.
+  val progress = rememberOverridableRemoteFloat("progress", 0.66f)
+  RemoteCircularProgressIndicator(progress = progress, modifier = RemoteModifier.size(72.rdp))
 }
 
 // ---------------------------------------------------------------------------
@@ -280,7 +286,10 @@ fun CircularProgressRemote() = RemoteSticker {
 @CatalogRemoteModes
 @Composable
 fun IconRemote() = RemoteSticker {
-  RemoteIcon(starIcon, "Star".rs, modifier = RemoteModifier.size(48.rdp))
+  // An editable `iconSize` dp knob: reseeding `rc.iconSize=dp:<value>` resizes the icon live. dp is
+  // carried distinctly from a bare float so the connector binds it as a density-independent value.
+  val iconSize = rememberOverridableRemoteDp("iconSize", 48.dp)
+  RemoteIcon(starIcon, "Star".rs, modifier = RemoteModifier.size(iconSize))
 }
 
 // ---------------------------------------------------------------------------
@@ -292,9 +301,15 @@ fun IconRemote() = RemoteSticker {
 @CatalogRemoteModes
 @Composable
 fun RemoteTextSticker() = RemoteSticker {
-  // Same copy as the truncated sticker (and Wear's) — here it flows in full; the
-  // `Text/MaxLines-Truncated` pair below shows the same string clipped.
-  RemoteText("This body text is long enough to overflow two lines and truncate.".rs)
+  // Same default copy as the truncated sticker (and Wear's) — here it flows in full; the
+  // `Text/MaxLines-Truncated` pair below shows the same string clipped. The body is an editable
+  // `text` string knob, so the viewer can retype it live (`rc.text=<string>`).
+  val text =
+    rememberOverridableRemoteString(
+      "text",
+      "This body text is long enough to overflow two lines and truncate.",
+    )
+  RemoteText(text)
 }
 
 // The text primitive exercising the maxLines / overflow product on a narrow column —


### PR DESCRIPTION
## Summary

Follow-on to the "auto-render Remote Compose knobs" series (all merged): now that the `remote-m3` catalog serves live with per-knob viewer controls, this gives it **more genuinely useful knobs** to edit. Only two stickers declared knobs (`label`, `shaderColor`); this brings it to five and adds two new knob kinds.

## What changed

**`:data-remotecompose-connector`** — extend the declaring `rememberOverridableRemote*` family with **float** and **dp** variants. The alpha `rememberNamedRemoteFloat` / `rememberNamedRemoteDp` have no plain-default overload (they take a lambda that produces the default `RemoteFloat` / `RemoteDp`), so the wrappers wrap the bare default with `.rf` / `.rdp`. String and colour wrappers already existed.

**`:samples:design-catalog-remote-m3`** — expose useful editable knobs:
- `CircularProgressRemote` → **`progress`** float (the 0..1 arc fill — a slider in the viewer).
- `IconRemote` → **`iconSize`** dp (resize the icon live).
- `RemoteTextSticker` → **`text`** string (retype the body copy live).

Each edit round-trips through `rc.<name>=<kind>:<value>` (the serve override `ServeOverrides` already parses) and reseeds the live Robolectric render without rebuilding the document.

## A boolean knob was tried and dropped

I first added an `enabled` boolean knob on `NamedLabelRemoteButton`, but the alpha `RemoteButton` rejects a **named-value-bound** `enabled` at render — `NotImplementedError: Dynamic clickable enabled value is not supported` (`RemoteButton.kt:874`). So the boolean/int wrappers aren't shipped; only the verified float/dp kinds are. Re-add them when a component that accepts dynamic booleans lands.

## Verification (in-session render)

Non-visual: the knob defaults match the previous hard-coded values, so the **render PNGs are unchanged** — the new editable surface rides the `previews/<id>.remotecompose.json` sidecars (same as the declaring-wrapper PR #2690). `:samples:design-catalog-remote-m3:composePreviewRenderAll` renders **all 22 stickers** and writes the new sidecars:

```json
CircularProgressRemote.remotecompose.json  {"declarations":[{"name":"progress","default":{"kind":"float","value":0.66}}]}
IconRemote.remotecompose.json              {"declarations":[{"name":"iconSize","default":{"kind":"dp","value":48.0}}]}
RemoteTextSticker.remotecompose.json       {"declarations":[{"name":"text","default":{"kind":"string","value":"This body text is long enough to overflow two lines and truncate."}}]}
```

The CI visual-diff bot will confirm the sticker renders are unchanged. The RC knob *controls* these feed are already covered by the `serve-viewer-catalog-knobs` preview-harness fixture (from #2696).

---
_Generated by [Claude Code](https://claude.ai/code/session_011K7sgCfdsbhN7fwMb3WhSS)_