### PR TITLE
fix: reconcile Wear scroll fixture after merge

### DIFF
--- a/vscode-extension/preview-harness/fixtures/pages/serve-wear-scroll-long-capsule.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-wear-scroll-long-capsule.html
@@ -24,238 +24,176 @@
 <g transform="translate(16, 16)" clip-path="url(#deviceRound)">
   <rect x="0" y="0" width="227" height="1201" rx="113" ry="113" fill="#000000"/>
   <g id="WearScrollExtract">
-    <g id="CurvedLayoutKt">
+    <g id="ReusableComposeNode">
       <path id="curve-c0" d="M 93.49 18.2 A 97.37 97.37 0 0 1 133.5 18.2" fill="none"/><text font-size="15" font-weight="599" fill="#C6C6C7" dominant-baseline="alphabetic"><textPath href="#curve-c0" startOffset="50%" text-anchor="middle">10:10</textPath></text>
-      <g id="BoxKt">
+      <g id="ReusableComposeNode">
       </g>
     </g>
-    <g id="RowMeasurePolicy">
+    <g id="ReusableComposeNode">
       <text x="85" y="61.88" font-size="16" font-family="sans-serif" font-weight="550" letter-spacing="0.4" fill="#FFFFFF">Activity</text>
-      <g id="EmptyMeasurePolicy">
-      </g>
     </g>
-    <g id="ColumnMeasurePolicy">
+    <g id="ReusableComposeNode">
       <rect x="12" y="82" width="203" height="64" rx="26" ry="26" fill="#332E3C"/>
-      <g id="RowMeasurePolicy">
-        <g id="RowMeasurePolicy">
-          <g id="EmptyMeasurePolicy">
-            <text x="24" y="108.88" font-size="16" font-family="sans-serif" font-weight="550" letter-spacing="0.4" fill="#F6EDFF">Morning run 1</text>
-          </g>
-        </g>
+      <g id="ReusableComposeNode">
+        <text x="24" y="108.88" font-size="16" font-family="sans-serif" font-weight="550" letter-spacing="0.4" fill="#F6EDFF">Morning run 1</text>
       </g>
-      <g id="SpacerMeasurePolicy">
+      <g id="ReusableComposeNode">
       </g>
-      <g id="EmptyMeasurePolicy">
+      <g id="ReusableComposeNode">
         <text x="24" y="129.17" font-size="15" font-family="sans-serif" font-weight="500" letter-spacing="0.4" fill="#FFDCC2">5.2 km · 28 min</text>
       </g>
     </g>
-    <g id="ColumnMeasurePolicy">
+    <g id="ReusableComposeNode">
       <rect x="12" y="150" width="203" height="64" rx="26" ry="26" fill="#332E3C"/>
-      <g id="RowMeasurePolicy">
-        <g id="RowMeasurePolicy">
-          <g id="EmptyMeasurePolicy">
-            <text x="24" y="176.88" font-size="16" font-family="sans-serif" font-weight="550" letter-spacing="0.4" fill="#F6EDFF">Heart rate 2</text>
-          </g>
-        </g>
+      <g id="ReusableComposeNode">
+        <text x="24" y="176.88" font-size="16" font-family="sans-serif" font-weight="550" letter-spacing="0.4" fill="#F6EDFF">Heart rate 2</text>
       </g>
-      <g id="SpacerMeasurePolicy">
+      <g id="ReusableComposeNode">
       </g>
-      <g id="EmptyMeasurePolicy">
+      <g id="ReusableComposeNode">
         <text x="24" y="197.17" font-size="15" font-family="sans-serif" font-weight="500" letter-spacing="0.4" fill="#FFDCC2">71 bpm</text>
       </g>
     </g>
-    <g id="ColumnMeasurePolicy">
+    <g id="ReusableComposeNode">
       <rect x="12" y="218" width="203" height="64" rx="26" ry="26" fill="#332E3C"/>
