### PR TITLE
fix(gradle-plugin): order composePreviewDaemonStart after composePreviewDiscover

### DIFF
--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DaemonBootstrapFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DaemonBootstrapFunctionalTest.kt
@@ -42,6 +42,54 @@ class DaemonBootstrapFunctionalTest {
       .isIn(listOf(TaskOutcome.UP_TO_DATE, TaskOutcome.FROM_CACHE))
   }
 
+  @Test
+  fun `discover and daemonStart in one invocation pass validation, discover first`() {
+    // `previewsManifest` is an @InputFile pointing at composePreviewDiscover's `previews.json`, but
+    // it's wired from a layout directory Provider that carries no build dependency. Gradle's strict
+    // validation rejected the pair the moment both tasks were in one graph:
+    //
+    //   Task ':composePreviewDaemonStart' uses this output of task ':composePreviewDiscover'
+    //   without declaring an explicit or implicit dependency.
+    //
+    // Only reproducible with both tasks requested together, which is why it survived until a
+    // combined invocation happened to be run by hand.
+    val projectDir = createCmpTestProject()
+
+    val result =
+      GradleRunner.create()
+        .withProjectDir(projectDir)
+        .withArguments("composePreviewDiscover", "composePreviewDaemonStart", "--stacktrace")
+        .withPluginClasspath()
+        .build()
+
+    assertThat(result.task(":composePreviewDaemonStart")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+
+    val executed = result.tasks.map { it.path }
+    assertThat(executed).containsAtLeast(":composePreviewDiscover", ":composePreviewDaemonStart")
+    assertThat(executed.indexOf(":composePreviewDiscover"))
+      .isLessThan(executed.indexOf(":composePreviewDaemonStart"))
+  }
+
+  @Test
+  fun `daemonStart alone does not drag in discovery`() {
+    // Guards the choice of `mustRunAfter` over `dependsOn`. The daemon has to be warmable before
+    // anything has been discovered — that's why `previewsManifest` is @Optional (see its kdoc, and
+    // DaemonMain's `manifestFile.isFile` check). "Fixing" the validation error with `dependsOn`
+    // would satisfy Gradle and silently make every VS Code warm pay for a full discovery pass,
+    // deleting the fresh-module path the optionality exists to serve. This fails if anyone does.
+    val projectDir = createCmpTestProject()
+
+    val result =
+      GradleRunner.create()
+        .withProjectDir(projectDir)
+        .withArguments("composePreviewDaemonStart", "--stacktrace")
+        .withPluginClasspath()
+        .build()
+
+    assertThat(result.task(":composePreviewDaemonStart")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+    assertThat(result.task(":composePreviewDiscover")).isNull()
+  }
+
   private fun createCmpTestProject(): File {
     val projectDir = tempDir.root
 

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -2876,6 +2876,20 @@ internal object AndroidPreviewSupport {
           }
         }
       )
+      // …but that Provider is derived from a layout directory, not from `composePreviewDiscover`'s
+      // output, so it carries no build dependency. Gradle's strict validation rejects that the
+      // moment both tasks are in one graph:
+      //
+      //   Task ':composePreviewDaemonStart' uses this output of task ':composePreviewDiscover'
+      //   without declaring an explicit or implicit dependency.
+      //
+      // `mustRunAfter`, not `dependsOn`: the daemon must be warmable *before* anything has been
+      // discovered — that's the whole reason `previewsManifest` is `@Optional` (see its kdoc, and
+      // DaemonMain's `manifestFile.isFile` check). Forcing discovery here would make every VS Code
+      // warm pay for a full discovery pass and would delete the fresh-module path the optionality
+      // exists to serve. Ordering-only is exactly the relation that holds: if discovery is in the
+      // graph it must land first, and if it isn't, nothing changes.
+      mustRunAfter(discoverTask)
       this.outputFile.set(previewOutputDir.map { it.file("daemon-launch.json") })
     }
   }

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -814,6 +814,12 @@ internal object ComposePreviewTasks {
           }
         }
       )
+      // Ordering-only relation to the manifest's producer — same reasoning as the Android
+      // registration: that Provider carries no build dependency, so Gradle's strict validation
+      // rejects the pair once both tasks are in one graph, and `dependsOn` would break warming a
+      // daemon before anything has been discovered. Referenced by name because the desktop
+      // pipeline registers discovery separately from this block.
+      mustRunAfter("composePreviewDiscover")
       outputFile.set(outputFileProvider)
       dependsOn(daemonClasspathGuard)
       // Stage the consumer's resources (so `sourceResourceDirs` on the daemon `-cp` is populated)


### PR DESCRIPTION
## Summary

Fixes the implicit-dependency validation failure I found while testing #2761 and flagged there. Reproduced on unmodified `main` before attributing it, so it predates that change.

`DaemonBootstrapTask.previewsManifest` is an `@InputFile` pointing at `composePreviewDiscover`'s `previews.json`, but it's wired from a **layout directory** Provider:

```kotlin
previewsManifest.fileProvider(
  previewOutputDir.flatMap { dir ->
    project.providers.provider {
      val f = dir.file("previews.json").asFile
      if (f.isFile) f else null
    }
  }
)
```

That Provider carries no build dependency — nothing connects it to the task that writes the file — so Gradle's strict validation rejects the pair the moment both tasks are in one graph:

```
Task ':composePreviewDaemonStart' uses this output of task ':composePreviewDiscover'
without declaring an explicit or implicit dependency.
```

It's only reproducible with both tasks requested together, which is why it survived: the VS Code warm path and the render path each request one.

## `mustRunAfter`, not `dependsOn`

Gradle offers both as fixes and `dependsOn` is the reflex, but it's wrong here.

The daemon must stay warmable **before anything has been discovered** — that's the entire reason `previewsManifest` is `@Optional`, and `DaemonMain`'s `manifestFile.isFile` check is the other half of the same design. `dependsOn` would satisfy the validator and quietly make every editor warm pay for a full discovery pass, deleting the fresh-module path the optionality exists to serve.

Ordering-only is the relation that actually holds: discovery first when it's in the graph, nothing changed when it isn't.

Applied to both backends — the Android registration and the CMP/desktop one, which had identical wiring.

## Test plan

Both directions verified on `:samples:android`:

| | before | after |
| --- | --- | --- |
| `composePreviewRender composePreviewDaemonStart` together | **FAILED** — implicit dependency | **SUCCESS**, discover ordered ahead |
| `composePreviewDaemonStart` alone, `previews.json` deleted | success | **success in 10s, discover does NOT run**, descriptor still written |

The second row is the one that matters for the `mustRunAfter` choice — `dependsOn` would have dragged discovery in.

Two functional tests added to `DaemonBootstrapFunctionalTest` covering both. I confirmed the combined-invocation test **fails with the fix reverted**, so it guards the regression rather than passing vacuously.

`:gradle-plugin:test` and `:gradle-plugin:ktfmtCheck` green.

Non-visual — task-graph wiring only, no renderer or output changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ULa9AYFHcJgEQmKbzJPYtx)_