### PR TITLE
fix(serve): expose and retry partial catalog failures

### DIFF
--- a/.github/workflows/preview-host-image.yml
+++ b/.github/workflows/preview-host-image.yml
@@ -187,19 +187,34 @@ jobs:
             200|202) echo "roll triggered." ;;
             *) echo "::warning::deploy hook returned ${code}; the box will still roll on its next poll." ;;
           esac
-          # Advisory convergence check: poll the ungated /version until it reports the
-          # new build, so this run shows the box actually rolled. Non-fatal on timeout
-          # (a slow catalog fetch + first readiness render can outlast this; the roll
-          # still completes).
+          # Deployment convergence + catalog health reporting. The incident that motivated this
+          # check ran the right version while silently omitting three configured catalogs. Catalog
+          # loading stays best-effort (one external branch must not block the server rollout), but
+          # the run now prints a prominent warning with every failed/stale catalog instead of
+          # declaring success from /version alone.
           base="${HOOK_URL%/__hooks/rollout}"
           for i in $(seq 1 30); do
-            live=$(curl -fsS -m 10 "${base}/version" 2>/dev/null \
+            version_json=$(curl -fsS -m 10 "${base}/version" 2>/dev/null || true)
+            status_json=$(curl -fsS -m 10 "${base}/status.json" 2>/dev/null || true)
+            live=$(printf '%s' "${version_json}" \
               | tr -d ' \n' | sed -n 's/.*"version":"\([^"]*\)".*/\1/p' || true)
-            if [ "${live}" = "${V}" ]; then
-              echo "preview.coo.ee now serving ${V}."
+            loaded=$(printf '%s' "${status_json}" | jq -r '.catalogs.loaded // -1' 2>/dev/null || echo -1)
+            total=$(printf '%s' "${status_json}" | jq -r '.catalogs.total // -1' 2>/dev/null || echo -1)
+            failed=$(printf '%s' "${status_json}" | jq -r '.catalogs.failed // -1' 2>/dev/null || echo -1)
+            if [ "${live}" = "${V}" ] && [ "${total}" -ge 0 ] && [ "${loaded}" -ge 0 ] &&
+               [ "${failed}" -ge 0 ]; then
+              problems=$(printf '%s' "${status_json}" | jq -r \
+                '[.catalogList[] | select(.loadState != "loaded") |
+                  "\(.id) [\(.loadState)]: \(.loadError // "pending")"] | join("; ")')
+              if [ -n "${problems}" ]; then
+                echo "::warning::preview.coo.ee deployed ${V}, but catalogs are partial (${loaded}/${total} loaded, ${failed} failed): ${problems}"
+              else
+                echo "preview.coo.ee now serving ${V} with ${loaded}/${total} catalogs loaded."
+              fi
               exit 0
             fi
-            echo "waiting for preview.coo.ee to report ${V} (currently '${live:-?}', attempt ${i}/30)…"
+            echo "waiting for preview.coo.ee: version=${live:-?}/${V}, catalogs=${loaded}/${total}, failed=${failed} (attempt ${i}/30)…"
             sleep 20
           done
-          echo "::warning::preview.coo.ee did not report ${V} within ~10 min — it may still be warming or will roll on its next poll; not failing the publish."
+          echo "::error::preview.coo.ee did not converge to ${V} with a readable catalog status within ~10 min." >&2
+          exit 1

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -1,6 +1,7 @@
 package ee.schimke.composeai.cli
 
 import ee.schimke.composeai.cli.serve.BundleVerifier
+import ee.schimke.composeai.cli.serve.CatalogLoadTracker
 import ee.schimke.composeai.cli.serve.DaemonStartupLog
 import ee.schimke.composeai.cli.serve.GitWorktrees
 import ee.schimke.composeai.cli.serve.GradleRevisionBuilder
@@ -505,9 +506,9 @@ class ServeCommand(args: List<String>) : Command(args) {
     // Keep the catalogs fresh against their (routinely-changing) branches without a restart.
     val catalogRefresher =
       catalogReg
-        ?.let { buildCatalogRefresher(it.store) }
+        ?.let { buildCatalogRefresher(it.store, it.loads) }
         ?.also {
-          it.seedInitialHeads()
+          it.seedInitialHeads(catalogReg.loads.availableSystems())
           it.start()
         }
     // Runtime ingestion (--accept-bundles): clients POST a bundle (or a ?url= to one) and it's
@@ -536,6 +537,7 @@ class ServeCommand(args: List<String>) : Command(args) {
           catalogRefresher,
           catalogPerPreviewPoolsCloseable,
         ),
+      catalogLoads = catalogReg?.loads,
     )
   }
 
@@ -568,9 +570,9 @@ class ServeCommand(args: List<String>) : Command(args) {
     // public preview server (preview.coo.ee) runs this module-less path.
     val catalogRefresher =
       catalogReg
-        ?.let { buildCatalogRefresher(it.store) }
+        ?.let { buildCatalogRefresher(it.store, it.loads) }
         ?.also {
-          it.seedInitialHeads()
+          it.seedInitialHeads(catalogReg.loads.availableSystems())
           it.start()
         }
     val bundleStore = if (acceptBundles) openUploadStore(registry) else null
@@ -616,6 +618,7 @@ class ServeCommand(args: List<String>) : Command(args) {
       mdnsModuleLabel = null,
       mdnsPreviewIds = null,
       closeables = listOfNotNull(catalogPerPreviewPoolsCloseable, catalogRefresher),
+      catalogLoads = catalogReg?.loads,
     )
   }
 
