### PR TITLE
feat(ci): persist the downloadable-font cache across apply-action runs

### DIFF
--- a/.github/actions/apply/README.md
+++ b/.github/actions/apply/README.md
@@ -301,6 +301,42 @@ A group is only surfaced when at least one of its variants actually changed
 non-nominated variants of the same function keep the historical "Other
 variants" treatment.
 
+## Downloadable-font cache
+
+Previews that use `Font(GoogleFont(...))` resolve their faces through a
+machine-local cache at `$XDG_CACHE_HOME/composeai/fonts` (else
+`~/.cache/composeai/fonts`), keyed by `(family, weight, italic)`. On a miss the
+renderer fetches the TTF from the Google Fonts CSS API — *during the render*,
+inside the Robolectric JVM.
+
+On CI that cache starts empty on every runner, so every face is re-fetched
+every run. The action persists it across runs with `actions/cache` (on by
+default; set `fonts-cache: false` to opt out).
+
+This is a correctness fix more than a speed one. The CSS API can serve a
+different face for the same key — a static sub-font at the exact weight, or the
+family's variable TTF — and those carry different text metrics. A run that
+resolved the other one renders its whole text layer shifted by a fraction of a
+pixel, which shows up as a visual diff on a PR that changed nothing. Caching
+the bytes means the face is chosen once instead of re-rolled per run.
+
+The cache is append-only — a key always means the same face — so the save key
+is unique per run and `restore-keys` pulls the newest prior entry forward. A
+fixed key would restore but never save, and a face first seen on run N would be
+re-fetched on every run after it. Restore and save are separate steps so a run
+that fails *after* paying the downloads still persists them, and the rerun
+starts warm.
+
+Two caveats worth knowing:
+
+- **Cache scope is per branch.** A PR run reads its own branch's cache and the
+  default branch's, so the baseline runs on `main` are what keep PR runs warm.
+  A brand-new face still costs one live fetch on the run that first needs it.
+- **This narrows the window, it does not close it.** A face is still fetched
+  live the first time it is seen, and whatever the API served then is what gets
+  cached. Pinning faces by content hash — so a substitution is a hard failure
+  rather than a silent metric change — needs a lockfile and is not part of this.
+
 ## Related actions
 
 - [`install`](../install/) — just put the CLI on `$PATH`, no pipelines.

--- a/.github/actions/apply/README.md
+++ b/.github/actions/apply/README.md
@@ -327,6 +327,14 @@ re-fetched on every run after it. Restore and save are separate steps so a run
 that fails *after* paying the downloads still persists them, and the rerun
 starts warm.
 
+Keys are scoped per job (`github.job`), and the restore prefixes try this job's
+own lineage before falling back to any job's. Cache archives are snapshots and
+are never merged, so a shared prefix would restore whichever job saved most
+recently — and with the compose and a11y jobs running concurrently over
+different font sets that never settles: both restore the same snapshot, each
+saves its own superset, and the next run restores one of them while the other
+job refetches its faces live. Per-job lineage converges to each job's own set.
+
 Two caveats worth knowing:
 
 - **Cache scope is per branch.** A PR run reads its own branch's cache and the

--- a/.github/actions/apply/action.yml
+++ b/.github/actions/apply/action.yml
@@ -564,7 +564,18 @@ runs:
       with:
         path: ${{ steps.fonts-dir.outputs.dir }}
         key: composeai-fonts-${{ runner.os }}-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
+        # This job's own lineage first, any job's as a cold-start fallback.
+        # Cache archives are snapshots and are never merged, so an OS-only
+        # prefix would restore whichever job saved most recently rather than
+        # this job's last state. With the compose and a11y jobs running
+        # concurrently over different font sets that never converges: both
+        # restore snapshot S, one saves S∪compose and the other S∪a11y, and the
+        # next run restores whichever landed last — so the other job refetches
+        # its own faces live, every run, which is the nondeterminism this cache
+        # exists to remove. Per-job lineage converges to each job's own set; the
+        # OS-only fallback only matters on a job's very first run.
         restore-keys: |
