### PR TITLE
test(gradle-plugin): make the KMP-Android daemon-classpath regression hermetic

### DIFF
--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/KmpAndroidDaemonClasspathFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/KmpAndroidDaemonClasspathFunctionalTest.kt
@@ -3,7 +3,6 @@ package ee.schimke.composeai.plugin
 import com.google.common.truth.Truth.assertThat
 import java.io.File
 import org.gradle.testkit.runner.GradleRunner
-import org.junit.Assume.assumeTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -12,67 +11,44 @@ import org.junit.rules.TemporaryFolder
  * Issue #1852 regression: the desktop daemon-start path must resolve a KMP-Android module's
  * `androidRuntimeClasspath` through an `artifactType`-pinned artifact view.
  *
- * A pure `com.android.kotlin.multiplatform.library` dependency publishes an `androidRuntimeElements`
- * whose runtime graph carries ~12 secondary variants keyed by `artifactType` (`android-classes-jar`,
- * `android-aar-metadata`, … `jar`) and no unambiguous default. Resolving the consumer's
- * `androidRuntimeClasspath` through a bare `incoming.artifactView {}` (no attributes) then fails with
- * `AmbiguousArtifactsFailure` — "cannot choose between the following variants" — under AGP 9.3's
- * stricter matching, which sank `composePreviewDaemonStart` (and with it the a11y pipeline that
- * drives it) on such modules. The BTA-input wiring at `ComposePreviewTasks.wireDesktopBtaInputs`
- * must pin `artifactType=jar` (via `pinnedConsumerClasspath`) exactly like the render / discover /
- * guard consumer views already do — this test is the missing coverage for that desktop path (the
- * existing `CliA11yEndToEndFunctionalTest` exercises the classic `com.android.library` path only).
+ * A pure `com.android.kotlin.multiplatform.library` dependency publishes an
+ * `androidRuntimeElements` whose runtime graph carries ~12 secondary variants keyed by
+ * `artifactType` (`android-classes-jar`, `android-aar-metadata`, … `jar`) and no unambiguous
+ * default. Resolving the consumer's `androidRuntimeClasspath` through a bare `incoming.artifactView
+ * {}` (no attributes) then fails with `AmbiguousArtifactsFailure` — "cannot choose between the
+ * following variants" — under AGP 9.3's stricter matching, which sank `composePreviewDaemonStart`
+ * (and with it the a11y pipeline that drives it) on such modules.
+ * `ComposePreviewTasks.wireDesktopBtaInputs` must pin `artifactType=jar` (via
+ * `pinnedConsumerClasspath`) exactly like the render / discover / guard consumer views already do —
+ * this is the missing coverage for that desktop path (the existing `CliA11yEndToEndFunctionalTest`
+ * exercises the classic `com.android.library` path only).
  *
- * The *variant-selection* half is reproduced in plain Gradle — no AGP or Android SDK, since the
- * ambiguity is a pure Gradle attribute-matching phenomenon: a producer subproject exposes an
- * `androidRuntimeElements`-shaped consumable configuration with multiple `artifactType` secondary
- * variants and no base artifact, and a consumer whose only runtime configuration is
- * `androidRuntimeClasspath` (the candidate the desktop path picks ahead of `runtimeClasspath`)
- * depends on it. Serializing `composePreviewDaemonStart` into the configuration cache resolves the
- * task's classpath inputs, so a bare view aborts the build here while the pinned view succeeds.
- *
- * Realizing the daemon-start task also resolves the desktop renderer closure, so — like the other
- * renderer-backed functional tests — this needs `ee.schimke.composeai:renderer-desktop:<version>` in
- * mavenLocal (published by the `functionalTestWithAndroid` / publish-backed CI flow). It skips when
- * that artifact is absent so a bare `:gradle-plugin:functionalTest` run stays green.
+ * Reproduced in plain Gradle — no AGP, Android SDK, or published renderer. The ambiguity is a pure
+ * Gradle attribute-matching phenomenon: a producer subproject exposes an `androidRuntimeElements`-
+ * shaped consumable configuration with multiple `artifactType` secondary variants and no base
+ * artifact, and a consumer whose only runtime configuration is `androidRuntimeClasspath` (the
+ * candidate the desktop path picks ahead of `runtimeClasspath`) depends on it. The build resolves
+ * only `composePreviewDaemonStart.btaCompileClasspath` (the wiring under test) — never the daemon's
+ * renderer closure — so the test stays hermetic and runs in the standard `functionalTest` job with
+ * no `publishToMavenLocal` pre-step.
  */
 class KmpAndroidDaemonClasspathFunctionalTest {
 
   @get:Rule val tempDir = TemporaryFolder()
 
-  private val mavenLocal: String =
-    System.getProperty("ee.schimke.composeai.functionalTest.mavenLocal", "")
-
-  private val pluginVersion: String =
-    System.getProperty("ee.schimke.composeai.functionalTest.pluginVersion", "")
-
   @Test
-  fun `daemon-start resolves a multi-variant androidRuntimeClasspath without ambiguity`() {
-    // The daemon-start task realizes the desktop renderer closure; skip unless it's published to
-    // mavenLocal (the publish-backed CI flow does this; a bare functionalTest run does not).
-    val rendererPublished =
-      mavenLocal.isNotBlank() &&
-        pluginVersion.isNotBlank() &&
-        File(mavenLocal, "ee/schimke/composeai/renderer-desktop/$pluginVersion").isDirectory
-    assumeTrue(
-      "Skipping: renderer-desktop-$pluginVersion not in mavenLocal " +
-        "(run via ./gradlew functionalTestWithAndroid, which publishes first)",
-      rendererPublished,
-    )
-
+  fun `daemon-start bta classpath resolves a multi-variant androidRuntimeClasspath`() {
     val projectDir = createKmpAndroidConsumerProject()
 
     val result =
       GradleRunner.create()
         .withProjectDir(projectDir)
-        .withArguments("composePreviewDaemonStart", "--configuration-cache", "--stacktrace")
+        .withArguments("resolveDaemonBtaClasspath", "--stacktrace")
         .withPluginClasspath()
         .build()
 
-    // `composePreviewDaemonStart` is `onlyIf`-gated off for a pure `androidRuntimeClasspath` module,
-    // so the assertion is simply that the build resolved: storing the config cache resolves the
-    // task's classpath inputs, and a bare artifact view would have failed with
-    // AmbiguousArtifactsFailure on `:lib` before we ever reach BUILD SUCCESSFUL.
+    // A bare artifact view would fail resolving `:lib`'s runtime variants with
+    // AmbiguousArtifactsFailure; the `artifactType=jar`-pinned view resolves cleanly.
     assertThat(result.output).doesNotContain("cannot choose between")
     assertThat(result.output).doesNotContain("AmbiguousArtifactsFailure")
     assertThat(result.output).contains("BUILD SUCCESSFUL")
@@ -94,7 +70,6 @@ class KmpAndroidDaemonClasspathFunctionalTest {
         dependencyResolutionManagement {
             repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
             repositories {
-                mavenLocal()
                 google()
                 mavenCentral()
             }
@@ -106,7 +81,8 @@ class KmpAndroidDaemonClasspathFunctionalTest {
       )
 
     // Producer: an `androidRuntimeElements`-shaped consumable configuration exposing several
-    // `artifactType` secondary variants (mirroring AGP's KMP-Android runtime) with no base artifact.
+    // `artifactType` secondary variants (mirroring AGP's KMP-Android runtime) with no base
+    // artifact.
     // The artifact files need not exist — variant *selection* fails before artifact *access*.
     val libDir = File(projectDir, "lib").apply { mkdirs() }
     File(libDir, "build.gradle.kts")
@@ -131,12 +107,18 @@ class KmpAndroidDaemonClasspathFunctionalTest {
       )
 
     // Consumer: the desktop path picks `androidRuntimeClasspath` ahead of `runtimeClasspath`, so a
-    // Kotlin/JVM + Compose module whose `androidRuntimeClasspath` carries the multi-variant producer
-    // exercises exactly the daemon-start classpath resolution that regressed.
+    // Kotlin/JVM + Compose module whose `androidRuntimeClasspath` carries the multi-variant
+    // producer
+    // exercises exactly the daemon-start classpath resolution that regressed. The custom task
+    // resolves only `composePreviewDaemonStart.btaCompileClasspath` — the wiring under test — which
+    // triggers the `androidRuntimeClasspath` view without realizing the daemon's renderer closure.
     File(projectDir, "build.gradle.kts")
       .writeText(
         """
         @file:Suppress("DEPRECATION")
+
+        import ee.schimke.composeai.plugin.daemon.DaemonBootstrapTask
+
         plugins {
             kotlin("jvm") version "2.2.21"
             kotlin("plugin.compose") version "2.2.21"
@@ -159,6 +141,16 @@ class KmpAndroidDaemonClasspathFunctionalTest {
                 }
             }
         dependencies { androidRuntimeClasspath(project(":lib")) }
+
+        // Resolve only the daemon-start BTA compile classpath (the fixed `androidRuntimeClasspath`
+        // view); the daemon's renderer closure is never realized, so no published renderer is needed.
+        tasks.register("resolveDaemonBtaClasspath") {
+            val bta =
+                tasks.named("composePreviewDaemonStart", DaemonBootstrapTask::class.java).map {
+                    it.btaCompileClasspath
+                }
+            doLast { logger.lifecycle("resolved BTA classpath entries: ${'$'}{bta.get().files.size}") }
+        }
         """
           .trimIndent()
       )


### PR DESCRIPTION
## Summary

Fast-follow to #2722. Two problems with the regression test that landed there:

1. **It silently skipped in CI** (Codex's review caught this): it gated on a published `renderer-desktop` in mavenLocal, but the standard `functionalTest` job (`ci.yml`) doesn't publish the desktop closure — so the guard never actually ran.
2. **It tripped `ktfmtCheckFunctionalTest` on `main`** (the formatting fix didn't make it into the merged commit).

## Fix

Rework the test to resolve **only** `composePreviewDaemonStart.btaCompileClasspath` — the `androidRuntimeClasspath` view that regressed — via a small custom task, instead of running the whole daemon-start task under `--configuration-cache`. That never realizes the daemon's renderer closure, so the build needs **no AGP, Android SDK, or published artifact** and runs in the standard `functionalTest` job with no `publishToMavenLocal` pre-step (no skip). Also re-formatted, so `ktfmtCheckFunctionalTest` is green.

## Test plan
- `./gradlew :gradle-plugin:functionalTest --tests KmpAndroidDaemonClasspathFunctionalTest` — **runs (no skip) and passes**.
- Reverted the `pinnedConsumerClasspath` fix locally → the test **fails** with `AmbiguousArtifactsFailure` / "cannot choose between the following variants", confirming it's a real guard.
- `ktfmtCheckFunctionalTest` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMLGezfVXDZrpJmwHrdYWC)_