### PR TITLE
fix(figma-svg): preserve brush backgrounds and expressive shapes

### DIFF
--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/RenderEngineTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/RenderEngineTest.kt
@@ -374,6 +374,54 @@ class RenderEngineTest {
   }
 
   @Test
+  fun figmaSvgExportRastersBrushBackgroundWithItsCompleteSubtree() {
+    val outputDir = tempFolder.newFolder("renders-figma-gradient")
+    System.setProperty(RenderEngine.OUTPUT_DIR_PROP, outputDir.absolutePath)
+    System.setProperty("roborazzi.test.record", "true")
+    val host = RobolectricHost()
+    host.start()
+    try {
+      host.submit(
+        RenderRequest.Render(
+          payload =
+            "className=ee.schimke.composeai.daemon.RedFixturePreviewsKt;" +
+              "functionName=GradientBackgroundCard;" +
+              "widthPx=128;heightPx=48;density=1.0;" +
+              "showBackground=true;" +
+              "outputBaseName=figma-gradient"
+        ),
+        timeoutMs = 120_000,
+      )
+
+      val previewDir = outputDir.parentFile!!.resolve("data").resolve("figma-gradient")
+      val svg = previewDir.resolve("compose-figma.svg").readText()
+      assertTrue("brush-backed layer must use the hybrid raster path", svg.contains("<image "))
+      assertFalse(
+        "the complete raster already contains the label, so no editable duplicate should survive",
+        svg.contains(">Gradient<"),
+      )
+
+      val crop =
+        previewDir
+          .resolve("figma-raster")
+          .listFiles { file -> file.extension == "png" }
+          ?.singleOrNull()
+      assertNotNull("gradient layer must produce one raster crop", crop)
+      val image = ByteArrayInputStream(crop!!.readBytes()).use { ImageIO.read(it) }
+      assertNotNull("gradient raster crop must decode", image)
+      val left = image!!.getRGB(image.width / 8, image.height / 2)
+      val right = image.getRGB(image.width * 7 / 8, image.height / 2)
+      assertTrue("left side should remain red-dominant", ((left shr 16) and 0xFF) > (left and 0xFF))
+      assertTrue(
+        "right side should remain blue-dominant",
+        (right and 0xFF) > ((right shr 16) and 0xFF),
+      )
+    } finally {
+      host.shutdown()
+    }
+  }
+
+  @Test
   fun figmaSvgLongRenderModeProducesFullPageSvg() {
     // Parity with the desktop backend: the `figma-svg-long` render mode grows the viewport until a
     // virtualised LazyColumn composes every row, sizes to content, and writes the full-page SVG to

--- a/daemon/android/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
+++ b/daemon/android/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.painter.ColorPainter
 import androidx.compose.ui.input.pointer.changedToUp
 import androidx.compose.ui.input.pointer.pointerInput
@@ -164,6 +165,22 @@ fun OpaqueImageSquare() {
       contentDescription = null,
       modifier = Modifier.size(32.dp),
     )
+  }
+}
+
+/** Brush-background hybrid SVG fixture: gradient pixels plus editable-looking child content. */
+@Composable
+fun GradientBackgroundCard() {
+  Box(
+    modifier =
+      Modifier.fillMaxSize()
+        .background(
+          Brush.horizontalGradient(listOf(Color(0xFFFF0000), Color(0xFF0000FF))),
+          RoundedCornerShape(8.dp),
+        ),
+    contentAlignment = Alignment.Center,
+  ) {
+    Text("Gradient", color = Color.White)
   }
 }
 

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopLayoutInspectorTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopLayoutInspectorTest.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.ImageComposeScene
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.paint
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.ImageBitmap
@@ -211,6 +212,24 @@ class DesktopLayoutInspectorTest {
     // 0xFF * 0.5 = 127.5 → 0x80 alpha over the opaque red.
     val faded = root.firstWhere { it.tokens?.backgroundColor == "#80FF0000" }
     assertNotNull("Modifier.paint alpha must fold into the resolved background alpha", faded)
+  }
+
+  @Test
+  fun carries_brush_background_identity_when_inspector_properties_are_absent() {
+    val root = writeAndRead {
+      Box(
+        Modifier.testTag("gradient")
+          .size(120.dp, 40.dp)
+          .background(Brush.horizontalGradient(listOf(Color.Red, Color.Blue)))
+      )
+    }
+
+    val gradient = root.firstWhere { node ->
+      node.modifiers.any {
+        it.name == "BackgroundElement" && it.properties["brush"]?.contains("Gradient") == true
+      }
+    }
+    assertNotNull("a brush background must remain identifiable in layout-inspector data", gradient)
   }
 
   @Test

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopSemanticsTokensTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopSemanticsTokensTest.kt
@@ -18,7 +18,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.ImageComposeScene
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Outline
+import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.text.SpanStyle
@@ -29,6 +32,7 @@ import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsNode
@@ -215,6 +219,24 @@ class DesktopSemanticsTokensTest {
   }
 
   @Test
