### PR TITLE
fix(renderer): stop swallowing locale-local reflection failures, and cache the lookup

### DIFF
--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/LocaleCompositionLocals.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/LocaleCompositionLocals.kt
@@ -96,24 +96,44 @@ object LocaleCompositionLocals {
     }
   }
 
-  @Suppress("UNCHECKED_CAST")
-  private fun resolve(classLoader: ClassLoader, findClass: (String) -> Class<*>): Resolution =
-    try {
-      val compositionLocals = findClass("androidx.compose.ui.platform.CompositionLocalsKt")
-      val local =
-        compositionLocals.getMethod("getLocalProvidableLocaleList").invoke(null)
-          as ProvidableCompositionLocal<Any>
+  /**
+   * Resolve in two steps, because the same exception means different things either side of the
+   * line: **before** the local is found, a missing class or accessor is just an older Compose UI;
+   * **after** it, the locale locals demonstrably exist, so anything that then fails to line up —
+   * including a `LocaleList` without the `String` constructor — is a present-but-incompatible
+   * classpath, which is exactly what must be reported rather than silently ignored.
+   */
+  private fun resolve(classLoader: ClassLoader, findClass: (String) -> Class<*>): Resolution {
+    val local = findProvidableLocaleList(classLoader, findClass) ?: return Resolution.Absent
+    return try {
       val localeListClass = findClass("androidx.compose.ui.text.intl.LocaleList")
       Resolution.Bound(local, localeListClass.getConstructor(String::class.java))
+    } catch (e: ReflectiveOperationException) {
+      report(classLoader, "LocalProvidableLocaleList found but LocaleList(String) is not usable", e)
+      Resolution.Absent
+    }
+  }
+
+  /** The providable local, or null when this Compose UI simply predates it (silent, expected). */
+  @Suppress("UNCHECKED_CAST")
+  private fun findProvidableLocaleList(
+    classLoader: ClassLoader,
+    findClass: (String) -> Class<*>,
+  ): ProvidableCompositionLocal<Any>? =
+    try {
+      findClass("androidx.compose.ui.platform.CompositionLocalsKt")
+        .getMethod("getLocalProvidableLocaleList")
+        .invoke(null) as ProvidableCompositionLocal<Any>
     } catch (_: ClassNotFoundException) {
       // Compose UI older than the locale locals — the compat-BOM case. Nothing to say.
-      Resolution.Absent
+      null
     } catch (_: NoSuchMethodException) {
       // Same: the accessor arrived with the locals, so its absence means an older Compose UI.
-      Resolution.Absent
+      null
     } catch (e: ReflectiveOperationException) {
-      report(classLoader, "locale composition locals found but unusable", e)
-      Resolution.Absent
+      // The class is there but the accessor won't yield a local — not a version gap.
+      report(classLoader, "LocalProvidableLocaleList accessor is not usable", e)
+      null
     }
 
   private fun report(classLoader: ClassLoader, what: String, e: Throwable) {

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/LocaleCompositionLocals.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/LocaleCompositionLocals.kt
@@ -2,8 +2,10 @@ package ee.schimke.composeai.renderer
 
 import android.content.res.Configuration
 import android.os.Build
-import androidx.compose.runtime.ProvidedValue
 import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.ProvidedValue
+import java.lang.reflect.Constructor
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Bridges the locale from the preview's Robolectric [Configuration] into the locale composition
@@ -22,31 +24,110 @@ import androidx.compose.runtime.ProvidableCompositionLocal
  * platform-derived public local. The other addition, runtime's `LocalRetainedValuesStore`, is
  * lifecycle state owned and installed by the composition host itself; synthesizing it here would
  * break retention semantics.
+ *
+ * Two failures are deliberately told apart, because they mean opposite things:
+ * * **[Resolution.Absent]** — this classpath's Compose UI predates the locale locals. Expected on
+ *   the compat BOM, so it stays silent, and it's cached: the miss then costs one lookup per class
+ *   loader instead of a thrown `ClassNotFoundException` per composition.
+ * * **anything else** — the symbols are there but couldn't be used (a renamed accessor, a changed
+ *   `LocaleList` constructor, an unparseable language tag). That's a renderer bug or an upstream
+ *   break, not a compatibility case, so it's reported on stderr rather than swallowed into a
+ *   silently wrong default locale.
  */
 object LocaleCompositionLocals {
-  @Suppress("UNCHECKED_CAST")
+
+  /** What one class loader's Compose UI offers, resolved once. See [resolve]. */
+  private sealed interface Resolution {
+    /** The locale locals exist here: the providable local, plus `LocaleList(String)`. */
+    data class Bound(
+      val local: ProvidableCompositionLocal<Any>,
+      val localeListConstructor: Constructor<*>,
+    ) : Resolution
+
+    /** This Compose UI has no locale locals — the expected case on the 1.9 compat BOM. */
+    data object Absent : Resolution
+  }
+
+  /**
+   * Per-class-loader resolution cache. The daemon renders thousands of previews per process and
+   * every composition asks for this, so neither the reflective lookup nor — in the far more common
+   * [Resolution.Absent] case — the cost of *throwing* `ClassNotFoundException` should be paid per
+   * render. Keyed by class loader because one daemon can host preview bytecode from several.
+   */
+  private val resolutions = ConcurrentHashMap<ClassLoader, Resolution>()
+
+  /** Reported at most once per class loader, so a broken classpath says so without spamming. */
+  private val reportedFailures = ConcurrentHashMap.newKeySet<ClassLoader>()
+
+  private val defaultClassLoader: ClassLoader
+    get() = LocaleCompositionLocals::class.java.classLoader ?: ClassLoader.getSystemClassLoader()
+
+  /**
+   * `LocalProvidableLocaleList provides LocaleList(<tags>)` for [configuration], or null when this
+   * Compose UI has no locale locals (or the bridge could not be built — see the class docs).
+   */
   fun providedValue(
     configuration: Configuration,
-    classLoader: ClassLoader =
-      LocaleCompositionLocals::class.java.classLoader ?: ClassLoader.getSystemClassLoader(),
-  ): ProvidedValue<*>? =
-    runCatching {
-        val compositionLocals =
-          Class.forName("androidx.compose.ui.platform.CompositionLocalsKt", false, classLoader)
-        val local =
-          compositionLocals.getMethod("getLocalProvidableLocaleList").invoke(null)
-            as ProvidableCompositionLocal<Any>
-        val localeListClass =
-          Class.forName("androidx.compose.ui.text.intl.LocaleList", false, classLoader)
-        val localeList =
-          localeListClass.getConstructor(String::class.java).newInstance(languageTags(configuration))
-        local provides localeList
-      }
-      .getOrNull()
+    classLoader: ClassLoader = defaultClassLoader,
+  ): ProvidedValue<*>? = providedValue(languageTags(configuration), classLoader)
+
+  /**
+   * The reflective half, split from the [Configuration] reading so a test can drive it directly.
+   *
+   * [findClass] is the seam a test substitutes to stand in a newer Compose UI: a stub *class
+   * loader* can't do it, because `Class.forName` rejects a class whose name doesn't match the one
+   * requested, and Robolectric's sandbox resolves `Class.forName` against its own loader anyway.
+   * Production always uses the default, which is exactly what the daemon runs.
+   */
+  internal fun providedValue(
+    languageTags: String,
+    classLoader: ClassLoader,
+    findClass: (String) -> Class<*> = { Class.forName(it, false, classLoader) },
+  ): ProvidedValue<*>? {
+    val bound =
+      resolutions.computeIfAbsent(classLoader) { resolve(it, findClass) } as? Resolution.Bound
+        ?: return null
+    return try {
+      bound.local provides bound.localeListConstructor.newInstance(languageTags)
+    } catch (e: ReflectiveOperationException) {
+      // The locals ARE present, so this is a real break rather than an old-Compose classpath.
+      report(classLoader, "could not build LocaleList(\"$languageTags\")", e)
+      null
+    }
+  }
+
+  @Suppress("UNCHECKED_CAST")
+  private fun resolve(classLoader: ClassLoader, findClass: (String) -> Class<*>): Resolution =
+    try {
+      val compositionLocals = findClass("androidx.compose.ui.platform.CompositionLocalsKt")
+      val local =
+        compositionLocals.getMethod("getLocalProvidableLocaleList").invoke(null)
+          as ProvidableCompositionLocal<Any>
+      val localeListClass = findClass("androidx.compose.ui.text.intl.LocaleList")
+      Resolution.Bound(local, localeListClass.getConstructor(String::class.java))
+    } catch (_: ClassNotFoundException) {
+      // Compose UI older than the locale locals — the compat-BOM case. Nothing to say.
+      Resolution.Absent
+    } catch (_: NoSuchMethodException) {
+      // Same: the accessor arrived with the locals, so its absence means an older Compose UI.
+      Resolution.Absent
+    } catch (e: ReflectiveOperationException) {
+      report(classLoader, "locale composition locals found but unusable", e)
+      Resolution.Absent
+    }
+
+  private fun report(classLoader: ClassLoader, what: String, e: Throwable) {
+    if (!reportedFailures.add(classLoader)) return
+    System.err.println(
+      "Locale composition locals unavailable — previews render in the default locale ($what): " +
+        "${e::class.java.simpleName}: ${e.message}"
+    )
+  }
 
   internal fun languageTags(configuration: Configuration): String {
     if (Build.VERSION.SDK_INT >= 24) {
-      val locales = configuration.locales.takeUnless { it.isEmpty } ?: android.os.LocaleList.getDefault()
+      val locales =
+        configuration.locales.takeUnless { it.isEmpty } ?: android.os.LocaleList.getDefault()
       return (0 until locales.size()).joinToString(",") { locales[it].toLanguageTag() }
     }
     @Suppress("DEPRECATION")

--- a/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/LocaleCompositionLocalsResolutionTest.kt
+++ b/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/LocaleCompositionLocalsResolutionTest.kt
@@ -2,10 +2,13 @@ package ee.schimke.composeai.renderer
 
 import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.compositionLocalOf
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
 import java.util.concurrent.atomic.AtomicInteger
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
@@ -38,6 +41,9 @@ internal class FakeLocaleList(val languageTags: String) {
 
 /** A Compose UI whose `CompositionLocalsKt` predates the accessor (present, but wrong shape). */
 internal object AccessorlessCompositionLocalsKt
+
+/** A `LocaleList` that exists but can't be built from a language-tag string. */
+internal class ConstructorlessLocaleList private constructor()
 
 /**
  * A stand-in Compose UI classpath: serves [names] and records every lookup, so a test can assert
@@ -107,6 +113,48 @@ class LocaleCompositionLocalsResolutionTest {
     // The miss is cached too: a per-render ClassNotFoundException is the expensive default case.
     assertNull(provide(olderCompose))
     assertEquals(1, olderCompose.lookups.get())
+  }
+
+  /** Runs [body] with stderr captured, returning what it printed. */
+  private fun capturingStderr(body: () -> Unit): String {
+    val original = System.err
+    val captured = ByteArrayOutputStream()
+    System.setErr(PrintStream(captured, true))
+    try {
+      body()
+    } finally {
+      System.setErr(original)
+    }
+    return captured.toString()
+  }
+
+  @Test
+  fun `a locale list that cannot be built from tags is reported, not treated as an old compose`() {
+    // The distinction that matters: the accessor resolved, so the locale locals demonstrably
+    // exist. A LocaleList without the String constructor is then a present-but-incompatible
+    // classpath — the exact case this bridge must not swallow into a silent default locale.
+    val incompatible =
+      StubClasspath(
+        mapOf(
+          "androidx.compose.ui.platform.CompositionLocalsKt" to FakeCompositionLocalsKt::class.java,
+          "androidx.compose.ui.text.intl.LocaleList" to ConstructorlessLocaleList::class.java,
+        )
+      )
+
+    val stderr = capturingStderr { assertNull(provide(incompatible)) }
+
+    assertTrue(stderr, stderr.contains("LocaleList(String) is not usable"))
+    assertTrue(stderr, stderr.contains("default locale"))
+  }
+
+  @Test
+  fun `an old compose classpath is not reported`() {
+    val olderCompose = StubClasspath(emptyMap())
+
+    val stderr = capturingStderr { assertNull(provide(olderCompose)) }
+
+    // A compat-BOM render is the normal case; it must not print on every daemon start.
+    assertEquals("", stderr)
   }
 
   @Test

--- a/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/LocaleCompositionLocalsResolutionTest.kt
+++ b/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/LocaleCompositionLocalsResolutionTest.kt
@@ -1,0 +1,124 @@
+package ee.schimke.composeai.renderer
+
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.compositionLocalOf
+import java.util.concurrent.atomic.AtomicInteger
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * A Compose UI that HAS the locale locals, standing in for a newer Compose than the renderer's
+ * compat BOM. The bridge only needs the shape — a static accessor returning a providable local — so
+ * this is a faithful stand-in for `androidx.compose.ui.platform.CompositionLocalsKt`, and lets the
+ * positive path be tested on a classpath that doesn't ship the real thing.
+ */
+internal object FakeCompositionLocalsKt {
+  @JvmStatic
+  fun getLocalProvidableLocaleList(): ProvidableCompositionLocal<Any> = compositionLocalOf {
+    "unset"
+  }
+}
+
+/**
+ * Stands in for `androidx.compose.ui.text.intl.LocaleList`, constructed from a language-tag string.
+ * Records the tags it was built with: `ProvidedValue.value` isn't public API on the compat BOM, so
+ * this is how a test sees what the bridge actually handed to Compose.
+ */
+internal class FakeLocaleList(val languageTags: String) {
+  init {
+    lastTags = languageTags
+  }
+
+  companion object {
+    @JvmStatic var lastTags: String? = null
+  }
+}
+
+/** A Compose UI whose `CompositionLocalsKt` predates the accessor (present, but wrong shape). */
+internal object AccessorlessCompositionLocalsKt
+
+/**
+ * A stand-in Compose UI classpath: serves [names] and records every lookup, so a test can assert
+ * both *what* resolved and *how often* — the point of the resolution cache. Each instance also acts
+ * as its own cache key, keeping the cases independent.
+ */
+private class StubClasspath(private val names: Map<String, Class<*>>) {
+  val lookups = AtomicInteger()
+
+  /** A unique, empty loader: only the identity matters, since [findClass] does the resolving. */
+  val key: ClassLoader = object : ClassLoader(null) {}
+
+  val findClass: (String) -> Class<*> = { name ->
+    lookups.incrementAndGet()
+    names[name] ?: throw ClassNotFoundException(name)
+  }
+}
+
+/**
+ * The reflective half of [LocaleCompositionLocals], driven against stub classpaths.
+ *
+ * The stand-in classpath is injected as a lookup function rather than a class loader: `Class.forName`
+ * rejects a class whose name doesn't match the one requested, so a loader that maps
+ * `androidx.compose…` to a fake can never satisfy it. Deliberately NOT a Robolectric test either —
+ * the sandbox resolves `Class.forName` against its own loader regardless of what is passed in.
+ */
+class LocaleCompositionLocalsResolutionTest {
+
+  private fun newerCompose() =
+    StubClasspath(
+      mapOf(
+        "androidx.compose.ui.platform.CompositionLocalsKt" to FakeCompositionLocalsKt::class.java,
+        "androidx.compose.ui.text.intl.LocaleList" to FakeLocaleList::class.java,
+      )
+    )
+
+  private fun provide(cp: StubClasspath, tags: String = "de-DE") =
+    LocaleCompositionLocals.providedValue(tags, cp.key, cp.findClass)
+
+  @Test
+  fun `a compose with locale locals gets the requested locale provided`() {
+    // The regression this test exists to prevent: before, EVERY failure — including a renamed
+    // accessor — collapsed to null, so the bridge could be entirely dead with the suite still
+    // green. Nothing asserted that a Compose which HAS the locals actually receives them.
+    FakeLocaleList.lastTags = null
+
+    assertNotNull(provide(newerCompose()))
+
+    assertEquals("de-DE", FakeLocaleList.lastTags)
+  }
+
+  @Test
+  fun `the reflective resolution is cached per class loader`() {
+    val cp = newerCompose()
+
+    repeat(5) { assertNotNull(provide(cp)) }
+
+    // Two classes resolved, once — not once per composition. Every preview render asks for this.
+    assertEquals(2, cp.lookups.get())
+  }
+
+  @Test
+  fun `older compose versions without locale locals remain supported`() {
+    val olderCompose = StubClasspath(emptyMap())
+
+    assertNull(provide(olderCompose))
+    // The miss is cached too: a per-render ClassNotFoundException is the expensive default case.
+    assertNull(provide(olderCompose))
+    assertEquals(1, olderCompose.lookups.get())
+  }
+
+  @Test
+  fun `a compose whose accessor is missing degrades instead of failing the render`() {
+    val accessorless =
+      StubClasspath(
+        mapOf(
+          "androidx.compose.ui.platform.CompositionLocalsKt" to
+            AccessorlessCompositionLocalsKt::class.java
+        )
+      )
+
+    assertNull(provide(accessorless))
+  }
+}

--- a/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/LocaleCompositionLocalsTest.kt
+++ b/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/LocaleCompositionLocalsTest.kt
@@ -4,12 +4,16 @@ import android.content.res.Configuration
 import android.os.LocaleList
 import java.util.Locale
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.annotation.Config
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 
+/**
+ * The [Configuration]-reading half. The reflective half needs a stub classpath, which the
+ * Robolectric sandbox can't provide (it resolves `Class.forName` against its own loader and ignores
+ * the one passed in), so that lives in [LocaleCompositionLocalsResolutionTest] — a plain JVM test.
+ */
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [34])
 class LocaleCompositionLocalsTest {
@@ -30,13 +34,5 @@ class LocaleCompositionLocalsTest {
     } finally {
       Locale.setDefault(previous)
     }
-  }
-
-  @Test
-  fun `older compose versions without locale locals remain supported`() {
-    val configuration = Configuration().apply { setLocale(Locale.GERMANY) }
-    val emptyLoader = object : ClassLoader(null) {}
-
-    assertNull(LocaleCompositionLocals.providedValue(configuration, emptyLoader))
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to #2799. The locale bridge wrapped its entire reflective lookup in `runCatching { … }.getOrNull()`, which conflates two opposite situations:

- **"this Compose UI predates the locale locals"** — expected on the 1.9 compat BOM, correct to ignore.
- **"the symbols are there but unusable"** — a renamed accessor, a changed `LocaleList(String)` constructor, an unparseable tag. That's a renderer bug or an upstream break, and it silently rendered every preview in the default locale with nothing on stderr.

Since it binds reflectively to `LocalProvidableLocaleList` — an internal Compose symbol with no compat guarantee — the second case is the likely one, and it was invisible.

Three changes:

1. **Tell the failures apart.** `ClassNotFoundException` / `NoSuchMethodException` → silent `Absent`. Anything else → one stderr line per class loader (`System.err.println`, matching the renderer's convention), never swallowed.
2. **Cache the resolution per class loader.** Every composition called this, on four `RenderEngine` sites plus `RobolectricHost`; on the common absent path that meant *throwing* a `ClassNotFoundException` per render. Now one lookup per loader (`ConcurrentHashMap`, keyed by loader since a daemon can host several).
3. **Test the positive path**, which nothing did — only the empty-classloader negative case was covered, so the feature could have been entirely dead with CI green.

Public API is unchanged (`providedValue(Configuration, ClassLoader)`); `:daemon:android` compiles untouched.

## Test plan

`./gradlew :renderer-android:testDebugUnitTest --tests '*LocaleComposition*'` — green. Split into two classes for a reason worth recording:

- `LocaleCompositionLocalsTest` (Robolectric) keeps the `Configuration` → language-tags cases.
- `LocaleCompositionLocalsResolutionTest` (plain JUnit) drives the reflection against a stand-in Compose UI:
  - `a compose with locale locals gets the requested locale provided` — the missing positive path; asserts the tags actually reached the constructed `LocaleList`, not just "non-null came back"
  - `the reflective resolution is cached per class loader` — 5 calls, 2 class lookups
  - `older compose versions without locale locals remain supported` — and the miss is cached too
  - `a compose whose accessor is missing degrades instead of failing the render`

The stand-in classpath is injected as a class-lookup function rather than a stub `ClassLoader`, because `Class.forName` rejects a class whose name doesn't match the request — a loader mapping `androidx.compose…` to a fake can never satisfy it. Robolectric additionally resolves `Class.forName` against its own sandbox loader and ignores the one passed in, which is why that half can't be a Robolectric test. Both facts are now comments in the code rather than something the next person rediscovers.

Non-visual change (no rendered output differs on the compat BOM, where the bridge is inert); the locale behaviour it guards only appears on a newer Compose classpath.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V9QFVfWmNCNEWVXAf9gdPs)_