### PR TITLE
feat(gradle-plugin): detect split-family version skew on the render classpath

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderClasspathDuplicates.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderClasspathDuplicates.kt
@@ -155,7 +155,19 @@ internal object RenderClasspathDuplicates {
   fun find(
     paths: Iterable<String>,
     coordinates: Map<String, String> = emptyMap(),
-  ): List<Duplicate> {
+  ): List<Duplicate> =
+    bucketByModule(paths, coordinates)
+      .filterValues { bucket -> bucket.map { it.version }.distinct().size > 1 }
+      .map { (key, bucket) -> Duplicate(key, bucket) }
+
+  /**
+   * Groups [paths] into `group:artifact` buckets, in classpath order. Shared by [find] and
+   * [findFamilySkew] so both see exactly the same view of the classpath.
+   */
+  private fun bucketByModule(
+    paths: Iterable<String>,
+    coordinates: Map<String, String>,
+  ): LinkedHashMap<String, MutableList<Entry>> {
     val buckets = LinkedHashMap<String, MutableList<Entry>>()
     val unattributed = mutableListOf<Entry>()
 
@@ -184,15 +196,82 @@ internal object RenderClasspathDuplicates {
       val group = groups.singleOrNull() ?: continue
       buckets["$group:${entry.artifact}"]?.add(entry)
     }
-
     return buckets
-      .filterValues { bucket -> bucket.map { it.version }.distinct().size > 1 }
-      .map { (key, bucket) -> Duplicate(key, bucket) }
   }
 
   /** Convenience overload for a resolved [org.gradle.api.file.FileCollection]'s files. */
   fun findInFiles(files: Iterable<File>, coordinates: Map<String, String> = emptyMap()) =
     find(files.map { it.absolutePath }, coordinates)
+
+  /**
+   * A set of coordinates that are really one release train, published under separate module names.
+   *
+   * Gradle aligns *a module* against itself, and nothing more. A library shipped as several
+   * coordinates with no BOM or platform gets each coordinate resolved independently, so the graph
+   * can settle on `bcprov-jdk18on:1.85` while leaving `bcutil-jdk18on:1.84` — one version each, so
+   * [find] sees nothing wrong, and the classes still don't agree at runtime.
+   *
+   * The bar for adding an entry here is a **failure someone actually hit**, not a hunch that a
+   * group looks splittable. A false report is expensive: it trains people to ignore the warning,
+   * which is the same reasoning that keeps [find] from guessing at ambiguous artifact names.
+   */
+  data class SplitFamily(val group: String, val why: String)
+
+  private val SPLIT_FAMILIES =
+    listOf(
+      // homeassistant-remotecompose#495. BC 1.84+'s post-quantum `compositekem.KeyFactorySpi`
+      // references `IANAObjectIdentifiers` fields added in 1.81; pair it with an older asn1 jar
+      // from a sibling coordinate and its static init throws NoSuchFieldError, failing every a11y
+      // preview. BouncyCastle publishes no BOM.
+      SplitFamily("org.bouncycastle", "bcprov/bcutil/bcpkix ship as one release train, no BOM"),
+      // Espresso's bytecode calls Hamcrest 1.3's 2-arg `AllOf.allOf`, which 2.x replaced with
+      // varargs. The merged `hamcrest` 2.x artifact and the legacy split `hamcrest-core` /
+      // `hamcrest-library` 1.3 jars are different coordinates, so Gradle never dedups them and
+      // `Espresso.<clinit>` throws NoSuchMethodError. See `applyRenderGraphResolutionRules`, which
+      // substitutes the render graph back to 1.3 — this catches the case where that rule misses.
+      SplitFamily("org.hamcrest", "the merged 2.x jar and the split 1.3 jars overlap by class"),
+    )
+
+  /** One split family whose members resolved to more than one version. */
+  data class FamilySkew(val group: String, val why: String, val members: List<Entry>) {
+    val versions: List<String>
+      get() = members.map { it.version }.distinct()
+
+    /** Distinct `artifact:version`, in classpath order — what the report prints. */
+    val coordinates: List<String>
+      get() = members.map { "${it.artifact}:${it.version}" }.distinct()
+  }
+
+  /**
+   * Returns every [SPLIT_FAMILIES] entry whose members are on the classpath at more than one
+   * version.
+   *
+   * This is the gap [find] can't see: it compares a module against itself, so `bcprov 1.85` next to
+   * `bcutil 1.84` reads as two healthy modules. Reporting it needs the prior knowledge that those
+   * coordinates move together, which is what [SPLIT_FAMILIES] encodes.
+   *
+   * Requires at least two distinct *artifacts* in the family — a single coordinate at two versions
+   * is already [find]'s job, and reporting it twice would just add noise.
+   *
+   * Only entries with a known group participate: an unattributed jar can't be assigned to a family
+   * without guessing, and guessing is what makes a warning ignorable.
+   */
+  fun findFamilySkew(
+    paths: Iterable<String>,
+    coordinates: Map<String, String> = emptyMap(),
+  ): List<FamilySkew> {
+    val entries = bucketByModule(paths, coordinates).values.flatten().filter { it.group != null }
+    return SPLIT_FAMILIES.mapNotNull { family ->
+      val members = entries.filter {
+        it.group == family.group || it.group!!.startsWith("${family.group}.")
+      }
+      val distinctArtifacts = members.map { it.artifact }.distinct()
+      val distinctVersions = members.map { it.version }.distinct()
+      if (distinctArtifacts.size > 1 && distinctVersions.size > 1) {
+        FamilySkew(family.group, family.why, members)
+      } else null
+    }
+  }
 
   /**
    * Human-readable report. Lists each module, the versions present, and which jar wins classload —
@@ -212,12 +291,61 @@ internal object RenderClasspathDuplicates {
       duplicate.entries.drop(1).forEach { appendLine("    also: ${it.path}") }
     }
     appendLine(
-      "Align the module in your build (a version force, a `belongsTo` alignment rule for a " +
-        "split family such as org.bouncycastle:bcprov/bcutil/bcpkix, or an exclude on whichever " +
-        "graph shouldn't carry it). Set -PcomposePreview.classpathDuplicates=fail to make this " +
-        "an error, or =off to silence it."
+      "Align the module in your build (a version force, or an exclude on whichever graph " +
+        "shouldn't carry it). Set -PcomposePreview.classpathDuplicates=fail to make this an " +
+        "error, or =off to silence it."
     )
   }
+
+  /**
+   * Human-readable report for [findFamilySkew], with the alignment rule to paste.
+   *
+   * The remediation is spelled out rather than described because the fix isn't obvious: a version
+   * force works but goes stale (and silently becomes a *downgrade* the moment one member's floor
+   * moves), while a virtual platform states the actual fact — these coordinates are one unit — and
+   * lets Gradle keep picking the highest version any member asks for.
+   *
+   * The plugin deliberately does NOT apply this rule itself. `ComponentMetadataRule`s register on
+   * `DependencyHandler` and so apply to *every* configuration in the project, including the
+   * consumer's `releaseRuntimeClasspath`. Aligning a family upward is usually right for a render
+   * classpath and emphatically not the preview plugin's call to make for a shipped app — so this
+   * reports and hands the decision back.
+   */
+  fun reportFamilySkew(skews: List<FamilySkew>, taskPath: String): String = buildString {
+    appendLine(
+      "compose-preview: ${skews.size} dependency family/families on the $taskPath JVM classpath " +
+        "resolved to more than one version. Each coordinate is at a single version, so ordinary " +
+        "conflict resolution sees nothing wrong — but these coordinates ship as one release train " +
+        "and their classes reference each other, so mixing versions link-errors at runtime."
+    )
+    skews.forEach { skew ->
+      appendLine("  ${skew.group}  (${skew.why})")
+      skew.coordinates.forEach { appendLine("    $it") }
+      appendLine("    align with:")
+      appendLine("      abstract class ${alignmentRuleName(skew.group)} : ComponentMetadataRule {")
+      appendLine("        override fun execute(context: ComponentMetadataContext) {")
+      appendLine("          val id = context.details.id")
+      appendLine("          if (id.group == \"${skew.group}\") {")
+      appendLine(
+        "            context.details.belongsTo(\"${skew.group}:${skew.group.substringAfterLast('.')}-virtual-platform:\${id.version}\")"
+      )
+      appendLine("          }")
+      appendLine("        }")
+      appendLine("      }")
+      appendLine(
+        "      dependencies { components.all(${alignmentRuleName(skew.group)}::class.java) }"
+      )
+    }
+    appendLine(
+      "Applying that rule is your call — it aligns the family across EVERY configuration in the " +
+        "module, not just the render classpath, so check it doesn't move a version your app " +
+        "ships. Set -PcomposePreview.classpathDuplicates=off to silence this."
+    )
+  }
+
+  /** `org.bouncycastle` → `BouncyCastleAlignmentRule`-ish: a legal, readable Kotlin class name. */
+  private fun alignmentRuleName(group: String): String =
+    group.substringAfterLast('.').replaceFirstChar { it.uppercase() } + "AlignmentRule"
 
   /** Valid values for `-PcomposePreview.classpathDuplicates`. */
   const val MODE_WARN = "warn"
@@ -244,7 +372,18 @@ internal object RenderClasspathDuplicates {
     coordinates: Map<String, String> = emptyMap(),
   ) {
     if (mode == MODE_OFF) return
-    val duplicates = findInFiles(files, coordinates)
+    val paths = files.map { it.absolutePath }
+    // Two independent faults, reported independently. A classpath can have one, the other, or
+    // both: `find` catches one module at two versions, `findFamilySkew` catches sibling
+    // coordinates of one library disagreeing — which `find` cannot see, because each coordinate is
+    // internally consistent.
+    val skews = findFamilySkew(paths, coordinates)
+    if (skews.isNotEmpty()) {
+      val skewMessage = reportFamilySkew(skews, task.path)
+      if (mode == MODE_FAIL) throw GradleException(skewMessage)
+      task.logger.warn(skewMessage)
+    }
+    val duplicates = find(paths, coordinates)
     if (duplicates.isEmpty()) return
     val message = report(duplicates, task.path)
     if (mode == MODE_FAIL) throw GradleException(message)

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderClasspathDuplicates.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderClasspathDuplicates.kt
@@ -215,7 +215,66 @@ internal object RenderClasspathDuplicates {
    * group looks splittable. A false report is expensive: it trains people to ignore the warning,
    * which is the same reasoning that keeps [find] from guessing at ambiguous artifact names.
    */
-  data class SplitFamily(val group: String, val why: String)
+  /**
+   * @param artifact which artifacts *in* [group] belong to the train. Deliberately not "everything
+   *   in the group": `org.bouncycastle` also publishes the FIPS line (`bc-fips`, `bcpkix-fips`,
+   *   `bctls-fips`), whose versions advance **independently** — `bc-fips:2.1.0` alongside
+   *   `bcpkix-fips:2.1.9` is a correct, healthy classpath. Matching the whole group would report
+   *   that as skew and, under `classpathDuplicates=fail`, break a build that has nothing wrong with
+   *   it.
+   * @param remediation the fix to print. Per-family because the right answer differs: BouncyCastle
+   *   wants aligning *up* to the highest member, Hamcrest wants pinning *down* to 1.3.
+   */
+  data class SplitFamily(
+    val group: String,
+    val why: String,
+    val artifact: Regex,
+    val remediation: String,
+  )
+
+  /**
+   * Align the family *upward* on a virtual platform. Right for BouncyCastle: the members really do
+   * move together, every member has a release at the highest version, and a hardcoded force would
+   * go stale — silently becoming a downgrade as soon as one member's floor moves, which is what
+   * happened when Robolectric went to 1.85 against a pinned 1.84.
+   */
+  private val BOUNCYCASTLE_REMEDIATION =
+    """
+    |    abstract class BouncyCastleAlignmentRule : ComponentMetadataRule {
+    |      override fun execute(context: ComponentMetadataContext) {
+    |        val id = context.details.id
+    |        if (id.group == "org.bouncycastle") {
+    |          context.details.belongsTo("org.bouncycastle:bouncycastle-virtual-platform:${'$'}{id.version}")
+    |        }
+    |      }
+    |    }
+    |    dependencies { components.all(BouncyCastleAlignmentRule::class.java) }
+    """
+      .trimMargin()
+
+  /**
+   * Pin the family *downward* to 1.3. The opposite of the BouncyCastle fix, and the reason
+   * remediation is per-family rather than one generic snippet.
+   *
+   * `hamcrest-core:2.2` / `hamcrest-library:2.2` do exist — as deprecated shims that just depend on
+   * the merged `hamcrest:2.2` — so a virtual platform *would* resolve. It would resolve to the
+   * wrong place: Espresso's compiled bytecode calls the 2-arg `AllOf.allOf(Matcher, Matcher)` that
+   * 2.x deleted, so aligning up to 2.x trades a silent mismatch for a guaranteed
+   * `NoSuchMethodError`. Substituting back to 1.3 is what `applyRenderGraphResolutionRules` already
+   * does on the render graph.
+   */
+  private val HAMCREST_REMEDIATION =
+    """
+    |    configurations.all {
+    |      resolutionStrategy.eachDependency {
+    |        if (requested.group == "org.hamcrest" && requested.name == "hamcrest") {
+    |          useTarget("org.hamcrest:hamcrest-core:1.3")
+    |          because("Espresso needs 1.3's AllOf.allOf(Matcher, Matcher); 2.x removed it")
+    |        }
+    |      }
+    |    }
+    """
+      .trimMargin()
 
   private val SPLIT_FAMILIES =
     listOf(
@@ -223,17 +282,39 @@ internal object RenderClasspathDuplicates {
       // references `IANAObjectIdentifiers` fields added in 1.81; pair it with an older asn1 jar
       // from a sibling coordinate and its static init throws NoSuchFieldError, failing every a11y
       // preview. BouncyCastle publishes no BOM.
-      SplitFamily("org.bouncycastle", "bcprov/bcutil/bcpkix ship as one release train, no BOM"),
+      //
+      // Scoped to the `-jdkXXon` / `-jdkXXtoYYon` line, which is the one that moves in lockstep.
+      // The FIPS artifacts share the group but not the release train, so they must not match.
+      SplitFamily(
+        group = "org.bouncycastle",
+        why = "bcprov/bcutil/bcpkix ship as one release train, no BOM",
+        // `bcprov-jdk18on`, `bcprov-jdk15on`, and the legacy `bcprov-jdk15to18` (which ends in the
+        // JDK number, not `on`) — all real published coordinates. `bc-fips` / `bcpkix-fips` have no
+        // `-jdk` segment at all, which is what keeps them out.
+        artifact = Regex("^bc[a-z]*-jdk\\d+(?:on|to\\d+)$"),
+        remediation = BOUNCYCASTLE_REMEDIATION,
+      ),
       // Espresso's bytecode calls Hamcrest 1.3's 2-arg `AllOf.allOf`, which 2.x replaced with
       // varargs. The merged `hamcrest` 2.x artifact and the legacy split `hamcrest-core` /
       // `hamcrest-library` 1.3 jars are different coordinates, so Gradle never dedups them and
       // `Espresso.<clinit>` throws NoSuchMethodError. See `applyRenderGraphResolutionRules`, which
       // substitutes the render graph back to 1.3 — this catches the case where that rule misses.
-      SplitFamily("org.hamcrest", "the merged 2.x jar and the split 1.3 jars overlap by class"),
+      SplitFamily(
+        group = "org.hamcrest",
+        why = "the merged 2.x jar and the split 1.3 jars overlap by class",
+        artifact = Regex("^hamcrest(?:-core|-library|-integration|-all)?$"),
+        remediation = HAMCREST_REMEDIATION,
+      ),
     )
 
   /** One split family whose members resolved to more than one version. */
-  data class FamilySkew(val group: String, val why: String, val members: List<Entry>) {
+  data class FamilySkew(val family: SplitFamily, val members: List<Entry>) {
+    val group: String
+      get() = family.group
+
+    val why: String
+      get() = family.why
+
     val versions: List<String>
       get() = members.map { it.version }.distinct()
 
@@ -263,12 +344,12 @@ internal object RenderClasspathDuplicates {
     val entries = bucketByModule(paths, coordinates).values.flatten().filter { it.group != null }
     return SPLIT_FAMILIES.mapNotNull { family ->
       val members = entries.filter {
-        it.group == family.group || it.group!!.startsWith("${family.group}.")
+        it.group == family.group && family.artifact.matches(it.artifact)
       }
       val distinctArtifacts = members.map { it.artifact }.distinct()
       val distinctVersions = members.map { it.version }.distinct()
       if (distinctArtifacts.size > 1 && distinctVersions.size > 1) {
-        FamilySkew(family.group, family.why, members)
+        FamilySkew(family, members)
       } else null
     }
   }
@@ -298,18 +379,18 @@ internal object RenderClasspathDuplicates {
   }
 
   /**
-   * Human-readable report for [findFamilySkew], with the alignment rule to paste.
+   * Human-readable report for [findFamilySkew], with the family's own remediation to paste.
    *
-   * The remediation is spelled out rather than described because the fix isn't obvious: a version
-   * force works but goes stale (and silently becomes a *downgrade* the moment one member's floor
-   * moves), while a virtual platform states the actual fact — these coordinates are one unit — and
-   * lets Gradle keep picking the highest version any member asks for.
+   * The fix is spelled out rather than described because it isn't obvious *and* it isn't uniform:
+   * BouncyCastle wants aligning up to the highest member, Hamcrest wants pinning down to 1.3
+   * (aligning it up is what breaks Espresso). Emitting one generic snippet for both would hand half
+   * of readers a fix that makes their build worse, so the text lives on [SplitFamily].
    *
-   * The plugin deliberately does NOT apply this rule itself. `ComponentMetadataRule`s register on
+   * The plugin deliberately does NOT apply any of it. `ComponentMetadataRule`s register on
    * `DependencyHandler` and so apply to *every* configuration in the project, including the
-   * consumer's `releaseRuntimeClasspath`. Aligning a family upward is usually right for a render
-   * classpath and emphatically not the preview plugin's call to make for a shipped app — so this
-   * reports and hands the decision back.
+   * consumer's `releaseRuntimeClasspath`. Changing a dependency version project-wide is
+   * emphatically not the preview plugin's call to make for a shipped app — so this reports and
+   * hands the decision back.
    */
   fun reportFamilySkew(skews: List<FamilySkew>, taskPath: String): String = buildString {
     appendLine(
@@ -321,31 +402,15 @@ internal object RenderClasspathDuplicates {
     skews.forEach { skew ->
       appendLine("  ${skew.group}  (${skew.why})")
       skew.coordinates.forEach { appendLine("    $it") }
-      appendLine("    align with:")
-      appendLine("      abstract class ${alignmentRuleName(skew.group)} : ComponentMetadataRule {")
-      appendLine("        override fun execute(context: ComponentMetadataContext) {")
-      appendLine("          val id = context.details.id")
-      appendLine("          if (id.group == \"${skew.group}\") {")
-      appendLine(
-        "            context.details.belongsTo(\"${skew.group}:${skew.group.substringAfterLast('.')}-virtual-platform:\${id.version}\")"
-      )
-      appendLine("          }")
-      appendLine("        }")
-      appendLine("      }")
-      appendLine(
-        "      dependencies { components.all(${alignmentRuleName(skew.group)}::class.java) }"
-      )
+      appendLine("    fix:")
+      appendLine(skew.family.remediation)
     }
     appendLine(
-      "Applying that rule is your call — it aligns the family across EVERY configuration in the " +
-        "module, not just the render classpath, so check it doesn't move a version your app " +
-        "ships. Set -PcomposePreview.classpathDuplicates=off to silence this."
+      "Applying that is your call — these rules act on EVERY configuration in the module, not " +
+        "just the render classpath, so check it doesn't move a version your app ships. Set " +
+        "-PcomposePreview.classpathDuplicates=off to silence this."
     )
   }
-
-  /** `org.bouncycastle` → `BouncyCastleAlignmentRule`-ish: a legal, readable Kotlin class name. */
-  private fun alignmentRuleName(group: String): String =
-    group.substringAfterLast('.').replaceFirstChar { it.uppercase() } + "AlignmentRule"
 
   /** Valid values for `-PcomposePreview.classpathDuplicates`. */
   const val MODE_WARN = "warn"
@@ -373,19 +438,21 @@ internal object RenderClasspathDuplicates {
   ) {
     if (mode == MODE_OFF) return
     val paths = files.map { it.absolutePath }
-    // Two independent faults, reported independently. A classpath can have one, the other, or
-    // both: `find` catches one module at two versions, `findFamilySkew` catches sibling
-    // coordinates of one library disagreeing — which `find` cannot see, because each coordinate is
-    // internally consistent.
+    // Two independent faults: `find` catches one module at two versions, `findFamilySkew` catches
+    // sibling coordinates of one library disagreeing — which `find` cannot see, because each
+    // coordinate is internally consistent. A classpath can have one, the other, or both.
+    //
+    // BOTH are computed and reported before anything throws. Failing on the first would hide the
+    // second until the reader fixed it and re-ran, which for a slow render task means paying the
+    // full build twice to learn something we already knew on the first pass.
     val skews = findFamilySkew(paths, coordinates)
-    if (skews.isNotEmpty()) {
-      val skewMessage = reportFamilySkew(skews, task.path)
-      if (mode == MODE_FAIL) throw GradleException(skewMessage)
-      task.logger.warn(skewMessage)
-    }
     val duplicates = find(paths, coordinates)
-    if (duplicates.isEmpty()) return
-    val message = report(duplicates, task.path)
+    val messages = buildList {
+      if (skews.isNotEmpty()) add(reportFamilySkew(skews, task.path))
+      if (duplicates.isNotEmpty()) add(report(duplicates, task.path))
+    }
+    if (messages.isEmpty()) return
+    val message = messages.joinToString("\n")
     if (mode == MODE_FAIL) throw GradleException(message)
     task.logger.warn(message)
   }

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/RenderClasspathDuplicatesTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/RenderClasspathDuplicatesTest.kt
@@ -49,7 +49,10 @@ class RenderClasspathDuplicatesTest {
   }
 
   @Test
-  fun `clean classpath reports nothing`() {
+  fun `module-level check ignores a split family - each coordinate is at one version`() {
+    // Scope boundary, not a clean bill of health: bcprov 1.85 next to bcutil 1.84 is one version
+    // per coordinate, so `find` correctly sees nothing. Catching it needs `findFamilySkew` (below)
+    // — without that, this classpath passes `classpathDuplicates=fail` and still link-errors.
     val duplicates =
       RenderClasspathDuplicates.find(
         listOf(
@@ -65,6 +68,155 @@ class RenderClasspathDuplicatesTest {
       )
 
     assertThat(duplicates).isEmpty()
+  }
+
+  @Test
+  fun `family check catches the bouncycastle split that the module check cannot`() {
+    val skews =
+      RenderClasspathDuplicates.findFamilySkew(
+        listOf(
+          cached("org.bouncycastle", "bcprov-jdk18on", "1.85"),
+          cached("org.bouncycastle", "bcutil-jdk18on", "1.84"),
+          cached("org.bouncycastle", "bcpkix-jdk18on", "1.84"),
+          cached("androidx.test", "core", "1.6.1"),
+        ),
+        coordinates(
+          module("org.bouncycastle", "bcprov-jdk18on", "1.85"),
+          module("org.bouncycastle", "bcutil-jdk18on", "1.84"),
+          module("org.bouncycastle", "bcpkix-jdk18on", "1.84"),
+          module("androidx.test", "core", "1.6.1"),
+        ),
+      )
+
+    assertThat(skews.map { it.group }).containsExactly("org.bouncycastle")
+    assertThat(skews.single().versions).containsExactly("1.85", "1.84").inOrder()
+    assertThat(skews.single().coordinates)
+      .containsExactly("bcprov-jdk18on:1.85", "bcutil-jdk18on:1.84", "bcpkix-jdk18on:1.84")
+      .inOrder()
+  }
+
+  @Test
+  fun `an aligned family is not reported`() {
+    val skews =
+      RenderClasspathDuplicates.findFamilySkew(
+        listOf(
+          cached("org.bouncycastle", "bcprov-jdk18on", "1.85"),
+          cached("org.bouncycastle", "bcutil-jdk18on", "1.85"),
+          cached("org.bouncycastle", "bcpkix-jdk18on", "1.85"),
+        ),
+        coordinates(
+          module("org.bouncycastle", "bcprov-jdk18on", "1.85"),
+          module("org.bouncycastle", "bcutil-jdk18on", "1.85"),
+          module("org.bouncycastle", "bcpkix-jdk18on", "1.85"),
+        ),
+      )
+
+    assertThat(skews).isEmpty()
+  }
+
+  @Test
+  fun `one coordinate at two versions is left to the module check, not double-reported`() {
+    // `find` already names this; repeating it as a family skew would be noise, and noise is what
+    // makes a warning ignorable.
+    val skews =
+      RenderClasspathDuplicates.findFamilySkew(
+        listOf(
+          cached("org.bouncycastle", "bcprov-jdk18on", "1.85"),
+          cached("org.bouncycastle", "bcprov-jdk18on", "1.84"),
+        ),
+        coordinates(
+          module("org.bouncycastle", "bcprov-jdk18on", "1.85"),
+          module("org.bouncycastle", "bcprov-jdk18on", "1.84"),
+        ),
+      )
+
+    assertThat(skews).isEmpty()
+  }
+
+  @Test
+  fun `a group outside the known-families table is not guessed at`() {
+    // `com.example` might well be one release train, but the plugin has no way to know that, and
+    // inventing families would produce exactly the false reports this detector avoids elsewhere.
+    val skews =
+      RenderClasspathDuplicates.findFamilySkew(
+        listOf(
+          cached("com.example", "thing-core", "1.0"),
+          cached("com.example", "thing-util", "2.0"),
+        ),
+        coordinates(
+          module("com.example", "thing-core", "1.0"),
+          module("com.example", "thing-util", "2.0"),
+        ),
+      )
+
+    assertThat(skews).isEmpty()
+  }
+
+  @Test
+  fun `family report names the coordinates and hands back a pasteable alignment rule`() {
+    val skews =
+      RenderClasspathDuplicates.findFamilySkew(
+        listOf(
+          cached("org.bouncycastle", "bcprov-jdk18on", "1.85"),
+          cached("org.bouncycastle", "bcutil-jdk18on", "1.84"),
+        ),
+        coordinates(
+          module("org.bouncycastle", "bcprov-jdk18on", "1.85"),
+          module("org.bouncycastle", "bcutil-jdk18on", "1.84"),
+        ),
+      )
+
+    val report = RenderClasspathDuplicates.reportFamilySkew(skews, ":app:composePreviewRender")
+
+    assertThat(report).contains(":app:composePreviewRender")
+    assertThat(report).contains("org.bouncycastle")
+    assertThat(report).contains("bcprov-jdk18on:1.85")
+    assertThat(report).contains("bcutil-jdk18on:1.84")
+    assertThat(report).contains("BouncycastleAlignmentRule : ComponentMetadataRule")
+    assertThat(report).contains("belongsTo")
+    // The caveat matters as much as the snippet: the rule is project-wide, so applying it can move
+    // a version the consumer's app actually ships.
+    assertThat(report).contains("EVERY configuration")
+  }
+
+  @Test
+  fun `check fails on a family skew in fail mode and warns by default`() {
+    val project = ProjectBuilder.builder().build()
+    val task = project.tasks.register("probeFamily").get()
+    val prov = project.file(cached("org.bouncycastle", "bcprov-jdk18on", "1.85"))
+    val util = project.file(cached("org.bouncycastle", "bcutil-jdk18on", "1.84"))
+    val coords =
+      mapOf(
+        prov.absolutePath to "org.bouncycastle:bcprov-jdk18on:1.85",
+        util.absolutePath to "org.bouncycastle:bcutil-jdk18on:1.84",
+      )
+
+    RenderClasspathDuplicates.check(
+      task,
+      listOf(prov, util),
+      RenderClasspathDuplicates.MODE_WARN,
+      coords,
+    )
+    RenderClasspathDuplicates.check(
+      task,
+      listOf(prov, util),
+      RenderClasspathDuplicates.MODE_OFF,
+      coords,
+    )
+
+    val thrown =
+      runCatching {
+          RenderClasspathDuplicates.check(
+            task,
+            listOf(prov, util),
+            RenderClasspathDuplicates.MODE_FAIL,
+            coords,
+          )
+        }
+        .exceptionOrNull()
+
+    assertThat(thrown).isInstanceOf(GradleException::class.java)
+    assertThat(thrown!!.message).contains("one release train")
   }
 
   @Test

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/RenderClasspathDuplicatesTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/RenderClasspathDuplicatesTest.kt
@@ -134,6 +134,127 @@ class RenderClasspathDuplicatesTest {
   }
 
   @Test
+  fun `BouncyCastle FIPS artifacts are not a family - they version independently`() {
+    // `org.bouncycastle` also publishes the FIPS line, whose versions advance on their own
+    // schedule: `bc-fips:2.1.0` alongside `bcpkix-fips:2.1.9` is a correct classpath, and both
+    // coordinates really do exist at those versions. Matching the whole group would report it as
+    // skew and break an innocent build under `classpathDuplicates=fail`.
+    val skews =
+      RenderClasspathDuplicates.findFamilySkew(
+        listOf(
+          cached("org.bouncycastle", "bc-fips", "2.1.0"),
+          cached("org.bouncycastle", "bcpkix-fips", "2.1.9"),
+          cached("org.bouncycastle", "bctls-fips", "2.1.20"),
+        ),
+        coordinates(
+          module("org.bouncycastle", "bc-fips", "2.1.0"),
+          module("org.bouncycastle", "bcpkix-fips", "2.1.9"),
+          module("org.bouncycastle", "bctls-fips", "2.1.20"),
+        ),
+      )
+
+    assertThat(skews).isEmpty()
+  }
+
+  @Test
+  fun `FIPS jars alongside a real jdk18on skew do not pollute the report`() {
+    val skews =
+      RenderClasspathDuplicates.findFamilySkew(
+        listOf(
+          cached("org.bouncycastle", "bcprov-jdk18on", "1.85"),
+          cached("org.bouncycastle", "bcutil-jdk18on", "1.84"),
+          cached("org.bouncycastle", "bc-fips", "2.1.0"),
+        ),
+        coordinates(
+          module("org.bouncycastle", "bcprov-jdk18on", "1.85"),
+          module("org.bouncycastle", "bcutil-jdk18on", "1.84"),
+          module("org.bouncycastle", "bc-fips", "2.1.0"),
+        ),
+      )
+
+    assertThat(skews.single().coordinates)
+      .containsExactly("bcprov-jdk18on:1.85", "bcutil-jdk18on:1.84")
+      .inOrder()
+  }
+
+  @Test
+  fun `the legacy jdk15to18 line still counts as the same train`() {
+    val skews =
+      RenderClasspathDuplicates.findFamilySkew(
+        listOf(
+          cached("org.bouncycastle", "bcprov-jdk15to18", "1.85"),
+          cached("org.bouncycastle", "bcutil-jdk15to18", "1.84"),
+        ),
+        coordinates(
+          module("org.bouncycastle", "bcprov-jdk15to18", "1.85"),
+          module("org.bouncycastle", "bcutil-jdk15to18", "1.84"),
+        ),
+      )
+
+    assertThat(skews.single().group).isEqualTo("org.bouncycastle")
+  }
+
+  @Test
+  fun `hamcrest remediation pins down to 1_3 rather than aligning up`() {
+    // Aligning Hamcrest UP is the one thing that must not be suggested: `hamcrest-core:2.2` does
+    // exist (as a shim), so a virtual platform resolves fine — straight onto 2.x, where Espresso's
+    // 2-arg `AllOf.allOf` is gone. That's why remediation is per-family.
+    val skews =
+      RenderClasspathDuplicates.findFamilySkew(
+        listOf(
+          cached("org.hamcrest", "hamcrest", "2.2"),
+          cached("org.hamcrest", "hamcrest-core", "1.3"),
+        ),
+        coordinates(
+          module("org.hamcrest", "hamcrest", "2.2"),
+          module("org.hamcrest", "hamcrest-core", "1.3"),
+        ),
+      )
+
+    val report = RenderClasspathDuplicates.reportFamilySkew(skews, ":app:composePreviewRender")
+
+    assertThat(report).contains("org.hamcrest")
+    assertThat(report).contains("useTarget(\"org.hamcrest:hamcrest-core:1.3\")")
+    assertThat(report).doesNotContain("belongsTo")
+    assertThat(report).doesNotContain("virtual-platform")
+  }
+
+  @Test
+  fun `a classpath with both faults reports both before failing`() {
+    // Throwing on the family skew alone would hide the duplicate until the reader fixed it and
+    // re-ran — a full render's wall-clock to learn something already known on the first pass.
+    val project = ProjectBuilder.builder().build()
+    val task = project.tasks.register("probeBoth").get()
+    val provNew = project.file(cached("org.bouncycastle", "bcprov-jdk18on", "1.85"))
+    val provOld = project.file(cached("org.bouncycastle", "bcprov-jdk18on", "1.84"))
+    val util = project.file(cached("org.bouncycastle", "bcutil-jdk18on", "1.84"))
+    val coords =
+      mapOf(
+        provNew.absolutePath to "org.bouncycastle:bcprov-jdk18on:1.85",
+        provOld.absolutePath to "org.bouncycastle:bcprov-jdk18on:1.84",
+        util.absolutePath to "org.bouncycastle:bcutil-jdk18on:1.84",
+      )
+
+    val thrown =
+      runCatching {
+          RenderClasspathDuplicates.check(
+            task,
+            listOf(provNew, provOld, util),
+            RenderClasspathDuplicates.MODE_FAIL,
+            coords,
+          )
+        }
+        .exceptionOrNull()
+
+    assertThat(thrown).isInstanceOf(GradleException::class.java)
+    // The family skew…
+    assertThat(thrown!!.message).contains("one release train")
+    // …and the duplicate module, in one message.
+    assertThat(thrown.message).contains("at more than one version")
+    assertThat(thrown.message).contains("org.bouncycastle:bcprov-jdk18on")
+  }
+
+  @Test
   fun `a group outside the known-families table is not guessed at`() {
     // `com.example` might well be one release train, but the plugin has no way to know that, and
     // inventing families would produce exactly the false reports this detector avoids elsewhere.
@@ -172,7 +293,7 @@ class RenderClasspathDuplicatesTest {
     assertThat(report).contains("org.bouncycastle")
     assertThat(report).contains("bcprov-jdk18on:1.85")
     assertThat(report).contains("bcutil-jdk18on:1.84")
-    assertThat(report).contains("BouncycastleAlignmentRule : ComponentMetadataRule")
+    assertThat(report).contains("BouncyCastleAlignmentRule : ComponentMetadataRule")
     assertThat(report).contains("belongsTo")
     // The caveat matters as much as the snippet: the rule is project-wide, so applying it can move
     // a version the consumer's app actually ships.

--- a/site/install.md
+++ b/site/install.md
@@ -225,10 +225,44 @@ than one version, naming each version and the jar that wins:
 | `composePreview.classpathDuplicates` | `warn` | `fail` turns a duplicate into a build error (good for CI); `off` silences the check. |
 | `composePreview.legacyClasspathUnion` | `false` | `true` restores the old concatenated classpath. Escape hatch only — set it if a render suddenly can't find a class that lives solely on your unit-test classpath, and please file an issue. |
 
-If the guard reports a duplicate, align the module in your own build: a version
-force, or a `belongsTo` alignment rule for a family published under several
-coordinates (`org.bouncycastle:bcprov`/`bcutil`/`bcpkix` is the common one —
-Gradle can only align coordinates it knows are the same module).
+If the guard reports a duplicate module, align it in your own build with a
+version force, or exclude it from whichever graph shouldn't carry it.
+
+### Split families
+
+A second check covers libraries published as **several coordinates with no BOM**
+— `org.bouncycastle:bcprov`/`bcutil`/`bcpkix` is the usual offender. Gradle
+aligns a module against itself and nothing further, so the graph can settle on
+`bcprov-jdk18on:1.85` while leaving `bcutil-jdk18on:1.84`: one version per
+coordinate, no conflict to resolve, and classes that still don't agree at
+runtime. That's what failed every accessibility preview in
+[homeassistant-remotecompose#495](https://github.com/yschimke/homeassistant-remotecompose/issues/495).
+
+The fix is a virtual platform, which states that the coordinates move together
+and lets normal conflict resolution pick the highest version any member asks
+for:
+
+```kotlin
+abstract class BouncyCastleAlignmentRule : ComponentMetadataRule {
+  override fun execute(context: ComponentMetadataContext) {
+    val id = context.details.id
+    if (id.group == "org.bouncycastle") {
+      context.details.belongsTo("org.bouncycastle:bouncycastle-virtual-platform:${id.version}")
+    }
+  }
+}
+
+dependencies { components.all(BouncyCastleAlignmentRule::class.java) }
+```
+
+Prefer that over `useVersion("1.84")`: a force goes stale, and silently becomes
+a *downgrade* the moment one member's floor moves (Robolectric's did).
+
+The plugin reports this rather than applying it. `ComponentMetadataRule`s
+register on `DependencyHandler`, so they apply to **every** configuration in the
+module — including your `releaseRuntimeClasspath`. Aligning a family upward is
+usually right for a render classpath and isn't a preview tool's call to make for
+a shipped app, so the decision stays yours.
 
 ## Requirements
 


### PR DESCRIPTION
## Summary

Closes a gap #2739 left open — and one where the existing guard actively implied safety it wasn't providing.

`RenderClasspathDuplicates` compares a module against **itself**. A library published as several coordinates with no BOM slips straight past it: the graph settles on `bcprov-jdk18on:1.85` while leaving `bcutil-jdk18on:1.84`, so there's one version per coordinate, nothing for conflict resolution to do — and classes that still don't agree at runtime. That's exactly the shape that failed every a11y preview in [homeassistant-remotecompose#495](https://github.com/yschimke/homeassistant-remotecompose/issues/495).

The guard called that classpath clean. I even had a test asserting it:

```kotlin
fun `clean classpath reports nothing`() {
  // bcprov 1.85, bcutil 1.84, androidx.test:core 1.6.1
  assertThat(duplicates).isEmpty()
}
```

A green `-PcomposePreview.classpathDuplicates=fail` run that still link-errors is worse than no check, because it's read as a clearance. That test is renamed and repurposed here to document the scope boundary, with the family check picking up what it can't see.

## What it does

`findFamilySkew` reports members of a known split family resolving to different versions, against a table grounded in **failures actually observed in this repo**:

- `org.bouncycastle` — #495.
- `org.hamcrest` — the Espresso `AllOf.allOf` `NoSuchMethodError` that `applyRenderGraphResolutionRules` already substitutes around; this catches the case where that substitution misses.

The bar for adding to that table is a real incident, not a hunch that a group looks splittable. A false report is what trains people to ignore a warning — the same reasoning that already keeps `find` from guessing at ambiguous artifact names.

It also skips a family where only one coordinate is present at two versions (that's the existing module check's job; double-reporting is noise), and skips entries whose group is unknown rather than guessing.

## Reports, deliberately does not mutate

The report carries the `belongsTo` rule to paste, but the plugin does not apply it. `ComponentMetadataRule`s register on `DependencyHandler`, so they cover **every** configuration in the module — including `releaseRuntimeClasspath`. Aligning a family upward is usually right for a render classpath and is emphatically not a preview tool's call to make for a shipped app; installing a preview plugin must not silently move the BouncyCastle version in someone's APK.

There's no config-scoped alternative: `resolutionStrategy.eachDependency` is per-configuration but can't see the graph's resolved max, and `ComponentMetadataRule` can see it but can't be scoped. That constraint is the whole argument for report-don't-mutate.

## Test plan

- **No false positives here.** `:samples:android`, `:samples:wear` and `:samples:android-screenshot-test` all render green under this repo's `classpathDuplicates=fail`, **121 PNGs**, no family reported.
- **Firing case** covered by unit tests using the real versions from #495 — bcprov 1.85 alongside bcutil/bcpkix 1.84 — plus aligned-family, single-coordinate-at-two-versions, unknown-group, report-content and `check()` mode tests.
- `:gradle-plugin:test` and `:gradle-plugin:ktfmtCheck` green.

Docs: `site/install.md` gains a "Split families" section with the pasteable rule and the project-wide caveat.

## Unrelated bug found while testing

Requesting `composePreviewRender` and `composePreviewDaemonStart` in one invocation fails validation — `composePreviewDaemonStart` reads `previews.json` without declaring a dependency on `composePreviewDiscover`:

```
Task ':samples:android:composePreviewDaemonStart' uses this output of task
':samples:android:composePreviewDiscover' without declaring an explicit or implicit dependency.
```

I reproduced it on unmodified `main`, so it predates this change and isn't caused by it. Left out of this PR to keep the change focused — happy to fix separately.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ULa9AYFHcJgEQmKbzJPYtx)_