### PR TITLE
fix(ci): wait out the daemon's cold sandbox boot in the round-trip test

### DIFF
--- a/.github/ci/daemon-roundtrip.py
+++ b/.github/ci/daemon-roundtrip.py
@@ -19,6 +19,13 @@ Asserts:
 * Every reported PNG path exists and is non-empty after both passes.
 * The PNG files were rewritten by the second pass (mtime advanced).
 
+`initialize` is the long pole: the Android daemon boots its whole
+Robolectric sandbox pool before it answers (see docs/daemon/STARTUP.md),
+which on a cold CI runner is minutes, not seconds. `--init-timeout-s`
+defaults to 600s to stay at or above the daemon's own
+`composeai.daemon.sandboxBootTimeoutMs` budget, so a slow boot surfaces as
+the daemon's failure rather than this script's impatience.
+
 The mtime check is the proof that the daemon actually re-rendered in
 response to the edit. We do NOT assert pixel diffs — a no-op-comment edit
 shouldn't change pixels, and pixel parity across recompiles is the
@@ -52,11 +59,19 @@ def _frame(payload: dict[str, Any]) -> bytes:
 
 
 class FramedReader:
-    """Reads LSP-framed JSON-RPC messages from a binary stream."""
+    """Reads LSP-framed JSON-RPC messages from a binary stream.
+
+    `read_message` returns None both when the stream hit EOF and when the
+    caller's timeout expired — [at_eof] is what tells the two apart. Callers
+    MUST check it: conflating them reports a healthy-but-slow daemon as a
+    crashed one, which is exactly the misdiagnosis that made a 120s
+    `initialize` timeout look like "daemon stream closed".
+    """
 
     def __init__(self, stream):
         self._stream = stream
         self._buf = bytearray()
+        self.at_eof = False
 
     def read_message(self, timeout_s: float) -> dict[str, Any] | None:
         deadline = time.monotonic() + timeout_s
@@ -64,6 +79,8 @@ class FramedReader:
             msg = self._try_extract()
             if msg is not None:
                 return msg
+            if self.at_eof:
+                return None
             remaining = deadline - time.monotonic()
             if remaining <= 0:
                 return None
@@ -72,7 +89,7 @@ class FramedReader:
                 continue
             chunk = os.read(self._stream.fileno(), 4096)
             if not chunk:
-                # EOF
+                self.at_eof = True
                 return None
             self._buf.extend(chunk)
 
@@ -148,6 +165,11 @@ class DaemonDriver:
         self._proc.stdin.write(_frame(payload))
         self._proc.stdin.flush()
 
+    def _exit_note(self) -> str:
+        """Suffix naming the daemon's exit code when it has already died."""
+        code = self._proc.poll() if self._proc is not None else None
+        return "" if code is None else f" (daemon process exited with code {code})"
+
     def request(self, method: str, params: dict[str, Any] | None, timeout_s: float = 60.0) -> dict[str, Any]:
         req_id = self._next_id
         self._next_id += 1
@@ -162,7 +184,13 @@ class DaemonDriver:
                 raise TimeoutError(f"no response to {method} (id={req_id}) within {timeout_s}s")
             msg = self._reader.read_message(remaining)
             if msg is None:
-                raise RuntimeError(f"daemon stream closed before responding to {method}")
+                if not self._reader.at_eof:
+                    # Timeout, not a dead daemon — loop so the deadline check
+                    # above raises the accurate TimeoutError.
+                    continue
+                raise RuntimeError(
+                    f"daemon stream closed before responding to {method}{self._exit_note()}"
+                )
             if "id" in msg and msg.get("id") == req_id:
                 if "error" in msg:
                     raise RuntimeError(f"{method} returned error: {msg['error']}")
@@ -197,7 +225,11 @@ class DaemonDriver:
                 )
             msg = self._reader.read_message(time_left)
             if msg is None:
-                raise RuntimeError("daemon stream closed mid-collect")
+                if not self._reader.at_eof:
+                    # Timeout — let the deadline check above raise with the
+                    # "only saw N/M" detail rather than blaming the transport.
+                    continue
+                raise RuntimeError(f"daemon stream closed mid-collect{self._exit_note()}")
             if msg.get("method") in methods:
                 collected.append(msg)
             else:
@@ -351,7 +383,23 @@ def main() -> int:
         "'--no-configuration-cache -Dorg.gradle.unsafe.isolated-projects=false')",
     )
     ap.add_argument("--render-timeout-s", type=float, default=180.0)
