### PR TITLE
fix(renderer): render downloadable GoogleFonts on the daemon path (+ enforce fatal-on-fallback there)

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -48,6 +48,9 @@ import ee.schimke.composeai.data.theme.NodeThemeFacts
 import ee.schimke.composeai.data.theme.ThemeConsumerAttribution
 import ee.schimke.composeai.data.theme.ThemePayload
 import ee.schimke.composeai.renderer.AccessibilityDataProducts
+import ee.schimke.composeai.renderer.FontFallbackException
+import ee.schimke.composeai.renderer.FontResolutionDiagnostics
+import ee.schimke.composeai.renderer.RenderWarningsSidecar
 import ee.schimke.composeai.renderer.WearScrollSvgAssembler
 import ee.schimke.composeai.renderer.AccessibilityHierarchyContextKeys
 import ee.schimke.composeai.renderer.AccessibilityHierarchyExtension
@@ -916,6 +919,12 @@ class RenderEngine(
           }
         }
       }
+    // Bracket this preview's downloadable-font resolution so a face that couldn't be resolved (and
+    // fell back to Roboto) is attributed to exactly this render — mirrors the gradle-plugin's
+    // `RobolectricRenderTest`. Drained after the render below to gate on it. Without this, the
+    // `bundle pack` / serve daemon render path (which design-artifacts uses) silently shipped a
+    // Roboto-fallback sticker while `RobolectricRenderTest`'s gate only guarded the plugin path.
+    FontResolutionDiagnostics.beginPreview()
     // B2.0 — install the child classloader as the context classloader for the duration of the
     // render dispatch. Compose's reflection paths (notably PreviewParameter providers — see
     // CLASSLOADER.md § Risks 2) consult the context classloader; without this install they would
@@ -941,6 +950,19 @@ class RenderEngine(
     } finally {
       Thread.currentThread().contextClassLoader = previousContext
     }
+
+    // Font-fallback gate (reached only on a successful render — a thrown body propagated above).
+    // A downloadable face that couldn't be resolved fell back to Roboto, so this preview would ship
+    // the wrong typeface. Fail the render by default (the daemon's per-preview catch drops the PNG
+    // and records the reason, so a design-artifacts publish can't silently bake Roboto);
+    // `-Dcomposeai.fonts.failOnFallback=false` downgrades it to a `<png>.warnings.json` sidecar kept
+    // beside the PNG. Mirrors `RobolectricRenderTest`'s gate so both Android render paths behave the
+    // same.
+    val fontFallbacks = FontResolutionDiagnostics.drainPreview()
+    if (fontFallbacks.isNotEmpty() && FontResolutionDiagnostics.failOnFallback) {
+      throw FontFallbackException(fontFallbacks)
+    }
+    RenderWarningsSidecar.writeOrDelete(outputFile, fontFallbacks)
 
     val tookMs = (System.nanoTime() - startNs) / 1_000_000L
     val metrics = SandboxMeasurement.collect(sandboxStats, tookMs = tookMs)

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/SandboxHoldingRunner.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/SandboxHoldingRunner.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.daemon
 
