### PR TITLE
ci: catch agent attribution that reaches main, not just PRs

### DIFF
--- a/.github/scripts/agent-attribution-scan.sh
+++ b/.github/scripts/agent-attribution-scan.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Shared agent-attribution detector for the "No Agent Attribution" gate.
+#
+# Two callers, one implementation — a PR-layer check that blocks the merge and a
+# post-merge drift check on `main`. They MUST agree, so the matching lives here
+# rather than being copy-pasted into each job: a gate that disagrees with itself
+# is worse than no gate.
+#
+# Usage:
+#   agent-attribution-scan.sh --range <base>..<head> [--text-file <file>]
+#
+#   --range      commit range to scan for author/committer identity and for
+#                Co-authored-by trailers in the commit messages.
+#   --text-file  extra text to scan for trailers (the PR title + body, which the
+#                squash commit is built from). Optional — the drift check has no
+#                PR to read.
+#
+# Exits 1 and prints the offending records when anything is found, 0 otherwise.
+#
+# Keep AGENT_NAME / AGENT_EMAIL in sync with .githooks/commit-msg and the
+# workflow's documentation block.
+set -uo pipefail
+
+AGENT_NAME='(Claude|Codex|ChatGPT|Copilot|Gemini)'
+AGENT_EMAIL='@(anthropic|openai)[.]com'
+
+range=""
+text_file=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --range) range="${2:-}"; shift 2 ;;
+    --text-file) text_file="${2:-}"; shift 2 ;;
+    *) printf 'agent-attribution-scan: unknown argument: %s\n' "$1" >&2; exit 2 ;;
+  esac
+done
+[ -n "$range" ] || { printf 'agent-attribution-scan: --range is required\n' >&2; exit 2; }
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT
+
+problems=""
+
+# 1. Author / committer identity of every commit in the range.
+#
+#    This is also what produces a `Co-authored-by:` trailer on `main`: GitHub's
+#    squash credits every distinct commit author of the branch as a co-author,
+#    so an agent identity here lands a trailer even when the PR title and body
+#    are spotless. That is not hypothetical — it is how commit 5aacb786 got its
+#    `Co-authored-by: Claude` line.
+#
+#    One record per identity: <sha>\t<role>\t<name>\t<email>.
+git log \
+  --format='%H%x09author%x09%an%x09%ae%x0a%H%x09committer%x09%cn%x09%ce' \
+  "$range" > "$workdir/idents.txt"
+# tolower() rather than IGNORECASE so this holds on mawk (the default awk on
+# ubuntu-latest) as well as gawk. The email match is a substring (any
+# …@anthropic.com / …@openai.com address), but the NAME match is anchored to the
+# whole identity ("^…$") so it catches an identity set literally to
+# "Claude"/"Codex"/… without snagging a human whose name merely contains the
+# token ("Claude Martin", "Alice Copilotson") — and it naturally exempts GitHub
+# App bots, whose name is "claude[bot]", not "claude".
+ident_hits="$(awk -F'\t' -v nre="$AGENT_NAME" -v ere="$AGENT_EMAIL" '
+  BEGIN { nre = tolower(nre); ere = tolower(ere) }
+  tolower($4) ~ ere            { print; next }
+  tolower($3) ~ ("^" nre "$")  { print }
+' "$workdir/idents.txt" || true)"
+if [ -n "$ident_hits" ]; then
+  problems="${problems}Commit author/committer identity is an agent:
+${ident_hits}
+"
+fi
+
+# 2. Co-authored-by trailers (start-of-line only) in commit messages, and in the
+#    supplied text (PR title + body) when given — flagged when the name or email
+#    is an agent. Trailer position only, so prose that merely *mentions* a
+#    trailer does not trip the gate.
+{
+  git log --format='%B' "$range"
+  [ -n "$text_file" ] && cat "$text_file"
+} > "$workdir/all_text.txt"
+
+coauthor_hits="$(grep -iE '^[[:space:]]*Co-authored-by:' "$workdir/all_text.txt" \
+                 | grep -Ei "Co-authored-by:[[:space:]]*${AGENT_NAME}|${AGENT_EMAIL}" \
+                 || true)"
+if [ -n "$coauthor_hits" ]; then
+  problems="${problems}Agent Co-authored-by trailer(s):
+${coauthor_hits}
+"
+fi
+
+if [ -n "$problems" ]; then
+  printf '%s\n' "$problems" >&2
+  exit 1
+fi
+
+echo "No agent co-author trailers or agent commit identities found."

