### PR TITLE
fix(bundle): fetch --with-semantics by raw preview id, inject by bundle id

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
@@ -523,12 +523,23 @@ private class PackSubcommand(private val args: List<String>) {
   ): String? {
     val previewIds = meta.manifest.previewIds
     if (previewIds.isEmpty()) return null
+    // The manifest's previewIds carry the sanitised in-bundle form; the daemon keys renders on the
+    // RAW discovery id. Fetch by raw (rawPreviewIds, parallel to previewIds — falling back to the
+    // bundle form for pre-field bundles, correct when nothing needed sanitising) and re-key each
+    // returned map to the bundle form before injecting, so `previews/<id>.semantics.json` matches
+    // the entry names readers reconstruct.
+    val rawIds =
+      if (meta.manifest.rawPreviewIds.size == previewIds.size) meta.manifest.rawPreviewIds
+      else previewIds
+    val bundleIdByRaw = rawIds.zip(previewIds).toMap()
+    fun <V> Map<String, V>.keyedByBundleId(): Map<String, V> =
+      entries.associate { (raw, v) -> (bundleIdByRaw[raw] ?: raw) to v }
     val fetcher = DaemonSemanticsFetcher(onLog = { System.err.println("[daemon semantics] $it") })
     val outcome =
       fetcher.fetch(
         projectDir = target.projectDir,
         moduleName = target.gradlePath,
-        previewIds = previewIds,
+        previewIds = rawIds,
       )
     when (outcome) {
       is DaemonSemanticsFetcher.Outcome.Ok -> {
@@ -539,23 +550,23 @@ private class PackSubcommand(private val args: List<String>) {
           )
           return null
         }
-        val written = injectSemanticsIntoBundle(bundleFile, outcome.semanticsById)
+        val written = injectSemanticsIntoBundle(bundleFile, outcome.semanticsById.keyedByBundleId())
         val missing = previewIds.size - written
         // The layout-inspector tree rides alongside the semantics blob (best-effort): a preview
         // that produced a tree gets `previews/<id>.layout.json` so a consumer can build slot-level
         // redlines/wireframes. Injected after semantics so its byte count is reflected too.
-        val layoutWritten = injectLayoutIntoBundle(bundleFile, outcome.layoutById)
+        val layoutWritten = injectLayoutIntoBundle(bundleFile, outcome.layoutById.keyedByBundleId())
         // The fonts/used record rides the same render (best-effort, Android daemon only): carried
         // so the design-catalog export can generate the Wasm tier's fonts.json from actual usage.
-        val fontsWritten = injectFontsIntoBundle(bundleFile, outcome.fontsById)
+        val fontsWritten = injectFontsIntoBundle(bundleFile, outcome.fontsById.keyedByBundleId())
         // The layered `compose/figma-svg` export rides the same render (best-effort): carried so
         // the
         // design-catalog export can ship an editable vector per sticker beside the raster PNG.
-        val figmaSvgWritten = injectFigmaSvgIntoBundle(bundleFile, outcome.figmaSvgById)
+        val figmaSvgWritten = injectFigmaSvgIntoBundle(bundleFile, outcome.figmaSvgById.keyedByBundleId())
         // A hybrid figma-svg references `figma-raster/<node>.png` crops; carry them verbatim as
         // `previews/<id>.figma-raster/<node>.png` so the SVG's `<image>` layers resolve once the
         // export copies the SVG onto the delivery branch. Empty for the common vector-only case.
-        val figmaRasterWritten = injectFigmaRasterIntoBundle(bundleFile, outcome.figmaRasterById)
+        val figmaRasterWritten = injectFigmaRasterIntoBundle(bundleFile, outcome.figmaRasterById.keyedByBundleId())
         val semanticsLine =
           "  semantics:     $written / ${previewIds.size} preview(s) carried as " +
             "previews/<id>$BUNDLE_SEMANTICS_SUFFIX" +
@@ -1618,6 +1629,11 @@ internal object BundleReader {
     val backend: String,
     val previewIds: List<String>,
     val coverPreviewId: String?,
+    /**
+     * Raw discovery ids parallel to [previewIds] (schema ≥ the sanitised-entry-name change).
+     * Empty on older bundles — fall back to [previewIds], correct whenever no sanitising happened.
+     */
+    val rawPreviewIds: List<String> = emptyList(),
     val classpath: List<ClasspathEntry>,
     val modulePath: String,
     val producedBy: String,

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
@@ -532,8 +532,9 @@ private class PackSubcommand(private val args: List<String>) {
       if (meta.manifest.rawPreviewIds.size == previewIds.size) meta.manifest.rawPreviewIds
       else previewIds
     val bundleIdByRaw = rawIds.zip(previewIds).toMap()
-    fun <V> Map<String, V>.keyedByBundleId(): Map<String, V> =
-      entries.associate { (raw, v) -> (bundleIdByRaw[raw] ?: raw) to v }
+    fun <V> Map<String, V>.keyedByBundleId(): Map<String, V> = entries.associate { (raw, v) ->
+      (bundleIdByRaw[raw] ?: raw) to v
+    }
     val fetcher = DaemonSemanticsFetcher(onLog = { System.err.println("[daemon semantics] $it") })
     val outcome =
       fetcher.fetch(
@@ -562,11 +563,13 @@ private class PackSubcommand(private val args: List<String>) {
         // The layered `compose/figma-svg` export rides the same render (best-effort): carried so
         // the
         // design-catalog export can ship an editable vector per sticker beside the raster PNG.
-        val figmaSvgWritten = injectFigmaSvgIntoBundle(bundleFile, outcome.figmaSvgById.keyedByBundleId())
+        val figmaSvgWritten =
+          injectFigmaSvgIntoBundle(bundleFile, outcome.figmaSvgById.keyedByBundleId())
         // A hybrid figma-svg references `figma-raster/<node>.png` crops; carry them verbatim as
         // `previews/<id>.figma-raster/<node>.png` so the SVG's `<image>` layers resolve once the
         // export copies the SVG onto the delivery branch. Empty for the common vector-only case.
-        val figmaRasterWritten = injectFigmaRasterIntoBundle(bundleFile, outcome.figmaRasterById.keyedByBundleId())
+        val figmaRasterWritten =
+          injectFigmaRasterIntoBundle(bundleFile, outcome.figmaRasterById.keyedByBundleId())
         val semanticsLine =
           "  semantics:     $written / ${previewIds.size} preview(s) carried as " +
             "previews/<id>$BUNDLE_SEMANTICS_SUFFIX" +
@@ -1630,8 +1633,8 @@ internal object BundleReader {
     val previewIds: List<String>,
     val coverPreviewId: String?,
     /**
-     * Raw discovery ids parallel to [previewIds] (schema ≥ the sanitised-entry-name change).
-     * Empty on older bundles — fall back to [previewIds], correct whenever no sanitising happened.
+     * Raw discovery ids parallel to [previewIds] (schema ≥ the sanitised-entry-name change). Empty
+     * on older bundles — fall back to [previewIds], correct whenever no sanitising happened.
      */
     val rawPreviewIds: List<String> = emptyList(),
     val classpath: List<ClasspathEntry>,

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleSplit.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleSplit.kt
@@ -190,6 +190,16 @@ private fun perPreviewManifest(manifest: JsonObject, id: String, fullMode: Boole
     for ((key, value) in manifest) {
       when (key) {
         "previewIds" -> put(key, buildJsonArray { add(JsonPrimitive(id)) })
+        // Keep the raw-id list parallel to previewIds: subset to this preview's raw id (same
+        // index in the source lists), falling back to the bundle id when the source bundle
+        // predates the field or the lists disagree.
+        "rawPreviewIds" -> {
+          val bundleIds =
+            manifest["previewIds"]?.jsonArray?.map { it.jsonPrimitive.content } ?: emptyList()
+          val raws = value.jsonArray.map { it.jsonPrimitive.content }
+          val raw = bundleIds.indexOf(id).takeIf { it in raws.indices }?.let { raws[it] } ?: id
+          put(key, buildJsonArray { add(JsonPrimitive(raw)) })
+        }
         "coverPreviewId" -> put(key, JsonPrimitive(id))
         // View-only carries no re-render classpath, so record that honestly.
         "classpath" -> put(key, if (fullMode) value else JsonArray(emptyList()))

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
@@ -497,6 +497,7 @@ abstract class BundlePreviewTask : DefaultTask() {
         schemaVersion = BUNDLE_SCHEMA_VERSION,
         backend = backend.get(),
         previewIds = selected.map { bundleIds.getValue(it.id) },
+        rawPreviewIds = selected.map { it.id },
         coverPreviewId = coverId,
         classpath = classpathEntries,
         modulePath = modulePath.get(),

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewBundleFormat.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewBundleFormat.kt
@@ -137,10 +137,23 @@ data class BundleManifest(
   val schemaVersion: Int,
   /** Backend the bundle was packed for. v1 = "desktop"; "android" follows. */
   val backend: String,
-  /** Selected preview ids (matches `previews.json[].id`). First entry = cover. */
+  /**
+   * Selected preview ids in their in-bundle (entry-name) form — sanitised by
+   * `sanitizeBundleEntryId`, so no spaces or shell-hostile characters. First entry = cover.
+   */
   val previewIds: List<String>,
   /** Preview id whose PNG forms the polyglot's leading bytes. Usually `previewIds[0]`. */
   val coverPreviewId: String?,
+  /**
+   * The raw discovery ids (`previews.json[].id` as the producing module knows them), parallel to
+   * [previewIds] — same order, same length. Sanitisation is lossy (`"A B"` and `"A_B"` both become
+   * `A_B`), so a consumer that must address the producing module's daemon or renderer — which key
+   * strictly on the raw id, e.g. `bundle pack --with-semantics`'s per-preview semantics fetch —
+   * translates through this list instead of guessing. Empty on bundles packed before the field
+   * existed; readers fall back to [previewIds], which is correct whenever the raw id needed no
+   * sanitising.
+   */
+  val rawPreviewIds: List<String> = emptyList(),
   /**
    * Classpath in load order. First entry is always [ClasspathEntry.Module] for the inlined
    * `classes/app.jar`; remaining entries are [ClasspathEntry.Maven] coordinates the player resolves


### PR DESCRIPTION
## Summary

Fixes the `design-artifacts` wear-m3 failure from [run 30154657847](https://github.com/yschimke/compose-ai-tools/actions/runs/30154657847): `no semantics for: EdgeButton, TransformingLazyColumn, Layout/List, Template/TimeText, Template/PageIndicator, Template/EdgeButton` → `incomplete render — refusing to publish`.

**Root cause:** #2733 sanitised in-bundle preview ids (entry names + both manifests), but `bundle pack --with-semantics` kept feeding `manifest.previewIds` to `DaemonSemanticsFetcher` — and the daemon keys renders strictly on the **raw** discovery id. Every preview whose id needed sanitising (spaces, slashes) fetched nothing, and the catalog export's completeness gate correctly refused to publish.

**Fix:** sanitisation is lossy (`"A B"` and `"A_B"` both become `A_B`), so the manifest now carries the mapping instead of consumers guessing:

- `BundleManifest.rawPreviewIds` — raw discovery ids, parallel to `previewIds` (same order/length). Optional with an empty default, so older bundles decode unchanged and readers fall back to `previewIds` (correct whenever nothing needed sanitising).
- `BundlePreviewTask` populates it from the selection's raw ids.
- `BundleCommand.packSemanticsBlob` fetches semantics/layout/fonts/figma-svg/figma-raster by **raw** id and re-keys each returned map to the **bundle** form before injecting, so `previews/<id>.semantics.json` keeps matching the entry names readers reconstruct.
- `bundle split` subsets `rawPreviewIds` in lockstep with `previewIds` so per-preview manifests stay parallel.

## Test plan

- `:cli:test` — full suite green (includes the bundle split goldens exercising `perPreviewManifest`).
- `:gradle-plugin:test --tests "*SanitizeBundleEntryIdTest*"` — green.
- Non-visual data-plumbing change: no rendered surface differs; the end-to-end proof is the `design-artifacts.yml` wear-m3 job going green again, which I'll re-dispatch on `main` once this merges and confirm.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YPCREPCooaNqSreNChWn42)_