### PR TITLE
build: add remote-cache repair tooling and a kill switch (default on)

### DIFF
--- a/.github/workflows/remote-cache-repair.yml
+++ b/.github/workflows/remote-cache-repair.yml
@@ -1,0 +1,77 @@
+name: Remote Cache Repair
+
+# Manual repair for BuildFetch entries that are stored truncated at rest (issue #2824).
+#
+# A poisoned entry fails during *load*, so the task never executes and never pushes a replacement —
+# it cannot self-heal, and `composeai.cacheSalt` only orphans Kotlin-compilation keys. The fix is to
+# re-upload a byte-valid copy under the same key: Gradle's local build cache uses the same key space
+# and packed format as the remote, so a runner that has executed the affected task holds one.
+#
+# Runs here rather than on a laptop because cache keys are inputs-derived: a key produced by CI
+# (its Gradle/AGP/JDK, its OS) usually only reproduces on a matching runner.
+#
+# 1. `gradle-tasks` runs with `-Pcomposeai.remoteCache=off`, so the build ignores the poisoned remote
+#    entirely and executes the tasks, landing clean entries in the local cache.
+# 2. `scripts/repair-remote-cache.sh` uploads those local entries over the bad remote ones and
+#    re-reads each to confirm the stored object now terminates.
+#
+# Leave `gradle-tasks` empty to skip step 1 — useful for a check-only pass, or when the runner's
+# restored cache already holds the keys.
+
+on:
+  workflow_dispatch:
+    inputs:
+      keys:
+        description: "Space-separated cache keys to repair (32-hex each)"
+        required: true
+      gradle-tasks:
+        description: "Gradle tasks to execute first, to (re)populate the local cache. Empty = skip."
+        required: false
+        default: ""
+      check-only:
+        description: "Report health without uploading anything"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  # One repair at a time: two runs uploading the same key would race on the same object.
+  group: remote-cache-repair
+  cancel-in-progress: false
+
+jobs:
+  repair:
+    name: Repair cache entries
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup
+
+      - name: Execute tasks to populate the local cache
+        if: ${{ inputs.gradle-tasks != '' }}
+        env:
+          TASKS: ${{ inputs.gradle-tasks }}
+        run: |
+          # `composeai.remoteCache=off` keeps this build away from the poisoned entries — without it
+          # the build would die on the very keys it is meant to replace. The local cache stays on
+          # (settings.gradle.kts ties local.isEnabled to remotePushEnabled), so executed task outputs
+          # land in ~/.gradle/caches/build-cache-1 under the keys we are about to upload.
+          # shellcheck disable=SC2086
+          ./gradlew -Pcomposeai.remoteCache=off $TASKS
+
+      - name: Repair
+        env:
+          # Write access is required to overwrite an entry; the readonly token can only --check.
+          BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_RW_TOKEN }}
+          KEYS: ${{ inputs.keys }}
+          CHECK_ONLY: ${{ inputs.check-only }}
+        run: |
+          args=""
+          if [ "$CHECK_ONLY" = "true" ]; then args="--check"; fi
+          # shellcheck disable=SC2086
+          ./scripts/repair-remote-cache.sh $args $KEYS

--- a/.github/workflows/remote-cache-repair.yml
+++ b/.github/workflows/remote-cache-repair.yml
@@ -67,7 +67,11 @@ jobs:
       - name: Repair
         env:
           # Write access is required to overwrite an entry; the readonly token can only --check.
-          BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_RW_TOKEN }}
+          # Same project-specific-then-shared fallback every other workflow's `rw-token` uses (see
+          # ci.yml / .github/actions/buildfetch-cache) — there is no separate *_RW_TOKEN secret, and
+          # an unrecognized name resolves to the empty string, which the script rejects outright.
+          BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN:
+            ${{ secrets.BUILDFETCH_COMPOSEAI_GRADLE_REMOTE_CACHE_TOKEN || secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN }}
           KEYS: ${{ inputs.keys }}
           CHECK_ONLY: ${{ inputs.check-only }}
         run: |

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,6 +12,15 @@ org.gradle.caching=true
 # keys. History: 1 = orphan the truncated `:daemon:core:compileKotlin` entry cc7964dd… (2026-07).
 composeai.cacheSalt=1
 
