### PR TITLE
fix(serve): attribute every homepage section by provenance, not by catalog id

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -1539,35 +1539,15 @@ object ServeWeb {
       </div>
       """
         .trimIndent()
-    val designSystemIds = setOf("compose-m3", "remote-m3", "wear-m3")
-    val androidComposeSampleIds =
-      setOf("jetnews", "jetcaster", "jetchat", "jetsnack", "jetlagged", "reply")
-    val designSystems = systems.filter { it.system in designSystemIds }
-    val androidComposeSampleRepos = setOf("android/compose-samples", "yschimke/compose-samples")
-    val androidComposeSamples = systems.filter {
-      it.system in androidComposeSampleIds && it.sourceRepo in androidComposeSampleRepos
-    }
-    val remaining = systems.filterNot {
-      it.system in designSystemIds || it in androidComposeSamples
-    }
-    val yschimkeSystems = remaining.filter { it.sourceRepo?.startsWith("yschimke/") == true }
-    val otherSystems = remaining - yschimkeSystems.toSet()
-    val sections =
-      listOf(
-          Triple("Design Systems", designSystems, "design system(s)"),
-          Triple("android/compose-samples", androidComposeSamples, "sample(s)"),
-          Triple("yschimke org", yschimkeSystems, "catalog(s)"),
-          Triple("Other", otherSystems, "catalog(s)"),
-        )
-        .filter { (_, list, _) -> list.isNotEmpty() }
+    val sections = homeSections(systems)
     val body =
       if (systems.isEmpty()) {
         "<h1 class=\"cp-head\">Design Systems</h1>\n" +
           "<p class=\"cp-sub\">No design systems are configured on this server.</p>"
       } else {
         sections
-          .mapIndexed { index, (heading, list, noun) ->
-            section(heading, list, noun, if (index == 0) "cp-grid" else "cp-grid-$index")
+          .mapIndexed { index, s ->
+            section(s.heading, s.systems, s.noun, if (index == 0) "cp-grid" else "cp-grid-$index")
           }
           .joinToString("\n")
       }
@@ -1579,6 +1559,61 @@ object ServeWeb {
         """
           .trimIndent(),
     )
