### PR TITLE
fix(serve): make catalog navigation tabs sticky

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -688,6 +688,12 @@ object ServeWeb {
     return "cp-theme:${WebEscaping.urlEncodeSegment(catalog)}"
   }
 
+  /** Stable, catalog-specific key for the last section selected on that catalog's landing page. */
+  private fun tabStorageKey(sessionId: String?, basePath: String): String {
+    val catalog = basePath.trim('/').ifBlank { sessionId ?: "default" }
+    return "cp-tab:${WebEscaping.urlEncodeSegment(catalog)}"
+  }
+
   /**
    * The flattened id with its theme token stripped — the key that pairs a component's light and
    * dark variants into ONE grid card. `button-filled__ideal__default__light` and `…__dark` both key
@@ -1160,6 +1166,7 @@ object ServeWeb {
     hasTabs: Boolean,
     hasGroups: Boolean,
     themeStorageKey: String,
+    tabStorageKey: String,
   ): String {
     val themeInit =
       if (hasThemes)
@@ -1224,6 +1231,15 @@ object ServeWeb {
         "\n      var tabBtns = document.querySelectorAll(\".cp-tab\");" +
           "\n      var tabSections = document.querySelectorAll(\".cp-section\");" +
           "\n      var current = tabBtns.length ? tabBtns[0].getAttribute(\"data-tab\") : null;" +
+          "\n      try {" +
+          "\n        var storedTab = localStorage.getItem(\"$tabStorageKey\");" +
+          "\n        tabBtns.forEach(function (t) {" +
+          "\n          if (t.getAttribute(\"data-tab\") === storedTab) current = storedTab;" +
+          "\n        });" +
+          "\n      } catch (e) {}" +
+          "\n      tabBtns.forEach(function (t) {" +
+          "\n        t.setAttribute(\"aria-selected\", t.getAttribute(\"data-tab\") === current ? \"true\" : \"false\");" +
+          "\n      });" +
           "\n      document.documentElement.classList.add(\"cp-js\");"
       else ""
     // A card is shown when it matches the search AND (while not searching) sits in the current tab.
@@ -1249,6 +1265,7 @@ object ServeWeb {
           "\n        t.addEventListener(\"click\", function (e) {" +
           "\n          e.preventDefault();" +
           "\n          current = t.getAttribute(\"data-tab\");" +
+          "\n          try { localStorage.setItem(\"$tabStorageKey\", current); } catch (e) {}" +
           "\n          tabBtns.forEach(function (x) { x.setAttribute(\"aria-selected\", x === t ? \"true\" : \"false\"); });" +
           "\n          apply();" +
           "\n        });" +
@@ -2243,7 +2260,13 @@ object ServeWeb {
       else ""
     val filterScript =
       if (hasPreviews)
-        "\n<script>${catalogFilterScript(hasThemes, hasTabs, hasGroups, themeStorageKey(sessionId, basePath))}</script>"
+        "\n<script>${catalogFilterScript(
+          hasThemes,
+          hasTabs,
+          hasGroups,
+          themeStorageKey(sessionId, basePath),
+          tabStorageKey(sessionId, basePath),
+        )}</script>"
       else ""
     return document(
       title = "$moduleLabel — compose-preview",

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -1058,6 +1058,11 @@ class ServeWebFixtureTest {
         landingSections.contains("querySelectorAll(\".cp-tab\")"),
       "the sectioned landing wires the tab-switching script",
     )
+    assertTrue(
+      landingSections.contains("localStorage.getItem(\"cp-tab:meshcore-mobile\")") &&
+        landingSections.contains("localStorage.setItem(\"cp-tab:meshcore-mobile\", current)"),
+      "the selected tab persists per catalog and is restored when returning from a preview",
+    )
     // `role="tablist"` (the tab bar) and `classList.add("cp-js")` (the tab script) appear ONLY when
     // tabs are rendered — the shared stylesheet's `.cp-tabs` / `html.cp-js` rules are on every
     // page,

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-sections.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-sections.html
@@ -565,6 +565,15 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
   var tabBtns = document.querySelectorAll(".cp-tab");
   var tabSections = document.querySelectorAll(".cp-section");
   var current = tabBtns.length ? tabBtns[0].getAttribute("data-tab") : null;
+  try {
+    var storedTab = localStorage.getItem("cp-tab:meshcore-mobile");
+    tabBtns.forEach(function (t) {
+      if (t.getAttribute("data-tab") === storedTab) current = storedTab;
+    });
+  } catch (e) {}
+  tabBtns.forEach(function (t) {
+    t.setAttribute("aria-selected", t.getAttribute("data-tab") === current ? "true" : "false");
+  });
   document.documentElement.classList.add("cp-js");
   
   function apply() {
@@ -592,6 +601,7 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
     t.addEventListener("click", function (e) {
       e.preventDefault();
       current = t.getAttribute("data-tab");
+      try { localStorage.setItem("cp-tab:meshcore-mobile", current); } catch (e) {}
       tabBtns.forEach(function (x) { x.setAttribute("aria-selected", x === t ? "true" : "false"); });
       apply();
     });


### PR DESCRIPTION
## Summary

- persist the selected catalog section tab in catalog-scoped local storage
- restore only tab values that still exist in the current catalog
- synchronize `aria-selected` before the landing grid's first filtered render
- update the sectioned landing fixture and regression assertion

## Why

Returning from a preview rebuilt the catalog landing page with the first section selected because tab state existed only in page-local JavaScript. The selected section now survives navigation while remaining isolated per catalog.

## Validation

- `./gradlew :cli:test --tests '*ServeWebFixtureTest*'`
- `./gradlew :cli:ktfmtCheck`
- `git diff --check`

Fixes #2809