### PR TITLE
fix(server): accept JSON catalog props

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
@@ -12,6 +12,7 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.builtins.MapSerializer
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
 import okhttp3.OkHttpClient
 import okhttp3.Request
 
@@ -160,10 +161,12 @@ class ServeCatalogStore(
         return Result.Failed(system, "could not fetch catalog.json: ${e.message}")
       } ?: return Result.Failed(system, "could not fetch $base$CATALOG_FILE")
     val catalog =
-      runCatching {
-          json.decodeFromString(Catalog.serializer(), catalogBytes.toString(Charsets.UTF_8))
-        }
-        .getOrNull() ?: return Result.Failed(system, "could not parse catalog.json")
+      try {
+        json.decodeFromString(Catalog.serializer(), catalogBytes.toString(Charsets.UTF_8))
+      } catch (e: Exception) {
+        val detail = e.message?.takeIf { it.isNotBlank() } ?: e::class.simpleName ?: "unknown error"
+        return Result.Failed(system, "could not parse catalog.json: $detail")
+      }
 
     // Stage the fetch so a re-load (ServeCatalogRefresher) can't turn a healthy catalog into 404s:
     // fetch the images into a sibling `.staging` dir and only swap it over the live `dir` once we
@@ -925,7 +928,7 @@ class ServeCatalogStore(
      * axis. Carried into `previews/variants.json` so the serve grid can fold these variants onto
      * the component's one card (like [state]) instead of showing each as its own tile.
      */
-    val props: Map<String, String>? = null,
+    val props: JsonObject? = null,
   )
 
   /**
@@ -950,7 +953,7 @@ class ServeCatalogStore(
      * for the default render. Lets a preview host fold props variants onto the component's one card
      * (like [state]) and offer a variant switcher. Null for a catalog that varies on neither props.
      */