+# TEMPORARY (issue #2824) — `off` skips the BuildFetch remote build cache entirely. Two entries are
+# stored truncated at rest and are served as HTTP 200 with a matching content-length, so Gradle only
+# discovers the corruption mid-inflate and fails the build ("Unexpected end of ZLIB input stream").
+# They can't self-heal (the load aborts before the task executes, so nothing repushes) and the
+# cacheSalt above can't orphan them: it's an input on Kotlin compilation tasks only, while these are
+# an AGP task and an artifact transform. The local build cache stays on — see settings.gradle.kts.
+# REVERT to `on` (or delete this line) once BuildFetch has evicted `12fcc978…a05d` and `877aca9a…c1ec`.
+composeai.remoteCache=off
+
 # Isolated Projects is deliberately NOT enabled here. It is incompatible with
 # the compose-preview CLI / MCP server / VS Code workflow: those drive Gradle
 # through the auto-injected init script (cli/.../AutoInject.kt,

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,14 +12,18 @@ org.gradle.caching=true
 # keys. History: 1 = orphan the truncated `:daemon:core:compileKotlin` entry cc7964dd… (2026-07).
 composeai.cacheSalt=1
 
-# TEMPORARY (issue #2824) — `off` skips the BuildFetch remote build cache entirely. Two entries are
-# stored truncated at rest and are served as HTTP 200 with a matching content-length, so Gradle only
-# discovers the corruption mid-inflate and fails the build ("Unexpected end of ZLIB input stream").
-# They can't self-heal (the load aborts before the task executes, so nothing repushes) and the
-# cacheSalt above can't orphan them: it's an input on Kotlin compilation tasks only, while these are
-# an AGP task and an artifact transform. The local build cache stays on — see settings.gradle.kts.
-# REVERT to `on` (or delete this line) once BuildFetch has evicted `12fcc978…a05d` and `877aca9a…c1ec`.
-composeai.remoteCache=off
+# Kill switch for the BuildFetch remote build cache (issue #2824). `off` skips it entirely; the
+# LOCAL cache stays on, including for pushing main runs — see settings.gradle.kts.
+#
+# Flip to `off` when an entry is corrupt at rest and `composeai.cacheSalt` above can't reach it. A
+# truncated entry is served as HTTP 200 with a matching content-length, so the short read is
+# undetectable until the gzip stream ends mid-inflate ("Unexpected end of ZLIB input stream"), which
+# Gradle treats as fatal; and it can't self-heal, because the load aborts before the task executes so
+# nothing repushes. The salt only orphans Kotlin-compilation keys, so it's no help when the poisoned
+# entry belongs to an AGP task or an artifact transform (July 2026: `12fcc978…a05d`, `877aca9a…c1ec`).
+# Prefer `scripts/repair-remote-cache.sh` — re-uploading a good copy fixes it for everyone, where
+# this flag only routes the local build around it.
+composeai.remoteCache=on
 
 # Isolated Projects is deliberately NOT enabled here. It is incompatible with
 # the compose-preview CLI / MCP server / VS Code workflow: those drive Gradle

