### PR TITLE
feat(server): Attribute Compose sample catalogs to android/compose-samples

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -1534,8 +1534,9 @@ object ServeWeb {
       setOf("jetnews", "jetcaster", "jetchat", "jetsnack", "jetlagged", "reply")
     val designSystems = systems.filter { it.system in designSystemIds }
     val androidComposeSamples = systems.filter { it.system in androidComposeSampleIds }
-    val remaining =
-      systems.filterNot { it.system in designSystemIds || it.system in androidComposeSampleIds }
+    val remaining = systems.filterNot {
+      it.system in designSystemIds || it.system in androidComposeSampleIds
+    }
     val yschimkeSystems = remaining.filter { it.trust?.startsWith("branch:yschimke/") == true }
     val otherSystems = remaining - yschimkeSystems.toSet()
     val sections =

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -1449,8 +1449,11 @@ object ServeWeb {
    * repeat visit no image requests at all.
    *
    * [systems] are the published catalogs (the `--catalogs` set), grouped into the Compose design
-   * systems, catalogs published by the `yschimke` GitHub organization, and a final "Other" section
-   * for every remaining publisher (for example, Confetti from `joreilly`). The
+   * systems, Android's Compose samples, catalogs published by the `yschimke` GitHub organization,
+   * and a final "Other" section for every remaining publisher (for example, Confetti from
+   * `joreilly`). The sample catalogs are currently fetched from preview branches in the
+   * `yschimke/compose-samples` fork, but they represent `android/compose-samples`; grouping by the
+   * branch-trust origin would incorrectly present the fork as their publisher.
    * `--catalogs-unlisted` app catalogs are deliberately NOT indexed here — they're served at
    * `/<system>/` (shareable by direct link) but stay off the front door entirely, so an operator
    * can publish an app catalog without advertising it on the public landing.
@@ -1527,13 +1530,18 @@ object ServeWeb {
       """
         .trimIndent()
     val designSystemIds = setOf("compose-m3", "remote-m3", "wear-m3")
+    val androidComposeSampleIds =
+      setOf("jetnews", "jetcaster", "jetchat", "jetsnack", "jetlagged", "reply")
     val designSystems = systems.filter { it.system in designSystemIds }
-    val remaining = systems.filterNot { it.system in designSystemIds }
+    val androidComposeSamples = systems.filter { it.system in androidComposeSampleIds }
+    val remaining =
+      systems.filterNot { it.system in designSystemIds || it.system in androidComposeSampleIds }
     val yschimkeSystems = remaining.filter { it.trust?.startsWith("branch:yschimke/") == true }
     val otherSystems = remaining - yschimkeSystems.toSet()
     val sections =
       listOf(
           Triple("Design Systems", designSystems, "design system(s)"),
+          Triple("android/compose-samples", androidComposeSamples, "sample(s)"),
           Triple("yschimke org", yschimkeSystems, "catalog(s)"),
           Triple("Other", otherSystems, "catalog(s)"),
         )

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebThumbCropTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebThumbCropTest.kt
@@ -85,19 +85,18 @@ class ServeWebThumbCropTest {
   @Test
   fun `all compose sample catalogs are attributed to android and shown on the homepage`() {
     val sampleIds = listOf("jetnews", "jetcaster", "jetchat", "jetsnack", "jetlagged", "reply")
-    val systems =
-      sampleIds.map { id ->
-        ServeWeb.HomeSystem(
-          system = id,
-          title = id,
-          subtitle = null,
-          previewCount = 1,
-          // The preview branches currently live in this fork. That fetch/trust origin must not
-          // make the public homepage attribute Android's samples to the fork owner.
-          trust = "branch:yschimke/compose-samples@design-artifacts/$id",
-          heroPreviewId = null,
-        )
-      }
+    val systems = sampleIds.map { id ->
+      ServeWeb.HomeSystem(
+        system = id,
+        title = id,
+        subtitle = null,
+        previewCount = 1,
+        // The preview branches currently live in this fork. That fetch/trust origin must not
+        // make the public homepage attribute Android's samples to the fork owner.
+        trust = "branch:yschimke/compose-samples@design-artifacts/$id",
+        heroPreviewId = null,
+      )
+    }
 
     val html = ServeWeb.homeIndexPage(systems, token = "t", isPublic = true)
 

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebThumbCropTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebThumbCropTest.kt
@@ -81,4 +81,30 @@ class ServeWebThumbCropTest {
       "img escapes the fit-to-box cap",
     )
   }
+
+  @Test
+  fun `all compose sample catalogs are attributed to android and shown on the homepage`() {
+    val sampleIds = listOf("jetnews", "jetcaster", "jetchat", "jetsnack", "jetlagged", "reply")
+    val systems =
+      sampleIds.map { id ->
+        ServeWeb.HomeSystem(
+          system = id,
+          title = id,
+          subtitle = null,
+          previewCount = 1,
+          // The preview branches currently live in this fork. That fetch/trust origin must not
+          // make the public homepage attribute Android's samples to the fork owner.
+          trust = "branch:yschimke/compose-samples@design-artifacts/$id",
+          heroPreviewId = null,
+        )
+      }
+
+    val html = ServeWeb.homeIndexPage(systems, token = "t", isPublic = true)
+
+    assertTrue(html.contains("<h1 class=\"cp-head\">android/compose-samples</h1>"))
+    assertFalse(html.contains("<h1 class=\"cp-head\">yschimke org</h1>"))
+    sampleIds.forEach { id ->
+      assertTrue(html.contains("href=\"/$id/\""), "$id is linked from the homepage")
+    }
+  }
 }


### PR DESCRIPTION
### Motivation
- Preview branches for the Jetpack Compose samples are fetched from a fork (`yschimke/compose-samples`) but should be presented as the canonical `android/compose-samples` publisher rather than attributed to the fork.
- The public homepage grouping must surface all six sample catalogs (JetNews, Jetcaster, Jetchat, Jetsnack, JetLagged, Reply) under a dedicated samples section so users can find them easily.

### Description
- Add explicit sample grouping in the homepage generator by introducing an `androidComposeSampleIds` set and excluding those IDs from the generic `yschimke` grouping so they render under an `android/compose-samples` section. (edited file: `cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt`).
- Add a regression test that builds a homepage with the six sample systems and asserts they appear under the `android/compose-samples` heading, are linked from the homepage, and do not cause a `yschimke org` section to appear. (edited file: `cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebThumbCropTest.kt`).
- Commit message: "fix: attribute Compose samples to Android".

### Testing
- Ran the focused unit test: `./gradlew :cli:test --tests ee.schimke.composeai.cli.serve.ServeWebThumbCropTest`, which completed successfully (build reported `BUILD SUCCESSFUL`).
- Verified repository hygiene with `git diff --check` and `git status --short`, both clean after committing the change.
- Confirmed the deploy image configuration lists the sample systems by default so the six samples remain available to the public server (checked `deploy/image/entrypoint.sh`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6656b300408324ac26bed659653b02)