### PR TITLE
feat(daemon)!: default backgroundSandboxBoot to true

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -325,21 +325,18 @@ jobs:
             # that the standalone `composePreviewRender` task can't see. See
             # .github/ci/daemon-roundtrip.py.
             daemon: true
-            # Answer `initialize` as soon as slot 0 is hot; boot the rest of the
-            # warm-spare pool behind it. `start()` boots the eager slots
-            # sequentially, so the default (all 5 up before `initialize`) spends
-            # ~58s at ~11.6s/sandbox buying capacity this round-trip never uses —
-            # it renders one module's previews, edits, re-renders. See
-            # docs/daemon/SANDBOX-POOL.md § Background pool boot.
+            # `daemon_background_boot` is deliberately UNSET here, so the cell
+            # inherits `composePreview.daemon.backgroundSandboxBoot`'s default
+            # (now `true`) and therefore exercises exactly what plugin consumers
+            # get. Measured effect on this leg: `initialize` answers in ~6.5s
+            # instead of waiting ~58s for all five warm-spare slots.
             #
-            # The trade: this cell no longer covers the eager all-sandboxes-ready
-            # contract end-to-end. That contract stays pinned by
-            # RobolectricHostPoolTest (real sandboxes, both paths) and by the
-            # default-off assertions in DaemonExtensionTest /
-            # KmpAndroidDesktopRoutingTest. If it needs e2e coverage again, add a
-            # second daemon cell with `daemon_background_boot: false` — that's
-            # why this is a matrix field and not a hardcoded literal.
-            daemon_background_boot: true
+            # The eager all-sandboxes-ready contract has no end-to-end cell now.
+            # It stays pinned by RobolectricHostPoolTest (real sandboxes, both
+            # paths) and by the opt-out assertions in KmpAndroidDesktopRoutingTest
+            # / DaemonBootstrapFunctionalTest. To cover it here, add a second
+            # daemon cell with `daemon_background_boot: false` — that's what the
+            # matrix field is for.
             # Surfaced in the published compose-preview/integration/<slug>
             # branch README so browsers see what this cell exercises +
             # any caveats. Hand-written; auto-derived facts (patch / build
@@ -1220,17 +1217,19 @@ jobs:
           # Idempotent for the CI-injected block, but still overrides a consumer block that
           # explicitly sets enabled = false.
           #
-          # `backgroundSandboxBoot` comes from the cell (`matrix.daemon_background_boot`) rather
-          # than being hardcoded, so the two boot contracts are both reachable from the matrix:
-          # true = `initialize` answers once slot 0 is hot (the pool finishes behind it), false =
-          # the eager contract where the whole warm-spare pool is up first. A cell that wants to
-          # cover the eager path end-to-end is a one-line matrix addition, not a workflow edit.
+          # `backgroundSandboxBoot` is only written when the cell sets
+          # `matrix.daemon_background_boot`; otherwise the line is omitted and the extension's own
+          # default applies. That matters: the default is now `true`, so unconditionally emitting
+          # `= false` for cells that don't set the field would silently opt them OUT of the
+          # default every consumer gets, and the leg would be testing a configuration nobody runs.
+          # Setting the field to `false` is how a cell covers the eager all-sandboxes-ready path.
           python3 - <<'PY'
           from pathlib import Path
           import os
           module = os.environ["MATRIX_MODULE"]