+    ap.add_argument(
+        "--init-timeout-s",
+        type=float,
+        default=600.0,
+        help="how long to wait for the `initialize` response. The Android daemon "
+        "does NOT answer initialize until its Robolectric sandbox pool is booted "
+        "(docs/daemon/STARTUP.md), and that boot is budgeted at 10 minutes by "
+        "`composeai.daemon.sandboxBootTimeoutMs`. Keep this >= that budget so a "
+        "cold runner reports the daemon's own failure instead of our impatience.",
+    )
     args = ap.parse_args()
+
+    # Line-buffer stdout so this script's progress interleaves correctly with
+    # the daemon's (unbuffered) stderr in CI logs. Block-buffered stdout dumps
+    # every print at exit, which puts the whole round-trip narrative *after*
+    # the stack trace that ended it.
+    sys.stdout.reconfigure(line_buffering=True)
 
     descriptor_path = Path(args.descriptor)
     descriptor = json.loads(descriptor_path.read_text())
@@ -396,6 +444,10 @@ def main() -> int:
     driver = DaemonDriver(descriptor, workspace)
     driver.spawn()
     try:
+        print(
+            f"[daemon-roundtrip] waiting up to {args.init_timeout_s:.0f}s for initialize "
+            "(the daemon boots its Robolectric sandbox pool first — cold boots are slow)"
+        )
         init_result = driver.request(
             "initialize",
             {
@@ -406,7 +458,7 @@ def main() -> int:
                 "moduleProjectDir": descriptor["workingDirectory"],
                 "capabilities": {"visibility": True, "metrics": True},
             },
-            timeout_s=120.0,
+            timeout_s=args.init_timeout_s,
         )
         proto = init_result.get("protocolVersion")
         if proto != 2:

--- a/.github/ci/daemon-roundtrip.py
+++ b/.github/ci/daemon-roundtrip.py
@@ -21,10 +21,11 @@ Asserts:
 
 `initialize` is the long pole: the Android daemon boots its whole
 Robolectric sandbox pool before it answers (see docs/daemon/STARTUP.md),
-which on a cold CI runner is minutes, not seconds. `--init-timeout-s`
-defaults to 600s to stay at or above the daemon's own
-`composeai.daemon.sandboxBootTimeoutMs` budget, so a slow boot surfaces as
-the daemon's failure rather than this script's impatience.
+one slot at a time, and on a cold CI runner that is minutes, not seconds.
+`--init-timeout-s` therefore defaults to the daemon's own pool-wide worst
+case — slots × `composeai.daemon.sandboxBootTimeoutMs`, read from the
+launch descriptor — so a slow boot surfaces as the daemon's failure rather
+than this script's impatience.
 
 The mtime check is the proof that the daemon actually re-rendered in
 response to the edit. We do NOT assert pixel diffs — a no-op-comment edit
@@ -353,6 +354,68 @@ def _edit_source_file(path: Path, marker: str) -> None:
     print(f"[daemon-roundtrip] edited {path} (appended marker '{marker}')")
 
 
