### PR TITLE
ci: stop cancelling preview baseline runs on main

### DIFF
--- a/.github/workflows/compose-preview.yml
+++ b/.github/workflows/compose-preview.yml
@@ -48,7 +48,22 @@ concurrency:
   # Per-PR group so concurrent PRs don't cancel each other; push + dispatch
   # share one slot per ref.
   group: compose-preview-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  # PR runs cancel: a new push supersedes the render, and the comment is
+  # sticky so only the newest result matters.
+  #
+  # Baseline runs on main MUST NOT. They publish the "before" state every
+  # later PR diffs against, so cancelling one doesn't just waste a render —
+  # it strands the baseline at an older commit, and every subsequent PR
+  # reports the skipped commits' output as its own New/Changed/Removed. Back-
+  # to-back merges made that the norm rather than the exception: 24 of the 30
+  # main runs before this change were cancelled, so the baseline was stale far
+  # more often than not (#2766 and #2765, two PRs that touch no renderer code,
+  # both reported 19 phantom New + 19 Removed variants inherited from #2763).
+  #
+  # Queueing instead of cancelling is bounded, not unbounded: GitHub keeps at
+  # most one *pending* run per group and cancels the older pending one, so a
+  # burst of N merges runs the first and the last, not all N.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   # Keeps the historical job id + check name ("Apply compose-preview") so

--- a/.github/workflows/vscode-preview-baselines.yml
+++ b/.github/workflows/vscode-preview-baselines.yml
@@ -22,7 +22,15 @@ permissions:
 
 concurrency:
   group: vscode-preview-baselines
-  cancel-in-progress: true
+  # Same reasoning as `compose-preview.yml`: this workflow only ever
+  # publishes the "before" state for `vscode-preview-comment.yml`, so a
+  # cancelled run leaves `vscode-preview/main` behind the commits it skipped
+  # and every later PR inherits their diff. There is no PR trigger here at
+  # all — push-to-main and dispatch only — so cancelling can never be the
+  # right call. The path filter keeps this rare, but "rare" still means a
+  # silently stale baseline when two `vscode-extension/**` merges land close
+  # together.
+  cancel-in-progress: false
 
 jobs:
   update:


### PR DESCRIPTION
## Summary

The preview baseline on `main` is stale most of the time, and it has been silently poisoning the diff bot on unrelated PRs.

`compose-preview.yml` and `vscode-preview-baselines.yml` both publish the "before" state that later PRs diff against, and both carried `cancel-in-progress: true` on a concurrency group that push-to-`main` shares. So back-to-back merges don't supersede a redundant render — they **kill the baseline refresh**:

```
30168498925 22ee83076 push in_progress   ci: reject agent authorship on every branch (#2765)
30167938150 87bbc0ba4 push cancelled     fix(serve): trust compose-samples … (#2764)
30167490283 2640f88b9 push cancelled     fix(renderer): settle each Lottie APNG step … (#2762)
30167461027 16a64b33a push cancelled     feat(design-catalog-remote-m3): Wear render density (#2763)
30167357457 d9f5e0f5f push cancelled     feat(gradle-plugin): split-family version skew (#2761)
30165267442 f5b5c0f47 push success       fix(catalog): tag remote-m3 as dark-theme (#2759)
```

**24 of the last 30 `Compose Preview` runs on `main` were cancelled.** Five succeeded. The published baseline sat at `f5b5c0f47` while `main` moved four commits past it.

## What it costs

Every PR opened after a skipped baseline inherits the skipped commits' output *as its own diff*. Two PRs currently open, neither touching renderer code, prove it:

- **#2766** (Gradle task ordering) and **#2765** (CI hooks) each report the **same** 19 New + 19 Removed variants in `samples:design-catalog-remote-m3`, function names identical in both lists, the "New" ones carrying `_dpi_320` filename suffixes. That is #2763's density change — whose own baseline run was cancelled 48 seconds after it started.
- Both also report `lottie/spin.json` as changed against base render `7c601964`. That's #2762's APNG fix showing against a pre-#2762 baseline — not the nondeterminism I couldn't reproduce when it appeared on #2761.

So the bot's headline output on a PR is routinely someone else's change. In a repo whose stated purpose is putting rendered output in front of reviewers, a baseline that's stale 80% of the time makes the visual evidence actively misleading rather than merely absent.

## The fix

`cancel-in-progress: ${{ github.event_name == 'pull_request' }}` on `compose-preview.yml`.

PR runs still cancel — a new push genuinely supersedes the render, and the comment is sticky, so only the newest result matters. Baseline runs queue instead.

Queueing is **bounded, not unbounded**: GitHub keeps at most one *pending* run per concurrency group and cancels the older pending one when a newer arrives. A burst of N merges therefore renders the first and the last, not all N — the baseline converges on the newest commit at the cost of one extra render per burst.

`vscode-preview-baselines.yml` has no `pull_request` trigger at all (push-to-`main` + dispatch only), so cancelling there can never be right — plain `false`.

`xr-composite-build.yml` has the same group shape and is deliberately left alone: it's build-only, uploads CI artifacts, and nothing later diffs against it.

## Test plan

Config-only; the behaviour is GitHub-side scheduling, so there's nothing to unit-test locally.

- Both files parse and resolve as intended (`yaml.safe_load`): `compose-preview` → `cancel-in-progress: "${{ github.event_name == 'pull_request' }}"`, `vscode-preview-baselines` → `False`.
- Expressions are permitted in `concurrency.cancel-in-progress`, and `github.event_name` is in scope there.
- This PR's own `Compose Preview` run exercises the `pull_request` branch of the expression — it must still cancel on a force-push, and the run appearing at all confirms the expression evaluates.
- The `main` branch is observable after merge: the next pair of closely-spaced merges should show the earlier run `completed/success` rather than `cancelled`.

The change can't be verified by making the phantom diff disappear on this PR — the stale baseline is already published, and only a *successful* main run replaces it. Expect this PR's own bot comment to carry the same 19 phantom variants until a baseline run completes on `main`.

Non-visual — CI scheduling only, no renderer or fixture changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ULa9AYFHcJgEQmKbzJPYtx)_