### PR TITLE
feat(wear)!: migrate gesture indicators to alpha06

### DIFF
--- a/data/gestures/connector/build.gradle.kts
+++ b/data/gestures/connector/build.gradle.kts
@@ -59,18 +59,14 @@ dependencies {
   // `androidx.wear.compose.material3.onehandedgesture.*` — the real one-handed-gesture API the
   // reporting seam wraps (`oneHandedGesture`, `OneHandedGestureIndicator`, `GestureAction`,
   // `LocalOneHandedGestureEnabled`) plus `LocalContentColor`. `compileOnly` because consumers
-  // (e.g. `:samples:wear`) already pull wear-compose-material3 at runtime; the connector's public
-  // surface (extension / registry) exposes no wear types, so `:daemon:android` links without it.
+  // using the public reporting/indicator helpers are Wear apps that already pull
+  // wear-compose-material3 at runtime; `:daemon:android` can still link the connector without
+  // transitively publishing the alpha Wear stack.
   compileOnly(libs.wear.compose.material3)
   testImplementation(libs.wear.compose.material3)
 
-  // `androidx.compose.animation.graphics` — `GestureHint`'s force-show path draws
-  // wear-compose-material3's shipped gesture-indicator AVD via the official
-  // `AnimatedImageVector.animatedVectorResource` API (the real `OneHandedGestureIndicator` settles
-  // to hidden during a Robolectric pre-roll, so a forced preview draws the drawable directly).
-  // `compileOnly` because wear-compose-material3 already pulls it transitively onto every
-  // consumer's
-  // runtime classpath; the Compose BOM pins the unversioned coordinate.
+  // The forced still-capture path renders wear-compose-material3's shipped indicator AVD at its
+  // peak frame. The real alpha06 state-backed indicator completes during Robolectric idle pre-roll.
   compileOnly(platform(libs.compose.bom.stable))
   compileOnly("androidx.compose.animation:animation-graphics")
   testImplementation(platform(libs.compose.bom.stable))

--- a/data/gestures/connector/src/main/kotlin/ee/schimke/composeai/daemon/GestureIndicatorIcon.kt
+++ b/data/gestures/connector/src/main/kotlin/ee/schimke/composeai/daemon/GestureIndicatorIcon.kt
@@ -13,29 +13,27 @@ import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.wear.compose.material3.LocalContentColor
+import androidx.wear.compose.material3.onehandedgesture.GestureAction
 
 /**
- * Renders wear-compose-material3's shipped gesture-indicator AVD
- * (`wear_one_handed_gesture_{primary,dismiss}_indicator_animation`) as a static, tinted icon via the
- * official `androidx.compose.animation.graphics` API — the same drawable the real
- * `OneHandedGestureIndicator` draws internally, shown at its resting frame.
+ * Renders wear-compose-material3's shipped gesture-indicator AVD as a static, tinted peak frame.
  *
- * [GestureHint] overlays this on its force-show path: the interactive indicator's show/hide
- * coroutine settles to hidden during a Robolectric render's pre-roll, so a forced preview draws the
- * drawable directly to make the hint visible in a single captured frame. `SCROLL` / `PAGE` ride the
- * primary indicator, matching the framework.
+ * Alpha06's explicit indicator state triggers a finite animation and is reset by the real
+ * indicator. Robolectric completes that animation during idle pre-roll, so [GestureHint] uses this
+ * replica only for a forced still capture. Normal on-device rendering uses the real state-backed
+ * indicator.
  */
 @OptIn(ExperimentalAnimationGraphicsApi::class)
 @Composable
 fun GestureIndicatorIcon(
-  type: GestureType,
+  action: GestureAction,
   modifier: Modifier = Modifier,
   size: Dp = 40.dp,
   tint: Color = LocalContentColor.current,
 ) {
   val resId =
-    when (type) {
-      GestureType.DISMISS ->
+    when (action) {
+      GestureAction.Dismiss ->
         androidx.wear.compose.material3.R.drawable
           .wear_one_handed_gesture_dismiss_indicator_animation
       else ->

--- a/data/gestures/connector/src/main/kotlin/ee/schimke/composeai/daemon/GestureReporting.kt
+++ b/data/gestures/connector/src/main/kotlin/ee/schimke/composeai/daemon/GestureReporting.kt
@@ -1,15 +1,11 @@
 package ee.schimke.composeai.daemon
 
-import androidx.compose.foundation.interaction.Interaction
-import androidx.compose.foundation.interaction.InteractionSource
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.staticCompositionLocalOf
@@ -20,14 +16,12 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.wear.compose.material3.LocalContentColor
 import androidx.wear.compose.material3.onehandedgesture.GestureAction
 import androidx.wear.compose.material3.onehandedgesture.GestureIndicatorSize
-import androidx.wear.compose.material3.onehandedgesture.GesturePriority
 import androidx.wear.compose.material3.onehandedgesture.LocalOneHandedGestureEnabled
+import androidx.wear.compose.material3.onehandedgesture.OneHandedGestureConfiguration
 import androidx.wear.compose.material3.onehandedgesture.OneHandedGestureIndicator
-import androidx.wear.compose.material3.onehandedgesture.OneHandedGestureInteraction
+import androidx.wear.compose.material3.onehandedgesture.OneHandedGestureIndicatorState
 import androidx.wear.compose.material3.onehandedgesture.oneHandedGesture
 import ee.schimke.composeai.daemon.protocol.GestureKindOverride
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.launch
 
 /**
@@ -43,7 +37,7 @@ enum class GestureType(val wire: GestureKindOverride) {
   SCROLL(GestureKindOverride.SCROLL),
   PAGE(GestureKindOverride.PAGE);
 
-  internal fun toGestureAction(): GestureAction =
+  fun toGestureAction(): GestureAction =
     when (this) {
       PRIMARY,
       SCROLL,
@@ -73,10 +67,14 @@ val LocalGestureRegistry: ProvidableCompositionLocal<GestureStateController> =
  * framework's internal, Pixel-Watch-only registry exposes.
  *
  * @param type gesture kind (drives the framework [GestureAction] and the reported wire kind).
- * @param label accessibility / hint label, forwarded to `oneHandedGesture(gestureLabel = …)` and
+ * @param label accessibility / hint label, forwarded to `oneHandedGesture(onGestureLabel = …)` and
  *   used as the handler's identity in the data product.
- * @param interactionSource shared with the matching [GestureHint] so the real indicator can
- *   visualise the gesture.
+ * @param gestureConfiguration persistent action/key/priority specification shared with the matching
+ *   [GestureHint].
+ * @param indicatorState explicit indicator state shared with the matching [GestureHint], or `null`
+ *   when this handler has no indicator.
+ * @param interactionSource forwarded to the framework so gesture activation produces the same
+ *   pressed/ripple feedback as a touch interaction.
  * @param hintAvailable whether a [GestureHint] is wired for this handler (reported, not enforced).
  * @param onGesture the action to run when the gesture fires (on-device) or is invoked (data product).
  */
@@ -84,8 +82,9 @@ val LocalGestureRegistry: ProvidableCompositionLocal<GestureStateController> =
 fun Modifier.reportedOneHandedGesture(
   type: GestureType,
   label: String,
+  gestureConfiguration: OneHandedGestureConfiguration,
+  indicatorState: OneHandedGestureIndicatorState? = null,
   interactionSource: MutableInteractionSource,
-  priority: GesturePriority = GesturePriority.Clickable,
   enabledInAmbient: Boolean = false,
   hintAvailable: Boolean = true,
   onGesture: suspend () -> Unit,
@@ -104,11 +103,11 @@ fun Modifier.reportedOneHandedGesture(
     onDispose { controller.unregister(type.wire, label) }
   }
   return this.oneHandedGesture(
-    action = type.toGestureAction(),
-    priority = priority,
+    gestureConfiguration = gestureConfiguration,
     enabledInAmbient = enabledInAmbient,
     interactionSource = interactionSource,
-    gestureLabel = label,
+    onGestureLabel = label,
+    onGestureAvailable = { indicatorState?.isIndicatorActive = true },
     onGesture = onGesture,
   )
 }
@@ -116,74 +115,41 @@ fun Modifier.reportedOneHandedGesture(
 /**
  * Wraps [content] with the real Wear [OneHandedGestureIndicator] hint affordance.
  *
- * On-device the hint shows when the gesture emits an `Indicate` interaction on [interactionSource]:
- * the real [OneHandedGestureIndicator] **fades [content] out and swaps in** the gesture animation in
- * its place (it is not an overlay — the content underneath is hidden), then fades the content back.
- *
- * In a preview [forceShow] is set, or the daemon applied `overrides.gestures.showHints = true` (the
- * seam `@GestureHintPreview` drives). On that force path the real indicator's show/hide coroutine
- * settles back to hidden during a Robolectric render's pre-roll, so a still capture never catches it
- * — instead we render the indicator's **peak frame directly**: [content] faded out and the shipped
- * indicator drawable ([GestureIndicatorIcon]) centred in its place, matching what the device shows
- * mid-gesture. On-device (no override, [forceShow] `false`) this path is not taken and the real
- * indicator behaves exactly as before.
+ * The matching [reportedOneHandedGesture] sets [indicatorState] active when the framework reports
+ * the gesture as available. In a forced still preview, [forceShow] or the daemon's
+ * `overrides.gestures.showHints = true` renders the indicator's peak frame directly because the real
+ * finite animation completes during Robolectric idle pre-roll.
  */
 @Composable
 fun GestureHint(
-  type: GestureType,
-  interactionSource: InteractionSource,
+  gestureConfiguration: OneHandedGestureConfiguration,
+  indicatorState: OneHandedGestureIndicatorState,
   modifier: Modifier = Modifier,
   forceShow: Boolean = false,
   gestureIndicatorSize: GestureIndicatorSize = GestureIndicatorSize.Medium,
   gestureIndicatorTint: Color = LocalContentColor.current,
-  content: @Composable BoxScope.() -> Unit,
+  content: @Composable () -> Unit,
 ) {
   val hintsRequested by LocalGestureRegistry.current.hintsShownState
   val forced = forceShow || hintsRequested
   if (forced) {
-    // Peak-frame replica of the real indicator's swap: content hidden (alpha 0, still measured so
-    // the layout keeps its size), gesture icon centred where the content was.
+    // The real indicator resets its finite animation before an idle still capture. Preserve the
+    // peak frame deterministically while still measuring the original content.
     Box(modifier = modifier, contentAlignment = Alignment.Center) {
-      Box(modifier = Modifier.graphicsLayer { alpha = 0f }, content = content)
-      // `GestureIndicatorSize.size` is library-internal, so use the icon's own default (≈ the
-      // Medium indicator). Callers that need a specific size tint/scale via the icon directly.
-      GestureIndicatorIcon(type = type, tint = gestureIndicatorTint)
+      Box(modifier = Modifier.graphicsLayer { alpha = 0f }) { content() }
+      GestureIndicatorIcon(
+        action = gestureConfiguration.action,
+        tint = gestureIndicatorTint,
+      )
     }
-  } else {
-    OneHandedGestureIndicator(
-      interactionSource = interactionSource,
-      modifier = modifier,
-      gestureIndicatorSize = gestureIndicatorSize,
-      gestureIndicatorTint = gestureIndicatorTint,
-      content = content,
-    )
+    return
   }
+  OneHandedGestureIndicator(
+    gestureConfiguration = gestureConfiguration,
+    indicatorState = indicatorState,
+    modifier = modifier,
+    gestureIndicatorSize = gestureIndicatorSize,
+    gestureIndicatorTint = gestureIndicatorTint,
+    content = content,
+  )
 }
-
-/**
- * A [MutableInteractionSource] whose stream replays a single `Indicate` for [type], so a late
- * subscriber (a Wear gesture indicator collecting after composition settles) always observes it and
- * shows the hint deterministically in a single captured frame.
- *
- * [GestureHint] uses it on its force-show paths; the scroll / page indicators
- * (`OneHandedGestureScrollIndicator`, `OneHandedGestureHorizontalPageIndicator`) don't go through
- * [GestureHint], so a preview that wants their hint force-shown feeds them this source directly.
- */
-@Composable
-fun rememberForcedGestureHintSource(type: GestureType): MutableInteractionSource =
-  remember(type) {
-    object : MutableInteractionSource {
-      private val shared =
-        MutableSharedFlow<Interaction>(replay = 1, extraBufferCapacity = 16).apply {
-          tryEmit(OneHandedGestureInteraction.Indicate(type.toGestureAction(), key = "forced"))
-        }
-
-      override val interactions: Flow<Interaction> = shared
-
-      override suspend fun emit(interaction: Interaction) {
-        shared.emit(interaction)
-      }
-
-      override fun tryEmit(interaction: Interaction): Boolean = shared.tryEmit(interaction)
-    }
-  }

--- a/data/gestures/connector/src/main/kotlin/ee/schimke/composeai/daemon/ShadowSdkGestureInputManager.kt
+++ b/data/gestures/connector/src/main/kotlin/ee/schimke/composeai/daemon/ShadowSdkGestureInputManager.kt
@@ -17,10 +17,10 @@ import org.robolectric.annotation.Implements
  *
  * - [isAvailable] returns [GestureStateController.detectionArmed] (armed by [GestureOverrideExtension]
  *   while a gesture override is applied). When armed, `GestureRegistry.invalidate()` proceeds: it
- *   subscribes to gesture actions and, after the framework's 1s indicator delay, emits
- *   `OneHandedGestureInteraction.Indicate` on the app's own interaction source — so the app's own
- *   `OneHandedGestureIndicator` shows and animates without any reporting seam. (A captured frame must
- *   advance past that delay; the daemon does so via `advanceTimeMillis`.)
+ *   subscribes to gesture actions and, after the framework's indicator delay, invokes the
+ *   registered `onGestureAvailable` callback. The app uses that callback to activate its
+ *   `OneHandedGestureIndicatorState`, so its own indicator shows without any reporting seam. (A
+ *   captured frame must advance past that delay; the daemon does so via `advanceTimeMillis`.)
  * - [subscribeToSdkGestureAction] records the detected action + captures the framework's `onGesture`
  *   callback into [GestureStateController], so the gesture is **surfaced** in `compose/gestures` and
  *   an `overrides.gestures.invoke` can **fire** the real handler.

--- a/data/gestures/core/src/main/kotlin/ee/schimke/composeai/data/gestures/GestureModels.kt
+++ b/data/gestures/core/src/main/kotlin/ee/schimke/composeai/data/gestures/GestureModels.kt
@@ -60,7 +60,7 @@ data class RegisteredGesture(
    * Lower-case wire spelling of the handler kind — `"primary"`, `"dismiss"`, `"scroll"`, `"page"`.
    */
   val type: String,
-  /** Accessibility / hint label supplied to `Modifier.oneHandedGesture(gestureLabel = …)`. */
+  /** Accessibility / hint label supplied to `Modifier.oneHandedGesture(onGestureLabel = …)`. */
   val label: String,
   /** Whether a gesture hint (`OneHandedGestureIndicator`) is wired for this handler. */
   val hintAvailable: Boolean,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -89,14 +89,7 @@ navigation-compose = "2.9.8"
 # 1.1.x is the current stable line; bump when the Glance team ships a 1.2.x with the planned
 # preview-DSL stabilisation.
 glance-appwidget = "1.2.0-rc01"
-# Held at alpha05: alpha06 redesigned `androidx.wear.compose.material3.onehandedgesture`.
-# `OneHandedGestureInteraction` is gone, and both `Modifier.oneHandedGesture` and
-# `OneHandedGestureIndicator` now take an `OneHandedGestureConfiguration` (action + key + priority)
-# plus an explicit `OneHandedGestureIndicatorState` instead of an interaction source — which
-# `:data-gestures-connector` (`GestureReporting`) and the Wear gesture-hint previews are built on.
-# Migrating that seam changes rendered output, so it lands as its own PR with visual evidence;
-# bump this back to the alpha line then.
-wear-compose = "1.7.0-alpha05"
+wear-compose = "1.7.0-alpha06"
 wear-tiles = "1.6.1"
 wear-protolayout = "1.4.1"
 wear-tooling-preview = "1.0.0"

--- a/samples/wear/build.gradle.kts
+++ b/samples/wear/build.gradle.kts
@@ -58,9 +58,9 @@ dependencies {
   // `:data-gestures-connector` — the Wear OS one-handed-gesture data extension. `Gestures.kt`
   // wires its screens with the connector's `reportedOneHandedGesture` / `GestureHint` seam so the
   // handlers show up in `compose/gestures` and are drivable via `renderNow.overrides.gestures`.
-  // Static `@Preview` rendering doesn't run the daemon extension chain, so previews pass
-  // `forceHint = true` (or `rememberForcedGestureHintSource`) to render the hint affordance; the
-  // daemon path force-shows it from `overrides.gestures.showHints`.
+  // Static `@Preview` rendering doesn't run the daemon extension chain, so previews activate an
+  // explicit `OneHandedGestureIndicatorState`; the daemon path activates the same state from
+  // `overrides.gestures.showHints`.
   implementation(project(":data-gestures-connector"))
 
   // `:data-ambient-connector` — the Wear OS ambient-mode data extension. The

--- a/samples/wear/src/main/kotlin/com/example/samplewear/GestureHintPreviews.kt
+++ b/samples/wear/src/main/kotlin/com/example/samplewear/GestureHintPreviews.kt
@@ -43,6 +43,12 @@ fun MediaGestureScreen(onDismiss: () -> Unit = {}) {
   var playing by remember { mutableStateOf(false) }
   val playSource = remember { MutableInteractionSource() }
   val backSource = remember { MutableInteractionSource() }
+  val playConfiguration =
+    rememberGestureConfiguration(GestureType.PRIMARY, key = "samplewear:media-play")
+  val playIndicatorState = rememberGestureIndicatorState()
+  val backConfiguration =
+    rememberGestureConfiguration(GestureType.DISMISS, key = "samplewear:media-back")
+  val backIndicatorState = rememberGestureIndicatorState()
   ScreenScaffold {
     Column(
       modifier = Modifier.fillMaxSize().padding(horizontal = 24.dp),
@@ -57,12 +63,17 @@ fun MediaGestureScreen(onDismiss: () -> Unit = {}) {
           Modifier.reportedOneHandedGesture(
             type = GestureType.PRIMARY,
             label = if (playing) "Pause" else "Play",
+            gestureConfiguration = playConfiguration,
+            indicatorState = playIndicatorState,
             interactionSource = playSource,
           ) {
             playing = !playing
           },
       ) {
-        GestureHint(type = GestureType.PRIMARY, interactionSource = playSource) {
+        GestureHint(
+          gestureConfiguration = playConfiguration,
+          indicatorState = playIndicatorState,
+        ) {
           Text(if (playing) "Pause" else "Play")
         }
       }
@@ -74,12 +85,19 @@ fun MediaGestureScreen(onDismiss: () -> Unit = {}) {
           Modifier.reportedOneHandedGesture(
             type = GestureType.DISMISS,
             label = "Back",
+            gestureConfiguration = backConfiguration,
+            indicatorState = backIndicatorState,
             interactionSource = backSource,
           ) {
             onDismiss()
           },
       ) {
-        GestureHint(type = GestureType.DISMISS, interactionSource = backSource) { Text("Back") }
+        GestureHint(
+          gestureConfiguration = backConfiguration,
+          indicatorState = backIndicatorState,
+        ) {
+          Text("Back")
+        }
       }
     }
   }

--- a/samples/wear/src/main/kotlin/com/example/samplewear/Gestures.kt
+++ b/samples/wear/src/main/kotlin/com/example/samplewear/Gestures.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -54,16 +55,19 @@ import androidx.wear.compose.material3.Text
 import androidx.wear.compose.material3.TimeText
 import androidx.wear.compose.material3.TitleCard
 import androidx.wear.compose.material3.onehandedgesture.LocalOneHandedGestureEnabled
+import androidx.wear.compose.material3.onehandedgesture.GesturePriority
 import androidx.wear.compose.material3.onehandedgesture.OneHandedGestureDefaults
+import androidx.wear.compose.material3.onehandedgesture.OneHandedGestureConfiguration
 import androidx.wear.compose.material3.onehandedgesture.OneHandedGestureHorizontalPageIndicator
+import androidx.wear.compose.material3.onehandedgesture.OneHandedGestureIndicatorState
 import androidx.wear.compose.material3.onehandedgesture.OneHandedGestureScrollIndicator
+import androidx.wear.compose.material3.onehandedgesture.rememberOneHandedGestureConfiguration
 import androidx.wear.compose.navigation.SwipeDismissableNavHost
 import androidx.wear.compose.navigation.composable
 import androidx.wear.compose.navigation.rememberSwipeDismissableNavController
 import androidx.wear.compose.ui.tooling.preview.WearPreviewLargeRound
 import ee.schimke.composeai.daemon.GestureHint
 import ee.schimke.composeai.daemon.GestureType
-import ee.schimke.composeai.daemon.rememberForcedGestureHintSource
 import ee.schimke.composeai.daemon.reportedOneHandedGesture
 import kotlinx.coroutines.launch
 
@@ -91,6 +95,31 @@ object GestureRoutes {
   const val DISABLED = "disabled"
   const val HINT_BUTTON = "hint-button"
   const val HINT_FLOATING = "hint-floating"
+}
+
+@Composable
+internal fun rememberGestureConfiguration(
+  type: GestureType,
+  key: String,
+  priority: GesturePriority = GesturePriority.Clickable,
+): OneHandedGestureConfiguration =
+  rememberOneHandedGestureConfiguration(
+    action = type.toGestureAction(),
+    key = key,
+    priority = priority,
+  )
+
+@Composable
+internal fun rememberGestureIndicatorState(
+  forceShow: Boolean = false
+): OneHandedGestureIndicatorState {
+  val state = remember { OneHandedGestureIndicatorState() }
+  LaunchedEffect(forceShow, state) {
+    if (forceShow) {
+      state.isIndicatorActive = true
+    }
+  }
+  return state
 }
 
 @Composable
@@ -256,9 +285,12 @@ private fun GestureDemoScreen(
 private fun PlayGestureButton(forceHint: Boolean) {
   var playing by remember { mutableStateOf(false) }
   val interactionSource = remember { MutableInteractionSource() }
+  val gestureConfiguration =
+    rememberGestureConfiguration(GestureType.PRIMARY, key = "samplewear:play")
+  val indicatorState = rememberGestureIndicatorState()
   GestureHint(
-    type = GestureType.PRIMARY,
-    interactionSource = interactionSource,
+    gestureConfiguration = gestureConfiguration,
+    indicatorState = indicatorState,
     forceShow = forceHint,
   ) {
     Button(
@@ -268,6 +300,8 @@ private fun PlayGestureButton(forceHint: Boolean) {
         Modifier.reportedOneHandedGesture(
           type = GestureType.PRIMARY,
           label = if (playing) "Pause" else "Play",
+          gestureConfiguration = gestureConfiguration,
+          indicatorState = indicatorState,
           interactionSource = interactionSource,
         ) {
           playing = !playing
@@ -294,14 +328,17 @@ fun PrimaryActionScreen(forceHint: Boolean = false) {
 @Composable
 fun DismissActionScreen(onDismiss: () -> Unit = {}, forceHint: Boolean = false) {
   val interactionSource = remember { MutableInteractionSource() }
+  val gestureConfiguration =
+    rememberGestureConfiguration(GestureType.DISMISS, key = "samplewear:dismiss")
+  val indicatorState = rememberGestureIndicatorState()
   GestureDemoScreen(
     title = "Dismiss",
     instruction = "Wrist-turn to go back",
     gestureType = GestureType.DISMISS,
   ) {
     GestureHint(
-      type = GestureType.DISMISS,
-      interactionSource = interactionSource,
+      gestureConfiguration = gestureConfiguration,
+      indicatorState = indicatorState,
       forceShow = forceHint,
     ) {
       FilledTonalButton(
@@ -311,6 +348,8 @@ fun DismissActionScreen(onDismiss: () -> Unit = {}, forceHint: Boolean = false) 
           Modifier.reportedOneHandedGesture(
             type = GestureType.DISMISS,
             label = "Dismiss",
+            gestureConfiguration = gestureConfiguration,
+            indicatorState = indicatorState,
             interactionSource = interactionSource,
           ) {
             onDismiss()
@@ -327,8 +366,9 @@ fun DismissActionScreen(onDismiss: () -> Unit = {}, forceHint: Boolean = false) 
 fun ScrollGestureScreen(forceHint: Boolean = false) {
   val listState = rememberTransformingLazyColumnState()
   val interactionSource = remember { MutableInteractionSource() }
-  val hintSource =
-    if (forceHint) rememberForcedGestureHintSource(GestureType.SCROLL) else interactionSource
+  val gestureConfiguration =
+    rememberGestureConfiguration(GestureType.SCROLL, key = "samplewear:scroll")
+  val indicatorState = rememberGestureIndicatorState(forceHint)
   ScreenScaffold(scrollState = listState) { contentPadding ->
     Box(modifier = Modifier.fillMaxSize()) {
       TransformingLazyColumn(
@@ -339,6 +379,8 @@ fun ScrollGestureScreen(forceHint: Boolean = false) {
             .reportedOneHandedGesture(
               type = GestureType.SCROLL,
               label = "Scroll down",
+              gestureConfiguration = gestureConfiguration,
+              indicatorState = indicatorState,
               interactionSource = interactionSource,
             ) {
               OneHandedGestureDefaults.scrollDown(listState)
@@ -355,8 +397,9 @@ fun ScrollGestureScreen(forceHint: Boolean = false) {
         }
       }
       OneHandedGestureScrollIndicator(
-        interactionSource = hintSource,
-        state = listState,
+        gestureConfiguration = gestureConfiguration,
+        indicatorState = indicatorState,
+        scrollState = listState,
         modifier = Modifier.align(Alignment.CenterEnd),
       )
     }
@@ -368,8 +411,9 @@ fun ScrollGestureScreen(forceHint: Boolean = false) {
 fun PageGestureScreen(forceHint: Boolean = false) {
   val pagerState = rememberPagerState(initialPage = 0, pageCount = { 4 })
   val interactionSource = remember { MutableInteractionSource() }
-  val hintSource =
-    if (forceHint) rememberForcedGestureHintSource(GestureType.PAGE) else interactionSource
+  val gestureConfiguration =
+    rememberGestureConfiguration(GestureType.PAGE, key = "samplewear:page")
+  val indicatorState = rememberGestureIndicatorState(forceHint)
   ScreenScaffold {
     Box(modifier = Modifier.fillMaxSize()) {
       HorizontalPager(
@@ -379,6 +423,8 @@ fun PageGestureScreen(forceHint: Boolean = false) {
             .reportedOneHandedGesture(
               type = GestureType.PAGE,
               label = "Next page",
+              gestureConfiguration = gestureConfiguration,
+              indicatorState = indicatorState,
               interactionSource = interactionSource,
             ) {
               OneHandedGestureDefaults.scrollToNextPage(pagerState)
@@ -397,7 +443,8 @@ fun PageGestureScreen(forceHint: Boolean = false) {
         }
       }
       OneHandedGestureHorizontalPageIndicator(
-        interactionSource = hintSource,
+        gestureConfiguration = gestureConfiguration,
+        indicatorState = indicatorState,
         pagerState = pagerState,
         modifier = Modifier.align(Alignment.BottomCenter),
       )
@@ -409,6 +456,8 @@ fun PageGestureScreen(forceHint: Boolean = false) {
 @Composable
 fun DisabledGestureScreen() {
   val interactionSource = remember { MutableInteractionSource() }
+  val gestureConfiguration =
+    rememberGestureConfiguration(GestureType.PRIMARY, key = "samplewear:disabled-play")
   CompositionLocalProvider(LocalOneHandedGestureEnabled provides false) {
     GestureDemoScreen(title = "Disabled", instruction = "Gestures off on this screen") {
       Button(
@@ -417,6 +466,7 @@ fun DisabledGestureScreen() {
           Modifier.reportedOneHandedGesture(
             type = GestureType.PRIMARY,
             label = "Play (disabled)",
+            gestureConfiguration = gestureConfiguration,
             interactionSource = interactionSource,
           ) {},
       ) {
@@ -435,6 +485,8 @@ fun DisabledGestureScreen() {
 @Composable
 fun ButtonHintScreen(showHint: Boolean = true) {
   val interactionSource = remember { MutableInteractionSource() }
+  val gestureConfiguration =
+    rememberGestureConfiguration(GestureType.PRIMARY, key = "samplewear:button-hint")
   GestureDemoScreen(title = "Button hint", instruction = "Icon drawn on the button") {
     Box(contentAlignment = Alignment.Center) {
       Button(
@@ -444,6 +496,7 @@ fun ButtonHintScreen(showHint: Boolean = true) {
           Modifier.reportedOneHandedGesture(
             type = GestureType.PRIMARY,
             label = "Play",
+            gestureConfiguration = gestureConfiguration,
             interactionSource = interactionSource,
           ) {},
       ) {
@@ -467,6 +520,8 @@ fun ButtonHintScreen(showHint: Boolean = true) {
 @Composable
 fun FloatingHintScreen(showHint: Boolean = true) {
   val interactionSource = remember { MutableInteractionSource() }
+  val gestureConfiguration =
+    rememberGestureConfiguration(GestureType.PRIMARY, key = "samplewear:floating-hint")
   GestureDemoScreen(title = "Floating hint", instruction = "Bubble points to the button") {
     Column(horizontalAlignment = Alignment.CenterHorizontally) {
       if (showHint) {
@@ -480,6 +535,7 @@ fun FloatingHintScreen(showHint: Boolean = true) {
           Modifier.reportedOneHandedGesture(
             type = GestureType.PRIMARY,
             label = "Play",
+            gestureConfiguration = gestureConfiguration,
             interactionSource = interactionSource,
           ) {},
       ) {
@@ -541,9 +597,12 @@ fun PrimaryActionStickerPreview() {
 fun ScrollIndicatorStickerPreview() {
   GestureSticker {
     val listState = rememberTransformingLazyColumnState()
+    val gestureConfiguration =
+      rememberGestureConfiguration(GestureType.SCROLL, key = "samplewear:scroll-sticker")
     OneHandedGestureScrollIndicator(
-      interactionSource = rememberForcedGestureHintSource(GestureType.SCROLL),
-      state = listState,
+      gestureConfiguration = gestureConfiguration,
+      indicatorState = rememberGestureIndicatorState(forceShow = true),
+      scrollState = listState,
       modifier = Modifier.size(48.dp),
     )
   }
@@ -553,8 +612,11 @@ fun ScrollIndicatorStickerPreview() {
 @Composable
 fun PageIndicatorStickerPreview() {
   GestureSticker {
+    val gestureConfiguration =
+      rememberGestureConfiguration(GestureType.PAGE, key = "samplewear:page-sticker")
     OneHandedGestureHorizontalPageIndicator(
-      interactionSource = rememberForcedGestureHintSource(GestureType.PAGE),
+      gestureConfiguration = gestureConfiguration,
+      indicatorState = rememberGestureIndicatorState(forceShow = true),
       pagerState = rememberPagerState(initialPage = 1, pageCount = { 4 }),
     )
   }

--- a/samples/wear/src/test/kotlin/com/example/samplewear/GestureHintPreviewPixelTest.kt
+++ b/samples/wear/src/test/kotlin/com/example/samplewear/GestureHintPreviewPixelTest.kt
@@ -16,8 +16,7 @@ import org.junit.Test
  * - discovery dropped the annotation from `previews.json` (the `gestureHint` capture arrives null), or
  * - the renderer didn't wrap the composition with `:data-gestures-connector`'s
  *   `GestureOverrideExtension`, or
- * - `GestureHint`'s force-show path stopped compositing the indicator drawable (the interactive
- *   `OneHandedGestureIndicator` alone settles to hidden in a still, so both would render plain).
+ * - `GestureHint`'s forced-still peak-frame path stopped drawing the configured gesture action.
  */
 class GestureHintPreviewPixelTest {
 


### PR DESCRIPTION
## Summary

- bump Wear Compose from `1.7.0-alpha05` to `1.7.0-alpha06`
- migrate the gesture reporting seam to `OneHandedGestureConfiguration` and `OneHandedGestureIndicatorState`
- share explicit configurations and indicator state between gesture handlers and indicators
- keep the static peak-frame path only for forced Robolectric still captures, where the real finite animation completes during idle pre-roll

Fixes #2828.

## Breaking change

`rememberForcedGestureHintSource` is removed. `reportedOneHandedGesture` now requires an `OneHandedGestureConfiguration` and optionally accepts the matching `OneHandedGestureIndicatorState`; `GestureHint` now accepts that configuration and state instead of a gesture type and interaction source.

Normal on-device indicators use the alpha06 state-backed API. The forced still-capture replica remains because removing it causes the hints-on and hints-off previews to become identical after Robolectric settles the finite animation.

## Visual verification

The alpha05 and alpha06 renders are byte-identical (`2248a99a…` for hints on and `5166dd3a…` for hints off).

| Before — alpha05 | After — alpha06 |
| --- | --- |
| ![Gesture hints before](https://raw.githubusercontent.com/yschimke/compose-ai-tools/main/docs/renders/wear-gestures/gesture-hint-on.png) | ![Gesture hints after](https://raw.githubusercontent.com/yschimke/compose-ai-tools/agent/migrate-wear-widget-alpha-api/docs/renders/wear-gestures/gesture-hint-on.png) |

## Validation

- `./gradlew :data-gestures-core:ktfmtFormat :data-gestures-connector:ktfmtFormat :samples:wear:ktfmtFormat :data-gestures-core:check :data-gestures-connector:check :samples:wear:testDebugUnitTest`
- rendered all 40 `samples:wear` previews with `compose-preview`
- visually inspected gesture-hints on/off plus scroll and page indicator previews
- verified before/after gesture-hint PNG SHA-256 hashes match