### PR TITLE
fix(figma): Fix Code Connect target inference for preview wrappers

### DIFF
--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewTargetInference.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewTargetInference.kt
@@ -2,9 +2,11 @@ package ee.schimke.composeai.discovery
 
 import io.github.classgraph.ClassInfo
 import io.github.classgraph.MethodInfo
+import io.github.classgraph.Resource
 import io.github.classgraph.ScanResult
 import org.objectweb.asm.ClassReader
 import org.objectweb.asm.ClassVisitor
+import org.objectweb.asm.Handle
 import org.objectweb.asm.MethodVisitor
 import org.objectweb.asm.Opcodes
 
@@ -19,10 +21,9 @@ import org.objectweb.asm.Opcodes
  * forward-compatible with later multi-target inference (e.g. `Row { Foo(); Bar() }` returning
  * both), but the current scoring pass keeps only the top-scored candidate.
  *
- * Wrapper detection is FQN-prefix based. Project-local theme wrappers (e.g. `MyAppTheme { … }`) are
- * intentionally **not** unwrapped here — that needs reading the lambda's synthetic `invoke` class
- * and is reserved for a follow-up. The [TargetSignal.WRAPPER_UNWRAPPED] enum value is declared for
- * that future use.
+ * Project-local theme/preview wrappers are filtered by source/name, and compiler-generated lambda
+ * methods reachable from the preview are traversed so `Theme { Component() }` can still nominate
+ * `Component`.
  */
 object PreviewTargetInference {
 
@@ -112,7 +113,7 @@ object PreviewTargetInference {
     variantName: String,
     hasPreviewParameter: Boolean,
   ): List<PreviewTarget> {
-    val calls =
+    val directCalls =
       try {
         extractCalls(previewClassInfo, previewMethod)
       } catch (_: Throwable) {
@@ -121,6 +122,10 @@ object PreviewTargetInference {
         // to whatever signal they had before.
         return emptyList()
       }
+    val unwrappedCalls =
+      extractComposeSingletonLambdaCalls(directCalls, scanResult, projectClassFqns)
+    val calls = directCalls + unwrappedCalls
+    val unwrappedTargets = unwrappedCalls.mapTo(mutableSetOf()) { it.ownerFqn to it.methodName }
 
     val previewFqn = previewClassInfo.name
     val previewMethodName = previewMethod.name
@@ -133,6 +138,10 @@ object PreviewTargetInference {
         .filterNot { isWrapperFqn(it.ownerFqn) }
         .filter { it.ownerFqn in projectClassFqns }
         .mapNotNull { resolveCandidate(it, scanResult) }
+        .filterNot { candidate ->
+          !isValidKotlinImportIdentifier(candidate.method.name) ||
+            isPreviewOnlyWrapper(candidate.method.name, resolveSourceFile(candidate.ownerFqn))
+        }
         .distinctBy { it.ownerFqn to it.method.name }
         .toList()
 
@@ -160,6 +169,7 @@ object PreviewTargetInference {
               // `@PreviewParameter color: Long → Foo(color)` pattern.
               p.annotationInfo?.none { it.name == COMPOSABLE_FQN } ?: true
             } == true,
+          wrapperUnwrapped = candidate.ownerFqn to candidate.method.name in unwrappedTargets,
           totalSurvivors = survivors,
           resolveSourceFile = resolveSourceFile,
         )
@@ -206,9 +216,23 @@ object PreviewTargetInference {
     previewMethod: MethodInfo,
   ): List<Invocation> {
     val resource = previewClassInfo.resource ?: return emptyList()
-    val targetName = previewMethod.name
-    val targetDescriptor = previewMethod.typeDescriptorStr
-    val collected = mutableListOf<Invocation>()
+    val root = MethodKey(previewMethod.name, previewMethod.typeDescriptorStr)
+    return extractCalls(
+      resource = resource,
+      ownerFqn = previewClassInfo.name,
+      isRoot = { it == root },
+      shouldFollow = { candidate -> candidate.name.startsWith(previewMethod.name + '$') },
+    )
+  }
+
+  private fun extractCalls(
+    resource: Resource,
+    ownerFqn: String,
+    isRoot: (MethodKey) -> Boolean,
+    shouldFollow: (MethodKey) -> Boolean,
+  ): List<Invocation> {
+    val ownerInternal = ownerFqn.replace('.', '/')
+    val bodies = mutableMapOf<MethodKey, MethodBody>()
     resource.open().use { stream ->
       ClassReader(stream)
         .accept(
@@ -220,8 +244,10 @@ object PreviewTargetInference {
               signature: String?,
               exceptions: Array<out String>?,
             ): MethodVisitor? {
-              if (name != targetName) return null
-              if (descriptor != targetDescriptor) return null
+              val key = MethodKey(name, descriptor)
+              val calls = mutableListOf<Invocation>()
+              val nestedMethods = mutableSetOf<MethodKey>()
+              bodies[key] = MethodBody(calls, nestedMethods)
               return object : MethodVisitor(Opcodes.ASM9) {
                 override fun visitMethodInsn(
                   opcode: Int,
@@ -230,7 +256,22 @@ object PreviewTargetInference {
                   descriptor: String,
                   isInterface: Boolean,
                 ) {
-                  collected += Invocation(owner.replace('/', '.'), name, descriptor)
+                  calls += Invocation(owner.replace('/', '.'), name, descriptor)
+                  if (owner == ownerInternal) {
+                    nestedMethods += MethodKey(name, descriptor)
+                  }
+                }
+
+                override fun visitInvokeDynamicInsn(
+                  name: String,
+                  descriptor: String,
+                  bootstrapMethodHandle: Handle,
+                  vararg bootstrapMethodArguments: Any,
+                ) {
+                  bootstrapMethodArguments
+                    .filterIsInstance<Handle>()
+                    .filter { it.owner == ownerInternal }
+                    .forEach { nestedMethods += MethodKey(it.name, it.desc) }
                 }
               }
             }
@@ -238,8 +279,127 @@ object PreviewTargetInference {
           ClassReader.SKIP_DEBUG or ClassReader.SKIP_FRAMES,
         )
     }
+    val collected = mutableListOf<Invocation>()
+    val pending = ArrayDeque<MethodKey>().apply { addAll(bodies.keys.filter(isRoot)) }
+    val visited = mutableSetOf<MethodKey>()
+    while (pending.isNotEmpty()) {
+      val key = pending.removeFirst()
+      if (!visited.add(key)) continue
+      val body = bodies[key] ?: continue
+      collected += body.calls
+      pending.addAll(body.nestedMethods.filter(shouldFollow))
+    }
     return collected
   }
+
+  private data class MethodKey(val name: String, val descriptor: String)
+
+  private data class MethodBody(val calls: List<Invocation>, val nestedMethods: Set<MethodKey>)
+
+  /**
+   * Compose 2.x stores non-capturing composable lambdas in generated
+   * `ComposableSingletons$…$lambda$<key>$…` classes. A preview only calls the matching
+   * `getLambda$<key>$…` getter, so walk that narrowly identified generated class to find the
+   * component rendered inside `Theme { … }` / `Wrap { … }`.
+   */
+  private fun extractComposeSingletonLambdaCalls(
+    directCalls: List<Invocation>,
+    scanResult: ScanResult,
+    projectClassFqns: Set<String>,
+  ): List<Invocation> =
+    directCalls
+      .asSequence()
+      .filter {
+        it.ownerFqn in projectClassFqns &&
+          ".ComposableSingletons$" in it.ownerFqn &&
+          it.methodName.startsWith("getLambda$")
+      }
+      .flatMap { getter ->
+        val lambdaKey = getter.methodName.removePrefix("getLambda$").substringBefore('$')
+        if (lambdaKey.isEmpty()) return@flatMap emptySequence()
+        val lambdaClassPrefix = getter.ownerFqn + "\$lambda\$$lambdaKey\$"
+        val ownerResource = scanResult.getClassInfo(getter.ownerFqn)?.resource
+        if (ownerResource == null) return@flatMap emptySequence()
+        referencedClasses(ownerResource, lambdaClassPrefix)
+          .asSequence()
+          .flatMap { lambdaClassFqn ->
+            scanResult
+              .getResourcesWithPathIgnoringAccept(lambdaClassFqn.replace('.', '/') + ".class")
+              .asSequence()
+              .map { lambdaClassFqn to it }
+          }
+          .filter { it.second.classpathElementURI == ownerResource.classpathElementURI }
+          .flatMap { (lambdaClassFqn, resource) ->
+            try {
+              extractCalls(
+                  resource = resource,
+                  ownerFqn = lambdaClassFqn,
+                  isRoot = { key ->
+                    key.name == "invoke" && "Landroidx/compose/runtime/Composer;" in key.descriptor
+                  },
+                  shouldFollow = { false },
+                )
+                .asSequence()
+            } catch (_: Throwable) {
+              emptySequence()
+            }
+          }
+      }
+      .distinct()
+      .toList()
+
+  private fun referencedClasses(resource: Resource, classFqnPrefix: String): Set<String> {
+    val internalPrefix = classFqnPrefix.replace('.', '/')
+    val referenced = mutableSetOf<String>()
+    resource.open().use { stream ->
+      ClassReader(stream)
+        .accept(
+          object : ClassVisitor(Opcodes.ASM9) {
+            override fun visitMethod(
+              access: Int,
+              name: String,
+              descriptor: String,
+              signature: String?,
+              exceptions: Array<out String>?,
+            ): MethodVisitor =
+              object : MethodVisitor(Opcodes.ASM9) {
+                override fun visitFieldInsn(
+                  opcode: Int,
+                  owner: String,
+                  name: String,
+                  descriptor: String,
+                ) {
+                  if (owner.startsWith(internalPrefix)) {
+                    referenced += owner.replace('/', '.')
+                  }
+                }
+              }
+          },
+          ClassReader.SKIP_DEBUG or ClassReader.SKIP_FRAMES,
+        )
+    }
+    return referenced
+  }
+
+  internal fun isValidKotlinImportIdentifier(name: String): Boolean =
+    KOTLIN_IMPORT_IDENTIFIER.matches(name)
+
+  internal fun isPreviewOnlyWrapper(methodName: String, sourceFile: String?): Boolean {
+    val sourceName = methodName.substringBefore('$')
+    if (
+      sourceName == "Wrap" ||
+        sourceName.endsWith("Theme") ||
+        sourceName.endsWith("PreviewWrapper") ||
+        sourceName.endsWith("PreviewScope")
+    ) {
+      return true
+    }
+    val path = sourceFile?.replace('\\', '/')?.lowercase() ?: return false
+    val isDebugSource = path.startsWith("src/debug/") || "/src/debug/" in path
+    return isDebugSource && (path.startsWith("catalog/") || "/catalog/" in path)
+  }
+
+  private val KOTLIN_IMPORT_IDENTIFIER = Regex("[A-Za-z_][A-Za-z0-9_]*")
 
   private data class ResolvedCandidate(
     val ownerFqn: String,
@@ -284,6 +444,7 @@ object PreviewTargetInference {
     variantName: String,
     hasPreviewParameter: Boolean,
     callerMethodHasComposableParam: Boolean,
+    wrapperUnwrapped: Boolean,
     totalSurvivors: Int,
     resolveSourceFile: (String) -> String?,
   ): ScoredCandidate {
@@ -335,6 +496,10 @@ object PreviewTargetInference {
     if (hasPreviewParameter && callerMethodHasComposableParam) {
       score += 1
       signals += TargetSignal.PARAMETER_FORWARDED
+    }
+
+    if (wrapperUnwrapped) {
+      signals += TargetSignal.WRAPPER_UNWRAPPED
     }
 
     return ScoredCandidate(

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewTargetInferenceTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewTargetInferenceTest.kt
@@ -41,4 +41,33 @@ class PreviewTargetInferenceTest {
   fun `nameMatches rejects bare Preview when nothing left after strip`() {
     assertThat(PreviewTargetInference.nameMatches("Preview", "Anything")).isFalse()
   }
+
+  @Test
+  fun `invalid JVM names are rejected as Kotlin import targets`() {
+    assertThat(PreviewTargetInference.isValidKotlinImportIdentifier("Screen")).isTrue()
+    assertThat(PreviewTargetInference.isValidKotlinImportIdentifier("_Screen2")).isTrue()
+    assertThat(PreviewTargetInference.isValidKotlinImportIdentifier("Screen-G2aJUZY")).isFalse()
+    assertThat(PreviewTargetInference.isValidKotlinImportIdentifier("Screen\$module")).isFalse()
+  }
+
+  @Test
+  fun `preview wrapper names and debug catalog sources are rejected`() {
+    assertThat(PreviewTargetInference.isPreviewOnlyWrapper("Wrap", null)).isTrue()
+    assertThat(PreviewTargetInference.isPreviewOnlyWrapper("JetnewsTheme", null)).isTrue()
+    assertThat(PreviewTargetInference.isPreviewOnlyWrapper("JetsnackPreviewWrapper", null)).isTrue()
+    assertThat(
+        PreviewTargetInference.isPreviewOnlyWrapper(
+          "Component",
+          "src/debug/kotlin/com/example/catalog/Components.kt",
+        )
+      )
+      .isTrue()
+    assertThat(
+        PreviewTargetInference.isPreviewOnlyWrapper(
+          "Component",
+          "src/main/kotlin/com/example/components/Components.kt",
+        )
+      )
+      .isFalse()
+  }
 }

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
@@ -2235,6 +2235,97 @@ class DiscoveryFunctionalTest {
   }
 
   @Test
+  fun `composePreviewDiscover looks through theme and catalog lambdas and rejects mangled targets`() {
+    val projectDir = createCmpTestProject()
+
+    val srcDir = File(projectDir, "src/main/kotlin/test")
+    File(srcDir, "Previews.kt").delete()
+
+    File(srcDir, "Components.kt")
+      .writeText(
+        """
+        package test
+
+        import androidx.compose.material3.Text
+        import androidx.compose.runtime.Composable
+
+        @Composable
+        fun HomeScreen() {
+            Text("home")
+        }
+
+        @JvmInline
+        value class ScreenValue(val value: Int)
+
+        @Composable
+        fun Screen(value: ScreenValue = ScreenValue(0)) {
+            Text("${'$'}{value.value}")
+        }
+        """
+          .trimIndent()
+      )
+
+    File(srcDir, "Previews.kt")
+      .writeText(
+        """
+        package test
+
+        import androidx.compose.runtime.Composable
+        import androidx.compose.ui.tooling.preview.Preview
+
+        @Composable
+        fun DemoTheme(content: @Composable () -> Unit) {
+            content()
+        }
+
+        @Composable
+        fun Wrap(content: @Composable () -> Unit) {
+            content()
+        }
+
+        @Preview
+        @Composable
+        fun ThemePreview() {
+            DemoTheme { HomeScreen() }
+        }
+
+        @Preview
+        @Composable
+        fun WrapPreview() {
+            Wrap { HomeScreen() }
+        }
+
+        @Preview
+        @Composable
+        fun MangledPreview() {
+            Screen()
+        }
+        """
+          .trimIndent()
+      )
+
+    GradleRunner.create()
+      .withProjectDir(projectDir)
+      .withArguments("composePreviewDiscover", "--stacktrace")
+      .withPluginClasspath()
+      .build()
+    val manifest =
+      json.decodeFromString<PreviewManifest>(
+        File(projectDir, "build/compose-previews/previews.json").readText()
+      )
+    val themeTarget =
+      manifest.previews.single { it.functionName == "ThemePreview" }.targets.single()
+    val wrapTarget = manifest.previews.single { it.functionName == "WrapPreview" }.targets.single()
+    assertThat(themeTarget.functionName).isEqualTo("HomeScreen")
+    assertThat(wrapTarget.functionName).isEqualTo("HomeScreen")
+    assertThat(themeTarget.sourceFile).contains("Components.kt")
+    assertThat(wrapTarget.sourceFile).contains("Components.kt")
+    assertThat(themeTarget.signals).contains(TargetSignal.WRAPPER_UNWRAPPED)
+    assertThat(wrapTarget.signals).contains(TargetSignal.WRAPPER_UNWRAPPED)
+    assertThat(manifest.previews.single { it.functionName == "MangledPreview" }.targets).isEmpty()
+  }
+
+  @Test
   fun `composePreviewDiscover emits no target when preview body is purely framework`() {
     // A preview that only calls AndroidX Compose primitives (no project-local composable) gets no
     // target — the inference should not invent one from theming / layout calls.

--- a/scripts/design-artifacts/figma-code-connect-emit.mjs
+++ b/scripts/design-artifacts/figma-code-connect-emit.mjs
@@ -48,8 +48,21 @@ export function resolveSource({ repo, ref, module, sourceFile } = {}) {
  */
 export function importFor(className, componentName) {
   if (!className || !componentName) return null;
-  const pkg = className.split(".").slice(0, -1).join(".");
+  const ownerParts = className.split(".");
+  const packageParts = ownerParts.slice(0, -1);
+  if (
+    !isValidKotlinIdentifier(componentName) ||
+    packageParts.length === 0 ||
+    packageParts.some((part) => !isValidKotlinIdentifier(part))
+  ) {
+    return null;
+  }
+  const pkg = packageParts.join(".");
   return pkg ? `import ${pkg}.${componentName}` : null;
+}
+
+function isValidKotlinIdentifier(value) {
+  return typeof value === "string" && /^[A-Za-z_][A-Za-z0-9_]*$/.test(value);
 }
 
 /**

--- a/scripts/design-artifacts/figma-code-connect-emit.test.mjs
+++ b/scripts/design-artifacts/figma-code-connect-emit.test.mjs
@@ -19,6 +19,8 @@ test("importFor derives the import from the owner-facade FQN", () => {
   assert.equal(importFor("com.x.ui.ButtonsKt", "Button"), "import com.x.ui.Button");
   assert.equal(importFor("Button", "Button"), null); // no package
   assert.equal(importFor(undefined, "Button"), null);
+  assert.equal(importFor("com.x.ScreenKt", "Screen-G2aJUZY"), null);
+  assert.equal(importFor("com.bad-package.ScreenKt", "Screen"), null);
 });
 
 test("renderCallSite renders only required params, slots as lambdas", () => {

--- a/scripts/design-artifacts/figma-code-connect-target.mjs
+++ b/scripts/design-artifacts/figma-code-connect-target.mjs
@@ -21,7 +21,7 @@
  */
 export function bestTarget(targets) {
   const t = Array.isArray(targets) ? targets[0] : undefined;
-  if (!t || !t.functionName) return null;
+  if (!t || !isValidKotlinIdentifier(t.functionName)) return null;
   return {
     functionName: t.functionName,
     className: t.className ?? undefined,
@@ -32,6 +32,11 @@ export function bestTarget(targets) {
     // signature couldn't be read.
     parameters: Array.isArray(t.parameters) ? t.parameters : [],
   };
+}
+
+/** Conservative source-level Kotlin identifier check for generated call sites/imports. */
+export function isValidKotlinIdentifier(value) {
+  return typeof value === "string" && /^[A-Za-z_][A-Za-z0-9_]*$/.test(value);
 }
 
 /** Parse the raw `previews.json` entry (a `{ previews: [...] }` manifest or a bare array). */

--- a/scripts/design-artifacts/figma-code-connect-target.test.mjs
+++ b/scripts/design-artifacts/figma-code-connect-target.test.mjs
@@ -8,7 +8,11 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import { bestTarget, targetsByFunction } from "./figma-code-connect-target.mjs";
+import {
+  bestTarget,
+  isValidKotlinIdentifier,
+  targetsByFunction,
+} from "./figma-code-connect-target.mjs";
 
 test("bestTarget takes the first (most-confident) entry, or null when none", () => {
   assert.deepEqual(
@@ -36,6 +40,12 @@ test("bestTarget takes the first (most-confident) entry, or null when none", () 
   assert.equal(bestTarget([{ sourceFile: "a.kt" }]), null);
   // A target with no parameters carried yields an empty array (never undefined).
   assert.deepEqual(bestTarget([{ functionName: "X" }]).parameters, []);
+});
+
+test("bestTarget rejects JVM-mangled names that cannot appear in Kotlin source", () => {
+  assert.equal(bestTarget([{ functionName: "Screen-G2aJUZY", confidence: "HIGH" }]), null);
+  assert.equal(isValidKotlinIdentifier("Screen"), true);
+  assert.equal(isValidKotlinIdentifier("Screen-G2aJUZY"), false);
 });
 
 test("targetsByFunction reads parsed preview.targets, preferring the light variant", () => {


### PR DESCRIPTION
## Summary

- look through Compose-generated singleton lambdas so `Theme { Component() }` and `Wrap { Component() }` infer the nested production composable
- reject common preview-only wrappers and debug catalog helpers as automatic production targets
- reject JVM-mangled target names and validate generated Kotlin import identifiers before emitting Code Connect mappings
- report `WRAPPER_UNWRAPPED` when inference traverses a wrapper

## Root cause

The Compose compiler hoists non-capturing composable lambdas into package-private `ComposableSingletons$…$lambda$…` classes. Discovery inspected only the preview facade method, so it saw the outer theme or `Wrap` call but not the component inside the generated lambda. It also trusted JVM method names directly, allowing value-class/default-parameter mangled names containing `-` to become invalid Kotlin imports.

The lambda traversal is bounded to the exact getter key referenced by the preview and to the same project classpath element, avoiding unrelated generated lambdas or dependency classes.

## Validation

- `node --test scripts/design-artifacts/figma-code-connect-target.test.mjs scripts/design-artifacts/figma-code-connect-emit.test.mjs`
- `./gradlew :gradle-plugin:preview-discovery:test --tests 'ee.schimke.composeai.discovery.PreviewTargetInferenceTest'`
- `./gradlew :gradle-plugin:functionalTest --tests 'ee.schimke.composeai.plugin.DiscoveryFunctionalTest.composePreviewDiscover looks through theme and catalog lambdas and rejects mangled targets'`

Fixes #2840