### PR TITLE
perf(ci): cache the android-all runtime and wire BuildFetch into build-plugin

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -119,6 +119,17 @@ jobs:
 
       - uses: ./.github/actions/setup
 
+      # This is the one job in this workflow that builds *this* repo's Gradle
+      # tasks (the matrix jobs build external consumers, which never see our
+      # settings.gradle.kts), so it's the only place the BuildFetch remote cache
+      # applies. Same token gating as ci.yml: the write token resolves only on
+      # trusted main-branch pushes; PRs get read-only and pull task outputs
+      # instead of building the publish/installDist fan-out cold.
+      - uses: ./.github/actions/buildfetch-cache
+        with:
+          rw-token: ${{ github.event_name == 'push' && (secrets.BUILDFETCH_COMPOSEAI_GRADLE_REMOTE_CACHE_TOKEN || secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN) || '' }}
+          ro-token: ${{ secrets.BUILDFETCH_COMPOSEAI_GRADLE_REMOTE_CACHE_TOKEN_RO || secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN_RO }}
+
       - name: Publish plugin + renderer-android + renderer-xr + data-* + daemon-* to mavenLocal
         # Both `gradle-plugin` and `renderer-android` are needed end-to-end:
         # the plugin resolves through the init script's buildscript classpath
@@ -723,6 +734,55 @@ jobs:
         with:
           cache-provider: basic
 
+      # Robolectric's instrumented `android-all` runtime (~150-250 MB) is fetched
+      # at RUN time by Robolectric's own Maven resolver into ~/.m2/repository —
+      # not by Gradle — so setup-gradle's cache doesn't cover it and every render
+      # / daemon cell re-downloads it from Maven Central. That download is the
+      # cold half of the daemon's ~141s boot on this leg;
+      # `deploy/image/Dockerfile` prefetches the same coordinate into the image
+      # for exactly this reason.
+      #
+      # The exact key is deliberately unmatchable — restore always falls through
+      # to the prefix, picking up the most recent saved entry whatever coordinate
+      # it holds. The save step below re-keys on the coordinate actually on disk,
+      # so a `robolectric` bump heals itself instead of pinning the cache to a
+      # dead jar forever. (A `github.run_id` key like the font cache uses would
+      # be simpler, but at this size it would save a fresh quarter-gig per cell
+      # per run and evict everything else in the repo's 10 GB budget.)
+      - name: Restore Robolectric android-all cache
+        if: matrix.render || matrix.render_xr || matrix.daemon
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.m2/repository/org/robolectric/android-all-instrumented
+          key: android-all-instrumented-${{ runner.os }}-
+          restore-keys: |
+            android-all-instrumented-${{ runner.os }}-
+
+      # A truncated jar restored from cache is worse than no cache at all:
+      # Robolectric's MavenArtifactFetcher skips its download when the target
+      # path already exists, so a corrupt file boots the sandbox against a broken
+      # android-all instead of re-fetching. Structural check only (central
+      # directory, no full decompress) — drop anything that fails it.
+      - name: Drop corrupt android-all jars
+        if: matrix.render || matrix.render_xr || matrix.daemon
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import zipfile
+          from pathlib import Path
+
+          root = Path.home() / ".m2/repository/org/robolectric/android-all-instrumented"
+          if not root.exists():
+              print("no restored android-all cache")
+              raise SystemExit(0)
+          for jar in sorted(root.rglob("*.jar")):
+              if zipfile.is_zipfile(jar):
+                  print(f"ok: {jar.name} ({jar.stat().st_size} bytes)")
+              else:
+                  print(f"::warning::dropping corrupt android-all jar {jar}")
+                  jar.unlink()
+          PY
+
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: compose-ai-bundle
@@ -1274,6 +1334,53 @@ jobs:
           if-no-files-found: warn
           retention-days: 7
 