-      <g id="RowMeasurePolicy">
-        <g id="RowMeasurePolicy">
-          <g id="EmptyMeasurePolicy">
-            <text x="24" y="244.88" font-size="16" font-family="sans-serif" font-weight="550" letter-spacing="0.4" fill="#F6EDFF">Sleep day 3</text>
-          </g>
-        </g>
+      <g id="ReusableComposeNode">
+        <text x="24" y="244.88" font-size="16" font-family="sans-serif" font-weight="550" letter-spacing="0.4" fill="#F6EDFF">Sleep day 3</text>
       </g>
-      <g id="SpacerMeasurePolicy">
+      <g id="ReusableComposeNode">
       </g>
-      <g id="EmptyMeasurePolicy">
+      <g id="ReusableComposeNode">
         <text x="24" y="265.17" font-size="15" font-family="sans-serif" font-weight="500" letter-spacing="0.4" fill="#FFDCC2">7h 6m</text>
       </g>
     </g>
-    <g id="ColumnMeasurePolicy">
+    <g id="ReusableComposeNode">
       <rect x="12" y="286" width="203" height="64" rx="26" ry="26" fill="#332E3C"/>
-      <g id="RowMeasurePolicy">
-        <g id="RowMeasurePolicy">
-          <g id="EmptyMeasurePolicy">
-            <text x="24" y="312.88" font-size="16" font-family="sans-serif" font-weight="550" letter-spacing="0.4" fill="#F6EDFF">Steps day 4</text>
-          </g>
-        </g>
+      <g id="ReusableComposeNode">
+        <text x="24" y="312.88" font-size="16" font-family="sans-serif" font-weight="550" letter-spacing="0.4" fill="#F6EDFF">Steps day 4</text>
       </g>
-      <g id="SpacerMeasurePolicy">
+      <g id="ReusableComposeNode">
       </g>
-      <g id="EmptyMeasurePolicy">
+      <g id="ReusableComposeNode">
         <text x="24" y="333.17" font-size="15" font-family="sans-serif" font-weight="500" letter-spacing="0.4" fill="#FFDCC2">6360</text>
       </g>
     </g>
-    <g id="ColumnMeasurePolicy">
+    <g id="ReusableComposeNode">
       <rect x="12" y="354" width="203" height="64" rx="26" ry="26" fill="#332E3C"/>
-      <g id="RowMeasurePolicy">
-        <g id="RowMeasurePolicy">
-          <g id="EmptyMeasurePolicy">
-            <text x="24" y="380.88" font-size="16" font-family="sans-serif" font-weight="550" letter-spacing="0.4" fill="#F6EDFF">Calories day 5</text>
-          </g>
-        </g>
+      <g id="ReusableComposeNode">
+        <text x="24" y="380.88" font-size="16" font-family="sans-serif" font-weight="550" letter-spacing="0.4" fill="#F6EDFF">Calories day 5</text>
       </g>
-      <g id="SpacerMeasurePolicy">
+      <g id="ReusableComposeNode">
       </g>
-      <g id="EmptyMeasurePolicy">
+      <g id="ReusableComposeNode">
         <text x="24" y="401.17" font-size="15" font-family="sans-serif" font-weight="500" letter-spacing="0.4" fill="#FFDCC2">420 kcal</text>
       </g>
     </g>
-    <g id="ColumnMeasurePolicy">
+    <g id="ReusableComposeNode">
       <rect x="12" y="422" width="203" height="64" rx="26" ry="26" fill="#332E3C"/>
-      <g id="RowMeasurePolicy">
-        <g id="RowMeasurePolicy">
-          <g id="EmptyMeasurePolicy">
-            <text x="24" y="448.88" font-size="16" font-family="sans-serif" font-weight="550" letter-spacing="0.4" fill="#F6EDFF">Timer 6</text>
-          </g>
-        </g>
+      <g id="ReusableComposeNode">
+        <text x="24" y="448.88" font-size="16" font-family="sans-serif" font-weight="550" letter-spacing="0.4" fill="#F6EDFF">Timer 6</text>
       </g>
