### PR TITLE
feat(renderer): Support LocalLocale and LocalLocaleList in Android previews

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.layout.layout
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.platform.ViewRootForTest
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
@@ -447,6 +448,9 @@ class RenderEngine(
                         add(LocalContext provides placeholderContext)
                       }
                       add(LocalInspectionMode provides inspectionMode)
+                      ee.schimke.composeai.renderer.LocaleCompositionLocals
+                        .providedValue(LocalConfiguration.current, classLoader)
+                        ?.let(::add)
                       // Cleared background ("crisp outline"): a composable drawing its own opaque
                       // fill drops it to match the transparent decor-view background. Defaults false.
                       add(
@@ -1133,6 +1137,9 @@ class RenderEngine(
             val provided =
               buildList {
                   add(LocalInspectionMode provides false)
+                  ee.schimke.composeai.renderer.LocaleCompositionLocals
+                    .providedValue(LocalConfiguration.current, classLoader)
+                    ?.let(::add)
                   add(
                     ee.schimke.composeai.preview.slots.LocalPreviewBackgroundCleared provides
                       spec.clearBackground
@@ -1292,6 +1299,9 @@ class RenderEngine(
             val provided =
               buildList {
                   add(LocalInspectionMode provides (spec.inspectionMode ?: true))
+                  ee.schimke.composeai.renderer.LocaleCompositionLocals
+                    .providedValue(LocalConfiguration.current, classLoader)
+                    ?.let(::add)
                   add(
                     ee.schimke.composeai.preview.slots.LocalPreviewBackgroundCleared provides
                       spec.clearBackground
@@ -1615,6 +1625,9 @@ class RenderEngine(
                   // final SVG render re-enters `render` in the non-a11y path, i.e.
                   // `spec.inspectionMode ?: true`.
                   add(LocalInspectionMode provides (spec.inspectionMode ?: true))
+                  ee.schimke.composeai.renderer.LocaleCompositionLocals
+                    .providedValue(LocalConfiguration.current, classLoader)
+                    ?.let(::add)
                   add(
                     ee.schimke.composeai.preview.slots.LocalPreviewBackgroundCleared provides
                       spec.clearBackground

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -2533,6 +2533,12 @@ open class RobolectricHost(
                             androidx.compose.ui.platform.LocalInspectionMode provides
                               (start.inspectionMode ?: false)
                           )
+                          ee.schimke.composeai.renderer.LocaleCompositionLocals
+                            .providedValue(
+                              androidx.compose.ui.platform.LocalConfiguration.current,
+                              classLoader,
+                            )
+                            ?.let(::add)
                           add(
                             ee.schimke.composeai.preview.slots.LocalPreviewBackgroundCleared provides
                               start.clearBackground

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/LocaleCompositionLocals.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/LocaleCompositionLocals.kt
@@ -1,0 +1,47 @@
+package ee.schimke.composeai.renderer
+
+import android.content.res.Configuration
+import android.os.Build
+import androidx.compose.runtime.ProvidedValue
+import androidx.compose.runtime.ProvidableCompositionLocal
+
+/**
+ * Bridges the locale from the preview's Robolectric [Configuration] into the locale composition
+ * locals added in newer Compose UI releases.
+ *
+ * The renderer deliberately compiles against the Compose 1.9 compatibility BOM, while
+ * `LocalLocaleList` and `LocalLocale` were added later. Resolve the providable backing local and
+ * `LocaleList` reflectively so previews using a newer Compose UI can read both APIs without making
+ * older consumers fail class loading. `LocalLocale` is computed from the first entry in
+ * `LocalLocaleList`, so providing `LocalProvidableLocaleList` supports both public locals.
+ */
+object LocaleCompositionLocals {
+  @Suppress("UNCHECKED_CAST")
+  fun providedValue(
+    configuration: Configuration,
+    classLoader: ClassLoader =
+      LocaleCompositionLocals::class.java.classLoader ?: ClassLoader.getSystemClassLoader(),
+  ): ProvidedValue<*>? =
+    runCatching {
+        val compositionLocals =
+          Class.forName("androidx.compose.ui.platform.CompositionLocalsKt", false, classLoader)
+        val local =
+          compositionLocals.getMethod("getLocalProvidableLocaleList").invoke(null)
+            as ProvidableCompositionLocal<Any>
+        val localeListClass =
+          Class.forName("androidx.compose.ui.text.intl.LocaleList", false, classLoader)
+        val localeList =
+          localeListClass.getConstructor(String::class.java).newInstance(languageTags(configuration))
+        local provides localeList
+      }
+      .getOrNull()
+
+  internal fun languageTags(configuration: Configuration): String {
+    if (Build.VERSION.SDK_INT >= 24) {
+      return (0 until configuration.locales.size())
+        .joinToString(",") { configuration.locales[it].toLanguageTag() }
+    }
+    @Suppress("DEPRECATION")
+    return configuration.locale.toLanguageTag()
+  }
+}

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/LocaleCompositionLocals.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/LocaleCompositionLocals.kt
@@ -14,6 +14,14 @@ import androidx.compose.runtime.ProvidableCompositionLocal
  * `LocaleList` reflectively so previews using a newer Compose UI can read both APIs without making
  * older consumers fail class loading. `LocalLocale` is computed from the first entry in
  * `LocalLocaleList`, so providing `LocalProvidableLocaleList` supports both public locals.
+ *
+ * Normally `AbstractComposeView` installs the platform locals through Compose UI's
+ * `ProvideCommonCompositionLocals`. The preview renderer must also work when its 1.9-compiled
+ * composition host runs preview bytecode built against 1.11, however. An audit of the Compose UI
+ * platform locals added between those versions found this locale list as the only new
+ * platform-derived public local. The other addition, runtime's `LocalRetainedValuesStore`, is
+ * lifecycle state owned and installed by the composition host itself; synthesizing it here would
+ * break retention semantics.
  */
 object LocaleCompositionLocals {
   @Suppress("UNCHECKED_CAST")
@@ -38,10 +46,10 @@ object LocaleCompositionLocals {
 
   internal fun languageTags(configuration: Configuration): String {
     if (Build.VERSION.SDK_INT >= 24) {
-      return (0 until configuration.locales.size())
-        .joinToString(",") { configuration.locales[it].toLanguageTag() }
+      val locales = configuration.locales.takeUnless { it.isEmpty } ?: android.os.LocaleList.getDefault()
+      return (0 until locales.size()).joinToString(",") { locales[it].toLanguageTag() }
     }
     @Suppress("DEPRECATION")
-    return configuration.locale.toLanguageTag()
+    return (configuration.locale ?: java.util.Locale.getDefault()).toLanguageTag()
   }
 }

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -81,6 +81,7 @@ import kotlinx.serialization.json.Json
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.ParameterizedRobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
 
 private fun ScrollAxis.toProductAxis(): ProductScrollAxis =
   when (this) {
@@ -1100,6 +1101,10 @@ abstract class RobolectricRenderTestBase(
           val providedValues =
             buildList {
                 add(LocalInspectionMode provides inspectionMode)
+                LocaleCompositionLocals.providedValue(
+                    RuntimeEnvironment.getApplication().resources.configuration
+                  )
+                  ?.let(::add)
                 if (scrollCaptureProvidable != null) {
                   add(scrollCaptureProvidable provides scrollCaptureInProgress)
                 }

--- a/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/LocaleCompositionLocalsTest.kt
+++ b/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/LocaleCompositionLocalsTest.kt
@@ -21,6 +21,18 @@ class LocaleCompositionLocalsTest {
   }
 
   @Test
+  fun `empty preview configuration falls back to a nonempty platform locale list`() {
+    val previous = Locale.getDefault()
+    try {
+      Locale.setDefault(Locale.CANADA_FRENCH)
+
+      assertEquals("fr-CA", LocaleCompositionLocals.languageTags(Configuration()))
+    } finally {
+      Locale.setDefault(previous)
+    }
+  }
+
+  @Test
   fun `older compose versions without locale locals remain supported`() {
     val configuration = Configuration().apply { setLocale(Locale.GERMANY) }
     val emptyLoader = object : ClassLoader(null) {}

--- a/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/LocaleCompositionLocalsTest.kt
+++ b/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/LocaleCompositionLocalsTest.kt
@@ -1,0 +1,30 @@
+package ee.schimke.composeai.renderer
+
+import android.content.res.Configuration
+import android.os.LocaleList
+import java.util.Locale
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class LocaleCompositionLocalsTest {
+  @Test
+  fun `configuration locales become a compose locale list language tag string`() {
+    val configuration = Configuration().apply { setLocales(LocaleList(Locale.UK, Locale.JAPAN)) }
+
+    assertEquals("en-GB,ja-JP", LocaleCompositionLocals.languageTags(configuration))
+  }
+
+  @Test
+  fun `older compose versions without locale locals remain supported`() {
+    val configuration = Configuration().apply { setLocale(Locale.GERMANY) }
+    val emptyLoader = object : ClassLoader(null) {}
+
+    assertNull(LocaleCompositionLocals.providedValue(configuration, emptyLoader))
+  }
+}


### PR DESCRIPTION
### Motivation

- Previews should surface the newer Compose UI locale composition locals (`LocalLocaleList` / `LocalLocale`) when available so `@Preview(locale=...)` overrides render correctly on newer Compose versions.  
- Keep backward compatibility with projects compiled against older Compose BOMs by resolving the new locals reflectively.

### Description

- Add `LocaleCompositionLocals.kt` which reflectively looks up `LocalProvidableLocaleList` and constructs a `LocaleList` from an Android `Configuration`, returning a `ProvidedValue` suitable for `CompositionLocal` provisioning.  
- Wire the provider into the standalone Robolectric preview path by adding the provided locale entry in `RobolectricRenderTest.kt` (using `RuntimeEnvironment.getApplication().resources.configuration`).  
- Wire the same provider into the daemon render paths in `daemon/android/.../RenderEngine.kt` across the normal, raster and scroll/SVG render branches so both daemon and standalone renders honor locale overrides.  
- Add unit tests `LocaleCompositionLocalsTest.kt` to cover multi-locale language-tag conversion and the graceful fallback case when the new locals are absent on the classpath.  
- Small robustness fixes: ensure a fallback `ClassLoader` is used when resolving reflective types and add the necessary Robolectric imports and config for tests.

### Testing

- Ran compilation for the affected modules with `./gradlew :renderer-android:compileDebugKotlin :daemon:android:compileDebugKotlin` and it completed successfully.  
- Ran formatter and checks with `./gradlew :renderer-android:ktfmtFormat` and related ktfmt tasks and they completed successfully.  
- Executed the new unit test with `./gradlew :renderer-android:testDebugUnitTest --tests ee.schimke.composeai.renderer.LocaleCompositionLocalsTest` and it passed after the reflected classloader / Robolectric SDK configuration adjustments.  
- Ran `git diff --check` to verify no whitespace/patch issues and the repository checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a666be23b6883249b3fa6f80a98b5cc)