### PR TITLE
fix(design-artifacts): derive --source-repo from the git remote

### DIFF
--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -633,7 +633,47 @@ const previewBase =
 const repo =
   values["source-repo"] ||
   process.env.GITHUB_REPOSITORY ||
-  "yschimke/compose-ai-tools";
+  repoFromGitRemote() ||
+  fallbackRepo();
+
+/**
+ * `<owner>/<repo>` from the checkout's `origin` remote, or null.
+ *
+ * Covers the local/manual run: CI always exports $GITHUB_REPOSITORY, but a
+ * developer or agent generating a catalog by hand from a consumer repo has
+ * neither that nor `--source-repo`, and silently inheriting compose-ai-tools
+ * bakes README/asset links that RESOLVE but point at the wrong repository —
+ * worse than a 404, because nothing looks broken.
+ *
+ * owner/repo are the last two path segments of every GitHub remote form
+ * (`git@github.com:owner/repo.git`, `https://github.com/owner/repo`), and of
+ * the proxied remotes agent sandboxes rewrite to.
+ */
+function repoFromGitRemote() {
+  try {
+    const url = execFileSync("git", ["config", "--get", "remote.origin.url"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    const match = url.replace(/\.git$/, "").match(/[:/]([^/:]+)\/([^/]+)$/);
+    return match ? `${match[1]}/${match[2]}` : null;
+  } catch {
+    // Not a git checkout, or no origin — fall through to the warned default.
+    return null;
+  }
+}
+
+/** Last resort. Warn: every link in the bundle is about to point at this repo. */
+function fallbackRepo() {
+  const fallback = "yschimke/compose-ai-tools";
+  console.warn(
+    `could not determine the source repo (no --source-repo, no ` +
+      `$GITHUB_REPOSITORY, no git origin) — defaulting to ${fallback}. Every ` +
+      `README and asset link in this bundle will point there. Pass ` +
+      `--source-repo <owner>/<repo> if that is not where you publish.`,
+  );
+  return fallback;
+}
 
 // Bundle the in-browser CMP Wasm app into the branch (out/web/wasm/) and record
 // a `webRender` descriptor in catalog.json. `compose-preview serve --catalogs`


### PR DESCRIPTION
## Summary

`generate-design-catalog.mjs` resolved the source repo as `--source-repo` → `$GITHUB_REPOSITORY` → hardcoded `yschimke/compose-ai-tools`. CI always exports `GITHUB_REPOSITORY`, so it was fine there — but a local or agent-driven run from a *consumer* repo has neither and silently inherited `compose-ai-tools`, baking README and asset links that **resolve while pointing at the wrong repository**. That's worse than a 404, because nothing looks broken. Hit while generating the JetNews catalog by hand.

Adds a git-origin fallback ahead of the constant (owner/repo are the last two path segments of every GitHub remote form, including the rewritten remotes agent sandboxes use), and warns loudly when even that fails, naming the repo every link is about to point at.

## Test plan

- `node --check scripts/design-artifacts/generate-design-catalog.mjs`.
- Verified in this sandbox — where `GITHUB_REPOSITORY` is unset and the remote is proxy-rewritten — that the fallback yields `yschimke/compose-samples` rather than `yschimke/compose-ai-tools`.
- Non-visual (link plumbing) — no rendered surface changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RMHn8ZzptyeQQDx1tiVjj3)_