### PR TITLE
fix(figma-svg): preserve graphics-layer transforms

### DIFF
--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/RenderEngineTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/RenderEngineTest.kt
@@ -465,6 +465,49 @@ class RenderEngineTest {
   }
 
   @Test
+  fun figmaSvgExportPreservesGraphicsLayerAlphaAndVectorAspectRatio() {
+    val outputDir = tempFolder.newFolder("renders-figma-transforms")
+    System.setProperty(RenderEngine.OUTPUT_DIR_PROP, outputDir.absolutePath)
+    System.setProperty("roborazzi.test.record", "true")
+    val host = RobolectricHost()
+    host.start()
+    try {
+      host.submit(
+        RenderRequest.Render(
+          payload =
+            "className=ee.schimke.composeai.daemon.RedFixturePreviewsKt;" +
+              "functionName=GraphicsLayerAndWideVector;" +
+              "widthPx=96;heightPx=48;density=1.0;" +
+              "showBackground=true;outputBaseName=figma-transforms"
+        ),
+        timeoutMs = 120_000,
+      )
+
+      val svg =
+        outputDir.parentFile!!
+          .resolve("data")
+          .resolve("figma-transforms")
+          .resolve("compose-figma.svg")
+          .readText()
+      assertTrue("alpha-zero graphics layer must remain transparent", svg.contains("""opacity="0""""))
+      assertTrue("the ImageVector must remain an editable path", svg.contains("<path "))
+
+      val scales =
+        Regex("""scale\(([-0-9.]+) ([-0-9.]+)\)""")
+          .findAll(svg)
+          .map { it.groupValues[1].toDouble() to it.groupValues[2].toDouble() }
+          .toList()
+      assertTrue("the wide vector must emit a scale transform", scales.isNotEmpty())
+      assertTrue(
+        "a square viewport must never be stretched non-uniformly: $scales",
+        scales.all { (x, y) -> abs(x - y) < 0.0001 },
+      )
+    } finally {
+      host.shutdown()
+    }
+  }
+
+  @Test
   fun figmaSvgLongRenderModeProducesFullPageSvg() {
     // Parity with the desktop backend: the `figma-svg-long` render mode grows the viewport until a
     // virtualised LazyColumn composes every row, sizes to content, and writes the full-page SVG to

--- a/daemon/android/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
+++ b/daemon/android/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
@@ -36,9 +37,13 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.painter.ColorPainter
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
 import androidx.compose.ui.input.pointer.changedToUp
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.input.rotary.onRotaryScrollEvent
@@ -202,6 +207,45 @@ fun EmojiAndAnnotatedText() {
       },
       modifier = Modifier.testTag("annotated"),
       style = TextStyle(fontFamily = FontFamily.SansSerif, fontSize = 16.sp),
+    )
+  }
+}
+
+/**
+ * Android end-to-end fixture for #2853: a transparent graphics-layer container beside a square
+ * vector painter measured into a deliberately non-square slot.
+ */
+@Composable
+fun GraphicsLayerAndWideVector() {
+  val diamond =
+    ImageVector.Builder(
+        defaultWidth = 24.dp,
+        defaultHeight = 24.dp,
+        viewportWidth = 24f,
+        viewportHeight = 24f,
+      )
+      .apply {
+        path(fill = SolidColor(Color.White)) {
+          moveTo(12f, 0f)
+          lineTo(24f, 12f)
+          lineTo(12f, 24f)
+          lineTo(0f, 12f)
+          close()
+        }
+      }
+      .build()
+
+  Row(modifier = Modifier.fillMaxSize().background(Color.Black)) {
+    Box(
+      Modifier.testTag("hidden-circle")
+        .size(40.dp)
+        .graphicsLayer { alpha = 0f }
+        .background(Color.Blue, RoundedCornerShape(20.dp))
+    )
+    Icon(
+      imageVector = diamond,
+      contentDescription = "diamond",
+      modifier = Modifier.testTag("wide-vector").size(width = 48.dp, height = 16.dp),
     )
   }
 }

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopLayoutInspectorTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopLayoutInspectorTest.kt
@@ -126,6 +126,11 @@ class DesktopLayoutInspectorTest {
     val layer = root.firstWhere { it.tokens?.backgroundColor == "#FFFF0000" }
     assertNotNull("the transformed layer must be captured", layer)
     assertEquals("effective graphicsLayer alpha", 0.25, layer!!.tokens!!.opacity!!, 0.001)
+    val graphicsLayer =
+      layer.modifiers.firstOrNull {
+        it.name == "graphicsLayer" || it.name.contains("GraphicsLayer")
+      }
+    assertEquals("ordered graphicsLayer alpha", "0.25", graphicsLayer?.properties?.get("alpha"))
     // Translation and scale are already applied by LayoutCoordinates.boundsIn(root), so the
     // exporter must not apply them a second time.
     assertEquals(LayoutInspectorBounds(left = 27, top = 14, right = 67, bottom = 44), layer.bounds)

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopLayoutInspectorTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopLayoutInspectorTest.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.painter.BitmapPainter
 import androidx.compose.ui.graphics.painter.ColorPainter
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -26,6 +27,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
+import ee.schimke.composeai.data.layoutinspector.LayoutInspectorBounds
 import ee.schimke.composeai.data.layoutinspector.LayoutInspectorNode
 import ee.schimke.composeai.data.layoutinspector.LayoutInspectorPayload
 import java.io.File
@@ -102,6 +104,31 @@ class DesktopLayoutInspectorTest {
     // reflection walk reaches `LayoutNode` children after `scene.render()` Z-sorts the tree.
     assertTrue("root must have a measured width", root.size.width > 0)
     assertTrue("root must have a non-empty subtree", root.children.isNotEmpty())
+  }
+
+  @Test
+  fun captures_effective_graphics_layer_alpha() {
+    val root = writeAndRead {
+      Box(
+        Modifier.testTag("layer")
+          .size(80.dp, 40.dp)
+          .graphicsLayer {
+            alpha = 0.25f
+            scaleX = 0.5f
+            scaleY = 0.75f
+            translationX = 7f
+            translationY = 9f
+          }
+          .background(Color.Red)
+      )
+    }
+
+    val layer = root.firstWhere { it.tokens?.backgroundColor == "#FFFF0000" }
+    assertNotNull("the transformed layer must be captured", layer)
+    assertEquals("effective graphicsLayer alpha", 0.25, layer!!.tokens!!.opacity!!, 0.001)
+    // Translation and scale are already applied by LayoutCoordinates.boundsIn(root), so the
+    // exporter must not apply them a second time.
+    assertEquals(LayoutInspectorBounds(left = 27, top = 14, right = 67, bottom = 44), layer.bounds)
   }
 
   @Test

--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
@@ -1088,6 +1088,12 @@ internal object ComposeLayoutInspector {
         .getOrNull()
         ?.let { properties["brush"] = it.wireValue() }
     }
+    if (
+      "alpha" !in properties &&
+        (name == "graphicsLayer" || modifier.javaClass.simpleName.contains("GraphicsLayer"))
+    ) {
+      ModifierTokenResolver.graphicsLayerAlpha(this)?.let { properties["alpha"] = it.toString() }
+    }
     return LayoutInspectorModifier(
       name = name,
       value = value,

--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ModifierTokenResolver.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ModifierTokenResolver.kt
@@ -174,7 +174,7 @@ internal object ModifierTokenResolver {
    * only expose the block itself, but their [ModifierInfo.coordinates] coordinator retains the
    * evaluated `ReusableGraphicsLayerScope`; direct overloads may expose `alpha` on the element.
    */
-  private fun graphicsLayerAlpha(info: ModifierInfo): Double? {
+  internal fun graphicsLayerAlpha(info: ModifierInfo): Double? {
     val scope = reflectedField(info.coordinates, "graphicsLayerScope")
     val effective =
       scope?.let { reflectedFloat(it, "alpha") }

--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ModifierTokenResolver.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ModifierTokenResolver.kt
@@ -55,6 +55,7 @@ internal object ModifierTokenResolver {
     var elevation: String? = null
     var minWidth: String? = null
     var minHeight: String? = null
+    var opacity = 1.0
     // `CircleShape` / `CornerSize(50%)` resolve to dp against the node's shorter measured side.
     val minSidePx = minOf(sizeWidthPx, sizeHeightPx)
     for (info in modifierInfo) {
@@ -71,6 +72,7 @@ internal object ModifierTokenResolver {
       // graphicsLayers
       // — a clip and the shadow). Skipped when zero (a clip-only graphicsLayer).
       if (name == "graphicsLayer" || simpleName.contains("GraphicsLayer")) {
+        graphicsLayerAlpha(info)?.let { opacity *= it }
         shadowElevationDp(mod, elements, density)?.let { dp ->
           if (elevation == null || dp > (elevation.removeSuffix("dp").toDoubleOrNull() ?: 0.0)) {
             elevation = "${dp}dp"
@@ -145,6 +147,7 @@ internal object ModifierTokenResolver {
         gap == null &&
         padding == null &&
         elevation == null &&
+        opacity >= 0.999 &&
         minWidth == null &&
         minHeight == null
     )
@@ -162,8 +165,42 @@ internal object ModifierTokenResolver {
         gap = gap,
         padding = padding,
         elevation = elevation,
+        opacity = opacity.takeIf { it < 0.999 },
       )
   }
+
+  /**
+   * Effective alpha of one graphics-layer modifier. Lambda-based `graphicsLayer { … }` elements
+   * only expose the block itself, but their [ModifierInfo.coordinates] coordinator retains the
+   * evaluated `ReusableGraphicsLayerScope`; direct overloads may expose `alpha` on the element.
+   */
+  private fun graphicsLayerAlpha(info: ModifierInfo): Double? {
+    val scope = reflectedField(info.coordinates, "graphicsLayerScope")
+    val effective =
+      scope?.let { reflectedFloat(it, "alpha") }
+        ?: reflectedFloat(info.modifier, "alpha")
+        ?: (info.modifier as? InspectableValue)
+          ?.inspectableElements
+          ?.firstOrNull { it.name == "alpha" }
+          ?.value
+          ?.let(::floatValue)
+    return effective?.coerceIn(0f, 1f)?.toDouble()
+  }
+
+  private fun reflectedFloat(instance: Any, name: String): Float? =
+    reflectedField(instance, name)?.let(::floatValue)
+
+  private fun reflectedField(instance: Any, name: String): Any? =
+    generateSequence(instance.javaClass as Class<*>?) { it.superclass }
+      .flatMap { it.declaredFields.asSequence() }
+      .firstOrNull { it.name == name }
+      ?.let { field ->
+        runCatching {
+            field.isAccessible = true
+            field.get(instance)
+          }
+          .getOrNull()
+      }
 
   /**
    * The shadow elevation of a `graphicsLayer`/`shadow` modifier in dp, or null when it casts no

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/ComposeSemanticsModels.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/ComposeSemanticsModels.kt
@@ -36,11 +36,12 @@ object ComposeSemanticsProduct {
   // px relative to the node's top-left) for wrapped text, so the figma-svg export places one run
   // per line at the render's break points instead of collapsing the string onto one baseline.
   // Additive; older entries decode with `lines = null` (single-line rendering).
+  // v9: `tokens` may carry `opacity`, the effective alpha of the node's graphics layers. Additive;
+  // older entries decode it as null (fully opaque).
   // v10 (#2854): typography may carry effective styled `spans`, and wrapped line entries carry
   // their UTF-16 start/end offsets. This preserves the paragraph face across AnnotatedString runs
   // while retaining explicit per-span overrides (for example Karla body text with a monospace code
   // span). Additive; older entries decode with `spans = null` and line offsets unset.
-  // v9 is reserved by the independent graphics-layer export change in #2853.
   const val SCHEMA_VERSION: Int = 10
   const val FILE: String = "compose-semantics.json"
 }
@@ -69,7 +70,9 @@ object LayoutInspectorProduct {
   // `Icon`/`Image`'s `ImageVector` or (draw-capture) from a control's imperative draw lambda; its
   // paths may carry `strokeCap` / `strokeJoin` (SVG linecap/linejoin) for round-capped chrome.
   // Additive — older entries parse with `vectorGraphic = null` and paths with butt/miter defaults.
-  const val SCHEMA_VERSION: Int = 6
+  // v7: `tokens` may carry effective graphics-layer `opacity`. Additive; older entries decode it
+  // as null (fully opaque).
+  const val SCHEMA_VERSION: Int = 7
   const val FILE: String = "layout-inspector.json"
 }
 
@@ -379,6 +382,12 @@ data class ComposeSemanticsTokens(
    * so an elevated surface carries its shadow instead of reading as a flat fill against the render.
    */
   val elevation: String? = null,
+  /**
+   * Effective alpha of the node's `graphicsLayer` chain (`0.0` transparent, `1.0` opaque).
+   * Translation and scale are already reflected in captured bounds; alpha is not, so the figma-svg
+   * exporter applies this value to the layer group. Null is the common fully-opaque case.
+   */
+  val opacity: Double? = null,
 )
 
 /** Per-edge insets in dp (`"16.0dp"`), as resolved from `Modifier.padding` (issue #1897). */

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/ComposeSemanticsModels.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/ComposeSemanticsModels.kt
@@ -450,10 +450,10 @@ data class LayoutInspectorNode(
 /**
  * An editable vector graphic (an `ImageVector` an `Icon`/`Image` painted) captured off a node's
  * `VectorPainter`. Path coordinates are in the vector's own viewport ([viewportWidth] ×
- * [viewportHeight]); the figma-svg export scales+translates them onto the node's placed bounds, so
- * the same icon renders crisp at any component size. Only solid (`SolidColor`) fills/strokes are
- * captured — a gradient/brush leaves its colour null and the export drops that fill rather than
- * guessing — matching the vector-vs-raster rule the rest of the export follows.
+ * [viewportHeight]); the figma-svg export uniformly scales and centers them in the node's placed
+ * bounds, so the same icon renders crisp without changing aspect ratio. Only solid (`SolidColor`)
+ * fills/strokes are captured — a gradient/brush leaves its colour null and the export drops that
+ * fill rather than guessing — matching the vector-vs-raster rule the rest of the export follows.
  */
 @Serializable
 data class LayoutInspectorVectorGraphic(

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvg.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvg.kt
@@ -129,6 +129,7 @@ object FigmaLayeredSvg {
     options: Options,
     familyOverrides: Map<String, String>,
     depth: Int,
+    inheritedOpacity: Double = 1.0,
     // Monotonic counter for curved-text `<path>` ids, threaded through the whole walk so every arc
     // gets a document-unique id even when two `CurvedLayout`s share a component name — otherwise
     // duplicate ids make a later `<textPath href>` resolve to the first path (Codex #2395).
@@ -138,9 +139,9 @@ object FigmaLayeredSvg {
     // An opaque layer is a leaf `<image>` — the background-free raster stands in for a subtree the
     // exporter can't vectorise. No shape/text/children; the group keeps the composable name.
     if (layer.raster != null) {
-      sb
-        .append("""$indent<g id="${escapeAttr(layer.name)}"${opacityAttr(layer.opacity)}>""")
-        .append('\n')
+      // Raster crops come from the final composited frame, so every ancestor/local graphics-layer
+      // alpha is already baked into the pixels. Reapplying it here would fade the crop twice.
+      sb.append("""$indent<g id="${escapeAttr(layer.name)}">""").append('\n')
       sb.append(indent).append("  ").append(image(layer, layer.raster)).append('\n')
       sb.append("$indent</g>\n")
       return
@@ -149,7 +150,7 @@ object FigmaLayeredSvg {
     // transform that maps the vector's own viewport onto the layer's placed box — the vector
     // alternative to the `<image>` leaf above. Also a leaf: an icon's art has no editable subtree.
     if (layer.vector != null) {
-      sb.append(vectorGroup(layer, layer.vector, indent)).append('\n')
+      sb.append(vectorGroup(layer, layer.vector, indent, inheritedOpacity)).append('\n')
       return
     }
     val tokenName = layer.fill?.tokenName ?: layer.stroke?.tokenName
@@ -162,8 +163,11 @@ object FigmaLayeredSvg {
     val filterAttr =
       if (layer.elevationPx >= 1.0) """ filter="url(#${shadowFilterId(layer.elevationPx)})""""
       else ""
+    val containsRaster = layer.containsCapturedRaster()
+    val outerOpacity = inheritedOpacity * layer.opacity
+    val namedGroupOpacity = if (containsRaster) 1.0 else outerOpacity
     sb.append(
-      """$indent<g id="${escapeAttr(layer.name)}"$dataToken$filterAttr${opacityAttr(layer.opacity)}>"""
+      """$indent<g id="${escapeAttr(layer.name)}"$dataToken$filterAttr${opacityAttr(namedGroupOpacity)}>"""
     )
     sb.append('\n')
     if (options.annotateTokens && tokenName != null) {
@@ -177,25 +181,109 @@ object FigmaLayeredSvg {
     layer.background?.let { bg ->
       sb.append(indent).append("  ").append(backgroundImage(bg)).append('\n')
     }
-    if (layer.fill != null || layer.stroke != null) {
-      sb.append(indent).append("  ").append(shape(layer)).append('\n')
+    if (containsRaster) {
+      // A group containing a final-frame crop cannot carry inherited opacity without fading that
+      // crop twice. Apply the outer alpha only to this layer's vector shape, then thread the
+      // combined outer/content alpha into editable descendants; raster leaves deliberately ignore
+      // it above.
+      if (layer.fill != null || layer.stroke != null) {
+        appendOpacityGroup(sb, indent + "  ", outerOpacity) {
+          sb.append(indent).append("    ").append(shape(layer)).append('\n')
+        }
+      }
+      val contentOpacity = outerOpacity * layer.contentOpacity
+      if (layer.text != null || layer.curvedTexts.isNotEmpty()) {
+        appendOpacityGroup(sb, indent + "  ", contentOpacity) {
+          appendTextContent(layer, sb, options, familyOverrides, indent + "    ", curveSeq)
+        }
+      }
+      for (child in layer.children) {
+        renderLayer(
+          child,
+          sb,
+          options,
+          familyOverrides,
+          depth + 1,
+          inheritedOpacity = contentOpacity,
+          curveSeq = curveSeq,
+        )
+      }
+    } else {
+      if (layer.fill != null || layer.stroke != null) {
+        sb.append(indent).append("  ").append(shape(layer)).append('\n')
+      }
+      val hasInnerContent =
+        layer.text != null || layer.curvedTexts.isNotEmpty() || layer.children.isNotEmpty()
+      if (hasInnerContent && layer.contentOpacity < 0.999) {
+        sb
+          .append(indent)
+          .append("  ")
+          .append("""<g${opacityAttr(layer.contentOpacity)}>""")
+          .append('\n')
+        appendTextContent(layer, sb, options, familyOverrides, indent + "    ", curveSeq)
+        for (child in layer.children) {
+          renderLayer(
+            child,
+            sb,
+            options,
+            familyOverrides,
+            depth + 2,
+            inheritedOpacity = 1.0,
+            curveSeq = curveSeq,
+          )
+        }
+        sb.append(indent).append("  </g>\n")
+      } else {
+        appendTextContent(layer, sb, options, familyOverrides, indent + "  ", curveSeq)
+        for (child in layer.children) {
+          renderLayer(
+            child,
+            sb,
+            options,
+            familyOverrides,
+            depth + 1,
+            inheritedOpacity = 1.0,
+            curveSeq = curveSeq,
+          )
+        }
+      }
     }
-    if (layer.text != null) {
-      sb.append(indent).append("  ").append(text(layer, options, familyOverrides)).append('\n')
-    }
-    layer.curvedTexts.forEach { ct ->
-      sb.append(indent).append("  ").append(curvedText(ct, "c${curveSeq[0]++}")).append('\n')
-    }
-    for (child in layer.children) renderLayer(
-      child,
-      sb,
-      options,
-      familyOverrides,
-      depth + 1,
-      curveSeq,
-    )
     sb.append("$indent</g>\n")
   }
+
+  private fun appendTextContent(
+    layer: FigmaSvgLayer,
+    sb: StringBuilder,
+    options: Options,
+    familyOverrides: Map<String, String>,
+    indent: String,
+    curveSeq: IntArray,
+  ) {
+    if (layer.text != null) {
+      sb.append(indent).append(text(layer, options, familyOverrides)).append('\n')
+    }
+    layer.curvedTexts.forEach { ct ->
+      sb.append(indent).append(curvedText(ct, "c${curveSeq[0]++}")).append('\n')
+    }
+  }
+
+  private inline fun appendOpacityGroup(
+    sb: StringBuilder,
+    indent: String,
+    opacity: Double,
+    content: () -> Unit,
+  ) {
+    if (opacity >= 0.999) {
+      content()
+      return
+    }
+    sb.append(indent).append("""<g${opacityAttr(opacity)}>""").append('\n')
+    content()
+    sb.append(indent).append("</g>\n")
+  }
+
+  private fun FigmaSvgLayer.containsCapturedRaster(): Boolean =
+    raster != null || background != null || children.any { it.containsCapturedRaster() }
 
   /**
    * A Wear curved-text run (a `TimeText` clock) as an SVG `<textPath>` on its baseline arc. The
@@ -277,26 +365,47 @@ object FigmaLayeredSvg {
       """width="${bg.width}" height="${bg.height}"/>"""
 
   /**
-   * A captured icon [FigmaSvgVector] as a named `<g>` holding a centered, uniform fit transform.
-   * Compose's `VectorPainter` preserves the viewport aspect ratio when the layout node and vector
-   * have different shapes; stretching X and Y independently flattened icons captured from
-   * animated/transitioning content into wide slivers.
+   * A captured icon [FigmaSvgVector] fitted in its pre-transform layout slot, then mapped through
+   * the captured placed bounds. This preserves the normal aspect fit while retaining an explicit
+   * nonuniform graphics-layer scale; `ContentScale.FillBounds` opts directly into a stretched fit.
    */
-  private fun vectorGroup(layer: FigmaSvgLayer, vec: FigmaSvgVector, indent: String): String {
-    val sx = if (vec.viewportWidth > 0f) layer.width / vec.viewportWidth.toDouble() else 1.0
-    val sy = if (vec.viewportHeight > 0f) layer.height / vec.viewportHeight.toDouble() else 1.0
-    val scale = minOf(sx, sy)
-    val fittedWidth = vec.viewportWidth.toDouble() * scale
-    val fittedHeight = vec.viewportHeight.toDouble() * scale
+  private fun vectorGroup(
+    layer: FigmaSvgLayer,
+    vec: FigmaSvgVector,
+    indent: String,
+    inheritedOpacity: Double,
+  ): String {
+    val layoutWidth = vec.layoutWidth.takeIf { it > 0 }?.toDouble() ?: layer.width.toDouble()
+    val layoutHeight = vec.layoutHeight.takeIf { it > 0 }?.toDouble() ?: layer.height.toDouble()
+    val scaleX: Double
+    val scaleY: Double
+    if (vec.fillBounds) {
+      scaleX = if (vec.viewportWidth > 0f) layer.width / vec.viewportWidth.toDouble() else 1.0
+      scaleY = if (vec.viewportHeight > 0f) layer.height / vec.viewportHeight.toDouble() else 1.0
+    } else {
+      val layoutScale =
+        minOf(
+          layoutWidth / vec.viewportWidth.toDouble(),
+          layoutHeight / vec.viewportHeight.toDouble(),
+        )
+      val placedScaleX = if (layoutWidth > 0.0) layer.width / layoutWidth else 1.0
+      val placedScaleY = if (layoutHeight > 0.0) layer.height / layoutHeight else 1.0
+      scaleX = layoutScale * placedScaleX
+      scaleY = layoutScale * placedScaleY
+    }
+    val fittedWidth = vec.viewportWidth.toDouble() * scaleX
+    val fittedHeight = vec.viewportHeight.toDouble() * scaleY
     val x = layer.left + (layer.width - fittedWidth) / 2.0
     val y = layer.top + (layer.height - fittedHeight) / 2.0
     val sb = StringBuilder()
     sb
-      .append("""$indent<g id="${escapeAttr(layer.name)}"${opacityAttr(layer.opacity)}>""")
+      .append(
+        """$indent<g id="${escapeAttr(layer.name)}"${opacityAttr(inheritedOpacity * layer.opacity)}>"""
+      )
       .append('\n')
     sb
       .append(
-        """$indent  <g transform="translate(${fmt(x)} ${fmt(y)}) scale(${fmt(scale)} ${fmt(scale)})">"""
+        """$indent  <g transform="translate(${fmt(x)} ${fmt(y)}) scale(${fmt(scaleX)} ${fmt(scaleY)})"${opacityAttr(layer.contentOpacity)}>"""
       )
       .append('\n')
     for (p in vec.paths) sb.append(indent).append("    ").append(vectorPath(p)).append('\n')

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvg.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvg.kt
@@ -273,18 +273,24 @@ object FigmaLayeredSvg {
       """width="${bg.width}" height="${bg.height}"/>"""
 
   /**
-   * A captured icon [FigmaSvgVector] as a named `<g>` holding a `translate(left,top)
-   * scale(w/viewportW, h/viewportH)` group of `<path>`s — the vector's viewport coordinates mapped
-   * onto the layer's placed box, so the icon draws crisp at the component's actual size.
+   * A captured icon [FigmaSvgVector] as a named `<g>` holding a centered, uniform fit transform.
+   * Compose's `VectorPainter` preserves the viewport aspect ratio when the layout node and vector
+   * have different shapes; stretching X and Y independently flattened icons captured from
+   * animated/transitioning content into wide slivers.
    */
   private fun vectorGroup(layer: FigmaSvgLayer, vec: FigmaSvgVector, indent: String): String {
     val sx = if (vec.viewportWidth > 0f) layer.width / vec.viewportWidth.toDouble() else 1.0
     val sy = if (vec.viewportHeight > 0f) layer.height / vec.viewportHeight.toDouble() else 1.0
+    val scale = minOf(sx, sy)
+    val fittedWidth = vec.viewportWidth.toDouble() * scale
+    val fittedHeight = vec.viewportHeight.toDouble() * scale
+    val x = layer.left + (layer.width - fittedWidth) / 2.0
+    val y = layer.top + (layer.height - fittedHeight) / 2.0
     val sb = StringBuilder()
     sb.append("""$indent<g id="${escapeAttr(layer.name)}">""").append('\n')
     sb
       .append(
-        """$indent  <g transform="translate(${layer.left} ${layer.top}) scale(${fmt(sx)} ${fmt(sy)})">"""
+        """$indent  <g transform="translate(${fmt(x)} ${fmt(y)}) scale(${fmt(scale)} ${fmt(scale)})">"""
       )
       .append('\n')
     for (p in vec.paths) sb.append(indent).append("    ").append(vectorPath(p)).append('\n')

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvg.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvg.kt
@@ -138,7 +138,9 @@ object FigmaLayeredSvg {
     // An opaque layer is a leaf `<image>` — the background-free raster stands in for a subtree the
     // exporter can't vectorise. No shape/text/children; the group keeps the composable name.
     if (layer.raster != null) {
-      sb.append("""$indent<g id="${escapeAttr(layer.name)}">""").append('\n')
+      sb
+        .append("""$indent<g id="${escapeAttr(layer.name)}"${opacityAttr(layer.opacity)}>""")
+        .append('\n')
       sb.append(indent).append("  ").append(image(layer, layer.raster)).append('\n')
       sb.append("$indent</g>\n")
       return
@@ -160,7 +162,9 @@ object FigmaLayeredSvg {
     val filterAttr =
       if (layer.elevationPx >= 1.0) """ filter="url(#${shadowFilterId(layer.elevationPx)})""""
       else ""
-    sb.append("""$indent<g id="${escapeAttr(layer.name)}"$dataToken$filterAttr>""")
+    sb.append(
+      """$indent<g id="${escapeAttr(layer.name)}"$dataToken$filterAttr${opacityAttr(layer.opacity)}>"""
+    )
     sb.append('\n')
     if (options.annotateTokens && tokenName != null) {
       sb.append("""$indent  <title>${escape(layer.name)} · ${escape(tokenName)}</title>""")
@@ -287,7 +291,9 @@ object FigmaLayeredSvg {
     val x = layer.left + (layer.width - fittedWidth) / 2.0
     val y = layer.top + (layer.height - fittedHeight) / 2.0
     val sb = StringBuilder()
-    sb.append("""$indent<g id="${escapeAttr(layer.name)}">""").append('\n')
+    sb
+      .append("""$indent<g id="${escapeAttr(layer.name)}"${opacityAttr(layer.opacity)}>""")
+      .append('\n')
     sb
       .append(
         """$indent  <g transform="translate(${fmt(x)} ${fmt(y)}) scale(${fmt(scale)} ${fmt(scale)})">"""
@@ -312,6 +318,9 @@ object FigmaLayeredSvg {
       } else ""
     return """<path d="${escapeAttr(p.pathData)}" $fill$fillRule$stroke/>"""
   }
+
+  private fun opacityAttr(opacity: Double): String =
+    if (opacity < 0.999) """ opacity="${fmt(opacity.coerceIn(0.0, 1.0))}"""" else ""
 
   /**
    * A captured `#AARRGGBB` paint as an SVG colour + opacity pair (`fill="#RRGGBB"

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgModel.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgModel.kt
@@ -115,12 +115,16 @@ data class FigmaSvgRaster(val href: String)
 /**
  * An editable vector graphic (an `Icon`/`Image`'s `ImageVector`) emitted as real `<path>` layers —
  * the vector alternative to a [FigmaSvgRaster] leaf. Path coordinates are in the vector's own
- * [viewportWidth] × [viewportHeight]; the emitter uniformly scales and centers them in the layer's
- * placed box, matching `VectorPainter`'s aspect-preserving fit.
+ * [viewportWidth] × [viewportHeight]. [layoutWidth] × [layoutHeight] is the pre-transform layout
+ * slot, allowing the emitter to distinguish an intentionally transformed vector from a merely
+ * non-square slot. [fillBounds] preserves an explicit `ContentScale.FillBounds`.
  */
 data class FigmaSvgVector(
   val viewportWidth: Float,
   val viewportHeight: Float,
+  val layoutWidth: Int,
+  val layoutHeight: Int,
+  val fillBounds: Boolean = false,
   val paths: List<FigmaSvgVectorPath>,
 )
 
@@ -229,8 +233,10 @@ data class FigmaSvgLayer(
    * its drop shadow instead of reading as a flat fill against the render.
    */
   val elevationPx: Double = 0.0,
-  /** Effective `graphicsLayer` alpha for this layer and its subtree. */
+  /** Alpha from `graphicsLayer`s outside this layer's own drawing modifiers. */
   val opacity: Double = 1.0,
+  /** Alpha from `graphicsLayer`s inside this layer's own drawing modifiers. */
+  val contentOpacity: Double = 1.0,
   /**
    * Wear curved text (a `CurvedLayout`/`TimeText` clock) carried on this layer — drawn as an SVG
    * `<textPath>` along its baseline arc. Empty for the common straight-text/no-text case.
@@ -254,7 +260,8 @@ data class FigmaSvgLayer(
         vector != null ||
         background != null ||
         curvedTexts.isNotEmpty() ||
-        opacity < 0.999
+        opacity < 0.999 ||
+        contentOpacity < 0.999
 }
 
 /**
@@ -488,7 +495,11 @@ data class FigmaSvgModel(
      * gradient/brush-filled paths (whose colour the capture left null, matching the
      * vector-vs-raster rule: what we can't resolve to a flat paint, we don't emit as vector).
      */
-    private fun LayoutInspectorVectorGraphic.toFigmaSvgVector(): FigmaSvgVector? {
+    private fun LayoutInspectorVectorGraphic.toFigmaSvgVector(
+      layoutWidth: Int,
+      layoutHeight: Int,
+      fillBounds: Boolean,
+    ): FigmaSvgVector? {
       if (viewportWidth <= 0f || viewportHeight <= 0f) return null
       val emittable =
         paths
@@ -507,7 +518,15 @@ data class FigmaSvgModel(
             )
           }
       return if (emittable.isEmpty()) null
-      else FigmaSvgVector(viewportWidth, viewportHeight, emittable)
+      else
+        FigmaSvgVector(
+          viewportWidth = viewportWidth,
+          viewportHeight = viewportHeight,
+          layoutWidth = layoutWidth,
+          layoutHeight = layoutHeight,
+          fillBounds = fillBounds,
+          paths = emittable,
+        )
     }
 
     private fun LayoutInspectorNode.toLayer(
@@ -527,23 +546,30 @@ data class FigmaSvgModel(
       // origin, clamped to the parent, and use it everywhere below. Best-effort geometry for a
       // pathological capture; a normally-placed node keeps its real `bounds` untouched.
       val bounds = recoverBounds(parentBounds)
-      val opacity = tokens?.opacity?.coerceIn(0.0, 1.0) ?: 1.0
+      val (opacity, contentOpacity) = orderedOpacities()
       // An `Icon`/`Image` whose `ImageVector` the inspector captured emits as editable `<path>`
       // layers rather than a raster crop — the vector alternative to the opaque-by-name fallback
       // below. Placed before the raster branch so a vector-backed icon never rasterises; a
       // bitmap-backed one (no `vectorGraphic`) falls through and rasters as before. An empty/
       // gradient-only capture yields null and also falls through.
-      vectorGraphic?.toFigmaSvgVector()?.let { vec ->
-        return FigmaSvgLayer(
-          name = layerName(),
-          left = bounds.left,
-          top = bounds.top,
-          right = bounds.right,
-          bottom = bounds.bottom,
-          vector = vec,
-          opacity = opacity,
+      vectorGraphic
+        ?.toFigmaSvgVector(
+          layoutWidth = size.width,
+          layoutHeight = size.height,
+          fillBounds = hasFillBoundsContentScale(),
         )
-      }
+        ?.let { vec ->
+          return FigmaSvgLayer(
+            name = layerName(),
+            left = bounds.left,
+            top = bounds.top,
+            right = bounds.right,
+            bottom = bounds.bottom,
+            vector = vec,
+            opacity = opacity,
+            contentOpacity = contentOpacity,
+          )
+        }
       // An opaque component matched by name (Image/Icon/TextField/…) can't be vectorised at all —
       // emit an <image> for the whole node and drop the subtree.
       val opaqueByName = isOpaque(ctx.rasterComponents)
@@ -560,6 +586,7 @@ data class FigmaSvgModel(
           bottom = bounds.bottom,
           raster = FigmaSvgRaster(href),
           opacity = opacity,
+          contentOpacity = contentOpacity,
         )
       }
       // A container filled by paint the token model cannot flatten — a non-ColorPainter
@@ -584,6 +611,7 @@ data class FigmaSvgModel(
           bottom = region.bottom,
           raster = FigmaSvgRaster(href),
           opacity = opacity,
+          contentOpacity = contentOpacity,
         )
       }
       // A *leaf* node that paints via an imperative Canvas draw (`drawBehind`/`drawWithContent`) —
@@ -735,10 +763,48 @@ data class FigmaSvgModel(
         background = background,
         elevationPx = elevationPx,
         opacity = opacity,
+        contentOpacity = contentOpacity,
         curvedTexts = curvedTexts,
         children = children.map { it.toLayer(ctx, bounds) },
       )
     }
+
+    /**
+     * Split evaluated graphics-layer alpha at the first drawing modifier. Compose modifier order is
+     * outer-to-inner: `graphicsLayer().background()` fades the background and content, while
+     * `background().graphicsLayer()` leaves the background outside the faded content group.
+     */
+    private fun LayoutInspectorNode.orderedOpacities(): Pair<Double, Double> {
+      val alphas = modifiers.mapIndexedNotNull { index, modifier ->
+        modifier.properties["alpha"]?.toDoubleOrNull()?.coerceIn(0.0, 1.0)?.let { index to it }
+      }
+      if (alphas.isEmpty()) {
+        return (tokens?.opacity?.coerceIn(0.0, 1.0) ?: 1.0) to 1.0
+      }
+      val firstDraw =
+        modifiers.indexOfFirst { it.isDrawingModifier() }.takeIf { it >= 0 } ?: modifiers.size
+      val outer =
+        alphas.filter { it.first < firstDraw }.fold(1.0) { acc, (_, alpha) -> acc * alpha }
+      val content =
+        alphas.filter { it.first >= firstDraw }.fold(1.0) { acc, (_, alpha) -> acc * alpha }
+      return outer to content
+    }
+
+    private fun LayoutInspectorModifier.isDrawingModifier(): Boolean {
+      val lower = name.lowercase()
+      return lower == "background" ||
+        lower.contains("backgroundelement") ||
+        lower == "paint" ||
+        lower.contains("painterelement") ||
+        lower == "border" ||
+        lower.contains("bordermodifier") ||
+        lower.startsWith("draw")
+    }
+
+    private fun LayoutInspectorNode.hasFillBoundsContentScale(): Boolean =
+      modifiers.any { modifier ->
+        modifier.properties["contentScale"]?.contains("FillBounds", ignoreCase = true) == true
+      }
 
     /**
      * Collapse pure-grouping pass-through layers — a `<g>` that draws nothing (no

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgModel.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgModel.kt
@@ -229,6 +229,8 @@ data class FigmaSvgLayer(
    * its drop shadow instead of reading as a flat fill against the render.
    */
   val elevationPx: Double = 0.0,
+  /** Effective `graphicsLayer` alpha for this layer and its subtree. */
+  val opacity: Double = 1.0,
   /**
    * Wear curved text (a `CurvedLayout`/`TimeText` clock) carried on this layer — drawn as an SVG
    * `<textPath>` along its baseline arc. Empty for the common straight-text/no-text case.
@@ -251,7 +253,8 @@ data class FigmaSvgLayer(
         raster != null ||
         vector != null ||
         background != null ||
-        curvedTexts.isNotEmpty()
+        curvedTexts.isNotEmpty() ||
+        opacity < 0.999
 }
 
 /**
@@ -524,6 +527,7 @@ data class FigmaSvgModel(
       // origin, clamped to the parent, and use it everywhere below. Best-effort geometry for a
       // pathological capture; a normally-placed node keeps its real `bounds` untouched.
       val bounds = recoverBounds(parentBounds)
+      val opacity = tokens?.opacity?.coerceIn(0.0, 1.0) ?: 1.0
       // An `Icon`/`Image` whose `ImageVector` the inspector captured emits as editable `<path>`
       // layers rather than a raster crop — the vector alternative to the opaque-by-name fallback
       // below. Placed before the raster branch so a vector-backed icon never rasterises; a
@@ -537,6 +541,7 @@ data class FigmaSvgModel(
           right = bounds.right,
           bottom = bounds.bottom,
           vector = vec,
+          opacity = opacity,
         )
       }
       // An opaque component matched by name (Image/Icon/TextField/…) can't be vectorised at all —
@@ -554,6 +559,7 @@ data class FigmaSvgModel(
           right = bounds.right,
           bottom = bounds.bottom,
           raster = FigmaSvgRaster(href),
+          opacity = opacity,
         )
       }
       // A container filled by paint the token model cannot flatten — a non-ColorPainter
@@ -577,6 +583,7 @@ data class FigmaSvgModel(
           right = region.right,
           bottom = region.bottom,
           raster = FigmaSvgRaster(href),
+          opacity = opacity,
         )
       }
       // A *leaf* node that paints via an imperative Canvas draw (`drawBehind`/`drawWithContent`) —
@@ -727,6 +734,7 @@ data class FigmaSvgModel(
         text = ctx.textByNodeId[nodeId],
         background = background,
         elevationPx = elevationPx,
+        opacity = opacity,
         curvedTexts = curvedTexts,
         children = children.map { it.toLayer(ctx, bounds) },
       )

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgModel.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgModel.kt
@@ -115,8 +115,8 @@ data class FigmaSvgRaster(val href: String)
 /**
  * An editable vector graphic (an `Icon`/`Image`'s `ImageVector`) emitted as real `<path>` layers —
  * the vector alternative to a [FigmaSvgRaster] leaf. Path coordinates are in the vector's own
- * [viewportWidth] × [viewportHeight]; the emitter wraps them in a `translate(left,top)
- * scale(w/viewportWidth, h/viewportHeight)` group so they land on the layer's placed box.
+ * [viewportWidth] × [viewportHeight]; the emitter uniformly scales and centers them in the layer's
+ * placed box, matching `VectorPainter`'s aspect-preserving fit.
  */
 data class FigmaSvgVector(
   val viewportWidth: Float,

--- a/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvgTest.kt
+++ b/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvgTest.kt
@@ -87,6 +87,36 @@ class FigmaLayeredSvgTest {
   }
 
   @Test
+  fun vectorPreservesItsAspectRatioInsideANonSquareLayer() {
+    val node =
+      LayoutInspectorNode(
+        nodeId = "icon",
+        component = "Icon",
+        bounds = bounds(10, 20, 58, 32),
+        size = LayoutInspectorSize(48, 12),
+        vectorGraphic =
+          LayoutInspectorVectorGraphic(
+            viewportWidth = 24f,
+            viewportHeight = 24f,
+            paths =
+              listOf(
+                LayoutInspectorVectorPath(
+                  pathData = "M0,0 L24,0 L24,24 L0,24 Z",
+                  fillArgb = "#FF000000",
+                )
+              ),
+          ),
+      )
+
+    val svg = render(node)
+
+    // A 24×24 vector fits the 48×12 layer at 0.5× and is horizontally centered. Independent
+    // scaling would emit scale(2 0.5), visibly flattening the icon.
+    assertTrue(svg, svg.contains("""transform="translate(28 20) scale(0.5 0.5)""""))
+    assertFalse(svg, svg.contains("scale(2 0.5)"))
+  }
+
+  @Test
   fun everyLayoutNodeBecomesANamedGroup() {
     val svg =
       render(

--- a/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvgTest.kt
+++ b/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvgTest.kt
@@ -1283,6 +1283,37 @@ class FigmaLayeredSvgTest {
   }
 
   @Test
+  fun graphicsLayerOpacityAppliesToTheWholeSvgGroup() {
+    val svg =
+      render(
+        layoutNode(
+          "FadingButton",
+          0,
+          0,
+          100,
+          40,
+          tokens = ComposeSemanticsTokens(backgroundColor = "#FF6750A4", opacity = 0.25),
+          children =
+            listOf(
+              layoutNode(
+                "Label",
+                10,
+                10,
+                90,
+                30,
+                tokens = ComposeSemanticsTokens(backgroundColor = "#FFFFFFFF"),
+              )
+            ),
+        )
+      )
+
+    assertTrue(
+      "opacity belongs on the parent group so it affects fill and descendants",
+      svg.contains("""<g id="FadingButton" opacity="0.25">"""),
+    )
+  }
+
+  @Test
   fun rawPixelCornerRadiusRendersRoundedRectWithoutDensityScaling() {
     // `RoundedCornerShape(20f)` rides on `cornerRadiusPx` (not the dp `cornerRadius`) and is
     // already

--- a/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvgTest.kt
+++ b/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvgTest.kt
@@ -32,6 +32,7 @@ class FigmaLayeredSvgTest {
     r: Int,
     b: Int,
     tokens: ComposeSemanticsTokens? = null,
+    modifiers: List<LayoutInspectorModifier> = emptyList(),
     children: List<LayoutInspectorNode> = emptyList(),
   ) =
     LayoutInspectorNode(
@@ -39,6 +40,7 @@ class FigmaLayeredSvgTest {
       component = component,
       bounds = bounds(l, t, r, b),
       size = LayoutInspectorSize(r - l, b - t),
+      modifiers = modifiers,
       tokens = tokens,
       children = children,
     )
@@ -114,6 +116,67 @@ class FigmaLayeredSvgTest {
     // scaling would emit scale(2 0.5), visibly flattening the icon.
     assertTrue(svg, svg.contains("""transform="translate(28 20) scale(0.5 0.5)""""))
     assertFalse(svg, svg.contains("scale(2 0.5)"))
+  }
+
+  @Test
+  fun vectorRetainsAnExplicitNonuniformLayoutTransform() {
+    val node =
+      LayoutInspectorNode(
+        nodeId = "icon",
+        component = "Icon",
+        bounds = bounds(10, 20, 58, 44),
+        size = LayoutInspectorSize(24, 24),
+        vectorGraphic =
+          LayoutInspectorVectorGraphic(
+            viewportWidth = 24f,
+            viewportHeight = 24f,
+            paths =
+              listOf(
+                LayoutInspectorVectorPath(
+                  pathData = "M0,0 L24,0 L24,24 L0,24 Z",
+                  fillArgb = "#FF000000",
+                )
+              ),
+          ),
+      )
+
+    val svg = render(node)
+
+    assertTrue(svg, svg.contains("""transform="translate(10 20) scale(2 1)""""))
+  }
+
+  @Test
+  fun vectorHonorsExplicitFillBoundsContentScale() {
+    val node =
+      LayoutInspectorNode(
+        nodeId = "image",
+        component = "Image",
+        bounds = bounds(10, 20, 58, 32),
+        size = LayoutInspectorSize(48, 12),
+        modifiers =
+          listOf(
+            LayoutInspectorModifier(
+              name = "paint",
+              properties = mapOf("contentScale" to "ContentScale.FillBounds"),
+            )
+          ),
+        vectorGraphic =
+          LayoutInspectorVectorGraphic(
+            viewportWidth = 24f,
+            viewportHeight = 24f,
+            paths =
+              listOf(
+                LayoutInspectorVectorPath(
+                  pathData = "M0,0 L24,0 L24,24 L0,24 Z",
+                  fillArgb = "#FF000000",
+                )
+              ),
+          ),
+      )
+
+    val svg = render(node)
+
+    assertTrue(svg, svg.contains("""transform="translate(10 20) scale(2 0.5)""""))
   }
 
   @Test
@@ -1311,6 +1374,73 @@ class FigmaLayeredSvgTest {
       "opacity belongs on the parent group so it affects fill and descendants",
       svg.contains("""<g id="FadingButton" opacity="0.25">"""),
     )
+  }
+
+  @Test
+  fun graphicsLayerAfterBackgroundNestsOnlyTheInnerContent() {
+    val svg =
+      render(
+        layoutNode(
+          "FadingButton",
+          0,
+          0,
+          100,
+          40,
+          tokens = ComposeSemanticsTokens(backgroundColor = "#FF6750A4", opacity = 0.25),
+          modifiers =
+            listOf(
+              LayoutInspectorModifier(name = "BackgroundElement"),
+              LayoutInspectorModifier(name = "graphicsLayer", properties = mapOf("alpha" to "0.25")),
+            ),
+          children =
+            listOf(
+              layoutNode(
+                "Label",
+                10,
+                10,
+                90,
+                30,
+                tokens = ComposeSemanticsTokens(backgroundColor = "#FFFFFFFF"),
+              )
+            ),
+        )
+      )
+
+    val shapeIndex = svg.indexOf("""fill="#6750A4"""")
+    val innerOpacityIndex = svg.indexOf("""<g opacity="0.25">""")
+    val labelIndex = svg.indexOf("""id="Label"""")
+    assertTrue("the background must stay outside the opacity group", shapeIndex < innerOpacityIndex)
+    assertTrue(
+      "the content must be nested inside the opacity group",
+      innerOpacityIndex < labelIndex,
+    )
+    assertFalse(svg.contains("""id="FadingButton" opacity="0.25""""))
+  }
+
+  @Test
+  fun finalFrameRasterDoesNotReapplyLocalOrAncestorOpacity() {
+    val node =
+      layoutNode(
+        "FadingContainer",
+        0,
+        0,
+        100,
+        100,
+        tokens = ComposeSemanticsTokens(backgroundColor = "#FF6750A4", opacity = 0.25),
+        modifiers =
+          listOf(
+            LayoutInspectorModifier(name = "graphicsLayer", properties = mapOf("alpha" to "0.25")),
+            LayoutInspectorModifier(name = "BackgroundElement"),
+          ),
+        children = listOf(layoutNode("Image", 10, 10, 90, 90)),
+      )
+    val model = FigmaSvgModel.from(LayoutInspectorPayload(node), rasterComponents = setOf("Image"))
+    val svg = FigmaLayeredSvg.render(model)
+
+    assertFalse(svg.contains("""id="FadingContainer" opacity="0.25""""))
+    assertFalse(svg.contains("""id="Image" opacity="""))
+    assertTrue(svg.contains("""<g opacity="0.25">"""))
+    assertTrue(svg.contains("<image "))
   }
 
   @Test


### PR DESCRIPTION
## Summary
- preserve evaluated graphics-layer alpha at its position in the modifier chain and emit nested SVG groups
- keep final-frame raster crops outside inherited opacity so alpha is not applied twice
- distinguish aspect-fitted vector slots from explicit nonuniform transforms and `ContentScale.FillBounds`
- retain transformed layout bounds without applying translation or scale twice
- add core, desktop-capture, and Android end-to-end regressions

## Tests
- `:data-layoutinspector-core:test --tests ee.schimke.composeai.data.layoutinspector.FigmaLayeredSvgTest`
- `:data-layoutinspector-connector:test`
- `:daemon:desktop:test --tests ee.schimke.composeai.daemon.DesktopLayoutInspectorTest.captures_effective_graphics_layer_alpha`
- `:daemon:android:testDebugUnitTest` SVG regression tests
- ktfmt checks for all affected modules

Fixes #2853