### PR TITLE
fix(gradle-plugin): resolve the render classpath as one graph, not four

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewClasspath.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewClasspath.kt
@@ -4,6 +4,8 @@ import java.io.File
 import java.util.zip.ZipFile
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier
+import org.gradle.api.artifacts.component.ProjectComponentIdentifier
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.file.Directory
 import org.gradle.api.file.FileCollection
@@ -25,14 +27,19 @@ import org.gradle.api.provider.Provider
  * Ordering invariants (load-bearing — see callers' comments and `AndroidPreviewSupport.kt`):
  * - Robolectric properties dir BEFORE consumer test resources, so the renderer's
  *   `robolectric.properties` wins classloader lookup.
- * - Renderer artifacts BEFORE consumer test runtime, so the renderer's pinned kotlinx-serialization
- *   / Roborazzi versions win on classload conflicts.
+ * - Renderer artifacts BEFORE the consumer's remaining test entries, so the renderer's pinned
+ *   kotlinx-serialization / Roborazzi versions win on classload conflicts.
  * - SDK boot classpath LAST in the outer FileCollection, since it's only there to satisfy JUnit's
  *   introspection of the test class signatures (the sandbox supplies its own `android-all`
  *   framework jars).
  *
- * Behaviour must match the inline construction byte-for-byte; this file is a refactor with no
- * semantic change.
+ * Single-resolution invariant: every *module* artifact on the render classpath comes from
+ * `rendererConfig`, which `extendsFrom(testConfig)` and therefore resolves the renderer's and the
+ * consumer's test dependencies as ONE graph with one version per module. The consumer's
+ * separately-resolved graph is no longer concatenated on top — see [buildAgpClasspathExtras] and
+ * [RenderClasspathDuplicates] for what went wrong when it was. Ordering only decides class-lookup
+ * winners when duplicates exist, so keeping the classpath duplicate-free is what makes the ordering
+ * rules above a safety net rather than the primary mechanism.
  */
 internal object AndroidPreviewClasspath {
 
@@ -58,6 +65,7 @@ internal object AndroidPreviewClasspath {
     screenshotTestRuntimeConfig: Configuration?,
     unitTestConfigDir: Provider<Directory>,
     robolectricPropertiesDir: Provider<Directory>,
+    legacyClasspathUnion: Boolean = false,
   ): FileCollection =
     project.files().apply {
       // Robolectric properties dir BEFORE consumer test resources so our
@@ -67,8 +75,39 @@ internal object AndroidPreviewClasspath {
       // for this renderer's test class.
       from(robolectricPropertiesDir)
       from(rendererConfig.incoming.artifactView { attributes.attribute(artifactType, "jar") }.files)
+      // `android-classes` alongside `jar` so AAR-packaged modules (sibling project deps published
+      // as AARs, AndroidX libraries) contribute their `classes.jar`. Previously this view was
+      // taken from `testConfig` instead; sourcing it from `rendererConfig` keeps every module
+      // artifact coming from ONE resolution — see the block below.
+      from(
+        rendererConfig.incoming
+          .artifactView { attributes.attribute(artifactType, "android-classes") }
+          .files
+      )
       from(rendererClassDirs)
-      if (testConfig != null) {
+      // `rendererConfig` already `extendsFrom(testConfig)` (see AndroidPreviewSupport), so it
+      // resolves the renderer's dependencies and the consumer's test-runtime dependencies in ONE
+      // graph — Gradle picks a single coherent version per module. Re-adding `testConfig`'s own
+      // artifact view on top of that undoes exactly what `extendsFrom` bought: the second view is
+      // a SEPARATE resolution, so any module the combined graph upgraded lands here twice, at two
+      // versions, in front of one classloader.
+      //
+      // Measured on homeassistant-remotecompose (plugin 0.17.16, AGP 9.3): every module in the
+      // unit-test graph is also in the renderer graph — the re-add contributed zero unique modules
+      // and nine duplicated ones (androidx.test:core 1.5.0+1.6.1, monitor 1.6.1+1.8.0, espresso,
+      // asm 9.7.1+9.10.1, commons-logging, okhttp …). Also `org.bouncycastle:bcprov-jdk18on` at
+      // 1.85 (Robolectric, via renderer-android) and 1.84 (the consumer's own mockserver test
+      // dep), whose mixed asn1/provider classes threw `NoSuchFieldError` out of
+      // `compositekem.KeyFactorySpi.<clinit>` and failed every a11y preview —
+      // homeassistant-remotecompose#495, worked around downstream with a version force.
+      //
+      // Non-module entries that live ONLY on AGP's test classpath (the unit-test merged `R.jar`,
+      // generated dirs) are preserved — they're appended separately via
+      // [buildAgpClasspathExtras], which subtracts just the module artifacts.
+      //
+      // `-PcomposePreview.legacyClasspathUnion=true` restores the old concatenation for a
+      // consumer who turns out to depend on a testConfig-only artifact we haven't anticipated.
+      if (testConfig != null && legacyClasspathUnion) {
         from(testConfig.incoming.artifactView { attributes.attribute(artifactType, "jar") }.files)
         from(
           testConfig.incoming
@@ -78,17 +117,21 @@ internal object AndroidPreviewClasspath {
       }
       // screenshotTest source set has its own runtime config — any
       // `screenshotTestImplementation(...)` dep the consumer declared is
-      // only visible here, not via `testConfig`. Include it so previews
-      // under `src/screenshotTest/` can reference those classes at
-      // render time. No-op when the screenshot plugin isn't applied.
-      screenshotTestRuntimeConfig?.let { stConfig ->
-        from(stConfig.incoming.artifactView { attributes.attribute(artifactType, "jar") }.files)
-        from(
-          stConfig.incoming
-            .artifactView { attributes.attribute(artifactType, "android-classes") }
-            .files
-        )
-      }
+      // only visible here, not via `testConfig`. `rendererConfig` now
+      // `extendsFrom`s it (see AndroidPreviewSupport), so those deps are already
+      // in the single graph above at coherent versions; re-adding this
+      // separately-resolved view is the legacy concatenation behaviour.
+      // No-op when the screenshot plugin isn't applied.
+      screenshotTestRuntimeConfig
+        ?.takeIf { legacyClasspathUnion }
+        ?.let { stConfig ->
+          from(stConfig.incoming.artifactView { attributes.attribute(artifactType, "jar") }.files)
+          from(
+            stConfig.incoming
+              .artifactView { attributes.attribute(artifactType, "android-classes") }
+              .files
+          )
+        }
       from(sourceClassDirs)
       from(unitTestConfigDir)
       // SDK stub android.jar on the OUTER classpath so JUnit can introspect
@@ -112,6 +155,96 @@ internal object AndroidPreviewClasspath {
       from(project.files(bootClasspath))
       from(project.files(bootClasspathFallback))
     }
+
+  /**
+   * AGP's `test<Variant>UnitTest` classpath with the module artifacts removed — i.e. only the
+   * entries that exist *nowhere else*, which is the reason that classpath is appended at all.
+   *
+   * The render tasks append `agpTestTask.classpath` to pick up files AGP contributes outside the
+   * resolved artifact views: chiefly the unit-test merged `R.jar` (added to
+   * `<variant>UnitTestRuntimeClasspath` as a raw file dep with no `artifactType` attribute, so the
+   * attribute-filtered `artifactView` in [buildTestClasspath] drops it — issue #136), plus
+   * generated class dirs. Those must stay.
+   *
+   * What must NOT stay is the rest of it: AGP's classpath also carries every module artifact from
+   * the consumer's unit-test graph, resolved independently of the renderer graph. Appending those
+   * puts a second, older copy of any module the renderer graph upgraded in front of the same
+   * classloader — the duplicate-jar failure mode described on [RenderClasspathDuplicates].
+   *
+   * Subtraction is by *file identity* against `testConfig`'s own artifact views, which is exactly
+   * right for this: when the two graphs disagree on a version they resolve to different files, so
+   * the consumer-graph copy is the one that gets dropped and the renderer-graph copy survives.
+   * `FileCollection.minus` keeps the whole thing lazy and configuration-cache friendly.
+   *
+   * Returns [agpTestClasspath] untouched when there's no `testConfig` to subtract (nothing was
+   * double-added in the first place) or when `legacyClasspathUnion` restores the old behaviour.
+   */
+  fun buildAgpClasspathExtras(
+    project: Project,
+    agpTestClasspath: FileCollection,
+    testConfig: Configuration?,
+    legacyClasspathUnion: Boolean = false,
+  ): FileCollection {
+    if (testConfig == null || legacyClasspathUnion) return agpTestClasspath
+    val moduleArtifacts =
+      project.files(
+        testConfig.incoming.artifactView { attributes.attribute(artifactType, "jar") }.files,
+        testConfig.incoming
+          .artifactView { attributes.attribute(artifactType, "android-classes") }
+          .files,
+      )
+    return agpTestClasspath.minus(moduleArtifacts)
+  }
+
+  /**
+   * Maps every resolved artifact file on the render classpath to the exact `group:name:version`
+   * Gradle picked for it, so [RenderClasspathDuplicates] can compare modules by identity instead of
+   * guessing from filenames.
+   *
+   * Built from the same two artifact views the classpath itself uses (`jar` and `android-classes`)
+   * across [configurations] — the *default* view would return `.aar` files that never appear on the
+   * classpath, so the map would match nothing. Pass every configuration that can contribute module
+   * artifacts (renderer or daemon, plus screenshotTest and — in legacy-union mode — testConfig);
+   * overlapping entries agree by construction, since the key is the file path.
+   *
+   * Project artifacts are keyed `project:<path>` with an empty version, so a project's own jar
+   * forms a single-version bucket rather than being mistaken for a module.
+   *
+   * Returns a `Provider` so nothing resolves at configuration time: task actions call `get()`, and
+   * the configuration cache serialises the provider rather than the live `Configuration`.
+   */
+  fun buildArtifactCoordinates(
+    project: Project,
+    configurations: List<Configuration>,
+  ): Provider<Map<String, String>> {
+    val views = configurations.flatMap { configuration ->
+      listOf("jar", "android-classes").map { type ->
+        configuration.incoming
+          .artifactView {
+            attributes.attribute(artifactType, type)
+            // A view that can't resolve some artifact must not sink the whole render — this is
+            // diagnostic input, so degrade to a smaller map instead of failing the task.
+            isLenient = true
+          }
+          .artifacts
+          .resolvedArtifacts
+          .map { artifacts ->
+            artifacts.associate { artifact ->
+              val id = artifact.id.componentIdentifier
+              val coordinate =
+                when (id) {
+                  is ModuleComponentIdentifier -> "${id.group}:${id.module}:${id.version}"
+                  is ProjectComponentIdentifier -> "project:${id.projectPath}:"
+                  else -> "${id.displayName}:"
+                }
+              artifact.file.absolutePath to coordinate
+            }
+          }
+      }
+    }
+    if (views.isEmpty()) return project.provider { emptyMap() }
+    return views.reduce { acc, next -> acc.zip(next) { a, b -> a + b } }
+  }
 
   /**
    * Lazy fallback for `android.jar`, used when AGP's `sdkComponents.bootClasspath` provider returns

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -2730,6 +2730,22 @@ internal object AndroidPreviewSupport {
           legacyClasspathUnion = legacyClasspathUnion,
         )
       )
+      // Same duplicate guard the render Test tasks run, applied to the classpath that goes into
+      // `daemon-launch.json`. This is the path that matters most: a11y renders and the VS Code
+      // extension drive the daemon, never the standalone Test task, so the motivating failure
+      // (homeassistant-remotecompose#495) happened HERE. Checking only the Test tasks would leave
+      // a duplicate surviving in the AGP extras — or introduced by a future daemon-only addition —
+      // invisible to both the warning and `composePreview.classpathDuplicates=fail`. Runs before
+      // the descriptor is written, so a `fail` build never emits a descriptor the daemon would
+      // then launch from.
+      doFirst {
+        RenderClasspathDuplicates.check(
+          this,
+          classpath.files,
+          classpathDuplicatesMode,
+          renderArtifactCoordinates.get(),
+        )
+      }
       // Static JVM open flags from the shared helper, plus the
       // daemon-specific heap ceiling. AGP test task's own jvmArgs are
       // intentionally NOT inherited here — they're test-runner specific

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -10,6 +10,7 @@ import ee.schimke.composeai.daemonlaunch.*
 import ee.schimke.composeai.discovery.*
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.attributes.AttributeContainer
 import org.gradle.api.provider.Property
@@ -182,6 +183,80 @@ internal object AndroidPreviewSupport {
         else -> return null
       }
     return name.removeSuffix(replacementSuffix) + "-android"
+  }
+
+  /**
+   * Applies the resolution rules every render-graph configuration needs, to [configuration].
+   *
+   * Shared between `composePreviewAndroidRenderer<Variant>` and
+   * `composePreviewAndroidDaemon<Variant>`. The daemon config `extendsFrom` the renderer config,
+   * but `extendsFrom` inherits *dependencies* only — `resolutionStrategy` is per-configuration — so
+   * without this helper the two graphs would silently drift apart and the render JVM and the daemon
+   * JVM would load different versions of the same module for the same previews.
+   *
+   * Rule 1 — KMP-Android sibling substitution. Force AndroidX / Compose Multiplatform KMP-published
+   * modules (`-desktop` / `-jvmstubs` siblings of the same coordinate) to their `-android` sibling.
+   * Kotlin's `org.jetbrains.kotlin.platform.type` attribute (`androidJvm` vs `jvm`) is the official
+   * disambiguator, but its compatibility/disambiguation rules are only registered when the Kotlin
+   * plugin is applied — consumers that build Kotlin via AGP alone (e.g. WearTilesKotlin: tile-only
+   * app, only `kotlin.compose` applied through `compose-compiler`, no `kotlin.android` anywhere)
+   * never pick `androidJvm` and Gradle then selects the desktop variant. The desktop
+   * `ViewModelProvider` is the KMP rewrite (only `<init>(ViewModelProviderImpl)` survives — the
+   * legacy `(ViewModelStoreOwner, Factory)` constructor is gone), while
+   * `lifecycle-viewmodel-savedstate-android:2.8.7`'s `getSavedStateHandlesVM` bytecode at line 107
+   * still calls that legacy constructor. Result: `NoSuchMethodError: 'void
+   * ViewModelProvider.<init>(ViewModelStoreOwner, ViewModelProvider$Factory)'` the first time
+   * `createAndroidComposeRule<ComponentActivity>()` launches the host activity, in the
+   * `ReportFragment` → `LifecycleRegistry` → `SavedStateHandleAttacher.onStateChanged` chain.
+   *
+   * Substitute by coordinate rather than attribute: setting `platform.type=androidJvm` on the
+   * config breaks resolution of pure-JVM artifacts like `kotlin-stdlib` (no `androidJvm` variant)
+   * because the compat rule isn't installed. Scoped to the render-graph configs only — consumer
+   * test runs are untouched. Re-using `requested.version` keeps it future-proof: whatever version
+   * Gradle picks for the `-desktop`/`-jvmstubs` sibling is what gets re-routed to `-android`, so
+   * the rule doesn't pin AndroidX to a stale floor. Scoped to `androidx.*` and
+   * `org.jetbrains.compose.*` because those KMP module families publish matching `-android`
+   * siblings; other JVM artifacts (kotlinx-coroutines, okio, kotlin-stdlib) are genuinely JVM-only
+   * at the published name and must not be rewritten.
+   *
+   * Rule 2 — Hamcrest. Espresso (transitively pulled by `androidx.compose.ui:ui-test-junit4`) was
+   * compiled against Hamcrest 1.3, whose `Matchers.java:33` invokes
+   * `org.hamcrest.core.AllOf.allOf(Matcher, Matcher)` — an explicit 2-arg overload that 2.x removed
+   * in favour of varargs. When a consumer adds `org.hamcrest:hamcrest:2.x` (e.g. via
+   * `junit-jupiter:5.x`), the merged 2.x jar coexists with the legacy split `hamcrest-core` /
+   * `hamcrest-library` 1.3 jars — different module coordinates, so Gradle's conflict resolution
+   * doesn't dedup them. Whichever class wins for `AllOf` vs `Matchers` is classpath-order
+   * dependent; in the failing case `Matchers` comes from 1.3 and calls into 2.x's `AllOf` —
+   * `NoSuchMethodError` at `Espresso.<clinit>`, triggered the first time `runUntilIdle` walks
+   * through `EspressoLink`. Substituting the merged artifact back to `hamcrest-core:1.3` on the
+   * render graph settles it. Note this is a *split-family* conflict, the same shape as
+   * `org.bouncycastle:bcprov`/`bcutil`/`bcpkix` — Gradle can only align coordinates it knows are
+   * the same module, so families published under several names need an explicit rule.
+   */
+  internal fun applyRenderGraphResolutionRules(configuration: Configuration) {
+    configuration.resolutionStrategy.eachDependency {
+      val req = requested
+      val targetName = kmpAndroidSiblingName(req.group, req.name)
+      if (targetName != null) {
+        useTarget(mapOf("group" to req.group, "name" to targetName, "version" to req.version))
+        because(
+          "Gradle resolved a desktop/JVM-stub KMP sibling on a config without the " +
+            "Kotlin-plugin platform-type compat rule. Force the Android sibling so the " +
+            "renderer's bytecode links against the AGP-flavoured class shapes (e.g. the " +
+            "legacy `ViewModelProvider(ViewModelStoreOwner, Factory)` constructor that " +
+            "lifecycle-viewmodel-savedstate-android still calls but the desktop variant " +
+            "removed in the KMP rewrite)."
+        )
+      }
+    }
+    configuration.resolutionStrategy.eachDependency {
+      if (requested.group == "org.hamcrest" && requested.name == "hamcrest") {
+        useTarget("org.hamcrest:hamcrest-core:1.3")
+        because(
+          "Espresso bytecode needs Hamcrest 1.3's AllOf.allOf(Matcher,Matcher); 2.x removed it"
+        )
+      }
+    }
   }
 
   /**
@@ -1339,84 +1414,21 @@ internal object AndroidPreviewSupport {
           copyAttributes(attributes, testConfig.attributes)
           extendsFrom(testConfig)
         }
-        // Force AndroidX / Compose Multiplatform KMP-published modules
-        // (`-android` / `-desktop` / `-jvmstubs` siblings of the same
-        // coordinate) to their Android sibling on the
-        // renderer test JVM. Kotlin's `org.jetbrains.kotlin.platform.type`
-        // attribute (`androidJvm` vs `jvm`) is the official disambiguator,
-        // but its compatibility/disambiguation rules are only registered when
-        // the Kotlin plugin is applied — consumers that build Kotlin via AGP
-        // alone (e.g. WearTilesKotlin: tile-only app, only `kotlin.compose`
-        // applied through `compose-compiler`, no `kotlin.android` anywhere)
-        // never pick `androidJvm` and Gradle then selects the desktop variant.
-        // The desktop `ViewModelProvider` is the KMP rewrite (only
-        // `<init>(ViewModelProviderImpl)` survives — the legacy
-        // `(ViewModelStoreOwner, Factory)` constructor is gone), while
-        // `lifecycle-viewmodel-savedstate-android:2.8.7`'s
-        // `getSavedStateHandlesVM` bytecode at line 107 still calls that
-        // legacy constructor. Result: `NoSuchMethodError: 'void
-        // ViewModelProvider.<init>(ViewModelStoreOwner, ViewModelProvider$Factory)'`
-        // the first time `createAndroidComposeRule<ComponentActivity>()`
-        // launches the host activity, in the
-        // `ReportFragment` → `LifecycleRegistry` →
-        // `SavedStateHandleAttacher.onStateChanged` chain.
-        //
-        // Substitute by coordinate rather than attribute: setting
-        // `platform.type=androidJvm` on the config breaks resolution of
-        // pure-jvm artifacts like `kotlin-stdlib` (no `androidJvm` variant)
-        // because the compat rule isn't installed. Substitution is scoped to
-        // the rendererConfig only — consumer test runs are untouched. Re-using
-        // `requested.version` keeps us future-proof: any version Gradle picks
-        // for the `-desktop`/`-jvmstubs` sibling is what we re-route to the
-        // `-android` sibling, so this rule doesn't pin AndroidX to a stale
-        // floor.
-        //
-        // Scoped to `androidx.*` and `org.jetbrains.compose.*` because those
-        // KMP module families publish matching `-android` siblings for their
-        // `-desktop` / `-jvmstubs` artifacts. Other JVM artifacts
-        // (kotlinx-coroutines, okio, kotlin-stdlib) are genuinely JVM-only at
-        // the published name and must not be rewritten.
-        resolutionStrategy.eachDependency {
-          val req = requested
-          val targetName = kmpAndroidSiblingName(req.group, req.name)
-          if (targetName != null) {
-            useTarget(mapOf("group" to req.group, "name" to targetName, "version" to req.version))
-            because(
-              "Gradle resolved a desktop/JVM-stub KMP sibling on a config without the " +
-                "Kotlin-plugin platform-type compat rule. Force the Android sibling so the " +
-                "renderer's bytecode links against the AGP-flavoured class shapes (e.g. the " +
-                "legacy `ViewModelProvider(ViewModelStoreOwner, Factory)` constructor that " +
-                "lifecycle-viewmodel-savedstate-android still calls but the desktop variant " +
-                "removed in the KMP rewrite)."
-            )
-          }
-        }
-        // Espresso (transitively pulled by `androidx.compose.ui:ui-test-junit4`) was
-        // compiled against Hamcrest 1.3, whose `Matchers.java:33` invokes
-        // `org.hamcrest.core.AllOf.allOf(Matcher, Matcher)` — an explicit 2-arg
-        // overload that 2.x removed in favour of varargs. When a consumer adds
-        // `org.hamcrest:hamcrest:2.x` (e.g. via `junit-jupiter:5.x`), the merged
-        // 2.x jar coexists with the legacy split `hamcrest-core` / `hamcrest-library`
-        // 1.3 jars (different module coordinates → no Gradle dedup). Whichever
-        // class wins for `AllOf` vs `Matchers` is classpath-order-dependent; in
-        // the failing case `Matchers` comes from 1.3 and calls into 2.x's
-        // `AllOf` — `NoSuchMethodError` at `Espresso.<clinit>` triggered the
-        // first time `runUntilIdle` walks through `EspressoLink`.
-        //
-        // Substituting the merged artifact back to `hamcrest-core:1.3` on
-        // *this* configuration is enough: `resolvedClasspath` puts rendererConfig's
-        // files ahead of the AGP test classpath in the composePreviewRender JVM
-        // classpath (see comment above `resolvedClasspath` below), so Hamcrest
-        // 1.3 wins class lookup even if the consumer's `${variant}UnitTestRuntimeClasspath`
-        // still resolves 2.x for their own tests.
-        resolutionStrategy.eachDependency {
-          if (requested.group == "org.hamcrest" && requested.name == "hamcrest") {
-            useTarget("org.hamcrest:hamcrest-core:1.3")
-            because(
-              "Espresso bytecode needs Hamcrest 1.3's AllOf.allOf(Matcher,Matcher); 2.x removed it"
-            )
-          }
-        }
+        // …and the screenshotTest source set's runtime classpath, when Google's screenshot plugin
+        // is applied. `screenshotTestImplementation(...)` deps are invisible to `testConfig`, so
+        // previews under `src/screenshotTest/` need them — but resolving that configuration
+        // separately and concatenating it is the same mistake as the unit-test graph: a module it
+        // upgrades lands next to the renderer graph's copy at a different version. Folding it in
+        // here keeps one graph. `extendsFrom` only contributes dependencies; they resolve under
+        // THIS configuration's (unit-test-flavoured) attributes, which is what the render JVM
+        // wants.
+        screenshotTestRuntimeConfig?.let { extendsFrom(it) }
+        // The KMP-Android sibling substitution and the Hamcrest rule — see
+        // [applyRenderGraphResolutionRules] for why each exists and what breaks without it. They
+        // live in a shared helper because `composePreviewAndroidDaemon$capVariant` extends this
+        // configuration and needs the identical graph: `extendsFrom` inherits dependencies but
+        // NOT `resolutionStrategy`, so the rules have to be applied to each config by hand.
+        applyRenderGraphResolutionRules(this)
       }
 
     if (useLocalRenderer) {
@@ -1512,8 +1524,21 @@ internal object AndroidPreviewSupport {
         isCanBeConsumed = false
         if (testConfig != null) {
           copyAttributes(attributes, testConfig.attributes)
-          extendsFrom(testConfig)
         }
+        // `extendsFrom(rendererConfig)` (which itself extends `testConfig`) makes this a strict
+        // superset of the render graph *by construction*, resolved in ONE pass. The daemon JVM
+        // classpath used to be `daemonRendererConfig ++ rendererConfig ++ testConfig ++ AGP's
+        // test classpath` — four independent resolutions concatenated, so a module any one of
+        // them upgraded appeared several times at several versions. That's why the BouncyCastle
+        // failure (homeassistant-remotecompose#495) hit a11y previews specifically: a11y renders
+        // run through the daemon, which stacked the most graphs.
+        extendsFrom(rendererConfig)
+        // `extendsFrom` inherits DEPENDENCIES, not `resolutionStrategy` — so the KMP-Android
+        // sibling substitution and the Hamcrest rule have to be applied here as well, or the
+        // daemon resolves `-desktop` KMP siblings and Hamcrest 2.x while the render task resolves
+        // the Android siblings and 1.3. Two JVMs rendering the same previews off different graphs
+        // is precisely the divergence this change exists to remove.
+        applyRenderGraphResolutionRules(this)
       }
 
     val daemonRendererProjectDir = project.rootDir.resolve("daemon/android")
@@ -1673,6 +1698,42 @@ internal object AndroidPreviewSupport {
     // (they need `findByName("test${capVariant}UnitTest")` which only resolves
     // late).
     val bootClasspathFallback = AndroidPreviewClasspath.buildBootClasspathFallback(project)
+    // Escape hatch back to the pre-#2731 behaviour, where the consumer's separately-resolved
+    // unit-test graph was concatenated on top of the renderer graph. That concatenation is what
+    // put two versions of one module in front of the render classloader (see
+    // [RenderClasspathDuplicates]); the flag exists only so a consumer who turns out to depend on
+    // a testConfig-only artifact has a one-line unblock while we fix the real gap.
+    val legacyClasspathUnion =
+      project.providers.gradleProperty("composePreview.legacyClasspathUnion").orNull == "true"
+    // warn (default) | fail | off — see [RenderClasspathDuplicates]. Read once at configuration
+    // time so the render task's doFirst closure captures a plain String (configuration-cache safe;
+    // the task action must never touch `project.*`).
+    val classpathDuplicatesMode =
+      project.providers
+        .gradleProperty("composePreview.classpathDuplicates")
+        .orNull
+        ?.lowercase()
+        ?.takeIf {
+          it in
+            setOf(
+              RenderClasspathDuplicates.MODE_WARN,
+              RenderClasspathDuplicates.MODE_FAIL,
+              RenderClasspathDuplicates.MODE_OFF,
+            )
+        } ?: RenderClasspathDuplicates.MODE_WARN
+    // Exact file → `group:name:version` map for the duplicate guard, covering every configuration
+    // that can put a module artifact on a render classpath. Lazy: nothing resolves here.
+    val renderArtifactCoordinates =
+      AndroidPreviewClasspath.buildArtifactCoordinates(
+        project = project,
+        configurations =
+          listOfNotNull(
+            rendererConfig,
+            daemonRendererConfig,
+            testConfig,
+            screenshotTestRuntimeConfig,
+          ),
+      )
     val resolvedClasspath =
       AndroidPreviewClasspath.buildTestClasspath(
         project = project,
@@ -1685,6 +1746,7 @@ internal object AndroidPreviewSupport {
         screenshotTestRuntimeConfig = screenshotTestRuntimeConfig,
         unitTestConfigDir = unitTestConfigDir,
         robolectricPropertiesDir = generateRobolectricPropertiesTask.flatMap { it.outputDir },
+        legacyClasspathUnion = legacyClasspathUnion,
       )
 
     val manifestFile = previewOutputDir.map { it.file("previews.json").asFile.absolutePath }
@@ -1854,13 +1916,21 @@ internal object AndroidPreviewSupport {
         // which is added to `debugUnitTestRuntimeClasspath` as a raw file
         // dep without the `artifactType=jar` attribute, so our
         // attribute-filtered `artifactView` above silently drops it).
-        // Ordering is load-bearing — putting it last means our renderer's
-        // pinned versions still win classload lookups in the earlier
-        // classpath entries. No-op on applications, since
-        // `process${Cap}Resources` puts the merged R.jar on the main
-        // runtime classpath where our existing `artifactView` already
-        // picks it up. See issue #136.
-        val agpTestClasspath = agpTestTask?.classpath ?: project.files()
+        // No-op on applications, since `process${Cap}Resources` puts the
+        // merged R.jar on the main runtime classpath where our existing
+        // `artifactView` already picks it up. See issue #136.
+        //
+        // Only those AGP-only extras are taken: `buildAgpClasspathExtras` subtracts the module
+        // artifacts, which the renderer graph already supplies at coherent versions. Appending
+        // them raw is what produced two-versions-of-one-module classpaths (issue #2731 /
+        // homeassistant-remotecompose#495).
+        val agpTestClasspath =
+          AndroidPreviewClasspath.buildAgpClasspathExtras(
+            project = project,
+            agpTestClasspath = agpTestTask?.classpath ?: project.files(),
+            testConfig = testConfig,
+            legacyClasspathUnion = legacyClasspathUnion,
+          )
         classpath =
           if (compileShardsTask != null) {
             resolvedClasspath +
@@ -2003,7 +2073,17 @@ internal object AndroidPreviewSupport {
         // compileSdk / unresolved SDK location). doFirst runs in the Gradle
         // process at task-execution time, so `classpath.files` is fully
         // resolved by the time we inspect it.
-        doFirst { AndroidPreviewClasspath.validateApplicationOnClasspath(classpath.files) }
+        doFirst {
+          AndroidPreviewClasspath.validateApplicationOnClasspath(classpath.files)
+          // Backstop for the duplicate-jar failure mode (see [RenderClasspathDuplicates]).
+          // Warns by default; `-PcomposePreview.classpathDuplicates=fail` makes it an error.
+          RenderClasspathDuplicates.check(
+            this,
+            classpath.files,
+            classpathDuplicatesMode,
+            renderArtifactCoordinates.get(),
+          )
+        }
 
         dependsOn(discoverTask)
         dependsOn(generateRobolectricPropertiesTask)
@@ -2075,7 +2155,15 @@ internal object AndroidPreviewSupport {
         description = "Render Android XML resource previews via Robolectric"
         val agpTestTask = project.tasks.findByName("test${capVariant}UnitTest") as? Test
         testClassesDirs = rendererClassDirs + (agpTestTask?.testClassesDirs ?: project.files())
-        val agpTestClasspath = agpTestTask?.classpath ?: project.files()
+        // AGP-only extras (unit-test merged R.jar, generated dirs); the module artifacts come
+        // from the single renderer graph. Same rationale as composePreviewRender above.
+        val agpTestClasspath =
+          AndroidPreviewClasspath.buildAgpClasspathExtras(
+            project = project,
+            agpTestClasspath = agpTestTask?.classpath ?: project.files(),
+            testConfig = testConfig,
+            legacyClasspathUnion = legacyClasspathUnion,
+          )
         classpath =
           resolvedClasspath + (agpTestTask?.testClassesDirs ?: project.files()) + agpTestClasspath
         include("**/ResourcePreviewRenderTest.class")
@@ -2097,7 +2185,17 @@ internal object AndroidPreviewSupport {
         // Same #1243 guard as composePreviewRender above — the resource render task
         // boots Robolectric through the identical classpath and hits the same
         // `Config.<clinit>` -> `Application.class` resolution at runner init.
-        doFirst { AndroidPreviewClasspath.validateApplicationOnClasspath(classpath.files) }
+        doFirst {
+          AndroidPreviewClasspath.validateApplicationOnClasspath(classpath.files)
+          // Backstop for the duplicate-jar failure mode (see [RenderClasspathDuplicates]).
+          // Warns by default; `-PcomposePreview.classpathDuplicates=fail` makes it an error.
+          RenderClasspathDuplicates.check(
+            this,
+            classpath.files,
+            classpathDuplicatesMode,
+            renderArtifactCoordinates.get(),
+          )
+        }
 
         dependsOn("composePreviewDiscoverAndroidResources")
         dependsOn(generateRobolectricPropertiesTask)
@@ -2129,7 +2227,15 @@ internal object AndroidPreviewSupport {
         description = "Render XR subspace previews to scene.json via Robolectric"
         val agpTestTask = project.tasks.findByName("test${capVariant}UnitTest") as? Test
         testClassesDirs = xrRendererClassDirs + (agpTestTask?.testClassesDirs ?: project.files())
-        val agpTestClasspath = agpTestTask?.classpath ?: project.files()
+        // AGP-only extras (unit-test merged R.jar, generated dirs); the module artifacts come
+        // from the single renderer graph. Same rationale as composePreviewRender above.
+        val agpTestClasspath =
+          AndroidPreviewClasspath.buildAgpClasspathExtras(
+            project = project,
+            agpTestClasspath = agpTestTask?.classpath ?: project.files(),
+            testConfig = testConfig,
+            legacyClasspathUnion = legacyClasspathUnion,
+          )
         classpath =
           (resolvedClasspath +
               xrRendererClassDirs +
@@ -2180,7 +2286,17 @@ internal object AndroidPreviewSupport {
 
         // Same #1243 guard as composePreviewRender — boots Robolectric through the same classpath
         // and hits the same `Config.<clinit>` -> `Application.class` resolution at runner init.
-        doFirst { AndroidPreviewClasspath.validateApplicationOnClasspath(classpath.files) }
+        doFirst {
+          AndroidPreviewClasspath.validateApplicationOnClasspath(classpath.files)
+          // Backstop for the duplicate-jar failure mode (see [RenderClasspathDuplicates]).
+          // Warns by default; `-PcomposePreview.classpathDuplicates=fail` makes it an error.
+          RenderClasspathDuplicates.check(
+            this,
+            classpath.files,
+            classpathDuplicatesMode,
+            renderArtifactCoordinates.get(),
+          )
+        }
 
         dependsOn(discoverTask)
         dependsOn(generateRobolectricPropertiesTask)
@@ -2578,22 +2694,42 @@ internal object AndroidPreviewSupport {
       // built classes JAR, `jar` would be a plain Kotlin JAR if Stream
       // B ever splits the module. Same defensive pair as
       // AndroidPreviewClasspath uses for testConfig.
+      // One graph, not three. `daemonRendererConfig` extends `rendererConfig` (which extends
+      // `testConfig`), so a single resolution of it covers the daemon module, the renderer and
+      // the consumer's test-runtime dependencies with exactly one version per module.
+      // `buildTestClasspath` is therefore given the DAEMON config as its module-artifact source —
+      // the non-module entries it adds (Robolectric properties dir, renderer class dirs, the
+      // consumer's own class dirs, the unit-test config dir, the SDK boot classpath) are
+      // identical to the render task's.
+      //
+      // Before: `daemonRendererConfig ++ rendererConfig ++ testConfig ++ AGP's test classpath`,
+      // four independent resolutions stacked in front of one classloader. Only the AGP-only
+      // extras (unit-test merged R.jar, generated dirs) are still appended, via
+      // [AndroidPreviewClasspath.buildAgpClasspathExtras].
       this.classpath.from(
-        daemonRendererConfig.incoming
-          .artifactView { attributes.attribute(artifactType, "jar") }
-          .files
+        AndroidPreviewClasspath.buildTestClasspath(
+          project = project,
+          bootClasspath = bootClasspath,
+          bootClasspathFallback = bootClasspathFallback,
+          rendererConfig = daemonRendererConfig,
+          rendererClassDirs = rendererClassDirs,
+          sourceClassDirs = sourceClassDirs,
+          testConfig = testConfig,
+          screenshotTestRuntimeConfig = screenshotTestRuntimeConfig,
+          unitTestConfigDir = unitTestConfigDir,
+          robolectricPropertiesDir = generateRobolectricPropertiesTask.flatMap { it.outputDir },
+          legacyClasspathUnion = legacyClasspathUnion,
+        )
       )
-      this.classpath.from(
-        daemonRendererConfig.incoming
-          .artifactView { attributes.attribute(artifactType, "android-classes") }
-          .files
-      )
-      // Same FileCollection the composePreviewRender `Test` task assembles, plus
-      // the AGP unit-test task's classpath (R.jar etc.) appended at the
-      // tail — see line ~764 for the rationale.
-      this.classpath.from(resolvedClasspath)
       this.classpath.from(agpTestTask?.testClassesDirs ?: project.files())
-      this.classpath.from(agpTestTask?.classpath ?: project.files())
+      this.classpath.from(
+        AndroidPreviewClasspath.buildAgpClasspathExtras(
+          project = project,
+          agpTestClasspath = agpTestTask?.classpath ?: project.files(),
+          testConfig = testConfig,
+          legacyClasspathUnion = legacyClasspathUnion,
+        )
+      )
       // Static JVM open flags from the shared helper, plus the
       // daemon-specific heap ceiling. AGP test task's own jvmArgs are
       // intentionally NOT inherited here — they're test-runner specific

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderClasspathDuplicates.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderClasspathDuplicates.kt
@@ -1,0 +1,253 @@
+package ee.schimke.composeai.plugin
+
+import java.io.File
+import org.gradle.api.GradleException
+import org.gradle.api.Task
+
+/**
+ * Detects the same module sitting on one render JVM classpath at more than one version.
+ *
+ * The render / daemon classpaths are assembled by *concatenating* several separately-resolved
+ * dependency graphs (the renderer config, AGP's unit-test runtime classpath, the screenshotTest
+ * runtime config, the daemon config). Gradle runs conflict resolution *within* a graph, never
+ * across a `FileCollection` concatenation — so two graphs that each resolved `foo:bar` to a
+ * different version put BOTH jars in front of the same classloader. Whichever entry comes first
+ * wins per-class, and a class from the winning jar can end up calling into a sibling class that
+ * only the losing jar's version defines. The symptom is always a link error far from the cause:
+ * ```
+ * java.lang.NoSuchFieldError: Class org.bouncycastle.asn1.iana.IANAObjectIdentifiers
+ *   does not have member field '…id_MLKEM768_RSA2048_SHA3_256'
+ *   at …compositekem.KeyFactorySpi.<clinit>
+ * ```
+ *
+ * — two `bcprov-jdk18on` jars (1.84 from the consumer's own test deps via mockserver, 1.85 from
+ * Robolectric via `renderer-android`), reported downstream as `homeassistant-remotecompose#495`.
+ * The same shape has previously surfaced as Hamcrest `NoSuchMethodError` at `Espresso.<clinit>` and
+ * as `NoSuchFieldError` on `androidx.lifecycle.ReportFragment.Companion`.
+ *
+ * [ComposePreviewPlugin] no longer concatenates the consumer's separately-resolved unit-test graph
+ * (see `AndroidPreviewClasspath.buildAgpClasspathExtras`), so the common case is fixed at source.
+ * This detector is the backstop for the paths that still stack graphs — the screenshotTest runtime
+ * config, the daemon config — and for any future regression. It runs as a `doFirst` on the render
+ * tasks and reports rather than guesses: the message names the module, every version present, and
+ * the jar that will actually win.
+ *
+ * It inspects the *final* `FileCollection` the JVM is handed, so it validates reality rather than
+ * re-deriving what resolution intended — a config-level comparison would go green the moment the
+ * plugin stopped re-adding a graph, even if some other code path put the jars back. Each entry is
+ * then resolved to its exact `group:name:version` through the map from
+ * [AndroidPreviewClasspath.buildArtifactCoordinates]; filename parsing is only the fallback for
+ * entries that map doesn't cover, because on-disk names carry no group and several unrelated
+ * modules are called `core`.
+ */
+internal object RenderClasspathDuplicates {
+
+  /** One classpath entry that parsed to a recognisable `<artifact>` @ `<version>`. */
+  data class Entry(val group: String?, val artifact: String, val version: String, val path: String)
+
+  /** One module present at more than one version, in classpath order (first entry wins). */
+  data class Duplicate(val coordinate: String, val entries: List<Entry>) {
+    val versions: List<String>
+      get() = entries.map { it.version }.distinct()
+
+    /** The jar that actually wins class lookup — the earliest on the classpath. */
+    val winner: Entry
+      get() = entries.first()
+  }
+
+  /**
+   * Gradle's module cache layout:
+   * `…/modules-2/files-2.1/<group>/<name>/<version>/<sha1>/<name>-<version>.jar`. The only shape
+   * that yields a *group*, so it anchors the group backfill in [find].
+   */
+  private val MODULE_CACHE =
+    Regex("/files-2\\.1/([^/]+)/([^/]+)/([^/]+)/[0-9a-f]{20,}/", RegexOption.IGNORE_CASE)
+
+  /**
+   * Artifact-transform outputs:
+   * `…/.transforms/<hash>/transformed/<name>-<version>/jars/classes.jar` (AAR → classes.jar) or
+   * `…/transformed/<name>-<version>.jar` (jetified jars). The directory segment carries
+   * `<name>-<version>` but never the group.
+   */
+  private val TRANSFORMED = Regex("/transformed/([^/]+?)(?:\\.jar)?/")
+
+  /**
+   * Gradle variant suffixes AGP appends to a transform output's directory name. `glance-1.2.0-rc01`
+   * (the AAR's `classes.jar`) and `glance-1.2.0-rc01-runtime` (the runtime-variant jar) are the
+   * SAME module at the SAME version — the render classpath deliberately pulls both the `jar` and
+   * `android-classes` artifact views, so seeing the pair is normal and harmless. Without stripping
+   * these, every AAR on the classpath reads as a version conflict and the report is pure noise (77
+   * false positives on `samples/android` alone).
+   */
+  private val VARIANT_SUFFIXES = listOf("-runtime", "-api")
+
+  /**
+   * Splits `<name>-<version>` at the first `-` followed by a digit. That boundary is what makes
+   * `bcprov-jdk18on-1.85` → `bcprov-jdk18on` @ `1.85` (and not `bcprov` @ `jdk18on-1.85`), while
+   * still keeping multi-segment versions whole: `robolectric-4.17-beta-2` → `4.17-beta-2`,
+   * `listenablefuture-9999.0-empty-to-avoid-conflict-with-guava` → the full sentinel version.
+   *
+   * The parsed version has any [VARIANT_SUFFIXES] marker removed, so the `jar` and
+   * `android-classes` views of one artifact compare equal.
+   */
+  internal fun splitNameVersion(stem: String): Pair<String, String>? {
+    val match = Regex("-(?=\\d)").find(stem) ?: return null
+    val name = stem.substring(0, match.range.first)
+    var version = stem.substring(match.range.first + 1)
+    VARIANT_SUFFIXES.firstOrNull { version.endsWith(it) }
+      ?.let { version = version.removeSuffix(it) }
+    if (name.isEmpty() || version.isEmpty()) return null
+    return name to version
+  }
+
+  /**
+   * Parses one classpath entry into a module coordinate, or null when it isn't a versioned module
+   * artifact (a class directory, `R.jar`, the unit-test config dir, `android.jar`, a generated
+   * shard-classes dir — all of which are legitimately unversioned and must never be flagged).
+   *
+   * Tries the module cache first (it supplies the group), then the transform output directory, then
+   * the bare filename.
+   */
+  internal fun coordinateOf(path: String): Entry? {
+    val normalized = path.replace('\\', '/')
+    if (!normalized.endsWith(".jar", ignoreCase = true)) return null
+
+    MODULE_CACHE.find(normalized)?.let { m ->
+      return Entry(
+        group = m.groupValues[1],
+        artifact = m.groupValues[2],
+        version = m.groupValues[3],
+        path = path,
+      )
+    }
+
+    TRANSFORMED.find(normalized)?.let { m ->
+      // `jetified-` is AGP's own prefix on transformed artifacts; strip it so the jetified and
+      // non-jetified copies of one module compare equal.
+      val stem = m.groupValues[1].removePrefix("jetified-")
+      splitNameVersion(stem)?.let { (name, version) ->
+        return Entry(group = null, artifact = name, version = version, path = path)
+      }
+    }
+
+    val filename = normalized.substringAfterLast('/').removeSuffix(".jar").removeSuffix(".JAR")
+    splitNameVersion(filename.removePrefix("jetified-"))?.let { (name, version) ->
+      return Entry(group = null, artifact = name, version = version, path = path)
+    }
+    return null
+  }
+
+  /**
+   * Returns every module on [paths] that appears at more than one version, in classpath order.
+   *
+   * [coordinates] maps an absolute classpath path to the exact `group:name:version` Gradle resolved
+   * it to (see [AndroidPreviewClasspath.buildArtifactCoordinates]). Preferring it over path parsing
+   * is what makes the report trustworthy: transform outputs are named `<artifact>-<version>` with
+   * no group, so three unrelated modules that happen to be called `core` — `androidx.core:core`,
+   * `androidx.test:core`, `ee.schimke.composeai:core` — look identical on disk and get reported as
+   * one module at three versions. Asking Gradle removes the guesswork entirely.
+   *
+   * Paths absent from [coordinates] (class dirs, `R.jar`, `android.jar`, generated shard classes)
+   * fall back to path parsing, and are then attributed to a known module ONLY when exactly one
+   * known group uses that artifact name. Ambiguous or unattributable entries are skipped: a missed
+   * duplicate is a far cheaper failure than a false one, which trains people to ignore the warning.
+   */
+  fun find(
+    paths: Iterable<String>,
+    coordinates: Map<String, String> = emptyMap(),
+  ): List<Duplicate> {
+    val buckets = LinkedHashMap<String, MutableList<Entry>>()
+    val unattributed = mutableListOf<Entry>()
+
+    for (path in paths) {
+      val exact = coordinates[path]
+      if (exact != null) {
+        val key = exact.substringBeforeLast(':')
+        val version = exact.substringAfterLast(':')
+        val artifact = key.substringAfterLast(':')
+        buckets
+          .getOrPut(key) { mutableListOf() }
+          .add(Entry(key.substringBeforeLast(':'), artifact, version, path))
+      } else {
+        coordinateOf(path)?.let { unattributed.add(it) }
+      }
+    }
+
+    // Artifact name → the single group that owns it, or null when several do. Only unambiguous
+    // names can absorb an unattributed entry.
+    val groupsByArtifact = LinkedHashMap<String, MutableSet<String>>()
+    buckets.values.flatten().forEach { entry ->
+      groupsByArtifact.getOrPut(entry.artifact) { linkedSetOf() }.add(entry.group ?: "")
+    }
+    for (entry in unattributed) {
+      val groups = groupsByArtifact[entry.artifact] ?: continue
+      val group = groups.singleOrNull() ?: continue
+      buckets["$group:${entry.artifact}"]?.add(entry)
+    }
+
+    return buckets
+      .filterValues { bucket -> bucket.map { it.version }.distinct().size > 1 }
+      .map { (key, bucket) -> Duplicate(key, bucket) }
+  }
+
+  /** Convenience overload for a resolved [org.gradle.api.file.FileCollection]'s files. */
+  fun findInFiles(files: Iterable<File>, coordinates: Map<String, String> = emptyMap()) =
+    find(files.map { it.absolutePath }, coordinates)
+
+  /**
+   * Human-readable report. Lists each module, the versions present, and which jar wins classload —
+   * enough for the reader to decide whether to align the dependency or exclude it, without
+   * re-running anything.
+   */
+  fun report(duplicates: List<Duplicate>, taskPath: String): String = buildString {
+    appendLine(
+      "compose-preview: ${duplicates.size} module(s) are on the $taskPath JVM classpath at more " +
+        "than one version. Java loads the FIRST match per class, so a class from the winning jar " +
+        "can link against a sibling that only the other version defines (NoSuchFieldError / " +
+        "NoSuchMethodError at an unrelated <clinit>)."
+    )
+    duplicates.forEach { duplicate ->
+      appendLine("  ${duplicate.coordinate}  ${duplicate.versions.joinToString(", ")}")
+      appendLine("    wins: ${duplicate.winner.path}")
+      duplicate.entries.drop(1).forEach { appendLine("    also: ${it.path}") }
+    }
+    appendLine(
+      "Align the module in your build (a version force, a `belongsTo` alignment rule for a " +
+        "split family such as org.bouncycastle:bcprov/bcutil/bcpkix, or an exclude on whichever " +
+        "graph shouldn't carry it). Set -PcomposePreview.classpathDuplicates=fail to make this " +
+        "an error, or =off to silence it."
+    )
+  }
+
+  /** Valid values for `-PcomposePreview.classpathDuplicates`. */
+  const val MODE_WARN = "warn"
+  const val MODE_FAIL = "fail"
+  const val MODE_OFF = "off"
+
+  /**
+   * Runs the check for [task] and reports according to [mode].
+   *
+   * Called from a `doFirst` on each render task, alongside
+   * [AndroidPreviewClasspath.validateApplicationOnClasspath] — by then `classpath.files` is fully
+   * resolved, and a `doFirst` touches only the task (never `project.*`), so it stays
+   * configuration-cache safe.
+   *
+   * Warns by default rather than failing. A duplicate is a strong smell but not always fatal —
+   * plenty of consumers have carried one for months without a visible symptom because the classes
+   * that differ are never loaded. Failing every such build on upgrade would be worse than the
+   * disease; `-PcomposePreview.classpathDuplicates=fail` opts into the strict behaviour for CI.
+   */
+  fun check(
+    task: Task,
+    files: Iterable<File>,
+    mode: String,
+    coordinates: Map<String, String> = emptyMap(),
+  ) {
+    if (mode == MODE_OFF) return
+    val duplicates = findInFiles(files, coordinates)
+    if (duplicates.isEmpty()) return
+    val message = report(duplicates, task.path)
+    if (mode == MODE_FAIL) throw GradleException(message)
+    task.logger.warn(message)
+  }
+}

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/RenderClasspathDuplicatesTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/RenderClasspathDuplicatesTest.kt
@@ -1,0 +1,256 @@
+package ee.schimke.composeai.plugin
+
+import com.google.common.truth.Truth.assertThat
+import org.gradle.api.GradleException
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Test
+
+class RenderClasspathDuplicatesTest {
+
+  private val cache = "/home/u/.gradle/caches/modules-2/files-2.1"
+  private val sha = "0123456789abcdef0123456789abcdef01234567"
+
+  private fun cached(group: String, name: String, version: String) =
+    "$cache/$group/$name/$version/$sha/$name-$version.jar"
+
+  /** Mirrors what `AndroidPreviewClasspath.buildArtifactCoordinates` hands the detector. */
+  private fun coordinates(vararg entries: Pair<String, String>) = entries.toMap()
+
+  private fun module(group: String, name: String, version: String): Pair<String, String> =
+    cached(group, name, version) to "$group:$name:$version"
+
+  @Test
+  fun `flags the bouncycastle split that broke a11y renders`() {
+    // homeassistant-remotecompose#495: Robolectric (via renderer-android) resolved bcprov 1.85 in
+    // the renderer graph while the consumer's own mockserver test dep resolved 1.84 in the
+    // unit-test graph. Both jars reached one classloader and BC's post-quantum
+    // `compositekem.KeyFactorySpi.<clinit>` linked against the wrong `IANAObjectIdentifiers`.
+    val paths =
+      listOf(
+        cached("org.bouncycastle", "bcprov-jdk18on", "1.85"),
+        cached("org.bouncycastle", "bcutil-jdk18on", "1.84"),
+        cached("org.bouncycastle", "bcprov-jdk18on", "1.84"),
+      )
+    val duplicates =
+      RenderClasspathDuplicates.find(
+        paths,
+        coordinates(
+          module("org.bouncycastle", "bcprov-jdk18on", "1.85"),
+          module("org.bouncycastle", "bcutil-jdk18on", "1.84"),
+          module("org.bouncycastle", "bcprov-jdk18on", "1.84"),
+        ),
+      )
+
+    assertThat(duplicates.map { it.coordinate }).containsExactly("org.bouncycastle:bcprov-jdk18on")
+    assertThat(duplicates.single().versions).containsExactly("1.85", "1.84").inOrder()
+    // The winner is the earliest entry — that's the one the JVM actually loads, so it's what the
+    // report has to name.
+    assertThat(duplicates.single().winner.version).isEqualTo("1.85")
+  }
+
+  @Test
+  fun `clean classpath reports nothing`() {
+    val duplicates =
+      RenderClasspathDuplicates.find(
+        listOf(
+          cached("org.bouncycastle", "bcprov-jdk18on", "1.85"),
+          cached("org.bouncycastle", "bcutil-jdk18on", "1.84"),
+          cached("androidx.test", "core", "1.6.1"),
+        ),
+        coordinates(
+          module("org.bouncycastle", "bcprov-jdk18on", "1.85"),
+          module("org.bouncycastle", "bcutil-jdk18on", "1.84"),
+          module("androidx.test", "core", "1.6.1"),
+        ),
+      )
+
+    assertThat(duplicates).isEmpty()
+  }
+
+  @Test
+  fun `same artifact name under different groups is not a duplicate`() {
+    // `androidx.core:core`, `androidx.test:core` and this repo's own `:daemon:core` all land on
+    // the render classpath as files called `core-<version>`. Grouping on the filename alone
+    // reported them as one module at three versions — which is why the detector asks Gradle for
+    // coordinates instead of parsing paths.
+    val androidxCore = "/c/transforms/aa/transformed/core-1.18.0/jars/classes.jar"
+    val testCore = "/c/transforms/bb/transformed/core-1.6.1/jars/classes.jar"
+    val daemonCore = "/w/daemon/core/build/libs/core-0.17.20-SNAPSHOT.jar"
+
+    val duplicates =
+      RenderClasspathDuplicates.find(
+        listOf(androidxCore, testCore, daemonCore),
+        coordinates(
+          androidxCore to "androidx.core:core:1.18.0",
+          testCore to "androidx.test:core:1.6.1",
+          daemonCore to "project::daemon:core:",
+        ),
+      )
+
+    assertThat(duplicates).isEmpty()
+  }
+
+  @Test
+  fun `unversioned classpath entries are never flagged`() {
+    // R.jar, class dirs, the unit-test config dir and android.jar are legitimately unversioned and
+    // appear on every render classpath. They're absent from the coordinate map, and flagging them
+    // would make the warning useless.
+    val duplicates =
+      RenderClasspathDuplicates.find(
+        listOf(
+          "/w/app/build/intermediates/compile_and_runtime_r_class_jar/debugUnitTest/R.jar",
+          "/w/app/build/tmp/kotlin-classes/debug",
+          "/w/app/build/intermediates/unit_test_config_directory/debugUnitTest",
+          "/opt/android-sdk/platforms/android-36/android.jar",
+          "/w/app/build/generated/composeai/render-shards/classes",
+        )
+      )
+
+    assertThat(duplicates).isEmpty()
+  }
+
+  @Test
+  fun `AGP runtime-variant jar is not a second version`() {
+    // The render classpath deliberately pulls BOTH the `jar` and `android-classes` artifact views,
+    // so every AAR shows up as `<name>-<version>/jars/classes.jar` AND
+    // `<name>-<version>-runtime.jar`. Same module, same version — reporting the pair made the
+    // warning fire 77 times on samples/android and rendered it worthless.
+    val classes = "/c/transforms/aa/transformed/glance-1.2.0-rc01/jars/classes.jar"
+    val runtime = "/c/transforms/bb/transformed/glance-1.2.0-rc01-runtime.jar"
+
+    val duplicates =
+      RenderClasspathDuplicates.find(
+        listOf(classes, runtime),
+        coordinates(
+          classes to "androidx.glance:glance:1.2.0-rc01",
+          runtime to "androidx.glance:glance:1.2.0-rc01",
+        ),
+      )
+
+    assertThat(duplicates).isEmpty()
+  }
+
+  @Test
+  fun `an entry missing from the coordinate map joins an unambiguous module`() {
+    // Backstop for a jar that reaches the classpath from a configuration the map doesn't cover.
+    // Only one group owns the name `monitor`, so attribution is safe.
+    val known = "/c/transforms/aa/transformed/monitor-1.8.0/jars/classes.jar"
+    val unmapped = "/c/transforms/bb/transformed/monitor-1.6.1-runtime.jar"
+
+    val duplicates =
+      RenderClasspathDuplicates.find(
+        listOf(known, unmapped),
+        coordinates(known to "androidx.test:monitor:1.8.0"),
+      )
+
+    assertThat(duplicates.map { it.coordinate }).containsExactly("androidx.test:monitor")
+    assertThat(duplicates.single().versions).containsExactly("1.8.0", "1.6.1").inOrder()
+  }
+
+  @Test
+  fun `an unmapped entry whose name spans several groups is skipped`() {
+    // Attributing it would be a coin flip, and a false duplicate trains people to ignore the
+    // warning. Silently skipping is the cheaper failure.
+    val androidxCore = "/c/transforms/aa/transformed/core-1.18.0/jars/classes.jar"
+    val testCore = "/c/transforms/bb/transformed/core-1.6.1/jars/classes.jar"
+    val unmapped = "/c/transforms/cc/transformed/core-9.9.9/jars/classes.jar"
+
+    val duplicates =
+      RenderClasspathDuplicates.find(
+        listOf(androidxCore, testCore, unmapped),
+        coordinates(
+          androidxCore to "androidx.core:core:1.18.0",
+          testCore to "androidx.test:core:1.6.1",
+        ),
+      )
+
+    assertThat(duplicates).isEmpty()
+  }
+
+  @Test
+  fun `splits name from version at the first digit-led segment`() {
+    // The boundary rule has to survive artifact names that themselves contain dashes and
+    // versions that contain several.
+    assertThat(RenderClasspathDuplicates.splitNameVersion("bcprov-jdk18on-1.85"))
+      .isEqualTo("bcprov-jdk18on" to "1.85")
+    assertThat(RenderClasspathDuplicates.splitNameVersion("robolectric-4.17-beta-2"))
+      .isEqualTo("robolectric" to "4.17-beta-2")
+    assertThat(RenderClasspathDuplicates.splitNameVersion("ui-android-1.9.5"))
+      .isEqualTo("ui-android" to "1.9.5")
+    assertThat(
+        RenderClasspathDuplicates.splitNameVersion(
+          "listenablefuture-9999.0-empty-to-avoid-conflict-with-guava"
+        )
+      )
+      .isEqualTo("listenablefuture" to "9999.0-empty-to-avoid-conflict-with-guava")
+    assertThat(RenderClasspathDuplicates.splitNameVersion("classes")).isNull()
+  }
+
+  @Test
+  fun `report names the module, every version, and the winning jar`() {
+    val duplicates =
+      RenderClasspathDuplicates.find(
+        listOf(
+          cached("org.bouncycastle", "bcprov-jdk18on", "1.85"),
+          cached("org.bouncycastle", "bcprov-jdk18on", "1.84"),
+        ),
+        coordinates(
+          module("org.bouncycastle", "bcprov-jdk18on", "1.85"),
+          module("org.bouncycastle", "bcprov-jdk18on", "1.84"),
+        ),
+      )
+
+    val report = RenderClasspathDuplicates.report(duplicates, ":app:composePreviewRender")
+
+    assertThat(report).contains(":app:composePreviewRender")
+    assertThat(report).contains("org.bouncycastle:bcprov-jdk18on")
+    assertThat(report).contains("1.85, 1.84")
+    assertThat(report).contains("wins: ${cached("org.bouncycastle", "bcprov-jdk18on", "1.85")}")
+    assertThat(report).contains("also: ${cached("org.bouncycastle", "bcprov-jdk18on", "1.84")}")
+    assertThat(report).contains("composePreview.classpathDuplicates=fail")
+  }
+
+  @Test
+  fun `check warns by default and fails only in fail mode`() {
+    val project = ProjectBuilder.builder().build()
+    val task = project.tasks.register("probe").get()
+    val files =
+      listOf(
+        project.file(cached("org.bouncycastle", "bcprov-jdk18on", "1.85")),
+        project.file(cached("org.bouncycastle", "bcprov-jdk18on", "1.84")),
+      )
+    val coords = files.associate {
+      it.absolutePath to
+        "org.bouncycastle:bcprov-jdk18on:${it.name.substringAfterLast('-').removeSuffix(".jar")}"
+    }
+
+    // warn: reports without breaking the build — a duplicate is a strong smell, not proof the
+    // clashing classes are ever loaded, so upgrading the plugin must not fail existing consumers.
+    RenderClasspathDuplicates.check(task, files, RenderClasspathDuplicates.MODE_WARN, coords)
+    // off: silent even with duplicates present.
+    RenderClasspathDuplicates.check(task, files, RenderClasspathDuplicates.MODE_OFF, coords)
+
+    val thrown =
+      runCatching {
+          RenderClasspathDuplicates.check(task, files, RenderClasspathDuplicates.MODE_FAIL, coords)
+        }
+        .exceptionOrNull()
+
+    assertThat(thrown).isInstanceOf(GradleException::class.java)
+    assertThat(thrown!!.message).contains("org.bouncycastle:bcprov-jdk18on")
+  }
+
+  @Test
+  fun `check is a no-op on a clean classpath even in fail mode`() {
+    val project = ProjectBuilder.builder().build()
+    val task = project.tasks.register("probeClean").get()
+    val file = project.file(cached("androidx.test", "core", "1.6.1"))
+
+    RenderClasspathDuplicates.check(
+      task,
+      listOf(file),
+      RenderClasspathDuplicates.MODE_FAIL,
+      mapOf(file.absolutePath to "androidx.test:core:1.6.1"),
+    )
+  }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -45,3 +45,10 @@ org.jetbrains.compose.hot.reload.disable=true
 # x-release-please-start-version
 composeaiReleasedRuntimeVersion=0.17.19
 # x-release-please-end
+
+# Fail this repo's own renders when a module lands on the render/daemon JVM classpath at more than
+# one version (see `RenderClasspathDuplicates`). Consumers get `warn` by default — an existing
+# duplicate shouldn't break their build on a plugin upgrade — but the samples here are exactly
+# where a regression in the single-graph classpath construction would first show up, so they gate
+# on it. Override per-invocation with `-PcomposePreview.classpathDuplicates=warn` (or `off`).
+composePreview.classpathDuplicates=fail

--- a/site/install.md
+++ b/site/install.md
@@ -199,6 +199,37 @@ Rendering is the long pole. Two levers, both about parallelism:
   into real wall-clock savings. RAM scales with cores on GitHub-hosted runners,
   which keeps the per-fork memory bound out of the way.
 
+## Render classpath conflicts
+
+The render JVM classpath is built from a **single** resolved dependency graph:
+the plugin's renderer configuration `extendsFrom` your module's unit-test
+runtime classpath (and its `screenshotTest` runtime classpath, when Google's
+screenshot plugin is applied), so Gradle picks one version per module across
+the renderer's dependencies and your own. Only entries that exist nowhere else
+— the unit-test merged `R.jar`, generated class dirs — are appended from AGP's
+test task on top.
+
+Before this, those graphs were resolved separately and concatenated, which put
+two versions of the same module in front of one classloader. Java loads the
+first match per class, so a class from the winning jar could link against a
+sibling only the other version defined, and you'd get a `NoSuchFieldError` or
+`NoSuchMethodError` in an unrelated `<clinit>` — e.g. two `bcprov-jdk18on`
+jars failing every accessibility preview inside BouncyCastle's post-quantum
+`KeyFactorySpi`.
+
+A guard runs before each render and reports any module still present at more
+than one version, naming each version and the jar that wins:
+
+| Property | Default | Effect |
+| --- | --- | --- |
+| `composePreview.classpathDuplicates` | `warn` | `fail` turns a duplicate into a build error (good for CI); `off` silences the check. |
+| `composePreview.legacyClasspathUnion` | `false` | `true` restores the old concatenated classpath. Escape hatch only — set it if a render suddenly can't find a class that lives solely on your unit-test classpath, and please file an issue. |
+
+If the guard reports a duplicate, align the module in your own build: a version
+force, or a `belongsTo` alignment rule for a family published under several
+coordinates (`org.bouncycastle:bcprov`/`bcutil`/`bcpkix` is the common one —
+Gradle can only align coordinates it knows are the same module).
+
 ## Requirements
 
 Java 17+, Gradle 8.13+, AGP 8.13.0+ (Android), Kotlin 2.0.21+, Compose


### PR DESCRIPTION
## Summary

The render and daemon JVM classpaths were assembled by **concatenating several independently-resolved dependency graphs**. Gradle runs conflict resolution *within* a graph, never across a `FileCollection` concatenation — so any module two graphs disagreed on landed twice, at two versions, in front of one classloader. Java loads the first match per class, so a class from the winning jar can link against a sibling only the losing jar's version defines, and the failure surfaces as a link error far from the cause.

That is the root cause behind homeassistant-remotecompose#495, which worked the symptom around downstream with a hardcoded BouncyCastle version force.

`rendererConfig` already does `extendsFrom(testConfig)` *precisely* to get one coherent graph (the comment at `AndroidPreviewSupport.kt:1324` says so). But `buildTestClasspath` then re-added `testConfig`'s own artifact view, and the `Test` task appended AGP's test classpath on top — undoing it at the last step. The daemon was worse: `daemonRendererConfig ++ rendererConfig ++ testConfig ++ AGP's test classpath`, four resolutions. That's why the BouncyCastle failure hit **a11y previews specifically** — a11y renders go through the daemon, which stacked the most graphs.

### What the leak actually was

Measured on `homeassistant-remotecompose` (plugin 0.17.16, AGP 9.3), with the downstream BC force temporarily disabled:

```
bcprov-jdk18on:1.85 ← org.robolectric:robolectric:4.17-beta-2 ← ee.schimke.composeai:renderer-android
bcprov-jdk18on:1.84 ← bcutil/bcpkix-jdk18on:1.84 ← org.mock-server:mockserver-core ← :app testImplementation
```

Every module in that repo's unit-test graph was **already** in the renderer graph — the re-add contributed zero unique modules and nine duplicated ones (`androidx.test:core` 1.5.0+1.6.1, `monitor` 1.6.1+1.8.0, espresso, `asm` 9.7.1+9.10.1, commons-logging, okhttp, …).

## Changes

- **Module artifacts come from one graph only.** `rendererConfig` now also `extendsFrom` the `screenshotTest` runtime classpath, and supplies both the `jar` and `android-classes` views. AGP's test classpath is subtracted down to its genuinely unique entries — the unit-test merged `R.jar` and generated dirs, the reason it was appended in the first place (#136) — via `AndroidPreviewClasspath.buildAgpClasspathExtras`.
- **The daemon uses one graph too.** `daemonRendererConfig` `extendsFrom(rendererConfig)` and now supplies the whole daemon classpath itself.
- **Shared resolution rules extracted** to `applyRenderGraphResolutionRules`. `extendsFrom` inherits dependencies but **not** `resolutionStrategy`, so the daemon config was silently missing the KMP-Android sibling substitution and the Hamcrest rule the renderer has — two JVMs rendering the same previews off different graphs.
- **New `RenderClasspathDuplicates` guard** runs as a `doFirst` on every render task and reports any module still on the classpath at more than one version, naming each version and the jar that wins. It resolves each entry to its exact `group:name:version` by asking Gradle (`buildArtifactCoordinates`) rather than parsing filenames — necessary because transform outputs carry no group and `androidx.core:core`, `androidx.test:core` and this repo's own `:daemon:core` all land on disk as `core-<version>`.
- **Escape hatches.** `-PcomposePreview.classpathDuplicates=warn|fail|off` (default `warn` for consumers — an existing duplicate shouldn't break someone's build on upgrade); this repo's own `gradle.properties` sets `fail` so a regression fails CI here. `-PcomposePreview.legacyClasspathUnion=true` restores the old concatenation.

## Test plan

Non-visual change (build/classpath wiring only), so no render output differs — verified by the render counts below being unchanged.

- **`:samples:android:composePreviewRender`** — 16 duplicated modules on the old classpath (`-PcomposePreview.legacyClasspathUnion=true`), **0** after. All **115 PNGs** still render, `BUILD SUCCESSFUL` both ways.
- **`:samples:android:composePreviewDaemonStart`** — daemon launch descriptor builds; its 505-entry classpath has no module at two versions.
- **Gate check** — `:samples:android-screenshot-test`, `:samples:wear` and `:samples:android` all render green under `composePreview.classpathDuplicates=fail`, covering the screenshotTest and Wear paths.
- **`:gradle-plugin:test`** — full unit suite green, including 11 new `RenderClasspathDuplicatesTest` cases covering the BouncyCastle shape, the `-runtime` variant-jar false positive (77 of them on `samples/android` before it was fixed), the three-different-`core` false positive, and unversioned entries (`R.jar`, class dirs, `android.jar`).
- `:gradle-plugin:ktfmtCheck` green.

## Known remaining gap

The BTA compile classpath (`wireBtaInputs`) still takes AGP's classpath unfiltered — that's a *compile* classpath where dropping modules would be wrong, and duplicate jars there don't have the classloading failure mode.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ULa9AYFHcJgEQmKbzJPYtx)_