+# Daemon-side knobs that decide how long `initialize` can legitimately take.
+# Mirrors DaemonMain.kt / RobolectricHost.kt — see _derive_init_timeout_s.
+_SANDBOX_COUNT_PROP = "composeai.daemon.sandboxCount"
+_WARM_SPARE_PROP = "composeai.daemon.warmSpare"
+_WARM_SPARE_SANDBOX_COUNT = 5
+_BACKGROUND_BOOT_PROP = "composeai.daemon.backgroundSandboxBoot"
+_BOOT_TIMEOUT_PROP = "composeai.daemon.sandboxBootTimeoutMs"
+_DEFAULT_BOOT_TIMEOUT_MS = 10 * 60 * 1000
+# Slack over the daemon's own worst case: JVM start, classpath resolve, and the
+# JSON-RPC hop that carries the response back.
+_INIT_TIMEOUT_SLACK_S = 60.0
+
+
+def _prop_is_true(props: dict[str, Any], key: str, default: bool) -> bool:
+    raw = props.get(key)
+    if raw is None:
+        return default
+    return str(raw).strip().lower() == "true"
+
+
+def _derive_init_timeout_s(descriptor: dict[str, Any]) -> float:
+    """How long `initialize` may legitimately take, given the launch descriptor.
+
+    The Android daemon answers `initialize` only once `RobolectricHost.start()`
+    returns, and that boots the eager sandbox slots SEQUENTIALLY, applying
+    `composeai.daemon.sandboxBootTimeoutMs` (10 min default) to EACH slot. A
+    warm-spare pool is 5 slots, so the daemon's own worst case is 5 × 10 min —
+    a flat client budget under that would once again blame our impatience for
+    the daemon's slowness. Derive from the same properties the descriptor
+    launches the JVM with so the two can't drift.
+
+    Under `backgroundSandboxBoot` only slot 0 is on the critical path.
+
+    A ceiling this high doesn't strand CI on a wedged daemon: a slot that
+    misses its budget makes the daemon exit, which lands as EOF and fails us
+    immediately. It only buys patience for a daemon that is still working.
+    """
+    props = descriptor.get("systemProperties") or {}
+    boot_timeout_ms = _DEFAULT_BOOT_TIMEOUT_MS
+    raw_timeout = props.get(_BOOT_TIMEOUT_PROP)
+    if raw_timeout is not None:
+        try:
+            boot_timeout_ms = int(str(raw_timeout).strip())
+        except ValueError:
+            pass
+    raw_count = props.get(_SANDBOX_COUNT_PROP)
+    try:
+        sandbox_count = int(str(raw_count).strip()) if raw_count is not None else None
+    except ValueError:
+        sandbox_count = None
+    if sandbox_count is None:
+        # DaemonMain: warmSpare (default on) implies a 5-sandbox pool.
+        sandbox_count = (
+            _WARM_SPARE_SANDBOX_COUNT
+            if _prop_is_true(props, _WARM_SPARE_PROP, default=True)
+            else 1
+        )
+    sandbox_count = max(1, sandbox_count)
+    eager_slots = 1 if _prop_is_true(props, _BACKGROUND_BOOT_PROP, default=False) else sandbox_count
+    return eager_slots * (boot_timeout_ms / 1000.0) + _INIT_TIMEOUT_SLACK_S
+
+
 def _gradle_recompile(workspace: Path, gradle_args: list[str]) -> None:
     cmd = ["./gradlew", *gradle_args, "compileDebugKotlin", "--quiet"]
     print(f"[daemon-roundtrip] running: {' '.join(cmd)} (cwd={workspace})")
@@ -386,12 +449,14 @@ def main() -> int:
     ap.add_argument(
         "--init-timeout-s",
         type=float,
-        default=600.0,
+        default=None,
         help="how long to wait for the `initialize` response. The Android daemon "
         "does NOT answer initialize until its Robolectric sandbox pool is booted "
-        "(docs/daemon/STARTUP.md), and that boot is budgeted at 10 minutes by "
-        "`composeai.daemon.sandboxBootTimeoutMs`. Keep this >= that budget so a "
-        "cold runner reports the daemon's own failure instead of our impatience.",
+        "(docs/daemon/STARTUP.md), one slot at a time, each with its own "
+        "`composeai.daemon.sandboxBootTimeoutMs` budget. Defaults to that "
+        "pool-wide worst case, derived from the descriptor's own system "
+        "properties (60s slack on top), so a cold runner reports the daemon's "
+        "failure instead of our impatience.",
     )
     args = ap.parse_args()
 
@@ -444,8 +509,13 @@ def main() -> int:
     driver = DaemonDriver(descriptor, workspace)
     driver.spawn()
     try:
+        init_timeout_s = (
+            args.init_timeout_s
+            if args.init_timeout_s is not None
+            else _derive_init_timeout_s(descriptor)
+        )
         print(
-            f"[daemon-roundtrip] waiting up to {args.init_timeout_s:.0f}s for initialize "
+            f"[daemon-roundtrip] waiting up to {init_timeout_s:.0f}s for initialize "
             "(the daemon boots its Robolectric sandbox pool first — cold boots are slow)"
         )
         init_result = driver.request(
@@ -458,7 +528,7 @@ def main() -> int:
                 "moduleProjectDir": descriptor["workingDirectory"],
                 "capabilities": {"visibility": True, "metrics": True},
             },
-            timeout_s=args.init_timeout_s,
+            timeout_s=init_timeout_s,
         )
         proto = init_result.get("protocolVersion")
         if proto != 2:

