### PR TITLE
feat(plugin): match the desktop render JVM to the consumer's bytecode

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -685,12 +685,12 @@ internal object ComposePreviewTasks {
       maxHeapMb.set(extension.daemon.maxHeapMb)
       maxRendersPerSandbox.set(extension.daemon.maxRendersPerSandbox)
       warmSpare.set(extension.daemon.warmSpare)
-      // Bake an explicit render JVM into `daemon-launch.json` when the module's bytecode outruns
-      // the
-      // Gradle daemon JVM (or `renderJavaVersion` is pinned) — otherwise the desktop daemon's
-      // launcher is null and VS Code spawns it on its own bundled JDK, which can't load newer
-      // consumer classes. Mirrors the Android daemon wiring. See [RenderJvmSelection].
-      desktopRenderJavaExecutable(project, extension)?.let { javaLauncher.set(it) }
+      // Bake an explicit render JVM into `daemon-launch.json`. Unlike the in-Gradle `javaexec`
+      // render, the daemon is spawned by VS Code / MCP on *their* JDK, so we always pin a launcher
+      // (>= the module's bytecode target) rather than leaving it null — otherwise a JDK-17 editor
+      // spawns the daemon on Java 17 and can't load newer consumer classes. See
+      // [RenderJvmSelection.daemonDescriptorExecutable].
+      desktopDaemonJavaExecutable(project, extension)?.let { javaLauncher.set(it) }
       // Stage-2 BTA wiring. The configurations + dep adds are owned by
       // `wireDesktopBtaInputs` so the registration block stays scannable. Daemon JVM
       // lazily loads BTA only when the editor's save loop calls `compileSources` (gated
@@ -1208,6 +1208,28 @@ internal object ComposePreviewTasks {
       project.providers.gradleProperty("composePreview.renderJavaVersion").orNull?.toIntOrNull()
         ?: extension.renderJavaVersion.orNull
     return RenderJvmSelection.daemonJvmExecutable(
+      toolchains = toolchains,
+      gradleDaemonMajor = JavaVersion.current().majorVersion.toInt(),
+      bytecodeMajor = detectDesktopBytecodeMajor(project),
+      explicitOverride = override,
+    )
+  }
+
+  /**
+   * Like [desktopRenderJavaExecutable] but for the desktop **daemon descriptor** — always pins a
+   * launcher (never null when a toolchain service exists), because VS Code / MCP spawn the daemon
+   * on their own JDK rather than the Gradle daemon JVM, so a null launcher lets a JDK-17 editor run
+   * newer bytecode and fail. See [RenderJvmSelection.daemonDescriptorExecutable].
+   */
+  internal fun desktopDaemonJavaExecutable(
+    project: Project,
+    extension: PreviewExtension,
+  ): Provider<String>? {
+    val toolchains = project.extensions.findByType(JavaToolchainService::class.java) ?: return null
+    val override =
+      project.providers.gradleProperty("composePreview.renderJavaVersion").orNull?.toIntOrNull()
+        ?: extension.renderJavaVersion.orNull
+    return RenderJvmSelection.daemonDescriptorExecutable(
       toolchains = toolchains,
       gradleDaemonMajor = JavaVersion.current().majorVersion.toInt(),
       bytecodeMajor = detectDesktopBytecodeMajor(project),

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -4,13 +4,16 @@ import ee.schimke.composeai.discovery.*
 import kotlinx.serialization.json.Json
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
+import org.gradle.api.JavaVersion
 import org.gradle.api.Project
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.file.Directory
 import org.gradle.api.file.FileCollection
+import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskProvider
+import org.gradle.jvm.toolchain.JavaToolchainService
 
 private val previewManifestJson = Json { ignoreUnknownKeys = true }
 
@@ -244,6 +247,11 @@ internal object ComposePreviewTasks {
         // long-PNG and GIF artifacts; older Android Test wiring uses the same `data/` subdir.
         dataProductsDir.set(previewOutputDir.map { it.dir("data") })
         renderBackend.set("desktop")
+        // Fork the render subprocess on a JDK new enough for the module's bytecode. The desktop
+        // `javaexec` otherwise runs on the Gradle daemon JVM (JDK 17 here), so a consumer compiling
+        // to Java 21 would fail every preview with UnsupportedClassVersionError. See
+        // [RenderJvmSelection]; null (no upgrade needed) leaves the daemon-JVM default.
+        desktopRenderJavaExecutable(project, extension)?.let { renderJavaExecutable.set(it) }
         tier.set(tierProperty(project))
         // `composePreview.filter` convention for the `--preview` name filter (issue #2066); the
         // repeatable `--preview` CLI option overrides it. Comma-separated so a single `-P` can name
@@ -677,6 +685,12 @@ internal object ComposePreviewTasks {
       maxHeapMb.set(extension.daemon.maxHeapMb)
       maxRendersPerSandbox.set(extension.daemon.maxRendersPerSandbox)
       warmSpare.set(extension.daemon.warmSpare)
+      // Bake an explicit render JVM into `daemon-launch.json` when the module's bytecode outruns
+      // the
+      // Gradle daemon JVM (or `renderJavaVersion` is pinned) — otherwise the desktop daemon's
+      // launcher is null and VS Code spawns it on its own bundled JDK, which can't load newer
+      // consumer classes. Mirrors the Android daemon wiring. See [RenderJvmSelection].
+      desktopRenderJavaExecutable(project, extension)?.let { javaLauncher.set(it) }
       // Stage-2 BTA wiring. The configurations + dep adds are owned by
       // `wireDesktopBtaInputs` so the registration block stays scannable. Daemon JVM
       // lazily loads BTA only when the editor's save loop calls `compileSources` (gated
@@ -1176,6 +1190,53 @@ internal object ComposePreviewTasks {
       .gradleProperty("composePreview.tier")
       .map { v -> if (v.equals("fast", ignoreCase = true)) "fast" else "full" }
       .orElse("full")
+
+  /**
+   * Absolute `java` path for the desktop render subprocess when the module's bytecode target
+   * outruns the Gradle daemon JVM (or `composePreview.renderJavaVersion` is pinned), else `null` to
+   * keep the default. The desktop `javaexec` inherits no launcher, so [RenderJvmSelection] treats
+   * the daemon JVM as the baseline and only ever raises it. Returns `null` when no
+   * `JavaToolchainService` is available (never on a JVM/CMP module, defensive) so the render simply
+   * stays on the daemon JVM.
+   */
+  internal fun desktopRenderJavaExecutable(
+    project: Project,
+    extension: PreviewExtension,
+  ): Provider<String>? {
+    val toolchains = project.extensions.findByType(JavaToolchainService::class.java) ?: return null
+    val override =
+      project.providers.gradleProperty("composePreview.renderJavaVersion").orNull?.toIntOrNull()
+        ?: extension.renderJavaVersion.orNull
+    return RenderJvmSelection.daemonJvmExecutable(
+      toolchains = toolchains,
+      gradleDaemonMajor = JavaVersion.current().majorVersion.toInt(),
+      bytecodeMajor = detectDesktopBytecodeMajor(project),
+      explicitOverride = override,
+    )
+  }
+
+  /**
+   * Highest JVM bytecode target a desktop/JVM (Compose Multiplatform or plain Kotlin JVM) module
+   * compiles to — Java `targetCompatibility` off [JavaPluginExtension] plus Kotlin
+   * `compilerOptions.jvmTarget` off the JVM/desktop compile tasks — or `null` when neither reads.
+   * Feeds [desktopRenderJavaExecutable]. Fully defensive, mirroring the Android detector.
+   */
+  private fun detectDesktopBytecodeMajor(project: Project): Int? {
+    val candidates = mutableListOf<Int>()
+    runCatching {
+      project.extensions
+        .findByType(JavaPluginExtension::class.java)
+        ?.targetCompatibility
+        ?.let { BytecodeTargetDetector.parseTargetMajor(it.toString()) }
+        ?.let { candidates += it }
+    }
+    BytecodeTargetDetector.detectKotlinJvmTarget(
+        project,
+        listOf("compileKotlin", "compileKotlinJvm", "compileKotlinDesktop"),
+      )
+      ?.let { candidates += it }
+    return candidates.filter { it > 0 }.maxOrNull()
+  }
 
   /**
    * `Provider<List<String>>` for the `composePreview.filter` Gradle property — the `--preview` name

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderJvmSelection.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderJvmSelection.kt
@@ -123,6 +123,30 @@ internal object RenderJvmSelection {
     launcherFor(toolchains, null, gradleDaemonMajor, bytecodeMajor, explicitOverride)?.map {
       it.executablePath.asFile.absolutePath
     }
+
+  /**
+   * The absolute `java` path to bake into a **daemon launch descriptor** (`daemon-launch.json`).
+   * Unlike [daemonJvmExecutable], this is **always** non-null (for the selected major), because the
+   * daemon is spawned by an *external* process — VS Code (`findJavaOnPath()`) or the MCP server
+   * (its own `java.home`), not Gradle. A null launcher there does not mean "use the Gradle daemon
+   * JVM"; it means "let the editor guess", and a JDK-17 editor will then spawn the daemon on Java
+   * 17 and hit `UnsupportedClassVersionError` even when the Gradle build ran on a newer JVM. So the
+   * descriptor pins the JVM unconditionally: `max(Gradle daemon JVM, bytecode target)`, or the
+   * explicit override. The `max` with the Gradle daemon JVM keeps it resolvable with no
+   * provisioning in the common case (that JVM is always a detectable toolchain), while still
+   * writing an explicit path so the editor never falls back to an older JDK.
+   */
+  fun daemonDescriptorExecutable(
+    toolchains: JavaToolchainService,
+    gradleDaemonMajor: Int,
+    bytecodeMajor: Int?,
+    explicitOverride: Int?,
+  ): Provider<String> {
+    val target = selectMajor(null, gradleDaemonMajor, bytecodeMajor, explicitOverride)
+    return toolchains
+      .launcherFor { languageVersion.set(JavaLanguageVersion.of(target)) }
+      .map { it.executablePath.asFile.absolutePath }
+  }
 }
 
 /**

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderJvmSelection.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderJvmSelection.kt
@@ -105,6 +105,24 @@ internal object RenderJvmSelection {
       }
     }
   }
+
+  /**
+   * The absolute `java` path for a render that forks the **Gradle daemon JVM** rather than an
+   * inherited launcher — the desktop (`javaexec`) render path, which sets no executable today and
+   * so runs on whatever JVM Gradle is on (in this repo, the JDK-17 daemon). Returns `null` when no
+   * upgrade is warranted (bytecode fits the daemon JVM and no override), so the caller leaves the
+   * `javaexec` default untouched — byte-for-byte the prior behaviour. A non-null value is a
+   * config-cache-safe [Provider] resolved lazily from the toolchain service.
+   */
+  fun daemonJvmExecutable(
+    toolchains: JavaToolchainService,
+    gradleDaemonMajor: Int,
+    bytecodeMajor: Int?,
+    explicitOverride: Int?,
+  ): Provider<String>? =
+    launcherFor(toolchains, null, gradleDaemonMajor, bytecodeMajor, explicitOverride)?.map {
+      it.executablePath.asFile.absolutePath
+    }
 }
 
 /**

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderPreviewsTask.kt
@@ -110,6 +110,16 @@ abstract class RenderPreviewsTask : DefaultTask() {
 
   @get:Inject abstract val execOperations: ExecOperations
 
+  /**
+   * Absolute path to the `java` binary the render subprocess forks into. Unset (default) means the
+   * `javaexec` below runs on the Gradle daemon JVM — the historical behaviour. The plugin sets this
+   * only when the module's bytecode target outruns that daemon JVM (or `composePreview
+   * .renderJavaVersion` is pinned), raising the render fork to a JDK that can load the classes
+   * instead of failing with `UnsupportedClassVersionError`. See [RenderJvmSelection]. `@Input` so a
+   * JDK change re-renders; `@Optional` so the "no upgrade needed" path leaves it null.
+   */
+  @get:org.gradle.api.tasks.Optional @get:Input abstract val renderJavaExecutable: Property<String>
+
   init {
     // Explicit empty default so the desktop `composePreviewRender` registration (which never sets
     // `includeKinds`) has a configured value for this non-optional `@Input` rather than relying on
@@ -327,6 +337,9 @@ abstract class RenderPreviewsTask : DefaultTask() {
     fanoutSiblingStems: List<String> = emptyList(),
   ) {
     execOperations.javaexec {
+      // Fork on a JDK new enough for the consumer's bytecode when the plugin raised it (see
+      // [RenderJvmSelection]); otherwise leave the default (Gradle daemon JVM).
+      renderJavaExecutable.orNull?.let { executable = it }
       classpath = renderClasspath
       this.mainClass.set(mainClass)
       // Run the render JVM as a macOS "background agent" (LSUIElement) so it never claims a Dock


### PR DESCRIPTION
Follow-up to #2712, extending render-JVM selection to the desktop (Compose Multiplatform) path.

## Problem

#2712 fixed the Android/Robolectric + Android-daemon paths. The desktop paths had the same gap:

- **Desktop `composePreviewRender`** forks via `execOperations.javaexec { … }` with **no executable set**, so it runs on the Gradle daemon JVM (JDK 17 in this repo). A CMP module compiling to Java 21 failed every desktop preview with `UnsupportedClassVersionError`.
- **Desktop VS Code daemon** (`composePreviewDaemonStart` → `daemon-launch.json`) carried **no launcher**, so the editor spawned it on its own bundled JDK — the same fall-back that bit the Android daemon.

## What changed

- `RenderPreviewsTask` gains an optional `renderJavaExecutable` input, applied to the `javaexec` fork. Unset (the default) keeps the daemon-JVM behaviour byte-for-byte.
- `RenderJvmSelection.daemonJvmExecutable(...)` — the no-inherited-launcher convenience (the desktop render has no AGP launcher to inherit, so the Gradle daemon JVM is the baseline). Only ever raises the JVM; returns `null` when the daemon JVM already suffices.
- `ComposePreviewTasks.desktopRenderJavaExecutable` + `detectDesktopBytecodeMajor` — Java `targetCompatibility` (`JavaPluginExtension`) plus Kotlin `jvmTarget` off `compileKotlin{,Jvm,Desktop}`, reusing the same defensive `BytecodeTargetDetector`. Wired into the desktop CMP render **and** the desktop daemon descriptor.

The **Lottie/SVG** asset renders (Android modules, desktop backend) deliberately stay on the daemon JVM — they inflate `.json` / `.svg` assets via the renderer and never load the consumer's `@Composable` classes, so no JVM match is needed. Noted in code.

## Test plan

- `./gradlew :gradle-plugin:ktfmtFormat :gradle-plugin:test --tests "*RenderJvmSelectionTest"` — BUILD SUCCESSFUL; plugin (incl. the two desktop task files) recompiles and the selection/parse unit tests stay green; configuration-cache entry stores cleanly.
- **Relies on CI:** the desktop render / daemon functional E2Es that actually fork the JVM and load CMP bytecode.
- Non-visual build wiring — text-only evidence is appropriate.

With this, all render subprocesses (Android render, Android daemon, desktop render, desktop daemon) fork a JDK matched to the consumer's bytecode. `RenderJvmSelection` is now the single policy across every path.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rdn8bx3BjXBQoZFoxRWm6c)_