### PR TITLE
fix(renderer): never write a still PNG into a .gif output path

### DIFF
--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -1462,7 +1462,31 @@ abstract class RobolectricRenderTestBase(
             // Write a structured error sidecar instead so the panel
             // surfaces the real failure.
             val productFellThrough = job is ProductRenderJob && !longHandled && !gifHandled
-            if (productFellThrough) {
+            // The same reasoning applies to a CAPTURE job that targets a GIF —
+            // `@AnimatedPreview`, or `@FocusedPreview(gif = true)`. Those are
+            // CaptureRenderJobs, so the guard above never covered them: when the
+            // animated pass bailed (no frames, encoder refused, …) they fell
+            // through to the single `captureRoboImage` below and wrote PNG bytes
+            // to a `.gif` path. Nothing failed, the file looked plausible, and
+            // the extension lied to every consumer that trusts it — browser,
+            // Figma import, the preview server. Decide on the output extension,
+            // not the job type, so a still can never land under a `.gif` name.
+            val animatedCaptureFellThrough =
+              job is CaptureRenderJob &&
+                !animationHandled &&
+                !focusGifHandled &&
+                outputFile.extension.equals("gif", ignoreCase = true)
+            if (animatedCaptureFellThrough) {
+              RenderErrorSidecar.write(
+                outputFile,
+                IllegalStateException(
+                  "Animated capture on '${preview.id}' produced no GIF — refusing to " +
+                    "write a single-frame PNG into the .gif output path. Most often the " +
+                    "preview has an unbounded axis: pin widthDp AND heightDp on an " +
+                    "@AnimatedPreview so the frames share one fixed size."
+                ),
+              )
+            } else if (productFellThrough) {
               val modeName = scroll?.mode?.name ?: "?"
               val axisName = scroll?.axis?.name ?: "VERTICAL"
               RenderErrorSidecar.write(
@@ -1510,6 +1534,7 @@ abstract class RobolectricRenderTestBase(
             // extent / frame size, not the composable's intrinsic box.
             if (
               !productFellThrough &&
+                !animatedCaptureFellThrough &&
                 !longHandled &&
                 !gifHandled &&
                 !animationHandled &&


### PR DESCRIPTION
## Summary

When an `@AnimatedPreview`'s animated pass bailed — no frames captured, the GIF encoder refused — the capture fell through to the ordinary single `captureRoboImage`, which wrote **PNG bytes to the `.gif` output path**. Nothing failed and the file looked plausible, so the extension lied to every consumer that trusts it: browser, Figma import, the preview server. Found on a JetNews motion fixture whose height was unbounded; pinning `heightDp` produced a real 386 KB GIF from the identical composable.

The guard for this already existed — the `ProductRenderJob` branch even spells out the reasoning — but `@AnimatedPreview` and `@FocusedPreview(gif = true)` are `CaptureRenderJob`s, so it never covered them. The fix decides on the **output extension** rather than the job type: any capture targeting `.gif` that wasn't handled by an animated path now writes a `RenderErrorSidecar` naming the likely cause instead of a still, and is excluded from the wrapped-axis crop that would otherwise follow.

## Visual impact

There is no "after" image to embed, because the change is precisely a refusal to produce one: before, the pipeline emitted a `.gif` file containing PNG bytes; after, it emits an error sidecar and no file. What a *correctly* captured animated preview looks like — the same JetLagged/JetNews motion path, once the height is bounded — is the committed render:

![JetLagged fading-circle motion capture](https://raw.githubusercontent.com/yschimke/compose-samples/bf57ae5d4268f131efd05691de57b7a798e24c34/images/motion-fading-circle/ideal__default.png)

The broken output can't be shown inline for the obvious reason: GitHub won't render a `.gif` whose bytes are a PNG — which is the whole bug.

## Test plan

- `:renderer-android:compileDebugKotlin` — BUILD SUCCESSFUL.
- Reproduced the original corruption by magic-byte check on the emitted `.gif` (`89 50 4E 47` — PNG signature) before the change; the fixture that produced it now yields a sidecar instead.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RMHn8ZzptyeQQDx1tiVjj3)_