### PR TITLE
fix(bundle): bound figma-raster crops when packing, not only when serving

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
@@ -1422,17 +1422,31 @@ internal fun injectFigmaSvgIntoBundle(
  * href="figma-raster/<node>.png">` layers resolve after the export carries them. Same in-place,
  * idempotent, byte-stable contract as the other injectors. Returns the number of crops written
  * across all previews.
+ *
+ * Each crop is bounded to [maxEdgePx] on its longest edge on the way in. Crops arrive at device
+ * resolution, and the only consumer — the serve host inlining them into a self-contained figma-svg
+ * — has always downsampled to exactly this bound before serving them, so the extra pixels were
+ * carried across the network and then discarded. They are not free: a handful of full-screen photo
+ * crops pushed Jetchat's live bundle to 27MB, past the serve host's 25MiB per-file fetch cap, and
+ * the catalog silently degraded to baked PNGs. Pass `Int.MAX_VALUE` to store crops verbatim.
+ *
+ * Byte-stability is preserved: [downscaleRaster] returns the original bytes unchanged for a crop
+ * already within the bound (the common case — component-sized crops), for one that fails to decode,
+ * and for one whose re-encode wouldn't actually shrink it. So re-packing an already-bounded bundle
+ * writes identical entries.
  */
 internal fun injectFigmaRasterIntoBundle(
   bundleFile: File,
   figmaRasterById: Map<String, Map<String, ByteArray>>,
   fileSystem: FileSystem = SystemFileSystem,
+  maxEdgePx: Int = MAX_FIGMA_RASTER_EDGE_PX,
 ): Int {
   val entries =
     figmaRasterById.entries
       .flatMap { (id, crops) ->
         crops.map { (name, bytes) ->
-          "$BUNDLE_PREVIEWS_DIR/$id$BUNDLE_FIGMA_RASTER_DIR_SUFFIX/$name" to bytes
+          "$BUNDLE_PREVIEWS_DIR/$id$BUNDLE_FIGMA_RASTER_DIR_SUFFIX/$name" to
+            downscaleRaster(bytes, maxEdgePx)
         }
       }
       .toMap()

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/FigmaRasterScaling.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/FigmaRasterScaling.kt
@@ -1,0 +1,56 @@
+package ee.schimke.composeai.cli
+
+/**
+ * Longest-edge bound (px) for a hybrid figma-svg's raster crops, applied in **two** places that
+ * must agree:
+ * - `bundle pack` / the export, when a crop is written into the bundle
+ *   ([injectFigmaRasterIntoBundle]);
+ * - the serve host, when a crop is base64-inlined into a self-contained figma-svg
+ *   (`inlineFigmaRasters`).
+ *
+ * One constant, deliberately. A crop is captured at device resolution, so a full-screen photo
+ * region runs to megabytes, and the serve host has always downsampled to this bound before anyone
+ * saw the pixels — storing the originals bought nothing for the only consumer and cost the bundle
+ * real bytes. Jetchat's profile stickers were 1176x1050 crops at ~1.9MB each; six of them made its
+ * live bundle 27MB, past the serve host's 25MiB per-file fetch cap, so the catalog silently fell
+ * back to baked PNGs. Bounding at pack time took that bundle to ~22.5MB and the crops stayed
+ * pixel-identical to what the server was already serving.
+ *
+ * 1024px keeps a component-sized crop untouched and a screen-sized one at roughly
+ * thumbnail-to-retina fidelity — right for a design reference layer. If these two call sites ever
+ * diverge, the waste comes straight back, so change the bound here rather than at either site.
+ */
+internal const val MAX_FIGMA_RASTER_EDGE_PX: Int = 1024
+
+/**
+ * [png] re-encoded with its longest edge capped at [maxEdgePx] (aspect preserved, bilinear), or the
+ * original bytes when it's already within the cap, fails to decode, or the re-encode doesn't
+ * actually shrink the payload (a tiny palette PNG can grow when re-encoded as ARGB). Never throws —
+ * both callers must degrade to the full-resolution bytes rather than a broken layer or a failed
+ * pack.
+ */
+internal fun downscaleRaster(png: ByteArray, maxEdgePx: Int): ByteArray {
+  if (maxEdgePx <= 0 || maxEdgePx == Int.MAX_VALUE) return png
+  return try {
+    val image = javax.imageio.ImageIO.read(java.io.ByteArrayInputStream(png)) ?: return png
+    val longest = maxOf(image.width, image.height)
+    if (longest <= maxEdgePx) return png
+    val scale = maxEdgePx.toDouble() / longest
+    val w = (image.width * scale).toInt().coerceAtLeast(1)
+    val h = (image.height * scale).toInt().coerceAtLeast(1)
+    val scaled = java.awt.image.BufferedImage(w, h, java.awt.image.BufferedImage.TYPE_INT_ARGB)
+    scaled.createGraphics().run {
+      setRenderingHint(
+        java.awt.RenderingHints.KEY_INTERPOLATION,
+        java.awt.RenderingHints.VALUE_INTERPOLATION_BILINEAR,
+      )
+      drawImage(image, 0, 0, w, h, null)
+      dispose()
+    }
+    val out = java.io.ByteArrayOutputStream()
+    javax.imageio.ImageIO.write(scaled, "png", out)
+    out.toByteArray().takeIf { it.isNotEmpty() && it.size < png.size } ?: png
+  } catch (t: Throwable) {
+    png
+  }
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeFigmaSvg.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeFigmaSvg.kt
@@ -1,5 +1,7 @@
 package ee.schimke.composeai.cli.serve
 
+import ee.schimke.composeai.cli.MAX_FIGMA_RASTER_EDGE_PX
+import ee.schimke.composeai.cli.downscaleRaster
 import java.util.Base64
 import okio.FileSystem
 import okio.Path
@@ -32,10 +34,13 @@ internal fun figmaRasterHrefs(svg: String): List<String> =
  * run to megabytes — and the base64 embedding adds a third on top, ballooning the "paste into
  * Figma" SVG. A crop whose longest edge exceeds this is downscaled (aspect preserved) before
  * embedding; the SVG's `<image x y width height>` box is unchanged, so the bitmap still fills the
- * layer exactly, just at a bounded density. 1024px keeps a component-sized crop untouched and a
- * screen-sized one at roughly thumbnail-to-retina fidelity — right for a design reference layer.
+ * layer exactly, just at a bounded density.
+ *
+ * Aliases the shared [MAX_FIGMA_RASTER_EDGE_PX], which `bundle pack` now applies when it *writes* a
+ * crop — the two must stay equal or the pack-time bound would either discard pixels this path still
+ * wanted, or leave bytes it is about to throw away.
  */
-internal const val MAX_INLINE_RASTER_EDGE_PX: Int = 1024
+internal const val MAX_INLINE_RASTER_EDGE_PX: Int = MAX_FIGMA_RASTER_EDGE_PX
 
 /**
  * Inline an SVG's `figma-raster/<node>.png` crops as `data:image/png;base64` URIs, reading each
@@ -61,38 +66,6 @@ internal fun inlineFigmaRasters(
     val crop = fileSystem.read(cropPath) { readByteArray() }
     val bounded = downscaleRaster(crop, maxEdgePx)
     "href=\"data:image/png;base64,${Base64.getEncoder().encodeToString(bounded)}\""
-  }
-}
-
-/**
- * [png] re-encoded with its longest edge capped at [maxEdgePx] (aspect preserved, bilinear), or the
- * original bytes when it's already within the cap, fails to decode, or the re-encode doesn't
- * actually shrink the payload (a tiny palette PNG can grow when re-encoded as ARGB). Never throws —
- * a served SVG must degrade to the full-resolution embed rather than a broken layer.
- */
-internal fun downscaleRaster(png: ByteArray, maxEdgePx: Int): ByteArray {
-  if (maxEdgePx <= 0 || maxEdgePx == Int.MAX_VALUE) return png
-  return try {
-    val image = javax.imageio.ImageIO.read(java.io.ByteArrayInputStream(png)) ?: return png
-    val longest = maxOf(image.width, image.height)
-    if (longest <= maxEdgePx) return png
-    val scale = maxEdgePx.toDouble() / longest
-    val w = (image.width * scale).toInt().coerceAtLeast(1)
-    val h = (image.height * scale).toInt().coerceAtLeast(1)
-    val scaled = java.awt.image.BufferedImage(w, h, java.awt.image.BufferedImage.TYPE_INT_ARGB)
-    scaled.createGraphics().run {
-      setRenderingHint(
-        java.awt.RenderingHints.KEY_INTERPOLATION,
-        java.awt.RenderingHints.VALUE_INTERPOLATION_BILINEAR,
-      )
-      drawImage(image, 0, 0, w, h, null)
-      dispose()
-    }
-    val out = java.io.ByteArrayOutputStream()
-    javax.imageio.ImageIO.write(scaled, "png", out)
-    out.toByteArray().takeIf { it.isNotEmpty() && it.size < png.size } ?: png
-  } catch (t: Throwable) {
-    png
   }
 }
 

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleSemanticsInjectTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleSemanticsInjectTest.kt
@@ -36,6 +36,26 @@ class BundleSemanticsInjectTest {
     return baos.toByteArray()
   }
 
+  /**
+   * A [w]x[h] PNG of deterministic pseudo-random pixels. Flat-colour images compress to almost
+   * nothing, so they can't distinguish "bounded the crop" from "PNG is good at solid fills" — noise
+   * stands in for the photographic content that makes real crops expensive. Seeded from the
+   * coordinates, so the bytes are identical run to run.
+   */
+  private fun noisyPng(w: Int, h: Int): ByteArray {
+    val img = BufferedImage(w, h, BufferedImage.TYPE_INT_RGB)
+    var state = 0x9E3779B9.toInt()
+    for (y in 0 until h) {
+      for (x in 0 until w) {
+        state = state * 1664525 + 1013904223
+        img.setRGB(x, y, state ushr 8 and 0xFFFFFF)
+      }
+    }
+    val baos = ByteArrayOutputStream()
+    ImageIO.write(img, "png", baos)
+    return baos.toByteArray()
+  }
+
   private fun polyglot(cover: ByteArray, entries: Map<String, ByteArray>): File {
     val zip = ByteArrayOutputStream()
     ZipOutputStream(zip).use { z ->
@@ -225,6 +245,72 @@ class BundleSemanticsInjectTest {
     assertEquals(crop.toList(), names.getValue("previews/a.figma-raster/n1.png").toList())
     // SVG untouched.
     assertTrue("previews/a.figma.svg" in names.keys)
+  }
+
+  @Test
+  fun `an oversized figma-raster crop is bounded on the way into the bundle`() {
+    val file =
+      polyglot(
+        png(4, 8),
+        linkedMapOf("bundle.json" to "{}".toByteArray(), "previews/a.png" to png()),
+      )
+
+    // A device-resolution crop: 2048x1024 of incompressible noise, standing in for the full-screen
+    // photo regions that pushed a real catalog's bundle past the serve host's per-file fetch cap.
+    val crop = noisyPng(2048, 1024)
+    assertEquals(1, injectFigmaRasterIntoBundle(file, mapOf("a" to linkedMapOf("n1.png" to crop))))
+
+    val stored =
+      entries(BundleReader.extractZipBytes(file)).getValue("previews/a.figma-raster/n1.png")
+    val decoded = ImageIO.read(ByteArrayInputStream(stored))
+    assertEquals(1024, decoded.width, "longest edge bounded at MAX_FIGMA_RASTER_EDGE_PX")
+    assertEquals(512, decoded.height, "aspect ratio preserved")
+    assertTrue(
+      stored.size < crop.size,
+      "bounded crop should be smaller than the ${crop.size}-byte original, was ${stored.size}",
+    )
+  }
+
+  @Test
+  fun `a figma-raster crop within the bound is stored byte-for-byte`() {
+    val file =
+      polyglot(
+        png(4, 8),
+        linkedMapOf("bundle.json" to "{}".toByteArray(), "previews/a.png" to png()),
+      )
+
+    // Component-sized crops are the common case and must not be re-encoded: `bundle pack` is
+    // byte-stable, so re-packing an unchanged catalog has to produce an identical entry.
+    val crop = noisyPng(800, 600)
+    injectFigmaRasterIntoBundle(file, mapOf("a" to linkedMapOf("n1.png" to crop)))
+
+    val stored =
+      entries(BundleReader.extractZipBytes(file)).getValue("previews/a.figma-raster/n1.png")
+    assertEquals(
+      crop.toList(),
+      stored.toList(),
+      "within the bound → original bytes, not a re-encode",
+    )
+  }
+
+  @Test
+  fun `maxEdgePx of Int MAX_VALUE stores an oversized crop verbatim`() {
+    val file =
+      polyglot(
+        png(4, 8),
+        linkedMapOf("bundle.json" to "{}".toByteArray(), "previews/a.png" to png()),
+      )
+
+    val crop = noisyPng(2048, 1024)
+    injectFigmaRasterIntoBundle(
+      file,
+      mapOf("a" to linkedMapOf("n1.png" to crop)),
+      maxEdgePx = Int.MAX_VALUE,
+    )
+
+    val stored =
+      entries(BundleReader.extractZipBytes(file)).getValue("previews/a.figma-raster/n1.png")
+    assertEquals(crop.toList(), stored.toList(), "opt-out preserves the full-resolution crop")
   }
 
   @Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeFigmaSvgWebModeTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeFigmaSvgWebModeTest.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.cli.serve
 
+import ee.schimke.composeai.cli.downscaleRaster
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse


### PR DESCRIPTION
## Summary

A hybrid figma-svg's raster crops are stored at device resolution and bounded to 1024px on the longest edge only later, when the serve host base64-inlines them into a self-contained SVG (`downscaleRaster`, called from `inlineFigmaRasters` — `ServeBundleHost.kt:304` and `ServeRenderHost.kt:673`). That inline is the crops' **only** consumer, and neither caller passes the `Int.MAX_VALUE` escape hatch that would ask for full-resolution bytes. So every pixel above the bound was written onto the delivery branch, fetched over the network, and then discarded.

Those pixels aren't free. Jetchat's profile screen is a full-bleed photo, so each of six variants stored a ~1.9MB crop at 1.5–1.65 bytes/pixel:

```
1,920,301  1176x1050  1.56 B/px  ProfilePreview480MeDark….figma-raster/7.png
1,918,188  1176x1050  1.55 B/px  ProfilePreview480Me….figma-raster/130.png
1,331,548   1176x785  1.44 B/px  ProfilePreview480Other….figma-raster/23.png
…
```

figma-raster crops were **43% of that bundle** (11,632,214 of 27,023,731 bytes), which put it past the serve host's `MAX_FETCH_BYTES` (25 MiB, `ServeCatalogStore.kt:1043`). `readCapped` throws, `fetchLiveBundle` swallows it via `runCatching { fetch(url) }.getOrNull()`, and the catalog degrades to baked PNGs reporting only *"the bundle could not be fetched from the delivery branch"* — the size never reaches the message. The visible symptom is that the viewer's device / theme / knob controls silently stop working.

Applying the **existing** bound at pack time:

| catalog | figma-raster | bounded | bundle → |
|---|---:|---:|---:|
| jetchat | 11,632,214 | 7,132,171 | 27,023,731 → **~22.5MB** ✅ under 26,214,400 |
| jetnews | 4,711,461 | 2,769,284 | 14,605,516 → ~12.7MB |

Only 5 crops per bundle exceed 1024px, so the change is concentrated and the long tail is untouched. The stored crops become pixel-identical to what the server was already serving.

## Changes

- `downscaleRaster` and the bound move to a new `FigmaRasterScaling.kt` in `ee.schimke.composeai.cli`, so the pack and serve paths can't drift apart. `MAX_INLINE_RASTER_EDGE_PX` now aliases the shared `MAX_FIGMA_RASTER_EDGE_PX` — if the two ever diverge, the waste comes straight back.
- `injectFigmaRasterIntoBundle` takes `maxEdgePx` (default: the shared bound; `Int.MAX_VALUE` stores crops verbatim) and applies it to each crop. Both production callers — `BundleCommand.kt:572` and `Commands.kt:1350` — pick it up by default.

Byte-stability is preserved, which matters because `bundle pack` is expected to be reproducible: `downscaleRaster` returns the *original array* for a crop already within the bound (the common case), one that fails to decode, or one whose re-encode wouldn't shrink it. Re-packing an unchanged catalog writes identical entries.

This is deliberately narrower than raising `MAX_FETCH_BYTES`, which would treat the symptom. It also doesn't touch the related-but-separate finding that jetnews carries 1,236,751 bytes of pixel-identical duplicate crops — that wants the existing sha256-keyed `res/` pool (`bundle externalize`) extended from fonts to rasters, and is a fair-sized change of its own.

## Test plan

`./gradlew :cli:test --tests '*BundleSemanticsInjectTest*' --tests '*ServeFigmaSvg*'` — 22 tests, 0 failures. Three new cases in `BundleSemanticsInjectTest`:

- an oversized crop (2048x1024 of deterministic noise, since flat colour compresses too well to distinguish "bounded it" from "PNG is good at solid fills") is stored at 1024x512 with aspect preserved and fewer bytes;
- a crop within the bound is stored **byte-for-byte**, guarding reproducibility;
- `maxEdgePx = Int.MAX_VALUE` stores the oversized crop verbatim.

The pre-existing `injects hybrid figma-raster crops under a per-preview dir` still asserts byte-equality on a 6x6 crop and passes unchanged.

Not visually captured: this changes the resolution at which a raster *layer inside a figma-svg* is stored, and the served SVG is byte-identical to before the change — the server was already downsampling these crops to exactly this bound, so there is no before/after to render. The size figures above were measured against the published `design-artifacts/jetchat` and `design-artifacts/jetnews` bundles; the real check is the next catalog regen, where jetchat should move from "baked PNG" to live on preview.coo.ee.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RMHn8ZzptyeQQDx1tiVjj3)_