### PR TITLE
fix(deps): move the XR line to beta01 and null-guard the panel tag lookup

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -98,7 +98,7 @@ xr-glimmer = "1.0.0-alpha15"
 # 2D Home-Space fallback of these composables through the Android Robolectric
 # pipeline (see docs/design/XR_SPATIAL_PREVIEW.md). Alpha14 was published
 # 2026-05-19.
-xr-compose = "1.0.0-alpha15"
+xr-compose = "1.0.0-alpha16"
 # XR `*-testing` fakes injected onto the offline render/test classpath (the
 # Robolectric `composePreviewRenderXr` path + `:renderer-xr` / sample tests).
 # Single source of truth: the plugin bakes these into a generated resource (see
@@ -106,9 +106,9 @@ xr-compose = "1.0.0-alpha15"
 # `AndroidPreviewSupport.kt` can't drift from the catalog. The runtime/scenecore
 # alpha line runs one ahead of the compose/arcore line — bump together with
 # `xr-compose`.
-xr-runtime-testing = "1.0.0-alpha15"
-xr-scenecore-testing = "1.0.0-alpha16"
-xr-arcore-testing = "1.0.0-alpha15"
+xr-runtime-testing = "1.0.0-beta01"
+xr-scenecore-testing = "1.0.0-beta01"
+xr-arcore-testing = "1.0.0-beta01"
 # `androidx.wear:wear` carries `androidx.wear.ambient.AmbientLifecycleObserver` —
 # the AOSP entry point both horologist's `AmbientAware` and direct subscribers
 # wrap. Used only by `:data-ambient-connector` (the Robolectric shadow + state

--- a/renderers/xr/src/main/kotlin/ee/schimke/composeai/renderer/xr/SubspaceSceneRecorder.kt
+++ b/renderers/xr/src/main/kotlin/ee/schimke/composeai/renderer/xr/SubspaceSceneRecorder.kt
@@ -103,8 +103,11 @@ public object SubspaceSceneRecorder {
   ): RecordedSubspace {
     val tagged =
       allSemanticsNodes(rule).mapNotNull { node ->
+        // `semanticsConfiguration` is nullable as of `androidx.xr.compose:compose-testing`
+        // 1.0.0-beta01 — a node with no semantics reports null instead of an empty config.
+        // Either shape means "untagged", which this path already skips.
         val tag =
-          node.semanticsConfiguration.getOrNull(SemanticsProperties.TestTag)
+          node.semanticsConfiguration?.getOrNull(SemanticsProperties.TestTag)
             ?: return@mapNotNull null
         tag to node
       }


### PR DESCRIPTION
Split out of the grouped Renovate bump (#2805), which now holds the XR pins so the low-risk updates can land on their own.

## What changed

- `androidx.xr.{runtime,scenecore,arcore}:*-testing` → `1.0.0-beta01`, `androidx.xr.compose` → `1.0.0-alpha16`.
- `SubspaceSceneRecorder.recordAll` uses a safe call for the tag lookup: `SubspaceSemanticsInfo.semanticsConfiguration` is nullable in beta01, which is what broke `:renderer-xr:compileReleaseKotlin` on #2805 (`Only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable receiver`).

A node with no semantics now reports `null` instead of an empty config. Both mean "untagged", and that path already skipped untagged nodes, so the recovered scene is unchanged.

## Test plan

- `./gradlew :renderer-xr:compileReleaseKotlin :renderer-xr:ktfmtCheck` — green locally, which is the failure #2805 hit.
- `:renderer-xr` / `:samples:xr-spatial` unit tests are **not** a usable local signal in this container: they load the real `SpatialCoreXrExtensionsHolderProvider` instead of the XR testing fakes and fail with `NoClassDefFoundError: com/android/extensions/xr/XrExtensions`. On `origin/main` 7 of them fail here; on this branch 3 do. CI is the authority for the XR suite — if it flags the reflective `getRtEntity$scenecore` → `getView` chain in `contentView`, that seam needs migrating too and I'll follow up on this branch.

No visual surface changes intended: the scene, panel poses and texture paths are byte-identical for tagged panels.


---
_Generated by [Claude Code](https://claude.ai/code/session_01V9QFVfWmNCNEWVXAf9gdPs)_