+  fun resolves_effective_corner_shape_from_animated_shape_state() {
+    // Material 3 expressive ToggleButton wraps its current CornerBasedShape in an anonymous Shape
+    // whose `$state.getMorphedShape()` supplies the actual outline. Pin that structure without
+    // taking a Material 3 internal dependency: the exported button must keep the live 15dp corner
+    // instead of becoming a sharp rectangle (#2852).
+    val animatedShape = AnimatedShapeWrapper(AnimatedShapeState(RoundedCornerShape(15.dp)))
+    val root = buildTree {
+      Box(
+        Modifier.testTag("animated")
+          .size(width = 76.dp, height = 56.dp)
+          .background(Color(0xFFFFE523), animatedShape)
+      )
+    }
+
+    assertEquals("15.0dp", root.find("animated")?.tokens?.cornerRadius)
+  }
+
+  @Test
   fun resolves_text_typography_identity() {
     // #1934: a text node must surface *which face* it's drawn in — size, family, weight, style,
     // letter spacing, line height — all under the `typography` object (size folded in by #1903).
@@ -339,4 +361,14 @@ class DesktopSemanticsTokensTest {
     assertNotNull("chip must carry resolved tokens", tokens)
     assertEquals("#FFCAC4D0", tokens!!.borderColor)
   }
+}
+
+private class AnimatedShapeState(val morphedShape: Shape)
+
+private class AnimatedShapeWrapper(private val state: AnimatedShapeState) : Shape {
+  override fun createOutline(
+    size: Size,
+    layoutDirection: LayoutDirection,
+    density: Density,
+  ): Outline = state.morphedShape.createOutline(size, layoutDirection, density)
 }

