### PR TITLE
fix(deploy): migrate legacy compose-samples catalog override

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -577,6 +577,11 @@ jobs:
         run: python3 .github/ci/test_change_scope.py -v
       - name: Run daemon round-trip transport tests
         run: python3 .github/ci/test_daemon_roundtrip.py -v
+      # The deploy image's .env migrations edit an operator's live config on an
+      # already-deployed box, so the "leaves a custom catalog list alone" cases
+      # are worth a gate rather than a manual check.
+      - name: Run deploy .env migration tests
+        run: ./deploy/image/test-env-migrations.sh
 
   # VS Code extension tests — both the existing in-process Mocha suite and
   # the @vscode/test-electron integration tests. The latter download a

--- a/deploy/image/README.md
+++ b/deploy/image/README.md
@@ -238,6 +238,7 @@ docker run -d --restart always -p 8080:8080 \
 | `deploy-hook.sh` | Token-gated `POST /__hooks/rollout` webhook (the `hook` service) that runs `rollout.sh` on demand — instant roll on publish. |
 | `docker-rollout` | Vendored [docker-rollout](https://github.com/wowu/docker-rollout) CLI plugin (adds `docker rollout`). |
 | `setup.sh` | Install Docker + the docker-rollout plugin, write `.env`, pull + start. |
+| `env-migrations.sh` + `test-env-migrations.sh` | One-off `.env` rewrites `setup.sh` applies to an already-deployed box (currently: drop the legacy three-app `SERVE_CATALOGS` pin so the baked catalog default applies), and their tests. |
 
 ## Serving a different project
 

--- a/deploy/image/docker-compose.yml
+++ b/deploy/image/docker-compose.yml
@@ -35,9 +35,11 @@ services:
       # SERVE_PUBLIC=0 and SERVE_TOKEN in .env.
       SERVE_PUBLIC: "${SERVE_PUBLIC:-1}"
       # The catalog set is BAKED INTO THE IMAGE (entrypoint): the front-page systems
-      # (compose-m3,wear-m3,remote-m3) and the app systems served unlisted from their own repos
-      # (meshcore-mobile, homeassistant-remotecompose, cadence). Leave these empty to inherit the
-      # baked defaults — so a bare image pull self-heals without editing this compose.
+      # (compose-m3, wear-m3, remote-m3) and the app systems fetched from their own repos
+      # (MeshCore Mobile, Home Assistant Remote Compose, the six compose-samples apps, and the two
+      # Confetti apps); Cadence is served unlisted. Leave these empty to inherit the baked defaults
+      # — so a bare image pull self-heals without editing this compose. setup.sh removes the exact
+      # legacy three-compose-samples override, which would otherwise shadow that complete default.
       # Set your own comma list to override, or the literal `none` to serve none of that
       # kind. (Empty is NOT `none` — it falls back to the baked default.)
       SERVE_CATALOGS: "${SERVE_CATALOGS:-}"

--- a/deploy/image/env-migrations.sh
+++ b/deploy/image/env-migrations.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# One-off `.env` migrations for an already-deployed box, sourced by setup.sh.
+# Kept in its own file (rather than inline in setup.sh) so the rewrite rules can
+# be exercised by test-env-migrations.sh without running the real installer —
+# these edit an operator's live config, so "only touches what it claims to" has
+# to be a test, not a comment.
+
+# The public server briefly pinned only the first three compose-samples apps in
+# SERVE_CATALOGS. An explicit value shadows the catalog set baked into the image
+# (the entrypoint only falls back when SERVE_CATALOGS is unset or empty), so an
+# image rollout alone can never add Jetcaster, Jetsnack, and Reply to such a box.
+LEGACY_COMPOSE_SAMPLES_CATALOGS='jetnews@yschimke/compose-samples,jetchat@yschimke/compose-samples,jetlagged@yschimke/compose-samples'
+
+# True when the line is a SERVE_CATALOGS assignment whose value is exactly the
+# legacy list. Tolerates the shapes a hand-edited .env actually shows up in —
+# `export `, surrounding quotes, leading/trailing whitespace, CRLF — while still
+# comparing the *value*, so an operator's own list is never matched.
+_env_line_is_legacy_catalogs() {
+  local line="${1%$'\r'}" value
+  line="${line#"${line%%[![:space:]]*}"}"
+  line="${line#export }"
+  line="${line#"${line%%[![:space:]]*}"}"
+  [[ "${line}" == SERVE_CATALOGS=* ]] || return 1
+  value="${line#SERVE_CATALOGS=}"
+  value="${value%"${value##*[![:space:]]}"}"
+  if [[ ${#value} -ge 2 && ( "${value}" == \"*\" || "${value}" == \'*\' ) ]]; then
+    value="${value:1:${#value}-2}"
+  fi
+  [[ "${value}" == "${LEGACY_COMPOSE_SAMPLES_CATALOGS}" ]]
+}
+
+# Drop only the legacy three-app SERVE_CATALOGS assignment from $1, so the next
+# `compose up` inherits the complete image default. Any other SERVE_CATALOGS
+# value — an operator's own list, or a later override in the same file — is left
+# alone. Returns 0 when something was removed (so callers can log), 1 otherwise.
+migrate_legacy_serve_catalogs() {
+  local env_file="${1:?env file required}"
+  [[ -f "${env_file}" ]] || return 1
+
+  local line removed=0 out=""
+  while IFS= read -r line || [[ -n "${line}" ]]; do
+    if _env_line_is_legacy_catalogs "${line}"; then
+      removed=1
+      continue
+    fi
+    out+="${line}"$'\n'
+  done < "${env_file}"
+
+  (( removed )) || return 1
+  # Truncate-in-place rather than sed -i: keeps the file's 0600 mode, owner and
+  # inode, which a temp-file rename would quietly reset on a live box.
+  printf '%s' "${out}" > "${env_file}"
+}

--- a/deploy/image/setup.sh
+++ b/deploy/image/setup.sh
@@ -44,14 +44,12 @@ else
     printf 'DEPLOY_HOOK_TOKEN=%s\n' "$(openssl rand -hex 24)" >> .env
     echo "==> Added a generated DEPLOY_HOOK_TOKEN to .env (instant-roll webhook)"
   fi
-  # The public server briefly pinned only the first three compose-samples apps in
-  # SERVE_CATALOGS. That explicit value shadows the catalog set baked into newer
-  # images, so image rollouts alone cannot add Jetcaster, Jetsnack, and Reply.
-  # Remove only that known legacy override; operator-defined catalog lists remain
-  # untouched, while the next compose up inherits the complete image default.
-  LEGACY_COMPOSE_SAMPLES_CATALOGS='jetnews@yschimke/compose-samples,jetchat@yschimke/compose-samples,jetlagged@yschimke/compose-samples'
-  if grep -Fxq "SERVE_CATALOGS=${LEGACY_COMPOSE_SAMPLES_CATALOGS}" .env; then
-    sed -i "\\|^SERVE_CATALOGS=${LEGACY_COMPOSE_SAMPLES_CATALOGS}$|d" .env
+  # Drop the known legacy three-compose-samples SERVE_CATALOGS pin so the box
+  # inherits the fuller catalog set baked into newer images (see
+  # env-migrations.sh). Operator-defined catalog lists are left untouched.
+  # shellcheck source=deploy/image/env-migrations.sh
+  source ./env-migrations.sh
+  if migrate_legacy_serve_catalogs .env; then
     echo "==> Removed the legacy three-app SERVE_CATALOGS override (using the image default)"
   fi
   echo "==> Reusing existing .env (tokens preserved)"

--- a/deploy/image/setup.sh
+++ b/deploy/image/setup.sh
@@ -51,7 +51,7 @@ else
   # untouched, while the next compose up inherits the complete image default.
   LEGACY_COMPOSE_SAMPLES_CATALOGS='jetnews@yschimke/compose-samples,jetchat@yschimke/compose-samples,jetlagged@yschimke/compose-samples'
   if grep -Fxq "SERVE_CATALOGS=${LEGACY_COMPOSE_SAMPLES_CATALOGS}" .env; then
-    sed -i '/^SERVE_CATALOGS=/d' .env
+    sed -i "\\|^SERVE_CATALOGS=${LEGACY_COMPOSE_SAMPLES_CATALOGS}$|d" .env
     echo "==> Removed the legacy three-app SERVE_CATALOGS override (using the image default)"
   fi
   echo "==> Reusing existing .env (tokens preserved)"

--- a/deploy/image/setup.sh
+++ b/deploy/image/setup.sh
@@ -44,6 +44,16 @@ else
     printf 'DEPLOY_HOOK_TOKEN=%s\n' "$(openssl rand -hex 24)" >> .env
     echo "==> Added a generated DEPLOY_HOOK_TOKEN to .env (instant-roll webhook)"
   fi
+  # The public server briefly pinned only the first three compose-samples apps in
+  # SERVE_CATALOGS. That explicit value shadows the catalog set baked into newer
+  # images, so image rollouts alone cannot add Jetcaster, Jetsnack, and Reply.
+  # Remove only that known legacy override; operator-defined catalog lists remain
+  # untouched, while the next compose up inherits the complete image default.
+  LEGACY_COMPOSE_SAMPLES_CATALOGS='jetnews@yschimke/compose-samples,jetchat@yschimke/compose-samples,jetlagged@yschimke/compose-samples'
+  if grep -Fxq "SERVE_CATALOGS=${LEGACY_COMPOSE_SAMPLES_CATALOGS}" .env; then
+    sed -i '/^SERVE_CATALOGS=/d' .env
+    echo "==> Removed the legacy three-app SERVE_CATALOGS override (using the image default)"
+  fi
   echo "==> Reusing existing .env (tokens preserved)"
 fi
 

--- a/deploy/image/test-env-migrations.sh
+++ b/deploy/image/test-env-migrations.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# Tests for deploy/image/env-migrations.sh — the `.env` rewrites setup.sh runs on
+# an already-deployed box. These edit an operator's live config, so the cases that
+# matter are the ones where NOTHING should change: a custom catalog list, or a
+# custom list sitting alongside the legacy pin.
+#
+#   ./deploy/image/test-env-migrations.sh
+set -uo pipefail
+cd "$(dirname "$0")"
+
+# shellcheck source=deploy/image/env-migrations.sh
+source ./env-migrations.sh
+
+LEGACY="${LEGACY_COMPOSE_SAMPLES_CATALOGS}"
+CUSTOM='compose-m3,wear-m3,acme@acme/design-system'
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP}"' EXIT
+
+pass=0
+fail=0
+
+# run_case <name> <expected-return: removed|kept> <expected .env contents> <.env contents>
+run_case() {
+  local name="$1" expect_rc="$2" expected="$3" input="$4"
+  local env_file="${TMP}/env" rc=0 actual
+  printf '%s' "${input}" > "${env_file}"
+  chmod 600 "${env_file}"
+  migrate_legacy_serve_catalogs "${env_file}" || rc=$?
+
+  local want_rc=0
+  [[ "${expect_rc}" == "removed" ]] || want_rc=1
+  actual="$(cat "${env_file}")"
+
+  if [[ "${rc}" -ne "${want_rc}" ]]; then
+    echo "FAIL ${name}: expected ${expect_rc} (rc ${want_rc}), got rc ${rc}"
+    fail=$((fail + 1))
+  elif [[ "${actual}" != "${expected%$'\n'}" ]]; then
+    echo "FAIL ${name}: .env contents differ"
+    diff <(printf '%s\n' "${expected%$'\n'}") <(printf '%s\n' "${actual}") || true
+    fail=$((fail + 1))
+  else
+    pass=$((pass + 1))
+  fi
+}
+
+run_case "removes the exact legacy pin" removed \
+  "DOMAIN=preview.coo.ee
+SERVE_TOKEN=abc123" \
+  "DOMAIN=preview.coo.ee
+SERVE_CATALOGS=${LEGACY}
+SERVE_TOKEN=abc123
+"
+
+run_case "removes a quoted legacy pin" removed \
+  "DOMAIN=preview.coo.ee" \
+  "DOMAIN=preview.coo.ee
+SERVE_CATALOGS=\"${LEGACY}\"
+"
+
+run_case "removes an exported legacy pin with trailing whitespace" removed \
+  "DOMAIN=preview.coo.ee" \
+  "DOMAIN=preview.coo.ee
+export SERVE_CATALOGS=${LEGACY}
+"
+
+run_case "removes a CRLF legacy pin" removed \
+  "DOMAIN=preview.coo.ee" \
+  "$(printf 'DOMAIN=preview.coo.ee\nSERVE_CATALOGS=%s\r\n' "${LEGACY}")"
+
+# The point of the migration: an operator's own list is config, not legacy cruft.
+run_case "keeps an operator's custom list" kept \
+  "DOMAIN=preview.coo.ee
+SERVE_CATALOGS=${CUSTOM}" \
+  "DOMAIN=preview.coo.ee
+SERVE_CATALOGS=${CUSTOM}
+"
+
+# Docker Compose takes the LAST assignment, so a custom line after the legacy one
+# is the value actually in force — removing it would silently reset the box.
+run_case "keeps a custom list that follows the legacy pin" removed \
+  "DOMAIN=preview.coo.ee
+SERVE_CATALOGS=${CUSTOM}" \
+  "DOMAIN=preview.coo.ee
+SERVE_CATALOGS=${LEGACY}
+SERVE_CATALOGS=${CUSTOM}
+"
+
+run_case "keeps a superset that merely contains the legacy list" kept \
+  "SERVE_CATALOGS=${LEGACY},reply@yschimke/compose-samples" \
+  "SERVE_CATALOGS=${LEGACY},reply@yschimke/compose-samples
+"
+
+run_case "keeps an unrelated key whose value is the legacy list" kept \
+  "SERVE_CATALOGS_UNLISTED=${LEGACY}" \
+  "SERVE_CATALOGS_UNLISTED=${LEGACY}
+"
+
+run_case "leaves a file without SERVE_CATALOGS alone" kept \
+  "DOMAIN=preview.coo.ee
+SERVE_TOKEN=abc123" \
+  "DOMAIN=preview.coo.ee
+SERVE_TOKEN=abc123
+"
+
+# A rewrite must not widen the token file's permissions.
+mode_file="${TMP}/mode-env"
+printf 'SERVE_TOKEN=abc123\nSERVE_CATALOGS=%s\n' "${LEGACY}" > "${mode_file}"
+chmod 600 "${mode_file}"
+migrate_legacy_serve_catalogs "${mode_file}" || true
+mode="$(stat -c '%a' "${mode_file}" 2>/dev/null || stat -f '%Lp' "${mode_file}")"
+if [[ "${mode}" == "600" ]]; then
+  pass=$((pass + 1))
+else
+  echo "FAIL preserves 0600 mode: got ${mode}"
+  fail=$((fail + 1))
+fi
+
+# A missing .env is a no-op, not an error the installer should die on.
+rc=0
+migrate_legacy_serve_catalogs "${TMP}/does-not-exist" || rc=$?
+if [[ "${rc}" -eq 1 && ! -e "${TMP}/does-not-exist" ]]; then
+  pass=$((pass + 1))
+else
+  echo "FAIL missing .env is a no-op: rc ${rc}"
+  fail=$((fail + 1))
+fi
+
+echo "${pass} passed, ${fail} failed"
+[[ "${fail}" -eq 0 ]]

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -236,10 +236,10 @@ Both container profiles take this config from env (the entrypoint maps `SERVE_PU
 `SERVE_CATALOGS`, `SERVE_CATALOGS_UNLISTED`, `SERVE_TRUST_STORE`, `SERVE_WASM_DIR`,
 `SERVE_ACCEPT_BUNDLES` → flags) and put **Caddy** in front for TLS. They default to the **open public
 profile** (`SERVE_PUBLIC=1`, catalogs `compose-m3,wear-m3,remote-m3` plus the app systems `meshcore-mobile`,
-`homeassistant-remotecompose`, all six compose-samples apps (`jetnews`, `jetcaster`, `jetchat`, `jetsnack`,
-`jetlagged`, and `reply`), and the two Confetti apps on the front-page index; `cadence` is served unlisted at
-`/cadence/` — off the front page — via `SERVE_CATALOGS_UNLISTED`); set `SERVE_PUBLIC=0` + `SERVE_TOKEN` for a
-token-gated box.
+`homeassistant-remotecompose`, and all six compose-samples apps (`jetnews`, `jetcaster`, `jetchat`, `jetsnack`,
+`jetlagged`, and `reply`) on the front-page index; `cadence` is served unlisted at `/cadence/` — off the front
+page — via `SERVE_CATALOGS_UNLISTED`). The prebuilt `deploy/image` profile additionally includes the two
+Confetti apps. Set `SERVE_PUBLIC=0` + `SERVE_TOKEN` for a token-gated box.
 
 The prebuilt `deploy/image` **bakes a branch-trust store** at `/trust/producers.json` (trusting
 `design-artifacts/*` on `yschimke/compose-ai-tools`, `yschimke/meshcore-mobile`, and

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -235,9 +235,11 @@ to get the pure module-less server above.
 Both container profiles take this config from env (the entrypoint maps `SERVE_PUBLIC`,
 `SERVE_CATALOGS`, `SERVE_CATALOGS_UNLISTED`, `SERVE_TRUST_STORE`, `SERVE_WASM_DIR`,
 `SERVE_ACCEPT_BUNDLES` → flags) and put **Caddy** in front for TLS. They default to the **open public
-profile** (`SERVE_PUBLIC=1`, catalogs `compose-m3,wear-m3,remote-m3` plus the app systems `meshcore-mobile` /
-`homeassistant-remotecompose` on the front-page index, and `cadence` served unlisted at `/cadence/` — off the
-front page — via `SERVE_CATALOGS_UNLISTED`); set `SERVE_PUBLIC=0` + `SERVE_TOKEN` for a token-gated box.
+profile** (`SERVE_PUBLIC=1`, catalogs `compose-m3,wear-m3,remote-m3` plus the app systems `meshcore-mobile`,
+`homeassistant-remotecompose`, all six compose-samples apps (`jetnews`, `jetcaster`, `jetchat`, `jetsnack`,
+`jetlagged`, and `reply`), and the two Confetti apps on the front-page index; `cadence` is served unlisted at
+`/cadence/` — off the front page — via `SERVE_CATALOGS_UNLISTED`); set `SERVE_PUBLIC=0` + `SERVE_TOKEN` for a
+token-gated box.
 
 The prebuilt `deploy/image` **bakes a branch-trust store** at `/trust/producers.json` (trusting
 `design-artifacts/*` on `yschimke/compose-ai-tools`, `yschimke/meshcore-mobile`, and
@@ -248,11 +250,15 @@ Mount your own over that path (or set `SERVE_TRUST_STORE` to it) to pin differen
 out — which also means a bare image pull self-heals a box without editing its compose.)
 
 The **catalog set is baked into the image the same way**: the entrypoint defaults `SERVE_CATALOGS`
-to `compose-m3,wear-m3,remote-m3,meshcore-mobile@yschimke/meshcore-mobile,homeassistant-remotecompose@yschimke/homeassistant-remotecompose`
-(front-page index) and `SERVE_CATALOGS_UNLISTED` to `cadence@yschimke/cadence` (served at `/cadence/`,
-off the front page). So a bare `docker pull` / Watchtower update serves them
+to the three built-in design systems, MeshCore Mobile, Home Assistant Remote Compose, all six
+`yschimke/compose-samples` apps, and both Confetti apps (front-page index), and defaults
+`SERVE_CATALOGS_UNLISTED` to `cadence@yschimke/cadence` (served at `/cadence/`, off the front page).
+So a bare `docker pull` / Watchtower update serves them
 without editing the box's compose. Override either with your own comma list, or `none` to serve none
-of that kind (empty inherits the baked default). The `deploy/vps` from-source path still sets these
+of that kind (empty inherits the baked default). Re-running `deploy/image/setup.sh` also removes the
+known legacy override containing only `jetnews`, `jetchat`, and `jetlagged`, allowing older
+`preview.coo.ee` deployments to inherit the complete image default without disturbing custom lists.
+The `deploy/vps` from-source path still sets these
 in its compose (it builds `main`, so the flags exist immediately; the prebuilt image needs a CLI
 release that carries `--catalogs-unlisted`).
 


### PR DESCRIPTION
### Motivation

- The public preview server was missing three compose-samples apps (Jetcaster, Jetsnack, Reply) because an older explicit `SERVE_CATALOGS` value in deployed `.env` files shadowed the fuller catalog list baked into newer images. 
- The goal is to migrate running deployments to inherit the image-default catalog set without altering operator-defined catalog customizations.

### Description

- Add a targeted migration in `deploy/image/setup.sh` that removes the exact legacy `SERVE_CATALOGS` override `jetnews@yschimke/compose-samples,jetchat@yschimke/compose-samples,jetlagged@yschimke/compose-samples` from existing `.env` files so the prebuilt image default (which includes all six compose-samples apps) can take effect. 
- Update `deploy/image/docker-compose.yml` comments to document the complete baked `SERVE_CATALOGS` default and note that `setup.sh` removes the legacy three-app override. 
- Update `docs/public-preview-server.md` to list all six compose-samples apps (`jetnews`, `jetcaster`, `jetchat`, `jetsnack`, `jetlagged`, `reply`) and to document the migration behavior for older deployments.

### Testing

- Ran `bash -n deploy/image/setup.sh` to validate shell syntax and it completed successfully. 
- Executed a Python assertion that `deploy/image/entrypoint.sh` contains `jetcaster@yschimke/compose-samples`, `jetsnack@yschimke/compose-samples`, and `reply@yschimke/compose-samples`, and the check passed. 
- Simulated the migration against a temporary legacy `.env` containing the three-app `SERVE_CATALOGS` and confirmed the script removes the `SERVE_CATALOGS` line while preserving `SERVE_TOKEN`. 
- Ran repository checks (`git diff --check` and workspace status) with no issues reported, and noted that `shellcheck` was unavailable in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a668e8fd5fc8324b03c9663bae9cd53)