+      # Keep exactly one coordinate. After a `robolectric` bump the restored
+      # entry holds the OLD jar and this run downloads the new one alongside it,
+      # so a blind save would carry a dead quarter-gig forever. The freshly
+      # downloaded directory is strictly newer than everything the restore
+      # materialised, so newest-mtime is a reliable "current". Then key on what
+      # survived: unchanged coordinate → same key → save is a no-op; bumped
+      # coordinate → new key → new entry, old one ages out.
+      - name: Resolve android-all cache key
+        id: android-all
+        if: always() && (matrix.render || matrix.render_xr || matrix.daemon)
+        run: |
+          set -euo pipefail
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          import shutil
+          import sys
+          from pathlib import Path
+
+          root = Path.home() / ".m2/repository/org/robolectric/android-all-instrumented"
+          versions = sorted(
+              (d for d in root.glob("*") if d.is_dir() and any(d.glob("*.jar"))),
+              key=lambda d: max(j.stat().st_mtime for j in d.glob("*.jar")),
+          ) if root.is_dir() else []
+          if not versions:
+              print("no android-all coordinate on disk — nothing to cache", file=sys.stderr)
+              print("coordinate=")
+              raise SystemExit(0)
+          current = versions[-1]
+          for stale in versions[:-1]:
+              print(f"::warning::pruning superseded android-all coordinate {stale.name}", file=sys.stderr)
+              shutil.rmtree(stale)
+          print(f"caching android-all coordinate {current.name}", file=sys.stderr)
+          print(f"coordinate={current.name}")
+          PY
+
+      # Split restore/save (rather than plain `actions/cache`) so a cell that
+      # failed AFTER paying the download still persists it — the rerun starts
+      # warm instead of downloading a quarter-gig again to fail the same way.
+      # Saving an already-present key logs a warning and is not fatal, which is
+      # the steady state here: only the first cell to finish actually uploads.
+      - name: Save Robolectric android-all cache
+        if: always() && steps.android-all.outputs.coordinate != ''
+        continue-on-error: true
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.m2/repository/org/robolectric/android-all-instrumented
+          key: android-all-instrumented-${{ runner.os }}-${{ steps.android-all.outputs.coordinate }}
+
   agp8-min:
     # Consumes build-plugin's bundle, so it rides the same change-scope gate:
     # skipped on out-of-scope PRs (not a required check, so a plain skip is
@@ -1313,6 +1420,39 @@ jobs:
       - uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-provider: basic
