### PR TITLE
build: Prefer project repositories so Kotlin WASM Node distribution can resolve

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -28,7 +28,13 @@ val matrixRobolectricVersion: String? =
   providers.gradleProperty("composeai.matrix.robolectricVersion").orNull
 
 dependencyResolutionManagement {
-  repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+  // Kotlin's wasmJs toolchain resolves Node.js from an Ivy repository that the Kotlin Gradle
+  // plugin adds to the root project while kotlinWasmNodeJsSetup is realized. Rejecting or ignoring
+  // that project repository makes the aggregate `check` task fail before any tests run because
+  // org.nodejs:node is not published to our Maven repositories. The build scripts themselves keep
+  // dependency repositories centralized here; project preference exists solely so the plugin-owned
+  // Node.js distribution repository remains usable.
+  repositoriesMode.set(RepositoriesMode.PREFER_PROJECT)
   repositories {
     google()
     mavenCentral()


### PR DESCRIPTION
### Motivation

- Allow the Kotlin wasmJs toolchain's plugin-added Ivy repository (used to resolve the Node.js distribution) to be honored during dependency resolution because rejecting project repositories caused the aggregate `check` task to fail when `org.nodejs:node` could not be found in the centralized repos.

### Description

- Change `repositoriesMode` from `RepositoriesMode.FAIL_ON_PROJECT_REPOS` to `RepositoriesMode.PREFER_PROJECT` in `settings.gradle.kts` and add explanatory comments about the Kotlin Gradle plugin adding an Ivy repo for the Node distribution.

### Testing

- Ran `./gradlew check` locally and the build completed successfully, indicating dependency resolution and the aggregate checks no longer fail due to the kotlinWasm Node repository being rejected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a65520af494832485ca3312f82faa20)