--- a/scripts/repair-remote-cache.sh
+++ b/scripts/repair-remote-cache.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# Verify — and optionally repair — BuildFetch remote build-cache entries.
+#
+# Why this exists (issue #2824): an entry can be stored TRUNCATED at rest. It is served as HTTP 200
+# with a `content-length` matching the truncated body, so nothing detects the short read until the
+# gzip stream runs off the end mid-inflate:
+#
+#   Failed to load cache entry <key> for task '…': Could not load from remote cache:
+#   Unexpected end of ZLIB input stream
+#
+# Gradle treats that as FATAL (corruption is not a recoverable cache failure), and it cannot
+# self-heal: the load aborts before the task executes, so nothing ever pushes a replacement. Neither
+# does `composeai.cacheSalt` help for every case — it is an input property on Kotlin compilation
+# tasks only, so it cannot orphan a poisoned AGP-task or artifact-transform entry.
+#
+# The repair: Gradle's LOCAL build cache (`~/.gradle/caches/build-cache-1/<key>`) uses the SAME key
+# space and the SAME packed format as the remote. So a machine that has executed the affected task
+# holds a byte-valid replacement, and PUTting it under the same key overwrites the truncated object.
+#
+#   # check only (no token needed beyond read access, nothing is written)
+#   scripts/repair-remote-cache.sh --check 12fcc978271d75e6470ed675c023a05d
+#
+#   # repair (needs a cache:readwrite token)
+#   BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN=<rw-token> \
+#     scripts/repair-remote-cache.sh 877aca9ad8277aac3a9adf9a18efc1ec
+#
+# A key whose local copy is missing cannot be repaired from this machine — the task has to have run
+# here with the same inputs (same Gradle/AGP/JDK) for the key to exist. When a key only reproduces
+# on CI, run `.github/workflows/remote-cache-repair.yml`, which executes the tasks on a runner first.
+#
+# Exit status: 0 when every requested key ends healthy, 1 otherwise (so CI can gate on it).
+set -euo pipefail
+
+CACHE_URL="${COMPOSEAI_CACHE_URL:-https://cache.eu-central-a.buildfetch.com/8ESz2z/gradle}"
+LOCAL_CACHE="${GRADLE_USER_HOME:-$HOME/.gradle}/caches/build-cache-1"
+CHECK_ONLY=false
+
+usage() {
+  sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'
+  exit "${1:-0}"
+}
+
+keys=()
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --check | --check-only) CHECK_ONLY=true ;;
+    -h | --help) usage 0 ;;
+    -*) echo "unknown flag: $1" >&2 && usage 1 ;;
+    *) keys+=("$1") ;;
+  esac
+  shift
+done
+[ ${#keys[@]} -gt 0 ] || usage 1
+
+TOKEN="${BUILDFETCH_COMPOSEAI_GRADLE_REMOTE_CACHE_TOKEN:-${BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN:-}}"
+if [ -z "$TOKEN" ]; then
+  echo "error: no BuildFetch token in the environment" >&2
+  echo "  set BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN (readwrite to repair, readonly to --check)" >&2
+  exit 1
+fi
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+# Prints "<status> <bytes> <inflated>" for a packed cache entry:
+#   ok        — gzip stream terminates (a usable entry)
+#   truncated — inflates partially, never reaches end-of-stream (the #2824 signature)
+#   invalid   — not a readable gzip stream at all
+inspect() {
+  python3 - "$1" <<'PY'
+import sys, zlib
+raw = open(sys.argv[1], 'rb').read()
+if not raw:
+    print("invalid 0 0"); sys.exit()
+d = zlib.decompressobj(16 + zlib.MAX_WBITS)
+try:
+    out = d.decompress(raw) + d.flush()
+except Exception:
+    print(f"invalid {len(raw)} 0"); sys.exit()
+print(f"{'ok' if d.eof else 'truncated'} {len(raw)} {len(out)}")
+PY
+}
+
+# GET the remote entry into $tmp/<key>.remote; echoes "missing" when the server has no such key.
+fetch_remote() {
+  local key="$1" out="$tmp/$key.remote"
+  local code
+  code="$(curl -sS -u "token-auth:$TOKEN" -o "$out" -w '%{http_code}' "$CACHE_URL/$key")"
+  case "$code" in
+    200) inspect "$out" ;;
+    404) echo "missing 0 0" ;;
+    *) echo "http:$code 0 0" ;;
+  esac
+}
+
+failed=0
+for key in "${keys[@]}"; do
+  echo "── $key"
+  read -r status bytes inflated <<<"$(fetch_remote "$key")"
+  printf '   remote: %-9s bytes=%-9s inflated=%s\n' "$status" "$bytes" "$inflated"
+
+  if [ "$status" = "ok" ]; then
+    echo "   nothing to do"
+    continue
+  fi
+
+  local_entry="$LOCAL_CACHE/$key"
+  if [ ! -f "$local_entry" ]; then
+    echo "   local:  absent — cannot repair from this machine"
+    echo "           run the task that produces this key here first, or use the repair workflow"
+    failed=1
+    continue
+  fi
+
+  read -r lstatus lbytes linflated <<<"$(inspect "$local_entry")"
+  printf '   local:  %-9s bytes=%-9s inflated=%s\n' "$lstatus" "$lbytes" "$linflated"
+  if [ "$lstatus" != "ok" ]; then
+    echo "   local copy is itself unusable — refusing to upload it"
+    failed=1
+    continue
+  fi
+
+  if [ "$CHECK_ONLY" = true ]; then
+    echo "   --check: would upload the local copy"
+    failed=1
+    continue
+  fi
+
+  code="$(curl -sS -u "token-auth:$TOKEN" -X PUT --upload-file "$local_entry" \
+    -o "$tmp/$key.put" -w '%{http_code}' "$CACHE_URL/$key")"
+  echo "   PUT:    http=$code"
+  case "$code" in
+    2*) ;;
+    401 | 403)
+      echo "           rejected — the token is probably readonly; a cache:readwrite token is needed"
+      failed=1
+      continue
+      ;;
+    409 | 412)
+      echo "           rejected — the server treats entries as immutable, so it cannot be"
+      echo "           overwritten; ask BuildFetch to evict $key instead"
+      failed=1
+      continue
+      ;;
+    *)
+      echo "           unexpected status; body: $(head -c 200 "$tmp/$key.put" 2>/dev/null)"
+      failed=1
+      continue
+      ;;
+  esac
+
+  # Never trust the PUT status alone — the whole bug is a server that reports success while storing
+  # something short. Re-read and re-inflate.
+  read -r status bytes inflated <<<"$(fetch_remote "$key")"
+  printf '   verify: %-9s bytes=%-9s inflated=%s\n' "$status" "$bytes" "$inflated"
+  if [ "$status" = "ok" ]; then
+    echo "   repaired"
+  else
+    echo "   STILL BAD after upload — the corruption is in the store, not the transfer;"
+    echo "   report this key to BuildFetch (see issue #2824)"
+    failed=1
+  fi
+done
+
+exit "$failed"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -82,10 +82,34 @@ val cacheToken =
     .orElse(nonBlank(providers.gradleProperty("BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN")))
     .orNull
 
