### PR TITLE
build(deps): update AGP to 9.3.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ kotlin = "2.4.0"
 # `configureKotlinCompatibility(...)`; remove the flag (and bump this to
 # `2.1.x`) when the removal lands and we're ready to drop 2.0.x consumers.
 kotlinCoreLibraries = "2.0.21"
-agp = "9.2.1"
+agp = "9.3.0"
 ktfmt = "0.26.0"
 tapmoc = "0.4.2"
 robolectric = "4.17-beta-2"


### PR DESCRIPTION
Split out of the grouped Renovate bump (#2805). AGP drives every module's compile and variant wiring, so a regression here should not be ambiguous with a library update landing in the same commit.

`com.android.tools.build:gradle`, `com.android.library`, `com.android.application`: `9.2.1` → `9.3.0`.

## Test plan

Locally on JDK 21:

- `./gradlew publishToMavenLocal :cli:installDist` — the integration job's build step, green.
- `./gradlew :samples:android:composePreviewDiscover :samples:cmp:composePreviewDiscover :samples:android-screenshot-test:composePreviewRenderAll` — preview discovery + full render, green.
- `./gradlew :renderer-android:testDebugUnitTest` — green, including the `WearScrollSvgGrowthTest` capsule-fixture drift guard, so the AGP bump doesn't move rendered vector output.

Non-visual: no renderer, catalog or fixture source changes, and the render suite above reproduces the committed output.


---
_Generated by [Claude Code](https://claude.ai/code/session_01V9QFVfWmNCNEWVXAf9gdPs)_