-          # Gradle wants a lowercase literal; the matrix field arrives as "true"/"false"/"".
-          background_boot = "true" if os.environ.get("MATRIX_BACKGROUND_BOOT") == "true" else "false"
+          # Unset -> emit nothing and inherit the extension default. Set -> pin it explicitly.
+          raw_boot = os.environ.get("MATRIX_BACKGROUND_BOOT", "").strip().lower()
+          boot_line = f"    backgroundSandboxBoot = {raw_boot}\n" if raw_boot in ("true", "false") else ""
           # Find the most likely build script for that module: top-level <module>/build.gradle.kts
           # (most apps), then fall back to top-level build.gradle. ComposeStarter has app/build.gradle.kts.
           candidates = [
@@ -1243,13 +1242,13 @@ jobs:
               text = p.read_text()
               suffix = (
                   "\n\ncomposePreview {\n  daemon {\n    enabled = true\n"
-                  f"    backgroundSandboxBoot = {background_boot}\n  }}\n}}\n"
+                  f"{boot_line}  }}\n}}\n"
               )
               if suffix.strip() in text:
                   print(f"daemon enable block already present in {p}")
                   break
               p.write_text(text + suffix)
-              print(f"appended daemon enable block to {p} (backgroundSandboxBoot={background_boot})")
+              print(f"appended daemon enable block to {p} (backgroundSandboxBoot={raw_boot or 'default'})")
               break
           else:
               raise SystemExit(f"no build script found for module {module}")

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -471,16 +471,22 @@ open class RobolectricHost(
    * rather than rendering against a half-built host. Blocking here in [start] delivers that —
    * `JsonRpcServer.run()` only enters its read loop once we return.
    *
-   * **Background pool boot** (`-Dcomposeai.daemon.backgroundSandboxBoot=true`, default off): with a
+   * **Background pool boot** (`-Dcomposeai.daemon.backgroundSandboxBoot=true`): with a
    * pool (`sandboxCount > 1`), [start] blocks only until **slot 0** is ready and boots slots
    * 1..N-1 on a background thread. Sandbox boot is the dominant cold-start cost (~11.6 s measured
    * per sandbox on a warm `android-all` cache — see the serve cold-render handover), so a
    * 3-sandbox pool otherwise keeps `initialize` (and therefore serve's first live render) waiting
    * ~35 s for capacity it doesn't need yet. Dispatch routes only across ready slots
    * ([readySlotCount]) until the pool completes, so `daemonReady = firstSandboxReady` and the
-   * remaining boots never sit on the request path. Off by default so in-process hosts and the
-   * Gradle-plugin launch keep the strict all-sandboxes-ready contract their tests pin;
-   * `ServeBundleDaemon` and the deploy image opt serve-spawned Android daemons in.
+   * remaining boots never sit on the request path.
+   *
+   * Two defaults, deliberately different. This sysprop falls back to **off**, so a host
+   * constructed in-process (embedders, harness, unit tests) still boots the whole pool eagerly and
+   * keeps the strict all-sandboxes-ready contract those tests pin. Launch *descriptors* default it
+   * **on** — `composePreview.daemon.backgroundSandboxBoot` (docs/daemon/CONFIG.md), matching what
+   * `ServeBundleDaemon` and the deploy image already did — so every spawned daemon answers
+   * `initialize` once slot 0 is hot. A descriptor always carries an explicit value, so this
+   * fallback only applies where nothing set one.
    *
    * Configurable via `composeai.daemon.sandboxBootTimeoutMs` (default 600_000 = 10 minutes). On
    * timeout the daemon refuses to start; the client surfaces the failure via initialize never

--- a/docs/daemon/CONFIG.md
+++ b/docs/daemon/CONFIG.md
@@ -11,7 +11,7 @@ composePreview {
     maxHeapMb = 1024
     maxRendersPerSandbox = 1000
     warmSpare = true
-    backgroundSandboxBoot = false
+    backgroundSandboxBoot = true
   }
 }
 ```
@@ -65,15 +65,19 @@ Higher values amortise the spare-rebuild cost over more renders; lower values ca
 
 | | |
 |-|-|
-| **Default** | `false` |
+| **Default** | `true` |
 | **Range** | `true` / `false` |
-| **Effect** | Whether `initialize` may be answered as soon as the **first** sandbox is ready, with the rest of the pool booting on a background thread. Default `false` means the whole eager pool must be hot first. See [SANDBOX-POOL.md](SANDBOX-POOL.md) § Background pool boot. |
+| **Effect** | Whether `initialize` may be answered as soon as the **first** sandbox is ready, with the rest of the pool booting on a background thread. `false` makes the whole eager pool boot before `initialize` returns. See [SANDBOX-POOL.md](SANDBOX-POOL.md) § Background pool boot. |
 
-This is a time-to-**first**-render vs time-to-**full-capacity** trade, and it only bites when the pool is bigger than one. `RobolectricHost.start()` boots the eager slots *sequentially*, so with `warmSpare = true` (5 sandboxes) `initialize` waits for roughly `5 × sandbox boot` — ~58s at the ~11.6s-per-sandbox figure measured in SANDBOX-POOL.md — before the client may render anything.
+This is a time-to-**first**-render vs time-to-**full-capacity** trade, and it only bites when the pool is bigger than one. `RobolectricHost.start()` boots the eager slots *sequentially*, so with `warmSpare = true` (5 sandboxes) and this off, `initialize` waits for roughly `5 × sandbox boot` — ~58s at the ~11.6s-per-sandbox figure measured in SANDBOX-POOL.md — before the client may render anything.
 
-Turn it on when the first render matters more than the fifth: a cold CI leg that renders once, or an editor opening a single preview. Leave it off when a client fans out N renders the instant `initialize` returns and would rather not have them queue on the ready prefix while the pool fills.
+**Default `true`, because time-to-first-render is what a human waits on.** Nothing can render until `initialize` returns, so the eager path charges every client for the whole pool before it may draw anything — capacity that isn't needed until the *second* render. Measured on the integration daemon leg, `initialize` answers in ~6.5s with this on.
 
-Once the pool completes, dispatch is bit-identical either way; this only changes what happens *during* boot. `ServeBundleDaemon` and the deploy image already default it on for serve-spawned daemons — this knob is what makes the same trade available to the Gradle-plugin launch path.
+Set `false` when a client fans out N renders the instant `initialize` returns and would rather not have them queue on the ready prefix while the pool fills — i.e. when time-to-full-capacity genuinely beats time-to-first-render.
+
+Once the pool completes, dispatch is bit-identical either way; this only changes what happens *during* boot. `ServeBundleDaemon` and the deploy image already made this trade for serve-spawned daemons, so the Gradle-plugin launch path now matches them rather than diverging.
+
+Note this is the **descriptor** default. A `RobolectricHost` constructed in-process still boots eagerly unless its caller sets `composeai.daemon.backgroundSandboxBoot` — embedding code owns that choice directly.
 
 ### MCP-only — `replicasPerDaemon`
 

--- a/docs/daemon/SANDBOX-POOL.md
+++ b/docs/daemon/SANDBOX-POOL.md
@@ -183,13 +183,32 @@ one sandbox instead of the whole daemon JVM.
 
 ## Background pool boot (cold-start fast path)
 
-`-Dcomposeai.daemon.backgroundSandboxBoot=true` (default **off**) changes
+`composeai.daemon.backgroundSandboxBoot` changes
 `RobolectricHost.start()`'s contract for a pool: it blocks only until
 **slot 0** is registered, then boots slots 1..N-1 sequentially on a
 background daemon thread. Sandbox boot is the dominant cold-start cost
 (~11.6 s measured per sandbox on a warm `android-all` cache), so a
 3-sandbox pool otherwise holds `initialize` — and therefore serve's first
 live render — for ~35 s of capacity nothing needs yet.
+
+**Two different defaults, and the distinction matters when diagnosing:**
+
+- **Launch descriptors default it ON.** `composePreview.daemon
+  .backgroundSandboxBoot` defaults to `true`
+  ([CONFIG.md](CONFIG.md)), so every daemon the Gradle plugin describes —
+  VS Code, MCP, the integration leg — answers `initialize` once slot 0 is
+  hot. `ServeBundleDaemon` and the deploy image do the same. Set it
+  `false` in the `daemon { … }` block to get the eager
+  all-sandboxes-ready contract back.
+- **The sysprop itself defaults OFF.** `RobolectricHost` reads
+  `-Dcomposeai.daemon.backgroundSandboxBoot` with a `false` fallback, so a
+  host constructed **in-process** (embedders, `:daemon:harness`, unit
+  tests) still boots the whole pool eagerly unless its caller opts in.
+  That code sets the property directly and its tests pin the eager
+  contract, so the fallback stays conservative.
+
+In practice a descriptor always carries an explicit value, so the sysprop
+fallback only applies where nothing set one.
 
 Semantics under background boot:
 

--- a/docs/daemon/STARTUP.md
+++ b/docs/daemon/STARTUP.md
@@ -139,17 +139,24 @@ Menu of follow-ups, by leverage:
 - ~~**Reconsider the eager warm-spare pool on the launch-descriptor
   path.**~~ **Done** — `composePreview.daemon.backgroundSandboxBoot`
   ([CONFIG.md](CONFIG.md)) exposes it to the Gradle-plugin launch path,
-  default `false` so the eager contract is still what consumers get
-  unless they ask otherwise. The integration daemon cell opts in via the
-  `daemon_background_boot` matrix field, which drops its eager slots from
-  5 to 1. `.github/ci/daemon-roundtrip.py` prints the measured
-  `initialize` latency and the eager-slot count on every run, so the
-  effect is readable off the leg's log rather than inferred.
+  and it **defaults to `true`** — optimise for latency. Nothing renders
+  until `initialize` returns, so the eager contract charged every client
+  for the whole pool before it could draw anything: capacity not needed
+  until the second render. Eager slots on the critical path drop from 5
+  to 1.
 
-  What remains open is the *default*: whether the eager
-  all-sandboxes-ready contract is the right one for editor clients, or
-  whether they'd also rather render sooner. That's a product question,
-  not a perf one.
+  Measured on the integration daemon leg: `initialize` answers in
+  **~6.5 s**, against the ~141 s that started this whole thread (that
+  figure also included a cold `android-all` fetch, now cached, so the two
+  changes share the credit).
+
+  Clients that would rather have full capacity up front set
+  `backgroundSandboxBoot = false`. The integration daemon cell
+  deliberately leaves the `daemon_background_boot` matrix field unset so
+  the leg exercises the default consumers actually get;
+  `.github/ci/daemon-roundtrip.py` prints the measured `initialize`
+  latency and the eager-slot count on every run, so a silent regression
+  to 5 slots is readable off the log rather than inferred.
 - **Machine-resident daemon** (highest priority). Daemon survives editor
   restarts; cold start moves from "every editor open" to "every reboot."
   Lifecycle change only; needs a different anchor than parent-PID.

--- a/gradle-plugin/gradle-plugin-config/src/main/kotlin/ee/schimke/composeai/plugin/daemon/DaemonExtension.kt
+++ b/gradle-plugin/gradle-plugin-config/src/main/kotlin/ee/schimke/composeai/plugin/daemon/DaemonExtension.kt
@@ -70,24 +70,34 @@ abstract class DaemonExtension @Inject constructor(objects: ObjectFactory) {
 
   /**
    * Whether the daemon may answer `initialize` as soon as the FIRST sandbox is ready, booting the
-   * rest of the pool on a background thread. Default: `false`.
+   * rest of the pool on a background thread. Default: `true`.
    *
    * `RobolectricHost.start()` boots the eager slots sequentially and applies the per-slot boot
-   * budget to each, so a [warmSpare] pool (5 sandboxes) holds `initialize` for roughly
+   * budget to each, so a [warmSpare] pool (5 sandboxes) would hold `initialize` for roughly
    * `5 × sandbox boot` — ~58s at the ~11.6s-per-sandbox figure in
    * `docs/daemon/SANDBOX-POOL.md` — before the client may render anything. With this on, only slot
    * 0 is on the critical path; dispatch routes across the ready prefix while the remaining slots
    * boot behind it, and once the pool completes behaviour is bit-identical with the eager path.
    *
-   * Off by default because the eager path is the stricter contract: when `initialize` returns, the
-   * whole pool is hot, and an editor that immediately fans out N renders gets N sandboxes. Turn it
-   * on when time-to-first-render matters more than time-to-full-capacity — a cold CI leg that
-   * renders once, or an editor opening a single preview. `ServeBundleDaemon` and the deploy image
-   * already make that trade for serve-spawned daemons.
+   * On by default: time-to-first-render is what a human waits on. Nothing can render until
+   * `initialize` returns, so the eager path makes every client pay for the whole pool before it may
+   * draw anything — capacity it doesn't need until the *second* render. Measured on the CI daemon
+   * leg, `initialize` answers in ~6.5s with this on. `ServeBundleDaemon` and the deploy image
+   * already made this trade for serve-spawned daemons; this aligns the Gradle-plugin launch path
+   * with them.
+   *
+   * Set `false` to get the stricter contract back: when `initialize` returns, the whole pool is
+   * hot, so a client that immediately fans out N renders gets N sandboxes rather than queueing on
+   * the ready prefix while the pool fills. Worth it only when time-to-full-capacity genuinely
+   * matters more than time-to-first-render.
+   *
+   * Note this is the *descriptor* default, not `RobolectricHost`'s. A host constructed in-process
+   * still boots eagerly unless its caller sets `composeai.daemon.backgroundSandboxBoot` — the
+   * embedding code owns that choice directly, and its tests pin the eager contract.
    *
    * See `docs/daemon/SANDBOX-POOL.md` § Background pool boot for the dispatch, interactive-slot,
    * and slot-failure semantics this changes.
    */
   val backgroundSandboxBoot: Property<Boolean> =
-    objects.property(Boolean::class.java).convention(false)
+    objects.property(Boolean::class.java).convention(true)
 }

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DaemonBootstrapFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DaemonBootstrapFunctionalTest.kt
@@ -24,14 +24,14 @@ class DaemonBootstrapFunctionalTest {
    * build with repositories. Only a real `composePreviewDaemonStart` proves the wiring end to end.
    */
   @Test
-  fun `backgroundSandboxBoot set in the daemon block reaches the descriptor`() {
+  fun `backgroundSandboxBoot opt-out in the daemon block reaches the descriptor`() {
     val projectDir =
       createCmpTestProject(
         extraBuildScript =
           """
           composePreview {
               daemon {
-                  backgroundSandboxBoot = true
+                  backgroundSandboxBoot = false
               }
           }
           """
@@ -45,13 +45,13 @@ class DaemonBootstrapFunctionalTest {
       .build()
 
     val descriptor = File(projectDir, "build/compose-previews/daemon-launch.json").readText()
-    assertThat(backgroundSandboxBootIn(descriptor)).isEqualTo("true")
+    assertThat(backgroundSandboxBootIn(descriptor)).isEqualTo("false")
   }
 
   @Test
-  fun `backgroundSandboxBoot defaults to false in the descriptor`() {
-    // Default-off has to hold at the descriptor, not just the extension: the eager
-    // all-sandboxes-ready contract is what every plugin consumer gets unless they opt out.
+  fun `backgroundSandboxBoot defaults to true in the descriptor`() {
+    // Default-on has to hold at the descriptor, not just the extension: this is what every plugin
+    // consumer gets, and the descriptor is the daemon JVM's only view of it.
     val projectDir = createCmpTestProject()
 
     GradleRunner.create()
@@ -61,7 +61,7 @@ class DaemonBootstrapFunctionalTest {
       .build()
 
     val descriptor = File(projectDir, "build/compose-previews/daemon-launch.json").readText()
-    assertThat(backgroundSandboxBootIn(descriptor)).isEqualTo("false")
+    assertThat(backgroundSandboxBootIn(descriptor)).isEqualTo("true")
   }
 
   /**

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/KmpAndroidDesktopRoutingTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/KmpAndroidDesktopRoutingTest.kt
@@ -195,7 +195,7 @@ class KmpAndroidDesktopRoutingTest {
   }
 
   @Test
-  fun `backgroundSandboxBoot flows from the daemon extension onto the bootstrap task`() {
+  fun `backgroundSandboxBoot opt-out flows from the daemon extension onto the bootstrap task`() {
     // Extension -> task @Input half of the wiring. The other half — that it also lands in the
     // descriptor's `systemProperties`, which is the only thing the daemon JVM actually reads —
     // can't be asserted here: querying that map resolves the `composePreviewDesktopDaemon`
@@ -207,19 +207,20 @@ class KmpAndroidDesktopRoutingTest {
       isCanBeResolved = true
       isCanBeConsumed = false
     }
-    extension.daemon { backgroundSandboxBoot.set(true) }
+    // Explicitly opting OUT is the interesting direction now that the default is on.
+    extension.daemon { backgroundSandboxBoot.set(false) }
 
     ComposePreviewTasks.registerDesktopTasks(project, extension)
 
     val daemon =
       project.tasks.getByName("composePreviewDaemonStart")
         as ee.schimke.composeai.plugin.daemon.DaemonBootstrapTask
-    assertThat(daemon.backgroundSandboxBoot.get()).isTrue()
+    assertThat(daemon.backgroundSandboxBoot.get()).isFalse()
   }
 
   @Test
-  fun `backgroundSandboxBoot defaults to false on the bootstrap task`() {
-    // Default-off must survive the extension -> task hop, not just the extension's convention.
+  fun `backgroundSandboxBoot defaults to true on the bootstrap task`() {
+    // Default-on must survive the extension -> task hop, not just the extension's convention.
     val project = ProjectBuilder.builder().withProjectDir(tmp.root).build()
     val extension = project.extensions.create("composePreview", PreviewExtension::class.java)
     project.configurations.create("desktopRuntimeClasspath") {
@@ -232,6 +233,6 @@ class KmpAndroidDesktopRoutingTest {
     val daemon =
       project.tasks.getByName("composePreviewDaemonStart")
         as ee.schimke.composeai.plugin.daemon.DaemonBootstrapTask
-    assertThat(daemon.backgroundSandboxBoot.get()).isFalse()
+    assertThat(daemon.backgroundSandboxBoot.get()).isTrue()
   }
 }

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/daemon/DaemonExtensionTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/daemon/DaemonExtensionTest.kt
@@ -27,10 +27,10 @@ class DaemonExtensionTest {
     // Warm spare on by default — pays double idle memory for zero
     // user-visible recycle pause. Off-by-default would be a regression.
     assertThat(daemon.warmSpare.get()).isTrue()
-    // Background pool boot OFF by default: `initialize` must not return until the whole eager
-    // pool is hot, which is the contract plugin consumers (and the integration daemon leg) rely
-    // on. On-by-default would silently weaken that for every consumer.
-    assertThat(daemon.backgroundSandboxBoot.get()).isFalse()
+    // Background pool boot ON by default: `initialize` answers once slot 0 is hot, so
+    // time-to-first-render doesn't pay for the whole warm-spare pool. Flipping this back to
+    // off-by-default would restore the ~58s eager wait for every consumer.
+    assertThat(daemon.backgroundSandboxBoot.get()).isTrue()
   }
 
   @Test


### PR DESCRIPTION
Follow-up to #2783, which added the knob but left it off. Optimising the launch-descriptor default for latency.

## Why

Nothing can render until `initialize` returns, and `RobolectricHost.start()` boots the eager slots **sequentially**. With `warmSpare` on (5 sandboxes), the old default charged every client ~58s for the whole pool before it could draw anything — capacity not needed until the *second* render.

Measured on the integration daemon leg with this on: `initialize` answers in **~6.5s** with `eager slots on the critical path: 1`.

This also aligns the Gradle-plugin launch path with `ServeBundleDaemon` and the deploy image, which already made the same trade for serve-spawned daemons — they were the outlier before, not this.

**Opting out** (`backgroundSandboxBoot = false`) restores the strict all-sandboxes-ready contract: when `initialize` returns the whole pool is hot, so a client that immediately fans out N renders gets N sandboxes rather than queueing on the ready prefix while the pool fills. Worth it only when time-to-full-capacity genuinely beats time-to-first-render.

**Scope**: this is the **descriptor** default. `RobolectricHost`'s own sysprop default stays `false`, so in-process embedders keep booting eagerly unless their caller opts in — that code owns the choice directly and its tests pin the eager contract. The descriptor always carries an explicit value, so the host default only applies where nothing set one.

## A bug the flip would otherwise have introduced

The CI "Configure daemon in consumer build" step wrote the property **unconditionally**, emitting `= false` whenever a cell left `daemon_background_boot` unset. Under the new default that would have silently opted every daemon cell *out* of what consumers get — the leg would have been testing a configuration nobody runs, and passing.

Now the line is emitted only when a cell explicitly sets the field, and `wear-os-samples` deliberately leaves it unset so the leg exercises the shipped default. Covering the eager path end-to-end is a cell with `daemon_background_boot: false` — that's what the matrix field is for.

## Coverage

Tests invert rather than disappear, so both directions stay pinned:

| Layer | Default (`true`) | Opt-out (`false`) |
|---|---|---|
| Extension | `DaemonExtensionTest` | — |
| Task `@Input` | `KmpAndroidDesktopRoutingTest` | `KmpAndroidDesktopRoutingTest` |
| Descriptor JSON | `DaemonBootstrapFunctionalTest` | `DaemonBootstrapFunctionalTest` |

The eager all-sandboxes-ready path keeps its behavioural coverage in `RobolectricHostPoolTest` (real Robolectric sandboxes, both boot paths).

## Test plan

- `:gradle-plugin:test` + `:gradle-plugin:functionalTest` — BUILD SUCCESSFUL, exit 0 read from Gradle directly. `DaemonExtensionTest` 2/2, `KmpAndroidDesktopRoutingTest` 8/8, `DaemonBootstrapFunctionalTest` 5/5, including all four new/inverted `backgroundSandboxBoot` cases.
- Inject-step logic exercised against a fixture consumer build for **unset / empty / `true` / `false`**, asserting the property line is emitted only in the last two, plus idempotency across two runs (one `composePreview` block, not two).
- Workflow parses; confirmed the daemon cell now inherits the default.

Docs: `CONFIG.md` default and rationale updated; `STARTUP.md`'s options-menu entry rewritten — including the paragraph above it, which still asserted default-`false` and would otherwise have contradicted the new text on the same page.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JxpY7zw1fjYjsAE4vR4FaF)_