--- a/.github/scripts/agent-attribution-scan.sh
+++ b/.github/scripts/agent-attribution-scan.sh
@@ -7,15 +7,26 @@
 # is worse than no gate.
 #
 # Usage:
-#   agent-attribution-scan.sh --range <base>..<head> [--text-file <file>]
+#   agent-attribution-scan.sh --range <rev-arg> [--text-file <file>]
 #
-#   --range      commit range to scan for author/committer identity and for
-#                Co-authored-by trailers in the commit messages.
+#   --range      any `git log` revision argument — a range (<base>..<head>) or a
+#                single commit (meaning "everything reachable from it"). Scanned
+#                for author/committer identity and for Co-authored-by trailers
+#                in the commit messages.
 #   --text-file  extra text to scan for trailers (the PR title + body, which the
 #                squash commit is built from). Optional — the drift check has no
 #                PR to read.
 #
-# Exits 1 and prints the offending records when anything is found, 0 otherwise.
+# Exit codes:
+#   0  nothing found
+#   1  agent attribution found (records printed to stderr)
+#   2  could not scan — bad arguments, or a revision that does not resolve
+#
+# FAIL CLOSED. `git log` on an unresolvable revision exits nonzero and writes
+# nothing; with only `set -uo pipefail` that used to sail through both checks
+# and report "No agent ... found" with exit 0 — a security gate silently
+# passing because it scanned an empty set. Every `git log` status is therefore
+# checked explicitly, and an unresolvable revision is exit 2, never exit 0.
 #
 # Keep AGENT_NAME / AGENT_EMAIL in sync with .githooks/commit-msg and the
 # workflow's documentation block.
@@ -49,9 +60,14 @@ problems=""
 #    `Co-authored-by: Claude` line.
 #
 #    One record per identity: <sha>\t<role>\t<name>\t<email>.
-git log \
+if ! git log \
   --format='%H%x09author%x09%an%x09%ae%x0a%H%x09committer%x09%cn%x09%ce' \
-  "$range" > "$workdir/idents.txt"
+  "$range" > "$workdir/idents.txt" 2> "$workdir/git.err"; then
+  printf 'agent-attribution-scan: cannot resolve revision argument %s — refusing to report clean.\n' \
+    "$range" >&2
+  sed 's/^/  git: /' "$workdir/git.err" >&2
+  exit 2
+fi
 # tolower() rather than IGNORECASE so this holds on mawk (the default awk on
 # ubuntu-latest) as well as gawk. The email match is a substring (any
 # …@anthropic.com / …@openai.com address), but the NAME match is anchored to the
@@ -74,10 +90,20 @@ fi
 #    supplied text (PR title + body) when given — flagged when the name or email
 #    is an agent. Trailer position only, so prose that merely *mentions* a
 #    trailer does not trip the gate.
-{
-  git log --format='%B' "$range"
-  [ -n "$text_file" ] && cat "$text_file"
-} > "$workdir/all_text.txt"
+if ! git log --format='%B' "$range" > "$workdir/messages.txt" 2> "$workdir/git.err"; then
+  printf 'agent-attribution-scan: cannot read commit messages for %s — refusing to report clean.\n' \
+    "$range" >&2
+  sed 's/^/  git: /' "$workdir/git.err" >&2
+  exit 2
+fi
+cat "$workdir/messages.txt" > "$workdir/all_text.txt"
+if [ -n "$text_file" ]; then
+  if ! cat "$text_file" >> "$workdir/all_text.txt"; then
+    printf 'agent-attribution-scan: cannot read --text-file %s — refusing to report clean.\n' \
+      "$text_file" >&2
+    exit 2
+  fi
+fi
 
 coauthor_hits="$(grep -iE '^[[:space:]]*Co-authored-by:' "$workdir/all_text.txt" \
                  | grep -Ei "Co-authored-by:[[:space:]]*${AGENT_NAME}|${AGENT_EMAIL}" \

--- a/.github/workflows/no-agent-attribution.yml
+++ b/.github/workflows/no-agent-attribution.yml
@@ -83,8 +83,19 @@ jobs:
           # rather than interpolated into the shell.
           { printf '%s\n' "${PR_TITLE:-}"; printf '%s\n' "${PR_BODY:-}"; } > pr_text.txt
 
