### PR TITLE
fix(ci): key the android-all cache on every coordinate a cell needs

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1375,43 +1375,49 @@ jobs:
           if-no-files-found: warn
           retention-days: 7
 
-      # Keep exactly one coordinate. After a `robolectric` bump the restored
-      # entry holds the OLD jar and this run downloads the new one alongside it,
-      # so a blind save would carry a dead quarter-gig forever. The freshly
-      # downloaded directory is strictly newer than everything the restore
-      # materialised, so newest-mtime is a reliable "current". Then key on what
-      # survived: unchanged coordinate → same key → save is a no-op; bumped
-      # coordinate → new key → new entry, old one ages out.
+      # Key on the FULL SET of coordinates present, and prune nothing.
       #
-      # Pruning is only sound because the key is per-cell and a cell renders at
-      # one SDK: the coordinate it wants this run is the one it wanted last run.
-      # Under a shared key this would be the thrash described on the restore
-      # step — don't collapse these keys back together.
+      # An earlier version kept only the newest-mtime coordinate, on the theory
+      # that a cell renders at one SDK. That is false: `wear-os-samples` fetched
+      # both `15-robolectric-13954326-i7` and `16-robolectric-13921718-i7` in a
+      # single run, because the Gradle render path and the daemon path resolve
+      # different SDKs. Pruning one of them made the saved entry permanently
+      # incomplete — the dropped coordinate was re-downloaded (~200 MB) on every
+      # subsequent run, and the save then no-op'd because the key hadn't changed.
+      # Silent, and strictly worse than not caching that coordinate at all.
+      #
+      # So: the key is the sorted set. Same coordinates → same key → save
+      # no-ops. A `robolectric` bump or a new SDK adds one → new key → new entry
+      # carrying everything the cell actually needs. The cost is that a
+      # superseded coordinate rides along until the entry is evicted; that is a
+      # bounded ~200 MB, where dropping it is an unbounded per-run re-download.
       - name: Resolve android-all cache key
         id: android-all
         if: always() && (matrix.render || matrix.render_xr || matrix.daemon)
         run: |
           set -euo pipefail
           python3 - <<'PY' >> "$GITHUB_OUTPUT"
-          import shutil
+          import hashlib
           import sys
           from pathlib import Path
 
           root = Path.home() / ".m2/repository/org/robolectric/android-all-instrumented"