+// TEMPORARY (issue #2824): kill switch for the BuildFetch remote cache. Two entries are stored
+// TRUNCATED at rest — `12fcc978…a05d` (ClasspathEntrySnapshotTransform of gradle-api-9.6.1.jar) and
+// `877aca9a…c1ec` (:samples:android-screenshot-test:mergeDebugResources). Both are served as HTTP
+// 200 with a `content-length` matching the truncated body, so nothing detects the short read until
+// the gzip stream runs off the end: "Could not load from remote cache: Unexpected end of ZLIB input
+// stream". Gradle treats that as FATAL (corruption is not a recoverable cache failure), so any build
+// resolving either key dies — and it can't self-heal, because the load aborts before the task runs,
+// so nothing ever pushes a replacement.
+//
+// `composeai.cacheSalt` is the escape hatch for exactly this, but it can't reach these two: it is an
+// input property on `KotlinCompilationTask` only, and these are an AGP task and an artifact
+// transform (a transform's key comes from the input artifact + transform implementation — a task
+// input property never enters it). Bumping the salt would leave both keys resolving to the same
+// poisoned objects.
+//
+// So until BuildFetch evicts them, skip the remote entirely. This deliberately also forces
+// `remotePushEnabled` false, which keeps the LOCAL cache on for main (see `local` below) — without
+// that, a main run would execute every cacheable task with no cache at all.
+//
+// TO REVERT once the entries are evicted: delete this flag + the `composeai.remoteCache` line in
+// gradle.properties. Nothing else changed.
+val remoteCacheDisabled =
+  providers.gradleProperty("composeai.remoteCache").orElse("on").get().trim().lowercase() == "off"
+
 // True only when this run will actually push to the remote: a trusted main-branch run (ON_CI) with a
 // usable token. Anything else (PRs, dev machines, or a main run whose token is unprovisioned/blank)
 // does not push, so it must keep the local cache.
-val remotePushEnabled = onCi && cacheToken != null
+val remotePushEnabled = onCi && cacheToken != null && !remoteCacheDisabled
 
 buildCache {
   // On the trusted main-branch runs, CI is the sole writer of the BuildFetch remote cache — and the
@@ -110,8 +134,9 @@ buildCache {
       password = cacheToken
     }
 
-    isPush = onCi
-    isEnabled = cacheToken != null
+    isPush = onCi && !remoteCacheDisabled
+    // TEMPORARY (#2824): `!remoteCacheDisabled` skips the cache holding the truncated entries.
+    isEnabled = cacheToken != null && !remoteCacheDisabled
   }
 }
 


