### PR TITLE
feat(wear): Merge origin/main into PR #2796 — Wear dark-mode normalization and catalog-scoped theme persistence

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -1174,7 +1174,8 @@ class ServeHttpServer(
    */
   private suspend fun RoutingContext.handleStorybookIframe(sessionInPath: Boolean) {
     if (rejectBadToken()) return
-    withLeasedSession(selectedSessionId(sessionInPath)) { renderHost ->
+    val sessionId = selectedSessionId(sessionInPath)
+    withLeasedSession(sessionId) { renderHost ->
       val storyId = call.request.queryParameters["id"]
       if (storyId.isNullOrBlank()) {
         call.respondText("missing story id", status = HttpStatusCode.BadRequest)
@@ -1193,13 +1194,15 @@ class ServeHttpServer(
             if (ServeOverrides.isOverrideParam(key)) key to value else null
           }
           .toMap()
+      val normalizedOverrideParams =
+        ServeWeb.SystemDisplay.normalizeOverrideParams(sessionId, overrideParams)
       val knobKinds =
         ServeOverrides.declaredKnobKinds(renderHost.previews.firstOrNull { it.id == previewId })
       // `?format=svg` serves the figma-svg export as an inert svg <img> (vector, for DOM-capture
       // visual tools); default (png) inlines the raster. SVG is daemon-only, so a static bundle
       // 404s.
       val wantSvg = call.request.queryParameters["format"]?.lowercase() == "svg"
-      when (val parsed = ServeOverrides.parse(overrideParams, knobKinds)) {
+      when (val parsed = ServeOverrides.parse(normalizedOverrideParams, knobKinds)) {
         is OverrideParse.Invalid ->
           call.respondText(parsed.message, status = HttpStatusCode.BadRequest)
         is OverrideParse.Ok ->
@@ -1444,18 +1447,19 @@ class ServeHttpServer(
             if (ServeOverrides.isOverrideParam(key)) key to value else null
           }
           .toMap()
+      val normalizedOverrideParams =
+        ServeWeb.SystemDisplay.normalizeOverrideParams(sessionId, overrideParams)
       // Type a bare `knob.<key>=<value>` from the preview's declared knobs (an explicit
       // `<kind>:<value>` still wins) so the viewer never has to spell the type in the URL.
       val knobKinds =
         ServeOverrides.declaredKnobKinds(renderHost.previews.firstOrNull { it.id == previewId })
-      when (val parsed = ServeOverrides.parse(overrideParams, knobKinds)) {
+      when (val parsed = ServeOverrides.parse(normalizedOverrideParams, knobKinds)) {
         is OverrideParse.Invalid ->
           call.respondText(parsed.message, status = HttpStatusCode.BadRequest)
         is OverrideParse.Ok -> {
-          // Wear/watch surfaces are always dark. The generic viewer used to leak its shared
-          // `cp-theme=light` preference into these URLs, needlessly waking the live daemon and
-          // producing a second encoding/render for an unsupported mode.
-          val overrides = ServeWeb.SystemDisplay.normalizeOverrides(sessionId, parsed.overrides)
+          // Wear/watch surfaces are always dark. Ignore a generic or hand-authored uiMode query so
+          // it cannot wake the live daemon and produce another render for an unsupported mode.
+          val overrides = parsed.overrides
           if (wantSvg) {
             // `?scroll=long` (or `full`/`page`) asks for the full-page export of a scrolling
             // preview (compose/figma-svg-long) instead of the viewport-sized one.
@@ -1677,6 +1681,10 @@ class ServeHttpServer(
               if (ServeOverrides.isOverrideParam(key)) key to value else null
             }
             .toMap()
+            .let { ServeWeb.SystemDisplay.normalizeOverrideParams(sessionId, it) }
+        val normalizeOverrides: (Map<String, String>) -> Map<String, String> = {
+          ServeWeb.SystemDisplay.normalizeOverrideParams(sessionId, it)
+        }
         // Non-suspending hand-off to the socket; drop frames a slow client can't keep up with.
         val send: (String) -> Unit = { text -> outgoing.trySend(Frame.Text(text)) }
         // Optional stream tuning: codec (WebP is ~30–60% smaller; the daemon downgrades to PNG if
@@ -1703,6 +1711,7 @@ class ServeHttpServer(
               codec,
               maxFps,
               send,
+              normalizeOverrides,
             ) { reason ->
               if (liveUnavailableReason == null) liveUnavailableReason = reason
             }
@@ -1725,6 +1734,7 @@ class ServeHttpServer(
               previewId,
               initialOverrides,
               send,
+              normalizeOverrides = normalizeOverrides,
               liveUnavailableReason = liveUnavailableReason,
             )
           // Renders block (renderNow + await); keep them off the socket's event-loop thread.

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeLiveSession.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeLiveSession.kt
@@ -23,21 +23,24 @@ private constructor(
   private val codec: StreamCodec?,
   private val maxFps: Int?,
   private val send: (String) -> Unit,
+  private val normalizeOverrides: (Map<String, String>) -> Map<String, String>,
 ) {
   @Volatile private var handle: StreamHandle? = null
 
   /** Handle one client text message: forward input, restart the stream on new overrides, etc. */
   fun onClientMessage(text: String) {
     when (val message = ServeStreamProtocol.parseClient(text)) {
-      is ServeStreamProtocol.ClientMessage.SetOverrides ->
-        when (val parsed = ServeOverrides.parse(message.overrides, knobKindsFor(previewId))) {
+      is ServeStreamProtocol.ClientMessage.SetOverrides -> {
+        val normalized = normalizeOverrides(message.overrides)
+        when (val parsed = ServeOverrides.parse(normalized, knobKindsFor(previewId))) {
           is OverrideParse.Invalid -> send(ServeStreamProtocol.errorMessage(parsed.message))
           is OverrideParse.Ok -> {
             // stream/start fixes overrides for the held session, so an override change restarts it.
-            overrides = message.overrides
+            overrides = normalized
             restart(parsed.overrides)
           }
         }
+      }
       is ServeStreamProtocol.ClientMessage.Input -> dispatchInput(message)
       is ServeStreamProtocol.ClientMessage.Switch -> switchTo(message)
       // Frames are pushed by the daemon; an explicit refresh is a no-op on the live lane.
@@ -86,7 +89,7 @@ private constructor(
    * view intact rather than going blank.
    */
   private fun switchTo(message: ServeStreamProtocol.ClientMessage.Switch) {
-    val nextOverrides = message.overrides ?: overrides
+    val nextOverrides = message.overrides?.let(normalizeOverrides) ?: overrides
     val parsed =
       when (val p = ServeOverrides.parse(nextOverrides, knobKindsFor(message.previewId))) {
         is OverrideParse.Invalid -> {
@@ -146,14 +149,25 @@ private constructor(
       codec: StreamCodec? = null,
       maxFps: Int? = null,
       send: (String) -> Unit,
+      normalizeOverrides: (Map<String, String>) -> Map<String, String> = { it },
       onUnavailable: ((String) -> Unit)? = null,
     ): ServeLiveSession? {
       val knobKinds =
         ServeOverrides.declaredKnobKinds(renderHost.previews.firstOrNull { it.id == previewId })
+      val normalizedOverrides = normalizeOverrides(overrides)
       val initial =
-        (ServeOverrides.parse(overrides, knobKinds) as? OverrideParse.Ok)?.overrides
+        (ServeOverrides.parse(normalizedOverrides, knobKinds) as? OverrideParse.Ok)?.overrides
           ?: PreviewOverrides()
-      val session = ServeLiveSession(renderHost, previewId, overrides, codec, maxFps, send)
+      val session =
+        ServeLiveSession(
+          renderHost,
+          previewId,
+          normalizedOverrides,
+          codec,
+          maxFps,
+          send,
+          normalizeOverrides,
+        )
       session.handle =
         renderHost.subscribeStream(
           previewId,

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeStreamSession.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeStreamSession.kt
@@ -22,6 +22,7 @@ class ServeStreamSession(
   previewId: String,
   initialOverrides: Map<String, String> = emptyMap(),
   private val send: (String) -> Unit,
+  private val normalizeOverrides: (Map<String, String>) -> Map<String, String> = { it },
   /**
    * Why this connection is on the snapshot-fallback lane rather than the live daemon stream — the
    * daemon's original failure captured by [ServeLiveSession.tryStart]'s `onUnavailable` (e.g.
@@ -42,16 +43,18 @@ class ServeStreamSession(
   /** Handle one client text message: update overrides / re-render, or echo a protocol error. */
   fun onClientMessage(text: String) {
     when (val message = ServeStreamProtocol.parseClient(text)) {
-      is ServeStreamProtocol.ClientMessage.SetOverrides ->
+      is ServeStreamProtocol.ClientMessage.SetOverrides -> {
         // Validate before committing: a bad override message is reported but must not poison the
         // session — the previous (valid) overrides stay in effect for subsequent frames.
-        when (val parsed = ServeOverrides.parse(message.overrides, knobKindsFor(previewId))) {
+        val normalized = normalizeOverrides(message.overrides)
+        when (val parsed = ServeOverrides.parse(normalized, knobKindsFor(previewId))) {
           is OverrideParse.Invalid -> send(ServeStreamProtocol.errorMessage(parsed.message))
           is OverrideParse.Ok -> {
-            overrides = message.overrides
+            overrides = normalized
             sendFrame(parsed.overrides)
           }
         }
+      }
       ServeStreamProtocol.ClientMessage.RequestFrame -> renderCurrent()
       is ServeStreamProtocol.ClientMessage.Switch -> switchTo(message)
       is ServeStreamProtocol.ClientMessage.Input ->
@@ -76,7 +79,7 @@ class ServeStreamSession(
     // Validate before committing either field: a bad override must leave the current preview +
     // overrides intact (so later requestFrame keeps working), mirroring setOverrides / the live
     // lane.
-    val nextOverrides = message.overrides ?: overrides
+    val nextOverrides = message.overrides?.let(normalizeOverrides) ?: overrides
     val parsed =
       when (val p = ServeOverrides.parse(nextOverrides, knobKindsFor(message.previewId))) {
         is OverrideParse.Invalid -> {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -679,6 +679,12 @@ object ServeWeb {
   private fun bgTheme(id: String, darkFirst: Boolean): String? =
     cardTheme(id) ?: if (darkFirst) "dark" else null
 
+  /** Stable, catalog-specific persistence key shared by that catalog's landing and viewer pages. */
+  private fun themeStorageKey(sessionId: String?, basePath: String): String {
+    val catalog = basePath.trim('/').ifBlank { sessionId ?: "default" }
+    return "cp-theme:${WebEscaping.urlEncodeSegment(catalog)}"
+  }
+
   /**
    * The flattened id with its theme token stripped — the key that pairs a component's light and
    * dark variants into ONE grid card. `button-filled__ideal__default__light` and `…__dark` both key
@@ -1065,11 +1071,11 @@ object ServeWeb {
   }
 
   /**
-   * The sticky light/dark control for the catalog header. Persists to `localStorage['cp-theme']`
-   * (shared with the viewer's Theme select). [catalogFilterScript] wires it to *swap* each
-   * swappable card between its baked light/dark render in place — a no-JS client still sees the
-   * full catalog on its default renders. Shown only when the grid has at least one light/dark pair
-   * to swap.
+   * The sticky light/dark control for the catalog header. Persists to a catalog-scoped localStorage
+   * key (shared only with that catalog's viewer Theme select). [catalogFilterScript] wires it to
+   * *swap* each swappable card between its baked light/dark render in place — a no-JS client still
+   * sees the full catalog on its default renders. Shown only when the grid has at least one
+   * light/dark pair to swap.
    */
   private fun themeToggleHtml(): String =
     """
@@ -1108,9 +1114,10 @@ object ServeWeb {
    * the catalog carries light/dark pairs, the sticky Light/Dark **toggle** — which *swaps* each
    * swappable card between its baked light and dark render in place (image, viewer link, id, label,
    * and stage backing), rather than hiding cards. Single-theme / theme-neutral cards carry no swap
-   * data and are left untouched. Theme state persists to the shared `localStorage['cp-theme']` key
-   * (round-tripped with the viewer's Theme select); the search text is ephemeral. Fully client-side
-   * progressive enhancement — a no-JS client sees the full grid on its baked (default) renders.
+   * data and are left untouched. Theme state persists to a catalog-scoped localStorage key
+   * (round-tripped with that catalog's viewer Theme select); the search text is ephemeral. Fully
+   * client-side progressive enhancement — a no-JS client sees the full grid on its baked (default)
+   * renders.
    *
    * When [hasTabs] (a sectioned catalog), the same script also drives the section **tabs**:
    * clicking a tab shows only that section's panel (others' cards hidden) while a search spans
@@ -1122,12 +1129,13 @@ object ServeWeb {
     hasThemes: Boolean,
     hasTabs: Boolean,
     hasGroups: Boolean,
+    themeStorageKey: String,
   ): String {
     val themeInit =
       if (hasThemes)
         """
         var stored = null;
-        try { stored = localStorage.getItem("cp-theme"); } catch (e) {}
+        try { stored = localStorage.getItem("$themeStorageKey"); } catch (e) {}
         var theme = (stored === "light" || stored === "dark") ? stored
           : (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light");
         var themeBtns = document.querySelectorAll(".cp-theme-btn");
@@ -1166,7 +1174,7 @@ object ServeWeb {
         """themeBtns.forEach(function (b) {
         b.addEventListener("click", function () {
           theme = b.getAttribute("data-theme-choice");
-          try { localStorage.setItem("cp-theme", theme); } catch (e) {}
+          try { localStorage.setItem("$themeStorageKey", theme); } catch (e) {}
           apply();
         });
       });"""
@@ -1267,11 +1275,11 @@ object ServeWeb {
   }
 
   /**
-   * Viewer theme-sticky script: when the Theme select is set to light/dark, write it to the shared
-   * `localStorage['cp-theme']` so the catalog remembers the last theme the visitor viewed a
-   * component in (the other half of the catalog toggle's stickiness).
+   * Viewer theme-sticky script: when the Theme select is set to light/dark, write it to this
+   * catalog's localStorage key so only this catalog remembers the last theme the visitor viewed a
+   * component in (the other half of its landing-page toggle's stickiness).
    */
-  private fun viewerThemeStickyScript(): String =
+  private fun viewerThemeStickyScript(themeStorageKey: String): String =
     """
     (function () {
       var el = document.getElementById("cp-uiMode");
@@ -1285,7 +1293,7 @@ object ServeWeb {
       var pid = (root && root.getAttribute("data-preview-id")) || "";
       var themed = pid.split("__").some(function (s) { return s === "light" || s === "dark"; });
       try {
-        var stored = localStorage.getItem("cp-theme");
+        var stored = localStorage.getItem("$themeStorageKey");
         if (!themed && !el.value && (stored === "light" || stored === "dark")) el.value = stored;
       } catch (e) {}
       // Keep the stage backing colour in step with the CHOSEN theme, so a re-render in the opposite
@@ -1305,11 +1313,11 @@ object ServeWeb {
         if (m) root.setAttribute("data-bg-theme", m);
         else root.removeAttribute("data-bg-theme");
       }
-      // Round-trip: a Theme change writes the shared key so the catalog remembers it, and re-syncs
+      // Round-trip: a Theme change writes this catalog's key so it remembers it, and re-syncs
       // the stage backing colour.
       el.addEventListener("change", function () {
         if (el.value === "light" || el.value === "dark") {
-          try { localStorage.setItem("cp-theme", el.value); } catch (e) {}
+          try { localStorage.setItem("$themeStorageKey", el.value); } catch (e) {}
         }
         syncBg();
       });
@@ -1833,6 +1841,12 @@ object ServeWeb {
     }
 
     /** Wear/watch renders have no day mode; discard a generic UI's accidental light override. */
+    fun normalizeOverrideParams(
+      system: String,
+      overrides: Map<String, String>,
+    ): Map<String, String> = if (isDarkFirst(system)) overrides - "uiMode" else overrides
+
+    /** Apply the same always-dark policy after raw override parameters have been parsed. */
     fun normalizeOverrides(system: String, overrides: PreviewOverrides): PreviewOverrides =
       if (isDarkFirst(system)) overrides.copy(uiMode = null) else overrides
 
@@ -2134,7 +2148,8 @@ object ServeWeb {
         "\n<p id=\"cp-empty\" class=\"cp-empty\" hidden>No previews match your filter.</p>"
       else ""
     val filterScript =
-      if (hasPreviews) "\n<script>${catalogFilterScript(hasThemes, hasTabs, hasGroups)}</script>"
+      if (hasPreviews)
+        "\n<script>${catalogFilterScript(hasThemes, hasTabs, hasGroups, themeStorageKey(sessionId, basePath))}</script>"
       else ""
     return document(
       title = "$moduleLabel — compose-preview",
@@ -2275,9 +2290,10 @@ object ServeWeb {
     val idText = WebEscaping.htmlEscape(preview.id)
     val modes = preview.modes.joinToString(",") { it.wire }
     // Wear OS is an always-dark surface. Do not expose the generic day/night override: besides
-    // being meaningless for Wear, the shared sticky theme could otherwise replay a phone
-    // catalog's remembered "light" choice into a confetti-wear live render.
+    // being meaningless for Wear, an old light choice within the Wear catalog must not turn into a
+    // confetti-wear live render.
     val wearAlwaysDark = SystemDisplay.isDarkFirst(basePath.trim('/').ifBlank { sessionId ?: "" })
+    val alwaysDarkAttr = if (wearAlwaysDark) " data-always-dark=\"1\"" else ""
     // The Wasm tier is opt-in via a toggle (like "Live (stream)"), so the always-works PNG snapshot
     // stays the default. Both the iframe and the toggle are omitted entirely when no Wasm app backs
     // this session.
@@ -2564,7 +2580,7 @@ object ServeWeb {
         $navToggle
         <button type="button" class="cp-drawer-toggle" id="cp-controls-toggle" aria-expanded="true" aria-controls="cp-controls">⚙ Overrides</button>
       </div>
-      <div class="cp-viewer cp-controls-open"$bgThemeAttr data-preview-id="$idText" data-mode="snapshot" data-modes="$modes" data-static-snapshot="$staticSnapshot" data-can-render-overrides="$canRenderOverrides" data-snapshot-backend="$backendLabel" data-live-backend="$liveLabel" data-render-density="$RENDER_DENSITY"$wasmAttr$rcAttr>
+      <div class="cp-viewer cp-controls-open"$bgThemeAttr$alwaysDarkAttr data-preview-id="$idText" data-mode="snapshot" data-modes="$modes" data-static-snapshot="$staticSnapshot" data-can-render-overrides="$canRenderOverrides" data-snapshot-backend="$backendLabel" data-live-backend="$liveLabel" data-render-density="$RENDER_DENSITY"$wasmAttr$rcAttr>
         $navDrawer
         <div class="cp-stage"><span class="cp-backend" id="cp-backend"></span><img id="cp-img" alt="$label"><canvas id="cp-canvas" hidden></canvas>$rcCanvas$wasmFrame<div class="cp-error" id="cp-error" role="alert" hidden></div></div>
         <div class="cp-controls" id="cp-controls">
@@ -2696,7 +2712,7 @@ object ServeWeb {
       <div class="cp-scrim" id="cp-scrim" aria-hidden="true"></div>
       <script>${groupStickyScript()}</script>
       <script>${drawerScript()}</script>
-      <script>${viewerThemeStickyScript()}</script>
+      <script>${viewerThemeStickyScript(themeStorageKey(sessionId, basePath))}</script>
       <script>${viewerScript()}</script>
       <script>${backendBadgeScript()}</script>
       """
@@ -3713,6 +3729,7 @@ object ServeWeb {
         ["device", "orientation", "background", "sizeMode",
          "fixedW", "fixedH", "minW", "minH", "maxW", "maxH"];
       var wasmHonouredControlIds = ["uiMode", "localeTag", "fontScale"];
+      var alwaysDark = root.getAttribute("data-always-dark") === "1";
       function syncServerControls() {
         // The in-browser Wasm lane only honours the wasm-honoured trio (uiMode/locale/fontScale) +
         // knobs (see wasmOverridePatch); size/device/orientation/background and the app-theme
@@ -3735,7 +3752,8 @@ object ServeWeb {
         // canvas lane, which doesn't map them onto the document.
         wasmHonouredControlIds.forEach(function (id) {
           var el = document.getElementById("cp-" + id);
-          if (el) el.disabled = !(canServerRender || (wasmSrc && !onRc));
+          if (el) el.disabled = (id === "uiMode" && alwaysDark) ||
+            !(canServerRender || (wasmSrc && !onRc));
         });
         // The app-theme (themeProvider) selector is a daemon-only override the Wasm app doesn't
         // honour: dead in the in-browser lane. Disable it there; otherwise mirror its server-side

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeLiveSessionTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeLiveSessionTest.kt
@@ -232,6 +232,32 @@ class ServeLiveSessionTest {
   }
 
   @Test
+  fun `override normalizer applies to live setOverrides and switch messages`() {
+    val session = FakeRenderSession(newRenderRoot(), streaming = true)
+    host(session).use { h ->
+      val sent = CopyOnWriteArrayList<String>()
+      val live =
+        assertNotNull(
+          ServeLiveSession.tryStart(
+            h,
+            previewId,
+            emptyMap(),
+            send = sent::add,
+            normalizeOverrides = { it - "uiMode" },
+          )
+        )
+
+      live.onClientMessage("""{"type":"setOverrides","overrides":{"uiMode":"chartreuse"}}""")
+      live.onClientMessage(
+        """{"type":"switch","previewId":"$previewId","overrides":{"uiMode":"chartreuse"}}"""
+      )
+
+      assertEquals(2, session.streamStarts.get())
+      assertTrue(sent.none { typeOf(it) == "error" })
+    }
+  }
+
+  @Test
   fun `two live sessions for the same preview share one daemon stream`() {
     val session = FakeRenderSession(newRenderRoot(), streaming = true)
     host(session).use { h ->

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeStreamSessionTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeStreamSessionTest.kt
@@ -63,6 +63,27 @@ class ServeStreamSessionTest {
   }
 
   @Test
+  fun `override normalizer applies to setOverrides and switch messages`() {
+    host().use { h ->
+      val sent = CopyOnWriteArrayList<String>()
+      val session =
+        ServeStreamSession(
+          h,
+          previewId,
+          emptyMap(),
+          sent::add,
+          normalizeOverrides = { it - "uiMode" },
+        )
+      session.onClientMessage("""{"type":"setOverrides","overrides":{"uiMode":"chartreuse"}}""")
+      session.onClientMessage(
+        """{"type":"switch","previewId":"$previewId","overrides":{"uiMode":"light"}}"""
+      )
+
+      assertEquals(listOf("frame", "frame"), sent.map(::typeOf))
+    }
+  }
+
+  @Test
   fun `seq is monotonic across frames`() {
     host().use { h ->
       val sent = CopyOnWriteArrayList<String>()

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -610,6 +610,7 @@ class ServeWebFixtureTest {
         "compose-m3",
         themedPreviews,
         token,
+        sessionId = "compose-m3",
         trust = "branch:yschimke/compose-ai-tools@design-artifacts/compose-m3",
         isPublic = true,
         hasHomeIndex = true,
@@ -1289,6 +1290,27 @@ class ServeWebFixtureTest {
       "fallback: a non-Wear system stays on the light stage",
     )
     assertNull(
+      ServeWeb.SystemDisplay.normalizeOverrideParams("confetti-wear", mapOf("uiMode" to "light"))[
+          "uiMode"],
+      "Wear ignores the generic light override",
+    )
+    assertEquals(
+      "light",
+      ServeWeb.SystemDisplay.normalizeOverrideParams("compose-m3", mapOf("uiMode" to "light"))[
+          "uiMode"],
+      "non-Wear systems retain day/night overrides",
+    )
+    assertTrue(
+      landingThemed.contains("localStorage.getItem(\"cp-theme:compose-m3\")") &&
+        landingThemed.contains("localStorage.setItem(\"cp-theme:compose-m3\", theme)"),
+      "the catalog landing persists theme under its own catalog key",
+    )
+    assertTrue(
+      viewerGestures.contains("localStorage.getItem(\"cp-theme:wear-m3\")") &&
+        !viewerGestures.contains("cp-theme:compose-m3"),
+      "a viewer reads only its own catalog's sticky theme",
+    )
+    assertNull(
       ServeWeb.SystemDisplay.normalizeOverrides(
           "confetti-wear",
           PreviewOverrides(uiMode = UiMode.LIGHT),
@@ -1324,10 +1346,6 @@ class ServeWebFixtureTest {
     assertFalse(
       landingThemed.contains(">button-filled__ideal__default__dark</div>"),
       "the dark variant is folded into the swap card, not a separate card",
-    )
-    assertTrue(
-      landingThemed.contains("localStorage.setItem(\"cp-theme\""),
-      "toggle persists the choice to the shared cp-theme key",
     )
     // The swap re-points the image + viewer link + id + label to the chosen theme's baked render.
     assertTrue(
@@ -1375,19 +1393,19 @@ class ServeWebFixtureTest {
     // The combined filter composes search with theme: on a themed catalog the script still persists
     // the theme choice, so search didn't displace the theme half.
     assertTrue(
-      landingThemed.contains("localStorage.setItem(\"cp-theme\"") &&
+      landingThemed.contains("localStorage.setItem(\"cp-theme:compose-m3\"") &&
         landingThemed.contains("getElementById(\"cp-search\")"),
       "the themed landing's filter script drives both the theme toggle and the search box",
     )
-    // The viewer both seeds its Theme select from the shared cp-theme on load (so a theme-less
-    // preview inherits the catalog choice) and writes it back on change — the sticky round-trip.
+    // The viewer both seeds its Theme select from the catalog-scoped theme key on load (so a
+    // theme-less preview inherits the catalog choice) and writes it back on change.
     assertTrue(
-      viewer.contains("localStorage.getItem(\"cp-theme\""),
-      "viewer seeds its Theme select from the shared cp-theme on load",
+      viewer.contains("localStorage.getItem(\"cp-theme:default\""),
+      "viewer seeds its Theme select from the catalog-scoped theme key on load",
     )
     assertTrue(
-      viewer.contains("localStorage.setItem(\"cp-theme\""),
-      "viewer Theme change writes the shared cp-theme key",
+      viewer.contains("localStorage.setItem(\"cp-theme:default\""),
+      "viewer Theme change writes the catalog-scoped theme key",
     )
 
     // The backend-provenance badge names the active tier. The Wasm tier is always CMP-WASM; the

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-grouped.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-grouped.html
@@ -567,7 +567,7 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
       var total = cards.length;
       var navGroups = document.querySelectorAll(".cp-subgroup");
       var stored = null;
-try { stored = localStorage.getItem("cp-theme"); } catch (e) {}
+try { stored = localStorage.getItem("cp-theme:default"); } catch (e) {}
 var theme = (stored === "light" || stored === "dark") ? stored
   : (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light");
 var themeBtns = document.querySelectorAll(".cp-theme-btn");
@@ -608,7 +608,7 @@ cards.forEach(function (c) {
       themeBtns.forEach(function (b) {
         b.addEventListener("click", function () {
           theme = b.getAttribute("data-theme-choice");
-          try { localStorage.setItem("cp-theme", theme); } catch (e) {}
+          try { localStorage.setItem("cp-theme:default", theme); } catch (e) {}
           apply();
         });
       });

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-states.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-states.html
@@ -476,7 +476,7 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
       var empty = document.getElementById("cp-empty");
       var total = cards.length;
       var stored = null;
-try { stored = localStorage.getItem("cp-theme"); } catch (e) {}
+try { stored = localStorage.getItem("cp-theme:default"); } catch (e) {}
 var theme = (stored === "light" || stored === "dark") ? stored
   : (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light");
 var themeBtns = document.querySelectorAll(".cp-theme-btn");
@@ -516,7 +516,7 @@ cards.forEach(function (c) {
       themeBtns.forEach(function (b) {
         b.addEventListener("click", function () {
           theme = b.getAttribute("data-theme-choice");
-          try { localStorage.setItem("cp-theme", theme); } catch (e) {}
+          try { localStorage.setItem("cp-theme:default", theme); } catch (e) {}
           apply();
         });
       });

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-themed.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-themed.html
@@ -428,7 +428,7 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
   </span>
 </div>
 <p class="cp-sub">5 preview(s) · click one to view with overrides ·
-          <a href="/bundle.zip">download all (.zip)</a></p>
+          <a href="/bundle.zip?session=compose-m3">download all (.zip)</a></p>
         <div class="cp-searchbar">
   <input id="cp-search" class="cp-search" type="search" placeholder="Filter previews…"
     autocomplete="off" spellcheck="false" aria-label="Filter previews" aria-controls="cp-grid">
@@ -440,13 +440,13 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
 </div>
 <div class="cp-grid" id="cp-grid">
         <a class="cp-card" data-swap="1" data-bg-theme="light"
-  data-l-src="/render/button-filled__ideal__default__light.png" data-l-href="/p/button-filled__ideal__default__light"
+  data-l-src="/render/button-filled__ideal__default__light.png?session=compose-m3" data-l-href="/p/button-filled__ideal__default__light?session=compose-m3"
   data-l-id="button-filled__ideal__default__light" data-l-label="Button · Filled (light)"
-  data-d-src="/render/button-filled__ideal__default__dark.png" data-d-href="/p/button-filled__ideal__default__dark"
+  data-d-src="/render/button-filled__ideal__default__dark.png?session=compose-m3" data-d-href="/p/button-filled__ideal__default__dark?session=compose-m3"
   data-d-id="button-filled__ideal__default__dark" data-d-label="Button · Filled (dark)"
-  href="/p/button-filled__ideal__default__light">
+  href="/p/button-filled__ideal__default__light?session=compose-m3">
   <div class="cp-imgwrap">
-    <img loading="lazy" alt="Button · Filled (light)" src="/render/button-filled__ideal__default__light.png">
+    <img loading="lazy" alt="Button · Filled (light)" src="/render/button-filled__ideal__default__light.png?session=compose-m3">
   </div>
   <div class="cp-meta">
     <div class="cp-label" title="Button · Filled (light)">Button · Filled (light)</div>
@@ -454,22 +454,22 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
   </div>
 </a>
 <a class="cp-card" data-swap="1" data-bg-theme="light"
-  data-l-src="/render/switch-on__ideal__default__light.png" data-l-href="/p/switch-on__ideal__default__light"
+  data-l-src="/render/switch-on__ideal__default__light.png?session=compose-m3" data-l-href="/p/switch-on__ideal__default__light?session=compose-m3"
   data-l-id="switch-on__ideal__default__light" data-l-label="Switch · On (light)"
-  data-d-src="/render/switch-on__ideal__default__dark.png" data-d-href="/p/switch-on__ideal__default__dark"
+  data-d-src="/render/switch-on__ideal__default__dark.png?session=compose-m3" data-d-href="/p/switch-on__ideal__default__dark?session=compose-m3"
   data-d-id="switch-on__ideal__default__dark" data-d-label="Switch · On (dark)"
-  href="/p/switch-on__ideal__default__light">
+  href="/p/switch-on__ideal__default__light?session=compose-m3">
   <div class="cp-imgwrap">
-    <img loading="lazy" alt="Switch · On (light)" src="/render/switch-on__ideal__default__light.png">
+    <img loading="lazy" alt="Switch · On (light)" src="/render/switch-on__ideal__default__light.png?session=compose-m3">
   </div>
   <div class="cp-meta">
     <div class="cp-label" title="Switch · On (light)">Switch · On (light)</div>
     <div class="cp-id">switch-on__ideal__default__light</div>
   </div>
 </a>
-<a class="cp-card" href="/p/badge">
+<a class="cp-card" href="/p/badge?session=compose-m3">
   <div class="cp-imgwrap">
-    <img loading="lazy" alt="Badge" src="/render/badge.png">
+    <img loading="lazy" alt="Badge" src="/render/badge.png?session=compose-m3">
   </div>
   <div class="cp-meta">
     <div class="cp-label" title="badge">Badge</div>
@@ -485,7 +485,7 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
       var empty = document.getElementById("cp-empty");
       var total = cards.length;
       var stored = null;
-try { stored = localStorage.getItem("cp-theme"); } catch (e) {}
+try { stored = localStorage.getItem("cp-theme:compose-m3"); } catch (e) {}
 var theme = (stored === "light" || stored === "dark") ? stored
   : (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light");
 var themeBtns = document.querySelectorAll(".cp-theme-btn");
@@ -525,7 +525,7 @@ cards.forEach(function (c) {
       themeBtns.forEach(function (b) {
         b.addEventListener("click", function () {
           theme = b.getAttribute("data-theme-choice");
-          try { localStorage.setItem("cp-theme", theme); } catch (e) {}
+          try { localStorage.setItem("cp-theme:compose-m3", theme); } catch (e) {}
           apply();
         });
       });

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-variants.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-variants.html
@@ -462,7 +462,7 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
       var empty = document.getElementById("cp-empty");
       var total = cards.length;
       var stored = null;
-try { stored = localStorage.getItem("cp-theme"); } catch (e) {}
+try { stored = localStorage.getItem("cp-theme:default"); } catch (e) {}
 var theme = (stored === "light" || stored === "dark") ? stored
   : (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light");
 var themeBtns = document.querySelectorAll(".cp-theme-btn");
@@ -502,7 +502,7 @@ cards.forEach(function (c) {
       themeBtns.forEach(function (b) {
         b.addEventListener("click", function () {
           theme = b.getAttribute("data-theme-choice");
-          try { localStorage.setItem("cp-theme", theme); } catch (e) {}
+          try { localStorage.setItem("cp-theme:default", theme); } catch (e) {}
           apply();
         });
       });

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
@@ -739,7 +739,7 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
   var pid = (root && root.getAttribute("data-preview-id")) || "";
   var themed = pid.split("__").some(function (s) { return s === "light" || s === "dark"; });
   try {
-    var stored = localStorage.getItem("cp-theme");
+    var stored = localStorage.getItem("cp-theme:compose-m3");
     if (!themed && !el.value && (stored === "light" || stored === "dark")) el.value = stored;
   } catch (e) {}
   // Keep the stage backing colour in step with the CHOSEN theme, so a re-render in the opposite
@@ -759,11 +759,11 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     if (m) root.setAttribute("data-bg-theme", m);
     else root.removeAttribute("data-bg-theme");
   }
-  // Round-trip: a Theme change writes the shared key so the catalog remembers it, and re-syncs
+  // Round-trip: a Theme change writes this catalog's key so it remembers it, and re-syncs
   // the stage backing colour.
   el.addEventListener("change", function () {
     if (el.value === "light" || el.value === "dark") {
-      try { localStorage.setItem("cp-theme", el.value); } catch (e) {}
+      try { localStorage.setItem("cp-theme:compose-m3", el.value); } catch (e) {}
     }
     syncBg();
   });
@@ -1766,6 +1766,7 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     ["device", "orientation", "background", "sizeMode",
      "fixedW", "fixedH", "minW", "minH", "maxW", "maxH"];
   var wasmHonouredControlIds = ["uiMode", "localeTag", "fontScale"];
+  var alwaysDark = root.getAttribute("data-always-dark") === "1";
   function syncServerControls() {
     // The in-browser Wasm lane only honours the wasm-honoured trio (uiMode/locale/fontScale) +
     // knobs (see wasmOverridePatch); size/device/orientation/background and the app-theme
@@ -1788,7 +1789,8 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     // canvas lane, which doesn't map them onto the document.
     wasmHonouredControlIds.forEach(function (id) {
       var el = document.getElementById("cp-" + id);
-      if (el) el.disabled = !(canServerRender || (wasmSrc && !onRc));
+      if (el) el.disabled = (id === "uiMode" && alwaysDark) ||
+        !(canServerRender || (wasmSrc && !onRc));
     });
     // The app-theme (themeProvider) selector is a daemon-only override the Wasm app doesn't
     // honour: dead in the in-browser lane. Disable it there; otherwise mirror its server-side

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-focus.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-focus.html
@@ -698,7 +698,7 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
   var pid = (root && root.getAttribute("data-preview-id")) || "";
   var themed = pid.split("__").some(function (s) { return s === "light" || s === "dark"; });
   try {
-    var stored = localStorage.getItem("cp-theme");
+    var stored = localStorage.getItem("cp-theme:compose-m3");
     if (!themed && !el.value && (stored === "light" || stored === "dark")) el.value = stored;
   } catch (e) {}
   // Keep the stage backing colour in step with the CHOSEN theme, so a re-render in the opposite
@@ -718,11 +718,11 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     if (m) root.setAttribute("data-bg-theme", m);
     else root.removeAttribute("data-bg-theme");
   }
-  // Round-trip: a Theme change writes the shared key so the catalog remembers it, and re-syncs
+  // Round-trip: a Theme change writes this catalog's key so it remembers it, and re-syncs
   // the stage backing colour.
   el.addEventListener("change", function () {
     if (el.value === "light" || el.value === "dark") {
-      try { localStorage.setItem("cp-theme", el.value); } catch (e) {}
+      try { localStorage.setItem("cp-theme:compose-m3", el.value); } catch (e) {}
     }
     syncBg();
   });
@@ -1725,6 +1725,7 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     ["device", "orientation", "background", "sizeMode",
      "fixedW", "fixedH", "minW", "minH", "maxW", "maxH"];
   var wasmHonouredControlIds = ["uiMode", "localeTag", "fontScale"];
+  var alwaysDark = root.getAttribute("data-always-dark") === "1";
   function syncServerControls() {
     // The in-browser Wasm lane only honours the wasm-honoured trio (uiMode/locale/fontScale) +
     // knobs (see wasmOverridePatch); size/device/orientation/background and the app-theme
@@ -1747,7 +1748,8 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     // canvas lane, which doesn't map them onto the document.
     wasmHonouredControlIds.forEach(function (id) {
       var el = document.getElementById("cp-" + id);
-      if (el) el.disabled = !(canServerRender || (wasmSrc && !onRc));
+      if (el) el.disabled = (id === "uiMode" && alwaysDark) ||
+        !(canServerRender || (wasmSrc && !onRc));
     });
     // The app-theme (themeProvider) selector is a daemon-only override the Wasm app doesn't
     // honour: dead in the in-browser lane. Disable it there; otherwise mirror its server-side

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-gestures.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-gestures.html
@@ -426,7 +426,7 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
         
         <button type="button" class="cp-drawer-toggle" id="cp-controls-toggle" aria-expanded="true" aria-controls="cp-controls">⚙ Overrides</button>
       </div>
-      <div class="cp-viewer cp-controls-open" data-bg-theme="dark" data-preview-id="com.example.OneHandedPreview" data-mode="snapshot" data-modes="snapshot" data-static-snapshot="false" data-can-render-overrides="true" data-snapshot-backend="Snapshot" data-live-backend="Live" data-render-density="2">
+      <div class="cp-viewer cp-controls-open" data-bg-theme="dark" data-always-dark="1" data-preview-id="com.example.OneHandedPreview" data-mode="snapshot" data-modes="snapshot" data-static-snapshot="false" data-can-render-overrides="true" data-snapshot-backend="Snapshot" data-live-backend="Live" data-render-density="2">
         
         <div class="cp-stage"><span class="cp-backend" id="cp-backend"></span><img id="cp-img" alt="One-handed"><canvas id="cp-canvas" hidden></canvas><div class="cp-error" id="cp-error" role="alert" hidden></div></div>
         <div class="cp-controls" id="cp-controls">
@@ -696,7 +696,7 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
   var pid = (root && root.getAttribute("data-preview-id")) || "";
   var themed = pid.split("__").some(function (s) { return s === "light" || s === "dark"; });
   try {
-    var stored = localStorage.getItem("cp-theme");
+    var stored = localStorage.getItem("cp-theme:wear-m3");
     if (!themed && !el.value && (stored === "light" || stored === "dark")) el.value = stored;
   } catch (e) {}
   // Keep the stage backing colour in step with the CHOSEN theme, so a re-render in the opposite
@@ -716,11 +716,11 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     if (m) root.setAttribute("data-bg-theme", m);
     else root.removeAttribute("data-bg-theme");
   }
-  // Round-trip: a Theme change writes the shared key so the catalog remembers it, and re-syncs
+  // Round-trip: a Theme change writes this catalog's key so it remembers it, and re-syncs
   // the stage backing colour.
   el.addEventListener("change", function () {
     if (el.value === "light" || el.value === "dark") {
-      try { localStorage.setItem("cp-theme", el.value); } catch (e) {}
+      try { localStorage.setItem("cp-theme:wear-m3", el.value); } catch (e) {}
     }
     syncBg();
   });
@@ -1723,6 +1723,7 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     ["device", "orientation", "background", "sizeMode",
      "fixedW", "fixedH", "minW", "minH", "maxW", "maxH"];
   var wasmHonouredControlIds = ["uiMode", "localeTag", "fontScale"];
+  var alwaysDark = root.getAttribute("data-always-dark") === "1";
   function syncServerControls() {
     // The in-browser Wasm lane only honours the wasm-honoured trio (uiMode/locale/fontScale) +
     // knobs (see wasmOverridePatch); size/device/orientation/background and the app-theme
@@ -1745,7 +1746,8 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     // canvas lane, which doesn't map them onto the document.
     wasmHonouredControlIds.forEach(function (id) {
       var el = document.getElementById("cp-" + id);
-      if (el) el.disabled = !(canServerRender || (wasmSrc && !onRc));
+      if (el) el.disabled = (id === "uiMode" && alwaysDark) ||
+        !(canServerRender || (wasmSrc && !onRc));
     });
     // The app-theme (themeProvider) selector is a daemon-only override the Wasm app doesn't
     // honour: dead in the in-browser lane. Disable it there; otherwise mirror its server-side

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-nav-collapsed.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-nav-collapsed.html
@@ -694,7 +694,7 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
   var pid = (root && root.getAttribute("data-preview-id")) || "";
   var themed = pid.split("__").some(function (s) { return s === "light" || s === "dark"; });
   try {
-    var stored = localStorage.getItem("cp-theme");
+    var stored = localStorage.getItem("cp-theme:compose-m3");
     if (!themed && !el.value && (stored === "light" || stored === "dark")) el.value = stored;
   } catch (e) {}
   // Keep the stage backing colour in step with the CHOSEN theme, so a re-render in the opposite
@@ -714,11 +714,11 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     if (m) root.setAttribute("data-bg-theme", m);
     else root.removeAttribute("data-bg-theme");
   }
-  // Round-trip: a Theme change writes the shared key so the catalog remembers it, and re-syncs
+  // Round-trip: a Theme change writes this catalog's key so it remembers it, and re-syncs
   // the stage backing colour.
   el.addEventListener("change", function () {
     if (el.value === "light" || el.value === "dark") {
-      try { localStorage.setItem("cp-theme", el.value); } catch (e) {}
+      try { localStorage.setItem("cp-theme:compose-m3", el.value); } catch (e) {}
     }
     syncBg();
   });
@@ -1721,6 +1721,7 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     ["device", "orientation", "background", "sizeMode",
      "fixedW", "fixedH", "minW", "minH", "maxW", "maxH"];
   var wasmHonouredControlIds = ["uiMode", "localeTag", "fontScale"];
+  var alwaysDark = root.getAttribute("data-always-dark") === "1";
   function syncServerControls() {
     // The in-browser Wasm lane only honours the wasm-honoured trio (uiMode/locale/fontScale) +
     // knobs (see wasmOverridePatch); size/device/orientation/background and the app-theme
@@ -1743,7 +1744,8 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     // canvas lane, which doesn't map them onto the document.
     wasmHonouredControlIds.forEach(function (id) {
       var el = document.getElementById("cp-" + id);
-      if (el) el.disabled = !(canServerRender || (wasmSrc && !onRc));
+      if (el) el.disabled = (id === "uiMode" && alwaysDark) ||
+        !(canServerRender || (wasmSrc && !onRc));
     });
     // The app-theme (themeProvider) selector is a daemon-only override the Wasm app doesn't
     // honour: dead in the in-browser lane. Disable it there; otherwise mirror its server-side

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
@@ -692,7 +692,7 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
   var pid = (root && root.getAttribute("data-preview-id")) || "";
   var themed = pid.split("__").some(function (s) { return s === "light" || s === "dark"; });
   try {
-    var stored = localStorage.getItem("cp-theme");
+    var stored = localStorage.getItem("cp-theme:meshcore-mobile");
     if (!themed && !el.value && (stored === "light" || stored === "dark")) el.value = stored;
   } catch (e) {}
   // Keep the stage backing colour in step with the CHOSEN theme, so a re-render in the opposite
@@ -712,11 +712,11 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     if (m) root.setAttribute("data-bg-theme", m);
     else root.removeAttribute("data-bg-theme");
   }
-  // Round-trip: a Theme change writes the shared key so the catalog remembers it, and re-syncs
+  // Round-trip: a Theme change writes this catalog's key so it remembers it, and re-syncs
   // the stage backing colour.
   el.addEventListener("change", function () {
     if (el.value === "light" || el.value === "dark") {
-      try { localStorage.setItem("cp-theme", el.value); } catch (e) {}
+      try { localStorage.setItem("cp-theme:meshcore-mobile", el.value); } catch (e) {}
     }
     syncBg();
   });
@@ -1719,6 +1719,7 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     ["device", "orientation", "background", "sizeMode",
      "fixedW", "fixedH", "minW", "minH", "maxW", "maxH"];
   var wasmHonouredControlIds = ["uiMode", "localeTag", "fontScale"];
+  var alwaysDark = root.getAttribute("data-always-dark") === "1";
   function syncServerControls() {
     // The in-browser Wasm lane only honours the wasm-honoured trio (uiMode/locale/fontScale) +
     // knobs (see wasmOverridePatch); size/device/orientation/background and the app-theme
@@ -1741,7 +1742,8 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     // canvas lane, which doesn't map them onto the document.
     wasmHonouredControlIds.forEach(function (id) {
       var el = document.getElementById("cp-" + id);
-      if (el) el.disabled = !(canServerRender || (wasmSrc && !onRc));
+      if (el) el.disabled = (id === "uiMode" && alwaysDark) ||
+        !(canServerRender || (wasmSrc && !onRc));
     });
     // The app-theme (themeProvider) selector is a daemon-only override the Wasm app doesn't
     // honour: dead in the in-browser lane. Disable it there; otherwise mirror its server-side

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-states.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-states.html
@@ -691,7 +691,7 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
   var pid = (root && root.getAttribute("data-preview-id")) || "";
   var themed = pid.split("__").some(function (s) { return s === "light" || s === "dark"; });
   try {
-    var stored = localStorage.getItem("cp-theme");
+    var stored = localStorage.getItem("cp-theme:compose-m3");
     if (!themed && !el.value && (stored === "light" || stored === "dark")) el.value = stored;
   } catch (e) {}
   // Keep the stage backing colour in step with the CHOSEN theme, so a re-render in the opposite
@@ -711,11 +711,11 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     if (m) root.setAttribute("data-bg-theme", m);
     else root.removeAttribute("data-bg-theme");
   }
-  // Round-trip: a Theme change writes the shared key so the catalog remembers it, and re-syncs
+  // Round-trip: a Theme change writes this catalog's key so it remembers it, and re-syncs
   // the stage backing colour.
   el.addEventListener("change", function () {
     if (el.value === "light" || el.value === "dark") {
-      try { localStorage.setItem("cp-theme", el.value); } catch (e) {}
+      try { localStorage.setItem("cp-theme:compose-m3", el.value); } catch (e) {}
     }
     syncBg();
   });
@@ -1718,6 +1718,7 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     ["device", "orientation", "background", "sizeMode",
      "fixedW", "fixedH", "minW", "minH", "maxW", "maxH"];
   var wasmHonouredControlIds = ["uiMode", "localeTag", "fontScale"];
+  var alwaysDark = root.getAttribute("data-always-dark") === "1";
   function syncServerControls() {
     // The in-browser Wasm lane only honours the wasm-honoured trio (uiMode/locale/fontScale) +
     // knobs (see wasmOverridePatch); size/device/orientation/background and the app-theme
@@ -1740,7 +1741,8 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     // canvas lane, which doesn't map them onto the document.
     wasmHonouredControlIds.forEach(function (id) {
       var el = document.getElementById("cp-" + id);
-      if (el) el.disabled = !(canServerRender || (wasmSrc && !onRc));
+      if (el) el.disabled = (id === "uiMode" && alwaysDark) ||
+        !(canServerRender || (wasmSrc && !onRc));
     });
     // The app-theme (themeProvider) selector is a daemon-only override the Wasm app doesn't
     // honour: dead in the in-browser lane. Disable it there; otherwise mirror its server-side

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-themes.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-themes.html
@@ -697,7 +697,7 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
   var pid = (root && root.getAttribute("data-preview-id")) || "";
   var themed = pid.split("__").some(function (s) { return s === "light" || s === "dark"; });
   try {
-    var stored = localStorage.getItem("cp-theme");
+    var stored = localStorage.getItem("cp-theme:compose-m3");
     if (!themed && !el.value && (stored === "light" || stored === "dark")) el.value = stored;
   } catch (e) {}
   // Keep the stage backing colour in step with the CHOSEN theme, so a re-render in the opposite
@@ -717,11 +717,11 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     if (m) root.setAttribute("data-bg-theme", m);
     else root.removeAttribute("data-bg-theme");
   }
-  // Round-trip: a Theme change writes the shared key so the catalog remembers it, and re-syncs
+  // Round-trip: a Theme change writes this catalog's key so it remembers it, and re-syncs
   // the stage backing colour.
   el.addEventListener("change", function () {
     if (el.value === "light" || el.value === "dark") {
-      try { localStorage.setItem("cp-theme", el.value); } catch (e) {}
+      try { localStorage.setItem("cp-theme:compose-m3", el.value); } catch (e) {}
     }
     syncBg();
   });
@@ -1724,6 +1724,7 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     ["device", "orientation", "background", "sizeMode",
      "fixedW", "fixedH", "minW", "minH", "maxW", "maxH"];
   var wasmHonouredControlIds = ["uiMode", "localeTag", "fontScale"];
+  var alwaysDark = root.getAttribute("data-always-dark") === "1";
   function syncServerControls() {
     // The in-browser Wasm lane only honours the wasm-honoured trio (uiMode/locale/fontScale) +
     // knobs (see wasmOverridePatch); size/device/orientation/background and the app-theme
@@ -1746,7 +1747,8 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     // canvas lane, which doesn't map them onto the document.
     wasmHonouredControlIds.forEach(function (id) {
       var el = document.getElementById("cp-" + id);
-      if (el) el.disabled = !(canServerRender || (wasmSrc && !onRc));
+      if (el) el.disabled = (id === "uiMode" && alwaysDark) ||
+        !(canServerRender || (wasmSrc && !onRc));
     });
     // The app-theme (themeProvider) selector is a daemon-only override the Wasm app doesn't
     // honour: dead in the in-browser lane. Disable it there; otherwise mirror its server-side

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-variants.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-variants.html
@@ -685,7 +685,7 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
   var pid = (root && root.getAttribute("data-preview-id")) || "";
   var themed = pid.split("__").some(function (s) { return s === "light" || s === "dark"; });
   try {
-    var stored = localStorage.getItem("cp-theme");
+    var stored = localStorage.getItem("cp-theme:compose-m3");
     if (!themed && !el.value && (stored === "light" || stored === "dark")) el.value = stored;
   } catch (e) {}
   // Keep the stage backing colour in step with the CHOSEN theme, so a re-render in the opposite
@@ -705,11 +705,11 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     if (m) root.setAttribute("data-bg-theme", m);
     else root.removeAttribute("data-bg-theme");
   }
-  // Round-trip: a Theme change writes the shared key so the catalog remembers it, and re-syncs
+  // Round-trip: a Theme change writes this catalog's key so it remembers it, and re-syncs
   // the stage backing colour.
   el.addEventListener("change", function () {
     if (el.value === "light" || el.value === "dark") {
-      try { localStorage.setItem("cp-theme", el.value); } catch (e) {}
+      try { localStorage.setItem("cp-theme:compose-m3", el.value); } catch (e) {}
     }
     syncBg();
   });
@@ -1712,6 +1712,7 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     ["device", "orientation", "background", "sizeMode",
      "fixedW", "fixedH", "minW", "minH", "maxW", "maxH"];
   var wasmHonouredControlIds = ["uiMode", "localeTag", "fontScale"];
+  var alwaysDark = root.getAttribute("data-always-dark") === "1";
   function syncServerControls() {
     // The in-browser Wasm lane only honours the wasm-honoured trio (uiMode/locale/fontScale) +
     // knobs (see wasmOverridePatch); size/device/orientation/background and the app-theme
@@ -1734,7 +1735,8 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     // canvas lane, which doesn't map them onto the document.
     wasmHonouredControlIds.forEach(function (id) {
       var el = document.getElementById("cp-" + id);
-      if (el) el.disabled = !(canServerRender || (wasmSrc && !onRc));
+      if (el) el.disabled = (id === "uiMode" && alwaysDark) ||
+        !(canServerRender || (wasmSrc && !onRc));
     });
     // The app-theme (themeProvider) selector is a daemon-only override the Wasm app doesn't
     // honour: dead in the in-browser lane. Disable it there; otherwise mirror its server-side

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
@@ -689,7 +689,7 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
   var pid = (root && root.getAttribute("data-preview-id")) || "";
   var themed = pid.split("__").some(function (s) { return s === "light" || s === "dark"; });
   try {
-    var stored = localStorage.getItem("cp-theme");
+    var stored = localStorage.getItem("cp-theme:compose-m3");
     if (!themed && !el.value && (stored === "light" || stored === "dark")) el.value = stored;
   } catch (e) {}
   // Keep the stage backing colour in step with the CHOSEN theme, so a re-render in the opposite
@@ -709,11 +709,11 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     if (m) root.setAttribute("data-bg-theme", m);
     else root.removeAttribute("data-bg-theme");
   }
-  // Round-trip: a Theme change writes the shared key so the catalog remembers it, and re-syncs
+  // Round-trip: a Theme change writes this catalog's key so it remembers it, and re-syncs
   // the stage backing colour.
   el.addEventListener("change", function () {
     if (el.value === "light" || el.value === "dark") {
-      try { localStorage.setItem("cp-theme", el.value); } catch (e) {}
+      try { localStorage.setItem("cp-theme:compose-m3", el.value); } catch (e) {}
     }
     syncBg();
   });
@@ -1716,6 +1716,7 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     ["device", "orientation", "background", "sizeMode",
      "fixedW", "fixedH", "minW", "minH", "maxW", "maxH"];
   var wasmHonouredControlIds = ["uiMode", "localeTag", "fontScale"];
+  var alwaysDark = root.getAttribute("data-always-dark") === "1";
   function syncServerControls() {
     // The in-browser Wasm lane only honours the wasm-honoured trio (uiMode/locale/fontScale) +
     // knobs (see wasmOverridePatch); size/device/orientation/background and the app-theme
@@ -1738,7 +1739,8 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     // canvas lane, which doesn't map them onto the document.
     wasmHonouredControlIds.forEach(function (id) {
       var el = document.getElementById("cp-" + id);
-      if (el) el.disabled = !(canServerRender || (wasmSrc && !onRc));
+      if (el) el.disabled = (id === "uiMode" && alwaysDark) ||
+        !(canServerRender || (wasmSrc && !onRc));
     });
     // The app-theme (themeProvider) selector is a daemon-only override the Wasm app doesn't
     // honour: dead in the in-browser lane. Disable it there; otherwise mirror its server-side

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
@@ -680,7 +680,7 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
   var pid = (root && root.getAttribute("data-preview-id")) || "";
   var themed = pid.split("__").some(function (s) { return s === "light" || s === "dark"; });
   try {
-    var stored = localStorage.getItem("cp-theme");
+    var stored = localStorage.getItem("cp-theme:compose-m3");
     if (!themed && !el.value && (stored === "light" || stored === "dark")) el.value = stored;
   } catch (e) {}
   // Keep the stage backing colour in step with the CHOSEN theme, so a re-render in the opposite
@@ -700,11 +700,11 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     if (m) root.setAttribute("data-bg-theme", m);
     else root.removeAttribute("data-bg-theme");
   }
-  // Round-trip: a Theme change writes the shared key so the catalog remembers it, and re-syncs
+  // Round-trip: a Theme change writes this catalog's key so it remembers it, and re-syncs
   // the stage backing colour.
   el.addEventListener("change", function () {
     if (el.value === "light" || el.value === "dark") {
-      try { localStorage.setItem("cp-theme", el.value); } catch (e) {}
+      try { localStorage.setItem("cp-theme:compose-m3", el.value); } catch (e) {}
     }
     syncBg();
   });
@@ -1707,6 +1707,7 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     ["device", "orientation", "background", "sizeMode",
      "fixedW", "fixedH", "minW", "minH", "maxW", "maxH"];
   var wasmHonouredControlIds = ["uiMode", "localeTag", "fontScale"];
+  var alwaysDark = root.getAttribute("data-always-dark") === "1";
   function syncServerControls() {
     // The in-browser Wasm lane only honours the wasm-honoured trio (uiMode/locale/fontScale) +
     // knobs (see wasmOverridePatch); size/device/orientation/background and the app-theme
@@ -1729,7 +1730,8 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     // canvas lane, which doesn't map them onto the document.
     wasmHonouredControlIds.forEach(function (id) {
       var el = document.getElementById("cp-" + id);
-      if (el) el.disabled = !(canServerRender || (wasmSrc && !onRc));
+      if (el) el.disabled = (id === "uiMode" && alwaysDark) ||
+        !(canServerRender || (wasmSrc && !onRc));
     });
     // The app-theme (themeProvider) selector is a daemon-only override the Wasm app doesn't
     // honour: dead in the in-browser lane. Disable it there; otherwise mirror its server-side

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
@@ -692,7 +692,7 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
   var pid = (root && root.getAttribute("data-preview-id")) || "";
   var themed = pid.split("__").some(function (s) { return s === "light" || s === "dark"; });
   try {
-    var stored = localStorage.getItem("cp-theme");
+    var stored = localStorage.getItem("cp-theme:default");
     if (!themed && !el.value && (stored === "light" || stored === "dark")) el.value = stored;
   } catch (e) {}
   // Keep the stage backing colour in step with the CHOSEN theme, so a re-render in the opposite
@@ -712,11 +712,11 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     if (m) root.setAttribute("data-bg-theme", m);
     else root.removeAttribute("data-bg-theme");
   }
-  // Round-trip: a Theme change writes the shared key so the catalog remembers it, and re-syncs
+  // Round-trip: a Theme change writes this catalog's key so it remembers it, and re-syncs
   // the stage backing colour.
   el.addEventListener("change", function () {
     if (el.value === "light" || el.value === "dark") {
-      try { localStorage.setItem("cp-theme", el.value); } catch (e) {}
+      try { localStorage.setItem("cp-theme:default", el.value); } catch (e) {}
     }
     syncBg();
   });
@@ -1719,6 +1719,7 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     ["device", "orientation", "background", "sizeMode",
      "fixedW", "fixedH", "minW", "minH", "maxW", "maxH"];
   var wasmHonouredControlIds = ["uiMode", "localeTag", "fontScale"];
+  var alwaysDark = root.getAttribute("data-always-dark") === "1";
   function syncServerControls() {
     // The in-browser Wasm lane only honours the wasm-honoured trio (uiMode/locale/fontScale) +
     // knobs (see wasmOverridePatch); size/device/orientation/background and the app-theme
@@ -1741,7 +1742,8 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     // canvas lane, which doesn't map them onto the document.
     wasmHonouredControlIds.forEach(function (id) {
       var el = document.getElementById("cp-" + id);
-      if (el) el.disabled = !(canServerRender || (wasmSrc && !onRc));
+      if (el) el.disabled = (id === "uiMode" && alwaysDark) ||
+        !(canServerRender || (wasmSrc && !onRc));
     });
     // The app-theme (themeProvider) selector is a daemon-only override the Wasm app doesn't
     // honour: dead in the in-browser lane. Disable it there; otherwise mirror its server-side


### PR DESCRIPTION
### Motivation

- Bring PR #2796 up-to-date with `origin/main` and preserve the Wear/watch always‑dark policy across all rendering lanes.
- Prevent the shared catalog sticky theme from leaking into Wear renders and make theme persistence catalog‑scoped.

### Description

- Merged `origin/main` into the PR and resolved conflicts across the web serve stack, preserving both the new generation/caching headers and the Wear normalization changes in `ServeHttpServer.kt` and `ServeWeb.kt`.
- Applied an always‑dark normalization in two places: raw query-parameter level (`SystemDisplay.normalizeOverrideParams`) and parsed `PreviewOverrides` level (`SystemDisplay.normalizeOverrides`), and threaded a `normalizeOverrides` function through live and stream session flows (`ServeLiveSession`, `ServeStreamSession`) so `setOverrides`/`switch` messages are normalized before parsing/dispatch.
- Implemented catalog‑scoped theme storage keys (`themeStorageKey`) and updated landing/viewer JS fixtures and emitted HTML to read/write `localStorage` per catalog (e.g. `cp-theme:compose-m3`, `cp-theme:wear-m3`, `cp-theme:default`).
- Added response generation header and cache-control handling for static/dynamic resources (`markGeneration`, cache constants) in `ServeHttpServer.kt`, and updated numerous fixtures/tests to reflect the new behavior.

### Testing

- Ran formatting and checks with `./gradlew :cli:ktfmtCheck` and code-style checks where applicable, which passed.
- Ran targeted test suite with `./gradlew :cli:test --tests 'ee.schimke.composeai.cli.serve.ServeWebFixtureTest' --tests 'ee.schimke.composeai.cli.serve.ServeLiveSessionTest' --tests 'ee.schimke.composeai.cli.serve.ServeStreamSessionTest'` and resolved fixture assertions; the tests completed successfully (final build reported `BUILD SUCCESSFUL`).
- Verified `git diff --check` reported no whitespace/conflict markers and committed the merge resolution.
- Verified the local working tree and commit (`Merge origin/main into PR #2796`) are clean via `git status` and commit log.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a666c548a0483248e20bf134a6ebbb7)