### PR TITLE
feat(serve): materialise catalog RC docs so the browser canvas lane works on catalogs

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
@@ -1,11 +1,13 @@
 package ee.schimke.composeai.cli.serve
 
 import ee.schimke.composeai.cli.BundleReader
+import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.InputStream
 import java.security.MessageDigest
 import java.util.concurrent.TimeUnit
+import java.util.zip.ZipInputStream
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.builtins.MapSerializer
 import kotlinx.serialization.builtins.serializer
@@ -335,6 +337,11 @@ class ServeCatalogStore(
             "the bundle could not be fetched from the delivery branch"
           )
       } else {
+        // Materialise the captured Remote Compose documents (`ir/<daemon-id>.rc`) from the fetched
+        // bundle, re-keyed to the published catalog ids, so the baked host's in-browser canvas lane
+        // can serve them. Done regardless of the rehydrate/daemon outcome below — the client-side
+        // `.rc` lane needs no daemon, so it must survive a live-tier fallback.
+        extractCatalogRcDocs(bundleFile, alias, dir)
         // Rehydrate any resources the bundle externalized (fonts lifted out of classes/app.jar)
         // from
         // the branch's content-addressed pool into a shared cache + a materialized classpath dir.
@@ -521,6 +528,59 @@ class ServeCatalogStore(
     target.parentFile?.mkdirs()
     target.writeBytes(bytes)
     return target
+  }
+
+  /**
+   * Extract the captured Remote Compose documents from the fetched live [bundleFile] and
+   * materialise them beside the baked previews so the baked host's in-browser canvas lane can serve
+   * them.
+   *
+   * The packed bundle carries them as `ir/<daemon-id>.rc` (keyed by the daemon preview id — the
+   * function-descriptor id the renderer packed), but the published routes use the catalog id
+   * (`button-filled__ideal__default__dark`). [alias] is exactly that catalog-id → daemon-id map, so
+   * re-key each entry through it and write `<dir>/ir/<catalog-id>.rc` — the sibling of
+   * `<dir>/previews/` that [ServeBundleHost.remoteComposeDoc] reads. A catalog id whose daemon twin
+   * has no `.rc` entry (a non-Remote-Compose preview) is simply skipped, so only the RC previews
+   * advertise the lane. Best-effort: a malformed/unreadable bundle yields no docs (the lane stays
+   * off) rather than failing the whole catalog load.
+   */
+  private fun extractCatalogRcDocs(bundleFile: File, alias: Map<String, String>, dir: File) {
+    val docsByDaemonId =
+      try {
+        val zipBytes = BundleReader.extractZipBytes(bundleFile)
+        val out = HashMap<String, ByteArray>()
+        ZipInputStream(ByteArrayInputStream(zipBytes)).use { zin ->
+          var entry = zin.nextEntry
+          while (entry != null) {
+            val name = entry.name.replace('\\', '/')
+            if (
+              !entry.isDirectory &&
+                name.startsWith("$IR_DOC_DIR/") &&
+                name.endsWith(RC_DOC_SUFFIX) &&
+                ".." !in name.split("/")
+            ) {
+              val daemonId = name.removePrefix("$IR_DOC_DIR/").removeSuffix(RC_DOC_SUFFIX)
+              out[daemonId] = zin.readBytes()
+            }
+            zin.closeEntry()
+            entry = zin.nextEntry
+          }
+        }
+        out
+      } catch (e: Exception) {
+        return
+      }
+    if (docsByDaemonId.isEmpty()) return
+    val irDir = File(dir, IR_DOC_DIR)
+    val irRoot = irDir.canonicalFile.toPath()
+    for ((catalogId, daemonId) in alias) {
+      val bytes = docsByDaemonId[daemonId] ?: continue
+      val target = File(irDir, "$catalogId$RC_DOC_SUFFIX")
+      // Containment: a crafted catalog id must not let the write escape the ir/ dir.
+      if (!target.canonicalFile.toPath().startsWith(irRoot)) continue
+      target.parentFile?.mkdirs()
+      target.writeBytes(bytes)
+    }
   }
 
   /**
@@ -890,6 +950,14 @@ class ServeCatalogStore(
     private const val MAX_WASM_FILES = 64
     /** Local subdir a catalog's `liveBundle` file is fetched into (`<dir>/bundle/<file>`). */
     const val LIVE_BUNDLE_DIR = "bundle"
+
+    /**
+     * Sibling of `previews/` holding the captured Remote Compose documents (`ir/<catalog-id>.rc`),
+     * extracted from the live bundle's `ir/<daemon-id>.rc` entries by [extractCatalogRcDocs] and
+     * read back by [ServeBundleHost.remoteComposeDoc]. Mirrors the bundle's own `ir/` prefix.
+     */
+    const val IR_DOC_DIR = "ir"
+    const val RC_DOC_SUFFIX = ".rc"
 
     /**
      * Branch- and local-relative subdir (under `liveBundle.path` / [LIVE_BUNDLE_DIR]) holding the

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
@@ -319,6 +319,70 @@ class ServeCatalogStoreTest {
   }
 
   @Test
+  fun `a trusted liveBundle catalog materialises ir rc docs re-keyed to the catalog id`() {
+    // The live bundle carries the captured Remote Compose document as `ir/<daemon-id>.rc`; the
+    // store
+    // re-keys it to the published catalog id (via the same alias) so the baked host's client-side
+    // canvas lane serves it at `/render/<catalog-id>.rc`. A preview whose daemon twin has no `.rc`
+    // entry stays docless.
+    val root = tempRoot()
+    val rcBytes = byteArrayOf(0x52, 0x43, 0x07, 0x08)
+    val bundle =
+      polyglotBundle(
+        manifest =
+          """{"schemaVersion":8,"backend":"desktop","previewIds":["a"],"coverPreviewId":"a",""" +
+            """"externalResources":[]}""",
+        extra = mapOf("ir/FilledButton_Dark.rc" to rcBytes),
+      )
+    val json =
+      """
+      {"schema":"design-parity-catalog/v1","system":"compose-m3",
+       "liveBundle":{"path":"bundle/","file":"compose-m3-bundle.png"},
+       "components":[{"componentId":"Button/Filled","images":[
+         {"path":"images/button-filled/ideal__default__dark.png","theme":"dark","previewId":"FilledButton_Dark"},
+         {"path":"images/button-filled/ideal__keyboard-focus__dark.png","theme":"dark","previewId":"FilledButton_Focus"}]}]}
+      """
+        .trimIndent()
+    val fetch: (String) -> ByteArray? = { url ->
+      when {
+        url.endsWith("/${ServeCatalogStore.CATALOG_FILE}") -> json.toByteArray()
+        url.endsWith("bundle/compose-m3-bundle.png") -> bundle
+        url.endsWith(".png") -> png()
+        else -> null
+      }
+    }
+    val trust =
+      TrustStore(
+        branches = listOf(TrustedBranch("yschimke/compose-ai-tools", "design-artifacts/*"))
+      )
+    val store =
+      ServeCatalogStore(
+        root = root,
+        register = { n, h -> registered[n] = h },
+        trust = trust,
+        fetch = fetch,
+        // Return false so the live builder yields and the baked static host is registered — that's
+        // the host whose `remoteComposeDoc` serves the materialised `.rc`.
+        buildTrustedBundle = { _, _, _, _, _, _ -> false },
+      )
+    assertTrue(store.load("compose-m3") is ServeCatalogStore.Result.Ok)
+
+    // On disk: the daemon-keyed entry landed re-keyed to the catalog id, beside `previews/`.
+    assertTrue(
+      File(root, "compose-m3/ir/button-filled__ideal__default__dark.rc").isFile,
+      "ir/<catalog-id>.rc materialised",
+    )
+    val host = registered.getValue("compose-m3")
+    assertTrue(
+      rcBytes.contentEquals(host.remoteComposeDoc("button-filled__ideal__default__dark")),
+      "the baked host serves the re-keyed document bytes",
+    )
+    assertTrue(host.hasRemoteComposeDoc("button-filled__ideal__default__dark"))
+    // The focus variant's daemon twin (FilledButton_Focus) has no `.rc` entry → docless.
+    assertEquals(null, host.remoteComposeDoc("button-filled__ideal__keyboard-focus__dark"))
+  }
+
+  @Test
   fun `the per-preview fetcher fetches a daemon-id's own split bundle beside the liveBundle`() {
     // The builder is handed a per-preview fetcher: given a daemon-preview id it fetches that
     // preview's OWN FULL split bundle from <liveBundle.path>/previews/<daemon-id>.png on the same
@@ -640,7 +704,10 @@ class ServeCatalogStoreTest {
     }
 
   /** Build a minimal desktop-bundle polyglot (PNG cover + zip) with the given bundle.json. */
-  private fun polyglotBundle(manifest: String): ByteArray {
+  private fun polyglotBundle(
+    manifest: String,
+    extra: Map<String, ByteArray> = emptyMap(),
+  ): ByteArray {
     val cover = png()
     val appJar =
       ByteArrayOutputStream()
@@ -661,6 +728,7 @@ class ServeCatalogStoreTest {
                 "bundle.json" to manifest.toByteArray(),
                 "previews.json" to """{"previews":[{"id":"a","functionName":"A"}]}""".toByteArray(),
                 "classes/app.jar" to appJar,
+                *extra.entries.map { it.key to it.value }.toTypedArray(),
               )) {
               z.putNextEntry(java.util.zip.ZipEntry(name))
               z.write(bytes)


### PR DESCRIPTION
## Summary

Follow-up A, part 2 — the deferred catalog path. The in-browser Remote Compose canvas lane (#2720) only lit up for uploaded/`--bundles` sessions. A **`--catalogs`** session (e.g. `remote-m3` on preview.coo.ee) is served from the `design-artifacts/<system>` delivery branch, whose baked host carried no `ir/` docs — so `hasRemoteComposeDoc` was `false` and `/remote-m3/render/<id>.rc` **404'd**. Verified live after the v0.17.17 deploy: the player bundle served, but the catalog viewers had no lane.

The delivery branch's live bundle **already carries** the captured documents as `ir/<daemon-id>.rc` (keyed by the daemon preview id — I confirmed 19 entries in `design-artifacts/remote-m3/bundle/bundle.png`). This wires the serve side to use them:

- On catalog load, right after the live bundle is fetched, extract the `ir/*.rc` entries and **re-key them to the published catalog ids** via the existing catalog-id → daemon-id `alias`, writing `<dir>/ir/<catalog-id>.rc` beside `<dir>/previews/`.
- That's the exact path `ServeBundleHost.remoteComposeDoc` reads, so the baked host — and the live-fronted `ServeCatalogLiveHost`, which delegates to it — now advertises + serves the lane with **no host-code changes**.
- Runs **before** the rehydrate/daemon step, so the client-side lane survives even when the live daemon tier is skipped (it needs no daemon).
- Best-effort + zip-slip safe: a malformed bundle or a crafted id yields no docs rather than failing the catalog load; a preview whose daemon twin has no `.rc` entry stays docless.

**No delivery-branch change needed** — the published bundles already ship `ir/*.rc` (post-rename), so once this serves it, the lane activates on the catalogs.

## What it enables

This is the data-plumbing that feeds the already-shipped viewer lane (#2720) on the public catalogs. The rendered outcome is unchanged from #2720 — remote-m3's `CircularProgressRemote` painting client-side in a `<canvas>`, no Robolectric daemon:

![client-side canvas render](``https://raw.githubusercontent.com/yschimke/compose-ai-tools/ac0953f8b26e8e66a59f1be0c59cf69ba6e4a8e7/docs/design/evidence/rc-canvas-lane/client-side-canvas.png)``

## Test plan

- `:cli:test` (full suite) + `:cli:ktfmtCheck`/`ktfmtCheckTest` — green.

New test (`ServeCatalogStoreTest`): a trusted `liveBundle` catalog whose polyglot bundle carries `ir/FilledButton_Dark.rc` → the store materialises it re-keyed as `ir/button-filled__ideal__default__dark.rc`, the registered host serves those bytes via `remoteComposeDoc` (+ `hasRemoteComposeDoc` true), and a docless twin returns `null`.

Data-plumbing that activates the existing lane on catalog sessions (no viewer/render change), so the #2720 render above is the visual outcome; final confirmation is on preview.coo.ee's `remote-m3` once this ships.

---
_Generated by [Claude Code](https://claude.ai/code/session_011K7sgCfdsbhN7fwMb3WhSS)_