### PR TITLE
fix(tiles): avoid linking 1.6 scope on older runtimes

### DIFF
--- a/renderers/android/build.gradle.kts
+++ b/renderers/android/build.gradle.kts
@@ -238,6 +238,9 @@ dependencies {
   testImplementation(libs.compose.material3)
   testImplementation(libs.compose.runtime)
   testImplementation(libs.wear.compose.foundation)
+  // TileScopeResourcesCompatTest exercises both the pre-1.6 no-scope path and the modern
+  // scope-resource merge. Production remains compileOnly so consumers supply their Tiles version.
+  testImplementation(libs.wear.protolayout)
   // Wear Material3 on the TEST classpath only — it supplies `SurfaceTransformation` /
   // `transformedHeight` so `WearScrollSvgGrowthTest` can render a round preview with the real Wear
   // item scaling and show reduce-motion flatten it. Test-scoped on purpose: the daemon must never

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/TilePreviewRenderer.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/TilePreviewRenderer.kt
@@ -13,7 +13,6 @@ import androidx.compose.ui.viewinterop.AndroidView
 import androidx.wear.protolayout.DeviceParametersBuilders
 import androidx.wear.protolayout.DeviceParametersBuilders.DeviceParameters
 import androidx.wear.protolayout.LayoutElementBuilders
-import androidx.wear.protolayout.ProtoLayoutScope
 import androidx.wear.protolayout.ResourceBuilders
 import androidx.wear.protolayout.proto.LayoutElementProto
 import androidx.wear.protolayout.proto.ResourceProto
@@ -119,7 +118,7 @@ private fun renderTileInto(
   // `onTileResourceRequest` returns an empty bundle and `TileRenderer` only inflates the
   // `Resources` we pass it, so unharvested scope images (contact avatars) render blank.
   val resources =
-    mergeScopeResources(data.onTileResourceRequest(resourcesRequest), tileRequest.scope)
+    TileScopeResourcesCompat.merge(data.onTileResourceRequest(resourcesRequest), tileRequest)
 
   val layout =
     tile.tileTimeline?.timelineEntries?.firstOrNull()?.layout
@@ -144,24 +143,40 @@ private fun renderTileInto(
 }
 
 /**
- * Combines the resources returned by `onTileResourceRequest` ([requested]) with any images the
- * layout registered into the TileRequest's [scope] during `onTileRequest` — the modern
- * `ProtoLayoutScope` image API (`materialScopeWithResources` / `avatarImage` / `basicImage`). Scope
- * images are merged on top of the requested map (proto map merge is last-wins per id). Returns
- * [requested] unchanged when the scope holds nothing, so the classic explicit-mapping path is
- * byte-for-byte untouched.
+ * Compatibility bridge for the `TileRequest.getScope()` API added in Wear Tiles 1.6.
+ *
+ * The renderer still supports consumers on Tiles 1.5, whose `TileRequest` has no scope method or
+ * `ProtoLayoutScope` return type. Keeping both types out of this object's signatures and bytecode
+ * prevents the JVM from linking the 1.6 API while rendering a classic `onTileResourceRequest`
+ * preview. On 1.6+, scope images are merged on top of the requested map (last resource id wins).
  */
-private fun mergeScopeResources(
-  requested: ResourceBuilders.Resources,
-  scope: ProtoLayoutScope,
-): ResourceBuilders.Resources {
-  if (!scope.hasResources()) return requested
-  val merged =
-    ResourceProto.Resources.newBuilder()
-      .mergeFrom(requested.toProto())
-      .mergeFrom(scope.collectResources().toProto())
-      .build()
-  return ResourceBuilders.Resources.fromProto(merged)
+internal object TileScopeResourcesCompat {
+  fun merge(
+    requested: ResourceBuilders.Resources,
+    tileRequest: Any,
+  ): ResourceBuilders.Resources {
+    val scope =
+      runCatching { tileRequest.javaClass.getMethod("getScope").invoke(tileRequest) }.getOrNull()
+        ?: return requested
+    val hasResources =
+      runCatching {
+          scope.javaClass.getMethod("hasResources").invoke(scope) as? Boolean
+        }
+        .getOrNull() == true
+    if (!hasResources) return requested
+    val scopeResources =
+      runCatching {
+          scope.javaClass.getMethod("collectResources").invoke(scope)
+            as? ResourceBuilders.Resources
+        }
+        .getOrNull() ?: return requested
+    val merged =
+      ResourceProto.Resources.newBuilder()
+        .mergeFrom(requested.toProto())
+        .mergeFrom(scopeResources.toProto())
+        .build()
+    return ResourceBuilders.Resources.fromProto(merged)
+  }
 }
 
 /**

--- a/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/TileScopeResourcesCompatTest.kt
+++ b/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/TileScopeResourcesCompatTest.kt
@@ -1,0 +1,58 @@
+package ee.schimke.composeai.renderer
+
+import androidx.wear.protolayout.ResourceBuilders.ImageResource
+import androidx.wear.protolayout.ResourceBuilders.Resources
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Test
+
+class TileScopeResourcesCompatTest {
+  @Test
+  fun `classic resources remain unchanged when TileRequest has no scope API`() {
+    val requested = resources("classic")
+
+    val merged = TileScopeResourcesCompat.merge(requested, LegacyTileRequest())
+
+    assertSame(requested, merged)
+  }
+
+  @Test
+  fun `empty modern scope leaves classic resources unchanged`() {
+    val requested = resources("classic")
+    val request = ModernTileRequest(FakeScope(hasResources = false, resources = resources("scope")))
+
+    val merged = TileScopeResourcesCompat.merge(requested, request)
+
+    assertSame(requested, merged)
+  }
+
+  @Test
+  fun `modern scope resources are merged with classic resources`() {
+    val request = ModernTileRequest(FakeScope(hasResources = true, resources = resources("scope")))
+
+    val merged = TileScopeResourcesCompat.merge(resources("classic"), request)
+
+    assertEquals(setOf("classic", "scope"), merged.idToImageMapping.keys)
+  }
+
+  private fun resources(id: String): Resources =
+    Resources.Builder()
+      .setVersion("1")
+      .addIdToImageMapping(id, ImageResource.Builder().build())
+      .build()
+
+  private class LegacyTileRequest
+
+  private class ModernTileRequest(private val scope: FakeScope) {
+    @Suppress("unused") fun getScope(): FakeScope = scope
+  }
+
+  private class FakeScope(
+    private val hasResources: Boolean,
+    private val resources: Resources,
+  ) {
+    @Suppress("unused") fun hasResources(): Boolean = hasResources
+
+    @Suppress("unused") fun collectResources(): Resources = resources
+  }
+}


### PR DESCRIPTION
## Summary

- remove the direct `TileRequest.scope` / `ProtoLayoutScope` linkage from the Android tile renderer
- harvest scope-registered resources reflectively when the Tiles 1.6+ API is present
- leave classic `onTileResourceRequest` resources byte-for-byte unchanged when the scope API is absent or empty
- add regression coverage for pre-1.6, empty-scope, and modern scope-resource paths

Fixes #2354.

## Root cause

The scope-resource support added in #2305 compiled a direct call to `TileRequest.getScope(): ProtoLayoutScope`. Wear Tiles 1.5 `TileRequest` has no such method or return type, so the JVM could fail linkage before a classic tile preview reached `onTileResourceRequest`.

The compatibility bridge keeps `getScope`, `hasResources`, and `collectResources` behind reflection. That preserves the modern image merge without requiring the 1.6 API to link on older consumer classpaths.

## Validation

- `./gradlew :renderer-android:ktfmtFormat :renderer-android:testDebugUnitTest --tests ee.schimke.composeai.renderer.TileScopeResourcesCompatTest`
- `:renderer-android:testDebugUnitTest` passed as part of `:renderer-android:check`
- inspected the compiled renderer classes and confirmed they contain no `ProtoLayoutScope` bytecode reference
- inspected the official Wear Tiles 1.5.0 AAR and confirmed `TileRequest` has no scope API

`./gradlew :renderer-android:check` reaches the repository's existing renderer lint backlog and fails on 17 unrelated diagnostics (starting with `NotificationSidecar.kt` API-level usage and existing restricted ProtoLayout calls); the unit and focused compatibility tests pass.