--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
@@ -996,7 +996,26 @@ internal object ComposeLayoutInspector {
       inspectable?.nameFallback?.takeIf { it.isNotBlank() } ?: modifier.javaClass.simpleName
     val value = inspectable?.valueOverride?.wireValue()
     val properties =
-      inspectable?.inspectableElements?.associate { it.name to it.value.wireValue() }.orEmpty()
+      inspectable
+        ?.inspectableElements
+        ?.associate { it.name to it.value.wireValue() }
+        .orEmpty()
+        .toMutableMap()
+    // Desktop/release Compose commonly compiles `BackgroundElement` inspector properties out, so
+    // a `Modifier.background(Brush…)` otherwise serialises as an empty modifier and the figma-svg
+    // model cannot distinguish a real gradient from an unpainted node. Carry only the presence /
+    // identity string of the brush; hybrid export uses it as the signal to crop the complete layer
+    // from the rendered frame rather than silently dropping the paint.
+    if (
+      "brush" !in properties &&
+        (name == "background" || modifier.javaClass.simpleName == "BackgroundElement")
+    ) {
+      runCatching {
+          modifier.javaClass.getDeclaredField("brush").apply { isAccessible = true }.get(modifier)
+        }
+        .getOrNull()
+        ?.let { properties["brush"] = it.wireValue() }
+    }
     return LayoutInspectorModifier(
       name = name,
       value = value,

--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ModifierTokenResolver.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ModifierTokenResolver.kt
@@ -124,14 +124,15 @@ internal object ModifierTokenResolver {
       val nodeShape =
         if (isPlaceholderShapeModifier(name, simpleName)) null else shapeOf(mod, elements)
       if (nodeShape != null) {
-        if (cornerRadius == null) cornerRadius = nodeShape.cornerRadiusWire(minSidePx, density)
+        val effectiveShape = nodeShape.effectiveCornerShape()
+        if (cornerRadius == null) cornerRadius = effectiveShape.cornerRadiusWire(minSidePx, density)
         // A `RoundedCornerShape(<px>f)` has no dp `cornerRadius`; capture its raw-pixel radii so
         // the
         // figma-svg export can still round the corner instead of dropping to a sharp rect.
         if (cornerRadius == null && cornerRadiusPx == null) {
-          cornerRadiusPx = nodeShape.cornerRadiusPxWire()
+          cornerRadiusPx = effectiveShape.cornerRadiusPxWire()
         }
-        if (shape == null) shape = nodeShape.shapeDescriptor()
+        if (shape == null) shape = effectiveShape.shapeDescriptor()
       }
     }
     val gap = arrangementGapWire(measurePolicy)
@@ -509,6 +510,32 @@ internal object ModifierTokenResolver {
           as? Shape
       }
       .getOrNull()
+  }
+
+  /**
+   * Material 3 expressive buttons expose their clipping shape through the anonymous
+   * `rememberAnimatedShape` wrapper. The wrapper is a [Shape], but not a `CornerBasedShape`, so its
+   * effective corners live on the wrapper's `state.morphedShape` and the ordinary corner getters
+   * above cannot see them. Resolve that current shape reflectively rather than coupling this module
+   * to Material 3 internals.
+   *
+   * This is deliberately a narrow fallback: normal corner shapes retain their direct getter path,
+   * and an unknown shape without a state exposing `getMorphedShape()` is returned unchanged.
+   */
+  private fun Shape.effectiveCornerShape(): Shape {
+    if (invokeNoArg("getTopStart") != null) return this
+    return javaClass.declaredFields
+      .asSequence()
+      .filter { it.name.endsWith("state", ignoreCase = true) }
+      .mapNotNull { field ->
+        runCatching {
+            field.isAccessible = true
+            field.get(this)
+          }
+          .getOrNull()
+      }
+      .mapNotNull { state -> state.invokeNoArg("getMorphedShape") as? Shape }
+      .firstOrNull() ?: this
   }
 
   /**

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgModel.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgModel.kt
@@ -536,17 +536,12 @@ data class FigmaSvgModel(
           raster = FigmaSvgRaster(href),
         )
       }
-      // A container filled by a `Modifier.paint(painter)` whose painter is NOT a plain
-      // `ColorPainter`
-      // — a component's private `Painter` (Wear `SwitchButton`'s animated colour painter, a
-      // lazy-list `BackgroundPainter`), a `BitmapPainter`, a gradient — leaves `backgroundColor`
-      // unresolved, so the fill would silently vanish from a vector-only export (the pill/card just
-      // disappears). We can't teach the token resolver every component's private painter type, so
-      // fall back to the frame: in hybrid mode capture the painted region as an `<image>` (exactly
-      // as an opaque `Image`/`Icon` is handled) and drop the subtree. The ONLY painter we can turn
-      // into a flat vector fill is a `ColorPainter`, so "the painter isn't `ColorPainter(...)`" is
-      // the general signal to raster — no per-class knowledge, keyed only off the captured painter
-      // string + the modifier's own drawn bounds.
+      // A container filled by paint the token model cannot flatten — a non-ColorPainter
+      // `Modifier.paint`, or a brush-backed `Modifier.background` — leaves `backgroundColor`
+      // unresolved, so the fill would silently vanish. Fall back to the frame in hybrid mode:
+      // capture the complete painted region as an `<image>` and drop its subtree. Rasterising the
+      // complete layer is deliberate for brush containers with text/children: a background-only
+      // crop is unavailable, and keeping editable descendants would draw them twice.
       if (
         ctx.captureCanvasDraws && tokens?.backgroundColor == null && hasUnvectorizablePaintFill()
       ) {
@@ -828,12 +823,18 @@ data class FigmaSvgModel(
       setOf("paint", "PainterElement", "content", "ContentPainterElement", "ContentPainterModifier")
 
     /**
-     * True when this node is filled by a `Modifier.paint` painter we can't turn into a flat colour.
-     * The token resolver only reads a plain [androidx.compose.ui.graphics.painter.ColorPainter]
-     * (whose captured string is `ColorPainter(color=Color(…))`); any other painter — a component's
-     * private `Painter`, a `BitmapPainter`, a gradient — stringifies to a class name and leaves the
-     * fill unresolved. Recognising the one painter we CAN vectorise (and rastering everything else)
-     * keeps this free of per-component knowledge: a painter present but of any other form ⇒ raster.
+     * True when this node is filled by paint we can't turn into a flat colour.
+     *
+     * A brush-backed `Modifier.background` is always unvectorisable in the current model. The
+     * connector explicitly carries a `brush` property even when Compose compiled inspector metadata
+     * out, so a gradient cannot be mistaken for an unpainted node.
+     *
+     * For `Modifier.paint`, the token resolver only reads a plain
+     * [androidx.compose.ui.graphics.painter.ColorPainter] (whose captured string is
+     * `ColorPainter(color=Color(…))`); any other painter — a component's private `Painter`, a
+     * `BitmapPainter`, a gradient — stringifies to a class name and leaves the fill unresolved.
+     * Recognising the one painter we CAN vectorise (and rastering everything else) keeps this free
+     * of per-component knowledge: a painter present but of any other form ⇒ raster.
      *
      * The one caveat is a `ColorPainter` carrying a `colorFilter`: the string still starts with
      * `ColorPainter(`, but the resolver deliberately leaves the fill unresolved because a
@@ -846,6 +847,11 @@ data class FigmaSvgModel(
      * vector export could read from it — raster.
      */
     private fun LayoutInspectorNode.hasUnvectorizablePaintFill(): Boolean {
+      val brushBackground = modifiers.firstOrNull {
+        (it.name == "background" || it.name == "BackgroundElement") &&
+          it.properties["brush"]?.let { brush -> brush != "null" } == true
+      }
+      if (brushBackground != null) return true
       val paint = modifiers.firstOrNull { it.name in PAINT_FILL_MODIFIERS } ?: return false
       val painter = paint.properties["painter"] ?: return true
       if (!painter.startsWith("ColorPainter(")) return true
@@ -855,8 +861,13 @@ data class FigmaSvgModel(
 
     /** The region a paint-fill painter actually covers — its modifier bounds, else the node box. */
     private fun LayoutInspectorNode.paintFillRegion(): LayoutInspectorBounds =
-      modifiers.firstOrNull { it.name in PAINT_FILL_MODIFIERS && it.bounds != null }?.bounds
-        ?: bounds
+      modifiers
+        .firstOrNull {
+          (it.name in PAINT_FILL_MODIFIERS ||
+            it.name == "background" ||
+            it.name == "BackgroundElement") && it.bounds != null
+        }
+        ?.bounds ?: bounds
 
     /** The Compose modifiers that paint via an imperative Canvas the token export can't read. */
     private val DRAW_MODIFIERS = setOf("drawBehind", "drawWithContent", "drawWithCache")

--- a/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvgTest.kt
+++ b/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvgTest.kt
@@ -871,6 +871,48 @@ class FigmaLayeredSvgTest {
   }
 
   @Test
+  fun aBrushBackgroundRastersTheCompleteLayerInHybridMode() {
+    val node =
+      LayoutInspectorNode(
+        nodeId = "gradient",
+        component = "BoxMeasurePolicy",
+        bounds = bounds(12, 20, 212, 68),
+        size = LayoutInspectorSize(200, 48),
+        modifiers =
+          listOf(
+            LayoutInspectorModifier(
+              name = "BackgroundElement",
+              properties = mapOf("brush" to "LinearGradient(colors=[red, blue])"),
+              bounds = bounds(12, 20, 212, 68),
+            )
+          ),
+        children =
+          listOf(
+            layoutNode(
+              "GradientLabel",
+              24,
+              30,
+              160,
+              58,
+              tokens = ComposeSemanticsTokens(backgroundColor = "#FFFFFFFF"),
+            )
+          ),
+      )
+
+    val svg =
+      FigmaLayeredSvg.render(
+        FigmaSvgModel.from(LayoutInspectorPayload(node), captureCanvasDraws = true)
+      )
+
+    assertTrue("the gradient layer must survive as rendered pixels", svg.contains("<image "))
+    assertTrue(svg.contains("""x="12" y="20" width="200" height="48""""))
+    assertFalse(
+      "the composited raster already contains descendants, so they must not be drawn twice",
+      svg.contains("""id="GradientLabel""""),
+    )
+  }
+
+  @Test
   fun aCoil3AsyncImageContentPainterRastersFromTheFrameInHybridMode() {
     // Coil 3's `AsyncImage` draws through its own `ContentPainterElement` (inspector name
     // `content`, carrying `request`/`imageLoader` but no `painter` property) on a `Layout` whose


### PR DESCRIPTION
## Summary

- rasterize the complete affected layer when a Compose `Brush` background cannot be represented faithfully
- resolve Material 3 expressive animated shape wrappers to their live rounded/circle shape
- cover gradient pixels, subtree deduplication, and animated corner resolution

## Tests

- `:daemon:android:testDebugUnitTest` brush-background render regression
- `:daemon:desktop:test` semantics/token regressions
- `:data-layoutinspector-core:test`
- formatting checks for affected modules

Fixes #2852