### PR TITLE
fix: treat renderFailed as terminal in the daemon wait loops

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DaemonSemanticsFetcher.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DaemonSemanticsFetcher.kt
@@ -16,6 +16,7 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import okio.FileSystem
 import okio.Path.Companion.toPath
@@ -101,11 +102,24 @@ internal class DaemonSemanticsFetcher(
       val latch = CountDownLatch(previewIds.size)
       live
         .onNotification { method, params ->
-          if (method != "renderFinished" || params == null) return@onNotification
+          val failed = method == "renderFailed"
+          if ((method != "renderFinished" && !failed) || params == null) return@onNotification
           val id = params["id"]?.jsonPrimitive?.contentOrNull ?: return@onNotification
-          // Count down on any finish for a pending id, regardless of pngPath — a failed render
-          // emits renderFinished without one, and we must not block forever waiting on it. Whether
-          // a sidecar actually materialised is decided by the disk read below.
+          // Count down on either terminal event for a pending id — the daemon owes exactly one
+          // (`renderFinished` OR `renderFailed`) per queued render, and a render whose composition
+          // throws emits only the latter. Waiting on `renderFinished` alone meant one broken
+          // preview burned the ENTIRE batch budget: a Glance composable reached through the plain
+          // `androidx.compose.ui.tooling.preview.Preview` annotation dies in the Compose applier
+          // within seconds, yet `bundle pack --with-semantics` sat out all 180s and then failed the
+          // whole catalog, reading as "the daemon hangs on widgets". Same fix ServeRenderHost
+          // already carries. Whether a sidecar actually materialised is decided by the disk read
+          // below, so a failure needs no special-casing beyond releasing the wait.
+          if (failed) {
+            val reason =
+              params["error"]?.jsonObject?.get("message")?.jsonPrimitive?.contentOrNull
+                ?: "daemon reported renderFailed"
+            onLog("render failed for '$id': $reason")
+          }
           if (pending.remove(id)) latch.countDown()
         }
         .use {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/MatrixRenderFetcher.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/MatrixRenderFetcher.kt
@@ -12,6 +12,7 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import okio.FileSystem
 import okio.Path.Companion.toPath
@@ -75,11 +76,26 @@ internal class MatrixRenderFetcher(
       val pngPath = AtomicReference<String?>(null)
       live
         .onNotification { method, params ->
-          if (method != "renderFinished" || params == null) return@onNotification
+          val failedEvent = method == "renderFailed"
+          if ((method != "renderFinished" && !failedEvent) || params == null) return@onNotification
           val id = params["id"]?.jsonPrimitive?.contentOrNull ?: return@onNotification
           if (id != previewId) return@onNotification
-          // `unchanged` renders still carry a (re-used) pngPath, so this captures bytes either way.
-          params["pngPath"]?.jsonPrimitive?.contentOrNull?.let { pngPath.set(it) }
+          // Either terminal event releases the cell — the daemon owes exactly one per queued
+          // render, and a composition that throws emits only `renderFailed`. Without this a broken
+          // preview made every cell sit out the full RENDER_TIMEOUT_SECONDS, so an N-cell matrix
+          // took N × 180s to report what the daemon knew in seconds. `pngPath` stays null on
+          // failure, which the caller already reads as "no PNG for this cell".
+          if (failedEvent) {
+            onLog(
+              "render failed for '$id': " +
+                (params["error"]?.jsonObject?.get("message")?.jsonPrimitive?.contentOrNull
+                  ?: "daemon reported renderFailed")
+            )
+          } else {
+            // `unchanged` renders still carry a (re-used) pngPath, so this captures bytes either
+            // way.
+            params["pngPath"]?.jsonPrimitive?.contentOrNull?.let { pngPath.set(it) }
+          }
           pending.get()?.countDown()
         }
         .use {

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/DaemonSemanticsFetcherTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/DaemonSemanticsFetcherTest.kt
@@ -35,6 +35,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonObject
 
 /**
  * Contract for [DaemonSemanticsFetcher]: with a fake [RenderSessionFactory] whose `renderNow`
@@ -170,6 +171,53 @@ class DaemonSemanticsFetcherTest {
   }
 
   @Test
+  fun `a renderFailed preview releases the wait instead of burning the render budget`() {
+    val projectDir = newTempFolder("semantics-render-failed")
+    writeDescriptor(projectDir)
+
+    // Alpha renders; Beta's composition throws, so the daemon emits `renderFailed` — the *other*
+    // terminal event — and never a `renderFinished`. This is what a Glance composable reached
+    // through the plain `androidx.compose.ui.tooling.preview.Preview` annotation does (jetchat's
+    // MessagesWidget previews): it dies in the Compose applier within seconds. The fetcher used to
+    // wait only on `renderFinished`, so one such preview sat out the entire 180s batch budget and
+    // failed the whole catalog pack.
+    val logs = mutableListOf<String>()
+    val fetcher =
+      DaemonSemanticsFetcher(
+        factory =
+          FakeFactory(
+            produced =
+              mapOf("AlphaPreview" to """{"root":{"nodeId":"1","boundsInRoot":"0,0,4,8"}}"""),
+            failedIds = mapOf("BetaPreview" to "java.lang.ClassCastException: GlanceNode"),
+          ),
+        onLog = { logs += it },
+      )
+
+    val startedAt = System.nanoTime()
+    val outcome =
+      fetcher.fetch(
+        projectDir = projectDir,
+        moduleName = "sample",
+        previewIds = listOf("AlphaPreview", "BetaPreview"),
+      )
+    val elapsedMs = (System.nanoTime() - startedAt) / 1_000_000
+
+    assertTrue(outcome is DaemonSemanticsFetcher.Outcome.Ok, "expected Ok, got $outcome")
+    assertEquals(setOf("AlphaPreview"), outcome.semanticsById.keys)
+    // The failure must be reported, not swallowed into a generic timeout.
+    assertTrue(
+      logs.any { "render failed for 'BetaPreview'" in it && "GlanceNode" in it },
+      "the daemon's failure message must be surfaced, got: $logs",
+    )
+    assertTrue(
+      logs.none { "timed out" in it },
+      "a reported failure must not degrade into a timeout, got: $logs",
+    )
+    // Guard the regression directly: with the bug, this fetch blocks for the full 180s budget.
+    assertTrue(elapsedMs < 30_000, "fetch should return promptly, took ${elapsedMs}ms")
+  }
+
+  @Test
   fun `missing descriptor returns DescriptorMissing`() {
     val projectDir = newTempFolder("semantics-no-descriptor")
     val fetcher = DaemonSemanticsFetcher(factory = FakeFactory(emptyMap()))
@@ -210,6 +258,7 @@ class DaemonSemanticsFetcherTest {
   private class FakeFactory(
     private val produced: Map<String, String>,
     private val fontsProduced: Map<String, String> = emptyMap(),
+    private val failedIds: Map<String, String> = emptyMap(),
   ) : RenderSessionFactory {
     override val backendKind: RenderSessionBackend = RenderSessionBackend.Subprocess
 
@@ -218,6 +267,7 @@ class DaemonSemanticsFetcherTest {
         workspaceRoot = config.workspaceRoot.absolutePath,
         produced = produced,
         fontsProduced = fontsProduced,
+        failedIds = failedIds,
         dataRoot = File(config.workspaceRoot, "build/compose-previews/data"),
       )
   }
@@ -232,14 +282,16 @@ class DaemonSemanticsFetcherTest {
   /**
    * Minimal [RenderSession] modelling the real daemon's async render: [renderNow] writes the
    * always-on `compose-semantics.json` sidecar for every preview it has canned content for, then
-   * emits a `renderFinished` notification per requested id (the signal the fetcher waits on before
-   * reading the files). Every other method throws.
+   * emits one terminal notification per requested id — `renderFailed` for ids in [failedIds],
+   * `renderFinished` otherwise. Both are signals the fetcher must stop waiting on. Every other
+   * method throws.
    */
   private class FakeSession(
     override val workspaceRoot: String,
     private val produced: Map<String, String>,
     private val dataRoot: File,
     private val fontsProduced: Map<String, String> = emptyMap(),
+    private val failedIds: Map<String, String> = emptyMap(),
   ) : RenderSession {
     private val listeners = java.util.concurrent.CopyOnWriteArrayList<NotificationListener>()
 
@@ -274,6 +326,18 @@ class DaemonSemanticsFetcherTest {
       timeout: kotlin.time.Duration,
     ): RenderNowResult {
       for (id in previewIds) {
+        val failure = failedIds[id]
+        if (failure != null) {
+          // A render whose composition throws emits `renderFailed` and *no* `renderFinished` — the
+          // daemon owes exactly one terminal event per queued render.
+          val params =
+            kotlinx.serialization.json.buildJsonObject {
+              put("id", id)
+              putJsonObject("error") { put("message", failure) }
+            }
+          listeners.forEach { it.onNotification("renderFailed", params) }
+          continue
+        }
         produced[id]?.let { content ->
           val dir = File(dataRoot, id).also { it.mkdirs() }
           File(dir, "compose-semantics.json").writeText(content)
@@ -282,8 +346,8 @@ class DaemonSemanticsFetcherTest {
           val dir = File(dataRoot, id).also { it.mkdirs() }
           File(dir, "fonts-used.json").writeText(content)
         }
-        // Emit renderFinished for *every* requested id — including ones that wrote no sidecar — so
-        // the fetcher's wait completes (a failed render still finishes) rather than timing out.
+        // Emit renderFinished for every remaining id — including ones that wrote no sidecar — so
+        // the fetcher's wait completes rather than timing out.
         val params =
           kotlinx.serialization.json.buildJsonObject {
             put("id", id)

--- a/render-session/cli/src/main/kotlin/ee/schimke/composeai/render/cli/RenderCli.kt
+++ b/render-session/cli/src/main/kotlin/ee/schimke/composeai/render/cli/RenderCli.kt
@@ -9,6 +9,7 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import kotlin.system.exitProcess
 import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 
 /**
@@ -35,9 +36,11 @@ import kotlinx.serialization.json.jsonPrimitive
  * published JAR will fail with `NoClassDefFoundError` — see the "CLI invocation" section in
  * `docs/NON_GRADLE_INTEGRATION.md`.
  *
- * `--previews` accepts a comma-separated list and can be repeated. The CLI waits for one
- * `renderFinished` notification per requested preview id, prints the resulting PNG path to stdout
- * (`<id>\t<pngPath>`), and exits 0 on success.
+ * `--previews` accepts a comma-separated list and can be repeated. The CLI waits for one terminal
+ * notification per requested preview id — `renderFinished` (success) or `renderFailed` (the
+ * composition threw) — prints the resulting PNG path to stdout (`<id>\t<pngPath>`), and exits 0
+ * when every render succeeded. A `renderFailed` ends the wait immediately and reports the daemon's
+ * error message on stderr rather than sitting out `--timeout-seconds`.
  *
  * Exit codes: `0` = all renders succeeded, `1` = at least one render rejected, failed, or timed
  * out, `2` = argument parsing failure.
@@ -62,6 +65,7 @@ public object RenderCli {
   internal fun run(parsed: ParsedArgs): Int {
     val pending = ConcurrentHashMap.newKeySet<String>().apply { addAll(parsed.previewIds) }
     val results = ConcurrentHashMap<String, String>()
+    val failures = ConcurrentHashMap<String, String>()
     val latch = CountDownLatch(parsed.previewIds.size)
 
     SubprocessRenderSessions.open(
@@ -75,14 +79,27 @@ public object RenderCli {
       .use { session ->
         session
           .onNotification { method, params ->
-            if (method != "renderFinished" || params == null) return@onNotification
+            if (params == null) return@onNotification
             val id = params["id"]?.jsonPrimitive?.contentOrNull ?: return@onNotification
-            val pngPath = params["pngPath"]?.jsonPrimitive?.contentOrNull
-            if (id in pending && pngPath != null) {
-              results[id] = pngPath
-              pending.remove(id)
-              latch.countDown()
+            if (id !in pending) return@onNotification
+            // The daemon owes exactly one terminal event per queued render: `renderFinished` with a
+            // pngPath, or `renderFailed` when the composition throws. Releasing the wait on the
+            // failure too turns a broken preview into an immediate, explanatory exit 1 instead of
+            // sitting out `--timeout-seconds` for a render the daemon already reported dead.
+            when (method) {
+              "renderFinished" -> {
+                val pngPath =
+                  params["pngPath"]?.jsonPrimitive?.contentOrNull ?: return@onNotification
+                results[id] = pngPath
+              }
+              "renderFailed" ->
+                failures[id] =
+                  params["error"]?.jsonObject?.get("message")?.jsonPrimitive?.contentOrNull
+                    ?: "daemon reported renderFailed"
+              else -> return@onNotification
             }
+            pending.remove(id)
+            latch.countDown()
           }
           .use {
             val ack =
@@ -104,6 +121,13 @@ public object RenderCli {
                 "render-cli: timed out after ${parsed.timeoutSeconds}s waiting for: " +
                   pending.joinToString(",")
               )
+              return 1
+            }
+
+            if (failures.isNotEmpty()) {
+              for ((id, message) in failures) {
+                System.err.println("render-cli: failed $id: $message")
+              }
               return 1
             }
 


### PR DESCRIPTION
## Summary

`renderNow` only queues; the daemon then owes exactly **one** terminal notification per queued render — `renderFinished` on success, or `renderFailed` when the composition throws. Three wait loops listened for `renderFinished` alone, so a preview that *failed* never released its latch and the caller sat out its entire budget before reporting a generic timeout.

That is what jetchat's Glance app-widget previews hit. `MessagesWidget` and `MessageItem` are Glance composables reached through the plain `androidx.compose.ui.tooling.preview.Preview` annotation, so discovery classifies them `COMPOSE` and the daemon renders them down the Compose applier path, where they die in seconds. `bundle pack --with-semantics` nevertheless blocked for the full 180 s and then failed the whole catalog:

```
[daemon semantics] timed out after 180s waiting for renders:
  ...MessagesWidgetKt.WidgetPreview,...MessagesWidgetKt.MessageItemPreview
```

- `DaemonSemanticsFetcher` now counts a failure down and logs the daemon's message, so `bundle pack` reports which preview broke and why, and carries the previews that did render.
- `MatrixRenderFetcher` releases the in-flight cell, so an N-cell matrix over a broken preview no longer costs N × 180 s.
- `RenderCli` collects failures and exits 1 with `failed <id>: <message>` instead of timing out — matching the exit codes its KDoc already documents.

`ServeRenderHost` already carried this fix (with a comment describing the same symptom profiled on the confetti-mobile bundle); these three are the remaining copies of the same wait loop.

Note this makes the failure *fast and legible*, it does not make Glance-via-`@Preview` render. That's a separate discovery-classification question.

## Test plan

- `:cli:test --tests "*DaemonSemanticsFetcherTest*" --tests "*MatrixRenderFetcherTest*"` — green. New case drives a fake session that emits `renderFailed` for one of two previews and asserts the fetch returns promptly, surfaces the daemon's message, logs no timeout, and still carries the preview that succeeded. The elapsed-time assertion fails outright (180 s) against the old code.
- `:render-cli:test` — green.
- `ktfmtCheckAll` — green.
- Non-visual (wait-loop plumbing) — no rendered surface changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RMHn8ZzptyeQQDx1tiVjj3)_