### PR TITLE
feat(daemon): expose backgroundSandboxBoot to the Gradle-plugin launch path

### DIFF
--- a/.github/ci/daemon-roundtrip.py
+++ b/.github/ci/daemon-roundtrip.py
@@ -374,31 +374,18 @@ def _prop_is_true(props: dict[str, Any], key: str, default: bool) -> bool:
     return str(raw).strip().lower() == "true"
 
 
-def _derive_init_timeout_s(descriptor: dict[str, Any]) -> float:
-    """How long `initialize` may legitimately take, given the launch descriptor.
+def _eager_slot_count(descriptor: dict[str, Any]) -> int:
+    """How many sandbox slots sit on `initialize`'s critical path.
 
-    The Android daemon answers `initialize` only once `RobolectricHost.start()`
-    returns, and that boots the eager sandbox slots SEQUENTIALLY, applying
-    `composeai.daemon.sandboxBootTimeoutMs` (10 min default) to EACH slot. A
-    warm-spare pool is 5 slots, so the daemon's own worst case is 5 × 10 min —
-    a flat client budget under that would once again blame our impatience for
-    the daemon's slowness. Derive from the same properties the descriptor
-    launches the JVM with so the two can't drift.
+    `RobolectricHost.start()` boots the eager slots SEQUENTIALLY and only then
+    lets `initialize` answer, so this is the multiplier on both the client's
+    patience and the observed cold-start latency.
 