-          if ! .github/scripts/agent-attribution-scan.sh \
-                 --range "${BASE_SHA}..${HEAD_SHA}" --text-file pr_text.txt; then
+          .github/scripts/agent-attribution-scan.sh \
+            --range "${BASE_SHA}..${HEAD_SHA}" --text-file pr_text.txt
+          status=$?
+          # 2 means the scan could not run (unresolvable revision). That is not
+          # "clean" and it is not "found" either — say so, rather than printing
+          # the attribution message for what is actually a broken checkout.
+          if [ "$status" -eq 2 ]; then
+            printf '::error::Agent-attribution scan could not run\n'
+            echo "Could not resolve ${BASE_SHA}..${HEAD_SHA}. The scanner fails" >&2
+            echo "closed rather than reporting clean — check the checkout depth." >&2
+            exit 1
+          fi
+          if [ "$status" -ne 0 ]; then
             printf '::error::Agent attribution found in this PR\n'
             cat >&2 <<'MSG'
 
@@ -146,17 +157,57 @@ jobs:
         run: |
           set -uo pipefail
 
-          # A branch-creation or force-push reports an all-zero `before`, and
-          # after a squash merge `before` is the previous main tip. Fall back to
-          # the single pushed commit when the range is unusable, so the job
-          # never silently scans nothing.
-          range="${BEFORE_SHA}..${AFTER_SHA}"
-          if [ -z "${BEFORE_SHA//0/}" ] || ! git rev-parse --quiet --verify "${BEFORE_SHA}^{commit}" >/dev/null; then
-            range="${AFTER_SHA}~1..${AFTER_SHA}"
+          # Determining WHAT this push added is the whole job, and getting it
+          # wrong silently under-scans. Three cases:
+          #
+          #  • Branch creation — `before` is all-zero. Scan everything reachable
+          #    from the new tip; there is no earlier state to diff against.
+          #  • Ordinary push / squash merge — `before` is the previous tip and
+          #    `fetch-depth: 0` has it. Scan before..after.
+          #  • Force push — `before` is ALSO the previous tip (GitHub does not
+          #    zero it; it flags `forced` separately), but that commit may now be
+          #    unreachable and so absent from the clone. Try to fetch it by sha.
+          #
+          # If the old tip cannot be resolved even after fetching, we do NOT
+          # narrow to the tip commit: a multi-commit force push would then hide
+          # attribution in every replacement commit but the last. We fail instead
+          # — a red main run demanding a manual look is the correct outcome for a
+          # gate that cannot see its own scope.
+          if [ -z "${BEFORE_SHA//0/}" ]; then
+            range="${AFTER_SHA}"
+            echo "Branch creation — scanning all history reachable from ${AFTER_SHA}"
+          else
+            if ! git rev-parse --quiet --verify "${BEFORE_SHA}^{commit}" >/dev/null; then
+              echo "Previous tip ${BEFORE_SHA} not in the clone (force push?) — fetching it"
+              git fetch --no-tags --quiet origin "${BEFORE_SHA}" || true
+            fi
+            if ! git rev-parse --quiet --verify "${BEFORE_SHA}^{commit}" >/dev/null; then
+              printf '::error::Cannot determine what this push added\n'
+              cat >&2 <<MSG
+
+          The previous tip ${BEFORE_SHA} could not be resolved, even after
+          fetching it by sha, so the set of commits this push added to main is
+          unknown. Scanning only ${AFTER_SHA} would silently miss every other
+          commit of a multi-commit force push, so this job fails instead.
+
+          Check the pushed commits by hand:
+            git fetch origin main && git log --format='%H %an <%ae>' origin/main
+          MSG
+              exit 1
+            fi
+            range="${BEFORE_SHA}..${AFTER_SHA}"
           fi
           echo "Scanning ${range}"
 
-          if ! .github/scripts/agent-attribution-scan.sh --range "$range"; then
+          .github/scripts/agent-attribution-scan.sh --range "$range"
+          status=$?
+          if [ "$status" -eq 2 ]; then
+            printf '::error::Agent-attribution scan could not run\n'
+            echo "The scanner could not resolve '${range}'. It fails closed rather" >&2
+            echo "than reporting clean — investigate before trusting this push." >&2
+            exit 1
+          fi
+          if [ "$status" -ne 0 ]; then
             printf '::error::Agent attribution reached main\n'
             cat >&2 <<'MSG'
 

--- a/.github/workflows/no-agent-attribution.yml
+++ b/.github/workflows/no-agent-attribution.yml
@@ -16,23 +16,44 @@ name: No Agent Attribution
 # not matched, as are ordinary PR comments.
 #
 # Why this lives at the PR layer (not just the local .githooks/commit-msg
