### PR TITLE
build(deps): update roborazzi to 1.70.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,7 @@ agp = "9.2.1"
 ktfmt = "0.26.0"
 tapmoc = "0.4.2"
 robolectric = "4.17-beta-2"
-roborazzi = "1.68.0"
+roborazzi = "1.70.0"
 # androidx.tracing — atrace-level sections for the Android daemon's render phases (see
 # `AndroidxTraceSections` in :daemon:android). Version-pinned (not BOM-managed) because the daemon
 # ships it in the standalone lib-daemon-android sidecar where no BOM applies.


### PR DESCRIPTION
Split out of the grouped Renovate bump (#2805). Roborazzi owns the capture path behind every rendered PNG, so it lands alone where a pixel change would be unambiguous.

`io.github.takahirom.roborazzi:{roborazzi,roborazzi-compose,roborazzi-annotations,roborazzi-accessibility-check}`: `1.68.0` → `1.70.0`.

What's in the two releases that touches us:

- **1.69.0** rewrote the `Bitmap` → `BufferedImage` conversion to write straight into the backing raster instead of a per-pixel `setRGB` pass. Upstream reports byte-identical recorded output, verified against their full sample baseline.
- **1.70.0** republished `roborazzi-annotations` as a Kotlin Multiplatform library — same Maven coordinate, same signatures, packaging only.

The new opt-in features (Compose Desktop preview generation, UI tree dump) are off by default and not enabled here.

## Test plan

Locally on JDK 21:

- `./gradlew :samples:android-screenshot-test:composePreviewRenderAll` — full render suite, green.
- `./gradlew :samples:wear:testDebugUnitTest` — Wear pixel tests against the committed goldens, green.
- `./gradlew :renderer-android:testDebugUnitTest` — green, including the `WearScrollSvgGrowthTest` capsule-fixture drift guard.

No golden or fixture updates were needed, which is the evidence that capture output is unchanged; the CI visual-diff bot covers the rendered PNGs on this PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01V9QFVfWmNCNEWVXAf9gdPs)_