+          composeai-fonts-${{ runner.os }}-${{ github.job }}-
           composeai-fonts-${{ runner.os }}-
 
     - name: Run pipelines

--- a/.github/actions/apply/action.yml
+++ b/.github/actions/apply/action.yml
@@ -108,6 +108,26 @@ inputs:
       globally to every module the action invokes Gradle for (notifications
       pipeline + the compose / a11y pipelines via the CLI).
     default: 'fail'
+  fonts-cache:
+    description: >
+      Persist the downloadable-font cache (`$XDG_CACHE_HOME/composeai/fonts`,
+      else `~/.cache/composeai/fonts`) across runs with `actions/cache`.
+
+      Without it every fresh runner re-fetches every `Font(GoogleFont(...))`
+      face from the Google Fonts CSS API *during the render*, inside the
+      Robolectric JVM. That is slow, but the real cost is correctness: the CSS
+      API can serve a different face for the same `(family, weight, italic)` —
+      a static sub-font at the exact weight vs the family's variable TTF — and
+      those have different text metrics. A render that resolved the other one
+      shifts its whole text layer by a fraction of a pixel, which reads as a
+      spurious visual diff on a PR that changed nothing. Fetching once and
+      reusing the bytes removes the per-run coin flip.
+
+      The cache is append-only: entries are keyed by `(family, weight, italic)`
+      and a given key always means the same face, so a run only ever adds to
+      it. Set `false` to opt out (e.g. a consumer that vendors its own fonts,
+      or an air-gapped runner with a pre-seeded directory).
+    default: 'true'
   pr-number:
     description: 'Override for PR number when context is ambiguous.'
     default: ''
@@ -514,6 +534,39 @@ runs:
         echo "generic serif      → $(fc-match -f '%{family}\n' serif) (was: ${prev_serif:-none})"
         echo "generic monospace  → $(fc-match -f '%{family}\n' monospace) (was: ${prev_mono:-none})"
 
+    # Resolve the same directory the renderer's `GoogleFontCache` uses, via the
+    # same XDG rule as `composeAiFontsCacheDir` in the Gradle plugin. Computed
+    # in a step (rather than hardcoded in the cache `path`) so the two can't
+    # drift silently: if a runner sets XDG_CACHE_HOME, we cache what the render
+    # will actually read rather than an empty `~/.cache` sibling.
+    - name: Resolve downloadable-font cache dir
+      id: fonts-dir
+      if: inputs.fonts-cache == 'true' && steps.scope.outputs.mode != 'skip'
+      shell: bash
+      run: |
+        set -euo pipefail
+        base="${XDG_CACHE_HOME:-$HOME/.cache}"
+        dir="$base/composeai/fonts"
+        mkdir -p "$dir"
+        echo "dir=$dir" >> "$GITHUB_OUTPUT"
+        echo "downloadable-font cache: $dir"
+
+    # Append-only cache, so the key is unique per run and `restore-keys` pulls
+    # the newest prior entry. A fixed key would restore but never save, so a
+    # face first seen on run N would be re-fetched on every run after it.
+    # Split restore/save (rather than plain `actions/cache`) for the same reason
+    # the android-all cache is split in integration.yml: a run that failed AFTER
+    # paying the downloads still persists them, so the rerun starts warm.
+    - name: Restore downloadable-font cache
+      id: fonts-cache-restore
+      if: inputs.fonts-cache == 'true' && steps.scope.outputs.mode != 'skip'
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ${{ steps.fonts-dir.outputs.dir }}
+        key: composeai-fonts-${{ runner.os }}-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
+        restore-keys: |
+          composeai-fonts-${{ runner.os }}-
+
     - name: Run pipelines
       id: pipelines
       if: steps.scope.outputs.mode != 'skip'
@@ -586,6 +639,20 @@ runs:
         # Don't fail here — the trailing "surface failures" step decides
         # after pushes + comments have run.
         exit 0
