### PR TITLE
feat(deploy): instant-roll webhook so preview.coo.ee deploys the moment an image publishes

### DIFF
--- a/.github/workflows/preview-host-image.yml
+++ b/.github/workflows/preview-host-image.yml
@@ -152,3 +152,53 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      # Roll preview.coo.ee onto the just-published image IMMEDIATELY, instead of
+      # waiting up to the box's ROLLOUT_INTERVAL (default 1200s) for its poll loop
+      # to notice the new :latest. This is the RIGHT moment to fire: the image is now
+      # on GHCR and is fully self-contained (CLI + plugin jars + warm caches + the
+      # Android daemon are all baked in above), so the box needs ONLY GHCR to roll —
+      # no Maven wait can race it (the build already absorbed Central propagation via
+      # the seeded local m2 + the Dockerfile warm-render retry). Contrast a `release:
+      # published` trigger, which fires BEFORE this job builds the image and would
+      # roll the box onto the OLD :latest.
+      #
+      # Best-effort and OPTIONAL: it fires only when a DEPLOY_HOOK_TOKEN secret is set
+      # (forks / other deployers have none → skipped), and a failure never fails the
+      # publish — the box's poll loop is the fallback that still rolls within one
+      # interval. The hook only triggers a rollout CHECK of the already-configured
+      # image tag (it can't be parameterised to run anything else), so the call is a
+      # bounded no-op, not an RCE lever. See deploy/image/deploy-hook.sh.
+      - name: Notify preview.coo.ee to roll (best-effort)
+        env:
+          HOOK_URL: ${{ vars.DEPLOY_HOOK_URL || 'https://preview.coo.ee/__hooks/rollout' }}
+          HOOK_TOKEN: ${{ secrets.DEPLOY_HOOK_TOKEN }}
+          V: ${{ steps.ver.outputs.version }}
+        run: |
+          set -u
+          if [ -z "${HOOK_TOKEN}" ]; then
+            echo "no DEPLOY_HOOK_TOKEN secret — skipping deploy notify (the box's poll loop rolls within its interval)."
+            exit 0
+          fi
+          code=$(curl -sS -o /dev/null -w '%{http_code}' -m 30 \
+            -X POST -H "Authorization: Bearer ${HOOK_TOKEN}" "${HOOK_URL}" 2>/dev/null || echo 000)
+          echo "deploy hook POST ${HOOK_URL} → HTTP ${code}"
+          case "${code}" in
+            200|202) echo "roll triggered." ;;
+            *) echo "::warning::deploy hook returned ${code}; the box will still roll on its next poll." ;;
+          esac
+          # Advisory convergence check: poll the ungated /version until it reports the
+          # new build, so this run shows the box actually rolled. Non-fatal on timeout
+          # (a slow cold-start warm render can outlast this; the roll still completes).
+          base="${HOOK_URL%/__hooks/rollout}"
+          for i in $(seq 1 30); do
+            live=$(curl -fsS -m 10 "${base}/version" 2>/dev/null \
+              | tr -d ' \n' | sed -n 's/.*"version":"\([^"]*\)".*/\1/p' || true)
+            if [ "${live}" = "${V}" ]; then
+              echo "preview.coo.ee now serving ${V}."
+              exit 0
+            fi
+            echo "waiting for preview.coo.ee to report ${V} (currently '${live:-?}', attempt ${i}/30)…"
+            sleep 20
+          done
+          echo "::warning::preview.coo.ee did not report ${V} within ~10 min — it may still be warming or will roll on its next poll; not failing the publish."