--- a/.github/ci/test_daemon_roundtrip.py
+++ b/.github/ci/test_daemon_roundtrip.py
@@ -12,7 +12,6 @@ Only a real EOF on the daemon's stdout is a closed stream.
 import importlib.util
 import json
 import os
-import re
 import subprocess
 import sys
 import unittest
@@ -145,15 +144,60 @@ class CollectNotifications(_PipeFixture):
         self.assertIn("closed mid-collect", str(ctx.exception))
 
 
-class InitTimeoutDefault(unittest.TestCase):
-    """Client patience must be >= the daemon's own sandbox-boot budget.
+class InitTimeoutDerivation(unittest.TestCase):
+    """Client patience must cover the daemon's own pool-wide boot worst case.
 
-    The daemon defaults `composeai.daemon.sandboxBootTimeoutMs` to 10 minutes
-    and refuses to answer `initialize` until the pool is up, so anything below
-    that here turns a slow-but-healthy cold boot into a red CI leg.
+    `RobolectricHost.start()` boots the eager slots sequentially and applies
+    `composeai.daemon.sandboxBootTimeoutMs` to EACH one, so a warm-spare pool's
+    worst case is 5 x 10 minutes. A flat client budget under that turns a
+    slow-but-healthy cold boot into a red CI leg — the exact bug this file
+    exists to prevent.
     """
 
-    def test_flag_default_is_at_least_the_ten_minute_boot_budget(self):
+    TEN_MIN_S = 600.0
+
+    def derive(self, props):
+        return mod._derive_init_timeout_s({"systemProperties": props})
+
+    def test_warm_spare_pool_default_covers_five_sequential_slots(self):
+        # DaemonMain defaults warmSpare on -> 5 sandboxes.
+        self.assertGreaterEqual(self.derive({}), 5 * self.TEN_MIN_S)
+
+    def test_explicit_sandbox_count_wins(self):
+        derived = self.derive({"composeai.daemon.sandboxCount": "3"})
+        self.assertGreaterEqual(derived, 3 * self.TEN_MIN_S)
+        self.assertLess(derived, 4 * self.TEN_MIN_S)
+
+    def test_warm_spare_off_is_a_single_slot(self):
+        derived = self.derive({"composeai.daemon.warmSpare": "false"})
+        self.assertGreaterEqual(derived, self.TEN_MIN_S)
+        self.assertLess(derived, 2 * self.TEN_MIN_S)
+
+    def test_background_boot_puts_only_slot_zero_on_the_critical_path(self):
+        derived = self.derive({"composeai.daemon.backgroundSandboxBoot": "true"})
+        self.assertGreaterEqual(derived, self.TEN_MIN_S)
+        self.assertLess(derived, 2 * self.TEN_MIN_S)
+
+    def test_custom_boot_budget_is_honoured(self):
+        derived = self.derive(
+            {
+                "composeai.daemon.sandboxCount": "2",
+                "composeai.daemon.sandboxBootTimeoutMs": "30000",
+            }
+        )
+        self.assertGreaterEqual(derived, 60.0)
+        self.assertLess(derived, 5 * self.TEN_MIN_S)
+
+    def test_garbage_properties_fall_back_to_the_safe_default(self):
+        derived = self.derive(
+            {
+                "composeai.daemon.sandboxCount": "not-a-number",
+                "composeai.daemon.sandboxBootTimeoutMs": "soon",
+            }
+        )
+        self.assertGreaterEqual(derived, 5 * self.TEN_MIN_S)
+
+    def test_flag_is_still_documented_as_an_override(self):
         help_text = subprocess.run(
             [sys.executable, str(_HERE / "daemon-roundtrip.py"), "--help"],
             capture_output=True,
@@ -161,14 +205,6 @@ class InitTimeoutDefault(unittest.TestCase):
             check=True,
         ).stdout
         self.assertIn("--init-timeout-s", help_text)
-        match = re.search(r"--init-timeout-s INIT_TIMEOUT_S\s+.*?\(default: ([\d.]+)\)", help_text, re.S)
-        if match is None:
-            # argparse only prints the default when the help string asks for
-            # it; fall back to parsing the source constant.
-            match = re.search(r'"--init-timeout-s",\s*\n\s*type=float,\s*\n\s*default=([\d.]+)',
-                              (_HERE / "daemon-roundtrip.py").read_text())
-        self.assertIsNotNone(match, "could not determine the --init-timeout-s default")
-        self.assertGreaterEqual(float(match.group(1)), 600.0)
 
 
 if __name__ == "__main__":

--- a/.github/ci/test_daemon_roundtrip.py
+++ b/.github/ci/test_daemon_roundtrip.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Unit tests for daemon-roundtrip.py's JSON-RPC transport.
+
+Pure stdlib (unittest). Run: python3 .github/ci/test_daemon_roundtrip.py -v
+
+The cases pin the distinction that cost a CI misdiagnosis: a daemon that is
+alive but still booting its Robolectric sandbox pool must surface as a
+TimeoutError naming the method and the budget, NOT as "daemon stream closed".
+Only a real EOF on the daemon's stdout is a closed stream.
+"""
+
+import importlib.util
+import json
+import os
+import re
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+
+# Load daemon-roundtrip.py as a module (hyphenated filename → importlib).
+_spec = importlib.util.spec_from_file_location(
+    "daemon_roundtrip", _HERE / "daemon-roundtrip.py"
+)
+mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(mod)
+
+
+class FakeStdin:
+    """Collects the frames the driver writes, so requests don't need a JVM."""
+
+    def __init__(self):
+        self.written = bytearray()
+
+    def write(self, data):
+        self.written.extend(data)
+
+    def flush(self):
+        pass
+
+
+class FakeProc:
+    """Minimal subprocess.Popen stand-in: stdin sink + a settable exit code."""
+
+    def __init__(self, exit_code=None):
+        self.stdin = FakeStdin()
+        self._exit_code = exit_code
+
+    def poll(self):
+        return self._exit_code
+
+
+class _PipeFixture(unittest.TestCase):
+    """Wires a DaemonDriver to an os.pipe we can feed (or close) by hand."""
+
+    def setUp(self):
+        read_fd, self.write_fd = os.pipe()
+        self.read_end = os.fdopen(read_fd, "rb", buffering=0)
+        self.addCleanup(self.read_end.close)
+        self.addCleanup(self._close_write)
+        self.driver = mod.DaemonDriver({}, Path("."))
+        self.driver._proc = FakeProc()
+        self.driver._reader = mod.FramedReader(self.read_end)
+
+    def _close_write(self):
+        try:
+            os.close(self.write_fd)
+        except OSError:
+            pass
+
+    def feed(self, payload):
+        body = json.dumps(payload).encode("utf-8")
+        os.write(self.write_fd, f"Content-Length: {len(body)}\r\n\r\n".encode("ascii"))
+        os.write(self.write_fd, body)
+
+
+class FramedReaderEofVsTimeout(_PipeFixture):
+    def test_timeout_does_not_set_eof(self):
+        reader = self.driver._reader
+        self.assertIsNone(reader.read_message(timeout_s=0.05))
+        self.assertFalse(reader.at_eof, "a silent-but-open stream is not EOF")
+
+    def test_close_sets_eof(self):
+        self._close_write()
+        reader = self.driver._reader
+        self.assertIsNone(reader.read_message(timeout_s=5.0))
+        self.assertTrue(reader.at_eof)
+
+    def test_message_split_across_writes(self):
+        body = json.dumps({"jsonrpc": "2.0", "id": 1, "result": {"ok": True}}).encode()
+        os.write(self.write_fd, f"Content-Length: {len(body)}\r\n\r\n".encode("ascii"))
+        os.write(self.write_fd, body[:5])
+        os.write(self.write_fd, body[5:])
+        msg = self.driver._reader.read_message(timeout_s=5.0)
+        self.assertEqual(msg["result"], {"ok": True})
+
+
+class RequestErrors(_PipeFixture):
+    def test_slow_daemon_reports_timeout_not_closed_stream(self):
+        """The regression: initialize outliving its budget on a live daemon."""
+        with self.assertRaises(TimeoutError) as ctx:
+            self.driver.request("initialize", {}, timeout_s=0.2)
+        self.assertIn("initialize", str(ctx.exception))
+        self.assertNotIn("stream closed", str(ctx.exception))
+
+    def test_dead_daemon_reports_closed_stream_with_exit_code(self):
+        self.driver._proc = FakeProc(exit_code=1)
+        self._close_write()
+        with self.assertRaises(RuntimeError) as ctx:
+            self.driver.request("initialize", {}, timeout_s=30.0)
+        message = str(ctx.exception)
+        self.assertIn("stream closed", message)
+        self.assertIn("exited with code 1", message)
+
+    def test_response_returns_result(self):
+        self.feed({"jsonrpc": "2.0", "id": 1, "result": {"protocolVersion": 2}})
+        self.assertEqual(
+            self.driver.request("initialize", {}, timeout_s=5.0),
+            {"protocolVersion": 2},
+        )
+
+    def test_notifications_are_stashed_not_dropped(self):
+        self.feed({"jsonrpc": "2.0", "method": "daemonReady"})
+        self.feed({"jsonrpc": "2.0", "id": 1, "result": {}})
+        self.driver.request("initialize", {}, timeout_s=5.0)
+        self.assertEqual(
+            [m.get("method") for m in self.driver._pending_notifications],
+            ["daemonReady"],
+        )
+
+
+class CollectNotifications(_PipeFixture):
+    def test_timeout_reports_shortfall_not_closed_stream(self):
+        self.feed({"jsonrpc": "2.0", "method": "renderFinished", "params": {}})
+        with self.assertRaises(TimeoutError) as ctx:
+            self.driver.collect_notifications({"renderFinished"}, expected=2, timeout_s=0.2)
+        self.assertIn("only saw 1/2", str(ctx.exception))
+
+    def test_eof_reports_closed_stream(self):
+        self._close_write()
+        with self.assertRaises(RuntimeError) as ctx:
+            self.driver.collect_notifications({"renderFinished"}, expected=1, timeout_s=30.0)
+        self.assertIn("closed mid-collect", str(ctx.exception))
+
+
+class InitTimeoutDefault(unittest.TestCase):
+    """Client patience must be >= the daemon's own sandbox-boot budget.
+
+    The daemon defaults `composeai.daemon.sandboxBootTimeoutMs` to 10 minutes
+    and refuses to answer `initialize` until the pool is up, so anything below
+    that here turns a slow-but-healthy cold boot into a red CI leg.
+    """
+
+    def test_flag_default_is_at_least_the_ten_minute_boot_budget(self):
+        help_text = subprocess.run(
+            [sys.executable, str(_HERE / "daemon-roundtrip.py"), "--help"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+        self.assertIn("--init-timeout-s", help_text)
+        match = re.search(r"--init-timeout-s INIT_TIMEOUT_S\s+.*?\(default: ([\d.]+)\)", help_text, re.S)
+        if match is None:
+            # argparse only prints the default when the help string asks for
+            # it; fall back to parsing the source constant.
+            match = re.search(r'"--init-timeout-s",\s*\n\s*type=float,\s*\n\s*default=([\d.]+)',
+                              (_HERE / "daemon-roundtrip.py").read_text())
+        self.assertIsNotNone(match, "could not determine the --init-timeout-s default")
+        self.assertGreaterEqual(float(match.group(1)), 600.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -544,6 +544,8 @@ jobs:
         run: python3 .github/actions/apply/test_compute_scope.py -v
       - name: Run change-scope classifier tests
         run: python3 .github/ci/test_change_scope.py -v
+      - name: Run daemon round-trip transport tests
+        run: python3 .github/ci/test_daemon_roundtrip.py -v
 
   # VS Code extension tests — both the existing in-process Mocha suite and
   # the @vscode/test-electron integration tests. The latter download a

--- a/docs/daemon/STARTUP.md
+++ b/docs/daemon/STARTUP.md
@@ -48,6 +48,13 @@ Two changes shipped:
 
    This is a correctness fix. It doesn't make cold start faster.
 
+   **Client contract:** because `initialize` can't answer until the pool
+   is up, every client's `initialize` timeout has to be at least the
+   sandbox-boot budget. `.github/ci/daemon-roundtrip.py` waits
+   `--init-timeout-s` (600s by default) for exactly this reason — its
+   old 120s ceiling turned a 141s cold boot on a GitHub runner into a
+   red `wear-os-samples (ComposeStarter)` leg.
+
 2. **`StartupTimings` instrumentation.**
    [`StartupTimings.kt`](../../daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/StartupTimings.kt)
    records labelled instants on a JVM-start-relative timeline. Marks emit

--- a/docs/daemon/STARTUP.md
+++ b/docs/daemon/STARTUP.md
@@ -48,12 +48,18 @@ Two changes shipped:
 
    This is a correctness fix. It doesn't make cold start faster.
 
-   **Client contract:** because `initialize` can't answer until the pool
-   is up, every client's `initialize` timeout has to be at least the
-   sandbox-boot budget. `.github/ci/daemon-roundtrip.py` waits
-   `--init-timeout-s` (600s by default) for exactly this reason — its
-   old 120s ceiling turned a 141s cold boot on a GitHub runner into a
-   red `wear-os-samples (ComposeStarter)` leg.
+   **Client contract:** because `initialize` can't answer until the
+   eager slots are up — and `start()` boots them sequentially, applying
+   the budget to *each* — a client's `initialize` timeout has to cover
+   `slots × sandboxBootTimeoutMs`, not one slot's worth.
+   `.github/ci/daemon-roundtrip.py` derives `--init-timeout-s` from the
+   launch descriptor's own `sandboxCount` / `warmSpare` /
+   `backgroundSandboxBoot` / `sandboxBootTimeoutMs` properties for
+   exactly this reason — its old flat 120s ceiling turned a 141s cold
+   boot on a GitHub runner into a red `wear-os-samples (ComposeStarter)`
+   leg. The high ceiling costs nothing when the daemon is genuinely
+   stuck: a slot that misses its budget exits the daemon, and the client
+   sees EOF immediately.
 
 2. **`StartupTimings` instrumentation.**
    [`StartupTimings.kt`](../../daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/StartupTimings.kt)


### PR DESCRIPTION
### Motivation

The `wear-os-samples (ComposeStarter)` integration leg failed on [run 30195638245](https://github.com/yschimke/compose-ai-tools/actions/runs/30195638245/job/89777074560?pr=2776) with:

```
RuntimeError: daemon stream closed before responding to initialize
```

The daemon's stream was never closed. Per [docs/daemon/STARTUP.md](docs/daemon/STARTUP.md), `JsonRpcServer.run()` calls `host.start()` — which blocks until the eager Robolectric sandbox slots are ready — *before* entering its read loop, so `initialize` can't be answered during a cold boot. On that runner the first sandbox worker took 135s and the pool was ready at +141.5s:

```
[+   509ms] worker 0 launched (Robolectric init begins)
[+135171ms] worker 1 launched (Robolectric init begins)
[+141532ms] all sandbox-ready latches fired
[+141574ms] initialize responded      <- 21s after the driver had already given up
```

`daemon-roundtrip.py` waited only 120s, and its `FramedReader.read_message` returned `None` for *both* timeout and EOF — so the timeout was reported as a closed stream, pointing the investigation at a daemon crash that never happened. The client was the impatient party.

### Description

- **`--init-timeout-s`, defaulting to the daemon's own pool-wide worst case.** `RobolectricHost.start()` boots the eager slots sequentially and applies `composeai.daemon.sandboxBootTimeoutMs` to *each*, and this leg runs the default warm-spare pool (`sandboxCount=5`), so a flat budget is wrong by up to 5×. The default is derived from the launch descriptor's own `systemProperties` — `sandboxCount`, else `warmSpare` → 5; `backgroundSandboxBoot` → only slot 0 is on the critical path; `sandboxBootTimeoutMs` — plus 60s slack. The flag stays as an override. The tall ceiling doesn't strand a wedged job: a slot that misses its budget exits the daemon, which lands as EOF and fails immediately.
- **EOF and timeout are no longer conflated.** `FramedReader` tracks `at_eof`; `request` / `collect_notifications` now raise `TimeoutError` naming the method and budget when the daemon is alive but slow, and only say "stream closed" on a real EOF — appending the daemon's exit code when it has one.
- **Line-buffered stdout**, so the driver's progress interleaves with the daemon's unbuffered stderr instead of dumping the whole narrative after the traceback (which is why the failing log reads out of order).
- **New `.github/ci/test_daemon_roundtrip.py`** (stdlib unittest, same shape as `test_change_scope.py`), wired into the `Actions Script Tests` job: EOF-vs-timeout, both error messages, frames split across writes, notification stashing, and the six timeout-derivation cases.

### Testing

- `python3 .github/ci/test_daemon_roundtrip.py -v` — 16 tests, all pass.
- `wear-os-samples (ComposeStarter)` passed on the first commit of this PR; `.github/ci/**` is not in `change-scope-safe-paths.json`, so the integration matrix runs the patched driver end-to-end on every push here.

No visual surfaces touched — CI driver, its tests, and a daemon-startup doc note only.
