### PR TITLE
fix(serve): honor live catalog runtime versions

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt
@@ -33,7 +33,7 @@ import okio.Path.Companion.toPath
  * Backend-aware, mirroring `bundle daemon`'s two launches over the **same** `DaemonMain`
  * entrypoint: a `desktop` bundle spawns the CMP/Skiko daemon (`lib-daemon-desktop` +
  * `lib-renderer`), an `android` bundle spawns the Robolectric daemon (`lib-daemon-android` +
- * `android.jar` + the JDK-17 `--add-opens` + `robolectric.*` sysprops [AndroidBundleLaunch]
+ * `android.jar` + the required `--add-opens` + `robolectric.*` sysprops [AndroidBundleLaunch]
  * supplies). Wiring the Android backend here is what gives an Android/Wear catalog (e.g. `wear-m3`)
  * a live daemon session — and hence per-variant renders + the daemon-produced `compose/figma-svg`
  * lane (`renderSvg` on [ServeCatalogLiveHost]) that a baked, per-slug `figma/<slug>.svg` can't
@@ -164,7 +164,7 @@ internal object ServeBundleDaemon {
 
     val libJars = BundleReader.extractEmbeddedLibs(zipBytes, libsDir, fileSystem)
     val mavenCoords = manifest.classpath.filterIsInstance<BundleReader.ClasspathEntry.Maven>()
-    val resolvedJars =
+    val resolvedDependencies =
       CoordinateResolver(
           warn = { onLog("catalog $system: $it") },
           networkEnabled = if (offline) false else CoordinateResolver.defaultNetworkEnabled(),
@@ -173,13 +173,11 @@ internal object ServeBundleDaemon {
               extraMavenRepos.filter { it.isNotBlank() },
         )
         .resolveAll(mavenCoords)
-        .mapNotNull { it.file }
-    // The rehydrated external-resource dirs go right after the bundle's own classes so a lifted
-    // font resolves at the same `/fonts/…` classpath path it did when carried inline.
-    val userClassPath =
-      (listOf(classesDir) + extraClasspathDirs.filter { it.isDirectory } + libJars + resolvedJars)
-        .joinToString(File.pathSeparator) { it.absolutePath }
-
+        .mapNotNull { resolution ->
+          resolution.file?.let { file -> ResolvedBundleDependency(resolution.coordinate, file) }
+        }
+    val (parentOverlayDependencies, childDependencies) =
+      resolvedDependencies.partition { shouldPrecedeDaemonSidecar(it.coordinate) }
     // Android app-resource carriage: a classic `@Preview` that calls `stringResource(R.string.…)`
     // needs the app's own `0x7f` resource table at render time. Extract the bundle's carried
     // `android/` payload and synthesize the Robolectric `test_config.properties` onto the daemon
@@ -205,6 +203,23 @@ internal object ServeBundleDaemon {
         "android" -> androidBundleDaemonLaunch(system, onLog)
         else -> desktopBundleDaemonLaunch(system, onLog)
       } ?: return null
+    val classpaths =
+      bundleDaemonClasspaths(
+        classesDir = classesDir,
+        extraClasspathDirs = extraClasspathDirs,
+        embeddedLibJars = libJars,
+        parentOverlayJars = parentOverlayDependencies.map { it.file },
+        childDependencyJars = childDependencies.map { it.file },
+        daemonSidecarClasspath = backendLaunch.daemonClasspath,
+        androidResourceClasspath = androidResourceClasspath,
+      )
+    if (parentOverlayDependencies.isNotEmpty()) {
+      onLog(
+        "catalog $system: ${parentOverlayDependencies.size} shared bundle dependency classpath " +
+          "entry(s) precede the daemon sidecar; ${childDependencies.size} app dependency " +
+          "entry(s) remain isolated"
+      )
+    }
 
     val descriptor =
       DaemonLaunchDescriptor(
@@ -216,11 +231,11 @@ internal object ServeBundleDaemon {
         // classpath / JVM args / sysprops differ (see [BackendDaemonLaunch]).
         mainClass = DAEMON_MAIN_CLASS,
         javaLauncher = null,
-        classpath = backendLaunch.daemonClasspath + androidResourceClasspath,
+        classpath = classpaths.daemonClasspath,
         jvmArgs = backendLaunch.jvmArgs,
         systemProperties =
           buildMap {
-            put("composeai.daemon.userClassDirs", userClassPath)
+            put("composeai.daemon.userClassDirs", classpaths.userClassPath)
             put("composeai.daemon.previewsJsonPath", previewsJson.absolutePath)
             // Point the daemon's render output at `<destDir>/renders`. This is what makes
             // `DaemonMain.dataRoot` non-null (`<destDir>/data`), which is the gate that *registers*
@@ -438,6 +453,74 @@ internal object ServeBundleDaemon {
   }
 
   /**
+   * Split a packed bundle's runtime into the daemon parent and disposable user child classpaths.
+   *
+   * Compose, AndroidX, Kotlin, and kotlinx packages deliberately delegate to the daemon parent
+   * loader so renderer and preview code share one class identity. Consequently, leaving the
+   * bundle's resolved Maven jars in `composeai.daemon.userClassDirs` cannot make those catalog
+   * versions win: [ee.schimke.composeai.daemon.UserClassLoaderHolder] delegates them straight to
+   * the server sidecar, producing `NoSuchMethodError` when the catalog was compiled against newer
+   * Material, Lifecycle, or coroutines APIs.
+   *
+   * Put the bundle's shared AndroidX/Compose and coroutines dependencies first on the parent `-cp`,
+   * ahead of the daemon sidecar. The JVM's left-to-right classpath order then selects the catalog's
+   * framework versions while retaining one parent-loaded copy for both renderer and app code. Keep
+   * ordinary app dependencies in the child loader. In particular, do not overlay
+   * kotlinx-serialization: the daemon's generated JSON-RPC serializers and its runtime must stay
+   * version-aligned.
+   */
+  internal fun bundleDaemonClasspaths(
+    classesDir: File,
+    extraClasspathDirs: List<File>,
+    embeddedLibJars: List<File>,
+    parentOverlayJars: List<File>,
+    childDependencyJars: List<File>,
+    daemonSidecarClasspath: List<String>,
+    androidResourceClasspath: List<String>,
+  ): BundleDaemonClasspaths {
+    // The carried r-classes.jar belongs to the catalog's AndroidX graph too. It must precede the
+    // sidecar's generated R.jar or newer Compose UI bytecode can resolve an older R$id class and
+    // fail with NoSuchFieldError.
+    val parentEntries =
+      (parentOverlayJars.map { it.absolutePath } +
+          androidResourceClasspath +
+          daemonSidecarClasspath)
+        .distinct()
+    // The rehydrated external-resource dirs go right after the bundle's own classes so a lifted
+    // font resolves at the same `/fonts/…` path it did when carried inline.
+    val childEntries =
+      (listOf(classesDir) +
+          extraClasspathDirs.filter { it.isDirectory } +
+          embeddedLibJars +
+          childDependencyJars)
+        .map { it.absolutePath }
+        .distinct()
+    return BundleDaemonClasspaths(
+      daemonClasspath = parentEntries,
+      userClassPath = childEntries.joinToString(File.pathSeparator),
+    )
+  }
+
+  internal data class BundleDaemonClasspaths(
+    val daemonClasspath: List<String>,
+    val userClassPath: String,
+  )
+
+  /**
+   * Dependencies whose packages [ee.schimke.composeai.daemon.UserClassLoaderHolder] deliberately
+   * resolves from the parent and whose consumer ABI must therefore win over the baked sidecar.
+   */
+  internal fun shouldPrecedeDaemonSidecar(coordinate: BundleReader.ClasspathEntry.Maven): Boolean =
+    coordinate.group.startsWith("androidx.") ||
+      (coordinate.group == "org.jetbrains.kotlinx" &&
+        coordinate.artifact.startsWith("kotlinx-coroutines"))
+
+  private data class ResolvedBundleDependency(
+    val coordinate: BundleReader.ClasspathEntry.Maven,
+    val file: File,
+  )
+
+  /**
    * The backend-specific half of a bundle daemon launch: the daemon (parent `-cp`) classpath, the
    * JVM args, and any extra `-D` system properties. Mirrors `BundleDaemonCommand.DaemonLaunch` but
    * flattened for the descriptor path (which applies `jvmArgs` + `systemProperties` + `classpath`
@@ -499,7 +582,7 @@ internal object ServeBundleDaemon {
   }
 
   /**
-   * Android (Robolectric) launch: `lib-daemon-android` + `android.jar`, plus the JDK-17
+   * Android (Robolectric) launch: `lib-daemon-android` + `android.jar`, plus the required
    * `--add-opens` args and `robolectric.*` mode sysprops [AndroidBundleLaunch] supplies (the same
    * ones `bundle daemon`'s `androidDaemonLaunch` passes). `resolveAndroidJar(null)` falls back to
    * `ANDROID_HOME`/`ANDROID_SDK_ROOT` since a module-less serve has no `local.properties`. Missing

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemonTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemonTest.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.cli.serve
 
+import ee.schimke.composeai.cli.BundleReader
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.daemon.protocol.RenderTier
 import ee.schimke.composeai.mcp.DaemonLaunchDescriptor
@@ -12,6 +13,7 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.contentOrNull
@@ -34,6 +36,79 @@ import kotlinx.serialization.json.jsonPrimitive
  * override via `-Dcomposeai.cli.appHome=<install-root>` to point elsewhere.
  */
 class ServeBundleDaemonTest {
+
+  @Test
+  fun `bundle dependencies precede daemon sidecars on the shared parent classpath`() {
+    val root = Files.createTempDirectory("serve-bundle-classpaths").toFile()
+    val classes = File(root, "classes").apply { mkdirs() }
+    val resources = File(root, "resources").apply { mkdirs() }
+    val embedded = File(root, "app-project.jar")
+    val catalogMaterial = File(root, "material3-catalog.jar")
+    val catalogCoroutines = File(root, "coroutines-catalog.jar")
+    val catalogSerialization = File(root, "serialization-catalog.jar")
+    val sidecarMaterial = File(root, "material3-sidecar.jar")
+    val daemon = File(root, "daemon.jar")
+    val androidResources = File(root, "android-resources")
+
+    val result =
+      ServeBundleDaemon.bundleDaemonClasspaths(
+        classesDir = classes,
+        extraClasspathDirs = listOf(resources, File(root, "missing-resources")),
+        embeddedLibJars = listOf(embedded),
+        parentOverlayJars = listOf(catalogMaterial, catalogCoroutines, catalogMaterial),
+        childDependencyJars = listOf(catalogSerialization),
+        daemonSidecarClasspath = listOf(sidecarMaterial.absolutePath, daemon.absolutePath),
+        androidResourceClasspath = listOf(androidResources.absolutePath),
+      )
+
+    assertEquals(
+      listOf(
+        catalogMaterial.absolutePath,
+        catalogCoroutines.absolutePath,
+        androidResources.absolutePath,
+        sidecarMaterial.absolutePath,
+        daemon.absolutePath,
+      ),
+      result.daemonClasspath,
+      "catalog dependencies must win parent-classpath lookup ahead of host sidecars",
+    )
+    assertEquals(
+      listOf(classes, resources, embedded, catalogSerialization).joinToString(File.pathSeparator) {
+        it.absolutePath
+      },
+      result.userClassPath,
+    )
+    assertTrue(
+      catalogMaterial.absolutePath !in result.userClassPath,
+      "parent-loaded framework dependencies must not be duplicated in the user child loader",
+    )
+  }
+
+  @Test
+  fun `only consumer shared ABI dependencies overlay daemon internals`() {
+    fun coordinate(group: String, artifact: String) =
+      BundleReader.ClasspathEntry.Maven(group, artifact, "1", "jar")
+
+    assertTrue(
+      ServeBundleDaemon.shouldPrecedeDaemonSidecar(
+        coordinate("androidx.compose.material3", "material3")
+      )
+    )
+    assertTrue(
+      ServeBundleDaemon.shouldPrecedeDaemonSidecar(
+        coordinate("org.jetbrains.kotlinx", "kotlinx-coroutines-core-jvm")
+      )
+    )
+    assertTrue(
+      !ServeBundleDaemon.shouldPrecedeDaemonSidecar(
+        coordinate("org.jetbrains.kotlinx", "kotlinx-serialization-json-jvm")
+      ),
+      "daemon protocol serializers must remain version-aligned with the sidecar runtime",
+    )
+    assertTrue(
+      !ServeBundleDaemon.shouldPrecedeDaemonSidecar(coordinate("com.squareup.okhttp3", "okhttp"))
+    )
+  }
 
   @Test
   fun `materialize produces a valid descriptor plus previews from a packed desktop bundle`() {
@@ -158,6 +233,84 @@ class ServeBundleDaemonTest {
       assertTrue(png.isFile, "rendered PNG must exist on disk: $pngPath")
       assertTrue(png.length() > 0L)
     }
+  }
+
+  /**
+   * Production compatibility proof for a published Android catalog whose Compose/AndroidX/Kotlin
+   * dependencies differ from the daemon sidecar's. This caught Jetcaster's
+   * `MotionScheme.expressive()` / mangled `TopAppBar` failures: materialization used to leave the
+   * catalog dependency graph in the child loader even though those packages delegate to the parent,
+   * so the older sidecar APIs won.
+   *
+   * Self-skips unless `-Dcomposeai.test.androidCompatibilityBundlePath=<bundle.png>` is supplied.
+   * Optionally select a known compatibility-sensitive preview with
+   * `-Dcomposeai.test.androidCompatibilityPreviewContains=<substring>`; otherwise the first preview
+   * is rendered.
+   */
+  @Test
+  fun `android bundle renders against its carried dependency versions`() {
+    val bundlePath = System.getProperty(ANDROID_COMPATIBILITY_BUNDLE_PATH_PROPERTY)
+    if (bundlePath.isNullOrBlank()) {
+      System.err.println(
+        "[ServeBundleDaemonTest] skipping android dependency compatibility — set " +
+          "-D$ANDROID_COMPATIBILITY_BUNDLE_PATH_PROPERTY=<published android bundle .png>."
+      )
+      return
+    }
+    val bundleFile = File(bundlePath)
+    assertTrue(bundleFile.isFile, "no compatibility bundle at $bundlePath")
+    ensureAppHomeConfigured()
+
+    val state =
+      assertNotNull(
+        ServeBundleDaemon.materialize(
+          bundleFile,
+          Files.createTempDirectory("serve-bundle-daemon-android-compat").toFile(),
+          "android-compatibility",
+        ),
+        "published Android compatibility bundle should materialize",
+      )
+    val parsed =
+      descriptorJson.decodeFromString(
+        DaemonLaunchDescriptor.serializer(),
+        state.descriptor.readText(),
+      )
+    val firstSidecar =
+      parsed.classpath.indexOfFirst {
+        it.contains("staged-daemon-android-libs") || it.contains("lib-daemon-android")
+      }
+    assertTrue(firstSidecar > 0, "descriptor should contain bundle dependencies before the sidecar")
+    assertTrue(
+      parsed.classpath.take(firstSidecar).any { it.contains("bundle-deps") },
+      "at least one bundle-resolved dependency should precede the Android daemon sidecar",
+    )
+
+    val selector = System.getProperty(ANDROID_COMPATIBILITY_PREVIEW_CONTAINS_PROPERTY)
+    val target =
+      selector?.let { needle -> state.previews.firstOrNull { needle in it.id } }
+        ?: state.previews.firstOrNull()
+    assertNotNull(target, "compatibility bundle should contain a selectable preview")
+
+    ServeRenderHost.open(
+        descriptorPath = state.descriptor,
+        workspaceRoot = state.workspaceRoot,
+        workspaceName = state.workspaceName,
+        previews = state.previews,
+        label = state.label,
+        declaredThemes = state.declaredThemes,
+        onLog = { line -> System.err.println("[android compatibility daemon] $line") },
+      )
+      .use { host ->
+        var outcome: RenderOutcome? = null
+        repeat(3) {
+          outcome = host.render(target.id, PreviewOverrides())
+          if (outcome is RenderOutcome.Ok) return@use
+        }
+        assertTrue(
+          outcome is RenderOutcome.Ok,
+          "catalog preview ${target.id} should render with its carried dependency APIs; got $outcome",
+        )
+      }
   }
 
   /**
@@ -358,6 +511,10 @@ class ServeBundleDaemonTest {
   private companion object {
     const val BUNDLE_PATH_PROPERTY = "composeai.test.bundlePath"
     const val ANDROID_BUNDLE_PATH_PROPERTY = "composeai.test.androidBundlePath"
+    const val ANDROID_COMPATIBILITY_BUNDLE_PATH_PROPERTY =
+      "composeai.test.androidCompatibilityBundlePath"
+    const val ANDROID_COMPATIBILITY_PREVIEW_CONTAINS_PROPERTY =
+      "composeai.test.androidCompatibilityPreviewContains"
     const val APP_HOME_PROPERTY = "composeai.cli.appHome"
     const val DEFAULT_BUNDLE_PATH = "/tmp/m3-bundle.png"
 

--- a/deploy/image/Dockerfile
+++ b/deploy/image/Dockerfile
@@ -20,7 +20,7 @@ ARG CP_VERSION=0.18.6
 # Stage 0: base — JDK + Skiko's native deps (same rationale as the cloudrun image:
 # libGL via libgl1, Mesa software GLX/DRI, fonts; force software GL).
 # ---------------------------------------------------------------------------
-FROM eclipse-temurin:17.0.19_10-jdk AS base
+FROM eclipse-temurin:21.0.11_10-jdk AS base
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
       libfreetype6 libfontconfig1 fontconfig fonts-dejavu-core \
@@ -152,8 +152,8 @@ RUN ln -s "/opt/compose-preview-${CP_VERSION}" /opt/compose-preview
 COPY --from=android-daemon /opt/lib-daemon-android /opt/lib-daemon-android
 COPY --from=android-daemon /opt/android-sdk /opt/android-sdk
 # JAVA_TOOL_OPTIONS (inherited by the spawned daemon JVM too) points the CLI at the
-# unpacked Android daemon sidecar, warms the daemon off the request path
-# (warmInBackground → serve's prewarm), and lifts BOTH cold-start budgets so a cold
+# unpacked Android daemon sidecar, keeps per-preview daemons lazy
+# (warmInBackground=false), and lifts BOTH cold-start budgets so a cold
 # Robolectric daemon doesn't abort before it can serve live:
 #   * sandboxBootTimeoutMs — the Robolectric sandbox boot (the one-time
 #     `android-all-instrumented` ~150 MB fetch + instrumentation, in RobolectricHost.start,
@@ -165,7 +165,7 @@ COPY --from=android-daemon /opt/android-sdk /opt/android-sdk
 #     which surfaced as `/render?knob.…` returning `500 timed out after 10s`. Lift it in lockstep
 #     with the cold budget so warm overrides/Wear frames have room (ServeRenderHost also gives the
 #     first override render the cold budget, so this only bounds steady-state frames).
-# Both are absorbed by prewarm off the request path, so a browse never blocks. See
+# Baked catalog pixels remain available while a requested live daemon warms. See
 # RobolectricHost / ServeCatalogLiveHost / ServeRenderHost.
 #
 # sandboxCount — the Android/Robolectric daemon defaults to a **5**-sandbox pool (DaemonMain,
@@ -190,7 +190,7 @@ ENV PATH="/opt/compose-preview/bin:${PATH}" \
     COMPOSE_PREVIEW_INIT_USE_MAVEN_LOCAL=1 \
     ANDROID_HOME=/opt/android-sdk \
     ANDROID_SDK_ROOT=/opt/android-sdk \
-    JAVA_TOOL_OPTIONS="-XX:MaxRAMPercentage=70 -Dcomposeai.cli.libDaemonAndroidDir=/opt/lib-daemon-android -Dcomposeai.serve.warmInBackground=true -Dcomposeai.serve.renderTimeoutSeconds=900 -Dcomposeai.serve.frameRenderTimeoutSeconds=120 -Dcomposeai.daemon.sandboxCount=3 -Dcomposeai.daemon.sandboxBootTimeoutMs=1800000 -Dcomposeai.daemon.backgroundSandboxBoot=true"
+    JAVA_TOOL_OPTIONS="-XX:MaxRAMPercentage=70 -Dcomposeai.cli.libDaemonAndroidDir=/opt/lib-daemon-android -Dcomposeai.serve.warmInBackground=false -Dcomposeai.serve.renderTimeoutSeconds=900 -Dcomposeai.serve.frameRenderTimeoutSeconds=120 -Dcomposeai.daemon.sandboxCount=3 -Dcomposeai.daemon.sandboxBootTimeoutMs=1800000 -Dcomposeai.daemon.backgroundSandboxBoot=true"
 
 WORKDIR /project
 # Carry the release Maven tree so live bundles can resolve the plugin/runtime


### PR DESCRIPTION
## Summary

- load bundle-carried AndroidX/Compose and coroutines jars ahead of the daemon sidecar while keeping daemon serialization internals version-aligned
- place the bundle's generated AndroidX `R` classes ahead of the sidecar `R.jar`
- run the release image on Java 21 for Java 21-compiled catalogs
- disable eager live-catalog prewarming by default so catalog startup does not fan out dozens of daemon JVMs
- add classpath-policy coverage plus an opt-in published-bundle compatibility render test

## Production verification

- published Jetcaster bundle: `JetcasterHomeLibraryPreview` renders successfully (covers Material 3 `MotionScheme.expressive`, mangled app-bar APIs, and newer Compose UI resource symbols)
- published Jetnews bundle: `PreviewHomeFeedLoading` renders successfully (covers `kotlinx.coroutines` 1.11 `runBlockingK$default`)
- `preview.coo.ee` with eager warming disabled: healthy at roughly 9 GiB / 11 JVMs, down from ~42 child JVMs and cgroup OOM

## Tests

- `./gradlew :cli:ktfmtCheck :cli:test --tests 'ee.schimke.composeai.cli.serve.ServeBundleDaemonTest'`
- opt-in real bundle compatibility test against published Jetcaster
- opt-in real bundle compatibility test against published Jetnews

Fixes #2833
Fixes #2839

Related to #2843 (memory profiling and bounded prewarm follow-up).