-      <g id="SpacerMeasurePolicy">
+      <g id="ReusableComposeNode">
       </g>
-      <g id="EmptyMeasurePolicy">
+      <g id="ReusableComposeNode">
         <text x="24" y="469.17" font-size="15" font-family="sans-serif" font-weight="500" letter-spacing="0.4" fill="#FFDCC2">15:35 remaining</text>
       </g>
     </g>
-    <g id="ColumnMeasurePolicy">
+    <g id="ReusableComposeNode">
       <rect x="12" y="490" width="203" height="64" rx="26" ry="26" fill="#332E3C"/>
-      <g id="RowMeasurePolicy">
-        <g id="RowMeasurePolicy">
-          <g id="EmptyMeasurePolicy">
-            <text x="24" y="516.88" font-size="16" font-family="sans-serif" font-weight="550" letter-spacing="0.4" fill="#F6EDFF">Morning run 7</text>
-          </g>
-        </g>
+      <g id="ReusableComposeNode">
+        <text x="24" y="516.88" font-size="16" font-family="sans-serif" font-weight="550" letter-spacing="0.4" fill="#F6EDFF">Morning run 7</text>
       </g>
-      <g id="SpacerMeasurePolicy">
+      <g id="ReusableComposeNode">
       </g>
-      <g id="EmptyMeasurePolicy">
+      <g id="ReusableComposeNode">
         <text x="24" y="537.17" font-size="15" font-family="sans-serif" font-weight="500" letter-spacing="0.4" fill="#FFDCC2">5.2 km · 28 min</text>
       </g>
     </g>
-    <g id="ColumnMeasurePolicy">
+    <g id="ReusableComposeNode">
       <rect x="12" y="558" width="203" height="64" rx="26" ry="26" fill="#332E3C"/>
-      <g id="RowMeasurePolicy">
-        <g id="RowMeasurePolicy">
-          <g id="EmptyMeasurePolicy">
-            <text x="24" y="584.88" font-size="16" font-family="sans-serif" font-weight="550" letter-spacing="0.4" fill="#F6EDFF">Heart rate 8</text>
-          </g>
-        </g>
+      <g id="ReusableComposeNode">
+        <text x="24" y="584.88" font-size="16" font-family="sans-serif" font-weight="550" letter-spacing="0.4" fill="#F6EDFF">Heart rate 8</text>
       </g>
-      <g id="SpacerMeasurePolicy">
+      <g id="ReusableComposeNode">
       </g>
-      <g id="EmptyMeasurePolicy">
+      <g id="ReusableComposeNode">
         <text x="24" y="605.17" font-size="15" font-family="sans-serif" font-weight="500" letter-spacing="0.4" fill="#FFDCC2">77 bpm</text>
       </g>
     </g>
-    <g id="ColumnMeasurePolicy">
+    <g id="ReusableComposeNode">
       <rect x="12" y="626" width="203" height="64" rx="26" ry="26" fill="#332E3C"/>
-      <g id="RowMeasurePolicy">
-        <g id="RowMeasurePolicy">
-          <g id="EmptyMeasurePolicy">
-            <text x="24" y="652.88" font-size="16" font-family="sans-serif" font-weight="550" letter-spacing="0.4" fill="#F6EDFF">Sleep day 9</text>
-          </g>
-        </g>
+      <g id="ReusableComposeNode">
+        <text x="24" y="652.88" font-size="16" font-family="sans-serif" font-weight="550" letter-spacing="0.4" fill="#F6EDFF">Sleep day 9</text>
       </g>
-      <g id="SpacerMeasurePolicy">
+      <g id="ReusableComposeNode">
       </g>
-      <g id="EmptyMeasurePolicy">
+      <g id="ReusableComposeNode">
         <text x="24" y="673.17" font-size="15" font-family="sans-serif" font-weight="500" letter-spacing="0.4" fill="#FFDCC2">7h 24m</text>
       </g>
     </g>