-    val props: Map<String, String>? = null,
+    val props: JsonObject? = null,
     val section: String? = null,
     val group: String? = null,
     val order: Int? = null,

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
@@ -26,6 +26,7 @@ import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.contentOrNull
@@ -109,7 +110,7 @@ data class ServePreview(
    * fold these variants onto the component's one card (like [state], rather than a tile each) and
    * the viewer offer a variant switcher. Null keeps the current behaviour everywhere.
    */
-  val props: Map<String, String>? = null,
+  val props: JsonObject? = null,
   /**
    * The top-level **section** (tab) this preview belongs to — `"Themes"`, `"Components"`,
    * `"Screens"`, `"Animations"`, … — from the catalog's `previews/variants.json`. Drives the

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -1,5 +1,10 @@
 package ee.schimke.composeai.cli.serve
 
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+
 /**
  * In-code HTML/CSS/JS for the `compose-preview serve` web surface. Generated as Kotlin raw strings
  * (the house style — see [ee.schimke.composeai.cli.WebEmbed]) so the token + preview ids inject
@@ -815,20 +820,47 @@ object ServeWeb {
       .trimIndent()
   }
 
-  /** A stable signature for a preview's props axis (sorted `k=v` pairs); `""` for the default. */
-  private fun propsSignature(props: Map<String, String>?): String =
-    props?.entries?.sortedBy { it.key }?.joinToString(",") { "${it.key}=${it.value}" } ?: ""
+  /**
+   * Canonical JSON for a props value. Objects sort their keys recursively, while arrays preserve
+   * their authored order. This keeps the variant identity stable even when two producers emit an
+   * equivalent object with a different property order, and it keeps JSON types distinct (`true` is
+   * not the same variant as `"true"`).
+   */
+  private fun canonicalPropsJson(value: JsonElement): String =
+    when (value) {
+      is JsonObject ->
+        value.entries
+          .sortedBy { it.key }
+          .joinToString(prefix = "{", postfix = "}") { (key, child) ->
+            "${JsonPrimitive(key)}:${canonicalPropsJson(child)}"
+          }
+      is JsonArray ->
+        value.joinToString(prefix = "[", postfix = "]") { child -> canonicalPropsJson(child) }
+      else -> value.toString()
+    }
+
+  /** Human-readable form of a props value: unquote scalars, retain compact JSON for structures. */
+  private fun propsValueLabel(value: JsonElement): String =
+    if (value is JsonPrimitive) value.content else canonicalPropsJson(value)
+
+  /** A stable signature for a preview's props axis (sorted `k=value` pairs); `""` for default. */
+  private fun propsSignature(props: JsonObject?): String =
+    props
+      ?.entries
+      ?.sortedBy { it.key }
+      ?.joinToString(",") { "${it.key}=${canonicalPropsJson(it.value)}" } ?: ""
 
   /**
    * Human label for a props-variant axis: "Default" for none, else a compact per-axis phrasing
    * ("RTL", "Locale ar-XB", "Font 2.0×", "Icon+label"), falling back to `key value` for an unknown
    * axis. Multiple axes join with " · ". Used for the viewer's variant-switcher buttons.
    */
-  private fun propsLabel(props: Map<String, String>?): String {
+  private fun propsLabel(props: JsonObject?): String {
     if (props.isNullOrEmpty()) return "Default"
     return props.entries
       .sortedBy { it.key }
-      .joinToString(" · ") { (k, v) ->
+      .joinToString(" · ") { (k, rawValue) ->
+        val v = propsValueLabel(rawValue)
         when (k) {
           "direction" -> v.uppercase()
           "locale" -> "Locale $v"

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
@@ -12,6 +12,8 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
 
 /**
  * Coverage for [ServeCatalogStore] — fetching a published `design-artifacts/<system>` catalog and
@@ -215,6 +217,77 @@ class ServeCatalogStoreTest {
       "default" to "light",
       byId.getValue("checkbox__ideal__default__light").let { it.state to it.theme },
     )
+  }
+
+  @Test
+  fun `catalog props preserve arbitrary JSON values through the variants manifest`() {
+    val flexibleProps =
+      """
+      {"schema":"design-parity-catalog/v1","system":"reply","components":[
+        {"componentId":"Adaptive/Phone","images":[
+          {"path":"images/adaptive-phone/ideal__default.png","props":{
+            "enabled":true,
+            "count":3,
+            "nullable":null,
+            "nested":{"mode":"compact"},
+            "items":[1,"two"]
+          }}]}]}
+      """
+        .trimIndent()
+    val root = tempRoot()
+    val fetch: (String) -> ByteArray? = { url ->
+      when {
+        url.endsWith("/${ServeCatalogStore.CATALOG_FILE}") -> flexibleProps.toByteArray()
+        url.endsWith(".png") -> png()
+        else -> null
+      }
+    }
+    val store =
+      ServeCatalogStore(
+        root = root,
+        register = { n, h -> registered[n] = h },
+        trust = TrustStore.EMPTY,
+        fetch = fetch,
+      )
+
+    assertTrue(store.load("reply") is ServeCatalogStore.Result.Ok)
+    val expected =
+      Json.parseToJsonElement(
+          """{"enabled":true,"count":3,"nullable":null,"nested":{"mode":"compact"},"items":[1,"two"]}"""
+        )
+        .jsonObject
+    val preview = registered.getValue("reply").previews.single()
+    assertEquals(expected, preview.props)
+
+    val manifest = File(root, "reply/previews/${ServeCatalogStore.VARIANTS_FILE}").readText()
+    assertEquals(
+      expected,
+      Json.parseToJsonElement(manifest)
+        .jsonObject
+        .values
+        .single()
+        .jsonObject
+        .getValue("props")
+        .jsonObject,
+    )
+  }
+
+  @Test
+  fun `a malformed catalog reports the deserialization error`() {
+    val malformed = """{"components":"not-an-array"}"""
+    val result =
+      store(
+          TrustStore.EMPTY,
+          fetch = { url ->
+            if (url.endsWith("/${ServeCatalogStore.CATALOG_FILE}")) malformed.toByteArray()
+            else null
+          },
+        )
+        .load("broken")
+
+    assertTrue(result is ServeCatalogStore.Result.Failed)
+    assertTrue(result.reason.startsWith("could not parse catalog.json: "), result.reason)
+    assertTrue(result.reason.length > "could not parse catalog.json: ".length, result.reason)
   }
 
   @Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -17,6 +17,9 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
 
 /**
  * Golden generator + drift guard for the `serve` web surfaces captured by the preview-harness.
@@ -38,6 +41,10 @@ import kotlin.test.assertTrue
  * forked test JVM but not arbitrary system properties.)
  */
 class ServeWebFixtureTest {
+
+  private fun jsonProps(vararg entries: Pair<String, String>): JsonObject = buildJsonObject {
+    for ((key, value) in entries) put(key, JsonPrimitive(value))
+  }
 
   private val token = "demo-token-fixture"
   private val moduleLabel = ":samples:cmp"
@@ -292,42 +299,42 @@ class ServeWebFixtureTest {
         "Button · Filled · RTL (light)",
         state = "default",
         theme = "light",
-        props = mapOf("direction" to "rtl"),
+        props = jsonProps("direction" to "rtl"),
       ),
       ServePreview(
         "button-filled__ideal__default__dark__direction-rtl",
         "Button · Filled · RTL (dark)",
         state = "default",
         theme = "dark",
-        props = mapOf("direction" to "rtl"),
+        props = jsonProps("direction" to "rtl"),
       ),
       ServePreview(
         "button-filled__ideal__default__light__locale-ar-xb",
         "Button · Filled · ar-XB (light)",
         state = "default",
         theme = "light",
-        props = mapOf("locale" to "ar-XB"),
+        props = jsonProps("locale" to "ar-XB"),
       ),
       ServePreview(
         "button-filled__ideal__default__dark__locale-ar-xb",
         "Button · Filled · ar-XB (dark)",
         state = "default",
         theme = "dark",
-        props = mapOf("locale" to "ar-XB"),
+        props = jsonProps("locale" to "ar-XB"),
       ),
       ServePreview(
         "button-filled__ideal__default__light__fontscale-2.0",
         "Button · Filled · 2× font (light)",
         state = "default",
         theme = "light",
-        props = mapOf("fontScale" to "2.0"),
+        props = jsonProps("fontScale" to "2.0"),
       ),
       ServePreview(
         "button-filled__ideal__default__dark__fontscale-2.0",
         "Button · Filled · 2× font (dark)",
         state = "default",
         theme = "dark",
-        props = mapOf("fontScale" to "2.0"),
+        props = jsonProps("fontScale" to "2.0"),
       ),
     )
 

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebTest.kt
@@ -4,6 +4,9 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
 
 /**
  * Pins the **component-state toggle** wiring in [ServeWeb]: baked non-default states
@@ -12,6 +15,10 @@ import kotlin.test.assertTrue
  * states *in the same theme*. Stateless previews (a plain uploaded bundle) are untouched.
  */
 class ServeWebTest {
+
+  private fun jsonProps(vararg entries: Pair<String, String>): JsonObject = buildJsonObject {
+    for ((key, value) in entries) put(key, JsonPrimitive(value))
+  }
 
   /**
    * A themed, state-bearing preview (id carries the theme token so the grid's theme swap still
@@ -166,28 +173,28 @@ class ServeWebTest {
         "Filled · RTL",
         state = "default",
         theme = "light",
-        props = mapOf("direction" to "rtl"),
+        props = jsonProps("direction" to "rtl"),
       ),
       ServePreview(
         "button-filled__ideal__default__dark__direction-rtl",
         "Filled · RTL",
         state = "default",
         theme = "dark",
-        props = mapOf("direction" to "rtl"),
+        props = jsonProps("direction" to "rtl"),
       ),
       ServePreview(
         "button-filled__ideal__default__light__locale-ar-xb",
         "Filled · ar-XB",
         state = "default",
         theme = "light",
-        props = mapOf("locale" to "ar-XB"),
+        props = jsonProps("locale" to "ar-XB"),
       ),
       ServePreview(
         "button-filled__ideal__default__dark__locale-ar-xb",
         "Filled · ar-XB",
         state = "default",
         theme = "dark",
-        props = mapOf("locale" to "ar-XB"),
+        props = jsonProps("locale" to "ar-XB"),
       ),
     )
 

--- a/scripts/design-artifacts/catalog-variants.mjs
+++ b/scripts/design-artifacts/catalog-variants.mjs
@@ -28,7 +28,7 @@
  * fold so the workflow render matches the parity flow.
  *
  * @param {Array<{state?: string}>} defaultImages the default preview's images.
- * @param {{componentId: string, variants?: Array<{state?: string, props?: Record<string,string>, preview: string}>}} component
+ * @param {{componentId: string, variants?: Array<{state?: string, props?: Record<string,unknown>, preview: string}>}} component
  *   the spec component (its `variants` drive the fold).
  * @param {Map<string, {images: Array<object>}>} byFunction rendered candidates
  *   keyed by `@Preview` function name.


### PR DESCRIPTION
## What changed

- model catalog and served-preview `props` as JSON objects rather than string-only maps
- preserve booleans, numbers, nulls, arrays, and nested objects through `variants.json`
- canonicalize structured values for stable variant grouping and human-readable viewer labels
- include the underlying serialization error when a catalog cannot be parsed
- align the catalog-variant JSDoc with the existing schema’s arbitrary JSON-value contract

## Why

`preview.coo.ee` omitted Jetcaster, Jetsnack, and Reply because their published catalogs contain boolean, numeric, or null prop values. `ServeCatalogStore` declared `props` as `Map<String, String>`, so `kotlinx.serialization` rejected each entire catalog as `could not parse catalog.json`. JetNews, Jetchat, and JetLagged worked only because all of their prop values happened to be strings.

This accepts the contract already expressed by `catalog.spec.schema.json` (`additionalProperties: true`) and prevents one valid prop value from dropping an entire catalog.

## Validation

- `./gradlew :cli:ktfmtCheck :cli:test --tests '*ServeCatalogStoreTest*' --tests '*ServeWebTest*' --tests '*ServeWebFixtureTest*'`
- `node --test scripts/design-artifacts/catalog-variants.test.mjs`

Regression coverage verifies boolean, number, null, array, and nested-object values survive catalog loading, the generated variants manifest, and host registration.