+
+    # `always()` so a render that failed partway still persists whatever it
+    # fetched — the rerun does not re-download the same faces to fail the same
+    # way. `continue-on-error` because a cache upload is never worth failing a
+    # render over, and concurrent jobs (the compose and a11y jobs run as
+    # separate workflow jobs on the same commit) will race to save: the loser
+    # logs a "key already exists" warning, which is the expected steady state.
+    - name: Save downloadable-font cache
+      if: always() && inputs.fonts-cache == 'true' && steps.fonts-dir.outputs.dir != ''
+      continue-on-error: true
+      uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ${{ steps.fonts-dir.outputs.dir }}
+        key: composeai-fonts-${{ runner.os }}-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
 
     # Upload artifacts as top-level GHA steps (can't run from subshells).
     # Fires whenever the relevant pipeline flagged a non-zero render rc,


### PR DESCRIPTION
## Summary

Previews using `Font(GoogleFont(...))` resolve faces through a machine-local cache at `$XDG_CACHE_HOME/composeai/fonts` (else `~/.cache/composeai/fonts`), keyed by `(family, weight, italic)`. **Nothing persisted that directory on CI** — `setup-gradle` caches `~/.gradle`, not `~/.cache/composeai` — so every runner started empty and re-fetched every face from the Google Fonts CSS API *during the render*, inside the Robolectric JVM.

The cost is correctness more than time. The CSS API can serve a different face for the same key — a static sub-font at the exact weight vs the family's variable TTF — and those carry different text metrics. A run that resolved the other one renders its whole text layer shifted by a fraction of a pixel, which reads as a visual diff on a PR that changed nothing. Fetching once and reusing the bytes means the face is chosen once instead of re-rolled per run.

Restore before the pipelines, save after. On by default; `fonts-cache: false` opts out.

## Design notes

- **Unique save key per run + `restore-keys` prefix.** The cache is append-only — a key always means the same face — so this is safe, and it's necessary: a fixed key would restore but never save, so a face first seen on run N would be re-fetched on every run after it.
- **Split restore/save** rather than plain `actions/cache`, matching the android-all cache idiom in `integration.yml`: a run that fails *after* paying the downloads still persists them, so the rerun starts warm.
- **`github.job` in the key** — the compose and a11y jobs share a `run_id` and would otherwise collide on save.
- **Path resolved in a step**, using the same XDG rule as `composeAiFontsCacheDir`, rather than hardcoded — so a runner that sets `XDG_CACHE_HOME` caches what the render will actually read instead of an empty `~/.cache` sibling.

## Relationship to #2786

Complementary, not overlapping. #2786 makes a *failed* font fetch loud instead of silently substituting a differently-metricked face. This stops the fetch happening at all on the common path. Neither depends on the other; this branch is cut from `main`, so it doesn't disturb #2786's auto-merge.

## What this does NOT do

**It narrows the window, it doesn't close it.** A face is still fetched live the first time it's seen, and whatever the API served at that moment is what gets cached — permanently. Genuinely closing it means pinning faces by content hash in a lockfile, so a substitution is a hard failure with a diff rather than a silent metric change. That needs render-time recording of successful resolutions (today only *failures* are recorded, in `FontResolutionDiagnostics`), a committed lockfile, and a cacheable warm task. Deliberately out of scope here — happy to do it as a follow-up if you want it.

Also worth knowing: **cache scope is per branch.** A PR run reads its own branch's cache and the default branch's, so the `main` baseline runs are what keep PR runs warm.

## Test plan

- `action.yml` parses; step order verified as fonts-dir → restore → pipelines → save.
- No unit-testable surface — this is CI wiring. The observable effect is the "Restore downloadable-font cache" step reporting a hit on the second run of this PR, and the render log no longer showing font fetches. Worth checking on this PR's own run before merging, since compose-ai-tools' own samples use downloadable fonts.


---
_Generated by [Claude Code](https://claude.ai/code/session_014XYVcWMboPQeAHgw5Y7qCM)_