### PR TITLE
fix(gradle-plugin): pin artifactType on the desktop daemon-start consumer classpath

### DIFF
--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/KmpAndroidDaemonClasspathFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/KmpAndroidDaemonClasspathFunctionalTest.kt
@@ -1,0 +1,168 @@
+package ee.schimke.composeai.plugin
+
+import com.google.common.truth.Truth.assertThat
+import java.io.File
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Assume.assumeTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * Issue #1852 regression: the desktop daemon-start path must resolve a KMP-Android module's
+ * `androidRuntimeClasspath` through an `artifactType`-pinned artifact view.
+ *
+ * A pure `com.android.kotlin.multiplatform.library` dependency publishes an `androidRuntimeElements`
+ * whose runtime graph carries ~12 secondary variants keyed by `artifactType` (`android-classes-jar`,
+ * `android-aar-metadata`, … `jar`) and no unambiguous default. Resolving the consumer's
+ * `androidRuntimeClasspath` through a bare `incoming.artifactView {}` (no attributes) then fails with
+ * `AmbiguousArtifactsFailure` — "cannot choose between the following variants" — under AGP 9.3's
+ * stricter matching, which sank `composePreviewDaemonStart` (and with it the a11y pipeline that
+ * drives it) on such modules. The BTA-input wiring at `ComposePreviewTasks.wireDesktopBtaInputs`
+ * must pin `artifactType=jar` (via `pinnedConsumerClasspath`) exactly like the render / discover /
+ * guard consumer views already do — this test is the missing coverage for that desktop path (the
+ * existing `CliA11yEndToEndFunctionalTest` exercises the classic `com.android.library` path only).
+ *
+ * The *variant-selection* half is reproduced in plain Gradle — no AGP or Android SDK, since the
+ * ambiguity is a pure Gradle attribute-matching phenomenon: a producer subproject exposes an
+ * `androidRuntimeElements`-shaped consumable configuration with multiple `artifactType` secondary
+ * variants and no base artifact, and a consumer whose only runtime configuration is
+ * `androidRuntimeClasspath` (the candidate the desktop path picks ahead of `runtimeClasspath`)
+ * depends on it. Serializing `composePreviewDaemonStart` into the configuration cache resolves the
+ * task's classpath inputs, so a bare view aborts the build here while the pinned view succeeds.
+ *
+ * Realizing the daemon-start task also resolves the desktop renderer closure, so — like the other
+ * renderer-backed functional tests — this needs `ee.schimke.composeai:renderer-desktop:<version>` in
+ * mavenLocal (published by the `functionalTestWithAndroid` / publish-backed CI flow). It skips when
+ * that artifact is absent so a bare `:gradle-plugin:functionalTest` run stays green.
+ */
+class KmpAndroidDaemonClasspathFunctionalTest {
+
+  @get:Rule val tempDir = TemporaryFolder()
+
+  private val mavenLocal: String =
+    System.getProperty("ee.schimke.composeai.functionalTest.mavenLocal", "")
+
+  private val pluginVersion: String =
+    System.getProperty("ee.schimke.composeai.functionalTest.pluginVersion", "")
+
+  @Test
+  fun `daemon-start resolves a multi-variant androidRuntimeClasspath without ambiguity`() {
+    // The daemon-start task realizes the desktop renderer closure; skip unless it's published to
+    // mavenLocal (the publish-backed CI flow does this; a bare functionalTest run does not).
+    val rendererPublished =
+      mavenLocal.isNotBlank() &&
+        pluginVersion.isNotBlank() &&
+        File(mavenLocal, "ee/schimke/composeai/renderer-desktop/$pluginVersion").isDirectory
+    assumeTrue(
+      "Skipping: renderer-desktop-$pluginVersion not in mavenLocal " +
+        "(run via ./gradlew functionalTestWithAndroid, which publishes first)",
+      rendererPublished,
+    )
+
+    val projectDir = createKmpAndroidConsumerProject()
+
+    val result =
+      GradleRunner.create()
+        .withProjectDir(projectDir)
+        .withArguments("composePreviewDaemonStart", "--configuration-cache", "--stacktrace")
+        .withPluginClasspath()
+        .build()
+
+    // `composePreviewDaemonStart` is `onlyIf`-gated off for a pure `androidRuntimeClasspath` module,
+    // so the assertion is simply that the build resolved: storing the config cache resolves the
+    // task's classpath inputs, and a bare artifact view would have failed with
+    // AmbiguousArtifactsFailure on `:lib` before we ever reach BUILD SUCCESSFUL.
+    assertThat(result.output).doesNotContain("cannot choose between")
+    assertThat(result.output).doesNotContain("AmbiguousArtifactsFailure")
+    assertThat(result.output).contains("BUILD SUCCESSFUL")
+  }
+
+  private fun createKmpAndroidConsumerProject(): File {
+    val projectDir = tempDir.root
+
+    File(projectDir, "settings.gradle.kts")
+      .writeText(
+        """
+        pluginManagement {
+            repositories {
+                gradlePluginPortal()
+                google()
+                mavenCentral()
+            }
+        }
+        dependencyResolutionManagement {
+            repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+            repositories {
+                mavenLocal()
+                google()
+                mavenCentral()
+            }
+        }
+        rootProject.name = "kmp-android-daemon-test"
+        include(":lib")
+        """
+          .trimIndent()
+      )
+
+    // Producer: an `androidRuntimeElements`-shaped consumable configuration exposing several
+    // `artifactType` secondary variants (mirroring AGP's KMP-Android runtime) with no base artifact.
+    // The artifact files need not exist — variant *selection* fails before artifact *access*.
+    val libDir = File(projectDir, "lib").apply { mkdirs() }
+    File(libDir, "build.gradle.kts")
+      .writeText(
+        """
+        val artifactType = Attribute.of("artifactType", String::class.java)
+        val elements =
+            configurations.consumable("androidRuntimeElements") {
+                attributes {
+                    attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage::class.java, Usage.JAVA_RUNTIME))
+                    attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category::class.java, Category.LIBRARY))
+                }
+            }
+        listOf("android-classes-jar", "android-aar-metadata", "jar").forEach { type ->
+            elements.get().outgoing.variants.create(type) {
+                attributes.attribute(artifactType, type)
+                artifact(layout.buildDirectory.file("stub-${'$'}type.jar"))
+            }
+        }
+        """
+          .trimIndent()
+      )
+
+    // Consumer: the desktop path picks `androidRuntimeClasspath` ahead of `runtimeClasspath`, so a
+    // Kotlin/JVM + Compose module whose `androidRuntimeClasspath` carries the multi-variant producer
+    // exercises exactly the daemon-start classpath resolution that regressed.
+    File(projectDir, "build.gradle.kts")
+      .writeText(
+        """
+        @file:Suppress("DEPRECATION")
+        plugins {
+            kotlin("jvm") version "2.2.21"
+            kotlin("plugin.compose") version "2.2.21"
+            id("org.jetbrains.compose") version "1.10.3"
+            id("ee.schimke.composeai.preview")
+        }
+        dependencies {
+            implementation(compose.desktop.currentOs)
+        }
+        java {
+            toolchain { languageVersion.set(JavaLanguageVersion.of(17)) }
+        }
+        val androidRuntimeClasspath by
+            configurations.creating {
+                isCanBeResolved = true
+                isCanBeConsumed = false
+                attributes {
+                    attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage::class.java, Usage.JAVA_RUNTIME))
+                    attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category::class.java, Category.LIBRARY))
+                }
+            }
+        dependencies { androidRuntimeClasspath(project(":lib")) }
+        """
+          .trimIndent()
+      )
+
+    return projectDir
+  }
+}

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -1004,11 +1004,16 @@ internal object ComposePreviewTasks {
       task = task,
       // CMP / Kotlin-JVM: the consumer's runtime classpath is the compile classpath. Empty
       // file collection when no runtime config was found (rare; the desktop task wiring
-      // would have logged that case). Resolved through a lazy `incoming.artifactView {}.files`
-      // view so the BTA compile classpath never pins the raw `Configuration` into the daemon
-      // bootstrap task's config-cache state — see issue #1796. (The Android caller already passes
-      // AGP's config-cache-safe `Test.classpath`, so only this desktop path needs the wrap.)
-      userCompileClasspath = userRuntimeConfig?.incoming?.artifactView {}?.files ?: project.files(),
+      // would have logged that case). Resolved through `pinnedConsumerClasspath`'s lazy
+      // `incoming.artifactView { … }.files` view so the BTA compile classpath never pins the raw
+      // `Configuration` into the daemon bootstrap task's config-cache state — see issue #1796. (The
+      // Android caller already passes AGP's config-cache-safe `Test.classpath`, so only this
+      // desktop path needs the wrap.) The view pins `artifactType=jar` (issue #1852): a KMP-Android
+      // module's `androidRuntimeClasspath` exposes ~12 secondary variants, so a bare
+      // `artifactView {}` here fails with `AmbiguousArtifactsFailure` under AGP 9.3 and sinks the
+      // whole daemon-start — the same fix the render/discover/guard consumer views already carry.
+      userCompileClasspath =
+        userRuntimeConfig?.let { pinnedConsumerClasspath(project, it.name) } ?: project.files(),
       // MODULE_NAME mirrors KGP's default `compileKotlin` for non-multiplatform JVM modules
       // — `project.name`, no path-mangling. The bta-host-fixture spike confirmed Gradle
       // uses this exact spelling in `kotlin.Metadata.d2[]`.


### PR DESCRIPTION
## Summary

Fixes `compose-preview a11y` failing on pure `com.android.kotlin.multiplatform.library` modules under **AGP 9.3**.

`ComposePreviewTasks.wireDesktopBtaInputs` resolved the consumer's `androidRuntimeClasspath` through a **bare `incoming.artifactView {}`** (no attributes). A KMP-Android module's `androidRuntimeClasspath` exposes ~12 secondary runtime variants keyed by `artifactType` (`android-classes-jar`, `android-aar-metadata`, … `jar`) with no unambiguous default, so under AGP 9.3's stricter variant matching the resolution fails with `AmbiguousArtifactsFailure` — *"cannot choose between the following variants of project ':…'"* — which sinks `composePreviewDaemonStart` and, with it, the a11y pipeline that drives it.

This was the **one** consumer-classpath view in `ComposePreviewTasks` still left bare — the render (`:261`), guard (`:931`), daemon `-cp` (`:715`), discover, and bundle views already resolve through `pinnedConsumerClasspath`, which pins `artifactType=jar` (lenient for `androidRuntimeClasspath`) exactly for this issue (#1852). The fix routes the daemon-start BTA input through the same helper.

```kotlin
// before
userCompileClasspath = userRuntimeConfig?.incoming?.artifactView {}?.files ?: project.files(),
// after
userCompileClasspath =
    userRuntimeConfig?.let { pinnedConsumerClasspath(project, it.name) } ?: project.files(),
```

## Root cause evidence
Reproduced against a downstream KMP-Android consumer (homeassistant-remotecompose) with the released `0.17.15` CLI:
```
> Could not resolve all dependencies for configuration ':terrazzo-core:androidRuntimeClasspath'.
  … we cannot choose between the following variants of project ':ha-client':
      - variant android-classes-jar … Provides attribute 'artifactType' … but the consumer didn't ask for it
      - variant android-aar-metadata …
      - variant jar …
```

## Test plan
- **New regression test** `KmpAndroidDaemonClasspathFunctionalTest` (TestKit) reproduces the multi-secondary-variant `androidRuntimeClasspath` in plain Gradle (no AGP/SDK needed — the ambiguity is pure Gradle attribute matching) and asserts `composePreviewDaemonStart` resolves without ambiguity. Fills a real gap: the existing `CliA11yEndToEndFunctionalTest` covers only the classic `com.android.library` path, not the KMP-Android desktop path.
  - Verified locally (renderer published to mavenLocal): **passes with the fix; fails without it** with the exact `cannot choose between` / `AmbiguousArtifactsFailure` error.
  - Gated on the desktop renderer being in mavenLocal, so a bare `:gradle-plugin:functionalTest` run skips cleanly; runs under the publish-backed flow.
- Existing `KmpAndroidDesktopRoutingTest` unit tests pass.
- Rebuilt `:cli:installDist` and re-ran `compose-preview a11y` against the downstream module: the `androidRuntimeClasspath` ambiguity is gone.

Non-visual change (Gradle plugin plumbing + test), so no render evidence applies.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMLGezfVXDZrpJmwHrdYWC)_