### PR TITLE
refactor(serve): resolve the Wear override policy from the catalog id, not an injected lambda

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -1683,9 +1683,6 @@ class ServeHttpServer(
             }
             .toMap()
             .let { ServeWeb.SystemDisplay.normalizeOverrideParams(sessionId, it) }
-        val normalizeOverrides: (Map<String, String>) -> Map<String, String> = {
-          ServeWeb.SystemDisplay.normalizeOverrideParams(sessionId, it)
-        }
         // Non-suspending hand-off to the socket; drop frames a slow client can't keep up with.
         val send: (String) -> Unit = { text -> outgoing.trySend(Frame.Text(text)) }
         // Optional stream tuning: codec (WebP is ~30–60% smaller; the daemon downgrades to PNG if
@@ -1712,7 +1709,7 @@ class ServeHttpServer(
               codec,
               maxFps,
               send,
-              normalizeOverrides,
+              system = sessionId,
             ) { reason ->
               if (liveUnavailableReason == null) liveUnavailableReason = reason
             }
@@ -1735,7 +1732,7 @@ class ServeHttpServer(
               previewId,
               initialOverrides,
               send,
-              normalizeOverrides = normalizeOverrides,
+              system = sessionId,
               liveUnavailableReason = liveUnavailableReason,
             )
           // Renders block (renderNow + await); keep them off the socket's event-loop thread.

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeLiveSession.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeLiveSession.kt
@@ -23,15 +23,23 @@ private constructor(
   private val codec: StreamCodec?,
   private val maxFps: Int?,
   private val send: (String) -> Unit,
-  private val normalizeOverrides: (Map<String, String>) -> Map<String, String>,
+  private val system: String,
 ) {
   @Volatile private var handle: StreamHandle? = null
+
+  /**
+   * This catalog's always-dark (and any future per-system) override policy, applied to every
+   * client-supplied override map before it is parsed. Resolved from [system] rather than injected,
+   * so a socket lane can't be wired up without it — see [ServeWeb.SystemDisplay].
+   */
+  private fun normalize(overrides: Map<String, String>): Map<String, String> =
+    ServeWeb.SystemDisplay.normalizeOverrideParams(system, overrides)
 
   /** Handle one client text message: forward input, restart the stream on new overrides, etc. */
   fun onClientMessage(text: String) {
     when (val message = ServeStreamProtocol.parseClient(text)) {
       is ServeStreamProtocol.ClientMessage.SetOverrides -> {
-        val normalized = normalizeOverrides(message.overrides)
+        val normalized = normalize(message.overrides)
         when (val parsed = ServeOverrides.parse(normalized, knobKindsFor(previewId))) {
           is OverrideParse.Invalid -> send(ServeStreamProtocol.errorMessage(parsed.message))
           is OverrideParse.Ok -> {
@@ -89,7 +97,7 @@ private constructor(
    * view intact rather than going blank.
    */
   private fun switchTo(message: ServeStreamProtocol.ClientMessage.Switch) {
-    val nextOverrides = message.overrides?.let(normalizeOverrides) ?: overrides
+    val nextOverrides = message.overrides?.let(::normalize) ?: overrides
     val parsed =
       when (val p = ServeOverrides.parse(nextOverrides, knobKindsFor(message.previewId))) {
         is OverrideParse.Invalid -> {
@@ -149,25 +157,18 @@ private constructor(
       codec: StreamCodec? = null,
       maxFps: Int? = null,
       send: (String) -> Unit,
-      normalizeOverrides: (Map<String, String>) -> Map<String, String> = { it },
+      /** Catalog id, for the per-system override policy. Required: there is no "no policy" case. */
+      system: String,
       onUnavailable: ((String) -> Unit)? = null,
     ): ServeLiveSession? {
       val knobKinds =
         ServeOverrides.declaredKnobKinds(renderHost.previews.firstOrNull { it.id == previewId })
-      val normalizedOverrides = normalizeOverrides(overrides)
+      val normalizedOverrides = ServeWeb.SystemDisplay.normalizeOverrideParams(system, overrides)
       val initial =
         (ServeOverrides.parse(normalizedOverrides, knobKinds) as? OverrideParse.Ok)?.overrides
           ?: PreviewOverrides()
       val session =
-        ServeLiveSession(
-          renderHost,
-          previewId,
-          normalizedOverrides,
-          codec,
-          maxFps,
-          send,
-          normalizeOverrides,
-        )
+        ServeLiveSession(renderHost, previewId, normalizedOverrides, codec, maxFps, send, system)
       session.handle =
         renderHost.subscribeStream(
           previewId,

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeStreamSession.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeStreamSession.kt
@@ -22,7 +22,8 @@ class ServeStreamSession(
   previewId: String,
   initialOverrides: Map<String, String> = emptyMap(),
   private val send: (String) -> Unit,
-  private val normalizeOverrides: (Map<String, String>) -> Map<String, String> = { it },
+  /** Catalog id, for the per-system override policy. Required: there is no "no policy" case. */
+  private val system: String,
   /**
    * Why this connection is on the snapshot-fallback lane rather than the live daemon stream — the
    * daemon's original failure captured by [ServeLiveSession.tryStart]'s `onUnavailable` (e.g.
@@ -37,6 +38,14 @@ class ServeStreamSession(
   private var overrides: Map<String, String> = initialOverrides
   private val seq = AtomicLong(0)
 
+  /**
+   * This catalog's always-dark (and any future per-system) override policy, applied to every
+   * client-supplied override map before it is parsed. Resolved from [system] rather than injected,
+   * so a socket lane can't be wired up without it — see [ServeWeb.SystemDisplay].
+   */
+  private fun normalize(overrides: Map<String, String>): Map<String, String> =
+    ServeWeb.SystemDisplay.normalizeOverrideParams(system, overrides)
+
   /** Push the first frame at the initial overrides when the connection opens. */
   fun onOpen() = renderCurrent()
 
@@ -46,7 +55,7 @@ class ServeStreamSession(
       is ServeStreamProtocol.ClientMessage.SetOverrides -> {
         // Validate before committing: a bad override message is reported but must not poison the
         // session — the previous (valid) overrides stay in effect for subsequent frames.
-        val normalized = normalizeOverrides(message.overrides)
+        val normalized = normalize(message.overrides)
         when (val parsed = ServeOverrides.parse(normalized, knobKindsFor(previewId))) {
           is OverrideParse.Invalid -> send(ServeStreamProtocol.errorMessage(parsed.message))
           is OverrideParse.Ok -> {
@@ -79,7 +88,7 @@ class ServeStreamSession(
     // Validate before committing either field: a bad override must leave the current preview +
     // overrides intact (so later requestFrame keeps working), mirroring setOverrides / the live
     // lane.
-    val nextOverrides = message.overrides?.let(normalizeOverrides) ?: overrides
+    val nextOverrides = message.overrides?.let(::normalize) ?: overrides
     val parsed =
       when (val p = ServeOverrides.parse(nextOverrides, knobKindsFor(message.previewId))) {
         is OverrideParse.Invalid -> {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -1,7 +1,5 @@
 package ee.schimke.composeai.cli.serve
 
-import ee.schimke.composeai.daemon.protocol.PreviewOverrides
-
 /**
  * In-code HTML/CSS/JS for the `compose-preview serve` web surface. Generated as Kotlin raw strings
  * (the house style — see [ee.schimke.composeai.cli.WebEmbed]) so the token + preview ids inject
@@ -1854,15 +1852,18 @@ object ServeWeb {
       return darkFirstIdPattern.containsMatchIn(s)
     }
 
-    /** Wear/watch renders have no day mode; discard a generic UI's accidental light override. */
+    /**
+     * Wear/watch renders have no day mode; discard a generic UI's accidental light override.
+     *
+     * Applied to the RAW parameter map — before [ServeOverrides.parse] — so every lane (render,
+     * storybook iframe, and both socket lanes) drops the override at one point, and a dropped
+     * `uiMode` never reaches the daemon as a distinct cache key. There is deliberately no
+     * post-parse twin of this: two normalizers at two layers is how one of them ends up dead.
+     */
     fun normalizeOverrideParams(
       system: String,
       overrides: Map<String, String>,
     ): Map<String, String> = if (isDarkFirst(system)) overrides - "uiMode" else overrides
-
-    /** Apply the same always-dark policy after raw override parameters have been parsed. */
-    fun normalizeOverrides(system: String, overrides: PreviewOverrides): PreviewOverrides =
-      if (isDarkFirst(system)) overrides.copy(uiMode = null) else overrides
 
     /**
      * Resolve whether [system] draws on a DARK stage, preferring the catalog's declared

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeLiveSessionTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeLiveSessionTest.kt
@@ -31,7 +31,9 @@ class ServeLiveSessionTest {
   fun `tryStart returns null when streaming is unsupported`() {
     val session = FakeRenderSession(newRenderRoot()) // streaming = false
     host(session).use { h ->
-      assertNull(ServeLiveSession.tryStart(h, previewId, emptyMap(), send = {}))
+      assertNull(
+        ServeLiveSession.tryStart(h, previewId, emptyMap(), send = {}, system = "compose-m3")
+      )
     }
   }
 
@@ -46,6 +48,7 @@ class ServeLiveSessionTest {
           previewId,
           emptyMap(),
           send = {},
+          system = "compose-m3",
           onUnavailable = { reason = it },
         )
       )
@@ -65,6 +68,7 @@ class ServeLiveSessionTest {
           previewId,
           emptyMap(),
           send = {},
+          system = "compose-m3",
           onUnavailable = { reason = it },
         )
       )
@@ -94,6 +98,7 @@ class ServeLiveSessionTest {
           previewId,
           emptyMap(),
           send = {},
+          system = "compose-m3",
           onUnavailable = { reason = it },
         )
       )
@@ -106,7 +111,9 @@ class ServeLiveSessionTest {
     val session = FakeRenderSession(newRenderRoot(), streaming = true)
     host(session).use { h ->
       val sent = CopyOnWriteArrayList<String>()
-      assertNotNull(ServeLiveSession.tryStart(h, previewId, emptyMap(), send = sent::add))
+      assertNotNull(
+        ServeLiveSession.tryStart(h, previewId, emptyMap(), send = sent::add, system = "compose-m3")
+      )
       val fsid = assertNotNull(session.lastFrameStreamId)
       val payload = Base64.getEncoder().encodeToString("xy".toByteArray())
 
@@ -126,7 +133,15 @@ class ServeLiveSessionTest {
     host(session).use { h ->
       val sent = CopyOnWriteArrayList<String>()
       assertNotNull(
-        ServeLiveSession.tryStart(h, previewId, emptyMap(), StreamCodec.WEBP, null, sent::add)
+        ServeLiveSession.tryStart(
+          h,
+          previewId,
+          emptyMap(),
+          StreamCodec.WEBP,
+          null,
+          sent::add,
+          system = "compose-m3",
+        )
       )
       assertEquals(StreamCodec.WEBP, session.lastCodec)
       session.emitStreamFrame(
@@ -145,7 +160,9 @@ class ServeLiveSessionTest {
     val session = FakeRenderSession(newRenderRoot(), streaming = true)
     host(session).use { h ->
       val sent = CopyOnWriteArrayList<String>()
-      assertNotNull(ServeLiveSession.tryStart(h, previewId, emptyMap(), send = sent::add))
+      assertNotNull(
+        ServeLiveSession.tryStart(h, previewId, emptyMap(), send = sent::add, system = "compose-m3")
+      )
       session.emitStreamFrame(
         assertNotNull(session.lastFrameStreamId),
         seq = 0,
@@ -159,7 +176,10 @@ class ServeLiveSessionTest {
   fun `input messages dispatch interactive input`() {
     val session = FakeRenderSession(newRenderRoot(), streaming = true)
     host(session).use { h ->
-      val live = assertNotNull(ServeLiveSession.tryStart(h, previewId, emptyMap(), send = {}))
+      val live =
+        assertNotNull(
+          ServeLiveSession.tryStart(h, previewId, emptyMap(), send = {}, system = "compose-m3")
+        )
       live.onClientMessage("""{"type":"input","kind":"click","pixelX":10,"pixelY":20}""")
       assertEquals(1, session.interactiveInputs.size)
       val input = session.interactiveInputs[0]
@@ -173,7 +193,10 @@ class ServeLiveSessionTest {
   fun `pointer drag, scroll and key inputs are forwarded with their fields`() {
     val session = FakeRenderSession(newRenderRoot(), streaming = true)
     host(session).use { h ->
-      val live = assertNotNull(ServeLiveSession.tryStart(h, previewId, emptyMap(), send = {}))
+      val live =
+        assertNotNull(
+          ServeLiveSession.tryStart(h, previewId, emptyMap(), send = {}, system = "compose-m3")
+        )
       live.onClientMessage(
         """{"type":"input","kind":"pointerDown","pixelX":3,"pixelY":4,"pointerId":1}"""
       )
@@ -209,7 +232,15 @@ class ServeLiveSessionTest {
     host(session).use { h ->
       val sent = CopyOnWriteArrayList<String>()
       val live =
-        assertNotNull(ServeLiveSession.tryStart(h, previewId, emptyMap(), send = sent::add))
+        assertNotNull(
+          ServeLiveSession.tryStart(
+            h,
+            previewId,
+            emptyMap(),
+            send = sent::add,
+            system = "compose-m3",
+          )
+        )
       live.onClientMessage("""{"type":"input","kind":"telepathy"}""")
       assertEquals("error", typeOf(sent.last()))
       assertTrue(session.interactiveInputs.isEmpty())
@@ -220,7 +251,10 @@ class ServeLiveSessionTest {
   fun `setOverrides restarts the held stream`() {
     val session = FakeRenderSession(newRenderRoot(), streaming = true)
     host(session).use { h ->
-      val live = assertNotNull(ServeLiveSession.tryStart(h, previewId, emptyMap(), send = {}))
+      val live =
+        assertNotNull(
+          ServeLiveSession.tryStart(h, previewId, emptyMap(), send = {}, system = "compose-m3")
+        )
       val first = assertNotNull(session.lastFrameStreamId)
       assertEquals(1, session.streamStarts.get())
 
@@ -232,10 +266,12 @@ class ServeLiveSessionTest {
   }
 
   @Test
-  fun `override normalizer applies to live setOverrides and switch messages`() {
+  fun `a dark-first system drops uiMode from live setOverrides and switch messages`() {
     val session = FakeRenderSession(newRenderRoot(), streaming = true)
     host(session).use { h ->
       val sent = CopyOnWriteArrayList<String>()
+      // The REAL per-system policy, resolved from the catalog id — not an injected stand-in. A
+      // uiMode the parser would reject proves it was dropped before parsing.
       val live =
         assertNotNull(
           ServeLiveSession.tryStart(
@@ -243,7 +279,7 @@ class ServeLiveSessionTest {
             previewId,
             emptyMap(),
             send = sent::add,
-            normalizeOverrides = { it - "uiMode" },
+            system = "confetti-wear",
           )
         )
 
@@ -258,13 +294,42 @@ class ServeLiveSessionTest {
   }
 
   @Test
+  fun `a light-capable system keeps uiMode on the live lane`() {
+    val session = FakeRenderSession(newRenderRoot(), streaming = true)
+    host(session).use { h ->
+      val sent = CopyOnWriteArrayList<String>()
+      val live =
+        assertNotNull(
+          ServeLiveSession.tryStart(
+            h,
+            previewId,
+            emptyMap(),
+            send = sent::add,
+            system = "compose-m3",
+          )
+        )
+
+      // Same message, non-Wear catalog: the override reaches the parser, which rejects the bogus
+      // value and does NOT restart the stream.
+      live.onClientMessage("""{"type":"setOverrides","overrides":{"uiMode":"chartreuse"}}""")
+
+      assertEquals(1, session.streamStarts.get())
+      assertTrue(sent.any { typeOf(it) == "error" })
+    }
+  }
+
+  @Test
   fun `two live sessions for the same preview share one daemon stream`() {
     val session = FakeRenderSession(newRenderRoot(), streaming = true)
     host(session).use { h ->
       val a = CopyOnWriteArrayList<String>()
       val b = CopyOnWriteArrayList<String>()
-      assertNotNull(ServeLiveSession.tryStart(h, previewId, emptyMap(), send = a::add))
-      assertNotNull(ServeLiveSession.tryStart(h, previewId, emptyMap(), send = b::add))
+      assertNotNull(
+        ServeLiveSession.tryStart(h, previewId, emptyMap(), send = a::add, system = "compose-m3")
+      )
+      assertNotNull(
+        ServeLiveSession.tryStart(h, previewId, emptyMap(), send = b::add, system = "compose-m3")
+      )
 
       assertEquals(1, session.streamStarts.get(), "two clients should ride one daemon stream/start")
       assertEquals(1, h.activeStreamCount())
@@ -290,7 +355,10 @@ class ServeLiveSessionTest {
         renderTimeoutSeconds = 30,
       )
       .use { h ->
-        val live = assertNotNull(ServeLiveSession.tryStart(h, previewId, emptyMap(), send = {}))
+        val live =
+          assertNotNull(
+            ServeLiveSession.tryStart(h, previewId, emptyMap(), send = {}, system = "compose-m3")
+          )
         val firstFsid = assertNotNull(session.lastFrameStreamId)
         assertEquals(1, session.streamStarts.get())
 
@@ -311,7 +379,15 @@ class ServeLiveSessionTest {
     host(session).use { h ->
       val sent = CopyOnWriteArrayList<String>()
       val live =
-        assertNotNull(ServeLiveSession.tryStart(h, previewId, emptyMap(), send = sent::add))
+        assertNotNull(
+          ServeLiveSession.tryStart(
+            h,
+            previewId,
+            emptyMap(),
+            send = sent::add,
+            system = "compose-m3",
+          )
+        )
       val fsid = assertNotNull(session.lastFrameStreamId)
 
       live.onClientMessage("""{"type":"switch","previewId":"com.example.Missing"}""")
@@ -328,7 +404,10 @@ class ServeLiveSessionTest {
   fun `closing the live session stops the stream`() {
     val session = FakeRenderSession(newRenderRoot(), streaming = true)
     host(session).use { h ->
-      val live = assertNotNull(ServeLiveSession.tryStart(h, previewId, emptyMap(), send = {}))
+      val live =
+        assertNotNull(
+          ServeLiveSession.tryStart(h, previewId, emptyMap(), send = {}, system = "compose-m3")
+        )
       val fsid = assertNotNull(session.lastFrameStreamId)
       live.close()
       assertEquals(listOf(fsid), session.streamStops)

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeStreamSessionTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeStreamSessionTest.kt
@@ -38,7 +38,7 @@ class ServeStreamSessionTest {
   fun `onOpen pushes one frame`() {
     host().use { h ->
       val sent = CopyOnWriteArrayList<String>()
-      ServeStreamSession(h, previewId, emptyMap(), sent::add).onOpen()
+      ServeStreamSession(h, previewId, emptyMap(), sent::add, system = "compose-m3").onOpen()
       assertEquals(1, sent.size)
       assertEquals("frame", typeOf(sent[0]))
     }
@@ -48,7 +48,7 @@ class ServeStreamSessionTest {
   fun `setOverrides re-renders and the frame reflects the new overrides`() {
     host().use { h ->
       val sent = CopyOnWriteArrayList<String>()
-      val session = ServeStreamSession(h, previewId, emptyMap(), sent::add)
+      val session = ServeStreamSession(h, previewId, emptyMap(), sent::add, system = "compose-m3")
       session.onOpen()
       session.onClientMessage("""{"type":"setOverrides","overrides":{"uiMode":"dark"}}""")
 
@@ -63,17 +63,13 @@ class ServeStreamSessionTest {
   }
 
   @Test
-  fun `override normalizer applies to setOverrides and switch messages`() {
+  fun `a dark-first system drops uiMode from setOverrides and switch messages`() {
     host().use { h ->
       val sent = CopyOnWriteArrayList<String>()
+      // The REAL per-system policy, resolved from the catalog id — not an injected stand-in. A
+      // uiMode the parser would reject proves it was dropped before parsing.
       val session =
-        ServeStreamSession(
-          h,
-          previewId,
-          emptyMap(),
-          sent::add,
-          normalizeOverrides = { it - "uiMode" },
-        )
+        ServeStreamSession(h, previewId, emptyMap(), sent::add, system = "confetti-wear")
       session.onClientMessage("""{"type":"setOverrides","overrides":{"uiMode":"chartreuse"}}""")
       session.onClientMessage(
         """{"type":"switch","previewId":"$previewId","overrides":{"uiMode":"light"}}"""
@@ -84,10 +80,23 @@ class ServeStreamSessionTest {
   }
 
   @Test
+  fun `a light-capable system keeps uiMode on the socket lane`() {
+    host().use { h ->
+      val sent = CopyOnWriteArrayList<String>()
+      val session = ServeStreamSession(h, previewId, emptyMap(), sent::add, system = "compose-m3")
+      // Same message, non-Wear catalog: the override reaches the parser, which rejects the bogus
+      // value. If normalization ever leaked to every system, this would silently become a frame.
+      session.onClientMessage("""{"type":"setOverrides","overrides":{"uiMode":"chartreuse"}}""")
+
+      assertEquals(listOf("error"), sent.map(::typeOf))
+    }
+  }
+
+  @Test
   fun `seq is monotonic across frames`() {
     host().use { h ->
       val sent = CopyOnWriteArrayList<String>()
-      val session = ServeStreamSession(h, previewId, emptyMap(), sent::add)
+      val session = ServeStreamSession(h, previewId, emptyMap(), sent::add, system = "compose-m3")
       session.onOpen()
       session.onClientMessage("""{"type":"requestFrame"}""")
       session.onClientMessage("""{"type":"requestFrame"}""")
@@ -102,7 +111,7 @@ class ServeStreamSessionTest {
   fun `invalid overrides produce an error frame, not a crash, and the lane stays open`() {
     host().use { h ->
       val sent = CopyOnWriteArrayList<String>()
-      val session = ServeStreamSession(h, previewId, emptyMap(), sent::add)
+      val session = ServeStreamSession(h, previewId, emptyMap(), sent::add, system = "compose-m3")
       session.onClientMessage("""{"type":"setOverrides","overrides":{"uiMode":"chartreuse"}}""")
       assertEquals("error", typeOf(sent.last()))
       // Still usable afterwards.
@@ -121,7 +130,7 @@ class ServeStreamSessionTest {
       )
       .use { h ->
         val sent = CopyOnWriteArrayList<String>()
-        val session = ServeStreamSession(h, previewId, emptyMap(), sent::add)
+        val session = ServeStreamSession(h, previewId, emptyMap(), sent::add, system = "compose-m3")
         session.onOpen()
         session.onClientMessage("""{"type":"switch","previewId":"$blue"}""")
         assertEquals(2, sent.size)
@@ -133,7 +142,7 @@ class ServeStreamSessionTest {
   fun `switch to an unknown preview errors and keeps the current one`() {
     host().use { h ->
       val sent = CopyOnWriteArrayList<String>()
-      val session = ServeStreamSession(h, previewId, emptyMap(), sent::add)
+      val session = ServeStreamSession(h, previewId, emptyMap(), sent::add, system = "compose-m3")
       session.onOpen()
       session.onClientMessage("""{"type":"switch","previewId":"com.example.Missing"}""")
       assertEquals("error", typeOf(sent.last()))
@@ -146,7 +155,7 @@ class ServeStreamSessionTest {
   fun `switch with invalid overrides errors and keeps the working view`() {
     host().use { h ->
       val sent = CopyOnWriteArrayList<String>()
-      val session = ServeStreamSession(h, previewId, emptyMap(), sent::add)
+      val session = ServeStreamSession(h, previewId, emptyMap(), sent::add, system = "compose-m3")
       session.onOpen()
       session.onClientMessage(
         """{"type":"switch","previewId":"$previewId","overrides":{"uiMode":"chartreuse"}}"""
@@ -168,6 +177,7 @@ class ServeStreamSessionTest {
           previewId,
           emptyMap(),
           sent::add,
+          system = "compose-m3",
           liveUnavailableReason =
             "the daemon could not hold an interactive session for this preview",
         )
@@ -187,7 +197,7 @@ class ServeStreamSessionTest {
     host().use { h ->
       val sent = CopyOnWriteArrayList<String>()
       // No liveUnavailableReason (e.g. a backend that returned null without one).
-      val session = ServeStreamSession(h, previewId, emptyMap(), sent::add)
+      val session = ServeStreamSession(h, previewId, emptyMap(), sent::add, system = "compose-m3")
       session.onClientMessage("""{"type":"input","kind":"click","pixelX":1,"pixelY":1}""")
       assertEquals("input requires a live stream", messageOf(sent.single()))
     }
@@ -197,7 +207,8 @@ class ServeStreamSessionTest {
   fun `unsupported message yields an error`() {
     host().use { h ->
       val sent = CopyOnWriteArrayList<String>()
-      ServeStreamSession(h, previewId, emptyMap(), sent::add).onClientMessage("""{"type":"nope"}""")
+      ServeStreamSession(h, previewId, emptyMap(), sent::add, system = "compose-m3")
+        .onClientMessage("""{"type":"nope"}""")
       assertEquals("error", typeOf(sent.single()))
     }
   }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -1,8 +1,6 @@
 package ee.schimke.composeai.cli.serve
 
-import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.daemon.protocol.RemoteNamedValue
-import ee.schimke.composeai.daemon.protocol.UiMode
 import ee.schimke.composeai.data.overrides.PreviewOverrideDeclaration
 import ee.schimke.composeai.data.overrides.PreviewOverrideType
 import ee.schimke.composeai.data.overrides.PreviewOverrideValue
@@ -1313,22 +1311,13 @@ class ServeWebFixtureTest {
         !viewerGestures.contains("cp-theme:compose-m3"),
       "a viewer reads only its own catalog's sticky theme",
     )
-    assertNull(
-      ServeWeb.SystemDisplay.normalizeOverrides(
-          "confetti-wear",
-          PreviewOverrides(uiMode = UiMode.LIGHT),
-        )
-        .uiMode,
-      "Wear ignores the generic light override",
-    )
     assertEquals(
-      UiMode.LIGHT,
-      ServeWeb.SystemDisplay.normalizeOverrides(
-          "compose-m3",
-          PreviewOverrides(uiMode = UiMode.LIGHT),
-        )
-        .uiMode,
-      "non-Wear systems retain day/night overrides",
+      mapOf("fontScale" to "1.5"),
+      ServeWeb.SystemDisplay.normalizeOverrideParams(
+        "confetti-wear",
+        mapOf("uiMode" to "light", "fontScale" to "1.5"),
+      ),
+      "normalizing drops only uiMode — every other override survives",
     )
 
     // The sticky theme toggle appears only for a catalog with light/dark pairs, and each paired


### PR DESCRIPTION
## Summary

Follow-up to #2793 / #2800. Two problems with how the Wear always-dark override policy ended up wired:

1. **A policy parameter that defaults to "no policy".** `ServeLiveSession.tryStart` and `ServeStreamSession` took it as `(Map<String,String>) -> Map<String,String> = { it }`. A default that *disables* the policy means the next construction site silently loses Wear normalization, with nothing to catch it. Both now take the catalog id (`system: String`, required, no default) and call `ServeWeb.SystemDisplay.normalizeOverrideParams` themselves — there is no "no policy" case to express.

2. **The tests never exercised the real policy.** Both injected `normalizeOverrides = { it - "uiMode" }`, so they proved a stand-in worked, not the wiring. They now pass a real catalog id, and each lane gains its mirror case: a Wear catalog drops `uiMode`, a non-Wear catalog keeps it and still rejects a bogus value. If normalization ever leaked to every system — or stopped reaching a lane — one of the two fails.

3. **Dead twin removed.** `SystemDisplay.normalizeOverrides(system, PreviewOverrides)` (the post-parse variant) lost its last production caller in #2800 when the param-level normalizer replaced it, but stayed behind with its own tests — coverage for code nothing ran. Deleted, with a note on the survivor saying why there is deliberately only one.

No behaviour change: the same catalogs drop the same override at the same point.

## Test plan

- `./gradlew :cli:test --tests '*Serve*'` — green locally.
- New: `a light-capable system keeps uiMode on the socket lane` / `…on the live lane` (both assert the non-Wear path still parses and rejects, and that the live lane does *not* restart the stream).
- Rewritten: the two normalizer tests now drive the real `SystemDisplay` policy via `system = "confetti-wear"`.
- `ServeWebFixtureTest` keeps the param-level assertions and gains one that only `uiMode` is dropped (a sibling `fontScale` override survives).
- `ktfmtFormat` clean.

Non-visual change — no rendered output differs, so no before/after images apply (the golden page fixtures are unchanged, which is itself the check).

---
_Generated by [Claude Code](https://claude.ai/code/session_01V9QFVfWmNCNEWVXAf9gdPs)_