--- a/deploy/image/Caddyfile
+++ b/deploy/image/Caddyfile
@@ -7,47 +7,61 @@
 {$DOMAIN} {
 	encode zstd gzip
 
-	# The /ws/ WebSocket frame lane (Live Compose) was 502ing: a `read_timeout` on
-	# the http transport puts a read deadline on the upstream connection and fails
-	# the WebSocket upgrade before a 101 is produced. Dropping it fixes the upgrade —
-	# WebSockets are proxied by connection hijack (no read deadline, no response
-	# buffering involved), and long cold renders are already bounded by the app's own
-	# --timeout, so the proxy needn't cap the read. Bound only the initial dial.
-	#
-	# Deliberately NOT `flush_interval -1`: a negative flush interval disables
-	# response buffering globally AND, per Caddy's reverse_proxy docs, does not cancel
-	# the upstream request on client disconnect — an abandoned /render/*.png|svg tab
-	# would then hold a render slot for the whole cold-render budget. WS doesn't need
-	# it (hijacked); render endpoints must keep cancel-on-disconnect.
-	reverse_proxy {
-		# Zero-downtime rollout support. During a docker-rollout swap the `preview`
-		# service briefly has TWO replicas (old still serving + new booting), then one
-		# again. Resolve the service name via Docker's embedded DNS (127.0.0.11 inside
-		# the compose network) on a short refresh so the upstream set tracks that
-		# without a Caddy reload — a plain `reverse_proxy preview:8080` resolves once
-		# and would keep pointing at the retired container.
-		dynamic a {
-			name preview
-			port 8080
-			refresh 3s
-			resolvers 127.0.0.11
-		}
+	# Deploy webhook: the image-publish CI POSTs here to roll `preview` immediately
+	# when a new image is published (instead of waiting for the rollout poll). Routed
+	# to the `hook` sidecar, which enforces the bearer-token check and runs a
+	# single-flight rollout.sh — Caddy only forwards; the auth gate lives in the hook.
+	# `handle` (not a bare directive) so this one path peels off before the catch-all
+	# proxy below. The hook is fail-closed (idle without DEPLOY_HOOK_TOKEN), and only
+	# reachable here — it publishes no host port of its own.
+	handle /__hooks/rollout {
+		reverse_proxy hook:9000
+	}
 
-		# Retry across replicas so the swap is invisible to clients: a request that
-		# lands on a just-started replica before it's accepting connections gets a dial
-		# refusal, which Caddy retries against the healthy replica within
-		# lb_try_duration (nothing was written upstream yet, so this is safe to retry).
-		# docker-rollout keeps the OLD replica up until the new one passes its /readyz
-		# healthcheck, so there's always a warm backend to retry onto. Deliberately no
-		# passive `fail_duration` / `unhealthy_status`: in steady state there's a single
-		# backend, and benching it on a transient error or an app-level 5xx would
-		# self-inflict an outage with no alternative to fail over to.
-		lb_policy least_conn
-		lb_try_duration 10s
-		lb_try_interval 250ms
+	# Everything else → the preview server.
+	handle {
+		# The /ws/ WebSocket frame lane (Live Compose) was 502ing: a `read_timeout` on
+		# the http transport puts a read deadline on the upstream connection and fails
+		# the WebSocket upgrade before a 101 is produced. Dropping it fixes the upgrade —
+		# WebSockets are proxied by connection hijack (no read deadline, no response
+		# buffering involved), and long cold renders are already bounded by the app's own
+		# --timeout, so the proxy needn't cap the read. Bound only the initial dial.
+		#
+		# Deliberately NOT `flush_interval -1`: a negative flush interval disables
+		# response buffering globally AND, per Caddy's reverse_proxy docs, does not cancel
+		# the upstream request on client disconnect — an abandoned /render/*.png|svg tab
+		# would then hold a render slot for the whole cold-render budget. WS doesn't need
+		# it (hijacked); render endpoints must keep cancel-on-disconnect.
+		reverse_proxy {
+			# Zero-downtime rollout support. During a docker-rollout swap the `preview`
+			# service briefly has TWO replicas (old still serving + new booting), then one
+			# again. Resolve the service name via Docker's embedded DNS (127.0.0.11 inside
+			# the compose network) on a short refresh so the upstream set tracks that
+			# without a Caddy reload — a plain `reverse_proxy preview:8080` resolves once
+			# and would keep pointing at the retired container.
+			dynamic a {
+				name preview
+				port 8080
+				refresh 3s
+				resolvers 127.0.0.11
+			}
 
-		transport http {
-			dial_timeout 30s
+			# Retry across replicas so the swap is invisible to clients: a request that
+			# lands on a just-started replica before it's accepting connections gets a dial
+			# refusal, which Caddy retries against the healthy replica within
+			# lb_try_duration (nothing was written upstream yet, so this is safe to retry).
+			# docker-rollout keeps the OLD replica up until the new one passes its /readyz
+			# healthcheck, so there's always a warm backend to retry onto. Deliberately no
+			# passive `fail_duration` / `unhealthy_status`: in steady state there's a single
+			# backend, and benching it on a transient error or an app-level 5xx would
+			# self-inflict an outage with no alternative to fail over to.
+			lb_policy least_conn
+			lb_try_duration 10s
+			lb_try_interval 250ms
+
+			transport http {
+				dial_timeout 30s
+			}
 		}
 	}
 }

--- a/deploy/image/README.md
+++ b/deploy/image/README.md
@@ -82,6 +82,45 @@ services split the work:
   fixed `80`/`443` ports, so it can't be scaled/rolled; Watchtower's in-place
   recreate is a ~1s proxy blip, and only when the baked-Caddyfile image changes.
 
+### Instant roll on publish (webhook — skips the poll wait)
+
+The `rollout` poll only notices a new image on its next tick, so a fresh release
+sits up to `ROLLOUT_INTERVAL` (default 1200s) before the box even *starts* rolling.
+The **`hook`** service closes that gap: it exposes a token-gated
+`POST /__hooks/rollout` (routed through Caddy) that runs `rollout.sh` immediately, so
+the publish CI can push the roll the moment the image lands:
+
+> merge → release → `preview-host-image.yml` builds & pushes `:latest` → **its final
+> step POSTs `/__hooks/rollout`** → `hook` runs `rollout.sh` → new replica boots +
+> goes healthy → traffic drains over → old replica retired
+
+**Fire on the image, not the release.** The webhook is triggered from the *end of the
+image build*, not a `release: published` event — at image-publish time the GHCR image
+is fully self-contained (baked CLI + plugin jars + warm caches + Android daemon), so
+the box needs **only GHCR** to roll and **no Maven propagation can race it** (the build
+already waited Central out via the seeded local `m2` + the Dockerfile warm-render retry).
+A `release: published` webhook would fire *before* the image exists and roll the box onto
+the *old* `:latest`.
+
+**Safe to expose (behind Caddy TLS):**
+- A bearer `DEPLOY_HOOK_TOKEN` is required; **fail-closed** — with none set the `hook`
+  service stays up but idle and never opens its port (never an unauthenticated exec
+  endpoint).
+- The only effect is `rollout.sh` on the **already-configured** image tag. The caller
+  can't choose what image runs, so a leaked/replayed token forces at most a rollout
+  *check* of the tag the box is already pinned to — a bounded no-op, and idempotent
+  (`rollout.sh` rolls only if the pulled digest actually changed).
+- Single-flight: overlapping calls fold into the in-progress roll instead of launching
+  parallel rollouts.
+
+**Wiring it up.** `setup.sh` generates `DEPLOY_HOOK_TOKEN` into `.env` and prints it;
+add the **same value** as the repo's `DEPLOY_HOOK_TOKEN` Actions secret. If the box
+isn't `preview.coo.ee`, also set a `DEPLOY_HOOK_URL` repo *variable* to
+`https://<your-domain>/__hooks/rollout`. The CI step is **best-effort** — with no
+secret it's skipped, and any failure just falls back to the poll loop, which still
+rolls within one interval. To disable the webhook entirely, comment out the `hook`
+service **and** the Caddyfile `/__hooks/rollout` route; the poll loop keeps working.
+
 **How the swap stays seamless.** `preview` has a Docker `healthcheck` on the
 app's ungated `/readyz` **readiness** route — green only once the new replica has
 actually rendered a preview, not merely bound its port (that's `/healthz`), so a
@@ -167,8 +206,9 @@ Requirements / options:
   `PREVIEW_MEM_LIMIT` (which also lowers the derived live-seat budget per replica).
 - **Private GHCR package:** mount registry creds so the in-container pull can
   authenticate — add `- ~/.docker/config.json:/root/.docker/config.json:ro` to the
-  `rollout` service (for `preview`) and `- ~/.docker/config.json:/config.json:ro`
-  to `watchtower` (for `caddy`), after `docker login ghcr.io`. Public packages need
+  `rollout` service **and** the `hook` service (both run `rollout.sh` → `docker
+  compose pull preview`) and `- ~/.docker/config.json:/config.json:ro` to
+  `watchtower` (for `caddy`), after `docker login ghcr.io`. Public packages need
   nothing.
 - **Pause auto-rollout:** comment out the `rollout` service and update `preview` by
   hand with `sudo docker rollout preview` (still zero-downtime) or the blunt
@@ -193,8 +233,9 @@ docker run -d --restart always -p 8080:8080 \
 | `Dockerfile` | Downloads the released CLI, warm-renders `sample-project/`. |
 | `sample-project/` | Self-contained Compose Desktop module (foundation-only previews) + Gradle wrapper. Applies the published plugin via auto-inject. |
 | `entrypoint.sh` | Maps `$PORT`/`$SERVE_TOKEN` onto serve flags; generous `--timeout`. |
-| `docker-compose.yml` + `Caddyfile` | Pull the image + Caddy auto-HTTPS + zero-downtime (`rollout`) / Watchtower auto-updates. |
+| `docker-compose.yml` + `Caddyfile` | Pull the image + Caddy auto-HTTPS + zero-downtime (`rollout`) / Watchtower auto-updates + the `hook` instant-roll webhook. |
 | `rollout.sh` | Poll loop / one-shot that pulls `preview` and rolls it via docker-rollout. |
+| `deploy-hook.sh` | Token-gated `POST /__hooks/rollout` webhook (the `hook` service) that runs `rollout.sh` on demand — instant roll on publish. |
 | `docker-rollout` | Vendored [docker-rollout](https://github.com/wowu/docker-rollout) CLI plugin (adds `docker rollout`). |
 | `setup.sh` | Install Docker + the docker-rollout plugin, write `.env`, pull + start. |
 

--- a/deploy/image/deploy-hook.sh
+++ b/deploy/image/deploy-hook.sh
@@ -35,7 +35,13 @@ HOOK_PORT="${HOOK_PORT:-9000}"
 LOCK="/tmp/deploy-hook-rollout.lock"
 TOKEN="${DEPLOY_HOOK_TOKEN:-}"
 
-log() { echo "deploy-hook: $*"; }
+# ALWAYS log to stderr, never stdout. In --handle mode stdout IS the client
+# socket (socat wires the connection to the handler's stdin/stdout), so a log line
+# on stdout would land on the wire BEFORE the HTTP status line and corrupt the
+# response — the CI POST would see a malformed reply / 502. socat leaves the
+# handler's stderr on the container log (no `stderr` EXEC option), so stderr logs
+# stay visible via `docker compose logs hook` in every mode.
+log() { echo "deploy-hook: $*" >&2; }
 
 # ---- one HTTP request, on stdin → response on stdout -----------------------
 handle() {

--- a/deploy/image/deploy-hook.sh
+++ b/deploy/image/deploy-hook.sh
@@ -1,0 +1,138 @@
+#!/bin/sh
+# Token-gated deploy webhook: roll `preview` the INSTANT a new image is published,
+# instead of waiting up to ROLLOUT_INTERVAL (default 1200s) for the `rollout`
+# service's poll loop to notice.
+#
+# The image-publish CI (preview-host-image.yml) POSTs here once the new
+# ghcr.io/…/compose-preview-host:latest is pushed; this triggers a one-shot
+# `rollout.sh`, which pulls the tag and rolls ONLY if the digest actually changed
+# (so a duplicate / replayed / racing-with-the-poll call is a cheap no-op). The
+# poll loop stays on as the fallback, so a missed webhook still self-heals within
+# one interval.
+#
+# WHY it's safe to expose (behind Caddy TLS):
+#   * A bearer token (DEPLOY_HOOK_TOKEN) is required; fail-closed if unset — the
+#     service stays up but inert (never an unauthenticated exec endpoint).
+#   * The ONLY effect is `rollout.sh` on the ALREADY-CONFIGURED image tag. The
+#     caller can't parameterise what image runs, so a leaked/replayed token forces
+#     at most a rollout CHECK of the tag the box is already pinned to — a bounded
+#     no-op, not an RCE lever.
+#   * Single-flight lock: concurrent/rapid calls don't launch parallel rollouts.
+#
+# Runs on the same docker:*-cli base + mounts as the `rollout` service (Docker
+# socket, this dir at /workspace:ro, the docker-rollout plugin), so it reuses
+# rollout.sh verbatim. socat is apk-added at start, mirroring how rollout.sh
+# apk-adds the compose plugin — runtime apk-add is the established pattern here.
+#
+# Modes:
+#   deploy-hook.sh --serve    listen on $HOOK_PORT (default 9000), fork a handler
+#                             per connection (used by the `hook` compose service)
+#   deploy-hook.sh --handle   process ONE HTTP request on stdin/stdout (socat EXEC)
+#   deploy-hook.sh --roll     run the single-flight rollout (spawned detached)
+set -eu
+
+HOOK_PORT="${HOOK_PORT:-9000}"
+LOCK="/tmp/deploy-hook-rollout.lock"
+TOKEN="${DEPLOY_HOOK_TOKEN:-}"
+
+log() { echo "deploy-hook: $*"; }
+
+# ---- one HTTP request, on stdin → response on stdout -----------------------
+handle() {
+  # Request line: "POST /__hooks/rollout HTTP/1.1". Split on whitespace.
+  IFS=' ' read -r method path _rest || return 0
+  : "${path:=/}"
+
+  # Headers until the blank line; capture Authorization + Content-Length. Use tr
+  # (not bash `${//}`, which busybox ash lacks) to strip CR and surrounding space.
+  auth=""
+  clen=0
+  while IFS= read -r header; do
+    header=$(printf '%s' "$header" | tr -d '\r')
+    [ -z "$header" ] && break
+    case "$header" in
+      [Aa]uthorization:*) auth=$(printf '%s' "${header#*:}" | sed 's/^[[:space:]]*//') ;;
+      [Cc]ontent-[Ll]ength:*) clen=$(printf '%s' "${header#*:}" | tr -cd '0-9') ;;
+    esac
+  done
+
+  # Drain any request body so the read side finishes cleanly (our CI POST sends
+  # none, so clen is normally 0 and this is a no-op).
+  case "$clen" in
+    ''|*[!0-9]*) clen=0 ;;
+  esac
+  [ "$clen" -gt 0 ] && dd bs=1 count="$clen" >/dev/null 2>&1 || true
+
+  if [ "$method" != "POST" ]; then
+    respond "405 Method Not Allowed" "POST only"
+    return 0
+  fi
+  if [ -z "$TOKEN" ] || [ "$auth" != "Bearer $TOKEN" ]; then
+    log "rejected ${method} ${path} (bad or missing token)"
+    respond "401 Unauthorized" "bad token"
+    return 0
+  fi
+
+  # Single-flight: mkdir is atomic. Got it → start a detached rollout; else a
+  # rollout is already running and this call folds into it.
+  if mkdir "$LOCK" 2>/dev/null; then
+    log "authorized — triggering rollout"
+    respond "202 Accepted" "rolling"
+    # Detach into its own session so the multi-minute rollout survives this
+    # short-lived connection handler being reaped by socat when the socket closes.
+    # Log to the service's stdout (pid 1) so `docker compose logs hook` shows it.
+    setsid "$0" --roll </dev/null >/proc/1/fd/1 2>&1 &
+  else
+    log "authorized — rollout already in progress"
+    respond "200 OK" "rollout already in progress"
+  fi
+}
+
+# HTTP/1.1 response with an explicit Content-Length + Connection: close, so the
+# client (curl) sees a complete message and the socket closes deterministically.
+respond() {
+  _status="$1"
+  _body="$2"
+  _len=$(printf '%s' "$_body" | wc -c | tr -d ' ')
+  printf 'HTTP/1.1 %s\r\nContent-Type: text/plain\r\nContent-Length: %s\r\nConnection: close\r\n\r\n%s' \
+    "$_status" "$_len" "$_body"
+}
+
+# ---- the actual rollout (detached; always frees the lock) ------------------
+roll() {
+  # rmdir on ANY exit so a crash can't wedge the single-flight lock permanently.
+  trap 'rmdir "$LOCK" 2>/dev/null || true' EXIT INT TERM
+  log "rollout.sh start"
+  # Reuse the vendored one-shot rollout verbatim (pull + roll only if changed).
+  ROLLOUT_SERVICE="${ROLLOUT_SERVICE:-preview}" sh /workspace/rollout.sh || log "rollout.sh exited non-zero"
+  log "rollout.sh done"
+}
+
+# ---- listener --------------------------------------------------------------
+serve() {
+  if ! command -v socat >/dev/null 2>&1; then
+    log "installing socat"
+    apk add --no-cache socat >/dev/null 2>&1 || {
+      log "could not install socat — deploy hook unavailable"; exec sleep infinity; }
+  fi
+  if [ -z "$TOKEN" ]; then
+    # Fail-closed: without a token we will NEVER authorize a roll, so don't even
+    # open the port. Stay up (idle) rather than crash-loop under restart:always.
+    log "DEPLOY_HOOK_TOKEN unset — deploy hook DISABLED (idle). Set it in .env to enable."
+    exec sleep infinity
+  fi
+  # Clear a stale lock left by an unclean previous stop, so the first call works.
+  rmdir "$LOCK" 2>/dev/null || true
+  log "listening on :${HOOK_PORT} (POST → single-flight rollout of '${ROLLOUT_SERVICE:-preview}')"
+  # Invoke via `/bin/sh <script>` (not the bare exec bit) so it works even if the
+  # read-only bind mount didn't preserve the file's executable mode. socat splits
+  # the EXEC command on spaces into argv; the script path has none.
+  exec socat "TCP-LISTEN:${HOOK_PORT},reuseaddr,fork" "EXEC:/bin/sh $0 --handle"
+}
+
+case "${1:-}" in
+  --serve)  serve ;;
+  --handle) handle ;;
+  --roll)   roll ;;
+  *) echo "usage: $0 --serve|--handle|--roll" >&2; exit 64 ;;
+esac

