### PR TITLE
test(gradle-plugin): assert the pinned jar variant is actually selected

### DIFF
--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/KmpAndroidDaemonClasspathFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/KmpAndroidDaemonClasspathFunctionalTest.kt
@@ -52,6 +52,12 @@ class KmpAndroidDaemonClasspathFunctionalTest {
     assertThat(result.output).doesNotContain("cannot choose between")
     assertThat(result.output).doesNotContain("AmbiguousArtifactsFailure")
     assertThat(result.output).contains("BUILD SUCCESSFUL")
+    // Assert the pinned `jar` variant was actually selected — not merely that resolution didn't
+    // throw. `pinnedConsumerClasspath` applies `lenient(true)` for `androidRuntimeClasspath`, so a
+    // future regression that dropped the `artifactType=jar` pin but kept `lenient` would resolve to
+    // an *empty* collection (the ambiguous artifact silently dropped) and still pass the checks
+    // above; requiring `stub-jar.jar` keeps the pinning itself under guard.
+    assertThat(result.output).contains("stub-jar.jar")
   }
 
   private fun createKmpAndroidConsumerProject(): File {
@@ -149,7 +155,7 @@ class KmpAndroidDaemonClasspathFunctionalTest {
                 tasks.named("composePreviewDaemonStart", DaemonBootstrapTask::class.java).map {
                     it.btaCompileClasspath
                 }
-            doLast { logger.lifecycle("resolved BTA classpath entries: ${'$'}{bta.get().files.size}") }
+            doLast { logger.lifecycle("resolved BTA classpath: ${'$'}{bta.get().files.map { it.name }}") }
         }
         """
           .trimIndent()


### PR DESCRIPTION
## Summary

Follow-up to #2723, addressing [Codex's review](https://github.com/yschimke/compose-ai-tools/pull/2723) on that PR.

`KmpAndroidDaemonClasspathFunctionalTest` only checked that resolution didn't raise `AmbiguousArtifactsFailure`. But `pinnedConsumerClasspath` applies `lenient(true)` for `androidRuntimeClasspath`, so a *future* regression that dropped the `artifactType=jar` pin while keeping `lenient` would resolve to an **empty** collection (the ambiguous artifact silently dropped) — no failure, and all three existing assertions would still pass, leaving the pinning unguarded.

Log the resolved file names and assert `stub-jar.jar` is present, so the test requires the `jar` variant to actually be selected.

## Test plan
- `./gradlew :gradle-plugin:functionalTest --tests KmpAndroidDaemonClasspathFunctionalTest` — passes; the resolved BTA classpath is `[stub-jar.jar]`, so the new `contains("stub-jar.jar")` assertion holds.
- The three failure modes are now all covered: bare view → `AmbiguousArtifactsFailure` (fails); pin-dropped-but-lenient-kept → empty collection, no `stub-jar.jar` (fails); pinned view → `stub-jar.jar` (passes).

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMLGezfVXDZrpJmwHrdYWC)_