### PR TITLE
fix(plugin): detect jvmTarget on the KMP Android compile task

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -2866,10 +2866,15 @@ internal object AndroidPreviewSupport {
   /**
    * Highest JVM bytecode target the consumer's classes compile to, across the Java
    * (`compileOptions.targetCompatibility` on AGP's `CommonExtension`) and Kotlin
-   * (`compilerOptions.jvmTarget` on the variant's `compile<Variant>Kotlin` task) toolchains, or
-   * `null` when neither can be read. Feeds [RenderJvmSelection] so the render JVM is raised to
-   * match the classes it must load. Fully defensive — a probe that throws (no Kotlin plugin, a
-   * renamed KGP accessor, no AGP `compileOptions`) is skipped rather than failing configuration.
+   * (`compilerOptions.jvmTarget`) toolchains, or `null` when neither can be read. Feeds
+   * [RenderJvmSelection] so the render JVM is raised to match the classes it must load. Fully
+   * defensive — a probe that throws (no Kotlin plugin, a renamed KGP accessor, no AGP
+   * `compileOptions`) is skipped rather than failing configuration.
+   *
+   * Probes both `compile<Variant>Kotlin` (android-library-only modules) and
+   * `compile<Variant>KotlinAndroid` (KMP Android modules, which route their real compile through
+   * the per-target task) — the same pair the discovery/compile wiring uses above, so a KMP module
+   * on `jvmTarget = 21` with a 17 unit-test toolchain isn't missed.
    */
   private fun detectRenderBytecodeMajor(project: Project, capVariant: String): Int? {
     val candidates = mutableListOf<Int>()
@@ -2881,7 +2886,10 @@ internal object AndroidPreviewSupport {
         ?.let { BytecodeTargetDetector.parseTargetMajor(it.toString()) }
         ?.let { candidates += it }
     }
-    BytecodeTargetDetector.detectKotlinJvmTarget(project, listOf("compile${capVariant}Kotlin"))
+    BytecodeTargetDetector.detectKotlinJvmTarget(
+        project,
+        listOf("compile${capVariant}Kotlin", "compile${capVariant}KotlinAndroid"),
+      )
       ?.let { candidates += it }
     return candidates.filter { it > 0 }.maxOrNull()
   }


### PR DESCRIPTION
Follow-up to #2712, addressing a Codex review point that landed after that PR auto-merged.

## Problem

The render-JVM bytecode detector added in #2712 only probes `compile<Variant>Kotlin`. KMP Android modules route their real Kotlin compile through **`compile<Variant>KotlinAndroid`** (the same per-target task `AndroidPreviewSupport` already uses for discovery/compile wiring, see the `isKmp` branch around lines 589-590). So a KMP Android module on `jvmTarget = 21` with a JDK-17 unit-test toolchain was missed — `renderBytecodeMajor` fell back to the lower Java `targetCompatibility` (or `null`), the render JVM stayed too old, and previews still failed with `UnsupportedClassVersionError`. Exactly the failure the parent PR set out to fix, just on the KMP shape.

## Fix

Pass both task names to `detectKotlinJvmTarget`. The detector already `findByName`-skips absent tasks and returns the max across candidates, so this covers android-library-only modules (`compile<Variant>Kotlin`) and KMP Android modules (`compile<Variant>KotlinAndroid`) without any branching.

## Test plan

- `./gradlew :gradle-plugin:ktfmtFormat :gradle-plugin:test --tests "*RenderJvmSelectionTest"` — BUILD SUCCESSFUL; the pure selection/parse unit tests stay green and the plugin recompiles with the wider candidate list.
- Non-visual build wiring — text-only evidence is appropriate.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rdn8bx3BjXBQoZFoxRWm6c)_