### PR TITLE
fix(renderer): provide LocalSession so XR 2D-fallback previews render

### DIFF
--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/OfflineXrSession.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/OfflineXrSession.kt
@@ -1,0 +1,80 @@
+package ee.schimke.composeai.renderer
+
+import android.app.Activity
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.ProvidedValue
+
+/**
+ * Provides `androidx.xr.compose.platform.LocalSession` to the ordinary (non-subspace) render so XR
+ * Compose composables taking their **2D fallback** can compose off-device.
+ *
+ * Why: `Orbiter`, `SpatialElevation`, `SpatialPopup` and friends are written once and render inline
+ * when the app isn't in Full Space — that flat fallback is exactly what an ordinary `@Preview`
+ * captures. As of `androidx.xr.compose:compose` 1.0.0-alpha16 those composables consume
+ * `LocalSession` and `checkNotNull` it *before* branching to the 2D case, so a preview that merely
+ * mentions `Orbiter` dies with `IllegalStateException: session must be initialized` where alpha15
+ * fell back without asking. The preview then writes no PNG, and under
+ * `-PcomposePreview.missingRenders=fail` that fails the whole module's render.
+ *
+ * Providing the composition local directly is what makes this work offline. `LocalSession`'s own
+ * default resolves through `LocalComposeXrOwners`, whose session is populated by a **suspend**
+ * `initialize$compose` → `getOrCreateSession(activity, …)`; under the render's paused clock that
+ * coroutine never lands, so the default stays null no matter what the host window carries. Seeding
+ * the decor-view tag — the hand-off [ee.schimke.composeai.renderer.xr.FakeXrHeadPose] uses for
+ * `@XrSubspacePreview`s — does not reach this path.
+ *
+ * Everything is reflective and best-effort by design:
+ * - `renderer-android` must not gain a compile dependency on `androidx.xr.*`; the overwhelming
+ *   majority of consumers have no XR artifacts at all, and for them every lookup here misses and
+ *   the whole thing is a no-op (the normal case, not an error).
+ * - A consumer using `androidx.xr.compose` without our `:renderer-xr` module gets the same repair,
+ *   because this reaches the XR runtime directly rather than through that module.
+ * - Session creation needs a `PerceptionRuntimeFactory` on the classpath (the `*-testing` fakes,
+ *   registered for `ServiceLoader`). Where that's absent, creation fails, this returns null and the
+ *   preview behaves exactly as it does today rather than crashing differently.
+ */
+internal object OfflineXrSession {
+
+  /** Resolved once; null means "XR Compose isn't on this preview's classpath". */
+  private val binding: Binding? by lazy { resolve() }
+
+  private class Binding(
+    val local: ProvidableCompositionLocal<Any?>,
+    val createSession: (Activity) -> Any?,
+  )
+
+  /**
+   * A `LocalSession provides <offline session>` entry for the render's composition-local array, or
+   * null when XR isn't present / no session could be created.
+   *
+   * Mirrors [LocaleCompositionLocals.providedValue]'s shape so the caller stays a one-liner.
+   */
+  fun providedValue(activity: Activity): ProvidedValue<*>? {
+    val bound = binding ?: return null
+    return runCatching {
+        val session = bound.createSession(activity) ?: return null
+        bound.local provides session
+      }
+      .getOrNull()
+  }
+
+  @Suppress("UNCHECKED_CAST")
+  private fun resolve(): Binding? =
+    runCatching {
+        val local =
+          Class.forName("androidx.xr.compose.platform.LocalSessionKt")
+            .getDeclaredMethod("getLocalSession")
+            .invoke(null) as ProvidableCompositionLocal<Any?>
+        val sessionClass = Class.forName("androidx.xr.runtime.Session")
+        // `create(Activity)` is the Kotlin default-argument entry point, emitted as a real static
+        // on both 1.0.0-alpha15 and 1.0.0-beta01 — no `create$default` synthetic juggling needed.
+        val create = sessionClass.getMethod("create", Activity::class.java)
+        val successClass = Class.forName("androidx.xr.runtime.SessionCreateSuccess")
+        val getSession = successClass.getMethod("getSession")
+        Binding(local) { activity ->
+          val result = create.invoke(null, activity)
+          if (successClass.isInstance(result)) getSession.invoke(result) else null
+        }
+      }
+      .getOrNull()
+}

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -1108,6 +1108,13 @@ abstract class RobolectricRenderTestBase(
                 if (scrollCaptureProvidable != null) {
                   add(scrollCaptureProvidable provides scrollCaptureInProgress)
                 }
+                // XR Compose composables (`Orbiter`, `SpatialElevation`, …) are written once and
+                // take a 2D fallback off-device — which is what an ordinary @Preview captures.
+                // Since `androidx.xr.compose` 1.0.0-alpha16 that fallback consumes `LocalSession`
+                // and null-checks it before branching, so hand it an offline session. Null (and
+                // therefore absent) whenever XR isn't on the preview's classpath, which is the
+                // overwhelmingly common case. See [OfflineXrSession].
+                OfflineXrSession.providedValue(rule.activity)?.let(::add)
               }
               .toTypedArray()
           // `showSystemUi = true` on a phone-shape preview wraps the