--- a/deploy/image/docker-compose.yml
+++ b/deploy/image/docker-compose.yml
@@ -155,6 +155,41 @@ services:
     working_dir: /workspace
     entrypoint: ["/bin/sh", "/workspace/rollout.sh", "--loop"]
 
+  # Instant roll on publish: a token-gated webhook that rolls `preview` the moment
+  # a new image is published, instead of waiting up to ROLLOUT_INTERVAL (1200s) for
+  # the `rollout` poll above to notice. The image-publish CI (preview-host-image.yml)
+  # POSTs https://<domain>/__hooks/rollout (Caddy routes /__hooks/rollout here) with
+  # a bearer DEPLOY_HOOK_TOKEN; deploy-hook.sh checks the token and runs rollout.sh
+  # ONE-SHOT (pull + roll only if the digest changed — so a duplicate/replayed call,
+  # or one racing the poll, is a cheap no-op). The poll loop stays on as the fallback,
+  # so a missed webhook still self-heals within one interval. Same base + mounts as
+  # `rollout` (Docker socket, project ro, the docker-rollout plugin) so it reuses
+  # rollout.sh verbatim; socat is apk-added at start like rollout.sh adds compose.
+  # Fail-closed: with no DEPLOY_HOOK_TOKEN the service stays up but idle (never opens
+  # the port) — set it in .env (setup.sh generates one) to enable. Only `expose`d on
+  # the compose network, never a host port; reachable solely via Caddy's route.
+  # Comment this service out (and the Caddyfile /__hooks/rollout route) to disable the
+  # webhook and rely on the poll loop alone.
+  hook:
+    image: docker:29-cli
+    restart: always
+    depends_on:
+      - preview
+    environment:
+      # The shared secret the publish CI must present. Empty ⇒ hook disabled (idle).
+      DEPLOY_HOOK_TOKEN: "${DEPLOY_HOOK_TOKEN:-}"
+      # Passed through to the rollout it triggers (same meaning as the `rollout` svc).
+      ROLLOUT_HEALTH_TIMEOUT: "${ROLLOUT_HEALTH_TIMEOUT:-300}"
+      HOOK_PORT: "9000"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./:/workspace:ro
+      - ./docker-rollout:/usr/local/lib/docker/cli-plugins/docker-rollout:ro
+    working_dir: /workspace
+    expose:
+      - "9000"
+    entrypoint: ["/bin/sh", "/workspace/deploy-hook.sh", "--serve"]
+
   # Auto-update for `caddy` only: poll GHCR and recreate `caddy` when the
   # preview-caddy-image workflow publishes a new baked-Caddyfile image. `preview`
   # is intentionally NOT labelled here — it's rolled by the `rollout` service