@@ -711,7 +714,14 @@ class ServeCommand(args: List<String>) : Command(args) {
     mdnsModuleLabel: String?,
     mdnsPreviewIds: List<String>?,
     closeables: List<AutoCloseable?>,
+    catalogLoads: CatalogLoadTracker?,
   ) {
+    val configuredCatalogs =
+      catalogLoads?.snapshot()?.filter { it.config.listed }?.map { it.config.system }
+        ?: registeredCatalogs.toList()
+    val configuredApps =
+      catalogLoads?.snapshot()?.filter { !it.config.listed }?.map { it.config.system }
+        ?: registeredUnlistedCatalogs.toList()
     val server =
       ServeHttpServer(
         host = host,
@@ -722,8 +732,11 @@ class ServeCommand(args: List<String>) : Command(args) {
         bundleStore = bundleStore,
         isPublic = public,
         wasmCatalogs = wasmCatalogs,
-        catalogSessions = registeredCatalogs.toList(),
-        appCatalogSessions = registeredUnlistedCatalogs.toList(),
+        // Preserve the CONFIGURED set, not only startup successes. Failed rows then stay visible on
+        // /status, and a catalog recovered by the refresher appears on the home index immediately.
+        catalogSessions = configuredCatalogs,
+        appCatalogSessions = configuredApps,
+        catalogLoads = catalogLoads,
         maxLiveSeats = liveSeats,
         daemonLog = daemonLog,
         allowRenderTrusted = allowRenderTrusted,
@@ -990,9 +1003,15 @@ class ServeCommand(args: List<String>) : Command(args) {
    * it as a pinned `?session=<system>` session ([ServeCatalogStore]). Trusted-by-origin when the
    * branch is in the trust store; otherwise served as `unverified` (the images execute no code).
    * Best-effort per system — one catalog failing to fetch doesn't sink the others or the server.
+   *
+   * [registerCatalogs] result: wasm-app dirs, the store a refresher re-loads from, and the
+   * configured/load state exposed through status.
    */
-  /** [registerCatalogs] result: the wasm-app dirs plus the [store] a refresher re-loads from. */
-  private class CatalogRegistration(val wasm: Map<String, File>, val store: ServeCatalogStore)
+  private class CatalogRegistration(
+    val wasm: Map<String, File>,
+    val store: ServeCatalogStore,
+    val loads: CatalogLoadTracker,
+  )
 
   private fun registerCatalogs(
     registry: ServeSessionRegistry,
@@ -1002,6 +1021,17 @@ class ServeCommand(args: List<String>) : Command(args) {
     val dir =
       java.nio.file.Files.createTempDirectory("serve-catalogs").toFile().also { it.deleteOnExit() }
     val wasm = linkedMapOf<String, File>()
+    val loads =
+      CatalogLoadTracker(
+        catalogRefs.map { ref ->
+          CatalogLoadTracker.Config(
+            system = ref.system,
+            listed = ref.listed,
+            repo = ref.repo,
+            branch = "$catalogBranchPrefix${ref.system}",
+          )
+        }
+      )
     val store =
       ServeCatalogStore(
         root = dir,
@@ -1046,7 +1076,9 @@ class ServeCommand(args: List<String>) : Command(args) {
         },
       )
     for (ref in catalogRefs) {
-      when (val r = store.load(ref.system, sourceRepo = ref.repo)) {
+      val result = store.load(ref.system, sourceRepo = ref.repo)
+      loads.record(result)
+      when (val r = result) {
         is ServeCatalogStore.Result.Ok -> {
           // Listed catalogs feed the front-page "Design systems" nav; unlisted app catalogs feed
           // the separate "Apps" section (both reachable at /<system>/ and ?session=<system>).
@@ -1060,7 +1092,8 @@ class ServeCommand(args: List<String>) : Command(args) {
           System.err.println("serve: catalog ${r.system} not served: ${r.reason}")
       }
     }
-    return CatalogRegistration(wasm = wasm, store = store)
+    System.err.println("serve: ${loads.startupSummary()}")
+    return CatalogRegistration(wasm = wasm, store = store, loads = loads)
   }
 
   /**
@@ -1071,7 +1104,10 @@ class ServeCommand(args: List<String>) : Command(args) {
    * place (the registry closes the replaced daemon) and rewrites the on-disk `web/wasm/` dir the
    * `/wasm/<system>/` route serves.
    */
-  private fun buildCatalogRefresher(store: ServeCatalogStore): ServeCatalogRefresher? {
+  private fun buildCatalogRefresher(
+    store: ServeCatalogStore,
+    loads: CatalogLoadTracker,
+  ): ServeCatalogRefresher? {
     if (catalogRefreshSeconds <= 0 || catalogRefs.isEmpty()) return null
     val entries = catalogRefs.map {
       ServeCatalogRefresher.Entry(
@@ -1083,7 +1119,14 @@ class ServeCommand(args: List<String>) : Command(args) {
     return ServeCatalogRefresher(
       entries = entries,
       reload = { system, repo ->
-        store.load(system, sourceRepo = repo) is ServeCatalogStore.Result.Ok
+        val result = store.load(system, sourceRepo = repo)
+        loads.record(result)
+        if (result is ServeCatalogStore.Result.Failed) {
+          System.err.println("serve: catalog $system refresh failed: ${result.reason}")
+          false
+        } else {
+          true
+        }
       },
       intervalMillis = catalogRefreshSeconds * 1000,
     )

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogLoadTracker.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogLoadTracker.kt
@@ -1,0 +1,99 @@
+package ee.schimke.composeai.cli.serve
+
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Thread-safe source of truth for every catalog the operator configured and its latest load
+ * outcome.
+ *
+ * A failed catalog used to disappear completely: startup logged one stderr line, while readiness,
+ * `/status`, the home index, and the branch refresher only knew about successfully registered
+ * sessions. That made "configured but broken" indistinguishable from "not configured". This tracker
+ * preserves the configured set across startup and background refreshes so every consumer observes
+ * the same state.
+ *
+ * [State.available] means a usable copy is currently registered. A refresh failure after an earlier
+ * success keeps it true because [ServeCatalogStore] retains the last good staged copy; the
+ * [State.error] still records that the latest refresh failed. An initial failure has
+ * `available=false`, remains visible in status, and stays eligible for refresh retry. Catalog
+ * availability deliberately does not gate server readiness: a usable server with a partial external
+ * catalog set should still deploy.
+ */
+class CatalogLoadTracker(
+  configured: List<Config>,
+  private val clock: () -> Long = System::currentTimeMillis,
+) {
+  /** One configured catalog and where its delivery branch lives. */
+  data class Config(val system: String, val listed: Boolean, val repo: String, val branch: String)
+
+  /** Immutable snapshot of one catalog's current availability and latest attempt. */
+  data class State(
+    val config: Config,
+    val available: Boolean = false,
+    val error: String? = null,
+    val lastAttemptEpochMillis: Long? = null,
+  ) {
+    val loadState: String
+      get() =
+        when {
+          available && error == null -> "loaded"
+          available -> "stale"
+          error != null -> "failed"
+          else -> "pending"
+        }
+  }
+
+  private val ordered =
+    configured
+      .distinctBy { it.system }
+      .also { require(it.size == configured.size) { "duplicate catalog system id" } }
+  private val states = ConcurrentHashMap(ordered.associate { it.system to State(it) })
+
+  fun record(result: ServeCatalogStore.Result) {
+    when (result) {
+      is ServeCatalogStore.Result.Ok -> recordSuccess(result.system)
+      is ServeCatalogStore.Result.Failed -> recordFailure(result.system, result.reason)
+    }
+  }
+
+  fun recordSuccess(system: String) {
+    val at = clock()
+    states.computeIfPresent(system) { _, previous ->
+      previous.copy(available = true, error = null, lastAttemptEpochMillis = at)
+    }
+  }
+
+  fun recordFailure(system: String, reason: String) {
+    val at = clock()
+    states.computeIfPresent(system) { _, previous ->
+      // A refresh is staged before swap, so failure leaves an earlier usable copy available.
+      previous.copy(error = oneLine(reason), lastAttemptEpochMillis = at)
+    }
+  }
+
+  /** Stable configured-order snapshot, safe to iterate without holding a lock. */
+  fun snapshot(): List<State> = ordered.map { states.getValue(it.system) }
+
+  /** Catalogs with a usable registered copy; used to seed only successful branch heads. */
+  fun availableSystems(): Set<String> =
+    states.values.asSequence().filter { it.available }.map { it.config.system }.toSet()
+
+  /** True only after every explicitly configured catalog has a usable registered copy. */
+  fun allAvailable(): Boolean = states.values.all { it.available }
+
+  fun startupSummary(): String {
+    val current = snapshot()
+    val available = current.count { it.available }
+    val failed = current.filter { !it.available && it.error != null }
+    return buildString {
+      append("catalogs ").append(available).append('/').append(current.size).append(" loaded")
+      if (failed.isNotEmpty()) {
+        append("; failed: ")
+        append(failed.joinToString(", ") { it.config.system })
+      }
+    }
+  }
+
+  private fun oneLine(reason: String): String =
+    reason.lineSequence().map { it.trim() }.firstOrNull { it.isNotEmpty() } ?: "unknown error"
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogRefresher.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogRefresher.kt
@@ -48,12 +48,18 @@ internal class ServeCatalogRefresher(
   }
 
   /**
-   * Record each branch's current head so the first tick only reloads a branch that has *moved since
-   * boot*, not every branch once. Best-effort — an unresolvable branch stays absent, so its first
-   * successful resolve later counts as "changed" and triggers one reload (harmless, idempotent).
+   * Record the current head for catalogs that loaded successfully at boot, so their first tick only
+   * reloads after a branch move. [systems] deliberately excludes startup failures: leaving their
+   * head absent makes the first tick retry the unchanged branch, then every later tick until it
+   * succeeds. Previously every configured head was seeded, permanently suppressing retries for an
+   * initial fetch/parse failure until someone happened to publish a new commit.
    */
-  fun seedInitialHeads() {
-    for (e in entries) headResolver(e.repo, e.branch)?.let { lastHead[e.system] = it }
+  fun seedInitialHeads(systems: Set<String> = entries.mapTo(linkedSetOf()) { it.system }) {
+    for (e in entries) {
+      if (e.system in systems) {
+        headResolver(e.repo, e.branch)?.let { lastHead[e.system] = it }
+      }
+    }
   }
 
   /** Start the daemon poller. Idempotent-safe to call once after [seedInitialHeads]. */

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -110,6 +110,13 @@ class ServeHttpServer(
    * exists, so an app's own landing keeps a "← back" link whenever the server also lists systems.
    */
   private val appCatalogSessions: List<String> = emptyList(),
+  /**
+   * Configured catalog availability shared with startup + refresh. When present, `/status` includes
+   * failed/pending catalogs instead of silently omitting them. Catalog loading remains best-effort:
+   * `/readyz` validates a representative usable session, while this tracker makes partial service
+   * explicit and recoverable. Null preserves the plain/test server behaviour.
+   */
+  private val catalogLoads: CatalogLoadTracker? = null,
   portRange: Int = DEFAULT_PORT_RANGE,
   /**
    * Max renders in flight across the HTTP `/render` lane. Defaults to the host's CPU count so a
@@ -238,9 +245,9 @@ class ServeHttpServer(
         }
 
         // `/status` — the operator/observer view of this running host: published catalogs + their
-        // trust/liveness, the render daemons up right now, the effective config, and recent daemon
-        // startup failures. HTML by default (`?format=json` for the machine form); `/status.json`
-        // is
+        // trust/liveness/load errors, the render daemons up right now, the effective config, and
+        // recent daemon startup failures. HTML by default (`?format=json` for the machine form);
+        // `/status.json` is
         // the canonical JSON a monitor / Home Assistant sensor polls. Both are gated like the rest
         // (open in `--public`, else token-required) — the running-daemon + config detail is more
         // sensitive than `/version`/`/healthz`, so a private box keeps it behind the token.
@@ -633,10 +640,10 @@ class ServeHttpServer(
 
   /**
    * `GET /status` (HTML, or JSON with `?format=json`) and `GET /status.json` (JSON): a live
-   * snapshot of this host — published catalogs + their trust/liveness, the render daemons up right
-   * now, the effective config, and recent daemon startup failures. Gated like the API routes (open
-   * in `--public`, else token-required). The JSON form is the canonical machine surface for a
-   * monitor / Home Assistant sensor; the HTML form is its human face.
+   * snapshot of this host — configured catalogs + their availability/trust/liveness, the render
+   * daemons up right now, the effective config, and recent daemon startup failures. Gated like the
+   * API routes (open in `--public`, else token-required). The JSON form is the canonical machine
+   * surface for a monitor / Home Assistant sensor; the HTML form is its human face.
    */
   private suspend fun RoutingContext.handleStatus(json: Boolean) {
     if (rejectBadToken()) return
@@ -747,6 +754,13 @@ class ServeHttpServer(
     val running: Boolean,
     val degradation: String?,
     val provenance: ServeWeb.CatalogProvenance?,
+    /** A usable catalog session is currently registered (possibly the last good refresh copy). */
+    val available: Boolean,
+    /**
+     * Latest startup/refresh error; may coexist with [available] when the old copy was retained.
+     */
+    val loadError: String?,
+    val lastLoadAttemptEpochMillis: Long?,
     /**
      * The metadata above is a **last-known snapshot** of a now-suspended catalog
      * ([catalogMetaSeen]) rather than a live read, because the session's daemon is idle. Facts a
@@ -754,7 +768,16 @@ class ServeHttpServer(
      * not-live.
      */
     val stale: Boolean = false,
-  )
+  ) {
+    val loadState: String
+      get() =
+        when {
+          available && loadError == null -> "loaded"
+          available -> "stale"
+          loadError != null -> "failed"
+          else -> "pending"
+        }
+  }
 
   /**
    * Last-known catalog metadata per session id, captured while the host was resident. A suspended
@@ -842,7 +865,8 @@ class ServeHttpServer(
       StatusResponse(
         version = BUNDLE_VERSION,
         public = isPublic,
-        status = if (failures.isEmpty()) "ok" else "degraded",
+        status =
+          if (failures.isEmpty() && catalogs.none { it.loadError != null }) "ok" else "degraded",
         uptimeSeconds = uptimeSeconds,
         catalogs =
           CatalogSummaryDto(
@@ -850,7 +874,10 @@ class ServeHttpServer(
             listed = catalogs.count { it.listed },
             unlisted = catalogs.count { !it.listed },
             trusted = catalogs.count { it.trust != null && it.trust != "unverified" },
-            degraded = catalogs.count { it.degradation != null },
+            degraded = catalogs.count { it.degradation != null || it.loadError != null },
+            loaded = catalogs.count { it.available },
+            failed = catalogs.count { !it.available && it.loadError != null },
+            pending = catalogs.count { !it.available && it.loadError == null },
           ),
         daemons =
           DaemonSummaryDto(
@@ -888,6 +915,9 @@ class ServeHttpServer(
               generatedAt = c.provenance?.generatedAt,
               path = "/${c.id}/",
               metaStale = c.stale,
+              loadState = c.loadState,
+              loadError = c.loadError,
+              lastLoadAttemptEpochMillis = c.lastLoadAttemptEpochMillis,
             )
           },
         runningServers =
@@ -924,7 +954,7 @@ class ServeHttpServer(
             .filter { it.renders + it.cacheHits + it.busy > 0 }
         )
       val summary = buildList {
-        add(ServeWeb.Stat("Catalogs", catalogs.size.toString()))
+        add(ServeWeb.Stat("Catalogs", "${catalogs.count { it.available }}/${catalogs.size} loaded"))
         add(ServeWeb.Stat("Live daemons running", liveDaemons.size.toString()))
         add(ServeWeb.Stat("Active streams", activeStreams.toString()))
         add(ServeWeb.Stat("Live seats", seatsText))
@@ -964,7 +994,7 @@ class ServeHttpServer(
       return ServeWeb.StatusView(
         version = BUNDLE_VERSION,
         public = isPublic,
-        overallOk = failures.isEmpty(),
+        overallOk = failures.isEmpty() && catalogs.none { it.loadError != null },
         summary = summary,
         config = config,
         catalogs =
@@ -986,6 +1016,8 @@ class ServeHttpServer(
                     p.generatedAt?.let { append(" · ").append(it) }
                   }
                 },
+              loadState = c.loadState,
+              loadError = c.loadError,
             )
           },
         servers =
@@ -1042,15 +1074,20 @@ class ServeHttpServer(
   private fun buildStatusData(): StatusData {
     val running = sessions.runningDaemons()
     val byId = running.associateBy { it.id }
-    val entries = catalogSessions.map { it to true } + appCatalogSessions.map { it to false }
+    val tracked = catalogLoads?.snapshot()?.associateBy { it.config.system }.orEmpty()
+    val entries =
+      if (tracked.isNotEmpty()) tracked.values.map { it.config.system to it.config.listed }
+      else catalogSessions.map { it to true } + appCatalogSessions.map { it to false }
     val catalogs = entries.map { (id, listed) ->
+      val load = tracked[id]
       val daemon = byId[id]
       val host = sessions.peekHost(id)
       val bundle = host?.let { catalogBundleHost(it) }
       // Liveness from the resident snapshot only (never resume): absent ⇒ a suspended live
       // catalog; present-with-live-stream ⇒ its daemon is up; present-without ⇒ static baked host.
       val running = daemon?.hasLiveStream == true
-      val live = daemon == null || daemon.hasLiveStream
+      val available = load?.available ?: true
+      val live = available && (daemon == null || daemon.hasLiveStream)
       // Resident: read live and refresh the snapshot (a catalog refresh can change provenance).
       if (host != null) rememberCatalogMeta(id, host)
       val seen = if (host == null) catalogMetaSeen[id] else null
@@ -1063,7 +1100,13 @@ class ServeHttpServer(
         live = live,
         running = running,
         degradation = host?.degradations?.firstOrNull()?.detail ?: seen?.degradation,
-        provenance = bundle?.provenance ?: seen?.provenance,
+        provenance =
+          bundle?.provenance
+            ?: seen?.provenance
+            ?: load?.config?.let { ServeWeb.CatalogProvenance(it.repo, it.branch) },
+        available = available,
+        loadError = load?.error,
+        lastLoadAttemptEpochMillis = load?.lastAttemptEpochMillis,
         stale = seen != null,
       )
     }
@@ -1950,7 +1993,7 @@ private data class StatusResponse(
   val version: String,
   /** True when the box serves token-free (public preview server). */
   val public: Boolean,
-  /** `ok` when there are no recent daemon startup failures, else `degraded`. */
+  /** `ok` when there are no catalog load or recent daemon startup failures, else `degraded`. */
   val status: String,
   /** Seconds since the server started. */
   val uptimeSeconds: Long,
@@ -1976,6 +2019,12 @@ private data class CatalogSummaryDto(
   val unlisted: Int,
   val trusted: Int,
   val degraded: Int,
+  /** Configured catalogs with a usable registered copy. */
+  val loaded: Int,
+  /** Configured catalogs whose latest attempt failed before any usable copy registered. */
+  val failed: Int,
+  /** Configured catalogs not attempted yet (normally only visible during concurrent startup). */
+  val pending: Int,
 )
 
 @Serializable
@@ -2037,6 +2086,11 @@ private data class CatalogDto(
    * `compose-preview-serve/status/v1`.
    */
   val metaStale: Boolean = false,
+  /** `pending`, `loaded`, `failed`, or `stale` (last good copy + latest refresh error). */
+  val loadState: String = "loaded",
+  /** Latest catalog fetch/parse/image error, null after a successful latest attempt. */
+  val loadError: String? = null,
+  val lastLoadAttemptEpochMillis: Long? = null,
 )
 
 @Serializable

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -1688,6 +1688,10 @@ object ServeWeb {
     val degradation: String?,
     /** `repo@branch · date` provenance for a fetched catalog; null for a plain bundle. */
     val provenance: String?,
+    /** `pending`, `loaded`, `failed`, or `stale` (last good copy + latest refresh error). */
+    val loadState: String = "loaded",
+    /** Latest catalog load/refresh error. */
+    val loadError: String? = null,
     /**
      * The row's facts are a last-known snapshot of a catalog whose daemon is idle, not a live read
      * (`/status` never resumes one). Rendered as a "last known" qualifier next to the trust badge,
@@ -1728,7 +1732,7 @@ object ServeWeb {
   data class StatusView(
     val version: String,
     val public: Boolean,
-    /** No recent daemon startup failures — the healthy case (drives the header badge). */
+    /** No catalog load or recent daemon startup failures (drives the header badge). */
     val overallOk: Boolean,
     val summary: List<Stat>,
     val config: List<Stat>,
@@ -1760,9 +1764,7 @@ object ServeWeb {
 
     val healthBadge =
       if (view.overallOk) " <span class=\"cp-badge cp-badge--trusted\">✓ healthy</span>"
-      else
-        " <span class=\"cp-badge cp-badge--unverified\">⚠ ${view.failures.size} recent " +
-          "daemon failure(s)</span>"
+      else " <span class=\"cp-badge cp-badge--unverified\">⚠ degraded</span>"
 
     val summaryGrid = view.summary.joinToString("\n") { stat(it) }
     val configGrid = view.config.joinToString("\n") { stat(it) }
@@ -1777,22 +1779,31 @@ object ServeWeb {
           val prov = c.provenance?.let { "<div class=\"cp-muted\">${esc(it)}</div>" } ?: ""
           val stateCell =
             when {
+              c.loadState == "failed" ->
+                "<span class=\"cp-badge cp-badge--unverified\">failed to load</span>"
+              c.loadState == "pending" -> "<span class=\"cp-muted\">loading</span>"
+              c.loadState == "stale" ->
+                "<span class=\"cp-badge cp-badge--unverified\">stale copy</span>"
               c.running -> "<span class=\"cp-ok\">live · running</span>"
               c.live -> "live · idle"
               else -> "<span class=\"cp-muted\">baked PNG</span>"
             }
           val degrade = c.degradation?.let { "<div class=\"cp-muted\">${esc(it)}</div>" } ?: ""
+          val loadError = c.loadError?.let { "<div class=\"cp-muted\">${esc(it)}</div>" } ?: ""
           // An idle catalog's facts are last-known, not live — say so next to the badge rather than
           // leaving the cell blank, which would read as untrusted.
           val staleNote = if (c.stale) "<div class=\"cp-muted\">last known</div>" else ""
           val trustCell =
             compactTrustBadge(c.trust).ifBlank { "<span class=\"cp-muted\">—</span>" } + staleNote
+          val title =
+            if (c.loadState == "failed" || c.loadState == "pending") esc(c.title)
+            else "<a href=\"/$idSeg/$suffix\">${esc(c.title)}</a>"
           "<tr>" +
-            "<td><a href=\"/$idSeg/$suffix\">${esc(c.title)}</a>$listed" +
+            "<td>$title$listed" +
             "<div class=\"cp-muted\">${esc(c.id)}</div>$prov</td>" +
             "<td>$trustCell</td>" +
             "<td>${c.previews}</td>" +
-            "<td>$stateCell$degrade</td>" +
+            "<td>$stateCell$loadError$degrade</td>" +
             "</tr>"
         }
 
@@ -1840,9 +1851,10 @@ object ServeWeb {
       <p class="cp-sub">compose-preview serve · $mode$ver</p>
       <section class="cp-about">
         <p class="cp-about-title">Status &amp; monitoring</p>
-        <p class="cp-about-body">A live snapshot of this preview server — the catalogs it publishes,
-          the render daemons running now, its configuration, and recent daemon startup failures. The
-          same data is available as JSON for a monitor or Home Assistant sensor.</p>
+        <p class="cp-about-body">A live snapshot of this preview server — every configured catalog
+          and its latest load result, the render daemons running now, its configuration, and recent
+          daemon startup failures. The same data is available as JSON for a monitor or Home
+          Assistant sensor.</p>
         <p class="cp-about-links">
           <a href="/status.json$suffix">/status.json</a> ·
           <a href="/version">/version</a> ·

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/CatalogLoadTrackerTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/CatalogLoadTrackerTest.kt
@@ -1,0 +1,70 @@
+package ee.schimke.composeai.cli.serve
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class CatalogLoadTrackerTest {
+
+  private fun tracker() =
+    CatalogLoadTracker(
+      listOf(
+        CatalogLoadTracker.Config(
+          system = "jetnews",
+          listed = true,
+          repo = "yschimke/compose-samples",
+          branch = "design-artifacts/jetnews",
+        ),
+        CatalogLoadTracker.Config(
+          system = "reply",
+          listed = true,
+          repo = "yschimke/compose-samples",
+          branch = "design-artifacts/reply",
+        ),
+      ),
+      clock = { 123L },
+    )
+
+  @Test
+  fun `initial failures remain visible and block completeness`() {
+    val tracker = tracker()
+    tracker.recordSuccess("jetnews")
+    tracker.recordFailure("reply", "could not parse catalog.json\nstack trace")
+
+    assertFalse(tracker.allAvailable())
+    assertEquals(setOf("jetnews"), tracker.availableSystems())
+    assertEquals("catalogs 1/2 loaded; failed: reply", tracker.startupSummary())
+    val reply = tracker.snapshot().single { it.config.system == "reply" }
+    assertEquals("failed", reply.loadState)
+    assertEquals("could not parse catalog.json", reply.error)
+    assertEquals(123L, reply.lastAttemptEpochMillis)
+  }
+
+  @Test
+  fun `a later success clears the error and satisfies completeness`() {
+    val tracker = tracker()
+    tracker.recordSuccess("jetnews")
+    tracker.recordFailure("reply", "network unavailable")
+    tracker.recordSuccess("reply")
+
+    assertTrue(tracker.allAvailable())
+    val reply = tracker.snapshot().single { it.config.system == "reply" }
+    assertEquals("loaded", reply.loadState)
+    assertEquals(null, reply.error)
+  }
+
+  @Test
+  fun `a refresh failure keeps the last good copy available but reports stale`() {
+    val tracker = tracker()
+    tracker.recordSuccess("jetnews")
+    tracker.recordSuccess("reply")
+    tracker.recordFailure("reply", "new branch content is malformed")
+
+    assertTrue(tracker.allAvailable(), "the staged refresh retains the prior usable copy")
+    val reply = tracker.snapshot().single { it.config.system == "reply" }
+    assertTrue(reply.available)
+    assertEquals("stale", reply.loadState)
+    assertEquals("new branch content is malformed", reply.error)
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogRefresherTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogRefresherTest.kt
@@ -116,6 +116,35 @@ class ServeCatalogRefresherTest {
   }
 
   @Test
+  fun `a catalog that failed at startup retries without a branch change`() {
+    var succeed = false
+    val reloads = AtomicInteger(0)
+    val r =
+      ServeCatalogRefresher(
+        entries = listOf(entry("jetnews"), entry("reply")),
+        reload = { system, _ ->
+          if (system == "reply") reloads.incrementAndGet()
+          system == "jetnews" || succeed
+        },
+        intervalMillis = 1_000,
+        headResolver = { _, branch -> "stable-${branch.substringAfterLast('/')}" },
+        onLog = {},
+      )
+    // jetnews loaded at boot; reply did not. Seed only the usable catalog.
+    r.seedInitialHeads(setOf("jetnews"))
+    r.tick()
+    assertEquals(1, reloads.get(), "the unchanged failed catalog retries on the first tick")
+    r.tick()
+    assertEquals(2, reloads.get(), "it keeps retrying while unavailable")
+    succeed = true
+    r.tick()
+    assertEquals(3, reloads.get(), "the successful retry records the head")
+    r.tick()
+    assertEquals(3, reloads.get(), "the stable successful head is no longer retried")
+    r.close()
+  }
+
+  @Test
   fun `each catalog is tracked independently`() {
     val heads = ConcurrentHashMap(mapOf("compose-m3" to "a1", "cadence" to "c1"))
     val reloads = mutableListOf<String>()

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
@@ -160,6 +160,49 @@ class ServeHttpRoutingTest {
   }
 
   @Test
+  fun `a failed optional catalog does not block readiness`() {
+    val partialRegistry = ServeSessionRegistry(open = { null })
+    partialRegistry.register("default-mod", host = bundle("partial-default"), pinned = true)
+    val loads =
+      CatalogLoadTracker(
+        listOf(
+          CatalogLoadTracker.Config(
+            system = "reply",
+            listed = true,
+            repo = "yschimke/compose-samples",
+            branch = "design-artifacts/reply",
+          )
+        )
+      )
+    loads.recordFailure("reply", "could not parse catalog.json")
+    val partialServer =
+      ServeHttpServer(
+          host = "127.0.0.1",
+          requestedPort = 0,
+          token = "unused-in-public",
+          sessions = partialRegistry,
+          defaultSessionId = "default-mod",
+          isPublic = true,
+          catalogSessions = listOf("reply"),
+          catalogLoads = loads,
+        )
+        .also { it.start() }
+    try {
+      var response = 503 to "warming"
+      for (attempt in 0 until 50) {
+        val req = Request.Builder().url("http://127.0.0.1:${partialServer.port}/readyz").build()
+        client.newCall(req).execute().use { r -> response = r.code to (r.body?.string() ?: "") }
+        if (response.first == 200) break
+        Thread.sleep(100)
+      }
+      assertEquals(200 to "ready", response)
+    } finally {
+      partialServer.stop()
+      partialRegistry.close()
+    }
+  }
+
+  @Test
   fun `readyz withholds ready when the default session cannot render`() {
     // A server whose default session resolves to nothing (an empty registry) can't render a
     // representative preview, so /readyz must report 503 "warming" — NOT a false green. This is the

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeStatusTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeStatusTest.kt
@@ -39,7 +39,11 @@ class ServeStatusTest {
   private val registry = ServeSessionRegistry(open = { null })
   private val daemonLog = DaemonStartupLog(clock = { 1_000L })
 
-  private fun newServer(public: Boolean, token: String): ServeHttpServer {
+  private fun newServer(
+    public: Boolean,
+    token: String,
+    catalogLoads: CatalogLoadTracker? = null,
+  ): ServeHttpServer {
     registry.register(
       "default-mod",
       host = bundle("default-mod", listOf("com.example.Red")),
@@ -67,6 +71,7 @@ class ServeStatusTest {
         isPublic = public,
         catalogSessions = listOf("compose-m3"),
         appCatalogSessions = listOf("cadence"),
+        catalogLoads = catalogLoads,
         daemonLog = daemonLog,
         allowRenderTrusted = true,
         trustStoreConfigured = true,
@@ -127,8 +132,51 @@ class ServeStatusTest {
     assertTrue(body.contains("Compose Material 3"), body)
     assertTrue(body.contains("href=\"/status.json\""), body)
     // The recent failure surfaces the degraded badge + row.
-    assertTrue(body.contains("recent daemon failure(s)"), body)
+    assertTrue(body.contains("degraded"), body)
     assertTrue(body.contains("daemon launch timed out"), body)
+  }
+
+  @Test
+  fun `configured catalog failures remain visible in status`() {
+    val loads =
+      CatalogLoadTracker(
+        listOf(
+          CatalogLoadTracker.Config(
+            "compose-m3",
+            listed = true,
+            repo = "yschimke/compose-ai-tools",
+            branch = "design-artifacts/compose-m3",
+          ),
+          CatalogLoadTracker.Config(
+            "reply",
+            listed = true,
+            repo = "yschimke/compose-samples",
+            branch = "design-artifacts/reply",
+          ),
+        ),
+        clock = { 4_242L },
+      )
+    loads.recordSuccess("compose-m3")
+    loads.recordFailure("reply", "could not parse catalog.json: expected a string")
+    server = newServer(public = true, token = "unused", catalogLoads = loads)
+
+    val (jsonCode, json) = get("/status.json")
+    assertEquals(200, jsonCode)
+    assertTrue(json.contains("\"status\":\"degraded\""), json)
+    assertTrue(json.contains("\"total\":2"), json)
+    assertTrue(json.contains("\"loaded\":1"), json)
+    assertTrue(json.contains("\"failed\":1"), json)
+    assertTrue(json.contains("\"id\":\"reply\""), json)
+    assertTrue(json.contains("\"loadState\":\"failed\""), json)
+    assertTrue(json.contains("could not parse catalog.json: expected a string"), json)
+    assertTrue(json.contains("\"lastLoadAttemptEpochMillis\":4242"), json)
+
+    val (htmlCode, html) = get("/status")
+    assertEquals(200, htmlCode)
+    assertTrue(html.contains("1/2 loaded"), html)
+    assertTrue(html.contains("failed to load"), html)
+    assertTrue(html.contains("could not parse catalog.json: expected a string"), html)
+    assertTrue(!html.contains("href=\"/reply/\""), "a failed catalog must not link to a 404: $html")
   }
 
   @Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -720,7 +720,7 @@ class ServeWebFixtureTest {
       ServeWeb.notFoundPage("That preview does not exist in this catalog.", token, isPublic = true)
 
     // The server STATUS page (GET /status): a snapshot of the running host — published catalogs +
-    // their trust/liveness, the render daemons up now, the effective config, and recent daemon
+    // their load/trust/liveness, the render daemons up now, the effective config, and recent daemon
     // startup failures. A representative spread (a live+running catalog, a degraded baked one, an
     // unlisted one, a running desktop daemon, and one recent failure so the amber "degraded" badge
     // +
@@ -973,7 +973,7 @@ class ServeWebFixtureTest {
       "status page headers the status and links its JSON form",
     )
     assertTrue(
-      serveStatus.contains("recent daemon failure(s)") &&
+      serveStatus.contains("⚠ degraded") &&
         serveStatus.contains("daemon launch timed out after 300s"),
       "a recent failure surfaces the degraded badge and the failure row",
     )

--- a/vscode-extension/preview-harness/fixtures/pages/serve-status.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-status.html
@@ -419,13 +419,14 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
       </head>
       <body>
         <main class="cp-main">
-              <h1 class="cp-head">Server status <span class="cp-badge cp-badge--unverified">⚠ 1 recent daemon failure(s)</span></h1>
+              <h1 class="cp-head">Server status <span class="cp-badge cp-badge--unverified">⚠ degraded</span></h1>
       <p class="cp-sub">compose-preview serve · public (open) <span class="cp-about-ver">v0.0.0-fixture</span></p>
       <section class="cp-about">
         <p class="cp-about-title">Status &amp; monitoring</p>
-        <p class="cp-about-body">A live snapshot of this preview server — the catalogs it publishes,
-          the render daemons running now, its configuration, and recent daemon startup failures. The
-          same data is available as JSON for a monitor or Home Assistant sensor.</p>
+        <p class="cp-about-body">A live snapshot of this preview server — every configured catalog
+          and its latest load result, the render daemons running now, its configuration, and recent
+          daemon startup failures. The same data is available as JSON for a monitor or Home
+          Assistant sensor.</p>
         <p class="cp-about-links">
           <a href="/status.json">/status.json</a> ·
           <a href="/version">/version</a> ·


### PR DESCRIPTION
## Summary

- keep every configured catalog in a shared load-state tracker, so startup failures appear on `/status` and `/status.json` as `failed` instead of disappearing
- keep catalog completeness out of `/readyz`, while marking status degraded and retaining the exact latest load/refresh error
- retry catalogs that failed at startup even when their delivery branch SHA has not changed; retain and report a stale last-good copy after refresh failures
- make the preview-host deployment check report partial/stale catalogs as a GitHub warning after the new server version converges

## Why

The earlier incident had two different causes with the same visible symptom: first only three catalogs were configured, then all six were configured but three failed to parse. Successful sessions were the only state retained, so the failed configured catalogs vanished from status and the refresher seeded their branch heads, preventing retries until another branch update. The release workflow only checked `/version`, so it could not distinguish a complete deployment from a partial one.

This keeps the server best-effort: one external catalog cannot hold back a usable deployment. The missing catalog and its reason are now visible and self-healing.

## Validation

- `./gradlew :cli:ktfmtCheck :cli:test`
- focused tracker, refresher, readiness, status, and web-fixture tests
- workflow YAML parse and `git diff --check`