### PR TITLE
fix(serve): trust compose-samples in the trust store that is actually baked

### DIFF
--- a/deploy/image/trust/producers.json
+++ b/deploy/image/trust/producers.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Trust store baked into the prebuilt preview-host image so a public deploy badges the published design-system catalogs as Trusted(Branch) out of the box, instead of Unverified. Branch (origin) trust only — the image carries no signing key, and branch trust is exactly what the --catalogs fetch needs: a catalog the server itself pulled from one of these branches is trusted by TLS origin, no per-bundle crypto. SERVE_TRUST_STORE defaults to this file (deploy/image/docker-compose.yml); override it, or mount your own at /trust/producers.json, to pin different producers. See docs/public-preview-server.md.",
+  "_comment": "Trust store baked into the prebuilt preview-host image so a public deploy badges the published design-system catalogs as Trusted(Branch) out of the box, instead of Unverified. Branch (origin) trust only \u2014 the image carries no signing key, and branch trust is exactly what the --catalogs fetch needs: a catalog the server itself pulled from one of these branches is trusted by TLS origin, no per-bundle crypto. SERVE_TRUST_STORE defaults to this file (deploy/image/docker-compose.yml); override it, or mount your own at /trust/producers.json, to pin different producers. See docs/public-preview-server.md.",
   "branches": [
     {
       "repo": "yschimke/compose-ai-tools",
@@ -15,6 +15,10 @@
     },
     {
       "repo": "yschimke/cadence",
+      "branch": "design-artifacts/*"
+    },
+    {
+      "repo": "yschimke/compose-samples",
       "branch": "design-artifacts/*"
     },
     {

--- a/trust/producers.json
+++ b/trust/producers.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Producer-trust allowlist for a public `compose-preview serve --trust-store`. Three independent bases — pinned Ed25519 keys, trusted GitHub branches (origin trust), and CI provenance identities. A bundle/catalog the server can attribute to one of these is shown as trusted (and, with operator opt-in, eligible for server-side re-render of its executable Compose); everything else still serves its data tiers as `unverified`. Empty = trust nothing (fail-closed). See docs/public-preview-server.md.",
+  "_comment": "NOT THE FILE THE PUBLIC SERVER USES. The preview.coo.ee image is built with context `deploy/image`, so the Dockerfile's `COPY trust/ /trust/` bakes deploy/image/trust/producers.json \u2014 not this one. Edit BOTH, or the catalog appears on the front page (SERVE_CATALOGS lives in deploy/image/entrypoint.sh, which IS baked) while badging `unverified`, which is how #2750 shipped half a change. This copy is the reference/example for operators running their own server with --trust-store. Producer-trust allowlist for a public `compose-preview serve --trust-store`. Three independent bases \u2014 pinned Ed25519 keys, trusted GitHub branches (origin trust), and CI provenance identities. A bundle/catalog the server can attribute to one of these is shown as trusted (and, with operator opt-in, eligible for server-side re-render of its executable Compose); everything else still serves its data tiers as `unverified`. Empty = trust nothing (fail-closed). See docs/public-preview-server.md.",
   "keys": [
     {
       "keyId": "compose-ai-tools-ci",
@@ -32,7 +32,7 @@
   ],
   "oidc": [
     {
-      "_comment": "Advisory until full Sigstore/Fulcio+Rekor verification lands — an oidc entry only annotates a signature a pinned key already verified; it does not by itself grant trust.",
+      "_comment": "Advisory until full Sigstore/Fulcio+Rekor verification lands \u2014 an oidc entry only annotates a signature a pinned key already verified; it does not by itself grant trust.",
       "identity": "repo:yschimke/compose-ai-tools:ref:refs/heads/main"
     }
   ]


### PR DESCRIPTION
## Summary

All six compose-samples catalogs badge **⚠ unverified** on preview.coo.ee, and are therefore refused server-side re-render (fail-closed), even though #2750 added `yschimke/compose-samples` to `trust/producers.json`.

There are **two** `producers.json` in this repo, and #2750 edited the one that isn't shipped:

- `preview-host-image.yml` builds with `context: deploy/image`
- the Dockerfile's `COPY trust/ /trust/` resolves against that context
- so the image bakes **`deploy/image/trust/producers.json`**
- the repo-root `trust/producers.json` never enters the image

#2750's other half — `SERVE_CATALOGS` — lives in `deploy/image/entrypoint.sh`, which *is* baked. So the catalogs appeared on the front page while their trust silently didn't apply: exactly the "half a change" shape that's hard to spot, because the visible symptom (they're listed) looks like success.

## How it was diagnosed

Not by reading the diff — by reading the running server, which is what made it unambiguous:

- `/status` shows `joreilly/Confetti@design-artifacts/*` as ✓ trusted. Confetti has **never** appeared in the repo-root `trust/producers.json` (`git log -S'joreilly/Confetti'` on that path returns nothing). It *is* in `deploy/image/trust/producers.json`. So the effective store had to be the latter.
- `/version` reports `0.17.23`, so this isn't a stale image lagging the fix.
- Every other producer in `deploy/image/trust/producers.json` is trusted live; the only unverified rows are the six compose-samples ones — the exact set missing from that file.

## Changes

- Add `yschimke/compose-samples` → `design-artifacts/*` to `deploy/image/trust/producers.json` (the baked one).
- Prefix the repo-root `trust/producers.json` `_comment` with a warning that it is **not** the file the public server uses, naming the context/COPY mechanism and this incident. Cheapest way to stop the next edit going to the decoy.

## Test plan

- `jq .` clean on both files; branch list verified to contain compose-samples exactly once.
- **Verification is the live badge, not CI**: once the image republishes and the host rolls, the six compose-samples rows on https://preview.coo.ee/status should read `✓ trusted` instead of `⚠ unverified`, and become eligible for server-side re-render. I can't verify that from CI — the trust decision is made by the deployed server against the baked file.
- Non-visual (deploy config) — no rendered surface changes.

## Worth considering separately

Two files that must agree, where disagreement is silent and only observable in production, will do this again. Options: make the root file a symlink, drop it entirely, or add a check that the two branch lists match. I haven't done any of those here — it's a design call, and this PR is the fix for the live symptom.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RMHn8ZzptyeQQDx1tiVjj3)_