--- a/deploy/image/setup.sh
+++ b/deploy/image/setup.sh
@@ -25,16 +25,26 @@ fi
 
 if [[ ! -f .env ]]; then
   TOKEN="$(openssl rand -hex 24)"
-  printf 'DOMAIN=%s\nSERVE_TOKEN=%s\n' "${DOMAIN}" "${TOKEN}" > .env
+  # DEPLOY_HOOK_TOKEN gates the /__hooks/rollout webhook that lets image-publish CI
+  # roll this box the instant a new image ships (else it waits for the poll loop).
+  # Add the SAME value as the repo's DEPLOY_HOOK_TOKEN Actions secret (printed below).
+  HOOK_TOKEN="$(openssl rand -hex 24)"
+  printf 'DOMAIN=%s\nSERVE_TOKEN=%s\nDEPLOY_HOOK_TOKEN=%s\n' "${DOMAIN}" "${TOKEN}" "${HOOK_TOKEN}" > .env
   chmod 600 .env
-  echo "==> Wrote .env with a freshly generated token"
+  echo "==> Wrote .env with freshly generated tokens"
 else
   if grep -q '^DOMAIN=' .env; then
     sed -i "s#^DOMAIN=.*#DOMAIN=${DOMAIN}#" .env
   else
     printf 'DOMAIN=%s\n' "${DOMAIN}" >> .env
   fi
