### PR TITLE
feat(serve): serve captured Remote Compose docs over /render/&lt;id&gt;.rcdoc

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
@@ -228,11 +228,26 @@ class ServeBundleHost(
 
   private val previewIds: Set<String> = previews.map { it.id }.toHashSet()
 
+  // The captured Remote Compose documents ride in the bundle's `ir/<id>.rcdoc` sidecars (a sibling
+  // of `previews/`), the browser player's replayable input.
+  private val irDir = File(bundleDir, IR_SUBDIR)
+
   override fun render(previewId: String, overrides: PreviewOverrides): RenderOutcome {
     if (previewId !in previewIds) return RenderOutcome.NotFound
     val png = File(previewsDir, "$previewId$PNG_SUFFIX").toOkioPath()
     if (!fileSystem.exists(png)) return RenderOutcome.NotFound
     return RenderOutcome.Ok(fileSystem.read(png) { readByteArray() })
+  }
+
+  override fun remoteComposeDoc(previewId: String): ByteArray? {
+    if (previewId !in previewIds) return null
+    val doc = File(irDir, "$previewId$RCDOC_SUFFIX").toOkioPath()
+    if (!fileSystem.exists(doc)) return null
+    return try {
+      fileSystem.read(doc) { readByteArray() }
+    } catch (e: Exception) {
+      null
+    }
   }
 
   /**
@@ -381,6 +396,9 @@ class ServeBundleHost(
 
     private const val OVERRIDES_SUFFIX = ".overrides.json"
     private const val REMOTECOMPOSE_SUFFIX = ".remotecompose.json"
+    /** Sibling of `previews/` holding the captured Remote Compose docs (`ir/<id>.rcdoc`). */
+    private const val IR_SUBDIR = "ir"
+    private const val RCDOC_SUFFIX = ".rcdoc"
     private const val PREVIEWS_JSON = "previews.json"
     private val OVERRIDES_JSON = Json { ignoreUnknownKeys = true }
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleStore.kt
@@ -169,7 +169,8 @@ class ServeBundleStore(
         val isRemoteCompose = underPreviews && name.endsWith(REMOTECOMPOSE_SUFFIX)
         // Also keep the captured Remote Compose documents from the sibling `ir/<id>.rcdoc` tree —
         // the browser player's replayable input, served over `GET /render/<id>.rcdoc`. Dropping
-        // these here would strip the client-side render lane from the upload path (POST / URL) while
+        // these here would strip the client-side render lane from the upload path (POST / URL)
+        // while
         // the directory path (which reads the bundle dir straight from disk) kept them.
         val underIr = name.startsWith("$IR_SUBDIR/") && ".." !in segments
         val isRcdoc = underIr && name.endsWith(RCDOC_SUFFIX)

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleStore.kt
@@ -145,8 +145,9 @@ class ServeBundleStore(
 
   /**
    * Extract the servable `previews/` entries (baked `<id>.png`, the `<id>.overrides.json` /
-   * `<id>.remotecompose.json` knob sidecars) plus the root `previews.json` into [dir] (zip-slip
-   * safe, size-capped). Returns the PNG count — only a baked image makes a servable preview.
+   * `<id>.remotecompose.json` knob sidecars), the sibling `ir/<id>.rcdoc` Remote Compose documents,
+   * plus the root `previews.json` into [dir] (zip-slip safe, size-capped). Returns the PNG count —
+   * only a baked image makes a servable preview.
    */
   private fun extractPreviews(zipBytes: ByteArray, dir: File): Int {
     val rootPath = dir.canonicalFile.toPath()
@@ -166,12 +167,21 @@ class ServeBundleStore(
         val isPng = underPreviews && name.endsWith(PNG_SUFFIX)
         val isOverrides = underPreviews && name.endsWith(OVERRIDES_SUFFIX)
         val isRemoteCompose = underPreviews && name.endsWith(REMOTECOMPOSE_SUFFIX)
+        // Also keep the captured Remote Compose documents from the sibling `ir/<id>.rcdoc` tree —
+        // the browser player's replayable input, served over `GET /render/<id>.rcdoc`. Dropping
+        // these here would strip the client-side render lane from the upload path (POST / URL) while
+        // the directory path (which reads the bundle dir straight from disk) kept them.
+        val underIr = name.startsWith("$IR_SUBDIR/") && ".." !in segments
+        val isRcdoc = underIr && name.endsWith(RCDOC_SUFFIX)
         // Also keep the root `previews.json` manifest so a served bundle can surface the app's
         // declared @ThemeCatalog themes (the synthetic THEME_CATALOG entries live only here, not in
         // the per-preview sidecars). A top-level file (no path segments), so it's exempt from the
         // `previews/` prefix check but still zip-slip guarded below.
         val isPreviewsJson = name == PREVIEWS_JSON
-        if (!entry.isDirectory && (isPng || isOverrides || isRemoteCompose || isPreviewsJson)) {
+        if (
+          !entry.isDirectory &&
+            (isPng || isOverrides || isRemoteCompose || isRcdoc || isPreviewsJson)
+        ) {
           val target = File(dir, name)
           // Zip-slip guard: the resolved path must stay under the bundle dir.
           if (target.canonicalFile.toPath().startsWith(rootPath)) {
@@ -212,6 +222,8 @@ class ServeBundleStore(
     private const val PNG_SUFFIX = ".png"
     private const val OVERRIDES_SUFFIX = ".overrides.json"
     private const val REMOTECOMPOSE_SUFFIX = ".remotecompose.json"
+    private const val IR_SUBDIR = "ir"
+    private const val RCDOC_SUFFIX = ".rcdoc"
     private const val PREVIEWS_JSON = "previews.json"
     private const val DEFAULT_MAX_BYTES = 100L * 1024 * 1024 // 100 MB
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
@@ -236,6 +236,14 @@ class ServeCatalogLiveHost(
   }
 
   /**
+   * The captured Remote Compose document rides in the baked bundle's `ir/<id>.rcdoc` sidecar (the
+   * daemon has no such static export), so delegate straight to [baked]. The in-browser player
+   * replays it and applies knob edits client-side — no daemon round-trip — so the live twin never
+   * enters this lane.
+   */
+  override fun remoteComposeDoc(previewId: String): ByteArray? = baked.remoteComposeDoc(previewId)
+
+  /**
    * The daemon-backed host to route a mapped [daemonId] to: the per-preview daemon if
    * [perPreviewResolve] resolves one (the default lane, exercised routinely), else the monolithic
    * [live] daemon. Both re-render the same daemon id — the per-preview bundle simply carries only

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHost.kt
@@ -132,6 +132,15 @@ interface ServeHost : AutoCloseable {
   fun render(previewId: String, overrides: PreviewOverrides): RenderOutcome
 
   /**
+   * The captured Remote Compose document bytes for [previewId] — the bundle's `ir/<id>.rcdoc`
+   * sidecar — or null when this host carries none. Served over `GET /render/<id>.rcdoc` so an
+   * in-browser Remote Compose player can render the document client-side (the browser counterpart of
+   * the daemon render). Defaults to null: only a bundle host that carries the `ir/` sidecars returns
+   * bytes; a daemon-only host has none.
+   */
+  fun remoteComposeDoc(previewId: String): ByteArray? = null
+
+  /**
    * Render [previewId] at [overrides] and return its figma-svg export, or [SvgOutcome.NotFound]
    * when this host can't produce SVG. Defaults to `NotFound`: only the daemon-backed
    * [ServeRenderHost] overrides this — a static [ServeBundleHost] has no daemon to export one.

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHost.kt
@@ -134,9 +134,9 @@ interface ServeHost : AutoCloseable {
   /**
    * The captured Remote Compose document bytes for [previewId] — the bundle's `ir/<id>.rcdoc`
    * sidecar — or null when this host carries none. Served over `GET /render/<id>.rcdoc` so an
-   * in-browser Remote Compose player can render the document client-side (the browser counterpart of
-   * the daemon render). Defaults to null: only a bundle host that carries the `ir/` sidecars returns
-   * bytes; a daemon-only host has none.
+   * in-browser Remote Compose player can render the document client-side (the browser counterpart
+   * of the daemon render). Defaults to null: only a bundle host that carries the `ir/` sidecars
+   * returns bytes; a daemon-only host has none.
    */
   fun remoteComposeDoc(previewId: String): ByteArray? = null
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -1218,9 +1218,11 @@ class ServeHttpServer(
 
   /**
    * `GET /render/{name}` (query) and `GET /{system}/render/{name}` (path): a preview's rendered
-   * bytes — a PNG for `<id>.png` (or no suffix), the figma-svg export for `<id>.svg`, or the
-   * declared preview slots as JSON for `<id>.slots`. All take the same override query params; SVG
-   * and slots are only produced by a daemon-backed host (a static bundle 404s them).
+   * bytes — a PNG for `<id>.png` (or no suffix), the figma-svg export for `<id>.svg`, the declared
+   * preview slots as JSON for `<id>.slots`, or the captured Remote Compose document for
+   * `<id>.rcdoc`. All but `.rcdoc` take the same override query params; SVG and slots are only
+   * produced by a daemon-backed host, and `.rcdoc` only by a bundle host that carries `ir/` sidecars
+   * (each 404s where unavailable).
    */
   private suspend fun RoutingContext.handleRender(sessionInPath: Boolean) {
     if (rejectBadToken()) return
@@ -1232,7 +1234,26 @@ class ServeHttpServer(
       }
       val wantSvg = rawName.endsWith(".svg")
       val wantSlots = rawName.endsWith(".slots")
-      val previewId = rawName.removeSuffix(".png").removeSuffix(".svg").removeSuffix(".slots")
+      val wantRcDoc = rawName.endsWith(".rcdoc")
+      val previewId =
+        rawName
+          .removeSuffix(".png")
+          .removeSuffix(".svg")
+          .removeSuffix(".slots")
+          .removeSuffix(".rcdoc")
+      // The `.rcdoc` lane serves the captured Remote Compose document bytes verbatim (no override
+      // pass — the in-browser player replays the doc and applies knob edits client-side), so it
+      // short-circuits ahead of the override parse. A host with no `ir/<id>.rcdoc` sidecar (a
+      // daemon-only host, or an unknown id) returns null → 404.
+      if (wantRcDoc) {
+        val bytes = renderHost.remoteComposeDoc(previewId)
+        if (bytes == null) {
+          call.respondText("no such remote compose document", status = HttpStatusCode.NotFound)
+        } else {
+          call.respondBytes(bytes, ContentType.Application.OctetStream)
+        }
+        return@withLeasedSession
+      }
       // Forward the fixed render axes plus any dynamic override params (`knob.<key>=…` knobs and
       // `rc.<name>=…` Remote Compose seeds, neither in SUPPORTED_KEYS) so a live knob / Remote
       // Compose edit reaches ServeOverrides.parse instead of being silently dropped.

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -1221,8 +1221,8 @@ class ServeHttpServer(
    * bytes — a PNG for `<id>.png` (or no suffix), the figma-svg export for `<id>.svg`, the declared
    * preview slots as JSON for `<id>.slots`, or the captured Remote Compose document for
    * `<id>.rcdoc`. All but `.rcdoc` take the same override query params; SVG and slots are only
-   * produced by a daemon-backed host, and `.rcdoc` only by a bundle host that carries `ir/` sidecars
-   * (each 404s where unavailable).
+   * produced by a daemon-backed host, and `.rcdoc` only by a bundle host that carries `ir/`
+   * sidecars (each 404s where unavailable).
    */
   private suspend fun RoutingContext.handleRender(sessionInPath: Boolean) {
     if (rejectBadToken()) return

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleStoreTest.kt
@@ -99,6 +99,27 @@ class ServeBundleStoreTest {
   }
 
   @Test
+  fun `ir rcdoc sidecars are extracted and served as the browser player's document`() {
+    // The upload path must keep the captured Remote Compose docs from the sibling `ir/` tree so the
+    // client-side player lane (`GET /render/<id>.rcdoc`) works on an uploaded bundle, not just the
+    // directory path that reads the bundle dir straight from disk.
+    val doc = byteArrayOf(0x52, 0x43, 0x01, 0x02, 0x03) // arbitrary RC doc bytes
+    val zip =
+      zipOf(
+        "previews/com.example.Red.png" to byteArrayOf(1, 2, 3),
+        "ir/com.example.Red.rcdoc" to doc,
+        "ir/../../evil.rcdoc" to byteArrayOf(9), // path traversal — must be skipped
+      )
+    val result = store().add("demo", zip, isSecurityChecked = true)
+    assertEquals(ServeBundleStore.Result.Ok("demo", 1), result)
+
+    val host = registered.getValue("demo")
+    assertTrue(doc.contentEquals(host.remoteComposeDoc("com.example.Red")))
+    // A preview with no `ir/<id>.rcdoc` sidecar has no client-side document.
+    assertEquals(null, host.remoteComposeDoc("com.example.Missing"))
+  }
+
+  @Test
   fun `the root previews_json is extracted so an uploaded bundle surfaces its declared themes`() {
     val previewsJson =
       """

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
@@ -52,16 +52,24 @@ class ServeHttpRoutingTest {
   private val rcColorKnob =
     RemoteComposeKnobDeclaration("shaderColor", RemoteNamedValue.ColorValue("#FF7DE2FF"))
 
+  /** Arbitrary Remote Compose document bytes, carried into the bundle as an `ir/<id>.rcdoc`. */
+  private val rcDocBytes = byteArrayOf(0x52, 0x43, 0x01, 0x02, 0x03)
+
   private fun bundle(
     label: String,
     overrides: List<PreviewOverrideDeclaration> = emptyList(),
     remoteComposeKnobs: List<RemoteComposeKnobDeclaration> = emptyList(),
     degradations: List<ServeDegradation> = emptyList(),
+    rcDoc: ByteArray? = null,
   ): ServeBundleHost {
     val dir = Files.createTempDirectory("routing-$label").toFile().also { it.deleteOnExit() }
     File(dir, "index.html").writeText("<html></html>")
     File(dir, "previews").apply { mkdirs() }
     File(dir, "previews/$previewId.png").writeBytes(png())
+    if (rcDoc != null) {
+      File(dir, "ir").apply { mkdirs() }
+      File(dir, "ir/$previewId.rcdoc").writeBytes(rcDoc)
+    }
     if (overrides.isNotEmpty()) {
       val sidecar =
         Json.encodeToString(
@@ -86,7 +94,7 @@ class ServeHttpRoutingTest {
     registry.register("default-mod", host = bundle("default-mod"), pinned = true)
     registry.register(
       "compose-m3",
-      host = bundle("compose-m3", listOf(labelKnob), listOf(rcColorKnob)),
+      host = bundle("compose-m3", listOf(labelKnob), listOf(rcColorKnob), rcDoc = rcDocBytes),
       pinned = true,
     )
     // A baked-only session carrying a degradation reason — reachable at /baked-only/… but kept off
@@ -230,6 +238,32 @@ class ServeHttpRoutingTest {
     // semantics tree, so it resolves to NotFound (only a daemon-backed ServeRenderHost extracts
     // slots).
     val (code, _) = get("/compose-m3/render/$previewId.slots")
+    assertEquals(404, code)
+  }
+
+  @Test
+  fun `the rcdoc render lane serves the captured remote compose document bytes`() {
+    // compose-m3 carries an `ir/<id>.rcdoc` sidecar, so `GET /render/<id>.rcdoc` returns those bytes
+    // verbatim (octet-stream) for the in-browser player to replay client-side.
+    val req =
+      Request.Builder()
+        .url("http://127.0.0.1:${server.port}/compose-m3/render/$previewId.rcdoc")
+        .build()
+    client.newCall(req).execute().use { r ->
+      assertEquals(200, r.code)
+      assertEquals(
+        "application/octet-stream",
+        r.body?.contentType()?.let { "${it.type}/${it.subtype}" },
+      )
+      assertTrue(rcDocBytes.contentEquals(r.body?.bytes()), "rcdoc bytes served verbatim")
+    }
+  }
+
+  @Test
+  fun `a bundle without an rcdoc sidecar 404s the rcdoc render lane`() {
+    // default-mod carries no `ir/` tree, so the client-side player lane resolves to NotFound rather
+    // than serving an empty document.
+    val (code, _) = get("/render/$previewId.rcdoc?session=default-mod")
     assertEquals(404, code)
   }
 

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
@@ -243,7 +243,8 @@ class ServeHttpRoutingTest {
 
   @Test
   fun `the rcdoc render lane serves the captured remote compose document bytes`() {
-    // compose-m3 carries an `ir/<id>.rcdoc` sidecar, so `GET /render/<id>.rcdoc` returns those bytes
+    // compose-m3 carries an `ir/<id>.rcdoc` sidecar, so `GET /render/<id>.rcdoc` returns those
+    // bytes
     // verbatim (octet-stream) for the in-browser player to replay client-side.
     val req =
       Request.Builder()


### PR DESCRIPTION
## Summary

Follow-up A, part 1 of the in-browser TypeScript Remote Compose player lane (the client-side counterpart of the CMP Wasm tier). This slice is pure Kotlin plumbing — it carries the captured Remote Compose document bytes through the serve extractors and exposes them over a new route, the foundation the upcoming `<canvas>` render lane will fetch from.

A preview's captured RC document rides in the bundle's `ir/<id>.rcdoc` sidecar (packed beside `previews/<id>.png`). This wires that sidecar all the way to the wire:

- **`ServeHost`** gains `remoteComposeDoc(previewId): ByteArray?`, defaulting `null` so only a bundle host that carries the `ir/` sidecars returns bytes (a daemon-only host has none).
- **`ServeBundleHost`** reads `ir/<id>.rcdoc` from a sibling of its `previews/` tree.
- **`ServeBundleStore.extractPreviews`** now keeps the sibling `ir/*.rcdoc` entries (zip-slip safe, size-capped) so the **upload path** (`POST /bundles` / `?url=`) carries them just like the directory path already does — dropping them here would silently strip the client-side lane from uploads.
- **`ServeCatalogLiveHost`** delegates `remoteComposeDoc` to its baked twin (the daemon has no static RC-doc export; the browser player replays the doc and applies knob edits client-side, so the live twin never enters this lane).
- **`ServeHttpServer.handleRender`** dispatches the `.rcdoc` suffix ahead of the override parse (no override pass — knob edits apply client-side in the player), returning the bytes as `application/octet-stream`, or 404 where no sidecar exists.

New route: `GET /render/<id>.rcdoc` (and the path form `GET /<system>/render/<id>.rcdoc`).

## Test plan

- `:cli:test --tests ServeBundleStoreTest --tests ServeHttpRoutingTest --tests ServeBundleHostTest` — green.
- `:cli:ktfmtCheck` — clean.

New tests:
- `ServeBundleStoreTest`: `ir/*.rcdoc` sidecars are extracted and served as the browser player's document; a traversal (`ir/../../evil.rcdoc`) entry is skipped; a preview with no sidecar returns `null`.
- `ServeHttpRoutingTest`: the `.rcdoc` render lane serves the captured bytes verbatim (octet-stream); a bundle carrying no `ir/` tree 404s the lane.

Non-visual change (data-product plumbing + route), so no rendered evidence applies.

---
_Generated by [Claude Code](https://claude.ai/code/session_011K7sgCfdsbhN7fwMb3WhSS)_