### PR TITLE
feat(discovery): support @Preview functions whose parameters are all defaulted

### DIFF
--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
@@ -1551,12 +1551,13 @@ object PreviewDiscovery {
         !isNotificationPreview &&
         !isGlanceAppWidgetPreview &&
         !isXrSubspacePreview &&
-        hasUnsupportedPreviewParameters(method, previewParameter)
+        hasUnsupportedPreviewParameters(classInfo, method, previewParameter)
     if (hasUnsupportedParameters) {
       warnings.add(
         "composePreview: skipping @Preview '${classInfo.name}.${method.name}' — " +
-          "method has parameter(s) without @PreviewParameter provider wiring. " +
-          "Only parameterless previews or @PreviewParameter-injected previews are supported."
+          "method has parameter(s) that are neither @PreviewParameter-injected nor fully " +
+          "defaulted. Supported shapes: no parameters, exactly one @PreviewParameter value, " +
+          "or a default for every parameter."
       )
       return
     }
@@ -1849,14 +1850,48 @@ object PreviewDiscovery {
   }
 
   private fun hasUnsupportedPreviewParameters(
+    classInfo: ClassInfo,
     method: MethodInfo,
     previewParameter: Pair<String, Int>?,
   ): Boolean {
     val userParameters = userPreviewParameters(method)
     if (userParameters.isEmpty()) return false
-    // Current renderer contract: preview methods are either parameterless,
-    // or take exactly one value sourced by @PreviewParameter.
-    return userParameters.size != 1 || previewParameter == null
+    // Renderer contract: preview methods are parameterless, take exactly one
+    // value sourced by @PreviewParameter, or have a default for *every*
+    // parameter.
+    if (previewParameter != null) return userParameters.size != 1
+    // All-defaults is the Studio contract too, and it's common in real
+    // codebases: production composables are frequently annotated `@Preview`
+    // in place, and they nearly always carry `modifier: Modifier = Modifier`.
+    // Rejecting them dropped 5 of JetLagged's 8 previews silently — the
+    // omission only surfaced at the very end of the catalog pipeline as
+    // "missing renders". The renderer needs no change: it resolves the
+    // composable with `getDeclaredComposableMethod(functionName)` and invokes
+    // it with no args, and androidx's ComposableMethod fills every parameter
+    // from Kotlin's synthetic `$default` bridge.
+    return !allParametersHaveDefaults(classInfo, method, userParameters.size)
+  }
+
+  /**
+   * True when [method]'s first [userParameterCount] Kotlin value parameters all declare a default,
+   * read from the class's `@kotlin.Metadata`.
+   *
+   * Bytecode alone can't answer this: Kotlin emits a single synthetic `<name>$default` bridge when
+   * *any* parameter has a default, so its presence doesn't imply *all* do. Invoking with an
+   * all-bits default mask when some parameter lacks a default would pass it `null`/`0` and NPE at
+   * render time, so require metadata to confirm before admitting the preview. Unreadable metadata
+   * degrades to `false` — the preview is skipped with the existing warning, i.e. today's behaviour.
+   */
+  internal fun allParametersHaveDefaults(
+    classInfo: ClassInfo,
+    method: MethodInfo,
+    userParameterCount: Int,
+  ): Boolean {
+    val parameters = ComposableSignature.parametersOf(classInfo, method)
+    // Metadata unreadable, or it disagrees with the JVM signature about how many parameters the
+    // author wrote — don't guess.
+    if (parameters.isEmpty() || parameters.size != userParameterCount) return false
+    return parameters.all { it.hasDefault }
   }
 
   private fun userPreviewParameters(method: MethodInfo): List<MethodParameterInfo> {

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewDiscoveryDefaultedParametersTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewDiscoveryDefaultedParametersTest.kt
@@ -1,0 +1,59 @@
+package ee.schimke.composeai.discovery
+
+import com.google.common.truth.Truth.assertThat
+import io.github.classgraph.ClassGraph
+import org.junit.Test
+
+/**
+ * Covers the rule that admits a `@Preview` whose parameters are *all* defaulted.
+ *
+ * Production composables are routinely annotated `@Preview` in place, and they nearly always carry
+ * `modifier: Modifier = Modifier`. Discovery used to reject any parameter that wasn't
+ * `@PreviewParameter`-injected, so those previews were dropped silently — 5 of JetLagged's 8
+ * vanished, and the loss only surfaced at the end of the catalog pipeline as "missing renders".
+ *
+ * The distinction cannot be made from bytecode alone: Kotlin emits one synthetic `<name>$default`
+ * bridge when *any* parameter has a default, so its presence says nothing about the rest. The rule
+ * therefore reads `@kotlin.Metadata`, which carries a per-parameter default flag.
+ */
+class PreviewDiscoveryDefaultedParametersTest {
+
+  /**
+   * Run [block] against the fixture facade inside an open ClassGraph scan — `ClassInfo.resource`,
+   * which the metadata read goes through, is only valid while the scan is open.
+   */
+  private fun allDefaults(simpleName: String, userParameterCount: Int): Boolean {
+    ClassGraph()
+      .enableClassInfo()
+      .enableMethodInfo()
+      .acceptPackages("ee.schimke.composeai.discovery")
+      .scan()
+      .use { scan ->
+        val classInfo =
+          scan.getClassInfo("ee.schimke.composeai.discovery.SignatureFixturesKt")
+            ?: error("fixture facade class not found")
+        // A defaulted function also emits a synthetic `<name>$default`; match the real one.
+        val method = classInfo.methodInfo.first { it.name == simpleName }
+        return PreviewDiscovery.allParametersHaveDefaults(classInfo, method, userParameterCount)
+      }
+  }
+
+  @Test
+  fun `a fully defaulted function is admitted`() {
+    assertThat(allDefaults("allDefaultedComponent", userParameterCount = 2)).isTrue()
+  }
+
+  @Test
+  fun `a partially defaulted function is rejected`() {
+    // sampleComponent defaults only `count` and `note`; `state` and `labels` are required, so
+    // invoking with an all-bits default mask would pass them null/0 and NPE at render time.
+    assertThat(allDefaults("sampleComponent", userParameterCount = 5)).isFalse()
+  }
+
+  @Test
+  fun `a metadata parameter-count mismatch is rejected rather than guessed`() {
+    // The caller derives the count from the JVM signature. If it disagrees with what the author
+    // wrote, the two views are out of sync and the safe answer is "not all defaulted".
+    assertThat(allDefaults("allDefaultedComponent", userParameterCount = 3)).isFalse()
+  }
+}

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/SignatureFixtures.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/SignatureFixtures.kt
@@ -14,3 +14,10 @@ fun sampleComponent(
 ) {}
 
 @Suppress("unused") fun noParams() {}
+
+/**
+ * Every parameter defaulted — the shape a production composable annotated `@Preview` in place
+ * almost always has (`modifier: Modifier = Modifier`). Discovery admits these.
+ */
+@Suppress("unused", "UNUSED_PARAMETER")
+fun allDefaultedComponent(modifier: String = "", count: Int = 1) {}

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
@@ -1532,6 +1532,65 @@ class DiscoveryFunctionalTest {
   }
 
   @Test
+  fun `composePreviewDiscover accepts a preview whose parameters are all defaulted`() {
+    val projectDir = createCmpTestProject()
+
+    File(projectDir, "src/main/kotlin/test/Previews.kt")
+      .writeText(
+        """
+        package test
+
+        import androidx.compose.foundation.background
+        import androidx.compose.foundation.layout.Box
+        import androidx.compose.foundation.layout.size
+        import androidx.compose.runtime.Composable
+        import androidx.compose.ui.Modifier
+        import androidx.compose.ui.graphics.Color
+        import androidx.compose.ui.tooling.preview.Preview
+        import androidx.compose.ui.unit.dp
+
+        // The shape a production composable annotated @Preview in place almost always has.
+        // Studio renders it by filling every parameter from Kotlin's synthetic ${'$'}default
+        // bridge, and so does our renderer — discovery must not drop it.
+        // `size` is a plain Int rather than a Color: an inline value class in the signature
+        // mangles the JVM method name (DefaultedPreview-iJQMabo), which is orthogonal to the
+        // rule under test.
+        @Preview(name = "Defaulted")
+        @Composable
+        fun DefaultedPreview(modifier: Modifier = Modifier, size: Int = 50) {
+            Box(modifier = modifier.size(size.dp).background(Color.Gray))
+        }
+
+        // Only SOME parameters defaulted: `label` is required, so an all-bits default mask
+        // would pass it null and NPE at render. Must still be skipped.
+        @Preview(name = "Partially defaulted")
+        @Composable
+        fun PartiallyDefaultedPreview(label: String, modifier: Modifier = Modifier) {
+            Box(modifier = modifier.size(label.length.dp).background(Color.Gray))
+        }
+        """
+          .trimIndent()
+      )
+
+    val result =
+      GradleRunner.create()
+        .withProjectDir(projectDir)
+        .withArguments("composePreviewDiscover", "--stacktrace")
+        .withPluginClasspath()
+        .build()
+
+    assertThat(result.task(":composePreviewDiscover")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+
+    val manifest =
+      json.decodeFromString<PreviewManifest>(
+        File(projectDir, "build/compose-previews/previews.json").readText()
+      )
+    val functionNames = manifest.previews.map { it.functionName }
+    assertThat(functionNames).contains("DefaultedPreview")
+    assertThat(functionNames).doesNotContain("PartiallyDefaultedPreview")
+  }
+
+  @Test
   fun `composePreviewDiscover discovers private preview methods`() {
     val projectDir = createCmpTestProject()
 
@@ -1640,7 +1699,10 @@ class DiscoveryFunctionalTest {
         .withPluginClasspath()
         .build()
 
-    assertThat(result.output).contains("parameter(s) without @PreviewParameter provider wiring")
+    // The warning now enumerates all three admitted shapes, since "no @PreviewParameter" stopped
+    // being the whole story once fully-defaulted parameter lists became renderable.
+    assertThat(result.output)
+      .contains("parameter(s) that are neither @PreviewParameter-injected nor fully defaulted")
     val manifest =
       json.decodeFromString<PreviewManifest>(
         File(projectDir, "build/compose-previews/previews.json").readText()


### PR DESCRIPTION
## Summary

Discovery rejected any preview parameter that wasn't `@PreviewParameter`-injected, so a production composable annotated `@Preview` **in place** was silently skipped — and those nearly always carry `modifier: Modifier = Modifier`. It cost JetLagged 5 of its 8 previews, and the loss only surfaced at the end of the catalog pipeline as "missing renders", naming components rather than the cause.

Studio renders these by filling every parameter from Kotlin's synthetic `$default` bridge. The renderer already does the same — `ComposePreviewStrategy` resolves the function with `getDeclaredComposableMethod(functionName)` and invokes it with no args, and androidx's `ComposableMethod` supplies the defaults — so only the discovery gate needed to change.

Admitting them requires knowing that **every** parameter has a default, which bytecode alone cannot answer: Kotlin emits one `$default` bridge when *any* parameter has one. The check therefore reads `@kotlin.Metadata` through the `ComposableSignature` reader already in this module, which carries a per-parameter default flag. Unreadable metadata, or a parameter count that disagrees with the JVM signature, stays rejected rather than guessed — a *required* parameter passed an all-bits default mask would arrive null and NPE at render.

## Visual impact

The affected components render identically either way — this changes *whether* they are discovered, not how they draw. JetLagged's catalog reaches these components today only via hand-written zero-arg wrapper previews added as a workaround; after this lands the production composable is discovered in place and the wrappers are deleted, producing the same pixels:

![JetLagged AverageTimeAsleepCard](``https://raw.githubusercontent.com/yschimke/compose-samples/bf57ae5d4268f131efd05691de57b7a798e24c34/images/cards-time-asleep/ideal__default__compact.png``)

## Test plan

- `:gradle-plugin-preview-discovery:test --tests "*PreviewDiscoveryDefaultedParametersTest*"` — new unit coverage for the all-defaulted / partially-defaulted / count-mismatch cases against real compiled `@kotlin.Metadata`.
- `:gradle-plugin:functionalTest --tests "*DiscoveryFunctionalTest*"` — new case compiles real Compose fixtures and asserts `DefaultedPreview` is discovered while `PartiallyDefaultedPreview` is not.
- End-to-end: the six compose-samples catalogs render through this pipeline; JetLagged is the one that regressed without it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RMHn8ZzptyeQQDx1tiVjj3)_