### PR TITLE
feat(plugin): render previews on a JDK matching the consumer's bytecode

### DIFF
--- a/docs/CLOUD-TESTING.md
+++ b/docs/CLOUD-TESTING.md
@@ -69,7 +69,7 @@ and logs `queryRawGalleryExtensions Failed to fetch` plus a few
 `ssl_client_socket … handshake failed` lines. Side-loaded extensions are
 unaffected.
 
-### 2 + 3. JDK 17, trust store, and the toolchain symlink
+### 2 + 3. JDKs, trust store, and the toolchain symlinks
 
 ```bash
 export JAVA_HOME="$(scripts/setup-cloud-jdk.sh)"
@@ -78,10 +78,19 @@ export JAVA_HOME="$(scripts/setup-cloud-jdk.sh)"
 [`setup-cloud-jdk.sh`](../scripts/setup-cloud-jdk.sh) does three things,
 each fixing a distinct cloud-specific failure:
 
-- **Installs Temurin 17** from Adoptium's GitHub releases, because the
-  container ships only JDK 21 but the build pins `toolchainVersion=17`
-  ([`gradle/gradle-daemon-jvm.properties`](../gradle/gradle-daemon-jvm.properties)),
-  and foojay auto-provisioning is blocked. (The bootstrap
+- **Installs a set of Temurin JDKs** (default majors `17 21 25`, override
+  with `CLOUD_JDK_MAJORS`) from Adoptium's GitHub releases. JDK 17 is the
+  build's own pinned `toolchainVersion`
+  ([`gradle/gradle-daemon-jvm.properties`](../gradle/gradle-daemon-jvm.properties));
+  the newer majors are there so the render subprocess can fork on a JDK
+  that matches the **consumer's** bytecode target — a consumer whose modules
+  compile to Java 21 needs a JDK 21 the render can load their classes on, or
+  every preview fails with `UnsupportedClassVersionError` (see
+  [`RenderJvmSelection`](../gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderJvmSelection.kt)).
+  Foojay toolchain auto-provisioning is blocked in the sandbox, so the JDKs
+  have to be placed on disk out-of-band; the primary major's `JAVA_HOME` is
+  printed on stdout, additional majors are best-effort (a not-yet-published
+  major logs a warning and is skipped). (The bootstrap
   [`scripts/install.sh --android-sdk`](../scripts/install.sh) tries to
   apt-install JDK 17 and fails here — `security.ubuntu.com` 404s the
   pinned `.deb`; the Adoptium tarball is the reliable path.)
@@ -92,15 +101,16 @@ each fixing a distinct cloud-specific failure:
   with `PKIX path building failed: unable to find valid certification
   path`. `curl` and the system JDK 21 work because their trust stores
   already carry the CA; a tarball Temurin does not.
-- **Symlinks the JDK into `/usr/lib/jvm`** so Gradle's "Common Linux
-  Locations" toolchain auto-detection finds it. This is the linchpin:
-  Gradle otherwise only sees a JDK that is the *current* daemon JVM, so a
-  build whose daemon runs on JDK 21 (because `JAVA_HOME` did not propagate
-  to a spawned `gradlew`) can't resolve a `languageVersion=17` toolchain
-  even with the JDK on disk. The symlink is what makes the repo's own
-  `toolchainVersion=17` daemon run under a JDK-21 launcher, and what lets
-  Confetti's `:proto` toolchain-17 module resolve while the daemon renders
-  on JDK 21.
+- **Symlinks each JDK into `/usr/lib/jvm`** (`temurin-17`, `temurin-21`,
+  …) so Gradle's "Common Linux Locations" toolchain auto-detection finds
+  them. This is the linchpin: Gradle otherwise only sees a JDK that is the
+  *current* daemon JVM, so a build whose daemon runs on JDK 21 (because
+  `JAVA_HOME` did not propagate to a spawned `gradlew`) can't resolve a
+  `languageVersion=17` toolchain even with the JDK on disk. The symlinks are
+  what make the repo's own `toolchainVersion=17` daemon run under a JDK-21
+  launcher, let Confetti's `:proto` toolchain-17 module resolve while the
+  daemon renders on JDK 21, and let the plugin raise a consumer's render
+  fork to a JDK 21/25 that matches their bytecode.
 
 ## JDK topology for the Confetti e2e
 

--- a/gradle-plugin/gradle-plugin-config/src/main/kotlin/ee/schimke/composeai/plugin/PreviewExtension.kt
+++ b/gradle-plugin/gradle-plugin-config/src/main/kotlin/ee/schimke/composeai/plugin/PreviewExtension.kt
@@ -28,6 +28,29 @@ abstract class PreviewExtension @Inject constructor(private val objects: ObjectF
   val enabled: Property<Boolean> = objects.property(Boolean::class.java).convention(true)
 
   /**
+   * JDK major version the preview *render subprocess* forks into (e.g. `21`). Escape hatch for the
+   * automatic selection: leave it unset (default) and the plugin picks a render JVM new enough to
+   * load the module's compiled classes on its own — the maximum of the consumer's toolchain, the
+   * JVM Gradle is running on, and the highest detected Kotlin `jvmTarget` / Java
+   * `targetCompatibility` — provisioning a matching JDK through Gradle's toolchain service when an
+   * upgrade is needed.
+   *
+   * Set this only to override that decision: pin a specific JDK for reproducibility, or force one
+   * when the module's bytecode target can't be auto-detected (e.g. a non-standard Kotlin compile
+   * setup). The value is honoured verbatim, including a deliberately *lower* JDK than the module
+   * compiles to — in which case classes may fail to load with `UnsupportedClassVersionError`, so
+   * lower it only when you know the render classpath stays within that JDK's bytecode level.
+   *
+   * A matching JDK must be resolvable — installed and discoverable by Gradle toolchain detection,
+   * or downloadable. When it isn't, Gradle fails with a toolchain-resolution error rather than
+   * silently falling back; `composePreviewDoctor` explains the mismatch and this knob is the fix.
+   *
+   * Override at the command line with `-PcomposePreview.renderJavaVersion=21` for a single run
+   * without editing `build.gradle.kts`.
+   */
+  val renderJavaVersion: Property<Int> = objects.property(Int::class.java)
+
+  /**
    * Number of parallel JVM forks used to render previews. Default `0` (auto).
    *
    * Special values:

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -16,6 +16,8 @@ import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.compile.JavaCompile
 import org.gradle.api.tasks.testing.Test
+import org.gradle.jvm.toolchain.JavaLauncher
+import org.gradle.jvm.toolchain.JavaToolchainService
 
 /**
  * All AGP-touching code lives here, segregated from [ComposePreviewPlugin] so the plugin class
@@ -1793,6 +1795,31 @@ internal object AndroidPreviewSupport {
         }
       } else null
 
+    // --- Render JVM selection ---------------------------------------------------------------
+    // The render/daemon subprocess must fork on a JDK new enough to LOAD the consumer's compiled
+    // classes. AGP's unit-test javaLauncher follows the consumer *toolchain*, but Kotlin can emit
+    // newer bytecode than that toolchain JDK (and the VS Code daemon may fall back to its own older
+    // bundled JDK), so blindly inheriting it throws UnsupportedClassVersionError on every preview —
+    // the situation meshcore-mobile#271 worked around by downgrading app bytecode across a dozen
+    // modules. Instead pick the max of {inherited toolchain, Gradle daemon JVM, detected bytecode
+    // target}, overridable via `composePreview.renderJavaVersion`, and provision it through the
+    // toolchain service. See [RenderJvmSelection]. Computed once here and reused across the render,
+    // resource, XR and daemon-start tasks below.
+    val javaToolchains = project.extensions.getByType(JavaToolchainService::class.java)
+    val gradleDaemonMajor = JavaVersion.current().majorVersion.toInt()
+    val renderJavaOverride =
+      project.providers.gradleProperty("composePreview.renderJavaVersion").orNull?.toIntOrNull()
+        ?: extension.renderJavaVersion.orNull
+    val renderBytecodeMajor = detectRenderBytecodeMajor(project, capVariant)
+    fun renderJavaLauncher(agpTestTask: Test?): Provider<JavaLauncher>? =
+      RenderJvmSelection.launcherFor(
+        toolchains = javaToolchains,
+        inherited = agpTestTask?.javaLauncher,
+        gradleDaemonMajor = gradleDaemonMajor,
+        bytecodeMajor = renderBytecodeMajor,
+        explicitOverride = renderJavaOverride,
+      )
+
     val renderTask =
       project.tasks.register("composePreviewRender", Test::class.java) {
         group = "compose preview"
@@ -1860,19 +1887,18 @@ internal object AndroidPreviewSupport {
         // preview daemon can reuse the same set when launching its own JVM.
         jvmArgs(AndroidPreviewClasspath.buildJvmArgs())
 
-        // Inherit AGP's unit-test javaLauncher so the forked test worker
-        // runs on the same JDK as `test${capVariant}UnitTest` — which
-        // AGP has already wired to the project's Java toolchain if the
-        // consumer configured one (`java { toolchain { … } }` /
-        // `kotlin { jvmToolchain(…) }`), or to the daemon JVM otherwise.
-        //
-        // Without this, a custom `Test` task's `javaLauncher` property
-        // defaults to the first `java` on PATH, which on CI and in local
-        // shells with `JAVA_HOME` overrides is NOT necessarily the same
-        // JVM the Gradle daemon is running. That mismatch produces
-        // `ClassNotFoundException: android.app.Application` during JUnit
-        // discovery on some JVM/classloader combinations. See #142.
-        agpTestTask?.javaLauncher?.orNull?.let { javaLauncher.set(it) }
+        // Fork the render worker on AGP's unit-test javaLauncher — the JDK
+        // `test${capVariant}UnitTest` uses, wired to the project's Java toolchain
+        // (`java { toolchain { … } }` / `kotlin { jvmToolchain(…) }`) or the daemon
+        // JVM otherwise — UNLESS the consumer's bytecode target is newer than that
+        // JDK, in which case [renderJavaLauncher] raises it (via the toolchain
+        // service) so the classes actually load. Inheriting matters for the base
+        // case: a custom `Test` task's `javaLauncher` otherwise defaults to the first
+        // `java` on PATH, not the daemon JVM, producing `ClassNotFoundException:
+        // android.app.Application` during JUnit discovery on some JVM/classloader
+        // combinations (#142); raising it matters for newer bytecode, else every
+        // preview fails with `UnsupportedClassVersionError` (meshcore-mobile#271).
+        renderJavaLauncher(agpTestTask)?.let { javaLauncher.set(it) }
 
         // GoogleFont interceptor cache lives in the shared, machine-local
         // `${'$'}XDG_CACHE_HOME/composeai/fonts` (else `~/.cache/composeai/fonts`).