-# hook): PRs are squash-merged, and GitHub builds the squash commit from the
-# **PR title + PR body**, NOT the branch commit messages. A `Co-authored-by:`
-# trailer at the start of a line in the PR description therefore becomes a real
-# trailer on `main`, bypassing every local hook. So we scan the PR title, the
-# PR body, and every commit message in the range — but only at trailer
-# position (start of line), so prose that merely *mentions* a trailer (like
-# this very PR) does not trip the gate.
+# hook): PRs are squash-merged, and GitHub builds the squash commit *message*
+# from the **PR title + PR body**, NOT the branch commit messages. A
+# `Co-authored-by:` trailer at the start of a line in the PR description
+# therefore becomes a real trailer on `main`, bypassing every local hook. So we
+# scan the PR title, the PR body, and every commit message in the range — but
+# only at trailer position (start of line), so prose that merely *mentions* a
+# trailer (like this very PR) does not trip the gate.
+#
+# There is a SECOND path to a trailer on `main`, and it is the one that actually
+# bit us: GitHub's squash credits every distinct **commit author** of the branch
+# as a co-author. So a branch commit authored by an agent lands
+# `Co-authored-by: Claude <noreply@anthropic.com>` on `main` even when the PR
+# title and body are clean. That is how 5aacb786 got its trailer. The identity
+# check below is therefore not just about the branch — it is what keeps the
+# trailer off `main`, and the failure message says so.
 #
 # Untrusted text (title/body) is passed through env: and never interpolated
 # into the shell, per the repo zizmor policy.
 #
-# Keep AGENT_NAME / AGENT_EMAIL in sync with .githooks/commit-msg.
-# Make this a required status check on the "Protect Main" ruleset to block merges.
+# Two layers, because a check that only *warns* is not a gate:
+#   • `scan` runs on the PR and is meant to BLOCK the merge. Make it a required
+#     status check on the "Protect Main" ruleset — without that, a red run is
+#     merely advisory and can be merged straight past (which is exactly what
+#     happened for #2749).
+#   • `drift` runs on every push to `main` and fails loudly if attribution got
+#     in anyway — via an unblocked merge, an admin override, or a direct push.
+#     It cannot prevent the commit, but it makes the breach visible instead of
+#     silent, and dates it to a single push.
+#
+# Detection lives in .github/scripts/agent-attribution-scan.sh so both jobs
+# share one implementation. Keep AGENT_NAME / AGENT_EMAIL there in sync with
+# .githooks/commit-msg.
 
 on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
+  push:
+    branches: [main]
 
 permissions:
   contents: read
@@ -40,6 +61,7 @@ permissions:
 jobs:
   scan:
     name: Reject agent attribution
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -56,60 +78,14 @@ jobs:
         run: |
           set -uo pipefail
 
-          # Shared agent definition — keep in sync with .githooks/commit-msg.
-          AGENT_NAME='(Claude|Codex|ChatGPT|Copilot|Gemini)'
-          AGENT_EMAIL='@(anthropic|openai)[.]com'
+          # The squash commit is built from the PR title + body, so they are
+          # scanned alongside the commit messages. Untrusted — written to a file
+          # rather than interpolated into the shell.
+          { printf '%s\n' "${PR_TITLE:-}"; printf '%s\n' "${PR_BODY:-}"; } > pr_text.txt
 
