### PR TITLE
fix(previews): label parameterized captures

### DIFF
--- a/.github/actions/lib/compare-previews.py
+++ b/.github/actions/lib/compare-previews.py
@@ -220,11 +220,15 @@ def _capture_label(capture: dict) -> str:
 
     Mirrors the TS `captureLabels.captureLabel` in the VS Code extension so
     the two surfaces agree on wording. Static captures (no dimensions)
-    return ``""``; time fan-outs read ``"500ms"``; scroll captures read
-    ``"scroll top"`` / ``"scroll end"`` / ``"scroll long"``; the
+    return ``""``; parameter fan-outs read ``"parameter 0"``; time fan-outs
+    read ``"500ms"``; scroll captures read ``"scroll top"`` /
+    ``"scroll end"`` / ``"scroll long"``; the
     cross-product reads ``"500ms \u00B7 scroll end"``.
     """
     parts: list[str] = []
+    parameter = capture.get("parameterLabel")
+    if parameter:
+        parts.append(str(parameter))
     ms = capture.get("advanceTimeMillis")
     if ms is not None:
         parts.append(f"{ms}ms")

--- a/.github/actions/lib/test_compare_previews.py
+++ b/.github/actions/lib/test_compare_previews.py
@@ -57,7 +57,8 @@ def _entry(*, id: str, module: str = "app", function: str = "Fn",
 def _capture(*, png: str | None = None, sha: str | None = None,
              advanceTimeMillis: int | None = None,
              scroll: dict | None = None,
-             optional: bool = False) -> dict:
+             optional: bool = False,
+             parameterLabel: str | None = None) -> dict:
     """Build a CaptureResult-shaped dict for use in `_entry(captures=[…])`."""
     return {
         "pngPath": png,
@@ -65,6 +66,7 @@ def _capture(*, png: str | None = None, sha: str | None = None,
         "advanceTimeMillis": advanceTimeMillis,
         "scroll": scroll,
         "optional": optional,
+        "parameterLabel": parameterLabel,
     }
 
 
@@ -1157,6 +1159,16 @@ class CaptureLabelTest(unittest.TestCase):
     def test_time_only(self):
         self.assertEqual(cp._capture_label({"advanceTimeMillis": 500, "scroll": None}), "500ms")
 
+    def test_parameter_label_combines_with_other_dimensions(self):
+        self.assertEqual(
+            cp._capture_label({
+                "parameterLabel": "parameter 2",
+                "advanceTimeMillis": 500,
+                "scroll": None,
+            }),
+            "parameter 2 \u00B7 500ms",
+        )
+
     def test_scroll_only(self):
         self.assertEqual(
             cp._capture_label({"advanceTimeMillis": None, "scroll": {"mode": "LONG"}}),
@@ -1224,6 +1236,39 @@ class MultiCaptureGenerateTest(unittest.TestCase):
         readme = (self.out / "README.md").read_text()
         self.assertIn("Fn \u00B7 scroll top", readme)
         self.assertIn("Fn \u00B7 scroll end", readme)
+
+    def test_parameter_fanout_rows_include_their_distinct_labels(self):
+        from types import SimpleNamespace
+        self.cli_path.write_text(json.dumps({
+            "previews": [_entry(
+                id="Widget", module="wear-widget", function="WidgetPreview",
+                png=str(self.top_png), sha="zero-sha",
+                captures=[
+                    _capture(
+                        png=str(self.top_png),
+                        sha="zero-sha",
+                        parameterLabel="parameter 0",
+                    ),
+                    _capture(
+                        png=str(self.end_png),
+                        sha="one-sha",
+                        parameterLabel="parameter 1",
+                    ),
+                ],
+            )],
+        }))
+
+        rc = cp.cmd_generate(SimpleNamespace(
+            cli_json=str(self.cli_path),
+            output_dir=str(self.out),
+            repo="owner/repo",
+            branch="compose-preview/main",
+        ))
+        self.assertEqual(rc, 0)
+
+        readme = (self.out / "README.md").read_text()
+        self.assertIn("WidgetPreview \u00B7 parameter 0", readme)
+        self.assertIn("WidgetPreview \u00B7 parameter 1", readme)
 
 
 class MultiCaptureCopyChangedTest(unittest.TestCase):

--- a/api/gradle-preview-driver/src/main/kotlin/ee/schimke/composeai/cli/PreviewResultBuilder.kt
+++ b/api/gradle-preview-driver/src/main/kotlin/ee/schimke/composeai/cli/PreviewResultBuilder.kt
@@ -81,22 +81,24 @@ object PreviewResultBuilder {
         // `@PreviewParameter`-driven previews render at `<stem>_<suffix>.<ext>`, one file per
         // provider value. The manifest carries a single template capture; here we glob the actual
         // fan-out and synthesize a `CaptureResult` per file on disk.
-        val captures =
+        val captures: List<ExpandedCapture> =
           if (p.params.previewParameterProviderClassName != null) {
             p.captures.flatMap { capture ->
               expandParamCaptures(module, capture, siblingRenderOutputs, fileSystem)
             }
           } else {
-            p.captures
+            p.captures.map(::ExpandedCapture)
           }
-        val productCaptures = p.dataProducts.mapNotNull { it.asPreviewArtifactCapture(module) }
+        val productCaptures =
+          p.dataProducts.mapNotNull { it.asPreviewArtifactCapture(module) }.map(::ExpandedCapture)
         val resultCaptures =
-          if (captures.isSingleStaticCapture() && productCaptures.isNotEmpty()) {
+          if (captures.map { it.capture }.isSingleStaticCapture() && productCaptures.isNotEmpty()) {
             productCaptures
           } else {
             captures + productCaptures
           }
-        val captureResults = resultCaptures.map { capture ->
+        val captureResults = resultCaptures.map { expanded ->
+          val capture = expanded.capture
           val pngFile =
             capture.renderOutput
               .takeIf { it.isNotEmpty() }
@@ -110,6 +112,7 @@ object PreviewResultBuilder {
             sha256 = sha,
             changed = null,
             optional = capture.optional,
+            parameterLabel = expanded.parameterLabel,
           )
         }
         val first = captureResults.firstOrNull()
@@ -164,13 +167,13 @@ object PreviewResultBuilder {
     template: Capture,
     siblingRenderOutputs: Set<String>,
     fileSystem: FileSystem = SystemFileSystem,
-  ): List<Capture> {
+  ): List<ExpandedCapture> {
     val rel =
       template.renderOutput.ifEmpty {
-        return listOf(template)
+        return listOf(ExpandedCapture(template))
       }
     val file = module.projectDir.resolve("build/compose-previews/$rel").canonicalFile
-    val dir = file.parentFile ?: return listOf(template)
+    val dir = file.parentFile ?: return listOf(ExpandedCapture(template))
     val prefix = file.nameWithoutExtension + "_"
     val ext = ".${file.extension}"
     val templateDir = rel.substringBeforeLast('/', "")
@@ -188,11 +191,28 @@ object PreviewResultBuilder {
     // those dimensions. Each fan-out file points back at the same conceptual capture, just at a
     // different provider value.
     return matches.map { f ->
-      Capture(
-        advanceTimeMillis = template.advanceTimeMillis,
-        scroll = template.scroll,
-        renderOutput = dirPrefix + f.name,
+      ExpandedCapture(
+        capture =
+          Capture(
+            advanceTimeMillis = template.advanceTimeMillis,
+            scroll = template.scroll,
+            renderOutput = dirPrefix + f.name,
+          ),
+        parameterLabel = paramFanoutLabel(f.name, prefix, ext),
       )
+    }
+  }
+
+  private data class ExpandedCapture(val capture: Capture, val parameterLabel: String? = null)
+
+  private fun paramFanoutLabel(name: String, prefix: String, ext: String): String? {
+    val suffix = name.removePrefix(prefix).removeSuffix(ext)
+    val parameterIndex =
+      suffix.removePrefix("PARAM_").toIntOrNull()?.takeIf { suffix.startsWith("PARAM_") }
+    return if (parameterIndex != null) {
+      "parameter $parameterIndex"
+    } else {
+      suffix.replace('_', ' ').trim().ifEmpty { null }
     }
   }
 

--- a/api/gradle-preview-driver/src/test/kotlin/ee/schimke/composeai/cli/PreviewResultBuilderTest.kt
+++ b/api/gradle-preview-driver/src/test/kotlin/ee/schimke/composeai/cli/PreviewResultBuilderTest.kt
@@ -133,6 +133,10 @@ class PreviewResultBuilderTest {
       listOf("ParamShow_PARAM_0.png", "ParamShow_PARAM_2.png", "ParamShow_PARAM_10.png"),
       names,
     )
+    assertEquals(
+      listOf("parameter 0", "parameter 2", "parameter 10"),
+      captures.map { it.parameterLabel },
+    )
   }
 
   @Test

--- a/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/cli/PreviewData.kt
+++ b/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/cli/PreviewData.kt
@@ -206,6 +206,8 @@ data class CaptureResult(
    * the skip as expected instead of reporting a render failure.
    */
   val optional: Boolean = false,
+  /** `@PreviewParameter` coordinate that distinguishes this capture from its siblings. */
+  val parameterLabel: String? = null,
 )
 
 /**

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -889,6 +889,7 @@ internal fun previewsMissingPng(results: List<PreviewResult>): List<PreviewResul
  */
 internal fun captureCoordLabel(c: CaptureResult): String =
   listOfNotNull(
+      c.parameterLabel,
       c.advanceTimeMillis?.let { "${it}ms" },
       c.scroll?.let { "scroll ${it.mode.lowercase()}" },
     )

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/MissingRendersPolicyTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/MissingRendersPolicyTest.kt
@@ -158,5 +158,9 @@ class MissingRendersPolicyTest {
         CaptureResult(advanceTimeMillis = 500, scroll = ScrollCapture(mode = "END"))
       ),
     )
+    assertEquals(
+      "parameter 2 · 500ms",
+      captureCoordLabel(CaptureResult(advanceTimeMillis = 500, parameterLabel = "parameter 2")),
+    )
   }
 }


### PR DESCRIPTION
## Summary

- derive a stable human-readable coordinate from each expanded `@PreviewParameter` output (`PARAM_0` → `parameter 0`, named suffixes → readable text)
- carry the coordinate in `CaptureResult` alongside time and scroll dimensions
- include it in CLI diagnostics and baseline-gallery row labels
- add end-to-end README coverage showing parameterized Wear widget rows remain distinct

## Tests

- `./gradlew :preview-data-api:ktfmtCheck :gradle-preview-driver:ktfmtCheck :cli:ktfmtCheck :gradle-preview-driver:test --tests 'ee.schimke.composeai.cli.PreviewResultBuilderTest' :cli:test --tests 'ee.schimke.composeai.cli.MissingRendersPolicyTest'`
- `python3 .github/actions/lib/test_compare_previews.py` (91 tests, 3 skipped)

Fixes #2812