### PR TITLE
fix(rc-player): only adopt same-component ComponentValues nested in containers

### DIFF
--- a/cli/src/main/resources/rc-player/bundle.js
+++ b/cli/src/main/resources/rc-player/bundle.js
@@ -9566,6 +9566,7 @@ var RC = (() => {
                 contentOp.setComponent(this);
               }
               this.mContentOps.push(contentOp);
+              this.hoistNestedComponentValues(contentOp);
             }
           }
           if (op instanceof CanvasContent) {
@@ -9583,6 +9584,7 @@ var RC = (() => {
           } else {
             this.mContentOps.push(op);
           }
+          this.hoistNestedComponentValues(op);
         }
       }
       if (!this.mWidthMod) {
@@ -9668,6 +9670,30 @@ var RC = (() => {
       return -1;
     }
     // --- ComponentValue (Java ComponentData pattern) ---
+    /**
+     * Collect ComponentValue bindings that live *inside* a content container (e.g.
+     * a `CanvasOperations` draw block) so this component's measured size reaches
+     * them via updateComponentValues. Without this, a CanvasOperations fill whose
+     * path geometry is built from `FloatExpression`s reading WIDTH/HEIGHT sees
+     * those variables unset (zero) and draws an empty path. Recurses through
+     * non-Component containers only — a nested child `Component` owns and collects
+     * its own ComponentValues in its own `inflate()`.
+     */
+    hoistNestedComponentValues(op) {
+      if (op instanceof Component) return;
+      const getList = op.getList;
+      if (typeof getList !== "function") return;
+      for (const child of getList.call(op)) {
+        if (child instanceof ComponentValue) {
+          if (child.getComponentId2() === this.getComponentId()) {
+            if (this.mComponentValues === null) this.mComponentValues = [];
+            this.mComponentValues.push(child);
+          }
+        } else {
+          this.hoistNestedComponentValues(child);
+        }
+      }
+    }
     /** Update bound float variables with this component's dimensions/position.
      *  Matches Java Component.updateComponentValues — called during both measure
      *  (for WIDTH/HEIGHT) and layout (for all types including POS_X/POS_Y). */

--- a/third_party/remote-compose-player/src/core/operations/layout/LayoutComponent.ts
+++ b/third_party/remote-compose-player/src/core/operations/layout/LayoutComponent.ts
@@ -168,6 +168,7 @@ export class LayoutComponent extends Component {
                             (contentOp as any).setComponent(this);
                         }
                         this.mContentOps.push(contentOp);
+                        this.hoistNestedComponentValues(contentOp);
                     }
                 }
                 if (op instanceof CanvasContent) {
@@ -186,6 +187,7 @@ export class LayoutComponent extends Component {
                 } else {
                     this.mContentOps.push(op);
                 }
+                this.hoistNestedComponentValues(op);
             }
         }
 
@@ -290,6 +292,37 @@ export class LayoutComponent extends Component {
     }
 
     // --- ComponentValue (Java ComponentData pattern) ---
+
+    /**
+     * Collect ComponentValue bindings that live *inside* a content container (e.g.
+     * a `CanvasOperations` draw block) so this component's measured size reaches
+     * them via updateComponentValues. Without this, a CanvasOperations fill whose
+     * path geometry is built from `FloatExpression`s reading WIDTH/HEIGHT sees
+     * those variables unset (zero) and draws an empty path. Recurses through
+     * non-Component containers only — a nested child `Component` owns and collects
+     * its own ComponentValues in its own `inflate()`.
+     */
+    private hoistNestedComponentValues(op: Operation): void {
+        if (op instanceof Component) return;
+        const getList = (op as { getList?: () => Operation[] }).getList;
+        if (typeof getList !== 'function') return;
+        for (const child of getList.call(op)) {
+            if (child instanceof ComponentValue) {
+                // Only adopt a binding that actually targets *this* component.
+                // updateComponentValues writes this component's dimensions to every
+                // entry, so a nested cross-component reference (its own
+                // `getComponentId2()`) must be left alone — it's resolved against
+                // its real target by ComponentValue.apply, and adopting it here
+                // would clobber that value with our dimensions each measure.
+                if (child.getComponentId2() === this.getComponentId()) {
+                    if (this.mComponentValues === null) this.mComponentValues = [];
+                    this.mComponentValues.push(child);
+                }
+            } else {
+                this.hoistNestedComponentValues(child);
+            }
+        }
+    }
 
     /** Update bound float variables with this component's dimensions/position.
      *  Matches Java Component.updateComponentValues — called during both measure


### PR DESCRIPTION
## Summary

`LayoutComponent.inflate` collected `ComponentValue` bindings only from its direct `LayoutComponentContent`. This extends collection to `ComponentValue`s nested one or more levels deep inside a **content container** (e.g. a `CanvasOperations` draw block), so a binding that targets *this* component is updated with its measured size by `updateComponentValues`.

Crucially — per review — it hoists a nested binding **only when it targets the enclosing component** (`getComponentId2() === getComponentId()`). A cross-component reference is left alone, so it's resolved against its real target by `ComponentValue.apply` instead of being clobbered by this component's dimensions on every measure. Recurses through non-`Component` containers only (a nested child `Component` owns its own bindings).

## Scope correction (what this does *not* fix)

I opened this expecting it to make the Material3 button/card fill *shape* render. Investigation showed it doesn't, and why: the button's fill-path WIDTH/HEIGHT `ComponentValue`s target component id **-6** (a sentinel), not the structurally-enclosing `RowLayout` — so under the correct same-component filter they aren't hoisted, and they resolve to `0` because the player's `doc.getComponent(-6)` doesn't resolve that sentinel.

So this PR is now the **narrow, safe correctness change** (adopt only genuinely same-component nested bindings, and avoid the cross-component clobber a naive hoist would cause). The fill *shape* stays blocked by two separate, deeper bugs, both tracked in #2741 for a fix here and upstream:

1. **sentinel/negative component-id resolution** — `ComponentValue.apply` resolves `doc.getComponent(-6)` to nothing, so WIDTH/HEIGHT read `0`;
2. **`CanvasPaintContext.buildPath2D` coordinate dereference** — it reads NaN-id path *coordinates* as literal floats (`→ NaN →` empty path) instead of dereferencing them.

## Test plan

- Rebuilt the IIFE bundle + regenerated the committed CLI resource.
- Headless render of all 19 `remote-m3` `.rc` docs: 19/19 render, mean mismatch holds at 12.51% with **no regressions**.
- Verified the filter drops the button's sentinel-targeted (`-6`) bindings rather than clobbering them, and adopts only same-component ones.

---
_Generated by [Claude Code](https://claude.ai/code/session_011K7sgCfdsbhN7fwMb3WhSS)_