+import ee.schimke.composeai.renderer.ShadowFontsContractCompat
 import org.junit.runners.model.FrameworkMethod
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
@@ -179,6 +180,16 @@ open class SandboxHoldingRunner(testClass: Class<*>) : RobolectricTestRunner(tes
     // implementation and records the query in `PermissionsController` for the
     // `compose/permissions` data product.
     shadows += ShadowContextWrapperPermissionTracker::class.java
+    // Downloadable-GoogleFont shadow. Always registered — androidx.core's `FontsContractCompat` is
+    // on every Compose consumer classpath, so the `@Implements` link always resolves (same safety as
+    // the permission-tracker shadow above). Without it the daemon render path (`bundle pack` /
+    // serve, incl. `--with-semantics`) hits the real GMS Fonts provider — absent under Robolectric —
+    // so every `Font(GoogleFont(...))` silently rendered in the platform fallback (Roboto). The
+    // one-shot `bundle render` path got this shadow via its synthesized `robolectric.properties`, but
+    // the daemon never did. With it, a face resolves from the shared cache
+    // (`composeai.fonts.cacheDir`) / a live fetch, and a genuinely unresolvable face is recorded for
+    // `RenderEngine`'s fatal-on-fallback gate instead of vanishing.
+    shadows += ShadowFontsContractCompat::class.java
     return shadows.toTypedArray()
   }
 }

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/SandboxHoldingRunnerFontShadowTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/SandboxHoldingRunnerFontShadowTest.kt
@@ -1,0 +1,50 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.renderer.ShadowFontsContractCompat
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runners.model.FrameworkMethod
+
+/**
+ * Locks the daemon sandbox's registration of [ShadowFontsContractCompat] through
+ * [SandboxHoldingRunner.getExtraShadows].
+ *
+ * Without it the daemon render path (`bundle pack` / serve, including `--with-semantics` — the path
+ * `design-artifacts` uses) hits the real GMS Fonts provider, which is absent under Robolectric, so
+ * every `Font(GoogleFont(...))` silently rendered in the platform fallback (Roboto) and — because
+ * the shadow is the only place that records a fallback — the render still "succeeded". The one-shot
+ * `bundle render` path always got this shadow via its synthesized `robolectric.properties`; this
+ * test guards the daemon parity so the gap can't silently reopen.
+ *
+ * Mirrors [SandboxHoldingRunnerApplicationOverrideTest]'s exposer pattern: construct the runner with
+ * a dummy test class and read the resolved shadow set back via a subclass that widens the
+ * `protected` [org.robolectric.RobolectricTestRunner.getExtraShadows].
+ */
+class SandboxHoldingRunnerFontShadowTest {
+
+  @Test
+  fun registersDownloadableFontShadow() {
+    val runner = ExposedRunner(DummyTest::class.java)
+    val method = FrameworkMethod(DummyTest::class.java.getMethod("stub"))
+    val shadows = runner.exposedExtraShadows(method).map { it.name }
+    assertTrue(
+      "daemon sandbox must register ShadowFontsContractCompat so downloadable GoogleFonts resolve " +
+        "(or record a fallback for the fatal-on-fallback gate) instead of silently falling back to " +
+        "Roboto; got $shadows",
+      shadows.contains(ShadowFontsContractCompat::class.java.name),
+    )
+  }
+
+  /** Exposes the `protected` [org.robolectric.RobolectricTestRunner.getExtraShadows]. */
+  private class ExposedRunner(testClass: Class<*>) : SandboxHoldingRunner(testClass) {
+    fun exposedExtraShadows(method: FrameworkMethod): Array<Class<*>> = getExtraShadows(method)
+  }
+
+  // A minimal valid test class for the `RobolectricTestRunner(Class)` constructor the exposer uses.
+  // Deliberately NOT `@RunWith(SandboxHoldingRunner::class)`: we only read `getExtraShadows` back
+  // (no sandbox bootstrap), so it needn't — and shouldn't — spin up a Robolectric sandbox, which
+  // needs the CI's Java 21 toolchain (SDK 36).
+  class DummyTest {
+    @Test fun stub() = Unit
+  }
+}

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/GoogleFontInterceptor.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/GoogleFontInterceptor.kt
@@ -76,7 +76,12 @@ internal object GoogleFontCacheAccess {
  * hundreds of times) — matching the daemon's other self-diagnostics, surfaced in the VS Code
  * extension as `[daemon stderr] …`.
  */