-    <g id="ColumnMeasurePolicy">
+    <g id="ReusableComposeNode">
       <rect x="12" y="694" width="203" height="64" rx="26" ry="26" fill="#332E3C"/>
-      <g id="RowMeasurePolicy">
-        <g id="RowMeasurePolicy">
-          <g id="EmptyMeasurePolicy">
-            <text x="24" y="720.88" font-size="16" font-family="sans-serif" font-weight="550" letter-spacing="0.4" fill="#F6EDFF">Steps day 10</text>
-          </g>
-        </g>
+      <g id="ReusableComposeNode">
+        <text x="24" y="720.88" font-size="16" font-family="sans-serif" font-weight="550" letter-spacing="0.4" fill="#F6EDFF">Steps day 10</text>
       </g>
-      <g id="SpacerMeasurePolicy">
+      <g id="ReusableComposeNode">
       </g>
-      <g id="EmptyMeasurePolicy">
+      <g id="ReusableComposeNode">
         <text x="24" y="741.17" font-size="15" font-family="sans-serif" font-weight="500" letter-spacing="0.4" fill="#FFDCC2">7080</text>
       </g>
     </g>
-    <g id="ColumnMeasurePolicy">
+    <g id="ReusableComposeNode">
       <rect x="12" y="762" width="203" height="64" rx="26" ry="26" fill="#332E3C"/>
-      <g id="RowMeasurePolicy">
-        <g id="RowMeasurePolicy">
-          <g id="EmptyMeasurePolicy">
-            <text x="24" y="788.88" font-size="16" font-family="sans-serif" font-weight="550" letter-spacing="0.4" fill="#F6EDFF">Calories day 11</text>
-          </g>
-        </g>
+      <g id="ReusableComposeNode">
+        <text x="24" y="788.88" font-size="16" font-family="sans-serif" font-weight="550" letter-spacing="0.4" fill="#F6EDFF">Calories day 11</text>
       </g>
-      <g id="SpacerMeasurePolicy">
+      <g id="ReusableComposeNode">
       </g>
-      <g id="EmptyMeasurePolicy">
+      <g id="ReusableComposeNode">
         <text x="24" y="809.17" font-size="15" font-family="sans-serif" font-weight="500" letter-spacing="0.4" fill="#FFDCC2">450 kcal</text>
       </g>
     </g>
-    <g id="ColumnMeasurePolicy">
+    <g id="ReusableComposeNode">
       <rect x="12" y="830" width="203" height="64" rx="26" ry="26" fill="#332E3C"/>
-      <g id="RowMeasurePolicy">
-        <g id="RowMeasurePolicy">
-          <g id="EmptyMeasurePolicy">
-            <text x="24" y="856.88" font-size="16" font-family="sans-serif" font-weight="550" letter-spacing="0.4" fill="#F6EDFF">Timer 12</text>
-          </g>
-        </g>
+      <g id="ReusableComposeNode">
+        <text x="24" y="856.88" font-size="16" font-family="sans-serif" font-weight="550" letter-spacing="0.4" fill="#F6EDFF">Timer 12</text>
       </g>
-      <g id="SpacerMeasurePolicy">
+      <g id="ReusableComposeNode">
       </g>
-      <g id="EmptyMeasurePolicy">
+      <g id="ReusableComposeNode">
         <text x="24" y="877.17" font-size="15" font-family="sans-serif" font-weight="500" letter-spacing="0.4" fill="#FFDCC2">21:17 remaining</text>
       </g>
     </g>
-    <g id="ColumnMeasurePolicy">
+    <g id="ReusableComposeNode">
       <rect x="12" y="898" width="203" height="64" rx="26" ry="26" fill="#332E3C"/>
-      <g id="RowMeasurePolicy">
-        <g id="RowMeasurePolicy">
-          <g id="EmptyMeasurePolicy">
-            <text x="24" y="924.88" font-size="16" font-family="sans-serif" font-weight="550" letter-spacing="0.4" fill="#F6EDFF">Morning run 13</text>
-          </g>
-        </g>
+      <g id="ReusableComposeNode">
+        <text x="24" y="924.88" font-size="16" font-family="sans-serif" font-weight="550" letter-spacing="0.4" fill="#F6EDFF">Morning run 13</text>
       </g>
