### PR TITLE
fix(scroll): deflake stitched LONG captures and downloadable-font resolution

### DIFF
--- a/data/scroll/core/src/main/kotlin/ee/schimke/composeai/scroll/ScrollSliceStitcher.kt
+++ b/data/scroll/core/src/main/kotlin/ee/schimke/composeai/scroll/ScrollSliceStitcher.kt
@@ -918,17 +918,27 @@ private fun readLuminanceRowsOfRegion(img: BufferedImage, y0: Int, h: Int): Arra
 }
 
 /**
- * Scans `topLum` for the bottommost position whose `anchor.size` rows match `anchor` below the
- * per-pixel SAD threshold [ANCHOR_MATCH_MAX_SAD_PER_PIXEL]. Returns the row *after* the matched
+ * Scans `topLum` for the position whose `anchor.size` rows best match `anchor`, among those under
+ * the per-pixel SAD threshold [ANCHOR_MATCH_MAX_SAD_PER_PIXEL]. Returns the row *after* the matched
  * band — i.e. anchor matched at `topLum[y − anchor.size, y)` — suitable for use as a prefix-end cut
  * point, or `null` if no position hits the threshold.
  *
- * Bottommost-acceptable rather than global-min: once the EdgeButton reveals, the last list item
- * appears near the bottom of the stitched strip. A global-min search can prefer an earlier
- * similar-content scroll position (real Wear previews repeat card templates; synthetic jitter
- * patterns repeat by construction) — which would glue the EdgeButton on far above the true scroll
- * end and throw away the tail of the stitched content. Walking bottom-up and accepting the first
- * match locks onto the most recent occurrence of the last-item signature.
+ * Biased toward the bottom, but only among near-equal scores: once the EdgeButton reveals, the last
+ * list item appears near the bottom of the stitched strip, and a plain global-min search can prefer
+ * an earlier similar-content scroll position (real Wear previews repeat card templates; synthetic
+ * jitter patterns repeat by construction) — which would glue the EdgeButton on far above the true
+ * scroll end and throw away the tail of the stitched content. So we keep the "most recent
+ * occurrence" intent by walking bottom-up, but require a lower candidate to score within
+ * [ANCHOR_MATCH_TIE_MARGIN_PER_PIXEL] of the best one before it wins.
+ *
+ * Why not simply take the bottommost *acceptable* match (the original behaviour):
+ * [ANCHOR_MATCH_MAX_SAD_PER_PIXEL] is a fixed cutoff, so on a list of visually-similar rows a wrong
+ * position one row-pitch below the true one can also land under it — its score sits near the cutoff
+ * rather than near zero. Whether it did was decided by sub-pixel text rendering, so the same commit
+ * stitched two different images on different runs: the taller one repeated the final list row, and
+ * the output grew by exactly one row height. Scoring every candidate and demanding near-parity with
+ * the best makes the choice depend on how well the rows actually match rather than on which side of
+ * a fixed threshold noise pushed them.
  */
 private fun findBestAnchorMatch(
   topLum: Array<IntArray>,
@@ -941,16 +951,38 @@ private fun findBestAnchorMatch(
 
   val perPixelCutoff = (ANCHOR_MATCH_MAX_SAD_PER_PIXEL * k * width).toLong()
 
+  // Bottom-up, so `candidates` is already ordered bottommost-first.
+  val candidates = mutableListOf<Pair<Int, Long>>()
+  var bestSad = Long.MAX_VALUE
   for (y in h downTo k) {
     var sad = 0L
+    var overCutoff = false
     for (kk in 0 until k) {
       sad += rowSad(anchor[kk], topLum[y - k + kk])
-      if (sad > perPixelCutoff) break
+      if (sad > perPixelCutoff) {
+        overCutoff = true
+        break
+      }
     }
-    if (sad <= perPixelCutoff) return y
+    if (overCutoff) continue
+    candidates += y to sad
+    if (sad < bestSad) bestSad = sad
   }
-  return null
+  if (candidates.isEmpty()) return null
+
+  val tieCutoff = bestSad + (ANCHOR_MATCH_TIE_MARGIN_PER_PIXEL * k * width).toLong()
+  return candidates.first { (_, sad) -> sad <= tieCutoff }.first
 }
+
+/**
+ * How much worse (in per-pixel 0–255 luminance SAD) than the best match a *lower* anchor position
+ * may score and still be preferred for its position. The true last-item position SADs to ~0; a
+ * genuine repeat of the same card template elsewhere in the strip also SADs to ~0, so near-parity
+ * is the right test for "these are the same content, take the later one". A row-pitch-off mismatch
+ * scores well above 1 per pixel even when it squeaks under [ANCHOR_MATCH_MAX_SAD_PER_PIXEL], so it
+ * can no longer win on position alone.
+ */
+private const val ANCHOR_MATCH_TIE_MARGIN_PER_PIXEL = 1.0
 
 /**
  * Clips [file]'s image into a pill/stadium shape: half-circle at the top, rectangular middle,

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/GoogleFontInterceptor.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/GoogleFontInterceptor.kt
@@ -262,10 +262,21 @@ internal class GoogleFontCache(
  * Two-stage lookup:
  * 1. Try `wght@<exact>` — works for static families (Roboto, Lobster Two) and for the default
  *    weight of variable families.
- * 2. If that returns no TTF URL (purely-variable fonts like Roboto Flex reject single-weight
- *    requests at non-default weights), retry with `wght@<min>..<max>` covering the full 1–1000
- *    range. For variable fonts the response is a single `@font-face` pointing at the variable TTF;
- *    for static fonts it's multiple blocks and we pick the closest to the requested weight.
+ * 2. If that request *succeeded but carried no TTF URL* (purely-variable fonts like Roboto Flex
+ *    reject single-weight requests at non-default weights), retry with `wght@<min>..<max>` covering
+ *    the full 1–1000 range. For variable fonts the response is a single `@font-face` pointing at the
+ *    variable TTF; for static fonts it's multiple blocks and we pick the closest to the requested
+ *    weight.
+ *
+ * The stage-1/stage-2 distinction is load-bearing for reproducibility, which is why a *failed*
+ * stage-1 request returns false rather than falling through. The two stages can legitimately resolve
+ * the same `(family, weight, italic)` to different faces — a static sub-font at the exact weight vs
+ * the family's variable TTF — and those have different text metrics. Falling through on a network
+ * error therefore let a transient blip resolve a key to the other face, and because the result is
+ * cached under the same filename, that face then stuck for every later render on the machine.
+ * Consumers saw it as a whole-text-layer sub-pixel shift appearing and disappearing between CI runs
+ * on unrelated commits. Failing instead routes through the usual unresolved-font path, which is
+ * fatal per-preview by default (see [FontResolutionDiagnostics.failOnFallback]) and says so.
  *
  * The CSS2 endpoint serves WOFF2 by default (Android doesn't parse WOFF2 natively), so we send an
  * Android-2.3 User-Agent — one of the few UAs for which the API still returns TrueType. Same
@@ -276,9 +287,11 @@ internal fun downloadFromGoogleFonts(
   destination: File,
   fileSystem: FileSystem = SystemFileSystem,
 ): Boolean {
-  val exactUrl = httpGet(buildCssUrl(key), TTF_USER_AGENT)?.let { extractFirstTruetypeUrl(it) }
+  // A null here is a *failed request*, not "this family has no TTF at this weight" — don't let it
+  // silently pick up the range query's (differently-metricked) answer. See the KDoc.
+  val exactCss = httpGet(buildCssUrl(key), TTF_USER_AGENT) ?: return false
   val url =
-    exactUrl
+    extractFirstTruetypeUrl(exactCss)
       ?: run {
         val rangeCss = httpGet(buildRangeCssUrl(key), TTF_USER_AGENT) ?: return false
         pickClosestTruetypeUrl(rangeCss, key.weight.weight) ?: return false


### PR DESCRIPTION
## Summary

Two independent sources of **bimodal** render output: the same commit produced one of two stable PNGs depending on the run, so roughly half of all CI runs disagreed with the baseline on previews nothing had touched. Found while investigating why joreilly/Confetti's preview + a11y bots fire on unrelated PRs ([#1738 comment](https://github.com/joreilly/Confetti/pull/1738#issuecomment-5083137862)).

The tell that this was a renderer bug rather than real change: `compose-preview/main` flip-flops between two fixed blob hashes across consecutive main-branch renders, *returning to the same hash* — which rules out genuine content change.

```
HomeListViewKotlinConf_Devices_Large_Round.png, compose-preview/main history:
  cfdc5e47  f738b291
  c6370ed2  d787d228
  15450dcf  f738b291      ← same bytes as two renders earlier
  417b116e  d787d228
```

### 1. `findBestAnchorMatch` — duplicated list row

`ScrollSliceStitcher.kt` took the **bottommost** anchor position under a fixed `8.0` per-pixel SAD cutoff. On a list of visually similar cards, a wrong position one row-pitch below the true one can also land under that cutoff — its score sits near the cutoff rather than near zero — and whether it did was decided by sub-pixel text rendering. When it did, the stitch kept a duplicate of the final list row:

| | height | tail |
|---|---|---|
| variant A | 454 × 1650 | correct |
| variant B | 454 × 1762 | "Friday" rendered twice — the extra 112 px is one duplicated row |

Now every candidate is scored, and a lower-positioned one must be within `ANCHOR_MATCH_TIE_MARGIN_PER_PIXEL` (1.0) of the best to win. Genuine repeats of a card template score near-identically, so the original "most recent occurrence" intent is preserved; a row-pitch-off mismatch no longer wins on position alone.

### 2. `downloadFromGoogleFonts` — cached wrong typeface

The two-stage lookup fell through from the exact-weight query to the `wght@100..1000` range query whenever stage 1 produced no TTF URL — **including when the HTTP request itself failed**.

Those two stages can legitimately resolve one `(family, weight, italic)` to different faces: a static sub-font at the exact weight vs the family's variable TTF. Different text metrics. And the result is cached under the same filename, so a single transient network error pinned the wrong face for every later render on that machine — visible downstream as a whole-text-layer sub-pixel shift appearing and disappearing across runs on `_Fonts_Large` / `_Fonts_Largest` / `_SCROLL_long` variants.

Now a failed request returns `false` and routes into the existing unresolved-font path, which is fatal per-preview by default (`composeai.fonts.failOnFallback`) and says why. Only a fetched-but-empty response falls through.

## Test plan

- `./gradlew :data-scroll-core:test` — passes (7 tests), so the matcher change doesn't regress the existing honest/overreport/underreport/no-move fixtures.
- `./gradlew ktfmtFormatAll` — clean.

**Outstanding: no regression test pins the new anchor-tie behaviour.** Reproducing the bug needs a fixture whose wrong candidate scores *between* the tie margin (1.0) and the cutoff (8.0) per pixel. The existing fixtures use high-contrast pseudo-random content where any misalignment scores ~85 per pixel, so they can't express it — it needs low-contrast self-similar content plus a synthetic Wear EdgeButton. Flagging rather than merging quietly; happy to add it before this lands if you'd prefer.

## Visual evidence

Not captured. This changes rendered output of `@ScrollingPreview(LONG)` Wear captures, so per the repo's convention it warrants before/after pixels — but the reproduction is a *bimodal* renderer, so a single before/after pair from this container wouldn't demonstrate anything a reviewer could trust: the "before" image is whichever of the two variants that run happened to produce. What actually demonstrates the fix is the baseline branch ceasing to flip-flop across consecutive main renders, which only CI can show. The evidence above is drawn from the committed history of `compose-preview/main` on Confetti.


---
_Generated by [Claude Code](https://claude.ai/code/session_014XYVcWMboPQeAHgw5Y7qCM)_