-internal object FontResolutionDiagnostics {
+// Public (not `internal`) so BOTH Android render paths can drive it: the gradle-plugin's
+// `RobolectricRenderTest` (same module) and the CLI `bundle pack` / serve daemon's
+// `:daemon:android` `RenderEngine`, which lives in a different module and would otherwise be unable
+// to bracket a preview's font resolution — the gap that let a daemon-path render silently ship a
+// Roboto-fallback sticker.
+object FontResolutionDiagnostics {
 
   /** One downloadable face that couldn't be resolved and fell back to the platform default. */
   data class FontFallback(
@@ -114,7 +119,7 @@ internal object FontResolutionDiagnostics {
    * Record that [key] couldn't be resolved (so text will render in the platform fallback) for
    * [reason]. Adds it to the current preview's buffer and emits a de-duplicated stderr line.
    */
-  fun recordFallback(key: GoogleFontKey, reason: String) {
+  internal fun recordFallback(key: GoogleFontKey, reason: String) {
     val fallback = FontFallback(key.name, key.weight.weight, key.italic, reason)
     currentPreview.add(fallback)
     if (warnedThisProcess.add(key.fileName())) System.err.println(describe(fallback))
@@ -158,7 +163,7 @@ internal object FontResolutionDiagnostics {
  * existing per-preview `catch (Throwable)` so the failure lands in the `.error.json` sidecar and the
  * (wrong-typeface) PNG is dropped — the same surface a preview that threw uses.
  */
-internal class FontFallbackException(
+class FontFallbackException(
   fallbacks: List<FontResolutionDiagnostics.FontFallback>
 ) :
   RuntimeException(

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RenderWarningsSidecar.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RenderWarningsSidecar.kt
@@ -18,7 +18,10 @@ import okio.Path.Companion.toPath
  * plugin reads this back (`ComposePreviewTasks.WarningSidecar`) and the bundle packs it next to the
  * PNG.
  */
-internal object RenderWarningsSidecar {
+// Public (not `internal`) so the CLI `bundle pack` / serve daemon's `:daemon:android` `RenderEngine`
+// can write the warnings sidecar on the daemon render path, the same as the gradle-plugin's
+// `RobolectricRenderTest` does on its path.
+object RenderWarningsSidecar {
 
   const val SCHEMA: String = "compose-preview-warnings/v1"
 


### PR DESCRIPTION
## Why

`preview.coo.ee/meshcore-mobile/.../theme-meshcore-dark…svg` renders in **Roboto** instead of the theme's Orbitron / Space Grotesk. Root cause is entirely on the renderer, in two layers:

1. **The GoogleFont shadow was never registered on the daemon render path.** `ShadowFontsContractCompat` (which intercepts `FontsContractCompat.requestFont` and resolves downloadable `Font(GoogleFont(...))` faces from the cache / a live fetch) was only registered for the one-shot `bundle render` path, via its synthesized `robolectric.properties`. The **daemon** path — `bundle pack` (incl. `--with-semantics`) and `serve`, which `design-artifacts` uses to render `:app` — registers its shadows programmatically in `SandboxHoldingRunner.getExtraShadows`, and never included it. So a daemon render hit the *real* GMS Fonts provider (absent under Robolectric) and every `Font(GoogleFont(...))` fell back to Roboto.

2. **The fallback was invisible.** The fatal-on-fallback gate lived only in the gradle plugin's `RobolectricRenderTest`; the daemon's `RenderEngine.render` never bracketed font resolution. And because a fallback is only *recorded* inside the shadow (which wasn't registered), the render also had nothing to report — so it "succeeded" and published the Roboto sticker silently.

## What

- **`fix(renderer): register the GoogleFont shadow on the daemon render path`** — add `ShadowFontsContractCompat` to `SandboxHoldingRunner.getExtraShadows`, unconditionally (androidx.core's `FontsContractCompat` is on every Compose classpath — same safety basis as the permission-tracker shadow beside it). Downloadable faces now resolve on the daemon path from the shared cache (`composeai.fonts.cacheDir`) / a live fetch, exactly as they already did on the `bundle render` path.
- **`fix(renderer): enforce font fatal-on-fallback on the bundle-pack/daemon render`** — bracket each daemon render with `FontResolutionDiagnostics.beginPreview`/`drainPreview` and apply the same gate as the plugin path: fail the preview by default (dropping the PNG so a publish can't bake Roboto), or write a `<png>.warnings.json` sidecar when `composeai.fonts.failOnFallback=false`. Widened `FontResolutionDiagnostics` / `FontFallbackException` / `RenderWarningsSidecar` to public so `:daemon:android` can drive them (`recordFallback` stays internal — it takes the module-internal `GoogleFontKey`).

Together: downloadable faces **resolve** on the daemon path (so meshcore's stickers render in Orbitron / Space Grotesk), and if one genuinely can't resolve, the render **fails loudly and names the face** instead of silently shipping Roboto.

## Test plan

- `:renderer-android:compileDebugKotlin`, `:daemon:android:compileDebugKotlin` — green.
- `:renderer-android:testDebugUnitTest --tests *FontResolutionDiagnosticsTest*` — green (visibility change intact).
- New `SandboxHoldingRunnerFontShadowTest` asserts the daemon sandbox now registers `ShadowFontsContractCompat` — green. Guards the exact gap so it can't silently reopen.
- ktfmt clean on both modules.

## Visual evidence

This is renderer plumbing; there is **no compose-ai-tools `@Preview`/fixture that changes** — the compose-m3 catalog deliberately *vendors* its faces, so its stickers are byte-identical. The pixel-level change manifests in a **downstream consumer** (meshcore's `:app` foundation stickers, which use downloadable `Font(GoogleFont("Orbitron"))`). I could not capture a local before/after: the daemon render requires the CI's Java 21 toolchain (SDK 36) + font egress, neither available in this sandbox — the sandbox-bootstrapping daemon tests can't run under the local Java 17. Verification path: this repo's `samples/android` GoogleFont preview through the CI visual-diff bot, and the meshcore `design-artifacts` re-render after merge (the Roboto → Orbitron flip on `theme-meshcore-*`). Holding the meshcore catalog re-dispatch until this lands.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KL6aMkWHRwot53LnwDoAc2)_