+
+      # Phase 1/3 below run `composePreviewRender`, which boots a Robolectric
+      # sandbox and so pays the same ~150-250 MB `android-all` fetch the
+      # integration matrix does. Same restore/prune/save shape as the matrix
+      # job — see the rationale on its "Restore Robolectric android-all cache"
+      # step. Kept inline rather than factored into a composite action because
+      # the matrix job has no checkout of this repo and so can't call one.
+      - name: Restore Robolectric android-all cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.m2/repository/org/robolectric/android-all-instrumented
+          key: android-all-instrumented-${{ runner.os }}-
+          restore-keys: |
+            android-all-instrumented-${{ runner.os }}-
+
+      - name: Drop corrupt android-all jars
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import zipfile
+          from pathlib import Path
+
+          root = Path.home() / ".m2/repository/org/robolectric/android-all-instrumented"
+          if not root.exists():
+              print("no restored android-all cache")
+              raise SystemExit(0)
+          for jar in sorted(root.rglob("*.jar")):
+              if zipfile.is_zipfile(jar):
+                  print(f"ok: {jar.name} ({jar.stat().st_size} bytes)")
+              else:
+                  print(f"::warning::dropping corrupt android-all jar {jar}")
+                  jar.unlink()
+          PY
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -1539,6 +1679,41 @@ jobs:
             ${{ runner.temp }}/fixture/**/build/compose-previews/renders/*.error.json
           if-no-files-found: warn
           retention-days: 7
+
+      - name: Resolve android-all cache key
+        id: android-all
+        if: always()
+        run: |
+          set -euo pipefail
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          import shutil
+          import sys
+          from pathlib import Path
+
+          root = Path.home() / ".m2/repository/org/robolectric/android-all-instrumented"
+          versions = sorted(
+              (d for d in root.glob("*") if d.is_dir() and any(d.glob("*.jar"))),
+              key=lambda d: max(j.stat().st_mtime for j in d.glob("*.jar")),
+          ) if root.is_dir() else []
+          if not versions:
+              print("no android-all coordinate on disk — nothing to cache", file=sys.stderr)
+              print("coordinate=")
+              raise SystemExit(0)
+          current = versions[-1]
+          for stale in versions[:-1]:
+              print(f"::warning::pruning superseded android-all coordinate {stale.name}", file=sys.stderr)
+              shutil.rmtree(stale)
+          print(f"caching android-all coordinate {current.name}", file=sys.stderr)
+          print(f"coordinate={current.name}")
+          PY
+
+      - name: Save Robolectric android-all cache
+        if: always() && steps.android-all.outputs.coordinate != ''
+        continue-on-error: true
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.m2/repository/org/robolectric/android-all-instrumented
+          key: android-all-instrumented-${{ runner.os }}-${{ steps.android-all.outputs.coordinate }}
 
   publish-previews:
     name: Publish integration preview branches

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -749,14 +749,28 @@ jobs:
       # dead jar forever. (A `github.run_id` key like the font cache uses would
       # be simpler, but at this size it would save a fresh quarter-gig per cell
       # per run and evict everything else in the repo's 10 GB budget.)
+      #
+      # Keyed PER CELL (`matrix.slug`), not globally. Cells don't all want the
+      # same coordinate: the SDK Robolectric synthesizes depends on the cell's
+      # JDK and any `composePreview.sdkVersion` pin (docs/SDK_COMPATIBILITY.md —
+      # JDK 17 clamps where JDK 21 doesn't, and `jetstream-xr` runs 21 while the
+      # rest run 17). Under one shared prefix those cells would ping-pong: each
+      # restores whichever coordinate was saved most recently, downloads the one
+      # it actually needs, and then cannot save — cache keys are immutable, so
+      # the entry for its own coordinate already exists and is never refreshed.
+      # Every cell would pay the full download every run, plus a pointless
+      # restore and upload. Per-cell keys give each one a stable coordinate.
+      # Deliberately no global restore-keys fallback either: seeding a new cell
+      # from a foreign coordinate costs a quarter-gig restore and still needs the
+      # real download.
       - name: Restore Robolectric android-all cache
         if: matrix.render || matrix.render_xr || matrix.daemon
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.m2/repository/org/robolectric/android-all-instrumented
-          key: android-all-instrumented-${{ runner.os }}-
+          key: android-all-instrumented-${{ runner.os }}-${{ matrix.slug }}-
           restore-keys: |
-            android-all-instrumented-${{ runner.os }}-
+            android-all-instrumented-${{ runner.os }}-${{ matrix.slug }}-
 
       # A truncated jar restored from cache is worse than no cache at all:
       # Robolectric's MavenArtifactFetcher skips its download when the target
@@ -1341,6 +1355,11 @@ jobs:
       # materialised, so newest-mtime is a reliable "current". Then key on what
       # survived: unchanged coordinate → same key → save is a no-op; bumped
       # coordinate → new key → new entry, old one ages out.
+      #
+      # Pruning is only sound because the key is per-cell and a cell renders at
+      # one SDK: the coordinate it wants this run is the one it wanted last run.
+      # Under a shared key this would be the thrash described on the restore
+      # step — don't collapse these keys back together.
       - name: Resolve android-all cache key
         id: android-all
         if: always() && (matrix.render || matrix.render_xr || matrix.daemon)
@@ -1379,7 +1398,7 @@ jobs:
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.m2/repository/org/robolectric/android-all-instrumented
-          key: android-all-instrumented-${{ runner.os }}-${{ steps.android-all.outputs.coordinate }}
+          key: android-all-instrumented-${{ runner.os }}-${{ matrix.slug }}-${{ steps.android-all.outputs.coordinate }}
 
   agp8-min:
     # Consumes build-plugin's bundle, so it rides the same change-scope gate:
@@ -1427,13 +1446,18 @@ jobs:
       # job — see the rationale on its "Restore Robolectric android-all cache"
       # step. Kept inline rather than factored into a composite action because
       # the matrix job has no checkout of this repo and so can't call one.
+      #
+      # Own key namespace for the same reason the matrix keys per cell: this
+      # fixture pins `composePreview.sdkVersion = 35` to stay inside JDK 17's
+      # Robolectric window, so its coordinate is its own and must not share an
+      # entry with cells that resolve a different SDK.
       - name: Restore Robolectric android-all cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.m2/repository/org/robolectric/android-all-instrumented
-          key: android-all-instrumented-${{ runner.os }}-
+          key: android-all-instrumented-${{ runner.os }}-agp8-min-
           restore-keys: |
-            android-all-instrumented-${{ runner.os }}-
+            android-all-instrumented-${{ runner.os }}-agp8-min-
 
       - name: Drop corrupt android-all jars
         run: |
@@ -1713,7 +1737,7 @@ jobs:
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.m2/repository/org/robolectric/android-all-instrumented
-          key: android-all-instrumented-${{ runner.os }}-${{ steps.android-all.outputs.coordinate }}
+          key: android-all-instrumented-${{ runner.os }}-agp8-min-${{ steps.android-all.outputs.coordinate }}
 
   publish-previews:
     name: Publish integration preview branches

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -459,8 +459,10 @@ open class RobolectricHost(
    * waits, no cold-start cliff where the first N submits each race a 60s timeout before the sandbox
    * finishes building.
    *
-   * Cold-start cost on a fresh `~/.cache/robolectric` is dominated by downloading
-   * `android-all-instrumented-{ver}-{sdk}.jar` (~150 MB) and instrumenting every class on the
+   * Cold-start cost on a fresh Maven local repo is dominated by downloading
+   * `android-all-instrumented-{ver}-{sdk}.jar` (~150 MB, into
+   * `~/.m2/repository/org/robolectric/android-all-instrumented/` via Robolectric's own resolver —
+   * see docs/daemon/STARTUP.md) and instrumenting every class on the
    * daemon's classpath; that can run into minutes. Warm starts (cache hit + no incremental rebuild)
    * are ~5–15s. The configurable timeout below is the upper bound on the cold path.
    *
@@ -1639,7 +1641,7 @@ open class RobolectricHost(
 
     /**
      * Sysprop knob for [start]'s sandbox-bootstrap deadline. Cold first run on an empty
-     * `~/.cache/robolectric` is dominated by the `android-all-instrumented-{ver}-{sdk}.jar`
+     * Maven local repo is dominated by the `android-all-instrumented-{ver}-{sdk}.jar`
      * download (~150 MB) plus instrumenting every class on the daemon's classpath; the default
      * 10-minute ceiling covers that. Warm boots (cache hit) are 5–15s and never approach this
      * limit. Override with `-Dcomposeai.daemon.sandboxBootTimeoutMs=<ms>` for slower CI runners or

--- a/docs/daemon/STARTUP.md
+++ b/docs/daemon/STARTUP.md
@@ -9,12 +9,20 @@ submits 14+ succeeded because by the time they arrived, the sandbox had
 finished bootstrapping ~60s after submit 1.
 
 The 60-second timeout was sized for warm boots ("5–15s in practice"),
-which is accurate when
-`~/.cache/robolectric/android-all-instrumented-{ver}-{sdk}.jar` already
-exists. On a fresh checkout that 150 MB jar has to come down from Maven
+which is accurate when the instrumented `android-all` jar already exists
+locally. On a fresh checkout that jar has to come down from Maven
 Central first, plus instrumentation of every class on the daemon's
 classpath, plus the actual sandbox boot. Cold end-to-end: 60 s+ is
 normal.
+
+**Where that jar lives:** Robolectric fetches it with its own Maven
+resolver, at run time, into the Maven local repo —
+`~/.m2/repository/org/robolectric/android-all-instrumented/{ver}/`. Not
+`~/.cache/robolectric`, and not via Gradle: no Gradle dependency
+declares it, so neither a Gradle cache nor the BuildFetch remote cache
+covers it. `deploy/image/Dockerfile` prefetches that exact coordinate
+into the image layer, and the integration matrix restores the same
+directory from an Actions cache, both for this reason.
 
 ## Where the time goes
 
@@ -28,6 +36,48 @@ Rough breakdown on cold first run:
 3. **JVM startup + classpath resolve + first render.** ~1–2 s + ~50–500 ms.
 
 (1) is the persistent cost. (2) piles on for cold-cache first runs.
+
+**Multiply (1) by the pool.** `start()` boots the eager slots
+*sequentially*, and `warmSpare` (on by default on the Gradle-plugin
+launch path) means five of them. At ~11.6 s per sandbox on a warm
+`android-all` cache — the figure
+[SANDBOX-POOL.md](SANDBOX-POOL.md) measures — a warm-spare pool is
+~58 s of boot before `initialize` can answer, on top of (2). That is
+what makes the observed 141 s on a GitHub runner: a cold jar download
+plus five sequential sandbox boots.
+
+## What caching can and can't reach
+
+Three of these costs look cacheable and only two are:
+
+| Cost | Cacheable today | By what |
+|------|-----------------|---------|
+| `android-all` jar download | yes | Actions cache / image layer over `~/.m2/repository/org/robolectric/android-all-instrumented` |
+| Building the plugin + CLI the daemon runs | yes | BuildFetch remote Gradle cache |
+| Robolectric instrumenting the classpath | **no** | — nothing caches it yet |
+| Sequential per-slot sandbox boot | **no** | — it's pool policy, not a cache miss |
+
+**BuildFetch does not touch daemon boot, and can't.** It's a Gradle
+*task-output* cache: it replays the outputs of tasks whose inputs hash
+the same. Sandbox boot isn't a Gradle task — it's work a spawned JVM
+does at run time (Maven fetch, then ASM rewriting at class-load), inside
+a process Gradle has already handed off to. There is no task, so there
+is no cache key. The integration matrix compounds this: those jobs build
+*external* consumer repos, which never see our `settings.gradle.kts` and
+so never reach the BuildFetch cache at all.
+
+Where BuildFetch *does* pay off in that workflow is the `build-plugin`
+job — the one job that builds this repo (`publishToMavenLocal` +
+`:cli:installDist`) and was running cold. It's wired to
+`.github/actions/buildfetch-cache` on the same read-only-on-PRs gating
+as `ci.yml`.
+
+BuildFetch becomes relevant to boot only *downstream* of the
+instrumented-bytecode work in the menu below: if instrumentation output
+were produced by a cacheable Gradle task keyed on (classpath, Robolectric
+version, shadow set), then that task's output would ride the remote cache
+to every CI runner and developer machine. Persisting the bytes is the
+hard part; sharing them is free once it exists.
 
 ## The current fix
 
@@ -86,6 +136,17 @@ Two changes shipped:
 
 Menu of follow-ups, by leverage:
 
+- **Reconsider the eager warm-spare pool on the launch-descriptor path.**
+  The cheapest un-taken win, and the only one that is a config decision
+  rather than a project. `backgroundSandboxBoot=true` already exists and
+  already has the semantics worked out (dispatch across the ready
+  prefix — see [SANDBOX-POOL.md](SANDBOX-POOL.md)); `ServeBundleDaemon`
+  and the deploy image opt in, the Gradle-plugin path does not, so it
+  pays for five sandboxes before answering `initialize`. Turning it on
+  for the CI daemon leg would cut ~45 s from that leg immediately — but
+  it would also stop that leg exercising the strict
+  all-sandboxes-ready contract real plugin consumers get, so it is a
+  coverage trade, not a free win. Deliberately left as a decision.
 - **Machine-resident daemon** (highest priority). Daemon survives editor
   restarts; cold start moves from "every editor open" to "every reboot."
   Lifecycle change only; needs a different anchor than parent-PID.


### PR DESCRIPTION
Follow-up to #2780. That PR made CI *wait out* the daemon's ~141s cold boot; this one removes the part of it that was redundant work.

## What the 141s actually is

Two costs stacked, not one:

| | cost | why |
|---|---|---|
| `android-all` jar fetch | 0–60s+ | ~150–250 MB from Maven Central |
| Sandbox boot | ~58s | `warmSpare` is on by default on the Gradle-plugin launch path → 5 slots, booted **sequentially**, ~11.6s each ([SANDBOX-POOL.md](docs/daemon/SANDBOX-POOL.md)) |
| JVM + first render | ~2s | — |

The pool multiplication wasn't written down anywhere: `initialize` can't answer until all five eager slots are up, and the round-trip test uses exactly one.

## The jar fetch was uncached — by everyone

Robolectric fetches `android-all-instrumented` at **run time**, with its own Maven resolver, into `~/.m2/repository/org/robolectric/android-all-instrumented`. No Gradle dependency declares it, so `setup-gradle`'s cache never covered it and every render / daemon cell re-downloaded it from Maven Central. `deploy/image/Dockerfile` already prefetches that exact coordinate into the image layer for this reason; CI never did the equivalent.

Added restore/prune/save to the integration matrix and to `agp8-min` (which renders, so it pays the same fetch):

- **Per-cell keys: `android-all-instrumented-<os>-<slug>-<coordinate>`.** Cells don't all resolve the same coordinate — the SDK Robolectric synthesizes depends on the cell's JDK and any `sdkVersion` pin ([SDK_COMPATIBILITY.md](docs/SDK_COMPATIBILITY.md): JDK 17 clamps where 21 doesn't, and `jetstream-xr` runs 21 while `wear-os-samples` / `wear-tiles` run 17; `agp8-min` pins 35). Under one shared key they'd ping-pong — each restoring whichever coordinate was saved last, downloading the one it needs, then unable to save because keys are immutable — paying the full download every run *plus* a wasted restore and upload. Caught in review; see [this thread](https://github.com/yschimke/compose-ai-tools/pull/2781#discussion_r3652285323).
- **Discover-then-save.** The coordinate isn't knowable before the restore, so the restore's exact key is unmatchable and falls through to the cell's prefix; the save re-keys on what's actually on disk. A `robolectric` bump therefore heals itself instead of pinning the cache to a dead jar. The matrix job has no checkout of this repo, so `hashFiles()` on our version catalog isn't available — hence the shape.
- **Prune before save**, so a bump doesn't leave a dead quarter-gig in the entry. Sound by construction now that keys are per-cell: a cell renders at one SDK, so the coordinate it wants this run is the one it wanted last run.
- **Split restore/save**, so a cell that fails *after* paying the download still persists it and the rerun starts warm.
- **Corrupt-jar guard.** Robolectric's `MavenArtifactFetcher` skips its download when the target path exists, so a truncated restore would boot a sandbox against a broken `android-all` instead of re-fetching. Structural zip check, drop anything that fails.
- Not a `github.run_id` key like the font cache uses: at this size that would save a fresh quarter-gig per cell per run and evict everything else in the repo's 10 GB budget.

## BuildFetch

It **cannot** reach daemon boot, and it isn't a wiring gap. BuildFetch replays Gradle *task outputs*; sandbox boot is run-time work in a spawned JVM (Maven fetch, then ASM rewriting at class-load) with no task and no cache key. The integration matrix compounds this — those jobs build *external* consumer repos that never see our `settings.gradle.kts`.

Where it does apply is `build-plugin`, the one job in `integration.yml` that builds this repo (`publishToMavenLocal` + `:cli:installDist`) and was running the whole fan-out cold. Wired to `.github/actions/buildfetch-cache` on the same gating as `ci.yml` — write token only on trusted `push`, read-only on PRs.

BuildFetch becomes relevant to boot only *downstream* of the instrumented-bytecode item in the options menu: make instrumentation a cacheable Gradle task and its output rides the remote cache to every runner and dev machine for free. Persisting the bytes is the hard part; sharing them is then solved.

## Also

- Corrects the `~/.cache/robolectric` path named in `STARTUP.md` and two `RobolectricHost` comments. That is not where 4.16/4.17 put the jar, and it is the first place someone would look to cache it.
- Documents the pool cost and adds the un-taken lever to the options menu: `backgroundSandboxBoot=true` on the CI daemon leg would cut ~45s immediately (the flag exists; `ServeBundleDaemon` and the deploy image already opt in), but the Gradle-plugin path deliberately doesn't, and that leg is what exercises the strict all-sandboxes-ready contract real plugin consumers get. Left as a decision rather than made — it's a coverage trade, not a free win.

## Test plan

- `python3 .github/ci/test_daemon_roundtrip.py` — 16 tests, OK.
- `python3 .github/ci/test_change_scope.py` — 20 tests, OK.
- Both inline cache scripts exercised against four fixture layouts under a fake `$HOME` (empty cache, steady state, corrupt jar dropped, robolectric bump → old coordinate pruned + re-keyed). All pass.
- Workflow parses; new steps confirmed in the right jobs and order, and no global (non-cell-scoped) key remains.
- **On CI the first run is a cache miss by construction** — it populates the entry. The speedup shows from the second run onward, so this wants reading across two runs, not one.

No visual surface changed (CI wiring + docs + comments), so no render evidence applies.