### PR TITLE
fix(figma-svg): preserve emoji and annotated text fonts

### DIFF
--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/RenderEngineTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/RenderEngineTest.kt
@@ -422,6 +422,49 @@ class RenderEngineTest {
   }
 
   @Test
+  fun figmaSvgExportKeepsClickableEmojiAndAnnotatedFontRuns() {
+    val outputDir = tempFolder.newFolder("renders-figma-emoji")
+    System.setProperty(RenderEngine.OUTPUT_DIR_PROP, outputDir.absolutePath)
+    System.setProperty("roborazzi.test.record", "true")
+    System.setProperty("composeai.svg.embedFonts", "false")
+    val host = RobolectricHost()
+    host.start()
+    try {
+      host.submit(
+        RenderRequest.Render(
+          payload =
+            "className=ee.schimke.composeai.daemon.RedFixturePreviewsKt;" +
+              "functionName=EmojiAndAnnotatedText;" +
+              "widthPx=180;heightPx=80;density=1.0;" +
+              "showBackground=true;outputBaseName=figma-emoji"
+        ),
+        timeoutMs = 120_000,
+      )
+
+      val svg =
+        outputDir.parentFile!!
+          .resolve("data")
+          .resolve("figma-emoji")
+          .resolve("compose-figma.svg")
+          .readText()
+      assertTrue("supplementary-plane emoji must remain editable text", svg.contains("😀"))
+      assertTrue("annotated text must preserve its base run", svg.contains(">body </tspan>"))
+      assertTrue("annotated text must preserve its explicit code run", svg.contains(">code</tspan>"))
+      assertTrue(
+        "the explicit span face must remain distinct",
+        svg.contains("""font-family="monospace""""),
+      )
+      assertFalse(
+        "known base and span families must not trigger global tofu",
+        svg.contains("ComposeAI Missing Font"),
+      )
+    } finally {
+      host.shutdown()
+      System.clearProperty("composeai.svg.embedFonts")
+    }
+  }
+
+  @Test
   fun figmaSvgLongRenderModeProducesFullPageSvg() {
     // Parity with the desktop backend: the `figma-svg-long` render mode grows the viewport until a
     // virtualised LazyColumn composes every row, sizes to content, and writes the full-page SVG to

--- a/daemon/android/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
+++ b/daemon/android/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
@@ -46,9 +46,13 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 
 /**
  * Test fixtures for [RenderEngineTest] and the D-harness.v2 Android real-mode scenarios. Lives in
@@ -181,6 +185,24 @@ fun GradientBackgroundCard() {
     contentAlignment = Alignment.Center,
   ) {
     Text("Gradient", color = Color.White)
+  }
+}
+
+/** Android end-to-end fixture for #2854's emoji and annotated-font export paths. */
+@Composable
+fun EmojiAndAnnotatedText() {
+  Column(modifier = Modifier.fillMaxSize().background(Color.White)) {
+    Text("😀", modifier = Modifier.testTag("emoji").clickable {})
+    Text(
+      buildAnnotatedString {
+        append("body ")
+        withStyle(SpanStyle(fontFamily = FontFamily.Monospace, fontSize = 12.sp)) {
+          append("code")
+        }
+      },
+      modifier = Modifier.testTag("annotated"),
+      style = TextStyle(fontFamily = FontFamily.SansSerif, fontSize = 16.sp),
+    )
   }
 }
 

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopSemanticsTokensTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopSemanticsTokensTest.kt
@@ -308,6 +308,33 @@ class DesktopSemanticsTokensTest {
   }
 
   @Test
+  fun annotated_text_keeps_base_family_and_effective_span_overrides() {
+    val root = buildTree {
+      Text(
+        buildAnnotatedString {
+          append("base ")
+          withStyle(SpanStyle(fontFamily = FontFamily.Serif)) { append("code") }
+        },
+        modifier = Modifier.testTag("annotated"),
+        style = TextStyle(fontFamily = FontFamily.Monospace),
+      )
+    }
+
+    val typography = root.find("annotated")?.typography
+    assertNotNull("annotated text must retain typography", typography)
+    assertEquals("monospace", typography!!.fontFamily)
+    val spans = typography.spans
+    assertNotNull("effective annotated ranges must be captured", spans)
+    assertEquals(2, spans!!.size)
+    assertEquals("monospace", spans[0].fontFamily)
+    assertEquals(0, spans[0].start)
+    assertEquals(5, spans[0].end)
+    assertEquals("serif", spans[1].fontFamily)
+    assertEquals(5, spans[1].start)
+    assertEquals(9, spans[1].end)
+  }
+
+  @Test
   fun unstyled_run_plus_styled_span_omits_weight() {
     // #1935 (review): when a run is left *unstyled* (drawing at the inherited default weight) and a
     // span overrides only part to bold, the node draws mixed weights. The unstyled run must count

--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeFigmaSvgDataProduct.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeFigmaSvgDataProduct.kt
@@ -162,7 +162,10 @@ object ComposeFigmaSvgDataProducer {
   /** Every family named on a `<text>` in [layer]'s subtree. */
   private fun capturedFamilies(layer: FigmaSvgLayer): Set<String> = buildSet {
     fun walk(node: FigmaSvgLayer) {
-      node.text?.fontFamily?.takeIf { it.isNotBlank() }?.let { add(it) }
+      node.text?.let { text ->
+        text.fontFamily?.takeIf { it.isNotBlank() }?.let { add(it) }
+        text.spans?.forEach { span -> span.fontFamily?.takeIf { it.isNotBlank() }?.let { add(it) } }
+      }
       node.children.forEach(::walk)
     }
     walk(layer)
@@ -318,12 +321,31 @@ object ComposeFigmaSvgDataProducer {
     val codePointsByFace = LinkedHashMap<Triple<String?, Int, Boolean>, MutableSet<Int>>()
     fun collect(layer: FigmaSvgLayer) {
       layer.text?.let { t ->
-        val cps =
-          codePointsByFace.getOrPut(Triple(t.fontFamily, t.fontWeight ?: 400, t.italic)) {
-            LinkedHashSet()
+        val spans = t.spans
+        if (spans.isNullOrEmpty()) {
+          val cps =
+            codePointsByFace.getOrPut(Triple(t.fontFamily, t.fontWeight ?: 400, t.italic)) {
+              LinkedHashSet()
+            }
+          t.content.codePoints().toArray().forEach { cps.add(it) }
+          t.lines?.forEach { line -> line.content.codePoints().toArray().forEach { cps.add(it) } }
+        } else {
+          spans.forEach { span ->
+            val start = span.start.coerceIn(0, t.content.length)
+            val end = span.end.coerceIn(start, t.content.length)
+            val cps =
+              codePointsByFace.getOrPut(
+                Triple(
+                  span.fontFamily ?: t.fontFamily,
+                  span.fontWeight ?: t.fontWeight ?: 400,
+                  span.italic,
+                )
+              ) {
+                LinkedHashSet()
+              }
+            t.content.substring(start, end).codePoints().toArray().forEach { cps.add(it) }
           }
-        t.content.codePoints().toArray().forEach { cps.add(it) }
-        t.lines?.forEach { line -> line.content.codePoints().toArray().forEach { cps.add(it) } }
+        }
       }
       layer.children.forEach(::collect)
     }

--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
@@ -13,7 +13,6 @@ import androidx.compose.ui.semantics.SemanticsConfiguration
 import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.getOrNull
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.font.Font
@@ -309,11 +308,27 @@ object ComposeSemanticsDataProducer {
     // (inherited-default) run and a styled span omits the field rather than reporting the span's
     // value as if the node were uniform.
     val spans = results.flatMap { it.effectiveSpanStyles() }
-    val fontFamily =
+    val uniformFontFamily =
       spans
         .map { fontFamilyLabel(it.fontFamily, it.fontWeight, it.fontStyle) }
         .distinct()
         .singleOrNull()
+    // A node with explicit face overrides (for example Jetchat's Karla paragraph plus a monospace
+    // code span) is not uniformly one family, but the SVG still needs its paragraph/base face.
+    // Keep that base here and carry the effective overrides in `spans` below; returning null made
+    // the whole annotated node look unnamed and triggered the global tofu fallback.
+    val baseFontFamily =
+      results
+        .map {
+          fontFamilyLabel(
+            it.layoutInput.style.fontFamily,
+            it.layoutInput.style.fontWeight,
+            it.layoutInput.style.fontStyle,
+          )
+        }
+        .distinct()
+        .singleOrNull()
+    val fontFamily = uniformFontFamily ?: baseFontFamily
     val fontWeight = spans.map { it.fontWeight?.weight }.distinct().singleOrNull()
     val fontStyle = spans.map { fontStyleName(it.fontStyle) }.distinct().singleOrNull()
     val fontVariationSettings =
@@ -366,8 +381,32 @@ object ComposeSemanticsDataProducer {
               text = str.substring(start, end) + ellipsis,
               left = r.getLineLeft(i).roundToInt(),
               baseline = r.getLineBaseline(i).roundToInt(),
+              start = start,
+              end = end,
             )
           }
+        }
+    val styledSpans =
+      results
+        .singleOrNull()
+        ?.takeIf { it.layoutInput.text.spanStyles.isNotEmpty() }
+        ?.effectiveStyleRanges()
+        ?.map { range ->
+          ComposeSemanticsTextSpan(
+            start = range.start,
+            end = range.end,
+            fontSize = range.style.fontSize.toWireTextUnit(),
+            fontFamily =
+              fontFamilyLabel(
+                range.style.fontFamily,
+                range.style.fontWeight,
+                range.style.fontStyle,
+              ),
+            fontWeight = range.style.fontWeight?.weight,
+            fontStyle = fontStyleName(range.style.fontStyle),
+            foregroundColor =
+              range.style.color.takeIf { it != Color.Unspecified }?.let(::colorToWireString),
+          )
         }
     return LayoutTextDetails(
       text = text,
@@ -390,6 +429,7 @@ object ComposeSemanticsDataProducer {
       didOverflowWidth = didOverflowWidth.takeIf { results.isNotEmpty() },
       didOverflowHeight = didOverflowHeight.takeIf { results.isNotEmpty() },
       lines = lines,
+      spans = styledSpans,
     )
   }
 
@@ -403,26 +443,53 @@ object ComposeSemanticsDataProducer {
    * as mixed. Lets the typography extraction reason about every face actually drawn.
    */
   private fun TextLayoutResult.effectiveSpanStyles(): List<SpanStyle> {
-    val paragraph = layoutInput.style.toSpanStyle()
-    val annotated = layoutInput.text
-    val spanStyles = annotated.spanStyles
-    if (spanStyles.isEmpty()) return listOf(paragraph)
-    val merged = spanStyles.map { paragraph.merge(it.item) }
-    return if (spanStyles.coverAll(annotated.text.length)) merged else listOf(paragraph) + merged
+    return effectiveStyleRanges().map { it.style }
   }
 
-  /** Whether [spans] tile `[0, length)` with no gap — i.e. every glyph is covered by some span. */
-  private fun List<AnnotatedString.Range<SpanStyle>>.coverAll(length: Int): Boolean {
-    if (length <= 0) return true
-    var covered = 0
-    for (range in sortedBy { it.start }) {
-      val start = range.start.coerceIn(0, length)
-      val end = range.end.coerceIn(0, length)
-      if (start > covered) return false
-      if (end > covered) covered = end
-      if (covered >= length) return true
+  private data class EffectiveStyleRange(val start: Int, val end: Int, val style: SpanStyle)
+
+  /**
+   * Effective style for every drawn UTF-16 interval. Compose spans may overlap: each active style
+   * is merged over the paragraph in declaration order, so a colour-only mention keeps the Karla
+   * base while a nested code range can explicitly replace it with monospace.
+   */
+  private fun TextLayoutResult.effectiveStyleRanges(): List<EffectiveStyleRange> {
+    val paragraph = layoutInput.style.toSpanStyle()
+    val annotated = layoutInput.text
+    val length = annotated.text.length
+    val spans = annotated.spanStyles
+    if (spans.isEmpty() || length <= 0) {
+      return listOf(EffectiveStyleRange(0, length, paragraph))
     }
-    return covered >= length
+    val boundaries =
+      buildSet {
+          add(0)
+          add(length)
+          spans.forEach {
+            add(it.start.coerceIn(0, length))
+            add(it.end.coerceIn(0, length))
+          }
+        }
+        .sorted()
+    val ranges =
+      boundaries.zipWithNext().mapNotNull { (start, end) ->
+        if (start >= end) return@mapNotNull null
+        val effective =
+          spans
+            .filter { it.start < end && it.end > start }
+            .fold(paragraph) { style, span -> style.merge(span.item) }
+        EffectiveStyleRange(start, end, effective)
+      }
+    // Adjacent source ranges with the same effective style need no separate SVG tspan.
+    return ranges.fold(mutableListOf()) { merged, range ->
+      val previous = merged.lastOrNull()
+      if (previous != null && previous.end == range.start && previous.style == range.style) {
+        merged[merged.lastIndex] = previous.copy(end = range.end)
+      } else {
+        merged += range
+      }
+      merged
+    }
   }
 
   private fun TextLayoutResult.textColors(): List<Color> = buildList {
@@ -590,6 +657,7 @@ object ComposeSemanticsDataProducer {
     val didOverflowWidth: Boolean?,
     val didOverflowHeight: Boolean?,
     val lines: List<ComposeSemanticsTextLine>?,
+    val spans: List<ComposeSemanticsTextSpan>?,
   )
 
   /**
@@ -619,6 +687,7 @@ object ComposeSemanticsDataProducer {
         fontFeatureSettings = fontFeatureSettings,
         letterSpacing = letterSpacing,
         lineHeight = lineHeight,
+        spans = spans,
       )
 
   /** Groups the resolved text colours (issue #1903), or null when the node resolves none. */
@@ -750,6 +819,9 @@ typealias ComposeSemanticsTextOverflow =
 
 typealias ComposeSemanticsTextLine =
   ee.schimke.composeai.data.layoutinspector.ComposeSemanticsTextLine
+
+typealias ComposeSemanticsTextSpan =
+  ee.schimke.composeai.data.layoutinspector.ComposeSemanticsTextSpan
 
 typealias ComposeSemanticsInsets = ee.schimke.composeai.data.layoutinspector.ComposeSemanticsInsets
 

--- a/data/layoutinspector/connector/src/test/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProductRegistryTest.kt
+++ b/data/layoutinspector/connector/src/test/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProductRegistryTest.kt
@@ -29,7 +29,7 @@ class ComposeSemanticsDataProductRegistryTest {
     val registry = ComposeSemanticsDataProductRegistry(rootDir)
     val cap = registry.capabilities.single()
     assertEquals("compose/semantics", cap.kind)
-    assertEquals(8, cap.schemaVersion)
+    assertEquals(ComposeSemanticsDataProducer.SCHEMA_VERSION, cap.schemaVersion)
     assertTrue(cap.attachable)
     assertTrue(cap.fetchable)
     assertTrue(!cap.requiresRerender)

--- a/data/layoutinspector/connector/src/test/kotlin/ee/schimke/composeai/daemon/FigmaSvgTofuFallbackTest.kt
+++ b/data/layoutinspector/connector/src/test/kotlin/ee/schimke/composeai/daemon/FigmaSvgTofuFallbackTest.kt
@@ -2,6 +2,7 @@ package ee.schimke.composeai.daemon
 
 import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsNode
 import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsPayload
+import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsTextSpan
 import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsTypography
 import ee.schimke.composeai.data.layoutinspector.LayoutInspectorBounds
 import ee.schimke.composeai.data.layoutinspector.LayoutInspectorNode
@@ -145,6 +146,53 @@ class FigmaSvgTofuFallbackTest {
     assertTrue("the real family must survive", svg.contains("Orbitron"))
     assertFalse("nothing was lost, so no boxes", svg.contains(TofuFont.FAMILY))
     assertFalse("nothing was lost, so no warning", warnings("named").exists())
+  }
+
+  @Test
+  fun `annotated base and explicit span families are both named without tofu`() {
+    FigmaSvgRenderedFonts.record("Karla")
+    FigmaSvgRenderedFonts.record("monospace")
+    val semantics =
+      ComposeSemanticsPayload(
+        ComposeSemanticsNode(
+          nodeId = "root",
+          boundsInRoot = "0,0,200,100",
+          children =
+            listOf(
+              ComposeSemanticsNode(
+                nodeId = "Text",
+                boundsInRoot = "8,8,192,40",
+                text = "body code",
+                typography =
+                  ComposeSemanticsTypography(
+                    fontSize = "16.0sp",
+                    fontFamily = "Karla",
+                    spans =
+                      listOf(
+                        ComposeSemanticsTextSpan(0, 5, "16.0sp", "Karla", 400),
+                        ComposeSemanticsTextSpan(5, 9, "12.0sp", "monospace", 400),
+                      ),
+                  ),
+              )
+            ),
+        )
+      )
+
+    ComposeFigmaSvgDataProducer.writeSvg(
+      rootDir = dir,
+      previewId = "annotated",
+      layout = layout(),
+      semantics = semantics,
+    )
+
+    val svg = dir.resolve("annotated").resolve(ComposeFigmaSvgDataProducer.FILE_SVG).readText()
+    assertTrue(svg.contains("""font-family="Karla, sans-serif""""))
+    assertTrue(svg.contains("""font-family="monospace""""))
+    assertFalse(
+      "known annotated faces must not poison the whole node",
+      svg.contains(TofuFont.FAMILY),
+    )
+    assertFalse("known annotated faces must not warn", warnings("annotated").exists())
   }
 
   @Test

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/ComposeSemanticsModels.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/ComposeSemanticsModels.kt
@@ -36,7 +36,12 @@ object ComposeSemanticsProduct {
   // px relative to the node's top-left) for wrapped text, so the figma-svg export places one run
   // per line at the render's break points instead of collapsing the string onto one baseline.
   // Additive; older entries decode with `lines = null` (single-line rendering).
-  const val SCHEMA_VERSION: Int = 8
+  // v10 (#2854): typography may carry effective styled `spans`, and wrapped line entries carry
+  // their UTF-16 start/end offsets. This preserves the paragraph face across AnnotatedString runs
+  // while retaining explicit per-span overrides (for example Karla body text with a monospace code
+  // span). Additive; older entries decode with `spans = null` and line offsets unset.
+  // v9 is reserved by the independent graphics-layer export change in #2853.
+  const val SCHEMA_VERSION: Int = 10
   const val FILE: String = "compose-semantics.json"
 }
 
@@ -219,6 +224,24 @@ data class ComposeSemanticsTypography(
   val letterSpacing: String? = null,
   /** Resolved line height as `"<value>sp"` / `"<value>em"`. */
   val lineHeight: String? = null,
+  /**
+   * Effective styles for the text's UTF-16 ranges when it contains an `AnnotatedString`. Each entry
+   * has already been merged over the paragraph style and any overlapping spans, so a consumer can
+   * emit editable styled runs without losing the base family. Null for plain text.
+   */
+  val spans: List<ComposeSemanticsTextSpan>? = null,
+)
+
+/** One effective styled UTF-16 range within a text node. */
+@Serializable
+data class ComposeSemanticsTextSpan(
+  val start: Int,
+  val end: Int,
+  val fontSize: String? = null,
+  val fontFamily: String? = null,
+  val fontWeight: Int? = null,
+  val fontStyle: String? = null,
+  val foregroundColor: String? = null,
 )
 
 /**
@@ -271,7 +294,14 @@ data class ComposeSemanticsTextOverflow(
  * for centred/right-aligned text).
  */
 @Serializable
-data class ComposeSemanticsTextLine(val text: String, val left: Int, val baseline: Int)
+data class ComposeSemanticsTextLine(
+  val text: String,
+  val left: Int,
+  val baseline: Int,
+  /** UTF-16 offsets into the node's full text; absent on schema v8 captures. */
+  val start: Int? = null,
+  val end: Int? = null,
+)
 
 /**
  * Resolved design-token data for a single semantics node (issues #1897, #1908). Populated from the

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvg.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvg.kt
@@ -454,11 +454,20 @@ object FigmaLayeredSvg {
           val lineEnd = line.end
           val styled =
             if (lineStart != null && lineEnd != null) {
+              val sourceStart = lineStart.coerceIn(0, t.content.length)
+              val sourceEnd = lineEnd.coerceIn(sourceStart, t.content.length)
+              val sourceLine = t.content.substring(sourceStart, sourceEnd)
               styledTspans(
                 content = t.content,
                 spans = t.spans,
                 rangeStart = lineStart,
                 rangeEnd = lineEnd,
+                trailingContent =
+                  if (line.content.startsWith(sourceLine)) {
+                    line.content.removePrefix(sourceLine)
+                  } else {
+                    ""
+                  },
                 firstPosition =
                   """ x="${layer.left + line.left}" y="${layer.top + line.baseline}"""",
                 options = options,
@@ -490,6 +499,7 @@ object FigmaLayeredSvg {
     spans: List<FigmaSvgTextSpan>?,
     rangeStart: Int,
     rangeEnd: Int,
+    trailingContent: String = "",
     firstPosition: String,
     options: Options,
     familyOverrides: Map<String, String>,
@@ -506,6 +516,7 @@ object FigmaLayeredSvg {
     return pieces
       .mapIndexed { index, (pieceStart, pieceEnd, span) ->
         val position = if (index == 0) firstPosition else ""
+        val suffix = if (index == pieces.lastIndex) trailingContent else ""
         val size = span.fontSizePx?.let { """ font-size="${fmt(it)}"""" } ?: ""
         val family =
           span.fontFamily?.let { captured ->
@@ -517,7 +528,7 @@ object FigmaLayeredSvg {
         val weight = span.fontWeight?.let { """ font-weight="$it"""" } ?: ""
         val style = if (span.italic) """ font-style="italic"""" else ""
         val fill = span.color?.let { """ fill="${it.hex}"${opacity("fill", it)}""" } ?: ""
-        """<tspan$position$size$family$weight$style$fill>${escape(content.substring(pieceStart, pieceEnd))}</tspan>"""
+        """<tspan$position$size$family$weight$style$fill>${escape(content.substring(pieceStart, pieceEnd) + suffix)}</tspan>"""
       }
       .joinToString("")
   }

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvg.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvg.kt
@@ -449,13 +449,77 @@ object FigmaLayeredSvg {
       // the captured per-line offset), so line alignment (centre/right) and the real break points
       // are preserved on Figma import.
       val tspans =
-        lines.joinToString("") {
-          """<tspan x="${layer.left + it.left}" y="${layer.top + it.baseline}">${escape(it.content)}</tspan>"""
+        lines.joinToString("") { line ->
+          val lineStart = line.start
+          val lineEnd = line.end
+          val styled =
+            if (lineStart != null && lineEnd != null) {
+              styledTspans(
+                content = t.content,
+                spans = t.spans,
+                rangeStart = lineStart,
+                rangeEnd = lineEnd,
+                firstPosition =
+                  """ x="${layer.left + line.left}" y="${layer.top + line.baseline}"""",
+                options = options,
+                familyOverrides = familyOverrides,
+              )
+            } else null
+          styled
+            ?: """<tspan x="${layer.left + line.left}" y="${layer.top + line.baseline}">${escape(line.content)}</tspan>"""
         }
       return """<text font-size="${fmt(size)}"$family$weight$style$letterSpacing$fill>$tspans</text>"""
     }
+    val styled =
+      styledTspans(
+        content = t.content,
+        spans = t.spans,
+        rangeStart = 0,
+        rangeEnd = t.content.length,
+        firstPosition = "",
+        options = options,
+        familyOverrides = familyOverrides,
+      )
     return """<text x="${layer.left}" y="${fmt(baseline)}" font-size="${fmt(size)}"$family$weight$style$letterSpacing$fill>""" +
-      "${escape(t.content)}</text>"
+      "${styled ?: escape(t.content)}</text>"
+  }
+
+  /** Styled `<tspan>`s for the intersections of [spans] with `[rangeStart, rangeEnd)`. */
+  private fun styledTspans(
+    content: String,
+    spans: List<FigmaSvgTextSpan>?,
+    rangeStart: Int,
+    rangeEnd: Int,
+    firstPosition: String,
+    options: Options,
+    familyOverrides: Map<String, String>,
+  ): String? {
+    spans ?: return null
+    val start = rangeStart.coerceIn(0, content.length)
+    val end = rangeEnd.coerceIn(start, content.length)
+    val pieces = spans.mapNotNull { span ->
+      val pieceStart = maxOf(start, span.start).coerceIn(start, end)
+      val pieceEnd = minOf(end, span.end).coerceIn(pieceStart, end)
+      if (pieceStart >= pieceEnd) null else Triple(pieceStart, pieceEnd, span)
+    }
+    if (pieces.isEmpty()) return null
+    return pieces
+      .mapIndexed { index, (pieceStart, pieceEnd, span) ->
+        val position = if (index == 0) firstPosition else ""
+        val size = span.fontSizePx?.let { """ font-size="${fmt(it)}"""" } ?: ""
+        val family =
+          span.fontFamily?.let { captured ->
+            val emitted =
+              familyOverrides[captured]
+                ?: withGenericFallback(resolveFamily(captured, options.defaultFontFamily))
+            """ font-family="${escapeAttr(emitted)}""""
+          } ?: ""
+        val weight = span.fontWeight?.let { """ font-weight="$it"""" } ?: ""
+        val style = if (span.italic) """ font-style="italic"""" else ""
+        val fill = span.color?.let { """ fill="${it.hex}"${opacity("fill", it)}""" } ?: ""
+        """<tspan$position$size$family$weight$style$fill>${escape(content.substring(pieceStart, pieceEnd))}</tspan>"""
+      }
+      .joinToString("")
   }
 
   // Typical UI-font metrics as a fraction of the em (font size). Compose lays a line out as the

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgModel.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgModel.kt
@@ -63,6 +63,8 @@ data class FigmaSvgText(
    * registers.
    */
   val letterSpacingPx: Double? = null,
+  /** Effective styled UTF-16 ranges for annotated text; null for a uniform/plain run. */
+  val spans: List<FigmaSvgTextSpan>? = null,
   /**
    * Per-line runs for wrapped text, in px relative to the layer's top-left, in draw order. When
    * present (2+ lines) the renderer emits one positioned `<tspan>` per line instead of a single
@@ -72,7 +74,25 @@ data class FigmaSvgText(
 )
 
 /** One laid-out line of a wrapped [FigmaSvgText], px offsets from the text layer's top-left. */
-data class FigmaSvgTextLine(val content: String, val left: Int, val baseline: Int)
+data class FigmaSvgTextLine(
+  val content: String,
+  val left: Int,
+  val baseline: Int,
+  /** UTF-16 offsets into the full text; null for schema-v8 captures. */
+  val start: Int? = null,
+  val end: Int? = null,
+)
+
+/** One effective styled UTF-16 range within [FigmaSvgText.content]. */
+data class FigmaSvgTextSpan(
+  val start: Int,
+  val end: Int,
+  val fontSizePx: Double? = null,
+  val fontFamily: String? = null,
+  val fontWeight: Int? = null,
+  val italic: Boolean = false,
+  val color: FigmaSvgColor? = null,
+)
 
 /**
  * A font face to embed in the export as an SVG `@font-face` so the `<text>` renders with the real
@@ -1017,6 +1037,18 @@ data class FigmaSvgModel(
           node.typography?.letterSpacing?.let {
             lineHeightToPx(it, node.typography.fontSize, density, fontScale)
           },
+        spans =
+          node.typography?.spans?.map { span ->
+            FigmaSvgTextSpan(
+              start = span.start,
+              end = span.end,
+              fontSizePx = span.fontSize?.let { spToPx(it, density, fontScale) },
+              fontFamily = span.fontFamily,
+              fontWeight = span.fontWeight,
+              italic = span.fontStyle == "italic",
+              color = span.foregroundColor?.let { argbToColor(it, emptyMap()) },
+            )
+          },
         // Carry per-line runs only for genuinely wrapped text (2+ lines). The captured offsets are
         // already in render px (same space as the node bounds), so they map straight to layer space
         // with no density conversion.
@@ -1024,7 +1056,15 @@ data class FigmaSvgModel(
           node.textOverflow
             ?.lines
             ?.takeIf { it.size > 1 }
-            ?.map { FigmaSvgTextLine(content = it.text, left = it.left, baseline = it.baseline) },
+            ?.map {
+              FigmaSvgTextLine(
+                content = it.text,
+                left = it.left,
+                baseline = it.baseline,
+                start = it.start,
+                end = it.end,
+              )
+            },
       )
 
     /**

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgModel.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgModel.kt
@@ -937,13 +937,20 @@ data class FigmaSvgModel(
     ): Map<String, FigmaSvgText> {
       val candidates = mutableListOf<Triple<String, IntArray, Int>>()
       fun collect(n: LayoutInspectorNode, depth: Int) {
-        candidates.add(
-          Triple(
-            n.nodeId,
-            intArrayOf(n.bounds.left, n.bounds.top, n.bounds.right, n.bounds.bottom),
-            depth,
-          )
-        )
+        val candidateBounds =
+          buildList {
+              add(n.bounds)
+              // A Text's semantics bounds include semantic modifiers such as clickable, minimum
+              // touch size, and padding, while LayoutInspectorNode.bounds is the inner glyph box.
+              // Keep the text attached to that same layout node by accepting any captured
+              // modifier boundary as a matching surface. This is essential for emoji-table cells:
+              // their 42dp clickable semantics surround a much smaller padded text layout.
+              n.modifiers.mapNotNullTo(this) { it.bounds }
+            }
+            .distinct()
+        candidateBounds.forEach { b ->
+          candidates.add(Triple(n.nodeId, intArrayOf(b.left, b.top, b.right, b.bottom), depth))
+        }
         n.children.forEach { collect(it, depth + 1) }
       }
       collect(layoutRoot, 0)

--- a/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvgTest.kt
+++ b/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvgTest.kt
@@ -1672,6 +1672,48 @@ class FigmaLayeredSvgTest {
   }
 
   @Test
+  fun annotatedTextKeepsEllipsisOnTheFinalStyledLine() {
+    val layout =
+      layoutNode("Screen", 0, 0, 200, 100, children = listOf(layoutNode("Text", 10, 10, 190, 90)))
+    val semantics =
+      ComposeSemanticsNode(
+        nodeId = "root",
+        boundsInRoot = "0,0,200,100",
+        children =
+          listOf(
+            ComposeSemanticsNode(
+              nodeId = "t",
+              boundsInRoot = "10,10,190,90",
+              text = "base truncated",
+              typography =
+                ComposeSemanticsTypography(
+                  fontSize = "16.0sp",
+                  fontFamily = "monospace",
+                  spans =
+                    listOf(
+                      ComposeSemanticsTextSpan(0, 5, "16.0sp", "monospace", 400),
+                      ComposeSemanticsTextSpan(5, 14, "12.0sp", "serif", 400),
+                    ),
+                ),
+              textOverflow =
+                ComposeSemanticsTextOverflow(
+                  lineCount = 2,
+                  lines =
+                    listOf(
+                      ComposeSemanticsTextLine("base ", 0, 20, start = 0, end = 5),
+                      ComposeSemanticsTextLine("trunc…", 0, 44, start = 5, end = 10),
+                    ),
+                ),
+            )
+          ),
+      )
+
+    val svg = render(layout, semantics = semantics)
+    assertTrue(svg.contains(">trunc…</tspan>"))
+    assertFalse(svg.contains(">trunc</tspan>"))
+  }
+
+  @Test
   fun wrappedTextEmitsOnePositionedTspanPerLineInsteadOfOneBaseline() {
     val layout =
       layoutNode("Screen", 0, 0, 200, 100, children = listOf(layoutNode("Text", 10, 10, 190, 90)))

--- a/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvgTest.kt
+++ b/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvgTest.kt
@@ -1628,6 +1628,50 @@ class FigmaLayeredSvgTest {
   }
 
   @Test
+  fun annotatedTextEmitsStyledTspansAcrossWrappedLines() {
+    val layout =
+      layoutNode("Screen", 0, 0, 200, 100, children = listOf(layoutNode("Text", 10, 10, 190, 90)))
+    val semantics =
+      ComposeSemanticsNode(
+        nodeId = "root",
+        boundsInRoot = "0,0,200,100",
+        children =
+          listOf(
+            ComposeSemanticsNode(
+              nodeId = "t",
+              boundsInRoot = "10,10,190,90",
+              text = "base code",
+              typography =
+                ComposeSemanticsTypography(
+                  fontSize = "16.0sp",
+                  fontFamily = "monospace",
+                  spans =
+                    listOf(
+                      ComposeSemanticsTextSpan(0, 5, "16.0sp", "monospace", 400),
+                      ComposeSemanticsTextSpan(5, 9, "12.0sp", "serif", 400),
+                    ),
+                ),
+              textOverflow =
+                ComposeSemanticsTextOverflow(
+                  lineCount = 2,
+                  lines =
+                    listOf(
+                      ComposeSemanticsTextLine("base ", 0, 20, start = 0, end = 5),
+                      ComposeSemanticsTextLine("code", 0, 44, start = 5, end = 9),
+                    ),
+                ),
+            )
+          ),
+      )
+
+    val svg = render(layout, semantics = semantics)
+    assertTrue(svg.contains("""<tspan x="10" y="30" font-size="16" font-family="monospace""""))
+    assertTrue(svg.contains(">base </tspan>"))
+    assertTrue(svg.contains("""<tspan x="10" y="54" font-size="12" font-family="serif""""))
+    assertTrue(svg.contains(">code</tspan>"))
+  }
+
+  @Test
   fun wrappedTextEmitsOnePositionedTspanPerLineInsteadOfOneBaseline() {
     val layout =
       layoutNode("Screen", 0, 0, 200, 100, children = listOf(layoutNode("Text", 10, 10, 190, 90)))

--- a/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvgTest.kt
+++ b/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvgTest.kt
@@ -1873,6 +1873,41 @@ class FigmaLayeredSvgTest {
   }
 
   @Test
+  fun textAttachesThroughItsOuterClickableModifierBounds() {
+    // Jetchat's emoji cells expose the full 42dp click target to semantics, while the layout
+    // node's own bounds are the inner padded glyph box. Matching only node bounds dropped every
+    // supplementary-plane emoji from the SVG even though semantics captured them.
+    val emoji =
+      LayoutInspectorNode(
+        nodeId = "emoji",
+        component = "EmptyMeasurePolicy",
+        bounds = bounds(20, 20, 40, 40),
+        size = LayoutInspectorSize(42, 42),
+        modifiers =
+          listOf(LayoutInspectorModifier(name = "clickable", bounds = bounds(0, 0, 42, 42))),
+      )
+    val layout = layoutNode("Screen", 0, 0, 100, 100, children = listOf(emoji))
+    val semantics =
+      ComposeSemanticsNode(
+        nodeId = "root",
+        boundsInRoot = "0,0,100,100",
+        children =
+          listOf(
+            ComposeSemanticsNode(
+              nodeId = "emoji-semantics",
+              boundsInRoot = "0,0,42,42",
+              text = "😀",
+              typography = ComposeSemanticsTypography(fontSize = "18.0sp"),
+            )
+          ),
+      )
+
+    val svg = render(layout, semantics = semantics)
+    assertTrue("surrogate-pair emoji text must remain editable", svg.contains(">😀</text>"))
+    assertTrue("text uses the inner layout origin", svg.contains("""<text x="20""""))
+  }
+
+  @Test
   fun textIsNotAttachedToAWildlyDifferentNode() {
     // A text node far from any layout node must not be force-attached (tolerance is tight).
     val layout =


### PR DESCRIPTION
## Summary

- match text semantics against modifier bounds so clickable supplementary-plane emoji are not dropped
- preserve the resolved paragraph family across `AnnotatedString` runs while retaining explicit span overrides
- emit editable styled SVG `<tspan>` runs and subset each font face for the characters it actually draws
- add a real Android render regression for clickable emoji and annotated font runs

## Tests

- `:data-layoutinspector-core:test`
- `:data-layoutinspector-connector:test`
- focused desktop semantics token tests
- `:daemon:android:testDebugUnitTest --tests ee.schimke.composeai.daemon.RenderEngineTest.figmaSvgExportKeepsClickableEmojiAndAnnotatedFontRuns`
- formatting checks for affected modules

Fixes #2854