-  echo "==> Reusing existing .env (token preserved)"
+  # Backfill DEPLOY_HOOK_TOKEN on an older .env so the instant-roll webhook is armed
+  # (missing ⇒ the `hook` service stays idle and the box only rolls on its poll).
+  if ! grep -q '^DEPLOY_HOOK_TOKEN=' .env; then
+    printf 'DEPLOY_HOOK_TOKEN=%s\n' "$(openssl rand -hex 24)" >> .env
+    echo "==> Added a generated DEPLOY_HOOK_TOKEN to .env (instant-roll webhook)"
+  fi
+  echo "==> Reusing existing .env (tokens preserved)"
 fi
 
 # Install the vendored docker-rollout CLI plugin so `sudo docker rollout preview`
@@ -66,3 +76,14 @@ else
   echo "    https://${DOMAIN}/?token=${TOKEN}   (token-gated — SERVE_PUBLIC=0)"
 fi
 echo "    Logs: sudo docker compose logs -f preview"
+
+# Surface the deploy-hook token so CI can be wired to roll this box on publish.
+HOOK_TOKEN="$( (grep '^DEPLOY_HOOK_TOKEN=' .env || true) | cut -d= -f2- )"
+if [[ -n "${HOOK_TOKEN}" ]]; then
+  echo
+  echo "==> Instant-roll webhook: to have image-publish CI roll this box the moment a"
+  echo "    new image ships (instead of waiting for the poll), add this repo Actions secret:"
+  echo "      DEPLOY_HOOK_TOKEN=${HOOK_TOKEN}"
+  echo "    (and, if this box isn't preview.coo.ee, a DEPLOY_HOOK_URL variable ="
+  echo "     https://${DOMAIN}/__hooks/rollout). Until then the box still rolls on its poll."
+fi

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -246,8 +246,21 @@ release that carries `--catalogs-unlisted`).
 released `compose-preview-host` image on an **8 GB host**, no build. The **whole deploy chain is
 automatic**: cutting a CLI release publishes the host image to GHCR (release-please invokes
 [`preview-host-image.yml`](../.github/workflows/preview-host-image.yml) via `workflow_call`, tagging
-that version **and** `:latest`), and **Watchtower** on the box polls the `:latest` tag hourly and
-rolls the `preview` container onto the new image — no manual step.
+that version **and** `:latest`), and the box's zero-downtime **`rollout`** service rolls the
+`preview` container onto the new image (`caddy` is rolled separately by **Watchtower**) — no manual
+step.
+
+The roll happens two ways, whichever fires first: the publish workflow's **final step POSTs a
+token-gated `/__hooks/rollout` webhook** so the box rolls the *instant* the image lands, and the
+`rollout` service **also polls** GHCR every `ROLLOUT_INTERVAL`s (default 1200) as a fallback so a
+missed webhook still self-heals. The webhook is fired from the **image-publish step, not a `release:
+published` event** — on purpose: at image-publish time the GHCR image is fully self-contained (baked
+CLI + plugin jars + warm caches + Android daemon), so the box needs **only GHCR** to roll and no
+Maven-Central propagation can race it (the image build already absorbed that via the seeded local
+`m2` + the Dockerfile warm-render retry). A release-event webhook would fire *before* the image is
+built and roll onto the *old* image. It's gated by a `DEPLOY_HOOK_TOKEN` (fail-closed if unset) and
+can only trigger a rollout *check* of the already-configured tag — see
+[`deploy/image` README → Instant roll on publish](../deploy/image/README.md#instant-roll-on-publish-webhook--skips-the-poll-wait).
 
 > **Why the *Publish preview-host image* Actions list can look stale.** Because that publish runs as
 > a **reusable-workflow call** from the release job, its runs appear *inside the release-please run*,
@@ -256,9 +269,10 @@ rolls the `preview` container onto the new image — no manual step.
 > **every release rebuilds the image**. To confirm which build is deployed, check the release-please
 > run, the GHCR `:latest` digest, or [`GET /version`](#endpoints) — not the preview-host-image run list.
 
-The two delivery paths move on **different clocks**: a **daemon/CLI change** reaches the box on the
-next Watchtower pull of a new release image, while a **`design-artifacts` regen** reaches it much
-sooner — the server **auto-refreshes the catalog branches** in between image rolls (re-checks each
+The two delivery paths move on **different clocks**: a **daemon/CLI change** reaches the box when it
+rolls onto a new release image (now near-instant via the publish webhook, else within one `rollout`
+poll), while a **`design-artifacts` regen** reaches it a different way — the server **auto-refreshes
+the catalog branches** in between image rolls (re-checks each
 `design-artifacts/<system>` head every `SERVE_CATALOG_REFRESH`s, default 600, and re-fetches on
 change, no restart). So a catalog repack needs no image roll, but a change to how the daemon *renders*
 (or *loads resources*) does. This is the canonical public deployment. The image bakes the


### PR DESCRIPTION
## Summary

Makes the `preview.coo.ee` deploy **faster and more predictable** by closing the polling gap between "image published to GHCR" and "box actually rolls onto it."

Today the box's `rollout` service only notices a new image on its next poll tick, so a fresh release sits **up to `ROLLOUT_INTERVAL` (default 1200s)** before the box even *starts* rolling. This adds a token-gated `POST /__hooks/rollout` webhook that the image-publish workflow fires as its final step, so the box rolls the **instant** the image lands. The poll loop stays on as a fallback, so a missed webhook still self-heals within one interval.

### Fire on the image, not the release — this is the crux

The webhook is triggered from the **end of `preview-host-image.yml`** (image published), **not** a `release: published` event. This is deliberate and answers the "is that too soon / will Maven not be ready?" question:

- At image-publish time the GHCR image is **fully self-contained** (baked CLI + plugin jars in `~/.m2` + warm Gradle cache + Android daemon/SDK/`android-all`), so the box needs **only GHCR** to roll. No Maven-Central propagation can race it — the image *build* already absorbed that wait (finalize-release's Central poll + the seeded local `m2` artifact + the Dockerfile's warm-render retry loop).
- A `release: published` webhook would fire **before** this job builds the image, and roll the box onto the **old** `:latest`. So the release event is genuinely "too soon"; the image-publish event is not.

## What changed

- **`deploy/image/deploy-hook.sh`** (new) — a small socat-based receiver that reuses `rollout.sh` verbatim. Bearer-token gated (`DEPLOY_HOOK_TOKEN`), **fail-closed** (stays idle and never opens its port when the token is unset), single-flight lock (overlapping calls fold into the in-progress roll), detached so the multi-minute roll survives the short-lived connection.
- **`deploy/image/docker-compose.yml`** — new `hook` service (same base + mounts as `rollout`: Docker socket, project `:ro`, the docker-rollout plugin; `expose`d only, no host port).
- **`deploy/image/Caddyfile`** — route `/__hooks/rollout` to the `hook` sidecar (auth enforced in the hook, not Caddy); everything else still proxies to `preview`.
- **`.github/workflows/preview-host-image.yml`** — best-effort notify step after the build: POSTs the hook (skipped when no `DEPLOY_HOOK_TOKEN` secret, never fails the publish), then confirms convergence by polling the ungated `/version` until it reports the new build.
- **`deploy/image/setup.sh`** — generate `DEPLOY_HOOK_TOKEN` into `.env` (backfilled on existing boxes) and print it so it can be registered as the repo's `DEPLOY_HOOK_TOKEN` Actions secret.
- **Docs** — `deploy/image/README.md` (new "Instant roll on publish" section + Files table + private-GHCR note) and `docs/public-preview-server.md`.

## Safety

Exposing an endpoint that triggers `docker rollout` (root-equivalent via the socket) is bounded by construction:
- Bearer token required; fail-closed when unset (never an unauthenticated exec endpoint), behind Caddy TLS.
- The **only** effect is `rollout.sh` on the **already-configured** image tag — the caller can't choose what image runs, and `rollout.sh` rolls only if the pulled digest actually changed. So a leaked/replayed token forces at most a rollout *check* of the tag the box is already pinned to: a bounded, idempotent no-op, not an RCE lever.

## Test plan

- Unit-tested the receiver's request handling locally (`--handle` on crafted HTTP): bad/missing token → `401`, wrong method → `405`, valid POST → `202` + single-flight lock acquired, second call while locked → `200 "already in progress"`. `setsid` present on the target base.
- `sh -n` / `bash -n` clean on `deploy-hook.sh` and `setup.sh`; YAML parses for the compose file and workflow.
- Text-only change (deploy plumbing + CI wiring) — no visual surfaces affected, so no render evidence applies.

### Operator wiring (one-time)

`setup.sh` prints a generated `DEPLOY_HOOK_TOKEN`; add the same value as the repo's `DEPLOY_HOOK_TOKEN` Actions secret. For a box other than `preview.coo.ee`, also set a `DEPLOY_HOOK_URL` repo variable to `https://<domain>/__hooks/rollout`. Until the secret exists the CI step is skipped and the box keeps rolling on its poll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VpYf4iz5DXvX9bneyzhNcc)_