### PR TITLE
build: add a bumpable build-cache salt

### DIFF
--- a/build-logic/src/main/kotlin/ee/schimke/composeai/buildlogic/ComposeAiBaseConventionsPlugin.kt
+++ b/build-logic/src/main/kotlin/ee/schimke/composeai/buildlogic/ComposeAiBaseConventionsPlugin.kt
@@ -6,6 +6,7 @@ import org.gradle.api.Project
 import org.gradle.api.tasks.testing.Test
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.withType
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 /**
  * Conventions that previously lived in the root build's `allprojects {}` block. Isolated Projects
@@ -30,6 +31,34 @@ class ComposeAiBaseConventionsPlugin : Plugin<Project> {
     project.tasks.withType<Test>().configureEach {
       systemProperty("composeai.history.enabled", "true")
       systemProperty("composeai.history.gitProvenanceTtlMs", "0")
+    }
+
+    // Build-cache salt. A Gradle cache key is the hash of a task's declared inputs, so an extra
+    // declared input property lets us move every Kotlin compilation to a fresh set of keys by
+    // bumping one number in gradle.properties.
+    //
+    // This exists because a remote-cache entry can go bad at rest: in July 2026 the BuildFetch
+    // entry for `:daemon:core:compileKotlin` was stored truncated, and every consumer that
+    // resolved that key died in the *load* ("Failed to load cache entry cc7964dd…: Could not load
+    // from remote cache: Unexpected end of ZLIB input stream") — before the task could execute,
+    // so nothing ever pushed a replacement. PR runs are read-only (see settings.gradle.kts) and
+    // main runs aborted at the same point, so it could not self-heal; it blocked every build that
+    // touched `:daemon:core` until the key changed. BuildFetch documents no way to evict a single
+    // entry (LRU under storage pressure is the only documented eviction), so a salt we control is
+    // the escape hatch.
+    //
+    // Bumping it orphans the poisoned key rather than deleting it: the next pushing main run
+    // executes the affected tasks and stores clean entries under the new keys, and everything else
+    // reads those. Cost is one cold main build; the stale entries age out via LRU. Prefer asking
+    // BuildFetch to evict the specific entry when that's an option — this is the lever for
+    // when it isn't.
+    //
+    // Applied here rather than in `composeai.kotlin-conventions` deliberately: base-conventions
+    // is the plugin *every* module applies, and `:daemon:core` — the module that was actually
+    // poisoned — does not apply the Kotlin conventions plugin.
+    val cacheSalt = project.providers.gradleProperty("composeai.cacheSalt").orElse("0")
+    project.tasks.withType<KotlinCompilationTask<*>>().configureEach {
+      inputs.property("composeai.cacheSalt", cacheSalt)
     }
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,14 @@ org.gradle.configuration-cache=true
 org.gradle.configuration-cache.problems=fail
 org.gradle.caching=true
 
+# Build-cache salt — an extra declared input on every Kotlin compilation task, so bumping this
+# number moves the whole repo to fresh build-cache keys (see ComposeAiBaseConventionsPlugin for the
+# why and the cost). Bump it when a remote-cache entry is corrupt at rest and can't be evicted
+# server-side: a poisoned entry fails during *load*, so the task never executes and never pushes a
+# replacement, and no amount of re-running clears it. One cold main build reseeds under the new
+# keys. History: 1 = orphan the truncated `:daemon:core:compileKotlin` entry cc7964dd… (2026-07).
+composeai.cacheSalt=1
+
 # Isolated Projects is deliberately NOT enabled here. It is incompatible with
 # the compose-preview CLI / MCP server / VS Code workflow: those drive Gradle
 # through the auto-injected init script (cli/.../AutoInject.kt,


### PR DESCRIPTION
### Motivation

A remote build-cache entry can go bad at rest, and when it does the build has no way out. The failure happens while *loading* the entry, so the task never executes and never pushes a replacement:

```
Execution failed for task ':daemon:core:compileKotlin'
> Failed to load cache entry cc7964ddd5f6e49aebe3aa8b69a6cc6e for task ':daemon:core:compileKotlin':
  Could not load from remote cache: Unexpected end of ZLIB input stream
```

That entry was stored truncated on 2026-07-26 and blocked every build touching `:daemon:core` — PRs #2802 and #2805, and `main` itself — for hours. It could not self-heal: PR runs are read-only (`isPush = onCi`, settings.gradle.kts), and `main` runs died at the same load step before reaching the push. Re-running is useless; the failure is deterministic. BuildFetch's public docs describe no way to evict a single entry (LRU under storage pressure is the only documented eviction), so there was no lever at all.

### Description

- Declare an extra input property, `composeai.cacheSalt`, on every `KotlinCompilationTask` in `ComposeAiBaseConventionsPlugin`, sourced from `gradle.properties`. A cache key is the hash of a task's declared inputs, so bumping the number moves the repo to a fresh set of keys — the next pushing `main` run executes and stores clean entries, everything else reads those, and the poisoned key is orphaned rather than deleted (it ages out via LRU).
- Set `composeai.cacheSalt=1` to orphan `cc7964dd…` now.
- Applied in `base-conventions` rather than `kotlin-conventions` deliberately: base-conventions is the plugin *every* module applies, and `:daemon:core` — the module actually poisoned — does not apply the Kotlin conventions plugin.

Cost of a bump is one cold `main` build. Evicting the specific entry server-side is still the cleaner fix when that's available; this is the lever for when it isn't.

### Testing

Verified the salt actually moves the cache key, against a local build cache:

| Run | Command | `:daemon:core:compileKotlin` |
| --- | --- | --- |
| Seed | `./gradlew :daemon:core:compileKotlin --build-cache` | executed |
| Wipe outputs, re-run at salt=1 | `rm -rf daemon/core/build/classes && ./gradlew … --build-cache` | `FROM-CACHE` |
| Wipe outputs, re-run at salt=2 | `rm -rf daemon/core/build/classes && ./gradlew … -Pcomposeai.cacheSalt=2` | **miss — executed** |

Configuration succeeds with the configuration cache on (`org.gradle.configuration-cache=true`, `problems=fail`), so the added input is CC-safe. `ktfmtCheckAll` couldn't run in this container (offline; missing `kotlin-daemon-embeddable` artifact) — the edited file is in `build-logic`, which ktfmt doesn't cover, and lines were kept inside 100 columns by hand.

No visual surfaces are touched — build-cache plumbing only, so no render evidence applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qpo8N1ZoYfpSHwJWdVgots

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qpo8N1ZoYfpSHwJWdVgots)_