### PR TITLE
fix(bundle): sanitize preview ids in bundle entry names so no file name carries spaces

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
@@ -305,7 +305,11 @@ abstract class BundlePreviewTask : DefaultTask() {
     val manifestFile = previewsJson.get().asFile
     val manifest = JSON.decodeFromString(PreviewManifest.serializer(), manifestFile.readText())
     val selected = resolveSelection(manifest, previewIds.get())
-    val coverId = selected.first().id
+    // The raw id addresses renderer-written content on disk (render sidecars, extension reports,
+    // which are keyed by the un-sanitised id); [coverId] is its bundle form, used for every id that
+    // lands *inside* the bundle — entry names and both manifests. See [sanitizeBundleEntryId].
+    val coverIdRaw = selected.first().id
+    val coverId = sanitizeBundleEntryId(coverIdRaw)
 
     // Previews whose flavour emitted a serialisable intermediate representation (Remote Compose doc
     // / Wear protolayout proto) during the render step are replayed from that IR, not by re-running
@@ -412,17 +416,18 @@ abstract class BundlePreviewTask : DefaultTask() {
     val irZipFiles = LinkedHashMap<String, ByteArray>()
     for (preview in selected) {
       val ir = irByPreview[preview.id] ?: continue
-      val irPath = "$BUNDLE_IR_DIR/${preview.id}.${ir.ext}"
+      val bundleId = sanitizeBundleEntryId(preview.id)
+      val irPath = "$BUNDLE_IR_DIR/$bundleId.${ir.ext}"
       irZipFiles[irPath] = ir.bytes
       val resourcesPath =
         ir.resourcesBytes?.let { rb ->
-          val rp = "$BUNDLE_IR_DIR/${preview.id}.${ir.resourcesExt}"
+          val rp = "$BUNDLE_IR_DIR/$bundleId.${ir.resourcesExt}"
           irZipFiles[rp] = rb
           rp
         }
       irEntries +=
         BundleIr(
-          previewId = preview.id,
+          previewId = bundleId,
           format = ir.format,
           path = irPath,
           resourcesPath = resourcesPath,
@@ -479,7 +484,7 @@ abstract class BundlePreviewTask : DefaultTask() {
           continue
         }
         val zipPath = "$BUNDLE_EXTENSIONS_DIR/$id.json"
-        dataExtensionZipFiles[zipPath] = scopeReportToCoverPreview(src.readBytes(), coverId)
+        dataExtensionZipFiles[zipPath] = scopeReportToCoverPreview(src.readBytes(), coverIdRaw)
         dataExtensionEntries += BundleDataExtension(extensionId = id, path = zipPath)
       }
     }
@@ -488,7 +493,7 @@ abstract class BundlePreviewTask : DefaultTask() {
       BundleManifest(
         schemaVersion = BUNDLE_SCHEMA_VERSION,
         backend = backend.get(),
-        previewIds = selected.map { it.id },
+        previewIds = selected.map { sanitizeBundleEntryId(it.id) },
         coverPreviewId = coverId,
         classpath = classpathEntries,
         modulePath = modulePath.get(),
@@ -505,7 +510,7 @@ abstract class BundlePreviewTask : DefaultTask() {
     // simply omitted — the reader treats an absent entry as "not rendered yet".
     val previewPngs = LinkedHashMap<String, ByteArray>()
     for (preview in selected) {
-      resolvePreviewPng(preview)?.let { previewPngs[preview.id] = it }
+      resolvePreviewPng(preview)?.let { previewPngs[sanitizeBundleEntryId(preview.id)] = it }
     }
 
     // (v8) Per-preview override sidecars: the editable knobs a preview declared via
@@ -516,8 +521,9 @@ abstract class BundlePreviewTask : DefaultTask() {
     // that declared none.
     val overrideFiles = LinkedHashMap<String, ByteArray>()
     for (preview in selected) {
+      val bundleId = sanitizeBundleEntryId(preview.id)
       resolvePreviewOverrides(preview)?.let {
-        overrideFiles["$BUNDLE_PREVIEWS_DIR/${preview.id}.$BUNDLE_OVERRIDES_SIDECAR_EXT"] = it
+        overrideFiles["$BUNDLE_PREVIEWS_DIR/$bundleId.$BUNDLE_OVERRIDES_SIDECAR_EXT"] = it
       }
       // Per-preview Remote Compose knob sidecars (`renders/<stem>.remotecompose.json`), packed
       // under `previews/<id>.remotecompose.json` — a separate channel from the plain-Compose
@@ -525,7 +531,7 @@ abstract class BundlePreviewTask : DefaultTask() {
       // the same verbatim-copied `overrideFiles` map, so no `buildZip` signature change. Absent for
       // previews that declared no Remote Compose knobs.
       resolvePreviewRemoteCompose(preview)?.let {
-        overrideFiles["$BUNDLE_PREVIEWS_DIR/${preview.id}.$BUNDLE_REMOTECOMPOSE_SIDECAR_EXT"] = it
+        overrideFiles["$BUNDLE_PREVIEWS_DIR/$bundleId.$BUNDLE_REMOTECOMPOSE_SIDECAR_EXT"] = it
       }
     }
 
@@ -541,10 +547,17 @@ abstract class BundlePreviewTask : DefaultTask() {
     for (preview in selected) {
       resolvePreviewCatalogTokens(preview)?.let {
         catalogTokenEntries[
-          "$BUNDLE_PREVIEWS_DIR/${preview.id}.$BUNDLE_CATALOG_TOKENS_SIDECAR_EXT"] = it
+          "$BUNDLE_PREVIEWS_DIR/${sanitizeBundleEntryId(preview.id)}.$BUNDLE_CATALOG_TOKENS_SIDECAR_EXT"] =
+          it
       }
     }
 
+    // The bundled `previews.json` addresses the same in-bundle entries as `bundle.json`, and
+    // readers
+    // reconstruct `previews/<id>.png` from these ids — so its `id`s carry the bundle form too, kept
+    // in lockstep with the entry names and [BundleManifest] ids above. (`renderOutput` and other
+    // producer-side paths are irrelevant in a detached bundle, so they're left as-is.)
+    val bundlePreviews = selected.map { it.copy(id = sanitizeBundleEntryId(it.id)) }
     val filteredManifest =
       if (includeDataExtensions.getOrElse(false)) {
         // When carrying extension data, rewrite the bundled manifest's `dataExtensionReports` to
@@ -557,11 +570,11 @@ abstract class BundlePreviewTask : DefaultTask() {
         // that were skipped (source missing) drop out of the map so nothing dangles. Left untouched
         // in the default (non-carrying) pack, preserving the historical on-disk pointers.
         manifest.copy(
-          previews = selected,
+          previews = bundlePreviews,
           dataExtensionReports = dataExtensionEntries.associate { it.extensionId to it.path },
         )
       } else {
-        manifest.copy(previews = selected)
+        manifest.copy(previews = bundlePreviews)
       }
     val zipBytes =
       buildZip(
@@ -1520,3 +1533,16 @@ internal fun resolveIrSidecar(rendersRoot: File, stem: String, ext: String): Fil
     }
     ?.minByOrNull { it.name }
 }
+
+/**
+ * Map a preview `id` to the form used for its file names *inside a bundle* — zip entry names
+ * (`previews/<id>.png`, `ir/<id>.rc`, …) and the ids in the bundle's own `bundle.json` /
+ * `previews.json`. A `@Preview(name = "Image Widget Squircle")` yields an id carrying spaces; the
+ * on-disk renderer already collapses those for its file stems (`[^A-Za-z0-9._-]` → `_`), but the
+ * pack step historically copied the raw id verbatim, so bundle entries alone kept the spaces. This
+ * applies the *same* per-character substitution the renderer uses so the whole bundle is shell- and
+ * URL-friendly and internally consistent: entry names, the ids readers reconstruct those names
+ * from, and the two manifests all agree. Dots and dashes are preserved (they never need quoting and
+ * keep dot-vs-underscore-distinct ids distinct). Kept top-level + internal so it's unit-testable.
+ */
+internal fun sanitizeBundleEntryId(id: String): String = id.replace(Regex("[^A-Za-z0-9._-]"), "_")

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
@@ -306,10 +306,13 @@ abstract class BundlePreviewTask : DefaultTask() {
     val manifest = JSON.decodeFromString(PreviewManifest.serializer(), manifestFile.readText())
     val selected = resolveSelection(manifest, previewIds.get())
     // The raw id addresses renderer-written content on disk (render sidecars, extension reports,
-    // which are keyed by the un-sanitised id); [coverId] is its bundle form, used for every id that
-    // lands *inside* the bundle — entry names and both manifests. See [sanitizeBundleEntryId].
+    // which are keyed by the un-sanitised id); the bundle form is used for every id that lands
+    // *inside* the bundle — entry names and both manifests. [bundleIds] is that raw→bundle mapping,
+    // computed once over the whole selection so it's collision-free and every materialisation
+    // agrees (see [assignBundleEntryIds]).
+    val bundleIds = assignBundleEntryIds(selected.map { it.id })
     val coverIdRaw = selected.first().id
-    val coverId = sanitizeBundleEntryId(coverIdRaw)
+    val coverId = bundleIds.getValue(coverIdRaw)
 
     // Previews whose flavour emitted a serialisable intermediate representation (Remote Compose doc
     // / Wear protolayout proto) during the render step are replayed from that IR, not by re-running
@@ -416,7 +419,7 @@ abstract class BundlePreviewTask : DefaultTask() {
     val irZipFiles = LinkedHashMap<String, ByteArray>()
     for (preview in selected) {
       val ir = irByPreview[preview.id] ?: continue
-      val bundleId = sanitizeBundleEntryId(preview.id)
+      val bundleId = bundleIds.getValue(preview.id)
       val irPath = "$BUNDLE_IR_DIR/$bundleId.${ir.ext}"
       irZipFiles[irPath] = ir.bytes
       val resourcesPath =
@@ -493,7 +496,7 @@ abstract class BundlePreviewTask : DefaultTask() {
       BundleManifest(
         schemaVersion = BUNDLE_SCHEMA_VERSION,
         backend = backend.get(),
-        previewIds = selected.map { sanitizeBundleEntryId(it.id) },
+        previewIds = selected.map { bundleIds.getValue(it.id) },
         coverPreviewId = coverId,
         classpath = classpathEntries,
         modulePath = modulePath.get(),
@@ -510,7 +513,7 @@ abstract class BundlePreviewTask : DefaultTask() {
     // simply omitted — the reader treats an absent entry as "not rendered yet".
     val previewPngs = LinkedHashMap<String, ByteArray>()
     for (preview in selected) {
-      resolvePreviewPng(preview)?.let { previewPngs[sanitizeBundleEntryId(preview.id)] = it }
+      resolvePreviewPng(preview)?.let { previewPngs[bundleIds.getValue(preview.id)] = it }
     }
 
     // (v8) Per-preview override sidecars: the editable knobs a preview declared via
@@ -521,7 +524,7 @@ abstract class BundlePreviewTask : DefaultTask() {
     // that declared none.
     val overrideFiles = LinkedHashMap<String, ByteArray>()
     for (preview in selected) {
-      val bundleId = sanitizeBundleEntryId(preview.id)
+      val bundleId = bundleIds.getValue(preview.id)
       resolvePreviewOverrides(preview)?.let {
         overrideFiles["$BUNDLE_PREVIEWS_DIR/$bundleId.$BUNDLE_OVERRIDES_SIDECAR_EXT"] = it
       }
@@ -547,7 +550,7 @@ abstract class BundlePreviewTask : DefaultTask() {
     for (preview in selected) {
       resolvePreviewCatalogTokens(preview)?.let {
         catalogTokenEntries[
-          "$BUNDLE_PREVIEWS_DIR/${sanitizeBundleEntryId(preview.id)}.$BUNDLE_CATALOG_TOKENS_SIDECAR_EXT"] =
+          "$BUNDLE_PREVIEWS_DIR/${bundleIds.getValue(preview.id)}.$BUNDLE_CATALOG_TOKENS_SIDECAR_EXT"] =
           it
       }
     }
@@ -557,7 +560,7 @@ abstract class BundlePreviewTask : DefaultTask() {
     // reconstruct `previews/<id>.png` from these ids — so its `id`s carry the bundle form too, kept
     // in lockstep with the entry names and [BundleManifest] ids above. (`renderOutput` and other
     // producer-side paths are irrelevant in a detached bundle, so they're left as-is.)
-    val bundlePreviews = selected.map { it.copy(id = sanitizeBundleEntryId(it.id)) }
+    val bundlePreviews = selected.map { it.copy(id = bundleIds.getValue(it.id)) }
     val filteredManifest =
       if (includeDataExtensions.getOrElse(false)) {
         // When carrying extension data, rewrite the bundled manifest's `dataExtensionReports` to
@@ -1546,3 +1549,31 @@ internal fun resolveIrSidecar(rendersRoot: File, stem: String, ext: String): Fil
  * keep dot-vs-underscore-distinct ids distinct). Kept top-level + internal so it's unit-testable.
  */
 internal fun sanitizeBundleEntryId(id: String): String = id.replace(Regex("[^A-Za-z0-9._-]"), "_")
+
+/**
+ * Assign a collision-free bundle-entry id to every preview in [rawIds], preserving order. Preview
+ * `id`s are unique, but [sanitizeBundleEntryId] can map two distinct ones to the same form (sibling
+ * `@Preview` names `"A B"` and `"A_B"` both sanitise to `A_B`). Left unchecked that would collide
+ * the `previews/<id>.png` / `ir/<id>.rc` entry keys — the later capture silently overwriting the
+ * earlier — and emit duplicate ids in both bundled manifests. So the first claimant of a sanitised
+ * form keeps it and each subsequent collision gets a `_<n>` suffix, mirroring how discovery
+ * disambiguates render stems. Computed once over the whole selection and reused for every entry
+ * name and manifest so all id materialisations agree. A repeated raw id (same preview requested
+ * twice) maps to the one bundle id, not a fresh disambiguated one.
+ */
+internal fun assignBundleEntryIds(rawIds: List<String>): Map<String, String> {
+  val used = HashSet<String>()
+  val result = LinkedHashMap<String, String>()
+  for (raw in rawIds) {
+    if (result.containsKey(raw)) continue
+    val base = sanitizeBundleEntryId(raw)
+    var candidate = base
+    var n = 1
+    while (!used.add(candidate)) {
+      candidate = "${base}_$n"
+      n++
+    }
+    result[raw] = candidate
+  }
+  return result
+}

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/SanitizeBundleEntryIdTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/SanitizeBundleEntryIdTest.kt
@@ -1,0 +1,46 @@
+package ee.schimke.composeai.plugin
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Pins [sanitizeBundleEntryId] — the mapping from a preview `id` to the form used for its file
+ * names inside a bundle (`previews/<id>.png`, `ir/<id>.rc`, and the ids in the bundle's own
+ * `bundle.json` / `previews.json`). A `@Preview(name = "Image Widget Squircle")` yields an id with
+ * spaces; the pack step used to copy it verbatim, so the bundle entries alone carried spaces while
+ * the on-disk renders were already collapsed. This makes the bundle match the renderer's own
+ * `[^A-Za-z0-9._-]` → `_` per-character substitution so entry names, the ids readers reconstruct
+ * them from, and both manifests all agree — and nothing a shell or URL would have to quote
+ * survives.
+ */
+class SanitizeBundleEntryIdTest {
+
+  @Test
+  fun `collapses spaces to underscores`() {
+    assertThat(sanitizeBundleEntryId("ImageWidgetSquirclePreview_Image Widget Squircle"))
+      .isEqualTo("ImageWidgetSquirclePreview_Image_Widget_Squircle")
+  }
+
+  @Test
+  fun `preserves dots and dashes`() {
+    // Dots never need quoting and keep dot-vs-underscore-distinct ids distinct (the manifest dedups
+    // by id); dashes are shell- and URL-safe too. Both must survive untouched.
+    assertThat(sanitizeBundleEntryId("com.example.FooKt.Bar_Font scale 1.5x"))
+      .isEqualTo("com.example.FooKt.Bar_Font_scale_1.5x")
+    assertThat(sanitizeBundleEntryId("Foo_wearos-small-round")).isEqualTo("Foo_wearos-small-round")
+  }
+
+  @Test
+  fun `replaces every shell- or URL-awkward character`() {
+    assertThat(sanitizeBundleEntryId("Foo_tile (light) \"a/b\""))
+      .isEqualTo("Foo_tile__light___a_b_")
+  }
+
+  @Test
+  fun `is idempotent on an already-clean id`() {
+    val clean = "pkg.Foo_Devices_Large_Round"
+    assertThat(sanitizeBundleEntryId(clean)).isEqualTo(clean)
+    assertThat(sanitizeBundleEntryId(sanitizeBundleEntryId("Foo_A B")))
+      .isEqualTo(sanitizeBundleEntryId("Foo_A B"))
+  }
+}

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/SanitizeBundleEntryIdTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/SanitizeBundleEntryIdTest.kt
@@ -43,4 +43,29 @@ class SanitizeBundleEntryIdTest {
     assertThat(sanitizeBundleEntryId(sanitizeBundleEntryId("Foo_A B")))
       .isEqualTo(sanitizeBundleEntryId("Foo_A B"))
   }
+
+  @Test
+  fun `assignBundleEntryIds leaves non-colliding ids untouched, in order`() {
+    val map = assignBundleEntryIds(listOf("pkg.Foo_A B", "pkg.Bar_C D"))
+    assertThat(map.values.toList()).containsExactly("pkg.Foo_A_B", "pkg.Bar_C_D").inOrder()
+  }
+
+  @Test
+  fun `assignBundleEntryIds disambiguates two ids that sanitise to the same form`() {
+    // `"A B"` and `"A_B"` are distinct preview ids (the manifest dedups by raw id) that both
+    // sanitise to `Foo_A_B`. Without disambiguation their `previews/<id>.png` / `ir/<id>.rc` keys
+    // would collide and one capture would silently overwrite the other. First claimant keeps the
+    // clean form; the collision gets a numeric suffix.
+    val map = assignBundleEntryIds(listOf("Foo_A B", "Foo_A_B"))
+    assertThat(map.getValue("Foo_A B")).isEqualTo("Foo_A_B")
+    assertThat(map.getValue("Foo_A_B")).isEqualTo("Foo_A_B_1")
+    assertThat(map.values.toSet()).hasSize(2)
+  }
+
+  @Test
+  fun `assignBundleEntryIds maps a repeated raw id to a single bundle id`() {
+    val map = assignBundleEntryIds(listOf("pkg.Foo_A B", "pkg.Foo_A B"))
+    assertThat(map).hasSize(1)
+    assertThat(map.getValue("pkg.Foo_A B")).isEqualTo("pkg.Foo_A_B")
+  }
 }


### PR DESCRIPTION
## Summary

A `@Preview(name = "Image Widget Squircle")` produces a preview `id` that carries spaces. The renderer already collapses those for its on-disk file stems (`[^A-Za-z0-9._-]` → `_`, e.g. `…_Image_Widget_Squircle_PARAM_0.png`), but `BundlePreviewTask` copied the raw `id` **verbatim** into every bundle entry name and into both bundled manifests — so the portable bundle alone shipped file names a shell or URL has to quote:

```
ir/…ImageWidgetSquirclePreview_Image Widget Squircle.rc
previews/…ImageWidgetSquirclePreview_Image Widget Squircle.png
```

This sanitizes at the **bundle boundary** so the self-contained artifact is space-free and internally consistent.

## What changed

- Added `sanitizeBundleEntryId` (top-level `internal`, unit-testable) applying the renderer's own `[^A-Za-z0-9._-]` → `_` per-character mapping. Dots and dashes are preserved (never need quoting; keeps dot-vs-underscore-distinct ids distinct).
- Applied it in `BundlePreviewTask.pack()` to everything that lands **inside** the bundle:
  - zip entry names — `previews/<id>.png`, `ir/<id>.{rc,tilelayout,tileresources}`, `previews/<id>.{overrides,remotecompose,catalog}.json`
  - `bundle.json` — `previewIds`, `coverPreviewId`, `BundleIr.previewId` + `path`
  - the bundled `previews.json` — each `PreviewInfo.id`
- Left **raw** ids where they must stay raw: on-disk render/sidecar resolution (already keyed off render stems / `renderOutput`) and data-extension report scoping (the report JSON is keyed by the un-sanitised id the renderer wrote). Live serve-from-project is untouched.

Because writer and readers now agree on the same sanitized string, readers that reconstruct `previews/<id>.png` from `previewIds`, and `BundleLoader`'s `intermediateRepresentations.previewId` ↔ `previews.json` id correlation, keep resolving.

## Test plan

- New `SanitizeBundleEntryIdTest` — spaces → `_`, dots/dashes preserved, every shell/URL-awkward char replaced, idempotent on clean ids.
- Existing `PreviewBundleFormatTest`, `ResolveIrSidecarTest`, and full `:gradle-plugin:test` + `ktfmtCheck` green.
- End-to-end: rebuilt `:samples:wear-widget:composePreviewBundle` and confirmed every `previews/` + `ir/` entry, plus `bundle.json`'s `previewIds`/`coverPreviewId`/`ir[].path` and `previews.json`'s ids, are now space-free and mutually consistent:

```
ir/….ImageWidgetSquirclePreview_Image_Widget_Squircle.rc
previews/….ImageWidgetSquirclePreview_Image_Widget_Squircle.png
```

Note: existing published `design-artifacts/*` delivery branches will pick up the space-free ids the next time they're regenerated from `main`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ew6bJN6X8Z2u8dAhsCWYkm)_