@@ -2006,18 +2032,26 @@ internal object AndroidPreviewSupport {
         }
       }
 
-    // Feed the JDK-aware Robolectric SDK ceiling with the JVM the render forks into. Default to the
-    // Gradle build JVM: the `composePreviewRender` Test task inherits AGP's unit-test
-    // `javaLauncher`, which — absent a consumer toolchain — is the build JVM, so this is the JVM
-    // `DefaultSdkProvider.verifySupportedSdk` actually runs under (the Confetti case the fix
-    // targets). Deliberately a plain value, NOT a provider derived from `renderTask` — mapping a
-    // `TaskProvider` carries that task as a dependency, and `renderTask` already dependsOn this
-    // generator (via the generated-resources classpath), so that would be a circular dependency.
-    // The SDK matrix forks tests into `composeai.matrix.jvmToolchain` and overrides this input
-    // directly (see `samples/sdk-matrix/build.gradle.kts`). See
+    // Feed the JDK-aware Robolectric SDK ceiling with the JVM the render actually forks into —
+    // which is exactly what [renderJavaLauncher] resolves (the raised toolchain when the consumer's
+    // bytecode outruns their toolchain, else the inherited AGP launcher, else the build JVM).
+    // Keying
+    // off the real render launcher rather than `JavaVersion.current()` also fixes the toolchain=17
+    // /
+    // Gradle-daemon=21 case, where the render forks on 17 but the ceiling used to be computed as if
+    // it were 21. Derived from `agpTestTask.javaLauncher` / the toolchain service (NOT from
+    // `renderTask`, which already dependsOn this generator — that would be a circular dependency),
+    // so no task dependency is introduced. The SDK matrix still overrides this input directly (see
+    // `samples/sdk-matrix/build.gradle.kts`). See
     // [GenerateRobolectricPropertiesTask.buildJavaMajor].
     generateRobolectricPropertiesTask.configure {
-      buildJavaMajor.set(JavaVersion.current().majorVersion.toInt())
+      val agpTestTask = project.tasks.findByName("test${capVariant}UnitTest") as? Test
+      val launcher = renderJavaLauncher(agpTestTask) ?: agpTestTask?.javaLauncher
+      if (launcher != null) {
+        buildJavaMajor.set(launcher.map { it.metadata.languageVersion.asInt() })
+      } else {
+        buildJavaMajor.set(gradleDaemonMajor)
+      }
     }
 
     if (extension.resourcePreviews.enabled.get()) {
@@ -2049,7 +2083,7 @@ internal object AndroidPreviewSupport {
 
         jvmArgs(agpTestTask?.jvmArgs ?: emptyList<String>())
         jvmArgs(AndroidPreviewClasspath.buildJvmArgs())
-        agpTestTask?.javaLauncher?.orNull?.let { javaLauncher.set(it) }
+        renderJavaLauncher(agpTestTask)?.let { javaLauncher.set(it) }
 
         systemProperty("robolectric.graphicsMode", "NATIVE")
         systemProperty("robolectric.looperMode", "PAUSED")
@@ -2128,7 +2162,7 @@ internal object AndroidPreviewSupport {
 
         jvmArgs(agpTestTask?.jvmArgs ?: emptyList<String>())
         jvmArgs(AndroidPreviewClasspath.buildJvmArgs())
-        agpTestTask?.javaLauncher?.orNull?.let { javaLauncher.set(it) }
+        renderJavaLauncher(agpTestTask)?.let { javaLauncher.set(it) }
 
         systemProperty("robolectric.graphicsMode", "NATIVE")
         systemProperty("robolectric.looperMode", "PAUSED")
@@ -2526,13 +2560,15 @@ internal object AndroidPreviewSupport {
       // Property leaves room for future variants (foreground / debug) without
       // schema churn. See [DaemonBootstrapTask] / [DaemonClasspathDescriptor].
       this.mainClass.set("ee.schimke.composeai.daemon.DaemonMain")
-      // Inherit AGP's unit-test javaLauncher exactly the way composePreviewRender
-      // does (see line ~802 above) so the daemon runs on the project's
-      // configured toolchain rather than the first `java` on PATH. AGP's
-      // javaLauncher Property is itself a config-cache-safe Provider produced
-      // by the toolchains plugin, so mapping it to an absolute path doesn't
-      // introduce any new captures.
-      agpTestTask?.javaLauncher?.let { launcher ->
+      // Bake an explicit render JVM into `daemon-launch.json` the same way composePreviewRender
+      // forks — the raised toolchain when the consumer's bytecode outruns their toolchain, else the
+      // inherited AGP launcher (the project toolchain rather than the first `java` on PATH). This
+      // is
+      // the load-bearing fix for the VS Code daemon: its `javaLauncher` is `@Optional`, and when
+      // left null the extension falls back to *its own* bundled JDK (commonly 17), which then can't
+      // load Java-21 classes (meshcore-mobile#271). Both branches are config-cache-safe Providers
+      // from the toolchains service, so mapping to an absolute path introduces no new captures.
+      renderJavaLauncher(agpTestTask)?.let { launcher ->
         this.javaLauncher.set(launcher.map { it.executablePath.asFile.absolutePath })
       }
       // Daemon module's classes FIRST so [mainClass] resolves before
@@ -2825,6 +2861,29 @@ internal object AndroidPreviewSupport {
     @get:org.gradle.api.tasks.Input val tier: org.gradle.api.provider.Provider<String>
   ) : org.gradle.process.CommandLineArgumentProvider {
     override fun asArguments(): Iterable<String> = listOf("-Dcomposeai.render.tier=${tier.get()}")
+  }
+
+  /**
+   * Highest JVM bytecode target the consumer's classes compile to, across the Java
+   * (`compileOptions.targetCompatibility` on AGP's `CommonExtension`) and Kotlin
+   * (`compilerOptions.jvmTarget` on the variant's `compile<Variant>Kotlin` task) toolchains, or
+   * `null` when neither can be read. Feeds [RenderJvmSelection] so the render JVM is raised to
+   * match the classes it must load. Fully defensive — a probe that throws (no Kotlin plugin, a
+   * renamed KGP accessor, no AGP `compileOptions`) is skipped rather than failing configuration.
+   */
+  private fun detectRenderBytecodeMajor(project: Project, capVariant: String): Int? {
+    val candidates = mutableListOf<Int>()
+    runCatching {
+      project.extensions
+        .findByType(CommonExtension::class.java)
+        ?.compileOptions
+        ?.targetCompatibility
+        ?.let { BytecodeTargetDetector.parseTargetMajor(it.toString()) }
+        ?.let { candidates += it }
+    }
+    BytecodeTargetDetector.detectKotlinJvmTarget(project, listOf("compile${capVariant}Kotlin"))
+      ?.let { candidates += it }
+    return candidates.filter { it > 0 }.maxOrNull()
   }
 
   private fun copyAttributes(target: AttributeContainer, source: AttributeContainer) {

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderJvmSelection.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderJvmSelection.kt
@@ -1,0 +1,156 @@
+package ee.schimke.composeai.plugin
+
+import org.gradle.api.Project
+import org.gradle.api.provider.Provider
+import org.gradle.jvm.toolchain.JavaLanguageVersion
+import org.gradle.jvm.toolchain.JavaLauncher
+import org.gradle.jvm.toolchain.JavaToolchainService
+
+/**
+ * Picks the JDK the preview *render subprocess* forks into so it can load the consumer's compiled
+ * classes, instead of asking the consumer to downgrade their bytecode target.
+ *
+ * ## The problem
+ *
+ * Every render path (`composePreviewRender`, the resource/XR render tasks, the VS Code daemon) runs
+ * the consumer's `.class` files in a forked JVM, and that JVM is chosen by inheriting AGP's
+ * unit-test `javaLauncher` — which follows the consumer's *toolchain*. But Kotlin's `jvmTarget` can
+ * emit **newer** bytecode than the toolchain JDK (kotlinc on JDK 17 happily emits Java-21 class
+ * files), and the VS Code daemon frequently falls back to its own bundled JDK 17. When the render
+ * JVM is older than the bytecode it must load, the class loader throws
+ * `UnsupportedClassVersionError` and *every* preview fails — with no message that points at the
+ * JDK.
+ *
+ * The historical workaround (see meshcore-mobile#271) was for the app to pin every module's
+ * bytecode back down to Java 17. That's invasive — a dozen `build.gradle.kts` edits — and it fights
+ * the direction consumers actually want to move. Instead the plugin selects a render JVM new enough
+ * for the consumer's bytecode and provisions it through Gradle's toolchain service.
+ *
+ * ## Selection
+ *
+ * [selectMajor] is the pure decision. It never returns *below* the inherited launcher (so an
+ * upgrade is the only automatic move — we never silently render on an older JVM than the consumer's
+ * own toolchain), and an explicit `composePreview.renderJavaVersion` override wins outright so the
+ * SDK matrix (and anyone deliberately pinning a JDK) keeps working.
+ */
+internal object RenderJvmSelection {
+  /**
+   * The JDK major the render subprocess should run on.
+   *
+   * @param inheritedMajor the major of AGP's unit-test `javaLauncher` (the consumer toolchain), or
+   *   `null` when AGP exposes none and the render would fall through to the Gradle daemon JVM.
+   * @param gradleDaemonMajor `JavaVersion.current()` — the JVM Gradle itself runs on, always
+   *   available without provisioning.
+   * @param bytecodeMajor the highest bytecode target detected across the module's Kotlin/Java
+   *   compilation, or `null` when it can't be determined.
+   * @param explicitOverride `composePreview.renderJavaVersion` (or the matching `-P` property);
+   *   when set it is honoured verbatim, including deliberately *lower* values.
+   */
+  fun selectMajor(
+    inheritedMajor: Int?,
+    gradleDaemonMajor: Int,
+    bytecodeMajor: Int?,
+    explicitOverride: Int?,
+  ): Int {
+    explicitOverride?.let {
+      return it
+    }
+    // max of every signal: never below the inherited toolchain, never below the JVM Gradle runs on,
+    // and always at least the consumer's bytecode target when we could detect it.
+    return maxOf(inheritedMajor ?: 0, gradleDaemonMajor, bytecodeMajor ?: 0)
+  }
+
+  /**
+   * Build the launcher provider for a render task, given AGP's inherited launcher. Stays lazy — the
+   * inherited launcher is only resolved inside the returned provider — so config-cache
+   * serialization and toolchain resolution both defer to execution time and nothing captures the
+   * [Project].
+   *
+   * When the selected major matches (or is below) what was inherited, the *original* inherited
+   * launcher provider is returned unchanged, preserving the exact JVM AGP wired (issue #142). Only
+   * a genuine upgrade — or an explicit override — routes through [JavaToolchainService], which then
+   * finds an installed JDK of that version or provisions one.
+   */
+  fun launcherFor(
+    toolchains: JavaToolchainService,
+    inherited: Provider<JavaLauncher>?,
+    gradleDaemonMajor: Int,
+    bytecodeMajor: Int?,
+    explicitOverride: Int?,
+  ): Provider<JavaLauncher>? {
+    if (explicitOverride != null) {
+      return toolchains.launcherFor {
+        languageVersion.set(JavaLanguageVersion.of(explicitOverride))
+      }
+    }
+    if (inherited == null) {
+      // No inherited launcher: the render would fall through to the Gradle daemon JVM. Only take
+      // over (routing through the toolchain service) when the bytecode target genuinely exceeds it;
+      // otherwise return null so the caller leaves the convention untouched — no toolchain
+      // resolution, byte-for-byte the prior behaviour.
+      val target = selectMajor(null, gradleDaemonMajor, bytecodeMajor, null)
+      return if (target > gradleDaemonMajor) {
+        toolchains.launcherFor { languageVersion.set(JavaLanguageVersion.of(target)) }
+      } else {
+        null
+      }
+    }
+    return inherited.flatMap { launcher ->
+      val inheritedMajor = launcher.metadata.languageVersion.asInt()
+      val target = selectMajor(inheritedMajor, gradleDaemonMajor, bytecodeMajor, null)
+      if (target <= inheritedMajor) {
+        inherited
+      } else {
+        toolchains.launcherFor { languageVersion.set(JavaLanguageVersion.of(target)) }
+      }
+    }
+  }
+}
+
+/**
+ * Best-effort detection of the highest JVM bytecode target the consumer's classes are compiled to,
+ * so [RenderJvmSelection] can raise the render JVM to match. Every probe is defensive: a missing
+ * Kotlin Gradle plugin, a renamed KGP method, or an unrealised task yields `null`/skips rather than
+ * failing configuration. Detection under-reporting is safe (we fall back to the toolchain/daemon
+ * JVM); over-reporting only matters if a matching JDK can't be provisioned, which surfaces as a
+ * clear toolchain error plus the `composePreview.renderJavaVersion` escape hatch.
+ */
+internal object BytecodeTargetDetector {
+  /**
+   * Parse a Kotlin `JvmTarget` / Java `targetCompatibility` string to its class-file major-version
+   * "feature" number: `"21"`/`"JVM_21"` -> 21, `"1.8"`/`"VERSION_1_8"` -> 8. Returns `null` when no
+   * version-shaped token is present.
+   */
+  fun parseTargetMajor(raw: String?): Int? {
+    if (raw.isNullOrBlank()) return null
+    // Strip any prefix (JVM_, VERSION_) down to the numeric tail; normalise the legacy "1.8" form.
+    val digits = raw.substringAfterLast('_').substringAfterLast('=').trim()
+    val normalised = if (digits.startsWith("1.")) digits.removePrefix("1.") else digits
+    return normalised.takeWhile { it.isDigit() }.toIntOrNull()?.takeIf { it in 1..99 }
+  }
+
+  /**
+   * Read `compilerOptions.jvmTarget` off the named Kotlin compile tasks by reflection, so the
+   * plugin needn't declare a compile dependency on the Kotlin Gradle plugin. Returns the highest
+   * major found, or `null`.
+   */
+  fun detectKotlinJvmTarget(project: Project, candidateTaskNames: List<String>): Int? {
+    var best: Int? = null
+    for (name in candidateTaskNames) {
+      val task = project.tasks.findByName(name) ?: continue
+      val major =
+        runCatching {
+            val opts = task.javaClass.getMethod("getCompilerOptions").invoke(task)
+            val prop =
+              opts.javaClass.methods.firstOrNull { it.name == "getJvmTarget" }?.invoke(opts)
+                ?: return@runCatching null
+            val value =
+              prop.javaClass.getMethod("getOrNull").invoke(prop) ?: return@runCatching null
+            parseTargetMajor(value.toString())
+          }
+          .getOrNull()
+      if (major != null && (best == null || major > best!!)) best = major
+    }
+    return best
+  }
+}

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/RenderJvmSelectionTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/RenderJvmSelectionTest.kt
@@ -1,0 +1,74 @@
+package ee.schimke.composeai.plugin
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Behavioural tests for the render-JVM selection policy. These pin *decisions* about which JDK the
+ * render subprocess forks into — never render on an older JVM than the consumer's bytecode, prefer
+ * an upgrade, honour an explicit override verbatim — independent of any single call site's wiring.
+ */
+class RenderJvmSelectionTest {
+
+  // --- selectMajor ---------------------------------------------------------
+
+  @Test
+  fun `keeps the inherited toolchain when it already covers everything`() {
+    // Toolchain 21, Gradle on 21, bytecode 21 -> no upgrade needed.
+    assertThat(RenderJvmSelection.selectMajor(21, 21, 21, null)).isEqualTo(21)
+  }
+
+  @Test
+  fun `raises the render JVM to the bytecode target above the toolchain`() {
+    // The meshcore case: toolchain/test-launcher is 17 but classes are Java-21 bytecode.
+    assertThat(RenderJvmSelection.selectMajor(17, 17, 21, null)).isEqualTo(21)
+  }
+
+  @Test
+  fun `raises to the Gradle daemon JVM when it is newer than the inherited launcher`() {
+    // VS Code daemon fell back to JDK 17 but Gradle runs on 21 and bytecode is unknown.
+    assertThat(RenderJvmSelection.selectMajor(17, 21, null, null)).isEqualTo(21)
+  }
+
+  @Test
+  fun `falls back to the Gradle daemon JVM when no launcher is inherited`() {
+    assertThat(RenderJvmSelection.selectMajor(null, 21, null, null)).isEqualTo(21)
+  }
+
+  @Test
+  fun `never selects below the inherited toolchain even if bytecode reads lower`() {
+    // A stray low bytecode reading must not drag a genuinely-21 toolchain render down to 17.
+    assertThat(RenderJvmSelection.selectMajor(21, 17, 8, null)).isEqualTo(21)
+  }
+
+  @Test
+  fun `explicit override wins outright, including deliberately lower values`() {
+    // The SDK matrix pins a specific JDK; honour it exactly even below the other signals.
+    assertThat(RenderJvmSelection.selectMajor(21, 21, 21, 17)).isEqualTo(17)
+    assertThat(RenderJvmSelection.selectMajor(17, 17, 17, 25)).isEqualTo(25)
+  }
+
+  @Test
+  fun `picks the highest of the bytecode and daemon signals`() {
+    assertThat(RenderJvmSelection.selectMajor(17, 23, 21, null)).isEqualTo(23)
+    assertThat(RenderJvmSelection.selectMajor(17, 21, 25, null)).isEqualTo(25)
+  }
+
+  // --- parseTargetMajor ----------------------------------------------------
+
+  @Test
+  fun `parses Kotlin JvmTarget and Java target forms`() {
+    assertThat(BytecodeTargetDetector.parseTargetMajor("21")).isEqualTo(21)
+    assertThat(BytecodeTargetDetector.parseTargetMajor("JVM_21")).isEqualTo(21)
+    assertThat(BytecodeTargetDetector.parseTargetMajor("VERSION_17")).isEqualTo(17)
+    assertThat(BytecodeTargetDetector.parseTargetMajor("1.8")).isEqualTo(8)
+    assertThat(BytecodeTargetDetector.parseTargetMajor("VERSION_1_8")).isEqualTo(8)
+  }
+
+  @Test
+  fun `parseTargetMajor tolerates junk`() {
+    assertThat(BytecodeTargetDetector.parseTargetMajor(null)).isNull()
+    assertThat(BytecodeTargetDetector.parseTargetMajor("")).isNull()
+    assertThat(BytecodeTargetDetector.parseTargetMajor("nope")).isNull()
+  }
+}

--- a/scripts/setup-cloud-jdk.sh
+++ b/scripts/setup-cloud-jdk.sh
@@ -1,53 +1,75 @@
 #!/usr/bin/env bash
-# Provision a Temurin JDK 17 that trusts the sandbox's TLS-intercepting
-# egress proxy, for cloud environments where the project toolchain
-# (JDK 17, pinned in `gradle/gradle-daemon-jvm.properties`) is not the
-# JDK the container ships.
+# Provision Temurin JDKs that trust the sandbox's TLS-intercepting egress
+# proxy, for cloud environments where Gradle toolchain auto-provisioning
+# (which goes through api.foojay.io) is blocked by an allowlist network
+# policy.
+#
+# Historically this placed a single JDK 17 on disk — the project toolchain
+# pinned in `gradle/gradle-daemon-jvm.properties`. But the render subprocess
+# now forks on a JDK chosen to match the *consumer's* bytecode target (see
+# `RenderJvmSelection` in the Gradle plugin): a consumer whose modules compile
+# to Java 21 needs a JDK 21 the render can fork into, or every preview fails
+# with `UnsupportedClassVersionError`. In a sandbox where foojay is blocked,
+# that JDK has to be on disk out-of-band too — so this script now provisions a
+# *set* of JDK majors (default: 17 21 25) and symlinks each into
+# `/usr/lib/jvm` so Gradle toolchain detection finds them.
 #
 # Two problems this solves, both specific to locked-down cloud sandboxes
-# (the Claude Code on the web "custom" network mode is the motivating
-# case):
+# (the Claude Code on the web "custom" network mode is the motivating case):
 #
-#  1. **Wrong JDK major.** The container commonly ships only JDK 21, but
-#     this repo pins `toolchainVersion=17`. Gradle's toolchain
-#     auto-provision goes through api.foojay.io, which an allowlist
-#     network policy blocks — so a JDK 17 has to be placed on disk
-#     out-of-band. Adoptium publishes Temurin as GitHub release assets,
+#  1. **Missing JDK major.** The container commonly ships only one JDK, but
+#     the daemon toolchain and the per-consumer render toolchain may need
+#     others. Gradle's toolchain auto-provision goes through api.foojay.io,
+#     which an allowlist network policy blocks — so the JDKs have to be
+#     placed on disk. Adoptium publishes Temurin as GitHub release assets,
 #     which allowlists that permit github.com *do* serve.
 #
-#  2. **MITM proxy CA not trusted by a freshly-downloaded JDK.** The
-#     sandbox proxy terminates TLS with its own CA. The OS trust store
-#     (and the system JDK, whose `cacerts` symlinks to it) carries that
-#     CA, which is why `curl` and the pre-installed JDK 21 work. A
-#     Temurin tarball straight from Adoptium ships the vanilla Adoptium
-#     trust store *without* the proxy CA, so every Java-side HTTPS fetch
-#     (Gradle wrapper distribution, Maven Central / Google Maven
-#     dependency resolution) fails with:
-#       PKIX path building failed: unable to find valid certification
-#       path to requested target
+#  2. **MITM proxy CA not trusted by a freshly-downloaded JDK.** The sandbox
+#     proxy terminates TLS with its own CA. The OS trust store (and the
+#     system JDK, whose `cacerts` symlinks to it) carries that CA, which is
+#     why `curl` and the pre-installed JDK work. A Temurin tarball straight
+#     from Adoptium ships the vanilla Adoptium trust store *without* the proxy
+#     CA, so every Java-side HTTPS fetch (Gradle wrapper distribution, Maven
+#     Central / Google Maven dependency resolution) fails with:
+#       PKIX path building failed: unable to find valid certification path
+#       to requested target
 #     The fix is to copy the system Java trust store over Temurin's.
 #
 # Usage:
-#   scripts/setup-cloud-jdk.sh [INSTALL_DIR]
+#   scripts/setup-cloud-jdk.sh [PRIMARY_INSTALL_DIR]
 #
 # Env (override defaults):
-#   JDK17_VERSION   Temurin tag to pin (default: latest 17 GA)
-#   JDK17_DIR       install dir (default: /opt/jdk17, or arg 1)
+#   CLOUD_JDK_MAJORS  space-separated JDK majors to provision
+#                     (default: "17 21 25"). The FIRST is the "primary" — its
+#                     JAVA_HOME is printed on stdout for
+#                     `export JAVA_HOME=$(scripts/setup-cloud-jdk.sh)`.
+#   JDK17_VERSION     pin the primary's Temurin tag (back-compat alias for the
+#                     primary major when it is 17; default: latest GA).
+#   JDK17_DIR         primary install dir (default: /opt/jdk<primary>, or arg 1).
+#   JDK<major>_DIR    install dir for a specific major (default: /opt/jdk<major>).
+#   JDK<major>_VERSION pin a specific major's Temurin tag (default: latest GA).
 #
-# Output: prints the absolute JAVA_HOME on stdout (suitable for
-# `export JAVA_HOME=$(scripts/setup-cloud-jdk.sh)`).
+# Output: prints the absolute JAVA_HOME of the PRIMARY JDK on stdout.
+# Additional majors are best-effort: a major Adoptium hasn't published yet
+# (or a transient download failure) logs a warning and is skipped rather than
+# failing the whole run — the primary JDK and any that did install are still
+# usable.
 
 set -euo pipefail
 
-install_dir="${1:-${JDK17_DIR:-/opt/jdk17}}"
+# The set of majors to provision. First entry is primary (its JAVA_HOME is
+# emitted on stdout and never treated as best-effort).
+read -r -a JDK_MAJORS <<<"${CLOUD_JDK_MAJORS:-17 21 25}"
+primary_major="${JDK_MAJORS[0]}"
 
 # Locate the system Java trust store that already trusts the proxy CA.
-# Order: the ca-certificates-managed store, then the system JDK's
-# cacerts (usually a symlink to the former).
+# Order: the ca-certificates-managed store, then the system JDK's cacerts
+# (usually a symlink to the former).
 system_truststore=""
 for candidate in \
   /etc/ssl/certs/java/cacerts \
   /usr/lib/jvm/java-21-openjdk-amd64/lib/security/cacerts \
+  /usr/lib/jvm/java-17-openjdk-amd64/lib/security/cacerts \
   "${JAVA_HOME:-}/lib/security/cacerts"; do
   if [[ -n "$candidate" && -f "$candidate" ]]; then
     system_truststore="$candidate"
@@ -72,19 +94,19 @@ fix_truststore() {
 
 # Symlink the JDK into a directory Gradle scans for toolchains
 # (`/usr/lib/jvm`, one of the "Common Linux Locations"). Without this,
-# Gradle only finds the JDK when it is the *current* daemon JVM — so a
-# build whose daemon runs on a different JDK (e.g. the system JDK 21,
-# because `JAVA_HOME` did not propagate to a spawned `gradlew`) cannot
-# resolve a `languageVersion=17` toolchain even though the JDK is on
-# disk. This is what makes the repo's own `toolchainVersion=17`
-# daemon-jvm pin work under a JDK-21 launcher, and what lets a Confetti
-# `:proto` toolchain-17 module resolve while the daemon runs on JDK 21
-# for the Robolectric-36 render. foojay auto-provisioning is the usual
+# Gradle only finds the JDK when it is the *current* daemon JVM — so a build
+# whose daemon runs on a different JDK (e.g. the system JDK, because
+# `JAVA_HOME` did not propagate to a spawned `gradlew`) cannot resolve a
+# `languageVersion=N` toolchain even though the JDK is on disk. This is what
+# makes the repo's own `toolchainVersion=17` daemon-jvm pin work under a
+# different launcher, and what lets a consumer's Java-21 render fork resolve
+# a JDK 21 while the daemon runs on 17. foojay auto-provisioning is the usual
 # fallback, but cloud allowlists block it.
 link_into_jvm_dir() {
   local jdk="$1"
+  local major="$2"
   local jvm_dir="/usr/lib/jvm"
-  local link="$jvm_dir/temurin-17"
+  local link="$jvm_dir/temurin-$major"
   if [[ ! -d "$jvm_dir" ]]; then
     mkdir -p "$jvm_dir" 2>/dev/null || {
       echo "[setup-cloud-jdk] WARNING: cannot create $jvm_dir; toolchain auto-detection may miss this JDK" >&2
@@ -97,47 +119,116 @@ link_into_jvm_dir() {
   fi
 }
 
-# Reuse an existing install; just make sure its trust store + symlink are set.
-if [[ -x "$install_dir/bin/java" ]]; then
-  echo "[setup-cloud-jdk] reusing existing JDK at $install_dir" >&2
-  fix_truststore "$install_dir"
-  link_into_jvm_dir "$install_dir"
-  echo "$install_dir"
-  exit 0
-fi
-
 arch="$(uname -m)"
 case "$arch" in
   x86_64) jdk_arch="x64" ;;
-  aarch64|arm64) jdk_arch="aarch64" ;;
-  *) echo "[setup-cloud-jdk] unsupported arch: $arch" >&2; exit 1 ;;
+  aarch64 | arm64) jdk_arch="aarch64" ;;
+  *)
+    echo "[setup-cloud-jdk] unsupported arch: $arch" >&2
+    exit 1
+    ;;
 esac
 
-tag="${JDK17_VERSION:-}"
-if [[ -z "$tag" ]]; then
-  tag="$(curl -fsSL -o /dev/null -w '%{url_effective}' \
-    https://github.com/adoptium/temurin17-binaries/releases/latest | sed 's#.*/tag/##')"
-fi
-# Adoptium asset naming: tag `jdk-17.0.19+10` -> file `..._17.0.19_10.tar.gz`
-ver="${tag#jdk-}"
-fname_ver="${ver/+/_}"
-url="https://github.com/adoptium/temurin17-binaries/releases/download/${tag}/OpenJDK17U-jdk_${jdk_arch}_linux_hotspot_${fname_ver}.tar.gz"
+# Resolve the install dir for a major, honouring the back-compat JDK17_DIR /
+# arg-1 override for the primary and the generic JDK<major>_DIR otherwise.
+install_dir_for() {
+  local major="$1"
+  local var="JDK${major}_DIR"
+  if [[ "$major" == "$primary_major" && -n "${PRIMARY_INSTALL_DIR:-}" ]]; then
+    echo "${PRIMARY_INSTALL_DIR}"
+  else
+    echo "${!var:-/opt/jdk${major}}"
+  fi
+}
 
-echo "[setup-cloud-jdk] tag=$tag arch=$jdk_arch" >&2
-echo "[setup-cloud-jdk] downloading $url" >&2
+# Resolve a pinned Temurin tag for a major, if the caller set JDK<major>_VERSION
+# (or the legacy JDK17_VERSION for major 17).
+pinned_tag_for() {
+  local major="$1"
+  local var="JDK${major}_VERSION"
+  local pinned="${!var:-}"
+  if [[ -z "$pinned" && "$major" == "17" ]]; then
+    pinned="${JDK17_VERSION:-}"
+  fi
+  echo "$pinned"
+}
 
-mkdir -p "$install_dir"
-tmp="$(mktemp)"
-trap 'rm -f "$tmp"' EXIT
-curl -fsSL -o "$tmp" "$url"
-tar -xzf "$tmp" --strip-components=1 -C "$install_dir"
+# Install one JDK major. Echoes the install dir on success (stdout), returns
+# non-zero on failure. All human-readable logging goes to stderr.
+install_major() {
+  local major="$1"
+  local install_dir
+  install_dir="$(install_dir_for "$major")"
 
-if [[ ! -x "$install_dir/bin/java" ]]; then
-  echo "[setup-cloud-jdk] expected $install_dir/bin/java after extract — layout changed?" >&2
+  # Reuse an existing install; just make sure its trust store + symlink are set.
+  if [[ -x "$install_dir/bin/java" ]]; then
+    echo "[setup-cloud-jdk] reusing existing JDK $major at $install_dir" >&2
+    fix_truststore "$install_dir"
+    link_into_jvm_dir "$install_dir" "$major"
+    echo "$install_dir"
+    return 0
+  fi
+
+  local tag
+  tag="$(pinned_tag_for "$major")"
+  if [[ -z "$tag" ]]; then
+    tag="$(curl -fsSL -o /dev/null -w '%{url_effective}' \
+      "https://github.com/adoptium/temurin${major}-binaries/releases/latest" | sed 's#.*/tag/##')"
+  fi
+  if [[ -z "$tag" ]]; then
+    echo "[setup-cloud-jdk] WARNING: could not resolve a Temurin $major release tag; skipping" >&2
+    return 1
+  fi
+  # Adoptium asset naming: tag `jdk-17.0.19+10` -> file `..._17.0.19_10.tar.gz`;
+  # early-access lines use `jdk-25+36-ea-beta` -> `..._25_36-ea-beta.tar.gz`.
+  local ver="${tag#jdk-}"
+  local fname_ver="${ver/+/_}"
+  local url="https://github.com/adoptium/temurin${major}-binaries/releases/download/${tag}/OpenJDK${major}U-jdk_${jdk_arch}_linux_hotspot_${fname_ver}.tar.gz"
+
+  echo "[setup-cloud-jdk] major=$major tag=$tag arch=$jdk_arch" >&2
+  echo "[setup-cloud-jdk] downloading $url" >&2
+
+  mkdir -p "$install_dir"
+  local tmp
+  tmp="$(mktemp)"
+  if ! curl -fsSL -o "$tmp" "$url"; then
+    rm -f "$tmp"
+    echo "[setup-cloud-jdk] WARNING: download failed for JDK $major ($url); skipping" >&2
+    return 1
+  fi
+  tar -xzf "$tmp" --strip-components=1 -C "$install_dir"
+  rm -f "$tmp"
+
+  if [[ ! -x "$install_dir/bin/java" ]]; then
+    echo "[setup-cloud-jdk] WARNING: expected $install_dir/bin/java after extract (JDK $major) — skipping" >&2
+    return 1
+  fi
+
+  fix_truststore "$install_dir"
+  link_into_jvm_dir "$install_dir" "$major"
+  echo "[setup-cloud-jdk] installed Temurin $tag at $install_dir" >&2
+  echo "$install_dir"
+  return 0
+}
+
+# arg 1 overrides the PRIMARY install dir (back-compat with the single-JDK contract).
+export PRIMARY_INSTALL_DIR="${1:-${JDK17_DIR:-}}"
+
+primary_home=""
+for major in "${JDK_MAJORS[@]}"; do
+  if [[ "$major" == "$primary_major" ]]; then
+    # The primary is required — a failure here is fatal (preserves the old
+    # single-JDK behaviour where a failed install exited non-zero).
+    primary_home="$(install_major "$major")"
+  else
+    # Additional majors are best-effort — never fail the whole run for one.
+    install_major "$major" >/dev/null || true
+  fi
+done
+
+if [[ -z "$primary_home" ]]; then
+  echo "[setup-cloud-jdk] ERROR: primary JDK $primary_major failed to install" >&2
   exit 1
 fi
 
-fix_truststore "$install_dir"
-link_into_jvm_dir "$install_dir"
-echo "[setup-cloud-jdk] installed Temurin $tag at $install_dir" >&2
-echo "$install_dir"
+echo "$primary_home"


### PR DESCRIPTION
## Problem

The preview render subprocess forks on a JDK **inherited from the consumer's toolchain** (AGP's unit-test `javaLauncher`), or falls through to the Gradle daemon JVM. But Kotlin can emit **newer bytecode than the toolchain JDK** (kotlinc on JDK 17 happily emits Java-21 class files), and the VS Code daemon frequently falls back to its own bundled JDK 17. When the render JVM is older than the bytecode it must load, the class loader throws `UnsupportedClassVersionError` and *every* preview fails, with no message that points at the JDK.

The historical workaround ([meshcore-mobile#271](https://github.com/yschimke/meshcore-mobile/pull/271)) was for the app to pin every module's bytecode back down to Java 17 — a dozen `build.gradle.kts` edits, and it fights the direction consumers want to move. This does the inverse on the tool side: raise the render JVM to match the bytecode, with no app changes.

## What changed

- **`RenderJvmSelection` + `BytecodeTargetDetector`** (new, unit-tested): pick the render JVM as `max(inherited toolchain, Gradle daemon JVM, detected Kotlin jvmTarget / Java targetCompatibility)`, provisioned via Gradle's `JavaToolchainService`. Only ever an **upgrade** — never renders on an older JVM than inherited — and preserves the exact inherited launcher when no upgrade is needed (keeps #142 intact). Bytecode detection is reflective, so the plugin keeps **no KGP compile dependency**, and every probe is defensive (a failure yields `null`, never a config failure).
- Wired into `composePreviewRender`, the resource + XR render tasks, and the **VS Code daemon descriptor** — the latter now bakes an explicit launcher into `daemon-launch.json`, so the daemon stops falling back to its own bundled JDK (the meshcore case).
- `buildJavaMajor` (the Robolectric SDK ceiling) now follows the **actual** render JVM instead of `JavaVersion.current()`, fixing the toolchain-17 / Gradle-daemon-21 skew as a side effect.
- New escape-hatch knob **`composePreview.renderJavaVersion`** (+ `-PcomposePreview.renderJavaVersion`) to pin a specific JDK.
- **`scripts/setup-cloud-jdk.sh`** now provisions a set of JDK majors (default `17 21 25`, `CLOUD_JDK_MAJORS`-overridable) and symlinks each into `/usr/lib/jvm`, so the render fork resolves a matching JDK in sandboxes where foojay auto-download is blocked. The primary's `JAVA_HOME`-on-stdout contract is unchanged; additional majors are best-effort.

## Test plan

- `./gradlew :gradle-plugin:test --tests "*RenderJvmSelectionTest"` — new unit tests for the selection policy and bytecode-string parsing pass.
- Full `:gradle-plugin` main + test compile is green; the configuration-cache entry stores cleanly (no `project` capture in the new provider chains).
- `ktfmtFormat` applied; `setup-cloud-jdk.sh` passes `bash -n`.
- **Not run in this environment (relies on CI):** the Robolectric render / daemon functional E2Es that actually fork the render JVM and load consumer bytecode. Those are the real end-to-end proof of the raised launcher — worth watching on this PR.

## Scope / follow-up

Scoped to the Android/Robolectric render + daemon paths (exactly the reported case). The desktop (Compose Multiplatform) render sites — `RenderPreviewsTask.invokeRenderer`'s `javaexec`, which forks the daemon JVM (pinned to 17) — are genuinely affected too, but left for a fast-follow that adopts the same `RenderJvmSelection` core, to keep this change verifiable.

Text-only evidence is appropriate here — this is build wiring, with no rendered-surface change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rdn8bx3BjXBQoZFoxRWm6c)_