### PR TITLE
fix(catalog): reject colliding variants

### DIFF
--- a/scripts/design-artifacts/catalog-spec.mjs
+++ b/scripts/design-artifacts/catalog-spec.mjs
@@ -350,13 +350,25 @@ export function validateSpec(spec, opts = {}) {
         } else {
           variants.forEach((v, vi) => {
             const vp = `${cp}.variants[${vi}]`;
+            const allowedKeys = new Set(["preview", "caption", "state", "props", "theme"]);
+            for (const key of Object.keys(v ?? {})) {
+              if (!allowedKeys.has(key)) {
+                errors.push(
+                  `${vp}.${key} is not supported; expected only ${[...allowedKeys]
+                    .map((k) => `\`${k}\``)
+                    .join(", ")}`,
+                );
+              }
+            }
             if (typeof v?.preview !== "string" || v.preview.length === 0) {
               errors.push(`${vp}.preview is required`);
             } else {
               pushMulti(previewToPaths, v.preview, vp);
             }
             if (v?.state === undefined && v?.props === undefined && v?.theme === undefined) {
-              warnings.push(`${vp} has neither \`state\`, \`props\` nor \`theme\` — it won't be distinguishable from the default`);
+              errors.push(
+                `${vp} has neither \`state\`, \`props\` nor \`theme\` — it would overwrite the default artifact`,
+              );
             }
             if (v?.theme !== undefined && v.theme !== "light" && v.theme !== "dark") {
               errors.push(`${vp}.theme must be "light" or "dark" when present`);

--- a/scripts/design-artifacts/catalog-spec.test.mjs
+++ b/scripts/design-artifacts/catalog-spec.test.mjs
@@ -203,7 +203,7 @@ test("validateSpec warns about @Preview functions absent from the catalog", () =
   assert.ok(warnings.some((w) => w.includes("Unused")));
 });
 
-test("validateSpec warns when a variant has neither state, props nor theme", () => {
+test("validateSpec rejects a variant with no distinguishing axis", () => {
   const spec = {
     system: "s",
     title: "T",
@@ -214,8 +214,30 @@ test("validateSpec warns when a variant has neither state, props nor theme", () 
       },
     ],
   };
-  const { warnings } = validateSpec(spec);
-  assert.ok(warnings.some((w) => w.includes("neither `state`, `props` nor `theme`")));
+  const { errors } = validateSpec(spec);
+  assert.ok(errors.some((e) => e.includes("neither `state`, `props` nor `theme`")));
+  assert.ok(errors.some((e) => e.includes("overwrite the default artifact")));
+});
+
+test("validateSpec rejects unsupported variant properties", () => {
+  const spec = {
+    system: "s",
+    title: "T",
+    groups: [
+      {
+        name: "G",
+        components: [
+          {
+            componentId: "A",
+            preview: "P",
+            variants: [{ mode: "dark", preview: "PDark" }],
+          },
+        ],
+      },
+    ],
+  };
+  const { errors } = validateSpec(spec);
+  assert.ok(errors.some((e) => e.includes(".mode is not supported")));
 });
 
 test("validateSpec accepts a theme variant and still resolves its preview name", () => {

--- a/scripts/design-artifacts/catalog-variants.mjs
+++ b/scripts/design-artifacts/catalog-variants.mjs
@@ -40,6 +40,10 @@
 export function foldVariants(defaultImages, component, byFunction) {
   const ideal = [...defaultImages];
   const missing = [];
+  const outputKeys = new Set();
+  for (const image of defaultImages) {
+    recordOutputKey(outputKeys, image, component.componentId);
+  }
   for (const variant of component.variants ?? []) {
     const candidate = byFunction.get(variant.preview);
     if (!candidate || candidate.images.length === 0) {
@@ -51,10 +55,36 @@ export function foldVariants(defaultImages, component, byFunction) {
       if (variant.state !== undefined) tagged.state = variant.state;
       if (variant.props) tagged.props = { ...image.props, ...variant.props };
       if (variant.theme !== undefined) tagged.theme = variant.theme;
+      recordOutputKey(outputKeys, tagged, component.componentId);
       ideal.push(tagged);
     }
   }
   return { ideal, missing };
+}
+
+/**
+ * Refuse two images that the exporter would name from the same effective variant axes. Catching
+ * this before `buildCatalog` writes either PNG prevents last-write-wins pixels paired with stale
+ * manifest metadata.
+ */
+function recordOutputKey(seen, image, componentId) {
+  const props = Object.fromEntries(
+    Object.entries(image.props ?? {}).sort(([a], [b]) => a.localeCompare(b)),
+  );
+  const key = JSON.stringify({
+    variant: image.variant ?? "ideal",
+    state: image.state ?? "default",
+    theme: image.theme ?? null,
+    size: image.size ?? null,
+    props,
+  });
+  if (seen.has(key)) {
+    throw new Error(
+      `catalog component "${componentId}" produces duplicate output axes ${key}; ` +
+        "each variant must have a unique state, theme, size, or props value",
+    );
+  }
+  seen.add(key);
 }
 
 /** A short label for a variant, for the missing-render report: its state, props and/or theme. */

--- a/scripts/design-artifacts/catalog-variants.test.mjs
+++ b/scripts/design-artifacts/catalog-variants.test.mjs
@@ -133,6 +133,24 @@ test("foldVariants reports a theme variant that did not render, labelled by its 
   assert.deepEqual(missing, ["Screen/Foo [dark]"]);
 });
 
+test("foldVariants refuses duplicate effective output axes before export", () => {
+  const byFunction = new Map([
+    ["SecondDark", { images: [img("default", "light")] }],
+  ]);
+  assert.throws(
+    () =>
+      foldVariants(
+        [img("default", "dark")],
+        {
+          componentId: "Screen/Foo",
+          variants: [{ theme: "dark", preview: "SecondDark" }],
+        },
+        byFunction,
+      ),
+    /produces duplicate output axes/,
+  );
+});
+
 // --- index.html: default in the grid, states in the zoom view -----------------
 
 const catalogWithStates = () => ({

--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -984,6 +984,7 @@ for (const component of catalog.components) {
 const figmaSvgsById = figmaSvgByIds([bundle, extraBundle]);
 let figmaVariantSvgCount = 0;
 let figmaVariantGapCount = 0;
+const figmaVariantSvgPaths = new Set();
 // Components with at least one image carrying no `previewId`. Some of those are legitimate
 // (`bridgeLivePreviewIds` deliberately skips a state with no desktop source, and any function
 // the Android-only supplement overrode) — but a component where NONE of the images bridged is
@@ -1036,6 +1037,7 @@ for (const component of indexManifest.components ?? []) {
     }
     await mkdir(variantDir, { recursive: true });
     await writeFile(variantPath, svg, "utf8");
+    figmaVariantSvgPaths.add(target);
     figmaVariantSvgCount += 1;
   }
 }
@@ -1208,6 +1210,7 @@ await writeFile(
   comparePath,
   renderCompareHtml(indexManifest, {
     figmaSvgSlugs,
+    figmaVariantSvgPaths,
     hybridSlugs: figmaSvgHybridSlugs,
   }),
   "utf8",

--- a/scripts/design-artifacts/render-compare-html.mjs
+++ b/scripts/design-artifacts/render-compare-html.mjs
@@ -45,6 +45,7 @@
  */
 
 import { slug } from "./render-wireframe-svg.mjs";
+import { figmaVariantSvgPath } from "./figma-svg-emit.mjs";
 
 /** Minimal HTML-escape for text interpolated into the page. */
 function esc(s) {
@@ -131,11 +132,13 @@ const SCORER = String.raw`
     OV.bg = bg ? bg.value : "checker";
   }
 
-  // Whether any override departs from identity. When true the score is a *probe* of
+  // Whether a vector mutation departs from identity. Theme selects a separately authored
+  // PNG/SVG pair, so it remains a baseline comparison rather than an override probe.
+  // When true the score is a *probe* of
   // the SVG's sensitivity to the knob (the PNG is the capture-time render), not a
   // baseline fidelity number — the header says so.
   function overridesActive() {
-    return Math.abs(OV.fontScale - 1) > 1e-6 || !OV.fonts || OV.theme !== "light";
+    return Math.abs(OV.fontScale - 1) > 1e-6 || !OV.fonts;
   }
 
   // Apply the active overrides to the figma-svg source text.
@@ -163,9 +166,18 @@ const SCORER = String.raw`
   }
 
   // The PNG the current theme override selects — the dark capture if the row carries
-  // one, else the light default (so the toggle is a no-op for light-only rows).
+  // a matching dark vector too, else the light default. Switching only one side would
+  // manufacture the exact cross-variant diff this page exists to prevent.
   function currentPng(tr) {
-    return OV.theme === "dark" && tr.dataset.pngDark ? tr.dataset.pngDark : tr.dataset.png;
+    return OV.theme === "dark" && tr.dataset.pngDark && tr.dataset.svgDark
+      ? tr.dataset.pngDark
+      : tr.dataset.png;
+  }
+
+  // Keep the vector on the same authored variant as the PNG. A row without a dark vector falls
+  // back to its light/base vector, matching currentPng's fallback for a missing dark capture.
+  function currentSvg(tr) {
+    return OV.theme === "dark" && tr.dataset.svgDark ? tr.dataset.svgDark : tr.dataset.svg;
   }
 
   function loadImage(src) {
@@ -247,13 +259,12 @@ const SCORER = String.raw`
   }
 
   // Put the display <img> back to the authored figma-svg once the overrides return to
-  // identity — otherwise the column keeps showing the last override's blob while the
-  // score is recomputed from the baseline vector. Only acts when a blob was actually
-  // installed, so an unchanged rescore doesn't thrash the src.
+  // identity or the selected theme changes — otherwise the column keeps showing the last
+  // override's blob or the previous theme while the score uses a different authored vector.
   function restoreSvg(tr) {
-    if (tr.dataset.svgShown !== "override") return;
     const img = tr.querySelector(".col-svg .shot img");
-    if (img) img.src = tr.dataset.svg;
+    const svgPath = currentSvg(tr);
+    if (img && img.getAttribute("src") !== svgPath) img.src = svgPath;
     tr.dataset.svgShown = "base";
   }
 
@@ -405,9 +416,10 @@ const SCORER = String.raw`
       // translate, apply the active overrides, and inline any raster crops). Both are
       // same-origin and cache-shared.
       const pngPath = currentPng(tr);
+      const svgPath = currentSvg(tr);
       const [png, resp] = await Promise.all([
         loadImage(pngPath),
-        fetch(tr.dataset.svg),
+        fetch(svgPath),
       ]);
       const rawSvg = await resp.text();
       // Apply the header overrides (font scale, drop embedded @font-face) to the vector
@@ -424,7 +436,7 @@ const SCORER = String.raw`
       // Overridden or hybrid → rasterize the (blob) string; untouched vector-only → the
       // cheap <img src=svg> path.
       const changed = inlined !== rawSvg;
-      const svg = changed ? await loadSvgString(inlined) : await loadImage(tr.dataset.svg);
+      const svg = changed ? await loadSvgString(inlined) : await loadImage(svgPath);
       // The render PNG defines the aligned coordinate space (padding-free, content at
       // (0,0)); size the shared canvas from it, capped to MAX_SIDE for offset-robustness.
       const rw = png.naturalWidth || png.width, rh = png.naturalHeight || png.height;
@@ -612,14 +624,34 @@ const SCORER = String.raw`
  * Components missing a PNG or a figma-svg still get a row (so the table is a complete
  * inventory) but with an inert "—" score that sorts to the bottom.
  */
-function componentRow(component, figmaSvgSlugs, hybridSlugs) {
+function componentSvgPaths(component, figmaSvgSlugs, figmaVariantSvgPaths) {
+  const s = slug(component.componentId ?? "(unnamed)");
+  const fallback = figmaSvgSlugs?.has(s) ? `figma/${s}.svg` : null;
+  const png = comparePng(component);
+  const pngDark = compareDarkPng(component);
+  const variantPath = (image) => {
+    const path = image && figmaVariantSvgPath(image.path);
+    return path && figmaVariantSvgPaths?.has(path) ? path : null;
+  };
+  return {
+    light: variantPath(png) ?? fallback,
+    // Callers predating per-variant vectors supplied no path set and retain the legacy flat
+    // fallback. A supplied (even empty) set is authoritative: never call one flat SVG "dark".
+    dark: variantPath(pngDark) ?? (figmaVariantSvgPaths === undefined ? fallback : null),
+  };
+}
+
+function componentRow(component, figmaSvgSlugs, figmaVariantSvgPaths, hybridSlugs) {
   const id = component.componentId ?? "(unnamed)";
   const group = component.group ?? "Components";
   const s = slug(id);
   const png = comparePng(component);
   const pngDark = compareDarkPng(component);
-  const hasSvg = figmaSvgSlugs && figmaSvgSlugs.has(s);
-  const svgPath = hasSvg ? `figma/${s}.svg` : null;
+  const { light: svgPath, dark: svgDarkPath } = componentSvgPaths(
+    component,
+    figmaSvgSlugs,
+    figmaVariantSvgPaths,
+  );
   const hybrid = Boolean(hybridSlugs && hybridSlugs.has(s));
 
   const pngCell = png
@@ -638,7 +670,7 @@ function componentRow(component, figmaSvgSlugs, hybridSlugs) {
 
   const rowAttrs =
     png && svgPath
-      ? ` data-png="${esc(png.path)}"${pngDark ? ` data-png-dark="${esc(pngDark.path)}"` : ""} data-svg="${esc(svgPath)}"`
+      ? ` data-png="${esc(png.path)}"${pngDark ? ` data-png-dark="${esc(pngDark.path)}"` : ""} data-svg="${esc(svgPath)}"${svgDarkPath ? ` data-svg-dark="${esc(svgDarkPath)}"` : ""}`
       : "";
 
   return `<tr class="crow"${rowAttrs}>
@@ -652,32 +684,35 @@ function componentRow(component, figmaSvgSlugs, hybridSlugs) {
 /**
  * Render the catalog to a complete PNG-vs-SVG comparison page.
  * @param {object} catalog the flattened manifest (system, title, components, …)
- * @param {object} [opts] { figmaSvgSlugs?: Set<string>, hybridSlugs?: Set<string> } — the slugs a
- *   figma-svg was written for, and the subset whose SVG is a hybrid (carries raster crop layers).
+ * @param {object} [opts] { figmaSvgSlugs?: Set<string>, figmaVariantSvgPaths?: Set<string>,
+ *   hybridSlugs?: Set<string> } — the back-compat slugs and exact per-variant paths written, plus
+ *   the subset whose SVG is a hybrid (carries raster crop layers).
  * @returns {string} a self-contained compare.html
  */
 export function renderCompareHtml(catalog, opts = {}) {
   const components = catalog.components ?? [];
   const figmaSvgSlugs = opts.figmaSvgSlugs;
+  const figmaVariantSvgPaths = opts.figmaVariantSvgPaths;
   const hybridSlugs = opts.hybridSlugs;
 
   const comparable = components.filter(
-    (c) => comparePng(c) && figmaSvgSlugs && figmaSvgSlugs.has(slug(c.componentId)),
+    (c) => comparePng(c) && componentSvgPaths(c, figmaSvgSlugs, figmaVariantSvgPaths).light,
   ).length;
 
   // Whether any comparable component carries a dark default capture — the theme
   // override is only offered when there's a dark PNG to switch to.
   const hasDark = components.some(
-    (c) =>
-      figmaSvgSlugs &&
-      figmaSvgSlugs.has(slug(c.componentId)) &&
-      comparePng(c) &&
-      compareDarkPng(c),
+    (c) => {
+      const paths = componentSvgPaths(c, figmaSvgSlugs, figmaVariantSvgPaths);
+      return paths.light && paths.dark && comparePng(c) && compareDarkPng(c);
+    },
   );
 
   // One flat, client-sortable table — initial paint is catalog order; the scorer
   // re-orders worst-match-first once every row has a score.
-  const body = components.map((c) => componentRow(c, figmaSvgSlugs, hybridSlugs)).join("\n");
+  const body = components
+    .map((c) => componentRow(c, figmaSvgSlugs, figmaVariantSvgPaths, hybridSlugs))
+    .join("\n");
 
   const meta = catalog.meta ?? catalog;
   const title = meta.title ?? meta.system ?? "Design catalog";

--- a/scripts/design-artifacts/render-compare-html.test.mjs
+++ b/scripts/design-artifacts/render-compare-html.test.mjs
@@ -52,6 +52,38 @@ test("a comparable component wires data-png + data-svg for the scorer", () => {
   assert.match(html, /<img[^>]*src="figma\/button-filled\.svg"/);
 });
 
+test("each theme pairs its PNG with the matching per-variant SVG", () => {
+  const themed = {
+    system: "compose-m3",
+    components: [
+      {
+        componentId: "button-filled",
+        group: "Buttons",
+        images: [
+          png("images/button-filled/ideal__default__light.png", { theme: "light" }),
+          png("images/button-filled/ideal__default__dark.png", { theme: "dark" }),
+        ],
+      },
+    ],
+  };
+  const html = renderCompareHtml(themed, {
+    figmaSvgSlugs: new Set(["button-filled"]),
+    figmaVariantSvgPaths: new Set([
+      "figma/button-filled/ideal__default__light.svg",
+      "figma/button-filled/ideal__default__dark.svg",
+    ]),
+    hybridSlugs: new Set(["button-filled"]),
+  });
+  assert.match(
+    html,
+    /data-png="images\/button-filled\/ideal__default__light\.png" data-png-dark="images\/button-filled\/ideal__default__dark\.png" data-svg="figma\/button-filled\/ideal__default__light\.svg" data-svg-dark="figma\/button-filled\/ideal__default__dark\.svg"/,
+  );
+  assert.match(html, /function currentSvg/);
+  assert.match(html, /fetch\(svgPath\)/);
+  // Raster hrefs are resolved from whichever variant SVG was fetched.
+  assert.match(html, /inlineRasters\(svgText, resp\.url\)/);
+});
+
 test("the in-page SSIM scorer is embedded", () => {
   const html = renderCompareHtml(catalog, { figmaSvgSlugs: new Set(["button-filled"]) });
   assert.match(html, /function ssim/);
@@ -75,7 +107,7 @@ test("the scorer aligns the SVG's export padding out before scoring (translate c
   assert.match(html, /function translateOf/);
   assert.match(html, /translate\\\(/); // reads the SVG's root translate
   assert.match(html, /-tx \* scale, -ty \* scale/); // draws the SVG offset to crop the padding
-  assert.match(html, /fetch\(tr\.dataset\.svg\)/); // fetches the SVG source to read the translate
+  assert.match(html, /fetch\(svgPath\)/); // fetches the theme-matched SVG to read the translate
 });
 
 test("both columns are framed to the component's content bbox", () => {
@@ -240,7 +272,7 @@ test("identity overrides keep the cheap unchanged-vector path (baseline score pr
   const html = renderCompareHtml(catalog, { figmaSvgSlugs: new Set(["button-filled"]) });
   // When applyOverrides returns the text unchanged, the plain <img src=svg> load is used.
   assert.match(html, /const changed = inlined !== rawSvg/);
-  assert.match(html, /changed \? await loadSvgString\(inlined\) : await loadImage\(tr\.dataset\.svg\)/);
+  assert.match(html, /changed \? await loadSvgString\(inlined\) : await loadImage\(svgPath\)/);
 });
 
 test("returning overrides to identity restores the displayed SVG (not the last blob)", () => {
@@ -248,9 +280,9 @@ test("returning overrides to identity restores the displayed SVG (not the last b
   assert.match(html, /function restoreSvg/);
   // The scorer takes the restore branch when the vector is unchanged.
   assert.match(html, /if \(changed\) showSvg\(tr, inlined\);\s*else restoreSvg\(tr\);/);
-  // restoreSvg only acts when a blob was actually installed, and puts src back to the source.
-  assert.match(html, /tr\.dataset\.svgShown !== "override"/);
-  assert.match(html, /img\.src = tr\.dataset\.svg/);
+  // restoreSvg puts src back to the currently selected authored theme variant.
+  assert.match(html, /const svgPath = currentSvg\(tr\)/);
+  assert.match(html, /img\.getAttribute\("src"\) !== svgPath/);
 });
 
 test("the theme override repoints the displayed PNG, not just the scored one", () => {


### PR DESCRIPTION
## Summary

- make the custom catalog validator enforce the schema variant property set
- reject variants with no distinguishing state, props, or theme axis
- fail before export when two folded images resolve to the same effective output axes
- pass the emitted per-variant SVG path inventory into compare.html
- switch both PNG and SVG together for light/dark comparisons, including variant-local hybrid raster resolution

## Tests

- `node --test scripts/design-artifacts/*.test.mjs`
- `git diff --check`

Fixes #2855