### PR TITLE
feat(serve): list the compose-samples catalogs on preview.coo.ee

### DIFF
--- a/deploy/image/entrypoint.sh
+++ b/deploy/image/entrypoint.sh
@@ -30,7 +30,7 @@ fi
 # The published catalog set is BAKED INTO THE IMAGE (same `:=` + `none` convention
 # as SERVE_TRUST_STORE below), so a bare `docker pull` / Watchtower auto-update
 # self-heals without editing the box's compose. Front-page systems:
-: "${SERVE_CATALOGS:=compose-m3,wear-m3,remote-m3,meshcore-mobile@yschimke/meshcore-mobile,homeassistant-remotecompose@yschimke/homeassistant-remotecompose,confetti-wear@joreilly/Confetti,confetti-mobile@joreilly/Confetti}"
+: "${SERVE_CATALOGS:=compose-m3,wear-m3,remote-m3,meshcore-mobile@yschimke/meshcore-mobile,homeassistant-remotecompose@yschimke/homeassistant-remotecompose,jetnews@yschimke/compose-samples,jetcaster@yschimke/compose-samples,jetchat@yschimke/compose-samples,jetsnack@yschimke/compose-samples,jetlagged@yschimke/compose-samples,reply@yschimke/compose-samples,confetti-wear@joreilly/Confetti,confetti-mobile@joreilly/Confetti}"
 [[ "${SERVE_CATALOGS}" != "none" ]] && args+=(--catalogs "${SERVE_CATALOGS}")
 # …and cadence, served UNLISTED from its own repo — reachable at /cadence/ (and ?session=cadence)
 # but kept OFF the front-page index. (meshcore-mobile / homeassistant-remotecompose are LISTED above

--- a/deploy/vps/docker-compose.yml
+++ b/deploy/vps/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       # serves the in-browser CMP tier from the image's local wasm build via
       # SERVE_WASM_DIR. For a token-gated box, set SERVE_PUBLIC=0 + SERVE_TOKEN.
       SERVE_PUBLIC: "${SERVE_PUBLIC:-1}"
-      SERVE_CATALOGS: "${SERVE_CATALOGS:-compose-m3,wear-m3,remote-m3,meshcore-mobile@yschimke/meshcore-mobile,homeassistant-remotecompose@yschimke/homeassistant-remotecompose}"
+      SERVE_CATALOGS: "${SERVE_CATALOGS:-compose-m3,wear-m3,remote-m3,meshcore-mobile@yschimke/meshcore-mobile,homeassistant-remotecompose@yschimke/homeassistant-remotecompose,jetnews@yschimke/compose-samples,jetcaster@yschimke/compose-samples,jetchat@yschimke/compose-samples,jetsnack@yschimke/compose-samples,jetlagged@yschimke/compose-samples,reply@yschimke/compose-samples}"
       # cadence is served UNLISTED from its own repo — reachable at /cadence/ (and ?session=cadence)
       # but kept OFF the front-page index. (meshcore-mobile / homeassistant-remotecompose are LISTED
       # above so they DO show on the front page.) <system>@<owner>/<repo> points serve at each app's

--- a/trust/producers.json
+++ b/trust/producers.json
@@ -1,6 +1,5 @@
 {
   "_comment": "Producer-trust allowlist for a public `compose-preview serve --trust-store`. Three independent bases — pinned Ed25519 keys, trusted GitHub branches (origin trust), and CI provenance identities. A bundle/catalog the server can attribute to one of these is shown as trusted (and, with operator opt-in, eligible for server-side re-render of its executable Compose); everything else still serves its data tiers as `unverified`. Empty = trust nothing (fail-closed). See docs/public-preview-server.md.",
-
   "keys": [
     {
       "keyId": "compose-ai-tools-ci",
@@ -9,7 +8,6 @@
       "publicKey": "REPLACE_WITH_BASE64_ED25519_PUBLIC_KEY"
     }
   ],
-
   "branches": [
     {
       "repo": "yschimke/compose-ai-tools",
@@ -26,9 +24,12 @@
     {
       "repo": "yschimke/cadence",
       "branch": "design-artifacts/*"
+    },
+    {
+      "repo": "yschimke/compose-samples",
+      "branch": "design-artifacts/*"
     }
   ],
-
   "oidc": [
     {
       "_comment": "Advisory until full Sigstore/Fulcio+Rekor verification lands — an oidc entry only annotates a signature a pinned key already verified; it does not by itself grant trust.",


### PR DESCRIPTION
## Summary

Adds the six sample catalogs published from `yschimke/compose-samples` — `design-artifacts/{jetnews,jetcaster,jetchat,jetsnack,jetlagged,reply}` — to the front-page catalog set, and trusts that repo's `design-artifacts/*` so they badge **Trusted (Branch)** rather than Unverified.

`jetcaster-wear` is deliberately unlisted: 9 of its 12 previews take a `@PreviewParameter`, which the daemon render path gives no data products, so it cannot pass the catalog completeness gate yet.

`deploy/image/docker-compose.yml` needs no change — it passes `SERVE_CATALOGS` through empty and inherits the entrypoint's baked default.

## Visual impact

This change is a *listing* — it adds entries to the front page; the catalog pages themselves are rendered from the delivery branches and are unchanged by this diff. The pixels the front page now surfaces are already published and committed. Two of them, at the commits the branches currently point at:

**JetNews — home feed (`screens-home-feed`)**

![JetNews home feed](https://raw.githubusercontent.com/yschimke/compose-samples/30cfbfa865aac32a8c1ef9b7c5640f852993311f/images/screens-home-feed/ideal__default.png)

**JetNews — popular post card (`postcard-popular`), light and dark**

![PostCardPopular light](``https://raw.githubusercontent.com/yschimke/compose-samples/30cfbfa865aac32a8c1ef9b7c5640f852993311f/images/postcard-popular/ideal__default__compact.png``)
![PostCardPopular dark](``https://raw.githubusercontent.com/yschimke/compose-samples/30cfbfa865aac32a8c1ef9b7c5640f852993311f/images/postcard-popular/ideal__default__dark__compact.png)``

I could not screenshot the deployed front page itself from this container — it renders against the live server, which isn't reachable here. The listing is verifiable by reading `deploy/image/entrypoint.sh`'s `SERVE_CATALOGS` default and confirming each branch exists (all six do, listed above).

## Test plan

- All six `design-artifacts/*` branches confirmed present on `yschimke/compose-samples` and carrying `catalog.json` + `images/`.
- `jq . trust/producers.json` — valid.
- Deploy-config change only; the render pipeline is untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RMHn8ZzptyeQQDx1tiVjj3)_