### PR TITLE
feat(serve): add preview zoom modes

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -2672,6 +2672,10 @@ object ServeWeb {
       $switchers
       <div class="cp-viewer-bar">
         $navToggle
+        <span class="cp-bg" role="group" aria-label="Preview zoom">
+          <button type="button" class="cp-bg-btn cp-zoom-btn" data-zoom-mode="fit" aria-pressed="true">Fit screen</button>
+          <button type="button" class="cp-bg-btn cp-zoom-btn" data-zoom-mode="width" aria-pressed="false">Fit width</button>
+        </span>
         <button type="button" class="cp-drawer-toggle" id="cp-controls-toggle" aria-expanded="true" aria-controls="cp-controls">⚙ Overrides</button>
       </div>
       <div class="cp-viewer cp-controls-open"$bgThemeAttr$alwaysDarkAttr data-preview-id="$idText" data-mode="snapshot" data-modes="$modes" data-static-snapshot="$staticSnapshot" data-can-render-overrides="$canRenderOverrides" data-snapshot-backend="$backendLabel" data-live-backend="$liveLabel" data-render-density="$RENDER_DENSITY"$wasmAttr$rcAttr>
@@ -2834,6 +2838,36 @@ object ServeWeb {
       var status = document.getElementById("cp-status");
       var errorBox = document.getElementById("cp-error");
       var live = document.getElementById("cp-live");
+      // Tall previews used to size the stage from their full width-constrained height, which could
+      // push the rest of the viewer several screens below the fold. Default to a viewport-bounded
+      // contain fit; "Fit width" deliberately restores the old unconstrained-height presentation.
+      // The snapshot remains the geometry source for Live/Wasm, so re-pin an active overlay after
+      // changing modes.
+      var zoomBtns = document.querySelectorAll(".cp-zoom-btn");
+      function applyZoom(mode) {
+        if (mode !== "width") mode = "fit";
+        var maxHeight = mode === "fit" ? "72vh" : "";
+        img.style.maxHeight = maxHeight;
+        var rcZoomCanvas = document.getElementById("cp-rc-canvas");
+        if (rcZoomCanvas) rcZoomCanvas.style.maxHeight = maxHeight;
+        root.setAttribute("data-zoom", mode);
+        zoomBtns.forEach(function (b) {
+          b.setAttribute(
+            "aria-pressed",
+            b.getAttribute("data-zoom-mode") === mode ? "true" : "false"
+          );
+        });
+        window.requestAnimationFrame(function () {
+          if (live && live.checked && !canvas.hidden) fitLiveCanvas();
+          if (wasmActive()) positionWasmFrame();
+        });
+      }
+      zoomBtns.forEach(function (b) {
+        b.addEventListener("click", function () {
+          applyZoom(b.getAttribute("data-zoom-mode"));
+        });
+      });
+      applyZoom("fit");
       // Surface a mode-activation failure visibly, instead of leaving a stale frame that reads as a
       // (wrong) render. Every lane routes its failure here — a dead Live stream, a Wasm app that
       // never boots, a /render that errors — so "can't activate this mode" is never silent.

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -1614,6 +1614,27 @@ class ServeWebFixtureTest {
   }
 
   @Test
+  fun `viewer defaults to fit screen and offers an explicit fit width mode`() {
+    val view = ServeWeb.viewerPage(previews.first(), token)
+    assertTrue(
+      view.contains("aria-label=\"Preview zoom\"") &&
+        view.contains("data-zoom-mode=\"fit\" aria-pressed=\"true\">Fit screen</button>") &&
+        view.contains("data-zoom-mode=\"width\" aria-pressed=\"false\">Fit width</button>"),
+      "the viewer exposes screen and width fit modes with screen fit selected",
+    )
+    assertTrue(
+      view.contains("var maxHeight = mode === \"fit\" ? \"72vh\" : \"\";") &&
+        view.contains("applyZoom(\"fit\");"),
+      "screen fit bounds tall previews to the viewport before the initial render",
+    )
+    assertTrue(
+      view.contains("if (live && live.checked && !canvas.hidden) fitLiveCanvas();") &&
+        view.contains("if (wasmActive()) positionWasmFrame();"),
+      "changing zoom re-pins active live and Wasm overlays to the snapshot geometry",
+    )
+  }
+
+  @Test
   fun `SVG is an on-screen format toggle and an export format when the session can export SVG`() {
     val card = previews.first { it.id.endsWith("CardPreview") }
     // SVG isn't part of the awkward PNG/live radio group any more, but it's still an on-screen

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
@@ -424,6 +424,10 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
       
       <div class="cp-viewer-bar">
         
+        <span class="cp-bg" role="group" aria-label="Preview zoom">
+          <button type="button" class="cp-bg-btn cp-zoom-btn" data-zoom-mode="fit" aria-pressed="true">Fit screen</button>
+          <button type="button" class="cp-bg-btn cp-zoom-btn" data-zoom-mode="width" aria-pressed="false">Fit width</button>
+        </span>
         <button type="button" class="cp-drawer-toggle" id="cp-controls-toggle" aria-expanded="true" aria-controls="cp-controls">⚙ Overrides</button>
       </div>
       <div class="cp-viewer cp-controls-open" data-bg-theme="light" data-preview-id="button-filled__ideal__default__light" data-mode="snapshot" data-modes="snapshot" data-static-snapshot="true" data-can-render-overrides="true" data-snapshot-backend="Snapshot" data-live-backend="Live" data-render-density="2" data-wasm-src="/wasm/compose-m3/?id=button-filled">
@@ -777,6 +781,36 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
   var status = document.getElementById("cp-status");
   var errorBox = document.getElementById("cp-error");
   var live = document.getElementById("cp-live");
+  // Tall previews used to size the stage from their full width-constrained height, which could
+  // push the rest of the viewer several screens below the fold. Default to a viewport-bounded
+  // contain fit; "Fit width" deliberately restores the old unconstrained-height presentation.
+  // The snapshot remains the geometry source for Live/Wasm, so re-pin an active overlay after
+  // changing modes.
+  var zoomBtns = document.querySelectorAll(".cp-zoom-btn");
+  function applyZoom(mode) {
+    if (mode !== "width") mode = "fit";
+    var maxHeight = mode === "fit" ? "72vh" : "";
+    img.style.maxHeight = maxHeight;
+    var rcZoomCanvas = document.getElementById("cp-rc-canvas");
+    if (rcZoomCanvas) rcZoomCanvas.style.maxHeight = maxHeight;
+    root.setAttribute("data-zoom", mode);
+    zoomBtns.forEach(function (b) {
+      b.setAttribute(
+        "aria-pressed",
+        b.getAttribute("data-zoom-mode") === mode ? "true" : "false"
+      );
+    });
+    window.requestAnimationFrame(function () {
+      if (live && live.checked && !canvas.hidden) fitLiveCanvas();
+      if (wasmActive()) positionWasmFrame();
+    });
+  }
+  zoomBtns.forEach(function (b) {
+    b.addEventListener("click", function () {
+      applyZoom(b.getAttribute("data-zoom-mode"));
+    });
+  });
+  applyZoom("fit");
   // Surface a mode-activation failure visibly, instead of leaving a stale frame that reads as a
   // (wrong) render. Every lane routes its failure here — a dead Live stream, a Wasm app that
   // never boots, a /render that errors — so "can't activate this mode" is never silent.

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-focus.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-focus.html
@@ -424,6 +424,10 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
       
       <div class="cp-viewer-bar">
         
+        <span class="cp-bg" role="group" aria-label="Preview zoom">
+          <button type="button" class="cp-bg-btn cp-zoom-btn" data-zoom-mode="fit" aria-pressed="true">Fit screen</button>
+          <button type="button" class="cp-bg-btn cp-zoom-btn" data-zoom-mode="width" aria-pressed="false">Fit width</button>
+        </span>
         <button type="button" class="cp-drawer-toggle" id="cp-controls-toggle" aria-expanded="true" aria-controls="cp-controls">⚙ Overrides</button>
       </div>
       <div class="cp-viewer cp-controls-open" data-preview-id="com.example.FocusRingPreview" data-mode="snapshot" data-modes="snapshot" data-static-snapshot="false" data-can-render-overrides="true" data-snapshot-backend="Snapshot" data-live-backend="Live" data-render-density="2">
@@ -736,6 +740,36 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
   var status = document.getElementById("cp-status");
   var errorBox = document.getElementById("cp-error");
   var live = document.getElementById("cp-live");
+  // Tall previews used to size the stage from their full width-constrained height, which could
+  // push the rest of the viewer several screens below the fold. Default to a viewport-bounded
+  // contain fit; "Fit width" deliberately restores the old unconstrained-height presentation.
+  // The snapshot remains the geometry source for Live/Wasm, so re-pin an active overlay after
+  // changing modes.
+  var zoomBtns = document.querySelectorAll(".cp-zoom-btn");
+  function applyZoom(mode) {
+    if (mode !== "width") mode = "fit";
+    var maxHeight = mode === "fit" ? "72vh" : "";
+    img.style.maxHeight = maxHeight;
+    var rcZoomCanvas = document.getElementById("cp-rc-canvas");
+    if (rcZoomCanvas) rcZoomCanvas.style.maxHeight = maxHeight;
+    root.setAttribute("data-zoom", mode);
+    zoomBtns.forEach(function (b) {
+      b.setAttribute(
+        "aria-pressed",
+        b.getAttribute("data-zoom-mode") === mode ? "true" : "false"
+      );
+    });
+    window.requestAnimationFrame(function () {
+      if (live && live.checked && !canvas.hidden) fitLiveCanvas();
+      if (wasmActive()) positionWasmFrame();
+    });
+  }
+  zoomBtns.forEach(function (b) {
+    b.addEventListener("click", function () {
+      applyZoom(b.getAttribute("data-zoom-mode"));
+    });
+  });
+  applyZoom("fit");
   // Surface a mode-activation failure visibly, instead of leaving a stale frame that reads as a
   // (wrong) render. Every lane routes its failure here — a dead Live stream, a Wasm app that
   // never boots, a /render that errors — so "can't activate this mode" is never silent.

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-gestures.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-gestures.html
@@ -424,6 +424,10 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
       
       <div class="cp-viewer-bar">
         
+        <span class="cp-bg" role="group" aria-label="Preview zoom">
+          <button type="button" class="cp-bg-btn cp-zoom-btn" data-zoom-mode="fit" aria-pressed="true">Fit screen</button>
+          <button type="button" class="cp-bg-btn cp-zoom-btn" data-zoom-mode="width" aria-pressed="false">Fit width</button>
+        </span>
         <button type="button" class="cp-drawer-toggle" id="cp-controls-toggle" aria-expanded="true" aria-controls="cp-controls">⚙ Overrides</button>
       </div>
       <div class="cp-viewer cp-controls-open" data-bg-theme="dark" data-always-dark="1" data-preview-id="com.example.OneHandedPreview" data-mode="snapshot" data-modes="snapshot" data-static-snapshot="false" data-can-render-overrides="true" data-snapshot-backend="Snapshot" data-live-backend="Live" data-render-density="2">
@@ -734,6 +738,36 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
   var status = document.getElementById("cp-status");
   var errorBox = document.getElementById("cp-error");
   var live = document.getElementById("cp-live");
+  // Tall previews used to size the stage from their full width-constrained height, which could
+  // push the rest of the viewer several screens below the fold. Default to a viewport-bounded
+  // contain fit; "Fit width" deliberately restores the old unconstrained-height presentation.
+  // The snapshot remains the geometry source for Live/Wasm, so re-pin an active overlay after
+  // changing modes.
+  var zoomBtns = document.querySelectorAll(".cp-zoom-btn");
+  function applyZoom(mode) {
+    if (mode !== "width") mode = "fit";
+    var maxHeight = mode === "fit" ? "72vh" : "";
+    img.style.maxHeight = maxHeight;
+    var rcZoomCanvas = document.getElementById("cp-rc-canvas");
+    if (rcZoomCanvas) rcZoomCanvas.style.maxHeight = maxHeight;
+    root.setAttribute("data-zoom", mode);
+    zoomBtns.forEach(function (b) {
+      b.setAttribute(
+        "aria-pressed",
+        b.getAttribute("data-zoom-mode") === mode ? "true" : "false"
+      );
+    });
+    window.requestAnimationFrame(function () {
+      if (live && live.checked && !canvas.hidden) fitLiveCanvas();
+      if (wasmActive()) positionWasmFrame();
+    });
+  }
+  zoomBtns.forEach(function (b) {
+    b.addEventListener("click", function () {
+      applyZoom(b.getAttribute("data-zoom-mode"));
+    });
+  });
+  applyZoom("fit");
   // Surface a mode-activation failure visibly, instead of leaving a stale frame that reads as a
   // (wrong) render. Every lane routes its failure here — a dead Live stream, a Wasm app that
   // never boots, a /render that errors — so "can't activate this mode" is never silent.

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-nav-collapsed.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-nav-collapsed.html
@@ -429,6 +429,10 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
       </nav>
       <div class="cp-viewer-bar">
         <button type="button" class="cp-drawer-toggle" id="cp-nav-toggle" aria-expanded="false" aria-controls="cp-nav">☰ Components</button>
+        <span class="cp-bg" role="group" aria-label="Preview zoom">
+          <button type="button" class="cp-bg-btn cp-zoom-btn" data-zoom-mode="fit" aria-pressed="true">Fit screen</button>
+          <button type="button" class="cp-bg-btn cp-zoom-btn" data-zoom-mode="width" aria-pressed="false">Fit width</button>
+        </span>
         <button type="button" class="cp-drawer-toggle" id="cp-controls-toggle" aria-expanded="true" aria-controls="cp-controls">⚙ Overrides</button>
       </div>
       <div class="cp-viewer cp-controls-open" data-bg-theme="light" data-preview-id="button-filled__ideal__default__light" data-mode="snapshot" data-modes="snapshot" data-static-snapshot="true" data-can-render-overrides="false" data-snapshot-backend="Snapshot" data-live-backend="Live" data-render-density="2">
@@ -732,6 +736,36 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
   var status = document.getElementById("cp-status");
   var errorBox = document.getElementById("cp-error");
   var live = document.getElementById("cp-live");
+  // Tall previews used to size the stage from their full width-constrained height, which could
+  // push the rest of the viewer several screens below the fold. Default to a viewport-bounded
+  // contain fit; "Fit width" deliberately restores the old unconstrained-height presentation.
+  // The snapshot remains the geometry source for Live/Wasm, so re-pin an active overlay after
+  // changing modes.
+  var zoomBtns = document.querySelectorAll(".cp-zoom-btn");
+  function applyZoom(mode) {
+    if (mode !== "width") mode = "fit";
+    var maxHeight = mode === "fit" ? "72vh" : "";
+    img.style.maxHeight = maxHeight;
+    var rcZoomCanvas = document.getElementById("cp-rc-canvas");
+    if (rcZoomCanvas) rcZoomCanvas.style.maxHeight = maxHeight;
+    root.setAttribute("data-zoom", mode);
+    zoomBtns.forEach(function (b) {
+      b.setAttribute(
+        "aria-pressed",
+        b.getAttribute("data-zoom-mode") === mode ? "true" : "false"
+      );
+    });
+    window.requestAnimationFrame(function () {
+      if (live && live.checked && !canvas.hidden) fitLiveCanvas();
+      if (wasmActive()) positionWasmFrame();
+    });
+  }
+  zoomBtns.forEach(function (b) {
+    b.addEventListener("click", function () {
+      applyZoom(b.getAttribute("data-zoom-mode"));
+    });
+  });
+  applyZoom("fit");
   // Surface a mode-activation failure visibly, instead of leaving a stale frame that reads as a
   // (wrong) render. Every lane routes its failure here — a dead Live stream, a Wasm app that
   // never boots, a /render that errors — so "can't activate this mode" is never silent.

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
@@ -424,6 +424,10 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
       
       <div class="cp-viewer-bar">
         <button type="button" class="cp-drawer-toggle" id="cp-nav-toggle" aria-expanded="false" aria-controls="cp-nav">☰ Components</button>
+        <span class="cp-bg" role="group" aria-label="Preview zoom">
+          <button type="button" class="cp-bg-btn cp-zoom-btn" data-zoom-mode="fit" aria-pressed="true">Fit screen</button>
+          <button type="button" class="cp-bg-btn cp-zoom-btn" data-zoom-mode="width" aria-pressed="false">Fit width</button>
+        </span>
         <button type="button" class="cp-drawer-toggle" id="cp-controls-toggle" aria-expanded="true" aria-controls="cp-controls">⚙ Overrides</button>
       </div>
       <div class="cp-viewer cp-controls-open" data-preview-id="com.example.ProfileScreenPreview" data-mode="snapshot" data-modes="snapshot,live" data-static-snapshot="true" data-can-render-overrides="false" data-snapshot-backend="Snapshot" data-live-backend="Live" data-render-density="2">
@@ -730,6 +734,36 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
   var status = document.getElementById("cp-status");
   var errorBox = document.getElementById("cp-error");
   var live = document.getElementById("cp-live");
+  // Tall previews used to size the stage from their full width-constrained height, which could
+  // push the rest of the viewer several screens below the fold. Default to a viewport-bounded
+  // contain fit; "Fit width" deliberately restores the old unconstrained-height presentation.
+  // The snapshot remains the geometry source for Live/Wasm, so re-pin an active overlay after
+  // changing modes.
+  var zoomBtns = document.querySelectorAll(".cp-zoom-btn");
+  function applyZoom(mode) {
+    if (mode !== "width") mode = "fit";
+    var maxHeight = mode === "fit" ? "72vh" : "";
+    img.style.maxHeight = maxHeight;
+    var rcZoomCanvas = document.getElementById("cp-rc-canvas");
+    if (rcZoomCanvas) rcZoomCanvas.style.maxHeight = maxHeight;
+    root.setAttribute("data-zoom", mode);
+    zoomBtns.forEach(function (b) {
+      b.setAttribute(
+        "aria-pressed",
+        b.getAttribute("data-zoom-mode") === mode ? "true" : "false"
+      );
+    });
+    window.requestAnimationFrame(function () {
+      if (live && live.checked && !canvas.hidden) fitLiveCanvas();
+      if (wasmActive()) positionWasmFrame();
+    });
+  }
+  zoomBtns.forEach(function (b) {
+    b.addEventListener("click", function () {
+      applyZoom(b.getAttribute("data-zoom-mode"));
+    });
+  });
+  applyZoom("fit");
   // Surface a mode-activation failure visibly, instead of leaving a stale frame that reads as a
   // (wrong) render. Every lane routes its failure here — a dead Live stream, a Wasm app that
   // never boots, a /render that errors — so "can't activate this mode" is never silent.

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-states.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-states.html
@@ -427,6 +427,10 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
       </nav>
       <div class="cp-viewer-bar">
         <button type="button" class="cp-drawer-toggle" id="cp-nav-toggle" aria-expanded="false" aria-controls="cp-nav">☰ Components</button>
+        <span class="cp-bg" role="group" aria-label="Preview zoom">
+          <button type="button" class="cp-bg-btn cp-zoom-btn" data-zoom-mode="fit" aria-pressed="true">Fit screen</button>
+          <button type="button" class="cp-bg-btn cp-zoom-btn" data-zoom-mode="width" aria-pressed="false">Fit width</button>
+        </span>
         <button type="button" class="cp-drawer-toggle" id="cp-controls-toggle" aria-expanded="true" aria-controls="cp-controls">⚙ Overrides</button>
       </div>
       <div class="cp-viewer cp-controls-open" data-bg-theme="light" data-preview-id="checkbox__ideal__default__light" data-mode="snapshot" data-modes="snapshot" data-static-snapshot="true" data-can-render-overrides="false" data-snapshot-backend="Snapshot" data-live-backend="Live" data-render-density="2">
@@ -729,6 +733,36 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
   var status = document.getElementById("cp-status");
   var errorBox = document.getElementById("cp-error");
   var live = document.getElementById("cp-live");
+  // Tall previews used to size the stage from their full width-constrained height, which could
+  // push the rest of the viewer several screens below the fold. Default to a viewport-bounded
+  // contain fit; "Fit width" deliberately restores the old unconstrained-height presentation.
+  // The snapshot remains the geometry source for Live/Wasm, so re-pin an active overlay after
+  // changing modes.
+  var zoomBtns = document.querySelectorAll(".cp-zoom-btn");
+  function applyZoom(mode) {
+    if (mode !== "width") mode = "fit";
+    var maxHeight = mode === "fit" ? "72vh" : "";
+    img.style.maxHeight = maxHeight;
+    var rcZoomCanvas = document.getElementById("cp-rc-canvas");
+    if (rcZoomCanvas) rcZoomCanvas.style.maxHeight = maxHeight;
+    root.setAttribute("data-zoom", mode);
+    zoomBtns.forEach(function (b) {
+      b.setAttribute(
+        "aria-pressed",
+        b.getAttribute("data-zoom-mode") === mode ? "true" : "false"
+      );
+    });
+    window.requestAnimationFrame(function () {
+      if (live && live.checked && !canvas.hidden) fitLiveCanvas();
+      if (wasmActive()) positionWasmFrame();
+    });
+  }
+  zoomBtns.forEach(function (b) {
+    b.addEventListener("click", function () {
+      applyZoom(b.getAttribute("data-zoom-mode"));
+    });
+  });
+  applyZoom("fit");
   // Surface a mode-activation failure visibly, instead of leaving a stale frame that reads as a
   // (wrong) render. Every lane routes its failure here — a dead Live stream, a Wasm app that
   // never boots, a /render that errors — so "can't activate this mode" is never silent.

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-themes.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-themes.html
@@ -424,6 +424,10 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
       
       <div class="cp-viewer-bar">
         
+        <span class="cp-bg" role="group" aria-label="Preview zoom">
+          <button type="button" class="cp-bg-btn cp-zoom-btn" data-zoom-mode="fit" aria-pressed="true">Fit screen</button>
+          <button type="button" class="cp-bg-btn cp-zoom-btn" data-zoom-mode="width" aria-pressed="false">Fit width</button>
+        </span>
         <button type="button" class="cp-drawer-toggle" id="cp-controls-toggle" aria-expanded="true" aria-controls="cp-controls">⚙ Overrides</button>
       </div>
       <div class="cp-viewer cp-controls-open" data-preview-id="com.example.ProfileScreenPreview" data-mode="snapshot" data-modes="snapshot,live" data-static-snapshot="false" data-can-render-overrides="true" data-snapshot-backend="Snapshot" data-live-backend="Live" data-render-density="2">
@@ -735,6 +739,36 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
   var status = document.getElementById("cp-status");
   var errorBox = document.getElementById("cp-error");
   var live = document.getElementById("cp-live");
+  // Tall previews used to size the stage from their full width-constrained height, which could
+  // push the rest of the viewer several screens below the fold. Default to a viewport-bounded
+  // contain fit; "Fit width" deliberately restores the old unconstrained-height presentation.
+  // The snapshot remains the geometry source for Live/Wasm, so re-pin an active overlay after
+  // changing modes.
+  var zoomBtns = document.querySelectorAll(".cp-zoom-btn");
+  function applyZoom(mode) {
+    if (mode !== "width") mode = "fit";
+    var maxHeight = mode === "fit" ? "72vh" : "";
+    img.style.maxHeight = maxHeight;
+    var rcZoomCanvas = document.getElementById("cp-rc-canvas");
+    if (rcZoomCanvas) rcZoomCanvas.style.maxHeight = maxHeight;
+    root.setAttribute("data-zoom", mode);
+    zoomBtns.forEach(function (b) {
+      b.setAttribute(
+        "aria-pressed",
+        b.getAttribute("data-zoom-mode") === mode ? "true" : "false"
+      );
+    });
+    window.requestAnimationFrame(function () {
+      if (live && live.checked && !canvas.hidden) fitLiveCanvas();
+      if (wasmActive()) positionWasmFrame();
+    });
+  }
+  zoomBtns.forEach(function (b) {
+    b.addEventListener("click", function () {
+      applyZoom(b.getAttribute("data-zoom-mode"));
+    });
+  });
+  applyZoom("fit");
   // Surface a mode-activation failure visibly, instead of leaving a stale frame that reads as a
   // (wrong) render. Every lane routes its failure here — a dead Live stream, a Wasm app that
   // never boots, a /render that errors — so "can't activate this mode" is never silent.

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-variants.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-variants.html
@@ -429,6 +429,10 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
       </nav>
       <div class="cp-viewer-bar">
         
+        <span class="cp-bg" role="group" aria-label="Preview zoom">
+          <button type="button" class="cp-bg-btn cp-zoom-btn" data-zoom-mode="fit" aria-pressed="true">Fit screen</button>
+          <button type="button" class="cp-bg-btn cp-zoom-btn" data-zoom-mode="width" aria-pressed="false">Fit width</button>
+        </span>
         <button type="button" class="cp-drawer-toggle" id="cp-controls-toggle" aria-expanded="true" aria-controls="cp-controls">⚙ Overrides</button>
       </div>
       <div class="cp-viewer cp-controls-open" data-bg-theme="light" data-preview-id="button-filled__ideal__default__light" data-mode="snapshot" data-modes="snapshot" data-static-snapshot="true" data-can-render-overrides="false" data-snapshot-backend="Snapshot" data-live-backend="Live" data-render-density="2">
@@ -723,6 +727,36 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
   var status = document.getElementById("cp-status");
   var errorBox = document.getElementById("cp-error");
   var live = document.getElementById("cp-live");
+  // Tall previews used to size the stage from their full width-constrained height, which could
+  // push the rest of the viewer several screens below the fold. Default to a viewport-bounded
+  // contain fit; "Fit width" deliberately restores the old unconstrained-height presentation.
+  // The snapshot remains the geometry source for Live/Wasm, so re-pin an active overlay after
+  // changing modes.
+  var zoomBtns = document.querySelectorAll(".cp-zoom-btn");
+  function applyZoom(mode) {
+    if (mode !== "width") mode = "fit";
+    var maxHeight = mode === "fit" ? "72vh" : "";
+    img.style.maxHeight = maxHeight;
+    var rcZoomCanvas = document.getElementById("cp-rc-canvas");
+    if (rcZoomCanvas) rcZoomCanvas.style.maxHeight = maxHeight;
+    root.setAttribute("data-zoom", mode);
+    zoomBtns.forEach(function (b) {
+      b.setAttribute(
+        "aria-pressed",
+        b.getAttribute("data-zoom-mode") === mode ? "true" : "false"
+      );
+    });
+    window.requestAnimationFrame(function () {
+      if (live && live.checked && !canvas.hidden) fitLiveCanvas();
+      if (wasmActive()) positionWasmFrame();
+    });
+  }
+  zoomBtns.forEach(function (b) {
+    b.addEventListener("click", function () {
+      applyZoom(b.getAttribute("data-zoom-mode"));
+    });
+  });
+  applyZoom("fit");
   // Surface a mode-activation failure visibly, instead of leaving a stale frame that reads as a
   // (wrong) render. Every lane routes its failure here — a dead Live stream, a Wasm app that
   // never boots, a /render that errors — so "can't activate this mode" is never silent.

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
@@ -424,6 +424,10 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
       
       <div class="cp-viewer-bar">
         
+        <span class="cp-bg" role="group" aria-label="Preview zoom">
+          <button type="button" class="cp-bg-btn cp-zoom-btn" data-zoom-mode="fit" aria-pressed="true">Fit screen</button>
+          <button type="button" class="cp-bg-btn cp-zoom-btn" data-zoom-mode="width" aria-pressed="false">Fit width</button>
+        </span>
         <button type="button" class="cp-drawer-toggle" id="cp-controls-toggle" aria-expanded="true" aria-controls="cp-controls">⚙ Overrides</button>
       </div>
       <div class="cp-viewer cp-controls-open" data-preview-id="com.example.CardPreview" data-mode="snapshot" data-modes="snapshot,live" data-static-snapshot="true" data-can-render-overrides="false" data-snapshot-backend="Snapshot" data-live-backend="Live" data-render-density="2" data-wasm-src="/wasm/compose-m3/?id=card-filled">
@@ -727,6 +731,36 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
   var status = document.getElementById("cp-status");
   var errorBox = document.getElementById("cp-error");
   var live = document.getElementById("cp-live");
+  // Tall previews used to size the stage from their full width-constrained height, which could
+  // push the rest of the viewer several screens below the fold. Default to a viewport-bounded
+  // contain fit; "Fit width" deliberately restores the old unconstrained-height presentation.
+  // The snapshot remains the geometry source for Live/Wasm, so re-pin an active overlay after
+  // changing modes.
+  var zoomBtns = document.querySelectorAll(".cp-zoom-btn");
+  function applyZoom(mode) {
+    if (mode !== "width") mode = "fit";
+    var maxHeight = mode === "fit" ? "72vh" : "";
+    img.style.maxHeight = maxHeight;
+    var rcZoomCanvas = document.getElementById("cp-rc-canvas");
+    if (rcZoomCanvas) rcZoomCanvas.style.maxHeight = maxHeight;
+    root.setAttribute("data-zoom", mode);
+    zoomBtns.forEach(function (b) {
+      b.setAttribute(
+        "aria-pressed",
+        b.getAttribute("data-zoom-mode") === mode ? "true" : "false"
+      );
+    });
+    window.requestAnimationFrame(function () {
+      if (live && live.checked && !canvas.hidden) fitLiveCanvas();
+      if (wasmActive()) positionWasmFrame();
+    });
+  }
+  zoomBtns.forEach(function (b) {
+    b.addEventListener("click", function () {
+      applyZoom(b.getAttribute("data-zoom-mode"));
+    });
+  });
+  applyZoom("fit");
   // Surface a mode-activation failure visibly, instead of leaving a stale frame that reads as a
   // (wrong) render. Every lane routes its failure here — a dead Live stream, a Wasm app that
   // never boots, a /render that errors — so "can't activate this mode" is never silent.

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
@@ -424,6 +424,10 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
       
       <div class="cp-viewer-bar">
         
+        <span class="cp-bg" role="group" aria-label="Preview zoom">
+          <button type="button" class="cp-bg-btn cp-zoom-btn" data-zoom-mode="fit" aria-pressed="true">Fit screen</button>
+          <button type="button" class="cp-bg-btn cp-zoom-btn" data-zoom-mode="width" aria-pressed="false">Fit width</button>
+        </span>
         <button type="button" class="cp-drawer-toggle" id="cp-controls-toggle" aria-expanded="true" aria-controls="cp-controls">⚙ Overrides</button>
       </div>
       <div class="cp-viewer cp-controls-open" data-preview-id="com.example.CardPreview" data-mode="snapshot" data-modes="snapshot,live" data-static-snapshot="true" data-can-render-overrides="false" data-snapshot-backend="Snapshot" data-live-backend="Live" data-render-density="2" data-wasm-src="/wasm/compose-m3/?id=card-filled">
@@ -718,6 +722,36 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
   var status = document.getElementById("cp-status");
   var errorBox = document.getElementById("cp-error");
   var live = document.getElementById("cp-live");
+  // Tall previews used to size the stage from their full width-constrained height, which could
+  // push the rest of the viewer several screens below the fold. Default to a viewport-bounded
+  // contain fit; "Fit width" deliberately restores the old unconstrained-height presentation.
+  // The snapshot remains the geometry source for Live/Wasm, so re-pin an active overlay after
+  // changing modes.
+  var zoomBtns = document.querySelectorAll(".cp-zoom-btn");
+  function applyZoom(mode) {
+    if (mode !== "width") mode = "fit";
+    var maxHeight = mode === "fit" ? "72vh" : "";
+    img.style.maxHeight = maxHeight;
+    var rcZoomCanvas = document.getElementById("cp-rc-canvas");
+    if (rcZoomCanvas) rcZoomCanvas.style.maxHeight = maxHeight;
+    root.setAttribute("data-zoom", mode);
+    zoomBtns.forEach(function (b) {
+      b.setAttribute(
+        "aria-pressed",
+        b.getAttribute("data-zoom-mode") === mode ? "true" : "false"
+      );
+    });
+    window.requestAnimationFrame(function () {
+      if (live && live.checked && !canvas.hidden) fitLiveCanvas();
+      if (wasmActive()) positionWasmFrame();
+    });
+  }
+  zoomBtns.forEach(function (b) {
+    b.addEventListener("click", function () {
+      applyZoom(b.getAttribute("data-zoom-mode"));
+    });
+  });
+  applyZoom("fit");
   // Surface a mode-activation failure visibly, instead of leaving a stale frame that reads as a
   // (wrong) render. Every lane routes its failure here — a dead Live stream, a Wasm app that
   // never boots, a /render that errors — so "can't activate this mode" is never silent.

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
@@ -424,6 +424,10 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
       
       <div class="cp-viewer-bar">
         <button type="button" class="cp-drawer-toggle" id="cp-nav-toggle" aria-expanded="false" aria-controls="cp-nav">☰ Components</button>
+        <span class="cp-bg" role="group" aria-label="Preview zoom">
+          <button type="button" class="cp-bg-btn cp-zoom-btn" data-zoom-mode="fit" aria-pressed="true">Fit screen</button>
+          <button type="button" class="cp-bg-btn cp-zoom-btn" data-zoom-mode="width" aria-pressed="false">Fit width</button>
+        </span>
         <button type="button" class="cp-drawer-toggle" id="cp-controls-toggle" aria-expanded="true" aria-controls="cp-controls">⚙ Overrides</button>
       </div>
       <div class="cp-viewer cp-controls-open" data-preview-id="com.example.ProfileScreenPreview" data-mode="snapshot" data-modes="snapshot,live" data-static-snapshot="true" data-can-render-overrides="false" data-snapshot-backend="Snapshot" data-live-backend="Live" data-render-density="2">
@@ -730,6 +734,36 @@ html:not(.cp-bg-transparent) .cp-viewer[data-bg-theme="light"] .cp-stage { backg
   var status = document.getElementById("cp-status");
   var errorBox = document.getElementById("cp-error");
   var live = document.getElementById("cp-live");
+  // Tall previews used to size the stage from their full width-constrained height, which could
+  // push the rest of the viewer several screens below the fold. Default to a viewport-bounded
+  // contain fit; "Fit width" deliberately restores the old unconstrained-height presentation.
+  // The snapshot remains the geometry source for Live/Wasm, so re-pin an active overlay after
+  // changing modes.
+  var zoomBtns = document.querySelectorAll(".cp-zoom-btn");
+  function applyZoom(mode) {
+    if (mode !== "width") mode = "fit";
+    var maxHeight = mode === "fit" ? "72vh" : "";
+    img.style.maxHeight = maxHeight;
+    var rcZoomCanvas = document.getElementById("cp-rc-canvas");
+    if (rcZoomCanvas) rcZoomCanvas.style.maxHeight = maxHeight;
+    root.setAttribute("data-zoom", mode);
+    zoomBtns.forEach(function (b) {
+      b.setAttribute(
+        "aria-pressed",
+        b.getAttribute("data-zoom-mode") === mode ? "true" : "false"
+      );
+    });
+    window.requestAnimationFrame(function () {
+      if (live && live.checked && !canvas.hidden) fitLiveCanvas();
+      if (wasmActive()) positionWasmFrame();
+    });
+  }
+  zoomBtns.forEach(function (b) {
+    b.addEventListener("click", function () {
+      applyZoom(b.getAttribute("data-zoom-mode"));
+    });
+  });
+  applyZoom("fit");
   // Surface a mode-activation failure visibly, instead of leaving a stale frame that reads as a
   // (wrong) render. Every lane routes its failure here — a dead Live stream, a Wasm app that
   // never boots, a /render that errors — so "can't activate this mode" is never silent.


### PR DESCRIPTION
## Summary

- add explicit **Fit screen** and **Fit width** controls to the preview viewer
- default every preview to a viewport-bounded screen fit before its first render
- keep Remote Compose canvases and live/Wasm overlays aligned when zoom mode changes
- regenerate viewer fixtures and add focused regression coverage

## Why

The viewer previously constrained previews only by width. Tall previews could therefore occupy several screens and push the controls below the fold. Screen fit now caps media at 72% of the viewport height, while Fit width preserves the previous presentation as an explicit choice.

## Validation

- `./gradlew :cli:test --tests '*ServeWebFixtureTest*' :cli:ktfmtCheck`
- `HARNESS_FIXTURE=serve-viewer playwright test -c preview-harness/playwright.config.mjs pages-snapshot.spec.mjs` (light and dark)
- visual inspection of both generated viewer screenshots
- `git diff --check`

Fixes #2810