-          problems=""
-
-          # 1. Author / committer identity of every commit in the PR range.
-          #    Flag an agent *email* (…@anthropic.com / …@openai.com) always, and
-          #    an agent *name* (Claude, Codex, …) except on GitHub App bot
-          #    accounts (…[bot], e.g. claude[bot]) — those land on branches by
-          #    design and never reach the squash-authored main. One record per
-          #    identity: <sha>\t<role>\t<name>\t<email>.
-          git log \
-            --format='%H%x09author%x09%an%x09%ae%x0a%H%x09committer%x09%cn%x09%ce' \
-            "${BASE_SHA}..${HEAD_SHA}" > idents.txt
-          # tolower() rather than IGNORECASE so this holds on mawk (the default
-          # awk on ubuntu-latest) as well as gawk. The email match is a
-          # substring (any …@anthropic.com / …@openai.com address), but the
-          # NAME match is anchored to the whole identity ("^…$") so it catches
-          # an identity set literally to "Claude"/"Codex"/… without snagging a
-          # human whose name merely contains the token ("Claude Martin", "Alice
-          # Copilotson") — and it naturally exempts GitHub App bots, whose name
-          # is "claude[bot]", not "claude".
-          ident_hits="$(awk -F'\t' -v nre="$AGENT_NAME" -v ere="$AGENT_EMAIL" '
-            BEGIN { nre = tolower(nre); ere = tolower(ere) }
-            tolower($4) ~ ere            { print; next }
-            tolower($3) ~ ("^" nre "$")  { print }
-          ' idents.txt || true)"
-          if [ -n "$ident_hits" ]; then
-            problems="${problems}Commit author/committer identity is an agent:
-          ${ident_hits}
-          "
-          fi
-
-          # 2. Co-authored-by trailers (start-of-line only) in commit messages,
-          #    PR title, and PR body — flagged when the name or email is an agent.
-          {
-            git log --format='%B' "${BASE_SHA}..${HEAD_SHA}"
-            printf '%s\n' "${PR_TITLE:-}"
-            printf '%s\n' "${PR_BODY:-}"
-          } > all_text.txt
-
-          coauthor_hits="$(grep -iE '^[[:space:]]*Co-authored-by:' all_text.txt \
-                           | grep -Ei "Co-authored-by:[[:space:]]*${AGENT_NAME}|${AGENT_EMAIL}" \
-                           || true)"
-          if [ -n "$coauthor_hits" ]; then
-            problems="${problems}Agent Co-authored-by trailer(s):
-          ${coauthor_hits}
-          "
-          fi
-
-          if [ -n "$problems" ]; then
+          if ! .github/scripts/agent-attribution-scan.sh \
+                 --range "${BASE_SHA}..${HEAD_SHA}" --text-file pr_text.txt; then
             printf '::error::Agent attribution found in this PR\n'
-            printf '%s\n' "$problems" >&2
             cat >&2 <<'MSG'
 
           ───────────────────────────────────────────────────────────────
@@ -127,11 +103,74 @@ jobs:
           with …" / "Generated by [Claude Code]" footers, and ordinary PR
           comments.
 
-          Remember PRs squash-merge from the title + body, so remove the
-          trailer from the PR description too, not just the commits.
+          MERGING PAST THIS CHECK DOES NOT AVOID IT. GitHub's squash credits
+          every distinct branch commit author as a co-author, so an agent
+          identity above becomes a real
+
+            Co-authored-by: Claude <noreply@anthropic.com>
+
+          trailer on main — and rewriting main after a release has been tagged
+          off it is not a cheap fix. Repoint the identity and force-push the
+          branch instead:
+
+            git config user.name  "<your name>"
+            git config user.email "<your email>"
+            git rebase --exec 'git commit --amend --no-edit --reset-author' \
+              origin/main
+
+          And remove any Co-authored-by line from the PR description too, not
+          just the commits.
           ───────────────────────────────────────────────────────────────
           MSG
             exit 1
           fi
 
-          echo "No agent co-author trailers or agent commit emails found."
+  drift:
+    # Post-merge backstop. `scan` can only block a merge when it is a required
+    # status check; until then (and against admin overrides / direct pushes)
+    # this makes a breach loud and pins it to one push, instead of it sitting
+    # undiscovered in the permanent history.
+    name: Main history has no agent attribution
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Scan the commits this push added to main
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+          AFTER_SHA: ${{ github.sha }}
+        run: |
+          set -uo pipefail
+
+          # A branch-creation or force-push reports an all-zero `before`, and
+          # after a squash merge `before` is the previous main tip. Fall back to
+          # the single pushed commit when the range is unusable, so the job
+          # never silently scans nothing.
+          range="${BEFORE_SHA}..${AFTER_SHA}"
+          if [ -z "${BEFORE_SHA//0/}" ] || ! git rev-parse --quiet --verify "${BEFORE_SHA}^{commit}" >/dev/null; then
+            range="${AFTER_SHA}~1..${AFTER_SHA}"
+          fi
+          echo "Scanning ${range}"
+
+          if ! .github/scripts/agent-attribution-scan.sh --range "$range"; then
+            printf '::error::Agent attribution reached main\n'
+            cat >&2 <<'MSG'
+
+          ───────────────────────────────────────────────────────────────
+          Agent attribution is present in commits just pushed to main.
+
+          The PR-layer check either was not a required status check, was
+          overridden, or was bypassed by a direct push. Fixing this now means
+          rewriting published history — weigh that against the release tags and
+          artifacts already pointing at it before you do.
+
+          To stop it recurring, make "Reject agent attribution" a REQUIRED
+          status check on the Protect Main ruleset.
+          ───────────────────────────────────────────────────────────────
+          MSG
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

