### PR TITLE
fix(deps): revert wear-compose-remote to alpha07

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -163,7 +163,12 @@ horologist = "0.7.15"
 #    `RemoteDensity.from` dropped its trailing `Context` arg and now derives
 #    density solely from the `RemoteCreationDisplayInfo` it's handed.
 compose-remote = "1.0.0-alpha15"
-wear-compose-remote = "1.0.0-alpha08"
+#    alpha08 does not exist: the whole `androidx.wear.compose.remote` group stops
+#    at alpha07 on Google Maven (remote-material3 / remote-core / remote-player all
+#    404), so #2823's bump made `:samples:design-catalog-remote-m3` unresolvable and
+#    took `main` red. Back to alpha07 until the wear side actually publishes; when it
+#    does, bump it together with `compose-remote` as the paragraph above requires.
+wear-compose-remote = "1.0.0-alpha07"
 # Glance Wear — the Wear OS *widget* layer on top of Remote Compose. Used by
 # `:samples:design-catalog-remote-m3` to sticker the widget **container** (the
 # squircle the host draws around widget content) via the


### PR DESCRIPTION
`main` is red: `1.0.0-alpha08` does not exist.

The whole `androidx.wear.compose.remote` group stops at **alpha07** on Google Maven. I checked three artifacts — `remote-material3`, `remote-core`, `remote-player` — and all 404 at alpha08 across Google Maven, Maven Central and Gradle's repo. So #2823's bump left `:samples:design-catalog-remote-m3` unable to resolve:

```
Could not determine the dependencies of task ':samples:design-catalog-remote-m3:compileDebugKotlin'.
> Could not resolve all dependencies for configuration ':samples:design-catalog-remote-m3:debugCompileClasspath'.
   > Could not find androidx.wear.compose.remote:remote-material3:1.0.0-alpha08.
```

It fails at *dependency resolution*, so it hits every job that touches the module, on any branch cut from `main`. On #2825 that took down both `Analyze (java-kotlin)` (`debugCompileClasspath`) and `Apply compose-preview` (`debugRuntimeClasspath` + `debugUnitTestRuntimeClasspath`) — neither related to that PR's diff.

## One thing to be aware of before merging

The pin's own comment documents that `compose-remote` and `wear-compose-remote` move as a **mutually-rebuilt pair**, naming alpha13/alpha06 and alpha14/alpha07 as verified pairs, and warning that bumping only one side reintroduces a runtime `NoClassDefFoundError` in `RemoteButtonImpl` at render time.

#2823 looks like it was trying to complete such a pair — #2805 had already moved `compose-remote` alpha14 → **alpha15**, so alpha08 would have been the matching wear side, except it was never published.

This revert therefore leaves `compose-remote alpha15` + `wear-compose-remote alpha07`, which that rule does **not** list as a verified pair. I chose it deliberately over also walking `compose-remote` back to alpha14:

- it restores exactly the state `main` was in for several hours and several merges before #2823, so it's known-survivable rather than theoretical;
- it's the minimal revert of the breaking change, rather than also undoing part of #2805.

If you'd rather have the fully-paired rollback (alpha14 + alpha07), say so and I'll extend it. When the wear side actually publishes alpha08, bump both together as that paragraph requires — I left a note at the pin saying so.

## Test plan

- `./gradlew :samples:design-catalog-remote-m3:compileDebugKotlin` → **BUILD SUCCESSFUL in 53s**. That's the exact task whose classpath couldn't resolve, so it verifies both that alpha07 resolves and that the alpha15/alpha07 pairing compiles.

Not covered locally: the runtime side of the pairing warning (`RemoteButtonImpl` at preview-render time) — this container can't render that module's previews (no GL libs). CI's compose-preview job is the check that matters there, and it should now get far enough to run.

Non-visual: a single version-catalog line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V9QFVfWmNCNEWVXAf9gdPs

---
_Generated by [Claude Code](https://claude.ai/code/session_01V9QFVfWmNCNEWVXAf9gdPs)_