### PR DESCRIPTION
`main` currently fails `Apply compose-preview` on every PR. `samples:xr-spatial` reports **"render produced no output file for 1 of 15 preview(s)"**, which under `-PcomposePreview.missingRenders=fail` fails the whole compose pipeline — the empty `_previews.json` is also why the sticky comment says "nothing to compare, skipping".

## Root cause

`androidx.xr.compose` moved alpha15 → alpha16 in #2819. In alpha16, `Orbiter` (and its `SpatialElevation` / `SpatialPopup` siblings) consume `LocalSession` and null-check it **before** branching to the flat fallback, where alpha15 fell back without asking:

```
Caused by: java.lang.IllegalStateException: session must be initialized
	at androidx.xr.compose.spatial.OrbiterKt.Orbiter(Orbiter.kt:348)
	at com.example.samplexrspatial.SpatialPreviewsKt.OrbiterControlsPreview(SpatialPreviews.kt:57)
```

`OrbiterControlsPreview` is an ordinary 2D `@Preview` that deliberately exercises that fallback — the sample's own KDoc says "in the 2D fallback captured here it renders inline above the panel content", and `samples/xr-spatial/build.gradle.kts` records the now-stale assumption that "the 2D fallback path the previews exercise never reaches for a `Session`". Disassembling `OrbiterKt` confirms the read:

```
invokestatic androidx/xr/compose/platform/LocalSessionKt.getLocalSession
Composer.consume(CompositionLocal)
ldc "session must be initialized"
```

This is a `main` regression, not a dependency-PR one. It surfaced on #2805 / #2820 / #2821 simultaneously only because CI builds the PR **merge ref**: those branches were cut before #2819 and still carried `xr-compose` alpha15, so the failure never reproduced on the branch itself.

## Why the composition local, and not the decor-view tag

The first attempt seeded the host window's `compose_xr_session` decor-view tag — the hand-off `FakeXrHeadPose` uses for `@XrSubspacePreview`s — and changed nothing. `LocalSession`'s computed default resolves through `LocalComposeXrOwners`, whose session is populated by a **suspend** `initialize$compose` → `getOrCreateSession(activity, …)`; under the render's paused clock (`mainClock.autoAdvance = false`) that coroutine never lands, so the default stays null regardless of what the window carries. Providing the local directly is what works offline.

The lookup is reflective, so `renderer-android` gains no `androidx.xr.*` compile dependency: it misses entirely for the vast majority of previews with no XR artifacts, and where a session can't be created for want of a `PerceptionRuntimeFactory` it returns null and the preview behaves exactly as it does today. Both `Session.create(Activity)` and `LocalSessionKt.getLocalSession()` are present in 1.0.0-alpha15 and 1.0.0-beta01 (checked with `javap` against both artifacts), so this doesn't pin the XR line.

Fixing it in the renderer rather than in the sample is deliberate: any consumer whose 2D preview calls `Orbiter` hits this identically, and rendering consumer previews faithfully is what this repo is for.

## Test plan

Locally on JDK 21, against `main` (`bae86c7`):

- `./gradlew :samples:xr-spatial:composePreviewRenderAll` with a wiped `build/` — **green**, all 15 previews, `OrbiterControlsPreview_Orbiter_TopControls.png` produced and **zero** `.error.json` sidecars. The same command on `main` without this commit fails with the trace above, so the repro and the fix are both confirmed on the same tree.
- `./gradlew :renderer-android:testDebugUnitTest` — green.
- `./gradlew :samples:android-screenshot-test:composePreviewRenderAll` — green (non-XR module, confirming the null path is inert).

## Visual evidence

The change restores a preview that currently renders nothing at all, so the before/after is "no PNG" → the panel with its orbiter control strip. I can't embed the rendered pixels from this container — this environment has no GL libs (`libskiko-linux-x64.so: libGL.so.1: cannot open shared object file`), which is also why `:samples:design-catalog-m3` fails locally here for 86 of 89 previews on this branch *and* on unmodified `main`; that failure is environmental and unrelated. The CI visual-diff bot will render `OrbiterControlsPreview` on this PR — I'll embed the committed render PNG from `compose-preview/pr` in this body once it lands, so the pixels are visible here without clicking through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V9QFVfWmNCNEWVXAf9gdPs

---
_Generated by [Claude Code](https://claude.ai/code/session_01V9QFVfWmNCNEWVXAf9gdPs)_