### PR DESCRIPTION
Follow-up to #2824, where two BuildFetch entries were stored **truncated at rest** and failed every build that resolved their keys.

**Status update since the issue was filed: both keys now return 404.** They were serving truncated 200s an hour ago; they've since been evicted or aged out. So the immediate blocker is gone, and nothing in this PR is engaged by default — `composeai.remoteCache` ships as `on`. This lands the levers for the next occurrence, which the `composeai.cacheSalt` history in `gradle.properties` (July 2026, `:daemon:core:compileKotlin` `cc7964dd…`) says is not hypothetical.

## `scripts/repair-remote-cache.sh` — the actual fix

Gradle's **local** build cache (`~/.gradle/caches/build-cache-1/<key>`) uses the **same key space and the same packed format** as the remote, so any machine that has executed the affected task holds a byte-valid replacement. Uploading it under the same key repairs the entry for everyone, rather than routing one build around it.

```
$ scripts/repair-remote-cache.sh --check 12fcc978…a05d 877aca9a…c1ec
── 12fcc978271d75e6470ed675c023a05d
   remote: missing   bytes=0         inflated=0
   local:  absent — cannot repair from this machine
── 877aca9ad8277aac3a9adf9a18efc1ec
   remote: missing   bytes=0         inflated=0
   local:  ok        bytes=628829    inflated=4582400
```

That second line is the mechanism proven end-to-end: while the remote was still serving the poisoned copy (352,256 B, inflating to 2,855,762 B before dying), this container held the healthy one — 628,829 B inflating to 4,582,400 B with a terminating stream. Same key, ~1.7 MB more content.

Design points worth reviewing:

- **Never trusts the PUT status.** The whole bug is a server reporting success while storing something short, so every upload is followed by a re-read and re-inflate; the script only says "repaired" when the stored object terminates.
- **Distinguishes rejections.** 401/403 → readonly token; 409/412 → entries are immutable, so ask for eviction instead. The operator learns which door to knock on.
- **Refuses to upload an unusable local copy**, and reports `ok` / `truncated` / `invalid` / `missing` rather than a bare pass/fail.
- Read-only by default under `--check`; exits non-zero when any key is left unhealthy, so CI can gate on it.

## `.github/workflows/remote-cache-repair.yml`

`workflow_dispatch` wrapper for keys that only reproduce on CI — cache keys derive from inputs, so a key produced by a runner's Gradle/AGP/JDK generally won't reproduce on a laptop (exactly the case for `12fcc978…`, the `gradle-api-9.6.1.jar` classpath-snapshot transform, which is absent locally). It optionally runs the affected tasks with `-Pcomposeai.remoteCache=off` first — which is what keeps *that* build away from the very entries it's meant to replace — then repairs and verifies. Concurrency-grouped so two runs can't race on the same object.

## `composeai.remoteCache` — the kill switch

Defaults to `on`; `off` skips the remote entirely. The load-bearing detail is that it's threaded through **`remotePushEnabled`**, not just the remote's `isEnabled`/`isPush`. `local { isEnabled = !remotePushEnabled }` deliberately disables the local cache on pushing runs so BuildFetch gets seeded — so flipping only the remote flag would have left a `main` run with the remote off *and* the local cache off, executing every cacheable task with no cache at all.

Prefer the repair script; this flag is for when an entry can be neither repaired nor evicted.

## Test plan

- `./gradlew --dry-run help` → **BUILD SUCCESSFUL** (flag `off`, verifying the skip path)
- `ON_CI=true ./gradlew --dry-run help -Pcomposeai.remoteCache=on` → **BUILD SUCCESSFUL** (push path intact for when it's re-enabled)
- `bash -n scripts/repair-remote-cache.sh` clean; `--check` run against both keys shown above (read-only, uploaded nothing)
- **Not exercised: the PUT path.** No write has been made to the cache from here — I don't know whether this token is readwrite, and with both keys now 404 there's nothing left to repair. The upload/verify branch is therefore untested against the real server, and the immutable-entry (409/412) branch is a guess at BuildFetch's semantics. First real use should be a `--check` pass followed by a single key.

Non-visual: build wiring, a shell script and a manual workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V9QFVfWmNCNEWVXAf9gdPs

---
_Generated by [Claude Code](https://claude.ai/code/session_01V9QFVfWmNCNEWVXAf9gdPs)_