-    Under `backgroundSandboxBoot` only slot 0 is on the critical path.
-
-    A ceiling this high doesn't strand CI on a wedged daemon: a slot that
-    misses its budget makes the daemon exit, which lands as EOF and fails us
-    immediately. It only buys patience for a daemon that is still working.
+    Normally that's the whole pool — `warmSpare` (default on) means 5. Under
+    `composeai.daemon.backgroundSandboxBoot` only slot 0 is eager and the rest
+    boot on a background thread, so the count is 1 however big the pool is.
     """
     props = descriptor.get("systemProperties") or {}
-    boot_timeout_ms = _DEFAULT_BOOT_TIMEOUT_MS
-    raw_timeout = props.get(_BOOT_TIMEOUT_PROP)
-    if raw_timeout is not None:
-        try:
-            boot_timeout_ms = int(str(raw_timeout).strip())
-        except ValueError:
-            pass
     raw_count = props.get(_SANDBOX_COUNT_PROP)
     try:
         sandbox_count = int(str(raw_count).strip()) if raw_count is not None else None
@@ -412,8 +399,37 @@ def _derive_init_timeout_s(descriptor: dict[str, Any]) -> float:
             else 1
         )
     sandbox_count = max(1, sandbox_count)
-    eager_slots = 1 if _prop_is_true(props, _BACKGROUND_BOOT_PROP, default=False) else sandbox_count
-    return eager_slots * (boot_timeout_ms / 1000.0) + _INIT_TIMEOUT_SLACK_S
+    return 1 if _prop_is_true(props, _BACKGROUND_BOOT_PROP, default=False) else sandbox_count
+
+
+def _derive_init_timeout_s(descriptor: dict[str, Any]) -> float:
+    """How long `initialize` may legitimately take, given the launch descriptor.
+
+    The Android daemon answers `initialize` only once `RobolectricHost.start()`
+    returns, and that boots the eager sandbox slots SEQUENTIALLY, applying
+    `composeai.daemon.sandboxBootTimeoutMs` (10 min default) to EACH slot. A
+    warm-spare pool is 5 slots, so the daemon's own worst case is 5 × 10 min —
+    a flat client budget under that would once again blame our impatience for
+    the daemon's slowness. Derive from the same properties the descriptor
+    launches the JVM with so the two can't drift.
+
+    Under `backgroundSandboxBoot` only slot 0 is on the critical path — see
+    [_eager_slot_count], which is also what the measured-latency line reports so
+    the budget and the report can't disagree.
+
+    A ceiling this high doesn't strand CI on a wedged daemon: a slot that
+    misses its budget makes the daemon exit, which lands as EOF and fails us
+    immediately. It only buys patience for a daemon that is still working.
+    """
+    props = descriptor.get("systemProperties") or {}
+    boot_timeout_ms = _DEFAULT_BOOT_TIMEOUT_MS
+    raw_timeout = props.get(_BOOT_TIMEOUT_PROP)
+    if raw_timeout is not None:
+        try:
+            boot_timeout_ms = int(str(raw_timeout).strip())
+        except ValueError:
+            pass
+    return _eager_slot_count(descriptor) * (boot_timeout_ms / 1000.0) + _INIT_TIMEOUT_SLACK_S
 
 
 def _gradle_recompile(workspace: Path, gradle_args: list[str]) -> None:
@@ -518,6 +534,7 @@ def main() -> int:
             f"[daemon-roundtrip] waiting up to {init_timeout_s:.0f}s for initialize "
             "(the daemon boots its Robolectric sandbox pool first — cold boots are slow)"
         )
+        init_started_at = time.monotonic()
         init_result = driver.request(
             "initialize",
             {
@@ -533,7 +550,17 @@ def main() -> int:
         proto = init_result.get("protocolVersion")
         if proto != 2:
             raise RuntimeError(f"daemon protocolVersion={proto}, expected 2")
-        print(f"[daemon-roundtrip] initialize OK (daemonVersion={init_result.get('daemonVersion')})")
+        # Report the measured latency, not just success. This is the number that moves when the
+        # sandbox pool's boot policy changes (`composeai.daemon.backgroundSandboxBoot`) or when a
+        # cold `android-all` fetch is or isn't cached, and it's otherwise invisible — the leg just
+        # looks "slow" or "fast" in aggregate. Printed unconditionally so any run can be compared
+        # against any other without re-instrumenting.
+        init_elapsed_s = time.monotonic() - init_started_at
+        print(
+            f"[daemon-roundtrip] initialize OK in {init_elapsed_s:.1f}s "
+            f"(daemonVersion={init_result.get('daemonVersion')}, "
+            f"eager slots on the critical path: {_eager_slot_count(descriptor)})"
+        )
         driver.notify("initialized")
 
         # Pass 1: initial render of all previews.

--- a/.github/ci/test_daemon_roundtrip.py
+++ b/.github/ci/test_daemon_roundtrip.py
@@ -178,6 +178,36 @@ class InitTimeoutDerivation(unittest.TestCase):
         self.assertGreaterEqual(derived, self.TEN_MIN_S)
         self.assertLess(derived, 2 * self.TEN_MIN_S)
 
+    def test_eager_slot_count_defaults_to_the_warm_spare_pool(self):
+        # The number the measured-latency line reports. Default is the whole eager pool, which is
+        # what makes a cold `initialize` cost ~5 sandbox boots rather than one.
+        self.assertEqual(mod._eager_slot_count({"systemProperties": {}}), 5)
+
+    def test_eager_slot_count_is_one_under_background_boot(self):
+        # Background boot must collapse this to 1 regardless of pool size — that IS the change.
+        descriptor = {
+            "systemProperties": {
+                "composeai.daemon.sandboxCount": "5",
+                "composeai.daemon.backgroundSandboxBoot": "true",
+            }
+        }
+        self.assertEqual(mod._eager_slot_count(descriptor), 1)
+
+    def test_eager_slot_count_agrees_with_the_derived_budget(self):
+        # The reported slot count and the timeout must come from the same derivation — a drift
+        # here would mean the log explains a latency the budget didn't actually allow for.
+        for props in (
+            {},
+            {"composeai.daemon.backgroundSandboxBoot": "true"},
+            {"composeai.daemon.sandboxCount": "3"},
+            {"composeai.daemon.warmSpare": "false"},
+        ):
+            with self.subTest(props=props):
+                descriptor = {"systemProperties": props}
+                slots = mod._eager_slot_count(descriptor)
+                expected = slots * self.TEN_MIN_S + 60.0
+                self.assertEqual(mod._derive_init_timeout_s(descriptor), expected)
+
     def test_custom_boot_budget_is_honoured(self):
         derived = self.derive(
             {

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -325,6 +325,21 @@ jobs:
             # that the standalone `composePreviewRender` task can't see. See
             # .github/ci/daemon-roundtrip.py.
             daemon: true
+            # Answer `initialize` as soon as slot 0 is hot; boot the rest of the
+            # warm-spare pool behind it. `start()` boots the eager slots
+            # sequentially, so the default (all 5 up before `initialize`) spends
+            # ~58s at ~11.6s/sandbox buying capacity this round-trip never uses —
+            # it renders one module's previews, edits, re-renders. See
+            # docs/daemon/SANDBOX-POOL.md § Background pool boot.
+            #
+            # The trade: this cell no longer covers the eager all-sandboxes-ready
+            # contract end-to-end. That contract stays pinned by
+            # RobolectricHostPoolTest (real sandboxes, both paths) and by the
+            # default-off assertions in DaemonExtensionTest /
+            # KmpAndroidDesktopRoutingTest. If it needs e2e coverage again, add a
+            # second daemon cell with `daemon_background_boot: false` — that's
+            # why this is a matrix field and not a hardcoded literal.
+            daemon_background_boot: true
             # Surfaced in the published compose-preview/integration/<slug>
             # branch README so browsers see what this cell exercises +
             # any caveats. Hand-written; auto-derived facts (patch / build
@@ -1204,10 +1219,18 @@ jobs:
           # so composePreviewDaemonStart writes `enabled: true` into the launch descriptor.
           # Idempotent for the CI-injected block, but still overrides a consumer block that
           # explicitly sets enabled = false.
+          #
+          # `backgroundSandboxBoot` comes from the cell (`matrix.daemon_background_boot`) rather
+          # than being hardcoded, so the two boot contracts are both reachable from the matrix:
+          # true = `initialize` answers once slot 0 is hot (the pool finishes behind it), false =
+          # the eager contract where the whole warm-spare pool is up first. A cell that wants to
+          # cover the eager path end-to-end is a one-line matrix addition, not a workflow edit.
           python3 - <<'PY'
           from pathlib import Path
           import os
           module = os.environ["MATRIX_MODULE"]
+          # Gradle wants a lowercase literal; the matrix field arrives as "true"/"false"/"".
+          background_boot = "true" if os.environ.get("MATRIX_BACKGROUND_BOOT") == "true" else "false"
           # Find the most likely build script for that module: top-level <module>/build.gradle.kts
           # (most apps), then fall back to top-level build.gradle. ComposeStarter has app/build.gradle.kts.
           candidates = [
@@ -1218,18 +1241,22 @@ jobs:
               if not p.exists():
                   continue
               text = p.read_text()
-              suffix = "\n\ncomposePreview {\n  daemon {\n    enabled = true\n  }\n}\n"
+              suffix = (
+                  "\n\ncomposePreview {\n  daemon {\n    enabled = true\n"
+                  f"    backgroundSandboxBoot = {background_boot}\n  }}\n}}\n"
+              )
               if suffix.strip() in text:
                   print(f"daemon enable block already present in {p}")
                   break
               p.write_text(text + suffix)
-              print(f"appended daemon enable block to {p}")
+              print(f"appended daemon enable block to {p} (backgroundSandboxBoot={background_boot})")
               break
           else:
               raise SystemExit(f"no build script found for module {module}")
           PY
         env:
           MATRIX_MODULE: ${{ matrix.module }}
+          MATRIX_BACKGROUND_BOOT: ${{ matrix.daemon_background_boot }}
 
       - name: Emit daemon launch descriptor (composePreviewDaemonStart)
         if: matrix.daemon

--- a/docs/daemon/CONFIG.md
+++ b/docs/daemon/CONFIG.md
@@ -11,6 +11,7 @@ composePreview {
     maxHeapMb = 1024
     maxRendersPerSandbox = 1000
     warmSpare = true
+    backgroundSandboxBoot = false
   }
 }
 ```
@@ -60,6 +61,20 @@ Higher values amortise the spare-rebuild cost over more renders; lower values ca
 
 `true` doubles the daemon's idle memory footprint. Set to `false` on memory-constrained dev machines (< 16GB system RAM, or where multiple modules' daemons run side by side). The recycle pause is still bounded by `maxHeapMb` + `maxRendersPerSandbox` so the worst case stays predictable.
 
+### `backgroundSandboxBoot: Boolean`
+
+| | |
+|-|-|
+| **Default** | `false` |
+| **Range** | `true` / `false` |
+| **Effect** | Whether `initialize` may be answered as soon as the **first** sandbox is ready, with the rest of the pool booting on a background thread. Default `false` means the whole eager pool must be hot first. See [SANDBOX-POOL.md](SANDBOX-POOL.md) § Background pool boot. |
+
+This is a time-to-**first**-render vs time-to-**full-capacity** trade, and it only bites when the pool is bigger than one. `RobolectricHost.start()` boots the eager slots *sequentially*, so with `warmSpare = true` (5 sandboxes) `initialize` waits for roughly `5 × sandbox boot` — ~58s at the ~11.6s-per-sandbox figure measured in SANDBOX-POOL.md — before the client may render anything.
+
+Turn it on when the first render matters more than the fifth: a cold CI leg that renders once, or an editor opening a single preview. Leave it off when a client fans out N renders the instant `initialize` returns and would rather not have them queue on the ready prefix while the pool fills.
+
+Once the pool completes, dispatch is bit-identical either way; this only changes what happens *during* boot. `ServeBundleDaemon` and the deploy image already default it on for serve-spawned daemons — this knob is what makes the same trade available to the Gradle-plugin launch path.
+
 ### MCP-only — `replicasPerDaemon`
 
 Configured at the **MCP server**, not the per-module Gradle DSL. Pass `--replicas-per-daemon N`
@@ -91,4 +106,6 @@ There is intentionally NO `-PcomposePreview.daemon.enabled=...` property overrid
 
 The descriptor written to `<module>/build/compose-previews/daemon-launch.json` carries the resolved values plus the daemon's spawn parameters (classpath, JVM args, system properties, java launcher path). Schema is versioned via the top-level `schemaVersion` field — VS Code's `daemonProcess.ts` gates on it and forces a re-run on mismatch. See `DaemonClasspathDescriptor` in the Gradle plugin.
 
-The daemon JVM reads the same values back at startup via `composeai.daemon.maxHeapMb` / `composeai.daemon.maxRendersPerSandbox` / `composeai.daemon.warmSpare` system properties, so a value change requires re-running `composePreviewDaemonStart` to refresh the descriptor.
+The daemon JVM reads the same values back at startup via `composeai.daemon.maxHeapMb` / `composeai.daemon.maxRendersPerSandbox` / `composeai.daemon.warmSpare` / `composeai.daemon.backgroundSandboxBoot` system properties, so a value change requires re-running `composePreviewDaemonStart` to refresh the descriptor.
+
+`composeai.daemon.backgroundSandboxBoot` is also read *client-side*: `.github/ci/daemon-roundtrip.py` derives its `initialize` budget from how many slots are on the critical path, so the descriptor stays the single source of truth for both ends.

--- a/docs/daemon/STARTUP.md
+++ b/docs/daemon/STARTUP.md
@@ -136,17 +136,20 @@ Two changes shipped:
 
 Menu of follow-ups, by leverage:
 
-- **Reconsider the eager warm-spare pool on the launch-descriptor path.**
-  The cheapest un-taken win, and the only one that is a config decision
-  rather than a project. `backgroundSandboxBoot=true` already exists and
-  already has the semantics worked out (dispatch across the ready
-  prefix — see [SANDBOX-POOL.md](SANDBOX-POOL.md)); `ServeBundleDaemon`
-  and the deploy image opt in, the Gradle-plugin path does not, so it
-  pays for five sandboxes before answering `initialize`. Turning it on
-  for the CI daemon leg would cut ~45 s from that leg immediately — but
-  it would also stop that leg exercising the strict
-  all-sandboxes-ready contract real plugin consumers get, so it is a
-  coverage trade, not a free win. Deliberately left as a decision.
+- ~~**Reconsider the eager warm-spare pool on the launch-descriptor
+  path.**~~ **Done** — `composePreview.daemon.backgroundSandboxBoot`
+  ([CONFIG.md](CONFIG.md)) exposes it to the Gradle-plugin launch path,
+  default `false` so the eager contract is still what consumers get
+  unless they ask otherwise. The integration daemon cell opts in via the
+  `daemon_background_boot` matrix field, which drops its eager slots from
+  5 to 1. `.github/ci/daemon-roundtrip.py` prints the measured
+  `initialize` latency and the eager-slot count on every run, so the
+  effect is readable off the leg's log rather than inferred.
+
+  What remains open is the *default*: whether the eager
+  all-sandboxes-ready contract is the right one for editor clients, or
+  whether they'd also rather render sooner. That's a product question,
+  not a perf one.
 - **Machine-resident daemon** (highest priority). Daemon survives editor
   restarts; cold start moves from "every editor open" to "every reboot."
   Lifecycle change only; needs a different anchor than parent-PID.

--- a/gradle-plugin/gradle-plugin-config/src/main/kotlin/ee/schimke/composeai/plugin/daemon/DaemonExtension.kt
+++ b/gradle-plugin/gradle-plugin-config/src/main/kotlin/ee/schimke/composeai/plugin/daemon/DaemonExtension.kt
@@ -67,4 +67,27 @@ abstract class DaemonExtension @Inject constructor(objects: ObjectFactory) {
    * inline and emit a `daemonWarming` notification while the new sandbox builds.
    */
   val warmSpare: Property<Boolean> = objects.property(Boolean::class.java).convention(true)
+
+  /**
+   * Whether the daemon may answer `initialize` as soon as the FIRST sandbox is ready, booting the
+   * rest of the pool on a background thread. Default: `false`.
+   *
+   * `RobolectricHost.start()` boots the eager slots sequentially and applies the per-slot boot
+   * budget to each, so a [warmSpare] pool (5 sandboxes) holds `initialize` for roughly
+   * `5 × sandbox boot` — ~58s at the ~11.6s-per-sandbox figure in
+   * `docs/daemon/SANDBOX-POOL.md` — before the client may render anything. With this on, only slot
+   * 0 is on the critical path; dispatch routes across the ready prefix while the remaining slots
+   * boot behind it, and once the pool completes behaviour is bit-identical with the eager path.
+   *
+   * Off by default because the eager path is the stricter contract: when `initialize` returns, the
+   * whole pool is hot, and an editor that immediately fans out N renders gets N sandboxes. Turn it
+   * on when time-to-first-render matters more than time-to-full-capacity — a cold CI leg that
+   * renders once, or an editor opening a single preview. `ServeBundleDaemon` and the deploy image
+   * already make that trade for serve-spawned daemons.
+   *
+   * See `docs/daemon/SANDBOX-POOL.md` § Background pool boot for the dispatch, interactive-slot,
+   * and slot-failure semantics this changes.
+   */
+  val backgroundSandboxBoot: Property<Boolean> =
+    objects.property(Boolean::class.java).convention(false)
 }

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DaemonBootstrapFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DaemonBootstrapFunctionalTest.kt
@@ -12,6 +12,69 @@ class DaemonBootstrapFunctionalTest {
 
   @get:Rule val tempDir = TemporaryFolder()
 
+  /**
+   * `backgroundSandboxBoot` only does anything if it reaches the descriptor's `systemProperties` —
+   * that map is the daemon JVM's whole view of the config, and `.github/ci/daemon-roundtrip.py`
+   * reads the same key to size its `initialize` budget. An extension property that stops short of
+   * it is silently inert: the build script looks configured, the daemon still boots the entire
+   * eager pool, and nothing anywhere fails.
+   *
+   * Asserted here rather than in a `ProjectBuilder` unit test on purpose — querying
+   * `systemProperties` resolves the `composePreviewDesktopDaemon` configuration, which needs a real
+   * build with repositories. Only a real `composePreviewDaemonStart` proves the wiring end to end.
+   */
+  @Test
+  fun `backgroundSandboxBoot set in the daemon block reaches the descriptor`() {
+    val projectDir =
+      createCmpTestProject(
+        extraBuildScript =
+          """
+          composePreview {
+              daemon {
+                  backgroundSandboxBoot = true
+              }
+          }
+          """
+            .trimIndent()
+      )
+
+    GradleRunner.create()
+      .withProjectDir(projectDir)
+      .withArguments("composePreviewDaemonStart", "--stacktrace")
+      .withPluginClasspath()
+      .build()
+
+    val descriptor = File(projectDir, "build/compose-previews/daemon-launch.json").readText()
+    assertThat(backgroundSandboxBootIn(descriptor)).isEqualTo("true")
+  }
+
+  @Test
+  fun `backgroundSandboxBoot defaults to false in the descriptor`() {
+    // Default-off has to hold at the descriptor, not just the extension: the eager
+    // all-sandboxes-ready contract is what every plugin consumer gets unless they opt out.
+    val projectDir = createCmpTestProject()
+
+    GradleRunner.create()
+      .withProjectDir(projectDir)
+      .withArguments("composePreviewDaemonStart", "--stacktrace")
+      .withPluginClasspath()
+      .build()
+
+    val descriptor = File(projectDir, "build/compose-previews/daemon-launch.json").readText()
+    assertThat(backgroundSandboxBootIn(descriptor)).isEqualTo("false")
+  }
+
+  /**
+   * Pulls the flag's value out of the emitted descriptor without pinning its JSON formatting — the
+   * descriptor is written pretty-printed (`"key": "value"`), and an assertion that hard-codes the
+   * spacing fails for a reason that has nothing to do with the wiring under test.
+   */
+  private fun backgroundSandboxBootIn(descriptorJson: String): String? =
+    Regex("\"composeai\\.daemon\\.backgroundSandboxBoot\"\\s*:\\s*\"([^\"]*)\"")
+      .find(descriptorJson)
+      ?.groupValues
+      ?.get(1)
+
   @Test
   fun `composePreviewDaemonStart is cached after source edit`() {
     val projectDir = createCmpTestProject()
@@ -90,7 +153,7 @@ class DaemonBootstrapFunctionalTest {
     assertThat(result.task(":composePreviewDiscover")).isNull()
   }
 
-  private fun createCmpTestProject(): File {
+  private fun createCmpTestProject(extraBuildScript: String = ""): File {
     val projectDir = tempDir.root
 
     File(projectDir, "settings.gradle.kts")
@@ -135,6 +198,7 @@ class DaemonBootstrapFunctionalTest {
         java {
             toolchain { languageVersion.set(JavaLanguageVersion.of(17)) }
         }
+        $extraBuildScript
         """
           .trimIndent()
       )

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -2662,6 +2662,7 @@ internal object AndroidPreviewSupport {
       this.maxHeapMb.set(extension.daemon.maxHeapMb)
       this.maxRendersPerSandbox.set(extension.daemon.maxRendersPerSandbox)
       this.warmSpare.set(extension.daemon.warmSpare)
+      this.backgroundSandboxBoot.set(extension.daemon.backgroundSandboxBoot)
       // Stage-2 BTA wiring. The AGP unit-test task's `classpath` carries every input
       // `compileDebugKotlin` would see — Compose runtime, kotlin-stdlib, AGP-generated
       // R.jar / BuildConfig outputs, the consumer's transitive dependencies. Feed that
@@ -2804,6 +2805,10 @@ internal object AndroidPreviewSupport {
       this.systemProperties.put(
         "composeai.daemon.warmSpare",
         extension.daemon.warmSpare.map { it.toString() },
+      )
+      this.systemProperties.put(
+        "composeai.daemon.backgroundSandboxBoot",
+        extension.daemon.backgroundSandboxBoot.map { it.toString() },
       )
       // Mirrors the `application=android.app.Application` line
       // GenerateRobolectricPropertiesTask writes for the composePreviewRender Test path.

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -685,6 +685,7 @@ internal object ComposePreviewTasks {
       maxHeapMb.set(extension.daemon.maxHeapMb)
       maxRendersPerSandbox.set(extension.daemon.maxRendersPerSandbox)
       warmSpare.set(extension.daemon.warmSpare)
+      backgroundSandboxBoot.set(extension.daemon.backgroundSandboxBoot)
       // Bake an explicit render JVM into `daemon-launch.json`. Unlike the in-Gradle `javaexec`
       // render, the daemon is spawned by VS Code / MCP on *their* JDK, so we always pin a launcher
       // (>= the module's bytecode target) rather than leaving it null — otherwise a JDK-17 editor
@@ -757,6 +758,10 @@ internal object ComposePreviewTasks {
       systemProperties.put(
         "composeai.daemon.warmSpare",
         extension.daemon.warmSpare.map { it.toString() },
+      )
+      systemProperties.put(
+        "composeai.daemon.backgroundSandboxBoot",
+        extension.daemon.backgroundSandboxBoot.map { it.toString() },
       )
       systemProperties.put("composeai.daemon.modulePath", project.path)
       systemProperties.put(

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/daemon/DaemonBootstrapTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/daemon/DaemonBootstrapTask.kt
@@ -99,6 +99,12 @@ abstract class DaemonBootstrapTask : DefaultTask() {
   @get:Input abstract val warmSpare: Property<Boolean>
 
   /**
+   * Mirror of [DaemonExtension.backgroundSandboxBoot]. Baked into
+   * `composeai.daemon.backgroundSandboxBoot`.
+   */
+  @get:Input abstract val backgroundSandboxBoot: Property<Boolean>
+
+  /**
    * Fully-qualified daemon entry point class. Convention is
    * `ee.schimke.composeai.daemon.DaemonMain` (Stream B / task B1.1 will provide the
    * implementation). Surfaced as a [Property] so future variants (foreground / debug / shadow

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/KmpAndroidDesktopRoutingTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/KmpAndroidDesktopRoutingTest.kt
@@ -195,12 +195,12 @@ class KmpAndroidDesktopRoutingTest {
   }
 
   @Test
-  fun `backgroundSandboxBoot reaches the launch descriptor's system properties`() {
-    // The daemon JVM only ever learns about background pool boot through the descriptor's
-    // systemProperties — RobolectricHost reads `composeai.daemon.backgroundSandboxBoot` at
-    // startup, and `.github/ci/daemon-roundtrip.py` reads the same key to size its `initialize`
-    // budget. An extension property that doesn't reach this map is silently inert: the build
-    // script looks configured, the daemon still boots the whole pool eagerly, and nothing fails.
+  fun `backgroundSandboxBoot flows from the daemon extension onto the bootstrap task`() {
+    // Extension -> task @Input half of the wiring. The other half — that it also lands in the
+    // descriptor's `systemProperties`, which is the only thing the daemon JVM actually reads —
+    // can't be asserted here: querying that map resolves the `composePreviewDesktopDaemon`
+    // configuration, and a bare ProjectBuilder project has no repositories to resolve it against.
+    // DaemonBootstrapFunctionalTest covers that end of it against a real build.
     val project = ProjectBuilder.builder().withProjectDir(tmp.root).build()
     val extension = project.extensions.create("composePreview", PreviewExtension::class.java)
     project.configurations.create("desktopRuntimeClasspath") {
@@ -214,15 +214,12 @@ class KmpAndroidDesktopRoutingTest {
     val daemon =
       project.tasks.getByName("composePreviewDaemonStart")
         as ee.schimke.composeai.plugin.daemon.DaemonBootstrapTask
-    assertThat(daemon.systemProperties.get())
-      .containsEntry("composeai.daemon.backgroundSandboxBoot", "true")
     assertThat(daemon.backgroundSandboxBoot.get()).isTrue()
   }
 
   @Test
-  fun `backgroundSandboxBoot defaults to false in the launch descriptor`() {
-    // Default-off must survive all the way to the descriptor, not just the extension: the eager
-    // all-sandboxes-ready contract is what plugin consumers get today.
+  fun `backgroundSandboxBoot defaults to false on the bootstrap task`() {
+    // Default-off must survive the extension -> task hop, not just the extension's convention.
     val project = ProjectBuilder.builder().withProjectDir(tmp.root).build()
     val extension = project.extensions.create("composePreview", PreviewExtension::class.java)
     project.configurations.create("desktopRuntimeClasspath") {
@@ -235,7 +232,6 @@ class KmpAndroidDesktopRoutingTest {
     val daemon =
       project.tasks.getByName("composePreviewDaemonStart")
         as ee.schimke.composeai.plugin.daemon.DaemonBootstrapTask
-    assertThat(daemon.systemProperties.get())
-      .containsEntry("composeai.daemon.backgroundSandboxBoot", "false")
+    assertThat(daemon.backgroundSandboxBoot.get()).isFalse()
   }
 }

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/KmpAndroidDesktopRoutingTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/KmpAndroidDesktopRoutingTest.kt
@@ -193,4 +193,49 @@ class KmpAndroidDesktopRoutingTest {
     val daemon = project.tasks.getByName("composePreviewDaemonStart") as TaskInternal
     assertThat(daemon.onlyIf.isSatisfiedBy(daemon)).isTrue()
   }
+
+  @Test
+  fun `backgroundSandboxBoot reaches the launch descriptor's system properties`() {
+    // The daemon JVM only ever learns about background pool boot through the descriptor's
+    // systemProperties — RobolectricHost reads `composeai.daemon.backgroundSandboxBoot` at
+    // startup, and `.github/ci/daemon-roundtrip.py` reads the same key to size its `initialize`
+    // budget. An extension property that doesn't reach this map is silently inert: the build
+    // script looks configured, the daemon still boots the whole pool eagerly, and nothing fails.
+    val project = ProjectBuilder.builder().withProjectDir(tmp.root).build()
+    val extension = project.extensions.create("composePreview", PreviewExtension::class.java)
+    project.configurations.create("desktopRuntimeClasspath") {
+      isCanBeResolved = true
+      isCanBeConsumed = false
+    }
+    extension.daemon { backgroundSandboxBoot.set(true) }
+
+    ComposePreviewTasks.registerDesktopTasks(project, extension)
+
+    val daemon =
+      project.tasks.getByName("composePreviewDaemonStart")
+        as ee.schimke.composeai.plugin.daemon.DaemonBootstrapTask
+    assertThat(daemon.systemProperties.get())
+      .containsEntry("composeai.daemon.backgroundSandboxBoot", "true")
+    assertThat(daemon.backgroundSandboxBoot.get()).isTrue()
+  }
+
+  @Test
+  fun `backgroundSandboxBoot defaults to false in the launch descriptor`() {
+    // Default-off must survive all the way to the descriptor, not just the extension: the eager
+    // all-sandboxes-ready contract is what plugin consumers get today.
+    val project = ProjectBuilder.builder().withProjectDir(tmp.root).build()
+    val extension = project.extensions.create("composePreview", PreviewExtension::class.java)
+    project.configurations.create("desktopRuntimeClasspath") {
+      isCanBeResolved = true
+      isCanBeConsumed = false
+    }
+
+    ComposePreviewTasks.registerDesktopTasks(project, extension)
+
+    val daemon =
+      project.tasks.getByName("composePreviewDaemonStart")
+        as ee.schimke.composeai.plugin.daemon.DaemonBootstrapTask
+    assertThat(daemon.systemProperties.get())
+      .containsEntry("composeai.daemon.backgroundSandboxBoot", "false")
+  }
 }

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/daemon/DaemonExtensionTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/daemon/DaemonExtensionTest.kt
@@ -27,6 +27,10 @@ class DaemonExtensionTest {
     // Warm spare on by default — pays double idle memory for zero
     // user-visible recycle pause. Off-by-default would be a regression.
     assertThat(daemon.warmSpare.get()).isTrue()
+    // Background pool boot OFF by default: `initialize` must not return until the whole eager
+    // pool is hot, which is the contract plugin consumers (and the integration daemon leg) rely
+    // on. On-by-default would silently weaken that for every consumer.
+    assertThat(daemon.backgroundSandboxBoot.get()).isFalse()
   }
 
   @Test


### PR DESCRIPTION
Follow-up to #2781. That PR removed the `android-all` download from the daemon leg's ~141s cold start; this one goes after the larger half — the ~58s of sequential sandbox boot.

## The cost

`RobolectricHost.start()` boots the eager slots **sequentially** and only then answers `initialize`. `warmSpare` is on by default, so that's 5 sandboxes at ~11.6s each ([SANDBOX-POOL.md](docs/daemon/SANDBOX-POOL.md)) before a client may render anything.

The daemon has had a fast path for this since the pool landed — `composeai.daemon.backgroundSandboxBoot`: block on slot 0, boot the rest on a background thread, dispatch across the ready prefix. But only `ServeBundleDaemon` and the deploy image could reach it. **Descriptors written by the Gradle plugin had no way to set it**, so every plugin consumer, and the integration daemon leg, paid for the whole pool up front. This wasn't a config gap — the property didn't exist.

## The change

Threaded through exactly like `warmSpare`: extension property → `DaemonBootstrapTask` `@Input` → descriptor `systemProperties`, on both the desktop and Android registration paths.

**Default `false`** — the eager all-sandboxes-ready contract is unchanged for every existing consumer. This only makes the trade available.

The integration daemon cell opts in via a new `daemon_background_boot` matrix field rather than a hardcoded literal, so covering the eager contract end-to-end again is a one-line cell addition. Being explicit about the cost: that cell no longer exercises the eager path e2e. It stays pinned by `RobolectricHostPoolTest` (real sandboxes, both paths) and by default-off assertions at the extension, task, and descriptor layers.

## Making the effect measurable

`daemon-roundtrip.py` now prints the observed `initialize` latency and the eager-slot count on every run, both from one helper so the reported count and the timeout budget can't drift apart.

This matters beyond curiosity: if the plumbing ever silently breaks, that line reports **5 eager slots and a ~140s latency** instead of 1 and ~80s. Without it, a broken descriptor looks identical to a working one — the leg just passes, slowly.

## Test plan

Everything below was run locally, and the results read off the JUnit XML rather than an exit code:

- **`:daemon:android:testDebugUnitTest --tests '*RobolectricHostPoolTest*'`** — 10/10, real Robolectric sandboxes, 81s. Includes `backgroundBootServesRendersBeforePoolCompletesAndWarmsTheLateSlot`: a render succeeds immediately after `start()` while the pool is still filling, the pool then completes, and the late slot gets its warm render. Sibling timing (`twoSandboxesServeDistinctClassloaders`, 13.8s for 2) corroborates the ~11.6s/sandbox figure behind the ~58s claim.
- **`:gradle-plugin:test`** — `DaemonExtensionTest` 2/2, `KmpAndroidDesktopRoutingTest` 8/8 (extension → task `@Input`, set and default).
- **`:gradle-plugin:functionalTest --tests '*DaemonBootstrapFunctionalTest*'`** — 5/5. Two new cases run a real `composePreviewDaemonStart` and read the emitted `daemon-launch.json`:

  ```json
  "composeai.daemon.warmSpare": "true",
  "composeai.daemon.backgroundSandboxBoot": "true",
  ```

  Asserted here rather than in a `ProjectBuilder` unit test for a concrete reason: querying `systemProperties` resolves the `composePreviewDesktopDaemon` configuration, which a bare test project has no repositories for, so the query throws before any assertion runs. That's why no existing unit test in that class touches the map.
- **`.github/ci/test_daemon_roundtrip.py`** — 19/19, including three new cases pinning that the reported eager-slot count and the derived `initialize` budget come from the same derivation.

**Not yet measured: the actual CI wall-clock saving.** That needs a real integration run, and the new latency line is what will show it. I'd rather state that than infer a number from the arithmetic.

Docs: `CONFIG.md` documents the knob as a time-to-first-render vs time-to-full-capacity trade; `STARTUP.md`'s options menu moves this item from open to done, leaving the genuinely open question — whether *default*-eager is right for editor clients — flagged as a product decision rather than a perf one.

No visual surface changed (daemon config plumbing, CI wiring, docs), so no render evidence applies.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JxpY7zw1fjYjsAE4vR4FaF)_