### PR TITLE
fix(bundle): pack per-param IR for @PreviewParameter previews

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
@@ -703,10 +703,12 @@ abstract class BundlePreviewTask : DefaultTask() {
    * protolayout proto. Returns `null` when the preview's flavour has no IR (the common case — every
    * plain `@Composable @Preview`), in which case the preview stays on the class-minimisation path.
    *
-   * Resolution mirrors [resolvePreviewPng]: the stem comes from the primary capture's
-   * `renderOutput`, and the file lives under [rendersDir]. IR sidecars are NOT fanned out across
-   * `@PreviewParameter` variants (a tile / remote document is a single artefact), so unlike the PNG
-   * path there's no sibling search.
+   * Resolution mirrors [resolvePreviewPng] — including its `@PreviewParameter` sibling search. A
+   * device-less param preview renders one document per value into `<stem>_<param>.<ext>` siblings
+   * (there is no un-suffixed `<stem>.<ext>`), and the bundle carries one representative artefact
+   * per preview id: [resolvePreviewPng] bakes the first (min-named) sibling PNG, so this packs the
+   * IR of that same sibling. Without the sibling fallback a param-driven Remote Compose / tile
+   * preview found its cover PNG but no IR, and silently dropped back to bytecode carriage.
    */
   /**
    * Look for the per-preview override sidecar the render step wrote next to [preview]'s PNG
@@ -819,21 +821,29 @@ abstract class BundlePreviewTask : DefaultTask() {
       preview.captures.firstOrNull()?.renderOutput?.takeIf { it.isNotEmpty() } ?: return null
     val stem = rel.substringAfterLast('/').removeSuffix(".png")
 
-    fun read(ext: String): ByteArray? {
-      val f = File(rendersRoot, "$stem.$ext")
-      return if (f.isFile && f.length() > 0) f.readBytes() else null
-    }
+    fun resolveIrFile(ext: String): File? = resolveIrSidecar(rendersRoot, stem, ext)
 
-    read(IR_EXT_REMOTECOMPOSE)?.let {
-      return ResolvedIr(format = IR_FORMAT_REMOTECOMPOSE, ext = IR_EXT_REMOTECOMPOSE, bytes = it)
+    resolveIrFile(IR_EXT_REMOTECOMPOSE)?.let {
+      return ResolvedIr(
+        format = IR_FORMAT_REMOTECOMPOSE,
+        ext = IR_EXT_REMOTECOMPOSE,
+        bytes = it.readBytes(),
+      )
     }
-    read(IR_EXT_PROTOLAYOUT_LAYOUT)?.let { layout ->
+    resolveIrFile(IR_EXT_PROTOLAYOUT_LAYOUT)?.let { layout ->
+      // The tile's resources proto shares the layout's exact stem (param suffix and all), so derive
+      // the companion from the resolved layout file rather than re-searching independently.
+      val layoutStem = layout.name.removeSuffix(".$IR_EXT_PROTOLAYOUT_LAYOUT")
+      val resources =
+        File(rendersRoot, "$layoutStem.$IR_EXT_PROTOLAYOUT_RESOURCES").takeIf {
+          it.isFile && it.length() > 0
+        }
       return ResolvedIr(
         format = IR_FORMAT_PROTOLAYOUT,
         ext = IR_EXT_PROTOLAYOUT_LAYOUT,
-        bytes = layout,
+        bytes = layout.readBytes(),
         resourcesExt = IR_EXT_PROTOLAYOUT_RESOURCES,
-        resourcesBytes = read(IR_EXT_PROTOLAYOUT_RESOURCES),
+        resourcesBytes = resources?.readBytes(),
       )
     }
     return null
@@ -1488,4 +1498,25 @@ abstract class BundlePreviewTask : DefaultTask() {
       baos.toByteArray()
     }
   }
+}
+
+/**
+ * Resolve the captured IR sidecar of extension [ext] for a preview whose primary render stem is
+ * [stem], under [rendersRoot]. Returns the exact `<stem>.<ext>` when present, else the first
+ * (lexicographically min-named) `@PreviewParameter` sibling — `<stem>_<param>.<ext>` or
+ * `<stem>--<dim>.<ext>` — matching the representative cover PNG
+ * `BundlePreviewTask.resolvePreviewPng` bakes for the same preview. `null` when neither exists.
+ * Top-level + internal so the fan-out behaviour is unit-testable without a Gradle task instance.
+ */
+internal fun resolveIrSidecar(rendersRoot: File, stem: String, ext: String): File? {
+  val exact = File(rendersRoot, "$stem.$ext")
+  if (exact.isFile && exact.length() > 0) return exact
+  return rendersRoot
+    .listFiles { f ->
+      f.isFile &&
+        f.length() > 0 &&
+        f.name.endsWith(".$ext") &&
+        (f.name.startsWith("${stem}_") || f.name.startsWith("$stem--"))
+    }
+    ?.minByOrNull { it.name }
 }

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/ResolveIrSidecarTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/ResolveIrSidecarTest.kt
@@ -1,0 +1,63 @@
+package ee.schimke.composeai.plugin
+
+import com.google.common.truth.Truth.assertThat
+import java.io.File
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * Pins [resolveIrSidecar] — how the bundle finds a preview's captured IR (`.rc` Remote Compose doc
+ * / `.tilelayout` protolayout) next to its render. An exact `<stem>.<ext>` wins; otherwise the
+ * first (min-named) `@PreviewParameter` / multi-variant sibling is used, matching the
+ * representative cover PNG the bundle bakes for the same preview. Before this, param-driven Remote
+ * Compose / tile previews found their cover PNG but no IR and dropped back to bytecode carriage.
+ */
+class ResolveIrSidecarTest {
+
+  @get:Rule val tmp = TemporaryFolder()
+
+  private fun write(name: String, content: String = "doc") = File(tmp.root, name).writeText(content)
+
+  @Test
+  fun `exact stem wins over any sibling`() {
+    write("Foo.rc")
+    write("Foo_PARAM_0.rc")
+    assertThat(resolveIrSidecar(tmp.root, "Foo", "rc")?.name).isEqualTo("Foo.rc")
+  }
+
+  @Test
+  fun `falls back to the first min-named PreviewParameter sibling`() {
+    write("Foo_PARAM_2.rc")
+    write("Foo_PARAM_0.rc")
+    write("Foo_PARAM_1.rc")
+    // The same representative resolvePreviewPng picks (min-named), so the packed IR and cover
+    // agree.
+    assertThat(resolveIrSidecar(tmp.root, "Foo", "rc")?.name).isEqualTo("Foo_PARAM_0.rc")
+  }
+
+  @Test
+  fun `matches dimension-suffixed multi-variant siblings`() {
+    write("Foo--wearos_small_round.rc")
+    assertThat(resolveIrSidecar(tmp.root, "Foo", "rc")?.name)
+      .isEqualTo("Foo--wearos_small_round.rc")
+  }
+
+  @Test
+  fun `ignores a different extension and a different stem`() {
+    write("Foo_PARAM_0.tilelayout")
+    write("Bar_PARAM_0.rc")
+    assertThat(resolveIrSidecar(tmp.root, "Foo", "rc")).isNull()
+  }
+
+  @Test
+  fun `skips an empty sidecar`() {
+    write("Foo.rc", "")
+    assertThat(resolveIrSidecar(tmp.root, "Foo", "rc")).isNull()
+  }
+
+  @Test
+  fun `null when no sidecar exists`() {
+    assertThat(resolveIrSidecar(tmp.root, "Foo", "rc")).isNull()
+  }
+}


