### PR TITLE
fix(serve): keep IR previews out of daemon lane

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
@@ -134,6 +134,35 @@ class ServeCatalogStore(
     return alias
   }
 
+  /**
+   * Restrict a carried bundle's server-side alias to previews that still have executable bytecode.
+   *
+   * An IR-backed preview (currently Remote Compose) is intentionally omitted from
+   * `classes/app.jar`: the bundle carries its captured document under `ir/` instead. It remains in
+   * the full alias while [extractCatalogRcDocs] re-keys that document for browser replay, but
+   * handing it to the daemon would deterministically fail with `ClassNotFoundException`.
+   *
+   * Metadata failures retain the original alias; the bundle builder owns diagnostics and rejection
+   * for malformed bundles, and this filter must not hide that more useful failure path.
+   */
+  private fun classBackedAliasForBundle(
+    bundleFile: File,
+    alias: Map<String, String>,
+  ): Map<String, String> {
+    val irPreviewIds =
+      try {
+        BundleReader.readMetadata(bundleFile).manifest.intermediateRepresentations.mapTo(
+          mutableSetOf()
+        ) {
+          it.previewId
+        }
+      } catch (_: Exception) {
+        return alias
+      }
+    if (irPreviewIds.isEmpty()) return alias
+    return alias.filterValues { it !in irPreviewIds }
+  }
+
   sealed interface Result {
     data class Ok(val system: String, val previewCount: Int, val trust: String) : Result
 
@@ -347,6 +376,9 @@ class ServeCatalogStore(
         // can serve them. Done regardless of the rehydrate/daemon outcome below — the client-side
         // `.rc` lane needs no daemon, so it must survive a live-tier fallback.
         extractCatalogRcDocs(bundleFile, alias, dir)
+        // IR-backed previews have no class in app.jar by design. Preserve their full alias above
+        // for `.rc` extraction, but never advertise them to either daemon lane.
+        val classBackedAlias = classBackedAliasForBundle(bundleFile, alias)
         // Rehydrate any resources the bundle externalized (fonts lifted out of classes/app.jar)
         // from
         // the branch's content-addressed pool into a shared cache + a materialized classpath dir.
@@ -368,21 +400,22 @@ class ServeCatalogStore(
             // which suffix maps to which id without the publisher's ordering, so we only serve the
             // per-preview lane for ids with an unambiguous stem; a colliding id resolves null and
             // falls back to the monolithic daemon (which serves every preview correctly).
-            val safeStems = uniquePerPreviewStems(alias.values)
+            val safeStems = uniquePerPreviewStems(classBackedAlias.values)
             val fetchPerPreview: (String) -> File? = { daemonId ->
               safeStems[daemonId]?.let { stem ->
                 fetchPerPreviewBundle(stem, liveBundle, base, dir, safe)
               }
             }
             if (
-              buildTrustedBundle(
-                safe,
-                bundleFile,
-                res.dir,
-                alias,
-                { bakedFallback(emptyList()) },
-                fetchPerPreview,
-              )
+              classBackedAlias.isNotEmpty() &&
+                buildTrustedBundle(
+                  safe,
+                  bundleFile,
+                  res.dir,
+                  classBackedAlias,
+                  { bakedFallback(emptyList()) },
+                  fetchPerPreview,
+                )
             ) {
               return Result.Ok(safe, count, "${BundleVerifier.summary(verdict)} (live bundle)")
             }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
@@ -392,6 +392,72 @@ class ServeCatalogStoreTest {
   }
 
   @Test
+  fun `a mixed liveBundle routes only class-backed previews to the daemon`() {
+    val remoteId = "com.example.CatalogKt.RemotePreview"
+    val widgetId = "com.example.WidgetKt.WidgetPreview"
+    val rcBytes = byteArrayOf(0x52, 0x43, 0x01)
+    val bundle =
+      polyglotBundle(
+        manifest =
+          """
+          {"schemaVersion":8,"backend":"android",
+           "previewIds":["$remoteId","$widgetId"],"coverPreviewId":"$remoteId",
+           "classpath":[{"kind":"module","path":"classes/app.jar"}],
+           "modulePath":":samples:remote","producedBy":"test",
+           "intermediateRepresentations":[
+             {"previewId":"$remoteId","format":"remotecompose","path":"ir/$remoteId.rc"}
+           ],"externalResources":[]}
+          """
+            .trimIndent(),
+        extra = mapOf("ir/$remoteId.rc" to rcBytes),
+      )
+    val catalog =
+      """
+      {"schema":"design-parity-catalog/v1","system":"remote-m3",
+       "liveBundle":{"path":"bundle/","file":"bundle.png"},
+       "components":[
+         {"componentId":"Remote","images":[
+           {"path":"images/remote/ideal__default.png","previewId":"$remoteId"}]},
+         {"componentId":"Widget","images":[
+           {"path":"images/widget/ideal__default.png","previewId":"$widgetId"}]}
+       ]}
+      """
+        .trimIndent()
+    val fetch: (String) -> ByteArray? = { url ->
+      when {
+        url.endsWith("/${ServeCatalogStore.CATALOG_FILE}") -> catalog.toByteArray()
+        url.endsWith("bundle/bundle.png") -> bundle
+        url.endsWith(".png") -> png()
+        else -> null
+      }
+    }
+    val root = tempRoot()
+    var captured: Map<String, String>? = null
+    val store =
+      ServeCatalogStore(
+        root = root,
+        register = { n, h -> registered[n] = h },
+        trust =
+          TrustStore(
+            branches = listOf(TrustedBranch("yschimke/compose-ai-tools", "design-artifacts/*"))
+          ),
+        fetch = fetch,
+        buildTrustedBundle = { _, _, _, alias, _, _ ->
+          captured = alias
+          true
+        },
+      )
+
+    assertTrue(store.load("remote-m3") is ServeCatalogStore.Result.Ok)
+    assertEquals(mapOf("widget__ideal__default" to widgetId), captured)
+    assertContentEquals(
+      rcBytes,
+      File(root, "remote-m3/ir/remote__ideal__default.rc").readBytes(),
+      "the IR-backed preview remains available for browser-side replay",
+    )
+  }
+
+  @Test
   fun `live bundles use the larger dedicated download envelope`() {
     // jetchat (36.5 MB) and jetsnack (51.2 MB) are valid published bundles that exceed the 25 MB
     // catalog-asset cap. The ordinary fetcher must remain tight for images, while the executable

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -1892,7 +1892,7 @@ class JsonRpcServer(
     val renderError =
       RenderError(
         kind = classification.kind,
-        message = failure.cause.message ?: failure.cause.javaClass.name,
+        message = renderFailureMessage(failure.cause),
         suggestion = classification.suggestion,
       )
     val payload = buildJsonObject {
@@ -4223,6 +4223,12 @@ class JsonRpcServer(
 
     private val SHUTDOWN_SENTINEL = ByteArray(0)
   }
+}
+
+internal fun renderFailureMessage(cause: Throwable): String {
+  val type = cause.javaClass.simpleName.ifBlank { cause.javaClass.name }
+  val detail = cause.message?.takeIf { it.isNotBlank() } ?: return type
+  return "$type: $detail"
 }
 
 // ---------------------------------------------------------------------------

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/RenderErrorClassifierTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/RenderErrorClassifierTest.kt
@@ -109,4 +109,13 @@ class RenderErrorClassifierTest {
     assertEquals(RenderErrorKind.SDK_MISMATCH, RenderErrorClassifier.classify(cause).kind)
     assertNotNull(RenderErrorClassifier.classify(cause).suggestion)
   }
+
+  @Test
+  fun renderFailureMessagePrefixesTheExceptionType() {
+    assertEquals(
+      "ClassNotFoundException: com.example.CatalogPreviewsKt",
+      renderFailureMessage(ClassNotFoundException("com.example.CatalogPreviewsKt")),
+    )
+    assertEquals("IllegalStateException", renderFailureMessage(IllegalStateException()))
+  }
 }


### PR DESCRIPTION
## Summary

- filter carried-bundle daemon aliases to previews that are not represented by bundle IR
- keep the full alias for Remote Compose document extraction and browser-side replay
- prefix daemon render failures with the exception type so status no longer reports ambiguous bare class names

## Production diagnosis

The published remote-m3 bundle is mixed by design: 19 `CatalogPreviewsKt` previews are Remote Compose IR entries and therefore intentionally absent from `classes/app.jar`; the three `WidgetContainerPreviewsKt` previews remain class-backed. Serve was routing all 22 aliases into the server daemon, producing the observed `ClassNotFoundException` for every Remote Compose preview.

## Tests

- `./gradlew :cli:test --tests ee.schimke.composeai.cli.serve.ServeCatalogStoreTest :daemon:core:test --tests ee.schimke.composeai.daemon.RenderErrorClassifierTest`
- `./gradlew :cli:ktfmtCheck :daemon:core:ktfmtCheck`

Fixes #2707