-      <g id="SpacerMeasurePolicy">
+      <g id="ReusableComposeNode">
       </g>
-      <g id="EmptyMeasurePolicy">
+      <g id="ReusableComposeNode">
         <text x="24" y="945.17" font-size="15" font-family="sans-serif" font-weight="500" letter-spacing="0.4" fill="#FFDCC2">5.2 km · 28 min</text>
       </g>
     </g>
-    <g id="ColumnMeasurePolicy">
+    <g id="ReusableComposeNode">
       <rect x="12" y="966" width="203" height="64" rx="26" ry="26" fill="#332E3C"/>
-      <g id="RowMeasurePolicy">
-        <g id="RowMeasurePolicy">
-          <g id="EmptyMeasurePolicy">
-            <text x="24" y="992.88" font-size="16" font-family="sans-serif" font-weight="550" letter-spacing="0.4" fill="#F6EDFF">Heart rate 14</text>
-          </g>
-        </g>
+      <g id="ReusableComposeNode">
+        <text x="24" y="992.88" font-size="16" font-family="sans-serif" font-weight="550" letter-spacing="0.4" fill="#F6EDFF">Heart rate 14</text>
       </g>
-      <g id="SpacerMeasurePolicy">
+      <g id="ReusableComposeNode">
       </g>
-      <g id="EmptyMeasurePolicy">
+      <g id="ReusableComposeNode">
         <text x="24" y="1013.17" font-size="15" font-family="sans-serif" font-weight="500" letter-spacing="0.4" fill="#FFDCC2">83 bpm</text>
       </g>
     </g>
-    <g id="ColumnMeasurePolicy">
+    <g id="ReusableComposeNode">
       <rect x="12" y="1034" width="203" height="64" rx="26" ry="26" fill="#332E3C"/>
-      <g id="RowMeasurePolicy">
-        <g id="RowMeasurePolicy">
-          <g id="EmptyMeasurePolicy">
-            <text x="24" y="1060.88" font-size="16" font-family="sans-serif" font-weight="550" letter-spacing="0.4" fill="#F6EDFF">Sleep day 15</text>
-          </g>
-        </g>
+      <g id="ReusableComposeNode">
+        <text x="24" y="1060.88" font-size="16" font-family="sans-serif" font-weight="550" letter-spacing="0.4" fill="#F6EDFF">Sleep day 15</text>
       </g>
-      <g id="SpacerMeasurePolicy">
+      <g id="ReusableComposeNode">
       </g>
-      <g id="EmptyMeasurePolicy">
+      <g id="ReusableComposeNode">
         <text x="24" y="1081.17" font-size="15" font-family="sans-serif" font-weight="500" letter-spacing="0.4" fill="#FFDCC2">7h 42m</text>
       </g>
     </g>


### PR DESCRIPTION
### Motivation
- The renderer's SVG node structure changed in a merged change, which made the committed Wear long-scroll capsule fixture diverge and tripped the renderer's drift-guard test.

### Description
- Regenerated the committed fixture `vscode-extension/preview-harness/fixtures/pages/serve-wear-scroll-long-capsule.html` to match the renderer's current SVG output by replacing the previous Compose-specific node hierarchy with the emitted `ReusableComposeNode` structure while preserving visual content and embedded raster data.

### Testing
- Ran the targeted unit test with the fixture regeneration flag using `UPDATE_WEAR_SCROLL_FIXTURE=true ./gradlew --no-build-cache :renderer-android:testDebugUnitTest --tests 'ee.schimke.composeai.renderer.WearScrollSvgGrowthTest'` which completed successfully.
- Verified repository cleanliness and formatting with `git diff --check` and `git status --short --branch`, both reporting no remaining issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a669043dab88324a342c59c4d99611b)