### PR DESCRIPTION
## Summary

Follow-up to #2727, which flagged this limitation. `BundlePreviewTask.resolvePreviewPng` already falls back to the first (min-named) `@PreviewParameter` sibling (`<stem>_<param>.png`) when there's no un-suffixed cover, so the bundle bakes a representative PNG for a param-driven preview. **`resolvePreviewIr` did not** — it only read `<stem>.<ext>` — so a device-less `@PreviewParameter` Remote Compose (or Wear tile) preview found its cover PNG but **no IR**, and silently dropped back to bytecode carriage.

## Fix

Make IR resolution mirror the PNG path: exact `<stem>.<ext>` wins, else the first min-named sibling — the same representative the cover PNG picks, so the packed IR and PNG agree. The protolayout `.tileresources` companion is derived from the resolved layout's stem so it stays param-consistent. The fan-out lookup is extracted as a top-level internal `resolveIrSidecar` so it's unit-testable without a Gradle task instance.

## Verified end-to-end

Rebuilt `:samples:wear-widget`'s bundle (its widget previews are `@PreviewParameter`-driven). Before, only the fixed-params preview's `.rc` was packed; now all three widget documents land in `ir/`:

```
ir/…ImageWidgetSquirclePreview_Image Widget Squircle.rc          ← @PreviewParameter, now packed
ir/…ImageWidgetSquircleLargePreview_Image Widget Squircle Large.rc ← @PreviewParameter, now packed
ir/…ImageWidgetFixedPreview_Image Widget Fixed.rc               ← already worked
```

So a param-driven Wear widget now travels in the bundle as its encoded document, not bytecode.

## Test plan

- **`ResolveIrSidecarTest`** (new) — exact stem wins; falls back to the first min-named `_PARAM_N` / `--<dim>` sibling; ignores wrong extension / wrong stem / empty sidecar; null when absent.
- Manual end-to-end: `:samples:wear-widget:composePreviewBundle` packs all three `.rc` docs (above), no widget bytecode in `classes/app.jar`.
- `:gradle-plugin:test` (ResolveIrSidecarTest) + `ktfmtCheck` green locally.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ew6bJN6X8Z2u8dAhsCWYkm)_