### PR TITLE
refactor(ci): extract the android-all cache-key policy into a tested script

### DIFF
--- a/.github/ci/android-all-cache-key.py
+++ b/.github/ci/android-all-cache-key.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Bound the Robolectric `android-all` cache payload and print its cache key.
+
+Used by integration.yml's two "Resolve android-all cache key" steps (the
+external-repo matrix and the daemon-harness leg). It runs AFTER the build, over
+whatever `~/.m2/repository/org/robolectric/android-all-instrumented` holds, and
+prints one `coordinate=<key>` line for `$GITHUB_OUTPUT`; the caller feeds that
+into the split restore/save cache key.
+
+Two failure modes bound the retained set from either side, and both have been
+hit in this repo:
+
+  - Keep only ONE (the newest). Wrong: a cell can legitimately need several.
+    `wear-os-samples` fetched both `15-robolectric-13954326-i7` and
+    `16-robolectric-13921718-i7` in one run, because the Gradle render path and
+    the daemon path resolve different SDKs. Dropping one left the entry
+    permanently incomplete — re-downloaded (~200 MB) every run, with the save
+    no-op'ing because the key never changed.
+  - Keep ALL. Also wrong: the restore hands back the previous set, so each
+    `robolectric` bump folds another dead coordinate into the next entry.
+    Evicting older entries doesn't shrink the newest one, so the payload grows
+    ~200 MB per bump forever.
+
+There is no way to ask which coordinates this run actually USED: a restored jar
+that gets used is not rewritten, so it looks identical to one that sat
+untouched. Usage can't be inferred after the fact, so the bound is a deliberate
+policy instead — keep the [MAX_COORDINATES] highest Android versions and delete
+the rest, loudly. That covers a multi-SDK cell (2 today) with headroom, and a
+bump evicts the oldest rather than accumulating. A drop is logged as a workflow
+warning, so if a cell ever genuinely needs more than the cap the re-download
+shows up as a warning rather than as an unexplained slow leg.
+
+Env:
+    ANDROID_ALL_ROOT   override the coordinate directory (default
+                       ~/.m2/repository/org/robolectric/android-all-instrumented)
+
+Pure stdlib; unit-tested by test_android_all_cache_key.py. Lives here rather
+than inline in the workflow so the retention policy can be exercised without
+running a 40-minute matrix leg — it deletes ~200 MB directories, so "only drops
+what it says it drops" has to be a test, not a comment.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+import shutil
+import sys
+from pathlib import Path
+
+# Headroom over the 2 a render+daemon cell needs today. Raise it if a cell
+# starts warning that it dropped a coordinate it wanted.
+MAX_COORDINATES = 3
+
+DEFAULT_ROOT = Path.home() / ".m2/repository/org/robolectric/android-all-instrumented"
+
+
+def materialised_coordinates(root: Path) -> list[Path]:
+    """Coordinate directories under [root] that actually carry a jar.
+
+    A directory with no jar is a half-finished download (or a stale marker
+    dir); caching or keying on it would pin an entry that can't serve a build.
+    """
+    if not root.is_dir():
+        return []
+    return [d for d in root.glob("*") if d.is_dir() and any(d.glob("*.jar"))]
+
+
+def _rank(name: str) -> tuple[int, str]:
+    """Sort key: Android version (leading int of `16-robolectric-13921718-i7`),
+    then the full name so two builds of one version order stably."""
+    match = re.match(r"(\d+)", name)
+    return (int(match.group(1)) if match else -1, name)
+
+
+def partition(names: list[str], cap: int = MAX_COORDINATES) -> tuple[list[str], list[str]]:
+    """Split [names] into (keep, drop): the [cap] highest-ranked, then the rest."""
+    ranked = sorted(names, key=_rank, reverse=True)
+    return ranked[:cap], ranked[cap:]
+
+
+def cache_key(names: list[str]) -> str:
+    """The cache-key fragment for a retained coordinate set.
+
+    One coordinate reads plainly in the key; several would blow past a sensible
+    key length, so collapse those to a stable digest. Either way the key changes
+    if and only if the retained SET changes — which is what makes the save a
+    no-op on an unchanged cell and a fresh entry after a bump.
+    """
+    joined = "_".join(sorted(names))
+    if len(names) == 1:
+        return joined
+    return f"{len(names)}x-{hashlib.sha256(joined.encode()).hexdigest()[:16]}"
+
+
+def resolve(root: Path, cap: int = MAX_COORDINATES) -> str:
+    """Prune [root] to the cap and return the resulting key ("" when empty).
+
+    Deletes the dropped coordinate directories — the caller is about to save the
+    whole tree, so pruning has to happen on disk, not just in the key.
+    """
+    present = [d.name for d in materialised_coordinates(root)]
+    if not present:
+        print("no android-all coordinate on disk — nothing to cache", file=sys.stderr)
+        return ""
+
+    keep, drop = partition(present, cap)
+    for name in drop:
+        print(
+            f"::warning::dropping android-all coordinate {name} — over the "
+            f"{cap}-coordinate cache cap. If this cell needs it, it will be "
+            "re-downloaded every run; raise MAX_COORDINATES.",
+            file=sys.stderr,
+        )
+        shutil.rmtree(root / name)
+
+    print(
+        f"caching {len(keep)} android-all coordinate(s): {'_'.join(sorted(keep))}",
+        file=sys.stderr,
+    )
+    return cache_key(keep)
+
+
+def main() -> int:
+    root = Path(os.environ.get("ANDROID_ALL_ROOT") or DEFAULT_ROOT)
+    print(f"coordinate={resolve(root)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/ci/test_android_all_cache_key.py
+++ b/.github/ci/test_android_all_cache_key.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Unit tests for android-all-cache-key.py's retention policy.
+
+Pure stdlib (unittest). Run: python3 .github/ci/test_android_all_cache_key.py -v
+
+The cases that matter are the two that cost real CI time when they regress:
+a multi-SDK cell must keep every coordinate it fetched (up to the cap), and the
+key must change if and only if the retained SET changes — a key that moves on an
+unchanged cell writes a new ~600 MB entry every run, and a key that sticks after
+a bump leaves the entry permanently incomplete.
+"""
+
+import importlib.util
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+_HERE = Path(__file__).resolve().parent
+
+# Load android-all-cache-key.py as a module (hyphenated filename → importlib).
+_spec = importlib.util.spec_from_file_location(
+    "android_all_cache_key", _HERE / "android-all-cache-key.py"
+)
+mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(mod)
+
+
+def _tree(root: Path, coordinates, with_jar=True):
+    """Materialise coordinate dirs under [root], each carrying a dummy jar."""
+    for name in coordinates:
+        d = root / name
+        d.mkdir(parents=True)
+        if with_jar:
+            (d / f"android-all-instrumented-{name}.jar").write_bytes(b"jar")
+
+
+class Partition(unittest.TestCase):
+    def test_keeps_the_highest_android_versions(self):
+        keep, drop = mod.partition(
+            [
+                "14-robolectric-10818077-i7",
+                "16-robolectric-13921718-i7",
+                "15-robolectric-13954326-i7",
+            ],
+            cap=2,
+        )
+        self.assertEqual(
+            ["16-robolectric-13921718-i7", "15-robolectric-13954326-i7"], keep
+        )
+        self.assertEqual(["14-robolectric-10818077-i7"], drop)
+
+    def test_a_multi_sdk_cell_keeps_every_coordinate_under_the_cap(self):
+        # The wear-os-samples case: the Gradle render path and the daemon path
+        # resolve different SDKs, and dropping either re-downloads ~200 MB every
+        # run while the key never changes.
+        present = ["15-robolectric-13954326-i7", "16-robolectric-13921718-i7"]
+        keep, drop = mod.partition(present, cap=3)
+        self.assertCountEqual(present, keep)
+        self.assertEqual([], drop)
+
+    def test_same_version_orders_by_build_newest_first(self):
+        keep, drop = mod.partition(
+            ["16-robolectric-13921718-i7", "16-robolectric-14000000-i7"], cap=1
+        )
+        self.assertEqual(["16-robolectric-14000000-i7"], keep)
+        self.assertEqual(["16-robolectric-13921718-i7"], drop)
+
+    def test_an_unversioned_directory_is_dropped_first(self):
+        keep, drop = mod.partition(["scratch", "16-robolectric-13921718-i7"], cap=1)
+        self.assertEqual(["16-robolectric-13921718-i7"], keep)
+        self.assertEqual(["scratch"], drop)
+
+
+class CacheKey(unittest.TestCase):
+    def test_a_single_coordinate_reads_plainly(self):
+        self.assertEqual(
+            "16-robolectric-13921718-i7", mod.cache_key(["16-robolectric-13921718-i7"])
+        )
+
+    def test_several_coordinates_collapse_to_a_short_stable_digest(self):
+        names = ["16-robolectric-13921718-i7", "15-robolectric-13954326-i7"]
+        key = mod.cache_key(names)
+        self.assertTrue(key.startswith("2x-"), key)
+        self.assertEqual(len("2x-") + 16, len(key))
+        # Order-independent: the same SET must key the same, or a cell whose
+        # directory listing shuffles writes a redundant entry.
+        self.assertEqual(key, mod.cache_key(list(reversed(names))))
+
+    def test_the_key_changes_when_the_retained_set_changes(self):
+        before = mod.cache_key(["15-robolectric-13954326-i7", "16-robolectric-13921718-i7"])
+        after = mod.cache_key(["16-robolectric-13921718-i7", "17-robolectric-14100000-i7"])
+        self.assertNotEqual(before, after)
+
+
+class Resolve(unittest.TestCase):
+    def test_prunes_over_cap_directories_from_disk(self):
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _tree(
+                root,
+                [
+                    "14-robolectric-10818077-i7",
+                    "15-robolectric-13954326-i7",
+                    "16-robolectric-13921718-i7",
+                ],
+            )
+
+            key = mod.resolve(root, cap=2)
+
+            self.assertEqual(
+                ["15-robolectric-13954326-i7", "16-robolectric-13921718-i7"],
+                sorted(d.name for d in root.iterdir()),
+            )
+            self.assertEqual(
+                mod.cache_key(
+                    ["15-robolectric-13954326-i7", "16-robolectric-13921718-i7"]
+                ),
+                key,
+            )
+
+    def test_keeps_everything_when_under_the_cap(self):
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            present = ["15-robolectric-13954326-i7", "16-robolectric-13921718-i7"]
+            _tree(root, present)
+
+            key = mod.resolve(root, cap=3)
+
+            self.assertCountEqual(present, [d.name for d in root.iterdir()])
+            self.assertEqual(mod.cache_key(present), key)
+
+    def test_a_jarless_directory_is_not_cached_or_keyed(self):
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _tree(root, ["16-robolectric-13921718-i7"], with_jar=False)
+
+            self.assertEqual("", mod.resolve(root))
+
+    def test_a_missing_root_yields_an_empty_key(self):
+        with TemporaryDirectory() as tmp:
+            self.assertEqual("", mod.resolve(Path(tmp) / "never-downloaded"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -577,6 +577,11 @@ jobs:
         run: python3 .github/ci/test_change_scope.py -v
       - name: Run daemon round-trip transport tests
         run: python3 .github/ci/test_daemon_roundtrip.py -v
+      # The android-all cache-key script DELETES ~200 MB coordinate directories
+      # on the integration runners, so "only drops what it says it drops" — and
+      # "the key moves iff the retained set moves" — are gated, not eyeballed.
+      - name: Run android-all cache-key tests
+        run: python3 .github/ci/test_android_all_cache_key.py -v
       # The deploy image's .env migrations edit an operator's live config on an
       # already-deployed box, so the "leaves a custom catalog list alone" cases
       # are worth a gate rather than a manual check.

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1389,66 +1389,17 @@ jobs:
       #    Evicting older entries doesn't shrink the newest one, so the payload
       #    grows ~200 MB per bump forever.
       #
-      # There is no way to ask which coordinates this run actually USED: a
-      # restored jar that gets used is not rewritten, so it looks identical to
-      # one that sat untouched. Usage can't be inferred after the fact, so the
-      # bound is a deliberate policy instead — keep the MAX_COORDINATES highest
-      # Android versions and drop the rest, loudly. That covers a multi-SDK cell
-      # (2 today) with headroom, and a bump evicts the oldest rather than
-      # accumulating. A drop is logged, so if a cell ever genuinely needs more
-      # than the cap the re-download shows up as a warning rather than as an
-      # unexplained slow leg.
+      # The policy that resolves this — keep the highest few Android versions,
+      # delete the rest loudly — and the reasoning behind it live in
+      # .github/ci/android-all-cache-key.py, unit-tested by
+      # test_android_all_cache_key.py. Both this step and the daemon-harness one
+      # below call that one script; they must not drift apart.
       - name: Resolve android-all cache key
         id: android-all
         if: always() && (matrix.render || matrix.render_xr || matrix.daemon)
         run: |
           set -euo pipefail
-          python3 - <<'PY' >> "$GITHUB_OUTPUT"
-          import hashlib
-          import re
-          import shutil
-          import sys
-          from pathlib import Path
-
-          # Headroom over the 2 a render+daemon cell needs today. Raise it if a
-          # cell starts warning that it dropped a coordinate it wanted.
-          MAX_COORDINATES = 3
-
-          root = Path.home() / ".m2/repository/org/robolectric/android-all-instrumented"
-          present = [d for d in root.glob("*") if d.is_dir() and any(d.glob("*.jar"))] if root.is_dir() else []
-          if not present:
-              print("no android-all coordinate on disk — nothing to cache", file=sys.stderr)
-              print("coordinate=")
-              raise SystemExit(0)
-
-          # Order by Android version (the leading int of e.g. `16-robolectric-13921718-i7`),
-          # newest first, name as a stable tie-break.
-          def version_of(d):
-              m = re.match(r"(\d+)", d.name)
-              return (int(m.group(1)) if m else -1, d.name)
-
-          ranked = sorted(present, key=version_of, reverse=True)
-          keep, drop = ranked[:MAX_COORDINATES], ranked[MAX_COORDINATES:]
-          for d in drop:
-              print(
-                  f"::warning::dropping android-all coordinate {d.name} — over the "
-                  f"{MAX_COORDINATES}-coordinate cache cap. If this cell needs it, "
-                  "it will be re-downloaded every run; raise MAX_COORDINATES.",
-                  file=sys.stderr,
-              )
-              shutil.rmtree(d)
-
-          coordinates = sorted(d.name for d in keep)
-          # One coordinate reads plainly in the key; several would blow past a
-          # sensible key length, so collapse those to a stable digest. Either way
-          # the key changes if and only if the retained SET changes.
-          joined = "_".join(coordinates)
-          key = joined if len(coordinates) == 1 else (
-              f"{len(coordinates)}x-{hashlib.sha256(joined.encode()).hexdigest()[:16]}"
-          )
-          print(f"caching {len(coordinates)} android-all coordinate(s): {joined}", file=sys.stderr)
-          print(f"coordinate={key}")
-          PY
+          python3 .github/ci/android-all-cache-key.py >> "$GITHUB_OUTPUT"
 
       # Split restore/save (rather than plain `actions/cache`) so a cell that
       # failed AFTER paying the download still persists it — the rerun starts
@@ -1767,57 +1718,14 @@ jobs:
           if-no-files-found: warn
           retention-days: 7
 
+      # Same retention policy + reasoning as the matrix leg above:
+      # .github/ci/android-all-cache-key.py (unit-tested).
       - name: Resolve android-all cache key
         id: android-all
         if: always()
         run: |
           set -euo pipefail
-          python3 - <<'PY' >> "$GITHUB_OUTPUT"
-          import hashlib
-          import re
-          import shutil
-          import sys
-          from pathlib import Path
-
-          # Headroom over the 2 a render+daemon cell needs today. Raise it if a
-          # cell starts warning that it dropped a coordinate it wanted.
-          MAX_COORDINATES = 3
-
-          root = Path.home() / ".m2/repository/org/robolectric/android-all-instrumented"
-          present = [d for d in root.glob("*") if d.is_dir() and any(d.glob("*.jar"))] if root.is_dir() else []
-          if not present:
-              print("no android-all coordinate on disk — nothing to cache", file=sys.stderr)
-              print("coordinate=")
-              raise SystemExit(0)
-
-          # Order by Android version (the leading int of e.g. `16-robolectric-13921718-i7`),
-          # newest first, name as a stable tie-break.
-          def version_of(d):
-              m = re.match(r"(\d+)", d.name)
-              return (int(m.group(1)) if m else -1, d.name)
-
-          ranked = sorted(present, key=version_of, reverse=True)
-          keep, drop = ranked[:MAX_COORDINATES], ranked[MAX_COORDINATES:]
-          for d in drop:
-              print(
-                  f"::warning::dropping android-all coordinate {d.name} — over the "
-                  f"{MAX_COORDINATES}-coordinate cache cap. If this cell needs it, "
-                  "it will be re-downloaded every run; raise MAX_COORDINATES.",
-                  file=sys.stderr,
-              )
-              shutil.rmtree(d)
-
-          coordinates = sorted(d.name for d in keep)
-          # One coordinate reads plainly in the key; several would blow past a
-          # sensible key length, so collapse those to a stable digest. Either way
-          # the key changes if and only if the retained SET changes.
-          joined = "_".join(coordinates)
-          key = joined if len(coordinates) == 1 else (
-              f"{len(coordinates)}x-{hashlib.sha256(joined.encode()).hexdigest()[:16]}"
-          )
-          print(f"caching {len(coordinates)} android-all coordinate(s): {joined}", file=sys.stderr)
-          print(f"coordinate={key}")
-          PY
+          python3 .github/ci/android-all-cache-key.py >> "$GITHUB_OUTPUT"
 
       - name: Save Robolectric android-all cache
         if: always() && steps.android-all.outputs.coordinate != ''

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -189,6 +189,10 @@ jobs:
           # compare-previews.py can't reach them) — used by render_xr cells.
           cp .github/actions/lib/xr-gallery.py bundle/ci/
           cp .github/actions/apply/lib/push-branch.sh bundle/ci/
+          # Bounds the saved android-all cache payload after the build. Same
+          # reason as the scripts above: the matrix legs that call it have no
+          # checkout of this repo, so it has to ride in via the bundle.
+          cp .github/ci/android-all-cache-key.py bundle/ci/
           # Ship consumer patches (e.g. the adaptive-apps-samples XR
           # alpha14 upgrade) so the integration matrix can apply them to
           # the checked-out external repo before Gradle configures it.
@@ -1399,7 +1403,17 @@ jobs:
         if: always() && (matrix.render || matrix.render_xr || matrix.daemon)
         run: |
           set -euo pipefail
-          python3 .github/ci/android-all-cache-key.py >> "$GITHUB_OUTPUT"
+          # Ships in the bundle (these legs have no checkout of this repo). The
+          # step is `always()`, so it can also run after a failure that happened
+          # before the bundle was unpacked — treat that as "nothing to cache"
+          # rather than failing the leg on a missing file.
+          script="$GITHUB_WORKSPACE/bundle/ci/android-all-cache-key.py"
+          if [ -f "$script" ]; then
+            python3 "$script" >> "$GITHUB_OUTPUT"
+          else
+            echo "bundle not unpacked — nothing to cache" >&2
+            echo "coordinate=" >> "$GITHUB_OUTPUT"
+          fi
 
       # Split restore/save (rather than plain `actions/cache`) so a cell that
       # failed AFTER paying the download still persists it — the rerun starts
@@ -1725,7 +1739,17 @@ jobs:
         if: always()
         run: |
           set -euo pipefail
-          python3 .github/ci/android-all-cache-key.py >> "$GITHUB_OUTPUT"
+          # Ships in the bundle (these legs have no checkout of this repo). The
+          # step is `always()`, so it can also run after a failure that happened
+          # before the bundle was unpacked — treat that as "nothing to cache"
+          # rather than failing the leg on a missing file.
+          script="$GITHUB_WORKSPACE/bundle/ci/android-all-cache-key.py"
+          if [ -f "$script" ]; then
+            python3 "$script" >> "$GITHUB_OUTPUT"
+          else
+            echo "bundle not unpacked — nothing to cache" >&2
+            echo "coordinate=" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Save Robolectric android-all cache
         if: always() && steps.android-all.outputs.coordinate != ''


### PR DESCRIPTION
## Summary

#2785 grew the android-all cache retention logic to ~45 lines of Python and left it inlined **twice** — once in the integration matrix leg, once in the daemon-harness leg. That logic deletes ~200 MB coordinate directories on the runner and decides the cache key, but it could only be exercised by running a 40-minute matrix leg, and the two copies could drift apart silently.

Moves it to `.github/ci/android-all-cache-key.py`, alongside the repo's existing tested CI scripts (`change-scope.py`, `daemon-roundtrip.py`), and adds `test_android_all_cache_key.py` gated in `ci.yml`.

**No behaviour change** — same version ranking, same `MAX_COORDINATES = 3` cap, same key shape (plain name for one coordinate, `Nx-<sha256[:16]>` for several), same `::warning::` on a drop. The reasoning comments moved into the script's docstring; the workflow steps keep a pointer.

## Test plan

- `python3 .github/ci/test_android_all_cache_key.py -v` — 11 tests, all passing locally. Cases cover the two failure modes that cost real CI time:
  - a multi-SDK cell (the `wear-os-samples` render+daemon case) keeps every coordinate it fetched
  - over-cap directories are actually deleted from disk
  - the key changes if and only if the retained *set* changes, and is order-independent
  - a jarless (half-downloaded) directory is neither cached nor keyed; a missing root yields an empty key
- Both workflow files re-parse as valid YAML.
- New CI step `Run android-all cache-key tests` runs it on every PR.

Non-visual change (CI plumbing), so no render evidence applies.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V9QFVfWmNCNEWVXAf9gdPs)_