### PR TITLE
fix(serve): don't open a replacement daemon while the outgoing one is closing

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistry.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistry.kt
@@ -73,6 +73,15 @@ class ServeSessionRegistry(
      * daemon is re-opened so it reflects the *current* run, not the session's first-ever open.
      */
     @Volatile var startedAt: Long? = null,
+    /**
+     * A suspension detached this entry's host and is closing it **right now** (outside the lock, so
+     * a blocking daemon shutdown doesn't stall every other session). [liveHost] waits this out
+     * before reopening: without it, a request arriving inside that window sees `host == null` and
+     * launches a replacement daemon while the previous one is still shutting down, so a single
+     * session momentarily runs two daemon subprocesses and overshoots the live-seat/memory budget.
+     * Closing under the lock used to serialise this implicitly.
+     */
+    @Volatile var closing: Boolean = false,
   )
 
   /**
@@ -106,6 +115,9 @@ class ServeSessionRegistry(
   private val lock = ReentrantLock()
   private val sessions = HashMap<String, Entry>()
   private var closed = false
+
+  /** Signalled when a detached host finishes closing, releasing waiters in [liveHost]. */
+  private val closeFinished = lock.newCondition()
 
   /**
    * Observers notified as a session transitions resident→suspended, with the host that's about to
@@ -255,12 +267,16 @@ class ServeSessionRegistry(
    * released — a `close()` can block on daemon shutdown, and a listener may re-enter the registry —
    * so the only work under the lock is detaching each host from its entry. Listeners see the host
    * before it's closed, so a snapshot they take reads live state.
+   *
+   * Each detached entry is marked [Entry.closing] for that window so a concurrent resume waits for
+   * the old daemon to die rather than starting a second one alongside it (see [liveHost]) — the
+   * serialisation that closing-under-the-lock used to provide, without the stall.
    */
   fun suspendIdle(): Int {
     val detached = lock.withLock {
       if (closed) return 0
       val now = clock()
-      val detached = mutableListOf<Pair<String, ServeHost>>()
+      val detached = mutableListOf<Triple<String, Entry, ServeHost>>()
       for ((id, entry) in sessions) {
         val host = entry.host ?: continue
         if (
@@ -271,14 +287,24 @@ class ServeSessionRegistry(
         ) {
           entry.host = null
           entry.startedAt = null
-          detached += id to host
+          entry.closing = true
+          detached += Triple(id, entry, host)
         }
       }
       detached
     }
-    for ((id, host) in detached) {
-      suspendListeners.forEach { listener -> runCatching { listener(id, host) } }
-      runCatching { host.close() }
+    for ((id, entry, host) in detached) {
+      try {
+        suspendListeners.forEach { listener -> runCatching { listener(id, host) } }
+        runCatching { host.close() }
+      } finally {
+        // Always clear the gate, even if a listener threw something runCatching doesn't hold —
+        // a stuck `closing` flag would block this session's resume forever.
+        lock.withLock {
+          entry.closing = false
+          closeFinished.signalAll()
+        }
+      }
     }
     return detached.size
   }
@@ -339,6 +365,8 @@ class ServeSessionRegistry(
     val hosts = lock.withLock {
       if (closed) return
       closed = true
+      // Release anyone parked on a mid-suspension close; they re-check `closed` and give up.
+      closeFinished.signalAll()
       sessions.values.mapNotNull { it.host }.also { sessions.clear() }
     }
     reaper?.shutdownNow()
@@ -360,8 +388,20 @@ class ServeSessionRegistry(
     }
   }
 
-  /** The entry's live host, resuming (re-opening) from its state if it was suspended. */
+  /**
+   * The entry's live host, resuming (re-opening) from its state if it was suspended. Caller holds
+   * [lock].
+   *
+   * A resume that lands mid-suspension first waits for the outgoing daemon to finish closing
+   * ([Entry.closing]) — otherwise this would open its replacement alongside a daemon that is still
+   * shutting down, briefly doubling that session's memory and live-seat cost. `await` releases the
+   * lock while parked, so the closer (which re-takes it only to clear the flag) still makes
+   * progress, and other sessions are unaffected.
+   */
   private fun liveHost(entry: Entry): ServeHost? {
+    while (entry.closing) closeFinished.awaitUninterruptibly()
+    // The registry may have been closed while we were parked; don't resurrect a daemon into it.
+    if (closed) return null
     entry.host?.let {
       return it
     }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistryTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistryTest.kt
@@ -2,8 +2,12 @@ package ee.schimke.composeai.cli.serve
 
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import java.io.File
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -53,6 +57,86 @@ class ServeSessionRegistryTest {
       built.incrementAndGet()
       return stateFor(sessionId)
     }
+  }
+
+  /**
+   * Suspension closes the outgoing daemon OUTSIDE the registry lock (so a blocking shutdown doesn't
+   * stall unrelated sessions), which opens a window where the entry's host is already null while
+   * its daemon is still alive. A resume landing in that window must WAIT, not open a replacement
+   * alongside it — otherwise one session briefly runs two daemon subprocesses and overshoots the
+   * live-seat / memory budget the limiter is there to enforce.
+   */
+  @Test
+  fun `a resume waits for the outgoing daemon to finish closing`() {
+    val clock = AtomicLong(0)
+    val opener = Opener()
+    val releaseClose = CountDownLatch(1)
+    val closeStarted = CountDownLatch(1)
+    val closeFinished = AtomicBoolean(false)
+    // Wrap the opened host so its close() parks until the test lets it go.
+    val blockingOpener: (ServeSessionState) -> ServeHost? = { state ->
+      val delegate = opener(state)
+      object : ServeHost by delegate {
+        override fun close() {
+          closeStarted.countDown()
+          // BOUNDED park: if this test ever fails mid-flight, the registry's own close() must not
+          // block forever on a latch nobody will release — a regression should fail, not hang CI.
+          releaseClose.await(10, TimeUnit.SECONDS)
+          delegate.close()
+          closeFinished.set(true)
+        }
+      }
+    }
+    ServeSessionRegistry(
+        open = blockingOpener,
+        idleTimeoutMillis = 10,
+        reaperIntervalMillis = 0,
+        clock = { clock.get() },
+      )
+      .use { reg ->
+        try {
+          reg.register("a", stateFor("a"))
+          assertNotNull(reg.acquire("a"))
+          assertEquals(1, opener.opened.get())
+
+          clock.set(100)
+          val suspender = Thread { reg.suspendIdle() }.apply { start() }
+          assertTrue(closeStarted.await(5, TimeUnit.SECONDS), "the suspension started closing")
+
+          // The host is detached but its daemon is still shutting down. A resume now must block.
+          val resumed = AtomicReference<ServeHost?>(null)
+          val resumeReturned = CountDownLatch(1)
+          Thread {
+              resumed.set(reg.acquire("a"))
+              resumeReturned.countDown()
+            }
+            .start()
+          assertTrue(
+            !resumeReturned.await(300, TimeUnit.MILLISECONDS),
+            "the resume must not complete while the previous daemon is still closing",
+          )
+          assertEquals(
+            1,
+            opener.opened.get(),
+            "no second daemon is opened alongside the closing one",
+          )
+
+          // Let the close finish; the parked resume then opens exactly one replacement.
+          releaseClose.countDown()
+          assertTrue(resumeReturned.await(5, TimeUnit.SECONDS), "the resume completes once closed")
+          suspender.join(5_000)
+          assertTrue(
+            closeFinished.get(),
+            "the outgoing daemon closed before the replacement opened",
+          )
+          assertNotNull(resumed.get())
+          assertEquals(2, opener.opened.get(), "exactly one replacement daemon")
+        } finally {
+          // Never leave a blocked close() parked — an assertion failure above would otherwise
+          // stall the registry's own close() inside use{}.
+          releaseClose.countDown()
+        }
+      }
   }
 
   @Test


### PR DESCRIPTION
## Summary

Follow-up to #2738, which merged before this landed. Codex flagged it on that PR and the finding is correct.

#2738 moved the suspension's `host.close()` outside the registry lock so a blocking daemon shutdown couldn't stall every other session. But closing under the lock had been doing double duty — it also **serialised resume against close**.

Without that serialisation, a request arriving between `entry.host = null` and the close returning sees a suspended session and opens a replacement daemon while the previous subprocess is still shutting down. For that window one session runs **two daemons**, overshooting the live-seat permit budget and the memory headroom `LiveSeatLimiter` exists to protect — worst on exactly the heavy Android/Robolectric catalogs the weighting is meant to bound.

The fix keeps both properties instead of trading one for the other: mark the entry `closing` while its detached host is being closed, and have `liveHost()` wait that out before reopening. The wait uses a condition on the existing lock, so it parks **without holding it** — the closer still makes progress, unrelated sessions are untouched, and listeners + `close()` stay outside the lock. The flag is cleared in a `finally`, so a throwing listener can't wedge a session's resume permanently, and `close()` signals waiters so a parked resume doesn't outlive the registry.

## Test plan

- New `ServeSessionRegistryTest."a resume waits for the outgoing daemon to finish closing"`: opens a session, suspends it on a background thread with a host whose `close()` parks, then asserts a concurrent `acquire()` does **not** return and opens **no** second daemon while the close is in flight — then that it completes with exactly one replacement once the close is released.
- Verified the test **fails without the fix**: removing just the wait reproduces it as `AssertionFailedError: the resume must not complete while the previous daemon is still closing`.
- The blocked `close()` is bounded and the latch released in a `finally`, so a future regression **fails fast rather than hanging CI** — confirmed by running the negative check both ways.
- `./gradlew :cli:test` on top of `ec4b0d9` — 839 tests, 0 failures. `:cli:ktfmtCheck` clean.

No visual surface is touched by this change, so there's no before/after to embed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Ho8YfDhA2muEctYxqecAN

---
_Generated by [Claude Code](https://claude.ai/code/session_017Ho8YfDhA2muEctYxqecAN)_