The gate flagged #2749 correctly — it was merged past a red check, because `Reject agent attribution` is not a required status check. So an agent co-author trailer landed on `main` as [`5aacb786`](https://github.com/yschimke/compose-ai-tools/commit/5aacb786244b68e200d5c498c45e42e052b0232b), and by the time it was noticed, v0.17.22 and v0.17.23 were tagged off that history. (There's a second, older instance at `0da37499` from #2738.) Those are being left in place — rewriting published history that release artifacts point into costs more than it's worth. This closes the gaps that let it happen quietly.

**1. The workflow documented only one route to a trailer on `main`, and missed the one that actually fired.**

The header explained that the squash *message* is built from the PR title + body, so a co-author line there reaches `main`. True — but GitHub's squash *separately* credits every distinct branch **commit author** as a co-author. An agent-authored commit therefore lands a trailer even when the PR text is spotless. That's the mechanism here, and neither the comment nor the failure message mentioned it.

The failure message now states it outright — merging past the check does not avoid it, because the identity itself becomes the trailer — and gives the fix (`user.name` / `user.email`, then `git rebase --exec 'git commit --amend --no-edit --reset-author' origin/main`).

**2. Nothing checked `main` itself.**

New `drift` job on push to `main` scans the commits the push added and fails if any carry agent attribution. It can't *prevent* the commit — only a required status check does that, and the message says so — but it turns a silent breach into a red run pinned to a single push.

**3. The scanner failed open (found in review — thanks @chatgpt-codex-connector).**

With only `set -uo pipefail`, a `git log` on an unresolvable revision wrote nothing and the script carried on to print "No agent … found" and exit **0**. A missing checkout ref — or the drift job's own invalid `~1` against a root commit — read as a clean gate. Every `git log` status is now checked; an unresolvable revision exits 2 ("could not scan"), which both jobs report distinctly from 1 ("found").

**4. The drift job under-scanned force pushes (same review).**

GitHub doesn't zero `before` on a force push — it sends the old tip and flags `forced` separately — and `fetch-depth: 0` doesn't guarantee an unreachable old tip is in the clone. The old fallback would have narrowed a multi-commit force push to its new tip and passed. It now fetches the old tip by sha and, failing that, **fails** rather than scanning a range it knows is incomplete. Genuine branch creation scans everything reachable from the new tip.

Detection lives in `.github/scripts/agent-attribution-scan.sh` so both jobs share one implementation. Two copies of a gate that can drift apart is worse than one.

## This PR failed its own check, correctly

First run went red on `Reject agent attribution`. Not a false positive: an earlier revision of this description quoted the example trailer at the start of a line inside a code fence. GitHub builds the squash message from the body verbatim and does not care about markdown fences, so merging that revision would have written a real trailer onto `main` — precisely what this PR is about. The body now keeps such examples inline in prose. Branch commits were clean throughout; confirmed by running the scanner over the branch range with and without the body text.

## Still needs you

`Reject agent attribution` has to be made a **required status check** on the Protect Main ruleset. That's a repo setting I can't change from here, and it's the only thing that actually blocks a merge — everything here is detection, not prevention.

## Test plan

Scanner exit codes, against real history in this repo:

| input | expected | got |
|---|---|---|
| `5aacb786~1..5aacb786` (known trailer) | 1 found | 1 |
| `7aa92c71~1..7aa92c71` (clean squash) | 0 clean | 0 |
| `deadbeef1234..cafebabe5678` (unresolvable) | 2 could-not-scan | 2 |
| `7aa92c71` (single sha, branch-creation form) | not 2 | 1 — full history reaches `0da37499`'s trailer, as it should |
| `--text-file /nope` | 2 could-not-scan | 2 |
| this branch's own range | 0 clean | 0 |

- Workflow YAML parses; two jobs (`scan`, `drift`); both triggers present; each gated by `github.event_name` so neither runs on the wrong event.
- `bash -n` clean on the script.
- Not verified from here: the `drift` job on a real push event, and the fetch-by-sha path for an unreachable force-pushed tip (which can legitimately fail if the server no longer serves the object — hence the explicit failure with a manual-inspection command rather than a guessed verdict). `drift` exercises itself on the merge that lands it.
- Non-visual (CI wiring) — no rendered surface changes.