-          versions = sorted(
-              (d for d in root.glob("*") if d.is_dir() and any(d.glob("*.jar"))),
-              key=lambda d: max(j.stat().st_mtime for j in d.glob("*.jar")),
+          coordinates = sorted(
+              d.name for d in root.glob("*") if d.is_dir() and any(d.glob("*.jar"))
           ) if root.is_dir() else []
-          if not versions:
+          if not coordinates:
               print("no android-all coordinate on disk — nothing to cache", file=sys.stderr)
               print("coordinate=")
               raise SystemExit(0)
-          current = versions[-1]
-          for stale in versions[:-1]:
-              print(f"::warning::pruning superseded android-all coordinate {stale.name}", file=sys.stderr)
-              shutil.rmtree(stale)
-          print(f"caching android-all coordinate {current.name}", file=sys.stderr)
-          print(f"coordinate={current.name}")
+          # One coordinate reads plainly in the key; several would blow past a
+          # sensible key length, so collapse those to a stable digest. Either way
+          # the key changes if and only if the SET changes.
+          joined = "_".join(coordinates)
+          key = joined if len(coordinates) == 1 else (
+              f"{len(coordinates)}x-{hashlib.sha256(joined.encode()).hexdigest()[:16]}"
+          )
+          print(f"caching {len(coordinates)} android-all coordinate(s): {joined}", file=sys.stderr)
+          print(f"coordinate={key}")
           PY
 
       # Split restore/save (rather than plain `actions/cache`) so a cell that
@@ -1737,25 +1743,27 @@ jobs:
         run: |
           set -euo pipefail
           python3 - <<'PY' >> "$GITHUB_OUTPUT"
-          import shutil
+          import hashlib
           import sys
           from pathlib import Path
 
           root = Path.home() / ".m2/repository/org/robolectric/android-all-instrumented"
-          versions = sorted(
-              (d for d in root.glob("*") if d.is_dir() and any(d.glob("*.jar"))),
-              key=lambda d: max(j.stat().st_mtime for j in d.glob("*.jar")),
+          coordinates = sorted(
+              d.name for d in root.glob("*") if d.is_dir() and any(d.glob("*.jar"))
           ) if root.is_dir() else []
-          if not versions:
+          if not coordinates:
               print("no android-all coordinate on disk — nothing to cache", file=sys.stderr)
               print("coordinate=")
               raise SystemExit(0)
-          current = versions[-1]
-          for stale in versions[:-1]:
-              print(f"::warning::pruning superseded android-all coordinate {stale.name}", file=sys.stderr)
-              shutil.rmtree(stale)
-          print(f"caching android-all coordinate {current.name}", file=sys.stderr)
-          print(f"coordinate={current.name}")
+          # One coordinate reads plainly in the key; several would blow past a
+          # sensible key length, so collapse those to a stable digest. Either way
+          # the key changes if and only if the SET changes.
+          joined = "_".join(coordinates)
+          key = joined if len(coordinates) == 1 else (
+              f"{len(coordinates)}x-{hashlib.sha256(joined.encode()).hexdigest()[:16]}"
+          )
+          print(f"caching {len(coordinates)} android-all coordinate(s): {joined}", file=sys.stderr)
+          print(f"coordinate={key}")
           PY
 
       - name: Save Robolectric android-all cache

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1375,22 +1375,30 @@ jobs:
           if-no-files-found: warn
           retention-days: 7
 
-      # Key on the FULL SET of coordinates present, and prune nothing.
+      # Key on the set of coordinates present, capped at the newest few.
       #
-      # An earlier version kept only the newest-mtime coordinate, on the theory
-      # that a cell renders at one SDK. That is false: `wear-os-samples` fetched
-      # both `15-robolectric-13954326-i7` and `16-robolectric-13921718-i7` in a
-      # single run, because the Gradle render path and the daemon path resolve
-      # different SDKs. Pruning one of them made the saved entry permanently
-      # incomplete — the dropped coordinate was re-downloaded (~200 MB) on every
-      # subsequent run, and the save then no-op'd because the key hadn't changed.
-      # Silent, and strictly worse than not caching that coordinate at all.
+      # Two failure modes bound this from either side, and both have been hit:
       #
-      # So: the key is the sorted set. Same coordinates → same key → save
-      # no-ops. A `robolectric` bump or a new SDK adds one → new key → new entry
-      # carrying everything the cell actually needs. The cost is that a
-      # superseded coordinate rides along until the entry is evicted; that is a
-      # bounded ~200 MB, where dropping it is an unbounded per-run re-download.
+      #  - Keep only ONE (newest mtime). Wrong: a cell can legitimately need
+      #    several. `wear-os-samples` fetched both `15-robolectric-13954326-i7`
+      #    and `16-robolectric-13921718-i7` in one run, because the Gradle render
+      #    path and the daemon path resolve different SDKs. Dropping one left the
+      #    entry permanently incomplete — re-downloaded (~200 MB) every run, with
+      #    the save no-op'ing because the key never changed.
+      #  - Keep ALL. Also wrong: the restore hands back the previous set, so each
+      #    `robolectric` bump folds another dead coordinate into the next entry.
+      #    Evicting older entries doesn't shrink the newest one, so the payload
+      #    grows ~200 MB per bump forever.
+      #
+      # There is no way to ask which coordinates this run actually USED: a
+      # restored jar that gets used is not rewritten, so it looks identical to
+      # one that sat untouched. Usage can't be inferred after the fact, so the
+      # bound is a deliberate policy instead — keep the MAX_COORDINATES highest
+      # Android versions and drop the rest, loudly. That covers a multi-SDK cell
+      # (2 today) with headroom, and a bump evicts the oldest rather than
+      # accumulating. A drop is logged, so if a cell ever genuinely needs more
+      # than the cap the re-download shows up as a warning rather than as an
+      # unexplained slow leg.
       - name: Resolve android-all cache key
         id: android-all
         if: always() && (matrix.render || matrix.render_xr || matrix.daemon)
@@ -1398,20 +1406,43 @@ jobs:
           set -euo pipefail
           python3 - <<'PY' >> "$GITHUB_OUTPUT"
           import hashlib
+          import re
+          import shutil
           import sys
           from pathlib import Path
 
+          # Headroom over the 2 a render+daemon cell needs today. Raise it if a
+          # cell starts warning that it dropped a coordinate it wanted.
+          MAX_COORDINATES = 3
+
           root = Path.home() / ".m2/repository/org/robolectric/android-all-instrumented"
-          coordinates = sorted(
-              d.name for d in root.glob("*") if d.is_dir() and any(d.glob("*.jar"))
-          ) if root.is_dir() else []
-          if not coordinates:
+          present = [d for d in root.glob("*") if d.is_dir() and any(d.glob("*.jar"))] if root.is_dir() else []
+          if not present:
               print("no android-all coordinate on disk — nothing to cache", file=sys.stderr)
               print("coordinate=")
               raise SystemExit(0)
+
+          # Order by Android version (the leading int of e.g. `16-robolectric-13921718-i7`),
+          # newest first, name as a stable tie-break.
+          def version_of(d):
+              m = re.match(r"(\d+)", d.name)
+              return (int(m.group(1)) if m else -1, d.name)
+
+          ranked = sorted(present, key=version_of, reverse=True)
+          keep, drop = ranked[:MAX_COORDINATES], ranked[MAX_COORDINATES:]
+          for d in drop:
+              print(
+                  f"::warning::dropping android-all coordinate {d.name} — over the "
+                  f"{MAX_COORDINATES}-coordinate cache cap. If this cell needs it, "
+                  "it will be re-downloaded every run; raise MAX_COORDINATES.",
+                  file=sys.stderr,
+              )
+              shutil.rmtree(d)
+
+          coordinates = sorted(d.name for d in keep)
           # One coordinate reads plainly in the key; several would blow past a
           # sensible key length, so collapse those to a stable digest. Either way
-          # the key changes if and only if the SET changes.
+          # the key changes if and only if the retained SET changes.
           joined = "_".join(coordinates)
           key = joined if len(coordinates) == 1 else (
               f"{len(coordinates)}x-{hashlib.sha256(joined.encode()).hexdigest()[:16]}"
@@ -1744,20 +1775,43 @@ jobs:
           set -euo pipefail
           python3 - <<'PY' >> "$GITHUB_OUTPUT"
           import hashlib
+          import re
+          import shutil
           import sys
           from pathlib import Path
 
+          # Headroom over the 2 a render+daemon cell needs today. Raise it if a
+          # cell starts warning that it dropped a coordinate it wanted.
+          MAX_COORDINATES = 3
+
           root = Path.home() / ".m2/repository/org/robolectric/android-all-instrumented"
-          coordinates = sorted(
-              d.name for d in root.glob("*") if d.is_dir() and any(d.glob("*.jar"))
-          ) if root.is_dir() else []
-          if not coordinates:
+          present = [d for d in root.glob("*") if d.is_dir() and any(d.glob("*.jar"))] if root.is_dir() else []
+          if not present:
               print("no android-all coordinate on disk — nothing to cache", file=sys.stderr)
               print("coordinate=")
               raise SystemExit(0)
+
+          # Order by Android version (the leading int of e.g. `16-robolectric-13921718-i7`),
+          # newest first, name as a stable tie-break.
+          def version_of(d):
+              m = re.match(r"(\d+)", d.name)
+              return (int(m.group(1)) if m else -1, d.name)
+
+          ranked = sorted(present, key=version_of, reverse=True)
+          keep, drop = ranked[:MAX_COORDINATES], ranked[MAX_COORDINATES:]
+          for d in drop:
+              print(
+                  f"::warning::dropping android-all coordinate {d.name} — over the "
+                  f"{MAX_COORDINATES}-coordinate cache cap. If this cell needs it, "
+                  "it will be re-downloaded every run; raise MAX_COORDINATES.",
+                  file=sys.stderr,
+              )
+              shutil.rmtree(d)
+
+          coordinates = sorted(d.name for d in keep)
           # One coordinate reads plainly in the key; several would blow past a
           # sensible key length, so collapse those to a stable digest. Either way
-          # the key changes if and only if the SET changes.
+          # the key changes if and only if the retained SET changes.
           joined = "_".join(coordinates)
           key = joined if len(coordinates) == 1 else (
               f"{len(coordinates)}x-{hashlib.sha256(joined.encode()).hexdigest()[:16]}"


### PR DESCRIPTION
Fixes a defect I introduced in #2781. Found by reading #2783's integration log rather than by a test — worth stating up front, because no test would have caught it.

## What the log showed

The `wear-os-samples` cell, in a **single run**:

```
##[warning]pruning superseded android-all coordinate 15-robolectric-13954326-i7
caching android-all coordinate 16-robolectric-13921718-i7
Cache saved with key: android-all-instrumented-Linux-wear-os-samples-16-robolectric-13921718-i7
```

Two coordinates, one cell. The restore was a cold miss (per-cell keys were new that run), so **both were downloaded by this run's own steps** — the Gradle render path and the daemon path resolve different SDKs.

## Why that was a bug

#2781's resolve step kept only the newest-mtime coordinate and deleted the rest, justified in a comment as:

> Pruning is only sound because the key is per-cell and a cell renders at one SDK: the coordinate it wants this run is the one it wanted last run.

False, and the log above is the counterexample. Steady state: restore returns coordinate 16 → the render path re-downloads coordinate 15 (~200 MB) → prune deletes it again → save no-ops because the key is unchanged → repeat forever. **Worse than not caching that coordinate at all**: same download, plus a restore and an upload on top. And silent — the leg stays green, just slow.

## Both extremes are broken

My first fix here kept the full set and pruned nothing. Codex correctly flagged ([thread](https://github.com/yschimke/compose-ai-tools/pull/2785#discussion_r3652372250)) that this is unbounded in the other direction: prefix restore returns the previous set, so every `robolectric` bump folds another dead coordinate into the next entry, and evicting older entries never shrinks the newest one. ~200 MB per bump, no ceiling. The "bounded" claim in the original version of this description was wrong.

- Keep **one** → starves a multi-SDK cell (the bug this PR opened for).
- Keep **all** → grows without limit.

The obvious middle — keep what this run actually used — **isn't available**. A restored jar that gets used is not rewritten, so afterwards it is indistinguishable from one that sat untouched: no mtime change, and `relatime` won't move atime either since the restore already set it. Usage cannot be inferred after the fact without instrumenting Robolectric.

## The fix

Bound it by explicit policy instead of a derived truth: retain the **3 highest Android versions**, drop the rest, and **log every drop** as a warning naming the coordinate and the cap.

- Fits today's 2-coordinate cell with headroom.
- A bump evicts the oldest instead of accumulating.
- If a cell ever genuinely needs more than the cap, the resulting re-download announces itself as a warning rather than presenting as an unexplained slow leg.
- `MAX_COORDINATES` is a named constant with a comment saying to raise it if that warning appears.

Applied to both the integration matrix and `agp8-min`.

## Test plan

Both inline scripts exercised against fixture layouts under a fake `$HOME`:

| Case | Expected | Result |
|---|---|---|
| 2 coordinates (the real render+daemon case) | both kept, nothing dropped | ✅ |
| reverse discovery order | identical key (set-stable, not insertion-ordered) | ✅ |
| 4 coordinates (simulated bump accumulation) | oldest evicted, 3 kept, drop logged | ✅ |
| 1 coordinate | key stays human-readable | ✅ |
| empty cache | `coordinate=`, save step skips | ✅ |

Workflow parses; both jobs confirmed on the capped path.

The real confirmation is the next integration run: the daemon cell should report caching 2 coordinates with no drop warning, and the run after that should restore both instead of re-downloading one.