+  }
+
+  /**
+   * One publisher-grouped section of the front page: its heading, its cards, and its count noun.
+   */
+  data class HomeSection(val heading: String, val systems: List<HomeSystem>, val noun: String)
+
+  /**
+   * Group the published catalogs by **publisher**, for the front-page sections.
+   *
+   * Attribution is decided by [HomeSystem.sourceRepo] — the repository the catalog was generated
+   * from — because that is the only field that says who *wrote* the components. Neither of the
+   * alternatives works:
+   * * The **catalog id** is claimed by whoever publishes it. A third-party catalog served as
+   *   `compose-m3` or `jetnews` would otherwise be presented as an official design system or one of
+   *   Android's samples, purely for picking that name.
+   * * The **trust verdict** names the branch the bytes were *fetched* from, which is a delivery
+   *   detail: Android's samples are currently fetched from preview branches in the
+   *   `yschimke/compose-samples` fork, and grouping on that would credit the fork owner for
+   *   Android's work.
+   *
+   * The known ids are still required alongside the repo (a repo publishing an unrelated catalog
+   * doesn't make it a design system), so the two must agree for a curated section to claim a card.
+   * A catalog with no provenance falls to "Other" — unattributed, never promoted.
+   */
+  internal fun homeSections(systems: List<HomeSystem>): List<HomeSection> {
+    fun published(ids: Set<String>, repos: Set<String>): (HomeSystem) -> Boolean = { s ->
+      s.system in ids && s.sourceRepo in repos
+    }
+
+    val isDesignSystem =
+      published(
+        ids = setOf("compose-m3", "remote-m3", "wear-m3"),
+        repos = setOf("yschimke/compose-ai-tools"),
+      )
+    val isAndroidSample =
+      published(
+        ids = setOf("jetnews", "jetcaster", "jetchat", "jetsnack", "jetlagged", "reply"),
+        // The preview branches currently live in the fork; both spellings are Android's samples.
+        repos = setOf("android/compose-samples", "yschimke/compose-samples"),
+      )
+
+    val designSystems = systems.filter(isDesignSystem)
+    val androidComposeSamples = systems.filter(isAndroidSample)
+    val remaining = systems.filterNot { isDesignSystem(it) || isAndroidSample(it) }
+    val yschimkeSystems = remaining.filter { it.sourceRepo?.startsWith("yschimke/") == true }
+    val otherSystems = remaining.filterNot { it.sourceRepo?.startsWith("yschimke/") == true }
+
+    return listOf(
+        HomeSection("Design Systems", designSystems, "design system(s)"),
+        HomeSection("android/compose-samples", androidComposeSamples, "sample(s)"),
+        HomeSection("yschimke org", yschimkeSystems, "catalog(s)"),
+        HomeSection("Other", otherSystems, "catalog(s)"),
+      )
+      .filter { it.systems.isNotEmpty() }
   }
 
   /**

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -391,6 +391,7 @@ class ServeWebFixtureTest {
             subtitle = "androidx.compose.material3:material3",
             previewCount = 42,
             trust = "branch:yschimke/compose-ai-tools@design-artifacts/compose-m3",
+            sourceRepo = "yschimke/compose-ai-tools",
             heroPreviewId = "button-filled__ideal__default__light",
             // The normal path: a prebaked, content-hashed hero on the immutable `/hero/` lane, the
             // crop already in its pixels. Captured here so the golden pins the fast markup — eager
@@ -408,6 +409,7 @@ class ServeWebFixtureTest {
             subtitle = "androidx.wear.compose:compose-material3",
             previewCount = 18,
             trust = "branch:yschimke/compose-ai-tools@design-artifacts/wear-m3",
+            sourceRepo = "yschimke/compose-ai-tools",
             heroPreviewId = "button-filled__ideal__default__light",
             heroImage =
               ServeWeb.HeroImage(
@@ -424,6 +426,7 @@ class ServeWebFixtureTest {
             subtitle = "androidx.wear.compose.remote:remote-material3",
             previewCount = 6,
             trust = "branch:yschimke/compose-ai-tools@design-artifacts/remote-m3",
+            sourceRepo = "yschimke/compose-ai-tools",
             heroPreviewId = "Button-Filled__ideal__default__light",
             // Remote Compose draws the dark-first Wear scheme, so its catalog declares
             // `display.surface: "dark"` and the hero backs on the dark stage too.

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebThumbCropTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebThumbCropTest.kt
@@ -1,6 +1,7 @@
 package ee.schimke.composeai.cli.serve
 
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -126,5 +127,65 @@ class ServeWebThumbCropTest {
     assertFalse(html.contains("<h1 class=\"cp-head\">android/compose-samples</h1>"))
     assertTrue(html.contains("<h1 class=\"cp-head\">Other</h1>"))
     assertTrue(html.contains("href=\"/jetnews/\""))
+  }
+
+  @Test
+  fun `a reused design-system id is attributed to its actual catalog repository`() {
+    // The same spoof the sample ids are already guarded against: a catalog id is claimed by
+    // whoever publishes it, so `compose-m3` from someone else must not read as the official
+    // design system on the public front door.
+    val impostor =
+      ServeWeb.HomeSystem(
+        system = "compose-m3",
+        title = "Definitely Material 3",
+        subtitle = null,
+        previewCount = 1,
+        trust = "branch:someorg/unrelated@design-artifacts/compose-m3",
+        sourceRepo = "someorg/unrelated",
+        heroPreviewId = null,
+      )
+
+    val sections = ServeWeb.homeSections(listOf(impostor))
+
+    assertEquals(listOf("Other"), sections.map { it.heading })
+  }
+
+  @Test
+  fun `the real design systems are grouped by their source repository`() {
+    val real =
+      listOf("compose-m3", "wear-m3", "remote-m3").map { id ->
+        ServeWeb.HomeSystem(
+          system = id,
+          title = id,
+          subtitle = null,
+          previewCount = 1,
+          trust = "branch:yschimke/compose-ai-tools@design-artifacts/$id",
+          sourceRepo = "yschimke/compose-ai-tools",
+          heroPreviewId = null,
+        )
+      }
+
+    val sections = ServeWeb.homeSections(real)
+
+    assertEquals(listOf("Design Systems"), sections.map { it.heading })
+    assertEquals(3, sections.single().systems.size)
+  }
+
+  @Test
+  fun `a catalog with no provenance is never promoted into a curated section`() {
+    // Unattributed bytes: an old catalog with no provenance carries no publisher claim at all, so
+    // it lands in Other rather than inheriting a curated section from its id.
+    val unattributed =
+      ServeWeb.HomeSystem(
+        system = "wear-m3",
+        title = "Wear Compose Material 3",
+        subtitle = null,
+        previewCount = 1,
+        trust = null,
+        sourceRepo = null,
+        heroPreviewId = null,
+      )
+
+    assertEquals(listOf("Other"), ServeWeb.homeSections(listOf(unattributed)).map { it.heading })
   }
 }


### PR DESCRIPTION
## Summary

#2798 grouped Android's samples by catalog id; #2801 corrected that by also requiring `sourceRepo`, because a catalog id is claimed by whoever publishes it. But it only fixed the samples — **the design systems still matched on id alone**, so a third-party catalog served as `compose-m3` / `wear-m3` / `remote-m3` was presented under "Design Systems" on the public front door, exactly the spoof the samples are now guarded against.

- Every section groups on `sourceRepo` (the repo the catalog was generated from) paired with its known ids, so the two must agree before a curated section claims a card.
- A catalog with **no provenance** now lands in "Other" instead of inheriting a curated section from its name.
- The policy moved out of the HTML builder into `ServeWeb.homeSections(...)`, returning a typed `HomeSection` list — so attribution can be asserted directly instead of by scraping `<h1>` text, and the id/repo pairs read as data rather than four `filter`s over inline literals. That also drops the `it in androidComposeSamples` list-containment scan #2801 introduced.

## Test plan

- `./gradlew :cli:test --tests '*ServeWeb*'` — green.
- New in `ServeWebThumbCropTest`:
  - `a reused design-system id is attributed to its actual catalog repository` — `compose-m3` from `someorg/unrelated` → "Other"
  - `the real design systems are grouped by their source repository` — the three real ids from `yschimke/compose-ai-tools` → one "Design Systems" section
  - `a catalog with no provenance is never promoted into a curated section`
- Existing sample-attribution tests unchanged and still passing.
- `ServeWebFixtureTest` now supplies `sourceRepo` on the design-system cards, mirroring production (`homeSystemsFor` fills it from `provenance.repo`).

## Visual evidence

None needed: **the `serve-home-index.html` golden is byte-identical** — the working tree shows no fixture change after the run, which is the check that the real front page renders exactly as before. Only mis-attributed (spoofed or unattributed) catalogs move, and none exist on the live server.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V9QFVfWmNCNEWVXAf9gdPs)_