### PR TITLE
fix(rc-player): parse the accessibility-semantics op (250) instead of truncating

### DIFF
--- a/cli/src/main/resources/rc-player/bundle.js
+++ b/cli/src/main/resources/rc-player/bundle.js
@@ -14954,6 +14954,48 @@ var RC = (() => {
   _Custom.OP_CODE = 93;
   var Custom = _Custom;
 
+  // src/core/operations/semantics/CoreSemantics.ts
+  var _CoreSemantics = class _CoreSemantics extends Operation {
+    constructor(mContentDescriptionId, mRole, mTextId, mStateDescriptionId, mMode, mEnabled, mClickable) {
+      super();
+      this.mContentDescriptionId = mContentDescriptionId;
+      this.mRole = mRole;
+      this.mTextId = mTextId;
+      this.mStateDescriptionId = mStateDescriptionId;
+      this.mMode = mMode;
+      this.mEnabled = mEnabled;
+      this.mClickable = mClickable;
+    }
+    write(_buffer) {
+    }
+    // Accessibility metadata has no visual effect, so applying it paints nothing.
+    apply(_context) {
+    }
+    deepToString(indent) {
+      return `${indent}CoreSemantics(contentDescription=${this.mContentDescriptionId}, role=${this.mRole}, text=${this.mTextId}, stateDescription=${this.mStateDescriptionId}, mode=${this.mMode}, enabled=${this.mEnabled}, clickable=${this.mClickable})`;
+    }
+    static read(buffer, operations) {
+      const contentDescriptionId = buffer.declareId();
+      const role = buffer.readByte();
+      const textId = buffer.declareId();
+      const stateDescriptionId = buffer.declareId();
+      const mode = buffer.readByte();
+      const enabled = buffer.readBoolean();
+      const clickable = buffer.readBoolean();
+      operations.push(new _CoreSemantics(
+        contentDescriptionId,
+        role,
+        textId,
+        stateDescriptionId,
+        mode,
+        enabled,
+        clickable
+      ));
+    }
+  };
+  _CoreSemantics.OP_CODE = 250;
+  var CoreSemantics = _CoreSemantics;
+
   // src/core/Operations.ts
   var _Operations = class _Operations {
     static init() {
@@ -15107,6 +15149,7 @@ var RC = (() => {
       m.set(PatternArgument.OP_CODE, PatternArgument.read);
       m.set(PatternDefine.OP_CODE, PatternDefine.read);
       m.set(Custom.OP_CODE, Custom.read);
+      m.set(CoreSemantics.OP_CODE, CoreSemantics.read);
     }
     static getOperations() {
       _Operations.init();

--- a/third_party/remote-compose-player/PROVENANCE.md
+++ b/third_party/remote-compose-player/PROVENANCE.md
@@ -18,10 +18,23 @@ without a server-side Robolectric daemon.
 
 ## Local modifications
 
-None — vendored verbatim from the upstream path above (`src/`, `package.json`,
+Vendored from the upstream path above (`src/`, `package.json`,
 `package-lock.json`, `tsconfig.json`, `README.md`, `BUILDING.md`). Upstream's own
 `packaging/`, `vscode-extension/`, and standalone-site tooling are intentionally
 not vendored; only the library source needed to build the browser bundle.
+
+Local deltas over that snapshot (each also filed upstream):
+
+- **`CoreSemantics` (opcode 250 / `ACCESSIBILITY_SEMANTICS`).** Added
+  `src/core/operations/semantics/CoreSemantics.ts` and registered it in
+  `src/core/Operations.ts`. Before this, an `AccessibilityModifier` op in the
+  stream hit the unknown-opcode path in `RemoteComposeBuffer.inflateFromBuffer`,
+  which logs `Unknown operation opcode: 250, skipping rest of buffer` and
+  abandons the rest of the document — so any component carrying accessibility
+  semantics (every Material3 catalog preview) lost all operations after it. The
+  op is accessibility metadata with no visual instructions, so the reader just
+  consumes its wire payload (matching `CoreSemantics.read` in remote-core) and
+  paints nothing, letting the rest of the document parse.
 
 ## Building the browser bundle
 

--- a/third_party/remote-compose-player/src/core/Operations.ts
+++ b/third_party/remote-compose-player/src/core/Operations.ts
@@ -115,6 +115,7 @@ import {
     PatternArgument, PatternDefine
 } from './operations/loom/PatternOperations';
 import { Custom } from './operations/layout/managers/Custom';
+import { CoreSemantics } from './operations/semantics/CoreSemantics';
 
 export class Operations {
     private static readonly sMap = new Map<number, CompanionOperationFn>();
@@ -314,6 +315,9 @@ export class Operations {
 
         // Custom layout component (parse-only)
         m.set(Custom.OP_CODE, Custom.read);
+
+        // Accessibility semantics (parse-only — no visual effect)
+        m.set(CoreSemantics.OP_CODE, CoreSemantics.read);
     }
 
     static getOperations(): Map<number, CompanionOperationFn> {

--- a/third_party/remote-compose-player/src/core/operations/semantics/CoreSemantics.ts
+++ b/third_party/remote-compose-player/src/core/operations/semantics/CoreSemantics.ts
@@ -1,0 +1,63 @@
+// CoreSemantics: accessibility semantics operation (opcode 250).
+//
+// Mirrors androidx.compose.remote.core.semantics.CoreSemantics — an
+// `AccessibilityModifier` that annotates the preceding component with
+// accessibility metadata (content description, role, state description,
+// text, enabled/clickable flags). It carries no visual instructions, so
+// the player only needs to consume its wire payload so the rest of the
+// document keeps parsing; painting is a no-op.
+//
+// Wire layout (after the opcode byte), matching CoreSemantics.read /
+// CoreSemantics.apply in remote-core:
+//   contentDescriptionId : declareId (int32)
+//   role                 : byte
+//   textId               : declareId (int32)
+//   stateDescriptionId   : declareId (int32)
+//   mode                 : byte
+//   enabled              : boolean
+//   clickable            : boolean
+
+import { Operation } from '../../Operation';
+import type { WireBuffer } from '../../WireBuffer';
+import type { RemoteContext } from '../../RemoteContext';
+
+export class CoreSemantics extends Operation {
+    static readonly OP_CODE = 250;
+
+    constructor(
+        public readonly mContentDescriptionId: number,
+        public readonly mRole: number,
+        public readonly mTextId: number,
+        public readonly mStateDescriptionId: number,
+        public readonly mMode: number,
+        public readonly mEnabled: boolean,
+        public readonly mClickable: boolean,
+    ) {
+        super();
+    }
+
+    write(_buffer: WireBuffer): void { /* stub — player never re-serializes */ }
+
+    // Accessibility metadata has no visual effect, so applying it paints nothing.
+    apply(_context: RemoteContext): void { /* no-op */ }
+
+    deepToString(indent: string): string {
+        return `${indent}CoreSemantics(contentDescription=${this.mContentDescriptionId}, ` +
+            `role=${this.mRole}, text=${this.mTextId}, ` +
+            `stateDescription=${this.mStateDescriptionId}, mode=${this.mMode}, ` +
+            `enabled=${this.mEnabled}, clickable=${this.mClickable})`;
+    }
+
+    static read(buffer: WireBuffer, operations: Operation[]): void {
+        const contentDescriptionId = buffer.declareId();
+        const role = buffer.readByte();
+        const textId = buffer.declareId();
+        const stateDescriptionId = buffer.declareId();
+        const mode = buffer.readByte();
+        const enabled = buffer.readBoolean();
+        const clickable = buffer.readBoolean();
+        operations.push(new CoreSemantics(
+            contentDescriptionId, role, textId, stateDescriptionId, mode, enabled, clickable,
+        ));
+    }
+}


### PR DESCRIPTION
## Summary

The vendored TypeScript Remote Compose player had no reader for **opcode 250** (`ACCESSIBILITY_SEMANTICS` — androidx `CoreSemantics`). When the player hit it, `RemoteComposeBuffer.inflateFromBuffer` fell through to the unknown-opcode path:

```
Unknown operation opcode: 250, skipping rest of buffer
```

…and **abandoned the rest of the document**. Every Material3 catalog preview carries an accessibility modifier, so the player silently dropped every operation after the first semantics op.

This adds `CoreSemantics` (opcode 250), mirroring `CoreSemantics.read` in `remote-core`: it consumes the wire payload and paints nothing (accessibility metadata has no visual instructions), so the document parses to completion.

## What changed

- **New** `third_party/remote-compose-player/src/core/operations/semantics/CoreSemantics.ts` — reads the exact 16-byte payload the encoder writes (verified against `CoreSemantics.apply`/`read` in `androidx.compose.remote:remote-core:1.0.0-alpha14`):

  | field | wire | bytes |
  |---|---|---|
  | contentDescriptionId | `declareId` (int32) | 4 |
  | role | `readByte` | 1 |
  | textId | `declareId` (int32) | 4 |
  | stateDescriptionId | `declareId` (int32) | 4 |
  | mode | `readByte` | 1 |
  | enabled | `readBoolean` | 1 |
  | clickable | `readBoolean` | 1 |

  `apply()` is a no-op; the op lands in the layout component's content ops and is ignored at paint time (it matches no modifier `instanceof` branch and its no-op `apply` is safe).
- Registered it in `src/core/Operations.ts`.
- Regenerated the committed CLI resource bundle `cli/src/main/resources/rc-player/bundle.js` from source (per its README's `esbuild --external:canvas` command), so `compose-preview serve` and the deployed preview host pick up the reader.
- Recorded the delta in `PROVENANCE.md` (was "vendored verbatim").

## Evidence — a `remote-m3` catalog doc now parses to completion

Decoding `ir/…FilledRemoteButton.rc` with the player's own `rc2json`:

- **Before:** console logs `Unknown operation opcode: 250, skipping rest of buffer`; parsing stops at the first semantics op — the canvas is fully transparent (0 painted pixels).
- **After:** no warning; the full tree inflates — `HEADER, LAYOUT_ROOT → LAYOUT_BOX/LAYOUT_ROW, MODIFIER_*, DATA_TEXT×3, CANVAS_OPERATIONS, DRAW_PATH, _CoreSemantics×2, …` — and a `RootLayoutComponent` (525×525) is built and laid out.

## Not visual yet (separate follow-up)

This is a **parser-correctness** fix, so there is no pixel delta to embed for the Material3 previews: their draw commands flow through `CanvasOperationsOp` (`CANVAS_OPERATIONS`), which the vendored player still registers as a **parse-only stub**, so the button/card body paints nothing even now that the document parses fully. Implementing `CanvasOperationsOp` (replaying its nested draw list) is the next step to get these previews rendering client-side — tracked as a follow-up. The canvas-draw previews (progress/shader/text stickers) already render; this fix stops their trailing draws from being truncated when a semantics op precedes them.

## Upstream

The player is vendored from `camaelon/remotecompose-experiments@d8b07da` (`players/typescript/`). The same fix is filed upstream.

## Test plan

- `tsc` on the new file is clean (the pre-existing `ColorAttribute`/`BoxLayout` `--noEmit` errors are unrelated and predate this change; the bundle is built with esbuild).
- Rebuilt the IIFE bundle; confirmed `CoreSemantics` is present in the committed resource.
- Headless render of all 19 `remote-m3` `ir/*.rc` docs via the rebuilt player in Chromium: no `opcode 250` warnings; documents parse fully.

---
_Generated by [Claude Code](https://claude.ai/code/session_011K7sgCfdsbhN7fwMb3WhSS)_